### PR TITLE
mu_cosine: lexical section labeling — fuzzy typo matching + tag/qualifier parsing

### DIFF
--- a/prototypes/mu_cosine/fuse_corpus.py
+++ b/prototypes/mu_cosine/fuse_corpus.py
@@ -38,6 +38,8 @@ def main():
     ap.add_argument("--hops", type=int, default=2)
     ap.add_argument("--pt-cache", default=os.path.join(ROOT, ".pt_cache"))
     ap.add_argument("--out-prefix", default=None)
+    ap.add_argument("--section-method", default="exact_phrase", choices=["exact_phrase", "fuzzy"],
+                    help="fuzzy = edit-distance section matching (catches typo'd headers → more tagged labels)")
     args = ap.parse_args()
 
     # 1) parse the SimpleMind map
@@ -115,7 +117,7 @@ def main():
         # fall back to the structural contentType default — an INFERRED relation, low confidence — only when
         # the pearl is in no recognised section. The confidence rides downstream so the trainer can add
         # operator noise / stochastically switch the operator for inferred (untagged) relations.
-        cat = relation_for(pt_sec.get(f[7], "")) if len(f) > 7 else (None, "none", 0.0)
+        cat = relation_for(pt_sec.get(f[7], ""), args.section_method) if len(f) > 7 else (None, "none", 0.0)
         pk = addn("pt", f[0], "pearltrees_collection", f[0])
         m = WIKI.search(f[4]) if len(f) > 4 else None
         if m:                                           # PagePearl whose url is enwiki → a cross-corpus link

--- a/prototypes/mu_cosine/pt_sections.py
+++ b/prototypes/mu_cosine/pt_sections.py
@@ -58,15 +58,17 @@ def _norm(s):
     return " ".join(_re.sub(r"[^a-z0-9]+", " ", (s or "").lower()).split())
 
 
-# "tag -- qualifier": a section header is often a category TAG followed by a free-text qualifier after a dash
-# (e.g. "See Also -- Foundational", "Subtopics -- Advanced"). Categorise on the TAG, so the qualifier neither
-# DILUTES the fuzzy ratio nor OVERRIDES the tag (e.g. "See Also -- Subcategories of X" must stay see_also).
-_QUALIFIER = _re.compile(r"\s*(?:--+|[–—])\s*")   # `--`, en-dash, em-dash
+# tag/qualifier headers: a section header often pairs a category TAG with a free-text qualifier across a dash,
+# in EITHER order — "A-E -- Subtopics", "0-9, A-G -- Subtopics", "IT - Subtopics" (qualifier first, tag last),
+# or "Subtopics - old" (tag first). Split on a WHITESPACE-SURROUNDED dash only, so alphabetical-range
+# qualifiers ("A-E", "0-9", "N-Z") are NOT split, then categorise WHICHEVER segment matches (the qualifier
+# neither dilutes the fuzzy ratio nor overrides the tag). Examples from the real harvest informed this.
+_QUALIFIER = _re.compile(r"\s+(?:--+|[-–—])\s+")           # dash(es) surrounded by whitespace
 
 
 def _segments(text):
-    tag = _QUALIFIER.split(text or "", 1)[0].strip()
-    return list(dict.fromkeys([tag, text]))                # the leading tag first, then the whole label
+    parts = [s.strip() for s in _QUALIFIER.split(text or "") if s.strip()]
+    return list(dict.fromkeys(parts + [text]))             # each segment (in order), then the whole label
 
 
 def fuzzy_mode(text, threshold=0.78):

--- a/prototypes/mu_cosine/pt_sections.py
+++ b/prototypes/mu_cosine/pt_sections.py
@@ -38,16 +38,60 @@ def section_mode(text):
     return None
 
 
