### PR TITLE
mu_cosine: operator-axis cleanup (WIKI→HIER, LLM demoted) + parameterized path-operator design

### DIFF
--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -143,6 +143,14 @@ FiLM will. (Vector params like per-edge-type weights: Fourier-encode each scalar
 discrete — uniform vs type-weighted vs confidence — that choice is semantic and goes in the attention query; only the
 actual weight *values* take the Fourier+FiLM path.)
 
+Notes: frequencies are indexed by the *dimension* (each dim a fixed ωᵢ, geometrically spaced), and the value is fed
+to all — so the wavelength lives on the *β-axis*; set the lowest ω so its wavelength covers β's range (distinct,
+non-wrapping codes), higher ω for resolution. The sin/cos *pair* handles sign automatically (β as an angle on the
+unit circle) — no phase-shift term needed. Frequencies may be fixed or learned. *Prior art:* sinusoidal positional
+encoding (Vaswani et al. 2017, §3.5); Fourier features & the MLP spectral-bias motivation (Tancik et al., NeurIPS
+2020; Rahimi & Recht, NeurIPS 2007); continuous-coordinate encoding (NeRF, Mildenhall et al. 2020); learned scalar
+encoding (Time2Vec, Kazemi et al. 2019); FiLM modulation (Perez et al., AAAI 2018).
+
 ## 6. Why PATH (multi-path) is *not* redundant to HIER, though LINEAGE was
 
 `HIER` = the single category-hierarchy **edge**. Single-path `LINEAGE` = one chain of `HIER` edges ⊂ (`HIER` +

--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -34,11 +34,34 @@ distribution, embed it, apply wildcard masking (id-dropout + prefix-dropout), an
 learns the *expectation over paths* across steps — no need to embed every path and weight-average explicitly. The
 wildcards are an orthogonal masking augmentation on top of the path sampling.
 
+## 3b. Passage representation — per-node tokens, NOT a fixed whole-path embedding
+
+Once paths are *sampled* (random walk × stop-β × multi-path × wildcards), the space is **combinatorial** — you cannot
+precompute a fixed e5 embedding for every sampled path (the variant-cache trick that worked for LINEAGE's ~6
+variants/folder breaks entirely). **Resolution: stop embedding the whole path as one e5 string.** Represent the path
+as a **set of per-node embeddings** — embed each ancestor node's *title* **once** (cached, linear in #nodes) — and
+let the model **attend / aggregate over the sampled subset**. Then all the sampling (which nodes, how deep, which of
+the DAG's paths, wildcard-masked) is just **selecting which cached node-tokens enter the passage**:
+- No re-embedding, ever — the combinatorial path space is handled by *token selection over a linear node cache*
+  (this also kills the re-embed-per-step compute concern that dogged the whole-path-string approach).
+- The μ-attention block already supports a **multi-token passage**, so this is a representation change, not an
+  architecture change.
+- The materialized-id line / wildcards become per-node attributes rather than substrings of one blob.
+
+So the path operator factors on **three** axes: **operator** (ancestor-path membership) × **method** (sampling incl.
+stop-β) × **representation** (per-node tokens, attention-aggregated). The whole-path-string embedding was scaffolding
+that doesn't scale; per-node composition is the structure that does — and it's what the decoder's per-node /
+optimizer view wanted anyway (§0 of the decoder sketch: the optimizer reads a per-node partial-path state).
+
 ## 4. The three path-sampling methods (document all three)
 
-**(1) Uniform random walk — default, cheapest.** Going up the DAG, pick a parent **uniformly** at each node;
-a path's probability is `∏ 1/|parents(level)|`. Parameter-free — literally "sample a parent at each level." Weights
-paths by *structural* (branching) likelihood: a node with two parents splits its mass evenly. Start here.
+**(1) Uniform random walk (+ stop-β) — default, cheapest.** Going up the DAG, pick a parent **uniformly** at each
+node, and **terminate with probability β at each step**. Path prob ≈ `∏ 1/|parents(level)|` × the geometric
+stopping term. Parameter-free but for β — literally "sample a parent at each level, sometimes stop early." Two
+bonuses: **(a)** the stop gives geometric-depth (variable-length) paths ⇒ a *principled depth sampler* (graded-depth
+ancestor membership — a better-motivated prefix-dropout); **(b)** a uniform up-walk with per-step stop **IS discrete
+PPR** — β is the PPR restart — so **methods (1) and (3) collapse into one knob** (β→0 walks to the root; larger β
+stays shallow). Start here.
 
 **(2) Edge-weighted — canonical strength.** Weight edges by **type/confidence** — RefPearl (inside/owned) ≫
 AliasPearl (cross-link), or graph-edge confidence — so a path's probability = normalized product of its edge

--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -88,6 +88,27 @@ But **with only one method live, a method token is constant = no signal.** So:
 (Same conclusion as the source-type discussion: design for it; adopt the machinery when the instance count justifies
 it, not before.)
 
+**Correction / the real mechanism — a learned MLP encoder, not more tokens.** A `method_emb` *token* (and the fixed
+`op_emb` **codebook** generally) fits a *small discrete* set — fine for `{SYM, HIER, ELEM}`. But once operators are
+**higher-order and parameterized** (`ancestor-path × method × stop-β × edge-weights`) the space is **continuous and
+compositional**, and no lookup table — nor a handful of factored tokens — can span it (you can't *index* a real-valued
+β, nor enumerate compositions). The mechanism that can: **compute the operator encoding with a small MLP from an
+operator SPECIFICATION** — `op_encoding = MLP([relation_emb, method_emb, params…])` — instead of looking it up. The
+MLP is the *higher-order function realized in the architecture*: the "operator constructor" that takes the parameters
+(method, β, edge-weights) and emits the `d_model` operator token.
+- **Parameterized:** β / edge-weights enter as real-valued inputs (a codebook holds points, not a continuum).
+- **Compositional + interpolable:** unseen (method, β) configs map smoothly; the base relations `{SYM, HIER, ELEM}`
+  become special *points* the MLP can still produce — the current codebook is the degenerate "lookup for one-hot
+  specs" case.
+- **Hypernetwork-flavored:** a small net generating the conditioning vector from a spec — the honest way to feed a
+  *function-with-parameters* to the model. Spec source = learned per-component embeddings (relation/method) + scalar
+  params; optionally grounded in e5-of-description (but that reintroduces prompt-rewriting; the MLP mediates it into a
+  *learned* encoding).
+- **Scope:** overkill for 3 discrete relations; it is the **enabling piece** for parameterized/higher-order operators
+  — it's what turns "operator × method × representation" from a *factoring* into something the model can actually
+  consume. Adopt it *when building* PATH-with-methods, and the codebook stays valid for the base relations meanwhile
+  (the MLP can be introduced as `op_encoding = MLP(spec)` with the current ops as its first, one-hot-spec outputs).
+
 ## 6. Why PATH (multi-path) is *not* redundant to HIER, though LINEAGE was
 
 `HIER` = the single category-hierarchy **edge**. Single-path `LINEAGE` = one chain of `HIER` edges ⊂ (`HIER` +

--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -146,7 +146,12 @@ actual weight *values* take the Fourier+FiLM path.)
 Notes: frequencies are indexed by the *dimension* (each dim a fixed ωᵢ, geometrically spaced), and the value is fed
 to all — so the wavelength lives on the *β-axis*; set the lowest ω so its wavelength covers β's range (distinct,
 non-wrapping codes), higher ω for resolution. The sin/cos *pair* handles sign automatically (β as an angle on the
-unit circle) — no phase-shift term needed. Frequencies may be fixed or learned. *Prior art:* sinusoidal positional
+unit circle) — no phase-shift term needed. **Use FIXED (not learned) frequencies** — chosen deliberately for
+*reduced training* (consumer-grade hardware): fixed makes the encoding **parameter-free** (only the small FiLM MLP
+trains), deterministic, and stable. Since β has a **known bounded range** (a probability/restart in [0,1]), the
+frequency band is set **analytically** to that range, so learned frequencies — which mainly help when the relevant
+scales are *unknown* — buy nothing here while adding parameters and mild instability. The only knob is the band
+(set-once hyperparameter), not a learned weight. *Prior art:* sinusoidal positional
 encoding (Vaswani et al. 2017, §3.5); Fourier features & the MLP spectral-bias motivation (Tancik et al., NeurIPS
 2020; Rahimi & Recht, NeurIPS 2007); continuous-coordinate encoding (NeRF, Mildenhall et al. 2020); learned scalar
 encoding (Time2Vec, Kazemi et al. 2019); FiLM modulation (Perez et al., AAAI 2018).

