### PR TITLE
docs(design): bridge detector — philosophy / specification / implementation plan

### DIFF
--- a/docs/design/WAM_RUST_BRIDGE_DETECTOR_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_RUST_BRIDGE_DETECTOR_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,76 @@
+# WAM-Rust Bridge Detector — Implementation Plan
+
+*Build order for the detector specified in `WAM_RUST_BRIDGE_DETECTOR_SPECIFICATION.md` (philosophy:
+`..._PHILOSOPHY.md`; theory: `WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md` §5f–§5g). Each increment is its own
+small PR, **additive** (no change to existing functions), `cargo test`-verified by rendering the
+`boundary_cache.rs.mustache` template (only `{{date}}` is a real tag; render at **edition 2021**).*
+
+## Where it goes
+
+`templates/targets/rust_wam/boundary_cache.rs.mustache`, next to `descendant_mu_mass_gated` /
+`gated_ic_node_filtered` / `cone_purity` / the sketch functions it reuses. No ML, no HF, no torch — the μ
+map is an input, produced separately (the directional model #3302, or any dense `name→μ` map).
+
+## Increment 1 — `fanout_diversity` (the foundational piece)
+
+The `n_eff` core, exact first.
+
+- Compute `U_P` from `descendant_mu_mass_gated(P)` (the path-gated reachable set).
+- For each in-domain child `c_i` (`μ(c_i) ≥ θ`): `E_i^P = {nodes of U_P under c_i}`; `μ(E_i^P)` = its
+  in-domain mass; accumulate `Σ μ(E_i^P)` and the union set `⋃ E_i^P`.
+- `diversity = μ(⋃) / Σ μ(E_i^P)`; `n_eff = n · diversity`. `None` if `< 2` in-domain children.
+
+**Tests** (exact, hand DAGs):
+- disjoint branches (a tree fan-out) → `diversity = 1`, `n_eff = n`;
+- `n` children all pointing at the *same* shared descendant set → `diversity ≈ 1/n`, `n_eff ≈ 1`;
+- partial overlap → strictly between;
+- `< 2` children / leaf → `None`.
+
+Runnable and self-contained — this is the increment to do first.
+
+## Increment 2 — purity + `bridge_classify`
+
+Combine `n_eff` with `cone_purity` into the 2-D classification (`BridgeScore` / `BridgeClass`).
+
+- `bridge_classify(P, params)` → `{n_eff, diversity, purity, fan_out, class}`.
+- **Tests**: three synthetic nodes — a **bridge** (distinct *in-domain* branches: high `n_eff`, high
+  purity), a **leak conduit** (distinct *out-of-domain* branches: high `n_eff`, low purity — give the
+  branch subtrees `μ < θ`), and a **redundant hub** (overlapping branches: low `n_eff`). Assert each lands
+  in the right quadrant.
+
+## Increment 3 — candidate generation + `rank_bridges`
+
+- Fan-out filter (`φ ≥ φ_min`) as the default candidate set; `rank_bridges` returns sorted
+  `(node, BridgeScore)`.
+- *(Optional, layered)* MICA-frequency candidates via `resnik_from_ic` over sampled distant pairs, if the
+  fan-out filter over-generates.
+- **Test**: ordering on a graph with a planted bridge, leak conduit, and hub — the bridge ranks above the
+  hub; the leak conduit is labeled `LeakConduit` not `Bridge`.
+
+## Increment 4 — scale path (sketches) + live wiring
+
+- Swap the exact cone walk for the **sketch union read**: per-child bottom-`k` sketches restricted to
+  `U_P`, merged, mass via `sketch_mu_mass`; cross-parent ranking via `sketch_mu_overlap_lift`. Assert the
+  sketch `n_eff` matches the exact `n_eff` within the KMV tolerance on the test graphs (the same
+  exact-vs-sketch assertion pattern the `gated_ic`/`resnik` tests already use).
+- Live path: `WamState::build_bridge_scores` (precompute) + `category_bridge_score(p)` (per-query),
+  mirroring `build_descendant_sketches`.
+
+## Increment 5 — real-data validation (measurement doc)
+
+Run on the physics category graph with a real μ map (the directional `SYM`/`LLM` map from #3302, or the
+e5 dense map). Confirm the qualitative predictions and write them up as an addendum to
+`WAM_RUST_CARET_REALDATA_MEASUREMENT_*.md`:
+
+- known generic apexes (`Main_topic_classifications`, `Categories`) classify as **leak conduits** (high
+  `n_eff`, low purity) — recovering the earlier leak-conduit finding from the *positive* side;
+- genuine in-domain merge points score as **bridges**;
+- redundant `X_by_country`-style fan-outs score as **redundant hubs**.
+
+## Conventions
+
+- Additive only — never modify `descendant_mu_mass_gated`, `gated_ic`, or the similarity functions.
+- Exact functions for correctness tests, sketches for scale (and assert they agree).
+- Edition 2021 when rendering for `cargo test` (the template hits an edition-2024 match-ergonomics error
+  in a *pre-existing* test otherwise — not your code).
+- Keep the μ map an **input**; do not couple the detector to any particular μ producer.

--- a/docs/design/WAM_RUST_BRIDGE_DETECTOR_PHILOSOPHY.md
+++ b/docs/design/WAM_RUST_BRIDGE_DETECTOR_PHILOSOPHY.md
@@ -1,0 +1,82 @@
+# WAM-Rust Bridge Detector — Philosophy
+
+*Why a bridge detector exists, what it is for, and how it fits the μ / similarity work. The **theory**
+lives in `WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md` §5f–§5g; the precise definitions in
+`WAM_RUST_BRIDGE_DETECTOR_SPECIFICATION.md`; the build order in
+`WAM_RUST_BRIDGE_DETECTOR_IMPLEMENTATION_PLAN.md`. This doc is the **why**.*
+
+## The question
+
+On a DAG like the Wikipedia category graph, which nodes are *meaningful bridges* — articulation points
+where genuinely distinct sub-domains connect through one organizing category — and which are *leak
+conduits* — generic apex categories (`Main_topic_classifications`, `Categories`) that connect everything
+indiscriminately and pollute the gated cones?
+
+## The same problem, two faces
+
+We already met the bad face in the real-data work (`WAM_RUST_CARET_REALDATA_MEASUREMENT_2026-06-18.md`,
+cone-purity addendum): leak conduits — low-fan-in generic apexes with low cone purity — leak membership
+across unrelated domains, which is the whole reason μ-gating exists. The bridge detector is the **positive
+framing** of that same structure: instead of only flagging leaks to prune, it identifies the nodes that
+*legitimately* organize a domain into distinct subfields. Diagnosing bridges and diagnosing leaks turn out
+to be the **same computation read two ways** — see "the 2-D map" below.
+
+## The insight: high branching is not high *bridging*
+
+A node with many children is not automatically a bridge. There are three cases, and only one is a bridge:
+
+- **Redundant hub** — many children, but their subtrees *overlap* (reconverge). The node isn't organizing
+  distinct things; it's a pile of near-duplicates. *Low branch diversity.*
+- **Leak conduit** — many children carving genuinely distinct regions, but the regions are *unrelated*
+  (out-of-domain). The node connects everything; that is exactly a leak. *High diversity, low domain
+  coherence.*
+- **Meaningful bridge** — many children carving distinct regions that are *in-domain*. *High diversity,
+  high domain coherence.*
+
+So a bridge needs **three** signals, not one (each from a primitive that already exists):
+
+1. **Fan-out** — is it a branch point at all? (degree / merge-frequency)
+2. **Diversity of branching** — are the branches *distinct* or redundant? (`n_eff`, §5g)
+3. **Domain coherence** — are the branches *in-domain* or junk? (cone purity / μ, the leak detector)
+
+This is the synthesis from the theory note: **MICA proposes** (a high-fan-out merge point is a candidate),
+**overlap disposes** (`n_eff` says whether the fan-out is diverse), and **μ judges** (purity says whether
+it is a real bridge or a leak conduit).
+
+## The 2-D map (bridge vs leak vs hub)
+
+Diversity (`n_eff`) and domain coherence (cone purity / μ) are **orthogonal**, and together they classify
+every high-fan-out node:
+
+| | **high purity (in-domain)** | **low purity (out-of-domain)** |
+|---|---|---|
+| **high `n_eff` (diverse)** | **meaningful bridge** — organizes distinct subfields | **leak conduit** — connects distinct *unrelated* regions → prune / down-weight |
+| **low `n_eff` (redundant)** | redundant hub — children overlap; candidate to collapse | weak generic node |
+
+That single table is why the bridge detector and the earlier cone-purity leak detector are the same tool:
+**leaks are one quadrant of the bridge map.**
+
+## How we might use it
+
+1. **Principled leak pruning / cone cleanup.** The high-`n_eff`-low-purity quadrant *is* the set of leak
+   conduits. Down-weighting or cutting them cleans the gated cones — the original leak problem, now
+   diagnosed positively rather than patched.
+2. **Landmark / bridge selection for the caret precompute** (§5b–5c). Good bridges are the natural
+   *designated bridges* / landmarks for between-node distance precompute; the detector picks them instead
+   of hand-listing them.
+3. **Domain-structure understanding & taxonomy QA.** Where does a domain genuinely branch into subfields?
+   In-domain bridges are the structural joints; redundant hubs flag *mergeable* children; leak conduits
+   flag *edges to cut*. A map of a category graph's real skeleton.
+4. **Navigation / routing.** Bridges are the hub waypoints for moving between sub-domains — the high-value
+   nodes to index for "how do I get from here to there."
+5. **Feeding the directional-μ model.** The bridge structure marks the meaningful merge points (the MICA
+   candidates) the directional model should care about — a structural prior for where order matters.
+
+## Where it sits
+
+Pure **read-out / selection** on top of the shipped machinery — it introduces *no new math*. It reuses the
+descendant sketches (`descendant_minhash_weighted`, `sketch_mu_mass`, `sketch_mu_overlap`), the node-gated
+similarity (`gated_ic_node_filtered`, #3296), the membership cone (`descendant_mu_mass_gated`), and cone
+purity. The detector is **assembly**, which is why it can be built and tested entirely in the Rust core
+with no ML/HF dependency — the μ map it consumes is produced separately (the directional model, #3302, or
+any dense μ map).

--- a/docs/design/WAM_RUST_BRIDGE_DETECTOR_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BRIDGE_DETECTOR_SPECIFICATION.md
@@ -1,0 +1,106 @@
+# WAM-Rust Bridge Detector — Specification
+
+*Precise definitions, the API, and the invariants. The **why** is in
+`WAM_RUST_BRIDGE_DETECTOR_PHILOSOPHY.md`; the **theory** in `WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md`
+§5f–§5g; the **build order** in `WAM_RUST_BRIDGE_DETECTOR_IMPLEMENTATION_PLAN.md`.*
+
+## Inputs
+
+- `parents: HashMap<u32, Vec<u32>>` (child → parents) and the derived `children` map — the DAG.
+- `mu: HashMap<u32, f64>` — membership, `μ ≥ 0`. The dense μ map: directional `μ(·|root)` from the
+  attention model (#3302), the symmetric map, or any `name→μ` map fed through the usual loaders.
+- `threshold θ` — the gating threshold (default `0.3`).
+- For scale: the descendant sketches (`descendant_minhash_weighted`). For correctness tests on small
+  graphs: the exact `descendant_mu_mass*` functions.
+
+## Definitions
+
+For a candidate node `P` with in-domain children `c_1 … c_n` (children with `μ(c_i) ≥ θ`):
+
+- **Universe** `U_P` = `P`'s **path-gated** cone — the reachable set of `descendant_mu_mass_gated(P)` (the
+  membership frontier: "what `P` organizes"). *Path-gated on purpose* — the universe is what `P` reaches
+  while staying in-domain. (Contrast the *similarity* IC of §5f, which uses the node-gated cone.)
+- **Child region** `E_i^P` = `desc(c_i) ∩ U_P` — child `c_i`'s contribution inside `P`'s frame. Concretely
+  the nodes of `U_P` that lie under `c_i`. A child whose subtree leaves the domain contributes only its
+  in-domain part; a low-μ child contributes `∅`.
+- **Diversity** `diversity(P)` = `μ(⋃_i E_i^P) / Σ_i μ(E_i^P)` ∈ `[1/n, 1]`. By inclusion–exclusion the
+  union ≤ the sum, with equality iff the child regions are disjoint; the shortfall is exactly the
+  **reconvergence** (mass shared across sibling subtrees).
+- **Effective branches** `n_eff(P)` = `n · diversity(P)` — equals `n` for disjoint branches, collapses to
+  `1` for `n` identical ones. *(Mass-weighted variant: replace the count `n` by the in-domain child-mass
+  share if branch* importance *matters more than branch* count.)*
+- **Purity** `purity(P)` = `cone_purity(P)` = `m_μ(desc(P)) / |desc(P)|` (the existing leak-detector
+  read — in-domain mass per node of the raw cone).
+- **Fan-out** `φ(P)` = the in-domain child count `n`.
+
+## Classification
+
+Parameters `φ_min` (min fan-out), `τ_div` (diversity / `n_eff`), `τ_pure` (purity). Report the continuous
+`(n_eff, purity)` for ranking; the labels are a convenience cut:
+
+- `NotCandidate` — `φ(P) < φ_min` or `< 2` in-domain children (not a branch point).
+- `RedundantHub` — `n_eff(P)` low (children overlap) — candidate for *collapse*.
+- `Bridge` — `n_eff(P)` high **and** `purity(P) ≥ τ_pure` — organizes distinct in-domain subfields.
+- `LeakConduit` — `n_eff(P)` high **and** `purity(P) < τ_pure` — distinct but *unrelated* regions → prune /
+  down-weight.
+
+## Candidate generation (the MICA / upward step)
+
+Two options, cheap-first:
+
+- **Fan-out filter** (default): every node with `φ(P) ≥ φ_min`. Cheap, a good first cut.
+- **MICA-frequency** (principled, optional): sample distant pairs and count how often `P` is their MICA
+  (`resnik_from_ic`); a frequent merge point is a stronger candidate than raw degree. Heavier; layer it on
+  only if the fan-out filter over-generates.
+
+## API (Rust, additive — no change to existing functions)
+
+```rust
+pub enum BridgeClass { Bridge, LeakConduit, RedundantHub, NotCandidate }
+
+pub struct BridgeScore { pub n_eff: f64, pub diversity: f64, pub purity: f64,
+                         pub fan_out: u32, pub class: BridgeClass }
+
+/// (diversity, n_eff) for P over its in-domain children; None if < 2 in-domain children or U_P empty.
+pub fn fanout_diversity(p: u32, parents: &.., mu: &.., threshold: f64 /*, sketches or exact*/)
+    -> Option<(f64, f64)>;
+
+pub fn bridge_classify(p: u32, parents: &.., mu: &.., threshold: f64, params: &BridgeParams)
+    -> BridgeScore;
+
+/// All candidates, sorted (e.g. by n_eff·purity, or n_eff within the Bridge class).
+pub fn rank_bridges(parents: &.., mu: &.., threshold: f64, params: &BridgeParams)
+    -> Vec<(u32, BridgeScore)>;
+```
+
+Live path (mirroring `build_descendant_sketches` / `build_boundary_distances`):
+`WamState::build_bridge_scores` precomputes once; `category_bridge_score(p)` answers per-node; `None`
+until built, eager-edge only.
+
+**Cross-parent ranking note.** Raw `diversity`/`n_eff` are computed inside each `P`'s own universe `U_P`,
+so they are comparable *as ratios* but their universes differ in size. To rank bridges *across* parents on
+an absolute footing, use the configuration-model **lift** (`sketch_mu_overlap_lift`, shared mass vs the
+`m_u·m_v/|U_P|` null) — the same normalization the fan-in hub work uses — rather than comparing raw union
+masses.
+
+## Invariants & edge cases
+
+- **Tree-triviality.** In a pure tree, siblings have disjoint subtrees, so `diversity ≡ 1` and
+  `n_eff ≡ n`: *every* node looks like a perfect fan-out. The measure only discriminates on a **DAG**
+  (where it detects reconvergence). Document it; do not error. (Wikipedia categories are a DAG, so this is
+  fine here.)
+- **Leaves / `< 2` children** → `NotCandidate` (`fanout_diversity` returns `None`).
+- **`P` out-of-domain** (empty `U_P`) → `None`.
+- **Determinism / approximation.** With sketches, fix the sketch seed; `diversity`/`n_eff` carry the KMV
+  error bounds of `sketch_mu_mass` (exact `descendant_mu_mass*` for the correctness tests, sketches for
+  scale).
+- **Guards** (the usual): `μ ≥ 0` (it is summed as mass); category names must resolve verbatim or they
+  silently become `μ = 0`.
+
+## Reuses (no new math)
+
+`descendant_minhash_weighted`, `sketch_mu_mass`, `sketch_mu_overlap`, `sketch_mu_overlap_lift`
+(cross-parent ranking), `descendant_mu_mass_gated` (`U_P`), `cone_purity`, `resnik_from_ic` (MICA
+candidates). The one new sketch *operation* is a **union read** — merge the per-child bottom-`k` sketches
+(restricted to `U_P`), take the bottom-`k` of the union, read its mass with `sketch_mu_mass`. KMV union is
+standard (bottom-`k` of a union of bottom-`k` sketches is exact for the union's bottom-`k`).

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -1149,7 +1149,8 @@ fan-in hub work already uses. Plain Jaccard for `P`-local branch diversity; lift
   (high-μ) branches, a leak conduit into low-μ junk (the leak-conduit structure of the real-data doc's
   cone-purity addendum). Pair the fan-out score with μ; don't read it alone.
 
-Deferred until the bridge detector is built; documented here so its gate choice is settled.
+Deferred until the bridge detector is built; documented here so its gate choice is settled. The detector
+itself is specified in `WAM_RUST_BRIDGE_DETECTOR_{PHILOSOPHY,SPECIFICATION,IMPLEMENTATION_PLAN}.md`.
 
 ## 6. Aside: the kernel-trick analogy
 

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -1077,7 +1077,54 @@ on the cones, `I(E_u ∩ E_v) / I(E_u ∪ E_v)`, for which the carry-weight KMV 
 (`sketch_mu_overlap` / `sketch_mu_overlap_lift`). It measures shared *descendants* (instances) rather than
 a shared *ancestor* (generality) — the right tool for comparing broad internal categories by content,
 degenerate for leaves with empty cones. We land path-1 now (a small additive change; the measures are
-already generic over IC) and leave path-2 for the first consumer that wants content-overlap.
+already generic over IC) and leave path-2 for the first consumer that wants content-overlap — its gate
+choice is worked out in §5g.
+
+### 5g. Parent-relative overlap — the fan-out / bridge diagnostic (deferred, path-2)
+
+Path-2's first intended consumer is the **fan-out bridge detector**: given a candidate bridge node `P`,
+do its child branches carve out *distinct* sub-regions (a genuine fan-out across sub-domains) or
+*overlapping* ones (redundant branches)? That question fixes how to gate — and, crucially, it is **not**
+§5f's monotonicity repair.
+
+**Gate relative to the parent, not the children.** Jaccard/Dice compare two sets, and the comparison is
+only well-posed inside a **common universe**. For the bridge question that universe is `P`'s own evidence
+— what `P` is responsible for organizing — so gate by `P`, not by each child's private gate:
+
+```
+U_P      = gated_cone(P)                          # P's PATH-gated cone — the local admissible universe
+E_u^P    = desc(u) ∩ U_P                           # child u's contribution within P's frame (low-μ child ⇒ ∅)
+J_P(u,v) = μ(E_u^P ∩ E_v^P) / μ(E_u^P ∪ E_v^P)     # or Dice: 2·μ(∩) / (μ(E_u^P)+μ(E_v^P))
+```
+
+The superscript `P` is the whole point: the overlap is measured *inside the parent's frame of reference*.
+Contrast §5f, where the gate logic ran the other way — child gates forcing closure *upward* to keep
+`IC(MICA) ≤ IC(child)`. Here there is no MICA and no IC ratio, so monotonicity is irrelevant; the only
+requirement is a shared universe, which `U_P` supplies. (Use `P`'s path-gated cone for `U_P` — the
+membership frontier is the natural reading of "the evidence `P` organizes.")
+
+**Reading it.** `J_P(u,v) ≈ 0` ⇒ inside `P`, the branches of `u` and `v` are distinct (`P` fans out into
+different regions); `J_P(u,v) ≈ 1` ⇒ they reconverge (`P`'s children are redundant). Aggregate the
+pairwise `J_P` over `P`'s children (e.g. mean) for a single **fan-out score** per candidate `P` — low mean
+= clean fan-out / strong bridge.
+
+**Reuses the existing sketches.** `μ(E_u^P ∩ E_v^P)` is exactly the carry-weight KMV overlap
+(`sketch_mu_overlap`) restricted to `U_P`. For *ranking* bridges across different parents — whose universes
+differ in size — don't compare raw Jaccards; use the configuration-model **lift**
+(`sketch_mu_overlap_lift`, shared mass against the `m_u·m_v/|U_P|` null), the same normalization the
+fan-in hub work already uses. Plain Jaccard for `P`-local branch diversity; lift for a global ranking.
+
+**Two cautions.**
+- *Tree-triviality.* In a pure tree, siblings have disjoint subtrees, so `J_P ≡ 0` and *every* node looks
+  like a perfect fan-out. The measure only discriminates on a **DAG**, where it detects branch
+  *reconvergence* (shared descendants) — exactly the regime Wikipedia categories live in.
+- *Fan-out ≠ meaningful bridge.* Low overlap says `P` fans into structurally-distinct regions, but a
+  generic apex (`Main_topic_classifications`) also fans into distinct — *unrelated* — regions. Telling a
+  real conceptual bridge from a leak conduit needs the membership signal: a bridge fans into **in-domain**
+  (high-μ) branches, a leak conduit into low-μ junk (the leak-conduit structure of the real-data doc's
+  cone-purity addendum). Pair the fan-out score with μ; don't read it alone.
+
+Deferred until the bridge detector is built; documented here so its gate choice is settled.
 
 ## 6. Aside: the kernel-trick analogy
 

--- a/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
+++ b/docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md
@@ -1087,6 +1087,14 @@ do its child branches carve out *distinct* sub-regions (a genuine fan-out across
 *overlapping* ones (redundant branches)? That question fixes how to gate — and, crucially, it is **not**
 §5f's monotonicity repair.
 
+**MICA proposes, overlap disposes — the two measures compose.** §5e/§5f's MICA is the *upward* primitive:
+it finds the merge points where otherwise-separate branches join, so a node that serves as the MICA for
+many *distant* pairs is a **candidate** bridge. But being a merge point (high fan-out) is necessary, not
+sufficient — a node with a hundred near-identical children is a redundant hub, not a bridge. The
+parent-relative overlap is the **qualifier**: a good bridge has high *diversity* of branching, not just
+high branching. So MICA generates candidates (look up), overlap-diversity keeps the ones whose branches
+are genuinely distinct, and μ (below) keeps the ones whose branches are in-domain — a three-signal test.
+
 **Gate relative to the parent, not the children.** Jaccard/Dice compare two sets, and the comparison is
 only well-posed inside a **common universe**. For the bridge question that universe is `P`'s own evidence
 — what `P` is responsible for organizing — so gate by `P`, not by each child's private gate:
@@ -1107,6 +1115,23 @@ membership frontier is the natural reading of "the evidence `P` organizes.")
 different regions); `J_P(u,v) ≈ 1` ⇒ they reconverge (`P`'s children are redundant). Aggregate the
 pairwise `J_P` over `P`'s children (e.g. mean) for a single **fan-out score** per candidate `P` — low mean
 = clean fan-out / strong bridge.
+
+**A whole-node diversity score (cheaper than averaging pairs).** Rather than aggregate the `O(children²)`
+pairwise `J_P`, read the diversity off the **union** directly:
+
+```
+diversity(P) = μ(⋃_i E_{c_i}^P) / Σ_i μ(E_{c_i}^P)   ∈ [1/n, 1]
+n_eff(P)     = n · diversity(P)                        # effective number of DISTINCT branches
+```
+
+`diversity(P)` is `1` when the children are disjoint (every branch covers new ground) and `1/n` when they
+fully overlap (`n` redundant copies); `n_eff` then equals the child count `n` for disjoint branches and
+**collapses to `1` for identical ones**. That single number *is* "diversity of branching, not just
+branching": a 100-child apex of near-duplicates scores `n_eff ≈ 1` (not a bridge), a 100-child node with
+distinct branches scores `n_eff ≈ 100` (strong bridge). Union mass and per-child masses are both direct
+KMV-sketch reads, so it is cheap. This is an effective-count / entropy reading of the branching — the same
+effective-number idea the hierarchy objective uses for `H`, applied to cone overlap instead of a label
+histogram. (Mass-weight by `Σμ` rather than count `n` if you want branch *importance* over branch *count*.)
 
 **Reuses the existing sketches.** `μ(E_u^P ∩ E_v^P)` is exactly the carry-weight KMV overlap
 (`sketch_mu_overlap`) restricted to `U_P`. For *ranking* bridges across different parents — whose universes


### PR DESCRIPTION
Architect-level design for the **fan-out bridge detector** — the first consumer of the gated-similarity theory (§5f–§5g) — as three docs following the project's philosophy/spec/plan convention. Docs only; no code.

Also **rescues the stranded §5g** theory commits (parent-relative overlap + `n_eff`): they were pushed to #3298's branch *after* it merged at its §5f tip, so they never reached main. This PR cherry-picks them back, so the theory is complete and the new detector docs' §5g references resolve.

## The three docs
- **`..._PHILOSOPHY.md`** — the bridge-vs-leak-vs-hub question; "high branching ≠ high *bridging*"; the three signals (fan-out, `n_eff` diversity, μ/purity); the **2-D map** (leaks are one quadrant — the detector and the cone-purity leak detector are the same tool); and the **use cases** (principled leak pruning, caret landmark selection, taxonomy QA, navigation, feeding the directional-μ model).
- **`..._SPECIFICATION.md`** — `U_P` = `P`'s path-gated cone; `E_i^P = desc(c_i) ∩ U_P`; `diversity = μ(∪)/Σμ`; `n_eff = n·diversity`; `purity = cone_purity`; the `BridgeClass` quadrants; the API (`fanout_diversity` / `bridge_classify` / `rank_bridges` + live `build_bridge_scores`); edge cases (tree-triviality, leaves, determinism); and the reuse list — **no new math**.
- **`..._IMPLEMENTATION_PLAN.md`** — 5 additive, `cargo test`-verified increments (n_eff core → purity + classify → candidates + rank → sketch scale + live wiring → real-data validation), with the edition-2021 render note.

The detector is **pure read-out** on shipped primitives (descendant sketches, `sketch_mu_overlap[_lift]`, `descendant_mu_mass_gated`, `cone_purity`, `resnik_from_ic`), so it builds and tests entirely in the Rust core with no ML/HF dependency — the μ map is an input (the directional model #3302, or any dense μ map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_