### PR TITLE
mu_cosine: cross-corpus fusion walker + provenance/group-representation design

### DIFF
--- a/prototypes/mu_cosine/.gitignore
+++ b/prototypes/mu_cosine/.gitignore
@@ -38,3 +38,4 @@ mu_pairs_pages_gaps.tsv
 mu_pairs_scored_pages_gaps_*_div.tsv
 .pt_cache/
 *_bridges.tsv
+*_fused_*.tsv

--- a/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
+++ b/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
@@ -1,0 +1,57 @@
+# Provenance axes & node representation — what gets a learned table vs frozen e5
+
+Design decisions from the multi-corpus (SimpleMind + Pearltrees + enwiki) work, on where to spend learned
+parameters. Companion to `DESIGN_calibrated_judges.md` §7 (operators / node-types).
+
+## The dividing line: **if the table grows with the data, it is NOT a learned table**
+
+Learned **factored tokens** are only for **small, closed, categorical** axes — a handful of values, each
+seen often enough to train. Everything **open-ended** rides **frozen e5** instead (the reason nodes have no
+per-node embedding: cold-start safety, no overfitting, no table that grows with the corpus).
+
+| axis | kind | values | mechanism |
+|---|---|---|---|
+| `op` | closed | SYM / WIKI / ELEM / LLM | learned token + readout row |
+| `corpus` (source) | closed | simplewiki / enwiki / pearltrees / mindmap | learned token (maskable provenance) |
+| `judge` | closed | haiku / graph / human | learned token (maskable provenance) |
+| **`account`** | closed | **`s243a` / `s243a_groups`** | learned token (maskable provenance) — NEW |
+| `nodetype` | closed | category / page / mindmap_node / pearltrees_collection | learned token (+ optional transform, below) |
+| **node identity** | open | every concept | **frozen e5** (no table) |
+| **group** | open | every Pearltrees group | **frozen e5**, optionally a *transform* (below) — NOT a per-group table |
+
+## Account (the two Pearltrees accounts)
+
+`account ∈ {s243a, s243a_groups}` is a 2-value token in the **maskable provenance** slot, alongside
+`corpus ⊗ judge`. Maskable ⇒ an account-agnostic default (marginalize it out) plus the ability to condition
+when the accounts differ in convention/quality. The field is already in the harvested `trees.account` /
+API `asso`, so carrying it through `parse_pearltrees.py` → the graded pairs is free. Gate `--use-account`,
+default off; activate once **both** accounts' data is in (single-account data makes `account` collinear with
+`corpus` — node-type's collinearity trap again).
+
+## Groups: a transform of e5, never a per-group table
+
+A Pearltrees **group** is open-ended (grows with the data), so it is a **node with frozen e5**, not a
+learned table. When group-level conditioning is wanted *beyond* what e5 + the `account` token give, use a
+**learned transform of e5** — `group_repr = T(e5_group)` — NOT a per-group row:
+
+- **Parametric & shared.** `T` is the parameters, not a per-entity row, so it never grows with the number
+  of groups and **generalizes to unseen groups** (any new group's e5 → `T` → a sensible rep).
+- **Piggybacks e5.** Initialise `T` **near identity** ⇒ at warm start a group's rep *is* its e5 (full
+  piggyback on e5's pretrained semantics); fine-tuning learns only the group-specific **delta**. Same bet
+  as the rest of the model (frozen e5 carries meaning; learned parts are small deltas).
+- **Generalises node-type.** Today node-type conditions e5 *additively* (`e5 + nodetype_emb[type]`, a per-
+  type shift). A transform conditions it *multiplicatively* (`T_type(e5)`, a per-type projection that can
+  rotate/rescale/reweight e5 dims) — strictly more expressive, same cold-start safety.
+
+### Choices to settle when we build it
+- **Input e5:** the group's **title** e5 (cheap, uniform) vs the **centroid of its members' e5** (a group
+  *is* its contents) vs both concatenated. Lean: member-centroid for collections.
+- **Scope:** one `T_group`, or **per-node-type** transforms (`T_category`, `T_page`, `T_group`, …) making
+  the whole node-type axis projection-based.
+- **Form:** start a **Linear** `d→d` (~150K params at d=384), init near identity; MLP only if it underfits.
+- **Compose or replace:** keep the additive `nodetype_emb` *and* add `T`, or let `T` subsume it.
+
+### Discipline (same as node-type)
+Init near identity, **gate** (`--group-transform`), and **A/B** it — only once group/multi-account data is
+flowing. Adding an expressive transform before the data has group diversity is node-type's collinearity
+problem with more parameters to overfit.

--- a/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
+++ b/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
@@ -52,7 +52,8 @@ learned table. Group membership conditions a member node via a **learned transfo
   *is* its contents) vs both concatenated. Lean: member-centroid for collections.
 - **Scope:** one `T_group`, or **per-node-type** transforms (`T_category`, `T_page`, `T_group`, …) making
   the whole node-type axis projection-based.
