### PR TITLE
μ-attention: retrieval algorithm + formal filing eval + the bitter-lesson result

### DIFF
--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -224,6 +224,28 @@ fit ⇒ a **hybrid**: operator embedding = the **low-rank bivector-mapped partia
 from `K` blades), transformer reads μ on top — strong prior *and* learned refinement, both at forward-pass cost.
 (The `> root` rotor is also amortised — computed once per root, reused across all candidates.)
 
+**Precedent — this is already built (the federated rotation machinery), and K-blades was the *representation*, not
+the whole trick.** The repo's Pearltrees federated projection (`scripts/infer_pearltrees_federated.py`,
+`scripts/train_orthogonal_codebook.py`, `scripts/train_bivector_codebook.py`, `src/.../rotation_transformer.py`)
+already beats the naïve per-cluster `logm`/`expm` (O(n³)). What actually carries the speed:
+- **The blades are made axis-aligned / orthogonal, and *that* is load-bearing.** Orthogonal planes **commute**, so
+  `exp(Σ wᵢBᵢ) = Π exp(wᵢBᵢ)` — which licenses the **Rodrigues / Givens product** application
+  (`train_orthogonal_codebook.py:351-439, 965-1077`). It is "K **commuting** blades," not just "K blades"; the
+  commuting removes the matrix exp. (Matryoshka structure ⇒ the first ~64 axis dims suffice —
+  `docs/design/ORTHOGONAL_CODEBOOK_DESIGN.md`.)
+- **Canonical plane-angle decomposition** (`infer_pearltrees_federated.py:191-391`, `rotational-fast`) is the
+  actual inference-time `logm`-beater: split `W` into d/2 axis-aligned 2×2 blocks, read each angle via `arctan2`,
+  blend angles by scalar weighted-average, apply vectorized 2×2 rotations — O(K·d), no matrix functions.
+- **Learned codebook** (PCA/SVD over cluster generators → K principal bivectors; defaults **K=64**, **top-8**
+  blended per query — matching the "K≈8" estimate above) learns *which* blades.
+- **Distillation pays the matrix functions once, at training, never at inference**: the exact `logm`/`expm`
+  teacher is distilled into a cheap student (a transformer / a Givens layer)
+  (`scripts/distill_federated_to_transformer.py`). So even the "high" cost is a *one-time training* cost — which
+  collapses the cost axis further toward the transformer once distilled.
+So our hybrid has a **proven recipe**: K commuting (axis-aligned) blades, applied via Rodrigues/Givens, selected
+by a small codebook, optionally distilled into the μ transformer so inference is a plain forward pass. The
+geodesic `x_root ∧ x_node` is the K=1 special case (`src/.../minimal_transform.py:_rotation_between_vectors`).
+
 **Rotations on the sphere → bivectors as the generator.** e5 embeddings are **unit-normed**, so they live on a
 sphere and the relationship root→node is a **geodesic rotation**: rotor `R = exp(−½ θ B)`, applied
 `x_node = R x_root R̃`, where the **plane** `B = (x_root ∧ x_node)`-normalized and the **angle**

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -171,6 +171,32 @@ Our operators split *exactly* along this seam:
 So μ's symmetric/directional operator structure *is* the scalar/bivector grade structure of a multivector — the
 asymmetry is geometric **by construction**, not bolted on.
 
