### PR TITLE
feat(wam-c): T9 fact-table inline (backtrackable, default in-range, capped)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -98,6 +98,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | scala   | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✓ | ✗ | ✗ |
 | rust    | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | `~` gated | ✓ | ✓ capped | ✗ | ✗ |
 | cpp     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✗ | ✗ | ✗ | ✗ |
+| c       | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✓ capped | ✗ | ✗ |
 | go      | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
 | haskell | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✓ | ✗ | ✗ |
 | fsharp  | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ~ | ✓ capped | ✗ | ✗ |
@@ -179,7 +180,17 @@ Verification notes:
   `factTableAttempt` enumerator leaves a `FactTableRetry` choice point per
   remaining row, mirroring `select/3`. Tests:
   `tests/test_wam_fsharp_fact_table_exec.pl` (query-mode matrix),
-  `tests/test_wam_fsharp_fact_table_emit.pl`.
+  `tests/test_wam_fsharp_fact_table_emit.pl`. **c = ✓ (default, capped):** C
+  already had a deterministic static-row-table + first-arg bucket scan; T9 makes
+  the in-window fact lowering *backtrackable* — the handler drives a shared
+  `wam_fact_table_scan` that leaves a `WAM_FACT_TABLE_RETRY` choice point
+  (a `WamFactTableFrame` side-stack + resume function mirroring the runtime's
+  disjunction CP), so every matching row is enumerated; registered as a foreign
+  predicate, so it is reachable as a query and from another predicate unchanged.
+  Below `t9_min_rows` keeps the cheap deterministic scanner; opt out with
+  `fact_table_inline(false)`; above `t9_max_rows` declines + warns. Tests:
+  `tests/test_wam_c_fact_table_exec.pl` (query-mode matrix),
+  `tests/test_wam_c_fact_table_emit.pl`.
 - **T8** (native kernels) is a curated library feature dispatched via shared
   `kernel_dispatch` plumbing, not a generic per-predicate lowering. ✓ marks
   the roadmap's validated full-parity set (Rust / Haskell / Elixir / Go /

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -33,6 +33,7 @@
 #define WAM_META_DISJ_RIGHT -7
 #define WAM_META_ITE_THEN -8
 #define WAM_META_ITE_ELSE -9
+#define WAM_FACT_TABLE_RETRY -10
 
 typedef struct WamState WamState;
 typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
@@ -72,6 +73,7 @@ typedef struct {
     int conj_top;
     int disj_top;
     int ite_top;
+    int fact_table_top;
     int arity;
     WamValue a_regs[32]; // Reduced from MAX_REGS to save memory (typical max arity)
 } ChoicePoint;
@@ -143,6 +145,21 @@ typedef struct {
     int return_pc;
     int base_b;
 } WamIteFrame;
