### PR TITLE
mu_cosine: infer-blend — random operator embedding from the joint posterior (§5b applied)

### DIFF
--- a/prototypes/mu_cosine/REPORT_infer_blend.md
+++ b/prototypes/mu_cosine/REPORT_infer_blend.md
@@ -1,0 +1,46 @@
+# Infer-blend — random operator embedding from the joint posterior (the design, applied)
+
+Wiring the fitted joint `P(relation | μ_vec)` into the trainer as a **random operator embedding** for inferred
+rows (`--infer-blend`), per `DESIGN_inferred_operator_superposition.md` §5b. This is the payoff increment:
+the estimator → model-input pipeline running in the training loop.
+
+## What it does (§5b, the #3359-corrected spec)
+- **Enabler:** `MuAttention.forward(op_weights=…)` — a blended operator overriding the op token *and* the
+  readout head (one-hot ≡ indexed, Δ=0; gradients reach `op_emb`/`readout_w`).
+- **Curriculum:** tagged-only until `--blend-warmup`, then the blend turns on (a warm-up gate, not a switch).
+- **Refresh** (every `--blend-refresh`, stop-grad target-network): measure the 6-readout vector with the
+  *current* model, fit `JointPosterior` on tagged rows, predict for inferred → **operator-marginal** `P(op)` +
+  a **relation-level direction-specific** blended target `Σ P(rel)·target_dir(rel)` (so SYM's bridge/see_also/
+  assoc, which share an operator but differ in μ, are not collapsed).
+- **Per step:** `op_weights ~ Dirichlet(α·P(op))` on an **isolated RNG** → blended forward → MSE to the
+  blended target.
+
+## A/B (warm-start `model_nodetype.pt`, graded6, 700 steps, bs 128, seed 1, clean isolated-RNG harness)
+
+| arm | discrimination | SYM held-out | WIKI order-acc | ELEM corr |
+|---|---|---|---|---|
+| no-switch | 89% (32/36) | +0.830 | 99.8% | +0.698 |
+| v1 fixed-breadth switch | 94% (34/36) | +0.838 | 99.8% | +0.702 |
+| **infer-blend (posterior)** | **94% (34/36)** | **+0.839** | **99.9%** | **+0.706** |
+
+## Honest verdict
+The principled posterior-driven blend **matches the v1 heuristic** on the headline metric (94%, +5 over
+no-switch) with only a **marginal** edge on SYM/ELEM. At this scale it does **not** dramatically outperform
+the cheap fixed-breadth switch. What it buys is **not** a big number here but:
+- **Generality** — v1 only switches `element_of→subcategory`; the blend handles *every* inferred relation via
+  `P(relation|μ_vec)`, including the see_also↔membership reconsideration μ enables.
+- **Principle** — the operator is a calibrated random superposition (the joint head beats the corrected PoE,
+  PR #3359), with the noise decomposition's knobs (α, out-of-set) instead of a hand-tuned breadth rule.
+- **Headroom** — only **350** inferred rows here (mostly typo'd `Subtoipcs` fallbacks, which are *really*
+  element_of). The blend should matter more with **more diverse inferred data** (more fused mindmaps, the
+  fuzzy/LLM section categoriser surfacing genuinely-ambiguous relations) — that is where a fixed
+  element→subcategory rule breaks and the posterior earns its keep.
+
+So: the design works end-to-end and is at parity with the heuristic now; its value is the principled,
+general framework that scales with data diversity, not a win at this (small, low-diversity) inferred set.
+
+## Next
+- Grow the inferred set (more mindmaps; fuzzy/LLM section categorisation) and re-measure — the regime where
+  the blend should separate from v1.
+- Tune α / out-of-set noise; try `--blend-hidden` (MLP joint head) vs LR.
+- Deterministic-mean blend at inference (already specified; the eval path uses one-hot operators).

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -328,7 +328,12 @@ class MuAttention(nn.Module):
         nn.init.zeros_(self.account_emb.weight)             # no-op until items carry an account id
 
     def forward(self, content, gen_id, is_anchor, op_pos, op_of, pad,
-                is_prov=None, corpus_of=None, judge_of=None, account_of=None, nodetype_of=None):
+                is_prov=None, corpus_of=None, judge_of=None, account_of=None, nodetype_of=None,
+                op_weights=None):
+        # op_weights [B, n_ops] (optional): a BLENDED operator — a weight vector over operators that replaces
+        # the one-hot op token AND the per-operator readout head (a random superposition for inferred rows;
+        # a one-hot for tagged rows reproduces the indexed path exactly). See
+        # DESIGN_inferred_operator_superposition.md (random operator embedding).
         emb = content.clone()
         gmask = (gen_id >= 0).unsqueeze(-1)
         emb = emb + self.gen_emb(gen_id.clamp(min=0)) * gmask
