### PR TITLE
μ-attention eval suite + methodology report — what a learned layer adds over frozen e5

### DIFF
--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -263,6 +263,25 @@ axis every time. **This is settled: μ's value is NOT being a better symmetric r
 calibration** (the axes e5 structurally lacks). Stop benchmarking μ-vs-e5 on magnitude; build on direction +
 calibration — exactly what membership/filing need and cosine cannot give.
 
+**Negative-rejection test (honest correction — calibration ≠ separability):** at a fixed operating point (~90%
+positive-recall) **neither μ nor e5 rejects negatives cleanly, and μ is marginally *worse*** (FPR on cross-domain
+EASY-NEG: e5 52% vs μ-super 58%). μ's calibration gives different *means* (POS 0.37 vs EASY 0.10) but the
+**distributions overlap** (high within-stratum variance), so admitting 90% of positives drops the threshold low
+enough to readmit negatives. **A wide dynamic range ≠ functional thresholding.** So the "μ rejects negatives
+where e5 can't" hypothesis does **not** hold at the operating point.
+
+#### Consolidated verdict (tested 5 ways) — μ's one robust win is DIRECTIONALITY; use a hybrid
+Across clean-domain coverage, fine-subdomain rank, deep-pair discrimination, filing, and negative-rejection,
+**e5-cos is competitive-or-better on every symmetric / magnitude / rejection axis.** μ-super is a *reasonable*
+symmetric ranker (AUC 0.67 vs 0.73) but not a better one, and its calibration does not translate into functional
+negative-rejection. **The single robust, unique, repeatable μ advantage is DIRECTIONALITY** (member|container vs
+container|member: AUC **0.78 vs e5 0.51**) — structural, e5 cannot represent it. **Architectural conclusion: not
+"μ replaces e5" but a HYBRID** — e5 for symmetric relatedness/ranking (its genuine strength), **μ for direction**
+(orient membership, member→container, build/verify hierarchy). This is the same "structure ∩ semantics" split as
+the greedy gather, and why the bookmarking agent pairs e5 with learned structure rather than discarding e5. Build
+the application around μ's *directional* contribution on top of e5's symmetric ranking; don't expect μ to win the
+symmetric contest. *(We still track symmetric performance — μ-super stays near e5 — but the design bet is direction.)*
+
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM
 core's effective-distance). Those are *structural only*: graph-near ≠ semantically-related. The new algorithm

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -287,6 +287,12 @@ sibling-of** ("everything looks similar"). μ separates them (0.48 vs 0.21) and 
 confusions that matter in retrieval (the top-k is full of siblings, not random cross-domain nodes). This is also
 why μ took filing recall@10 (0.90 vs 0.63): it pushed close-but-wrong folders down, which e5 can't.
 
+**State it as a low μ value, not a threshold (the right framing).** The sibling subset-relation is *negative*, and
+the usable signal is that **μ gives siblings a low degree (0.22)** vs the true parent (0.48) — calibrated, readable
+("barely a member"). e5 gives siblings **0.815 ≈ parent 0.832**: it has *no way to say "low."* (A binary
+FPR@90%-TPR understates this — μ's long positive low-tail drops the cutoff to ~0.001, so FPR is leaky for both
+μ 74.5% / e5 91.5%; the *degree*, not the threshold, is what's usable and where μ wins structurally.)
+
 #### Consolidated verdict (corrected) — μ wins direction + close-negative discrimination; hybrid
 **μ's robust wins are two:** (1) **directionality** (member|container vs reverse: AUC **0.78 vs e5 0.51**); (2)
 **close-negative discrimination** (member-of vs sibling-of: **0.73 vs 0.62**). e5 wins only on *easy/medium*

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -158,26 +158,33 @@ Trained→held-out drop is **~3%**; the STEM-core win is **unchanged** (held-out
 **0.637 vs 0.393**, median **7 vs 27** — the same numbers). μ ranks never-seen nodes almost exactly as well as
 seen ones ⇒ **the home-turf win is generalisation, not memorisation.** Baseline locked.
 
-#### Data quality > data quantity — dropping admin categories inverts the result (`--drop-admin`)
-Probing the "coverage" gap revealed the FAR-from-core bin is dominated by **Wikipedia admin/maintenance/nav
-scaffolding** (`CatAutoTOC generates no TOC` deg 1219, `Navseasoncats…`, `Establishments by year`, `X by
-country`) — titles with **no topical meaning**, so neither e5-cos nor μ can rank them and *no training data
-fixes a meaningless label*. Dropping them (`--drop-admin`, a name-pattern filter) **inverts the home-turf
-"tie"**:
+#### Data quality, two tiers — Tier-1 junk removal flips μ to a clear win; keep Tier-2 (`--drop-admin junk|all`)
+Probing the "coverage gap" found the FAR-from-core bin mixes **two very different things**, which must be treated
+differently:
+- **Tier-1 — meaningless:** maintenance / template / nav categories (`CatAutoTOC generates no TOC` deg 1219,
+  `Navseasoncats…`) — procedural titles, *zero* topical content. No ranker can place them, no training fixes them.
+- **Tier-2 — loosely semantic:** structural / temporal groupings (`Years of the 20th century`, `Establishments
+  by year`, `People by nationality`, `Cities by country`). Real but lower-density meaning (the year/place signal
+  *is* useful) — **keep in eval, *down-sample* in training**, do not drop.
 
-| in-domain | recall@10 | MRR | med.rank |
-|---|---|---|---|
-| with admin junk (earlier) | mu 0.494 / e5 0.424 | mu 0.255 / e5 0.270 (tie) | 11 / 29 |
-| **admin dropped — e5-cos** | 0.634 | 0.450 | 3 |
-| **admin dropped — mu-super** | **0.898** | **0.488** | **2** |
+Decomposing the gain (home-turf, 500 queries) shows the win is **almost entirely Tier-1 removal**:
 
-The junk depressed *both* rankers and masked μ's edge. Cleaned, **μ clearly beats e5-cos** and **dominates at
-recall@10 (0.898 vs 0.634 — the answer in the top-10 90% vs 63% of the time)** — the LLM-re-rank operating point.
-Stratified: μ wins big in MID/NEAR-STEM (recall@10 0.86–0.88 vs 0.44–0.51, median 4 vs 8–23); on clean FAR
-*content* e5-cos leads at recall@1 but ties at recall@10. **Bitter-lesson footnote:** the "coverage" bet's first
-and cheapest win was **data quality** (drop ~meaningless labels), not quantity — and it sharpens where real
-coverage gaps remain (genuine non-STEM content, where e5 already does okay at recall@1, so the marginal value of
-more training there is lower than the headline gap suggested). Admin cats should also be filtered from *training*.
+| filter | folders | e5-cos MRR | mu-super MRR | **μ − e5** | recall@10 (μ / e5) |
+|---|---|---|---|---|---|
+| none (junk in) | 295 | 0.270 | 0.255 | −0.015 *(tie)* | 0.494 / 0.424 |
+| **Tier-1 junk only** *(honest)* | 273 | 0.408 | 0.448 | **+0.040** | **0.812 / 0.660** |
+| Tier-1+2 (`all`) | 132 | 0.454 | 0.502 | +0.048 | 0.904 / 0.634 |
+
+**Dropping Tier-1 alone flips the home-turf "tie" to a clear μ win** (μ−e5 −0.015 → **+0.040**, recall@10
+**0.812 vs 0.660**) — legitimate noise removal. Dropping Tier-2 *as well* lifts **both** rankers' absolutes
+(easier candidate set) but the μ-advantage gap barely moves (+0.040 → +0.048) — so Tier-2 is **not** the source
+of μ's win; keeping it is honest (μ still wins) and dropping it would only inflate the headline. **Policy: Tier-1
+→ drop (eval + training); Tier-2 → keep in eval, down-sample in training.** **Bitter-lesson footnote:** the
+"coverage" bet's first and cheapest win was **data quality** (drop *meaningless* labels), not quantity — and it
+relocates the real gap to genuine non-STEM content (where e5 already does okay at recall@1, so more training there
+buys less than the raw gap suggested). **Generalises to never-trained nodes** (`--holdout-nodes`, aggressive
+`all` level shown): mu-super recall@10 **0.919 vs 0.662** on nodes never seen ⇒ μ is a strong **first-stage
+retriever** (feed top-10 to an LLM re-ranker), the recall@10 operating point.
 
 ### Filing fine-tune learning curve — μ CROSSES the e5-cos bar (`train_filing.py`)
 The quantified "with enough in-domain data the attention model wins." Warm-start `model_nodetype`, fine-tune on
@@ -215,6 +222,19 @@ candidates. μ excels at exactly the shortlist metric and recovers the early win
 — so "μ slightly behind at recall@1" is a **non-issue** for the real application: μ is the right **first-stage
 retriever** (return top-10, hand to the LLM), where median-rank-7 means the answer is almost always in the window
 the LLM sees. The early in-domain win lands precisely at the hit@(≥10) operating point that re-ranking uses.
+
+#### Coverage round 1 (enwiki linguistics/poli-sci/STS) — negative, and it sharpens *where* coverage pays
+Harvested 3 absent/weak STEM-adjacent domains from the local enwiki category DB (`build_slice.py`, ~3k new
+content nodes, 0% admin), trained a directional graded round (warm-start, `model_cov1`), evaluated on the merged
+graph. **Result: no μ gain on the new domains** — mu-super MRR **0.39 vs e5-cos 0.53**, recall@10 0.62 vs 0.71;
+the fine-tune barely moved it; originals roughly preserved (within n=400 single-run noise — e5-cos itself wobbled
+±0.013). **Why:** these are *clean, well-separated* domains where **e5's symmetric similarity already captures the
+structure** (same as "Music" generalising), so μ has nothing to add. **Lesson:** the bitter-lesson "more data →
+μ wins" is **conditional on e5 being *weak* in that region.** μ's value — and where coverage pays — is where e5
+is weak: **conflated** domains (Cooking→movies), the **dense STEM core** (directional structure matters), or
+**OOD tasks** (filing). So **prioritise coverage by e5-weakness** (the disagreement signal), *not* by
+"absent-but-clean." `model_cov1` is an experimental artifact, not an improvement. See
+`DESIGN_wikipedia_sampling.md`.
 
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -270,17 +270,31 @@ EASY-NEG: e5 52% vs μ-super 58%). μ's calibration gives different *means* (POS
 enough to readmit negatives. **A wide dynamic range ≠ functional thresholding.** So the "μ rejects negatives
 where e5 can't" hypothesis does **not** hold at the operating point.
 
-#### Consolidated verdict (tested 5 ways) — μ's one robust win is DIRECTIONALITY; use a hybrid
-Across clean-domain coverage, fine-subdomain rank, deep-pair discrimination, filing, and negative-rejection,
-**e5-cos is competitive-or-better on every symmetric / magnitude / rejection axis.** μ-super is a *reasonable*
-symmetric ranker (AUC 0.67 vs 0.73) but not a better one, and its calibration does not translate into functional
-negative-rejection. **The single robust, unique, repeatable μ advantage is DIRECTIONALITY** (member|container vs
-container|member: AUC **0.78 vs e5 0.51**) — structural, e5 cannot represent it. **Architectural conclusion: not
-"μ replaces e5" but a HYBRID** — e5 for symmetric relatedness/ranking (its genuine strength), **μ for direction**
-(orient membership, member→container, build/verify hierarchy). This is the same "structure ∩ semantics" split as
-the greedy gather, and why the bookmarking agent pairs e5 with learned structure rather than discarding e5. Build
-the application around μ's *directional* contribution on top of e5's symmetric ranking; don't expect μ to win the
-symmetric contest. *(We still track symmetric performance — μ-super stays near e5 — but the design bet is direction.)*
+#### CLOSE-negative test — μ DOES win where it matters (corrects the verdict below)
+The "hard negatives" above (cross-fine-subdomain) weren't close enough. The **closest** negative is a *sibling*
+(another child of the same parent — same fine topic, no membership relation, often *more* e5-similar than the
+true parent). On that test (POS = child→parent vs CLOSE-NEG = child→sibling):
+
+| negative type | e5-cos AUC | μ AUC | winner |
+|---|---|---|---|
+| EASY (cross-domain) | 0.84 | 0.81 | e5 |
+| HARD (cross-fine-subdomain) | 0.73 | 0.68 | e5 |
+| **CLOSE (sibling, same parent)** | **0.62** | **0.73** | **μ** |
+
+**e5 scores a child's true parent (0.832) and its sibling (0.815) within 0.017 — it cannot tell member-of from
+sibling-of** ("everything looks similar"). μ separates them (0.48 vs 0.21) and wins 0.73 vs 0.62. **μ's advantage
+*grows as negatives get closer*** (e5 degrades 0.84→0.73→0.62; μ holds) — and close neighbours are exactly the
+confusions that matter in retrieval (the top-k is full of siblings, not random cross-domain nodes). This is also
+why μ took filing recall@10 (0.90 vs 0.63): it pushed close-but-wrong folders down, which e5 can't.
+
+#### Consolidated verdict (corrected) — μ wins direction + close-negative discrimination; hybrid
+**μ's robust wins are two:** (1) **directionality** (member|container vs reverse: AUC **0.78 vs e5 0.51**); (2)
+**close-negative discrimination** (member-of vs sibling-of: **0.73 vs 0.62**). e5 wins only on *easy/medium*
+symmetric relatedness (coarse topical separation) and on negative-*rejection thresholding* (neither great).
+So the earlier "e5 better on everything symmetric" was wrong — it held only because the negatives tested weren't
+close enough. **Architecture = HYBRID:** e5 for coarse symmetric ranking (cheap, strong), **μ for the hard part —
+direction + close-neighbour disambiguation** (which determines the actual top of the retrieval list). Same
+"structure ∩ semantics" split; μ carries the practically-decisive cases e5 conflates.
 
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -253,6 +253,16 @@ provide. **Re-judges coverage round 1:** `cov1` didn't move rank-AUC (e5 already
 calibration on the new domains** (POS mean μ 0.40→0.51) — so it *did* contribute; the filing eval just couldn't
 see it. Going forward, evaluate coverage/μ on **directional + calibrated** metrics, not symmetric rank.
 
