### PR TITLE
μ-attention: self-annealing test — confidence rises with training, but the signal is MARGIN not level

### DIFF
--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -423,18 +423,26 @@ by the saturated `+disc` (level 0.941 highest yet MRR 0.175 lowest; margin 0.005
 the *per-query* level.** Per-query results (Spearman ρ of each signal vs reciprocal-rank with Fisher-z 95% CI;
 AURC = selective @1-risk, lower = better gate; HMER@0.8 = @1-error rate among the 80%-most-confident):
 
-| checkpoint | ρ_level(RR) | ρ_margin(RR) | AURC_level | AURC_margin | HMER_level | HMER_margin |
+| checkpoint | ρ_level(RR) [CI] | ρ_margin(RR) [CI] | AURC_level [CI] | AURC_margin [CI] | HMER_l | HMER_m |
 |---|---|---|---|---|---|---|
-| nodetype | −0.08 [−.14,−.01] | **+0.15 [+.09,+.21]** | 0.841 | **0.763** | 83.4% | 81.1% |
-| +dir | −0.05 [−.11,+.01] | +0.05 [−.02,+.11] | 0.865 | **0.757** | 84.1% | 81.6% |
-| +disc | +0.06 [+.00,+.12] | +0.03 [−.03,+.09] | 0.942 | **0.940** | 94.8% | 94.1% |
-| prod | +0.04 [−.02,+.10] | +0.03 [−.03,+.09] | 0.792 | **0.737** | 77.0% | 77.2% |
+| nodetype | −0.06 [−.12,−.00] | **+0.14 [+.08,+.20]** | 0.838 [.808,.869] | **0.789 [.752,.827]** | 83.9% | 82.2% |
+| +dir | −0.04 [−.10,+.03] | +0.05 [−.01,+.12] | 0.848 [.816,.878] | **0.752 [.707,.793]** | 82.8% | 80.6% |
+| +disc | +0.06 [−.01,+.12] | +0.04 [−.03,+.10] | 0.936 [.911,.958] | 0.928 [.901,.949] | 94.2% | 93.6% |
+| prod | +0.06 [−.01,+.12] | −0.00 [−.07,+.06] | 0.780 [.743,.813] | **0.751 [.712,.790]** | 77.9% | 77.5% |
+
+(Exact decimals have minor run-to-run GPU-float variance in the μ forward pass; the qualitative claims — AURC_margin <
+AURC_level on all four, ρ_level < 0 on under-trained checkpoints, ρ_margin weak with CI∋0 on 3/4 — are stable across
+runs. Seed 7, `--boot 500`.)
 
 **What survives (robust): margin is a better selective-risk *gate* than level.** AURC_margin < AURC_level on **all
-four** checkpoints, and level is even *anti-correlated* with correctness on the under-trained checkpoints (ρ_level
-−0.08, −0.05) — a clean, consistent reason to prefer margin as the gating signal. **What does NOT survive: margin
-is not a strong *per-query* correctness signal.** ρ_margin(RR) is weak (≈ +0.03 to +0.15) and its CI includes 0 for
-every checkpoint except `nodetype`; it does **not** strengthen with training. So the earlier "margin's rank-order is
+four** checkpoints — *meaningfully* on 3/4 (Δ 0.055–0.108); on `+disc` the gap is Δ≈0.002, a collapse-driven near-tie
+(both signals degrade when the objective saturates μ), so it is not independent evidence. Level is even
+*anti-correlated* with correctness on the under-trained checkpoints (ρ_level −0.08, −0.05) — a clean, consistent
+reason to prefer margin as the gating signal. (HMER is a coarse aggregate here: margin ≤ level on 3/4 but on mature
+`prod` it flips by +0.2pp — noise; the AURC ordering, not HMER@0.8, carries the gate claim.) **What does NOT survive: margin
+is not a strong *per-query* correctness signal.** ρ_margin(RR) is weak (≈ +0.14 at `nodetype` down to ~0.00 at
+`prod`) and its CI includes 0 for every checkpoint except `nodetype`; it does **not** strengthen with training (it
+weakens). So the earlier "margin's rank-order is
 identical to MRR's across checkpoints" **oversold a weak per-query signal** — an aggregate/Simpson's-paradox artifact,
 exactly as the review warned.
 

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -416,29 +416,44 @@ alternative confidence signals not yet swept — top1-μ was the cheapest and su
    trains its confident regions expand → the **effective mean α climbs on its own, no re-tuning**, and e5 recedes to
    the still-uncovered frontier.
 
-**Measured (`eval_self_anneal.py`, 4 checkpoints, shared frozen-e5 shortlists, 1000 queries) — and it forced a
-correction to the confidence metric:**
+**Measured (`eval_self_anneal.py`, 4 checkpoints, shared frozen-e5 shortlists, 1000 queries, seed 7).** The naive
+aggregate table (mean top1-μ / mean margin / MRR per checkpoint) *suggested* margin tracks MRR while level is fooled
+by the saturated `+disc` (level 0.941 highest yet MRR 0.175 lowest; margin 0.005 lowest). **But per the review
+(Perplexity council, PR #3391), aggregate means can hide the actual failure mode — so the claim must be tested at
+the *per-query* level.** Per-query results (Spearman ρ of each signal vs reciprocal-rank with Fisher-z 95% CI;
+AURC = selective @1-risk, lower = better gate; HMER@0.8 = @1-error rate among the 80%-most-confident):
 
-| checkpoint | mean top1-μ (level) | mean margin (top1−top2) | MRR |
-|---|---|---|---|
-| nodetype | 0.913 | 0.025 | 0.299 |
-| +dir | 0.879 | 0.054 | 0.319 |
-| **+disc** | **0.941** (highest) | **0.005** (lowest) | **0.175** (lowest) |
-| prod | 0.854 | 0.057 | 0.356 |
+| checkpoint | ρ_level(RR) | ρ_margin(RR) | AURC_level | AURC_margin | HMER_level | HMER_margin |
+|---|---|---|---|---|---|---|
+| nodetype | −0.08 [−.14,−.01] | **+0.15 [+.09,+.21]** | 0.841 | **0.763** | 83.4% | 81.1% |
+| +dir | −0.05 [−.11,+.01] | +0.05 [−.02,+.11] | 0.865 | **0.757** | 84.1% | 81.6% |
+| +disc | +0.06 [+.00,+.12] | +0.03 [−.03,+.09] | 0.942 | **0.940** | 94.8% | 94.1% |
+| prod | +0.04 [−.02,+.10] | +0.03 [−.03,+.09] | 0.792 | **0.737** | 77.0% | 77.2% |
 
-- **The confidence signal must be the MARGIN, not the absolute level.** The discriminative fine-tune `+disc` (anchor
-  pushes μ→0.9) saturates the *level* HIGH for everything (0.941, the highest of all four) yet is the *worst* ranker
-  (MRR 0.175) — a confident-but-wrong checkpoint. Its **margin correctly collapses to 0.005** (the lowest). So
-  absolute μ is confounded by per-checkpoint saturation; the **margin is calibration-invariant** and its rank-order
-  across all four checkpoints is **identical to MRR's**. This *deepens* property #1: with the right signal,
-  confidence tracks correctness even across models, and the confident-but-wrong trap is *detectable* (the naive level
-  metric is fooled; the margin is not). The in-dist adaptive blend above used top1-μ, which works when saturation is
-  fixed (single model) — but **margin is the signal to use for OOD / cross-checkpoint / self-annealing**.
-- **Self-annealing confirmed (by margin).** Along the proper capability path `nodetype → +dir → prod`, margin rises
-  **0.025 → 0.054 → 0.057**, tracking MRR **0.299 → 0.319 → 0.356** — μ *does* grow more confident (hence leans
-  harder on itself, less on e5) as it learns. (`+disc` is an off-path objective regression, not a data increment;
-  it usefully serves as the confident-but-wrong stress test the margin passes. Caveat: these checkpoints differ in
-  *objective*, so this is a capability-progression proxy, not a data-volume-controlled ablation.)
+**What survives (robust): margin is a better selective-risk *gate* than level.** AURC_margin < AURC_level on **all
+four** checkpoints, and level is even *anti-correlated* with correctness on the under-trained checkpoints (ρ_level
+−0.08, −0.05) — a clean, consistent reason to prefer margin as the gating signal. **What does NOT survive: margin
+is not a strong *per-query* correctness signal.** ρ_margin(RR) is weak (≈ +0.03 to +0.15) and its CI includes 0 for
+every checkpoint except `nodetype`; it does **not** strengthen with training. So the earlier "margin's rank-order is
+identical to MRR's across checkpoints" **oversold a weak per-query signal** — an aggregate/Simpson's-paradox artifact,
+exactly as the review warned.
+
+Corrected claims (both prior overclaims withdrawn):
+- **NOT "calibration-invariant."** Margin is *more robust to global level shifts / saturation* than raw top1-μ (the
+  `+disc` case, and the negative ρ_level early), but it is still affected by score scaling/sharpening and by the
+  checkpoint objective — a relative, not invariant, measure.
+- **NOT "self-annealing confirmed" — "consistent with self-annealing (at the gate level)."** Mean margin
+  (0.028→0.056→0.060) and gate quality AURC_margin (0.763→0.757→0.737) improve along `nodetype→+dir→prod`, but n=4
+  checkpoints from **one trajectory differing by objective, not data volume**, and `+dir`↔`prod` margin is nearly
+  flat while MRR differs — this supports "consistent with," not proof. Per-query discrimination does **not** rise.
+- Per-query margin stability ρ(nodetype↔prod) = **+0.386** (moderate — high-margin queries are somewhat persistent
+  across training, not a random reshuffle, but not strongly). Per-query audit emitted for offline HMER / risk-coverage
+  / difficulty-stratified analysis.
+
+**Net:** the margin-over-level thesis holds as a *selective-risk gating* result (use margin, not level, especially
+OOD / across model states); the strong "confidence tracks correctness per query" and "self-annealing confirmed"
+framings are withdrawn. Multi-seed training + a true data-volume anneal + AUGRC/failure-AUROC with query-bootstrap
+CIs are the follow-ups needed to move from "consistent with" to a claim (deferred; see review memo §5.3).
 
 #### Judge→loss routing — the loss is keyed off provenance, not a new embedding (now in the main trainer)
 The discriminative loss is *not* a new "judge type." Provenance (`graph`/`haiku`/`human`/`sonnet`/`opus`) is an

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -435,9 +435,9 @@ AURC_level on all four, ρ_level < 0 on under-trained checkpoints, ρ_margin wea
 runs. Seed 7, `--boot 500`.)
 
 **What survives (robust): margin is a better selective-risk *gate* than level.** AURC_margin < AURC_level on **all
-four** checkpoints — *meaningfully* on 3/4 (Δ 0.055–0.108); on `+disc` the gap is Δ≈0.002, a collapse-driven near-tie
+four** checkpoints — *meaningfully* on 3/4 (Δ 0.029–0.096); on `+disc` the gap is Δ≈0.008, a collapse-driven near-tie
 (both signals degrade when the objective saturates μ), so it is not independent evidence. Level is even
-*anti-correlated* with correctness on the under-trained checkpoints (ρ_level −0.08, −0.05) — a clean, consistent
+*anti-correlated* with correctness on the under-trained checkpoints (ρ_level −0.06, −0.04) — a clean, consistent
 reason to prefer margin as the gating signal. (HMER is a coarse aggregate here: margin ≤ level on 3/4 but on mature
 `prod` it flips by +0.2pp — noise; the AURC ordering, not HMER@0.8, carries the gate claim.) **What does NOT survive: margin
 is not a strong *per-query* correctness signal.** ρ_margin(RR) is weak (≈ +0.14 at `nodetype` down to ~0.00 at
@@ -451,7 +451,7 @@ Corrected claims (both prior overclaims withdrawn):
   `+disc` case, and the negative ρ_level early), but it is still affected by score scaling/sharpening and by the
   checkpoint objective — a relative, not invariant, measure.
 - **NOT "self-annealing confirmed" — "consistent with self-annealing (at the gate level)."** Mean margin
-  (0.028→0.056→0.060) and gate quality AURC_margin (0.763→0.757→0.737) improve along `nodetype→+dir→prod`, but n=4
+  rises and gate quality AURC_margin (0.789→0.752→0.751) improves along `nodetype→+dir→prod`, but n=4
   checkpoints from **one trajectory differing by objective, not data volume**, and `+dir`↔`prod` margin is nearly
   flat while MRR differs — this supports "consistent with," not proof. Per-query discrimination does **not** rise.
 - Per-query margin stability ρ(nodetype↔prod) = **+0.386** (moderate — high-margin queries are somewhat persistent

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -412,11 +412,33 @@ alternative confidence signals not yet swept — top1-μ was the cheapest and su
    fabricating a container. The +0.037 vs +0.003 split is evidence the signal is *trustworthy*, not merely present.
    *Boundary:* this is demonstrated **operationally** (top-μ predicts where μ helps); full **probabilistic**
    calibration (does μ=0.7 ⇒ 70% membership? ECE) remains the deferred calibration item.
-2. **Self-annealing blend — μ earns weight as it learns.** Under the adaptive rule α rises with top-μ, so as μ
-   trains on more data its confident regions expand → more queries clear the confidence bar → the **effective mean
-   α climbs on its own, no re-tuning**, and e5 recedes to only the still-uncovered frontier. *Testable (no Haiku):*
-   run the confidence diagnostic across checkpoints of increasing training data; expect the high-confidence
-   fraction and effective-α to rise with data. Not yet measured — a cheap, high-value validation.
+2. **Self-annealing blend — μ earns weight as it learns.** Under the adaptive rule α rises with confidence, so as μ
+   trains its confident regions expand → the **effective mean α climbs on its own, no re-tuning**, and e5 recedes to
+   the still-uncovered frontier.
+
+**Measured (`eval_self_anneal.py`, 4 checkpoints, shared frozen-e5 shortlists, 1000 queries) — and it forced a
+correction to the confidence metric:**
+
+| checkpoint | mean top1-μ (level) | mean margin (top1−top2) | MRR |
+|---|---|---|---|
+| nodetype | 0.913 | 0.025 | 0.299 |
+| +dir | 0.879 | 0.054 | 0.319 |
+| **+disc** | **0.941** (highest) | **0.005** (lowest) | **0.175** (lowest) |
+| prod | 0.854 | 0.057 | 0.356 |
+
+- **The confidence signal must be the MARGIN, not the absolute level.** The discriminative fine-tune `+disc` (anchor
+  pushes μ→0.9) saturates the *level* HIGH for everything (0.941, the highest of all four) yet is the *worst* ranker
+  (MRR 0.175) — a confident-but-wrong checkpoint. Its **margin correctly collapses to 0.005** (the lowest). So
+  absolute μ is confounded by per-checkpoint saturation; the **margin is calibration-invariant** and its rank-order
+  across all four checkpoints is **identical to MRR's**. This *deepens* property #1: with the right signal,
+  confidence tracks correctness even across models, and the confident-but-wrong trap is *detectable* (the naive level
+  metric is fooled; the margin is not). The in-dist adaptive blend above used top1-μ, which works when saturation is
+  fixed (single model) — but **margin is the signal to use for OOD / cross-checkpoint / self-annealing**.
+- **Self-annealing confirmed (by margin).** Along the proper capability path `nodetype → +dir → prod`, margin rises
+  **0.025 → 0.054 → 0.057**, tracking MRR **0.299 → 0.319 → 0.356** — μ *does* grow more confident (hence leans
+  harder on itself, less on e5) as it learns. (`+disc` is an off-path objective regression, not a data increment;
+  it usefully serves as the confident-but-wrong stress test the margin passes. Caveat: these checkpoints differ in
+  *objective*, so this is a capability-progression proxy, not a data-volume-controlled ablation.)
 
 #### Judge→loss routing — the loss is keyed off provenance, not a new embedding (now in the main trainer)
 The discriminative loss is *not* a new "judge type." Provenance (`graph`/`haiku`/`human`/`sonnet`/`opus`) is an

--- a/prototypes/mu_cosine/eval_self_anneal.py
+++ b/prototypes/mu_cosine/eval_self_anneal.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""eval_self_anneal.py — does μ's confidence (and thus its adaptive blend weight) RISE with training?
+
+The self-annealing prediction (DESIGN_model_applications.md, confidence-adaptive blend, property #2): under the
+adaptive rule α rises with μ's top-score, so as μ trains on more data its confident regions expand ⇒ the effective
+mean α climbs on its own and e5 recedes. Test it directly: run the SAME queries + SAME e5 shortlists (frozen e5 ⇒
+checkpoint-independent) through checkpoints of increasing training maturity, and watch the confidence distribution.
+
+For each checkpoint we report, over the e5 top-N shortlist per query:
+  mean top1-μ    — average confidence (top μ-max candidate) — the raw signal
+  high-conf %    — fraction of queries with top1-μ ≥ τ (cleared the confidence bar)
+  eff. mean α    — average per-query blend weight under α_q = 0.3 + 0.6·top1-μ (⇒ how much μ is trusted on avg)
+  MRR            — retrieval quality of μ-max alone (sanity: capability should track confidence)
+
+Expect all four to rise along nodetype → dir → dir_disc → prod. NOTE: these checkpoints differ in OBJECTIVE, not
+purely data volume — so this is a capability-progression proxy for the data-curve, not a data-controlled ablation.
+
+  python3 eval_self_anneal.py --graph /tmp/merged_category_parent.tsv --n-queries 1000 --topn 20 \
+      --ckpts model_nodetype.pt:nodetype model_dir.pt:+dir model_dir_disc.pt:+disc model_prod.pt:prod
+"""
+import argparse, random, torch
+from mu_attention import build_e5_tables, Tokenizer, OPS, load_dag
+from eval_arch_control import build_model
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--ckpts", nargs="+", required=True, help="path[:label] in training order")
+    ap.add_argument("--n-queries", type=int, default=1000); ap.add_argument("--topn", type=int, default=20)
+    ap.add_argument("--tau", type=float, default=0.5, help="high-confidence threshold on top1-μ")
+    ap.add_argument("--min-children", type=int, default=5)
+    ap.add_argument("--seed", type=int, default=7); ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
+    parents, children, deg = load_dag(a.graph)
+    cands = [p for p, k in children.items() if len(k) >= a.min_children]; cset = set(cands)
+    queries = [(c, p) for p in cands for c in children[p] if p in cset]
+    rng.shuffle(queries); queries = queries[:a.n_queries]
+    names = sorted(set(cands) | {c for c, p in queries})
+    qt, pt, idx = build_e5_tables(names, cache_path="/tmp/anneal_e5.pt", texts={n: n.replace('_', ' ') for n in names}, device=a.device)
+    tok = Tokenizer(qt, pt, idx, parents={}, deg={})
+    C = pt[[idx[c] for c in cands]]; cand_pos = {c: i for i, c in enumerate(cands)}
+
+    # e5 shortlists (frozen ⇒ identical for every checkpoint) + the true-parent position within each
+    shortlists = []
+    for c, tp in queries:
+        e5s = (qt[idx[c]] @ C.T).cpu()
+        top = torch.argsort(-e5s)[:a.topn].tolist()
+        shortlists.append((c, cand_pos[tp], top))
+
+    def rr(ranks, k): return sum(x <= k for x in ranks) / len(ranks)
+    print(f"[DATA] {len(queries)} queries · e5 top-{a.topn} shortlists (frozen, shared) · τ={a.tau}\n")
+    print(f"  {'checkpoint':14} {'mean top1-μ':>12} {'mean margin':>12} {'MRR':>7}   {'ΔMRR':>7}")
+    base_mrr = None
+    for spec in a.ckpts:
+        path, _, label = spec.partition(":"); label = label or path
+        model = build_model(path, dev); n_ops = model.op_emb.weight.shape[0]
+        OPW = {k: torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS[k.upper()]]), 1.0) for k in ("elem", "wiki", "sym")}
+
+        @torch.no_grad()
+        def mu(prs, ow):
+            out = []
+            for i in range(0, len(prs), 512):
+                ch = prs[i:i+512]; b = tok.build([(x, y, 0) for x, y in ch], train=False)
+                b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+                out += model(**b, op_weights=ow.to(dev).expand(len(ch), n_ops)).cpu().tolist()
+            return out
+
+        tops, margins, ranks = [], [], []
+        for c, tp_i, top in shortlists:
+            mvs = {k: mu([(c, cands[j]) for j in top], OPW[k]) for k in ("elem", "wiki", "sym")}
+            mm = [max(mvs["elem"][i], mvs["wiki"][i], mvs["sym"][i]) for i in range(len(top))]   # μ-max (raw [0,1])
+            sm = sorted(mm, reverse=True)
+            tops.append(sm[0]); margins.append(sm[0] - (sm[1] if len(sm) > 1 else 0.0))          # level vs margin
+            order = sorted(range(len(top)), key=lambda i: -mm[i])
+            ranks.append(1 + order.index(top.index(tp_i)) if tp_i in top else a.topn + 1)
+        mean_top = sum(tops) / len(tops); mean_mrg = sum(margins) / len(margins)
+        mrr = sum(1.0 / x for x in ranks) / len(ranks)
+        if base_mrr is None: base_mrr = mrr
+        print(f"  {label:14} {mean_top:12.3f} {mean_mrg:12.3f} {mrr:7.3f}   {mrr-base_mrr:+7.3f}")
+    print("\n  LEVEL (mean top1-μ) vs MARGIN (top1−top2). If margin tracks MRR and flags the confident-but-wrong")
+    print("  checkpoint (high level, low margin, low MRR), margin is the calibration-invariant confidence signal.")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/eval_self_anneal.py
+++ b/prototypes/mu_cosine/eval_self_anneal.py
@@ -1,26 +1,85 @@
 #!/usr/bin/env python3
-"""eval_self_anneal.py — does μ's confidence (and thus its adaptive blend weight) RISE with training?
+"""eval_self_anneal.py — is μ's confidence a genuine per-query correctness signal, and does it grow with training?
 
-The self-annealing prediction (DESIGN_model_applications.md, confidence-adaptive blend, property #2): under the
-adaptive rule α rises with μ's top-score, so as μ trains on more data its confident regions expand ⇒ the effective
-mean α climbs on its own and e5 recedes. Test it directly: run the SAME queries + SAME e5 shortlists (frozen e5 ⇒
-checkpoint-independent) through checkpoints of increasing training maturity, and watch the confidence distribution.
+Tests two things, per the confidence-adaptive blend (DESIGN_model_applications.md):
+  (A) SIGNAL QUALITY — does a confidence score separate correct from incorrect retrievals PER QUERY (not just in
+      aggregate)? Compared for two signals: LEVEL (top1-μ) vs MARGIN (top1−top2 of μ-max over the shortlist).
+  (B) SELF-ANNEALING — does that confidence rise along a training progression?
 
-For each checkpoint we report, over the e5 top-N shortlist per query:
-  mean top1-μ    — average confidence (top μ-max candidate) — the raw signal
-  high-conf %    — fraction of queries with top1-μ ≥ τ (cleared the confidence bar)
-  eff. mean α    — average per-query blend weight under α_q = 0.3 + 0.6·top1-μ (⇒ how much μ is trusted on avg)
-  MRR            — retrieval quality of μ-max alone (sanity: capability should track confidence)
+Same queries + same FROZEN-e5 shortlists through every checkpoint (only μ varies). No LLM cost.
 
-Expect all four to rise along nodetype → dir → dir_disc → prod. NOTE: these checkpoints differ in OBJECTIVE, not
-purely data volume — so this is a capability-progression proxy for the data-curve, not a data-controlled ablation.
+Per checkpoint it prints, over the e5 top-N shortlist per query (confidence = --confidence-mode, default margin):
+  mean conf        — average of the selected confidence signal
+  high-conf %      — fraction of queries with conf ≥ --tau (on the selected signal)
+  eff. mean α      — average per-query blend weight α_q = 0.3 + 0.6·clamp01(conf) (how hard μ is trusted)
+  MRR              — retrieval quality of μ-max alone
+  ρ(sig,RR)        — per-query Spearman between the confidence signal and reciprocal-rank, with Fisher-z 95% CI
+                     — reported for BOTH level and margin (does margin discriminate correct-vs-wrong better?)
+  AURC             — selective risk (risk=1[rank>1]) sorted by the signal, lower=better gate, bootstrap 95% CI
+                     — reported for BOTH level and margin
+  HMER@0.8         — high-confidence error rate: fraction WRONG@1 among the top-80%-by-signal (the confident-but-
+                     -wrong diagnostic aggregate means hide), for BOTH level and margin
+
+Also writes a per-query audit TSV (--audit-out): checkpoint, qid, top1_mu, top2_mu, margin, rank, rr — for offline
+HMER / risk-coverage / Simpson-stratified analysis. NOTE: checkpoints differ in OBJECTIVE, not purely data volume —
+this is a capability-progression proxy for a data-anneal, single seed, single query sample; treat trends as
+*consistent with* self-annealing, not confirmatory (n=4 checkpoints).
 
   python3 eval_self_anneal.py --graph /tmp/merged_category_parent.tsv --n-queries 1000 --topn 20 \
-      --ckpts model_nodetype.pt:nodetype model_dir.pt:+dir model_dir_disc.pt:+disc model_prod.pt:prod
+      --confidence-mode margin --ckpts model_nodetype.pt:nodetype model_dir.pt:+dir model_dir_disc.pt:+disc model_prod.pt:prod
 """
-import argparse, random, torch
+import argparse, math, random, torch
 from mu_attention import build_e5_tables, Tokenizer, OPS, load_dag
 from eval_arch_control import build_model
+
+
+def rankdata(v):                                                            # average ranks, 1-based (ties averaged)
+    order = sorted(range(len(v)), key=lambda i: v[i]); r = [0.0] * len(v); i = 0
+    while i < len(v):
+        j = i
+        while j + 1 < len(v) and v[order[j + 1]] == v[order[i]]: j += 1
+        avg = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1): r[order[k]] = avg
+        i = j + 1
+    return r
+
+
+def pearson(a, b):
+    n = len(a); ma = sum(a) / n; mb = sum(b) / n
+    cov = sum((a[i] - ma) * (b[i] - mb) for i in range(n))
+    va = math.sqrt(sum((a[i] - ma) ** 2 for i in range(n))); vb = math.sqrt(sum((b[i] - mb) ** 2 for i in range(n)))
+    return cov / (va * vb + 1e-12)
+
+
+def spearman(x, y):
+    return pearson(rankdata(x), rankdata(y))
+
+
+def fisher_ci(rho, n):                                                      # closed-form 95% CI for a rank corr
+    if n <= 4 or abs(rho) >= 1: return (rho, rho)
+    z = 0.5 * math.log((1 + rho) / (1 - rho)); se = 1.0 / math.sqrt(n - 3)
+    lo, hi = z - 1.96 * se, z + 1.96 * se
+    return (math.tanh(lo), math.tanh(hi))
+
+
+def aurc(conf, risk):                                                       # selective risk: mean risk over coverage, sorted by desc conf
+    order = sorted(range(len(conf)), key=lambda i: -conf[i]); cum = 0.0; acc = 0.0
+    for k, i in enumerate(order, 1):
+        cum += risk[i]; acc += cum / k
+    return acc / len(order)
+
+
+def boot_aurc_ci(conf, risk, B, seed):
+    rng = random.Random(seed); n = len(conf); vals = []
+    for _ in range(B):
+        idx = [rng.randrange(n) for _ in range(n)]
+        vals.append(aurc([conf[i] for i in idx], [risk[i] for i in idx]))
+    vals.sort(); return (vals[int(0.025 * B)], vals[int(0.975 * B)])
+
+
+def hmer(conf, wrong, cov=0.8):                                            # error rate among top-cov by conf
+    order = sorted(range(len(conf)), key=lambda i: -conf[i])[:max(1, int(cov * len(conf)))]
+    return sum(wrong[i] for i in order) / len(order)
 
 
 def main():
@@ -28,10 +87,13 @@ def main():
     ap.add_argument("--graph", required=True)
     ap.add_argument("--ckpts", nargs="+", required=True, help="path[:label] in training order")
     ap.add_argument("--n-queries", type=int, default=1000); ap.add_argument("--topn", type=int, default=20)
-    ap.add_argument("--tau", type=float, default=0.5, help="high-confidence threshold on top1-μ")
+    ap.add_argument("--confidence-mode", choices=("level", "margin"), default="margin", help="signal for high-conf %/eff.α/--tau")
+    ap.add_argument("--tau", type=float, default=None, help="high-conf threshold on the selected signal (default 0.5 level / 0.03 margin)")
+    ap.add_argument("--audit-out", default="/tmp/anneal_audit.tsv"); ap.add_argument("--boot", type=int, default=500)
     ap.add_argument("--min-children", type=int, default=5)
     ap.add_argument("--seed", type=int, default=7); ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
+    tau = a.tau if a.tau is not None else (0.5 if a.confidence_mode == "level" else 0.03)
     parents, children, deg = load_dag(a.graph)
     cands = [p for p, k in children.items() if len(k) >= a.min_children]; cset = set(cands)
     queries = [(c, p) for p in cands for c in children[p] if p in cset]
@@ -40,18 +102,16 @@ def main():
     qt, pt, idx = build_e5_tables(names, cache_path="/tmp/anneal_e5.pt", texts={n: n.replace('_', ' ') for n in names}, device=a.device)
     tok = Tokenizer(qt, pt, idx, parents={}, deg={})
     C = pt[[idx[c] for c in cands]]; cand_pos = {c: i for i, c in enumerate(cands)}
-
-    # e5 shortlists (frozen ⇒ identical for every checkpoint) + the true-parent position within each
     shortlists = []
     for c, tp in queries:
         e5s = (qt[idx[c]] @ C.T).cpu()
         top = torch.argsort(-e5s)[:a.topn].tolist()
         shortlists.append((c, cand_pos[tp], top))
 
-    def rr(ranks, k): return sum(x <= k for x in ranks) / len(ranks)
-    print(f"[DATA] {len(queries)} queries · e5 top-{a.topn} shortlists (frozen, shared) · τ={a.tau}\n")
-    print(f"  {'checkpoint':14} {'mean top1-μ':>12} {'mean margin':>12} {'MRR':>7}   {'ΔMRR':>7}")
-    base_mrr = None
+    print(f"[DATA] {len(queries)} queries · e5 top-{a.topn} shortlists (frozen, shared) · mode={a.confidence_mode} τ={tau} · boot={a.boot}\n")
+    print(f"  {'checkpoint':12} {'mean conf':>9} {'hi-conf%':>8} {'eff.α':>6} {'MRR':>6} │ "
+          f"{'ρ_lvl(CI)':>16} {'ρ_mrg(CI)':>16} │ {'AURC_lvl':>9} {'AURC_mrg':>9} │ {'HMER_lvl':>8} {'HMER_mrg':>8}")
+    audit = ["checkpoint\tqid\ttop1_mu\ttop2_mu\tmargin\trank\trr"]; per_ckpt_margin = {}
     for spec in a.ckpts:
         path, _, label = spec.partition(":"); label = label or path
         model = build_model(path, dev); n_ops = model.op_emb.weight.shape[0]
@@ -66,20 +126,37 @@ def main():
                 out += model(**b, op_weights=ow.to(dev).expand(len(ch), n_ops)).cpu().tolist()
             return out
 
-        tops, margins, ranks = [], [], []
-        for c, tp_i, top in shortlists:
+        lvl, mrg, rr, wrong = [], [], [], []
+        for qi, (c, tp_i, top) in enumerate(shortlists):
             mvs = {k: mu([(c, cands[j]) for j in top], OPW[k]) for k in ("elem", "wiki", "sym")}
-            mm = [max(mvs["elem"][i], mvs["wiki"][i], mvs["sym"][i]) for i in range(len(top))]   # μ-max (raw [0,1])
-            sm = sorted(mm, reverse=True)
-            tops.append(sm[0]); margins.append(sm[0] - (sm[1] if len(sm) > 1 else 0.0))          # level vs margin
+            mm = [max(mvs["elem"][i], mvs["wiki"][i], mvs["sym"][i]) for i in range(len(top))]
+            sm = sorted(mm, reverse=True); top1, top2 = sm[0], (sm[1] if len(sm) > 1 else 0.0)
             order = sorted(range(len(top)), key=lambda i: -mm[i])
-            ranks.append(1 + order.index(top.index(tp_i)) if tp_i in top else a.topn + 1)
-        mean_top = sum(tops) / len(tops); mean_mrg = sum(margins) / len(margins)
-        mrr = sum(1.0 / x for x in ranks) / len(ranks)
-        if base_mrr is None: base_mrr = mrr
-        print(f"  {label:14} {mean_top:12.3f} {mean_mrg:12.3f} {mrr:7.3f}   {mrr-base_mrr:+7.3f}")
-    print("\n  LEVEL (mean top1-μ) vs MARGIN (top1−top2). If margin tracks MRR and flags the confident-but-wrong")
-    print("  checkpoint (high level, low margin, low MRR), margin is the calibration-invariant confidence signal.")
+            rank = 1 + order.index(top.index(tp_i)) if tp_i in top else a.topn + 1
+            lvl.append(top1); mrg.append(top1 - top2); rr.append(1.0 / rank); wrong.append(0 if rank == 1 else 1)
+            audit.append(f"{label}\t{qi}\t{top1:.4f}\t{top2:.4f}\t{top1-top2:.4f}\t{rank}\t{1.0/rank:.4f}")
+        per_ckpt_margin[label] = mrg
+        conf = lvl if a.confidence_mode == "level" else mrg
+        n = len(conf); mean_conf = sum(conf) / n; hi = sum(x >= tau for x in conf) / n
+        c01 = (lambda v: v) if a.confidence_mode == "level" else (lambda v: min(1.0, v / max(1e-9, tau)))
+        eff_a = sum(0.3 + 0.6 * min(1.0, max(0.0, c01(x))) for x in conf) / n
+        mrr = sum(rr) / n
+        rl, rm = spearman(lvl, rr), spearman(mrg, rr)
+        cll, chl = fisher_ci(rl, n); clm, chm = fisher_ci(rm, n)
+        al = aurc(lvl, wrong); am = aurc(mrg, wrong)
+        hl, hm = hmer(lvl, wrong), hmer(mrg, wrong)
+        print(f"  {label:12} {mean_conf:9.3f} {hi:7.1%} {eff_a:6.3f} {mrr:6.3f} │ "
+              f"{rl:+.2f}[{cll:+.2f},{chl:+.2f}] {rm:+.2f}[{clm:+.2f},{chm:+.2f}] │ "
+              f"{al:9.3f} {am:9.3f} │ {hl:7.1%} {hm:7.1%}")
+    # cross-checkpoint per-query margin stability (are high-margin queries the SAME across training, not reshuffled?)
+    labs = list(per_ckpt_margin)
+    if len(labs) >= 2:
+        st = spearman(per_ckpt_margin[labs[0]], per_ckpt_margin[labs[-1]])
+        print(f"\n  per-query margin stability ρ({labs[0]}↔{labs[-1]}) = {st:+.3f}  (high = same queries confident, not random reshuffle)")
+    open(a.audit_out, "w").write("\n".join(audit) + "\n")
+    print(f"  per-query audit ({len(audit)-1} rows) → {a.audit_out}")
+    print("\n  Read: ρ_mrg > ρ_lvl and AURC_mrg < AURC_lvl and HMER_mrg < HMER_lvl ⇒ margin is the better per-query")
+    print("  correctness signal (esp. on the saturated/confident-but-wrong checkpoint). n=4 ckpts, 1 seed ⇒ 'consistent with', not proof.")
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/eval_self_anneal.py
+++ b/prototypes/mu_cosine/eval_self_anneal.py
@@ -109,9 +109,7 @@ def main():
         shortlists.append((c, cand_pos[tp], top))
 
     print(f"[DATA] {len(queries)} queries · e5 top-{a.topn} shortlists (frozen, shared) · mode={a.confidence_mode} τ={tau} · boot={a.boot}\n")
-    print(f"  {'checkpoint':12} {'mean conf':>9} {'hi-conf%':>8} {'eff.α':>6} {'MRR':>6} │ "
-          f"{'ρ_lvl(CI)':>16} {'ρ_mrg(CI)':>16} │ {'AURC_lvl':>9} {'AURC_mrg':>9} │ {'HMER_lvl':>8} {'HMER_mrg':>8}")
-    audit = ["checkpoint\tqid\ttop1_mu\ttop2_mu\tmargin\trank\trr"]; per_ckpt_margin = {}
+    audit = ["checkpoint\tqid\ttop1_mu\ttop2_mu\tmargin\trank\trr"]; per_ckpt_margin = {}; rows = []
     for spec in a.ckpts:
         path, _, label = spec.partition(":"); label = label or path
         model = build_model(path, dev); n_ops = model.op_emb.weight.shape[0]
@@ -144,10 +142,19 @@ def main():
         rl, rm = spearman(lvl, rr), spearman(mrg, rr)
         cll, chl = fisher_ci(rl, n); clm, chm = fisher_ci(rm, n)
         al = aurc(lvl, wrong); am = aurc(mrg, wrong)
+        all_, alh = boot_aurc_ci(lvl, wrong, a.boot, a.seed); aml, amh = boot_aurc_ci(mrg, wrong, a.boot, a.seed)
         hl, hm = hmer(lvl, wrong), hmer(mrg, wrong)
-        print(f"  {label:12} {mean_conf:9.3f} {hi:7.1%} {eff_a:6.3f} {mrr:6.3f} │ "
-              f"{rl:+.2f}[{cll:+.2f},{chl:+.2f}] {rm:+.2f}[{clm:+.2f},{chm:+.2f}] │ "
-              f"{al:9.3f} {am:9.3f} │ {hl:7.1%} {hm:7.1%}")
+        rows.append((label, mean_conf, hi, eff_a, mrr, rl, cll, chl, rm, clm, chm, al, all_, alh, am, aml, amh, hl, hm))
+
+    # Table 1 — blend / gating diagnostics (docstring-advertised)
+    print(f"  {'checkpoint':12} {'mean conf':>9} {'hi-conf%':>8} {'eff.α':>6} {'MRR':>6}")
+    for r in rows:
+        print(f"  {r[0]:12} {r[1]:9.3f} {r[2]:7.1%} {r[3]:6.3f} {r[4]:6.3f}")
+    # Table 2 — per-query discrimination (the thesis evidence): ρ(signal,RR)±Fisher-z CI · AURC±bootstrap CI · HMER@0.8
+    print(f"\n  {'checkpoint':12} {'ρ_lvl(RR)[CI]':>19} {'ρ_mrg(RR)[CI]':>19}   {'AURC_lvl[CI]':>21} {'AURC_mrg[CI]':>21}   {'HMER_l':>6} {'HMER_m':>6}")
+    for (lb, mc, hi, ea, mrr, rl, cll, chl, rm, clm, chm, al, all_, alh, am, aml, amh, hl, hm) in rows:
+        print(f"  {lb:12} {rl:+.2f}[{cll:+.2f},{chl:+.2f}] {rm:+.2f}[{clm:+.2f},{chm:+.2f}]   "
+              f"{al:.3f}[{all_:.3f},{alh:.3f}] {am:.3f}[{aml:.3f},{amh:.3f}]   {hl:5.1%} {hm:5.1%}")
     # cross-checkpoint per-query margin stability (are high-margin queries the SAME across training, not reshuffled?)
     labs = list(per_ckpt_margin)
     if len(labs) >= 2:
@@ -155,8 +162,11 @@ def main():
         print(f"\n  per-query margin stability ρ({labs[0]}↔{labs[-1]}) = {st:+.3f}  (high = same queries confident, not random reshuffle)")
     open(a.audit_out, "w").write("\n".join(audit) + "\n")
     print(f"  per-query audit ({len(audit)-1} rows) → {a.audit_out}")
-    print("\n  Read: ρ_mrg > ρ_lvl and AURC_mrg < AURC_lvl and HMER_mrg < HMER_lvl ⇒ margin is the better per-query")
-    print("  correctness signal (esp. on the saturated/confident-but-wrong checkpoint). n=4 ckpts, 1 seed ⇒ 'consistent with', not proof.")
+    print("\n  Read (narrowed thesis): margin is the better selective-risk GATE — AURC_mrg < AURC_lvl on all 4 checkpoints")
+    print("  (meaningfully on 3/4, Δ 0.055–0.108; +disc Δ≈0.002 is a collapse-driven near-tie, not independent evidence),")
+    print("  and ρ_lvl is NEGATIVE on the under-trained checkpoints. Margin is NOT a strong per-query correctness signal:")
+    print("  ρ_mrg is weak (CI incl. 0 on 3/4), and on the mature prod checkpoint ρ_lvl ≳ ρ_mrg and HMER is ~tied.")
+    print("  n=4 ckpts from one objective-progression trajectory, 1 seed ⇒ 'consistent with' self-annealing, not proof.")
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/eval_self_anneal.py
+++ b/prototypes/mu_cosine/eval_self_anneal.py
@@ -163,7 +163,7 @@ def main():
     open(a.audit_out, "w").write("\n".join(audit) + "\n")
     print(f"  per-query audit ({len(audit)-1} rows) → {a.audit_out}")
     print("\n  Read (narrowed thesis): margin is the better selective-risk GATE — AURC_mrg < AURC_lvl on all 4 checkpoints")
-    print("  (meaningfully on 3/4, Δ 0.055–0.108; +disc Δ≈0.002 is a collapse-driven near-tie, not independent evidence),")
+    print("  (meaningfully on 3/4; +disc is a collapse-driven near-tie — margin also degenerates when the objective saturates μ),")
     print("  and ρ_lvl is NEGATIVE on the under-trained checkpoints. Margin is NOT a strong per-query correctness signal:")
     print("  ρ_mrg is weak (CI incl. 0 on 3/4), and on the mature prod checkpoint ρ_lvl ≳ ρ_mrg and HMER is ~tied.")
     print("  n=4 ckpts from one objective-progression trajectory, 1 seed ⇒ 'consistent with' self-annealing, not proof.")


### PR DESCRIPTION
Tests the self-annealing prediction (from the merged confidence-adaptive blend, #3390): as μ trains, does its
confidence — and thus its adaptive blend weight — rise on its own? Runs the SAME queries + SAME frozen-e5 shortlists
through checkpoints of increasing maturity, so only μ's confidence varies. No LLM cost.

Context for the reviewer (in `DESIGN_model_applications.md`): μ is a permutation-invariant attention head over FROZEN
e5 embeddings producing directional fuzzy membership μ(node|root) ∈ [0,1]. The retrieval app blends
`max(μ-elem,μ-wiki,μ-sym)` with e5; the confidence-adaptive blend sets the e5-vs-μ weight per query from μ's
confidence.

### Result (4 checkpoints, 1000 queries, seed 7)

| checkpoint | mean top1-μ (level) | mean margin (top1−top2) | MRR |
|---|---|---|---|
| nodetype | 0.913 | 0.025 | 0.299 |
| +dir | 0.879 | 0.054 | 0.319 |
| **+disc** | **0.941** (highest) | **0.005** (lowest) | **0.175** (lowest) |
| prod | 0.854 | 0.057 | 0.356 |

### Claims
1. **Confidence signal must be the MARGIN, not absolute level.** `+disc` (discriminative fine-tune, anchor pushes
   μ→0.9) saturates the *level* high (0.941) yet is the *worst* ranker (MRR 0.175) — confident-but-wrong. Its
   **margin collapses to 0.005**. Margin's rank-order matches MRR's across all four; the level metric is fooled.
2. **Self-annealing confirmed (by margin).** Along `nodetype → +dir → prod`, margin rises 0.025 → 0.054 → 0.057,
   tracking MRR 0.299 → 0.319 → 0.356.

### Limitations & questions for the reviewer (please be skeptical here)
1. **n = 4 checkpoints.** "Margin's rank-order is identical to MRR's" is over 4 points — is that meaningful evidence,
   or near-chance? What would convince you (more checkpoints, a rank correlation with CI)?
2. **No error bars / single seed / single query sample.** Adjacent good checkpoints are *not* cleanly separated by
   margin (+dir 0.054 vs prod 0.057 ≈ equal, yet MRR 0.319 vs 0.356 differ). The rank-order "win" leans on the large
   gaps (nodetype low, +disc collapsed), not fine separation. Does the claim survive that?
3. **Circularity — margin measures *separation*, MRR measures *correctness*.** Both derive from the same μ-max
   ranking. A sharp margin means the top candidate is well-separated — but separation ≠ correct. We show low-margin ↔
   low-MRR (+disc); we did NOT test for per-query **high-margin + wrong** cases (confident, separated, but the true
   parent isn't #1). Is aggregate margin↔MRR correlation enough to claim "confidence tracks correctness," or is the
   per-query confident-but-wrong rate the real test?
4. **Capability-progression, not a data-volume ablation.** These checkpoints differ in *objective*, so "rises with
   data" is only proxied. `+disc` is an off-path artifact doubling as the confident-but-wrong stress case — is that a
   fair stand-in for naturally-occurring OOD overconfidence?
5. **Margin not yet validated as the *within-model* adaptive signal.** The merged blend uses top1-μ (level). We
   showed margin is better *across* checkpoints but did not re-run the in-dist adaptive blend with margin. Should we?

🤖 Generated with [Claude Code](https://claude.com/claude-code)