### PR TITLE
feat(wam): emit native items for compound args

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -13,10 +13,12 @@ The first implementation step is intentionally conservative:
 - `compile_predicate_to_wam_text/3` is now the explicit legacy text API.
 - `compile_predicate_to_wam_items/3` is available as the structured API. It now
   emits single-clause facts, simple user-predicate calls, generic builtin calls,
-  and conjunctions of those simple shapes directly as items. It falls back to
-  the existing text generator plus `wam_text_to_items/2` for multi-clause
-  predicates, aggregates, indexing, lowered builtins, control flow, compound
-  body arguments, and other complex shapes.
+  compound body arguments with default args-first `set_*` ordering, and
+  conjunctions of those simple shapes directly as items. It falls back to the
+  existing text generator plus `wam_text_to_items/2` for multi-clause predicates,
+  aggregates, indexing, lowered builtins, control flow, legacy interleaved
+  compound-argument emission via `args_first_emission(false)`, and other complex
+  shapes.
 - `compile_predicate_to_wam/3` still returns text by default for compatibility
   with the existing targets. The default-output flip described below remains a
   later migration step after more callers consume items directly.

--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -54,10 +54,11 @@ interpreter-mode predicate emission. Today that target path consumes the common
 structured WAM items directly and is output-equivalent to `wam_items_bridge`;
 the shared `compile_predicate_to_wam_items/3` producer now skips WAM text for
 single-clause facts, simple user-predicate calls, generic builtin calls, and
-conjunctions of those simple shapes, then falls back to the text-to-items bridge
-for more complex predicate shapes. As the native producer expands, the same
-explicit Python mode will skip WAM text for more predicates without changing the
-Python emitter.
+compound body arguments with default args-first `set_*` ordering, then falls
+back to the text-to-items bridge for more complex predicate shapes and the
+legacy `args_first_emission(false)` compound-argument order. As the native
+producer expands, the same explicit Python mode will skip WAM text for more
+predicates without changing the Python emitter.
 
 Lua, R, and Elixir follow the same partial migration shape as Python:
 interpreter-mode generated predicates consume common WAM items through the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -205,9 +205,10 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
 %% compile_clauses_to_wam_items_native(+Pred, +Arity, +Clauses, +Options, -Items)
 %  Direct items path for simple single-clause predicates. This incremental
 %  native producer slice covers facts, simple user calls, generic builtin calls,
-%  and conjunctions of those shapes. Aggregates, indexing, lowered builtins,
-%  control flow, compound body arguments, and peephole-sensitive shapes
-%  intentionally fall back to the legacy text bridge.
+%  compound body arguments using the default args-first set_* ordering, and
+%  conjunctions of those shapes. Aggregates, indexing, lowered builtins,
+%  control flow, legacy interleaved compound-arg emission, and other
+%  peephole-sensitive shapes intentionally fall back to the text bridge.
 compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], _Options, Items) :-
     normalize_goals(Body, []),
     !,
@@ -217,10 +218,10 @@ compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], _Options, Items) :
     format(string(Label), "~w/~w", [Pred, Arity]),
     append(HeadItems, [proceed], InstrItems),
     Items = [label(Label)|InstrItems].
-compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], _Options, Items) :-
+compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], Options, Items) :-
     normalize_goals(Body, Goals),
     Goals = [_|_],
-    native_simple_goal_sequence(Goals),
+    native_simple_goal_sequence(Goals, Options),
     !,
     Head =.. [_|Args],
     empty_varmap(V0),
@@ -244,19 +245,19 @@ native_simple_goals_need_env(Goals, ExpandedGoals) :-
     ),
     !.
 
-native_simple_goal_sequence(Goals) :-
-    forall(member(Goal, Goals), native_simple_goal(Goal)).
+native_simple_goal_sequence(Goals, Options) :-
+    forall(member(Goal, Goals), native_simple_goal(Goal, Options)).
 
-native_simple_goal(M:InnerGoal) :-
+native_simple_goal(M:InnerGoal, Options) :-
     (atom(M) ; string(M)),
     !,
-    native_simple_goal(InnerGoal).
-native_simple_goal(Goal) :-
+    native_simple_goal(InnerGoal, Options).
+native_simple_goal(Goal, Options) :-
     callable(Goal),
     \+ native_special_goal(Goal),
     Goal =.. [_GoalPred|Args],
     \+ goal_has_visited_set_arg(Goal),
