### PR TITLE
WAM-Rust: μ-weighted KMV sketch — scalable partial-admission IC + leak-robust global fan-in

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -797,10 +797,28 @@ calibration of the relatedness read-out.)
 > sibling. The admission weight need not be linear in `μ`: `fuzzy_admission` is an **S-curve**
 > (logistic) transfer `w(μ) = 1/(1+e^{−k(μ−c)})` — default `c=0.55, k≈4.39` fits the anchors
 > `w(0.8)=0.75`, `w(0.3)=0.25` — for a nearly-full/nearly-zero admission with a tunable knee.
-> *Scaling caveat:* `descendant_mu_mass` is exact (per-node BFS, `O(V·(V+E))`); the large-graph form
-> wants a **`μ`-weighted MinHash** sketch (the weighted analogue of `descendant_minhash`), future
-> work. And this is exactly where membership *matters* (per §-aside): a read-out over the *global*
-> cone, not the per-pair caret, which is membership-robust.
+> *Scaling — now done:* `descendant_mu_mass` is exact (per-node BFS, `O(V·(V+E))`); the large-graph
+> form is `descendant_minhash_weighted`, a **`μ`-weighted KMV sketch** built in one reverse-topo pass
+> (`O((V+E)·k)`). Each element is a `(hash, μ)` pair kept as the bottom-`k` by hash (deduped ⇒
+> diamonds once); because the hashes are drawn independently of `μ`, the bottom-`k` is a *uniform*
+> sample of the cone and the carried weights are an unbiased sample of its weight distribution, so the
+> mass read-out is `m̂_μ = D̂ · μ̄_sample` — the Cohen–Kaplan bottom-`k` subset-sum estimator
+> (`sketch_mu_mass`), exact while unsaturated and reducing to `sketch_card` at `μ ≡ 1`.
+> `information_content_weighted_sketch` is the drop-in scalable IC (clamping the estimate at
+> `total_mu`, the mass analogue of the `.min(1.0)` ratio clamp). And this is exactly where membership
+> *matters* (per §-aside): a read-out over the *global* cone, not the per-pair caret (membership-
+> robust). Two global hooks the weighted sketch unlocks:
+> - **Leak-robust fan-in** (`sketch_mu_overlap`): the μ-weighted mass two cones *share* (Broder
+>   bottom-`k` intersection, weighted). A funnel hub is one many cones reach, but a weighted funnel
+>   discounts the associative leak — cones overlapping only on low-μ descendants score ≈ 0 — so hub
+>   selection stops being fooled by the leak. (Measured: core-shared overlap `3.00` vs leak-shared
+>   `0.15`.)
+> - **Depth-stability** (`mu_weighted_count_is_depth_stable`): the raw cone count *explodes* toward
+>   the root as the leak accumulates (more deep nodes than shallow), but the weighted mass barely
+>   moves because the deep nodes are out-of-domain — on the spine test the raw cone grows `201 → 645`
+>   (+444) while the μ-mass grows only `5 → 18` (+13), ~3% of the raw growth. So the **weighted count
+>   converges as you descend** where the raw count diverges: a depth-robust global signal, which is
+>   the property the global hub problem needs.
 >
 > **Novel-contribution flag.** Resnik-style IC over a frequency null (Resnik 1995; Seco 2004's
 > intrinsic descendant-count form) is established; *graded* (fuzzy `μ ∈ [0,1]`) **partial admission**

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -802,8 +802,13 @@ calibration of the relatedness read-out.)
 > (`O((V+E)·k)`). Each element is a `(hash, μ)` pair kept as the bottom-`k` by hash (deduped ⇒
 > diamonds once); because the hashes are drawn independently of `μ`, the bottom-`k` is a *uniform*
 > sample of the cone and the carried weights are an unbiased sample of its weight distribution, so the
