### PR TITLE
mu_cosine: independent (Sonnet) check of the tail augmentation + cascade triage

### DIFF
--- a/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
+++ b/prototypes/mu_cosine/REPORT_haiku_tail_pilot.md
@@ -178,3 +178,31 @@ were, no weighting would help).
 **Caveats:** still the agree-with-Haiku frame (the independent Sonnet/human check via the now-tagged
 provenance is the next rigor tier); 82 holdout rows; equal-weight-superposition probe. But a 3-seed
 replication at sd 0.006 is signal, not noise — this is the payoff of measuring the tail + repeating across seeds.
+
+## Independent (Sonnet) check — inconclusive; and the cascade triage
+Scored the 84 holdout-tail rows with **Sonnet** (one batch, the independent judge) and re-ran base vs tw6
+against that reference. **Inter-judge agreement (Haiku vs Sonnet) on the tail: corr +0.277** — i.e. read as
+reliability, **~70–80% of per-row tail variance is judge-noise**. This is largely a *selection effect*: the
+tail IS the conf<1.0 region the categoriser couldn't confidently tag — we deliberately scored the
+high-disagreement rows; the tagged (conf=1.0) data is far cleaner.
+
+**Model vs Sonnet (independent):** base 0.413/0.324, tw6 0.260/0.491 — **means ~0.37 vs ~0.38, variance ±0.15
+swamps any effect → INCONCLUSIVE.** (A seed-1-only read of "tw6 < base" was an artifact; seed 2 flipped it —
+the same single-seed trap.) So the tw6 +0.12 lift is **agreement-with-Haiku**; it does **not** demonstrably
+transfer to an independent judge at this sample size. Notably **base-vs-Sonnet (~0.37) > Haiku-vs-Sonnet
+(+0.28)** → the latent signal IS learnable; **Haiku is a noisy teacher of it**, and the frozen-e5 base already
+reads the tail better than Haiku labels it.
+
+**Cascade triage (built — `score_inferred_tail.py flag`):** Haiku as cheap triage → escalate only contentious
+rows to a stronger judge/human. Two signals (OR): `P[none] ≥ none_min` (graph↔judge contradiction, the
+spurious subset) and normalised `entropy(P(cell)) ≥ ent_min` (judge unsure which relation, the fuzzy subset);
+ranked by contention, `--top-k` budget-bounds it. **Finding:** at reasonable thresholds ~**half** the tail
+flags (211/417) — the tail is *uniformly* ambiguous, so triage-by-uncertainty doesn't shrink to a tiny set;
+`--top-k` (e.g. 42 = one Sonnet query) is the practical form, and the **`none` subset dominates contention**.
+
+**Forward path (revised by these results):**
+1. **Don't scale single-judge tail data** — its independent value is unproven and it overfits the teacher.
+2. **Denoise the target instead:** ensemble judges (avg Haiku+Sonnet) on the contentious set, or the model's
+   **self-posterior** (§13) — empirically motivated since base-vs-Sonnet (0.37) > Haiku-vs-Sonnet (0.28).
+3. **Cascade, don't blanket-spend:** Haiku triage → top-K escalation to Sonnet/Opus/human (Anthropic tiers via
+   subagents today; a non-Anthropic interface is a future generalisation).

--- a/prototypes/mu_cosine/score_inferred_tail.py
+++ b/prototypes/mu_cosine/score_inferred_tail.py
@@ -16,6 +16,7 @@ Spends NO budget itself — extraction + ingest are pure I/O; the Haiku call is 
 import argparse
 import glob
 import json
+import math
 import os
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
@@ -184,26 +185,40 @@ def ingest(pairs_path, responses_path, out, judge="haiku"):
     print(f"ingested {n}/{len(pairs)} pairs (judge={judge}) → {out}")
 
 
