### PR TITLE
mu_cosine: account/provenance plumbing (parser + model) + e5-text role/id design

### DIFF
--- a/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
+++ b/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
@@ -17,7 +17,7 @@ per-node embedding: cold-start safety, no overfitting, no table that grows with 
 | **`account`** | closed | **`s243a` / `s243a_groups`** | learned token (maskable provenance) — NEW |
 | `nodetype` | closed | category / page / mindmap_node / pearltrees_collection | learned token (+ optional transform, below) |
 | **node identity** | open | every concept | **frozen e5** (no table) |
-| **group** | open | every Pearltrees group | **frozen e5 → required transform `T`** added to the member node (below) — NOT a per-group table, never raw e5 |
+| **group** | open | every Pearltrees group/team | **frozen e5**: first try a `"Team <name> <id>"` e5-text prefix (role+identity, zero params); else a transform `T` added to the member node — NOT a per-group table, never raw e5 |
 
 ## Account (the two Pearltrees accounts)
 
@@ -100,6 +100,26 @@ still no growing table. Start `α` at a neutral constant (≡ v1 behaviour) and 
 
 Note the closed-vs-open split holds here too: **account**-level credibility (`s243a` vs `s243a_groups`) is
 fine as the small 2-value token; **per-group** credibility is the open case that *must* be a function.
+
+### Cheaper than a transform: encode the role (and identity) in the embedded *text*
+
+e5 already uses text prefixes to mark role (`query:` / `passage:`). The same trick can encode a node's
+**structural role directly into its e5**, sometimes removing the need for a learned transform at all:
+
+- **Role via prefix.** Embed `"Team Physics"` (Pearltrees calls a group a *team*), not just `"Physics"`. The
+  `"Team "` prefix pushes the vector into the "this is a team/group" region of e5-space, so for a group that
+  appears as **its own node**, `T` may be **unnecessary** — the prefix does the role-injection the transform
+  would. This drops `T` from *mandatory* to *optional* for the standalone-group-node use. (It does **not**
+  remove `T` for the additive-membership use — conditioning a *different* member node still needs a map into
+  add-space; but even there a role-marked group e5 means `T` has *less* to learn.)
+- **Identity via id-in-text.** Fold the **team id** into the embedded text — `"Team Physics 13580844"` — so
+  two same-named teams get **distinct** e5 vectors. Uniqueness **without a per-team table** (it is still
+  frozen e5; the id is just input text), and still cold-start-safe. The parser already emits each node's
+  `pearltrees_id` + `account`, so the e5-text builder has what it needs to construct `"Team <title> <id>"`
+  for team/group nodes (and a plain title for ordinary nodes).
+
+This is the **first** thing to try for groups — text-prefix + id is zero new parameters; reach for the
+learned transform/credibility gate only if the prefix proves insufficient.
 
 ### Alternative: the transform's input embedding (documented, deferred)
 

--- a/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
+++ b/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
@@ -28,6 +28,13 @@ API `asso`, so carrying it through `parse_pearltrees.py` → the graded pairs is
 default off; activate once **both** accounts' data is in (single-account data makes `account` collinear with
 `corpus` — node-type's collinearity trap again).
 
+**Status (implemented):** `parse_pearltrees.py` emits each node's `account` column; `mu_attention.py` has the
+`ACCOUNTS` codebook + a zero-init `account_emb` factored into the same maskable provenance token as
+`corpus⊗judge` (threaded as item position 7 → `account_of`). It is a **no-op until items carry an account
+id**, so the effective gate is whether the graded-round generator tags items with one — `--use-account` will
+live in that data/training layer, added alongside the graded round. `CORPORA` also gained `pearltrees`/
+`mindmap` and `JUDGES` gained `human` for the multi-corpus round; warm-start grows those embedding rows.
+
 ## Groups: a transform of e5, never a per-group table
 
 A Pearltrees **group** is open-ended (grows with the data), so it is a **node with frozen e5**, not a

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -49,9 +49,10 @@ OPS = {"SYM": 0, "WIKI": 1, "LLM": 2, "ELEM": 3}
 # corpus⊗judge product is representable while it presents to the set as one input. The token is MASKABLE
 # (off-manifold noise, exactly like an absent ancestor slot); masking ⇒ provenance-AGNOSTIC μ, which is
 # the DEFAULT inference path (marginalize over sources). Reserved entries (enwiki) are for later corpora.
