### PR TITLE
feat(wam-rust): min-plus cyclic closure — the tropical foundation (increment 2a)

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -275,7 +275,14 @@ graph. This is the right and load-bearing domain:
   **closed-semiring** version (`a* = ⊕ aⁱ` must converge — min-plus on nonnegative
   weights does, counting does not without truncation), which in this codebase is the
   existing **budget + visited-guard** truncation. Exact on poset/taxonomic data;
-  truncation-approximate on general graphs.
+  truncation-approximate on general graphs. **The DFS+memo recurrences are themselves
+  unsound on cycles** — the `on_stack` guard makes a node's value depend on the current
+  stack, and that context-dependent value is then memoised (a node first reached inside a
+  cycle can be cached as wrongly `None`/unreachable). The closed-semiring solve is
+  context-free; for min-plus it is `min_distance_closure` (**[2a, implemented]** a BFS
+  fixpoint from the root over the reversed graph, `a* = 0`, O(V+E), cycle-correct).
+  `min_distance_closure_is_cycle_correct_where_dfs_poisons` exhibits exactly the cyclic
+  case where the DFS memo poisons a node and the closure does not.
 
 ### Convergence, not just acyclicity: why unbounded length is meaningful here
 
@@ -451,6 +458,15 @@ future work — `m₃` is now carried, so they are a read-out away.
    `astar_shortest_path4` (boundary suffixes as ALT landmarks), adding the
    closed-semiring / budget-truncation path for cyclic up-sets — the only genuinely new
    correctness work.
+   - **[2a DONE]** the min-plus closure foundation: `min_distance_closure` (a BFS fixpoint,
+     `a* = 0`) computes cycle-correct shortest `node→root` distances, where the DFS+memo
+     recurrences are unsound on cycles (§4). This is also the §1.5 closure characterization
+     for the min-plus payload, settled before the kernel wiring.
+   - **[2b next]** the weighted min-plus payload (edge weights, not hop count) and the
+     distance splice (`min_B (dist(seed→B) + dist(B→root))` — the ALT landmark lower bound),
+     then the `transitive_distance3` / `astar_shortest_path4` kernel wiring. This is also
+     where a second concrete instance finally motivates extracting the `PathSemiring` trait
+     (with the now-settled star/closure contract).
 
 ## 9. Relationship to the other docs
 

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -310,6 +310,58 @@ pub fn suffix_interval(
     acc
 }
 
+// --- Increment 2: the tropical (min-plus) closure for cyclic graphs ---
+//
+// The DFS recurrences above (`suffix_histogram`, `suffix_moment_jet`, `suffix_interval`)
+// are exact on a DAG but **unsound on a cyclic graph**: the `on_stack` guard makes a
+// node's value depend on which ancestors are currently on the stack, and that
+// context-dependent value is then *memoised* — so a node first computed inside a cycle
+// can be cached with a wrong (e.g. `None`/unreachable) value. On an acyclic ancestor
+// space this never bites (no node is its own ancestor); on a general graph it does.
+//
+// The fix is the **closed-semiring** solve, which is context-free. For min-plus
+// (shortest distance) on non-negative weights the star is `a* = 0` — looping never
+// shortens a path — so the closure is a plain fixpoint: a breadth-first sweep from the
+// root over the reversed (parent→child) edges. This is the foundation for the distance /
+// shortest-path kernels (the second semiring). Max-plus (longest) and counting are NOT
+// closed on cycles (a cycle makes them diverge) and still require budget truncation.
+
+/// Shortest `node → root` hop-distance for every node that can reach `root`, as the
+/// **min-plus (tropical) closure** — correct even on cyclic graphs, where the DFS
+/// `suffix_interval` recurrence is not. A BFS from `root` over the reversed parent graph
+/// (`parent → child`), O(V+E), cycle-safe by construction. Nodes that cannot reach `root`
+/// are absent from the map (distance `+∞`). `root` maps to `0`.
+pub fn min_distance_closure(
+    root: u32,
+    parents: &std::collections::HashMap<u32, Vec<u32>>,
+) -> std::collections::HashMap<u32, u32> {
+    use std::collections::{HashMap, VecDeque};
+    // reverse child->parent into parent->children, so a BFS from root walks *toward* the
+    // nodes (its hop-level = their shortest distance back to root).
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    for (&child, ps) in parents {
+        for &p in ps {
+            children.entry(p).or_default().push(child);
+        }
+    }
+    let mut dist: HashMap<u32, u32> = HashMap::new();
+    let mut q: VecDeque<u32> = VecDeque::new();
+    dist.insert(root, 0);
+    q.push_back(root);
+    while let Some(u) = q.pop_front() {
+        let du = dist[&u];
+        if let Some(cs) = children.get(&u) {
+            for &c in cs {
+                if !dist.contains_key(&c) {
+                    dist.insert(c, du + 1);
+                    q.push_back(c);
+                }
+            }
+        }
+    }
+    dist
+}
+
 /// Oracle read-outs: the `(M, m1, m2, m3)` moment jet of an explicit histogram. The
 /// directly-propagated `suffix_moment_jet` must equal this on an untruncated histogram —
 /// the exactness check the tests assert.
