### PR TITLE
WAM-Rust: μ-weighted overlap lift — the membership-aware hub-selection read-out

### DIFF
--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -832,7 +832,15 @@ calibration of the relatedness read-out.)
 >   bottom-`k` intersection, weighted). A funnel hub is one many cones reach, but a weighted funnel
 >   discounts the associative leak — cones overlapping only on low-μ descendants score ≈ 0 — so hub
 >   selection stops being fooled by the leak. (Measured: core-shared overlap `3.00` vs leak-shared
->   `0.15`.)
+>   `0.15`.) The **hub-selection read-out** built on this is `sketch_mu_overlap_lift`, the μ-weighted
+>   analogue of `sketch_overlap_lift`: shared mass against the *mass* configuration-model null
+>   `E = m_A·m_B / M`, so `lift > 1` is an excess in-domain funnel and `lift ≈ 1` is the small-world
+>   background; `μ ≡ 1` reduces exactly to the unweighted lift. This is where the leak finally bites
+>   the *global* signal and the weighting pays off: on a test with a real in-domain hub and a
+>   leak-driven false hub of **identical cone sizes** — so identical *unweighted* lift (`4.01` both,
+>   fooled) — the weighted lift reads the real hub `2.50` (excess funnel, `> 1`) and the leak hub
+>   `0.25` (*below* chance, correctly suppressed), a 10× separation
+>   (`mu_overlap_lift_separates_real_hub_from_leak_hub`). The unweighted lift cannot tell them apart.
 > - **Depth-stability** (`mu_weighted_count_is_depth_stable`): the raw cone count *explodes* toward
 >   the root as the leak accumulates (more deep nodes than shallow), but the weighted mass barely
 >   moves because the deep nodes are out-of-domain — on the spine test the raw cone grows `201 → 645`

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -834,13 +834,20 @@ calibration of the relatedness read-out.)
 >   selection stops being fooled by the leak. (Measured: core-shared overlap `3.00` vs leak-shared
 >   `0.15`.) The **hub-selection read-out** built on this is `sketch_mu_overlap_lift`, the μ-weighted
 >   analogue of `sketch_overlap_lift`: shared mass against the *mass* configuration-model null
->   `E = m_A·m_B / M`, so `lift > 1` is an excess in-domain funnel and `lift ≈ 1` is the small-world
->   background; `μ ≡ 1` reduces exactly to the unweighted lift. This is where the leak finally bites
->   the *global* signal and the weighting pays off: on a test with a real in-domain hub and a
->   leak-driven false hub of **identical cone sizes** — so identical *unweighted* lift (`4.01` both,
->   fooled) — the weighted lift reads the real hub `2.50` (excess funnel, `> 1`) and the leak hub
->   `0.25` (*below* chance, correctly suppressed), a 10× separation
->   (`mu_overlap_lift_separates_real_hub_from_leak_hub`). The unweighted lift cannot tell them apart.
+>   `E = m_A·m_B / M` — the **weighted configuration model** of Barrat et al. (2004) / Newman (2004),
+>   `s_i·s_j/2W` with admitted mass as the strength `s` — so `lift > 1` is an excess in-domain funnel
+>   and `lift ≈ 1` is the small-world background. In the **exact (`k ≥ |cone|`) regime** `μ ≡ 1`
+>   reduces *exactly* to the unweighted lift (under saturation the weighted path applies the cap and
+>   the unweighted does not, so the reduction is then only approximate). This is where the leak finally
+>   bites the *global* signal and the weighting pays off: on a test (exact regime) with a real
+>   in-domain hub and a leak-driven false hub of **identical cone sizes** — so identical *unweighted*
+>   lift (`4.01` both, fooled) — the weighted lift reads the real hub `2.50` (excess funnel, `> 1`) and
+>   the leak hub `0.25` (*below* chance, correctly suppressed), a 10× separation
+>   (`mu_overlap_lift_separates_real_hub_from_leak_hub`); the discrimination survives sketch saturation
+>   (`mu_overlap_lift_saturated_regime_and_cap_is_live`, `k=32`: real `2.33`, leak `0.18`). The
+>   unweighted lift cannot tell them apart. *Caveat:* the lift is high-variance for tiny cones
+>   (product-lift RSE ≈ `√3/√k`), so the read-out gates cones with mass `< 1e-9·M` to `0` (the weighted
+>   resolution limit); gate harder upstream if many small cones are in play.
 > - **Depth-stability** (`mu_weighted_count_is_depth_stable`): the raw cone count *explodes* toward
 >   the root as the leak accumulates (more deep nodes than shallow), but the weighted mass barely
 >   moves because the deep nodes are out-of-domain — on the spine test the raw cone grows `201 → 645`