-    forall(member(Arg, Args), native_simple_goal_arg(Arg)).
+    forall(member(Arg, Args), native_simple_goal_arg(Arg, Options)).
 
 native_special_goal('!') :- !.
 native_special_goal(Goal) :-
@@ -274,10 +275,13 @@ native_special_goal(Goal) :-
     ;   is_term_construction_goal(Goal)
     ).
 
-native_simple_goal_arg(Arg) :-
+native_simple_goal_arg(Arg, _Options) :-
     var(Arg), !.
-native_simple_goal_arg(Arg) :-
-    atomic(Arg).
+native_simple_goal_arg(Arg, _Options) :-
+    atomic(Arg), !.
+native_simple_goal_arg(Arg, Options) :-
+    compound(Arg),
+    \+ option(args_first_emission(false), Options).
 
 compile_goals_items_simple([], V, _, V, []).
 compile_goals_items_simple([Goal], V0, HasEnv, Vf, Items) :-
@@ -352,10 +356,79 @@ compile_put_argument_items_simple(Arg, I, V0, V1, Items) :-
             Items = [put_variable(XRegTok, Ai)]
         )
     ;   atomic(Arg)
-    ->  quote_wam_constant(Arg, ArgTok),
+    ->  wam_constant_token(Arg, ArgTok),
         Items = [put_constant(ArgTok, Ai)],
         V1 = V0
+    ;   is_list_term(Arg),
+        proper_list(Arg, _)
+    ->  Arg = [H|T],
+        next_x_reg(V0, XReg, VTemp),
+        bind_var(Arg, XReg, VTemp, V2),
+        compile_set_arguments_items_split([H, T], V2, V1, SetItems),
+        Items = [put_list(Ai)|SetItems]
+    ;   compound(Arg)
+    ->  Arg =.. [F|SubArgs],
+        length(SubArgs, SArity),
+        next_x_reg(V0, XReg, VTemp),
+        bind_var(Arg, XReg, VTemp, V2),
+        wam_functor_token(F, SArity, FunctorTok),
+        compile_set_arguments_items_split(SubArgs, V2, V1, SetItems),
+        Items = [put_structure(FunctorTok, Ai)|SetItems]
+    ;   next_x_reg(V0, XReg, VTemp),
+        bind_var(Arg, XReg, VTemp, V1),
+        wam_operand_string(XReg, XRegTok),
+        Items = [put_variable(XRegTok, Ai)]
     ).
+
+compile_set_arguments_items_split(Args, V0, Vf, Items) :-
+    compile_set_arguments_items_split_(Args, V0, Vf, ImmItems, DeferredItems),
+    append(ImmItems, DeferredItems, Items).
+
+compile_set_arguments_items_split_([], V, V, [], []).
+compile_set_arguments_items_split_([Arg|Rest], V0, Vf, Items, Deferred) :-
+    arg_items_split(Arg, V0, V1, ImmArg, DefArg),
+    compile_set_arguments_items_split_(Rest, V1, Vf, ImmRest, DefRest),
+    append(ImmArg, ImmRest, Items),
+    append(DefArg, DefRest, Deferred).
+
+arg_items_split(Arg, V0, V1, Items, []) :-
+    var(Arg),
+    !,
+    (   get_var_reg(Arg, V0, Reg)
+    ->  wam_operand_string(Reg, RegTok),
+        Items = [set_value(RegTok)],
+        V1 = V0
+    ;   get_yi_alloc(Arg, V0, YReg, V1)
+    ->  wam_operand_string(YReg, YRegTok),
+        Items = [set_variable(YRegTok)]
+    ;   next_x_reg(V0, XReg, VTemp),
+        bind_var(Arg, XReg, VTemp, V1),
+        wam_operand_string(XReg, XRegTok),
+        Items = [set_variable(XRegTok)]
+    ).
+arg_items_split(Arg, V0, V0, Items, []) :-
+    atomic(Arg),
+    !,
+    wam_constant_token(Arg, ArgTok),
+    Items = [set_constant(ArgTok)].
+arg_items_split(Arg, V0, V1, Items, Deferred) :-
+    compound(Arg),
+    !,
+    Arg =.. [F|NestedArgs],
+    length(NestedArgs, NArity),
+    next_x_reg(V0, XReg, VTemp),
+    bind_var(Arg, XReg, VTemp, V1a),
+    wam_operand_string(XReg, XRegTok),
+    wam_functor_token(F, NArity, FunctorTok),
+    compile_set_arguments_items_split_(NestedArgs, V1a, V1,
+                                       NestedImm, NestedDef),
+    Items = [set_variable(XRegTok)],
+    append([put_structure(FunctorTok, XRegTok)|NestedImm], NestedDef, Deferred).
+arg_items_split(Arg, V0, V1, Items, []) :-
+    next_x_reg(V0, XReg, VTemp),
+    bind_var(Arg, XReg, VTemp, V1),
+    wam_operand_string(XReg, XRegTok),
+    Items = [set_variable(XRegTok)].
 
 compile_head_arguments_items([], _, V, V, []).
 compile_head_arguments_items([Arg|Rest], I, V0, Vf, Items) :-
