### PR TITLE
WAM-Clojure: fix backtracking + add ClojureScript transpile (runs in Scittle)

### DIFF
--- a/src/unifyweaver/targets/clojurescript_target.pl
+++ b/src/unifyweaver/targets/clojurescript_target.pl
@@ -117,7 +117,12 @@ cljs_interop_rules([
     'Float/parseFloat'-'js/parseFloat',
     % --- Math host object: specific first, then generic prefix ---
     'Math/abs'-'js/Math.abs',
+    'Math/rint'-'js/Math.round',   % JS has no Math.rint; round is fine for the integral test
     'Math/'-'js/Math.',
+    % --- integer coercion: CLJS has no (long x) ---
+    '(long '-'(js/Math.trunc ',
+    % --- JVM type hints are meaningless in CLJS ---
+    '^String '-'',
     % --- exceptions: JS has no java.lang.Exception ---
     '(catch Exception '-'(catch :default ',
     '(.getMessage '-'(.-message ',

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -16,6 +16,7 @@
 :- module(wam_clojure_target, [
     compile_wam_predicate_to_clojure/4,  % +Pred/Arity, +WamCode, +Options, -ClojureCode
     write_wam_clojure_project/3,         % +Predicates, +Options, +ProjectDir
+    write_wam_clojurescript_files/3,     % +Predicates, +Options, +OutDir (runtime.cljs + core.cljs)
     clojure_foreign_predicate/3,         % +Pred, +Arity, +Options
     prepare_wam_clojure_lmdb_runtime_support/2, % +ProjectDir, +Options
     clojure_lmdb_reader_open_expr/3,     % +PathLiteral, +Options, -Expr
@@ -33,6 +34,53 @@
     lower_predicate_to_clojure/4,
     clojure_lowered_func_name/2
 ]).
+:- use_module('../targets/clojurescript_target', [clojurescript_interop_rewrite/2]).
+:- use_module(library(readutil), [read_file_to_string/3]).
+
+%% write_wam_clojurescript_files(+Predicates, +Options, +OutDir)
+%  Transpile predicates to ClojureScript that runs under Scittle/SCI (browser) or
+%  nbb. Generates the JVM WAM-Clojure project, then rewrites the JVM host interop
+%  (Integer/parseInt, Math/rint, (long ...), catch Exception, ...) into JS interop
+%  via the ClojureScript target's rewriter, writing OutDir/runtime.cljs and
+%  OutDir/core.cljs. The runtime's format/Character/Pattern usage is already
+%  portable in the template. core's CLI -main (edn-based) is dropped — the browser
+%  drives predicates directly via invoke-predicate. The two namespaces cross-
+%  require (SCI resolves a require of a namespace defined by a prior eval).
+write_wam_clojurescript_files(Predicates, Options, OutDir) :-
+    option(namespace(BaseNamespace), Options, 'generated.wam'),
+    make_directory_path(OutDir),
+    directory_file_path(OutDir, '.wamclj_tmp', TmpDir),
+    write_wam_clojure_project(Predicates, Options, TmpDir),
+    atomic_list_concat(NsParts, '.', BaseNamespace),
+    atomic_list_concat(NsParts, '/', NsPath),
+    format(atom(RuntimeClj), "~w/src/~w/runtime.clj", [TmpDir, NsPath]),
+    format(atom(CoreClj),    "~w/src/~w/core.clj",    [TmpDir, NsPath]),
+    % runtime.cljs
+    read_file_to_string(RuntimeClj, RuntimeSrc, []),
+    clojurescript_interop_rewrite(RuntimeSrc, RuntimeCljs),
+    format(atom(RuntimeOut), "~w/runtime.cljs", [OutDir]),
+    write_text_file(RuntimeOut, RuntimeCljs),
+    % core.cljs (drop CLI -main + its edn require — JVM/CLI only)
+    read_file_to_string(CoreClj, CoreSrc0, []),
+    wamcljs_strip_main(CoreSrc0, CoreSrc1),
+    wamcljs_replace(CoreSrc1, "[clojure.edn :as edn]", "", CoreSrc2),
+    clojurescript_interop_rewrite(CoreSrc2, CoreCljs),
+    format(atom(CoreOut), "~w/core.cljs", [OutDir]),
+    write_text_file(CoreOut, CoreCljs).
+
+wamcljs_strip_main(In, Out) :-
+    ( sub_string(In, B, _, _, "(defn -main")
+    ->  sub_string(In, 0, B, _, Out)
+    ;   Out = In ).
+
+wamcljs_replace(In, From, To, Out) :-
+    ( sub_string(In, _, _, _, From)
+    ->  atomic_list_concat(Parts, From, In),
+        atomic_list_concat(Parts, To, Out)
+    ;   Out = In ).
+
+write_text_file(Path, Text) :-
+    setup_call_cleanup(open(Path, write, S), write(S, Text), close(S)).
 
 %% write_wam_clojure_project(+Predicates, +Options, +ProjectDir)
 %  Generate a minimal hybrid/WAM Clojure project with:

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -26,7 +26,11 @@
 :- use_module(library(lists)).
 :- use_module(library(option)).
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
-:- use_module(library(process), [process_create/3, process_wait/2]).
+% library(process) is absent in swipl-wasm; only the LMDB runtime path uses it.
+% Load best-effort so this module still loads in the browser (Scittle/SciREPL);
+% process_create/3 throws existence_error at call time there, which is fine since
+% the browser transpile path never invokes it.
+:- catch(use_module(library(process), [process_create/3, process_wait/2]), _, true).
 :- use_module('../core/template_system', [render_template/3]).
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
 :- use_module('../targets/wam_clojure_lowered_emitter', [

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -39,7 +39,14 @@
     clojure_lowered_func_name/2
 ]).
 :- use_module('../targets/clojurescript_target', [clojurescript_interop_rewrite/2]).
-:- use_module(library(readutil), [read_file_to_string/3]).
+
+%% read_whole_file(+Path, -String)
+%  Read a file into a string using only core builtins (open/read_string) — avoids
+%  library(readutil), which is absent in swipl-wasm.
+read_whole_file(Path, String) :-
+    setup_call_cleanup(open(Path, read, S),
+                       read_string(S, _, String),
+                       close(S)).
 
 %% write_wam_clojurescript_files(+Predicates, +Options, +OutDir)
 %  Transpile predicates to ClojureScript that runs under Scittle/SCI (browser) or
@@ -60,12 +67,12 @@ write_wam_clojurescript_files(Predicates, Options, OutDir) :-
     format(atom(RuntimeClj), "~w/src/~w/runtime.clj", [TmpDir, NsPath]),
     format(atom(CoreClj),    "~w/src/~w/core.clj",    [TmpDir, NsPath]),
     % runtime.cljs
-    read_file_to_string(RuntimeClj, RuntimeSrc, []),
+    read_whole_file(RuntimeClj, RuntimeSrc),
     clojurescript_interop_rewrite(RuntimeSrc, RuntimeCljs),
     format(atom(RuntimeOut), "~w/runtime.cljs", [OutDir]),
     write_text_file(RuntimeOut, RuntimeCljs),
     % core.cljs (drop CLI -main + its edn require — JVM/CLI only)
-    read_file_to_string(CoreClj, CoreSrc0, []),
+    read_whole_file(CoreClj, CoreSrc0),
     wamcljs_strip_main(CoreSrc0, CoreSrc1),
     wamcljs_replace(CoreSrc1, "[clojure.edn :as edn]", "", CoreSrc2),
     clojurescript_interop_rewrite(CoreSrc2, CoreCljs),

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -796,10 +796,17 @@ namespace_relative_path(Namespace, RelativePath) :-
     ).
 
 read_template_file(Path, Content) :-
-    (   exists_file(Path)
-    ->  read_file_to_string(Path, Content, [])
+    (   template_abs_path(Path, Abs)
+    ->  read_whole_file(Abs, Content)
     ;   format(atom(Content), '; Template not found: ~w', [Path])
     ).
+
+%% template_abs_path(+RelPath, -AbsPath)
+%  Resolve a 'templates/...' path. In tests/CLI the cwd is the UnifyWeaver root,
+%  so the path resolves as-is. In swipl-wasm (SciREPL) the cwd is a notebook dir
+%  but the package is mounted at /user/, so fall back to /user/<path>.
+template_abs_path(Path, Path) :- exists_file(Path), !.
+template_abs_path(Path, Abs) :- atom_concat('/user/', Path, Abs), exists_file(Abs), !.
 
 write_file(Path, Content) :-
     open(Path, write, Stream),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -552,7 +552,8 @@
                 :else 2))
             (variable-key [v]
               (cond
-                (logic-var? v) (format "v%020d" (long (:var v)))
+                (logic-var? v) (let [s (str (:var v))]
+                                 (str "v" (subs "00000000000000000000" 0 (max 0 (- 20 (count s)))) s))
                 (keyword? v) (name v)
                 :else ""))
             (atom-key [v]
@@ -1804,7 +1805,7 @@
            (not= "" separator-text)
            (some? out-text))
       (let [segments (str/split out-text
-                                (re-pattern (java.util.regex.Pattern/quote separator-text))
+                                (re-pattern (str/replace separator-text #"[.*+?^${}()|\[\]\\]" (fn [m] (str "\\" m))))
                                 -1)
             [next-state list-term] (atomic-concat-list-term state segments)
             [ok unified-state] (unify-values next-state list-value list-term)]
@@ -1922,19 +1923,20 @@
       (backtrack state))))
 
 (defn char-type-class? [ch class-name]
-  (case class-name
-    "alpha" (Character/isLetter ch)
-    "alnum" (Character/isLetterOrDigit ch)
-    "digit" (Character/isDigit ch)
-    "upper" (Character/isUpperCase ch)
-    "lower" (Character/isLowerCase ch)
-    "whitespace" (Character/isWhitespace ch)
-    "space" (Character/isWhitespace ch)
-    "ascii" (<= (int ch) 127)
-    "punct" (and (<= (int ch) 127)
-                 (not (Character/isLetterOrDigit ch))
-                 (not (Character/isWhitespace ch)))
-    false))
+  ;; Portable char classification (JVM + ClojureScript): regex on (str ch)
+  ;; instead of JVM-only Character/* statics.
+  (let [s (str ch)]
+    (case class-name
+      "alpha" (boolean (re-find #"[A-Za-z]" s))
+      "alnum" (boolean (re-find #"[A-Za-z0-9]" s))
+      "digit" (boolean (re-find #"[0-9]" s))
+      "upper" (boolean (re-find #"[A-Z]" s))
+      "lower" (boolean (re-find #"[a-z]" s))
+      "whitespace" (boolean (re-find #"\s" s))
+      "space" (boolean (re-find #"\s" s))
+      "ascii" (boolean (re-find #"[\x00-\x7f]" s))
+      "punct" (boolean (re-find #"[!-/:-@\[-`{-~]" s))
+      false)))
 
 (defn char-type-code-arg [state type-value]
   (when (and (structure-term? type-value)

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -636,11 +636,15 @@
       (Double/parseDouble text)
       (Long/parseLong text))))
 
+(declare eval-arithmetic-term)
+
 (defn arithmetic-value [state value]
   (let [cur (deref-value (:bindings state) value)]
     (cond
       (number? cur) cur
       (atom-term? cur) (parse-numeric-atom (deintern-atom (:intern-context state) (:id cur)))
+      ;; compound arithmetic term (e.g. Q0+D0): evaluate it
+      (structure-term? cur) (eval-arithmetic-term state cur)
       :else nil)))
 
 (defn arithmetic-equal? [state left right]
@@ -2556,6 +2560,13 @@
     (if-not instr
       (backtrack state)
       (case (:op instr)
+        :raw
+        ;; switch_on_* are first-argument indexing hints; if unimplemented, fall
+        ;; through to the try_me_else clause chain (correct, just unindexed).
+        (if (re-find #"^switch_on_" (or (:text instr) ""))
+          (advance state)
+          (backtrack state))
+
         :get-constant
         (let [reg (:reg instr)
               constant (:constant instr)
@@ -2634,6 +2645,18 @@
                   (enter-unify-mode (:args reg-val))
                   advance)
               (backtrack state))
+
+            ;; WRITE mode: unbound register → build a fresh [H|T] cell, bind the
+            ;; register (var) to it, and read-unify against the fresh arg vars so
+            ;; the following unify-* instructions construct the list.
+            (or (logic-var? reg-val) (= reg-val ::unbound))
+            (let [[h s1] (fresh-var state)
+                  [t s2] (fresh-var s1)
+                  cell (structure-term list-functor [h t])
+                  s3 (if (logic-var? reg-val)
+                       (bind-var s2 reg-val cell)
+                       (reg-set-raw s2 (:reg instr) cell))]
+              (-> s3 (enter-unify-mode [h t]) advance))
 
             :else
             (backtrack state)))


### PR DESCRIPTION
## What
Makes the WAM-Clojure target produce **correct** code and adds a **ClojureScript
output path**, so Prolog can be transpiled to ClojureScript that runs in the SciREPL
Scittle kernel (or nbb). Validated end-to-end with n-queens.

## Changes (5 commits)
1. **Backtracking correctness** — n-queens returned wrong results (even on the JVM):
   - `switch_on_*` indexing ops were treated as failure → now advance to the
     `try_me_else` clause chain.
   - `arithmetic-value` now evaluates compound terms (e.g. `Q0+D0`).
   - `get-list` gains WRITE mode for unbound output registers (term construction).
2. **ClojureScript dialect** — `write_wam_clojurescript_files/3` emits `runtime.cljs`
   + `core.cljs`; the runtime template is made JVM/CLJS-portable
   (format/Character/Pattern) and the interop rewriter is extended
   (`Math/rint`→`js/Math.round`, `(long`→`(js/Math.trunc`, drop `^String`).
3–5. **swipl-wasm compatibility** (so the transpile runs in-app):
   - `library(process)` loaded best-effort (absent in swipl-wasm; only the unused
     LMDB path needs it).
   - read files via core `read_string` instead of `library(readutil)` (absent in wasm).
   - resolve `templates/...` under the `/user` mount, not cwd.

## Validation
- **JVM Clojure**: `queens_q(4,[2,4,1,3])`=true, `[3,1,4,2]`=true, `[1,2,3,4]`=false;
  select/permutation/safe all correct.
- **nbb (SCI)**: same results.
- **On-device (SciREPL Scittle)**: Prolog transpiles → `/shared/{runtime,core}.cljs`
  → synced to `sharedVFS` → Scittle runs queens correctly.

## Notes
- WAM front-end unchanged — the Scala target uses the same bytecode and its committed
  classic-programs test passes.
- The browser transpile path invokes no subprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)