### PR TITLE
Support basic PLAWK printf actions

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -270,6 +270,10 @@ through the shared primary emitter followed by a shared binary `i64` operation.
 Print-only `tolower($N)` and `toupper($N)` lower through shared
 `@wam_print_ascii_lower_slice` and `@wam_print_ascii_upper_slice` helpers, so
 case mapping streams bytes without allocating a transformed atom.
+Basic rule-local `printf` actions now lower to native vararg `@printf` calls.
+The supported format subset is `%%`, `%s`, `%d`, `%i`, and `%ld`; field-slice
+`%s` arguments are rewritten to `%.*s` and passed as allocation-free length and
+pointer pairs.
 Numeric field guards such as `$3 > 100` lower through the shared
 `@wam_atom_field_i64_cmp_value` helper, which parses the projected field slice
 as a strict signed decimal `i64` and compares with numeric op codes.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -89,6 +89,12 @@ The first arithmetic composition forms add or subtract a non-negative integer
 constant from native `i64` primaries such as `NR`, `NF`, `length($N)`,
 `int($N)`, and `index($N, "literal")`, e.g.
 `$1 == "ERROR" { print NR - 1, int($3) + 1, index($2, "sk") + 1 }`.
+Rule actions can also use basic `printf` forms, e.g.
+`$1 == "ERROR" { printf "%s=%s\n", $2, $3 }`. `printf` does not add `OFS` or
+an implicit newline; supported native formats are `%%`, `%s` for strings and
+field slices, and `%d`/`%i`/`%ld` for native `i64` values. Field slices are
+lowered allocation-free by rewriting `%s` to `%.*s` and passing the slice length
+and pointer to the native vararg call.
 Numeric field guards use the shared WAM/LLVM `i64` comparison helper, so forms
 such as `$3 > 100 { print $1, $3 }` and `$2 <= -5 { cold++ }` stay in the native
 streaming loop.

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -133,6 +133,12 @@ and an `END` action:
 $1 == "ERROR" { count++ } END { print count }
 ```
 
+It can also compile basic rule-local `printf` actions:
+
+```awk
+$1 == "ERROR" { printf "%s=%s\n", $2, $3 }
+```
+
 It can also compile multiple scalar increments in one action list:
 
 ```awk
@@ -439,6 +445,9 @@ net,down
 
 The native output path writes the single-byte separator directly, so separators
 such as `%` are treated as data rather than `printf` format strings.
+Use `printf` when the rule action should control formatting directly; supported
+native specifiers are `%%`, `%s`, `%d`, `%i`, and `%ld`, with field-slice `%s`
+lowered as `%.*s`.
 This path keeps the streaming loop native while the WAM runtime supplies the
 reader, atom helpers, and reusable associative table primitive.
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -41,6 +41,7 @@
 %      BEGIN { print "kind", "count" } { total++ } END { print "total", total }
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
+%      $1 == "ERROR" { printf "%s=%s\n", $2, $3 }
 %      $3 > 100 { big++ } END { print big }
 %      $1 == "ERROR" { print $3, int($3) }
 %      $1 == "ERROR" { print int($3) + 1 }
@@ -61,17 +62,19 @@
 %  function emits the target-specific native main that streams the file, lowers
 %  the deterministic guard, and prints matching records.
 plawk_program_native_driver_ir(
-    program(BeginClauses, [rule(Pattern, [print(Fields)])], []),
+    program(BeginClauses, [rule(Pattern, [Action])], []),
     InputPath,
     DriverIR
 ) :-
+    plawk_rule_body_print_action(Action),
+    plawk_output_action_exprs(Action, Exprs),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_field_separator(BeginClauses, FieldSeparator),
     plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardGlobalIR-GuardCallIR),