-def flag(scored_path, pairs_path, none_min, out):
-    """Escalation selector: every tail row IS a graph edge (conf<1.0 asserts a relation), so a high Haiku
-    `P[none]` is a direct graph↔Haiku contradiction. Emit those rows (none >= none_min) as a pairs file to
-    re-judge with a STRONGER model (Sonnet ¼-budget, Opus less) — the selective multi-source tie-break."""
-    scored = {}
-    sh = open(scored_path, encoding="utf-8").readline().strip().split("\t")
+def flag(scored_path, none_min, ent_min, out, top_k=0):
+    """Cascade triage: select CONTENTIOUS tail rows for a stronger judge (Sonnet/Opus/human), emitted as a
+    pairs file (ranked, most-contentious first). Two signals — a row is flagged if EITHER fires:
+      * `P[none] >= none_min` — graph↔judge contradiction (the spurious/no-relation subset);
+      * normalised entropy of P(cell) >= ent_min — the judge is unsure WHICH relation (spread mass), which
+        catches the genuinely-fuzzy cases (e.g. assoc↔see_also) that the none signal misses.
+    The cheap Haiku target is kept for everything else — we spend the good judge only where it's needed (the
+    measured insight: on the high-disagreement tail one cheap judge is too noisy to trust wholesale)."""
+    sh = open(scored_path, encoding="utf-8").readline().lstrip("#").strip().split("\t")
+    pcols = [i for i, h in enumerate(sh) if h.startswith("P[")]
     ni = sh.index("P[none]")
-    for r in (l.rstrip("\n").split("\t") for l in open(scored_path, encoding="utf-8") if not l.startswith("#")):
-        scored[(r[0].lower(), r[1].lower())] = float(r[ni])
-    kept = []
-    for ln in open(pairs_path, encoding="utf-8"):
+    kept = []                                                  # (contention, none, ent, reconstructed pairs line)
+    for ln in open(scored_path, encoding="utf-8"):
         if ln.startswith("#"):
             continue
-        p = ln.rstrip("\n").split("\t")
-        if scored.get((p[0].lower(), p[1].lower()), 0.0) >= none_min:
-            kept.append(ln.rstrip("\n"))
+        c = ln.rstrip("\n").split("\t")
+        ps = [max(1e-9, float(c[i])) for i in pcols]
+        ent = -sum(p * math.log(p) for p in ps) / math.log(len(ps))     # normalised entropy ∈ [0,1]
+        none = float(c[ni])
+        if none >= none_min or ent >= ent_min:
+            contention = max(none / max(none_min, 1e-9), ent / max(ent_min, 1e-9))
+            pair = "\t".join([c[0], c[1], c[2], "0.40", c[3], "", "", ""])   # reconstruct the pairs schema
+            kept.append((contention, none, ent, pair))
+    kept.sort(reverse=True)
+    total = len(kept)
+    if top_k and len(kept) > top_k:                           # budget-bound: keep the most contentious top_k
+        kept = kept[:top_k]
     with open(out, "w", encoding="utf-8") as f:
         f.write("# node_title\troot_title\tcur_relation\tconf\tneighborhood\tnode_type\troot_type\traw\n")
-        f.write("\n".join(kept) + ("\n" if kept else ""))
-    print(f"flagged {len(kept)} sharp rows (Haiku P[none] >= {none_min}) → {out}")
+        f.write("\n".join(p for _, _, _, p in kept) + ("\n" if kept else ""))
+    n_none = sum(1 for _, no, _, _ in kept if no >= none_min)
+    n_ent = sum(1 for _, _, e, _ in kept if e >= ent_min)
+    print(f"flagged {total} contentious rows{f' → top-{top_k} kept' if (top_k and total > top_k) else ''} → {out}"
+          f"  (none>={none_min}: {n_none}; entropy>={ent_min}: {n_ent})")
 
 
 def main():
@@ -215,13 +230,14 @@ def main():
     ig = sub.add_parser("ingest"); ig.add_argument("--pairs", required=True)
     ig.add_argument("--responses", required=True); ig.add_argument("--out", required=True)
     ig.add_argument("--judge", default="haiku", help="provenance tag for these scores (haiku/sonnet/opus)")
