### PR TITLE
docs(sampler): depth-balanced bidirectional walk — design + derivation

### DIFF
--- a/prototypes/mu_cosine/DESIGN_bidirectional_walk.md
+++ b/prototypes/mu_cosine/DESIGN_bidirectional_walk.md
@@ -1,0 +1,87 @@
+# Depth-balanced bidirectional sampler walk — design
+
+*Detail for a future `gen_mu_pairs.py` option: a bidirectional random walk whose **depth doesn't drift**
+(neither toward leaves nor toward the root). Complements the `--child-only` (downward) mode; the two are
+**mixed** for training-data diversity. Theory cousin: §5d depth-stability and the λ-biased walk.*
+
+## The goal
+
+The sampler does short walks from a seed and emits `(start, endpoint)` pairs. We want the endpoint to land
+at a depth *representative* of the seed — not systematically deeper (drifting toward leaves) nor shallower
+(drifting toward the generic apex, the leak-conduit direction). Formally: **zero expected depth change per
+step**.
+
+## The handshake lemma — the means are equal
+
+Every edge is exactly one `(child, parent)` relationship, so summed over all nodes,
+`Σ children = Σ parents = #edges`. Therefore **`E[c] = E[p]` exactly**, in *any* DAG. The up/down asymmetry
+is never about the mean degree (always equal) — it is about the **distribution shape**: parents are
+concentrated (most nodes have 1–2), children are heavy-tailed (a few hubs have hundreds). That tail is what
+`E[c²]` sees and `E[p²]` doesn't.
+
+## The exact zero-drift rule (local)
+
+Weight each child-edge (down) by `1` and each parent-edge (up) by `β`. At a node with `c` children and `p`
+parents:
+
+```
+P(down) = c/(c+βp),   P(up) = βp/(c+βp),   E[Δdepth] = (c − βp)/(c + βp).
+```
+
+`E[Δdepth] = 0` at **every** node ⟺ `β = c/p`. Equivalently — and with no per-node arithmetic —
+**flip a fair coin for up-vs-down, then pick uniformly within that direction** (`P(down)=P(up)=½`). This
+makes the depth a **martingale**: `E[depth_t − depth_0] = 0` for any number of steps, regardless of the
+graph. (Boundary caveat: the root has `p=0` (must go down) and leaves have `c=0` (must go up), so the
+martingale holds in the bulk with reflecting-ish boundaries — fine for short walks from interior seeds.)
+
+## The global-constant variant (the `E[c²]/E[p²]` weight)
+
+If you'd rather a single up-weight `β` (one weighted graph, no per-node `c/p`), balance the branching the
+walk *experiences*. A walk lands on nodes **size-biased by degree**, so the branching it sees is the
+size-biased mean — `E[c²]/E[c]` going down, `E[p²]/E[p]` going up. Balancing them:
+
+```
+β = (E[c²]/E[c]) / (E[p²]/E[p]) = E[c²]/E[p²]      (using E[c]=E[p]).
+```
+
+So this is the **up-edge weight** that balances the walk *on average* — a size-biased mean-field estimate,
+exact only in aggregate (the per-node `c/p` is exact pointwise). Estimate it once from the graph. **It is a
+weight on the (few) parent edges, not the down/up probability ratio** — with it applied, the down/up
+*probabilities* come out ≈ balanced, which is the point.
+
+This is the Lyons–Pemantle–Peres λ-biased walk at criticality (up-weight = branching number ⟹ zero speed);
+`c/p` and `E[c²]/E[p²]` are its local-exact and global-average forms.
+
+## Mix unidirectional + bidirectional (diversity)
+
+The two walk modes sample **different relations**, so mixing them enriches the training distribution:
+
+- **`--child-only` (downward):** stays inside the seed's subtree → in-domain ancestor→descendant pairs,
+  deep coherent structure, zero domain drift (can't reach siblings). Cross-domain pairs come from pairing
+  two roots' downward walks (see the Physics+Chemistry task).
+- **bidirectional depth-balanced:** reaches *siblings and cousins* (up to a shared parent, back down) at a
+  representative depth → the lateral, same-level relations a downward walk never sees (e.g. Physics↔
+  Chemistry via `Physical_sciences`), without drifting deep or into the apex.
+
+So **sample a mix** (e.g. a `--bidir-frac` knob): downward walks for vertical/in-domain structure,
+depth-balanced bidirectional for lateral/cross-domain structure. The graded μ labels then cover both axes.
+
+## Orthogonal: keep hub-down-weighting
+
+Depth-balance (up vs down) is independent of the existing **hub-down-weighting** (`1/deg^β` *within* a
+direction, to avoid stepping into leak-conduit apexes — §"real-data" cone-purity). They compose: balance
+up/down, and *within* "down" still down-weight hub children. Depth-balance fixes *depth* drift; hub-down-
+weighting fixes *domain* drift; you want both. (Bridge-aware seeding, philosophy use case 6, is the sharper
+domain-drift fix later.)
+
+## Implementation & validation
+
+- Add to `gen_mu_pairs.py`: a `--bidir` mode with `--bidir-mode {coinflip,global}` (per-node `c/p` coin-flip
+  vs the single `E[c²]/E[p²]` weight), and a `--bidir-frac` to mix bidirectional with `--child-only` walks.
+  Keep hub-down-weighting within direction.
+- **Validate depth-neutrality on the real 10k graph:** from a set of interior seeds, run each mode and plot
+  `depth(endpoint) − depth(seed)`. Expect: current undirected → skewed deep; `child-only` → strictly ≥ 0;
+  `coinflip` → ≈ symmetric about 0 (tightest); `global` → ≈ symmetric (the cheaper single-weight approx).
+  Report the mean/spread per mode. **No LLM budget** — this is sampler engineering + measurement.
+- **Domain-reach sanity:** confirm bidirectional from `Physics` actually reaches sibling domains
+  (`Chemistry`, `Computer_science`) without the endpoint distribution drifting into generic apexes.


### PR DESCRIPTION
Works out the zero-drift bias for a future bidirectional sampler walk (your `(E[c²]/E[c])/(E[p²]/E[p])` idea), as a design note in `prototypes/mu_cosine/`. Docs only.

## The result
- **Handshake lemma:** `Σ children = Σ parents = #edges`, so `E[c] = E[p]` *exactly* in any DAG. The up/down asymmetry is distribution *shape* (children heavy-tailed, parents concentrated), not the mean — which is why the formula collapses to `E[c²]/E[p²]`.
- **Exact zero-drift (local):** up-weight parent edges by `c/p` per node ⟺ **coin-flip** (½/½ direction, uniform within) ⟺ the depth is a **martingale** (zero expected drift over any number of steps, modulo root/leaf boundaries). No statistics needed.
- **Your formula, correctly placed:** `β = E[c²]/E[p²]` is the right *single global up-weight on parent edges* (balances the size-biased branching the walk experiences) — with it applied, the down/up *probabilities* come out balanced. The one correction: it's the parent-edge **weight**, not the probability ratio. It's a mean-field estimate (exact only on average); the per-node `c/p` is exact pointwise. (= the Lyons–Pemantle–Peres λ-biased walk at criticality.)

## Design choices captured
- **Mix unidirectional + bidirectional** (your latest point) for diversity: `--child-only` gives vertical/in-domain structure, depth-balanced bidirectional gives the lateral/cross-domain (sibling) relations a downward walk can't reach — a `--bidir-frac` knob mixes them.
- **Keep hub-down-weighting** — orthogonal: depth-balance fixes *depth* drift, hub-down-weighting fixes *domain* drift.
- A **budget-free** real-graph validation plan (measure `depth(endpoint) − depth(seed)` per mode; confirm bidirectional reaches `Chemistry`/`Computer_science` from `Physics` without apex drift).

This is the spec for the second (parallel) agent — sampler engineering + measurement, no LLM budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_