+
+/* T9 fact-table enumeration frame.  Carries the static row table (flattened,
+ * row-major: rows[i*arity + col]), the candidate row-index array (NULL = scan
+ * all rows 0..count), the candidate count, the next position to try on
+ * backtrack, the predicate arity, and the proceed PC to continue at on a match.
+ * Mirrors WamDisjFrame; the difference is it can be resumed once per remaining
+ * matching row. */
+typedef struct {
+    const WamValue *rows;
+    const int *indices;
+    int count;
+    int pos;
+    int arity;
+    int return_pc;
+} WamFactTableFrame;
 
 /* Environment Frame */
 typedef struct {
@@ -415,6 +432,8 @@ struct WamState {
     int disj_top;
     WamIteFrame ite_frames[WAM_META_GOAL_STACK_SIZE];
     int ite_top;
+    WamFactTableFrame fact_table_frames[WAM_META_GOAL_STACK_SIZE];
+    int fact_table_top;
 
     /* Native category_ancestor kernel data */
     CategoryEdge *category_edges;
@@ -1001,6 +1020,14 @@ static inline void wam_trim_ite_frames(WamState *state, int target_top) {
     state->ite_top = target_top;
 }
 
+static inline void wam_trim_fact_table_frames(WamState *state, int target_top) {
+    if (target_top < 0) target_top = 0;
+    if (target_top > state->fact_table_top) {
+        target_top = state->fact_table_top;
+    }
+    state->fact_table_top = target_top;
+}
+
 static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     if (state->B >= state->B_cap) {
         state->B_cap = state->B_cap ? state->B_cap * 2 : WAM_INITIAL_CAP;
@@ -1017,7 +1044,8 @@ static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     cp->conj_top = state->conj_top;
     cp->disj_top = state->disj_top;
     cp->ite_top = state->ite_top;
-    
+    cp->fact_table_top = state->fact_table_top;
+
     int save_arity = arity < 32 ? arity : 32;
     cp->arity = save_arity;
     memcpy(cp->a_regs, state->A, sizeof(WamValue) * save_arity);
@@ -1040,6 +1068,7 @@ static inline void restore_choice_point(WamState *state, ChoicePoint *cp) {
     wam_trim_conj_frames(state, cp->conj_top);
     wam_trim_disj_frames(state, cp->disj_top);
     wam_trim_ite_frames(state, cp->ite_top);
+    wam_trim_fact_table_frames(state, cp->fact_table_top);
     unwind_trail(state, cp->trail_size);
     memcpy(state->A, cp->a_regs, sizeof(WamValue) * cp->arity);
 }
@@ -1058,11 +1087,13 @@ static inline void wam_prune_choice_points(WamState *state, int target_b) {
     int target_conj_top = 0;
     int target_disj_top = 0;
     int target_ite_top = 0;
+    int target_fact_table_top = 0;
     if (target_b > 0 && target_b <= state->B) {
         target_group_top = state->B_array[target_b - 1].aggregate_group_top;
         target_conj_top = state->B_array[target_b - 1].conj_top;
         target_disj_top = state->B_array[target_b - 1].disj_top;
         target_ite_top = state->B_array[target_b - 1].ite_top;
+        target_fact_table_top = state->B_array[target_b - 1].fact_table_top;
     }
     while (state->B > target_b) {
         pop_choice_point(state);
@@ -1071,11 +1102,64 @@ static inline void wam_prune_choice_points(WamState *state, int target_b) {
     wam_trim_conj_frames(state, target_conj_top);
     wam_trim_disj_frames(state, target_disj_top);
     wam_trim_ite_frames(state, target_ite_top);
+    wam_trim_fact_table_frames(state, target_fact_table_top);
 }
 static inline void update_choice_point(WamState *state, int next_pc) {
     if (state->B > 0) {
         state->B_array[state->B - 1].next_pc = next_pc;
     }
+}
+
+/* T9 fact-table enumerator.  Scans candidate rows from `start`, unifying each
+ * bound query arg against the corresponding column (an unbound query arg matches
+ * any column and is bound).  On the first match it leaves a fact-table choice
+ * point (only if more candidates remain) so backtracking yields the next match,
+ * binds the unbound args, and returns true.  Does NOT touch state->P: the
+ * initial call advances via the INSTR_CALL_FOREIGN `state->P++`; the resume path
+ * (wam_resume_fact_table) restores state->P from the frame return_pc.  Defined
+ * here (static inline) so both the generated handlers and the resume function
+ * can call it across translation units.  rows is row-major flattened. */
+static inline bool wam_fact_table_scan(WamState *state, const WamValue *rows,
+                                       int arity, const int *indices, int count,
+                                       int start, int return_pc) {
+    if (arity > WAM_MAX_REGS) return false;
+    WamValue *cells[WAM_MAX_REGS];
+    for (int i = 0; i < arity; i++) {
+        cells[i] = wam_deref_ptr(state, &state->A[i]);
+    }
+    for (int pos = start; pos < count; pos++) {
+        int row_index = indices ? indices[pos] : pos;
+        const WamValue *row = &rows[row_index * arity];
+        bool match = true;
+        for (int col = 0; col < arity; col++) {
+            if (!val_is_unbound(*cells[col]) && !val_equal(*cells[col], row[col])) {
+                match = false;
+                break;
+            }
+        }
+        if (!match) continue;
+        /* Leave a choice point for the remaining candidates BEFORE binding, so
+         * the snapshot captures the pre-binding registers and trail. */
+        if (pos + 1 < count) {
+            if (state->fact_table_top >= WAM_META_GOAL_STACK_SIZE) return false;
+            WamFactTableFrame *frame = &state->fact_table_frames[state->fact_table_top++];
+            frame->rows = rows;
+            frame->indices = indices;
+            frame->count = count;
+            frame->pos = pos + 1;
+            frame->arity = arity;
+            frame->return_pc = return_pc;
+            push_choice_point(state, WAM_FACT_TABLE_RETRY, arity);
+        }
+        for (int col = 0; col < arity; col++) {
+            if (val_is_unbound(*cells[col])) {
+                trail_binding(state, cells[col]);
+                *cells[col] = row[col];
+            }
+        }
+        return true;
+    }
+    return false;
 }
 
 #endif /* WAM_RUNTIME_H */

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -24,6 +24,8 @@
     generate_setup_reverse_index_c/2, % +Options, -CCode
     resolve_wam_c_reverse_index_plan/2, % +Options, -Plan
     plan_wam_c_lowered_helpers/4,     % +Predicates, +Options, +DetectedKeys, -Plans
+    wam_c_fact_table_classify/3,      % +PredIndicator, +Options, -fact_info(Arity,Rows)
+    wam_c_fact_table_helper_for_predicate/5, % +PI, +Rows, -Key, -Code, -SetupLine
     write_wam_c_project/3             % +Predicates, +Options, +ProjectDir
 ]).
 
@@ -540,7 +542,8 @@ wam_c_kernel_float_config(ConfigOps, Key, Default, Value) :-
 plan_wam_c_lowered_helpers(Predicates, Options, DetectedKeys, Plans) :-
     (   option(lowered_helpers(true), Options)
     ->  maplist(wam_c_predicate_key, Predicates, AvailableKeys),
-        maplist(plan_wam_c_lowered_helper(DetectedKeys, AvailableKeys), Predicates, Plans)
+        forall(member(P, Predicates), wam_c_maybe_warn_oversized_facts(P, Options)),
+        maplist(plan_wam_c_lowered_helper(DetectedKeys, AvailableKeys, Options), Predicates, Plans)
     ;   maplist(plan_wam_c_lowered_helper_disabled, Predicates, Plans)
     ).
 
@@ -548,11 +551,14 @@ wam_c_predicate_key(PredIndicator, Key) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     format(atom(Key), '~w/~w', [Pred, Arity]).
 
-plan_wam_c_lowered_helper(DetectedKeys, AvailableKeys, PredIndicator, Plan) :-
+plan_wam_c_lowered_helper(DetectedKeys, AvailableKeys, Options, PredIndicator, Plan) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     format(atom(Key), '~w/~w', [Pred, Arity]),
     (   memberchk(Key, DetectedKeys)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, interpreted, detected_kernel)
+    ;   \+ option(fact_table_inline(false), Options),
+        wam_c_fact_table_classify(PredIndicator, Options, fact_info(_, Rows))
+    ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_table(Rows))
     ;   lowered_fact_helper_rows(PredIndicator, Rows)
     ->  Plan = wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows))
     ;   lowered_body_call_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity)