--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -109,6 +109,25 @@ MLP is the *higher-order function realized in the architecture*: the "operator c
   consume. Adopt it *when building* PATH-with-methods, and the codebook stays valid for the base relations meanwhile
   (the MLP can be introduced as `op_encoding = MLP(spec)` with the current ops as its first, one-hot-spec outputs).
 
+**Preferred realization — a key–value *attention* lookup that reuses `op_weights` (not a plain MLP).** Rather than a
+generic MLP, make the encoder a content-addressable attention over the *existing* operators:
+- **keys** = e5(operator *names/descriptions*), one per existing operator;
+- **values** = the existing learned `op_emb` rows (SYM/HIER/ELEM), used as *initialized* values (warm-start, still
+  trainable);
+- **query** = e5(the desired operator's spec/description);
+- **encoding** = `softmax(query·keysᵀ / τ) @ values`.
+
+The softmax **IS `op_weights`**, and the model already has the blended-operator pathway `op_weights @ op_emb.weight`
+— so this doesn't add machinery, it **generates the superposition weights from the operator *description*** instead
+of hand-setting them (the operator-superposition design, made content-addressed). It degenerates cleanly: a query
+matching one key → one-hot `op_weights` → the current codebook lookup. And it **sidesteps the prompt-rewriting
+worry**: e5 is only the *key* (routing); the *learned value* carries the semantics — new operators are *addressed*
+by language but *encoded* by learned embeddings. Caveats: (i) continuous params (β) aren't words, so they layer on
+separately (concat to the query / FiLM after the blend) — the attention is the relation/method *router*, not the
+parameter injector; (ii) the key is the name/description, so **naming/description quality matters** (close
+descriptions → close keys → blended operators — right when they're related, under-resolved when they aren't; use
+fuller descriptions than the bare short name).
+
 ## 6. Why PATH (multi-path) is *not* redundant to HIER, though LINEAGE was
 
 `HIER` = the single category-hierarchy **edge**. Single-path `LINEAGE` = one chain of `HIER` edges ⊂ (`HIER` +

--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -122,11 +122,26 @@ The softmax **IS `op_weights`**, and the model already has the blended-operator 
 of hand-setting them (the operator-superposition design, made content-addressed). It degenerates cleanly: a query
 matching one key → one-hot `op_weights` → the current codebook lookup. And it **sidesteps the prompt-rewriting
 worry**: e5 is only the *key* (routing); the *learned value* carries the semantics — new operators are *addressed*
-by language but *encoded* by learned embeddings. Caveats: (i) continuous params (β) aren't words, so they layer on
-separately (concat to the query / FiLM after the blend) — the attention is the relation/method *router*, not the
-parameter injector; (ii) the key is the name/description, so **naming/description quality matters** (close
-descriptions → close keys → blended operators — right when they're related, under-resolved when they aren't; use
-fuller descriptions than the bare short name).
+by language but *encoded* by learned embeddings. Caveat (naming): the key is the name/description, so **naming/description
+quality matters** (close descriptions → close keys → blended operators — right when they're related, under-resolved
+when they aren't; use fuller descriptions than the bare short name).
+
+**Numeric parameters (β, edge-weight scalars, τ) — Fourier-encode, then FiLM-modulate.** The attention lookup routes
+the *discrete/semantic* selection (which relation, which method); it cannot carry a **continuum** — β=0.3 isn't a
+word and has no key. So numeric params are injected on a **separate path**, in two steps:
+1. **Fourier-feature encode each scalar** — `β → [sin(ω₁β), cos(ω₁β), …, sin(ω_kβ), cos(ω_kβ)]` at several
+   frequencies. A *raw scalar is a poor MLP input* (one dimension; nets learn ~linear-only functions of it or ignore
+   it); sinusoidal features lift it into a space where a small net can express a **rich, smooth** function of β
+   across its range (same trick as transformer positional encodings / NeRF).
+2. **FiLM-modulate the base encoding** — a tiny MLP maps the Fourier features → a **scale γ and shift**, applied to
+   the attention-lookup output: `op_encoding = γ(fourier(β)) ⊙ base + shift(fourier(β))`.
+
+So: **attention lookup = the discrete router (relation/method); Fourier + FiLM = the continuous parameter injector.**
+This matches the semantics — β controls the path *depth distribution* (small β → deep paths, large β → shallow), so
+the encoding should move *smoothly but expressively* as β sweeps, which a raw-scalar concat won't give but Fourier+
+FiLM will. (Vector params like per-edge-type weights: Fourier-encode each scalar, or, if the *choice* of weighting is
+discrete — uniform vs type-weighted vs confidence — that choice is semantic and goes in the attention query; only the
+actual weight *values* take the Fourier+FiLM path.)
 
 ## 6. Why PATH (multi-path) is *not* redundant to HIER, though LINEAGE was
 

--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -27,12 +27,24 @@ So factor it: **operator = ancestor-path membership (what); method = aggregation
 This unifies lineage/path into one operator and generalizes the pattern (any operator with multiple computation
 strategies can be method-parameterized).
 
+*Clarification (per review) — LINEAGE does NOT stay a separate codebook row.* The redundant experiment grew a
+distinct index-4 `LINEAGE` op; going forward that is **retired**. "Keep LINEAGE" means *keep the canonical-chain
+behaviour as a **method** (`method=canonical`)* of the single `ancestor-path` operator — a method selection at
+data-gen / inference time, **not** a new `op_emb` slot. So **`n_ops` does not grow**: `ancestor-path` is one operator
+(encoded via the `MLP(spec)`/attention-lookup once that exists; a single row meanwhile), and `canonical` vs
+`random-walk` vs `PPR` are its methods, not codebook entries.
+
 ## 3. "Random superposition" = sampling (cheap; reuses the variant cache)
 
 Realize the superposition **stochastically**: each training step, **sample ONE ancestor path** from the method's
 distribution, embed it, apply wildcard masking (id-dropout + prefix-dropout), and use it as the passage. The model
 learns the *expectation over paths* across steps — no need to embed every path and weight-average explicitly. The
 wildcards are an orthogonal masking augmentation on top of the path sampling.
+
+*Gradient-variance note (per review):* the 1-sample estimator has variance set by the *spread* of a node's ancestor
+chains — high-branching DAG nodes with divergent parents give dissimilar samples ⇒ noisy gradients. Two cheap
+mitigations (both reuse the pre-built node cache): **sample k paths per step and average**, and/or **warm up with the
+edge-weighted method** (lower-variance, canonical-path-dominated) before annealing toward uniform.
 
 ## 3b. Passage representation — per-node tokens, NOT a fixed whole-path embedding
 
@@ -48,6 +60,17 @@ the DAG's paths, wildcard-masked) is just **selecting which cached node-tokens e
   architecture change.
 - The materialized-id line / wildcards become per-node attributes rather than substrings of one blob.
 
+*Three implementation points the review flagged (resolve before building):*
+- **Ordered set → depth positional encoding.** The passage is a *set* of node tokens, but ancestor paths are
+  **ordered** (child→parent→grandparent). Attention over an unordered set would discard depth — which is exactly the
+  graded-depth signal we want. So **add a depth-position embedding** to each node token (0 = the node itself, 1 =
+  direct parent, …) before aggregation, so "direct parent" vs "grandparent" is distinguishable. (This is the natural
+  home for the graded-depth membership target.)
+- **Padding masking.** Variable-length paths (from stop-β / multi-path) are padded to a fixed slot count; the
+  attention block must **mask the padding tokens** so they don't pollute the aggregate. Standard, but must be wired.
+- **Cache invalidation.** The per-node embedding cache assumes static titles. On a graph refresh (Pearltrees/Wikipedia
+  snapshot), do **incremental update** — re-embed only new/changed nodes — rather than a full rebuild.
+
 So the path operator factors on **three** axes: **operator** (ancestor-path membership) × **method** (sampling incl.
 stop-β) × **representation** (per-node tokens, attention-aggregated). The whole-path-string embedding was scaffolding
 that doesn't scale; per-node composition is the structure that does — and it's what the decoder's per-node /
@@ -59,14 +82,20 @@ optimizer view wanted anyway (§0 of the decoder sketch: the optimizer reads a p
 node, and **terminate with probability β at each step**. Path prob ≈ `∏ 1/|parents(level)|` × the geometric
 stopping term. Parameter-free but for β — literally "sample a parent at each level, sometimes stop early." Two
 bonuses: **(a)** the stop gives geometric-depth (variable-length) paths ⇒ a *principled depth sampler* (graded-depth
-ancestor membership — a better-motivated prefix-dropout); **(b)** a uniform up-walk with per-step stop **IS discrete
-PPR** — β is the PPR restart — so **methods (1) and (3) collapse into one knob** (β→0 walks to the root; larger β
-stays shallow). Start here.
+ancestor membership — a better-motivated prefix-dropout); **(b)** a uniform up-walk with per-step stop is **closely
+analogous to discrete PPR** for depth weighting — β plays the role of the PPR restart — so methods (1) and (3)
+largely collapse into one knob. *Hedge (per review):* it is **not numerically identical** to PPR — a stop-walk
+*terminates* at a node, whereas PPR *teleports back to the source* and keeps circulating mass; treat them as the same
+*family* (geometric depth decay), not the same estimator, when comparing against a PPR baseline. *Direction
+convention (state once so the knob isn't swapped):* **β = the per-step stop probability, so larger β → shallower**
+paths (β→0 walks to the root; β→1 stays at the leaf). Start here.
 
 **(2) Edge-weighted — canonical strength.** Weight edges by **type/confidence** — RefPearl (inside/owned) ≫
-AliasPearl (cross-link), or graph-edge confidence — so a path's probability = normalized product of its edge
-weights. Down-weights incidental cross-link lineages; encodes "primary home vs cross-reference." The right refinement
-once uniform over-weights incidental multi-parenting.
+AliasPearl (cross-link), or graph-edge confidence — path probability = product of its edge weights. **Normalize
+LOCALLY, per step** (a softmax over a node's parent edges at each hop), *not* globally over all root-paths — global
+path normalization requires enumerating every path (intractable for large DAGs), while local per-step normalization
+is a cheap, differentiable random-walk transition. Down-weights incidental cross-link lineages; encodes "primary home
+vs cross-reference." The right refinement once uniform over-weights incidental multi-parenting.
 
 **(3) PPR / flux — principled continuous.** Personalized PageRank from the node over the **reverse (ancestor)**
 graph; each path's mass = the PPR flow along it, giving exp-decay / power-law weighting by depth × branching for
@@ -124,11 +153,18 @@ matching one key → one-hot `op_weights` → the current codebook lookup. And i
 worry**: e5 is only the *key* (routing); the *learned value* carries the semantics — new operators are *addressed*
 by language but *encoded* by learned embeddings. Caveat (naming): the key is the name/description, so **naming/description
 quality matters** (close descriptions → close keys → blended operators — right when they're related, under-resolved
-when they aren't; use fuller descriptions than the bare short name).
+when they aren't; use fuller descriptions than the bare short name). *Two more the review flagged:* **(cold-start)**
+a genuinely-new operator's query spreads softmax mass over existing keys → a blend biased toward neighbours; early
+gradients can then *pull the existing op embeddings*. Mitigate by **freezing `values` while a new operator's
+representation converges**, or treating the new operator as an *additive residual* on top of the blend.
+**(diagnostic)** on registration/startup, print `softmax(query·keysᵀ)` for each known operator — you want it
+**near one-hot** for `SYM/HIER/ELEM`; a diffuse row flags a silent description collision.
 
-**Numeric parameters (β, edge-weight scalars, τ) — Fourier-encode, then FiLM-modulate.** The attention lookup routes
+**Numeric parameters (β, edge-weight scalars) — Fourier-encode, then FiLM-modulate.** The attention lookup routes
 the *discrete/semantic* selection (which relation, which method); it cannot carry a **continuum** — β=0.3 isn't a
-word and has no key. So numeric params are injected on a **separate path**, in two steps:
+word and has no key. *(Note, per review: the lookup temperature **τ** is NOT one of these — it's a sharpness
+hyperparameter of the router, not a path-sampling semantic; keep it a **fixed** scalar, or at most a single learned
+scalar, and do NOT Fourier/FiLM it, else the model can learn to blur its own routing.)* So numeric params are injected on a **separate path**, in two steps:
 1. **Fourier-feature encode each scalar** — `β → [sin(ω₁β), cos(ω₁β), …, sin(ω_kβ), cos(ω_kβ)]` at several
    frequencies. A *raw scalar is a poor MLP input* (one dimension; nets learn ~linear-only functions of it or ignore
    it); sinusoidal features lift it into a space where a small net can express a **rich, smooth** function of β

--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -1,0 +1,80 @@
+# PATH operator — multi-path ancestor membership over the DAG (design / future-work)
+
+Design note (nothing built yet). Follows the finding that single-path LINEAGE is redundant to HIER, but a
+**multi-path** ancestor operator is *not* — because a DAG node has many ancestor chains, and the harvested
+single-path collapse (`parent_map` precedence) threw all but one away.
+
+## 1. Motivation
+
+`LINEAGE` (as built) scored `μ(node | ONE materialized ancestor chain)` — the jsonL picks a single parent per node
+(RefPearl "inside" over AliasPearl "cross-link"), collapsing the **DAG** (multi-parent: Pearltrees aliases, Wikipedia
+categories) to one arbitrary path. A **PATH** operator instead scores the node against a **superposition over all
+valid ancestor chains** — the full set of hierarchical contexts it belongs to ("this AI paper is under both
+`CS ▸ ML` and `Research ▸ ToRead`"). Keep LINEAGE (the canonical chain); add PATH (the multi-path superposition).
+
+## 2. Unification: one operator, a METHOD parameter (a higher-order operator)
+
+Ancestor-path membership is a *single relation*; LINEAGE and PATH differ only in **how the paths are aggregated**.
+So factor it: **operator = ancestor-path membership (what); method = aggregation/sampling strategy (how).**
+`operator × method` is a **higher-order operator** — the operator takes a *strategy* as a parameter:
+
+| name today | = |
+|---|---|
+| `LINEAGE` | `ancestor-path(method = canonical)` — the single primary chain |
+| `PATH` | `ancestor-path(method = random-walk)` — uniform-parent superposition |
+| (future) | `ancestor-path(method = edge-weighted / PPR)` — richer variants |
+
+This unifies lineage/path into one operator and generalizes the pattern (any operator with multiple computation
+strategies can be method-parameterized).
+
+## 3. "Random superposition" = sampling (cheap; reuses the variant cache)
+
+Realize the superposition **stochastically**: each training step, **sample ONE ancestor path** from the method's
+distribution, embed it, apply wildcard masking (id-dropout + prefix-dropout), and use it as the passage. The model
+learns the *expectation over paths* across steps — no need to embed every path and weight-average explicitly. The
+wildcards are an orthogonal masking augmentation on top of the path sampling.
+
+## 4. The three path-sampling methods (document all three)
+
+**(1) Uniform random walk — default, cheapest.** Going up the DAG, pick a parent **uniformly** at each node;
+a path's probability is `∏ 1/|parents(level)|`. Parameter-free — literally "sample a parent at each level." Weights
+paths by *structural* (branching) likelihood: a node with two parents splits its mass evenly. Start here.
+
+**(2) Edge-weighted — canonical strength.** Weight edges by **type/confidence** — RefPearl (inside/owned) ≫
+AliasPearl (cross-link), or graph-edge confidence — so a path's probability = normalized product of its edge
+weights. Down-weights incidental cross-link lineages; encodes "primary home vs cross-reference." The right refinement
+once uniform over-weights incidental multi-parenting.
+
+**(3) PPR / flux — principled continuous.** Personalized PageRank from the node over the **reverse (ancestor)**
+graph; each path's mass = the PPR flow along it, giving exp-decay / power-law weighting by depth × branching for
+free. Reuses the scan-strategy flux machinery (the Green's-function / KCL framing). The continuous version of (1)+(2).
+
+**Weighting semantics.** (1) = structural likelihood, (2) = lineage strength, (3) = both / continuous. Default (1);
+move to (2) (effectively *structural × confidence*) because a node's *true* contexts are its canonical ancestors,
+and pure branching over-weights incidental multi-parenting; (3) if/when the full flux is worth computing.
+
+## 5. Method as a model input — higher-order, but adopt lazily
+
+Conceptually `method` is a **factored token** like `corpus_emb`/`judge_emb`: the model conditions on
+`(operator, method)`, and PATH becomes **queryable by method at inference** ("give me the PPR-weighted membership").
+But **with only one method live, a method token is constant = no signal.** So:
+- **Now:** method is a **data-generation choice** (how we sample the training paths) — *not* a model input.
+- **Promote to a model input (`method_emb`)** only when **(a) ≥2 methods are trained** *and* **(b) inference needs to
+  select/distinguish them.** Then the higher-order operator is realized.
+
+(Same conclusion as the source-type discussion: design for it; adopt the machinery when the instance count justifies
+it, not before.)
+
+## 6. Why PATH (multi-path) is *not* redundant to HIER, though LINEAGE was
+
+`HIER` = the single category-hierarchy **edge**. Single-path `LINEAGE` = one chain of `HIER` edges ⊂ (`HIER` +
+transitive closure) — hence redundant. But the **multi-path superposition** is the DAG's *ancestor set / closure
+with weights* — it expresses multi-context membership that a single chain (or a bare edge) does not emphasize. That
+is the part our experiments did **not** test, and the reason to build PATH rather than conclude "paths don't help."
+
+## 7. Start
+
+`ancestor-path` operator, `method = random-walk`, sampled per step with wildcard masking, method kept as a
+data-generation knob (no token yet). Add the `method` token when a second method (edge-weighted or PPR) is trained
+and inference wants to select. Eval with the graceful-degradation metrics already built (path-overlap / matched-depth
+on the paired hard subset) — the question is whether multi-path recovers ancestor branches better than HIER alone.

--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -65,7 +65,9 @@ the DAG's paths, wildcard-masked) is just **selecting which cached node-tokens e
   **ordered** (child→parent→grandparent). Attention over an unordered set would discard depth — which is exactly the
   graded-depth signal we want. So **add a depth-position embedding** to each node token (0 = the node itself, 1 =
   direct parent, …) before aggregation, so "direct parent" vs "grandparent" is distinguishable. (This is the natural
-  home for the graded-depth membership target.)
+  home for the graded-depth membership target.) *Max depth:* stop-β/multi-path give variable, possibly-deep paths, so
+  fix a **max-depth slot count with truncation** (simplest — deepest ancestors beyond it are dropped, acceptable as
+  branch signal is shallow-heavy), or use **relative** depth PEs if arbitrary depth must be exact.
 - **Padding masking.** Variable-length paths (from stop-β / multi-path) are padded to a fixed slot count; the
   attention block must **mask the padding tokens** so they don't pollute the aggregate. Standard, but must be wired.
 - **Cache invalidation.** The per-node embedding cache assumes static titles. On a graph refresh (Pearltrees/Wikipedia
@@ -205,3 +207,6 @@ is the part our experiments did **not** test, and the reason to build PATH rathe
 data-generation knob (no token yet). Add the `method` token when a second method (edge-weighted or PPR) is trained
 and inference wants to select. Eval with the graceful-degradation metrics already built (path-overlap / matched-depth
 on the paired hard subset) — the question is whether multi-path recovers ancestor branches better than HIER alone.
+*Interpretability guard (per review):* the `matched-depth` metric is only meaningful once the **depth PEs (§3b) are
+active** — a per-node baseline *without* them makes the model depth-blind, so a flat matched-depth would reflect the
+missing PEs, not a lack of PATH signal. Wire depth PEs before reading matched-depth results.

--- a/prototypes/mu_cosine/build_graded_round.py
+++ b/prototypes/mu_cosine/build_graded_round.py
@@ -35,10 +35,10 @@ JUDGE_OF = {"mindmap": "human", "pearltrees": "human", "enwiki": "graph"}
 # relation → (op, kind, mu_hi, mu_lo). kind: "down" dst is member/narrower of src; "up" dst is broader of
 # src; "sym" symmetric. mu_lo = the reverse-direction target (semantic-drift floor) for directional rels.
 RELATION_SPEC = {
-    "subtopic":       ("WIKI", "down", 0.85, 0.12),
-    "subcategory":    ("WIKI", "down", 0.90, 0.10),
+    "subtopic":       ("HIER", "down", 0.85, 0.12),
+    "subcategory":    ("HIER", "down", 0.90, 0.10),
     "element_of":     ("ELEM", "down", 0.90, 0.10),
-    "super_category": ("WIKI", "up",   0.85, 0.12),
+    "super_category": ("HIER", "up",   0.85, 0.12),
     "see_also":       ("SYM",  "sym",  0.40, 0.40),
     "assoc":          ("SYM",  "sym",  0.30, 0.30),
     "sequence":       ("SYM",  "sym",  0.30, 0.30),

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -122,7 +122,7 @@ def rank_all(model, tok, qtbl, ptbl, idx, q_keys, f_keys, truepos, dev):
     n_ops = model.op_emb.weight.shape[0]
     ow_of = lambda op: torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS[op]]), 1.0)
     sm = lambda ow: torch.tensor(score_mu(model, tok, idx, q_keys, f_keys, ow, dev))   # [Q,F] μ score matrix
-    S_elem, S_wiki, S_sym = sm(ow_of("ELEM")), sm(ow_of("WIKI")), sm(ow_of("SYM"))
+    S_elem, S_wiki, S_sym = sm(ow_of("ELEM")), sm(ow_of("HIER")), sm(ow_of("SYM"))
     S_super = sm(torch.full((1, n_ops), 1.0 / n_ops))
     S_max = torch.maximum(torch.maximum(S_elem, S_wiki), S_sym)   # operator-OR — the Wikipedia-eval winner
     C = (qtbl[[idx[k] for k in q_keys]] @ ptbl[[idx[k] for k in f_keys]].T).cpu()       # e5 cosine [Q,F], unit-normed

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -122,9 +122,9 @@ def rank_all(model, tok, qtbl, ptbl, idx, q_keys, f_keys, truepos, dev):
     n_ops = model.op_emb.weight.shape[0]
     ow_of = lambda op: torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS[op]]), 1.0)
     sm = lambda ow: torch.tensor(score_mu(model, tok, idx, q_keys, f_keys, ow, dev))   # [Q,F] μ score matrix
-    S_elem, S_wiki, S_sym = sm(ow_of("ELEM")), sm(ow_of("HIER")), sm(ow_of("SYM"))
+    S_elem, S_hier, S_sym = sm(ow_of("ELEM")), sm(ow_of("HIER")), sm(ow_of("SYM"))
     S_super = sm(torch.full((1, n_ops), 1.0 / n_ops))
-    S_max = torch.maximum(torch.maximum(S_elem, S_wiki), S_sym)   # operator-OR — the Wikipedia-eval winner
+    S_max = torch.maximum(torch.maximum(S_elem, S_hier), S_sym)   # operator-OR — the hierarchy-eval winner
     C = (qtbl[[idx[k] for k in q_keys]] @ ptbl[[idx[k] for k in f_keys]].T).cpu()       # e5 cosine [Q,F], unit-normed
     def nzrow(M):                                                 # per-query min-max → [0,1] across folders
         lo = M.min(dim=1, keepdim=True).values; hi = M.max(dim=1, keepdim=True).values

--- a/prototypes/mu_cosine/eval_hybrid.py
+++ b/prototypes/mu_cosine/eval_hybrid.py
@@ -43,7 +43,7 @@ def main():
     tok = Tokenizer(qt, pt, idx, parents={}, deg={})
     model = build_model(a.ckpt, dev); n_ops = model.op_emb.weight.shape[0]
     OPW = {"elem": torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["ELEM"]]), 1.0),
-           "wiki": torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["HIER"]]), 1.0),
+           "hier": torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["HIER"]]), 1.0),
            "sym":  torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["SYM"]]), 1.0),
            "super": torch.full((1, n_ops), 1.0 / n_ops)}                    # blend = operator superposition
     C = pt[[idx[c] for c in cands]]                                          # candidate containers as passage
