### PR TITLE
 mu_cosine: --early-stop (held-out graded MSE, keep best) + 4L/0.7 base

### DIFF
--- a/prototypes/mu_cosine/REPORT_4l_base_train.md
+++ b/prototypes/mu_cosine/REPORT_4l_base_train.md
@@ -1,0 +1,47 @@
+# 4-layer / 0.7-confidence base model — first training run (and an overtraining flag)
+
+The first real training of the chosen **4L / `--blend-tagged-conf 0.7`** config (per
+`REPORT_capacity_conf_tradeoff.md` + the design dialogue) — the base we intend to **build up by
+fine-tuning** as new Pearltrees harvests + mindmap bridges arrive.
+
+## Run
+```
+train_mu_attention.py --graded context/graded_cx_pairs.tsv \
+  --init-from model_nodetype.pt --use-nodetype --layers 4 \
+  --infer-blend --blend-tagged-conf 0.7 --steps 1500 --bs 128 --seed 1 \
+  --save model_4l_blend07.pt
+```
+- Warm-started from the 3-layer `model_nodetype.pt` (3 shared layers + heads loaded; **4th layer
+  random-init**, fine-tuned).
+- Graded round: 2865 train / 505 held-out; **115 inferred** rows (the fuzzy-unlabelled residual) trained via
+  the posterior blend, tagged rows regularised at `c=0.7`.
+- Artifact: `model_4l_blend07.pt` (gitignored; regenerable).
+
+## Result
+
+| metric | this run (4L/0.7, 1500 steps) | 4L/0.7 A/B reference (700 steps) |
+|---|---|---|
+| multi-domain discrimination | **100% (25/25)** | 97.3% (mean) |
+| WIKI held-out order-acc | 99.9% | 99.8% |
+| **SYM held-out corr** | **+0.554** | **+0.689** (range 0.63–0.77) |
+
+## The flag: 1500 steps OVERTRAINED relative to 700
+Discrimination saturated at 100% while **SYM held-out dropped to +0.554 — below every 700-step A/B seed.**
+That is the in-distribution-up / held-out-down signature of mild overfitting: the extra 800 steps bought a
+perfect discrimination probe at the cost of SYM generalisation. (SYM is a noisy 40-positive held-out set, so
+some of the gap is noise — but 0.554 is *outside* the A/B range, so it is partly real.)
+
+**Recommendation for the production base:** train **fewer steps (~700–900)** — or add early-stopping on the
+SYM held-out corr — so the base starts from a better-generalising point. The current 1500-step model is
+usable (disc/WIKI are strong) and SYM should partly recover under fine-tuning, but a shorter base is the
+cleaner starting point for the build-up-by-fine-tuning plan.
+
+## Next
+- (Recommended) re-save the base at ~700–900 steps for better SYM generalisation.
+- Begin the **fine-tuning arc**: fold each new harvested Pearltrees tree + bridged mindmap into the graded
+  round and continue-train from this base — the 4th layer trains up gradually across rounds (dissolving the
+  random-init handicap), and `c` can be tightened from 0.7 toward 0.85 as data grows.
+- The ~30 fuzzy-unlabelled section labels are mostly **topical content sections** (correctly inferred, not a
+  parser failure) + a little Pearltrees nav junk + ~4 genuinely ambiguous (`Courses`/`Links`/`Papers`/
+  `course material`) — the only candidates worth an LLM pass, and only if a cheap source-side triage doesn't
+  resolve them first.

--- a/prototypes/mu_cosine/REPORT_4l_base_train.md
+++ b/prototypes/mu_cosine/REPORT_4l_base_train.md
@@ -31,10 +31,31 @@ That is the in-distribution-up / held-out-down signature of mild overfitting: th
 perfect discrimination probe at the cost of SYM generalisation. (SYM is a noisy 40-positive held-out set, so
 some of the gap is noise — but 0.554 is *outside* the A/B range, so it is partly real.)
 
