### PR TITLE
WAM-Rust: μ-weighted IC (partial admission) + fuzzy S-curve admission

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -801,6 +801,16 @@ calibration of the relatedness read-out.)
 > wants a **`μ`-weighted MinHash** sketch (the weighted analogue of `descendant_minhash`), future
 > work. And this is exactly where membership *matters* (per §-aside): a read-out over the *global*
 > cone, not the per-pair caret, which is membership-robust.
+>
+> **Novel-contribution flag.** Resnik-style IC over a frequency null (Resnik 1995; Seco 2004's
+> intrinsic descendant-count form) is established; *graded* (fuzzy `μ ∈ [0,1]`) **partial admission**
+> into that descendant-mass null — as the calibration fix for the associative leak on a non-taxonomic
+> DAG — is, to our knowledge, original here and not a restatement of a published estimator. It is a
+> strict generalization: `μ ≡ 1` reduces *exactly* to the sketch IC (regression-tested in
+> `mu_weighted_ic_reduces_to_sketch_ic_at_mu_one`). The default S-curve steepness is the *exact*
+> anchor fit `k = 4·ln 3 ≈ 4.3944` (symmetric anchors `0.25` either side of `c`); the logistic only
+> *asymptotes* to `0`/`1`, so if exact endpoints are wanted (fully-out nodes contributing *exactly*
+> zero) Zadeh's piecewise-quadratic S-function is the drop-in alternative.
 
 ### 5e. A gentle primer on information-content similarity (for the reader learning this)
 

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -785,6 +785,23 @@ calibrated on deep DAGs — the principled absolute-score companion to the lift'
 (Hub *selection* from these scores is still the open global problem; this only fixes the
 calibration of the relatedness read-out.)
 
+> **`μ`-weighted IC — "partial admission" (the first membership-weighted read-out).** `IC` counts
+> every descendant as `1`; on a non-taxonomic graph the **associative leak** bloats a domain node's
+> cone with out-of-domain descendants, so its `|desc|` looks huge and the raw `IC` mistakes it for
+> *generality* (big cone → low `IC`). Fix it by **admitting each node with weight `μ ∈ [0,1]`**
+> instead of 0/1 (the fuzzy-membership `μ` of the measurement note): `IC_μ(t) = −log₂(Σ_{d∈desc(t)}
+> μ_d / Σ_all μ)` (`information_content_weighted`, with `descendant_mu_mass` the distinct weighted
+> mass; `μ ≡ 1` recovers `IC`). Low-`μ` leaked descendants barely count, so the effective cone
+> shrinks to its in-domain size and the node's `IC` is *raised* to its true specificity — on a leaky
+> test graph a physics node's IC goes `0.49 → 1.28`, closing the false generality gap to a clean
+> sibling. The admission weight need not be linear in `μ`: `fuzzy_admission` is an **S-curve**
+> (logistic) transfer `w(μ) = 1/(1+e^{−k(μ−c)})` — default `c=0.55, k≈4.39` fits the anchors
+> `w(0.8)=0.75`, `w(0.3)=0.25` — for a nearly-full/nearly-zero admission with a tunable knee.
+> *Scaling caveat:* `descendant_mu_mass` is exact (per-node BFS, `O(V·(V+E))`); the large-graph form
+> wants a **`μ`-weighted MinHash** sketch (the weighted analogue of `descendant_minhash`), future
+> work. And this is exactly where membership *matters* (per §-aside): a read-out over the *global*
+> cone, not the per-pair caret, which is membership-robust.
+
 ### 5e. A gentle primer on information-content similarity (for the reader learning this)
 
 *§5d is written for someone who already has the vocabulary. This subsection builds the same idea

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -1521,6 +1521,68 @@ pub fn information_content(dsig: &[u64], n_total: usize, k: usize) -> f64 {
     -p.log2()
 }
 
