### PR TITLE
Support PLAWK index i64 binary expressions

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -265,8 +265,8 @@ Explicit print-side numeric coercions such as `int($N)` lower through the shared
 `@wam_atom_field_i64_value` parse helper and print zero when the field is
 missing or not a strict signed decimal. The first composed arithmetic forms add
 or subtract a non-negative integer constant from native `i64` primaries such as
-`NR`, `NF`, `length($N)`, and `int($N)`; each lowers through the shared primary
-emitter followed by a shared binary `i64` operation.
+`NR`, `NF`, `length($N)`, `int($N)`, and `index($N, "literal")`; each lowers
+through the shared primary emitter followed by a shared binary `i64` operation.
 Print-only `tolower($N)` and `toupper($N)` lower through shared
 `@wam_print_ascii_lower_slice` and `@wam_print_ascii_upper_slice` helpers, so
 case mapping streams bytes without allocating a transformed atom.
@@ -306,8 +306,8 @@ branch-local prints; the context supplies prefixed names while `$N`, `NF`,
 lowering clauses. Numeric expression lowering is also factored through a shared
 `plawk_i64_expr_ir` layer, so scalar updates and print expressions both consume
 the same native `i64` emitters for constants, `NR`, `NF`, `length($N)`, numeric
-field coercion, `index($N, "...")`, and native `NR`/`NF`/`length`/`int` primary
-`+/- K` forms where those forms apply.
+field coercion, `index($N, "...")`, and native `NR`/`NF`/`length`/`int`/`index`
+primary `+/- K` forms where those forms apply.
 Terminal
 branch-local `next` branches directly to the stream-loop continuation and adds
 the selected branch's scalar values to the loop phi inputs. Terminal

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -105,7 +105,8 @@ order with later updates, e.g. `$1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }`. The current assignment expression subset is
 integer literals, `NR`, `NF`, `length($N)`, `index($N, "literal")`, numeric
 `$N`, explicit `int($N)`, and native scalar `i64` primary `+/- K` forms such as
-`NF + K`, `length($N) - K`, and `int($N) + K`.
+`NF + K`, `length($N) - K`, `int($N) + K`, and
+`index($N, "literal") + K`.
 Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -256,7 +256,7 @@ END { print hits, last_len }
 The current assignment expression subset is integer literals, `NR`, `NF`,
 `length($N)`, `index($N, "literal")`, numeric `$N`, explicit `int($N)`, and
 native scalar `i64` primary `+/- K` forms such as `NF + K`, `length($N) - K`,
-and `int($N) + K`.
+`int($N) + K`, and `index($N, "literal") + K`.
 
 Numeric field guards are also native:
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -45,10 +45,10 @@
 %      $1 == "ERROR" { print $3, int($3) }
 %      $1 == "ERROR" { print int($3) + 1 }
 %      $1 == "ERROR" { print int($3) - 1 }
-%      $1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3 }
+%      $1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3, index($2, "sk") + 1 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
-%      { last_pos = index($2, "sk"); total_pos += index($0, "disk") } END { print last_pos, total_pos }
+%      { last_pos = index($2, "sk") + 1; total_pos += index($0, "disk") - 1 } END { print last_pos, total_pos }
 %      { adjusted += length($0) - 3; width = NF; fields += NF } END { print adjusted, width, fields }
 %      { last = NR; prev = NR - 1; total += NR + 1 } END { print last, prev, total }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
@@ -1357,6 +1357,9 @@ plawk_i64_binary_primary_expr(int(field(FieldIndex))) :-
     FieldIndex >= 0.
 plawk_i64_binary_primary_expr(length(field(FieldIndex))) :-
     FieldIndex >= 0.
+plawk_i64_binary_primary_expr(index(field(FieldIndex), string(Needle))) :-
+    FieldIndex >= 0,
+    string(Needle).
 
 plawk_i64_scalar_const_binary_expr(Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, int(Value)),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -24,10 +24,10 @@
 %      $1 == "ERROR" { print $3, int($3) }
 %      $1 == "ERROR" { print int($3) + 1 }
 %      $1 == "ERROR" { print int($3) - 1 }