@@ -1703,9 +1755,41 @@ mod tests {
         }
     }
 
-    // The ⊗ laws (binomial moment convolution; interval addition) reproduce the moments
-    // of an explicit splice — so a query may convolve cached jets instead of histograms.
+    // Increment 2a — min-plus closure. On a DAG it agrees with the DFS recurrence's `min`.
     #[test]
+    fn min_distance_closure_matches_dfs_on_dag() {
+        let g = graph();
+        let dist = min_distance_closure(0, &g);
+        for node in [0u32, 1, 2, 3, 4, 5] {
+            let mut memo = HashMap::new();
+            let mut on_stack = vec![];
+            let dfs = suffix_interval(node, 0, &g, &mut memo, &mut on_stack);
+            assert_eq!(dist.get(&node).copied(), dfs.map(|iv| iv.min),
+                "node {} shortest distance", node);
+        }
+    }
+
+    // On a CYCLIC graph the closure is correct, while the DFS+memo recurrence poisons a
+    // node reached inside the cycle to `None` (unreachable). root = 0; W(5) and Z(6) form a
+    // cycle (5→6, 6→5) and W reaches the root (5→0). True shortest-to-root: W=1, Z=2.
+    #[test]
+    fn min_distance_closure_is_cycle_correct_where_dfs_poisons() {
+        let mut parents: HashMap<u32, Vec<u32>> = HashMap::new();
+        parents.insert(5, vec![0, 6]); // W: parents root and Z
+        parents.insert(6, vec![5]);    // Z: parent W  -> the 5↔6 cycle
+        // the closure gets both right.
+        let dist = min_distance_closure(0, &parents);
+        assert_eq!(dist.get(&5), Some(&1), "W shortest = 1");
+        assert_eq!(dist.get(&6), Some(&2), "Z shortest = 2 (6→5→0)");
+        // the DFS recurrence, querying W first, memoises Z as unreachable — the
+        // cyclic-unsound result the closure exists to fix.
+        let mut memo = HashMap::new();
+        let mut on_stack = vec![];
+        let _w = suffix_interval(5, 0, &parents, &mut memo, &mut on_stack);
+        assert_eq!(memo.get(&6), Some(&None),
+            "DFS+memo poisons Z to None on the cycle (the bug the closure avoids)");
+    }
+
     fn convolve_laws_match_spliced_histogram() {
         // two arbitrary length distributions (as histograms).
         let a: Hist = vec![0, 3, 5, 2];     // lengths 1,2,3


### PR DESCRIPTION
**Increment 2a** — opens the distance / second-semiring frontier with its genuinely-new correctness piece: a shortest-distance solve that is correct on **cyclic** graphs.

## The problem it fixes

The DFS+memo recurrences from increment 1 (`suffix_histogram`, `suffix_moment_jet`, `suffix_interval`) are exact on a DAG but **unsound on a cyclic graph**: the `on_stack` guard makes a node's value depend on which ancestors are currently on the stack, and that context-dependent value is then *memoised* — so a node first reached inside a cycle can be cached as wrongly `None`/unreachable. On the acyclic ancestor space (increment 1's domain) this never bites; on a general graph it does.

## What's added

- **`min_distance_closure(root, parents)`** — the min-plus (tropical) **closure**: a BFS fixpoint from the root over the reversed parent graph. Min-plus on non-negative weights is a closed semiring (`a* = 0`: looping never shortens a path), so the closure is context-free and cycle-correct, O(V+E). Nodes that can't reach the root are absent (distance `+∞`).

## Tests (46 lib tests pass)

- `min_distance_closure_matches_dfs_on_dag` — on a DAG it agrees with the DFS recurrence's `min` at every node.
- `min_distance_closure_is_cycle_correct_where_dfs_poisons` — a `5↔6` cycle where the closure gets `W=1, Z=2` right while the DFS+memo **poisons** `Z` to `None`. This makes the correctness boundary concrete (and is why the closure exists).

## Scope

This is also the **§1.5 closure characterization** for the min-plus payload — settled *before* the kernel wiring, so the next step confronts one unknown at a time. Docs: theory §4 (the cyclic-closure paragraph now names the DFS-memo unsoundness and the closure) and §8 (2a done).

**Next (2b):** the weighted min-plus payload (edge weights, not just hop count) + the distance splice (`min_B (dist(seed→B) + dist(B→root))` — the ALT landmark lower bound), then the `transitive_distance3` / `astar_shortest_path4` kernel wiring — which is where a second concrete instance finally motivates extracting the `PathSemiring` trait with the now-settled star/closure contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_