### PR TITLE
mu_cosine: inferred-tail distributional augmentation — helps at ~30% tail-weight (§9–§14)

### DIFF
--- a/prototypes/mu_cosine/.gitignore
+++ b/prototypes/mu_cosine/.gitignore
@@ -39,3 +39,7 @@ mu_pairs_scored_pages_gaps_*_div.tsv
 .pt_cache/
 *_bridges.tsv
 *_fused_*.tsv
+# inferred-tail Haiku augmentation (score_inferred_tail.py): pearltrees-derived titles = private-tier,
+# kept LOCAL like context/. The expensive Haiku scores persist on disk but are not committed.
+inferred_tail*.tsv
+haiku_scored_tail.tsv

--- a/prototypes/mu_cosine/DESIGN_inferred_operator_superposition.md
+++ b/prototypes/mu_cosine/DESIGN_inferred_operator_superposition.md
@@ -590,3 +590,35 @@ several") to surface overlaps directly. Defer any numeric pairwise correlation u
 `mu_*` (REL_SPEC / Haiku for named, `mu_unknown` for atoms, 0 for `none`) → the per-cell μ feeding the target
 and the `expected` / `mc_expected` reducers (§12(1)/(6)). Haiku is the distribution **source**; the draw,
 the partition closure, and the expectation are all **ours** (§13).
+
+## 15. Implementation status & validated operating point (what this PR ships)
+This doc is largely a *proposal* record. This section maps it to what is actually **built/validated** here vs
+still **proposed**, and states the empirically-validated operating point. Empirical detail:
+`REPORT_haiku_tail_pilot.md`.
+
+### Validated operating point — `--tail-weight 6` (the *shipped* dilution fix, vs §13's ramp/self-posterior)
+§13 proposed forward-only fine-tuning + self-posterior + a ramp. **What was actually built and validated is
+simpler:** train on the (re-pooled) graded round and **upweight the inferred tail's loss via `--tail-weight`**.
+At its natural ~7% share the tail is drowned; **`--tail-weight 6` lifts it to ~30% effective share** (the §13
+target) → a **robust +0.12 held-out-tail corr lift (3-seed, sd 0.006)**. `--tail-weight 12` over-weights
+(inverted-U → the 3-layer capacity ceiling). **Recommended: `--tail-weight 6`.** Forward-only policy,
+self-posterior, and the ramp remain **proposed** — not needed for this result.
+
+### Build status by section
+| design element | status |
+|---|---|
+| §8 anchored basis (`anchored_basis.py`) | **BUILT + A/B-validated**, but NOT on the augmentation path (that uses `--haiku-tail`) |
+| §8b grow/prune K | **proposed** |
+| §9 Haiku-expectation training | **BUILT** as `--haiku-tail` (override inferred conf<1.0 targets with cached LLM **E[μ]** fwd/rev + judge). Self-posterior for the labelled bulk = **proposed** |
+| §10 disjoint partition | **BUILT** (`score_inferred_tail` closure applies++unknown++none→Σ1 + E[μ]); overlap-atom **promotion proposed** |
+| §11 sample-don't-feed-the-mean | `cell_sampler.py` = **tested reference** (sampler + analytic/MC reducers), **not wired into training**; the trainer uses the **deterministic E[μ] target** (the cheaper Jensen-biased form §11 names) — empirically sufficient |
+| §12 review resolutions | **BUILT** where code-touching: isolated RNG, `none` cell, sonnet/opus provenance; τ/MC-N live in `cell_sampler` |
+| §13 dilution fix | **BUILT** as `--tail-weight`; ramp/self-posterior/forward-only = proposed |
+| §14 Haiku prompt contract | **BUILT** in `score_inferred_tail.py` |
+| `--eval-tail` (tail instrument) | **BUILT** — model E[μ] (equal-weight superposition) vs held-out Haiku E[μ]; the only eval that sees the tail (base metrics saturate) |
+
+### Honest scope of the result
+The +0.12 lift is in the **agree-with-Haiku** frame (treatment trained on Haiku tail, judged vs held-out
+Haiku tail; non-leaking per §12(3), but not ground truth). The independent **Sonnet/human** check (provenance
+tagging + `score_inferred_tail.py flag` already support it; the sharp-disagreement set fits ~one query) is the
+next rigor tier.

--- a/prototypes/mu_cosine/DESIGN_inferred_operator_superposition.md
+++ b/prototypes/mu_cosine/DESIGN_inferred_operator_superposition.md
@@ -542,3 +542,51 @@ mostly already in place:
 **Headline:** forward 70/30 fine-tuning is the preferred lever (it dissolves the imbalance at its source);
 self-posterior + ramp are the refinement/fallback; and the cells are always drawn *by us* from Haiku's cached
 parameters, never by Haiku.
+
+## 14. Haiku prompt contract — the per-row output schema + the two non-normalisation rules
+
+What we ask Haiku for, per `(node, root)` pair. Haiku supplies **parameters**; *we* sample + close the
+partition (§13). One cached call per row serves both the training target and the eval reference (§9).
+
+### Output schema (per pair)
+For each **named relation R** (both directions where asymmetric):
+- `mu_fwd[R]`, `mu_rev[R]` ∈ [0,1] — **fuzzy membership**: how strongly `(node|root)` / `(root|node)` belongs
+  to R.
+- `applies[R]` ∈ [0,1] — how much of the "which relation is operative" mass goes to R.
+
+Plus two **open-world** slots for the leftover mass:
+- **`none`** — mass for *no relation* → we map μ≈0 (the §9 negative anchor).
+- **`unknown`** — mass for *a real relation NOT in the list* → routes to the §8/§10 learnable **atoms**
+  (novel positives); carries its own estimate `mu_unknown` > 0.
+
+### The two opposite non-normalisation rules (the crux — state both explicitly in the prompt)
+- **μ memberships MAY SUM TO MORE THAN 1.** They are independent fuzzy degrees, *not* a distribution;
+  overlapping relations (`element_of` ∧ `subcategory`) both fire at once. **Never normalise them down.**
+- **The named relation weights MAY SUM TO LESS THAN 1.** The remainder `1 − Σ applies[named]` is split between
+  **`none`** and **`unknown`**. **Never inflate the named relations to reach 1.** The full partition
+  `applies[named] ++ none ++ unknown` sums to 1 — *that* closure is **our** job (the §12(5) construction),
+  not Haiku's.
+
+> One principle, opposite directions: **μ → don't cap the sum at 1; weights → don't pad the named sum up to
+> 1.** No forced normalisation of either.
+
+### `none` vs `unknown` — why both buckets
+- `none` = no relation (μ≈0) → fixed negative anchor (§9).
+- `unknown` = relation present but unnamed (μ>0) → learnable atoms (§8/§10).
+
+Conflating them is a bug: `none` mass would pull novel relations toward 0; `unknown` mass would inflate true
+negatives. Payoff: **Haiku's `unknown` mass is the supervision signal for atom growth** — a region that
+persistently carries `unknown` with a distinct μ is the §8b grow trigger.
+
+### Correlations — NOT requested as numbers
+LLMs are uncalibrated for correlation coefficients, and coverage beats exact correlations for training (§11).
+Correlation is captured **structurally**: rows where two `applies[R]` co-clear τ become an **overlap cell**
+(§12(5)). Optionally ask Haiku for the **multi-label set** ("list every relation that applies, possibly
+several") to surface overlaps directly. Defer any numeric pairwise correlation until an inference need is
+*measured*.
+
+### How it feeds the pipeline
+`applies[named] ++ none ++ unknown` → the disjoint partition we sample (§12(5), `cell_sampler.sample_index`);
+`mu_*` (REL_SPEC / Haiku for named, `mu_unknown` for atoms, 0 for `none`) → the per-cell μ feeding the target
+and the `expected` / `mc_expected` reducers (§12(1)/(6)). Haiku is the distribution **source**; the draw,
+the partition closure, and the expectation are all **ours** (§13).

--- a/prototypes/mu_cosine/DESIGN_inferred_operator_superposition.md
+++ b/prototypes/mu_cosine/DESIGN_inferred_operator_superposition.md
@@ -499,3 +499,46 @@ step draws **one cell** from `P_Haiku(cell)` to feed+target. So: `τ` answers *"
 Haiku's mass). A row's `τ`-cell is its *dominant* cell; the draw additionally visits the lower-mass cells
 Haiku assigns (below `τ` but non-zero) for coverage (§11). Inference (6) samples from the same
 `P_Haiku(cell)` / model posterior over that fixed cell set.
+
+## 13. Data imbalance: forward 70/30 fine-tune policy (preferred), with self-posterior + ramp as fallback
+
+We have **far more label data than Haiku distributional data** (Haiku is budget-gated to the inferred tail).
+Naively pooling everything lets label *count* drown the distributional signal; forcing the scarce Haiku rows
+to a fixed 30% by re-weighting instead **overfits the tiny sample** (§12 variance). Both are symptoms of
+*pooling all history*. The clean fix is to not pool.
+
+### Who samples — Haiku gives parameters, WE draw (precision on §12(2)/(4)/(7))
+**Haiku is the distribution *source*, never the sampler.** Per row, Haiku supplies the **distributional
+parameters** `P_Haiku(cell)` (cached once, §9). The **training loop draws the cell** from those parameters
+using the dedicated isolated RNG (§12(4)). So a "stochastic Haiku draw" = `our_rng.sample(P_Haiku(cell))`,
+fully reproducible from the cache + seed — no Haiku call at train time, and A/Bs share the batch trajectory.
+
+### The policy: fine-tune forward, don't re-balance the past
+The base model **already encodes the per-relation μ** (anchors + readout, learned from the abundant labels).
+So fine-tuning doesn't re-balance the historical label corpus — it **adds the distributional correction
+incrementally** on new data:
+- Apply the **70/30 mix to the new stream going forward** (70% label μ, 30% sampled-cell μ from
+  `P_Haiku(cell)` / self-posterior). The historical labels are *not replayed*, so they can't drown the 30%.
+- Run the fine-tune **right after scoring a tail batch**, so that batch is **Haiku-enriched** — 70/30 is hit
+  by plain sampling, with no heavy oversampling of a handful of rows. The overfit-the-scarce-sample risk
+  largely evaporates because the fine-tune set isn't 99% label to begin with.
+
+### Forgetting guard (the one real risk of forward fine-tuning)
+A forward fine-tune on a narrow new slice can pull the anchors off the label knowledge they hold. Guards,
+mostly already in place:
+- the **70% label share** in the new stream self-anchors it;
+- the **anchor-KL** pins the anchor *values* to the labels (its job, §8);
+- **early-stop on the held-out *graded* (label) MSE** trips the moment base competence degrades;
+- a **low LR** keeps the update incremental.
+
+### Composition with §12 / the earlier refinements
+- **Self-posterior for the labeled bulk:** labeled rows' 30% share can target the **model's own posterior**
+  (self-distillation), so Haiku is *spent and weighted only on the genuine tail* (§9) — shrinking the
+  imbalance to just the tail.
+- **Ramp as thin-batch fallback:** if even a fresh batch arrives Haiku-thin, scale the distributional weight
+  `λ_dist = λ_target · min(1, n_haiku / n_needed)` so a noisy handful can't dominate; it degrades to a no-op
+  once batches are adequately scored.
+
+**Headline:** forward 70/30 fine-tuning is the preferred lever (it dissolves the imbalance at its source);
+self-posterior + ramp are the refinement/fallback; and the cells are always drawn *by us* from Haiku's cached
+parameters, never by Haiku.

--- a/prototypes/mu_cosine/REPORT_anchored_basis_ab.md
+++ b/prototypes/mu_cosine/REPORT_anchored_basis_ab.md
@@ -69,3 +69,30 @@ helped. Three arms, adding the changes one at a time:
   is probably the 384-d raw text; provenance alone might be neutral/positive). Project `e5_raw` down before
   fusing, or drop it.
 - Then the deferred v2: value-token, μ-refresh, **utilisation readout** (is K=5 right?), grow/prune.
+
+## The proper §8c test — section-header text, symmetric e5 (the real verification)
+
+After threading the **real section-header text** through the pipeline and adding the **symmetric**
+e5(header)→e5(label-anchor) attention (`--anchor-query header`), the 3-arm re-test on the regenerated round:
+
+| arm | SYM mean | disc mean (per-seed) |
+|---|---|---|
+| baseline | +0.691 | 93.3% (96/92/92) |
+| **anchored-μ** (architecture only) | **+0.743** | **94.7% (96/92/96)** |
+| anchored-hdr (proper header text, symmetric) | +0.736 | 92.0% (92/96/88) |
+
+**Verdict: the architecture is the win; the text-in-query is not.**
+- **anchored-μ > baseline** on both metrics — the anchored attention/atoms genuinely help, confirmed a 2nd time.
+- **anchored-hdr ≈ μ on SYM, *below* on discrimination** — the *properly-routed* header text (right text, right
+  e5-symmetric encoding) still does **not** beat μ-only, and costs disc. So the earlier "raw text hurts" was
+  **not** just the wrong text — the text genuinely doesn't earn its place in the query as tested.
+- **Why (honest caveat):** the `header` mode *replaced* μ with the header text rather than *fusing* them, so
+  it lost the μ-evidence discrimination relies on (likely the disc drop). A clean **μ+header fusion** is still
+  untested. But neither simple version (v1 wrong-text-fusion, header-only) beats μ-only.
+- Likely root cause beyond that: the **anchor-KL already injects the categoriser's decision** (which reads the
+  same header via fuzzy matching), so the header-in-query is largely **redundant** with the supervision.
+
+## Operating point
+**Anchored architecture with `--anchor-query mu`** — best discrimination, good SYM, simplest. The text signal
+is already captured by the anchor-KL supervision; adding it to the query (any version tried) doesn't help.
+A μ+header *fusion* remains the one untested variant if we want to revisit the text later.

