### PR TITLE
mu_cosine: graded-round generator (relation→operator→μ calibration)

### DIFF
--- a/prototypes/mu_cosine/REPORT_graded_round.md
+++ b/prototypes/mu_cosine/REPORT_graded_round.md
@@ -1,0 +1,59 @@
+# The multi-corpus graded round — calibration & distribution
+
+`build_graded_round.py` turns the PRIVACY-SCRUBBED fused neighbourhoods (`fuse_corpus.py`) into a calibrated,
+tagged graded round for the trainer. This documents the **relation→operator→μ calibration** (the heart of
+it) and the distribution it produces on the two banked neighbourhoods (cybernetics 2-hop + dynamical-systems
+3-hop).
+
+## Calibration — relation → operator + μ
+
+Corpus differences are **not** baked into the target μ; they ride the maskable provenance token so the model
+conditions/marginalizes them (per `DESIGN_provenance_and_representation.md`). One human-judge μ per relation:
+
+| relation | operator | kind | μ(member\|container) | μ(reverse) | rationale |
+|---|---|---|---|---|---|
+| `subcategory` | WIKI | directional | 0.90 | 0.10 | explicit narrower category |
+| `subtopic` | WIKI | directional | 0.85 | 0.12 | narrower topic (mindmap), looser than a category |
+| `element_of` | ELEM | directional | 0.90 | 0.10 | page/collection membership |
+| `super_category` | WIKI | directional (dst broader) | 0.85 | 0.12 | src belongs to the broader dst |
+| `see_also` | SYM | symmetric | 0.40 | 0.40 | weakly related |
+| `assoc` | SYM | symmetric | 0.30 | 0.30 | associative cross-link |
+| `sequence` | SYM | symmetric | 0.30 | 0.30 | reading-order (navigation) |
+| `bridge` | SYM | symmetric | 0.90 | 0.90 | the SAME concept across corpora |
+
+Reverse targets (0.10–0.12) are the **semantic-drift floor**: a member is mostly-not its container. Each
+directional edge emits BOTH directions so the model learns the asymmetry, not just the positive.
+
+**Provenance = the human-curated endpoint.** A bridge is mm/pt ↔ wiki; enwiki didn't assert it, the
+mindmap/pearltrees curation did — so *both* directions of a bridge get the mm/pt side's `corpus`/`judge`
+(priority mindmap > pearltrees > enwiki), never `enwiki/graph`.
+
+## Distribution (cybernetics 2-hop + dynamical-systems 3-hop)
+
+916 nodes, 1212 fused edges → **2334 graded targets**.
+
+- **by operator:** WIKI 244, SYM 2084, ELEM 6
+- **by relation:** bridge 1654, assoc 408, subtopic 222, see_also 22, super_category 22, element_of 6
+- **by corpus⊗judge:** pearltrees/human 2122, mindmap/human 212
+- **by μ:** 0.90 ×1657, 0.85 ×122, 0.40 ×22, 0.30 ×408, 0.12 ×122, 0.10 ×3
+
+## Two things the trainer step must handle
+
+1. **Bridge dominance.** 1654 / 2334 targets are `bridge` at μ=0.90. That is the cross-corpus **node-type
+   diversity** `--use-nodetype` needs (mm↔pt↔wiki, distinct node-types under one relation) — but left
+   unweighted it would teach "everything bridged is similar" and swamp the directional WIKI/ELEM signal.
+   The trainer should **subsample or down-weight** bridges (and balance per operator).
+2. **ELEM is thin here (6).** These neighbourhoods are collection/category/bridge-heavy, few member pages;
+   ELEM is already trained on the wiki page data, so this round mainly contributes WIKI (mindmap hierarchy)
+   + SYM (bridges/assoc/see_also) with the new cross-corpus type diversity.
+
+## Outputs (not committed — derived from gitignored fused/`.pt_cache` data)
+- `<out>_pairs.tsv`: `node  root  mu  op  relation  node_type  root_type  corpus  judge`
+- `<out>_nodes.tsv`: `key  corpus  node_type  title  embed_text` — `embed_text` is the e5 string per node
+  (the `Team <name> <id>` prefix hook lives here; inert until the `s243a_groups`/teams account is harvested).
+
+## Next
+Wire the trainer to consume `<out>_pairs.tsv`: a mixed-operator graded path (per-row `op`, MSE to μ +
+directional margins), bridge down-weighting, the fused nodes unioned into the e5 build, then train with
+`--use-nodetype` on and measure whether type diversity now helps (`REPORT_nodetype.md` found it collinear
+*without* this data).

