### PR TITLE
Support PLAWK loop-control tail trimming

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -319,9 +319,9 @@ early-exit rule's scalar values to the loop phi inputs, while assoc-only chains
 update tables before the continuation branch. Terminal `break` uses the sibling
 path: matching rules branch to a dedicated stream-close block and scalar/mixed
 programs feed `END` through final-state phis. This native slice deliberately
-supports terminal `next`/`break` only; non-terminal loop control needs a future
-intra-rule control-flow lowering rather than implicit fall-through after the
-skipped or final record. The current
+trims unreachable tail actions after `next`/`break` in the same rule body or
+branch before lowering, so parser-accepted non-final control statements still
+reuse the terminal native continuation/close paths. The current
 associative-count surface allocates one reusable WAM/LLVM
 interned-atom-keyed growable `i64` table primitive (`wam_assoc_i64_*`) per source
 array, increments those tables in the native streaming loop, and performs `END`

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -87,8 +87,8 @@ Explicit numeric field coercion is available as `int($N)`, e.g.
 `$1 == "ERROR" { print $3, int($3) }`; failed numeric parses print `0`.
 The first arithmetic composition forms add or subtract a non-negative integer
 constant from native `i64` primaries such as `NR`, `NF`, `length($N)`,
-and `int($N)`, e.g.
-`$1 == "ERROR" { print NR - 1, int($3) + 1 }`.
+`int($N)`, and `index($N, "literal")`, e.g.
+`$1 == "ERROR" { print NR - 1, int($3) + 1, index($2, "sk") + 1 }`.
 Numeric field guards use the shared WAM/LLVM `i64` comparison helper, so forms
 such as `$3 > 100 { print $1, $3 }` and `$2 <= -5 { cold++ }` stay in the native
 streaming loop.
@@ -122,10 +122,10 @@ Terminal `next` is supported in native rule chains, so `$1 == "DEBUG" {
 skipped++; next } { total++ } END { print total, skipped }` skips the later
 rule for matching records. Terminal `break` is supported in the same native
 rule-chain shape and closes the stream before running `END`, e.g. `$1 == "ERROR"
-{ hits++; break } { total++ } END { print hits, total }`. In the current surface
-slice, `next` and `break` must be the last action in their rule body; branch
-`next`/`break` must also be terminal in that branch. Non-terminal loop control is
-intentionally rejected by the native codegen boundary. The first
+{ hits++; break } { total++ } END { print hits, total }`. If `next` or `break`
+appears before the end of a rule body or branch, later actions in that same
+action list are treated as unreachable tail actions and skipped by native
+codegen. The first
 associative-count surface now supports multiple source arrays, e.g.
 `{ counts[$1]++; by_component[$2]++ } END { print counts["ERROR"], by_component["disk"] }`.
 Codegen allocates one WAM/LLVM runtime interned-atom-keyed `i64` table per

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -347,8 +347,8 @@ $1 == "ERROR" { hits++; break }
 END { print hits, total }
 ```
 
-For now, `next` and `break` must be the last action in the rule body. Inside a
-branch, `next` or `break` must be the last action in that branch.
+If `next` or `break` appears before the end of a rule body or branch, later
+actions in that same action list are unreachable and skipped by native codegen.
 
 `BEGIN` can emit literal report headers before the first input record is read:
 
@@ -388,7 +388,7 @@ The current arithmetic print subset can add or subtract a non-negative integer
 constant from native `i64` primaries:
 
 ```awk
-$1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3 }
+$1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3, index($2, "sk") + 1 }
 $1 == "ERROR" { print int($3) + 1 }
 $1 == "ERROR" { print int($3) - 1 }
 ```

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -247,15 +247,33 @@ plawk_state_slot_index(StatePlan, Slot, Index) :-
     plawk_state_plan_slots(StatePlan, Slots),
     nth0(Index, Slots, Slot).
 