@@ -380,7 +453,7 @@ compile_head_argument_items(Arg, I, V0, V1, Items) :-
             Items = [get_variable(XRegTok, Ai)]
         )
     ;   atomic(Arg)
-    ->  quote_wam_constant(Arg, ArgTok),
+    ->  wam_constant_token(Arg, ArgTok),
         Items = [get_constant(ArgTok, Ai)],
         V1 = V0
     ;   is_list_term(Arg)
@@ -411,7 +484,7 @@ compile_unify_arguments_items([Arg|Rest], V0, Vf, Items) :-
             ArgItems = [unify_variable(XRegTok)]
         )
     ;   atomic(Arg)
-    ->  quote_wam_constant(Arg, ArgTok),
+    ->  wam_constant_token(Arg, ArgTok),
         ArgItems = [unify_constant(ArgTok)],
         V1 = V0
     ;   compound(Arg)
@@ -439,6 +512,10 @@ wam_functor_token(F, Arity, Token) :-
 
 wam_arity_token(Arity, Token) :-
     number_string(Arity, Token).
+
+wam_constant_token(Value, Token) :-
+    quote_wam_constant(Value, RawToken),
+    wam_operand_string(RawToken, Token).
 
 wam_operand_string(Value, String) :-
     (   string(Value)

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -7,7 +7,7 @@
 
 %% Test data (facts) - MUST BE DYNAMIC for clause/2 to work across modules
 :- dynamic test_parent/2, test_grandparent/2, test_ancestor/2, test_wrap/2,
-           test_alias/2, test_len/2.
+           test_alias/2, test_len/2, test_list_check/1, test_list_wrap/1.
 
 test_parent(alice, bob).
 test_parent(bob, charlie).
@@ -30,6 +30,10 @@ test_ancestor(X, Y) :- test_parent(X, Z), test_ancestor(Z, Y).
 :- dynamic test_check/1.
 test_check(pair(_, _)).
 test_wrap(X) :- test_check(pair(X, done)).
+
+%% Rule with list body argument — exercises put_list + nested [|]/2 emit.
+test_list_check([_, _]).
+test_list_wrap(X) :- test_list_check([X, done]).
 
 %% Compound head — exercises get_structure + unify_constant
 :- dynamic test_color/2.
@@ -409,15 +413,90 @@ test_wam_items_native_simple_builtin :-
     ;   fail_test(Test, 'Native simple-builtin items do not match canonical WAM text shape')
     ).
 