--- a/prototypes/mu_cosine/build_graded_round.py
+++ b/prototypes/mu_cosine/build_graded_round.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Turn one or more PRIVACY-SCRUBBED fused neighbourhoods (fuse_corpus.py → <prefix>_nodes.tsv +
+<prefix>_edges.tsv) into a calibrated, tagged GRADED ROUND for the mu-attention trainer.
+
+Each fused edge (src, dst, relation) becomes directional μ targets under one of the existing operators,
+with the relation's calibrated μ (the human-judge target) — corpus differences are NOT baked into the
+target; they ride the maskable provenance token so the model conditions/marginalizes them
+(DESIGN_calibrated_judges.md, DESIGN_provenance_and_representation.md).
+
+  RELATION → OPERATOR + μ (see RELATION_SPEC):
+    subtopic / subcategory   → WIKI  (directional narrower-membership): μ(member|container) high, reverse low
+    element_of               → ELEM  (page/collection membership):      μ(member|container) high, reverse low
+    super_category           → WIKI  (the dst is the BROADER one):       μ(src|dst) high, reverse low
+    see_also / assoc / sequence → SYM (symmetric, weak associative):     μ both directions ~low-mid
+    bridge                   → SYM  (SAME concept across corpora):       μ both directions high
+
+Edge direction convention from the parsers: (src=container/parent, dst=member/child), except super_category
+where dst is the broader node. An item is (node, root, op) ⇒ a target for μ(node|root).
+
+Outputs (consumed by the trainer in the next step; not committed — derived from gitignored fused data):
+  <out>_pairs.tsv : node  root  mu  op  relation  node_type  root_type  corpus  judge
+  <out>_nodes.tsv : key  corpus  node_type  title  embed_text   (embed_text = the e5 string per node)
+
+    python3 build_graded_round.py --fused /tmp/cyb_fused_2 --fused /tmp/ds_fused_3 --out /tmp/graded
+"""
+import argparse
+import os
+from collections import Counter
+
+# corpus prefix (fuse_corpus keys mm:/pt:/wiki:) → CORPORA codebook name, and its default judge.
+CORPUS_OF = {"mm": "mindmap", "pt": "pearltrees", "wiki": "enwiki"}
+JUDGE_OF = {"mindmap": "human", "pearltrees": "human", "enwiki": "graph"}
+
+# relation → (op, kind, mu_hi, mu_lo). kind: "down" dst is member/narrower of src; "up" dst is broader of
+# src; "sym" symmetric. mu_lo = the reverse-direction target (semantic-drift floor) for directional rels.
+RELATION_SPEC = {
+    "subtopic":       ("WIKI", "down", 0.85, 0.12),
+    "subcategory":    ("WIKI", "down", 0.90, 0.10),
+    "element_of":     ("ELEM", "down", 0.90, 0.10),
+    "super_category": ("WIKI", "up",   0.85, 0.12),
+    "see_also":       ("SYM",  "sym",  0.40, 0.40),
+    "assoc":          ("SYM",  "sym",  0.30, 0.30),
+    "sequence":       ("SYM",  "sym",  0.30, 0.30),
+    "bridge":         ("SYM",  "sym",  0.90, 0.90),   # same concept, different corpus/node-type
+}
+
+
+def load_fused(prefix):
+    nodes = {}                                            # key → (corpus_prefix, node_type, title)
+    with open(prefix + "_nodes.tsv", encoding="utf-8") as f:
+        for ln in f:
+            if ln.startswith("#"):
+                continue
+            c = ln.rstrip("\n").split("\t")               # key, corpus, node_type, title
+            if len(c) >= 4:
+                nodes[c[0]] = (c[1], c[2], c[3])
+    edges = []
+    with open(prefix + "_edges.tsv", encoding="utf-8") as f:
+        for ln in f:
+            if ln.startswith("#"):
+                continue
+            c = ln.rstrip("\n").split("\t")               # a_key, b_key, relation
+            if len(c) >= 3:
+                edges.append((c[0], c[1], c[2]))
+    return nodes, edges
+
+
+def embed_text(corpus, node_type, title, pid=""):
+    """The e5 string for a node. Hook for the role/identity prefix (DESIGN §Cheaper-than-a-transform): a
+    Pearltrees TEAM would be 'Team <title> <id>'. We have no teams (groups account) harvested yet, so for
+    now every node embeds its plain title; the prefix activates when the s243a_groups account is added."""
+    return title
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fused", action="append", required=True, help="fused prefix (repeatable)")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    nodes = {}                                            # key → (corpus_prefix, node_type, title)
+    edges = []
+    for pref in args.fused:
+        n, e = load_fused(pref)
+        nodes.update(n)
+        edges.extend(e)
+
+    def corpus_judge(node, root):
+        # Provenance = the corpus that ASSERTED the edge = the HUMAN-curated (non-enwiki) endpoint. A bridge
+        # is mm/pt ↔ wiki: enwiki didn't assert it, the mindmap/pearltrees curation did — so BOTH directions
+        # get that side's provenance, not enwiki/graph. Priority mindmap > pearltrees > enwiki.
+        prefixes = {nodes.get(node, ("",))[0], nodes.get(root, ("",))[0]}
+        corpus = ("mindmap" if "mm" in prefixes else
+                  "pearltrees" if "pt" in prefixes else "enwiki")
+        return corpus, JUDGE_OF[corpus]
+
+    def ntype(key):
+        return nodes.get(key, ("", "category", ""))[1]
+
+    rows, skipped = {}, Counter()                         # (node,root,op) → row ; dedup keeps strongest |μ-.5|
+    def emit(node, root, mu, op, rel):
+        if node == root or node not in nodes or root not in nodes:
+            skipped["dangling"] += 1
+            return
+        corpus, judge = corpus_judge(node, root)          # provenance = the human-curated endpoint's corpus
+        k = (node, root, op)
+        if k in rows and abs(rows[k][0] - 0.5) >= abs(mu - 0.5):
+            return                                        # keep the more decisive existing target
+        rows[k] = (mu, rel, ntype(node), ntype(root), corpus, judge)
+
+    for src, dst, rel in edges:
+        spec = RELATION_SPEC.get(rel)
+        if not spec:
+            skipped[f"rel:{rel}"] += 1
+            continue
+        op, kind, hi, lo = spec
+        if kind == "down":                                # dst is a member/narrower of src
+            emit(dst, src, hi, op, rel); emit(src, dst, lo, op, rel)
+        elif kind == "up":                                # dst is the broader; src belongs to dst
+            emit(src, dst, hi, op, rel); emit(dst, src, lo, op, rel)
+        else:                                             # symmetric
+            emit(dst, src, hi, op, rel); emit(src, dst, hi, op, rel)
+
+    with open(args.out + "_pairs.tsv", "w", encoding="utf-8") as f:
+        f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\n")
+        for (node, root, op), (mu, rel, nty, rty, corpus, judge) in sorted(rows.items()):
+            f.write(f"{node}\t{root}\t{mu:.2f}\t{op}\t{rel}\t{nty}\t{rty}\t{corpus}\t{judge}\n")
+    with open(args.out + "_nodes.tsv", "w", encoding="utf-8") as f:
+        f.write("# key\tcorpus\tnode_type\ttitle\tembed_text\n")
+        for key, (cp, nty, title) in sorted(nodes.items()):
+            corpus = CORPUS_OF.get(cp, "mindmap")
+            f.write(f"{key}\t{corpus}\t{nty}\t{title}\t{embed_text(corpus, nty, title)}\n")
+
+    op_c = Counter(op for (_, _, op) in rows)
+    rel_c = Counter(r[1] for r in rows.values())
+    cj_c = Counter((r[4], r[5]) for r in rows.values())
+    print(f"{len(nodes)} nodes, {len(edges)} fused edges → {len(rows)} graded targets")
+    print(f"  by op:       {dict(op_c)}")
+    print(f"  by relation: {dict(rel_c)}")
+    print(f"  by corpus⊗judge: { {f'{c}/{j}': n for (c, j), n in cj_c.items()} }")
+    if skipped:
+        print(f"  skipped: {dict(skipped)}")
+    print(f"  wrote {args.out}_pairs.tsv + {args.out}_nodes.tsv")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
`build_graded_round.py` turns the privacy-scrubbed fused neighbourhoods into a
calibrated, tagged graded round. Its core is the relation→operator→μ table:

| relation | op | μ fwd | μ rev |
|---|---|---|---|
| subcategory | WIKI | 0.90 | 0.10 |
| subtopic | WIKI | 0.85 | 0.12 |
| element_of | ELEM | 0.90 | 0.10 |
| super_category | WIKI | 0.85 (src∈dst) | 0.12 |
| see_also | SYM | 0.40 | 0.40 |
| assoc / sequence | SYM | 0.30 | 0.30 |
| bridge | SYM | 0.90 | 0.90 |

Corpus differences are **not** baked into μ — they ride the maskable provenance
token. Provenance = the human-curated endpoint (a bridge's wiki side is tagged
mindmap/pearltrees, never enwiki/graph — enwiki didn't assert the bridge).

## Distribution (cybernetics 2-hop + dynamical-systems 3-hop)
916 nodes, 1212 edges → **2334 targets**: SYM 2084 / WIKI 244 / ELEM 6;
bridge-dominated (1654); pearltrees/human 2122, mindmap/human 212.

## Trainer step must handle
1. **Bridge dominance** — down-weight/subsample so "everything bridged is similar"
   doesn't swamp the directional WIKI/ELEM signal (it *is* the node-type diversity
   `--use-nodetype` needs).
2. **Thin ELEM** here — these neighbourhoods are collection/bridge-heavy.

## Notes
- Outputs (`<out>_pairs.tsv`, `<out>_nodes.tsv`) derive from gitignored fused/
  `.pt_cache` data — **not** committed. `embed_text` carries the `Team <name> <id>`
  hook, inert until the groups account is harvested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)