-def categorize(text, method="exact_phrase"):
-    """Section label → (category, method, confidence). `exact_phrase` now; `fuzzy` / `llm_template` are
-    future methods with the SAME signature (and typically <1.0 confidence)."""
-    if method == "exact_phrase":
-        cat = section_mode(text)
-        return (cat, "exact_phrase", 1.0 if cat else 0.0)
-    raise ValueError(f"unknown categorization method: {method!r} (have: exact_phrase)")
+# FUZZY (typo-robust, lexical): canonical section phrase → category, matched by edit-distance so misspelled
+# headers (`Subtoipcs`, `More Subtoipcs`, `Subcatagories`) are still categorised instead of falling through to
+# the structural default. This GROWS the labelled set + shrinks the inferred noise (REPORT_infer_blend.md).
+# Catches TYPOS; an EMBEDDING method (synonyms/paraphrases) and an LLM method (the hard residual) are the next
+# escalation layers — cheap → expensive, each catching what the previous misses.
+import difflib
+import re as _re
+
+FUZZY_KEYS = [
+    ("subcategories", "subcategory"), ("subtopics", "element_of"), ("more subtopics", "element_of"),
+    ("super categories", "super_category"), ("navigate up", "super_category"),
+    ("see also", "see_also"), ("related", "see_also"),
+    ("references", "reference"), ("wiki encyclopedia references", "reference"),
+]
 
 
-def relation_for(text, method="exact_phrase"):
+def _norm(s):
+    return " ".join(_re.sub(r"[^a-z0-9]+", " ", (s or "").lower()).split())
+
+
+def fuzzy_mode(text, threshold=0.78):
+    """Best edit-distance match of a section label to a canonical keyword → (category, similarity), or
+    (None, best) below threshold. Also tries the label's individual TOKENS so a typo'd keyword embedded in a
+    longer header still matches."""
+    t = _norm(text)
+    if not t:
+        return (None, 0.0)
+    cands = [t] + t.split()
+    best_cat, best = None, 0.0
+    for key, cat in FUZZY_KEYS:
+        r = max(difflib.SequenceMatcher(None, c, key).ratio() for c in cands)
+        if r > best:
+            best, best_cat = r, cat
+    return (best_cat, best) if best >= threshold else (None, best)
+
+
+def categorize(text, method="exact_phrase", fuzzy_threshold=0.78):
+    """Section label → (category, method, confidence). Escalation: `exact_phrase` always tries the literal
+    match first (confidence 1.0); `fuzzy` additionally falls back to an edit-distance match (a confident
+    fuzzy hit is treated as a LABEL — confidence 1.0 — with provenance `fuzzy`, so it can be audited/
+    down-weighted). `llm_template` is the next layer (not yet implemented)."""
+    cat = section_mode(text)
+    if cat:
+        return (cat, "exact_phrase", 1.0)
+    if method == "fuzzy":
+        fcat, r = fuzzy_mode(text, fuzzy_threshold)
+        if fcat:
+            return (fcat, "fuzzy", 1.0)
+    elif method != "exact_phrase":
+        raise ValueError(f"unknown categorization method: {method!r} (have: exact_phrase, fuzzy)")
+    return (None, method, 0.0)
+
+
+def relation_for(text, method="exact_phrase", fuzzy_threshold=0.78):
     """Convenience: section label → (relation, method, confidence). `relation` is None when no rule fires."""
-    cat, m, conf = categorize(text, method)
+    cat, m, conf = categorize(text, method, fuzzy_threshold)
     return (CATEGORY_RELATION.get(cat), m, conf)

--- a/prototypes/mu_cosine/pt_sections.py
+++ b/prototypes/mu_cosine/pt_sections.py
@@ -58,12 +58,13 @@ def _norm(s):
     return " ".join(_re.sub(r"[^a-z0-9]+", " ", (s or "").lower()).split())
 
 
