### PR TITLE
feat(wam-rust): shortest_distance result extractor — distance cache in the codegen (increment 2d-ii)

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md
@@ -51,7 +51,7 @@ itself. They compose — the boundary win sits on top of a warm edge cache (phil
 | working set | unbudgeted · two-budget eviction · spill-and-continue | unbudgeted | `evict_budget` / `live_budget` / `..._with_spill` |
 | representation | exact histogram · g_B pre-weighted basis · fitted (tail-prune/binomial/beta-binomial/mixture/quantised-CDF/discretised-GMM) | exact | `build_boundary_basis_weighted_power` / `boundary_suffix_reprs` |
 | persistence | ephemeral · LMDB histograms · LMDB fitted reprs | ephemeral | `save/load_boundary_basis` / `save/load_boundary_reprs` |
-| result | scalar · effective_distance · distribution | scalar | `boundary_result_extractor` / the extractor read |
+| result | scalar · effective_distance · distribution · shortest_distance | scalar | `boundary_result_extractor` / the extractor read |
 
 They are genuinely independent — e.g. *lazy LMDB edges + entry-frontier band + fitted
 reprs persisted to LMDB* is a valid configuration, as is *eager edges + region band +
@@ -122,9 +122,14 @@ write_wam_rust_project([user:category_ancestor/4],
     [ module_name(myapp),
       boundary_optimization(true),          % off by default
       boundary_weight_n(2.0),               % the functional exponent N (default 2.0)
-      boundary_result_extractor(scalar)     % scalar | effective_distance | distribution
+      boundary_result_extractor(scalar)     % scalar | effective_distance | distribution | shortest_distance
     ], 'output/myapp').
 ```
+
+> `shortest_distance` returns the **cycle-correct shortest hop-distance to root** via the
+> min-plus distance cache (precompute with `vm.build_boundary_distances(band, root_id,
+> edge_pred)`, not `build_boundary_suffix`); with an empty cache it degrades to a plain
+> correct BFS. The other three read the path-length histogram.
 
 This is the *codegen* decision. At runtime the emitted wrapper splices against the
 side-table you populate (§4). **With an empty side-table the kernel is still correct**

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -178,6 +178,7 @@ extractor** reads it into the foreign predicate's result. All use the existing
 |------|----------------|-----------------------------------|
 | `scalar(functional)` | `Float`/`Integer` | `f` = `∫ w dμ` (e.g. `weighted_power`) |
 | `effective_distance` | `Float` | `WeightSum^(-1/N)` |
+| `shortest_distance` | `Integer` | shortest hop-distance to root (the support floor `min`) — read from the **min-plus distance cache** (cycle-correct), not the histogram; see `WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md` |
 | `distribution` | `List` of counts (PMF) — or the parametric/CDF encoding for a non-discrete backing | μ itself (possibly truncated) |
 | `interval_mass(a, b)` | `Float` | `interval_mass(a, b) = μ((a, b])` (§1a; half-open) |
 | `cdf(x)` / `quantile(p)` | `Float` | cumulative reads of μ |

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -485,9 +485,19 @@ future work — `m₃` is now carried, so they are a read-out away.
      generic `suffix_value::<S>`. The cyclic star stays a per-payload free function (only
      min-plus is closed), the ⊕/⊗ asymmetry is on the trait, and the laws are guarded by
      `path_semiring_laws_and_generic_equivalence`.
-   - **[2d-ii next]** wire the distance cache into the `transitive_distance3` /
-     `astar_shortest_path4` kernel *codegen* (the Prolog target) so a compiled query uses
-     it, closing increment 2.
+   - **[2d-ii DONE]** the distance cache is wired into the kernel *codegen*. The faithful
+     home turned out to be the existing **to-a-fixed-root** kernel, not `transitive_distance3`
+     (which is a general *source→any-target* stream with no fixed root — the to-root cache
+     does not apply without artificially pinning the target). So `boundary_optimization`
+     gains a `boundary_result_extractor(shortest_distance)` mode: the upgraded
+     `category_ancestor_boundary` wrapper returns the cycle-correct shortest hop-distance to
+     root via `category_ancestor_boundary_distance` (the min-plus cache), not the histogram.
+     Validated by `option_shortest_distance_extractor` (lowering) and
+     `wrapper_shortest_distance_matches_closure` (cargo-gated exec, incl. the empty-cache
+     fallback). **This closes increment 2.**
+   - *Deferred (own track):* a dedicated fixed-target `transitive_distance3` variant and
+     `astar_shortest_path4` ALT landmarks (`|d(u,L) − d(v,L)|`) — a general *between-nodes*
+     query needs the landmark formulation, not the to-root splice.
 
 ## 9. Relationship to the other docs
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -2378,25 +2378,38 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     .map(|s| s.to_string()).unwrap_or_else(|| "scalar".to_string());
                 let cat_id = self.intern_atom(&cat);
                 let root_id = self.intern_atom(&root);
-                let mut hist: Vec<u64> = Vec::new();
-                let mut visited: Vec<u32> = vec![cat_id];
                 let acc = self.resolve_edge_accessor(&edge_pred);
-                self.collect_native_category_ancestor_boundary_hist(
-                    cat_id, root_id, &mut visited, max_depth, &acc, 0, &mut hist);
-                // weighted_power read: WeightSum = sum_{L>0} H[L] * L^-n
-                let weight_sum = || -> f64 {
-                    hist.iter().enumerate().filter(|(l, _)| *l > 0)
-                        .map(|(l, &c)| c as f64 * (l as f64).powf(-n)).sum()
-                };
-                let result: Value = match extractor.as_str() {
-                    "distribution" => Value::List(
-                        hist.iter().map(|&c| Value::Integer(c as i64)).collect()),
-                    "effective_distance" => {
-                        let ws = weight_sum();
-                        if ws > 0.0 { Value::Float(ws.powf(-1.0 / n)) } else { return false; }
+                let result: Value = if extractor == "shortest_distance" {
+                    // min-plus distance read (graph-functional-semiring increment 2):
+                    // the CYCLE-CORRECT shortest hop-distance to root via the distance
+                    // cache (build_boundary_distances / boundary_dist), splice-pruned at
+                    // cached boundaries. Degrades to a plain (correct) BFS with an empty
+                    // cache, so it is safe without a precompute. Distinct from reading the
+                    // histogram support: that DFS histogram is unsound on cycles.
+                    match self.category_ancestor_boundary_distance(cat_id, root_id, &acc) {
+                        Some(d) => Value::Integer(d as i64),
+                        None => return false, // root unreachable
                     }
-                    // default: scalar(weighted_power)
-                    _ => Value::Float(weight_sum()),
+                } else {
+                    let mut hist: Vec<u64> = Vec::new();
+                    let mut visited: Vec<u32> = vec![cat_id];
+                    self.collect_native_category_ancestor_boundary_hist(
+                        cat_id, root_id, &mut visited, max_depth, &acc, 0, &mut hist);
+                    // weighted_power read: WeightSum = sum_{L>0} H[L] * L^-n
+                    let weight_sum = || -> f64 {
+                        hist.iter().enumerate().filter(|(l, _)| *l > 0)
+                            .map(|(l, &c)| c as f64 * (l as f64).powf(-n)).sum()
+                    };
+                    match extractor.as_str() {
+                        "distribution" => Value::List(
+                            hist.iter().map(|&c| Value::Integer(c as i64)).collect()),
+                        "effective_distance" => {
+                            let ws = weight_sum();
+                            if ws > 0.0 { Value::Float(ws.powf(-1.0 / n)) } else { return false; }
+                        }
+                        // default: scalar(weighted_power)
+                        _ => Value::Float(weight_sum()),
+                    }
                 };
                 self.finish_foreign_results(
                     &pred_key, vec![out_reg],
@@ -5703,12 +5716,14 @@ rust_bidirectional_config_extras(Options, Extras) :-
 %  emitting ONE deterministic result (no choice point) read from the
 %  path-length measure of the spliced boundary histogram. The result_extractor
 %  config selects which read: scalar (weighted_power), effective_distance
-%  (d_eff = WeightSum^(-1/N)), or distribution (the raw histogram).
+%  (d_eff = WeightSum^(-1/N)), distribution (the raw histogram), or
+%  shortest_distance (the cycle-correct min-plus shortest hop-distance to root,
+%  read from the distance cache rather than the histogram — increment 2).
 %
 %  Config extras (project options, with defaults):
 %    boundary_weight_n(N)            — the functional exponent N (default 2.0)
 %    boundary_result_extractor(E)    — scalar | effective_distance | distribution
-%                                      (default scalar)
+%                                      | shortest_distance   (default scalar)
 %
 %  max_depth and edge_pred carry over from the detected category_ancestor
 %  config. The boundary side-table (build_boundary_suffix) is a separate runtime
@@ -5902,7 +5917,7 @@ emit_kernel_config_ops(Key, [Op|Rest]) :-
 %                          (default false; see rust_maybe_upgrade_boundary/3).
 %                          Tunables: boundary_weight_n(N) (default 2.0),
 %                          boundary_result_extractor(scalar | effective_distance
-%                          | distribution; default scalar).
+%                          | distribution | shortest_distance; default scalar).
 %    csr_child_index(Bool) — emit src/csr_fact_source.rs, a LookupSource
 %                          over the reverse-CSR artifact for the
 %                          bidirectional kernel child direction

--- a/tests/test_wam_rust_boundary_lowering.pl
+++ b/tests/test_wam_rust_boundary_lowering.pl
@@ -94,6 +94,19 @@ test(option_tunables_flow_through,
     sub_string(Lib, _, _, _, "register_foreign_f64_config(\"bcat_ancestor/3\", \"weight_n\", 3.0)"),
     sub_string(Lib, _, _, _, "register_foreign_string_config(\"bcat_ancestor/3\", \"result_extractor\", \"effective_distance\")").
 
+% shortest_distance extractor (increment 2): the config flows through, and the
+% dispatch routes it through the min-plus distance cache, not the histogram.
+test(option_shortest_distance_extractor,
+     [cleanup(safe_rmdir('output/test_bl_dist'))]) :-
+    Dir = 'output/test_bl_dist',
+    gen([boundary_optimization(true),
+         boundary_result_extractor(shortest_distance)], Dir),
+    read_src(Dir, '/src/lib.rs', Lib),
+    sub_string(Lib, _, _, _, "register_foreign_string_config(\"bcat_ancestor/3\", \"result_extractor\", \"shortest_distance\")"),
+    read_src(Dir, '/src/state.rs', St),
+    sub_string(St, _, _, _, "extractor == \"shortest_distance\""),
+    sub_string(St, _, _, _, "category_ancestor_boundary_distance(cat_id, root_id").
+
 % cargo-gated: the upgraded crate builds and the emitted wrapper reproduces the
 % production hop-stream aggregate.
 test(boundary_wrapper_matches_production,
@@ -193,6 +206,71 @@ fn wrapper_with_root_near_precompute() {
     ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
     ->  true
     ;   format(user_error, "~n[boundary lowering exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+% cargo-gated: the shortest_distance wrapper returns the cycle-correct shortest
+% hop-distance to root (the min-plus closure), via the distance cache.
+test(wrapper_shortest_distance_matches_closure,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_bl_distexec'))]) :-
+    Dir = 'output/test_bl_distexec',
+    gen([boundary_optimization(true),
+         boundary_result_extractor(shortest_distance)], Dir),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/bld_test.rs', TestPath),
+    TestSrc = '
+use bl::state::WamState;
+use bl::value::Value;
+use std::collections::HashMap;
+
+#[test]
+fn wrapper_returns_shortest_distance() {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    vm.register_ffi_fact_pairs("bcat_parent", &[
+        ("5","4"),("5","2"),("4","3"),("4","1"),("3","1"),("3","2"),
+        ("1","0"),("2","0"),("6","5"),("7","4"),("8","6"),("8","7"),
+    ]);
+    let root = vm.intern_atom("0");
+    // precompute the distance cache over a root-near band.
+    let bnodes: Vec<u32> = ["1","2"].iter().map(|s| vm.intern_atom(s)).collect();
+    assert!(vm.build_boundary_distances(&bnodes, root, "bcat_parent"));
+    // shortest hop-distances to root for the diamond DAG.
+    let want: HashMap<&str, i64> =
+        [("3",2),("4",2),("5",2),("6",3),("7",3),("8",4)].into_iter().collect();
+    let mut checked = 0;
+    for sname in ["3","4","5","6","7","8"] {
+        let out = Value::Unbound(format!("D{}", checked));
+        let ok = bl::bcat_ancestor(&mut vm, Value::Atom(sname.to_string()),
+                                   Value::Atom("0".to_string()), out);
+        assert!(ok, "wrapper should succeed for seed {}", sname);
+        let got = match vm.deref_var(&vm.get_reg_raw("A3").unwrap()) {
+            Value::Integer(i) => i, other => panic!("expected Integer, got {:?}", other) };
+        assert_eq!(got, want[sname], "seed {}: shortest distance", sname);
+        checked += 1;
+    }
+    assert_eq!(checked, 6);
+    // and it is still correct with NO precompute (empty cache -> plain BFS).
+    let mut vm2 = WamState::new(vec![], HashMap::new());
+    vm2.register_ffi_fact_pairs("bcat_parent", &[("5","2"),("2","0")]);
+    let out = Value::Unbound("E".to_string());
+    assert!(bl::bcat_ancestor(&mut vm2, Value::Atom("5".to_string()),
+                              Value::Atom("0".to_string()), out));
+    match vm2.deref_var(&vm2.get_reg_raw("A3").unwrap()) {
+        Value::Integer(i) => assert_eq!(i, 2, "5->2->0 = 2 with empty cache"),
+        other => panic!("expected Integer, got {:?}", other) };
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test bld_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[shortest_distance exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
         fail ).
 
 :- end_tests(wam_rust_boundary_lowering).


### PR DESCRIPTION
**Increment 2d-ii — closes increment 2.** A compiled query now uses the min-plus distance machinery, exposed through the compiler.

## The design pivot (from the codegen investigation)

`transitive_distance3` turned out to be a general **source→any-target** stream with **no fixed root**, so the to-root distance cache doesn't fit it — wiring it in would mean artificially pinning the target, changing the query's meaning. The faithful home is the kernel that is *already* a to-a-fixed-root query: **`category_ancestor_boundary`**, which has a `boundary_result_extractor` axis. So the distance cache becomes a new extractor there.

## What's added

- **`boundary_result_extractor(shortest_distance)`** — the upgraded 3-ary wrapper `Pred(Cat, Root, Result)` returns the **cycle-correct shortest hop-distance to root**, read from the min-plus distance cache via `WamState::category_ancestor_boundary_distance` (the `build_boundary_distances` / `boundary_dist` machinery from 2c), **not** the histogram support — whose DFS build is unsound on cycles (2a). The dispatch (`wam_rust_target.pl`) is restructured so `shortest_distance` skips the histogram build entirely, and it degrades to a plain correct BFS with an empty cache.

## Tests (suite ALL_PASS)

- `option_shortest_distance_extractor` — the config flows through and the emitted dispatch routes via the distance cache (`category_ancestor_boundary_distance`), not the histogram.
- `wrapper_shortest_distance_matches_closure` (cargo-gated) — generates the crate, builds the distance cache, calls the emitted wrapper, and asserts it returns the correct shortest distances for the diamond DAG, **including the empty-cache fallback**.

## Docs

Theory §8 marks **2d-ii done / increment 2 complete**; HOWTO + spec extractor tables updated; the lowering option docs in `wam_rust_target.pl` updated. A dedicated fixed-target `transitive_distance3` variant and `astar_shortest_path4` ALT landmarks (`|d(u,L) − d(v,L)|`) are noted as a separate *between-nodes* track — they need the landmark formulation, not the to-root splice.

## Increment 2 — complete

```
2a ✅ closure   2b ✅ weighted+splice   2c ✅ WamState cache   2d-i ✅ trait   2d-ii ✅ codegen (this PR)
```

Both semirings (counting/moments from increment 1, tropical/distance from increment 2) now run end-to-end through the boundary cache, behind one `PathSemiring` framework, exposed via the compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_