### PR TITLE
feat(wam): emit native items for constant fallthrough indexes

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -17,11 +17,12 @@ The first implementation step is intentionally conservative:
   conjunctions of those simple shapes directly as items. The same native path
   also emits non-indexed linear multi-clause predicates when every clause has one
   of those supported simple shapes, plus the simplest A1 `switch_on_constant`
-  indexed variant when no extra dispatch chains are needed. It falls back to the
-  existing text generator plus `wam_text_to_items/2` for A2 indexing,
-  fallthrough indexes, dispatch-chain indexes, aggregates, lowered builtins,
-  control flow, legacy interleaved compound-argument emission via
-  `args_first_emission(false)`, and other complex shapes.
+  and `switch_on_constant_fallthrough` indexed variants when no extra dispatch
+  chains are needed. It falls back to the existing text generator plus
+  `wam_text_to_items/2` for A2 indexing, structure/term indexing,
+  dispatch-chain indexes, aggregates, lowered builtins, control flow, legacy
+  interleaved compound-argument emission via `args_first_emission(false)`, and
+  other complex shapes.
 - `compile_predicate_to_wam/3` still returns text by default for compatibility
   with the existing targets. The default-output flip described below remains a
   later migration step after more callers consume items directly.

--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -56,12 +56,13 @@ the shared `compile_predicate_to_wam_items/3` producer now skips WAM text for
 single-clause facts, simple user-predicate calls, generic builtin calls, and
 compound body arguments with default args-first `set_*` ordering. It also skips
 WAM text for non-indexed linear multi-clause predicates made from the same
-simple clause shapes, and for the simplest A1 `switch_on_constant` indexed
-variant when no extra dispatch chains are needed. A2 indexing, fallthrough
-indexes, dispatch-chain indexes, more complex predicate shapes, and the legacy
-`args_first_emission(false)` compound-argument order still use the text-to-items
-bridge. As the native producer expands, the same explicit Python mode will skip
-WAM text for more predicates without changing the Python emitter.
+simple clause shapes, and for the simplest A1 `switch_on_constant` and
+`switch_on_constant_fallthrough` indexed variants when no extra dispatch chains
+are needed. A2 indexing, structure/term indexing, dispatch-chain indexes, more
+complex predicate shapes, and the legacy `args_first_emission(false)`
+compound-argument order still use the text-to-items bridge. As the native
+producer expands, the same explicit Python mode will skip WAM text for more
+predicates without changing the Python emitter.
 
 Lua, R, and Elixir follow the same partial migration shape as Python:
 interpreter-mode generated predicates consume common WAM items through the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -207,8 +207,8 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
 %  slice covers facts, simple user calls, generic builtin calls, compound body
 %  arguments using the default args-first set_* ordering, conjunctions of those
 %  shapes, non-indexed linear multi-clause predicates composed of the same
-%  clause shapes, and the simplest A1 switch_on_constant indexed variant.
-%  Aggregates, dispatch-chain indexing, lowered builtins, control flow, legacy
+%  clause shapes, and the simplest A1 switch_on_constant / fallthrough indexed
+%  variants. Aggregates, dispatch-chain indexing, lowered builtins, control flow, legacy
 %  interleaved compound-arg emission, and other peephole-sensitive shapes
 %  intentionally fall back to the text bridge.
 compile_clauses_to_wam_items_native(Pred, Arity, [Clause], Options, Items) :-
@@ -219,6 +219,14 @@ compile_clauses_to_wam_items_native(Pred, Arity, [Clause], Options, Items) :-
 compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items) :-
     Clauses = [_,_|_],
     native_first_arg_constant_index_item(Pred, Arity, Clauses, SwitchItem),
+    length(Clauses, N),
+    compile_multi_clause_items_linear(Clauses, 1, N, Pred, Arity, Options, ClauseItems),
+    !,
+    format(string(Label), "~w/~w", [Pred, Arity]),
+    Items = [label(Label), SwitchItem|ClauseItems].
+compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items) :-
+    Clauses = [_,_|_],
+    native_first_arg_constant_fallthrough_index_item(Pred, Arity, Clauses, SwitchItem),
     length(Clauses, N),
     compile_multi_clause_items_linear(Clauses, 1, N, Pred, Arity, Options, ClauseItems),
     !,
