### PR TITLE
mu_cosine: SimpleMind cloudmapref direction + linked-root naming + bridge relation (typed cross-corpus join)

### DIFF
--- a/prototypes/mu_cosine/SKILL_understand_smmx.md
+++ b/prototypes/mu_cosine/SKILL_understand_smmx.md
@@ -25,8 +25,11 @@ A `.smmx` file is a **zip** containing `document/mindmap.xml`. The XML is a tree
   - `urllink="…en.wikipedia.org/wiki/<Title>"` — a **Wikipedia anchor** for the node (the join key to
     enwiki).
   - `cloudmapref="../Other Map.smmx" element="…"` — a **cross-map link** (relative path) to **another
-    mindmap, at its ROOT** (`element` is usually absent ⇒ the whole map). These form the upward chain to
-    broader "parent tree" maps.
+    mindmap, at its ROOT** (`element` usually absent ⇒ the whole map). **The path direction sets the
+    relation** (when no container tags it): a `../` path UP to a **parent folder** ⇒ the target is a
+    broader **parent / `super_category`** (the upward parent-tree chain); a path DOWN into a **subfolder**
+    ⇒ the target is a narrower **`subcategory`** (a dedicated sub-map expanding this node — e.g. a
+    `Chaos theory` node linking down to its own detailed `Chaos theory.smmx`).
 - `<relation source="123" target="141"/>` (at the end of the map) — an explicit **associative cross-link**
   between two topics.
 
@@ -74,8 +77,9 @@ For each real (non-container, non-`wiki`) node:
    `see_also`; `Super Categories` ⇒ `super_category`; none (or only blanks) ⇒ `subtopic`.
 3. Record the node's **Pearltrees slug** (identity) and any **Wikipedia anchor** (its own wiki urllink, or
    a `wiki`-labelled child).
-4. `cloudmapref` on a node (or its blank link-holder child) ⇒ a `cloudmapref` edge to that other map's root
-   (a broader parent-tree / context).
+4. `cloudmapref` on a node (or its blank link-holder child) ⇒ a cross-map edge to that other map's root.
+   Set the relation by the **path direction**: `../` (parent folder) ⇒ `super_category` (broader);
+   subfolder (down) ⇒ `subcategory` (narrower).
 
 ---
 