-%      $1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3 }
+%      $1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3, index($2, "sk") + 1 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
-%      { last_pos = index($2, "sk"); total_pos += index($0, "disk") } END { print last_pos, total_pos }
+%      { last_pos = index($2, "sk") + 1; total_pos += index($0, "disk") - 1 } END { print last_pos, total_pos }
 %      { adjusted += length($0) - 3; width = NF; fields += NF } END { print adjusted, width, fields }
 %      { last = NR; prev = NR - 1; total += NR + 1 } END { print last, prev, total }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
@@ -551,6 +551,20 @@ i64_binary_primary_expr(length(Field)) -->
     simple_field_expr(Field),
     ws,
     ")".
+i64_binary_primary_expr(index(Field, string(Needle))) -->
+    "index",
+    ws,
+    "(",
+    ws,
+    simple_field_expr(Field),
+    ws,
+    ",",
+    ws,
+    quoted_string(NeedleCodes),
+    ws,
+    ")",
+    { NeedleCodes \== [],
+      string_codes(Needle, NeedleCodes) }.
 
 simple_field_expr(field(Index)) -->
     "$",

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -91,11 +91,12 @@ test(parses_field_eq_print_int_sub_field_rule) :-
         [print([sub_i64(int(field(3)), int(1))])])], [])).
 
 test(parses_field_eq_print_i64_primary_binary_rule) :-
-    plawk_parse_string("$1 == \"ERROR\" { print NR - 1, NF + 1, length($0) - 3 }\n", Program),
+    plawk_parse_string("$1 == \"ERROR\" { print NR - 1, NF + 1, length($0) - 3, index($2, \"sk\") + 1 }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [print([sub_i64(special('NR'), int(1)),
                 add_i64(special('NF'), int(1)),
-                sub_i64(length(field(0)), int(3))])])], [])).
+                sub_i64(length(field(0)), int(3)),
+                add_i64(index(field(2), string("sk")), int(1))])])], [])).
 
 test(parses_field_eq_print_case_field_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print tolower($2), toupper($0) }\n", Program),
@@ -266,6 +267,13 @@ test(parses_scalar_index_add_assign_end_print_rule) :-
     assertion(Program == program([], [rule(always,
         [set(var(pos), index(field(2), string("sk"))),
          add(var(total), index(field(0), string("disk")))])],
+        [end([print([var(pos), var(total)])])])).
+
+test(parses_scalar_index_binary_add_assign_end_print_rule) :-
+    plawk_parse_string("{ pos = index($2, \"sk\") + 1; total += index($0, \"disk\") - 1 } END { print pos, total }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [set(var(pos), add_i64(index(field(2), string("sk")), int(1))),
+         add(var(total), sub_i64(index(field(0), string("disk")), int(1)))])],
         [end([print([var(pos), var(total)])])])).
 
 test(parses_always_scalar_add_assign_end_print_rule) :-
@@ -601,9 +609,9 @@ test(surface_begin_field_separator_drives_int_sub_printing) :-
         "10,9\n-3,-4\nnope,-1\n").
 
 test(surface_begin_field_separator_drives_i64_primary_binary_printing) :-