@@ -336,7 +341,10 @@ class MuAttention(nn.Module):
         if nodetype_of is not None:                          # per-endpoint structural role
             emb = emb + self.nodetype_emb(nodetype_of.clamp(min=0)) * (nodetype_of >= 0).unsqueeze(-1)
         omask = (op_pos >= 0).unsqueeze(-1)
-        emb = emb + self.op_emb(op_pos.clamp(min=0)) * omask
+        if op_weights is None:
+            emb = emb + self.op_emb(op_pos.clamp(min=0)) * omask                     # indexed (one-hot) op token
+        else:
+            emb = emb + (op_weights @ self.op_emb.weight).unsqueeze(1) * omask       # blended op token
         if is_prov is not None:
             emb = emb + self.prov_tag * is_prov.unsqueeze(-1)            # mark the provenance slot
             if corpus_of is not None:                                    # add factored source (if revealed)
@@ -351,8 +359,11 @@ class MuAttention(nn.Module):
         # set, giving a relation-conditioned summary. Cleaner than mean-pool, which dilutes the input
         # signal with the large learned op-embedding and collapses each operator's readout to a constant.
         pooled = h[:, 0, :]
-        w = self.readout_w[op_of]
-        logit = (pooled * w).sum(-1) + self.readout_b[op_of]
+        if op_weights is None:
+            w, b = self.readout_w[op_of], self.readout_b[op_of]                      # per-operator head
+        else:
+            w, b = op_weights @ self.readout_w, op_weights @ self.readout_b          # blended head
+        logit = (pooled * w).sum(-1) + b
         return torch.sigmoid(logit)
 
 

