### PR TITLE
WAM-Rust: 3f — landmark-cached designated-bridge caret (O(1) per pair)

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -596,7 +596,10 @@ caching, the **designated-bridge** measure is cacheable.
 >   `B` a funnel." Two fixes, both O(k): (a) **height-agnosticism** — summarize each node's
 >   *whole* lineage to root once, as a fixed-size **KMV/MinHash ancestor sketch**
 >   `sig(B) = bottom-k( {B} ∪ ⋃_p sig(p) )`, one root→leaf pass; overlap (`sketch_jaccard`) is
->   then read at *any* depth with no knob (error ∝ 1/√k, not a depth cutoff). (b) **baseline
+>   then read at *any* depth with no knob (error ∝ 1/√k, not a depth cutoff). (The sketch is the
+>   bottom-`k`/KMV lineage: MinHash for Jaccard, Broder 1997; the one-pass bottom-`k` Jaccard
+>   estimator, Cohen & Kaplan 2007; the `(k−1)/ĥ_k` distinct-count read, Bar-Yossef et al. 2002 /
+>   Beyer et al. 2007.) (b) **baseline
 >   correction** — a real hub reconverges *more than chance*: against the configuration-model
 >   null `E|A∩B| ≈ |A|·|B|/N`, the signal is `lift = observed |A∩B| / E|A∩B|` (`sketch_overlap_
 >   lift`), `>1` an excess funnel, `≈1` just small-world background. The sketch yields `|A|`,
@@ -709,7 +712,10 @@ category `t`." How *informative* is that? If `t` is the root (every article is u
 learned nothing — it was certain. If `t` is a tiny, specific leaf category, you learned a lot —
 that was surprising. So a node's information is its **rarity**: let `p(t) = |desc(t)| / N` be the
 fraction of all nodes that fall under `t` (its descendant cone over the total). The root has
-`p = 1`; a leaf has `p = 1/N`.
+`p = 1`; a leaf has `p = 1/N`. This descendant-fraction definition is **intrinsic** IC — it reads
+the rarity off the graph structure alone, needing no external corpus of annotation frequencies;
+Seco, Veale & Hayes (2004) introduced it and showed it matches corpus-based IC closely (≈ 0.84 vs
+0.79 correlation with human similarity benchmarks), which is why we use it here.
 
 **Why `−log₂`.** We want "information" to be `0` for the certain thing (`p=1`) and to *grow* as
 things get rarer (`p → 0`), and we want it to *add up* for independent facts. The function with
@@ -748,7 +754,7 @@ is an `O(k)` read, but calling `resnik`/`lin` is *not* `O(k)` — each runs a pe
 upward BFS to find the MICA; cache the ancestor sets for repeated queries on the same graph.)
 
 **FaITH similarity: the Jiang–Conrath-faithful sibling.** Lin isn't the only way to normalize
-Resnik. The *Jiang–Conrath distance* `JC(u,v) = IC(u) + IC(v) − 2·IC(MICA)` measures *how far
+Resnik. The *Jiang–Conrath distance* (Jiang & Conrath 1997) `JC(u,v) = IC(u) + IC(v) − 2·IC(MICA)` measures *how far
 apart* `u` and `v` are: it is the IC you'd have to "spend" climbing from each down to the MICA —
 `0` for identical nodes, large when they meet only high up. **FaITH** (Pirró & Euzenat 2010) turns
 that distance into a bounded similarity, `sim(u,v) = IC(MICA) / (IC(u) + IC(v) − IC(MICA))`, which
@@ -1022,3 +1028,53 @@ buy diminishing returns and is not carried).
 - `WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md` — phase status of shipped work.
 - This note — the algebraic generalization (product semirings, ancestor-space domain,
   the implicit-functional / kernel-trick framing) that the next increments build on.
