### PR TITLE
feat(wam-clojure): support aggregate_all runtime modes

### DIFF
--- a/PR_WAM_CLOJURE_AGGREGATE_ALL_RUNTIME.md
+++ b/PR_WAM_CLOJURE_AGGREGATE_ALL_RUNTIME.md
@@ -1,0 +1,29 @@
+# PR Title
+
+feat(wam-clojure): support aggregate_all runtime modes
+
+# Description
+
+## Summary
+
+- Extends the Clojure WAM runtime aggregate finalizer beyond `findall`/`collect` to support `aggregate_all/3` modes: `count`, `sum`, `bag`, `set`, `min`, and `max`.
+- Uses existing runtime term ordering for `set` sorting/deduplication so generated results match SWI-style standard order for the covered cases.
+- Preserves SWI-compatible empty aggregate behavior: `count` and `sum` return `0`, `bag` and `set` return `[]`, and empty `min`/`max` fail.
+- Adds generated Clojure smoke coverage for the new aggregate modes, including negative assertions and empty-min failure.
+
+## Scope
+
+- This is sequential/runtime-mediated aggregate support for the existing WAM aggregate frame.
+- Direct `bagof/3` and `setof/3` are not changed here; the observed compiler path still emits them as runtime calls rather than Clojure WAM `begin_aggregate` instructions.
+- No lowered aggregate path or parallel aggregate execution is introduced in this PR.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
+- `swipl -q -s tests/test_wam_clojure_lowered_t4.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_lowered_ite_exec.pl`
+- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -225,7 +225,13 @@
 (defn restore-choice-regs [state saved-regs]
   (assoc state :regs saved-regs))
 
-(declare activate-choice copy-term list->term reg-get-raw)
+(declare activate-choice
+         copy-term
+         deref-value
+         list->term
+         parse-number-text
+         reg-get-raw
+         sorted-unique-terms)
 
 (defn choice-snapshot [state target-pc]
   {:kind :wam
@@ -284,11 +290,54 @@
           :else
           (recur (inc idx) depth))))))
 
