### PR TITLE
plawk: pattern combinators && || ! with awk precedence

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -291,6 +291,11 @@ pointer pairs.
 Numeric field guards such as `$3 > 100` lower through the shared
 `@wam_atom_field_i64_cmp_value` helper, which parses the projected field slice
 as a strict signed decimal `i64` and compares with numeric op codes.
+Patterns compose with `&&`, `||`, and `!` (awk precedence, parentheses
+group) in both rule guards and `if` conditions. The base guards are
+side-effect-free straight-line native checks, so combined guards lower to
+bitwise `i1` `and`/`or`/`xor` over per-subpattern `_l`/`_r`/`_n` suffixed
+names, keeping the whole guard a single block with no extra branches.
 The parser itself is factored as `@wam_atom_field_i64_value`, returning a value
 plus success flag, so the same machinery also feeds scalar expressions such as
 `bytes += $3` and `last = $3`; PLAWK uses zero for failed numeric coercions in

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -75,6 +75,7 @@ swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR
 swipl -q -s tests/test_plawk_surface_forin_end_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_stdin_input.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_arith_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_pattern_combinators.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -106,7 +107,12 @@ lowered allocation-free by rewriting `%s` to `%.*s` and passing the slice length
 and pointer to the native vararg call.
 Numeric field guards use the shared WAM/LLVM `i64` comparison helper, so forms
 such as `$3 > 100 { print $1, $3 }` and `$2 <= -5 { cold++ }` stay in the native