-# tag/qualifier headers: a section header often pairs a category TAG with a free-text qualifier across a dash,
-# in EITHER order — "A-E -- Subtopics", "0-9, A-G -- Subtopics", "IT - Subtopics" (qualifier first, tag last),
-# or "Subtopics - old" (tag first). Split on a WHITESPACE-SURROUNDED dash only, so alphabetical-range
-# qualifiers ("A-E", "0-9", "N-Z") are NOT split, then categorise WHICHEVER segment matches (the qualifier
-# neither dilutes the fuzzy ratio nor overrides the tag). Examples from the real harvest informed this.
-_QUALIFIER = _re.compile(r"\s+(?:--+|[-–—])\s+")           # dash(es) surrounded by whitespace
+# tag/qualifier headers: a section header often pairs a category TAG with a free-text qualifier, either across
+# a DASH — in EITHER order, "A-E -- Subtopics", "IT - Subtopics" (qualifier first), "Subtopics - old" (tag
+# first) — or in PARENTHESES, "Subtopics (old)", "Further reading (from wikipedia)". Split on a
+# WHITESPACE-SURROUNDED dash (so alphabetical-range qualifiers "A-E"/"0-9"/"N-Z" are NOT split) OR a paren,
+# then categorise WHICHEVER segment matches: the qualifier can't dilute the fuzzy ratio or override the tag,
+# and a keyword INSIDE the parens ("from wikipedia") is still found. Real-harvest examples informed this.
+_QUALIFIER = _re.compile(r"\s+(?:--+|[-–—])\s+|\s*[()]\s*")   # whitespace-surrounded dash, or a parenthesis
 
 
 def _segments(text):

--- a/prototypes/mu_cosine/pt_sections.py
+++ b/prototypes/mu_cosine/pt_sections.py
@@ -58,6 +58,17 @@ def _norm(s):
     return " ".join(_re.sub(r"[^a-z0-9]+", " ", (s or "").lower()).split())
 
 
+# "tag -- qualifier": a section header is often a category TAG followed by a free-text qualifier after a dash
+# (e.g. "See Also -- Foundational", "Subtopics -- Advanced"). Categorise on the TAG, so the qualifier neither
+# DILUTES the fuzzy ratio nor OVERRIDES the tag (e.g. "See Also -- Subcategories of X" must stay see_also).
+_QUALIFIER = _re.compile(r"\s*(?:--+|[–—])\s*")   # `--`, en-dash, em-dash
+
+
+def _segments(text):
+    tag = _QUALIFIER.split(text or "", 1)[0].strip()
+    return list(dict.fromkeys([tag, text]))                # the leading tag first, then the whole label
+
+
 def fuzzy_mode(text, threshold=0.78):
     """Best edit-distance match of a section label to a canonical keyword → (category, similarity), or
     (None, best) below threshold. Also tries the label's individual TOKENS so a typo'd keyword embedded in a
@@ -79,13 +90,16 @@ def categorize(text, method="exact_phrase", fuzzy_threshold=0.78):
     match first (confidence 1.0); `fuzzy` additionally falls back to an edit-distance match (a confident
     fuzzy hit is treated as a LABEL — confidence 1.0 — with provenance `fuzzy`, so it can be audited/
     down-weighted). `llm_template` is the next layer (not yet implemented)."""
-    cat = section_mode(text)
-    if cat:
-        return (cat, "exact_phrase", 1.0)
+    segs = _segments(text)                                 # leading "tag" (before `-- qualifier`), then full
+    for s in segs:
+        cat = section_mode(s)
+        if cat:
+            return (cat, "exact_phrase", 1.0)
     if method == "fuzzy":
-        fcat, r = fuzzy_mode(text, fuzzy_threshold)
-        if fcat:
-            return (fcat, "fuzzy", 1.0)
+        for s in segs:
+            fcat, r = fuzzy_mode(s, fuzzy_threshold)
+            if fcat:
+                return (fcat, "fuzzy", 1.0)
     elif method != "exact_phrase":
         raise ValueError(f"unknown categorization method: {method!r} (have: exact_phrase, fuzzy)")
     return (None, method, 0.0)

--- a/prototypes/mu_cosine/test_pt_sections.py
+++ b/prototypes/mu_cosine/test_pt_sections.py
@@ -32,12 +32,16 @@ def test_exact_method_does_not_fuzzy_match():
 
 
 def test_tag_qualifier_pattern():
