### PR TITLE
WAM-Rust: cone purity — a structural leak detector (real-data validated)

### DIFF
--- a/docs/design/WAM_RUST_CARET_REALDATA_MEASUREMENT_2026-06-18.md
+++ b/docs/design/WAM_RUST_CARET_REALDATA_MEASUREMENT_2026-06-18.md
@@ -253,43 +253,74 @@ graph-functional-semiring move applied to a *soft* node set rather than a hard o
    deeper reason structure alone can't pick good *global* bridges — the deferred diversity-based
    selection (§5d) is what would. Per-pair bridges, by contrast, are already good *without* it.
 
-## Addendum (2026-06-19) — cone purity confirms leak conduits are universal fan-in hubs
+## Addendum (2026-06-19) — cone purity as a leak detector, and what it taught us about leak structure
 
-Once `condense_scc` unblocked the descendant-sketch family on the raw cyclic graph, the
-μ-weighted machinery could finally run a *global* read-out on real data. Two things came out of it.
+Once `condense_scc` unblocked the descendant-sketch family on the raw cyclic graph, the μ-weighted
+machinery could finally run a *global* read-out on real data. A thread of investigation followed; the
+findings corrected several natural-but-wrong hypotheses (including some of my own first framings).
 
 **Measurement caveat first.** The μ-weighted KMV *sketch* underflows on the real graph: only 90 of
-8669 nodes are scored, so a `k=128` MinHash sample of a large cone routinely contains *zero* scored
+~8200 nodes are scored, so a `k=128` MinHash sample of a large cone routinely contains *zero* scored
 nodes and reports `mass ≈ 0`. For a one-off 8k-node measurement the right tool is the **exact**
 `descendant_mu_mass`; the sketch is for scale, not for a 1%-density signal in a whole-graph cone.
 
-**The finding (`wikipedia_cone_purity_flags_leak_conduits`).** Define **cone purity** `= m_μ(desc) /
-|desc|`, the in-domain fraction of a node's descendant cone (`cone_purity`). Measured on the condensed
-10k graph with exact masses:
+**Cone purity (`wikipedia_cone_purity_flags_leak_conduits`).** Define **cone purity** `= m_μ(desc) /
+|desc|`, the in-domain fraction of a node's descendant cone (`cone_purity`). `IC` is `−log₂(m_μ/N)`
+with `N` the raw node count (the direct μ-generalization of intrinsic IC — see below). On the
+condensed 10k graph, exact masses:
 
-| node | μ | raw cone | in-domain mass | purity | `IC_w` |
+| node | μ | raw cone | in-domain mass | purity | IC (`/N`) |
 |---|---|---:|---:|---:|---:|
-| `Matter` | 1.0 | **8669** (whole graph) | 37.9 (all) | **0.0044** | 0.00 |
-| `Physical_objects` | 0.5 | **8669** | 37.9 | **0.0044** | 0.00 |
-| `Astronomical_objects` | 0.7 | 5270 | 1.8 | **0.0003** | 4.40 |
-| `Time` | 1.0 | 3608 | 2.3 | **0.0006** | 4.04 |
-| `Thermodynamics` | 1.0 | 49 | 5.5 | **0.112** | 2.78 |
-| `Physical_quantity` | 1.0 | 49 | 5.5 | **0.112** | 2.78 |
-| `Atoms` | 0.9 | 214 | 6.0 | **0.0289** | 2.66 |
-| `States_of_matter` | 1.0 | 194 | 4.5 | **0.0223** | 3.07 |
+| `Matter` / `Physical_objects` (one SCC) | 1.0 / 0.5 | **~8000** (≈ whole graph) | 37.9 (all) | **0.0045** | **7.76** |
+| `Astronomical_objects` | 0.7 | 4632 | 1.8 | **0.0004** | 12.15 |
+| `Time` | 1.0 | 4101 | 2.3 | **0.0006** | 11.80 |
+| `Thermodynamics` / `Physical_quantity` | 1.0 | 49 | 5.5 | **0.112** | 10.54 |
+| `States_of_matter` | 1.0 | 231 | 4.5 | **0.0225** | 10.83 |
+| `Atoms` | 0.9 | 214 | 6.0 | **0.0276** | 10.42 |
 