@@ -270,6 +278,17 @@ native_first_arg_constant_index_item(Pred, Arity, Clauses, switch_on_constant(It
     collect_const_groups(Clauses, 1, ConstGroups),
     groups_to_entries_and_chains(ConstGroups, Pred, Arity, const,
                                  Entries, ""),
+    Entries = [_|_],
+    index_entries_to_item_entries(Entries, ItemEntries).
+
+native_first_arg_constant_fallthrough_index_item(Pred, Arity, Clauses,
+                                                switch_on_constant_fallthrough(ItemEntries)) :-
+    classify_first_args(Clauses, Types),
+    member(variable, Types),
+    indexed_prefix(Types, Clauses, PrefixTypes, PrefixClauses),
+    PrefixClauses = [_|_],
+    forall(member(Type, PrefixTypes), Type = constant),
+    build_constant_index(PrefixClauses, 1, Pred, Arity, Entries),
     Entries = [_|_],
     index_entries_to_item_entries(Entries, ItemEntries).
 

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -605,15 +605,58 @@ test_wam_items_native_switch_on_constant_index :-
     ;   fail_test(Test, 'Native switch_on_constant items do not match canonical WAM text shape')
     ).
 
+test_wam_items_native_switch_on_constant_fallthrough_index :-
+    Test = 'WAM: native items API for switch_on_constant_fallthrough indexed clauses',
+    ExpectedItems = [
+        label("test_mma_middle/2"),
+        switch_on_constant_fallthrough(["a:default"]),
+        try_me_else("L_test_mma_middle_2_2"),
+        get_constant("a", "A1"),
+        get_constant("1", "A2"),
+        proceed,
+        label("L_test_mma_middle_2_2"),
+        retry_me_else("L_test_mma_middle_2_3"),
+        label("L_test_mma_middle_2_2_body"),
+        get_variable("X1", "A1"),
+        get_constant("99", "A2"),
+        proceed,
+        label("L_test_mma_middle_2_3"),
+        trust_me,
+        label("L_test_mma_middle_2_3_body"),
+        get_constant("b", "A1"),
+        get_constant("2", "A2"),
+        proceed
+    ],
+    (   wam_target:compile_predicate_to_wam_text(user:test_mma_middle/2, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_mma_middle/2, [], Items),
+        wam_target:wam_predicate_clauses(user:test_mma_middle/2, [], Pred, Arity, Clauses),
+        wam_target:compile_clauses_to_wam_items_native(Pred, Arity, Clauses, [], NativeItems),
+        NativeItems == ExpectedItems,
+        Items == ExpectedItems,
+        Items == BridgeItems,
+        member(switch_on_constant_fallthrough(["a:default"]), Items),
+        member(label("test_mma_middle/2"), Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Native switch_on_constant_fallthrough items do not match canonical WAM text shape')
+    ).
+
 test_wam_items_a2_indexed_multi_clause_still_bridges :-
     Test = 'WAM: A2 indexed multi-clause items still use bridge',
-    (   wam_target:wam_predicate_clauses(user:test_a2_const/2, [], Pred, Arity, Clauses),
-        \+ wam_target:compile_clauses_to_wam_items_native(Pred, Arity, Clauses, [], _NativeItems),
+    (   wam_target:wam_predicate_clauses(user:test_a2_const/2, [], Pred1, Arity1, Clauses1),
+        \+ wam_target:compile_clauses_to_wam_items_native(Pred1, Arity1, Clauses1, [], _NativeItems1),
         wam_target:compile_predicate_to_wam_text(user:test_a2_const/2, [], TextCode),
         wam_text_to_items(TextCode, BridgeItems),
         wam_target:compile_predicate_to_wam_items(user:test_a2_const/2, [], Items),
         Items == BridgeItems,
-        member(switch_on_constant_a2(_), Items)
+        member(switch_on_constant_a2(_), Items),
+        wam_target:wam_predicate_clauses(user:test_mma2_trailing/3, [], Pred2, Arity2, Clauses2),
+        \+ wam_target:compile_clauses_to_wam_items_native(Pred2, Arity2, Clauses2, [], _NativeItems2),
+        wam_target:compile_predicate_to_wam_text(user:test_mma2_trailing/3, [], TextCode2),
+        wam_text_to_items(TextCode2, BridgeItems2),
+        wam_target:compile_predicate_to_wam_items(user:test_mma2_trailing/3, [], Items2),
+        Items2 == BridgeItems2,
+        member(switch_on_constant_a2_fallthrough(_), Items2)
     ->  pass(Test)
     ;   fail_test(Test, 'A2 indexed multi-clause predicate did not remain on bridge')
     ).
@@ -642,6 +685,7 @@ run_tests :-
     test_wam_items_native_linear_fact_clauses,
     test_wam_items_native_linear_rule_clauses,
     test_wam_items_native_switch_on_constant_index,
+    test_wam_items_native_switch_on_constant_fallthrough_index,
     test_wam_items_a2_indexed_multi_clause_still_bridges,
     test_wam_multi_clause_findall_emits_allocate,
     test_wam_a2_indexing,


### PR DESCRIPTION
## Summary

- extends the native WAM-items producer to emit A1 `switch_on_constant_fallthrough` indexed predicates directly as items
- reuses the existing linear multi-clause item emitter so output remains canonical and bridge-equivalent
- keeps A2 indexing, A2 fallthrough indexing, structure/term indexing, dispatch-chain indexes, and complex predicate shapes on the text-to-items bridge
- adds tests that pin native output for `test_mma_middle/2` and confirm A2 indexed and A2 fallthrough predicates still bridge
- updates WAM items representation docs to describe the expanded native indexed slice and remaining bridge boundaries

## Tests

- `swipl -q -f tests/test_wam_target.pl`
- `swipl -q -f tests/test_wam_ir_mode.pl`
- `swipl -q -f tests/test_wam_text_parser.pl -g run_tests -t halt`
- `swipl -q -f tests/test_wam_python_target.pl`
- `swipl -q -f tests/test_wam_lua_generator.pl`
- `swipl -q -f tests/test_wam_elixir_target.pl`
- `swipl -q -f tests/test_wam_r_generator.pl`
- `git diff --check`
