### PR TITLE
feat(wam-rust): designated-bridge caret + the gap between the two caret measures

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -386,6 +386,40 @@ Validated by `caret_distance_on_a_tree_equals_true_distance`,
 is the natural *between-nodes* use of the to-root cache — the general companion to
 increment 2's *to-root* query.
 
+### 5b. Two caret measures: auto-LCA (shortest path) vs designated bridge
+
+There are **two** ways to pick the bridge, and they answer different questions:
+
+- **Auto-LCA** — `caret_distance_lca` minimises over bridges, so the bridge is *implicit*
+  (the lowest common ancestor). But minimising over `B` means it **collapses to the
+  (undirected) shortest path** (on a tree, exactly the tree distance). So it carries **no
+  information beyond distance** — you don't pick a bridge, but you also learn nothing the
+  shortest path wouldn't tell you. `caret_distance_budgeted(u, v, budget)` is this measure
+  *scoped*: the budget admits only bridges within a radius (the support upper bound is the
+  natural value), but within scope it is still the auto-minimising shortest path.
+- **Designated bridge** — `caret_through_bridge(u, v, B) = d(u→B) + d(v→B)` *fixes* the
+  bridge to a chosen reference node `B` (defined when `B` is an ancestor of both). It
+  measures relatedness **as seen from a chosen level** — "through the physics category", or
+  through a node higher up. You pick the bridge, and in exchange it keeps information the
+  shortest path discards.
+
+**The distance between the two measures.** With the LCA below the chosen bridge `B`, on a
+tree `d(u→B) = d(u→LCA) + d(LCA→B)` (and likewise for `v`), so
+
+```
+through(B)  −  lca   =   2 · d(LCA → B)
+```
+
+— the designated-bridge caret is the **shortest-path caret plus twice the lift of the
+reference above the true LCA** (`caret_through_bridge_vs_lca_and_the_gap`). That gap is
+exactly the signal the auto-LCA throws away: two topic pairs with the *same* shortest path
+get *different* through-`B` distances when their LCAs sit at different depths below `B`. So
+`through(B)` decomposes as **intrinsic distance** (the shortest path) + **2 × (how far the
+pair's meeting point sits below your reference level)**. Choosing `B` = the physics category
+yields "relatedness within physics"; raising `B` yields relatedness at a coarser level — the
+multi-level reading the budgeted measure cannot give (it only scopes, never reframes). On a
+DAG both are upper-bound approximations, as the caret itself is.
+
 ## 6. Aside: the kernel-trick analogy
 
 *(A mnemonic, not load-bearing — the mechanics above stand on their own; skip if you only
@@ -583,6 +617,11 @@ buy diminishing returns and is not carried).
      1), which bounds depth-to-subtree-root — so the increment-1 payload feeds the
      increment-3 caret. Validated by `budgeted_caret_scopes_the_bridge_by_level` and
      `support_upper_bound_is_a_sufficient_caret_budget`.
+   - **[3d′ DONE]** `caret_through_bridge(u, v, B)` — the caret through a *designated*
+     reference `B` (§5b). The complement to the auto-LCA measure: the LCA caret collapses to
+     the shortest path (no info beyond distance), while a fixed bridge keeps the level
+     signal, with the exact gap `through(B) − lca = 2·d(LCA→B)`
+     (`caret_through_bridge_vs_lca_and_the_gap`).
    - **[3e next]** a **real-data integration** on a Wikipedia subtree (e.g. physics): extract
      the root-anchored region (`build_scoped_subtree_lmdb.py`), propagate the support
      interval, and compute multi-level budgeted carets between topics — the end-to-end

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -624,6 +624,57 @@ pub fn caret_distance_budgeted(
         .min()
 }
 