-> mass read-out is `m̂_μ = D̂ · μ̄_sample` — the Cohen–Kaplan bottom-`k` subset-sum estimator
-> (`sketch_mu_mass`), exact while unsaturated and reducing to `sketch_card` at `μ ≡ 1`.
+> mass read-out is `m̂_μ = D̂ · μ̄_sample` — a bottom-`k` *plug-in* (ratio) subset-sum estimator
+> (`sketch_mu_mass`), in the spirit of Cohen–Kaplan bottom-`k` sketches (PODC/SIGMETRICS 2007), but
+> *not* their VLDB 2008 Horvitz–Thompson form (per-item adjusted weights, zero covariance, formally
+> tighter); the product is unbiased to `O(1/k)`. Exact while unsaturated and reducing to `sketch_card`
+> at `μ ≡ 1`. (This is *carry-weight KMV* — uniform hash + weight as side data — **not** Weighted
+> MinHash à la Ioffe 2010, which bakes the weight into the hash to estimate the weighted Jaccard
+> `J_w`; this sketch estimates weighted *mass*, not `J_w`. `k ≥ 2`; `D̂` is capped at the node count.)
 > `information_content_weighted_sketch` is the drop-in scalable IC (clamping the estimate at
 > `total_mu`, the mass analogue of the `.min(1.0)` ratio clamp). And this is exactly where membership
 > *matters* (per §-aside): a read-out over the *global* cone, not the per-pair caret (membership-
@@ -1218,7 +1223,12 @@ Each is referenced inline at the section that uses it.
   Distinct-Value Estimation Under Multiset Operations.* SIGMOD 2007. — the bottom-`k` / KMV
   `(k−1)/ĥ_k` cardinality estimator (`sketch_card`).
 - Cohen, E., & Kaplan, H. (2007). *Summarizing Data Using Bottom-k Sketches.* PODC 2007. — the
-  one-pass bottom-`k` Jaccard estimator (`sketch_jaccard`).
+  one-pass bottom-`k` Jaccard estimator (`sketch_jaccard`); the bottom-`k` plug-in subset-sum form
+  that `sketch_mu_mass` follows (their VLDB 2008 *Tighter Estimation* Horvitz–Thompson RC/SC
+  estimators are the formally tighter alternative not used here).
+- Ioffe, S. (2010). *Improved Consistent Sampling, Weighted Minhash and L1 Sketching.* ICDM 2010. —
+  Weighted MinHash (weight baked into the hash to estimate weighted Jaccard `J_w`); contrasted with
+  the *carry-weight KMV* of `descendant_minhash_weighted`, which estimates weighted mass, not `J_w`.
 
 **2-hop cover / hub labeling and landmark distance (§5c, roadmap 3f).**
 - Cohen, E., Halperin, E., Kaplan, H., & Zwick, U. (2002/2003). *Reachability and Distance

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -808,11 +808,26 @@ calibration of the relatedness read-out.)
 > tighter); the product is unbiased to `O(1/k)`. Exact while unsaturated and reducing to `sketch_card`
 > at `μ ≡ 1`. (This is *carry-weight KMV* — uniform hash + weight as side data — **not** Weighted
 > MinHash à la Ioffe 2010, which bakes the weight into the hash to estimate the weighted Jaccard
-> `J_w`; this sketch estimates weighted *mass*, not `J_w`. `k ≥ 2`; `D̂` is capped at the node count.)
+> `J_w`; this sketch estimates weighted *mass*, not `J_w`. `k ≥ 2` is required.)
 > `information_content_weighted_sketch` is the drop-in scalable IC (clamping the estimate at
 > `total_mu`, the mass analogue of the `.min(1.0)` ratio clamp). And this is exactly where membership
 > *matters* (per §-aside): a read-out over the *global* cone, not the per-pair caret (membership-
-> robust). Two global hooks the weighted sketch unlocks:
+> robust).
+>
+> *Cardinality-cap knob (`CardCap`).* `D̂ = (k−1)/ĥ_k` is unbounded in principle: a pathologically
+> tiny `ĥ_k` can blow it to `~10¹⁹`, polluting the raw mass and hub score. The read-outs take a
+> configurable cap — passable as the explicit enum *or* a bare number (`usize ⇒ Universe`, `f64 ⇒
+> Ceiling`):
+> - **`Universe(N)`** — cap at the node count. A cone (or union of cones) is `⊆` the graph, so
+>   `D̂ ≤ N` is an *exact, tight* bound that also clips ordinary KMV over-estimates, cutting variance
+>   near the root. **Recommended whenever `N` is known** (the usual case). Cost: pass `N`.
+> - **`Ceiling(c)`** — a fixed ceiling. For streaming / incrementally-built graphs where `N` is
+>   unknown or expensive, or when comparing cones *across* differently-sized graphs (a size-independent
+>   ceiling). A pure overflow guard if set well above any real cone. Default is `Ceiling(1e12)`.
+> - **`Uncapped`** — raw KMV; only when a downstream stage clamps anyway (the IC read-out already does
+>   `.min(total_mu)`) or in tests.
+>
+> Two global hooks the weighted sketch unlocks:
 > - **Leak-robust fan-in** (`sketch_mu_overlap`): the μ-weighted mass two cones *share* (Broder
 >   bottom-`k` intersection, weighted). A funnel hub is one many cones reach, but a weighted funnel
 >   discounts the associative leak — cones overlapping only on low-μ descendants score ≈ 0 — so hub

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -1606,12 +1606,20 @@ pub fn descendant_mu_mass(
 /// drawn independently of `μ`, so the bottom-`k` is a *uniform* sample of the distinct cone and the
 /// weights on it are an unbiased sample of the cone's weight distribution — that is what makes the
 /// read-out work. `None` on a cyclic graph (no reverse-topo order); SCC-condense first.
+///
+/// **Naming:** this is a *carry-weight KMV* / *weighted bottom-`k`* sketch — uniform hashes with the
+/// weight carried as side data — **not** Weighted MinHash (Ioffe 2010), which encodes the weight
+/// *into* the hash so collision probability equals the weighted Jaccard `J_w`. This sketch cannot
+/// estimate `J_w`; it estimates weighted *mass* (`sketch_mu_mass`) and shared mass
+/// (`sketch_mu_overlap`). `k ≥ 2` is required (the `(k−1)/ĥ_k` cardinality read is undefined at
+/// `k=1` and panics at `k=0`).
 pub fn descendant_minhash_weighted(
     parents: &std::collections::HashMap<u32, Vec<u32>>,
     mu: &std::collections::HashMap<u32, f64>,
     k: usize,
 ) -> Option<std::collections::HashMap<u32, Vec<(u64, f64)>>> {
     use std::collections::{HashMap, HashSet, VecDeque};
+    debug_assert!(k >= 2, "k must be ≥ 2: the (k−1)/ĥ_k estimator is undefined at k=1 and panics at k=0");
     debug_assert!(
         mu.values().all(|&w| (0.0..=1.0).contains(&w)),
         "membership weights μ must lie in [0,1]"
@@ -1653,13 +1661,20 @@ pub fn descendant_minhash_weighted(
 
 /// Bottom-`k` **subset-sum** read-out: estimate `m_μ = Σ_{d∈cone} μ_d` from a μ-weighted sketch.
 /// While unsaturated (`< k` pairs kept) the cone is fully captured, so this is the **exact** sum.
-/// Once saturated it is the Cohen–Kaplan bottom-`k` estimator `m̂_μ = D̂ · μ̄_sample` — the distinct
-/// cardinality `D̂ = (k−1)/ĥ_k` (the KMV estimate, identical to `sketch_card`) times the mean weight
-/// over the `k` sampled pairs. Because the bottom-`k` is a uniform sample of the cone independent of
-/// `μ`, `μ̄_sample` is unbiased for the cone's mean weight, so the product estimates the total mass.
-/// At `μ ≡ 1` it reduces exactly to `sketch_card` (the unweighted distinct count). Error is the KMV
-/// `∝ 1/√k` plus the sampling variance of `μ̄`, both tunable by `k`.
-pub fn sketch_mu_mass(s: &[(u64, f64)], k: usize) -> f64 {
+/// Once saturated it is a bottom-`k` *plug-in* subset-sum estimator `m̂_μ = D̂ · μ̄_sample` — the
+/// distinct cardinality `D̂ = (k−1)/ĥ_k` (the KMV estimate, identical to `sketch_card`) times the
+/// mean weight over the `k` sampled pairs. Because the bottom-`k` is a uniform sample of the cone
+/// independent of `μ`, `μ̄_sample` is unbiased for the cone's mean weight; the product is unbiased to
+/// `O(1/k)` (a ratio-estimator term). This is *in the spirit of* Cohen–Kaplan bottom-`k` sketches
+/// (PODC/SIGMETRICS 2007), but it is **not** their VLDB 2008 Horvitz–Thompson form (per-item adjusted
+/// weights, zero covariance), which is formally tighter. At `μ ≡ 1` it reduces exactly to
+/// `sketch_card`. Error is the KMV `∝ 1/√k` plus the `μ̄` sampling variance, both tunable by `k`.
+///
+/// `n_universe` is the total node count — the cardinality `D̂` cannot exceed it (a distinct cone is a
+/// subset of the graph), so `D̂` is capped at `n_universe` to defend against a pathologically tiny
+/// `ĥ_k` blowing `(k−1)/ĥ_k` up to `~10¹⁹`. `k ≥ 2` (`k=1` makes `(k−1)/ĥ_k ≡ 0`).
+pub fn sketch_mu_mass(s: &[(u64, f64)], k: usize, n_universe: usize) -> f64 {
+    debug_assert!(k >= 2, "k must be ≥ 2: k=1 makes (k−1)/ĥ_k ≡ 0 (mass 0 ⇒ IC 0), k=0 panics");
     if s.is_empty() {
         return 0.0;
     }
@@ -1667,7 +1682,8 @@ pub fn sketch_mu_mass(s: &[(u64, f64)], k: usize) -> f64 {
         return s.iter().map(|&(_, w)| w).sum(); // unsaturated ⇒ exact
     }
     let hk = s[k - 1].0 as f64 / (u64::MAX as f64 + 1.0);
-    let card = if hk <= 0.0 { s.len() as f64 } else { (k as f64 - 1.0) / hk };
+    let raw_card = if hk <= 0.0 { s.len() as f64 } else { (k as f64 - 1.0) / hk };
+    let card = raw_card.min(n_universe as f64); // cone ⊆ graph ⇒ D̂ ≤ N (caps tiny-ĥ_k overflow)
     let mean_w = s.iter().map(|&(_, w)| w).sum::<f64>() / s.len() as f64;
     card * mean_w
 }
@@ -1675,11 +1691,20 @@ pub fn sketch_mu_mass(s: &[(u64, f64)], k: usize) -> f64 {
 /// Scalable **μ-weighted IC**: `information_content_weighted` fed by the sketch mass instead of the
 /// exact `descendant_mu_mass`. The drop-in large-graph form of partial-admission IC — same
 /// `−log₂(m_μ/M_μ)`, but `m_μ` is the `O((V+E)·k)` sketch estimate. `total_mu` is still the exact
-/// universe mass `Σ_all μ` (cheap: one pass over the μ-map). The sketch estimate can overshoot
-/// `total_mu` by KMV sampling noise near the root (cone ≈ universe), so it is clamped at `total_mu`
-/// before the log — the mass analogue of `information_content`'s `.min(1.0)` ratio clamp.
-pub fn information_content_weighted_sketch(s: &[(u64, f64)], total_mu: f64, k: usize) -> f64 {
-    information_content_weighted(sketch_mu_mass(s, k).min(total_mu), total_mu)
+/// universe mass `Σ_all μ` (cheap: one pass over the μ-map); `n_universe` the node count (cone cap).
+/// The sketch estimate can overshoot `total_mu` by KMV sampling noise near the root (cone ≈ universe),
+/// so it is clamped at `total_mu` before the log — the mass analogue of `information_content`'s
+/// `.min(1.0)` ratio clamp.
+///
+/// **DEPENDENCY:** the zero-mass semantics are inherited from `information_content_weighted`, which
+/// returns `+∞` for an empty cone (`m_μ = 0`, the maximal-surprise limit). Near zero mass the *sketch*
+/// path is high-variance: the saturated sample can miss the cone's few in-domain nodes and read
+/// `μ̄_sample = 0 ⇒ m̂_μ = 0 ⇒ IC = +∞` even when the exact mass is small-positive (or vice versa). So
+/// the exact and sketch IC agree at *exactly* zero (both `+∞`) and in the bulk, but can diverge in a
+/// thin near-zero band — use the exact `descendant_mu_mass` path when the mass is near zero and the
+/// distinction matters.
+pub fn information_content_weighted_sketch(s: &[(u64, f64)], total_mu: f64, k: usize, n_universe: usize) -> f64 {
+    information_content_weighted(sketch_mu_mass(s, k, n_universe).min(total_mu), total_mu)
 }
 
 /// **μ-weighted cone-overlap mass** — the global-hub read-out. Estimates `Σ_{d∈A∩B} μ_d`, the
@@ -1690,8 +1715,22 @@ pub fn information_content_weighted_sketch(s: &[(u64, f64)], total_mu: f64, k: u
 /// signal: a *funnel* hub is one many cones reach, but a μ-weighted funnel discounts the associative
 /// leak — two cones that overlap only on low-μ (out-of-domain) descendants score near zero, so hub
 /// selection stops being fooled by the leak. `0` if either sketch is empty.
-pub fn sketch_mu_overlap(a: &[(u64, f64)], b: &[(u64, f64)], k: usize) -> f64 {
+///
+/// **Estimator:** algebraically `D̂_∪ · mean_{d∈union sample}( μ_d · 𝟙[d∈A∩B] )` — the *same* single
+/// product estimator as `sketch_mu_mass`, with the intersection indicator folded into a 0/1-gated μ
+/// (not a Jaccard estimate times a separate conditional mean). Both factors are read off the *same*
+/// union sample, so their variance compounds, and `mean_shared_w` divides by `shared.len()`, which is
+/// small exactly when the leak-discount bites (few shared high-μ elements). **Use as a ranking signal,
+/// not an absolute mass** — it is high-variance in the low-overlap regime.
+///
+/// **Precondition:** `a` and `b` must have been built with the *same* `k` (the Broder union-bottom-`k`
+/// argument requires it); mixing `k`s silently biases `D̂_∪`. `n_universe` caps `D̂_∪` (a union of
+/// cones is `⊆` the graph), defending against a tiny `ĥ_k` overflow exactly as in `sketch_mu_mass`.
+pub fn sketch_mu_overlap(a: &[(u64, f64)], b: &[(u64, f64)], k: usize, n_universe: usize) -> f64 {
     use std::collections::HashMap;
+    debug_assert!(k >= 2, "k must be ≥ 2");
+    debug_assert!(a.len() <= k && b.len() <= k,
+        "both sketches must be built with the same k; mixing k biases the union-card estimate");
     if a.is_empty() || b.is_empty() {
         return 0.0;
     }
@@ -1717,7 +1756,7 @@ pub fn sketch_mu_overlap(a: &[(u64, f64)], b: &[(u64, f64)], k: usize) -> f64 {
     let union_card = if union.len() < k || hk <= 0.0 {
         union.len() as f64
     } else {
-        (k as f64 - 1.0) / hk
+        ((k as f64 - 1.0) / hk).min(n_universe as f64) // cap tiny-ĥ_k overflow (union ⊆ graph)
     };
     // jaccard-by-mass: (shared count / sample size) gives |A∩B|/|A∪B|; multiply by union mass-per-sample.
     let mean_shared_w = shared.iter().sum::<f64>() / shared.len() as f64;
@@ -4544,12 +4583,13 @@ mod tests {
         let total_mu: f64 = mu.values().sum();
 
         let exact = descendant_mu_mass(&g, &mu);
+        let n = exact.len(); // universe node count (cone cap)
         let wsig = descendant_minhash_weighted(&g, &mu, K).unwrap();
         for (&node, &m) in &exact {
-            let est = sketch_mu_mass(&wsig[&node], K);
+            let est = sketch_mu_mass(&wsig[&node], K, n);
             assert!((est - m).abs() < 1e-9, "node {node}: sketch mass {est} != exact {m}");
             // Scalable IC must match the exact-mass IC.
-            let ic_sketch = information_content_weighted_sketch(&wsig[&node], total_mu, K);
+            let ic_sketch = information_content_weighted_sketch(&wsig[&node], total_mu, K, n);
             let ic_exact = information_content_weighted(m, total_mu);
             assert!((ic_sketch - ic_exact).abs() < 1e-9, "node {node}: IC mismatch");
         }
@@ -4559,9 +4599,38 @@ mod tests {
         let w1 = descendant_minhash_weighted(&g, &mu_one, K).unwrap();
         let d = descendant_minhash(&g, K).unwrap();
         for &node in mu.keys() {
-            assert!((sketch_mu_mass(&w1[&node], K) - sketch_card(&d[&node], K)).abs() < 1e-9,
+            assert!((sketch_mu_mass(&w1[&node], K, n) - sketch_card(&d[&node], K)).abs() < 1e-9,
                 "node {node}: μ≡1 sketch mass != unweighted distinct count");
         }
+    }
+
+    // R2/NB6 + DEPENDENCY: zero-mass IC and the None-on-cycle path. A node whose whole cone is
+    // out-of-domain (μ≡0) has m_μ=0 ⇒ IC=+∞ in BOTH the exact and the sketch path (the sketch's
+    // sampled mean weight is also 0), so they agree at exactly zero — pinning the inherited #3271
+    // +∞ semantics. And a cyclic graph yields None (no reverse-topo order).
+    #[test]
+    fn mu_weighted_sketch_zero_mass_is_infinite_and_cycle_is_none() {
+        const K: usize = 8;
+        // Star: 1,2,3 -> 0. μ≡0 over the cone of node 0 (everything out of domain) but a positive
+        // universe mass elsewhere so total_mu>0 (the empty-cone, not empty-universe, case).
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        g.insert(1, vec![0]); g.insert(2, vec![0]); g.insert(3, vec![0]);
+        let mut mu: HashMap<u32, f64> = [(0u32, 0.0), (1, 0.0), (2, 0.0), (3, 0.0)].into_iter().collect();
+        mu.insert(99, 1.0); // an out-of-cone node carrying the universe mass
+        let total_mu: f64 = mu.values().sum(); // = 1.0 > 0
+        let w = descendant_minhash_weighted(&g, &mu, K).unwrap();
+        let n = mu.len();
+        let exact = descendant_mu_mass(&g, &mu);
+        assert_eq!(exact[&0], 0.0, "cone of 0 is fully out of domain");
+        assert!(information_content_weighted(exact[&0], total_mu).is_infinite(), "exact zero-mass ⇒ +∞");
+        assert!(information_content_weighted_sketch(&w[&0], total_mu, K, n).is_infinite(),
+            "sketch zero-mass ⇒ +∞ (agrees with exact at exactly zero)");
+
+        // None on a cycle (0 <-> 1).
+        let mut cyc: HashMap<u32, Vec<u32>> = HashMap::new();
+        cyc.insert(0, vec![1]); cyc.insert(1, vec![0]);
+        let cmu: HashMap<u32, f64> = [(0u32, 1.0), (1, 1.0)].into_iter().collect();
+        assert!(descendant_minhash_weighted(&cyc, &cmu, K).is_none(), "cycle ⇒ None");
     }
 
     // At scale the sketch is approximate (k << cone): build a wide tree, check the weighted-mass
@@ -4584,20 +4653,24 @@ mod tests {
         }
         let total_mu: f64 = mu.values().sum();
         let exact = descendant_mu_mass(&g, &mu);
+        let n = exact.len();
         let wsig = descendant_minhash_weighted(&g, &mu, K).unwrap();
 
-        let est_root = sketch_mu_mass(&wsig[&0], K);
+        let est_root = sketch_mu_mass(&wsig[&0], K, n);
         let rel_err = (est_root - exact[&0]).abs() / exact[&0];
+        // 20% tolerance is a non-flaky ~1.7σ guard: at k=256 the KMV cardinality CV ≈ 1/√(k−2) ≈ 6.3%
+        // and the μ̄ sampling CV ≈ std(μ)/mean(μ)/√k ≈ 10% for this mixture; they add in quadrature
+        // (≈12%), plus an O(1/k) ratio-bias term, over a single draw. Do NOT tighten into flakiness.
         assert!(rel_err < 0.20, "root mass est {est_root} vs exact {} (rel err {:.3})", exact[&0], rel_err);
 
         // A leaf cone is a single node ⇒ unsaturated ⇒ exact.
         let leaf = next - 1;
-        assert!((sketch_mu_mass(&wsig[&leaf], K) - exact[&leaf]).abs() < 1e-12, "leaf must be exact");
+        assert!((sketch_mu_mass(&wsig[&leaf], K, n) - exact[&leaf]).abs() < 1e-12, "leaf must be exact");
 
         // IC is finite and ordered: the root (huge cone) is less specific than a graded child.
-        let ic_root = information_content_weighted_sketch(&wsig[&0], total_mu, K);
+        let ic_root = information_content_weighted_sketch(&wsig[&0], total_mu, K, n);
         let child1 = 1u32;
-        let ic_child = information_content_weighted_sketch(&wsig[&child1], total_mu, K);
+        let ic_child = information_content_weighted_sketch(&wsig[&child1], total_mu, K, n);
         assert!(ic_root < ic_child, "root must be more general (lower IC) than a child");
         eprintln!("μ-sketch @scale: root mass exact {:.1} est {:.1} (rel {:.1}%), IC root {:.2} child {:.2}",
             exact[&0], est_root, 100.0 * rel_err, ic_root, ic_child);
@@ -4622,20 +4695,47 @@ mod tests {
         for u in [1u32, 2, 10, 11, 12, 13, 20, 21, 22, 23] { leak.insert(u, 1.0); }
         leak.insert(50, 0.05); leak.insert(90, 0.05); leak.insert(91, 0.05);
         let wl = descendant_minhash_weighted(&g, &leak, K).unwrap();
-        let ov_leak = sketch_mu_overlap(&wl[&1], &wl[&2], K);
+        let nl = leak.len();
+        let ov_leak = sketch_mu_overlap(&wl[&1], &wl[&2], K, nl);
 
         // Case 2: shared set is the CORE (μ high). Overlap mass should be larger.
         let mut core: HashMap<u32, f64> = leak.clone();
         core.insert(50, 1.0); core.insert(90, 1.0); core.insert(91, 1.0);
         let wc = descendant_minhash_weighted(&g, &core, K).unwrap();
-        let ov_core = sketch_mu_overlap(&wc[&1], &wc[&2], K);
+        let ov_core = sketch_mu_overlap(&wc[&1], &wc[&2], K, core.len());
 
         assert!(ov_core > ov_leak + 1.0, "μ-overlap must discount the leak: core {ov_core} vs leak {ov_leak}");
         // Disjoint cones share nothing ⇒ ~0 overlap (hub 1 vs a private leaf cone).
         let priv_only = descendant_minhash_weighted(&{ let mut h = HashMap::new();
             h.insert(30u32, vec![1u32]); h.insert(40u32, vec![2u32]); h }, &core, K).unwrap();
-        assert!(sketch_mu_overlap(&priv_only[&30], &priv_only[&40], K) < 1e-9, "disjoint ⇒ no overlap");
+        assert!(sketch_mu_overlap(&priv_only[&30], &priv_only[&40], K, core.len()) < 1e-9, "disjoint ⇒ no overlap");
         eprintln!("μ-overlap: leak-shared {:.2} vs core-shared {:.2} (leak-robust fan-in)", ov_leak, ov_core);
+    }
+
+    // NB4: sketch_mu_overlap in the SATURATED (approximate) regime, not just the tiny exact graphs.
+    // Two cones with a large shared CORE subtree (high-μ) and large private leaf bundles; with
+    // k << cone the Broder union-bottom-k still recovers the shared mass as a ranking signal within
+    // tolerance. Checked against the exact shared mass Σ_{d∈A∩B} μ_d.
+    #[test]
+    fn mu_weighted_overlap_saturated_regime() {
+        const K: usize = 256;
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        let mut mu: HashMap<u32, f64> = HashMap::new();
+        mu.insert(1, 1.0); mu.insert(2, 1.0);
+        let mut next = 100u32;
+        // Shared CORE of 400 high-μ nodes, each a child of BOTH hubs 1 and 2.
+        let mut core_nodes: Vec<u32> = Vec::new();
+        for _ in 0..400 { let c = next; next += 1; g.insert(c, vec![1, 2]); mu.insert(c, 0.9); core_nodes.push(c); }
+        // Private leaf bundles (out-of-overlap) under each hub.
+        for _ in 0..500 { let a = next; next += 1; g.insert(a, vec![1]); mu.insert(a, 0.4); }
+        for _ in 0..500 { let b = next; next += 1; g.insert(b, vec![2]); mu.insert(b, 0.4); }
+        let n = mu.len();
+        let w = descendant_minhash_weighted(&g, &mu, K).unwrap();
+        let est = sketch_mu_overlap(&w[&1], &w[&2], K, n);
+        let exact_shared: f64 = core_nodes.iter().map(|c| mu[c]).sum(); // 400 * 0.9 = 360
+        let rel = (est - exact_shared).abs() / exact_shared;
+        assert!(rel < 0.25, "saturated overlap est {est} vs exact {exact_shared} (rel {:.3})", rel);
+        eprintln!("μ-overlap @scale: exact shared {:.0} est {:.0} (rel {:.1}%)", exact_shared, est, 100.0 * rel);
     }
 
     // The user's depth-convergence hypothesis: the RAW descendant count explodes as you go deeper

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -1597,6 +1597,133 @@ pub fn descendant_mu_mass(
     out
 }
 
+/// **μ-weighted descendant KMV sketch** — the scalable companion to `descendant_mu_mass`. Where
+/// `descendant_mu_mass` does an exact per-node BFS (`O(V·(V+E))`), this builds *every* node's sketch
+/// in **one reverse-topological pass** (`O((V+E)·k)`), the same shape as `descendant_minhash`. Each
+/// sketch element is a `(hash, μ)` pair — `(mix64(node), μ_node)` — kept as the bottom-`k` by hash
+/// over the descendant cone, deduped by hash so diamonds count once (a set, like the unweighted
+/// sketch). The carried weight rides along for the mass read-out (`sketch_mu_mass`); the hashes are
+/// drawn independently of `μ`, so the bottom-`k` is a *uniform* sample of the distinct cone and the
+/// weights on it are an unbiased sample of the cone's weight distribution — that is what makes the
+/// read-out work. `None` on a cyclic graph (no reverse-topo order); SCC-condense first.
+pub fn descendant_minhash_weighted(
+    parents: &std::collections::HashMap<u32, Vec<u32>>,
+    mu: &std::collections::HashMap<u32, f64>,
+    k: usize,
+) -> Option<std::collections::HashMap<u32, Vec<(u64, f64)>>> {
+    use std::collections::{HashMap, HashSet, VecDeque};
+    debug_assert!(
+        mu.values().all(|&w| (0.0..=1.0).contains(&w)),
+        "membership weights μ must lie in [0,1]"
+    );
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut nodes: HashSet<u32> = HashSet::new();
+    for (&c, ps) in parents {
+        nodes.insert(c);
+        for &p in ps { nodes.insert(p); children.entry(p).or_default().push(c); }
+    }
+    let muv = |u: u32| mu.get(&u).copied().unwrap_or(0.0); // absent ⇒ μ=0 (out of domain; see descendant_mu_mass)
+    let mut pending: HashMap<u32, usize> = nodes
+        .iter()
+        .map(|&n| (n, children.get(&n).map_or(0, |v| v.len())))
+        .collect();
+    let mut q: VecDeque<u32> = pending.iter().filter(|&(_, &c)| c == 0).map(|(&n, _)| n).collect();
+    let mut sig: HashMap<u32, Vec<(u64, f64)>> = HashMap::new();
+    while let Some(b) = q.pop_front() {
+        let mut cand: Vec<(u64, f64)> = vec![(mix64(b as u64), muv(b))];
+        if let Some(cs) = children.get(&b) {
+            for &c in cs {
+                if let Some(s) = sig.get(&c) { cand.extend_from_slice(s); }
+            }
+        }
+        cand.sort_unstable_by_key(|&(h, _)| h);
+        cand.dedup_by_key(|&mut (h, _)| h); // dedup by element hash ⇒ distinct cone (diamonds once)
+        cand.truncate(k);
+        sig.insert(b, cand);
+        if let Some(ps) = parents.get(&b) {
+            for &p in ps {
+                let e = pending.get_mut(&p).unwrap();
+                *e -= 1;
+                if *e == 0 { q.push_back(p); }
+            }
+        }
+    }
+    if sig.len() == nodes.len() { Some(sig) } else { None } // short => a cycle
+}
+
+/// Bottom-`k` **subset-sum** read-out: estimate `m_μ = Σ_{d∈cone} μ_d` from a μ-weighted sketch.
+/// While unsaturated (`< k` pairs kept) the cone is fully captured, so this is the **exact** sum.
+/// Once saturated it is the Cohen–Kaplan bottom-`k` estimator `m̂_μ = D̂ · μ̄_sample` — the distinct
+/// cardinality `D̂ = (k−1)/ĥ_k` (the KMV estimate, identical to `sketch_card`) times the mean weight
+/// over the `k` sampled pairs. Because the bottom-`k` is a uniform sample of the cone independent of
+/// `μ`, `μ̄_sample` is unbiased for the cone's mean weight, so the product estimates the total mass.
+/// At `μ ≡ 1` it reduces exactly to `sketch_card` (the unweighted distinct count). Error is the KMV
+/// `∝ 1/√k` plus the sampling variance of `μ̄`, both tunable by `k`.
+pub fn sketch_mu_mass(s: &[(u64, f64)], k: usize) -> f64 {
+    if s.is_empty() {
+        return 0.0;
+    }
+    if s.len() < k {
+        return s.iter().map(|&(_, w)| w).sum(); // unsaturated ⇒ exact
+    }
+    let hk = s[k - 1].0 as f64 / (u64::MAX as f64 + 1.0);
+    let card = if hk <= 0.0 { s.len() as f64 } else { (k as f64 - 1.0) / hk };
+    let mean_w = s.iter().map(|&(_, w)| w).sum::<f64>() / s.len() as f64;
+    card * mean_w
+}
+
+/// Scalable **μ-weighted IC**: `information_content_weighted` fed by the sketch mass instead of the
+/// exact `descendant_mu_mass`. The drop-in large-graph form of partial-admission IC — same
+/// `−log₂(m_μ/M_μ)`, but `m_μ` is the `O((V+E)·k)` sketch estimate. `total_mu` is still the exact
+/// universe mass `Σ_all μ` (cheap: one pass over the μ-map). The sketch estimate can overshoot
+/// `total_mu` by KMV sampling noise near the root (cone ≈ universe), so it is clamped at `total_mu`
+/// before the log — the mass analogue of `information_content`'s `.min(1.0)` ratio clamp.
+pub fn information_content_weighted_sketch(s: &[(u64, f64)], total_mu: f64, k: usize) -> f64 {
+    information_content_weighted(sketch_mu_mass(s, k).min(total_mu), total_mu)
+}
+
+/// **μ-weighted cone-overlap mass** — the global-hub read-out. Estimates `Σ_{d∈A∩B} μ_d`, the
+/// *admitted* mass two cones share, from their μ-weighted sketches: take the bottom-`k` of the
+/// union, then (Broder) the elements present in **both** sketches are exactly the shared ones whose
+/// hash is small enough to survive in each, so their sampled fraction times the union cardinality,
+/// scaled by the shared mean weight, estimates the shared mass. This is the membership-aware fan-in
+/// signal: a *funnel* hub is one many cones reach, but a μ-weighted funnel discounts the associative
+/// leak — two cones that overlap only on low-μ (out-of-domain) descendants score near zero, so hub
+/// selection stops being fooled by the leak. `0` if either sketch is empty.
+pub fn sketch_mu_overlap(a: &[(u64, f64)], b: &[(u64, f64)], k: usize) -> f64 {
+    use std::collections::HashMap;
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let bset: HashMap<u64, f64> = b.iter().copied().collect();
+    let mut union: Vec<(u64, f64)> = a.iter().chain(b).copied().collect();
+    union.sort_unstable_by_key(|&(h, _)| h);
+    union.dedup_by_key(|&mut (h, _)| h);
+    union.truncate(k);
+    if union.is_empty() {
+        return 0.0;
+    }
+    let aset: HashMap<u64, f64> = a.iter().copied().collect();
+    // Shared sample: pairs in the union bottom-k that appear in BOTH sketches; their μ is the weight.
+    let shared: Vec<f64> = union
+        .iter()
+        .filter(|(h, _)| aset.contains_key(h) && bset.contains_key(h))
+        .map(|&(_, w)| w)
+        .collect();
+    if shared.is_empty() {
+        return 0.0;
+    }
+    let hk = union[union.len() - 1].0 as f64 / (u64::MAX as f64 + 1.0);
+    let union_card = if union.len() < k || hk <= 0.0 {
+        union.len() as f64
+    } else {
+        (k as f64 - 1.0) / hk
+    };
+    // jaccard-by-mass: (shared count / sample size) gives |A∩B|/|A∪B|; multiply by union mass-per-sample.
+    let mean_shared_w = shared.iter().sum::<f64>() / shared.len() as f64;
+    union_card * (shared.len() as f64 / union.len() as f64) * mean_shared_w
+}
+
 /// **Fuzzy admission curve**: an S-shaped (logistic) transfer from the raw membership `μ` to an
 /// admission weight in `[0,1]`, `w(μ) = 1/(1 + e^{−k(μ−c)})`. Shapes *how* `μ` translates to
 /// admission — nearly-full weight well above the boundary, nearly-zero well below, a smooth knee
@@ -4397,6 +4524,164 @@ mod tests {
             assert!((ic_sketch - ic_mu).abs() < 1e-9,
                 "node {node}: sketch IC {ic_sketch} != μ≡1 IC {ic_mu}");
         }
+    }
+
+    // μ-weighted KMV sketch: the scalable companion to the exact descendant_mu_mass. With k >> cone
+    // the sketch is exact, so it must match descendant_mu_mass node-for-node, AND at μ≡1 reduce to
+    // the unweighted distinct count (sketch_card). Diamond included (8 -> [3,4]) so dedup is tested.
+    #[test]
+    fn mu_weighted_sketch_matches_exact_mass_and_reduces_unweighted() {
+        const K: usize = 64; // exact regime
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        g.insert(1, vec![0]); g.insert(2, vec![0]);
+        g.insert(3, vec![1]); g.insert(4, vec![1]); g.insert(5, vec![2]);
+        g.insert(8, vec![3, 4]); // diamond: 8 reachable from 0 via both 3 and 4
+
+        // Graded μ: a leaked low-μ tail (5,8) under otherwise in-domain nodes.
+        let mut mu: HashMap<u32, f64> = HashMap::new();
+        for i in [0u32, 1, 2, 3, 4] { mu.insert(i, 1.0); }
+        mu.insert(5, 0.1); mu.insert(8, 0.2);
+        let total_mu: f64 = mu.values().sum();
+
+        let exact = descendant_mu_mass(&g, &mu);
+        let wsig = descendant_minhash_weighted(&g, &mu, K).unwrap();
+        for (&node, &m) in &exact {
+            let est = sketch_mu_mass(&wsig[&node], K);
+            assert!((est - m).abs() < 1e-9, "node {node}: sketch mass {est} != exact {m}");
+            // Scalable IC must match the exact-mass IC.
+            let ic_sketch = information_content_weighted_sketch(&wsig[&node], total_mu, K);
+            let ic_exact = information_content_weighted(m, total_mu);
+            assert!((ic_sketch - ic_exact).abs() < 1e-9, "node {node}: IC mismatch");
+        }
+
+        // μ≡1: weighted mass == distinct cone size (the unweighted KMV read-out).
+        let mu_one: HashMap<u32, f64> = mu.keys().map(|&u| (u, 1.0)).collect();
+        let w1 = descendant_minhash_weighted(&g, &mu_one, K).unwrap();
+        let d = descendant_minhash(&g, K).unwrap();
+        for &node in mu.keys() {
+            assert!((sketch_mu_mass(&w1[&node], K) - sketch_card(&d[&node], K)).abs() < 1e-9,
+                "node {node}: μ≡1 sketch mass != unweighted distinct count");
+        }
+    }
+
+    // At scale the sketch is approximate (k << cone): build a wide tree, check the weighted-mass
+    // estimate stays within KMV tolerance of the exact mass at the root, and that the unsaturated
+    // small cones are EXACT (the bottom-k captures the whole cone when it fits).
+    #[test]
+    fn mu_weighted_sketch_approximates_at_scale() {
+        const K: usize = 256;
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        // root 0 with FANOUT children, each child a small leaf bundle.
+        const FANOUT: u32 = 600;
+        let mut next = 1u32;
+        let mut mu: HashMap<u32, f64> = HashMap::new();
+        mu.insert(0, 1.0);
+        for _ in 0..FANOUT {
+            let c = next; next += 1;
+            g.insert(c, vec![0]);
+            mu.insert(c, 0.5); // graded
+            for _ in 0..2 { let l = next; next += 1; g.insert(l, vec![c]); mu.insert(l, 0.3); }
+        }
+        let total_mu: f64 = mu.values().sum();
+        let exact = descendant_mu_mass(&g, &mu);
+        let wsig = descendant_minhash_weighted(&g, &mu, K).unwrap();
+
+        let est_root = sketch_mu_mass(&wsig[&0], K);
+        let rel_err = (est_root - exact[&0]).abs() / exact[&0];
+        assert!(rel_err < 0.20, "root mass est {est_root} vs exact {} (rel err {:.3})", exact[&0], rel_err);
+
+        // A leaf cone is a single node ⇒ unsaturated ⇒ exact.
+        let leaf = next - 1;
+        assert!((sketch_mu_mass(&wsig[&leaf], K) - exact[&leaf]).abs() < 1e-12, "leaf must be exact");
+
+        // IC is finite and ordered: the root (huge cone) is less specific than a graded child.
+        let ic_root = information_content_weighted_sketch(&wsig[&0], total_mu, K);
+        let child1 = 1u32;
+        let ic_child = information_content_weighted_sketch(&wsig[&child1], total_mu, K);
+        assert!(ic_root < ic_child, "root must be more general (lower IC) than a child");
+        eprintln!("μ-sketch @scale: root mass exact {:.1} est {:.1} (rel {:.1}%), IC root {:.2} child {:.2}",
+            exact[&0], est_root, 100.0 * rel_err, ic_root, ic_child);
+    }
+
+    // The GLOBAL hook: μ-weighted cone-overlap mass is LEAK-ROBUST. Two cones that share only a
+    // low-μ (out-of-domain) leak score near zero; two that share a high-μ core score high. This is
+    // the membership-aware fan-in a hub selector wants — it is not fooled by the associative leak.
+    #[test]
+    fn mu_weighted_overlap_is_leak_robust() {
+        const K: usize = 64;
+        // A: 10..=13 over hub 1; B: 20..=23 over hub 2. They SHARE a leaked tail {90,91} (under both)
+        // and a clean core {50} (under both). Vary μ to make the shared set leak vs core.
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        for c in 10u32..=13 { g.insert(c, vec![1]); }
+        for c in 20u32..=23 { g.insert(c, vec![2]); }
+        g.insert(50, vec![13, 23]);          // clean core shared by both cones
+        g.insert(90, vec![12, 22]); g.insert(91, vec![90]); // leaked tail shared by both cones
+
+        // Case 1: shared set is a LEAK (μ low). Overlap mass should be small.
+        let mut leak: HashMap<u32, f64> = HashMap::new();
+        for u in [1u32, 2, 10, 11, 12, 13, 20, 21, 22, 23] { leak.insert(u, 1.0); }
+        leak.insert(50, 0.05); leak.insert(90, 0.05); leak.insert(91, 0.05);
+        let wl = descendant_minhash_weighted(&g, &leak, K).unwrap();
+        let ov_leak = sketch_mu_overlap(&wl[&1], &wl[&2], K);
+
+        // Case 2: shared set is the CORE (μ high). Overlap mass should be larger.
+        let mut core: HashMap<u32, f64> = leak.clone();
+        core.insert(50, 1.0); core.insert(90, 1.0); core.insert(91, 1.0);
+        let wc = descendant_minhash_weighted(&g, &core, K).unwrap();
+        let ov_core = sketch_mu_overlap(&wc[&1], &wc[&2], K);
+
+        assert!(ov_core > ov_leak + 1.0, "μ-overlap must discount the leak: core {ov_core} vs leak {ov_leak}");
+        // Disjoint cones share nothing ⇒ ~0 overlap (hub 1 vs a private leaf cone).
+        let priv_only = descendant_minhash_weighted(&{ let mut h = HashMap::new();
+            h.insert(30u32, vec![1u32]); h.insert(40u32, vec![2u32]); h }, &core, K).unwrap();
+        assert!(sketch_mu_overlap(&priv_only[&30], &priv_only[&40], K) < 1e-9, "disjoint ⇒ no overlap");
+        eprintln!("μ-overlap: leak-shared {:.2} vs core-shared {:.2} (leak-robust fan-in)", ov_leak, ov_core);
+    }
+
+    // The user's depth-convergence hypothesis: the RAW descendant count explodes as you go deeper
+    // (the associative leak piles up), but the μ-WEIGHTED mass stays bounded because the deep nodes
+    // are out-of-domain (low μ). So a weighted count is a depth-STABLE global signal where the raw
+    // count is not. Chain 0->1->...->5 (each via parents) with an exploding leak hung off each node
+    // and μ decaying with depth.
+    #[test]
+    fn mu_weighted_count_is_depth_stable() {
+        const K: usize = 256;
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        let mut mu: HashMap<u32, f64> = HashMap::new();
+        // Spine 0..=5; node i has μ = 1 (in-domain core). Deeper spine nodes carry a bigger LEAK
+        // subtree (out-of-domain, μ≈0.02) — the "more deep nodes than shallow" effect.
+        let mut next = 1000u32;
+        mu.insert(0, 1.0);
+        for i in 1u32..=5 {
+            g.insert(i, vec![i - 1]); // spine
+            mu.insert(i, 1.0);
+            for _ in 0..(i * 40) { // leak grows with depth
+                let l = next; next += 1; g.insert(l, vec![i]); mu.insert(l, 0.02);
+            }
+        }
+        let exact = descendant_mu_mass(&g, &mu);
+        let d = descendant_minhash(&g, K).unwrap();
+
+        // Walk DOWN the spine 5->0 and watch raw cone size vs weighted mass.
+        let mut raw_prev = 0.0f64;
+        let mut wmass_prev = 0.0f64;
+        let mut raw_growth = 0.0f64;     // how much the raw count grows per step up toward root
+        let mut wmass_growth = 0.0f64;
+        for &node in &[5u32, 4, 3, 2, 1, 0] {
+            let raw = sketch_card(&d[&node], K);
+            let wmass = exact[&node];
+            if raw_prev > 0.0 {
+                raw_growth += raw - raw_prev;
+                wmass_growth += wmass - wmass_prev;
+            }
+            raw_prev = raw; wmass_prev = wmass;
+            eprintln!("depth-stable: node {node}  raw cone {:.0}  μ-mass {:.2}", raw, wmass);
+        }
+        // The raw count balloons toward the root (it sums every leak); the weighted mass barely moves
+        // (the leaks are discounted). So weighted growth is a small fraction of raw growth.
+        assert!(raw_growth > 100.0, "raw cone must explode toward the root (leak accumulation)");
+        assert!(wmass_growth < raw_growth * 0.1,
+            "μ-mass must be depth-stable: weighted growth {wmass_growth} vs raw {raw_growth}");
     }
 
     // IC-based semantic similarity (Resnik/Lin) via the descendant sketch -- the calibrated,

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -1659,6 +1659,63 @@ pub fn descendant_minhash_weighted(
     if sig.len() == nodes.len() { Some(sig) } else { None } // short => a cycle
 }
 
+/// **How to cap the KMV cardinality estimate** `D̂ = (k−1)/ĥ_k` in the μ-weighted read-outs. The KMV
+/// estimator is unbounded in principle, so a pathologically tiny `ĥ_k` (e.g. a `mix64` output of `1`
+/// ⇒ `ĥ_k ≈ 5.4e−20`) can blow `D̂` up to `~10¹⁹`, which then propagates into the raw mass and the
+/// hub-overlap score. This selects the cap *policy*; both choices are legitimate for different
+/// settings, so it is a knob, not a hard-coded constant.
+///
+/// - [`CardCap::Universe`]`(n)` — cap at the graph node count `N`. A distinct cone (or a union of
+///   cones) is a *subset* of the graph, so `D̂ ≤ N` is an **exact, tight** bound: it both contains the
+///   overflow and clips any ordinary KMV *over*-estimate back to a real ceiling, slightly cutting
+///   variance near the root (where the cone ≈ `N`). **Recommended whenever `N` is known** — which is
+///   the usual case, since you built the sketches from a known graph. Cost: you must pass `N`.
+/// - [`CardCap::Ceiling`]`(c)` — cap at a fixed value. Use when `N` is unknown or expensive to obtain
+///   (streaming / incrementally-built graphs), or when you are deliberately comparing cones *across*
+///   graphs of different sizes and want a size-independent ceiling. Set well above any real cone it is
+///   a pure overflow guard and never clips a valid estimate. The [`Default`] is `Ceiling(1e12)` — far
+///   above any realistic node count, so real data is untouched but a tiny-`ĥ_k` blow-up is contained.
+/// - [`CardCap::Uncapped`] — raw KMV, no cap. Only safe when a downstream stage clamps anyway (e.g.
+///   `information_content_weighted_sketch` already does `.min(total_mu)`), or in tests.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CardCap {
+    /// Cap `D̂` at the graph node count `N` (cone ⊆ graph ⇒ `D̂ ≤ N`). Tightest; needs `N`.
+    Universe(usize),
+    /// Cap `D̂` at a fixed ceiling. Caller-free overflow guard; no semantic tightening.
+    Ceiling(f64),
+    /// No cap (raw KMV). Only when a downstream stage clamps, or for testing.
+    Uncapped,
+}
+
+impl Default for CardCap {
+    /// Caller-free overflow guard: `Ceiling(1e12)`. Prefer [`CardCap::Universe`] when `N` is known.
+    fn default() -> Self { CardCap::Ceiling(1e12) }
+}
+
+// Numeric convenience: the read-outs take `impl Into<CardCap>`, so a caller may pass the explicit
+// enum *or* a bare number — a `usize` node count is read as the (recommended) `Universe(n)` cap, a
+// bare `f64` as a fixed `Ceiling(c)`. `sketch_mu_mass(s, k, n)` and `sketch_mu_mass(s, k, 1e12)` and
+// `sketch_mu_mass(s, k, CardCap::Uncapped)` are all valid.
+impl From<usize> for CardCap {
+    /// A plain node count ⇒ [`CardCap::Universe`] (the tight, recommended cap).
+    fn from(n: usize) -> Self { CardCap::Universe(n) }
+}
+impl From<f64> for CardCap {
+    /// A plain float ⇒ [`CardCap::Ceiling`] (a fixed overflow ceiling).
+    fn from(c: f64) -> Self { CardCap::Ceiling(c) }
+}
+
+impl CardCap {
+    /// Apply the cap policy to a raw KMV cardinality estimate.
+    fn apply(self, card: f64) -> f64 {
+        match self {
+            CardCap::Universe(n) => card.min(n as f64),
+            CardCap::Ceiling(c) => card.min(c),
+            CardCap::Uncapped => card,
+        }
+    }
+}
+
 /// Bottom-`k` **subset-sum** read-out: estimate `m_μ = Σ_{d∈cone} μ_d` from a μ-weighted sketch.
 /// While unsaturated (`< k` pairs kept) the cone is fully captured, so this is the **exact** sum.
 /// Once saturated it is a bottom-`k` *plug-in* subset-sum estimator `m̂_μ = D̂ · μ̄_sample` — the
@@ -1670,10 +1727,11 @@ pub fn descendant_minhash_weighted(
 /// weights, zero covariance), which is formally tighter. At `μ ≡ 1` it reduces exactly to
 /// `sketch_card`. Error is the KMV `∝ 1/√k` plus the `μ̄` sampling variance, both tunable by `k`.
 ///
-/// `n_universe` is the total node count — the cardinality `D̂` cannot exceed it (a distinct cone is a
-/// subset of the graph), so `D̂` is capped at `n_universe` to defend against a pathologically tiny
-/// `ĥ_k` blowing `(k−1)/ĥ_k` up to `~10¹⁹`. `k ≥ 2` (`k=1` makes `(k−1)/ĥ_k ≡ 0`).
-pub fn sketch_mu_mass(s: &[(u64, f64)], k: usize, n_universe: usize) -> f64 {
+/// `cap` selects the cardinality-cap policy ([`CardCap`]) that defends against a pathologically tiny
+/// `ĥ_k` blowing `(k−1)/ĥ_k` up to `~10¹⁹`; `CardCap::Universe(N)` is the tight, recommended choice
+/// when the node count `N` is known. `k ≥ 2` (`k=1` makes `(k−1)/ĥ_k ≡ 0`).
+pub fn sketch_mu_mass(s: &[(u64, f64)], k: usize, cap: impl Into<CardCap>) -> f64 {
+    let cap = cap.into();
     debug_assert!(k >= 2, "k must be ≥ 2: k=1 makes (k−1)/ĥ_k ≡ 0 (mass 0 ⇒ IC 0), k=0 panics");
     if s.is_empty() {
         return 0.0;
@@ -1683,7 +1741,7 @@ pub fn sketch_mu_mass(s: &[(u64, f64)], k: usize, n_universe: usize) -> f64 {
     }
     let hk = s[k - 1].0 as f64 / (u64::MAX as f64 + 1.0);
     let raw_card = if hk <= 0.0 { s.len() as f64 } else { (k as f64 - 1.0) / hk };
-    let card = raw_card.min(n_universe as f64); // cone ⊆ graph ⇒ D̂ ≤ N (caps tiny-ĥ_k overflow)
+    let card = cap.apply(raw_card); // see CardCap (caps tiny-ĥ_k overflow)
     let mean_w = s.iter().map(|&(_, w)| w).sum::<f64>() / s.len() as f64;
     card * mean_w
 }
@@ -1691,7 +1749,7 @@ pub fn sketch_mu_mass(s: &[(u64, f64)], k: usize, n_universe: usize) -> f64 {
 /// Scalable **μ-weighted IC**: `information_content_weighted` fed by the sketch mass instead of the
 /// exact `descendant_mu_mass`. The drop-in large-graph form of partial-admission IC — same
 /// `−log₂(m_μ/M_μ)`, but `m_μ` is the `O((V+E)·k)` sketch estimate. `total_mu` is still the exact
-/// universe mass `Σ_all μ` (cheap: one pass over the μ-map); `n_universe` the node count (cone cap).
+/// universe mass `Σ_all μ` (cheap: one pass over the μ-map); `cap` the [`CardCap`] policy.
 /// The sketch estimate can overshoot `total_mu` by KMV sampling noise near the root (cone ≈ universe),
 /// so it is clamped at `total_mu` before the log — the mass analogue of `information_content`'s
 /// `.min(1.0)` ratio clamp.
@@ -1703,8 +1761,8 @@ pub fn sketch_mu_mass(s: &[(u64, f64)], k: usize, n_universe: usize) -> f64 {
 /// the exact and sketch IC agree at *exactly* zero (both `+∞`) and in the bulk, but can diverge in a
 /// thin near-zero band — use the exact `descendant_mu_mass` path when the mass is near zero and the
 /// distinction matters.
-pub fn information_content_weighted_sketch(s: &[(u64, f64)], total_mu: f64, k: usize, n_universe: usize) -> f64 {
-    information_content_weighted(sketch_mu_mass(s, k, n_universe).min(total_mu), total_mu)
+pub fn information_content_weighted_sketch(s: &[(u64, f64)], total_mu: f64, k: usize, cap: impl Into<CardCap>) -> f64 {
+    information_content_weighted(sketch_mu_mass(s, k, cap.into()).min(total_mu), total_mu)
 }
 
 /// **μ-weighted cone-overlap mass** — the global-hub read-out. Estimates `Σ_{d∈A∩B} μ_d`, the
@@ -1724,10 +1782,11 @@ pub fn information_content_weighted_sketch(s: &[(u64, f64)], total_mu: f64, k: u
 /// not an absolute mass** — it is high-variance in the low-overlap regime.
 ///
 /// **Precondition:** `a` and `b` must have been built with the *same* `k` (the Broder union-bottom-`k`
-/// argument requires it); mixing `k`s silently biases `D̂_∪`. `n_universe` caps `D̂_∪` (a union of
-/// cones is `⊆` the graph), defending against a tiny `ĥ_k` overflow exactly as in `sketch_mu_mass`.
-pub fn sketch_mu_overlap(a: &[(u64, f64)], b: &[(u64, f64)], k: usize, n_universe: usize) -> f64 {
+/// argument requires it); mixing `k`s silently biases `D̂_∪`. `cap` is the [`CardCap`] policy for
+/// `D̂_∪` (a union of cones is `⊆` the graph), defending against a tiny `ĥ_k` overflow as in `sketch_mu_mass`.
+pub fn sketch_mu_overlap(a: &[(u64, f64)], b: &[(u64, f64)], k: usize, cap: impl Into<CardCap>) -> f64 {
     use std::collections::HashMap;
+    let cap = cap.into();
     debug_assert!(k >= 2, "k must be ≥ 2");
     debug_assert!(a.len() <= k && b.len() <= k,
         "both sketches must be built with the same k; mixing k biases the union-card estimate");
@@ -1756,7 +1815,7 @@ pub fn sketch_mu_overlap(a: &[(u64, f64)], b: &[(u64, f64)], k: usize, n_univers
     let union_card = if union.len() < k || hk <= 0.0 {
         union.len() as f64
     } else {
-        ((k as f64 - 1.0) / hk).min(n_universe as f64) // cap tiny-ĥ_k overflow (union ⊆ graph)
+        cap.apply((k as f64 - 1.0) / hk) // cap tiny-ĥ_k overflow (union ⊆ graph)
     };
     // jaccard-by-mass: (shared count / sample size) gives |A∩B|/|A∪B|; multiply by union mass-per-sample.
     let mean_shared_w = shared.iter().sum::<f64>() / shared.len() as f64;
@@ -4631,6 +4690,38 @@ mod tests {
         cyc.insert(0, vec![1]); cyc.insert(1, vec![0]);
         let cmu: HashMap<u32, f64> = [(0u32, 1.0), (1, 1.0)].into_iter().collect();
         assert!(descendant_minhash_weighted(&cyc, &cmu, K).is_none(), "cycle ⇒ None");
+    }
+
+    // CardCap: the cardinality-cap policy is configurable as the explicit enum OR a bare numeric
+    // value (usize ⇒ Universe, f64 ⇒ Ceiling). A saturated cone of 21 nodes (all μ=1) lets a tiny
+    // ceiling visibly clip the estimate, proving the knob is live and the two numeric spellings map
+    // to the documented variants.
+    #[test]
+    fn card_cap_config_enum_and_numeric_forms() {
+        const K: usize = 4;
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        let mut mu: HashMap<u32, f64> = HashMap::new();
+        mu.insert(0, 1.0);
+        for i in 1u32..=20 { g.insert(i, vec![0]); mu.insert(i, 1.0); } // cone(0) = 21 distinct, μ≡1
+        let w = descendant_minhash_weighted(&g, &mu, K).unwrap();
+        let s = &w[&0];
+
+        let raw = sketch_mu_mass(s, K, CardCap::Uncapped);
+        assert!(raw > 5.0, "uncapped estimate tracks the true ~21-node cone, got {raw}");
+
+        // A deliberately tiny ceiling clips D̂ (hence mass, since mean_w=1) down to the ceiling.
+        let clipped = sketch_mu_mass(s, K, CardCap::Ceiling(2.0));
+        assert!((clipped - 2.0).abs() < 1e-9, "Ceiling(2.0) caps mass at 2 (mean_w=1), got {clipped}");
+        assert!(clipped < raw, "the tiny ceiling actually clips");
+
+        // Numeric convenience: bare f64 ⇒ Ceiling, bare usize ⇒ Universe.
+        assert_eq!(sketch_mu_mass(s, K, 2.0_f64), clipped, "bare f64 ⇒ Ceiling(2.0)");
+        assert_eq!(sketch_mu_mass(s, K, 2usize), sketch_mu_mass(s, K, CardCap::Universe(2)),
+            "bare usize ⇒ Universe(n)");
+        // Default is a high ceiling ⇒ no clip for a real cone.
+        assert_eq!(sketch_mu_mass(s, K, CardCap::default()), raw, "default high ceiling never clips real data");
+        // Overlap takes the same knob.
+        let _ = sketch_mu_overlap(s, s, K, CardCap::Universe(21));
     }
 
     // At scale the sketch is approximate (k << cone): build a wide tree, check the weighted-mass


### PR DESCRIPTION
Closes the documented scaling caveat on μ-weighted IC (#3271). `descendant_mu_mass` is exact but `O(V·(V+E))`; this adds the bottom-`k` sketch that builds **every** node's weighted descendant mass in one reverse-topo pass `O((V+E)·k)`. It also opens the global hub problem (the reason this increment was chosen).

## Core — Cohen–Kaplan bottom-`k` subset-sum over the descendant cone
- **`descendant_minhash_weighted`** — bottom-`k` of `(hash, μ)` pairs, deduped by hash so diamonds count once (a set, like `descendant_minhash`). The hashes are drawn independently of `μ`, so the bottom-`k` is a *uniform* sample of the cone and the carried weights are an unbiased sample of its weight distribution.
- **`sketch_mu_mass`** — `m̂_μ = D̂ · μ̄_sample` (distinct cardinality × sample-mean weight). Exact while unsaturated; reduces to `sketch_card` at `μ ≡ 1`.
- **`information_content_weighted_sketch`** — drop-in scalable `IC_μ`, clamping the estimate at `total_mu` (the mass analogue of `information_content`'s `.min(1.0)` ratio clamp).

## Global hooks — why this serves hub selection
- **`sketch_mu_overlap`** — μ-weighted Broder intersection mass = **leak-robust fan-in**. Cones sharing only low-μ (out-of-domain) descendants score ≈ 0, so hub selection is no longer fooled by the associative leak. *Measured:* core-shared `3.00` vs leak-shared `0.15`.
- **Depth-stability** — the raw cone count *explodes* toward the root as the leak accumulates (more deep nodes than shallow), but the weighted mass stays bounded because deep nodes are out-of-domain. On the spine test the raw cone grows `201 → 645` (+444) while the μ-mass grows only `5 → 18` (+13), ~3% of the raw growth. **The weighted count converges as you descend where the raw count diverges** — the depth-robust global signal the hub problem needs.

## Tests (6 new, 93/93 lib pass)
`mu_weighted_sketch_matches_exact_mass_and_reduces_unweighted`, `…_approximates_at_scale` (k≪cone, rel err 2.6% at the root, exact on unsaturated leaves), `mu_weighted_overlap_is_leak_robust`, `mu_weighted_count_is_depth_stable`. Prolog template guard passes.

References already in §10: Cohen & Kaplan 2007 (bottom-k sketches / subset sums), Broder 1997 (MinHash intersection), Bar-Yossef et al. 2002 (KMV distinct count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_