### PR TITLE
refactor(wam-rust): extract the PathSemiring trait (increment 2d-i)

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -214,35 +214,41 @@ carry the whole histogram, or accept the cheap **bracket** of §5 instead.
 
 ## 3. The `PathSemiring` framework
 
+**[Implemented — increment 2d.]** With two concrete instances in hand (the moment jet and
+the tropical interval) and the cyclic star settled (§4, increment 2a), the trait is now
+real, not a sketch:
+
 ```rust
-trait PathSemiring {
-    type Elem: Clone;
-    fn zero() -> Self::Elem;          // ⊕-identity: "no path here" / unreachable
-    fn one()  -> Self::Elem;          // ⊗-identity: the root / empty path
-    fn add(a: &Self::Elem, b: &Self::Elem) -> Self::Elem;   // combine alternatives
-    fn mul(a: &Self::Elem, b: &Self::Elem) -> Self::Elem;   // extend by one edge / concat
-    // optional: edge label for weighted graphs; a degree/budget truncation hook
+pub trait PathSemiring: Copy {
+    fn zero() -> Self;            // ⊕-identity: unreachable / no path
+    fn one()  -> Self;            // ⊗-identity: the root / empty path
+    fn add(self, other: Self) -> Self;   // ⊕ — combine a node's parents
+    fn step(self) -> Self;               // ⊗ by one edge (shift_one); keeps `zero` inert
 }
-// suffix_value::<S>(node, root, parents, budget, memo)  — generic `suffix_histogram`
+// suffix_value::<S>(node, root, parents, memo, on_stack) — the one generic recurrence;
+// suffix_moment_jet = suffix_value::<MomentJet>, suffix_interval wraps suffix_value::<Interval>.
 ```
 
-`suffix_histogram` becomes one instance; `(min, max, mass, m₁, m₂)` becomes another (a
-product semiring); the future scalar shortest-distance is a third. The band selection,
-shared-memo sweep, eviction, and persistence skeleton are payload-agnostic — only the
-per-node `Elem` changes (from `Vec<u64>` to a 5-scalar tuple, etc.).
+`MomentJet` and `Interval` both implement it, so the two recurrences collapse to one
+generic `suffix_value`. Adding a payload is now: implement four methods. How the review's
+three trait gaps were resolved:
 
-> **The trait above is illustrative, not the final contract — three gaps to close at §8.**
-> (1) **Star / closure for cycles.** The "optional truncation hook" cannot encode the
-> per-semiring divergence profile the cyclic increment (§8.2) needs: counting *diverges*
-> without truncation, min-plus *terminates* freely, and the moment jet's star converges
-> only if mass `< 1` (the walk terminates with probability 1; cf. closed/`*`-semirings,
-> Droste–Kuich). A real `star`/closure operation is per-semiring and deserves a dedicated
-> design step, not a boolean flag. (2) **No read-out / decode contract.** There is no typed
-> surface for "project `Elem` → the query answer" — the step both §8.1's bucket-for-bucket
-> validation and the Edgeworth read-out (§7) need. (3) **The `⊕`/`⊗` exactness asymmetry is
-> invisible.** Raw moments are exact under both, but a budget truncation breaks only `⊗`
-> (concatenation), never `⊕` (§2 precondition) — an invariant that currently lives only in
-> prose and will not survive a second implementor through a flat `add`/`mul` interface.
+- **(1) Star / closure for cycles** — *not* a trait method, deliberately. The closure
+  exists only for *closed* payloads: min-plus is closed (its star is the separate
+  `min_distance_closure` / `weighted_distance_closure`), while counting/moments diverge on
+  a cycle. So `star` is a per-payload free function, not a method some impls could not
+  honour. (`suffix_value` itself is the acyclic recurrence.)
+- **(2) ⊕/⊗ asymmetry** — `step` (⊗ by an edge) is exact only untruncated; a budget would
+  break `step`/⊗ but never `add`/⊕. The recurrence never truncates (acyclic, budget-free),
+  so it is exact; the asymmetry is documented on the trait and the budgeted case lives in
+  the histogram path. The `zero`-inert-under-`step` law (so unreachable parents contribute
+  nothing) is enforced by `path_semiring_laws_and_generic_equivalence`.
+- **(3) Read-out / decode** — left payload-specific for now (`MomentJet` → mean/variance/
+  skew; `Interval` → min/max), since a common typed read-out has no clean shared codomain;
+  a generic `project` is deferred until a consumer needs it.
+
+The band selection, shared-memo sweep, eviction, and persistence skeleton remain
+payload-agnostic — only the per-node element type changes.
 
 | payload | semiring | cost | answers | exact for |
 |---|---|---|---|---|
