### PR TITLE
fix(wam-rust): caret distance has no cache lower bound off a tree (correct 3a)

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -348,31 +348,43 @@ sets the *scale*. (`(min, max, mass)` alone, no `m₁`/`m₂` needed for the bra
 validated in `boundary_cache::tests::interval_and_mass_bracket_d_eff`.) It is the cheap
 surrogate for the `WeightSum` functional that §2 showed cannot be carried as a scalar.
 
-### 5a. Composite caret distance — bracketing the *between-nodes* distance
+### 5a. Composite caret distance — a between-nodes *upper* bound
 
 The to-root distance cache (increment 2) answers "how far is `v` from the root". The same
-two cached scalars also bracket the distance **between two nodes**, by the same idea as
-§5. A path `u → v` can always go **up to a shared ancestor (a *bridge*) and back down** —
-a `∧`/caret path `u ↑ B ↓ v` of length `d(u→B) + d(v→B)`. The **root is a universal
-bridge**, so from the cached `d(u→root)`, `d(v→root)` alone, the triangle inequality (root
-as reference point) gives a two-sided bound:
+two cached scalars give an **upper bound** on the distance **between two nodes**. A path
+`u → v` can always go **up to a shared ancestor (a *bridge*) and back down** — a `∧`/caret
+path `u ↑ B ↓ v` of length `d(u→B) + d(v→B)`. The **root is a universal bridge**, so
 
 ```
-|d(u→root) − d(v→root)|   ≤   d(u,v)   ≤   d(u→root) + d(v→root)
-      A*/ALT lower bound                    composite caret (root bridge, upper)
+d_undirected(u, v)   ≤   d(u→root) + d(v→root)        (composite caret, root bridge)
 ```
 
