### PR TITLE
mu_cosine: SVD/mu-coverage page selector + subcategory augmentation

### DIFF
--- a/prototypes/mu_cosine/REPORT_page_selection.md
+++ b/prototypes/mu_cosine/REPORT_page_selection.md
@@ -52,6 +52,25 @@ Two honest caveats on *why* this isn't a refutation of the diversity idea:
    **larger scale** (redundancy + compute bite) and needs a **disjoint held-out** (excluding pruned pages)
    to measure fairly — not at few-hundred-page scale where quantity dominates.
 
+**Method, precisely (documenting what was actually run).** `select_diverse.py` is **greedy
+quality-weighted farthest-point** on e5 cosine (drop μ<0.4, seed highest-Haiku, then add the page
+maximising `centrality·(1 − max cos to picked)`) — a cheap **DPP-MAP proxy, NOT a PCA/SVD decomposition**.
+PCA/SVD was the *suggested* framing. It is now **implemented as `select_svd_coverage.py`**: take the top-K
+SVD axes of the page-embedding matrix and keep a subset covering the **μ distribution along each axis**
+(both ends × low/mid/high μ), ensuring enough negatives — coverage of the *(e5-axis × μ)* joint, with the
+kept-count set by the SVD **variance elbow** (intrinsic dimension) rather than a fixed `--frac`. It adds a
+**sufficiency threshold** (`--min-pages`: keep a category whole below it) and pairs with **subcategory
+augmentation** (`fetch_category_pages.py --recurse-subcats`) to push a thin category over that threshold.
+Both selectors remain the larger-scale "must filter" knob; not used at current scale.
+
+**Page-sampling policy (the operative conclusion).** There is far more page than category data, but because
+page-membership trains on its **own `ELEM` operator**, the imbalance is *contained* in `ELEM` rather than
+drowning the category operators — so **don't filter page data for `ELEM`; use all**. Instead, **monitor**
+whether growing `ELEM` learning degrades the other operators (shared-trunk interference), and if so
+**throttle `ELEM`'s gradient** (`--elem-weight`, or a per-operator learning rate / reduced backprop — not
+yet implemented) or **add capacity** (the 3rd layer already removed the interference) — rather than cutting
+the data. Diversity-pruning (`select_diverse.py`) is reserved for the larger-scale "must filter" regime.
+
 `select_diverse.py` is kept as the knob (`--frac`, `--min-mu`) for that larger-scale regime. The **full**
 326-page set is folded into the cumulative (25,651 rows). Reproduce: `find_data_gaps.py` →
 `fetch_category_pages.py` → Haiku centrality → `gen_page_pairs.py`; A/B via two `train_mu_attention.py

--- a/prototypes/mu_cosine/TECHNIQUES.md
+++ b/prototypes/mu_cosine/TECHNIQUES.md
@@ -42,7 +42,7 @@ All tools are reusable and live in this directory. The pair-file format is
 | 2b. **page** pairs | `fetch_category_pages.py` → `gen_page_pairs.py` | pull category **member pages** via the MediaWiki API (`cmtype=page`), emit `element_of` candidates (page→category) |
 | 2c. **pearltrees** pairs | `fetch_pearltrees_tree.py` → `gen_pearltrees_pairs.py` | harvest a Pearltrees tree (cookie session; collections/pages/shortcuts) for topics enwiki has no category for; PagePearl `url`s carry the enwiki anchor |
 | 3. grade | (inline Haiku subagents) | 6-band centrality rubric — see `DESIGN_sampling_and_grading.md` §3 (the "instruct grading" technique) |
-| 4. select | `select_diverse.py` | optional quality×diversity pruning (drop μ<0.4 junk, then quality-weighted farthest-point ≈ DPP-MAP). At small scale keep all; see `REPORT_page_selection.md` |
+| 4. select (large scale only) | `select_diverse.py` (farthest-point ≈ DPP-MAP) **or** `select_svd_coverage.py` (top-K SVD axes × μ-coverage, with `--min-pages` sufficiency gate) | optional pruning for big page pools; at current scale **keep all** (policy in §5). See `REPORT_page_selection.md` |
 | 5. assemble | `make_cumulative.sh` | union all `mu_pairs_scored_<round>_<yymmdd-HHMMSS>.tsv` into the (gitignored) cumulative + prior replay sets |
 
 Filenames: scored rounds are timestamped `mu_pairs_scored_<round>_<yymmdd-HHMMSS>.tsv` (first-commit time,
@@ -138,10 +138,40 @@ python3 find_data_gaps.py --region-root Systems_theory --region-root Dynamical_s
   to the domain roots is one e5 (and thus the model) can't place confidently — the ex-ante predictor of
   model weakness. Validated: the finder independently flagged `Ergodic_theory`, the exact stratum the
   trained model ranked worst, and supplementing it nudged its corr up (`REPORT_page_selection.md`).
-- **How much to keep per category:** at few-hundred-page scale, **keep all (prune only μ<0.4 junk)** — the
-  ELEM operator is data-hungry and "redundant" pages carry distinct centrality; the diversity A/B
-  (`select_diverse.py`, `REPORT_page_selection.md`) favoured the full set. Quality×diversity selection is
-  the knob for larger scale (needs a disjoint held-out to measure fairly).
+### Page-sampling policy (how much page data to keep, and why)
+
+There is **far more page data than category data** (a thin category can have 60+ member pages), which would
+normally argue for subsampling the majority class. The key insight: **because page-membership trains on its
+own `ELEM` operator, the imbalance is *contained* in `ELEM` rather than drowning the category operators
+(`SYM`/`WIKI`).** That structural isolation — not a sampling trick — is what neutralises the imbalance. So
+the policy is:
+
+1. **Don't filter page data for `ELEM` — use all of it.** The A/B (`REPORT_page_selection.md`) confirmed
+   keep-all beat a diversity-pruned subset at current scale (the operator is data-hungry; "redundant"
+   filter/wavelet pages carry distinct centrality; frozen e5 means it can't overfit duplicates). Filtering
+   is the wrong lever.
+2. **Monitor cross-operator degradation every run.** `ELEM` shares the trunk, so heavy `ELEM` learning can
+   pull the shared representation and degrade `SYM`/`WIKI` — exactly the capacity interference measured at
+   2 layers (discrimination 90%→79%, `REPORT_element_operator.md`). Watch the `[SYM]` corr and 6-domain
+   discrimination as `ELEM`'s share of the data grows.
+3. **If it degrades the others, throttle `ELEM`'s gradient — don't cut the data.** Reduce `ELEM`'s pull on
+   the shared trunk via **`--elem-weight`** (existing lever; 0.4 recovered discrimination) or, as a
+   stronger next lever, a **per-operator learning rate / scaled backprop on `ELEM`** (not yet implemented).
+   Adding **capacity (a layer)** is the cleanest fix when available — 3 layers removed the interference at
+   full `ELEM` weight without throttling — which is why `--layers` defaults to 3.
+
+**The selection method, precisely (for the larger-scale "must filter" regime).** `select_diverse.py` is
+**greedy quality-weighted farthest-point** on e5 cosine — drop μ<0.4 junk, seed the highest-Haiku page,
+then add the page maximising `centrality · (1 − max cosine to already-picked)`. This is a cheap **DPP-MAP
+proxy; it is NOT a PCA/SVD decomposition.** The **second method, `select_svd_coverage.py`, IS the
+SVD/μ-coverage one:** take the **top-K SVD axes** of the category's page-embedding matrix (K from the
+variance elbow = intrinsic dimension, not a fixed `--frac`) and keep a subset that **covers the
+*(e5-axis × μ)* joint** — both ends of each principal axis × low/mid/high centrality — so the operator
+learns how membership varies along each subtopic direction; junk (μ<min) dropped, negatives passed
+through. It adds the two design preconditions: a **sufficiency threshold** (`--min-pages` — below it a
+category is kept whole, sampling isn't worthwhile) and **subcategory augmentation** (push a thin category
+over the threshold by pooling its subtree's pages via `fetch_category_pages.py --recurse-subcats`). Both
+selectors are the **larger-scale "must filter" knob**; at current scale the policy is keep-all (above).
 
 ---
 

--- a/prototypes/mu_cosine/fetch_category_pages.py
+++ b/prototypes/mu_cosine/fetch_category_pages.py
@@ -62,17 +62,37 @@ def members(cat, cmtype, delay=1.0):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--cat", action="append", default=[], required=True)
+    ap.add_argument("--recurse-subcats", type=int, default=0, help="AUGMENT: also pull pages from "
+                    "subcategories down to this depth (attributed to the parent --cat), to push a thin "
+                    "category over a sampling threshold (select_svd_coverage.py --min-pages)")
     ap.add_argument("--out", default=os.path.join(ROOT, "page_members.tsv"))
     args = ap.parse_args()
 
     rows, summary = [], []
     for cat in args.cat:
-        pages = sorted(set(members(cat, "page")))
-        nsub = sum(1 for _ in members(cat, "subcat"))
+        if args.recurse_subcats > 0:
+            # BFS the subcategory subtree; pool member pages of cat + all subcats, attributed to `cat`
+            seen_sub, frontier = {cat}, [cat]
+            pages = set(members(cat, "page"))
+            for _ in range(args.recurse_subcats):
+                nxt = []
+                for sc in frontier:
+                    for sub in members(sc, "subcat"):
+                        if sub not in seen_sub:
+                            seen_sub.add(sub); nxt.append(sub)
+                            pages.update(members(sub, "page"))
+                            time.sleep(0.3)
+                frontier = nxt
+            pages = sorted(pages)
+            nsub = len(seen_sub) - 1
+        else:
+            pages = sorted(set(members(cat, "page")))
+            nsub = sum(1 for _ in members(cat, "subcat"))
         for p in pages:
             rows.append((p, cat, "element_of"))
         summary.append((cat, len(pages), nsub))
-        print(f"  {cat:26} pages={len(pages):4d}  subcats={nsub}")
+        print(f"  {cat:26} pages={len(pages):4d}  subcats={nsub}"
+              + (f"  (incl. subtree depth {args.recurse_subcats})" if args.recurse_subcats else ""))
         time.sleep(1.0)
 
     with open(args.out, "w", encoding="utf-8") as f:

--- a/prototypes/mu_cosine/select_diverse.py
+++ b/prototypes/mu_cosine/select_diverse.py
@@ -3,9 +3,21 @@
 BEST-RANKED pages (high Haiku centrality) but maintain e5 DIVERSITY (don't over-weight a dense cluster of
 near-identical pages). Not a fixed percentage — the kept count is the category's INTRINSIC e5 diversity
 (an SVD/variance elbow), so a 60-page filter category collapses to its ~k distinct subtopics while a
-category of genuinely distinct pages keeps most. Greedy quality-weighted farthest-point selection (a cheap
-DPP-MAP proxy): seed with the highest-Haiku page, then repeatedly add the page maximising
-score·(1−max_cosine_to_already_picked). Drops junk (μ < --min-mu) first.
+category of genuinely distinct pages keeps most.
+
+METHOD: greedy quality-weighted farthest-point selection (a cheap DPP-MAP proxy) — seed with the
+highest-Haiku page, then repeatedly add the page maximising score·(1−max_cosine_to_already_picked). Drops
+junk (μ < --min-mu) first. This is NOT a PCA/SVD decomposition.
+
+ALTERNATIVE (implemented as select_svd_coverage.py) — PCA/μ-coverage: take the top-K SVD axes of the
+page-embedding matrix and cover the μ distribution along EACH axis (both ends × low/mid/high μ), ensuring
+enough negatives — the (e5-axis × μ) joint, kept-count from the SVD variance elbow instead of a fixed
+--frac, with a --min-pages sufficiency gate.
+
+POLICY (TECHNIQUES.md §5): at current scale do NOT filter page data for the ELEM operator — its
+own-operator isolation contains the page/category imbalance; use all pages and monitor cross-operator
+degradation, throttling ELEM's gradient (--elem-weight / per-op LR) if it appears. This selector is for the
+larger-scale "must filter" regime.
 
     python3 select_diverse.py --scored mu_pairs_scored_pages_gaps_<ts>.tsv --frac 0.55 \
         --out mu_pairs_scored_pages_gaps_div.tsv

--- a/prototypes/mu_cosine/select_svd_coverage.py
+++ b/prototypes/mu_cosine/select_svd_coverage.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""SVD / μ-coverage page selector — the second sampling method (cf. select_diverse.py's farthest-point).
+Per the user's design: take the top-K SVD axes of a category's page-embedding matrix and keep a subset that
+COVERS the (e5-principal-axis × μ) joint — along EACH principal direction, keep pages spanning the μ
+(centrality) distribution (both ends of the axis × low/mid/high μ), so the ELEM operator learns how
+membership varies along each subtopic direction rather than only seeing the densest cluster. Junk (μ <
+--min-mu) dropped; negatives passed through (so "enough negatives" is preserved).
+
+PRECONDITIONS (the user's two design points):
+  * SUFFICIENCY THRESHOLD — selection is only worthwhile once a category has enough page data. Below
+    --min-pages the category is kept WHOLE (no sampling).
+  * SUBCATEGORY AUGMENTATION — to push a thin-but-has-subcats category over the threshold, harvest its
+    subcategories' pages too first: `fetch_category_pages.py --recurse-subcats N`.
+
+K is chosen by the SVD variance elbow (cumulative explained variance ≥ --var-thresh, capped at --max-k) —
+the category's intrinsic dimension, not a fixed fraction.
+
+    python3 select_svd_coverage.py --scored mu_pairs_scored_pages_<ts>.tsv --min-pages 25 \
+        --out mu_pairs_scored_pages_svd.tsv
+"""
+import argparse
+import os
+from collections import defaultdict
+
+import numpy as np
+
+from mu_attention import build_e5_tables
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scored", required=True)
+    ap.add_argument("--min-mu", type=float, default=0.4, help="drop pages below this centrality (junk)")
+    ap.add_argument("--min-pages", type=int, default=25, help="SUFFICIENCY: below this, keep the category whole")
+    ap.add_argument("--var-thresh", type=float, default=0.9, help="cumulative explained variance to pick K")
+    ap.add_argument("--max-k", type=int, default=6, help="cap on SVD axes")
+    ap.add_argument("--mu-bins", type=int, default=3, help="μ levels to cover along each axis")
+    ap.add_argument("--cache", default=os.path.join(ROOT, "e5_svdsel_cos.pt"))
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    header, rows = [], []
+    cat_rows = defaultdict(list)
+    for ln in open(args.scored, encoding="utf-8"):
+        if ln.startswith("#"):
+            header.append(ln); continue
+        c = ln.rstrip("\n").split("\t")
+        rows.append(c)
+        if len(c) >= 5 and c[2] != "neg" and c[2].startswith("pos_pageof_"):
+            cat_rows[c[0]].append(c)
+
+    pages = sorted({c[1] for cs in cat_rows.values() for c in cs})
+    q, p, idx = build_e5_tables(pages, cache_path=args.cache)
+    P = p.numpy()   # passage embeddings (unit-normed), [N,384]
+
+    keep, report = set(), []
+    for cat, cs in sorted(cat_rows.items()):
+        cand = [c for c in cs if float(c[4]) >= args.min_mu] or cs
+        n = len(cand)
+        if n < args.min_pages:                       # sufficiency gate: keep whole
+            for c in cand:
+                keep.add((c[0], c[1]))
+            report.append((cat, len(cs), n, n, "whole<thr"))
+            continue
+        X = np.stack([P[idx[c[1]]] for c in cand])    # [n,384]
+        mu = np.array([float(c[4]) for c in cand])
+        Xc = X - X.mean(0, keepdims=True)
+        # SVD → principal axes (right singular vectors) + variance elbow for K
+        _, S, Vt = np.linalg.svd(Xc, full_matrices=False)
+        var = (S ** 2); cum = np.cumsum(var) / var.sum()
+        K = int(min(args.max_k, max(1, np.searchsorted(cum, args.var_thresh) + 1)))
+        proj = Xc @ Vt[:K].T                          # [n,K] projection on each axis
+        # μ bins (low..high centrality)
+        edges = np.linspace(mu.min(), mu.max() + 1e-9, args.mu_bins + 1)
+        mubin = np.clip(np.digitize(mu, edges[1:-1]), 0, args.mu_bins - 1)
+        picked = set()
+        # cover each principal axis at BOTH ends × each μ level
+        for k in range(K):
+            for b in range(args.mu_bins):
+                cell = [i for i in range(n) if mubin[i] == b]
+                if not cell:
+                    continue
+                hi = max(cell, key=lambda i: proj[i, k])   # most +aligned with axis k in this μ band
+                lo = min(cell, key=lambda i: proj[i, k])   # most −aligned
+                picked.add(hi); picked.add(lo)
+        for i in picked:
+            keep.add((cand[i][0], cand[i][1]))
+        report.append((cat, len(cs), n, len(picked), f"K={K}"))
+
+    # negatives & non-pageof rows pass through verbatim; only pageof rows are filtered
+    with open(args.out, "w", encoding="utf-8") as f:
+        for h in header:
+            f.write(h)
+        kept = dropped = 0
+        for c in rows:
+            if len(c) >= 3 and c[2].startswith("pos_pageof_"):
+                if (c[0], c[1]) in keep:
+                    f.write("\t".join(c) + "\n"); kept += 1
+                else:
+                    dropped += 1
+            else:
+                f.write("\t".join(c) + "\n")
+    print(f"{'category':30} {'all':>4} {'≥μ':>4} {'kept':>4}  note")
+    for cat, a, b, k, note in report:
+        print(f"  {cat[:28]:28} {a:>4} {b:>4} {k:>4}  {note}")
+    print(f"\nkept {kept} / dropped {dropped} pos_pageof rows -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The second sampling method (cf. select_diverse.py farthest-point), implementing the
user's design:
- select_svd_coverage.py: take the top-K SVD axes of a category's page-embedding matrix
  (K from the variance elbow = intrinsic dimension, not a fixed frac) and keep a subset
  COVERING the (e5-axis x mu) joint -- both ends of each principal axis x low/mid/high
  centrality -- so the ELEM operator learns how membership varies along each subtopic
  direction. Junk (mu<min-mu) dropped; negatives passed through.
  * SUFFICIENCY THRESHOLD (--min-pages): below it a category is kept WHOLE. Verified on
    the gap set: <25-page cats kept whole; Linear_filters 66->25, Wavelets 54->26,
    Linear_programming 59->26 at K=6.
- fetch_category_pages.py --recurse-subcats N: SUBCATEGORY AUGMENTATION -- pool a
  category's subtree pages (attributed to the parent) to push a thin-but-has-subcats
  category over --min-pages before selecting.

Docs (TECHNIQUES.md S5, REPORT_page_selection.md) flipped from "deferred" to
"implemented" for the PCA/mu-coverage variant. Policy unchanged: don't filter for ELEM
at current scale; this is the larger-scale "must filter" tool.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>