### PR TITLE
feat(wam): emit native items for linear multi-clause predicates

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -14,11 +14,12 @@ The first implementation step is intentionally conservative:
 - `compile_predicate_to_wam_items/3` is available as the structured API. It now
   emits single-clause facts, simple user-predicate calls, generic builtin calls,
   compound body arguments with default args-first `set_*` ordering, and
-  conjunctions of those simple shapes directly as items. It falls back to the
-  existing text generator plus `wam_text_to_items/2` for multi-clause predicates,
-  aggregates, indexing, lowered builtins, control flow, legacy interleaved
-  compound-argument emission via `args_first_emission(false)`, and other complex
-  shapes.
+  conjunctions of those simple shapes directly as items. The same native path
+  also emits non-indexed linear multi-clause predicates when every clause has one
+  of those supported simple shapes. It falls back to the existing text generator
+  plus `wam_text_to_items/2` for indexed multi-clause predicates, aggregates,
+  lowered builtins, control flow, legacy interleaved compound-argument emission
+  via `args_first_emission(false)`, and other complex shapes.
 - `compile_predicate_to_wam/3` still returns text by default for compatibility
   with the existing targets. The default-output flip described below remains a
   later migration step after more callers consume items directly.

--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -54,11 +54,13 @@ interpreter-mode predicate emission. Today that target path consumes the common
 structured WAM items directly and is output-equivalent to `wam_items_bridge`;
 the shared `compile_predicate_to_wam_items/3` producer now skips WAM text for
 single-clause facts, simple user-predicate calls, generic builtin calls, and
-compound body arguments with default args-first `set_*` ordering, then falls
-back to the text-to-items bridge for more complex predicate shapes and the
-legacy `args_first_emission(false)` compound-argument order. As the native
-producer expands, the same explicit Python mode will skip WAM text for more
-predicates without changing the Python emitter.
+compound body arguments with default args-first `set_*` ordering. It also skips
+WAM text for non-indexed linear multi-clause predicates made from the same
+simple clause shapes, while indexed multi-clause predicates and more complex
+predicate shapes still use the text-to-items bridge. The legacy
+`args_first_emission(false)` compound-argument order also remains on the bridge.
+As the native producer expands, the same explicit Python mode will skip WAM text
+for more predicates without changing the Python emitter.
 
 Lua, R, and Elixir follow the same partial migration shape as Python:
 interpreter-mode generated predicates consume common WAM items through the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -89,13 +89,13 @@ compile_predicate_to_wam_text(PredIndicator, Options, Code) :-
     compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code).
 
 %% compile_predicate_to_wam_items(+PredIndicator, +Options, -Items)
-%  Compile a predicate to structured WAM items. Facts and simple one-goal user
-%  tail calls use direct item emission. More complex predicates fall back to the
-%  text generator plus shared parser until the full WAM emitter is items-first.
+%  Compile a predicate to structured WAM items. Simple native shapes use direct
+%  item emission. More complex predicates fall back to the text generator plus
+%  shared parser until the full WAM emitter is items-first.
 compile_predicate_to_wam_items(PredIndicator, Options, Items) :-
     wam_predicate_clauses(PredIndicator, Options, Pred, Arity, Clauses),
-    (   compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items)
-    ->  true
+    (   compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, NativeItems)
+    ->  peephole_optimize_items(NativeItems, Items)
     ;   compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code),
         wam_text_to_items(Code, Items)
     ).
@@ -203,41 +203,114 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
     ).
 
 %% compile_clauses_to_wam_items_native(+Pred, +Arity, +Clauses, +Options, -Items)
-%  Direct items path for simple single-clause predicates. This incremental
-%  native producer slice covers facts, simple user calls, generic builtin calls,
-%  compound body arguments using the default args-first set_* ordering, and
-%  conjunctions of those shapes. Aggregates, indexing, lowered builtins,
-%  control flow, legacy interleaved compound-arg emission, and other
-%  peephole-sensitive shapes intentionally fall back to the text bridge.
-compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], _Options, Items) :-
-    normalize_goals(Body, []),
+%  Direct items path for simple predicates. This incremental native producer
+%  slice covers facts, simple user calls, generic builtin calls, compound body
+%  arguments using the default args-first set_* ordering, conjunctions of those
+%  shapes, and non-indexed linear multi-clause predicates composed of the same
+%  clause shapes. Aggregates, indexing, lowered builtins, control flow, legacy
+%  interleaved compound-arg emission, and other peephole-sensitive shapes
+%  intentionally fall back to the text bridge.
+compile_clauses_to_wam_items_native(Pred, Arity, [Clause], Options, Items) :-
+    compile_clause_body_items_native(Clause, Options, InstrItems),
     !,
