### PR TITLE
plawk: runtime input path via argv with stdin default

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -189,11 +189,17 @@ The first WAM/LLVM probes now live under `examples/plawk/probes/`.
 **Success:** a native binary that reads stdin, counts records, prints matching
 lines — identical behaviour to Phase 0, running as compiled LLVM.
 
-**Current boundary:** the compiled and native stream smokes still read from file
-paths rather than stdin. WAM/LLVM exposes general stream helpers
-(`@wam_stream_open_value`, `@wam_stream_read_line_value`, and
-`@wam_stream_close_value`) that native LLVM code can call directly, alongside
-the existing `stream_open/2`, `read_line/2`, and `stream_close/1` builtins.
+**Current boundary:** WAM/LLVM exposes general stream helpers
+(`@wam_stream_open_value`, `@wam_stream_read_line_value`,
+`@wam_stream_close_value`, and `@wam_stream_open_fd_value` for wrapping an
+already-open descriptor such as stdin) that native LLVM code can call
+directly, alongside the existing `stream_open/2`, `read_line/2`, and
+`stream_close/1` builtins. `llvm_emit_stream_driver_ir/3` accepts either a
+concrete compile-time path or the `stdin_or_argv` sentinel; the sentinel
+emits a `main(argc, argv)` that opens `argv[1]` at runtime, treats `-` as
+stdin, and defaults to stdin when no argument is given, so compiled PLAWK
+binaries work as awk-style pipeline filters
+(`tests/test_plawk_surface_stdin_input.pl`).
 The `tests/test_plawk_native_stream_loop_driver.pl` smoke proves a native LLVM
 loop can open a runtime file path, read lines until `end_of_file`, call a
 compiled PLAWK handler once per record, and thread PLAWK state through WAM.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -73,6 +73,7 @@ swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_
 swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_forin_end_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_stdin_input.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -149,7 +150,12 @@ explicit single-byte `FS` values such as `BEGIN { FS = ":" }` for native field
 equality, selected-field printing, and associative key extraction. Single-byte
 `OFS` values such as `BEGIN { OFS = "," }` drive comma-separated `print` fields;
 the native path emits separator bytes directly, so values such as `%` are data,
-not `printf` formats. Mixed scalar/associative state is
+not `printf` formats. Compiled binaries take their input the awk way: passing the
+`stdin_or_argv` sentinel instead of a compile-time path emits a
+`main(argc, argv)` that opens `argv[1]` at runtime, treats `-` as stdin, and
+defaults to stdin when no argument is given, so `./prog file.txt`,
+`./prog < file.txt`, and `cat file.txt | ./prog` all work.
+Mixed scalar/associative state is
 supported in the same native loop, e.g. `{ total++; counts[$1]++ }` with an
 `END` print of both `total` and `counts["ERROR"]`. `END` print fields can also
 include literal labels such as `print "total", total, "errors", counts["ERROR"]`.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4463,6 +4463,66 @@ soh.close_all_fail:
   br label %soh.fail
 }
 
