### PR TITLE
feat(wam-rust): budgeted caret distance — support upper-bound as the bridge-level knob

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -575,7 +575,19 @@ buy diminishing returns and is not carried).
      ancestor queries; a *general* speedup wants **periphery** landmarks (classic ALT picks
      landmarks "beyond" the targets), which the boundary machinery could precompute but does
      not yet — the honest next measurement-driven step if A* on general graphs is wanted.
-   - **[3c next, optional]** a between-nodes *kernel* result mode in the Prolog codegen
+   - **[3d DONE]** `caret_distance_budgeted(u, v, parents, budget)` — the caret with a
+     path-length **budget** on the joint up-walk, so the **budget is the bridge-level knob**:
+     a small budget admits only a LOW common ancestor (a tight, local relation), a budget ≥
+     the subtree height always reaches the bridge and equals `caret_distance_lca`. Its
+     natural value is the **support upper bound** (`max` from the interval payload, increment
+     1), which bounds depth-to-subtree-root — so the increment-1 payload feeds the
+     increment-3 caret. Validated by `budgeted_caret_scopes_the_bridge_by_level` and
+     `support_upper_bound_is_a_sufficient_caret_budget`.
+   - **[3e next]** a **real-data integration** on a Wikipedia subtree (e.g. physics): extract
+     the root-anchored region (`build_scoped_subtree_lmdb.py`), propagate the support
+     interval, and compute multi-level budgeted carets between topics — the end-to-end
+     composition on real (cyclic) data, where the 2a/2b cycle-correctness earns its keep.
+   - **[3c, optional]** a between-nodes *kernel* result mode in the Prolog codegen
      (the caret query has two query nodes, so it needs a kernel shape distinct from the
      to-root `category_ancestor_boundary`); and periphery-landmark selection for general A*.
 

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -386,6 +386,40 @@ Validated by `caret_distance_on_a_tree_equals_true_distance`,
 is the natural *between-nodes* use of the to-root cache — the general companion to
 increment 2's *to-root* query.
 
+### 5b. Two caret measures: auto-LCA (shortest path) vs designated bridge
+
+There are **two** ways to pick the bridge, and they answer different questions:
+
+- **Auto-LCA** — `caret_distance_lca` minimises over bridges, so the bridge is *implicit*
+  (the lowest common ancestor). But minimising over `B` means it **collapses to the
+  (undirected) shortest path** (on a tree, exactly the tree distance). So it carries **no
+  information beyond distance** — you don't pick a bridge, but you also learn nothing the
+  shortest path wouldn't tell you. `caret_distance_budgeted(u, v, budget)` is this measure
+  *scoped*: the budget admits only bridges within a radius (the support upper bound is the
+  natural value), but within scope it is still the auto-minimising shortest path.
+- **Designated bridge** — `caret_through_bridge(u, v, B) = d(u→B) + d(v→B)` *fixes* the
+  bridge to a chosen reference node `B` (defined when `B` is an ancestor of both). It
+  measures relatedness **as seen from a chosen level** — "through the physics category", or
+  through a node higher up. You pick the bridge, and in exchange it keeps information the
+  shortest path discards.
+
+**The distance between the two measures.** With the LCA below the chosen bridge `B`, on a
+tree `d(u→B) = d(u→LCA) + d(LCA→B)` (and likewise for `v`), so
+
+```
+through(B)  −  lca   =   2 · d(LCA → B)
+```
+
+— the designated-bridge caret is the **shortest-path caret plus twice the lift of the
+reference above the true LCA** (`caret_through_bridge_vs_lca_and_the_gap`). That gap is
+exactly the signal the auto-LCA throws away: two topic pairs with the *same* shortest path
+get *different* through-`B` distances when their LCAs sit at different depths below `B`. So
+`through(B)` decomposes as **intrinsic distance** (the shortest path) + **2 × (how far the
+pair's meeting point sits below your reference level)**. Choosing `B` = the physics category
+yields "relatedness within physics"; raising `B` yields relatedness at a coarser level — the
+multi-level reading the budgeted measure cannot give (it only scopes, never reframes). On a
+DAG both are upper-bound approximations, as the caret itself is.
+
 ## 6. Aside: the kernel-trick analogy
 
 *(A mnemonic, not load-bearing — the mechanics above stand on their own; skip if you only
@@ -583,6 +617,11 @@ buy diminishing returns and is not carried).
      1), which bounds depth-to-subtree-root — so the increment-1 payload feeds the
      increment-3 caret. Validated by `budgeted_caret_scopes_the_bridge_by_level` and
      `support_upper_bound_is_a_sufficient_caret_budget`.
