### PR TITLE
mu_cosine: bridge = same-concept + section-driven relations (ensemble judge, harvest/categorise split)

### DIFF
--- a/prototypes/mu_cosine/REPORT_bridge_cybernetics.md
+++ b/prototypes/mu_cosine/REPORT_bridge_cybernetics.md
@@ -24,6 +24,11 @@ nodes** through 207 bridges; by 3 hops, **1020 enwiki nodes** / 1151 bridges. Th
 almost pure mindmap (the mm↔mm `subtopic`/`see_also`/`super_category` structure); pt and wiki enter at hop 2
 (the seeds' own collections + their enwiki references) and explode at hop 3 (the collections' members).
 
+> **Correction (later):** these `bridge` counts predate the same-concept gate. Most pt→wiki links here are
+> the collection's cross-dataset *references* (different concepts), now correctly typed `see_also`, not
+> `bridge`. Post-fix the 2-hop split is bridge **19** / see_also 196 (not 207 bridges). See
+> `REPORT_graded_round.md` §Correction.
+
 ## Privacy — the scrub-everywhere filter fired on real data
 The fresh harvest pulled **2 collections containing `*private*` markers** (`Intelegence & mind`,
 `System Perspective (Philosophy)` — each a `*private*` shortcut). `fuse_corpus.py` now applies the same

