### PR TITLE
mu_cosine: bridge_seeds.py — connect SimpleMind mindmaps to Wikipedia via Pearltrees (72 concepts, 2665 bridges)

### DIFF
--- a/prototypes/mu_cosine/.gitignore
+++ b/prototypes/mu_cosine/.gitignore
@@ -36,3 +36,5 @@ data_gaps.tsv
 page_members_gaps.tsv
 mu_pairs_pages_gaps.tsv
 mu_pairs_scored_pages_gaps_*_div.tsv
+.pt_cache/
+*_bridges.tsv

--- a/prototypes/mu_cosine/REPORT_bridge_to_wikipedia.md
+++ b/prototypes/mu_cosine/REPORT_bridge_to_wikipedia.md
@@ -1,0 +1,41 @@
+# Bridging the SimpleMind mindmaps to Wikipedia — via Pearltrees (3 hops)
+
+The end-to-end "try what we built" run: connect the **systems-theory SimpleMind mindmap** to the Wikipedia
+category/page graph, using Pearltrees as the bridge corpus.
+
+## Pipeline
+1. `parse_smmx.py "System Theory.smmx"` → 110 nodes; **91 carry a Pearltrees tree-id** (the harvest seeds).
+2. `bridge_seeds.py` takes each seed and reads its harvested Pearltrees subtree (harvesting via the private
+   `.local` cookie harvester if not cached) for the enwiki links each collection carries (its
+   `Wiki / Encyclopedia type References`).
+3. Output: **mindmap-concept → enwiki** `bridge` edges — the concept's own Wikipedia category plus its
+   neighbourhood.
+
+## Result (sample of 6 seeds, depth 1)
+6 concepts → **208 bridges (43 to enwiki Categories)**. Each concept reaches its own category *and* a rich
+neighbourhood:
+
+| mindmap concept | principal bridge | + neighbourhood (sample) |
+|---|---|---|
+| `chaos-theory` | `Category:Chaos_theory` | Butterfly_effect, Catastrophe_theory, Feigenbaum_constants, `Category:Quantum_chaos_theory`, ~50 more |
+| `bifurcation-theory` | `Category:Bifurcation_theory` | Pitchfork/Saddle-node/Transcritical bifurcation, Feigenbaum_constants |
+| `dynamical-systems` | `Category:Dynamical_systems` | `Category:Ergodic_theory`, `Category:Stability_theory`, `Category:Symbolic_dynamics` |
+| `celestial-mechanics` | `Category:Celestial_mechanics` | `Category:Astrodynamics`, `Category:Orbits`, Barycenter |
+| `artificial-life` | `Category:Artificial_life` | Boids, Langton's_ant, Tierra, ~50 ALife pages |
+| `butterfly-effect` | `Butterfly_effect` (page) | — |
+
+So the bridge is **dense**: a single mindmap concept maps not to one Wikipedia node but to its category +
+dozens of member pages / sibling categories — exactly the bridge-rich behaviour expected of Pearltrees.
+
+## Notes
+- **Harvester relocation fix.** Moving `fetch_pearltrees_tree.py` into `.local` broke its cookie path
+  (it assumed the old `prototypes/mu_cosine` location and doubled `.local/tools`). Fixed in the private
+  `.local` copy: cookies now resolved as `<script>/../pearltrees_cookies.txt`.
+- `bridge_seeds.py` is **ref-based** and committed; the harvest cache (`.pt_cache/`) and `*_bridges.tsv`
+  are gitignored (regenerable, contain private Pearltrees data). `--no-harvest` runs on cached harvests
+  only (graceful on clones without `.local`).
+
+## Next
+Feed the `bridge` edges (+ the mindmap `subtopic`/`see_also`/… edges, tagged `corpus=mindmap, judge=human`,
+node-types `mindmap_node`/`category`/`page`) into a graded round, then flip `--use-nodetype` on — these
+mindmap↔enwiki bridges are exactly the within-operator type diversity `REPORT_nodetype.md` found missing.

