### PR TITLE
mu_cosine: stratified hetero A/B — heteroscedastic is NEUTRAL at this scale (closes the feature)

### DIFF
--- a/prototypes/mu_cosine/REPORT_transitive_verification.md
+++ b/prototypes/mu_cosine/REPORT_transitive_verification.md
@@ -66,3 +66,27 @@ replicated win on a leakage-aware holdout; the magnitude is largest in the under
 improves calibration — on clean graph-truth. The stage-2 upgrades (dual-ascent λ, heteroscedastic loss,
 LLM-anchored multi-factor μ_bound, noisy-OR multi-path) are justified; recommended order starts with
 **dual-ascent λ** (target a satisfaction rate, removing the hand-tuned weight).
+
+## Heteroscedastic A/B — NEUTRAL at this scale (honest result)
+Homoscedastic vs `--transitive-hetero`, 700 steps, 2 seeds, **stratified by hop-length** (the test: does
+hetero soften 3-hop while holding 2-hop?).
+
+| seed/arm | 2-hop sat / μ_trans | 3-hop sat / μ_trans | overall |
+|---|---|---|---|
+| 1/homo | 95% / 0.06 | 95% / 0.06 | 95% |
+| 1/hetero | 95% / 0.08 | 96% / 0.08 | 95% |
+| 2/homo | 96% / 0.10 | 93% / 0.13 | 95% |
+| 2/hetero | 96% / 0.10 | 92% / 0.12 | 94% |
+
+**Verdict: NEUTRAL** — hetero's per-hop μ_trans and satisfaction are within seed-noise of homoscedastic; the
+expected 3-hop softening did not appear.
+
+**Why (mechanistic, not a shrug):** on the **strong-chain curriculum** (high-product, μ≈0.9 links) the
+variance is small *and* uniform across lengths — `V(2-hop)=0.22`, `V(3-hop)=0.33` → `s_pair = s/√(1+V)` =
+**9.05 vs 8.67**, a ~4% scale difference, too small to bite. Hetero only matters where `V` varies a lot:
+**weak links** (low μ ⇒ large `(1−μ)/μ`) or **long chains** — precisely what the product-curriculum
+deprioritises. So on the data we actually train, homo ≈ hetero.
+
+**Conclusion:** hetero is built, correct, and composes, but is **currently neutral** — keep it **off by
+default** (available for a weak/long-chain regime). The core constraint (ranking-CE + dual-ascent λ) is the
+verified win; hetero is a correct-but-dormant option here.

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -56,7 +56,8 @@ def load_transitive(path, idx):
         c = ln.rstrip("\n").split("\t")
         if len(c) >= 6 and c[0] in idx and c[1] in idx and c[3] in idx and c[4] in idx:
             var = float(c[9]) if len(c) > 9 and c[9] else 0.0   # product-propagated chain variance (heteroscedastic)
-            rows.append((c[0], c[1], c[2], c[3], c[4], c[5], var))
+            hops = int(c[8]) if len(c) > 8 and c[8] else 2      # chain length (for stratified eval)
+            rows.append((c[0], c[1], c[2], c[3], c[4], c[5], var, hops))
     return rows
 
 
@@ -309,6 +310,15 @@ def eval_transitive(model, tok, path, idx, use_nodetype):
     mbm, mtm = sum(mb) / n, sum(mt) / n
     if was:
         model.train()
+    # stratify by hop-length — the heteroscedastic test: does it hold 2-hop while softening 3-hop?
+    by_h = {}
+    for i, t in enumerate(rows):
+        by_h.setdefault(t[7], []).append(i)
+    strat = "  ".join(
+        f"{h}h(n={len(ix)}): sat {100*sum(1 for i in ix if mt[i] <= mb[i])/len(ix):.0f}%, "
+        f"μ_bound {sum(mb[i] for i in ix)/len(ix):.2f}, μ_trans {sum(mt[i] for i in ix)/len(ix):.2f}"
+        for h, ix in sorted(by_h.items()))
+    print(f"[TRANS-EVAL/hops] {strat}")
     print(f"[TRANS-EVAL] {n} held-out pairs: satisfaction μ_trans≤μ_bound = {100*sat:.0f}%  | "
           f"anti-collapse: μ_bound̄ {mbm:.3f} (must stay high), μ_trans̄ {mtm:.3f}, gap {mbm-mtm:+.3f}")
 


### PR DESCRIPTION
Per-hop-stratified eval + the homo-vs-hetero A/B it enables.

## Change
`eval_transitive` now prints `[TRANS-EVAL/hops]` — satisfaction / μ_bound / μ_trans **per hop-length** (the
instrument; aggregate 95% can't show the effect).

## Result (700 steps, 2 seeds, stratified)
Hetero's per-hop μ_trans and satisfaction are **within seed-noise of homoscedastic** — the expected 3-hop
softening didn't appear. **Why:** on the strong-chain curriculum (μ≈0.9), `V` is small + uniform —
`V(2h)=0.22`, `V(3h)=0.33` → `s_pair` 9.05 vs 8.67 (~4%, too small to bite). Hetero only matters with weak
links / long chains, which the product-curriculum deprioritises.

## Verdict
Hetero is built, correct, and composes — but **currently neutral**; keep it **off by default** (available for
a weak/long-chain regime). The verified win is the core (ranking-CE + dual-ascent λ). Closes the transitive
feature's open questions. Docs + report only (no behavior change; hetero stays opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)