### PR TITLE
feat(wam-fsharp): T9 fact-table inline (default in-range, capped)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -100,7 +100,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | cpp     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✗ | ✗ | ✗ | ✗ |
 | go      | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
 | haskell | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✓ | ✗ | ✗ |
-| fsharp  | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ~ | ✗ | ✗ | ✗ |
+| fsharp  | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ~ | ✓ capped | ✗ | ✗ |
 | clojure | ✓ | ✓ T2a | ✓ | ✓ | ✗ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | llvm    | ✓ | ✓ T2a | ✓ (c1) | ✓ | ✓ | ✗ | ✗ | ~ | ✗ | ✗ | ~ |
 | lua     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✗ | ✓ | ✗ | ✗ |
@@ -173,7 +173,13 @@ Verification notes:
   `tests/test_wam_rust_fact_table_emit.pl`,
   `tests/test_wam_rust_fact_table_callsite_exec.pl`,
   `tests/test_wam_rust_fact_table_throughput.pl`; benchmark
-  `docs/reports/wam_rust_t9_fact_table_benchmark.md`.
+  `docs/reports/wam_rust_t9_fact_table_benchmark.md`. **fsharp = ✓ (default,
+  capped):** same policy, emitted as a lowered fact-table predicate registered in
+  `loweredPredicates` (so `call`/`execute` reach it like any T4/T5/T6 lowering); a
+  `factTableAttempt` enumerator leaves a `FactTableRetry` choice point per
+  remaining row, mirroring `select/3`. Tests:
+  `tests/test_wam_fsharp_fact_table_exec.pl` (query-mode matrix),
+  `tests/test_wam_fsharp_fact_table_emit.pl`.
 - **T8** (native kernels) is a curated library feature dispatched via shared
   `kernel_dispatch` plumbing, not a generic per-predicate lowering. ✓ marks
   the roadmap's validated full-parity set (Rust / Haskell / Elixir / Go /

--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -152,7 +152,13 @@ fsharp_wam_builtin_state_type :-
     /// for the next unifiable element.  Needed because the parser uses
     /// `member(op(Name, P, T), OpTable), is_op_type(T), !` and depends on
     /// backtracking into member when the type guard fails.
-    | MemberRetry    of elemReg: int * remaining: Value list * retPC: int").
+    | MemberRetry    of elemReg: int * remaining: Value list * retPC: int
+    /// T9 fact-table enumeration choice point.  `args` are the query argument
+    /// values (deref''d at call time); `remaining` are the candidate rows still
+    /// to try, each a `VList` of column values.  On backtrack the runtime
+    /// restores the CP snapshot and unifies every column of the next matching
+    /// row against `args`, leaving a fresh FactTableRetry CP if more remain.
+    | FactTableRetry of args: Value list * remaining: Value list * retPC: int").
 
 % ============================================================================
 % EnvFrame — mirrors Haskell `EnvFrame`
@@ -457,6 +463,17 @@ fsharp_wam_helpers :-
 "// ============================================================================
 // Helper functions
 // ============================================================================