@@ -474,11 +480,14 @@ future work — `m₃` is now carried, so they are a read-out away.
      `category_ancestor_boundary_distance` (a BFS from the seed that stops at a cached
      boundary and adds its suffix — the ALT-landmark prune; degrades to a plain correct
      BFS with an empty cache). Validated by `boundary_distance_splice_matches_closure`.
-   - **[2d next]** wire it into the `transitive_distance3` / `astar_shortest_path4` kernel
-     *codegen* (the Prolog target), and extract the `PathSemiring` trait now that two
-     concrete instances (moment-jet, distance) and the star/closure contract exist — a
-     deduplicating refactor of `suffix_moment_jet` / `suffix_interval` behind one generic
-     `suffix_value::<S>`, with the closure as the min-plus `star`.
+   - **[2d-i DONE]** the `PathSemiring` trait is extracted (§3): `MomentJet` and `Interval`
+     implement it, and `suffix_moment_jet` / `suffix_interval` are now thin instances of one
+     generic `suffix_value::<S>`. The cyclic star stays a per-payload free function (only
+     min-plus is closed), the ⊕/⊗ asymmetry is on the trait, and the laws are guarded by
+     `path_semiring_laws_and_generic_equivalence`.
+   - **[2d-ii next]** wire the distance cache into the `transitive_distance3` /
+     `astar_shortest_path4` kernel *codegen* (the Prolog target) so a compiled query uses
+     it, closing increment 2.
 
 ## 9. Relationship to the other docs
 

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -257,25 +257,71 @@ impl Interval {
     }
 }
 