@@ -712,7 +718,9 @@ wam_c_lowered_ordering_guard((=\=)).
 
 compile_lowered_helpers_for_project(Plans, LoweredKeys, Code, SetupCode) :-
     findall(Key-CodePart-SetupLine,
-            (   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows)), Plans),
+            (   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_table(Rows)), Plans),
+                wam_c_fact_table_helper_for_predicate(PredIndicator, Rows, Key, CodePart, SetupLine)
+            ;   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, fact_only(Rows)), Plans),
                 lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, CodePart, SetupLine)
             ;   member(wam_c_lowered_helper_plan(Key, PredIndicator, lowered, filtered_fact(_CalleeKey, Rows)), Plans),
                 lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, CodePart, SetupLine)
@@ -767,6 +775,7 @@ wam_c_lowered_helper_plan_by_action(Plans, Action, Key, ReasonLabel) :-
     member(wam_c_lowered_helper_plan(Key, _, Action, Reason), Plans),
     wam_c_lowered_plan_reason_label(Reason, ReasonLabel).
 
+wam_c_lowered_plan_reason_label(fact_table(_Rows), fact_table) :- !.
 wam_c_lowered_plan_reason_label(fact_only(_Rows), fact_only) :- !.
 wam_c_lowered_plan_reason_label(body_call(_CalleeKey, _CalleeArity), body_call) :- !.
 wam_c_lowered_plan_reason_label(body_call_projected(_CalleeKey, _CalleeArity, _CalleeArgs), body_call_projected) :- !.
@@ -790,6 +799,42 @@ lowered_fact_helper_rows_(PredIndicator, Rows) :-
             Rows),
     Rows \= [],
     \+ ( user:clause(Head, Body), Body \== true ).