+(defn aggregate-number-value [state value]
+  (let [value* (deref-value (:bindings state) value)]
+    (cond
+      (number? value*) value*
+      (string? value*) (parse-number-text value*)
+      (atom-term? value*) (parse-number-text (deintern-atom (:intern-context state) (:id value*)))
+      :else nil)))
+
+(defn aggregate-sum-term [state collected]
+  (loop [remaining (seq collected)
+         total 0]
+    (if remaining
+      (if-let [n (aggregate-number-value state (first remaining))]
+        (recur (next remaining) (+ total n))
+        ::aggregate-failure)
+      total)))
+
+(defn aggregate-extreme-term [state collected better?]
+  (if-let [items (seq collected)]
+    (if-let [first-number (aggregate-number-value state (first items))]
+      (loop [best first-number
+             remaining (next items)]
+        (if remaining
+          (if-let [n (aggregate-number-value state (first remaining))]
+            (recur (if (better? n best) n best) (next remaining))
+            ::aggregate-failure)
+          best))
+      ::aggregate-failure)
+    ::aggregate-failure))
+
+(defn aggregate-list-term [state collected]
+  (list->term (:intern-context state) collected))
+
+(defn aggregate-set-term [state collected]
+  (list->term (:intern-context state) (sorted-unique-terms state collected)))
+
 (defn aggregate-result-term [state kind collected]
   (case kind
     "count" (count collected)
-    "collect" (list->term (:intern-context state) collected)
-    (list->term (:intern-context state) collected)))
+    "sum" (aggregate-sum-term state collected)
+    "min" (aggregate-extreme-term state collected <)
+    "max" (aggregate-extreme-term state collected >)
+    "collect" (aggregate-list-term state collected)
+    "bag" (aggregate-list-term state collected)
+    "set" (aggregate-set-term state collected)
+    "bagof" (if (seq collected) (aggregate-list-term state collected) ::aggregate-failure)
+    "setof" (if (seq collected) (aggregate-set-term state collected) ::aggregate-failure)
+    (aggregate-list-term state collected)))
 
 (defn aggregate-choice-index [choice-points]
   (some (fn [[idx cp]]
@@ -2473,16 +2522,18 @@
     (apply-member-solution state (:pc cp) (:member-elem cp) (:member-rest cp))
 
     :aggregate
-    (let [bag (aggregate-result-term state (:aggregate-kind cp) (:aggregate-collected cp))
-          bag-reg (:aggregate-bag-reg cp)
-          current (or (reg-get-raw state bag-reg) ::unbound)
-          resumed-state (assoc state :pc (:aggregate-next-pc cp))
-          [ok next-state] (if (= current ::unbound)
-                            [true (reg-set-raw resumed-state bag-reg bag)]
-                            (unify-values resumed-state current bag))]
-      (if ok
-        next-state
-        (backtrack resumed-state)))
+    (let [bag (aggregate-result-term state (:aggregate-kind cp) (:aggregate-collected cp))]
+      (if (= bag ::aggregate-failure)
+        (backtrack state)
+        (let [bag-reg (:aggregate-bag-reg cp)
+              current (or (reg-get-raw state bag-reg) ::unbound)
+              resumed-state (assoc state :pc (:aggregate-next-pc cp))
+              [ok next-state] (if (= current ::unbound)
+                                [true (reg-set-raw resumed-state bag-reg bag)]
+                                (unify-values resumed-state current bag))]
+          (if ok
+            next-state
+            (backtrack resumed-state)))))
 
     (assoc state :status :running)))
 

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -18,6 +18,13 @@
 :- dynamic user:wam_findall_choice/1.
 :- dynamic user:wam_findall_member/1.
 :- dynamic user:wam_findall_empty/1.
+:- dynamic user:wam_agg_count/1.
+:- dynamic user:wam_agg_sum/1.
+:- dynamic user:wam_agg_bag/1.
+:- dynamic user:wam_agg_set/1.
+:- dynamic user:wam_agg_min/1.
+:- dynamic user:wam_agg_max/1.
+:- dynamic user:wam_agg_min_empty/1.
 :- dynamic user:wam_bind_then_fact/1.
 :- dynamic user:wam_bind_after_call/1.
 :- dynamic user:wam_bind_before_execute/1.
@@ -415,6 +422,13 @@ user:wam_choice_or_z(z).
 user:wam_findall_choice(L) :- findall(X, user:wam_choice_fact(X), L).
 user:wam_findall_member(L) :- findall(X, member(X, [a,b,c]), L).
 user:wam_findall_empty(L) :- findall(X, member(X, []), L).
+user:wam_agg_count(N) :- aggregate_all(count, member(_, [a,b,c]), N).
+user:wam_agg_sum(S) :- aggregate_all(sum(X), member(X, [1,2,3]), S).
+user:wam_agg_bag(L) :- aggregate_all(bag(X), member(X, [a,b,a]), L).
+user:wam_agg_set(L) :- aggregate_all(set(X), member(X, [b,a,b]), L).
+user:wam_agg_min(M) :- aggregate_all(min(X), member(X, [3,1,2]), M).
+user:wam_agg_max(M) :- aggregate_all(max(X), member(X, [3,1,2]), M).
+user:wam_agg_min_empty(M) :- aggregate_all(min(X), member(X, []), M).
 user:wam_bind_then_fact(X) :- Y = X, user:wam_fact(Y).
 user:wam_bind_after_call(X) :- user:wam_fact(X), X = a.
 user:wam_bind_before_execute(X) :- X = a, user:wam_fact(X).
@@ -813,6 +827,13 @@ run_smoke :-
           user:wam_findall_choice/1,
           user:wam_findall_member/1,
           user:wam_findall_empty/1,
+          user:wam_agg_count/1,
+          user:wam_agg_sum/1,
+          user:wam_agg_bag/1,
+          user:wam_agg_set/1,
+          user:wam_agg_min/1,
+          user:wam_agg_max/1,
+          user:wam_agg_min_empty/1,
           user:wam_bind_then_fact/1,
           user:wam_bind_after_call/1,
           user:wam_bind_before_execute/1,
@@ -1281,6 +1302,19 @@ smoke_cases([
     case('wam_findall_choice/1', '[a,b]', "false"),
     case('wam_findall_member/1', '[a,b,c]', "true"),
     case('wam_findall_empty/1', '[]', "true"),
+    case('wam_agg_count/1', 3, "true"),
+    case('wam_agg_count/1', 2, "false"),
+    case('wam_agg_sum/1', 6, "true"),
+    case('wam_agg_sum/1', 5, "false"),
+    case('wam_agg_bag/1', '[a,b,a]', "true"),
+    case('wam_agg_bag/1', '[a,b]', "false"),
+    case('wam_agg_set/1', '[a,b]', "true"),
+    case('wam_agg_set/1', '[b,a]', "false"),
+    case('wam_agg_min/1', 1, "true"),
+    case('wam_agg_min/1', 2, "false"),
+    case('wam_agg_max/1', 3, "true"),
+    case('wam_agg_max/1', 2, "false"),
+    case('wam_agg_min_empty/1', 0, "false"),
     case('wam_bind_then_fact/1', 'a', "true"),
     case('wam_bind_then_fact/1', 'b', "false"),
     case('wam_bind_after_call/1', 'a', "true"),
@@ -2556,6 +2590,7 @@ prolog_term_string_to_edn('[''4'']', "{:tag :struct :functor \"[|]/2\" :args [\"
 prolog_term_string_to_edn('[''4'',''2'']', "{:tag :struct :functor \"[|]/2\" :args [\"4\" {:tag :struct :functor \"[|]/2\" :args [\"2\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[f,a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[a,b,a]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[c]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
@@ -2596,6 +2631,7 @@ prolog_term_string_to_edn("['4']", "{:tag :struct :functor \"[|]/2\" :args [\"4\
 prolog_term_string_to_edn("['4','2']", "{:tag :struct :functor \"[|]/2\" :args [\"4\" {:tag :struct :functor \"[|]/2\" :args [\"2\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[f,a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn("[a,b,a]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[c]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.


### PR DESCRIPTION
## Summary

- Extends the Clojure WAM runtime aggregate finalizer beyond `findall`/`collect` to support `aggregate_all/3` modes: `count`, `sum`, `bag`, `set`, `min`, and `max`.
- Uses existing runtime term ordering for `set` sorting/deduplication so generated results match SWI-style standard order for the covered cases.
- Preserves SWI-compatible empty aggregate behavior: `count` and `sum` return `0`, `bag` and `set` return `[]`, and empty `min`/`max` fail.
- Adds generated Clojure smoke coverage for the new aggregate modes, including negative assertions and empty-min failure.

## Scope

- This is sequential/runtime-mediated aggregate support for the existing WAM aggregate frame.
- Direct `bagof/3` and `setof/3` are not changed here; the observed compiler path still emits them as runtime calls rather than Clojure WAM `begin_aggregate` instructions.
- No lowered aggregate path or parallel aggregate execution is introduced in this PR.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `swipl -q -s tests/test_wam_clojure_lowered_t4.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_lowered_ite_exec.pl`
- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
