### PR TITLE
μ-attention: real Pearltrees filing — the review-hardened recipe, honestly evaluated end-to-end

### DIFF
--- a/prototypes/mu_cosine/DESIGN_lineage_decoder.md
+++ b/prototypes/mu_cosine/DESIGN_lineage_decoder.md
@@ -196,6 +196,13 @@ the residual:
    - **Tier-2: a small learned subword vocab + character floor** for the **~6,864 singleton/tail** words (don't spend
      a token each; compose from subwords, chars as the no-hard-OOV floor).
    - Optional: recurring multi-word folder n-grams as atomic units for fluent phrases.
+   - **Punctuation = structure, not characters** (measured: parens in 8% of titles, hyphens 2%). *Parentheticals are
+     disambiguators/glosses* ("Satire (Social forces)") — split "X (Y)" into base `X` + qualifier `Y` (Y is a
+     human-readable disambiguator, same role as the id-anchor/lineage; for gloss/acronym cases Y also enriches the e5
+     embedding). Naming: generate base, add "(Y)" only on a name collision (Wikipedia-style), Y from the parent
+     branch. *Hyphens* split two ways: semantic compounds ("Counter-activism") stay whole (one concept), slug
+     artifacts ("s243a-wikispaces") are rare singletons → Tier-2 subword backoff. For *matching*, e5 absorbs all of it
+     ("20th-century" ≈ "20th century"); punctuation is a vocab/naming concern only, not a placement one.
    The full vocab is **~2k whole words + a few-hundred subword pieces** — on-device-trivial (fits the PWA ethos, no
    mandatory LLM). And Tier-1 is mostly **SELECTION not generation** (mirror placement): pick the folder-words nearest
    the slot embedding, order them; the tiny AR namer composes selected words + generates only tail subwords.

--- a/prototypes/mu_cosine/DESIGN_lineage_decoder.md
+++ b/prototypes/mu_cosine/DESIGN_lineage_decoder.md
@@ -5,6 +5,18 @@ counterpart to the **retrieval** LINEAGE operator (`train_lineage.py`): instead 
 folder/path, a decoder *generates* the placement path — and, crucially, can **propose a folder that doesn't exist
 yet**. Everything below is design, not built.
 
+> **Status: ROUGH FIRST DRAFT / future-work.** Confidence is highest on the optimizer framing (§0/§0b — decoder =
+> projected optimizer around the encoder) and the numbers/IDs handling (§4c); **least settled: the parenthesis /
+> hyphen handling in §6** (base+qualifier split, compound vs slug hyphens) — treat that as a starting hypothesis.
+>
+> **Simplification from the increment-2 result:** the composition sweep found **WIKI (subcategory) does branch
+> recovery better than the LINEAGE operator, and LINEAGE is redundant** to `max(μ-elem, μ-wiki)` (see
+> DESIGN_model_applications.md, "Composition (increment 2)"). So a decoder likely does **not** need the lineage/path
+> machinery at all — it can be the same projected optimizer, but walking the tree with **`μ-wiki` (branch/descend) +
+> `μ-elem` (commit to leaf)** over *folder-title* passages, with **no path embedding, no id line, and none of the
+> numbers-in-the-path problem** of §4c. That materially simplifies §2–§4c. Read the lineage-specific parts below as
+> "the general mechanism"; substitute wiki+elem for the operators.
+
 ## 0. Core framing: the decoder is a *constrained optimizer around the encoder* (no separate decoder network)
 
 The cleanest conception (supersedes the architecture-first framing below): the encoder defines a score/energy