@@ -69,7 +69,7 @@ def main():
         order = torch.argsort(-e5s).tolist(); tp_i = cand_pos[tp]
         e5_ranks.append(1 + order.index(tp_i))
         top = order[:a.topn]
-        muvs = {k: mu([(c, cands[j]) for j in top], OPW[k]) for k in ("elem", "wiki", "sym", "super")}
+        muvs = {k: mu([(c, cands[j]) for j in top], OPW[k]) for k in ("elem", "hier", "sym", "super")}
         store.append((tp_i, top, [e5s[j].item() for j in top], muvs))
 
     def blend_ranks(mufn, alpha):
@@ -90,9 +90,9 @@ def main():
     print(f"  e5-cos alone: recall@1 {rr(e5_ranks,1):.3f}  recall@5 {rr(e5_ranks,5):.3f}  MRR {e5_mrr:.3f}")
     # GRID: μ-part (which operators, combined how) × α (e5 weight; α=1 ⇒ μ-only, 0 ⇒ e5-only)
     muparts = {"super": lambda m: m["super"], "elem": lambda m: m["elem"],
-               "mean(e,w,s)": lambda m: [(m["elem"][i]+m["wiki"][i]+m["sym"][i])/3 for i in range(len(m["elem"]))],
-               "max(e,s)": mx("elem", "sym"), "max(e,w)": mx("elem", "wiki"),
-               "max(e,w,s)": mx("elem", "wiki", "sym"), "max(sup,e,w,s)": mx("super", "elem", "wiki", "sym")}
+               "mean(e,w,s)": lambda m: [(m["elem"][i]+m["hier"][i]+m["sym"][i])/3 for i in range(len(m["elem"]))],
+               "max(e,s)": mx("elem", "sym"), "max(e,w)": mx("elem", "hier"),
+               "max(e,w,s)": mx("elem", "hier", "sym"), "max(sup,e,w,s)": mx("super", "elem", "hier", "sym")}
     alphas = [0.0, 0.3, 0.5, 0.7, 0.9, 1.0]
     print(f"\n  MRR grid — μ-part × α (e5 weight):   [e5-cos={e5_mrr:.3f}]")
     print(f"  {'μ-part':14} " + "".join(f"α={a_:<5}" for a_ in alphas))