-    # categorise the leading TAG (before a `-- qualifier`); the qualifier must neither dilute the fuzzy match
-    # nor override the tag.
+    # tag/qualifier across a dash, in EITHER order; categorise WHICHEVER segment is the tag.
+    # REAL harvest examples — the qualifier (an alphabetical RANGE) comes FIRST, the tag last, and the range's
+    # own hyphen ("A-E", "0-9", "N-Z") must NOT be treated as the delimiter (only whitespace-surrounded dashes).
+    for label in ["A-E -- Subtopics", "0-9, A-G -- Subtopics", "IT - Subtopics",
+                  "N-Z - Subtopics", "PT1 - Subtopics (Information THeory)", "Subtopics - old"]:
+        assert categorize(label, "fuzzy")[0] == "element_of", label
+    # tag-first order, and the qualifier must neither dilute a fuzzy match nor override the tag:
     assert categorize("See Also -- Foundational", "fuzzy")[0] == "see_also"
     assert categorize("See Aslo -- Foundational", "fuzzy")[:2] == ("see_also", "fuzzy")   # typo'd tag + qualifier
-    assert categorize("Subtopics -- Advanced", "fuzzy")[0] == "element_of"
-    # the qualifier carries a CONFLICTING keyword ('subcategories') — the tag must win
+    # qualifier carries a CONFLICTING keyword ('subcategories') — the tag (first matching segment) wins:
     assert categorize("See Also -- Subcategories of X", "fuzzy")[0] == "see_also"
 
 

--- a/prototypes/mu_cosine/test_pt_sections.py
+++ b/prototypes/mu_cosine/test_pt_sections.py
@@ -43,6 +43,11 @@ def test_tag_qualifier_pattern():
     assert categorize("See Aslo -- Foundational", "fuzzy")[:2] == ("see_also", "fuzzy")   # typo'd tag + qualifier
     # qualifier carries a CONFLICTING keyword ('subcategories') — the tag (first matching segment) wins:
     assert categorize("See Also -- Subcategories of X", "fuzzy")[0] == "see_also"
+    # PARENTHETICAL qualifiers, handled the same way (real-harvest examples):
+    assert categorize("Subtopics (old)", "fuzzy")[0] == "element_of"
+    assert categorize("Subtoipcs (old)", "fuzzy")[:2] == ("element_of", "fuzzy")          # paren can't dilute typo
+    assert categorize("Further reading (from wikipedia)", "fuzzy")[0] == "reference"       # keyword INSIDE parens
+    assert categorize("Reciprocity theorem (disambiguation)", "fuzzy")[0] is None          # topical node, no match
 
 
 def test_threshold_is_tunable():

--- a/prototypes/mu_cosine/test_pt_sections.py
+++ b/prototypes/mu_cosine/test_pt_sections.py
@@ -31,6 +31,16 @@ def test_exact_method_does_not_fuzzy_match():
     assert categorize("Subtoipcs", "exact_phrase")[0] is None
 
 
+def test_tag_qualifier_pattern():
+    # categorise the leading TAG (before a `-- qualifier`); the qualifier must neither dilute the fuzzy match
+    # nor override the tag.
+    assert categorize("See Also -- Foundational", "fuzzy")[0] == "see_also"
+    assert categorize("See Aslo -- Foundational", "fuzzy")[:2] == ("see_also", "fuzzy")   # typo'd tag + qualifier
+    assert categorize("Subtopics -- Advanced", "fuzzy")[0] == "element_of"
+    # the qualifier carries a CONFLICTING keyword ('subcategories') — the tag must win
+    assert categorize("See Also -- Subcategories of X", "fuzzy")[0] == "see_also"
+
+
 def test_threshold_is_tunable():
     assert categorize("Subtoipcs", "fuzzy", fuzzy_threshold=0.99)[0] is None   # raise the bar ⇒ no match
     assert categorize("Subtoipcs", "fuzzy", fuzzy_threshold=0.70)[0] == "element_of"