-1. **Leak conduits are the universal fan-in hubs.** `Matter` and `Physical_objects` have a descendant
-   cone that *is the entire graph* — everything funnels up into them, so going down they reach
-   everything. That is exactly what makes them leak, and purity (`0.0044`) marks them; every clean
-   physics node is strictly purer, by `≥ 4.85×`. This confirms the hypothesis that the associative
-   leak is a **fan-in** phenomenon (concept mixing at a convergence node), not a per-edge accident.
-2. **Purity catches a leak `IC` cannot.** `Matter` is a genuine physics concept (μ=1) whose leaked
-   cone re-encompasses *all* in-domain mass, so `IC_w ≈ 0` reads it as maximally *general* — IC is
-   structurally blind to this total-leak case. Purity flags it because it divides by the *raw* cone
-   size, not the admitted mass. So `cone_purity` is a genuinely complementary signal, not a
-   restatement of μ-weighted IC.
-3. **Immediate fan-out is not the signal.** `Astronomical_objects` has a single child but a 5270-node
-   cone; `Time` has 8 children. Branching factor does not predict the leak — transitive cone
-   *diversity* (low purity) does. The fuller notion (entropy of a cone over *multiple* domains) would
-   need multi-domain μ; with a single physics-relevance μ, purity is the computable proxy and it
-   already separates leak conduits from clean hubs cleanly.
+1. **Purity cleanly separates leak conduits from clean hubs; IC does not.** Every clean physics node
+   is strictly purer than every leak conduit (`≥ 4.85×`). IC, by contrast, tracks in-domain *mass*,
+   which is unrelated to leak-ness, so the leak conduits **straddle** a clean node in IC rank: `Matter`
+   (huge in-domain mass) reads *more general* (`7.76`) than the clean `Atoms` (`10.42`), while
+   `Astronomical_objects` (tiny in-domain mass) reads *more specific* (`12.15`). Two leak conduits on
+   opposite sides of one clean node ⇒ IC ordering cannot isolate the leak; purity can.
+
+2. **Leak conduits are *generic apex* nodes, NOT high-fan-in hubs** (correcting my first framing).
+   With **fan-in = #parents, fan-out = #children**, a degree-vs-cone correlation over all ~8200 nodes
+   gives `corr(fan-in, cone) = −0.10` and `corr(fan-out, cone) = +0.17`. Fan-in **anti**-correlates:
+   more parents ⇒ *smaller* cone (a heavily cross-filed node is a *specific* node several domains each
+   claim). The big-cone leak conduits have *few* parents — they are generic nodes near the apex
+   (`Matter` has 1 parent). So the leak is not a fan-in (parent-convergence) phenomenon.
+
+3. **It is a transitive descendant-cone-diversity phenomenon, and immediate degree does not capture
+   it.** `Astronomical_objects` has a single child but a 4632-node cone; `Container_categories` has
+   1778 children and the same giant cone as `Animal_phyla` which has 1. Neither immediate fan-out nor
+   fan-in predicts the leak — the cone explodes *transitively*.
+
+4. **"Union vs intersection" is a real axis, but needs μ.** A node's children can be *coherent* (an
+   intersection/specialisation — child cones overlap) or a *disjoint union* (a grab-bag bucket).
+   Child-cone coherence (mean pairwise Jaccard of children's cones) directionally tracks it — the
+   leak SCC `Matter`/`Physical_objects` is the *least* coherent (`0.05`, disjoint children), `Mechanics`
+   the most (`0.30`). But coherence **cannot** separate a *good* union (a diverse but in-domain hub
+   like `Subfields_of_physics`, coherence `0.10`) from a *bad* one (a diverse out-of-domain bucket
+   like `Time`, `0.12`) — they cross over. Structure sees *diversity*, not *domain*; only `μ` (purity)
+   tells in-domain diversity from leak. This re-confirms the arc's thesis: topology alone can't find
+   leaks — the external membership signal is irreducible.
+
+**On the IC denominator (`N` vs `Σμ`).** Intrinsic IC is `−log₂(|desc|/N)`; the direct μ-generalization
+weights the *numerator* count (`|desc| → m_μ`) and keeps `N` as the reference universe:
+`IC = −log₂(m_μ/N)`. An earlier version normalized by `Σμ` instead, which is the in-domain-*conditional*
+IC and pins any cone that sweeps all in-domain mass to `IC = 0` (the misleading `Matter = 0.00`). The
+two differ by the constant offset `log₂(N/Σμ) ≈ 7.8`, so node *ranking* is identical, but `/N` avoids
+the degenerate zero and reads as absolute generality against the whole graph. (`Σμ` is the right
+denominator for μ-weighted *similarity* — Lin/FaITH — where the offset would compress scores toward 1;
+that read-out is future work.)
+
+**What μ-weighting does and does not fix.** It cancels the **out-of-domain** leak (biology, geography
+descendants contribute `0`). It does **not** fix the **in-domain** leak: `Matter`'s cone wrongly
+contains other physics concepts (`Energy`, `Optics`) which are genuinely in-domain (`μ=1`), so they
+*are* counted — membership can't veto a bad *edge*. That residual is why `Matter` still ranks most-
+general, and why the robust real-data answer remains the **per-pair bidirectional bridge** (or
+bounded-depth scoping), not the global descendant cone. A distance-discounted descendant mass (down-
+weighting in-domain nodes reached only via long leak paths) is the candidate mechanism to attack it,
+and is deferred future work.

--- a/docs/design/WAM_RUST_CARET_REALDATA_MEASUREMENT_2026-06-18.md
+++ b/docs/design/WAM_RUST_CARET_REALDATA_MEASUREMENT_2026-06-18.md
@@ -252,3 +252,44 @@ graph-functional-semiring move applied to a *soft* node set rather than a hard o
    `Physicists_by_nationality` over `Subfields_of_physics`; the associative-leak finding is the
    deeper reason structure alone can't pick good *global* bridges — the deferred diversity-based
    selection (§5d) is what would. Per-pair bridges, by contrast, are already good *without* it.
+
+## Addendum (2026-06-19) — cone purity confirms leak conduits are universal fan-in hubs
+
+Once `condense_scc` unblocked the descendant-sketch family on the raw cyclic graph, the
+μ-weighted machinery could finally run a *global* read-out on real data. Two things came out of it.
+
+**Measurement caveat first.** The μ-weighted KMV *sketch* underflows on the real graph: only 90 of
+8669 nodes are scored, so a `k=128` MinHash sample of a large cone routinely contains *zero* scored
+nodes and reports `mass ≈ 0`. For a one-off 8k-node measurement the right tool is the **exact**
+`descendant_mu_mass`; the sketch is for scale, not for a 1%-density signal in a whole-graph cone.
+
+**The finding (`wikipedia_cone_purity_flags_leak_conduits`).** Define **cone purity** `= m_μ(desc) /
+|desc|`, the in-domain fraction of a node's descendant cone (`cone_purity`). Measured on the condensed
+10k graph with exact masses:
+
+| node | μ | raw cone | in-domain mass | purity | `IC_w` |
+|---|---|---:|---:|---:|---:|
+| `Matter` | 1.0 | **8669** (whole graph) | 37.9 (all) | **0.0044** | 0.00 |
+| `Physical_objects` | 0.5 | **8669** | 37.9 | **0.0044** | 0.00 |
+| `Astronomical_objects` | 0.7 | 5270 | 1.8 | **0.0003** | 4.40 |
+| `Time` | 1.0 | 3608 | 2.3 | **0.0006** | 4.04 |
+| `Thermodynamics` | 1.0 | 49 | 5.5 | **0.112** | 2.78 |
+| `Physical_quantity` | 1.0 | 49 | 5.5 | **0.112** | 2.78 |
+| `Atoms` | 0.9 | 214 | 6.0 | **0.0289** | 2.66 |
+| `States_of_matter` | 1.0 | 194 | 4.5 | **0.0223** | 3.07 |
+
+1. **Leak conduits are the universal fan-in hubs.** `Matter` and `Physical_objects` have a descendant
+   cone that *is the entire graph* — everything funnels up into them, so going down they reach
+   everything. That is exactly what makes them leak, and purity (`0.0044`) marks them; every clean
+   physics node is strictly purer, by `≥ 4.85×`. This confirms the hypothesis that the associative
+   leak is a **fan-in** phenomenon (concept mixing at a convergence node), not a per-edge accident.
+2. **Purity catches a leak `IC` cannot.** `Matter` is a genuine physics concept (μ=1) whose leaked
+   cone re-encompasses *all* in-domain mass, so `IC_w ≈ 0` reads it as maximally *general* — IC is
+   structurally blind to this total-leak case. Purity flags it because it divides by the *raw* cone
+   size, not the admitted mass. So `cone_purity` is a genuinely complementary signal, not a
+   restatement of μ-weighted IC.
+3. **Immediate fan-out is not the signal.** `Astronomical_objects` has a single child but a 5270-node
+   cone; `Time` has 8 children. Branching factor does not predict the leak — transitive cone
+   *diversity* (low purity) does. The fuller notion (entropy of a cone over *multiple* domains) would
+   need multi-domain μ; with a single physics-relevance μ, purity is the computable proxy and it
+   already separates leak conduits from clean hubs cleanly.

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -865,6 +865,19 @@ calibration of the relatedness read-out.)
 >   (+444) while the μ-mass grows only `5 → 18` (+13), ~3% of the raw growth. So the **weighted count
 >   converges as you descend** where the raw count diverges: a depth-robust global signal, which is
 >   the property the global hub problem needs.