@@ -105,7 +105,7 @@ def main():
         star = lambda m: ("*" if m == max(cells) else " ")
         print(f"  {nm:14} " + "".join(f"{c:.3f}{star(c)} " for c in cells))
     print(f"\n  BEST: {best[0]}  MRR {best[1]:.3f}  (recall@1 {rr(best[2],1):.3f}  recall@5 {rr(best[2],5):.3f})  vs e5-cos {e5_mrr:.3f}")
-    hy_ranks = blend_ranks(mx("elem", "wiki", "sym"), 1.0)                  # μ-max for the sibling metric below
+    hy_ranks = blend_ranks(mx("elem", "hier", "sym"), 1.0)                  # μ-max for the sibling metric below
     # how often μ promotes the true parent that e5 buried below rank 1 but within the shortlist
     fixed = sum(1 for e, h in zip(e5_ranks, hy_ranks) if e > 1 and h == 1)
     broke = sum(1 for e, h in zip(e5_ranks, hy_ranks) if e == 1 and h > 1)
@@ -139,7 +139,7 @@ def main():
     # Coverage-insurance made per-query: trust μ where it is confident (sharp / high top-μ over the shortlist), fall
     # back to e5 where μ is flat/low (untrained/OOD). μ is a calibrated [0,1] membership degree ⇒ the top candidate's
     # μ-max IS a confidence signal, computed for free from the scores we already have.
