### PR TITLE
mu_cosine: PT-rooted walks — fuse_corpus --pt-seed; Chaos + Emergence bridging

### DIFF
--- a/prototypes/mu_cosine/REPORT_bridge_chaos.md
+++ b/prototypes/mu_cosine/REPORT_bridge_chaos.md
@@ -1,0 +1,24 @@
+# Bridging the Chaos theory mindmap to Wikipedia — 1 / 2 / 3 hops (fused, privacy-scrubbed)
+
+Same `fuse_corpus.py` walk as the other systems-theory maps, from the **Chaos theory** SimpleMind map
+(`Subjects/.../sys/sys/complex/chaos/`). Fuzzy section categorisation.
+
+## Pipeline
+1. `parse_smmx.py "Chaos theory.smmx"` → **37 nodes, 20 carry a Pearltrees tree-id**.
+2. `bridge_seeds.py --depth 1` → harvested **20/20 seeds**, 732 bridges (50 to enwiki Categories) over 15 concepts.
+3. `fuse_corpus.py --start chaos-theory --hops {1,2,3} --section-method fuzzy`.
+
+## Result
+
+| hops | nodes | by corpus | edges | inferred |
+|---|---|---|---|---|
+| 1 | 8 | mm 7, pt 1 | 8 | 0 |
+| 2 | 98 | wiki 66, pt 19, mm 13 | 132 | 2 |
+| 3 | 378 | **wiki 294**, pt 63, mm 21 | 438 | 8 |
+
+3-hop relation diversity: **element_of 291, subcategory 50, super_category 45, see_also 20, bridge 18,
+subtopic 12, assoc 2**. Only 8/438 inferred — the fuzzy layer tagged almost every section relation.
+
+## Notes
+- Map + fused TSVs in gitignored `context/`; `.pt_cache/` harvests are private-tier, not committed.
+- Folds into the systems-theory fine-tuning pool (cybernetics + dynamical + LTI + complex + chaos).

--- a/prototypes/mu_cosine/REPORT_bridge_emergence.md
+++ b/prototypes/mu_cosine/REPORT_bridge_emergence.md
@@ -1,0 +1,34 @@
+# Bridging the Emergence Pearltrees tree to Wikipedia — 1 / 2 / 3 hops (PT-rooted, no mindmap)
+
+The first **Pearltrees-rooted** bridging walk (no SimpleMind map). Motivation: "Emergence" is a **leaf** in our
+Wikipedia category graph (`enwiki_named`: parents `Ontology`/`Holism`, but **0 children**), so a wiki-only
+bidirectional walk can't go down from it. The user's Pearltrees Emergence tree
+(`pearltrees.com/s243a/emergence`, id **60457194**) has real category connectivity — **223 enwiki bridges**
+across 4 sub-trees (Modularity, Superorganisms, …) — so we root the walk there instead.
+
+## Enabler: `fuse_corpus.py --pt-seed SLUG:TREEID`
+New option to root the fused walk **directly at a Pearltrees tree** (a start `mm:` node bridged to the PT
+tree), bypassing the mindmap. `--smmx` is now optional; reusable for any PT-rooted walk.
+
+## Pipeline
+1. Harvest: `fetch_pearltrees_tree.py --tree-id 60457194 --depth 3` → 252 edges / 19 sections / **223 enwiki
+   bridges** over 4 trees.
+2. `fuse_corpus.py --pt-seed emergence:60457194 --start emergence --hops {1,2,3} --section-method fuzzy`.
+
+## Result
+
+| hops | nodes | by corpus | edges | inferred |
+|---|---|---|---|---|
+| 1 | 2 | mm 1, pt 1 | 1 | 0 |
+| 2 | 118 | **wiki 108**, pt 9, mm 1 | 133 | 2 |
+| 3 | 196 | **wiki 178**, pt 17, mm 1 | 217 | 3 |
+
+Reaches Wikipedia **immediately** (108 wiki at hop 2) — the PT tree's PagePearls carry direct enwiki anchors.
+3-hop relation diversity: **element_of 167, super_category 32, subcategory 14, bridge 4**. Only 3/217
+inferred. (Membership-heavy, as expected for a PagePearl-rich tree; lighter on `see_also`/`assoc` than the
+mindmap walks.)
+
+## Notes
+- PT harvest + fused TSVs are private-tier / gitignored (`.pt_cache/`, `context/`); not committed.
+- Adds the Emergence region to the data pool — and validates the PT-rooted path for future "the Pearltrees
+  page is better connected than the wiki node" cases.

--- a/prototypes/mu_cosine/fuse_corpus.py
+++ b/prototypes/mu_cosine/fuse_corpus.py
@@ -33,19 +33,21 @@ def norm(s):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--smmx", required=True)
+    ap.add_argument("--smmx", default=None, help="SimpleMind map to root the walk at (optional if --pt-seed)")
     ap.add_argument("--start", default=None, help="start node slug (default: the map filename slug = root)")
     ap.add_argument("--hops", type=int, default=2)
     ap.add_argument("--pt-cache", default=os.path.join(ROOT, ".pt_cache"))
     ap.add_argument("--out-prefix", default=None)
+    ap.add_argument("--pt-seed", action="append", default=[], metavar="SLUG:TREEID",
+                    help="root directly at a Pearltrees tree (no mindmap): a start mm node SLUG bridged to "
+                         "Pearltrees tree TREEID. Repeatable. e.g. --pt-seed emergence:60457194")
     ap.add_argument("--section-method", default="exact_phrase", choices=["exact_phrase", "fuzzy"],
                     help="fuzzy = edit-distance section matching (catches typo'd headers → more tagged labels)")
     args = ap.parse_args()
