### PR TITLE
mu_cosine: bridge negatives + e5-prior review gate in the graded generator

### DIFF
--- a/prototypes/mu_cosine/REPORT_graded_round.md
+++ b/prototypes/mu_cosine/REPORT_graded_round.md
@@ -52,8 +52,41 @@ mindmap/pearltrees curation did — so *both* directions of a bridge get the mm/
 - `<out>_nodes.tsv`: `key  corpus  node_type  title  embed_text` — `embed_text` is the e5 string per node
   (the `Team <name> <id>` prefix hook lives here; inert until the `s243a_groups`/teams account is harvested).
 
+## Bridge quality — negatives + an e5-prior review gate
+
+Two refinements to how bridges are handled (a bridge asserts "same concept across corpora" at μ≈0.9):
+
+### Bridge negative sampling (`--bridge-neg-ratio`, default 1.0)
+Bridges were all *positive*, so the model never saw "these two cross-corpus nodes are NOT the same concept" —
+down-weighting controls dominance but not discrimination. Now each surviving bridge source also gets a
+random wiki node it is *not* bridged to, at μ≈0.1 (SYM, `rel=bridge_neg`, **full-weight**). On the two
+neighbourhoods: 92 negative pairs → 184 targets.
+
+### e5-prior review gate (`--e5-cache`, `--bridge-min-cos`)
+The frozen e5 already gives a similarity prior, so a bridge whose endpoints are *far* in e5 is suspect — a
+bad link, or a non-obvious synonym e5 can't see — exactly the case to **quarantine for LLM review before
+training** rather than feed a possibly-wrong μ=0.9. e5 cosines are **compressed** (here min 0.784, median
+0.874, max 1.0), so the threshold is e5-calibrated (default 0.80 ≈ suspect bottom decile). It quarantined
+**8** bridges to `<out>_bridge_review.tsv` — a clean mix of genuinely-questionable (`ladybird-of-szeged`,
+`norbit`) and legit-but-non-obvious (`BELBIC` a real control architecture; `towards-a-new-socialism` =
+cybernetic planning) — precisely the set worth an LLM call. The LLM adjudication itself is **deferred (Haiku
+budget-gated)**; the gate produces the candidate list for free.
+
+### Honest A/B (fine-tune ±negatives+quarantine, both `--use-nodetype`)
+| metric | no neg | +neg +quarantine |
+|---|---|---|
+| discrimination | 94% | 92% |
+| SYM held-out | +0.838 | +0.832 |
+| ELEM corr | +0.702 | **+0.731** |
+| graded WIKI fit (r) | +0.757 | **+0.817** |
+
+Headline metrics are **flat within noise** (±1 discrimination example). This *confirms* the earlier read that
+**bridge down-weighting was already sufficient** — negatives are cheap, sound insurance (they stop "all
+cross-corpus pairs look similar") but don't move the needle at this scale. (The graded-SYM held-out r is not
+comparable across the two: the negatives make that held-out set wider/harder.) The e5-prior **quarantine** is
+the clearer, training-independent win — a data-quality gate.
+
 ## Next
-Wire the trainer to consume `<out>_pairs.tsv`: a mixed-operator graded path (per-row `op`, MSE to μ +
-directional margins), bridge down-weighting, the fused nodes unioned into the e5 build, then train with
-`--use-nodetype` on and measure whether type diversity now helps (`REPORT_nodetype.md` found it collinear
-*without* this data).
+- **LLM-review the quarantined bridges** (budget-gated) → re-include the legit non-obvious ones, drop the
+  bad links. Re-measure as the bridge set grows (negatives may matter more at larger scale).
+- Wire `account` + the `Team <name> <id>` e5-text once the `s243a_groups` account is harvested.

