### PR TITLE
Feat/wam go stream eof output

### DIFF
--- a/PR_go_wam_stream_eof_output.md
+++ b/PR_go_wam_stream_eof_output.md
@@ -1,0 +1,29 @@
+# PR Title
+
+Add Go WAM stream EOF and helper output builtins
+
+# PR Description
+
+## Summary
+
+- Registers `at_end_of_stream/1`, `write_to_stream/2`, and `nl_to_stream/1` as direct Go WAM builtins.
+- Adds Go WAM runtime support for non-consuming file-backed EOF checks and simple helper output to writable streams.
+- Extends the generated Go builtin E2E test to cover EOF before and after reads, closed-stream failure, helper output, and read-stream output failure.
+- Updates the Go WAM parity audit to record the Python/C++-aligned stream EOF and helper-output surface.
+
+## Tests
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+
+## Push Command
+
+```sh
+git push -u origin feat/wam-go-stream-eof-output
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -21,7 +21,7 @@ current cross-target builtin/runtime baseline.
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
 | Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Present for current baseline, including isolated user-goal NAF and race-to-true over multi-clause WAM targets |
-| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `write_canonical/1`, `put_char/1`, `put_char/2`, `put_code/1`, `put_code/2`, `get_char/1`, `get_char/2`, `peek_char/1`, `peek_char/2`, `get_code/1`, `get_code/2`, `open/3`, `close/1`, `read_line_to_string/2`, `read_string/5`, `format/1`, `format/2`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; Python/C++ also cover `write_canonical/1`; Python/C++/LLVM also cover `put_char/1` and `put_code/1`; Python also covers default-stream `get_char/1`, `peek_char/1`, and `get_code/1` plus file-backed stream char IO, line reads, and bounded chunk reads; R/C++/Python also cover `format/N`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, bounded canonical output, single-character output, default and file-backed stream character IO, bounded line/chunk reads, bounded format output, tab output, and bounded environment access |
+| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `write_canonical/1`, `put_char/1`, `put_char/2`, `put_code/1`, `put_code/2`, `get_char/1`, `get_char/2`, `peek_char/1`, `peek_char/2`, `get_code/1`, `get_code/2`, `open/3`, `close/1`, `read_line_to_string/2`, `read_string/5`, `at_end_of_stream/1`, `write_to_stream/2`, `nl_to_stream/1`, `format/1`, `format/2`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; Python/C++ also cover `write_canonical/1`; Python/C++/LLVM also cover `put_char/1` and `put_code/1`; Python also covers default-stream `get_char/1`, `peek_char/1`, and `get_code/1` plus file-backed stream char IO, line reads, bounded chunk reads, EOF checks, and stream output helpers; C++ also covers stream EOF checks and helper output; R/C++/Python also cover `format/N`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, bounded canonical output, single-character output, default and file-backed stream character IO, bounded line/chunk reads, stream EOF checks, helper stream output, bounded format output, tab output, and bounded environment access |
 
 ## Immediate Findings
 
@@ -91,6 +91,11 @@ current cross-target builtin/runtime baseline.
   the generated builtin E2E test for bounded chunk reads, short EOF reads, and
   zero-count EOF reads, matching the bounded Python chunk-reader surface while
   leaving separator output behavior outside this slice.
+- File-backed `at_end_of_stream/1`, `write_to_stream/2`, and `nl_to_stream/1`
+  are now direct Go WAM builtins and are covered by the generated builtin E2E
+  test for non-consuming EOF checks, EOF after bounded reads, closed-stream
+  failure, simple helper output, and read-stream output failure, matching the
+  bounded Python/C++ stream EOF and helper-output surface.
 - Bounded `format/1` and `format/2` are now direct Go WAM builtins and are
   covered by the generated builtin E2E test for literal `~~`, newline `~n`,
   `~w`, `~a`, `~d`, `~p`, `~q`, and `~s` argument substitution, and

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -600,6 +600,15 @@ wam_go_direct_builtin("read_line_to_string/2", 2, 'read_line_to_string/2').
 wam_go_direct_builtin(read_string/5, 5, 'read_string/5').
 wam_go_direct_builtin('read_string/5', 5, 'read_string/5').
 wam_go_direct_builtin("read_string/5", 5, 'read_string/5').
+wam_go_direct_builtin(at_end_of_stream/1, 1, 'at_end_of_stream/1').
+wam_go_direct_builtin('at_end_of_stream/1', 1, 'at_end_of_stream/1').
+wam_go_direct_builtin("at_end_of_stream/1", 1, 'at_end_of_stream/1').
+wam_go_direct_builtin(write_to_stream/2, 2, 'write_to_stream/2').
+wam_go_direct_builtin('write_to_stream/2', 2, 'write_to_stream/2').
+wam_go_direct_builtin("write_to_stream/2", 2, 'write_to_stream/2').
+wam_go_direct_builtin(nl_to_stream/1, 1, 'nl_to_stream/1').
+wam_go_direct_builtin('nl_to_stream/1', 1, 'nl_to_stream/1').
+wam_go_direct_builtin("nl_to_stream/1", 1, 'nl_to_stream/1').
 wam_go_direct_builtin(format/1, 1, 'format/1').
 wam_go_direct_builtin('format/1', 1, 'format/1').
 wam_go_direct_builtin("format/1", 1, 'format/1').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1920,6 +1920,13 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return false
 		}
 		return vm.Unify(arg5, internAtom(text))
+	case "at_end_of_stream/1":
+		_, eof, ok := peekStreamRune(vm.deref(arg1))
+		return ok && eof
+	case "write_to_stream/2":
+		return writeStreamText(vm.deref(arg1), vm.deref(arg2).String())
+	case "nl_to_stream/1":
+		return writeStreamText(vm.deref(arg1), "\n")
 	case "writeln/1":
 		fmt.Println(vm.deref(arg1).String())
 		return true

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -738,6 +738,33 @@ test(builtins_execution) :-
                 close(S),
                 \+ read_string(S, 1, _, _, _)
             )),
+          assertz(user:test_stream_eof_builtin :-
+            (   open('eof.txt', read, S),
+                \+ at_end_of_stream(S),
+                peek_char(S, C0), C0 = a,
+                \+ at_end_of_stream(S),
+                get_char(S, C1), C1 = a,
+                \+ at_end_of_stream(S),
+                read_string(S, 1, N, _, S1), N =:= 1, S1 = b,
+                at_end_of_stream(S),
+                read_string(S, 1, N2, _, S2), N2 =:= 0, atom_length(S2, 0),
+                at_end_of_stream(S),
+                close(S),
+                \+ at_end_of_stream(S)
+            )),
+          assertz(user:test_stream_output_helper_builtin :-
+            (   open('stream_helpers.txt', write, Out),
+                write_to_stream(Out, alpha),
+                nl_to_stream(Out),
+                write_to_stream(Out, beta),
+                close(Out),
+                \+ write_to_stream(Out, closed),
+                \+ nl_to_stream(Out),
+                open('stream_helpers.txt', read, In),
+                \+ write_to_stream(In, bad),
+                \+ nl_to_stream(In),
+                close(In)
+            )),
           assertz(user:test_format_builtin :-
             (   format('fmt_one ~~ ok~n'),
                 format('fmt_two ~w ~w~~~n', [go, 42]),
@@ -812,6 +839,8 @@ test(builtins_execution) :-
           retractall(user:test_stream_char_io_builtin),
           retractall(user:test_read_line_builtin),
           retractall(user:test_read_string_builtin),
+          retractall(user:test_stream_eof_builtin),
+          retractall(user:test_stream_output_helper_builtin),
           retractall(user:test_format_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
@@ -822,7 +851,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_output_builtin/0, test_char_input_builtin/0, test_stream_char_io_builtin/0, test_read_line_builtin/0, test_read_string_builtin/0, test_format_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_output_builtin/0, test_char_input_builtin/0, test_stream_char_io_builtin/0, test_read_line_builtin/0, test_read_string_builtin/0, test_stream_eof_builtin/0, test_stream_output_helper_builtin/0, test_format_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -905,6 +934,9 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "close/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "read_line_to_string/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "read_string/5"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "at_end_of_stream/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "write_to_stream/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "nl_to_stream/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "format/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "format/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
@@ -1333,6 +1365,30 @@ func main() {
 		fmt.Println("READ_STRING_FAILURE")
 	}
 
+	if writeErr := os.WriteFile("eof.txt", []byte("ab"), 0644); writeErr != nil {
+		panic(writeErr)
+	}
+	streamEofVM := wam.NewWamState(wam.Test_stream_eof_builtinCode, wam.Test_stream_eof_builtinLabels)
+	streamEofVM.PC = wam.Test_stream_eof_builtinStartPC
+	if streamEofVM.Run() {
+		fmt.Println("STREAM_EOF_SUCCESS")
+	} else {
+		fmt.Println("STREAM_EOF_FAILURE")
+	}
+
+	streamOutputHelperVM := wam.NewWamState(wam.Test_stream_output_helper_builtinCode, wam.Test_stream_output_helper_builtinLabels)
+	streamOutputHelperVM.PC = wam.Test_stream_output_helper_builtinStartPC
+	if streamOutputHelperVM.Run() {
+		fmt.Println("STREAM_OUTPUT_HELPER_SUCCESS")
+	} else {
+		fmt.Println("STREAM_OUTPUT_HELPER_FAILURE")
+	}
+	streamHelperOut, streamHelperErr := os.ReadFile("stream_helpers.txt")
+	if streamHelperErr != nil {
+		panic(streamHelperErr)
+	}
+	fmt.Printf("STREAM_OUTPUT_HELPER_OUTPUT=%q\\n", string(streamHelperOut))
+
 	formatVM := wam.NewWamState(wam.Test_format_builtinCode, wam.Test_format_builtinLabels)
 	formatVM.PC = wam.Test_format_builtinStartPC
 	if formatVM.Run() {
@@ -1436,6 +1492,9 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "STREAM_CHAR_IO_OUTPUT=\"xy\\n\"")),
         assertion(sub_string(FullOutput, _, _, _, "READ_LINE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "READ_STRING_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "STREAM_EOF_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "STREAM_OUTPUT_HELPER_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "STREAM_OUTPUT_HELPER_OUTPUT=\"alpha\\nbeta\"")),
         assertion(sub_string(FullOutput, _, _, _, "'Hello World'")),
         assertion(sub_string(FullOutput, _, _, _, "[a, 'two words', 42]")),
         assertion(sub_string(FullOutput, _, _, _, "pair('two words', 7)")),


### PR DESCRIPTION
# Add Go WAM stream EOF and helper output builtins

## Summary

- Registers `at_end_of_stream/1`, `write_to_stream/2`, and `nl_to_stream/1` as direct Go WAM builtins.
- Adds Go WAM runtime support for non-consuming file-backed EOF checks and simple helper output to writable streams.
- Extends the generated Go builtin E2E test to cover EOF before and after reads, closed-stream failure, helper output, and read-stream output failure.
- Updates the Go WAM parity audit to record the Python/C++-aligned stream EOF and helper-output surface.

## Tests

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`

## Push Command

```sh
git push -u origin feat/wam-go-stream-eof-output
```
