### PR TITLE
WAM-Rust: fuzzy / graded membership (μ ∈ [0,1]) with threshold knob + signal fusion

### DIFF
--- a/docs/design/WAM_RUST_CARET_REALDATA_MEASUREMENT_2026-06-18.md
+++ b/docs/design/WAM_RUST_CARET_REALDATA_MEASUREMENT_2026-06-18.md
@@ -155,6 +155,19 @@ exercised by `wikipedia_fuzzy_membership_threshold_and_fusion`.
   low-`μ` (≤0.3) at **4.77** — so each can audit the other. The disagreements are the interesting
   cases the fusion surfaces (e.g. `Sound`, `Waves`, `Cold` read `μ=1.0` but sit slightly farther
   structurally — genuine physics the graph places at a remove).
+- **The single-anchor version agrees too: depth-to-root vs `μ`.** Distance to the `Physics` root is
+  the *one-legged caret* `caret(u, Physics) = d(u→Physics)` (the root is a universal ancestor, so one
+  leg is zero). Statistically it anti-correlates with `μ`: there are more deep nodes than shallow,
+  and each downward hop has a chance to leak out of the semantic space, so deeper ⇒ more likely
+  non-physics (a few deep-but-genuine physics nodes buck it). Measured: high-`μ`(≥0.8) depth **2.24**,
+  low-`μ`(≤0.3) depth **3.86**, **`corr(μ, depth) = −0.48`**. So the cheap single-anchor signal
+  agrees with the multi-anchor mean-caret and with the LLM — "either way, similar results." (Note
+  this is the *robust* use of depth: the per-pair caret to a chosen anchor, not the raw root-depth
+  ranking that the associative leak makes unreliable — a leaked chemistry node is deep via a long
+  associative path, which is exactly why deep ⇒ less-physics holds *statistically* here.)
+- **Generating `μ` from semantic vectors** (category embeddings) instead of an LLM is the natural
+  alternative — same fuzzy membership, a different prior source; the structural agreement above
+  predicts it would land in the same place. (Future: needs an embedding source.)
 
 Still future work: **membership-weighted read-outs** — carry `μ` as a per-node weight into the
 functionals (`μ`-weighted Resnik/Lin that down-weights borderline ancestors in the MICA search, or

--- a/docs/design/WAM_RUST_CARET_REALDATA_MEASUREMENT_2026-06-18.md
+++ b/docs/design/WAM_RUST_CARET_REALDATA_MEASUREMENT_2026-06-18.md
@@ -136,30 +136,30 @@ whole curated set on the **raw 10k graph** (1035 pairs, all related within budge
   flags the LLM's borderline calls. They are complementary — neither alone is enough, together they
   are a clean, self-checking pipeline for building a semantic test set on a non-taxonomic graph.
 
-## Future direction: fuzzy / graded membership
+## Fuzzy / graded membership (implemented)
 
 Binary keep/discard is lossy at the boundary — `Fire` (combustion → thermodynamics) and `Nitrogen`
-(physical chemistry) are not physics *topics* yet are not unrelated either. A natural
-generalization: have the classifier return a **graded physics-relevance score** `μ ∈ [0,1]` per
-node (a fuzzy-set membership, Zadeh 1965) instead of a bit. A single **threshold knob** then
-selects the test set — strict (`μ ≥ 0.8`) = core physics, loose (`μ ≥ 0.3`) admits `Fire`, the
-chemistry boundary, etc. — the same tightness-vs-reuse knob that runs through §5c (budget,
-quantization) and §7 (hard vs soft distance), now on the *membership* side. (The user's framing: a
-number that falls in the range of a category, with a looser criterion pulling in `Fire`.)
+(physical chemistry) are not physics *topics* yet are not unrelated either. So the classifier now
+returns a **graded physics-relevance score** `μ ∈ [0,1]` per node (a fuzzy-set membership,
+Zadeh 1965) instead of a bit — `tests/fixtures/wikipedia_physics_fuzzy_nodes.tsv` (Haiku-scored),
+exercised by `wikipedia_fuzzy_membership_threshold_and_fusion`.
 
-Two refinements it enables:
+- **The threshold knob works.** On the 90-node fixture: `|μ≥0.8| = 25` (core) → `|μ≥0.5| = 42` →
+  `|μ≥0.4| = 48` — a strict cut keeps the core, a loose cut pulls in the chemistry/combustion
+  boundary. `Fire` lands at `μ = 0.5` (loose-in, strict-out), exactly the graded boundary case.
+  This is the same tightness-vs-reuse knob as §5c (budget, quantization) and §7 (hard vs soft
+  distance), now on the *membership* side.
+- **The two signals fuse, and they agree.** The LLM `μ` is the *semantic* prior; the graph's
+  **mean optimal-bridge caret to the physics core** (a few canonical `μ=1.0` anchors) is the
+  *structural* signal. They correlate: high-`μ` (≥0.8) nodes sit at mean caret-to-core **3.02**,
+  low-`μ` (≤0.3) at **4.77** — so each can audit the other. The disagreements are the interesting
+  cases the fusion surfaces (e.g. `Sound`, `Waves`, `Cold` read `μ=1.0` but sit slightly farther
+  structurally — genuine physics the graph places at a remove).
 
-- **Fuse the two complementary signals.** The LLM score `μ` is the *semantic* prior; the graph
-  mean-caret-to-core is a *structural* membership signal (it already separated the chemistry
-  outliers above). A node's membership could be a blend of the two, each catching the other's
-  errors — the self-checking pipeline made continuous rather than a hard keep/discard.
-- **Membership-weighted read-outs.** Carry `μ` as a per-node weight into the functionals:
-  `μ`-weighted Resnik/Lin (down-weight borderline ancestors in the MICA search), or a
-  `μ`-thresholded boundary so a query "stays in physics with tolerance `τ`". This is the
-  graph-functional-semiring move applied to a *soft* node set rather than a hard one.
-
-Cost is small: the fixture grows one column (`node<TAB>μ`) and the classifier prompt asks for a
-score rather than a label. Recorded for future work.
+Still future work: **membership-weighted read-outs** — carry `μ` as a per-node weight into the
+functionals (`μ`-weighted Resnik/Lin that down-weights borderline ancestors in the MICA search, or
+a `μ`-thresholded boundary so a query "stays in physics with tolerance `τ`"). That is the
+graph-functional-semiring move applied to a *soft* node set rather than a hard one.
 
 ## Takeaways
 

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -3798,6 +3798,32 @@ mod tests {
         for &(mu, mc, u) in rows.iter().take(4) {
             eprintln!("      μ={:.1}  mean_caret={:.1}  {}", mu, mc, names[u as usize]);
         }
+
+        // (3) DISTANCE-TO-ROOT vs μ (the single-anchor structural signal). Depth to the Physics
+        // root is the one-legged caret `caret(u, Physics) = d(u→Physics)`. Statistically it should
+        // anti-correlate with μ: there are more deep nodes than shallow, and each downward hop has
+        // a chance to exit the semantic space, so deeper ⇒ more likely non-physics (even though a
+        // few deep-but-genuine physics nodes buck it). This is the cheap single-anchor version of
+        // the mean-caret-to-core above; they should agree.
+        if let Some(&root_id) = ids.get("Physics") {
+            let depth = min_distance_closure(root_id, &parents); // d(node → Physics) for all
+            let pts: Vec<(f64, f64)> = scored.iter()
+                .filter_map(|&(u, mu)| depth.get(&u).map(|&d| (mu, d as f64)))
+                .collect();
+            let npt = pts.len() as f64;
+            let (mx, my) = (pts.iter().map(|p| p.0).sum::<f64>() / npt,
+                            pts.iter().map(|p| p.1).sum::<f64>() / npt);
+            let (mut sxy, mut sxx, mut syy) = (0.0, 0.0, 0.0);
+            for &(x, y) in &pts { sxy += (x - mx) * (y - my); sxx += (x - mx).powi(2); syy += (y - my).powi(2); }
+            let r = sxy / (sxx.sqrt() * syy.sqrt());
+            let (mut hi, mut lo) = ((0.0, 0u32), (0.0, 0u32));
+            for &(mu, d) in &pts { if mu >= 0.8 { hi.0 += d; hi.1 += 1; } else if mu <= 0.3 { lo.0 += d; lo.1 += 1; } }
+            eprintln!("fuzzy: depth-to-Physics-root  high-μ(≥0.8)={:.2}  low-μ(≤0.3)={:.2}  | corr(μ,depth)={:.2}",
+                hi.0 / hi.1.max(1) as f64, lo.0 / lo.1.max(1) as f64, r);
+            // Statistically, μ and depth-to-root anti-correlate — the single-anchor signal agrees
+            // with the mean-caret-to-core (and with the LLM μ).
+            assert!(r < 0.0, "μ and depth-to-physics-root anti-correlate statistically: r={}", r);
+        }
     }
 
     // Downward convergence (fan-in) hub selection + the quantized-LCA min-over-hubs caret.

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -3721,6 +3721,85 @@ mod tests {
         assert!(with_bridge * 4 >= pairs, "curated physics pairs mostly related: {}/{}", with_bridge, pairs);
     }
 
+    // Fuzzy / graded membership: the LLM scores each node μ ∈ [0,1] instead of keep/discard
+    // (tests/fixtures/wikipedia_physics_fuzzy_nodes.tsv). Two things: (1) a THRESHOLD KNOB — a
+    // strict cut keeps the core, a loose cut pulls in Fire / the chemistry boundary; (2) FUSION of
+    // the LLM's *semantic* μ with the *structural* mean-caret-to-core, each catching the other's
+    // errors. Gated on `UW_CATEGORY_TSV` + `UW_FUZZY_NODES` (skips in CI).
+    #[test]
+    fn wikipedia_fuzzy_membership_threshold_and_fusion() {
+        let tsv = match std::env::var("UW_CATEGORY_TSV") {
+            Ok(p) => p, Err(_) => { eprintln!("fuzzy: skip (UW_CATEGORY_TSV)"); return; } };
+        let fuzz = match std::env::var("UW_FUZZY_NODES") {
+            Ok(p) => p, Err(_) => { eprintln!("fuzzy: skip (UW_FUZZY_NODES)"); return; } };
+        let text = std::fs::read_to_string(&tsv).expect("read UW_CATEGORY_TSV");
+        let mut ids: HashMap<String, u32> = HashMap::new();
+        let mut names: Vec<String> = Vec::new();
+        let mut parents: HashMap<u32, Vec<u32>> = HashMap::new();
+        for (ln, line) in text.lines().enumerate() {
+            if ln == 0 && line.starts_with("child") { continue; }
+            let mut it = line.split('\t');
+            let (c, p) = match (it.next(), it.next()) { (Some(c), Some(p)) => (c, p), _ => continue };
+            let intern = |s: &str, ids: &mut HashMap<String, u32>, names: &mut Vec<String>| {
+                *ids.entry(s.to_string()).or_insert_with(|| { names.push(s.to_string()); (names.len() - 1) as u32 }) };
+            let ci = intern(c, &mut ids, &mut names);
+            let pi = intern(p, &mut ids, &mut names);
+            parents.entry(ci).or_default().push(pi);
+        }
+        // load (node, μ), keeping only nodes present in the graph.
+        let scored: Vec<(u32, f64)> = std::fs::read_to_string(&fuzz).expect("read UW_FUZZY_NODES")
+            .lines().filter(|l| !l.trim_start().starts_with('#'))
+            .filter_map(|l| {
+                let mut it = l.split('\t');
+                match (it.next(), it.next().and_then(|s| s.trim().parse::<f64>().ok())) {
+                    (Some(n), Some(mu)) => ids.get(n.trim()).map(|&id| (id, mu)),
+                    _ => None,
+                }
+            }).collect();
+        eprintln!("fuzzy: {} scored nodes present", scored.len());
+
+        // (1) THRESHOLD KNOB: the set grows as the cut loosens, and the chemistry/combustion
+        // boundary (μ≈0.5, e.g. Fire) enters only under a loose criterion.
+        let count_at = |tau: f64| scored.iter().filter(|&&(_, mu)| mu >= tau).count();
+        let (strict, mid, loose) = (count_at(0.8), count_at(0.5), count_at(0.4));
+        eprintln!("fuzzy: |μ≥0.8|={}  |μ≥0.5|={}  |μ≥0.4|={}", strict, mid, loose);
+        assert!(strict <= mid && mid <= loose, "threshold cut is monotone");
+        let fire_mu = scored.iter().find(|&&(id, _)| names[id as usize] == "Fire").map(|&(_, mu)| mu);
+        if let Some(mu) = fire_mu {
+            assert!(mu >= 0.4 && mu < 0.8, "Fire is a graded boundary case (loose-in, strict-out): μ={}", mu);
+        }
+
+        // (2) FUSION: structural signal = mean optimal-bridge caret (budget 10) to the physics
+        // core (a few canonical μ=1.0 anchors). Low caret = structurally close to physics.
+        let anchors: Vec<u32> = ["Thermodynamics", "Electromagnetism", "Mechanics", "Optics", "Energy", "Matter"]
+            .iter().filter_map(|s| ids.get(*s).copied()).collect();
+        let mean_caret = |u: u32| -> Option<f64> {
+            let cs: Vec<u32> = anchors.iter().filter(|&&a| a != u)
+                .filter_map(|&a| caret_optimal_bridge(u, a, &parents, 10).map(|(_, c)| c)).collect();
+            if cs.is_empty() { None } else { Some(cs.iter().map(|&c| c as f64).sum::<f64>() / cs.len() as f64) }
+        };
+        // bucket the structural signal by the LLM grade — the two should AGREE on average.
+        let (mut hi, mut lo) = ((0.0f64, 0u32), (0.0f64, 0u32));
+        let mut rows: Vec<(f64, f64, u32)> = Vec::new(); // (μ, mean_caret, node)
+        for &(u, mu) in &scored {
+            if let Some(mc) = mean_caret(u) {
+                rows.push((mu, mc, u));
+                if mu >= 0.8 { hi.0 += mc; hi.1 += 1; } else if mu <= 0.3 { lo.0 += mc; lo.1 += 1; }
+            }
+        }
+        let (hi_mean, lo_mean) = (hi.0 / hi.1.max(1) as f64, lo.0 / lo.1.max(1) as f64);
+        eprintln!("fuzzy: mean caret-to-core  high-μ(≥0.8)={:.2}  low-μ(≤0.3)={:.2}", hi_mean, lo_mean);
+        // The signals correlate: high-μ nodes are structurally CLOSER to the physics core than low-μ.
+        assert!(hi_mean < lo_mean, "semantic μ and structural caret agree: {:.2} vs {:.2}", hi_mean, lo_mean);
+
+        // Disagreements are where the fusion earns its keep — each signal flags the other's errors.
+        rows.sort_by(|a, b| (b.0 - 1.0 / (1.0 + b.1)).partial_cmp(&(a.0 - 1.0 / (1.0 + a.1))).unwrap());
+        eprintln!("fuzzy: largest μ-vs-structure disagreements (high μ, structurally far):");
+        for &(mu, mc, u) in rows.iter().take(4) {
+            eprintln!("      μ={:.1}  mean_caret={:.1}  {}", mu, mc, names[u as usize]);
+        }
+    }
+
     // Downward convergence (fan-in) hub selection + the quantized-LCA min-over-hubs caret.
     // Tree-with-a-merge: 1->0; 2,3->1; 4,5->2; 6,7->3; and 8 is cross-listed under BOTH 2 and
     // 3 (8 -> [2,3]). Fan-in counts direct children: 0<-{1}, 1<-{2,3}, 2<-{4,5,8}, 3<-{6,7,8}.

--- a/tests/fixtures/wikipedia_physics_fuzzy_nodes.tsv
+++ b/tests/fixtures/wikipedia_physics_fuzzy_nodes.tsv
@@ -1,0 +1,99 @@
+# Fuzzy (graded) physics-membership scores for the WAM-Rust caret test set.
+#
+# Format: `node<TAB>mu`, mu in [0,1] = graded physics-relevance. '#' lines are comments.
+# Provenance: random walks DOWN the Wikipedia category graph from "Physics"
+# (scripts/physics_random_walk_candidates.py --tsv data/benchmark/10k/category_parent.tsv
+#  --walks 400 --depth 6 --seed 1234 --top 90), then scored 0..1 by a Haiku subagent (graded,
+# not binary). LLM-curated and not authoritative. The point of the grade is a THRESHOLD KNOB:
+# a strict cut (mu >= 0.8) keeps the core, a loose cut (mu >= 0.4) pulls in Fire / the chemistry
+# boundary. Fuse with the structural mean-caret-to-core signal (each catches the other's errors).
+Temperature	1.0
+Fire	0.5
+Fires	0.5
+Physical_quantity	1.0
+Energy	1.0
+Subfields_of_physics	1.0
+Physicists	0.0
+Physicists_by_nationality	0.0
+Hungarian_physicists	0.0
+Matter	1.0
+Heat	1.0
+Cold	1.0
+Ice	0.5
+Ice_sports	0.0
+Time	1.0
+Electric_vehicles	0.3
+States_of_matter	1.0
+Gases	0.9
+Fires_by_decade	0.0
+Electric_rail_transport	0.0
+Fires_by_continent	0.0
+Light	1.0
+Ice_hockey	0.0
+Building_and_structure_fires	0.0
+Atoms	0.9
+Chemical_elements	0.5
+Physical_objects	0.5
+Electromagnetic_radiation	1.0
+Alternative_propulsion	0.2
+Green_vehicles	0.0
+Figure_skating	0.0
+Thermodynamics	1.0
+Classical_mechanics	1.0
+Wave_mechanics	1.0
+Electromagnetism	1.0
+Electricity	1.0
+Noble_gases	0.5
+Noble_gas_compounds	0.4
+Energy_in_transport	0.2
+Arsenic	0.4
+Oxygen	0.5
+Alternative_energy	0.3
+Mechanics	1.0
+Breathing_gases	0.3
+Oxygen_compounds	0.4
+Electric_railways	0.0
+Arsenic_compounds	0.4
+Time_travel	0.1
+Time_travel_television_series	0.0
+2010s_time_travel_television_series	0.0
+History	0.0
+Waves	1.0
+Electricity_distribution	0.7
+Electrification	0.6
+Optics	1.0
+Vision	0.4
+Groups_(periodic_table)	0.5
+Oscillation	1.0
+Causality	0.7
+Chronology	0.0
+Propulsion	0.4
+21st-century_time_travel_television_series	0.0
+Acoustics	1.0
+Sound	1.0
+Music	0.0
+Future	0.0
+Astronomical_objects	0.7
+Planets	0.6
+Earth	0.5
+Birth	0.0
+Births_by_time	0.0
+Religious_objects	0.0
+Religious_buildings	0.0
+Shrines	0.0
+Shinto_shrines	0.0
+Pnictogens	0.5
+Cosmology	0.8
+Creation_myths	0.0
+Creator_deities	0.0
+Creator_gods_and_goddesses	0.0
+God	0.0
+Blind_sportspeople	0.0
+Electronics	0.7
+Past	0.0
+2000s_fires	0.0
+Calendars	0.0
+Metalloids	0.5
+Fires_in_North_America	0.0
+Building_and_structure_fires_in_Europe	0.0
+Prevention	0.0


### PR DESCRIPTION
## What & why

Graduates the binary curated test set (#3264) into a **fuzzy / graded** one: the LLM classifier
now returns a physics-relevance score `μ ∈ [0,1]` per node (a fuzzy-set membership, Zadeh 1965)
instead of keep/discard — the deferred future direction from the 3e measurement doc, now built.
Binary was lossy at the boundary (`Fire`, `Nitrogen` aren't physics *topics* yet aren't unrelated);
a graded `μ` with a threshold captures exactly that middle.

- **Fixture:** `tests/fixtures/wikipedia_physics_fuzzy_nodes.tsv` — 90 random-walk candidates,
  Haiku-scored `node<TAB>μ` (genuinely graded: `Fire 0.5`, `Cosmology 0.8`, `Electronics 0.7`,
  core physics `1.0`, sports/people/admin `0.0`).
- **Harness:** `wikipedia_fuzzy_membership_threshold_and_fusion` (env-gated on `UW_CATEGORY_TSV` +
  `UW_FUZZY_NODES`, skips in CI).

## Results

- **Threshold knob.** `|μ≥0.8| = 25` (core) → `|μ≥0.5| = 42` → `|μ≥0.4| = 48` (monotone). `Fire`
  lands at `μ = 0.5` — loose-in, strict-out, the graded boundary case. Same tightness-vs-reuse
  knob as §5c (budget/quantization) and §7 (hard vs soft distance), now on the *membership* side.
- **Signal fusion.** The LLM's *semantic* `μ` and the graph's *structural* mean-caret-to-core
  agree: high-`μ` (≥0.8) nodes sit at mean caret **3.02**, low-`μ` (≤0.3) at **4.77** — so each
  signal audits the other. Disagreements (`Sound`, `Waves`, `Cold`: `μ=1.0` but structurally a bit
  farther) are the cases the fusion surfaces.

## Scope

This is the test-set / curation half. The **membership-weighted read-outs** (`μ`-weighted
Resnik/Lin, a `μ`-thresholded boundary) — carrying `μ` into the functionals for a *soft* node set —
are left as documented future work.

Measurement doc section flipped from "future direction" to "implemented". Full suite: **85 passed**
(the fuzzy test skips in CI without the env vars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_