### PR TITLE
plawk: native END for-in associative iteration

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -338,6 +338,14 @@ needed per record for those count updates.
 Guarded associative-count rules now reuse the same native guard emitters and
 rule-chain structure as scalar counters, so the loop can run field/prefix checks
 and table increments without per-record WAM dispatch for the supported surface.
+`END` supports the canonical for-in report idiom,
+`END { for (k in counts) print k, counts[k] }`: the WAM/LLVM assoc runtime
+gained `wam_assoc_i64_iter_next`/`wam_assoc_i64_key_at`/`wam_assoc_i64_value_at`
+slot-walking helpers, and PLAWK lowers the loop to a native table walk that
+resolves key text through `wam_atom_to_string`, reads same-array values
+directly from the visited slot, and looks up other arrays (and string
+literals) per key with awk's missing-key-prints-0 behaviour. Iteration order
+is hash-slot order, unspecified as in awk.
 Mixed scalar/associative programs use a combined native state plan: scalar
 counters remain `i64` phi slots, assoc arrays remain runtime table pointers, and
 `END` printing can interleave scalar variables with associative lookups.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -72,6 +72,7 @@ swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW
 swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_forin_end_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -152,6 +153,14 @@ not `printf` formats. Mixed scalar/associative state is
 supported in the same native loop, e.g. `{ total++; counts[$1]++ }` with an
 `END` print of both `total` and `counts["ERROR"]`. `END` print fields can also
 include literal labels such as `print "total", total, "errors", counts["ERROR"]`.