-plawk_split_terminal_control(Actions, BodyActions, terminal_next) :-
+plawk_trim_control_tails([], []).
+plawk_trim_control_tails([next | _Rest], [next]) :-
+    !.
+plawk_trim_control_tails([break | _Rest], [break]) :-
+    !.
+plawk_trim_control_tails([if(Pattern, ThenActions, ElseActions) | Rest],
+        [if(Pattern, TrimmedThenActions, TrimmedElseActions) | TrimmedRest]) :-
+    !,
+    plawk_trim_control_tails(ThenActions, TrimmedThenActions),
+    plawk_trim_control_tails(ElseActions, TrimmedElseActions),
+    plawk_trim_control_tails(Rest, TrimmedRest).
+plawk_trim_control_tails([Action | Rest], [Action | TrimmedRest]) :-
+    plawk_trim_control_tails(Rest, TrimmedRest).
+
+plawk_split_terminal_control(Actions0, BodyActions, Control) :-
+    plawk_trim_control_tails(Actions0, Actions),
+    plawk_split_normalized_terminal_control(Actions, BodyActions, Control).
+
+plawk_split_normalized_terminal_control(Actions, BodyActions, terminal_next) :-
     append(BodyActions, [next], Actions),
     !,
     \+ plawk_actions_have_control(BodyActions).
-plawk_split_terminal_control(Actions, BodyActions, terminal_break) :-
+plawk_split_normalized_terminal_control(Actions, BodyActions, terminal_break) :-
     append(BodyActions, [break], Actions),
     !,
     \+ plawk_actions_have_control(BodyActions).
-plawk_split_terminal_control(Actions, Actions, fallthrough) :-
+plawk_split_normalized_terminal_control(Actions, Actions, fallthrough) :-
     \+ plawk_actions_have_control(Actions).
 
 plawk_actions_have_control(Actions) :-
@@ -270,11 +288,12 @@ plawk_action_has_control(if(_Pattern, ThenActions, ElseActions)) :-
     ).
 
 plawk_branch_actions_have_unsupported_control(Actions) :-
