### PR TITLE
feat(wam): emit native items for constant indexes

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -16,10 +16,12 @@ The first implementation step is intentionally conservative:
   compound body arguments with default args-first `set_*` ordering, and
   conjunctions of those simple shapes directly as items. The same native path
   also emits non-indexed linear multi-clause predicates when every clause has one
-  of those supported simple shapes. It falls back to the existing text generator
-  plus `wam_text_to_items/2` for indexed multi-clause predicates, aggregates,
-  lowered builtins, control flow, legacy interleaved compound-argument emission
-  via `args_first_emission(false)`, and other complex shapes.
+  of those supported simple shapes, plus the simplest A1 `switch_on_constant`
+  indexed variant when no extra dispatch chains are needed. It falls back to the
+  existing text generator plus `wam_text_to_items/2` for A2 indexing,
+  fallthrough indexes, dispatch-chain indexes, aggregates, lowered builtins,
+  control flow, legacy interleaved compound-argument emission via
+  `args_first_emission(false)`, and other complex shapes.
 - `compile_predicate_to_wam/3` still returns text by default for compatibility
   with the existing targets. The default-output flip described below remains a
   later migration step after more callers consume items directly.

--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -56,11 +56,12 @@ the shared `compile_predicate_to_wam_items/3` producer now skips WAM text for
 single-clause facts, simple user-predicate calls, generic builtin calls, and
 compound body arguments with default args-first `set_*` ordering. It also skips
 WAM text for non-indexed linear multi-clause predicates made from the same
-simple clause shapes, while indexed multi-clause predicates and more complex
-predicate shapes still use the text-to-items bridge. The legacy
-`args_first_emission(false)` compound-argument order also remains on the bridge.
-As the native producer expands, the same explicit Python mode will skip WAM text
-for more predicates without changing the Python emitter.
+simple clause shapes, and for the simplest A1 `switch_on_constant` indexed
+variant when no extra dispatch chains are needed. A2 indexing, fallthrough
+indexes, dispatch-chain indexes, more complex predicate shapes, and the legacy
+`args_first_emission(false)` compound-argument order still use the text-to-items
+bridge. As the native producer expands, the same explicit Python mode will skip
+WAM text for more predicates without changing the Python emitter.
 
 Lua, R, and Elixir follow the same partial migration shape as Python:
 interpreter-mode generated predicates consume common WAM items through the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -206,8 +206,9 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
 %  Direct items path for simple predicates. This incremental native producer
 %  slice covers facts, simple user calls, generic builtin calls, compound body
 %  arguments using the default args-first set_* ordering, conjunctions of those
-%  shapes, and non-indexed linear multi-clause predicates composed of the same
-%  clause shapes. Aggregates, indexing, lowered builtins, control flow, legacy
+%  shapes, non-indexed linear multi-clause predicates composed of the same
+%  clause shapes, and the simplest A1 switch_on_constant indexed variant.
+%  Aggregates, dispatch-chain indexing, lowered builtins, control flow, legacy
 %  interleaved compound-arg emission, and other peephole-sensitive shapes
 %  intentionally fall back to the text bridge.
 compile_clauses_to_wam_items_native(Pred, Arity, [Clause], Options, Items) :-
@@ -215,6 +216,14 @@ compile_clauses_to_wam_items_native(Pred, Arity, [Clause], Options, Items) :-
     !,
     format(string(Label), "~w/~w", [Pred, Arity]),
     Items = [label(Label)|InstrItems].
+compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items) :-
+    Clauses = [_,_|_],
+    native_first_arg_constant_index_item(Pred, Arity, Clauses, SwitchItem),
+    length(Clauses, N),
+    compile_multi_clause_items_linear(Clauses, 1, N, Pred, Arity, Options, ClauseItems),
+    !,
+    format(string(Label), "~w/~w", [Pred, Arity]),
+    Items = [label(Label), SwitchItem|ClauseItems].
 compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items) :-
     Clauses = [_,_|_],
     \+ native_clauses_would_index(Pred, Arity, Clauses),
@@ -253,6 +262,22 @@ native_clauses_would_index(Pred, Arity, Clauses) :-
         build_second_arg_index(Pred, Arity, Clauses, _IndexHeader, _DispatchChains)
     ),
     !.