+   - **[3d′ DONE]** `caret_through_bridge(u, v, B)` — the caret through a *designated*
+     reference `B` (§5b). The complement to the auto-LCA measure: the LCA caret collapses to
+     the shortest path (no info beyond distance), while a fixed bridge keeps the level
+     signal, with the exact gap `through(B) − lca = 2·d(LCA→B)`
+     (`caret_through_bridge_vs_lca_and_the_gap`).
    - **[3e next]** a **real-data integration** on a Wikipedia subtree (e.g. physics): extract
      the root-anchored region (`build_scoped_subtree_lmdb.py`), propagate the support
      interval, and compute multi-level budgeted carets between topics — the end-to-end

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -578,6 +578,52 @@ pub fn caret_distance_lca(
         .min()
 }
 
+/// Composite caret distance with a path-length **budget** on the joint up-walk: the caret
+/// `min_B (d(u→B) + d(v→B))` over shared ancestors `B` reachable within `budget` hops of
+/// *both* `u` and `v`. Returns `None` if they share no ancestor within budget — i.e. they
+/// are not "related within this scope". The **budget is the multi-level-bridge knob**: a
+/// small budget admits only a LOW common ancestor (a tight, local relation), while a
+/// budget ≥ the subtree height always reaches the bridge (at worst the subtree root) and
+/// equals `caret_distance_lca`. Its natural value is the **support upper bound** (`max`
+/// from the interval payload), which bounds depth-to-subtree-root, so the budget says "the
+/// bridge is somewhere in this subtree". (Because the LCA is the *lowest* common ancestor,
+/// growing the budget past the LCA's depth never changes the answer — it only admits
+/// higher, larger-sum bridges that lose the `min`.)
+pub fn caret_distance_budgeted(
+    u: u32,
+    v: u32,
+    parents: &std::collections::HashMap<u32, Vec<u32>>,
+    budget: u32,
+) -> Option<u32> {
+    use std::collections::{HashMap, VecDeque};
+    fn up_dist_bounded(
+        src: u32, parents: &HashMap<u32, Vec<u32>>, budget: u32,
+    ) -> HashMap<u32, u32> {
+        let mut d: HashMap<u32, u32> = HashMap::new();
+        let mut q: VecDeque<u32> = VecDeque::new();
+        d.insert(src, 0);
+        q.push_back(src);
+        while let Some(x) = q.pop_front() {
+            let dx = d[&x];
+            if dx >= budget { continue; } // nodes at depth `budget` are kept; not expanded
+            if let Some(ps) = parents.get(&x) {
+                for &p in ps {
+                    if !d.contains_key(&p) {
+                        d.insert(p, dx + 1);
+                        q.push_back(p);
+                    }
+                }
+            }
+        }
+        d
+    }
+    let du = up_dist_bounded(u, parents, budget);
+    let dv = up_dist_bounded(v, parents, budget);
+    du.iter()
+        .filter_map(|(b, &a)| dv.get(b).map(|&c| a + c))
+        .min()
+}
+
 /// Oracle read-outs: the `(M, m1, m2, m3)` moment jet of an explicit histogram. The
 /// directly-propagated `suffix_moment_jet` must equal this on an untruncated histogram —
 /// the exactness check the tests assert.