+define %Value @wam_stream_open_fd_value(i64 %fd64) {
+entry:
+  ; Wrap an already-open file descriptor (e.g. fd 0 for stdin) in a
+  ; buffered reader handle. The fd is not opened or validated here;
+  ; wam_stream_close_value closes it like any other stream. On
+  ; allocation failure the caller keeps ownership of the fd.
+  %sfd.fd_ok = icmp sge i64 %fd64, 0
+  br i1 %sfd.fd_ok, label %sfd.alloc_reader, label %sfd.fail
+
+sfd.fail:
+  %sfd.bad = call %Value @wam_stream_fail_value()
+  ret %Value %sfd.bad
+
+sfd.alloc_reader:
+  %sfd.fd = trunc i64 %fd64 to i32
+  %sfd.reader_size = ptrtoint %WamLineReader* getelementptr (%WamLineReader, %WamLineReader* null, i32 1) to i64
+  %sfd.reader_mem = call i8* @malloc(i64 %sfd.reader_size)
+  %sfd.reader_null = icmp eq i8* %sfd.reader_mem, null
+  br i1 %sfd.reader_null, label %sfd.fail, label %sfd.alloc_buf
+
+sfd.alloc_buf:
+  %sfd.buf = call i8* @malloc(i64 4096)
+  %sfd.buf_null = icmp eq i8* %sfd.buf, null
+  br i1 %sfd.buf_null, label %sfd.free_reader_fail, label %sfd.init
+
+sfd.free_reader_fail:
+  call void @free(i8* %sfd.reader_mem)
+  br label %sfd.fail
+
+sfd.init:
+  %sfd.reader = bitcast i8* %sfd.reader_mem to %WamLineReader*
+  %sfd.fd_slot = getelementptr %WamLineReader, %WamLineReader* %sfd.reader, i32 0, i32 0
+  store i32 %sfd.fd, i32* %sfd.fd_slot
+  %sfd.buf_slot = getelementptr %WamLineReader, %WamLineReader* %sfd.reader, i32 0, i32 1
+  store i8* %sfd.buf, i8** %sfd.buf_slot
+  %sfd.cap_slot = getelementptr %WamLineReader, %WamLineReader* %sfd.reader, i32 0, i32 2
+  store i64 4096, i64* %sfd.cap_slot
+  %sfd.len_slot = getelementptr %WamLineReader, %WamLineReader* %sfd.reader, i32 0, i32 3
+  store i64 0, i64* %sfd.len_slot
+  %sfd.pos_slot = getelementptr %WamLineReader, %WamLineReader* %sfd.reader, i32 0, i32 4
+  store i64 0, i64* %sfd.pos_slot
+  %sfd.count = load i32, i32* @wam_stream_handle_count
+  %sfd.next = add i32 %sfd.count, 1
+  %sfd.cap_ok = icmp ult i32 %sfd.next, 4096
+  br i1 %sfd.cap_ok, label %sfd.store_handle, label %sfd.free_all_fail
+
+sfd.store_handle:
+  %sfd.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %sfd.next
+  store %WamLineReader* %sfd.reader, %WamLineReader** %sfd.slot
+  store i32 %sfd.next, i32* @wam_stream_handle_count
+  %sfd.handle = zext i32 %sfd.next to i64
+  %sfd.v = call %Value @value_integer(i64 %sfd.handle)
+  ret %Value %sfd.v
+
+sfd.free_all_fail:
+  call void @free(i8* %sfd.buf)
+  call void @free(i8* %sfd.reader_mem)
+  br label %sfd.fail
+}
+
 define %Value @wam_stream_read_line_value(%Value %handle_value) {
 entry:
   %rhv.t = call i32 @value_tag(%Value %handle_value)
@@ -17185,6 +17245,12 @@ llvm_emit_printf0(FmtGlobal, FmtLen, FmtVar, PrintVar, [FmtPtr, PrintCall]) :-
 %  lowerers provide runtime globals, optional entry setup, loop-carried phis,
 %  per-record lowered IR, continuation phis, optional terminal-break close IR,
 %  and the close-success block.
+%
+%  InputPath is either a concrete path (compiled into the binary as a
+%  string global) or the atom `stdin_or_argv`, which emits a
+%  main(argc, argv) that opens argv[1] at runtime, treats "-" as stdin,
+%  and defaults to stdin (fd 0) when no argument is given -- the awk
+%  pipeline-filter convention.
 llvm_emit_stream_driver_ir(
     InputPath,
     driver_blocks(RuntimeGlobals, LoopPhiIR, LoweredLabel, RecordIR,
@@ -17206,6 +17272,108 @@ llvm_emit_stream_driver_ir(
         driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
             ContinueIR, '', CloseOkLabel, CloseOkIR),
         DriverIR).
+
+llvm_emit_stream_driver_ir(
+    stdin_or_argv,
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    !,
+    format(atom(DriverIR),
+'@.wam_stream_eof = private constant [12 x i8] c"end_of_file\\00"
+@.wam_stream_stdin_dash = private constant [2 x i8] c"-\\00"
+~w
+
+define i32 @main(i32 %argc, i8** %argv) {
+entry:
+~w
+  %have_arg = icmp sgt i32 %argc, 1
+  br i1 %have_arg, label %check_argv_path, label %use_stdin
+
+check_argv_path:
+  %argv1_ptr = getelementptr i8*, i8** %argv, i64 1
+  %argv1 = load i8*, i8** %argv1_ptr
+  %dash_ptr = getelementptr [2 x i8], [2 x i8]* @.wam_stream_stdin_dash, i32 0, i32 0
+  %dash_cmp = call i32 @strcmp(i8* %argv1, i8* %dash_ptr)
+  %is_dash = icmp eq i32 %dash_cmp, 0
+  br i1 %is_dash, label %use_stdin, label %open_argv_file
+
+open_argv_file:
+  %argv1_len = call i64 @strlen(i8* %argv1)
+  %path_id = call i64 @wam_intern_atom(i8* %argv1, i64 %argv1_len)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %file_handle = call %Value @wam_stream_open_value(%Value %path)
+  br label %have_handle
+
+use_stdin:
+  %stdin_handle = call %Value @wam_stream_open_fd_value(i64 0)
+  br label %have_handle
+
+have_handle:
+  %handle = phi %Value [ %file_handle, %open_argv_file ], [ %stdin_handle, %use_stdin ]
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+~w
+  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_payload = extractvalue %Value %line, 1
+  %line_is_int = icmp eq i32 %line_tag, 1
+  %line_bad_payload = icmp slt i64 %line_payload, 0
+  %line_bad = and i1 %line_is_int, %line_bad_payload
+  br i1 %line_bad, label %fail_read, label %check_line_atom
+
+check_line_atom:
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
+
+check_eof:
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %eof_s = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof, i32 0, i32 0
+  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
+  %is_eof = icmp eq i32 %eof_cmp, 0
+  br i1 %is_eof, label %close_stream, label %~w
+
+~w:
+~w
+
+continue_loop:
+~w
+  br label %loop
+
+~w
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %~w, label %fail_close
+
+~w
+
+fail_open:
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_line_tag:
+  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 12
+
+fail_close:
+  ret i32 16
+}
+',
+        [RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel,
+         LoweredLabel, RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR]).
 
 llvm_emit_stream_driver_ir(
     InputPath,

--- a/tests/test_plawk_surface_stdin_input.pl
+++ b/tests/test_plawk_surface_stdin_input.pl
@@ -1,0 +1,178 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_stdin_marker/0.
+
+user:plawk_stdin_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_stdin_input, [condition(clang_available)]).
+
+test(stdin_driver_emits_argv_main) :-
+    plawk_parse_string("$1 == \"ERROR\" { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv, DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define i32 @main(i32 %argc, i8** %argv)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_stream_open_fd_value(i64 0)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.wam_stream_stdin_dash = private constant [2 x i8] c"-\\00"'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@.wam_stream_input_path')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(stdin_driver_keeps_check_handle_value_phi_predecessor) :-
+    % Scalar loop phis name %check_handle_value as the loop entry
+    % predecessor; the argv/stdin main must preserve that block label.
+    plawk_parse_string("$1 == \"ERROR\" { count++ } END { print count }\n", Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv, DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%slot_0 = phi i64 [0, %check_handle_value], [%next_slot_0, %continue_loop]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_stream_open_value(%Value %path)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_stream_open_fd_value(i64 0)'))),
+    !.
+
+test(concrete_path_driver_unchanged) :-
+    plawk_parse_string("$1 == \"ERROR\" { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define i32 @main() {'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.wam_stream_input_path'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_stream_open_fd_value')),
+    !.
+
+test(stdin_print_rule_reads_all_input_modes) :-
+    run_stdin_smoke("$1 == \"ERROR\" { print $0 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "ERROR disk full\nERROR net down\n").
+
+test(stdin_scalar_end_reads_all_input_modes) :-
+    run_stdin_smoke("$1 == \"ERROR\" { count++ } END { print count }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "2\n").
+
+test(stdin_assoc_end_reads_all_input_modes) :-
+    run_stdin_smoke("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "2 1\n").
+
+test(stdin_forin_end_reads_all_input_modes) :-
+    run_stdin_smoke_sorted("{ counts[$1]++ } END { for (k in counts) print k, counts[k] }\n",
+        "INFO boot ok\nERROR disk full\nERROR net down\n",
+        ["ERROR 2", "INFO 1"]).
+
+test(stdin_missing_file_exits_with_open_failure) :-
+    build_stdin_binary("$1 == \"ERROR\" { print $0 }\n", _Dir, BinPath),
+    format(atom(Cmd), '~w /nonexistent_plawk_input_file', [BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, Status),
+    assertion(Status == exit(10)),
+    !.
+
+build_stdin_binary(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_stdin_input', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_stdin_input.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_stdin_marker/0 ],
+        [module_name('plawk_surface_stdin_input')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_stdin_input_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk stdin input build output]~n~w~n", [BuildOut]),
+       throw(plawk_surface_stdin_input_build_failed(Status))
+    ).
+
+% One binary, four awk-style invocations: an argv path, stdin
+% redirection, the "-" stdin alias, and a shell pipe.
+run_stdin_smoke(Source, Input, ExpectedOutput) :-
+    build_stdin_binary(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    forall(member(Mode, [argv, redirect, dash, pipe]),
+        ( run_stdin_mode(Mode, BinPath, InputPath, OutStr),
+          ( OutStr == ExpectedOutput
+          -> true
+          ;  format(user_error,
+                 "~n[plawk stdin input ~w mode output]~nexpected: ~q~ngot: ~q~n",
+                 [Mode, ExpectedOutput, OutStr]),
+             throw(plawk_surface_stdin_input_mode_failed(Mode))
+          )
+        )),
+    !.
+
+run_stdin_smoke_sorted(Source, Input, ExpectedSortedLines) :-
+    build_stdin_binary(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    maplist(atom_string, ExpectedSortedLines, ExpectedStrings0),
+    msort(ExpectedStrings0, ExpectedStrings),
+    forall(member(Mode, [argv, redirect, dash, pipe]),
+        ( run_stdin_mode(Mode, BinPath, InputPath, OutStr),
+          split_string(OutStr, "\n", "", Lines0),
+          exclude(==(""), Lines0, Lines),
+          msort(Lines, SortedLines),
+          ( SortedLines == ExpectedStrings
+          -> true
+          ;  format(user_error,
+                 "~n[plawk stdin input ~w mode output]~nexpected: ~q~ngot: ~q~n",
+                 [Mode, ExpectedStrings, SortedLines]),
+             throw(plawk_surface_stdin_input_mode_failed(Mode))
+          )
+        )),
+    !.
+
+run_stdin_mode(Mode, BinPath, InputPath, OutStr) :-
+    stdin_mode_command(Mode, BinPath, InputPath, Cmd),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk stdin input ~w mode output]~n~w~n",
+              [Mode, OutStr]),
+       throw(plawk_surface_stdin_input_run_failed(Mode, Status))
+    ).
+
+stdin_mode_command(argv, BinPath, InputPath, Cmd) :-
+    format(atom(Cmd), '~w ~w', [BinPath, InputPath]).
+stdin_mode_command(redirect, BinPath, InputPath, Cmd) :-
+    format(atom(Cmd), '~w < ~w', [BinPath, InputPath]).
+stdin_mode_command(dash, BinPath, InputPath, Cmd) :-
+    format(atom(Cmd), '~w - < ~w', [BinPath, InputPath]).
+stdin_mode_command(pipe, BinPath, InputPath, Cmd) :-
+    format(atom(Cmd), 'cat ~w | ~w', [InputPath, BinPath]).
+
+:- end_tests(plawk_surface_stdin_input).


### PR DESCRIPTION
## Summary

**Stacked on #3396.**

Makes compiled PLAWK binaries usable as real awk-style pipeline filters. Previously `plawk_program_native_driver_ir/3` baked the input path into the binary at compile time, so a compiled program could not read stdin or take a filename argument — the Phase 1 plan flagged this as the current boundary, and the original reader sketch reserved handle 0 ⇒ fd 0.

```sh
./prog file.txt        # argv path
./prog < file.txt      # stdin redirect
./prog - < file.txt    # awk's "-" stdin alias
cat file.txt | ./prog  # pipeline filter
```

## Changes

**Runtime (`src/unifyweaver/targets/wam_llvm_target.pl`)**
- New `wam_stream_open_fd_value(i64)` wraps an already-open file descriptor (e.g. fd 0) in a buffered `%WamLineReader` handle, reusing the existing handle table; `wam_stream_close_value` closes it like any other stream.

**Driver skeleton**
- `llvm_emit_stream_driver_ir/3` now accepts the atom `stdin_or_argv` in place of a concrete path. The sentinel emits `main(i32 %argc, i8** %argv)`: `argv[1]` opens a file at runtime, `-` means stdin, no argument defaults to stdin. Open failure keeps the existing exit code 10.
- The `%check_handle_value` block label is preserved so existing loop-carried phis (scalar slots, `NR` counter) keep their predecessor unchanged.
- Concrete compile-time paths emit exactly the previous `main()` shape — no change for existing callers.
- plawk's codegen needed no changes: all driver clauses pass `InputPath` through.

**Tests (`tests/test_plawk_surface_stdin_input.pl`)**
- 8 tests: IR assertions (argv main emitted, fd-wrap called, no baked path global; concrete-path shape unchanged) and end-to-end smokes that build one binary per program shape and run it all four ways, plus a missing-file exit-code check. Covers the print-only, scalar END, assoc END, and END for-in driver shapes.

## Testing

- `tests/test_plawk_surface_stdin_input.pl` — 8/8 pass
- `tests/test_wam_llvm_target.pl` — full 80-test suite passes (driver emitter regression check)
- `tests/test_plawk_surface_prefix_print.pl`, `tests/test_plawk_surface_forin_end_print.pl` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_