-- **Form:** start a **Linear** `d→d` (~150K params at d=384), init near identity; MLP only if it underfits.
+- **Form:** start a **Linear** `d→d` (~150K params at d=384), **zero-init its output** so it starts as a
+  no-op (see "Warm-start no-op" above — *not* identity); MLP only if it underfits.
 - **Compose or replace:** keep the additive `nodetype_emb` *and* add `T`, or let `T` subsume it.
 
 ### Group is a *weak* structural signal (calibration & magnitude)
@@ -133,7 +134,7 @@ the *attachment point*.
 | 1 | **Per-group learned axis** (treat group like type/op) | a per-group **table row** | ✗ open-ended → table grows with data; most groups seen too rarely to train a row. This is "adding it to types," and it breaks on **many-groups ≫ few-types**. |
 | 2 | **Separate group token** in the sequence (maskable, provenance-style) | `T(e5_group)` | ✗ one per-example token can't say *different nodes belong to different groups* — group is **per-node**, not per-example; + costs a token. |
 | 3 | **Added to the node embedding, per-node** (parallel to `nodetype_emb`) | `T(e5_group_of_node)` | ✓ **the lean.** Per-node (each node carries its own group's signal); identical mechanism, warm-start, and gating story as node-type; no extra token. |
-| 4 | **Concat + project** the node and group e5 | `W·[e5_node ; T(e5_group)]` | ~ more expressive (interaction terms) but changes the input projection and is hard to init near-identity; hold as an upgrade if (3) underfits. |
+| 4 | **Concat + project** the node and group e5 | `W·[e5_node ; T(e5_group)]` | ~ more expressive (interaction terms) but changes the input projection and is harder to warm-start as a clean no-op; hold as an upgrade if (3) underfits. |
 
 **Recommendation: option 3.** `node_emb += T(e5_group_of_node)`, exactly mirroring
 `node_emb += nodetype_emb[type]`, with `T` a shared Linear whose **output is zero-initialised** so it starts
@@ -160,6 +161,6 @@ The group's **title** e5 (cheap, uniform) vs the **centroid of its member nodes'
 contents). Lean: member-centroid for collections; revisit if titles prove more discriminative.
 
 ## Discipline (same as node-type)
-Init near identity, **gate** (`--group-transform`), and **A/B** it — only once group/multi-account data is
-flowing. Adding an expressive transform before the data has group diversity is node-type's collinearity
-problem with more parameters to overfit.
+**Zero-init `T`'s output** (no-op at warm start — *not* identity), **gate** (`--group-transform`), and
+**A/B** it — only once group/multi-account data is flowing. Adding an expressive transform before the data
+has group diversity is node-type's collinearity problem with more parameters to overfit.