-    (   append(BodyActions, [next], Actions)
+    plawk_trim_control_tails(Actions, TrimmedActions),
+    (   append(BodyActions, [next], TrimmedActions)
     ->  plawk_actions_have_control(BodyActions)
-    ;   append(BodyActions, [break], Actions)
+    ;   append(BodyActions, [break], TrimmedActions)
     ->  plawk_actions_have_control(BodyActions)
-    ;   plawk_actions_have_control(Actions)
+    ;   plawk_actions_have_control(TrimmedActions)
     ).
 
 plawk_rule_target(fallthrough, NextLabel, NextLabel).
@@ -385,7 +404,8 @@ plawk_scalar_rule_controls(Rules, Controls) :-
 plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
     findall(Name,
         ( member(rule(_Pattern, Actions), Rules),
-          member(Action, Actions),
+          plawk_trim_control_tails(Actions, ReachableActions),
+          member(Action, ReachableActions),
           plawk_scalar_update_action_name(Action, Name)
         ),
         ActionVars),
@@ -415,7 +435,8 @@ plawk_mixed_state_plan(Rules, PrintFields, mixed_plan(ScalarPlan, AssocPlan, Pla
 plawk_mixed_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
     findall(Name,
         ( member(rule(_Pattern, Actions), Rules),
-          member(Action, Actions),
+          plawk_trim_control_tails(Actions, ReachableActions),
+          member(Action, ReachableActions),
           plawk_scalar_update_action_name(Action, Name)
         ),
         ActionVars),
@@ -469,7 +490,8 @@ plawk_rules_scalar_update_exprs(Rules, Exprs) :-
         Exprs).
 
 plawk_actions_scalar_update_expr(Actions, Expr) :-
-    member(Action, Actions),
+    plawk_trim_control_tails(Actions, ReachableActions),
+    member(Action, ReachableActions),
     plawk_action_scalar_update_expr(Action, Expr).
 
 plawk_action_scalar_update_expr(if(_Pattern, ThenActions, ElseActions), Expr) :-
@@ -485,7 +507,8 @@ plawk_scalar_operation_expr(add(Expr), Expr).
 plawk_scalar_operation_expr(set(Expr), Expr).
 
 plawk_actions_body_print_field(Actions, Field) :-
-    member(Action, Actions),
+    plawk_trim_control_tails(Actions, ReachableActions),
+    member(Action, ReachableActions),
     plawk_action_body_print_field(Action, Field).
 
 plawk_action_body_print_field(print(Fields), Field) :-
@@ -549,19 +572,24 @@ plawk_scalar_conditional_action(if(_Pattern, ThenActions, ElseActions)) :-
 plawk_scalar_plain_update_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
 
-plawk_split_branch_control(Actions, BodyActions, branch_next) :-
+plawk_split_branch_control(Actions0, BodyActions, Control) :-
+    plawk_trim_control_tails(Actions0, Actions),
+    plawk_split_normalized_branch_control(Actions, BodyActions, Control).
+
+plawk_split_normalized_branch_control(Actions, BodyActions, branch_next) :-
     append(BodyActions, [next], Actions),
     !,
     \+ plawk_actions_have_control(BodyActions).
-plawk_split_branch_control(Actions, BodyActions, branch_break) :-
+plawk_split_normalized_branch_control(Actions, BodyActions, branch_break) :-
     append(BodyActions, [break], Actions),
     !,
     \+ plawk_actions_have_control(BodyActions).
-plawk_split_branch_control(Actions, Actions, fallthrough) :-
+plawk_split_normalized_branch_control(Actions, Actions, fallthrough) :-
     \+ plawk_actions_have_control(Actions).
 
 plawk_assoc_increment_spec_in_actions(Actions, Spec) :-
-    member(Action, Actions),
+    plawk_trim_control_tails(Actions, ReachableActions),
+    member(Action, ReachableActions),
     plawk_assoc_increment_spec_in_action(Action, Spec).
 
 plawk_assoc_increment_specs_in_actions(Actions, Specs) :-

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -533,15 +533,30 @@ test(surface_terminal_next_skips_remaining_scalar_rules) :-
         "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
         "2 2\n").
 
+test(surface_nonterminal_next_skips_dead_scalar_tail) :-
+    run_surface_print_smoke("$1 == \"DEBUG\" { next; skipped++ } { total++ } END { print total, skipped }\n",
+        "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
+        "2 0\n").
+
 test(surface_terminal_next_skips_remaining_assoc_rules) :-
     run_surface_print_smoke("$1 == \"DEBUG\" { skipped[$2]++; next } { counts[$1]++ } END { print skipped[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n",
         "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
         "2 0 1\n").
 
+test(surface_nonterminal_next_skips_dead_assoc_tail) :-
+    run_surface_print_smoke("$1 == \"DEBUG\" { next; skipped[$2]++ } { counts[$1]++ } END { print skipped[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n",
+        "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
+        "0 0 1\n").
+
 test(surface_terminal_next_skips_remaining_mixed_rules) :-
     run_surface_print_smoke("$1 == \"DEBUG\" { skipped++; by_kind[$2]++; next } { total++; counts[$1]++ } END { print total, skipped, by_kind[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n",
         "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
         "2 2 2 0 1\n").
+
+test(surface_nonterminal_next_skips_dead_mixed_tail) :-
+    run_surface_print_smoke("$1 == \"DEBUG\" { next; skipped++; by_kind[$2]++ } { total++; counts[$1]++ } END { print total, skipped, by_kind[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n",
+        "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
+        "2 0 0 0 1\n").
 
 test(surface_terminal_next_only_skips_remaining_scalar_rules) :-
     run_surface_print_smoke("$1 == \"DEBUG\" { next } { total++ } END { print total }\n",
@@ -563,15 +578,30 @@ test(surface_terminal_break_stops_scalar_rule_chain_and_runs_end) :-
         "INFO boot ok\nWARN cpu hot\nERROR disk full\nERROR net down\n",
         "1 2\n").
 
+test(surface_nonterminal_break_skips_dead_scalar_tail) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { break; hits++ } { total++ } END { print hits, total }\n",
+        "INFO boot ok\nWARN cpu hot\nERROR disk full\nERROR net down\n",
+        "0 2\n").
+
 test(surface_terminal_break_stops_assoc_rule_chain_and_runs_end) :-
     run_surface_print_smoke("$1 == \"ERROR\" { seen[$2]++; break } { counts[$1]++ } END { print seen[\"disk\"], counts[\"ERROR\"], counts[\"WARN\"] }\n",
         "WARN cpu hot\nERROR disk full\nERROR net down\n",
         "1 0 1\n").
 
