### PR TITLE
mu_cosine: privacy-scrub fuse_corpus (shared rule) + cybernetics 1/2/3-hop bridging

### DIFF
--- a/prototypes/mu_cosine/REPORT_bridge_cybernetics.md
+++ b/prototypes/mu_cosine/REPORT_bridge_cybernetics.md
@@ -1,0 +1,45 @@
+# Bridging the Cybernetics mindmap to Wikipedia — 1 / 2 / 3 hops (fused, privacy-scrubbed)
+
+The "1, 2, 3 hop from the cybernetics mindmap, with bridging" run, using `fuse_corpus.py` — the unified
+cross-corpus walker — over the **Cybernetics** SimpleMind map + its Pearltrees harvests + Wikipedia. A "hop"
+is ANY cross-corpus edge (mm↔mm, mm↔pt, pt↔pt, pt↔enwiki), not only paths that reach enwiki.
+
+## Pipeline
+1. `parse_smmx.py Cybernetics.smmx` → **32 nodes, 23 carry a Pearltrees tree-id** (the harvest seeds). The
+   map itself has **0 direct enwiki anchors** — all bridges come via Pearltrees.
+2. Harvested all 23 seeds (depth 1) via the private `.local` harvester → **1389 bridges (267 to enwiki
+   Categories) over 20 concepts**.
+3. `fuse_corpus.py --start cybernetics --hops {1,2,3}` over the fused, **privacy-scrubbed** graph.
+
+## Result
+
+| hops | nodes | by corpus | edges | bridges |
+|---|---|---|---|---|
+| 1 | 14 | mm 13, pt 1 | 13 | 1 |
+| 2 | 196 | mm 19, pt 27, **wiki 150** | 280 | **207** |
+| 3 | 1269 | mm 27, pt 222, **wiki 1020** | 1476 | **1151** |
+
+Cybernetics bridges **densely** to Wikipedia: by 2 hops a mindmap of 32 concepts reaches **150 enwiki
+nodes** through 207 bridges; by 3 hops, **1020 enwiki nodes** / 1151 bridges. The 1-hop neighbourhood is
+almost pure mindmap (the mm↔mm `subtopic`/`see_also`/`super_category` structure); pt and wiki enter at hop 2
+(the seeds' own collections + their enwiki references) and explode at hop 3 (the collections' members).
+
+## Privacy — the scrub-everywhere filter fired on real data
+The fresh harvest pulled **2 collections containing `*private*` markers** (`Intelegence & mind`,
+`System Perspective (Philosophy)` — each a `*private*` shortcut). `fuse_corpus.py` now applies the same
+scrub-everywhere rule to the raw `.pt_cache` harvests (which do **not** pass through `parse_pearltrees.py`):
+it dropped those private rows + their inherited subtree, and the emitted fused TSVs contain **no** private
+data (verified). This closed a real gap — before this run, the Pearltrees side of a fused walk was
+unscrubbed, so private collections would have leaked into the fused output.
+
+## Notes
+- The privacy rule now lives in one place (`privacy.py`), imported by `parse_smmx.py`,
+  `parse_pearltrees.py`, and `fuse_corpus.py`, so it can't drift between corpora.
+- The mindmap lives under the gitignored `context/`; `.pt_cache/` and the fused `*_nodes/_edges.tsv` are
+  local/regenerable (contain private-tier Pearltrees data) and are **not** committed.
+
+## Next
+Feed the 2-hop fused neighbourhood (196 nodes: mm 19 / pt 27 / wiki 150, with 207 bridges) into the graded
+round — relation→μ targets, `Team <name> <id>` e5-text, and the `corpus`/`judge`/`account`/`node-type` tags
+— then train with `--use-nodetype` on. This is the within-operator type diversity `REPORT_nodetype.md` found
+missing, now privacy-clean.

--- a/prototypes/mu_cosine/fuse_corpus.py
+++ b/prototypes/mu_cosine/fuse_corpus.py
@@ -18,6 +18,8 @@ import re
 import subprocess
 import sys
 
