### PR TITLE
feat(wam-rust): discretised-GMM approximation rung (escalation fallback)

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -412,8 +412,15 @@ Phasing:
     prefix-mass). `encode_repr`/`decode_repr` tag 4. Validated:
     `quant_cdf_is_the_no_fit_fallback` (five spikes — binomial/mixture rejected, the
     chooser falls back to QuantCdf, smaller than exact, within `ε_K`).
-  - **Fitted forms [next].** discretised-GMM as escalation only (the last rung;
-    bounded integer data make it lowest priority).
+  - **Discretised-GMM [DONE].** `HistRepr::DiscGmm{support,comps,total}` —
+    `fit_discretised_gmm` (EM over the integer support) fits free-`(weight,mu,sigma)`
+    components, so it places the narrow interior modes the mean-coupled binomial
+    families cannot. Most params/mode of any rung, so the chooser picks it only when
+    every cheaper rung misses the gate AND it still undercuts the quant-CDF table on
+    bytes. `encode_repr`/`decode_repr` tag 5. Validated:
+    `disc_gmm_fits_narrow_interior_modes` (two σ=1.5 modes at 20/40 — binomial, beta-
+    binomial, and K≤3 binomial mixture all rejected; the GMM fits and is chosen).
+    **The approximation ladder is now complete (Rungs 1–6).**
 
 ## 6. What to measure (re-derive, don't inherit)
 

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -420,7 +420,12 @@ Phasing:
     bytes. `encode_repr`/`decode_repr` tag 5. Validated:
     `disc_gmm_fits_narrow_interior_modes` (two σ=1.5 modes at 20/40 — binomial, beta-
     binomial, and K≤3 binomial mixture all rejected; the GMM fits and is chosen).
