### PR TITLE
Feat/wam go read string

### DIFF
--- a/PR_go_wam_read_string_builtin.md
+++ b/PR_go_wam_read_string_builtin.md
@@ -1,0 +1,28 @@
+# PR Title
+
+Add Go WAM `read_string/5` builtin parity
+
+# PR Description
+
+## Summary
+
+- Registers `read_string/5` as a direct Go WAM builtin.
+- Adds Go WAM runtime support for bounded file-backed stream reads, unifying the actual character count and output atom.
+- Extends the generated Go builtin E2E test to cover bounded reads, short EOF reads, zero-count EOF reads, and closed-stream failure.
+- Updates the Go WAM parity audit to record the Python-aligned bounded chunk-read surface.
+
+## Tests
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+
+## Push Command
+
+```sh
+git push -u origin feat/wam-go-read-string
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -21,7 +21,7 @@ current cross-target builtin/runtime baseline.
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
 | Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Present for current baseline, including isolated user-goal NAF and race-to-true over multi-clause WAM targets |
-| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `write_canonical/1`, `put_char/1`, `put_char/2`, `put_code/1`, `put_code/2`, `get_char/1`, `get_char/2`, `peek_char/1`, `peek_char/2`, `get_code/1`, `get_code/2`, `open/3`, `close/1`, `read_line_to_string/2`, `format/1`, `format/2`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; Python/C++ also cover `write_canonical/1`; Python/C++/LLVM also cover `put_char/1` and `put_code/1`; Python also covers default-stream `get_char/1`, `peek_char/1`, and `get_code/1` plus file-backed stream char IO and line reads; R/C++/Python also cover `format/N`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, bounded canonical output, single-character output, default and file-backed stream character IO, bounded line reads, bounded format output, tab output, and bounded environment access |
+| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `write_canonical/1`, `put_char/1`, `put_char/2`, `put_code/1`, `put_code/2`, `get_char/1`, `get_char/2`, `peek_char/1`, `peek_char/2`, `get_code/1`, `get_code/2`, `open/3`, `close/1`, `read_line_to_string/2`, `read_string/5`, `format/1`, `format/2`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; Python/C++ also cover `write_canonical/1`; Python/C++/LLVM also cover `put_char/1` and `put_code/1`; Python also covers default-stream `get_char/1`, `peek_char/1`, and `get_code/1` plus file-backed stream char IO, line reads, and bounded chunk reads; R/C++/Python also cover `format/N`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, bounded canonical output, single-character output, default and file-backed stream character IO, bounded line/chunk reads, bounded format output, tab output, and bounded environment access |
 
 ## Immediate Findings
 
@@ -87,6 +87,10 @@ current cross-target builtin/runtime baseline.
   covered by the generated builtin E2E test for normal lines, blank lines,
   final lines without a trailing newline, and EOF as `end_of_file`, matching
   the bounded Python line-reader surface without adding bounded chunk reads.
+- File-backed `read_string/5` is now a direct Go WAM builtin and is covered by
+  the generated builtin E2E test for bounded chunk reads, short EOF reads, and
+  zero-count EOF reads, matching the bounded Python chunk-reader surface while
+  leaving separator output behavior outside this slice.
 - Bounded `format/1` and `format/2` are now direct Go WAM builtins and are
   covered by the generated builtin E2E test for literal `~~`, newline `~n`,
   `~w`, `~a`, `~d`, `~p`, `~q`, and `~s` argument substitution, and

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -597,6 +597,9 @@ wam_go_direct_builtin("close/1", 1, 'close/1').
 wam_go_direct_builtin(read_line_to_string/2, 2, 'read_line_to_string/2').
 wam_go_direct_builtin('read_line_to_string/2', 2, 'read_line_to_string/2').
 wam_go_direct_builtin("read_line_to_string/2", 2, 'read_line_to_string/2').
+wam_go_direct_builtin(read_string/5, 5, 'read_string/5').
+wam_go_direct_builtin('read_string/5', 5, 'read_string/5').
+wam_go_direct_builtin("read_string/5", 5, 'read_string/5').
 wam_go_direct_builtin(format/1, 1, 'format/1').
 wam_go_direct_builtin('format/1', 1, 'format/1').
 wam_go_direct_builtin("format/1", 1, 'format/1').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1195,6 +1195,28 @@ func readLineStreamValue(value Value) (Value, bool) {
 	}
 }
 
+func readStringStreamText(value Value, length int64) (string, bool) {
+	if length < 0 {
+		return "", false
+	}
+	handle, ok := streamHandle(value)
+	if !ok || handle.Reader == nil {
+		return "", false
+	}
+	var b strings.Builder
+	for i := int64(0); i < length; i++ {
+		r, _, err := handle.Reader.ReadRune()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", false
+		}
+		b.WriteRune(r)
+	}
+	return b.String(), true
+}
+
 func writeStreamText(value Value, text string) bool {
 	handle, ok := streamHandle(value)
 	if !ok || handle.Mode == "read" {
@@ -1885,6 +1907,19 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return false
 		}
 		return vm.Unify(arg2, line)
+	case "read_string/5":
+		length, ok := vm.deref(arg2).(*Integer)
+		if !ok {
+			return false
+		}
+		text, ok := readStringStreamText(vm.deref(arg1), length.Val)
+		if !ok {
+			return false
+		}
+		if !vm.Unify(arg3, &Integer{Val: int64(len([]rune(text)))}) {
+			return false
+		}
+		return vm.Unify(arg5, internAtom(text))
 	case "writeln/1":
 		fmt.Println(vm.deref(arg1).String())
 		return true

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -729,6 +729,15 @@ test(builtins_execution) :-
                 read_line_to_string(S, L4), L4 = end_of_file,
                 close(S)
             )),
+          assertz(user:test_read_string_builtin :-
+            (   open('string.txt', read, S),
+                peek_char(S, C0), C0 = h,
+                read_string(S, 5, N1, _, S1), N1 =:= 5, S1 = hello,
+                read_string(S, 100, N2, _, S2), N2 =:= 6, S2 = ' world',
+                read_string(S, 3, N3, _, S3), N3 =:= 0, atom_length(S3, 0),
+                close(S),
+                \+ read_string(S, 1, _, _, _)
+            )),
           assertz(user:test_format_builtin :-
             (   format('fmt_one ~~ ok~n'),
                 format('fmt_two ~w ~w~~~n', [go, 42]),
@@ -802,6 +811,7 @@ test(builtins_execution) :-
           retractall(user:test_char_input_builtin),
           retractall(user:test_stream_char_io_builtin),
           retractall(user:test_read_line_builtin),
+          retractall(user:test_read_string_builtin),
           retractall(user:test_format_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
@@ -812,7 +822,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_output_builtin/0, test_char_input_builtin/0, test_stream_char_io_builtin/0, test_read_line_builtin/0, test_format_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_output_builtin/0, test_char_input_builtin/0, test_stream_char_io_builtin/0, test_read_line_builtin/0, test_read_string_builtin/0, test_format_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -894,6 +904,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "open/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "close/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "read_line_to_string/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "read_string/5"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "format/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "format/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
@@ -1311,6 +1322,17 @@ func main() {
 		fmt.Println("READ_LINE_FAILURE")
 	}
 
+	if writeErr := os.WriteFile("string.txt", []byte("hello world"), 0644); writeErr != nil {
+		panic(writeErr)
+	}
+	readStringVM := wam.NewWamState(wam.Test_read_string_builtinCode, wam.Test_read_string_builtinLabels)
+	readStringVM.PC = wam.Test_read_string_builtinStartPC
+	if readStringVM.Run() {
+		fmt.Println("READ_STRING_SUCCESS")
+	} else {
+		fmt.Println("READ_STRING_FAILURE")
+	}
+
 	formatVM := wam.NewWamState(wam.Test_format_builtinCode, wam.Test_format_builtinLabels)
 	formatVM.PC = wam.Test_format_builtinStartPC
 	if formatVM.Run() {
@@ -1413,6 +1435,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "STREAM_CHAR_IO_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "STREAM_CHAR_IO_OUTPUT=\"xy\\n\"")),
         assertion(sub_string(FullOutput, _, _, _, "READ_LINE_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "READ_STRING_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "'Hello World'")),
         assertion(sub_string(FullOutput, _, _, _, "[a, 'two words', 42]")),
         assertion(sub_string(FullOutput, _, _, _, "pair('two words', 7)")),


### PR DESCRIPTION
# Add Go WAM `read_string/5` builtin parity

## Summary

- Registers `read_string/5` as a direct Go WAM builtin.
- Adds Go WAM runtime support for bounded file-backed stream reads, unifying the actual character count and output atom.
- Extends the generated Go builtin E2E test to cover bounded reads, short EOF reads, zero-count EOF reads, and closed-stream failure.
- Updates the Go WAM parity audit to record the Python-aligned bounded chunk-read surface.

## Tests

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`

## Push Command

```sh
git push -u origin feat/wam-go-read-string
```
