### PR TITLE
prototype(mu_cosine): validate #3287 as control baseline + resolve theory questions

### DIFF
--- a/prototypes/mu_cosine/README.md
+++ b/prototypes/mu_cosine/README.md
@@ -23,6 +23,7 @@ torch 2.x + sentence-transformers (ML pieces).
 | **scoring the pairs (μ labels)** | ✅ **sampler labels done** — `mu_pairs_scored.tsv` (200 Haiku-scored positives + 1000 free μ=0 negatives); cutoff-band rescore (Prompt C) still pending |
 | training on the scored pairs | ✅ **done** — `train_cosine_mu_torch.py --mode pairs --minilm` on `mu_pairs_scored.tsv`; held-out pos corr **+0.726**, lin-agreement moved **−0.13 → +0.10** |
 | wiring dense μ back to the Rust core | 🟡 **emitter done** — `emit_dense_mu.py` / `dense_mu_direct.py` (clamped, verbatim names, 100% coverage); Rust consumption verified by `check_feeds_rust.py`, not run end-to-end in CI |
+| control baseline + theory questions | ✅ **done** — `validate_control_baseline.py` → `REPORT_control_baseline.md` (the #3287 control arm the directional model must beat; lin-saturation, decision-flip, cold-start all resolved) |
 
 ### Progress — ML-environment port (folded in from #3283)
 

--- a/prototypes/mu_cosine/REPORT_control_baseline.md
+++ b/prototypes/mu_cosine/REPORT_control_baseline.md
@@ -1,0 +1,84 @@
+# Control baseline — symmetric MiniLM μ-encoder (#3287)
+
+The symmetric MiniLM pairwise encoder (`train_cosine_mu_torch.py --mode pairs --minilm`, merged in
+#3287) validated as the **control arm** for `DESIGN_directional_attention.md`. These are the numbers the
+directional (e5 multi-operator) model must beat to justify its extra machinery. **No LLM budget spent** —
+all analysis runs on the existing maps + the faithful `gated_ic`/`lin_from_ic` port.
+
+Reproduce:
+```bash
+python3 train_cosine_mu_torch.py --mode pairs --pairs mu_pairs_scored.tsv --minilm \
+    --holdout 0.2 --weight-decay 1.0 --epochs 2000 --lr 0.01 --save-encoder control.pt
+python3 validate_lin_agreement.py --encoder control.pt
+python3 emit_dense_mu.py --encoder control.pt --out dense_mu_control.tsv
+python3 dense_mu_direct.py --model e5 --out dense_mu_e5.tsv          # proxy map for the flip test
+python3 validate_control_baseline.py --encoder control.pt \
+    --control-map dense_mu_control.tsv --proxy-map dense_mu_e5.tsv
+```
+
+## Control numbers
+
+| metric | value |
+|---|---|
+| held-out pairwise-μ corr (40 held-out positives) | **+0.726** (MSE 0.065) |
+| lin-agreement Pearson / Spearman (1275 pairs) | **+0.098 / +0.113** |
+| lin-agreement on non-saturated pairs (the real signal) | **+0.124** (42 pairs) |
+| lin saturation fraction | **96.7%** (1233/1275 pinned at 1.0) |
+| decision-flip rate, band vs confident | **40% vs 4.0%** (proxy); 28% (5/18) ground-truth |
+| cold-start OOD gate-leak (dist ≥ 5, never trained) | **1.1%** (49/4280, μ̄ 0.043) |
+| gate-leak (5-probe, from #3287) | **0/5** |
+
+## Q1 — `lin_from_ic` saturation ceiling
+
+**96.7% (1233/1275)** of scored-physics-node pairs saturate at `Lin ≥ 0.999`. Cause (a **graph/gating
+property, not the μ map**): `Lin = min(2·IC(MICA)/(IC(u)+IC(v)), 1)`, and **all 1233** saturated pairs
+have `2·IC(MICA) ≥ IC(u)+IC(v)` — 1224 have an *un-clamped* `Lin > 1` (median **1.39**). This is because
+**μ-gating prunes ancestor cones**: a common ancestor reachable only through low-μ (out-of-domain)
+connectors has a tiny *gated* descendant cone and therefore a **high IC — often higher than the nodes it
+sits above** (e.g. `Temperature`/`Fire`: IC 3.07, 5.24 but `MICA` IC = 6.24). IC is non-monotone up the
+gated DAG (the same in-domain-leak pruning the Rust core does on purpose), so the Lin ratio overshoots 1
+and clamps.
+
+**Ceiling / headroom:** graph-Lin carries gradable signal on only **42/1275 (3.3%)** of pairs; the rest
+are pinned at 1.0 and add only label-noise to the Pearson. **lin-agreement is a low-resolution metric** —
+the directional model's real headroom is those 42 non-saturated pairs (control already **+0.124** there),
+not the global `r`. *Conclusion: do not over-weight the global lin-agreement Pearson; it is structurally
+capped low and the per-pair signal is thin.*
+
+## Q2 — decision-flip rate (active-learning premise)
+
+**360** categories sit in the control decision band `μ ∈ [0.2, 0.45]` (of 8 247). How many would a better
+membership signal flip across the 0.3 gate?
+
+- **(a) ground truth** vs the 90-node Haiku fixture: 18 band nodes are fixture-scored; **5 (28%) flip**.
+- **(b) proxy** vs an independent map (e5-direct): **145/360 (40%) flip** — vs only **4.0%** in the
+  confident region (μ outside the band).
+
+The band flips **~10× more** than the confident region, confirming it is the genuinely-uncertain set —
+**the active-learning premise holds**: a budget-bounded boundary rescore targeted at this band is well
+spent (≈ a third of it changes the gate decision), whereas rescoring the confident region would be waste.
+
+## Q3 — cold-start coverage (out-of-domain, never trained)
+
+The shared encoder is frozen-MiniLM + learned blocks, so all 8 247 nodes are scored; only ~1 225 names
+were ever in training. On unseen nodes:
+
+- **OOD rejection:** of **4 280** nodes far from Physics (graph dist ≥ 5) and never trained, only
+  **1.1% (49) leak** the 0.3 gate (μ̄ 0.043, max 0.67) — clean rejection.
+- **Unseen in-domain generalisation:** the 9 never-trained nodes at dist ≤ 2 are scored by **semantics,
+  not graph proximity** — physics-adjacent fields pass (Mechanics 0.75, Electricity 0.67, Chemistry 0.57,
+  Academic_disciplines 0.51) while generic apex neighbours are correctly rejected (Geography 0.13,
+  Everyday_life 0.08, Past/Chronology/Future ≈ 0).
+- **No memorisation:** at *matched* graph distance, trained-vs-unseen gate-pass is identical for far
+  nodes (**1% vs 1%**, n=4 280). The shared encoder generalises; it is not a per-node lookup. (The near
+  d≤2 sample is only 9 unseen nodes — too small for a parity claim, but the per-node scores above show
+  correct discrimination.)
+
+## What the directional model must beat
+
+`SYM`/relatedness and **gate-leak** are the head-to-head metrics (per the design's "control arm"). The
+control sets: **gate-leak 0/5 (probe) and 1.1% (4 280-node OOD)**, **held-out pairwise-μ +0.726**, and
+**non-saturated lin-agreement +0.124**. Two cautions the directional track inherits: (1) the global
+lin-agreement Pearson is a **low-resolution metric** (96.7% saturated) — judge it on the non-saturated
+pairs; (2) the **decision band is real** (40% flip) — that is where the budgeted `LLM_*` boundary labels
+should go.

--- a/prototypes/mu_cosine/validate_control_baseline.py
+++ b/prototypes/mu_cosine/validate_control_baseline.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Validate the symmetric MiniLM μ-encoder (#3287) as the **control baseline** and resolve the three
+open theory questions from `DESIGN_directional_attention.md`. Pure analysis on the existing maps +
+faithful `gated_ic`/`lin_from_ic` port (no LLM budget). The numbers it prints are the baseline the
+directional (e5 multi-operator) track must beat.
+
+Q1  lin_from_ic SATURATION CEILING — what fraction of scored-pair graph-Lin pin at 1.0, *why* (a graph
+    property), and the ceiling that puts on the lin-agreement Pearson (the directional model's headroom).
+Q2  DECISION-FLIP RATE — of the decision-band categories (control μ ∈ [0.2,0.45]), how many would a
+    membership rescore flip across the 0.3 gate? Measured two ways with no new budget: (a) ground-truth
+    against the 90-node Haiku fixture, (b) proxy against an independent map (e5-direct).
+Q3  COLD-START COVERAGE — does the symmetric map give sane μ for out-of-domain nodes never seen in
+    training? Extends the 5-probe gate-leak test to a large graph-distance-based out-of-domain sample,
+    and compares trained-vocab vs never-seen parity.
+
+    python3 validate_control_baseline.py --encoder control.pt \
+        --control-map dense_mu_control.tsv --proxy-map dense_mu_e5.tsv
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import os
+from collections import deque
+from itertools import combinations
+
+import torch
+
+from validate_lin_agreement import (load_graph, load_mu, lin_from_ic, gated_ic_for,
+                                     reflexive_ancestors, pearson, spearman, GRAPH, FIXTURE)
+from mu_encoder_torch import Config, MuEncoder, build_minilm_init
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+SCORED = os.path.join(ROOT, "mu_pairs_scored.tsv")
+ANCHOR = "Physics"
+SAT = 0.999      # Lin ≥ SAT counts as saturated
+BAND = (0.2, 0.45)
+GATE = 0.3
+
+
+def bfs_dist_undirected(parents, src):
+    adj = {}
+    for c, ps in parents.items():
+        for p in ps:
+            adj.setdefault(c, set()).add(p)
+            adj.setdefault(p, set()).add(c)
+    dist = {src: 0}
+    q = deque([src])
+    while q:
+        x = q.popleft()
+        for y in adj.get(x, ()):
+            if y not in dist:
+                dist[y] = dist[x] + 1
+                q.append(y)
+    return dist
+
+
+def training_vocab():
+    names = set()
+    with open(SCORED) as f:
+        for line in f:
+            if line.startswith("#"):
+                continue
+            p = line.rstrip("\n").split("\t")
+            if len(p) >= 2:
+                names.update((p[0], p[1]))
+    return names
+
+
+# --------------------------------------------------------------------------------------------------
+def unclamped_lin(a, b, parents, children, mu, threshold, total_mu, cache):
+    """Lin BEFORE the `.min(1.0)` cap — `2·IC(MICA)/(IC(u)+IC(v))`. None if undefined."""
+    au, av = reflexive_ancestors(a, parents), reflexive_ancestors(b, parents)
+    mica = None
+    for n in au & av:
+        ic = gated_ic_for(n, children, mu, threshold, total_mu, cache)
+        if math.isfinite(ic) and (mica is None or ic > mica):
+            mica = ic
+    if mica is None:
+        return None
+    ica = gated_ic_for(a, children, mu, threshold, total_mu, cache)
+    icb = gated_ic_for(b, children, mu, threshold, total_mu, cache)
+    if ica + icb <= 0:
+        return None
+    return 2.0 * mica / (ica + icb)
+
+
+def q1_saturation(args, parents, children, mu_fix, total_mu):
+    print("\n" + "=" * 90)
+    print("Q1  lin_from_ic SATURATION CEILING")
+    print("=" * 90)
+    nodes = [n for n in mu_fix if n in parents and mu_fix[n] >= args.threshold]
+    cache = {}
+    pairs, lin, unc = [], [], []
+    for a, b in combinations(nodes, 2):
+        v = lin_from_ic(a, b, parents, children, mu_fix, args.threshold, total_mu, cache)
+        if v is not None:
+            pairs.append((a, b))
+            lin.append(v)
+            unc.append(unclamped_lin(a, b, parents, children, mu_fix, args.threshold, total_mu, cache))
+    n = len(pairs)
+    sat_idx = [i for i, v in enumerate(lin) if v >= SAT]
+    p_sat = len(sat_idx) / n
+    print(f"{n} scored-node pairs with a finite-IC common ancestor; "
+          f"{len(sat_idx)} ({100*p_sat:.1f}%) saturate at Lin ≥ {SAT}")
+
+    # WHY (the graph property): Lin = min(2·IC(MICA)/(IC(u)+IC(v)), 1). It clamps to 1.0 whenever
+    # 2·IC(MICA) ≥ IC(u)+IC(v) — and under μ-GATING that is the common case, because gating prunes
+    # ancestor cones: a common ancestor reachable only THROUGH low-μ (out-of-domain) connectors has a
+    # tiny *gated* descendant cone, hence a HIGH IC — often higher than the nodes it sits above. So the
+    # MICA is over-informative and the ratio blows past 1.0 and clamps. (IC is non-monotone up the DAG
+    # once the cone is gated — the same in-domain-leak pruning the Rust core does on purpose.)
+    clamp_active = sum(1 for i in sat_idx if unc[i] is not None and unc[i] >= 1.0 - 1e-9)
+    mica_gt = sum(1 for i in sat_idx if unc[i] is not None and unc[i] > 1.0 + 1e-6)
+    med_unc = sorted(unc[i] for i in sat_idx if unc[i] is not None)[len(sat_idx)//2]
+    print(f"  WHY: {clamp_active}/{len(sat_idx)} saturated pairs have 2·IC(MICA) ≥ IC(u)+IC(v) (clamp "
+          f"active); {mica_gt} have un-clamped Lin strictly > 1 (median un-clamped {med_unc:.2f}). "
+          f"μ-gating prunes ancestor cones ⇒ IC(MICA) is often > IC(u),IC(v) (non-monotone up the DAG), "
+          f"so the ratio overshoots 1.0. A graph/gating property — independent of the μ map.")
+
+    # semantic cosines for the SAME pairs (control encoder)
+    names = sorted({x for p in pairs for x in p})
+    init = build_minilm_init(names)
+    ckpt = torch.load(args.encoder, map_location="cpu", weights_only=False)
+    model = MuEncoder(Config(**ckpt["cfg"]), init_embeddings=init, names=names, freeze_init=True)
+    model.blocks.load_state_dict(ckpt["blocks"])
+    model.eval()
+    with torch.no_grad():
+        cos, _ = model.mu(model._ids([a for a, _ in pairs]), model._ids([b for _, b in pairs]))
+    cos = cos.clamp(0, 1).tolist()
+
+    r_all, rho_all = pearson(lin, cos), spearman(lin, cos)
+    ns = [i for i in range(n) if i not in set(sat_idx)]
+    r_ns = pearson([lin[i] for i in ns], [cos[i] for i in ns]) if len(ns) > 2 else float("nan")
+    print(f"  control lin-agreement Pearson r={r_all:+.3f}  Spearman ρ={rho_all:+.3f} (all {n})")
+    print(f"  on the {len(ns)} NON-saturated pairs (the only ones whose Lin VARIES): Pearson r={r_ns:+.3f}")
+    print(f"  CEILING: graph-Lin carries gradable signal on only {len(ns)}/{n} ({100*(1-p_sat):.1f}%) "
+          f"of pairs — the other {100*p_sat:.1f}% are pinned at 1.0 and add only label-noise to the "
+          f"Pearson. So lin-agreement is a LOW-RESOLUTION metric; the directional model's headroom is "
+          f"those {len(ns)} non-saturated pairs (control already +{r_ns:.3f} there), not the global r.")
+    return {"pairs": n, "sat_frac": p_sat, "clamp_active": clamp_active / max(1, len(sat_idx)),
+            "med_unclamped": med_unc, "r_all": r_all, "rho_all": rho_all, "r_nonsat": r_ns,
+            "n_nonsat": len(ns)}
+
+
+def q2_decision_flip(args, parents, control, proxy, mu_fix):
+    print("\n" + "=" * 90)
+    print("Q2  DECISION-FLIP RATE (active-learning premise)")
+    print("=" * 90)
+    lo, hi = BAND
+    band = [n for n, m in control.items() if lo <= m <= hi]
+    print(f"{len(band)} categories in the control decision band μ∈[{lo},{hi}] (of {len(control)})")
+
+    # (a) ground truth: fixture nodes in the band, do their Haiku μ land on the other side of the gate?
+    fix_band = [n for n in band if n in mu_fix]
+    flips_gt = sum(1 for n in fix_band if (control[n] < GATE) != (mu_fix[n] < GATE))
+    if fix_band:
+        print(f"  (a) ground-truth vs 90-node Haiku fixture: {len(fix_band)} band nodes are fixture-"
+              f"scored; {flips_gt} ({100*flips_gt/len(fix_band):.0f}%) flip across the {GATE} gate")
+    else:
+        print("  (a) no band node overlaps the fixture (expected — fixture nodes are high-μ physics)")
+
+    # (b) proxy: an independent map (e5-direct) as a stand-in 'rescore'
+    both = [n for n in band if n in proxy]
+    flips_px = sum(1 for n in both if (control[n] < GATE) != (proxy[n] < GATE))
+    print(f"  (b) proxy vs independent e5-direct map: {flips_px}/{len(both)} "
+          f"({100*flips_px/max(1,len(both)):.0f}%) flip across the {GATE} gate")
+    # baseline: how often do two maps disagree OUTSIDE the band (confident region)? should be lower.
+    conf = [n for n in control if n in proxy and (control[n] < lo or control[n] > hi)]
+    flips_conf = sum(1 for n in conf if (control[n] < GATE) != (proxy[n] < GATE))
+    print(f"      vs confident region (μ outside the band): {flips_conf}/{len(conf)} "
+          f"({100*flips_conf/max(1,len(conf)):.1f}%) flip — the band SHOULD flip more if it is the "
+          f"genuinely-uncertain set (validates active learning).")
+    return {"band": len(band), "flip_gt": (flips_gt, len(fix_band)),
+            "flip_proxy_pct": 100*flips_px/max(1, len(both)),
+            "flip_conf_pct": 100*flips_conf/max(1, len(conf))}
+
+
+def q3_cold_start(args, parents, control, dist):
+    print("\n" + "=" * 90)
+    print("Q3  COLD-START COVERAGE (out-of-domain, never trained)")
+    print("=" * 90)
+    train = training_vocab()
+    far = args.far_dist
+    # out-of-domain proxy: far from Physics in the undirected graph AND never seen in training
+    ood = [n for n in control if dist.get(n, 99) >= far and n not in train]
+    leak = sum(1 for n in ood if control[n] >= GATE)
+    print(f"trained vocab {len(train)} names; {len(ood)} out-of-domain nodes "
+          f"(graph dist ≥ {far} from {ANCHOR}, never trained)")
+    print(f"  OOD gate-leak: {leak}/{len(ood)} ({100*leak/max(1,len(ood)):.1f}%) pass the {GATE} gate "
+          f"(lower = cleaner rejection). μ mean {sum(control[n] for n in ood)/max(1,len(ood)):.3f}, "
+          f"max {max(control[n] for n in ood):.2f}")
+
+    # unseen IN-DOMAIN: near Physics (dist ≤ 2) but never trained — cold-start must still score these
+    # high (generalisation INTO the domain, not just rejection of far nodes).
+    near_unseen = [n for n in control if dist.get(n, 99) <= 2 and n not in train and n != ANCHOR]
+    near_hi = sum(1 for n in near_unseen if control[n] >= GATE)
+    print(f"  unseen in-domain (dist ≤ 2, never trained): {len(near_unseen)} nodes, "
+          f"{100*near_hi/max(1,len(near_unseen)):.0f}% pass the gate, μ̄="
+          f"{sum(control[n] for n in near_unseen)/max(1,len(near_unseen)):.3f}")
+
+    # cold-start parity at MATCHED distance (the unbiased test: does being in training change μ?)
+    def band_stats(dmin, dmax):
+        seen = [control[n] for n in control if dmin <= dist.get(n, 99) <= dmax and n in train]
+        uns = [control[n] for n in control if dmin <= dist.get(n, 99) <= dmax and n not in train]
+        gp = lambda ms: 100*sum(1 for m in ms if m >= GATE)/max(1, len(ms))
+        return (len(seen), gp(seen)), (len(uns), gp(uns))
+    for label, (dmin, dmax) in [("near d≤2", (0, 2)), ("far d≥5", (far, 99))]:
+        (ns_, gs), (nu, gu) = band_stats(dmin, dmax)
+        print(f"  parity {label}: seen ({ns_}) gate-pass {gs:.0f}%  vs  unseen ({nu}) gate-pass {gu:.0f}% "
+              f"— matched distance, so a gap would mean memorisation")
+    return {"ood": len(ood), "ood_leak_pct": 100*leak/max(1, len(ood)),
+            "near_unseen_pass": 100*near_hi/max(1, len(near_unseen)), "n_near_unseen": len(near_unseen)}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--encoder", required=True)
+    ap.add_argument("--control-map", required=True, help="dense μ map from the control encoder")
+    ap.add_argument("--proxy-map", required=True, help="independent map (e5-direct) for the flip proxy")
+    ap.add_argument("--threshold", type=float, default=GATE)
+    ap.add_argument("--far-dist", type=int, default=5, help="graph dist ≥ this = out-of-domain")
+    args = ap.parse_args()
+
+    parents, children = load_graph(GRAPH)
+    mu_fix = load_mu(FIXTURE)
+    total_mu = sum(mu_fix.values())
+    control = load_mu(args.control_map)
+    proxy = load_mu(args.proxy_map)
+    dist = bfs_dist_undirected(parents, ANCHOR)
+
+    r1 = q1_saturation(args, parents, children, mu_fix, total_mu)
+    r2 = q2_decision_flip(args, parents, control, proxy, mu_fix)
+    r3 = q3_cold_start(args, parents, control, dist)
+
+    print("\n" + "=" * 90)
+    print("CONTROL BASELINE SUMMARY (the number the directional track must beat)")
+    print("=" * 90)
+    print(f"  held-out pairwise-μ corr ............ +0.726  (MSE 0.065)   [from #3287 reproduction]")
+    print(f"  lin-agreement Pearson / Spearman .... {r1['r_all']:+.3f} / {r1['rho_all']:+.3f}")
+    print(f"  lin saturation fraction ............. {100*r1['sat_frac']:.1f}%  ({r1['n_nonsat']} of "
+          f"{r1['pairs']} pairs carry gradable signal)")
+    print(f"  lin-agreement on non-saturated ...... {r1['r_nonsat']:+.3f}  (the real headroom)")
+    print(f"  decision-flip rate (band, proxy) .... {r2['flip_proxy_pct']:.0f}%  vs {r2['flip_conf_pct']:.1f}% confident region")
+    print(f"  cold-start OOD gate-leak ............ {r3['ood_leak_pct']:.1f}%  ({r3['ood']} nodes, dist≥{args.far_dist})")
+    print(f"  cold-start unseen in-domain pass .... {r3['near_unseen_pass']:.0f}%  ({r3['n_near_unseen']} near, never trained)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Validates the symmetric MiniLM pairwise μ-encoder (#3287) as the **control arm** for `DESIGN_directional_attention.md` and answers the three open theory questions. **No LLM budget** — pure analysis on the existing maps + the faithful `gated_ic`/`lin_from_ic` port. WAM-Rust core untouched.

## Gating check (passed)
- ✅ deps present (`torch 2.12`, `sentence-transformers 5.6`); `pip install -r requirements.txt` satisfied
- ✅ HuggingFace reaches `all-MiniLM-L6-v2` (encodes at 384-d)

## Reproduced #3287 (control numbers)
| metric | value |
|---|---|
| held-out pairwise-μ corr (40 held-out positives) | **+0.726** (MSE 0.065) |
| lin-agreement Pearson / Spearman (1275 pairs) | **+0.098 / +0.113** |
| gate-leak (5-probe) | **0/5** |
| dense map | 100% coverage, IC general→specific, `lin ∈ [0,1]` |

## Theory validation

**Q1 — `lin_from_ic` saturation ceiling.** **96.7% (1233/1275)** of scored-physics-node pairs pin at `Lin ≥ 0.999`. Cause is a **graph/gating property, not the μ map**: `Lin = min(2·IC(MICA)/(IC(u)+IC(v)), 1)`, and all 1233 have `2·IC(MICA) ≥ IC(u)+IC(v)` (median *un-clamped* Lin **1.39**). μ-gating prunes ancestor cones, so a common ancestor reachable only via low-μ connectors has a tiny gated cone and a **high IC — often higher than the nodes below it** (e.g. `Temperature`/`Fire`: IC 3.07, 5.24 but MICA IC = 6.24); IC is non-monotone up the gated DAG, so the ratio overshoots 1 and clamps. **Ceiling:** only **42/1275 (3.3%)** of pairs carry gradable signal → lin-agreement is a **low-resolution metric**; the directional model's real headroom is those 42 non-saturated pairs (control already **+0.124** there), not the global `r`.

**Q2 — decision-flip rate (active-learning premise).** **360** categories in the band `μ ∈ [0.2,0.45]`. Flip across the 0.3 gate: **40%** (proxy vs e5-direct) / **28%** (5/18 ground-truth vs the Haiku fixture) — vs **4.0%** in the confident region. The band flips **~10×** more → the active-learning premise holds; a budgeted boundary rescore belongs here, not in the confident region.

**Q3 — cold-start coverage.** OOD gate-leak **1.1%** (49/4280 far, never-trained nodes; μ̄ 0.043). **No memorisation:** matched-distance parity is identical for far nodes (seen 1% vs unseen 1%, n=4280). Unseen near-Physics nodes are scored by **semantics, not graph proximity** — physics-adjacent fields pass (Mechanics 0.75, Electricity 0.67, Chemistry 0.57) while generic apex neighbours are rejected (Geography 0.13, Everyday_life 0.08, Past/Future ≈ 0).

## What the directional model must beat
`SYM`/relatedness + **gate-leak** are the head-to-head metrics. Control: **gate-leak 0/5 (probe), 1.1% (OOD)**, **held-out +0.726**, **non-saturated lin-agreement +0.124**. Two inherited cautions: judge lin-agreement on the **non-saturated** pairs (global Pearson is structurally capped by 96.7% saturation); and aim the budgeted `LLM_*` boundary labels at the **decision band** (40% flip).

Full write-up in `prototypes/mu_cosine/REPORT_control_baseline.md`; reproduce with `validate_control_baseline.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0162Dbotn3rbbdSSy4FtCqwM)_