### PR TITLE
Fix/wam clojure functor arity integer

### DIFF
--- a/PR_WAM_CLOJURE_INTEGER_TERMS.md
+++ b/PR_WAM_CLOJURE_INTEGER_TERMS.md
@@ -1,0 +1,24 @@
+# PR Title
+
+fix(wam-clojure): preserve integer terms in WAM runtime
+
+# PR Description
+
+## Summary
+
+- Emit bare numeric WAM constants as Clojure numeric literals while preserving quoted numeric atoms as atoms.
+- Return integer terms from Clojure WAM runtime helpers that model Prolog integer outputs.
+- Add regression coverage for numeric WAM token emission.
+
+## Details
+
+This fixes Clojure WAM smoke regressions where builtins such as `functor/3`, `compound_name_arity/3`, `atom_codes/2`, `char_code/2`, `string_code/3`, `atom_length/2`, and `sub_atom/5` produced atom-like numeric terms instead of integers.
+
+The generator now distinguishes unquoted numeric WAM tokens like `2` from quoted atom tokens like `'2'`, so WAM constants retain their intended Prolog type in generated Clojure EDN.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -510,8 +510,20 @@ wam_atom_token_text(Token, AtomText) :-
     clj_unquote_wam_atom_token(Token, AtomText).
 
 wam_atom_token_literal(Token, Literal) :-
+    wam_unquoted_number_token(Token, Num),
+    !,
+    format(atom(Literal), '~w', [Num]).
+wam_atom_token_literal(Token, Literal) :-
     wam_atom_token_text(Token, AtomText),
     clj_string_literal(AtomText, Literal).
+
+wam_unquoted_number_token(Token, Num) :-
+    (   number(Token)
+    ->  Num = Token
+    ;   (   string(Token) -> S = Token ; atom_string(Token, S) ),
+        \+ sub_string(S, 0, 1, _, "'"),
+        catch(number_string(Num, S), _, fail)
+    ).
 
 wam_op_intern_seeds("get_constant", [Const, _], [AtomText], []) :- wam_atom_token_text(Const, AtomText).
 wam_op_intern_seeds("put_constant", [Const, _], [AtomText], []) :- wam_atom_token_text(Const, AtomText).

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -736,7 +736,7 @@
     :else nil))
 
 (defn functor-arity-term [state arity]
-  (normalize-literal-term (:intern-context state) (str arity)))
+  arity)
 
 (defn compound-name-text [state value]
   (when (atom-term? value)
@@ -1517,7 +1517,7 @@
 
 (defn code-list-term [state text]
   [state (list->term (:intern-context state)
-                     (map #(normalize-literal-term (:intern-context state) (str (int %))) text))])
+                     (map int text))])
 
 (defn char-list-term [state text]
   (let [[next-state chars] (intern-char-terms state text)]
@@ -1771,7 +1771,7 @@
   (and (integer? value) (not (neg? value)) (<= value 65535)))
 
 (defn char-code-count-term [state code]
-  (normalize-literal-term (:intern-context state) (str code)))
+  code)
 
 (defn apply-char-code-solution [state]
   (let [char-value (deref-value (:bindings state)
@@ -1936,7 +1936,7 @@
       (some? text)
       (let [len (count text)
             [ok next-state] (if (logic-var? out)
-                              (unify-values state out (normalize-literal-term (:intern-context state) (str len)))
+                              (unify-values state out len)
                               [(= out-count len) state])]
         (if ok
           (advance next-state)
@@ -1961,7 +1961,7 @@
     :else nil))
 
 (defn sub-atom-count-term [state n]
-  (normalize-literal-term (:intern-context state) (str n)))
+  n)
 
 (defn sub-atom-solution-results [state text before length after sub]
   (let [n (count text)

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -176,6 +176,14 @@ test(compile_time_intern_tables_are_emitted_and_deduplicated) :-
         delete_directory_and_contents(TmpDir)
     )).
 
+test(numeric_wam_constants_preserve_number_vs_atom_tokens) :-
+    once((
+        wam_clojure_target:wam_op_to_clojure_literal("put_constant", ["2", "A1"], _, NumericLiteral),
+        wam_clojure_target:wam_op_to_clojure_literal("put_constant", ["'2'", "A1"], _, AtomLiteral),
+        assertion(NumericLiteral == '{:op :put-constant :constant 2 :reg "A1"}'),
+        assertion(AtomLiteral == '{:op :put-constant :constant "2" :reg "A1"}')
+    )).
+
 test(foreign_predicates_emit_call_foreign_stub) :-
     once((
         unique_tmp_dir('tmp_wam_clojure_foreign', TmpDir),


### PR DESCRIPTION
# fix(wam-clojure): preserve integer terms in WAM runtime

## Summary

- Emit bare numeric WAM constants as Clojure numeric literals while preserving quoted numeric atoms as atoms.
- Return integer terms from Clojure WAM runtime helpers that model Prolog integer outputs.
- Add regression coverage for numeric WAM token emission.

## Details

This fixes Clojure WAM smoke regressions where builtins such as `functor/3`, `compound_name_arity/3`, `atom_codes/2`, `char_code/2`, `string_code/3`, `atom_length/2`, and `sub_atom/5` produced atom-like numeric terms instead of integers.

The generator now distinguishes unquoted numeric WAM tokens like `2` from quoted atom tokens like `'2'`, so WAM constants retain their intended Prolog type in generated Clojure EDN.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