-    mm_all = [[max(mv["elem"][i], mv["wiki"][i], mv["sym"][i]) for i in range(len(mv["elem"]))] for _, _, _, mv in store]
+    mm_all = [[max(mv["elem"][i], mv["hier"][i], mv["sym"][i]) for i in range(len(mv["elem"]))] for _, _, _, mv in store]
     t1 = [max(mm) for mm in mm_all]; med = sorted(t1)[len(t1) // 2]; alli = list(range(len(store)))
     def mrr_on(idxs, alpha_of):                                             # α_of(i)→per-query blend weight
         rs = []

--- a/prototypes/mu_cosine/eval_hybrid.py
+++ b/prototypes/mu_cosine/eval_hybrid.py
@@ -43,7 +43,7 @@ def main():
     tok = Tokenizer(qt, pt, idx, parents={}, deg={})
     model = build_model(a.ckpt, dev); n_ops = model.op_emb.weight.shape[0]
     OPW = {"elem": torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["ELEM"]]), 1.0),
-           "wiki": torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["WIKI"]]), 1.0),
+           "wiki": torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["HIER"]]), 1.0),
            "sym":  torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["SYM"]]), 1.0),
            "super": torch.full((1, n_ops), 1.0 / n_ops)}                    # blend = operator superposition
     C = pt[[idx[c] for c in cands]]                                          # candidate containers as passage

--- a/prototypes/mu_cosine/eval_rerank.py
+++ b/prototypes/mu_cosine/eval_rerank.py
@@ -29,7 +29,7 @@ def gen(a):
                                   texts={n: n.replace('_', ' ') for n in names}, device=a.device)
     tok = Tokenizer(qt, pt, idx, parents={}, deg={})
     model = build_model(a.ckpt, dev); n_ops = model.op_emb.weight.shape[0]
-    OPW = {k: (torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS[k.upper()]]), 1.0)) for k in ("elem", "wiki", "sym")}
+    OPW = {k: (torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS[k.upper()]]), 1.0)) for k in ("elem", "hier", "sym")}
     C = pt[[idx[c] for c in cands]]; cand_pos = {c: i for i, c in enumerate(cands)}
     nz = lambda v: [(x - min(v)) / (max(v) - min(v) + 1e-9) for x in v]
 
@@ -46,9 +46,9 @@ def gen(a):
         e5_top = torch.argsort(-e5s)[:a.topk].tolist()
         # blend over e5's top-N pool then take top-K
         pool = torch.argsort(-e5s)[:a.pool].tolist()
-        muv = {k: nz(mu([(c, cands[j]) for j in pool], OPW[k])) for k in ("elem", "wiki", "sym")}
+        muv = {k: nz(mu([(c, cands[j]) for j in pool], OPW[k])) for k in ("elem", "hier", "sym")}
         e5p = nz([e5s[j].item() for j in pool])
-        blend = [0.9 * max(muv["elem"][i], muv["wiki"][i], muv["sym"][i]) + 0.1 * e5p[i] for i in range(len(pool))]
+        blend = [0.9 * max(muv["elem"][i], muv["hier"][i], muv["sym"][i]) + 0.1 * e5p[i] for i in range(len(pool))]
         bl_top = [pool[i] for i in sorted(range(len(pool)), key=lambda i: -blend[i])[:a.topk]]
         out.append({"child": c, "true": tp,
                     "e5": [cands[j] for j in e5_top],           # e5 shortlist (ranked)

--- a/prototypes/mu_cosine/eval_self_anneal.py
+++ b/prototypes/mu_cosine/eval_self_anneal.py
@@ -113,7 +113,7 @@ def main():
     for spec in a.ckpts:
         path, _, label = spec.partition(":"); label = label or path
         model = build_model(path, dev); n_ops = model.op_emb.weight.shape[0]
-        OPW = {k: torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS[k.upper()]]), 1.0) for k in ("elem", "wiki", "sym")}
+        OPW = {k: torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS[k.upper()]]), 1.0) for k in ("elem", "hier", "sym")}
 
         @torch.no_grad()
         def mu(prs, ow):
@@ -126,8 +126,8 @@ def main():
 
         lvl, mrg, rr, wrong = [], [], [], []
         for qi, (c, tp_i, top) in enumerate(shortlists):