-streaming loop.
+streaming loop. Patterns compose with `&&`, `||`, and `!` using awk precedence
+(`!` over `&&` over `||`, parentheses group), e.g.
+`$1 == "ERROR" && $3 > 100 { print $0 }`, `/^ERROR/ || /^WARN/ { print $1 }`,
+and `!/disk/ { print $0 }`. Combined guards lower to straight-line bitwise
+`i1` ops over the existing native guard helpers — no extra branches — and the
+same combinators work in `if (...)` conditions.
 Scalar state works with `$1 ==
 "ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2102,6 +2102,10 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, ''-GuardCall
     plawk_field_cmp_op_code(Op, OpCode),
     llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
         FieldSeparator, '%is_match', GuardCallIR).
+plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardIR) :-
+    plawk_combined_pattern(Pattern),
+    plawk_pattern_guard_ir(Pattern, FieldSeparator, plawk_surface_pattern,
+        '%is_match', GuardIR).
 
 plawk_pattern_guard_ir(always, _GlobalBase, MatchValue, GuardIR) :-
     format(atom(GuardCallIR), '  ~w = icmp eq i1 true, true', [MatchValue]),
@@ -2134,6 +2138,49 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, _GlobalBase,
     plawk_field_cmp_op_code(Op, OpCode),
     llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
         FieldSeparator, MatchValue, GuardCallIR).
+plawk_pattern_guard_ir(and_pat(Left, Right), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
+    plawk_binary_pattern_guard_ir(and, Left, Right, FieldSeparator, GlobalBase,
+        MatchValue, GuardIR).
+plawk_pattern_guard_ir(or_pat(Left, Right), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
+    plawk_binary_pattern_guard_ir(or, Left, Right, FieldSeparator, GlobalBase,
+        MatchValue, GuardIR).
+plawk_pattern_guard_ir(not_pat(Pattern), FieldSeparator, GlobalBase, MatchValue, GlobalIR-GuardCallIR) :-
+    format(atom(InnerBase), '~w_n', [GlobalBase]),
+    format(atom(InnerValue), '~w_n', [MatchValue]),
+    plawk_pattern_guard_ir(Pattern, FieldSeparator, InnerBase, InnerValue,
+        GlobalIR-InnerCallIR),
+    format(atom(GuardCallIR),
+'~w
+  ~w = xor i1 ~w, true',
+        [InnerCallIR, MatchValue, InnerValue]).
+
+plawk_combined_pattern(and_pat(_Left, _Right)).
+plawk_combined_pattern(or_pat(_Left, _Right)).
+plawk_combined_pattern(not_pat(_Pattern)).
+
+%% plawk_binary_pattern_guard_ir(+Op, +Left, +Right, +FieldSeparator,
+%%     +GlobalBase, +MatchValue, -GuardIR)
+%
+%  Combine two pattern guards with a bitwise i1 op. The base guards are
+%  side-effect-free straight-line checks, so evaluating both operands
+%  keeps the combined guard a single block; awk's short-circuit order
+%  is unobservable here.
+plawk_binary_pattern_guard_ir(Op, Left, Right, FieldSeparator, GlobalBase,
+        MatchValue, GlobalIR-GuardCallIR) :-
+    format(atom(LeftBase), '~w_l', [GlobalBase]),
+    format(atom(LeftValue), '~w_l', [MatchValue]),
+    plawk_pattern_guard_ir(Left, FieldSeparator, LeftBase, LeftValue,
+        LeftGlobalIR-LeftCallIR),
+    format(atom(RightBase), '~w_r', [GlobalBase]),
+    format(atom(RightValue), '~w_r', [MatchValue]),
+    plawk_pattern_guard_ir(Right, FieldSeparator, RightBase, RightValue,
+        RightGlobalIR-RightCallIR),
+    plawk_join_nonempty_ir([LeftGlobalIR, RightGlobalIR], GlobalIR),
+    format(atom(GuardCallIR),
+'~w
+~w
+  ~w = ~w i1 ~w, ~w',
+        [LeftCallIR, RightCallIR, MatchValue, Op, LeftValue, RightValue]).
 
 plawk_literal_contains_guard_ir(GlobalBase, Needle, FieldSeparator, MatchValue, GlobalIR-GuardCallIR) :-
     format(atom(IndexBase), '~w_contains_index', [GlobalBase]),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -79,16 +79,68 @@ action_block(Actions) -->
     "}",
     ws.
 
+%% pattern(-Pattern)//
+%
+%  awk pattern combinators: `!` binds tighter than `&&`, which binds
+%  tighter than `||`; both binary forms associate left and parentheses
+%  group. The base patterns are the existing prefix, contains,
+%  numeric-compare, and field-equality guards.
 pattern(Pattern) -->
+    or_pattern(Pattern).
+
+or_pattern(Pattern) -->
+    and_pattern(First),
+    or_pattern_chain(First, Pattern).
+
+or_pattern_chain(Acc, Pattern) -->
+    ws,
+    "||",
+    ws,
+    and_pattern(Right),
+    !,
+    or_pattern_chain(or_pat(Acc, Right), Pattern).
+or_pattern_chain(Pattern, Pattern) -->
+    [].
+
+and_pattern(Pattern) -->
+    not_pattern(First),
+    and_pattern_chain(First, Pattern).
+
+and_pattern_chain(Acc, Pattern) -->
+    ws,
+    "&&",
+    ws,
+    not_pattern(Right),
+    !,
+    and_pattern_chain(and_pat(Acc, Right), Pattern).
+and_pattern_chain(Pattern, Pattern) -->
+    [].
+
+not_pattern(not_pat(Pattern)) -->
+    "!",
+    ws,
+    not_pattern(Pattern),
+    !.
+not_pattern(Pattern) -->
+    "(",
+    ws,
+    or_pattern(Pattern),
+    ws,
+    ")",
+    !.
+not_pattern(Pattern) -->
+    base_pattern(Pattern).
+
+base_pattern(Pattern) -->
     prefix_pattern(Pattern),
     !.
-pattern(Pattern) -->
+base_pattern(Pattern) -->
     literal_pattern(Pattern),
     !.
-pattern(Pattern) -->
+base_pattern(Pattern) -->
     field_i64_cmp_pattern(Pattern),
     !.
-pattern(Pattern) -->
+base_pattern(Pattern) -->
     field_eq_pattern(Pattern).
 
 prefix_pattern(prefix(Prefix)) -->
@@ -393,10 +445,7 @@ if_action(if(Pattern, ThenActions, ElseActions)) -->
     action_block(ElseActions).
 
 condition_pattern(Pattern) -->
-    field_i64_cmp_pattern(Pattern),
-    !.
-condition_pattern(Pattern) -->
-    field_eq_pattern(Pattern).
+    or_pattern(Pattern).
 
 increment_action(inc_assoc(var(Name), KeyExpr)) -->
     identifier(Name),

--- a/tests/test_plawk_surface_pattern_combinators.pl
+++ b/tests/test_plawk_surface_pattern_combinators.pl
@@ -1,0 +1,177 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_patcomb_marker/0.
+
+user:plawk_patcomb_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_pattern_combinators, [condition(clang_available)]).
+
+test(parses_and_pattern) :-
+    plawk_parse_string("$1 == \"ERROR\" && $3 > 100 { print $0 }\n", Program),
+    assertion(Program == program([], [rule(
+        and_pat(field_eq(1, "ERROR"), field_cmp(3, gt, 100)),
+        [print([field(0)])])], [])).
+
+test(parses_or_pattern) :-
+    plawk_parse_string("/^ERROR/ || /^WARN/ { print $1 }\n", Program),
+    assertion(Program == program([], [rule(
+        or_pat(prefix("ERROR"), prefix("WARN")),
+        [print([field(1)])])], [])).
+
+test(parses_not_pattern) :-
+    plawk_parse_string("!/disk/ { print $0 }\n", Program),
+    assertion(Program == program([], [rule(
+        not_pat(contains("disk")),
+        [print([field(0)])])], [])).
+
+test(parses_and_binds_tighter_than_or) :-
+    plawk_parse_string("$1 == \"A\" || $1 == \"B\" && $3 > 5 { h++ } END { print h }\n", Program),
+    assertion(Program == program([], [rule(
+        or_pat(field_eq(1, "A"), and_pat(field_eq(1, "B"), field_cmp(3, gt, 5))),
+        [inc(var(h))])],
+        [end([print([var(h)])])])).
+
+test(parses_parenthesized_grouping) :-
+    plawk_parse_string("($1 == \"A\" || $1 == \"B\") && $3 > 5 { h++ } END { print h }\n", Program),
+    assertion(Program == program([], [rule(
+        and_pat(or_pat(field_eq(1, "A"), field_eq(1, "B")), field_cmp(3, gt, 5)),
+        [inc(var(h))])],
+        [end([print([var(h)])])])).
+
+test(parses_not_parenthesized_pattern) :-
+    plawk_parse_string("!($1 == \"ERROR\") { ok++ } END { print ok }\n", Program),
+    assertion(Program == program([], [rule(
+        not_pat(field_eq(1, "ERROR")),
+        [inc(var(ok))])],
+        [end([print([var(ok)])])])).
+
+test(parses_left_associative_and_chain) :-
+    plawk_parse_string("$1 == \"A\" && $3 > 5 && $3 < 10 { h++ } END { print h }\n", Program),
+    assertion(Program == program([], [rule(
+        and_pat(and_pat(field_eq(1, "A"), field_cmp(3, gt, 5)), field_cmp(3, lt, 10)),
+        [inc(var(h))])],
+        [end([print([var(h)])])])).
+
+test(parses_combined_if_condition) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\" && $3 > 100) { big++ } else { small++ } } END { print big, small }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [if(and_pat(field_eq(1, "ERROR"), field_cmp(3, gt, 100)),
+            [inc(var(big))],
+            [inc(var(small))])])],
+        [end([print([var(big), var(small)])])])).
+
+test(combined_guard_ir_is_single_block) :-
+    plawk_parse_string("$1 == \"ERROR\" && $3 > 100 { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%is_match_l = call i1 @wam_atom_field_eq_value'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%is_match_r = call i1 @wam_atom_field_i64_cmp_value'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%is_match = and i1 %is_match_l, %is_match_r'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(not_guard_ir_uses_xor) :-
+    plawk_parse_string("!/disk/ { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%is_match = xor i1 %is_match_n, true'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_and_pattern_filters_records) :-
+    run_patcomb_print_smoke("$1 == \"ERROR\" && $3 > 100 { print $0 }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "ERROR net 200\n").
+
+test(surface_or_pattern_matches_either) :-
+    run_patcomb_print_smoke("/^ERROR/ || /^WARN/ { print $1, $3 }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "ERROR 50\nERROR 200\nWARN 300\n").
+
+test(surface_not_pattern_inverts_match) :-
+    run_patcomb_print_smoke("!/disk/ { print $1 }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "ERROR\nWARN\nINFO\n").
+
+test(surface_precedence_and_over_or) :-
+    % INFO 100 matches `INFO || (WARN && >250)` but not `(INFO || WARN) && >250`.
+    run_patcomb_print_smoke("$1 == \"INFO\" || $1 == \"WARN\" && $3 > 250 { hits++ } END { print hits }\n",
+        "ERROR disk 50\nWARN cpu 300\nINFO ok 100\nWARN io 200\n",
+        "2\n").
+
+test(surface_parens_group_or_before_and) :-
+    run_patcomb_print_smoke("($1 == \"INFO\" || $1 == \"WARN\") && $3 > 250 { hits++ } END { print hits }\n",
+        "ERROR disk 50\nWARN cpu 300\nINFO ok 100\nWARN io 200\n",
+        "1\n").
+
+test(surface_combined_if_condition_updates_slots) :-
+    run_patcomb_print_smoke("{ if ($1 == \"ERROR\" && $3 > 100) { big++ } else { small++ } } END { print big, small }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "1 3\n").
+
+test(surface_or_pattern_guards_assoc_counts) :-
+    run_patcomb_print_smoke("$1 == \"ERROR\" || $1 == \"WARN\" { counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "2 1\n").
+
+test(surface_not_field_eq_counts_others) :-
+    run_patcomb_print_smoke("!($1 == \"ERROR\") { ok++ } END { print ok }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "2\n").
+
+test(surface_left_associative_and_chain_range) :-
+    run_patcomb_print_smoke("$1 == \"WARN\" && $3 > 100 && $3 < 250 { print $2 }\n",
+        "WARN cpu 300\nWARN io 200\nWARN net 50\nERROR disk 200\n",
+        "io\n").
+
+run_patcomb_print_smoke(Source, Input, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_pattern_combinators', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_pattern_combinators.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_patcomb_marker/0 ],
+        [module_name('plawk_surface_pattern_combinators')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_pattern_combinators_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[plawk surface pattern combinators output]~n~w~n",
+              [OutStr]),
+       throw(plawk_surface_pattern_combinators_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_surface_pattern_combinators).


### PR DESCRIPTION
## Summary

**Stacked on #3398** (→ #3397 → #3396). Final PR in this series.

Rule patterns and `if` conditions now compose with `&&`, `||`, and `!`:

```awk
$1 == "ERROR" && $3 > 100 { print $0 }
/^ERROR/ || /^WARN/ { print $1 }
!/disk/ { print $0 }
($1 == "INFO" || $1 == "WARN") && $3 > 250 { hits++ } END { print hits }
{ if ($1 == "ERROR" && $3 > 100) { big++ } else { small++ } }
```

## Changes

**Parser (`examples/plawk/parser/plawk_parser.pl`)**
- `pattern//1` becomes a combinator grammar over the existing base patterns (prefix, contains, numeric compare, field equality): `!` binds tighter than `&&`, which binds tighter than `||`; both binary forms associate left; parentheses group. AST: `and_pat/2`, `or_pat/2`, `not_pat/1`.
- `if` conditions accept the same grammar — including prefix/contains base patterns, which were previously rule-position-only.

