### PR TITLE
Support PLAWK literal contains pattern guards

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -252,8 +252,11 @@ prints matching records from a text file without calling `run_loop` in the hot
 record loop. The reusable file open/read/eof/close skeleton now lives in the
 WAM/LLVM target as `llvm_emit_stream_driver_ir/3`, so PLAWK supplies only the
 surface-specific globals, per-record lowering, continuation phis, and close
-block. The field-equality path scans fields in native code without
-allocating substrings; selected-field printing projects byte slices directly.
+block. Literal contains-pattern rules such as `/disk/ { print $0 }` lower to
+whole-record native index checks; the only regex metacharacter currently
+special-cased is the existing leading `^` prefix shortcut. The field-equality
+path scans fields in native code without allocating substrings; selected-field
+printing projects byte slices directly.
 Rule prints can include native `NR`, implemented as a record-number `i64` phi in
 the print-only streaming loop, and native `NF`, implemented with the shared
 `@wam_atom_field_count_value` helper over the active single-byte `FS`. Rule

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -75,7 +75,8 @@ swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
-The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }` and
+The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }`,
+literal contains-pattern rules such as `/disk/ { print $0 }`, and
 `$1 == "ERROR" { print $0 }`, plus selected-field actions such as
 `$1 == "ERROR" { print $2, $3 }`. Rule prints can include native `NR` and
 `NF`, e.g. `$1 == "ERROR" { print NR, NF, $2, $3 }`, plus native field lengths

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -123,11 +123,13 @@ The Phase 0 examples use the counter as `NR`, collect printed lines in
 The native Phase 2 surface can compile rule prints with `NR`, `NF`, selected
 fields, native field lengths such as `length($2)`, native byte substrings such as
 `substr($2, 1, 3)`, and `OFS`, matching the first awk-style example above. It can
