### PR TITLE
mu_cosine: node-type token (DESIGN §7) — implemented, gated off by default, + collinearity finding & architecture diagram

### DIFF
--- a/prototypes/mu_cosine/REPORT_nodetype.md
+++ b/prototypes/mu_cosine/REPORT_nodetype.md
@@ -1,0 +1,52 @@
+# Node-type token — implemented, and an honest collinearity finding
+
+Finishes the second axis of `DESIGN_calibrated_judges.md` §7: a factored **per-endpoint** node-type token
+(`category` / `page` / `mindmap_node` / `pearltrees_collection`), orthogonal *in principle* to the
+operator. Added to each endpoint token (anchor = root's type, node = candidate's type, ancestors =
+`category`), zero-initialised so it's a no-op at warm start. Architecture diagram in `TECHNIQUES.md` §1.
+
+## A/B — node-type ON vs OFF
+
+Both warm-started from `model_mathfields.pt`, same cumulative data, 3 layers, 600 steps, `--lr 1.5e-4`
+(only difference = the node-type token). OFF arm = `model_gap_all.pt`.
+
+| metric | OFF (`model_gap_all`) | **ON (`model_nodetype`)** |
+|---|---|---|
+| ELEM held-out centrality corr | **+0.620** | +0.470 |
+| overall held-out SYM corr | +0.855 | +0.849 |
+| discrimination | 87% | 87% |
+| page strata (e.g. `linear_filters` / `linear_programming` / `non-equilibrium`) | +0.70 / +0.77 / +0.55 | +0.53 / +0.40 / +0.13 |
+
+**Node-type *hurt*** — ELEM and the page strata dropped broadly; discrimination unchanged.
+
+## Why — collinearity with the operator
+
+In today's data the operator and the node-type are **not orthogonal, they're collinear**:
+
+- `ELEM` ⟺ page-membership (node is always a `page`, root always a `category`),
+- `SYM`/`WIKI` ⟺ category–category.
+
+So "this endpoint is a `page`" is **already implied by the operator being `ELEM`** — the node-type token
+carries **zero marginal information** given the operator. All it adds is extra zero-init parameters that,
+under-trained in 600 steps, perturb the shared representation → a small but real regression. The
+design's orthogonality assumption (operator ⊥ node-type) is an assumption *about the data*, and the data
+doesn't satisfy it yet.
+
+## Decision + when it pays off
+
+- **Gated behind `--use-nodetype`, default OFF.** The implementation is correct and banked; normal training
+  is byte-for-byte the prior behavior (no tags ⇒ `nodetype_of=-1` ⇒ the token is never applied;
+  `nodetype_emb` receives no gradient). `model_gap_all` (no node-type) remains the deployed model.
+- **Activate it once the data has within-operator type diversity** — i.e. when the *same* operator sees
+  *different* endpoint types. Concretely:
+  - **pearltrees collections**: `ELEM` over `collection` nodes *and* `page` nodes — now node-type
+    distinguishes collection-membership from page-membership *within* `ELEM`;
+  - **mindmap nodes** (`mindmap_node`) under the human-judge corpus;
+  - any `page` appearing as an endpoint in a `SYM`-like relation.
+
+  Then operator and node-type decorrelate, and the token can carry real information. Until then it's
+  premature.
+
+This is a **data-precondition** result, not an implementation flaw — the cheap experiment (one A/B run, no
+new Haiku) saved us from baking a redundant axis into the trained model, and tells us exactly what data
+unlocks it: the mindmap / pearltrees-collection expansion.

--- a/prototypes/mu_cosine/TECHNIQUES.md
+++ b/prototypes/mu_cosine/TECHNIQUES.md
@@ -27,6 +27,45 @@ so the trunk learns the common "membership geometry" once and each operator embe
 delta. That's why page-membership needed `ELEM` (see §3). Full theory — including calibrating the graph
 judge's target and supervising **ranges** instead of points — in `DESIGN_calibrated_judges.md`.
 