+/// **μ-weighted ("partial admission") information content.** Standard `IC` counts every descendant
+/// as `1`; here each node is admitted with weight `μ ∈ [0,1]`, so `IC_μ(t) = −log₂( m_μ(t) / M_μ )`
+/// with `m_μ(t) = Σ_{d∈desc(t)} μ_d` the admitted mass under `t` and `M_μ = Σ_all μ` the total. Low-μ
+/// (out-of-domain / leaked) descendants barely count, so a *domain* node whose cone is bloated by
+/// the associative leak — which the raw `IC` mistakes for *generality* (a big cone → low IC) — has
+/// its effective cone shrunk back to its in-domain size and its IC *raised* to its true specificity.
+/// `μ ≡ 1` recovers `information_content`. (`m_μ` is the **distinct** weighted mass; see
+/// `descendant_mu_mass`.)
+pub fn information_content_weighted(desc_mu_mass: f64, total_mu: f64) -> f64 {
+    if total_mu <= 0.0 || desc_mu_mass <= 0.0 {
+        return 0.0;
+    }
+    -((desc_mu_mass / total_mu).min(1.0)).log2()
+}
+
+/// Exact **distinct** μ-weighted descendant mass per node: `m_μ(t) = Σ_{d∈desc(t)} μ_d` over the
+/// distinct descendant set (`t` included), so diamonds count once. A downward BFS per node
+/// (`O(V·(V+E))`) — exact, for small graphs / validation. At scale this wants a **μ-weighted
+/// MinHash** sketch (the weighted analogue of `descendant_minhash`), which is future work; this
+/// grounds `information_content_weighted`. With `μ ≡ 1` it equals the distinct descendant count.
+pub fn descendant_mu_mass(
+    parents: &std::collections::HashMap<u32, Vec<u32>>,
+    mu: &std::collections::HashMap<u32, f64>,
+) -> std::collections::HashMap<u32, f64> {
+    use std::collections::{HashMap, HashSet, VecDeque};
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut nodes: HashSet<u32> = HashSet::new();
+    for (&c, ps) in parents {
+        nodes.insert(c);
+        for &p in ps { nodes.insert(p); children.entry(p).or_default().push(c); }
+    }
+    let muv = |u: u32| mu.get(&u).copied().unwrap_or(0.0);
+    let mut out: HashMap<u32, f64> = HashMap::new();
+    for &t in &nodes {
+        let mut seen: HashSet<u32> = HashSet::new();
+        seen.insert(t);
+        let mut q: VecDeque<u32> = VecDeque::new();
+        q.push_back(t);
+        let mut mass = muv(t);
+        while let Some(x) = q.pop_front() {
+            if let Some(cs) = children.get(&x) {
+                for &c in cs { if seen.insert(c) { mass += muv(c); q.push_back(c); } }
+            }
+        }
+        out.insert(t, mass);
+    }
+    out
+}
+
+/// **Fuzzy admission curve**: an S-shaped (logistic) transfer from the raw membership `μ` to an
+/// admission weight in `[0,1]`, `w(μ) = 1/(1 + e^{−k(μ−c)})`. Shapes *how* `μ` translates to
+/// admission — nearly-full weight well above the boundary, nearly-zero well below, a smooth knee
+/// through the middle — instead of admitting linearly by raw `μ`. The default `c = 0.55, k ≈ 4.39`
+/// fits the anchors `w(0.8) = 0.75` (small drop) and `w(0.3) = 0.25` (significant drop), with the
+/// crossover `w(0.55) = 0.5`; raise `k` for a sharper accept/reject knee, move `c` for the
+/// boundary. (Zadeh's piecewise-quadratic S-function is the classic alternative shape.) Feed
+/// `w(μ_d)` as the per-node admission weight to `descendant_mu_mass` for a fuzzy partial-admission
+/// `IC`.
+pub fn fuzzy_admission(mu: f64, center: f64, steepness: f64) -> f64 {
+    1.0 / (1.0 + (-steepness * (mu - center)).exp())
+}
+
 /// Reflexive ancestor set of `node` (`node` itself plus every strict ancestor), by up-BFS.
 /// **O(|ancestors(node)| + edges above it)** per call — it allocates a fresh `HashSet`/`VecDeque`.
 /// For repeated queries on the same node, cache the returned set rather than recomputing.
