### PR TITLE
mu_cosine: heteroscedastic transitive loss via product-propagated chain variance

### DIFF
--- a/prototypes/mu_cosine/README_transitive.md
+++ b/prototypes/mu_cosine/README_transitive.md
@@ -35,6 +35,13 @@ loss-note "adaptive dual-ascent"): `λ ← clamp(λ + lr·(target − sat), 0, m
     [--transitive-lambda-lr 0.1 --transitive-lambda-max 20]
 ```
 
+**Scale: homoscedastic vs heteroscedastic** (orthogonal to λ — this sets the logistic *sharpness*, not the
+weight). Default = global `s` (`--transitive-scale`). Add **`--transitive-hetero`** for **per-pair**
+`s_pair = s/√(1+V)`, where `V` is the **product-propagated chain variance** carried in the triples:
+`V = Σ_links (1−μ)/μ` — the textbook product error-propagation (relative variances add; additive in
+log-variance, the dual of the log-μ chaining). **Longer / weaker chains → larger `V` → softer constraint** —
+which the global-`s` form cannot express. DESIGN §"The loss must be over the predicted DISTRIBUTION".
+
 ### 3. Evaluate — `--eval-transitive` (leakage-aware)
 On a **held-out node-split** (hold out destination nodes so held-out pairs share no endpoints with training —
 DESIGN §"Eval ... leakage-aware split"):
@@ -66,14 +73,16 @@ PY
 | `--transitive-weight` | fixed-λ multiplier (also the dual-ascent init) | 0.0 (off) |
 | `--transitive-margin` | `m`: enforce `μ_bound − μ_trans ≥ m` | 0.05 |
 | `--transitive-scale` | logistic `s` (global confidence; homoscedastic) | 10.0 |
+| `--transitive-hetero` | per-pair `s_pair=s/√(1+V)` from product-propagated chain variance (heteroscedastic) | off |
 | `--transitive-target-sat` | dual-ascent target satisfaction (0=fixed-λ) | 0.0 |
 | `--transitive-lambda-lr` / `-max` | dual-ascent step / cap | 0.1 / 20 |
 | `--eval-transitive PATH` | held-out triples → satisfaction + anti-collapse | — |
 
 ## Deferred methods (proposed, not built — see DESIGN open questions)
-- **Heteroscedastic loss** — per-pair confidence from the superposition variance (`−log Φ((ΔE−m)/√ΣVar)`),
-  replacing the global `s` (DESIGN §"The loss must be over the predicted DISTRIBUTION"). NB: the variance is
-  *not* free — it needs R hard-cell forwards / MC.
+- **Heteroscedastic via superposition variance** — the design's *original* variance source (per-pair
+  `Var[μ]` from the operator-superposition, needing R hard-cell forwards / MC). **Built instead:** the cheaper,
+  cleaner **product-propagated chain variance** (`--transitive-hetero`, above) — structural, no extra forwards.
+  The superposition-variance variant remains an alternative if a per-pair (non-chain) uncertainty is wanted.
 - **Noisy-OR multi-path** — reinforcement when multiple paths exist; NOT a semiring closure (needs path
   enumeration), unlike the `max` default (DESIGN §"Multi-path: semiring closure vs path enumeration").
 - **LLM-anchored multi-factor `μ_bound`** — a judge term anchoring the absolute bound, weighted by *inter-judge

--- a/prototypes/mu_cosine/test_transitive_closure.py
+++ b/prototypes/mu_cosine/test_transitive_closure.py
@@ -24,6 +24,7 @@ def test_two_hop_product_and_bound():
     assert (p["src"], p["dst"]) == ("A", "C") and p["hops"] == 2 and p["rel"] == "subcategory"
     assert abs(p["product"] - 0.81) < 1e-9            # 0.9·0.9, the ranking key
     assert abs(p["min_link"] - 0.90) < 1e-9           # min link = the ordinal BOUND
+    assert abs(p["var"] - 2 * (0.1 / 0.9)) < 1e-6     # Σ (1−μ)/μ over 2 links = product-propagated variance
 
 
 def test_element_of_through_containment():

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -55,7 +55,8 @@ def load_transitive(path, idx):
             continue
         c = ln.rstrip("\n").split("\t")
         if len(c) >= 6 and c[0] in idx and c[1] in idx and c[3] in idx and c[4] in idx:
-            rows.append((c[0], c[1], c[2], c[3], c[4], c[5]))
+            var = float(c[9]) if len(c) > 9 and c[9] else 0.0   # product-propagated chain variance (heteroscedastic)
+            rows.append((c[0], c[1], c[2], c[3], c[4], c[5], var))
     return rows
 
 
@@ -726,7 +727,12 @@ def train(args):
             bi2 = [(t[3], t[4], OPS[REL_SPEC[t[5]][0]], CORPORA[_corp_of(t[3])], JUDGES["graph"]) + extra(t[3]) for t in tb]
             mu_t = model(**bld(ti, train=True, rng=rng, p_mask_prov=args.prov_mask))
             mu_bnd = model(**bld(bi2, train=True, rng=rng, p_mask_prov=args.prov_mask))
-            L_trans = F.softplus(-args.transitive_scale * (mu_bnd - mu_t - args.transitive_margin)).mean()
+            if args.transitive_hetero:                         # per-pair scale from product-propagated chain variance
+                v = torch.tensor([t[6] for t in tb], dtype=torch.float32, device=device)
+                s_eff = args.transitive_scale / (1.0 + v).sqrt()    # s_pair = s/√(1+V): longer/weaker chains → softer
+            else:
+                s_eff = args.transitive_scale                 # global s (homoscedastic)
+            L_trans = F.softplus(-s_eff * (mu_bnd - mu_t - args.transitive_margin)).mean()
             if args.transitive_target_sat > 0:                 # DUAL-ASCENT λ (Lagrangian): adapt to a target sat rate
                 sat = (mu_t <= mu_bnd).float().mean().item()
                 trans_lambda = min(args.transitive_lambda_max,
@@ -1090,6 +1096,9 @@ def main():
                     "transitive weight to hit this held-in satisfaction rate (0=off → fixed --transitive-weight). e.g. 0.92")
     ap.add_argument("--transitive-lambda-lr", type=float, default=0.1, help="dual-ascent step: λ ← λ + lr·(target − sat)")
     ap.add_argument("--transitive-lambda-max", type=float, default=20.0, help="cap on λ (runaway guard)")
+    ap.add_argument("--transitive-hetero", action="store_true", help="heteroscedastic: per-pair scale s_pair = "
+                    "s/√(1+V) from the product-propagated chain variance V (longer/weaker chains → softer); "
+                    "vs the default global s (homoscedastic). DESIGN §'loss over the DISTRIBUTION'")
     ap.add_argument("--eval-transitive", default=None, help="held-out transitive triples → report constraint "
                     "satisfaction + anti-collapse level (use a node-split holdout, not the training triples)")
     ap.add_argument("--graded-nodes", default=None, help="override the graded nodes file (default: derive "

--- a/prototypes/mu_cosine/transitive_closure.py
+++ b/prototypes/mu_cosine/transitive_closure.py
@@ -53,9 +53,10 @@ def transitive_pairs(edges, rel_mu=REL_MU, max_hops=3):
         adj[s].append((d, r, mu)); direct.add((s, d))
     best = {}                                          # (src,dst) -> dict, keep max product
     for src in list(adj):                              # snapshot — the search below must not mutate adj
-        stack = [(src, None, 1.0, 1.0, None, 0, (src,))]   # node, acc_rel, prod, min_link, bound_edge, hops, path
+        # state: node, acc_rel, prod, min_link, bound_edge, var (Σ rel-variance, log-space product propagation), hops, path
+        stack = [(src, None, 1.0, 1.0, None, 0.0, 0, (src,))]
         while stack:
-            node, acc_rel, prod, mn, be, hops, path = stack.pop()
+            node, acc_rel, prod, mn, be, var, hops, path = stack.pop()
             if hops >= max_hops:
                 continue
             for d, r, mu in adj.get(node, ()):         # .get → don't auto-create leaf entries
@@ -65,13 +66,14 @@ def transitive_pairs(edges, rel_mu=REL_MU, max_hops=3):
                 if rel is None:                        # incompatible chain — prune
                     continue
                 nbe = (node, d, r) if (be is None or mu < mn) else be    # weakest link = the BOUND edge
+                nvar = var + (1.0 - mu) / mu           # additive log-variance (Bernoulli rel-var, product propagation)
                 np, nmn, nh, npath = prod * mu, min(mn, mu), hops + 1, path + (d,)
                 if nh >= 2 and (src, d) not in direct:        # a transitive pair (not a direct edge)
                     key = (src, d)
                     if key not in best or np > best[key]["product"]:
                         best[key] = {"src": src, "dst": d, "product": np, "min_link": nmn,
-                                     "hops": nh, "rel": rel, "bound": nbe, "path": npath}
-                stack.append((d, rel, np, nmn, nbe, nh, npath))
+                                     "hops": nh, "rel": rel, "bound": nbe, "var": nvar, "path": npath}
+                stack.append((d, rel, np, nmn, nbe, nvar, nh, npath))
     return sorted(best.values(), key=lambda x: -x["product"])
 
 