-CORPORA = {"simplewiki": 0, "enwiki": 1}
-JUDGES = {"haiku": 0, "graph": 1}        # haiku = a bought LLM judgment (SYM/LLM); graph = a Wikipedia
-                                         # edge / non-edge (WIKI, and the free μ=0 SYM negatives)
+CORPORA = {"simplewiki": 0, "enwiki": 1, "pearltrees": 2, "mindmap": 3}
+JUDGES = {"haiku": 0, "graph": 1, "human": 2}    # haiku = a bought LLM judgment (SYM/LLM); graph = a
+                                         # Wikipedia edge / non-edge (WIKI, free μ=0 SYM negatives);
+                                         # human = a hand-curated edge (the mindmap/pearltrees corpora)
 # NODE-TYPE (DESIGN_calibrated_judges.md §7): a factored per-ENDPOINT token saying WHAT each node is — a
 # `category`/`mindmap_node` is an internal node that can have children; a `page` is a LEAF; a
 # `pearltrees_collection` is a curated container. Orthogonal to the OPERATOR (which says what the RELATION
@@ -59,6 +60,12 @@ JUDGES = {"haiku": 0, "graph": 1}        # haiku = a bought LLM judgment (SYM/LL
 # convey. category=0 is the implicit default; the embedding is zero-initialised so it is a no-op at warm
 # start and the type signal is learned during fine-tuning.
 NODETYPE = {"category": 0, "page": 1, "mindmap_node": 2, "pearltrees_collection": 3}
+# ACCOUNT (DESIGN_provenance_and_representation.md): a SECOND maskable provenance axis — which Pearltrees
+# account a label came from — factored into the SAME provenance token as corpus⊗judge (so it is masked /
+# marginalised out together with them). Small + closed (two accounts), so a learned token is right. It is a
+# no-op until items actually carry an account id (position 7); zero-initialised so warm-starts are safe and
+# the signal is learned only once BOTH accounts are harvested (single-account data is collinear with corpus).
+ACCOUNTS = {"s243a": 0, "s243a_groups": 1}
 
 
 # --------------------------------------------------------------------------------------------------
@@ -199,6 +206,7 @@ class Tokenizer:
         for it in items:
             node, root, op = it[0], it[1], it[2]
             corpus_id, judge_id = (it[3], it[4]) if len(it) >= 5 else (None, None)
+            account_id = it[7] if len(it) >= 8 else None             # optional 2nd provenance axis (account)
             if len(it) >= 7:
                 ntypes.append(it[5]); rtypes.append(it[6]); has_nt.append(True)
             else:                               # no node-type tags ⇒ leave nodetype_of=-1 (emb not applied)
@@ -222,7 +230,7 @@ class Tokenizer:
             if masked:
                 toks.append(("prov_mask", node, None, 0))                # off-manifold noise ⇒ agnostic
             else:
-                toks.append(("prov", None, (corpus_id, judge_id), 0))    # corpus_emb + judge_emb
+                toks.append(("prov", None, (corpus_id, judge_id, account_id), 0))  # corpus+judge(+account)
             rows.append(toks)
 
         T = max(len(r) for r in rows)
@@ -233,6 +241,7 @@ class Tokenizer:
         is_prov = torch.zeros(B, T, dtype=torch.bool)                     # the provenance slot (any state)
         corpus_of = torch.full((B, T), -1, dtype=torch.long)
         judge_of = torch.full((B, T), -1, dtype=torch.long)
+        account_of = torch.full((B, T), -1, dtype=torch.long)             # 2nd provenance axis (account)
         nodetype_of = torch.full((B, T), -1, dtype=torch.long)            # per-endpoint structural role
         pad = torch.ones(B, T, dtype=torch.bool)                          # True = pad (ignored)
         op_of = torch.tensor([it[2] for it in items], dtype=torch.long)