-/// `MomentJet` for `node → root` by the moment recurrence — never forming the histogram.
-/// Memoised, cycle-safe (a node on the current DFS stack contributes `zero`). No budget:
-/// exact on an acyclic ancestor space (the moment law requires untruncated convolution).
-pub fn suffix_moment_jet(
+/// The algebraic-path-problem interface a payload implements so the *one* generic
+/// recurrence `suffix_value` can propagate it: `f(root) = one; f(v) = ⊕_p (edge ⊗ f(p))`.
+/// `zero` is the ⊕-identity (unreachable / no path), `one` the ⊗-identity (the root /
+/// empty path), `add` is ⊕ (combine a node's parents), `step` is ⊗ by one edge
+/// (`shift_one`). See docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md §2–§3.
+///
+/// Two deliberate scoping notes (the review's trait gaps):
+/// - **The ⊕/⊗ asymmetry.** `step` (⊗ by an edge) is exact only untruncated; a budget cap
+///   would break `step`/⊗ but never `add`/⊕ (§2 precondition). The acyclic recurrence here
+///   never truncates, so it is exact; the cyclic/budgeted case is handled elsewhere.
+/// - **The *star* is not a method here.** The closed-semiring closure (the cyclic solve)
+///   exists only for *closed* payloads: min-plus is closed — its star is the separate
+///   `min_distance_closure` / `weighted_distance_closure` — while counting/moments are NOT
+///   closed (they diverge on a cycle). So `star` lives as a per-payload free function, not
+///   a trait method that some impls could not honour.
+pub trait PathSemiring: Copy {
+    /// ⊕-identity: unreachable / no path.
+    fn zero() -> Self;
+    /// ⊗-identity: the root / empty path.
+    fn one() -> Self;
+    /// ⊕ — combine alternative path sets (a node's several parents).
+    fn add(self, other: Self) -> Self;
+    /// ⊗ by one edge — prepend an edge (`shift_one`). Must keep `zero` inert (`zero.step()`
+    /// stays add-neutral) so unreachable parents contribute nothing.
+    fn step(self) -> Self;
+}
+
+impl PathSemiring for MomentJet {
+    fn zero() -> Self { MomentJet::zero() }
+    fn one() -> Self { MomentJet::root() }
+    fn add(self, o: Self) -> Self { self.union(o) }
+    fn step(self) -> Self { self.shift_one() } // zero-mass jet shifts to itself: inert
+}
+
+impl PathSemiring for Interval {
+    /// Unreachable sentinel `{min: u32::MAX, max: 0}` — an impossible real interval
+    /// (`min > max`), so it never collides with a genuine one and is the `union` identity.
+    fn zero() -> Self { Interval { min: u32::MAX, max: 0 } }
+    fn one() -> Self { Interval::root() }
+    fn add(self, o: Self) -> Self { self.union(o) } // min-of-mins / max-of-maxes; zero is id
+    fn step(self) -> Self {
+        if self == <Interval as PathSemiring>::zero() { self } else { self.shift_one() }
+    }
+}
+
+/// The one generic `node → root` recurrence, parameterised by the payload semiring `S`:
+/// `f(root) = one; f(v) = ⊕_p (edge ⊗ f(p))`. Memoised, cycle-safe (a node on the DFS
+/// stack contributes `zero`), **no budget** — exact on an acyclic ancestor space.
+/// `suffix_moment_jet` and `suffix_interval` are its two instances; the cyclic case needs
+/// the per-payload closure instead (see the trait note).
+pub fn suffix_value<S: PathSemiring>(
     node: u32,
     root: u32,
     parents: &std::collections::HashMap<u32, Vec<u32>>,
-    memo: &mut std::collections::HashMap<u32, MomentJet>,
+    memo: &mut std::collections::HashMap<u32, S>,
     on_stack: &mut Vec<u32>,
-) -> MomentJet {
-    if node == root { return MomentJet::root(); }
-    if let Some(j) = memo.get(&node) { return *j; }
-    if on_stack.contains(&node) { return MomentJet::zero(); }
+) -> S {
+    if node == root { return S::one(); }
+    if let Some(&v) = memo.get(&node) { return v; }
+    if on_stack.contains(&node) { return S::zero(); }
     on_stack.push(node);
-    let mut acc = MomentJet::zero();
+    let mut acc = S::zero();
     if let Some(ps) = parents.get(&node) {
         for &p in ps {
-            let pj = suffix_moment_jet(p, root, parents, memo, on_stack);
-            acc = acc.union(pj.shift_one());
+            acc = acc.add(suffix_value(p, root, parents, memo, on_stack).step());
         }
     }
     on_stack.pop();
@@ -283,32 +329,32 @@ pub fn suffix_moment_jet(
     acc
 }
 
-/// `Interval` for `node → root` by the tropical recurrence. `None` = unreachable.
-/// Memoised, cycle-safe (a node on the stack contributes `None`). No budget.
+/// `MomentJet` for `node → root` — the moment-semiring instance of `suffix_value` (never
+/// forms the histogram). Memoised, cycle-safe, no budget (exact on an acyclic ancestor
+/// space; the moment law requires untruncated convolution).
+pub fn suffix_moment_jet(
+    node: u32,
+    root: u32,
+    parents: &std::collections::HashMap<u32, Vec<u32>>,
+    memo: &mut std::collections::HashMap<u32, MomentJet>,
+    on_stack: &mut Vec<u32>,
+) -> MomentJet {
+    suffix_value(node, root, parents, memo, on_stack)
+}
+
+/// `Interval` for `node → root` — the tropical instance of `suffix_value`. `None` =
+/// unreachable (the `zero` sentinel). Memoised, cycle-safe, no budget.
 pub fn suffix_interval(
     node: u32,
     root: u32,
     parents: &std::collections::HashMap<u32, Vec<u32>>,
-    memo: &mut std::collections::HashMap<u32, Option<Interval>>,
+    memo: &mut std::collections::HashMap<u32, Interval>,
     on_stack: &mut Vec<u32>,
 ) -> Option<Interval> {
-    if node == root { return Some(Interval::root()); }
-    if let Some(iv) = memo.get(&node) { return *iv; }
-    if on_stack.contains(&node) { return None; }
-    on_stack.push(node);
-    let mut acc: Option<Interval> = None;
-    if let Some(ps) = parents.get(&node) {
-        for &p in ps {
-            if let Some(pi) = suffix_interval(p, root, parents, memo, on_stack) {
-                let shifted = pi.shift_one();
-                acc = Some(match acc { Some(a) => a.union(shifted), None => shifted });
-            }
-        }
-    }
-    on_stack.pop();
-    memo.insert(node, acc);
-    acc
+    let v = suffix_value(node, root, parents, memo, on_stack);
+    if v == <Interval as PathSemiring>::zero() { None } else { Some(v) }
 }
+
 
 // --- Increment 2: the tropical (min-plus) closure for cyclic graphs ---
 //
@@ -1849,8 +1895,37 @@ mod tests {
         let mut memo = HashMap::new();
         let mut on_stack = vec![];
         let _w = suffix_interval(5, 0, &parents, &mut memo, &mut on_stack);
-        assert_eq!(memo.get(&6), Some(&None),
-            "DFS+memo poisons Z to None on the cycle (the bug the closure avoids)");
+        assert_eq!(memo.get(&6), Some(&<Interval as PathSemiring>::zero()),
+            "DFS+memo poisons Z to the unreachable sentinel on the cycle (the closure avoids it)");
+    }
+
+    // Increment 2d — the PathSemiring laws both payloads must satisfy for the generic
+    // `suffix_value` to be exact: `zero` is the ⊕-identity and stays inert under `step`
+    // (so unreachable parents contribute nothing), and the named recurrences route through
+    // the one generic.
+    #[test]
+    fn path_semiring_laws_and_generic_equivalence() {
+        // MomentJet: zero is add-identity and shifts to itself.
+        let mz = <MomentJet as PathSemiring>::zero();
+        let mx = MomentJet { mass: 3.0, m1: 4.0, m2: 9.0, m3: 27.0 };
+        assert_eq!(mx.add(mz), mx);
+        assert_eq!(mz.add(mx), mx);
+        assert_eq!(mz.step(), mz);
+        assert_eq!(mz.step().add(mx), mx);
+        // Interval: the sentinel zero is union-identity and stays inert under an edge.
+        let iz = <Interval as PathSemiring>::zero();
+        let ix = Interval { min: 2, max: 5 };
+        assert_eq!(ix.add(iz), ix);
+        assert_eq!(iz.add(ix), ix);
+        assert_eq!(iz.step(), iz, "unreachable stays unreachable under an edge");
+        // the named wrappers are exactly the generic instances.
+        let g = graph();
+        let (mut m1, mut s1) = (HashMap::new(), vec![]);
+        let (mut m2, mut s2) = (HashMap::new(), vec![]);
+        assert_eq!(
+            suffix_value::<MomentJet>(5, 0, &g, &mut m1, &mut s1),
+            suffix_moment_jet(5, 0, &g, &mut m2, &mut s2),
+        );
     }
 
     // Increment 2b — the weighted min-plus closure agrees with the unweighted BFS closure


### PR DESCRIPTION
**Increment 2d-i** — extracts the `PathSemiring` trait, the unifying abstraction the whole arc has been building toward. I deferred it through 1c/2c on purpose (premature until there were two instances and a settled star contract); both conditions now hold, so it earns its place rather than being churn-for-churn's-sake.

## What's added (`boundary_cache.rs.mustache`)

- **`trait PathSemiring`** — `zero` (⊕-identity), `one` (⊗-identity), `add` (⊕ — combine a node's parents), `step` (⊗ by one edge). `MomentJet` and `Interval` both implement it. `Interval`'s ⊕-identity is an unreachable sentinel `{min: u32::MAX, max: 0}` (an impossible real interval), with `step` keeping it inert.
- **`suffix_value::<S>`** — the *one* generic `node→root` recurrence. `suffix_moment_jet` is now `suffix_value::<MomentJet>`; `suffix_interval` wraps `suffix_value::<Interval>` (converting the sentinel back to `None`). Two near-identical ~15-line recurrences collapse to one. Adding a payload is now: implement four methods.

## The review's three trait gaps, resolved

- **(1) Star / closure** — deliberately *not* a trait method. Only *closed* payloads have one (min-plus → the separate `min_distance_closure` / `weighted_distance_closure`); counting/moments diverge on a cycle. So `star` is a per-payload free function, not a method some impls couldn't honour. `suffix_value` is the acyclic recurrence.
- **(2) ⊕/⊗ asymmetry** — documented on the trait; `step` (⊗) is exact only untruncated, `add` (⊕) always. The `zero`-inert-under-`step` law is enforced by a test.
- **(3) Read-out / decode** — left payload-specific (`MomentJet` → mean/variance/skew; `Interval` → min/max), since a common read-out has no clean shared codomain yet.

## Tests (52 lib tests pass)

`path_semiring_laws_and_generic_equivalence` guards the algebraic laws and that the named wrappers equal the generic. The behavior is otherwise unchanged — every existing test now simply routes through `suffix_value`, and they all still pass (the cycle-poisoning test was updated for the new memo element type).

## Increment 2 status

```
2a ✅ min-plus cyclic closure    2b ✅ weighted closure + splice    2c ✅ distance cache in WamState
2d-i ✅ PathSemiring trait extraction (this PR)
2d-ii ⏭ transitive_distance3 / astar_shortest_path4 kernel codegen (the Prolog target)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_