-    Head =.. [_|Args],
-    empty_varmap(V0),
-    compile_head_arguments_items(Args, 1, V0, _V1, HeadItems),
     format(string(Label), "~w/~w", [Pred, Arity]),
-    append(HeadItems, [proceed], InstrItems),
     Items = [label(Label)|InstrItems].
-compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], Options, Items) :-
-    normalize_goals(Body, Goals),
-    Goals = [_|_],
-    native_simple_goal_sequence(Goals, Options),
+compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items) :-
+    Clauses = [_,_|_],
+    \+ native_clauses_would_index(Pred, Arity, Clauses),
+    length(Clauses, N),
+    compile_multi_clause_items_linear(Clauses, 1, N, Pred, Arity, Options, ClauseItems),
     !,
-    Head =.. [_|Args],
-    empty_varmap(V0),
-    expand_aggregate_goals_for_perm_vars(Goals, ExpandedGoals),
     format(string(Label), "~w/~w", [Pred, Arity]),
-    (   native_simple_goals_need_env(Goals, ExpandedGoals)
-    ->  pre_assign_permanent_vars(ExpandedGoals, V0, V0a),
-        compile_head_arguments_items(Args, 1, V0a, V1, HeadItems),
-        compile_goals_items_simple(Goals, V1, yes, _Vf, GoalItems),
-        PrefixItems = [label(Label), allocate]
-    ;   compile_head_arguments_items(Args, 1, V0, V1, HeadItems),
-        compile_goals_items_simple(Goals, V1, no, _Vf, GoalItems),
-        PrefixItems = [label(Label)]
+    Items = [label(Label)|ClauseItems].
+
+compile_clause_body_items_native(Head-Body, Options, Items) :-
+    set_clause_binding_context(Head, Body),
+    set_clause_visited_context(Head),
+    Head =.. [_|Args],
+    normalize_goals(Body, Goals),
+    empty_varmap(V0),
+    (   Goals == []
+    ->  compile_head_arguments_items(Args, 1, V0, _V1, HeadItems),
+        append(HeadItems, [proceed], Items)
+    ;   Goals = [_|_],
+        native_simple_goal_sequence(Goals, Options),
+        expand_aggregate_goals_for_perm_vars(Goals, ExpandedGoals),
+        (   native_simple_goals_need_env(Goals, ExpandedGoals)
+        ->  pre_assign_permanent_vars(ExpandedGoals, V0, V0a),
+            compile_head_arguments_items(Args, 1, V0a, V1, HeadItems),
+            compile_goals_items_simple(Goals, V1, yes, _Vf, GoalItems),
+            append([allocate|HeadItems], GoalItems, Items)
+        ;   compile_head_arguments_items(Args, 1, V0, V1, HeadItems),
+            compile_goals_items_simple(Goals, V1, no, _Vf, GoalItems),
+            append(HeadItems, GoalItems, Items)
+        )
+    ).
+
+native_clauses_would_index(Pred, Arity, Clauses) :-
+    (   build_first_arg_index(Pred, Arity, Clauses, _IndexHeader, _DispatchChains)
+    ;   Arity >= 2,
+        build_second_arg_index(Pred, Arity, Clauses, _IndexHeader, _DispatchChains)
     ),
-    append(HeadItems, GoalItems, InstrItems),
-    append(PrefixItems, InstrItems, Items).
+    !.
+
+compile_multi_clause_items_linear([], _, _, _, _, _, []).
+compile_multi_clause_items_linear([Clause|Rest], I, N, Pred, Arity, Options, Items) :-
+    linear_clause_choice_items(I, N, Pred, Arity, ChoiceItems),
+    compile_clause_body_items_native(Clause, Options, BodyItems),
+    append(ChoiceItems, BodyItems, ThisItems),
+    NextI is I + 1,
+    compile_multi_clause_items_linear(Rest, NextI, N, Pred, Arity, Options, RestItems),
+    append(ThisItems, RestItems, Items).
+
+linear_clause_choice_items(1, _N, Pred, Arity, [try_me_else(NextLabel)]) :-
+    !,
+    format(string(NextLabel), "L_~w_~w_2", [Pred, Arity]).
+linear_clause_choice_items(I, I, Pred, Arity,
+                           [label(Label), trust_me, label(BodyLabel)]) :-
+    !,
+    format(string(Label), "L_~w_~w_~w", [Pred, Arity, I]),
+    format(string(BodyLabel), "L_~w_~w_~w_body", [Pred, Arity, I]).
+linear_clause_choice_items(I, _N, Pred, Arity,
+                           [label(Label), retry_me_else(NextLabel), label(BodyLabel)]) :-
+    NextI is I + 1,
+    format(string(Label), "L_~w_~w_~w", [Pred, Arity, I]),
+    format(string(NextLabel), "L_~w_~w_~w", [Pred, Arity, NextI]),
+    format(string(BodyLabel), "L_~w_~w_~w_body", [Pred, Arity, I]).
+
+peephole_optimize_items(Items, Optimized) :-
+    peephole_item_list(Items, Optimized).
+
+peephole_item_list([], []).
+peephole_item_list([put_value(Reg, Ai), get_variable(Reg, Ai)|Rest], Result) :-
+    !,
+    peephole_item_list(Rest, Result).
+peephole_item_list([Item, Item|Rest], [Item|Result]) :-
+    put_instruction_item(Item),
+    !,
+    peephole_item_list(Rest, Result).
+peephole_item_list([get_variable(Reg, Ai), put_value(Reg, Ai)|Rest], Result) :-
+    \+ item_reg_used_in_rest(Reg, Rest),
+    !,
+    peephole_item_list(Rest, Result).
+peephole_item_list([put_variable(Reg, Ai), put_value(Reg, Ai)|Rest],
+                   [put_variable(Reg, Ai)|Result]) :-
+    !,
+    peephole_item_list(Rest, Result).
+peephole_item_list([Item|Rest], [Item|Result]) :-
+    peephole_item_list(Rest, Result).
+
+put_instruction_item(Item) :-
+    compound(Item),
+    functor(Item, Name, _),
+    atom(Name),
+    sub_atom(Name, 0, 4, _, 'put_').
+
+item_reg_used_in_rest(Reg, Items) :-
+    member(Item, Items),
+    term_string(Item, ItemString),
+    sub_string(ItemString, _, _, _, Reg),
+    !.
 
 native_simple_goals_need_env(Goals, ExpandedGoals) :-
     (   length(ExpandedGoals, N), N > 1

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -7,7 +7,9 @@
 
 %% Test data (facts) - MUST BE DYNAMIC for clause/2 to work across modules
 :- dynamic test_parent/2, test_grandparent/2, test_ancestor/2, test_wrap/2,
-           test_alias/2, test_len/2, test_list_check/1, test_list_wrap/1.
+           test_alias/2, test_len/2, test_list_check/1, test_list_wrap/1,
+           test_linear_fact/1, test_linear_three/1, test_linear_a/1,
+           test_linear_b/1, test_linear_c/1.
 
 test_parent(alice, bob).
 test_parent(bob, charlie).
@@ -20,6 +22,18 @@ test_alias(X, Y) :- test_parent(X, Y).
 
 %% Simple builtin rule — exercises native items for generic builtin_call.
 test_len(L, N) :- length(L, N).
+
+%% Non-indexed multi-clause shapes — exercises native items for linear
+%  try/retry/trust chains without going through the WAM text parser.
+test_linear_fact(_).
+test_linear_fact(_).
+
+test_linear_a(_).
+test_linear_b(_).
+test_linear_c(_).
+test_linear_three(X) :- test_linear_a(X).
+test_linear_three(X) :- test_linear_b(X).
+test_linear_three(X) :- test_linear_c(X).
 
 %% Recursive ancestor rule
 test_ancestor(X, Y) :- test_parent(X, Y).
@@ -499,6 +513,80 @@ test_wam_items_compound_arg_legacy_order_fallback :-
     ;   fail_test(Test, 'Compound body arg legacy-order fallback does not match canonical WAM text shape')
     ).
 
+test_wam_items_native_linear_fact_clauses :-
+    Test = 'WAM: native items API for linear multi-clause facts',
+    ExpectedItems = [
+        label("test_linear_fact/1"),
+        try_me_else("L_test_linear_fact_1_2"),
+        get_variable("X1", "A1"),
+        proceed,
+        label("L_test_linear_fact_1_2"),
+        trust_me,
+        label("L_test_linear_fact_1_2_body"),
+        get_variable("X1", "A1"),
+        proceed
+    ],
+    (   wam_target:compile_predicate_to_wam_text(user:test_linear_fact/1, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_linear_fact/1, [], Items),
+        Items == ExpectedItems,
+        Items == BridgeItems,
+        \+ member(switch_on_constant(_), Items),
+        member(try_me_else("L_test_linear_fact_1_2"), Items),
+        member(trust_me, Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Native linear fact items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_native_linear_rule_clauses :-
+    Test = 'WAM: native items API for linear multi-clause rules',
+    ExpectedItems = [
+        label("test_linear_three/1"),
+        try_me_else("L_test_linear_three_1_2"),
+        allocate,
+        get_variable("X1", "A1"),
+        put_value("X1", "A1"),
+        deallocate,
+        execute("test_linear_a/1"),
+        label("L_test_linear_three_1_2"),
+        retry_me_else("L_test_linear_three_1_3"),
+        label("L_test_linear_three_1_2_body"),
+        allocate,
+        get_variable("X1", "A1"),
+        put_value("X1", "A1"),
+        deallocate,
+        execute("test_linear_b/1"),
+        label("L_test_linear_three_1_3"),
+        trust_me,
+        label("L_test_linear_three_1_3_body"),
+        allocate,
+        deallocate,
+        execute("test_linear_c/1")
+    ],
+    (   wam_target:compile_predicate_to_wam_text(user:test_linear_three/1, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_linear_three/1, [], Items),
+        Items == ExpectedItems,
+        Items == BridgeItems,
+        \+ member(switch_on_constant(_), Items),
+        member(retry_me_else("L_test_linear_three_1_3"), Items),
+        member(execute("test_linear_c/1"), Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Native linear rule items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_indexed_multi_clause_still_bridges :-
+    Test = 'WAM: indexed multi-clause items still use bridge',
+    (   wam_target:compile_predicate_to_wam_text(user:test_parent/2, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_parent/2, [], Items),
+        Items == BridgeItems,
+        member(switch_on_constant(_), Items),
+        member(label("test_parent/2"), Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Indexed multi-clause predicate did not match bridge items')
+    ).
+
 %% Run all tests
 run_tests :-
     format('~n========================================~n'),
@@ -520,6 +608,9 @@ run_tests :-
     test_wam_items_native_nested_compound_body_arg,
     test_wam_items_native_list_body_arg,
     test_wam_items_compound_arg_legacy_order_fallback,
+    test_wam_items_native_linear_fact_clauses,
+    test_wam_items_native_linear_rule_clauses,
+    test_wam_items_indexed_multi_clause_still_bridges,
     test_wam_multi_clause_findall_emits_allocate,
     test_wam_a2_indexing,
     test_wam_mixed_mode_a1_indexing,


### PR DESCRIPTION
## Summary

- extends `compile_predicate_to_wam_items/3` to emit direct WAM items for non-indexed linear multi-clause predicates made from currently supported simple clause shapes
- keeps indexed multi-clause predicates on the text-to-items bridge so existing `switch_on_*` generation stays canonical
- applies the same simple peephole cleanups to native item output that the text path applies before parsing
- updates WAM items representation docs to describe the expanded native-items surface

## Tests

- `swipl -q -f tests/test_wam_target.pl`
- `swipl -q -f tests/test_wam_ir_mode.pl`
- `swipl -q -f tests/test_wam_text_parser.pl -g run_tests -t halt`
- `swipl -q -f tests/test_wam_python_target.pl`
- `swipl -q -f tests/test_wam_lua_generator.pl`
- `swipl -q -f tests/test_wam_elixir_target.pl`
- `swipl -q -f tests/test_wam_r_generator.pl`
- `git diff --check`
