### PR TITLE
Support PLAWK scalar NF expressions

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -287,10 +287,10 @@ Scalar counters lower through an explicit codegen state plan that keeps
 source-level state recognition separate from LLVM slot numbering. The same
 native slots now support `+=` with integer constants and field lengths, so
 programs such as `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`
-stay in the compiled stream loop. Plain scalar assignment to integer literals or
-field lengths uses the same native slot path and is folded in source order with
-later `++`/`+=` updates, so programs such as `$1 == "ERROR" { last_len =
-length($0); hits++ } END { print hits, last_len }` also stay native. The first
+stay in the compiled stream loop. Plain scalar assignment to integer literals,
+`NR`, `NF`, or field lengths uses the same native slot path and is folded in
+source order with later `++`/`+=` updates, so `last_len = length($0)` followed
+by `hits++` also stays native. The first
 native `if/else` action slice lowers field-equality conditions once at rule-body
 scope, threads the whole scalar slot vector through then/else action sequences,
 emits per-slot phis at the branch join, and can run field-key associative

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -103,9 +103,9 @@ e.g. `$1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }`.
 Plain scalar assignment uses the same native slot path and preserves source
 order with later updates, e.g. `$1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }`. The current assignment expression subset is
-integer literals, `length($N)`, numeric `$N`, explicit `int($N)`, and
-native scalar `i64` primary `+/- K` forms such as `NF + K`, `length($N) - K`,
-and `int($N) + K`.
+integer literals, `NR`, `NF`, `length($N)`, numeric `$N`, explicit `int($N)`,
+and native scalar `i64` primary `+/- K` forms such as `NF + K`,
+`length($N) - K`, and `int($N) + K`.
 Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -253,9 +253,9 @@ $1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }
 ```
 
-The current assignment expression subset is integer literals, `length($N)`,
-numeric `$N`, explicit `int($N)`, and native scalar `i64` primary `+/- K` forms
-such as `NF + K`, `length($N) - K`, and `int($N) + K`.
+The current assignment expression subset is integer literals, `NR`, `NF`,
+`length($N)`, numeric `$N`, explicit `int($N)`, and native scalar `i64`
+primary `+/- K` forms such as `NF + K`, `length($N) - K`, and `int($N) + K`.
 
 Numeric field guards are also native:
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -48,7 +48,7 @@
 %      $1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
-%      { adjusted += length($0) - 3; width = NF + 1 } END { print adjusted, width }
+%      { adjusted += length($0) - 3; width = NF; fields += NF } END { print adjusted, width, fields }
 %      { last = NR; prev = NR - 1; total += NR + 1 } END { print last, prev, total }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -27,7 +27,7 @@
 %      $1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
-%      { adjusted += length($0) - 3; width = NF + 1 } END { print adjusted, width }
+%      { adjusted += length($0) - 3; width = NF; fields += NF } END { print adjusted, width, fields }
 %      { last = NR; prev = NR - 1; total += NR + 1 } END { print last, prev, total }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
@@ -362,6 +362,8 @@ scalar_delta_expr(Expr) -->
     i64_const_binary_expr(Expr).
 scalar_delta_expr(special('NR')) -->
     "NR".
+scalar_delta_expr(special('NF')) -->
+    "NF".
 scalar_delta_expr(field(Index)) -->
     "$",
     integer_codes(IndexCodes),

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -252,6 +252,15 @@ test(parses_scalar_nr_add_assign_end_print_rule) :-
          add(var(next_total), add_i64(special('NR'), int(1)))])],
         [end([print([var(last), var(total), var(prev), var(next_total)])])])).
 
+test(parses_scalar_nf_add_assign_end_print_rule) :-
+    plawk_parse_string("{ width = NF; total += NF; adjusted = NF - 1; next_width += NF + 1 } END { print width, total, adjusted, next_width }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [set(var(width), special('NF')),
+         add(var(total), special('NF')),
+         set(var(adjusted), sub_i64(special('NF'), int(1))),
+         add(var(next_width), add_i64(special('NF'), int(1)))])],
+        [end([print([var(width), var(total), var(adjusted), var(next_width)])])])).
+
 test(parses_always_scalar_add_assign_end_print_rule) :-
     plawk_parse_string("{ total += 3 } END { print total }\n", Program),
     assertion(Program == program([], [rule(always, [add(var(total), int(3))])],
@@ -609,6 +618,11 @@ test(surface_scalar_nr_accumulates_values) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\n",
         "3 6 2 9\n").
 
+test(surface_scalar_nf_accumulates_values) :-
+    run_surface_print_smoke("{ width = NF; total += NF; adjusted = NF - 1; next_width += NF + 1 } END { print width, total, adjusted, next_width }\n",
+        "INFO boot ok\nERROR disk full now\nWARN cpu\n",
+        "2 9 1 12\n").
+
 test(surface_always_scalar_add_assign_accumulates_constants) :-
     run_surface_print_smoke("{ total += 3 } END { print total }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -958,6 +972,17 @@ test(surface_scalar_nr_uses_native_record_counter) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 0, %current_nr'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '= sub i64 %current_nr, 1'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 %current_nr, 1'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_scalar_nf_uses_native_field_count_primary) :-
+    plawk_parse_string("BEGIN { FS = \":\" } { width = NF; total += NF; adjusted = NF - 1; next_width += NF + 1 } END { print width, total, adjusted, next_width }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= call i64 @wam_atom_field_count_value(%Value %line, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 0, %rule_0_body_slot_3_op_0_i64_primary'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 %slot_2, %rule_0_body_slot_2_op_1_i64_primary'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= sub i64 %rule_0_body_slot_0_op_2_i64_sub_lhs, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 %rule_0_body_slot_1_op_3_i64_add_lhs, 1'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
  ## Summary
  - Parse bare `NF` in PLAWK scalar assignment and `+=` expressions.
  - Add native smoke and IR coverage for `NF`, `NF - K`, and `NF + K` in scalar state updates.
  - Update PLAWK docs/examples to list bare `NR` and `NF` as supported scalar assignment expressions.

  ## Tests
  - `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/
  uw_smoke_nf_full'),run_tests" -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_nf_core swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_nf_compiled_stream swipl -q -s tests/test_plawk_compiled_stream_core.pl -g run_tests
  -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_nf_native_outer swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g run_tests
  -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_nf_native_stream swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g
  run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_nf_native_counter swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl
  -g run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_nf_native_output swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g
  run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_nf_native_lowered swipl -q -s tests/
  test_plawk_native_lowered_handler_stream_loop_driver.pl -g run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_nf_compiled_append swipl -q -s tests/test_plawk_compiled_output_append.pl -g
  run_tests -t halt`
  - `git diff --check`