+`END` can also iterate an associative array with the canonical awk report
+idiom, e.g. `{ counts[$1]++ } END { for (k in counts) print k, counts[k] }`.
+The loop lowers to a native walk over the runtime table's occupied slots via
+`wam_assoc_i64_iter_next`, maps each key id back to its text with
+`wam_atom_to_string`, and prints the loop key, same-array values (direct slot
+reads), other-array lookups such as `errs[k]` (hash lookups, `0` for missing
+keys), and string literal labels. Iteration order follows the hash table's
+slot order and, as in awk, is unspecified.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -220,6 +220,161 @@ plawk_program_native_driver_ir(
             RecordIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules, [end([for_in(var(LoopVar), var(ArrayName), BodyActions)])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions, AssocPlan, PrintFields),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_field_separator(BeginClauses, FieldSeparator),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_forin_end_print_ir(LoopVar, ArrayName, PrintFields, AssocPlan,
+        OutputSeparator, EndPrintIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, AssocRuleGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w',
+        [EndPrintIR]),
+    llvm_emit_stream_driver_ir(InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
+            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
+%% plawk_forin_end_plan(+Rules, +LoopVar, +ArrayName, +BodyActions, -AssocPlan, -PrintFields)
+%
+%  Plan the first END for-in surface: rules are associative-count updates and
+%  the loop body is one print whose fields are the loop key, associative
+%  lookups keyed by the loop variable, or string literals.
+plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions,
+        assoc_plan(Tables, PlannedRules), PrintFields) :-
+    BodyActions = [print(PrintFields)],
+    PrintFields = [_ | _],
+    maplist(plawk_forin_print_field(LoopVar), PrintFields),
+    maplist(plawk_assoc_rule_action_specs, Rules, RuleSpecs),
+    RuleSpecs \== [],
+    findall(RuleArrayName,
+        ( member(rule(_Pattern, ActionSpecs, _Control), RuleSpecs),
+          member(RuleArrayName-_KeyIndex, ActionSpecs)
+        ),
+        ActionArrays),
+    findall(LookupArrayName,
+        member(assoc(var(LookupArrayName), var(LoopVar)), PrintFields),
+        LookupArrays),
+    append([ActionArrays, [ArrayName], LookupArrays], ArrayNames0),
+    sort(ArrayNames0, Tables),
+    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, 0), PlannedRules).
+
+plawk_forin_print_field(LoopVar, var(LoopVar)).
+plawk_forin_print_field(LoopVar, assoc(var(_ArrayName), var(LoopVar))).
+plawk_forin_print_field(_LoopVar, string(_Value)).
+
+%% plawk_forin_end_print_ir(+LoopVar, +ArrayName, +PrintFields, +AssocPlan,
+%%     +OutputSeparator, -IR)
+%
+%  Emit the native END for-in loop: walk the iterated table's occupied slots
+%  through @wam_assoc_i64_iter_next, print each record's fields, then free
+%  every table and return.
+plawk_forin_end_print_ir(LoopVar, ArrayName, PrintFields, AssocPlan,
+        OutputSeparator, IR) :-
+    plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
+    phrase(plawk_forin_body_print_lines(PrintFields, LoopVar, ArrayName,
+        TableIndex, AssocPlan, OutputSeparator, 0), BodyLines),
+    atomic_list_concat(BodyLines, '\n', BodyIR),
+    phrase(plawk_assoc_free_lines(AssocPlan), FreeLines),
+    atomic_list_concat(FreeLines, '\n', FreeIR),
+    format(atom(IR),
+'  br label %forin_head
+
+forin_head:
+  %forin_idx = phi i64 [0, %end_print], [%forin_next_idx, %forin_body_done]
+  %forin_slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_idx)
+  %forin_done = icmp slt i64 %forin_slot, 0
+  br i1 %forin_done, label %forin_after, label %forin_body
+
+forin_body:
+  %forin_key_id = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)
+~w
+  %forin_printed_newline = call i32 @putchar(i32 10)
+  br label %forin_body_done
+
+forin_body_done:
+  %forin_next_idx = add i64 %forin_slot, 1
+  br label %forin_head
+
+forin_after:
+~w
+  ret i32 0',
+        [TableIndex, TableIndex, BodyIR, FreeIR]).
+
+plawk_forin_body_print_lines([], _LoopVar, _ArrayName, _TableIndex, _AssocPlan,
+        _OutputSeparator, _) -->
+    [].
+plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
+        TableIndex, AssocPlan, OutputSeparator, PrintIndex) -->
+    plawk_forin_separator_lines(PrintIndex, OutputSeparator),
+    { format(atom(KeyString),
+          '  %forin_key_s_~w = call i8* @wam_atom_to_string(i64 %forin_key_id)',
+          [PrintIndex]),
+      format(atom(FmtVar), 'forin_key_fmt_~w', [PrintIndex]),
+      format(atom(PrintVar), 'forin_printed_key_~w', [PrintIndex]),
+      format(atom(PtrIR), '%forin_key_s_~w', [PrintIndex]),
+      llvm_emit_printf_string(plawk_surface_print_string, FmtVar, PrintVar, PtrIR,
+          [FmtPtr, PrintCall]),
+      NextPrintIndex is PrintIndex + 1
+    },
+    [KeyString, FmtPtr, PrintCall],
+    plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
+        OutputSeparator, NextPrintIndex).
+plawk_forin_body_print_lines([assoc(var(LookupArrayName), var(LoopVar)) | Rest],
+        LoopVar, ArrayName, TableIndex, AssocPlan, OutputSeparator, PrintIndex) -->
+    plawk_forin_separator_lines(PrintIndex, OutputSeparator),
+    { (   LookupArrayName == ArrayName
+      ->  format(atom(Value),
+              '  %forin_value_~w = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)',
+              [PrintIndex, TableIndex])
+      ;   plawk_assoc_table_index(AssocPlan, LookupArrayName, LookupTableIndex),
+          format(atom(Value),
+              '  %forin_value_~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_key_id)',
+              [PrintIndex, LookupTableIndex])
+      ),
+      format(atom(FmtVar), 'forin_i64_fmt_~w', [PrintIndex]),
+      format(atom(PrintVar), 'forin_printed_i64_~w', [PrintIndex]),
+      format(atom(ValueIR), '%forin_value_~w', [PrintIndex]),
+      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
+          [FmtPtr, PrintCall]),
+      NextPrintIndex is PrintIndex + 1
+    },
+    [Value, FmtPtr, PrintCall],
+    plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
+        OutputSeparator, NextPrintIndex).
+plawk_forin_body_print_lines([string(Value) | Rest], LoopVar, ArrayName,
+        TableIndex, AssocPlan, OutputSeparator, PrintIndex) -->
+    plawk_forin_separator_lines(PrintIndex, OutputSeparator),
+    plawk_end_string_print_lines(Value, PrintIndex),
+    { NextPrintIndex is PrintIndex + 1 },
+    plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
+        OutputSeparator, NextPrintIndex).
+
+plawk_forin_separator_lines(0, _OutputSeparator) -->
+    !,
+    [].
+plawk_forin_separator_lines(PrintIndex, OutputSeparator) -->
+    { format(atom(SpaceCall),
+          '  %forin_printed_separator_~w = call i32 @putchar(i32 ~w)',
+          [PrintIndex, OutputSeparator])
+    },
+    [SpaceCall].
+
 plawk_combine_entry_ir('', IR, IR) :-
     !.
 plawk_combine_entry_ir(IR, '', IR) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -298,18 +298,46 @@ begin_assignment_name('FS') -->
 begin_assignment_name('OFS') -->
     "OFS".
 