+
+## 10. References
+
+Collected for understanding the theory and as a citation base for possible future write-up.
+Each is referenced inline at the section that uses it.
+
+**Information-content semantic similarity (§5d, §5e).**
+- Resnik, P. (1995). *Using Information Content to Evaluate Semantic Similarity in a Taxonomy.*
+  IJCAI-95. — `resnik_similarity = IC(MICA)`.
+- Lin, D. (1998). *An Information-Theoretic Definition of Similarity.* ICML 1998. —
+  `lin_similarity = 2·IC(MICA)/(IC(u)+IC(v))`.
+- Jiang, J. J., & Conrath, D. W. (1997). *Semantic Similarity Based on Corpus Statistics and
+  Lexical Taxonomy.* ROCLING X (also arXiv cmp-lg/9709008). — the JC distance `IC(u)+IC(v)−2·IC(MICA)`.
+- Seco, N., Veale, T., & Hayes, J. (2004). *An Intrinsic Information Content Metric for Semantic
+  Similarity in WordNet.* ECAI 2004. — the **intrinsic** (descendant-count) IC we use, `IC(t) =
+  −log₂(|desc(t)|/N)`, ≈0.84 vs 0.79 human-benchmark correlation against corpus IC.
+- Pirró, G., & Euzenat, J. (2010). *A Feature and Information Theoretic Framework for Semantic
+  Similarity and Relatedness.* ISWC 2010. — the **FaITH** measure `IC(MICA)/(IC(u)+IC(v)−IC(MICA))`.
+
+**MinHash / KMV sketches and distinct-count estimation (rung 4, §5d; descendant sketch, §5e).**
+- Broder, A. Z. (1997). *On the Resemblance and Containment of Documents.* SEQUENCES 1997. —
+  MinHash for Jaccard.
+- Bar-Yossef, Z., Jayram, T. S., Kumar, R., Sivakumar, D., & Trevisan, L. (2002). *Counting
+  Distinct Elements in a Data Stream.* RANDOM 2002. — k-minimum-values (KMV) distinct-count.
+- Beyer, K., Haas, P. J., Reinwald, B., Sismanis, Y., & Gemulla, R. (2007). *On Synopses for
+  Distinct-Value Estimation Under Multiset Operations.* SIGMOD 2007. — the bottom-`k` / KMV
+  `(k−1)/ĥ_k` cardinality estimator (`sketch_card`).
+- Cohen, E., & Kaplan, H. (2007). *Summarizing Data Using Bottom-k Sketches.* PODC 2007. — the
+  one-pass bottom-`k` Jaccard estimator (`sketch_jaccard`).
+
+**2-hop cover / hub labeling and landmark distance (§5c, roadmap 3f).**
+- Cohen, E., Halperin, E., Kaplan, H., & Zwick, U. (2002/2003). *Reachability and Distance
+  Queries via 2-Hop Labels.* SODA 2002 / SIAM J. Comput. 2003. — the 2-hop label framework that
+  `bridge_distance_fields` instantiates.
+- Abraham, I., Delling, D., Goldberg, A. V., & Werneck, R. F. (2012). *Hierarchical Hub Labelings
+  for Shortest Paths.* ESA 2012.
+- Akiba, T., Iwata, Y., & Yoshida, Y. (2013). *Fast Exact Shortest-Path Distance Queries on Large
+  Networks by Pruned Landmark Labeling.* SIGMOD 2013.
+- Tretyakov, K., Armas-Cervantes, A., García-Bañuelos, L., Vilo, J., & Dumas, M. (2011). *Fast
+  Fully Dynamic Landmark-based Estimation of Shortest Path Distances in Very Large Graphs.* CIKM
+  2011. — the `O(K·V)` space-tightness for O(1)-lookup landmarks.
+- Storandt, S. (2022). *Algorithms for Landmark Hub Labeling.* ISAAC 2022. — `min_B(d(u→B)+d(v→B))`
+  as a valid upper bound, exact iff an optimal meeting node is a landmark.
+
+**Distribution reconstruction (§7).**
+- Lindeberg, J. W. (1922). *Eine neue Herleitung des Exponentialgesetzes in der
+  Wahrscheinlichkeitsrechnung.* Math. Z. 15. — the CLT condition for the moment-jet → Gaussian rung.
+- Blinnikov, S., & Moessner, R. (1998). *Expansions for Nearly Gaussian Distributions.* A&A
+  Suppl. Ser. 130. — practical Gram–Charlier / Edgeworth series (the `MomentNormal` → `GramCharlier`
+  reconstruction rungs).

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -971,10 +971,18 @@ buy diminishing returns and is not carried).
      the root-anchored region (`build_scoped_subtree_lmdb.py`), propagate the support
      interval, and compute multi-level budgeted carets between topics — the end-to-end
      composition on real (cyclic) data, where the 2a/2b cycle-correctness earns its keep.