-**Recommendation for the production base:** train **fewer steps (~700–900)** — or add early-stopping on the
-SYM held-out corr — so the base starts from a better-generalising point. The current 1500-step model is
-usable (disc/WIKI are strong) and SYM should partly recover under fine-tuning, but a shorter base is the
-cleaner starting point for the build-up-by-fine-tuning plan.
+## Early stopping — implemented and applied (the fix)
+Added `--early-stop` (`--eval-every`, `--patience`): every N steps, eval the **held-out graded MSE** (the
+505-target hold-out — the largest, most stable held-out set), keep the **best** checkpoint (not the last),
+stop after `patience` evals without improvement. It's the targeted anti-overtraining lever *and* the standing
+safeguard for the fine-tuning arc (each small increment overfits fast; this auto-finds the stop per round).
+
+Re-trained the base with it (`--steps 2000 --eval-every 100 --patience 6`): held-out graded MSE bottomed at
+**step 1400 (0.0276)** then climbed, so it stopped at 2000 and **reloaded best @ 1400**. The saved
+`model_4l_blend07.pt` is now that best checkpoint:
+
+| metric | 1500 steps (overtrained) | **early-stop, best @ 1400** |
+|---|---|---|
+| discrimination | 100% | **100%** |
+| WIKI order-acc | 99.9% | 99.8% |
+| SYM held-out | +0.554 | **+0.583** |
+| held-out graded MSE | — | **0.0276** |
+
+### Nuance: the stop-SIGNAL matters (graded MSE vs SYM peak at different steps)
+Early-stop on graded MSE recovered SYM (0.554 → 0.583) but **not** all the way to the 700-step A/B's ~0.689.
+Reason: the graded held-out MSE is roughly **flat (and noisy) from ~700 to 1400** (0.0339 → 0.0276, mostly
+noise), while the SYM-specific corr *degrades* over that same range — i.e. **SYM peaks earlier (~700) than
+the graded objective.** Optimising graded MSE therefore picks a later point than SYM alone would. The graded
+hold-out (505) is the more reliable signal and the main objective, so we keep it as the default; if SYM is
+the priority, a **composite criterion** (graded MSE + SYM corr, or stop on SYM) would land ~700 and trade a
+sliver of graded fit for ~+0.1 SYM. Left as an easy knob, not changed by default.
 
 ## Next
 - (Recommended) re-save the base at ~700–900 steps for better SYM generalisation.

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -175,6 +175,23 @@ def mu_batch(model, tok, items, bs=256):
 
 
 @torch.no_grad()
+def graded_hold_mse(model, tok, graded_hold, use_nodetype):
+    """Overall held-out graded MSE (μ vs calibrated target) — the early-stopping signal. The 15% graded
+    hold-out is the largest, most stable held-out set (vs SYM's ~40), and it IS the training objective."""
+    was_training = model.training
+    model.eval()
+    if use_nodetype:
+        items = [(r[0], r[1], OPS[r[3]], CORPORA[r[7]], JUDGES[r[8]], nt(r[5]), nt(r[6])) for r in graded_hold]
+    else:
+        items = [(r[0], r[1], OPS[r[3]], CORPORA[r[7]], JUDGES[r[8]]) for r in graded_hold]
+    pred = mu_batch(model, tok, items).tolist()
+    tgt = [r[2] for r in graded_hold]
+    if was_training:
+        model.train()
+    return sum((pred[i] - tgt[i]) ** 2 for i in range(len(tgt))) / max(1, len(tgt))
+
+
+@torch.no_grad()
 def emit_dense(model, tok, names, op, root="Physics", bs=512):
     items = [(n, root, OPS[op]) for n in names]
     mu = mu_batch(model, tok, items, bs)
@@ -401,6 +418,7 @@ def train(args):
 
     eps = 1e-6
     bce = lambda x, t: F.binary_cross_entropy(x.clamp(eps, 1 - eps), torch.full_like(x, float(t)))
