### PR TITLE
mu_cosine: scrub-everywhere privacy filter — no private data in the public dataset

### DIFF
--- a/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
+++ b/prototypes/mu_cosine/DESIGN_provenance_and_representation.md
@@ -136,6 +136,29 @@ only what goes into `T`). We **defer** it deliberately: adopting it now would fr
 space every node shares into two encoder spaces to manage — implicit complexity for no present gain. Recorded
 as a real option, not ruled out; **stick to e5** until there's a measured reason group needs its own encoder.
 
+## Privacy: scrub-everywhere, at parse time
+
+**Private data must never appear in the public dataset.** The chosen policy is **scrub-everywhere**: private
+nodes are **dropped at parse time** — never emitted, never trained on — with **no include-private escape
+hatch**. Privacy is **inherited down the subtree** (children inherit, like the Pearltrees/RDF `private`
+field), and we **err toward dropping** (a topical "Private equity" is scrubbed too) and **log every scrub**
+(no silent drops) — a false positive only loses public data; a false negative would *leak* private data.
+
+Markers, per corpus:
+
+- **Pearltrees** (`parse_pearltrees.py`): (1) `trees.visibility` set to anything other than public (`0`);
+  (2) a collection/pearl whose **title contains the word "private"** (the user's `*private*` marker). A
+  private collection seeds privacy on its child tree; privacy then **propagates down tree-containment** so a
+  private collection takes its whole harvested subtree. On the harvest DB this scrubs the 5 `*private*`
+  shortcuts; nothing private reaches the TSVs.
+- **SimpleMind** (`parse_smmx.py`): a topic whose **label contains "private"** marks itself **and its whole
+  subtree**; a **private ROOT ⇒ the entire map** is dropped. Verified: a private interior node scrubs its
+  subtree (siblings kept); a private root emits nothing.
+
+Both use `\bprivate\b` (word-boundary, case-insensitive) so `Privacy`/`privatize` don't trigger but
+`*private*` / "… Private …" do. The downstream graded-round generator inherits this for free: it consumes
+the parsers' already-scrubbed output, so private data cannot reach training or a committed artifact.
+
 ## Two buckets, not one: **provenance** (maskable token) vs **structure** (on the node)
 
 The first cut lumped everything "factored" together; sharpen it into two buckets that behave differently:

--- a/prototypes/mu_cosine/parse_pearltrees.py
+++ b/prototypes/mu_cosine/parse_pearltrees.py
@@ -26,6 +26,10 @@ corpora join). node_type ∈ pearltrees_collection | page | category. Each pearl
 bridge nodes carry none. See DESIGN_provenance_and_representation.md (account = maskable provenance token;
 groups/teams = a transform of e5, or a "Team <name> <id>" e5-text prefix).
 