@@ -259,7 +268,9 @@ class Tokenizer:
                         nodetype_of[bi, ti] = NODETYPE["category"]        # ancestors are categories
                 elif kind == "prov":
                     is_prov[bi, ti] = True                                # content stays 0; forward adds
-                    corpus_of[bi, ti], judge_of[bi, ti] = op              # corpus_emb + judge_emb + prov_tag
+                    corpus_of[bi, ti], judge_of[bi, ti], _acc = op        # corpus_emb + judge_emb + prov_tag
+                    if _acc is not None:
+                        account_of[bi, ti] = _acc                         # + account_emb (if item carries it)
                 elif kind in ("noise", "prov_mask"):
                     if train:                                 # fast path: fresh noise, no per-seed RNG
                         v = torch.randn(self.d)
@@ -274,7 +285,7 @@ class Tokenizer:
                         gen_id[bi, ti] = d
         return {"content": content, "gen_id": gen_id, "is_anchor": is_anchor, "op_pos": op_pos,
                 "is_prov": is_prov, "corpus_of": corpus_of, "judge_of": judge_of,
-                "nodetype_of": nodetype_of, "op_of": op_of, "pad": pad}
+                "account_of": account_of, "nodetype_of": nodetype_of, "op_of": op_of, "pad": pad}
 
 
 # --------------------------------------------------------------------------------------------------
@@ -283,7 +294,7 @@ class Tokenizer:
 class MuAttention(nn.Module):
     def __init__(self, d_model=384, n_ops=len(OPS), n_heads=4, n_layers=1, max_gen=5,
                  dim_ff=None, dropout=0.0, n_corpus=len(CORPORA), n_judge=len(JUDGES),
-                 n_nodetype=len(NODETYPE)):
+                 n_nodetype=len(NODETYPE), n_account=len(ACCOUNTS)):
         super().__init__()
         self.d = d_model
         self.op_emb = nn.Embedding(n_ops, d_model)
@@ -297,6 +308,9 @@ class MuAttention(nn.Module):
         # can locate "the provenance input" regardless of whether its source is revealed.
         self.corpus_emb = nn.Embedding(n_corpus, d_model)
         self.judge_emb = nn.Embedding(n_judge, d_model)
+        # ACCOUNT: a 2nd factored provenance axis on the SAME maskable token. Zero-init ⇒ a no-op at warm
+        # start (and whenever items carry no account), so the signal is learned only once both accounts exist.
+        self.account_emb = nn.Embedding(n_account, d_model)
         self.prov_tag = nn.Parameter(torch.randn(d_model) * 0.02)
         layer = nn.TransformerEncoderLayer(d_model, n_heads, dim_feedforward=dim_ff or 2 * d_model,
                                            dropout=dropout, batch_first=True, activation="gelu",
@@ -307,9 +321,10 @@ class MuAttention(nn.Module):
         for emb in (self.op_emb, self.gen_emb, self.corpus_emb, self.judge_emb):
             nn.init.normal_(emb.weight, std=0.02)
         nn.init.zeros_(self.nodetype_emb.weight)            # no-op at warm start; learned during fine-tune
+        nn.init.zeros_(self.account_emb.weight)             # no-op until items carry an account id
 
     def forward(self, content, gen_id, is_anchor, op_pos, op_of, pad,
-                is_prov=None, corpus_of=None, judge_of=None, nodetype_of=None):
+                is_prov=None, corpus_of=None, judge_of=None, account_of=None, nodetype_of=None):
         emb = content.clone()
         gmask = (gen_id >= 0).unsqueeze(-1)
         emb = emb + self.gen_emb(gen_id.clamp(min=0)) * gmask
@@ -324,6 +339,9 @@ class MuAttention(nn.Module):
                 cmask = (corpus_of >= 0).unsqueeze(-1)
                 emb = emb + self.corpus_emb(corpus_of.clamp(min=0)) * cmask
                 emb = emb + self.judge_emb(judge_of.clamp(min=0)) * cmask
+            if account_of is not None:                                   # 2nd provenance axis (account)
+                amask = (account_of >= 0).unsqueeze(-1)
+                emb = emb + self.account_emb(account_of.clamp(min=0)) * amask
         h = self.encoder(emb, src_key_padding_mask=pad)
         # CLS-style readout: the operator token (always position 0, never padded) attends over the whole
         # set, giving a relation-conditioned summary. Cleaner than mean-pool, which dilutes the input