+    es_best, es_best_step, es_wait, es_saved = float("inf"), 0, 0, False   # early-stopping state
     for step in range(args.steps):
         model.train()
         opt.zero_grad()
@@ -508,6 +526,23 @@ def train(args):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
         opt.step()
+        # EARLY STOPPING: track the best held-out graded MSE, save the BEST checkpoint, stop after patience.
+        if args.early_stop and graded_hold and not args.sym_only and (step + 1) % args.eval_every == 0:
+            vmse = graded_hold_mse(model, tok, graded_hold, args.use_nodetype)
+            if vmse < es_best - 1e-5:
+                es_best, es_best_step, es_wait = vmse, step + 1, 0
+                if args.save:
+                    torch.save({"state": model.state_dict(), "cfg": {"d_model": q.shape[1],
+                                "heads": args.heads, "layers": args.layers}}, args.save)
+                    es_saved = True
+            else:
+                es_wait += 1
+            print(f"  [early-stop] step {step+1:5d}  held-out graded MSE {vmse:.4f}  "
+                  f"(best {es_best:.4f} @ {es_best_step}, wait {es_wait}/{args.patience})")
+            if es_wait >= args.patience:
+                print(f"  [early-stop] no improvement for {args.patience} evals — stop at step {step+1}; "
+                      f"best @ {es_best_step}")
+                break
         if (step + 1) % max(1, args.steps // 6) == 0:
             print(f"  step {step+1:5d}  L_sym {float(L_sym):.4f}  L_wiki {float(L_wiki):.4f}"
                   + (f"  L_elem {float(L_elem):.4f}" if (elem_tr and not args.sym_only) else "")
@@ -515,10 +550,14 @@ def train(args):
                   + (f"  L_blend {float(L_blend):.4f}" if blend_on else "")
                   + (f"  L_llm {float(L_llm):.4f}" if (llm and not args.sym_only) else ""))
 
+    if es_saved:                                          # early-stop kept the BEST — validate THAT, not the last
+        ck = torch.load(args.save, weights_only=False)
+        model.load_state_dict(ck["state"])
+        print(f"\n[early-stop] reloaded best checkpoint (held-out graded MSE {es_best:.4f} @ step {es_best_step})")
     model.eval()
     validate(model, tok, names, idx, adj, edges_hold, pos_hold, llm, args, elem_hold=elem_hold,
              graded_hold=graded_hold)
-    if args.save:
+    if args.save and not es_saved:                        # early-stop already saved the best; else save the final
         torch.save({"state": model.state_dict(), "cfg": {"d_model": q.shape[1], "heads": args.heads,
                     "layers": args.layers}}, args.save)
         print(f"\nsaved model → {args.save}")
@@ -765,6 +804,10 @@ def node_gated_lin_agreement(model, tok, idx):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--steps", type=int, default=1200)
+    ap.add_argument("--early-stop", action="store_true", help="stop when the held-out graded MSE stops "
+                    "improving; keep the BEST checkpoint (not the last). The targeted anti-overtraining fix.")
+    ap.add_argument("--eval-every", type=int, default=100, help="early-stop: eval the held-out graded MSE every N steps")
+    ap.add_argument("--patience", type=int, default=6, help="early-stop: stop after this many evals with no improvement")
     ap.add_argument("--bs", type=int, default=128)
     ap.add_argument("--lr", type=float, default=1e-3)
     ap.add_argument("--weight-decay", type=float, default=0.01)


### PR DESCRIPTION
--early-stop evals the 505-target held-out graded MSE every N steps, keeps the BEST checkpoint,  stops after patience — targeted anti-overtraining fix and the standing safeguard for the fine-tuning arc  (auto-finds the per-round stop). 4L/0.7 base trained with it; the 1500-step run overtrained SYM (0.554), early-stop recovered it (0.583), and the 6-source fine-tune reached SYM 0.671 / disc 100% (stopped @ 100).