### PR TITLE
mu_cosine: anchored-basis attention module (DESIGN §8 prototype, step 1)

### DIFF
--- a/prototypes/mu_cosine/anchored_basis.py
+++ b/prototypes/mu_cosine/anchored_basis.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Anchored-basis attention over the relation space (DESIGN_inferred_operator_superposition.md §8/§8b) —
+the open-set generalisation of the operator superposition.
+
+The relation basis is two-part: **frozen, label-tied ANCHORS** (one per principle tag) ++ **K learnable
+residual ATOMS** (the unnamed/out-of-set relations). Realised as ATTENTION (§1b): each basis entry is a
+(key, value) pair —
+  * query   = the μ-feature vector,
+  * keyᵢ    = sets how much entry i fires:  wᵢ = softmax(q_proj(query)·keyᵀ)ᵢ,
+  * valueᵢ  = entry i's contribution to the token:  token = Σ wᵢ·valueᵢ.
+
+Anchors: VALUE frozen (seeded from the e5 phrase embedding — stable, interpretable), KEY learnable but
+CALIBRATED by the anchor-confidence KL (labels teach *when* it fires; *what* it contributes stays pinned).
+Atoms: key AND value learnable — they compete with the anchors in the same softmax for the residual mass.
+
+Weights are a finite categorical on a simplex (no integration). This module is the basis; wiring it into the
+trainer's blend path + the grow/prune controller are the next increments."""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class AnchoredBasis(nn.Module):
+    def __init__(self, anchor_values, n_atoms=5, d_query=6, d_k=64, atom_init=0.02):
+        """anchor_values: [A, d_model] FROZEN value embeddings (e5 phrase seeds). n_atoms K: learnable atoms."""
+        super().__init__()
+        n_anchors, d_model = anchor_values.shape
+        self.n_anchors, self.n_atoms, self.d_model = n_anchors, n_atoms, d_model
+        self.register_buffer("anchor_values", anchor_values.clone())        # FROZEN (not a Parameter)
+        self.anchor_keys = nn.Parameter(torch.randn(n_anchors, d_k) * atom_init)   # learnable, KL-calibrated
+        self.atom_keys = nn.Parameter(torch.randn(max(n_atoms, 0), d_k) * atom_init)
+        self.atom_values = nn.Parameter(torch.randn(max(n_atoms, 0), d_model) * atom_init)
+        self.q_proj = nn.Linear(d_query, d_k)
+
+    def _keys_values(self):
+        if self.n_atoms:
+            return (torch.cat([self.anchor_keys, self.atom_keys], 0),
+                    torch.cat([self.anchor_values, self.atom_values], 0))
+        return self.anchor_keys, self.anchor_values
+
+    def forward(self, query):
+        """query [B, d_query] → (token [B, d_model], weights [B, A+K] on the simplex)."""
+        keys, values = self._keys_values()
+        w = F.softmax(self.q_proj(query) @ keys.t(), dim=-1)            # finite categorical, sums to 1
+        return w @ values, w
+
+    def anchor_kl(self, w, anchor_target):
+        """KL( renormalised anchor weights ‖ label-confidence target ) — pins the anchor block to the labels.
+        anchor_target [B, A] is the confidence-calibrated distribution over anchors for labelled rows."""
+        a = w[:, :self.n_anchors]
+        a = a / a.sum(-1, keepdim=True).clamp_min(1e-9)
+        return F.kl_div((a + 1e-9).log(), anchor_target, reduction="batchmean")
+
+    @torch.no_grad()
+    def utilization(self, w):
+        """Per-entry mean mass-share (the grow/prune signal, §8b). atom_mass near 0 ⇒ prunable;
+        all-saturated + gap-open ⇒ grow."""
+        m = w.mean(0)
+        return {"anchor_mass": m[:self.n_anchors].tolist(),
+                "atom_mass": m[self.n_anchors:].tolist()}

--- a/prototypes/mu_cosine/test_anchored_basis.py
+++ b/prototypes/mu_cosine/test_anchored_basis.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Tests for the anchored-basis attention module (DESIGN §8/§8b/§1b). Needs torch.
+Run: `python3 test_anchored_basis.py`."""
+import torch
+
+from anchored_basis import AnchoredBasis
+
+
+def test_shapes_and_simplex():
+    ab = AnchoredBasis(torch.randn(4, 384), n_atoms=5, d_query=6, d_k=64)
+    q = torch.randn(8, 6)
+    token, w = ab(q)
+    assert token.shape == (8, 384)
+    assert w.shape == (8, 4 + 5)
+    assert torch.allclose(w.sum(-1), torch.ones(8), atol=1e-5)      # simplex: weights sum to 1
+    assert (w >= 0).all()                                          # positive
+
+
+def test_anchor_values_frozen_atoms_learn():
+    ab = AnchoredBasis(torch.randn(4, 384), n_atoms=5, d_query=6, d_k=64)
+    # anchor_values is a buffer (frozen), not in parameters; atoms + keys + q_proj are
+    names = {n for n, _ in ab.named_parameters()}
+    assert "anchor_values" not in names                            # frozen value block
+    assert "atom_values" in names and "atom_keys" in names and "anchor_keys" in names
+    token, w = ab(torch.randn(8, 6))
+    token.sum().backward()
+    assert ab.atom_values.grad is not None and ab.atom_values.grad.abs().sum() > 0
+    assert ab.anchor_keys.grad is not None                         # keys are learnable (KL-calibrated)
+
+
+def test_anchor_kl_and_utilization():
+    ab = AnchoredBasis(torch.randn(4, 384), n_atoms=5, d_query=6, d_k=64)
+    _, w = ab(torch.randn(8, 6))
+    tgt = torch.full((8, 4), 0.25)                                 # uniform anchor target
+    kl = ab.anchor_kl(w, tgt)
+    assert kl.shape == () and torch.isfinite(kl)
+    u = ab.utilization(w)
+    assert len(u["anchor_mass"]) == 4 and len(u["atom_mass"]) == 5
+    total = sum(u["anchor_mass"]) + sum(u["atom_mass"])
+    assert abs(total - 1.0) < 1e-4                                 # mean mass-shares sum to 1
+
+
+def test_zero_atoms_is_k0_special_case():
+    ab = AnchoredBasis(torch.randn(4, 384), n_atoms=0, d_query=6, d_k=64)   # §8: K=0 = anchors-only
+    token, w = ab(torch.randn(8, 6))
+    assert w.shape == (8, 4) and token.shape == (8, 384)
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"  ok  {t.__name__}")
+    print(f"all {len(tests)} anchored_basis tests passed")


### PR DESCRIPTION
AnchoredBasis nn.Module — frozen e5-seeded anchor values (buffer) ++ K learnable atoms (key+value) ++ learnable-but-KL-calibrated anchor keys. forward(query)->(token, simplex weights); anchor_kl() pins the anchor block; utilization() exposes per-entry mass-share (grow/prune signal). K=0 = anchors-only. 4/4 torch tests. Next: wire into the trainer blend path, anchor-KL on labelled rows, A/B vs K=0, then grow/prune.