### PR TITLE
measure(wam-rust): A* ALT pruning — where the distance landmark pays off

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -565,9 +565,19 @@ buy diminishing returns and is not carried).
      the loaded distance-to-root table — admissible/consistent; degrades to Dijkstra with
      an empty `min_dist`). Validated by `live_caret_distance_matches_lca` and
      `astar_ancestor_distance_matches_closure`.
+   - **[measured]** the A* prune is **structure-dependent, and that is inherent to a single
+     root landmark.** `h(n) = d(n→root) − d(target→root)` is *exact* exactly when `target`
+     **dominates** the path to root (every `n→root` shortest path crosses `target`) — there
+     A* expands only the optimal path and prunes hard (`astar_alt_prunes_a_dominator_decoy`:
+     ALT expands strictly fewer nodes than Dijkstra). Across a branch that **bypasses**
+     `target`, the same `h` is a loose lower bound and cannot prune (a root landmark sits
+     *behind* an ancestor target). So the distance-cache A* pays off for dominator-shaped
+     ancestor queries; a *general* speedup wants **periphery** landmarks (classic ALT picks
+     landmarks "beyond" the targets), which the boundary machinery could precompute but does
+     not yet — the honest next measurement-driven step if A* on general graphs is wanted.
    - **[3c next, optional]** a between-nodes *kernel* result mode in the Prolog codegen
      (the caret query has two query nodes, so it needs a kernel shape distinct from the
-     to-root `category_ancestor_boundary`).
+     to-root `category_ancestor_boundary`); and periphery-landmark selection for general A*.
 
 ## 9. Relationship to the other docs
 

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -1347,8 +1347,21 @@ impl WamState {
     /// reachable upward from `u`. The boundary distance cache (increment 2) is the
     /// landmark; this is its A* consumer.
     pub fn category_ancestor_astar(&self, u: u32, target: u32, acc: &EdgeAccessor) -> Option<u32> {
+        self.category_ancestor_astar_counted(u, target, acc).0
+    }
+
+    /// As `category_ancestor_astar`, also returning the **number of nodes expanded** — the
+    /// canonical A\* effectiveness measure. With `min_dist` loaded the heuristic prunes
+    /// suboptimal branches; with an empty `min_dist` (`h = 0`) it is plain Dijkstra, the
+    /// baseline. The heuristic is **exact where `target` dominates the path to root** (then
+    /// it prunes hard) and a loose lower bound across branches that bypass `target` (where
+    /// it cannot prune — a single root landmark is behind an ancestor target). A closed set
+    /// gives each node one expansion (valid: the heuristic is consistent).
+    pub fn category_ancestor_astar_counted(
+        &self, u: u32, target: u32, acc: &EdgeAccessor,
+    ) -> (Option<u32>, usize) {
         use std::cmp::Reverse;
-        use std::collections::{BinaryHeap, HashMap};
+        use std::collections::{BinaryHeap, HashMap, HashSet};
         let heuristic = |n: u32| -> u32 {
             if self.min_dist.is_empty() { return 0; }
             match (self.min_dist.get(&(n as i32)), self.min_dist.get(&(target as i32))) {
@@ -1357,12 +1370,16 @@ impl WamState {
             }
         };
         let mut g: HashMap<u32, u32> = HashMap::new();
+        let mut closed: HashSet<u32> = HashSet::new();
         let mut heap: BinaryHeap<Reverse<(u32, u32)>> = BinaryHeap::new(); // (f = g+h, node)
+        let mut expansions = 0usize;
         g.insert(u, 0);
         heap.push(Reverse((heuristic(u), u)));
         while let Some(Reverse((_f, node))) = heap.pop() {
+            if !closed.insert(node) { continue; } // stale heap entry — already expanded
+            expansions += 1;
             let gn = g[&node];
-            if node == target { return Some(gn); } // consistent h: first pop is optimal
+            if node == target { return (Some(gn), expansions); } // consistent h: optimal
             for p in self.edge_parents_via(node, acc) {
                 let gp = gn + 1;
                 if gp < *g.get(&p).unwrap_or(&u32::MAX) {
@@ -1371,7 +1388,7 @@ impl WamState {
                 }
             }
         }
-        None
+        (None, expansions)
     }
 
     /// Top-down boundary precompute with the liveness-prioritised eviction of spec
@@ -2901,6 +2918,43 @@ mod boundary_kernel_tests {
         let t = vm2.intern_atom("0");
         let acc2 = vm2.resolve_edge_accessor("category_parent");
         assert_eq!(vm2.category_ancestor_astar(u, t, &acc2), Some(2));
+    }
+
+    // MEASUREMENT — the ALT heuristic's pruning, where it works. `u`=3 reaches the target
+    // `t`=1 two ways, both through the DOMINATOR 1:
+    //     short  3 → 2 → 1        (len 2)
+    //     decoy  3 → 4 → 5 → 1    (len 3)
+    // Because 1 dominates every path to root, the root-landmark heuristic is EXACT, so A*
+    // prunes the decoy (node 4 is never expanded), while plain Dijkstra (h=0) expands it.
+    // This is the regime where the increment-2 distance landmark pays off as an A* prune.
+    #[test]
+    fn astar_alt_prunes_a_dominator_decoy() {
+        let edges = &[("1", "0"), ("2", "1"), ("5", "1"), ("4", "5"), ("3", "2"), ("3", "4")];
+        // ALT: load distance-to-root so the heuristic is active.
+        let mut vm = WamState::new(vec![], HashMap::new());
+        vm.register_ffi_fact_pairs("category_parent", edges);
+        let mut md: HashMap<i32, i32> = HashMap::new();
+        for (name, d) in [("0", 0), ("1", 1), ("2", 2), ("5", 2), ("4", 3), ("3", 3)] {
+            md.insert(vm.intern_atom(name) as i32, d);
+        }
+        let (u, t) = (vm.intern_atom("3"), vm.intern_atom("1"));
+        vm.set_min_dist(&md);
+        let (alt_dist, alt_exp) = {
+            let acc = vm.resolve_edge_accessor("category_parent");
+            vm.category_ancestor_astar_counted(u, t, &acc)
+        };
+        // Dijkstra baseline: same query, empty min_dist -> h = 0.
+        let mut vm2 = WamState::new(vec![], HashMap::new());
+        vm2.register_ffi_fact_pairs("category_parent", edges);
+        let (u2, t2) = (vm2.intern_atom("3"), vm2.intern_atom("1"));
+        let (dij_dist, dij_exp) = {
+            let acc2 = vm2.resolve_edge_accessor("category_parent");
+            vm2.category_ancestor_astar_counted(u2, t2, &acc2)
+        };
+        assert_eq!(alt_dist, Some(2));
+        assert_eq!(dij_dist, Some(2), "same optimal answer");
+        assert!(alt_exp < dij_exp,
+            "ALT expansions {} should be < Dijkstra {} (the decoy is pruned)", alt_exp, dij_exp);
     }
 
     #[test]


### PR DESCRIPTION
The first **measurement** of the increment-2/3 distance line's runtime payoff — and an honest characterization of where it does and doesn't materialize.

## What's added (`state.rs.mustache`)

- **`category_ancestor_astar_counted(u, target, acc) → (Option<u32>, usize)`** — the A* now also returns the **node-expansion count** (the canonical A* effectiveness measure), with a closed set so each node is expanded once (valid: the heuristic is consistent). The plain `category_ancestor_astar` delegates to it.

## The measurement

`astar_alt_prunes_a_dominator_decoy`: `u` reaches the target two ways — a short path and a longer **decoy** — both passing through the target, which **dominates** the path to root. Because of that, the root-landmark heuristic `h(n) = d(n→root) − d(target→root)` is *exact*, so A* prunes the decoy: it expands **strictly fewer** nodes than plain Dijkstra (`h=0`), while both return the same optimal distance.

## The honest finding (theory §8)

The prune is **structure-dependent, and that's inherent to a single root landmark**:
- **Where the target dominates** the path to root, `h` is exact → A* expands only the optimal path (strong prune). ✅
- **Across a branch that bypasses** the target, the same `h` is a loose lower bound → no prune (a root landmark sits *behind* an ancestor target).

So the distance-cache A* pays off for dominator-shaped ancestor queries. A *general*-graph speedup wants **periphery** landmarks (classic ALT picks landmarks "beyond" the targets) — which the boundary machinery could precompute but doesn't yet. I'd rather surface that limit honestly with a measurement than imply a blanket speedup. 63 lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_