--- a/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
+++ b/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
@@ -55,6 +55,34 @@ learned table. Group membership conditions a member node via a **learned transfo
 - **Form:** start a **Linear** `d→d` (~150K params at d=384), init near identity; MLP only if it underfits.
 - **Compose or replace:** keep the additive `nodetype_emb` *and* add `T`, or let `T` subsume it.
 
+### Group is a *weak* structural signal (calibration & magnitude)
+
+Group membership is **softer than category membership**: a group is user-curated and may not stay perfectly
+on topic (a "Systems Theory" group can hold off-topic pearls). There is a **confidence gradient** among the
+structural modifiers:
+
+> **node-type** (a hard fact — a page *is* a page) > **category membership** (curated, reliable) >
+> **group membership** (user-curated, *drifty*).
+
+Encode that weakness two ways — both levers we already use elsewhere:
+
+- **Soft / one-sided target.** Train group edges to a *ranged* target, `μ(node|group) ≳ low`, not a sharp
+  value (cf. the cross-entropy "it can be a range (e.g. `>`)" idea) — so topical drift isn't punished as
+  error the way a curated category miss would be.
+- **Small-magnitude modifier.** Extra weight-decay / lower LR on `T` so it learns a **gentle nudge**, not a
+  shift that overwrites the node's own e5 (the same "back-prop on it less" lever as the ELEM operator).
+
+The weakness also **reinforces** the transform-over-table choice: a per-group table could *memorise* the
+noisy membership, whereas a shared, zero-init, regularised `T` with a soft target is far more robust to drift.
+
+### Deferred: the transform's input embedding
+
+`T`'s input is **e5 for now**. In principle it could take a *different* frozen encoder (e.g. miniLM) — `T`
+doesn't care what vector feeds it, so adopting one later is a **localised** change (swap only what goes into
+`T`). Adopting it *now* would fragment the single uniform e5 space every node shares into two encoder spaces
+to manage — implicit complexity for no present gain. **Stick to e5**; revisit miniLM only if e5 proves
+insufficient for the group signal specifically.
+
 ## Two buckets, not one: **provenance** (maskable token) vs **structure** (on the node)
 
 The first cut lumped everything "factored" together; sharpen it into two buckets that behave differently:

--- a/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
+++ b/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
@@ -75,13 +75,38 @@ Encode that weakness two ways — both levers we already use elsewhere:
 The weakness also **reinforces** the transform-over-table choice: a per-group table could *memorise* the
 noisy membership, whereas a shared, zero-init, regularised `T` with a soft target is far more robust to drift.
 
-### Deferred: the transform's input embedding
+### Learned per-group credibility (v2 extension; v1 stays uniform)
 
-`T`'s input is **e5 for now**. In principle it could take a *different* frozen encoder (e.g. miniLM) — `T`
-doesn't care what vector feeds it, so adopting one later is a **localised** change (swap only what goes into
-`T`). Adopting it *now* would fragment the single uniform e5 space every node shares into two encoder spaces
-to manage — implicit complexity for no present gain. **Stick to e5**; revisit miniLM only if e5 proves
-insufficient for the group signal specifically.
+The weakness is **heterogeneous**: groups vary *a lot* in internal source credibility / on-topic-ness — more
+than categories do. The model **can** learn which groups are more credible — but **only as a function of
+observable group features**, *never* a per-group learned scalar (that is the growing-table violation again).
+
+Implement as a learned **gate** `α(group) ∈ (0,1]` scaling the membership modifier:
+
+```
+node_emb += α(group) · T(e5_group)
+```
+
+with `α` computed from:
+- the group's **e5** (topic), and/or
+- the **dispersion of its members' e5** — a *tight* cluster of member embeddings = on-topic/credible →
+  larger `α`; a *scattered* group = drifty → smaller `α`. Coherence is computable straight from the members,
+  **no table**.
+
+Credible groups nudge harder, drifty ones barely. This turns the *global* "small-magnitude modifier"
+regulariser into a **per-group, e5/coherence-derived** one — still cold-start-safe (works on unseen groups),
+still no growing table. Start `α` at a neutral constant (≡ v1 behaviour) and learn deviations.
+
+Note the closed-vs-open split holds here too: **account**-level credibility (`s243a` vs `s243a_groups`) is
+fine as the small 2-value token; **per-group** credibility is the open case that *must* be a function.
+
+### Alternative: the transform's input embedding (documented, deferred)
+
+`T`'s input is **e5 for now**, but a *different* frozen encoder (e.g. **miniLM**) is a legitimate alternative
+input — `T` doesn't care what vector feeds it, so swapping/adding one later is a **localised** change (change
+only what goes into `T`). We **defer** it deliberately: adopting it now would fragment the single uniform e5
+space every node shares into two encoder spaces to manage — implicit complexity for no present gain. Recorded
+as a real option, not ruled out; **stick to e5** until there's a measured reason group needs its own encoder.
 
 ## Two buckets, not one: **provenance** (maskable token) vs **structure** (on the node)
 