--- a/prototypes/mu_cosine/DESIGN_lineage_decoder.md
+++ b/prototypes/mu_cosine/DESIGN_lineage_decoder.md
@@ -1,0 +1,230 @@
+# Lineage Decoder — design sketch (FUTURE WORK, not an immediate priority)
+
+Sketched during a training run, per the "would be cool to design for future work" note. This is the generative
+counterpart to the **retrieval** LINEAGE operator (`train_lineage.py`): instead of *picking* the best existing
+folder/path, a decoder *generates* the placement path — and, crucially, can **propose a folder that doesn't exist
+yet**. Everything below is design, not built.
+
+## 0. Core framing: the decoder is a *constrained optimizer around the encoder* (no separate decoder network)
+
+The cleanest conception (supersedes the architecture-first framing below): the encoder defines a score/energy
+landscape `μ_lineage(bookmark | path)`, and **decoding = optimize the path to maximize that score** — an
+energy-based / inference-as-optimization view. There is *no decoder network to train*; the "decoder" is a test-time
+optimization loop over the encoder we already have.
+
+**The one thing that makes it work: it must be a PROJECTED optimizer.** Free optimization of the path embeddings
+finds off-manifold degenerate maxima (high score, not a real path). The **snap-to-existing-children step is the
+projection** — it keeps each iterate on the manifold of real, tree-connected folders (or marks NEW). So precisely:
+*decoding = projected iterative optimization of the encoder's score; projection = snap to actual folders + respect
+tree connectivity.*
+
+This unifies everything already built:
+- **Retrieval = the 1-step greedy version** (single argmax). The decoder is just *more iterations of the same
+  objective* — retrieval and decoding are one system at different iteration counts.
+- **Margin gate = the stop/novelty rule** — converged with sharp margin → snap; flat → propose NEW; confidence
+  plateau → stop deepening (depth placement).
+- **Anytime/partial for free** — stop early → a coarse general-branch solution, which is actionable.
+- **Diffusion/recursive (§4b) = the update rule** — a refinement step moves toward the encoder's high-score region;
+  warm-init from the retrieval top-1. So §4b's "architectures" are really *choices of optimizer/update rule*, not
+  separate models.
+
+Net: the decoder collapses to **init from retrieval → iterate the encoder score under the snap-projection → stop by
+margin.** The sections below (why, novelty, training, naming, eval) all still apply — read them as details of this
+optimizer.
+
+## 0b. Training the optimizer = meta-learning (learning-to-optimize) — staged, with a safety net
+
+If the decoder is an optimizer around the encoder (§0), then *training* it is **learning-to-optimize / meta-learning
+/ amortized inference**: encoder = learned *scoring* (good path), meta-learned optimizer = learned *search* (find it
+fast). Same "model carries its own meta-signal" through-line as the confidence-adaptive blend (there: *when* to trust
+itself; here: *how* to search itself).
+
+**Optimizer state / IO (the L2O template):** the learned optimizer's inputs are (1) the **bookmark embedding** — the
+task/target descriptor, fixed across steps — and (2) the **last encoder output on the current partial path** — the
+current-solution feedback (analogue of "current params + gradient"). It outputs the next path-embedding estimate,
+which snap-projects to identities; re-encode; repeat. Two design points:
+- **Markovian-sufficient by re-encoding.** Because the encoder re-reads the *whole* partial path each step, its
+  output summarizes the entire partial solution — so the optimizer can **revise an earlier level (backtrack)** with
+  no separate memory. That's precisely what greedy can't do. (A recurrent trajectory memory is an L2 add-on for
+  sharper backtracking; L1 stays Markovian on these two inputs.)
+- **Feedback must carry DIRECTION, not just magnitude.** The scalar μ says "how good," not "which way" — you can't
+  step from one number. Feed the encoder's **hidden representation** of the partial path (attention output pre-readout)
+  and/or the **per-frontier-child μ distribution** (says which child to move toward). The optimizer then learns a
+  vector field: "given where I am (hidden state) and where I want to be (bookmark), here's the next move."
+
+Do it **staged**, cheapest first:
+- **L0 — hand-designed optimizer** (greedy projected walk, retrieval-init). No meta-training; likely most of the value.
+- **L1 — small learned update rule** (the recursive net). Add ONLY if L0 leaves a measurable gap (greedy stuck / no
+  backtracking).
+- **L2 — full learned optimizer** (recurrent state, learned step size/schedule). Only if L1 shows headroom.
+
+Why the meta-learning is realistic here (not a research gamble):
+- **Learn only the RESIDUAL.** μ_lineage was trained on prefixes (coarse-to-fine), so a greedy walk already converges
+  decently — the optimizer only needs to learn the *revision/lookahead* greedy lacks (fix an early level after seeing
+  the leaf). Small correction ≫ easier than learning search from scratch.
+- **Freeze the encoder** during optimizer meta-training (fixed energy; learned search over it — no moving target).
+- **Dense loss** — supervise every step to reduce path-error / raise μ, plus a convergence-speed term. Sparse
+  final-only reward is where learned optimizers go unstable / fail past the training horizon.
+- **Safety net (why it's safe to try here):** the snap projection means even a bad optimizer step lands on a *real
+  folder* — worst case the decoder degrades to retrieval, never to garbage. Anytime + monotonic-ish by construction.
+
+## 1. Why a decoder (what it adds beyond retrieval)
+
+Retrieval (current) scores `μ_lineage(bookmark | candidate-path)` over existing folders + their prefixes, and takes
+the top hit. It can place into any *existing* node (leaf or intermediate). It **cannot**:
+- propose a **new leaf** under a good branch ("create `Wave momentum` under `Physics ▸ Waves`"),
+- propose a **new intermediate branch** when the topic isn't covered,
+- express placement as a *path the tree doesn't yet contain*.
+
+A decoder emits the path level-by-level and, at each level, may **create** rather than select. That's the
+"this belongs somewhere new" capability.
+
+## 2. Core idea: decoding = autoregressive prefix-extension in lineage space
+
+The retrieval work already gives us the decoder's backbone. We trained on **prefixes** (path-prefix dropout), so the
+model already scores `μ_lineage(bookmark | prefix)` at every depth — that *is* a per-level SELECT distribution.
+Decoding is just walking it:
+
+```
+path = [root]
+loop:
+    children = existing children of path[-1]                      # candidates at this level
+    s = μ_lineage(bookmark | path + [c])  for c in children      # per-child fit (reuse the operator)
+    if max(s) margin is CONFIDENT:  path.append(argmax c)         # SELECT an existing child
+    else:                           path.append(NEW(bookmark, path))   # PROPOSE a new node
+    stop when depth-confidence drops (the depth-placement signal) or a leaf is chosen
+```
+
+So the decoder is autoregressive prefix-extension, and **selection at each step is the LINEAGE operator we already
+have.** The only genuinely new pieces are the *stop/novelty* decision and *naming*.
+
+## 3. Novelty detection = the margin gate we already built
+
+The decision "select existing vs propose new" is exactly the **confidence/margin gate** from #3391 and the filing
+composition: if the best existing child's `μ_lineage` **margin is sharp**, an existing folder fits → SELECT; if the
+margin is **flat/low** (no existing child is a good home), that's the signal to **propose a new node**. So novelty
+detection is not new machinery — it's the margin signal, reused at each decode step. (This also reuses the "gate
+self-adjusts to how much μ can be trusted" property: confident → commit to existing structure; uncertain → create.)
+
+Likewise **stop depth** = where per-level margin stops being confident (the depth-placement signal): decode down the
+tree until the model is no longer sure a deeper child is warranted, then stop (or propose a leaf).
+
+## 4. Three architecture options (increasing ambition)
+
+- **A. Embedding-space snap-or-new (smallest, fits our stack).** Decode the path as a sequence of *target embeddings*
+  in lineage space. At each level, snap the target to the nearest existing child if within a margin; else mark a
+  **NEW node** (a point in embedding space) to be named later. No text generation inside the model. Most consistent
+  with the frozen-e5 + μ-attention design; the "new folder" is an embedding + a naming step (§6).
+- **B. Retrieval-augmented select-or-new head.** At each level, retrieve existing children via `μ_lineage`, plus a
+  learned `[PROPOSE-NEW]` option; a small classifier head picks among {children, propose-new}. If propose-new, hand
+  off to a naming step. Modest new head on top of the existing encoder.
+- **C. Full text-autoregressive path decoder.** Generate folder-title tokens level by level, conditioned on the
+  bookmark + path-so-far (seq2seq). Most flexible (free-form new folders) but the heaviest — needs a real decoder
+  stack and the most data, and drifts from the embedding-centric approach. Likely overkill vs (A/B).
+
+**Lean: A first** (or B) — it reuses μ_lineage as the selector, adds only novelty (margin) + a naming step, and
+stays in embedding space. C only if free-form generation is later shown to be needed.
+
+## 4b. Decoding paradigm: iterative refinement (diffusion / recursive) — PREFERRED over autoregressive
+
+The §2/§4 framing was left-to-right autoregressive. A better fit is **non-autoregressive iterative refinement**
+(diffusion or recursive): represent the whole path as a fixed-width sequence of node slots, start from a rough/partial
+estimate, and **refine all slots jointly over several steps** — "start with a partial solution and optimize." Why it
+suits filing:
+- **Coarse-to-fine = general→specific.** Early steps set the general (root-ward) slots at high confidence; later
+  steps sharpen the specific (leaf-ward) slots — the exact structure the retrieval results showed (general levels
+  reliable, leaf hard).
+- **Anytime / partial-is-valid.** Any intermediate state is a usable placement — a correct general branch is
+  actionable (searchable by name, resolvable by id). Stop refining when per-slot confidence plateaus.
+- **Revisability (the big one over AR).** If sharpening the leaf reveals the branch was wrong, refinement can *fix an
+  earlier slot*; autoregressive commits left-to-right and cannot backtrack.
+- **Compute allocation.** More refinement steps where uncertain, fewer where confident.
+
+**Output sizing:** fixed width = **2× the longest existing path (13 → 26 slots)**. The 2× headroom is for
+*propose-new* (a generated path with new intermediate nodes can be deeper than any existing path) and for
+overshoot-then-prune during refinement. Unused slots decode to EOS/empty.
+
+**Embedding-space diffusion (fits the frozen-e5 stack):** the sequence is 26 path-node *embeddings*. Condition on the
+bookmark embedding; iteratively denoise the sequence toward the true-path embeddings (from noise, or from a
+bookmark-broadcast init). **Readout per slot = snap-or-new** (§3): snap to the nearest existing child within a
+confidence margin, else mark NEW; the **margin gate is the per-slot novelty detector**, and confidence plateau across
+refinement steps is the **stop-depth** signal. Recursive variant: a net that maps (bookmark, current-path-estimate)
+→ improved estimate, iterated — same properties, simpler than a full diffusion schedule; a reasonable first cut.
+
+## 4c. Numbers / IDs — converge in embedding space, resolve IDs by snapping (never generate them)
+
+The hierarchical list starts with a materialized `/id/id` line of **tree IDs (arbitrary numbers)**. A decoder must
+NOT try to *generate* these — there's no per-number embedding and number tokenization is a known headache. The
+resolution makes the problem vanish: **the decoder converges in EMBEDDING space and resolves IDs by lookup, not
+generation.**
+- The refinement target is the **semantic (title) content** of the path — "converge to the target hierarchical list"
+  means converge the node-embedding sequence toward the target *titles' embeddings*, not reproduce the `/id` string.
+- **Readout resolves identity by SNAP:** each converged node-embedding → nearest existing folder → its ID comes from
+  the **lookup** (we already store folder→id). No number is ever emitted.
+- **New nodes** (embedding far from any existing → margin = NEW): no ID needed — Pearltrees assigns one on creation,
+  and the name comes from a Haiku call (§6). Again, nothing numeric is generated.
+- The `/id` line stays an **encoder-side anchor** for μ_lineage matching (with ID-dropout); it is deliberately not a
+  decoder output. (Even encoding needs no number vocabulary — e5's subword/digit tokenizer already yields *some*
+  embedding per id-string, enough to act as a unique-ish anchor.)
+
+So iteration converges *embeddings*; identity/IDs are a nearest-neighbor + lookup step at readout. This keeps the
+whole decoder in the frozen-e5 embedding space and avoids number-tokenization entirely.
+
+## 5. Training (teacher-forcing on paths; held-out-leaf for propose-new)
+
+- **Selection:** teacher-force on the true path — same jsonL, same prefixes we already cache. At each level the
+  target is the true child; the operator already learns this.
+- **Propose-new supervision:** hold out some leaf (or intermediate) folders during training so the true path's
+  final node is *absent from the candidate set* — the model must learn to emit NEW there instead of forcing a wrong
+  existing child. This is the generative analogue of bookmark-holdout, and it's the only new data recipe needed.
+- The **prefix-dropout / ID-dropout** masking we built already trains robustness to partial paths — directly useful
+  for a decoder that must extend truncated/partial trees.
+
+## 6. Naming a proposed new folder — a spectrum (retrieval-first; learned compact vocab; LLM only for the novel tail)
+
+Embedding-space + snap needs *no vocabulary for placement*; a vocabulary only resurfaces here, for naming a proposed
+node (a slot = embedding + parent/sibling context). Mirror the placement philosophy — retrieval-first, generate only
+the residual:
+1. **Retrieval / template naming (no generation, no vocab).** Most new-folder names are *recombinations of known
+   topics* (the folder is new; its words aren't). Try nearest existing titles / nearest inner-bookmark titles to the
+   slot embedding, or a template compose ("X and Y" from the two nearest concepts). Handles a large fraction, zero OOV.
+2. **Learned compact, multi-granularity vocabulary + a tiny AR namer** (for the residual). Build a *domain-scoped*
+   vocab from the title corpus: **characters** (no-hard-OOV floor) + subwords + whole words + **multi-word units**
+   (mine common title n-grams — "Machine Learning", "Quantum Mechanics" — as single tokens for fluent compositional
+   names). A small AR namer decodes over it, **conditioned on the slot embedding + parent/sibling context**. This is
+   learned tokenization tailored to the user's topic space (hundreds–few-thousand units, not a 30k fixed vocab), and
+   it runs **on-device** — fits the PWA/on-device ethos; no mandatory LLM.
+3. **LLM (Haiku) — only the genuinely-novel tail**, where even the learned vocab lacks coverage; or a one-tap user
+   confirmation. Small, because placement already succeeded and naming is recombination most of the time.
+
+Honest caveat: the compact vocab reintroduces OOV *only at the naming tail* (truly novel topics); the char floor
+prevents hard failure but can be awkward there — which is exactly where step 3 earns its place. Older option:
+**cluster naming** — accumulate unfiled bookmarks whose slots land near the same new-node embedding and name the
+cluster (any of steps 1–3), better when proposing folders in batch.
+
+## 7. Evaluation (the genuinely hard part — scope before building)
+
+No ground truth for "propose new," so:
+- **Held-out-folder recovery:** hide a real leaf; does the decoder (a) get its parent path right and (b) propose a
+  new-node embedding close to the hidden folder's embedding, with a sensible name? Measurable via path-overlap on the
+  prefix + embedding distance on the proposed leaf.
+- **Path-overlap with partial credit** (already have): correct prefix + reasonable new leaf scores well.
+- **Human/LLM judgement** for name quality (last resort; costs budget).
+Define this eval *before* building — it's the riskiest part.
+
+## 8. Integration with the existing agent
+
+Today: `infer_pearltrees_federated.py` retrieves folders, then **parent-walks** for the breadcrumb, then the LLM
+assistant picks. A decoder would **replace the parent-walk** with a learned path *and* feed the assistant a
+`[create new folder here]` candidate — turning "file into existing" into "file, creating structure as needed."
+Intermediate proposed nodes remain actionable exactly as the retrieval ones (searchable by name / resolvable by id).
+
+## 9. Smallest first step (when we pick this up)
+
+Not now. When we do, the smallest viable cut is the **recursive** variant of §4b (simpler than a full diffusion
+schedule): a small net mapping `(bookmark, current-26-slot-path-estimate) → improved estimate`, iterated a few steps,
+on top of the trained LINEAGE operator. Reuse `μ_lineage` for per-slot **snap-or-new** (margin = novelty), start the
+estimate from the retrieval top-1's path (already a decent partial solution), and refine. Eval = **held-out-leaf
+recovery** (scope this first — riskiest part). Naming via a single Haiku call per proposed node. Diffusion is the
+richer version if the recursive first cut shows the paradigm works. Net new cost: one small refinement head + one
+eval recipe — everything else (operator, margin gate, prefix training, embeddings) already exists.

--- a/prototypes/mu_cosine/DESIGN_lineage_decoder.md
+++ b/prototypes/mu_cosine/DESIGN_lineage_decoder.md
@@ -188,12 +188,17 @@ the residual:
 1. **Retrieval / template naming (no generation, no vocab).** Most new-folder names are *recombinations of known
    topics* (the folder is new; its words aren't). Try nearest existing titles / nearest inner-bookmark titles to the
    slot embedding, or a template compose ("X and Y" from the two nearest concepts). Handles a large fraction, zero OOV.
-2. **Learned compact, multi-granularity vocabulary + a tiny AR namer** (for the residual). Build a *domain-scoped*
-   vocab from the title corpus: **characters** (no-hard-OOV floor) + subwords + whole words + **multi-word units**
-   (mine common title n-grams — "Machine Learning", "Quantum Mechanics" — as single tokens for fluent compositional
-   names). A small AR namer decodes over it, **conditioned on the slot embedding + parent/sibling context**. This is
-   learned tokenization tailored to the user's topic space (hundreds–few-thousand units, not a 30k fixed vocab), and
-   it runs **on-device** — fits the PWA/on-device ethos; no mandatory LLM.
+2. **Two-tier domain vocabulary + a tiny AR namer** (for the residual) — word-level with subword backoff:
+   - **Tier-1: whole-word tokens from the titles.** Measured on the real harvest: **~1,804 unique *folder*-title
+     words** (the natural naming pool — folder names are generic recombinations), or ~5,361 words if you include
+     recurring (≥2×) bookmark words. No training — just collect them. Frequency-thresholded (≥2×) is the natural
+     Tier-1/Tier-2 boundary.
+   - **Tier-2: a small learned subword vocab + character floor** for the **~6,864 singleton/tail** words (don't spend
+     a token each; compose from subwords, chars as the no-hard-OOV floor).
+   - Optional: recurring multi-word folder n-grams as atomic units for fluent phrases.
+   The full vocab is **~2k whole words + a few-hundred subword pieces** — on-device-trivial (fits the PWA ethos, no
+   mandatory LLM). And Tier-1 is mostly **SELECTION not generation** (mirror placement): pick the folder-words nearest
+   the slot embedding, order them; the tiny AR namer composes selected words + generates only tail subwords.
 3. **LLM (Haiku) — only the genuinely-novel tail**, where even the learned vocab lacks coverage; or a one-tap user
    confirmation. Small, because placement already succeeded and naming is recombination most of the time.
 

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -285,6 +285,29 @@ leaf-certainty). Masking's prefix-dropout also buys robustness to truncated / RD
 depth-placement. (Paired subset is the honest test — per-ranker miss-sets differ, so unpaired overlap|MISS was
 confounded; single split — a multi-split CI is the remaining follow-up.)
 
+#### Composition (increment 2) — best filer is `e5 + max(μ-elem, μ-wiki)`; LINEAGE is redundant (`train_lineage.py --eval-only`)
+Combiner sweep over `model_lineage` (held-out n=300, seed 7 — single-seed, multi-seed confirm is the follow-up):
+
+| combiner | recall@1 | MRR | ov\|miss | depth\|miss |
+|---|---|---|---|---|
+| mu-elem | 0.310 | 0.447 | 0.312 | 1.43 | *(leaf champ)* |
+| mu-wiki | 0.253 | 0.359 | **0.401** | **2.00** | *(BRANCH champ)* |
+| mu-lineage | 0.193 | 0.308 | 0.359 | 1.65 | |
+| **e5+max(elem,wiki)** | 0.303 | 0.438 | 0.391 | 1.94 | *(best all-rounder)* |
+| e5+max(elem,lin) | 0.313 | 0.438 | 0.379 | 1.83 | |
+| e5+max(el,wk,lin) | 0.307 | 0.434 | 0.392 | 1.89 | *(lineage adds ~0)* |
+
+Findings: (1) **Surprise — WIKI (subcategory/subset) is the graceful-degradation champion** (ov|miss 0.401, depth
+2.00), beating the purpose-built LINEAGE (0.359/1.65) *and simpler* (folder-title passage, no path). Subcategory is
+inherently general/structural containment ⇒ it *is* the branch operator. The complementary pair is **ELEM (leaf) +
+WIKI (branch), both pre-existing** — as the "why not subset?" question anticipated. (2) **The composition achieves the
+goal:** `e5 + max(μ-elem, μ-wiki)` gets ~elem's leaf (recall@1 0.303 / MRR 0.438) *and* ~wiki's branch (ov|miss
+0.391) in **one** ranker — the best all-rounder. (3) **LINEAGE is redundant** — adding it (`e5+max(el,wk,lin)` 0.392)
+gives ~0 over `e5+max(elem,wiki)` (0.391); the new operator, as built, doesn't earn its place. The lineage work still
+delivered the graceful-degradation *insight* + the path-overlap *metric* that revealed this. **Verdict: filer =
+`e5 + max(μ-elem, μ-wiki)`, no new operator required.** (Open: lineage *might* improve with more training / a cleaner
+path representation, but it's not needed given wiki.)
+
 #### Operating point — μ's edge is at recall@10 / median rank, which is exactly what an LLM re-ranker consumes
 Across **all three** results, μ's advantage over `e5-cos` concentrates at **recall@10 and median rank**, *not*
 recall@1 (where e5-cos is often comparable or slightly ahead): home-turf recall@10 **0.494 vs 0.424** /

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -211,6 +211,31 @@ highest, std 0.025.) Remaining headroom: a longer fine-tune / more data per the 
 *scaffolding*, per the bitter-lesson framing below): the local-tangent **bivector feature** only if a thin
 sub-domain needs sample-efficiency; otherwise the bet is simply more data + training.
 
+#### Review-hardened rankers, zero-shot OOD — the margin gate is the best zero-shot strategy (damage control)
+`eval_filing.py` now carries the review-hardened rankers from the Wikipedia arc: **`mu-max`** = `max(μ-elem, μ-wiki,
+μ-sym)` (the operator-OR), **`e5+mu-max`** = the coverage-insurance blend, **`margin-gate`** = per-query α from the
+μ-max margin (the #3391 finding operationalised). Run **zero-shot** (Wikipedia-trained `model_prod`, *no* filing
+fine-tune) on 500 real filing decisions (335 folders):
+
+| ranker | recall@1 | MRR | | strat MRR (e5 / margin-gate): FAR·MID·NEAR |
+|---|---|---|---|---|
+| **e5-cos** | **0.196** | **0.295** | | 0.306 · 0.324 · 0.255 |
+| mu-super / mu-elem / mu-max | 0.06 | 0.12–0.13 | | (μ ~0.11–0.16 at every stratum) |
+| e5+mu-max | 0.078 | 0.144 | | |
+| **margin-gate** | 0.146 | **0.212** | | 0.202 · 0.253 · 0.181 |
+
+**Re-confirms the known ~2× zero-shot OOD loss** — and sharpens it: e5-cos wins at *every* core-distance stratum,
+including NEAR the STEM core, so this is **transfer failure** (Wikipedia *category* structure ≠ personal *folder*
+structure), **not** a trained-region effect (the gap is a uniform ~0.07–0.10 everywhere, refuting "μ helps in its
+trained region"). **New finding:** the **margin gate is by far the best zero-shot ranker** — 0.212 vs `mu-max` 0.125
+(+70%), recovering **~60% of the gap to e5**. It works exactly as designed: it detects μ's OOD low-confidence
+(flat margins) and defers to e5, so the *mechanism* validated in #3391 holds on real data even though the *payoff*
+(μ adding value OOD) does not — the optimal μ-weight zero-shot is ≈0 and the gate trends there (damage control where
+μ is net-harmful). Coverage-insurance vindicated in spirit: the whole domain is untrained for μ, e5 is the robust
+baseline, and the gate correctly leans on it. **The fix is in-domain training** (the learning curve above: fine-tune
+crosses e5 at 30%+ data, +23% at 100%). **Open next:** run these same rankers on a *filing-fine-tuned* μ — does the
+operator-OR + margin gate push *further* above e5 in-domain, on top of the +23% fine-tune win?
+
 #### Operating point — μ's edge is at recall@10 / median rank, which is exactly what an LLM re-ranker consumes
 Across **all three** results, μ's advantage over `e5-cos` concentrates at **recall@10 and median rank**, *not*
 recall@1 (where e5-cos is often comparable or slightly ahead): home-turf recall@10 **0.494 vs 0.424** /

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -233,8 +233,25 @@ trained region"). **New finding:** the **margin gate is by far the best zero-sho
 (μ adding value OOD) does not — the optimal μ-weight zero-shot is ≈0 and the gate trends there (damage control where
 μ is net-harmful). Coverage-insurance vindicated in spirit: the whole domain is untrained for μ, e5 is the robust
 baseline, and the gate correctly leans on it. **The fix is in-domain training** (the learning curve above: fine-tune
-crosses e5 at 30%+ data, +23% at 100%). **Open next:** run these same rankers on a *filing-fine-tuned* μ — does the
-operator-OR + margin gate push *further* above e5 in-domain, on top of the +23% fine-tune win?
+crosses e5 at 30%+ data, +23% at 100%).
+
+**In-domain (fine-tuned μ, `train_filing.py --save` → `rank_all` on the HELD-OUT split — fair, no train-on-test):**
+
+| ranker | recall@1 | MRR | note |
+|---|---|---|---|
+| e5-cos | 0.200 | 0.284 | the bar |
+| mu-elem | 0.258 | 0.362 | the documented fine-tune win (+27%) |
+| mu-max (OR) | 0.233 | 0.342 | **OR *dilutes* in-domain** — only ELEM was fine-tuned, so wiki/sym are stale |
+| **e5+mu-elem** | **0.307** | **0.396** | **best — +39% over e5, +9% over mu-elem** |
+| e5+mu-max | 0.302 | 0.391 | blend still strong even on the diluted OR |
+| margin-gate | 0.278 | 0.365 | ≈ mu-elem — gate redundant when μ is trustworthy in-domain |
+
+Three lessons, and they line up with the rest of the arc:
+1. **The coverage-insurance blend generalises to in-domain** — `e5+mu-elem` (0.396) beats *both* plain fine-tuned μ (0.362) and e5 (0.284), with a big recall@1 lift (0.307 vs 0.258/0.200). The blend adds value *on top of* the fine-tune win, exactly as on Wikipedia.
+2. **The operator-OR only helps if its operators are trained for the domain.** On Wikipedia (multi-relationally trained) `mu-max` won; here (ELEM-only fine-tune) it *dilutes* below `mu-elem`. → this is the direct argument for training *more* filing operators (e.g. a `LINEAGE` op), then OR-ing them.
+3. **The margin gate is redundant in-domain** (≈ mu-elem) — consistent with #3391: the gate's value is OOD damage-control, not in-domain, because in-domain μ is trustworthy and deserves full weight. Zero-shot the gate was the *best* μ-variant; in-domain it's a wash. The gate correctly self-adjusts to how much μ can be trusted.
+
+Net filing verdict: **zero-shot, use e5 (μ doesn't transfer, gate limits the damage); in-domain, use `e5 + μ-elem` (best, +39% over e5).**
 
 #### Operating point — μ's edge is at recall@10 / median rank, which is exactly what an LLM re-ranker consumes
 Across **all three** results, μ's advantage over `e5-cos` concentrates at **recall@10 and median rank**, *not*

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -311,6 +311,15 @@ path-overlap *metric* that revealed this. **Verdict: filer = `e5 + max(μ-elem, 
 required.** (Open: lineage was a *fresh* op with only 300 steps vs wiki's rich Wikipedia pretraining, so it may be
 undertrained rather than wrong — but it's not needed given wiki/sym.)
 
+**Multi-seed confirm (3 seeds, retrained on own splits):** `e5+max(elem,wiki,sym)` beats `mu-elem` on all axes every
+seed — mean recall@1 0.304 vs 0.280, MRR 0.425 vs 0.414, ov|miss 0.388 vs 0.304. Adding lineage at inference stays a
+wash (`e5+max(all4)` 0.302 / 0.419 / 0.391 — recall@1/MRR a hair lower, branch a hair higher). So "best filer =
+`e5+max(elem,wiki,sym)`, lineage redundant *at inference*" is CI-hardened. *(Data note: `api_tree_paths_v8.jsonl`
+paths are 99% complete to the account root — the rate-limited harvester successfully backfilled the partial RDF
+export — so the lineage finding is NOT a path-truncation artifact; ~89% of trees have a path entry at all, the rest
+excluded. Separately testing whether *training* lineage helps the shared encoder — the auxiliary-task hypothesis —
+via a `--lineage-weight 0` ablation.)*
+
 #### Operating point — μ's edge is at recall@10 / median rank, which is exactly what an LLM re-ranker consumes
 Across **all three** results, μ's advantage over `e5-cos` concentrates at **recall@10 and median rank**, *not*
 recall@1 (where e5-cos is often comparable or slightly ahead): home-turf recall@10 **0.494 vs 0.424** /

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -253,6 +253,31 @@ Three lessons, and they line up with the rest of the arc:
 
 Net filing verdict: **zero-shot, use e5 (μ doesn't transfer, gate limits the damage); in-domain, use `e5 + μ-elem` (best, +39% over e5).**
 
+#### LINEAGE operator (increment 1) — graceful degradation confirms "file general→specific" (`train_lineage.py`)
+A new **`LINEAGE`** operator scores `μ(bookmark | hierarchical-PATH)` — the *undifferentiated* generalization of
+ELEM+WIKI (the embedded `target_text` path carries no relation-type; verified). Built per the agreed design: a
+**fresh op row** (n_ops 4→5 via row-copy warm-start of `model_filing` — *not* hand-initialized from ELEM/WIKI; it
+learns its relation to them through training), fine-tuned with **ELEM replay** + **masking** (ID-dropout via
+precomputed `/*`-wildcard variants + path-prefix dropout; the id line stays as unique anchors). Held-out filing
+(n=300):
+
+| ranker | recall@1 | MRR | overlap(all) | overlap \| elem-miss (paired, n=207) |
+|---|---|---|---|---|
+| e5-cos | 0.170 | 0.270 | 0.380 | 0.332 |
+| mu-elem | 0.310 | 0.447 | 0.525 | 0.312 |
+| **mu-lineage** | 0.193 | 0.308 | 0.453 | **0.359** |
+
+Findings: (1) `mu-lineage` beats e5 on *every* metric — a real, distinct signal. (2) `mu-elem` dominates exact-leaf
++ overall-overlap — it's the leaf specialist. (3) **But on the PAIRED hard subset** (the 207 queries where `mu-elem`
+misses the leaf), **`mu-lineage` recovers the ancestor branch best — 0.359 > e5 0.332 > elem 0.312.** The
+"file general→specific" hypothesis, confirmed: when the leaf can't be nailed, lineage stays in the right general
+branch (densely-reused upper levels), while the leaf-specialist, *on its own misses, wanders below even raw e5*
+(0.312 < 0.332) because it optimises leaf-specificity over the general path. (4) So **elem and lineage are
+complementary** — leaf-specialist + graceful branch-fallback — which *data-motivates* the composition (increment 2:
+a margin-gate / OR switching on leaf-certainty). Masking's prefix-dropout also buys robustness to truncated /
+RDF-partial paths and free depth-placement. Caveats: single-seed, one split (multi-seed + CI = follow-up); the
+paired subset is the honest test (per-ranker miss-sets differ, so unpaired overlap|MISS was confounded).
+
 #### Operating point — μ's edge is at recall@10 / median rank, which is exactly what an LLM re-ranker consumes
 Across **all three** results, μ's advantage over `e5-cos` concentrates at **recall@10 and median rank**, *not*
 recall@1 (where e5-cos is often comparable or slightly ahead): home-turf recall@10 **0.494 vs 0.424** /

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -292,21 +292,24 @@ Combiner sweep over `model_lineage` (held-out n=300, seed 7 — single-seed, mul
 |---|---|---|---|---|
 | mu-elem | 0.310 | 0.447 | 0.312 | 1.43 | *(leaf champ)* |
 | mu-wiki | 0.253 | 0.359 | **0.401** | **2.00** | *(BRANCH champ)* |
+| mu-sym | 0.293 | 0.431 | 0.340 | 1.57 | |
 | mu-lineage | 0.193 | 0.308 | 0.359 | 1.65 | |
-| **e5+max(elem,wiki)** | 0.303 | 0.438 | 0.391 | 1.94 | *(best all-rounder)* |
-| e5+max(elem,lin) | 0.313 | 0.438 | 0.379 | 1.83 | |
-| e5+max(el,wk,lin) | 0.307 | 0.434 | 0.392 | 1.89 | *(lineage adds ~0)* |
+| e5+max(elem,wiki) | 0.303 | 0.438 | 0.391 | 1.94 | |
+| **e5+max(elem,wiki,sym)** | 0.313 | 0.439 | 0.395 | 1.93 | *(BEST — all three)* |
+| e5+max(all4) | 0.313 | 0.436 | 0.391 | 1.86 | *(+lineage adds ~0)* |
 
 Findings: (1) **Surprise — WIKI (subcategory/subset) is the graceful-degradation champion** (ov|miss 0.401, depth
 2.00), beating the purpose-built LINEAGE (0.359/1.65) *and simpler* (folder-title passage, no path). Subcategory is
 inherently general/structural containment ⇒ it *is* the branch operator. The complementary pair is **ELEM (leaf) +
-WIKI (branch), both pre-existing** — as the "why not subset?" question anticipated. (2) **The composition achieves the
-goal:** `e5 + max(μ-elem, μ-wiki)` gets ~elem's leaf (recall@1 0.303 / MRR 0.438) *and* ~wiki's branch (ov|miss
-0.391) in **one** ranker — the best all-rounder. (3) **LINEAGE is redundant** — adding it (`e5+max(el,wk,lin)` 0.392)
-gives ~0 over `e5+max(elem,wiki)` (0.391); the new operator, as built, doesn't earn its place. The lineage work still
-delivered the graceful-degradation *insight* + the path-overlap *metric* that revealed this. **Verdict: filer =
-`e5 + max(μ-elem, μ-wiki)`, no new operator required.** (Open: lineage *might* improve with more training / a cleaner
-path representation, but it's not needed given wiki.)
+WIKI (branch), both pre-existing** — as the "why not subset?" question anticipated. (2) **All three win:**
+`e5 + max(μ-elem, μ-wiki, μ-sym)` is the best combiner (recall@1 0.313 ≥ elem's 0.310, MRR 0.439 ≈ 0.447, ov|miss
+0.395 ≈ wiki's 0.401) — sym adds a small lift over elem+wiki, so the full base-operator OR is best. Notably this is
+**the *same* operator-OR that won the Wikipedia retrieval eval** — same combiner, now confirmed in-domain on real
+filing. (3) **LINEAGE is redundant** — `e5+max(all4)` (0.391) is *below* `e5+max(elem,wiki,sym)` (0.395); the new
+operator adds ~0 even on top of all three. The lineage work still delivered the graceful-degradation *insight* +
+path-overlap *metric* that revealed this. **Verdict: filer = `e5 + max(μ-elem, μ-wiki, μ-sym)`, no new operator
+required.** (Open: lineage was a *fresh* op with only 300 steps vs wiki's rich Wikipedia pretraining, so it may be
+undertrained rather than wrong — but it's not needed given wiki/sym.)
 
 #### Operating point — μ's edge is at recall@10 / median rank, which is exactly what an LLM re-ranker consumes
 Across **all three** results, μ's advantage over `e5-cos` concentrates at **recall@10 and median rank**, *not*

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -317,8 +317,21 @@ wash (`e5+max(all4)` 0.302 / 0.419 / 0.391 — recall@1/MRR a hair lower, branch
 `e5+max(elem,wiki,sym)`, lineage redundant *at inference*" is CI-hardened. *(Data note: `api_tree_paths_v8.jsonl`
 paths are 99% complete to the account root — the rate-limited harvester successfully backfilled the partial RDF
 export — so the lineage finding is NOT a path-truncation artifact; ~89% of trees have a path entry at all, the rest
-excluded. Separately testing whether *training* lineage helps the shared encoder — the auxiliary-task hypothesis —
-via a `--lineage-weight 0` ablation.)*
+excluded.)*
+
+**Auxiliary-task ablation (`--lineage-weight 0` vs `1`, same warm-start/split/seed, 3 seeds).** Does *training* lineage
+improve the shared encoder even though it's redundant at inference? At 300 steps: **SYM is robustly helped** —
+with-lineage recall@1 0.293 vs elem-only 0.266 (+0.027; MRR +0.020), consistent across all 3 seeds. LINEAGE
+(undifferentiated path relatedness) is flavor-matched to SYM (symmetric relatedness), so co-training reinforces it;
+ELEM is wash/slightly-hurt, WIKI wash. **But at the *filer* level (`e5+max(elem,wiki,sym)`) the effect is marginal and
+mixed**: mean Δ recall@1 +0.008 (seed 13 *negative*), MRR +0.005, branch ov|miss +0.018 (2/3 seeds positive — the
+sym-flavored effect leaning toward branch recovery). So the sym gain does **not** cleanly propagate to the filer.
+**Verdict: the auxiliary-task hypothesis is OPEN** — one robust positive signal (sym) that doesn't robustly reach the
+filer at 300 steps. Crucially this is **early training**; early-mixed does NOT refute a late-training benefit
+(auxiliary tasks often slow early convergence yet improve the final representation). The real test is the A/B **at
+full training length — not run**. Net: lineage is *redundant as an inference ranker* (settled, CI-hardened),
+*plausibly useful as a training-time auxiliary* (open). It also slows end-model training — so any adoption is
+"worth it *iff* a full-length A/B confirms the filer benefit and it justifies the slowdown."
 
 #### Operating point — μ's edge is at recall@10 / median rank, which is exactly what an LLM re-ranker consumes
 Across **all three** results, μ's advantage over `e5-cos` concentrates at **recall@10 and median rank**, *not*

--- a/prototypes/mu_cosine/DESIGN_model_applications.md
+++ b/prototypes/mu_cosine/DESIGN_model_applications.md
@@ -261,22 +261,29 @@ learns its relation to them through training), fine-tuned with **ELEM replay** +
 precomputed `/*`-wildcard variants + path-prefix dropout; the id line stays as unique anchors). Held-out filing
 (n=300):
 
-| ranker | recall@1 | MRR | overlap(all) | overlap \| elem-miss (paired, n=207) |
-|---|---|---|---|---|
-| e5-cos | 0.170 | 0.270 | 0.380 | 0.332 |
-| mu-elem | 0.310 | 0.447 | 0.525 | 0.312 |
-| **mu-lineage** | 0.193 | 0.308 | 0.453 | **0.359** |
+(n=300). **Multi-seed (3 training seeds 7/13/23, split fixed at 7); means, with per-seed ranges on the hard subset:**
+
+| ranker | recall@1 | MRR | ov(all) | ov\|elem-miss | depth\|elem-miss |
+|---|---|---|---|---|---|
+| e5-cos | 0.170 | 0.270 | 0.380 | 0.323 (.317–.328) | 1.40 |
+| mu-elem | 0.303 | 0.436 | 0.510 | 0.297 (.291–.300) | 1.33 |
+| **mu-lineage** | 0.177 | 0.299 | 0.445 | **0.356 (.340–.371)** | **1.63 (1.53–1.75)** |
+
+`depth|elem-miss` = ABSOLUTE deepest correctly-reached ancestor (the actionable placement depth — an intermediate
+ancestor is usable: searchable by name, resolvable by id).
 
 Findings: (1) `mu-lineage` beats e5 on *every* metric — a real, distinct signal. (2) `mu-elem` dominates exact-leaf
-+ overall-overlap — it's the leaf specialist. (3) **But on the PAIRED hard subset** (the 207 queries where `mu-elem`
-misses the leaf), **`mu-lineage` recovers the ancestor branch best — 0.359 > e5 0.332 > elem 0.312.** The
-"file general→specific" hypothesis, confirmed: when the leaf can't be nailed, lineage stays in the right general
-branch (densely-reused upper levels), while the leaf-specialist, *on its own misses, wanders below even raw e5*
-(0.312 < 0.332) because it optimises leaf-specificity over the general path. (4) So **elem and lineage are
-complementary** — leaf-specialist + graceful branch-fallback — which *data-motivates* the composition (increment 2:
-a margin-gate / OR switching on leaf-certainty). Masking's prefix-dropout also buys robustness to truncated /
-RDF-partial paths and free depth-placement. Caveats: single-seed, one split (multi-seed + CI = follow-up); the
-paired subset is the honest test (per-ranker miss-sets differ, so unpaired overlap|MISS was confounded).
++ overall-overlap — it's the leaf specialist. (3) **But on the PAIRED hard subset** (queries where `mu-elem` misses
+the leaf), **`mu-lineage` recovers the ancestor branch best — and it is ROBUST TO SEED with non-overlapping ranges**:
+its ov|miss min (0.340) clears e5's max (0.328) clears elem's max (0.300), **same ordering all 3 seeds** (same for
+absolute depth: 1.63 vs 1.40 vs 1.33). The "file general→specific" hypothesis, confirmed and CI-hardened: when the
+leaf can't be nailed, lineage stays in the right general branch (densely-reused upper levels), while the
+leaf-specialist, *on its own misses, wanders below even raw e5 every seed* (0.297 < 0.323) — it optimises
+leaf-specificity over the general path. (4) So **elem and lineage are complementary** — leaf-specialist + graceful
+branch-fallback — which *data-motivates* the composition (increment 2: a margin-gate / OR switching on
+leaf-certainty). Masking's prefix-dropout also buys robustness to truncated / RDF-partial paths and free
+depth-placement. (Paired subset is the honest test — per-ranker miss-sets differ, so unpaired overlap|MISS was
+confounded; single split — a multi-split CI is the remaining follow-up.)
 
 #### Operating point — μ's edge is at recall@10 / median rank, which is exactly what an LLM re-ranker consumes
 Across **all three** results, μ's advantage over `e5-cos` concentrates at **recall@10 and median rank**, *not*

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -116,6 +116,37 @@ def metrics(ranks):
     return r
 
 
+def rank_all(model, tok, qtbl, ptbl, idx, q_keys, f_keys, truepos, dev):
+    """Build all six filing rankers → (rank_of, ordered-names). Caller owns the q_keys/truepos split (so this is
+    reusable for a FAIR held-out in-domain eval from train_filing, not just the zero-shot eval here)."""
+    n_ops = model.op_emb.weight.shape[0]
+    ow_of = lambda op: torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS[op]]), 1.0)
+    sm = lambda ow: torch.tensor(score_mu(model, tok, idx, q_keys, f_keys, ow, dev))   # [Q,F] μ score matrix
+    S_elem, S_wiki, S_sym = sm(ow_of("ELEM")), sm(ow_of("WIKI")), sm(ow_of("SYM"))
+    S_super = sm(torch.full((1, n_ops), 1.0 / n_ops))
+    S_max = torch.maximum(torch.maximum(S_elem, S_wiki), S_sym)   # operator-OR — the Wikipedia-eval winner
+    C = (qtbl[[idx[k] for k in q_keys]] @ ptbl[[idx[k] for k in f_keys]].T).cpu()       # e5 cosine [Q,F], unit-normed
+    def nzrow(M):                                                 # per-query min-max → [0,1] across folders
+        lo = M.min(dim=1, keepdim=True).values; hi = M.max(dim=1, keepdim=True).values
+        return (M - lo) / (hi - lo + 1e-9)
+    Cz, Sz, Se = nzrow(C), nzrow(S_max), nzrow(S_elem)
+    S_blend = 0.1 * Cz + 0.9 * Sz                                 # e5 + 0.9·μ-max (coverage insurance, tuned α)
+    S_blend_e = 0.1 * Cz + 0.9 * Se                               # e5 + 0.9·μ-elem (blend on the single trained op)
+    top2 = S_max.topk(min(2, S_max.shape[1]), dim=1).values       # per-query μ-max margin = top1 − top2 over folders
+    margin = (top2[:, 0] - top2[:, 1]).clamp(min=0) if top2.shape[1] > 1 else torch.zeros(S_max.shape[0])
+    mq = margin.argsort().argsort().float() / max(1, len(margin) - 1)   # cross-query quantile position (scale-free)
+    alpha = (0.3 + 0.6 * mq).unsqueeze(1)                         # low margin ⇒ lean e5; high ⇒ lean μ (the gate)
+    S_gate = (1 - alpha) * Cz + alpha * Sz
+    def ranks_from(M):                                            # per-query 1-based rank of the true folder
+        return [1 + int(((M[r] > M[r][truepos[r]]) |
+                         ((M[r] == M[r][truepos[r]]) & (torch.arange(M.shape[1]) < truepos[r]))).sum().item())
+                for r in range(M.shape[0])]
+    rank_of = {nm: ranks_from(M) for nm, M in (
+        ("e5-cos", C), ("mu-super", S_super), ("mu-elem", S_elem), ("mu-max", S_max),
+        ("e5+mu-max", S_blend), ("e5+mu-elem", S_blend_e), ("margin-gate", S_gate))}
+    return rank_of, ("e5-cos", "mu-super", "mu-elem", "mu-max", "e5+mu-max", "e5+mu-elem", "margin-gate")
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--ckpt", required=True)
@@ -188,39 +219,8 @@ def main():
     f_order = list(cand)                                          # tid order aligned with f_keys
     truepos = [f_order.index(t) for t in true_tids]
 
-    n_ops = model.op_emb.weight.shape[0]
-    ow_of = lambda op: torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS[op]]), 1.0)
-    sm = lambda ow: torch.tensor(score_mu(model, tok, idx, q_keys, f_keys, ow, dev))   # [Q,F] μ score matrix
-    S_elem, S_wiki, S_sym = sm(ow_of("ELEM")), sm(ow_of("WIKI")), sm(ow_of("SYM"))
-    S_super = sm(torch.full((1, n_ops), 1.0 / n_ops))
-    S_max = torch.maximum(torch.maximum(S_elem, S_wiki), S_sym)   # operator-OR — the Wikipedia-eval winner
-
-    # raw e5 cosine baseline: cos(query: bookmark, passage: folder) — symmetric, no model
-    qn = qtbl[[idx[k] for k in q_keys]]                           # bookmark query-embeddings
-    fn = ptbl[[idx[k] for k in f_keys]]                           # folder passage-embeddings
-    C = (qn @ fn.T).cpu()                                         # [Q, F] cosine (tables are unit-normed)
-
-    # review-hardened combined rankers (DESIGN_model_applications.md): coverage-insurance blend + margin gate
-    def nzrow(M):                                                 # per-query min-max → [0,1] across folders
-        lo = M.min(dim=1, keepdim=True).values; hi = M.max(dim=1, keepdim=True).values
-        return (M - lo) / (hi - lo + 1e-9)
-    Cz, Sz = nzrow(C), nzrow(S_max)
-    S_blend = 0.1 * Cz + 0.9 * Sz                                 # e5 + 0.9·μ-max (coverage insurance, tuned α)
-    top2 = S_max.topk(min(2, S_max.shape[1]), dim=1).values       # per-query μ-max margin = top1 − top2 over folders
-    margin = (top2[:, 0] - top2[:, 1]).clamp(min=0) if top2.shape[1] > 1 else torch.zeros(S_max.shape[0])
-    mq = margin.argsort().argsort().float() / max(1, len(margin) - 1)   # cross-query quantile position (scale-free)
-    alpha = (0.3 + 0.6 * mq).unsqueeze(1)                         # low margin ⇒ lean e5; high ⇒ lean μ (the gate)
-    S_gate = (1 - alpha) * Cz + alpha * Sz
-
-    def ranks_from(M):                                            # per-query 1-based rank of the true folder
-        return [1 + int(((M[r] > M[r][truepos[r]]) |
-                         ((M[r] == M[r][truepos[r]]) & (torch.arange(M.shape[1]) < truepos[r]))).sum().item())
-                for r in range(M.shape[0])]
-    rank_of = {nm: ranks_from(M) for nm, M in (
-        ("e5-cos", C), ("mu-super", S_super), ("mu-elem", S_elem),
-        ("mu-max", S_max), ("e5+mu-max", S_blend), ("margin-gate", S_gate))}
-
-    order = ("e5-cos", "mu-super", "mu-elem", "mu-max", "e5+mu-max", "margin-gate")
+    rank_of, order = rank_all(model, tok, qtbl, ptbl, idx, q_keys, f_keys, truepos, dev)
+    fn = ptbl[[idx[k] for k in f_keys]]                           # folder passage-embeddings (for core-sim stratification)
 
     def table(title, qsel):
         print(f"\n{title}  (n={len(qsel)})")

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -5,10 +5,17 @@ The formal, NON-CIRCULAR retrieval eval the applications roadmap asked for (DESI
 build-plan §1-2). Ground truth = where each bookmark is *actually filed* (its `treeId`) — a real human
 decision, not graph distance. Task: rank candidate folders by μ(bookmark|folder) and measure recall@k / MRR.
 
-Three rankers, head-to-head — isolating what the model adds over plain similarity:
-  * mu-super  — μ under the equal-weight operator superposition (unconditional relatedness; the eval_retrieval default).
-  * mu-elem   — μ under the ELEM (element_of) operator alone — the membership relation filing actually is.
-  * e5-cos    — raw e5 cosine(query: bookmark, passage: folder) — the symmetric, no-model baseline.
+Six rankers, head-to-head — isolating what the model adds over plain similarity, and whether the review-hardened
+recipe transfers OOD (μ trained on Wikipedia categories → REAL personal bookmark filing):
+  * e5-cos      — raw e5 cosine(query: bookmark, passage: folder) — the symmetric, no-model baseline.
+  * mu-super    — μ under the equal-weight operator superposition (unconditional relatedness).
+  * mu-elem     — μ under the ELEM (element_of) operator alone.
+  * mu-max      — max(μ-elem, μ-wiki, μ-sym): the non-linear operator-OR that won the Wikipedia retrieval eval.
+  * e5+mu-max   — e5 + 0.9·μ-max, the coverage-insurance blend (the tuned default; small e5 = untrained-region catch-all).
+  * margin-gate — per-query blend weight from the μ-max MARGIN (top1−top2 over folders): the self-annealing/#3391
+                  finding operationalised — lean on μ where its margin is sharp, fall back to e5 where it's flat.
+This is the OOD test of the central deferred claim: the margin gate / coverage-insurance were predicted to pay off
+exactly HERE (real data μ hasn't seen), where low confidence coincides with μ being wrong, not just unhelpful.
 
 The connection to the bookmarking agent (scripts/infer_pearltrees_federated.py): that agent solves the SAME
 rank-folders-by-relatedness task with a Procrustes-projection + cosine engine. This eval is the apparatus to
@@ -182,23 +189,38 @@ def main():
     truepos = [f_order.index(t) for t in true_tids]
 
     n_ops = model.op_emb.weight.shape[0]
-    rankers = {
-        "mu-super": torch.full((1, n_ops), 1.0 / n_ops),
-        "mu-elem":  torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["ELEM"]]), 1.0),
-    }
-    rank_of = {}                                                  # ranker -> per-query 1-based true-folder rank
-    for name, ow in rankers.items():
-        S = score_mu(model, tok, idx, q_keys, f_keys, ow, dev)
-        rank_of[name] = [1 + sum(1 for j, s in enumerate(row) if s > row[truepos[r]]
-                                 or (s == row[truepos[r]] and j < truepos[r])) for r, row in enumerate(S)]
+    ow_of = lambda op: torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS[op]]), 1.0)
+    sm = lambda ow: torch.tensor(score_mu(model, tok, idx, q_keys, f_keys, ow, dev))   # [Q,F] μ score matrix
+    S_elem, S_wiki, S_sym = sm(ow_of("ELEM")), sm(ow_of("WIKI")), sm(ow_of("SYM"))
+    S_super = sm(torch.full((1, n_ops), 1.0 / n_ops))
+    S_max = torch.maximum(torch.maximum(S_elem, S_wiki), S_sym)   # operator-OR — the Wikipedia-eval winner
 
     # raw e5 cosine baseline: cos(query: bookmark, passage: folder) — symmetric, no model
     qn = qtbl[[idx[k] for k in q_keys]]                           # bookmark query-embeddings
     fn = ptbl[[idx[k] for k in f_keys]]                           # folder passage-embeddings
-    C = qn @ fn.T                                                 # [Q, F] cosine (tables are unit-normed)
-    rank_of["e5-cos"] = [1 + int((C[r] > C[r][truepos[r]]).sum().item()) for r in range(C.shape[0])]
+    C = (qn @ fn.T).cpu()                                         # [Q, F] cosine (tables are unit-normed)
 
-    order = ("e5-cos", "mu-super", "mu-elem")
+    # review-hardened combined rankers (DESIGN_model_applications.md): coverage-insurance blend + margin gate
+    def nzrow(M):                                                 # per-query min-max → [0,1] across folders
+        lo = M.min(dim=1, keepdim=True).values; hi = M.max(dim=1, keepdim=True).values
+        return (M - lo) / (hi - lo + 1e-9)
+    Cz, Sz = nzrow(C), nzrow(S_max)
+    S_blend = 0.1 * Cz + 0.9 * Sz                                 # e5 + 0.9·μ-max (coverage insurance, tuned α)
+    top2 = S_max.topk(min(2, S_max.shape[1]), dim=1).values       # per-query μ-max margin = top1 − top2 over folders
+    margin = (top2[:, 0] - top2[:, 1]).clamp(min=0) if top2.shape[1] > 1 else torch.zeros(S_max.shape[0])
+    mq = margin.argsort().argsort().float() / max(1, len(margin) - 1)   # cross-query quantile position (scale-free)
+    alpha = (0.3 + 0.6 * mq).unsqueeze(1)                         # low margin ⇒ lean e5; high ⇒ lean μ (the gate)
+    S_gate = (1 - alpha) * Cz + alpha * Sz
+
+    def ranks_from(M):                                            # per-query 1-based rank of the true folder
+        return [1 + int(((M[r] > M[r][truepos[r]]) |
+                         ((M[r] == M[r][truepos[r]]) & (torch.arange(M.shape[1]) < truepos[r]))).sum().item())
+                for r in range(M.shape[0])]
+    rank_of = {nm: ranks_from(M) for nm, M in (
+        ("e5-cos", C), ("mu-super", S_super), ("mu-elem", S_elem),
+        ("mu-max", S_max), ("e5+mu-max", S_blend), ("margin-gate", S_gate))}
+
+    order = ("e5-cos", "mu-super", "mu-elem", "mu-max", "e5+mu-max", "margin-gate")
 
     def table(title, qsel):
         print(f"\n{title}  (n={len(qsel)})")

--- a/prototypes/mu_cosine/train_filing.py
+++ b/prototypes/mu_cosine/train_filing.py
@@ -21,7 +21,7 @@ import argparse, collections, os, random
 import torch
 import torch.nn.functional as F
 from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS
-from eval_filing import load_filing, score_mu, metrics
+from eval_filing import load_filing, score_mu, metrics, rank_all
 
 
 def build_model(ckpt, dev):
@@ -37,7 +37,7 @@ def build_model(ckpt, dev):
 
 
 def train_one(ckpt, tok, idx, bm_key, bm_folder, train_idx, f_order, eval_keys, eval_truepos,
-              f_keys, steps, bs, lr, dev, seed):
+              f_keys, steps, bs, lr, dev, seed, save_path=None, qtbl=None, ptbl=None):
     """Warm-start a fresh model, fine-tune on `train_idx` bookmarks, return MRR on the fixed eval set."""
     model, _ = build_model(ckpt, dev)
     n_ops = model.op_emb.weight.shape[0]
@@ -62,6 +62,18 @@ def train_one(ckpt, tok, idx, bm_key, bm_folder, train_idx, f_order, eval_keys, 
         pos, neg = target > 0.5, target <= 0.5                       # balance pos/neg (negatives dominate B×B)
         loss = bce[pos].mean() + bce[neg].mean()
         opt.zero_grad(); loss.backward(); opt.step()
+    if save_path:                                                    # persist the fine-tuned model for downstream eval
+        cfg = torch.load(ckpt, weights_only=False).get("cfg", {"d_model": 384, "heads": 4, "layers": 3})
+        torch.save({"state": model.state_dict(), "cfg": cfg}, save_path)
+        print(f"[SAVE] fine-tuned model ({steps} steps) → {save_path}")
+        if qtbl is not None:                                         # FAIR in-domain head-to-head of all 6 rankers on the HELD-OUT set
+            rank_of, order = rank_all(model, tok, qtbl, ptbl, idx, eval_keys, f_keys, eval_truepos, dev)
+            print(f"\n  [IN-DOMAIN held-out, all rankers on fine-tuned μ]  (n={len(eval_keys)})")
+            print(f"  {'ranker':12} {'recall@1':>9} {'recall@5':>9} {'recall@10':>10} {'MRR':>7} {'med.rank':>9}")
+            for nm in order:
+                m = metrics(rank_of[nm])
+                print(f"  {nm:12} {m['recall@1']:9.3f} {m['recall@5']:9.3f} {m['recall@10']:10.3f} "
+                      f"{m['MRR']:7.3f} {m['median_rank']:9d}")
     # eval on the fixed held-out set
     S = score_mu(model, tok, idx, eval_keys, f_keys, elem.cpu(), dev)
     ranks = [1 + sum(1 for j, s in enumerate(row) if s > row[eval_truepos[r]]
@@ -84,6 +96,7 @@ def main():
     ap.add_argument("--seeds", default=None, help="comma-sep TRAINING seeds (multi-seed lock); split stays at --seed")
     ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     ap.add_argument("--cache", default="/tmp/trainfiling_e5.pt")
+    ap.add_argument("--save", default=None, help="save fine-tuned model (largest frac, first seed) to this path")
     a = ap.parse_args()
     dev = torch.device(a.device)
 
@@ -135,7 +148,9 @@ def main():
         for sd in seeds:
             sub = random.Random(sd + 1).sample(train_idx, n)
             m = train_one(a.ckpt, tok, idx, bm_key, bm_folder, sub, f_order, eval_keys, eval_truepos,
-                          f_keys, a.steps, a.bs, a.lr, dev, sd)
+                          f_keys, a.steps, a.bs, a.lr, dev, sd,
+                          save_path=(a.save if (fr == fracs[-1] and sd == seeds[0]) else None),
+                          qtbl=qtbl, ptbl=ptbl)
             mrrs.append(m["MRR"]); r10s.append(m["recall@10"]); meds.append(m["median_rank"])
         mm, ms = stt.mean(mrrs), (stt.stdev(mrrs) if len(mrrs) > 1 else 0.0)
         rm, rs = stt.mean(r10s), (stt.stdev(r10s) if len(r10s) > 1 else 0.0)

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -65,10 +65,13 @@ def main():
     ap.add_argument("--steps", type=int, default=500); ap.add_argument("--bs", type=int, default=48)
     ap.add_argument("--lr", type=float, default=3e-4); ap.add_argument("--replay", type=float, default=1.0,
                     help="weight on the ELEM(bookmark|folder-title) replay loss")
-    ap.add_argument("--seed", type=int, default=7); ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    ap.add_argument("--seed", type=int, default=7, help="SPLIT seed (fix across runs for a comparable CI)")
+    ap.add_argument("--train-seed", type=int, default=None, help="TRAINING rng seed (default=--seed); vary for multi-seed CI")
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     ap.add_argument("--cache", default="/tmp/lineage_e5.pt")
     ap.add_argument("--eval-only", action="store_true", help="load --save model and eval only (no training)")
     a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
+    if a.train_seed is None: a.train_seed = a.seed
 
     queries, cand = load_filing(a.trees, a.min_bm)                  # [(bm_text, folder_tid)], {folder_tid: title}
     path_of, pids_of = {}, {}                                       # folder_tid -> target_text ; -> path_ids (root→leaf)
@@ -120,7 +123,7 @@ def main():
     bm_folder = [f for _, f in bm_list]
     train_idx = list(range(len(eval_q), len(bm_list)))
     opt = torch.optim.AdamW(model.parameters(), lr=a.lr, weight_decay=1e-4)
-    trng = random.Random(a.seed + 1)
+    trng = random.Random(a.train_seed + 1)                          # TRAINING rng — vary for multi-seed CI, split fixed by --seed
 
     def contrastive(bkidx, passages, ow):                           # B×B μ(bm_i | passage_j), same-folder = positive
         bk = [bm_key[i] for i in bkidx]
@@ -167,14 +170,14 @@ def main():
             n += 1
         return n
     def top1(S, r): return max(range(len(S[r])), key=lambda j: S[r][j])
-    def path_overlap(S, subset=None):                              # mean fraction of TRUE ancestor lineage recovered by top-1
-        vals = []
+    def path_overlap(S, subset=None):                              # → (mean normalized-LCP, mean ABSOLUTE matched-depth)
+        norm, absd = [], []                                        # abs matched-depth = deepest correctly-reached ancestor
         for r in (range(len(S)) if subset is None else subset):
             pred = fold_ids[top1(S, r)]; true = bm_folder[ev_idx[r]]
             tp = pids_of.get(true, []);  pp = pids_of.get(pred, [])
             if tp:
-                vals.append(lcp(pp, tp) / len(tp))
-        return sum(vals) / len(vals) if vals else 0.0
+                n = lcp(pp, tp); norm.append(n / len(tp)); absd.append(n)
+        return (sum(norm) / len(norm) if norm else 0.0, sum(absd) / len(absd) if absd else 0.0)
     lin_keys = [f"P:{f}:{full_variant[f]}" for f in fold_ids]       # full path per folder
     fol_keys = [f"F:{f}" for f in fold_ids]
     qn = qtbl[[idx[bm_key[i]] for i in ev_idx]]; fn = ptbl[[idx[k] for k in fol_keys]]
@@ -183,13 +186,13 @@ def main():
     S_elem, S_lin = score(fol_keys, ow_elem), score(lin_keys, ow_lin)
     S_e5 = C.tolist()
     elem_miss = [r for r in range(len(S_elem)) if top1(S_elem, r) != truepos[r]]   # FIXED hard subset (paired)
-    print(f"\n  [HELD-OUT n={len(ev_idx)}]  {'ranker':12} {'recall@1':>9} {'MRR':>7} {'overlap(all)':>13} "
-          f"{'overlap|elem-miss':>18}   [paired hard subset n={len(elem_miss)}]")
+    print(f"\n  [HELD-OUT n={len(ev_idx)} | seed {a.seed} train {a.train_seed}]  {'ranker':12} {'recall@1':>9} {'MRR':>7} "
+          f"{'ov(all)':>8} {'ov|miss':>8} {'depth|miss':>10}   [hard n={len(elem_miss)}]")
     for nm, R, S in (("e5-cos", e5_ranks, S_e5), ("mu-elem", ranks(S_elem), S_elem), ("mu-lineage", ranks(S_lin), S_lin)):
-        m = metrics(R)
-        print(f"  {'':13}{nm:12} {m['recall@1']:9.3f} {m['MRR']:7.3f} {path_overlap(S):13.3f} {path_overlap(S, elem_miss):18.3f}")
-    print("  (overlap|elem-miss = ancestor-lineage recovered on the SAME hard cases where the leaf-specialist mu-elem")
-    print("   fails — the paired graceful-degradation test: when the leaf can't be nailed, who stays in the right branch?)")
+        m = metrics(R); ov_all, _ = path_overlap(S); ov_m, depth_m = path_overlap(S, elem_miss)
+        print(f"  {'':13}{nm:12} {m['recall@1']:9.3f} {m['MRR']:7.3f} {ov_all:8.3f} {ov_m:8.3f} {depth_m:10.2f}")
+    print("  (ov|miss = normalized ancestor-lineage recovered on the SAME hard cases where mu-elem misses the leaf;")
+    print("   depth|miss = ABSOLUTE deepest correctly-reached ancestor there — the actionable placement depth.)")
 
     if a.save:
         torch.save({"state": model.state_dict(), "cfg": cfg, "ops_extra": ["LINEAGE"]}, a.save)

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -197,10 +197,12 @@ def main():
     emar = (t2[:, 0] - t2[:, 1]) if t2.shape[1] > 1 else torch.zeros(et.shape[0])
     ag = (emar.argsort().argsort().float() / max(1, len(emar) - 1)).unsqueeze(1)     # high elem-margin → lean elem
     combos = [("e5-cos", Ce), ("mu-elem", Se), ("mu-wiki", Sw), ("mu-sym", Ss), ("mu-lineage", Sl),
-              ("max(elem,lin)", mx(Se, Sl)), ("max(elem,wiki)", mx(Se, Sw)),
-              ("gate(elem→wiki)", ag * Se + (1 - ag) * Sw), ("gate(elem→lin)", ag * Se + (1 - ag) * Sl),
-              ("e5+max(elem,wiki)", 0.1 * Ce + 0.9 * mx(Se, Sw)), ("e5+max(elem,lin)", 0.1 * Ce + 0.9 * mx(Se, Sl)),
-              ("e5+max(el,wk,lin)", 0.1 * Ce + 0.9 * mx(Se, Sw, Sl))]
+              ("max(elem,wiki)", mx(Se, Sw)), ("max(elem,wiki,sym)", mx(Se, Sw, Ss)),
+              ("max(el,wk,sy,lin)", mx(Se, Sw, Ss, Sl)),
+              ("e5+max(elem,wiki)", 0.1 * Ce + 0.9 * mx(Se, Sw)),
+              ("e5+max(el,wk,sy)", 0.1 * Ce + 0.9 * mx(Se, Sw, Ss)),
+              ("e5+max(all4)", 0.1 * Ce + 0.9 * mx(Se, Sw, Ss, Sl)),
+              ("gate(elem→wiki)", ag * Se + (1 - ag) * Sw)]
     print(f"\n  [HELD-OUT n={len(ev_idx)} | seed {a.seed} train {a.train_seed}]  {'combiner':18} {'recall@1':>9} {'MRR':>7} "
           f"{'ov(all)':>8} {'ov|miss':>8} {'depth|miss':>10}   [hard n={len(elem_miss)}]")
     for nm, M in combos:

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""train_lineage.py — add a LINEAGE operator that scores μ(node | hierarchical-list-PATH), fine-tune with replay.
+
+The new operator (DESIGN_model_applications.md, "B"): LINEAGE is the *undifferentiated* generalization of ELEM
+(element-of) + WIKI (subcategory) — it scores how well a bookmark fits an ORDERED FOLDER PATH (the materialized
+`/id/id` line + indented root→leaf titles, the same `target_text` the old filer embedded). Per the design decision:
+  * NOT hand-initialised from ELEM/WIKI — a FRESH operator row; the model LEARNS its relation to the others by
+    training with REPLAY (the generalization emerges, it isn't assumed).
+  * warm-start everything else from `--ckpt` (row-copy so op_emb/readout grow 4→5, old rows preserved).
+  * masking = ID-dropout (sample a `/*`-wildcarded path variant) + path-PREFIX dropout (train on ancestor prefixes
+    ⇒ free depth-placement at inference). Variants are PRECOMPUTED into the e5 cache (pay the re-embed once, not
+    per step) — the materialised-id line gives unique anchors, ID-dropout stops it becoming a memorisation crutch.
+  * replay = interleave ELEM(bookmark|folder-title) batches so filing-elem stays sharp and elem↔lineage is learned.
+
+  python3 train_lineage.py --ckpt model_filing.pt --trees ../../.local/data/pearltrees_api/trees \
+      --paths ../../.local/data/api_tree_paths_v8.jsonl --save model_lineage.pt --steps 500
+"""
+import argparse, collections, json, random, os, torch
+import torch.nn.functional as F
+from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS
+from eval_filing import load_filing, metrics
+
+LINEAGE = len(OPS)                                                  # new op index in the grown (n_ops+1) model
+
+
+def load_grow(ckpt, dev, extra=1):
+    """Load a checkpoint into a model with `extra` MORE operators; copy overlapping rows, leave new rows fresh."""
+    ck = torch.load(ckpt, weights_only=False); sd = ck["state"]
+    cfg = ck.get("cfg", {"d_model": 384, "heads": 4, "layers": 3})
+    g = lambda k, d: sd[k].shape[0] if k in sd else d
+    model = MuAttention(d_model=cfg["d_model"], n_heads=cfg["heads"], n_layers=cfg["layers"],
+                        n_ops=g("op_emb.weight", len(OPS)) + extra, n_corpus=g("corpus_emb.weight", 2),
+                        n_judge=g("judge_emb.weight", 2), n_nodetype=g("nodetype_emb.weight", 4)).to(dev)
+    new = model.state_dict()
+    for k, v in sd.items():
+        if k not in new:
+            continue
+        if new[k].shape == v.shape:
+            new[k] = v
+        else:                                                       # n_ops-sized (op_emb.weight, readout_w, readout_b): copy old rows
+            new[k][:v.shape[0]] = v
+    model.load_state_dict(new, strict=False)
+    return model, cfg
+
+
+def path_variants(target_text, max_drop=2):
+    """target_text = '/id..\\n- t0\\n  - t1\\n ...' → list of (idmode, drop, text) variants: {full,wild id}×{prefix}."""
+    lines = target_text.split("\n")
+    id_line = lines[0] if lines and lines[0].startswith("/") else None
+    titles = lines[1:] if id_line is not None else lines            # indented '- title' lines, root→leaf
+    out = []
+    for drop in range(min(max_drop, max(0, len(titles) - 1)) + 1):  # drop 0..max_drop deepest levels (keep ≥1)
+        kept = titles[:len(titles) - drop]
+        for idmode, idl in (("full", id_line), ("wild", "/*")):
+            body = "\n".join(([idl] if idl is not None else []) + kept)
+            out.append((idmode, drop, body))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ckpt", required=True); ap.add_argument("--trees", required=True); ap.add_argument("--paths", required=True)
+    ap.add_argument("--save", default=None); ap.add_argument("--min-bm", type=int, default=3)
+    ap.add_argument("--eval-frac", type=float, default=0.3); ap.add_argument("--max-eval", type=int, default=400)
+    ap.add_argument("--steps", type=int, default=500); ap.add_argument("--bs", type=int, default=48)
+    ap.add_argument("--lr", type=float, default=3e-4); ap.add_argument("--replay", type=float, default=1.0,
+                    help="weight on the ELEM(bookmark|folder-title) replay loss")
+    ap.add_argument("--seed", type=int, default=7); ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    ap.add_argument("--cache", default="/tmp/lineage_e5.pt")
+    ap.add_argument("--eval-only", action="store_true", help="load --save model and eval only (no training)")
+    a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
+
+    queries, cand = load_filing(a.trees, a.min_bm)                  # [(bm_text, folder_tid)], {folder_tid: title}
+    path_of, pids_of = {}, {}                                       # folder_tid -> target_text ; -> path_ids (root→leaf)
+    for line in open(a.paths, encoding="utf-8"):
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        if r.get("tree_id") and r.get("target_text"):
+            path_of[str(r["tree_id"])] = r["target_text"]
+            pids_of[str(r["tree_id"])] = [str(x) for x in (r.get("path_ids") or [])]
+    queries = [(b, str(f)) for b, f in queries if str(f) in path_of]   # keep bookmarks whose folder has a path
+    cand = {str(f): t for f, t in cand.items() if str(f) in path_of}   # normalise folder ids to str (match path_of)
+    print(f"[DATA] {len(cand)} folders w/ paths, {len(queries)} bookmarks (of harvested set)")
+
+    # per-folder bookmark-holdout split (fixed seed) — folders are a stable taxonomy, held-out BOOKMARKS never trained
+    byf = collections.defaultdict(list)
+    for q in queries:
+        byf[q[1]].append(q)
+    eval_q, pool = [], []
+    for fid, qs in byf.items():
+        qs = qs[:]; rng.shuffle(qs); k = max(1, int(a.eval_frac * len(qs))) if len(qs) >= 2 else 0
+        eval_q += qs[:k]; pool += qs[k:]
+    rng.shuffle(eval_q); eval_q = eval_q[:a.max_eval]
+    print(f"[SPLIT] {len(pool)} train bookmarks, {len(eval_q)} held-out eval")
+
+    # ── build e5 tables: bookmarks (query) + folder titles + PRECOMPUTED path variants (passage). One embed pass. ──
+    bm_list = eval_q + pool
+    bm_key = [f"B:{i}" for i in range(len(bm_list))]
+    fold_ids = list(cand)
+    variants = {f: path_variants(path_of[f]) for f in fold_ids}     # folder -> [(idmode,drop,text)]
+    texts, names = {}, []
+    for i, (bt, _) in enumerate(bm_list):
+        texts[bm_key[i]] = bt; names.append(bm_key[i])
+    for f in fold_ids:
+        texts[f"F:{f}"] = cand[f]; names.append(f"F:{f}")           # folder title (ELEM replay target)
+        for vi, (_, _, vtext) in enumerate(variants[f]):
+            k = f"P:{f}:{vi}"; texts[k] = vtext; names.append(k)     # path variant (LINEAGE target)
+    qtbl, ptbl, idx = build_e5_tables(names, cache_path=a.cache, texts=texts, device=a.device)
+    tok = Tokenizer(qtbl, ptbl, idx, parents={}, deg={})
+    full_variant = {f: next(vi for vi, (im, dr, _) in enumerate(variants[f]) if im == "full" and dr == 0) for f in fold_ids}
+
+    model, cfg = load_grow(a.save if a.eval_only else a.ckpt, dev, extra=0 if a.eval_only else 1)
+    n_ops = model.op_emb.weight.shape[0]
+    print(f"[MODEL] {'eval-only ' + os.path.basename(a.save) if a.eval_only else f'grew 4→{n_ops} ops, warm-start ' + os.path.basename(a.ckpt)} (LINEAGE={LINEAGE}) {cfg}")
+    OW = lambda op: torch.zeros(1, n_ops, device=dev).index_fill_(1, torch.tensor([op], device=dev), 1.0)
+    ow_lin, ow_elem = OW(LINEAGE), OW(OPS["ELEM"])
+
+    bm_folder = [f for _, f in bm_list]
+    train_idx = list(range(len(eval_q), len(bm_list)))
+    opt = torch.optim.AdamW(model.parameters(), lr=a.lr, weight_decay=1e-4)
+    trng = random.Random(a.seed + 1)
+
+    def contrastive(bkidx, passages, ow):                           # B×B μ(bm_i | passage_j), same-folder = positive
+        bk = [bm_key[i] for i in bkidx]
+        items = [(bk[i], passages[j], 0) for i in range(len(bk)) for j in range(len(passages))]
+        b = tok.build(items, train=False); b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+        mu = model(**b, op_weights=ow.expand(len(items), n_ops)).view(len(bk), len(passages))
+        fi = torch.tensor([hash(bm_folder[i]) for i in bkidx], device=dev)
+        target = (fi[:, None] == fi[None, :]).float()
+        bce = F.binary_cross_entropy(mu.clamp(1e-6, 1 - 1e-6), target, reduction="none")
+        return bce[target > 0.5].mean() + bce[target <= 0.5].mean()
+
+    model.train()
+    for step in ([] if a.eval_only else range(a.steps)):
+        bkidx = trng.sample(train_idx, min(a.bs, len(train_idx)))
+        # LINEAGE: passage = a SAMPLED path variant (id-dropout + prefix-dropout) of each bookmark's folder
+        lin_pass = [f"P:{bm_folder[i]}:{trng.randrange(len(variants[bm_folder[i]]))}" for i in bkidx]
+        loss = contrastive(bkidx, lin_pass, ow_lin)
+        if a.replay > 0:                                            # ELEM replay: passage = folder TITLE
+            loss = loss + a.replay * contrastive(bkidx, [f"F:{bm_folder[i]}" for i in bkidx], ow_elem)
+        opt.zero_grad(); loss.backward(); opt.step()
+
+    # ── eval on held-out bookmarks: rank candidate folders; LINEAGE uses each folder's FULL path ──
+    model.eval()
+    ev_idx = list(range(len(eval_q)))
+    truepos = [fold_ids.index(bm_folder[i]) for i in ev_idx]
+
+    @torch.no_grad()
+    def score(passkeys, ow):
+        S = []
+        bk = [bm_key[i] for i in ev_idx]
+        for i in range(len(bk)):
+            items = [(bk[i], pk, 0) for pk in passkeys]
+            b = tok.build(items, train=False); b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+            S.append(model(**b, op_weights=ow.expand(len(passkeys), n_ops)).cpu().tolist())
+        return S
+    def ranks(S):
+        return [1 + sum(1 for j, s in enumerate(row) if s > row[truepos[r]] or (s == row[truepos[r]] and j < truepos[r]))
+                for r, row in enumerate(S)]
+    def lcp(a_ids, b_ids):                                          # shared ancestor depth from root
+        n = 0
+        for x, y in zip(a_ids, b_ids):
+            if x != y:
+                break
+            n += 1
+        return n
+    def top1(S, r): return max(range(len(S[r])), key=lambda j: S[r][j])
+    def path_overlap(S, subset=None):                              # mean fraction of TRUE ancestor lineage recovered by top-1
+        vals = []
+        for r in (range(len(S)) if subset is None else subset):
+            pred = fold_ids[top1(S, r)]; true = bm_folder[ev_idx[r]]
+            tp = pids_of.get(true, []);  pp = pids_of.get(pred, [])
+            if tp:
+                vals.append(lcp(pp, tp) / len(tp))
+        return sum(vals) / len(vals) if vals else 0.0
+    lin_keys = [f"P:{f}:{full_variant[f]}" for f in fold_ids]       # full path per folder
+    fol_keys = [f"F:{f}" for f in fold_ids]
+    qn = qtbl[[idx[bm_key[i]] for i in ev_idx]]; fn = ptbl[[idx[k] for k in fol_keys]]
+    C = (qn @ fn.T).cpu()
+    e5_ranks = [1 + int((C[r] > C[r][truepos[r]]).sum().item()) for r in range(C.shape[0])]
+    S_elem, S_lin = score(fol_keys, ow_elem), score(lin_keys, ow_lin)
+    S_e5 = C.tolist()
+    elem_miss = [r for r in range(len(S_elem)) if top1(S_elem, r) != truepos[r]]   # FIXED hard subset (paired)
+    print(f"\n  [HELD-OUT n={len(ev_idx)}]  {'ranker':12} {'recall@1':>9} {'MRR':>7} {'overlap(all)':>13} "
+          f"{'overlap|elem-miss':>18}   [paired hard subset n={len(elem_miss)}]")
+    for nm, R, S in (("e5-cos", e5_ranks, S_e5), ("mu-elem", ranks(S_elem), S_elem), ("mu-lineage", ranks(S_lin), S_lin)):
+        m = metrics(R)
+        print(f"  {'':13}{nm:12} {m['recall@1']:9.3f} {m['MRR']:7.3f} {path_overlap(S):13.3f} {path_overlap(S, elem_miss):18.3f}")
+    print("  (overlap|elem-miss = ancestor-lineage recovered on the SAME hard cases where the leaf-specialist mu-elem")
+    print("   fails — the paired graceful-degradation test: when the leaf can't be nailed, who stays in the right branch?)")
+
+    if a.save:
+        torch.save({"state": model.state_dict(), "cfg": cfg, "ops_extra": ["LINEAGE"]}, a.save)
+        print(f"\n[SAVE] lineage model (LINEAGE op @ {LINEAGE}) → {a.save}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -182,17 +182,32 @@ def main():
     fol_keys = [f"F:{f}" for f in fold_ids]
     qn = qtbl[[idx[bm_key[i]] for i in ev_idx]]; fn = ptbl[[idx[k] for k in fol_keys]]
     C = (qn @ fn.T).cpu()
-    e5_ranks = [1 + int((C[r] > C[r][truepos[r]]).sum().item()) for r in range(C.shape[0])]
+    # per-operator score matrices: elem/wiki/sym use the folder TITLE passage, lineage uses the folder PATH passage
     S_elem, S_lin = score(fol_keys, ow_elem), score(lin_keys, ow_lin)
-    S_e5 = C.tolist()
+    S_wiki, S_sym = score(fol_keys, OW(OPS["WIKI"])), score(fol_keys, OW(OPS["SYM"]))
     elem_miss = [r for r in range(len(S_elem)) if top1(S_elem, r) != truepos[r]]   # FIXED hard subset (paired)
-    print(f"\n  [HELD-OUT n={len(ev_idx)} | seed {a.seed} train {a.train_seed}]  {'ranker':12} {'recall@1':>9} {'MRR':>7} "
+
+    # ── increment 2: COMBINER SWEEP (don't assume the combiner or the operator subset — measure) ──
+    def nz(M):                                                      # per-query min-max → [0,1] over candidate folders
+        M = torch.tensor(M); lo = M.min(1, keepdim=True).values; hi = M.max(1, keepdim=True).values
+        return (M - lo) / (hi - lo + 1e-9)
+    Ce, Se, Sl, Sw, Ss = nz(C.tolist()), nz(S_elem), nz(S_lin), nz(S_wiki), nz(S_sym)
+    mx = lambda *Ms: torch.stack(Ms).amax(0)
+    et = torch.tensor(S_elem); t2 = et.topk(min(2, et.shape[1]), 1).values          # leaf-certainty gate from ELEM margin
+    emar = (t2[:, 0] - t2[:, 1]) if t2.shape[1] > 1 else torch.zeros(et.shape[0])
+    ag = (emar.argsort().argsort().float() / max(1, len(emar) - 1)).unsqueeze(1)     # high elem-margin → lean elem
+    combos = [("e5-cos", Ce), ("mu-elem", Se), ("mu-wiki", Sw), ("mu-sym", Ss), ("mu-lineage", Sl),
+              ("max(elem,lin)", mx(Se, Sl)), ("max(elem,wiki)", mx(Se, Sw)),
+              ("gate(elem→wiki)", ag * Se + (1 - ag) * Sw), ("gate(elem→lin)", ag * Se + (1 - ag) * Sl),
+              ("e5+max(elem,wiki)", 0.1 * Ce + 0.9 * mx(Se, Sw)), ("e5+max(elem,lin)", 0.1 * Ce + 0.9 * mx(Se, Sl)),
+              ("e5+max(el,wk,lin)", 0.1 * Ce + 0.9 * mx(Se, Sw, Sl))]
+    print(f"\n  [HELD-OUT n={len(ev_idx)} | seed {a.seed} train {a.train_seed}]  {'combiner':18} {'recall@1':>9} {'MRR':>7} "
           f"{'ov(all)':>8} {'ov|miss':>8} {'depth|miss':>10}   [hard n={len(elem_miss)}]")
-    for nm, R, S in (("e5-cos", e5_ranks, S_e5), ("mu-elem", ranks(S_elem), S_elem), ("mu-lineage", ranks(S_lin), S_lin)):
-        m = metrics(R); ov_all, _ = path_overlap(S); ov_m, depth_m = path_overlap(S, elem_miss)
-        print(f"  {'':13}{nm:12} {m['recall@1']:9.3f} {m['MRR']:7.3f} {ov_all:8.3f} {ov_m:8.3f} {depth_m:10.2f}")
-    print("  (ov|miss = normalized ancestor-lineage recovered on the SAME hard cases where mu-elem misses the leaf;")
-    print("   depth|miss = ABSOLUTE deepest correctly-reached ancestor there — the actionable placement depth.)")
+    for nm, M in combos:
+        S = M.tolist(); m = metrics(ranks(S)); ov_all, _ = path_overlap(S); ov_m, depth_m = path_overlap(S, elem_miss)
+        print(f"  {'':13}{nm:18} {m['recall@1']:9.3f} {m['MRR']:7.3f} {ov_all:8.3f} {ov_m:8.3f} {depth_m:10.2f}")
+    print("  (target: a combiner with elem's recall@1 AND lineage's ov|miss/depth|miss. gate = lean elem where its")
+    print("   margin is sharp, else lineage. Does adding stale wiki/sym dilute vs max(elem,lin)?)")
 
     if a.save:
         torch.save({"state": model.state_dict(), "cfg": cfg, "ops_extra": ["LINEAGE"]}, a.save)

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -65,6 +65,8 @@ def main():
     ap.add_argument("--steps", type=int, default=500); ap.add_argument("--bs", type=int, default=48)
     ap.add_argument("--lr", type=float, default=3e-4); ap.add_argument("--replay", type=float, default=1.0,
                     help="weight on the ELEM(bookmark|folder-title) replay loss")
+    ap.add_argument("--lineage-weight", type=float, default=1.0,
+                    help="weight on the LINEAGE loss; set 0 for the elem-only control (auxiliary-task ablation)")
     ap.add_argument("--seed", type=int, default=7, help="SPLIT seed (fix across runs for a comparable CI)")
     ap.add_argument("--train-seed", type=int, default=None, help="TRAINING rng seed (default=--seed); vary for multi-seed CI")
     ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
@@ -138,11 +140,10 @@ def main():
     model.train()
     for step in ([] if a.eval_only else range(a.steps)):
         bkidx = trng.sample(train_idx, min(a.bs, len(train_idx)))
-        # LINEAGE: passage = a SAMPLED path variant (id-dropout + prefix-dropout) of each bookmark's folder
-        lin_pass = [f"P:{bm_folder[i]}:{trng.randrange(len(variants[bm_folder[i]]))}" for i in bkidx]
-        loss = contrastive(bkidx, lin_pass, ow_lin)
-        if a.replay > 0:                                            # ELEM replay: passage = folder TITLE
-            loss = loss + a.replay * contrastive(bkidx, [f"F:{bm_folder[i]}" for i in bkidx], ow_elem)
+        loss = a.replay * contrastive(bkidx, [f"F:{bm_folder[i]}" for i in bkidx], ow_elem)     # ELEM replay (base)
+        if a.lineage_weight > 0:                                    # LINEAGE (auxiliary): passage = sampled path variant
+            lin_pass = [f"P:{bm_folder[i]}:{trng.randrange(len(variants[bm_folder[i]]))}" for i in bkidx]
+            loss = loss + a.lineage_weight * contrastive(bkidx, lin_pass, ow_lin)
         opt.zero_grad(); loss.backward(); opt.step()
 
     # ── eval on held-out bookmarks: rank candidate folders; LINEAGE uses each folder's FULL path ──


### PR DESCRIPTION
## μ-attention: real Pearltrees filing — the review-hardened recipe, honestly evaluated end-to-end

Takes the μ-vs-e5 machinery to the **actual bookmark-filing task** on real harvested Pearltrees data (ground truth =
where each bookmark is *actually filed*), and follows the evidence wherever it goes — including two documented
negatives. Every claim is multi-seed CI'd or explicitly flagged single-seed.

### What was actually trained (important — the composition is NOT a trained objective)
There is **no "composition" model and no composition embedding.** The only filing-supervised objective is **ELEM**,
trained by **in-batch contrastive BCE** (`μ(bookmark_i | folder_j)` over a B×B batch, same-folder = positive) against
the **folder TITLE** embedding. **WIKI and SYM are never fine-tuned** — they're warm-started from the Wikipedia
pretraining and only shift via the shared encoder. `e5 + max(μ-elem, μ-wiki, μ-sym)` is an **inference-time combiner**
(a `max` over the three per-operator scores + a fixed `0.1·e5` blend), not something we trained on.

### The filing verdict (what to actually use)
- **Zero-shot (Wikipedia-trained μ → personal bookmarks):** use **e5**. μ doesn't transfer — e5-cos wins at every
  core-distance stratum (transfer failure, not a trained-region effect). The **margin gate** is the best μ-variant
  (recovers ~60% of the gap by auto-deferring to e5) — damage control, exactly as #3391 predicted for OOD.
- **In-domain:** use **`e5 + max(μ-elem, μ-wiki, μ-sym)`** (multi-seed: recall@1 0.304 vs elem-only 0.280, MRR 0.425,
  path-overlap-on-hard-cases 0.388). It's the **same operator-OR that won the Wikipedia retrieval eval**.

### Why the combiner works (the non-obvious part)
Only **ELEM was filing-supervised** (leaf accuracy — the personal, idiosyncratic part). **WIKI/SYM transfer zero-shot
from Wikipedia** because *folder titles are category-like* ("Physics", "Politics of Italy" look like Wikipedia
categories), so "is X a subcategory of Y" generalizes to "is this bookmark in the broad area of this folder" — giving
**branch recovery for free**, no filing supervision. So: ELEM (fine-tuned) → leaf; WIKI/SYM (zero-shot transfer) →
branch/relatedness; e5 → topical anchor; `max`/blend → combine. **Honest fragility:** branch-recovery leans on an
*unsupervised transfer assumption* (works because these folders are named like categories; idiosyncratic folder names
could break it), and the combiner is hand-designed (fixed `max`, fixed α), not learned — so not guaranteed optimal.

### New: the graceful-degradation metric (and where it led)
Filing "general→specific" means an *intermediate ancestor* is a usable result (searchable by name / resolvable by id),
so exact-leaf recall undersells the model. Added **path-overlap** (normalized + absolute matched-depth) on a **paired
hard subset** (queries where the leaf-specialist misses). CI-hardened (3 seeds, non-overlapping ranges): on the hard
cases μ recovers the ancestor branch best, and **WIKI is the branch champion** — which is *why* `max(elem,wiki,sym)`
is the right filer, and why a purpose-built path operator wasn't needed.

### Two honest negatives (documented, not hidden)
- **LINEAGE operator** (new, `train_lineage.py`) — built as the purpose-made "branch" operator, trained by the same
  contrastive BCE but against the **hierarchical-list path** passage. **Redundant at inference** (CI-hardened): WIKI
  already transfers branch-recovery zero-shot, better and simpler (folder title, no path). It still earned its keep by
  producing the graceful-degradation *insight* and the path-overlap *metric* that revealed all of the above.
- **LINEAGE as a training-time auxiliary** — the hypothesis that *training* it improves the shared encoder. At 300
  steps: **SYM is robustly helped** (+0.027 recall@1, 3 seeds; lineage is flavor-matched to sym), but the **filer
  effect is marginal/mixed** (mean +0.008, one seed negative). **Verdict: OPEN** — early-training only; early-mixed
  does *not* refute a late-training benefit; the real test is a full-length A/B (not run); and it slows training.

### Also included
- `eval_filing.py`: 7-ranker sweep + the shared `rank_all()`; `train_filing.py`: `--save` + fair held-out in-domain
  head-to-head; `train_lineage.py`: grow-operator loader, path-variant cache (id/prefix dropout), `--lineage-weight`
  ablation, `--eval-only`, combiner sweep.
- **Design (future-work, rough draft):** `DESIGN_lineage_decoder.md` — the decoder as a **projected optimizer around
  the frozen encoder** (retrieval = its 1-step case; margin gate = novelty/stop rule; snap = manifold projection),
  trained by **staged meta-learning**; numbers/IDs resolved by snap-not-generate; two-tier on-device naming vocab.
  Flagged rough; parens/hyphen handling is the least-settled part.

### Caveats
Single-seed where noted. Path data is 99% complete to root (harvester backfilled the partial RDF), so the lineage
findings are **not** a truncation artifact. `model_*.pt` and harvested data are gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)