--- a/prototypes/mu_cosine/bridge_seeds.py
+++ b/prototypes/mu_cosine/bridge_seeds.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Bridge a SimpleMind mindmap to Wikipedia, via Pearltrees — the end-to-end "3 hops from the mindmap"
+walk. Ref-based: it reads a parsed mindmap's nodes (parse_smmx.py → *_nodes.tsv), takes each node's
+Pearltrees tree-id as a harvest SEED, and reads the harvested Pearltrees subtree for the enwiki links each
+collection carries (its "Wiki / Encyclopedia type References"). Output: mindmap-concept → enwiki edges
+(`bridge`), the cross-corpus join that connects the mindmap to the Wikipedia category/page graph.
+
+Harvesting is PRIVATE (`.local`): if a seed isn't already harvested under --cache and the private harvester
+exists, this drives it (`.local/tools/browser-automation/scripts/fetch_pearltrees_tree.py`, cookie session);
+otherwise it skips (graceful on clones without `.local`). See SKILL_understand_pearltrees.md.
+
+    python3 parse_smmx.py "System Theory.smmx" --out-prefix systh
+    python3 bridge_seeds.py --nodes systh_nodes.tsv --depth 1 --out systh_bridges.tsv
+"""
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(ROOT, "..", ".."))
+HARVESTER = os.path.join(REPO, ".local", "tools", "browser-automation", "scripts", "fetch_pearltrees_tree.py")
+WIKI = re.compile(r"en\.wikipedia\.org/wiki/(.+)$")
+
+
+def harvested_path(cache, tid):
+    return os.path.join(cache, f"pt_{tid}.tsv")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--nodes", required=True, help="*_nodes.tsv from parse_smmx.py")
+    ap.add_argument("--cache", default=os.path.join(ROOT, ".pt_cache"), help="harvested-subtree cache dir")
+    ap.add_argument("--depth", type=int, default=1, help="harvest depth per seed (1 = the collection only)")
+    ap.add_argument("--account", default="s243a")
+    ap.add_argument("--no-harvest", action="store_true", help="only use already-cached harvests")
+    ap.add_argument("--out", default=os.path.join(ROOT, "mindmap_bridges.tsv"))
+    args = ap.parse_args()
+    os.makedirs(args.cache, exist_ok=True)
+
+    seeds = []                                    # (concept_slug, pearltrees_tree_id)
+    for ln in open(args.nodes, encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        c = ln.rstrip("\n").split("\t")
+        if len(c) >= 5 and c[4].strip().isdigit():   # node_key, node_type, title, slug, pearltrees_id
+            seeds.append((c[0], c[4].strip()))
+    print(f"{len(seeds)} mindmap concepts carry a Pearltrees tree-id (seeds)")
+
+    can_harvest = (not args.no_harvest) and os.path.exists(HARVESTER)
+    if not can_harvest:
+        print("  (harvesting disabled — using cached harvests only)" if args.no_harvest
+              else "  (private harvester not found in .local — using cached harvests only)")
+
+    rows, harvested, skipped = [], 0, 0
+    for slug, tid in seeds:
+        path = harvested_path(args.cache, tid)
+        if not os.path.exists(path) and can_harvest:
+            try:
+                subprocess.run([sys.executable, HARVESTER, "--tree-id", tid, "--account", args.account,
+                                "--depth", str(args.depth), "--out", path],
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=120)
+            except Exception:
+                pass
+        if not os.path.exists(path):
+            skipped += 1
+            continue
+        harvested += 1
+        seen = set()
+        for hl in open(path, encoding="utf-8"):
+            if hl.startswith("#"):
+                continue
+            f = hl.rstrip("\n").split("\t")
+            if len(f) >= 5:
+                m = WIKI.search(f[4])
+                if m:
+                    title = m.group(1).split("#")[0]
+                    if title not in seen:
+                        seen.add(title)
+                        rows.append((slug, title))
+
+    with open(args.out, "w", encoding="utf-8") as f:
+        f.write("# mindmap_concept\tenwiki_title\trelation=bridge  (concept → Wikipedia, via Pearltrees)\n")
+        for slug, title in rows:
+            f.write(f"{slug}\t{title}\tbridge\n")
+    cats = sum(1 for _, t in rows if t.startswith("Category:"))
+    print(f"harvested {harvested}/{len(seeds)} seeds ({skipped} unavailable); {len(rows)} bridges "
+          f"({cats} to enwiki Categories) over {len({s for s, _ in rows})} concepts -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
End-to-end "try what we built": bridge the **systems-theory SimpleMind mindmap** to the
Wikipedia category/page graph, using **Pearltrees** as the bridge corpus. Confirms the
three-corpus identity fabric is real and operational. Prototype only; no model/training
code touched; no credentials or private data committed.

## Pipeline
1. `parse_smmx.py "System Theory.smmx"` → 110 nodes; **91 carry a Pearltrees tree-id** (seeds).
2. **`bridge_seeds.py`** (new) takes each seed and reads its harvested Pearltrees subtree
   for the enwiki links the collection carries (its `Wiki / Encyclopedia type References`),
   emitting **mindmap-concept → enwiki `bridge`** edges.
3. It is **ref-based**: drives the *private* `.local` cookie harvester **only if it exists**
   (`--no-harvest` for cached-only); graceful on clones without `.local`.

## Result (full run — all 91 seeds harvested)
- **2,665 bridges, 256 to enwiki Categories, over 72 of 91 concepts.**
- **40+ concepts map *exactly* to their Wikipedia category** (name-matched principal
  bridges): `chaos-theory→Category:Chaos_theory`, `bifurcation-theory→Category:Bifurcation_theory`,
  `dynamical-systems→Category:Dynamical_systems`, `control-theory→Category:Control_theory`,
  `emergence→Category:Emergence`, `feedback→Category:Feedback`, `holism→Category:Holism`,
  `network-flow-problem→Category:Network_flow_problem`, `systems-analysis→Category:Systems_analysis`, …
- Each concept also reaches a dense Wikipedia neighbourhood (e.g. `chaos-theory` → its
  category + ~50 pages/sibling categories).

## What's committed
- `bridge_seeds.py` — the ref-based driver.
- `REPORT_bridge_to_wikipedia.md` — the run + a note on the `.local` harvester cookie-path
  fix (the earlier move into `.local` had doubled `.local/tools`; fixed in the private copy).
- `.gitignore` — `.pt_cache/` and `*_bridges.tsv` (regenerable; contain private Pearltrees data).

## Verified
`91/91` seeds harvested; **2,665 bridges / 256 Categories / 72 concepts**. Confirmed no
`.local` content, harvest cache, or `*_bridges.tsv` staged.

## Next (not in this PR)
Turn these bridges + the mindmap's typed edges into a graded `corpus=mindmap, judge=human`
round, then flip `--use-nodetype` on — the 2,665 `mindmap_node ⟷ category/page` bridges are
the within-operator type diversity `REPORT_nodetype.md` found missing. (Harvest depth 2 would
likely fill the 19 unbridged seeds.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)