+**Partial application (currying) — `μ(·|root)` *is* a partial application.** With `>` = subset, the binary
+relation `A > B` (A ⊆ B) curries into two unary predicates: **`A >`** = λx. A ⊆ x = *supersets of A* = "A as a
+**member**" = the `μ(A|·)` predicate; **`> B`** = λx. x ⊆ B = *subsets of B* = "B as a **container**" = the
+`μ(·|B)` predicate. So **conditioning on the root is currying the relation** — `μ(·|root)` is exactly the partial
+application `> root` (rank the *members* of root). The proposal: **the bivector mapping outputs the
+partial-application embedding** (the operator `> root` as a vector/rotor), and `μ(node|root) = ⟨node, (>root)⟩`
+(contract node against it). A node's two structural roles — *member* (`node >`) vs *container* (`> node`) — are
+the **two signs of its bivector** (`x_a∧x_b = −x_b∧x_a` = subset-vs-superset = `μ(a|b)≠μ(b|a)`), so the sign
+picks the role for free. This re-grounds the symmetric/asymmetric split: a symmetric op has `A ~ = ~ A` (no
+orientation) ⇒ the **dot product suffices**; an asymmetric op has `A > ≠ > A` ⇒ you **need** the bivector to tell
+the two curryings apart (the dot product cannot curry asymmetrically). Consistency check: `μ(node|root)` computed
+as `⟨node,(>root)⟩` or `⟨(node>),root⟩` must agree — the associativity of the geometric product (one relation,
+two views).
+
+**Cost tradeoff — bivector = inference cost, transformer = training cost (the unifying axis).** The bivector
+carries a **strong geometric prior** (directionality is *given*), so it needs **little training data** but pays a
+**high inference cost** (rotor exp/log per pair). The transformer has a **weak prior** (must *learn* the
+direction from data), so it has a **high training/data cost** but **cheap inference** (one forward pass). This
+*is* the filing-vs-home-turf result: e5/Procrustes(+bivector) wins OOD where in-domain data is absent (strong
+prior pays); transformer μ wins in-domain where it had the data. With our **currently low training coverage**,
+the cost axis favours the strong-prior tool — which argues for a **hybrid**: make the operator embeddings the
+**bivector-mapped partial applications** (`> root` computed geometrically) and let the transformer read μ on top.
+Pay the rotor cost at inference, hand the transformer the directional primitive pre-built ⇒ far less data to
+reach in-domain-competitive. Strong prior *and* learned refinement, composed. (Open: the rotor cost is
+amortisable — a root's `> root` operator is computed once and reused across all candidate nodes.)
+
 **Rotations on the sphere → bivectors as the generator.** e5 embeddings are **unit-normed**, so they live on a
 sphere and the relationship root→node is a **geodesic rotation**: rotor `R = exp(−½ θ B)`, applied
 `x_node = R x_root R̃`, where the **plane** `B = (x_root ∧ x_node)`-normalized and the **angle**

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -123,12 +123,29 @@ many regions separated by boundary manifolds (the nonlinear analog of routed per
 loses ~2× everywhere" conflates OOD-task + cold-start + (maybe) wrong-region; stratification rules out
 wrong-region-as-sole-cause but not the rest.
 
-**Decisive next test — μ vs e5-cos on home turf:** hold out *simplewiki* category→parent memberships
-(in-distribution, *with* lineage) and run the same recall@k. If μ beats e5-cos there, the filing loss is fully
-OOD + cold-start (your "with training data it wins" holds → filing fine-tune, then per-region/mixture μ like
-the routed per-cluster Procrustes). If μ still loses on home turf, that's a finding about the readout itself and
-reshapes the roadmap. Only *after* that: the filing fine-tune learning-curve (warm-start, folder-disjoint split,
-data fractions vs the flat e5-cos bar).
+### Home-turf result — the readout is healthy; filing loss was OOD (`--source simplewiki`)
+Ran the in-domain analog: simplewiki category→member ranking (folders = categories ≥10 members ≈ 295, to match
+filing's chance baseline; 500 queries; **lineage-free**, apples-to-apples with filing — only the *domain* changed).
+
+| | recall@1 | recall@5 | recall@10 | MRR | med.rank |
+|---|---|---|---|---|---|
+| e5-cos | 0.180 | 0.376 | 0.424 | 0.270 | 29 |
+| **mu-super** | 0.144 | 0.386 | **0.494** | 0.255 | **11** |
+| mu-elem | 0.156 | 0.328 | 0.436 | 0.247 | 16 |
+
+**The story flips vs OOD filing (where e5-cos *doubled* μ):** in-domain they are **tied** on MRR, and μ **beats**
+e5-cos on recall@10 (0.494 vs 0.424) and **median rank (11 vs 29)** — μ pushes the true container into the
+shortlist better; e5-cos holds a thin recall@1 edge (different operating point). **The physics-core hypothesis
+revives in the stratification:** NEAR-core (STEM) μ-super recall@10 **0.637 vs 0.393**, median **7 vs 30** — μ
+wins *decisively* where training was densest. It was invisible in filing only because *all* Pearltrees folders
+are OOD (no bin had training signal); on in-domain data where the core proxy is meaningful, μ's edge concentrates
+exactly in the trained region, as predicted. Two caveats: **lineage-free** (so μ ties/beats cosine *without* its
+ancestor context — the strong form); **memorisation-allowed** (trained on these edges) — but recall@1 0.144 ≪ the
+~1.0 of rote lookup, so this is *learned in-region generalisation*, not a table. **Verdict:** the readout works;
+the filing 2× loss is **OOD transfer**, not a broken model — so your "with training data it wins" is the right
+read. Clean follow-ups: a node-holdout in-domain run (kill the memorisation caveat); then the filing fine-tune
+learning-curve (warm-start, folder-disjoint split, data fractions vs the flat e5-cos 0.299 bar); the local-tangent
+**bivector feature** is the geometric enhancement on top.
 
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -107,10 +107,24 @@ not an architecture ceiling:** the checkpoint was trained on *simplewiki categor
 Pearltrees collections; and the gather runs with **no lineage** (empty DAG — the "absent lineage = off-manifold
 noise" regime). The learned transform, tuned for a different regime, *distorts* e5 for this task. Since the
 readout sits **on top of** frozen e5 and can represent near-identity, filing fine-tuning should recover *and*
-beat `e5-cos` via directionality — `e5-cos` MRR **0.299** is now the bar. **Next experiment:** fine-tune on a
-folder-disjoint *train* split of the filing pairs, re-run `eval_filing.py` on the held-out folders, and see if
-μ crosses the e5-cosine bar (the "with enough training data" test). This mirrors the bookmarking agent's own
-Procrustes engine — cheap e5-leverage wins at low data; the attention model needs in-domain data to pay off.
+beat `e5-cos` via directionality — `e5-cos` MRR **0.299** is now the bar.
+
+**Stratified by distance to the trained region** (`--core-anchors`, max folder-similarity to
+Physics/Math/Chem/CS/Eng — testing "μ only helps inside its region"): the e5-cos − mu-elem MRR gap is
+**flat at ~0.5× ratio across all three bins** (FAR 0.309/0.161, MID 0.327/0.185, NEAR-STEM 0.263/0.136). μ does
+**not** close the gap near the core — the loss is *uniform*, not region-specific. Two confounds keep this from
+refuting the region hypothesis: (1) weak stratifier (e5-small's high cosine floor — even "FAR" folders sit at
+0.74 to *Physics*); (2) **the lineage confound** — the model trained *with* ancestor lineage but runs here on
+**cold, lineage-free** bookmarks (empty DAG), a uniform handicap that could itself flatten the ratio. So "μ
+loses ~2× everywhere" conflates OOD-task + cold-start + (maybe) wrong-region; stratification rules out
+wrong-region-as-sole-cause but not the rest.
+
+**Decisive next test — μ vs e5-cos on home turf:** hold out *simplewiki* category→parent memberships
+(in-distribution, *with* lineage) and run the same recall@k. If μ beats e5-cos there, the filing loss is fully
+OOD + cold-start (your "with training data it wins" holds → filing fine-tune, then per-region/mixture μ like
+the routed per-cluster Procrustes). If μ still loses on home turf, that's a finding about the readout itself and
+reshapes the roadmap. Only *after* that: the filing fine-tune learning-curve (warm-start, folder-disjoint split,
+data fractions vs the flat e5-cos bar).
 
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -178,6 +178,18 @@ bookmark domain — the prediction confirmed. Caveats: single seed (multi-seed t
 short fine-tune (more steps/data only helps per the slope). **Next:** the local-tangent **bivector feature** /
 orthogonalised codebook is the geometric enhancement on top (and per-region mixture for the long OOD tail).
 
+#### Operating point — μ's edge is at recall@10 / median rank, which is exactly what an LLM re-ranker consumes
+Across **all three** results, μ's advantage over `e5-cos` concentrates at **recall@10 and median rank**, *not*
+recall@1 (where e5-cos is often comparable or slightly ahead): home-turf recall@10 **0.494 vs 0.424** /
+median **11 vs 29**; node-holdout **0.482 vs 0.414** / **12 vs 36**; fine-tuned filing **0.573 vs 0.440** /
+**7 vs 17** — yet recall@1 stays close (e.g. filing 0.235 vs ~0.20). **This is the ideal profile for a two-stage
+retrieve-then-rerank pipeline.** A first-stage retriever's job is to get the right answer *into the top-K
+shortlist* (high recall@K, low median rank); an **LLM re-ranker** then supplies precision@1 by reading the K
+candidates. μ excels at exactly the shortlist metric and recovers the early win *before* its recall@1 catches up
+— so "μ slightly behind at recall@1" is a **non-issue** for the real application: μ is the right **first-stage
+retriever** (return top-10, hand to the LLM), where median-rank-7 means the answer is almost always in the window
+the LLM sees. The early in-domain win lands precisely at the hit@(≥10) operating point that re-ranking uses.
+
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM
 core's effective-distance). Those are *structural only*: graph-near ≠ semantically-related. The new algorithm
@@ -254,8 +266,9 @@ already beats the naïve per-cluster `logm`/`expm` (O(n³)). What actually carri
 - **Canonical plane-angle decomposition** (`infer_pearltrees_federated.py:191-391`, `rotational-fast`) is the
   actual inference-time `logm`-beater: split `W` into d/2 axis-aligned 2×2 blocks, read each angle via `arctan2`,
   blend angles by scalar weighted-average, apply vectorized 2×2 rotations — O(K·d), no matrix functions.
-- **Learned codebook** (PCA/SVD over cluster generators → K principal bivectors; defaults **K=64**, **top-8**
-  blended per query — matching the "K≈8" estimate above) learns *which* blades.
+- **Codebook of K planes** (defaults **K=64**, **top-8** blended per query — matching the "K≈8" estimate above).
+  Two variants — **canonical axis-aligned** (fixed planes, *recommended*) vs **PCA-derived** principal bivectors;
+  the canonical one wins on Matryoshka embeddings (see "Free planes vs axis-aligned" below — a non-obvious result).
 - **Distillation pays the matrix functions once, at training, never at inference**: the exact `logm`/`expm`
   teacher is distilled into a cheap student (a transformer / a Givens layer)
   (`scripts/distill_federated_to_transformer.py`). So even the "high" cost is a *one-time training* cost — which
@@ -264,19 +277,23 @@ So our hybrid has a **proven recipe**: K commuting blades, applied via Rodrigues
 codebook, optionally distilled into the μ transformer so inference is a plain forward pass. The geodesic
 `x_root ∧ x_node` is the K=1 special case (`src/.../minimal_transform.py:_rotation_between_vectors`).
 
-**Free planes vs axis-aligned — fewer blades for the same error, but a commuting catch (and its resolution).**
-Data-adaptive 2-planes are *more expressive per blade* than fixed coordinate (Givens) planes — same logic as PCA
-vs a fixed-axis projection — so the blade count drops to roughly the **effective rank** of the structural
-rotation (its number of significant rotation planes), not however many coordinate planes are needed to *span*
-them. The catch: arbitrary planes generally **don't commute** (`exp(B₁+B₂) ≠ exp(B₁)exp(B₂)`), so the cheap
-Rodrigues *product* becomes an order-dependent BCH approximation, and *finding* the optimal planes costs an
-eigendecomposition (≈ O(n³)) per rotation. The codebook's resolution gets both: find the planes **data-adaptively**
-(PCA/SVD over generators → principal bivectors) **then orthogonalise them** (`train_orthogonal_codebook.py`) — so
-they are data-chosen (small K) *and* mutually orthogonal (commuting ⇒ exact Rodrigues product) *and* the
-plane-finding is amortised once into the codebook. That is why **top-8** suffices: 8 *optimally placed* planes,
-not 8 arbitrary coordinate planes. (The axis-aligned `rotational-fast` path is the cruder cousin that skips even
-this, leaning on Matryoshka structure to make coordinate axes ≈ principal directions.) **For our hybrid:** use a
-small *orthogonalised, data-chosen* codebook, not raw Givens — smallest K per unit error, commuting preserved.
+**Free planes vs axis-aligned — the theory says "fewer blades," but the repo found the *opposite* in practice
+(and the reason matters for us).** *Theory:* data-adaptive 2-planes are more expressive per blade than fixed
+coordinate (Givens) planes — PCA-vs-fixed-axis logic — so in principle the blade count drops to the rotation's
+**effective rank**, not the coordinate planes needed to *span* it. And there's a real catch: arbitrary planes
+**don't commute** (`exp(B₁+B₂) ≠ exp(B₁)exp(B₂)` ⇒ order-dependent BCH error in the Rodrigues product) and cost an
+eigendecomposition (≈ O(n³)) to find. *The obvious fix — PCA the planes then orthogonalise them — **backfires***:
+`docs/design/ORTHOGONAL_CODEBOOK_DESIGN.md` reports that forcing data-planes orthogonal **distorts** the original
+bivectors (information loss, broken clean commutativity), so the student must learn complex plane interactions.
+The **canonical axis-aligned** codebook *wins* instead (**0.9997** cosine vs the exact teacher) because its planes
+are orthogonal *by construction* — each weight is an **independent knob** (decomposable learning, changing `wᵢ`
+never needs compensating `wⱼ`). It can afford *fixed* coordinate planes because **Matryoshka** embeddings (Nomic)
+pack core meaning into dims 0-127, so the first ~64 axis planes already ≈ the principal directions — data-alignment
+*for free*, no PCA. **Caveat for our hybrid — `e5-small-v2` is *not* known to use Matryoshka representation
+learning**, so the canonical shortcut may not transfer: an **open question** (we may need PCA planes, more planes,
+or to first profile e5's per-dimension importance). Net: "small codebook + Rodrigues + distill" holds; *which*
+planes (canonical vs data-adaptive) is **embedding-structure-dependent and unsettled for e5** — verify before
+assuming axis-aligned. (The `rotational-fast` path leans hardest on Matryoshka; it is the least e5-portable.)
 
 **Rotations on the sphere → bivectors as the generator.** e5 embeddings are **unit-normed**, so they live on a
 sphere and the relationship root→node is a **geodesic rotation**: rotor `R = exp(−½ θ B)`, applied

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -139,13 +139,26 @@ shortlist better; e5-cos holds a thin recall@1 edge (different operating point).
 revives in the stratification:** NEAR-core (STEM) μ-super recall@10 **0.637 vs 0.393**, median **7 vs 30** — μ
 wins *decisively* where training was densest. It was invisible in filing only because *all* Pearltrees folders
 are OOD (no bin had training signal); on in-domain data where the core proxy is meaningful, μ's edge concentrates
-exactly in the trained region, as predicted. Two caveats: **lineage-free** (so μ ties/beats cosine *without* its
-ancestor context — the strong form); **memorisation-allowed** (trained on these edges) — but recall@1 0.144 ≪ the
-~1.0 of rote lookup, so this is *learned in-region generalisation*, not a table. **Verdict:** the readout works;
-the filing 2× loss is **OOD transfer**, not a broken model — so your "with training data it wins" is the right
-read. Clean follow-ups: a node-holdout in-domain run (kill the memorisation caveat); then the filing fine-tune
-learning-curve (warm-start, folder-disjoint split, data fractions vs the flat e5-cos 0.299 bar); the local-tangent
-**bivector feature** is the geometric enhancement on top.
+exactly in the trained region, as predicted. (Was lineage-free — so μ ties/beats cosine *without* its ancestor
+context, the strong form.) **Verdict:** the readout works; the filing 2× loss is **OOD transfer**, not a broken
+model — so your "with training data it wins" is the right read.
+
+#### Node-holdout — memorisation caveat KILLED (`--holdout-nodes`)
+The one caveat above (trained on these edges) is now removed *without a retrain*. 21% of graph nodes (1760) appear
+in **neither** the SYM pairs **nor** the graded context edges — a ready-made never-trained holdout. Restricting
+the home-turf queries to these (`--holdout-nodes`, 500 sampled; candidates unchanged) ranks nodes the checkpoint
+**never saw** — pure generalisation. Result is **near-identical to the memorised run**:
+
+| | mu-super MRR | mu-super recall@10 | mu-super med.rank | e5-cos recall@10 | e5-cos med.rank |
+|---|---|---|---|---|---|
+| home-turf (mem-allowed) | 0.255 | 0.494 | 11 | 0.424 | 29 |
+| **node-holdout (never-trained)** | **0.247** | **0.482** | **12** | **0.414** | **36** |
+
+Trained→held-out drop is **~3%**; the STEM-core win is **unchanged** (held-out core mu-super recall@10
+**0.637 vs 0.393**, median **7 vs 27** — the same numbers). μ ranks never-seen nodes almost exactly as well as
+seen ones ⇒ **the home-turf win is generalisation, not memorisation.** Baseline locked. **Next:** the filing
+fine-tune learning-curve (warm-start, folder-disjoint split, data fractions vs the flat e5-cos 0.299 bar); the
+local-tangent **bivector feature** is the geometric enhancement on top.
 
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -242,9 +242,23 @@ already beats the naïve per-cluster `logm`/`expm` (O(n³)). What actually carri
   teacher is distilled into a cheap student (a transformer / a Givens layer)
   (`scripts/distill_federated_to_transformer.py`). So even the "high" cost is a *one-time training* cost — which
   collapses the cost axis further toward the transformer once distilled.
-So our hybrid has a **proven recipe**: K commuting (axis-aligned) blades, applied via Rodrigues/Givens, selected
-by a small codebook, optionally distilled into the μ transformer so inference is a plain forward pass. The
-geodesic `x_root ∧ x_node` is the K=1 special case (`src/.../minimal_transform.py:_rotation_between_vectors`).
+So our hybrid has a **proven recipe**: K commuting blades, applied via Rodrigues/Givens, selected by a small
+codebook, optionally distilled into the μ transformer so inference is a plain forward pass. The geodesic
+`x_root ∧ x_node` is the K=1 special case (`src/.../minimal_transform.py:_rotation_between_vectors`).
+
+**Free planes vs axis-aligned — fewer blades for the same error, but a commuting catch (and its resolution).**
+Data-adaptive 2-planes are *more expressive per blade* than fixed coordinate (Givens) planes — same logic as PCA
+vs a fixed-axis projection — so the blade count drops to roughly the **effective rank** of the structural
+rotation (its number of significant rotation planes), not however many coordinate planes are needed to *span*
+them. The catch: arbitrary planes generally **don't commute** (`exp(B₁+B₂) ≠ exp(B₁)exp(B₂)`), so the cheap
+Rodrigues *product* becomes an order-dependent BCH approximation, and *finding* the optimal planes costs an
+eigendecomposition (≈ O(n³)) per rotation. The codebook's resolution gets both: find the planes **data-adaptively**
+(PCA/SVD over generators → principal bivectors) **then orthogonalise them** (`train_orthogonal_codebook.py`) — so
+they are data-chosen (small K) *and* mutually orthogonal (commuting ⇒ exact Rodrigues product) *and* the
+plane-finding is amortised once into the codebook. That is why **top-8** suffices: 8 *optimally placed* planes,
+not 8 arbitrary coordinate planes. (The axis-aligned `rotational-fast` path is the cruder cousin that skips even
+this, leaning on Matryoshka structure to make coordinate axes ≈ principal directions.) **For our hybrid:** use a
+small *orthogonalised, data-chosen* codebook, not raw Givens — smallest K per unit error, commuting preserved.
 
 **Rotations on the sphere → bivectors as the generator.** e5 embeddings are **unit-normed**, so they live on a
 sphere and the relationship root→node is a **geodesic rotation**: rotor `R = exp(−½ θ B)`, applied

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -165,18 +165,23 @@ rising **data fractions**, eval MRR/recall on a **fixed held-out bookmark set** 
 folders are a stable taxonomy, the held-out *bookmarks* are never trained — the model carries no per-folder
 params, so a shared folder is not leakage). 500 steps, bs 48, single seed.
 
-| frac | n_train | MRR | recall@1 | recall@10 | med.rank | vs e5-cos (0.291) |
-|---|---|---|---|---|---|---|
-| 0.10 | 492 | 0.263 | 0.177 | 0.417 | 17 | −0.028 |
-| 0.30 | 1478 | 0.313 | 0.210 | 0.535 | 9 | **+0.022 ✓** |
-| 1.00 | 4929 | 0.352 | 0.235 | 0.573 | 7 | **+0.061 ✓** |
+**Multi-seed locked** (3 training seeds, fixed eval split; ✓ = *mean − sd* clears the bar, i.e. survives seed noise):
 
-μ **crosses between 10% and 30%** (~500–1500 bookmarks) and keeps climbing — at 100% **MRR 0.352 vs 0.291**
-(+21%), **recall@10 0.573 vs 0.440**, **median rank 7 vs 17** — monotonic and **still rising** (no plateau ⇒ more
-data helps). The OOD 2× loss (zero-shot) inverts to a clear win once the trained region is *extended* to the
-bookmark domain — the prediction confirmed. Caveats: single seed (multi-seed to lock — cf. perf-skepticism); a
-short fine-tune (more steps/data only helps per the slope). **Next:** the local-tangent **bivector feature** /
-orthogonalised codebook is the geometric enhancement on top (and per-region mixture for the long OOD tail).
+| frac | n_train | MRR (mean±sd) | recall@10 (mean±sd) | med.rank | vs e5-cos (0.291) |
+|---|---|---|---|---|---|
+| 0.10 | 492 | 0.230 ± 0.025 | 0.406 ± 0.028 | 19 | −0.061 |
+| 0.30 | 1478 | 0.317 ± 0.006 | 0.537 ± 0.006 | 8 | **+0.025 ✓ CROSSED** |
+| 1.00 | 4929 | 0.358 ± 0.018 | 0.573 ± 0.008 | 6 | **+0.066 ✓ CROSSED** |
+
+μ **crosses between 10% and 30%** (~500–1500 bookmarks) and keeps climbing — at 100% **MRR 0.358 vs 0.291**
+(+23%), **recall@10 0.573 vs 0.440**, **median rank 6 vs 17** — monotonic and **still rising** (no plateau ⇒ more
+data helps). The cross is **robust to seed**: at 30%/100% even *mean − sd* (0.311, 0.340) clears the bar, with
+tiny std (0.006–0.018). The OOD 2× loss (zero-shot) inverts to a clear, replicated win once the trained region is
+*extended* to the bookmark domain — the prediction confirmed and locked. (10% is correctly *below* the bar; the
+earlier single-seed 0.263 there was a touch optimistic — the lock matters most at low data, where variance is
+highest, std 0.025.) Remaining headroom: a longer fine-tune / more data per the still-rising slope. **Next** (now
+*scaffolding*, per the bitter-lesson framing below): the local-tangent **bivector feature** only if a thin
+sub-domain needs sample-efficiency; otherwise the bet is simply more data + training.
 
 #### Operating point — μ's edge is at recall@10 / median rank, which is exactly what an LLM re-ranker consumes
 Across **all three** results, μ's advantage over `e5-cos` concentrates at **recall@10 and median rank**, *not*

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -84,9 +84,33 @@ The two corrections, both visible in Cooking: **vs DENSE**, structure removes hi
 movie leak); **vs WSP**, semantics demotes low-μ-near false positives (`Home`). **Bonus —
 dense∩greedy overlap is a free reliability self-diagnostic**: high (Physics/Music) ⇒ structure and semantics
 agree, trust the result; low (Cooking 4/25) ⇒ e5 is leaking across a domain boundary, trust the
-structure-constrained greedy over raw μ. No ground truth required. *Still proposed:* the formal hop-stratified
-recall@k / AUC vs a held-out-edge ground truth (Build-plan §1–2) — the number that turns this qualitative
-validation into a head-to-head.
+structure-constrained greedy over raw μ. No ground truth required.
+
+### Formal eval — bookmark-filing ground truth (`eval_filing.py`)
+The non-circular head-to-head (Build-plan §1–2), using **real Pearltrees filing decisions** as labels (a
+bookmark's actual `treeId` = which folder it belongs in — a human decision, not graph distance). 335 candidate
+folders (≥3 bookmarks), 500 sampled query bookmarks; rank folders by μ(bookmark|folder); recall@k / MRR. Three
+rankers: **e5-cos** (raw e5 cosine, no model), **mu-super** (equal-weight operator superposition), **mu-elem**
+(the `element_of` operator — the membership relation filing *is*).
+
+| ranker | recall@1 | recall@5 | recall@10 | MRR | med.rank |
+|---|---|---|---|---|---|
+| **e5-cos** | **0.202** | **0.410** | **0.480** | **0.299** | **14** |
+| mu-super | 0.088 | 0.198 | 0.248 | 0.151 | 52 |
+| mu-elem  | 0.096 | 0.208 | 0.256 | 0.160 | 48 |
+
+**Raw e5 cosine ~doubles the μ model on every metric** (random@335 ≈ MRR 0.019, so both beat chance — but the
+learned readout *underperforms its own frozen substrate* here). `mu-elem` edges out `mu-super` — the membership
+operator is the right one, and directionality helps a hair even untrained. **Why μ loses — it's zero-shot OOD,
+not an architecture ceiling:** the checkpoint was trained on *simplewiki category→category membership*
+(Physics→Energy), never on *bookmark→folder filing*; bookmarks are noisy web-article titles, folders are
+Pearltrees collections; and the gather runs with **no lineage** (empty DAG — the "absent lineage = off-manifold
+noise" regime). The learned transform, tuned for a different regime, *distorts* e5 for this task. Since the
+readout sits **on top of** frozen e5 and can represent near-identity, filing fine-tuning should recover *and*
+beat `e5-cos` via directionality — `e5-cos` MRR **0.299** is now the bar. **Next experiment:** fine-tune on a
+folder-disjoint *train* split of the filing pairs, re-run `eval_filing.py` on the held-out folders, and see if
+μ crosses the e5-cosine bar (the "with enough training data" test). This mirrors the bookmarking agent's own
+Procrustes engine — cheap e5-leverage wins at low data; the attention model needs in-domain data to pay off.
 
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -1,8 +1,9 @@
 # Applications of the μ model — and a geometric (bivector) theory note
 
-**Status: FUTURE-WORK / roadmap.** Most of this is *proposed*, not built: the retrieval algorithm, the
-hop-stratified eval, and the geometric (bivector / root-centred) theory are directions, not shipped code. It
-builds on a few **existing** pieces — `emit_dense` → `dense_mu_attn_*.tsv` (density maps), the bridge detectors
+**Status: mixed — roadmap + a built core.** The **retrieval algorithm itself is now built + verified**
+(`eval_retrieval`, three-way DENSE/WSP/GREEDY comparison — see "Built + verified" below). Still *proposed*: the
+**formal hop-stratified recall@k / AUC eval** against a held-out-edge ground truth, and the geometric (bivector /
+root-centred) theory. It builds on a few **existing** pieces — `emit_dense` → `dense_mu_attn_*.tsv` (density maps), the bridge detectors
 (`bridge_ensemble.py`, PR #3322), and the `DESIGN_bidirectional_walk.md` traversal — and on the **built +
 verified** transitive μ (`DESIGN_transitive_relations.md`) it relies on for distance-awareness. The "Build
 plan" at the end is the concrete next increment.
@@ -65,6 +66,28 @@ ranking*.
    close, graph-distant — what μ adds over shortest-path) and low-μ-near (graph-adjacent but weak — what μ
    *corrects*). The scatter is a visual proof of whether semantics-on-structure beats structure-alone.
 
+### Built + verified (`eval_retrieval` in `train_mu_attention.py`, `--eval-retrieval`)
+Stages 1–3 are implemented (`--eval-retrieval "Root1,Root2" --retrieval-k 25 [--retrieval-out scatter.tsv]`),
+reporting **three rankings side-by-side** — DENSE-μ (score all nodes), WSP (graph-hop, μ tiebreak; the
+structural baseline), GREEDY (μ-ranked among graph-reachable; the new algorithm) — plus per-hop mean μ and the
+top-k hop distribution. Verified on `model_nodetype.pt` over three roots spanning the generalisation gradient:
+- **Physics (in-distribution)** — all three rankings agree; dense∩greedy overlap **21/25**.
+- **Music (clean OOD, not trained)** — all three agree, **25/25** — frozen e5 generalises cleanly outside the
+  physics training region.
+- **Cooking (confusable OOD)** — the discriminating case. DENSE-μ is **polluted** by `Movies_directed`,
+  `Movie_studios`, `Basketball_movie` (hops 4–6, μ 0.4–0.6) because e5 conflates cooking-TV → film. GREEDY
+  **removes all of them** (they're not in the gather's graph region) and recovers the actual cooking
+  subcategories ranked by μ; dense∩greedy overlap collapses to **4/25**. It *also* beats WSP, which keeps
+  `Home(0.04,h1)`/`Nutrition(0.18,h2)` purely for graph-adjacency — greedy's μ-ranking demotes them.
+
+The two corrections, both visible in Cooking: **vs DENSE**, structure removes high-μ-far false positives (the
+movie leak); **vs WSP**, semantics demotes low-μ-near false positives (`Home`). **Bonus —
+dense∩greedy overlap is a free reliability self-diagnostic**: high (Physics/Music) ⇒ structure and semantics
+agree, trust the result; low (Cooking 4/25) ⇒ e5 is leaking across a domain boundary, trust the
+structure-constrained greedy over raw μ. No ground truth required. *Still proposed:* the formal hop-stratified
+recall@k / AUC vs a held-out-edge ground truth (Build-plan §1–2) — the number that turns this qualitative
+validation into a head-to-head.
+
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM
 core's effective-distance). Those are *structural only*: graph-near ≠ semantically-related. The new algorithm
@@ -117,8 +140,11 @@ and a possible re-derivation, not for retrieval.
   `⅓+⅓+⅓` default.
 
 **New things:**
-- **Graph RAG / retrieval algorithm** — greedy bidirectional gather + μ-superposition sort (above).
-- **Hop-stratified retrieval eval** + the μ-vs-hop top-k scatter.
+- **Graph RAG / retrieval algorithm** — greedy bidirectional gather + μ-superposition sort. **Built + verified**
+  (`eval_retrieval`); the discriminating Cooking case shows it fixes the dense-μ domain-leak. The μ-vs-hop
+  top-k scatter is built too.
+- **Hop-stratified retrieval eval** (formal recall@k / AUC vs held-out-edge ground truth) — *still proposed*;
+  the head-to-head number against the WSP baseline.
 - **Embedding bivectors / geometric (GA) re-derivation** — the theory note (research thread).
 
 ## Build plan (the retrieval core — first concrete increment, no LLM, runs against existing models)

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -277,23 +277,34 @@ So our hybrid has a **proven recipe**: K commuting blades, applied via Rodrigues
 codebook, optionally distilled into the μ transformer so inference is a plain forward pass. The geodesic
 `x_root ∧ x_node` is the K=1 special case (`src/.../minimal_transform.py:_rotation_between_vectors`).
 
-**Free planes vs axis-aligned — the theory says "fewer blades," but the repo found the *opposite* in practice
-(and the reason matters for us).** *Theory:* data-adaptive 2-planes are more expressive per blade than fixed
-coordinate (Givens) planes — PCA-vs-fixed-axis logic — so in principle the blade count drops to the rotation's
-**effective rank**, not the coordinate planes needed to *span* it. And there's a real catch: arbitrary planes
-**don't commute** (`exp(B₁+B₂) ≠ exp(B₁)exp(B₂)` ⇒ order-dependent BCH error in the Rodrigues product) and cost an
-eigendecomposition (≈ O(n³)) to find. *The obvious fix — PCA the planes then orthogonalise them — **backfires***:
-`docs/design/ORTHOGONAL_CODEBOOK_DESIGN.md` reports that forcing data-planes orthogonal **distorts** the original
-bivectors (information loss, broken clean commutativity), so the student must learn complex plane interactions.
-The **canonical axis-aligned** codebook *wins* instead (**0.9997** cosine vs the exact teacher) because its planes
-are orthogonal *by construction* — each weight is an **independent knob** (decomposable learning, changing `wᵢ`
-never needs compensating `wⱼ`). It can afford *fixed* coordinate planes because **Matryoshka** embeddings (Nomic)
-pack core meaning into dims 0-127, so the first ~64 axis planes already ≈ the principal directions — data-alignment
-*for free*, no PCA. **Caveat for our hybrid — `e5-small-v2` is *not* known to use Matryoshka representation
-learning**, so the canonical shortcut may not transfer: an **open question** (we may need PCA planes, more planes,
-or to first profile e5's per-dimension importance). Net: "small codebook + Rodrigues + distill" holds; *which*
-planes (canonical vs data-adaptive) is **embedding-structure-dependent and unsettled for e5** — verify before
-assuming axis-aligned. (The `rotational-fast` path leans hardest on Matryoshka; it is the least e5-portable.)
+**Free planes vs axis-aligned — fewer blades in theory; canonical won *for Nomic* because Matryoshka made the
+data-adaptive step unnecessary (NOT because PCA is a bad tool).** *Theory:* data-adaptive 2-planes are more
+expressive per blade than fixed coordinate (Givens) planes — PCA-vs-fixed-axis logic — so in principle the blade
+count drops to the rotation's **effective rank**, not the coordinate planes needed to *span* it. The real catch:
+arbitrary planes **don't commute** (`exp(B₁+B₂) ≠ exp(B₁)exp(B₂)` ⇒ order-dependent BCH error in the Rodrigues
+product) and cost an eigendecomposition (≈ O(n³)) to find. `docs/design/ORTHOGONAL_CODEBOOK_DESIGN.md` reports
+that PCA-then-orthogonalise **distorts** the data-planes (info loss, broken clean commutativity) and **lost** to
+the **canonical axis-aligned** codebook (**0.9997** cosine vs the exact teacher; orthogonal-by-construction ⇒ each
+weight an independent knob, decomposable learning). **But that verdict is conditional, not general:** canonical won
+*because* **Matryoshka** (Nomic) already packs core meaning into dims 0-127, so the first ~64 axis planes ≈ the
+principal directions — Matryoshka **negates the need** for data-adaptive planes. It does **not** rule PCA-
+orthogonalise out where that free alignment is absent. **For our `e5-small-v2` (not known to use Matryoshka
+representation learning), data-adaptive PCA planes may be the *right* tool, not a fallback** — profile e5's
+per-dimension importance first; *which* planes (canonical vs data-adaptive) is **embedding-structure-dependent and
+genuinely open for e5**. "Small codebook + Rodrigues + distil" holds either way.
+
+**When to bother with the bivector prior at all — the bitter lesson (this is mostly orthogonal to our path).**
+Two limits on how much the above matters *for us*. (1) **We use a transformer, not a standalone rotation
+codebook.** The canonical-vs-PCA-vs-Rodrigues machinery exists to make a *geometric rotation* cheap; our model
+*learns* the transform, so the bivector is at most an **added feature/prior**, not the estimator. (2) **The bitter
+lesson** (Sutton): hand-built structure tends to be overtaken by general methods that scale with data + compute.
+The bivector is a geometric **prior for asymmetry**; with enough data a transformer can learn that asymmetry
+itself — and our **filing learning curve is exactly this lesson in miniature** (the transformer crossed the
+e5-cos bar with modest data and was *still climbing*). So the prior's value is **sample-efficiency in the low-data
+regime** (the rotation-wins-at-low-data result), not a permanent component. Use it as **distillable scaffolding**:
+bootstrap with the prior where data is thin, distil into the transformer, then *drop the prior* as coverage grows
+(the repo's distillation path makes this literal). The danger to avoid is baking it in a way that **caps the
+ceiling**. **Bridge, not destination** — the long-term bet is data + the transformer's general learning.
 
 **Rotations on the sphere → bivectors as the generator.** e5 embeddings are **unit-normed**, so they live on a
 sphere and the relationship root→node is a **geodesic rotation**: rotor `R = exp(−½ θ B)`, applied

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -115,7 +115,11 @@ Physics/Math/Chem/CS/Eng — testing "μ only helps inside its region"): the e5-
 **not** close the gap near the core — the loss is *uniform*, not region-specific. Two confounds keep this from
 refuting the region hypothesis: (1) weak stratifier (e5-small's high cosine floor — even "FAR" folders sit at
 0.74 to *Physics*); (2) **the lineage confound** — the model trained *with* ancestor lineage but runs here on
-**cold, lineage-free** bookmarks (empty DAG), a uniform handicap that could itself flatten the ratio. So "μ
+**cold, lineage-free** bookmarks (empty DAG), a uniform handicap that could itself flatten the ratio. **NB —
+the transformer is nonlinear, so multi-region is *not* a capacity question.** A single μ model can represent
+many regions separated by boundary manifolds (the nonlinear analog of routed per-cluster Procrustes — the
+*linear* model needs discrete routing precisely because it can't); so the flat ~2× loss is cold-start + lineage,
+*not* a single-global-transform ceiling. The mixture is the linear workaround, not the fix here. So "μ
 loses ~2× everywhere" conflates OOD-task + cold-start + (maybe) wrong-region; stratification rules out
 wrong-region-as-sole-cause but not the rest.
 
@@ -150,16 +154,34 @@ Our operators split *exactly* along this seam:
 So μ's symmetric/directional operator structure *is* the scalar/bivector grade structure of a multivector — the
 asymmetry is geometric **by construction**, not bolted on.
 
-**Embedding bivectors (novel-ish):** rather than embed each node as a vector and patch the similarity, embed
-the **relationship** as a multivector — the directional content lives in the **bivector grade**. (GA / Clifford
-layers exist in recent ML, but tying the *fuzzy-membership operator split* to the scalar/bivector grades is
-uncommon.) This is a research thread, not a dependency of the applications.
+**Rotations on the sphere → bivectors as the generator.** e5 embeddings are **unit-normed**, so they live on a
+sphere and the relationship root→node is a **geodesic rotation**: rotor `R = exp(−½ θ B)`, applied
+`x_node = R x_root R̃`, where the **plane** `B = (x_root ∧ x_node)`-normalized and the **angle**
+`θ = arccos(x_root·x_node)`. The bivector encodes *both* — its plane is the rotation plane, its magnitude
+`|x_root ∧ x_node| = sin θ` is the angle. **Off the sphere = rotation + scalar dilation:** `x' = s·R x R̃`, a
+*scaled rotor* (similarity transform) splitting magnitude (`s`) from orientation (`R`). This is why
+the bookmarking agent's exact-Procrustes used **logm/expm** (the `so(n)` Lie algebra *is* the bivector space) —
+exact, but matrix-exp/log expensive. **Why bivector, not cross product:** in 3D they are Hodge-duals
+(`a∧b = I(a×b)`), but the cross product exists *only* in 3D/7D; for 384-dim e5 the bivector is the only correct
+generalisation of "oriented plane of rotation."
+
+**Embedding bivectors from the tangent space of each input (the concrete construction).** Rather than feed raw
+`x_node, x_root` and hope attention discovers directionality, feed the **local-tangent bivector**
+`B = x_root ∧ x_node` (or its compact rotor/log form) as an explicit feature. At a sphere point `x`, the tangent
+space `T_x` is everything ⟂ `x`; `B` lies in the root's tangent plane and *is* the geodesic direction toward the
+node. Two payoffs, both geometric-by-construction rather than learned: (1) **directionality is the sign of the
+bivector** (`x_r∧x_n = −x_n∧x_r` ⇒ `μ(a|b)≠μ(b|a)`); (2) because the tangent frame is **local**, `B` is
+**automatically region-adaptive** — the same construction yields different oriented relations in different parts
+of the sphere, the *continuous* analog of routed per-cluster transforms (the tangent space **is** the local
+chart, so no discrete clusters). The model then learns μ *on top of* the right primitive (`a∧b`, the
+antisymmetric part the scalar cosine throws away — exactly the part `e5-cos` ignores yet still beats a fumbling
+learned readout with). This is the model variant the GA note points at, now with a definite construction.
 
 **Root-centred embeddings / tangent chart (for visualisation):** fix the **root as origin**; node embeddings
-become root-relative, and the relationship to the root is the oriented `node ∧ root`. A **local chart** for the
-density explorer: 2D/3D coordinates where displacement ≈ μ-relatedness and the **axes are the principal
-statistical variations of the root's neighbourhood** (local PCA / a "tangent plane" at the root). Less common
-than global vector embeddings, and naturally per-root (each root its own chart). Also a viz/research thread.
+become root-relative, and the relationship to the root is the oriented `node ∧ root` (the same tangent bivector,
+used for *display* not features). A **local chart** for the density explorer: 2D/3D coordinates where
+displacement ≈ μ-relatedness and the **axes are the principal statistical variations of the root's
+neighbourhood** (local PCA / a "tangent plane" at the root). Naturally per-root (each root its own chart).
 
 **For ranking we need none of this** — μ *is* the distance measure; embeddings/bivectors are for visualisation
 and a possible re-derivation, not for retrieval.

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -198,17 +198,31 @@ the two curryings apart (the dot product cannot curry asymmetrically). Consisten
 as `⟨node,(>root)⟩` or `⟨(node>),root⟩` must agree — the associativity of the geometric product (one relation,
 two views).
 
-**Cost tradeoff — bivector = inference cost, transformer = training cost (the unifying axis).** The bivector
-carries a **strong geometric prior** (directionality is *given*), so it needs **little training data** but pays a
-**high inference cost** (rotor exp/log per pair). The transformer has a **weak prior** (must *learn* the
-direction from data), so it has a **high training/data cost** but **cheap inference** (one forward pass). This
-*is* the filing-vs-home-turf result: e5/Procrustes(+bivector) wins OOD where in-domain data is absent (strong
-prior pays); transformer μ wins in-domain where it had the data. With our **currently low training coverage**,
-the cost axis favours the strong-prior tool — which argues for a **hybrid**: make the operator embeddings the
-**bivector-mapped partial applications** (`> root` computed geometrically) and let the transformer read μ on top.
-Pay the rotor cost at inference, hand the transformer the directional primitive pre-built ⇒ far less data to
-reach in-domain-competitive. Strong prior *and* learned refinement, composed. (Open: the rotor cost is
-amortisable — a root's `> root` operator is computed once and reused across all candidate nodes.)
+**Bivector dimensionality — general is O(n²), but ours are *simple* (O(n)).** A **general** bivector is an
+antisymmetric `n×n` matrix = `dim so(n) = n(n−1)/2`; for `n=384` that is **73,536** (≈ `n/2 ≈ 192×` the embedding
+dim) — materialising it per node is absurd. **But the bivectors we use are *blades* (rank-2): `x_a ∧ x_b` lies in
+the 2-plane `span(x_a,x_b)`**, parameterised by the two vectors (**O(n)**, never the 73k object). Its rotor acts
+*only* in that plane — apply `R x R̃` by projecting `x` onto the plane (two dot products), rotating that 2D part
+by `θ`, leaving the complement untouched: **O(n), closed form, no matrix exp**. Between the extremes sits a
+**low-rank bivector = sum of `K` blades** (= product of `K` Givens rotations), **O(Kn)** params/apply, `K`
+rotation planes — the expressiveness dial:
+
+| representation | params | apply | expressiveness |
+|---|---|---|---|
+| simple blade (`K=1`) | O(n) | O(n) | geodesic / one 2-plane |
+| **low-rank (`K` blades)** | **O(Kn)** | **O(Kn)** | `K` planes — *tunable* (`K≈8` ⇒ ~3k params) |
+| general (`K=n/2`) | n(n−1)/2 ≈ 73,536 | O(n²) | full `SO(n)` (the Procrustes case) |
+
+**Cost tradeoff — the unifying axis (corrected: the cost is *general rotation*, not bivectors per se).** The
+expensive object is the **general** rotation — the bookmarking agent's Procrustes `W` ∈ `SO(n)`, whose generator
+is a *general* (73k-dim) bivector recovered via `logm`/`expm` (O(n³)). **Simple/low-rank tangent blades avoid
+that entirely** (O(Kn), forward-pass cost). So the real axis is **prior strength vs data**, not inference cost:
+the bivector carries a **strong geometric prior** (directionality *given*) ⇒ little training data; the
+transformer has a **weak prior** ⇒ high data cost but cheap inference. This *is* the filing-vs-home-turf result
+(strong prior wins OOD; transformer wins in-domain-with-data). With our **low coverage**, the prior is the better
+fit ⇒ a **hybrid**: operator embedding = the **low-rank bivector-mapped partial application** (`> root` built
+from `K` blades), transformer reads μ on top — strong prior *and* learned refinement, both at forward-pass cost.
+(The `> root` rotor is also amortised — computed once per root, reused across all candidates.)
 
 **Rotations on the sphere → bivectors as the generator.** e5 embeddings are **unit-normed**, so they live on a
 sphere and the relationship root→node is a **geodesic rotation**: rotor `R = exp(−½ θ B)`, applied

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -156,9 +156,27 @@ the home-turf queries to these (`--holdout-nodes`, 500 sampled; candidates uncha
 
 Trained→held-out drop is **~3%**; the STEM-core win is **unchanged** (held-out core mu-super recall@10
 **0.637 vs 0.393**, median **7 vs 27** — the same numbers). μ ranks never-seen nodes almost exactly as well as
-seen ones ⇒ **the home-turf win is generalisation, not memorisation.** Baseline locked. **Next:** the filing
-fine-tune learning-curve (warm-start, folder-disjoint split, data fractions vs the flat e5-cos 0.299 bar); the
-local-tangent **bivector feature** is the geometric enhancement on top.
+seen ones ⇒ **the home-turf win is generalisation, not memorisation.** Baseline locked.
+
+### Filing fine-tune learning curve — μ CROSSES the e5-cos bar (`train_filing.py`)
+The quantified "with enough in-domain data the attention model wins." Warm-start `model_nodetype`, fine-tune on
+`element_of(bookmark→folder)` with **in-batch contrastive** negatives (B×B μ matrix; same-folder = positive), at
+rising **data fractions**, eval MRR/recall on a **fixed held-out bookmark set** (split is **bookmark-holdout**:
+folders are a stable taxonomy, the held-out *bookmarks* are never trained — the model carries no per-folder
+params, so a shared folder is not leakage). 500 steps, bs 48, single seed.
+
+| frac | n_train | MRR | recall@1 | recall@10 | med.rank | vs e5-cos (0.291) |
+|---|---|---|---|---|---|---|
+| 0.10 | 492 | 0.263 | 0.177 | 0.417 | 17 | −0.028 |
+| 0.30 | 1478 | 0.313 | 0.210 | 0.535 | 9 | **+0.022 ✓** |
+| 1.00 | 4929 | 0.352 | 0.235 | 0.573 | 7 | **+0.061 ✓** |
+
+μ **crosses between 10% and 30%** (~500–1500 bookmarks) and keeps climbing — at 100% **MRR 0.352 vs 0.291**
+(+21%), **recall@10 0.573 vs 0.440**, **median rank 7 vs 17** — monotonic and **still rising** (no plateau ⇒ more
+data helps). The OOD 2× loss (zero-shot) inverts to a clear win once the trained region is *extended* to the
+bookmark domain — the prediction confirmed. Caveats: single seed (multi-seed to lock — cf. perf-skepticism); a
+short fine-tune (more steps/data only helps per the slope). **Next:** the local-tangent **bivector feature** /
+orthogonalised codebook is the geometric enhancement on top (and per-region mixture for the long OOD tail).
 
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""eval_filing.py — bookmark-filing retrieval eval on REAL Pearltrees filing decisions.
+
+The formal, NON-CIRCULAR retrieval eval the applications roadmap asked for (DESIGN_model_applications.md
+build-plan §1-2). Ground truth = where each bookmark is *actually filed* (its `treeId`) — a real human
+decision, not graph distance. Task: rank candidate folders by μ(bookmark|folder) and measure recall@k / MRR.
+
+Three rankers, head-to-head — isolating what the model adds over plain similarity:
+  * mu-super  — μ under the equal-weight operator superposition (unconditional relatedness; the eval_retrieval default).
+  * mu-elem   — μ under the ELEM (element_of) operator alone — the membership relation filing actually is.
+  * e5-cos    — raw e5 cosine(query: bookmark, passage: folder) — the symmetric, no-model baseline.
+
+The connection to the bookmarking agent (scripts/infer_pearltrees_federated.py): that agent solves the SAME
+rank-folders-by-relatedness task with a Procrustes-projection + cosine engine. This eval is the apparatus to
+later drop that engine in as a 4th ranker. Filing data lives in .local (gitignored harvest); this script is
+committable, the data is not.
+
+Usage:
+  python3 eval_filing.py --ckpt model_nodetype.pt --trees ../../.local/data/pearltrees_api/trees \
+      --min-bm 3 --max-queries 500 [--seed 7]
+"""
+import argparse, glob, json, os, random, collections
+import torch
+from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS
+
+
+def load_filing(trees_dir, min_bm):
+    """Parse harvested tree JSONs → (queries, folders). A folder = a tree; its bookmarks (contentType 1)
+    are filed in it. Candidate folders = those with >= min_bm bookmarks; queries = the bookmarks therein."""
+    folders = {}                                  # tid -> title
+    by_folder = collections.defaultdict(list)     # tid -> [bookmark_title, ...]
+    for f in glob.glob(os.path.join(trees_dir, "*.json")):
+        try:
+            d = json.load(open(f, encoding="utf-8"))
+        except Exception:
+            continue
+        t = d.get("api_response", {}).get("tree", {}) if isinstance(d, dict) else {}
+        if not isinstance(t, dict):
+            continue
+        tid, ttitle = t.get("id"), t.get("title")
+        if tid is None or not ttitle:
+            continue
+        folders[tid] = ttitle
+        for p in t.get("pearls", []) if isinstance(t.get("pearls"), list) else []:
+            if isinstance(p, dict) and p.get("contentType") == 1 and p.get("title"):
+                by_folder[tid].append(p["title"])
+    cand = {tid: folders[tid] for tid, bms in by_folder.items() if len(bms) >= min_bm and tid in folders}
+    queries = [(bt, tid) for tid in cand for bt in by_folder[tid]]   # (bookmark_title, true_folder_tid)
+    return queries, cand
+
+
+@torch.no_grad()
+def score_mu(model, tok, idx, q_keys, f_keys, op_weights_row, dev, batch=512):
+    """μ(bookmark|folder) for every (query, folder) pair → [Q, F] score matrix, for a fixed op_weights row."""
+    n_ops = model.op_emb.weight.shape[0]
+    items = [(qk, fk, 0) for qk in q_keys for fk in f_keys]        # (node=bookmark, root=folder, op placeholder)
+    out = []
+    for i in range(0, len(items), batch):
+        chunk = items[i:i + batch]
+        b = tok.build(chunk, train=False)
+        b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+        ow = op_weights_row.expand(len(chunk), n_ops).to(dev)
+        out += model(**b, op_weights=ow).cpu().tolist()
+    F = len(f_keys)
+    return [out[r * F:(r + 1) * F] for r in range(len(q_keys))]    # row-major → [Q][F]
+
+
+def metrics(ranks):
+    """ranks: list of the true folder's 1-based rank per query. → recall@k, MRR, median rank."""
+    n = len(ranks)
+    r = {f"recall@{k}": sum(x <= k for x in ranks) / n for k in (1, 5, 10)}
+    r["MRR"] = sum(1.0 / x for x in ranks) / n
+    r["median_rank"] = sorted(ranks)[n // 2]
+    return r
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--trees", required=True, help="dir of harvested per-tree JSONs (.local)")
+    ap.add_argument("--min-bm", type=int, default=3, help="min bookmarks for a folder to be a candidate")
+    ap.add_argument("--max-queries", type=int, default=500)
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--device", default="cpu")
+    ap.add_argument("--cache", default="/tmp/filing_e5.pt", help="e5 table cache (regenerable)")
+    a = ap.parse_args()
+
+    queries, cand = load_filing(a.trees, a.min_bm)
+    print(f"[DATA] {len(cand)} candidate folders (>= {a.min_bm} bookmarks), {len(queries)} eligible bookmarks")
+    rng = random.Random(a.seed)
+    if len(queries) > a.max_queries:
+        queries = rng.sample(queries, a.max_queries)
+    print(f"[DATA] evaluating {len(queries)} sampled queries against {len(cand)} folders "
+          f"(random@{len(cand)} ≈ recall@10 {10/len(cand):.3f}, MRR {sum(1/r for r in range(1,len(cand)+1))/len(cand):.3f})")
+
+    # vocab: folders F:<tid>, query bookmarks B:<i> — unique keys, real titles via `texts`
+    f_keys = [f"F:{tid}" for tid in cand]
+    ftext = {f"F:{tid}": cand[tid] for tid in cand}
+    q_keys = [f"B:{i}" for i in range(len(queries))]
+    qtext = {f"B:{i}": queries[i][0] for i in range(len(queries))}
+    names = f_keys + q_keys
+    texts = {**ftext, **qtext}
+    qtbl, ptbl, idx = build_e5_tables(names, cache_path=a.cache, texts=texts, device=a.device)
+
+    dev = torch.device(a.device)
+    tok = Tokenizer(qtbl, ptbl, idx, parents={}, deg={})          # no DAG: bookmarks/folders have no lineage
+    ck = torch.load(a.ckpt, weights_only=False)
+    sd = ck["state"]
+    cfg = ck.get("cfg", {"d_model": qtbl.shape[1], "heads": 4, "layers": 3})
+    # provenance-axis sizes vary by checkpoint vintage — infer from the state dict; account_emb (if absent) is
+    # a zero-init no-op for our 3-tuple (provenance-masked) items, so load non-strict.
+    sz = lambda k, d: sd[k].shape[0] if k in sd else d
+    model = MuAttention(d_model=cfg["d_model"], n_heads=cfg["heads"], n_layers=cfg["layers"],
+                        n_ops=sz("op_emb.weight", len(OPS)), n_corpus=sz("corpus_emb.weight", 2),
+                        n_judge=sz("judge_emb.weight", 2), n_nodetype=sz("nodetype_emb.weight", 4)).to(dev)
+    missing, unexpected = model.load_state_dict(sd, strict=False)
+    assert not unexpected, f"unexpected keys: {unexpected}"
+    assert all("account" in k for k in missing), f"unexpected missing keys: {missing}"
+    model.eval()
+    print(f"[MODEL] {os.path.basename(a.ckpt)}  {cfg}  (n_ops={model.op_emb.weight.shape[0]})")
+
+    true_tids = [t for _, t in queries]
+    f_order = list(cand)                                          # tid order aligned with f_keys
+    truepos = [f_order.index(t) for t in true_tids]
+
+    n_ops = model.op_emb.weight.shape[0]
+    rankers = {
+        "mu-super": torch.full((1, n_ops), 1.0 / n_ops),
+        "mu-elem":  torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["ELEM"]]), 1.0),
+    }
+    results = {}
+    for name, ow in rankers.items():
+        S = score_mu(model, tok, idx, q_keys, f_keys, ow, dev)
+        ranks = []
+        for r, row in enumerate(S):
+            tp = truepos[r]
+            ranks.append(1 + sum(1 for j, s in enumerate(row) if s > row[tp] or (s == row[tp] and j < tp)))
+        results[name] = metrics(ranks)
+
+    # raw e5 cosine baseline: cos(query: bookmark, passage: folder) — symmetric, no model
+    qn = qtbl[[idx[k] for k in q_keys]]                           # bookmark query-embeddings
+    fn = ptbl[[idx[k] for k in f_keys]]                           # folder passage-embeddings
+    C = qn @ fn.T                                                 # [Q, F] cosine (tables are unit-normed)
+    ranks = []
+    for r in range(C.shape[0]):
+        tp = truepos[r]; row = C[r]
+        ranks.append(1 + int((row > row[tp]).sum().item()))
+    results["e5-cos"] = metrics(ranks)
+
+    print(f"\n{'ranker':10} {'recall@1':>9} {'recall@5':>9} {'recall@10':>10} {'MRR':>7} {'med.rank':>9}")
+    for name in ("e5-cos", "mu-super", "mu-elem"):
+        m = results[name]
+        print(f"{name:10} {m['recall@1']:9.3f} {m['recall@5']:9.3f} {m['recall@10']:10.3f} "
+              f"{m['MRR']:7.3f} {m['median_rank']:9d}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -21,7 +21,19 @@ Usage:
 """
 import argparse, glob, json, os, random, collections
 import torch
-from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS
+from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS, load_dag, GRAPH
+
+
+def load_membership(graph_path, min_bm):
+    """IN-DOMAIN home-turf analog of filing: the simplewiki category DAG. A 'folder' = a category; its
+    'bookmarks' = its child nodes. Same (member → container) shape as filing, but in the model's TRAINED
+    region. Returns (queries=[(child_title, parent_id)], cand={parent_id: parent_title}). NB the checkpoint
+    trained on these edges — this is a best-case (memorisation-allowed) probe; a clean holdout is a follow-up."""
+    parents, children, deg = load_dag(graph_path)
+    disp = lambda s: s.replace("_", " ")
+    cand = {par: disp(par) for par, kids in children.items() if len(kids) >= min_bm}
+    queries = [(disp(c), par) for par in cand for c in children[par]]
+    return queries, cand
 
 
 def load_filing(trees_dir, min_bm):
@@ -77,7 +89,11 @@ def metrics(ranks):
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--ckpt", required=True)
-    ap.add_argument("--trees", required=True, help="dir of harvested per-tree JSONs (.local)")
+    ap.add_argument("--source", choices=("pearltrees", "simplewiki"), default="pearltrees",
+                    help="pearltrees = OOD bookmark filing (.local); simplewiki = IN-DOMAIN home-turf "
+                         "category membership (isolates OOD by changing only the domain, lineage held off)")
+    ap.add_argument("--trees", default=None, help="dir of harvested per-tree JSONs (.local; pearltrees source)")
+    ap.add_argument("--graph", default=GRAPH, help="category_parent.tsv (simplewiki source)")
     ap.add_argument("--min-bm", type=int, default=3, help="min bookmarks for a folder to be a candidate")
     ap.add_argument("--max-queries", type=int, default=500)
     ap.add_argument("--seed", type=int, default=7)
@@ -88,8 +104,13 @@ def main():
                          "true-folder's max e5-similarity to these (tests 'μ only helps inside its region')")
     a = ap.parse_args()
 
-    queries, cand = load_filing(a.trees, a.min_bm)
-    print(f"[DATA] {len(cand)} candidate folders (>= {a.min_bm} bookmarks), {len(queries)} eligible bookmarks")
+    if a.source == "simplewiki":
+        queries, cand = load_membership(a.graph, a.min_bm)
+    else:
+        assert a.trees, "--trees required for --source pearltrees"
+        queries, cand = load_filing(a.trees, a.min_bm)
+    print(f"[DATA] source={a.source}: {len(cand)} candidate folders (>= {a.min_bm} members), "
+          f"{len(queries)} eligible members")
     rng = random.Random(a.seed)
     if len(queries) > a.max_queries:
         queries = rng.sample(queries, a.max_queries)

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -24,15 +24,19 @@ import torch
 from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS, load_dag, GRAPH
 
 
-def load_membership(graph_path, min_bm):
+def load_membership(graph_path, min_bm, holdout=None):
     """IN-DOMAIN home-turf analog of filing: the simplewiki category DAG. A 'folder' = a category; its
     'bookmarks' = its child nodes. Same (member → container) shape as filing, but in the model's TRAINED
-    region. Returns (queries=[(child_title, parent_id)], cand={parent_id: parent_title}). NB the checkpoint
-    trained on these edges — this is a best-case (memorisation-allowed) probe; a clean holdout is a follow-up."""
+    region. Returns (queries=[(child_title, parent_id)], cand={parent_id: parent_title}).
+
+    `holdout` (optional set of RAW node names): restrict QUERIES to members in this set — for the node-holdout
+    eval (members the checkpoint NEVER trained on; candidates stay the full folder set). Kills the memorisation
+    caveat: ranking never-seen nodes vs e5-cos is pure generalisation."""
     parents, children, deg = load_dag(graph_path)
     disp = lambda s: s.replace("_", " ")
     cand = {par: disp(par) for par, kids in children.items() if len(kids) >= min_bm}
-    queries = [(disp(c), par) for par in cand for c in children[par]]
+    queries = [(disp(c), par) for par in cand for c in children[par]
+               if holdout is None or c in holdout]
     return queries, cand
 
 
@@ -94,6 +98,8 @@ def main():
                          "category membership (isolates OOD by changing only the domain, lineage held off)")
     ap.add_argument("--trees", default=None, help="dir of harvested per-tree JSONs (.local; pearltrees source)")
     ap.add_argument("--graph", default=GRAPH, help="category_parent.tsv (simplewiki source)")
+    ap.add_argument("--holdout-nodes", default=None, help="JSON list of RAW node names never seen in training; "
+                    "restricts simplewiki queries to these (node-holdout: pure generalisation, no retrain)")
     ap.add_argument("--min-bm", type=int, default=3, help="min bookmarks for a folder to be a candidate")
     ap.add_argument("--max-queries", type=int, default=500)
     ap.add_argument("--seed", type=int, default=7)
@@ -105,7 +111,10 @@ def main():
     a = ap.parse_args()
 
     if a.source == "simplewiki":
-        queries, cand = load_membership(a.graph, a.min_bm)
+        held = set(json.load(open(a.holdout_nodes))) if a.holdout_nodes else None
+        if held is not None:
+            print(f"[HOLDOUT] restricting queries to {len(held)} never-trained nodes")
+        queries, cand = load_membership(a.graph, a.min_bm, holdout=held)
     else:
         assert a.trees, "--trees required for --source pearltrees"
         queries, cand = load_filing(a.trees, a.min_bm)

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -83,6 +83,9 @@ def main():
     ap.add_argument("--seed", type=int, default=7)
     ap.add_argument("--device", default="cpu")
     ap.add_argument("--cache", default="/tmp/filing_e5.pt", help="e5 table cache (regenerable)")
+    ap.add_argument("--core-anchors", default="Physics,Mathematics,Chemistry,Computer science,Engineering",
+                    help="comma-sep terms naming the model's TRAINED region; queries are stratified by their "
+                         "true-folder's max e5-similarity to these (tests 'μ only helps inside its region')")
     a = ap.parse_args()
 
     queries, cand = load_filing(a.trees, a.min_bm)
@@ -98,8 +101,11 @@ def main():
     ftext = {f"F:{tid}": cand[tid] for tid in cand}
     q_keys = [f"B:{i}" for i in range(len(queries))]
     qtext = {f"B:{i}": queries[i][0] for i in range(len(queries))}
-    names = f_keys + q_keys
-    texts = {**ftext, **qtext}
+    anchors = [s.strip() for s in a.core_anchors.split(",") if s.strip()]
+    a_keys = [f"A:{i}" for i in range(len(anchors))]
+    atext = {f"A:{i}": anchors[i] for i in range(len(anchors))}
+    names = f_keys + q_keys + a_keys
+    texts = {**ftext, **qtext, **atext}
     qtbl, ptbl, idx = build_e5_tables(names, cache_path=a.cache, texts=texts, device=a.device)
 
     dev = torch.device(a.device)
@@ -128,30 +134,46 @@ def main():
         "mu-super": torch.full((1, n_ops), 1.0 / n_ops),
         "mu-elem":  torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["ELEM"]]), 1.0),
     }
-    results = {}
+    rank_of = {}                                                  # ranker -> per-query 1-based true-folder rank
     for name, ow in rankers.items():
         S = score_mu(model, tok, idx, q_keys, f_keys, ow, dev)
-        ranks = []
-        for r, row in enumerate(S):
-            tp = truepos[r]
-            ranks.append(1 + sum(1 for j, s in enumerate(row) if s > row[tp] or (s == row[tp] and j < tp)))
-        results[name] = metrics(ranks)
+        rank_of[name] = [1 + sum(1 for j, s in enumerate(row) if s > row[truepos[r]]
+                                 or (s == row[truepos[r]] and j < truepos[r])) for r, row in enumerate(S)]
 
     # raw e5 cosine baseline: cos(query: bookmark, passage: folder) — symmetric, no model
     qn = qtbl[[idx[k] for k in q_keys]]                           # bookmark query-embeddings
     fn = ptbl[[idx[k] for k in f_keys]]                           # folder passage-embeddings
     C = qn @ fn.T                                                 # [Q, F] cosine (tables are unit-normed)
-    ranks = []
-    for r in range(C.shape[0]):
-        tp = truepos[r]; row = C[r]
-        ranks.append(1 + int((row > row[tp]).sum().item()))
-    results["e5-cos"] = metrics(ranks)
+    rank_of["e5-cos"] = [1 + int((C[r] > C[r][truepos[r]]).sum().item()) for r in range(C.shape[0])]
 
-    print(f"\n{'ranker':10} {'recall@1':>9} {'recall@5':>9} {'recall@10':>10} {'MRR':>7} {'med.rank':>9}")
-    for name in ("e5-cos", "mu-super", "mu-elem"):
-        m = results[name]
-        print(f"{name:10} {m['recall@1']:9.3f} {m['recall@5']:9.3f} {m['recall@10']:10.3f} "
-              f"{m['MRR']:7.3f} {m['median_rank']:9d}")
+    order = ("e5-cos", "mu-super", "mu-elem")
+
+    def table(title, qsel):
+        print(f"\n{title}  (n={len(qsel)})")
+        print(f"  {'ranker':10} {'recall@1':>9} {'recall@5':>9} {'recall@10':>10} {'MRR':>7} {'med.rank':>9}")
+        for name in order:
+            m = metrics([rank_of[name][i] for i in qsel])
+            print(f"  {name:10} {m['recall@1']:9.3f} {m['recall@5']:9.3f} {m['recall@10']:10.3f} "
+                  f"{m['MRR']:7.3f} {m['median_rank']:9d}")
+
+    table("[OVERALL]", list(range(len(queries))))
+
+    # ---- stratify by distance to the model's TRAINED region (the user's "outside the physics core" test) ----
+    an = ptbl[[idx[k] for k in a_keys]]                           # anchor passage-embeddings [A, d]
+    core_sim = (fn @ an.T).max(dim=1).values                      # per-folder max cosine to any core anchor
+    qcore = [core_sim[f_order.index(t)].item() for t in true_tids]    # per-query: its true folder's core-sim
+    order_by_core = sorted(range(len(queries)), key=lambda i: qcore[i])
+    third = len(queries) // 3
+    bins = [("FAR from core", order_by_core[:third]),
+            ("MID", order_by_core[third:2 * third]),
+            ("NEAR core (STEM)", order_by_core[2 * third:])]
+    print(f"\n[STRATIFIED by true-folder e5-similarity to core anchors: {anchors}]")
+    for label, qsel in bins:
+        lo, hi = qcore[qsel[0]], qcore[qsel[-1]]
+        table(f"  {label}  [core-sim {lo:.2f}..{hi:.2f}]", qsel)
+    print("\n  → if μ closes the gap to e5-cos NEAR the core but loses FAR, the model helps only in its trained "
+          "region\n    (a single global transform); the fix is per-region/mixture μ — cf. the bookmarking agent's "
+          "routed per-cluster Procrustes.")
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/train_filing.py
+++ b/prototypes/mu_cosine/train_filing.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""train_filing.py — filing fine-tune LEARNING CURVE (DESIGN_model_applications.md, build-plan).
+
+Tests the prediction "with enough in-domain data, the attention μ crosses the e5-cosine filing bar."
+Warm-start `model_nodetype.pt`, fine-tune on `element_of(bookmark→folder)` with **in-batch contrastive**
+negatives (a B×B μ matrix; same-folder = positive, else negative), at increasing **data fractions**, and eval
+MRR/recall@k on a **FIXED held-out bookmark set** (never trained, same across fractions) against the flat
+`e5-cos` baseline. The curve is μ-MRR vs fraction; the question is where (if) it crosses e5-cos.
+
+Split is **bookmark-holdout** (folders shared): folders are a stable taxonomy, new bookmarks get filed — so we
+hold out *bookmarks*, not folders. The model carries no per-folder parameters (a folder is only its e5 title),
+so a shared folder is not leakage — the gain is the readout adapting to the filing distribution.
+
+Data lives in .local (gitignored); this script is committable, the data is not.
+
+Usage:
+  python3 train_filing.py --ckpt model_nodetype.pt --trees ../../.local/data/pearltrees_api/trees \
+      --fracs 0.1,0.3,1.0 --steps 300 --bs 48
+"""
+import argparse, collections, os, random
+import torch
+import torch.nn.functional as F
+from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS
+from eval_filing import load_filing, score_mu, metrics
+
+
+def build_model(ckpt, dev):
+    ck = torch.load(ckpt, weights_only=False)
+    sd, cfg = ck["state"], ck.get("cfg", {"d_model": 384, "heads": 4, "layers": 3})
+    sz = lambda k, d: sd[k].shape[0] if k in sd else d
+    m = MuAttention(d_model=cfg["d_model"], n_heads=cfg["heads"], n_layers=cfg["layers"],
+                    n_ops=sz("op_emb.weight", len(OPS)), n_corpus=sz("corpus_emb.weight", 2),
+                    n_judge=sz("judge_emb.weight", 2), n_nodetype=sz("nodetype_emb.weight", 4)).to(dev)
+    miss, unexp = m.load_state_dict(sd, strict=False)
+    assert not unexp and all("account" in k for k in miss), (miss, unexp)
+    return m, cfg
+
+
+def train_one(ckpt, tok, idx, bm_key, bm_folder, train_idx, f_order, eval_keys, eval_truepos,
+              f_keys, steps, bs, lr, dev, seed):
+    """Warm-start a fresh model, fine-tune on `train_idx` bookmarks, return MRR on the fixed eval set."""
+    model, _ = build_model(ckpt, dev)
+    n_ops = model.op_emb.weight.shape[0]
+    elem = torch.zeros(1, n_ops, device=dev).index_fill_(1, torch.tensor([OPS["ELEM"]], device=dev), 1.0)
+    opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1e-4)
+    rng = random.Random(seed)
+    model.train()
+    for step in range(steps):
+        batch = rng.sample(train_idx, min(bs, len(train_idx)))
+        bk = [bm_key[i] for i in batch]
+        fid = [bm_folder[i] for i in batch]
+        # B×B grid: μ(bookmark_i | folder_of_j); same-folder = positive (supervised in-batch contrastive)
+        fkeys_b = [f"F:{f}" for f in fid]
+        items = [(bk[i], fkeys_b[j], 0) for i in range(len(batch)) for j in range(len(batch))]
+        b = tok.build(items, train=False)
+        b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+        ow = elem.expand(len(items), n_ops)
+        mu = model(**b, op_weights=ow).view(len(batch), len(batch))
+        fi = torch.tensor([hash(f) for f in fid], device=dev)
+        target = (fi[:, None] == fi[None, :]).float()
+        bce = F.binary_cross_entropy(mu.clamp(1e-6, 1 - 1e-6), target, reduction="none")
+        pos, neg = target > 0.5, target <= 0.5                       # balance pos/neg (negatives dominate B×B)
+        loss = bce[pos].mean() + bce[neg].mean()
+        opt.zero_grad(); loss.backward(); opt.step()
+    # eval on the fixed held-out set
+    S = score_mu(model, tok, idx, eval_keys, f_keys, elem.cpu(), dev)
+    ranks = [1 + sum(1 for j, s in enumerate(row) if s > row[eval_truepos[r]]
+                     or (s == row[eval_truepos[r]] and j < eval_truepos[r])) for r, row in enumerate(S)]
+    return metrics(ranks)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--trees", required=True)
+    ap.add_argument("--min-bm", type=int, default=3)
+    ap.add_argument("--fracs", default="0.1,0.3,1.0", help="comma-sep training-data fractions")
+    ap.add_argument("--eval-frac", type=float, default=0.3, help="fraction of bookmarks per folder held out for eval")
+    ap.add_argument("--max-eval", type=int, default=400)
+    ap.add_argument("--steps", type=int, default=300)
+    ap.add_argument("--bs", type=int, default=48)
+    ap.add_argument("--lr", type=float, default=3e-4)
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    ap.add_argument("--cache", default="/tmp/trainfiling_e5.pt")
+    a = ap.parse_args()
+    dev = torch.device(a.device)
+
+    queries, cand = load_filing(a.trees, a.min_bm)
+    rng = random.Random(a.seed)
+    byf = collections.defaultdict(list)
+    for q in queries:
+        byf[q[1]].append(q)
+    eval_q, pool = [], []
+    for fid, qs in byf.items():                                      # per-folder split: eval holdout vs train pool
+        qs = qs[:]; rng.shuffle(qs)
+        k = max(1, int(a.eval_frac * len(qs))) if len(qs) >= 2 else 0
+        eval_q += qs[:k]; pool += qs[k:]
+    rng.shuffle(eval_q); eval_q = eval_q[:a.max_eval]
+    print(f"[DATA] {len(cand)} folders, {len(queries)} bookmarks → {len(pool)} train-pool, "
+          f"{len(eval_q)} fixed eval (held-out)")
+
+    # e5 over folders + ALL bookmarks (eval first so eval keys are stable B:0..)
+    bm_list = eval_q + pool
+    f_keys = [f"F:{t}" for t in cand]
+    bm_key = [f"B:{i}" for i in range(len(bm_list))]
+    bm_folder = [bm_list[i][1] for i in range(len(bm_list))]
+    names = f_keys + bm_key
+    texts = {**{f"F:{t}": cand[t] for t in cand}, **{bm_key[i]: bm_list[i][0] for i in range(len(bm_list))}}
+    qtbl, ptbl, idx = build_e5_tables(names, cache_path=a.cache, texts=texts, device=a.device)
+    tok = Tokenizer(qtbl, ptbl, idx, parents={}, deg={})
+
+    f_order = list(cand)
+    eval_keys = [f"B:{i}" for i in range(len(eval_q))]
+    eval_truepos = [f_order.index(eval_q[i][1]) for i in range(len(eval_q))]
+    train_idx = list(range(len(eval_q), len(bm_list)))
+
+    # e5-cos baseline on the fixed eval set (the flat bar)
+    qn = qtbl[[idx[k] for k in eval_keys]]; fn = ptbl[[idx[k] for k in f_keys]]
+    C = qn @ fn.T
+    base_ranks = [1 + int((C[r] > C[r][eval_truepos[r]]).sum().item()) for r in range(C.shape[0])]
+    base = metrics(base_ranks)
+    print(f"\n[BASELINE] e5-cos (no training): MRR {base['MRR']:.3f}  recall@10 {base['recall@10']:.3f}  "
+          f"med.rank {base['median_rank']}")
+
+    print(f"\n{'frac':>6} {'n_train':>8} {'MRR':>7} {'recall@1':>9} {'recall@10':>10} {'med.rank':>9}  vs e5-cos")
+    fracs = [float(x) for x in a.fracs.split(",")]
+    for fr in fracs:
+        n = max(a.bs, int(fr * len(train_idx)))
+        sub = random.Random(a.seed + 1).sample(train_idx, min(n, len(train_idx)))
+        m = train_one(a.ckpt, tok, idx, bm_key, bm_folder, sub, f_order, eval_keys, eval_truepos,
+                      f_keys, a.steps, a.bs, a.lr, dev, a.seed)
+        delta = m["MRR"] - base["MRR"]
+        flag = "  ✓ CROSSED" if m["MRR"] > base["MRR"] else ""
+        print(f"{fr:6.2f} {len(sub):8d} {m['MRR']:7.3f} {m['recall@1']:9.3f} {m['recall@10']:10.3f} "
+              f"{m['median_rank']:9d}  {delta:+.3f}{flag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/train_filing.py
+++ b/prototypes/mu_cosine/train_filing.py
@@ -80,7 +80,8 @@ def main():
     ap.add_argument("--steps", type=int, default=300)
     ap.add_argument("--bs", type=int, default=48)
     ap.add_argument("--lr", type=float, default=3e-4)
-    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--seed", type=int, default=7, help="split seed (FIXED across training seeds for comparability)")
+    ap.add_argument("--seeds", default=None, help="comma-sep TRAINING seeds (multi-seed lock); split stays at --seed")
     ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     ap.add_argument("--cache", default="/tmp/trainfiling_e5.pt")
     a = ap.parse_args()
@@ -123,17 +124,24 @@ def main():
     print(f"\n[BASELINE] e5-cos (no training): MRR {base['MRR']:.3f}  recall@10 {base['recall@10']:.3f}  "
           f"med.rank {base['median_rank']}")
 
-    print(f"\n{'frac':>6} {'n_train':>8} {'MRR':>7} {'recall@1':>9} {'recall@10':>10} {'med.rank':>9}  vs e5-cos")
+    import statistics as stt
+    seeds = [int(s) for s in a.seeds.split(",")] if a.seeds else [a.seed]
+    print(f"\n[SEEDS] training seeds {seeds} (split fixed at seed {a.seed}); ✓ = mean−sd above the e5-cos bar")
+    print(f"\n{'frac':>6} {'n_train':>8} {'MRR (mean±sd)':>15} {'recall@10 (m±sd)':>18} {'med.rank':>9}  vs e5-cos")
     fracs = [float(x) for x in a.fracs.split(",")]
     for fr in fracs:
-        n = max(a.bs, int(fr * len(train_idx)))
-        sub = random.Random(a.seed + 1).sample(train_idx, min(n, len(train_idx)))
-        m = train_one(a.ckpt, tok, idx, bm_key, bm_folder, sub, f_order, eval_keys, eval_truepos,
-                      f_keys, a.steps, a.bs, a.lr, dev, a.seed)
-        delta = m["MRR"] - base["MRR"]
-        flag = "  ✓ CROSSED" if m["MRR"] > base["MRR"] else ""
-        print(f"{fr:6.2f} {len(sub):8d} {m['MRR']:7.3f} {m['recall@1']:9.3f} {m['recall@10']:10.3f} "
-              f"{m['median_rank']:9d}  {delta:+.3f}{flag}")
+        n = min(max(a.bs, int(fr * len(train_idx))), len(train_idx))
+        mrrs, r10s, meds = [], [], []
+        for sd in seeds:
+            sub = random.Random(sd + 1).sample(train_idx, n)
+            m = train_one(a.ckpt, tok, idx, bm_key, bm_folder, sub, f_order, eval_keys, eval_truepos,
+                          f_keys, a.steps, a.bs, a.lr, dev, sd)
+            mrrs.append(m["MRR"]); r10s.append(m["recall@10"]); meds.append(m["median_rank"])
+        mm, ms = stt.mean(mrrs), (stt.stdev(mrrs) if len(mrrs) > 1 else 0.0)
+        rm, rs = stt.mean(r10s), (stt.stdev(r10s) if len(r10s) > 1 else 0.0)
+        delta = mm - base["MRR"]
+        flag = "  ✓ CROSSED" if mm - ms > base["MRR"] else ("  ~at-bar" if mm > base["MRR"] else "")
+        print(f"{fr:6.2f} {n:8d}   {mm:.3f}±{ms:.3f}     {rm:.3f}±{rs:.3f}    {stt.median(meds):7.1f}  {delta:+.3f}{flag}")
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -324,6 +324,62 @@ def eval_transitive(model, tok, path, idx, use_nodetype):
 
 
 @torch.no_grad()
+def eval_retrieval(model, tok, idx, adj, roots, k=25, out=None):
+    """Retrieval diagnostic (DESIGN_model_applications.md — the first concrete increment). For each root, rank
+    ALL nodes by the **unconditional** μ(·|root) (equal-weight operator superposition) and relate it to graph
+    **hop-distance** (BFS). Reports: per-hop mean μ (does μ decay with distance?), the top-k hop distribution
+    (does retrieval pull in near AND far semantically-related nodes?), and a **greedy bidirectional gather**
+    (best-first over the graph by μ) vs the global dense top-k. Writes the top-k (root, node, μ, hop) for the
+    μ-vs-hop SCATTER. Pure inference — no LLM. Include an OOD root to probe e5 generalisation outside training."""
+    import heapq, collections, statistics as st
+    was = model.training; model.eval()
+    dev = next(model.parameters()).device
+    n_ops = model.op_emb.weight.shape[0]
+    allnodes = list(idx)
+    for root in roots:
+        if root not in idx:
+            print(f"[RETRIEVAL] root '{root}' not in vocab — skip"); continue
+        items = [(nd, root, 0) for nd in allnodes]                  # op_id placeholder; op_weights override below
+        mu = []
+        for i in range(0, len(items), 512):
+            b = tok.build(items[i:i + 512], train=False)
+            b = {kk: (v.to(dev) if torch.is_tensor(v) else v) for kk, v in b.items()}
+            ow = torch.full((len(items[i:i + 512]), n_ops), 1.0 / n_ops, device=dev)   # equal-weight superposition
+            mu += model(**b, op_weights=ow).cpu().tolist()
+        mu = {allnodes[i]: mu[i] for i in range(len(allnodes))}
+        hop = bfs_dist(adj, root)                                   # graph hop-distance from root
+        topk = sorted(allnodes, key=lambda nd: -mu[nd])[:k]
+        byhop = collections.defaultdict(list)
+        for nd in allnodes:
+            byhop[hop.get(nd, 99)].append(mu[nd])
+        print(f"[RETRIEVAL] root={root}  (n={len(allnodes)})")
+        print(f"  mean μ by hop:  " + "  ".join(f"h{h}:{st.mean(byhop[h]):.2f}(n{len(byhop[h])})"
+                                                 for h in sorted(byhop) if h != 99))
+        print(f"  top-{k} hop dist: {dict(collections.Counter(hop.get(nd, '∞') for nd in topk))}")
+        print(f"  top-8 by μ:  " + "  ".join(f"{nd.split(':')[-1][:16]}({mu[nd]:.2f},h{hop.get(nd, '∞')})" for nd in topk[:8]))
+        # greedy bidirectional gather: best-first over the graph by μ (structure ∩ semantics)
+        seen, gathered = {root}, []
+        fr = [(-mu[nd], nd) for nd in adj.get(root, ()) if nd in idx]; heapq.heapify(fr)
+        while fr and len(gathered) < k:
+            _, nd = heapq.heappop(fr)
+            if nd in seen:
+                continue
+            seen.add(nd); gathered.append(nd)
+            for m in adj.get(nd, ()):
+                if m not in seen and m in idx:
+                    heapq.heappush(fr, (-mu[m], m))
+        ov = len(set(gathered) & set(topk))
+        print(f"  greedy-gather top-{len(gathered)}: {ov}/{k} overlap with the global dense top-{k} "
+              f"(greedy = connected high-μ; dense may include disconnected/cross-domain)")
+        if out:
+            with open(out, "a", encoding="utf-8") as f:
+                for nd in topk:
+                    f.write(f"{root}\t{nd}\t{mu[nd]:.4f}\t{hop.get(nd, -1)}\n")
+    if was:
+        model.train()
+
+
+@torch.no_grad()
 def emit_dense(model, tok, names, op, root="Physics", bs=512):
     items = [(n, root, OPS[op]) for n in names]
     mu = mu_batch(model, tok, items, bs)
@@ -806,6 +862,8 @@ def train(args):
         eval_tail(model, tok, graded_text, _ntp, args.eval_tail, args.use_nodetype)
     if args.eval_transitive and os.path.exists(args.eval_transitive):     # held-out transitive eval (stage 3)
         eval_transitive(model, tok, args.eval_transitive, idx, args.use_nodetype)
+    if args.eval_retrieval:                                               # retrieval diagnostic (μ-vs-hop, greedy gather)
+        eval_retrieval(model, tok, idx, adj, args.eval_retrieval.split(","), k=args.retrieval_k, out=args.retrieval_out)
     if args.save and not es_saved:                        # early-stop already saved the best; else save the final
         torch.save({"state": model.state_dict(), "cfg": {"d_model": q.shape[1], "heads": args.heads,
                     "layers": args.layers}}, args.save)
@@ -1109,6 +1167,11 @@ def main():
     ap.add_argument("--transitive-hetero", action="store_true", help="heteroscedastic: per-pair scale s_pair = "
                     "s/√(1+V) from the product-propagated chain variance V (longer/weaker chains → softer); "
                     "vs the default global s (homoscedastic). DESIGN §'loss over the DISTRIBUTION'")
+    ap.add_argument("--eval-retrieval", default=None, help="comma-sep roots → retrieval diagnostic: rank all "
+                    "nodes by unconditional μ(·|root), report per-hop μ + greedy bidirectional gather + scatter "
+                    "(DESIGN_model_applications.md). Include an OOD root to probe e5 generalisation.")
+    ap.add_argument("--retrieval-k", type=int, default=25, help="top-k for the retrieval scatter/gather")
+    ap.add_argument("--retrieval-out", default=None, help="write top-k (root, node, μ, hop) for the μ-vs-hop scatter")
     ap.add_argument("--eval-transitive", default=None, help="held-out transitive triples → report constraint "
                     "satisfaction + anti-collapse level (use a node-split holdout, not the training triples)")
     ap.add_argument("--graded-nodes", default=None, help="override the graded nodes file (default: derive "

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -356,8 +356,12 @@ def eval_retrieval(model, tok, idx, adj, roots, k=25, out=None):
         print(f"  mean μ by hop:  " + "  ".join(f"h{h}:{st.mean(byhop[h]):.2f}(n{len(byhop[h])})"
                                                  for h in sorted(byhop) if h != 99))
         print(f"  top-{k} hop dist: {dict(collections.Counter(hop.get(nd, '∞') for nd in topk))}")
-        print(f"  top-8 by μ:  " + "  ".join(f"{nd.split(':')[-1][:16]}({mu[nd]:.2f},h{hop.get(nd, '∞')})" for nd in topk[:8]))
-        # greedy bidirectional gather: best-first over the graph by μ (structure ∩ semantics)
+        ex = lambda lst: "  ".join(f"{nd.split(':')[-1][:16]}({mu[nd]:.2f},h{hop.get(nd, '∞')})" for nd in lst[:8])
+        print(f"  DENSE-μ   top-8:  {ex(topk)}")
+        # WSP baseline: nearest by graph hop-distance (μ tiebreak) — structure only
+        wsp = sorted((nd for nd in allnodes if hop.get(nd, 99) < 99), key=lambda nd: (hop[nd], -mu[nd]))[:k]
+        print(f"  WSP(struct) top-8:  {ex(wsp)}")
+        # greedy bidirectional gather: best-first over the graph by μ (structure ∩ semantics — the new algorithm)
         seen, gathered = {root}, []
         fr = [(-mu[nd], nd) for nd in adj.get(root, ()) if nd in idx]; heapq.heapify(fr)
         while fr and len(gathered) < k:
@@ -368,9 +372,8 @@ def eval_retrieval(model, tok, idx, adj, roots, k=25, out=None):
             for m in adj.get(nd, ()):
                 if m not in seen and m in idx:
                     heapq.heappush(fr, (-mu[m], m))
-        ov = len(set(gathered) & set(topk))
-        print(f"  greedy-gather top-{len(gathered)}: {ov}/{k} overlap with the global dense top-{k} "
-              f"(greedy = connected high-μ; dense may include disconnected/cross-domain)")
+        print(f"  GREEDY    top-8:  {ex(gathered)}")
+        print(f"    (greedy = μ-ranked among graph-reachable; dense∩greedy overlap {len(set(gathered) & set(topk))}/{k})")
         if out:
             with open(out, "a", encoding="utf-8") as f:
                 for nd in topk:


### PR DESCRIPTION
Builds the retrieval/applications layer for the μ-attention model and answers, with real-data
evals, the central open question: **does the learned directional μ ever beat raw e5 cosine?**
Answer: **not zero-shot OOD, but yes in-domain — and yes on a new domain once given modest
training data, replicated across seeds.**

### What's built
- **Retrieval diagnostic** (`train_mu_attention.py --eval-retrieval`) — μ-vs-hop scatter + a
  three-way ranking compare: DENSE-μ (score all), WSP (graph-hop, structural baseline), and the
  **greedy bidirectional gather** (μ-ranked among graph-reachable — the new algorithm).
- **Formal filing eval** (`eval_filing.py`) — non-circular, on **real Pearltrees filing
  decisions** (a bookmark's actual `treeId` = ground truth). Rankers: `e5-cos`, `mu-super`,
  `mu-elem`; recall@k / MRR; core-distance stratification; `--source simplewiki` (in-domain
  home-turf) and `--holdout-nodes` (never-trained nodes).
- **Filing fine-tune learning curve** (`train_filing.py`) — warm-start + in-batch contrastive
  `element_of` loss at rising data fractions; multi-seed, fixed-split, mean±sd.

### Results
| eval | finding |
|---|---|
| **Greedy gather** | Fixes dense-μ's domain leak: Cooking dense∩greedy overlap **4/25** (vs 21–25 for clean domains) — structure removes high-μ-far false positives, μ demotes low-μ-near ones. |
| **Filing (zero-shot, OOD)** | `e5-cos` **doubles** μ (MRR 0.299 vs ~0.15) — but it's OOD transfer, not a broken model. |
| **Home-turf (in-domain)** | μ **ties/beats** e5-cos: recall@10 0.494 vs 0.424, median 11 vs 29; wins decisively in the STEM core (0.637 vs 0.393). |
| **Node-holdout** | Near-identical on **never-trained** nodes (~3% drop) ⇒ generalization, not memorization. |
| **Filing fine-tune (multi-seed)** | μ **crosses the e5-cos bar at ~30% data**, locked across 3 seeds: 100% → MRR **0.358±0.018 vs 0.291**, recall@10 **0.573 vs 0.440**, median **6 vs 17**, still rising. |

**Operating point:** μ's edge is at **recall@10 / median rank**, not recall@1 — exactly what a
first-stage retriever feeding an **LLM re-ranker** needs (get the answer into the top-K; the LLM
does precision@1).

### Theory (DESIGN_model_applications.md)
- μ's directionality **is** a curried subset relation: `μ(·|root)` = the partial application `> root`;
  the bivector supplies the orientation a symmetric dot product structurally cannot.
- **Cost axis:** rotation/bivector = strong prior, wins at low data; transformer = learns from data,
  wins at high data — and the filing curve is this in miniature.
- Bivector dimensionality: general is O(n²)=73,536 for n=384, but our blades are simple (O(n)) /
  low-rank (O(Kn)); the repo's rotation machinery (canonical commuting planes + Rodrigues +
  codebook + distillation) already beats `logm`/`expm`. Canonical-vs-PCA is embedding-structure-
  dependent (Matryoshka) and **open for e5**.
- **Bitter lesson:** the bivector is sample-efficiency *scaffolding* (distillable, removable), not
  the destination — the long-term bet is data + the transformer.

### Notes
- Pearltrees filing data lives in `.local` (gitignored, credentialed harvest); all scripts here are
  committable, the data is not.
- Single remaining caveat: the fine-tune is short and still climbing — more steps/data only help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)