### PR TITLE
docs(mu_cosine): revive lin-agreement on node-gated IC (follow-up to #3296)

### DIFF
--- a/prototypes/mu_cosine/DESIGN_directional_attention.md
+++ b/prototypes/mu_cosine/DESIGN_directional_attention.md
@@ -132,20 +132,23 @@ an arbitrary number of tokens, so adding it later is free.
 ## Validation (per operator)
 
 **Primary metrics:** held-out directional/pairwise-μ corr, **gate-leak** (probe + large OOD sample),
-decision-flip behaviour, and cold-start coverage. **Do _not_ optimise for lin-agreement** — the control
-baseline (#3294, `REPORT_control_baseline.md`) found pairwise `lin_from_ic` is **96.7% saturated at 1.0**:
-μ-gating prunes ancestor cones, so gated IC is **non-monotone up the DAG** (a common ancestor can out-IC
-the nodes below it ⇒ `2·IC(MICA)/(IC(u)+IC(v))` overshoots 1 and clamps). That's a graph/gating property,
-largely independent of the μ map, so **no** μ map can un-saturate it; only ~3.3% of pairs are gradable
-(control +0.124 there, ≈ noise on 42 pairs). Membership μ — not gated Lin — is the in-domain separator.
-Report lin-agreement only on the **non-saturated** pairs, as a weak secondary signal.
+decision-flip behaviour, and cold-start coverage. **Lin-agreement — revived by #3296, but compute it on
+*node-gated* IC.** The control baseline (#3294) found pairwise `lin_from_ic` **96.7% saturated at 1.0**,
+but that was the *path-gated* IC (`gated_ic`): μ-gating prunes ancestor cones, so gated IC is non-monotone
+up the DAG (a common ancestor can out-IC the nodes below it ⇒ `2·IC(MICA)/(IC(u)+IC(v))` overshoots 1 and
+clamps). **#3296's `gated_ic_node_filtered` (node-gated / downward-closed IC) fixes this** — on the same
+fixture it drops saturation to **0.1%** with 431 distinct Lin values (`node_gated_ic.py`). So feed
+`gated_ic_node_filtered` to `lin/resnik/faith_from_ic` and lin-agreement is a usable **secondary** signal
+again (a taxonomic-structure check). Do **not** use the path-gated `gated_ic` for similarity (it saturates),
+and do **not** validate against node-vs-root Lin (degenerate). Membership μ stays the **primary** in-domain
+separator; node-gated lin-agreement is a complementary check, not the target.
 
 - `WIKI`: held-out edge order-accuracy (does `μ(child|parent) > μ(parent|child)`?); decision-flip on the
   gated cone.
 - `LLM_*`: held-out directional-μ corr vs Haiku.
 - `SYM`: matches relatedness; `μ(X|root) ≈ μ(root|X)`.
 - Every operator's dense map → `check_feeds_rust.py` (100% coverage, IC general→specific, `lin ∈ [0,1]`,
-  gate-leak count).
+  gate-leak count). **Use `gated_ic_node_filtered`** when computing the Lin column.
 - **Control arm:** the MiniLM symmetric encoder (#3287, numbers in `REPORT_control_baseline.md`) is the
   baseline the e5 multi-operator model must **beat on held-out μ corr, `SYM`, and gate-leak** (control:
   held-out +0.726, gate-leak 0/5 probe & 1.1% on 4280 OOD nodes) — otherwise the extra machinery isn't
@@ -178,6 +181,7 @@ bounded `LLM_*` boundary labels (the cutoff band, ~tens of k Haiku tokens, bough
 > operator from a small Haiku boundary set (cutoff band only, ≤82k Haiku tokens, one inline subagent).
 > (4) Validate per operator: WIKI held-out edge order-accuracy, SYM relatedness + symmetry, each dense
 > map through `check_feeds_rust.py`; head-to-head vs the #3287 MiniLM-symmetric **control**
-> (`REPORT_control_baseline.md`) on **held-out μ corr, SYM, and gate-leak** — NOT lin-agreement, which is
-> 96.7% saturated and structurally low-resolution (judge it only on the non-saturated pairs). Do the
+> (`REPORT_control_baseline.md`) on **held-out μ corr, SYM, and gate-leak** (the primary metrics).
+> Lin-agreement is a usable *secondary* check **only when computed on `gated_ic_node_filtered`** (node-gated
+> IC, #3296) — the path-gated `gated_ic` saturates it (96.7%); don't use that one. Do the
 > judge axis later — start with one implicit judge. Report all per-operator numbers in the PR.


### PR DESCRIPTION
Follow-up to #3296. #3295 told the directional model "do not optimise for lin-agreement" because pairwise `lin_from_ic` was 96.7% saturated — but that was the **path-gated** IC. #3296's `gated_ic_node_filtered` (node-gated / downward-closed) de-saturates it to **0.1%** (431 distinct Lin values), so that guidance is now stale.

Corrects the directional spec:
- **Validation section + Prompt D:** lin-agreement is a usable **secondary** check again, *when computed on `gated_ic_node_filtered`* (a taxonomic-structure complement to the primary held-out-μ / gate-leak / decision-flip / cold-start metrics). Membership μ stays primary; the path-gated `gated_ic` must **not** be fed to the similarity functions (it saturates); node-vs-root Lin stays degenerate.
- Removes a duplicate bullet list introduced while editing.

Design doc only — no code/core changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_