### PR TITLE
plawk: general native i64 arithmetic with precedence

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -272,10 +272,15 @@ the allocation-free `@wam_atom_field_subslice_value` helper, and native
 `index($N, "literal")` through the shared `@wam_atom_field_index_value` helper.
 Explicit print-side numeric coercions such as `int($N)` lower through the shared
 `@wam_atom_field_i64_value` parse helper and print zero when the field is
-missing or not a strict signed decimal. The first composed arithmetic forms add
-or subtract a non-negative integer constant from native `i64` primaries such as
-`NR`, `NF`, `length($N)`, `int($N)`, and `index($N, "literal")`; each lowers
-through the shared primary emitter followed by a shared binary `i64` operation.
+missing or not a strict signed decimal. Arithmetic expressions support general
+`+`, `-`, `*`, `/`, and `%` with awk precedence and parentheses over `i64`
+operands: integer literals, `NR`, `NF`, `length($N)`, `int($N)`,
+`index($N, "literal")`, and bare numeric fields (`$3 + $4` coerces like
+`int/1`; a bare `$N` alone still prints as a slice). Each binary node lowers
+recursively through the shared `plawk_i64_expr_ir` emitter with `_lhs`/`_rhs`
+name suffixes; `/` and `%` emit branch-free guards so a zero divisor yields
+`0` and `INT64_MIN / -1` wraps instead of trapping. Scalar `+=`/`=` updates
+and `printf` arguments accept the same expression grammar.
 Print-only `tolower($N)` and `toupper($N)` lower through shared
 `@wam_print_ascii_lower_slice` and `@wam_print_ascii_upper_slice` helpers, so
 case mapping streams bytes without allocating a transformed atom.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -74,6 +74,7 @@ swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "se
 swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_forin_end_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_stdin_input.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_arith_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -88,10 +89,15 @@ as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
 case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0) }`.
 Explicit numeric field coercion is available as `int($N)`, e.g.
 `$1 == "ERROR" { print $3, int($3) }`; failed numeric parses print `0`.
-The first arithmetic composition forms add or subtract a non-negative integer
-constant from native `i64` primaries such as `NR`, `NF`, `length($N)`,
-`int($N)`, and `index($N, "literal")`, e.g.
-`$1 == "ERROR" { print NR - 1, int($3) + 1, index($2, "sk") + 1 }`.
+Arithmetic expressions support general `+`, `-`, `*`, `/`, and `%` between
+native `i64` operands with awk precedence (`* / %` bind tighter than `+ -`,
+both associate left) and parentheses, e.g.
+`{ print ($2 + $3) * $4, $2 + $3 * $4 }`. Operands are integer literals,
+`NR`, `NF`, `length($N)`, `int($N)`, `index($N, "literal")`, and bare numeric
+fields such as `$3`, which coerce like `int($3)` inside arithmetic (a bare
+`$N` on its own still prints as a byte slice). Division and modulo are
+guarded: a zero divisor yields `0`, and `INT64_MIN / -1` wraps to
+`INT64_MIN` (`% -1` yields `0`) instead of trapping.
 Rule actions can also use basic `printf` forms, e.g.
 `$1 == "ERROR" { printf "%s=%s\n", $2, $3 }`. `printf` does not add `OFS` or
 an implicit newline; supported native formats are `%%`, `%s` for strings and

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1530,18 +1530,31 @@ plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(int(field(_))).
 plawk_rule_body_print_field(Expr) :-
-    plawk_i64_const_binary_expr(Expr).
+    plawk_i64_general_binary_expr(Expr).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
 plawk_rule_body_print_field(index(field(_), string(_))).
 plawk_rule_body_print_field(tolower(field(_))).
 plawk_rule_body_print_field(toupper(field(_))).
 
-plawk_i64_const_binary_expr(Expr) :-
-    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, int(Value)),
-    plawk_i64_binary_primary_expr(Left),
-    integer(Value),
-    Value >= 0.
+%% plawk_i64_general_binary_expr(+Expr) is semidet.
+%
+%  Recognize a native i64 binary expression tree whose leaves are i64
+%  primaries, integer literals, or bare numeric field coercions.
+plawk_i64_general_binary_expr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    plawk_i64_operand_expr(Left),
+    plawk_i64_operand_expr(Right).
+
+plawk_i64_operand_expr(int(Value)) :-
+    integer(Value).
+plawk_i64_operand_expr(field(FieldIndex)) :-
+    integer(FieldIndex),
+    FieldIndex >= 0.
+plawk_i64_operand_expr(Expr) :-
+    plawk_i64_binary_primary_expr(Expr).
+plawk_i64_operand_expr(Expr) :-
+    plawk_i64_general_binary_expr(Expr).
 
 plawk_i64_binary_primary_expr(special('NR')).
 plawk_i64_binary_primary_expr(special('NF')).
@@ -1553,12 +1566,6 @@ plawk_i64_binary_primary_expr(index(field(FieldIndex), string(Needle))) :-
     FieldIndex >= 0,
     string(Needle).
 
-plawk_i64_scalar_const_binary_expr(Expr) :-
-    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, int(Value)),
-    plawk_i64_scalar_binary_primary_expr(Left),
-    integer(Value),
-    Value >= 0.
-
 plawk_i64_scalar_primary_expr(special('NR')).
 plawk_i64_scalar_primary_expr(special('NF')).
 plawk_i64_scalar_primary_expr(int(field(FieldIndex))) :-
@@ -1569,14 +1576,17 @@ plawk_i64_scalar_primary_expr(index(field(FieldIndex), string(Needle))) :-
     FieldIndex >= 0,
     string(Needle).
 
-plawk_i64_scalar_binary_primary_expr(Expr) :-
-    plawk_i64_scalar_primary_expr(Expr).
-
 plawk_i64_binary_expr(add_i64(Left, Right), add, add, Left, Right).
 plawk_i64_binary_expr(sub_i64(Left, Right), sub, sub, Left, Right).
+plawk_i64_binary_expr(mul_i64(Left, Right), mul, mul, Left, Right).
+plawk_i64_binary_expr(div_i64(Left, Right), sdiv, div, Left, Right).
+plawk_i64_binary_expr(mod_i64(Left, Right), srem, mod, Left, Right).
 
 plawk_i64_binary_print_kind(add, int_add).
 plawk_i64_binary_print_kind(sub, int_sub).
+plawk_i64_binary_print_kind(mul, int_mul).
+plawk_i64_binary_print_kind(div, int_div).
+plawk_i64_binary_print_kind(mod, int_mod).
 
 plawk_scalar_update_action_name(Action, Name) :-
     plawk_scalar_action_update(Action, Name, _Operation).
@@ -1599,7 +1609,7 @@ plawk_scalar_action_update(add(var(Name), int(field(FieldIndex))), Name, add(fie
 plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
     plawk_i64_scalar_primary_expr(Expr).
 plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
-    plawk_i64_scalar_const_binary_expr(Expr).
+    plawk_i64_general_binary_expr(Expr).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
@@ -1612,7 +1622,7 @@ plawk_scalar_action_update(set(var(Name), int(field(FieldIndex))), Name, set(fie
 plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
     plawk_i64_scalar_primary_expr(Expr).
 plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
-    plawk_i64_scalar_const_binary_expr(Expr).
+    plawk_i64_general_binary_expr(Expr).
 
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, CurrentLabel, []) -->
@@ -1781,6 +1791,14 @@ plawk_i64_expr_ir_parts(Expr, FieldSeparator, Base, GlobalBase,
 plawk_i64_expr_ir(const(Value), _FieldSeparator, _Base, _GlobalBase, ValueIR, [], []) :-
     integer(Value),
     format(atom(ValueIR), '~w', [Value]).
+plawk_i64_expr_ir(int(Value), _FieldSeparator, _Base, _GlobalBase, ValueIR, [], []) :-
+    integer(Value),
+    format(atom(ValueIR), '~w', [Value]).
+plawk_i64_expr_ir(field(FieldIndex), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    integer(FieldIndex),
+    plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts).
 plawk_i64_expr_ir(nr, _FieldSeparator, _Base, _GlobalBase, '%current_nr', [], []).
 plawk_i64_expr_ir(nf, FieldSeparator, Base, _GlobalBase, ValueIR, [], [CountIR]) :-
     llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
@@ -1814,21 +1832,62 @@ plawk_i64_expr_ir(index(field(FieldIndex), string(Needle)), FieldSeparator, Base
         ValueIR, GlobalParts, SetupParts).
 plawk_i64_expr_ir(Expr, FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts) :-
-    plawk_i64_binary_expr(Expr, LLVMOp, _NamePart, Left, int(Value)),
-    integer(Value),
+    plawk_i64_binary_expr(Expr, LLVMOp, _NamePart, Left, Right),
     format(atom(LeftBase), '~w_lhs', [Base]),
     format(atom(LeftGlobalBase), '~w_lhs', [GlobalBase]),
     plawk_i64_expr_ir(Left, FieldSeparator, LeftBase, LeftGlobalBase,
-        LeftValueIR, GlobalParts, LeftSetupParts),
+        LeftValueIR, LeftGlobalParts, LeftSetupParts),
+    format(atom(RightBase), '~w_rhs', [Base]),
+    format(atom(RightGlobalBase), '~w_rhs', [GlobalBase]),
+    plawk_i64_expr_ir(Right, FieldSeparator, RightBase, RightGlobalBase,
+        RightValueIR, RightGlobalParts, RightSetupParts),
     format(atom(ValueIR), '%~w', [Base]),
-    format(atom(BinaryIR), '  ~w = ~w i64 ~w, ~w',
-        [ValueIR, LLVMOp, LeftValueIR, Value]),
-    append(LeftSetupParts, [BinaryIR], SetupParts).
+    plawk_i64_binary_op_lines(LLVMOp, Base, LeftValueIR, RightValueIR, OpLines),
+    append(LeftGlobalParts, RightGlobalParts, GlobalParts),
+    append([LeftSetupParts, RightSetupParts, OpLines], SetupParts).
 plawk_i64_expr_ir(index(FieldIndex, Needle), FieldSeparator, Base, GlobalBase,
         ValueIR, [GlobalIR], [CallIR]) :-
     llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
         Base, GlobalIR-CallIR),
     format(atom(ValueIR), '%~w', [Base]).
+
+%% plawk_i64_binary_op_lines(+LLVMOp, +Base, +LeftIR, +RightIR, -Lines)
+%
+%  add/sub/mul emit one instruction. sdiv/srem are guarded so awk-side
+%  division stays defined: a zero divisor yields 0, and the
+%  INT64_MIN / -1 overflow case divides by 1 instead, wrapping to
+%  INT64_MIN for `/` and 0 for `%`.
+plawk_i64_binary_op_lines(sdiv, Base, LeftIR, RightIR, Lines) :-
+    !,
+    plawk_i64_guarded_div_lines(sdiv, Base, LeftIR, RightIR, Lines).
+plawk_i64_binary_op_lines(srem, Base, LeftIR, RightIR, Lines) :-
+    !,
+    plawk_i64_guarded_div_lines(srem, Base, LeftIR, RightIR, Lines).
+plawk_i64_binary_op_lines(LLVMOp, Base, LeftIR, RightIR, [Line]) :-
+    format(atom(Line), '  %~w = ~w i64 ~w, ~w',
+        [Base, LLVMOp, LeftIR, RightIR]).
+
+plawk_i64_guarded_div_lines(LLVMOp, Base, LeftIR, RightIR, Lines) :-
+    format(atom(DenZero),
+        '  %~w_den_zero = icmp eq i64 ~w, 0', [Base, RightIR]),
+    format(atom(LhsMin),
+        '  %~w_lhs_min = icmp eq i64 ~w, -9223372036854775808', [Base, LeftIR]),
+    format(atom(RhsNegOne),
+        '  %~w_rhs_negone = icmp eq i64 ~w, -1', [Base, RightIR]),
+    format(atom(Overflow),
+        '  %~w_overflow = and i1 %~w_lhs_min, %~w_rhs_negone',
+        [Base, Base, Base]),
+    format(atom(DenBad),
+        '  %~w_den_bad = or i1 %~w_den_zero, %~w_overflow', [Base, Base, Base]),
+    format(atom(SafeDen),
+        '  %~w_safe_den = select i1 %~w_den_bad, i64 1, i64 ~w',
+        [Base, Base, RightIR]),
+    format(atom(Raw),
+        '  %~w_raw = ~w i64 ~w, %~w_safe_den', [Base, LLVMOp, LeftIR, Base]),
+    format(atom(Result),
+        '  %~w = select i1 %~w_den_zero, i64 0, i64 %~w_raw',
+        [Base, Base, Base]),
+    Lines = [DenZero, LhsMin, RhsNegOne, Overflow, DenBad, SafeDen, Raw, Result].
 
 plawk_branch_to_done_ir(none, _DoneLabel, '  br label %continue_loop') :-
     !.
@@ -2106,8 +2165,10 @@ plawk_fields_include_nr(Fields) :-
 
 plawk_expr_uses_nr(special('NR')).
 plawk_expr_uses_nr(Expr) :-
-    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, _Right),
-    plawk_expr_uses_nr(Left).
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_uses_nr(Left)
+    ; plawk_expr_uses_nr(Right)
+    ).
 
 plawk_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, ''-IR) :-
     !,
@@ -2415,6 +2476,12 @@ plawk_normal_print_expr_value_base(int_add, Index, Base) :-
     format(atom(Base), 'plawk_int_add_~w', [Index]).
 plawk_normal_print_expr_value_base(int_sub, Index, Base) :-
     format(atom(Base), 'plawk_int_sub_~w', [Index]).
+plawk_normal_print_expr_value_base(int_mul, Index, Base) :-
+    format(atom(Base), 'plawk_int_mul_~w', [Index]).
+plawk_normal_print_expr_value_base(int_div, Index, Base) :-
+    format(atom(Base), 'plawk_int_div_~w', [Index]).
+plawk_normal_print_expr_value_base(int_mod, Index, Base) :-
+    format(atom(Base), 'plawk_int_mod_~w', [Index]).
 plawk_normal_print_expr_value_base(length, Index, Base) :-
     format(atom(Base), 'plawk_length_~w', [Index]).
 plawk_normal_print_expr_value_base(substr, Index, Base) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -437,13 +437,13 @@ assignment_action(set(var(Name), Value)) -->
 scalar_value_expr(Value) -->
     scalar_delta_expr(Value).
 
+scalar_delta_expr(Expr) -->
+    i64_binary_surface_expr(Expr).
 scalar_delta_expr(int(Value)) -->
     integer_codes(ValueCodes),
     { ValueCodes \== [],
       number_codes(Value, ValueCodes),
       Value >= 0 }.
-scalar_delta_expr(Expr) -->
-    i64_const_binary_expr(Expr).
 scalar_delta_expr(special('NR')) -->
     "NR".
 scalar_delta_expr(special('NF')) -->
@@ -529,7 +529,7 @@ print_fields_rest([]) -->
     [].
 
 field_expr(Expr) -->
-    i64_const_binary_expr(Expr).
+    i64_binary_surface_expr(Expr).
 field_expr(special('NR')) -->
     "NR".
 field_expr(special('NF')) -->
@@ -631,21 +631,88 @@ int_field_expr(int(Field)) -->
     ")",
     { Field = field(_) }.
 
-i64_const_binary_expr(Expr) -->
-    i64_binary_primary_expr(Left),
-    ws,
-    i64_binary_surface_operator(Functor),
-    ws,
-    integer_codes(ValueCodes),
-    { ValueCodes \== [],
-      number_codes(Value, ValueCodes),
-      Value >= 0,
-      Expr =.. [Functor, Left, int(Value)] }.
+%% i64_binary_surface_expr(-Expr)//
+%
+%  General native i64 arithmetic with awk precedence: * / % bind tighter
+%  than + -, both levels associate left, and parentheses group. Factors
+%  are the native i64 primaries plus integer literals and bare numeric
+%  field coercions such as `$3` (zero when the field is not a strict
+%  signed decimal). The top-level result must contain at least one
+%  operator so bare primaries keep their existing print/slice meaning.
+i64_binary_surface_expr(Expr) -->
+    i64_additive_expr(Expr),
+    { i64_binary_expr_ast(Expr) }.
 
-i64_binary_surface_operator(add_i64) -->
+i64_binary_expr_ast(Expr) :-
+    compound(Expr),
+    functor(Expr, Functor, 2),
+    memberchk(Functor, [add_i64, sub_i64, mul_i64, div_i64, mod_i64]).
+
+i64_additive_expr(Expr) -->
+    i64_multiplicative_expr(First),
+    i64_additive_chain(First, Expr).
+
+i64_additive_chain(Acc, Expr) -->
+    ws,
+    i64_additive_operator(Functor),
+    ws,
+    i64_multiplicative_expr(Right),
+    !,
+    { Acc1 =.. [Functor, Acc, Right] },
+    i64_additive_chain(Acc1, Expr).
+i64_additive_chain(Expr, Expr) -->
+    [].
+
+i64_multiplicative_expr(Expr) -->
+    i64_factor_expr(First),
+    i64_multiplicative_chain(First, Expr).
+
+i64_multiplicative_chain(Acc, Expr) -->
+    ws,
+    i64_multiplicative_operator(Functor),
+    ws,
+    i64_factor_expr(Right),
+    !,
+    { Acc1 =.. [Functor, Acc, Right] },
+    i64_multiplicative_chain(Acc1, Expr).
+i64_multiplicative_chain(Expr, Expr) -->
+    [].
+
+i64_additive_operator(add_i64) -->
     "+".
-i64_binary_surface_operator(sub_i64) -->
+i64_additive_operator(sub_i64) -->
     "-".
+
+i64_multiplicative_operator(mul_i64) -->
+    "*".
+i64_multiplicative_operator(div_i64) -->
+    "/".
+i64_multiplicative_operator(mod_i64) -->
+    "%".
+
+i64_factor_expr(Expr) -->
+    "(",
+    ws,
+    i64_additive_expr(Expr),
+    ws,
+    ")",
+    !.
+i64_factor_expr(Expr) -->
+    i64_binary_primary_expr(Expr),
+    !.
+i64_factor_expr(int(Value)) -->
+    integer_codes(ValueCodes),
+    !,
+    { ValueCodes \== [],
+      number_codes(Value, ValueCodes)
+    }.
+i64_factor_expr(field(Index)) -->
+    "$",
+    integer_codes(IndexCodes),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    }.
 
 i64_binary_primary_expr(special('NR')) -->
     "NR".

--- a/tests/test_plawk_surface_arith_exprs.pl
+++ b/tests/test_plawk_surface_arith_exprs.pl
@@ -1,0 +1,185 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_arith_marker/0.
+
+user:plawk_arith_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_arith_exprs, [condition(clang_available)]).
+
+test(parses_field_plus_field) :-
+    plawk_parse_string("{ print $2 + $3 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([add_i64(field(2), field(3))])])], [])).
+
+test(parses_multiplicative_precedence) :-
+    plawk_parse_string("{ print $2 + $3 * $4 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([add_i64(field(2), mul_i64(field(3), field(4)))])])], [])).
+
+test(parses_parenthesized_grouping) :-
+    plawk_parse_string("{ print ($2 + $3) * $4 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([mul_i64(add_i64(field(2), field(3)), field(4))])])], [])).
+
+test(parses_left_associative_subtraction) :-
+    plawk_parse_string("{ print $2 - $3 - $4 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([sub_i64(sub_i64(field(2), field(3)), field(4))])])], [])).
+
+test(parses_div_and_mod) :-
+    plawk_parse_string("{ print $2 / $3, $2 % $3 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([div_i64(field(2), field(3)),
+                mod_i64(field(2), field(3))])])], [])).
+
+test(parses_mixed_primary_arithmetic) :-
+    plawk_parse_string("$1 == \"ERROR\" { print NR * 10 + NF, length($2) * 2 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([add_i64(mul_i64(special('NR'), int(10)), special('NF')),
+                mul_i64(length(field(2)), int(2))])])], [])).
+
+test(parses_scalar_binary_update) :-
+    plawk_parse_string("{ sum += $2 * $3; last = $2 + $3 } END { print sum, last }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [add(var(sum), mul_i64(field(2), field(3))),
+         set(var(last), add_i64(field(2), field(3)))])],
+        [end([print([var(sum), var(last)])])])).
+
+test(parses_printf_binary_arg) :-
+    plawk_parse_string("{ printf \"%d\\n\", $2 + $3 * 2 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [printf(string("%d\n"),
+            [add_i64(field(2), mul_i64(field(3), int(2)))])])], [])).
+
+test(bare_fields_still_parse_as_slices) :-
+    plawk_parse_string("{ print $2, $3 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([field(2), field(3)])])], [])).
+
+test(legacy_primary_minus_constant_ast_unchanged) :-
+    plawk_parse_string("$1 == \"ERROR\" { print NR - 1, length($0) - 3 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([sub_i64(special('NR'), int(1)),
+                sub_i64(length(field(0)), int(3))])])], [])).
+
+test(arith_ir_guards_division) :-
+    plawk_parse_string("{ print $2 / $3 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_den_zero = icmp eq i64'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_lhs_min = icmp eq i64'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_safe_den = select i1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_raw = sdiv i64'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(arith_ir_nested_operands_get_unique_names) :-
+    plawk_parse_string("{ print index($2, \"a\") + index($3, \"b\") }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_lhs = call i64 @wam_atom_field_index_value(%Value %line, i64 2'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_rhs = call i64 @wam_atom_field_index_value(%Value %line, i64 3'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_prints_basic_binary_ops) :-
+    run_arith_print_smoke("{ print $2 + $3, $2 - $3, $2 * $3 }\n",
+        "x 7 2\ny 10 5\n",
+        "9 5 14\n15 5 50\n").
+
+test(surface_precedence_and_parens) :-
+    run_arith_print_smoke("{ print ($2 + $3) * $4, $2 + $3 * $4 }\n",
+        "x 2 3 4\n",
+        "20 14\n").
+
+test(surface_division_and_modulo) :-
+    run_arith_print_smoke("{ print $2 / $3, $2 % $3 }\n",
+        "a 7 2\nb -7 2\n",
+        "3 1\n-3 -1\n").
+
+test(surface_division_by_zero_yields_zero) :-
+    run_arith_print_smoke("{ print $2 / $3, $2 % $3 }\n",
+        "a 7 0\n",
+        "0 0\n").
+
+test(surface_int64_min_overflow_division_is_defined) :-
+    run_arith_print_smoke("{ print $2 / $3, $2 % $3 }\n",
+        "a -9223372036854775808 -1\n",
+        "-9223372036854775808 0\n").
+
+test(surface_nonnumeric_fields_coerce_to_zero) :-
+    run_arith_print_smoke("{ print $2 + $3 }\n",
+        "a nope 5\nb 3 4\n",
+        "5\n7\n").
+
+test(surface_scalar_accumulates_binary_expr) :-
+    run_arith_print_smoke("{ sum += $2 * $3 } END { print sum }\n",
+        "a 2 3\nb 4 5\n",
+        "26\n").
+
+test(surface_guarded_rule_prints_nr_nf_arithmetic) :-
+    run_arith_print_smoke("$1 == \"ERROR\" { print NR * 10 + NF }\n",
+        "INFO a\nERROR b c\n",
+        "23\n").
+
+test(surface_printf_binary_arg) :-
+    run_arith_print_smoke("{ printf \"%d;\", $2 + $3 * 2 }\n",
+        "x 1 2\ny 3 4\n",
+        "5;11;").
+
+test(surface_constant_operands_with_nf) :-
+    run_arith_print_smoke("{ print 100 / NF, NF % 2 }\n",
+        "a b c d\nx y z\n",
+        "25 0\n33 1\n").
+
+run_arith_print_smoke(Source, Input, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_arith_exprs', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_arith_exprs.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_arith_marker/0 ],
+        [module_name('plawk_surface_arith_exprs')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_arith_exprs_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[plawk surface arith exprs output]~n~w~n",
+              [OutStr]),
+       throw(plawk_surface_arith_exprs_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_surface_arith_exprs).


### PR DESCRIPTION
## Summary

**Stacked on #3397** (which stacks on #3396).

Extends plawk's arithmetic from the previous "primary ± non-negative constant" slice to general binary expressions with awk precedence:

```awk
{ print ($2 + $3) * $4, $2 + $3 * $4 }   # parens; * binds tighter than +
{ sum += $2 * $3 } END { print sum }      # scalar updates take full exprs
{ printf "%d;", $2 + $3 * 2 }             # printf args too
{ print $2 / $3, $2 % $3 }                # guarded division / modulo
```

## Changes

**Parser (`examples/plawk/parser/plawk_parser.pl`)**
- Replaces the single-operator `i64_const_binary_expr` with a precedence grammar: `* / %` bind tighter than `+ -`, both levels associate left, parentheses group.
- Factors are the existing i64 primaries (`NR`, `NF`, `length($N)`, `int($N)`, `index($N, "lit")`) plus integer literals and **bare numeric fields** — `$3 + $4` coerces each field like `int/1` (0 on failed parse, awk-style). A bare `$N` on its own keeps its byte-slice meaning because the top-level expression must contain at least one operator.
- Legacy ASTs are unchanged: `NR - 1` still parses to `sub_i64(special('NR'), int(1))`.

**Codegen (`examples/plawk/codegen/plawk_native_codegen.pl`)**
- The binary emitter in `plawk_i64_expr_ir` now recurses on **both** operands with `_lhs`/`_rhs` name suffixes (previously the RHS had to be an integer constant); nested operands like two `index()` calls get unique SSA names and globals.
- New ops: `mul`, `sdiv`, `srem`. Division and modulo emit branch-free guards (`icmp`/`select`) so awk-side arithmetic stays defined: a zero divisor yields `0`, and `INT64_MIN / -1` wraps to `INT64_MIN` (`%` yields `0`) instead of trapping.
- One general recognizer (`plawk_i64_general_binary_expr`) replaces the two const-RHS recognizers; scalar `+=`/`=` updates and printf args accept the same grammar.
- `NR`-usage detection now scans both operands so `1 + NR` correctly threads the record counter.

**Tests (`tests/test_plawk_surface_arith_exprs.pl`)**
- 22 tests: AST shapes (precedence, associativity, parens, legacy compatibility, bare fields staying slices), IR assertions (division guards, unique nested operand names, no `@run_loop`), and e2e binaries covering `7/2`, `-7/2` (C-style truncation), `x/0 → 0`, `INT64_MIN/-1`, non-numeric coercion, scalar accumulation, and printf.

## Testing

- `tests/test_plawk_surface_arith_exprs.pl` — 22/22 pass
- `tests/test_plawk_surface_prefix_print.pl`, `test_plawk_surface_forin_end_print.pl`, `test_plawk_surface_stdin_input.pl` — all pass (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_