@@ -107,11 +109,11 @@ def _cli():
               f"{p['src'].split(':')[-1][:24]} -> {p['dst'].split(':')[-1][:24]}")
     if a.out:
         with open(a.out, "w", encoding="utf-8") as f:
-            f.write("# trans_src\ttrans_dst\ttrans_rel\tbound_src\tbound_dst\tbound_rel\tproduct\tmin_link\thops\n")
+            f.write("# trans_src\ttrans_dst\ttrans_rel\tbound_src\tbound_dst\tbound_rel\tproduct\tmin_link\thops\tvar\n")
             for p in pairs:                            # already sorted by product (curriculum order)
                 bs, bd, br = p["bound"]
                 f.write(f"{p['src']}\t{p['dst']}\t{p['rel']}\t{bs}\t{bd}\t{br}\t"
-                        f"{p['product']:.4f}\t{p['min_link']:.4f}\t{p['hops']}\n")
+                        f"{p['product']:.4f}\t{p['min_link']:.4f}\t{p['hops']}\t{p['var']:.4f}\n")
         print(f"  wrote {len(pairs)} triples → {a.out}")
 
 


### PR DESCRIPTION
Stage-2 upgrade #2. Makes the constraint's per-pair confidence **heteroscedastic** — and the variance source
is the **product error-propagation** (standard error-analysis): just as μ chains via the product, the
uncertainty chains additively in log-variance.

## Both scale methods, configurable (`--transitive-hetero`)
- **Homoscedastic (default):** global logistic scale `s` (`--transitive-scale`).
- **Heteroscedastic (`--transitive-hetero`):** per-pair `s_pair = s/√(1+V)`, where
  `V = Σ_links (1−μ)/μ` is the **product-propagated chain variance** (Bernoulli relative variance per link,
  accumulated — relative variances add for a product, additive in log-variance, the dual of log-μ chaining).

## Why this variance source (vs a head / op-spread)
- **Structural, computed at generation time** — `transitive_closure.py` emits `V` as a new triple column. So
  **no variance head, no extra forwards** — the cleanest source (the review's "variance isn't free" concern
  is sidestepped because it's data-side, not a model artifact).
- **Grows with chain length** — longer/weaker chains accumulate more `V` → the constraint **auto-softens**
  for them (a 4-hop claim *should* be softer than a 2-hop one). The global-`s` form can't express this.
- **Composes with dual-ascent λ** — `V` sets the *sharpness* inside the logistic; λ sets the *weight* outside.

## Verification
- 7 `transitive_closure` tests pass (+ a `var` assertion: 2-hop 0.9·0.9 → V = 2·(0.1/0.9) ✓).
- Smoke run (`--transitive-hetero`): fires, trains (L_trans 0.33→0.08), held-out **95% satisfaction,
  μ_bound 0.798 (no collapse)**.
- `README_transitive.md` updated — hetero is now a built option; the superposition-variance variant is noted
  as the deferred alternative.

## Default-off → no behavior change. Docs + opt-in flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)