-            mvs = {k: mu([(c, cands[j]) for j in top], OPW[k]) for k in ("elem", "wiki", "sym")}
-            mm = [max(mvs["elem"][i], mvs["wiki"][i], mvs["sym"][i]) for i in range(len(top))]
+            mvs = {k: mu([(c, cands[j]) for j in top], OPW[k]) for k in ("elem", "hier", "sym")}
+            mm = [max(mvs["elem"][i], mvs["hier"][i], mvs["sym"][i]) for i in range(len(top))]
             sm = sorted(mm, reverse=True); top1, top2 = sm[0], (sm[1] if len(sm) > 1 else 0.0)
             order = sorted(range(len(top)), key=lambda i: -mm[i])
             rank = 1 + order.index(top.index(tp_i)) if tp_i in top else a.topn + 1

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -37,8 +37,13 @@ REPO = os.path.abspath(os.path.join(ROOT, "..", ".."))
 GRAPH = os.environ.get("UW_MU_GRAPH", os.path.join(REPO, "data", "benchmark", "10k", "category_parent.tsv"))
 E5_MODEL = "intfloat/e5-small-v2"
 
-# operator codebook (the relation axis).
-OPS = {"SYM": 0, "WIKI": 1, "LLM": 2, "ELEM": 3}
+# operator codebook (the relation axis). OPERATORS = pure RELATIONS (what the edge is). SOURCE lives on other axes:
+# corpus_emb (enwiki/simplewiki/pearltrees/mindmap) = which knowledge base; judge_emb (graph/haiku/…) = how labeled.
+#   SYM = symmetric relatedness · HIER = category-hierarchy (subcategory/subtopic/super_category; was "WIKI") ·
+#   ELEM = element_of (membership). Index 2 = DEPRECATED (was "LLM" — but the LLM is a *judge* on judge_emb, not a
+#   relation; the prompt gives the relation. The --llm fixture now routes to ELEM+haiku.) Kept only so n_ops stays 4
+#   (op_emb loads by shape); no relation maps to it.
+OPS = {"SYM": 0, "HIER": 1, "LLM": 2, "ELEM": 3}
 # ELEM = element-of (page-in-category / collection-membership): directional like WIKI (μ(page|category)
 # high, reverse low) but graded like SYM. Its own operator token + readout row on the shared trunk, so
 # page-membership trains as a DISTINCT relation instead of being conflated into SYM (see

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -43,7 +43,7 @@ E5_MODEL = "intfloat/e5-small-v2"
 #   ELEM = element_of (membership). Index 2 = DEPRECATED (was "LLM" — but the LLM is a *judge* on judge_emb, not a
 #   relation; the prompt gives the relation. The --llm fixture now routes to ELEM+haiku.) Kept only so n_ops stays 4
 #   (op_emb loads by shape); no relation maps to it.
-OPS = {"SYM": 0, "HIER": 1, "LLM": 2, "ELEM": 3}
+OPS = {"SYM": 0, "HIER": 1, "_DEPRECATED_LLM": 2, "ELEM": 3}   # index 2 kept for n_ops=4; explicit name so it can't be used by accident
 # ELEM = element-of (page-in-category / collection-membership): directional like WIKI (μ(page|category)
 # high, reverse low) but graded like SYM. Its own operator token + readout row on the shared trunk, so
 # page-membership trains as a DISTINCT relation instead of being conflated into SYM (see

--- a/prototypes/mu_cosine/mu_posterior.py
+++ b/prototypes/mu_cosine/mu_posterior.py
@@ -246,7 +246,7 @@ def model_readout_fn(ckpt_path, e5_cache, device="cpu", bs=2048):
     def readouts(pairs):                                   # pairs: list of (node, root) both in idx
         rev = [(b, a) for a, b in pairs]
         return {"sym": _mu(pairs, "SYM"),
-                "wiki_fwd": _mu(pairs, "WIKI"), "wiki_rev": _mu(rev, "WIKI"),
+                "wiki_fwd": _mu(pairs, "HIER"), "wiki_rev": _mu(rev, "HIER"),
                 "elem_fwd": _mu(pairs, "ELEM"), "elem_rev": _mu(rev, "ELEM")}
     readouts.idx = idx
     return readouts

--- a/prototypes/mu_cosine/test_infer_switch.py
+++ b/prototypes/mu_cosine/test_infer_switch.py
@@ -19,21 +19,21 @@ def test_tagged_never_switches():
 def test_non_element_never_switches():
     rng = random.Random(0)
     assert switched_op("SYM", "bridge", 0.4, 999, 0.4, 20, rng) == "SYM"
-    assert switched_op("WIKI", "subcategory", 0.4, 999, 0.4, 20, rng) == "WIKI"
+    assert switched_op("HIER", "subcategory", 0.4, 999, 0.4, 20, rng) == "HIER"
 
 
 def test_inferred_switches_at_expected_rate():
     # p = base·min(1, breadth/scale)·(1−conf) = 0.4 · min(1,100/20) · (1−0.4) = 0.4·1·0.6 = 0.24
     rng = random.Random(1)
-    n = sum(switched_op("ELEM", "element_of", 0.4, 100, 0.4, 20, rng) == "WIKI" for _ in range(4000))
+    n = sum(switched_op("ELEM", "element_of", 0.4, 100, 0.4, 20, rng) == "HIER" for _ in range(4000))
     assert 0.20 < n / 4000 < 0.28, n / 4000
 
 
 def test_confidence_scales_probability():
     # higher confidence ⇒ lower switch rate (0.8 inferred switches far less than 0.4)
     r1, r2 = random.Random(2), random.Random(2)
-    lo = sum(switched_op("ELEM", "element_of", 0.4, 100, 0.4, 20, r1) == "WIKI" for _ in range(4000))
-    hi = sum(switched_op("ELEM", "element_of", 0.8, 100, 0.4, 20, r2) == "WIKI" for _ in range(4000))
+    lo = sum(switched_op("ELEM", "element_of", 0.4, 100, 0.4, 20, r1) == "HIER" for _ in range(4000))
+    hi = sum(switched_op("ELEM", "element_of", 0.8, 100, 0.4, 20, r2) == "HIER" for _ in range(4000))
     assert hi < lo
 
 

--- a/prototypes/mu_cosine/test_op_weights.py
+++ b/prototypes/mu_cosine/test_op_weights.py
@@ -24,10 +24,10 @@ def _setup():
 def test_one_hot_equals_indexed():
     tok, m, names = _setup(); m.eval()
     a, b = names[100], names[200]
-    batch = tok.build([(a, b, OPS["WIKI"]), (a, b, OPS["ELEM"]), (a, b, OPS["SYM"])], train=False)
+    batch = tok.build([(a, b, OPS["HIER"]), (a, b, OPS["ELEM"]), (a, b, OPS["SYM"])], train=False)
     n_ops = m.op_emb.weight.shape[0]
     ow = torch.zeros(3, n_ops)
-    for k, op in enumerate(("WIKI", "ELEM", "SYM")):
+    for k, op in enumerate(("HIER", "ELEM", "SYM")):
         ow[k, OPS[op]] = 1.0
     with torch.no_grad():
         assert torch.allclose(m(**batch), m(**batch, op_weights=ow), atol=1e-6)
@@ -36,9 +36,9 @@ def test_one_hot_equals_indexed():
 def test_blend_differs_from_endpoints():
     tok, m, names = _setup(); m.eval()
     a, b = names[100], names[200]
-    batch = tok.build([(a, b, OPS["WIKI"])], train=False)
+    batch = tok.build([(a, b, OPS["HIER"])], train=False)
     n_ops = m.op_emb.weight.shape[0]
-    ow = torch.zeros(1, n_ops); ow[0, OPS["WIKI"]] = 0.5; ow[0, OPS["ELEM"]] = 0.5
+    ow = torch.zeros(1, n_ops); ow[0, OPS["HIER"]] = 0.5; ow[0, OPS["ELEM"]] = 0.5
     with torch.no_grad():
         wiki = float(m(**batch)[0])
         blend = float(m(**batch, op_weights=ow)[0])
@@ -48,7 +48,7 @@ def test_blend_differs_from_endpoints():
 def test_gradients_flow_through_op_weights():
     tok, m, names = _setup()
     a, b = names[100], names[200]
-    batch = tok.build([(a, b, OPS["WIKI"])], train=True)
+    batch = tok.build([(a, b, OPS["HIER"])], train=True)
     n_ops = m.op_emb.weight.shape[0]
     ow = torch.full((1, n_ops), 1.0 / n_ops)               # uniform blend (detached, like a sampled weight)
     m.zero_grad()

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -183,7 +183,7 @@ def main():
     fol_keys = [f"F:{f}" for f in fold_ids]
     qn = qtbl[[idx[bm_key[i]] for i in ev_idx]]; fn = ptbl[[idx[k] for k in fol_keys]]
     C = (qn @ fn.T).cpu()