--- a/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
+++ b/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
@@ -17,7 +17,7 @@ per-node embedding: cold-start safety, no overfitting, no table that grows with 
 | **`account`** | closed | **`s243a` / `s243a_groups`** | learned token (maskable provenance) — NEW |
 | `nodetype` | closed | category / page / mindmap_node / pearltrees_collection | learned token (+ optional transform, below) |
 | **node identity** | open | every concept | **frozen e5** (no table) |
-| **group** | open | every Pearltrees group | **frozen e5**, optionally a *transform* (below) — NOT a per-group table |
+| **group** | open | every Pearltrees group | **frozen e5 → required transform `T`** added to the member node (below) — NOT a per-group table, never raw e5 |
 
 ## Account (the two Pearltrees accounts)
 
@@ -31,17 +31,21 @@ default off; activate once **both** accounts' data is in (single-account data ma
 ## Groups: a transform of e5, never a per-group table
 
 A Pearltrees **group** is open-ended (grows with the data), so it is a **node with frozen e5**, not a
-learned table. When group-level conditioning is wanted *beyond* what e5 + the `account` token give, use a
-**learned transform of e5** — `group_repr = T(e5_group)` — NOT a per-group row:
+learned table. Group membership conditions a member node via a **learned transform of e5** that is
+**added** to the node — `node_emb += T(e5_group)` — NOT a per-group row, and **never raw e5**:
 
+- **The transform is mandatory, not optional.** A group's e5 is a point in *content space* (same space as
+  node e5). Adding it **raw** onto a member node would inject *another concept's vector* into the node, not
+  a membership signal. `T` is what **maps e5 → the additive node-role space** — it plays the role the table
+  plays for node-type, except its input is a *continuous e5* instead of a *discrete index*:
+  - node-type: `index → table-lookup → add` (the row is already a free learned vector in add-space)
+  - group:     `e5 → T → add`            (e5 is frozen, so a learned map into add-space is **required**)
 - **Parametric & shared.** `T` is the parameters, not a per-entity row, so it never grows with the number