+
+% --- T9 fact-table inline: thresholds, classifier, oversized warning ---------
+
+wam_c_t9_min_rows(Options, N) :- ( option(t9_min_rows(N), Options) -> true ; N = 64 ).
+wam_c_t9_max_rows(Options, N) :- ( option(t9_max_rows(N), Options) -> true ; N = 256 ).
+
+%% wam_c_fact_table_classify(+PredIndicator, +Options, -fact_info(Arity, Rows))
+%  An all-ground-facts predicate (arity >= 1) whose row count is in the inline
+%  window [t9_min_rows, t9_max_rows]. Reuses lowered_fact_helper_rows for the
+%  all-ground-facts check. Backtrackable T9 lowering applies when this holds and
+%  fact_table_inline(false) is not set.
+wam_c_fact_table_classify(PredIndicator, Options, fact_info(Arity, Rows)) :-
+    predicate_indicator_parts(PredIndicator, _Module, _Pred, Arity),
+    Arity >= 1,
+    lowered_fact_helper_rows(PredIndicator, Rows),
+    wam_c_t9_min_rows(Options, Min),
+    wam_c_t9_max_rows(Options, Max),
+    length(Rows, NR),
+    NR >= Min,
+    NR =< Max.
+
+%% wam_c_maybe_warn_oversized_facts(+PredIndicator, +Options)
+%  Warn (once) when an all-ground-facts predicate exceeds t9_max_rows and is not
+%  opted out — steer the user toward an external fact source. Always succeeds.
+wam_c_maybe_warn_oversized_facts(PredIndicator, Options) :-
+    (   \+ option(fact_table_inline(false), Options),
+        lowered_fact_helper_rows(PredIndicator, Rows),
+        wam_c_t9_max_rows(Options, Max),
+        length(Rows, NR),
+        NR > Max
+    ->  predicate_indicator_parts(PredIndicator, _M, Pred, Arity),
+        format(user_error,
+               '% [WAM-C T9] ~w/~w has ~w facts (> t9_max_rows ~w): not inlining as a fact table; consider an external fact source.~n',
+               [Pred, Arity, NR, Max])
+    ;   true
+    ).
 
 lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, Code, SetupLine) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
@@ -872,6 +917,85 @@ static bool ~w(WamState *state, const char *pred, int arity) {
            [RowTableCode, ScanSymbol, Arity, RowTableSymbol, Arity, RowTableSymbol,
             BucketArraysCode, Symbol, Arity, Arity, Arity, Mask, Mask, DispatchCasesCode,
             ScanSymbol, RowCount]).
+
+% --- T9 fact-table inline: backtrackable emitter -----------------------------
+% Same static row table + first-arg bucket index as the deterministic fact
+% lowering, but the handler drives wam_fact_table_scan, which leaves a
+% WAM_FACT_TABLE_RETRY choice point so backtracking enumerates every matching
+% row (the deterministic _scan_rows returns only the first match).
+
+wam_c_fact_table_helper_for_predicate(PredIndicator, Rows, Key, Code, SetupLine) :-
+    predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
+    format(atom(Key), '~w/~w', [Pred, Arity]),
+    wam_c_symbol_name(Pred, Arity, Symbol),
+    wam_c_fact_table_helper_code(Symbol, Arity, Rows, Code),
+    format(atom(SetupLine),
+           '    wam_register_foreign_predicate(state, "~w", ~w, ~w);',
+           [Key, Arity, Symbol]).
+
+wam_c_fact_table_helper_code(Symbol, Arity, Rows, Code) :-
+    Arity > 0,
+    length(Rows, RowCount),
+    format(atom(RowTableSymbol), '~w_rows', [Symbol]),
+    wam_c_lowered_static_row_table(RowTableSymbol, Arity, Rows, RowTableCode),
+    wam_c_fact_table_bucket_arrays(Symbol, Arity, Rows, BucketArraysCode, DispatchCasesCode, BucketCount),
+    Mask is BucketCount - 1,
+    format(atom(Code),
+'~w
+
+~w
+
+static bool ~w(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != ~w) return false;
+    const WamValue *rows = (const WamValue *)~w;
+    WamValue *first = wam_deref_ptr(state, &state->A[0]);
+    if (!val_is_unbound(*first)) {
+        unsigned int bucket = 0;
+        if (first->tag == VAL_ATOM) {
+            bucket = wam_hash_string(first->data.atom) & ~w;
+        } else if (first->tag == VAL_INT) {
+            bucket = ((unsigned int)first->data.integer * 2654435761u) & ~w;
+        } else {
+            return false;
+        }
+        switch (bucket) {
+~w
+        default:
+            return false;
+        }
+    }
+    return wam_fact_table_scan(state, rows, ~w, NULL, ~w, 0, state->P + 1);
+}',
+           [RowTableCode, BucketArraysCode, Symbol, Arity, RowTableSymbol,
+            Mask, Mask, DispatchCasesCode, Arity, RowCount]).
+
+% Bucket index arrays (reused verbatim) + T9 switch cases driving the
+% backtrackable scan from candidate index 0.
+wam_c_fact_table_bucket_arrays(Symbol, Arity, Rows, ArraysCode, CasesCode, BucketCount) :-
+    findall(First, member([First|_], Rows), FirstValues0),
+    sort(FirstValues0, FirstValues),
+    length(FirstValues, FirstValueCount),
+    lowered_fact_bucket_count(FirstValueCount, BucketCount),
+    findall(Bucket,
+            lowered_fact_bucket_for_values(FirstValues, BucketCount, Bucket),
+            Buckets),
+    findall(ArrayCode-CaseCode,
+            (   member(Bucket, Buckets),
+                lowered_fact_bucket_row_indices(Rows, BucketCount, Bucket, RowIndices),
+                lowered_fact_bucket_symbols(Symbol, Bucket, ArraySymbol),
+                lowered_fact_bucket_array(ArraySymbol, RowIndices, ArrayCode),
+                length(RowIndices, RowIndexCount),
+                format(atom(CaseCode),
+'        case ~w:
+            return wam_fact_table_scan(state, rows, ~w, ~w, ~w, 0, state->P + 1);',
+                       [Bucket, Arity, ArraySymbol, RowIndexCount])
+            ),
+            Pairs),
+    findall(Array, member(Array-_, Pairs), Arrays),
+    findall(Case, member(_-Case, Pairs), Cases),
+    atomic_list_concat(Arrays, '\n', ArraysCode),
+    atomic_list_concat(Cases, '\n', CasesCode).
 
 wam_c_lowered_static_row_table(RowTableSymbol, Arity, Rows, Code) :-
     maplist(wam_c_lowered_static_row, Rows, RowCodes),