+
+/// T9 first-argument index key: a canonical string for an atomic value, or
+/// None for compound / list / unbound values (which can only match via a full
+/// scan).  Keys both the stored rows and the query arg, so a bound atomic first
+/// argument selects exactly the matching index bucket.
+let factIndexKey (v: Value) : string option =
+    match v with
+    | Atom s    -> Some s
+    | Integer n -> Some (\"i\" + string n)
+    | Float f   -> Some (\"f\" + string f)
+    | _         -> None
 
 /// Resolve a fact lookup function for kernel dispatch.  Returns
 /// int -> int list, which kernels call directly instead of

--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -25,7 +25,9 @@
 
 :- module(wam_fsharp_lowered_emitter, [
     wam_fsharp_lowerable/3,
-    lower_predicate_to_fsharp/4
+    lower_predicate_to_fsharp/4,
+    fsharp_fact_table_classify/3,     % +PI, +Opts, -fact_info(Arity,Rows)
+    emit_fact_table_fsharp/4          % +FuncName, +Arity, +Rows, -Code
 ]).
 
 :- use_module(library(lists)).
@@ -204,6 +206,23 @@ supported_fs(T) :-
 % ============================================================================
 
 %% lower_predicate_to_fsharp(+PI, +WamCode, +Opts, -lowered(PredName, FuncName, Code))
+%  T9 fact-table inline: an all-ground-facts predicate whose row count is in the
+%  inline window [t9_min_rows, t9_max_rows] (defaults 64..256) lowers to a static
+%  row table + first-arg index + a backtracking enumerator (factTableAttempt),
+%  registered as a lowered predicate so call/execute reach it for free. Default
+%  in-range; opt out with fact_table_inline(false). Checked first so it wins.
+lower_predicate_to_fsharp(PI, _WamCode, Opts, lowered(PredName, FuncName, Code)) :-
+    \+ member(fact_table_inline(false), Opts),
+    fsharp_fact_table_classify(PI, Opts, fact_info(Arity, Rows)),
+    !,
+    ( PI = _M:Pred/_ -> true ; PI = Pred/_ ),
+    format(atom(PredName), '~w/~w', [Pred, Arity]),
+    atom_string(Pred, PredStr0),
+    split_string(PredStr0, "$", "", PParts),
+    atomic_list_concat(PParts, '_', SanPred),
+    format(atom(FuncName), 'lowered_~w_~w', [SanPred, Arity]),
+    emit_fact_table_fsharp(FuncName, Arity, Rows, Code).
+
 lower_predicate_to_fsharp(PI, WamCode, Opts, lowered(PredName, FuncName, Code)) :-
     (   PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
@@ -222,6 +241,82 @@ lower_predicate_to_fsharp(PI, WamCode, Opts, lowered(PredName, FuncName, Code)) 
     offset_labels_fs(LabelMap, Offset, GlobalLabelMap),
     with_output_to(string(Code),
         emit_func_fs(FuncName, GlobalPCInstrs, GlobalLabelMap, ForeignPreds, Opts)).
+
+% --- T9 fact-table inline: classification + emission ------------------------
+
+%% fsharp_fact_table_classify(+PI, +Opts, -fact_info(Arity, Rows))
+%  An all-ground-facts predicate (every clause a ground unit clause) whose row
+%  count is in [t9_min_rows, t9_max_rows]. Rows are arg tuples in source order.
+fsharp_fact_table_classify(PI, Opts, fact_info(Arity, Rows)) :-
+    ( PI = Module:Pred/Arity -> true ; PI = Pred/Arity, Module = user ),
+    Arity >= 1,
+    functor(Head, Pred, Arity),
+    findall(Head-Body, clause(Module:Head, Body), Clauses),
+    Clauses = [_|_],
+    forall(member(_-B, Clauses), B == true),
+    forall(member(H-_, Clauses), ( H =.. [_|As], forall(member(A, As), ground(A)) )),
+    findall(As, ( member(H-true, Clauses), H =.. [_|As] ), Rows),
+    fsharp_t9_min_rows(Opts, Min),
+    fsharp_t9_max_rows(Opts, Max),
+    length(Rows, NR),
+    NR >= Min,
+    NR =< Max.
+
+fsharp_t9_min_rows(Opts, N) :- ( member(t9_min_rows(N), Opts) -> true ; N = 64 ).
+fsharp_t9_max_rows(Opts, N) :- ( member(t9_max_rows(N), Opts) -> true ; N = 256 ).
+
+%% emit_fact_table_fsharp(+FuncName, +Arity, +Rows, -Code)
+%  Emit a static row table + first-arg index (built once at module init) and a
+%  lowered predicate that derefs its args, selects candidates (index bucket for a
+%  bound atomic first arg, else full scan) and drives factTableAttempt.
+emit_fact_table_fsharp(FuncName, Arity, Rows, Code) :-
+    maplist(fsharp_fact_row_literal, Rows, RowLits),
+    atomic_list_concat(RowLits, '\n          ', RowsBody),
+    format(string(Code),
+'let private ~w_rows : Value list =
+        [ ~w ]
+let private ~w_index : Map<string, Value list> =
+    ~w_rows
+    |> List.choose (fun r -> match r with | VList (c0 :: _) -> (match factIndexKey c0 with Some k -> Some (k, r) | None -> None) | _ -> None)
+    |> List.groupBy fst
+    |> List.map (fun (k, ps) -> (k, ps |> List.map snd))
+    |> Map.ofList
+let ~w (_ctx: WamContext) (s: WamState) : WamState option =
+    let args = [ for i in 1 .. ~w -> (match getReg i s with Some v -> derefVar s.WsBindings v | None -> Unbound -1) ]
+    let cands =
+        match args with
+        | a1 :: _ -> (match factIndexKey a1 with Some k -> (match Map.tryFind k ~w_index with Some rs -> rs | None -> []) | None -> ~w_rows)
+        | [] -> ~w_rows
+    factTableAttempt args cands s.WsCP s',
+        [FuncName, RowsBody, FuncName, FuncName, FuncName, Arity, FuncName, FuncName, FuncName]).
+
+% One row -> `VList [<col>; <col>; ...]`.
+fsharp_fact_row_literal(Row, Lit) :-
+    maplist(fsharp_term_to_value_literal, Row, ColLits),
+    atomic_list_concat(ColLits, '; ', Inner),
+    format(string(Lit), 'VList [~w]', [Inner]).
+
+% Ground Prolog term -> F# Value literal (matches the F# Value DU). Integers and
+% floats are parenthesised so a leading minus is not read as subtraction.
+fsharp_term_to_value_literal(T, L) :- integer(T), !, format(string(L), 'Integer (~w)', [T]).
+fsharp_term_to_value_literal(T, L) :- float(T), !, format(string(L), 'Float (~w)', [T]).
+fsharp_term_to_value_literal(T, L) :- is_list(T), !,
+    maplist(fsharp_term_to_value_literal, T, Es), atomic_list_concat(Es, '; ', I),
+    format(string(L), 'VList [~w]', [I]).
+fsharp_term_to_value_literal(T, L) :- atom(T), !,
+    fsharp_escape_string(T, E), format(string(L), 'Atom "~w"', [E]).
+fsharp_term_to_value_literal(T, L) :- string(T), !,
+    fsharp_escape_string(T, E), format(string(L), 'Atom "~w"', [E]).
+fsharp_term_to_value_literal(T, L) :- compound(T), !,
+    T =.. [F|As], fsharp_escape_string(F, EF),
+    maplist(fsharp_term_to_value_literal, As, Es), atomic_list_concat(Es, '; ', I),
+    format(string(L), 'Str ("~w", [~w])', [EF, I]).
+
+% Escape backslash and double-quote for an F# string literal.
+fsharp_escape_string(In, Out) :-
+    atom_string(In, S),
+    split_string(S, "\\", "", P1), atomic_list_concat(P1, '\\\\', S1),
+    split_string(S1, "\"", "", P2), atomic_list_concat(P2, '\\"', Out).
 
 offset_pcs_fs([], _, []).
 offset_pcs_fs([pc(PC, I)|Rest], Off, [pc(GPC, I)|Rest2]) :-

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -288,14 +288,18 @@ predicate_base_pc_fs(P, Map, PC) :-
 % lower_all: run the lowered emitter over LoweredList
 % ============================================================================
 
-lower_all_fs([], _, _, []).
-lower_all_fs([P|Rest], BasePCMap, DetectedKernels, [Entry|RestEntries]) :-
+lower_all_fs(Preds, BasePCMap, DetectedKernels, Entries) :-
+    lower_all_fs(Preds, BasePCMap, DetectedKernels, [], Entries).
+lower_all_fs([], _, _, _, []).
+lower_all_fs([P|Rest], BasePCMap, DetectedKernels, Options, [Entry|RestEntries]) :-
     wam_fsharp_predicate_wamcode(P, WamCode),
     predicate_base_pc_fs(P, BasePCMap, BasePC),
     pairs_keys(DetectedKernels, ForeignKeys),
+    % Thread the user Options (t9_min_rows / t9_max_rows / fact_table_inline)
+    % so lower_predicate_to_fsharp can apply the T9 fact-table inline.
     lower_predicate_to_fsharp(P, WamCode,
-        [base_pc(BasePC), foreign_preds(ForeignKeys)], Entry),
-    lower_all_fs(Rest, BasePCMap, DetectedKernels, RestEntries).
+        [base_pc(BasePC), foreign_preds(ForeignKeys)|Options], Entry),
+    lower_all_fs(Rest, BasePCMap, DetectedKernels, Options, RestEntries).
 
 
 % ============================================================================
@@ -583,6 +587,50 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                                  WsB0Stack = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
                                  WsCPs     = newCPs
                                  WsCPsLen  = List.length newCPs }
+        tryNext candidates
+    | FactTableRetry (_, [], _) ->
+        backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
+    | FactTableRetry (args, candidates, retPC) ->
+        // Restore from snapshot, then walk remaining candidate rows; unify all
+        // columns of the next matching row against the query args (the snapshot
+        // makes each row attempt independent).  Mirrors MemberRetry but with a
+        // multi-column unify per row.
+        let diff = s.WsTrailLen - cp.CpTrailLen
+        let restoredS = { s with
+                             WsRegs     = Array.copy cp.CpRegs
+                             WsStack    = cp.CpStack
+                             WsCP       = cp.CpCP
+                             WsTrail    = List.skip diff s.WsTrail
+                             WsTrailLen = cp.CpTrailLen
+                             WsHeap     = List.take cp.CpHeapLen s.WsHeap
+                             WsHeapLen  = cp.CpHeapLen
+                             WsBindings = cp.CpBindings
+                             WsCutBar   = cp.CpCutBar
+                             WsB0Stack  = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
+                             WsPC       = retPC }
+        let arity = List.length args
+        let rec tryNext cs =
+            match cs with
+            | [] -> backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
+            | row :: more ->
+                match row with
+                | VList cols when List.length cols = arity ->
+                    match unifyColumns (List.zip args cols) restoredS with
+                    | Some s2 ->
+                        let newCPs =
+                            match more with
+                            | [] -> rest
+                            | _  -> { cp with CpBuiltin = Some (FactTableRetry (args, more, retPC)) } :: rest
+                        Some { s2 with
+                                 WsPC      = retPC
+                                 WsStack   = cp.CpStack
+                                 WsCP      = cp.CpCP
+                                 WsCutBar  = cp.CpCutBar
+                                 WsB0Stack = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
+                                 WsCPs     = newCPs
+                                 WsCPsLen  = List.length newCPs }
+                    | None -> tryNext more
+                | _ -> tryNext more
         tryNext candidates
     | FFIStreamRetry (_, _, [], _) ->
         backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
@@ -2913,7 +2961,52 @@ and unifyVal (a: Value) (b: Value) (s: WamState) : WamState option =
     // step handler) doesn''t need to.
     match unifyTerms a b s with
     | None    -> None
-    | Some sN -> Some { sN with WsPC = sN.WsPC + 1 }'.
+    | Some sN -> Some { sN with WsPC = sN.WsPC + 1 }
+
+/// Unify a list of (arg, column) pairs left-to-right, threading state. Used by
+/// the T9 fact-table enumerator to unify every column of a candidate row.
+and unifyColumns (pairs: (Value * Value) list) (st: WamState) : WamState option =
+    match pairs with
+    | [] -> Some st
+    | (a, c) :: ps ->
+        match unifyTerms a c st with
+        | None     -> None
+        | Some st2 -> unifyColumns ps st2
+
+/// T9 fact-table enumerator: try each candidate row (a VList of column values)
+/// against the query args, leaving a FactTableRetry choice point for the rest so
+/// backtracking yields the next matching row. On success sets WsPC = retPC (the
+/// call-site continuation: pc+1 for `call`, the saved cp for tail-call
+/// `execute`). Mirrors select/3''s choice-point construction.
+and factTableAttempt (args: Value list) (cands: Value list) (retPC: int) (s: WamState) : WamState option =
+    let arity = List.length args
+    let rec tryNext cs =
+        match cs with
+        | [] -> None
+        | row :: more ->
+            match row with
+            | VList cols when List.length cols = arity ->
+                match unifyColumns (List.zip args cols) s with
+                | Some s2 ->
+                    let newCPs, newCPsLen =
+                        if List.isEmpty more then s.WsCPs, s.WsCPsLen
+                        else
+                            let cp = { CpNextPC   = retPC
+                                       CpRegs     = Array.copy s.WsRegs
+                                       CpStack    = s.WsStack
+                                       CpCP       = s.WsCP
+                                       CpTrailLen = s.WsTrailLen
+                                       CpHeapLen  = s.WsHeapLen
+                                       CpBindings = s.WsBindings
+                                       CpCutBar   = s.WsCutBar
+                                       CpB0StackLen = List.length s.WsB0Stack
+                                       CpAggFrame = None
+                                       CpBuiltin  = Some (FactTableRetry (args, more, retPC)) }
+                            cp :: s.WsCPs, s.WsCPsLen + 1
+                    Some { s2 with WsPC = retPC; WsCPs = newCPs; WsCPsLen = newCPsLen }
+                | None -> tryNext more
+            | _ -> tryNext more
+    tryNext cands'.
 
 % ============================================================================
 % PHASE 4: Run Loop
@@ -4905,7 +4998,7 @@ write_wam_fsharp_project(Predicates, Options0, ProjectDir) :-
     write_fs_file(PredsPath, PredsCode),
 
     % Generate Lowered.fs
-    lower_all_fs(LoweredList, BasePCMap, DetectedKernels, LoweredEntries),
+    lower_all_fs(LoweredList, BasePCMap, DetectedKernels, Options, LoweredEntries),
     generate_lowered_fs(LoweredEntries, LoweredCode),
     directory_file_path(ProjectDir, 'Lowered.fs', LoweredPath),
     write_fs_file(LoweredPath, LoweredCode),

--- a/tests/test_wam_fsharp_fact_table_emit.pl
+++ b/tests/test_wam_fsharp_fact_table_emit.pl
@@ -1,0 +1,56 @@
+% test_wam_fsharp_fact_table_emit.pl
+%
+% T9 fact-table inline for F# — codegen-level checks (no dotnet needed).
+% Verifies the value-literal mapping, the inline window gate (default in-range),
+% the fact_table_inline(false) opt-out, below-min, and above-cap behaviour.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_fsharp_lowered_emitter').
+
+:- dynamic user:ek/2.
+user:ek(a, 1). user:ek(a, 2). user:ek(b, 3).
+user:ek(a, 4). user:ek(c, 5). user:ek(b, 6).
+
+lower(Opts, Code) :-
+    wam_target:compile_predicate_to_wam(ek/2, [], W),
+    lower_predicate_to_fsharp(user:ek/2, W, Opts, lowered(_, _, Code)).
+
+:- begin_tests(wam_fsharp_fact_table_emit).
+
+% value-literal emitter maps each ground term kind to its F# Value variant.
+test(value_literals) :-
+    emit_fact_table_fsharp(lowered_p_2, 2, [[foo, 7], [bar, -3]], Code),
+    assertion(sub_string(Code, _, _, _, "Atom \"foo\"")),
+    assertion(sub_string(Code, _, _, _, "Integer (7)")),
+    assertion(sub_string(Code, _, _, _, "Integer (-3)")),
+    assertion(sub_string(Code, _, _, _, "factTableAttempt args cands")).
+
+% nested term / list / float literals.
+test(value_literals_compound) :-
+    emit_fact_table_fsharp(lowered_q_1, 1, [[f(a, [1, 2])], [3.5]], Code),
+    assertion(sub_string(Code, _, _, _, "Str (\"f\", [Atom \"a\"; VList [Integer (1); Integer (2)]])")),
+    assertion(sub_string(Code, _, _, _, "Float (3.5)")).
+
+% default in-range (no inline option): 6 rows in [4,256] -> fact table.
+test(default_in_range_classifies) :-
+    lower([t9_min_rows(4)], Code),
+    assertion(sub_string(Code, _, _, _, "factTableAttempt")),
+    assertion(sub_string(Code, _, _, _, "lowered_ek_2_rows")).
+
+% explicit opt-out -> ordinary lowering, no fact table.
+test(explicit_disable_off) :-
+    lower([t9_min_rows(4), fact_table_inline(false)], Code),
+    assertion(\+ sub_string(Code, _, _, _, "factTableAttempt")).
+
+% below t9_min_rows -> not a fact table.
+test(below_min_off) :-
+    lower([t9_min_rows(100)], Code),
+    assertion(\+ sub_string(Code, _, _, _, "factTableAttempt")).
+
+% above t9_max_rows -> not a fact table (steered to an external source).
+test(above_cap_off) :-
+    lower([t9_min_rows(2), t9_max_rows(5)], Code),
+    assertion(\+ sub_string(Code, _, _, _, "factTableAttempt")).
+
+:- end_tests(wam_fsharp_fact_table_emit).

--- a/tests/test_wam_fsharp_fact_table_exec.pl
+++ b/tests/test_wam_fsharp_fact_table_exec.pl
@@ -1,0 +1,136 @@
+% test_wam_fsharp_fact_table_exec.pl
+%
+% T9 fact-table inline for the F# target. An all-ground-facts predicate whose row
+% count is in [t9_min_rows, t9_max_rows] lowers to a static row table + first-arg
+% index + a backtracking enumerator (factTableAttempt + FactTableRetry choice
+% point), registered as a lowered predicate so call/execute reach it via the same
+% loweredPredicates map T4/T5/T6 use. Verifies the query-mode matrix end-to-end; a
+% rule calling the fact predicate (firstedge/1) is a compile check on the
+% call-site wiring.
+%
+% Skipped when dotnet is not on PATH.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_fsharp_target').
+:- use_module('../src/unifyweaver/targets/wam_fsharp_lowered_emitter').
+
+:- dynamic user:edge/2, user:firstedge/1.
+user:edge(a, 1). user:edge(a, 2). user:edge(b, 3).
+user:edge(a, 4). user:edge(c, 5). user:edge(b, 6).
+% call-site: a rule that calls the fact-table predicate
+user:firstedge(X) :- user:edge(a, X).
+
+dotnet_available :-
+    catch(( process_create(path(dotnet), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_fsharp_fact_table_exec, [condition(dotnet_available)]).
+
+% Codegen: edge/2 lowers to the T9 fact-table enumerator (default in-range).
+test(codegen_emits_fact_table) :-
+    wam_target:compile_predicate_to_wam(edge/2, [], W),
+    lower_predicate_to_fsharp(user:edge/2, W, [t9_min_rows(4)], lowered(_, _, Code)),
+    assertion(sub_string(Code, _, _, _, "factTableAttempt")),
+    assertion(sub_string(Code, _, _, _, "lowered_edge_2_rows")),
+    % opt-out forces the ordinary lowering (no fact table)
+    lower_predicate_to_fsharp(user:edge/2, W,
+        [t9_min_rows(4), fact_table_inline(false)], lowered(_, _, Code2)),
+    assertion(\+ sub_string(Code2, _, _, _, "factTableAttempt")).
+
+% Build + run: query-mode matrix + call-site dispatch.
+test(query_mode_matrix_exec) :-
+    Dir = 'output/test_wam_fsharp_t9_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_fsharp_project(
+        [user:edge/2, user:firstedge/1],
+        [module_name('t9proj'), emit_mode(functions), t9_min_rows(4)], Dir),
+    atomic_list_concat([Dir, '/Lowered.fs'], LoweredPath),
+    read_file_to_string(LoweredPath, LSrc, []),
+    assertion(sub_string(LSrc, _, _, _, "factTableAttempt")),
+    atomic_list_concat([Dir, '/Program.fs'], ProgPath),
+    fsharp_t9_source(Src),
+    setup_call_cleanup(open(ProgPath, write, S), write(S, Src), close(S)),
+    format(atom(Cmd),
+        'cd ~w && DOTNET_CLI_TELEMETRY_OPTOUT=1 DOTNET_NOLOGO=1 dotnet run --project t9proj.fsproj -c Release 2>&1',
+        [Dir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 5 PASS")
+    ->  true
+    ;   format(user_error, "~n[fsharp t9 test output]~n~w~n", [OutStr]),
+        throw(fsharp_t9_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_fsharp_fact_table_exec).
+
+% Harness: seed registers, call the lowered predicate, then drive backtracking
+% via WamRuntime.backtrack collecting each solution's bound vars. Exercises the
+% FactTableRetry choice point.
+fsharp_t9_source(
+"module Program
+
+open WamTypes
+open WamRuntime
+open Lowered
+
+let testEmptyState =
+    { WsPC = 0; WsRegs = Array.create MaxRegs (Unbound -1); WsStack = []
+      WsHeap = []; WsHeapLen = 0; WsTrail = []; WsTrailLen = 0
+      WsCP = 0; WsCPs = []; WsCPsLen = 0; WsBindings = Map.empty
+      WsCutBar = 0; WsVarCounter = 0; WsBuilder = None; WsBuilderStack = []
+      WsAggAccum = []; WsB0Stack = []; WsCatchers = [] }
+
+let testCtx : WamContext =
+    { WcCode = [||]; WcLabels = Map.empty; WcForeignFacts = Map.empty
+      WcFfiFacts = Map.empty; WcFfiWeightedFacts = Map.empty
+      WcAtomIntern = Map.empty; WcAtomDeintern = Map.empty
+      WcForeignConfig = Map.empty; WcLoweredPredicates = loweredPredicates
+      WcLookupSources = Map.empty; WcCancellationToken = None }
+
+let i (n: int) : Value = Integer n
+let a (s: string) : Value = Atom s
+
+// Enumerate all solutions of `f` seeded with `regs`, reading `vars` per solution.
+let sols (f: WamContext -> WamState -> WamState option) (regs: (int * Value) list) (vars: int list) : Value list list =
+    let arr = Array.create MaxRegs (Unbound -1)
+    regs |> List.iter (fun (idx, v) -> arr.[idx] <- v)
+    let s0 = { testEmptyState with WsRegs = arr }
+    let rec loop sOpt acc =
+        match sOpt with
+        | None -> List.rev acc
+        | Some s ->
+            let row = vars |> List.map (fun r -> match getReg r s with Some v -> derefVar s.WsBindings v | None -> Unbound -1)
+            loop (backtrack s) (row :: acc)
+    loop (f testCtx s0) []
+
+[<EntryPoint>]
+let main _argv =
+    // (+,-) edge(a, X) -> [1;2;4] in source order
+    let m1 = sols lowered_edge_2 [(1, a \"a\"); (2, Unbound 100)] [2]
+    // (-,+) edge(K, 3) -> [b]
+    let m2 = sols lowered_edge_2 [(1, Unbound 101); (2, i 3)] [1]
+    // (-,-) edge(K, X) -> all 6 rows
+    let m3 = sols lowered_edge_2 [(1, Unbound 102); (2, Unbound 103)] [1; 2]
+    // (+,+) membership
+    let m4yes = sols lowered_edge_2 [(1, a \"a\"); (2, i 2)] []
+    let m4no  = sols lowered_edge_2 [(1, a \"a\"); (2, i 3)] []
+    let cases : (string * bool) list =
+        [ (\"(+,-)\",   m1 = [[i 1];[i 2];[i 4]])
+          (\"(-,+)\",   m2 = [[a \"b\"]])
+          (\"(-,-)\",   m3 = [[a \"a\"; i 1];[a \"a\"; i 2];[a \"b\"; i 3];[a \"a\"; i 4];[a \"c\"; i 5];[a \"b\"; i 6]])
+          (\"(+,+)yes\", List.length m4yes = 1)
+          (\"(+,+)no\",  List.length m4no = 0) ]
+    let mutable fails = 0
+    for (name, ok) in cases do
+        if not ok then
+            fails <- fails + 1
+            printfn \"FAIL %s\" name
+    if fails = 0 then printfn \"ALL %d PASS\" (List.length cases)
+    else printfn \"%d FAILURES\" fails
+    0
+").


### PR DESCRIPTION
## What

Brings the Rust T9 fact-table inline work to the **F# WAM target** (first of "T9 for C and F#"). An all-ground-facts predicate whose row count is in `[t9_min_rows, t9_max_rows]` (defaults 64..256) lowers **by default** to a static row table + first-argument index + a backtracking enumerator, instead of T4/T5/T6. Opt out with `fact_table_inline(false)`; above the cap it falls back to ordinary lowering.

## How it fits F#

F# already dispatches `call`/`execute` through a `loweredPredicates : Map<string, …>`, so emitting T9 as a **lowered fact-table predicate** makes call-site dispatch free (same path T4/T5/T6 use — no new instruction).

- **Emitter** (`wam_fsharp_lowered_emitter.pl`): `lower_predicate_to_fsharp` intercepts a qualifying fact predicate and emits `let private <p>_rows`, `<p>_index` (a `Map<string,_>` built once at module init), and a lowered `<p> ctx s` that derefs args, selects candidates (index bucket for a bound atomic first arg, else full scan) and drives `factTableAttempt`. New `fsharp_fact_table_classify/3`, `emit_fact_table_fsharp/4`, `fsharp_term_to_value_literal/2`, `t9_min_rows`/`t9_max_rows`.
- **Runtime** (`wam_fsharp_target.pl` / `fsharp_wam_bindings.pl`): generic `factTableAttempt` + `unifyColumns` added to the run-loop group; a `FactTableRetry` `BuiltinState` variant + `resumeBuiltin` arm leave/resume a choice point per remaining candidate row — mirroring `select/3`/`member/2`. Adds a `factIndexKey` helper.
- `lower_all_fs` now threads the user `Options` so the T9 thresholds apply.

## Tests

- `test_wam_fsharp_fact_table_exec.pl` (dotnet-gated): query-mode matrix over `edge/2` — `(+,-)` index lookup, `(-,+)` value-bound scan, `(-,-)` full enumeration, `(+,+)` membership — each enumerated via `WamRuntime.backtrack`, **ALL 5 PASS**. (A rule calling the fact predicate is included as a compile check; full backtracking *through* a lowered wrapper needs the interpreter run loop, not the direct-call harness, so it isn't enumerated here — dispatch itself is the standard `loweredPredicates` path.)
- `test_wam_fsharp_fact_table_emit.pl` (fast, no dotnet): value literals (incl. nested `Str`/`VList`/`Float`), default-in-range, opt-out, below-min, above-cap.
- Existing F# **T4/T5/T6 + target** tests stay green (e.g. `shade/1`'s 10 facts < 64 → still T6).

Matrix updated: fsharp T9 `✗ → ✓ capped`. **C is next** (then T7 later, per plan).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_