### PR TITLE
feat(bridge): expose the bridge detector to Prolog as a foreign predicate (increment 1)

### DIFF
--- a/docs/design/WAM_RUST_BRIDGE_CLUSTERING.md
+++ b/docs/design/WAM_RUST_BRIDGE_CLUSTERING.md
@@ -102,3 +102,63 @@ declare*: you declare the **analysis pipeline**, not the plumbing. (It's the sam
 component/partition pass. Each increment renders `boundary_cache.rs.mustache` + `state.rs.mustache` and
 `cargo test`s at **edition 2021** (the established harness). Bridge detection stays additive; nothing in
 the merged similarity/detector changes.
+
+## Increment 1 — implemented: bridge detector exposed as a foreign predicate
+
+The detector is now Prolog-callable through the established 4-site foreign-predicate mechanism
+(mirroring `category_ancestor` / `category_ancestor_boundary`), additive throughout.
+
+**How μ is supplied (the decision).** The bridge detector consumes a dense `name→μ` membership map as an
+**input** (the directional model, the symmetric map, or any score). On the Prolog side that map is a
+**fact predicate** — `category_mu(Node, Score)` — exactly analogous to the edge predicate
+`category_parent(Child, Parent)`. It is materialised into a `HashMap<u32, f64>` by `register_ffi_mu`
+(the score-fact twin of `register_ffi_fact_pairs`) and stored in `WamState.mu_facts`, keyed by the μ
+predicate name. A node absent from the facts defaults to `μ = 0` (out of domain), the same convention as
+the rest of the detector. The μ predicate name is threaded as the `mu_pred` string config, so a project
+can carry several μ maps (e.g. `category_mu_sym`, `category_mu_llm`) and select one per declaration.
+
+**The four sites.**
+- **(A) `WamState` methods** (`state.rs.mustache`): the merged `build_bridge_scores` / `category_bridge_score`
+  plus new additive glue — `register_ffi_mu`, `build_bridge_scores_named(edge_pred, mu_pred, threshold,
+  params)`, `ensure_bridge_scores` (build-on-first-use), `category_bridge_class(node) -> (class atom,
+  n_eff)`, `bridge_candidates()` (ranked enumeration), and `atom_name` (id→atom for streaming).
+- **(B) the declaration** — a `foreign_predicate/3` spec passed as the `foreign_lowering(...)` option (the
+  same shape `category_ancestor` uses), now with a `register_foreign_f64_config` setup line (added) for
+  `threshold` and a `register_ffi_mu` setup line (added) for the μ facts.
+- **(C) dispatch arms** in `execute_foreign_predicate` (`wam_rust_target.pl`): `"category_bridge_score"`
+  (Node atom in → Class atom out, build-on-first-use) and `"bridge"` (enumerate ranked candidates as
+  Node, Class atom, `n_eff` float). The class atom is `boundary_cache::bridge_class_atom(class)` —
+  `bridge` / `leak_conduit` / `redundant_hub` / `not_candidate` — defined once next to `BridgeClass`.
+- **(D) registration** via the `foreign_lowering` setup ops (`register_foreign_native_kind` +
+  `register_foreign_result_mode(deterministic)` + `register_foreign_result_layout(tuple(1))` + the
+  configs).
+
+**The declaration an author writes** (lowering `category_bridge_score/2`):
+
+```prolog
+:- Mu = [ 'Subfields_of_physics'-1.0, 'Matter'-1.0, 'Energy'-1.0 /* … category_mu facts … */ ],
+   write_wam_rust_project([user:my_query/2],
+     [ module_name(physics),
+       foreign_lowering(
+         foreign_predicate(category_bridge_score/2,
+           [ register_foreign_native_kind(category_bridge_score/2, category_bridge_score),
+             register_foreign_result_mode(category_bridge_score/2, deterministic),
+             register_foreign_result_layout(category_bridge_score/2, tuple(1)),
+             register_foreign_string_config(category_bridge_score/2, edge_pred, category_parent),
+             register_foreign_string_config(category_bridge_score/2, mu_pred, category_mu),
+             register_foreign_f64_config(category_bridge_score/2, threshold, 0.3),
+             register_ffi_mu(category_bridge_score/2, category_mu, Mu) ],
+           [])) ],
+     'output/physics').
+```
+
+The author then queries `category_bridge_score(Node, Class)` — `Class` unifies with the bridge atom — or
+`bridge(Node, Class, Neff)` to enumerate the ranked candidates. `threshold` defaults to `0.3` and
+`τ_pure` is self-calibrating (the merged auto-calibration), so the cut needs no tuning. (Increment 3 will
+fold this boilerplate into the single `graph_analysis/4` macro.)
+
+**Tests.** `boundary_cache.rs.mustache`: `bridge_class_atom_wire_names` (the wire atoms) and the gated
+`wikipedia_bridge_foreign_predicate_atoms` (the 10k fixture through the same rank_bridges → class-atom
+path: `Subfields_of_physics ⇒ bridge`, `Matter ⇒ leak_conduit`) — both render + `cargo test` at edition
+2021 with no swipl. `tests/test_wam_rust_bridge_foreign_dispatch.pl` exercises the full
+transpile→dispatch path (swipl + cargo, CI-gated).

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -2415,6 +2415,83 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     &pred_key, vec![out_reg],
                     vec![Value::Str("__tuple__".to_string(), vec![result])])
             }