--- a/prototypes/mu_cosine/test_op_weights.py
+++ b/prototypes/mu_cosine/test_op_weights.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Tests for the BLENDED operator (`op_weights`) path in MuAttention.forward — the enabler for the random
+operator embedding. A one-hot op_weights must reproduce the indexed path exactly; a blend must differ;
+gradients must reach op_emb AND readout_w through op_weights. Needs torch.
+Run: `python3 test_op_weights.py`."""
+import torch
+
+from mu_attention import MuAttention, Tokenizer, OPS, load_dag, all_names
+
+
+def _setup():
+    parents, children, deg = load_dag()
+    names = all_names(parents, children)
+    idx = {n: i for i, n in enumerate(names)}
+    d = 384
+    torch.manual_seed(0)
+    q = torch.randn(len(names), d); q /= q.norm(dim=1, keepdim=True)
+    p = torch.randn(len(names), d); p /= p.norm(dim=1, keepdim=True)
+    tok = Tokenizer(q, p, idx, parents, deg)
+    m = MuAttention(d_model=d, n_layers=2)
+    return tok, m, names
+
+
+def test_one_hot_equals_indexed():
+    tok, m, names = _setup(); m.eval()
+    a, b = names[100], names[200]
+    batch = tok.build([(a, b, OPS["WIKI"]), (a, b, OPS["ELEM"]), (a, b, OPS["SYM"])], train=False)
+    n_ops = m.op_emb.weight.shape[0]
+    ow = torch.zeros(3, n_ops)
+    for k, op in enumerate(("WIKI", "ELEM", "SYM")):
+        ow[k, OPS[op]] = 1.0
+    with torch.no_grad():
+        assert torch.allclose(m(**batch), m(**batch, op_weights=ow), atol=1e-6)
+
+
+def test_blend_differs_from_endpoints():
+    tok, m, names = _setup(); m.eval()
+    a, b = names[100], names[200]
+    batch = tok.build([(a, b, OPS["WIKI"])], train=False)
+    n_ops = m.op_emb.weight.shape[0]
+    ow = torch.zeros(1, n_ops); ow[0, OPS["WIKI"]] = 0.5; ow[0, OPS["ELEM"]] = 0.5
+    with torch.no_grad():
+        wiki = float(m(**batch)[0])
+        blend = float(m(**batch, op_weights=ow)[0])
+    assert abs(blend - wiki) > 1e-4
+
+
+def test_gradients_flow_through_op_weights():
+    tok, m, names = _setup()
+    a, b = names[100], names[200]
+    batch = tok.build([(a, b, OPS["WIKI"])], train=True)
+    n_ops = m.op_emb.weight.shape[0]
+    ow = torch.full((1, n_ops), 1.0 / n_ops)               # uniform blend (detached, like a sampled weight)
+    m.zero_grad()
+    m(**batch, op_weights=ow).sum().backward()
+    # the blend touches every operator's embedding AND readout head ⇒ both get gradient
+    assert m.op_emb.weight.grad is not None and m.op_emb.weight.grad.abs().sum() > 0
+    assert m.readout_w.grad is not None and m.readout_w.grad.abs().sum() > 0
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"  ok  {t.__name__}")
+    print(f"all {len(tests)} op_weights tests passed")

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -39,6 +39,16 @@ def nt(s):
     return _NT.get(s, 0)
 
 
+# relation → (operator, forward target, reverse target) for the INFER-BLEND path (§5b: blend the operator
+# embedding at OPERATOR level, but keep the μ target at RELATION level — SYM's relations have different μ).
+REL_SPEC = {
+    "element_of":     ("ELEM", 0.90, 0.10), "subcategory": ("WIKI", 0.90, 0.10),
+    "subtopic":       ("WIKI", 0.85, 0.12), "super_category": ("WIKI", 0.85, 0.12),
+    "see_also":       ("SYM",  0.40, 0.40), "assoc": ("SYM", 0.30, 0.30),
+    "bridge":         ("SYM",  0.90, 0.90), "bridge_neg": ("SYM", 0.10, 0.10),
+}
+
+
 def switched_op(op, rel, conf, breadth, base, scale, rng):
     """For an INFERRED `element_of` (conf<1.0), stochastically return WIKI (subcategory) instead of ELEM, with
     p = base · min(1, breadth/scale) · (1−conf). Pure + module-level so it is unit-testable and so its RNG is
@@ -330,6 +340,43 @@ def train(args):
         b = tok.build(items, **kw)
         return {k: (v.to(device) if torch.is_tensor(v) else v) for k, v in b.items()}
 