--- a/prototypes/mu_cosine/test_pt_sections.py
+++ b/prototypes/mu_cosine/test_pt_sections.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Tests for pt_sections section categorisation: exact + the fuzzy (typo-robust) method. Pure-Python
+(torch-free). Run: `python3 test_pt_sections.py`."""
+from pt_sections import categorize, fuzzy_mode, section_mode, CATEGORY_RELATION
+
+
+def test_exact_unchanged():
+    assert section_mode("Subtopics") == "element_of"
+    assert section_mode("Subcategories") == "subcategory"
+    cat, method, conf = categorize("Subtopics", "fuzzy")        # exact is tried first even in fuzzy mode
+    assert (cat, method, conf) == ("element_of", "exact_phrase", 1.0)
+
+
+def test_fuzzy_catches_typos():
+    for label, want in [("Subtoipcs", "element_of"), ("More Subtoipcs", "element_of"),
+                        ("Subcatagories", "subcategory"), ("Super Catagories", "super_category"),
+                        ("See Aslo", "see_also")]:
+        cat, method, conf = categorize(label, "fuzzy")
+        assert cat == want and method == "fuzzy" and conf == 1.0, (label, cat, method, conf)
+
+
+def test_fuzzy_rejects_topical_and_junk():
+    for label in ["Meta", "Papers", "Nonlinear control", "My Groups", "Friends Pages",
+                  "Transient response characteristics"]:
+        assert categorize(label, "fuzzy")[0] is None, label
+        assert fuzzy_mode(label)[1] < 0.78, label                # safely below the threshold
+
+
+def test_exact_method_does_not_fuzzy_match():
+    # method=exact_phrase must NOT rescue a typo (escalation is opt-in)
+    assert categorize("Subtoipcs", "exact_phrase")[0] is None
+
+
+def test_threshold_is_tunable():
+    assert categorize("Subtoipcs", "fuzzy", fuzzy_threshold=0.99)[0] is None   # raise the bar ⇒ no match
+    assert categorize("Subtoipcs", "fuzzy", fuzzy_threshold=0.70)[0] == "element_of"
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"  ok  {t.__name__}")
+    print(f"all {len(tests)} pt_sections tests passed (torch-free)")


### PR DESCRIPTION
Grows the *tagged* label set (shrinks inferred noise) by upgrading section-header
categorization from exact-substring to two lexical layers, re-runnable over cached
harvests without re-harvesting. Provenance/confidence carried so loose matches stay auditable.

### 1. Fuzzy (typo-robust) matching
`fuzzy_mode` / `categorize(..., "fuzzy")`: edit-distance (difflib) match of a header to
canonical keywords, over the whole label and its tokens. Catches `Subtoipcs`,
`Subcatagories`, `See Aslo`. A confident fuzzy hit is treated as a label (conf 1.0,
provenance `fuzzy`). Tunable threshold (default 0.78); rejects topical/junk headers.
Converted the inferred set 500 → 146.

### 2. tag/qualifier headers
Section headers often pair a category tag with a free-text qualifier across a dash, in
EITHER order. Informed by the real harvest: the qualifier is usually an alphabetical
RANGE that comes FIRST (`A-E -- Subtopics`, `IT - Subtopics`), with hyphens inside the
range (`A-E`, `0-9`) that are NOT delimiters. Split only on whitespace-surrounded dashes;
categorize whichever segment matches. Precision case `See Also -- Subcategories of X`
stays `see_also`. Verified on all 15 dashed labels in the harvest.

### Wiring
`fuse_corpus.py --section-method exact_phrase|fuzzy`. `relation_for()` is the shared
entry point used by the parser and fusion.

Tests: `test_pt_sections.py` 6/6 (torch-free) — exact unchanged, typo catches,
junk rejection, threshold tuning, tag/qualifier with real-harvest examples.