--- a/prototypes/mu_cosine/REPORT_anchored_basis_ab.md
+++ b/prototypes/mu_cosine/REPORT_anchored_basis_ab.md
@@ -1,0 +1,37 @@
+# Anchored-basis A/B — first measurement (weights-only v1)
+
+The first real test of DESIGN §8: compute the blend `op_weights` via attention over frozen e5-phrase relation
+ANCHORS + 5 learnable ATOMS (`--anchored-basis`), vs the current JointPosterior+Dirichlet blend. Both
+warm-started from the 4L/0.7 base on the combined 6-source round (`graded_all`, 3824 targets), early-stopped,
+3 seeds.
+
+## Result
+
+| seed | baseline SYM | anchored SYM | baseline disc | anchored disc |
+|---|---|---|---|---|
+| 1 | +0.433 | **+0.578** | 88% | 88% |
+| 2 | +0.785 | **+0.834** | 80% | **92%** |
+| 3 | +0.767 | **+0.823** | 92% | 92% |
+| **mean** | +0.662 | **+0.745** | 86.7% | **90.7%** |
+
+**Anchored beats baseline on SYM in all 3 seeds (+0.083 mean) and is ≥ on discrimination in all 3 (+4pp).**
+The 3/3 consistency (not 50/50) is the signal that it's more than seed noise — notable since this is the
+stripped-down **weights-only v1**: the e5-phrase anchor *values* aren't the token yet, the query uses
+warm-start μ (not refreshed), and there's no utilisation readout.
+
+## Honest caveats
+- **Attribution unclear.** The anchored query also carries the categoriser **provenance + raw e5 text**, which
+  the baseline (JointPosterior on μ_vec alone) never sees. So the gain may be the anchored attention/atoms,
+  the richer query, or both. A clean ablation (baseline+provenance, or anchored−provenance) would separate
+  them. The A/B fairly shows "full anchored approach > baseline blend"; it does not yet attribute *why*.
+- **Noisy metrics.** SYM is 40 held-out positives (baseline swings 0.433→0.785 across seeds); disc is 25
+  probes. The effect is modest; read it as "consistent and promising," not "decisive."
+- The baseline mean (0.662) is in line with the earlier `ft1` run (0.671) — sanity check passes.
+
+## Verdict / next
+A consistent, modest improvement in the right direction — enough to justify the v2 build:
+1. **Ablation** to attribute (provenance-only vs anchored-attention).
+2. **Value-token** (use the e5-phrase anchor values as the token, the full §8).
+3. **μ-refresh** in the query (vs warm-start static).
+4. **Utilisation readout** (`anchored_rel.utilization()` at eval) → is K=5 right / grow? (§8b)
+5. then the **grow/prune controller**.

--- a/prototypes/mu_cosine/REPORT_anchored_basis_ab.md
+++ b/prototypes/mu_cosine/REPORT_anchored_basis_ab.md
@@ -35,3 +35,37 @@ A consistent, modest improvement in the right direction — enough to justify th
 3. **μ-refresh** in the query (vs warm-start static).
 4. **Utilisation readout** (`anchored_rel.utilization()` at eval) → is K=5 right / grow? (§8b)
 5. then the **grow/prune controller**.
+
+## Ablation — attributing the gain (the verification)
+
+**What an ablation is:** change the system *one piece at a time* so each piece's contribution is isolated.
+The first A/B changed two things at once (the **architecture** AND the **query**), so it couldn't say which
+helped. Three arms, adding the changes one at a time:
+
+| arm | architecture | query | SYM mean | disc mean (per-seed) |
+|---|---|---|---|---|
+| baseline | JointPosterior+Dirichlet | μ_vec | +0.662 | 86.7% (88/80/92) |
+| **anchored-μ** | anchored attention | **μ_vec only** | +0.714 | **96.0% (96/96/96)** |
+| anchored-full | anchored attention | §8c fusion | +0.745 | 90.7% (88/92/92) |
+
+- **anchored-μ vs baseline** (same input, new architecture): **discrimination +9.3pp and perfectly consistent
+  (96/96/96)**; SYM +0.052. ⇒ **the architecture genuinely helps** — it is *not* just the richer query.
+- **anchored-full vs anchored-μ** (same architecture, + rich query): discrimination **−5.3pp**; SYM +0.031.
+  ⇒ **the rich query HURTS discrimination** (small SYM gain, real disc cost).
+
+## Verdict
+- **The anchored-basis architecture is validated.** With the *same* input as baseline it beats it on both
+  metrics — strongly and consistently on discrimination. The attention-over-anchors+atoms → op_weights
+  mechanism (with the anchor-KL) is the real driver, not a query-richness artefact.
+- **The §8c full query is NOT worth it as-is.** Adding the provenance + raw e5 text drops discrimination
+  (−5.3pp) for a noisy SYM sliver. Likely the 384-d `e5_raw` (and/or the provenance) drowns the μ-evidence
+  the discrimination probe needs.
+- **Operating point: anchored architecture + `--anchor-query mu`** — best discrimination (96%, stable),
+  good SYM, *and* simpler (no provenance/raw-text plumbing).
+
+## Next (revised by the ablation)
+- Adopt **anchored-μ** as the anchored default.
+- If we still want the query signal: ablate it finer — **provenance-only** vs **raw-text-only** (the −5.3pp
+  is probably the 384-d raw text; provenance alone might be neutral/positive). Project `e5_raw` down before
+  fusing, or drop it.
+- Then the deferred v2: value-token, μ-refresh, **utilisation readout** (is K=5 right?), grow/prune.

--- a/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
+++ b/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
@@ -1,0 +1,51 @@
+# Haiku inferred-tail augmentation — pilot (DESIGN §9/§14)
+
+First real run of the §14 Haiku contract over the **inferred tail** (conf<1.0 fused-graph rows), via
+`score_inferred_tail.py` + `cell_sampler.py`. Goal: **validate the pipeline end-to-end**, not move the model.
+
+## What ran
+- **Extract:** 66 unique untagged pairs (`assoc` 22 / `subtopic` 23 / `element_of` 21) from
+  `context/*_edges.tsv`, physics/EE-concentrated (LTI 34, circuit 24, ds/chaos/cyb ~8). Bridge rows
+  (title-match identity) excluded — not a "which relation" question.
+- **Score:** 3 Haiku subagents, §14 prompt, batched 22/each → strict-JSON cell distributions.
+- **Ingest:** §12(5) closure (`applies[named] ++ unknown ++ none` → categorical Σ=1) → per-pair partition +
+  `E[μ]`, cached to `haiku_scored_tail.tsv` (gitignored — pearltrees-derived titles).
+
+## Pipeline: works ✅
+66/66 parsed and partitioned. **Both §14 rules held in the wild:**
+- μ memberships routinely sum **> 1** (overlapping relations both fire) — Haiku did not normalise them.
+- `applies[named]` sums **< 1**, leaving honest mass on `none`/`unknown` — Haiku did not pad to 1.
+
+`cell_sampler.expected` produces sane `E[μ]` (0.38–0.62 on these lateral/weak-taxonomic rows); the 9
+`cell_sampler` tests + this live run jointly exercise the §12–§14 core.
+
+## Label (conf 0.4) vs Haiku — the augmentation earns its keep
+| comparison | count | note |
+|---|---|---|
+| exact same cell | 15 (22%) | weak guess confirmed |
+| same family (taxonomic dir-flip, or see_also↔assoc) | 20 (30%) | right *kind*, e.g. label `subtopic` vs Haiku `super_category` = same edge, opposite direction |
+| different family | 28 (42%) | genuine disagreement |
+| Haiku says unrelated (`none`≥0.4) | 3 | weak "assoc" guesses Haiku rejects |
+
+**Only 53% label-consistent.** The conf-0.4 structural guesses diverge substantially from Haiku — exactly
+the correction signal the augmentation exists to provide. A recurring pattern: pearltrees parent→child edges
+labelled `subtopic` read as `super_category` to Haiku (the NODE is the *broader* one) — a **direction-convention
+mismatch worth a closer look**, not necessarily a Haiku error.
+
+## Honest caveats
+- **This validates the pipeline, not Haiku-as-truth.** Haiku shows apparent tendencies (favours
+  `super_category`; generous `see_also`) — a single-scorer pilot can't separate "label was wrong" from
+  "Haiku is biased." The §9 plan (eval vs Haiku on a *held-out* tail) still needs the held-out split.
+- **Budget overran:** ~**146k tokens** vs the ~30–70k estimate. Causes: Haiku verbose per pair, and
+  persisting each batch to file via a **second emission** (the SendMessage re-write doubled output).
+  **Lesson for scale:** have the scorer write its file on the *first* pass, trim the prompt, batch larger.
+- **83→66 after dedup**; the tail is small. Per §13, 66 distributional rows won't move the model against
+  the labelled bulk — **training impact needs the generate-more step** (grow the physics tail).
+
+## Next
+1. **Decide generate-more** (expand physics neighbourhoods → grow the tail) before wiring training — the
+   pilot proves the pipe; scale proves the signal.
+2. When wiring training: forward 70/30 (§13), draw cells from these cached `P(cell)` via `cell_sampler`
+   (isolated RNG), self-posterior for the labelled bulk, held-out tail for the §9 eval.
+3. Investigate the `subtopic`/`super_category` direction-convention mismatch — it may be a systematic
+   labelling-vs-prompt direction issue, cheap to fix and high-leverage.

--- a/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
+++ b/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
@@ -125,3 +125,30 @@ labeled-population-vs-inferred-tail blind spot flagged in the design.
 treatment on the train-tail only, and compare each model's μ/E[μ] to the held-out Haiku E[μ] *on the tail*.
 That is the only measurement that can see whether augmenting the tail improved the tail. Until it exists, the
 data-scaling payoff is unmeasured. (More data is cheap and unblocked; reading it is the gap.)
+
+## Held-out-TAIL eval — the decisive (negative) result
+Built `--eval-tail` (§9/§12(3)): model E[μ] under an equal-weight operator superposition (none excluded) vs
+the cached Haiku E[μ], on tail rows whose Haiku target the model never trained on. Split 417 → 333 train-tail
+/ 84 holdout; warm-start from `model_nodetype.pt`, 2 seeds × base/treat, only difference = the train-tail override.
+
+| seed | arm | TAIL corr | TAIL MSE | model μ̄ |
+|---|---|---|---|---|
+| 1 | base | +0.209 | 0.062 | 0.253 |
+| 1 | treat | +0.231 | 0.082 | 0.190 |
+| 2 | base | +0.196 | 0.063 | 0.262 |
+| 2 | treat | +0.187 | 0.070 | 0.231 |
+
+**The augmentation gives NO measurable lift on the tail.** Corr is flat (~+0.20 both arms, treat +0.02/−0.01
+across seeds = within noise); MSE slightly *worse* for treatment. The **baseline already correlates +0.20 with
+Haiku on the tail with zero Haiku training** — the frozen-e5 base extracts ~that much on its own, and the
+augmentation can't push past it.
+
+**Two interpretations → different levers:**
+1. **Representation ceiling (frozen e5):** the base already captures what e5 affords; better targets add no
+   information the embedding lacks. Lever = richer encoder, not more data.
+2. **Dilution (§13 imbalance, unsolved):** train-tail is only 333/~5000 graded targets (~7%), far below the
+   30% target. At 7% of the gradient even perfect targets can't move the model. Lever = upweight the tail.
+
+**Disambiguating experiment (next, cheap, no new data):** upweight the train-tail to ~30% effective share and
+re-run the tail eval. Beats baseline → it was dilution (more/heavier tail data helps). Still flat → it's the
+representation ceiling (need a better embedding). This is the experiment that tells us which ceiling we're against.

--- a/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
+++ b/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
@@ -96,3 +96,32 @@ Later we can **sort by highest `none`-disagreement to hunt genuine graph errors*
 asserts an edge a strong judge confidently rejects is a likely *real mistake*, distinct from honest
 uncertainty. Same column, different read (keep-as-data now vs sort-descending-to-audit later); `flag` already
 selects by `none`, so only a descending sort is needed when we want it.
+
+## Measurement arc — wiring, scale, and the saturation/blind-spot verdict
+**Wired** the §9/§14 path into the trainer (`--haiku-tail`: override inferred conf<1.0 graded targets with the
+cached LLM E[μ] + judge provenance, fwd/rev by title-match). **Scaled** the distributional set **66 → 228 →
+417** rows (pilot + Engineering + System&Control, all from cache, no harvester; 411 haiku + 6 sonnet).
+
+**Fresh from-scratch sweep (3 seeds × base/treat, 500 steps):** UNRELIABLE — seed-3 diverged for *both* arms
+(WIKI 36%, μ→0); on the 2 valid seeds treatment gave only a small WIKI-order gain (+0.7, +1.6%); SYM/OOD were
+noise (the dramatic first-run drop 23.6→7.9% OOD did NOT replicate). The repeat correctly deflated a fluke.
+
+**Warm-start sweep (2 seeds × base/treat from `model_nodetype.pt`, 400 steps):** STABLE (no divergence; the
+3→5 judge-embedding resize auto-handled). Result — **treatment ≈ baseline on every clean metric**:
+
+| metric (warm-start) | base (s1/s2) | treat (s1/s2) |
+|---|---|---|
+| WIKI order-acc | 99.8 / 99.8 | 99.8 / 99.9 |
+| SYM corr (40) | +0.665 / +0.698 | +0.676 / +0.711 |
+| WIKI OOD-leak | 28 / 20% | 28 / ~20% |
+
+**Conclusion (honest):** at convergence the base metrics are **saturated and indistinguishable** with/without
+augmentation. The fresh-run gain was undertraining, not quality. **Critically, these held-out metrics measure
+the BASE simplewiki population — they are structurally blind to the inferred physics/EE tail the augmentation
+changes.** "No effect on WIKI/SYM" ≠ "no effect" — it means we measured the wrong population. This is the same
+labeled-population-vs-inferred-tail blind spot flagged in the design.
+
+**The missing instrument (next):** a **held-out-tail eval** (§9/§12(3)) — split the 417 scored rows, train
+treatment on the train-tail only, and compare each model's μ/E[μ] to the held-out Haiku E[μ] *on the tail*.
+That is the only measurement that can see whether augmenting the tail improved the tail. Until it exists, the
+data-scaling payoff is unmeasured. (More data is cheap and unblocked; reading it is the gap.)

--- a/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
+++ b/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
@@ -49,3 +49,27 @@ mismatch worth a closer look**, not necessarily a Haiku error.
    (isolated RNG), self-posterior for the labelled bulk, held-out tail for the §9 eval.
 3. Investigate the `subtopic`/`super_category` direction-convention mismatch — it may be a systematic
    labelling-vs-prompt direction issue, cheap to fix and high-leverage.
+
+## Addendum — selective Sonnet escalation of sharp `none`-vs-graph rows
+Every tail row is a graph edge (conf<1.0 asserts a relation), so a high Haiku `P[none]` is a direct
+graph↔Haiku contradiction. `score_inferred_tail.py flag --none-min 0.3` selected **6** such rows; a single
+**Sonnet** subagent re-judged them (the ¼-budget tier; Opus reserved). Sonnet wrote its JSON on the *first*
+pass — ~21k tokens, no double-emission.
+
+| node → root | label | Haiku none | Sonnet none | read |
+|---|---|---|---|---|
+| thermodynamics → Flickr_(Thermodynamics) | element_of | 0.60 | 0.71 | **spurious** (ROOT is a Flickr collection) |
+| Z_transform → Zeta_function_regularization | element_of | 0.64 | 0.67 | **spurious** (different math domains) |
+| Z_transform → Recommended_for_beginner | element_of | 0.33 | **0.81** | escalation **sharpened** → navigational node |
+| control-system-eng → Technicien_automaticien | assoc | 0.30 | 0.45 | leans spurious |
+| Gaussian_Linear_Models → MIT…LecNote19 | element_of | 0.30 | 0.23 | both keep some relation (note may cover it) |
+| lti-system-theory → Tellegen's_theorem | subtopic | 0.52 | **0.27** | Sonnet **softened** → real-but-loose lateral |
+
+**Takeaways:**
+- The selective multi-judge tie-break is cheap and decisive — it confirmed 2 spurious edges, *sharpened* 1
+  borderline navigational case (0.33→0.81), and *corrected* Haiku's over-doubt on 2 real-but-loose ones.
+- **Many conf-0.4 edges target navigational/meta nodes** (Flickr collections, "recommended for beginners",
+  lecture-note PDFs) → the augmentation is also a **graph-cleaning** signal: these edges should likely be
+  pruned, not just down-weighted.
+- Where Haiku and Sonnet still diverge most (Tellegen, the lecture note), an **Opus** final tie-break is the
+  natural next escalation — but only for genuine judge-disagreement, not all `none` rows.