-    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print NR - 1, NF + 1, length($0) - 3, int($3) + 1 }\n",
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print NR - 1, NF + 1, length($0) - 3, int($3) + 1, index($2, \"work\") + 1 }\n",
         "ERROR:disk:10\nWARN:cpu:20\nERROR:network:-3\n",
-        "0,4,10,11\n2,4,13,-2\n").
+        "0,4,10,11,1\n2,4,13,-2,5\n").
 
 test(surface_field_int_add_scalar_accumulates_values) :-
     run_surface_print_smoke("$1 == \"ERROR\" { bytes += int($3) + 1; last = int($3) + 1 } END { print bytes, last }\n",
@@ -634,6 +642,11 @@ test(surface_scalar_index_accumulates_values) :-
     run_surface_print_smoke("{ pos = index($2, \"sk\"); total += index($0, \"disk\") } END { print pos, total }\n",
         "INFO boot ok\nERROR disk full\nWARN disk issue\n",
         "3 13\n").
+
+test(surface_scalar_index_binary_accumulates_values) :-
+    run_surface_print_smoke("{ pos = index($2, \"sk\") + 1; total += index($0, \"disk\") - 1 } END { print pos, total }\n",
+        "INFO boot ok\nERROR disk full\nWARN disk issue\n",
+        "4 10\n").
 
 test(surface_always_scalar_add_assign_accumulates_constants) :-
     run_surface_print_smoke("{ total += 3 } END { print total }\n",
@@ -964,7 +977,7 @@ test(surface_int_sub_print_uses_shared_i64_sub_lowering) :-
     !.
 
 test(surface_i64_primary_binary_print_uses_shared_lowering) :-
-    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print NR - 1, NF + 1, length($0) - 3, int($3) + 1 }\n", Program),
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print NR - 1, NF + 1, length($0) - 3, int($3) + 1, index($2, \"work\") + 1 }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_sub_0 = sub i64 %current_nr, 1'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_1_lhs = call i64 @wam_atom_field_count_value(%Value %line, i8 58)'))),
@@ -973,6 +986,9 @@ test(surface_i64_primary_binary_print_uses_shared_lowering) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_sub_2 = sub i64 %plawk_int_sub_2_lhs, 3'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_3_lhs_value_or_default = select i1 %plawk_int_add_3_lhs_ok, i64 %plawk_int_add_3_lhs_value, i64 0'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_3 = add i64 %plawk_int_add_3_lhs_value_or_default, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_5Fint_5Fadd_5F4_5Flhs = private constant [5 x i8] c"work\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_4_lhs = call i64 @wam_atom_field_index_value(%Value %line, i64 2, i8 58'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_4 = add i64 %plawk_int_add_4_lhs, 1'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
@@ -1007,6 +1023,20 @@ test(surface_scalar_index_uses_native_field_index_primary) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_1_op_1_i64_primary = call i64 @wam_atom_field_index_value(%Value %line, i64 0, i8 58'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 0, %rule_0_body_slot_0_op_0_i64_primary'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 %slot_1, %rule_0_body_slot_1_op_1_i64_primary'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_scalar_index_binary_uses_native_field_index_primary) :-
+    plawk_parse_string("BEGIN { FS = \":\" } { pos = index($2, \"work\") + 1; total += index($0, \"network\") - 1 } END { print pos, total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_5F0_5Fbody_5Fslot_5F0_5Fop_5F0_5Fi64_5Fadd_5Flhs = private constant [5 x i8] c"work\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_5F0_5Fbody_5Fslot_5F1_5Fop_5F1_5Fi64_5Fsub_5Flhs = private constant [8 x i8] c"network\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0_i64_add_lhs = call i64 @wam_atom_field_index_value(%Value %line, i64 2, i8 58'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0_i64_add = add i64 %rule_0_body_slot_0_op_0_i64_add_lhs, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_1_op_1_i64_sub_lhs = call i64 @wam_atom_field_index_value(%Value %line, i64 0, i8 58'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_1_op_1_i64_sub = sub i64 %rule_0_body_slot_1_op_1_i64_sub_lhs, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 0, %rule_0_body_slot_0_op_0_i64_add'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 %slot_1, %rule_0_body_slot_1_op_1_i64_sub'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
  ## Summary
  - Parse `index($N, "literal") +/- K` as a native PLAWK i64 binary primary.
  - Lower index-based binary expressions through the shared print/scalar native i64 codegen path.
  - Add parser, compiled smoke, and native IR coverage for print and scalar assignment/update forms.
  - Update PLAWK docs to include `index($N, "literal") + K` support.

  ## Verification
  - Direct parser checks for print and scalar `index(...) +/- K` forms.
  - `tests/test_plawk_surface_prefix_print.pl` full suite: 198 passed.
  - PLAWK core and native stream/driver smoke suites passed.
  - `git diff --check` passed.