### PR TITLE
mu_cosine: PATH multipath operator — build, test, and the honest verdict (single-path for Pearltrees, multipath for Wikipedia)

### DIFF
--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -1,5 +1,32 @@
 # PATH operator — multi-path ancestor membership over the DAG (design / future-work)
 
+## Empirical conclusion (2026-07-01, 3-seed CI) — multipath does NOT beat single-path on Pearltrees
+
+Built the deterministic shallow merged-multipath passage (`merged_ancestors.py`, `train_lineage --merged --dag`)
+and tested it on the RDF+API **assembled** Pearltrees DAG (which recovers 396/880 multi-parent filing folders — the
+API-only 20 was an artifact of the RDF-export truncation bug, see [[project_pearltrees_rdf_export_bug]]).
+
+**Result: multipath is not a win on Pearltrees.** A 3-seed CI (seeds 7/13/42) of `mu-lineage` PATH(merged) vs
+single-path LINEAGE:
+- *Full eval:* mean deltas positive but **within noise** (stdev ≥ mean; seed 42 reverses). Looked promising at
+  seed 7 alone — walked back by multi-seed.
+- *Multi-parent subset* (where the passage actually differs — 82% of queries, dilution was minor): the
+  branch-recovery metrics are **negative** — `ov|miss` mean −0.027, `depth|miss` mean −0.123. The full-eval
+  positivity was **training-side variance**, not the multipath passage doing work.
+
+**Decision — corpus-driven operator choice:**
+- **Pearltrees → single-path `LINEAGE`.** It has a *principal* parent (the RefPearl "inside" precedence = the actual
+  human filing decision — real signal), and multipath gives no measurable benefit over it. Simpler and cheaper.
+- **Wikipedia → multipath `PATH`.** Categories have *no* principal parent (every parent link equal), so single-path
+  is an arbitrary pick — multipath is the only meaningful ancestor representation. NB: this is "what Wikipedia
+  affords," **not** proven-superior — a proper Wikipedia branch-recovery eval (avoiding the mis-framed
+  context-on-candidate setup in `eval_path_wiki.py`) is still open if we need it.
+
+The machinery below is built and correct; it's the right tool for the multi-parent Wikipedia DAG, not for Pearltrees.
+The rest of this doc is the (still-unbuilt) full design.
+
+---
+
 Design note (nothing built yet). Follows the finding that single-path LINEAGE is redundant to HIER, but a
 **multi-path** ancestor operator is *not* — because a DAG node has many ancestor chains, and the harvested
 single-path collapse (`parent_map` precedence) threw all but one away.

--- a/prototypes/mu_cosine/DESIGN_path_operator.md
+++ b/prototypes/mu_cosine/DESIGN_path_operator.md
@@ -68,6 +68,14 @@ the DAG's paths, wildcard-masked) is just **selecting which cached node-tokens e
   home for the graded-depth membership target.) *Max depth:* stop-β/multi-path give variable, possibly-deep paths, so
   fix a **max-depth slot count with truncation** (simplest — deepest ancestors beyond it are dropped, acceptable as
   branch signal is shallow-heavy), or use **relative** depth PEs if arbitrary depth must be exact.
