### PR TITLE
mu_cosine: dual-ascent λ for the transitive constraint + methods doc

### DIFF
--- a/prototypes/mu_cosine/README_transitive.md
+++ b/prototypes/mu_cosine/README_transitive.md
@@ -1,0 +1,81 @@
+# Transitive ordinal constraints — methods & usage
+
+Teach the μ model **transitive decay** (`μ(A→C) ≤ min(links)`) from clean graph structure, as a soft ordinal
+constraint. Theory: [`DESIGN_transitive_relations.md`](DESIGN_transitive_relations.md). Verified results:
+[`REPORT_transitive_verification.md`](REPORT_transitive_verification.md) (generalises + no-collapse + survives
+convergence, replicated 2-seed on a leakage-aware holdout).
+
+## Pipeline (3 stages)
+
+### 1. Generate — `transitive_closure.py` (pure graph code, no LLM)
+Compose **tagged hierarchical** edges into transitive pairs, ranked by **product of link μ** (= highest-product
+path = Dijkstra on `−log μ`; max-product dominant path — DESIGN §"Generation order", §"Multi-path").
+```
+python3 transitive_closure.py --edges context/*_edges.tsv --max-hops 3 --out triples.tsv
+```
+Output triples: `trans_src trans_dst trans_rel | bound_src bound_dst bound_rel | product min_link hops`.
+The **bound edge** = the weakest link = the ordinal bound (`μ_trans ≤ μ_bound`, i.e. "transitive drop ≥ max
+pairwise drop" — DESIGN §"is the bound the product? No").
+
+### 2. Train with the ordinal constraint — `train_mu_attention.py --transitive`
+Adds `L_trans = softplus(−s·(μ_bound − μ_trans − m))` = `−log σ(s·Δ)`, the ranking CE (DESIGN §"The loss",
+§"statistical not logical"). **A Lagrangian relaxation** of the inequality — the weight is the multiplier λ.
+Two ways to set λ:
+
+**(a) Fixed λ** — the naive first cut (hand-set multiplier):
+```
+... --transitive triples.tsv --transitive-weight 1.0 [--transitive-margin 0.05 --transitive-scale 10]
+```
+
+**(b) Dual-ascent λ (recommended)** — adapt λ to a *target satisfaction rate* (DESIGN §"multi-factor",
+loss-note "adaptive dual-ascent"): `λ ← clamp(λ + lr·(target − sat), 0, max)`. Removes the hand-tuned weight;
+λ self-tunes to the *minimal* value that hits the target (decreases when over-satisfied).
+```
+... --transitive triples.tsv --transitive-weight 1.0 --transitive-target-sat 0.92 \
+    [--transitive-lambda-lr 0.1 --transitive-lambda-max 20]
+```
+
+### 3. Evaluate — `--eval-transitive` (leakage-aware)
+On a **held-out node-split** (hold out destination nodes so held-out pairs share no endpoints with training —
+DESIGN §"Eval ... leakage-aware split"):
+```
+... --eval-transitive holdout_triples.tsv
+```
+Reports **constraint satisfaction** (`μ_trans ≤ μ_bound`) **and the anti-collapse / level guard** (mean
+`μ_bound` must stay HIGH — not gamed by μ→0 — `μ_trans` below it). Both are needed: satisfaction alone is
+gamed by collapse (DESIGN §"Eval ... anti-collapse").
+
+**Leakage-aware split** (node-based, deterministic):
+```
+python3 transitive_closure.py --edges context/*_edges.tsv --out all.tsv
+python3 - <<'PY'
+import random
+rows=[l.rstrip() for l in open('all.tsv') if not l.startswith('#')]; hdr=open('all.tsv').readline().rstrip()
+nodes={n for l in rows for n in l.split('\t')[:2]}
+H=set(random.Random(7).sample(sorted(nodes), int(0.2*len(nodes))))
+tr=[l for l in rows if l.split('\t')[0] not in H and l.split('\t')[1] not in H]
+ho=[l for l in rows if l.split('\t')[1] in H]
+open('trans_train.tsv','w').write(hdr+'\n'+'\n'.join(tr)+'\n'); open('trans_hold.tsv','w').write(hdr+'\n'+'\n'.join(ho)+'\n')
+PY
+```
+
+## Knobs
+| flag | meaning | default |
+|---|---|---|
+| `--transitive PATH` | triples file (stage 1 `--out`) | — |
+| `--transitive-weight` | fixed-λ multiplier (also the dual-ascent init) | 0.0 (off) |
+| `--transitive-margin` | `m`: enforce `μ_bound − μ_trans ≥ m` | 0.05 |
+| `--transitive-scale` | logistic `s` (global confidence; homoscedastic) | 10.0 |
+| `--transitive-target-sat` | dual-ascent target satisfaction (0=fixed-λ) | 0.0 |
+| `--transitive-lambda-lr` / `-max` | dual-ascent step / cap | 0.1 / 20 |
+| `--eval-transitive PATH` | held-out triples → satisfaction + anti-collapse | — |
+
+## Deferred methods (proposed, not built — see DESIGN open questions)
+- **Heteroscedastic loss** — per-pair confidence from the superposition variance (`−log Φ((ΔE−m)/√ΣVar)`),
+  replacing the global `s` (DESIGN §"The loss must be over the predicted DISTRIBUTION"). NB: the variance is
+  *not* free — it needs R hard-cell forwards / MC.
+- **Noisy-OR multi-path** — reinforcement when multiple paths exist; NOT a semiring closure (needs path
+  enumeration), unlike the `max` default (DESIGN §"Multi-path: semiring closure vs path enumeration").
+- **LLM-anchored multi-factor `μ_bound`** — a judge term anchoring the absolute bound, weighted by *inter-judge
+  agreement* (not single-judge confidence — measured caveat) (DESIGN §"multi-factor loss", §"Measured caveat").
+- **Product soft floor** — band `[floor, μ_bound − m]` to prevent over-decay (DESIGN §"too low risk").

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -421,7 +421,7 @@ def train(args):
     # fused graded round (mixed-operator, hand-curated): hold out 15% for eval; bridges down-weighted in loss
     graded_rows = [r for r in graded_rows if r[0] in idx and r[1] in idx]
     trans_rows = []
-    if args.transitive and os.path.exists(args.transitive) and args.transitive_weight > 0:
+    if args.transitive and os.path.exists(args.transitive) and (args.transitive_weight > 0 or args.transitive_target_sat > 0):
         trans_rows = load_transitive(args.transitive, idx)
         print(f"TRANSITIVE (ordinal ranking-CE, w={args.transitive_weight:g}, m={args.transitive_margin:g}, "
               f"s={args.transitive_scale:g}): {trans_rows and len(trans_rows)} pairs in-vocab from "
@@ -610,6 +610,7 @@ def train(args):
     eps = 1e-6
     bce = lambda x, t: F.binary_cross_entropy(x.clamp(eps, 1 - eps), torch.full_like(x, float(t)))
     es_best, es_best_step, es_wait, es_saved = float("inf"), 0, 0, False   # early-stopping state
+    trans_lambda = args.transitive_weight if args.transitive_weight > 0 else 1.0   # running λ for dual-ascent
     for step in range(args.steps):
         model.train()
         opt.zero_grad()
@@ -717,7 +718,7 @@ def train(args):
         # −log σ(s·(μ_bound − μ_trans − m)) = softplus(−s·Δ). Naive global-s (homoscedastic) first cut.
         # NB: this is a Lagrangian relaxation of the hard inequality μ_trans ≤ μ_bound; --transitive-weight is
         # the multiplier λ (fixed here — adaptive dual-ascent on a target satisfaction rate is the upgrade).
-        L_trans = torch.zeros(())
+        L_trans = torch.zeros(()); tw_eff = 0.0
         if trans_rows and not args.sym_only:
             tb = [trans_rows[rng.randrange(len(trans_rows))] for _ in range(args.bs)]
             extra = (lambda k: (nt(""), nt(""))) if args.use_nodetype else (lambda k: ())
@@ -726,10 +727,17 @@ def train(args):
             mu_t = model(**bld(ti, train=True, rng=rng, p_mask_prov=args.prov_mask))
             mu_bnd = model(**bld(bi2, train=True, rng=rng, p_mask_prov=args.prov_mask))
             L_trans = F.softplus(-args.transitive_scale * (mu_bnd - mu_t - args.transitive_margin)).mean()
+            if args.transitive_target_sat > 0:                 # DUAL-ASCENT λ (Lagrangian): adapt to a target sat rate
+                sat = (mu_t <= mu_bnd).float().mean().item()
+                trans_lambda = min(args.transitive_lambda_max,
+                                   max(0.0, trans_lambda + args.transitive_lambda_lr * (args.transitive_target_sat - sat)))
+                tw_eff = trans_lambda
+            else:
+                tw_eff = args.transitive_weight                # fixed-λ (the multiplier set by hand)
         loss = (args.sym_weight * L_sym + (0.0 if args.sym_only else args.wiki_weight * L_wiki)
                 + (args.elem_weight * L_elem if (elem_tr and not args.sym_only) else 0.0)
                 + (args.graded_weight * L_graded if (graded_tr and not args.sym_only) else 0.0)
-                + (args.transitive_weight * L_trans if (trans_rows and not args.sym_only) else 0.0)
+                + (tw_eff * L_trans if (trans_rows and not args.sym_only) else 0.0)
                 + (args.blend_weight * L_blend if blend_on else 0.0)
                 + (args.anchor_kl_weight * L_anchor if blend_on else 0.0))
         # LLM (optional, already-bought) — skipped in single-task SYM mode
@@ -764,7 +772,8 @@ def train(args):
             print(f"  step {step+1:5d}  L_sym {float(L_sym):.4f}  L_wiki {float(L_wiki):.4f}"
                   + (f"  L_elem {float(L_elem):.4f}" if (elem_tr and not args.sym_only) else "")
                   + (f"  L_graded {float(L_graded):.4f}" if (graded_tr and not args.sym_only) else "")
-                  + (f"  L_trans {float(L_trans):.4f}" if (trans_rows and not args.sym_only) else "")
+                  + (f"  L_trans {float(L_trans):.4f}" + (f" λ{trans_lambda:.2f}" if args.transitive_target_sat > 0 else "")
+                     if (trans_rows and not args.sym_only) else "")
                   + (f"  L_blend {float(L_blend):.4f}" if blend_on else "")
                   + (f"  L_anchor {float(L_anchor):.4f}" if (blend_on and anchored_rel is not None) else "")
                   + (f"  L_llm {float(L_llm):.4f}" if (llm and not args.sym_only) else ""))
@@ -1077,6 +1086,10 @@ def main():
     ap.add_argument("--transitive-margin", type=float, default=0.05, help="margin m: enforce μ_bound − μ_trans ≥ m")
     ap.add_argument("--transitive-scale", type=float, default=10.0, help="logistic scale s (= global confidence; the "
                     "naive homoscedastic first cut — heteroscedastic per-pair variance is the stage-2 upgrade)")
+    ap.add_argument("--transitive-target-sat", type=float, default=0.0, help="dual-ascent λ (Lagrangian): adapt the "
+                    "transitive weight to hit this held-in satisfaction rate (0=off → fixed --transitive-weight). e.g. 0.92")
+    ap.add_argument("--transitive-lambda-lr", type=float, default=0.1, help="dual-ascent step: λ ← λ + lr·(target − sat)")
+    ap.add_argument("--transitive-lambda-max", type=float, default=20.0, help="cap on λ (runaway guard)")
     ap.add_argument("--eval-transitive", default=None, help="held-out transitive triples → report constraint "
                     "satisfaction + anti-collapse level (use a node-split holdout, not the training triples)")
     ap.add_argument("--graded-nodes", default=None, help="override the graded nodes file (default: derive "


### PR DESCRIPTION
Stage-2 upgrade #1: replace the hand-tuned fixed transitive weight with **dual-ascent λ** — the principled
Lagrangian. Plus `README_transitive.md` documenting all methods with links to the theory.

## Dual-ascent λ (`--transitive-target-sat`)
Adapt the transitive weight to a **target satisfaction rate** instead of hand-setting it:
`λ ← clamp(λ + lr·(target − sat), 0, max)`. Off by default (`target-sat=0` → fixed `--transitive-weight`,
unchanged). It's the principled form of the Lagrangian multiplier noted in the loss.

**Smoke-verified (target 0.92, warm-start, 120 steps):** λ self-tunes — rises (1.0→1.11) when satisfaction is
below target, then **falls** (1.04→0.93→0.81→0.68→0.53) once it clears 0.92 — settling *below* the hand-set
λ=1 because the target is easily met. Held-out: **95% satisfaction (≈ target), μ_bound 0.748 (no collapse).**
It finds the *minimal* weight to hit the target (avoids over-weighting).

## `README_transitive.md` — methods & usage
The 3-stage pipeline (generate → train → eval) with commands, **both** training methods (fixed-λ vs
dual-ascent), the **leakage-aware node-split** recipe, every knob, and the **deferred methods** — each linked
to the applicable `DESIGN_transitive_relations.md` section and `REPORT_transitive_verification.md`.

## New flags
`--transitive-target-sat` (dual-ascent target, 0=off), `--transitive-lambda-lr` (0.1), `--transitive-lambda-max`
(20). Default-off → no behavior change.

## Test plan
Parses; smoke-run shows λ adapting + 95% held-out satisfaction + no collapse. `test_transitive_closure.py`
(7) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)