-   - **[3f, buildable]** the **landmark-cached designated-bridge caret** (§5c): precompute
-     `d(·→B)` (one downward field) for each designated level `B`, so `caret_through_bridge`
-     is O(1) per pair — the boundary-cache reuse applied to the caret. `O(K·V)` for `K`
-     levels.
+   - **[3f DONE]** the **landmark-cached designated-bridge caret** (§5c): `bridge_distance_fields`
+     precomputes `d(·→B)` (one downward BFS per bridge over the shared children graph, `O(E +
+     Σ_B|desc(B)|) ≤ O(K·V)`), and `caret_through_bridge_cached` / `caret_min_over_cached_bridges`
+     then answer in **O(1)** / **O(#bridges)** per pair — the boundary-cache reuse applied to the
+     caret. Wired into the live path: `WamState::build_caret_landmarks`,
+     `category_caret_through_bridge`, `category_caret_min_over_landmarks`. This is the missing
+     amortization that makes hub *selection* (§5c rungs) pay off: pick the convergence hubs as
+     bridges, cache their fields once, and `caret_min_over_hubs` becomes O(#hubs) lookups instead
+     of a BFS per hub. The cached field is the **min-plus distance functional** read off a compact
+     precompute — never forming the path-length distribution between the pair, the §8 "carry the
+     functional, not the distribution" theme again. Validated by
+     `bridge_landmarks_cached_caret_matches_per_query` and `live_bridge_landmarks_match_library`.
    - **[deferred]** the **nested-cut** hierarchy (§5c) — cache the suffix above each cut and
      compose by convolution; worth it only for *deep* hierarchies, and needs the
      dominator/cut property maintained on a DAG. And **[3c, optional]** a between-nodes

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -491,6 +491,26 @@ caching, the **designated-bridge** measure is cacheable.
   multi-level bridges **are** the landmarks, and there are only a few. This is the
   boundary-cache *reuse*, finally applied to the caret — and the *computational* reason
   (beyond §5b's informational one) to prefer the designated bridge: it is the cacheable one.
+
+> **Theory grounding (3f, now built).** The designated-bridge landmark scheme is a
+> semantically-scoped instance of **2-hop cover / hub labeling** (Cohen, Halperin, Kaplan &
+> Zwick 2002; Abraham, Delling, Goldberg & Werneck 2012; *pruned landmark labeling*, Akiba,
+> Iwata & Yoshida 2013). Each bridge's field `d(·→B)` is one **column of the all-pairs distance
+> matrix in the min-plus (tropical) semiring** `(min, +)`, and the caret read
+> `min_B (d(u→B) + d(v→B))` is a **min-plus inner product** of `u`'s and `v`'s label rows — the
+> tropical analogue of `Σ_B x_u[B]·x_v[B]`. So "carry the functional, not the distribution" is
+> here *literally* the tropical-algebra strategy: the cached label is a min-plus vector, the
+> query a min-plus dot product, and no path-length distribution between the pair is ever formed.
+> The `O(K·V)` storage is **tight** for an O(1)-lookup landmark scheme (Tretyakov et al. 2011):
+> no asymptotically smaller compact representation supports constant-time distance reads. And
+> the read is the true LCA caret **only if the optimal common ancestor is one of the chosen
+> bridges**; with a sparser set it is a valid **upper bound**, larger by `2·d(LCA→nearest
+> bridge)` (§5b) — the standard landmark-distance over-estimate (Storandt 2022). The field
+> construction is the **reversed-BFS** identity: child edges are the exact reversal of parent
+> edges, so `src→B` up-paths and `B→src` down-paths are in length-preserving bijection and their
+> minima coincide (the Contraction-Hierarchies / bidirectional-search argument; holds on any
+> directed graph, diamonds included). (`bridge_distance_fields`, `caret_through_bridge_cached`,
+> `caret_min_over_cached_bridges`; live `build_caret_landmarks`.)
 - **Nested cuts (the convolution refinement).** A bridge is a **cut**, and distributions
   *factor* there: `H_{u→root} = H_{u→B} ⊛ H_{B→root}` (counting) / `d(u→root) = d(u→B) +
   d(B→root)` (min-plus). So one can cache the **suffix above** `B` and treat `B` as a *fresh
@@ -981,7 +1001,12 @@ buy diminishing returns and is not carried).
      bridges, cache their fields once, and `caret_min_over_hubs` becomes O(#hubs) lookups instead
      of a BFS per hub. The cached field is the **min-plus distance functional** read off a compact
      precompute — never forming the path-length distribution between the pair, the §8 "carry the
-     functional, not the distribution" theme again. Validated by
+     functional, not the distribution" theme again (formally a min-plus inner product over a
+     2-hop-cover / hub-labeling structure — see the §5c theory-grounding note for the literature
+     and the `O(K·V)` space-tightness result). The cached read **equals** the per-query
+     `caret_min_over_hubs`, but note *that* is the true LCA caret only when an optimal common
+     ancestor is among the bridges; with a sparser bridge set both are a valid **upper bound**
+     (gap `2·d(LCA→nearest bridge)`, §5c). Validated by
      `bridge_landmarks_cached_caret_matches_per_query` and `live_bridge_landmarks_match_library`.
    - **[deferred]** the **nested-cut** hierarchy (§5c) — cache the suffix above each cut and
      compose by convolution; worth it only for *deep* hierarchies, and needs the

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -883,17 +883,24 @@ pub fn caret_min_over_hubs(
 /// **Landmark distance fields for designated bridges** (roadmap 3f): for each bridge `B`,
 /// precompute `d(·→B)` — the up-distance from every descendant of `B` to `B` — as one downward
 /// BFS from `B` over the *children* graph (the reverse of `parents`). The children map is built
-/// **once** and shared across all bridges, so the whole precompute is `O(E + Σ_B |desc(B)|)`,
-/// at most `O(K·V)` for `K` bridges. With these fields cached, `caret_through_bridge` collapses
-/// from a per-query BFS to an **O(1)** table lookup (`caret_through_bridge_cached`) — the
-/// "designated bridges are landmarks" amortization (§5c): pay the field once, reuse it across
-/// every pair. (`d(src→B)` over parent edges equals the reverse BFS depth `B→src` over child
-/// edges, since reversing a shortest up-path gives an equal-length down-path.)
+/// **once** and shared across all bridges, so the precompute is
+/// `O(E + Σ_B(|desc(B)| + edges_within_desc(B))) ≤ O(K·(V+E))` time for `K` bridges, and
+/// `O(Σ_B|desc(B)|) ≤ O(K·V)` **memory** (tight for an O(1)-lookup landmark scheme). With these
+/// fields cached, `caret_through_bridge` collapses from a per-query BFS to an **O(1)** table
+/// lookup (`caret_through_bridge_cached`) — the "designated bridges are landmarks" amortization
+/// (§5c): pay the field once, reuse it across every pair. (`d(src→B)` over parent edges equals
+/// the reverse BFS depth `B→src` over child edges: child edges are the exact reversal of parent
+/// edges, so upward and downward paths are in length-preserving bijection and their minima
+/// coincide — the standard reversed-BFS argument, valid on any directed graph, diamonds
+/// included.) **Duplicate bridges** in the slice are de-duplicated (a repeated `B` would
+/// otherwise re-run its BFS, idempotent but wasteful). A **pure-leaf bridge** (no descendants)
+/// yields the field `{B: 0}`, so cached queries for any pair other than `(B,B)` correctly return
+/// `None`.
 pub fn bridge_distance_fields(
     bridges: &[u32],
     parents: &std::collections::HashMap<u32, Vec<u32>>,
 ) -> std::collections::HashMap<u32, std::collections::HashMap<u32, u32>> {
-    use std::collections::{HashMap, VecDeque};
+    use std::collections::{HashMap, HashSet, VecDeque};
     let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
     for (&c, ps) in parents {
         for &p in ps {
@@ -901,7 +908,9 @@ pub fn bridge_distance_fields(
         }
     }
     let mut fields: HashMap<u32, HashMap<u32, u32>> = HashMap::new();
+    let mut done: HashSet<u32> = HashSet::new();
     for &b in bridges {
+        if !done.insert(b) { continue; } // de-duplicate: skip a bridge already fielded
         let mut d: HashMap<u32, u32> = HashMap::new();
         let mut q: VecDeque<u32> = VecDeque::new();
         d.insert(b, 0);
@@ -931,6 +940,8 @@ pub fn caret_through_bridge_cached(
     v: u32,
     field: &std::collections::HashMap<u32, u32>,
 ) -> Option<u32> {
+    // Each depth is ≤ V−1, so the sum ≤ 2(V−1) < u32::MAX for any in-memory HashMap<u32,…> graph
+    // (consistent with up_distance_to's unchecked `dx + 1`).
     Some(field.get(&u)? + field.get(&v)?)
 }
 
@@ -938,6 +949,13 @@ pub fn caret_through_bridge_cached(
 /// designated bridges whose fields are precomputed (`bridge_distance_fields`). With the fields
 /// built for exactly the same bridge set, this equals `caret_min_over_hubs` — but at O(#bridges)
 /// table lookups per pair instead of a BFS per bridge.
+///
+/// It minimises over **every** field present in `fields`, not over a separate bridge list — the
+/// caller keeps `fields` in sync with the intended bridge set, and must `bridge_distance_fields`
+/// again if the graph or hub set changes. Like `caret_min_over_hubs` this is the LCA caret only
+/// when the optimal common ancestor is among the bridges; with a sparser set it is a valid
+/// **upper bound**, larger by `2·d(LCA→nearest bridge)` (§5b/§5c). `None` if no bridge is a
+/// common ancestor of both nodes.
 pub fn caret_min_over_cached_bridges(
     u: u32,
     v: u32,
@@ -3237,6 +3255,22 @@ mod tests {
                            "min over cached bridges ({},{})", u, v);
             }
         }
+
+        // No-common-bridge -> None: with bridges {2,3} only, the cross-branch pair (4,6) has
+        // no bridge that is a common ancestor (4 reaches 2 not 3; 6 reaches 3 not 2).
+        let low = bridge_distance_fields(&[2, 3], &t);
+        assert_eq!(caret_min_over_cached_bridges(4, 6, &low), None);
+        assert_eq!(caret_min_over_cached_bridges(4, 6, &low),
+                   caret_min_over_hubs(4, 6, &[2, 3], &t)); // parity on the None case too
+
+        // Pure-leaf bridge: a leaf (4) has no descendants, so its field is just {4: 0}.
+        let leaf = bridge_distance_fields(&[4], &t);
+        assert_eq!(leaf[&4].len(), 1);
+        assert_eq!(caret_through_bridge_cached(4, 4, &leaf[&4]), Some(0));
+        assert_eq!(caret_through_bridge_cached(5, 4, &leaf[&4]), None);
+
+        // Duplicate bridges are de-duplicated (same fields as the unique set).
+        assert_eq!(bridge_distance_fields(&[2, 2, 3], &t), bridge_distance_fields(&[2, 3], &t));
     }
 
     // Downward convergence (fan-in) hub selection + the quantized-LCA min-over-hubs caret.

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -880,6 +880,72 @@ pub fn caret_min_over_hubs(
         .min()
 }
 
+/// **Landmark distance fields for designated bridges** (roadmap 3f): for each bridge `B`,
+/// precompute `d(·→B)` — the up-distance from every descendant of `B` to `B` — as one downward
+/// BFS from `B` over the *children* graph (the reverse of `parents`). The children map is built
+/// **once** and shared across all bridges, so the whole precompute is `O(E + Σ_B |desc(B)|)`,
+/// at most `O(K·V)` for `K` bridges. With these fields cached, `caret_through_bridge` collapses
+/// from a per-query BFS to an **O(1)** table lookup (`caret_through_bridge_cached`) — the
+/// "designated bridges are landmarks" amortization (§5c): pay the field once, reuse it across
+/// every pair. (`d(src→B)` over parent edges equals the reverse BFS depth `B→src` over child
+/// edges, since reversing a shortest up-path gives an equal-length down-path.)
+pub fn bridge_distance_fields(
+    bridges: &[u32],
+    parents: &std::collections::HashMap<u32, Vec<u32>>,
+) -> std::collections::HashMap<u32, std::collections::HashMap<u32, u32>> {
+    use std::collections::{HashMap, VecDeque};
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    for (&c, ps) in parents {
+        for &p in ps {
+            children.entry(p).or_default().push(c);
+        }
+    }
+    let mut fields: HashMap<u32, HashMap<u32, u32>> = HashMap::new();
+    for &b in bridges {
+        let mut d: HashMap<u32, u32> = HashMap::new();
+        let mut q: VecDeque<u32> = VecDeque::new();
+        d.insert(b, 0);
+        q.push_back(b);
+        while let Some(x) = q.pop_front() {
+            let dx = d[&x];
+            if let Some(cs) = children.get(&x) {
+                for &c in cs {
+                    if !d.contains_key(&c) {
+                        d.insert(c, dx + 1);
+                        q.push_back(c);
+                    }
+                }
+            }
+        }
+        fields.insert(b, d);
+    }
+    fields
+}
+
+/// O(1) caret through a designated bridge using its precomputed `bridge_distance_fields` field
+/// `d(·→B)`: `field[u] + field[v]`. Equals `caret_through_bridge(u, v, B, parents)` exactly,
+/// and is `None` on the same condition (either node is not a descendant of `B`, so absent from
+/// the field).
+pub fn caret_through_bridge_cached(
+    u: u32,
+    v: u32,
+    field: &std::collections::HashMap<u32, u32>,
+) -> Option<u32> {
+    Some(field.get(&u)? + field.get(&v)?)
+}
+
+/// The cached counterpart of `caret_min_over_hubs`: minimise the O(1) cached caret over a set of
+/// designated bridges whose fields are precomputed (`bridge_distance_fields`). With the fields
+/// built for exactly the same bridge set, this equals `caret_min_over_hubs` — but at O(#bridges)
+/// table lookups per pair instead of a BFS per bridge.
+pub fn caret_min_over_cached_bridges(
+    u: u32,
+    v: u32,
+    fields: &std::collections::HashMap<u32, std::collections::HashMap<u32, u32>>,
+) -> Option<u32> {
+    fields.values().filter_map(|f| caret_through_bridge_cached(u, v, f)).min()
+}
+
 /// **Additive descendant weight** — the cheap, magnitude-aware cone-size proxy.
 ///
 /// A hub is where the descendant cone *steps*: large at `B`, but each child just below carries
@@ -3135,6 +3201,42 @@ mod tests {
         // through(1) keeps the shared-physics-level signal that the LCA caret also gives
         // here (their LCA *is* 1), so they agree — the gap is 0 only when bridge == LCA.
         assert_eq!(caret_through_bridge(4, 6, 1, &t), caret_distance_lca(4, 6, &t));
+    }
+
+    // Roadmap 3f: the landmark-cached designated-bridge caret equals the per-query
+    // caret_through_bridge everywhere, at O(1) per pair after one precompute per bridge.
+    #[test]
+    fn bridge_landmarks_cached_caret_matches_per_query() {
+        // Same tree as above plus a cross-listing so some pairs route through several bridges.
+        let mut t: HashMap<u32, Vec<u32>> = HashMap::new();
+        t.insert(1, vec![0]); t.insert(2, vec![1]); t.insert(3, vec![1]);
+        t.insert(4, vec![2]); t.insert(5, vec![2]); t.insert(6, vec![3]);
+        t.insert(7, vec![2, 3]); // cross-listed under both 2 and 3
+        let nodes: Vec<u32> = (0u32..=7).collect();
+        let bridges: Vec<u32> = vec![0, 1, 2, 3];
+        let fields = bridge_distance_fields(&bridges, &t);
+
+        // Field correctness: d(src->B) via the cached field == the per-query up_distance_to.
+        for &b in &bridges {
+            for &s in &nodes {
+                assert_eq!(fields[&b].get(&s).copied(), up_distance_to(s, b, &t),
+                    "field d({}->{})", s, b);
+            }
+        }
+        // Cached caret == per-query caret_through_bridge for every (pair, bridge).
+        for &u in &nodes {
+            for &v in &nodes {
+                for &b in &bridges {
+                    assert_eq!(caret_through_bridge_cached(u, v, &fields[&b]),
+                               caret_through_bridge(u, v, b, &t),
+                               "cached caret through {} for ({},{})", b, u, v);
+                }
+                // min over cached bridges == caret_min_over_hubs over the same set.
+                assert_eq!(caret_min_over_cached_bridges(u, v, &fields),
+                           caret_min_over_hubs(u, v, &bridges, &t),
+                           "min over cached bridges ({},{})", u, v);
+            }
+        }
     }
 
     // Downward convergence (fan-in) hub selection + the quantized-LCA min-over-hubs caret.

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -538,6 +538,12 @@ pub struct WamState {
     pub desc_sketch: std::collections::HashMap<u32, Vec<u64>>,
     pub desc_sketch_n: usize,
     pub desc_sketch_k: usize,
+    /// Designated-bridge landmark fields (roadmap 3f): bridge `B` -> `d(·→B)`, the up-distance
+    /// from every descendant of `B` to `B`. Built once by `build_caret_landmarks`; the
+    /// `category_caret_through_bridge` / `category_caret_min_over_landmarks` read-outs then
+    /// answer the designated-bridge caret in O(1) per pair instead of a per-query BFS. Empty =
+    /// landmark caret off (default). Eager-edge only.
+    pub caret_landmarks: std::collections::HashMap<u32, std::collections::HashMap<u32, u32>>,
     /// Int-native edge mode: when true, the lazy edge path treats the kernel's
     /// u32 node id AS the raw LMDB int key directly (identity), bypassing
     /// `wam_to_lmdb`/`lmdb_to_wam`. Used for int-native fixtures whose seeds,
@@ -676,6 +682,7 @@ impl WamState {
             desc_sketch: std::collections::HashMap::new(),
             desc_sketch_n: 0,
             desc_sketch_k: 0,
+            caret_landmarks: std::collections::HashMap::new(),
             bindings: HashMap::new(),
             var_counter: 0,
             cut_barrier: 0,
@@ -1449,6 +1456,41 @@ impl WamState {
         let parents = self.ffi_facts.get(edge_pred)?;
         crate::boundary_cache::faith_similarity(
             u, v, parents, &self.desc_sketch, self.desc_sketch_n, self.desc_sketch_k)
+    }
+
+    /// Precompute the **designated-bridge landmark fields** (roadmap 3f): one downward
+    /// distance field `d(·→B)` per bridge in `bridges`, over the eager `edge_pred` graph
+    /// (`bridge_distance_fields`). A harness calls this once at setup after picking the
+    /// designated bridges (e.g. the convergence hubs of §5c); `category_caret_through_bridge`
+    /// and `category_caret_min_over_landmarks` then answer in O(1) / O(#bridges) per pair.
+    /// Returns `false` (no-op) if `edge_pred` has no eager facts. Eager-edge only.
+    pub fn build_caret_landmarks(&mut self, bridges: &[u32], edge_pred: &str) -> bool {
+        let fields = {
+            let parents = match self.ffi_facts.get(edge_pred) {
+                Some(p) => p,
+                None => return false,
+            };
+            crate::boundary_cache::bridge_distance_fields(bridges, parents)
+        };
+        self.caret_landmarks = fields;
+        true
+    }
+
+    /// O(1) designated-bridge caret `d(u→B) + d(v→B)` via the cached landmark field for `B`
+    /// (`build_caret_landmarks`). `None` if `B` is not a cached landmark, or either node is not
+    /// a descendant of `B`. Equals `category_caret_distance` *through that fixed bridge* — the
+    /// cache-backed entry point for `boundary_cache::caret_through_bridge`.
+    pub fn category_caret_through_bridge(&self, u: u32, v: u32, bridge: u32) -> Option<u32> {
+        let field = self.caret_landmarks.get(&bridge)?;
+        crate::boundary_cache::caret_through_bridge_cached(u, v, field)
+    }
+
+    /// The **quantized-LCA caret over the cached landmarks**: the minimum cached
+    /// designated-bridge caret over all landmarks (`build_caret_landmarks`). With the landmarks
+    /// chosen as the convergence hubs, this is `caret_min_over_hubs` realized at O(#landmarks)
+    /// table lookups per pair (no per-query BFS). `None` if no landmark bridges both nodes.
+    pub fn category_caret_min_over_landmarks(&self, u: u32, v: u32) -> Option<u32> {
+        crate::boundary_cache::caret_min_over_cached_bridges(u, v, &self.caret_landmarks)
     }
 
     /// Directed shortest `u → target` hop-distance (following parent edges, so `target`
@@ -3059,6 +3101,41 @@ mod boundary_kernel_tests {
         }
         // Unknown edge predicate -> None.
         assert_eq!(vm.category_resnik(z, w, "no_such_pred"), None);
+    }
+
+    // Roadmap 3f: the live landmark-cached designated-bridge caret equals the per-query
+    // boundary_cache caret_through_bridge / caret_min_over_hubs, at O(1) per pair after build.
+    #[test]
+    fn live_bridge_landmarks_match_library() {
+        let mut vm = WamState::new(vec![], HashMap::new());
+        // tree with a cross-listing: 1->0; 2,3->1; 4,5->2; 6->3; 7->[2,3].
+        vm.register_ffi_fact_pairs("category_parent", &[
+            ("1", "0"), ("2", "1"), ("3", "1"), ("4", "2"), ("5", "2"),
+            ("6", "3"), ("7", "2"), ("7", "3"),
+        ]);
+        let parents = vm.ffi_facts.get("category_parent").unwrap().clone();
+        // intern node names + bridges before resolving anything else.
+        let id = |vm: &mut WamState, s: &str| vm.intern_atom(s);
+        let bridges: Vec<u32> = ["0", "1", "2", "3"].iter().map(|s| id(&mut vm, s)).collect();
+        // unbuilt -> None.
+        let (a, b) = (id(&mut vm, "4"), id(&mut vm, "5"));
+        assert_eq!(vm.category_caret_through_bridge(a, b, bridges[2]), None);
+
+        assert!(vm.build_caret_landmarks(&bridges, "category_parent"));
+        let names = ["0", "1", "2", "3", "4", "5", "6", "7"];
+        let ids: Vec<u32> = names.iter().map(|s| id(&mut vm, s)).collect();
+        for &u in &ids {
+            for &v in &ids {
+                for &br in &bridges {
+                    assert_eq!(vm.category_caret_through_bridge(u, v, br),
+                        crate::boundary_cache::caret_through_bridge(u, v, br, &parents),
+                        "cached through {} for ({},{})", br, u, v);
+                }
+                assert_eq!(vm.category_caret_min_over_landmarks(u, v),
+                    crate::boundary_cache::caret_min_over_hubs(u, v, &bridges, &parents),
+                    "min over landmarks ({},{})", u, v);
+            }
+        }
     }
 
     // Increment 3b — the A* ancestor search returns the directed shortest u->ancestor

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -3120,6 +3120,8 @@ mod boundary_kernel_tests {
         // unbuilt -> None.
         let (a, b) = (id(&mut vm, "4"), id(&mut vm, "5"));
         assert_eq!(vm.category_caret_through_bridge(a, b, bridges[2]), None);
+        // unknown edge predicate -> false no-op.
+        assert!(!vm.build_caret_landmarks(&bridges, "no_such_pred"));
 
         assert!(vm.build_caret_landmarks(&bridges, "category_parent"));
         let names = ["0", "1", "2", "3", "4", "5", "6", "7"];


### PR DESCRIPTION
## What & why

Closes roadmap **3f** and supplies the amortization that makes all the hub-selection work
actually pay off. Until now, `caret_min_over_hubs` recomputed `up_distance_to` (a BFS) per pair
per hub — so the "designated bridges are landmarks" reuse §5c describes wasn't realized. 3f
precomputes each bridge's distance field once, turning the designated-bridge caret into an O(1)
table lookup.

## Library (`boundary_cache`)

- **`bridge_distance_fields(bridges, parents)`** — one downward BFS per bridge over a **shared**
  children graph (built once), giving `d(·→B)` for every descendant of `B`. `O(E + Σ_B|desc(B)|)
  ≤ O(K·V)`. (`d(src→B)` over parent edges equals the reverse BFS depth `B→src` over child edges —
  reversing a shortest up-path gives an equal-length down-path.)
- **`caret_through_bridge_cached(u, v, field)`** — O(1) caret `field[u]+field[v]`; equals
  `caret_through_bridge` exactly, `None` on the same condition.
- **`caret_min_over_cached_bridges(u, v, fields)`** — the cached counterpart of
  `caret_min_over_hubs`: O(#bridges) lookups per pair instead of a BFS per bridge.

## Live (`WamState`)

`caret_landmarks` field + `build_caret_landmarks(bridges, edge_pred)` /
`category_caret_through_bridge` / `category_caret_min_over_landmarks`. Eager-edge only, `None`
until built.

## The pipeline this completes

**Pick** convergence hubs (the fan-in / jump / lift / reconvergence rungs) → **cache** their
distance fields once (this PR) → **answer** `caret_min_over_hubs` as O(#hubs) table lookups. The
cached field is the **min-plus distance functional** read off a compact precompute — the caret
answer never forms the pair's path-length distribution (the §8 "carry the functional, not the
distribution" theme).

## Tests

- `bridge_landmarks_cached_caret_matches_per_query` — field `== up_distance_to`; cached caret `==
  caret_through_bridge`; min `== caret_min_over_hubs`, across **all** pairs and bridges on a
  cross-listed tree.
- `live_bridge_landmarks_match_library` — parity through `WamState`; unbuilt `→ None`.

Full suite: **78 passed, 0 failed.** Roadmap 3f marked DONE in
`docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_