@@ -1252,6 +1259,11 @@ Each is referenced inline at the section that uses it.
 - Ioffe, S. (2010). *Improved Consistent Sampling, Weighted Minhash and L1 Sketching.* ICDM 2010. —
   Weighted MinHash (weight baked into the hash to estimate weighted Jaccard `J_w`); contrasted with
   the *carry-weight KMV* of `descendant_minhash_weighted`, which estimates weighted mass, not `J_w`.
+- Barrat, A., Barthélemy, M., Pastor-Satorras, R., & Vespignani, A. (2004). *The Architecture of
+  Complex Weighted Networks.* PNAS 101(11). — the weighted-network strength `s_i`; with Newman 2004
+  the `s_i·s_j/2W` weighted configuration-model null that `sketch_mu_overlap_lift` uses (mass = strength).
+- Newman, M. E. J. (2004). *Analysis of Weighted Networks.* Phys. Rev. E 70, 056131
+  (arXiv:cond-mat/0408187). — weighted modularity / the weighted configuration-model expectation.
 
 **2-hop cover / hub labeling and landmark distance (§5c, roadmap 3f).**
 - Cohen, E., Halperin, E., Kaplan, H., & Zwick, U. (2002/2003). *Reachability and Distance

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -1822,6 +1822,38 @@ pub fn sketch_mu_overlap(a: &[(u64, f64)], b: &[(u64, f64)], k: usize, cap: impl
     union_card * (shared.len() as f64 / union.len() as f64) * mean_shared_w
 }
 
+/// **μ-weighted overlap lift — the membership-aware hub funnel signal.** The weighted analogue of
+/// `sketch_overlap_lift`: it asks whether two cones share more *in-domain* mass than chance predicts,
+/// against the mass configuration-model null. With `m_A`, `m_B` the admitted masses (`sketch_mu_mass`)
+/// and `M = total_mu` the universe mass, the null expected shared mass is `E = m_A·m_B / M` (a random
+/// unit of admitted mass sits in `A` with prob `m_A/M` and in `B` with prob `m_B/M`, independently),
+/// and the signal is `lift = observed_shared_mass / E` with `observed = sketch_mu_overlap`. `lift > 1`
+/// is an *excess in-domain funnel* — a genuine domain hub; `lift ≈ 1` is the small-world background.
+/// At `μ ≡ 1` it reduces *exactly* to `sketch_overlap_lift` (`m_A=|A|`, `m_B=|B|`, `M=N`).
+///
+/// This is the read-out the weighted sketch was built for: the raw `sketch_overlap_lift` is fooled by
+/// the associative leak — two cones that overlap heavily on *out-of-domain* descendants look like a
+/// hub — but here the observed shared mass discounts those low-`μ` descendants, so a leak-driven false
+/// hub collapses to `lift ≈ 0` while a real in-domain hub stays `> 1`. `0` if either cone has no mass.
+pub fn sketch_mu_overlap_lift(
+    a: &[(u64, f64)],
+    b: &[(u64, f64)],
+    total_mu: f64,
+    k: usize,
+    cap: impl Into<CardCap>,
+) -> f64 {
+    let cap = cap.into();
+    if total_mu <= 0.0 {
+        return 0.0;
+    }
+    let (m_a, m_b) = (sketch_mu_mass(a, k, cap), sketch_mu_mass(b, k, cap));
+    let expected = m_a * m_b / total_mu;
+    if expected <= 0.0 {
+        return 0.0;
+    }
+    sketch_mu_overlap(a, b, k, cap) / expected
+}
+
 /// **Fuzzy admission curve**: an S-shaped (logistic) transfer from the raw membership `μ` to an
 /// admission weight in `[0,1]`, `w(μ) = 1/(1 + e^{−k(μ−c)})`. Shapes *how* `μ` translates to
 /// admission — nearly-full weight well above the boundary, nearly-zero well below, a smooth knee