-    **The approximation ladder is now complete (Rungs 1–6).**
+    **The fitted histogram-approximation ladder is now closed structurally (Rungs 1–6)**
+    — every *histogram-representation* form is in place. (A separate, cheaper moment-jet
+    / CLT *reconstruction* rung — carry `(M,m₁,m₂)`, no EM — remains unbuilt and is the
+    first increment in `WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md` §7–§8; it is not part of
+    this fitted ladder.) "Closed" is structural, not a claim that a measured workload has
+    been shown to need Rung 6.
 
 ## 6. What to measure (re-derive, don't inherit)
 

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md
@@ -49,7 +49,7 @@ itself. They compose — the boundary win sits on top of a warm edge cache (phil
 | band (the cut) | whole region · entry frontier | frontier (for storage) | `boundary_band_root_near` / `boundary_band_entry_frontier` |
 | precompute strategy | eager (enum / shared-memo / sweep) · lazy (demand-driven) | eager sweep | `build_boundary_suffix*` / `lazy_boundary_weightsum` |
 | working set | unbudgeted · two-budget eviction · spill-and-continue | unbudgeted | `evict_budget` / `live_budget` / `..._with_spill` |
-| representation | exact histogram · g_B pre-weighted basis · fitted (tail-prune/binomial/beta-binomial/mixture) | exact | `build_boundary_basis_weighted_power` / `boundary_suffix_reprs` |
+| representation | exact histogram · g_B pre-weighted basis · fitted (tail-prune/binomial/beta-binomial/mixture/quantised-CDF/discretised-GMM) | exact | `build_boundary_basis_weighted_power` / `boundary_suffix_reprs` |
 | persistence | ephemeral · LMDB histograms · LMDB fitted reprs | ephemeral | `save/load_boundary_basis` / `save/load_boundary_reprs` |
 | result | scalar · effective_distance · distribution | scalar | `boundary_result_extractor` / the extractor read |
 
@@ -248,7 +248,8 @@ let reprs = vm.boundary_suffix_reprs(50, 0.001);   // HashMap<u32, HistRepr>
 ```
 
 The chooser (`boundary_cache::choose_representation`) tries, cheapest-first within the
-Kolmogorov `ε_K` gate: **exact → tail-pruned → binomial → beta-binomial → mixture**.
+Kolmogorov `ε_K` gate: **exact → tail-pruned → binomial → beta-binomial → mixture →
+quantised-CDF → discretised-GMM**.
 `choose_representation_budget(h, min_points, max_bytes)` is the storage-driven
 complement (smallest error within a byte budget). The point count `min_points` is a
 *work trigger* / storage proxy, not an acceptance gate — acceptance is always the CDF

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md
@@ -248,8 +248,11 @@ let reprs = vm.boundary_suffix_reprs(50, 0.001);   // HashMap<u32, HistRepr>
 ```
 
 The chooser (`boundary_cache::choose_representation`) tries, cheapest-first within the
-Kolmogorov `ε_K` gate: **exact → tail-pruned → binomial → beta-binomial → mixture →
-quantised-CDF → discretised-GMM**.
+`ε_K` gate: **exact → tail-pruned → binomial → beta-binomial → mixture →
+quantised-CDF → discretised-GMM**. The gate is a **certified sup-CDF
+(Kolmogorov-distance) tolerance** — `max_t |F_fit(t) − F_exact(t)| ≤ ε_K` against the
+full exact CDF — *not* a Kolmogorov–Smirnov statistical test (no sample, null, or
+critical value), so it is a deterministic bound, not a probabilistic one.
 `choose_representation_budget(h, min_points, max_bytes)` is the storage-driven
 complement (smallest error within a byte budget). The point count `min_points` is a
 *work trigger* / storage proxy, not an acceptance gate — acceptance is always the CDF

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -466,14 +466,27 @@ histograms (support ≤ `budget`+1) the work trigger never fires; this matters a
 
 ### 9b. Ladder status and future work
 
-All six rungs above are **implemented** (Rungs 1–6: tail-pruned exact, binomial
-[moment + CDF fits], beta-binomial, mixture-of-binomials, quantised-CDF, discretised-
-GMM). The error/CDF-gate machinery, the chooser (error- and storage-driven), and the
-persistence path are general — adding a representation is just another candidate in
+All six **fitted histogram-approximation rungs** are implemented (Rungs 1–6: tail-pruned
+exact, binomial [moment + CDF fits], beta-binomial, mixture-of-binomials, quantised-CDF,
+discretised-GMM) — i.e. the *histogram-representation* ladder is closed structurally.
+This is a structural closure, not an empirical claim that every rung has been observed
+necessary on a measured workload (the GMM test uses a synthetic ground truth; whether a
+real boundary node escalates past Rung 5 is a measurement question, §6). The error/CDF-
+gate machinery, the chooser (error- and storage-driven), and the persistence path are
+general — adding a representation is just another candidate in
 `representation_candidates` with a `bytes()` and a `pmf()`/`expand()`.
+
+A **separate, cheaper reconstruction rung is still unbuilt**: the moment-jet / CLT
+reconstruction described in `WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md` §7 (carry
+`(M, m₁, m₂)`, reconstruct a discretised Normal). It is *not* part of this fitted ladder
+— it propagates without ever materialising the histogram — and per that note's roadmap
+it is the **first** (and cheapest, no-EM) reconstruction increment, even though the
+more-expensive GMM rung shipped first. So "ladder closed" here means the histogram-
+fitting forms; it does not mean the cheapest reconstruction path is done.
 
 Remaining, lower priority and added on demand:
 
+- **Moment-jet / CLT reconstruction rung** — see above and the functional-semiring note.
 - **heed-backend parity** for the `boundary_basis_repr` persistence and the spill
   sub-db (the `lmdb-zero` backend has both today).
 - **Higher-K / Bayesian model selection** for the mixture and GMM rungs (today `K =

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -420,8 +420,9 @@ Implemented (Rust, `boundary_cache.rs`):
 - **Rung 4 — mixture of binomials** — `fit_binomial_mixture(h, k, iters)` (EM,
   shared `trials`, PMF-weighted) fits the **multimodal** nodes a single binomial
   rejects (a bottleneck / topic-mixture cone). `HistRepr::Mixture{trials,comps,total}`
-  joins the candidate set (`K = 2,3`). Discretised-GMM stays escalation-only —
-  bounded integer path-length data favour binomial families.
+  joins the candidate set (`K = 2,3`). Costlier-per-mode escalation (discretised-GMM)
+  is Rung 6 — bounded integer path-length data favour binomial families, so it is
+  tried last.
 - **Rung 5 — quantised CDF table** — `HistRepr::QuantCdf{qcdf,total}` stores the
   exact CDF as one fixed-point `u16` per support point (`quantize_cdf` /
   `dequantize_cdf`; `F(i) ≈ qcdf[i]/65535`). **Always admissible** (error bounded by
@@ -429,6 +430,19 @@ Implemented (Rust, `boundary_cache.rs`):
   is the fallback when *no* parametric form fits an irregular/multi-spike node — and
   it gives O(1) prefix-mass reads (a natural fit for the `cdf`/`quantile` result
   modes). The chooser still prefers a cheaper parametric form when one passes.
+- **Rung 6 — discretised Gaussian mixture** — `fit_discretised_gmm(h, k, iters)` (EM
+  over the integer support, PMF-weighted) fits a mixture whose components carry a
+  **free** `(weight, mu, sigma)`. Every rung above is a *binomial* family, whose
+  per-component variance is pinned to its mean (`n*p*(1-p)`); that coupling means a
+  binomial mixture cannot place a *narrow* mode in the interior of the support (a tight
+  mode forces `p` toward an edge). The GMM lifts the coupling, so it fits the
+  arbitrarily-placed, arbitrarily-narrow interior modes the binomial families cannot.
+  `discretised_gmm_pmf` evaluates the components at each integer bin and renormalises
+  (truncation at the domain edges absorbed). `HistRepr::DiscGmm{support,comps,total}`
+  costs 3 params/mode — the most of any parametric form — so the chooser selects it
+  only when every cheaper rung misses the gate **and** it still undercuts the
+  quantised-CDF table on bytes. **Escalation only**, present for shapes the binomial
+  families genuinely cannot represent.
 - **Choice is multi-objective.** `choose_representation` is *error-driven* (cheapest
   within `ε_K`); `choose_representation_budget` is the *storage-driven* complement
   (smallest CDF error within a byte budget). Error is not always the binding
@@ -450,17 +464,21 @@ that certified bound for the affected nodes only). For typical small-budget boun
 histograms (support ≤ `budget`+1) the work trigger never fires; this matters at
 **large budget / deep paths**.
 
-### 9b. Remaining ladder rungs (future work)
+### 9b. Ladder status and future work
 
-The error/CDF-gate machinery, the chooser (error- and storage-driven), and the
+All six rungs above are **implemented** (Rungs 1–6: tail-pruned exact, binomial
+[moment + CDF fits], beta-binomial, mixture-of-binomials, quantised-CDF, discretised-
+GMM). The error/CDF-gate machinery, the chooser (error- and storage-driven), and the
 persistence path are general — adding a representation is just another candidate in
-`representation_candidates` with a `bytes()` and a `pmf()`/`expand()`. Not yet
-implemented, in rough priority order:
+`representation_candidates` with a `bytes()` and a `pmf()`/`expand()`.
 
-- **Discretised Gaussian mixture** — `(weight, mean, variance)` per mode; the
-  **escalation-only** family for sharp/narrow modes that the binomial mixture fits
-  poorly. Continuous prior on discrete data, more params per mode — used only after
-  the binomial family fails the gate.
+Remaining, lower priority and added on demand:
+
+- **heed-backend parity** for the `boundary_basis_repr` persistence and the spill
+  sub-db (the `lmdb-zero` backend has both today).
+- **Higher-K / Bayesian model selection** for the mixture and GMM rungs (today `K =
+  2,3` are tried and the gate + byte cost arbitrate); a BIC/MDL term would let the
+  chooser explore more components without overfitting.
 
 Each rung is justified by **storage at a tolerance**, never compute (the exact
 splice is ~ns), so they are added on demand as large-budget / deep-path workloads

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -169,8 +169,8 @@ pub fn decode_hist(b: &[u8]) -> Hist {
 //
 // This is OPT-IN: the boundary cache is exact by default. These are the tools a
 // storage-budgeted precompute uses when an exact histogram does not fit. The
-// first ladder rung (tail-pruned exact) is implemented; binomial / mixture /
-// discretised-GMM fits are the later rungs (future).
+// first ladder rung (tail-pruned exact) is implemented, as are the binomial,
+// beta-binomial, mixture, quantised-CDF, and discretised-GMM rungs below.
 //
 // Note: typical boundary histograms have support <= budget+1 (the path-length
 // budget), so for the small-budget effective-distance query the work trigger
@@ -266,8 +266,8 @@ pub fn compress_histogram(h: &Hist, min_points: usize, epsilon_k: f64) -> Hist {
 // The next rung after tail-pruned-exact: replace a long histogram with a small set
 // of parameters when a *fit* is within the CDF certificate. Ported from the Python
 // line (`fitted_binomial_pmf` / `choose_distribution_representation`): bounded
-// integer path-length data favour the **binomial** family (a GMM is escalation
-// only, not implemented here). The fit is method-of-moments; acceptance is the same
+// integer path-length data favour the **binomial** family (a discretised-GMM is the
+// escalation fallback below, tried last). The fit is method-of-moments; acceptance is the same
 // epsilon_K Kolmogorov gate as §9a — a fit that misses the gate is REJECTED and the
 // exact (or tail-pruned) form is kept, so this never silently degrades accuracy.
 
@@ -392,6 +392,10 @@ pub enum HistRepr {
     /// ~1/4 the bytes of the raw `u64` counts. The fallback when no parametric form
     /// fits; also gives O(1) prefix-mass reads.
     QuantCdf { qcdf: Vec<u16>, total: u64 },
+    /// Discretised Gaussian mixture over `0..support`; `comps` are `(weight, mu,
+    /// sigma)` triples. The escalation fallback for nodes with narrow, arbitrarily
+    /// placed interior modes that the mean-coupled binomial families cannot represent.
+    DiscGmm { support: usize, comps: Vec<(f64, f64, f64)>, total: u64 },
 }
 
 impl HistRepr {
@@ -404,6 +408,7 @@ impl HistRepr {
             HistRepr::BetaBinomial { .. } => 1 + 4 + 8 + 8 + 8, // tag + trials + alpha + beta + total
             HistRepr::Mixture { comps, .. } => 1 + 4 + 4 + comps.len() * 16 + 8,
             HistRepr::QuantCdf { qcdf, .. } => 1 + 4 + qcdf.len() * 2 + 8, // tag + u32 len + u16 cdf + total
+            HistRepr::DiscGmm { comps, .. } => 1 + 4 + 4 + comps.len() * 24 + 8, // tag + support + k + (w,mu,sigma) + total
         }
     }
     /// Reconstruct a count histogram (parametric forms expand to the PMF scaled to
@@ -426,6 +431,7 @@ impl HistRepr {
             HistRepr::BetaBinomial { trials, alpha, beta, .. } => beta_binomial_pmf(*trials, *alpha, *beta),
             HistRepr::Mixture { trials, comps, .. } => mixture_pmf(*trials, comps),
             HistRepr::QuantCdf { qcdf, .. } => dequantize_cdf(qcdf),
+            HistRepr::DiscGmm { support, comps, .. } => discretised_gmm_pmf(*support, comps),
         }
     }
     fn total(&self) -> u64 {
@@ -434,7 +440,8 @@ impl HistRepr {
             HistRepr::Binomial { total, .. }
             | HistRepr::BetaBinomial { total, .. }
             | HistRepr::Mixture { total, .. }
-            | HistRepr::QuantCdf { total, .. } => *total,
+            | HistRepr::QuantCdf { total, .. }
+            | HistRepr::DiscGmm { total, .. } => *total,
         }
     }
 }