+
+native_first_arg_constant_index_item(Pred, Arity, Clauses, switch_on_constant(ItemEntries)) :-
+    classify_first_args(Clauses, Types),
+    Types = [_|_],
+    forall(member(Type, Types), Type = constant),
+    collect_const_groups(Clauses, 1, ConstGroups),
+    groups_to_entries_and_chains(ConstGroups, Pred, Arity, const,
+                                 Entries, ""),
+    Entries = [_|_],
+    index_entries_to_item_entries(Entries, ItemEntries).
+
+index_entries_to_item_entries([], []).
+index_entries_to_item_entries([Key-Label|Rest], [Entry|RestEntries]) :-
+    quote_wam_constant(Key, KeyString),
+    format(string(Entry), "~w:~w", [KeyString, Label]),
+    index_entries_to_item_entries(Rest, RestEntries).
 
 compile_multi_clause_items_linear([], _, _, _, _, _, []).
 compile_multi_clause_items_linear([Clause|Rest], I, N, Pred, Arity, Options, Items) :-

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -575,16 +575,47 @@ test_wam_items_native_linear_rule_clauses :-
     ;   fail_test(Test, 'Native linear rule items do not match canonical WAM text shape')
     ).
 
-test_wam_items_indexed_multi_clause_still_bridges :-
-    Test = 'WAM: indexed multi-clause items still use bridge',
+test_wam_items_native_switch_on_constant_index :-
+    Test = 'WAM: native items API for switch_on_constant indexed clauses',
+    ExpectedItems = [
+        label("test_parent/2"),
+        switch_on_constant(["alice:default", "bob:L_test_parent_2_2_body"]),
+        try_me_else("L_test_parent_2_2"),
+        get_constant("alice", "A1"),
+        get_constant("bob", "A2"),
+        proceed,
+        label("L_test_parent_2_2"),
+        trust_me,
+        label("L_test_parent_2_2_body"),
+        get_constant("bob", "A1"),
+        get_constant("charlie", "A2"),
+        proceed
+    ],
     (   wam_target:compile_predicate_to_wam_text(user:test_parent/2, [], TextCode),
         wam_text_to_items(TextCode, BridgeItems),
         wam_target:compile_predicate_to_wam_items(user:test_parent/2, [], Items),
+        wam_target:wam_predicate_clauses(user:test_parent/2, [], Pred, Arity, Clauses),
+        wam_target:compile_clauses_to_wam_items_native(Pred, Arity, Clauses, [], NativeItems),
+        NativeItems == ExpectedItems,
+        Items == ExpectedItems,
         Items == BridgeItems,
-        member(switch_on_constant(_), Items),
+        member(switch_on_constant(["alice:default", "bob:L_test_parent_2_2_body"]), Items),
         member(label("test_parent/2"), Items)
     ->  pass(Test)
-    ;   fail_test(Test, 'Indexed multi-clause predicate did not match bridge items')
+    ;   fail_test(Test, 'Native switch_on_constant items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_a2_indexed_multi_clause_still_bridges :-
+    Test = 'WAM: A2 indexed multi-clause items still use bridge',
+    (   wam_target:wam_predicate_clauses(user:test_a2_const/2, [], Pred, Arity, Clauses),
+        \+ wam_target:compile_clauses_to_wam_items_native(Pred, Arity, Clauses, [], _NativeItems),
+        wam_target:compile_predicate_to_wam_text(user:test_a2_const/2, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_a2_const/2, [], Items),
+        Items == BridgeItems,
+        member(switch_on_constant_a2(_), Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'A2 indexed multi-clause predicate did not remain on bridge')
     ).
 
 %% Run all tests
@@ -610,7 +641,8 @@ run_tests :-
     test_wam_items_compound_arg_legacy_order_fallback,
     test_wam_items_native_linear_fact_clauses,
     test_wam_items_native_linear_rule_clauses,
-    test_wam_items_indexed_multi_clause_still_bridges,
+    test_wam_items_native_switch_on_constant_index,
+    test_wam_items_a2_indexed_multi_clause_still_bridges,
     test_wam_multi_clause_findall_emits_allocate,
     test_wam_a2_indexing,
     test_wam_mixed_mode_a1_indexing,


### PR DESCRIPTION
## Summary

- extends the native WAM-items producer to emit the simplest A1 `switch_on_constant` indexed multi-clause predicates directly as items
- keeps A2 indexing, fallthrough indexes, dispatch-chain indexes, and complex predicate shapes on the text-to-items bridge
- adds tests that pin native output for `test_parent/2` against canonical text items and confirm A2 indexed predicates still bridge
- updates WAM items representation docs to describe the new native indexed slice and remaining bridge boundaries

## Tests

- `swipl -q -f tests/test_wam_target.pl`
- `swipl -q -f tests/test_wam_ir_mode.pl`
- `swipl -q -f tests/test_wam_text_parser.pl -g run_tests -t halt`
- `swipl -q -f tests/test_wam_python_target.pl`
- `swipl -q -f tests/test_wam_lua_generator.pl`
- `swipl -q -f tests/test_wam_elixir_target.pl`
- `swipl -q -f tests/test_wam_r_generator.pl`
- `git diff --check`