-    plawk_print_record_counter_ir(Fields, LoopPhiIR, RecordCounterIR),
-    plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, PrintGlobalIR-PrintActionIR),
+    plawk_print_record_counter_ir(Exprs, LoopPhiIR, RecordCounterIR),
+    plawk_output_action_ir(Action, FieldSeparator, OutputSeparator, PrintGlobalIR-PrintActionIR),
     format(atom(RecordIR),
 '~w
 ~w
@@ -513,6 +516,8 @@ plawk_actions_body_print_field(Actions, Field) :-
 
 plawk_action_body_print_field(print(Fields), Field) :-
     member(Field, Fields).
+plawk_action_body_print_field(printf(string(_Format), Args), Field) :-
+    member(Field, Args).
 plawk_action_body_print_field(if(_Pattern, ThenActions, ElseActions), Field) :-
     (   plawk_actions_body_print_field(ThenActions, Field)
     ;   plawk_actions_body_print_field(ElseActions, Field)
@@ -1359,6 +1364,9 @@ plawk_scalar_rule_body_plain_action(Action) :-
 plawk_rule_body_print_action(print(Fields)) :-
     Fields = [_ | _],
     maplist(plawk_rule_body_print_field, Fields).
+plawk_rule_body_print_action(printf(string(Format), Args)) :-
+    string(Format),
+    maplist(plawk_rule_body_print_field, Args).
 
 plawk_rule_body_print_field(field(_)).
 plawk_rule_body_print_field(string(_)).
@@ -1482,6 +1490,17 @@ plawk_scalar_action_sequence_pairs([print(Fields) | Rest], Slots, AssocPlan, Fie
     { plawk_rule_body_print_action(print(Fields)),
       format(atom(PrintPrefix), '~w_print_~w', [Prefix, OpIndex]),
       plawk_prefixed_print_action_ir(Fields, FieldSeparator, OutputSeparator, PrintPrefix, Pair),
+      NextOpIndex is OpIndex + 1
+    },
+    [Pair],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits).
+plawk_scalar_action_sequence_pairs([printf(string(Format), Args) | Rest],
+        Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { plawk_rule_body_print_action(printf(string(Format), Args)),
+      format(atom(PrintPrefix), '~w_printf_~w', [Prefix, OpIndex]),
+      plawk_prefixed_printf_action_ir(Format, Args, FieldSeparator, PrintPrefix, Pair),
       NextOpIndex is OpIndex + 1
     },
     [Pair],
@@ -1926,6 +1945,14 @@ plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, GlobalIR-IR) :-
     plawk_join_nonempty_ir(GlobalParts, GlobalIR),
     atomic_list_concat(BodyParts, '\n', IR).
 
+plawk_output_action_exprs(print(Fields), Fields).
+plawk_output_action_exprs(printf(string(_Format), Args), Args).
+
+plawk_output_action_ir(print(Fields), FieldSeparator, OutputSeparator, Pair) :-
+    plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, Pair).
+plawk_output_action_ir(printf(string(Format), Args), FieldSeparator, _OutputSeparator, Pair) :-
+    plawk_prefixed_printf_action_ir(Format, Args, FieldSeparator, plawk_printf, Pair).
+
 plawk_prefixed_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, Prefix, ''-IR) :-
     !,
     format(atom(FmtVar), '~w_line_fmt', [Prefix]),
