### PR TITLE
mu_cosine: parent-signal guard — "Broad Categories"/"Super Topics" → super_category

### DIFF
--- a/prototypes/mu_cosine/pt_sections.py
+++ b/prototypes/mu_cosine/pt_sections.py
@@ -29,8 +29,9 @@ def section_mode(text):
         return "subcategory"                          # narrower category
     if "subtopic" in t:
         return "element_of"                           # element / membership
-    if ("super" in t and "categor" in t) or "navigate up" in t:
-        return "super_category"                       # broader / parent
+    if ((("super" in t or "broad" in t or "parent" in t) and ("categor" in t or "topic" in t))
+            or "navigate up" in t):
+        return "super_category"                       # broader / parent ("Broad Categories", "Super Topics")
     if "see also" in t or "via link" in t or "related" in t:
         return "see_also"                             # associative
     if "wiki" in t or "encyclopedia" in t or "reference" in t:
@@ -58,6 +59,15 @@ def _norm(s):
     return " ".join(_re.sub(r"[^a-z0-9]+", " ", (s or "").lower()).split())
 
 
+# parent-signal guard: a "Broad Categories" / "Super Topics" header is a BROADER (parent) grouping, but a bare
+# content token ("categories", "topics") is lexically closer to the SUB* keys ("subcategories", "subtopics")
+# than to "super categories" — so unguarded fuzzy flips the DIRECTION (super→sub). When a parent signal pairs
+# with a structural noun, force super_category (the user's Pearltrees convention). Requires BOTH so a plain
+# "Super Cool Resources" / "My Groups" is NOT swept up.
+_PARENT_SIGNAL = _re.compile(r"\b(super|broad(?:er)?|parent|ancestor)\b")
+_STRUCT_NOUN = _re.compile(r"(categor|topic|group|theme)")
+
+
 # tag/qualifier headers: a section header often pairs a category TAG with a free-text qualifier, either across
 # a DASH — in EITHER order, "A-E -- Subtopics", "IT - Subtopics" (qualifier first), "Subtopics - old" (tag
 # first) — or in PARENTHESES, "Subtopics (old)", "Further reading (from wikipedia)". Split on a
@@ -80,6 +90,9 @@ def fuzzy_mode(text, threshold=0.78):
     if not t:
         return (None, 0.0)
     cands = [t] + t.split()
+    if (_PARENT_SIGNAL.search(t) and _STRUCT_NOUN.search(t)) or "navigate up" in t:
+        r = max(difflib.SequenceMatcher(None, c, "super categories").ratio() for c in cands)
+        return ("super_category", max(r, threshold))   # parent-signal guard — never a sub* match
     best_cat, best = None, 0.0
     for key, cat in FUZZY_KEYS:
         r = max(difflib.SequenceMatcher(None, c, key).ratio() for c in cands)

--- a/prototypes/mu_cosine/test_pt_sections.py
+++ b/prototypes/mu_cosine/test_pt_sections.py
@@ -50,6 +50,21 @@ def test_tag_qualifier_pattern():
     assert categorize("Reciprocity theorem (disambiguation)", "fuzzy")[0] is None          # topical node, no match
 
 
+def test_parent_signal_guard():
+    # "super"/"broad"/"parent" + a category/topic noun is a BROADER grouping -> super_category, NEVER a sub*
+    # match (a bare "categories"/"topics" token is lexically closer to "subcategories"/"subtopics").
+    for label in ["Broad Categories", "Super Topics", "Broader Topics", "Parent Categories",
+                  "Broad Category", "Supercategories"]:                          # incl. singular + one-word
+        assert categorize(label, "fuzzy")[0] == "super_category", label
+    assert categorize("Broad Categories", "exact_phrase")[0] == "super_category"  # exact catches it too now
+    # scope: the guard keys on the parent WORD + a struct noun; a doubly-typo'd "Braod Catagories" (both
+    # misspelled) defeats it and is left for the semantic/embedding layer — not asserted here.
+    # the guard needs BOTH signals — a parent word alone or a noun alone must NOT force super_category:
+    assert categorize("Super Cool Resources", "fuzzy")[0] is None                 # parent word, no struct noun
+    assert categorize("My Groups", "fuzzy")[0] is None                            # struct noun, no parent word
+    assert categorize("Subcategories", "fuzzy")[0] == "subcategory"               # no regression on sub*
+
+
 def test_threshold_is_tunable():
     assert categorize("Subtoipcs", "fuzzy", fuzzy_threshold=0.99)[0] is None   # raise the bar ⇒ no match
     assert categorize("Subtoipcs", "fuzzy", fuzzy_threshold=0.70)[0] == "element_of"


### PR DESCRIPTION
Running the new fuzzy section categoriser over the **full 96-file harvest** (not just
synthetic cases) surfaced a directional **false positive**:

- `Broad Categories` fuzzy-matched **subcategory** (r=0.87)
- `Super Topics` matched **element_of** (r=0.80)

…because a bare content token (`categories`/`topics`) is lexically closer to the
`sub*` keys than to `super categories` — **flipping the relation DIRECTION**
(super → sub), the worst kind of label error for the directional-μ work.

### Fix — parent-signal guard
A parent signal (`super`/`broad(er)`/`parent`/`ancestor`, or `navigate up`) paired with
a structural noun (`categor`/`topic`/`group`/`theme`) forces **super_category** and can
never resolve to a `sub*` key. **Requires both signals**, so a plain `Super Cool
Resources` or `My Groups` is not swept up. Applied to the exact matcher too
(`section_mode` now tags `Broad Categories` instead of dropping it to inferred).

### Measured impact (3298 sectioned pearls, full harvest)
The ~5 mislabeled pearls move to the correct operator:

| | subcategory | element_of | super_category |
|---|---|---|---|
| before | 566 | 2116 | 263 |
| after | **563** | **2114** | **268** |

Tagged share unchanged (96%), but now **directionally correct**.

### Scope
Keys on the parent **word** + noun; a doubly-typo'd `Braod Catagories` (both misspelled)
defeats it and is left for the future semantic/embedding layer.

Tests: `test_pt_sections.py` 7/7 (torch-free) — parent-signal guard, both-signals-required,
no `sub*` regression.