### PR TITLE
docs(bridge): in-domain-frame purity refinement + bridge-guided sampler-seeding use case

### DIFF
--- a/docs/design/WAM_RUST_BRIDGE_DETECTOR_PHILOSOPHY.md
+++ b/docs/design/WAM_RUST_BRIDGE_DETECTOR_PHILOSOPHY.md
@@ -71,6 +71,19 @@ That single table is why the bridge detector and the earlier cone-purity leak de
    nodes to index for "how do I get from here to there."
 5. **Feeding the directional-μ model.** The bridge structure marks the meaningful merge points (the MICA
    candidates) the directional model should care about — a structural prior for where order matters.
+6. **Bridge-guided sampler seeding (a virtuous loop).** The training sampler (`gen_mu_pairs.py`) seeds
+   random walks from a root and grows a *mesh* by adding walk endpoints — but raw endpoints **drift out of
+   the domain** (the first real run wandered from `Physics` into `Tamils` / `Shinto_shrines`). A better
+   frontier: take a couple of *short* walks from the root to nearby points, find the **good bridge** that
+   joins their regions (their MICA, qualified by `n_eff` + purity), and seed the next walks from *that* — a
+   structurally-important, in-domain node, close to the root when the walks are short (walk length is the
+   locality knob). This replaces "add every endpoint" with "add good bridges," which (a) **keeps the mesh
+   in-domain** — a leak conduit or redundant hub is rejected as a seed, the principled fix for the drift —
+   and (b) covers the domain's real branch structure, yielding the *varied-anchor* pairs the directional
+   model was starved for. It closes a loop: the μ map drives bridge detection, and the bridges seed the
+   training data that sharpens the next μ map — a self-expanding, **drift-controlled** frontier. (Bound the
+   loop: keep discovered seeds within a μ-coherent neighbourhood of the root so the frontier expands
+   without wandering.)
 
 ## Where it sits
 

--- a/docs/design/WAM_RUST_BRIDGE_DETECTOR_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BRIDGE_DETECTOR_SPECIFICATION.md
@@ -29,8 +29,19 @@ For a candidate node `P` with in-domain children `c_1 … c_n` (children with `�
 - **Effective branches** `n_eff(P)` = `n · diversity(P)` — equals `n` for disjoint branches, collapses to
   `1` for `n` identical ones. *(Mass-weighted variant: replace the count `n` by the in-domain child-mass
   share if branch* importance *matters more than branch* count.)*
-- **Purity** `purity(P)` = `cone_purity(P)` = `m_μ(desc(P)) / |desc(P)|` (the existing leak-detector
-  read — in-domain mass per node of the raw cone).
+- **Purity** `purity(P)` — domain coherence of `P`'s cone, measured **in the same frame as `n_eff`** (the
+  in-domain cone), **not** the raw cone.
+  - *The original raw-cone read* `cone_purity(P) = m_μ(desc(P)) / |desc(P)|` *conflates leaky with
+    big/general* and must **not** be used as the classifier's purity: #3306's real-data run showed it
+    mislabels genuine in-domain hubs (`Subfields_of_physics` 0.019, `Energy` 0.014) as `LeakConduit`,
+    because a large raw cone accumulates out-of-domain nodes that dilute the average regardless of
+    coherence.
+  - *Use an in-domain-frame read.* Primary candidate — the **in-domain fraction**
+    `purity(P) = |gated_desc(P)| / |desc(P)|`: high when most of the cone is in-domain (a coherent hub),
+    low for a leak conduit whose cone reaches out-of-domain junk. Alternative — the gated average-μ
+    `m_μ(gated_desc(P)) / |gated_desc(P)|`. **Pick the cleaner separator by the increment-5 validation**
+    (the requirement: `Subfields_of_physics`/`Energy` → high, `Matter` → low). `descendant_mu_mass_gated`
+    supplies the gated cone; `cone_purity` (raw) remains available but is *not* the classifier input.
 - **Fan-out** `φ(P)` = the in-domain child count `n`.
 
 ## Classification


### PR DESCRIPTION
Two amendments to the bridge-detector design docs (on main via #3304). Docs only.

## SPECIFICATION — purity refinement (from #3306's real-data finding)
The spec mandated raw-cone purity `m_μ(desc)/|desc|`, but #3306's increment-5 run showed it **conflates "leaky" with "big/general"** — it mislabels genuine in-domain hubs (`Subfields_of_physics` 0.019, `Energy` 0.014) as `LeakConduit` because a large raw cone dilutes the average regardless of coherence. The spec now requires purity in the **same frame `n_eff` uses** (the in-domain cone), with the **in-domain fraction** `|gated_desc(P)|/|desc(P)|` as the primary candidate and the gated average-μ as the alternative — the increment picks the cleaner separator by validation (`Subfields_of_physics`/`Energy` → high, `Matter` → low). Raw `cone_purity` stays available but is no longer the classifier input.

## PHILOSOPHY — use case 6: bridge-guided sampler seeding
A new application: use the detector to choose **sampler seed points**. Take short walks from the root, find the good bridge joining their regions (MICA qualified by `n_eff` + purity), and seed the next walks there — replacing "add every walk endpoint to the mesh" with "add good bridges." This is the **principled fix for the sampler drift** we observed (the first run wandered from `Physics` into `Tamils`/`Shinto_shrines`): a leak conduit or redundant hub is rejected as a seed, so the mesh stays in-domain while still covering the domain's real branch structure (the varied-anchor pairs the directional model was starved for). It closes a **virtuous loop** — μ map → bridge detection → seeds → better μ map — bounded against drift.

This makes the purity-refinement increment prompt ready to run the moment #3306 lands (the spec now prescribes the in-domain-frame purity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_