-    fl = sub.add_parser("flag"); fl.add_argument("--scored", required=True); fl.add_argument("--pairs", required=True)
-    fl.add_argument("--none-min", type=float, default=0.3); fl.add_argument("--out", required=True)
+    fl = sub.add_parser("flag"); fl.add_argument("--scored", required=True); fl.add_argument("--out", required=True)
+    fl.add_argument("--none-min", type=float, default=0.3); fl.add_argument("--ent-min", type=float, default=0.75)
+    fl.add_argument("--top-k", type=int, default=0, help="budget-bound: keep only the top-K most contentious (0=all)")
     a = ap.parse_args()
     if a.cmd == "extract":
         extract(a.neighborhoods, a.out)
     elif a.cmd == "flag":
-        flag(a.scored, a.pairs, a.none_min, a.out)
+        flag(a.scored, a.none_min, a.ent_min, a.out, a.top_k)
     elif a.cmd == "prompt":
         pairs = [ln.rstrip("\n").split("\t") for ln in open(a.pairs, encoding="utf-8") if not ln.startswith("#")]
         for i, pr_text in enumerate(build_prompts(pairs, a.batch)):


### PR DESCRIPTION
Follow-up to the tail-augmentation PR. Adds the **independent-judge eval** (does the +0.12 Haiku-frame lift
survive a different judge?) and a **cascade triage** mechanism, and records the honest verdict.

## Independent-judge result (the headline — it's a *negative/inconclusive*)
Scored the 84 holdout-tail rows with **Sonnet** (one query, the independent reference) and re-ran
base vs `--tail-weight 6` against it:

| | corr vs **Sonnet** (seed 1 / seed 2) | mean |
|---|---|---|
| base (no aug) | 0.413 / 0.324 | ~0.37 |
| tw6 (Haiku-augmented) | 0.260 / 0.491 | ~0.38 |

**base ≈ tw6 vs the independent judge — variance (±0.15) swamps any effect → INCONCLUSIVE.** The robust
+0.12 lift from the prior PR is **agreement-with-Haiku**; it does **not** demonstrably transfer to an
independent judge at this sample size. (A seed-1-only "tw6 < base" read was a single-seed artifact — seed 2
flipped it.)

Context that explains it:
- **Inter-judge Haiku–Sonnet agreement on the tail: +0.28** → read as reliability, **~70–80% of per-row tail
  variance is judge-noise.** Largely a *selection effect*: the tail is the conf<1.0 region we deliberately
  scored *because* it's ambiguous; tagged (conf=1.0) data is far cleaner.
- **base-vs-Sonnet (0.37) > Haiku-vs-Sonnet (0.28)** → the latent signal *is* learnable; **Haiku is a noisy
  teacher**, and the frozen-e5 base already reads the tail better than Haiku labels it.

## What's added
- **Cascade triage** (`score_inferred_tail.py flag`, upgraded): contention = `P[none] ≥ none_min`
  (graph↔judge contradiction) **OR** normalised `entropy(P(cell)) ≥ ent_min` (which-relation uncertainty);
  ranked, `--top-k` budget-bounds it (e.g. 42 ≈ one Sonnet query). Finding: at reasonable thresholds ~half
  the tail flags (the tail is *uniformly* ambiguous), so `--top-k` is the practical form; the `none` subset
  dominates contention.
- **`REPORT_haiku_tail_pilot.md`** — the independent-eval verdict + cascade design + revised forward path.

## Forward path (revised by these results)
1. **Don't scale single-judge tail data** — its independent value is unproven; it overfits the teacher.
2. **Denoise the target instead:** ensemble judges (avg Haiku+Sonnet) on the contentious set, or the model's
   **self-posterior** (§13) — empirically motivated (base reads the tail better than Haiku).
3. **Cascade, don't blanket-spend:** Haiku triage → top-K escalation to Sonnet/Opus/human (Anthropic tiers
   via subagents today).

## Notes
- No production-code behavior change: this is the `flag` triage tool + analysis/report. Scored data stays
  gitignored (private-tier).
- Methodology held the line again: multi-seed + an independent judge kept a noise-driven "win" from shipping.

## Test plan
- `python3 score_inferred_tail.py flag --scored <…> --top-k 42` produces a ranked, budget-bounded escalation
  set; `python3 -c "import ast; ast.parse(open('score_inferred_tail.py').read())"` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)