@@ -2299,6 +2345,49 @@ mod tests {
         assert_eq!(directed_distance_lower(to_root[&5], to_root[&4]), 0);
         // and for 4->5 directed (unreachable, +inf), the bound max(0, 4-1) = 3 holds vacuously.
         assert_eq!(directed_distance_lower(to_root[&4], to_root[&5]), 3);
+    }
+
+    // The budget is the multi-level-bridge knob. Tree: 0; 1->0; 2,3 -> 1; 4,5 -> 2; 6 -> 3.
+    //   4 and 5 share the LOW ancestor 2 (1 hop each) -> caret 2, found within budget 1.
+    //   4 and 6 share only the HIGH ancestor 1 (2 hops each) -> caret 4, NOT within budget 1,
+    //   found at budget 2. A budget >= the subtree height equals the unbudgeted LCA caret.
+    #[test]
+    fn budgeted_caret_scopes_the_bridge_by_level() {
+        let mut t: HashMap<u32, Vec<u32>> = HashMap::new();
+        t.insert(1, vec![0]); t.insert(2, vec![1]); t.insert(3, vec![1]);
+        t.insert(4, vec![2]); t.insert(5, vec![2]); t.insert(6, vec![3]);
+        // low bridge: 4 & 5 meet at 2 within budget 1.
+        assert_eq!(caret_distance_budgeted(4, 5, &t, 1), Some(2));
+        // high bridge: 4 & 6 are NOT related within budget 1 (disjoint 1-hop ancestors)...
+        assert_eq!(caret_distance_budgeted(4, 6, &t, 1), None);
+        // ...but a budget of 2 reaches the bridge 1.
+        assert_eq!(caret_distance_budgeted(4, 6, &t, 2), Some(4));
+        // a generous budget equals the unbudgeted LCA caret.
+        assert_eq!(caret_distance_budgeted(4, 6, &t, 100), caret_distance_lca(4, 6, &t));
+    }
+
+    // The composition the physics-subtree idea is built on: propagate the SUPPORT interval
+    // (to the subtree root), take its upper bound `max` as the caret budget, and the
+    // budgeted caret then always finds the bridge for nodes in the subtree (at worst the
+    // root). This wires the increment-1 interval payload into the increment-3 caret.
+    #[test]
+    fn support_upper_bound_is_a_sufficient_caret_budget() {
+        let g = graph(); // diamond DAG, root 0
+        for &(u, v) in &[(3u32, 4u32), (5, 3), (4, 2), (5, 4)] {
+            // support upper bound = the longest path to root, from the interval payload.
+            let max_u = {
+                let mut m = HashMap::new(); let mut s = vec![];
+                suffix_interval(u, 0, &g, &mut m, &mut s).unwrap().max
+            };
+            let max_v = {
+                let mut m = HashMap::new(); let mut s = vec![];
+                suffix_interval(v, 0, &g, &mut m, &mut s).unwrap().max
+            };
+            let budget = max_u.max(max_v); // a bound on either node's depth-to-root
+            // with that budget, the budgeted caret equals the full (unbudgeted) caret.
+            assert_eq!(caret_distance_budgeted(u, v, &g, budget), caret_distance_lca(u, v, &g),
+                "support-bounded budget {} must reach the bridge for ({},{})", budget, u, v);
+        }
     }
 
     // Undirected BFS shortest distance — the oracle for the caret tests (treats each

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -624,6 +624,57 @@ pub fn caret_distance_budgeted(
         .min()
 }
 