--- a/prototypes/mu_cosine/build_graded_round.py
+++ b/prototypes/mu_cosine/build_graded_round.py
@@ -25,6 +25,7 @@ Outputs (consumed by the trainer in the next step; not committed — derived fro
 """
 import argparse
 import os
+import random
 from collections import Counter
 
 # corpus prefix (fuse_corpus keys mm:/pt:/wiki:) → CORPORA codebook name, and its default judge.
@@ -76,7 +77,19 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--fused", action="append", required=True, help="fused prefix (repeatable)")
     ap.add_argument("--out", required=True)
+    ap.add_argument("--bridge-neg-ratio", type=float, default=1.0, help="bridge negatives per positive "
+                    "bridge: a bridge source paired with a RANDOM wiki node it is NOT bridged to (μ≈0.1, "
+                    "SYM). Teaches discrimination, not just dominance control. 0 disables.")
+    ap.add_argument("--bridge-neg-mu", type=float, default=0.1)
+    ap.add_argument("--e5-cache", default=None, help="optional e5 table cache (e.g. e5_tables_graded.pt): if "
+                    "given, flag bridges whose endpoints are FAR in frozen e5 (likely bad/non-obvious links) "
+                    "and quarantine them to <out>_bridge_review.tsv for LLM review before training")
+    ap.add_argument("--bridge-min-cos", type=float, default=0.80, help="quarantine a bridge if its endpoints' "
+                    "e5 cosine is below this (only with --e5-cache). e5 cosines are COMPRESSED (~0.78–1.0 in "
+                    "practice), so this is e5-calibrated — 0.80 flags roughly the suspect bottom decile")
+    ap.add_argument("--seed", type=int, default=1)
     args = ap.parse_args()
+    rng = random.Random(args.seed)
 
     nodes = {}                                            # key → (corpus_prefix, node_type, title)
     edges = []
@@ -121,6 +134,56 @@ def main():
         else:                                             # symmetric
             emit(dst, src, hi, op, rel); emit(src, dst, hi, op, rel)
 
+    # --- e5-PRIOR bridge sanity gate: a bridge asserts "same concept across corpora"; if its endpoints are
+    # FAR in frozen e5, the link is suspect (a bad link, or a non-obvious synonym e5 can't see). Quarantine
+    # those for LLM/human review BEFORE training rather than feeding a possibly-wrong μ=0.9 (the user's idea).
+    review = []
+    if args.e5_cache and os.path.exists(args.e5_cache):
+        import torch
+        d = torch.load(args.e5_cache, weights_only=False)
+        vidx = {n: i for i, n in enumerate(d["names"])}
+        vec = d["passage"]                                # unit-normed ⇒ dot product = cosine
+        bridge_pairs = {tuple(sorted((n, r))) for (n, r, _op), v in rows.items() if v[1] == "bridge"}
+        quarantine = set()
+        for a, b in bridge_pairs:
+            ia, ib = vidx.get(a), vidx.get(b)
+            if ia is None or ib is None:
+                continue
+            c = float(vec[ia] @ vec[ib])
+            if c < args.bridge_min_cos:
+                quarantine.add(frozenset((a, b)))
+                review.append((a, b, c))
+        if quarantine:
+            rows = {k: v for k, v in rows.items()
+                    if not (v[1] == "bridge" and frozenset((k[0], k[1])) in quarantine)}
+
+    # --- bridge NEGATIVE sampling: each surviving bridge source vs a random wiki node it is NOT bridged to,
+    # at μ≈bridge_neg_mu (SYM). Teaches discrimination ("THIS pair is the same, random ones aren't") rather
+    # than relying on down-weighting alone. Full-weight (not a "bridge" rel ⇒ trainer won't down-weight them).
+    n_neg = 0
+    if args.bridge_neg_ratio > 0:
+        wiki_nodes = [k for k, v in nodes.items() if v[0] == "wiki"]
+        bsrc = {}                                         # mm/pt source → its true wiki bridge targets
+        for (n, r, _op), v in rows.items():
+            if v[1] == "bridge":
+                w, s = (n, r) if nodes.get(n, ("",))[0] == "wiki" else (r, n)
+                bsrc.setdefault(s, set()).add(w)
+        for s, targets in bsrc.items():
+            for _ in range(int(round(args.bridge_neg_ratio))):
+                w = rng.choice(wiki_nodes) if wiki_nodes else None
+                if not w or w == s or w in targets:
+                    continue
+                emit(s, w, args.bridge_neg_mu, "SYM", "bridge_neg")
+                emit(w, s, args.bridge_neg_mu, "SYM", "bridge_neg")
+                n_neg += 1
+
+    if review:
+        with open(args.out + "_bridge_review.tsv", "w", encoding="utf-8") as f:
+            f.write("# QUARANTINED bridges (e5 cosine < %.2f) — LLM-review before training\n"
+                    "# a\tb\te5_cosine\ta_title\tb_title\n" % args.bridge_min_cos)
+            for a, b, c in sorted(review, key=lambda x: x[2]):
+                f.write(f"{a}\t{b}\t{c:.3f}\t{nodes.get(a,('','',''))[2]}\t{nodes.get(b,('','',''))[2]}\n")
+
     with open(args.out + "_pairs.tsv", "w", encoding="utf-8") as f:
         f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\n")
         for (node, root, op), (mu, rel, nty, rty, corpus, judge) in sorted(rows.items()):
@@ -138,6 +201,11 @@ def main():
     print(f"  by op:       {dict(op_c)}")
     print(f"  by relation: {dict(rel_c)}")
     print(f"  by corpus⊗judge: { {f'{c}/{j}': n for (c, j), n in cj_c.items()} }")
+    if n_neg:
+        print(f"  bridge negatives added: {n_neg} pairs (μ={args.bridge_neg_mu}, full-weight, rel=bridge_neg)")
+    if review:
+        print(f"  PRIVACY/QUALITY: quarantined {len(review)} far-in-e5 bridges (cos<{args.bridge_min_cos}) "
+              f"→ {args.out}_bridge_review.tsv (LLM-review before training)")
     if skipped:
         print(f"  skipped: {dict(skipped)}")
     print(f"  wrote {args.out}_pairs.tsv + {args.out}_nodes.tsv")


### PR DESCRIPTION
## What
Two bridge-quality refinements to `build_graded_round.py` (a bridge asserts
"same concept across corpora" at μ≈0.9).

### Bridge negative sampling (`--bridge-neg-ratio`, default 1.0)
Each surviving bridge source also gets a random wiki node it is **not** bridged
to, at μ≈0.1 (SYM, `rel=bridge_neg`, full-weight). Teaches discrimination, not
just the dominance that down-weighting already controls.

### e5-prior review gate (`--e5-cache`, `--bridge-min-cos`)
Flag bridges whose endpoints are **far in frozen e5** (a bad link, or a
non-obvious synonym e5 can't see) and quarantine them to
`<out>_bridge_review.tsv` for LLM review before training. e5 cosines are
compressed (~0.78–1.0), so the threshold is e5-calibrated (default 0.80). On
the two neighbourhoods it quarantined **8** bridges — a clean mix of
questionable (`ladybird-of-szeged`, `norbit`) and legit-but-non-obvious
(`BELBIC`, `towards-a-new-socialism`).

## Honest A/B (fine-tune ±neg+quarantine, both `--use-nodetype`)
| metric | no neg | +neg+quarantine |
|---|---|---|
| discrimination | 94% | 92% |
| SYM held-out | +0.838 | +0.832 |
| ELEM corr | +0.702 | +0.731 |
| graded WIKI fit | +0.757 | +0.817 |

Headline metrics **flat within noise** — confirms bridge down-weighting was
already sufficient. Negatives are cheap, sound insurance but don't move the
needle at this scale; the **e5-prior quarantine** is the clearer,
training-independent win. LLM adjudication of the quarantine list is deferred
(Haiku budget-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)