### PR TITLE
chore: gitignore regenerable benchmark corpora + LMDB/CSR build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,23 @@ data/benchmark/50k_cats/
 data/benchmark/100k_cats/
 data/benchmark/500k_cats/
 data/benchmark/1m_cats/
+# Regenerable benchmark corpora (databases + extracted TSVs, built from Wikipedia dumps via the ingest
+# pipeline — ~13 GB; the curated 1k/10k/10x corpora stay tracked). Same convention as the dirs above.
+data/benchmark/100k_cats_resident_run/
+data/benchmark/simplewiki_cats/
+data/benchmark/simplewiki_articles/
+data/benchmark/enwiki_cats/
+data/benchmark/enwiki_cats_correct/
+data/benchmark/enwiki_articles/
+data/benchmark/enwiki_articles_hs/
+# LMDB databases + CSR build outputs anywhere (e.g. inside the tracked 10k/ corpus)
+*.mdb
+data/benchmark/**/lmdb/
+data/benchmark/**/lmdb_resident/
+data/benchmark/**/lmdb_scoped/
+data/benchmark/**/csr/
+# Playwright-MCP page-snapshot cache
+.playwright-mcp/
 test_input/
 output_*/
 


### PR DESCRIPTION
  ~13 GB of regenerable benchmark output was sitting stage-able in the working tree (incl. a 10 GB enwiki LMDB) and nearly
  got swept into an unrelated PR. This ignores it so it can't recur — the upcoming graph-widening round (#3313) will
  generate a fresh enwiki slice + multi-GB DB, so this should land first.

  **Ignored** (same convention as the existing `50k/100k/500k/1m_cats` rules):
  - Generated corpus dirs: `100k_cats_resident_run/`, `simplewiki_cats/`, `simplewiki_articles/`, `enwiki_cats/`,
  `enwiki_cats_correct/`, `enwiki_articles/`, `enwiki_articles_hs/`
  - Build artifacts anywhere under `data/benchmark/`: `*.mdb`, `**/lmdb/`, `**/lmdb_resident/`, `**/lmdb_scoped/`,
  `**/csr/`
  - `.playwright-mcp/` page-snapshot cache

  **Kept tracked** (curated, small): the `1k` / `10k` / `10x` corpora's source TSVs — only their generated LMDB/`.mdb` is
  ignored. The ingest scripts (`data/benchmark/build_*.py`) and docs stay trackable.

  No tracked files are removed; `.mdb` count in the repo is 0 both before and after.