+/// Composite caret distance **through a designated bridge** `bridge`: `d(u→bridge) +
+/// d(v→bridge)`, the length of the `∧`-path forced through a *chosen reference node*.
+/// `None` unless `bridge` is an ancestor of **both** `u` and `v` (the path must exist).
+///
+/// This is the complement of `caret_distance_lca`. The LCA caret minimises over bridges, so
+/// it **collapses to the (undirected) shortest path** — it carries no information beyond
+/// distance. This one *fixes* the bridge, so it measures relatedness **as seen from a chosen
+/// level** (e.g. "through the physics category"). The two relate exactly: with `B` an
+/// ancestor of the LCA, on a tree `d(u→B) = d(u→LCA) + d(LCA→B)`, so
+/// `through(B) = lca + 2·d(LCA→B)` — the shortest-path caret **plus twice the lift of the
+/// reference above the true LCA**. That gap is the extra signal a designated bridge keeps
+/// and the LCA caret discards. (On a DAG it is an upper-bound approximation, like the caret
+/// itself.)
+pub fn caret_through_bridge(
+    u: u32,
+    v: u32,
+    bridge: u32,
+    parents: &std::collections::HashMap<u32, Vec<u32>>,
+) -> Option<u32> {
+    Some(up_distance_to(u, bridge, parents)? + up_distance_to(v, bridge, parents)?)
+}
+
+/// Shortest upward hop-distance `src → target` following `parents` (`target` must be an
+/// ancestor of `src`); `None` if `target` is not reachable upward. A bounded helper for
+/// `caret_through_bridge`.
+pub fn up_distance_to(
+    src: u32,
+    target: u32,
+    parents: &std::collections::HashMap<u32, Vec<u32>>,
+) -> Option<u32> {
+    use std::collections::{HashMap, VecDeque};
+    if src == target { return Some(0); }
+    let mut d: HashMap<u32, u32> = HashMap::new();
+    let mut q: VecDeque<u32> = VecDeque::new();
+    d.insert(src, 0);
+    q.push_back(src);
+    while let Some(x) = q.pop_front() {
+        let dx = d[&x];
+        if let Some(ps) = parents.get(&x) {
+            for &p in ps {
+                if p == target { return Some(dx + 1); }
+                if !d.contains_key(&p) {
+                    d.insert(p, dx + 1);
+                    q.push_back(p);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Oracle read-outs: the `(M, m1, m2, m3)` moment jet of an explicit histogram. The
 /// directly-propagated `suffix_moment_jet` must equal this on an untruncated histogram —
 /// the exactness check the tests assert.
@@ -2388,6 +2439,31 @@ mod tests {
             assert_eq!(caret_distance_budgeted(u, v, &g, budget), caret_distance_lca(u, v, &g),
                 "support-bounded budget {} must reach the bridge for ({},{})", budget, u, v);
         }
+    }
+
+    // The TWO caret measures and the exact gap between them. Tree: 0; 1->0; 2,3 -> 1;
+    // 4,5 -> 2; 6 -> 3. For (4,5) the LCA is 2.
+    #[test]
+    fn caret_through_bridge_vs_lca_and_the_gap() {
+        let mut t: HashMap<u32, Vec<u32>> = HashMap::new();
+        t.insert(1, vec![0]); t.insert(2, vec![1]); t.insert(3, vec![1]);
+        t.insert(4, vec![2]); t.insert(5, vec![2]); t.insert(6, vec![3]);
+        // through the LCA (=2) equals the auto-LCA caret (= the shortest path, here 2).
+        assert_eq!(caret_through_bridge(4, 5, 2, &t), Some(2));
+        assert_eq!(caret_distance_lca(4, 5, &t), Some(2));
+        // through a HIGHER bridge carries more: the gap is exactly 2*d(LCA -> B).
+        let lca = caret_distance_lca(4, 5, &t).unwrap();
+        for &(bridge, lift) in &[(2u32, 0u32), (1, 1), (0, 2)] { // d(2->bridge)
+            let through = caret_through_bridge(4, 5, bridge, &t).unwrap();
+            assert_eq!(through, lca + 2 * lift,
+                "through({}) = lca + 2*d(LCA->bridge) = {} + 2*{}", bridge, lca, lift);
+        }
+        // the bridge must be an ancestor of BOTH: 3 is not an ancestor of 4 -> None.
+        assert_eq!(caret_through_bridge(4, 5, 3, &t), None);
+        // and a node that IS a common ancestor (1) but for a cross-branch pair (4,6):
+        // through(1) keeps the shared-physics-level signal that the LCA caret also gives
+        // here (their LCA *is* 1), so they agree — the gap is 0 only when bridge == LCA.
+        assert_eq!(caret_through_bridge(4, 6, 1, &t), caret_distance_lca(4, 6, &t));
     }
 
     // Undirected BFS shortest distance — the oracle for the caret tests (treats each


### PR DESCRIPTION
**Stacked on #3247.** Adds the designated-bridge caret you were describing, and updates the theory doc with the two measures and the exact distance between them — the headline ask.

> Base is the budgeted-caret branch so the diff is just this work; I'll retarget to `main` once #3247 merges.

## Your critique, made precise

The auto-LCA caret **collapses to the (undirected) shortest path** — minimising over bridges *is* the tree distance, so it carries no information beyond distance. You don't pick a bridge, but you also learn nothing new. So I added the complement:

- **`caret_through_bridge(u, v, B) = d(u→B) + d(v→B)`** — the `∧`-path forced through a *chosen reference* `B` (defined when `B` is an ancestor of both). It measures relatedness **as seen from a chosen level** — "through the physics category", or a node higher up. You pick the bridge, and in exchange it keeps the information the shortest path discards.

## The distance between the two measures

With the LCA below the chosen bridge `B`, on a tree `d(u→B) = d(u→LCA) + d(LCA→B)`, so:

```
through(B) − lca = 2·d(LCA→B)
```

The designated-bridge caret is the **shortest-path caret + twice the lift of the reference above the true LCA**. That gap is exactly the signal the auto-LCA throws away: two topic pairs with the *same* shortest path get *different* through-`B` distances when their meeting points sit at different depths below `B`. Choosing `B` = physics gives "relatedness within physics"; raising `B` reframes at a coarser level — the multi-level reading the budgeted measure can only *scope*, never *reframe*.

## Tests (66 lib tests pass)

`caret_through_bridge_vs_lca_and_the_gap` — `through(LCA) == lca == shortest path`; `through(higher B) == lca + 2·lift` for each level; the bridge must be a common ancestor (else `None`).

## Docs

New theory **§5b "Two caret measures: auto-LCA (shortest path) vs designated bridge"** with the gap decomposition; §8 records it as 3d′.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_