### PR TITLE
mu_cosine: embedding (semantic) section layer — conservative gate + honest calibration

### DIFF
--- a/prototypes/mu_cosine/REPORT_section_embedding.md
+++ b/prototypes/mu_cosine/REPORT_section_embedding.md
@@ -1,0 +1,62 @@
+# Embedding section-categorisation layer — built, calibrated, and an honest negative on current data
+
+The semantic escalation after exact + fuzzy (`pt_sections.py` ladder: `exact_phrase` → `fuzzy` → `embedding`).
+Lexical fuzzy catches **typos** (`Subtoipcs`); embedding is meant to catch **synonyms / paraphrases** that
+share no edit-distance with a keyword (`Members`, `Narrower areas`, `Parent concepts`). Each category has a
+few canonical **exemplars**; a section label is e5-encoded (`query:`) and cosine-matched against the
+exemplars (`passage:`), best-per-category. Encoder: the same frozen `intfloat/e5-small-v2` as the model,
+loaded **offline** from the HF cache (`section_embed.py`).
+
+## Why it needs a conservative gate (live calibration on the real harvest)
+Running e5 over the **28 residual labels** (the ones exact + fuzzy both miss, out of 73 distinct) showed the
+naive "nearest exemplar, absolute threshold" categoriser would **inject more noise than signal**:
+
+1. **The residual is overwhelmingly TOPICAL, not relational.** `Electromagnetism`, `Control Theory`,
+   `Transfer Functions`, `Vector Calculs`, `dimensional analysis`, `The Equations` are *content* section
+   names — not relation-type headers. They should stay inferred / structural-default, **not** be forced into
+   a relation.
+2. **Everything sits in a narrow e5 band (cos 0.80–0.89)** where `see also` / `related` is a generic
+   attractor; 2nd-place margins are tiny (0.01–0.02).
+3. **Genuine signal doesn't separate from junk.** The strongest real-ish hit `Links → reference (0.886)` is
+   barely above the junk `My Groups → element_of (0.873)` and `Friends Pages → see_also (0.865)` — which the
+   tests explicitly want rejected. A low absolute threshold sweeps in the topical pack, including the
+   *harmful directional* commitments (`The Equations` / `My Groups` → element_of).
+
+So `embed_mode` uses a **conservative threshold (0.88) + a 1st-vs-2nd margin gate (0.02)**, and an embedding
+hit carries **confidence = the cosine** — a *graded, <1.0* tier (a soft relation prior that feeds the
+operator-noise model, **not** a hard label), so even an accepted hit lands in the inferred tier rather than
+polluting the tagged set.
+
+## Result at the safe gate (threshold 0.88, margin 0.02)
+
+| | count | examples |
+|---|---|---|
+| **rescued** | **1 / 28** | `Links → reference` (cos 0.886) |
+| left inferred (correct) | 27 / 28 | the topical/content names above |
+| known junk rejected | all | `Meta`, `My Groups`, `Friends Pages`, `Papers`, `Transient response…`, `Nonlinear control` |
+
+**One real, non-directional rescue; zero false positives; zero junk admitted.**
+
+## Honest verdict
+On the **current** harvest the embedding layer is **near-neutral** — the lexical layers (exact + fuzzy +
+tag/qualifier + parent-signal guard) already capture essentially all the *relation-header* signal, and what
+remains is genuinely topical content or Pearltrees nav junk that *correctly* stays inferred. This directly
+explains the "surprised how much fuzzy tagged" observation: there were almost no paraphrase-style headers
+left for embedding to catch.
+
+What the layer buys is therefore **not a number now** but:
+- **Safety + readiness** — calibrated to reject the topical pack, so it can be enabled (`fuse_corpus.py
+  --section-method embedding`) without injecting noise, and it will earn its keep on **paraphrase-rich
+  corpora** (other users' Pearltrees, where headers like `Members` / `Narrower areas` actually occur).
+- **A reusable e5 encoder** (`section_embed.py`) for any other semantic-match need (e.g. feeding section→
+  exemplar cosine as a *feature* to the posterior rather than a hard label).
+
+## Future directions (deferred)
+- **Topical-section ⇒ membership.** A section literally named `Electromagnetism` under a Physics tree means
+  its pearls are *members of the Electromagnetism subtopic* — i.e. it implies `element_of` of a *new
+  subtopic node*, not a relation-type. Modelling that (synthesising the subtopic node) is a different
+  feature than label→relation-type categorisation; noted here as the higher-value way to use these topical
+  names.
+- **Section→exemplar cosine as a posterior feature** (graded confidence input) instead of a thresholded
+  label.
+- **LLM layer** for the genuinely-ambiguous residual + the anomaly/quarantine queue (budget-gated).

--- a/prototypes/mu_cosine/fuse_corpus.py
+++ b/prototypes/mu_cosine/fuse_corpus.py
@@ -38,9 +38,16 @@ def main():
     ap.add_argument("--hops", type=int, default=2)
     ap.add_argument("--pt-cache", default=os.path.join(ROOT, ".pt_cache"))
     ap.add_argument("--out-prefix", default=None)
-    ap.add_argument("--section-method", default="exact_phrase", choices=["exact_phrase", "fuzzy"],
-                    help="fuzzy = edit-distance section matching (catches typo'd headers → more tagged labels)")
+    ap.add_argument("--section-method", default="exact_phrase",
+                    choices=["exact_phrase", "fuzzy", "embedding"],
+                    help="fuzzy = edit-distance (typos); embedding = e5 semantic match (paraphrases, "
+                         "conservative gate, graded confidence — see REPORT_section_embedding.md)")
     args = ap.parse_args()
+
+    section_encoder = None
+    if args.section_method == "embedding":                 # build the e5 encoder once (offline, cached)
+        from section_embed import e5_encoder
+        section_encoder = e5_encoder()
 
     # 1) parse the SimpleMind map
     sm_pref = "/tmp/_fuse_sm"
@@ -117,7 +124,8 @@ def main():
         # fall back to the structural contentType default — an INFERRED relation, low confidence — only when
         # the pearl is in no recognised section. The confidence rides downstream so the trainer can add
         # operator noise / stochastically switch the operator for inferred (untagged) relations.
-        cat = relation_for(pt_sec.get(f[7], ""), args.section_method) if len(f) > 7 else (None, "none", 0.0)
+        cat = (relation_for(pt_sec.get(f[7], ""), args.section_method, encoder=section_encoder)
+               if len(f) > 7 else (None, "none", 0.0))
         pk = addn("pt", f[0], "pearltrees_collection", f[0])
         m = WIKI.search(f[4]) if len(f) > 4 else None
         if m:                                           # PagePearl whose url is enwiki → a cross-corpus link

--- a/prototypes/mu_cosine/pt_sections.py
+++ b/prototypes/mu_cosine/pt_sections.py
@@ -88,27 +88,74 @@ def fuzzy_mode(text, threshold=0.78):
     return (best_cat, best) if best >= threshold else (None, best)
 
 
-def categorize(text, method="exact_phrase", fuzzy_threshold=0.78):
-    """Section label → (category, method, confidence). Escalation: `exact_phrase` always tries the literal
-    match first (confidence 1.0); `fuzzy` additionally falls back to an edit-distance match (a confident
-    fuzzy hit is treated as a LABEL — confidence 1.0 — with provenance `fuzzy`, so it can be audited/
-    down-weighted). `llm_template` is the next layer (not yet implemented)."""
-    segs = _segments(text)                                 # leading "tag" (before `-- qualifier`), then full
+# EMBEDDING (semantic) layer — the escalation after exact + fuzzy. Catches SYNONYMS / PARAPHRASES that share
+# no edit-distance with a keyword (`Members`, `Narrower areas`, `Parent concepts`). Each category has a few
+# canonical EXEMPLARS; a label is e5-encoded and cosine-matched (best per category). Calibration on the real
+# harvest (REPORT_section_embedding.md) showed the post-fuzzy residual is mostly TOPICAL/junk sitting in a
+# narrow cosine band where `see also` is a generic attractor — so this layer uses a CONSERVATIVE
+# threshold + a 1st-vs-2nd MARGIN gate to reject that pack, and an embedding hit carries confidence = the
+# cosine (a GRADED, <1.0 tier — a soft relation prior feeding the operator-noise model, not a hard label).
+EMBED_EXEMPLARS = {
+    "element_of":    ["members", "elements", "instances", "subtopics", "things filed here"],
+    "subcategory":   ["subcategories", "narrower categories", "child categories", "more specific topics"],
+    "super_category": ["super categories", "broader categories", "parent categories", "more general topics"],
+    "see_also":      ["see also", "related topics", "cross references", "associated pages"],
+    "reference":     ["references", "sources", "further reading", "bibliography", "external links"],
+}
+
+
+def embed_mode(text, encoder, threshold=0.88, margin=0.02):
+    """Semantic match of a section label to the nearest category EXEMPLAR set → (category, cosine), or
+    (None, best) when the top cosine is below `threshold` OR within `margin` of the 2nd category (ambiguous,
+    likely a topical name). `encoder(texts)->[N,384]` unit-normed (see section_embed.e5_encoder); the label
+    is the `query:`, exemplars are `passage:` (e5's asymmetric prefixes)."""
+    import numpy as np
+    t = _norm(text)
+    if not t:
+        return (None, 0.0)
+    cats = list(EMBED_EXEMPLARS)
+    ex = [e for c in cats for e in EMBED_EXEMPLARS[c]]
+    vecs = np.asarray(encoder(["query: " + t] + ["passage: " + e for e in ex]))
+    sims = vecs[1:] @ vecs[0]
+    per, i = [], 0
+    for c in cats:
+        n = len(EMBED_EXEMPLARS[c])
+        per.append((float(sims[i:i + n].max()), c)); i += n
+    per.sort(reverse=True)
+    (best, best_cat), second = per[0], (per[1][0] if len(per) > 1 else -1.0)
+    return (best_cat, best) if (best >= threshold and best - second >= margin) else (None, best)
+
+
+def categorize(text, method="exact_phrase", fuzzy_threshold=0.78, encoder=None,
+               embed_threshold=0.88, embed_margin=0.02):
+    """Section label → (category, method, confidence). Escalation ladder (cheap→expensive, each catching what
+    the previous misses): `exact_phrase` literal match (conf 1.0) → `fuzzy` edit-distance (conf 1.0, audited)
+    → `embedding` semantic match (conf = cosine, a GRADED <1.0 tier; needs `encoder`). A given `method`
+    runs that rung and all cheaper ones."""
+    if method not in ("exact_phrase", "fuzzy", "embedding"):
+        raise ValueError(f"unknown categorization method: {method!r} (have: exact_phrase, fuzzy, embedding)")
+    segs = _segments(text)                                 # each dash/paren segment (tag & qualifier), then full
     for s in segs:
         cat = section_mode(s)
         if cat:
             return (cat, "exact_phrase", 1.0)
-    if method == "fuzzy":
+    if method in ("fuzzy", "embedding"):
         for s in segs:
             fcat, r = fuzzy_mode(s, fuzzy_threshold)
             if fcat:
                 return (fcat, "fuzzy", 1.0)
-    elif method != "exact_phrase":
-        raise ValueError(f"unknown categorization method: {method!r} (have: exact_phrase, fuzzy)")
+    if method == "embedding":
+        if encoder is None:
+            raise ValueError("method='embedding' needs an encoder (section_embed.e5_encoder())")
+        for s in segs:
+            ecat, sim = embed_mode(s, encoder, embed_threshold, embed_margin)
+            if ecat:
+                return (ecat, "embedding", round(float(sim), 3))
     return (None, method, 0.0)
 
 
-def relation_for(text, method="exact_phrase", fuzzy_threshold=0.78):
+def relation_for(text, method="exact_phrase", fuzzy_threshold=0.78, encoder=None,
+                 embed_threshold=0.88, embed_margin=0.02):
     """Convenience: section label → (relation, method, confidence). `relation` is None when no rule fires."""
-    cat, m, conf = categorize(text, method, fuzzy_threshold)
+    cat, m, conf = categorize(text, method, fuzzy_threshold, encoder, embed_threshold, embed_margin)
     return (CATEGORY_RELATION.get(cat), m, conf)

--- a/prototypes/mu_cosine/section_embed.py
+++ b/prototypes/mu_cosine/section_embed.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""e5 encoder for the EMBEDDING section-categorisation layer — the semantic escalation after exact + fuzzy
+(pt_sections.py). Lexical fuzzy catches TYPOS (`Subtoipcs`); this catches SYNONYMS / PARAPHRASES a section
+author might use that share no edit-distance with the canonical keyword (`Members`, `Narrower areas`,
+`Parent concepts`, `Things filed here`). Kept in a SEPARATE module so `pt_sections.py` stays stdlib-only and
+torch-free — `categorize(..., method="embedding", encoder=…)` takes the encoder as an injected callable.
+
+The encoder mirrors `mu_attention.build_e5_tables`: the same frozen `intfloat/e5-small-v2`, the same
+asymmetric `query:` / `passage:` prefixes (the section label is the query; the canonical relation exemplars
+are passages), unit-normalised. Loads OFFLINE from the HF cache (no egress)."""
+import functools
+import os
+
+E5_MODEL = "intfloat/e5-small-v2"
+
+
+@functools.lru_cache(maxsize=2)
+def _model(model_name=E5_MODEL, device=None):
+    os.environ.setdefault("HF_HUB_OFFLINE", "1")            # use the local cache only — no network
+    os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+    from sentence_transformers import SentenceTransformer
+    return SentenceTransformer(model_name, device=device)
+
+
+def e5_encoder(model_name=E5_MODEL, device=None, batch_size=64):
+    """Return a callable `encode(texts) -> [N, 384] unit-normed numpy array`. Texts are expected to already
+    carry their `query: ` / `passage: ` prefix (the caller decides which is which). The model is loaded once
+    and cached."""
+    model = _model(model_name, device)
+
+    def encode(texts):
+        return model.encode(list(texts), batch_size=batch_size, convert_to_numpy=True,
+                            normalize_embeddings=True, show_progress_bar=False)
+
+    return encode
+
+
+if __name__ == "__main__":                                 # smoke: encode a couple of phrases, print a cosine
+    enc = e5_encoder()
+    v = enc(["query: members of this category", "passage: members", "passage: broader categories"])
+    print("cos(label, 'members')        =", float(v[1] @ v[0]))
+    print("cos(label, 'broader cats')   =", float(v[2] @ v[0]))

--- a/prototypes/mu_cosine/test_pt_sections.py
+++ b/prototypes/mu_cosine/test_pt_sections.py
@@ -1,7 +1,35 @@
 #!/usr/bin/env python3
-"""Tests for pt_sections section categorisation: exact + the fuzzy (typo-robust) method. Pure-Python
-(torch-free). Run: `python3 test_pt_sections.py`."""
-from pt_sections import categorize, fuzzy_mode, section_mode, CATEGORY_RELATION
+"""Tests for pt_sections categorisation: exact + fuzzy (typo) + embedding (semantic, via a STUB encoder so
+no model/torch is needed; numpy only). Run: `python3 test_pt_sections.py`."""
+import numpy as np
+
+from pt_sections import categorize, embed_mode, fuzzy_mode, section_mode, CATEGORY_RELATION
+
+
+def _stub_encoder():
+    """A deterministic stand-in for e5: map keyword presence to one of 5 orthonormal category axes (else a
+    neutral vector). Lets us test the embed_mode wiring (per-category max, threshold + margin gate,
+    escalation order) without loading the real model."""
+    keymap = [(["member", "element", "instance", "subtopic"], 0),
+              (["subcategor", "narrower", "child"], 1),
+              (["super", "broader", "parent", "general"], 2),
+              (["see also", "related", "cross", "associat"], 3),
+              (["reference", "source", "reading", "bibliograph", "link", "extern"], 4)]
+
+    def enc(texts):
+        out = []
+        for t in texts:
+            tl = t.lower(); v = np.zeros(5)
+            for keys, ax in keymap:
+                for k in keys:
+                    if k in tl:
+                        v[ax] += 1.0
+            if v.sum() == 0:
+                v = np.ones(5)                            # neutral ⇒ low cosine (0.45) to every single axis
+            out.append(v / np.linalg.norm(v))
+        return np.array(out)
+
+    return enc
 
 
 def test_exact_unchanged():
@@ -53,6 +81,41 @@ def test_tag_qualifier_pattern():
 def test_threshold_is_tunable():
     assert categorize("Subtoipcs", "fuzzy", fuzzy_threshold=0.99)[0] is None   # raise the bar ⇒ no match
     assert categorize("Subtoipcs", "fuzzy", fuzzy_threshold=0.70)[0] == "element_of"
+
+
+def test_embedding_paraphrase_rescue():
+    # semantic matches that share NO edit-distance with a keyword (so fuzzy misses) — caught by embedding.
+    enc = _stub_encoder()
+    assert categorize("Narrower areas", "embedding", encoder=enc)[:2] == ("subcategory", "embedding")
+    assert categorize("Parent concepts", "embedding", encoder=enc)[0] == "super_category"
+    assert categorize("External links here", "embedding", encoder=enc)[0] == "reference"
+    assert categorize("The members", "embedding", encoder=enc)[0] == "element_of"
+
+
+def test_embedding_rejects_topical():
+    # a topical/content name (no relation keyword) must NOT be forced into a relation (the real-harvest risk)
+    enc = _stub_encoder()
+    for label in ["Quantum mechanics", "Thermodynamics", "Vector calculus"]:
+        assert categorize(label, "embedding", encoder=enc)[0] is None, label
+
+
+def test_embedding_escalation_order():
+    # embedding is the LAST rung — exact and fuzzy still win when they fire
+    enc = _stub_encoder()
+    assert categorize("Subcategories", "embedding", encoder=enc) == ("subcategory", "exact_phrase", 1.0)
+    assert categorize("Subtoipcs", "embedding", encoder=enc)[:2] == ("element_of", "fuzzy")
+    # and a missing encoder is an explicit error, not a silent miss
+    try:
+        categorize("Members", "embedding"); assert False
+    except ValueError:
+        pass
+
+
+def test_embedding_margin_gate():
+    # a label aligned EQUALLY to two categories is ambiguous (likely topical) ⇒ rejected by the margin gate
+    enc = _stub_encoder()
+    assert embed_mode("members narrower", enc, threshold=0.7, margin=0.05)[0] is None    # tie ⇒ rejected
+    assert embed_mode("members narrower", enc, threshold=0.7, margin=0.0)[0] is not None  # gate off ⇒ a pick
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
exact → fuzzy → embedding escalation (e5, offline). Calibrated live: the post-fuzzy residual is mostly topical/junk in a narrow cosine band, so a conservative threshold+margin gate rejects it (1/28 rescued, all junk rejected). Near-neutral on current data (the lexical layers already capture the signal); value is safety/readiness for paraphrase-rich corpora + a reusable encoder. pt_sections stays stdlib-only; torch-free stub tests.