@@ -4097,6 +4159,54 @@ mod tests {
         // Jaccard of two saturated sketches stays in [0,1] (no panic / out-of-range).
         let j = sketch_jaccard(&sig[&20], &sig[&19], K);
         assert!((0.0..=1.0).contains(&j));
+    }
+
+    // μ-weighted ("partial admission") IC + the fuzzy S-curve admission. A leaky graph: physics
+    // node 1 (μ=1) has a cone of mostly LEAKED low-μ descendants (3,4,5,6 at μ=0.1); physics node 2
+    // (μ=1) is a clean leaf. Raw IC mistakes node 1's big leaked cone for generality (low IC);
+    // partial admission discounts the leak and RAISES its IC to its true specificity.
+    #[test]
+    fn mu_weighted_ic_partial_admission_and_s_curve() {
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        g.insert(1, vec![0]); g.insert(2, vec![0]);
+        g.insert(3, vec![1]); g.insert(4, vec![3]); g.insert(5, vec![3]); g.insert(6, vec![3]);
+        let close = |a: f64, b: f64| (a - b).abs() < 1e-2;
+
+        // RAW IC (μ ≡ 1): node 1's leaked cone {1,3,4,5,6}=5 makes it look general; node 2={2}=1 specific.
+        let n = 7.0; // nodes 0..=6
+        let mass1: HashMap<u32, f64> = (0u32..=6).map(|i| (i, 1.0)).collect();
+        let raw = descendant_mu_mass(&g, &mass1);
+        let (ic_raw_1, ic_raw_2) = (information_content_weighted(raw[&1], n),
+                                    information_content_weighted(raw[&2], n));
+        assert!(close(raw[&1], 5.0) && close(raw[&2], 1.0));          // μ≡1 == distinct counts
+        assert!(ic_raw_1 < ic_raw_2 - 1.5, "raw IC: leaked node 1 looks falsely GENERAL");
+
+        // LINEAR μ-weighting: 3,4,5,6 at μ=0.1; 0,1,2 at μ=1. The leak is discounted.
+        let mut mu: HashMap<u32, f64> = (0u32..=2).map(|i| (i, 1.0)).collect();
+        for i in 3u32..=6 { mu.insert(i, 0.1); }
+        let total_mu: f64 = mu.values().sum();
+        let lin = descendant_mu_mass(&g, &mu);
+        let (ic_mu_1, ic_mu_2) = (information_content_weighted(lin[&1], total_mu),
+                                  information_content_weighted(lin[&2], total_mu));
+        // Node 1's IC is RAISED (its cone is mostly leaked); the false generality is corrected.
+        assert!(ic_mu_1 > ic_raw_1 + 0.5, "partial admission raises the leaked node's IC: {} -> {}", ic_raw_1, ic_mu_1);
+        assert!(ic_mu_2 - ic_mu_1 < ic_raw_2 - ic_raw_1, "the leak's false discrimination shrinks");
+
+        // FUZZY S-CURVE admission: the anchors w(0.8)=0.75, w(0.3)=0.25, crossover w(0.55)=0.5.
+        let (c, k) = (0.55, 4.39);
+        assert!(close(fuzzy_admission(0.8, c, k), 0.75));
+        assert!(close(fuzzy_admission(0.3, c, k), 0.25));
+        assert!(close(fuzzy_admission(0.55, c, k), 0.5));
+        assert!(fuzzy_admission(0.1, c, k) < fuzzy_admission(0.3, c, k));   // monotone
+        assert!(fuzzy_admission(1.0, c, k) > fuzzy_admission(0.8, c, k));
+        // Shape μ through the S-curve, then admit: still corrects the leak, with a tunable knee.
+        let mu_s: HashMap<u32, f64> = mu.iter().map(|(&u, &m)| (u, fuzzy_admission(m, c, k))).collect();
+        let tot_s: f64 = mu_s.values().sum();
+        let s = descendant_mu_mass(&g, &mu_s);
+        let ic_s_1 = information_content_weighted(s[&1], tot_s);
+        assert!(ic_s_1 > ic_raw_1 + 0.5, "S-curve partial admission also corrects the leak");
+        eprintln!("μ-IC: node1 raw {:.2} → linear-μ {:.2} → S-curve {:.2}  (node2 raw {:.2})",
+            ic_raw_1, ic_mu_1, ic_s_1, ic_raw_2);
     }
 
     // IC-based semantic similarity (Resnik/Lin) via the descendant sketch -- the calibrated,

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -1529,9 +1529,27 @@ pub fn information_content(dsig: &[u64], n_total: usize, k: usize) -> f64 {
 /// its effective cone shrunk back to its in-domain size and its IC *raised* to its true specificity.
 /// `μ ≡ 1` recovers `information_content`. (`m_μ` is the **distinct** weighted mass; see
 /// `descendant_mu_mass`.)
+///
+/// **Boundary semantics** (the two limits are *opposite*, so we do not collapse both to `0`):
+/// - `desc_mu_mass = 0` with `total_mu > 0` is a genuinely *empty* (fully out-of-domain) cone —
+///   `p = 0`, so `IC = −log₂ 0 = +∞`, the maximal-surprise limit. We return `f64::INFINITY`, not
+///   `0.0` (which would wrongly read as *root-like / fully general*, the exact inversion of an
+///   empty cone). Callers that aggregate IC should treat `+∞` as "drop / out of domain".
+/// - `total_mu ≤ 0` is a precondition violation (no admitted mass anywhere ⇒ no probability space):
+///   `IC` is undefined. `debug_assert` catches it in tests; release returns `0.0` as a safe inert
+///   fallback. `total_mu` must be `Σ_all μ` (the full universe mass), with `desc_mu_mass ≤ total_mu`.
 pub fn information_content_weighted(desc_mu_mass: f64, total_mu: f64) -> f64 {
-    if total_mu <= 0.0 || desc_mu_mass <= 0.0 {
-        return 0.0;
+    debug_assert!(total_mu > 0.0, "total_mu must be the positive universe mass Σ_all μ");
+    debug_assert!(desc_mu_mass >= 0.0, "desc_mu_mass is a sum of μ≥0 and cannot be negative");
+    debug_assert!(
+        desc_mu_mass <= total_mu + 1e-9,
+        "desc_mu_mass ({desc_mu_mass}) exceeds total_mu ({total_mu}); total_mu is not Σ_all μ"
+    );
+    if total_mu <= 0.0 {
+        return 0.0; // undefined universe; inert fallback (see doc)
+    }
+    if desc_mu_mass <= 0.0 {
+        return f64::INFINITY; // empty cone ⇒ p=0 ⇒ maximal surprise (see doc)
     }
     -((desc_mu_mass / total_mu).min(1.0)).log2()
 }
@@ -1541,18 +1559,27 @@ pub fn information_content_weighted(desc_mu_mass: f64, total_mu: f64) -> f64 {
 /// (`O(V·(V+E))`) — exact, for small graphs / validation. At scale this wants a **μ-weighted
 /// MinHash** sketch (the weighted analogue of `descendant_minhash`), which is future work; this
 /// grounds `information_content_weighted`. With `μ ≡ 1` it equals the distinct descendant count.
+///
+/// **Contract:** `mu` holds membership weights in `[0,1]`. A node *absent* from `mu` is admitted
+/// with weight `0` (`unwrap_or(0.0)`) — i.e. "not in the domain" is the default, so the caller
+/// only has to list the in-domain nodes and their grades. A `debug_assert` checks every supplied
+/// weight is in `[0,1]`.
 pub fn descendant_mu_mass(
     parents: &std::collections::HashMap<u32, Vec<u32>>,
     mu: &std::collections::HashMap<u32, f64>,
 ) -> std::collections::HashMap<u32, f64> {
     use std::collections::{HashMap, HashSet, VecDeque};
+    debug_assert!(
+        mu.values().all(|&w| (0.0..=1.0).contains(&w)),
+        "membership weights μ must lie in [0,1]"
+    );
     let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
     let mut nodes: HashSet<u32> = HashSet::new();
     for (&c, ps) in parents {
         nodes.insert(c);
         for &p in ps { nodes.insert(p); children.entry(p).or_default().push(c); }
     }
-    let muv = |u: u32| mu.get(&u).copied().unwrap_or(0.0);
+    let muv = |u: u32| mu.get(&u).copied().unwrap_or(0.0); // absent ⇒ μ=0 (out of domain; see contract)
     let mut out: HashMap<u32, f64> = HashMap::new();
     for &t in &nodes {
         let mut seen: HashSet<u32> = HashSet::new();
@@ -1579,7 +1606,17 @@ pub fn descendant_mu_mass(
 /// boundary. (Zadeh's piecewise-quadratic S-function is the classic alternative shape.) Feed
 /// `w(μ_d)` as the per-node admission weight to `descendant_mu_mass` for a fuzzy partial-admission
 /// `IC`.
+///
+/// The default `k` is **exact**: fitting `w(0.8)=0.75, w(0.3)=0.25` (symmetric anchors about
+/// `c=0.55`, each `0.25` away) forces `k·0.25 = ln 3`, i.e. `k = 4·ln 3 ≈ 4.3944`. Note the
+/// logistic only *asymptotes* to `0`/`1`: `w(0)=0.087, w(1)=0.135` are not pinned to the endpoints.
+/// If exact `0`/`1` at the extremes matters (so fully-out nodes contribute *exactly* nothing),
+/// Zadeh's piecewise-quadratic S-function is the drop-in alternative — it reaches `0` below the
+/// lower foot and `1` above the upper foot exactly. **Degenerate `steepness`:** `steepness = 0`
+/// collapses `w ≡ 0.5` (no discrimination); `steepness < 0` *inverts* the curve (admits low μ,
+/// rejects high) — almost always a sign error, so a `debug_assert` requires `steepness > 0`.
 pub fn fuzzy_admission(mu: f64, center: f64, steepness: f64) -> f64 {
+    debug_assert!(steepness > 0.0, "steepness must be > 0 (0 ⇒ constant 0.5, <0 inverts admission)");
     1.0 / (1.0 + (-steepness * (mu - center)).exp())
 }
 
@@ -4207,6 +4244,33 @@ mod tests {
         assert!(ic_s_1 > ic_raw_1 + 0.5, "S-curve partial admission also corrects the leak");
         eprintln!("μ-IC: node1 raw {:.2} → linear-μ {:.2} → S-curve {:.2}  (node2 raw {:.2})",
             ic_raw_1, ic_mu_1, ic_s_1, ic_raw_2);
+    }
+
+    // R6 regression: with μ ≡ 1 the partial-admission IC must AGREE with the independent
+    // sketch-based `information_content` (descendant MinHash), node for node — the μ-weighted
+    // path is a strict generalization that reduces to the established estimator at μ ≡ 1.
+    #[test]
+    fn mu_weighted_ic_reduces_to_sketch_ic_at_mu_one() {
+        const K: usize = 64; // k >> cone sizes ⇒ exact sketches
+        let mut t: HashMap<u32, Vec<u32>> = HashMap::new();
+        t.insert(1, vec![0]); t.insert(2, vec![0]);
+        t.insert(3, vec![1]); t.insert(4, vec![1]);
+        t.insert(5, vec![2]); t.insert(6, vec![2]);
+        let n = 7usize;
+
+        // Sketch path: distinct-cone IC.
+        let d = descendant_minhash(&t, K).unwrap();
+        // μ-weighted path at μ ≡ 1: exact distinct mass == distinct cone size.
+        let mu_one: HashMap<u32, f64> = (0u32..=6).map(|i| (i, 1.0)).collect();
+        let mass = descendant_mu_mass(&t, &mu_one);
+        let total_mu: f64 = mu_one.values().sum(); // == n
+
+        for node in 0u32..=6 {
+            let ic_sketch = information_content(&d[&node], n, K);
+            let ic_mu = information_content_weighted(mass[&node], total_mu);
+            assert!((ic_sketch - ic_mu).abs() < 1e-9,
+                "node {node}: sketch IC {ic_sketch} != μ≡1 IC {ic_mu}");
+        }
     }
 
     // IC-based semantic similarity (Resnik/Lin) via the descendant sketch -- the calibrated,


### PR DESCRIPTION
## What & why

The first **membership-weighted read-out** — `μ`-weighted IC ("partial admission") — and it
specifically *corrects the associative leak's effect on IC*.

Raw `IC(t) = −log₂(|desc(t)|/N)` counts every descendant as `1`. On a non-taxonomic graph the leak
bloats a domain node's cone with out-of-domain descendants, so its `|desc|` looks huge and the raw
IC mistakes it for **generality** (big cone → low IC). **Partial admission** admits each node with
weight `μ ∈ [0,1]` instead of 0/1, so low-`μ` (leaked) descendants barely count — the effective cone
shrinks to its in-domain size and the node's IC is *raised* to its true specificity.

## What's added

- **`information_content_weighted(desc_mu_mass, total_mu)`** = `−log₂(Σ_{d∈desc(t)} μ_d / Σ_all μ)`;
  `μ ≡ 1` recovers `information_content`.
- **`descendant_mu_mass(parents, μ)`** — the *distinct* μ-weighted descendant mass (per-node BFS,
  `O(V·(V+E))`, exact for small graphs; the scalable **μ-weighted MinHash** sketch is future work).
- **`fuzzy_admission(μ, c, k)`** — an **S-curve** (logistic) transfer `w(μ)=1/(1+e^{−k(μ−c)})`, so
  admission needn't be linear in `μ`. Default `c=0.55, k≈4.39` fits the anchors `w(0.8)=0.75` (small
  drop) and `w(0.3)=0.25` (significant drop), crossover `w(0.55)=0.5` — nearly-full/nearly-zero with
  a tunable knee.

## Test

`mu_weighted_ic_partial_admission_and_s_curve` — on a leaky graph (physics node with a cone of
mostly leaked `μ=0.1` descendants):
```
μ-IC: node1 raw 0.49 → linear-μ 1.28 → S-curve 1.19   (clean sibling node2 raw 2.81)
```
Raw IC falsely rates the leaked node as *general* (gap 2.32 to its clean sibling); partial admission
raises it to ~1.2–1.3, closing the false gap. `μ≡1` recovers the distinct-count IC; the S-curve fits
the anchors and is monotone.

Documented in §5d, including the note that this is exactly where membership *matters* — a **global**
cone read-out, unlike the membership-robust per-pair caret. Full suite: **86 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_