-    # per-operator score matrices: elem/wiki/sym use the folder TITLE passage, lineage uses the folder PATH passage
+    # per-operator score matrices: elem/hier/sym use the folder TITLE passage, lineage uses the folder PATH passage
     S_elem, S_lin = score(fol_keys, ow_elem), score(lin_keys, ow_lin)
     S_hier, S_sym = score(fol_keys, OW(OPS["HIER"])), score(fol_keys, OW(OPS["SYM"]))
     elem_miss = [r for r in range(len(S_elem)) if top1(S_elem, r) != truepos[r]]   # FIXED hard subset (paired)

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -185,14 +185,14 @@ def main():
     C = (qn @ fn.T).cpu()
     # per-operator score matrices: elem/wiki/sym use the folder TITLE passage, lineage uses the folder PATH passage
     S_elem, S_lin = score(fol_keys, ow_elem), score(lin_keys, ow_lin)
-    S_wiki, S_sym = score(fol_keys, OW(OPS["HIER"])), score(fol_keys, OW(OPS["SYM"]))
+    S_hier, S_sym = score(fol_keys, OW(OPS["HIER"])), score(fol_keys, OW(OPS["SYM"]))
     elem_miss = [r for r in range(len(S_elem)) if top1(S_elem, r) != truepos[r]]   # FIXED hard subset (paired)
 
     # ── increment 2: COMBINER SWEEP (don't assume the combiner or the operator subset — measure) ──
     def nz(M):                                                      # per-query min-max → [0,1] over candidate folders
         M = torch.tensor(M); lo = M.min(1, keepdim=True).values; hi = M.max(1, keepdim=True).values
         return (M - lo) / (hi - lo + 1e-9)
-    Ce, Se, Sl, Sw, Ss = nz(C.tolist()), nz(S_elem), nz(S_lin), nz(S_wiki), nz(S_sym)
+    Ce, Se, Sl, Sw, Ss = nz(C.tolist()), nz(S_elem), nz(S_lin), nz(S_hier), nz(S_sym)
     mx = lambda *Ms: torch.stack(Ms).amax(0)
     et = torch.tensor(S_elem); t2 = et.topk(min(2, et.shape[1]), 1).values          # leaf-certainty gate from ELEM margin
     emar = (t2[:, 0] - t2[:, 1]) if t2.shape[1] > 1 else torch.zeros(et.shape[0])

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -185,7 +185,7 @@ def main():
     C = (qn @ fn.T).cpu()
     # per-operator score matrices: elem/wiki/sym use the folder TITLE passage, lineage uses the folder PATH passage
     S_elem, S_lin = score(fol_keys, ow_elem), score(lin_keys, ow_lin)
-    S_wiki, S_sym = score(fol_keys, OW(OPS["WIKI"])), score(fol_keys, OW(OPS["SYM"]))
+    S_wiki, S_sym = score(fol_keys, OW(OPS["HIER"])), score(fol_keys, OW(OPS["SYM"]))
     elem_miss = [r for r in range(len(S_elem)) if top1(S_elem, r) != truepos[r]]   # FIXED hard subset (paired)
 
     # ── increment 2: COMBINER SWEEP (don't assume the combiner or the operator subset — measure) ──

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -849,6 +849,9 @@ def train(args):
             li = [(n, r, OPS["ELEM"], SW, HAIKU) for n, r, _ in lb]   # bought-Haiku MEMBERSHIP fixture = ELEM + judge=haiku (was mislabeled OPS["LLM"])
             lt = torch.tensor([mu for _, _, mu in lb]).to(device)
             L_llm = F.mse_loss(model(**bld(li, train=True, rng=rng, p_mask_prov=args.prov_mask)), lt)