-  of groups and **generalizes to unseen groups** (any new group's e5 → `T` → a sensible rep).
-- **Piggybacks e5.** Initialise `T` **near identity** ⇒ at warm start a group's rep *is* its e5 (full
-  piggyback on e5's pretrained semantics); fine-tuning learns only the group-specific **delta**. Same bet
-  as the rest of the model (frozen e5 carries meaning; learned parts are small deltas).
-- **Generalises node-type.** Today node-type conditions e5 *additively* (`e5 + nodetype_emb[type]`, a per-
-  type shift). A transform conditions it *multiplicatively* (`T_type(e5)`, a per-type projection that can
-  rotate/rescale/reweight e5 dims) — strictly more expressive, same cold-start safety.
+  of groups and **generalizes to unseen groups** (any new group's e5 → `T` → a sensible modifier).
+- **Warm-start no-op = zero output, NOT identity.** Zero-init `T`'s final layer so at warm start it **adds
+  nothing**, then learns the membership delta — exactly mirroring `nodetype_emb`'s zero-init. (Identity-init
+  would *add the raw group e5*, i.e. the wrong thing. Near-identity only applies to the *other* use — when a
+  group appears as its **own standalone node** and `T(e5)` *is* its representation; different role.)
 
 ### Choices to settle when we build it
 - **Input e5:** the group's **title** e5 (cheap, uniform) vs the **centroid of its members' e5** (a group
@@ -79,10 +83,12 @@ the *attachment point*.
 | 4 | **Concat + project** the node and group e5 | `W·[e5_node ; T(e5_group)]` | ~ more expressive (interaction terms) but changes the input projection and is hard to init near-identity; hold as an upgrade if (3) underfits. |
 
 **Recommendation: option 3.** `node_emb += T(e5_group_of_node)`, exactly mirroring
-`node_emb += nodetype_emb[type]`, with `T` a shared Linear init **near identity** so it starts as a **no-op**
-(warm-start-safe, the same reason `nodetype_emb` is zero-init). Minimal change; respects both constraints —
-the **per-node** nature of membership (so it goes on the node, not a global token) and the **open cardinality**
-(so the modifier is an e5-*transform* that generalizes, not a per-group row).
+`node_emb += nodetype_emb[type]`, with `T` a shared Linear whose **output is zero-initialised** so it starts
+as a **no-op** (warm-start-safe, the *same* reason `nodetype_emb` is zero-init — and **not** identity-init,
+which would add the raw group e5). Minimal change; respects both constraints — the **per-node** nature of
+membership (so it goes on the node, not a global token) and the **open cardinality** (so the modifier is an
+e5-*transform* that generalizes, not a per-group row). The transform is *required* here: raw e5 is the wrong
+space (see "The transform is mandatory" above).
 
 ### The unifying statement
 

--- a/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
+++ b/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
@@ -51,7 +51,56 @@ learned table. When group-level conditioning is wanted *beyond* what e5 + the `a
 - **Form:** start a **Linear** `d→d` (~150K params at d=384), init near identity; MLP only if it underfits.
 - **Compose or replace:** keep the additive `nodetype_emb` *and* add `T`, or let `T` subsume it.
 
-### Discipline (same as node-type)
+## Two buckets, not one: **provenance** (maskable token) vs **structure** (on the node)
+
+The first cut lumped everything "factored" together; sharpen it into two buckets that behave differently:
+
+- **Provenance** — *where a label came from*: `corpus`, `judge`, `account`. Lives on its **own maskable
+  token** (mask it ⇒ a provenance-agnostic μ; unmask ⇒ condition on the source). You want to be able to
+  *marginalize it out*, so it is deliberately separable from the node.
+- **Structure** — *what a node is / what it belongs to*: `node-type`, `group`. **Added to the node's own
+  embedding**, per-node, **always on** (it is an intrinsic property of the node, not something you'd average
+  away). `mu_attention.py:317` already does this for node-type: `emb += nodetype_emb[type] * mask`.
+
+`account` is provenance (maskable). **`group` is structure** — same bucket as node-type, *not* provenance.
+That is the crux of your point.
+
+## Alternatives: where does group conditioning attach?
+
+Group membership is a *node* property, so the design question is **where the group signal enters** and
+**where its modifier vector comes from**. Cardinality (many groups, few types) constrains the *source*, not
+the *attachment point*.
+
+| # | Attachment | Source of modifier | Verdict |
+|---|---|---|---|
+| 1 | **Per-group learned axis** (treat group like type/op) | a per-group **table row** | ✗ open-ended → table grows with data; most groups seen too rarely to train a row. This is "adding it to types," and it breaks on **many-groups ≫ few-types**. |
+| 2 | **Separate group token** in the sequence (maskable, provenance-style) | `T(e5_group)` | ✗ one per-example token can't say *different nodes belong to different groups* — group is **per-node**, not per-example; + costs a token. |
+| 3 | **Added to the node embedding, per-node** (parallel to `nodetype_emb`) | `T(e5_group_of_node)` | ✓ **the lean.** Per-node (each node carries its own group's signal); identical mechanism, warm-start, and gating story as node-type; no extra token. |
+| 4 | **Concat + project** the node and group e5 | `W·[e5_node ; T(e5_group)]` | ~ more expressive (interaction terms) but changes the input projection and is hard to init near-identity; hold as an upgrade if (3) underfits. |
+
+**Recommendation: option 3.** `node_emb += T(e5_group_of_node)`, exactly mirroring
+`node_emb += nodetype_emb[type]`, with `T` a shared Linear init **near identity** so it starts as a **no-op**
+(warm-start-safe, the same reason `nodetype_emb` is zero-init). Minimal change; respects both constraints —
+the **per-node** nature of membership (so it goes on the node, not a global token) and the **open cardinality**
+(so the modifier is an e5-*transform* that generalizes, not a per-group row).
+
+### The unifying statement
+
+Node-type and group are the **same conditioning** — "what role does this node play" — both **summed into the
+node embedding**. They differ only in the *source* of the summed vector, and cardinality picks the source:
+
+> **Closed, small role set → a learned table (lookup).  Open, large role set → a shared transform of e5.**
+> Both are added to the node embedding.
+
+Node-type is the degenerate *closed* case; group is the *open* case of one general "node-role" modifier. "Many
+more groups than types" is **precisely why** group's modifier must be the e5-transform branch — and why it
+still attaches at the very same point type does, which is what you noticed.
+
+### What is "the group's e5"?
+The group's **title** e5 (cheap, uniform) vs the **centroid of its member nodes' e5** (a group *is* its
+contents). Lean: member-centroid for collections; revisit if titles prove more discriminative.
+
+## Discipline (same as node-type)
 Init near identity, **gate** (`--group-transform`), and **A/B** it — only once group/multi-account data is
 flowing. Adding an expressive transform before the data has group diversity is node-type's collinearity
 problem with more parameters to overfit.

--- a/prototypes/mu_cosine/fuse_corpus.py
+++ b/prototypes/mu_cosine/fuse_corpus.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Fuse the three corpora (SimpleMind + Pearltrees + enwiki) into ONE typed graph and take the N-HOP
+neighbourhood of a start node — where a "hop" is ANY cross-corpus edge (SM↔SM, SM↔PT, PT↔PT, PT↔enwiki),
+not only a path that reaches enwiki. Nodes are corpus-prefixed (`mm:` SimpleMind, `pt:` Pearltrees,
+`wiki:` Wikipedia) so the same concept keeps its DISTINCT node-type across corpora, joined by `bridge`
+edges — exactly the within-operator type diversity the node-type token needs.
+
+Inputs (ref-based, no harvesting):
+  * a SimpleMind .smmx (parsed via parse_smmx.py)
+  * the cached Pearltrees harvests for its nodes' tree-ids (.pt_cache/pt_<id>.tsv, from bridge_seeds.py)
+
+    python3 fuse_corpus.py --smmx "System Theory.smmx" --start system-theory --hops 2 --out-prefix systh_fused
+"""
+import argparse
+import collections
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+WIKI = re.compile(r"en\.wikipedia\.org/wiki/(.+)$")
+PT_REL = {"element_of": "element_of", "collection_of": "subtopic", "subtopic": "subtopic",
+          "shortcut": "assoc", "assoc": "assoc"}
+
+
+def norm(s):
+    return re.sub(r"[^a-z0-9]+", "-", (s or "").replace("Category:", "").lower()).strip("-")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--smmx", required=True)
+    ap.add_argument("--start", default=None, help="start node slug (default: the map filename slug = root)")
+    ap.add_argument("--hops", type=int, default=2)
+    ap.add_argument("--pt-cache", default=os.path.join(ROOT, ".pt_cache"))
+    ap.add_argument("--out-prefix", default=None)
+    args = ap.parse_args()
+
+    # 1) parse the SimpleMind map
+    sm_pref = "/tmp/_fuse_sm"
+    subprocess.run([sys.executable, os.path.join(ROOT, "parse_smmx.py"), args.smmx, "--out-prefix", sm_pref],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    nodes = {}                                          # key → (corpus, type, title)
+    edges = []                                          # (a_key, b_key, relation)
+
+    def addn(corpus, slug, ntype, title):
+        k = f"{corpus}:{norm(slug)}"
+        nodes.setdefault(k, (corpus, ntype, title))
+        return k
+
+    sm_seeds = {}                                       # mm slug → pearltrees tree-id
+    for ln in open(sm_pref + "_nodes.tsv", encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        c = ln.rstrip("\n").split("\t")                 # key, type, title, slug, pt_id, enwiki
+        if len(c) < 3:
+            continue
+        mk = addn("mm", c[0], c[1] if len(c) > 1 else "mindmap_node", c[2] if len(c) > 2 else c[0])
+        if len(c) >= 6 and c[5]:                        # direct enwiki anchor on the SM node
+            edges.append((mk, addn("wiki", c[5], "category" if c[5].startswith("Category:") else "page", c[5]), "bridge"))
+        if len(c) >= 5 and c[4].strip().isdigit():
+            sm_seeds[norm(c[3] or c[0])] = c[4].strip()
+    for ln in open(sm_pref + "_edges.tsv", encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        a, b, rel = (ln.rstrip("\n").split("\t") + ["", "", ""])[:3]
+        if a and b:
+            edges.append((f"mm:{norm(a)}", f"mm:{norm(b)}", rel))
+
+    # 2) fold in the cached Pearltrees harvest for each SM node, + the SM↔PT and PT↔enwiki bridges
+    for slug, tid in sm_seeds.items():
+        path = os.path.join(args.pt_cache, f"pt_{tid}.tsv")
+        if not os.path.exists(path):
+            continue
+        edges.append((f"mm:{slug}", addn("pt", slug, "pearltrees_collection", slug), "bridge"))  # same concept
+        for hl in open(path, encoding="utf-8"):
+            if hl.startswith("#"):
+                continue
+            f = hl.rstrip("\n").split("\t")             # parent, child, rel, child_type, url, ...
+            if len(f) < 3:
+                continue
+            pk = addn("pt", f[0], "pearltrees_collection", f[0])
+            m = WIKI.search(f[4]) if len(f) > 4 else None
+            if m:                                       # PagePearl whose url is enwiki → a bridge
+                title = m.group(1).split("#")[0].replace("%28", "(").replace("%29", ")")
+                wk = addn("wiki", title, "category" if title.startswith("Category:") else "page", title)
+                edges.append((pk, wk, "bridge"))
+            else:
+                ck = addn("pt", f[1], "pearltrees_collection" if f[3] != "page" else "page", f[1]) if len(f) > 3 else None
+                if ck:
+                    edges.append((pk, ck, PT_REL.get(f[2], "assoc")))
+
+    # 3) N-hop BFS from the start over the UNDIRECTED fused graph (a hop = any cross-corpus edge)
+    adj = collections.defaultdict(set)
+    for a, b, _ in edges:
+        adj[a].add(b); adj[b].add(a)
+    start = f"mm:{norm(args.start) if args.start else norm(os.path.splitext(os.path.basename(args.smmx))[0])}"
+    if start not in nodes:
+        start = next((k for k in nodes if k.startswith("mm:")), None)
+    seen, frontier = {start}, {start}
+    for _ in range(args.hops):
+        nxt = set()
+        for u in frontier:
+            nxt |= adj[u] - seen
+        seen |= nxt; frontier = nxt
+    sub_edges = [(a, b, r) for a, b, r in edges if a in seen and b in seen]
+    seen2, uniq = set(), []
+    for e in sub_edges:
+        if e[0] != e[1] and e not in seen2:
+            seen2.add(e); uniq.append(e)
+
+    from collections import Counter
+    ntc = Counter(nodes[k][0] for k in seen if k in nodes)
+    print(f"start={start} hops={args.hops}: {len(seen)} nodes {dict(ntc)}, {len(uniq)} edges "
+          f"{dict(Counter(r for _, _, r in uniq))}")
+    if args.out_prefix:
+        with open(args.out_prefix + "_nodes.tsv", "w", encoding="utf-8") as f:
+            f.write("# node_key(corpus:slug)\tcorpus\tnode_type\ttitle\n")
+            for k in sorted(seen):
+                if k in nodes:
+                    co, ty, ti = nodes[k]
+                    f.write(f"{k}\t{co}\t{ty}\t{ti}\n")
+        with open(args.out_prefix + "_edges.tsv", "w", encoding="utf-8") as f:
+            f.write("# a_key\tb_key\trelation\n")
+            for a, b, r in uniq:
+                f.write(f"{a}\t{b}\t{r}\n")
+        print(f"  wrote {args.out_prefix}_nodes.tsv + {args.out_prefix}_edges.tsv")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Two additions to `prototypes/mu_cosine`, both from the multi-corpus
(SimpleMind + Pearltrees + enwiki) thread.

### 1. `fuse_corpus.py` — unified N-hop cross-corpus walker
Fuses the three corpora into ONE typed graph with corpus-prefixed keys
(`mm:` SimpleMind, `pt:` Pearltrees, `wiki:` Wikipedia) and takes the
N-hop neighbourhood of a start node, where a "hop" is ANY cross-corpus
edge (SM↔SM, SM↔PT, PT↔PT, PT↔enwiki) — not only paths that reach enwiki.
Same concept keeps its DISTINCT node-type across corpora, joined by
`bridge` edges — exactly the within-operator type diversity the node-type
token needs. Ref-based (no harvesting): reads a parsed `.smmx` plus the
cached Pearltrees harvests. On *System Theory*: 1 hop = 21 nodes;
2 hops = 251 nodes (260 bridges); 3 hops = 1567 nodes (1490 bridges).

### 2. `DESIGN_provenance_and_representation.md` — where learned params go
Locks the design decisions on the table-vs-e5 line for the upcoming
account/group work:

- **The dividing line:** if a table would grow with the data, it is not a
  learned table. Small closed categorical axes (op/corpus/judge/account/
  node-type) get learned tokens; open-ended entities (nodes, groups) ride
  frozen e5.
- **Two buckets:** *provenance* (corpus/judge/**account**) on a maskable
  token vs *structure* (node-type/**group**) added to the node embedding.
  `account` is provenance; `group` is structure.
- **Group = a required transform of e5, added to the member node**
  (`node_emb += T(e5_group)`), never raw e5 and never a per-group table.
  The transform is mandatory (maps e5 → the additive node-role space, the
  continuous-index analog of node-type's table lookup); warm-start no-op is
  **zero-output init**, not identity.
- **Group is a weak structural signal** (confidence gradient
  node-type > category membership > group membership): soft/one-sided
  target (`μ(node|group) ≳ low`) + small-magnitude modifier.
- **Per-group credibility (v2):** a learned gate `α(group)` from the
  group's e5 and/or member-e5 dispersion — a *function*, never a per-group
  scalar; lets the model learn which groups are more credible without a
  growing table.
- **miniLM** recorded as a documented alternative input to `T`, deliberately
  deferred to keep a single uniform e5 space.

## Why
`fuse_corpus.py` is the first place type/group diversity actually exists,
so it's the substrate for the next graded round; the design doc settles the
account/group representation before we build it.

## Notes
- Docs + one ref-based script; no model/training changes, no data committed.
- Build path remains gated on data: wire `account` through
  `parse_pearltrees.py`, then the graded round off the 2-hop neighbourhood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)