@@ -4873,6 +4905,74 @@ mod tests {
         assert!(raw_growth > 100.0, "raw cone must explode toward the root (leak accumulation)");
         assert!(wmass_growth < raw_growth * 0.1,
             "μ-mass must be depth-stable: weighted growth {wmass_growth} vs raw {raw_growth}");
+    }
+
+    // μ-weighted overlap LIFT reduces to the unweighted sketch_overlap_lift at μ≡1. Diamond: 3->[1,2],
+    // 4->[3]; 1,2->0. cone(1)={1,3,4}, cone(2)={2,3,4}, ∩={3,4}. k >> cone ⇒ exact, so the two lifts
+    // must agree to 1e-9.
+    #[test]
+    fn mu_overlap_lift_reduces_to_unweighted_at_mu_one() {
+        const K: usize = 16;
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        g.insert(1, vec![0]); g.insert(2, vec![0]);
+        g.insert(3, vec![1, 2]); g.insert(4, vec![3]);
+        let n = 5usize; // nodes 0,1,2,3,4
+        let mu_one: HashMap<u32, f64> = (0u32..=4).map(|i| (i, 1.0)).collect();
+        let total_mu: f64 = mu_one.values().sum(); // = 5 = n
+
+        let d = descendant_minhash(&g, K).unwrap();
+        let w = descendant_minhash_weighted(&g, &mu_one, K).unwrap();
+        let unweighted = sketch_overlap_lift(&d[&1], &d[&2], n, K);
+        let weighted = sketch_mu_overlap_lift(&w[&1], &w[&2], total_mu, K, CardCap::Universe(n));
+        assert!((unweighted - weighted).abs() < 1e-9,
+            "μ≡1 lift {weighted} must equal unweighted lift {unweighted}");
+        assert!(weighted > 1.0, "1 and 2 funnel into the shared {{3,4}} more than chance");
+    }
+
+    // THE HUB-SELECTOR PAYOFF: the μ-weighted lift discriminates a real in-domain hub from a
+    // leak-driven false hub where the UNWEIGHTED lift cannot. Two cone-pairs with IDENTICAL sizes
+    // (so identical unweighted lift): pair A,B shares 40 in-domain nodes (μ=1); pair C,D shares 40
+    // out-of-domain leak nodes (μ=0.02). Both also carry 30 private in-domain children so their total
+    // MASS is comparable. The unweighted lift is fooled (equal); the weighted lift ranks the real hub
+    // above chance (>1) and pushes the leak hub below chance (<1).
+    #[test]
+    fn mu_overlap_lift_separates_real_hub_from_leak_hub() {
+        const K: usize = 128; // > every cone (71) ⇒ exact
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        let mut mu: HashMap<u32, f64> = HashMap::new();
+        for q in [1u32, 2, 3, 4] { mu.insert(q, 1.0); } // 1,2 real hub queries; 3,4 leak hub queries
+        let mut next = 1000u32;
+        // Private in-domain children (μ=1): 30 under each of 1,2,3,4 — gives all four cones in-domain bulk.
+        for &q in &[1u32, 2, 3, 4] {
+            for _ in 0..30 { let c = next; next += 1; g.insert(c, vec![q]); mu.insert(c, 1.0); }
+        }
+        // Shared CORE for the real hub: 40 in-domain nodes under BOTH 1 and 2 (μ=1).
+        for _ in 0..40 { let s = next; next += 1; g.insert(s, vec![1, 2]); mu.insert(s, 1.0); }
+        // Shared LEAK for the false hub: 40 out-of-domain nodes under BOTH 3 and 4 (μ=0.02).
+        for _ in 0..40 { let l = next; next += 1; g.insert(l, vec![3, 4]); mu.insert(l, 0.02); }
+        // Filler to inflate the universe (small-world background): 300 nodes under a filler root.
+        let froot = next; next += 1; mu.insert(froot, 0.5);
+        for _ in 0..300 { let f = next; next += 1; g.insert(f, vec![froot]); mu.insert(f, 0.5); }
+
+        let d = descendant_minhash(&g, K).unwrap();
+        let w = descendant_minhash_weighted(&g, &mu, K).unwrap();
+        let n = d.len();
+        let total_mu: f64 = mu.values().sum();
+
+        let unw_real = sketch_overlap_lift(&d[&1], &d[&2], n, K);
+        let unw_leak = sketch_overlap_lift(&d[&3], &d[&4], n, K);
+        let w_real = sketch_mu_overlap_lift(&w[&1], &w[&2], total_mu, K, n);
+        let w_leak = sketch_mu_overlap_lift(&w[&3], &w[&4], total_mu, K, n);
+        eprintln!("hub-lift: unweighted real {:.2} leak {:.2} (FOOLED) | weighted real {:.2} leak {:.2}",
+            unw_real, unw_leak, w_real, w_leak);
+
+        // Unweighted lift cannot tell them apart (identical cone sizes).
+        assert!((unw_real - unw_leak).abs() < 1e-6, "unweighted lift is fooled: real {unw_real} leak {unw_leak}");
+        assert!(unw_real > 1.0, "both look like hubs structurally");
+        // Weighted lift: real hub is an excess in-domain funnel; leak hub falls below chance.
+        assert!(w_real > 1.0, "real in-domain hub: weighted lift > 1 ({w_real})");
+        assert!(w_leak < 1.0, "leak hub correctly suppressed below chance ({w_leak})");
+        assert!(w_real > w_leak * 5.0, "real hub ranks far above the leak hub ({w_real} vs {w_leak})");
     }
 
     // IC-based semantic similarity (Resnik/Lin) via the descendant sketch -- the calibrated,

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -1829,12 +1829,33 @@ pub fn sketch_mu_overlap(a: &[(u64, f64)], b: &[(u64, f64)], k: usize, cap: impl
 /// unit of admitted mass sits in `A` with prob `m_A/M` and in `B` with prob `m_B/M`, independently),
 /// and the signal is `lift = observed_shared_mass / E` with `observed = sketch_mu_overlap`. `lift > 1`
 /// is an *excess in-domain funnel* — a genuine domain hub; `lift ≈ 1` is the small-world background.
-/// At `μ ≡ 1` it reduces *exactly* to `sketch_overlap_lift` (`m_A=|A|`, `m_B=|B|`, `M=N`).
+/// **When `μ ≡ 1` *and* `k ≥ |cone|` (the exact / unsaturated regime)** it reduces *exactly* to
+/// `sketch_overlap_lift` (`m_A=|A|`, `m_B=|B|`, `M=N`). Under saturation (`k < |cone|`) the weighted
+/// path applies the cardinality `cap` while the unweighted `sketch_overlap_lift` does not, so the
+/// reduction is then only approximate.
+///
+/// This is the null model of the **weighted configuration model** (Barrat et al. 2004; Newman 2004):
+/// `s_i·s_j / 2W` with admitted mass playing the role of strength `s` and `M` of total weight `W`.
 ///
 /// This is the read-out the weighted sketch was built for: the raw `sketch_overlap_lift` is fooled by
 /// the associative leak — two cones that overlap heavily on *out-of-domain* descendants look like a
 /// hub — but here the observed shared mass discounts those low-`μ` descendants, so a leak-driven false
-/// hub collapses to `lift ≈ 0` while a real in-domain hub stays `> 1`. `0` if either cone has no mass.
+/// hub collapses below chance (`lift < 1`) while a real in-domain hub stays `> 1`.
+///
+/// # Preconditions
+/// - `total_mu` must be `Σ_all μ` over the **same** node universe the sketches were hashed from
+///   (`descendant_minhash_weighted`'s graph); a mismatched `total_mu` rescales every lift.
+/// - For `cap = CardCap::Ceiling(c)`, `c` must bound the cone **union** `|A ∪ B|`, not just the
+///   individual cones — the cap is applied to `m_A`, `m_B` *and* the union cardinality, and a ceiling
+///   sized to one cone lets the union exceed it, biasing the lift. Prefer `Universe(N)` (which bounds
+///   the union by construction) or `Uncapped` unless you have a safe global ceiling. (The lift ratio
+///   is in any case fairly *insensitive* to the cap: it appears in the numerator union-card and in the
+///   `m_A·m_B` denominator, so it largely cancels — the cap matters for the raw mass, less for the lift.)
+///
+/// Returns `0` if either cone has negligible mass (`< 1e-9·M`): a near-empty cone cannot support a
+/// meaningful lift, and dividing by its tiny expected value would amplify sketch noise into a
+/// spurious spike (the weighted resolution limit; product-lift RSE ≈ `√3/√k`). Gate harder upstream
+/// if your application has many small cones.
 pub fn sketch_mu_overlap_lift(
     a: &[(u64, f64)],
     b: &[(u64, f64)],
@@ -1847,6 +1868,10 @@ pub fn sketch_mu_overlap_lift(
         return 0.0;
     }
     let (m_a, m_b) = (sketch_mu_mass(a, k, cap), sketch_mu_mass(b, k, cap));
+    let floor = 1e-9 * total_mu; // resolution-limit gate: tiny cones cannot carry a meaningful lift
+    if m_a < floor || m_b < floor {
+        return 0.0;
+    }
     let expected = m_a * m_b / total_mu;
     if expected <= 0.0 {
         return 0.0;
@@ -4907,9 +4932,10 @@ mod tests {
             "μ-mass must be depth-stable: weighted growth {wmass_growth} vs raw {raw_growth}");
     }
 
-    // μ-weighted overlap LIFT reduces to the unweighted sketch_overlap_lift at μ≡1. Diamond: 3->[1,2],
-    // 4->[3]; 1,2->0. cone(1)={1,3,4}, cone(2)={2,3,4}, ∩={3,4}. k >> cone ⇒ exact, so the two lifts
-    // must agree to 1e-9.
+    // μ-weighted overlap LIFT reduces to the unweighted sketch_overlap_lift at μ≡1 — but only in the
+    // exact (k≥cone) regime; under saturation the weighted path applies the cap and the unweighted does
+    // not. Diamond: 3->[1,2], 4->[3]; 1,2->0. cone(1)={1,3,4}, cone(2)={2,3,4}, ∩={3,4}. k >> cone ⇒
+    // exact, so the two lifts must agree to 1e-9.
     #[test]
     fn mu_overlap_lift_reduces_to_unweighted_at_mu_one() {
         const K: usize = 16;
@@ -4929,42 +4955,44 @@ mod tests {
         assert!(weighted > 1.0, "1 and 2 funnel into the shared {{3,4}} more than chance");
     }
 
-    // THE HUB-SELECTOR PAYOFF: the μ-weighted lift discriminates a real in-domain hub from a
-    // leak-driven false hub where the UNWEIGHTED lift cannot. Two cone-pairs with IDENTICAL sizes
-    // (so identical unweighted lift): pair A,B shares 40 in-domain nodes (μ=1); pair C,D shares 40
-    // out-of-domain leak nodes (μ=0.02). Both also carry 30 private in-domain children so their total
-    // MASS is comparable. The unweighted lift is fooled (equal); the weighted lift ranks the real hub
-    // above chance (>1) and pushes the leak hub below chance (<1).
-    #[test]
-    fn mu_overlap_lift_separates_real_hub_from_leak_hub() {
-        const K: usize = 128; // > every cone (71) ⇒ exact
+    // Hub test graph: nodes 1,2 are the REAL-hub queries (share 40 in-domain μ=1 nodes); 3,4 are the
+    // LEAK-hub queries (share 40 out-of-domain μ=0.02 nodes). Each of 1,2,3,4 also carries 30 private
+    // in-domain children so all four cones have comparable MASS and IDENTICAL size (71). 300 filler
+    // nodes under a filler root inflate the universe (small-world background). 505 nodes total.
+    fn hub_test_graph() -> (HashMap<u32, Vec<u32>>, HashMap<u32, f64>) {
         let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
         let mut mu: HashMap<u32, f64> = HashMap::new();
-        for q in [1u32, 2, 3, 4] { mu.insert(q, 1.0); } // 1,2 real hub queries; 3,4 leak hub queries
+        for q in [1u32, 2, 3, 4] { mu.insert(q, 1.0); }
         let mut next = 1000u32;
-        // Private in-domain children (μ=1): 30 under each of 1,2,3,4 — gives all four cones in-domain bulk.
         for &q in &[1u32, 2, 3, 4] {
             for _ in 0..30 { let c = next; next += 1; g.insert(c, vec![q]); mu.insert(c, 1.0); }
         }
-        // Shared CORE for the real hub: 40 in-domain nodes under BOTH 1 and 2 (μ=1).
-        for _ in 0..40 { let s = next; next += 1; g.insert(s, vec![1, 2]); mu.insert(s, 1.0); }
-        // Shared LEAK for the false hub: 40 out-of-domain nodes under BOTH 3 and 4 (μ=0.02).
-        for _ in 0..40 { let l = next; next += 1; g.insert(l, vec![3, 4]); mu.insert(l, 0.02); }
-        // Filler to inflate the universe (small-world background): 300 nodes under a filler root.
+        for _ in 0..40 { let s = next; next += 1; g.insert(s, vec![1, 2]); mu.insert(s, 1.0); }   // real core
+        for _ in 0..40 { let l = next; next += 1; g.insert(l, vec![3, 4]); mu.insert(l, 0.02); }  // leak
         let froot = next; next += 1; mu.insert(froot, 0.5);
         for _ in 0..300 { let f = next; next += 1; g.insert(f, vec![froot]); mu.insert(f, 0.5); }
+        (g, mu)
+    }
 
+    // THE HUB-SELECTOR PAYOFF (exact regime, k > cone): the μ-weighted lift discriminates a real
+    // in-domain hub from a leak-driven false hub where the UNWEIGHTED lift cannot. With IDENTICAL
+    // cone sizes the unweighted lift is fooled (equal); the weighted lift ranks the real hub above
+    // chance (>1) and pushes the leak hub below chance (<1), a ~10× separation.
+    #[test]
+    fn mu_overlap_lift_separates_real_hub_from_leak_hub() {
+        const K: usize = 128; // > every cone (71) ⇒ exact, so the numbers are deterministic
+        let (g, mu) = hub_test_graph();
         let d = descendant_minhash(&g, K).unwrap();
         let w = descendant_minhash_weighted(&g, &mu, K).unwrap();
-        let n = d.len();
+        let n = d.len(); // 505 reachable nodes (every node appears as a parent or child edge)
         let total_mu: f64 = mu.values().sum();
 
         let unw_real = sketch_overlap_lift(&d[&1], &d[&2], n, K);
         let unw_leak = sketch_overlap_lift(&d[&3], &d[&4], n, K);
         let w_real = sketch_mu_overlap_lift(&w[&1], &w[&2], total_mu, K, n);
         let w_leak = sketch_mu_overlap_lift(&w[&3], &w[&4], total_mu, K, n);
-        eprintln!("hub-lift: unweighted real {:.2} leak {:.2} (FOOLED) | weighted real {:.2} leak {:.2}",
-            unw_real, unw_leak, w_real, w_leak);
+        eprintln!("hub-lift exact: unweighted real {:.2} leak {:.2} (FOOLED) | weighted real {:.2} leak {:.2} ({:.1}×)",
+            unw_real, unw_leak, w_real, w_leak, w_real / w_leak);
 
         // Unweighted lift cannot tell them apart (identical cone sizes).
         assert!((unw_real - unw_leak).abs() < 1e-6, "unweighted lift is fooled: real {unw_real} leak {unw_leak}");
@@ -4972,7 +5000,52 @@ mod tests {
         // Weighted lift: real hub is an excess in-domain funnel; leak hub falls below chance.
         assert!(w_real > 1.0, "real in-domain hub: weighted lift > 1 ({w_real})");
         assert!(w_leak < 1.0, "leak hub correctly suppressed below chance ({w_leak})");
-        assert!(w_real > w_leak * 5.0, "real hub ranks far above the leak hub ({w_real} vs {w_leak})");
+        assert!(w_real > w_leak * 9.0, "real hub ranks ~10× above the leak hub ({w_real} vs {w_leak})");
+    }
+
+    // R1 SATURATED regime (k < cone): the exact tests never reach the KMV-estimator/cap branch since
+    // every cone (71) fits in k. Here k=32 forces saturation, exercising that branch in the lift. Two
+    // claims: (a) the real-vs-leak discrimination SURVIVES sketching, and (b) the cap is load-bearing
+    // — a Ceiling below the cone size visibly clips the saturated mass the lift consumes (whereas the
+    // lift *ratio* is largely cap-insensitive, since the cap appears in both numerator and denominator).
+    #[test]
+    fn mu_overlap_lift_saturated_regime_and_cap_is_live() {
+        const K: usize = 32; // < cone (71) ⇒ sketches SATURATE
+        let (g, mu) = hub_test_graph();
+        let w = descendant_minhash_weighted(&g, &mu, K).unwrap();
+        let n = w.len();
+        let total_mu: f64 = mu.values().sum();
+        assert_eq!(w[&1].len(), K, "cone(1) sketch is saturated at k");
+
+        // (a) discrimination survives saturation.
+        let w_real = sketch_mu_overlap_lift(&w[&1], &w[&2], total_mu, K, n);
+        let w_leak = sketch_mu_overlap_lift(&w[&3], &w[&4], total_mu, K, n);
+        eprintln!("hub-lift saturated k={}: weighted real {:.2} leak {:.2}", K, w_real, w_leak);
+        assert!(w_real > w_leak * 3.0, "ranking survives saturation: real {w_real} leak {w_leak}");
+
+        // (b) the cap is load-bearing in the saturated regime: a Ceiling below the cone clips the mass.
+        let uncapped = sketch_mu_mass(&w[&1], K, CardCap::Uncapped);
+        let clipped = sketch_mu_mass(&w[&1], K, CardCap::Ceiling(20.0));
+        assert!(uncapped > 25.0, "uncapped saturated mass tracks the ~71-node cone, got {uncapped}");
+        assert!((clipped - 20.0).abs() < 1e-9, "Ceiling(20) clips the saturated mass (mean_w=1), got {clipped}");
+        // Universe(505) doesn't bite (cone << 505), so it matches Uncapped — and the lift ratio barely
+        // moves under a different cap (numerator/denominator cancellation).
+        assert_eq!(sketch_mu_mass(&w[&1], K, CardCap::Universe(505)), uncapped, "Universe(505) doesn't clip a 71-cone");
+    }
+
+    // NB6 edge cases: disjoint cones ⇒ lift 0; total_mu=0 ⇒ no panic, lift 0.
+    #[test]
+    fn mu_overlap_lift_edge_cases() {
+        const K: usize = 16;
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        // Two fully disjoint cones: {10}->{1}, {20}->{2}. No shared descendants.
+        g.insert(10, vec![1]); g.insert(20, vec![2]);
+        let mu: HashMap<u32, f64> = [(1u32, 1.0), (2, 1.0), (10, 1.0), (20, 1.0)].into_iter().collect();
+        let total_mu: f64 = mu.values().sum();
+        let w = descendant_minhash_weighted(&g, &mu, K).unwrap();
+        assert_eq!(sketch_mu_overlap_lift(&w[&1], &w[&2], total_mu, K, 4usize), 0.0, "disjoint ⇒ lift 0");
+        // total_mu = 0 must not panic (degenerate universe).
+        assert_eq!(sketch_mu_overlap_lift(&w[&1], &w[&2], 0.0, K, 4usize), 0.0, "total_mu=0 ⇒ 0, no panic");
     }
 
     // IC-based semantic similarity (Resnik/Lin) via the descendant sketch -- the calibrated,

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -1848,9 +1848,13 @@ pub fn sketch_mu_overlap(a: &[(u64, f64)], b: &[(u64, f64)], k: usize, cap: impl
 /// - For `cap = CardCap::Ceiling(c)`, `c` must bound the cone **union** `|A ∪ B|`, not just the
 ///   individual cones — the cap is applied to `m_A`, `m_B` *and* the union cardinality, and a ceiling
 ///   sized to one cone lets the union exceed it, biasing the lift. Prefer `Universe(N)` (which bounds
-///   the union by construction) or `Uncapped` unless you have a safe global ceiling. (The lift ratio
-///   is in any case fairly *insensitive* to the cap: it appears in the numerator union-card and in the
-///   `m_A·m_B` denominator, so it largely cancels — the cap matters for the raw mass, less for the lift.)
+///   the union by construction) or `Uncapped` unless you have a safe global ceiling. **The absolute
+///   lift is *not* cap-invariant:** when a ceiling `c` bites below the cone cardinalities it scales the
+///   numerator union-card once and the `m_A·m_B` denominator twice, so `lift ∝ 1/c` (a ceiling of `10`
+///   on a `~70`-node cone inflates the lift ~5× over `Uncapped`). What the cap *does* preserve is the
+///   **relative ranking** between cones — it rescales every cone comparably, so it (approximately)
+///   cancels in a `lift_A / lift_B` comparison. Use `Universe(N)` for a *calibrated* absolute lift;
+///   a `Ceiling` only changes the scale, not the hub *ordering*.
 ///
 /// Returns `0` if either cone has negligible mass (`< 1e-9·M`): a near-empty cone cannot support a
 /// meaningful lift, and dividing by its tiny expected value would amplify sketch noise into a
@@ -5006,8 +5010,8 @@ mod tests {
     // R1 SATURATED regime (k < cone): the exact tests never reach the KMV-estimator/cap branch since
     // every cone (71) fits in k. Here k=32 forces saturation, exercising that branch in the lift. Two
     // claims: (a) the real-vs-leak discrimination SURVIVES sketching, and (b) the cap is load-bearing
-    // — a Ceiling below the cone size visibly clips the saturated mass the lift consumes (whereas the
-    // lift *ratio* is largely cap-insensitive, since the cap appears in both numerator and denominator).
+    // — a Ceiling below the cone size visibly clips the saturated mass the lift consumes. (How the cap
+    // moves the *lift* is pinned separately in mu_overlap_lift_cap_rescales_absolute_keeps_ranking.)
     #[test]
     fn mu_overlap_lift_saturated_regime_and_cap_is_live() {
         const K: usize = 32; // < cone (71) ⇒ sketches SATURATE
@@ -5028,9 +5032,36 @@ mod tests {
         let clipped = sketch_mu_mass(&w[&1], K, CardCap::Ceiling(20.0));
         assert!(uncapped > 25.0, "uncapped saturated mass tracks the ~71-node cone, got {uncapped}");
         assert!((clipped - 20.0).abs() < 1e-9, "Ceiling(20) clips the saturated mass (mean_w=1), got {clipped}");
-        // Universe(505) doesn't bite (cone << 505), so it matches Uncapped — and the lift ratio barely
-        // moves under a different cap (numerator/denominator cancellation).
+        // Universe(505) doesn't bite (cone << 505), so it matches Uncapped on the raw mass.
         assert_eq!(sketch_mu_mass(&w[&1], K, CardCap::Universe(505)), uncapped, "Universe(505) doesn't clip a 71-cone");
+    }
+
+    // Corrected cap nuance (the earlier "lift is cap-insensitive" claim was wrong). A Ceiling that
+    // bites below the cone cardinalities does NOT cancel in the lift: it scales the numerator union-
+    // card once and the m_A·m_B denominator twice, so the ABSOLUTE lift ∝ 1/c. What survives is the
+    // RANKING: the cap rescales every cone comparably, so lift_real / lift_leak is ~preserved. Use
+    // Universe(N) for a calibrated absolute lift; a Ceiling only changes the scale, not the order.
+    #[test]
+    fn mu_overlap_lift_cap_rescales_absolute_keeps_ranking() {
+        const K: usize = 32; // saturated, so the cap bites
+        let (g, mu) = hub_test_graph();
+        let w = descendant_minhash_weighted(&g, &mu, K).unwrap();
+        let total_mu: f64 = mu.values().sum();
+
+        let real = |cap: CardCap| sketch_mu_overlap_lift(&w[&1], &w[&2], total_mu, K, cap);
+        let leak = |cap: CardCap| sketch_mu_overlap_lift(&w[&3], &w[&4], total_mu, K, cap);
+
+        let (r_unc, r_c20, r_c10) = (real(CardCap::Uncapped), real(CardCap::Ceiling(20.0)), real(CardCap::Ceiling(10.0)));
+        // Absolute lift is NOT cap-invariant: tighter ceiling ⇒ larger lift, ∝ 1/c.
+        assert!(r_c10 > r_unc * 2.0, "Ceiling(10) inflates the absolute lift well above Uncapped ({r_c10} vs {r_unc})");
+        assert!((r_c10 / r_c20 - 2.0).abs() < 0.1, "absolute lift ∝ 1/c: c=10 vs c=20 ⇒ ~2× ({r_c10} vs {r_c20})");
+
+        // Ranking (real/leak) is ~preserved across caps — the property hub SELECTION relies on.
+        let ratio = |cap: CardCap| real(cap) / leak(cap);
+        let (q_unc, q_c10) = (ratio(CardCap::Uncapped), ratio(CardCap::Ceiling(10.0)));
+        assert!((q_unc / q_c10 - 1.0).abs() < 0.25, "real/leak ranking preserved under cap ({q_unc} vs {q_c10})");
+        eprintln!("cap-rescale: real Uncapped {:.2} → C20 {:.2} → C10 {:.2}; ranking q_unc {:.1} q_c10 {:.1}",
+            r_unc, r_c20, r_c10, q_unc, q_c10);
     }
 
     // NB6 edge cases: disjoint cones ⇒ lift 0; total_mu=0 ⇒ no panic, lift 0.


### PR DESCRIPTION
The global read-out the μ-weighted KMV sketch (#3273) was built for: **`sketch_mu_overlap_lift`**, the membership-aware analogue of `sketch_overlap_lift`. It measures shared *in-domain* mass against the **mass configuration-model null** `E = m_A·m_B / M` (a random unit of admitted mass sits in cone A with prob `m_A/M` and in B with prob `m_B/M`, independently), so `lift > 1` is an *excess in-domain funnel* — a genuine domain hub — and `lift ≈ 1` is the small-world background. At `μ ≡ 1` it reduces **exactly** to the unweighted `sketch_overlap_lift`.

## Why this is the payoff
This is where the associative leak finally bites the *global* signal and the weighting earns its keep. The raw `sketch_overlap_lift` is fooled by the leak: two cones that overlap heavily on *out-of-domain* descendants look like a hub. The weighted lift discounts those low-μ descendants.

The test `mu_overlap_lift_separates_real_hub_from_leak_hub` pits a real in-domain hub against a leak-driven false hub with **identical cone sizes** (so identical *unweighted* lift):

| | unweighted lift | weighted lift |
|---|---:|---:|
| real in-domain hub (shared μ=1) | 4.01 | **2.50** (excess funnel, > 1) |
| leak-driven false hub (shared μ=0.02) | 4.01 | **0.25** (below chance, suppressed) |

The unweighted lift cannot tell them apart; the weighted lift separates them 10×, and correctly pushes the leak hub *below* chance. (Numbers are exact — every cone is unsaturated at k=128.)

## Contents
- `sketch_mu_overlap_lift(a, b, total_mu, k, cap)` — `sketch_mu_overlap / (m_A·m_B/M)`, takes the same `CardCap` knob (`impl Into<CardCap>`).
- `mu_overlap_lift_reduces_to_unweighted_at_mu_one` — exact agreement with `sketch_overlap_lift` at μ≡1.
- `mu_overlap_lift_separates_real_hub_from_leak_hub` — the hub-selection demonstration above.
- Documented in §5d.

98/98 lib tests pass; Prolog template guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_