+/// Composite caret distance **through a designated bridge** `bridge`: `d(u→bridge) +
+/// d(v→bridge)`, the length of the `∧`-path forced through a *chosen reference node*.
+/// `None` unless `bridge` is an ancestor of **both** `u` and `v` (the path must exist).
+///
+/// This is the complement of `caret_distance_lca`. The LCA caret minimises over bridges, so
+/// it **collapses to the (undirected) shortest path** — it carries no information beyond
+/// distance. This one *fixes* the bridge, so it measures relatedness **as seen from a chosen
+/// level** (e.g. "through the physics category"). The two relate exactly: with `B` an
+/// ancestor of the LCA, on a tree `d(u→B) = d(u→LCA) + d(LCA→B)`, so
+/// `through(B) = lca + 2·d(LCA→B)` — the shortest-path caret **plus twice the lift of the
+/// reference above the true LCA**. That gap is the extra signal a designated bridge keeps
+/// and the LCA caret discards. (On a DAG it is an upper-bound approximation, like the caret
+/// itself.)
+pub fn caret_through_bridge(
+    u: u32,
+    v: u32,
+    bridge: u32,
+    parents: &std::collections::HashMap<u32, Vec<u32>>,
+) -> Option<u32> {
+    Some(up_distance_to(u, bridge, parents)? + up_distance_to(v, bridge, parents)?)
+}
+
+/// Shortest upward hop-distance `src → target` following `parents` (`target` must be an
+/// ancestor of `src`); `None` if `target` is not reachable upward. A bounded helper for
+/// `caret_through_bridge`.
+pub fn up_distance_to(
+    src: u32,
+    target: u32,
+    parents: &std::collections::HashMap<u32, Vec<u32>>,
+) -> Option<u32> {
+    use std::collections::{HashMap, VecDeque};
+    if src == target { return Some(0); }
+    let mut d: HashMap<u32, u32> = HashMap::new();
+    let mut q: VecDeque<u32> = VecDeque::new();
+    d.insert(src, 0);
+    q.push_back(src);
+    while let Some(x) = q.pop_front() {
+        let dx = d[&x];
+        if let Some(ps) = parents.get(&x) {
+            for &p in ps {
+                if p == target { return Some(dx + 1); }
+                if !d.contains_key(&p) {
+                    d.insert(p, dx + 1);
+                    q.push_back(p);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Oracle read-outs: the `(M, m1, m2, m3)` moment jet of an explicit histogram. The
 /// directly-propagated `suffix_moment_jet` must equal this on an untruncated histogram —
 /// the exactness check the tests assert.
@@ -2388,6 +2439,31 @@ mod tests {
             assert_eq!(caret_distance_budgeted(u, v, &g, budget), caret_distance_lca(u, v, &g),
                 "support-bounded budget {} must reach the bridge for ({},{})", budget, u, v);
         }
+    }
+
+    // The TWO caret measures and the exact gap between them. Tree: 0; 1->0; 2,3 -> 1;
+    // 4,5 -> 2; 6 -> 3. For (4,5) the LCA is 2.
+    #[test]
+    fn caret_through_bridge_vs_lca_and_the_gap() {
+        let mut t: HashMap<u32, Vec<u32>> = HashMap::new();
+        t.insert(1, vec![0]); t.insert(2, vec![1]); t.insert(3, vec![1]);
+        t.insert(4, vec![2]); t.insert(5, vec![2]); t.insert(6, vec![3]);
+        // through the LCA (=2) equals the auto-LCA caret (= the shortest path, here 2).
+        assert_eq!(caret_through_bridge(4, 5, 2, &t), Some(2));
+        assert_eq!(caret_distance_lca(4, 5, &t), Some(2));
+        // through a HIGHER bridge carries more: the gap is exactly 2*d(LCA -> B).
+        let lca = caret_distance_lca(4, 5, &t).unwrap();
+        for &(bridge, lift) in &[(2u32, 0u32), (1, 1), (0, 2)] { // d(2->bridge)
+            let through = caret_through_bridge(4, 5, bridge, &t).unwrap();
+            assert_eq!(through, lca + 2 * lift,
+                "through({}) = lca + 2*d(LCA->bridge) = {} + 2*{}", bridge, lca, lift);
+        }
+        // the bridge must be an ancestor of BOTH: 3 is not an ancestor of 4 -> None.
+        assert_eq!(caret_through_bridge(4, 5, 3, &t), None);
+        // and a node that IS a common ancestor (1) but for a cross-branch pair (4,6):
+        // through(1) keeps the shared-physics-level signal that the LCA caret also gives
+        // here (their LCA *is* 1), so they agree — the gap is 0 only when bridge == LCA.
+        assert_eq!(caret_through_bridge(4, 6, 1, &t), caret_distance_lca(4, 6, &t));
     }
 
     // Undirected BFS shortest distance — the oracle for the caret tests (treats each


### PR DESCRIPTION
The algorithmic core of your physics-subtree idea, built and validated — the *data wrangling* stays separate (and is de-risked: the repo already has real Wikipedia category data + a subtree-extraction tool).

## What's added (`boundary_cache.rs.mustache`)

- **`caret_distance_budgeted(u, v, parents, budget)`** — the composite caret with a path-length **budget** on the joint up-walk: `min_B (d(u→B) + d(v→B))` over shared ancestors within `budget` hops of *both* nodes, or `None` if they share none within budget ("not related within this scope").

The key property — **the budget is your multi-level-bridge knob**:
- A *small* budget admits only a **low** common ancestor (a tight, local relation).
- A budget ≥ the subtree height always reaches the bridge (at worst the subtree root) and equals the unbudgeted `caret_distance_lca`.
- Its natural value is the **support upper bound** (`max` from the interval payload, increment 1), which bounds depth-to-subtree-root — exactly your "use the support max as the maximum path length."

## Tests (65 lib tests pass)

- `budgeted_caret_scopes_the_bridge_by_level` — a pair sharing a *low* bridge is related within budget 1; a pair sharing only a *high* bridge is `None` at budget 1 but found at budget 2; a generous budget equals the unbudgeted LCA caret.
- `support_upper_bound_is_a_sufficient_caret_budget` — the full composition: propagate `suffix_interval`, take its `max` as the budget, and the budgeted caret then equals the full caret. This is increment-1's payload feeding increment-3's distance.

## Next (3e) — now de-risked

The real-data integration: extract the physics subtree (`build_scoped_subtree_lmdb.py` on the in-repo 10k fixture — it has `Physics`, `Classical_mechanics`, `Electromagnetism`, …), propagate the support interval, and compute multi-level budgeted carets between topics. Because Wikipedia categories **have cycles**, this is where the 2a/2b cycle-correctness genuinely earns its keep — it's validation, not just a demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_