--- a/prototypes/mu_cosine/parse_pearltrees.py
+++ b/prototypes/mu_cosine/parse_pearltrees.py
@@ -21,7 +21,10 @@ ANY PagePearl whose url is en.wikipedia.org ALSO emits a `bridge` to the enwiki 
 Category:…, else page) — Pearltrees is the bridge-RICH corpus. Root (4) is skipped.
 
 Node identity = the title-derived slug (matching the Pearltrees slugs SimpleMind nodes carry, so the two
-corpora join). node_type ∈ pearltrees_collection | page | category.
+corpora join). node_type ∈ pearltrees_collection | page | category. Each pearltrees node also carries its
+`account` (provenance: e.g. `s243a` vs the `s243a_groups`/teams account) from `trees.account`; enwiki-side
+bridge nodes carry none. See DESIGN_provenance_and_representation.md (account = maskable provenance token;
+groups/teams = a transform of e5, or a "Team <name> <id>" e5-text prefix).
 
     python3 parse_pearltrees.py --out-prefix pt        # uses the .local harvested DB if it exists
 """
@@ -52,11 +55,18 @@ def main():
                          f"or pass --db")
 
     con = sqlite3.connect(args.db)
-    trees = {r[0]: r[1] for r in con.execute("SELECT id, title FROM trees")}
+    trees, tree_acct = {}, {}                              # tree_id → title ; tree_id → account
+    for tid_, title_, acct_ in con.execute("SELECT id, title, account FROM trees"):
+        trees[tid_] = title_
+        tree_acct[tid_] = acct_ or ""
     nodes, edges = {}, []
 
-    def add(key, ntype, title, pid="", enwiki=""):
-        nodes.setdefault(key, {"ntype": ntype, "title": title, "pid": pid, "enwiki": enwiki})
+    def add(key, ntype, title, pid="", enwiki="", account=""):
+        n = nodes.get(key)
+        if n is None:
+            nodes[key] = {"ntype": ntype, "title": title, "pid": pid, "enwiki": enwiki, "account": account}
+        elif account and not n.get("account"):            # backfill account once we learn it
+            n["account"] = account
 
     def enwiki_node(ew):                                  # register the enwiki node, return (key, type)
         if ew.startswith("Category:"):
@@ -90,8 +100,9 @@ def main():
             continue
         if tid != cur_tree:
             cur_tree, mode = tid, None                    # reset section scope at each tree
+        acct = tree_acct.get(tid, "")                     # this tree's Pearltrees account (provenance)
         src = slug(trees[tid])
-        add(src, "pearltrees_collection", trees[tid], str(tid))
+        add(src, "pearltrees_collection", trees[tid], str(tid), account=acct)
         if ctype == 7:                                    # Section header → set the mode for what follows
             mode = section_mode(sec_text or title)
             continue
@@ -101,16 +112,16 @@ def main():
         ew = ""
         if ctype == 2 and ct_title:                       # Collection (child tree)
             dk, base = slug(ct_title), "subtopic"
-            add(dk, "pearltrees_collection", ct_title, str(ct_id or ""))
+            add(dk, "pearltrees_collection", ct_title, str(ct_id or ""), account=tree_acct.get(ct_id) or acct)
         elif ctype == 1 and title:                        # PagePearl (a member page / url)
             dk, base = slug(title), "element_of"
             m = WIKI_URL.search(url or "")
             if m:
                 ew = unquote(m.group(1)).split("#")[0]
-            add(dk, "page", title, "", ew)
+            add(dk, "page", title, "", ew, account=acct)
         elif ctype == 5 and ct_title:                     # Shortcut (alias)
             dk, base = slug(ct_title), "assoc"
-            add(dk, "pearltrees_collection", ct_title, str(ct_id or ""))
+            add(dk, "pearltrees_collection", ct_title, str(ct_id or ""), account=tree_acct.get(ct_id) or acct)
         else:
             continue
         # relation = the section mode if it names one, else the contentType default
@@ -131,12 +142,13 @@ def main():
     print(f"{os.path.basename(args.db)}: {len(nodes)} nodes {dict(Counter(n['ntype'] for n in nodes.values()))}, "
           f"{len(uniq)} edges {dict(Counter(r for _, _, r in uniq))}")
     print(f"  bridges (pearltrees↔enwiki): {sum(1 for _, _, r in uniq if r == 'bridge')}")
+    print(f"  accounts: {dict(Counter(n['account'] for n in nodes.values() if n['account']))}")
 
     if args.out_prefix:
         with open(args.out_prefix + "_nodes.tsv", "w", encoding="utf-8") as f:
-            f.write("# node_key\tnode_type\ttitle\tpearltrees_id\tenwiki_alias\n")
+            f.write("# node_key\tnode_type\ttitle\tpearltrees_id\tenwiki_alias\taccount\n")
             for k, n in sorted(nodes.items()):
-                f.write(f"{k}\t{n['ntype']}\t{n['title']}\t{n['pid']}\t{n['enwiki']}\n")
+                f.write(f"{k}\t{n['ntype']}\t{n['title']}\t{n['pid']}\t{n['enwiki']}\t{n['account']}\n")
         with open(args.out_prefix + "_edges.tsv", "w", encoding="utf-8") as f:
             f.write("# src_key\tdst_key\trelation  "
                     "(subtopic|subcategory|element_of|super_category|see_also|bridge|assoc)\n")


### PR DESCRIPTION
## What

End-to-end plumbing for the multi-corpus provenance fabric, so the upcoming
graded round (corpus = mindmap | pearltrees, judge = human, two accounts) has
everything it needs. All additions are warm-start-safe and inert until the
graded round actually emits the new tags.

### Parser — `parse_pearltrees.py`
- Carries each Pearltrees node's `account` (from `trees.account`, e.g. `s243a`
  vs the `s243a_groups`/teams account) as a sixth `nodes.tsv` column;
  enwiki-side bridge nodes carry none; account is backfilled on first sight.
- On the harvest DB: `s243a` 173, `unknown` 16, 45 enwiki nodes blank (expected).

### Model — `mu_attention.py`
- `CORPORA` += `pearltrees`, `mindmap`; `JUDGES` += `human` (hand-curated edges).
- New `ACCOUNTS` codebook `{s243a, s243a_groups}` + a **zero-init** `account_emb`
  factored into the **same maskable provenance token** as `corpus⊗judge`
  (threaded as item position 7 → `account_of`). Masking the provenance token
  marginalizes account out alongside corpus/judge.
- Zero-init ⇒ an exact **no-op** until items carry an account id, so the effective
  gate is whether the graded-round generator tags items (the `--use-account`
  switch lands in that data layer).
- Every forward is `model(**tok.build(...))`, so no call-site churn; existing
  3/5/7-tuple training/eval paths are unchanged.
- Warm-start: the existing grow logic extends `corpus_emb`/`judge_emb` rows
  (new rows seeded from row 0); `account_emb` stays zero when absent from an old
  checkpoint.

### Design — `DESIGN_provenance_and_representation.md`
- **Encode the role in the embedded text:** a `"Team <name>"` prefix (e5's
  `query:`/`passage:` trick) can make the learned transform unnecessary for a
  standalone group node — `T` drops from mandatory to optional.
- **Identity via id-in-text:** fold the team id into the text
  (`"Team <name> <id>"`) so same-named teams get distinct e5 — uniqueness with
  no per-team table. The parser already emits `pearltrees_id` + `account`, so the
  e5-text builder has what it needs. Try text-prefix+id first (zero params).
- Implementation-status note added so the doc tracks the code.

## Verification
Mechanical: `account_of` is `-1` when agnostic, populated when revealed, a
numerical no-op at zero-init (Δ=0), and a 2→4 / 2→3 checkpoint grows cleanly.
All four touched modules import/parse.

## Notes
- No data committed; no training run in this PR.
- Next round: the graded-round generator off `fuse_corpus.py`'s 2-hop
  neighborhood (relation→μ targets, Team-prefix e5 text, `--use-account`/
  `--use-nodetype`), then train + eval + REPORT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)