+  **EMPIRICAL (dense-DAG calibration, wide_enwiki_math):** on Wikipedia (dense multi-parent) the *deterministic*
+  merged closure **explodes** — `max_depth 12–15` from any node reaches all of science/humanities via structural
+  connectors (even after admin-filtering) — an incoherent grab-bag. At **`max_depth 2`** it's small and coherent
+  (`Abstract algebra` → `Algebra` + `Fields of mathematics`; `People` → `Humans` + `Anthropology`). So the merged
+  list must be a **shallow LOCAL context (parents + grandparents), NOT the full closure** — the branch signal lives
+  there anyway. `max_depth 15` only worked for *shallow Pearltrees*; the stochastic stop-β must likewise be
+  **shallow-mean** on dense DAGs (not the mean-10 that suited Pearltrees). Plus admin-filter the few structural
+  connectors (`Container categories`, `Categories requiring diffusion`) that appear as grandparents.
 - **Padding masking.** Variable-length paths (from stop-β / multi-path) are padded to a fixed slot count; the
   attention block must **mask the padding tokens** so they don't pollute the aggregate. Standard, but must be wired.
 - **Cache invalidation.** The per-node embedding cache assumes static titles. On a graph refresh (Pearltrees/Wikipedia

--- a/prototypes/mu_cosine/eval_path_wiki.py
+++ b/prototypes/mu_cosine/eval_path_wiki.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""eval_path_wiki.py — does a MERGED shallow multi-ancestor passage beat a single-path / bare-title passage for
+directional membership on a DENSE multi-parent DAG (Wikipedia categories)?
+
+Reuses eval_hybrid's "find my container" task (query = child category, target = true parent) but varies the
+CANDIDATE PASSAGE that μ scores against, holding the operator at HIER to isolate the PASSAGE effect:
+  HIER     = bare candidate title (baseline)
+  LINEAGE  = candidate's single-path ancestor chain (first parent each hop)
+  PATH     = candidate's MERGED shallow ancestor context (ALL parents, max_depth 2) — the multi-path passage
+
+Reports recall@1/@5/MRR on ALL queries and on the MULTI-PARENT subset (children with >1 parent — where PATH can
+differ). e5 shortlist is by title (same for all three), so only the μ re-rank passage changes.
+
+  python3 eval_path_wiki.py --ckpt model_prod.pt --graph ../../data/benchmark/wide_enwiki_math/category_parent.tsv
+"""
+import argparse, random, torch
+from mu_attention import build_e5_tables, Tokenizer, OPS
+from eval_arch_control import build_model
+from merged_ancestors import load_category_graph, render_merged_list
+
+
+def single_path_text(node, parents_of, title_of, max_depth=6):
+    """One lineage chain: walk up following the first unseen parent each hop (the LINEAGE-style single path)."""
+    chain, cur, seen = [node], node, {node}
+    for _ in range(max_depth):
+        nxt = next((p for p in parents_of.get(cur, []) if p not in seen), None)
+        if not nxt:
+            break
+        chain.append(nxt); seen.add(nxt); cur = nxt
+    return "\n".join(f"{'  ' * i}- {title_of.get(n, n)}" for i, n in enumerate(reversed(chain)))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ckpt", required=True); ap.add_argument("--graph", required=True)
+    ap.add_argument("--n-queries", type=int, default=800); ap.add_argument("--topn", type=int, default=20)
+    ap.add_argument("--min-children", type=int, default=5)
+    ap.add_argument("--max-depth", type=int, default=2, help="PATH merged-context depth (shallow for dense DAGs)")
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
+
+    parents_of, title_of = load_category_graph(a.graph)
+    children = {}
+    for c, ps in parents_of.items():
+        for p in ps:
+            children.setdefault(p, []).append(c)
+    cands = [p for p, k in children.items() if len(k) >= a.min_children]; cset = set(cands)
+    queries = [(c, p) for p in cands for c in children[p] if p in cset]
+    rng.shuffle(queries); queries = queries[:a.n_queries]
+    names = sorted(set(cands) | {c for c, p in queries})
+    print(f"[PATH-WIKI] {len(queries)} queries, {len(cands)} candidate containers, {len(names)} names; embedding 3 passage variants (CPU-slow, cached)...", flush=True)
+
+    texts_title = {n: title_of.get(n, n) for n in names}
+    texts_lin = {n: single_path_text(n, parents_of, title_of) for n in names}
+    texts_path = {n: render_merged_list(n, parents_of, title_of, max_depth=a.max_depth) for n in names}
+    qt, pt_title, idx = build_e5_tables(names, cache_path="/tmp/pathwiki_title.pt", texts=texts_title, device=a.device)
+    _, pt_lin, _ = build_e5_tables(names, cache_path="/tmp/pathwiki_lin.pt", texts=texts_lin, device=a.device)
+    _, pt_path, _ = build_e5_tables(names, cache_path="/tmp/pathwiki_path.pt", texts=texts_path, device=a.device)
+
+    model = build_model(a.ckpt, dev); n_ops = model.op_emb.weight.shape[0]
+    OW = torch.zeros(1, n_ops).index_fill_(1, torch.tensor([OPS["HIER"]]), 1.0)
+    toks = {"HIER(title)": Tokenizer(qt, pt_title, idx, parents={}, deg={}),
+            "LINEAGE(1-path)": Tokenizer(qt, pt_lin, idx, parents={}, deg={}),
+            "PATH(merged)": Tokenizer(qt, pt_path, idx, parents={}, deg={})}
+
+    @torch.no_grad()
+    def mu(tok, prs):
+        out = []
+        for i in range(0, len(prs), 512):
+            ch = prs[i:i+512]; b = tok.build([(x, y, 0) for x, y in ch], train=False)
+            b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+            out += model(**b, op_weights=OW.to(dev).expand(len(ch), n_ops)).cpu().tolist()
+        return out
+
+    cand_pos = {c: i for i, c in enumerate(cands)}
+    C_e5 = pt_title[[idx[c] for c in cands]]                       # e5 shortlist by title (same for all variants)
+    R = {k: [] for k in toks}; Rmp = {k: [] for k in toks}
+    for c, tp in queries:
+        qv = qt[idx[c]]; e5s = (qv @ C_e5.T).cpu()
+        order = torch.argsort(-e5s).tolist(); tp_i = cand_pos[tp]; top = order[:a.topn]
+        mp = len(parents_of.get(c, [])) > 1
+        for k, tok in toks.items():
+            m = mu(tok, [(c, cands[j]) for j in top])
+            ro = [top[j] for j in sorted(range(len(top)), key=lambda j: -m[j])]
+            r = 1 + ro.index(tp_i) if tp_i in ro else a.topn + 1
+            R[k].append(r)
+            if mp:
+                Rmp[k].append(r)
+
+    def rep(nm, ranks):
+        r1 = sum(x <= 1 for x in ranks) / len(ranks); r5 = sum(x <= 5 for x in ranks) / len(ranks)
+        mrr = sum(1.0 / x for x in ranks) / len(ranks)
+        print(f"  {nm:16} recall@1 {r1:.3f}  recall@5 {r5:.3f}  MRR {mrr:.3f}  (n={len(ranks)})")
+    print(f"\n== ALL queries (op=HIER; passage varies) ==")
+    for k in toks:
+        rep(k, R[k])
+    print(f"== MULTI-PARENT children only (where PATH can differ; n={len(Rmp['HIER(title)'])}) ==")
+    for k in toks:
+        rep(k, Rmp[k])
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/merged_ancestors.py
+++ b/prototypes/mu_cosine/merged_ancestors.py
@@ -47,6 +47,32 @@ def load_multiparent_dag(trees_dir):
     return parents_of, title_of
 
 
+def load_category_graph(tsv):
+    """→ (parents_of: child→[parents], title_of: name→title) from a `child<TAB>parent` category graph (enwiki/
+    simplewiki — the genuine multi-parent DAG; Pearltrees' multi-parent is just this reflected in, so PATH belongs
+    here). Category name IS the node id and the title."""
+    from mu_attention import load_dag
+    parents, _children, _deg = load_dag(tsv)
+    parents_of = {c: list(ps) for c, ps in parents.items()}
+    title_of = {n: n.replace("_", " ") for n in parents}
+    return parents_of, title_of
+
+
+def subtree_scope(root, parents_of):
+    """Set of all descendants of `root` (BFS down) — pass as scope= to bound the ancestor walk to a content subtree
+    (e.g. Main_topic_classifications), avoiding admin-category wandering / weird long paths by construction."""
+    children_of = collections.defaultdict(list)
+    for c, ps in parents_of.items():
+        for p in ps:
+            children_of[p].append(c)
+    scope, frontier = {str(root)}, [str(root)]
+    while frontier:
+        for ch in children_of.get(frontier.pop(), []):
+            if ch not in scope:
+                scope.add(ch); frontier.append(ch)
+    return scope
+
+
 def merged_ancestor_list(node, parents_of, title_of, max_depth=15, scope=None):
     """Merged ancestor list for `node`: unique ancestors (ID-keyed) reached by walking up ALL parents.
     Cycle-detected (visited), max-depth bounded. Returns [(id, title, min_hop)] ordered root-ward first.
@@ -82,13 +108,14 @@ def render_merged_list(node, parents_of, title_of, max_depth=15, scope=None):
     return "\n".join(lines)
 
 
-if __name__ == "__main__":                                        # demo on a known multi-parent node
+if __name__ == "__main__":                                        # demo: category graph (.tsv) or Pearltrees trees dir
     import sys
-    td = sys.argv[1] if len(sys.argv) > 1 else "../../.local/data/pearltrees_api/trees"
-    parents_of, title_of = load_multiparent_dag(td)
+    src = sys.argv[1] if len(sys.argv) > 1 else "/tmp/merged_category_parent.tsv"
+    parents_of, title_of = (load_category_graph(src) if src.endswith(".tsv")
+                            else load_multiparent_dag(src))
     mp = [(c, ps) for c, ps in parents_of.items() if len(ps) > 1]
-    print(f"[DAG] {len(parents_of)} nodes with parents, {len(mp)} multi-parent")
+    print(f"[DAG] {len(parents_of)} nodes, {len(mp)} multi-parent ({100*len(mp)//max(1,len(parents_of))}%)")
     for cid, ps in mp[:3]:
-        print(f"\n=== '{title_of.get(cid, cid)}' (id {cid}) — {len(ps)} parents: {[title_of.get(p, p) for p in ps]} ===")
-        print("  single-path LINEAGE would pick ONE of those. Merged PATH list:")
+        print(f"\n=== '{title_of.get(cid, cid)}' — {len(ps)} parents: {[title_of.get(p, p) for p in ps][:6]} ===")
+        print("  single-path LINEAGE would pick ONE. Merged PATH list (root-ward first, max-depth 15):")
         print(render_merged_list(cid, parents_of, title_of))

--- a/prototypes/mu_cosine/merged_ancestors.py
+++ b/prototypes/mu_cosine/merged_ancestors.py
@@ -58,6 +58,24 @@ def load_category_graph(tsv):
     return parents_of, title_of
 
 
+def load_assembled_dag(dag_tsv, titles_tsv=None):
+    """→ (parents_of: child→[parents], title_of) from an assembled `child<TAB>parent` DAG TSV (e.g. the RDF+API
+    Pearltrees union that recovers the parents the truncated RDF export dropped) + an optional `id<TAB>title` map.
+    Nodes without a title fall back to the id string."""
+    parents_of = collections.defaultdict(list)
+    for line in open(dag_tsv, encoding="utf-8"):
+        p = line.rstrip("\n").split("\t")
+        if len(p) >= 2 and p[1] not in parents_of[p[0]]:
+            parents_of[p[0]].append(p[1])
+    title_of = {}
+    if titles_tsv:
+        for line in open(titles_tsv, encoding="utf-8"):
+            p = line.rstrip("\n").split("\t")
+            if len(p) >= 2:
+                title_of[p[0]] = p[1]
+    return dict(parents_of), title_of
+
+
 def subtree_scope(root, parents_of):
     """Set of all descendants of `root` (BFS down) — pass as scope= to bound the ancestor walk to a content subtree
     (e.g. Main_topic_classifications), avoiding admin-category wandering / weird long paths by construction."""
@@ -73,10 +91,11 @@ def subtree_scope(root, parents_of):
     return scope
 
 
-def merged_ancestor_list(node, parents_of, title_of, max_depth=15, scope=None):
+def merged_ancestor_list(node, parents_of, title_of, max_depth=15, scope=None, max_ancestors=None):
     """Merged ancestor list for `node`: unique ancestors (ID-keyed) reached by walking up ALL parents.
     Cycle-detected (visited), max-depth bounded. Returns [(id, title, min_hop)] ordered root-ward first.
-    `scope` (a set of allowed ids) restricts the walk to a subtree if given."""
+    `scope` (a set of allowed ids) restricts the walk to a subtree if given. `max_ancestors` keeps only the
+    NEAREST-N by hop (protects e5's token limit on dense high-level nodes — deep grab-bag drops first)."""
     node = str(node)
     min_hop = {}                                                   # ancestor id -> min hops from `node`
     # BFS upward over the multi-parent DAG (visited = cycle detection; depth = max_depth bound)
@@ -94,15 +113,18 @@ def merged_ancestor_list(node, parents_of, title_of, max_depth=15, scope=None):
                 min_hop[par] = h + 1
             if par not in seen:                                    # cycle detection
                 seen.add(par); frontier.append((par, h + 1))
-    # merged (ID-keyed → each ancestor once), ordered root-ward first (largest hop = closest to root)
-    anc = sorted(min_hop.items(), key=lambda kv: -kv[1])
+    # merged (ID-keyed → each ancestor once)
+    if max_ancestors:                                              # keep NEAREST-N by hop (drop the deep grab-bag)
+        keep = sorted(min_hop.items(), key=lambda kv: kv[1])[:max_ancestors]
+        min_hop = dict(keep)
+    anc = sorted(min_hop.items(), key=lambda kv: -kv[1])           # ordered root-ward first (largest hop = near root)
     return [(aid, title_of.get(aid, aid), hop) for aid, hop in anc]
 
 
-def render_merged_list(node, parents_of, title_of, max_depth=15, scope=None):
+def render_merged_list(node, parents_of, title_of, max_depth=15, scope=None, max_ancestors=None):
     """Text passage for e5: titles only, root-ward first, node title last. NO id line (merged/branching → no linear
     id anchor); ids stay internal merge keys. Depth shown by indent (informational; the model gets depth via PEs)."""
-    anc = merged_ancestor_list(node, parents_of, title_of, max_depth, scope)
+    anc = merged_ancestor_list(node, parents_of, title_of, max_depth, scope, max_ancestors)
     lines = [f"{'  ' * (len(anc) - i)}- {title}" for i, (_, title, _) in enumerate(anc)]
     lines.append(f"{'  ' * 0}- {title_of.get(str(node), str(node))}")   # the node itself, deepest
     return "\n".join(lines)

--- a/prototypes/mu_cosine/merged_ancestors.py
+++ b/prototypes/mu_cosine/merged_ancestors.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""merged_ancestors.py — build the MULTI-PARENT ancestor DAG and each node's MERGED ancestor list (PATH operator).
+
+The PATH increment-0 representation (DESIGN_path_operator.md, per the design discussion):
+  * the graph is a **DAG** — a folder can have several parents (7% of Pearltrees folders do, up to 13). Single-path
+    LINEAGE collapses that to one arbitrary chain; PATH scores against the **merged** set of ancestor contexts.
+  * a node's passage = its **merged ancestor list**: all reachable ancestors (titles), **ID-keyed merged** (each
+    unique ancestor once), **no materialized-id line** (a linear id line can't represent a branching/merged
+    structure — the id stays an internal merge key, not embedded text).
+  * guards: **cycle detection** (visited set) + **max-depth** cap (deterministic bound so the merged list stays
+    precomputable; the stochastic stop-β variant is for later sampling). Optionally **scope** to a root subtree.
+
+Parent edges come from each tree's sub-tree-reference pearls: a pearl's `treeId` is the PARENT, `contentTree.id`
+(contentType 2/5/6) is the CHILD it references.
+"""
+import glob, json, os, collections
+
+
+def load_multiparent_dag(trees_dir):
+    """→ (parents_of: child_id→[parent_id...], title_of: id→title). Multi-parent (the full DAG, not the collapse)."""
+    parents_of = collections.defaultdict(list); title_of = {}
+    for f in glob.glob(os.path.join(trees_dir, "*.json")):
+        try:
+            d = json.load(open(f, encoding="utf-8"))
+        except Exception:
+            continue
+        t = d.get("api_response", {}).get("tree", {}) if isinstance(d, dict) else {}
+        if not isinstance(t, dict):
+            continue
+        pid = t.get("id")
+        if pid is None:
+            continue
+        pid = str(pid)
+        if t.get("title"):
+            title_of[pid] = t["title"]
+        for p in (t.get("pearls") or []):
+            if not isinstance(p, dict):
+                continue
+            ct = p.get("contentTree")
+            cid = ct.get("id") if isinstance(ct, dict) else None
+            if cid and str(cid) != pid:
+                cid = str(cid)
+                if pid not in parents_of[cid]:
+                    parents_of[cid].append(pid)
+                if isinstance(ct, dict) and ct.get("title"):
+                    title_of.setdefault(cid, ct["title"])
+    return parents_of, title_of
+
+
+def merged_ancestor_list(node, parents_of, title_of, max_depth=15, scope=None):
+    """Merged ancestor list for `node`: unique ancestors (ID-keyed) reached by walking up ALL parents.
+    Cycle-detected (visited), max-depth bounded. Returns [(id, title, min_hop)] ordered root-ward first.
+    `scope` (a set of allowed ids) restricts the walk to a subtree if given."""
+    node = str(node)
+    min_hop = {}                                                   # ancestor id -> min hops from `node`
+    # BFS upward over the multi-parent DAG (visited = cycle detection; depth = max_depth bound)
+    frontier = [(node, 0)]; seen = {node}
+    while frontier:
+        cur, h = frontier.pop()
+        if h >= max_depth:
+            continue
+        for par in parents_of.get(cur, []):
+            if scope is not None and par not in scope:
+                continue                                           # subtree scoping: don't leave the allowed set
+            if par == cur:
+                continue
+            if par not in min_hop or h + 1 < min_hop[par]:
+                min_hop[par] = h + 1
+            if par not in seen:                                    # cycle detection
+                seen.add(par); frontier.append((par, h + 1))
+    # merged (ID-keyed → each ancestor once), ordered root-ward first (largest hop = closest to root)
+    anc = sorted(min_hop.items(), key=lambda kv: -kv[1])
+    return [(aid, title_of.get(aid, aid), hop) for aid, hop in anc]
+
+
+def render_merged_list(node, parents_of, title_of, max_depth=15, scope=None):
+    """Text passage for e5: titles only, root-ward first, node title last. NO id line (merged/branching → no linear
+    id anchor); ids stay internal merge keys. Depth shown by indent (informational; the model gets depth via PEs)."""
+    anc = merged_ancestor_list(node, parents_of, title_of, max_depth, scope)
+    lines = [f"{'  ' * (len(anc) - i)}- {title}" for i, (_, title, _) in enumerate(anc)]
+    lines.append(f"{'  ' * 0}- {title_of.get(str(node), str(node))}")   # the node itself, deepest
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":                                        # demo on a known multi-parent node
+    import sys
+    td = sys.argv[1] if len(sys.argv) > 1 else "../../.local/data/pearltrees_api/trees"
+    parents_of, title_of = load_multiparent_dag(td)
+    mp = [(c, ps) for c, ps in parents_of.items() if len(ps) > 1]
+    print(f"[DAG] {len(parents_of)} nodes with parents, {len(mp)} multi-parent")
+    for cid, ps in mp[:3]:
+        print(f"\n=== '{title_of.get(cid, cid)}' (id {cid}) — {len(ps)} parents: {[title_of.get(p, p) for p in ps]} ===")
+        print("  single-path LINEAGE would pick ONE of those. Merged PATH list:")
+        print(render_merged_list(cid, parents_of, title_of))

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -74,6 +74,9 @@ def main():
     ap.add_argument("--eval-only", action="store_true", help="load --save model and eval only (no training)")
     ap.add_argument("--merged", action="store_true", help="PATH: passage = MERGED multi-parent ancestor list (vs single-path)")
     ap.add_argument("--max-depth", type=int, default=15, help="merged-ancestor walk depth cap (cycle-detected)")
+    ap.add_argument("--dag", default=None, help="PATH: assembled child<TAB>parent DAG TSV (RDF+API union); overrides --trees for the merged walk")
+    ap.add_argument("--titles", default=None, help="id<TAB>title map for --dag nodes")
+    ap.add_argument("--max-ancestors", type=int, default=None, help="cap merged list to nearest-N ancestors (dense DAGs)")
     a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
     if a.train_seed is None: a.train_seed = a.seed
 
@@ -88,11 +91,16 @@ def main():
             path_of[str(r["tree_id"])] = r["target_text"]
             pids_of[str(r["tree_id"])] = [str(x) for x in (r.get("path_ids") or [])]
     if a.merged:                                                    # PATH: passage = MERGED multi-parent ancestor list
-        from merged_ancestors import load_multiparent_dag, render_merged_list
-        parents_of, title_of = load_multiparent_dag(a.trees)        # the full DAG (multi-parent), not the collapse
+        from merged_ancestors import render_merged_list
+        if a.dag:                                                   # assembled RDF+API DAG (recovers truncated parents)
+            from merged_ancestors import load_assembled_dag
+            parents_of, title_of = load_assembled_dag(a.dag, a.titles)
+        else:                                                       # API-trees-only DAG (sparse: RDF-export truncation)
+            from merged_ancestors import load_multiparent_dag
+            parents_of, title_of = load_multiparent_dag(a.trees)
         nmp = sum(1 for f in path_of if len(parents_of.get(f, [])) > 1)
         for f in list(path_of):                                     # override the single-path passage with the merged list
-            path_of[f] = render_merged_list(f, parents_of, title_of, max_depth=a.max_depth)
+            path_of[f] = render_merged_list(f, parents_of, title_of, max_depth=a.max_depth, max_ancestors=a.max_ancestors)
         print(f"[PATH] merged multi-parent passage; {nmp}/{len(path_of)} folders are multi-parent (pids_of stays single-path for eval ground-truth)")
     queries = [(b, str(f)) for b, f in queries if str(f) in path_of]   # keep bookmarks whose folder has a path
     cand = {str(f): t for f, t in cand.items() if str(f) in path_of}   # normalise folder ids to str (match path_of)

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -77,6 +77,7 @@ def main():
     ap.add_argument("--dag", default=None, help="PATH: assembled child<TAB>parent DAG TSV (RDF+API union); overrides --trees for the merged walk")
     ap.add_argument("--titles", default=None, help="id<TAB>title map for --dag nodes")
     ap.add_argument("--max-ancestors", type=int, default=None, help="cap merged list to nearest-N ancestors (dense DAGs)")
+    ap.add_argument("--mp-eval-dag", default=None, help="also print a MULTI-PARENT-SUBSET eval table (queries whose folder has >1 parent in this assembled DAG — where PATH can differ)")
     a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
     if a.train_seed is None: a.train_seed = a.seed
 
@@ -228,6 +229,18 @@ def main():
         print(f"  {'':13}{nm:18} {m['recall@1']:9.3f} {m['MRR']:7.3f} {ov_all:8.3f} {ov_m:8.3f} {depth_m:10.2f}")
     print("  (target: a combiner with elem's recall@1 AND lineage's ov|miss/depth|miss. gate = lean elem where its")
     print("   margin is sharp, else lineage. Does adding stale wiki/sym dilute vs max(elem,lin)?)")
+
+    if a.mp_eval_dag:                                              # MULTI-PARENT SUBSET: where PATH can actually differ
+        from merged_ancestors import load_assembled_dag
+        mp_par, _ = load_assembled_dag(a.mp_eval_dag, None)
+        mp_set = set(r for r in range(len(ev_idx)) if len(mp_par.get(str(bm_folder[ev_idx[r]]), [])) > 1)
+        mp_idx = sorted(mp_set); mp_miss = [r for r in elem_miss if r in mp_set]
+        print(f"\n  [MULTI-PARENT SUBSET n={len(mp_idx)} of {len(ev_idx)} | seed {a.seed}]  (folder has >1 parent in "
+              f"assembled DAG — where PATH differs from single-path)  [hard n={len(mp_miss)}]")
+        for nm, M in combos:
+            S = M.tolist(); rk = ranks(S); m = metrics([rk[r] for r in mp_idx])
+            ov_all, _ = path_overlap(S, mp_idx); ov_m, depth_m = path_overlap(S, mp_miss)
+            print(f"  {'':13}{nm:18} {m['recall@1']:9.3f} {m['MRR']:7.3f} {ov_all:8.3f} {ov_m:8.3f} {depth_m:10.2f}")
 
     if a.save:
         torch.save({"state": model.state_dict(), "cfg": cfg, "ops_extra": ["LINEAGE"]}, a.save)

--- a/prototypes/mu_cosine/train_lineage.py
+++ b/prototypes/mu_cosine/train_lineage.py
@@ -72,6 +72,8 @@ def main():
     ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     ap.add_argument("--cache", default="/tmp/lineage_e5.pt")
     ap.add_argument("--eval-only", action="store_true", help="load --save model and eval only (no training)")
+    ap.add_argument("--merged", action="store_true", help="PATH: passage = MERGED multi-parent ancestor list (vs single-path)")
+    ap.add_argument("--max-depth", type=int, default=15, help="merged-ancestor walk depth cap (cycle-detected)")
     a = ap.parse_args(); dev = torch.device(a.device); rng = random.Random(a.seed)
     if a.train_seed is None: a.train_seed = a.seed
 
@@ -85,6 +87,13 @@ def main():
         if r.get("tree_id") and r.get("target_text"):
             path_of[str(r["tree_id"])] = r["target_text"]
             pids_of[str(r["tree_id"])] = [str(x) for x in (r.get("path_ids") or [])]
+    if a.merged:                                                    # PATH: passage = MERGED multi-parent ancestor list
+        from merged_ancestors import load_multiparent_dag, render_merged_list
+        parents_of, title_of = load_multiparent_dag(a.trees)        # the full DAG (multi-parent), not the collapse
+        nmp = sum(1 for f in path_of if len(parents_of.get(f, [])) > 1)
+        for f in list(path_of):                                     # override the single-path passage with the merged list
+            path_of[f] = render_merged_list(f, parents_of, title_of, max_depth=a.max_depth)
+        print(f"[PATH] merged multi-parent passage; {nmp}/{len(path_of)} folders are multi-parent (pids_of stays single-path for eval ground-truth)")
     queries = [(b, str(f)) for b, f in queries if str(f) in path_of]   # keep bookmarks whose folder has a path
     cand = {str(f): t for f, t in cand.items() if str(f) in path_of}   # normalise folder ids to str (match path_of)
     print(f"[DATA] {len(cand)} folders w/ paths, {len(queries)} bookmarks (of harvested set)")


### PR DESCRIPTION
## Summary

Investigates a **multi-path ancestor operator** (PATH) — scoring a node against the *merged* set of its ancestor chains over the DAG, vs the single-path LINEAGE that collapses a multi-parent node to one arbitrary chain. Builds the machinery, tests it rigorously, and lands an **empirically-backed decision** rather than a fragile result.

**Verdict:** multipath does **not** beat single-path on Pearltrees (3-seed CI). Corpus-driven operator choice instead:
- **Pearltrees → single-path `LINEAGE`** — it has a *principal* parent (RefPearl "inside" precedence = the real human filing decision); multipath adds no measurable benefit and is cheaper.
- **Wikipedia → multipath `PATH`** — categories have *no* principal parent (every link equal), so multipath is the only meaningful ancestor representation. NB: "what Wikipedia affords," **not** proven-superior — a proper Wikipedia branch-recovery eval is still open.

## How we got there (the multi-seed rule earned its keep)

1. Built the merged-ancestor-list builder (`merged_ancestors.py`) — multi-parent DAG walk, **cycle detection**, max-depth bound, **ID-keyed merge**, no embedded id line (ids stay internal merge keys).
2. Pearltrees API-only looked too sparse (20 multi-parent folders) → pivoted to Wikipedia → found the **dense-DAG explosion** (the merged *closure* reaches all of science/humanities) → fix: **shallow local context** (`max_depth 2` + nearest-N cap), recorded in the design doc.
3. **RDF-export truncation bug diagnosed** (~24 MB / 5004-tree silent server-side cap) — this, not reality, was why the harvest looked 93% incomplete. The **assembled RDF+API DAG recovers 396/880 multi-parent Pearltrees folders** (vs 20).
4. LINEAGE-vs-PATH on the assembled DAG: seed 7 looked like a clear branch-recovery win (`depth|miss` +0.23)...
5. ...but the **3-seed CI** showed it was within noise (seed 42 reverses), and the **multi-parent-subset** test (where the passage actually differs) came back **negative** (`ov|miss` mean −0.027, `depth|miss` mean −0.123). The apparent win was training-side variance.

## Changes

- `merged_ancestors.py` (new) — multi-parent DAG builders (`load_multiparent_dag`, `load_category_graph`, `load_assembled_dag`), `merged_ancestor_list`/`render_merged_list` (shallow, capped, scoped), `subtree_scope`.
- `train_lineage.py` — `--merged` (merged-multipath passage), `--dag`/`--titles` (assembled DAG), `--max-depth`/`--max-ancestors`, `--mp-eval-dag` (multi-parent-subset eval table).
- `eval_path_wiki.py` (new) — Wikipedia find-my-container passage-variant eval (title/single-path/merged). **Note:** mis-framed (ancestor-context on the candidate dilutes) — kept for the record; a corrected Wikipedia branch-recovery eval is future work.
- `DESIGN_path_operator.md` — empirical conclusion at top; dense-DAG shallow-depth finding; review clarifications.

## What's reusable regardless of the verdict

- The **RDF-export-bug diagnosis** + assembled-DAG tooling (independent value — recovers most of the "missing" Pearltrees data).
- The multipath machinery (correct; the right tool for the multi-parent Wikipedia DAG).
- A clean, multi-seed-rigorous methodology (full-eval + subset CI) that caught a false single-seed win before anything was built on it.

## Not included / follow-ups

- Proper Wikipedia branch-recovery eval (the one open question).
- Pearltrees data completion (chunked RDF re-export + targeted API backfill).
- K-sample-per-node stochastic sampling (only if a future multipath use warrants it).

## Testing

- `merged_ancestors.py` demos on Pearltrees + Wikipedia graphs; all files parse; `test_op_weights` passes.
- Model/data artifacts remain gitignored; no committed data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)