+> - **Cone purity — the fan-in-hub leak detector** (`cone_purity`, validated on real data,
+>   `wikipedia_cone_purity_flags_leak_conduits`). `purity = m_μ(desc) / |desc|` — the in-domain
+>   *fraction* of a node's cone. This confirms a structural hypothesis about the leak: the worst leak
+>   conduits are the **universal fan-in hubs** — a node *everything* funnels up into has a down-cone
+>   that *is* everything, so it drags a vast, mostly-out-of-domain cone into the domain. On the real
+>   Wikipedia graph `Matter` and `Physical_objects` have a descendant cone of **all 8669 nodes**;
+>   their purity is `0.0044` vs clean physics nodes (`Thermodynamics`, `Physical_quantity`) at `0.112`
+>   (25×), and *every* clean node is strictly purer than *every* leak conduit. Crucially **purity
+>   catches a leak μ-weighted IC cannot**: `Matter` (μ=1, a real physics concept) has a cone that
+>   re-encompasses *all* in-domain mass, so `IC_w ≈ 0` reads it as maximally *general* — IC is blind to
+>   it — yet `purity = 0.0044` flags it, because it divides by the *raw* cone size. (Immediate fan-out
+>   — child count — is *not* the signal: `Astronomical_objects` has 1 child but a 5270-node cone; it is
+>   transitive cone *diversity*, i.e. low purity, that marks a leak.)
 >
 > **Novel-contribution flag.** Resnik-style IC over a frequency null (Resnik 1995; Seco 2004's
 > intrinsic descendant-count form) is established; *graded* (fuzzy `μ ∈ [0,1]`) **partial admission**

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -865,19 +865,26 @@ calibration of the relatedness read-out.)
 >   (+444) while the μ-mass grows only `5 → 18` (+13), ~3% of the raw growth. So the **weighted count
 >   converges as you descend** where the raw count diverges: a depth-robust global signal, which is
 >   the property the global hub problem needs.