--- a/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
+++ b/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
@@ -152,3 +152,29 @@ augmentation can't push past it.
 **Disambiguating experiment (next, cheap, no new data):** upweight the train-tail to ~30% effective share and
 re-run the tail eval. Beats baseline → it was dilution (more/heavier tail data helps). Still flat → it's the
 representation ceiling (need a better embedding). This is the experiment that tells us which ceiling we're against.
+
+## RESULT — augmentation helps at ~30% tail-weight (dilution confirmed, 3-seed)
+The tail-upweight disambiguation, held-out-tail corr (model E[μ] vs held-out Haiku E[μ]), 3 seeds:
+
+| arm | s1 | s2 | s3 | mean ± sd |
+|---|---|---|---|---|
+| base (tw1, no aug) | 0.202 | 0.144 | 0.143 | **+0.163 ± 0.028** |
+| **treat tw6 (~30%)** | 0.277 | 0.290 | 0.287 | **+0.285 ± 0.006** |
+| treat tw12 | 0.318 | 0.179 | 0.325 | +0.274 ± 0.067 |
+
+**Verdict: the distributional augmentation DOES help the inferred tail — a robust, low-variance +0.12 corr
+lift — but only at ~30% tail-weight (`--tail-weight 6`).** This is **dilution, confirmed**: at the natural ~7%
+share the tail signal was drowned (the earlier flat result); given its §13-intended ~30% share it replicates
+tightly (sd 0.006). `tw12` over-weights — same mean, 10× variance — an **inverted-U peaking near 30%**, the
+capacity-ceiling shape already located for this 3-layer model. **Frozen e5 is NOT the binding limit** (if it
+were, no weighting would help).
+
+**Actionable conclusions:**
+1. **Free lever now:** train with `--tail-weight ~6` (the §13 30% operating point). No new data needed.
+2. **Scaling the tail is justified:** the tail signal is real and learnable and we're below the representation
+   ceiling — so more tail data should compound (it just must carry ~30% weight, not 7%).
+3. **Don't over-weight** (tw12): past ~30% the small model destabilizes (no mean gain, high variance).
+
+**Caveats:** still the agree-with-Haiku frame (the independent Sonnet/human check via the now-tagged
+provenance is the next rigor tier); 82 holdout rows; equal-weight-superposition probe. But a 3-seed
+replication at sd 0.006 is signal, not noise — this is the payoff of measuring the tail + repeating across seeds.

--- a/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
+++ b/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
@@ -73,3 +73,20 @@ pass — ~21k tokens, no double-emission.
   pruned, not just down-weighted.
 - Where Haiku and Sonnet still diverge most (Tellegen, the lecture note), an **Opus** final tie-break is the
   natural next escalation — but only for genuine judge-disagreement, not all `none` rows.
+
+## Update — Engineering expansion + the no-clean decision
+**Generate-more, round 1 (no harvesting):** fused `Engineering.smmx` @ hops 3 against the 375 cached pt
+trees → 162 new untagged-tail pairs (assoc 92 / subtopic 51 / element_of 19), deduped vs the pilot and
+Haiku-scored (3 large batches, concise prompt). **Cumulative distributional rows: 66 → 228.**
+
+**Decision: do NOT clean the `none` cases** (supersedes the "prune spurious edges" suggestion in the
+escalation addendum). Rationale (user steer):
+- **Disagreement encodes uncertainty.** Graph-asserts-edge vs Haiku-says-`none` leaves mass on *both* the
+  relation cell and `none` → an honestly uncertain `E[μ]`. The fuzzy/distributional model is *built* to carry
+  that; resolving it away would discard information.
+- **Negatives are useful.** The 39 strong-`none` rows (≥0.4) are μ≈0 supervision for the `none` anchor (§9) —
+  exactly the negative signal the open-world partition needs.
+
+So: keep all 228 rows (positives + uncertain + negatives). The `flag`/escalation path stays available as an
+*optional* uncertainty-refinement on high-stakes rows, **not** a cleaning gate. The "navigational/meta node"
+observation is still a true characterisation of where `none` mass concentrates — just retained as data, not pruned.

--- a/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
+++ b/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
@@ -90,3 +90,9 @@ escalation addendum). Rationale (user steer):
 So: keep all 228 rows (positives + uncertain + negatives). The `flag`/escalation path stays available as an
 *optional* uncertainty-refinement on high-stakes rows, **not** a cleaning gate. The "navigational/meta node"
 observation is still a true characterisation of where `none` mass concentrates — just retained as data, not pruned.
+
+**Deferred (not yet):** the `none`-disagreement column is *multi-purpose*. Today it's uncertainty + negatives.
+Later we can **sort by highest `none`-disagreement to hunt genuine graph errors** — a graph that confidently
+asserts an edge a strong judge confidently rejects is a likely *real mistake*, distinct from honest
+uncertainty. Same column, different read (keep-as-data now vs sort-descending-to-audit later); `flag` already
+selects by `none`, so only a descending sort is needed when we want it.

--- a/prototypes/mu_cosine/anchored_basis.py
+++ b/prototypes/mu_cosine/anchored_basis.py
@@ -21,22 +21,31 @@ import torch.nn.functional as F
 
 
 class AnchoredBasis(nn.Module):
-    def __init__(self, anchor_values, n_atoms=5, d_query=6, d_k=64, atom_init=0.02):
-        """anchor_values: [A, d_model] FROZEN value embeddings (e5 phrase seeds). n_atoms K: learnable atoms."""
+    def __init__(self, anchor_values, n_atoms=5, d_query=6, d_k=64, atom_init=0.02, symmetric=False):
+        """anchor_values: [A, d_model] FROZEN value embeddings (e5 phrase seeds). n_atoms K: learnable atoms.
+        symmetric=True (§8c proper): query is an e5 vector (the header text), anchor KEYS are TIED to the
+        frozen e5 values, and atoms live in e5 space — so the weight is e5 cosine(header, label-anchor), the
+        embedding categorizer, with no q_proj and no dimensionality mismatch."""
         super().__init__()
         n_anchors, d_model = anchor_values.shape
-        self.n_anchors, self.n_atoms, self.d_model = n_anchors, n_atoms, d_model
+        self.n_anchors, self.n_atoms, self.d_model, self.symmetric = n_anchors, n_atoms, d_model, symmetric
         self.register_buffer("anchor_values", anchor_values.clone())        # FROZEN (not a Parameter)
-        self.anchor_keys = nn.Parameter(torch.randn(n_anchors, d_k) * atom_init)   # learnable, KL-calibrated
+        if symmetric:
+            d_k = d_model
+            self.anchor_keys = None                                         # tied to anchor_values (frozen)
+            self.q_proj = nn.Identity()
+        else:
+            self.anchor_keys = nn.Parameter(torch.randn(n_anchors, d_k) * atom_init)   # learnable, KL-calibrated
+            self.q_proj = nn.Linear(d_query, d_k)
         self.atom_keys = nn.Parameter(torch.randn(max(n_atoms, 0), d_k) * atom_init)
         self.atom_values = nn.Parameter(torch.randn(max(n_atoms, 0), d_model) * atom_init)
-        self.q_proj = nn.Linear(d_query, d_k)
 
     def _keys_values(self):
+        akeys = self.anchor_values if self.symmetric else self.anchor_keys
         if self.n_atoms:
-            return (torch.cat([self.anchor_keys, self.atom_keys], 0),
+            return (torch.cat([akeys, self.atom_keys], 0),
                     torch.cat([self.anchor_values, self.atom_values], 0))
-        return self.anchor_keys, self.anchor_values
+        return akeys, self.anchor_values
 
     def forward(self, query):
         """query [B, d_query] → (token [B, d_model], weights [B, A+K] on the simplex)."""
@@ -67,9 +76,9 @@ class AnchoredRelation(nn.Module):
     op_weights into MuAttention.forward(op_weights=…). Weights-only integration (the e5-phrase anchor *values*
     stay in AnchoredBasis, ready for the value-token upgrade)."""
 
-    def __init__(self, anchor_values, anchor_ops, n_ops, n_atoms=5, d_query=6, d_k=64):
+    def __init__(self, anchor_values, anchor_ops, n_ops, n_atoms=5, d_query=6, d_k=64, symmetric=False):
         super().__init__()
-        self.basis = AnchoredBasis(anchor_values, n_atoms=n_atoms, d_query=d_query, d_k=d_k)
+        self.basis = AnchoredBasis(anchor_values, n_atoms=n_atoms, d_query=d_query, d_k=d_k, symmetric=symmetric)
         self.n_anchors, self.n_atoms, self.n_ops = len(anchor_ops), n_atoms, n_ops
         R = torch.zeros(self.n_anchors, n_ops)
         for i, op in enumerate(anchor_ops):

--- a/prototypes/mu_cosine/anchored_basis.py
+++ b/prototypes/mu_cosine/anchored_basis.py
@@ -98,3 +98,35 @@ class AnchoredRelation(nn.Module):
     @torch.no_grad()
     def utilization(self, w):
         return self.basis.utilization(w)
+
+
+class TypedQuery(nn.Module):
+    """Build the anchored-basis query from a SET of named, TYPED, separately-regularised input tokens
+    (DESIGN §8c, the typed-token design) — instead of a flat concat. Each input k is projected to d_k, gets a
+    learned TYPE embedding (so the model can tell μ from label-e5 from header-e5), and the *extra* inputs
+    (everything except `core`) are heavily DROPOUT-regularised so the model can gate them off when the label
+    is confident and lean on them only when it's weak — and so they can never dominate (the flat-concat
+    failure). The typed tokens are SUMMED (the factored-token pattern of the main MuAttention model).
+
+    dims: {name: input_dim}. core: the name(s) that are NOT dropout-regularised (e.g. 'mu' — the evidence the
+    joint distribution is deduced from). dropout: rate on the extra tokens."""
+
+    def __init__(self, dims, d_k=64, core=("mu",), dropout=0.5):
+        super().__init__()
+        self.proj = nn.ModuleDict({k: nn.Linear(d, d_k) for k, d in dims.items()})
+        self.type_emb = nn.ParameterDict({k: nn.Parameter(torch.zeros(d_k)) for k in dims})
+        self.drop = nn.Dropout(dropout)
+        self.core = set(core)
+        self.d_k = d_k
+
+    def forward(self, inputs):
+        """inputs: {name: [B, dim]} (a subset/superset of dims is fine — only matched names are used)."""
+        q = None
+        for k, x in inputs.items():
+            if k not in self.proj:
+                continue
+            t = self.proj[k](x) + self.type_emb[k]
+            if k not in self.core:                                     # heavily regularise the extra inputs
+                t = self.drop(t)
+            q = t if q is None else q + t
+        return q                                                      # [B, d_k]

--- a/prototypes/mu_cosine/anchored_basis.py
+++ b/prototypes/mu_cosine/anchored_basis.py
@@ -58,3 +58,34 @@ class AnchoredBasis(nn.Module):
         m = w.mean(0)
         return {"anchor_mass": m[:self.n_anchors].tolist(),
                 "atom_mass": m[self.n_anchors:].tolist()}
+
+
+class AnchoredRelation(nn.Module):
+    """Trainer-facing wrapper: attend over [anchors ∪ atoms] (AnchoredBasis), then map the relation weights to
+    OPERATOR weights for the existing per-operator readout — anchors via a FIXED relation→operator table
+    (from REL_SPEC), atoms via a LEARNED soft-operator row each. `forward(query) -> (op_weights, w)`; feed
+    op_weights into MuAttention.forward(op_weights=…). Weights-only integration (the e5-phrase anchor *values*
+    stay in AnchoredBasis, ready for the value-token upgrade)."""
+
+    def __init__(self, anchor_values, anchor_ops, n_ops, n_atoms=5, d_query=6, d_k=64):
+        super().__init__()
+        self.basis = AnchoredBasis(anchor_values, n_atoms=n_atoms, d_query=d_query, d_k=d_k)
+        self.n_anchors, self.n_atoms, self.n_ops = len(anchor_ops), n_atoms, n_ops
+        R = torch.zeros(self.n_anchors, n_ops)
+        for i, op in enumerate(anchor_ops):
+            R[i, op] = 1.0                                             # fixed anchor → operator (one-hot)
+        self.register_buffer("R_anchor", R)
+        self.atom_op_logits = nn.Parameter(torch.zeros(max(n_atoms, 0), n_ops))   # learned atom → operator
+
+    def forward(self, query):
+        _, w = self.basis(query)                                      # w [B, A+K] on the simplex
+        R = (torch.cat([self.R_anchor, F.softmax(self.atom_op_logits, dim=-1)], 0)
+             if self.n_atoms else self.R_anchor)                      # [A+K, n_ops]
+        return w @ R, w                                               # op_weights [B, n_ops] (also a simplex)
+
+    def anchor_kl(self, w, anchor_target):
+        return self.basis.anchor_kl(w, anchor_target)
+
+    @torch.no_grad()
+    def utilization(self, w):
+        return self.basis.utilization(w)

--- a/prototypes/mu_cosine/build_graded_round.py
+++ b/prototypes/mu_cosine/build_graded_round.py
@@ -60,10 +60,10 @@ def load_fused(prefix):
         for ln in f:
             if ln.startswith("#"):
                 continue
-            c = ln.rstrip("\n").split("\t")               # a_key, b_key, relation, confidence
+            c = ln.rstrip("\n").split("\t")               # a_key, b_key, relation, confidence, raw_text
             if len(c) >= 3:
                 conf = float(c[3]) if len(c) > 3 and c[3] else 1.0
-                edges.append((c[0], c[1], c[2], conf))
+                edges.append((c[0], c[1], c[2], conf, c[4] if len(c) > 4 else ""))
     return nodes, edges
 
 
@@ -112,7 +112,8 @@ def main():
         return nodes.get(key, ("", "category", ""))[1]
 
     rows, skipped = {}, Counter()                         # (node,root,op) → row ; dedup keeps strongest |μ-.5|
-    def emit(node, root, mu, op, rel, conf=1.0):
+    row_text = {}                                         # (node,root,op) → raw section-header / annotation text
+    def emit(node, root, mu, op, rel, conf=1.0, raw=""):
         if node == root or node not in nodes or root not in nodes:
             skipped["dangling"] += 1
             return
@@ -121,19 +122,20 @@ def main():
         if k in rows and abs(rows[k][0] - 0.5) >= abs(mu - 0.5):
             return                                        # keep the more decisive existing target
         rows[k] = (mu, rel, ntype(node), ntype(root), corpus, judge, conf)
+        row_text[k] = raw                                 # carry the raw text alongside (side map)
 
-    for src, dst, rel, conf in edges:
+    for src, dst, rel, conf, raw in edges:
         spec = RELATION_SPEC.get(rel)
         if not spec:
             skipped[f"rel:{rel}"] += 1
             continue
         op, kind, hi, lo = spec
         if kind == "down":                                # dst is a member/narrower of src
-            emit(dst, src, hi, op, rel, conf); emit(src, dst, lo, op, rel, conf)
+            emit(dst, src, hi, op, rel, conf, raw); emit(src, dst, lo, op, rel, conf, raw)
         elif kind == "up":                                # dst is the broader; src belongs to dst
-            emit(src, dst, hi, op, rel, conf); emit(dst, src, lo, op, rel, conf)
+            emit(src, dst, hi, op, rel, conf, raw); emit(dst, src, lo, op, rel, conf, raw)
         else:                                             # symmetric
-            emit(dst, src, hi, op, rel, conf); emit(src, dst, hi, op, rel, conf)
+            emit(dst, src, hi, op, rel, conf, raw); emit(src, dst, hi, op, rel, conf, raw)
 
     # --- e5-PRIOR bridge sanity gate: a bridge asserts "same concept across corpora"; if its endpoints are
     # FAR in frozen e5, the link is suspect (a bad link, or a non-obvious synonym e5 can't see). Quarantine
@@ -186,9 +188,11 @@ def main():
                 f.write(f"{a}\t{b}\t{c:.3f}\t{nodes.get(a,('','',''))[2]}\t{nodes.get(b,('','',''))[2]}\n")
 
     with open(args.out + "_pairs.tsv", "w", encoding="utf-8") as f:
-        f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\tconfidence\n")
-        for (node, root, op), (mu, rel, nty, rty, corpus, judge, conf) in sorted(rows.items()):
-            f.write(f"{node}\t{root}\t{mu:.2f}\t{op}\t{rel}\t{nty}\t{rty}\t{corpus}\t{judge}\t{conf:.2f}\n")
+        f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\tconfidence\traw_text\n")
+        for k, (mu, rel, nty, rty, corpus, judge, conf) in sorted(rows.items()):
+            node, root, op = k
+            raw = row_text.get(k, "").replace("\t", " ").replace("\n", " ")
+            f.write(f"{node}\t{root}\t{mu:.2f}\t{op}\t{rel}\t{nty}\t{rty}\t{corpus}\t{judge}\t{conf:.2f}\t{raw}\n")
     with open(args.out + "_nodes.tsv", "w", encoding="utf-8") as f:
         f.write("# key\tcorpus\tnode_type\ttitle\tembed_text\n")
         for key, (cp, nty, title) in sorted(nodes.items()):

--- a/prototypes/mu_cosine/cell_sampler.py
+++ b/prototypes/mu_cosine/cell_sampler.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Hard-cell sampler + E[μ] reducers for the operator-superposition (DESIGN §12/§13).
+
+Haiku supplies the distributional **parameters** `P(cell)` per row (cached, §9); the TRAINING LOOP draws the
+cell HERE with an **isolated** rng (§12(4)) — reproducible from cache+seed, no train-time Haiku call, and an
+on/off A/B shares the batch trajectory. Pure + module-level (like `switched_op`) so it is unit-testable.
+
+A *cell* is just an INDEX into a probability vector; the caller maps index → meaning (a relation, an overlap
+set / atom, or the `none` cell, §9/§10). This module never decides WHICH cells exist — that is the §12(5)/(7)
+**construction** step (`threshold_to_cell` below, deterministic, run once). It only (a) SAMPLES from a given
+`P` and (b) REDUCES per-cell μ to the expectation `E[μ]` (§12(1) cell-level).
+
+Two reducers, by design equal in expectation (§11/§12(6)):
+  * `expected`     — analytic `E[μ] = Σ_i p_i·μ_i` over the per-cell HARD readouts (exact; R forwards).
+  * `mc_expected`  — Monte-Carlo mean ± SE over N sampled cells (for when you can't enumerate the partition).
+Feeding the *blended* cell `μ(Σ p·cell)` is the Jensen-biased shortcut and is NOT provided here (§11)."""
+import math
+
+
+def sample_index(p, rng):
+    """Draw one index from the finite categorical `p` (list, sums to ~1). Pure; `rng` is an isolated
+    `random.Random` (§12(4)). Robust to tiny normalisation drift."""
+    total = sum(p)
+    if total <= 0:
+        raise ValueError("sample_index: non-positive total mass")
+    x = rng.random() * total
+    acc = 0.0
+    for i, pi in enumerate(p):
+        acc += pi
+        if x < acc:
+            return i
+    return len(p) - 1                          # float-rounding fallback → last cell
+
+
+def threshold_to_cell(p_rel, tau=0.25):
+    """§12(5)/(7) CONSTRUCTION (deterministic, run once): the cell = the set of relation indices whose
+    parameter clears `tau`. Returns a tuple of indices (sorted); the EMPTY tuple `()` means the `none`
+    cell (no relation clears tau, §9). A singleton tuple is an ordinary anchor; 2+ is an overlap cell."""
+    cell = tuple(i for i, pi in enumerate(p_rel) if pi >= tau)
+    return cell                                # () == none
+
+
+def expected(p, mu):
+    """Analytic cell-level expectation `E[μ] = Σ_i p_i·μ_i` (§12(1)). `mu[i]` is the model's HARD-cell μ for
+    cell i (the `none` cell carries μ≈0). Normalises `p` defensively."""
+    if len(p) != len(mu):
+        raise ValueError("expected: len(p) != len(mu)")
+    total = sum(p) or 1.0
+    return sum((pi / total) * mi for pi, mi in zip(p, mu))
+
+
+def mc_expected(p, mu_fn, rng, n=32):
+    """Monte-Carlo `E[μ]` over N hard draws (§12(6)): sample a cell, evaluate `mu_fn(cell_index)` (a possibly
+    NON-linear model readout for that hard cell), average. Returns `(mean, se)` with `se = std/sqrt(N)`.
+    Converges to `expected(p, [mu_fn(i) for i])` as N→∞ — the test asserts this."""
+    if n < 1:
+        raise ValueError("mc_expected: n must be >= 1")
+    vals = [mu_fn(sample_index(p, rng)) for _ in range(n)]
+    mean = sum(vals) / n
+    if n == 1:
+        return mean, float("nan")
+    var = sum((v - mean) ** 2 for v in vals) / (n - 1)
+    return mean, math.sqrt(var) / math.sqrt(n)
+
+
+def n_for_se(sigma, target_se=0.02):
+    """§12(6) sample-count rule: smallest N with `sigma/sqrt(N) <= target_se`. With sigma~0.1 ⇒ N≈25 (default
+    N=32 in the trainer leaves headroom)."""
+    if target_se <= 0:
+        raise ValueError("n_for_se: target_se must be > 0")
+    return max(1, math.ceil((sigma / target_se) ** 2))

--- a/prototypes/mu_cosine/fuse_corpus.py
+++ b/prototypes/mu_cosine/fuse_corpus.py
@@ -56,7 +56,8 @@ def main():
 
     # 1) parse the SimpleMind map (optional) and/or inject direct Pearltrees seeds (--pt-seed)
     nodes = {}                                          # key → (corpus, type, title)
-    edges = []                                          # (a_key, b_key, relation)
+    edges = []                                          # (a_key, b_key, relation, confidence)
+    edge_text = {}                                      # (a,b,rel) → raw section-header / annotation text
 
     def addn(corpus, slug, ntype, title):
         k = f"{corpus}:{norm(slug)}"
@@ -151,12 +152,14 @@ def main():
             else:
                 rel, conf = PT_REL.get(f[2], "see_also"), 0.4   # structural fallback ⇒ INFERRED
             edges.append((pk, wk, rel, conf))
+            edge_text[(pk, wk, rel)] = pt_sec.get(f[7], "") if len(f) > 7 else ""   # the raw section header
         elif len(f) > 3:
             if norm(f[1]) in pt_priv:                   # private child → scrub
                 scrub_pt += 1; continue
             ck = addn("pt", f[1], "pearltrees_collection" if f[3] != "page" else "page", f[1])
             rel, conf = (cat[0], cat[2]) if cat[0] else (PT_REL.get(f[2], "assoc"), 0.4)
             edges.append((pk, ck, rel, conf))
+            edge_text[(pk, ck, rel)] = pt_sec.get(f[7], "") if len(f) > 7 else ""   # the raw section header
 
     # 3) N-hop BFS from the start over the UNDIRECTED fused graph (a hop = any cross-corpus edge)
     adj = collections.defaultdict(set)
@@ -199,9 +202,10 @@ def main():
                     co, ty, ti = nodes[k]
                     f.write(f"{k}\t{co}\t{ty}\t{ti}\n")
         with open(args.out_prefix + "_edges.tsv", "w", encoding="utf-8") as f:
-            f.write("# a_key\tb_key\trelation\tconfidence  (1.0 = tagged; <1.0 = inferred)\n")
+            f.write("# a_key\tb_key\trelation\tconfidence\traw_text  (header/annotation; 1.0=tagged <1.0=inferred)\n")
             for a, b, r, c in sorted(uniq):
-                f.write(f"{a}\t{b}\t{r}\t{c:.2f}\n")
+                raw = edge_text.get((a, b, r), "").replace("\t", " ").replace("\n", " ")
+                f.write(f"{a}\t{b}\t{r}\t{c:.2f}\t{raw}\n")
         print(f"  wrote {args.out_prefix}_nodes.tsv + {args.out_prefix}_edges.tsv")
 
 

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -50,9 +50,10 @@ OPS = {"SYM": 0, "WIKI": 1, "LLM": 2, "ELEM": 3}
 # (off-manifold noise, exactly like an absent ancestor slot); masking ⇒ provenance-AGNOSTIC μ, which is
 # the DEFAULT inference path (marginalize over sources). Reserved entries (enwiki) are for later corpora.
 CORPORA = {"simplewiki": 0, "enwiki": 1, "pearltrees": 2, "mindmap": 3}
-JUDGES = {"haiku": 0, "graph": 1, "human": 2}    # haiku = a bought LLM judgment (SYM/LLM); graph = a
-                                         # Wikipedia edge / non-edge (WIKI, free μ=0 SYM negatives);
-                                         # human = a hand-curated edge (the mindmap/pearltrees corpora)
+JUDGES = {"haiku": 0, "graph": 1, "human": 2, "sonnet": 3, "opus": 4}    # haiku = a bought LLM judgment
+                                         # (SYM/LLM); graph = a Wikipedia edge / non-edge (WIKI, free μ=0 SYM
+                                         # negatives); human = a hand-curated edge (mindmap/pearltrees);
+                                         # sonnet/opus = stronger-model judgments (escalated tie-breaks, §14)
 # NODE-TYPE (DESIGN_calibrated_judges.md §7): a factored per-ENDPOINT token saying WHAT each node is — a
 # `category`/`mindmap_node` is an internal node that can have children; a `page` is a LEAF; a
 # `pearltrees_collection` is a curated container. Orthogonal to the OPERATOR (which says what the RELATION

--- a/prototypes/mu_cosine/score_inferred_tail.py
+++ b/prototypes/mu_cosine/score_inferred_tail.py
@@ -132,21 +132,23 @@ def build_prompts(pairs, batch):
 
 
 def _cell_partition(obj):
-    """§14 → §12(5) closure: applies[named]++none++unknown, renormalised to a categorical that sums to 1.
-    Returns (cells, probs, mus) where mus[i] is the per-cell μ (forward) for E[μ]; symmetric cells use mu."""
-    cells, weights, mus = [], [], []
+    """§14 → §12(5) closure: applies[named]++unknown++none, renormalised to a categorical that sums to 1.
+    Returns (cells, probs, mus_fwd, mus_rev) — symmetric cells share one mu both directions; none = 0."""
+    cells, weights, mf, mr = [], [], [], []
     for r in NAMED_DIR:
         e = obj.get(r, {})
-        cells.append(r); weights.append(float(e.get("applies", 0))); mus.append(float(e.get("mu_fwd", 0)))
+        cells.append(r); weights.append(float(e.get("applies", 0)))
+        mf.append(float(e.get("mu_fwd", 0))); mr.append(float(e.get("mu_rev", 0)))
     for r in NAMED_SYM:
-        e = obj.get(r, {})
-        cells.append(r); weights.append(float(e.get("applies", 0))); mus.append(float(e.get("mu", 0)))
+        e = obj.get(r, {}); m = float(e.get("mu", 0))
+        cells.append(r); weights.append(float(e.get("applies", 0))); mf.append(m); mr.append(m)
     cells.append("unknown"); u = obj.get("unknown", {})
-    weights.append(float(u.get("applies", 0))); mus.append(float(u.get("mu_fwd", 0)))
-    cells.append("none"); weights.append(float(obj.get("none", {}).get("applies", 0))); mus.append(0.0)
+    weights.append(float(u.get("applies", 0)))
+    mf.append(float(u.get("mu_fwd", 0))); mr.append(float(u.get("mu_rev", 0)))
+    cells.append("none"); weights.append(float(obj.get("none", {}).get("applies", 0))); mf.append(0.0); mr.append(0.0)
     tot = sum(weights) or 1.0
     probs = [w / tot for w in weights]
-    return cells, probs, mus
+    return cells, probs, mf, mr
 
 
 def ingest(pairs_path, responses_path, out, judge="haiku"):
@@ -166,17 +168,18 @@ def ingest(pairs_path, responses_path, out, judge="haiku"):
     cells = NAMED_DIR + NAMED_SYM + ["unknown", "none"]
     with open(out, "w", encoding="utf-8") as f:
         f.write("# node\troot\tcur_rel\tneighborhood\tjudge\t" + "\t".join(f"P[{c}]" for c in cells)
-                + "\t" + "\t".join(f"mu[{c}]" for c in cells) + "\tE_mu_fwd\n")
+                + "\t" + "\t".join(f"mu[{c}]" for c in cells) + "\tE_mu_fwd\tE_mu_rev\n")
         n = 0
         for i, p in enumerate(pairs):
             o = by_id.get(i)
             if not o:
                 continue