-— `d(u,v)` is **bracketed from the cache**, the same shape as the `d_eff` bracket of §5
-(`caret_distance_bounds`). The lower bound is exactly the **ALT landmark heuristic** an A*
-search consumes; the upper bound is the *caret* (the user's "root bridge"). A **lower
-bridge** — a common ancestor nearer `u, v`, ultimately the **lowest common ancestor** —
-gives a *tighter* caret; `caret_distance_lca` computes that exact `∧`-distance
+is free from the cache (`caret_distance_upper`) — it is the length of a real `∧`-path. A
+**lower bridge** (a common ancestor nearer `u, v`, ultimately the **lowest common
+ancestor**) gives a *tighter* caret; `caret_distance_lca` computes the exact `∧`-distance
 `min_B (d(u→B) + d(v→B))` by a joint upward BFS. The caret **equals** the true shortest
 path on a *tree* (it is the cophenetic / tree distance) and is a **certified upper bound**
-on a DAG (a non-ancestor route can be shorter). Validated by
-`caret_distance_on_a_tree_equals_true_distance` and
-`caret_distance_on_a_dag_is_a_bracketed_upper_bound`. This is the natural *between-nodes*
-use of the to-root cache — the general companion to increment 2's *to-root* query.
+on a DAG (a non-ancestor route can be shorter).
+
+**No matching lower bound from the cache (the correction).** It is tempting to add
+`|d(u→root) − d(v→root)| ≤ d(u,v)` as a lower bound (the ALT landmark heuristic), but
+**that is false in general.** The reverse triangle inequality needs a *metric* (symmetric
+distances); the cache stores the *directed* up-distance, and the caret distance is
+*undirected*. On a DAG with a shortcut the undirected distance can be far smaller than
+`|d_u − d_v|` — e.g. a chain `4→3→2→1→0` (so `d(4→root)=4`) plus `5→0` and an edge `5—4`
+gives `d(5→root)=1` while `4,5` are *adjacent* (`d=1`), yet `|4−1| = 3 > 1`
+(`alt_lower_bound_is_directed_only`). The symmetric bound holds **only on a tree** (there
+the directed up-distance *is* the undirected metric). The valid cache lower bound is the
+*directed* one — `max(0, d(u→root) − d(v→root)) ≤ d(u→v)`, because `u→v→root` is a walk to
+root (`directed_distance_lower`) — the admissible A* heuristic for the **directed** query,
+a bound on a *different* quantity than the undirected caret. So on a DAG there is a
+certified upper bound (undirected caret) and a directed lower bound, but **not** a single
+two-sided bracket; the bracket is a tree-only special case.
+
+Validated by `caret_distance_on_a_tree_equals_true_distance`,
+`caret_distance_on_a_dag_is_an_upper_bound`, and `alt_lower_bound_is_directed_only`. This
+is the natural *between-nodes* use of the to-root cache — the general companion to
+increment 2's *to-root* query.
 
 ## 6. Aside: the kernel-trick analogy
 
@@ -527,13 +539,16 @@ future work — `m₃` is now carried, so they are a read-out away.
 
 3. **Between-nodes distance from the to-root cache (composite caret).** The *between-nodes*
    companion to increment 2, §5a.
-   - **[3a DONE]** `caret_distance_bounds` (the O(1) two-sided bracket from two cached
-     to-root scalars — ALT lower bound + root-bridge caret upper bound) and
-     `caret_distance_lca` (the exact `∧`-distance through the lowest common ancestor).
+   - **[3a DONE]** `caret_distance_upper` (the O(1) root-bridge caret — an *undirected*
+     upper bound) and `caret_distance_lca` (the exact `∧`-distance through the lowest common
+     ancestor). `directed_distance_lower` is the only valid cache lower bound, and only on
+     the *directed* `d(u→v)` — the symmetric `|d_u − d_v|` is NOT a lower bound on the
+     undirected distance off a tree (corrected; `alt_lower_bound_is_directed_only`).
      Validated on a tree (caret = true distance) and a DAG (caret = certified upper bound).
    - **[3b next]** wire it into the live WamState path and a kernel result mode (a
-     between-nodes `caret_distance(u, v)` reading the distance cache), and the `astar`
-     landmark heuristic that consumes the lower bound.
+     between-nodes `caret_distance(u, v)` reading the distance cache); feed
+     `directed_distance_lower` to an A* search as its admissible heuristic for *directed*
+     queries.
 
 ## 9. Relationship to the other docs
 

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -476,21 +476,35 @@ pub fn distance_splice(
 // A path between u and v can always go UP to a shared ancestor (a "bridge") and back
 // DOWN — a ∧/caret-shaped path `u ↑ B ↓ v` of length `d(u→B) + d(v→B)`. The ROOT is a
 // universal bridge (everything reaches it), so the two cached to-root distances give a
-// between-nodes distance for FREE. Two facts from the triangle inequality, with the root
-// as reference point, bracket the true distance from those same two scalars:
-//     |d(u→root) − d(v→root)|  ≤  d(u,v)  ≤  d(u→root) + d(v→root)
-//         ALT lower bound                     composite caret (root bridge, upper)
-// A LOWER bridge (a common ancestor nearer u,v — ultimately the LCA) gives a tighter
-// caret; `caret_distance_lca` computes that exact ∧-distance. The caret equals the true
-// shortest path on a tree (the cophenetic / tree distance) and is a certified upper bound
-// on a DAG (a non-ancestor route could be shorter).
+// between-nodes UPPER bound for FREE: `d_undirected(u,v) ≤ d(u→root) + d(v→root)` — the
+// length of a real ∧-path (up via parent edges, down via their reverse). A LOWER bridge
+// (a common ancestor nearer u,v — ultimately the LCA) gives a tighter caret;
+// `caret_distance_lca` computes that exact ∧-distance. The caret equals the true shortest
+// path on a tree (the cophenetic / tree distance) and is a certified upper bound on a DAG.
+//
+// CAUTION on a *lower* bound. The reverse triangle inequality
+// `|d(u→root) − d(v→root)| ≤ d(u,v)` needs a METRIC (symmetric distances). The cache
+// stores the *directed* up-distance, and the caret distance is *undirected* — so on a DAG
+// with a shortcut the undirected distance can be far smaller than `|d_u − d_v|` and the
+// `|·|` bound is FALSE (it holds only on a tree, where the directed up-distance IS the
+// undirected metric; see `alt_lower_bound_is_directed_only`). The valid lower bound from
+// the cache is the *directed* one, `max(0, d(u→root) − d(v→root)) ≤ d(u→v)` (because
+// `u→v→root` is a walk to root) — the admissible A* heuristic for the DIRECTED query.
 
-/// Caret distance **bounds** between two nodes from their cached to-root distances:
-/// `(lower, upper) = (|d_u − d_v|, d_u + d_v)`. O(1). The lower bound is the A*/ALT
-/// landmark heuristic; the upper bound is the root-bridge composite caret. The true
-/// `d(u,v)` lies in `[lower, upper]`.
-pub fn caret_distance_bounds(d_u_root: u32, d_v_root: u32) -> (u32, u32) {
-    (d_u_root.abs_diff(d_v_root), d_u_root + d_v_root)
+/// Caret **upper** bound on the *undirected* distance between `u` and `v`: the root-bridge
+/// caret `d(u→root) + d(v→root)`. Always valid — the length of a real ∧-path. The LCA
+/// tightens it (`caret_distance_lca`).
+pub fn caret_distance_upper(d_u_root: u32, d_v_root: u32) -> u32 {
+    d_u_root + d_v_root
+}
+
+/// ALT **lower** bound on the *directed* distance `d(u→v)`: `max(0, d(u→root) −
+/// d(v→root))`, valid because `u→v→root` is a walk to root, so
+/// `d(u→root) ≤ d(u→v) + d(v→root)`. The admissible A* heuristic for the directed query.
+/// It does **not** bound the *undirected* caret distance — only on a tree does the
+/// symmetric `|d_u − d_v|` hold (directed up-distance = undirected metric there).
+pub fn directed_distance_lower(d_u_root: u32, d_v_root: u32) -> u32 {
+    d_u_root.saturating_sub(d_v_root)
 }
 
 /// The **tight** composite caret distance: the shortest `∧`-path `u ↑ B ↓ v` over all
@@ -2040,7 +2054,9 @@ mod tests {
 
     // Increment 3a — composite caret distance. A small TREE (each node one parent): the
     // ∧-path through the LCA IS the unique shortest path, so the tight caret equals the
-    // true undirected distance, and the to-root bounds bracket it.
+    // true undirected distance, the caret upper bound bounds it, and — because on a tree
+    // the directed up-distance IS the undirected metric — the symmetric reverse-triangle
+    // lower bound also holds here.
     #[test]
     fn caret_distance_on_a_tree_equals_true_distance() {
         // root 0; 1,2 -> 0; 3,4 -> 1; 5 -> 2.
@@ -2052,30 +2068,56 @@ mod tests {
             let lca = caret_distance_lca(u, v, &t).unwrap();
             let truth = undirected_dist(u, v, &t).unwrap();
             assert_eq!(lca, truth, "tree caret({},{})", u, v);
-            let (lo, hi) = caret_distance_bounds(to_root[&u], to_root[&v]);
-            assert!(lo <= truth && truth <= hi, "{} <= d({},{})={} <= {}", lo, u, v, truth, hi);
+            assert!(truth <= caret_distance_upper(to_root[&u], to_root[&v]), "upper bound");
+            // valid ON A TREE only (up-distance = undirected metric):
+            assert!(to_root[&u].abs_diff(to_root[&v]) <= truth, "tree reverse-triangle");
         }
     }
 
     // On a DAG the ∧-path is an UPPER bound (a non-ancestor route can be shorter), and a
     // lower bridge strictly beats the root bridge where an LCA below the root exists.
     #[test]
-    fn caret_distance_on_a_dag_is_a_bracketed_upper_bound() {
+    fn caret_distance_on_a_dag_is_an_upper_bound() {
         let g = graph(); // diamond DAG, root 0
         let to_root = min_distance_closure(0, &g);
         for &(u, v) in &[(3u32, 4u32), (5, 3), (4, 2), (1, 2)] {
             let lca = caret_distance_lca(u, v, &g).unwrap();
             let truth = undirected_dist(u, v, &g).unwrap();
-            let (lo, hi) = caret_distance_bounds(to_root[&u], to_root[&v]);
             assert!(lca >= truth, "caret {} >= true {} for ({},{})", lca, truth, u, v);
-            assert!(lo <= truth && truth <= hi);
-            assert!(lo <= lca && lca <= hi, "caret in the cached bracket");
+            assert!(truth <= caret_distance_upper(to_root[&u], to_root[&v]), "upper bound");
             assert!(lca <= to_root[&u] + to_root[&v], "LCA caret <= root-bridge");
         }
         // 3 and 4 share the LCA 3 (4's parent), so the caret (1) strictly beats the
         // root bridge (d(3)+d(4) = 2+2 = 4).
         assert_eq!(caret_distance_lca(3, 4, &g), Some(1));
         assert!(1 < to_root[&3] + to_root[&4]);
+    }
+
+    // The lower bound is DIRECTED-only: the symmetric |d_u - d_v| is NOT a lower bound on
+    // the undirected distance on a DAG with a shortcut (the reverse triangle needs a
+    // metric, but the cached up-distance is directed). Chain 4->3->2->1->0 (d(4)=4) plus a
+    // shortcut 5->0 and the edge 5->4: d(5)=1, yet 4 and 5 are adjacent (undirected d=1),
+    // so |4-1| = 3 > 1.
+    #[test]
+    fn alt_lower_bound_is_directed_only() {
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        g.insert(1, vec![0]); g.insert(2, vec![1]); g.insert(3, vec![2]);
+        g.insert(4, vec![3]); g.insert(5, vec![0, 4]);
+        let to_root = min_distance_closure(0, &g);
+        assert_eq!(to_root[&4], 4);
+        assert_eq!(to_root[&5], 1);
+        let undirected = undirected_dist(4, 5, &g).unwrap();
+        assert_eq!(undirected, 1, "4 and 5 are adjacent undirected");
+        // the symmetric |d_u - d_v| OVERSHOOTS the undirected distance -> NOT a lower bound.
+        assert!(to_root[&4].abs_diff(to_root[&5]) > undirected,
+            "|d_u - d_v| = {} must exceed the undirected distance {}",
+            to_root[&4].abs_diff(to_root[&5]), undirected);
+        // the caret UPPER bound is still valid (a real ∧-path).
+        assert!(undirected <= caret_distance_upper(to_root[&4], to_root[&5]));
+        // the DIRECTED lower bound is sound: d(5->4) directed = 1 >= max(0, d_5 - d_4) = 0.
+        assert_eq!(directed_distance_lower(to_root[&5], to_root[&4]), 0);
+        // and for 4->5 directed (unreachable, +inf), the bound max(0, 4-1) = 3 holds vacuously.
+        assert_eq!(directed_distance_lower(to_root[&4], to_root[&5]), 3);
     }
 
     // Undirected BFS shortest distance — the oracle for the caret tests (treats each


### PR DESCRIPTION
**Corrects increment 3a** — you were right, the lower bound doesn't hold. Thank you for catching it.

## The bug

3a claimed `|d(u→root) − d(v→root)| ≤ d(u,v)` as an ALT lower bound. **It's false in general.** The reverse triangle inequality requires a **metric** (symmetric distances), but the cache stores the **directed** up-distance while the caret distance is **undirected**. When a shortcut exists, the directed up-distance overestimates the undirected distance to root, and the bound breaks.

Counterexample (now a test, `alt_lower_bound_is_directed_only`): a chain `4→3→2→1→0` (so `d(4→root)=4`) plus a shortcut `5→0` and an edge `5—4`. Then `d(5→root)=1`, but `4` and `5` are *adjacent* (undirected `d=1`), so `|4 − 1| = 3 > 1`. The diamond-DAG test passed before only by luck — it happens to have no such shortcut.

## The fix

- **`caret_distance_upper(d_u, d_v) = d_u + d_v`** — the root-bridge caret, a sound **undirected upper bound** (a real `∧`-path). Unchanged in substance, just the half that was always correct.
- **`directed_distance_lower(d_u, d_v) = max(0, d_u − d_v)`** — the only valid cache lower bound, and only on the **directed** `d(u→v)` (since `u→v→root` is a walk to root). This is the admissible A* heuristic for *directed* queries — a bound on a *different* quantity than the undirected caret.
- The symmetric `|d_u − d_v|` bound holds **only on a tree** (there the directed up-distance *is* the undirected metric); the tree test keeps that assertion, the DAG test drops it.

## Docs

§5a rewritten: the undirected caret upper bound and the directed lower bound are bounds on **different quantities** — a single two-sided "bracket" is a **tree-only special case**, not the general picture I'd claimed. §8 3a corrected too.

55 lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_