### PR TITLE
mu_cosine(docs): TECHNIQUES.md — practical guide to the new machinery

### DIFF
--- a/prototypes/mu_cosine/README.md
+++ b/prototypes/mu_cosine/README.md
@@ -6,6 +6,11 @@ WAM-Rust target) can run on domains where only a sparse set of categories has be
 
 This is a **separate project, prototyped on a branch** — it is Python/ML, not the Rust/Prolog core.
 
+> **New here? Start with [`TECHNIQUES.md`](TECHNIQUES.md)** — a practical guide to the multi-operator model
+> (`SYM`/`WIKI`/`ELEM`/`LLM`), the data-acquisition toolchain (category slices → page frontier → Pearltrees
+> gap-fill), and the find-weak → supplement → retrain loop, with runnable commands. Deep theory:
+> [`DESIGN_calibrated_judges.md`](DESIGN_calibrated_judges.md).
+
 ## Status & handoff (read this first)
 
 **Status:** merged to `main` (via #3280); the torch port + direct-embedding comparison are folded in

--- a/prototypes/mu_cosine/TECHNIQUES.md
+++ b/prototypes/mu_cosine/TECHNIQUES.md
@@ -1,0 +1,160 @@
+# Techniques guide — μ-attention: operators, data acquisition, and the weak-node loop
+
+A practical map of the machinery added on top of the base μ-cosine prototype: the **multi-operator /
+multi-corpus model**, the **data-acquisition toolchain** (category slices → page frontier → Pearltrees
+gap-fill), and the **find-weak → supplement → retrain loop**. Theory here is in brief with pointers; the
+deep treatments are `DESIGN_calibrated_judges.md` (judges, calibration, range targets, node-types) and
+`DESIGN_sampling_and_grading.md` (sampling + instruct grading + test matrix). Findings live in the
+`REPORT_*` files (cited inline).
+
+---
+
+## 1. The conceptual model
+
+Everything trains one quantity: **μ(node | root) ∈ [0,1]**, directional fuzzy membership. Four codebooks
+condition it (`mu_attention.py`), each answering a different question — all factored, additive, and
+(provenance) **maskable**, so the model learns a provenance-agnostic default plus conditioned variants:
+
+| axis | question | values (today) | mechanism |
+|---|---|---|---|
+| **operator** (`OPS`) | what *relation*? | `SYM` (graded symmetric), `WIKI` (subcat, directional, free), `ELEM` (page/collection membership, directional+graded), `LLM` (frozen fixture) | operator token + per-op **readout row** on a shared trunk |
+| **corpus** (`CORPORA`) | which *source graph*? | `simplewiki`, `enwiki`, (`pearltrees`) | `corpus_emb`, in the maskable provenance token |
+| **judge** (`JUDGES`) | who *graded* it? | `haiku` (bought LLM), `graph` (free structural), (`human`) | `judge_emb`, same token |
+| **node-type** (planned, §7 of the design doc) | what is each *endpoint*? | category, page, mindmap, pearltrees | factored token (not yet implemented) |
+
+The **operator is the key idea**: a relation gets its own token + readout on a *shared* transformer trunk,
+so the trunk learns the common "membership geometry" once and each operator embedding carries only the
+delta. That's why page-membership needed `ELEM` (see §3). Full theory — including calibrating the graph
+judge's target and supervising **ranges** instead of points — in `DESIGN_calibrated_judges.md`.
+
+---
+
+## 2. Data-acquisition toolchain (how-to)
+
+All tools are reusable and live in this directory. The pair-file format is
+`a · b · stratum · wl · μ · [relation · a_type · b_type · corpus · url]` — the first 5 columns are read by
+`load_pairs`; extras are ignored (so tagged page/pearltrees rows stay backward-compatible).
+
+| step | tool | what it does |
+|---|---|---|
+| 1. slice | `build_slice.py` | streaming-BFS neighbourhood of seed roots over the 615 MB full enwiki graph (downward closure + one level up + apex-capped siblings). The full graph OOMs if loaded. |
+| 2a. category pairs | `gen_boundary_pairs.py`, `gen_*_pairs.py` | down/bidir candidate pairs over a slice, e5-coherence-filtered, deduped vs the cumulative |
+| 2b. **page** pairs | `fetch_category_pages.py` → `gen_page_pairs.py` | pull category **member pages** via the MediaWiki API (`cmtype=page`), emit `element_of` candidates (page→category) |
+| 2c. **pearltrees** pairs | `fetch_pearltrees_tree.py` → `gen_pearltrees_pairs.py` | harvest a Pearltrees tree (cookie session; collections/pages/shortcuts) for topics enwiki has no category for; PagePearl `url`s carry the enwiki anchor |
+| 3. grade | (inline Haiku subagents) | 6-band centrality rubric — see `DESIGN_sampling_and_grading.md` §3 (the "instruct grading" technique) |
+| 4. select | `select_diverse.py` | optional quality×diversity pruning (drop μ<0.4 junk, then quality-weighted farthest-point ≈ DPP-MAP). At small scale keep all; see `REPORT_page_selection.md` |
+| 5. assemble | `make_cumulative.sh` | union all `mu_pairs_scored_<round>_<yymmdd-HHMMSS>.tsv` into the (gitignored) cumulative + prior replay sets |
+
+Filenames: scored rounds are timestamped `mu_pairs_scored_<round>_<yymmdd-HHMMSS>.tsv` (first-commit time,
+**Mountain Time**); candidate + cumulative files are gitignored (regenerable). After adding a round, list
+it in `make_cumulative.sh`'s `ROUNDS`.
+
+### Example — a category round
+
+```bash
+python3 build_slice.py --root Network_theory --root Dynamical_systems --depth 2 \
+    --out ../../data/benchmark/wide_enwiki_systheory/category_parent.tsv
+UW_MU_GRAPH=../../data/benchmark/wide_enwiki_systheory/category_parent.tsv \
+  python3 gen_boundary_pairs.py --down Network_theory --bidir Networks \
+    --coh-keep Mathematics,Computer_science,Engineering --out mu_pairs_systheory.tsv
+# → Haiku-grade the non-neg pairs → mu_pairs_scored_systheory_<ts>.tsv → add to make_cumulative.sh
+```
+
+### Example — a page round (the page frontier)
+
+```bash
+python3 fetch_category_pages.py --cat Bifurcation_theory --cat Ergodic_theory --out page_members.tsv
+python3 gen_page_pairs.py --members page_members.tsv --out mu_pairs_pages.tsv
+# → Haiku-grade CENTRALITY (element-of template) → mu_pairs_scored_pages_<ts>.tsv
+```
+
+`element_of` rows are tagged `relation=element_of, a_type=category, b_type=page`; the membership *fact* is
+free (a listed page IS a member) + free μ=0 negatives, **Haiku grades the centrality** (core 1.0 →
+peripheral 0.4 → mis-categorized 0.0). See `REPORT_train_consolidation.md` for why this matters.
+
+---
+
+## 3. The element-of operator (`ELEM`)
+
+**Why.** Page-membership ("article is *about* topic") is a different relation than subcategory membership
+("subfield is *part of* topic"). Fed as undifferentiated `SYM` positives, page labels were **inert** —
+the model couldn't rank centrality (corr +0.0–0.4 vs +0.85+ for categories), and a fine-tune barely beat
+a placebo that never saw them (`REPORT_train_consolidation.md`).
+
+**What.** `OPS["ELEM"]=3` — a 4th operator token + readout row on the shared trunk. **Directional** like
+`WIKI` (μ(page|category) high, reverse low) but **graded** like `SYM` (Haiku centrality target). Loss:
+`MSE(μ(page|cat), target) + margin·relu(m − (μ(page|cat) − μ(cat|page)))` on positives. `--elem-weight`
+tunes it. Rows route by their `relation` column. Warm-start across the op-count change is **partial**:
+overlapping weights copy, op-indexed tensors grow, and the new `ELEM` row is **seeded from `SYM`**.
+
+**Result + the capacity finding.** ELEM lifts page-centrality sharply (`pos_pageof_nonlinear`
++0.12 → +0.795). At 2 layers, full ELEM weight cost cross-domain discrimination (90%→79%, though top-2
+stayed 100% — all misses razor-thin multi-membership flips). **Adding a 3rd layer recovered discrimination
+fully (90%) at full ELEM weight while keeping the page gains** → it was a *capacity* limit, not data, and
+frozen e5-small (384-d) is rich enough. **`--layers` default is now 3.** Full grid:
+`REPORT_element_operator.md`.
+
+---
+
+## 4. Training & evaluation (how-to)
+
+Fine-tune-with-replay (continual learning — warm-start, mix a replay fraction of old data so the head
+doesn't forget):
+
+```bash
+UW_MU_GRAPH=…/wide_enwiki_math/category_parent.tsv UW_E5_CACHE=e5_tables_train_all.pt \
+python3 train_mu_attention.py \
+  --pairs mu_pairs_scored_cumulative.tsv --replay-pairs mu_pairs_scored_prior.tsv \
+  --init-from <baseline>.pt --pairs-corpus enwiki --lr 1.5e-4 --steps 600 --layers 3 --save model_new.pt
+```
+
+- **e5 union (important):** `train`/`eval` union every `--pairs`/`--replay` node into the e5 build, so
+  cold-start endpoints (cross-slice, page, pearltrees nodes) get a frozen embedding instead of being
+  silently dropped by the `in idx` filter. This is what makes new data actually train.
+- **Built-in eval** (per-operator): `[SYM]` held-out μ corr, `[ELEM]` held-out centrality corr + direction,
+  `[WIKI]` edge order-accuracy, gate-leak (5-probe + OOD), 6-domain discrimination + ranking/margin,
+  provenance Δ.
+- **Per-stratum corr:** `eval_per_stratum.py --model M.pt --pairs <scored>` — routes `element_of` strata
+  to `ELEM` directionally, the rest to `SYM`. The honest read on *which* rounds' ranking generalised.
+- **Drift control (always):** a **placebo** run (`--pairs <prior>`, no new data) on the same warm start —
+  any movement above placebo is the new data's real contribution, not churn. This pattern recurs across
+  every `REPORT_*`.
+
+---
+
+## 5. The weak-node loop (the acquisition policy)
+
+The data strategy, end to end: **find where the model is weak in an area of interest, supplement those
+nodes with page data, retrain, re-measure.**
+
+```bash
+# 1. find targets: THIN (few subcats) ∧ in REGION (closure of seeds) ∧ WEAK (low e5 domain margin)
+python3 find_data_gaps.py --region-root Systems_theory --region-root Dynamical_systems \
+    --max-subcats 3 --margin-max 0.18 --top 30 --page-counts
+# 2. harvest their pages → 3. Haiku centrality → 4. fold into cumulative → 5. train --layers 3 → re-eval
+```
+
+- **Why e5-margin = "weak":** the model's discrimination is e5-driven, so a node with low top1−top2 cosine
+  to the domain roots is one e5 (and thus the model) can't place confidently — the ex-ante predictor of
+  model weakness. Validated: the finder independently flagged `Ergodic_theory`, the exact stratum the
+  trained model ranked worst, and supplementing it nudged its corr up (`REPORT_page_selection.md`).
+- **How much to keep per category:** at few-hundred-page scale, **keep all (prune only μ<0.4 junk)** — the
+  ELEM operator is data-hungry and "redundant" pages carry distinct centrality; the diversity A/B
+  (`select_diverse.py`, `REPORT_page_selection.md`) favoured the full set. Quality×diversity selection is
+  the knob for larger scale (needs a disjoint held-out to measure fairly).
+
+---
+
+## 6. Where to read more
+
+| topic | doc |
+|---|---|
+| judges, calibration, range targets, node-types, relation operators, page frontier (theory) | `DESIGN_calibrated_judges.md` |
+| sampling modes, instruct grading rubric, data-rejection, test matrix, storage | `DESIGN_sampling_and_grading.md` |
+| directional attention architecture | `DESIGN_directional_attention.md` |
+| element-of operator + capacity finding | `REPORT_element_operator.md` |
+| consolidation train+eval (page-as-SYM is inert) | `REPORT_train_consolidation.md` |
+| targeted supplementation + diversity A/B | `REPORT_page_selection.md` |
+| per-region round findings | `REPORT_math_fields.md` (§§7–12), `REPORT_widen_enwiki.md`, … |
+
+Everything here is the **prototype** (`prototypes/mu_cosine/`); none of it touches the WAM-Rust core.


### PR DESCRIPTION
Single practical guide tying this session's additions together (theory in brief +
runnable how-to), cross-referencing the deep DESIGN_/REPORT_ docs:
- the multi-operator / multi-corpus / judge / node-type conceptual model;
- the data-acquisition toolchain (build_slice → gen_*_pairs → fetch_category_pages /
  fetch_pearltrees_tree → Haiku grading → select_diverse → make_cumulative), with
  category-round and page-round command examples;
- the element-of operator (why page-membership is its own relation; the 3-layer
  capacity finding) and how to route element_of rows;
- training + eval (fine-tune-with-replay, the e5-union, per-operator/per-stratum eval,
  the placebo drift control);
- the weak-node loop (find_data_gaps → harvest → grade → train 3L → re-measure) and the
  "keep all vs diversity-prune" guidance.
README points to it as the entry point.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>