-test_wam_items_api_compound_arg_fallback :-
-    Test = 'WAM: items API compound body arg fallback',
+test_wam_items_native_compound_body_arg :-
+    Test = 'WAM: native items API for compound body arg',
+    ExpectedItems = [
+        label("test_wrap/1"),
+        allocate,
+        get_variable("X1", "A1"),
+        put_structure("pair/2", "A1"),
+        set_value("X1"),
+        set_constant("done"),
+        deallocate,
+        execute("test_check/1")
+    ],
     (   wam_target:compile_predicate_to_wam_text(user:test_wrap/1, [], TextCode),
         wam_text_to_items(TextCode, BridgeItems),
         wam_target:compile_predicate_to_wam_items(user:test_wrap/1, [], Items),
+        Items == ExpectedItems,
         Items == BridgeItems,
         member(put_structure("pair/2", "A1"), Items)
     ->  pass(Test)
-    ;   fail_test(Test, 'Compound body arg fallback does not match canonical WAM text shape')
+    ;   fail_test(Test, 'Native compound-body-arg items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_native_nested_compound_body_arg :-
+    Test = 'WAM: native items API for nested compound body arg',
+    ExpectedItems = [
+        label("test_nested_wrap/1"),
+        allocate,
+        get_variable("X1", "A1"),
+        put_structure("box/1", "A1"),
+        set_variable("X3"),
+        put_structure("inner/2", "X3"),
+        set_value("X1"),
+        set_constant("done"),
+        deallocate,
+        execute("test_nested_check/1")
+    ],
+    (   wam_target:compile_predicate_to_wam_text(user:test_nested_wrap/1, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_nested_wrap/1, [], Items),
+        Items == ExpectedItems,
+        Items == BridgeItems,
+        member(put_structure("box/1", "A1"), Items),
+        member(put_structure("inner/2", "X3"), Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Native nested-compound-body-arg items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_native_list_body_arg :-
+    Test = 'WAM: native items API for list body arg',
+    ExpectedItems = [
+        label("test_list_wrap/1"),
+        allocate,
+        get_variable("X1", "A1"),
+        put_list("A1"),
+        set_value("X1"),
+        set_variable("X3"),
+        put_structure("[|]/2", "X3"),
+        set_constant("done"),
+        set_constant("[]"),
+        deallocate,
+        execute("test_list_check/1")
+    ],
+    (   wam_target:compile_predicate_to_wam_text(user:test_list_wrap/1, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_list_wrap/1, [], Items),
+        Items == ExpectedItems,
+        Items == BridgeItems,
+        member(put_list("A1"), Items),
+        member(put_structure("[|]/2", "X3"), Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Native list-body-arg items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_compound_arg_legacy_order_fallback :-
+    Test = 'WAM: items API compound arg legacy-order fallback',
+    Options = [args_first_emission(false)],
+    (   wam_target:compile_predicate_to_wam_text(user:test_nested_wrap/1, Options, TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_nested_wrap/1, Options, Items),
+        Items == BridgeItems,
+        member(put_structure("box/1", "A1"), Items),
+        member(put_structure("inner/2", "X3"), Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Compound body arg legacy-order fallback does not match canonical WAM text shape')
     ).
 
 %% Run all tests
@@ -437,7 +516,10 @@ run_tests :-
     test_wam_items_native_simple_tail_call,
     test_wam_items_native_multi_goal_rule,
     test_wam_items_native_simple_builtin,
-    test_wam_items_api_compound_arg_fallback,
+    test_wam_items_native_compound_body_arg,
+    test_wam_items_native_nested_compound_body_arg,
+    test_wam_items_native_list_body_arg,
+    test_wam_items_compound_arg_legacy_order_fallback,
     test_wam_multi_clause_findall_emits_allocate,
     test_wam_a2_indexing,
     test_wam_mixed_mode_a1_indexing,


### PR DESCRIPTION
## Summary

- extend native `compile_predicate_to_wam_items/3` emission to compound body arguments
- support default args-first `put_structure` / `put_list` plus `set_*` item ordering directly
- add native item coverage for nested compound body args and list body args
- preserve the text-bridge fallback for legacy `args_first_emission(false)` ordering
- normalize native constant tokens so values like `[]` match the shared text parser item shape
- update WAM items and representation-mode docs with the new native coverage boundary

## Notes

This keeps the migration incremental. Multi-clause predicates, aggregates, indexing, lowered builtins, control flow, and legacy interleaved compound-argument emission still use the existing WAM text plus `wam_text_to_items/2` bridge.

## Tests

- `swipl -q -f tests/test_wam_target.pl`
- `swipl -q -f tests/test_wam_ir_mode.pl`
- `swipl -q -f tests/test_wam_text_parser.pl -g run_tests -t halt`
- `swipl -q -f tests/test_wam_python_target.pl`
- `swipl -q -f tests/test_wam_lua_generator.pl`
- `swipl -q -f tests/test_wam_elixir_target.pl`
- `swipl -q -f tests/test_wam_r_generator.pl`
- `git diff --check`