+            "category_bridge_score" => {
+                // category_bridge_score(Node, Class): Node atom in (A1), Class atom out (A2). Builds
+                // the bridge scores on first use from edge_pred + mu_pred + threshold (self-calibrating
+                // tau_pure), then packs bridge_class_atom(class) as a Prolog atom. The mu map is a
+                // Prolog fact predicate (mu_pred config, e.g. category_mu/2) loaded via register_ffi_mu.
+                // See WAM_RUST_BRIDGE_CLUSTERING.md increment 1.
+                let node = match self.get_reg_raw("A1").map(|v| self.deref_var(&v)) {
+                    Some(Value::Atom(node)) => node,
+                    _ => return false,
+                };
+                let class_reg = match self.get_reg_raw("A2") {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let edge_pred = match self.foreign_string_config(&pred_key, "edge_pred") {
+                    Some(pred) => pred.to_string(),
+                    None => return false,
+                };
+                let mu_pred = match self.foreign_string_config(&pred_key, "mu_pred") {
+                    Some(pred) => pred.to_string(),
+                    None => return false,
+                };
+                let threshold = self.foreign_f64_config(&pred_key, "threshold").unwrap_or(0.3);
+                if !self.ensure_bridge_scores(&edge_pred, &mu_pred, threshold) {
+                    return false;
+                }
+                let node_id = self.intern_atom(&node);
+                let (class, _n_eff) = match self.category_bridge_class(node_id) {
+                    Some(pair) => pair,
+                    None => return false,
+                };
+                self.finish_foreign_results(&pred_key, vec![class_reg], vec![
+                    Value::Str("__tuple__".to_string(), vec![Value::Atom(class.to_string())])
+                ])
+            }
+            "bridge" => {
+                // bridge(Node, Class, Neff): enumerate all bridge candidates (ranking). Node atom (A1),
+                // Class atom (A2), Neff float (A3) — streamed one solution per candidate, sorted by
+                // n_eff descending. Same build-on-first-use as category_bridge_score.
+                let node_reg = match self.get_reg_raw("A1") {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let class_reg = match self.get_reg_raw("A2") {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let neff_reg = match self.get_reg_raw("A3") {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let edge_pred = match self.foreign_string_config(&pred_key, "edge_pred") {
+                    Some(pred) => pred.to_string(),
+                    None => return false,
+                };
+                let mu_pred = match self.foreign_string_config(&pred_key, "mu_pred") {
+                    Some(pred) => pred.to_string(),
+                    None => return false,
+                };
+                let threshold = self.foreign_f64_config(&pred_key, "threshold").unwrap_or(0.3);
+                if !self.ensure_bridge_scores(&edge_pred, &mu_pred, threshold) {
+                    return false;
+                }
+                let candidates = self.bridge_candidates();
+                if candidates.is_empty() {
+                    return false;
+                }
+                let results: Vec<Value> = candidates.into_iter().map(|(id, class, neff)| {
+                    let name = self.atom_name(id).unwrap_or("").to_string();
+                    Value::Str("__tuple__".to_string(), vec![
+                        Value::Atom(name),
+                        Value::Atom(class.to_string()),
+                        Value::Float(neff),
+                    ])
+                }).collect();
+                self.finish_foreign_results(&pred_key, vec![node_reg, class_reg, neff_reg], results)
+            }
             _ => false,
         }
     }'.
@@ -5289,6 +5366,16 @@ rust_foreign_setup_line(register_foreign_string_config(Pred/Arity, Key, Value), 
 rust_foreign_setup_line(register_foreign_usize_config(Pred/Arity, Key, Value), Line) :-
     format(string(Line),
         '    vm.register_foreign_usize_config("~w/~w", "~w", ~w);', [Pred, Arity, Key, Value]).
+rust_foreign_setup_line(register_foreign_f64_config(Pred/Arity, Key, Value), Line) :-
+    format(string(Line),
+        '    vm.register_foreign_f64_config("~w/~w", "~w", ~w);', [Pred, Arity, Key, Value]).
+rust_foreign_setup_line(register_ffi_mu(_Pred/_Arity, MuPred, Pairs), Line) :-
+    % Load a node->score (μ membership) fact table for the bridge detector, the score-fact analogue
+    % of register_indexed_atom_fact2. MuPred names the μ predicate (e.g. category_mu); Pairs is a list
+    % of Name-Score terms harvested from the μ facts.
+    rust_mu_pairs_literal(Pairs, PairsLiteral),
+    format(string(Line),
+        '    vm.register_ffi_mu("~w", &~w);', [MuPred, PairsLiteral]).
 rust_foreign_setup_line(register_indexed_atom_fact2(Pred/Arity, Pairs), Line) :-
     rust_fact_pairs_literal(Pairs, PairsLiteral),
     format(string(Line),
@@ -5309,6 +5396,15 @@ rust_fact_pair_literal(Left-Right, Literal) :-
     escape_rust_string(Left, ELeft),
     escape_rust_string(Right, ERight),
     format(string(Literal), '("~w", "~w")', [ELeft, ERight]).
+
+rust_mu_pairs_literal(Pairs, Literal) :-
+    maplist(rust_mu_pair_literal, Pairs, PairLiterals),
+    atomic_list_concat(PairLiterals, ', ', Joined),
+    format(string(Literal), '[~w]', [Joined]).
+
+rust_mu_pair_literal(Name-Score, Literal) :-
+    escape_rust_string(Name, EName),
+    format(string(Literal), '("~w", ~w)', [EName, Score]).
 
 rust_fact_triples_literal(Triples, Literal) :-
     maplist(rust_fact_triple_literal, Triples, TripleLiterals),

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -2459,6 +2459,19 @@ pub enum BridgeClass {
     NotCandidate,
 }
 
+/// **The canonical `BridgeClass` → Prolog-atom name.** The foreign predicate `category_bridge_score/2`
+/// (and `bridge/3`) exposes the class to Prolog as one of these lowercase atoms; the dispatch arm in
+/// `execute_foreign_predicate` packs `Value::Atom(bridge_class_atom(score.class))`. Kept here (next to
+/// the enum) so the wire name is defined once and the Rust side and the transpiler agree.
+pub fn bridge_class_atom(class: BridgeClass) -> &'static str {
+    match class {
+        BridgeClass::Bridge => "bridge",
+        BridgeClass::LeakConduit => "leak_conduit",
+        BridgeClass::RedundantHub => "redundant_hub",
+        BridgeClass::NotCandidate => "not_candidate",
+    }
+}
+
 /// Classification thresholds for `bridge_classify` / `rank_bridges`. The continuous `(n_eff, purity)`
 /// is the real read for ranking; these cut it into the convenience labels.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7464,5 +7477,70 @@ mod tests {
         assert_eq!(sh.class, BridgeClass::RedundantHub, "reconverging fan-out ⇒ RedundantHub: {sh:?}");
 
         assert!(ranked.iter().all(|(_, s)| s.n_eff.is_finite() && s.purity.is_finite()), "all scores finite");
+    }
+
+    // ── Bridge detector as a FOREIGN PREDICATE: the class→atom wire the Prolog side reads (#3317) ──
+
+    // The foreign predicate `category_bridge_score(Node, Class)` returns `bridge_class_atom(class)` as a
+    // Prolog atom. This is the cargo-testable proxy for the gated Prolog program in
+    // tests/test_wam_rust_bridge_foreign_dispatch.pl (which needs swipl+cargo to run the full
+    // transpile): it drives the SAME path the dispatch arm uses — rank_bridges (auto-τ_pure) → look up a
+    // node's BridgeScore → bridge_class_atom — directly on the 10k fixture and asserts the atom strings a
+    // Prolog author sees. Subfields_of_physics ⇒ 'bridge', Matter ⇒ 'leak_conduit'. Gated on
+    // UW_CATEGORY_TSV + UW_FUZZY_NODES (skips in CI).
+    #[test]
+    fn wikipedia_bridge_foreign_predicate_atoms() {
+        let tsv = match std::env::var("UW_CATEGORY_TSV") {
+            Ok(p) => p, Err(_) => { eprintln!("bridge-atom: skip (UW_CATEGORY_TSV)"); return; } };
+        let fuzz = match std::env::var("UW_FUZZY_NODES") {
+            Ok(p) => p, Err(_) => { eprintln!("bridge-atom: skip (UW_FUZZY_NODES)"); return; } };
+        let text = std::fs::read_to_string(&tsv).expect("read UW_CATEGORY_TSV");
+        let mut ids: HashMap<String, u32> = HashMap::new();
+        let mut names: Vec<String> = Vec::new();
+        let mut parents: HashMap<u32, Vec<u32>> = HashMap::new();
+        for (ln, line) in text.lines().enumerate() {
+            if ln == 0 && line.starts_with("child") { continue; }
+            let mut it = line.split('\t');
+            let (c, p) = match (it.next(), it.next()) { (Some(c), Some(p)) => (c, p), _ => continue };
+            let intern = |s: &str, ids: &mut HashMap<String, u32>, names: &mut Vec<String>| {
+                *ids.entry(s.to_string()).or_insert_with(|| { names.push(s.to_string()); (names.len() - 1) as u32 }) };
+            let ci = intern(c, &mut ids, &mut names);
+            let pi = intern(p, &mut ids, &mut names);
+            parents.entry(ci).or_default().push(pi);
+        }
+        let mu: HashMap<u32, f64> = std::fs::read_to_string(&fuzz).expect("read UW_FUZZY_NODES")
+            .lines().filter(|l| !l.trim_start().starts_with('#'))
+            .filter_map(|l| { let mut it = l.split('\t');
+                match (it.next(), it.next().and_then(|s| s.trim().parse::<f64>().ok())) {
+                    (Some(n), Some(m)) => ids.get(n.trim()).map(|&id| (id, m)),
+                    _ => None,
+                }
+            }).collect();
+
+        // Same call the WamState foreign-predicate path makes: rank_bridges (auto τ_pure) → per-node
+        // BridgeScore map → class atom. (The live path caches this as `bridge_scores`.)
+        let params = BridgeParams::default(); // φ_min=2, τ_div=1.5, τ_pure=None (self-calibrating)
+        let scores: HashMap<u32, BridgeScore> =
+            rank_bridges(&parents, &mu, 0.3, &params).into_iter().collect();
+        let class_atom = |nm: &str| ids.get(nm)
+            .and_then(|n| scores.get(n))
+            .map(|s| bridge_class_atom(s.class));
+
+        assert_eq!(class_atom("Subfields_of_physics"), Some("bridge"),
+            "category_bridge_score(Subfields_of_physics, Class) ⇒ Class = bridge");
+        assert_eq!(class_atom("Matter"), Some("leak_conduit"),
+            "category_bridge_score(Matter, Class) ⇒ Class = leak_conduit");
+        eprintln!("bridge-atom: Subfields_of_physics ⇒ {:?}, Matter ⇒ {:?}",
+            class_atom("Subfields_of_physics"), class_atom("Matter"));
+    }
+
+    // The class→atom wire names are stable and total (every BridgeClass maps to a distinct lowercase
+    // atom the Prolog side matches on).
+    #[test]
+    fn bridge_class_atom_wire_names() {
+        assert_eq!(bridge_class_atom(BridgeClass::Bridge), "bridge");
+        assert_eq!(bridge_class_atom(BridgeClass::LeakConduit), "leak_conduit");
+        assert_eq!(bridge_class_atom(BridgeClass::RedundantHub), "redundant_hub");
+        assert_eq!(bridge_class_atom(BridgeClass::NotCandidate), "not_candidate");
     }
 }

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -551,6 +551,13 @@ pub struct WamState {
     /// `category_bridge_score` read-out then answers per-node in O(1). Empty = bridge detector off
     /// (default). Eager-edge only. See `boundary_cache::{rank_bridges, bridge_classify}`.
     pub bridge_scores: std::collections::HashMap<u32, crate::boundary_cache::BridgeScore>,
+    /// **μ membership maps** for the bridge detector, keyed by the μ fact-predicate name
+    /// (e.g. `"category_mu"`) — the analogue of `ffi_facts` for node→score facts. The bridge detector
+    /// consumes a `name→μ` map as an INPUT (the directional model, the symmetric map, or any dense
+    /// score); this is how a Prolog fact predicate `category_mu(Node, Score)` is materialised into the
+    /// `HashMap<u32, f64>` `build_bridge_scores` needs. Populated by `register_ffi_mu`; read by
+    /// `build_bridge_scores_named` / the `category_bridge_score` foreign-predicate dispatch arm.
+    pub mu_facts: std::collections::HashMap<String, std::collections::HashMap<u32, f64>>,
     /// Int-native edge mode: when true, the lazy edge path treats the kernel's
     /// u32 node id AS the raw LMDB int key directly (identity), bypassing
     /// `wam_to_lmdb`/`lmdb_to_wam`. Used for int-native fixtures whose seeds,
@@ -691,6 +698,7 @@ impl WamState {
             desc_sketch_k: 0,
             caret_landmarks: std::collections::HashMap::new(),
             bridge_scores: std::collections::HashMap::new(),
+            mu_facts: std::collections::HashMap::new(),
             bindings: HashMap::new(),
             var_counter: 0,
             cut_barrier: 0,
@@ -794,6 +802,12 @@ impl WamState {
         self.atom_intern.insert(s.to_string(), id);
         self.atom_deintern.push(s.to_string());
         id
+    }
+
+    /// Reverse of `intern_atom`: the atom name for an interned id (`None` if never interned). Used by
+    /// foreign predicates that stream node ids back to Prolog as atoms (e.g. `bridge/3`).
+    pub fn atom_name(&self, id: u32) -> Option<&str> {
+        self.atom_deintern.get(id as usize).map(|s| s.as_str())
     }
 
     /// Register a foreign predicate implementation by "name/arity".
@@ -1463,6 +1477,79 @@ impl WamState {
     /// built. The live, cache-backed entry point for `boundary_cache::bridge_classify`.
     pub fn category_bridge_score(&self, p: u32) -> Option<crate::boundary_cache::BridgeScore> {
         self.bridge_scores.get(&p).copied()
+    }
+
+    /// Register a **μ membership map** for the bridge detector from `(node_atom, score)` pairs — the
+    /// score-fact analogue of `register_ffi_fact_pairs`. Interns each node atom to its u32 id and stores
+    /// the `HashMap<u32, f64>` under `mu_pred` (the μ fact-predicate name). This is how a Prolog fact
+    /// predicate `category_mu(Node, Score)` is materialised for `build_bridge_scores_named`. A node may
+    /// appear once (last write wins); nodes absent from the map default to `μ = 0` in the detector.
+    pub fn register_ffi_mu(&mut self, mu_pred: &str, pairs: &[(&str, f64)]) {
+        let mut table: std::collections::HashMap<u32, f64> = std::collections::HashMap::new();
+        for (node, score) in pairs {
+            let id = self.intern_atom(node);
+            table.insert(id, *score);
+        }
+        self.mu_facts.insert(mu_pred.to_string(), table);
+    }
+
+    /// Precompute the **bridge scores from named fact predicates** — the foreign-predicate entry point.
+    /// Looks up the eager edge graph (`ffi_facts[edge_pred]`) and the μ map (`mu_facts[mu_pred]`,
+    /// registered via `register_ffi_mu`), then runs `boundary_cache::rank_bridges` and caches the
+    /// per-node `BridgeScore`. `params` carries `φ_min` / `τ_div` / `τ_pure` (`None` ⇒ self-calibrating).
+    /// Returns `false` (no-op) if either fact predicate is unregistered. The named companion to
+    /// `build_bridge_scores` (which takes the μ map by reference); kept additive so neither changes.
+    pub fn build_bridge_scores_named(
+        &mut self,
+        edge_pred: &str,
+        mu_pred: &str,
+        threshold: f64,
+        params: &crate::boundary_cache::BridgeParams,
+    ) -> bool {
+        let ranked = {
+            let parents = match self.ffi_facts.get(edge_pred) {
+                Some(p) => p,
+                None => return false,
+            };
+            let mu = match self.mu_facts.get(mu_pred) {
+                Some(m) => m,
+                None => return false,
+            };
+            crate::boundary_cache::rank_bridges(parents, mu, threshold, params)
+        };
+        self.bridge_scores = ranked.into_iter().collect();
+        true
+    }
+
+    /// **Build-on-first-use** for the bridge scores: build from `edge_pred` / `mu_pred` / `threshold`
+    /// (self-calibrating `τ_pure`) only if the cache is empty, then report whether scores are available.
+    /// The `category_bridge_score` / `bridge` foreign-predicate dispatch arms call this so an author need
+    /// not order an explicit build step. Idempotent after the first successful build.
+    pub fn ensure_bridge_scores(&mut self, edge_pred: &str, mu_pred: &str, threshold: f64) -> bool {
+        if self.bridge_scores.is_empty() {
+            let params = crate::boundary_cache::BridgeParams::default();
+            self.build_bridge_scores_named(edge_pred, mu_pred, threshold, &params);
+        }
+        !self.bridge_scores.is_empty()
+    }
+
+    /// The cached bridge **class atom + `n_eff`** for node `p` — the read the `category_bridge_score/2`
+    /// and `bridge/3` foreign predicates pack into Prolog: `(bridge_class_atom(class), n_eff)`. `None`
+    /// if `p` is not a candidate (or the cache is unbuilt). The dispatch arm wraps the `&str` in a
+    /// `Value::Atom` and the `f64` in a `Value::Float`.
+    pub fn category_bridge_class(&self, p: u32) -> Option<(&'static str, f64)> {
+        self.bridge_scores.get(&p)
+            .map(|s| (crate::boundary_cache::bridge_class_atom(s.class), s.n_eff))
+    }
+
+    /// All cached bridge candidates as `(node, class atom, n_eff)`, sorted by `n_eff` descending (then
+    /// node id) — the enumeration the `bridge/3` foreign predicate streams. Empty until built.
+    pub fn bridge_candidates(&self) -> Vec<(u32, &'static str, f64)> {
+        let mut out: Vec<(u32, &'static str, f64)> = self.bridge_scores.iter()
+            .map(|(&n, s)| (n, crate::boundary_cache::bridge_class_atom(s.class), s.n_eff))
+            .collect();
+        out.sort_unstable_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal).then(a.0.cmp(&b.0)));
+        out
     }
 
     /// **Resnik** semantic similarity `IC(MICA(u,v))` over the eager `edge_pred` graph, using
@@ -3623,5 +3710,35 @@ mod boundary_kernel_tests {
         assert!(vm.boundary_suffix.is_empty(), "empty band -> empty side-table");
         let spl = norm(boundary_hist(&vm, seed, root, budget));
         assert_eq!(full, spl, "no-op precompute still correct (full enumeration)");
+    }
+
+    // Bridge detector foreign-predicate glue (WAM_RUST_BRIDGE_CLUSTERING.md increment 1): the μ map is
+    // loaded from a named fact predicate (register_ffi_mu), bridge scores build on first use, and
+    // category_bridge_class returns the class atom the dispatch arm packs into Prolog. A node with two
+    // disjoint in-domain child branches is a Bridge.
+    #[test]
+    fn bridge_foreign_glue_classifies_via_named_facts() {
+        let mut vm = WamState::new(vec![], HashMap::new());
+        // org fans out into two disjoint in-domain branches (a -> a1, b -> b1) => n_eff 2, fraction 1.0.
+        vm.register_ffi_fact_pairs("category_parent", &[
+            ("a", "org"), ("b", "org"), ("a1", "a"), ("b1", "b"),
+        ]);
+        vm.register_ffi_mu("category_mu", &[
+            ("org", 1.0), ("a", 1.0), ("b", 1.0), ("a1", 1.0), ("b1", 1.0),
+        ]);
+        // build-on-first-use, then classify.
+        assert!(vm.ensure_bridge_scores("category_parent", "category_mu", 0.3),
+            "bridge scores build from named edge + mu facts");
+        let org = vm.intern_atom("org");
+        let (class, n_eff) = vm.category_bridge_class(org).expect("org is a candidate");
+        assert_eq!(class, "bridge", "two disjoint in-domain branches => bridge (got {class})");
+        assert!((n_eff - 2.0).abs() < 1e-9, "n_eff = 2 for two disjoint branches, got {n_eff}");
+        // a leaf is not a candidate.
+        let a1 = vm.intern_atom("a1");
+        assert!(vm.category_bridge_class(a1).is_none(), "a leaf is not a bridge candidate");
+        // unregistered fact predicates => no-op build.
+        let mut vm2 = WamState::new(vec![], HashMap::new());
+        assert!(!vm2.build_bridge_scores_named("nope", "nope", 0.3,
+            &crate::boundary_cache::BridgeParams::default()), "missing facts => false");
     }
 }

--- a/tests/test_wam_rust_bridge_foreign_dispatch.pl
+++ b/tests/test_wam_rust_bridge_foreign_dispatch.pl
@@ -1,0 +1,116 @@
+% test_wam_rust_bridge_foreign_dispatch.pl
+%
+% INCREMENT 1 of WAM_RUST_BRIDGE_CLUSTERING.md: the fan-out bridge detector is
+% reachable from Prolog as a FOREIGN PREDICATE through execute_foreign_predicate.
+% Mirrors test_wam_rust_boundary_foreign_dispatch.pl: it validates the full
+% dispatch path a compiled query takes —
+%
+%   register category_bridge_score/2 as a foreign predicate
+%     -> native_kind "category_bridge_score"
+%     -> result_mode "deterministic", layout "tuple:1"
+%     -> config: edge_pred / mu_pred / threshold
+%   load edge facts (ffi_facts) + a mu map (register_ffi_mu)
+%   set A1 = node atom, A2 = unbound, call
+%     execute_foreign_predicate("category_bridge_score", 2)
+%   read the class atom back from A2
+%
+% and asserts a node with two disjoint in-domain child branches classifies as
+% 'bridge'. (The real-data classification — Subfields_of_physics -> bridge,
+% Matter -> leak_conduit on the 10k fixture — is the cargo-gated boundary_cache
+% test wikipedia_bridge_foreign_predicate_atoms, which renders without swipl.)
+%
+% cargo-gated.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic bfp_fact/2.
+bfp_fact(a, b).   % keeps the project non-trivial; the bridge graph is
+bfp_fact(b, c).   % registered inside the cargo test below.
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_bridge_foreign_dispatch).
+
+test(bridge_detector_reachable_via_foreign_dispatch,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_bridge_dispatch'))]) :-
+    Dir = 'output/test_bridge_dispatch',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:bfp_fact/2], [module_name(bfp)], Dir)),
+    % the generated runtime must carry the bridge dispatch arm + the WamState glue.
+    atom_concat(Dir, '/src/state.rs', StateRs),
+    read_file_to_string(StateRs, Src, []),
+    sub_string(Src, _, _, _, "\"category_bridge_score\" =>"),
+    sub_string(Src, _, _, _, "fn build_bridge_scores_named"),
+    sub_string(Src, _, _, _, "fn register_ffi_mu"),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/bridge_test.rs', TestPath),
+    TestSrc = '
+use bfp::state::WamState;
+use bfp::value::Value;
+use std::collections::HashMap;
+
+// Drive category_bridge_score/2 THROUGH the foreign-dispatch path: A1 = node
+// atom (in), A2 = fresh output var, read the class atom back from A2. A fresh
+// output-variable name per call mirrors the WAM allocating a new var per goal.
+fn dispatch_class(vm: &mut WamState, node: &str, tag: usize) -> Option<String> {
+    vm.set_reg("A1", Value::Atom(node.to_string()));
+    vm.set_reg("A2", Value::Unbound(format!("BClass{}", tag)));
+    let ok = vm.execute_foreign_predicate("category_bridge_score", 2);
+    if !ok { return None; }
+    match vm.deref_var(&vm.get_reg_raw("A2").unwrap()) {
+        Value::Atom(s) => Some(s),
+        _ => None,
+    }
+}
+
+fn setup() -> WamState {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    // org fans out into two DISJOINT in-domain child branches (a -> a1, b -> b1):
+    // n_eff = 2, in-domain fraction = 1.0 => Bridge. org is the only fan-out>=2 node.
+    vm.register_ffi_fact_pairs("category_parent", &[
+        ("a", "org"), ("b", "org"), ("a1", "a"), ("b1", "b"),
+    ]);
+    vm.register_ffi_mu("category_mu", &[
+        ("org", 1.0), ("a", 1.0), ("b", 1.0), ("a1", 1.0), ("b1", 1.0),
+    ]);
+    // register the foreign kernel exactly as the compiler would lower it.
+    let key = "category_bridge_score/2";
+    vm.register_foreign_predicate(key);
+    vm.register_foreign_native_kind(key, "category_bridge_score");
+    vm.register_foreign_result_mode(key, "deterministic");
+    vm.register_foreign_result_layout(key, "tuple:1");
+    vm.register_foreign_string_config(key, "edge_pred", "category_parent");
+    vm.register_foreign_string_config(key, "mu_pred", "category_mu");
+    vm.register_foreign_f64_config(key, "threshold", 0.3);
+    vm
+}
+
+#[test]
+fn bridge_node_classifies_as_bridge_via_dispatch() {
+    let mut vm = setup();
+    let got = dispatch_class(&mut vm, "org", 0).expect("dispatch should bind A2");
+    assert_eq!(got, "bridge", "org has two disjoint in-domain branches => bridge");
+    // A leaf (no fan-out) is not a candidate => dispatch fails (no solution).
+    assert!(dispatch_class(&mut vm, "a1", 1).is_none(), "a leaf is not a bridge candidate");
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test bridge_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[bridge foreign dispatch FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_bridge_foreign_dispatch).


### PR DESCRIPTION
## Summary

Increment 1 of `docs/design/WAM_RUST_BRIDGE_CLUSTERING.md`: the bridge detector — currently an internal
`WamState` method, not Prolog-callable — is wired through the established **4-site foreign-predicate
mechanism**, mirroring `category_ancestor`. **Additive only**: `descendant_mu_mass_gated`, `gated_ic`, the
similarity functions, `rank_bridges`, and `bridge_classify` are untouched.

## How μ is supplied (the decision)

The detector consumes a dense `name→μ` map as an **input**. On the Prolog side it is a **fact predicate**
`category_mu(Node, Score)` — the score-fact analogue of the edge predicate `category_parent(Child,
Parent)` — materialised into `HashMap<u32,f64>` by `register_ffi_mu` and stored in `WamState.mu_facts`,
keyed by the `mu_pred` config (so a project can carry several μ maps and select one per declaration). A
node absent from the facts defaults to `μ = 0`.

## The four sites

- **(A) `WamState` methods** (`state.rs`): the merged `build_bridge_scores` / `category_bridge_score` plus
  additive glue — `register_ffi_mu`, `build_bridge_scores_named`, `ensure_bridge_scores` (build-on-first-
  use), `category_bridge_class(node) → (class atom, n_eff)`, `bridge_candidates()`, `atom_name`. In
  `boundary_cache.rs`: `pub bridge_class_atom(BridgeClass) → &str` (`bridge`/`leak_conduit`/
  `redundant_hub`/`not_candidate`), the wire name defined once next to the enum.
- **(B) declaration** — a `foreign_predicate/3` spec passed as `foreign_lowering(...)`, now with new
  `register_foreign_f64_config` (for `threshold`) and `register_ffi_mu` (for the μ facts) setup-line
  clauses + a `rust_mu_pairs_literal` helper.
- **(C) dispatch arms** in `execute_foreign_predicate` (`wam_rust_target.pl`): `"category_bridge_score"`
  (Node atom → Class atom, build-on-first-use) and `"bridge"` (enumerate ranked candidates: Node, Class
  atom, `n_eff` float).
- **(D) registration** via the `foreign_lowering` setup ops (`native_kind` + `result_mode(deterministic)`
  + `result_layout(tuple(1))` + configs).

## The declaration an author writes

```prolog
:- write_wam_rust_project([user:my_query/2],
     [ module_name(physics),
       foreign_lowering(
         foreign_predicate(category_bridge_score/2,
           [ register_foreign_native_kind(category_bridge_score/2, category_bridge_score),
             register_foreign_result_mode(category_bridge_score/2, deterministic),
             register_foreign_result_layout(category_bridge_score/2, tuple(1)),
             register_foreign_string_config(category_bridge_score/2, edge_pred, category_parent),
             register_foreign_string_config(category_bridge_score/2, mu_pred, category_mu),
             register_foreign_f64_config(category_bridge_score/2, threshold, 0.3),
             register_ffi_mu(category_bridge_score/2, category_mu, Mu) ],
           [])) ],
     'output/physics').
```

Then query `category_bridge_score(Node, Class)` (Class unifies with the bridge atom) or `bridge(Node,
Class, Neff)` to enumerate ranked candidates. `threshold` defaults to `0.3`; `τ_pure` self-calibrates.

## Tests

`boundary_cache.rs.mustache` rendered + `cargo test` at **edition 2021**: **101 passed** (99 + 2), 0 warnings.
- `bridge_class_atom_wire_names` — the class→atom wire names.
- `wikipedia_bridge_foreign_predicate_atoms` (gated on `UW_CATEGORY_TSV`/`UW_FUZZY_NODES`): the 10k fixture
  through the same `rank_bridges → class-atom` path the dispatch arm uses — **verified
  `Subfields_of_physics ⇒ bridge`, `Matter ⇒ leak_conduit`**.

`state.rs` gains `bridge_foreign_glue_classifies_via_named_facts` (runs when the full crate builds in CI).
`tests/test_wam_rust_bridge_foreign_dispatch.pl` exercises the full transpile→dispatch path (swipl +
cargo, CI-gated).

**Note on verification:** swipl is unavailable in this environment, so the full transpile path (the
generated `execute_foreign_predicate` dispatch arm and the `state.rs` glue) could not be `cargo`-run here.
The Prolog-side wiring closely mirrors the proven `category_ancestor` / `category_ancestor_boundary`
pattern and is verified by review (balanced, no stray quotes); the cargo-tested portion is the
self-contained `boundary_cache.rs` (the class→atom path, on the real 10k fixture). The `.pl` e2e test and
the `state.rs` unit test run in a swipl+cargo CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017Vpeb4jzg2SjkLadvpLBs7)_