+test(surface_nonterminal_break_skips_dead_assoc_tail) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { break; seen[$2]++ } { counts[$1]++ } END { print seen[\"disk\"], counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        "WARN cpu hot\nERROR disk full\nERROR net down\n",
+        "0 0 1\n").
+
 test(surface_terminal_break_stops_mixed_rule_chain_and_runs_end) :-
     run_surface_print_smoke("$1 == \"ERROR\" { hits++; seen[$2]++; break } { total++; counts[$1]++ } END { print hits, total, seen[\"disk\"], counts[\"ERROR\"], counts[\"WARN\"] }\n",
         "WARN cpu hot\nERROR disk full\nERROR net down\n",
         "1 1 1 0 1\n").
+
+test(surface_nonterminal_break_skips_dead_mixed_tail) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { break; hits++; seen[$2]++ } { total++; counts[$1]++ } END { print hits, total, seen[\"disk\"], counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        "WARN cpu hot\nERROR disk full\nERROR net down\n",
+        "0 1 0 0 1\n").
 
 test(surface_terminal_break_as_last_rule_keeps_continue_phi_valid) :-
     run_surface_print_smoke("{ total++ } $1 == \"ERROR\" { hits++; break } END { print hits, total }\n",
@@ -728,6 +758,11 @@ test(surface_scalar_if_else_branch_next_skips_later_actions) :-
         "INFO boot ok\nDEBUG trace skip\nERROR disk full\nDEBUG trace drop\n",
         "2 2 2\n").
 
+test(surface_scalar_if_else_branch_next_skips_dead_tail_and_later_actions) :-
+    run_surface_print_smoke("{ if ($1 == \"DEBUG\") { next; skipped++ } else { seen++ }; total++ } END { print total, seen, skipped }\n",
+        "INFO boot ok\nDEBUG trace skip\nERROR disk full\nDEBUG trace drop\n",
+        "2 2 0\n").
+
 test(surface_mixed_if_else_branch_next_skips_later_rules) :-
     run_surface_print_smoke("{ if ($1 == \"DEBUG\") { skipped++; by_kind[$2]++; next } else { seen++ } } { total++; counts[$1]++ } END { print total, seen, skipped, by_kind[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n",
         "INFO boot ok\nDEBUG trace skip\nERROR disk full\nDEBUG trace drop\n",
@@ -737,6 +772,11 @@ test(surface_scalar_if_else_branch_break_stops_stream) :-
     run_surface_print_smoke("{ if ($1 == \"ERROR\") { hits++; break } else { total++ } } END { print hits, total }\n",
         "INFO boot ok\nWARN cpu hot\nERROR disk full\nINFO after break\n",
         "1 2\n").
+
+test(surface_scalar_if_else_branch_break_skips_dead_tail_and_stops_stream) :-
+    run_surface_print_smoke("{ if ($1 == \"ERROR\") { break; hits++ } else { total++ } } END { print hits, total }\n",
+        "INFO boot ok\nWARN cpu hot\nERROR disk full\nINFO after break\n",
+        "0 2\n").
 
 test(surface_mixed_if_else_branch_break_stops_stream) :-
     run_surface_print_smoke("{ if ($1 == \"ERROR\") { hits++; seen[$2]++; break } else { total++; counts[$1]++ } } END { print hits, total, seen[\"disk\"], counts[\"INFO\"], counts[\"WARN\"] }\n",
@@ -1179,21 +1219,42 @@ test(surface_terminal_next_only_uses_native_continue_branch) :-
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
-test(surface_nonterminal_next_scalar_rejected_by_native_codegen, [fail]) :-
+test(surface_nonterminal_next_scalar_uses_native_continue_branch) :-
     plawk_parse_string("$1 == \"DEBUG\" { next; skipped++ } { total++ } END { print total, skipped }\n", Program),
-    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_apply:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '  br label %continue_loop'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'rule_0_slot_1_op_0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
 
-test(surface_nonterminal_next_assoc_rejected_by_native_codegen, [fail]) :-
+test(surface_nonterminal_next_assoc_uses_native_continue_branch) :-
     plawk_parse_string("$1 == \"DEBUG\" { next; skipped[$2]++ } { counts[$1]++ } END { print skipped[\"trace\"], counts[\"ERROR\"] }\n", Program),
-    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_0_apply:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '  br label %continue_loop'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'assoc_rule_0_action_0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
 
-test(surface_nonterminal_next_mixed_rejected_by_native_codegen, [fail]) :-
+test(surface_nonterminal_next_mixed_uses_native_continue_branch) :-
     plawk_parse_string("$1 == \"DEBUG\" { next; skipped++; by_kind[$2]++ } { total++; counts[$1]++ } END { print total, skipped, by_kind[\"trace\"], counts[\"ERROR\"] }\n", Program),
-    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_apply:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '  br label %continue_loop'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'rule_0_slot_1_op_0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'rule_0_assoc_0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
 
-test(surface_branch_nonterminal_next_rejected_by_native_codegen, [fail]) :-
+test(surface_branch_nonterminal_next_uses_native_continue_branch) :-
     plawk_parse_string("{ if ($1 == \"DEBUG\") { next; skipped++ } else { total++ } } END { print total, skipped }\n", Program),
-    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_body_if_0_then:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '  br label %continue_loop'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'then_slot_1_op_0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
 
 test(surface_if_else_branch_break_uses_native_close_path) :-
     plawk_parse_string("{ if ($1 == \"ERROR\") { hits++; break } else { total++ } } END { print hits, total }\n", Program),
@@ -1205,9 +1266,14 @@ test(surface_if_else_branch_break_uses_native_close_path) :-
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
-test(surface_branch_nonterminal_break_rejected_by_native_codegen, [fail]) :-
+test(surface_branch_nonterminal_break_uses_native_close_path) :-
     plawk_parse_string("{ if ($1 == \"ERROR\") { break; hits++ } else { total++ } } END { print hits, total }\n", Program),
-    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_body_if_0_then:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'br label %break_close_stream'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'then_slot_0_op_0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
 
 test(surface_terminal_break_uses_close_path_and_final_state_phi) :-
     plawk_parse_string("$1 == \"ERROR\" { hits++; break } { total++ } END { print hits, total }\n", Program),
@@ -1237,17 +1303,33 @@ test(surface_mixed_terminal_break_uses_close_path_and_final_state_phi) :-
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
-test(surface_nonterminal_break_scalar_rejected_by_native_codegen, [fail]) :-
+test(surface_nonterminal_break_scalar_uses_native_close_path) :-
     plawk_parse_string("$1 == \"ERROR\" { break; hits++ } { total++ } END { print hits, total }\n", Program),
-    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'break_close_stream:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%break_slot_0 = phi i64 [%rule_0_slot_0, %rule_0_done]'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'rule_0_slot_0_op_0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
 
-test(surface_nonterminal_break_assoc_rejected_by_native_codegen, [fail]) :-
+test(surface_nonterminal_break_assoc_uses_native_close_path) :-
     plawk_parse_string("$1 == \"ERROR\" { break; seen[$2]++ } { counts[$1]++ } END { print seen[\"disk\"], counts[\"ERROR\"] }\n", Program),
-    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'break_close_stream:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_0_apply:'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'assoc_rule_0_action_0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
 
-test(surface_nonterminal_break_mixed_rejected_by_native_codegen, [fail]) :-
+test(surface_nonterminal_break_mixed_uses_native_close_path) :-
     plawk_parse_string("$1 == \"ERROR\" { break; hits++; seen[$2]++ } { total++; counts[$1]++ } END { print hits, total, seen[\"disk\"], counts[\"ERROR\"] }\n", Program),
-    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'break_close_stream:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%break_slot_0 = phi i64 [%rule_0_slot_0, %rule_0_done]'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'rule_0_slot_0_op_0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'rule_0_assoc_0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
 
 test(surface_end_string_literals_use_indexed_globals) :-
     plawk_parse_string("{ total++; counts[$1]++ } END { print \"total\", total, \"errors\", counts[\"ERROR\"] }\n", Program),


### PR DESCRIPTION
  ## Description
  Adds native PLAWK support for parser-accepted `next`/`break` forms that have unreachable tail actions after the
  control statement.

  ## Summary
  - Trim unreachable actions after `next`/`break` in rule bodies and branch bodies before native lowering.
  - Reuse the existing native continuation/stream-close paths for these normalized control forms.
  - Convert prior rejection tests into positive native IR coverage.
  - Add compiled smoke tests proving dead tail actions do not update scalar or associative state.
  - Update PLAWK docs to describe the new loop-control behavior.

  ## Verification
  - `tests/test_plawk_surface_prefix_print.pl`: 206 passed
  - PLAWK core/native stream driver smoke suites passed
  - `git diff --check` passed