@@ -2583,6 +2707,8 @@ compile_step_wam_to_c(_Options, CCode) :-
                         recovered = wam_resume_disjunction(state);
                     } else if (next_pc == WAM_META_ITE_ELSE) {
                         recovered = wam_resume_if_then_else(state);
+                    } else if (next_pc == WAM_FACT_TABLE_RETRY) {
+                        recovered = wam_resume_fact_table(state);
                     } else {
                         state->P = next_pc; // Explicitly jump to alternative
                         recovered = true;
@@ -2617,6 +2743,7 @@ static bool wam_continue_conjunction(WamState *state);
 static bool wam_resume_disjunction(WamState *state);
 static bool wam_continue_if_then_else(WamState *state);
 static bool wam_resume_if_then_else(WamState *state);
+static bool wam_resume_fact_table(WamState *state);
 
 static bool wam_ensure_heap_slots(WamState *state, int additional) {
     if (additional <= 0) return true;
@@ -3066,6 +3193,21 @@ static bool wam_resume_disjunction(WamState *state) {
     state->disj_top--;
     pop_choice_point(state);
     return wam_invoke_goal_as_call(state, right_goal, return_pc);
+}
+
+/* wam_fact_table_scan is a static inline in wam_runtime.h so both the generated
+ * fact-table handlers (in the lib TU) and this resume function can call it. */
+static bool wam_resume_fact_table(WamState *state) {
+    if (state->fact_table_top <= 0 || state->B <= 0) return false;
+    WamFactTableFrame frame = state->fact_table_frames[state->fact_table_top - 1];
+    state->fact_table_top--;
+    pop_choice_point(state);
+    if (wam_fact_table_scan(state, frame.rows, frame.arity, frame.indices,
+                            frame.count, frame.pos, frame.return_pc)) {
+        state->P = frame.return_pc;
+        return true;
+    }
+    return false;
 }
 
 static bool wam_continue_if_then_else(WamState *state) {

--- a/tests/test_wam_c_fact_table_emit.pl
+++ b/tests/test_wam_c_fact_table_emit.pl
@@ -1,0 +1,66 @@
+% test_wam_c_fact_table_emit.pl
+%
+% T9 fact-table inline for the C target — codegen-level checks (no gcc needed).
+% C already had a deterministic static-row-table + first-arg bucket scan; T9
+% makes the in-window fact lowering backtrackable (it drives wam_fact_table_scan,
+% which leaves a WAM_FACT_TABLE_RETRY choice point) and adds the t9 window /
+% opt-out / oversized semantics. Verifies the planner gating and the emitted C.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_c_target').
+
+:- dynamic user:ek/2.
+user:ek(a, 1). user:ek(a, 2). user:ek(b, 3).
+user:ek(a, 4). user:ek(c, 5). user:ek(b, 6).
+
+plan(Opts, Plans) :-
+    plan_wam_c_lowered_helpers([user:ek/2], [lowered_helpers(true)|Opts], [], Plans).
+
+:- begin_tests(wam_c_fact_table_emit).
+
+% default in-range (6 facts, window [4,256]) -> backtrackable fact_table plan.
+test(default_in_range_fact_table) :-
+    plan([t9_min_rows(4)], Plans),
+    assertion(member(wam_c_lowered_helper_plan('ek/2', _, lowered, fact_table(_)), Plans)).
+
+% explicit opt-out -> deterministic fact_only (no choice point).
+test(opt_out_fact_only) :-
+    plan([t9_min_rows(4), fact_table_inline(false)], Plans),
+    assertion(member(wam_c_lowered_helper_plan('ek/2', _, lowered, fact_only(_)), Plans)),
+    assertion(\+ member(wam_c_lowered_helper_plan('ek/2', _, lowered, fact_table(_)), Plans)).
+
+% below t9_min_rows -> keep the cheap deterministic scanner.
+test(below_min_fact_only) :-
+    plan([t9_min_rows(100)], Plans),
+    assertion(member(wam_c_lowered_helper_plan('ek/2', _, lowered, fact_only(_)), Plans)).
+
+% above t9_max_rows -> not inlined as a fact table (deterministic fallback).
+test(above_cap_fact_only) :-
+    plan([t9_min_rows(2), t9_max_rows(5)], Plans),
+    assertion(member(wam_c_lowered_helper_plan('ek/2', _, lowered, fact_only(_)), Plans)),
+    assertion(\+ member(wam_c_lowered_helper_plan('ek/2', _, lowered, fact_table(_)), Plans)).
+
+% classifier yields fact_info with the rows when in-window.
+test(classify_fact_info) :-
+    wam_c_fact_table_classify(user:ek/2, [t9_min_rows(4)], fact_info(2, Rows)),
+    assertion(length(Rows, 6)).
+
+% emitted C drives the backtrackable scan, with a static row table + bucket index.
+test(emitted_c_uses_scan) :-
+    wam_c_fact_table_helper_for_predicate(user:ek/2,
+        [[a,1],[a,2],[b,3],[a,4],[c,5],[b,6]], Key, Code, Setup),
+    assertion(Key == 'ek/2'),
+    assertion(sub_string(Code, _, _, _, "wam_fact_table_scan")),
+    assertion(sub_string(Code, _, _, _, "_rows[][2]")),
+    assertion(sub_string(Code, _, _, _, "switch (bucket)")),
+    assertion(sub_string(Setup, _, _, _, "wam_register_foreign_predicate")).
+
+% value-literal mapping (atom/int) in the emitted row table.
+test(value_literals) :-
+    wam_c_fact_table_helper_for_predicate(user:ek/2,
+        [[foo, 7], [bar, -3]], _Key, Code, _Setup),
+    assertion(sub_string(Code, _, _, _, ".tag = VAL_ATOM, .data.atom = \"foo\"")),
+    assertion(sub_string(Code, _, _, _, ".tag = VAL_INT, .data.integer = 7")),
+    assertion(sub_string(Code, _, _, _, ".tag = VAL_INT, .data.integer = -3")).
+
+:- end_tests(wam_c_fact_table_emit).

--- a/tests/test_wam_c_fact_table_exec.pl
+++ b/tests/test_wam_c_fact_table_exec.pl
@@ -1,0 +1,125 @@
+% test_wam_c_fact_table_exec.pl
+%
+% T9 fact-table inline for the C target — end-to-end. Builds a project where an
+% in-window fact predicate edge/2 lowers to the backtrackable fact-table handler
+% (driving wam_fact_table_scan + the WAM_FACT_TABLE_RETRY choice point) and runs
+% a generated C program that enumerates every solution per query arg mode by
+% forcing backtracking (a collect/2 foreign that records the bindings and fails).
+% Assertions are encoded as the process exit code (0 = ALL PASS).
+%
+% Skipped when gcc is not on PATH.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_c_target').
+
+:- dynamic user:edge/2.
+user:edge(a, 1). user:edge(a, 2). user:edge(b, 3).
+user:edge(a, 4). user:edge(c, 5). user:edge(b, 6).
+
+gcc_available :-
+    catch(process_create(path(gcc), ['--version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          _, fail),
+    process_wait(Pid, exit(0)).
+
+c_t9_compile(RuntimePath, PredPath, MainPath, ExePath) :-
+    IncludeDir = 'src/unifyweaver/targets/wam_c_runtime',
+    format(atom(Cmd),
+           'gcc -std=c11 -Wall -Wextra -I ~w ~w ~w ~w -o ~w',
+           [IncludeDir, RuntimePath, PredPath, MainPath, ExePath]),
+    shell(Cmd, Status),
+    Status =:= 0.
+
+:- begin_tests(wam_c_fact_table_exec, [condition(gcc_available)]).
+
+test(query_mode_matrix_exec) :-
+    % q/2 query stub: call edge (T9), then collect (records + fails -> redo).
+    QStub = 'q/2:\n    call_foreign edge/2, 2\n    call_foreign collect/2, 2\n    proceed',
+    compile_wam_predicate_to_c(user:q/2, QStub, [], QCode),
+    wam_c_fact_table_helper_for_predicate(user:edge/2,
+        [[a,1],[a,2],[b,3],[a,4],[c,5],[b,6]], _Key, EdgeCode, EdgeSetup),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now), Stamp is round(Now * 1000000),
+    format(atom(Base), '/tmp/unifyweaver_wam_c_t9_~w', [Stamp]),
+    format(atom(RuntimePath), '~w_runtime.c', [Base]),
+    format(atom(PredPath), '~w_pred.c', [Base]),
+    format(atom(MainPath), '~w_main.c', [Base]),
+    format(atom(ExePath), '~w_bin', [Base]),
+    setup_call_cleanup(open(RuntimePath, write, R), write(R, RuntimeCode), close(R)),
+    format(atom(PredTU),
+        '#include "wam_runtime.h"~n~n~w~n~n~w~n~nvoid setup_edge_t9(WamState* state) {~n~w~n}~n',
+        [QCode, EdgeCode, EdgeSetup]),
+    setup_call_cleanup(open(PredPath, write, P), write(P, PredTU), close(P)),
+    c_t9_exec_main(MainSrc),
+    setup_call_cleanup(open(MainPath, write, M), write(M, MainSrc), close(M)),
+    assertion(c_t9_compile(RuntimePath, PredPath, MainPath, ExePath)),
+    format(atom(RunCmd), 'timeout 10 ~w', [ExePath]),
+    shell(RunCmd, RunStatus),
+    assertion(RunStatus =:= 0).
+
+:- end_tests(wam_c_fact_table_exec).
+
+% Generated C driver. enumerate() runs q/2 with seeded args; collect2 records
+% each solution and returns false so wam_run backtracks into the fact-table
+% choice point, yielding the next matching row until exhaustion.
+c_t9_exec_main(
+'#include "wam_runtime.h"
+#include <stdio.h>
+#include <string.h>
+
+void setup_q_2(WamState* state);
+void setup_edge_t9(WamState* state);
+
+static int g_count;
+static WamValue g_a0[64];
+static WamValue g_a1[64];
+
+static bool collect2(WamState *state, const char *pred, int arity) {
+    (void)pred; (void)arity;
+    if (g_count < 64) {
+        g_a0[g_count] = *wam_deref_ptr(state, &state->A[0]);
+        g_a1[g_count] = *wam_deref_ptr(state, &state->A[1]);
+        g_count++;
+    }
+    return false;
+}
+
+static int enumerate(WamValue a0, WamValue a1) {
+    WamState state;
+    wam_state_init(&state);
+    setup_q_2(&state);
+    setup_edge_t9(&state);
+    wam_register_foreign_predicate(&state, "collect/2", 2, collect2);
+    g_count = 0;
+    int entry = resolve_predicate_hash(&state, "q/2");
+    if (entry < 0) { wam_free_state(&state); return -1; }
+    state.A[0] = val_is_unbound(a0) ? wam_make_ref(&state) : a0;
+    state.A[1] = val_is_unbound(a1) ? wam_make_ref(&state) : a1;
+    state.CP = WAM_HALT;
+    state.P = entry;
+    wam_run(&state);
+    int c = g_count;
+    wam_free_state(&state);
+    return c;
+}
+
+int main(void) {
+    /* (+,-) edge(a,X) -> rows 1,2,4 in source order */
+    if (enumerate(val_atom("a"), val_unbound("X")) != 3) return 11;
+    if (!(g_a1[0].tag==VAL_INT && g_a1[0].data.integer==1 &&
+          g_a1[1].tag==VAL_INT && g_a1[1].data.integer==2 &&
+          g_a1[2].tag==VAL_INT && g_a1[2].data.integer==4)) return 12;
+    /* (-,+) edge(K,3) -> 1 row: b */
+    if (enumerate(val_unbound("K"), val_int(3)) != 1) return 21;
+    if (!(g_a0[0].tag==VAL_ATOM && strcmp(g_a0[0].data.atom,"b")==0)) return 22;
+    /* (-,-) edge(K,X) -> all 6 */
+    if (enumerate(val_unbound("K"), val_unbound("X")) != 6) return 31;
+    /* (+,+) membership */
+    if (enumerate(val_atom("a"), val_int(2)) != 1) return 41;
+    if (enumerate(val_atom("a"), val_int(3)) != 0) return 42;
+    /* absent key -> 0 */
+    if (enumerate(val_atom("z"), val_unbound("X")) != 0) return 51;
+    printf("ALL 6 PASS\\n");
+    return 0;
+}
+').


### PR DESCRIPTION
## What

Brings T9 fact-table inline to the **C WAM target** (after Rust and F#). 

Key difference from the other targets: **C already had** a static row table + first-arg bucket index + a per-row unify scan — but the scan was **deterministic** (returned only the first matching row, so `edge(a,X)` over multiple `a` facts yielded just one solution). T9 makes the in-window fact lowering **backtrackable** so every matching row is enumerated, and adds the t9 window / opt-out / oversized policy around it.

## Policy (mirrors Rust/F#)

An all-ground-facts predicate (arity ≥ 1) whose row count is in `[t9_min_rows, t9_max_rows]` (defaults 64..256) lowers to the backtrackable fact-table handler **by default**. Opt out with `fact_table_inline(false)`; below `t9_min_rows` keeps the cheap deterministic scanner; above `t9_max_rows` declines + warns (steer to an external fact source).

## Mechanism (mirrors the runtime's disjunction side-stack choice point)

- **Runtime** (`wam_runtime.h`): a `WAM_FACT_TABLE_RETRY` sentinel; a `WamFactTableFrame` side-stack (flattened row-table pointer + candidate index array + position + arity + return PC) saved/restored/pruned alongside `disj_top` in the `ChoicePoint`; a shared `static inline wam_fact_table_scan` that, on a match, leaves a choice point for the remaining candidates **before** binding so backtracking yields the next row. `wam_run` dispatches `WAM_FACT_TABLE_RETRY` → `wam_resume_fact_table`. (Made the scan a header `static inline` so both the generated handlers and the resume function can call it across translation units.)
- **Emitter** (`wam_c_target.pl`): `wam_c_fact_table_classify` + thresholds + `wam_c_maybe_warn_oversized_facts`; a `fact_table(Rows)` plan gated ahead of the deterministic `fact_only` branch in `plan_wam_c_lowered_helper` (Options now threaded through the planner); `wam_c_fact_table_helper_for_predicate` reuses the existing row table + bucket index and emits a handler that derefs the first arg, picks the bucket (or full scan) and drives `wam_fact_table_scan`. Registered through the same foreign-predicate path as today's facts, so it's reachable **as a query and from another predicate with zero dispatch changes**.

## Tests

- `tests/test_wam_c_fact_table_exec.pl` (gcc-gated): builds a project and a C driver that enumerates all solutions per arg mode by forcing backtracking (a `collect/2` foreign that records bindings and fails). Verifies `(+,-)` index lookup → `[1,2,4]` in source order, `(-,+)` value-bound scan → `[b]`, `(-,-)` → all 6, `(+,+)` membership, and absent-key → 0. **ALL 6 PASS** (exit-code assertions).
- `tests/test_wam_c_fact_table_emit.pl` (fast): planner gating (default→`fact_table`, opt-out/below-min/above-cap→`fact_only`), oversized warning, classifier, emitted scan + row table + bucket switch, value literals.
- Existing C target suite stays green (0 failures — the shared header + planner changes don't regress).

Matrix: adds a `c` row (the matrix previously had none), T9 = ✓ capped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_