### PR TITLE
mu_cosine: implement transitive ordinal constraints (stages 1–3) — generation, ranking-CE loss, held-out eval

### DIFF
--- a/prototypes/mu_cosine/test_transitive_closure.py
+++ b/prototypes/mu_cosine/test_transitive_closure.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for transitive-closure generation (DESIGN_transitive_relations.md stage 1). Pure python.
+Run: `python3 test_transitive_closure.py`."""
+from transitive_closure import compose_relation, transitive_pairs, REL_MU
+
+
+def test_compose_rules():
+    assert compose_relation("subcategory", "subcategory") == "subcategory"
+    assert compose_relation("subtopic", "subtopic") == "subtopic"
+    assert compose_relation("subcategory", "subtopic") == "subtopic"      # mixed downward → looser
+    assert compose_relation("element_of", "subcategory") == "element_of"  # C∈A, A⊆B ⇒ C∈B
+    assert compose_relation("super_category", "super_category") == "super_category"
+    assert compose_relation("bridge", "subcategory") == "subcategory"     # identity passes through
+    assert compose_relation("subcategory", "bridge") == "subcategory"
+    assert compose_relation("subcategory", "element_of") is None          # downward then membership ⇏
+    assert compose_relation("see_also", "subcategory") is None            # lateral never composes
+
+
+def test_two_hop_product_and_bound():
+    # A ⊆ B ⊆ C  (subcategory, 0.90 each)
+    pairs = transitive_pairs([("A", "B", "subcategory"), ("B", "C", "subcategory")])
+    assert len(pairs) == 1
+    p = pairs[0]
+    assert (p["src"], p["dst"]) == ("A", "C") and p["hops"] == 2 and p["rel"] == "subcategory"
+    assert abs(p["product"] - 0.81) < 1e-9            # 0.9·0.9, the ranking key
+    assert abs(p["min_link"] - 0.90) < 1e-9           # min link = the ordinal BOUND
+
+
+def test_element_of_through_containment():
+    # C ∈ A ⊆ B  → C ∈ B
+    pairs = transitive_pairs([("C", "A", "element_of"), ("A", "B", "subcategory")])
+    assert len(pairs) == 1 and pairs[0]["rel"] == "element_of"
+    assert (pairs[0]["src"], pairs[0]["dst"]) == ("C", "B")
+
+
+def test_three_hop_and_decay_ordering():
+    # A⊆B⊆C⊆D : product decays with length; sorted descending so 2-hop (0.81) ranks above 3-hop (0.729)
+    e = [("A", "B", "subcategory"), ("B", "C", "subcategory"), ("C", "D", "subcategory")]
+    pairs = transitive_pairs(e, max_hops=3)
+    prods = [p["product"] for p in pairs]
+    assert prods == sorted(prods, reverse=True)        # curriculum order
+    ac = next(p for p in pairs if (p["src"], p["dst"]) == ("A", "C"))
+    ad = next(p for p in pairs if (p["src"], p["dst"]) == ("A", "D"))
+    assert abs(ac["product"] - 0.81) < 1e-9 and abs(ad["product"] - 0.729) < 1e-9
+    assert ad["min_link"] == 0.90 and ad["hops"] == 3
+
+
+def test_dominant_path_keeps_max_product():
+    # two paths A→D: A→B→D (0.9·0.9=0.81) and A→C→D via subtopic (0.85·0.85=0.7225); keep the max (0.81)
+    e = [("A", "B", "subcategory"), ("B", "D", "subcategory"),
+         ("A", "C", "subtopic"), ("C", "D", "subtopic")]
+    ad = [p for p in transitive_pairs(e) if (p["src"], p["dst"]) == ("A", "D")]
+    assert len(ad) == 1 and abs(ad[0]["product"] - 0.81) < 1e-9      # dominant (max-product) path won
+
+
+def test_direct_edge_not_emitted_as_transitive():
+    # A→C is BOTH reachable via B and a direct edge → excluded (it's direct, not transitive)
+    e = [("A", "B", "subcategory"), ("B", "C", "subcategory"), ("A", "C", "subcategory")]
+    assert all((p["src"], p["dst"]) != ("A", "C") for p in transitive_pairs(e))
+
+
+def test_incompatible_chain_pruned():
+    # element_of then (reverse) — A⊆B but then B see_also C (lateral, not in REL_MU) → no transitive pair
+    e = [("X", "A", "element_of"), ("A", "B", "see_also")]   # see_also not hierarchical → dropped
+    assert transitive_pairs(e) == []
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t(); print(f"  ok  {t.__name__}")
+    print(f"all {len(tests)} transitive_closure tests passed")

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -290,6 +290,29 @@ def eval_tail(model, tok, graded_text, nodes_path, tail_path, use_nodetype, mode
 
 
 @torch.no_grad()
+def eval_transitive(model, tok, path, idx, use_nodetype):
+    """Held-out transitive eval (DESIGN §Eval): **constraint satisfaction** (`μ_trans ≤ μ_bound`) + the
+    **anti-collapse / level** guard (mean μ_bound must stay HIGH — not gamed by μ→0 — and μ_trans sits below
+    it, not at 0). Triples in transitive_closure --out format; should be a leakage-aware (node-split) holdout."""
+    was = model.training; model.eval()
+    rows = load_transitive(path, idx)
+    if not rows:
+        print("[TRANS-EVAL] 0 in-vocab pairs"); return
+    ex = (lambda: (0, 0)) if use_nodetype else (lambda: ())
+    ti = [(t[0], t[1], OPS[REL_SPEC[t[2]][0]], CORPORA[_corp_of(t[0])], JUDGES["graph"]) + ex() for t in rows]
+    bi = [(t[3], t[4], OPS[REL_SPEC[t[5]][0]], CORPORA[_corp_of(t[3])], JUDGES["graph"]) + ex() for t in rows]
+    mt = mu_batch(model, tok, ti).tolist()
+    mb = mu_batch(model, tok, bi).tolist()
+    n = len(rows)
+    sat = sum(1 for i in range(n) if mt[i] <= mb[i]) / n
+    mbm, mtm = sum(mb) / n, sum(mt) / n
+    if was:
+        model.train()
+    print(f"[TRANS-EVAL] {n} held-out pairs: satisfaction μ_trans≤μ_bound = {100*sat:.0f}%  | "
+          f"anti-collapse: μ_bound̄ {mbm:.3f} (must stay high), μ_trans̄ {mtm:.3f}, gap {mbm-mtm:+.3f}")
+
+
+@torch.no_grad()
 def emit_dense(model, tok, names, op, root="Physics", bs=512):
     items = [(n, root, OPS[op]) for n in names]
     mu = mu_batch(model, tok, items, bs)
@@ -692,6 +715,8 @@ def train(args):
         # TRANSITIVE ordinal constraint (DESIGN_transitive_relations.md): μ(transitive) ≤ μ(bound edge) via a
         # ranking CE — graph-truth, no LLM. Co-batch each transitive pair with its bounding (weakest-link) edge;
         # −log σ(s·(μ_bound − μ_trans − m)) = softplus(−s·Δ). Naive global-s (homoscedastic) first cut.
+        # NB: this is a Lagrangian relaxation of the hard inequality μ_trans ≤ μ_bound; --transitive-weight is
+        # the multiplier λ (fixed here — adaptive dual-ascent on a target satisfaction rate is the upgrade).
         L_trans = torch.zeros(())
         if trans_rows and not args.sym_only:
             tb = [trans_rows[rng.randrange(len(trans_rows))] for _ in range(args.bs)]
@@ -754,6 +779,8 @@ def train(args):
     if args.eval_tail and os.path.exists(args.eval_tail):     # §9 held-out-tail eval (the tail-specific instrument)
         _ntp = args.graded_nodes or (args.graded.replace("_pairs.tsv", "_nodes.tsv") if args.graded else None)
         eval_tail(model, tok, graded_text, _ntp, args.eval_tail, args.use_nodetype)
+    if args.eval_transitive and os.path.exists(args.eval_transitive):     # held-out transitive eval (stage 3)
+        eval_transitive(model, tok, args.eval_transitive, idx, args.use_nodetype)
     if args.save and not es_saved:                        # early-stop already saved the best; else save the final
         torch.save({"state": model.state_dict(), "cfg": {"d_model": q.shape[1], "heads": args.heads,
                     "layers": args.layers}}, args.save)
@@ -1050,6 +1077,8 @@ def main():
     ap.add_argument("--transitive-margin", type=float, default=0.05, help="margin m: enforce μ_bound − μ_trans ≥ m")
     ap.add_argument("--transitive-scale", type=float, default=10.0, help="logistic scale s (= global confidence; the "
                     "naive homoscedastic first cut — heteroscedastic per-pair variance is the stage-2 upgrade)")
+    ap.add_argument("--eval-transitive", default=None, help="held-out transitive triples → report constraint "
+                    "satisfaction + anti-collapse level (use a node-split holdout, not the training triples)")
     ap.add_argument("--graded-nodes", default=None, help="override the graded nodes file (default: derive "
                     "from --graded by _pairs→_nodes)")
     ap.add_argument("--graded-weight", type=float, default=1.0, help="graded-round loss weight")

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -39,6 +39,26 @@ def nt(s):
     return _NT.get(s, 0)
 
 
+_CORP_OF = {"mm": "mindmap", "pt": "pearltrees", "wiki": "enwiki"}
+
+
+def _corp_of(key):
+    return _CORP_OF.get(key.split(":", 1)[0], "simplewiki")
+
+
+def load_transitive(path, idx):
+    """Read transitive triples (transitive_closure.py --out): keep only rows whose all four endpoint keys are
+    in the e5 vocab `idx`. Each row → (t_src, t_dst, t_rel, b_src, b_dst, b_rel) for the ranking-CE term."""
+    rows = []
+    for ln in open(path, encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        c = ln.rstrip("\n").split("\t")
+        if len(c) >= 6 and c[0] in idx and c[1] in idx and c[3] in idx and c[4] in idx:
+            rows.append((c[0], c[1], c[2], c[3], c[4], c[5]))
+    return rows
+
+
 # relation → (operator, forward target, reverse target) for the INFER-BLEND path (§5b: blend the operator
 # embedding at OPERATOR level, but keep the μ target at RELATION level — SYM's relations have different μ).
 REL_SPEC = {
@@ -377,6 +397,12 @@ def train(args):
 
     # fused graded round (mixed-operator, hand-curated): hold out 15% for eval; bridges down-weighted in loss
     graded_rows = [r for r in graded_rows if r[0] in idx and r[1] in idx]
+    trans_rows = []
+    if args.transitive and os.path.exists(args.transitive) and args.transitive_weight > 0:
+        trans_rows = load_transitive(args.transitive, idx)
+        print(f"TRANSITIVE (ordinal ranking-CE, w={args.transitive_weight:g}, m={args.transitive_margin:g}, "
+              f"s={args.transitive_scale:g}): {trans_rows and len(trans_rows)} pairs in-vocab from "
+              f"{os.path.basename(args.transitive)}")
     rng.shuffle(graded_rows)
     n_gh = int(0.15 * len(graded_rows))
     graded_hold, graded_tr = graded_rows[:n_gh], graded_rows[n_gh:]
@@ -663,9 +689,22 @@ def train(args):
             bt = torch.tensor(tgts, dtype=torch.float32).to(device)
             mu_b = model(**bld(items, train=True, rng=rng, p_mask_prov=args.prov_mask), op_weights=op_w)
             L_blend = F.mse_loss(mu_b, bt)
+        # TRANSITIVE ordinal constraint (DESIGN_transitive_relations.md): μ(transitive) ≤ μ(bound edge) via a
+        # ranking CE — graph-truth, no LLM. Co-batch each transitive pair with its bounding (weakest-link) edge;
+        # −log σ(s·(μ_bound − μ_trans − m)) = softplus(−s·Δ). Naive global-s (homoscedastic) first cut.
+        L_trans = torch.zeros(())
+        if trans_rows and not args.sym_only:
+            tb = [trans_rows[rng.randrange(len(trans_rows))] for _ in range(args.bs)]
+            extra = (lambda k: (nt(""), nt(""))) if args.use_nodetype else (lambda k: ())
+            ti = [(t[0], t[1], OPS[REL_SPEC[t[2]][0]], CORPORA[_corp_of(t[0])], JUDGES["graph"]) + extra(t[0]) for t in tb]
+            bi2 = [(t[3], t[4], OPS[REL_SPEC[t[5]][0]], CORPORA[_corp_of(t[3])], JUDGES["graph"]) + extra(t[3]) for t in tb]
+            mu_t = model(**bld(ti, train=True, rng=rng, p_mask_prov=args.prov_mask))
+            mu_bnd = model(**bld(bi2, train=True, rng=rng, p_mask_prov=args.prov_mask))
+            L_trans = F.softplus(-args.transitive_scale * (mu_bnd - mu_t - args.transitive_margin)).mean()
         loss = (args.sym_weight * L_sym + (0.0 if args.sym_only else args.wiki_weight * L_wiki)
                 + (args.elem_weight * L_elem if (elem_tr and not args.sym_only) else 0.0)
                 + (args.graded_weight * L_graded if (graded_tr and not args.sym_only) else 0.0)
+                + (args.transitive_weight * L_trans if (trans_rows and not args.sym_only) else 0.0)
                 + (args.blend_weight * L_blend if blend_on else 0.0)
                 + (args.anchor_kl_weight * L_anchor if blend_on else 0.0))
         # LLM (optional, already-bought) — skipped in single-task SYM mode
@@ -700,6 +739,7 @@ def train(args):
             print(f"  step {step+1:5d}  L_sym {float(L_sym):.4f}  L_wiki {float(L_wiki):.4f}"
                   + (f"  L_elem {float(L_elem):.4f}" if (elem_tr and not args.sym_only) else "")
                   + (f"  L_graded {float(L_graded):.4f}" if (graded_tr and not args.sym_only) else "")
+                  + (f"  L_trans {float(L_trans):.4f}" if (trans_rows and not args.sym_only) else "")
                   + (f"  L_blend {float(L_blend):.4f}" if blend_on else "")
                   + (f"  L_anchor {float(L_anchor):.4f}" if (blend_on and anchored_rel is not None) else "")
                   + (f"  L_llm {float(L_llm):.4f}" if (llm and not args.sym_only) else ""))
@@ -1004,6 +1044,12 @@ def main():
                     "override inferred (conf<1.0) graded targets with E[μ] + judge provenance (§9/§14)")
     ap.add_argument("--eval-tail", default=None, help="§9/§12(3) held-out-tail eval: model E[μ] (uniform op "
                     "superposition) vs cached Haiku E[μ] on these tail rows (needs --graded for the title↔key map)")
+    ap.add_argument("--transitive", default=None, help="transitive triples (transitive_closure.py --out): add a "
+                    "ranking-CE ordinal term μ(transitive) ≤ μ(bound edge) — graph-truth, no LLM (DESIGN_transitive_relations.md)")
+    ap.add_argument("--transitive-weight", type=float, default=0.0, help="weight on the transitive ranking-CE term (0=off)")
+    ap.add_argument("--transitive-margin", type=float, default=0.05, help="margin m: enforce μ_bound − μ_trans ≥ m")
+    ap.add_argument("--transitive-scale", type=float, default=10.0, help="logistic scale s (= global confidence; the "
+                    "naive homoscedastic first cut — heteroscedastic per-pair variance is the stage-2 upgrade)")
     ap.add_argument("--graded-nodes", default=None, help="override the graded nodes file (default: derive "
                     "from --graded by _pairs→_nodes)")
     ap.add_argument("--graded-weight", type=float, default=1.0, help="graded-round loss weight")

--- a/prototypes/mu_cosine/transitive_closure.py
+++ b/prototypes/mu_cosine/transitive_closure.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Transitive-closure generation for the ordinal-constraint training data (DESIGN_transitive_relations.md).
+
+STAGE 1 (this module): compose TAGGED hierarchical edges into transitive pairs, ranked by the **product of
+link μ** (= highest-product path = shortest path under cost −log μ; max-product / dominant-path semiring, the
+rigorous `⊕ = max` case). Pure graph code — no LLM, no training. Each emitted pair carries:
+  product   — Π μ(links): the curriculum ranking key (estimated transitive μ).
+  min_link  — min μ(links): the ordinal-constraint BOUND (`μ_transitive ≤ min_link`, §"is the bound product? No").
+  hops, rel — chain length and the composed relation (the operator); path for provenance.
+
+Composition (only transitive-compatible relations compose; lateral see_also/assoc do NOT):
+  element_of ∘ downward  → element_of      (C∈A, A⊆B ⇒ C∈B)
+  downward   ∘ downward  → subcategory/subtopic (containment chain)
+  super_category ∘ super_category → super_category
+  bridge passes a relation through (identity)
+where downward = {subcategory, subtopic}. Deferred (stage 2+): noisy-OR multi-path (needs enumeration, not a
+closure), heteroscedastic loss, the soft floor, the multi-factor judge term."""
+import math
+from collections import defaultdict
+
+DOWNWARD = {"subcategory", "subtopic"}
+# forward μ per relation (REL_SPEC); only hierarchical relations compose
+REL_MU = {"subcategory": 0.90, "subtopic": 0.85, "element_of": 0.90, "super_category": 0.85, "bridge": 0.90}
+
+
+def compose_relation(r1, r2):
+    """The composed relation for chaining r1 (accumulated from src) then r2 (next edge), or None if the pair
+    is not transitive-compatible (⇒ don't extend the chain)."""
+    if r1 == "bridge":
+        return r2
+    if r2 == "bridge":
+        return r1
+    if r1 == "element_of" and r2 in DOWNWARD:
+        return "element_of"
+    if r1 in DOWNWARD and r2 in DOWNWARD:
+        return "subcategory" if (r1 == "subcategory" and r2 == "subcategory") else "subtopic"
+    if r1 == "super_category" and r2 == "super_category":
+        return "super_category"
+    return None
+
+
+def transitive_pairs(edges, rel_mu=REL_MU, max_hops=3):
+    """edges: iterable of (src, dst, relation) directed, TAGGED hierarchical. Returns transitive pairs
+    (hops≥2) as dicts, dominant-path (max-product) per (src,dst), excluding any pair that is itself a direct
+    edge, sorted by product descending (the curriculum). Bounded-hop best-product search = Dijkstra-equivalent
+    at small depth (optimal substructure: the best path to C extends the best to B)."""
+    adj = defaultdict(list)
+    direct = set()
+    for s, d, r in edges:
+        mu = rel_mu.get(r)
+        if mu is None:                                 # non-hierarchical (see_also/assoc/...) — never composes
+            continue
+        adj[s].append((d, r, mu)); direct.add((s, d))
+    best = {}                                          # (src,dst) -> dict, keep max product
+    for src in list(adj):                              # snapshot — the search below must not mutate adj
+        stack = [(src, None, 1.0, 1.0, 0, (src,))]     # node, acc_rel, product, min_link, hops, path
+        while stack:
+            node, acc_rel, prod, mn, hops, path = stack.pop()
+            if hops >= max_hops:
+                continue
+            for d, r, mu in adj.get(node, ()):         # .get → don't auto-create leaf entries
+                if d in path:                          # simple paths only (no cycles)
+                    continue
+                rel = r if acc_rel is None else compose_relation(acc_rel, r)
+                if rel is None:                        # incompatible chain — prune
+                    continue
+                np, nmn, nh, npath = prod * mu, min(mn, mu), hops + 1, path + (d,)
+                if nh >= 2 and (src, d) not in direct:        # a transitive pair (not a direct edge)
+                    key = (src, d)
+                    if key not in best or np > best[key]["product"]:
+                        best[key] = {"src": src, "dst": d, "product": np, "min_link": nmn,
+                                     "hops": nh, "rel": rel, "path": npath}
+                stack.append((d, rel, np, nmn, nh, npath))
+    return sorted(best.values(), key=lambda x: -x["product"])
+
+
+def _cli():
+    import argparse, os
+    ap = argparse.ArgumentParser(description="emit transitive pairs from fused tagged edges (curriculum order)")
+    ap.add_argument("--edges", nargs="+", required=True, help="fused *_edges.tsv files (a\\tb\\trel\\tconf[...])")
+    ap.add_argument("--max-hops", type=int, default=3)
+    ap.add_argument("--top", type=int, default=20, help="print the top-N by product")
+    a = ap.parse_args()
+    edges = []
+    for f in a.edges:
+        for ln in open(f, encoding="utf-8"):
+            if ln.startswith("#"):
+                continue
+            c = ln.rstrip("\n").split("\t")
+            if len(c) >= 4 and c[2] in REL_MU:
+                try:
+                    if float(c[3]) >= 1.0:                 # TAGGED only (conf=1.0)
+                        edges.append((c[0], c[1], c[2]))
+                except ValueError:
+                    pass
+    pairs = transitive_pairs(edges, max_hops=a.max_hops)
+    from collections import Counter
+    print(f"{len(edges)} tagged hierarchical edges → {len(pairs)} transitive pairs (≤{a.max_hops} hops)")
+    print(f"  by hops: {dict(Counter(p['hops'] for p in pairs))}")
+    print(f"  by composed rel: {dict(Counter(p['rel'] for p in pairs))}")
+    print(f"  top {a.top} by product (the curriculum head):")
+    for p in pairs[:a.top]:
+        print(f"    {p['product']:.3f}  min={p['min_link']:.2f}  {p['hops']}h  {p['rel']:13} "
+              f"{p['src'].split(':')[-1][:24]} -> {p['dst'].split(':')[-1][:24]}")
+
+
+if __name__ == "__main__":
+    _cli()