-> - **Cone purity — the fan-in-hub leak detector** (`cone_purity`, validated on real data,
+> - **Cone purity — a structural leak detector** (`cone_purity`, validated on real data,
 >   `wikipedia_cone_purity_flags_leak_conduits`). `purity = m_μ(desc) / |desc|` — the in-domain
->   *fraction* of a node's cone. This confirms a structural hypothesis about the leak: the worst leak
->   conduits are the **universal fan-in hubs** — a node *everything* funnels up into has a down-cone
->   that *is* everything, so it drags a vast, mostly-out-of-domain cone into the domain. On the real
->   Wikipedia graph `Matter` and `Physical_objects` have a descendant cone of **all 8669 nodes**;
->   their purity is `0.0044` vs clean physics nodes (`Thermodynamics`, `Physical_quantity`) at `0.112`
->   (25×), and *every* clean node is strictly purer than *every* leak conduit. Crucially **purity
->   catches a leak μ-weighted IC cannot**: `Matter` (μ=1, a real physics concept) has a cone that
->   re-encompasses *all* in-domain mass, so `IC_w ≈ 0` reads it as maximally *general* — IC is blind to
->   it — yet `purity = 0.0044` flags it, because it divides by the *raw* cone size. (Immediate fan-out
->   — child count — is *not* the signal: `Astronomical_objects` has 1 child but a 5270-node cone; it is
->   transitive cone *diversity*, i.e. low purity, that marks a leak.)
+>   *fraction* of a node's cone. The leak conduits are **generic apex nodes** with a vast, mostly
+>   out-of-domain descendant cone: on the real Wikipedia graph `Matter` and `Physical_objects` (which
+>   share an SCC) have a descendant cone of essentially the whole graph, purity `0.0045` vs clean
+>   physics nodes (`Thermodynamics`, `Physical_quantity`) at `0.112` (25×), and *every* clean node is
+>   strictly purer than *every* leak conduit. **Purity catches what IC cannot**, but the precise reason
+>   matters: `IC` tracks in-domain *mass*, which is unrelated to leak-ness, so the leak conduits
+>   *straddle* a clean node in IC rank — `Matter` (huge in-domain mass) reads as **more general** than
+>   the clean `Atoms`, while `Astronomical_objects` (tiny in-domain mass) reads as **more specific** —
+>   two leak conduits on opposite sides of a clean node, so IC ordering cannot isolate the leak.
+>   *Note on the IC denominator:* the read-out uses `−log₂(m_μ/N)` (raw node count `N`, the direct
+>   μ-generalization of intrinsic IC), so `Matter` is `7.76`, **not** the misleading `0` that the
+>   in-domain-conditional denominator `Σμ` produces. *(Two structural caveats: immediate fan-out (child
+>   count) is **not** the signal — `Astronomical_objects` has 1 child but a 5270-node cone; and fan-in
+>   (#parents) **anti**-correlates with cone size (−0.10) — leak conduits are *low* fan-in generic
+>   nodes, not high fan-in. The leak is a transitive descendant-cone-diversity phenomenon. A purely
+>   structural proxy, child-cone coherence, partly detects the "union vs intersection" character of
+>   such nodes but cannot separate a diverse in-domain hub from a diverse leak bucket — only `μ` can,
+>   which is why purity needs the membership signal.)*
 >
 > **Novel-contribution flag.** Resnik-style IC over a frequency null (Resnik 1995; Seco 2004's
 > intrinsic descendant-count form) is established; *graded* (fuzzy `μ ∈ [0,1]`) **partial admission**

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -1648,28 +1648,39 @@ pub fn information_content(dsig: &[u64], n_total: usize, k: usize) -> f64 {
 }
 
 /// **μ-weighted ("partial admission") information content.** Standard `IC` counts every descendant
-/// as `1`; here each node is admitted with weight `μ ∈ [0,1]`, so `IC_μ(t) = −log₂( m_μ(t) / M_μ )`
-/// with `m_μ(t) = Σ_{d∈desc(t)} μ_d` the admitted mass under `t` and `M_μ = Σ_all μ` the total. Low-μ
-/// (out-of-domain / leaked) descendants barely count, so a *domain* node whose cone is bloated by
-/// the associative leak — which the raw `IC` mistakes for *generality* (a big cone → low IC) — has
-/// its effective cone shrunk back to its in-domain size and its IC *raised* to its true specificity.
-/// `μ ≡ 1` recovers `information_content`. (`m_μ` is the **distinct** weighted mass; see
-/// `descendant_mu_mass`.)
+/// as `1`; here each node is admitted with weight `μ ∈ [0,1]`, so `IC_μ(t) = −log₂( m_μ(t) / D )`
+/// with `m_μ(t) = Σ_{d∈desc(t)} μ_d` the admitted mass under `t`. Low-μ (out-of-domain / leaked)
+/// descendants barely count, so a *domain* node whose cone is bloated by the associative leak — which
+/// the raw `IC` mistakes for *generality* (a big cone → low IC) — has its effective cone shrunk back
+/// to its in-domain size. `μ ≡ 1` recovers `information_content`. (`m_μ` is the **distinct** weighted
+/// mass; see `descendant_mu_mass`.)
+///
+/// **The denominator `D` is a choice of *reference universe*, and it is the caller's** (the second
+/// argument). Two principled options, identical at `μ ≡ 1` (then `Σμ = N`), differing by the constant
+/// offset `log₂(N/Σμ)` otherwise:
+/// - **`D = N`, the raw node count** — the *direct* generalization of intrinsic IC (`−log₂(|desc|/N)`
+///   with the count μ-weighted, universe unchanged). Absolute generality against the full graph; a
+///   node whose cone sweeps *all* in-domain mass is **not** pinned to `IC = 0` (it gets `−log₂(Σμ/N) >
+///   0`). Prefer this for generality / leak read-outs.
+/// - **`D = Σμ`, the total admitted mass** — the in-domain-*conditional* IC ("IC within the in-domain
+///   world"), `IC = 0` at the in-domain root. Prefer this for μ-weighted *similarity* (Lin/FaITH),
+///   which the `N`-offset would compress toward 1. (`Σμ ≤ N`, so this gives larger IC values.)
+/// Either way `D > 0` and `m_μ ≤ D` are required.
 ///
 /// **Boundary semantics** (the two limits are *opposite*, so we do not collapse both to `0`):
 /// - `desc_mu_mass = 0` with `total_mu > 0` is a genuinely *empty* (fully out-of-domain) cone —
 ///   `p = 0`, so `IC = −log₂ 0 = +∞`, the maximal-surprise limit. We return `f64::INFINITY`, not
 ///   `0.0` (which would wrongly read as *root-like / fully general*, the exact inversion of an
 ///   empty cone). Callers that aggregate IC should treat `+∞` as "drop / out of domain".
-/// - `total_mu ≤ 0` is a precondition violation (no admitted mass anywhere ⇒ no probability space):
-///   `IC` is undefined. `debug_assert` catches it in tests; release returns `0.0` as a safe inert
-///   fallback. `total_mu` must be `Σ_all μ` (the full universe mass), with `desc_mu_mass ≤ total_mu`.
+/// - `total_mu ≤ 0` (the denominator `D`) is a precondition violation (no universe ⇒ no probability
+///   space): `IC` is undefined. `debug_assert` catches it in tests; release returns `0.0` as a safe
+///   inert fallback. `D` must be the chosen reference universe (`N` or `Σμ`), with `desc_mu_mass ≤ D`.
 pub fn information_content_weighted(desc_mu_mass: f64, total_mu: f64) -> f64 {
-    debug_assert!(total_mu > 0.0, "total_mu must be the positive universe mass Σ_all μ");
+    debug_assert!(total_mu > 0.0, "denominator (reference universe N or Σμ) must be positive");
     debug_assert!(desc_mu_mass >= 0.0, "desc_mu_mass is a sum of μ≥0 and cannot be negative");
     debug_assert!(
         desc_mu_mass <= total_mu + 1e-9,
-        "desc_mu_mass ({desc_mu_mass}) exceeds total_mu ({total_mu}); total_mu is not Σ_all μ"
+        "desc_mu_mass ({desc_mu_mass}) exceeds the denominator ({total_mu}); m_μ ≤ {{N or Σμ}} required"
     );
     if total_mu <= 0.0 {
         return 0.0; // undefined universe; inert fallback (see doc)
@@ -5118,33 +5129,40 @@ mod tests {
         const K: usize = 128;
         let cond = condense_scc(&parents);
         let cmu = lift_mu_to_components(&mu, &cond);
-        let total_mu: f64 = cmu.values().sum();
         let mass = descendant_mu_mass(&cond.parents, &cmu); // EXACT (avoid the sparse-sample underflow)
         let d = descendant_minhash(&cond.parents, K).unwrap();
-        let purity = |nm: &str| -> Option<(f64, f64)> { // (purity, IC_w)
+        // IC denominator is the RAW universe size N (component count) — the direct μ-generalization of
+        // intrinsic IC `−log₂(m_μ/N)`: μ weights the numerator count, N stays the reference universe.
+        // (Normalizing by Σμ instead would be the in-domain-CONDITIONAL IC — reserved for μ-weighted
+        // similarity, where the offset log₂(N/Σμ) matters; here we want absolute generality.)
+        let n_universe = cond.members.len() as f64;
+        let stat = |nm: &str| -> Option<(f64, f64)> { // (purity, IC)
             let c = cond.comp[ids.get(nm)?];
             let cone = sketch_card(&d[&c], K);
-            Some((cone_purity(mass[&c], cone), information_content_weighted(mass[&c], total_mu)))
+            Some((cone_purity(mass[&c], cone), information_content_weighted(mass[&c], n_universe)))
         };
         let leaks = ["Matter", "Physical_objects", "Astronomical_objects", "Time"];
         let clean = ["Thermodynamics", "Physical_quantity", "Atoms", "States_of_matter"];
         let mut leak_max = 0.0f64;
-        for nm in leaks { if let Some((p, ic)) = purity(nm) {
-            eprintln!("purity[leak]  {:20} {:.4}  IC_w {:.2}", nm, p, ic);
+        for nm in leaks { if let Some((p, ic)) = stat(nm) {
+            eprintln!("purity[leak]  {:20} {:.4}  IC {:.2}", nm, p, ic);
             leak_max = leak_max.max(p);
         }}
         let mut clean_min = 1.0f64;
-        for nm in clean { if let Some((p, ic)) = purity(nm) {
-            eprintln!("purity[clean] {:20} {:.4}  IC_w {:.2}", nm, p, ic);
+        for nm in clean { if let Some((p, ic)) = stat(nm) {
+            eprintln!("purity[clean] {:20} {:.4}  IC {:.2}", nm, p, ic);
             clean_min = clean_min.min(p);
         }}
-        // The leak conduits are strictly, substantially less pure than the clean physics nodes.
+        // Purity STRICTLY separates leak conduits from clean physics nodes.
         assert!(leak_max < clean_min, "every leak conduit is strictly less pure than every clean node (floor {clean_min} > ceil {leak_max})");
         assert!(clean_min > leak_max * 4.0, "clean physics ≥4× purer than the leakiest conduit (measured ~4.85×)");
-        // Purity catches Matter, which IC reads as maximally general (the leak IC cannot see).
-        if let Some((p, ic)) = purity("Matter") {
-            assert!(ic < 0.1 && p < 0.02, "Matter: IC sees it as general ({ic:.2}) but purity flags the leak ({p:.4})");
-        }
+        // IC does NOT — it tracks in-domain MASS, not leak-ness, so leak conduits straddle a clean
+        // node in IC rank: Matter (huge in-domain mass) reads as MORE general than the clean Atoms,
+        // while Astronomical_objects (tiny in-domain mass) reads as MORE specific. Two leak conduits
+        // on opposite sides of a clean node ⇒ IC cannot isolate the leak; purity can.
+        let (ic_matter, ic_astro, ic_atoms) = (stat("Matter").unwrap().1, stat("Astronomical_objects").unwrap().1, stat("Atoms").unwrap().1);
+        assert!(ic_matter < ic_atoms && ic_atoms < ic_astro,
+            "IC straddles a clean node with leaks: Matter {ic_matter:.2} < Atoms {ic_atoms:.2} < Astronomical {ic_astro:.2}");
     }
 
     // μ-weighted KMV sketch: the scalable companion to the exact descendant_mu_mass. With k >> cone

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -1891,6 +1891,31 @@ pub fn information_content_weighted_sketch(s: &[(u64, f64)], total_mu: f64, k: u
     information_content_weighted(sketch_mu_mass(s, k, cap.into()).min(total_mu), total_mu)
 }
 
+/// **Cone purity — the fan-in-hub leak detector.** The in-domain *fraction* of a node's descendant
+/// cone: `purity = m_μ(desc) / |desc|` ∈ `[0,1]`, the admitted (weighted) mass over the raw distinct
+/// cone size. A **leak conduit** has *low* purity — a huge cone that is mostly *out-of-domain* — while
+/// a clean in-domain region has *high* purity. This is the structural signature of the associative
+/// leak: a universal fan-in hub (a node everything funnels up into, so its down-cone is everything)
+/// pulls a vast, semantically scattered cone into the domain, and purity measures exactly how diluted
+/// that cone is.
+///
+/// **Complement to μ-weighted IC, and it catches a leak IC cannot.** IC `−log₂(m_μ/Σμ)` measures cone
+/// *size* (specificity); purity measures cone *in-domain fraction* (leak-ness). A *total*-leak conduit
+/// whose bloated cone re-encompasses **all** in-domain mass reads as maximally general by IC (`m_μ ≈
+/// Σμ ⇒ IC ≈ 0`) — IC is blind to it — yet purity flags it immediately (`m_μ / |desc| ≈ 0`, because
+/// it divides by the *raw* cone size). On the real Wikipedia graph `Matter` (μ=1, a genuine physics
+/// concept) has `IC_w = 0.00` but `purity = 0.0044`, vs `Thermodynamics` `purity = 0.112` (25×).
+///
+/// *Measurement caveat:* feed `weighted_mass` from the **exact** `descendant_mu_mass` (or a large `k`)
+/// for big cones — a sparse μ-signal (few scored nodes in a vast cone) underflows a small MinHash
+/// sample, which happens to read leak conduits as `≈0` purity (qualitatively right, but not precise).
+pub fn cone_purity(weighted_mass: f64, raw_cone_size: f64) -> f64 {
+    if raw_cone_size <= 0.0 {
+        return 0.0;
+    }
+    (weighted_mass / raw_cone_size).min(1.0)
+}
+
 /// **μ-weighted cone-overlap mass** — the global-hub read-out. Estimates `Σ_{d∈A∩B} μ_d`, the
 /// *admitted* mass two cones share, from their μ-weighted sketches: take the bottom-`k` of the
 /// union, then (Broder) the elements present in **both** sketches are exactly the shared ones whose
@@ -5026,6 +5051,99 @@ mod tests {
             assert!((a - b).abs() < 1e-6, "Σμ preserved on the real graph ({a} vs {b})");
             assert!(descendant_minhash_weighted(&cond.parents, &cmu, K).is_some(), "weighted sketch builds on condensed real graph");
             eprintln!("scc: μ lift preserved Σμ={:.1} over {} scored nodes; weighted sketch built", b, mu.len());
+        }
+    }
+
+    // Cone PURITY as a leak detector. A LEAK CONDUIT — an in-domain node (μ=1) with a huge
+    // out-of-domain subtree — has low purity; a CLEAN hub (in-domain subtree) has high purity.
+    #[test]
+    fn cone_purity_separates_leak_conduit_from_clean_hub() {
+        const K: usize = 256;
+        let mut g: HashMap<u32, Vec<u32>> = HashMap::new();
+        let mut mu: HashMap<u32, f64> = HashMap::new();
+        let mut next = 100u32;
+        // Leak conduit L=1 (μ=1) over 100 OUT-of-domain children (μ=0): cone 101, mass ~1, purity ~0.01.
+        mu.insert(1, 1.0);
+        for _ in 0..100 { let c = next; next += 1; g.insert(c, vec![1]); mu.insert(c, 0.0); }
+        // Clean hub C=2 (μ=1) over 10 IN-domain children (μ=1): cone 11, mass 11, purity 1.0.
+        mu.insert(2, 1.0);
+        for _ in 0..10 { let c = next; next += 1; g.insert(c, vec![2]); mu.insert(c, 1.0); }
+
+        let mass = descendant_mu_mass(&g, &mu);      // exact in-domain mass
+        let d = descendant_minhash(&g, K).unwrap();  // raw cone size
+        let pur = |h: u32| cone_purity(mass[&h], sketch_card(&d[&h], K));
+        let (p_leak, p_clean) = (pur(1), pur(2));
+        eprintln!("purity: leak conduit {:.3} vs clean hub {:.3}", p_leak, p_clean);
+        assert!(p_leak < 0.05, "leak conduit has low purity ({p_leak})");
+        assert!(p_clean > 0.95, "clean hub has high purity ({p_clean})");
+        assert!(p_clean > p_leak * 10.0, "purity separates them by >10×");
+        // Note: the leak conduit's cone (101) is LARGER than the clean hub's (11) — raw cone size
+        // mistakes it for a bigger/more-general hub; purity inverts that, exposing the leak.
+        assert!(sketch_card(&d[&1], K) > sketch_card(&d[&2], K), "the leak conduit's RAW cone is bigger");
+    }
+
+    // Gated real-data validation of the fan-in/leak hypothesis on the condensed Wikipedia graph:
+    // the universal fan-in hubs (Matter, Physical_objects — descendant cone ≈ the whole graph) are
+    // LEAK CONDUITS with tiny purity, while clean physics nodes (Thermodynamics, Physical_quantity)
+    // have ≥20× higher purity. Crucially purity flags Matter (a μ=1 physics concept whose leaked cone
+    // re-encompasses ALL in-domain mass) which μ-weighted IC reads as maximally general (IC≈0).
+    // Exact masses (the sparse μ-signal underflows a MinHash sample on huge cones). Gated on
+    // UW_CATEGORY_TSV + UW_FUZZY_NODES.
+    #[test]
+    fn wikipedia_cone_purity_flags_leak_conduits() {
+        let tsv = match std::env::var("UW_CATEGORY_TSV") {
+            Ok(p) => p, Err(_) => { eprintln!("purity: skip (UW_CATEGORY_TSV)"); return; } };
+        let fz = match std::env::var("UW_FUZZY_NODES") {
+            Ok(p) => p, Err(_) => { eprintln!("purity: skip (UW_FUZZY_NODES)"); return; } };
+        let text = std::fs::read_to_string(&tsv).expect("read UW_CATEGORY_TSV");
+        let mut ids: HashMap<String, u32> = HashMap::new();
+        let mut names: Vec<String> = Vec::new();
+        let mut parents: HashMap<u32, Vec<u32>> = HashMap::new();
+        for (ln, line) in text.lines().enumerate() {
+            if ln == 0 && line.starts_with("child") { continue; }
+            let mut it = line.split('\t');
+            let (c, p) = match (it.next(), it.next()) { (Some(c), Some(p)) => (c, p), _ => continue };
+            let mut intern = |s: &str| *ids.entry(s.to_string()).or_insert_with(|| { names.push(s.to_string()); (names.len() - 1) as u32 });
+            let ci = intern(c); let pi = intern(p);
+            parents.entry(ci).or_default().push(pi);
+        }
+        let mut mu: HashMap<u32, f64> = HashMap::new();
+        for l in std::fs::read_to_string(&fz).expect("read fuzzy").lines() {
+            if l.trim_start().starts_with('#') { continue; }
+            let mut it = l.split('\t');
+            if let (Some(nm), Some(m)) = (it.next(), it.next().and_then(|s| s.trim().parse::<f64>().ok())) {
+                if let Some(&i) = ids.get(nm.trim()) { mu.insert(i, m); }
+            }
+        }
+        const K: usize = 128;
+        let cond = condense_scc(&parents);
+        let cmu = lift_mu_to_components(&mu, &cond);
+        let total_mu: f64 = cmu.values().sum();
+        let mass = descendant_mu_mass(&cond.parents, &cmu); // EXACT (avoid the sparse-sample underflow)
+        let d = descendant_minhash(&cond.parents, K).unwrap();
+        let purity = |nm: &str| -> Option<(f64, f64)> { // (purity, IC_w)
+            let c = cond.comp[ids.get(nm)?];
+            let cone = sketch_card(&d[&c], K);
+            Some((cone_purity(mass[&c], cone), information_content_weighted(mass[&c], total_mu)))
+        };
+        let leaks = ["Matter", "Physical_objects", "Astronomical_objects", "Time"];
+        let clean = ["Thermodynamics", "Physical_quantity", "Atoms", "States_of_matter"];
+        let mut leak_max = 0.0f64;
+        for nm in leaks { if let Some((p, ic)) = purity(nm) {
+            eprintln!("purity[leak]  {:20} {:.4}  IC_w {:.2}", nm, p, ic);
+            leak_max = leak_max.max(p);
+        }}
+        let mut clean_min = 1.0f64;
+        for nm in clean { if let Some((p, ic)) = purity(nm) {
+            eprintln!("purity[clean] {:20} {:.4}  IC_w {:.2}", nm, p, ic);
+            clean_min = clean_min.min(p);
+        }}
+        // The leak conduits are strictly, substantially less pure than the clean physics nodes.
+        assert!(leak_max < clean_min, "every leak conduit is strictly less pure than every clean node (floor {clean_min} > ceil {leak_max})");
+        assert!(clean_min > leak_max * 4.0, "clean physics ≥4× purer than the leakiest conduit (measured ~4.85×)");
+        // Purity catches Matter, which IC reads as maximally general (the leak IC cannot see).
+        if let Some((p, ic)) = purity("Matter") {
+            assert!(ic < 0.1 && p < 0.02, "Matter: IC sees it as general ({ic:.2}) but purity flags the leak ({p:.4})");
         }
     }
 


### PR DESCRIPTION
With `condense_scc` (#3276) unblocking the sketch family on the cyclic Wikipedia graph, the μ-weighted machinery could finally run a *global* read-out on real data. A thread of investigation followed; it produced a new metric (`cone_purity`) **and** corrected several natural-but-wrong hypotheses about leak structure (including my own first framings).

## `cone_purity(weighted_mass, raw_cone_size)`
`purity = m_μ(desc) / |desc|` — the in-domain *fraction* of a node's descendant cone. Low purity = a huge, mostly out-of-domain cone = a leak conduit.

## Real-data finding (`wikipedia_cone_purity_flags_leak_conduits`)
IC here is `−log₂(m_μ/N)` (raw node count `N` — the direct μ-generalization of intrinsic IC):

| node | raw cone | in-domain mass | **purity** | IC (`/N`) |
|---|---:|---:|---:|---:|
| Matter / Physical_objects (one SCC) | ~8000 | 37.9 (all) | **0.0045** | 7.76 |
| Astronomical_objects | 4632 | 1.8 | **0.0004** | 12.15 |
| Thermodynamics / Physical_quantity | 49 | 5.5 | **0.112** | 10.54 |
| Atoms | 214 | 6.0 | **0.0276** | 10.42 |

1. **Purity cleanly separates leak conduits from clean hubs; IC does not.** Every clean node is strictly purer than every leak conduit (≥4.85×). IC tracks in-domain *mass*, not leak-ness, so leak conduits **straddle** a clean node in IC rank: `Matter 7.76 < Atoms 10.42 < Astronomical 12.15` — two leak conduits on opposite sides of one clean node, so IC ordering can't isolate the leak; purity can.
2. **Leak conduits are *generic apex* nodes, not high fan-in hubs.** Measured `corr(fan-in=#parents, cone) = −0.10` (anti-correlates — more parents ⇒ smaller, more specific cone) and `corr(fan-out=#children, cone) = +0.17`. `Matter` has 1 parent. The leak is a transitive descendant-cone-diversity phenomenon, not a fan-in convergence.
3. **"Union vs intersection" is a real axis but needs μ.** Child-cone coherence (μ-free) directionally tracks it (leak SCC least coherent at 0.05, `Mechanics` most at 0.30) but can't separate a diverse *in-domain* hub from a diverse *leak* bucket — structure sees diversity, not domain. Only μ does.
4. **μ-weighting fixes the out-of-domain leak, not the in-domain leak.** `Matter`'s cone wrongly contains `Energy`/`Optics` (genuinely in-domain, μ=1), so they're counted — membership can't veto a bad edge. Distance-discounted mass is the deferred candidate.

## On the IC denominator (raised in review)
`N` (raw node count) is the direct μ-generalization and avoids the misleading `Matter = 0.00` that the in-domain-conditional `Σμ` denominator produces; they differ by a constant offset `log₂(N/Σμ) ≈ 7.8` (ranking-preserving). `Σμ` is documented as the variant for μ-weighted similarity (future work).

## Measurement caveat
The μ-weighted *sketch* underflows on the real graph (90 scored / ~8200 nodes), so this uses exact `descendant_mu_mass`. The sketch is for scale.

## Tests & docs
`cone_purity_separates_leak_conduit_from_clean_hub` (synthetic), `wikipedia_cone_purity_flags_leak_conduits` (gated, straddle assertion); §5d hook + a corrected addendum in `WAM_RUST_CARET_REALDATA_MEASUREMENT_2026-06-18.md`. 109/109 lib tests pass; Prolog guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)