-            cs, probs, mus = _cell_partition(o)
-            emu = sum(pr * mu for pr, mu in zip(probs, mus))
+            cs, probs, mf, mr = _cell_partition(o)
+            emf = sum(pr * m for pr, m in zip(probs, mf))
+            emr = sum(pr * m for pr, m in zip(probs, mr))
             f.write("\t".join([p[0], p[1], p[2], p[4], judge]) + "\t"
                     + "\t".join(f"{x:.3f}" for x in probs) + "\t"
-                    + "\t".join(f"{x:.3f}" for x in mus) + f"\t{emu:.3f}\n")
+                    + "\t".join(f"{x:.3f}" for x in mf) + f"\t{emf:.3f}\t{emr:.3f}\n")
             n += 1
     print(f"ingested {n}/{len(pairs)} pairs (judge={judge}) → {out}")
 

--- a/prototypes/mu_cosine/score_inferred_tail.py
+++ b/prototypes/mu_cosine/score_inferred_tail.py
@@ -112,7 +112,8 @@ Output STRICT JSON: a list, one object per pair IN ORDER, each:
   {"id": <int>, "element_of":{"mu_fwd":_,"mu_rev":_,"applies":_}, "subcategory":{...}, "subtopic":{...},
    "super_category":{...}, "see_also":{"mu":_,"applies":_}, "assoc":{"mu":_,"applies":_},
    "none":{"applies":_}, "unknown":{"mu_fwd":_,"mu_rev":_,"applies":_}}