+            # NB: this MSE now targets the ELEM row (rerouted from the demoted LLM op), which also gets BCE from the
+            # main ELEM training. Aligned in intent (both = membership); --llm-weight controls the MSE/BCE balance on
+            # the shared row. Only active with --llm (optional, rarely used); name kept for the CLI flag.
             loss = loss + args.llm_weight * L_llm
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
@@ -928,7 +931,7 @@ def validate(model, tok, names, idx, adj, edges_hold, pos_hold, llm, args, elem_
         cp = mu_batch(model, tok, [(c, p, OPS["HIER"]) for c, p in edges_hold])
         pc = mu_batch(model, tok, [(p, c, OPS["HIER"]) for c, p in edges_hold])
         acc = float((cp > pc).float().mean())
-        print(f"[WIKI] held-out edge ORDER-accuracy μ(child|parent)>μ(parent|child): {acc*100:.1f}% "
+        print(f"[HIER] held-out edge ORDER-accuracy μ(child|parent)>μ(parent|child): {acc*100:.1f}% "
               f"({len(edges_hold)} edges)  mean μ(c|p)={float(cp.mean()):.3f} μ(p|c)={float(pc.mean()):.3f}")
 
     # --- SYM: held-out corr + symmetry (the headline metric for this work) ---

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -905,7 +905,7 @@ def train(args):
 
 def validate(model, tok, names, idx, adj, edges_hold, pos_hold, llm, args, elem_hold=None, graded_hold=None):
     print("\n=== PER-OPERATOR VALIDATION ===")
-    ops = ["SYM"] if args.sym_only else (["SYM", "HIER"] + (["LLM"] if llm else []))
+    ops = ["SYM"] if args.sym_only else ["SYM", "HIER"]   # LLM operator retired (fixture now trains ELEM); no op at idx 2 to validate
 
     # --- GRADED: held-out fused-round fit, per operator (revealed provenance + node-type as trained) ---
     if graded_hold and not args.sym_only:

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -64,8 +64,8 @@ def load_transitive(path, idx):
 # relation → (operator, forward target, reverse target) for the INFER-BLEND path (§5b: blend the operator
 # embedding at OPERATOR level, but keep the μ target at RELATION level — SYM's relations have different μ).
 REL_SPEC = {
-    "element_of":     ("ELEM", 0.90, 0.10), "subcategory": ("WIKI", 0.90, 0.10),
-    "subtopic":       ("WIKI", 0.85, 0.12), "super_category": ("WIKI", 0.85, 0.12),
+    "element_of":     ("ELEM", 0.90, 0.10), "subcategory": ("HIER", 0.90, 0.10),
+    "subtopic":       ("HIER", 0.85, 0.12), "super_category": ("HIER", 0.85, 0.12),
     "see_also":       ("SYM",  0.40, 0.40), "assoc": ("SYM", 0.30, 0.30),
     "bridge":         ("SYM",  0.90, 0.90), "bridge_neg": ("SYM", 0.10, 0.10),
 }
@@ -79,7 +79,7 @@ def switched_op(op, rel, conf, breadth, base, scale, rng):
     if op == "ELEM" and rel == "element_of" and conf < 1.0:
         p = base * min(1.0, breadth / max(1.0, scale)) * (1.0 - conf)
         if rng.random() < p:
-            return "WIKI"                                # train this untagged membership as a subcategory
+            return "HIER"                                # train this untagged membership as a subcategory
     return op
 
 # PART B provenance tags for the current single-corpus data. corpus = simplewiki (the 10k graph);
@@ -594,7 +594,7 @@ def train(args):
             return mu_batch(model, tok, items).numpy()
         e5 = _np.array([float(tok.p[idx[a]] @ tok.q[idx[b]]) if a in idx and b in idx else _np.nan for a, b in pairs])
         cols = [e5, mb([(a, b, OPS["SYM"]) for a, b in pairs]),
-                mb([(a, b, OPS["WIKI"]) for a, b in pairs]), mb([(b, a, OPS["WIKI"]) for a, b in pairs]),
+                mb([(a, b, OPS["HIER"]) for a, b in pairs]), mb([(b, a, OPS["HIER"]) for a, b in pairs]),
                 mb([(a, b, OPS["ELEM"]) for a, b in pairs]), mb([(b, a, OPS["ELEM"]) for a, b in pairs])]
         model.train()
         return _np.stack(cols, 1)
@@ -699,9 +699,9 @@ def train(args):
             # (no bce(·,1) ceiling on μ(child|parent) — that creates a "predict the mean (1/3)" collapse).
             eb = [edges_tr[rng.randrange(len(edges_tr))] for _ in range(args.bs)]
             negpar = [eb[(i + 1) % len(eb)][1] for i in range(len(eb))]
-            wiki_items = ([(c, par, OPS["WIKI"], SW, GRAPHJ) for c, par in eb]
-                          + [(par, c, OPS["WIKI"], SW, GRAPHJ) for c, par in eb]
-                          + [(c, negpar[i], OPS["WIKI"], SW, GRAPHJ) for i, (c, par) in enumerate(eb)])
+            wiki_items = ([(c, par, OPS["HIER"], SW, GRAPHJ) for c, par in eb]
+                          + [(par, c, OPS["HIER"], SW, GRAPHJ) for c, par in eb]
+                          + [(c, negpar[i], OPS["HIER"], SW, GRAPHJ) for i, (c, par) in enumerate(eb)])
             mu_w = model(**bld(wiki_items, train=True, rng=rng, p_mask_prov=args.prov_mask))
             mu_cp, mu_pc, mu_cpn = mu_w[:args.bs], mu_w[args.bs:2 * args.bs], mu_w[2 * args.bs:]
             L_wiki = (bce(mu_pc, 0) + bce(mu_cpn, 0)
@@ -846,7 +846,7 @@ def train(args):
         L_llm = torch.zeros(())
         if llm and not args.sym_only:
             lb = [llm[rng.randrange(len(llm))] for _ in range(args.bs)]
-            li = [(n, r, OPS["LLM"], SW, HAIKU) for n, r, _ in lb]
+            li = [(n, r, OPS["ELEM"], SW, HAIKU) for n, r, _ in lb]   # bought-Haiku MEMBERSHIP fixture = ELEM + judge=haiku (was mislabeled OPS["LLM"])
             lt = torch.tensor([mu for _, _, mu in lb]).to(device)
             L_llm = F.mse_loss(model(**bld(li, train=True, rng=rng, p_mask_prov=args.prov_mask)), lt)
             loss = loss + args.llm_weight * L_llm
@@ -902,7 +902,7 @@ def train(args):
 
 def validate(model, tok, names, idx, adj, edges_hold, pos_hold, llm, args, elem_hold=None, graded_hold=None):
     print("\n=== PER-OPERATOR VALIDATION ===")
-    ops = ["SYM"] if args.sym_only else (["SYM", "WIKI"] + (["LLM"] if llm else []))
+    ops = ["SYM"] if args.sym_only else (["SYM", "HIER"] + (["LLM"] if llm else []))
 
     # --- GRADED: held-out fused-round fit, per operator (revealed provenance + node-type as trained) ---
     if graded_hold and not args.sym_only:
@@ -925,8 +925,8 @@ def validate(model, tok, names, idx, adj, edges_hold, pos_hold, llm, args, elem_
 
     # --- WIKI: held-out edge order-accuracy ---
     if not args.sym_only:
-        cp = mu_batch(model, tok, [(c, p, OPS["WIKI"]) for c, p in edges_hold])
-        pc = mu_batch(model, tok, [(p, c, OPS["WIKI"]) for c, p in edges_hold])
+        cp = mu_batch(model, tok, [(c, p, OPS["HIER"]) for c, p in edges_hold])
+        pc = mu_batch(model, tok, [(p, c, OPS["HIER"]) for c, p in edges_hold])
         acc = float((cp > pc).float().mean())
         print(f"[WIKI] held-out edge ORDER-accuracy μ(child|parent)>μ(parent|child): {acc*100:.1f}% "
               f"({len(edges_hold)} edges)  mean μ(c|p)={float(cp.mean()):.3f} μ(p|c)={float(pc.mean()):.3f}")


### PR DESCRIPTION
Two things from one factorization question: **the operator axis should be pure *relations*; source and
computation-strategy belong on other axes.** Part 1 is a small code cleanup; Part 2 is a future-work design doc (the
reviewable part — architecture-on-paper, no empirical claims, nothing built).

### Part 1 — operator cleanup (code, checkpoint-safe, no behavior change)
- **`WIKI` → `HIER`.** `WIKI` named an operator after a *source* (Wikipedia), but the source axis already
  distinguishes `enwiki/simplewiki/pearltrees/mindmap` (`corpus_emb`). It's really the **category-hierarchy relation**
  (subcategory/subtopic/super_category) → renamed. `op_emb` is a *learned codebook indexed by ID*, so this is pure
  relabeling — the learned row is untouched (verified: `test_op_weights` passes; `REL_SPEC` maps only `ELEM/HIER/SYM`).
- **`LLM` demoted.** Never a relation — the LLM is a *judge* (already on `judge_emb` as `haiku/sonnet/opus`); the
  *prompt* defines the relation. Its `--llm` "bought-Haiku membership" fixture is really `ELEM` + `judge=haiku` →
  rerouted there. Index 2 kept (n_ops=4, checkpoint-compat) but deprecated.

Net: operator axis = pure relations (`SYM`, `HIER`, `ELEM`); sources on `corpus_emb`, judges on `judge_emb`.

### Part 2 — `DESIGN_path_operator.md` (future-work design; the part to review)
A multi-path ancestor operator for the DAG (a node has many ancestor chains; the earlier single-path LINEAGE
collapsed them and came out redundant to HIER — but multi-path is untested). Four choices, each resolving a real
strain and each **reusing existing machinery**:

1. **operator × method (higher-order).** Ancestor-path membership is *one* operator with a `method` parameter;
   `LINEAGE = method:canonical`, `PATH = method:random-walk`. Unifies lineage/path.
2. **stop-β.** A per-step stopping probability gives geometric-depth paths (a principled depth sampler) **and** makes
   uniform-walk-with-stop = discrete PPR (β = restart) — random-walk and PPR sampling collapse into one knob. Three
   methods documented: uniform-walk(+β), edge-weighted (RefPearl≫AliasPearl), PPR/flux.
3. **per-node token representation.** Sampled paths (walk × stop × multi-path × wildcards) are combinatorial, so
   whole-path embeddings can't be precomputed. Represent the path as per-node cached embeddings + attention
   aggregation; sampling = *selecting which cached node-tokens enter the passage*. No re-embedding; a multi-token
   passage the attention block already supports.
4. **operator encoder = key–value attention lookup; numeric params via fixed Fourier + FiLM.** The operator token is
   *computed* from a spec, not looked up: `keys = e5(operator names)`, `values = existing learned op_emb rows`,
   `query = e5(operator description)`, `encoding = softmax(query·keysᵀ) @ values`. That softmax **is** the existing
   `op_weights`, so it generates the superposition weights from the operator's *description* (degenerates to today's
   codebook when a query hits one key); e5 is only the *key* (routing), the *learned value* carries semantics —
   sidestepping the "raw-e5-name = prompt-rewriting" concern. **Numeric parameters (β, edge-weights) inject on a
   separate path — the attention can't route a continuum:** Fourier-feature encode each scalar (`β → [sin/cos at
   several frequencies]` — raw scalars underfit MLPs; sinusoidal features fix it), then **FiLM-modulate** the
   attention output (`op_encoding = γ(fourier(β)) ⊙ base + shift`). **Frequencies are FIXED, not learned** —
   parameter-free (only the small FiLM MLP trains) and sufficient because β's range is known ([0,1]); chosen for
   reduced training on consumer-grade hardware.

Honest scoping throughout: adopt the encoder + per-node representation *when building* PATH-with-methods; the codebook
+ single-node passages stay valid for the base relations meanwhile. Prior art cited in-doc (Vaswani 2017 sinusoidal
PE; Tancik 2020 + Rahimi & Recht 2007 Fourier features / spectral bias; NeRF 2020; Time2Vec 2019; FiLM Perez 2018).

### Review ask (light, no compute)
Scrutiny welcome on Part 2's *architecture*: does operator×method×representation×encoder hold together; is the
attention-lookup-as-`op_weights` reduction sound; is stop-β = discrete-PPR right; is Fourier+FiLM the right way to
inject continuous params (and fixed-frequencies the right call given a known [0,1] range); simpler alternatives to
the per-node representation or the encoder? Part 1 is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)