-also print explicit numeric field coercions with `int($N)`, where missing or
-non-numeric fields become `0`, and the first arithmetic composition forms add
-or subtract a non-negative integer constant from native `i64` primaries such as
-`NR`, `NF`, `length($N)`, and `int($N)`. It can also compile a scalar counter
-and an `END` action:
+also compile literal contains-pattern rules such as `/disk/ { print $0 }`, where
+the current `/.../` subset treats the body as a literal byte substring unless it
+uses the existing `^` prefix fast path. It can also print explicit numeric field
+coercions with `int($N)`, where missing or non-numeric fields become `0`, and
+the first arithmetic composition forms add or subtract a non-negative integer
+constant from native `i64` primaries such as `NR`, `NF`, `length($N)`, and
+`int($N)`. It can also compile a scalar counter and an `END` action:
 
 ```awk
 $1 == "ERROR" { count++ } END { print count }

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -29,6 +29,7 @@
 %  Emit the first native Phase-2 PLAWK driver shape:
 %
 %      /^PREFIX/ { print $0 }
+%      /LITERAL/ { print $0 }
 %      $N == "VALUE" { print $0 }
 %      $N == "VALUE" { print $M, $K }
 %      $N == "VALUE" { count++ } END { print count }
@@ -1865,6 +1866,8 @@ plawk_pattern_guard_ir(always, GuardIR) :-
 plawk_pattern_guard_ir(prefix(Prefix), GuardIR) :-
     llvm_emit_atom_prefix_guard(plawk_surface_prefix, '%line', Prefix,
         '%is_match', GuardIR).
+plawk_pattern_guard_ir(contains(Needle), GuardIR) :-
+    plawk_pattern_guard_ir(contains(Needle), 32, GuardIR).
 
 plawk_pattern_guard_ir(field_eq(Index, Value), GuardIR) :-
     plawk_pattern_guard_ir(field_eq(Index, Value), 32, GuardIR).
@@ -1875,6 +1878,9 @@ plawk_pattern_guard_ir(always, _FieldSeparator, GuardIR) :-
     plawk_pattern_guard_ir(always, GuardIR).
 plawk_pattern_guard_ir(prefix(Prefix), _FieldSeparator, GuardIR) :-
     plawk_pattern_guard_ir(prefix(Prefix), GuardIR).
+plawk_pattern_guard_ir(contains(Needle), FieldSeparator, GuardIR) :-
+    plawk_literal_contains_guard_ir(plawk_surface_contains, Needle, FieldSeparator,
+        '%is_match', GuardIR).
 plawk_pattern_guard_ir(field_eq(Index, Value), FieldSeparator, GuardIR) :-
     llvm_emit_atom_field_eq_guard(plawk_surface_field_eq, '%line', Index, Value,
         FieldSeparator, '%is_match', GuardIR).
@@ -1890,6 +1896,8 @@ plawk_pattern_guard_ir(always, _GlobalBase, MatchValue, GuardIR) :-
 plawk_pattern_guard_ir(prefix(Prefix), GlobalBase, MatchValue, GuardIR) :-
     llvm_emit_atom_prefix_guard(GlobalBase, '%line', Prefix, MatchValue,
         GuardIR).
+plawk_pattern_guard_ir(contains(Needle), GlobalBase, MatchValue, GuardIR) :-
+    plawk_pattern_guard_ir(contains(Needle), 32, GlobalBase, MatchValue, GuardIR).
 
 plawk_pattern_guard_ir(field_eq(Index, Value), GlobalBase, MatchValue, GuardIR) :-
     plawk_pattern_guard_ir(field_eq(Index, Value), 32, GlobalBase, MatchValue,
@@ -1902,6 +1910,9 @@ plawk_pattern_guard_ir(always, _FieldSeparator, GlobalBase, MatchValue, GuardIR)
     plawk_pattern_guard_ir(always, GlobalBase, MatchValue, GuardIR).
 plawk_pattern_guard_ir(prefix(Prefix), _FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     plawk_pattern_guard_ir(prefix(Prefix), GlobalBase, MatchValue, GuardIR).
+plawk_pattern_guard_ir(contains(Needle), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
+    plawk_literal_contains_guard_ir(GlobalBase, Needle, FieldSeparator, MatchValue,
+        GuardIR).
 plawk_pattern_guard_ir(field_eq(Index, Value), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     llvm_emit_atom_field_eq_guard(GlobalBase, '%line', Index, Value, FieldSeparator,
         MatchValue, GuardIR).
@@ -1909,6 +1920,15 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, _GlobalBase,
     plawk_field_cmp_op_code(Op, OpCode),
     llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
         FieldSeparator, MatchValue, GuardCallIR).
+
+plawk_literal_contains_guard_ir(GlobalBase, Needle, FieldSeparator, MatchValue, GlobalIR-GuardCallIR) :-
+    format(atom(IndexBase), '~w_contains_index', [GlobalBase]),
+    llvm_emit_atom_field_index(GlobalBase, '%line', 0, Needle, FieldSeparator,
+        IndexBase, GlobalIR-IndexCallIR),
+    format(atom(GuardCallIR),
+'~w
+  ~w = icmp sgt i64 %~w, 0',
+        [IndexCallIR, MatchValue, IndexBase]).
 
 plawk_field_cmp_op_code(eq, 0).
 plawk_field_cmp_op_code(ne, 1).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -10,6 +10,7 @@
 %  Parse the first Phase-2 surface slice:
 %
 %      /^PREFIX/ { print $0 }
+%      /LITERAL/ { print $0 }
 %      $N == "VALUE" { print $0 }
 %      $N == "VALUE" { print $M, $K }
 %      $N == "VALUE" { count++ } END { print count }
@@ -82,6 +83,9 @@ pattern(Pattern) -->
     prefix_pattern(Pattern),
     !.
 pattern(Pattern) -->
+    literal_pattern(Pattern),
+    !.
+pattern(Pattern) -->
     field_i64_cmp_pattern(Pattern),
     !.
 pattern(Pattern) -->
@@ -93,6 +97,14 @@ prefix_pattern(prefix(Prefix)) -->
     "/",
     { Codes \== [],
       string_codes(Prefix, Codes)
+    }.
+
+literal_pattern(contains(Literal)) -->
+    "/",
+    literal_pattern_codes(Codes),
+    "/",
+    { Codes \== [],
+      string_codes(Literal, Codes)
     }.
 
 field_eq_pattern(field_eq(Index, Value)) -->
@@ -151,6 +163,25 @@ prefix_codes_rest([Code | Codes]) -->
     !,
     prefix_codes_rest(Codes).
 prefix_codes_rest([]) -->
+    [].
+
+literal_pattern_codes([Code | Codes]) -->
+    [Code],
+    { Code =\= 0'/,
+      Code =\= 0'\n,
+      Code =\= 0'\r
+    },
+    literal_pattern_codes_rest(Codes).
+
+literal_pattern_codes_rest([Code | Codes]) -->
+    [Code],
+    { Code =\= 0'/,
+      Code =\= 0'\n,
+      Code =\= 0'\r
+    },
+    !,
+    literal_pattern_codes_rest(Codes).
+literal_pattern_codes_rest([]) -->
     [].
 
 integer_codes([Code | Codes]) -->

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -25,6 +25,10 @@ test(parses_prefix_print_rule) :-
     plawk_parse_string("/^ERROR/ { print $0 }\n", Program),
     assertion(Program == program([], [rule(prefix("ERROR"), [print([field(0)])])], [])).
 
+test(parses_literal_pattern_print_rule) :-
+    plawk_parse_string("/disk/ { print $0 }\n", Program),
+    assertion(Program == program([], [rule(contains("disk"), [print([field(0)])])], [])).
+
 test(parses_field_eq_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print $0 }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [print([field(0)])])], [])).
@@ -442,6 +446,16 @@ test(surface_prefix_prints_matching_records) :-
     run_surface_print_smoke("/^ERROR/ { print $0 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "ERROR disk full\nERROR net down\n").
+
+test(surface_literal_pattern_prints_containing_records) :-
+    run_surface_print_smoke("/disk/ { print $0 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "ERROR disk full\n").
+
+test(surface_literal_pattern_counts_containing_records) :-
+    run_surface_print_smoke("/disk/ { hits++ } END { print hits }\n",
+        "INFO boot ok\nERROR disk full\nWARN disk hot\nERROR net down\n",
+        "2\n").
 
 test(surface_field_eq_prints_matching_records) :-
     run_surface_print_smoke("$1 == \"ERROR\" { print $0 }\n",
@@ -952,6 +966,15 @@ test(surface_assoc_counts_long_record_first_field) :-
     format(string(Input), 'KEY ~w~n', [Payload]),
     run_surface_print_smoke("{ counts[$1]++ } END { print counts[\"KEY\"] }\n",
         Input, "1\n").
+
+test(surface_literal_pattern_uses_native_index_guard) :-
+    plawk_parse_string("/disk/ { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_5Fsurface_5Fcontains = private constant [5 x i8] c"disk\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_surface_contains_contains_index = call i64 @wam_atom_field_index_value(%Value %line, i64 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%is_match = icmp sgt i64 %plawk_surface_contains_contains_index, 0'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
 
 test(surface_assoc_counts_use_runtime_table) :-
     plawk_parse_string("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n", Program),


### PR DESCRIPTION
  Adds a narrow PLAWK Phase 2 pattern-guard slice for `/literal/ { ... }` rules.

  - Parses `/literal/` as a literal whole-record contains pattern.
  - Preserves `/^literal/` on the existing native prefix fast path.
  - Lowers contains guards through native whole-record index checks via `@wam_atom_field_index_value`.
  - Keeps supported programs out of `@run_loop` in the hot record path.
  - Adds parser, smoke, and IR coverage.
  - Updates PLAWK docs to clarify this is literal substring matching, not full regex semantics.

  Verification:
  - Focused literal-pattern tests passed.
  - `tests/test_plawk_surface_prefix_print.pl`: 221/221 passed.
  - Surrounding PLAWK core/native suites passed.
  - `git diff --check` passed.