-Output ONLY the JSON list, nothing else.
+BE TERSE: output COMPACT single-line JSON objects (no extra whitespace/newlines inside an object), no prose,
+no explanation, do NOT restate these rules. Just the raw JSON array.
 
 PAIRS:
 """
@@ -180,6 +181,28 @@ def ingest(pairs_path, responses_path, out):
     print(f"ingested {n}/{len(pairs)} pairs → {out}")
 
 
+def flag(scored_path, pairs_path, none_min, out):
+    """Escalation selector: every tail row IS a graph edge (conf<1.0 asserts a relation), so a high Haiku
+    `P[none]` is a direct graph↔Haiku contradiction. Emit those rows (none >= none_min) as a pairs file to
+    re-judge with a STRONGER model (Sonnet ¼-budget, Opus less) — the selective multi-source tie-break."""
+    scored = {}
+    sh = open(scored_path, encoding="utf-8").readline().strip().split("\t")
+    ni = sh.index("P[none]")
+    for r in (l.rstrip("\n").split("\t") for l in open(scored_path, encoding="utf-8") if not l.startswith("#")):
+        scored[(r[0].lower(), r[1].lower())] = float(r[ni])
+    kept = []
+    for ln in open(pairs_path, encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        p = ln.rstrip("\n").split("\t")
+        if scored.get((p[0].lower(), p[1].lower()), 0.0) >= none_min:
+            kept.append(ln.rstrip("\n"))
+    with open(out, "w", encoding="utf-8") as f:
+        f.write("# node_title\troot_title\tcur_relation\tconf\tneighborhood\tnode_type\troot_type\traw\n")
+        f.write("\n".join(kept) + ("\n" if kept else ""))
+    print(f"flagged {len(kept)} sharp rows (Haiku P[none] >= {none_min}) → {out}")
+
+
 def main():
     ap = argparse.ArgumentParser()
     sub = ap.add_subparsers(dest="cmd", required=True)
@@ -188,9 +211,13 @@ def main():
     pr = sub.add_parser("prompt"); pr.add_argument("--pairs", required=True); pr.add_argument("--batch", type=int, default=10)
     ig = sub.add_parser("ingest"); ig.add_argument("--pairs", required=True)
     ig.add_argument("--responses", required=True); ig.add_argument("--out", required=True)
+    fl = sub.add_parser("flag"); fl.add_argument("--scored", required=True); fl.add_argument("--pairs", required=True)
+    fl.add_argument("--none-min", type=float, default=0.3); fl.add_argument("--out", required=True)
     a = ap.parse_args()
     if a.cmd == "extract":
         extract(a.neighborhoods, a.out)
+    elif a.cmd == "flag":
+        flag(a.scored, a.pairs, a.none_min, a.out)
     elif a.cmd == "prompt":
         pairs = [ln.rstrip("\n").split("\t") for ln in open(a.pairs, encoding="utf-8") if not ln.startswith("#")]
         for i, pr_text in enumerate(build_prompts(pairs, a.batch)):

--- a/prototypes/mu_cosine/score_inferred_tail.py
+++ b/prototypes/mu_cosine/score_inferred_tail.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Augment the INFERRED TAIL with Haiku-estimated cell distributions (DESIGN §9/§14).
+
+The inferred tail = the conf<1.0 rows of the fused neighbourhoods (`context/*_edges.tsv`) — the untagged
+relations the anchored basis exists to serve. This script (a) EXTRACTS those pairs with readable
+titles+context, (b) builds the §14 prompt for a Haiku subagent, (c) INGESTS the returned JSON into a cached
+partition + E[μ] per pair (feeding `cell_sampler`). Haiku is the distribution SOURCE; the draw/closure is ours.
+
+Spends NO budget itself — extraction + ingest are pure I/O; the Haiku call is a separate subagent step.
+
+  python3 score_inferred_tail.py extract --out inferred_tail_pilot.tsv [--neighborhoods lti circuit]
+  python3 score_inferred_tail.py prompt  --pairs inferred_tail_pilot.tsv [--batch 10]   # prints §14 prompt(s)
+  python3 score_inferred_tail.py ingest  --pairs inferred_tail_pilot.tsv --responses haiku_resp.json \
+                                         --out haiku_scored_tail.tsv
+"""
+import argparse
+import glob
+import json
+import os
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+CTX = os.path.join(ROOT, "context")
+
+# the untagged relations §14 estimates (bridge = title-match IDENTITY heuristic, excluded — not a "which
+# relation" question). conf<1.0 AND relation in this set = the genuinely-untagged tail.
+TAIL_RELS = {"assoc", "subtopic", "element_of", "see_also", "super_category", "subcategory"}
+
+NAMED_DIR = ["element_of", "subcategory", "subtopic", "super_category"]   # directional (mu_fwd + mu_rev)
+NAMED_SYM = ["see_also", "assoc"]                                         # symmetric (single mu)
+NAMED = NAMED_DIR + NAMED_SYM
+
+
+def _load_nodes(prefix):
+    m = {}
+    p = os.path.join(CTX, prefix + "_nodes.tsv")
+    if not os.path.exists(p):
+        return m
+    for ln in open(p, encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        c = ln.rstrip("\n").split("\t")
+        if len(c) >= 4:
+            m[c[0]] = (c[3], c[2])            # key -> (title, node_type)
+    return m
+
+
+def extract(neighborhoods, out):
+    prefixes = []
+    for p in sorted(glob.glob(os.path.join(CTX, "*_edges.tsv"))):
+        base = os.path.basename(p)[:-len("_edges.tsv")]
+        if neighborhoods and not any(base.startswith(n) for n in neighborhoods):
+            continue
+        prefixes.append(base)
+    seen, rows = set(), []
+    for base in prefixes:
+        nodes = _load_nodes(base)
+        for ln in open(os.path.join(CTX, base + "_edges.tsv"), encoding="utf-8"):
+            if ln.startswith("#"):
+                continue
+            c = (ln.rstrip("\n").split("\t") + ["", "", "", "", ""])[:5]
+            a, b, rel, conf, raw = c
+            if not a or not b or rel not in TAIL_RELS:
+                continue
+            try:
+                if float(conf) >= 1.0:
+                    continue
+            except ValueError:
+                continue
+            at, atype = nodes.get(a, (a.split(":", 1)[-1].replace("-", " "), "?"))
+            bt, btype = nodes.get(b, (b.split(":", 1)[-1].replace("-", " "), "?"))
+            key = (at.lower(), bt.lower())
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append((at, bt, rel, conf, base, atype, btype, raw))
+    with open(out, "w", encoding="utf-8") as f:
+        f.write("# node_title\troot_title\tcur_relation\tconf\tneighborhood\tnode_type\troot_type\traw\n")
+        for r in rows:
+            f.write("\t".join(r) + "\n")
+    from collections import Counter
+    print(f"extracted {len(rows)} inferred-tail pairs → {out}")
+    print(f"  by relation: {dict(Counter(r[2] for r in rows))}")
+    print(f"  by neighborhood: {dict(Counter(r[4] for r in rows))}")
+    return rows
+
+
+PROMPT_HEADER = """You estimate fuzzy DIRECTIONAL relationships between two concept nodes in a knowledge graph.
+For each pair (NODE, ROOT) below, rate how NODE relates to ROOT.
+
+RELATIONS — directional (give mu_fwd AND mu_rev):
+  element_of      NODE is a member/instance/element of ROOT
+  subcategory     NODE is a narrower category beneath ROOT (taxonomic child)
+  subtopic        NODE is a subtopic within ROOT's subject
+  super_category  NODE is a broader category that CONTAINS ROOT (taxonomic parent)
+RELATIONS — symmetric (give a SINGLE mu):
+  see_also        a lateral relation — NODE and ROOT directly reference each other (a deliberate cross-link)
+  assoc           a lateral relation that is looser/weaker than see_also (incidental co-occurrence)
+  Note: see_also and assoc are close and overlap. If laterally related but you can't cleanly tell which,
+  put mass on BOTH (lean see_also for a deliberate link, assoc for a vague one). Don't agonize over it.
+
+Two OPEN-WORLD slots:
+  none     applies = probability NO listed relation holds (pair unrelated); its mu is 0
+  unknown  applies = probability a REAL relation holds but is NOT listed; give its mu_fwd / mu_rev too
+
+TWO RULES — read carefully:
+  (1) mu_* are FUZZY-SET memberships in [0,1], NOT a distribution. Independent; need NOT sum to 1; their
+      sum MAY EXCEED 1 when relations overlap (a pair can be element_of AND subtopic). DO NOT normalize.
+  (2) the `applies` values over the LISTED relations need NOT sum to 1 and SHOULD sum to LESS than 1 when
+      unsure — leftover mass belongs to none + unknown. DO NOT inflate the listed ones to reach 1.
+
+Output STRICT JSON: a list, one object per pair IN ORDER, each:
+  {"id": <int>, "element_of":{"mu_fwd":_,"mu_rev":_,"applies":_}, "subcategory":{...}, "subtopic":{...},
+   "super_category":{...}, "see_also":{"mu":_,"applies":_}, "assoc":{"mu":_,"applies":_},
+   "none":{"applies":_}, "unknown":{"mu_fwd":_,"mu_rev":_,"applies":_}}
+Output ONLY the JSON list, nothing else.
+
+PAIRS:
+"""
+
+
+def build_prompts(pairs, batch):
+    out = []
+    for s in range(0, len(pairs), batch):
+        chunk = pairs[s:s + batch]
+        lines = [PROMPT_HEADER]
+        for i, r in enumerate(chunk):
+            ctx = f'  (NODE type={r[5]}, ROOT type={r[6]}' + (f', section="{r[7]}"' if r[7] else "") + ")"
+            lines.append(f'{s + i}. NODE: "{r[0]}"   ROOT: "{r[1]}"\n{ctx}')
+        out.append("\n".join(lines))
+    return out
+
+
+def _cell_partition(obj):
+    """§14 → §12(5) closure: applies[named]++none++unknown, renormalised to a categorical that sums to 1.
+    Returns (cells, probs, mus) where mus[i] is the per-cell μ (forward) for E[μ]; symmetric cells use mu."""
+    cells, weights, mus = [], [], []
+    for r in NAMED_DIR:
+        e = obj.get(r, {})
+        cells.append(r); weights.append(float(e.get("applies", 0))); mus.append(float(e.get("mu_fwd", 0)))
+    for r in NAMED_SYM:
+        e = obj.get(r, {})
+        cells.append(r); weights.append(float(e.get("applies", 0))); mus.append(float(e.get("mu", 0)))
+    cells.append("unknown"); u = obj.get("unknown", {})
+    weights.append(float(u.get("applies", 0))); mus.append(float(u.get("mu_fwd", 0)))
+    cells.append("none"); weights.append(float(obj.get("none", {}).get("applies", 0))); mus.append(0.0)
+    tot = sum(weights) or 1.0
+    probs = [w / tot for w in weights]
+    return cells, probs, mus
+
+
+def ingest(pairs_path, responses_path, out):
+    pairs = [ln.rstrip("\n").split("\t") for ln in open(pairs_path, encoding="utf-8") if not ln.startswith("#")]
+    raw = open(responses_path, encoding="utf-8").read()
+    raw = raw.replace("```json", " ").replace("```", " ")          # strip any markdown fences
+    # robustly consume one-or-more concatenated JSON arrays/objects, separated by any whitespace
+    dec, objs, i = json.JSONDecoder(), [], 0
+    while i < len(raw):
+        while i < len(raw) and raw[i].isspace():
+            i += 1
+        if i >= len(raw):
+            break
+        val, i = dec.raw_decode(raw, i)
+        objs.extend(val if isinstance(val, list) else [val])
+    by_id = {int(o["id"]): o for o in objs if "id" in o}
+    cells = NAMED_DIR + NAMED_SYM + ["unknown", "none"]
+    with open(out, "w", encoding="utf-8") as f:
+        f.write("# node\troot\tcur_rel\tneighborhood\t" + "\t".join(f"P[{c}]" for c in cells)
+                + "\t" + "\t".join(f"mu[{c}]" for c in cells) + "\tE_mu_fwd\n")
+        n = 0
+        for i, p in enumerate(pairs):
+            o = by_id.get(i)
+            if not o:
+                continue
+            cs, probs, mus = _cell_partition(o)
+            emu = sum(pr * mu for pr, mu in zip(probs, mus))
+            f.write("\t".join([p[0], p[1], p[2], p[4]]) + "\t"
+                    + "\t".join(f"{x:.3f}" for x in probs) + "\t"
+                    + "\t".join(f"{x:.3f}" for x in mus) + f"\t{emu:.3f}\n")
+            n += 1
+    print(f"ingested {n}/{len(pairs)} pairs → {out}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    e = sub.add_parser("extract"); e.add_argument("--out", required=True)
+    e.add_argument("--neighborhoods", nargs="*", default=None)
+    pr = sub.add_parser("prompt"); pr.add_argument("--pairs", required=True); pr.add_argument("--batch", type=int, default=10)
+    ig = sub.add_parser("ingest"); ig.add_argument("--pairs", required=True)
+    ig.add_argument("--responses", required=True); ig.add_argument("--out", required=True)
+    a = ap.parse_args()
+    if a.cmd == "extract":
+        extract(a.neighborhoods, a.out)
+    elif a.cmd == "prompt":
+        pairs = [ln.rstrip("\n").split("\t") for ln in open(a.pairs, encoding="utf-8") if not ln.startswith("#")]
+        for i, pr_text in enumerate(build_prompts(pairs, a.batch)):
+            print(f"\n===== BATCH {i} =====\n{pr_text}")
+    elif a.cmd == "ingest":
+        ingest(a.pairs, a.responses, a.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/score_inferred_tail.py
+++ b/prototypes/mu_cosine/score_inferred_tail.py
@@ -149,7 +149,7 @@ def _cell_partition(obj):
     return cells, probs, mus
 
 
-def ingest(pairs_path, responses_path, out):
+def ingest(pairs_path, responses_path, out, judge="haiku"):
     pairs = [ln.rstrip("\n").split("\t") for ln in open(pairs_path, encoding="utf-8") if not ln.startswith("#")]
     raw = open(responses_path, encoding="utf-8").read()
     raw = raw.replace("```json", " ").replace("```", " ")          # strip any markdown fences
@@ -165,7 +165,7 @@ def ingest(pairs_path, responses_path, out):
     by_id = {int(o["id"]): o for o in objs if "id" in o}
     cells = NAMED_DIR + NAMED_SYM + ["unknown", "none"]
     with open(out, "w", encoding="utf-8") as f:
-        f.write("# node\troot\tcur_rel\tneighborhood\t" + "\t".join(f"P[{c}]" for c in cells)
+        f.write("# node\troot\tcur_rel\tneighborhood\tjudge\t" + "\t".join(f"P[{c}]" for c in cells)
                 + "\t" + "\t".join(f"mu[{c}]" for c in cells) + "\tE_mu_fwd\n")
         n = 0
         for i, p in enumerate(pairs):
@@ -174,11 +174,11 @@ def ingest(pairs_path, responses_path, out):
                 continue
             cs, probs, mus = _cell_partition(o)
             emu = sum(pr * mu for pr, mu in zip(probs, mus))
-            f.write("\t".join([p[0], p[1], p[2], p[4]]) + "\t"
+            f.write("\t".join([p[0], p[1], p[2], p[4], judge]) + "\t"
                     + "\t".join(f"{x:.3f}" for x in probs) + "\t"
                     + "\t".join(f"{x:.3f}" for x in mus) + f"\t{emu:.3f}\n")
             n += 1
-    print(f"ingested {n}/{len(pairs)} pairs → {out}")
+    print(f"ingested {n}/{len(pairs)} pairs (judge={judge}) → {out}")
 
 
 def flag(scored_path, pairs_path, none_min, out):
@@ -211,6 +211,7 @@ def main():
     pr = sub.add_parser("prompt"); pr.add_argument("--pairs", required=True); pr.add_argument("--batch", type=int, default=10)
     ig = sub.add_parser("ingest"); ig.add_argument("--pairs", required=True)
     ig.add_argument("--responses", required=True); ig.add_argument("--out", required=True)
+    ig.add_argument("--judge", default="haiku", help="provenance tag for these scores (haiku/sonnet/opus)")
     fl = sub.add_parser("flag"); fl.add_argument("--scored", required=True); fl.add_argument("--pairs", required=True)
     fl.add_argument("--none-min", type=float, default=0.3); fl.add_argument("--out", required=True)
     a = ap.parse_args()
@@ -223,7 +224,7 @@ def main():
         for i, pr_text in enumerate(build_prompts(pairs, a.batch)):
             print(f"\n===== BATCH {i} =====\n{pr_text}")
     elif a.cmd == "ingest":
-        ingest(a.pairs, a.responses, a.out)
+        ingest(a.pairs, a.responses, a.out, a.judge)
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/test_anchored_basis.py
+++ b/prototypes/mu_cosine/test_anchored_basis.py
@@ -67,6 +67,18 @@ def test_anchored_relation_k0_anchors_only():
     assert op_w.shape == (8, 3) and w.shape == (8, 4)                 # K=0: only anchors, fixed mapping
 
 
+def test_symmetric_e5_tied_keys():
+    # §8c proper: query is an e5 vector (header text), anchor keys TIED to the frozen e5 values (no q_proj)
+    ar = AnchoredRelation(torch.randn(4, 384), anchor_ops=[0, 1, 2, 2], n_ops=3, n_atoms=5, symmetric=True)
+    assert ar.basis.anchor_keys is None                              # tied to frozen anchor_values
+    q = torch.randn(8, 384)                                          # query lives in e5 space (d_model)
+    op_w, w = ar(q)
+    assert op_w.shape == (8, 3) and w.shape == (8, 4 + 5)
+    assert torch.allclose(op_w.sum(-1), torch.ones(8), atol=1e-5)
+    op_w.sum().backward()
+    assert ar.basis.atom_keys.grad is not None and ar.atom_op_logits.grad is not None
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     for t in tests:

--- a/prototypes/mu_cosine/test_anchored_basis.py
+++ b/prototypes/mu_cosine/test_anchored_basis.py
@@ -3,7 +3,7 @@
 Run: `python3 test_anchored_basis.py`."""
 import torch
 
-from anchored_basis import AnchoredBasis, AnchoredRelation
+from anchored_basis import AnchoredBasis, AnchoredRelation, TypedQuery
 
 
 def test_shapes_and_simplex():
@@ -77,6 +77,20 @@ def test_symmetric_e5_tied_keys():
     assert torch.allclose(op_w.sum(-1), torch.ones(8), atol=1e-5)
     op_w.sum().backward()
     assert ar.basis.atom_keys.grad is not None and ar.atom_op_logits.grad is not None
+
+
+def test_typed_query_tokens():
+    tq = TypedQuery({"mu": 6, "label": 384, "header": 384}, d_k=64, core=("mu",), dropout=0.5)
+    inp = {"mu": torch.randn(8, 6), "label": torch.randn(8, 384), "header": torch.randn(8, 384)}
+    q = tq(inp)
+    assert q.shape == (8, 64)
+    # core (mu) is NOT dropped; the extras get a distinct learned type embedding
+    assert "mu" in tq.core and "label" not in tq.core
+    q.sum().backward()
+    assert tq.proj["header"].weight.grad is not None and tq.type_emb["label"].grad is not None
+    # eval mode = no dropout (deterministic)
+    tq.eval()
+    assert torch.allclose(tq(inp), tq(inp))
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/test_anchored_basis.py
+++ b/prototypes/mu_cosine/test_anchored_basis.py
@@ -3,7 +3,7 @@
 Run: `python3 test_anchored_basis.py`."""
 import torch
 
-from anchored_basis import AnchoredBasis
+from anchored_basis import AnchoredBasis, AnchoredRelation
 
 
 def test_shapes_and_simplex():
@@ -44,6 +44,27 @@ def test_zero_atoms_is_k0_special_case():
     ab = AnchoredBasis(torch.randn(4, 384), n_atoms=0, d_query=6, d_k=64)   # §8: K=0 = anchors-only
     token, w = ab(torch.randn(8, 6))
     assert w.shape == (8, 4) and token.shape == (8, 384)
+
+
+def test_anchored_relation_op_weights():
+    # 4 anchors mapping to 3 operators (e.g. element_of→0, subcategory→1, see_also→2, bridge→2) + 5 atoms → 3 ops
+    anchor_ops = [0, 1, 2, 2]
+    ar = AnchoredRelation(torch.randn(4, 384), anchor_ops=anchor_ops, n_ops=3, n_atoms=5, d_query=6, d_k=64)
+    q = torch.randn(8, 6)
+    op_w, w = ar(q)
+    assert op_w.shape == (8, 3) and w.shape == (8, 4 + 5)
+    assert torch.allclose(op_w.sum(-1), torch.ones(8), atol=1e-5)     # op_weights is a simplex too
+    assert (op_w >= 0).all()
+    # gradient reaches the learned atom→op mapping AND the atom basis params
+    op_w.sum().backward()
+    assert ar.atom_op_logits.grad is not None and ar.atom_op_logits.grad.abs().sum() > 0
+    assert ar.basis.atom_keys.grad is not None
+
+
+def test_anchored_relation_k0_anchors_only():
+    ar = AnchoredRelation(torch.randn(4, 384), anchor_ops=[0, 1, 2, 2], n_ops=3, n_atoms=0, d_query=6, d_k=64)
+    op_w, w = ar(torch.randn(8, 6))
+    assert op_w.shape == (8, 3) and w.shape == (8, 4)                 # K=0: only anchors, fixed mapping
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/test_cell_sampler.py
+++ b/prototypes/mu_cosine/test_cell_sampler.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Tests for the hard-cell sampler + E[μ] reducers (DESIGN §12/§13). Pure python, no torch.
+Run: `python3 test_cell_sampler.py`."""
+import math
+import random
+
+from cell_sampler import sample_index, threshold_to_cell, expected, mc_expected, n_for_se
+
+
+def test_sample_index_matches_distribution():
+    rng = random.Random(0)
+    p = [0.1, 0.6, 0.3]
+    counts = [0, 0, 0]
+    N = 40000
+    for _ in range(N):
+        counts[sample_index(p, rng)] += 1
+    for i in range(3):
+        assert abs(counts[i] / N - p[i]) < 0.02, (i, counts[i] / N, p[i])   # empirical ≈ P
+
+
+def test_sample_index_isolated_and_reproducible():
+    p = [0.25, 0.25, 0.5]
+    a = [sample_index(p, random.Random(7)) for _ in range(50)]
+    b = [sample_index(p, random.Random(7)) for _ in range(50)]
+    assert a == b                                                           # same seed → same draws (§12(4))
+
+
+def test_sample_index_unnormalised_ok():
+    rng = random.Random(1)
+    p = [2.0, 6.0, 2.0]                                                     # sums to 10, not 1
+    counts = [0, 0, 0]
+    for _ in range(20000):
+        counts[sample_index(p, rng)] += 1
+    assert abs(counts[1] / 20000 - 0.6) < 0.02
+
+
+def test_threshold_construction_singleton_overlap_none():
+    assert threshold_to_cell([0.7, 0.2, 0.1], tau=0.25) == (0,)            # singleton anchor
+    assert threshold_to_cell([0.4, 0.4, 0.2], tau=0.25) == (0, 1)          # overlap cell (2+ rels)
+    assert threshold_to_cell([0.2, 0.2, 0.2], tau=0.25) == ()             # empty → none (§9)
+    assert threshold_to_cell([0.25, 0.1, 0.1], tau=0.25) == (0,)           # boundary inclusive (>= tau)
+
+
+def test_expected_is_convex_combination():
+    p = [0.2, 0.3, 0.5]
+    mu = [0.9, 0.4, 0.0]                                                    # last = none cell, μ≈0
+    e = expected(p, mu)
+    assert abs(e - (0.2 * 0.9 + 0.3 * 0.4 + 0.5 * 0.0)) < 1e-9
+    assert min(mu) <= e <= max(mu)                                          # bounded (§10)
+
+
+def test_expected_normalises_defensively():
+    assert abs(expected([2, 3, 5], [0.9, 0.4, 0.0]) - expected([0.2, 0.3, 0.5], [0.9, 0.4, 0.0])) < 1e-9
+
+
+def test_mc_converges_to_analytic():
+    p = [0.2, 0.3, 0.5]
+    mu = [0.9, 0.4, 0.0]
+    mu_fn = lambda i: mu[i]                                                 # hard-cell readout
+    mean, se = mc_expected(p, mu_fn, random.Random(3), n=20000)
+    assert abs(mean - expected(p, mu)) < 0.01                              # MC → analytic (§12(6))
+    assert se < 0.01 and math.isfinite(se)
+
+
+def test_mc_se_shrinks_with_n():
+    p, mu = [0.5, 0.5], [1.0, 0.0]
+    _, se_small = mc_expected(p, lambda i: mu[i], random.Random(4), n=64)
+    _, se_big = mc_expected(p, lambda i: mu[i], random.Random(4), n=4096)
+    assert se_big < se_small                                                # SE = std/sqrt(N) ↓
+
+
+def test_n_for_se_rule():
+    assert n_for_se(0.1, 0.02) == 25                                        # (0.1/0.02)^2 = 25
+    assert n_for_se(0.1, 0.02) <= 32                                        # trainer default N=32 has headroom
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"  ok  {t.__name__}")
+    print(f"all {len(tests)} cell_sampler tests passed")

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -223,6 +223,53 @@ def graded_hold_mse(model, tok, graded_hold, use_nodetype):
 
 
 @torch.no_grad()
+def eval_tail(model, tok, graded_text, nodes_path, tail_path, use_nodetype, mode="uniform"):
+    """§9/§12(3) held-out-TAIL eval: the model's E[μ] under an operator SUPERPOSITION vs the cached LLM E[μ],
+    on tail rows the model never trained the LLM target for. `uniform` = equal weight over operators (none
+    excluded — the base model has no none operator) = the unconditional expectation. Reports corr + MSE."""
+    was = model.training; model.eval()
+    title2key, ntype = {}, {}
+    if nodes_path and os.path.exists(nodes_path):
+        for ln in open(nodes_path, encoding="utf-8"):
+            if ln.startswith("#"):
+                continue
+            c = ln.rstrip("\n").split("\t")                  # key corpus node_type title [embed]
+            if len(c) >= 4:
+                title2key.setdefault(c[3].lower(), c[0]); ntype[c[0]] = c[2]
+    hdr = open(tail_path, encoding="utf-8").readline().lstrip("#").strip().split("\t")
+    fi = hdr.index("E_mu_fwd")
+    items, tgt = [], []
+    for ln in open(tail_path, encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        c = ln.rstrip("\n").split("\t")
+        nk, rk = title2key.get(c[0].lower()), title2key.get(c[1].lower())
+        if not nk or not rk or nk not in tok.idx or rk not in tok.idx:
+            continue
+        if use_nodetype:
+            items.append((nk, rk, 0, CORPORA["pearltrees"], JUDGES["haiku"], nt(ntype.get(nk, "")), nt(ntype.get(rk, ""))))
+        else:
+            items.append((nk, rk, 0, CORPORA["pearltrees"], JUDGES["haiku"]))
+        tgt.append(float(c[fi]))
+    if not items:
+        print("[TAIL] 0 tail rows matched the model vocab — check the graded nodes file"); return
+    dev = next(model.parameters()).device
+    n_ops = model.op_emb.weight.shape[0]
+    preds = []
+    for i in range(0, len(items), 256):
+        chunk = items[i:i + 256]
+        b = tok.build(chunk, train=False)
+        b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+        ow = torch.full((len(chunk), n_ops), 1.0 / n_ops, device=dev)     # equal-weight superposition (§ user)
+        preds += model(**b, op_weights=ow).cpu().tolist()
+    mse = sum((p - t) ** 2 for p, t in zip(preds, tgt)) / len(tgt)
+    if was:
+        model.train()
+    print(f"[TAIL] ({mode}) {len(tgt)} held-out tail rows — model E[μ] vs Haiku E[μ]: corr {pearson(preds, tgt):+.3f}"
+          f"  MSE {mse:.4f}  (model μ̄ {sum(preds)/len(preds):.3f}, haiku μ̄ {sum(tgt)/len(tgt):.3f})")
+
+
+@torch.no_grad()
 def emit_dense(model, tok, names, op, root="Physics", bs=512):
     items = [(n, root, OPS[op]) for n in names]
     mu = mu_batch(model, tok, items, bs)
@@ -662,6 +709,9 @@ def train(args):
     model.eval()
     validate(model, tok, names, idx, adj, edges_hold, pos_hold, llm, args, elem_hold=elem_hold,
              graded_hold=graded_hold)
+    if args.eval_tail and os.path.exists(args.eval_tail):     # §9 held-out-tail eval (the tail-specific instrument)
+        _ntp = args.graded_nodes or (args.graded.replace("_pairs.tsv", "_nodes.tsv") if args.graded else None)
+        eval_tail(model, tok, graded_text, _ntp, args.eval_tail, args.use_nodetype)
     if args.save and not es_saved:                        # early-stop already saved the best; else save the final
         torch.save({"state": model.state_dict(), "cfg": {"d_model": q.shape[1], "heads": args.heads,
                     "layers": args.layers}}, args.save)
@@ -950,6 +1000,8 @@ def main():
                     "<out>_pairs.tsv); its <out>_nodes.tsv supplies the e5 embed_text per fused node")
     ap.add_argument("--haiku-tail", default=None, help="cached LLM E[μ] scores (score_inferred_tail.py) — "
                     "override inferred (conf<1.0) graded targets with E[μ] + judge provenance (§9/§14)")
+    ap.add_argument("--eval-tail", default=None, help="§9/§12(3) held-out-tail eval: model E[μ] (uniform op "
+                    "superposition) vs cached Haiku E[μ] on these tail rows (needs --graded for the title↔key map)")
     ap.add_argument("--graded-nodes", default=None, help="override the graded nodes file (default: derive "
                     "from --graded by _pairs→_nodes)")
     ap.add_argument("--graded-weight", type=float, default=1.0, help="graded-round loss weight")

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -627,7 +627,9 @@ def train(args):
             else:
                 gi = [(r[0], r[1], OPS[graded_op(r)], CORPORA[r[7]], JUDGES[r[8]]) for r in gb]
             gt = torch.tensor([r[2] for r in gb]).to(device)
-            gw = torch.tensor([args.bridge_weight if r[4] == "bridge" else 1.0 for r in gb]).to(device)
+            gw = torch.tensor([args.bridge_weight if r[4] == "bridge"
+                               else (args.tail_weight if (len(r) > 9 and r[9] < 1.0) else 1.0)
+                               for r in gb]).to(device)            # §13: upweight the inferred tail to fight dilution
             mu_g = model(**bld(gi, train=True, rng=rng, p_mask_prov=args.prov_mask))
             L_graded = (gw * (mu_g - gt) ** 2).sum() / gw.sum().clamp_min(1.0)
         # INFER-BLEND: inferred rows trained with a RANDOM operator embedding from the fitted joint posterior
@@ -1005,6 +1007,8 @@ def main():
     ap.add_argument("--graded-nodes", default=None, help="override the graded nodes file (default: derive "
                     "from --graded by _pairs→_nodes)")
     ap.add_argument("--graded-weight", type=float, default=1.0, help="graded-round loss weight")
+    ap.add_argument("--tail-weight", type=float, default=1.0, help="§13: loss-weight multiplier for the inferred "
+                    "tail (conf<1.0, non-bridge) — counters dilution (~7%→30%% effective share at ~6)")
     ap.add_argument("--bridge-weight", type=float, default=0.2, help="down-weight bridge targets in the "
                     "graded loss (they dominate at μ≈0.9; keep them from swamping directional signal)")
     ap.add_argument("--infer-switch", action="store_true", help="for INFERRED graded relations (confidence "

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -137,6 +137,36 @@ def load_graded(pairs_path, nodes_path=None):
     return rows, node_text
 
 
+def apply_haiku_tail(graded_rows, graded_text, path):
+    """§9/§14 distributional augmentation: override the INFERRED (conf<1.0) graded rows' target μ with the
+    cached LLM E[μ] — forward or reverse by TITLE match — and stamp the judge provenance (haiku/sonnet/opus,
+    the stronger judge wins on a dup). Tagged rows (conf=1.0) are untouched. Returns (rows, n_overridden)."""
+    rank = {"haiku": 0, "graph": 0, "human": 0, "sonnet": 1, "opus": 2}
+    hdr = open(path, encoding="utf-8").readline().lstrip("#").strip().split("\t")
+    ji, fi, ri = hdr.index("judge"), hdr.index("E_mu_fwd"), hdr.index("E_mu_rev")
+    sc = {}                                                       # (node_title, root_title) → (E_fwd, E_rev, judge)
+    for ln in open(path, encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        c = ln.rstrip("\n").split("\t")
+        k = (c[0].lower(), c[1].lower()); cand = (float(c[fi]), float(c[ri]), c[ji])
+        if k not in sc or rank.get(c[ji], 0) > rank.get(sc[k][2], 0):
+            sc[k] = cand
+    out, n = [], 0
+    for r in graded_rows:
+        conf = r[9] if len(r) > 9 else 1.0
+        if conf < 1.0:                                           # inferred tail → eligible for the LLM E[μ]
+            nt = graded_text.get(r[0], "").lower(); rt = graded_text.get(r[1], "").lower()
+            hit, di = sc.get((nt, rt)), 0
+            if hit is None:
+                hit, di = sc.get((rt, nt)), 1                    # this graded row is the reverse direction
+            if hit is not None:
+                r = (r[0], r[1], hit[di], r[3], r[4], r[5], r[6], r[7], hit[2], r[9], r[10] if len(r) > 10 else "")
+                n += 1
+        out.append(r)
+    return out, n
+
+
 def load_mu(path):
     out = {}
     with open(path) as f:
@@ -240,6 +270,10 @@ def train(args):
     graded_rows, graded_text = ([], {})
     if args.graded and os.path.exists(args.graded):
         graded_rows, graded_text = load_graded(args.graded, args.graded_nodes)
+        if args.haiku_tail and os.path.exists(args.haiku_tail):   # §9/§14: LLM E[μ] targets for the inferred tail
+            graded_rows, _n_ht = apply_haiku_tail(graded_rows, graded_text, args.haiku_tail)
+            print(f"HAIKU-TAIL (§9/§14): overrode {_n_ht} inferred graded targets with cached LLM E[μ] "
+                  f"+ judge provenance from {os.path.basename(args.haiku_tail)}")
         for _k, _t in graded_text.items():
             if _k not in set(names):
                 extra.add(_k); extra_texts[_k] = _t
@@ -914,6 +948,8 @@ def main():
     ap.add_argument("--pairs", default=PAIRS, help="scored SYM pairs file (use mu_pairs_scored_large_260620-223001.tsv)")
     ap.add_argument("--graded", default=None, help="fused multi-corpus graded round (build_graded_round.py "
                     "<out>_pairs.tsv); its <out>_nodes.tsv supplies the e5 embed_text per fused node")
+    ap.add_argument("--haiku-tail", default=None, help="cached LLM E[μ] scores (score_inferred_tail.py) — "
+                    "override inferred (conf<1.0) graded targets with E[μ] + judge provenance (§9/§14)")
     ap.add_argument("--graded-nodes", default=None, help="override the graded nodes file (default: derive "
                     "from --graded by _pairs→_nodes)")
     ap.add_argument("--graded-weight", type=float, default=1.0, help="graded-round loss weight")

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -409,7 +409,7 @@ def train(args):
     # ANCHORED-BASIS (DESIGN §8): compute the blend op_weights via attention over frozen e5-phrase relation
     # ANCHORS + K learnable ATOMS instead of the JointPosterior+Dirichlet. Static query = §8c fusion
     # [μ_vec(warm) ++ provenance ++ e5_raw]; the anchor-KL pins the anchor block to the categoriser confidence.
-    anchored_rel, anchor_q, anchor_tgt = None, None, None
+    anchored_rel, anchor_q, anchor_tgt, typed_q, anchor_inputs = None, None, None, None, None
     if args.anchored_basis and (graded_inf or blend_tag_on):
         from anchored_basis import AnchoredRelation
         from section_embed import e5_encoder
@@ -435,7 +435,24 @@ def train(args):
                 _e5[i] = tok.p[idx[r[0]]].numpy()
         # query: `header` = §8c proper — e5(section-header text) attends SYMMETRICALLY to the e5 label
         # anchors (the embedding categoriser); `full` = the v1 fusion; `mu` = μ_vec only (architecture ablation)
-        if args.anchor_query == "header":
+        if args.anchor_query == "typed":                              # §8c token-set: μ + label-e5 + header-e5
+            from anchored_basis import TypedQuery
+            _label = _np.zeros((len(blend_all), _av.shape[1]), dtype="float32")
+            for i, r in enumerate(blend_all):
+                jj = _ri.get(r[4])
+                if jj is not None:
+                    _label[i] = _av[jj].numpy()                       # e5 of the row's categorised relation
+            _hdr = _enc(["query: " + (r[10] if len(r) > 10 else "") for r in blend_all]).astype("float32")
+            typed_q = TypedQuery({"mu": _mu.shape[1], "label": _av.shape[1], "header": _av.shape[1]},
+                                 d_k=args.anchor_dk, core=("mu",), dropout=args.anchor_dropout).to(device)
+            anchored_rel = AnchoredRelation(_av, _aops, n_ops=len(OPS), n_atoms=args.n_atoms,
+                                            d_query=args.anchor_dk, d_k=args.anchor_dk).to(device)
+            anchor_inputs = {"mu": torch.tensor(_mu, dtype=torch.float32).to(device),
+                             "label": torch.tensor(_label).to(device),
+                             "header": torch.tensor(_hdr).to(device)}
+            opt.add_param_group({"params": typed_q.parameters()})
+            _q = _mu                                                  # for the d= printout only
+        elif args.anchor_query == "header":
             _q = _enc(["query: " + (r[10] if len(r) > 10 else "") for r in blend_all]).astype("float32")
             anchored_rel = AnchoredRelation(_av, _aops, n_ops=len(OPS), n_atoms=args.n_atoms,
                                             d_query=_q.shape[1], symmetric=True).to(device)
@@ -552,7 +569,10 @@ def train(args):
                 items.append((r[0], r[1], OPS["SYM"], co, ju, nt(r[5]), nt(r[6])) if args.use_nodetype
                              else (r[0], r[1], OPS["SYM"], co, ju))
             if anchored_rel is not None:                                   # §8: op_weights from the anchored attention
-                op_w, w_rel = anchored_rel(anchor_q[bi])
+                if typed_q is not None:                                    # typed token-set query (μ + label + header)
+                    op_w, w_rel = anchored_rel(typed_q({k: v[bi] for k, v in anchor_inputs.items()}))
+                else:
+                    op_w, w_rel = anchored_rel(anchor_q[bi])
                 L_anchor = anchored_rel.anchor_kl(w_rel, anchor_tgt[bi])
             else:                                                          # default: Dirichlet sample of P(op)
                 ow = _np.stack([sample_operator_weights(p, args.blend_alpha, blend_nprng) for p in pops])
@@ -865,9 +885,11 @@ def main():
     ap.add_argument("--n-atoms", type=int, default=5, help="anchored-basis: # learnable residual atoms (§8b)")
     ap.add_argument("--anchor-kl-weight", type=float, default=1.0, help="anchored-basis: weight on the anchor-confidence KL")
     ap.add_argument("--anchor-dk", type=int, default=64, help="anchored-basis: attention key dim")
-    ap.add_argument("--anchor-query", choices=["full", "mu", "header"], default="full",
-                    help="header = §8c proper (e5(section-header) attends symmetrically to e5 label anchors); "
-                         "full = v1 fusion [μ ++ provenance ++ e5_node]; mu = μ_vec only (architecture ablation)")
+    ap.add_argument("--anchor-query", choices=["full", "mu", "header", "typed"], default="full",
+                    help="typed = §8c token-set [μ-token + label-e5 + header-e5], type-embedded, extras "
+                         "dropout-regularised; header = symmetric e5(header)→e5(anchor); full = v1 fusion; "
+                         "mu = μ_vec only (the validated core)")
+    ap.add_argument("--anchor-dropout", type=float, default=0.5, help="typed query: dropout on the extra (non-μ) tokens")
     ap.add_argument("--bs", type=int, default=128)
     ap.add_argument("--lr", type=float, default=1e-3)
     ap.add_argument("--weight-decay", type=float, default=0.01)

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -132,7 +132,8 @@ def load_graded(pairs_path, nodes_path=None):
             c = ln.rstrip("\n").split("\t")              # node root mu op relation n_type r_type corpus judge
             if len(c) >= 9:
                 conf = float(c[9]) if len(c) > 9 and c[9] else 1.0   # 1.0 tagged; <1.0 INFERRED
-                rows.append((c[0], c[1], float(c[2]), c[3], c[4], c[5], c[6], c[7], c[8], conf))
+                raw = c[10] if len(c) > 10 else ""                   # raw section-header / annotation text (§8c)
+                rows.append((c[0], c[1], float(c[2]), c[3], c[4], c[5], c[6], c[7], c[8], conf, raw))
     return rows, node_text
 
 

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -431,7 +431,8 @@ def train(args):
                 _tgt[i] = 1.0 / len(_rels)
             if r[0] in idx:
                 _e5[i] = tok.p[idx[r[0]]].numpy()
-        _q = _np.concatenate([_mu, _prov, _e5], 1)
+        # ablation knob: `full` = §8c fusion; `mu` = μ_vec only (isolates the architecture from query-richness)
+        _q = _mu if args.anchor_query == "mu" else _np.concatenate([_mu, _prov, _e5], 1)
         anchored_rel = AnchoredRelation(_av, _aops, n_ops=len(OPS), n_atoms=args.n_atoms,
                                         d_query=_q.shape[1], d_k=args.anchor_dk).to(device)
         anchor_q = torch.tensor(_q, dtype=torch.float32).to(device)
@@ -855,6 +856,8 @@ def main():
     ap.add_argument("--n-atoms", type=int, default=5, help="anchored-basis: # learnable residual atoms (§8b)")
     ap.add_argument("--anchor-kl-weight", type=float, default=1.0, help="anchored-basis: weight on the anchor-confidence KL")
     ap.add_argument("--anchor-dk", type=int, default=64, help="anchored-basis: attention key dim")
+    ap.add_argument("--anchor-query", choices=["full", "mu"], default="full", help="ablation: full = §8c fusion "
+                    "[μ ++ provenance ++ e5_raw]; mu = μ_vec only (isolates the architecture from query-richness)")
     ap.add_argument("--bs", type=int, default=128)
     ap.add_argument("--lr", type=float, default=1e-3)
     ap.add_argument("--weight-decay", type=float, default=0.01)

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -417,7 +417,8 @@ def train(args):
         _phrase = {"element_of": "element of", "subcategory": "subcategory", "subtopic": "subtopic",
                    "super_category": "super category", "see_also": "see also", "assoc": "association",
                    "bridge": "bridge", "bridge_neg": "unrelated"}
-        _av = torch.tensor(e5_encoder()(["passage: " + _phrase.get(r, r) for r in _rels]), dtype=torch.float32)
+        _enc = e5_encoder()
+        _av = torch.tensor(_enc(["passage: " + _phrase.get(r, r) for r in _rels]), dtype=torch.float32)
         _aops = [OPS[REL_SPEC[r][0]] for r in _rels]
         _ri = {r: i for i, r in enumerate(_rels)}
         _mu = _np.nan_to_num(measure_readouts([(r[0], r[1]) for r in blend_all]))        # [N,6] warm-start
@@ -432,14 +433,21 @@ def train(args):
                 _tgt[i] = 1.0 / len(_rels)
             if r[0] in idx:
                 _e5[i] = tok.p[idx[r[0]]].numpy()
-        # ablation knob: `full` = §8c fusion; `mu` = μ_vec only (isolates the architecture from query-richness)
-        _q = _mu if args.anchor_query == "mu" else _np.concatenate([_mu, _prov, _e5], 1)
-        anchored_rel = AnchoredRelation(_av, _aops, n_ops=len(OPS), n_atoms=args.n_atoms,
-                                        d_query=_q.shape[1], d_k=args.anchor_dk).to(device)
+        # query: `header` = §8c proper — e5(section-header text) attends SYMMETRICALLY to the e5 label
+        # anchors (the embedding categoriser); `full` = the v1 fusion; `mu` = μ_vec only (architecture ablation)
+        if args.anchor_query == "header":
+            _q = _enc(["query: " + (r[10] if len(r) > 10 else "") for r in blend_all]).astype("float32")
+            anchored_rel = AnchoredRelation(_av, _aops, n_ops=len(OPS), n_atoms=args.n_atoms,
+                                            d_query=_q.shape[1], symmetric=True).to(device)
+        else:
+            _q = _mu if args.anchor_query == "mu" else _np.concatenate([_mu, _prov, _e5], 1)
+            anchored_rel = AnchoredRelation(_av, _aops, n_ops=len(OPS), n_atoms=args.n_atoms,
+                                            d_query=_q.shape[1], d_k=args.anchor_dk).to(device)
         anchor_q = torch.tensor(_q, dtype=torch.float32).to(device)
         anchor_tgt = torch.tensor(_tgt, dtype=torch.float32).to(device)
         opt.add_param_group({"params": anchored_rel.parameters()})
-        print(f"ANCHORED-BASIS: {len(_rels)} e5-phrase anchors + {args.n_atoms} atoms, d_query={_q.shape[1]}")
+        print(f"ANCHORED-BASIS: {len(_rels)} e5-phrase anchors + {args.n_atoms} atoms, "
+              f"query={args.anchor_query} (d={_q.shape[1]}{', symmetric' if args.anchor_query=='header' else ''})")
 
     new_corpus = CORPORA.get(args.pairs_corpus, SW)        # corpus tag for the --pairs (new) data
     def draw_sym(pool, replay, k):
@@ -857,8 +865,9 @@ def main():
     ap.add_argument("--n-atoms", type=int, default=5, help="anchored-basis: # learnable residual atoms (§8b)")
     ap.add_argument("--anchor-kl-weight", type=float, default=1.0, help="anchored-basis: weight on the anchor-confidence KL")
     ap.add_argument("--anchor-dk", type=int, default=64, help="anchored-basis: attention key dim")
-    ap.add_argument("--anchor-query", choices=["full", "mu"], default="full", help="ablation: full = §8c fusion "
-                    "[μ ++ provenance ++ e5_raw]; mu = μ_vec only (isolates the architecture from query-richness)")
+    ap.add_argument("--anchor-query", choices=["full", "mu", "header"], default="full",
+                    help="header = §8c proper (e5(section-header) attends symmetrically to e5 label anchors); "
+                         "full = v1 fusion [μ ++ provenance ++ e5_node]; mu = μ_vec only (architecture ablation)")
     ap.add_argument("--bs", type=int, default=128)
     ap.add_argument("--lr", type=float, default=1e-3)
     ap.add_argument("--weight-decay", type=float, default=0.01)

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -405,6 +405,40 @@ def train(args):
                 tgt[i] += Pr[i, j] * REL_SPEC[rel][1 if r[2] >= 0.5 else 2]      # relation-level dir-specific target
         blend_state["pop"], blend_state["tgt"] = pop, tgt
 
+    # ANCHORED-BASIS (DESIGN §8): compute the blend op_weights via attention over frozen e5-phrase relation
+    # ANCHORS + K learnable ATOMS instead of the JointPosterior+Dirichlet. Static query = §8c fusion
+    # [μ_vec(warm) ++ provenance ++ e5_raw]; the anchor-KL pins the anchor block to the categoriser confidence.
+    anchored_rel, anchor_q, anchor_tgt = None, None, None
+    if args.anchored_basis and (graded_inf or blend_tag_on):
+        from anchored_basis import AnchoredRelation
+        from section_embed import e5_encoder
+        _rels = sorted(REL_SPEC)
+        _phrase = {"element_of": "element of", "subcategory": "subcategory", "subtopic": "subtopic",
+                   "super_category": "super category", "see_also": "see also", "assoc": "association",
+                   "bridge": "bridge", "bridge_neg": "unrelated"}
+        _av = torch.tensor(e5_encoder()(["passage: " + _phrase.get(r, r) for r in _rels]), dtype=torch.float32)
+        _aops = [OPS[REL_SPEC[r][0]] for r in _rels]
+        _ri = {r: i for i, r in enumerate(_rels)}
+        _mu = _np.nan_to_num(measure_readouts([(r[0], r[1]) for r in blend_all]))        # [N,6] warm-start
+        _prov = _np.zeros((len(blend_all), len(_rels) + 1)); _e5 = _np.zeros((len(blend_all), _av.shape[1]))
+        _tgt = _np.zeros((len(blend_all), len(_rels)))
+        for i, r in enumerate(blend_all):
+            j, conf = _ri.get(r[4]), float(r[9])
+            if j is not None:
+                _prov[i, j] = conf; _prov[i, -1] = conf
+                _tgt[i, j] = conf; _tgt[i] += (1.0 - conf) / len(_rels)                  # conf-weighted anchor target
+            else:
+                _tgt[i] = 1.0 / len(_rels)
+            if r[0] in idx:
+                _e5[i] = tok.p[idx[r[0]]].numpy()
+        _q = _np.concatenate([_mu, _prov, _e5], 1)
+        anchored_rel = AnchoredRelation(_av, _aops, n_ops=len(OPS), n_atoms=args.n_atoms,
+                                        d_query=_q.shape[1], d_k=args.anchor_dk).to(device)
+        anchor_q = torch.tensor(_q, dtype=torch.float32).to(device)
+        anchor_tgt = torch.tensor(_tgt, dtype=torch.float32).to(device)
+        opt.add_param_group({"params": anchored_rel.parameters()})
+        print(f"ANCHORED-BASIS: {len(_rels)} e5-phrase anchors + {args.n_atoms} atoms, d_query={_q.shape[1]}")
+
     new_corpus = CORPORA.get(args.pairs_corpus, SW)        # corpus tag for the --pairs (new) data
     def draw_sym(pool, replay, k):
         """Draw k SYM examples as (item, corpus_id): replay-frac OLD (replay, corpus=simplewiki) mixed with
@@ -490,6 +524,7 @@ def train(args):
             L_graded = (gw * (mu_g - gt) ** 2).sum() / gw.sum().clamp_min(1.0)
         # INFER-BLEND: inferred rows trained with a RANDOM operator embedding from the fitted joint posterior
         L_blend = torch.zeros(())
+        L_anchor = torch.zeros(())
         blend_on = (args.infer_blend and (graded_inf or blend_tag_on)
                     and step >= args.blend_warmup and not args.sym_only)
         if blend_on:
@@ -506,15 +541,20 @@ def train(args):
                     pops.append(tag_pop[i - n_inf_b]); tgts.append(r[2]); co, ju = CORPORA[r[7]], JUDGES[r[8]]
                 items.append((r[0], r[1], OPS["SYM"], co, ju, nt(r[5]), nt(r[6])) if args.use_nodetype
                              else (r[0], r[1], OPS["SYM"], co, ju))
-            ow = _np.stack([sample_operator_weights(p, args.blend_alpha, blend_nprng) for p in pops])
-            op_w = torch.tensor(ow, dtype=torch.float32).to(device)
+            if anchored_rel is not None:                                   # §8: op_weights from the anchored attention
+                op_w, w_rel = anchored_rel(anchor_q[bi])
+                L_anchor = anchored_rel.anchor_kl(w_rel, anchor_tgt[bi])
+            else:                                                          # default: Dirichlet sample of P(op)
+                ow = _np.stack([sample_operator_weights(p, args.blend_alpha, blend_nprng) for p in pops])
+                op_w = torch.tensor(ow, dtype=torch.float32).to(device)
             bt = torch.tensor(tgts, dtype=torch.float32).to(device)
             mu_b = model(**bld(items, train=True, rng=rng, p_mask_prov=args.prov_mask), op_weights=op_w)
             L_blend = F.mse_loss(mu_b, bt)
         loss = (args.sym_weight * L_sym + (0.0 if args.sym_only else args.wiki_weight * L_wiki)
                 + (args.elem_weight * L_elem if (elem_tr and not args.sym_only) else 0.0)
                 + (args.graded_weight * L_graded if (graded_tr and not args.sym_only) else 0.0)
-                + (args.blend_weight * L_blend if blend_on else 0.0))
+                + (args.blend_weight * L_blend if blend_on else 0.0)
+                + (args.anchor_kl_weight * L_anchor if blend_on else 0.0))
         # LLM (optional, already-bought) — skipped in single-task SYM mode
         L_llm = torch.zeros(())
         if llm and not args.sym_only:
@@ -548,6 +588,7 @@ def train(args):
                   + (f"  L_elem {float(L_elem):.4f}" if (elem_tr and not args.sym_only) else "")
                   + (f"  L_graded {float(L_graded):.4f}" if (graded_tr and not args.sym_only) else "")
                   + (f"  L_blend {float(L_blend):.4f}" if blend_on else "")
+                  + (f"  L_anchor {float(L_anchor):.4f}" if (blend_on and anchored_rel is not None) else "")
                   + (f"  L_llm {float(L_llm):.4f}" if (llm and not args.sym_only) else ""))
 
     if es_saved:                                          # early-stop kept the BEST — validate THAT, not the last
@@ -808,6 +849,12 @@ def main():
                     "improving; keep the BEST checkpoint (not the last). The targeted anti-overtraining fix.")
     ap.add_argument("--eval-every", type=int, default=100, help="early-stop: eval the held-out graded MSE every N steps")
     ap.add_argument("--patience", type=int, default=6, help="early-stop: stop after this many evals with no improvement")
+    ap.add_argument("--anchored-basis", action="store_true", help="DESIGN §8: compute the blend op_weights via "
+                    "attention over frozen e5-phrase relation ANCHORS + K learnable ATOMS (instead of the "
+                    "JointPosterior+Dirichlet); adds the anchor-confidence KL. Needs --infer-blend.")
+    ap.add_argument("--n-atoms", type=int, default=5, help="anchored-basis: # learnable residual atoms (§8b)")
+    ap.add_argument("--anchor-kl-weight", type=float, default=1.0, help="anchored-basis: weight on the anchor-confidence KL")
+    ap.add_argument("--anchor-dk", type=int, default=64, help="anchored-basis: attention key dim")
     ap.add_argument("--bs", type=int, default=128)
     ap.add_argument("--lr", type=float, default=1e-3)
     ap.add_argument("--weight-decay", type=float, default=0.01)


### PR DESCRIPTION
Builds the §9/§14 Haiku-expectation **distributional augmentation** for the inferred tail (on top of the
§8 anchored-basis wiring already on this branch), and — the headline — **establishes that it works, at the
right weight.**

## Result (the operating point this PR ships)
Held-out-tail eval (model E[μ] under equal-weight op-superposition vs held-out Haiku E[μ], 3 seeds):

| arm | held-out-tail corr (mean ± sd) |
|---|---|
| baseline (no aug) | +0.163 ± 0.028 |
| **augmentation @ `--tail-weight 6` (~30% share)** | **+0.285 ± 0.006** |
| augmentation @ tail-weight 12 | +0.274 ± 0.067 (unstable) |

**A robust +0.12 corr lift, replicated at sd 0.006.** The augmentation helps the inferred tail **only when it
carries ~30% gradient share** (the §13 target) — at its natural ~7% it's diluted to nothing (the earlier flat
result). `tail-weight 12` over-weights (inverted-U → the 3-layer capacity ceiling). **Frozen e5 is not the
binding limit.** ⇒ **Recommended operating point: `--tail-weight 6`** for tail-augmented training.

## What's included
- **`score_inferred_tail.py`** — extract conf<1.0 tail → §14 batched prompt → ingest LLM scores into the
  §12(5) partition + per-pair E[μ] (fwd/rev); `flag` mode for stronger-model escalation.
- **`cell_sampler.py`** (+ 9 tests) — the §12/§13 hard-cell sampler + analytic/MC E[μ] reducers (tested
  reference; the trainer path uses the deterministic E[μ] target — see §15).
- **Trainer hooks:** `--haiku-tail` (override inferred targets with cached LLM E[μ] + judge provenance),
  `--eval-tail` (the tail-specific instrument the saturated base metrics can't provide), `--tail-weight`
  (the §13 dilution fix). `JUDGES` += `sonnet`/`opus`.
- **Design** `DESIGN_inferred_operator_superposition.md` §9–§14 (training scheme, partition, sampling
  mechanics, Haiku prompt contract, forward-policy).
- **§15 implementation status** — honest map of built vs proposed; the shipped dilution fix is
  `--tail-weight 6`, with self-posterior / ramp / forward-only / grow-prune marked **proposed**.
- **Reports** `REPORT_haiku_tail_pilot.md` (full honest arc: pilot → scale → fresh-sweep deflation →
  warm-start saturation → held-out-tail negative → tail-weight positive), `REPORT_anchored_basis_ab.md`.

## How the result was earned (methodology notes)
The base WIKI/SYM held-out metrics are **saturated (~99.8%) and blind to the tail** — only `--eval-tail`
could see the effect. **Warm-start is required** (fresh from-scratch diverges ~1/3 seeds). The tail metric is
noisy (~±0.15/seed), so **every claim is 3-seed**; a dramatic single-run win was deflated to noise before the
real (tw6) win replicated tightly.

## Notes
- Distributional data (417 rows) and fused/graded TSVs are **gitignored** (Pearltrees-derived titles =
  private-tier); the code regenerates them from cache.
- `--tail-weight` defaults to 1.0 (no behavior change); the operating point is opt-in.
- Result is scoped to the **agree-with-Haiku** frame (non-leaking per §12(3), not ground truth); the
  independent Sonnet/human check is the next rigor tier (provenance tagging + `flag` already support it).

## Test plan
- `python3 test_cell_sampler.py` (9) + `python3 test_anchored_basis.py` (8) pass.
- `--haiku-tail` / `--eval-tail` verified end-to-end; 3-seed `--tail-weight` sweep reproduces the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)