@@ -1938,6 +1965,99 @@ plawk_prefixed_print_action_ir(Fields, FieldSeparator, OutputSeparator, Prefix, 
     plawk_print_ir_parts(Pairs, GlobalParts, BodyParts),
     plawk_join_nonempty_ir(GlobalParts, GlobalIR),
     atomic_list_concat(BodyParts, '\n', IR).
+
+plawk_prefixed_printf_action_ir(Format, Args, FieldSeparator, Prefix, GlobalIR-IR) :-
+    phrase(plawk_printf_arg_pairs(Args, FieldSeparator, Prefix, 0), ArgPairs),
+    pairs_keys_values(ArgPairs, ArgGlobalParts, ArgInfoPairs),
+    pairs_keys_values(ArgInfoPairs, ArgSetupParts, ArgCallArgLists),
+    append(ArgCallArgLists, CallArgs),
+    maplist(plawk_printf_call_arg_kind, CallArgs, ArgKinds),
+    plawk_printf_rewrite_format(Format, ArgKinds, PrintfFormat),
+    format(atom(FormatGlobal), '~w_fmt', [Prefix]),
+    llvm_emit_c_string_global(FormatGlobal, PrintfFormat, FormatGlobalIR, _FormatLen, FormatBytesLen),
+    format(atom(FmtPtrVar), '~w_fmt_ptr', [Prefix]),
+    format(atom(FmtPtr),
+        '  %~w = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
+        [FmtPtrVar, FormatBytesLen, FormatBytesLen, FormatGlobal]),
+    plawk_printf_call_args_ir(CallArgs, CallArgsIR),
+    format(atom(PrintVar), '~w_printed', [Prefix]),
+    (   CallArgsIR == ''
+    ->  format(atom(PrintCall),
+            '  %~w = call i32 (i8*, ...) @printf(i8* %~w)',
+            [PrintVar, FmtPtrVar])
+    ;   format(atom(PrintCall),
+            '  %~w = call i32 (i8*, ...) @printf(i8* %~w, ~w)',
+            [PrintVar, FmtPtrVar, CallArgsIR])
+    ),
+    plawk_join_nonempty_ir([FormatGlobalIR | ArgGlobalParts], GlobalIR),
+    append(ArgSetupParts, [FmtPtr, PrintCall], BodyParts),
+    atomic_list_concat(BodyParts, '\n', IR).
+
+plawk_printf_arg_pairs([], _FieldSeparator, _Prefix, _Index) -->
+    [].
+plawk_printf_arg_pairs([Arg | Args], FieldSeparator, Prefix, Index) -->
+    { plawk_emit_prefixed_print_expr_ir(Arg, FieldSeparator, Prefix, Index,
+          Type, GlobalParts, SetupParts),
+      plawk_printf_type_call_args(Type, CallArgs),
+      plawk_join_nonempty_ir(GlobalParts, GlobalIR),
+      plawk_join_nonempty_ir(SetupParts, SetupIR),
+      NextIndex is Index + 1
+    },
+    [GlobalIR-(SetupIR-CallArgs)],
+    plawk_printf_arg_pairs(Args, FieldSeparator, Prefix, NextIndex).
+
+plawk_printf_type_call_args(i64(_FmtPrefix, _PrintPrefix, ValueIR), [i64(ValueIR)]).
+plawk_printf_type_call_args(slice(_FmtPrefix, _PrintPrefix, LenIR, PtrIR), [slice_len(LenIR), slice_ptr(PtrIR)]).
+plawk_printf_type_call_args(string(_Base, PtrIR), [string_ptr(PtrIR)]).
+
+plawk_printf_call_arg_kind(i64(_ValueIR), i64).
+plawk_printf_call_arg_kind(slice_len(_LenIR), slice_len).
+plawk_printf_call_arg_kind(slice_ptr(_PtrIR), slice_ptr).
+plawk_printf_call_arg_kind(string_ptr(_PtrIR), string).
+
+plawk_printf_call_args_ir([], '') :-
+    !.
+plawk_printf_call_args_ir(CallArgs, IR) :-
+    maplist(plawk_printf_call_arg_ir, CallArgs, Parts),
+    atomic_list_concat(Parts, ', ', IR).
+
+plawk_printf_call_arg_ir(i64(ValueIR), IR) :-
+    format(atom(IR), 'i64 ~w', [ValueIR]).
+plawk_printf_call_arg_ir(slice_len(LenIR), IR) :-
+    format(atom(IR), 'i32 ~w', [LenIR]).
+plawk_printf_call_arg_ir(slice_ptr(PtrIR), IR) :-
+    format(atom(IR), 'i8* ~w', [PtrIR]).
+plawk_printf_call_arg_ir(string_ptr(PtrIR), IR) :-
+    format(atom(IR), 'i8* ~w', [PtrIR]).
+
+plawk_printf_rewrite_format(Format, ArgKinds, RewrittenFormat) :-
+    string_codes(Format, Codes),
+    plawk_printf_rewrite_codes(Codes, ArgKinds, RewrittenCodes),
+    string_codes(RewrittenFormat, RewrittenCodes).
+
+plawk_printf_rewrite_codes([], [], []).
+plawk_printf_rewrite_codes([Code | Rest], Kinds, [Code | RewrittenRest]) :-
+    Code =\= 0'%,
+    !,
+    plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
+plawk_printf_rewrite_codes([0'%, 0'% | Rest], Kinds, [0'%, 0'% | RewrittenRest]) :-
+    !,
+    plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
+plawk_printf_rewrite_codes([0'% | Rest], [i64 | Kinds], [0'%, 0'l, 0'd | RewrittenRest]) :-
+    plawk_printf_i64_spec_codes(Rest, RestAfterSpec),
+    !,
+    plawk_printf_rewrite_codes(RestAfterSpec, Kinds, RewrittenRest).
+plawk_printf_rewrite_codes([0'%, 0's | Rest], [string | Kinds], [0'%, 0's | RewrittenRest]) :-
+    !,
+    plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
+plawk_printf_rewrite_codes([0'%, 0's | Rest], [slice_len, slice_ptr | Kinds],
+        [0'%, 0'., 0'*, 0's | RewrittenRest]) :-
+    !,
+    plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
+
+plawk_printf_i64_spec_codes([0'l, 0'd | Rest], Rest).
+plawk_printf_i64_spec_codes([0'd | Rest], Rest).
+plawk_printf_i64_spec_codes([0'i | Rest], Rest).
 
 plawk_print_ir_parts([], [], []).
 plawk_print_ir_parts([GlobalIR-BodyIR | Parts], [GlobalIR | GlobalParts], [BodyIR | BodyParts]) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -19,6 +19,7 @@
 %      BEGIN { print "kind", "count" } { count++ } END { print "count", count }
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
+%      $1 == "ERROR" { printf "%s=%s\n", $2, $3 }
 %      { count++ } END { print "count", count }
 %      $3 > 100 { big++ } END { print big }
 %      $1 == "ERROR" { print $3, int($3) }
@@ -191,6 +192,12 @@ quoted_string(Codes) -->
     quoted_string_codes(Codes),
     "\"".
 
+quoted_string_codes(Codes) -->
+    "\\",
+    quoted_string_escape_codes(EscapedCodes),
+    !,
+    quoted_string_codes(RestCodes),
+    { append(EscapedCodes, RestCodes, Codes) }.
 quoted_string_codes([Code | Codes]) -->
     [Code],
     { Code =\= 0'", Code =\= 0'\n, Code =\= 0'\r },
@@ -198,6 +205,20 @@ quoted_string_codes([Code | Codes]) -->
     quoted_string_codes(Codes).
 quoted_string_codes([]) -->
     [].
+
+quoted_string_escape_codes([10]) -->
+    "n".
+quoted_string_escape_codes([9]) -->
+    "t".
+quoted_string_escape_codes([13]) -->
+    "r".
+quoted_string_escape_codes([0'"]) -->
+    "\"".
+quoted_string_escape_codes([0'\\]) -->
+    "\\".
+quoted_string_escape_codes([0'\\, Code]) -->
+    [Code],
+    { Code =\= 0'\n, Code =\= 0'\r }.
 
 begin_clauses([begin(Actions)]) -->
     "BEGIN",
@@ -275,6 +296,9 @@ actions_rest([]) -->
 
 action(Action) -->
     if_action(Action),
+    !.
+action(Action) -->
+    printf_action(Action),
     !.
 action(Action) -->
     print_action(Action),
@@ -403,6 +427,33 @@ print_action(print(Fields)) -->
     "print",
     required_ws,
     print_fields(Fields).
+
+printf_action(printf(string(Format), Args)) -->
+    "printf",
+    required_ws,
+    quoted_string(FormatCodes),
+    printf_args(Args),
+    { string_codes(Format, FormatCodes) }.
+
+printf_args([Arg | Args]) -->
+    ws,
+    ",",
+    ws,
+    !,
+    field_expr(Arg),
+    printf_args_rest(Args).
+printf_args([]) -->
+    [].
+
+printf_args_rest([Arg | Args]) -->
+    ws,
+    ",",
+    ws,
+    !,
+    field_expr(Arg),
+    printf_args_rest(Args).
+printf_args_rest([]) -->
+    [].
 
 print_fields([Field | Fields]) -->
     field_expr(Field),

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -50,6 +50,21 @@ test(parses_field_eq_print_fields_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print $2, $3 }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [print([field(2), field(3)])])], [])).
 
+test(parses_field_eq_printf_fields_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { printf \"%s=%s\\n\", $2, $3 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [printf(string("%s=%s\n"), [field(2), field(3)])])], [])).
+
+test(parses_field_eq_printf_literal_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { printf \"hit\\n\" }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [printf(string("hit\n"), [])])], [])).
+
+test(parses_field_eq_printf_string_arg_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { printf \"%s:%s\\n\", \"kind\", $1 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [printf(string("%s:%s\n"), [string("kind"), field(1)])])], [])).
+
 test(parses_field_eq_print_nr_fields_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print NR, $2, $3 }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
@@ -437,6 +452,21 @@ test(surface_field_eq_prints_selected_fields) :-
     run_surface_print_smoke("$1 == \"ERROR\" { print $2, $3 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "disk full\nnet down\n").
+
+test(surface_field_eq_printf_fields_prints_matching_records) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { printf \"%s=%s\\n\", $2, $3 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "disk=full\nnet=down\n").
+
+test(surface_field_eq_printf_has_no_implicit_newline) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { printf \"[%s]\", $2 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "[disk][net]").
+
+test(surface_printf_string_literal_arg) :-
+    run_surface_print_smoke("{ printf \"%s:%s\\n\", \"kind\", $1 }\n",
+        "INFO boot ok\nERROR disk full\n",
+        "kind:INFO\nkind:ERROR\n").
 
 test(surface_field_numeric_cmp_prints_matching_records) :-
     run_surface_print_smoke("$3 > 100 { print $1, $3 }\n",
@@ -838,6 +868,21 @@ test(surface_begin_field_separator_drives_selected_field_printing) :-
         "ERROR:disk:full\nWARN:cpu:hot\nERROR:net:down\n",
         "disk full\nnet down\n").
 
+test(surface_begin_field_separator_drives_printf_fields) :-
+    run_surface_print_smoke("BEGIN { FS = \":\" } $1 == \"ERROR\" { printf \"%s=%s\\n\", $2, $3 }\n",
+        "ERROR:disk:full\nWARN:cpu:hot\nERROR:net:down\n",
+        "disk=full\nnet=down\n").
+
+test(surface_printf_i64_and_percent_literals) :-
+    run_surface_print_smoke("{ printf \"row=%d %% %s\\n\", NR, $1 } END { print \"done\" }\n",
+        "INFO boot ok\nERROR disk full\n",
+        "row=1 % INFO\nrow=2 % ERROR\ndone\n").
+
+test(surface_if_else_branch_printf_prints_selected_branch) :-
+    run_surface_print_smoke("{ if ($1 == \"ERROR\") { printf \"E:%s\\n\", $2 } else { printf \"O:%s\\n\", $1 } } END { print \"done\" }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\n",
+        "O:INFO\nE:disk\nO:WARN\ndone\n").
+
 test(surface_begin_field_separator_prints_header) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; print \"kind\", \"count\" } { counts[$1]++ } END { print \"ERROR\", counts[\"ERROR\"] }\n",
         "ERROR:disk:full\nWARN:cpu:hot\nERROR:net:down\n",
@@ -982,6 +1027,25 @@ test(surface_scalar_add_assign_uses_native_field_i64_parse) :-
     assertion(once(sub_atom(DriverIR, _, _, _, 'select i1 %rule_0_body_slot_1_op_1_field_i64_ok'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0 = add i64 %slot_0, %rule_0_body_slot_0_op_0_field_i64_value_or_default'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_1_op_1 = add i64 0, %rule_0_body_slot_1_op_1_field_i64_value_or_default'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_printf_uses_native_vararg_call) :-
+    plawk_parse_string("{ printf \"row=%d %% %s\\n\", NR, $1 } END { print \"done\" }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_0_body_printf_0_fmt = private constant [17 x i8] c"row=%ld %% %.*s\\0A\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_printf_0_field_1 = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 1, i8 32)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_printf_0_printed = call i32 (i8*, ...) @printf(i8* %rule_0_body_printf_0_fmt_ptr, i64 %current_nr, i32 %rule_0_body_printf_0_field_1_len, i8* %rule_0_body_printf_0_field_1_ptr)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_branch_printf_uses_prefixed_native_vararg_call) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { printf \"E:%s\\n\", $2 } else { printf \"O:%s\\n\", $1 } } END { print \"done\" }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_0_body_if_0_then_printf_0_fmt = private constant [8 x i8] c"E:%.*s\\0A\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_0_body_if_0_else_printf_0_fmt = private constant [8 x i8] c"O:%.*s\\0A\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_then_printf_0_printed = call i32 (i8*, ...) @printf'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_else_printf_0_printed = call i32 (i8*, ...) @printf'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
  Adds basic rule-local `printf` support to the PLAWK surface parser and native LLVM/WAM codegen.

  - Parses `printf "format", args...` actions, including common quoted-string escapes.
  - Lowers supported `printf` actions to native vararg `@printf` calls.
  - Supports `%%`, `%s`, `%d`, `%i`, and `%ld`.
  - Rewrites field-slice `%s` arguments to `%.*s` so fields stay allocation-free.
  - Covers plain rules, `BEGIN { FS = ... }` field splitting, string literal args, native `i64` args, and `if/else`
  branch `printf` actions.
  - Updates PLAWK docs and implementation notes for the supported subset.

  Verification:
  - `tests/test_plawk_surface_prefix_print.pl`: 217/217 passed
  - PLAWK core/native surrounding suites passed
  - `git diff --check` passed