@@ -568,6 +575,96 @@ pub fn fit_binomial_mixture(h: &Hist, k: usize, iters: usize) -> (usize, Vec<(f6
     (trials, comps)
 }
 
+// --- Discretised Gaussian mixture (ladder rung 6): the escalation fallback ---
+//
+// Every parametric rung above is a *binomial* family, whose per-component variance
+// is pinned to its mean (`n*p*(1-p)`). That is exactly right for bounded path-length
+// data and is why the binomials are tried first. It also means a binomial mixture
+// CANNOT place a *narrow* mode in the interior of the support: a tight mode needs `p`
+// near 0/1, which drags the mode to an edge. The discretised-GMM lifts that coupling
+// — each component carries a FREE `(weight, mu, sigma)` — so it can fit arbitrarily
+// placed, arbitrarily narrow interior modes. It is the most expensive parametric form
+// (3 params/component vs the mixture's 2), so the chooser only ever selects it when
+// every cheaper rung misses the CDF gate AND it still undercuts the quantised-CDF
+// fallback on bytes. Hence "escalation only": present for the shapes the binomial
+// families genuinely cannot represent, never the default.
+
+/// Unit Gaussian density at `x` for `N(mu, sigma)` (sigma floored away from 0).
+fn gauss_density(x: f64, mu: f64, sigma: f64) -> f64 {
+    let s = sigma.max(1e-3);
+    let z = (x - mu) / s;
+    (-0.5 * z * z).exp() / (s * (2.0 * std::f64::consts::PI).sqrt())
+}
+
+/// PMF of a discretised Gaussian mixture over the integer domain `0..support`:
+/// `sum_k w_k * N(i; mu_k, sigma_k)`, evaluated at each integer bin and renormalised
+/// to sum to 1 (so truncation at the domain edges is absorbed exactly).
+pub fn discretised_gmm_pmf(support: usize, comps: &[(f64, f64, f64)]) -> Vec<f64> {
+    if support == 0 { return Vec::new(); }
+    let mut out = vec![0.0f64; support];
+    for i in 0..support {
+        let mut acc = 0.0f64;
+        for &(w, mu, sigma) in comps {
+            acc += w * gauss_density(i as f64, mu, sigma);
+        }
+        out[i] = acc;
+    }
+    let s: f64 = out.iter().sum();
+    if s > 0.0 { for x in &mut out { *x /= s; } }
+    out
+}
+
+/// Fit a `k`-component discretised Gaussian mixture by EM over the integer support,
+/// weighted by the empirical PMF. Components start spread across the domain with equal
+/// weight; each sweep re-estimates `(weight, mu, sigma)` freely (sigma floored at half
+/// a bin to avoid delta collapse). Returns `(support, [(weight, mu, sigma)])`.
+pub fn fit_discretised_gmm(h: &Hist, k: usize, iters: usize) -> (usize, Vec<(f64, f64, f64)>) {
+    let pmf = to_pmf(h);
+    let support = pmf.len();
+    let k = k.max(1);
+    if support <= 1 {
+        return (support, vec![(1.0, 0.0, 1.0)]);
+    }
+    let span = (support - 1) as f64;
+    let sigma0 = (span / (2.0 * k as f64)).max(0.75);
+    let mut comps: Vec<(f64, f64, f64)> = (0..k)
+        .map(|j| (1.0 / k as f64, span * (j as f64 + 0.5) / k as f64, sigma0))
+        .collect();
+    for _ in 0..iters {
+        let mut nw = vec![0.0f64; k];   // sum_i pmf[i] r_ij
+        let mut nmu = vec![0.0f64; k];  // sum_i pmf[i] r_ij i
+        let mut nmu2 = vec![0.0f64; k]; // sum_i pmf[i] r_ij i^2
+        for i in 0..support {
+            if pmf[i] <= 0.0 { continue; }
+            let mut resp = vec![0.0f64; k];
+            let mut denom = 0.0f64;
+            for j in 0..k {
+                let (w, mu, s) = comps[j];
+                let v = w * gauss_density(i as f64, mu, s);
+                resp[j] = v;
+                denom += v;
+            }
+            if denom <= 0.0 { continue; }
+            let xi = i as f64;
+            for j in 0..k {
+                let r = pmf[i] * (resp[j] / denom);
+                nw[j] += r;
+                nmu[j] += r * xi;
+                nmu2[j] += r * xi * xi;
+            }
+        }
+        let wsum: f64 = nw.iter().sum();
+        if wsum <= 0.0 { break; }
+        for j in 0..k {
+            if nw[j] <= 0.0 { continue; } // keep the stale component rather than NaN
+            let mu = nmu[j] / nw[j];
+            let var = (nmu2[j] / nw[j] - mu * mu).max(0.25); // floor sigma at 0.5 bin
+            comps[j] = (nw[j] / wsum, mu, var.sqrt());
+        }
+    }
+    (support, comps)
+}
+
 /// All candidate representations of `h`, each paired with its certified CDF error
 /// vs exact. Always includes `Exact` (error 0). Adds the lossy rungs — tail-pruned
 /// exact, single binomial (both fits), and K=2/3 binomial mixtures — only when the
@@ -598,6 +695,14 @@ fn representation_candidates(h: &Hist, min_points: usize) -> Vec<(HistRepr, f64)
         let (trials, comps) = fit_binomial_mixture(h, k, 60);
         let err = cdf_max_error_pmf(&exact_pmf, &mixture_pmf(trials, &comps));
         cands.push((HistRepr::Mixture { trials, comps, total }, err));
+    }
+    for k in [2usize, 3] {
+        // escalation: free-variance Gaussian modes (narrow interior modes the
+        // binomial families cannot place); costlier than the mixture, so only wins
+        // in that niche.
+        let (support, comps) = fit_discretised_gmm(h, k, 80);
+        let err = cdf_max_error_pmf(&exact_pmf, &discretised_gmm_pmf(support, &comps));
+        cands.push((HistRepr::DiscGmm { support, comps, total }, err));
     }
     {
         // always-admissible fallback: the exact CDF at u16 precision (~1/4 the bytes
@@ -641,7 +746,7 @@ pub fn choose_representation_budget(h: &Hist, min_points: usize, max_bytes: usiz
 /// Encode a `HistRepr` to a self-describing byte string (1-byte tag + fields), so
 /// a chosen representation can be persisted (the `boundary_basis_repr` LMDB sub-db)
 /// and `expand`ed on load. Tags: 0 = Exact, 1 = Binomial, 2 = Mixture,
-/// 3 = BetaBinomial, 4 = QuantCdf.
+/// 3 = BetaBinomial, 4 = QuantCdf, 5 = DiscGmm.
 pub fn encode_repr(r: &HistRepr) -> Vec<u8> {
     let mut out = Vec::new();
     match r {
@@ -677,6 +782,17 @@ pub fn encode_repr(r: &HistRepr) -> Vec<u8> {
             out.extend_from_slice(&(qcdf.len() as u32).to_le_bytes());
             for &q in qcdf {
                 out.extend_from_slice(&q.to_le_bytes());
+            }
+            out.extend_from_slice(&total.to_le_bytes());
+        }
+        HistRepr::DiscGmm { support, comps, total } => {
+            out.push(5u8);
+            out.extend_from_slice(&(*support as u32).to_le_bytes());
+            out.extend_from_slice(&(comps.len() as u32).to_le_bytes());
+            for &(w, mu, sigma) in comps {
+                out.extend_from_slice(&w.to_le_bytes());
+                out.extend_from_slice(&mu.to_le_bytes());
+                out.extend_from_slice(&sigma.to_le_bytes());
             }
             out.extend_from_slice(&total.to_le_bytes());
         }
@@ -741,6 +857,19 @@ pub fn decode_repr(b: &[u8]) -> HistRepr {
             }
             let total = if o + 8 <= b.len() { read_u64(b, o) } else { 0 };
             HistRepr::Mixture { trials, comps, total }
+        }
+        5 if b.len() >= 1 + 4 + 4 => {
+            let support = read_u32(b, 1) as usize;
+            let k = read_u32(b, 5) as usize;
+            let mut comps = Vec::with_capacity(k);
+            let mut o = 9;
+            for _ in 0..k {
+                if o + 24 > b.len() { break; }
+                comps.push((read_f64(b, o), read_f64(b, o + 8), read_f64(b, o + 16)));
+                o += 24;
+            }
+            let total = if o + 8 <= b.len() { read_u64(b, o) } else { 0 };
+            HistRepr::DiscGmm { support, comps, total }
         }
         _ => HistRepr::Exact(Vec::new()),
     }
@@ -889,6 +1018,7 @@ mod tests {
             HistRepr::BetaBinomial { trials: 30, alpha: 2.5, beta: 1.5, total: 8888 },
             HistRepr::Mixture { trials: 20, comps: vec![(0.6, 0.2), (0.4, 0.8)], total: 12345 },
             HistRepr::QuantCdf { qcdf: vec![0u16, 100, 30000, 65535], total: 7777 },
+            HistRepr::DiscGmm { support: 60, comps: vec![(0.5, 20.0, 1.5), (0.5, 40.0, 2.0)], total: 6543 },
         ];
         for r in reprs {
             assert_eq!(decode_repr(&encode_repr(&r)), r, "repr roundtrip {:?}", r);
@@ -918,6 +1048,38 @@ mod tests {
         assert!(matches!(repr, HistRepr::QuantCdf { .. }),
             "expected QuantCdf fallback, got {:?}", repr);
         assert!(repr.bytes() < HistRepr::Exact(h.clone()).bytes());
+        assert!(cdf_max_error(&h, &repr.expand()) <= 0.01 + 1e-6);
+    }
+
+    // Two NARROW interior modes (sigma well below any binomial's mean-coupled width
+    // at that location): the binomial families and K<=3 binomial mixture all miss the
+    // gate, but the free-variance discretised-GMM fits — and is chosen because it
+    // undercuts the quantised-CDF fallback on bytes at this support.
+    #[test]
+    fn disc_gmm_fits_narrow_interior_modes() {
+        let support = 60usize;
+        // ground truth: 0.5*N(20,1.5) + 0.5*N(40,1.5), discretised.
+        let truth = discretised_gmm_pmf(support, &[(0.5, 20.0, 1.5), (0.5, 40.0, 1.5)]);
+        let h: Hist = truth.iter().map(|&pr| (pr * 1_000_000.0).round() as u64).collect();
+        let exact_pmf = to_pmf(&h);
+        // a single binomial and the beta-binomial are unimodal -> reject.
+        let (tb, pb) = fit_binomial(&h);
+        assert!(cdf_max_error_pmf(&exact_pmf, &binomial_pmf(tb, pb)) > 0.01);
+        // even a K=3 BINOMIAL mixture cannot make the interior modes narrow enough.
+        let (tm, comps) = fit_binomial_mixture(&h, 3, 80);
+        assert!(cdf_max_error_pmf(&exact_pmf, &mixture_pmf(tm, &comps)) > 0.01,
+            "binomial mixture cannot place narrow interior modes");
+        // the discretised-GMM (K=2) does fit within the gate.
+        let (sg, gcomps) = fit_discretised_gmm(&h, 2, 80);
+        assert!(cdf_max_error_pmf(&exact_pmf, &discretised_gmm_pmf(sg, &gcomps)) <= 0.01,
+            "discretised-GMM should fit two narrow interior modes");
+        // and the chooser selects it: smaller than exact AND than the quant-CDF table.
+        let repr = choose_representation(&h, 10, 0.01);
+        assert!(matches!(repr, HistRepr::DiscGmm { .. }),
+            "expected DiscGmm escalation, got {:?}", repr);
+        assert!(repr.bytes() < HistRepr::Exact(h.clone()).bytes());
+        assert!(repr.bytes() < HistRepr::QuantCdf { qcdf: quantize_cdf(&h), total: 0 }.bytes(),
+            "GMM must undercut the quant-CDF fallback to be chosen");
         assert!(cdf_max_error(&h, &repr.expand()) <= 0.01 + 1e-6);
     }
 

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -163,9 +163,12 @@ pub fn decode_hist(b: &[u8]) -> Hist {
 //   * The point count is a WORK TRIGGER (when to TRY compressing), NOT an
 //     acceptance gate. The doc explicitly replaces "is it over 50 points?" with
 //     "which representation is cheapest at the requested error tolerance?".
-//   * Acceptance is an ERROR CERTIFICATE on the CDF — Kolmogorov epsilon_K (and
-//     optionally Wasserstein-1) — not a heuristic. Approximation only ever drops
-//     mass within that certified budget; everything kept stays exact.
+//   * Acceptance is an ERROR CERTIFICATE on the CDF — a deterministic **certified
+//     sup-CDF (Kolmogorov-distance) tolerance** `epsilon_K` (and optionally
+//     Wasserstein-1) — NOT a Kolmogorov–Smirnov statistical test: there is no sample,
+//     no null hypothesis, and no critical value, so the discrete-KS calibration caveats
+//     do not apply. It is `max_t |F_fit(t) - F_exact(t)|` against the full exact CDF.
+//     Approximation only ever drops mass within that certified budget; the rest is exact.
 //
 // This is OPT-IN: the boundary cache is exact by default. These are the tools a
 // storage-budgeted precompute uses when an exact histogram does not fit. The
@@ -182,6 +185,16 @@ pub fn decode_hist(b: &[u8]) -> Hist {
 pub const DEFAULT_COMPRESS_MIN_POINTS: usize = 50;
 /// Default acceptance certificate: max Kolmogorov CDF error (epsilon_K).
 pub const DEFAULT_COMPRESS_EPSILON_K: f64 = 0.001;
+/// EM sweeps for the iterative fits (binomial mixture, discretised-GMM). Fixed, not
+/// convergence-tested, because the output is **gate-protected**: a non-converged fit
+/// simply misses `epsilon_K` and a cheaper rung is kept, so under-iterating costs a
+/// rejection, never accuracy. (EM is known to converge slowly for unbalanced
+/// mixtures — the asymmetric case the GMM rung targets — so this is a real safeguard.)
+const EM_ITERS: usize = 80;
+/// Minimum component sigma for the discretised-GMM (half a bin) — floors variance away
+/// from a delta collapse in EM *and* in density evaluation, so a decoded/persisted GMM
+/// cannot evaluate through a looser floor. One value, used in both places.
+const SIGMA_FLOOR: f64 = 0.5;
 
 /// Kolmogorov error `max_t |F_a(t) - F_b(t)|` between two histograms, each
 /// normalised to a PMF by its own total mass. Bounds prefix-mass / CDF query
@@ -413,7 +426,12 @@ impl HistRepr {
     }
     /// Reconstruct a count histogram (parametric forms expand to the PMF scaled to
     /// `total` and rounded). The kernel always consumes counts, so a fitted node
-    /// expands on load.
+    /// expands on load — and a splice always convolves the **expanded histograms**, never
+    /// the parametric forms. That is deliberate: for the GMM the discretise+renormalise
+    /// step is nonlinear, so an "analytic" parametric convolution would not equal the
+    /// histogram splice and would break the certified-error invariant (besides exploding
+    /// component count K_a·K_b per cut). Histogram convolution is O(S_a·S_b) — cheap even
+    /// at depth-1000 — so expand-then-convolve is both correct and fast.
     pub fn expand(&self) -> Hist {
         match self {
             HistRepr::Exact(h) => h.clone(),
@@ -589,9 +607,10 @@ pub fn fit_binomial_mixture(h: &Hist, k: usize, iters: usize) -> (usize, Vec<(f6
 // fallback on bytes. Hence "escalation only": present for the shapes the binomial
 // families genuinely cannot represent, never the default.
 
-/// Unit Gaussian density at `x` for `N(mu, sigma)` (sigma floored away from 0).
+/// Unit Gaussian density at `x` for `N(mu, sigma)` (sigma floored at `SIGMA_FLOOR`,
+/// the same floor the EM applies, so a decoded GMM cannot slip through a looser bound).
 fn gauss_density(x: f64, mu: f64, sigma: f64) -> f64 {
-    let s = sigma.max(1e-3);
+    let s = sigma.max(SIGMA_FLOOR);
     let z = (x - mu) / s;
     (-0.5 * z * z).exp() / (s * (2.0 * std::f64::consts::PI).sqrt())
 }
@@ -615,9 +634,13 @@ pub fn discretised_gmm_pmf(support: usize, comps: &[(f64, f64, f64)]) -> Vec<f64
 }
 
 /// Fit a `k`-component discretised Gaussian mixture by EM over the integer support,
-/// weighted by the empirical PMF. Components start spread across the domain with equal
-/// weight; each sweep re-estimates `(weight, mu, sigma)` freely (sigma floored at half
-/// a bin to avoid delta collapse). Returns `(support, [(weight, mu, sigma)])`.
+/// weighted by the empirical PMF. Component means are **quantile-seeded** — `mu_j` at
+/// the empirical `(j+0.5)/k` quantile — so the init adapts to all-mass-at-one-end and
+/// asymmetric-bimodal shapes (the cases that justify the rung), where an equally-spaced
+/// seed strands a component on empty support. Seeding is deterministic, so a persisted
+/// cache stays reproducible (random restarts would not). Each sweep re-estimates
+/// `(weight, mu, sigma)` freely (sigma floored at `SIGMA_FLOOR` to avoid delta
+/// collapse). Returns `(support, [(weight, mu, sigma)])`.
 pub fn fit_discretised_gmm(h: &Hist, k: usize, iters: usize) -> (usize, Vec<(f64, f64, f64)>) {
     let pmf = to_pmf(h);
     let support = pmf.len();
@@ -627,8 +650,14 @@ pub fn fit_discretised_gmm(h: &Hist, k: usize, iters: usize) -> (usize, Vec<(f64
     }
     let span = (support - 1) as f64;
     let sigma0 = (span / (2.0 * k as f64)).max(0.75);
+    // empirical CDF -> quantile seeding of the component means.
+    let mut cum = 0.0f64;
+    let cdf: Vec<f64> = pmf.iter().map(|&p| { cum += p; cum }).collect();
+    let quantile = |q: f64| -> f64 {
+        cdf.iter().position(|&c| c >= q).unwrap_or(support - 1) as f64
+    };
     let mut comps: Vec<(f64, f64, f64)> = (0..k)
-        .map(|j| (1.0 / k as f64, span * (j as f64 + 0.5) / k as f64, sigma0))
+        .map(|j| (1.0 / k as f64, quantile((j as f64 + 0.5) / k as f64), sigma0))
         .collect();
     for _ in 0..iters {
         let mut nw = vec![0.0f64; k];   // sum_i pmf[i] r_ij
@@ -656,9 +685,14 @@ pub fn fit_discretised_gmm(h: &Hist, k: usize, iters: usize) -> (usize, Vec<(f64
         let wsum: f64 = nw.iter().sum();
         if wsum <= 0.0 { break; }
         for j in 0..k {
-            if nw[j] <= 0.0 { continue; } // keep the stale component rather than NaN
+            // A dead component (zero responsibility) keeps its stale weight rather than
+            // dividing by zero; the surviving components are renormalised by `wsum`, so
+            // the stored weights may then sum to < 1. `discretised_gmm_pmf` renormalises
+            // on read, so the reconstructed PMF is still correct — the stale weight is a
+            // harmless inconsistency in the persisted params, not in the distribution.
+            if nw[j] <= 0.0 { continue; }
             let mu = nmu[j] / nw[j];
-            let var = (nmu2[j] / nw[j] - mu * mu).max(0.25); // floor sigma at 0.5 bin
+            let var = (nmu2[j] / nw[j] - mu * mu).max(SIGMA_FLOOR * SIGMA_FLOOR);
             comps[j] = (nw[j] / wsum, mu, var.sqrt());
         }
     }
@@ -692,7 +726,7 @@ fn representation_candidates(h: &Hist, min_points: usize) -> Vec<(HistRepr, f64)
         cands.push((HistRepr::BetaBinomial { trials, alpha, beta, total }, err));
     }
     for k in [2usize, 3] {
-        let (trials, comps) = fit_binomial_mixture(h, k, 60);
+        let (trials, comps) = fit_binomial_mixture(h, k, EM_ITERS);
         let err = cdf_max_error_pmf(&exact_pmf, &mixture_pmf(trials, &comps));
         cands.push((HistRepr::Mixture { trials, comps, total }, err));
     }
@@ -700,7 +734,7 @@ fn representation_candidates(h: &Hist, min_points: usize) -> Vec<(HistRepr, f64)
         // escalation: free-variance Gaussian modes (narrow interior modes the
         // binomial families cannot place); costlier than the mixture, so only wins
         // in that niche.
-        let (support, comps) = fit_discretised_gmm(h, k, 80);
+        let (support, comps) = fit_discretised_gmm(h, k, EM_ITERS);
         let err = cdf_max_error_pmf(&exact_pmf, &discretised_gmm_pmf(support, &comps));
         cands.push((HistRepr::DiscGmm { support, comps, total }, err));
     }
@@ -1080,6 +1114,35 @@ mod tests {
         assert!(repr.bytes() < HistRepr::Exact(h.clone()).bytes());
         assert!(repr.bytes() < HistRepr::QuantCdf { qcdf: quantize_cdf(&h), total: 0 }.bytes(),
             "GMM must undercut the quant-CDF fallback to be chosen");
+        assert!(cdf_max_error(&h, &repr.expand()) <= 0.01 + 1e-6);
+    }
+
+    // Three narrow interior modes: K=2 cannot cover them (one mode mis-modelled, gate
+    // missed), so the chooser must escalate to a K=3 DiscGmm — exercising the K=3
+    // selection path and the quantile-seeded init on an asymmetric (uneven-weight) shape.
+    #[test]
+    fn disc_gmm_selects_k3_for_three_modes() {
+        let support = 60usize;
+        // uneven weights so the seeding/asymmetry path is exercised, not a symmetric one.
+        let truth = discretised_gmm_pmf(
+            support, &[(0.25, 12.0, 1.2), (0.45, 30.0, 1.2), (0.30, 48.0, 1.2)]);
+        let h: Hist = truth.iter().map(|&pr| (pr * 1_000_000.0).round() as u64).collect();
+        let exact_pmf = to_pmf(&h);
+        // K=2 GMM leaves one mode uncovered -> misses the gate.
+        let (s2, c2) = fit_discretised_gmm(&h, 2, EM_ITERS);
+        assert!(cdf_max_error_pmf(&exact_pmf, &discretised_gmm_pmf(s2, &c2)) > 0.01,
+            "K=2 cannot cover three modes");
+        // K=3 GMM fits.
+        let (s3, c3) = fit_discretised_gmm(&h, 3, EM_ITERS);
+        assert!(cdf_max_error_pmf(&exact_pmf, &discretised_gmm_pmf(s3, &c3)) <= 0.01,
+            "K=3 GMM should fit three narrow interior modes");
+        // the chooser picks a 3-component DiscGmm (cheaper than quant-CDF at this support).
+        let repr = choose_representation(&h, 10, 0.01);
+        match &repr {
+            HistRepr::DiscGmm { comps, .. } => assert_eq!(comps.len(), 3, "expected K=3"),
+            other => panic!("expected K=3 DiscGmm, got {:?}", other),
+        }
+        assert!(repr.bytes() < HistRepr::QuantCdf { qcdf: quantize_cdf(&h), total: 0 }.bytes());
         assert!(cdf_max_error(&h, &repr.expand()) <= 0.01 + 1e-6);
     }
 


### PR DESCRIPTION
Completes the boundary-suffix approximation ladder (**Rungs 1–6**). This rung was developed alongside PR #3224 but landed after that PR was merged at the quantised-CDF commit, so it's broken out here on its own so it isn't lost.

Every prior parametric rung is a **binomial family**, whose per-component variance is pinned to its mean (`n·p·(1−p)`); that coupling means a binomial mixture cannot place a **narrow** mode in the *interior* of the support (a tight mode forces `p` toward an edge).

`HistRepr::DiscGmm{support,comps,total}` lifts the coupling — each component carries a free `(weight, mu, sigma)`, fitted by EM over the integer support (`fit_discretised_gmm`) and evaluated/renormalised by `discretised_gmm_pmf`. It costs the most params/mode of any rung, so the chooser selects it only when **every cheaper rung misses the CDF gate AND** it still undercuts the quantised-CDF table on bytes. Escalation only, never the default.

- `encode_repr`/`decode_repr` tag 5; `bytes()`/`pmf()`/`expand()`/`total()` arms.
- `representation_candidates` adds K=2,3 GMM fits, gated like the mixture.
- Test `disc_gmm_fits_narrow_interior_modes`: two `σ=1.5` modes at 20/40 — binomial, beta-binomial, and K≤3 binomial mixture all rejected; the GMM fits within `ε_K` and is chosen. **35 lib tests pass.**
- Docs: spec Rung 6 + §9b ladder-complete status; cache-plan rung DONE; how-to chooser order + representation map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_