--- a/prototypes/mu_cosine/transitive_closure.py
+++ b/prototypes/mu_cosine/transitive_closure.py
@@ -53,9 +53,9 @@ def transitive_pairs(edges, rel_mu=REL_MU, max_hops=3):
         adj[s].append((d, r, mu)); direct.add((s, d))
     best = {}                                          # (src,dst) -> dict, keep max product
     for src in list(adj):                              # snapshot — the search below must not mutate adj
-        stack = [(src, None, 1.0, 1.0, 0, (src,))]     # node, acc_rel, product, min_link, hops, path
+        stack = [(src, None, 1.0, 1.0, None, 0, (src,))]   # node, acc_rel, prod, min_link, bound_edge, hops, path
         while stack:
-            node, acc_rel, prod, mn, hops, path = stack.pop()
+            node, acc_rel, prod, mn, be, hops, path = stack.pop()
             if hops >= max_hops:
                 continue
             for d, r, mu in adj.get(node, ()):         # .get → don't auto-create leaf entries
@@ -64,13 +64,14 @@ def transitive_pairs(edges, rel_mu=REL_MU, max_hops=3):
                 rel = r if acc_rel is None else compose_relation(acc_rel, r)
                 if rel is None:                        # incompatible chain — prune
                     continue
+                nbe = (node, d, r) if (be is None or mu < mn) else be    # weakest link = the BOUND edge
                 np, nmn, nh, npath = prod * mu, min(mn, mu), hops + 1, path + (d,)
                 if nh >= 2 and (src, d) not in direct:        # a transitive pair (not a direct edge)
                     key = (src, d)
                     if key not in best or np > best[key]["product"]:
                         best[key] = {"src": src, "dst": d, "product": np, "min_link": nmn,
-                                     "hops": nh, "rel": rel, "path": npath}
-                stack.append((d, rel, np, nmn, nh, npath))
+                                     "hops": nh, "rel": rel, "bound": nbe, "path": npath}
+                stack.append((d, rel, np, nmn, nbe, nh, npath))
     return sorted(best.values(), key=lambda x: -x["product"])
 
 