+PRIVACY (scrub-everywhere): a private tree (visibility≠public) or a collection/pearl titled "private" is
+dropped at parse time WITH its whole subtree (privacy propagates down tree-containment) — private data never
+reaches the public dataset. See DESIGN_provenance_and_representation.md §Privacy.
+
     python3 parse_pearltrees.py --out-prefix pt        # uses the .local harvested DB if it exists
 """
 import argparse
@@ -39,6 +43,21 @@ ROOT = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_DB = os.path.join(os.path.abspath(os.path.join(ROOT, "..", "..")),
                           ".local", "data", "pearltrees_api", "pearltrees_api.db")
 WIKI_URL = re.compile(r"en\.wikipedia\.org/wiki/(.+)$")
+# PRIVACY (scrub-everywhere — DESIGN_provenance_and_representation.md §Privacy): private data must NEVER reach
+# the public dataset, so it is dropped at PARSE time, inherited down the subtree, with no include-private
+# escape hatch. Two markers: (1) the title contains the word "private" (the user's "*private*" marker node /
+# a root named "… private …"); (2) the Pearltrees `visibility` is set to anything other than public (0).
+# We err toward dropping (a topical "Private equity" would be scrubbed too) and LOG every scrub — a false
+# positive only loses public data, a false negative would leak private data.
+PRIVATE_RE = re.compile(r"(?i)\bprivate\b")
+
+
+def is_private_title(t):
+    return bool(t) and bool(PRIVATE_RE.search(t))
+
+
+def vis_private(v):                                       # Pearltrees visibility: 0 = public; else restricted
+    return v is not None and str(v).strip() not in ("", "0")
 
 
 def slug(title):
@@ -56,10 +75,14 @@ def main():
 
     con = sqlite3.connect(args.db)
     trees, tree_acct = {}, {}                              # tree_id → title ; tree_id → account
-    for tid_, title_, acct_ in con.execute("SELECT id, title, account FROM trees"):
+    priv_trees = set()                                     # tree_ids that are private (seed + inherited)
+    for tid_, title_, acct_, vis_ in con.execute("SELECT id, title, account, visibility FROM trees"):
         trees[tid_] = title_
         tree_acct[tid_] = acct_ or ""
+        if vis_private(vis_) or is_private_title(title_):  # seed: this tree itself is private
+            priv_trees.add(tid_)
     nodes, edges = {}, []
+    scrub = Counter()                                      # what privacy dropped, by kind (logged, not silent)
 
     def add(key, ntype, title, pid="", enwiki="", account=""):
         n = nodes.get(key)
@@ -91,12 +114,33 @@ def main():
             return "reference"                      # → links that bridge the TREE to enwiki/encyclopedia
         return None                                 # topical/junk header (Algebra, Meta, …) ⇒ default
 
+    rows = list(con.execute("SELECT tree_id, content_type, title, url, content_tree_id, content_tree_title, "
+                            "section_text, left_index FROM pearls ORDER BY tree_id, left_index"))
+
+    # PRE-PASS (privacy): a collection NAMED private seeds privacy on its child tree; build tree containment
+    # (parent → child collection) and propagate privacy DOWN it so a private collection takes its whole
+    # harvested subtree with it (children inherit, exactly like the RDF `private` field).
+    contain = {}
+    for tid, ctype, title, _u, ct_id, ct_title, _s, _li in rows:
+        if tid not in trees or ctype != 2 or not ct_id:
+            continue
+        contain.setdefault(tid, set()).add(ct_id)
+        if is_private_title(ct_title):
+            priv_trees.add(ct_id)
+    frontier = list(priv_trees)                           # BFS the private mark down the containment graph
+    while frontier:
+        t = frontier.pop()
+        for c in contain.get(t, ()):
+            if c not in priv_trees:
+                priv_trees.add(c); frontier.append(c)
+
     # walk each tree's pearls IN ORDER (left_index) so section headers scope the pearls after them
-    rows = con.execute("SELECT tree_id, content_type, title, url, content_tree_id, content_tree_title, "
-                       "section_text, left_index FROM pearls ORDER BY tree_id, left_index")
     cur_tree, mode = None, None
     for tid, ctype, title, url, ct_id, ct_title, sec_text, _li in rows:
         if tid not in trees:
+            continue
+        if tid in priv_trees:                             # PRIVATE tree → scrub it and everything under it
+            scrub["tree"] += 1
             continue
         if tid != cur_tree:
             cur_tree, mode = tid, None                    # reset section scope at each tree
@@ -108,18 +152,24 @@ def main():
             continue
         if ctype == 4:                                    # Root pearl
             continue
-        # target node + base relation by contentType
+        # target node + base relation by contentType — but SCRUB any private target first
         ew = ""
         if ctype == 2 and ct_title:                       # Collection (child tree)
+            if ct_id in priv_trees or is_private_title(ct_title):
+                scrub["collection"] += 1; continue
             dk, base = slug(ct_title), "subtopic"
             add(dk, "pearltrees_collection", ct_title, str(ct_id or ""), account=tree_acct.get(ct_id) or acct)
         elif ctype == 1 and title:                        # PagePearl (a member page / url)
+            if is_private_title(title):
+                scrub["page"] += 1; continue
             dk, base = slug(title), "element_of"
             m = WIKI_URL.search(url or "")
             if m:
                 ew = unquote(m.group(1)).split("#")[0]
             add(dk, "page", title, "", ew, account=acct)
         elif ctype == 5 and ct_title:                     # Shortcut (alias)
+            if ct_id in priv_trees or is_private_title(ct_title):
+                scrub["shortcut"] += 1; continue
             dk, base = slug(ct_title), "assoc"
             add(dk, "pearltrees_collection", ct_title, str(ct_id or ""), account=tree_acct.get(ct_id) or acct)
         else:
@@ -143,6 +193,8 @@ def main():
           f"{len(uniq)} edges {dict(Counter(r for _, _, r in uniq))}")
     print(f"  bridges (pearltrees↔enwiki): {sum(1 for _, _, r in uniq if r == 'bridge')}")
     print(f"  accounts: {dict(Counter(n['account'] for n in nodes.values() if n['account']))}")
+    print(f"  PRIVACY scrubbed (dropped, never emitted): {dict(scrub) or 'none'}"
+          f"  [{len(priv_trees)} private tree-ids]")
 
     if args.out_prefix:
         with open(args.out_prefix + "_nodes.tsv", "w", encoding="utf-8") as f:

--- a/prototypes/mu_cosine/parse_smmx.py
+++ b/prototypes/mu_cosine/parse_smmx.py
@@ -18,6 +18,10 @@ Relation semantics (the structural container retypes its descendants' edge to th
        `page`. Same concept, DIFFERENT node-type (mindmap_node ⟷ category/page), possibly different name —
        the cross-corpus join key. (Scarce in the maps; most live in the Pearltrees data.)
 
+PRIVACY (scrub-everywhere): a topic labelled "private" drops itself AND its subtree; a private ROOT drops the
+whole map. Dropped at parse time, never emitted — private data never reaches the public dataset. See
+DESIGN_provenance_and_representation.md §Privacy.
+
 Node identity = Pearltrees slug (from a pearltrees urllink) if present, else the normalised title. Each node
 also carries: title, pearltrees id, enwiki_alias.
 
@@ -41,6 +45,16 @@ WIKI_LABEL = re.compile(r"^\s*(wiki|wikipedia|enwiki)\s*$", re.I)
 NAV_LABEL = re.compile(r"^([Pp][gG]\.?\s*\d+|\d+(\.\d+)+|[A-Za-z]\.\d+)$")
 PEARL = re.compile(r"pearltrees\.com/[^/]+/([^/\"]+)/id(\d+)")
 WIKI_URL = re.compile(r"en\.wikipedia\.org/wiki/(.+)$")
+# PRIVACY (scrub-everywhere — see DESIGN_provenance_and_representation.md §Privacy): a node whose label
+# contains the word "private" marks itself AND its whole subtree private (children inherit, like the
+# Pearltrees/RDF field); a private ROOT ⇒ the whole map is private. Private topics are DROPPED at parse time
+# so private data never reaches the public dataset — no include-private escape hatch. We err toward dropping
+# (a topical "Private equity" would go too) and LOG the count; a false positive only loses public data.
+PRIVATE_RE = re.compile(r"(?i)\bprivate\b")
+
+
+def is_private_title(t):
+    return bool(t) and bool(PRIVATE_RE.search(t))
 
 
 def load_xml(path):
@@ -139,6 +153,20 @@ def main():
         s, _ = slug_of(t)
         return s or re.sub(r"[^a-z0-9]+", "_", label(t).lower()).strip("_")
 
+    # PRIVACY: seed = topics labelled "private"; inherit DOWN the tree (a private node takes its subtree).
+    children_of = {}
+    for i, p in parent.items():
+        children_of.setdefault(p, []).append(i)
+    private_ids, fr = set(), [i for i, t in topics.items() if is_private_title(label(t))]
+    while fr:
+        x = fr.pop()
+        if x in private_ids:
+            continue
+        private_ids.add(x)
+        fr.extend(children_of.get(x, []))
+    root_id = next((i for i in topics if parent.get(i) in (None, "-1")), None)
+    map_private = bool(root_id) and root_id in private_ids        # private root ⇒ the whole map is private
+
     # pass 1: classify; collect enwiki anchors (wiki-labelled children + direct wiki urllinks)
     enwiki = {}                                     # node-id → enwiki title
     is_anchor = set()                              # ids that are wiki-anchor holders (not real nodes)
@@ -171,8 +199,8 @@ def main():
 
     nodes, edges, id2key = {}, [], {}
     for i, t in topics.items():
-        if i in is_anchor or label(topics[i]) in STRUCTURAL:
-            continue                               # skip wiki-anchor holders and structural containers
+        if i in is_anchor or label(topics[i]) in STRUCTURAL or i in private_ids:
+            continue                               # skip wiki-anchor holders, containers, and PRIVATE nodes
         k = key(t)
         sl, pid = slug_of(t)
         ntype = "navigation" if NAV_LABEL.match(label(t)) else "mindmap_node"
@@ -181,7 +209,7 @@ def main():
         id2key[i] = k
         # hierarchy edge to effective (non-structural) parent
         pp, rel = eff_parent_and_rel(i)
-        if pp in topics and pp not in is_anchor:
+        if pp in topics and pp not in is_anchor and pp not in private_ids:
             edges.append((key(topics[pp]), k, rel))
 
     # cross-map links (cloudmapref) — over ALL topics, since a blank "link-holder"/connector child often
@@ -192,7 +220,7 @@ def main():
         if not ref:
             continue
         src_id = eff_parent_and_rel(i)[0] if (label(t) in STRUCTURAL or i in is_anchor) else i
-        if src_id not in topics or src_id in is_anchor:
+        if src_id not in topics or src_id in is_anchor or src_id in private_ids:
             continue
         segs = [s for s in re.split(r"[\\/]+", ref) if s and s != "."]
         if not segs:
@@ -200,7 +228,7 @@ def main():
             # "connector" node doing this is often joining a node to an ADJACENT one (list/chapter
             # structure) ⇒ treat as an associative cross-link.
             tt = guid2t.get(el)
-            if tt is None:
+            if tt is None or tt.get("id") in private_ids:    # don't link to a PRIVATE intra-map target
                 continue
             tsl, tpid = slug_of(tt)
             tkey, rel = key(tt), "assoc"
@@ -232,7 +260,7 @@ def main():
     # and the differing endpoint TYPES under one `bridge` relation are exactly the within-operator type
     # diversity that makes the node-type token informative (REPORT_nodetype.md).
     for i, w in enwiki.items():
-        if i not in id2key or not w:
+        if i not in id2key or not w or i in private_ids:
             continue
         ww = unquote(w).split("#")[0]
         if ww.startswith("Category:"):
@@ -249,8 +277,9 @@ def main():
     # explicit <relation source target>: a chain between NAVIGATION nodes (page/section) is reading-order
     # `sequence` (book/course list structure); otherwise a genuine `assoc` cross-link.
     for r in root.findall(".//relation"):
-        s, d = topics.get(r.get("source")), topics.get(r.get("target"))
-        if s is not None and d is not None:
+        si, di = r.get("source"), r.get("target")
+        s, d = topics.get(si), topics.get(di)
+        if s is not None and d is not None and si not in private_ids and di not in private_ids:
             rel = "sequence" if (NAV_LABEL.match(label(s)) and NAV_LABEL.match(label(d))) else "assoc"
             edges.append((key(s), key(d), rel))
 
@@ -265,6 +294,10 @@ def main():
     ntc = Counter(n.get("ntype", "mindmap_node") for n in nodes.values())
     print(f"{os.path.basename(args.smmx)}: {len(nodes)} nodes {dict(ntc)}, {len(uniq)} edges {dict(rc)}")
     print(f"  bridges (mindmap↔enwiki): {rc.get('bridge', 0)}")
+    if map_private:
+        print(f"  PRIVACY: ROOT is marked private ⇒ WHOLE MAP scrubbed ({len(private_ids)} topics, nothing emitted)")
+    elif private_ids:
+        print(f"  PRIVACY scrubbed (dropped, never emitted): {len(private_ids)} topics (a node + its subtree)")
 
     if args.out_prefix:
         with open(args.out_prefix + "_nodes.tsv", "w", encoding="utf-8") as f:


### PR DESCRIPTION
## What

Enforces **private data never appears in the public dataset** by dropping it at
**parse time** (scrub-everywhere policy), before any graded-round generator,
training, or committed artifact can see it. Privacy is **inherited down the
subtree**; there is **no include-private escape hatch**. We **err toward
dropping** (a topical "Private equity" goes too) and **log every scrub** — a
false positive only loses public data, a false negative would *leak*.

### `parse_pearltrees.py`
- A tree with `visibility` ≠ public (`0`), or a collection/pearl **titled
  "private"**, is private. A pre-pass propagates the mark **down
  tree-containment**, so a private collection takes its whole harvested subtree.
- On the harvest DB: scrubs the 5 `*private*` shortcuts; emitted TSVs contain
  no "private".

### `parse_smmx.py`
- A topic **labelled "private"** drops itself **and its subtree** (children
  inherit); a **private ROOT** drops the **whole map**.
- Verified on synthetic maps: an interior private node scrubs its subtree
  (siblings kept); a private root emits nothing.

### Matching
- Both use `\bprivate\b` (word-boundary, case-insensitive): `*private*` and
  "… Private …" trigger; `Privacy`/`privatize` do not.

### Docs
- New **§Privacy** in `DESIGN_provenance_and_representation.md`: policy, markers,
  inheritance, and the err-toward-dropping + log rationale.

## Notes
- No data committed. Downstream (the graded-round generator) inherits scrubbing
  for free by consuming the parsers' already-clean output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)