-end_clauses([end([PrintAction])]) -->
+end_clauses([end([Action])]) -->
     "END",
     ws,
     "{",
     ws,
-    print_action(PrintAction),
+    end_action(Action),
     ws,
     "}",
     ws,
     !.
 end_clauses([]) -->
     [].
+
+end_action(Action) -->
+    for_in_action(Action),
+    !.
+end_action(Action) -->
+    print_action(Action).
+
+for_in_action(for_in(var(LoopVar), var(ArrayName), Body)) -->
+    "for",
+    ws,
+    "(",
+    ws,
+    identifier(LoopVar),
+    ws,
+    "in",
+    identifier_boundary,
+    ws,
+    identifier(ArrayName),
+    ws,
+    ")",
+    ws,
+    for_in_body(Body).
+
+for_in_body(Actions) -->
+    action_block(Actions),
+    !.
+for_in_body([PrintAction]) -->
+    print_action(PrintAction).
 
 actions([Action | Actions]) -->
     action(Action),

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4295,6 +4295,95 @@ done:
   ret void
 }
 
+define i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %table, i64 %start) {
+entry:
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %iter.miss, label %iter.load
+
+iter.load:
+  %cap_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 1
+  %cap = load i64, i64* %cap_slot
+  %entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  %entries = load %WamAssocI64Entry*, %WamAssocI64Entry** %entries_slot
+  %entries_null = icmp eq %WamAssocI64Entry* %entries, null
+  br i1 %entries_null, label %iter.miss, label %iter.loop
+
+iter.loop:
+  %idx = phi i64 [ %start, %iter.load ], [ %next_idx, %iter.next ]
+  %past_end = icmp uge i64 %idx, %cap
+  br i1 %past_end, label %iter.miss, label %iter.check
+
+iter.check:
+  %assoc_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %idx
+  %occupied_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 2
+  %occupied = load i1, i1* %occupied_slot
+  br i1 %occupied, label %iter.hit, label %iter.next
+
+iter.hit:
+  ret i64 %idx
+
+iter.next:
+  %next_idx = add i64 %idx, 1
+  br label %iter.loop
+
+iter.miss:
+  ret i64 -1
+}
+
+define i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %table, i64 %idx) {
+entry:
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %kat.miss, label %kat.load
+
+kat.load:
+  %cap_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 1
+  %cap = load i64, i64* %cap_slot
+  %past_end = icmp uge i64 %idx, %cap
+  br i1 %past_end, label %kat.miss, label %kat.entries
+
+kat.entries:
+  %entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  %entries = load %WamAssocI64Entry*, %WamAssocI64Entry** %entries_slot
+  %entries_null = icmp eq %WamAssocI64Entry* %entries, null
+  br i1 %entries_null, label %kat.miss, label %kat.read
+
+kat.read:
+  %assoc_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %idx
+  %key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 0
+  %key = load i64, i64* %key_slot
+  ret i64 %key
+
+kat.miss:
+  ret i64 0
+}
+
+define i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %table, i64 %idx) {
+entry:
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %vat.miss, label %vat.load
+
+vat.load:
+  %cap_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 1
+  %cap = load i64, i64* %cap_slot
+  %past_end = icmp uge i64 %idx, %cap
+  br i1 %past_end, label %vat.miss, label %vat.entries
+
+vat.entries:
+  %entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  %entries = load %WamAssocI64Entry*, %WamAssocI64Entry** %entries_slot
+  %entries_null = icmp eq %WamAssocI64Entry* %entries, null
+  br i1 %entries_null, label %vat.miss, label %vat.read
+
+vat.read:
+  %assoc_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %idx
+  %value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 1
+  %value = load i64, i64* %value_slot
+  ret i64 %value
+
+vat.miss:
+  ret i64 0
+}
+
 define %Value @wam_stream_fail_value() alwaysinline nounwind {
 entry:
   %bad = call %Value @value_integer(i64 -1)

--- a/tests/test_plawk_surface_forin_end_print.pl
+++ b/tests/test_plawk_surface_forin_end_print.pl
@@ -1,0 +1,155 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_forin_marker/0.
+
+user:plawk_forin_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_forin_end_print, [condition(clang_available)]).
+
+test(parses_forin_end_print_rule) :-
+    plawk_parse_string("{ counts[$1]++ } END { for (k in counts) print k, counts[k] }\n", Program),
+    assertion(Program == program([], [rule(always, [inc_assoc(var(counts), field(1))])],
+        [end([for_in(var(k), var(counts),
+            [print([var(k), assoc(var(counts), var(k))])])])])).
+
+test(parses_forin_end_print_braced_body) :-
+    plawk_parse_string("{ counts[$1]++ } END { for (k in counts) { print k, counts[k] } }\n", Program),
+    assertion(Program == program([], [rule(always, [inc_assoc(var(counts), field(1))])],
+        [end([for_in(var(k), var(counts),
+            [print([var(k), assoc(var(counts), var(k))])])])])).
+
+test(parses_forin_end_print_string_and_other_array) :-
+    plawk_parse_string("{ counts[$1]++ } $1 == \"ERROR\" { errs[$1]++ } END { for (k in counts) print \"key\", k, counts[k], errs[k] }\n", Program),
+    assertion(Program == program([],
+        [rule(always, [inc_assoc(var(counts), field(1))]),
+         rule(field_eq(1, "ERROR"), [inc_assoc(var(errs), field(1))])],
+        [end([for_in(var(k), var(counts),
+            [print([string("key"), var(k),
+                    assoc(var(counts), var(k)),
+                    assoc(var(errs), var(k))])])])])).
+
+test(parses_forin_without_keyword_space) :-
+    plawk_parse_string("{ counts[$1]++ } END { for(k in counts) print k }\n", Program),
+    assertion(Program == program([], [rule(always, [inc_assoc(var(counts), field(1))])],
+        [end([for_in(var(k), var(counts), [print([var(k)])])])])).
+
+test(forin_ir_walks_table_with_iter_next) :-
+    plawk_parse_string("{ counts[$1]++ } END { for (k in counts) print k, counts[k] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_0, i64 %forin_idx)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_key_at(%WamAssocI64Table* %plawk_assoc_table_0, i64 %forin_slot)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_0, i64 %forin_slot)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%forin_key_s_0 = call i8* @wam_atom_to_string(i64 %forin_key_id)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(forin_ir_other_array_lookup_uses_get) :-
+    plawk_parse_string("{ counts[$1]++ } $1 == \"ERROR\" { errs[$1]++ } END { for (k in counts) print k, counts[k], errs[k] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    % Tables are sorted by array name: counts is table 0, errs is table 1.
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_0, i64 %forin_slot)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_1, i64 %forin_key_id)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_forin_prints_counts_by_key) :-
+    run_forin_print_smoke("{ counts[$1]++ } END { for (k in counts) print k, counts[k] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        ["ERROR 2", "INFO 1", "WARN 1"]).
+
+test(surface_forin_prints_guarded_counts_by_key) :-
+    run_forin_print_smoke("$1 == \"ERROR\" { by_component[$2]++ } END { for (k in by_component) print k, by_component[k] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\nERROR disk warm\n",
+        ["disk 2", "net 1"]).
+
+test(surface_forin_prints_other_array_lookup_with_missing_default) :-
+    run_forin_print_smoke("{ counts[$1]++ } $1 == \"ERROR\" { errs[$1]++ } END { for (k in counts) print k, counts[k], errs[k] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        ["ERROR 2 2", "INFO 1 0", "WARN 1 0"]).
+
+test(surface_forin_prints_string_literal_labels) :-
+    run_forin_print_smoke("{ counts[$1]++ } END { for (k in counts) print \"key\", k, counts[k] }\n",
+        "INFO boot ok\nERROR disk full\nERROR net down\n",
+        ["key ERROR 2", "key INFO 1"]).
+
+test(surface_forin_uses_output_separator) :-
+    run_forin_print_smoke("BEGIN { OFS = \",\" } { counts[$1]++ } END { for (k in counts) print k, counts[k] }\n",
+        "INFO boot ok\nERROR disk full\nERROR net down\n",
+        ["ERROR,2", "INFO,1"]).
+
+test(surface_forin_uses_field_separator_for_keys) :-
+    run_forin_print_smoke("BEGIN { FS = \":\" } { counts[$2]++ } END { for (k in counts) print k, counts[k] }\n",
+        "a:disk:1\nb:net:2\nc:disk:3\n",
+        ["disk 2", "net 1"]).
+
+test(surface_forin_braced_body_prints_counts) :-
+    run_forin_print_smoke("{ counts[$1]++ } END { for (k in counts) { print k, counts[k] } }\n",
+        "INFO boot ok\nERROR disk full\nERROR net down\n",
+        ["ERROR 2", "INFO 1"]).
+
+test(surface_forin_empty_input_prints_nothing) :-
+    run_forin_print_smoke("{ counts[$1]++ } END { for (k in counts) print k, counts[k] }\n",
+        "",
+        []).
+
+% For-in iteration order follows the hash table's slot order, which awk
+% leaves unspecified. The smoke compares sorted output lines so assertions
+% stay stable across atom-id and hashing changes.
+run_forin_print_smoke(Source, Input, ExpectedSortedLines) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_forin_end_print', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_forin_end_print.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_forin_marker/0 ],
+        [module_name('plawk_surface_forin_end_print')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_forin_end_print_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> split_string(OutStr, "\n", "", Lines0),
+       exclude(==(""), Lines0, Lines),
+       msort(Lines, SortedLines),
+       maplist(atom_string, ExpectedSortedLines, ExpectedStrings0),
+       msort(ExpectedStrings0, ExpectedStrings),
+       assertion(SortedLines == ExpectedStrings)
+    ;  format(user_error, "~n[plawk surface forin end print output]~n~w~n",
+              [OutStr]),
+       throw(plawk_surface_forin_end_print_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_surface_forin_end_print).


### PR DESCRIPTION
## Summary

Adds the canonical awk report idiom to the compiled PLAWK surface:

```awk
{ counts[$1]++ } END { for (k in counts) print k, counts[k] }
```

Until now `END` could only look up **literal** keys (`counts["ERROR"]`), so associative arrays could count things but never report what they counted. This PR closes that gap with a fully native lowering — no `run_loop` dispatch anywhere.

## Changes

**Runtime (`src/unifyweaver/targets/wam_llvm_target.pl`)**
- New slot-walking helpers next to the existing `wam_assoc_i64_*` family:
  - `wam_assoc_i64_iter_next(table, start)` — index of the next occupied slot at or after `start`, `-1` when exhausted
  - `wam_assoc_i64_key_at(table, idx)` / `wam_assoc_i64_value_at(table, idx)` — bounds-checked entry reads
- Key text comes back through the existing `wam_atom_to_string`, which already covers both statically and runtime-interned atoms.

**Parser (`examples/plawk/parser/plawk_parser.pl`)**
- `END` now accepts `for (k in arr) print ...` (bare print or braced body) alongside the existing single print action.
- AST: `for_in(var(K), var(Arr), Body)`.

**Codegen (`examples/plawk/codegen/plawk_native_codegen.pl`)**
- New driver clause lowers the loop to a native walk over the iterated table's occupied slots. Body print fields support:
  - the loop key (`k`) — printed via `wam_atom_to_string`
  - same-array values (`counts[k]`) — direct read from the visited slot
  - other-array lookups (`errs[k]`) — hash lookup by key id, `0` for missing keys (awk semantics)
  - string literal labels
- `BEGIN` `FS`/`OFS` assignments and terminal `break` in rules compose with the new shape.

**Tests (`tests/test_plawk_surface_forin_end_print.pl`)**
- 14 tests: parse shapes, IR-level assertions (iter/key/value helpers used, no `@run_loop`), and end-to-end compiled binaries. E2E smokes compare **sorted** output lines since for-in iteration order is unspecified, as in awk.

## Testing

- `tests/test_plawk_surface_forin_end_print.pl` — 14/14 pass (builds and runs native binaries via clang)
- `tests/test_plawk_surface_prefix_print.pl` — full existing surface suite passes (regression check for shared codegen paths)
- `tests/test_plawk_compiled_stream_core.pl` — passes (regression check for the shared runtime template)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_