### PR TITLE
Support PLAWK scalar index expressions

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -288,9 +288,9 @@ source-level state recognition separate from LLVM slot numbering. The same
 native slots now support `+=` with integer constants and field lengths, so
 programs such as `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`
 stay in the compiled stream loop. Plain scalar assignment to integer literals,
-`NR`, `NF`, or field lengths uses the same native slot path and is folded in
-source order with later `++`/`+=` updates, so `last_len = length($0)` followed
-by `hits++` also stays native. The first
+`NR`, `NF`, field lengths, or field-index positions uses the same native slot
+path and is folded in source order with later `++`/`+=` updates, so a `last_len`
+assignment followed by `hits++` also stays native. The first
 native `if/else` action slice lowers field-equality conditions once at rule-body
 scope, threads the whole scalar slot vector through then/else action sequences,
 emits per-slot phis at the branch join, and can run field-key associative

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -103,9 +103,9 @@ e.g. `$1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }`.
 Plain scalar assignment uses the same native slot path and preserves source
 order with later updates, e.g. `$1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }`. The current assignment expression subset is
-integer literals, `NR`, `NF`, `length($N)`, numeric `$N`, explicit `int($N)`,
-and native scalar `i64` primary `+/- K` forms such as `NF + K`,
-`length($N) - K`, and `int($N) + K`.
+integer literals, `NR`, `NF`, `length($N)`, `index($N, "literal")`, numeric
+`$N`, explicit `int($N)`, and native scalar `i64` primary `+/- K` forms such as
+`NF + K`, `length($N) - K`, and `int($N) + K`.
 Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -254,8 +254,9 @@ END { print hits, last_len }
 ```
 
 The current assignment expression subset is integer literals, `NR`, `NF`,
-`length($N)`, numeric `$N`, explicit `int($N)`, and native scalar `i64`
-primary `+/- K` forms such as `NF + K`, `length($N) - K`, and `int($N) + K`.
+`length($N)`, `index($N, "literal")`, numeric `$N`, explicit `int($N)`, and
+native scalar `i64` primary `+/- K` forms such as `NF + K`, `length($N) - K`,
+and `int($N) + K`.
 
 Numeric field guards are also native:
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -48,6 +48,7 @@
 %      $1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
+%      { last_pos = index($2, "sk"); total_pos += index($0, "disk") } END { print last_pos, total_pos }
 %      { adjusted += length($0) - 3; width = NF; fields += NF } END { print adjusted, width, fields }
 %      { last = NR; prev = NR - 1; total += NR + 1 } END { print last, prev, total }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
@@ -1369,6 +1370,9 @@ plawk_i64_scalar_primary_expr(int(field(FieldIndex))) :-
     FieldIndex >= 0.
 plawk_i64_scalar_primary_expr(length(field(FieldIndex))) :-
     FieldIndex >= 0.
+plawk_i64_scalar_primary_expr(index(field(FieldIndex), string(Needle))) :-
+    FieldIndex >= 0,
+    string(Needle).
 
 plawk_i64_scalar_binary_primary_expr(Expr) :-
     plawk_i64_scalar_primary_expr(Expr).
@@ -1511,57 +1515,62 @@ plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest
     { append(BranchNextExits, RestNextExits, NextExits) }.
 
 plawk_scalar_update_operation_ir(add(Expr), FieldSeparator, Prefix, SlotIndex,
-        OpIndex, InputValue, NextValue, ''-IR) :-
+        OpIndex, InputValue, NextValue, GlobalIR-IR) :-
     plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
-        OpIndex, ValueIR, SetupIR),
+        OpIndex, ValueIR, GlobalIR, SetupIR),
     format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
     format(atom(AddLine), '  ~w = add i64 ~w, ~w',
         [NextValue, InputValue, ValueIR]),
     plawk_join_nonempty_ir([SetupIR, AddLine], IR).
 plawk_scalar_update_operation_ir(set(Expr), FieldSeparator, Prefix, SlotIndex,
-        OpIndex, _InputValue, NextValue, ''-IR) :-
+        OpIndex, _InputValue, NextValue, GlobalIR-IR) :-
     plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
-        OpIndex, ValueIR, SetupIR),
+        OpIndex, ValueIR, GlobalIR, SetupIR),
     format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
     format(atom(SetLine), '  ~w = add i64 0, ~w', [NextValue, ValueIR]),
     plawk_join_nonempty_ir([SetupIR, SetLine], IR).
 
 plawk_scalar_numeric_expr_ir(const(Value), _FieldSeparator, _Prefix, _SlotIndex,
-        _OpIndex, ValueIR, IR) :-
+        _OpIndex, ValueIR, GlobalIR, IR) :-
     plawk_i64_expr_ir_parts(const(Value), 0, scalar_const, scalar_const_global,
-        ValueIR, IR).
+        ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(length(FieldIndex), FieldSeparator, Prefix, SlotIndex,
-        OpIndex, ValueIR, IR) :-
+        OpIndex, ValueIR, GlobalIR, IR) :-
     format(atom(LengthBase), '~w_slot_~w_op_~w_len', [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(length(FieldIndex), FieldSeparator, LengthBase, LengthBase,
-        ValueIR, IR).
+        ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(field_i64(FieldIndex), FieldSeparator, Prefix, SlotIndex,
-        OpIndex, ValueIR, IR) :-
+        OpIndex, ValueIR, GlobalIR, IR) :-
     format(atom(ParseBase), '~w_slot_~w_op_~w_field_i64',
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(field_i64(FieldIndex), FieldSeparator, ParseBase, ParseBase,
-        ValueIR, IR).
+        ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
-        OpIndex, ValueIR, IR) :-
+        OpIndex, ValueIR, GlobalIR, IR) :-
     plawk_i64_scalar_primary_expr(Expr),
     format(atom(PrimaryBase), '~w_slot_~w_op_~w_i64_primary',
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(Expr, FieldSeparator, PrimaryBase, PrimaryBase,
-        ValueIR, IR).
+        ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
-        OpIndex, ValueIR, IR) :-
+        OpIndex, ValueIR, GlobalIR, IR) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, NamePart, _Left, _Right),
     format(atom(BinaryBase), '~w_slot_~w_op_~w_i64_~w',
         [Prefix, SlotIndex, OpIndex, NamePart]),
     plawk_i64_expr_ir_parts(Expr, FieldSeparator, BinaryBase,
-        BinaryBase, ValueIR, IR).
+        BinaryBase, ValueIR, GlobalIR, IR).
 
 plawk_i64_expr_ir_parts(Expr, FieldSeparator, Base, GlobalBase, ValueIR, IR) :-
+    plawk_i64_expr_ir_parts(Expr, FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalIR, SetupIR),
+    plawk_join_nonempty_ir([GlobalIR, SetupIR], IR).
+
+plawk_i64_expr_ir_parts(Expr, FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalIR, SetupIR) :-
     plawk_i64_expr_ir(Expr, FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts),
     plawk_join_nonempty_ir(GlobalParts, GlobalIR),
-    atomic_list_concat(SetupParts, '\n', SetupIR),
-    plawk_join_nonempty_ir([GlobalIR, SetupIR], IR).
+    atomic_list_concat(SetupParts, '\n', SetupIR).
 
 plawk_i64_expr_ir(const(Value), _FieldSeparator, _Base, _GlobalBase, ValueIR, [], []) :-
     integer(Value),
@@ -1593,6 +1602,10 @@ plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, _GlobalBase, Valu
     format(atom(ValueIR), '%~w_value_or_default', [Base]),
     llvm_emit_atom_field_i64_or_default('%line', FieldIndex, FieldSeparator, 0,
         Base, ValueIR, ParseIR).
+plawk_i64_expr_ir(index(field(FieldIndex), string(Needle)), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    plawk_i64_expr_ir(index(FieldIndex, Needle), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts).
 plawk_i64_expr_ir(Expr, FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts) :-
     plawk_i64_binary_expr(Expr, LLVMOp, _NamePart, Left, int(Value)),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -27,6 +27,7 @@
 %      $1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
+%      { last_pos = index($2, "sk"); total_pos += index($0, "disk") } END { print last_pos, total_pos }
 %      { adjusted += length($0) - 3; width = NF; fields += NF } END { print adjusted, width, fields }
 %      { last = NR; prev = NR - 1; total += NR + 1 } END { print last, prev, total }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
@@ -382,6 +383,21 @@ scalar_delta_expr(length(Field)) -->
     ws,
     ")",
     { Field = field(_) }.
+scalar_delta_expr(index(Field, string(Needle))) -->
+    "index",
+    ws,
+    "(",
+    ws,
+    field_expr(Field),
+    ws,
+    ",",
+    ws,
+    quoted_string(NeedleCodes),
+    ws,
+    ")",
+    { Field = field(_),
+      NeedleCodes \== [],
+      string_codes(Needle, NeedleCodes) }.
 
 print_action(print(Fields)) -->
     "print",

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -261,6 +261,13 @@ test(parses_scalar_nf_add_assign_end_print_rule) :-
          add(var(next_width), add_i64(special('NF'), int(1)))])],
         [end([print([var(width), var(total), var(adjusted), var(next_width)])])])).
 
+test(parses_scalar_index_add_assign_end_print_rule) :-
+    plawk_parse_string("{ pos = index($2, \"sk\"); total += index($0, \"disk\") } END { print pos, total }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [set(var(pos), index(field(2), string("sk"))),
+         add(var(total), index(field(0), string("disk")))])],
+        [end([print([var(pos), var(total)])])])).
+
 test(parses_always_scalar_add_assign_end_print_rule) :-
     plawk_parse_string("{ total += 3 } END { print total }\n", Program),
     assertion(Program == program([], [rule(always, [add(var(total), int(3))])],
@@ -623,6 +630,11 @@ test(surface_scalar_nf_accumulates_values) :-
         "INFO boot ok\nERROR disk full now\nWARN cpu\n",
         "2 9 1 12\n").
 
+test(surface_scalar_index_accumulates_values) :-
+    run_surface_print_smoke("{ pos = index($2, \"sk\"); total += index($0, \"disk\") } END { print pos, total }\n",
+        "INFO boot ok\nERROR disk full\nWARN disk issue\n",
+        "3 13\n").
+
 test(surface_always_scalar_add_assign_accumulates_constants) :-
     run_surface_print_smoke("{ total += 3 } END { print total }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -983,6 +995,18 @@ test(surface_scalar_nf_uses_native_field_count_primary) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 %slot_2, %rule_0_body_slot_2_op_1_i64_primary'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '= sub i64 %rule_0_body_slot_0_op_2_i64_sub_lhs, 1'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 %rule_0_body_slot_1_op_3_i64_add_lhs, 1'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_scalar_index_uses_native_field_index_primary) :-
+    plawk_parse_string("BEGIN { FS = \":\" } { pos = index($2, \"work\"); total += index($0, \"network\") } END { print pos, total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_5F0_5Fbody_5Fslot_5F0_5Fop_5F0_5Fi64_5Fprimary = private constant [5 x i8] c"work\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_5F0_5Fbody_5Fslot_5F1_5Fop_5F1_5Fi64_5Fprimary = private constant [8 x i8] c"network\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0_i64_primary = call i64 @wam_atom_field_index_value(%Value %line, i64 2, i8 58'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_1_op_1_i64_primary = call i64 @wam_atom_field_index_value(%Value %line, i64 0, i8 58'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 0, %rule_0_body_slot_0_op_0_i64_primary'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 %slot_1, %rule_0_body_slot_1_op_1_i64_primary'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
  ## Summary
  - Parse `index($N, "literal")` in PLAWK scalar assignment and `+=` expressions.
  - Classify scalar `index(...)` as a native i64 primary and reuse the existing field-index helper.
  - Preserve generated string constants in module globals for scalar update lowering.
  - Add parser, executable smoke, and native IR coverage.
  - Update PLAWK docs/examples for the scalar assignment expression subset.

  ## Tests
  - `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/
  uw_smoke_index_full'),run_tests" -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_index_core swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_index_compiled_stream swipl -q -s tests/test_plawk_compiled_stream_core.pl -g
  run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_index_native_outer swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g
  run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_index_native_stream swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g
  run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_index_native_counter swipl -q -s tests/
  test_plawk_native_counter_stream_loop_driver.pl -g run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_index_native_output swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl
  -g run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_index_native_lowered swipl -q -s tests/
  test_plawk_native_lowered_handler_stream_loop_driver.pl -g run_tests -t halt`
  - `UW_SMOKE_TMPDIR=/tmp/uw_smoke_index_compiled_append swipl -q -s tests/test_plawk_compiled_output_append.pl -g
  run_tests -t halt`
  - `git diff --check`