+**Depth test (settles the "μ wins deep" hypothesis — it doesn't):** stratified the membership discrimination by
+tree depth with a HARD distractor (a *sibling* of the true parent — same depth, same local domain). Both degrade
+with depth and **e5 stays ahead at every depth** (μ/e5 AUC(true>sibling): shallow 0.84/0.86, mid 0.79/0.83, deep
+0.72/0.79). e5's cosine doesn't saturate — deep child titles still lexically echo the true parent ("Medieval
+linguists"→"Linguists"). **So μ does not beat e5 on *magnitude* discrimination at any depth.** Tested four ways
+(clean domains, fine-subdomain rank, deep pairs, filing) — e5 is competitive-or-better on the symmetric/magnitude
+axis every time. **This is settled: μ's value is NOT being a better symmetric ranker; it is directionality +
+calibration** (the axes e5 structurally lacks). Stop benchmarking μ-vs-e5 on magnitude; build on direction +
+calibration — exactly what membership/filing need and cosine cannot give.
+
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM
 core's effective-distance). Those are *structural only*: graph-near ≠ semantically-related. The new algorithm

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -323,6 +323,15 @@ direction + symmetric pressure). Residual direction gap (0.84 vs 0.92) = μ's re
 probe's discriminative loss; a ranking/discriminative directional loss is the remaining lever. Net: μ is viable
 for directional membership once supervised for it; "μ can't beat a trained head" is too strong.
 
+**RESOLVED — discriminative loss: μ BEATS the probe (`train_dir_rank.py`).** Replaced the regression with a
+ranking CE `softplus(−s·(μ_fwd−μ_rev−m))`, fine-tuned on the probe's 70% split, evaluated on held-out 30%
+(μ never saw those edges): **DIRECTION 0.982 vs probe 0.930; CLOSE-NEG 0.864 vs probe 0.790** — non-overlapping
+CIs. So the gap was *entirely* the objective (symmetric-dominant + regression-to-constants); fix it (keep
+direction, drop symmetric pressure, rank not regress) and μ's nonlinear architecture **exceeds** a linear
+e5-probe. The review's control was the right test and drove the fix; "μ has no architectural advantage" is now
+**reversed** — it has one, once trained for the task. (Caveats: node-overlap remains → node-disjoint split next;
+single-run, tight CIs.)
+
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM
 core's effective-distance). Those are *structural only*: graph-near ≠ semantically-related. The new algorithm

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -332,6 +332,23 @@ e5-probe. The review's control was the right test and drove the fix; "μ has no 
 **reversed** — it has one, once trained for the task. (Caveats: node-overlap remains → node-disjoint split next;
 single-run, tight CIs.)
 
+#### Judge→loss routing — the loss is keyed off provenance, not a new embedding (now in the main trainer)
+The discriminative loss is *not* a new "judge type." Provenance (`graph`/`haiku`/`human`/`sonnet`/`opus`) is an
+**input token** that conditions μ's *output* (and is marginalised at inference); the **loss function** is a
+*training-time* choice the model never sees as input. So we don't enlarge the judge table with "discriminative" —
+we **route the loss by the judge token already on every row**:
+- **`graph` + a DIRECTIONAL relation** (`element_of`/`subcategory`/`subtopic`/`super_category`) ⇒ *certain &
+  oriented* ⇒ **discriminative ranking** loss `softplus(−s·(μ(member|container) − μ(container|member) − m))` (+ a
+  light regression anchor so degrees stay readable). This is the term that beats the e5-probe.
+- **`haiku`** (soft superposition / inferred tail) ⇒ a *distribution*, not a hard orientation ⇒ keep **regression
+  to the soft target** (`L_graded`/`L_blend`).
+
+Implemented in `train_mu_attention.py` (`--dir-rank-weight`, `--dir-rank-scale/-margin/-anchor`): graph-judged
+directional rows are collected (`dir_edges`) and trained by the ranking term; everything else stays on
+regression. The judge table is unchanged (it only grows when a new *source* appears, e.g. `sonnet`/`opus`). Maps
+directly onto the data recipe: **downward directional (`graph`) → rank; bidirectional lateral (`haiku`
+superpositions, ≤30%) → soft regression.**
+
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM
 core's effective-distance). Those are *structural only*: graph-near ≠ semantically-related. The new algorithm

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -158,6 +158,27 @@ Trained→held-out drop is **~3%**; the STEM-core win is **unchanged** (held-out
 **0.637 vs 0.393**, median **7 vs 27** — the same numbers). μ ranks never-seen nodes almost exactly as well as
 seen ones ⇒ **the home-turf win is generalisation, not memorisation.** Baseline locked.
 
+#### Data quality > data quantity — dropping admin categories inverts the result (`--drop-admin`)
+Probing the "coverage" gap revealed the FAR-from-core bin is dominated by **Wikipedia admin/maintenance/nav
+scaffolding** (`CatAutoTOC generates no TOC` deg 1219, `Navseasoncats…`, `Establishments by year`, `X by
+country`) — titles with **no topical meaning**, so neither e5-cos nor μ can rank them and *no training data
+fixes a meaningless label*. Dropping them (`--drop-admin`, a name-pattern filter) **inverts the home-turf
+"tie"**:
+
+| in-domain | recall@10 | MRR | med.rank |
+|---|---|---|---|
+| with admin junk (earlier) | mu 0.494 / e5 0.424 | mu 0.255 / e5 0.270 (tie) | 11 / 29 |
+| **admin dropped — e5-cos** | 0.634 | 0.450 | 3 |
+| **admin dropped — mu-super** | **0.898** | **0.488** | **2** |
+
+The junk depressed *both* rankers and masked μ's edge. Cleaned, **μ clearly beats e5-cos** and **dominates at
+recall@10 (0.898 vs 0.634 — the answer in the top-10 90% vs 63% of the time)** — the LLM-re-rank operating point.
+Stratified: μ wins big in MID/NEAR-STEM (recall@10 0.86–0.88 vs 0.44–0.51, median 4 vs 8–23); on clean FAR
+*content* e5-cos leads at recall@1 but ties at recall@10. **Bitter-lesson footnote:** the "coverage" bet's first
+and cheapest win was **data quality** (drop ~meaningless labels), not quantity — and it sharpens where real
+coverage gaps remain (genuine non-STEM content, where e5 already does okay at recall@1, so the marginal value of
+more training there is lower than the headline gap suggested). Admin cats should also be filtered from *training*.
+
 ### Filing fine-tune learning curve — μ CROSSES the e5-cos bar (`train_filing.py`)
 The quantified "with enough in-domain data the attention model wins." Warm-start `model_nodetype`, fine-tune on
 `element_of(bookmark→folder)` with **in-batch contrastive** negatives (B×B μ matrix; same-folder = positive), at

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -302,6 +302,17 @@ close enough. **Architecture = HYBRID:** e5 for coarse symmetric ranking (cheap,
 direction + close-neighbour disambiguation** (which determines the actual top of the retrieval list). Same
 "structure ∩ semantics" split; μ carries the practically-decisive cases e5 conflates.
 
+#### CORRECTION (architecture control, PR #3387 review) — the directional/close-neg wins are NOT μ-architectural
+`e5-cos` is the untrained *product* baseline; the *architecture* control is a **trained head on frozen e5**. A
+logistic probe on the ordered pair `concat(query[a], passage[b])` (held-out edges, `eval_arch_control.py`) **beats
+μ on both**: DIRECTION 0.92 vs μ 0.78; CLOSE-NEG (parent vs sibling) 0.78 vs μ 0.74. e5-cos fails direction only
+because cosine discards order — the signal is in e5's query/passage reps and a linear order-aware head recovers it
+*better* than μ. **So "μ wins direction + close-neg" is withdrawn:** against a trained-head baseline μ shows **no
+per-task advantage on any axis tested.** The only remaining candidate value is a *systems* argument — one general,
+calibrated, multi-relational estimator vs a per-(relation,direction) probe zoo — which is **untested**. The hybrid
+framing above stands only if that generality claim is substantiated; otherwise a trained e5-probe is the stronger,
+simpler tool. (This is the review's decisive catch; we ran the control and it overturned the headline.)
+
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM
 core's effective-distance). Those are *structural only*: graph-near ≠ semantically-related. The new algorithm

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -313,6 +313,16 @@ calibrated, multi-relational estimator vs a per-(relation,direction) probe zoo �
 framing above stands only if that generality claim is substantiated; otherwise a trained e5-probe is the stronger,
 simpler tool. (This is the review's decisive catch; we ran the control and it overturned the headline.)
 
+**UPDATE — the gap was mostly the OBJECTIVE; directional supervision largely closes it.** Root cause: μ's
+dominant SYM walk term is *order-invariant* (trains symmetry, competing with direction); direction was a minority
+graded component. Retrained `model_dir` keeping direction as the target (directional graded + transitive,
+`--sym-weight 0`): DIRECTION 0.776→**0.839**, CLOSE-NEG 0.738→**0.779 (≈ probe 0.787, CIs overlap)**. So μ
+**matches the probe on close-negatives and closed ~half the direction gap from an objective change alone** — the
+architecture is competitive, not inferior; the earlier loss was a supervision artifact (under-supervised
+direction + symmetric pressure). Residual direction gap (0.84 vs 0.92) = μ's regression-to-0.90/0.10 vs the
+probe's discriminative loss; a ranking/discriminative directional loss is the remaining lever. Net: μ is viable
+for directional membership once supervised for it; "μ can't beat a trained head" is too strong.
+
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM
 core's effective-distance). Those are *structural only*: graph-near ≠ semantically-related. The new algorithm

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -233,8 +233,25 @@ structure** (same as "Music" generalising), so μ has nothing to add. **Lesson:*
 μ wins" is **conditional on e5 being *weak* in that region.** μ's value — and where coverage pays — is where e5
 is weak: **conflated** domains (Cooking→movies), the **dense STEM core** (directional structure matters), or
 **OOD tasks** (filing). So **prioritise coverage by e5-weakness** (the disagreement signal), *not* by
-"absent-but-clean." `model_cov1` is an experimental artifact, not an improvement. See
-`DESIGN_wikipedia_sampling.md`.
+"absent-but-clean." See `DESIGN_wikipedia_sampling.md`.
+
+#### Eval correction — μ's value is DIRECTIONALITY + CALIBRATION, not symmetric rank (`eval_relatedness.py`)
+The filing eval (member→*exact* parent, ranked vs all folders) is a **classification** task relative to roots; it
+rewards exact title-match (favours e5-cos, understates μ — a member is related to its whole subdomain, not one
+parent). Re-evaluated on the model's actual objective:
+- **Symmetric relatedness** (within-vs-cross *fine* subdomain, `eval_relatedness.py`): e5-cos rank-discriminates
+  *slightly better* (AUC POS-vs-hard-neg **0.74 vs μ 0.68**) — so filing wasn't hiding a μ rank-win. **But** e5
+  squashes all strata into a 0.05 band (0.81/0.78/0.76 cosine floor) while μ has **4× dynamic range**
+  (0.40/0.20/0.09) — μ gives *calibrated* membership degrees; e5 gives near-uninformative absolute scores.
+- **Directional** (`μ(member|container)` vs `μ(container|member)`): **μ AUC(fwd>rev) 0.78, asymmetry 0.33**;
+  **e5-cos AUC 0.51, asymmetry 0.001 — a coin flip.** e5-cosine *cannot express direction at all* (symmetric;
+  the query/passage prefix gives ~nothing). **This is μ's structurally-unique win** and what membership needs.
+
+**Conclusion:** e5-cos is a strong *symmetric ranker*, so symmetric evals (filing, relatedness-AUC) measure μ on
+e5's home turf and miss its point. μ's value = **directionality** + **calibration**, neither of which e5 can
+provide. **Re-judges coverage round 1:** `cov1` didn't move rank-AUC (e5 already ranks fine) but **sharpened μ's
+calibration on the new domains** (POS mean μ 0.40→0.51) — so it *did* contribute; the filing eval just couldn't
+see it. Going forward, evaluate coverage/μ on **directional + calibrated** metrics, not symmetric rank.
 
 ### Relation to prior approaches
 Prior graph retrieval uses **distance metrics** — most relevantly **weighted shortest path** (and the WAM

--- a/prototypes/mu_cosine/DESIGN_wikipedia_sampling.md
+++ b/prototypes/mu_cosine/DESIGN_wikipedia_sampling.md
@@ -1,0 +1,175 @@
+# Wikipedia sampling strategy (μ-attention coverage)
+
+How to extend the μ model's training coverage from Wikipedia — **what to sample, where to get it (DB vs API),
+which tools to call, and how to build the DB if it doesn't exist.** Grounding result: coverage is the
+*bitter-lesson* lever (`DESIGN_model_applications.md` — with enough in-domain data the transformer beats raw
+e5-cosine; the win concentrates in trained regions). Prioritise **STEM-adjacent** domains (linguistics, political
+science, social sciences, economics, philosophy — close to AI/science) over low-interest ones (music, cooking,
+entertainment), which can be added later at lower budget for breadth.
+
+> **Measured caveat (coverage round 1, linguistics/poli-sci/STS):** adding clean, well-separated domains gave
+> **no μ gain** — μ stayed *below* e5-cosine there (new-domain mu-super MRR 0.39 vs e5-cos 0.53; recall@10 0.62
+> vs 0.71), because **e5 already handles clean content well** (cf. "Music" generalising). The bitter-lesson
+> "more data → μ wins" is **conditional on e5 being *weak* in that region.** So **prioritise coverage by
+> e5-weakness** (the §5.2 disagreement signal / domains e5 *conflates*, e.g. Cooking→movies, or the dense STEM
+> core where directional structure matters) — **not** "absent-but-clean" domains. Pick seeds where e5⇄μ disagree,
+> not just where the graph is thin.
+
+---
+
+## 1. Data sources — DB first, API only for the gap
+
+| source | what | when to use |
+|---|---|---|
+| **Category DB** (preferred) | `data/benchmark/enwiki_named/category_parent.tsv` — **title-based** `child<TAB>parent`, 9.9M edges, content-rooted (≈0 Tier-1 admin) | category hierarchy / subcategory edges — the default for downward sampling |
+| **Page/article membership** | `cl_type=="page"` edges (article→category, `element_of`) — **in the same dump**, just not emitted by the current ingest | leaf categories (see §4); a graph join from the dump, *not* an API call |
+| **Live MediaWiki API** | `fetch_category_pages.py` (en.wikipedia.org) | targeted leaves when the DB lacks pages, or freshness; rate-limited, polite |
+
+**Key fact:** "pages aren't in the DB" is an *ingest-filter* artifact, not missing data. The category DB is built
+from the `categorylinks` dump whose `cl_type` distinguishes `subcat` vs `page`; the ingest currently emits only
+`subcat`. The page memberships are in the same dump (resolve article titles via the `page` table, namespace 0).
+
+---
+
+## 2. Building the DB (if it doesn't exist)
+
+**Category graph** — `scripts/ingest_enwiki_categories.py` (correct 2024-schema 3-dump join):
+```
+python3 scripts/ingest_enwiki_categories.py \
+    --page       <dumps>/enwiki-latest-page.sql.gz \
+    --linktarget <dumps>/enwiki-latest-linktarget.sql.gz \
+    --categorylinks <dumps>/enwiki-latest-categorylinks.sql.gz \
+    --out data/benchmark/enwiki_named/category_parent.tsv
+```
+Joins `child_title = page[cl_from]` (ns 14) → `parent_title = linktarget[cl_target_id]` (ns 14), `cl_type==subcat`.
+Dumps live under `context/gemini/UnifyWeaver/data/{enwiki,simplewiki}/` (page / linktarget / categorylinks
+`.sql.gz`); both wikis present. **To add page `element_of`:** extend `load_titles` to also keep namespace-0
+(article) titles and emit `cl_type=="page"` edges — scoped to the categories in your slice to bound size.
+
+**Scoped slice** — `prototypes/mu_cosine/build_slice.py` (streaming BFS, the 644MB graph OOMs if loaded naively):
+```
+python3 build_slice.py --root Linguistics --graph data/benchmark/enwiki_named/category_parent.tsv \
+    --depth 3 --apex-cap 30 --out context/slice_Linguistics.tsv
+```
+Downward closure (depth-bounded) + one level **up** + **apex-capped siblings** = a hub-safe **bidirectional**
+slice. Depth 3 keeps drift low (depth 4 wandered: poli-sci → `1946 in aviation`); apex-cap bounds hub explosion.
+
+---
+
+## 3. Category sampling → training data
+
+1. **Slice** the seed domains (`build_slice.py`, §2). Observed: clean — 0% Tier-1, ~0% Tier-2, ~97% new content.
+2. **Convert to a graded round** (directional WIKI operator — what the membership eval measures), the
+   graph-truth route (no LLM scoring needed):
+   - slice is `child<TAB>parent`; the fused-edge convention is **`a_key=container/parent`, `b_key=member/child`**
+     (`build_graded_round.py:17`), so emit `parent<TAB>child<TAB>subcategory<TAB>1.0`.
+   - `build_graded_round.py --fused context/<prefix> --out <graded>` → `subcategory→WIKI, μ(member|container)=0.90`.
+3. **Train** (warm-start, anti-forgetting via SYM replay; the established recipe):
+   ```
+   UW_MU_GRAPH=<merged_category_parent.tsv> python3 train_mu_attention.py \
+       --init-from model_nodetype.pt --graded <graded>_pairs.tsv --use-nodetype \
+       --pairs mu_pairs_scored_cumulative.tsv --steps 500 --bs 128 --lr 3e-4 --device cuda --save model_cov.pt
+   ```
+4. **Eval** on the **merged** graph (new domains as candidates): `eval_filing.py --source simplewiki
+   --drop-admin junk` + `--holdout-nodes <slice_nodes.json>` to focus on the new domains; compare vs e5-cos and
+   vs the pre-coverage checkpoint.
+
+**SYM route (alternative):** `gen_mu_pairs.py --seeds … --bidir-frac 0` (downward) emits *unscored* candidate
+pairs — needs a scoring pass (μ column). Prefer the graded route for tagged category structure (no scoring).
+
+**Downward-vs-bidirectional ratio is the primary admin control** (`gen_mu_pairs --bidir-frac`): downward-from-
+content stays in content (admin is reached going *up*); `0` = pure child-only. On a content-rooted/admin-flagged
+DB, bidirectional becomes safe (reaches siblings/cousins for lateral coverage).
+
+---
+
+## 4. Page sampling — for leaf categories (`element_of ≈ subcategory`)
+
+Thin domains are **leaf-heavy** (measured: 81% of a linguistics/poli-sci slice were leaves with no subcats). For
+leaves the subcategory signal is exhausted; the rich signal is the **member pages** (`element_of`), which
+correlates with subcategory membership. For the μ model, "page data" = the **page title** (e5-embedded) + the
+`element_of` edge — no page *content* needed, so a fetch is cheap (≤500 titles/call) and the dump route is a join.
+
+- **Preferred:** build scoped page `element_of` from the dump (§2 extension) — all memberships within a slice.
+- **API:** `fetch_category_pages.py --cat <Cat> [--recurse-subcats N]` → `page<TAB>category<TAB>element_of`.
+
+---
+
+## 5. Which categories/leaves to mine for pages — the prioritisation funnel
+
+Cheap → expensive. With the dump local, fetching is *not* the bottleneck, so most of this prioritises **which
+edges to keep/weight**, not which to fetch. (When restricted to the live API, it prioritises the fetch.)
+
+1. **Structural prefilter (≈free, local):**
+   - **Article-count / richness** — rank by #articles (count rows per category in `article_category.tsv`); skip
+     near-empty leaves, prioritise content-rich.
+   - **Centrality / multi-parent** — leaves classified under many parents are bridging/important.
+2. **Informativeness — disagreement (μ vs an independent judge), *refined by model confidence* (§6):**
+   - Score each candidate's μ(node|root) vs an independent signal — **e5-cosine**, **Haiku**, and/or
+     **ModernBERT** (an independent encoder = a useful ensemble member; reuses the dense∩greedy reliability idea).
+   - **High disagreement + LOW model confidence (wide error bounds)** ⇒ **undertrained region → sample it.** This
+     is the common case and the main yield (Haiku is right, we're thin). *Disagreement is mostly undertraining,
+     not Haiku noise.*
+   - **High disagreement + HIGH model confidence (judge outside the bounds)** ⇒ genuine conflict / possible tail →
+     **escalate to a stronger model** (§7), don't blindly sample.
+3. **Quality gate — category↔page coherence:** among informative picks, keep those whose member pages cohere with
+   the category title (e5 sim) → informative *and* clean; drops genuinely-noisy categories. (Opposite objective to
+   #2, so apply as a filter, not a selector — it needs the titles first.)
+4. **Diversity:** cluster candidate e5-embeddings, take one per cluster → max breadth per budget, avoid redundancy.
+5. **Bridge leaves:** high *cross-domain* μ (the bridge detector, PR #3322) — best for lateral/operator-
+   superposition coverage.
+
+---
+
+## 6. Model confidence / error bounds
+
+The μ readout is a **sigmoid point estimate** (no native variance), but per-prediction error bounds are derivable
+cheaply — used as the disagreement discriminator in §5.2:
+- **Operator-superposition spread** — `Var[μ]` across SYM/WIKI/ELEM (already computed per operator); high spread =
+  relation-type ambiguity = low confidence.
+- **Ancestor-sampling MC** — lineage is sampled stochastically; K forwards with different sampled ancestors → a μ
+  distribution → σ (MC-dropout-style, no retrain).
+- **Transitive product-propagated variance** — `V = Σ_links (1−μ)/μ` for multi-hop chains (built;
+  `DESIGN_transitive_relations.md`).
+Compare `|μ − μ_judge|` to ~2σ: within ⇒ consistent-given-uncertainty (undertrained, sample); outside ⇒ conflict
+(escalate).
+
+---
+
+## 7. Judges & escalation (Haiku is trusted except in the tail)
+
+- **Haiku = source of truth for high-μ values**; weak **only in the tail** (low-μ / no-relation / borderline,
+  measured ~80% noise *there*). So trust Haiku for positive/membership signal; treat its tail judgments as noisy.
+- **Disagreement ≠ tail.** A μ⇄Haiku gap is usually **undertraining** (sample), not Haiku error — use §6 confidence
+  to tell them apart.
+- **Escalation:** when a case *is* flagged tail (low μ + confident model + Haiku conflict, or high inter-judge
+  entropy), escalate to a **stronger model** (Sonnet, then Opus). Budget: Sonnet ≈ ¼ Haiku, Opus less; the project
+  has headroom (budgeted at 10% of the usage limit). Tag the judge (`JUDGES` in `mu_attention.py`).
+
+---
+
+## 8. Admin / maintenance categories (two tiers)
+
+- **Tier-1 (meaningless):** maintenance/template/nav (`CatAutoTOC`, `Navseasoncats`, …) — procedural titles, zero
+  topical content. **Drop** (eval + training). Trivially small (≈0.7% of training) and downward-from-content
+  rarely reaches them; the content-rooted DB excludes most.
+- **Tier-2 (loosely semantic):** structural/temporal `by-year/country/nationality`, `Establishments`. Real but
+  thin meaning. **Keep in eval; down-sample (not drop) in training.** (~22% of training — down-sampling frees real
+  capacity.) Filter helper: `eval_filing.is_admin(name, level="junk"|"all")`.
+
+---
+
+## 9. Tools index
+
+| tool | purpose |
+|---|---|
+| `scripts/ingest_enwiki_categories.py` | build the title-based category DB from the 3 dumps (extend for `cl_type=page`) |
+| `prototypes/mu_cosine/build_slice.py` | streaming BFS slice (downward + apex-capped bidirectional) from named seeds |
+| `prototypes/mu_cosine/fetch_category_pages.py` | live-API page `element_of` for targeted/leaf categories |
+| `prototypes/mu_cosine/build_graded_round.py` | fused subcategory/element_of edges → directional graded targets |
+| `prototypes/mu_cosine/gen_mu_pairs.py` | walk-based SYM candidate pairs (needs a scoring pass) |
+| `prototypes/mu_cosine/train_mu_attention.py` | train (`--init-from` warm-start, `--graded`, `--pairs`, `UW_MU_GRAPH`) |
+| `prototypes/mu_cosine/eval_filing.py` | membership eval (`--source simplewiki`, `--drop-admin`, `--holdout-nodes`) |
+
+*(Superseded: `prototypes/mu_cosine/sample_enwiki_downward.py` — a downward-only reimplementation of
+`build_slice.py`; prefer `build_slice.py`, which also does the safe bidirectional context.)*

--- a/prototypes/mu_cosine/DESIGN_wikipedia_sampling.md
+++ b/prototypes/mu_cosine/DESIGN_wikipedia_sampling.md
@@ -81,6 +81,21 @@ pairs — needs a scoring pass (μ column). Prefer the graded route for tagged c
 content stays in content (admin is reached going *up*); `0` = pure child-only. On a content-rooted/admin-flagged
 DB, bidirectional becomes safe (reaches siblings/cousins for lateral coverage).
 
+### Full training recipe (judge→loss routing) — ~70% directional + ≤30% lateral
+The validated recipe that makes μ **beat** a trained e5-probe on direction/close-neg (REPORT §4.6):
+- **~70% downward DIRECTIONAL (`graph` judge)** → **ranking** loss, *not* regression. 1-hop edges via
+  `build_graded_round` (`subcategory`/`element_of`, `μ(member|container)=0.90/rev 0.10`); multi-hop via
+  `transitive_closure.py` → `--transitive --transitive-hetero` (hop-aware variance, keeps hop distance). Train
+  with `train_mu_attention.py --graded <dir> --dir-rank-weight 1.0 --sym-weight 0` (drops the order-invariant SYM
+  pressure that competes with direction). **DONE + integrated.**
+- **≤30% bidirectional LATERAL (`haiku` judge)** → **soft regression** to a Haiku operator **superposition**
+  (siblings/cousins from `gen_mu_pairs --bidir`, scored by the §14 superposition prompt, fed via `--infer-blend`).
+  The judge token routes the loss (graph→rank, haiku→regress) — `--dir-rank-weight` already keys off `r[8]=="graph"`.
+  **REMAINING INPUT:** a Haiku-scoring pass over the bidirectional pairs (a *budgeted* spend) — the lateral
+  superposition data does not yet exist (`haiku_scored_tail.tsv` is the *no-relation tail*, ~80% noise, not the
+  lateral superpositions). Once generated, the training command is just `… --infer-blend <lateral> …` alongside
+  the directional flags; no code change (the routing is in place).
+
 ---
 
 ## 4. Page sampling — for leaf categories (`element_of ≈ subcategory`)

--- a/prototypes/mu_cosine/DESIGN_wikipedia_sampling.md
+++ b/prototypes/mu_cosine/DESIGN_wikipedia_sampling.md
@@ -89,12 +89,16 @@ The validated recipe that makes μ **beat** a trained e5-probe on direction/clos
   with `train_mu_attention.py --graded <dir> --dir-rank-weight 1.0 --sym-weight 0` (drops the order-invariant SYM
   pressure that competes with direction). **DONE + integrated.**
 - **≤30% bidirectional LATERAL (`haiku` judge)** → **soft regression** to a Haiku operator **superposition**
-  (siblings/cousins from `gen_mu_pairs --bidir`, scored by the §14 superposition prompt, fed via `--infer-blend`).
-  The judge token routes the loss (graph→rank, haiku→regress) — `--dir-rank-weight` already keys off `r[8]=="graph"`.
-  **REMAINING INPUT:** a Haiku-scoring pass over the bidirectional pairs (a *budgeted* spend) — the lateral
-  superposition data does not yet exist (`haiku_scored_tail.tsv` is the *no-relation tail*, ~80% noise, not the
-  lateral superpositions). Once generated, the training command is just `… --infer-blend <lateral> …` alongside
-  the directional flags; no code change (the routing is in place).
+  (siblings from the merged graph, scored by a Haiku judge on the §14 superposition prompt). The judge token
+  routes the loss (graph→rank, haiku→regress) — `--dir-rank-weight` keys off `r[8]=="graph"`; `haiku` rows fall to
+  the regression pool automatically. **DONE (proof-of-pipeline):** sampled sibling pairs → Haiku scored the
+  superpositions → appended as `judge=haiku` `SYM` graded rows → `train_mu_attention.py --graded <dir+lateral>
+  --dir-rank-weight 1.5 --graded-weight 0.3 --transitive … --sym-weight 0`. The graded round shows the routing
+  (`51,632 WIKI → rank`, `SYM haiku → regress`); the full recipe trains end-to-end and **close-neg beats the
+  e5-probe (0.80 vs 0.78)**, direction ~0.88 (vs the sole-objective standalone ceiling 0.982 — the multi-objective
+  recipe trades some peak direction for lateral relatedness + transitive + calibration in one model). Scaling the
+  lateral to a true ≤30% needs a larger Haiku batch (the pipeline is the same; this run used a 17-pair proof
+  batch).
 
 ---
 

--- a/prototypes/mu_cosine/REPORT_eval_methodology.md
+++ b/prototypes/mu_cosine/REPORT_eval_methodology.md
@@ -1,0 +1,209 @@
+# Evaluating μ-attention vs frozen e5 — methodology & results
+
+**Purpose.** A self-contained report of how we evaluate the **μ-attention** model and what we found, written for
+external methodology review. The central question: **μ sits *on top of* frozen e5 embeddings — what does the
+learned layer add over its own frozen substrate (raw e5 cosine)?** We answer it across retrieval, pair
+discrimination, directionality, calibration, and a data-scaling curve, and we are explicit about what *doesn't*
+work. (Branch: `claude/mu-coverage-dataquality`. Tools: `eval_filing.py`, `eval_relatedness.py`, `train_filing.py`.)
+
+---
+
+## 1. Model and baseline
+
+- **μ-attention** produces `μ(node | root) ∈ [0,1]` — a **directional, fuzzy** membership/relatedness degree over
+  a concept graph. It is a small permutation-invariant transformer over **frozen** e5-small-v2 embeddings (the
+  root uses e5's `query:` role, candidates/ancestors use `passage:`, which is what lets `μ(a|b) ≠ μ(b|a)`), read
+  out per **operator** (`SYM` lateral; `WIKI`/`ELEM` directional membership). Only the attention/readout/operator
+  params are trained; **e5 is frozen.** `mu-super` = equal-weight operator superposition; `mu-elem` = the
+  `element_of` operator alone.
+- **Baseline: `e5-cos`** = cosine of the frozen e5 vectors (`query:` node vs `passage:` root). Zero trained
+  parameters. Because μ is built *on* e5, e5-cos is the honest "does the learned layer earn its keep" baseline.
+- **Key asymmetry of the comparison:** e5 is **frozen** (fixed at pretraining — no in-domain data can improve
+  it); μ is the **trained** layer (data-scalable). So any improvement from in-domain data accrues to μ, not e5
+  (see §6).
+
+## 2. Datasets
+
+| dataset | role | scale |
+|---|---|---|
+| simplewiki 10k category graph (`category_parent.tsv`) | in-domain (model trained here) | 8,247 category nodes |
+| enwiki named category DB (`enwiki_named/category_parent.tsv`) | coverage source (downward slices) | 9.9M title-based edges |
+| Pearltrees bookmark filing (`.local`, gitignored) | OOD, **real human labels** (a bookmark's actual folder) | 7,486 bookmarks / 988 folders |
+
+## 3. Metrics (and why each)
+
+- **recall@k, MRR, median rank** — retrieval: is the true target in the top-k / how high. recall@10 + median are
+  the **operating point for a two-stage retrieve-then-LLM-rerank pipeline** (first stage needs the answer in the
+  shortlist; the LLM does precision@1).
+- **AUC(POS vs NEG)** — *threshold-free rank* separability of related vs unrelated pairs (Mann-Whitney).
+- **FPR @ fixed TPR** — *thresholding*: at a cutoff admitting X% of positives, what fraction of negatives leak
+  through. Tests whether a usable decision boundary exists (distinct from rank).
+- **Directional asymmetry** — `AUC(μ(member|container) > μ(container|member))` and `mean fwd − mean rev`. Tests
+  the one thing a symmetric metric structurally cannot do.
+- **Calibration / dynamic range** — the spread of scores across strata (mean POS vs HARD vs EASY). A *readable*
+  degree (`μ=0.2` ⇒ "barely a member") vs a compressed band that can't express "low."
+
+## 4. Results
+
+### 4.1 OOD filing (real labels) — zero-shot, then a data-scaling curve
+Rank candidate folders by score; ground truth = the bookmark's actual folder (335 folders ≥3 bookmarks, 500
+sampled queries).
+
+**Zero-shot** (`model_nodetype`, never trained on filing):
+
+| ranker | recall@1 | recall@10 | MRR |
+|---|---|---|---|
+| **e5-cos** | **0.202** | **0.480** | **0.299** |
+| mu-super | 0.088 | 0.248 | 0.151 |
+
+e5-cos **doubles** the μ model — but this is **OOD transfer** (μ trained on simplewiki categories, not bookmark
+filing), not a verdict on the architecture (see 4.2). 
+
+**Filing fine-tune learning curve** (`train_filing.py`; warm-start, in-batch contrastive `element_of`, **3
+training seeds, fixed eval split**, ✓ = mean−sd above the e5-cos bar 0.291):
+
+| data frac | n_train | MRR (mean±sd) | recall@10 | vs e5-cos |
+|---|---|---|---|---|
+| 0.10 | 492 | 0.230 ± 0.025 | 0.406 | −0.061 |
+| 0.30 | 1478 | 0.317 ± 0.006 | 0.537 | **+0.025 ✓** |
+| 1.00 | 4929 | 0.358 ± 0.018 | 0.573 | **+0.066 ✓** |
+
+μ **crosses the e5-cos bar between 10–30% of the data and keeps rising** (no plateau); at 100%, recall@10 0.573
+vs 0.440, median rank 6 vs 17. The cross survives seed noise (mean−sd clears the bar at 30% and 100%).
+
+### 4.2 In-domain "home turf" (isolates OOD by changing only the domain)
+Same task on the simplewiki category graph (folders = categories, members = children); **lineage-free**,
+apples-to-apples with filing.
+
+- **With admin categories present:** μ ties e5 on MRR (0.255 vs 0.270) but **beats it on recall@10 (0.494 vs
+  0.424) and median rank (11 vs 29)**.
+- **Node-holdout (never-trained nodes — kills the memorisation caveat):** near-identical to the trained run
+  (mu-super recall@10 0.482 vs 0.494; ~3% drop) ⇒ **generalisation, not memorisation.**
+- **Data quality (Tier-1 admin removal) inverts the picture** — see §5: dropping *meaningless* maintenance
+  categories (`CatAutoTOC`, `Navseasoncats`) lifts mu-super recall@10 to **0.81 vs e5 0.66** (and to **0.90 vs
+  0.63** on the cleanest set). On never-trained clean nodes: mu-super recall@10 **0.919 vs 0.662**.
+
+### 4.3 Symmetric pair discrimination (aligned with the model's training objective)
+The sampler trains on *within-subdomain pairs = related, noise = not*. Strata over 6 coarse domains, 800
+pairs/stratum: **POS** (same fine subdomain), **HARD-NEG** (different fine subdomain, same coarse), **EASY-NEG**
+(different coarse).
+
+| scorer | AUC(POS vs HARD) | AUC(POS vs EASY) | mean POS / HARD / EASY |
+|---|---|---|---|
+| e5-cos | **0.726** | 0.838 | 0.814 / 0.781 / 0.761 |
+| mu-super | 0.671 | 0.814 | **0.367 / 0.214 / 0.095** |
+
+**On rank-AUC, e5 is competitive-or-better.** But note the means: **e5 squashes all strata into a 0.05 band
+(0.76–0.81); μ has a 4× dynamic range (0.37/0.21/0.10)** — the calibration point (§5).
+
+**Negative-rejection (thresholding) — FPR at ~90% TPR:**
+
+| scorer | threshold | FPR HARD-NEG | FPR EASY-NEG |
+|---|---|---|---|
+| e5-cos | 0.759 | 71.6% | 51.8% |
+| mu-super | 0.024 | 74.4% | 57.6% |
+
+Neither thresholds cleanly at 90% recall (distributions overlap); μ is marginally worse. **A wide dynamic range
+≠ clean separability** — so calibration helps *readability* (§5), not hard thresholding at high recall.
+
+### 4.4 Directionality — μ's decisive, structural win
+For 1,500 membership edges: `μ(member|container)` (forward) should be high, `μ(container|member)` (reverse) low.
+
+| scorer | mean fwd | mean rev | asymmetry | AUC(fwd > rev) |
+|---|---|---|---|---|
+| **mu-elem** | 0.512 | 0.185 | **0.326** | **0.776** |
+| e5-cos | 0.838 | 0.837 | 0.001 | 0.509 |
+
+**e5-cos cannot tell which way membership points (AUC 0.509 — a coin flip);** μ gets it right 78% of the time.
+The `query:`/`passage:` prefix gives e5 essentially nothing (asymmetry 0.001). This is the property a symmetric
+metric *cannot* have.
+
+### 4.5 Close-negative discrimination — μ's advantage grows as negatives get closer
+The hardest negative is a **sibling** (another child of the same parent — same fine topic, *no* membership
+relation, often *more* e5-similar than the true parent). 2,000 (child, parent, sibling) triples.
+
+| negative type | e5-cos AUC | μ AUC |
+|---|---|---|
+| EASY (cross-domain) | 0.84 | 0.81 |
+| HARD (cross-fine-subdomain) | 0.73 | 0.68 |
+| **CLOSE (sibling, same parent)** | **0.62** | **0.73** |
+
+**e5 degrades sharply as negatives tighten and *loses* at the closest negatives; μ holds.** On siblings, e5 scores
+the true parent (0.832) and the sibling (0.815) within **0.017** — it cannot distinguish member-of from
+sibling-of. μ gives the sibling a **low degree (0.22)** vs the parent (0.48). Depth-stratified with a
+sibling-of-parent distractor, both degrade with depth and e5 stays ahead — so μ's win is about negative
+*closeness* (sibling), **not** tree depth. **Close neighbours are exactly what fill the top of a retrieval list**,
+so this is the practically decisive regime — and it is why μ won filing recall@10.
+
+## 5. The e5 calibration issue (central methodological point)
+
+e5-small cosine similarities live in a **compressed high band (~0.76–0.84)**: a true parent, a different-fine-
+subdomain category, and a *sibling* all score ~0.78–0.83. Consequences:
+- **e5 cannot express "low"** — there is no cosine value that reads as "not a member"; everything related-ish is
+  ~0.8. A sibling (0.815) is indistinguishable from the true parent (0.832).
+- **Rank-AUC hides this** — rank order can survive compression, so AUC makes e5 look fine (§4.3) even though it
+  can't *threshold* or *read off a degree*.
+- **The usable signal is the calibrated degree, not a threshold.** μ outputs `0.48` for a member and `0.22` for a
+  sibling — directly readable. (We deliberately report the *degree*, because the binary FPR@TPR is leaky for both:
+  μ's positive low-tail forces a ~0.001 cutoff at 90% TPR.)
+This is *why* a learned layer over frozen e5 is worth having: e5 supplies coarse topical similarity; it
+structurally cannot supply **direction** or a **calibrated low-end**.
+
+## 6. How more data improves the μ numbers (and not e5's)
+
+- **e5 is frozen** — no amount of in-domain data changes it. The baseline is at its ceiling *by construction*.
+- **μ is the trained layer** — the filing learning curve (§4.1) is direct evidence: MRR 0.230 → 0.317 → 0.358
+  across 10/30/100% of the data, **monotonic, still rising at 100% (no plateau)**. Extrapolating the slope, more
+  in-domain data continues to widen μ's margin over the fixed e5 bar.
+- **Coverage sharpens calibration.** A coverage round (enwiki linguistics/poli-sci/STS) did **not** raise rank-AUC
+  on those clean domains (e5 already ranks clean content well) but **sharpened μ's positive degree** there
+  (mean POS μ 0.40 → 0.51) — i.e. data improves the *calibration/directional* axis even where rank is saturated.
+- **Where data pays:** where e5 is *weak* — conflated domains, **close-neighbour disambiguation**, and
+  **direction** — not where e5 is already strong (coarse/clean topical separation). So data scaling should target
+  e5-weak regions (by disagreement), not "absent-but-clean" domains.
+
+## 7. What works / what doesn't
+
+**Works (μ's robust, repeatable wins):**
+- **Directionality** — AUC 0.78 vs e5's 0.51 coin-flip. Structural; e5 cannot do it.
+- **Close-negative (sibling) discrimination** — AUC 0.73 vs 0.62; the win *grows* as negatives get closer.
+- **Calibrated degrees** — 4× dynamic range; readable "low" that e5 lacks.
+- **Data scaling** — fine-tuning crosses the e5-cos bar on a real OOD task with modest data and keeps rising.
+
+**Doesn't (honest negatives):**
+- μ is **not** a better *symmetric rank* metric than e5 on easy/medium negatives (e5 AUC ≥ μ there).
+- μ's calibration does **not** give clean high-recall thresholding (FPR leaky; distributions overlap).
+- **Clean-domain coverage gave no rank gain** (e5 already strong on clean content).
+- Zero-shot OOD μ loses badly (it needs in-domain data).
+
+**Architecture implied:** a **hybrid** — e5 for cheap coarse symmetric ranking; **μ for direction + close-
+neighbour disambiguation + calibrated degree** (the practically decisive top-of-list cases). Not "μ replaces e5."
+
+## 8. Threats to validity / limitations (for the reviewer)
+
+- **Misaligned first eval.** Our initial filing eval ranks a member against *all folders* (a classification task
+  relative to roots) — it rewards exact title-match and favours e5; we treat the relatedness/directional/close-
+  negative evals as the aligned ones. (Documented as a correction, not hidden.)
+- **"Hard negative" wasn't hard enough** initially (cross-fine-subdomain). The sibling test (§4.5) is the genuine
+  close negative; conclusions changed once we used it — a caution about negative *closeness* in any such eval.
+- **Sample sizes / seeds.** Filing learning curve is 3-seed; most discrimination evals are single-run, n=400–2000
+  (e5-cos wobbled ±0.013 between runs at n=400). Directional/close-negative effects are large enough to clear that
+  noise, but rank-AUC differences of ~0.05 are within it.
+- **Real labels are noisy.** Pearltrees filing reflects one person's organisation; "the" correct folder is partly
+  arbitrary (a bookmark could fit several) — which itself argues for recall@k over recall@1.
+- **e5-small specifics.** The compression band and the (non-)Matryoshka structure are model-specific; a different
+  frozen encoder could shift the e5 baseline.
+- **Memorisation control.** The in-domain win is checked on a node-holdout (nodes in *neither* the SYM pairs nor
+  the graded edges), so it is generalisation; but the holdout is from the same graph distribution.
+
+## 9. Questions we'd like the reviewer to scrutinise
+
+1. Is the **directional AUC(fwd>rev)** the right way to credit the one thing e5 can't do, or is there a stronger
+   directional metric (e.g., a directional ranking / hierarchy-reconstruction task)?
+2. Is reporting the **calibrated degree** (mean μ per stratum) defensible given the FPR@TPR is leaky, or should we
+   report a calibration metric directly (ECE, a reliability diagram, d-prime)?
+3. For the **close-negative** result, is "sibling" the right hardest negative, and is the closeness *trend*
+   (easy→hard→sibling) the right way to show e5's degradation?
+4. Is the **data-scaling argument** (frozen-e5-ceiling vs trained-μ-headroom, plus the learning curve) sound, and
+   what would make the extrapolation rigorous (e.g., more fractions, a fitted curve + CI, a second OOD domain)?
+5. Is the **hybrid** conclusion the right read, or does the evidence support μ-alone for the directional use case?

--- a/prototypes/mu_cosine/REPORT_eval_methodology.md
+++ b/prototypes/mu_cosine/REPORT_eval_methodology.md
@@ -156,6 +156,24 @@ while μ is one *general* multi-relational model trained on a different (walk) o
 *architectural-superiority* claim, not the possibility that a single general calibrated estimator is *useful*
 (an untested systems argument, §7).
 
+**Follow-up — the gap was mostly the OBJECTIVE, not the architecture (resolves the caveat).** Root cause: μ's
+*dominant* training term (the SYM walk pairs) is **order-invariant** ("feed both orders, same μ") — it actively
+trains *symmetry*, competing with direction; direction was only a minority graded component. We retrained
+(`model_dir`) keeping the direction as the target (directional graded bulk + transitive multi-hop, **`--sym-weight
+0`** to drop the symmetric pressure), warm-started, and re-ran the control:
+
+| task | model_nodetype (symmetric-trained) | **model_dir (directional supervision)** | e5-probe |
+|---|---|---|---|
+| DIRECTION (fwd vs rev) | 0.776 | **0.839** | 0.919 |
+| CLOSE-NEG (parent vs sibling) | 0.738 | **0.779** (≈ probe; CIs overlap) | 0.787 |
+
+**μ now matches the probe on close-negatives and closed ~half the direction gap — from an *objective* change
+alone.** So μ's earlier 0.78 was **mostly a supervision artifact** (the symmetric-dominant objective), not an
+architectural limit; the architecture is competitive once direction is supervised. The **residual** direction gap
+(0.84 vs 0.92) is the last of the objective mismatch — μ still *regresses to fixed 0.90/0.10 targets* (caps
+separation) where the probe optimises a *discriminative* loss; a ranking/discriminative directional loss is the
+remaining lever. (Single-run, n=1200 held-out; gains exceed the ±0.018 CI.)
+
 ## 5. The e5 calibration issue (central methodological point)
 
 e5-small cosine similarities live in a **compressed high band (~0.76–0.84)**: a true parent, a different-fine-
@@ -195,12 +213,16 @@ structurally cannot supply **direction** or a **calibrated low-end**.
 - **Data scaling:** fine-tuning crossed the **e5-*cos*** bar — but that baseline is uncontrolled; an e5-*probe*
   curve is the needed comparison and is **not yet run**.
 
-**Net (honest):** against a *properly controlled* e5 baseline (a trained head on the frozen features, not raw
-cosine), **μ has not demonstrated a per-task accuracy advantage on any axis tested.** The only remaining candidate
-value is a *systems* argument — **one general, calibrated, multi-relational estimator** (all relations/directions/
-superposition/transitive in a single model) versus a per-(relation,direction) probe zoo — which is **untested**.
-That is the claim to either substantiate or drop; the "μ's structural win" / "hybrid because μ owns direction"
-framing is **withdrawn** pending it.
+**Net (honest, updated after the directional retrain §4.6):** the symmetric-trained checkpoint lost to a trained
+e5-probe — but that was **mostly the objective** (μ's dominant SYM term trains *symmetry*). With direction
+actually supervised (`model_dir`), **μ matches the probe on close-negatives and closes ~half the direction gap**,
+so the **architecture is competitive**, not inferior. μ still does not *beat* the probe on pure direction (0.84
+vs 0.92) — the residual is the regression-to-fixed-targets objective vs a discriminative loss. So: μ is a viable
+directional/membership estimator once supervised for it; whether it should *replace* a per-task e5-probe rests on
+the **systems** argument (one general calibrated multi-relational model vs a probe zoo) plus closing the residual
+with a discriminative directional loss. The earlier "μ owns direction structurally" overclaim stays withdrawn,
+but "μ can't beat a trained head" is now **too strong** — it matches on close-neg and the gap is shrinking with
+the right objective.
 
 ## 8. Threats to validity / limitations (for the reviewer)
 

--- a/prototypes/mu_cosine/REPORT_eval_methodology.md
+++ b/prototypes/mu_cosine/REPORT_eval_methodology.md
@@ -231,6 +231,16 @@ structurally cannot supply **direction** or a **readable low-end** (a wide, usab
 - **μ is the trained layer** — the filing learning curve (§4.1) is direct evidence: MRR 0.230 → 0.317 → 0.358
   across 10/30/100% of the data, **monotonic, still rising at 100% (no plateau)**. Extrapolating the slope, more
   in-domain data continues to widen μ's margin over the fixed e5 bar.
+- **e5-probe baseline for filing (review #5, `eval_filing_probe.py`):** a *trained* head on frozen e5 (logistic on
+  `concat(bm, folder, bm⊙folder)`, contrastive, same fractions/split) lands at **MRR ~0.06 — well below e5-cos
+  (0.291)**, flat across fractions. *Why (and the caveat):* filing is a 335-way ranking dominated by *topically
+  similar* hard confusions; a binary probe trained on *random* negatives never learns to separate those, while
+  e5-cos ranks by topical closeness natively. So unlike the **direction** task — where the signal is *per-slot*
+  (generality) and a linear probe is *strong* (0.92, §4.6) — for the **interaction/match** task of filing the
+  strong e5 baseline is **e5-cos itself**, and μ crosses it with data. (A hard-negative-tuned ranking probe is the
+  rigorous version; it would at best approach e5-cos, which μ already beats. The split between "probe strong on
+  per-slot tasks / weak on interaction tasks" is itself a clean result: μ wins by being *nonlinear* on the
+  interaction tasks and *better-supervised* on the per-slot ones.)
 - **Coverage sharpens calibration.** A coverage round (enwiki linguistics/poli-sci/STS) did **not** raise rank-AUC
   on those clean domains (e5 already ranks clean content well) but **sharpened μ's positive degree** there
   (mean POS μ 0.40 → 0.51) — i.e. data improves the *calibration/directional* axis even where rank is saturated.

--- a/prototypes/mu_cosine/REPORT_eval_methodology.md
+++ b/prototypes/mu_cosine/REPORT_eval_methodology.md
@@ -135,6 +135,27 @@ sibling-of-parent distractor, both degrade with depth and e5 stays ahead — so 
 *closeness* (sibling), **not** tree depth. **Close neighbours are exactly what fill the top of a retrieval list**,
 so this is the practically decisive regime — and it is why μ won filing recall@10.
 
+### 4.6 Architecture control (added per review #5) — the directional/close-neg wins are NOT μ-architectural
+`e5-cos` is the *product* baseline (untrained). The *architecture* control is a **trained head on the same frozen
+e5 features**: a logistic regression on the **ordered** pair `concat(query[a], passage[b])` (768-d), trained on a
+70% edge split, evaluated on the 30% held-out (`eval_arch_control.py`; sibling negatives DAG-filtered to drop
+ancestor/descendant "siblings"; bootstrap 95% CIs):
+
+| task | e5-cos (untrained, symmetric) | **e5-probe (trained head on frozen e5)** | mu-elem |
+|---|---|---|---|
+| DIRECTION (fwd vs rev) | 0.515 | **0.922** [0.911, 0.931] | 0.776 [0.758, 0.793] |
+| CLOSE-NEG (parent vs sibling) | 0.635 | **0.783** [0.765, 0.800] | 0.738 [0.718, 0.757] |
+
+**The control beats μ on both.** e5-cos can't do direction only because cosine *discards order*; the directional
+signal is present in e5's `query:`/`passage:` representations and a **linear order-aware head recovers it at 0.92
+— above μ's 0.78.** So **directionality and close-negative discrimination are NOT μ-architectural wins** — a
+trivial trained head on frozen e5 does them *better*. Against this properly-controlled baseline, **μ has not
+demonstrated a per-task advantage on any axis we tested**; the earlier "μ's structural win" framing compared μ to
+symmetric cosine, not to a trained head. Caveat: the probe is *task-specialised* (trained directly on each task),
+while μ is one *general* multi-relational model trained on a different (walk) objective — so this refutes the
+*architectural-superiority* claim, not the possibility that a single general calibrated estimator is *useful*
+(an untested systems argument, §7).
+
 ## 5. The e5 calibration issue (central methodological point)
 
 e5-small cosine similarities live in a **compressed high band (~0.76–0.84)**: a true parent, a different-fine-
@@ -164,20 +185,22 @@ structurally cannot supply **direction** or a **calibrated low-end**.
 
 ## 7. What works / what doesn't
 
-**Works (μ's robust, repeatable wins):**
-- **Directionality** — AUC 0.78 vs e5's 0.51 coin-flip. Structural; e5 cannot do it.
-- **Close-negative (sibling) discrimination** — AUC 0.73 vs 0.62; the win *grows* as negatives get closer.
-- **Calibrated degrees** — 4× dynamic range; readable "low" that e5 lacks.
-- **Data scaling** — fine-tuning crosses the e5-cos bar on a real OOD task with modest data and keeps rising.
+**Corrected by the architecture control (§4.6) — the earlier "μ wins" claims do NOT survive a trained-head baseline:**
+- **Directionality:** signal is in frozen e5; an order-aware **linear probe beats μ (0.92 vs 0.78)**. Not μ-architectural.
+- **Close-negative (sibling):** **probe beats μ (0.78 vs 0.74)**. Not μ-architectural.
+- **Symmetric rank:** e5 ≥ μ (was already a non-win).
+- **Calibrated degrees:** μ has 4× dynamic range, but that is *readability/separation*, not probabilistic
+  calibration, and does not give clean high-recall thresholding (FPR leaky). Rename pending (§5).
+- **Clean-domain coverage:** no rank gain (e5 already strong).
+- **Data scaling:** fine-tuning crossed the **e5-*cos*** bar — but that baseline is uncontrolled; an e5-*probe*
+  curve is the needed comparison and is **not yet run**.
 
-**Doesn't (honest negatives):**
-- μ is **not** a better *symmetric rank* metric than e5 on easy/medium negatives (e5 AUC ≥ μ there).
-- μ's calibration does **not** give clean high-recall thresholding (FPR leaky; distributions overlap).
-- **Clean-domain coverage gave no rank gain** (e5 already strong on clean content).
-- Zero-shot OOD μ loses badly (it needs in-domain data).
-
-**Architecture implied:** a **hybrid** — e5 for cheap coarse symmetric ranking; **μ for direction + close-
-neighbour disambiguation + calibrated degree** (the practically decisive top-of-list cases). Not "μ replaces e5."
+**Net (honest):** against a *properly controlled* e5 baseline (a trained head on the frozen features, not raw
+cosine), **μ has not demonstrated a per-task accuracy advantage on any axis tested.** The only remaining candidate
+value is a *systems* argument — **one general, calibrated, multi-relational estimator** (all relations/directions/
+superposition/transitive in a single model) versus a per-(relation,direction) probe zoo — which is **untested**.
+That is the claim to either substantiate or drop; the "μ's structural win" / "hybrid because μ owns direction"
+framing is **withdrawn** pending it.
 
 ## 8. Threats to validity / limitations (for the reviewer)
 

--- a/prototypes/mu_cosine/REPORT_eval_methodology.md
+++ b/prototypes/mu_cosine/REPORT_eval_methodology.md
@@ -60,7 +60,10 @@ e5-cos **doubles** the μ model — but this is **OOD transfer** (μ trained on 
 filing), not a verdict on the architecture (see 4.2). 
 
 **Filing fine-tune learning curve** (`train_filing.py`; warm-start, in-batch contrastive `element_of`, **3
-training seeds, fixed eval split**, ✓ = mean−sd above the e5-cos bar 0.291):
+training seeds, fixed eval split**, ✓ = mean−sd above the e5-cos bar 0.291). *Baseline note (per review #7):* the
+**0.291** bar here is e5-cos on this run's **fixed held-out bookmark split** (`train_filing.py`'s split); the
+**0.299** in §4.1 is e5-cos on the **separate 500-query zero-shot sample** (335 folders, admin included) — *different
+splits, not a moving target*; each μ number is compared only against the e5-cos measured on its **own** split:
 
 | data frac | n_train | MRR (mean±sd) | recall@10 | vs e5-cos |
 |---|---|---|---|---|
@@ -186,10 +189,29 @@ was edge-leakage — μ had trained on the eval edges; this is the fair redo):
 review's control was right (an *untrained-for-the-task* μ loses to a probe) but the cause was **entirely the
 objective**: symmetric-dominant training, then regression-to-constants. Fix the objective (keep direction, drop
 symmetric pressure, *rank* instead of *regress*) and μ's nonlinear architecture **exceeds** a linear probe — it
-was never the bottleneck. Caveats: node-overlap remains (node-disjoint split is the next rigor step); single-run
-(CIs tight/non-overlapping); `model_dir_disc` is the cumulative recipe (directional graded → discriminative).
+was never the bottleneck. `model_dir_disc` is the cumulative recipe (directional graded → discriminative).
 
-## 5. The e5 calibration issue (central methodological point)
+**Hardened — node-disjoint + multi-seed (`eval_arch_harden.py`, addresses review #4/rigor): the win holds.** The
+above shares *nodes* between train and test (only edges held out). The strict control holds out **30% of NODES**
+(neither μ nor the probe sees an eval node as a *task example*; frozen-e5/base-model pretraining exposure is
+symmetric), warm-starts `model_nodetype`, fine-tunes μ on train-node edges only, over **3 seeds**:
+
+| scorer | DIRECTION (mean±sd) | CLOSE-NEG (mean±sd) |
+|---|---|---|
+| e5-cos | 0.515 ± 0.009 | 0.612 ± 0.048 |
+| e5-probe | 0.920 ± 0.013 | 0.777 ± 0.015 |
+| **μ** | **0.961 ± 0.010** | **0.812 ± 0.008** |
+
+**μ beats the probe on both axes, every seed, with non-overlapping sds — under unseen nodes.** So the
+μ-exceeds-a-trained-e5-probe result is not a split artifact; it survives the strict node-disjoint, multi-seed
+control. (Node-disjoint AUC 0.961 < the edge-held-out 0.982 — generalising to wholly unseen nodes is harder — but
+still clearly above the probe's 0.920.)
+
+## 5. The e5 *dynamic-range* issue — range/separation, NOT probabilistic calibration (terminology, per review #3)
+**Terminology disclaimer:** throughout, "calibration" in earlier drafts meant **dynamic range / degree
+readability** (the spread of scores, mean-μ-per-stratum), **not** probabilistic calibration in the formal sense
+(reliability / ECE / Brier against empirical membership rates). We do **not** measure the latter here; that is a
+named follow-up (§9 Q2). Read every "calibration" below as "dynamic range / readable degree."
 
 e5-small cosine similarities live in a **compressed high band (~0.76–0.84)**: a true parent, a different-fine-
 subdomain category, and a *sibling* all score ~0.78–0.83. Consequences:
@@ -197,11 +219,11 @@ subdomain category, and a *sibling* all score ~0.78–0.83. Consequences:
   ~0.8. A sibling (0.815) is indistinguishable from the true parent (0.832).
 - **Rank-AUC hides this** — rank order can survive compression, so AUC makes e5 look fine (§4.3) even though it
   can't *threshold* or *read off a degree*.
-- **The usable signal is the calibrated degree, not a threshold.** μ outputs `0.48` for a member and `0.22` for a
-  sibling — directly readable. (We deliberately report the *degree*, because the binary FPR@TPR is leaky for both:
-  μ's positive low-tail forces a ~0.001 cutoff at 90% TPR.)
+- **The usable signal is the readable *degree*, not a threshold.** μ outputs `0.48` for a member and `0.22` for a
+  sibling — directly readable as a *range* (this is separation/readability, not a reliability claim). (We report
+  the degree because the binary FPR@TPR is leaky for both: μ's positive low-tail forces a ~0.001 cutoff at 90% TPR.)
 This is *why* a learned layer over frozen e5 is worth having: e5 supplies coarse topical similarity; it
-structurally cannot supply **direction** or a **calibrated low-end**.
+structurally cannot supply **direction** or a **readable low-end** (a wide, usable dynamic range).
 
 ## 6. How more data improves the μ numbers (and not e5's)
 
@@ -219,9 +241,12 @@ structurally cannot supply **direction** or a **calibrated low-end**.
 ## 7. What works / what doesn't
 
 **Corrected by the architecture control (§4.6) — the earlier "μ wins" claims do NOT survive a trained-head baseline:**
-- **Directionality:** signal is in frozen e5; an order-aware **linear probe beats μ (0.92 vs 0.78)**. Not μ-architectural.
-- **Close-negative (sibling):** **probe beats μ (0.78 vs 0.74)**. Not μ-architectural.
-- **Symmetric rank:** e5 ≥ μ (was already a non-win).
+- **Directionality:** the *symmetric-trained* μ lost to a linear probe (0.78 vs 0.92) — but that was the
+  *objective*; with directional + discriminative supervision **μ beats the probe (0.961 vs 0.920, node-disjoint
+  3-seed, §4.6).** μ-architectural after all.
+- **Close-negative (sibling):** same — symmetric-trained μ lost, discriminatively-trained **μ beats the probe
+  (0.812 vs 0.777, node-disjoint 3-seed).**
+- **Symmetric rank:** e5 ≥ μ (a genuine non-win — μ's edge is direction + close-neg + readable degree, not coarse rank).
 - **Calibrated degrees:** μ has 4× dynamic range, but that is *readability/separation*, not probabilistic
   calibration, and does not give clean high-recall thresholding (FPR leaky). Rename pending (§5).
 - **Clean-domain coverage:** no rank gain (e5 already strong).
@@ -232,10 +257,11 @@ structurally cannot supply **direction** or a **calibrated low-end**.
 but that was **entirely the objective** (symmetric-dominant training, then regression-to-constants), not the
 architecture. With the objective fixed — directional supervision + a **discriminative ranking loss** — **μ beats
 the trained-head-on-frozen-e5 probe on both direction (0.982 vs 0.930) and close-negatives (0.864 vs 0.790)**,
-held-out, with non-overlapping CIs. So μ's nonlinear architecture **does add value over a linear probe**, once
-trained for the task; the earlier loss was supervision, not capacity. The review's control was the right test and
-it drove the fix. Remaining rigor: a node-disjoint split and multi-seed to harden the win; and the systems
-argument (one general model vs a per-task probe zoo) is now *supported* rather than merely hypothesised.
+held-out, with non-overlapping CIs — **and it holds under a node-disjoint, 3-seed control (0.961 vs 0.920;
+0.812 vs 0.777, §4.6).** So μ's nonlinear architecture **does add value over a linear probe**, once trained for
+the task; the earlier loss was supervision, not capacity. The review's control was the right test and it drove
+the fix. The systems argument (one general model vs a per-task probe zoo) is now *supported* rather than merely
+hypothesised.
 
 ## 8. Threats to validity / limitations (for the reviewer)
 
@@ -253,6 +279,20 @@ argument (one general model vs a per-task probe zoo) is now *supported* rather t
   frozen encoder could shift the e5 baseline.
 - **Memorisation control.** The in-domain win is checked on a node-holdout (nodes in *neither* the SYM pairs nor
   the graded edges), so it is generalisation; but the holdout is from the same graph distribution.
+- **In-sample threshold for FPR@90%TPR.** The §4.3 negative-rejection threshold is picked on the same data it is
+  measured on (no validation split). Since the conclusion there is "neither thresholds cleanly / μ marginally
+  worse," the in-sample choice only *flatters* both equally; a validation-split threshold is the clean fix.
+- **Reproducibility (resolved).** The directional and sibling close-negative results, flagged in review #1/#2 as
+  not reproducible from committed tooling, are now produced by committed scripts with DAG sibling-filters and
+  bootstrap CIs (`eval_arch_control.py`) and a shared train/test split (`build_triples`); the directional loss is
+  in the main trainer (`--dir-rank-weight`). The architecture-control + node-disjoint multi-seed are
+  `eval_arch_control.py` / `eval_arch_harden.py`.
+- **Architecture control caveat (resolved).** e5-cos was a *product* baseline; the *architecture* control (a
+  trained head on frozen e5) is now run (§4.6) and μ beats it once trained for the task.
+- **Still open:** an e5-*probe* learning curve for §4.1 (the filing curve beat e5-*cos* only); probabilistic
+  calibration (ECE/reliability) is unmeasured (§5); the node-disjoint base model (`model_nodetype`) still saw the
+  held-out nodes during *its* pretraining (only the task-example supervision is held out — symmetric with e5's
+  pretraining, but not a from-scratch node-disjoint train).
 
 ## 9. Questions we'd like the reviewer to scrutinise
 

--- a/prototypes/mu_cosine/REPORT_eval_methodology.md
+++ b/prototypes/mu_cosine/REPORT_eval_methodology.md
@@ -169,10 +169,25 @@ trains *symmetry*, competing with direction; direction was only a minority grade
 
 **μ now matches the probe on close-negatives and closed ~half the direction gap — from an *objective* change
 alone.** So μ's earlier 0.78 was **mostly a supervision artifact** (the symmetric-dominant objective), not an
-architectural limit; the architecture is competitive once direction is supervised. The **residual** direction gap
-(0.84 vs 0.92) is the last of the objective mismatch — μ still *regresses to fixed 0.90/0.10 targets* (caps
-separation) where the probe optimises a *discriminative* loss; a ranking/discriminative directional loss is the
-remaining lever. (Single-run, n=1200 held-out; gains exceed the ±0.018 CI.)
+architectural limit. The **residual** gap was the last of the objective mismatch — μ still *regressed to fixed
+0.90/0.10 targets* (caps separation) where the probe optimises a *discriminative* loss.
+
+**Final step — discriminative directional loss (`train_dir_rank.py`): μ BEATS the probe.** Replaced the
+regression with a ranking CE `softplus(−s·(μ_fwd − μ_rev − m))` (+ light calibration anchor); fine-tuned on the
+**same 70% split** the probe trains on; evaluated on the **held-out 30% μ never saw** (the earlier inline 0.999
+was edge-leakage — μ had trained on the eval edges; this is the fair redo):
+
+| task | e5-cos | e5-probe | model_nodetype | model_dir | **model_dir_disc** |
+|---|---|---|---|---|---|
+| DIRECTION (fwd vs rev) | 0.511 | 0.930 [.919,.938] | 0.776 | 0.839 | **0.982** [.975,.988] |
+| CLOSE-NEG (parent vs sib) | 0.627 | 0.790 [.772,.807] | 0.738 | 0.779 | **0.864** [.849,.881] |
+
+**μ now beats the trained-head-on-frozen-e5 probe on both axes, held-out, with non-overlapping CIs.** So the
+review's control was right (an *untrained-for-the-task* μ loses to a probe) but the cause was **entirely the
+objective**: symmetric-dominant training, then regression-to-constants. Fix the objective (keep direction, drop
+symmetric pressure, *rank* instead of *regress*) and μ's nonlinear architecture **exceeds** a linear probe — it
+was never the bottleneck. Caveats: node-overlap remains (node-disjoint split is the next rigor step); single-run
+(CIs tight/non-overlapping); `model_dir_disc` is the cumulative recipe (directional graded → discriminative).
 
 ## 5. The e5 calibration issue (central methodological point)
 
@@ -213,16 +228,14 @@ structurally cannot supply **direction** or a **calibrated low-end**.
 - **Data scaling:** fine-tuning crossed the **e5-*cos*** bar — but that baseline is uncontrolled; an e5-*probe*
   curve is the needed comparison and is **not yet run**.
 
-**Net (honest, updated after the directional retrain §4.6):** the symmetric-trained checkpoint lost to a trained
-e5-probe — but that was **mostly the objective** (μ's dominant SYM term trains *symmetry*). With direction
-actually supervised (`model_dir`), **μ matches the probe on close-negatives and closes ~half the direction gap**,
-so the **architecture is competitive**, not inferior. μ still does not *beat* the probe on pure direction (0.84
-vs 0.92) — the residual is the regression-to-fixed-targets objective vs a discriminative loss. So: μ is a viable
-directional/membership estimator once supervised for it; whether it should *replace* a per-task e5-probe rests on
-the **systems** argument (one general calibrated multi-relational model vs a probe zoo) plus closing the residual
-with a discriminative directional loss. The earlier "μ owns direction structurally" overclaim stays withdrawn,
-but "μ can't beat a trained head" is now **too strong** — it matches on close-neg and the gap is shrinking with
-the right objective.
+**Net (final, after §4.6's full objective fix):** the symmetric-trained checkpoint lost to a trained e5-probe —
+but that was **entirely the objective** (symmetric-dominant training, then regression-to-constants), not the
+architecture. With the objective fixed — directional supervision + a **discriminative ranking loss** — **μ beats
+the trained-head-on-frozen-e5 probe on both direction (0.982 vs 0.930) and close-negatives (0.864 vs 0.790)**,
+held-out, with non-overlapping CIs. So μ's nonlinear architecture **does add value over a linear probe**, once
+trained for the task; the earlier loss was supervision, not capacity. The review's control was the right test and
+it drove the fix. Remaining rigor: a node-disjoint split and multi-seed to harden the win; and the systems
+argument (one general model vs a per-task probe zoo) is now *supported* rather than merely hypothesised.
 
 ## 8. Threats to validity / limitations (for the reviewer)
 

--- a/prototypes/mu_cosine/REPORT_eval_methodology.md
+++ b/prototypes/mu_cosine/REPORT_eval_methodology.md
@@ -185,16 +185,20 @@ was edge-leakage — μ had trained on the eval edges; this is the fair redo):
 | DIRECTION (fwd vs rev) | 0.511 | 0.930 [.919,.938] | 0.776 | 0.839 | **0.982** [.975,.988] |
 | CLOSE-NEG (parent vs sib) | 0.627 | 0.790 [.772,.807] | 0.738 | 0.779 | **0.864** [.849,.881] |
 
-**μ now beats the trained-head-on-frozen-e5 probe on both axes, held-out, with non-overlapping CIs.** So the
+**μ now beats the trained *linear* e5-probe on both axes, held-out, with non-overlapping CIs.** So the
 review's control was right (an *untrained-for-the-task* μ loses to a probe) but the cause was **entirely the
 objective**: symmetric-dominant training, then regression-to-constants. Fix the objective (keep direction, drop
-symmetric pressure, *rank* instead of *regress*) and μ's nonlinear architecture **exceeds** a linear probe — it
+symmetric pressure, *rank* instead of *regress*) and μ's nonlinear architecture **exceeds the linear e5-probe
+under the directional-rank objective** (capacity-matched nonlinear probe / LoRA / e5 fine-tune = future work) — it
 was never the bottleneck. `model_dir_disc` is the cumulative recipe (directional graded → discriminative).
 
 **Hardened — node-disjoint + multi-seed (`eval_arch_harden.py`, addresses review #4/rigor): the win holds.** The
-above shares *nodes* between train and test (only edges held out). The strict control holds out **30% of NODES**
-(neither μ nor the probe sees an eval node as a *task example*; frozen-e5/base-model pretraining exposure is
-symmetric), warm-starts `model_nodetype`, fine-tunes μ on train-node edges only, over **3 seeds**:
+above shares *nodes* between train and test (only edges held out). The strict control holds out **30% of NODES** so
+the comparison is **node-disjoint in the *task supervision*** (neither μ's fine-tune nor the probe sees an eval
+node as a *task example*). It is **not pretraining-disjoint**: μ warm-starts `model_nodetype` (which saw these
+nodes during *its* pretraining), while the probe starts from frozen e5 features (which saw them during e5
+pretraining) — so the asymmetry is bounded but real; a from-scratch node-disjoint train is the stricter follow-up.
+μ fine-tunes on train-node edges only, over **3 seeds**:
 
 | scorer | DIRECTION (mean±sd) | CLOSE-NEG (mean±sd) |
 |---|---|---|
@@ -260,17 +264,21 @@ structurally cannot supply **direction** or a **readable low-end** (a wide, usab
 - **Calibrated degrees:** μ has 4× dynamic range, but that is *readability/separation*, not probabilistic
   calibration, and does not give clean high-recall thresholding (FPR leaky). Rename pending (§5).
 - **Clean-domain coverage:** no rank gain (e5 already strong).
-- **Data scaling:** fine-tuning crossed the **e5-*cos*** bar — but that baseline is uncontrolled; an e5-*probe*
-  curve is the needed comparison and is **not yet run**.
+- **Data scaling:** fine-tuning crossed the **e5-*cos*** bar; the **e5-*probe* filing baseline IS run** (§6,
+  `eval_filing_probe.py`) — it lands at ~0.06 (filing is an interaction/match task a linear probe can't compute),
+  so **e5-cos is the strong e5 baseline for filing** and μ crosses it. (A hard-negative-tuned ranking probe is the
+  rigorous version; it would at best approach e5-cos.)
 
 **Net (final, after §4.6's full objective fix):** the symmetric-trained checkpoint lost to a trained e5-probe —
 but that was **entirely the objective** (symmetric-dominant training, then regression-to-constants), not the
 architecture. With the objective fixed — directional supervision + a **discriminative ranking loss** — **μ beats
-the trained-head-on-frozen-e5 probe on both direction (0.982 vs 0.930) and close-negatives (0.864 vs 0.790)**,
-held-out, with non-overlapping CIs — **and it holds under a node-disjoint, 3-seed control (0.961 vs 0.920;
-0.812 vs 0.777, §4.6).** So μ's nonlinear architecture **does add value over a linear probe**, once trained for
-the task; the earlier loss was supervision, not capacity. The review's control was the right test and it drove
-the fix. The systems argument (one general model vs a per-task probe zoo) is now *supported* rather than merely
+the trained *linear* e5-probe** on both direction (0.982 vs 0.930) and close-negatives (0.864 vs 0.790), held-out,
+non-overlapping CIs — **and it holds under a node-disjoint, 3-seed control (0.961 vs 0.920; 0.812 vs 0.777,
+§4.6).** **Scope:** the control is a *linear, order-aware* head on frozen e5; the claim is "μ beats a **linear**
+e5-probe **under the directional-rank objective**," *not* that all trained e5 adaptations are exhausted — a
+capacity-matched **nonlinear probe / LoRA / e5 fine-tune** remains future work. The earlier loss was supervision,
+not capacity. The review's control was the right test and it drove the fix. The systems argument (one general
+model vs a per-task probe zoo) is now *supported* rather than merely
 hypothesised.
 
 ## 8. Threats to validity / limitations (for the reviewer)
@@ -299,10 +307,14 @@ hypothesised.
   `eval_arch_control.py` / `eval_arch_harden.py`.
 - **Architecture control caveat (resolved).** e5-cos was a *product* baseline; the *architecture* control (a
   trained head on frozen e5) is now run (§4.6) and μ beats it once trained for the task.
-- **Still open:** an e5-*probe* learning curve for §4.1 (the filing curve beat e5-*cos* only); probabilistic
-  calibration (ECE/reliability) is unmeasured (§5); the node-disjoint base model (`model_nodetype`) still saw the
-  held-out nodes during *its* pretraining (only the task-example supervision is held out — symmetric with e5's
-  pretraining, but not a from-scratch node-disjoint train).
+- **Filing e5-probe (resolved, §6).** A trained linear/bilinear e5 head for filing lands at ~0.06 (far below
+  e5-cos 0.291) — filing is an interaction/match task a linear probe can't compute, so e5-cos is the filing bar
+  μ crosses. A hard-negative-tuned *ranking* probe is the rigorous version (would at best approach e5-cos).
+- **Still open:** probabilistic calibration (ECE/reliability) is unmeasured (§5); the node-disjoint control is
+  **task-supervision-disjoint, not pretraining-disjoint** (`model_nodetype` saw the held-out nodes in *its*
+  pretraining, the probe saw them in e5's — a from-scratch node-disjoint train is the stricter follow-up); the
+  architecture claim is scoped to a **linear** e5-probe (capacity-matched nonlinear/LoRA = future work); the
+  Haiku lateral layer is a 17-pair proof-of-pipeline, not a full-scale ≤30% result.
 
 ## 9. Questions we'd like the reviewer to scrutinise
 

--- a/prototypes/mu_cosine/eval_arch_control.py
+++ b/prototypes/mu_cosine/eval_arch_control.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""eval_arch_control.py — does μ's win come from its ARCHITECTURE, or just from training a head on frozen e5?
+
+Addresses the PR #3387 review (architecture-control + reproducibility + CIs + sibling false-negative filters):
+e5-cos is the *product* baseline (untrained); the *architecture* control is a **trained head on the same frozen
+e5 features**. If a trivial logistic probe on the ORDERED pair matches μ, then μ's directional/close-negative
+"structural win" is really "any trained head on e5" — not μ-specific. We compare three scorers on held-out edges:
+
+  e5-cos      : cosine(query: a, passage: b)            — untrained, symmetric (the product baseline)
+  e5-probe    : logistic on concat(q[a], p[b]) (768-d)  — trained head on FROZEN e5, ORDER-AWARE (the control)
+  mu-elem     : μ(a|b) under the element_of operator    — the model
+
+Two paired tasks, on a held-out edge split (probe trained only on the train split):
+  DIRECTION  : forward (child,parent) vs reverse (parent,child)  → AUC(fwd > rev)
+  CLOSE-NEG  : member (child,parent) vs sibling (child,sibling)  → AUC(parent > sibling)
+
+Sibling negatives are FILTERED (DAG false-negative guard): a sibling is rejected if it is an ancestor or
+descendant of the child (so it isn't a true relative via multi-inheritance/transitive paths). Bootstrap CIs on
+every AUC.
+
+  python3 eval_arch_control.py --ckpt model_nodetype.pt --graph /tmp/merged_category_parent.tsv
+"""
+import argparse, random, collections
+import torch
+from mu_attention import build_e5_tables, Tokenizer, OPS, load_dag
+from eval_relatedness import build_model
+
+
+def reachable_down(children, root, cap=20000):
+    seen, fr = set(), [root]
+    while fr and len(seen) < cap:
+        n = fr.pop()
+        for c in children.get(n, ()):
+            if c not in seen:
+                seen.add(c); fr.append(c)
+    return seen
+
+
+def auc(pos, neg):
+    pos = sorted(pos); import bisect
+    s = sum(bisect.bisect_left(pos, n) + 0.5 * (bisect.bisect_right(pos, n) - bisect.bisect_left(pos, n)) for n in neg)
+    return 1.0 - s / (len(pos) * len(neg))
+
+
+def boot_auc(pos, neg, rng, B=400):
+    import statistics as st
+    vals = []
+    for _ in range(B):
+        p = [rng.choice(pos) for _ in pos]; n = [rng.choice(neg) for _ in neg]
+        vals.append(auc(p, n))
+    vals.sort()
+    return auc(pos, neg), vals[int(0.025 * B)], vals[int(0.975 * B)]
+
+
+def train_logistic(X, y, dev, steps=400, lr=0.05):
+    X = torch.tensor(X, dtype=torch.float32, device=dev); y = torch.tensor(y, dtype=torch.float32, device=dev)
+    w = torch.zeros(X.shape[1], device=dev, requires_grad=True); b = torch.zeros(1, device=dev, requires_grad=True)
+    opt = torch.optim.Adam([w, b], lr=lr)
+    for _ in range(steps):
+        loss = torch.nn.functional.binary_cross_entropy_with_logits(X @ w + b, y) + 1e-3 * (w @ w)
+        opt.zero_grad(); loss.backward(); opt.step()
+    return w.detach(), b.detach()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ckpt", required=True); ap.add_argument("--graph", required=True)
+    ap.add_argument("--n-edges", type=int, default=4000); ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    ap.add_argument("--cache", default="/tmp/archctrl_e5.pt")
+    a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
+    parents, children, deg = load_dag(a.graph)
+
+    # membership edges + a FILTERED sibling per edge (reject ancestor/descendant siblings — DAG false-neg guard)
+    triples = []
+    for p, kids in children.items():
+        kids = [k for k in kids if k]
+        if len(kids) < 2:
+            continue
+        for c in kids:
+            desc_c = reachable_down(children, c, 4000)
+            cands = [s for s in kids if s != c and s not in desc_c and c not in reachable_down(children, s, 4000)]
+            if cands:
+                triples.append((c, p, rng.choice(cands)))
+    rng.shuffle(triples); triples = triples[:a.n_edges]
+    cut = int(0.7 * len(triples)); tr, te = triples[:cut], triples[cut:]
+    print(f"[DATA] {len(triples)} filtered (child,parent,sibling) triples — {len(tr)} train / {len(te)} held-out")
+
+    names = sorted({x for t in triples for x in t})
+    qt, pt, idx = build_e5_tables(names, cache_path=a.cache, texts={n: n.replace('_', ' ') for n in names}, device=a.device)
+    feat = lambda a_, b_: torch.cat([qt[idx[a_]], pt[idx[b_]]]).tolist()       # ordered-pair e5 feature (768-d)
+
+    model = build_model(a.ckpt, dev); n_ops = model.op_emb.weight.shape[0]
+    elem = torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["ELEM"]]), 1.0)
+    tok = Tokenizer(qt, pt, idx, parents={}, deg={})
+
+    @torch.no_grad()
+    def mu(prs):
+        out = []
+        for i in range(0, len(prs), 512):
+            ch = prs[i:i+512]; bd = tok.build([(x, y, 0) for x, y in ch], train=False)
+            bd = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in bd.items()}
+            out += model(**bd, op_weights=elem.expand(len(ch), n_ops).to(dev)).cpu().tolist()
+        return out
+    e5cos = lambda prs: [(qt[idx[x]] * pt[idx[y]]).sum().item() for x, y in prs]
+
+    for task, pos_pairs, neg_pairs in [
+        ("DIRECTION (fwd vs rev)", [(c, p) for c, p, s in te], [(p, c) for c, p, s in te]),
+        ("CLOSE-NEG (parent vs sibling)", [(c, p) for c, p, s in te], [(c, s) for c, p, s in te])]:
+        # train the e5-probe on the TRAIN split for this task
+        if "DIRECTION" in task:
+            Xtr = [feat(c, p) for c, p, s in tr] + [feat(p, c) for c, p, s in tr]
+        else:
+            Xtr = [feat(c, p) for c, p, s in tr] + [feat(c, s) for c, p, s in tr]
+        ytr = [1.0] * len(tr) + [0.0] * len(tr)
+        w, b = train_logistic(Xtr, ytr, dev)
+        probe = lambda prs: (torch.tensor([feat(x, y) for x, y in prs], device=dev) @ w + b).cpu().tolist()
+        print(f"\n=== {task} ===  (held-out n={len(pos_pairs)})")
+        print(f"  {'scorer':10} {'AUC':>6}  {'95% CI':>16}")
+        for nm, fn in [("e5-cos", e5cos), ("e5-probe", probe), ("mu-elem", mu)]:
+            au, lo, hi = boot_auc(fn(pos_pairs), fn(neg_pairs), rng)
+            print(f"  {nm:10} {au:6.3f}  [{lo:.3f}, {hi:.3f}]")
+    print("\n  read: if e5-probe ≈ mu-elem, the win is 'trained head on e5' (generic); if mu-elem > e5-probe, it's μ's architecture.")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/eval_arch_control.py
+++ b/prototypes/mu_cosine/eval_arch_control.py
@@ -36,6 +36,25 @@ def reachable_down(children, root, cap=20000):
     return seen
 
 
+def build_triples(parents, children, n_edges, seed):
+    """Deterministic (child, parent, DAG-filtered sibling) triples, split 70/30. Shared by the eval and the
+    directional fine-tune so μ trains on the SAME 70% the probe does and both eval on the held-out 30% (no leak)."""
+    rng = random.Random(seed)
+    triples = []
+    for p, kids in children.items():
+        kids = [k for k in kids if k]
+        if len(kids) < 2:
+            continue
+        for c in kids:
+            desc_c = reachable_down(children, c, 4000)
+            cands = [s for s in kids if s != c and s not in desc_c and c not in reachable_down(children, s, 4000)]
+            if cands:
+                triples.append((c, p, rng.choice(cands)))
+    rng.shuffle(triples); triples = triples[:n_edges]
+    cut = int(0.7 * len(triples))
+    return triples[:cut], triples[cut:]
+
+
 def auc(pos, neg):
     pos = sorted(pos); import bisect
     s = sum(bisect.bisect_left(pos, n) + 0.5 * (bisect.bisect_right(pos, n) - bisect.bisect_left(pos, n)) for n in neg)
@@ -72,18 +91,8 @@ def main():
     parents, children, deg = load_dag(a.graph)
 
     # membership edges + a FILTERED sibling per edge (reject ancestor/descendant siblings — DAG false-neg guard)
-    triples = []
-    for p, kids in children.items():
-        kids = [k for k in kids if k]
-        if len(kids) < 2:
-            continue
-        for c in kids:
-            desc_c = reachable_down(children, c, 4000)
-            cands = [s for s in kids if s != c and s not in desc_c and c not in reachable_down(children, s, 4000)]
-            if cands:
-                triples.append((c, p, rng.choice(cands)))
-    rng.shuffle(triples); triples = triples[:a.n_edges]
-    cut = int(0.7 * len(triples)); tr, te = triples[:cut], triples[cut:]
+    tr, te = build_triples(parents, children, a.n_edges, a.seed)
+    triples = tr + te
     print(f"[DATA] {len(triples)} filtered (child,parent,sibling) triples — {len(tr)} train / {len(te)} held-out")
 
     names = sorted({x for t in triples for x in t})

--- a/prototypes/mu_cosine/eval_arch_control.py
+++ b/prototypes/mu_cosine/eval_arch_control.py
@@ -36,10 +36,16 @@ def reachable_down(children, root, cap=20000):
     return seen
 
 
-def build_triples(parents, children, n_edges, seed):
-    """Deterministic (child, parent, DAG-filtered sibling) triples, split 70/30. Shared by the eval and the
-    directional fine-tune so μ trains on the SAME 70% the probe does and both eval on the held-out 30% (no leak)."""
+def build_triples(parents, children, n_edges, seed, node_disjoint=False):
+    """Deterministic (child, parent, DAG-filtered sibling) triples, split train/test. Shared by the eval and the
+    directional fine-tune so μ trains on the SAME train split the probe does and both eval on the held-out test.
+    node_disjoint=True: hold out ~30% of NODES; train triples have all endpoints in the train-node set, test
+    triples all in the held-out-node set — so neither μ nor the probe ever saw an eval node (the strict control)."""
     rng = random.Random(seed)
+    held = None
+    if node_disjoint:
+        nodes = sorted(set(parents) | set(children))
+        held = set(random.Random(seed * 7 + 1).sample(nodes, int(0.30 * len(nodes))))
     triples = []
     for p, kids in children.items():
         kids = [k for k in kids if k]
@@ -50,7 +56,12 @@ def build_triples(parents, children, n_edges, seed):
             cands = [s for s in kids if s != c and s not in desc_c and c not in reachable_down(children, s, 4000)]
             if cands:
                 triples.append((c, p, rng.choice(cands)))
-    rng.shuffle(triples); triples = triples[:n_edges]
+    rng.shuffle(triples)
+    if node_disjoint:
+        tr = [t for t in triples if all(x not in held for x in t)][:int(0.7 * n_edges)]
+        te = [t for t in triples if all(x in held for x in t)][:int(0.3 * n_edges)]
+        return tr, te
+    triples = triples[:n_edges]
     cut = int(0.7 * len(triples))
     return triples[:cut], triples[cut:]
 

--- a/prototypes/mu_cosine/eval_arch_harden.py
+++ b/prototypes/mu_cosine/eval_arch_harden.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Node-disjoint, multi-seed hardening of the μ-vs-e5-probe comparison (PR #3387 rigor).
+
+Per seed: hold out 30% of NODES; fine-tune μ (directional ranking loss) on train-node edges only; train the
+e5-probe on the same; eval μ / e5-probe / e5-cos on held-out-NODE edges — neither μ nor the probe saw these
+nodes as *task examples* (frozen-e5 / base-model pretraining exposure is symmetric). Reports mean±sd across seeds.
+
+  python3 eval_arch_harden.py --ckpt model_nodetype.pt --graph /tmp/merged_category_parent.tsv --seeds 1,2,3
+"""
+import argparse, random, statistics as st
+import torch, torch.nn.functional as F
+from mu_attention import build_e5_tables, Tokenizer, OPS, load_dag
+from eval_arch_control import build_triples, build_model, auc, train_logistic
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ckpt", required=True); ap.add_argument("--graph", required=True)
+    ap.add_argument("--seeds", default="1,2,3"); ap.add_argument("--n-edges", type=int, default=5000)
+    ap.add_argument("--steps", type=int, default=400); ap.add_argument("--bs", type=int, default=256)
+    ap.add_argument("--lr", type=float, default=2e-4); ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    a = ap.parse_args(); dev = torch.device(a.device)
+    parents, children, deg = load_dag(a.graph)
+    seeds = [int(s) for s in a.seeds.split(",")]
+    acc = {k: {"dir": [], "cn": []} for k in ("e5-cos", "e5-probe", "mu")}
+
+    for seed in seeds:
+        rng = random.Random(seed)
+        tr, te = build_triples(parents, children, a.n_edges, seed, node_disjoint=True)
+        names = sorted({x for t in tr + te for x in t})
+        qt, pt, idx = build_e5_tables(names, cache_path=f"/tmp/harden_{seed}.pt",
+                                      texts={n: n.replace('_', ' ') for n in names}, device=a.device)
+        tok = Tokenizer(qt, pt, idx, parents={}, deg={})
+        model = build_model(a.ckpt, dev); model.train()
+        n_ops = model.op_emb.weight.shape[0]
+        elem = torch.zeros(1, n_ops, device=dev).index_fill_(1, torch.tensor([OPS["ELEM"]], device=dev), 1.0)
+        opt = torch.optim.AdamW(model.parameters(), lr=a.lr, weight_decay=1e-4)
+
+        def mu(prs):
+            out = []
+            for i in range(0, len(prs), 512):
+                ch = prs[i:i+512]; b = tok.build([(x, y, 0) for x, y in ch], train=False)
+                b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+                out += model(**b, op_weights=elem.expand(len(ch), n_ops)).detach().cpu().tolist()
+            return out
+
+        edges = [(c, p) for c, p, s in tr]
+        for _ in range(a.steps):                                   # fine-tune μ: rank μ(fwd) > μ(rev) on TRAIN nodes
+            batch = [rng.choice(edges) for _ in range(a.bs)]
+            def mug(prs):
+                b = tok.build([(x, y, 0) for x, y in prs], train=False)
+                b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+                return model(**b, op_weights=elem.expand(len(prs), n_ops))
+            f = mug([(c, p) for c, p in batch]); r = mug([(p, c) for c, p in batch])
+            loss = F.softplus(-10.0 * (f - r - 0.1)).mean() + 0.2 * (F.mse_loss(f, torch.full_like(f, 0.9)) + F.mse_loss(r, torch.full_like(r, 0.1)))
+            opt.zero_grad(); loss.backward(); opt.step()
+        model.eval()
+
+        feat = lambda x, y: torch.cat([qt[idx[x]], pt[idx[y]]]).tolist()
+        e5cos = lambda prs: [(qt[idx[x]] * pt[idx[y]]).sum().item() for x, y in prs]
+        for task, pos, neg in [("dir", [(c, p) for c, p, s in te], [(p, c) for c, p, s in te]),
+                               ("cn",  [(c, p) for c, p, s in te], [(c, s) for c, p, s in te])]:
+            # e5-probe trained on TRAIN nodes for this task
+            if task == "dir":
+                Xtr = [feat(c, p) for c, p, s in tr] + [feat(p, c) for c, p, s in tr]
+            else:
+                Xtr = [feat(c, p) for c, p, s in tr] + [feat(c, s) for c, p, s in tr]
+            w, b = train_logistic(Xtr, [1.0] * len(tr) + [0.0] * len(tr), dev)
+            probe = lambda prs: (torch.tensor([feat(x, y) for x, y in prs], device=dev) @ w + b).cpu().tolist()
+            acc["e5-cos"][task].append(auc(e5cos(pos), e5cos(neg)))
+            acc["e5-probe"][task].append(auc(probe(pos), probe(neg)))
+            acc["mu"][task].append(auc(mu(pos), mu(neg)))
+        print(f"  seed {seed}: |tr|={len(tr)} |te|={len(te)}  "
+              f"dir μ={acc['mu']['dir'][-1]:.3f}/probe={acc['e5-probe']['dir'][-1]:.3f}  "
+              f"cn μ={acc['mu']['cn'][-1]:.3f}/probe={acc['e5-probe']['cn'][-1]:.3f}")
+
+    m = lambda L: (st.mean(L), st.stdev(L) if len(L) > 1 else 0.0)
+    print(f"\n[NODE-DISJOINT, {len(seeds)} seeds]  mean ± sd")
+    print(f"  {'scorer':9} {'DIRECTION':>16} {'CLOSE-NEG':>16}")
+    for k in ("e5-cos", "e5-probe", "mu"):
+        d, c = m(acc[k]["dir"]), m(acc[k]["cn"])
+        print(f"  {k:9} {d[0]:.3f} ± {d[1]:.3f}    {c[0]:.3f} ± {c[1]:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -25,17 +25,24 @@ from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS, load_dag,
 
 
 import re
-# Wikipedia admin / maintenance / navigation / structural-intersection categories — titles carry NO topical
-# meaning, so neither e5-cos nor μ can rank them (no training data fixes a meaningless label). Drop with --drop-admin.
-_ADMIN = re.compile(r"catautotoc|navseasoncats|navbox|wikipedia|^articles?[ _]|^pages?[ _]|^categor|"
-                    r"[ _]stubs?\b|templates?|redirects?|hidden|tracking|maintenance|disambiguation|"
-                    r"by[ _]nationality|by[ _]country|by[ _]year|by[ _]decade|by[ _]century|by[ _]date|by[ _]state|"
-                    r"establishments|disestablishments|introductions|^years[ _]of|^decades|^centuries", re.I)
-def is_admin(name):
-    return bool(_ADMIN.search(name.replace("_", " ")))
+# TIER 1 — truly meaningless: maintenance / template / navigation categories whose TITLE is procedural noise
+# (zero topical content). Neither e5-cos nor μ can rank them; no training data fixes a meaningless label. Always
+# safe to drop (pure noise removal).
+_JUNK = re.compile(r"catautotoc|navseasoncats|navbox|wikipedia|^articles?[ _]|^pages?[ _]|^categor|"
+                   r"[ _]stubs?\b|templates?|redirects?|hidden|tracking|maintenance|disambiguation", re.I)
+# TIER 2 — loosely semantic: structural / temporal / by-X groupings (years, places, nationalities). These DO
+# carry meaning (just lower semantic density), so dropping them makes the eval EASIER on valid-but-hard targets.
+# Keep by default; down-SAMPLE (not drop) in training. Drop only with --drop-structural (to decompose the gain).
+_STRUCTURAL = re.compile(r"by[ _]nationality|by[ _]country|by[ _]year|by[ _]decade|by[ _]century|by[ _]date|"
+                         r"by[ _]state|establishments|disestablishments|introductions|^years[ _]of|^decades|"
+                         r"^centuries", re.I)
+def is_admin(name, level="junk"):
+    """level='junk' → Tier-1 only (meaningless); level='all' → Tier-1 + Tier-2 (also loosely-semantic structural)."""
+    n = name.replace("_", " ")
+    return bool(_JUNK.search(n) or (level == "all" and _STRUCTURAL.search(n)))
 
 
-def load_membership(graph_path, min_bm, holdout=None, drop_admin=False):
+def load_membership(graph_path, min_bm, holdout=None, drop_admin=None):
     """IN-DOMAIN home-turf analog of filing: the simplewiki category DAG. A 'folder' = a category; its
     'bookmarks' = its child nodes. Same (member → container) shape as filing, but in the model's TRAINED
     region. Returns (queries=[(child_title, parent_id)], cand={parent_id: parent_title}).
@@ -45,7 +52,7 @@ def load_membership(graph_path, min_bm, holdout=None, drop_admin=False):
     caveat: ranking never-seen nodes vs e5-cos is pure generalisation."""
     parents, children, deg = load_dag(graph_path)
     disp = lambda s: s.replace("_", " ")
-    ok = (lambda n: not is_admin(n)) if drop_admin else (lambda n: True)
+    ok = (lambda n: not is_admin(n, drop_admin)) if drop_admin else (lambda n: True)
     cand = {par: disp(par) for par, kids in children.items() if len(kids) >= min_bm and ok(par)}
     queries = [(disp(c), par) for par in cand for c in children[par]
                if ok(c) and (holdout is None or c in holdout)]
@@ -112,8 +119,9 @@ def main():
     ap.add_argument("--graph", default=GRAPH, help="category_parent.tsv (simplewiki source)")
     ap.add_argument("--holdout-nodes", default=None, help="JSON list of RAW node names never seen in training; "
                     "restricts simplewiki queries to these (node-holdout: pure generalisation, no retrain)")
-    ap.add_argument("--drop-admin", action="store_true", help="drop Wikipedia admin/maintenance/navigation "
-                    "categories (meaningless titles) from folders+members (simplewiki source)")
+    ap.add_argument("--drop-admin", nargs="?", const="junk", default=None, choices=("junk", "all"),
+                    help="drop categories: 'junk' = Tier-1 meaningless only (maintenance/template); "
+                         "'all' = also Tier-2 loosely-semantic structural (by-year/country/…). Default off.")
     ap.add_argument("--min-bm", type=int, default=3, help="min bookmarks for a folder to be a candidate")
     ap.add_argument("--max-queries", type=int, default=500)
     ap.add_argument("--seed", type=int, default=7)

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -173,7 +173,7 @@ def main():
                         n_judge=sz("judge_emb.weight", 2), n_nodetype=sz("nodetype_emb.weight", 4)).to(dev)
     missing, unexpected = model.load_state_dict(sd, strict=False)
     assert not unexpected, f"unexpected keys: {unexpected}"
-    assert all("account" in k for k in missing), f"unexpected missing keys: {missing}"
+    assert all(("account" in k or "prefix" in k) for k in missing), f"unexpected missing keys: {missing}"
     model.eval()
     print(f"[MODEL] {os.path.basename(a.ckpt)}  {cfg}  (n_ops={model.op_emb.weight.shape[0]})")
 

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -24,7 +24,18 @@ import torch
 from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS, load_dag, GRAPH
 
 
-def load_membership(graph_path, min_bm, holdout=None):
+import re
+# Wikipedia admin / maintenance / navigation / structural-intersection categories — titles carry NO topical
+# meaning, so neither e5-cos nor μ can rank them (no training data fixes a meaningless label). Drop with --drop-admin.
+_ADMIN = re.compile(r"catautotoc|navseasoncats|navbox|wikipedia|^articles?[ _]|^pages?[ _]|^categor|"
+                    r"[ _]stubs?\b|templates?|redirects?|hidden|tracking|maintenance|disambiguation|"
+                    r"by[ _]nationality|by[ _]country|by[ _]year|by[ _]decade|by[ _]century|by[ _]date|by[ _]state|"
+                    r"establishments|disestablishments|introductions|^years[ _]of|^decades|^centuries", re.I)
+def is_admin(name):
+    return bool(_ADMIN.search(name.replace("_", " ")))
+
+
+def load_membership(graph_path, min_bm, holdout=None, drop_admin=False):
     """IN-DOMAIN home-turf analog of filing: the simplewiki category DAG. A 'folder' = a category; its
     'bookmarks' = its child nodes. Same (member → container) shape as filing, but in the model's TRAINED
     region. Returns (queries=[(child_title, parent_id)], cand={parent_id: parent_title}).
@@ -34,9 +45,10 @@ def load_membership(graph_path, min_bm, holdout=None):
     caveat: ranking never-seen nodes vs e5-cos is pure generalisation."""
     parents, children, deg = load_dag(graph_path)
     disp = lambda s: s.replace("_", " ")
-    cand = {par: disp(par) for par, kids in children.items() if len(kids) >= min_bm}
+    ok = (lambda n: not is_admin(n)) if drop_admin else (lambda n: True)
+    cand = {par: disp(par) for par, kids in children.items() if len(kids) >= min_bm and ok(par)}
     queries = [(disp(c), par) for par in cand for c in children[par]
-               if holdout is None or c in holdout]
+               if ok(c) and (holdout is None or c in holdout)]
     return queries, cand
 
 
@@ -100,6 +112,8 @@ def main():
     ap.add_argument("--graph", default=GRAPH, help="category_parent.tsv (simplewiki source)")
     ap.add_argument("--holdout-nodes", default=None, help="JSON list of RAW node names never seen in training; "
                     "restricts simplewiki queries to these (node-holdout: pure generalisation, no retrain)")
+    ap.add_argument("--drop-admin", action="store_true", help="drop Wikipedia admin/maintenance/navigation "
+                    "categories (meaningless titles) from folders+members (simplewiki source)")
     ap.add_argument("--min-bm", type=int, default=3, help="min bookmarks for a folder to be a candidate")
     ap.add_argument("--max-queries", type=int, default=500)
     ap.add_argument("--seed", type=int, default=7)
@@ -114,7 +128,7 @@ def main():
         held = set(json.load(open(a.holdout_nodes))) if a.holdout_nodes else None
         if held is not None:
             print(f"[HOLDOUT] restricting queries to {len(held)} never-trained nodes")
-        queries, cand = load_membership(a.graph, a.min_bm, holdout=held)
+        queries, cand = load_membership(a.graph, a.min_bm, holdout=held, drop_admin=a.drop_admin)
     else:
         assert a.trees, "--trees required for --source pearltrees"
         queries, cand = load_filing(a.trees, a.min_bm)

--- a/prototypes/mu_cosine/eval_filing_probe.py
+++ b/prototypes/mu_cosine/eval_filing_probe.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""e5-probe baseline for the filing learning curve (PR #3387 review #5).
+
+The filing curve (train_filing.py) showed μ crossing e5-*cos*. The review asked for the *architecture* control —
+a TRAINED head on frozen e5 — at each data fraction, so the data-scaling claim isn't μ vs an untrained score.
+Here: at each fraction, train a logistic probe on `concat(query: bookmark, passage: folder)` with contrastive
+negatives, on the same train bookmarks, eval MRR on the SAME fixed held-out set (mirrors train_filing's split).
+Print alongside the known μ curve (0.230/0.317/0.358) and the flat e5-cos bar (0.291).
+
+  python3 eval_filing_probe.py --trees ../../.local/data/pearltrees_api/trees --fracs 0.1,0.3,1.0
+"""
+import argparse, collections, random
+import torch
+from mu_attention import build_e5_tables
+from eval_filing import load_filing, metrics
+from eval_arch_control import train_logistic
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--trees", required=True); ap.add_argument("--min-bm", type=int, default=3)
+    ap.add_argument("--fracs", default="0.1,0.3,1.0"); ap.add_argument("--eval-frac", type=float, default=0.3)
+    ap.add_argument("--max-eval", type=int, default=400); ap.add_argument("--neg", type=int, default=8)
+    ap.add_argument("--seed", type=int, default=7); ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    ap.add_argument("--cache", default="/tmp/filingprobe_e5.pt")
+    a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
+
+    queries, cand = load_filing(a.trees, a.min_bm)
+    byf = collections.defaultdict(list)
+    for q in queries:
+        byf[q[1]].append(q)
+    eval_q, pool = [], []
+    for fid, qs in byf.items():
+        qs = qs[:]; rng.shuffle(qs)
+        k = max(1, int(a.eval_frac * len(qs))) if len(qs) >= 2 else 0
+        eval_q += qs[:k]; pool += qs[k:]
+    rng.shuffle(eval_q); eval_q = eval_q[:a.max_eval]
+
+    bm_list = eval_q + pool
+    f_ids = list(cand)
+    names = [f"F:{t}" for t in f_ids] + [f"B:{i}" for i in range(len(bm_list))]
+    texts = {**{f"F:{t}": cand[t] for t in cand}, **{f"B:{i}": bm_list[i][0] for i in range(len(bm_list))}}
+    qt, pt, idx = build_e5_tables(names, cache_path=a.cache, texts=texts, device=a.device)
+    qF = pt[[idx[f"F:{t}"] for t in f_ids]]                              # folders as passage (the container slot)
+    f_pos = {t: i for i, t in enumerate(f_ids)}
+    eval_keys = list(range(len(eval_q))); train_pool = list(range(len(eval_q), len(bm_list)))
+    eval_true = [f_pos[bm_list[i][1]] for i in eval_keys]
+
+    def feat(bm_i, folder_row):                                          # concat + ELEMENT-WISE PRODUCT so the
+        b_, f_ = qt[idx[f"B:{bm_i}"]], qF[folder_row]                    # linear head can compute a bilinear
+        return torch.cat([b_, f_, b_ * f_]).tolist()                     # (≈ cosine) match — fair filing baseline
+
+    print(f"[DATA] {len(f_ids)} folders, {len(train_pool)} train-pool, {len(eval_q)} fixed eval")
+    print(f"\n  reference: e5-cos bar 0.291 (flat); μ curve 0.10→0.230  0.30→0.317  1.00→0.358\n")
+    print(f"  {'frac':>6} {'n_train':>8} {'e5-probe MRR':>13} {'recall@10':>10}")
+    for fr in [float(x) for x in a.fracs.split(",")]:
+        n = min(max(64, int(fr * len(train_pool))), len(train_pool))
+        sub = random.Random(a.seed + 1).sample(train_pool, n)
+        X, y = [], []
+        for bi in sub:                                                   # 1 positive + K contrastive negatives
+            tf = f_pos[bm_list[bi][1]]
+            X.append(feat(bi, tf)); y.append(1.0)
+            for nf in random.Random(bi).sample(range(len(f_ids)), a.neg + 1):
+                if nf != tf:
+                    X.append(feat(bi, nf)); y.append(0.0)
+        w, b = train_logistic(X, y, dev, steps=500)
+        # eval: score every (eval bm, folder), rank the true folder
+        ranks = []
+        for r, bi in enumerate(eval_keys):
+            Xe = torch.tensor([feat(bi, j) for j in range(len(f_ids))], device=dev)
+            sc = (Xe @ w + b).cpu()
+            ranks.append(1 + int((sc > sc[eval_true[r]]).sum().item()))
+        m = metrics(ranks)
+        print(f"  {fr:6.2f} {n:8d} {m['MRR']:13.3f} {m['recall@10']:10.3f}")
+    print("\n  → compare the e5-probe curve to μ's: does a trained e5 head also cross 0.291, and is μ above it?")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/eval_prefix_ablation.py
+++ b/prototypes/mu_cosine/eval_prefix_ablation.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Prefix ablation (PR #3387 / architecture study): does directional membership need e5's query:/passage:
+prefix, or is the signal in the RAW embedding (the per-node generality axis)?
+
+Trains an order-aware logistic probe on directional edges two ways and compares held-out direction AUC:
+  prefixed   : concat(e5[query: a], e5[passage: b])   — the role-prefix geometry (what μ uses today)
+  no-prefix  : concat(e5[a],         e5[b])            — same plain embedding for both slots, no role prefix
+
+If no-prefix ≈ prefixed, the directional signal is in the raw embedding (generality), and the prefix is optional;
+if no-prefix collapses toward 0.5, the prefix is the carrier. Node-disjoint split (eval_arch_control.build_triples).
+
+  python3 eval_prefix_ablation.py --graph /tmp/merged_category_parent.tsv
+"""
+import argparse, torch
+from sentence_transformers import SentenceTransformer
+from mu_attention import load_dag, E5_MODEL
+from eval_arch_control import build_triples, train_logistic, auc
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--graph", required=True); ap.add_argument("--n-edges", type=int, default=3000)
+    ap.add_argument("--seed", type=int, default=1); ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    a = ap.parse_args(); dev = torch.device(a.device)
+    parents, children, deg = load_dag(a.graph)
+    tr, te = build_triples(parents, children, a.n_edges, a.seed, node_disjoint=True)
+    names = sorted({x for t in tr + te for x in t})
+    txt = {n: n.replace('_', ' ') for n in names}
+    m = SentenceTransformer(E5_MODEL, device=a.device)
+    enc = lambda pre: dict(zip(names, m.encode([f"{pre}{txt[n]}" for n in names], normalize_embeddings=True, show_progress_bar=False)))
+    q, p, e = enc("query: "), enc("passage: "), enc("")     # prefixed query/passage, and no-prefix plain
+    import numpy as np
+    fp = lambda a_, b_: np.concatenate([q[a_], p[b_]]).tolist()    # prefixed ordered feature
+    fn = lambda a_, b_: np.concatenate([e[a_], e[b_]]).tolist()    # no-prefix ordered feature
+    cosp = lambda prs: [float(np.dot(q[x], p[y])) for x, y in prs]
+    cosn = lambda prs: [float(np.dot(e[x], e[y])) for x, y in prs]
+    pos, neg = [(c, pp) for c, pp, s in te], [(pp, c) for c, pp, s in te]   # forward vs reverse (DIRECTION)
+    print(f"[DATA] node-disjoint: {len(tr)} train / {len(te)} held-out edges\n")
+    print(f"{'feature':18} {'DIRECTION AUC (held-out)':>24}")
+    for nm, feat, cos in [("e5-cos prefixed", None, cosp), ("e5-cos no-prefix", None, cosn),
+                          ("probe prefixed", fp, None), ("probe no-prefix", fn, None)]:
+        if cos:
+            print(f"{nm:18} {auc(cos(pos), cos(neg)):24.3f}")
+        else:
+            X = [feat(c, pp) for c, pp, s in tr] + [feat(pp, c) for c, pp, s in tr]
+            w, b = train_logistic(X, [1.0] * len(tr) + [0.0] * len(tr), dev)
+            sc = lambda prs: (torch.tensor([feat(x, y) for x, y in prs], device=dev) @ w + b).cpu().tolist()
+            print(f"{nm:18} {auc(sc(pos), sc(neg)):24.3f}")
+    print("\n  read: probe no-prefix ≈ prefixed ⇒ direction lives in the RAW embedding (generality), prefix optional.")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/eval_relatedness.py
+++ b/prototypes/mu_cosine/eval_relatedness.py
@@ -135,14 +135,25 @@ def main():
                     "mu-sym": score_pairs(model, tok, idx, prs, sym, dev),
                     "mu-super": score_pairs(model, tok, idx, prs, sup, dev)}
 
-    print(f"\n{'scorer':9} {'AUC(POS vs HARD-NEG)':>22} {'AUC(POS vs EASY-NEG)':>22}   mean μ POS/HARD/EASY")
+    mean = lambda L: sum(L) / len(L)
+    print(f"\n{'scorer':9} {'AUC(P vs HARD)':>14} {'AUC(P vs EASY)':>14}   {'mean P/HARD/EASY':>20}")
     for scorer in ("e5-cos", "mu-sym", "mu-super"):
         ah = auc(sc["POS"][scorer], sc["HARD-NEG"][scorer], rng)
         ae = auc(sc["POS"][scorer], sc["EASY-NEG"][scorer], rng)
-        mean = lambda L: sum(L)/len(L)
-        print(f"{scorer:9} {ah:22.3f} {ae:22.3f}   "
+        print(f"{scorer:9} {ah:14.3f} {ae:14.3f}   "
               f"{mean(sc['POS'][scorer]):.3f}/{mean(sc['HARD-NEG'][scorer]):.3f}/{mean(sc['EASY-NEG'][scorer]):.3f}")
-    print("\n  headline = AUC(POS vs HARD-NEG): fine subdomain discrimination (the e5-weak regime).")
+
+    # NEGATIVE-REJECTION at a fixed operating point: threshold = 10th-percentile of POS (≈90% TPR); report the
+    # fraction of negatives that still pass (FPR). e5's compressed band ⇒ can't set a cutoff that rejects negs.
+    print(f"\n  Negative rejection — FPR at ~90% positive-recall (lower = better; tests THRESHOLDING, not rank):")
+    print(f"  {'scorer':9} {'threshold':>10} {'FPR HARD-NEG':>13} {'FPR EASY-NEG':>13}")
+    for scorer in ("e5-cos", "mu-sym", "mu-super"):
+        ps = sorted(sc["POS"][scorer]); thr = ps[max(0, int(0.10 * len(ps)))]   # admit ~90% of positives
+        fpr_h = sum(s >= thr for s in sc["HARD-NEG"][scorer]) / len(sc["HARD-NEG"][scorer])
+        fpr_e = sum(s >= thr for s in sc["EASY-NEG"][scorer]) / len(sc["EASY-NEG"][scorer])
+        print(f"  {scorer:9} {thr:10.3f} {fpr_h:13.2%} {fpr_e:13.2%}")
+    print("\n  headline: AUC = rank (e5's turf); FPR@90%TPR = can you THRESHOLD to reject negatives (μ's turf —"
+          " e5's compressed cosine band can't).")
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/eval_relatedness.py
+++ b/prototypes/mu_cosine/eval_relatedness.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""eval_relatedness.py — the ALIGNED eval: within-vs-cross subdomain pair discrimination.
+
+eval_filing measures μ(member|exact-parent) ranked against ALL folders — a classification task relative to
+roots that rewards exact-title-match (favours e5-cos, understates μ; a member is related to its whole subdomain,
+not just its one parent). This eval matches what the SAMPLER trains on (within-subdomain pairs = related, noise =
+not) and isolates the regime where e5 should be WEAK and μ strong: **same coarse domain, different fine
+subdomain** (e5 sees "all physics-ish"; μ trained on subdomain walks should separate fine structure).
+
+Strata (pairs (x,y) from the merged category graph):
+  POS       — x,y descend from the SAME fine subdomain (a direct child of a coarse root)  → should be HIGH μ
+  HARD-NEG  — x,y in DIFFERENT fine subdomains of the SAME coarse root                     → the e5-weak regime
+  EASY-NEG  — x,y in DIFFERENT coarse roots                                                → both should reject
+
+Reports AUC(POS vs HARD-NEG) and AUC(POS vs EASY-NEG) for e5-cos, mu-sym, mu-super. The headline is
+AUC(POS vs HARD-NEG): does μ beat e5-cos at FINE subdomain discrimination?
+
+  python3 eval_relatedness.py --ckpt model_nodetype.pt --graph /tmp/merged_category_parent.tsv \
+      --coarse Physics,Mathematics,Chemistry,Linguistics,Political_science
+"""
+import argparse, collections, random
+import torch
+from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS, load_dag
+
+
+def build_model(ckpt, dev):
+    ck = torch.load(ckpt, weights_only=False); sd = ck["state"]; cfg = ck.get("cfg", {"d_model":384,"heads":4,"layers":3})
+    sz = lambda k, d: sd[k].shape[0] if k in sd else d
+    m = MuAttention(d_model=cfg["d_model"], n_heads=cfg["heads"], n_layers=cfg["layers"],
+                    n_ops=sz("op_emb.weight", len(OPS)), n_corpus=sz("corpus_emb.weight", 2),
+                    n_judge=sz("judge_emb.weight", 2), n_nodetype=sz("nodetype_emb.weight", 4)).to(dev)
+    miss, unexp = m.load_state_dict(sd, strict=False); assert not unexp and all("account" in k for k in miss)
+    m.eval(); return m
+
+
+def descendants(children, root, cap=400, max_depth=4):
+    seen, frontier = set(), [root]
+    for _ in range(max_depth):
+        nxt = []
+        for n in frontier:
+            for c in children.get(n, ()):
+                if c not in seen:
+                    seen.add(c); nxt.append(c)
+                    if len(seen) >= cap:
+                        return seen
+        frontier = nxt
+    return seen
+
+
+def auc(pos, neg, rng, n=200000):
+    """P(pos_score > neg_score) via random sampling — Mann-Whitney AUC."""
+    if not pos or not neg:
+        return float("nan")
+    w = 0
+    for _ in range(n):
+        a, b = rng.choice(pos), rng.choice(neg)
+        w += 1 if a > b else (0.5 if a == b else 0)
+    return w / n
+
+
+@torch.no_grad()
+def score_pairs(model, tok, idx, pairs, ow, dev, batch=512):
+    items = [(a, b, 0) for a, b in pairs]
+    out = []
+    for i in range(0, len(items), batch):
+        ch = items[i:i+batch]
+        bd = tok.build(ch, train=False); bd = {k:(v.to(dev) if torch.is_tensor(v) else v) for k,v in bd.items()}
+        out += model(**bd, op_weights=ow.expand(len(ch), ow.shape[1]).to(dev)).cpu().tolist()
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--coarse", required=True, help="comma-sep coarse-domain roots (underscored)")
+    ap.add_argument("--n-pairs", type=int, default=800, help="pairs per stratum")
+    ap.add_argument("--cap", type=int, default=300, help="descendants kept per fine subdomain")
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    ap.add_argument("--cache", default="/tmp/relatedness_e5.pt")
+    ap.add_argument("--seed", type=int, default=7)
+    a = ap.parse_args()
+    dev = torch.device(a.device); rng = random.Random(a.seed)
+    parents, children, deg = load_dag(a.graph)
+    coarse = [c.strip() for c in a.coarse.split(",") if c.strip()]
+
+    # fine subdomains = direct children of each coarse root that actually have descendants
+    fine = {}   # coarse -> {fine_subdomain: [descendant nodes incl. itself]}
+    for cz in coarse:
+        fs = {}
+        for f in children.get(cz, ()):
+            d = descendants(children, f, a.cap); d.add(f)
+            if len(d) >= 3:
+                fs[f] = sorted(d)
+        if len(fs) >= 2:
+            fine[cz] = fs
+    coarse = [c for c in coarse if c in fine]
+    print(f"[DATA] coarse domains usable: {coarse}")
+    for cz in coarse:
+        print(f"  {cz}: {len(fine[cz])} fine subdomains, {sum(len(v) for v in fine[cz].values())} nodes")
+
+    def pick(pool):
+        return rng.choice(pool)
+
+    pos, hardneg, easyneg = [], [], []
+    for _ in range(a.n_pairs):
+        cz = pick(coarse); fs = fine[cz]; fkeys = list(fs)
+        f = pick(fkeys); pool = fs[f]
+        if len(pool) >= 2:
+            x, y = rng.sample(pool, 2); pos.append((x, y))
+        f1, f2 = rng.sample(fkeys, 2) if len(fkeys) >= 2 else (fkeys[0], fkeys[0])
+        hardneg.append((pick(fs[f1]), pick(fs[f2])))
+        if len(coarse) >= 2:
+            c1, c2 = rng.sample(coarse, 2)
+            easyneg.append((pick(fine[c1][pick(list(fine[c1]))]), pick(fine[c2][pick(list(fine[c2]))])))
+    strata = {"POS": pos, "HARD-NEG": hardneg, "EASY-NEG": easyneg}
+
+    # e5 + model over all involved nodes
+    names = sorted({n for s in strata.values() for p in s for n in p})
+    disp = {n: n.replace("_", " ") for n in names}
+    qt, pt, idx = build_e5_tables(names, cache_path=a.cache, texts=disp, device=a.device)
+    tok = Tokenizer(qt, pt, idx, parents={}, deg={})
+    model = build_model(a.ckpt, dev)
+    n_ops = model.op_emb.weight.shape[0]
+    sym = torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["SYM"]]), 1.0)
+    sup = torch.full((1, n_ops), 1.0 / n_ops)
+
+    # scores per stratum: e5-cos (symmetric), mu-sym, mu-super (μ(x|y))
+    def e5cos(prs):
+        qn = qt[[idx[x] for x, _ in prs]]; pn = pt[[idx[y] for _, y in prs]]
+        return (qn * pn).sum(-1).tolist()
+    sc = {}
+    for name, prs in strata.items():
+        sc[name] = {"e5-cos": e5cos(prs),
+                    "mu-sym": score_pairs(model, tok, idx, prs, sym, dev),
+                    "mu-super": score_pairs(model, tok, idx, prs, sup, dev)}
+
+    print(f"\n{'scorer':9} {'AUC(POS vs HARD-NEG)':>22} {'AUC(POS vs EASY-NEG)':>22}   mean μ POS/HARD/EASY")
+    for scorer in ("e5-cos", "mu-sym", "mu-super"):
+        ah = auc(sc["POS"][scorer], sc["HARD-NEG"][scorer], rng)
+        ae = auc(sc["POS"][scorer], sc["EASY-NEG"][scorer], rng)
+        mean = lambda L: sum(L)/len(L)
+        print(f"{scorer:9} {ah:22.3f} {ae:22.3f}   "
+              f"{mean(sc['POS'][scorer]):.3f}/{mean(sc['HARD-NEG'][scorer]):.3f}/{mean(sc['EASY-NEG'][scorer]):.3f}")
+    print("\n  headline = AUC(POS vs HARD-NEG): fine subdomain discrimination (the e5-weak regime).")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/eval_relatedness.py
+++ b/prototypes/mu_cosine/eval_relatedness.py
@@ -29,7 +29,7 @@ def build_model(ckpt, dev):
     m = MuAttention(d_model=cfg["d_model"], n_heads=cfg["heads"], n_layers=cfg["layers"],
                     n_ops=sz("op_emb.weight", len(OPS)), n_corpus=sz("corpus_emb.weight", 2),
                     n_judge=sz("judge_emb.weight", 2), n_nodetype=sz("nodetype_emb.weight", 4)).to(dev)
-    miss, unexp = m.load_state_dict(sd, strict=False); assert not unexp and all("account" in k for k in miss)
+    miss, unexp = m.load_state_dict(sd, strict=False); assert not unexp and all(("account" in k or "prefix" in k) for k in miss)
     m.eval(); return m
 
 

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -248,6 +248,7 @@ class Tokenizer:
         judge_of = torch.full((B, T), -1, dtype=torch.long)
         account_of = torch.full((B, T), -1, dtype=torch.long)             # 2nd provenance axis (account)
         nodetype_of = torch.full((B, T), -1, dtype=torch.long)            # per-endpoint structural role
+        prefix_of = torch.full((B, T), -1, dtype=torch.long)              # e5 prefix regime (0 query:/1 passage:/2 none)
         pad = torch.ones(B, T, dtype=torch.bool)                          # True = pad (ignored)
         op_of = torch.tensor([it[2] for it in items], dtype=torch.long)
 
@@ -259,16 +260,19 @@ class Tokenizer:
                 elif kind == "anchor":
                     content[bi, ti] = self.q[self.idx[name]]
                     is_anchor[bi, ti] = True
+                    prefix_of[bi, ti] = 0                                 # e5 query: regime
                     if has_nt[bi]:
                         nodetype_of[bi, ti] = rtypes[bi]                  # the root's type
                 elif kind == "node":
                     content[bi, ti] = self.p[self.idx[name]]
                     gen_id[bi, ti] = 0
+                    prefix_of[bi, ti] = 1                                 # e5 passage: regime
                     if has_nt[bi]:
                         nodetype_of[bi, ti] = ntypes[bi]                  # the candidate node's type
                 elif kind == "anc":
                     content[bi, ti] = self.p[self.idx[name]]
                     gen_id[bi, ti] = d
+                    prefix_of[bi, ti] = 1                                 # e5 passage: regime
                     if has_nt[bi]:
                         nodetype_of[bi, ti] = NODETYPE["category"]        # ancestors are categories
                 elif kind == "prov":
@@ -290,7 +294,8 @@ class Tokenizer:
                         gen_id[bi, ti] = d
         return {"content": content, "gen_id": gen_id, "is_anchor": is_anchor, "op_pos": op_pos,
                 "is_prov": is_prov, "corpus_of": corpus_of, "judge_of": judge_of,
-                "account_of": account_of, "nodetype_of": nodetype_of, "op_of": op_of, "pad": pad}
+                "account_of": account_of, "nodetype_of": nodetype_of, "prefix_of": prefix_of,
+                "op_of": op_of, "pad": pad}
 
 
 # --------------------------------------------------------------------------------------------------
@@ -306,6 +311,10 @@ class MuAttention(nn.Module):
         # NODE-TYPE: per-endpoint structural-role token (category/page/mindmap/pearltrees). Zero-init so it
         # is a no-op at warm start (category=0 default) and the type signal is learned during fine-tuning.
         self.nodetype_emb = nn.Embedding(n_nodetype, d_model)
+        # e5 PREFIX REGIME token (0 query: / 1 passage: / 2 none): lets the model know whether an input embedding
+        # carries e5's role prefix, so it can handle mixed/ablated regimes. Zero-init ⇒ no-op until used (direction
+        # survives with OR without the prefix — eval_prefix_ablation.py — so this is safe to add).
+        self.prefix_emb = nn.Embedding(3, d_model)
         self.gen_emb = nn.Embedding(max_gen + 1, d_model)                 # gen 0..max_gen
         self.anchor_tag = nn.Parameter(torch.randn(d_model) * 0.02)
         # PROVENANCE (PART B): factored corpus_emb + judge_emb on a single maskable token. `prov_tag`
@@ -326,11 +335,12 @@ class MuAttention(nn.Module):
         for emb in (self.op_emb, self.gen_emb, self.corpus_emb, self.judge_emb):
             nn.init.normal_(emb.weight, std=0.02)
         nn.init.zeros_(self.nodetype_emb.weight)            # no-op at warm start; learned during fine-tune
+        nn.init.zeros_(self.prefix_emb.weight)              # no-op until mixed prefix regimes are used
         nn.init.zeros_(self.account_emb.weight)             # no-op until items carry an account id
 
     def forward(self, content, gen_id, is_anchor, op_pos, op_of, pad,
                 is_prov=None, corpus_of=None, judge_of=None, account_of=None, nodetype_of=None,
-                op_weights=None):
+                prefix_of=None, op_weights=None):
         # op_weights [B, n_ops] (optional): a BLENDED operator — a weight vector over operators that replaces
         # the one-hot op token AND the per-operator readout head (a random superposition for inferred rows;
         # a one-hot for tagged rows reproduces the indexed path exactly). See
@@ -341,6 +351,8 @@ class MuAttention(nn.Module):
         emb = emb + self.anchor_tag * is_anchor.unsqueeze(-1)
         if nodetype_of is not None:                          # per-endpoint structural role
             emb = emb + self.nodetype_emb(nodetype_of.clamp(min=0)) * (nodetype_of >= 0).unsqueeze(-1)
+        if prefix_of is not None:                            # e5 prefix regime (query:/passage:/none); zero-init no-op
+            emb = emb + self.prefix_emb(prefix_of.clamp(min=0)) * (prefix_of >= 0).unsqueeze(-1)
         omask = (op_pos >= 0).unsqueeze(-1)
         if op_weights is None:
             emb = emb + self.op_emb(op_pos.clamp(min=0)) * omask                     # indexed (one-hot) op token

--- a/prototypes/mu_cosine/train_dir_rank.py
+++ b/prototypes/mu_cosine/train_dir_rank.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""train_dir_rank.py — discriminative (ranking) directional fine-tune.
+
+Closes the residual direction gap (μ 0.84 vs e5-probe 0.92). μ's directional supervision is *regression* to
+fixed 0.90/0.10 targets, which caps the forward-vs-reverse separation. This fine-tune instead optimizes the
+**comparison** directly — the same ranking-CE form as the transitive constraint:
+
+    L_rank = softplus( -s * ( μ(child|parent) - μ(parent|child) - margin ) )      # reward fwd > rev by a margin
+
+plus a light calibration anchor (keep μ readable, not just separable):
+
+    L_anchor = w * ( MSE(μ_fwd, 0.9) + MSE(μ_rev, 0.1) )
+
+Warm-starts model_dir.pt (the directionally-supervised model), lineage-free to match eval_arch_control.
+
+  python3 train_dir_rank.py --ckpt model_dir.pt --graph /tmp/merged_category_parent.tsv --save model_dir_disc.pt
+"""
+import argparse, random
+import torch
+import torch.nn.functional as F
+from mu_attention import build_e5_tables, Tokenizer, OPS, load_dag
+from eval_relatedness import build_model
+from eval_arch_control import build_triples
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ckpt", required=True); ap.add_argument("--graph", required=True)
+    ap.add_argument("--save", required=True)
+    ap.add_argument("--steps", type=int, default=600); ap.add_argument("--bs", type=int, default=256)
+    ap.add_argument("--lr", type=float, default=2e-4); ap.add_argument("--scale", type=float, default=10.0)
+    ap.add_argument("--margin", type=float, default=0.1); ap.add_argument("--anchor-w", type=float, default=0.2)
+    ap.add_argument("--seed", type=int, default=7); ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    ap.add_argument("--cache", default="/tmp/dirrank_e5.pt")
+    ap.add_argument("--n-edges", type=int, default=4000, help="must match eval_arch_control to share the split")
+    a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
+
+    # train ONLY on the 70% split that eval_arch_control trains its probe on; held-out 30% is never seen (no leak)
+    parents, children, deg = load_dag(a.graph)
+    tr, te = build_triples(parents, children, a.n_edges, a.seed)
+    edges = [(c, p) for c, p, s in tr]                          # (child=member, parent=container)
+    print(f"[DATA] fine-tuning on {len(edges)} TRAIN edges (held-out {len(te)} never seen)")
+    names = sorted({x for e in (edges + [(c, p) for c, p, s in te]) for x in e})
+    qt, pt, idx = build_e5_tables(names, cache_path=a.cache, texts={n: n.replace('_', ' ') for n in names}, device=a.device)
+    tok = Tokenizer(qt, pt, idx, parents={}, deg={})           # lineage-free (matches eval)
+    model = build_model(a.ckpt, dev); model.train()
+    n_ops = model.op_emb.weight.shape[0]
+    elem = torch.zeros(1, n_ops, device=dev).index_fill_(1, torch.tensor([OPS["ELEM"]], device=dev), 1.0)
+    opt = torch.optim.AdamW(model.parameters(), lr=a.lr, weight_decay=1e-4)
+
+    def mu(prs):
+        b = tok.build([(x, y, 0) for x, y in prs], train=False)
+        b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+        return model(**b, op_weights=elem.expand(len(prs), n_ops))
+
+    for step in range(a.steps):
+        batch = [rng.choice(edges) for _ in range(a.bs)]
+        fwd = mu([(c, p) for c, p in batch])                   # μ(member|container) — want HIGH
+        rev = mu([(p, c) for c, p in batch])                   # μ(container|member) — want LOW
+        L_rank = F.softplus(-a.scale * (fwd - rev - a.margin)).mean()
+        L_anchor = a.anchor_w * (F.mse_loss(fwd, torch.full_like(fwd, 0.9)) + F.mse_loss(rev, torch.full_like(rev, 0.1)))
+        loss = L_rank + L_anchor
+        opt.zero_grad(); loss.backward(); opt.step()
+        if (step + 1) % 150 == 0:
+            print(f"  step {step+1}: L_rank {L_rank.item():.4f}  mean fwd {fwd.mean().item():.3f}  rev {rev.mean().item():.3f}")
+    torch.save({"state": model.state_dict(), "cfg": torch.load(a.ckpt, weights_only=False).get("cfg", {})}, a.save)
+    print(f"saved → {a.save}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/train_filing.py
+++ b/prototypes/mu_cosine/train_filing.py
@@ -32,7 +32,7 @@ def build_model(ckpt, dev):
                     n_ops=sz("op_emb.weight", len(OPS)), n_corpus=sz("corpus_emb.weight", 2),
                     n_judge=sz("judge_emb.weight", 2), n_nodetype=sz("nodetype_emb.weight", 4)).to(dev)
     miss, unexp = m.load_state_dict(sd, strict=False)
-    assert not unexp and all("account" in k for k in miss), (miss, unexp)
+    assert not unexp and all(("account" in k or "prefix" in k) for k in miss), (miss, unexp)
     return m, cfg
 
 

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -565,6 +565,12 @@ def train(args):
     blend_nprng = _np.random.default_rng(args.seed + 9973)  # ISOLATED rng for the Dirichlet draws
     graded_inf = [r for r in graded_tr if len(r) > 9 and r[9] < 1.0]   # inferred rows (conf<1) for the blend
     graded_tag = [r for r in graded_tr if not (len(r) > 9 and r[9] < 1.0)]
+    # JUDGE→LOSS ROUTING (DESIGN): graph-judged DIRECTIONAL edges are *certain + oriented*, so train them with a
+    # RANKING loss (μ(member|container) > μ(container|member)) — discriminative, not regression-to-0.90/0.10
+    # (which caps separation). haiku/soft rows keep regression (L_graded/L_blend). The judge token already on
+    # every row is the router; no new embedding needed. (Beats the e5-probe on direction — REPORT §4.6.)
+    _DIR_REL = {"element_of", "subcategory", "subtopic", "super_category"}
+    dir_edges = [r for r in graded_tr if r[8] == "graph" and r[4] in _DIR_REL and r[2] >= 0.5]
     relset = sorted(set(r[4] for r in graded_tag))
     blend_state = {"pop": None, "tgt": None}               # per-inferred-row P(op) [N,n_ops] + blended target
     # tagged-blend (DESIGN §7): when --blend-tagged-conf c < 1.0, ALSO blend TAGGED rows as a REGULARIZER with
@@ -809,10 +815,27 @@ def train(args):
                 tw_eff = trans_lambda
             else:
                 tw_eff = args.transitive_weight                # fixed-λ (the multiplier set by hand)
+        # DISCRIMINATIVE DIRECTIONAL loss (judge=graph, directional rels): rank μ(member|container) above
+        # μ(container|member) instead of regressing both to fixed targets. Same form as L_trans; + light anchor.
+        L_dir = torch.zeros(())
+        if dir_edges and not args.sym_only and args.dir_rank_weight > 0:
+            db = [dir_edges[rng.randrange(len(dir_edges))] for _ in range(args.bs)]
+            if args.use_nodetype:
+                fi = [(r[0], r[1], OPS[graded_op(r)], CORPORA[r[7]], GRAPHJ, nt(r[5]), nt(r[6])) for r in db]
+                ri = [(r[1], r[0], OPS[graded_op(r)], CORPORA[r[7]], GRAPHJ, nt(r[6]), nt(r[5])) for r in db]
+            else:
+                fi = [(r[0], r[1], OPS[graded_op(r)], CORPORA[r[7]], GRAPHJ) for r in db]
+                ri = [(r[1], r[0], OPS[graded_op(r)], CORPORA[r[7]], GRAPHJ) for r in db]
+            mu_f = model(**bld(fi, train=True, rng=rng, p_mask_prov=args.prov_mask))   # μ(member|container) — HIGH
+            mu_r = model(**bld(ri, train=True, rng=rng, p_mask_prov=args.prov_mask))   # μ(container|member) — LOW
+            L_dir = (F.softplus(-args.dir_rank_scale * (mu_f - mu_r - args.dir_rank_margin)).mean()
+                     + args.dir_rank_anchor * (F.mse_loss(mu_f, torch.full_like(mu_f, 0.9))
+                                               + F.mse_loss(mu_r, torch.full_like(mu_r, 0.1))))
         loss = (args.sym_weight * L_sym + (0.0 if args.sym_only else args.wiki_weight * L_wiki)
                 + (args.elem_weight * L_elem if (elem_tr and not args.sym_only) else 0.0)
                 + (args.graded_weight * L_graded if (graded_tr and not args.sym_only) else 0.0)
                 + (tw_eff * L_trans if (trans_rows and not args.sym_only) else 0.0)
+                + (args.dir_rank_weight * L_dir if (dir_edges and not args.sym_only and args.dir_rank_weight > 0) else 0.0)
                 + (args.blend_weight * L_blend if blend_on else 0.0)
                 + (args.anchor_kl_weight * L_anchor if blend_on else 0.0))
         # LLM (optional, already-bought) — skipped in single-task SYM mode
@@ -1170,6 +1193,13 @@ def main():
     ap.add_argument("--transitive-hetero", action="store_true", help="heteroscedastic: per-pair scale s_pair = "
                     "s/√(1+V) from the product-propagated chain variance V (longer/weaker chains → softer); "
                     "vs the default global s (homoscedastic). DESIGN §'loss over the DISTRIBUTION'")
+    ap.add_argument("--dir-rank-weight", type=float, default=0.0, help="DISCRIMINATIVE directional loss "
+                    "(judge→loss routing: graph-judged DIRECTIONAL edges trained by RANKING not regression): "
+                    "softplus(-s·(μ(member|container) − μ(container|member) − m)). Beats e5-probe on direction. 0=off")
+    ap.add_argument("--dir-rank-scale", type=float, default=10.0, help="logistic scale s for the directional rank CE")
+    ap.add_argument("--dir-rank-margin", type=float, default=0.1, help="margin m: enforce μ_fwd − μ_rev ≥ m")
+    ap.add_argument("--dir-rank-anchor", type=float, default=0.2, help="light regression anchor (μ_fwd→0.9, "
+                    "μ_rev→0.1) so degrees stay readable/calibrated, not just separable")
     ap.add_argument("--eval-retrieval", default=None, help="comma-sep roots → retrieval diagnostic: rank all "
                     "nodes by unconditional μ(·|root), report per-hop μ + greedy bidirectional gather + scatter "
                     "(DESIGN_model_applications.md). Include an OOD root to probe e5 generalisation.")

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -571,9 +571,8 @@ def train(args):
     # every row is the router; no new embedding needed. (Beats the e5-probe on direction — REPORT §4.6.)
     _DIR_REL = {"element_of", "subcategory", "subtopic", "super_category"}
     dir_edges = [r for r in graded_tr if r[8] == "graph" and r[4] in _DIR_REL and r[2] >= 0.5]
-    # when the directional RANKING loss is on, graph-directional rows are rank-supervised (+ anchor) — exclude them
-    # from the REGRESSION pool so the 0.90/0.10 regression doesn't compete with the rank (haiku/lateral rows stay).
-    graded_nondir = [r for r in graded_tr if not (r[8] == "graph" and r[4] in _DIR_REL)]
+    # NB: directional graph rows go through BOTH the regression pool (foundation) and the rank term (sharpening) —
+    # rank-only from scratch underperforms, it needs the graded foundation first (REPORT §4.6 / the #2 commit).
     relset = sorted(set(r[4] for r in graded_tag))
     blend_state = {"pop": None, "tgt": None}               # per-inferred-row P(op) [N,n_ops] + blended target
     # tagged-blend (DESIGN §7): when --blend-tagged-conf c < 1.0, ALSO blend TAGGED rows as a REGULARIZER with

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -571,6 +571,9 @@ def train(args):
     # every row is the router; no new embedding needed. (Beats the e5-probe on direction — REPORT §4.6.)
     _DIR_REL = {"element_of", "subcategory", "subtopic", "super_category"}
     dir_edges = [r for r in graded_tr if r[8] == "graph" and r[4] in _DIR_REL and r[2] >= 0.5]
+    # when the directional RANKING loss is on, graph-directional rows are rank-supervised (+ anchor) — exclude them
+    # from the REGRESSION pool so the 0.90/0.10 regression doesn't compete with the rank (haiku/lateral rows stay).
+    graded_nondir = [r for r in graded_tr if not (r[8] == "graph" and r[4] in _DIR_REL)]
     relset = sorted(set(r[4] for r in graded_tag))
     blend_state = {"pop": None, "tgt": None}               # per-inferred-row P(op) [N,n_ops] + blended target
     # tagged-blend (DESIGN §7): when --blend-tagged-conf c < 1.0, ALSO blend TAGGED rows as a REGULARIZER with
@@ -745,6 +748,8 @@ def train(args):
         # until the warmup completes — the blend's joint posterior + μ readouts must be established BEFORE the
         # blend consumes them (DESIGN §4/§7) — then move into the blend.
         tag_blended_now = blend_tag_on and step >= args.blend_warmup
+        # directional rows get BOTH the regression (foundation) and the rank (sharpening) — the regression is the
+        # base the rank refines; rank-only from scratch underperforms (it needs the graded foundation first).
         graded_pool = (([] if tag_blended_now else graded_tag) if args.infer_blend else graded_tr)
         if graded_pool and not args.sym_only:
             gb = [graded_pool[rng.randrange(len(graded_pool))] for _ in range(args.bs)]


### PR DESCRIPTION
This branch builds the retrieval/applications + evaluation layer for the **μ-attention** model (directional fuzzy
membership `μ(node|root)` over **frozen** e5) and rigorously answers one question: **μ sits on top of frozen e5 —
what does the learned layer add over raw e5 cosine?** It surfaces honest negatives alongside the wins.

**📋 Review entry point: [`prototypes/mu_cosine/REPORT_eval_methodology.md`](prototypes/mu_cosine/REPORT_eval_methodology.md)** —
self-contained (model, baseline, datasets, metrics, all result tables, threats-to-validity, and open questions).
Deeper theory/results in `DESIGN_model_applications.md`; data-acquisition strategy in `DESIGN_wikipedia_sampling.md`.

### Core finding
μ does **not** beat e5 as a *symmetric ranker* (tested 5 ways — e5 is competitive-or-better on coarse/medium
relatedness and high-recall thresholding). μ wins on the axes a frozen symmetric encoder **structurally lacks**:
- **Directionality** — `AUC(μ(member|container) > μ(container|member))` **0.78 vs e5's 0.51 coin-flip** (e5 asymmetry 0.001).
- **Close-negative discrimination** — true-parent vs *sibling*: μ **0.73 vs e5 0.62**, and μ's edge **grows as
  negatives get closer** (e5 scores parent 0.832 ≈ sibling 0.815 — can't tell member-of from sibling-of).
- **Calibrated degrees** — μ has 4× the dynamic range; e5 squashes everything into a 0.76–0.84 band (can't express "low").
- **Data scaling** — on a real OOD task (Pearltrees bookmark filing), a 3-seed fine-tune **crosses the e5-cos bar
  (MRR 0.291) at ~30% of the data and is still rising at 100%** (0.358; recall@10 0.573 vs 0.440).

### The e5 calibration issue (central methodological point)
e5-small cosines are compressed (~0.76–0.84), so a parent, a cross-subdomain category, and a *sibling* all score
~0.8. Rank-AUC hides this; the usable signal is the **calibrated degree** (μ=0.22 ⇒ "barely a member"), not a
threshold. e5 is **frozen** (at its ceiling), μ is the **trained** layer (data-scalable) — so in-domain data
improves μ, not e5; the learning curve is the evidence.

### What works / what doesn't
- **Works:** directionality, close-neighbour disambiguation, calibrated degrees, data-scaling (filing curve).
- **Doesn't:** μ as a symmetric rank metric (e5 ≥ μ on easy/medium negatives); calibration ≠ clean high-recall
  thresholding (FPR leaky); clean-domain coverage gave no rank gain (e5 already strong there); zero-shot OOD μ loses.
- **Implied architecture:** a **hybrid** — e5 for coarse symmetric ranking, μ for the decisive top-of-list cases
  (direction + close-neighbour + calibrated degree). Not "μ replaces e5."

### Methodology notes (surfaced for fair review)
We document our own missteps: the first filing eval (member→*exact*-parent vs all folders) was a misaligned
classification task that favoured e5; an early "hard negative" wasn't close enough (siblings are the real test).
Single-run discrimination evals are n=400–2000 (e5-cos wobbled ±0.013 at n=400); the filing curve is 3-seed.

### Tooling
`eval_filing.py` (filing/home-turf/node-holdout/`--drop-admin`), `eval_relatedness.py` (pair discrimination +
directional + FPR), `train_filing.py` (multi-seed fine-tune), `train_mu_attention.py --eval-retrieval`. Harvested
data and `*.pt` checkpoints are gitignored build outputs.

### For the reviewer (REPORT §9)
1. Is `AUC(fwd>rev)` the right way to credit directionality, or is a hierarchy-reconstruction task stronger?
2. Should calibration be reported via a proper metric (ECE / reliability diagram / d-prime) rather than per-stratum means?
3. Is "sibling" the right hardest negative, and the easy→hard→sibling *trend* the right way to show e5's degradation?
4. Is the frozen-e5-ceiling vs trained-μ-headroom data-scaling argument sound — what would make the extrapolation rigorous (more fractions, fitted curve + CI, a 2nd OOD domain)?
5. Does the evidence support the **hybrid** conclusion, or μ-alone for the directional use case?