### PR TITLE
mu_cosine: label-data μ→relation estimator (static e5 source + label-anomaly review)

### DIFF
--- a/prototypes/mu_cosine/REPORT_mu_posterior.md
+++ b/prototypes/mu_cosine/REPORT_mu_posterior.md
@@ -1,0 +1,50 @@
+# Label-data μ→relation estimator — static e5 source + label-anomaly review
+
+First increment of the inferred-operator posterior (`DESIGN_inferred_operator_superposition.md`,
+`DESIGN_mu_sources_and_estimation.md`): `mu_posterior.py` estimates `P(μ | relation)` from the **tagged**
+pairs per μ source and Bayes-inverts to `P(relation | μ)`. This runs the **static e5 source now** (no
+training loop) and ships the **label-anomaly review** rule.
+
+## What it does
+- `MuPosterior.fit_source(source, (relation, μ)…)` — smoothed per-relation histogram of μ for a source.
+- `.posterior({source: μ})` — `P(relation | μ's)` as a **weighted product-of-experts** (`weights[source]`),
+  not a naive product (the sources are correlated — see the design doc).
+- `.band/.is_anomalous` — a relation's expected μ band ([q,1−q] quantiles); a TAGGED label whose measured μ
+  is outside it is flagged for review.
+- Pure-Python + numpy (torch-free core; `test_mu_posterior.py` 6/6). The e5 source loads an e5 cache.
+
+## Finding 1 — e5 weakly separates relations (spread 0.040)
+Per-relation e5-μ means on the tagged graded round:
+
+| relation | mean μ_e5 | band[0.05] | n |
+|---|---|---|---|
+| bridge | 0.932 | [0.906, 0.954] | 88 |
+| see_also | 0.853 | [0.787, 0.921] | 90 |
+| super_category | 0.843 | [0.789, 0.899] | 154 |
+| subcategory | 0.842 | [0.786, 0.904] | 396 |
+| subtopic | 0.824 | [0.770, 0.883] | 80 |
+| element_of | 0.818 | [0.763, 0.888] | 1098 |
+| bridge_neg | 0.795 | [0.752, 0.840] | 182 |
+
+e5 cleanly ranks the extremes — `bridge` (identity) top, `bridge_neg` (random) bottom — but the
+membership/associative relations **overlap** (0.82–0.85). This **empirically confirms** the design claim:
+e5 separates *membership vs associative / identity vs random* but **cannot** separate `element_of` from
+`subcategory`. So e5 is a real but **weak** source ⇒ small weight; the *model* μ (dynamic, next increment)
+must carry the finer axis. `P(relation | μ_e5)` is accordingly prior-dominated, shifting toward `bridge` only
+at high μ.
+
+## Finding 2 — label-anomaly review fires correctly (the side-note rule)
+**214 / 2088** tagged labels have a μ_e5 outside their relation's band ⇒ flagged for LLM/human review. They
+are exactly the suspect cross-dataset links: `norbit`, `ladybird-of-szeged`, `fast-and-frugal-trees ∈
+cybernetics`, `BELBIC` — the same set the bridge ensemble surfaced. (e5 is recall-heavy here: it also flags
+legit-but-opaque acronyms, which the *model* source — knowing the graph — would rescue; that's why the rule
+is **review**, not auto-drop.)
+
+## Next increments
+1. **Dynamic model source** — `P(μ_model | relation)` from the model's predictions on tagged pairs,
+   EMA-refreshed (stop-grad).
+2. **Set the weights** from the measured **e5↔model correlation** on the tagged set (the design's
+   non-independence correction) before combining.
+3. **Soft posterior-weighted operator loss** for inferred rows (replacing v1's fixed-breadth switch);
+   A/B against v1 / no-switch with the clean isolated-RNG harness.
+4. Route the 214 anomalies through an LLM/human pass (budget-gated) and re-confidence.

--- a/prototypes/mu_cosine/mu_posterior.py
+++ b/prototypes/mu_cosine/mu_posterior.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Label-data μ→relation distribution estimator — the foundation for inferred-operator assignment
+(DESIGN_inferred_operator_superposition.md) and multi-source combination
+(DESIGN_mu_sources_and_estimation.md).
+
+From the TAGGED pairs (whose relation we know) we estimate, per μ SOURCE (frozen e5, the training model,
+later an LLM), the generative `P(μ | relation)` — one smoothed histogram per relation — and Bayes-invert to
+the posterior `P(relation | μ)`. Two uses:
+  1. **Inferred-operator assignment**: for an untagged pair, measure μ and read the posterior over relations
+     (→ operator), instead of v1's fixed-breadth heuristic.
+  2. **Label-anomaly review** (the side-note rule): a tagged label keeps confidence 1.0 UNLESS its measured μ
+     is OUTSIDE the expected band for that relation — then it is flagged for LLM/human review.
+
+Sources are NOT independent (the model consumes e5) — combine with weighted product-of-experts, not a naive
+product; estimate the e5↔model dependence before trusting a tight combined posterior (see the design doc).
+
+This module is pure-Python + numpy (no torch); the static **e5** source runs now from an e5 cache.
+
+    python3 mu_posterior.py --pairs /tmp/graded_pairs.tsv --e5-cache e5_tables_graded.pt
+"""
+import argparse
+import math
+import os
+from collections import Counter, defaultdict
+
+import numpy as np
+
+
+class MuPosterior:
+    """Per-(source, relation) μ histograms; Bayes posterior P(relation | μ_1..μ_K); per-relation expected band."""
+
+    def __init__(self, nbins=20, lo=0.0, hi=1.0, smoothing=1.0):
+        self.nbins, self.lo, self.hi, self.smoothing = nbins, lo, hi, smoothing
+        self.edges = np.linspace(lo, hi, nbins + 1)
+        self.dens = {}                                    # (source, relation) -> density array (sums to 1)
+        self.raw = defaultdict(list)                      # (source, relation) -> list of μ (for quantile bands)
+        self.prior = {}                                   # relation -> P(relation)
+        self.weights = {}                                 # source -> weight in the product-of-experts
+        self.sources = []
+
+    def _bin(self, mu):
+        return int(np.clip(np.searchsorted(self.edges, mu, side="right") - 1, 0, self.nbins - 1))
+
+    def fit_source(self, source, rel_mu, weight=1.0):
+        """rel_mu: iterable of (relation, μ). Builds a smoothed density per relation for this source."""
+        if source not in self.sources:
+            self.sources.append(source)
+        self.weights[source] = weight
+        by_rel = defaultdict(list)
+        for rel, mu in rel_mu:
+            if mu == mu:                                  # drop NaN
+                by_rel[rel].append(float(mu))
+        for rel, mus in by_rel.items():
+            h = np.histogram(mus, bins=self.edges)[0].astype(float) + self.smoothing
+            self.dens[(source, rel)] = h / h.sum()
+            self.raw[(source, rel)] = sorted(mus)
+        # prior from the (first-source) relation frequencies
+        if not self.prior:
+            tot = sum(len(v) for v in by_rel.values())
+            self.prior = {rel: len(v) / tot for rel, v in by_rel.items()}
+
+    def relations(self):
+        return sorted(self.prior)
+
+    def posterior(self, mu_by_source, candidates=None):
+        """mu_by_source: {source: μ}. Returns {relation: P(relation | μ's)} over `candidates` (default all)."""
+        rels = candidates or self.relations()
+        logp = {}
+        for rel in rels:
+            lp = math.log(self.prior.get(rel, 1e-9))
+            for src, mu in mu_by_source.items():
+                if mu != mu or (src, rel) not in self.dens:
+                    continue
+                lp += self.weights.get(src, 1.0) * math.log(self.dens[(src, rel)][self._bin(mu)] + 1e-12)
+            logp[rel] = lp
+        m = max(logp.values())
+        exp = {r: math.exp(lp - m) for r, lp in logp.items()}
+        z = sum(exp.values()) or 1.0
+        return {r: v / z for r, v in exp.items()}
+
+    def band(self, source, relation, q=0.05):
+        """Expected μ band for a relation under a source = its [q, 1−q] quantiles on the tagged data."""
+        xs = self.raw.get((source, relation))
+        if not xs:
+            return (self.lo, self.hi)
+        return (float(np.quantile(xs, q)), float(np.quantile(xs, 1 - q)))
+
+    def is_anomalous(self, source, relation, mu, q=0.05):
+        """True if a TAGGED pair's measured μ is outside its relation's expected band ⇒ needs review."""
+        if mu != mu:
+            return False
+        lo, hi = self.band(source, relation, q)
+        return not (lo <= mu <= hi)
+
+    def separability(self, source):
+        """How well this source's μ separates the relations: pairwise band overlap summary + the mutual-info-ish
+        spread of per-relation means. Low ⇒ a weak source ⇒ small weight."""
+        means = {rel: float(np.mean(self.raw[(source, rel)])) for rel in self.relations() if self.raw.get((source, rel))}
+        if len(means) < 2:
+            return 0.0, means
+        return float(np.std(list(means.values()))), means
+
+
+# ---------- static e5 source: μ_e5(node, root) = cos(query[root], passage[node]) -------------------------
+def e5_mu_fn(cache_path):
+    import torch
+    d = torch.load(cache_path, weights_only=False)
+    idx = {n: i for i, n in enumerate(d["names"])}
+    q, p = d["query"].numpy(), d["passage"].numpy()       # unit-normed
+
+    def mu(node, root):
+        ni, ri = idx.get(node), idx.get(root)
+        return float("nan") if ni is None or ri is None else float(p[ni] @ q[ri])
+    return mu
+
+
+def load_pairs(path):
+    rows = []
+    with open(path, encoding="utf-8") as f:
+        for ln in f:
+            if ln.startswith("#"):
+                continue
+            c = ln.rstrip("\n").split("\t")               # node root mu op relation ... corpus judge conf
+            if len(c) >= 5:
+                conf = float(c[9]) if len(c) > 9 and c[9] else 1.0
+                rows.append({"node": c[0], "root": c[1], "mu": float(c[2]), "op": c[3], "rel": c[4], "conf": conf})
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pairs", required=True, help="graded _pairs.tsv (uses the TAGGED rows, conf≥1.0)")
+    ap.add_argument("--e5-cache", required=True)
+    ap.add_argument("--nbins", type=int, default=20)
+    ap.add_argument("--q", type=float, default=0.05, help="anomaly band quantile")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    rows = load_pairs(args.pairs)
+    tagged = [r for r in rows if r["conf"] >= 1.0]
+    e5mu = e5_mu_fn(args.e5_cache)
+
+    post = MuPosterior(nbins=args.nbins)
+    post.fit_source("e5", ((r["rel"], e5mu(r["node"], r["root"])) for r in tagged), weight=1.0)
+    spread, means = post.separability("e5")
+    print(f"tagged pairs: {len(tagged)} / {len(rows)} total")
+    print(f"e5 μ per-relation means (separability spread {spread:.3f}):")
+    for rel in sorted(means, key=lambda r: -means[r]):
+        lo, hi = post.band("e5", rel, args.q)
+        print(f"  {rel:14s} mean {means[rel]:.3f}  band[{args.q:.2f}] [{lo:.3f},{hi:.3f}]  n={len(post.raw[('e5',rel)])}")
+
+    print("\nP(relation | μ_e5) at sample μ values:")
+    for mu in (0.78, 0.84, 0.90, 0.96):
+        pst = post.posterior({"e5": mu})
+        top = sorted(pst.items(), key=lambda x: -x[1])[:3]
+        print(f"  μ_e5={mu:.2f} → " + ", ".join(f"{r} {p:.2f}" for r, p in top))
+
+    # the side-note rule: TAGGED labels whose measured μ is out of band ⇒ flag for LLM/human review
+    flagged = [(r, e5mu(r["node"], r["root"])) for r in tagged
+               if post.is_anomalous("e5", r["rel"], e5mu(r["node"], r["root"]), args.q)]
+    print(f"\nLABEL-ANOMALY review (tagged, μ_e5 outside its relation band): {len(flagged)}/{len(tagged)}")
+    for r, mu in sorted(flagged, key=lambda x: x[1])[:15]:
+        print(f"  μ_e5={mu:.3f}  [{r['rel']}]  {r['node']} ∈/~ {r['root']}")
+    if args.out and flagged:
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write("# node\troot\trelation\tmu_e5\treason=out_of_band\n")
+            for r, mu in sorted(flagged, key=lambda x: x[1]):
+                f.write(f"{r['node']}\t{r['root']}\t{r['rel']}\t{mu:.3f}\n")
+        print(f"  wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/test_mu_posterior.py
+++ b/prototypes/mu_cosine/test_mu_posterior.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Tests for MuPosterior (label-data μ→relation estimator). Pure-Python + numpy — genuinely torch-free.
+Run: `python3 test_mu_posterior.py`."""
+import math
+import random
+
+from mu_posterior import MuPosterior
+
+
+def _data(seed=0, n=300):
+    rng = random.Random(seed)
+    a = [("A", rng.uniform(0.85, 0.95)) for _ in range(n)]   # relation A lives high
+    b = [("B", rng.uniform(0.35, 0.45)) for _ in range(n)]   # relation B lives low
+    return a + b
+
+
+def test_posterior_separates_by_mu():
+    post = MuPosterior(nbins=20)
+    post.fit_source("s", _data())
+    assert post.posterior({"s": 0.90})["A"] > 0.9
+    assert post.posterior({"s": 0.40})["B"] > 0.9
+
+
+def test_posterior_normalised():
+    post = MuPosterior(nbins=20)
+    post.fit_source("s", _data())
+    for mu in (0.2, 0.4, 0.6, 0.9):
+        assert abs(sum(post.posterior({"s": mu}).values()) - 1.0) < 1e-6
+
+
+def test_anomaly_band():
+    post = MuPosterior(nbins=20)
+    post.fit_source("s", _data())
+    assert post.is_anomalous("s", "A", 0.40)            # far below A's band ⇒ review
+    assert not post.is_anomalous("s", "A", 0.90)
+    lo, hi = post.band("s", "A", 0.05)
+    assert 0.84 < lo and hi < 0.96
+
+
+def test_nan_falls_back_to_prior():
+    post = MuPosterior(nbins=20)
+    post.fit_source("s", _data())
+    p = post.posterior({"s": float("nan")})             # no evidence ⇒ posterior ≈ prior, still normalised
+    assert abs(sum(p.values()) - 1.0) < 1e-6
+    assert not post.is_anomalous("s", "A", float("nan"))
+
+
+def test_two_sources_product_and_weight():
+    post = MuPosterior(nbins=20)
+    post.fit_source("s1", _data(seed=1), weight=1.0)
+    post.fit_source("s2", _data(seed=2), weight=1.0)
+    assert post.posterior({"s1": 0.90, "s2": 0.90})["A"] > 0.9
+    # a zero-weighted source contributes nothing
+    post.weights["s2"] = 0.0
+    one = post.posterior({"s1": 0.90, "s2": 0.40})       # s2 says B, but weight 0 ⇒ s1 (A) wins
+    assert one["A"] > one["B"]
+
+
+def test_separability_reports_spread():
+    post = MuPosterior(nbins=20)
+    post.fit_source("s", _data())
+    spread, means = post.separability("s")
+    assert means["A"] > means["B"] and spread > 0.1     # well-separated synthetic data
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"  ok  {t.__name__}")
+    print(f"all {len(tests)} mu_posterior tests passed (torch-free)")


### PR DESCRIPTION
First implementation increment of the inferred-operator posterior
(`DESIGN_inferred_operator_superposition.md`, `DESIGN_mu_sources_and_estimation.md`).
`mu_posterior.py` estimates `P(μ | relation)` from the **tagged** pairs per μ
source and Bayes-inverts to `P(relation | μ)` — the foundation both the operator
posterior and the label-anomaly rule are built on. The **static e5 source runs
now** (no training loop), and the core is pure-Python + numpy (torch-free).

## What it does
- `MuPosterior.fit_source(source, (relation, μ)…)` — smoothed per-relation μ
  histogram for a source.
- `.posterior({source: μ})` — `P(relation | μ's)` as a **weighted
  product-of-experts** (`weights[source]`), not a naive product (the sources are
  correlated — see the design doc).
- `.band` / `.is_anomalous` — a relation's expected μ band ([q, 1−q] quantiles);
  a TAGGED label whose measured μ is outside it is flagged for review.
- **Side-note rule implemented:** tagged labels keep confidence 1.0 *unless* their
  measured μ is out-of-band → flagged for LLM/human review.
- `test_mu_posterior.py` — **6/6, genuinely torch-free** (the core has no torch
  dependency).

## Findings on the graded round
**1. e5 weakly separates relations (spread 0.040):**

| relation | mean μ_e5 | n |
|---|---|---|
| bridge | 0.932 | 88 |
| see_also | 0.853 | 90 |
| super_category | 0.843 | 154 |
| subcategory | 0.842 | 396 |
| subtopic | 0.824 | 80 |
| element_of | 0.818 | 1098 |
| bridge_neg | 0.795 | 182 |

e5 cleanly ranks the extremes (`bridge` identity top, `bridge_neg` random bottom)
but the membership/associative relations overlap (0.82–0.85) — **empirically
confirming** that e5 can't separate `element_of` from `subcategory`. So e5 is a
real but **weak** source (→ low weight); the dynamic model μ must carry the finer
axis.

**2. Label-anomaly review fires correctly:** 214/2088 tagged labels have μ_e5
outside their relation's band → flagged. They are exactly the suspect
cross-dataset links (`norbit`, `ladybird-of-szeged`, `BELBIC`,
`fast-and-frugal-trees ∈ cybernetics`) — the same set the bridge ensemble found.
e5 is recall-heavy (also flags legit-but-opaque acronyms), hence **review**, not
auto-drop.

## Next increments (the rest of the E→F path)
1. Dynamic model source — `P(μ_model | relation)`, EMA-refreshed, stop-grad.
2. Source weights from the measured e5↔model correlation (non-independence
   correction).
3. Soft posterior-weighted operator loss for inferred rows, A/B'd vs v1 with the
   clean isolated-RNG harness.
4. Route the 214 anomalies through a budget-gated LLM/human pass.

## Notes
- No data committed; e5 cache / graded pairs are local/gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)