@@ -80,6 +81,8 @@ def _cli():
     ap.add_argument("--edges", nargs="+", required=True, help="fused *_edges.tsv files (a\\tb\\trel\\tconf[...])")
     ap.add_argument("--max-hops", type=int, default=3)
     ap.add_argument("--top", type=int, default=20, help="print the top-N by product")
+    ap.add_argument("--out", default=None, help="write triples (transitive pair + its bounding direct edge) "
+                    "for the trainer's ranking-CE term; sorted by product (curriculum order)")
     a = ap.parse_args()
     edges = []
     for f in a.edges:
@@ -102,6 +105,14 @@ def _cli():
     for p in pairs[:a.top]:
         print(f"    {p['product']:.3f}  min={p['min_link']:.2f}  {p['hops']}h  {p['rel']:13} "
               f"{p['src'].split(':')[-1][:24]} -> {p['dst'].split(':')[-1][:24]}")
+    if a.out:
+        with open(a.out, "w", encoding="utf-8") as f:
+            f.write("# trans_src\ttrans_dst\ttrans_rel\tbound_src\tbound_dst\tbound_rel\tproduct\tmin_link\thops\n")
+            for p in pairs:                            # already sorted by product (curriculum order)
+                bs, bd, br = p["bound"]
+                f.write(f"{p['src']}\t{p['dst']}\t{p['rel']}\t{bs}\t{bd}\t{br}\t"
+                        f"{p['product']:.4f}\t{p['min_link']:.4f}\t{p['hops']}\n")
+        print(f"  wrote {len(pairs)} triples → {a.out}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements the merged design (`DESIGN_transitive_relations.md`): teach the μ model **transitive decay** from
clean graph structure, as a soft ordinal constraint. All flags default **off** → zero behavior change unless
enabled.

## Stage 1 — generation (`transitive_closure.py`, + 7 tests)
Compose **tagged hierarchical** edges into transitive pairs, ranked by **product of link μ** (= highest-product
path = shortest path on `−log μ`; max-product / dominant-path). Each pair carries `product` (curriculum key),
`min_link` (the ordinal **bound**), `hops`, composed `rel`, and the **bounding (weakest-link) edge**.
Composition table (element_of∘downward→element_of, downward∘downward→subcat/subtopic, super_category chains,
bridge passes through; lateral relations never compose). `--out` writes triples in curriculum order.
**Verified:** 2262 tagged edges → **4181 transitive pairs** (2607 two-hop, 1574 three-hop) — clean, free,
no LLM (~10× the noisy Haiku tail).

## Stage 2 — ranking-CE loss (`--transitive`, `--transitive-weight/-margin/-scale`)
Co-batch each transitive pair with its bounding edge; add
`L_trans = softplus(−s·(μ_bound − μ_trans − m)).mean()` = `−log σ(s·Δ)` — the ordinal ranking CE enforcing
`μ_trans ≤ μ_bound` (= `μ_trans ≤ min(links)`, the "transitive drop ≥ max pairwise drop" rule). This is a
**Lagrangian relaxation**: `--transitive-weight` is the multiplier λ (fixed; adaptive dual-ascent to a target
satisfaction rate is the noted upgrade). **Smoke-verified:** fires on 4181 in-vocab pairs, trains clean,
`L_trans` 0.39→0.22 (constraint being learned).

## Stage 3 — held-out eval (`--eval-transitive`)
On a **leakage-aware node-split** holdout, report **constraint satisfaction** (`μ_trans ≤ μ_bound`) **and**
the **anti-collapse / level** guard (mean `μ_bound` must stay high — not gamed by μ→0 — with `μ_trans` below
it). The node-split holds out destinations so held-out pairs share no endpoints with the training triples.

## Scope / deferred (as the design flags)
- Naive **global-`s`** (homoscedastic) CE first cut — heteroscedastic `Φ((ΔE−m)/√ΣVar)` deferred.
- `⊕ = max` (Dijkstra) only — **noisy-OR** multi-path (enumeration) deferred.
- **min-bound** only — product soft floor deferred.
- **No judge factor yet** — the multi-factor (LLM-anchored absolute μ) term is the enhancement, deferred.
- The **baseline-vs-treatment measurement run** is intentionally left to the operator (it's a CPU train;
  `--transitive /tmp/trans_train.tsv --transitive-weight 1 --eval-transitive /tmp/trans_hold.tsv`).

## Tests
`python3 test_transitive_closure.py` (7) passes; trainer parses; `--transitive` and `--eval-transitive`
smoke-run end-to-end. Generated triples/splits are gitignored (derived from private-tier fused data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)