+from privacy import is_private_title, propagate as privacy_propagate    # scrub-everywhere (see privacy.py)
+
 ROOT = os.path.dirname(os.path.abspath(__file__))
 WIKI = re.compile(r"en\.wikipedia\.org/wiki/(.+)$")
 PT_REL = {"element_of": "element_of", "collection_of": "subtopic", "subtopic": "subtopic",
@@ -68,28 +70,51 @@ def main():
         if a and b:
             edges.append((f"mm:{norm(a)}", f"mm:{norm(b)}", rel))
 
-    # 2) fold in the cached Pearltrees harvest for each SM node, + the SM↔PT and PT↔enwiki bridges
+    # 2) fold in the cached Pearltrees harvest for each SM node, + the SM↔PT and PT↔enwiki bridges.
+    # PRIVACY (scrub-everywhere): raw .pt_cache harvests are NOT pre-scrubbed (they come from the private
+    # harvester, not parse_pearltrees.py), so apply the SAME rule here — drop private-titled pt nodes and,
+    # inherited down pt containment, their whole subtree — before building any fused edge.
+    pt_rows, pt_children, pt_priv = [], {}, set()       # rows ; norm(parent)→{norm(child)} ; private norm-keys
     for slug, tid in sm_seeds.items():
         path = os.path.join(args.pt_cache, f"pt_{tid}.tsv")
         if not os.path.exists(path):
             continue
-        edges.append((f"mm:{slug}", addn("pt", slug, "pearltrees_collection", slug), "bridge"))  # same concept
         for hl in open(path, encoding="utf-8"):
             if hl.startswith("#"):
                 continue
             f = hl.rstrip("\n").split("\t")             # parent, child, rel, child_type, url, ...
             if len(f) < 3:
                 continue
-            pk = addn("pt", f[0], "pearltrees_collection", f[0])
-            m = WIKI.search(f[4]) if len(f) > 4 else None
-            if m:                                       # PagePearl whose url is enwiki → a bridge
-                title = m.group(1).split("#")[0].replace("%28", "(").replace("%29", ")")
-                wk = addn("wiki", title, "category" if title.startswith("Category:") else "page", title)
-                edges.append((pk, wk, "bridge"))
-            else:
-                ck = addn("pt", f[1], "pearltrees_collection" if f[3] != "page" else "page", f[1]) if len(f) > 3 else None
-                if ck:
-                    edges.append((pk, ck, PT_REL.get(f[2], "assoc")))
+            pt_rows.append(f)
+            if is_private_title(f[0]):
+                pt_priv.add(norm(f[0]))
+            if len(f) > 1 and is_private_title(f[1]):
+                pt_priv.add(norm(f[1]))
+            if len(f) > 3 and f[3] != "page" and f[1]:  # collection child → a containment edge
+                pt_children.setdefault(norm(f[0]), set()).add(norm(f[1]))
+    pt_priv = privacy_propagate(pt_priv, pt_children)   # inherit privacy down the subtree
+    scrub_pt = 0
+
+    for slug, tid in sm_seeds.items():                  # SM↔PT bridge per seed (skip private seeds)
+        if norm(slug) in pt_priv:
+            continue
+        if os.path.exists(os.path.join(args.pt_cache, f"pt_{tid}.tsv")):
+            edges.append((f"mm:{slug}", addn("pt", slug, "pearltrees_collection", slug), "bridge"))
+
+    for f in pt_rows:
+        if norm(f[0]) in pt_priv:                       # private parent → scrub the row
+            scrub_pt += 1; continue
+        pk = addn("pt", f[0], "pearltrees_collection", f[0])
+        m = WIKI.search(f[4]) if len(f) > 4 else None
+        if m:                                           # PagePearl whose url is enwiki → a bridge
+            title = m.group(1).split("#")[0].replace("%28", "(").replace("%29", ")")
+            wk = addn("wiki", title, "category" if title.startswith("Category:") else "page", title)
+            edges.append((pk, wk, "bridge"))
+        elif len(f) > 3:
+            if norm(f[1]) in pt_priv:                   # private child → scrub
+                scrub_pt += 1; continue
+            ck = addn("pt", f[1], "pearltrees_collection" if f[3] != "page" else "page", f[1])
+            edges.append((pk, ck, PT_REL.get(f[2], "assoc")))
 
     # 3) N-hop BFS from the start over the UNDIRECTED fused graph (a hop = any cross-corpus edge)
     adj = collections.defaultdict(set)
@@ -114,6 +139,8 @@ def main():
     ntc = Counter(nodes[k][0] for k in seen if k in nodes)
     print(f"start={start} hops={args.hops}: {len(seen)} nodes {dict(ntc)}, {len(uniq)} edges "
           f"{dict(Counter(r for _, _, r in uniq))}")
+    if scrub_pt or pt_priv:
+        print(f"  PRIVACY: scrubbed {scrub_pt} pt rows ({len(pt_priv)} private pt nodes, inherited)")
     if args.out_prefix:
         with open(args.out_prefix + "_nodes.tsv", "w", encoding="utf-8") as f:
             f.write("# node_key(corpus:slug)\tcorpus\tnode_type\ttitle\n")

--- a/prototypes/mu_cosine/parse_pearltrees.py
+++ b/prototypes/mu_cosine/parse_pearltrees.py
@@ -43,21 +43,10 @@ ROOT = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_DB = os.path.join(os.path.abspath(os.path.join(ROOT, "..", "..")),
                           ".local", "data", "pearltrees_api", "pearltrees_api.db")
 WIKI_URL = re.compile(r"en\.wikipedia\.org/wiki/(.+)$")
-# PRIVACY (scrub-everywhere — DESIGN_provenance_and_representation.md §Privacy): private data must NEVER reach
-# the public dataset, so it is dropped at PARSE time, inherited down the subtree, with no include-private
-# escape hatch. Two markers: (1) the title contains the word "private" (the user's "*private*" marker node /
-# a root named "… private …"); (2) the Pearltrees `visibility` is set to anything other than public (0).
-# We err toward dropping (a topical "Private equity" would be scrubbed too) and LOG every scrub — a false
-# positive only loses public data, a false negative would leak private data.
-PRIVATE_RE = re.compile(r"(?i)\bprivate\b")
-
-
-def is_private_title(t):
-    return bool(t) and bool(PRIVATE_RE.search(t))
-
-
-def vis_private(v):                                       # Pearltrees visibility: 0 = public; else restricted
-    return v is not None and str(v).strip() not in ("", "0")
+# PRIVACY (scrub-everywhere — DESIGN_provenance_and_representation.md §Privacy + privacy.py): drop private
+# data at PARSE time, inherited down the subtree, no include-private escape hatch. Markers: title contains
+# "private", or Pearltrees `visibility` != public (0). We err toward dropping and LOG every scrub.
+from privacy import is_private_title, vis_private    # noqa: E402  (single source of truth)
 
 
 def slug(title):

--- a/prototypes/mu_cosine/parse_smmx.py
+++ b/prototypes/mu_cosine/parse_smmx.py
@@ -45,16 +45,10 @@ WIKI_LABEL = re.compile(r"^\s*(wiki|wikipedia|enwiki)\s*$", re.I)
 NAV_LABEL = re.compile(r"^([Pp][gG]\.?\s*\d+|\d+(\.\d+)+|[A-Za-z]\.\d+)$")
 PEARL = re.compile(r"pearltrees\.com/[^/]+/([^/\"]+)/id(\d+)")
 WIKI_URL = re.compile(r"en\.wikipedia\.org/wiki/(.+)$")
-# PRIVACY (scrub-everywhere — see DESIGN_provenance_and_representation.md §Privacy): a node whose label
-# contains the word "private" marks itself AND its whole subtree private (children inherit, like the
-# Pearltrees/RDF field); a private ROOT ⇒ the whole map is private. Private topics are DROPPED at parse time
-# so private data never reaches the public dataset — no include-private escape hatch. We err toward dropping
-# (a topical "Private equity" would go too) and LOG the count; a false positive only loses public data.
-PRIVATE_RE = re.compile(r"(?i)\bprivate\b")
-
-
-def is_private_title(t):
-    return bool(t) and bool(PRIVATE_RE.search(t))
+# PRIVACY (scrub-everywhere — see DESIGN_provenance_and_representation.md §Privacy + privacy.py): a node whose
+# label contains the word "private" marks itself AND its whole subtree (children inherit); a private ROOT ⇒
+# the whole map. Dropped at parse time so private data never reaches the public dataset; we LOG every scrub.
+from privacy import is_private_title          # noqa: E402  (single source of truth for the privacy rule)
 
 
 def load_xml(path):

--- a/prototypes/mu_cosine/privacy.py
+++ b/prototypes/mu_cosine/privacy.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Single source of truth for the mu_cosine PRIVACY rule (scrub-everywhere): private data must NEVER reach
+the public dataset, so it is dropped at parse/fuse time, inherited down the subtree, with no include-private
+escape hatch. Defined ONCE here and imported by parse_smmx.py, parse_pearltrees.py and fuse_corpus.py so the
+rule can't drift between corpora. See DESIGN_provenance_and_representation.md §Privacy.
+
+We err toward dropping (a topical "Private equity" is scrubbed too) and callers LOG every scrub: a false
+positive only loses public data; a false negative would LEAK private data."""
+import re
+
+# Word-boundary, case-insensitive: the user's `*private*` marker and "… Private …" trigger; `Privacy`
+# and `privatize` do NOT.
+PRIVATE_RE = re.compile(r"(?i)\bprivate\b")
+
+
+def is_private_title(t):
+    """True if a node's title/label marks it (and, by inheritance, its subtree) private."""
+    return bool(t) and bool(PRIVATE_RE.search(t))
+
+
+def vis_private(v):
+    """Pearltrees `visibility`: 0 = public; any other set value is treated as private/restricted."""
+    return v is not None and str(v).strip() not in ("", "0")
+
+
+def propagate(private_seed, children_of):
+    """Inherit privacy DOWN a containment graph: given a seed set of private keys and a
+    parent_key -> iterable(child_key) map, return the full set including all descendants."""
+    private = set(private_seed)
+    frontier = list(private)
+    while frontier:
+        x = frontier.pop()
+        for c in children_of.get(x, ()):
+            if c not in private:
+                private.add(c)
+                frontier.append(c)
+    return private


### PR DESCRIPTION
## What

Runs the cybernetics mindmap → Wikipedia bridging walk, and closes a privacy
gap that the walk exposed.

### Privacy gap closed
`fuse_corpus.py` reads the raw `.pt_cache` harvests directly — they come from the
private harvester, **not** `parse_pearltrees.py` — so the Pearltrees side of a
fused walk was **unscrubbed**. A fresh cybernetics harvest proved this real: it
pulled 2 collections carrying `*private*` markers.

- **`privacy.py`** — single source of truth for the scrub-everywhere rule
  (`is_private_title` / `vis_private` / `propagate`). `parse_smmx.py` and
  `parse_pearltrees.py` now import it instead of each defining their own, so the
  rule can't drift between corpora.
- **`fuse_corpus.py`** — applies the same rule to `.pt_cache` rows: drops
  private-titled pt nodes and, inherited down pt containment, their whole
  subtree, before building any fused edge; logs the scrub count. Verified: the
  cybernetics fuse scrubbed the 2 `*private*` shortcuts; emitted TSVs contain no
  private data.

### Cybernetics bridging — `REPORT_bridge_cybernetics.md`
32-node map, 0 direct enwiki anchors, all bridges via Pearltrees (23 seeds
harvested → 1389 bridges / 267 Categories):

| hops | nodes | by corpus | bridges |
|---|---|---|---|
| 1 | 14 | mm 13, pt 1 | 1 |
| 2 | 196 | mm 19, pt 27, wiki 150 | 207 |
| 3 | 1269 | mm 27, pt 222, wiki 1020 | 1151 |

## Notes
- No data committed: `context/`, `.pt_cache/`, and the fused `*_nodes/_edges.tsv`
  are gitignored/local (private-tier Pearltrees data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)