### PR TITLE
prototype(mu_cosine): reconcile dense-μ PRs into one state (torch + e5, corrected docs)

### DIFF
--- a/prototypes/mu_cosine/.gitignore
+++ b/prototypes/mu_cosine/.gitignore
@@ -1,1 +1,6 @@
 mu_pairs.tsv
+# generated dense μ maps (regenerate with emit_dense_mu.py / dense_mu_direct.py); the committed
+# dense_mu_e5.sample.tsv is the illustrative sample. *.sample.tsv is kept (negated below).
+dense_mu*.tsv
+!dense_mu*.sample.tsv
+*.pt

--- a/prototypes/mu_cosine/README.md
+++ b/prototypes/mu_cosine/README.md
@@ -8,8 +8,9 @@ This is a **separate project, prototyped on a branch** — it is Python/ML, not 
 
 ## Status & handoff (read this first)
 
-**Status:** merged to `main` (via #3280). New work: branch from `main`, open your own PR. Last
-verified Python 3.11, stdlib only.
+**Status:** merged to `main` (via #3280); the torch port + direct-embedding comparison are folded in
+here. New work: branch from `main`, open your own PR. Last verified Python 3.11 (stdlib pieces) /
+torch 2.x + sentence-transformers (ML pieces).
 
 | piece | state |
 |---|---|
@@ -17,10 +18,87 @@ verified Python 3.11, stdlib only.
 | distance-biased sampler | ✅ implemented (in the trainer) |
 | pairwise label *generator* | ✅ **done** — `gen_mu_pairs.py` (emits candidate pairs; no LLM cost) |
 | encoder architecture (MLP/MoE, not a transformer) | ✅ **forward pass** only — `mu_encoder.py`, runs at 384-dim |
-| MiniLM init | ⬜ **not done** — random fallback (HuggingFace egress blocked in this env) |
-| training the full encoder | ⬜ **not done** — needs numpy/torch (neither installed here) |
-| **scoring the pairs (μ labels)** | ⬜ **not done** — the budget-spending step; `score_stub` in `gen_mu_pairs.py` |
-| wiring dense μ back to the Rust core | ⬜ **not done** — see "Integration" below |
+| MiniLM init | ✅ **done** — `mu_encoder_torch.py` `build_minilm_init` + `embed()` (ML env w/ HF egress) |
+| training the full encoder | ✅ **done** — `train_cosine_mu_torch.py` (torch port; objective + held-out generalisation) |
+| **scoring the pairs (μ labels)** | ⬜ **not done** — the budget-spending step; `score_stub` in `gen_mu_pairs.py` (awaiting user OK) |
+| wiring dense μ back to the Rust core | 🟡 **emitter done** — `emit_dense_mu.py` / `dense_mu_direct.py` (clamped, verbatim names, 100% coverage); Rust consumption verified by `check_feeds_rust.py`, not run end-to-end in CI |
+
+### Progress — ML-environment port (folded in from #3283)
+
+The handoff's "take it into the real ML environment" steps are implemented in torch (the steps that
+spend **no** LLM budget). Gating checks passed first: `pip install -r requirements.txt` succeeds and
+HuggingFace is reachable (MiniLM downloads + encodes, 384-d).
+
+| new file | what it does |
+|---|---|
+| `mu_encoder_torch.py` | torch port of the MLP/MoE encoder; **MiniLM init wired into `embed()`** (`build_minilm_init`); MoE load-balancing aux loss; `to_membership` clamp |
+| `train_cosine_mu_torch.py` | the cosine-μ objective in torch (Adam / SparseAdam). `--free-vectors` reproduces `train_cosine_mu.py` (**corr → 1.00**); `--minilm --holdout` is the generalisation test; `--mode pairs` for scored `gen_mu_pairs.py` (refuses unscored rows) |
+| `emit_dense_mu.py` | step 5 — dense `name<TAB>μ` for the whole graph from the trained encoder; **clamps [0,1]**, **emits names verbatim**, asserts coverage |
+| `validate_lin_agreement.py` | step 4b — faithful python port of `gated_ic`/`lin_from_ic` (threshold 0.3, Σμ denom), compares graph-side Lin vs semantic cosine |
+
+**Validation results (no LLM budget spent):**
+- **Objective**: `--free-vectors` → train MSE 0.0000, corr **+1.00** (torch matches the stdlib proof).
+- **Generalisation** (frozen MiniLM init + shared 1-layer encoder, 0.2 held-out): **held-out corr +0.946**,
+  MSE 0.023 — μ predicted for categories whose label the encoder never saw. Even the *untrained*
+  MiniLM-cosine already scores held-out corr +0.88.
+- **Dense μ**: emitted for all 8 247 categories, 100% name resolution; highest-μ are exactly physics
+  topics (Light, Electromagnetism, Thermodynamics, Acoustics…); 262 in the [0.3,0.7] boundary band.
+- **Lin agreement — the Step-4 claim, corrected.** The handoff's step 4 said the dense μ should
+  *converge* to the graph-side `lin_from_ic` (`μ(X|root) == Lin(X, root)`). **That validation is
+  degenerate and has been dropped:** node-vs-root Lin saturates at 1.0 for all 51 scored nodes (the
+  root is the most-general node, so every node's MICA-with-root *is* the root). The *pairwise* graph-Lin
+  vs semantic-cosine correlation is **weak** for the single-anchor-trained encoder (Pearson ≈ −0.13):
+  single-anchor μ(X|Physics) training collapses physics nodes onto the Physics direction, so pairwise
+  cosine saturates too. **This is the concrete motivation for the pairwise scored labels**
+  (`gen_mu_pairs.py`, the budget step) — the held-out *single-anchor* μ regression is strong, but
+  capturing pairwise/Lin structure needs the varied-anchor pairwise μ. Do **not** gate the encoder on
+  agreement with node-vs-root Lin.
+
+**Next (needs the budget step):** score `mu_pairs.tsv` (`gen_mu_pairs.py score_stub`, ~1200 pairs) →
+`train_cosine_mu_torch.py --mode pairs --minilm` → re-run `validate_lin_agreement.py` (expect the
+pairwise agreement to improve). **Confirm with the user before scoring.**
+
+### Progress — dense μ *without* training, model comparison (Prompt A, realized)
+
+The fastest path to unblock the graph work (Prompt A below) is a dense μ map by **direct asymmetric
+embedding** (encode the root as a *query*, each category as a *document*, cosine, clamp) — picking the
+embedder that minimises future Haiku re-scoring.
+
+| new file | what it does |
+|---|---|
+| `dense_mu_direct.py` | dense `name<TAB>μ` with no training, asymmetric query/doc prefixes; presets `minilm` / `e5` / `nomic`; `--compare` reports each model's **decision band** + fixture discrimination |
+| `check_feeds_rust.py` | confirms a chosen map feeds `gated_ic` / `lin_from_ic` (faithful port): names resolve verbatim, μ∈[0,1], gated IC finite + general→specific, membership separates physics/non-physics |
+| `dense_mu_e5.sample.tsv` | committed illustrative 20-row sample of the chosen map (full maps are git-ignored, regenerable) |
+
+**Decision-band metric & the trap (this corrects Prompt A's "smallest band wins").** The budget metric
+is the **decision band** — categories with μ ∈ [0.2, 0.45] straddling the 0.3 gate, the ones a later
+Haiku pass must re-score. But the **raw** band is misleading: asymmetric retrieval models have a high
+cosine *floor*, so they pile everything above the gate (e5 raw band = **0** — but Music=0.84 ≈
+Optics=0.87, no discrimination at all; "smallest raw band" would pick the *worst*, most-compressed
+model). The fix (no budget): **calibrate** each model's cosine→μ against the existing 90-node Haiku
+fixture (linear fit) **before** counting the band — only then is the band comparable and reflective of
+genuine ambiguity:
+
+| model | dim | raw band | **calibrated band** | fixture r | gate leak (non-phys passing 0.3) |
+|---|---|---|---|---|---|
+| `all-MiniLM-L6-v2` | 384 | 876 | 2028 | +0.573 | 4/5 |
+| **`e5-small-v2`** | **384** | 0 | **653** | **+0.665** | **3/5** (Cooking, Religious correctly out) |
+| `nomic-embed-text-v1.5` | 768 | 4109 | 1049 | +0.647 | — |
+
+**Pick: `intfloat/e5-small-v2`** — smallest *calibrated* band, best fixture correlation, cleanest gate
+separation, and 384-d (lightweight). `check_feeds_rust.py` confirms its map feeds the Rust core
+(IC general→specific: Physics 2.85 < Optics 5.12 < Thermodynamics 7.18). Caveat: pairwise `lin_from_ic`
+**saturates** toward 1.0 for many pairs on this graph (all maps) — the membership μ, not pairwise Lin,
+is the clean separator (same finding as the Step-4 correction above). Don't use BERT/ModernBERT
+(logit/entropy encoders, not sentence embedders). e5 still leaks a couple of loosely-related apexes
+near the gate (e.g. Music ≈ 0.52, Politics ≈ 0.50) — exactly what **Prompt C** (cutoff-band Haiku
+rescore) is for.
+
+```bash
+python3 dense_mu_direct.py --compare                              # the table above
+python3 dense_mu_direct.py --model e5 --out dense_mu_e5.tsv       # emit the chosen (calibrated) map
+python3 check_feeds_rust.py --mu-file dense_mu_e5.tsv             # sanity-check it feeds the Rust core
+```
 
 **Reproduce what exists (no deps):**
 ```bash
@@ -51,8 +129,11 @@ python3 gen_mu_pairs.py           # emits 1200 candidate pairs (200 pos / 1000 n
    sparse gradients — see batching); **do *not* re-apply `train_cosine_mu.py`'s `--dist-bias`** when
    training on `gen_mu_pairs.py` output — those pairs already encode the distance preference via the
    explicit negatives, so a distance bias on top double-penalises far pairs.
-4. Validate: held-out `μ` regression, and that the dense μ it predicts *agrees with the graph-side*
-   `lin_from_ic` (the two should converge — `μ(X|root) == Lin(X, root)`, the unification below).
+4. Validate: held-out `μ` regression (this is the real generalisation signal). **Do _not_ validate
+   against node-vs-root `lin_from_ic`** — that cross-check is degenerate (root is the most-general
+   node, so node-vs-root Lin saturates at 1.0); see the "ML-environment port" progress note above. If
+   you want a graph-side cross-check, use *pairwise* μ(a,b) for varied anchors, and expect it to need
+   the pairwise scored labels (step 2) before it agrees.
 5. Emit a dense `μ` map (`category → μ`) for the whole graph — **clamp cosine to `[0,1]`
    (`to_membership`) and emit names verbatim** (both load-bearing — see Integration) — and feed it to
    the Rust core.
@@ -100,9 +181,12 @@ single per-node scalar but the **cosine between two learned vectors**, one for `
 ```
 
 Learn the encoder so that cosine matches the LLM-provided `μ`. Because the root is just another encoded
-category, the *same* node embeddings serve any domain — swap the root vector, swap the domain. This
-also unifies `μ` with the graph-similarity work: `μ(X | root)` is exactly `Lin(X, root)` measured in
-semantic (vector) space instead of the category graph.
+category, the *same* node embeddings serve any domain — swap the root vector, swap the domain. This is
+*analogous* to the graph-similarity work — `μ(X | root)` plays the role `Lin(X, root)` plays on the
+category graph, but measured in semantic (vector) space. **It is not a literal identity:** the
+node-vs-root `Lin` is degenerate (saturates at 1.0 — the root is the most-general node), so don't try
+to validate the embedding μ against graph-side node-vs-root Lin (see the Step-4 note in the status
+section).
 
 ## Architecture (`mu_encoder.py`) — an MLP, not a transformer
 
@@ -205,7 +289,9 @@ own PR** — parallel sessions (A and B below) coordinate by cross-referencing t
 
 Two ready-to-paste kickoff prompts:
 
-**A — dense μ *without* training (fastest path to unblock the graph work).**
+**A — dense μ *without* training (fastest path to unblock the graph work).** ✅ **Realized** — see the
+"dense μ *without* training, model comparison" progress section above (`dense_mu_direct.py`; **e5-small
+picked** on smallest *calibrated* band). Kept here for the reasoning; re-run only to re-pick the model.
 Use an **asymmetric** embedder, not MiniLM. μ(X | root) is *directional* ("is X a member of *root*'s
 domain"); MiniLM is symmetric (generic relatedness — it conflates loose-relatedness with membership,
 e.g. `Music ≈ 0.34`). e5-small and nomic have query/passage prefixes for exactly this. The choice
@@ -221,8 +307,11 @@ discrimination (rank 1.2). So **measure it on our data** (zero LLM cost):
 > cosine, clamp to `[0,1]` (`prototypes/mu_cosine/mu_encoder.py:to_membership`), emit `name<TAB>μ` in
 > the `tests/fixtures/wikipedia_physics_fuzzy_nodes.tsv` format (names verbatim). For **each** model
 > report the **decision-band count** (categories with μ ∈ `[0.2,0.45]` near the 0.3 gate — MiniLM had
-> 876) and a few sanity cases (`Music`, `Optics`, `Thermodynamics`); the model with the *smallest* band
-> is the budget-optimal pick (fewest Haiku rescores in Prompt C). Sanity-check the chosen map feeds
+> 876) and a few sanity cases (`Music`, `Optics`, `Thermodynamics`). **Calibrate each model's cosine→μ
+> against the 90-node Haiku fixture (linear fit) _before_ counting the band** — the raw band rewards a
+> degenerate compressor (e5's raw band is 0 because it pins everything above the gate). The model with
+> the *smallest calibrated* band is the budget-optimal pick (fewest Haiku rescores in Prompt C).
+> Sanity-check the chosen map feeds
 > `gated_ic` / `lin_from_ic` in the Rust core. Deps: `pip install -r prototypes/mu_cosine/requirements.txt`
 > + HF egress. Branch off `main`, **open a PR**, report the band sizes there.
 
@@ -240,34 +329,35 @@ discrimination (rank 1.2). So **measure it on our data** (zero LLM cost):
 > do not touch the merged WAM-Rust core.
 
 **C — cascade-refine the dense μ where it changes cutoff decisions (correctness fix for A's output).**
-MiniLM measures *relatedness*, not *membership*: it rates loosely-connected categories (e.g. `Music`
-≈ 0.34 via acoustics/sound, but music is not a physics sub-topic) just above the gating cutoff, which
-re-pollutes the gated cones exactly where gating decides. The *highest-value* rescore set is **not** the
-whole uncertainty band — it's the categories whose μ sits close enough to the **cutoff** that a rescore
-could **flip the in/out decision** (the active-learning / uncertainty-sampling principle: a label's
-value ≈ its probability of changing a decision; a label far from the cutoff can't change anything). On
-A's `dense_mu_physics.tsv` (8247 cats), around the `0.3` gate that is tiny: **[0.25,0.35] = 319 cats,
-[0.20,0.45] = 876, the just-above-cutoff false-positive side (0.30,0.45] = 203** — a few hundred Haiku
-calls, ~7–19 KB. Use the model-cascade pattern already in the merged core
-(`wikipedia_model_cascade_haiku_then_sonnet`, `wikipedia_fuzzy_gated_hybrid_membership`, geometric-mean
-= log-opinion-pool fusion). The Haiku re-scores are *also* the highest-value (boundary) training labels
-for Prompt B — so **C feeds B** — and small/expensive, so **commit them as a fixture** (see the
-commit-vs-regenerate rule under Persistent storage).
-> In the UnifyWeaver repo, refine the dense μ map from PR #3281 with a model cascade. MiniLM rates
-> *relatedness*, not domain *membership*, so it mis-scores categories near the gating cutoff (e.g.
-> `Music` ≈ 0.34, but music is only loosely physics-related, not a physics sub-topic). Rescore only the
-> categories that could **change a cutoff decision** — those within a margin of the `0.3` gate, e.g.
-> μ ∈ `[0.2, 0.45]` (~880; or the tight straddle `[0.25,0.35]`, ~320), weighted toward the
-> just-above-cutoff false-positive side. (Don't spend budget far from the cutoff — those can't flip.)
-> Re-score with a Haiku subagent asking specifically about **membership** ("Is `<category>` a
-> sub-topic/subfield *of physics*? 0..1, 1 = core physics, 0 = unrelated" — not "related to"), batched,
-> same discipline as the `wikipedia_physics_*` fixtures. Fuse with the geometric mean `√(prior·haiku)`
-> (the log-opinion-pool used in the merged cascade tests — it hard-vetoes a loose connection: `Music` →
-> `√(0.34·0) = 0`). Keep categories far from the cutoff on the MiniLM prior untouched. Emit the refined
-> μ (same format) **and commit the Haiku rescores as a fixture** (e.g.
-> `tests/fixtures/wikipedia_physics_boundary_haiku.tsv`, `name<TAB>μ`) — it's small, expensive, and the
-> reusable boundary training data for Prompt B. **Spends LLM budget, bounded to the decision band —
-> report the band size and confirm with me before scoring.** Branch off `main`, open a PR.
+This is the **recommended next step** now that A is realized with e5. Even the chosen e5 prior measures
+*relatedness*, not *membership*, so it still rates a few loosely-connected apexes just above the gate
+(e.g. `Music` ≈ 0.52, `Politics` ≈ 0.50 — not physics sub-topics), re-polluting the gated cones exactly
+where gating decides. The *highest-value* rescore set is **not** the whole uncertainty band — it's the
+categories whose μ sits close enough to the **cutoff** that a rescore could **flip the in/out decision**
+(the active-learning / uncertainty-sampling principle: a label's value ≈ its probability of changing a
+decision; a label far from the cutoff can't change anything). On the e5 calibrated map the decision band
+(μ ∈ `[0.2, 0.45]`) is **≈653 cats** — a few hundred Haiku calls, ~tens of KB (measure the exact tight
+straddle `[0.25,0.35]` from the emitted `dense_mu_e5.tsv`). Use the model-cascade pattern already in the
+merged core (`wikipedia_model_cascade_haiku_then_sonnet`, `wikipedia_fuzzy_gated_hybrid_membership`,
+geometric-mean = log-opinion-pool fusion). The Haiku re-scores are *also* the highest-value (boundary)
+training labels for Prompt B — so **C feeds B** — and small/expensive, so **commit them as a fixture**
+(see the commit-vs-regenerate rule under Persistent storage).
+> In the UnifyWeaver repo, refine the chosen e5 dense μ map (`prototypes/mu_cosine/dense_mu_direct.py
+> --model e5 --out dense_mu_e5.tsv`) with a model cascade. e5 rates *relatedness*, not domain
+> *membership*, so it mis-scores a few categories near the gating cutoff (e.g. `Music` ≈ 0.52,
+> `Politics` ≈ 0.50, only loosely physics-related, not physics sub-topics). Rescore only the categories
+> that could **change a cutoff decision** — those within a margin of the `0.3` gate, e.g. μ ∈
+> `[0.2, 0.45]` (≈650; or the tight straddle `[0.25,0.35]`), weighted toward the just-above-cutoff
+> false-positive side. (Don't spend budget far from the cutoff — those can't flip.) Re-score with a
+> Haiku subagent asking specifically about **membership** ("Is `<category>` a sub-topic/subfield *of
+> physics*? 0..1, 1 = core physics, 0 = unrelated" — not "related to"), batched, same discipline as the
+> `wikipedia_physics_*` fixtures. Fuse with the geometric mean `√(prior·haiku)` (the log-opinion-pool
+> used in the merged cascade tests — it hard-vetoes a loose connection: `Music` → `√(0.52·0) = 0`). Keep
+> categories far from the cutoff on the e5 prior untouched. Emit the refined μ (same format) **and commit
+> the Haiku rescores as a fixture** (e.g. `tests/fixtures/wikipedia_physics_boundary_haiku.tsv`,
+> `name<TAB>μ`) — it's small, expensive, and the reusable boundary training data for Prompt B. **Spends
+> LLM budget, bounded to the decision band — report the band size and confirm with me before scoring.**
+> Branch off `main`, open a PR.
 
 ### What to commit vs. host externally
 
@@ -275,9 +365,10 @@ The deciding question is **cheap-and-regenerable vs. expensive-and-irreproducibl
 - **Commit (in git, as fixtures):** the **LLM-labelled** data — the Haiku boundary rescores (Prompt C),
   the existing `tests/fixtures/wikipedia_physics_*`. These are expensive (LLM budget), *not*
   reproducible, the highest-value asset, and small (the decision band is ~tens of KB). Never re-buy them.
-- **Regenerate or host externally (rclone, below):** **model-derived** artifacts — MiniLM embeddings,
-  the full dense-μ map (`dense_mu_physics.tsv` is ~150 KB and regenerable from the model in minutes),
-  checkpoints, the 1.5 GB full-graph embeddings. Cheap to remake, so don't bloat git; host the big ones.
+- **Regenerate or host externally (rclone, below):** **model-derived** artifacts — embeddings, the full
+  dense-μ map (`dense_mu_e5.tsv` is ~150 KB and regenerable from the model in minutes — git-ignored, with
+  only `dense_mu_e5.sample.tsv` committed as an illustrative sample), checkpoints, the 1.5 GB full-graph
+  embeddings. Cheap to remake, so don't bloat git; host the big ones.
 
 ### Persistent storage (rclone + Dropbox)
 

--- a/prototypes/mu_cosine/check_feeds_rust.py
+++ b/prototypes/mu_cosine/check_feeds_rust.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Sanity-check that a dense μ map feeds the Rust core's `gated_ic` / `lin_from_ic` (README step 4b /
+the chosen-map check). Faithful python port of those functions (reused from `validate_lin_agreement`),
+run on a `name<TAB>μ` file (e.g. `dense_mu_direct.py --model e5 --out ...`).
+
+Two layers, kept separate on purpose:
+  * **Mechanical integration (asserted)** — the load-bearing guards + that the map actually drives the
+    pipeline: every name resolves verbatim (else silent μ=0), μ ∈ [0,1] (clamp guard — mass is summed),
+    `gated_ic` is finite for in-domain anchors, and IC orders general→specific (big cone ⇒ low IC).
+  * **Discrimination (diagnostic, not asserted)** — membership μ and gated Lin for physics vs
+    non-physics probes. NOT a hard pass/fail because it is a property of the *map's quality*, not the
+    integration, and because pairwise Lin on this graph saturates toward 1.0 for many pairs (the
+    membership μ is the cleaner separator; an out-of-domain node only drives Lin→0 once it gates OUT).
+
+    python3 check_feeds_rust.py --mu-file dense_mu_e5.tsv
+"""
+from __future__ import annotations
+
+import argparse
+import math
+
+from validate_lin_agreement import (load_graph, load_mu, lin_from_ic, gated_ic_for, GRAPH)
+
+PHYSICS = ["Physics", "Optics", "Thermodynamics", "Electromagnetism", "Quantum_mechanics", "Atoms"]
+NONPHYS = ["Music", "Cooking", "Religious_buildings", "Politics", "Fashion"]
+IN_PAIRS = [("Optics", "Thermodynamics"), ("Optics", "Electromagnetism")]
+OUT_PAIRS = [("Optics", "Music"), ("Physics", "Cooking"), ("Thermodynamics", "Religious_buildings")]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mu-file", required=True, help="dense μ map (name<TAB>μ)")
+    ap.add_argument("--threshold", type=float, default=0.3)
+    args = ap.parse_args()
+
+    parents, children = load_graph(GRAPH)
+    graph_names = set(parents)
+    mu = load_mu(args.mu_file)
+    total_mu = sum(mu.values())
+    cache = {}
+
+    # ---- mechanical integration (asserted) ----
+    resolved = sum(1 for n in mu if n in graph_names)
+    out_of_range = [(n, m) for n, m in mu.items() if m < 0.0 or m > 1.0]
+    print(f"{len(mu)} μ rows; {resolved}/{len(mu)} resolve against the graph; Σμ={total_mu:.1f}")
+    assert resolved == len(mu), f"{len(mu)-resolved} names do NOT resolve (would silently become μ=0)"
+    assert not out_of_range, f"{len(out_of_range)} μ outside [0,1] (corrupts mass): {out_of_range[:3]}"
+
+    ics = {n: gated_ic_for(n, children, mu, args.threshold, total_mu, cache)
+           for n in PHYSICS if n in graph_names}
+    finite = {n: ic for n, ic in ics.items() if math.isfinite(ic)}
+    assert finite, "no in-domain anchor has a finite gated IC — the map gated everything out"
+    assert ics.get("Physics", math.inf) <= min(v for n, v in finite.items() if n != "Physics"), \
+        "IC(Physics) should be the lowest (most general) among in-domain anchors"
+    print("  guards OK: names resolve verbatim; μ∈[0,1]; gated_ic finite + general→specific ordered")
+    print("  gated IC (general→specific): " +
+          "  ".join(f"{n}={ic:.2f}" for n, ic in sorted(finite.items(), key=lambda kv: kv[1])))
+
+    # ---- discrimination (diagnostic) ----
+    print(f"\nmembership μ — physics:  " +
+          "  ".join(f"{n.split('_')[0]}={mu.get(n,0):.2f}" for n in PHYSICS if n in graph_names))
+    print(f"membership μ — non-phys: " +
+          "  ".join(f"{n.split('_')[0]}={mu.get(n,0):.2f}" for n in NONPHYS if n in graph_names))
+    in_above = sum(1 for n in PHYSICS if mu.get(n, 0) >= args.threshold and n in graph_names)
+    out_above = sum(1 for n in NONPHYS if mu.get(n, 0) >= args.threshold and n in graph_names)
+    print(f"  at the {args.threshold} gate: {in_above}/{sum(1 for n in PHYSICS if n in graph_names)} "
+          f"physics pass, {out_above}/{sum(1 for n in NONPHYS if n in graph_names)} non-physics pass "
+          f"(fewer non-physics passing = cleaner absolute separation)")
+
+    def lin(a, b):
+        return lin_from_ic(a, b, parents, children, mu, args.threshold, total_mu, cache) \
+            if a in graph_names and b in graph_names else None
+    print("  gated Lin in-domain:  " + "  ".join(f"{a[:4]}~{b[:4]}={lin(a,b)}" for a, b in IN_PAIRS))
+    print("  gated Lin out-domain: " + "  ".join(f"{a[:4]}~{b[:4]}={lin(a,b)}" for a, b in OUT_PAIRS))
+    print("\nmechanical integration: PASS (the map feeds gated_ic / lin_from_ic in the Rust core).")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/dense_mu_direct.py
+++ b/prototypes/mu_cosine/dense_mu_direct.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Dense μ map by **direct asymmetric embedding** — no training (README "prompt A", model-comparison
+variant). For every category in `category_parent.tsv`, cosine its embedding to the domain root and
+clamp to [0,1]; emit `name<TAB>μ` (names verbatim) in the fixture format.
+
+**Asymmetric** retrieval embedders score a *query* against *documents*, which is exactly the μ
+question ("how much does this category belong to the <root> domain?"): encode the root as the query
+and each category as a document, with the model's prefixes. Presets:
+
+  * `minilm` — `sentence-transformers/all-MiniLM-L6-v2` (384-d, symmetric, no prefix) — the baseline.
+  * `e5`     — `intfloat/e5-small-v2` (384-d, `query: ` / `passage: `).
+  * `nomic`  — `nomic-ai/nomic-embed-text-v1.5` (768-d, `search_query: ` / `search_document: `,
+               needs `trust_remote_code=True` + `einops`).
+
+**Budget metric:** the **decision band** = #categories with μ ∈ [lo, hi] straddling the 0.3 gate
+(default [0.2, 0.45]) — these are the ambiguous ones a later Haiku pass would have to re-score, so the
+model with the *smallest* band (that still discriminates — watch the sanity cases) is budget-optimal.
+
+    python3 dense_mu_direct.py --compare                       # band sizes + sanity for all presets
+    python3 dense_mu_direct.py --model e5 --out dense_mu_e5.tsv   # write the chosen map
+"""
+from __future__ import annotations
+
+import argparse
+import os
+
+import torch
+
+from emit_dense_mu import load_graph_names, GRAPH, REPO
+from mu_encoder_torch import to_membership
+from train_cosine_mu_torch import load_mu, FIXTURE, pearson
+
+
+def spearman(xs, ys):
+    def ranks(v):
+        order = sorted(range(len(v)), key=lambda i: v[i])
+        r = [0.0] * len(v)
+        for rank, i in enumerate(order):
+            r[i] = rank
+        return r
+    return pearson(ranks(xs), ranks(ys))
+
+PRESETS = {
+    "minilm": ("sentence-transformers/all-MiniLM-L6-v2", "", "", False),
+    "e5":     ("intfloat/e5-small-v2", "query: ", "passage: ", False),
+    "nomic":  ("nomic-ai/nomic-embed-text-v1.5", "search_query: ", "search_document: ", True),
+}
+SANITY = ["Music", "Optics", "Thermodynamics", "Quantum_mechanics", "Cooking", "Religious_buildings"]
+
+
+def humanize(n):
+    return n.replace("_", " ")
+
+
+def embed_mu(preset, names, root, batch_size=512):
+    """Return the **raw cosine** (∈[-1,1], one per name) of cos(doc(name), query(root)). Calibration /
+    clamping happen in `report` so the raw scale (which differs per model) stays inspectable."""
+    from sentence_transformers import SentenceTransformer
+
+    model_name, qpre, dpre, trust = PRESETS[preset]
+    model = SentenceTransformer(model_name, trust_remote_code=trust)
+    root_vec = model.encode([qpre + humanize(root)], normalize_embeddings=True, convert_to_tensor=True)
+    root_vec = root_vec[0]
+    cos_all = []
+    for i in range(0, len(names), batch_size):
+        chunk = [dpre + humanize(n) for n in names[i:i + batch_size]]
+        docs = model.encode(chunk, normalize_embeddings=True, convert_to_tensor=True,
+                            show_progress_bar=False)
+        cos_all.extend((docs @ root_vec).tolist())     # normalized ⇒ dot = cosine
+    return cos_all
+
+
+def lstsq_fit(x, y):
+    """Least-squares a,b for y ≈ a·x + b."""
+    n = len(x)
+    mx, my = sum(x) / n, sum(y) / n
+    sxx = sum((xi - mx) ** 2 for xi in x)
+    sxy = sum((xi - mx) * (yi - my) for xi, yi in zip(x, y))
+    a = sxy / sxx if sxx else 0.0
+    return a, my - a * mx
+
+
+def band_count(mus, lo, hi):
+    return (sum(1 for m in mus if m < lo), sum(1 for m in mus if lo <= m <= hi),
+            sum(1 for m in mus if m > hi))
+
+
+def report(preset, names, cos_all, lo, hi, fixture_mu):
+    idx = {n: i for i, n in enumerate(names)}
+    raw_mu = [to_membership(c) for c in cos_all]       # guard #1: clamp to [0,1]
+    below, band, above = band_count(raw_mu, lo, hi)
+
+    # discrimination + calibration against the 90-node Haiku fixture (no LLM budget):
+    fx = [(idx[n], m) for n, m in fixture_mu.items() if n in idx]
+    fcos = [cos_all[i] for i, _ in fx]
+    fmu = [m for _, m in fx]
+    r, rho = pearson(fcos, fmu), spearman(fcos, fmu)
+    a, b = lstsq_fit(fcos, fmu)
+    cal_mu = [min(1.0, max(0.0, a * c + b)) for c in cos_all]
+    cb_below, cb_band, cb_above = band_count(cal_mu, lo, hi)
+
+    print(f"\n[{preset}] {PRESETS[preset][0]}")
+    print(f"  RAW   band μ∈[{lo},{hi}]: {band:5d}  (below {below} / band {band} / above {above})")
+    print(f"  CALIB band μ∈[{lo},{hi}]: {cb_band:5d}  (below {cb_below} / band {cb_band} / above "
+          f"{cb_above})   [fit μ≈{a:.2f}·cos{b:+.2f}]")
+    print(f"  fixture discrimination ({len(fx)} nodes): Pearson r={r:+.3f}  Spearman ρ={rho:+.3f}")
+    print(f"  sanity RAW μ: " + "  ".join(
+        f"{n.split('_')[0]}={raw_mu[idx[n]]:.2f}" for n in SANITY if n in idx))
+    return {"raw_band": band, "cal_band": cb_band, "r": r, "rho": rho,
+            "raw_mu": raw_mu, "cal_mu": cal_mu, "fit": (a, b)}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", choices=list(PRESETS), default=None, help="write this preset's map")
+    ap.add_argument("--compare", action="store_true", help="report band sizes for all presets")
+    ap.add_argument("--root", default="Physics")
+    ap.add_argument("--lo", type=float, default=0.2)
+    ap.add_argument("--hi", type=float, default=0.45)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    names = load_graph_names(GRAPH)
+    fixture_mu = load_mu(FIXTURE)
+    print(f"{len(names)} categories; root '{args.root}'; decision band [{args.lo},{args.hi}]; "
+          f"{len(fixture_mu)} fixture nodes for discrimination/calibration")
+    if args.root not in names:
+        raise SystemExit(f"root '{args.root}' is not a graph name")
+
+    presets = list(PRESETS) if args.compare else [args.model]
+    if presets == [None]:
+        raise SystemExit("pass --compare or --model <preset>")
+
+    results = {}
+    for p in presets:
+        cos_all = embed_mu(p, names, args.root)
+        results[p] = report(p, names, cos_all, args.lo, args.hi, fixture_mu)
+
+    if args.compare:
+        # Budget-optimal = smallest band, BUT only among models that actually discriminate (the raw
+        # band rewards a model that piles everything above the gate — useless). Rank by CALIBRATED band
+        # (comparable across cosine scales), tie-broken by fixture correlation.
+        print("\n  model   raw_band  calib_band   fixture_r   fixture_ρ")
+        for p in presets:
+            x = results[p]
+            print(f"  {p:6s}  {x['raw_band']:7d}  {x['cal_band']:9d}   {x['r']:+.3f}      {x['rho']:+.3f}")
+        best = min(presets, key=lambda p: (results[p]["cal_band"], -results[p]["r"]))
+        print(f"\nbudget-optimal (smallest CALIBRATED band, then best fixture corr): {best}. "
+              f"NOTE: the RAW band is misleading — e5/nomic pile everything above {args.hi} (cosine "
+              f"floor), so their tiny/huge raw band does not reflect discrimination; calibrating each "
+              f"model's cosine→μ against the fixture makes the band comparable.")
+
+    if args.out and args.model:
+        # emit the CALIBRATED μ (raw cosine scale is not a membership; calibration aligns it with μ)
+        mus = results[args.model]["cal_mu"]
+        a, b = results[args.model]["fit"]
+        with open(args.out, "w") as f:
+            f.write(f"# Dense μ(category | {args.root}) — direct {PRESETS[args.model][0]} cosine "
+                    f"(asymmetric, no training), calibrated μ≈{a:.3f}·cos{b:+.3f} on the Haiku fixture. "
+                    f"clamp [0,1], names verbatim. Format: name<TAB>μ.\n")
+            for n, m in zip(names, mus):
+                f.write(f"{n}\t{m:.4f}\n")
+        print(f"\nwrote {len(names)} calibrated rows → {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/dense_mu_e5.sample.tsv
+++ b/prototypes/mu_cosine/dense_mu_e5.sample.tsv
@@ -1,0 +1,19 @@
+# Illustrative 20-row sample of the e5-small-v2 dense μ(category | Physics) map
+# (calibrated to the Haiku fixture; full map regenerate: dense_mu_direct.py --model e5).
+# Format: name<TAB>μ. Physics topics high; everyday topics low.
+Physics	1.0000
+Optics	0.7464
+Thermodynamics	0.8509
+Electromagnetism	0.6402
+Atoms	0.6260
+Light	0.4804
+Acoustics	0.4388
+Temperature	0.7479
+Energy	0.8160
+Waves	0.5340
+Music	0.5231
+Cooking	0.0934
+Religious_buildings	0.0000
+Politics	0.5001
+Fashion	0.3991
+Sports	0.0397

--- a/prototypes/mu_cosine/emit_dense_mu.py
+++ b/prototypes/mu_cosine/emit_dense_mu.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Emit a **dense** μ map for the whole category graph (README step 5) — the prototype's payoff.
+
+Takes the shared encoder trained by `train_cosine_mu_torch.py --save-encoder` (vocabulary-independent:
+it maps any MiniLM vector into the μ-cosine space), MiniLM-encodes **every** category name in
+`category_parent.tsv`, and emits `name<TAB>μ` where `μ = clamp(cos(encode(name), encode(root)), [0,1])`.
+
+The two integration guards the README flags as load-bearing are enforced here:
+  1. **Clamp cosine to [0,1]** (`to_membership`) before emitting — `descendant_mu_mass` / `sketch_mu_mass`
+     *sum* μ as mass and a negative weight corrupts the mass/KMV estimate.
+  2. **Names verbatim from the TSV** (case/underscore-sensitive). The Rust loaders intern names → ids;
+     a name absent from the graph hits `unwrap_or(0.0)` and silently becomes μ=0. We emit exactly the
+     graph's names, and the assertion below reports coverage (it is 100% by construction).
+
+Output matches `tests/fixtures/wikipedia_physics_fuzzy_nodes.tsv` (`name<TAB>μ`, '#'-comment header), so
+the existing Rust loaders consume it unchanged — just larger and dense.
+
+    python3 train_cosine_mu_torch.py --minilm --save-encoder enc.pt   # train + save first
+    python3 emit_dense_mu.py --encoder enc.pt --root Physics --out dense_mu_physics.tsv
+"""
+from __future__ import annotations
+
+import argparse
+import os
+
+import torch
+
+from mu_encoder_torch import Config, MuEncoder, build_minilm_init, to_membership
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(ROOT, "..", ".."))
+GRAPH = os.path.join(REPO, "data", "benchmark", "10k", "category_parent.tsv")
+
+
+def load_graph_names(path):
+    """Every distinct category name in the graph, **verbatim** (order: first appearance)."""
+    names, seen = [], set()
+    with open(path) as f:
+        for i, line in enumerate(f):
+            if i == 0 and line.startswith("child"):
+                continue
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 2:
+                continue
+            for n in (parts[0], parts[1]):
+                if n not in seen:
+                    seen.add(n)
+                    names.append(n)
+    return names
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--encoder", default=None, help="trained shared encoder from --save-encoder "
+                    "(omit to emit the *untrained* MiniLM-cosine baseline = README prompt A)")
+    ap.add_argument("--root", default="Physics", help="domain anchor (must be a graph name)")
+    ap.add_argument("--out", default=os.path.join(ROOT, "dense_mu.tsv"))
+    ap.add_argument("--batch-size", type=int, default=512)
+    args = ap.parse_args()
+
+    names = load_graph_names(GRAPH)
+    print(f"{len(names)} categories in the graph")
+    if args.root not in names:
+        raise SystemExit(f"root '{args.root}' is not a graph name (names are case/underscore-sensitive)")
+
+    print("MiniLM-encoding all category names ...")
+    init = build_minilm_init(names)
+
+    if args.encoder:
+        ckpt = torch.load(args.encoder, map_location="cpu", weights_only=False)
+        cfg = Config(**ckpt["cfg"])
+        model = MuEncoder(cfg, init_embeddings=init, names=names, freeze_init=True)
+        model.blocks.load_state_dict(ckpt["blocks"])
+        tag = f"trained encoder ({args.encoder})"
+    else:
+        cfg = Config(n_layers=0, d_model=init.shape[1])  # identity encoder = raw MiniLM cosine
+        model = MuEncoder(cfg, init_embeddings=init, names=names, freeze_init=True)
+        tag = "untrained MiniLM-cosine baseline (prompt A)"
+    model.eval()
+    print(f"emitting μ(·|{args.root}) with: {tag}")
+
+    root_id = model._ids([args.root])
+    mus = []
+    with torch.no_grad():
+        for i in range(0, len(names), args.batch_size):
+            ids = torch.arange(i, min(i + args.batch_size, len(names)), dtype=torch.long)
+            cos, _ = model.mu(ids, root_id.expand(ids.shape[0]))
+            mus.extend(to_membership(cos).tolist())   # guard #1: clamp to [0,1]
+
+    resolved = sum(1 for m in mus if m is not None)   # 100% by construction (we emit graph names)
+    with open(args.out, "w") as f:
+        f.write(f"# Dense μ(category | {args.root}) from the cosine-μ encoder ({tag}).\n")
+        f.write(f"# {resolved}/{len(names)} names resolved against {os.path.relpath(GRAPH, REPO)} "
+                f"(verbatim; clamp to [0,1] applied). Format: name<TAB>μ.\n")
+        for n, m in zip(names, mus):
+            f.write(f"{n}\t{m:.4f}\n")   # guard #2: name emitted verbatim
+
+    nz = sum(1 for m in mus if m > 0.0)
+    band = sum(1 for m in mus if 0.3 <= m <= 0.7)
+    print(f"wrote {len(names)} dense μ rows → {args.out}")
+    print(f"coverage: {resolved}/{len(names)} names resolve (assert PASS); "
+          f"{nz} have μ>0; {band} in boundary band [0.3,0.7]")
+    top = sorted(zip(names, mus), key=lambda x: -x[1])[:10]
+    print("highest-μ categories:")
+    for n, m in top:
+        print(f"  μ {m:.3f}  {n}")
+    assert resolved == len(names), "coverage assertion failed — some names did not resolve"
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/mu_encoder_torch.py
+++ b/prototypes/mu_cosine/mu_encoder_torch.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Torch port of the μ-cosine encoder (`mu_encoder.py`), with MiniLM init wired into `embed()`.
+
+Faithful to the stdlib scaffold: an **MLP/MoE encoder, not a transformer** (see `mu_encoder.py`'s
+docstring for why attention is the wrong tool for a single per-category vector). The only additions a
+real ML environment unlocks are the ones the handoff calls out:
+
+  * **MiniLM init** (`build_minilm_init`): each category's name is encoded with
+    `sentence-transformers/all-MiniLM-L6-v2` (384-d) and used as the *frozen* init embedding. The
+    shared encoder (the trained part) maps these into the μ-cosine space, so it produces dense μ for
+    *unlabelled* categories too — the whole point of the project (README "Resolved design decisions").
+  * **Adam-friendly torch params** with **sparse embedding gradients** (the embedding table is the
+    real memory lever at Wikipedia scale — README "Compute & batching").
+  * **MoE load-balancing aux loss** (`aux = n_experts · Σ_i f_i·P_i`) so a soft gate can't collapse
+    onto one expert (README "If you turn on MoE").
+
+`encode(ids) -> [B, d]`; `mu(a, root) = cosine(encode(a), encode(root))`. `to_membership` clamps the
+cosine to [0,1] before emitting to the Rust core (a negative weight corrupts the mass/KMV estimate).
+
+    python3 mu_encoder_torch.py              # forward parity smoke test (MLP and MoE), random init
+    python3 mu_encoder_torch.py --minilm     # same, but init the table from MiniLM (needs HF egress)
+"""
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+@dataclass
+class Config:
+    d_model: int = 384          # MiniLM-sized
+    n_layers: int = 1           # start at 1; few params ⇒ generalise from few labels
+    d_ff: int = 384 * 4         # FFN inner width (4x, standard)
+    n_experts: int = 1          # 1 = plain MLP; >1 = soft gated MoE (region routing, interpretable)
+    seed: int = 0
+
+
+class MLP(nn.Module):
+    """Linear → GELU → Linear (one FFN / expert). GELU(tanh) matches the stdlib scaffold."""
+
+    def __init__(self, cfg: Config):
+        super().__init__()
+        self.w1 = nn.Linear(cfg.d_model, cfg.d_ff)
+        self.w2 = nn.Linear(cfg.d_ff, cfg.d_model)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w2(F.gelu(self.w1(x), approximate="tanh"))
+
+
+class FeedForward(nn.Module):
+    """Plain MLP (n_experts=1), or a soft gated mixture of region experts (n_experts>1).
+
+    The soft gate (dot-product gating → softmax) is interpretable but can collapse all weight onto one
+    expert; `forward` returns the load-balancing aux term alongside the output so the trainer can add
+    `aux_weight · aux` to the loss (README). For n_experts=1 the aux term is 0."""
+
+    def __init__(self, cfg: Config):
+        super().__init__()
+        self.n_experts = cfg.n_experts
+        self.experts = nn.ModuleList([MLP(cfg) for _ in range(cfg.n_experts)])
+        self.gate = nn.Linear(cfg.d_model, cfg.n_experts) if cfg.n_experts > 1 else None
+
+    def forward(self, x: torch.Tensor):
+        if self.gate is None:
+            return self.experts[0](x), x.new_zeros(())
+        g = F.softmax(self.gate(x), dim=-1)                 # [B, E] region routing weights
+        outs = torch.stack([e(x) for e in self.experts], dim=-2)  # [B, E, d]
+        y = (g.unsqueeze(-1) * outs).sum(dim=-2)            # [B, d]
+        # load balancing: fraction routed (argmax) × mean gate, summed, ×E  (Switch-Transformer form)
+        with torch.no_grad():
+            routed = F.one_hot(g.argmax(dim=-1), self.n_experts).float().mean(dim=0)  # f_i
+        importance = g.mean(dim=0)                          # P_i
+        aux = self.n_experts * (routed * importance).sum()
+        return y, aux
+
+
+class Block(nn.Module):
+    """Pre-norm residual MLP/MoE block: x + FFN(LN(x)). (No attention — see module docstring.)"""
+
+    def __init__(self, cfg: Config):
+        super().__init__()
+        self.ln = nn.LayerNorm(cfg.d_model)
+        self.ff = FeedForward(cfg)
+
+    def forward(self, x: torch.Tensor):
+        y, aux = self.ff(self.ln(x))
+        return x + y, aux
+
+
+class MuEncoder(nn.Module):
+    """Shared encoder over a (mostly-frozen) MiniLM-init embedding table.
+
+    `init_embeddings`: a [n_cats, d_model] tensor (e.g. from `build_minilm_init`). `freeze_init=True`
+    (default) trains only the encoder blocks — required so unlabelled categories don't stay at random
+    init (README). `names` maps category name → row id, so `mu_by_name` / emission can use names that
+    match `category_parent.tsv` verbatim."""
+
+    def __init__(self, cfg: Config = Config(), init_embeddings=None, names=None,
+                 freeze_init: bool = True, sparse: bool = False):
+        super().__init__()
+        self.cfg = cfg
+        torch.manual_seed(cfg.seed)
+        n_cats = init_embeddings.shape[0] if init_embeddings is not None else 1
+        self.init_emb = nn.Embedding(n_cats, cfg.d_model, sparse=sparse)
+        if init_embeddings is not None:
+            with torch.no_grad():
+                self.init_emb.weight.copy_(init_embeddings)
+        else:
+            nn.init.normal_(self.init_emb.weight, std=1.0 / math.sqrt(cfg.d_model))
+        self.init_emb.weight.requires_grad = not freeze_init
+        self.blocks = nn.ModuleList([Block(cfg) for _ in range(cfg.n_layers)])
+        # name <-> id maps (verbatim names — load-bearing for the Rust integration)
+        self.names = list(names) if names is not None else None
+        self.id_of = {n: i for i, n in enumerate(self.names)} if self.names else None
+
+    # ---- core forward ----
+    def embed(self, ids: torch.Tensor) -> torch.Tensor:
+        """MiniLM-init embedding lookup (random fallback if no init was provided)."""
+        return self.init_emb(ids)
+
+    def encode(self, ids: torch.Tensor, neighbor_ids=None) -> torch.Tensor:
+        """ids: [B] long. Optional neighbor_ids: [B, K] long for cheap fixed mean-pool context."""
+        x = self.embed(ids)
+        if neighbor_ids is not None:
+            nb = self.embed(neighbor_ids).mean(dim=1)       # fixed-weight 'sum of vectors'
+            x = (x + nb * neighbor_ids.shape[1]) / (1 + neighbor_ids.shape[1])
+        aux_total = x.new_zeros(())
+        for blk in self.blocks:
+            x, aux = blk(x)
+            aux_total = aux_total + aux
+        return x, aux_total
+
+    def mu(self, a_ids: torch.Tensor, root_ids: torch.Tensor):
+        """Cosine μ(a | root) for batched ids. Returns (cos [B], aux scalar)."""
+        a, aux_a = self.encode(a_ids)
+        b, aux_b = self.encode(root_ids)
+        cos = F.cosine_similarity(a, b, dim=-1)
+        return cos, aux_a + aux_b
+
+    # ---- name-keyed convenience (verbatim names) ----
+    def _ids(self, names):
+        if self.id_of is None:
+            raise ValueError("encoder built without names; pass names= to use name-keyed methods")
+        return torch.tensor([self.id_of[n] for n in names], dtype=torch.long,
+                            device=self.init_emb.weight.device)
+
+    @torch.no_grad()
+    def mu_by_name(self, a_names, root_name):
+        a = self._ids(list(a_names))
+        r = self._ids([root_name] * len(a_names))
+        cos, _ = self.mu(a, r)
+        return cos
+
+
+def to_membership(cos):
+    """Clamp a cosine (∈[-1,1]) to a membership μ (∈[0,1]) for the Rust core (README guard #1).
+
+    `descendant_mu_mass` / `sketch_mu_mass` *sum* μ as mass and assume μ ≥ 0; a negative weight
+    corrupts the mass/KMV estimate. Works on python floats or torch tensors."""
+    if isinstance(cos, torch.Tensor):
+        return cos.clamp(0.0, 1.0)
+    return max(0.0, min(1.0, cos))
+
+
+# --------------------------------------------------------------------------------------------------
+# MiniLM init
+# --------------------------------------------------------------------------------------------------
+def build_minilm_init(names, model_name="sentence-transformers/all-MiniLM-L6-v2", batch_size=256,
+                      device=None, normalize=False, humanize=True):
+    """Encode each category *name* with MiniLM → a [len(names), 384] init tensor (one row per name).
+
+    Wikipedia category names are underscore-joined (`Quantum_mechanics`); `humanize` turns them into
+    natural text (`quantum mechanics`) for the sentence encoder, which is what MiniLM was trained on.
+    `normalize=False` keeps raw embeddings (the encoder + cosine handle scale); set True to unit-norm.
+    Requires `sentence-transformers` + HuggingFace egress."""
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer(model_name, device=device)
+
+    def humanized(n):
+        return n.replace("_", " ") if humanize else n
+
+    texts = [humanized(n) for n in names]
+    emb = model.encode(texts, batch_size=batch_size, convert_to_numpy=True,
+                       normalize_embeddings=normalize, show_progress_bar=False)
+    return torch.tensor(emb, dtype=torch.float32)
+
+
+def _smoke(use_minilm: bool):
+    names = ["Physics", "Electromagnetism", "Optics", "Electricity", "Quantum_mechanics",
+             "Religious_buildings", "Cooking"]
+    if use_minilm:
+        init = build_minilm_init(names)
+        print(f"MiniLM init: {tuple(init.shape)} (rows = categories)")
+    else:
+        init = None
+    for n_experts in (1, 4):
+        cfg = Config(n_layers=1, n_experts=n_experts)
+        if init is None:
+            torch.manual_seed(0)
+            init_t = torch.randn(len(names), cfg.d_model) / math.sqrt(cfg.d_model)
+        else:
+            init_t = init
+        enc = MuEncoder(cfg, init_embeddings=init_t, names=names)
+        em = enc.mu_by_name(["Electromagnetism"], "Physics").item()
+        rel = enc.mu_by_name(["Religious_buildings"], "Physics").item()
+        kind = "MLP" if n_experts == 1 else f"MoE({n_experts} experts)"
+        print(f"{kind:14} forward OK  μ(EM|Physics)={em:+.3f}  μ(Religious_buildings|Physics)={rel:+.3f}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--minilm", action="store_true", help="init the table from MiniLM (needs HF egress)")
+    args = ap.parse_args()
+    _smoke(args.minilm)
+    print("forward OK. Training: train_cosine_mu_torch.py (objective proven in train_cosine_mu.py).")

--- a/prototypes/mu_cosine/requirements.txt
+++ b/prototypes/mu_cosine/requirements.txt
@@ -5,6 +5,7 @@
 torch>=2.0
 numpy>=1.24
 sentence-transformers>=2.2    # provides the embedders below (needs HF egress)
+einops>=0.7                   # only for the nomic-ai/nomic-embed-text-v1.5 preset in dense_mu_direct.py
 # Embedder choice (see prior project eval: skill_embedding_models.md, reports/answer_level_*.json):
 #   intfloat/e5-small-v2          384-d, lightweight, query:/passage: prefixes  (best cosine-to-target)
 #   nomic-ai/nomic-embed-text-v1.5  768-d, search_query:/_document: prefixes    (best discrimination;

--- a/prototypes/mu_cosine/train_cosine_mu_torch.py
+++ b/prototypes/mu_cosine/train_cosine_mu_torch.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Train the cosine-μ objective in torch — the real-environment counterpart of `train_cosine_mu.py`.
+
+Same objective the stdlib proof validates: minimise `(cos(encode(X), encode(root)) − μ)²`. Two modes:
+
+  * `--mode fixture` (default): single-anchor regression on the Haiku-scored
+    `tests/fixtures/wikipedia_physics_fuzzy_nodes.tsv` (anchor `Physics`). Spends **no** LLM budget —
+    the fixture is already scored. Two sub-flavours:
+      - `--free-vectors`: learnable per-category vectors, identity encoder (`n_layers=0`), random init —
+        the torch re-creation of `train_cosine_mu.py`. With enough dim it reaches `corr→1.00`,
+        confirming the torch objective + Adam match the stdlib proof (capacity, not generalisation).
+      - default: **frozen MiniLM init + a trained shared encoder** (`n_layers=1`). This is the
+        generalisation setup — `--holdout` measures μ-prediction on categories whose label the encoder
+        never saw, which is the real test the proof can't make.
+
+  * `--mode pairs`: pairwise regression on `gen_mu_pairs.py` output once its `mu` column is **scored**
+    (the budget step — confirm with the user first). Varied anchors; `(a, b, μ)` per row.
+    NOTE: do **not** add `--dist-bias` here — those pairs already encode the distance preference via
+    explicit negatives (README), so a distance bias double-penalises far pairs. (`--dist-bias` is
+    fixture-only and ignored in pairs mode.)
+
+Optimiser: **Adam** (per-row adaptive steps suit an embedding table — README), `SparseAdam` when the
+embedding table is trainable and sparse. MoE (`--n-experts>1`) adds the load-balancing aux loss.
+
+    python3 train_cosine_mu_torch.py --free-vectors          # reproduce the proof (corr→1.00)
+    python3 train_cosine_mu_torch.py --minilm --holdout 0.2  # generalisation: shared encoder on MiniLM
+    python3 train_cosine_mu_torch.py --mode pairs --pairs mu_pairs.tsv --minilm
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import os
+from collections import deque
+
+import torch
+import torch.nn.functional as F
+
+from mu_encoder_torch import Config, MuEncoder, build_minilm_init
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(ROOT, "..", ".."))
+GRAPH = os.path.join(REPO, "data", "benchmark", "10k", "category_parent.tsv")
+FIXTURE = os.path.join(REPO, "tests", "fixtures", "wikipedia_physics_fuzzy_nodes.tsv")
+ANCHOR = "Physics"
+
+
+# --------------------------------------------------------------------------------------------------
+# data
+# --------------------------------------------------------------------------------------------------
+def load_graph(path):
+    adj = {}
+    with open(path) as f:
+        for i, line in enumerate(f):
+            if i == 0 and line.startswith("child"):
+                continue
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 2:
+                continue
+            c, p = parts[0], parts[1]
+            adj.setdefault(c, set()).add(p)
+            adj.setdefault(p, set()).add(c)
+    return adj
+
+
+def load_mu(path):
+    out = {}
+    with open(path) as f:
+        for line in f:
+            if line.lstrip().startswith("#"):
+                continue
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 2:
+                continue
+            try:
+                out[parts[0]] = float(parts[1])
+            except ValueError:
+                pass
+    return out
+
+
+def load_pairs(path):
+    """Read scored `gen_mu_pairs.py` output: name_a, name_b, stratum, walk_len, mu (mu filled)."""
+    rows = []
+    skipped = 0
+    with open(path) as f:
+        for line in f:
+            if line.lstrip().startswith("#"):
+                continue
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 5 or parts[4].strip() == "":
+                skipped += 1
+                continue
+            try:
+                mu = float(parts[4])
+            except ValueError:
+                skipped += 1
+                continue
+            rows.append((parts[0], parts[1], mu))
+    if skipped:
+        print(f"WARNING: {skipped} pair rows had a blank/non-numeric μ (unscored) — skipped. "
+              f"Score them first (gen_mu_pairs.py score_stub; spends LLM budget).")
+    return rows
+
+
+def bfs_dist(adj, src):
+    dist = {src: 0}
+    q = deque([src])
+    while q:
+        x = q.popleft()
+        for y in adj.get(x, ()):
+            if y not in dist:
+                dist[y] = dist[x] + 1
+                q.append(y)
+    return dist
+
+
+def pearson(xs, ys):
+    xs, ys = torch.as_tensor(xs, dtype=torch.float64), torch.as_tensor(ys, dtype=torch.float64)
+    xs, ys = xs - xs.mean(), ys - ys.mean()
+    denom = (xs.norm() * ys.norm()).clamp_min(1e-12)
+    return float((xs @ ys) / denom)
+
+
+# --------------------------------------------------------------------------------------------------
+# training
+# --------------------------------------------------------------------------------------------------
+def make_optimizer(model, lr):
+    """SparseAdam for a trainable sparse embedding table; Adam for everything else (README: Adam)."""
+    sparse_params, dense_params = [], []
+    for name, p in model.named_parameters():
+        if not p.requires_grad:
+            continue
+        if name == "init_emb.weight" and model.init_emb.sparse:
+            sparse_params.append(p)
+        else:
+            dense_params.append(p)
+    opts = []
+    if dense_params:
+        opts.append(torch.optim.Adam(dense_params, lr=lr))
+    if sparse_params:
+        opts.append(torch.optim.SparseAdam(sparse_params, lr=lr))
+    return opts
+
+
+def train_fixture(args):
+    adj = load_graph(GRAPH)
+    mu = load_mu(FIXTURE)
+    dist = bfs_dist(adj, ANCHOR)
+    nodes = [n for n in mu if n in adj and n != ANCHOR]
+    print(f"loaded {len(nodes)} scored nodes connected to '{ANCHOR}' "
+          f"(μ in [{min(mu[n] for n in nodes):.1f},{max(mu[n] for n in nodes):.1f}])")
+
+    # held-out split (generalisation test). Stratify-ish by shuffling with the seed.
+    g = torch.Generator().manual_seed(args.seed)
+    perm = torch.randperm(len(nodes), generator=g).tolist()
+    nodes = [nodes[i] for i in perm]
+    n_hold = int(round(args.holdout * len(nodes)))
+    hold = nodes[:n_hold]
+    train = nodes[n_hold:]
+    print(f"train {len(train)} / held-out {len(hold)} (holdout={args.holdout})")
+
+    names = [ANCHOR] + nodes
+    if args.minilm and not args.free_vectors:
+        print("building MiniLM init for fixture nodes ...")
+        init = build_minilm_init(names)
+        cfg = Config(n_layers=args.n_layers, n_experts=args.n_experts, d_model=init.shape[1])
+        model = MuEncoder(cfg, init_embeddings=init, names=names, freeze_init=not args.unfreeze)
+    else:
+        # free-vector mode: random init, identity encoder, trainable table (= train_cosine_mu.py)
+        cfg = Config(n_layers=0 if args.free_vectors else args.n_layers,
+                     n_experts=args.n_experts, d_model=args.dim)
+        torch.manual_seed(args.seed)
+        init = torch.randn(len(names), cfg.d_model) / math.sqrt(cfg.d_model)
+        model = MuEncoder(cfg, init_embeddings=init, names=names,
+                          freeze_init=False if args.free_vectors else not args.unfreeze)
+
+    # distance-bias sampling weights (fixture only). README: do NOT use in pairs mode.
+    def w(n):
+        return (1.0 / (1.0 + dist.get(n, 99))) ** args.dist_bias
+    train_w = torch.tensor([w(n) for n in train])
+
+    root_ids = model._ids([ANCHOR] * len(train))
+    train_ids = model._ids(train)
+    train_mu = torch.tensor([mu[n] for n in train])
+
+    opts = make_optimizer(model, args.lr)
+
+    def report(tag):
+        with torch.no_grad():
+            cos_tr = model.mu_by_name(train, ANCHOR)
+            line = f"{tag} train MSE {F.mse_loss(cos_tr, train_mu):.4f} corr {pearson(cos_tr, train_mu):+.3f}"
+            if hold:
+                cos_h = model.mu_by_name(hold, ANCHOR)
+                hmu = torch.tensor([mu[n] for n in hold])
+                line += f" | HELD-OUT MSE {F.mse_loss(cos_h, hmu):.4f} corr {pearson(cos_h, hmu):+.3f}"
+            print(line)
+
+    report("initial")
+    for ep in range(args.epochs):
+        for o in opts:
+            o.zero_grad()
+        cos, aux = model.mu(train_ids, root_ids)
+        err2 = (cos - train_mu) ** 2
+        loss = (err2 * train_w).sum() / train_w.sum() + args.aux_weight * aux
+        loss.backward()
+        for o in opts:
+            o.step()
+        if (ep + 1) % max(1, args.epochs // 5) == 0:
+            report(f"epoch {ep+1:5d}")
+    print()
+    report("FINAL")
+
+    if hold:
+        print("\nheld-out examples (μ vs predicted cosine):")
+        with torch.no_grad():
+            cos_h = model.mu_by_name(hold, ANCHOR)
+        ex = sorted(range(len(hold)), key=lambda i: mu[hold[i]])
+        for i in [ex[0], ex[len(ex)//2], ex[-1]]:
+            n = hold[i]
+            print(f"  μ {mu[n]:.2f}  cos {float(cos_h[i]):+.2f}  dist {dist.get(n,'?')}  {n}")
+    return model
+
+
+def train_pairs(args):
+    rows = load_pairs(args.pairs)
+    if not rows:
+        raise SystemExit(f"no scored pairs in {args.pairs} — fill the μ column first (budget step).")
+    print(f"loaded {len(rows)} scored pairs (μ in "
+          f"[{min(r[2] for r in rows):.2f},{max(r[2] for r in rows):.2f}])")
+    names = sorted({n for a, b, _ in rows for n in (a, b)})
+
+    if args.minilm:
+        print("building MiniLM init for paired categories ...")
+        init = build_minilm_init(names)
+        cfg = Config(n_layers=args.n_layers, n_experts=args.n_experts, d_model=init.shape[1])
+        model = MuEncoder(cfg, init_embeddings=init, names=names, freeze_init=not args.unfreeze)
+    else:
+        cfg = Config(n_layers=args.n_layers, n_experts=args.n_experts, d_model=args.dim)
+        torch.manual_seed(args.seed)
+        init = torch.randn(len(names), cfg.d_model) / math.sqrt(cfg.d_model)
+        model = MuEncoder(cfg, init_embeddings=init, names=names, freeze_init=False)
+
+    g = torch.Generator().manual_seed(args.seed)
+    perm = torch.randperm(len(rows), generator=g).tolist()
+    rows = [rows[i] for i in perm]
+    n_hold = int(round(args.holdout * len(rows)))
+    hold, train = rows[:n_hold], rows[n_hold:]
+    print(f"train {len(train)} / held-out {len(hold)} pairs")
+
+    def ids(split):
+        a = model._ids([r[0] for r in split])
+        b = model._ids([r[1] for r in split])
+        m = torch.tensor([r[2] for r in split])
+        return a, b, m
+
+    a_tr, b_tr, m_tr = ids(train)
+    opts = make_optimizer(model, args.lr)
+
+    def report(tag):
+        with torch.no_grad():
+            cos, _ = model.mu(a_tr, b_tr)
+            line = f"{tag} train MSE {F.mse_loss(cos, m_tr):.4f} corr {pearson(cos, m_tr):+.3f}"
+            if hold:
+                a_h, b_h, m_h = ids(hold)
+                cosh, _ = model.mu(a_h, b_h)
+                line += f" | HELD-OUT MSE {F.mse_loss(cosh, m_h):.4f} corr {pearson(cosh, m_h):+.3f}"
+            print(line)
+
+    report("initial")
+    for ep in range(args.epochs):
+        for o in opts:
+            o.zero_grad()
+        cos, aux = model.mu(a_tr, b_tr)
+        loss = F.mse_loss(cos, m_tr) + args.aux_weight * aux
+        loss.backward()
+        for o in opts:
+            o.step()
+        if (ep + 1) % max(1, args.epochs // 5) == 0:
+            report(f"epoch {ep+1:5d}")
+    print()
+    report("FINAL")
+    return model
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["fixture", "pairs"], default="fixture")
+    ap.add_argument("--pairs", default=os.path.join(ROOT, "mu_pairs.tsv"))
+    ap.add_argument("--free-vectors", action="store_true",
+                    help="fixture: learnable vectors + identity encoder (reproduce train_cosine_mu.py)")
+    ap.add_argument("--minilm", action="store_true", help="init the embedding table from MiniLM")
+    ap.add_argument("--unfreeze", action="store_true", help="also fine-tune the MiniLM init table")
+    ap.add_argument("--dim", type=int, default=16, help="dim for random-init (free-vector) mode")
+    ap.add_argument("--n-layers", type=int, default=1)
+    ap.add_argument("--n-experts", type=int, default=1)
+    ap.add_argument("--aux-weight", type=float, default=0.01, help="MoE load-balancing aux weight")
+    ap.add_argument("--epochs", type=int, default=4000)
+    ap.add_argument("--lr", type=float, default=0.05)
+    ap.add_argument("--seed", type=int, default=1)
+    ap.add_argument("--holdout", type=float, default=0.0, help="fraction held out for generalisation")
+    ap.add_argument("--dist-bias", type=float, default=1.0,
+                    help="fixture only: exponent on 1/(1+dist) sampling weight (0 = uniform)")
+    ap.add_argument("--save-encoder", default=None,
+                    help="save the trained shared encoder (blocks + cfg) for emit_dense_mu.py")
+    args = ap.parse_args()
+
+    if args.mode == "fixture":
+        model = train_fixture(args)
+    else:
+        if args.dist_bias != 1.0:
+            print("note: --dist-bias is ignored in pairs mode (pairs already encode distance via negatives)")
+        model = train_pairs(args)
+
+    if args.save_encoder:
+        # Save ONLY the shared encoder (blocks) + config — vocabulary-independent, so it can be
+        # applied to ANY MiniLM-init vector (the whole graph) to emit dense μ (emit_dense_mu.py).
+        torch.save({"cfg": vars(model.cfg), "blocks": model.blocks.state_dict()}, args.save_encoder)
+        print(f"saved shared encoder (config + {sum(p.numel() for p in model.blocks.parameters())} "
+              f"block params) → {args.save_encoder}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/validate_lin_agreement.py
+++ b/prototypes/mu_cosine/validate_lin_agreement.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Validate that the encoder's **semantic** μ agrees with the **graph-side** `lin_from_ic` (README
+step 4 — the unification `μ(X | root) == Lin(X, root)`, similarity in vector space vs the category DAG).
+
+Faithful pure-python port of the Rust `gated_ic` / `resnik_from_ic` / `lin_from_ic`
+(`boundary_cache.rs.mustache`), matching the parameters of the existing Rust test
+`wikipedia_gated_similarity_tracks_physics_relatedness`:
+
+  * sparse fixture μ (`wikipedia_physics_fuzzy_nodes.tsv`) as the membership map,
+  * gate `threshold = 0.3`, denominator `total_mu = Σ μ`,
+  * `gated_ic` = `−log2( min(gated_desc_mass / Σμ, 1) )`  (μ-gated descendant cone),
+  * `lin(a,b) = 2·IC(MICA) / (IC(a)+IC(b))`, MICA = max finite-IC common reflexive ancestor.
+
+Then it compares, over the scored physics nodes, the graph-side gated **Lin(a,b)** with the encoder's
+**cosine(a,b)** (its pairwise semantic μ). High rank/linear correlation ⇒ the two similarity spaces
+converge — the agreement the README asks for. (Pairwise is the right comparison: node-vs-root Lin is
+degenerate because the root is the most-general node, IC≈0.)
+
+    python3 validate_lin_agreement.py --encoder enc.pt          # trained encoder
+    python3 validate_lin_agreement.py                            # untrained MiniLM-cosine baseline
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import os
+from collections import deque
+from itertools import combinations
+
+import torch
+
+from mu_encoder_torch import Config, MuEncoder, build_minilm_init
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(ROOT, "..", ".."))
+GRAPH = os.path.join(REPO, "data", "benchmark", "10k", "category_parent.tsv")
+FIXTURE = os.path.join(REPO, "tests", "fixtures", "wikipedia_physics_fuzzy_nodes.tsv")
+
+
+def load_graph(path):
+    """parents: child -> set(parents); children: parent -> set(children)."""
+    parents, children = {}, {}
+    with open(path) as f:
+        for i, line in enumerate(f):
+            if i == 0 and line.startswith("child"):
+                continue
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 2:
+                continue
+            c, p = parts[0], parts[1]
+            parents.setdefault(c, set()).add(p)
+            children.setdefault(p, set()).add(c)
+            parents.setdefault(p, parents.get(p, set()))
+            children.setdefault(c, children.get(c, set()))
+    return parents, children
+
+
+def load_mu(path):
+    out = {}
+    with open(path) as f:
+        for line in f:
+            if line.lstrip().startswith("#"):
+                continue
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 2:
+                continue
+            try:
+                out[parts[0]] = float(parts[1])
+            except ValueError:
+                pass
+    return out
+
+
+def reflexive_ancestors(u, parents):
+    seen = {u}
+    q = deque([u])
+    while q:
+        x = q.popleft()
+        for p in parents.get(x, ()):
+            if p not in seen:
+                seen.add(p)
+                q.append(p)
+    return seen
+
+
+def gated_desc_mass(t, children, mu, threshold):
+    """μ-gated descendant cone mass for node t (faithful to descendant_mu_mass_gated): descend into a
+    child only if μ(child) ≥ threshold; root always kept; diamonds counted once (seen set)."""
+    seen = {t}
+    q = deque([t])
+    mass = mu.get(t, 0.0)
+    while q:
+        x = q.popleft()
+        for c in children.get(x, ()):
+            if c not in seen and mu.get(c, 0.0) >= threshold:
+                seen.add(c)
+                mass += mu.get(c, 0.0)
+                q.append(c)
+    return mass
+
+
+def gated_ic_for(node, children, mu, threshold, total_mu, cache):
+    if node in cache:
+        return cache[node]
+    mass = gated_desc_mass(node, children, mu, threshold)
+    ic = math.inf if mass <= 0.0 else -math.log2(min(mass / total_mu, 1.0))
+    cache[node] = ic
+    return ic
+
+
+def lin_from_ic(a, b, parents, children, mu, threshold, total_mu, cache):
+    au = reflexive_ancestors(a, parents)
+    av = reflexive_ancestors(b, parents)
+    common = au & av
+    mica = None
+    for n in common:
+        ic = gated_ic_for(n, children, mu, threshold, total_mu, cache)
+        if math.isfinite(ic) and (mica is None or ic > mica):
+            mica = ic
+    if mica is None:
+        return None
+    ica = gated_ic_for(a, children, mu, threshold, total_mu, cache)
+    icb = gated_ic_for(b, children, mu, threshold, total_mu, cache)
+    denom = ica + icb
+    if denom <= 0.0:
+        return None
+    return min(2.0 * mica / denom, 1.0)
+
+
+def pearson(xs, ys):
+    xs, ys = torch.tensor(xs, dtype=torch.float64), torch.tensor(ys, dtype=torch.float64)
+    xs, ys = xs - xs.mean(), ys - ys.mean()
+    return float((xs @ ys) / (xs.norm() * ys.norm()).clamp_min(1e-12))
+
+
+def spearman(xs, ys):
+    def ranks(v):
+        order = sorted(range(len(v)), key=lambda i: v[i])
+        r = [0.0] * len(v)
+        i = 0
+        while i < len(order):
+            j = i
+            while j + 1 < len(order) and v[order[j + 1]] == v[order[i]]:
+                j += 1
+            avg = (i + j) / 2.0
+            for k in range(i, j + 1):
+                r[order[k]] = avg
+            i = j + 1
+        return r
+    return pearson(ranks(xs), ranks(ys))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--encoder", default=None, help="trained shared encoder (omit = MiniLM baseline)")
+    ap.add_argument("--threshold", type=float, default=0.3)
+    ap.add_argument("--max-pairs", type=int, default=4000, help="cap scored-node pairs evaluated")
+    ap.add_argument("--root", default="Physics", help="anchor for the node-vs-root claim check")
+    ap.add_argument("--seed", type=int, default=1)
+    args = ap.parse_args()
+
+    parents, children = load_graph(GRAPH)
+    mu = load_mu(FIXTURE)
+    total_mu = sum(mu.values())
+    nodes = [n for n in mu if n in parents and mu[n] >= args.threshold]
+    print(f"{len(nodes)} scored nodes at μ≥{args.threshold}; Σμ={total_mu:.2f}")
+
+    # --- README's stated claim, directly: graph-side Lin(X, root) vs the LLM μ(X) target ---
+    cache0 = {}
+    xs_lin, xs_mu = [], []
+    for n in nodes:
+        if n == args.root:
+            continue
+        lin = lin_from_ic(n, args.root, parents, children, mu, args.threshold, total_mu, cache0)
+        if lin is not None:
+            xs_lin.append(lin)
+            xs_mu.append(mu[n])
+    if xs_lin:
+        print(f"\nclaim check  μ(X)  vs  graph Lin(X, {args.root})  over {len(xs_lin)} scored nodes:")
+        print(f"  Pearson r = {pearson(xs_mu, xs_lin):+.3f}  Spearman ρ = {spearman(xs_mu, xs_lin):+.3f}")
+        sat = sum(1 for v in xs_lin if v >= 0.999)
+        print(f"  ({sat}/{len(xs_lin)} node-vs-root Lin saturate at 1.0 — root is the most-general "
+              f"node, so node-vs-root Lin is largely degenerate; pairwise below is the real test)")
+
+    # graph-side gated Lin for scored-node pairs that share a finite-IC ancestor
+    cache = {}
+    pairs, lin_vals = [], []
+    for a, b in combinations(nodes, 2):
+        lin = lin_from_ic(a, b, parents, children, mu, args.threshold, total_mu, cache)
+        if lin is not None:
+            pairs.append((a, b))
+            lin_vals.append(lin)
+    print(f"{len(pairs)} pairs have a finite-IC common ancestor (graph-side Lin defined)")
+    if len(pairs) > args.max_pairs:
+        g = torch.Generator().manual_seed(args.seed)
+        idx = torch.randperm(len(pairs), generator=g)[: args.max_pairs].tolist()
+        pairs = [pairs[i] for i in idx]
+        lin_vals = [lin_vals[i] for i in idx]
+        print(f"sampled {len(pairs)} pairs")
+
+    # semantic side: encoder cosine for the same pairs
+    names = sorted({n for p in pairs for n in p})
+    print("MiniLM-encoding the scored nodes ...")
+    init = build_minilm_init(names)
+    if args.encoder:
+        ckpt = torch.load(args.encoder, map_location="cpu", weights_only=False)
+        cfg = Config(**ckpt["cfg"])
+        model = MuEncoder(cfg, init_embeddings=init, names=names, freeze_init=True)
+        model.blocks.load_state_dict(ckpt["blocks"])
+        tag = f"trained encoder ({args.encoder})"
+    else:
+        model = MuEncoder(Config(n_layers=0, d_model=init.shape[1]), init_embeddings=init,
+                          names=names, freeze_init=True)
+        tag = "untrained MiniLM-cosine baseline"
+    model.eval()
+    a_ids = model._ids([a for a, _ in pairs])
+    b_ids = model._ids([b for _, b in pairs])
+    with torch.no_grad():
+        cos, _ = model.mu(a_ids, b_ids)
+    cos = cos.clamp(0.0, 1.0).tolist()
+
+    print(f"\nagreement (graph-side gated Lin  vs  semantic cosine, {tag}):")
+    print(f"  Pearson  r = {pearson(lin_vals, cos):+.3f}")
+    print(f"  Spearman ρ = {spearman(lin_vals, cos):+.3f}   over {len(pairs)} pairs")
+    ex = sorted(range(len(pairs)), key=lambda i: -lin_vals[i])[:6]
+    print("  highest-Lin pairs (Lin / cos):")
+    for i in ex:
+        a, b = pairs[i]
+        print(f"    Lin {lin_vals[i]:.2f}  cos {cos[i]:.2f}   {a} ~ {b}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Collapses the two diverging open `mu_cosine` prototype PRs — **#3281** (MiniLM-only dense μ) and **#3283** (torch port + e5 comparison) — into a single clean state on top of the already-merged handoff fixups (#3282). Prototype only; the WAM-Rust core is untouched.

## Why one PR
The two open PRs branched from pre-#3282 `main` and diverged: #3283 has the real torch encoder + e5 calibration, #3281 has a MiniLM-only direct map. They also each edited `README.md` off the old base, so neither carries #3282's Prompt A/B/C guidance. This PR is the union: current `main` + #3283's code + the doc corrections #3283's findings imply, and it **supersedes both**.

## What's folded in (from #3283)
| file | what it does |
|---|---|
| `mu_encoder_torch.py` | torch port of the MLP/MoE encoder; MiniLM init wired into `embed()` (`build_minilm_init`); MoE load-balancing aux loss; `to_membership` clamp |
| `train_cosine_mu_torch.py` | cosine-μ objective in torch (Adam/SparseAdam). `--free-vectors` reproduces the stdlib proof (**corr → 1.00**); `--minilm --holdout` generalisation (**held-out corr +0.946**); `--mode pairs` refuses unscored rows (budget gate in code) |
| `emit_dense_mu.py` | dense `name<TAB>μ` for the whole graph from the trained encoder; clamps `[0,1]`, emits names verbatim, asserts coverage |
| `dense_mu_direct.py` | dense μ with **no training**, asymmetric query/doc prefixes; `minilm`/`e5`/`nomic` presets; `--compare` reports the calibrated decision band |
| `check_feeds_rust.py` | confirms a chosen map feeds `gated_ic`/`lin_from_ic` (faithful port of the Rust contract) |
| `validate_lin_agreement.py` | python port of `gated_ic`/`lin_from_ic` for the (now-corrected) graph-side cross-check |
| `dense_mu_e5.sample.tsv`, `.gitignore`, `requirements.txt` | sample-only committed map (full maps git-ignored, regenerable); `einops` added for the nomic preset |

## The model pick — calibrated decision band
The budget metric is the **decision band** (categories straddling the 0.3 gate that a later Haiku pass must re-score). The **raw** band is misleading — asymmetric retrievers floor the cosine, so e5's raw band is 0 by total compression (Music ≈ Optics). Fix (no budget): **calibrate cosine→μ against the 90-node Haiku fixture before counting the band.**

| model | dim | raw band | **calibrated band** | fixture r | gate leak |
|---|---|---|---|---|---|
| all-MiniLM-L6-v2 | 384 | 876 | 2028 | +0.573 | 4/5 |
| **e5-small-v2** | **384** | 0 | **653** | **+0.665** | **3/5** |
| nomic-embed-text-v1.5 | 768 | 4109 | 1049 | +0.647 | — |

**Pick: `intfloat/e5-small-v2`** — smallest calibrated band, best fixture correlation, lightweight 384-d. `check_feeds_rust.py` confirms general→specific IC (Physics 2.85 < Optics 5.12 < Thermodynamics 7.18).

## Docs corrected (the now-wrong handoff claims)
- **Dropped the Step-4 "dense μ should converge to node-vs-root `lin_from_ic`" validation** — it's degenerate (root is the most-general node, so node-vs-root Lin saturates at 1.0). Softened the "μ == Lin" unification to an analogy. Both now point at the pairwise-label motivation.
- **Corrected the decision-band metric** ("smallest band wins" → smallest *calibrated* band; raw band rewards a degenerate compressor).
- **Marked Prompt A realized** (e5 picked) and **retargeted Prompt C** at the e5 prior (Music ≈ 0.52, Politics ≈ 0.50 leaks; ≈653 band) — Prompt C (cutoff-band Haiku rescore) is the recommended next step.

## Why this supersedes #3281
#3281 uses symmetric MiniLM (the merged docs rank it below asymmetric e5/nomic for directional μ) and committed the full regenerable `dense_mu_physics.tsv`, which conflicts with the now-merged commit-vs-regenerate rule; its `sanity_check_rust.py` is covered by `check_feeds_rust.py`.

Guards honored: cosine clamped to `[0,1]`; names emitted verbatim from `category_parent.tsv`. No LLM budget spent. WAM-Rust core untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_