+    # ---- INFER-BLEND (§5b): random operator embedding from the fitted joint P(relation|μ_vec) ----
+    import numpy as _np
+    from mu_posterior import JointPosterior, sample_operator_weights
+    blend_rng = random.Random(args.seed + 9973)            # ISOLATED rng for inferred-row sampling
+    blend_nprng = _np.random.default_rng(args.seed + 9973)  # ISOLATED rng for the Dirichlet draws
+    graded_inf = [r for r in graded_tr if len(r) > 9 and r[9] < 1.0]   # inferred rows (conf<1) for the blend
+    graded_tag = [r for r in graded_tr if not (len(r) > 9 and r[9] < 1.0)]
+    relset = sorted(set(r[4] for r in graded_tag))
+    blend_state = {"pop": None, "tgt": None}               # per-inferred-row P(op) [N,n_ops] + blended target
+
+    @torch.no_grad()
+    def measure_readouts(pairs):                           # [N,6]: e5, sym, wiki_fwd/rev, elem_fwd/rev (current model)
+        model.eval()
+        def mb(items):
+            return mu_batch(model, tok, items).numpy()
+        e5 = _np.array([float(tok.p[idx[a]] @ tok.q[idx[b]]) if a in idx and b in idx else _np.nan for a, b in pairs])
+        cols = [e5, mb([(a, b, OPS["SYM"]) for a, b in pairs]),
+                mb([(a, b, OPS["WIKI"]) for a, b in pairs]), mb([(b, a, OPS["WIKI"]) for a, b in pairs]),
+                mb([(a, b, OPS["ELEM"]) for a, b in pairs]), mb([(b, a, OPS["ELEM"]) for a, b in pairs])]
+        model.train()
+        return _np.stack(cols, 1)
+
+    def refresh_blend():                                   # fit the joint head on tagged, predict P(op)+target for inferred
+        tag = graded_tag if len(graded_tag) <= 1500 else [graded_tag[i] for i in
+              random.Random(0).sample(range(len(graded_tag)), 1500)]
+        Xt = measure_readouts([(r[0], r[1]) for r in tag])
+        jp = JointPosterior(relset, n_features=6, hidden=args.blend_hidden).fit(Xt, [r[4] for r in tag])
+        Pr = jp.proba(measure_readouts([(r[0], r[1]) for r in graded_inf]))      # [N, n_rel]
+        pop = _np.zeros((len(graded_inf), len(OPS)))
+        tgt = _np.zeros(len(graded_inf))
+        for j, rel in enumerate(relset):
+            op_i = OPS[REL_SPEC[rel][0]]
+            for i, r in enumerate(graded_inf):
+                pop[i, op_i] += Pr[i, j]
+                tgt[i] += Pr[i, j] * REL_SPEC[rel][1 if r[2] >= 0.5 else 2]      # relation-level dir-specific target
+        blend_state["pop"], blend_state["tgt"] = pop, tgt
+
     new_corpus = CORPORA.get(args.pairs_corpus, SW)        # corpus tag for the --pairs (new) data
     def draw_sym(pool, replay, k):
         """Draw k SYM examples as (item, corpus_id): replay-frac OLD (replay, corpus=simplewiki) mixed with
@@ -397,8 +444,9 @@ def train(args):
         # bridges (μ≈0.9 "same concept", the bulk) are DOWN-WEIGHTED so they don't swamp the directional
         # WIKI/ELEM signal. Endpoints carry corpus/judge (maskable) + node-type tags (when --use-nodetype).
         L_graded = torch.zeros(())
-        if graded_tr and not args.sym_only:
-            gb = [graded_tr[rng.randrange(len(graded_tr))] for _ in range(args.bs)]
+        graded_pool = graded_tag if args.infer_blend else graded_tr   # blend handles inferred separately
+        if graded_pool and not args.sym_only:
+            gb = [graded_pool[rng.randrange(len(graded_pool))] for _ in range(args.bs)]
             if args.use_nodetype:
                 gi = [(r[0], r[1], OPS[graded_op(r)], CORPORA[r[7]], JUDGES[r[8]], nt(r[5]), nt(r[6])) for r in gb]
             else:
@@ -407,9 +455,27 @@ def train(args):
             gw = torch.tensor([args.bridge_weight if r[4] == "bridge" else 1.0 for r in gb]).to(device)
             mu_g = model(**bld(gi, train=True, rng=rng, p_mask_prov=args.prov_mask))
             L_graded = (gw * (mu_g - gt) ** 2).sum() / gw.sum().clamp_min(1.0)
+        # INFER-BLEND: inferred rows trained with a RANDOM operator embedding from the fitted joint posterior
+        L_blend = torch.zeros(())
+        blend_on = args.infer_blend and graded_inf and step >= args.blend_warmup and not args.sym_only
+        if blend_on:
+            if (step - args.blend_warmup) % args.blend_refresh == 0:        # refresh the posterior (stop-grad)
+                refresh_blend()
+            bi = [blend_rng.randrange(len(graded_inf)) for _ in range(args.bs)]
+            br = [graded_inf[i] for i in bi]
+            ow = _np.stack([sample_operator_weights(blend_state["pop"][i], args.blend_alpha, blend_nprng) for i in bi])
+            op_w = torch.tensor(ow, dtype=torch.float32).to(device)
+            bt = torch.tensor([blend_state["tgt"][i] for i in bi], dtype=torch.float32).to(device)
+            if args.use_nodetype:                                          # op=SYM is just the position marker;
+                items = [(r[0], r[1], OPS["SYM"], new_corpus, HAIKU, nt(r[5]), nt(r[6])) for r in br]
+            else:                                                          # op_weights overrides token + readout
+                items = [(r[0], r[1], OPS["SYM"], new_corpus, HAIKU) for r in br]
+            mu_b = model(**bld(items, train=True, rng=rng, p_mask_prov=args.prov_mask), op_weights=op_w)
+            L_blend = F.mse_loss(mu_b, bt)
         loss = (args.sym_weight * L_sym + (0.0 if args.sym_only else args.wiki_weight * L_wiki)
                 + (args.elem_weight * L_elem if (elem_tr and not args.sym_only) else 0.0)
-                + (args.graded_weight * L_graded if (graded_tr and not args.sym_only) else 0.0))
+                + (args.graded_weight * L_graded if (graded_tr and not args.sym_only) else 0.0)
+                + (args.blend_weight * L_blend if blend_on else 0.0))
         # LLM (optional, already-bought) — skipped in single-task SYM mode
         L_llm = torch.zeros(())
         if llm and not args.sym_only:
@@ -425,6 +491,7 @@ def train(args):
             print(f"  step {step+1:5d}  L_sym {float(L_sym):.4f}  L_wiki {float(L_wiki):.4f}"
                   + (f"  L_elem {float(L_elem):.4f}" if (elem_tr and not args.sym_only) else "")
                   + (f"  L_graded {float(L_graded):.4f}" if (graded_tr and not args.sym_only) else "")
+                  + (f"  L_blend {float(L_blend):.4f}" if blend_on else "")
                   + (f"  L_llm {float(L_llm):.4f}" if (llm and not args.sym_only) else ""))
 
     model.eval()
@@ -711,6 +778,13 @@ def main():
                     "(operator noise + element/subcategory ambiguity for untagged relations)")
     ap.add_argument("--infer-subcat", type=float, default=0.4, help="base switch prob (× container breadth)")
     ap.add_argument("--breadth-scale", type=float, default=20.0, help="member count at which breadth→1.0")
+    ap.add_argument("--infer-blend", action="store_true", help="§5b: train INFERRED graded rows with a RANDOM "
+                    "operator embedding drawn from the fitted joint P(relation|μ_vec) (supersedes --infer-switch)")
+    ap.add_argument("--blend-warmup", type=int, default=200, help="steps tagged-only before the blend starts")
+    ap.add_argument("--blend-refresh", type=int, default=100, help="re-measure readouts + re-fit joint head every N steps")
+    ap.add_argument("--blend-alpha", type=float, default=20.0, help="Dirichlet concentration (low=more op noise)")
+    ap.add_argument("--blend-hidden", type=int, default=0, help="joint head hidden units (0=logistic regression)")
+    ap.add_argument("--blend-weight", type=float, default=1.0, help="infer-blend loss weight")
     ap.add_argument("--sym-weight", type=float, default=1.0, help="SYM loss weight (ablation lever b)")
     ap.add_argument("--sym-only", action="store_true", help="single-task SYM head (ablation lever c)")
     ap.add_argument("--quick-val", action="store_true", help="skip dense-map emission/lin-agreement")


### PR DESCRIPTION
Applies the inferred-operator design: train INFERRED graded rows with a RANDOM
operator embedding drawn from the fitted joint `P(relation|μ_vec)`.

## Commits
1. **Blended-operator forward** (`op_weights`): a weight vector over operators
   overriding the op token AND the readout head. One-hot ≡ indexed (Δ=0);
   gradients reach op_emb/readout_w. `test_op_weights.py` 3/3.
2. **Trainer integration** (`--infer-blend`), the #3359-corrected §5b spec:
   curriculum warm-up (tagged-only first); periodic stop-grad refresh (measure
   the 6-readout vector with the current model → fit JointPosterior on tagged →
   operator-marginal P(op) + relation-level direction-specific blended target, so
   SYM's relations aren't collapsed); per-step `op_weights ~ Dirichlet(α·P(op))`
   on an isolated RNG → blended forward → MSE.
3. **A/B report.**

## A/B (warm-start, 700 steps, clean isolated-RNG harness)
no-switch 89% → v1 94% → infer-blend 94% (SYM +0.839, ELEM +0.706). The blend
**matches** v1 at this scale (350 inferred rows, low diversity); its value is
generality + principle + headroom with more diverse inferred data. Honest verdict
in `REPORT_infer_blend.md`.

## Notes
- No data/models committed. Eval path uses one-hot operators (deterministic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)