### PR TITLE
docs(wam-rust): hard vs soft shortest distance — admitted paths need not be one length

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -419,6 +419,22 @@ There are **two** ways to pick the bridge, and they answer different questions:
 > instance not yet built: the bare interval gives the floor but not its count, and the moment
 > jet gives mass/moments but not the count *at* the floor.)
 
+> **Hard vs. soft shortest distance — the admitted paths need not be one length.** The
+> floor functional above is the **hard** minimum (tropical / min-plus): *only* floor-length
+> paths get nonzero weight, so the value is `min L` exactly and the multiplicity `H[floor]`
+> is a separate read-out. But the framework's *original* distance functional is **soft** —
+> the effective distance `d_eff = (Σ_L H[L]·L^{-N})^{-1/N}` (§5) — a weighted sum that admits
+> paths of **all** lengths, weighting shorter ones more (`L^{-N}`). For finite `N` it is a
+> power mean in `[floor, ceiling]` (the §5 bracket), reaching the floor only as `N → ∞`. So
+> "shortest distance" is genuinely two functionals: the **hard** floor (one length, with a
+> separate count) or the **soft** `d_eff` (every length contributes a nonzero weight, short
+> ones dominating). The two even meet at the multiplicity — the large-`N` expansion is
+> `d_eff ≈ floor · H[floor]^{-1/N}`, so the soft functional's *leading term* is the floor and
+> its *first correction* encodes the **number** of shortest paths. A single soft functional
+> thus carries both the floor and (asymptotically) the multiplicity; the hard min carries
+> only the floor. This is why a caret built from `d_eff` rather than the hard min is, exactly
+> as it sounds, a weighted average over `∧`-paths of *different* lengths — not a single route.
+
 **The distance between the two measures.** With the LCA below the chosen bridge `B`, on a
 tree `d(u→B) = d(u→LCA) + d(LCA→B)` (and likewise for `v`), so
 


### PR DESCRIPTION
**Docs-only.** Captures the distinction you drew out: "the shortest-distance functional" is really *two* functionals, and the practical one weights paths of **different** lengths.

## The clarification (new §5b note)

- **Hard min** (the floor functional, tropical / min-plus): `min{L : H[L]>0}`. *Only* floor-length paths get nonzero weight — so the value is the floor exactly, the multiplicity `H[floor]` is a separate read-out, and the admitted paths *are* all one length.
- **Soft min** (the framework's *original* query): `d_eff = (Σ_L H[L]·L^{-N})^{-1/N}` — a weighted sum admitting paths of **all** lengths, weighting shorter ones more (`L^{-N}`). For finite `N` it's a power mean in `[floor, ceiling]` (the §5 bracket); it reaches the floor only as `N→∞`. So here the admitted paths are **not** one length — exactly your point.

## The bonus the two cases share

The large-`N` expansion is `d_eff ≈ floor · H[floor]^{-1/N}`, so the soft functional's *leading term* is the floor and its *first correction* encodes the **number** of shortest paths. A single soft functional carries both the floor and (asymptotically) the multiplicity; the hard min carries only the floor. A caret built from `d_eff` rather than the hard min is therefore — as it sounds — a weighted average over `∧`-paths of *different* lengths, not a single route.

This sits right next to the value-vs-route note and finishes the "what does applying the functional to the distribution actually give you" picture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_