--- a/prototypes/mu_cosine/REPORT_bridge_dynamical_systems.md
+++ b/prototypes/mu_cosine/REPORT_bridge_dynamical_systems.md
@@ -17,6 +17,10 @@ SimpleMind map. A "hop" is ANY cross-corpus edge (mm↔mm, mm↔pt, pt↔pt, pt�
 | 2 | 77 | mm 32, pt 29, wiki 16 | 123 | 34 |
 | 3 | 753 | mm 42, pt 175, **wiki 536** | 932 | **626** |
 
+> **Correction (later):** these `bridge` counts predate the same-concept gate — most pt→wiki links are
+> cross-dataset *references* (different concepts), now typed `see_also`. Post-fix the 3-hop split is bridge
+> **43** / see_also 586 (not 626 bridges). See `REPORT_graded_round.md` §Correction.
+
 ## Profile vs Cybernetics — bridge depth differs by how the map was curated
 | map | seeds | bridges (harvest) | 2-hop wiki | 3-hop wiki |
 |---|---|---|---|---|

--- a/prototypes/mu_cosine/REPORT_bridge_ensemble.md
+++ b/prototypes/mu_cosine/REPORT_bridge_ensemble.md
@@ -1,0 +1,50 @@
+# Ensemble bridge judge — architecture + a calibration finding
+
+`bridge_ensemble.py` scores each cross-corpus bridge with several **models** and combines them with a
+pluggable **judge** into a keep/quarantine verdict. Built to the spec: models are named scorers; the judge
+receives `{model_name: score}` (so it *knows* the models but need not use the names); the default judge is a
+factory-built closure `geomean_judge(threshold=0.7)` (geometric mean ≥ threshold, caller-overridable — 0.7
+is by-feel, not a law). A second factory, `confirm_judge(model_name, t)`, demonstrates a **name-aware**
+judge.
+
+## Models
+- **e5** — cosine of frozen e5 title vectors (independent of all labels).
+- **model:CKPT** — symmetric μ(a|b) from a trained MuAttention, provenance MASKED (agnostic). Use a
+  checkpoint that **predates** the bridges (`model_nodetype.pt`) ⇒ unbiased *and* richer than e5.
+- **llm** — optional, Haiku, budget-gated (same interface; not wired by default).
+
+## Calibration finding (the useful part)
+
+Running `e5` + the pre-bridge `model_nodetype.pt`, geomean ≥ 0.7, on 827 bridges → **quarantined 549 (66%)**.
+That is **too aggressive**, and *why* is the finding:
+
+| bridge | e5 | model | truth |
+|---|---|---|---|
+| `mm:cybernetics ↔ pt:cybernetics` | 1.00 | **0.91** | same concept ✓ |
+| `pt:cybernetics ↔ wiki:centrifugal-governor` | 0.83 | **0.047** | **legit** (textbook cybernetics) |
+| `pt:control-system-engineering ↔ wiki:norbit` | 0.78 | **0.047** | suspect |
+| `pt:cybernetics ↔ wiki:ladybird-of-szeged` | 0.80 | 0.018 | suspect |
+
+The pre-bridge model **confirms concepts it knows** (same-slug cross-corpus: 0.91) but **abstains** —
+≈0.04, *undifferentiated* — on the cross-corpus **page** pairs it never trained on. The legit textbook
+bridge (`centrifugal-governor`) and the bad one (`norbit`) get the **same** 0.047: the near-zero is "I don't
+know," not "wrong." So a geomean that lets abstention **veto** over-quarantines, sweeping in legit bridges.
+
+And **e5 alone can't reject** these either — its cosines are compressed (0.78–0.86 across the whole set), so
+it separates text-dissimilar links weakly and never abstains.
+
+### Conclusions
+1. **Pluggability vindicated.** The geomean default isn't right for an *abstaining* model — exactly the case
+   the configurable judge was designed for. `confirm_judge("model:model_nodetype.pt", 0.5)` trusts only the
+   model's positive votes and defers the rest, instead of letting abstention veto.
+2. **The cheap judges rank, they don't reject.** For cross-corpus *page* bridges, neither e5 (saturated) nor
+   the pre-bridge model (abstains) can reliably *reject* a legit-looking link. They are good at **ranking
+   suspicion** (the model's low-confidence set surfaces what to look at), not at the final call.
+3. **The real rejecter is the LLM** (or a model trained *with* the bridges — informed but circular). The
+   ensemble's job is to **bound the LLM bill**: rank by geomean, send the top-N most-suspicious to the LLM.
+
+## Next (item 2: review the current bridges)
+Use the ensemble **ranking** to feed a **bounded LLM review** — the top ~20–30 lowest-geomean bridges
+(model-abstained + any genuinely text-dissimilar), not all 549. That keeps the Haiku spend small while
+catching the real bad links; LLM verdicts then re-include legit non-obvious bridges (BELBIC,
+`centrifugal-governor`, `towards-a-new-socialism`) and drop the noise. Budget-gated — confirm before the run.

--- a/prototypes/mu_cosine/REPORT_bridge_ensemble.md
+++ b/prototypes/mu_cosine/REPORT_bridge_ensemble.md
@@ -43,6 +43,24 @@ it separates text-dissimilar links weakly and never abstains.
 3. **The real rejecter is the LLM** (or a model trained *with* the bridges — informed but circular). The
    ensemble's job is to **bound the LLM bill**: rank by geomean, send the top-N most-suspicious to the LLM.
 
+## Resolution: the over-quarantine was a DATA BUG, not just calibration
+
+The 66% quarantine had a root cause: **most "bridges" weren't bridges.** `fuse_corpus.py` /
+`parse_pearltrees.py` labelled *every* pt→wiki link `bridge`, but a bridge is the **same concept** across
+corpora (identity, μ≈0.9). A wiki page in a collection that names a *different* thing (`Cybernetics`
+collection → `Centrifugal governor` page) is the collection's cross-dataset **reference**, not identity.
+The model's abstention (~0.047) was the honest signal that these *aren't* the same concept — it was right.
+
+Fixed with a **same-concept gate** (`bridge` iff the endpoints' normalised titles match, else `see_also`).
+Result: 827 → **61** true bridges; the ensemble (e5 + pre-bridge model, geomean≥0.7) now **keeps 60/61**, and
+the single "quarantine" (`mm:courses-dynamical-systems ↔ pt:courses-dynamical-systems`, same slug) is itself
+legit (e5 0.911; the model is merely under-confident at 0.327). So once the bridges are *actually* identity
+links, the ensemble agrees with them — exactly as it should.
+
+The architecture finding still stands for the genuinely-unknown cross-corpus pairs (the model abstains, can't
+reject) — but those are now correctly typed `see_also`, so they no longer masquerade as bridges needing a
+verdict.
+
 ## Next (item 2: review the current bridges)
 Use the ensemble **ranking** to feed a **bounded LLM review** — the top ~20–30 lowest-geomean bridges
 (model-abstained + any genuinely text-dissimilar), not all 549. That keeps the Haiku spend small while

--- a/prototypes/mu_cosine/REPORT_graded_round.md
+++ b/prototypes/mu_cosine/REPORT_graded_round.md
@@ -60,12 +60,24 @@ their node-type (and group) tokens**, so identity doesn't collapse them. `fuse_c
 cross-dataset links to *different* things (`Cybernetics` collection → `Centrifugal governor` page) — not
 identity. A **same-concept gate** (normalised titles match ⇒ `bridge`) corrects this: **bridge 1654 → 122**.
 
-For the non-identity ones, use the **most specific** relation the structure gives — the harvester tags a wiki
-page in a collection `element_of` (it is a member), and `parse_pearltrees` has the section context
-(Subcategories/Subtopics/…) — and fall back to `see_also` only when nothing more specific is identifiable
-(*not* a blanket see_also). Result on the two neighbourhoods: **element_of 6 → 1538**, see_also 22, bridge
-122. So `centrifugal-governor` becomes `element_of cybernetics` (a member, μ≈0.9 directional), which also
-finally gives the **ELEM operator** (previously starved at 6) real cross-corpus, node-type-diverse signal.
+For the non-identity ones, the relation comes from the pearl's **Pearltrees section name** — the designed
+source — not a blanket default: *Subcategories* → `subcategory`, *Subtopics* → `element_of`,
+*Super Categories* → `super_category`, *See Also / References* → `see_also`, with the structural contentType
+default only when a pearl is in no recognised section. This is captured as a **layered pipeline** (see
+"Harvest vs categorise" below): the harvester records raw section text by position id; categorisation is a
+separate, re-runnable step (`pt_sections.py` / `categorize_sections.py`). Result on the two neighbourhoods —
+a properly diverse relation set instead of one bucket: **element_of 1446, subcategory 396, super_category
+154, see_also 90, bridge 122, subtopic 82** (WIKI 632 / ELEM 1446 / SYM 410 targets). The directional
+category relations are now separated correctly, and the ELEM operator (once starved at 6) gets real
+cross-corpus, node-type-diverse signal.
+
+### Harvest vs categorise — two layers, not one
+The cookie harvester (`.local`) previously dropped section headers and tagged every page `element_of` from
+its contentType. Now it does **faithful raw capture only**: each pearl carries `section_pos_id`, and the
+section labels are emitted as a `#SECTION` table (pos_id → text). **Categorisation is a separate step**
+(`pt_sections.section_mode`, `categorize_sections.py`) that maps section text → relation and records the
+**method** (`exact_phrase` now; `fuzzy` / `llm_template` later) and a **confidence** — so categorisation is
+itself provenance, and can be re-run / upgraded over cached harvests **without re-harvesting**.
 
 ## Bridge quality — negatives + an e5-prior review gate
 

--- a/prototypes/mu_cosine/REPORT_graded_round.md
+++ b/prototypes/mu_cosine/REPORT_graded_round.md
@@ -54,15 +54,18 @@ mindmap/pearltrees curation did — so *both* directions of a bridge get the mm/
 
 ## Correction: `bridge` is same-concept only (not every cross-dataset link)
 
-A `bridge` means the **same concept** across corpora (identity, μ≈0.9). `fuse_corpus.py` /
+A `bridge` means the **same concept** across corpora (identity, μ≈0.9) — the endpoints stay **distinct via
+their node-type (and group) tokens**, so identity doesn't collapse them. `fuse_corpus.py` /
 `parse_pearltrees.py` originally labelled *every* pt→wiki link `bridge`, but most are the collection's
-cross-dataset **references** to *different* things (`Cybernetics` collection → `Centrifugal governor` page) —
-those are `see_also` (associative, μ≈0.4), not identity. A **same-concept gate** (normalised titles match ⇒
-`bridge`, else `see_also`) corrects this: on the two neighbourhoods, **bridge 1654 → 122**, **see_also 22 →
-1550**. The remaining 122 bridges are genuine identity links (high e5; the ensemble keeps 60/61). This makes
-the round semantically honest — the model learns `centrifugal-governor ~0.4 cybernetics` (related), not
-`=0.9` (identical). Bridge dominance is no longer even an issue; `see_also` now carries the cross-dataset mass
-at its correct associative μ.
+cross-dataset links to *different* things (`Cybernetics` collection → `Centrifugal governor` page) — not
+identity. A **same-concept gate** (normalised titles match ⇒ `bridge`) corrects this: **bridge 1654 → 122**.
+
+For the non-identity ones, use the **most specific** relation the structure gives — the harvester tags a wiki
+page in a collection `element_of` (it is a member), and `parse_pearltrees` has the section context
+(Subcategories/Subtopics/…) — and fall back to `see_also` only when nothing more specific is identifiable
+(*not* a blanket see_also). Result on the two neighbourhoods: **element_of 6 → 1538**, see_also 22, bridge
+122. So `centrifugal-governor` becomes `element_of cybernetics` (a member, μ≈0.9 directional), which also
+finally gives the **ELEM operator** (previously starved at 6) real cross-corpus, node-type-diverse signal.
 
 ## Bridge quality — negatives + an e5-prior review gate
 

--- a/prototypes/mu_cosine/REPORT_graded_round.md
+++ b/prototypes/mu_cosine/REPORT_graded_round.md
@@ -52,6 +52,18 @@ mindmap/pearltrees curation did — so *both* directions of a bridge get the mm/
 - `<out>_nodes.tsv`: `key  corpus  node_type  title  embed_text` — `embed_text` is the e5 string per node
   (the `Team <name> <id>` prefix hook lives here; inert until the `s243a_groups`/teams account is harvested).
 
+## Correction: `bridge` is same-concept only (not every cross-dataset link)
+
+A `bridge` means the **same concept** across corpora (identity, μ≈0.9). `fuse_corpus.py` /
+`parse_pearltrees.py` originally labelled *every* pt→wiki link `bridge`, but most are the collection's
+cross-dataset **references** to *different* things (`Cybernetics` collection → `Centrifugal governor` page) —
+those are `see_also` (associative, μ≈0.4), not identity. A **same-concept gate** (normalised titles match ⇒
+`bridge`, else `see_also`) corrects this: on the two neighbourhoods, **bridge 1654 → 122**, **see_also 22 →
+1550**. The remaining 122 bridges are genuine identity links (high e5; the ensemble keeps 60/61). This makes
+the round semantically honest — the model learns `centrifugal-governor ~0.4 cybernetics` (related), not
+`=0.9` (identical). Bridge dominance is no longer even an issue; `see_also` now carries the cross-dataset mass
+at its correct associative μ.
+
 ## Bridge quality — negatives + an e5-prior review gate
 
 Two refinements to how bridges are handled (a bridge asserts "same concept across corpora" at μ≈0.9):

--- a/prototypes/mu_cosine/REPORT_graded_training.md
+++ b/prototypes/mu_cosine/REPORT_graded_training.md
@@ -50,6 +50,26 @@ carries real signal. The gate-and-bank strategy paid off.
 - Bridge dominance handled by `--bridge-weight 0.2`; the thin ELEM in this round (6 targets) rides the
   existing wiki-page ELEM training — ELEM stayed healthy (+0.702).
 
+## Re-measured on the corrected round (bridge = same-concept; references → element_of)
+
+The numbers above were on the *pre-correction* (bridge-dominated) round. After the same-concept fix —
+`bridge` 1654→122 (identity only) and cross-dataset references → their specific relation (`element_of`
+1538, see_also fallback) — the same warm-start fine-tune (`--use-nodetype`, GPU) gives:
+
+| metric | corrected round |
+|---|---|
+| graded held-out **ELEM** fit (r) | **+0.999** (MSE 0.002) |
+| graded held-out **SYM** fit (r) | +0.865 |
+| graded held-out **WIKI** fit (r) | +0.837 |
+| **SYM** held-out corr | **+0.836** (> control +0.726) |
+| **WIKI** order-acc | 99.8% |
+| **ELEM** centrality corr / direction | +0.662 / 100% |
+| discrimination | 94% (34/36) |
+
+The fix isn't just semantically honest — it *helps*: the references' correct `element_of` relation hands the
+previously-starved ELEM operator (6 → 1538 targets) rich cross-corpus, node-type-diverse signal, and it fits
+at **r +0.999** while every other operator stays healthy (SYM still beats the control).
+
 ## Next
 - Bring the **account** token + the `Team <name> <id>` e5-text online once the `s243a_groups` account is
   harvested (the plumbing is in; `--use-account` will gate it).

--- a/prototypes/mu_cosine/REPORT_graded_training.md
+++ b/prototypes/mu_cosine/REPORT_graded_training.md
@@ -70,6 +70,26 @@ The fix isn't just semantically honest — it *helps*: the references' correct `
 previously-starved ELEM operator (6 → 1538 targets) rich cross-corpus, node-type-diverse signal, and it fits
 at **r +0.999** while every other operator stays healthy (SYM still beats the control).
 
+### Section-driven relations (final): relations from the actual subsection names
+
+A further correction replaced the blanket `element_of` with the **section-derived** relation (Subcategories →
+subcategory, Subtopics → element_of, Super Categories → super_category, …; see `REPORT_graded_round.md`
+§Correction + §Harvest-vs-categorise). The graded mix becomes WIKI 534 / ELEM 1238 / SYM 343 (the
+directional category relations now feed WIKI). Same fine-tune:
+
+| metric | section-driven |
+|---|---|
+| graded **ELEM** fit (r) | +0.995 (MSE 0.002) |
+| graded **WIKI** fit (r) | **+0.852** (534 targets, ~2.5× more) |
+| graded **SYM** fit (r) | +0.792 |
+| **SYM** held-out | +0.830 (> control +0.726) |
+| **WIKI** order-acc | 99.9% |
+| **ELEM** corr / direction | +0.698 / 100% |
+| discrimination | 89% (32/36) |
+
+All operators stay healthy and the WIKI directional signal grows; discrimination dips ~5 pts (2 examples,
+within noise on a data-mix change). Net: the section-driven relations are both more correct and train well.
+
 ## Next
 - Bring the **account** token + the `Team <name> <id>` e5-text online once the `s243a_groups` account is
   harvested (the plumbing is in; `--use-account` will gate it).

--- a/prototypes/mu_cosine/bridge_ensemble.py
+++ b/prototypes/mu_cosine/bridge_ensemble.py
@@ -30,7 +30,12 @@ import os
 # ----- the JUDGE (pluggable; default is a factory that closes over the threshold) -------------------------
 def geomean_judge(threshold=0.7):
     """Factory → judge(scores: dict[name,float]) -> bool. Keep iff the GEOMETRIC MEAN of the model scores
-    is ≥ threshold. Ignores the model names (but receives them, so a custom judge could use them)."""
+    is ≥ threshold. Ignores the model names (but receives them, so a custom judge could use them).
+
+    Note: with a SINGLE model the geometric mean is just that model's score, so this (and most judges)
+    reduce to `score ≥ threshold` — the sensible degenerate behaviour. A judge only *needs* ≥2 models if it
+    computes ensemble statistics (variance / disagreement / uncertainty); such a judge can check len(scores)
+    and decide how to behave when it's handed only one."""
     def judge(scores):
         vals = [max(1e-12, float(v)) for v in scores.values()]
         if not vals:

--- a/prototypes/mu_cosine/bridge_ensemble.py
+++ b/prototypes/mu_cosine/bridge_ensemble.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Ensemble bridge judge — score each cross-corpus BRIDGE with several MODELS (embeddings and/or an LLM) and
+combine them with a pluggable JUDGE into a keep/quarantine verdict. A bridge asserts "same concept across
+corpora" (μ≈0.9); the ensemble flags the ones the models don't support, for review before training
+(DESIGN_provenance_and_representation.md §Privacy / REPORT_graded_round.md bridge quality).
+
+ARCHITECTURE
+  MODEL  : a named scorer (a_key, b_key) -> float in ~[0,1] ("confidence these are the same/related").
+           Provided models, by independence from the bridge label:
+             * e5            cosine of frozen e5 title vectors          (independent of ALL labels)
+             * model:CKPT    symmetric μ(a|b) from a trained MuAttention, provenance MASKED (agnostic).
+                             Use a checkpoint that PREDATES the bridges (e.g. model_nodetype.pt) ⇒ its
+                             opinion is unbiased AND richer than e5 (it knows the operators / node-types /
+                             relational graph that raw e5 can't see — e.g. it can rate BELBIC↔control-systems
+                             plausible where e5 saw only an opaque acronym).
+             * llm           (optional, Haiku — budget-gated) same interface; not wired by default.
+  JUDGE  : {model_name: score} -> keep(bool). It is GIVEN the model names, so it MAY weight or ignore
+           specific models, but need not use them. The DEFAULT is a factory-built closure
+           `geomean_judge(threshold=0.7)` (geometric mean ≥ threshold). 0.7 is a by-feel default, not a law —
+           pass your own threshold, or any lambda `scores -> bool`, to override.
+
+    python3 bridge_ensemble.py --fused /tmp/cyb_fused_2 --fused /tmp/ds_fused_3 \
+        --e5-cache e5_tables_graded.pt --judge-model model_nodetype.pt --threshold 0.7 --out /tmp/bridge_verdict
+"""
+import argparse
+import math
+import os
+
+
+# ----- the JUDGE (pluggable; default is a factory that closes over the threshold) -------------------------
+def geomean_judge(threshold=0.7):
+    """Factory → judge(scores: dict[name,float]) -> bool. Keep iff the GEOMETRIC MEAN of the model scores
+    is ≥ threshold. Ignores the model names (but receives them, so a custom judge could use them)."""
+    def judge(scores):
+        vals = [max(1e-12, float(v)) for v in scores.values()]
+        if not vals:
+            return True
+        gm = math.exp(sum(math.log(v) for v in vals) / len(vals))
+        return gm >= threshold
+    judge.label = f"geomean>={threshold:g}"
+    return judge
+
+
+def confirm_judge(model_name, threshold=0.5):
+    """Factory → a NAME-AWARE judge: keep iff the specified model confidently CONFIRMS (score ≥ threshold).
+    Useful when a model ABSTAINS with a low score (≈0) on inputs it never trained on — there a geomean lets
+    abstention veto, but a confirm-judge only trusts a positive vote and defers the rest (e.g. to an LLM).
+    Demonstrates that the judge is given the model names and MAY use them (the default geomean does not)."""
+    def judge(scores):
+        return scores.get(model_name, 0.0) >= threshold
+    judge.label = f"confirm[{model_name}]>={threshold:g}"
+    return judge
+
+
+# ----- the MODELS (named scorers) -------------------------------------------------------------------------
+def e5_scorer(cache_path):
+    import torch
+    d = torch.load(cache_path, weights_only=False)
+    vidx = {n: i for i, n in enumerate(d["names"])}
+    vec = d["passage"]                                     # unit-normed ⇒ dot = cosine
+
+    def score(a, b):
+        ia, ib = vidx.get(a), vidx.get(b)
+        return float("nan") if ia is None or ib is None else float(vec[ia] @ vec[ib])
+    return ("e5", score)
+
+
+def model_scorer(ckpt_path, e5_cache, name=None, device="cpu"):
+    """A trained-MuAttention judge: symmetric μ with provenance MASKED (agnostic). Loads the checkpoint with
+    the warm-start GROW logic so an older (smaller-codebook) checkpoint still loads; masked provenance ⇒ the
+    grown corpus/judge/account rows are never read."""
+    import torch
+    from mu_attention import MuAttention, Tokenizer, OPS, load_dag
+    d = torch.load(e5_cache, weights_only=False)
+    idx = {n: i for i, n in enumerate(d["names"])}
+    parents, children, deg = load_dag()
+    tok = Tokenizer(d["query"], d["passage"], idx, parents, deg)
+    ck = torch.load(ckpt_path, weights_only=False)
+    cfg = ck.get("cfg", {})
+    model = MuAttention(d_model=d["query"].shape[1], n_heads=cfg.get("heads", 4), n_layers=cfg.get("layers", 3))
+    sd, own = ck["state"], model.state_dict()
+    for k, v in sd.items():                               # copy matching; grow op-/codebook-indexed rows
+        if k in own and own[k].shape == v.shape:
+            own[k] = v
+        elif k in own and own[k].dim() >= 1 and own[k].shape[0] > v.shape[0] and own[k].shape[1:] == v.shape[1:]:
+            t = own[k].clone(); t[:v.shape[0]] = v; t[v.shape[0]:] = v[0]; own[k] = t
+    model.load_state_dict(own); model.to(device); model.eval()
+
+    @torch.no_grad()
+    def score(a, b):
+        if a not in idx or b not in idx:
+            return float("nan")
+        batch = tok.build([(a, b, OPS["SYM"]), (b, a, OPS["SYM"])], train=False)   # 3-tuple ⇒ masked prov
+        batch = {k: (v.to(device) if torch.is_tensor(v) else v) for k, v in batch.items()}
+        mu = model(**batch).cpu()
+        return float((mu[0] + mu[1]) / 2)                 # symmetric: mean of both directions
+    return (name or f"model:{os.path.basename(ckpt_path)}", score)
+
+
+# ----- the ENSEMBLE ---------------------------------------------------------------------------------------
+class BridgeEnsemble:
+    def __init__(self, models):                           # models: list of (name, scorer_fn)
+        self.models = models
+
+    def score(self, a, b):
+        return {name: fn(a, b) for name, fn in self.models}
+
+    def review(self, bridges, judge=None):
+        judge = judge or geomean_judge()
+        keep, quarantine = [], []
+        for a, b in bridges:
+            s = {k: v for k, v in self.score(a, b).items() if v == v}   # drop NaN (a model didn't know a node)
+            (keep if (not s or judge(s)) else quarantine).append((a, b, s))
+        return keep, quarantine
+
+
+def load_bridges(prefixes):
+    nodes, bridges = {}, set()
+    for pref in prefixes:
+        with open(pref + "_nodes.tsv", encoding="utf-8") as f:
+            for ln in f:
+                if not ln.startswith("#"):
+                    c = ln.rstrip("\n").split("\t")
+                    if len(c) >= 4:
+                        nodes[c[0]] = c[3]                 # key → title
+        with open(pref + "_edges.tsv", encoding="utf-8") as f:
+            for ln in f:
+                if not ln.startswith("#"):
+                    c = ln.rstrip("\n").split("\t")
+                    if len(c) >= 3 and c[2] == "bridge":
+                        bridges.add(tuple(sorted((c[0], c[1]))))
+    return nodes, sorted(bridges)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fused", action="append", required=True, help="fused prefix (repeatable)")
+    ap.add_argument("--e5-cache", required=True)
+    ap.add_argument("--judge-model", default=None, help="MuAttention checkpoint as a 2nd judge model "
+                    "(ideally pre-bridge, e.g. model_nodetype.pt)")
+    ap.add_argument("--threshold", type=float, default=0.7, help="default judge: geomean ≥ threshold")
+    ap.add_argument("--device", default="cpu")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    nodes, bridges = load_bridges(args.fused)
+    models = [e5_scorer(args.e5_cache)]
+    if args.judge_model:
+        models.append(model_scorer(args.judge_model, args.e5_cache, device=args.device))
+    ens = BridgeEnsemble(models)
+    judge = geomean_judge(args.threshold)
+    keep, quarantine = ens.review(bridges, judge)
+
+    names = [n for n, _ in models]
+    print(f"{len(bridges)} bridges · models {names} · judge {judge.label} "
+          f"→ keep {len(keep)}, quarantine {len(quarantine)}")
+    print("quarantined (judge says NOT same-concept) — review candidates, lowest geomean first:")
+    def gm(s): return math.exp(sum(math.log(max(1e-12, v)) for v in s.values()) / len(s)) if s else 1.0
+    for a, b, s in sorted(quarantine, key=lambda x: gm(x[2]))[:20]:
+        sc = "  ".join(f"{k}={v:.3f}" for k, v in s.items())
+        print(f"  gm={gm(s):.3f}  {a}  <->  {b}   [{sc}]")
+    if args.out:
+        with open(args.out + "_quarantine.tsv", "w", encoding="utf-8") as f:
+            f.write("# a\tb\tgeomean\t" + "\t".join(names) + "\ta_title\tb_title\n")
+            for a, b, s in sorted(quarantine, key=lambda x: gm(x[2])):
+                f.write(f"{a}\t{b}\t{gm(s):.3f}\t" + "\t".join(f"{s.get(n, float('nan')):.3f}" for n in names)
+                        + f"\t{nodes.get(a,'')}\t{nodes.get(b,'')}\n")
+        print(f"  wrote {args.out}_quarantine.tsv ({len(quarantine)} bridges for review)")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/categorize_sections.py
+++ b/prototypes/mu_cosine/categorize_sections.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""SECOND STEP (separate from the harvest): read the RAW section table that the harvester captured
+(`#SECTION` lines in the .pt_cache harvests) and emit the categorisation — `section_pos_id → relation,
+category, method, confidence, text`. This is the "feed the text output into a db and map categories to
+columns" step: it is re-runnable over cached harvests (NO re-harvest) and the `--method` is upgradeable
+(exact_phrase → fuzzy → llm_template). The method+confidence are PROVENANCE for each relation.
+
+    python3 categorize_sections.py --cache .pt_cache --out section_categories.tsv
+"""
+import argparse
+import glob
+import os
+from collections import Counter
+
+from pt_sections import categorize, CATEGORY_RELATION
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cache", default=os.path.join(ROOT, ".pt_cache"), help="dir of raw pt_*.tsv harvests")
+    ap.add_argument("--method", default="exact_phrase", help="exact_phrase (fuzzy / llm_template later)")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    seen, rows = set(), []
+    for path in sorted(glob.glob(os.path.join(args.cache, "pt_*.tsv"))):
+        for ln in open(path, encoding="utf-8"):
+            if not ln.startswith("#SECTION\t"):
+                continue
+            p = ln.rstrip("\n").split("\t")
+            if len(p) < 3 or p[1] in seen:
+                continue
+            seen.add(p[1])
+            cat, method, conf = categorize(p[2], args.method)
+            rows.append((p[1], CATEGORY_RELATION.get(cat) or "", cat or "", method, f"{conf:.2f}", p[2]))
+
+    matched = [r for r in rows if r[1]]
+    print(f"{len(rows)} sections → {len(matched)} categorised ({args.method})")
+    print(f"  by relation: {dict(Counter(r[1] for r in matched))}")
+    uncategorised = [r[5] for r in rows if not r[1]][:12]
+    if uncategorised:
+        print(f"  no rule fired (→ structural fallback downstream): {uncategorised}")
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write("# section_pos_id\trelation\tcategory\tmethod\tconfidence\ttext\n")
+            for r in rows:
+                f.write("\t".join(r) + "\n")
+        print(f"  wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/fuse_corpus.py
+++ b/prototypes/mu_cosine/fuse_corpus.py
@@ -109,10 +109,12 @@ def main():
         if m:                                           # PagePearl whose url is enwiki → a cross-corpus link
             title = m.group(1).split("#")[0].replace("%28", "(").replace("%29", ")")
             wk = addn("wiki", title, "category" if title.startswith("Category:") else "page", title)
-            # A `bridge` is the SAME concept across corpora (identity). A wiki page in a collection that names
-            # a DIFFERENT thing (e.g. "Cybernetics" collection → "Centrifugal governor" page) is not identity
-            # — it is the collection's cross-dataset REFERENCE, so use `see_also`, not bridge.
-            rel = "bridge" if norm(title) == norm(f[0]) else "see_also"
+            # A `bridge` is the SAME concept across corpora (identity) — the endpoints still stay DISTINCT via
+            # their node-type (and group) tokens, so identity doesn't collapse them. If NOT the same concept
+            # (e.g. "Cybernetics" collection → "Centrifugal governor" page) it is the collection's cross-
+            # dataset link: use the MOST SPECIFIC relation the harvester gives (element_of for a page,
+            # subtopic for a sub-collection, …) and fall back to see_also only when nothing more specific is.
+            rel = "bridge" if norm(title) == norm(f[0]) else PT_REL.get(f[2], "see_also")
             edges.append((pk, wk, rel))
         elif len(f) > 3:
             if norm(f[1]) in pt_priv:                   # private child → scrub

--- a/prototypes/mu_cosine/fuse_corpus.py
+++ b/prototypes/mu_cosine/fuse_corpus.py
@@ -106,10 +106,14 @@ def main():
             scrub_pt += 1; continue
         pk = addn("pt", f[0], "pearltrees_collection", f[0])
         m = WIKI.search(f[4]) if len(f) > 4 else None
-        if m:                                           # PagePearl whose url is enwiki → a bridge
+        if m:                                           # PagePearl whose url is enwiki → a cross-corpus link
             title = m.group(1).split("#")[0].replace("%28", "(").replace("%29", ")")
             wk = addn("wiki", title, "category" if title.startswith("Category:") else "page", title)
-            edges.append((pk, wk, "bridge"))
+            # A `bridge` is the SAME concept across corpora (identity). A wiki page in a collection that names
+            # a DIFFERENT thing (e.g. "Cybernetics" collection → "Centrifugal governor" page) is not identity
+            # — it is the collection's cross-dataset REFERENCE, so use `see_also`, not bridge.
+            rel = "bridge" if norm(title) == norm(f[0]) else "see_also"
+            edges.append((pk, wk, rel))
         elif len(f) > 3:
             if norm(f[1]) in pt_priv:                   # private child → scrub
                 scrub_pt += 1; continue

--- a/prototypes/mu_cosine/fuse_corpus.py
+++ b/prototypes/mu_cosine/fuse_corpus.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 
 from privacy import is_private_title, propagate as privacy_propagate    # scrub-everywhere (see privacy.py)
+from pt_sections import relation_for                                    # section label → relation (shared)
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 WIKI = re.compile(r"en\.wikipedia\.org/wiki/(.+)$")
@@ -75,14 +76,20 @@ def main():
     # harvester, not parse_pearltrees.py), so apply the SAME rule here — drop private-titled pt nodes and,
     # inherited down pt containment, their whole subtree — before building any fused edge.
     pt_rows, pt_children, pt_priv = [], {}, set()       # rows ; norm(parent)→{norm(child)} ; private norm-keys
+    pt_sec = {}                                         # section pos_id → label text (from the #SECTION table)
     for slug, tid in sm_seeds.items():
         path = os.path.join(args.pt_cache, f"pt_{tid}.tsv")
         if not os.path.exists(path):
             continue
         for hl in open(path, encoding="utf-8"):
+            if hl.startswith("#SECTION\t"):             # the raw section table (pos_id → label); categorise later
+                sp = hl.rstrip("\n").split("\t")
+                if len(sp) >= 3:
+                    pt_sec[sp[1]] = sp[2]
+                continue
             if hl.startswith("#"):
                 continue
-            f = hl.rstrip("\n").split("\t")             # parent, child, rel, child_type, url, ...
+            f = hl.rstrip("\n").split("\t")             # parent, child, rel_struct, child_type, url, …, sec_pos_id
             if len(f) < 3:
                 continue
             pt_rows.append(f)
@@ -104,23 +111,25 @@ def main():
     for f in pt_rows:
         if norm(f[0]) in pt_priv:                       # private parent → scrub the row
             scrub_pt += 1; continue
+        # relation comes from the pearl's SECTION (the most specific, designed source: Subcategories →
+        # subcategory, Subtopics → element_of, See Also/References → see_also, …); fall back to the
+        # structural contentType default only when the pearl is in no recognised section.
+        cat_rel = relation_for(pt_sec.get(f[7], "")) [0] if len(f) > 7 else None
         pk = addn("pt", f[0], "pearltrees_collection", f[0])
         m = WIKI.search(f[4]) if len(f) > 4 else None
         if m:                                           # PagePearl whose url is enwiki → a cross-corpus link
             title = m.group(1).split("#")[0].replace("%28", "(").replace("%29", ")")
             wk = addn("wiki", title, "category" if title.startswith("Category:") else "page", title)
-            # A `bridge` is the SAME concept across corpora (identity) — the endpoints still stay DISTINCT via
-            # their node-type (and group) tokens, so identity doesn't collapse them. If NOT the same concept
-            # (e.g. "Cybernetics" collection → "Centrifugal governor" page) it is the collection's cross-
-            # dataset link: use the MOST SPECIFIC relation the harvester gives (element_of for a page,
-            # subtopic for a sub-collection, …) and fall back to see_also only when nothing more specific is.
-            rel = "bridge" if norm(title) == norm(f[0]) else PT_REL.get(f[2], "see_also")
+            # A `bridge` is the SAME concept across corpora (identity) — the endpoints stay DISTINCT via their
+            # node-type/group tokens, so identity doesn't collapse them. If NOT the same concept it is the
+            # collection's cross-dataset link: use the section relation, else the structural default.
+            rel = "bridge" if norm(title) == norm(f[0]) else (cat_rel or PT_REL.get(f[2], "see_also"))
             edges.append((pk, wk, rel))
         elif len(f) > 3:
             if norm(f[1]) in pt_priv:                   # private child → scrub
                 scrub_pt += 1; continue
             ck = addn("pt", f[1], "pearltrees_collection" if f[3] != "page" else "page", f[1])
-            edges.append((pk, ck, PT_REL.get(f[2], "assoc")))
+            edges.append((pk, ck, cat_rel or PT_REL.get(f[2], "assoc")))
 
     # 3) N-hop BFS from the start over the UNDIRECTED fused graph (a hop = any cross-corpus edge)
     adj = collections.defaultdict(set)

--- a/prototypes/mu_cosine/parse_pearltrees.py
+++ b/prototypes/mu_cosine/parse_pearltrees.py
@@ -90,18 +90,10 @@ def main():
             add(ek, etype, ek.replace("_", " "), "", ek)
         return ek, etype
 
-    def section_mode(text):
-        """A SECTION header retypes the pearls that FOLLOW it (until the next section), like a SimpleMind
-        container. Recognised headers and the relation they impose:"""
-        t = (text or "").lower()
-        if "subcategor" in t:                       return "subcategory"      # → subcategory (narrower cat)
-        if "subtopic" in t:                         return "element_of"       # → element relations
-        if ("super" in t and "categor" in t) or "navigate up" in t:
-            return "super_category"                 # → parent (super-cat, or a page's parent)
-        if "see also" in t:                         return "see_also"         # → associative
-        if "wiki" in t or "encyclopedia" in t or "reference" in t:
-            return "reference"                      # → links that bridge the TREE to enwiki/encyclopedia
-        return None                                 # topical/junk header (Algebra, Meta, …) ⇒ default
+    # A SECTION header retypes the pearls that FOLLOW it (until the next section), like a SimpleMind
+    # container. The rule is the shared, re-runnable categoriser (pt_sections.section_mode) — exact-phrase
+    # match now, upgradeable to fuzzy/LLM, and the SAME rule fuse_corpus.py applies to the cookie-harvest.
+    from pt_sections import section_mode
 
     rows = list(con.execute("SELECT tree_id, content_type, title, url, content_tree_id, content_tree_title, "
                             "section_text, left_index FROM pearls ORDER BY tree_id, left_index"))

--- a/prototypes/mu_cosine/parse_pearltrees.py
+++ b/prototypes/mu_cosine/parse_pearltrees.py
@@ -171,8 +171,9 @@ def main():
             if ek:
                 edges.append((dk, ek, "bridge"))          # the pt page IS that wiki page (identity)
                 if mode == "reference":                   # the TREE ↔ this wiki page: a `bridge` ONLY if the
-                    # tree names the SAME concept; otherwise it's the tree's cross-dataset REFERENCE → see_also
-                    edges.append((src, ek, "bridge" if slug(ek) == src else "see_also"))
+                    # tree names the SAME concept; otherwise mirror the page's own relation (the MOST SPECIFIC
+                    # one — element_of / the section relation), falling back to see_also, not blanket see_also.
+                    edges.append((src, ek, "bridge" if slug(ek) == src else rel))
 
     seen, uniq = set(), []
     for a, b, rel in edges:

--- a/prototypes/mu_cosine/parse_pearltrees.py
+++ b/prototypes/mu_cosine/parse_pearltrees.py
@@ -166,12 +166,13 @@ def main():
         # relation = the section mode if it names one, else the contentType default
         rel = mode if mode in ("subcategory", "element_of", "super_category", "see_also") else base
         edges.append((src, dk, rel))
-        if ctype == 1 and ew:                             # any wiki PagePearl bridges to its enwiki node
+        if ctype == 1 and ew:                             # wiki PagePearl ↔ its enwiki node = SAME page
             ek, _ = enwiki_node(ew)
             if ek:
-                edges.append((dk, ek, "bridge"))
-                if mode == "reference":                   # a wiki/encyclopedia-REFERENCE section also
-                    edges.append((src, ek, "bridge"))     # bridges the whole TREE to enwiki
+                edges.append((dk, ek, "bridge"))          # the pt page IS that wiki page (identity)
+                if mode == "reference":                   # the TREE ↔ this wiki page: a `bridge` ONLY if the
+                    # tree names the SAME concept; otherwise it's the tree's cross-dataset REFERENCE → see_also
+                    edges.append((src, ek, "bridge" if slug(ek) == src else "see_also"))
 
     seen, uniq = set(), []
     for a, b, rel in edges:

--- a/prototypes/mu_cosine/pt_sections.py
+++ b/prototypes/mu_cosine/pt_sections.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Section categorizer — map a Pearltrees SECTION label to a graph RELATION, as a SEPARATE, re-runnable step
+over the harvester's RAW capture. The harvester records section text by position id and makes NO relation
+judgement; categorization happens here (and in categorize_sections.py / inline in the consumers), so we can
+re-categorise cached harvests WITHOUT re-harvesting, and upgrade the matching method over time.
+
+Recording the METHOD makes the categorisation itself PROVENANCE — it slots into the same judge axis as the
+rest of the pipeline: `exact_phrase` is deterministic (graph-judge-like, confidence 1.0); `fuzzy` /
+`llm_template` are probabilistic (typically <1.0 confidence) and a loose match could later carry a looser μ.
+
+Shared by parse_pearltrees.py, fuse_corpus.py and categorize_sections.py so the rule lives in ONE place.
+"""
+
+# category → the graph relation it implies. `reference` (a wiki/encyclopedia reference LIST) is associative.
+CATEGORY_RELATION = {
+    "subcategory": "subcategory",
+    "element_of": "element_of",
+    "super_category": "super_category",
+    "see_also": "see_also",
+    "reference": "see_also",
+}
+
+
+def section_mode(text):
+    """EXACT-PHRASE (case-insensitive substring) categoriser: a section label → category, or None when no
+    rule fires (the caller then falls back to the structural default — see_also is NOT assumed)."""
+    t = (text or "").lower()
+    if "subcategor" in t:
+        return "subcategory"                          # narrower category
+    if "subtopic" in t:
+        return "element_of"                           # element / membership
+    if ("super" in t and "categor" in t) or "navigate up" in t:
+        return "super_category"                       # broader / parent
+    if "see also" in t or "via link" in t or "related" in t:
+        return "see_also"                             # associative
+    if "wiki" in t or "encyclopedia" in t or "reference" in t:
+        return "reference"                            # a reference list (→ see_also)
+    return None
+
+
+def categorize(text, method="exact_phrase"):
+    """Section label → (category, method, confidence). `exact_phrase` now; `fuzzy` / `llm_template` are
+    future methods with the SAME signature (and typically <1.0 confidence)."""
+    if method == "exact_phrase":
+        cat = section_mode(text)
+        return (cat, "exact_phrase", 1.0 if cat else 0.0)
+    raise ValueError(f"unknown categorization method: {method!r} (have: exact_phrase)")
+
+
+def relation_for(text, method="exact_phrase"):
+    """Convenience: section label → (relation, method, confidence). `relation` is None when no rule fires."""
+    cat, m, conf = categorize(text, method)
+    return (CATEGORY_RELATION.get(cat), m, conf)


### PR DESCRIPTION
Corrects how cross-corpus relations are assigned and adds the machinery to keep
them honest. (Includes the bridge-ensemble commit, stacked from
`claude/mu-bridge-ensemble` — merge that first if you want them separate.)

## 1. Ensemble bridge judge (pluggable)
`bridge_ensemble.py`: score a bridge with several **models** (named scorers) and
combine with a pluggable **judge**. Judge receives `{model_name: score}` (knows
the models, need not use the names); default is a factory closure
`geomean_judge(threshold=0.7)` (caller-chosen); `confirm_judge(name, t)` is a
name-aware alternative. Models: `e5` (frozen cosine), `model:CKPT` (symmetric μ
from a pre-bridge MuAttention, provenance masked), `llm` (stub, budget-gated). A
single-model judge degenerates to `score ≥ threshold`; only ensemble-statistic
judges need ≥2 models.

## 2. `bridge` = same concept only
A `bridge` means the **same concept** across corpora (identity, μ≈0.9) — the
endpoints stay distinct via their node-type/group tokens, so identity doesn't
collapse them. The parsers labelled *every* pt→wiki link `bridge`, but most are
the collection's cross-dataset links to *different* things (`Cybernetics`
collection → `Centrifugal governor` page). A **same-concept gate** (normalised
titles match ⇒ `bridge`) fixes it: bridge **1654 → 122**. This also explained
the ensemble's 66% over-quarantine — a *data* bug, not calibration: the
pre-bridge model's abstention was honest "not the same concept" signal. Post-fix
the ensemble keeps 60/61.

## 3. Non-identity links → the specific relation, via section names
Don't blanket-label the rest `see_also` — use the **most specific** relation the
structure gives. The fix surfaced that the cookie harvester *dropped* section
headers and tagged every page `element_of` from its contentType, so relations
came from a default, not the designed section semantics. Split into two layers:

- **Harvest (raw, `.local`)** — captures sections as a `#SECTION` table + per-pearl
  `section_pos_id`; `rel` is structural-only. No judgement.
- **Categorise (separate, re-runnable)** — `pt_sections.py` maps section label →
  relation (Subcategories→subcategory, Subtopics→element_of, Super
  Categories→super_category, See Also/References→see_also), recording the
  **method** (`exact_phrase`→`fuzzy`→`llm_template`) + **confidence** as
  provenance. `categorize_sections.py` materialises it. Re-categorise cached
  harvests **without re-harvesting**.
- **Consumers** join `pearl → section_pos_id → relation`; `parse_pearltrees.py`
  shares `section_mode`.

Relations are now a proper mix from the subsection names (element_of 1446,
**subcategory 396, super_category 154**, see_also 90, bridge 122, subtopic 82)
instead of one bucket.

## Validation (warm-start fine-tune, GPU, `--use-nodetype`)
| metric | section-driven round |
|---|---|
| graded ELEM fit (r) | +0.995 |
| graded WIKI fit (r) | +0.852 (534 directional targets) |
| SYM held-out | +0.830 (> control +0.726) |
| WIKI order-acc | 99.9% |
| ELEM corr / direction | +0.698 / 100% |
| discrimination | 89% (32/36) |

All operators healthy; the WIKI directional signal grows with the now-separated
subcategory/super_category relations.

## Notes
- No data committed: harvests (`.pt_cache`), fused TSVs, e5 caches, models are
  gitignored/local; the harvester edit stays in `.local`.
- Reports updated: `REPORT_graded_round.md` (§Correction + §Harvest-vs-categorise),
  `REPORT_bridge_ensemble.md` (§Resolution), `REPORT_graded_training.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)