**Codegen (`examples/plawk/codegen/plawk_native_codegen.pl`)**
- Combined guards lower to bitwise `i1` `and`/`or`/`xor` over the existing native guard emitters, with per-subpattern `_l`/`_r`/`_n` suffixed SSA names and string globals so nested combinations never collide.
- The base guards are side-effect-free straight-line checks, so evaluating both operands keeps the whole combined guard a **single block** — no extra branches, and awk's short-circuit order is unobservable. This matters because guard IR is spliced into single-block contexts throughout the rule-chain, if/else, and assoc-rule emitters, which all pick the feature up for free through `plawk_pattern_guard_ir/5`.

**Tests (`tests/test_plawk_surface_pattern_combinators.pl`)**
- 19 tests: AST shapes (precedence, left associativity, parens, `!(...)`, combined `if`), IR assertions (single-block `and`/`xor` guards, no `@run_loop`), and e2e binaries — including an input where `a || b && c` and `(a || b) && c` produce different counts, combinator-guarded associative counts, and a three-term `&&` range chain.

## Testing

- `tests/test_plawk_surface_pattern_combinators.pl` — 19/19 pass
- `tests/test_plawk_surface_prefix_print.pl`, `test_plawk_surface_forin_end_print.pl`, `test_plawk_surface_stdin_input.pl`, `test_plawk_surface_arith_exprs.pl` — all pass (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_