+    if not args.smmx and not args.pt_seed:
+        ap.error("need --smmx and/or --pt-seed")
 
-    # 1) parse the SimpleMind map
-    sm_pref = "/tmp/_fuse_sm"
-    subprocess.run([sys.executable, os.path.join(ROOT, "parse_smmx.py"), args.smmx, "--out-prefix", sm_pref],
-                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    # 1) parse the SimpleMind map (optional) and/or inject direct Pearltrees seeds (--pt-seed)
     nodes = {}                                          # key → (corpus, type, title)
     edges = []                                          # (a_key, b_key, relation)
 
@@ -55,23 +57,32 @@ def main():
         return k
 
     sm_seeds = {}                                       # mm slug → pearltrees tree-id
-    for ln in open(sm_pref + "_nodes.tsv", encoding="utf-8"):
-        if ln.startswith("#"):
-            continue
-        c = ln.rstrip("\n").split("\t")                 # key, type, title, slug, pt_id, enwiki
-        if len(c) < 3:
-            continue
-        mk = addn("mm", c[0], c[1] if len(c) > 1 else "mindmap_node", c[2] if len(c) > 2 else c[0])
-        if len(c) >= 6 and c[5]:                        # direct enwiki anchor on the SM node — USER-TAGGED ⇒ 1.0
-            edges.append((mk, addn("wiki", c[5], "category" if c[5].startswith("Category:") else "page", c[5]), "bridge", 1.0))
-        if len(c) >= 5 and c[4].strip().isdigit():
-            sm_seeds[norm(c[3] or c[0])] = c[4].strip()
-    for ln in open(sm_pref + "_edges.tsv", encoding="utf-8"):
-        if ln.startswith("#"):
-            continue
-        a, b, rel = (ln.rstrip("\n").split("\t") + ["", "", ""])[:3]
-        if a and b:
-            edges.append((f"mm:{norm(a)}", f"mm:{norm(b)}", rel, 1.0))   # mindmap structure is explicit ⇒ tagged
+    if args.smmx:
+        sm_pref = "/tmp/_fuse_sm"
+        subprocess.run([sys.executable, os.path.join(ROOT, "parse_smmx.py"), args.smmx, "--out-prefix", sm_pref],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        for ln in open(sm_pref + "_nodes.tsv", encoding="utf-8"):
+            if ln.startswith("#"):
+                continue
+            c = ln.rstrip("\n").split("\t")             # key, type, title, slug, pt_id, enwiki
+            if len(c) < 3:
+                continue
+            mk = addn("mm", c[0], c[1] if len(c) > 1 else "mindmap_node", c[2] if len(c) > 2 else c[0])
+            if len(c) >= 6 and c[5]:                     # direct enwiki anchor on the SM node — USER-TAGGED ⇒ 1.0
+                edges.append((mk, addn("wiki", c[5], "category" if c[5].startswith("Category:") else "page", c[5]), "bridge", 1.0))
+            if len(c) >= 5 and c[4].strip().isdigit():
+                sm_seeds[norm(c[3] or c[0])] = c[4].strip()
+        for ln in open(sm_pref + "_edges.tsv", encoding="utf-8"):
+            if ln.startswith("#"):
+                continue
+            a, b, rel = (ln.rstrip("\n").split("\t") + ["", "", ""])[:3]
+            if a and b:
+                edges.append((f"mm:{norm(a)}", f"mm:{norm(b)}", rel, 1.0))   # mindmap structure is explicit ⇒ tagged
+    for spec in args.pt_seed:                           # PT-rooted seed: a start mm node bridged to a PT tree
+        slug, _, tid = spec.partition(":")
+        slug = norm(slug)
+        addn("mm", slug, "mindmap_node", slug.replace("-", " ").title())
+        sm_seeds[slug] = tid.strip()
 
     # 2) fold in the cached Pearltrees harvest for each SM node, + the SM↔PT and PT↔enwiki bridges.
     # PRIVACY (scrub-everywhere): raw .pt_cache harvests are NOT pre-scrubbed (they come from the private
@@ -143,7 +154,12 @@ def main():
     adj = collections.defaultdict(set)
     for a, b, *_ in edges:
         adj[a].add(b); adj[b].add(a)
-    start = f"mm:{norm(args.start) if args.start else norm(os.path.splitext(os.path.basename(args.smmx))[0])}"
+    if args.start:
+        start = f"mm:{norm(args.start)}"
+    elif args.smmx:
+        start = f"mm:{norm(os.path.splitext(os.path.basename(args.smmx))[0])}"
+    else:
+        start = f"mm:{next(iter(sm_seeds))}"            # PT-rooted: first --pt-seed slug
     if start not in nodes:
         start = next((k for k in nodes if k.startswith("mm:")), None)
     seen, frontier = {start}, {start}


### PR DESCRIPTION
Chaos theory mindmap walk (3-hop 378 nodes/294 wiki). Emergence is a LEAF in our wiki graph, so rooted at the user's Pearltrees Emergence tree (223 bridges) instead — via a new fuse_corpus --pt-seed SLUG:TREEID that roots the fused walk directly at a PT tree (--smmx now optional). Reusable for any  "PT page better-connected than the wiki node" case. Reports + feature; data gitignored.