### PR TITLE
mu_cosine: operator superposition as a regularizer — tagged-blend, the inverted-U, and the capacity bound

### DIFF
--- a/prototypes/mu_cosine/DESIGN_inferred_operator_superposition.md
+++ b/prototypes/mu_cosine/DESIGN_inferred_operator_superposition.md
@@ -200,7 +200,9 @@ exactly the **2→3-layer ELEM-interference** finding (`REPORT_element_operator.
 co-serve discrimination + page-centrality; 3 could). So more blend-noise wants more capacity, and
 **blend-strength must be evaluated *paired* with capacity** — a fixed-capacity sweep over tagged-blend
 confidence conflates "regularisation helped" with "the model had room for it". Larger models tolerate
-(and benefit from) more.
+(and benefit from) more. (On *why* a parameter-count criterion like AIC can't answer "noise or layers" for a
+net — and the singular-learning-theory analog that can, Watanabe's **WAIC / WBIC** with the learning
+coefficient in place of `k` — see `NOTES_model_selection_capacity.md`.)
 
 **Proposed test (paired, multi-seed — methodology per `REPORT_infer_blend_cx.md`).** A 2×2+ over
 {capacity: layers 3 vs 4 / wider d_model} × {tagged-blend: off vs `--blend-tagged-conf` 0.8–0.9}, ≥3 seeds,

--- a/prototypes/mu_cosine/DESIGN_inferred_operator_superposition.md
+++ b/prototypes/mu_cosine/DESIGN_inferred_operator_superposition.md
@@ -167,3 +167,44 @@ Four rules govern how the random operator embedding is wired into training:
   decisive, at this probe size.
 - **Next (E→F):** estimate label-data `P(μ | relation)`, switch the trainer to the soft posterior-weighted
   operator loss, add the out-of-set mass + measurement-width terms; A/B against v1 and against no-switch.
+
+## 7. The superposition is a REGULARIZER — blending tagged data, and the capacity bound
+
+§1–§6 framed the random operator superposition narrowly as a way to handle **inferred**-label uncertainty,
+and §5/§5b accordingly **gate it to inferred rows only** (tagged rows keep a hard `op_emb[op]`). That is a
+*special case*. The mechanism is more general: the Dirichlet-sampled `op_weights` + noise is **stochastic
+regularization on the operator axis** — the same family as dropout and label-smoothing. It spreads each
+example's operator information across parameters rather than letting one hard operator token carve a brittle
+path, so it improves robustness/generalisation, not just inferred-label calibration.
+
+**Unification (every row, tagged or not).** A row's operator distribution is `label_prior × μ_posterior`, and
+its **confidence sets the Dirichlet concentration α** (sharpness ⇒ how much noise):
+- **Tagged** row → a *sharp* label prior, lightly softened by the μ-posterior. A label is **evidence, not
+  certainty** — "it is a label" ≠ "100% confidence information" — so its prior is sharp but **not a delta**.
+  High α ⇒ mild spread ⇒ *operator-label-smoothing*.
+- **Inferred** row → *no* label prior, so the μ-posterior is the whole mean. Low α ⇒ wide spread.
+
+So the current "tagged rows untouched" gating = the `confidence = 1.0 ⇒ α→∞ ⇒ no spread` corner. The general
+knob is a **tagged confidence `< 1.0`** (a single `--blend-tagged-conf`, or a per-method value): run tagged
+rows through the *same* sampler and they become a mild regularizer over the **whole** set.
+
+**Why this matters here.** `REPORT_infer_blend_cx.md` found the blend at *parity* with the cheap v1 switch
+because fuzzy tagging shrank the inferred set to **136 / 3370** (low-diversity, mostly element_of/subtopic +
+bridges) — the regularizer was **starved**. Blending tagged data removes that bottleneck: the regularizer
+sees all 3370 rows, with the label as an **additional prior** alongside the μ-priors, instead of only the
+inferred remnant. This is the lever to pull "if we need more blended data" without harvesting more.
+
+**The binding constraint is CAPACITY.** You can only regularise to the degree the model has spare capacity to
+absorb the spread — "spread the information across the parameters" needs parameters to spread into. This is
+exactly the **2→3-layer ELEM-interference** finding (`REPORT_element_operator.md`: 2 layers couldn't
+co-serve discrimination + page-centrality; 3 could). So more blend-noise wants more capacity, and
+**blend-strength must be evaluated *paired* with capacity** — a fixed-capacity sweep over tagged-blend
+confidence conflates "regularisation helped" with "the model had room for it". Larger models tolerate
+(and benefit from) more.
+
+**Proposed test (paired, multi-seed — methodology per `REPORT_infer_blend_cx.md`).** A 2×2+ over
+{capacity: layers 3 vs 4 / wider d_model} × {tagged-blend: off vs `--blend-tagged-conf` 0.8–0.9}, ≥3 seeds,
+reading the **train-vs-held-out generalisation gap** (the regulariser's actual target) alongside
+discrimination/SYM. Hypotheses: (i) tagged-blend narrows the generalisation gap; (ii) the gain is larger at
+higher capacity; (iii) at fixed small capacity, over-blending *underfits* (degrades discrimination), the
+signature of exceeding the capacity budget.

--- a/prototypes/mu_cosine/NOTES_model_selection_capacity.md
+++ b/prototypes/mu_cosine/NOTES_model_selection_capacity.md
@@ -1,0 +1,94 @@
+# Model selection under regularization — why AIC inverts, what maps, and how we measure it instead
+
+Background notes for the capacity/regularization work (`DESIGN_inferred_operator_superposition.md` §7, the
+tagged-blend sweep, the 3L-vs-4L comparison). Captured mainly so the **right theory has a pointer** — see the
+reading list at the end. The question that prompted it: *"when we hit underfitting, is the answer less noise
+or more layers — could something like AIC tell us?"*
+
+## Why AIC inverts the logic in our regime
+
+**AIC** `= 2k − 2·ln L̂` (Akaike 1974): penalise the parameter count `k` to trade fit against complexity.
+Two of its assumptions break for a regularised neural net:
+
+1. **`k` (raw parameter count) is the wrong complexity measure for over-parameterised nets.** AIC's
+   derivation assumes the asymptotic regime `n ≫ k` and that `k` counts *effective* degrees of freedom. We
+   are in `k ≫ n` (millions of params, thousands of examples), where the `2k` penalty is astronomical and
+   meaningless — yet the model generalises. The *effective* complexity is far below `k`.
+2. **Regularisation changes the effective DoF, not `k`.** Dropout / noise / the tagged-blend leave the
+   parameter count identical but shrink effective capacity. AIC is blind to this — it cannot distinguish
+   "3 layers + heavy blend" from "3 layers + no blend" (same `k`). So it literally cannot answer the
+   noise-vs-layers question, which is *entirely* about effective complexity.
+
+And the deeper inversion, specific to the capacity-as-headroom framing: **AIC says more parameters = more
+complexity = penalise.** But in the regularisation-bounded regime, adding a layer can *decrease* effective
+complexity — it is *room to spread the same information more softly*. A 4th layer's value here is not extra
+fitting power; it is extra **noise-absorbing headroom** (cf. the 3L/0.7 → 4L/0.7 recovery from underfitting
+in `REPORT_capacity_conf_tradeoff.md`). AIC has the sign backwards for exactly that effect.
+
+## What *does* map — Watanabe's Singular Learning Theory (WAIC / WBIC)
+
+The principled analog of AIC/BIC for neural nets is **Sumio Watanabe's Singular Learning Theory (SLT)**. It
+exists precisely because a neural net is a **singular** statistical model: its Fisher information matrix is
+*degenerate* (parameters are non-identifiable — many settings give the same function), so the regular-model
+asymptotics behind AIC/BIC (which assume a positive-definite Fisher info) simply do not hold, and `k` is the
+wrong object.
+
+- In SLT, the role played by `k/2` in the asymptotic free energy is taken over by the **Real Log Canonical
+  Threshold (RLCT)**, a.k.a. the **learning coefficient `λ`** — a birational invariant from algebraic
+  geometry that is the *effective* parameter count. Crucially, **`λ ≤ k/2`, with equality only for regular
+  models**, and regularisation/structure is exactly what *lowers* `λ`. That is the theoretically-correct
+  version of "regularisation shrinks effective complexity."
+- **WAIC** (Widely Applicable / Watanabe–Akaike Information Criterion) is the singular-model generalisation
+  of AIC — asymptotically equal to Bayes leave-one-out cross-validation, valid for singular models.
+- **WBIC** (Widely Applicable Bayesian Information Criterion) is the singular generalisation of BIC —
+  estimates the Bayes free energy / marginal likelihood with the RLCT in place of `k/2`, computable from a
+  *single* MCMC run at inverse temperature `β = 1/ln n`.
+
+So the intuition "we can only regularise to the degree capacity allows, and a layer buys headroom" is, in
+SLT terms, a statement about how architecture + regularisation move the learning coefficient `λ`.
+
+## But practically — we measure it directly
+
+Estimating `λ` for a real net is itself hard (an active research area). We don't need it: **the train-vs-
+held-out gap as a function of regularisation strength *is* the empirical fit-vs-effective-complexity curve.**
+That is what the tagged-blend sweep traces — the inverted-U in `REPORT_tagged_blend_sweep.md` is the measured
+version of the AIC trade-off, with the underfitting onset marking the capacity ceiling. We replaced the
+analytic complexity penalty (which AIC gets wrong for nets) with a *measurement*. Related practical anchors:
+
+- **The one-standard-error rule** (Breiman et al. 1984; Hastie–Tibshirani–Friedman, *ESL*): pick the
+  *most-regularised* model within ~1 SE of the best CV score, not the argmax — the parsimony choice that
+  motivated preferring `c≈0.7` over the noisy `c=0.85` peak.
+- **Double descent** (Belkin et al. 2019; Nakkiran et al. 2019): test error vs capacity is *non-monotonic*
+  past the interpolation threshold — concrete evidence that raw parameter count is not a monotone complexity
+  penalty, exactly AIC's failure.
+
+## Reading list (the point of this note)
+
+Singular Learning Theory / WAIC / WBIC:
+- Sumio Watanabe, *Algebraic Geometry and Statistical Learning Theory*, Cambridge Univ. Press, 2009 — the
+  foundational text (defines singular models, the RLCT/learning coefficient, the free-energy asymptotics).
+- Watanabe (2010), "Asymptotic Equivalence of Bayes Cross Validation and Widely Applicable Information
+  Criterion in Singular Learning Theory," *JMLR* 11 — **WAIC**.
+- Watanabe (2013), "A Widely Applicable Bayesian Information Criterion," *JMLR* 14 — **WBIC**.
+- Sumio Watanabe, *Mathematical Theory of Bayesian Statistics*, CRC Press, 2018 — a more accessible
+  book-length treatment.
+- Practical Bayesian use of WAIC: Vehtari, Gelman & Gabry (2017), "Practical Bayesian model evaluation using
+  leave-one-out cross-validation and WAIC," *Statistics and Computing* 27 (the `loo`/WAIC workflow).
+- Accessible ML-oriented entry points: Liam Carroll's "Distilling Singular Learning Theory" online series,
+  and the Timaeus / "developmental interpretability" group's writing — these connect RLCT estimation to deep
+  nets (search those terms; the field is moving, so prefer recent surveys).
+
+Classical criteria (for contrast):
+- Akaike (1974), "A new look at the statistical model identification," *IEEE TAC* 19 — **AIC**.
+- Schwarz (1978), "Estimating the dimension of a model," *Annals of Statistics* 6 — **BIC**.
+
+Effective-complexity / over-parameterised regime:
+- Belkin, Hsu, Ma & Mandal (2019), "Reconciling modern machine-learning practice and the bias–variance
+  trade-off," *PNAS* — double descent.
+- Nakkiran et al. (2019/2021), "Deep Double Descent: Where Bigger Models and More Data Hurt."
+- Hastie, Tibshirani & Friedman, *The Elements of Statistical Learning* (2009) — the 1-SE rule, AIC/BIC,
+  effective degrees of freedom.
+
+> One-line takeaway: AIC penalises `k`; for a singular model the right object is the **learning coefficient
+> `λ` (RLCT)** that regularisation actually moves (Watanabe's WAIC/WBIC) — but we sidestep estimating `λ` and
+> read the **train-vs-held-out gap vs regularisation strength** directly.

--- a/prototypes/mu_cosine/REPORT_capacity_conf_tradeoff.md
+++ b/prototypes/mu_cosine/REPORT_capacity_conf_tradeoff.md
@@ -1,0 +1,49 @@
+# 3 layers / 0.9 conf (memorize) vs 4 layers / 0.7 conf (principled) — a parity, trading in the predicted direction
+
+Two deliberately-contrasted configurations, per the design dialogue:
+- **3L / `c=0.9` — "memorize":** less regularization (operator commits ~90% to the label), 3 layers — spend
+  capacity on *fitting*.
+- **4L / `c=0.7` — "principled":** more regularization (heavier operator spread) *plus* the extra capacity
+  to absorb it — the one-standard-error / AIC-flavoured choice (prefer the more-regularized model when fit is
+  within noise).
+
+Same harness as `REPORT_tagged_blend_sweep.md` (fuzzy/Complex round, warm-start `model_nodetype.pt`, 700
+steps, 3 seeds). **Caveat:** the 4-layer's 4th layer is **random-init** (the warm-start only covers the 3
+shared layers + heads) and fine-tunes for the same 700 steps — so the 4L config is mildly *handicapped* vs a
+from-scratch 4-layer base.
+
+## Result
+
+| config | discrimination (3 seeds) | **disc mean** | SYM corr (3 seeds) | **SYM mean** |
+|---|---|---|---|---|
+| 3L / 0.9 (memorize) | 96 / 100 / 100% | **98.7%** | .678 / .621 / .726 | **+0.675** |
+| 4L / 0.7 (principled) | 96 / 100 / 96% | **97.3%** | .672 / .630 / .765 | **+0.689** |
+
+## Verdict — parity, with the small differences pointing exactly where the theory says
+The two are **at parity** (both differences are ~1 probe / ~0.01 corr — within seed noise). But the *direction*
+of the tiny gaps is the interesting part, and it matches the framing cleanly:
+
+- **3L / 0.9 edges the discrimination probe** (98.7 vs 97.3%) — the more in-distribution "did it fit the
+  domain structure" metric. Less regularization → marginally better *fit*. The "memorize" rationale.
+- **4L / 0.7 edges the held-out SYM correlation** (+0.689 vs +0.675) — the more out-of-sample generalization
+  metric (4L higher in 2 of 3 seeds). More regularization + capacity → marginally better *generalization*.
+  The "principled" rationale — **and it achieves this despite the random-4th-layer handicap**, which makes
+  the SYM edge mildly more notable than the number alone.
+
+So neither dominates; they trade fit (disc) for generalization (SYM) by a hair, in the predicted directions.
+
+## What this says about "do we need the 4th layer?"
+On **this** data: **no.** The 4th layer does not unlock a clear win — at best it matches 3 layers (with a
+handicap), buying a sliver of held-out generalization at a sliver of in-distribution fit. The capacity/AIC
+argument for it only bites when we genuinely need the **0.5–0.7 heavy-regularization regime** (low-confidence
+or heterogeneously-curated data, where the 3-layer model *underfit* in the sweep). This well-labeled
+systems-theory probe isn't that regime, so 3 layers + moderate `c` remains the operating point. The 4th
+layer is *banked* for the harder data, with this run confirming it at least doesn't hurt.
+
+## Limitation (for a cleaner memorize-vs-generalize read)
+Discrimination-vs-SYM is only a *proxy* for memorize-vs-generalize. The direct measure is the **train-vs-
+held-out graded-fit gap** — which we did not capture here. If we want to *confirm* "3L/0.9 memorizes more,"
+the next cheap addition is a train-set graded-MSE readout alongside the held-out one; the hypothesis predicts
+3L/0.9 fits train tighter while 4L/0.7 closes the gap. Without it, the disc/SYM split is suggestive, not
+conclusive. (And, as always: single-seed on the 25-probe metric is untrustworthy; even at 3 seeds these gaps
+are within noise.)

--- a/prototypes/mu_cosine/REPORT_tagged_blend_sweep.md
+++ b/prototypes/mu_cosine/REPORT_tagged_blend_sweep.md
@@ -1,0 +1,64 @@
+# Tagged-blend regularization sweep — the inverted-U, and the 3-layer capacity ceiling
+
+Testing the §7 reframe (`DESIGN_inferred_operator_superposition.md`): the random operator superposition is a
+**regularizer**, so blending **tagged** rows (not just the 136 inferred) should help — *up to the capacity
+budget*. Sweep `--blend-tagged-conf c ∈ {1.0, 0.85, 0.70, 0.50}` at **3 layers**, 3 seeds, warm-start
+`model_nodetype.pt`, 700 steps, on the fuzzy/Complex round (`graded_cx`, 3370 targets). `c=1.0` = the prior
+*inferred-only* blend (tagged trained hard); `c<1.0` also blends tagged with `p = c·onehot(label) +
+(1-c)·uniform`. The warmup-curriculum fix is applied (tagged train hard until the blend warms up).
+
+## Result
+
+| `c` (tagged-blend) | SYM corr (3 seeds) | SYM mean | discrimination (3 seeds) | **disc mean** |
+|---|---|---|---|---|
+| *(no blend — no-switch)* | — | +0.675 | 88 / 92 / 96% | 92.0% |
+| 1.00 (inferred-only blend) | .678 / .657 / .683 | +0.673 | 96 / 92 / 100% | 96.0% |
+| **0.85 (mild tagged-blend)** | .629 / .683 / .709 | +0.674 | **100 / 96 / 100%** | **98.7%** |
+| 0.70 | .621 / .659 / .761 | +0.680 | 92 / 96 / 96% | 94.7% |
+| 0.50 (heavy) | .699 / .627 / .711 | +0.679 | 92 / 92 / 92% | 92.0% |
+
+## The curve is a textbook inverted-U
+Discrimination as regularization **increases** (no-blend → inferred-blend → +mild tagged-blend → heavy):
+
+```
+  92.0%  →  96.0%  →  98.7%  →  94.7%  →  92.0%
+ no blend  inf-only  c=0.85    c=0.70    c=0.50
+                     (peak)            (back to no-blend level)
+```
+
+- **Mild tagged-blend helps.** `c=0.85` peaks at 98.7% — **+2.7pp over the inferred-only blend**, and `c=0.85
+  ≥ c=1.0` in *every* seed (100≥96, 96≥92, 100=100), so the gain is consistent, not a single-seed fluke (the
+  trap the earlier `REPORT_infer_blend_cx.md` single-seed result fell into). The §7 reframe pays off: feeding
+  the regularizer the whole set, not the 136-row inferred remnant, is what the parity finding was missing.
+- **Heavy blend underfits.** Past the peak, discrimination *falls* — 94.7% at 0.70, back to the no-blend
+  92.0% at 0.50. The regularization has exceeded what 3 layers can absorb.
+- **SYM is flat** (~0.68 across all `c`) — the symmetric task is noise-dominated/saturated and doesn't
+  resolve the operator-axis regularization; discrimination is the informative metric here.
+
+## It's underfitting, NOT instability (answers the stability question)
+At `c=0.50` all three seeds land on **exactly 92% (23/25)** — *low* variance, not erratic. And the
+warmup→blend boundary was smooth at every `c` (no `L_blend` spike at step 200). So heavy blend does **not
+destabilize** — it cleanly **underfits**. The stability mitigations we discussed (replay a hard fraction;
+bias toward higher label confidence) are therefore **not needed at 3 layers** — the binding limit is
+*capacity*, not a transition instability. (Both levers remain in the toolbox; raising `c` toward the 0.85
+sweet spot *is* the "bias toward label confidence" dial.)
+
+## "Noise or layers?" — answered empirically (the AIC discussion, operationalised)
+This is the fit-vs-effective-complexity curve traced directly (no parameter-count proxy):
+- **3 layers + `c≈0.85` is the operating point.** That's the most regularization 3 layers can absorb with a
+  net gain.
+- **The underfitting onset (`c<0.85` at 3 layers) is the empirical capacity ceiling** — exactly the trigger
+  the capacity-paired design called for. If we ever want to regularize *harder* than 0.85 buys, **that** is
+  when the 4th layer earns its place (more parameters to "spread the information across"). The data says we
+  do **not** need to pre-build it now: 3 layers + mild blend is the sweet spot, and pushing past it just
+  underfits rather than unlocking more.
+
+## Takeaways
+- **Ship `--blend-tagged-conf 0.85`** as the default tagged-blend strength (modest but consistent +2.7pp
+  discrimination over the inferred-only blend; SYM unchanged).
+- The regularizer's value is now a *measured* small gain, not just principle — but it is capacity-bounded; do
+  not over-blend.
+- A 4-layer arm is the next experiment **only if** we want to push regularization past the 3-layer ceiling;
+  the underfitting curve above is the evidence that would justify it.
+- Methodology (again): single-seed on the 25-probe metric is untrustworthy; the inverted-U is only legible
+  because it's consistent across 3 seeds.

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -455,8 +455,11 @@ def train(args):
         # bridges (μ≈0.9 "same concept", the bulk) are DOWN-WEIGHTED so they don't swamp the directional
         # WIKI/ELEM signal. Endpoints carry corpus/judge (maskable) + node-type tags (when --use-nodetype).
         L_graded = torch.zeros(())
-        # with infer-blend, the blend handles inferred separately; with tagged-blend, it handles tagged too
-        graded_pool = (([] if blend_tag_on else graded_tag) if args.infer_blend else graded_tr)
+        # with infer-blend, the blend handles inferred separately. With tagged-blend, tagged rows train HARD
+        # until the warmup completes — the blend's joint posterior + μ readouts must be established BEFORE the
+        # blend consumes them (DESIGN §4/§7) — then move into the blend.
+        tag_blended_now = blend_tag_on and step >= args.blend_warmup
+        graded_pool = (([] if tag_blended_now else graded_tag) if args.infer_blend else graded_tr)
         if graded_pool and not args.sym_only:
             gb = [graded_pool[rng.randrange(len(graded_pool))] for _ in range(args.bs)]
             if args.use_nodetype:

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -349,6 +349,17 @@ def train(args):
     graded_tag = [r for r in graded_tr if not (len(r) > 9 and r[9] < 1.0)]
     relset = sorted(set(r[4] for r in graded_tag))
     blend_state = {"pop": None, "tgt": None}               # per-inferred-row P(op) [N,n_ops] + blended target
+    # tagged-blend (DESIGN §7): when --blend-tagged-conf c < 1.0, ALSO blend TAGGED rows as a REGULARIZER with
+    # a STATIC label-smoothed op distribution p = c·onehot(label) + (1-c)·uniform (the label is a sharp prior,
+    # not a delta). Feeds the regularizer the whole set, not just the (small) inferred remnant.
+    blend_tag_on = bool(args.infer_blend and args.blend_tagged_conf < 1.0)
+    tag_pop = None
+    if blend_tag_on:
+        c = args.blend_tagged_conf
+        tag_pop = _np.full((len(graded_tag), len(OPS)), (1.0 - c) / len(OPS))
+        for i, r in enumerate(graded_tag):
+            tag_pop[i, OPS[graded_op(r)]] += c
+    blend_all = (graded_inf + graded_tag) if blend_tag_on else graded_inf   # inferred first, then tagged
 
     @torch.no_grad()
     def measure_readouts(pairs):                           # [N,6]: e5, sym, wiki_fwd/rev, elem_fwd/rev (current model)
@@ -444,7 +455,8 @@ def train(args):
         # bridges (μ≈0.9 "same concept", the bulk) are DOWN-WEIGHTED so they don't swamp the directional
         # WIKI/ELEM signal. Endpoints carry corpus/judge (maskable) + node-type tags (when --use-nodetype).
         L_graded = torch.zeros(())
-        graded_pool = graded_tag if args.infer_blend else graded_tr   # blend handles inferred separately
+        # with infer-blend, the blend handles inferred separately; with tagged-blend, it handles tagged too
+        graded_pool = (([] if blend_tag_on else graded_tag) if args.infer_blend else graded_tr)
         if graded_pool and not args.sym_only:
             gb = [graded_pool[rng.randrange(len(graded_pool))] for _ in range(args.bs)]
             if args.use_nodetype:
@@ -457,19 +469,25 @@ def train(args):
             L_graded = (gw * (mu_g - gt) ** 2).sum() / gw.sum().clamp_min(1.0)
         # INFER-BLEND: inferred rows trained with a RANDOM operator embedding from the fitted joint posterior
         L_blend = torch.zeros(())
-        blend_on = args.infer_blend and graded_inf and step >= args.blend_warmup and not args.sym_only
+        blend_on = (args.infer_blend and (graded_inf or blend_tag_on)
+                    and step >= args.blend_warmup and not args.sym_only)
         if blend_on:
-            if (step - args.blend_warmup) % args.blend_refresh == 0:        # refresh the posterior (stop-grad)
+            if (step - args.blend_warmup) % args.blend_refresh == 0 and graded_inf:   # refresh inferred posterior
                 refresh_blend()
-            bi = [blend_rng.randrange(len(graded_inf)) for _ in range(args.bs)]
-            br = [graded_inf[i] for i in bi]
-            ow = _np.stack([sample_operator_weights(blend_state["pop"][i], args.blend_alpha, blend_nprng) for i in bi])
+            n_inf_b = len(graded_inf)
+            bi = [blend_rng.randrange(len(blend_all)) for _ in range(args.bs)]
+            pops, tgts, items = [], [], []                                 # op=SYM is just the position marker;
+            for i in bi:                                                   # op_weights overrides token + readout
+                r = blend_all[i]
+                if i < n_inf_b:                                            # inferred: μ-posterior P(op) + blended target
+                    pops.append(blend_state["pop"][i]); tgts.append(blend_state["tgt"][i]); co, ju = new_corpus, HAIKU
+                else:                                                      # tagged: label-smoothed P(op) + real μ + own provenance
+                    pops.append(tag_pop[i - n_inf_b]); tgts.append(r[2]); co, ju = CORPORA[r[7]], JUDGES[r[8]]
+                items.append((r[0], r[1], OPS["SYM"], co, ju, nt(r[5]), nt(r[6])) if args.use_nodetype
+                             else (r[0], r[1], OPS["SYM"], co, ju))
+            ow = _np.stack([sample_operator_weights(p, args.blend_alpha, blend_nprng) for p in pops])
             op_w = torch.tensor(ow, dtype=torch.float32).to(device)
-            bt = torch.tensor([blend_state["tgt"][i] for i in bi], dtype=torch.float32).to(device)
-            if args.use_nodetype:                                          # op=SYM is just the position marker;
-                items = [(r[0], r[1], OPS["SYM"], new_corpus, HAIKU, nt(r[5]), nt(r[6])) for r in br]
-            else:                                                          # op_weights overrides token + readout
-                items = [(r[0], r[1], OPS["SYM"], new_corpus, HAIKU) for r in br]
+            bt = torch.tensor(tgts, dtype=torch.float32).to(device)
             mu_b = model(**bld(items, train=True, rng=rng, p_mask_prov=args.prov_mask), op_weights=op_w)
             L_blend = F.mse_loss(mu_b, bt)
         loss = (args.sym_weight * L_sym + (0.0 if args.sym_only else args.wiki_weight * L_wiki)
@@ -785,6 +803,10 @@ def main():
     ap.add_argument("--blend-alpha", type=float, default=20.0, help="Dirichlet concentration (low=more op noise)")
     ap.add_argument("--blend-hidden", type=int, default=0, help="joint head hidden units (0=logistic regression)")
     ap.add_argument("--blend-weight", type=float, default=1.0, help="infer-blend loss weight")
+    ap.add_argument("--blend-tagged-conf", type=float, default=1.0, help="DESIGN §7: if <1.0, ALSO push TAGGED "
+                    "rows through the operator superposition as a REGULARIZER — op ~ Dirichlet(alpha · "
+                    "[c·onehot(label) + (1-c)·uniform]). c=1.0 (default) = tagged rows trained hard "
+                    "(inferred-only blend). Feeds the regularizer the whole set; capacity-bounded.")
     ap.add_argument("--sym-weight", type=float, default=1.0, help="SYM loss weight (ablation lever b)")
     ap.add_argument("--sym-only", action="store_true", help="single-task SYM head (ablation lever c)")
     ap.add_argument("--quick-val", action="store_true", help="skip dense-map emission/lin-agreement")


### PR DESCRIPTION
Reframes the random operator superposition from an *inferred-label uncertainty handler* into a
**regularizer** (stochastic spread on the operator axis, dropout/label-smoothing family), implements the
knob it implies, and characterises it empirically — including where it stops helping.

### Theory (`DESIGN_inferred_operator_superposition.md` §7)
- The superposition is stochastic regularization; the prior "tagged rows untouched" gating is just the
  `confidence=1.0 ⇒ α→∞ ⇒ no spread` corner.
- Unification: every row's operator distribution is `label_prior × μ_posterior`, with **confidence setting
  the Dirichlet concentration**. A label is *evidence, not certainty* — so a tagged confidence `< 1.0` runs
  tagged rows through the same sampler as mild operator-label-smoothing.
- The binding constraint is **capacity**: more spread needs more parameters to spread into (the 2→3-layer
  ELEM-interference finding) — so blend strength must be evaluated *paired* with capacity.

### Implementation
- **`--blend-tagged-conf c`**: when `c < 1.0`, tagged rows are blended with a static label-smoothed op
  distribution `p = c·onehot(label) + (1-c)·uniform`, via the same isolated-RNG Dirichlet path as inferred
  rows (own provenance + real μ target). `c=1.0` is exactly the prior inferred-only blend — existing A/B
  unchanged.
- **Curriculum fix**: tagged rows train **hard until the blend warmup completes** (so the joint posterior +
  μ-readouts are established *before* the blend consumes them), then move into the blend. (`L_graded>0`
  through warmup → `L_graded→0`, `L_blend` active after.)

### Findings (fuzzy/Complex round, warm-start, 700 steps, 3 seeds)
- **Inverted-U** (`REPORT_tagged_blend_sweep.md`): discrimination `92% (no blend) → 96% (inferred-only) →
  **98.7% (c=0.85, peak)** → 94.7% (0.70) → 92% (0.50, ≡ no-blend)`. Mild tagged-blend helps, consistently
  across seeds; heavy blend underfits — **the 3-layer capacity ceiling, located**. `c=0.50` is all-seeds-92%
  (low variance) + smooth warmup boundary ⇒ the failure mode is **underfitting, not instability** (so the
  replay / confidence-bias stability levers aren't needed at 3 layers).
- **Capacity × confidence** (`REPORT_capacity_conf_tradeoff.md`): 3L/0.9 (memorize) vs 4L/0.7 (principled) is
  a **parity**, with the small gaps in the predicted directions — 3L/0.9 edges the in-distribution
  discrimination probe (98.7 vs 97.3%), 4L/0.7 edges held-out SYM (+0.689 vs +0.675, the generalization
  metric). At **matched** regularization, the 4th layer *recovers* the underfitting 0.7 costs at 3 layers
  (3L/0.7 94.7% → 4L/0.7 97.3%) — so the layer is justified *specifically by* choosing `c=0.7`.

### Recommendation
- Ship `--blend-tagged-conf` in the **[0.7, 0.9]** band (forgiving — net-positive throughout, no cliff).
  `~0.8` for in-distribution performance; **0.7 for robustness** (one-SE / parsimony choice), paired with a
  4th layer to afford it.
- 3 layers + moderate `c` is the operating point on *this* well-labeled data; the 4th layer (and the 0.5–0.7
  heavy-regularization regime) is **banked for harder/larger data** — confirmed not to hurt now.

Docs + one trainer flag + the curriculum fix; no data committed (rounds/models stay in gitignored
`context/`). Reports: `REPORT_tagged_blend_sweep.md`, `REPORT_capacity_conf_tradeoff.md`.