@@ -100,8 +104,9 @@ These relations map onto membership strength for `μ(node | root)` grading (huma
 
 | relation | μ reading |
 |---|---|
-| `subtopic` | **high** membership — the child is part of / narrower than the parent topic |
-| `super_category` / `cloudmapref` | the *parent direction* — the target is **broader**; μ(node\|target) high, reverse low |
+| `subtopic` | **high** membership — the child is part of / narrower than the parent topic (in-map hierarchy) |
+| `subcategory` | **high** membership — the target map is narrower / a child (downward cloudmapref); μ(target\|node) high |
+| `super_category` | the *parent direction* — the target is **broader** (in-map Super Categories, or upward cloudmapref); μ(node\|target) high, reverse low |
 | `see_also` | **associative**, not membership — moderate-to-low, symmetric (grade like a boundary pair) |
 | `assoc` (explicit relation) | a deliberate cross-link — moderate associative |
 

--- a/prototypes/mu_cosine/SKILL_understand_smmx.md
+++ b/prototypes/mu_cosine/SKILL_understand_smmx.md
@@ -45,7 +45,7 @@ Some nodes are **containers / scaffolding**, not real concepts. Skip them as nod
 | `See Also`, `Via Link`, `Related` | **see-also**: weakly/associatively related (not membership) | `see_also` |
 | `Super Categories`, `Super Category`, `Navigate Up` | **broader / parent** category of the attached node | `super_category` |
 | blank (`text=""`) / section headers | just visual grouping — pass through, keep the relation from above | — |
-| a node labelled **`wiki`** / `Wikipedia` (with a Wikipedia urllink) | NOT a node — it gives the **enwiki anchor** of its **parent** | (anchor) |
+| a node labelled **`wiki`** / `Wikipedia` / `enwiki` (with a Wikipedia urllink), or any node with a direct `en.wikipedia.org` urllink | a **`bridge`**: the node ↔ the SAME concept in enwiki (a `category` if `Category:…`, else a `page`) — same concept, **different node-type**, possibly different name | `bridge` |
 
 Everything else is a **real node**, and a plain parent→child link (after skipping any containers) is a
 **`subtopic`** = membership / narrower-than.
@@ -110,6 +110,7 @@ These relations map onto membership strength for `μ(node | root)` grading (huma
 | `subcategory` | **high** membership — the target map is narrower / a child (downward cloudmapref); μ(target\|node) high |
 | `super_category` | the *parent direction* — the target is **broader** (in-map Super Categories, or upward cloudmapref); μ(node\|target) high, reverse low |
 | `see_also` | **associative**, not membership — moderate-to-low, symmetric (grade like a boundary pair) |
+| `bridge` | **near-identity** across corpora — the mindmap node and its enwiki `category`/`page` are the *same concept* (μ ≈ high). The endpoints differ in **node-type** (mindmap_node ⟷ category/page) and possibly name; this is the cross-corpus join (scarce in maps, more in Pearltrees) |
 | `assoc` (explicit relation) | a deliberate cross-link — moderate associative |
 
 The Pearltrees slug is the node identity; the `enwiki_alias`, where present, is the bridge into the enwiki

--- a/prototypes/mu_cosine/SKILL_understand_smmx.md
+++ b/prototypes/mu_cosine/SKILL_understand_smmx.md
@@ -79,7 +79,9 @@ For each real (non-container, non-`wiki`) node:
    a `wiki`-labelled child).
 4. `cloudmapref` on a node (or its blank link-holder child) ⇒ a cross-map edge to that other map's root.
    Set the relation by the **path direction**: `../` (parent folder) ⇒ `super_category` (broader);
-   subfolder (down) ⇒ `subcategory` (narrower).
+   subfolder (down) ⇒ `subcategory` (narrower). **The super-category/parent holder nodes are usually
+   UNNAMED** — to name the target you must **open the linked `.smmx` and read its ROOT node's title +
+   Pearltrees slug** (the tool does this automatically; `--no-resolve` falls back to the filename).
 
 ---
 

--- a/prototypes/mu_cosine/parse_smmx.py
+++ b/prototypes/mu_cosine/parse_smmx.py
@@ -7,8 +7,9 @@ Relation semantics (the structural container retypes its descendants' edge to th
   * plain hierarchy parent→child          → `subtopic`        (membership / narrower)
   * under  See Also / Via Link / Related  → `see_also`        (associative, weakly related)
   * under  Super Categories / Super Cat.  → `super_category`  (broader / parent category)
-  * `cloudmapref` (relative path to another .smmx) → `cloudmapref` (link to that map's ROOT = a parent
-       tree / broader context; element=None ⇒ the whole map)
+  * `cloudmapref` (relative path to another .smmx, when no container tags it) → DIRECTIONAL by the path:
+       `../` UP to a parent folder → `super_category` (target map is a broader PARENT tree);
+       DOWN into a subfolder       → `subcategory`    (target map is narrower / a child)
   * explicit <relation source target>     → `assoc`           (cross-link)
   * a child labelled "wiki"/"Wikipedia", or any node with a direct en.wikipedia.org urllink
        → NOT a node: it sets the enwiki ANCHOR of the node it is attached to (the join key into enwiki)
@@ -138,8 +139,13 @@ def main():
             src_id = i
         if src_id in topics and src_id not in is_anchor:
             tgt = re.sub(r"\.smmx$", "", os.path.basename(ref.rstrip("/")))
-            edges.append((key(topics[src_id]), re.sub(r"[^a-z0-9]+", "_", tgt.lower()).strip("_"),
-                          "cloudmapref"))
+            # DIRECTION from the relative path (when no container tags the relation): a ref UP to a parent
+            # folder (`../`) ⇒ the target map is a broader PARENT (`super_category`); a ref DOWN into a
+            # subfolder ⇒ the target is narrower (`subcategory`). Mirrors the directory-as-taxonomy layout.
+            segs = [s for s in re.split(r"[\\/]+", ref) if s and s != "."]
+            rel = "super_category" if ".." in segs else "subcategory"
+            edges.append((key(topics[src_id]),
+                          re.sub(r"[^a-z0-9]+", "_", tgt.lower()).strip("_"), rel))
 
     # explicit <relation source target> → assoc
     for r in root.findall(".//relation"):
@@ -164,7 +170,7 @@ def main():
             for k, n in sorted(nodes.items()):
                 f.write(f"{k}\t{n['title']}\t{n['slug']}\t{n['pid']}\t{n['enwiki']}\n")
         with open(args.out_prefix + "_edges.tsv", "w", encoding="utf-8") as f:
-            f.write("# src_key\tdst_key\trelation  (subtopic|see_also|super_category|cloudmapref|assoc)\n")
+            f.write("# src_key\tdst_key\trelation  (subtopic|subcategory|see_also|super_category|assoc)\n")
             for a, b, rel in uniq:
                 f.write(f"{a}\t{b}\t{rel}\n")
         print(f"  wrote {args.out_prefix}_nodes.tsv + {args.out_prefix}_edges.tsv")

--- a/prototypes/mu_cosine/parse_smmx.py
+++ b/prototypes/mu_cosine/parse_smmx.py
@@ -11,8 +11,10 @@ Relation semantics (the structural container retypes its descendants' edge to th
        `../` UP to a parent folder → `super_category` (target map is a broader PARENT tree);
        DOWN into a subfolder       → `subcategory`    (target map is narrower / a child)
   * explicit <relation source target>     → `assoc`           (cross-link)
-  * a child labelled "wiki"/"Wikipedia", or any node with a direct en.wikipedia.org urllink
-       → NOT a node: it sets the enwiki ANCHOR of the node it is attached to (the join key into enwiki)
+  * a child labelled "wiki"/"Wikipedia"/"enwiki", or any node with a direct en.wikipedia.org urllink
+       → a `bridge` edge: the node ↔ the SAME concept in enwiki, a node of type `category` (Category:…) or
+       `page`. Same concept, DIFFERENT node-type (mindmap_node ⟷ category/page), possibly different name —
+       the cross-corpus join key. (Scarce in the maps; most live in the Pearltrees data.)
 
 Node identity = Pearltrees slug (from a pearltrees urllink) if present, else the normalised title. Each node
 also carries: title, pearltrees id, enwiki_alias.
@@ -25,11 +27,12 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 import zipfile
+from urllib.parse import unquote
 
 SEE_ALSO = {"See Also", "Via Link", "Related"}
 SUPER = {"Super Categories", "Super Category", "Navigate Up"}
 STRUCTURAL = SEE_ALSO | SUPER | {""}            # "" = blank grouping/section node
-WIKI_LABEL = re.compile(r"^\s*(wiki|wikipedia)\s*$", re.I)
+WIKI_LABEL = re.compile(r"^\s*(wiki|wikipedia|enwiki)\s*$", re.I)
 PEARL = re.compile(r"pearltrees\.com/[^/]+/([^/\"]+)/id(\d+)")
 WIKI_URL = re.compile(r"en\.wikipedia\.org/wiki/(.+)$")
 
@@ -142,14 +145,15 @@ def main():
             p = parent.get(p)
         return p, rel
 
-    nodes, edges = {}, []
+    nodes, edges, id2key = {}, [], {}
     for i, t in topics.items():
         if i in is_anchor or label(topics[i]) in STRUCTURAL:
             continue                               # skip wiki-anchor holders and structural containers
         k = key(t)
         sl, pid = slug_of(t)
         nodes[k] = {"title": label(t), "slug": sl or "", "pid": pid or "",
-                    "enwiki": enwiki.get(i, "")}
+                    "enwiki": enwiki.get(i, ""), "ntype": "mindmap_node"}
+        id2key[i] = k
         # hierarchy edge to effective (non-structural) parent
         pp, rel = eff_parent_and_rel(i)
         if pp in topics and pp not in is_anchor:
@@ -177,12 +181,34 @@ def main():
                 os.path.normpath(os.path.join(base_dir, ref.replace("\\", "/"))))
             if ident:
                 tkey, ttitle, tsl, tpid = ident
-                nodes.setdefault(tkey, {"title": ttitle, "slug": tsl, "pid": tpid, "enwiki": ""})
+                nodes.setdefault(tkey, {"title": ttitle, "slug": tsl, "pid": tpid,
+                                        "enwiki": "", "ntype": "mindmap_node"})
             else:
                 fn = re.sub(r"\.smmx$", "", os.path.basename(ref.rstrip("/")))
                 tkey = re.sub(r"[^a-z0-9]+", "_", fn.lower()).strip("_")
-                nodes.setdefault(tkey, {"title": fn, "slug": "", "pid": "", "enwiki": ""})
+                nodes.setdefault(tkey, {"title": fn, "slug": "", "pid": "",
+                                        "enwiki": "", "ntype": "mindmap_node"})
             edges.append((key(topics[src_id]), tkey, rel))
+
+    # BRIDGE edges: a node tagged wiki/Wikipedia/enwiki ⇒ the SAME concept in enwiki, but a DIFFERENT
+    # node-type (mindmap_node ⟷ category/page) and possibly a different name. These cross-corpus identity
+    # edges are scarce in the maps (most enwiki links live in the Pearltrees data) and therefore valuable —
+    # and the differing endpoint TYPES under one `bridge` relation are exactly the within-operator type
+    # diversity that makes the node-type token informative (REPORT_nodetype.md).
+    for i, w in enwiki.items():
+        if i not in id2key or not w:
+            continue
+        ww = unquote(w).split("#")[0]
+        if ww.startswith("Category:"):
+            ek, etype = ww[len("Category:"):], "category"
+        else:
+            ek, etype = ww, "page"
+        ek = ek.replace(" ", "_").strip("_")
+        if not ek:
+            continue
+        nodes.setdefault(ek, {"title": ek.replace("_", " "), "slug": "", "pid": "",
+                              "enwiki": ek, "ntype": etype})
+        edges.append((id2key[i], ek, "bridge"))
 
     # explicit <relation source target> → assoc
     for r in root.findall(".//relation"):
@@ -198,16 +224,17 @@ def main():
 
     from collections import Counter
     rc = Counter(r for _, _, r in uniq)
-    print(f"{os.path.basename(args.smmx)}: {len(nodes)} nodes, {len(uniq)} edges  {dict(rc)}")
-    print(f"  enwiki-anchored nodes: {sum(1 for n in nodes.values() if n['enwiki'])}")
+    ntc = Counter(n.get("ntype", "mindmap_node") for n in nodes.values())
+    print(f"{os.path.basename(args.smmx)}: {len(nodes)} nodes {dict(ntc)}, {len(uniq)} edges {dict(rc)}")
+    print(f"  bridges (mindmap↔enwiki): {rc.get('bridge', 0)}")
 
     if args.out_prefix:
         with open(args.out_prefix + "_nodes.tsv", "w", encoding="utf-8") as f:
-            f.write("# node_key\ttitle\tpearltrees_slug\tpearltrees_id\tenwiki_alias\n")
+            f.write("# node_key\tnode_type\ttitle\tpearltrees_slug\tpearltrees_id\tenwiki_alias\n")
             for k, n in sorted(nodes.items()):
-                f.write(f"{k}\t{n['title']}\t{n['slug']}\t{n['pid']}\t{n['enwiki']}\n")
+                f.write(f"{k}\t{n.get('ntype','mindmap_node')}\t{n['title']}\t{n['slug']}\t{n['pid']}\t{n['enwiki']}\n")
         with open(args.out_prefix + "_edges.tsv", "w", encoding="utf-8") as f:
-            f.write("# src_key\tdst_key\trelation  (subtopic|subcategory|see_also|super_category|assoc)\n")
+            f.write("# src_key\tdst_key\trelation  (subtopic|subcategory|see_also|super_category|bridge|assoc)\n")
             for a, b, rel in uniq:
                 f.write(f"{a}\t{b}\t{rel}\n")
         print(f"  wrote {args.out_prefix}_nodes.tsv + {args.out_prefix}_edges.tsv")

--- a/prototypes/mu_cosine/parse_smmx.py
+++ b/prototypes/mu_cosine/parse_smmx.py
@@ -70,11 +70,39 @@ def cloud_of(t):
     return None, None
 
 
+def _key_from(slug, title):
+    return slug or re.sub(r"[^a-z0-9]+", "_", (title or "").lower()).strip("_")
+
+
+_ROOT_CACHE = {}
+def root_identity(smmx_path):
+    """Open a linked .smmx and read its ROOT node's identity — because super-category/parent (and many
+    cloudmapref) holder nodes are UNNAMED in the source map; the real name + Pearltrees slug lives on the
+    linked map's central theme. Returns (key, title, slug, pid) or None if the file can't be read."""
+    if smmx_path in _ROOT_CACHE:
+        return _ROOT_CACHE[smmx_path]
+    out = None
+    try:
+        r = load_xml(smmx_path)
+        ts = r.findall(".//topic")
+        rt = next((t for t in ts if (t.get("parent") in (None, "-1"))), ts[0] if ts else None)
+        if rt is not None:
+            sl, pid = slug_of(rt)
+            out = (_key_from(sl, label(rt)), label(rt), sl or "", pid or "")
+    except Exception:
+        out = None
+    _ROOT_CACHE[smmx_path] = out
+    return out
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("smmx")
     ap.add_argument("--out-prefix", default=None, help="write <prefix>_nodes.tsv + <prefix>_edges.tsv")
+    ap.add_argument("--no-resolve", action="store_true", help="don't open linked maps to name cloudmapref "
+                    "targets (offline / single-file mode); fall back to the filename")
     args = ap.parse_args()
+    base_dir = os.path.dirname(os.path.abspath(args.smmx))
 
     root = load_xml(args.smmx)
     topics = {t.get("id"): t for t in root.findall(".//topic")}
@@ -138,14 +166,23 @@ def main():
         else:
             src_id = i
         if src_id in topics and src_id not in is_anchor:
-            tgt = re.sub(r"\.smmx$", "", os.path.basename(ref.rstrip("/")))
             # DIRECTION from the relative path (when no container tags the relation): a ref UP to a parent
             # folder (`../`) ⇒ the target map is a broader PARENT (`super_category`); a ref DOWN into a
             # subfolder ⇒ the target is narrower (`subcategory`). Mirrors the directory-as-taxonomy layout.
             segs = [s for s in re.split(r"[\\/]+", ref) if s and s != "."]
             rel = "super_category" if ".." in segs else "subcategory"
-            edges.append((key(topics[src_id]),
-                          re.sub(r"[^a-z0-9]+", "_", tgt.lower()).strip("_"), rel))
+            # NAME the target from the linked map's ROOT node (holder/parent nodes are usually unnamed);
+            # fall back to the filename if the linked file can't be opened.
+            ident = None if args.no_resolve else root_identity(
+                os.path.normpath(os.path.join(base_dir, ref.replace("\\", "/"))))
+            if ident:
+                tkey, ttitle, tsl, tpid = ident
+                nodes.setdefault(tkey, {"title": ttitle, "slug": tsl, "pid": tpid, "enwiki": ""})
+            else:
+                fn = re.sub(r"\.smmx$", "", os.path.basename(ref.rstrip("/")))
+                tkey = re.sub(r"[^a-z0-9]+", "_", fn.lower()).strip("_")
+                nodes.setdefault(tkey, {"title": fn, "slug": "", "pid": "", "enwiki": ""})
+            edges.append((key(topics[src_id]), tkey, rel))
 
     # explicit <relation source target> → assoc
     for r in root.findall(".//relation"):


### PR DESCRIPTION
## Summary
Three refinements to the SimpleMind `.smmx` parser (`parse_smmx.py`) + its Haiku skill
(`SKILL_understand_smmx.md`), making the parsed mindmap graph faithful enough to feed the
human-judge (`corpus=mindmap`) pipeline. Prototype only; no model/training code touched.

## What changed

### 1. Directional `cloudmapref` (sub vs super by path)
When no container tags a cross-map link's relation, infer it from the relative-path
direction (the folder layout *is* the taxonomy):
- `../` **up** to a parent folder → `super_category` (target map is a broader parent tree)
- **down** into a subfolder → `subcategory` (target is narrower — a dedicated sub-map)

Replaces the generic `cloudmapref` relation. (Cybernetics' upward chain → all
`super_category`; System Theory → `subcategory` for chaos/complex/dynamical/LTI sub-maps.)

### 2. Name the target from the linked map's ROOT
Super-category / parent (and many cloudmapref) holder nodes are **unnamed** in the source
map — the real name + Pearltrees slug live on the **linked map's central theme**. The
parser now resolves each relative path, opens that `.smmx`, and reads its root topic's
title + slug as the target identity (cached; `--no-resolve` falls back to the filename).
It even fixes source typos (`Differentail Equation` node → linked root `Differential
Equation`); a node linking down to its own sub-map collapses to a self-edge and drops.

### 3. `bridge` relation — mindmap node ⟷ enwiki category/page
A node tagged `wiki`/`Wikipedia`/`enwiki` (or with a direct `en.wikipedia.org` urllink)
emits a typed **`bridge`** edge to the *same concept* in enwiki — a `category` (if
`Category:…`) or `page`. Same concept, **different node-type** (`mindmap_node` ⟷
`category`/`page`), possibly different name — the cross-corpus join key. `nodes.tsv`
gains a `node_type` column.

Bridges are **scarce in the maps** (System Theory: 1, `network_theory → Category:Network_theory`;
most enwiki links live in the Pearltrees data) and therefore **valuable**: the differing
endpoint types under one relation are exactly the **within-operator type diversity** that
makes the node-type token informative (`REPORT_nodetype.md`) — a primary source of the data
that activates `--use-nodetype`.

## Output
- `*_nodes.tsv`: `node_key · node_type · title · pearltrees_slug · pearltrees_id · enwiki_alias`
- `*_edges.tsv`: `src_key · dst_key · relation` — vocabulary now
  `subtopic | subcategory | see_also | super_category | bridge | assoc`

## Verified
Run on Cybernetics (29 nodes) and System Theory (115 nodes: 114 `mindmap_node` + 1
`category`; 133 edges incl. 26 `super_category`, 1 `subcategory`, 23 `see_also`, 1
`bridge`, 5 `assoc`), with cloudmapref targets correctly named from linked-map roots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)