+### Architecture at a glance
+
+One example — `μ(node | root)` under operator `OP`, corpus `C`, judge `J` — becomes a **set of tokens**
+(order-invariant; the transformer has no positional encoding). Each token's content is a frozen e5 vector
+(or 0 for the op/provenance slots) **plus** a sum of the factored, learned embeddings below. Note the
+**node-type token is added per ENDPOINT** — the anchor carries the *root's* type, the node carries the
+*candidate's* type — so a single ELEM example mixes a `page` node with a `category` anchor:
+
+```
+ example:  μ( node | root )   op=OP  corpus=C  judge=J   nodetype(node)=NTn  nodetype(root)=NTr
+
+ token:    [op]        [anchor=root]     [node=cand]     [anc × k]        [prov]  (maskable)
+ ───────   ─────       ────────────      ───────────     ──────────       ──────────────────
+ content:  0           e5.query(root)    e5.passage(cand) e5.passage(anc)  0
+ + adds :  op_emb[OP]  anchor_tag        gen_emb[0]       gen_emb[depth]   prov_tag
+                       nodetype_emb[NTr] nodetype_emb[NTn] nodetype_emb[cat] corpus_emb[C]
+                          ▲  per-endpoint type            (ancestors are    judge_emb[J]
+                          └─ root's type   candidate's      categories)      └─ factored, maskable
+                                            type                                 ⇒ provenance-agnostic
+                                                                                   default when masked
+                                  │
+                                  ▼
+              Transformer encoder  —  SHARED TRUNK (3 layers, norm-first, GELU)
+                                  │
+                                  ▼
+              pooled = h[op token]                          ← CLS-style readout (op token attends the set)
+              logit  = pooled · readout_w[OP] + readout_b[OP]   ← per-OPERATOR readout row
+                                  │
+                                  ▼
+                       μ = sigmoid(logit) ∈ [0,1]
+```
+
+Reading the asymmetry off the diagram: the **operator** appears **twice** — as an input token (`op_emb`)
+*and* as the readout row (`readout_w[OP]`), so it conditions both what goes in and which relation-function
+comes out. **Node-type** appears only on the **input** endpoint tokens (it's contextual "what is this
+node"); it has no readout row. **Provenance** (`corpus⊗judge`) rides one maskable token — masked ⇒ the
+agnostic default. `nodetype_emb` is zero-initialised, so at warm-start the whole node-type row is a no-op
+and the signal is learned during fine-tuning.
+
 ---
 
 ## 2. Data-acquisition toolchain (how-to)

--- a/prototypes/mu_cosine/eval_per_stratum.py
+++ b/prototypes/mu_cosine/eval_per_stratum.py
@@ -9,7 +9,11 @@ import random
 
 import torch
 
-from mu_attention import OPS, load_dag, all_names, build_e5_tables, Tokenizer, MuAttention
+from mu_attention import OPS, NODETYPE, load_dag, all_names, build_e5_tables, Tokenizer, MuAttention
+
+_NT = {"category": 0, "page": 1, "mindmap_node": 2, "collection": 3, "pearltrees_collection": 3}
+def nt(s):
+    return _NT.get(s, 0)
 from train_mu_attention import load_edges, load_mu, pearson, mu_batch
 from gen_mu_pairs import GRAPH
 
@@ -25,7 +29,9 @@ def load_pairs_strat(path):
         if len(p) < 5 or p[4].strip() == "":
             continue
         rel = p[5].strip() if len(p) > 5 and p[5].strip() else "subcat_of"
-        (neg if p[2] == "neg" else pos).append((p[0], p[1], float(p[4]), p[2], rel))
+        at = p[6].strip() if len(p) > 6 and p[6].strip() else "category"
+        bt = p[7].strip() if len(p) > 7 and p[7].strip() else "category"
+        (neg if p[2] == "neg" else pos).append((p[0], p[1], float(p[4]), p[2], rel, at, bt))
     return pos, neg
 
 
@@ -43,7 +49,7 @@ def main(pairs=os.path.join(ROOT, "mu_pairs_scored_multidomain_260620-235025.tsv
     ck = torch.load(model_path, weights_only=False)
     model = MuAttention(d_model=ck["cfg"]["d_model"], n_heads=ck["cfg"]["heads"],
                         n_layers=ck["cfg"]["layers"])
-    model.load_state_dict(ck["state"])
+    model.load_state_dict(ck["state"], strict=False)   # tolerate old checkpoints w/o nodetype_emb (zeros)
     model.eval()
 
     # reproduce the split EXACTLY (rng consumes the edge shuffle first, then the pos shuffle)
@@ -67,7 +73,8 @@ def main(pairs=os.path.join(ROOT, "mu_pairs_scored_multidomain_260620-235025.tsv
         for i, v in zip(sym_i, ((ab + ba) / 2).tolist()):
             pred[i] = v
     if elem_i and "ELEM" in OPS:
-        ef = mu_batch(model, tok, [(hold[i][1], hold[i][0], OPS["ELEM"]) for i in elem_i])
+        ef = mu_batch(model, tok, [(hold[i][1], hold[i][0], OPS["ELEM"], None, None,
+                                    nt(hold[i][6]), nt(hold[i][5])) for i in elem_i])
         for i, v in zip(elem_i, ef.tolist()):
             pred[i] = v
     tgt = [h[2] for h in hold]

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -52,6 +52,13 @@ OPS = {"SYM": 0, "WIKI": 1, "LLM": 2, "ELEM": 3}
 CORPORA = {"simplewiki": 0, "enwiki": 1}
 JUDGES = {"haiku": 0, "graph": 1}        # haiku = a bought LLM judgment (SYM/LLM); graph = a Wikipedia
                                          # edge / non-edge (WIKI, and the free μ=0 SYM negatives)
+# NODE-TYPE (DESIGN_calibrated_judges.md §7): a factored per-ENDPOINT token saying WHAT each node is — a
+# `category`/`mindmap_node` is an internal node that can have children; a `page` is a LEAF; a
+# `pearltrees_collection` is a curated container. Orthogonal to the OPERATOR (which says what the RELATION
+# is). e5 still encodes the title text; the node-type token only adds the structural role the title can't
+# convey. category=0 is the implicit default; the embedding is zero-initialised so it is a no-op at warm
+# start and the type signal is learned during fine-tuning.
+NODETYPE = {"category": 0, "page": 1, "mindmap_node": 2, "pearltrees_collection": 3}
 
 
 # --------------------------------------------------------------------------------------------------
@@ -188,9 +195,12 @@ class Tokenizer:
         so the model learns BOTH provenance-conditioned and provenance-agnostic μ."""
         B = len(items)
         rows = []          # per-example list of token dicts
+        ntypes, rtypes = [], []   # node-type of the node / the root, per example (category=0 default)
         for it in items:
             node, root, op = it[0], it[1], it[2]
             corpus_id, judge_id = (it[3], it[4]) if len(it) >= 5 else (None, None)
+            ntype, rtype = (it[5], it[6]) if len(it) >= 7 else (0, 0)
+            ntypes.append(ntype); rtypes.append(rtype)
             toks = []
             toks.append(("op", None, op, 0))                              # operator token
             toks.append(("anchor", root, None, 0))                       # anchor(root) — e5 query:
@@ -221,6 +231,7 @@ class Tokenizer:
         is_prov = torch.zeros(B, T, dtype=torch.bool)                     # the provenance slot (any state)
         corpus_of = torch.full((B, T), -1, dtype=torch.long)
         judge_of = torch.full((B, T), -1, dtype=torch.long)
+        nodetype_of = torch.full((B, T), -1, dtype=torch.long)            # per-endpoint structural role
         pad = torch.ones(B, T, dtype=torch.bool)                          # True = pad (ignored)
         op_of = torch.tensor([it[2] for it in items], dtype=torch.long)
 
@@ -232,12 +243,15 @@ class Tokenizer:
                 elif kind == "anchor":
                     content[bi, ti] = self.q[self.idx[name]]
                     is_anchor[bi, ti] = True
+                    nodetype_of[bi, ti] = rtypes[bi]                      # the root's type
                 elif kind == "node":
                     content[bi, ti] = self.p[self.idx[name]]
                     gen_id[bi, ti] = 0
+                    nodetype_of[bi, ti] = ntypes[bi]                      # the candidate node's type
                 elif kind == "anc":
                     content[bi, ti] = self.p[self.idx[name]]
                     gen_id[bi, ti] = d
+                    nodetype_of[bi, ti] = NODETYPE["category"]            # ancestors are categories
                 elif kind == "prov":
                     is_prov[bi, ti] = True                                # content stays 0; forward adds
                     corpus_of[bi, ti], judge_of[bi, ti] = op              # corpus_emb + judge_emb + prov_tag
@@ -255,7 +269,7 @@ class Tokenizer:
                         gen_id[bi, ti] = d
         return {"content": content, "gen_id": gen_id, "is_anchor": is_anchor, "op_pos": op_pos,
                 "is_prov": is_prov, "corpus_of": corpus_of, "judge_of": judge_of,
-                "op_of": op_of, "pad": pad}
+                "nodetype_of": nodetype_of, "op_of": op_of, "pad": pad}
 
 
 # --------------------------------------------------------------------------------------------------
@@ -263,10 +277,14 @@ class Tokenizer:
 # --------------------------------------------------------------------------------------------------
 class MuAttention(nn.Module):
     def __init__(self, d_model=384, n_ops=len(OPS), n_heads=4, n_layers=1, max_gen=5,
-                 dim_ff=None, dropout=0.0, n_corpus=len(CORPORA), n_judge=len(JUDGES)):
+                 dim_ff=None, dropout=0.0, n_corpus=len(CORPORA), n_judge=len(JUDGES),
+                 n_nodetype=len(NODETYPE)):
         super().__init__()
         self.d = d_model
         self.op_emb = nn.Embedding(n_ops, d_model)
+        # NODE-TYPE: per-endpoint structural-role token (category/page/mindmap/pearltrees). Zero-init so it
+        # is a no-op at warm start (category=0 default) and the type signal is learned during fine-tuning.
+        self.nodetype_emb = nn.Embedding(n_nodetype, d_model)
         self.gen_emb = nn.Embedding(max_gen + 1, d_model)                 # gen 0..max_gen
         self.anchor_tag = nn.Parameter(torch.randn(d_model) * 0.02)
         # PROVENANCE (PART B): factored corpus_emb + judge_emb on a single maskable token. `prov_tag`
@@ -283,13 +301,16 @@ class MuAttention(nn.Module):
         self.readout_b = nn.Parameter(torch.zeros(n_ops))
         for emb in (self.op_emb, self.gen_emb, self.corpus_emb, self.judge_emb):
             nn.init.normal_(emb.weight, std=0.02)
+        nn.init.zeros_(self.nodetype_emb.weight)            # no-op at warm start; learned during fine-tune
 
     def forward(self, content, gen_id, is_anchor, op_pos, op_of, pad,
-                is_prov=None, corpus_of=None, judge_of=None):
+                is_prov=None, corpus_of=None, judge_of=None, nodetype_of=None):
         emb = content.clone()
         gmask = (gen_id >= 0).unsqueeze(-1)
         emb = emb + self.gen_emb(gen_id.clamp(min=0)) * gmask
         emb = emb + self.anchor_tag * is_anchor.unsqueeze(-1)
+        if nodetype_of is not None:                          # per-endpoint structural role
+            emb = emb + self.nodetype_emb(nodetype_of.clamp(min=0)) * (nodetype_of >= 0).unsqueeze(-1)
         omask = (op_pos >= 0).unsqueeze(-1)
         emb = emb + self.op_emb(op_pos.clamp(min=0)) * omask
         if is_prov is not None:

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -195,12 +195,14 @@ class Tokenizer:
         so the model learns BOTH provenance-conditioned and provenance-agnostic μ."""
         B = len(items)
         rows = []          # per-example list of token dicts
-        ntypes, rtypes = [], []   # node-type of the node / the root, per example (category=0 default)
+        ntypes, rtypes, has_nt = [], [], []   # node-type of node/root per example; off unless item carries it
         for it in items:
             node, root, op = it[0], it[1], it[2]
             corpus_id, judge_id = (it[3], it[4]) if len(it) >= 5 else (None, None)
-            ntype, rtype = (it[5], it[6]) if len(it) >= 7 else (0, 0)
-            ntypes.append(ntype); rtypes.append(rtype)
+            if len(it) >= 7:
+                ntypes.append(it[5]); rtypes.append(it[6]); has_nt.append(True)
+            else:                               # no node-type tags ⇒ leave nodetype_of=-1 (emb not applied)
+                ntypes.append(0); rtypes.append(0); has_nt.append(False)
             toks = []
             toks.append(("op", None, op, 0))                              # operator token
             toks.append(("anchor", root, None, 0))                       # anchor(root) — e5 query:
@@ -243,15 +245,18 @@ class Tokenizer:
                 elif kind == "anchor":
                     content[bi, ti] = self.q[self.idx[name]]
                     is_anchor[bi, ti] = True
-                    nodetype_of[bi, ti] = rtypes[bi]                      # the root's type
+                    if has_nt[bi]:
+                        nodetype_of[bi, ti] = rtypes[bi]                  # the root's type
                 elif kind == "node":
                     content[bi, ti] = self.p[self.idx[name]]
                     gen_id[bi, ti] = 0
-                    nodetype_of[bi, ti] = ntypes[bi]                      # the candidate node's type
+                    if has_nt[bi]:
+                        nodetype_of[bi, ti] = ntypes[bi]                  # the candidate node's type
                 elif kind == "anc":
                     content[bi, ti] = self.p[self.idx[name]]
                     gen_id[bi, ti] = d
-                    nodetype_of[bi, ti] = NODETYPE["category"]            # ancestors are categories
+                    if has_nt[bi]:
+                        nodetype_of[bi, ti] = NODETYPE["category"]        # ancestors are categories
                 elif kind == "prov":
                     is_prov[bi, ti] = True                                # content stays 0; forward adds
                     corpus_of[bi, ti], judge_of[bi, ti] = op              # corpus_emb + judge_emb + prov_tag

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -283,9 +283,13 @@ def train(args):
         L_elem = torch.zeros(())
         if elem_tr and not args.sym_only:
             eb2 = [elem_tr[rng.randrange(len(elem_tr))] for _ in range(args.bs)]
-            # node-type tags: node=b (member, b_type=r[5]), root=a (topic, a_type=r[4])
-            fwd = [(r[1], r[0], OPS["ELEM"], new_corpus, HAIKU, nt(r[5]), nt(r[4])) for r in eb2]   # μ(page|cat)
-            rev = [(r[0], r[1], OPS["ELEM"], new_corpus, HAIKU, nt(r[4]), nt(r[5])) for r in eb2]   # μ(cat|page)
+            # node-type tags (opt-in): node=b (member, b_type=r[5]), root=a (topic, a_type=r[4])
+            if args.use_nodetype:
+                fwd = [(r[1], r[0], OPS["ELEM"], new_corpus, HAIKU, nt(r[5]), nt(r[4])) for r in eb2]
+                rev = [(r[0], r[1], OPS["ELEM"], new_corpus, HAIKU, nt(r[4]), nt(r[5])) for r in eb2]
+            else:
+                fwd = [(r[1], r[0], OPS["ELEM"], new_corpus, HAIKU) for r in eb2]   # μ(page|cat)
+                rev = [(r[0], r[1], OPS["ELEM"], new_corpus, HAIKU) for r in eb2]   # μ(cat|page)
             mu_e = model(**tok.build(fwd + rev, train=True, rng=rng, p_mask_prov=args.prov_mask))
             mu_ef, mu_er = mu_e[:args.bs], mu_e[args.bs:]
             tgt_e = torch.tensor([r[2] for r in eb2])
@@ -342,11 +346,15 @@ def validate(model, tok, names, idx, adj, edges_hold, pos_hold, llm, args, elem_
 
     # --- ELEM: held-out page/collection-membership centrality corr + direction (the new operator) ---
     if elem_hold and not args.sym_only:
-        # node-typed, provenance masked (None corpus): node=b (b_type=r[5]), root=a (a_type=r[4])
-        ef = mu_batch(model, tok, [(r[1], r[0], OPS["ELEM"], None, None, nt(r[5]), nt(r[4]))
-                                   for r in elem_hold])                          # μ(page|category)
-        er = mu_batch(model, tok, [(r[0], r[1], OPS["ELEM"], None, None, nt(r[4]), nt(r[5]))
-                                   for r in elem_hold])                          # μ(category|page)
+        # match training: node-type tags only when --use-nodetype (else plain 3-tuples)
+        if args.use_nodetype:
+            ef = mu_batch(model, tok, [(r[1], r[0], OPS["ELEM"], None, None, nt(r[5]), nt(r[4]))
+                                       for r in elem_hold])                      # μ(page|category)
+            er = mu_batch(model, tok, [(r[0], r[1], OPS["ELEM"], None, None, nt(r[4]), nt(r[5]))
+                                       for r in elem_hold])                      # μ(category|page)
+        else:
+            ef = mu_batch(model, tok, [(r[1], r[0], OPS["ELEM"]) for r in elem_hold])   # μ(page|category)
+            er = mu_batch(model, tok, [(r[0], r[1], OPS["ELEM"]) for r in elem_hold])   # μ(category|page)
         etgt = [r[2] for r in elem_hold]
         ecorr = pearson(ef.tolist(), etgt)
         edir = float((ef > er).float().mean())
@@ -546,6 +554,10 @@ def main():
                     help="weight on bce(μ(child|parent),0.9) — absolute anchor for the WIKI map")
     ap.add_argument("--wiki-weight", type=float, default=1.0, help="WIKI loss weight (parity)")
     ap.add_argument("--elem-weight", type=float, default=1.0, help="ELEM (element-of/page-membership) loss weight")
+    ap.add_argument("--use-nodetype", action="store_true", help="tag ELEM endpoints with the node-type token "
+                    "(DESIGN §7). DEFAULT OFF: at current data operator and node-type are COLLINEAR "
+                    "(ELEM⟺page), so it's redundant and hurts (REPORT_nodetype.md); enable once data has "
+                    "within-operator type diversity (pearltrees collections / mindmap nodes).")
     ap.add_argument("--llm-weight", type=float, default=1.0)
     ap.add_argument("--k", type=int, default=1, help="ancestor depth (1 = node+parents)")
     ap.add_argument("--max-anc", type=int, default=8)

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -30,8 +30,13 @@ from collections import deque
 import torch
 import torch.nn.functional as F
 
-from mu_attention import (OPS, CORPORA, JUDGES, GRAPH, load_dag, all_names, build_e5_tables,
+from mu_attention import (OPS, CORPORA, JUDGES, NODETYPE, GRAPH, load_dag, all_names, build_e5_tables,
                           Tokenizer, MuAttention)
+
+# map the pair-file a_type/b_type strings to NODETYPE ids (category=0 default; pearltrees "collection" → 3)
+_NT = {"category": 0, "page": 1, "mindmap_node": 2, "collection": 3, "pearltrees_collection": 3}
+def nt(s):
+    return _NT.get(s, 0)
 
 # PART B provenance tags for the current single-corpus data. corpus = simplewiki (the 10k graph);
 # judge = haiku for bought LLM labels (SYM positives, LLM fixture), graph for the free graph-derived
@@ -76,7 +81,9 @@ def load_pairs(path=PAIRS):
             # any non-neg stratum (pos / pos_phys / pos_chem / cross) is a graded positive; neg is μ=0.
             # 4th field = relation (extended page/pearltrees rows carry it; default subcat_of/SYM-style).
             rel = p[5].strip() if len(p) > 5 and p[5].strip() else "subcat_of"
-            (neg if p[2] == "neg" else pos).append((p[0], p[1], float(p[4]), rel))
+            at = p[6].strip() if len(p) > 6 and p[6].strip() else "category"   # a_type (root endpoint)
+            bt = p[7].strip() if len(p) > 7 and p[7].strip() else "category"   # b_type (node endpoint)
+            (neg if p[2] == "neg" else pos).append((p[0], p[1], float(p[4]), rel, at, bt))
     return pos, neg
 
 
@@ -276,8 +283,9 @@ def train(args):
         L_elem = torch.zeros(())
         if elem_tr and not args.sym_only:
             eb2 = [elem_tr[rng.randrange(len(elem_tr))] for _ in range(args.bs)]
-            fwd = [(r[1], r[0], OPS["ELEM"], new_corpus, HAIKU) for r in eb2]   # μ(page | category)
-            rev = [(r[0], r[1], OPS["ELEM"], new_corpus, HAIKU) for r in eb2]   # μ(category | page)
+            # node-type tags: node=b (member, b_type=r[5]), root=a (topic, a_type=r[4])
+            fwd = [(r[1], r[0], OPS["ELEM"], new_corpus, HAIKU, nt(r[5]), nt(r[4])) for r in eb2]   # μ(page|cat)
+            rev = [(r[0], r[1], OPS["ELEM"], new_corpus, HAIKU, nt(r[4]), nt(r[5])) for r in eb2]   # μ(cat|page)
             mu_e = model(**tok.build(fwd + rev, train=True, rng=rng, p_mask_prov=args.prov_mask))
             mu_ef, mu_er = mu_e[:args.bs], mu_e[args.bs:]
             tgt_e = torch.tensor([r[2] for r in eb2])
@@ -334,8 +342,11 @@ def validate(model, tok, names, idx, adj, edges_hold, pos_hold, llm, args, elem_
 
     # --- ELEM: held-out page/collection-membership centrality corr + direction (the new operator) ---
     if elem_hold and not args.sym_only:
-        ef = mu_batch(model, tok, [(b, a, OPS["ELEM"]) for a, b, *_ in elem_hold])   # μ(page|category)
-        er = mu_batch(model, tok, [(a, b, OPS["ELEM"]) for a, b, *_ in elem_hold])   # μ(category|page)
+        # node-typed, provenance masked (None corpus): node=b (b_type=r[5]), root=a (a_type=r[4])
+        ef = mu_batch(model, tok, [(r[1], r[0], OPS["ELEM"], None, None, nt(r[5]), nt(r[4]))
+                                   for r in elem_hold])                          # μ(page|category)
+        er = mu_batch(model, tok, [(r[0], r[1], OPS["ELEM"], None, None, nt(r[4]), nt(r[5]))
+                                   for r in elem_hold])                          # μ(category|page)
         etgt = [r[2] for r in elem_hold]
         ecorr = pearson(ef.tolist(), etgt)
         edir = float((ef > er).float().mean())


### PR DESCRIPTION
## Summary
Finishes the second factored axis of `DESIGN_calibrated_judges.md` §7 — a **per-endpoint node-type token**
(`category` / `page` / `mindmap_node` / `pearltrees_collection`), orthogonal *in principle* to the operator.
Implementing it let us actually test it, which surfaced a clean **collinearity finding**: at the current
data it's redundant with the operator and slightly hurts — so it's **gated behind `--use-nodetype`
(default OFF)**, banked and wired end-to-end for the pearltrees/SimpleMind expansion that will make it pay
off. Prototype only; no WAM-Rust core changes.

## What's added
- **`mu_attention.py`** — `NODETYPE` codebook + a zero-initialised `nodetype_emb` table. Added **per
  endpoint token**: the anchor carries the *root's* type, the node token the *candidate's* type, ancestors
  `category`. Orthogonal to the operator (which owns the input token **and** the readout row); node-type is
  input-only. Zero-init ⇒ no-op at warm start; the partial warm-start load tolerates the new param.
- **`train_mu_attention.py`** — `load_pairs` now carries `a_type`/`b_type`; ELEM items + the ELEM held-out
  eval tag `node=b` / `root=a` via an `nt()` string→id map; **opt-in `--use-nodetype` flag (default off)** so
  normal training is byte-for-byte the prior behaviour (no tags ⇒ `nodetype_of=-1` ⇒ token never applied).
- **`eval_per_stratum.py`** — routes `element_of` strata with node-types; loads checkpoints `strict=False`
  so old models (no `nodetype_emb`) still eval.
- **`TECHNIQUES.md` §1** — an ASCII **architecture diagram** of the token flow (per-endpoint node-type,
  per-operator readout, factored/maskable provenance).
- **`REPORT_nodetype.md`** — the A/B + the finding.

## The finding (A/B: node-type ON vs OFF, same warm-start / data / steps / 3 layers)
| metric | OFF (`model_gap_all`) | ON (`model_nodetype`) |
|---|---|---|
| ELEM held-out centrality corr | **+0.620** | +0.470 |
| overall SYM corr | +0.855 | +0.849 |
| discrimination | 87% | 87% |
| page strata (filters / LP / non-eq) | +0.70 / +0.77 / +0.55 | +0.53 / +0.40 / +0.13 |

**Why it hurt:** in today's data operator and node-type are **collinear** (`ELEM ⟺ page`,
`SYM ⟺ category`), so "this endpoint is a page" is already implied by the operator — the token carries zero
marginal information and its under-trained params just perturb the trunk. It's a **data-precondition**, not
an implementation flaw.

## When it activates
Once the *same* operator sees *different* endpoint types — **pearltrees collections** (`ELEM` over
`collection` + `page`) and **SimpleMind `mindmap_node`** endpoints under the human-judge corpus. The data
tagging (`a_type`/`b_type`, the `nt()` map incl. `collection`/`mindmap_node`) is already in place, so
activation is a one-flag flip (`--use-nodetype`). `model_gap_all` (no node-type) remains the deployed model
until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)