### PR TITLE
plawk: bring stdin input, i64 arithmetic, and pattern combinators to main

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -291,6 +291,11 @@ pointer pairs.
 Numeric field guards such as `$3 > 100` lower through the shared
 `@wam_atom_field_i64_cmp_value` helper, which parses the projected field slice
 as a strict signed decimal `i64` and compares with numeric op codes.
+Patterns compose with `&&`, `||`, and `!` (awk precedence, parentheses
+group) in both rule guards and `if` conditions. The base guards are
+side-effect-free straight-line native checks, so combined guards lower to
+bitwise `i1` `and`/`or`/`xor` over per-subpattern `_l`/`_r`/`_n` suffixed
+names, keeping the whole guard a single block with no extra branches.
 The parser itself is factored as `@wam_atom_field_i64_value`, returning a value
 plus success flag, so the same machinery also feeds scalar expressions such as
 `bytes += $3` and `last = $3`; PLAWK uses zero for failed numeric coercions in

--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -272,10 +272,15 @@ the allocation-free `@wam_atom_field_subslice_value` helper, and native
 `index($N, "literal")` through the shared `@wam_atom_field_index_value` helper.
 Explicit print-side numeric coercions such as `int($N)` lower through the shared
 `@wam_atom_field_i64_value` parse helper and print zero when the field is
-missing or not a strict signed decimal. The first composed arithmetic forms add
-or subtract a non-negative integer constant from native `i64` primaries such as
-`NR`, `NF`, `length($N)`, `int($N)`, and `index($N, "literal")`; each lowers
-through the shared primary emitter followed by a shared binary `i64` operation.
+missing or not a strict signed decimal. Arithmetic expressions support general
+`+`, `-`, `*`, `/`, and `%` with awk precedence and parentheses over `i64`
+operands: integer literals, `NR`, `NF`, `length($N)`, `int($N)`,
+`index($N, "literal")`, and bare numeric fields (`$3 + $4` coerces like
+`int/1`; a bare `$N` alone still prints as a slice). Each binary node lowers
+recursively through the shared `plawk_i64_expr_ir` emitter with `_lhs`/`_rhs`
+name suffixes; `/` and `%` emit branch-free guards so a zero divisor yields
+`0` and `INT64_MIN / -1` wraps instead of trapping. Scalar `+=`/`=` updates
+and `printf` arguments accept the same expression grammar.
 Print-only `tolower($N)` and `toupper($N)` lower through shared
 `@wam_print_ascii_lower_slice` and `@wam_print_ascii_upper_slice` helpers, so
 case mapping streams bytes without allocating a transformed atom.

--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -189,11 +189,17 @@ The first WAM/LLVM probes now live under `examples/plawk/probes/`.
 **Success:** a native binary that reads stdin, counts records, prints matching
 lines — identical behaviour to Phase 0, running as compiled LLVM.
 
-**Current boundary:** the compiled and native stream smokes still read from file
-paths rather than stdin. WAM/LLVM exposes general stream helpers
-(`@wam_stream_open_value`, `@wam_stream_read_line_value`, and
-`@wam_stream_close_value`) that native LLVM code can call directly, alongside
-the existing `stream_open/2`, `read_line/2`, and `stream_close/1` builtins.
+**Current boundary:** WAM/LLVM exposes general stream helpers
+(`@wam_stream_open_value`, `@wam_stream_read_line_value`,
+`@wam_stream_close_value`, and `@wam_stream_open_fd_value` for wrapping an
+already-open descriptor such as stdin) that native LLVM code can call
+directly, alongside the existing `stream_open/2`, `read_line/2`, and
+`stream_close/1` builtins. `llvm_emit_stream_driver_ir/3` accepts either a
+concrete compile-time path or the `stdin_or_argv` sentinel; the sentinel
+emits a `main(argc, argv)` that opens `argv[1]` at runtime, treats `-` as
+stdin, and defaults to stdin when no argument is given, so compiled PLAWK
+binaries work as awk-style pipeline filters
+(`tests/test_plawk_surface_stdin_input.pl`).
 The `tests/test_plawk_native_stream_loop_driver.pl` smoke proves a native LLVM
 loop can open a runtime file path, read lines until `end_of_file`, call a
 compiled PLAWK handler once per record, and thread PLAWK state through WAM.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -75,6 +75,7 @@ swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR
 swipl -q -s tests/test_plawk_surface_forin_end_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_stdin_input.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_arith_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_pattern_combinators.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -106,7 +107,12 @@ lowered allocation-free by rewriting `%s` to `%.*s` and passing the slice length
 and pointer to the native vararg call.
 Numeric field guards use the shared WAM/LLVM `i64` comparison helper, so forms
 such as `$3 > 100 { print $1, $3 }` and `$2 <= -5 { cold++ }` stay in the native
-streaming loop.
+streaming loop. Patterns compose with `&&`, `||`, and `!` using awk precedence
+(`!` over `&&` over `||`, parentheses group), e.g.
+`$1 == "ERROR" && $3 > 100 { print $0 }`, `/^ERROR/ || /^WARN/ { print $1 }`,
+and `!/disk/ { print $0 }`. Combined guards lower to straight-line bitwise
+`i1` ops over the existing native guard helpers — no extra branches — and the
+same combinators work in `if (...)` conditions.
 Scalar state works with `$1 ==
 "ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -74,6 +74,7 @@ swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "se
 swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_forin_end_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_stdin_input.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_arith_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -88,10 +89,15 @@ as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
 case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0) }`.
 Explicit numeric field coercion is available as `int($N)`, e.g.
 `$1 == "ERROR" { print $3, int($3) }`; failed numeric parses print `0`.
-The first arithmetic composition forms add or subtract a non-negative integer
-constant from native `i64` primaries such as `NR`, `NF`, `length($N)`,
-`int($N)`, and `index($N, "literal")`, e.g.
-`$1 == "ERROR" { print NR - 1, int($3) + 1, index($2, "sk") + 1 }`.
+Arithmetic expressions support general `+`, `-`, `*`, `/`, and `%` between
+native `i64` operands with awk precedence (`* / %` bind tighter than `+ -`,
+both associate left) and parentheses, e.g.
+`{ print ($2 + $3) * $4, $2 + $3 * $4 }`. Operands are integer literals,
+`NR`, `NF`, `length($N)`, `int($N)`, `index($N, "literal")`, and bare numeric
+fields such as `$3`, which coerce like `int($3)` inside arithmetic (a bare
+`$N` on its own still prints as a byte slice). Division and modulo are
+guarded: a zero divisor yields `0`, and `INT64_MIN / -1` wraps to
+`INT64_MIN` (`% -1` yields `0`) instead of trapping.
 Rule actions can also use basic `printf` forms, e.g.
 `$1 == "ERROR" { printf "%s=%s\n", $2, $3 }`. `printf` does not add `OFS` or
 an implicit newline; supported native formats are `%%`, `%s` for strings and

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -73,6 +73,7 @@ swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_
 swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_forin_end_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_stdin_input.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -149,7 +150,12 @@ explicit single-byte `FS` values such as `BEGIN { FS = ":" }` for native field
 equality, selected-field printing, and associative key extraction. Single-byte
 `OFS` values such as `BEGIN { OFS = "," }` drive comma-separated `print` fields;
 the native path emits separator bytes directly, so values such as `%` are data,
-not `printf` formats. Mixed scalar/associative state is
+not `printf` formats. Compiled binaries take their input the awk way: passing the
+`stdin_or_argv` sentinel instead of a compile-time path emits a
+`main(argc, argv)` that opens `argv[1]` at runtime, treats `-` as stdin, and
+defaults to stdin when no argument is given, so `./prog file.txt`,
+`./prog < file.txt`, and `cat file.txt | ./prog` all work.
+Mixed scalar/associative state is
 supported in the same native loop, e.g. `{ total++; counts[$1]++ }` with an
 `END` print of both `total` and `counts["ERROR"]`. `END` print fields can also
 include literal labels such as `print "total", total, "errors", counts["ERROR"]`.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1530,18 +1530,31 @@ plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(int(field(_))).
 plawk_rule_body_print_field(Expr) :-
-    plawk_i64_const_binary_expr(Expr).
+    plawk_i64_general_binary_expr(Expr).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
 plawk_rule_body_print_field(index(field(_), string(_))).
 plawk_rule_body_print_field(tolower(field(_))).
 plawk_rule_body_print_field(toupper(field(_))).
 
-plawk_i64_const_binary_expr(Expr) :-
-    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, int(Value)),
-    plawk_i64_binary_primary_expr(Left),
-    integer(Value),
-    Value >= 0.
+%% plawk_i64_general_binary_expr(+Expr) is semidet.
+%
+%  Recognize a native i64 binary expression tree whose leaves are i64
+%  primaries, integer literals, or bare numeric field coercions.
+plawk_i64_general_binary_expr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    plawk_i64_operand_expr(Left),
+    plawk_i64_operand_expr(Right).
+
+plawk_i64_operand_expr(int(Value)) :-
+    integer(Value).
+plawk_i64_operand_expr(field(FieldIndex)) :-
+    integer(FieldIndex),
+    FieldIndex >= 0.
+plawk_i64_operand_expr(Expr) :-
+    plawk_i64_binary_primary_expr(Expr).
+plawk_i64_operand_expr(Expr) :-
+    plawk_i64_general_binary_expr(Expr).
 
 plawk_i64_binary_primary_expr(special('NR')).
 plawk_i64_binary_primary_expr(special('NF')).
@@ -1553,12 +1566,6 @@ plawk_i64_binary_primary_expr(index(field(FieldIndex), string(Needle))) :-
     FieldIndex >= 0,
     string(Needle).
 
-plawk_i64_scalar_const_binary_expr(Expr) :-
-    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, int(Value)),
-    plawk_i64_scalar_binary_primary_expr(Left),
-    integer(Value),
-    Value >= 0.
-
 plawk_i64_scalar_primary_expr(special('NR')).
 plawk_i64_scalar_primary_expr(special('NF')).
 plawk_i64_scalar_primary_expr(int(field(FieldIndex))) :-
@@ -1569,14 +1576,17 @@ plawk_i64_scalar_primary_expr(index(field(FieldIndex), string(Needle))) :-
     FieldIndex >= 0,
     string(Needle).
 
-plawk_i64_scalar_binary_primary_expr(Expr) :-
-    plawk_i64_scalar_primary_expr(Expr).
-
 plawk_i64_binary_expr(add_i64(Left, Right), add, add, Left, Right).
 plawk_i64_binary_expr(sub_i64(Left, Right), sub, sub, Left, Right).
+plawk_i64_binary_expr(mul_i64(Left, Right), mul, mul, Left, Right).
+plawk_i64_binary_expr(div_i64(Left, Right), sdiv, div, Left, Right).
+plawk_i64_binary_expr(mod_i64(Left, Right), srem, mod, Left, Right).
 
 plawk_i64_binary_print_kind(add, int_add).
 plawk_i64_binary_print_kind(sub, int_sub).
+plawk_i64_binary_print_kind(mul, int_mul).
+plawk_i64_binary_print_kind(div, int_div).
+plawk_i64_binary_print_kind(mod, int_mod).
 
 plawk_scalar_update_action_name(Action, Name) :-
     plawk_scalar_action_update(Action, Name, _Operation).
@@ -1599,7 +1609,7 @@ plawk_scalar_action_update(add(var(Name), int(field(FieldIndex))), Name, add(fie
 plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
     plawk_i64_scalar_primary_expr(Expr).
 plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
-    plawk_i64_scalar_const_binary_expr(Expr).
+    plawk_i64_general_binary_expr(Expr).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
@@ -1612,7 +1622,7 @@ plawk_scalar_action_update(set(var(Name), int(field(FieldIndex))), Name, set(fie
 plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
     plawk_i64_scalar_primary_expr(Expr).
 plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
-    plawk_i64_scalar_const_binary_expr(Expr).
+    plawk_i64_general_binary_expr(Expr).
 
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, CurrentLabel, []) -->
@@ -1781,6 +1791,14 @@ plawk_i64_expr_ir_parts(Expr, FieldSeparator, Base, GlobalBase,
 plawk_i64_expr_ir(const(Value), _FieldSeparator, _Base, _GlobalBase, ValueIR, [], []) :-
     integer(Value),
     format(atom(ValueIR), '~w', [Value]).
+plawk_i64_expr_ir(int(Value), _FieldSeparator, _Base, _GlobalBase, ValueIR, [], []) :-
+    integer(Value),
+    format(atom(ValueIR), '~w', [Value]).
+plawk_i64_expr_ir(field(FieldIndex), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    integer(FieldIndex),
+    plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts).
 plawk_i64_expr_ir(nr, _FieldSeparator, _Base, _GlobalBase, '%current_nr', [], []).
 plawk_i64_expr_ir(nf, FieldSeparator, Base, _GlobalBase, ValueIR, [], [CountIR]) :-
     llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
@@ -1814,21 +1832,62 @@ plawk_i64_expr_ir(index(field(FieldIndex), string(Needle)), FieldSeparator, Base
         ValueIR, GlobalParts, SetupParts).
 plawk_i64_expr_ir(Expr, FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts) :-
-    plawk_i64_binary_expr(Expr, LLVMOp, _NamePart, Left, int(Value)),
-    integer(Value),
+    plawk_i64_binary_expr(Expr, LLVMOp, _NamePart, Left, Right),
     format(atom(LeftBase), '~w_lhs', [Base]),
     format(atom(LeftGlobalBase), '~w_lhs', [GlobalBase]),
     plawk_i64_expr_ir(Left, FieldSeparator, LeftBase, LeftGlobalBase,
-        LeftValueIR, GlobalParts, LeftSetupParts),
+        LeftValueIR, LeftGlobalParts, LeftSetupParts),
+    format(atom(RightBase), '~w_rhs', [Base]),
+    format(atom(RightGlobalBase), '~w_rhs', [GlobalBase]),
+    plawk_i64_expr_ir(Right, FieldSeparator, RightBase, RightGlobalBase,
+        RightValueIR, RightGlobalParts, RightSetupParts),
     format(atom(ValueIR), '%~w', [Base]),
-    format(atom(BinaryIR), '  ~w = ~w i64 ~w, ~w',
-        [ValueIR, LLVMOp, LeftValueIR, Value]),
-    append(LeftSetupParts, [BinaryIR], SetupParts).
+    plawk_i64_binary_op_lines(LLVMOp, Base, LeftValueIR, RightValueIR, OpLines),
+    append(LeftGlobalParts, RightGlobalParts, GlobalParts),
+    append([LeftSetupParts, RightSetupParts, OpLines], SetupParts).
 plawk_i64_expr_ir(index(FieldIndex, Needle), FieldSeparator, Base, GlobalBase,
         ValueIR, [GlobalIR], [CallIR]) :-
     llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
         Base, GlobalIR-CallIR),
     format(atom(ValueIR), '%~w', [Base]).
+
+%% plawk_i64_binary_op_lines(+LLVMOp, +Base, +LeftIR, +RightIR, -Lines)
+%
+%  add/sub/mul emit one instruction. sdiv/srem are guarded so awk-side
+%  division stays defined: a zero divisor yields 0, and the
+%  INT64_MIN / -1 overflow case divides by 1 instead, wrapping to
+%  INT64_MIN for `/` and 0 for `%`.
+plawk_i64_binary_op_lines(sdiv, Base, LeftIR, RightIR, Lines) :-
+    !,
+    plawk_i64_guarded_div_lines(sdiv, Base, LeftIR, RightIR, Lines).
+plawk_i64_binary_op_lines(srem, Base, LeftIR, RightIR, Lines) :-
+    !,
+    plawk_i64_guarded_div_lines(srem, Base, LeftIR, RightIR, Lines).
+plawk_i64_binary_op_lines(LLVMOp, Base, LeftIR, RightIR, [Line]) :-
+    format(atom(Line), '  %~w = ~w i64 ~w, ~w',
+        [Base, LLVMOp, LeftIR, RightIR]).
+
+plawk_i64_guarded_div_lines(LLVMOp, Base, LeftIR, RightIR, Lines) :-
+    format(atom(DenZero),
+        '  %~w_den_zero = icmp eq i64 ~w, 0', [Base, RightIR]),
+    format(atom(LhsMin),
+        '  %~w_lhs_min = icmp eq i64 ~w, -9223372036854775808', [Base, LeftIR]),
+    format(atom(RhsNegOne),
+        '  %~w_rhs_negone = icmp eq i64 ~w, -1', [Base, RightIR]),
+    format(atom(Overflow),
+        '  %~w_overflow = and i1 %~w_lhs_min, %~w_rhs_negone',
+        [Base, Base, Base]),
+    format(atom(DenBad),
+        '  %~w_den_bad = or i1 %~w_den_zero, %~w_overflow', [Base, Base, Base]),
+    format(atom(SafeDen),
+        '  %~w_safe_den = select i1 %~w_den_bad, i64 1, i64 ~w',
+        [Base, Base, RightIR]),
+    format(atom(Raw),
+        '  %~w_raw = ~w i64 ~w, %~w_safe_den', [Base, LLVMOp, LeftIR, Base]),
+    format(atom(Result),
+        '  %~w = select i1 %~w_den_zero, i64 0, i64 %~w_raw',
+        [Base, Base, Base]),
+    Lines = [DenZero, LhsMin, RhsNegOne, Overflow, DenBad, SafeDen, Raw, Result].
 
 plawk_branch_to_done_ir(none, _DoneLabel, '  br label %continue_loop') :-
     !.
@@ -2106,8 +2165,10 @@ plawk_fields_include_nr(Fields) :-
 
 plawk_expr_uses_nr(special('NR')).
 plawk_expr_uses_nr(Expr) :-
-    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, _Right),
-    plawk_expr_uses_nr(Left).
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_uses_nr(Left)
+    ; plawk_expr_uses_nr(Right)
+    ).
 
 plawk_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, ''-IR) :-
     !,
@@ -2415,6 +2476,12 @@ plawk_normal_print_expr_value_base(int_add, Index, Base) :-
     format(atom(Base), 'plawk_int_add_~w', [Index]).
 plawk_normal_print_expr_value_base(int_sub, Index, Base) :-
     format(atom(Base), 'plawk_int_sub_~w', [Index]).
+plawk_normal_print_expr_value_base(int_mul, Index, Base) :-
+    format(atom(Base), 'plawk_int_mul_~w', [Index]).
+plawk_normal_print_expr_value_base(int_div, Index, Base) :-
+    format(atom(Base), 'plawk_int_div_~w', [Index]).
+plawk_normal_print_expr_value_base(int_mod, Index, Base) :-
+    format(atom(Base), 'plawk_int_mod_~w', [Index]).
 plawk_normal_print_expr_value_base(length, Index, Base) :-
     format(atom(Base), 'plawk_length_~w', [Index]).
 plawk_normal_print_expr_value_base(substr, Index, Base) :-

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2102,6 +2102,10 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, ''-GuardCall
     plawk_field_cmp_op_code(Op, OpCode),
     llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
         FieldSeparator, '%is_match', GuardCallIR).
+plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardIR) :-
+    plawk_combined_pattern(Pattern),
+    plawk_pattern_guard_ir(Pattern, FieldSeparator, plawk_surface_pattern,
+        '%is_match', GuardIR).
 
 plawk_pattern_guard_ir(always, _GlobalBase, MatchValue, GuardIR) :-
     format(atom(GuardCallIR), '  ~w = icmp eq i1 true, true', [MatchValue]),
@@ -2134,6 +2138,49 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, _GlobalBase,
     plawk_field_cmp_op_code(Op, OpCode),
     llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
         FieldSeparator, MatchValue, GuardCallIR).
+plawk_pattern_guard_ir(and_pat(Left, Right), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
+    plawk_binary_pattern_guard_ir(and, Left, Right, FieldSeparator, GlobalBase,
+        MatchValue, GuardIR).
+plawk_pattern_guard_ir(or_pat(Left, Right), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
+    plawk_binary_pattern_guard_ir(or, Left, Right, FieldSeparator, GlobalBase,
+        MatchValue, GuardIR).
+plawk_pattern_guard_ir(not_pat(Pattern), FieldSeparator, GlobalBase, MatchValue, GlobalIR-GuardCallIR) :-
+    format(atom(InnerBase), '~w_n', [GlobalBase]),
+    format(atom(InnerValue), '~w_n', [MatchValue]),
+    plawk_pattern_guard_ir(Pattern, FieldSeparator, InnerBase, InnerValue,
+        GlobalIR-InnerCallIR),
+    format(atom(GuardCallIR),
+'~w
+  ~w = xor i1 ~w, true',
+        [InnerCallIR, MatchValue, InnerValue]).
+
+plawk_combined_pattern(and_pat(_Left, _Right)).
+plawk_combined_pattern(or_pat(_Left, _Right)).
+plawk_combined_pattern(not_pat(_Pattern)).
+
+%% plawk_binary_pattern_guard_ir(+Op, +Left, +Right, +FieldSeparator,
+%%     +GlobalBase, +MatchValue, -GuardIR)
+%
+%  Combine two pattern guards with a bitwise i1 op. The base guards are
+%  side-effect-free straight-line checks, so evaluating both operands
+%  keeps the combined guard a single block; awk's short-circuit order
+%  is unobservable here.
+plawk_binary_pattern_guard_ir(Op, Left, Right, FieldSeparator, GlobalBase,
+        MatchValue, GlobalIR-GuardCallIR) :-
+    format(atom(LeftBase), '~w_l', [GlobalBase]),
+    format(atom(LeftValue), '~w_l', [MatchValue]),
+    plawk_pattern_guard_ir(Left, FieldSeparator, LeftBase, LeftValue,
+        LeftGlobalIR-LeftCallIR),
+    format(atom(RightBase), '~w_r', [GlobalBase]),
+    format(atom(RightValue), '~w_r', [MatchValue]),
+    plawk_pattern_guard_ir(Right, FieldSeparator, RightBase, RightValue,
+        RightGlobalIR-RightCallIR),
+    plawk_join_nonempty_ir([LeftGlobalIR, RightGlobalIR], GlobalIR),
+    format(atom(GuardCallIR),
+'~w
+~w
+  ~w = ~w i1 ~w, ~w',
+        [LeftCallIR, RightCallIR, MatchValue, Op, LeftValue, RightValue]).
 
 plawk_literal_contains_guard_ir(GlobalBase, Needle, FieldSeparator, MatchValue, GlobalIR-GuardCallIR) :-
     format(atom(IndexBase), '~w_contains_index', [GlobalBase]),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -437,13 +437,13 @@ assignment_action(set(var(Name), Value)) -->
 scalar_value_expr(Value) -->
     scalar_delta_expr(Value).
 
+scalar_delta_expr(Expr) -->
+    i64_binary_surface_expr(Expr).
 scalar_delta_expr(int(Value)) -->
     integer_codes(ValueCodes),
     { ValueCodes \== [],
       number_codes(Value, ValueCodes),
       Value >= 0 }.
-scalar_delta_expr(Expr) -->
-    i64_const_binary_expr(Expr).
 scalar_delta_expr(special('NR')) -->
     "NR".
 scalar_delta_expr(special('NF')) -->
@@ -529,7 +529,7 @@ print_fields_rest([]) -->
     [].
 
 field_expr(Expr) -->
-    i64_const_binary_expr(Expr).
+    i64_binary_surface_expr(Expr).
 field_expr(special('NR')) -->
     "NR".
 field_expr(special('NF')) -->
@@ -631,21 +631,88 @@ int_field_expr(int(Field)) -->
     ")",
     { Field = field(_) }.
 
-i64_const_binary_expr(Expr) -->
-    i64_binary_primary_expr(Left),
-    ws,
-    i64_binary_surface_operator(Functor),
-    ws,
-    integer_codes(ValueCodes),
-    { ValueCodes \== [],
-      number_codes(Value, ValueCodes),
-      Value >= 0,
-      Expr =.. [Functor, Left, int(Value)] }.
+%% i64_binary_surface_expr(-Expr)//
+%
+%  General native i64 arithmetic with awk precedence: * / % bind tighter
+%  than + -, both levels associate left, and parentheses group. Factors
+%  are the native i64 primaries plus integer literals and bare numeric
+%  field coercions such as `$3` (zero when the field is not a strict
+%  signed decimal). The top-level result must contain at least one
+%  operator so bare primaries keep their existing print/slice meaning.
+i64_binary_surface_expr(Expr) -->
+    i64_additive_expr(Expr),
+    { i64_binary_expr_ast(Expr) }.
 
-i64_binary_surface_operator(add_i64) -->
+i64_binary_expr_ast(Expr) :-
+    compound(Expr),
+    functor(Expr, Functor, 2),
+    memberchk(Functor, [add_i64, sub_i64, mul_i64, div_i64, mod_i64]).
+
+i64_additive_expr(Expr) -->
+    i64_multiplicative_expr(First),
+    i64_additive_chain(First, Expr).
+
+i64_additive_chain(Acc, Expr) -->
+    ws,
+    i64_additive_operator(Functor),
+    ws,
+    i64_multiplicative_expr(Right),
+    !,
+    { Acc1 =.. [Functor, Acc, Right] },
+    i64_additive_chain(Acc1, Expr).
+i64_additive_chain(Expr, Expr) -->
+    [].
+
+i64_multiplicative_expr(Expr) -->
+    i64_factor_expr(First),
+    i64_multiplicative_chain(First, Expr).
+
+i64_multiplicative_chain(Acc, Expr) -->
+    ws,
+    i64_multiplicative_operator(Functor),
+    ws,
+    i64_factor_expr(Right),
+    !,
+    { Acc1 =.. [Functor, Acc, Right] },
+    i64_multiplicative_chain(Acc1, Expr).
+i64_multiplicative_chain(Expr, Expr) -->
+    [].
+
+i64_additive_operator(add_i64) -->
     "+".
-i64_binary_surface_operator(sub_i64) -->
+i64_additive_operator(sub_i64) -->
     "-".
+
+i64_multiplicative_operator(mul_i64) -->
+    "*".
+i64_multiplicative_operator(div_i64) -->
+    "/".
+i64_multiplicative_operator(mod_i64) -->
+    "%".
+
+i64_factor_expr(Expr) -->
+    "(",
+    ws,
+    i64_additive_expr(Expr),
+    ws,
+    ")",
+    !.
+i64_factor_expr(Expr) -->
+    i64_binary_primary_expr(Expr),
+    !.
+i64_factor_expr(int(Value)) -->
+    integer_codes(ValueCodes),
+    !,
+    { ValueCodes \== [],
+      number_codes(Value, ValueCodes)
+    }.
+i64_factor_expr(field(Index)) -->
+    "$",
+    integer_codes(IndexCodes),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    }.
 
 i64_binary_primary_expr(special('NR')) -->
     "NR".

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -79,16 +79,68 @@ action_block(Actions) -->
     "}",
     ws.
 
+%% pattern(-Pattern)//
+%
+%  awk pattern combinators: `!` binds tighter than `&&`, which binds
+%  tighter than `||`; both binary forms associate left and parentheses
+%  group. The base patterns are the existing prefix, contains,
+%  numeric-compare, and field-equality guards.
 pattern(Pattern) -->
+    or_pattern(Pattern).
+
+or_pattern(Pattern) -->
+    and_pattern(First),
+    or_pattern_chain(First, Pattern).
+
+or_pattern_chain(Acc, Pattern) -->
+    ws,
+    "||",
+    ws,
+    and_pattern(Right),
+    !,
+    or_pattern_chain(or_pat(Acc, Right), Pattern).
+or_pattern_chain(Pattern, Pattern) -->
+    [].
+
+and_pattern(Pattern) -->
+    not_pattern(First),
+    and_pattern_chain(First, Pattern).
+
+and_pattern_chain(Acc, Pattern) -->
+    ws,
+    "&&",
+    ws,
+    not_pattern(Right),
+    !,
+    and_pattern_chain(and_pat(Acc, Right), Pattern).
+and_pattern_chain(Pattern, Pattern) -->
+    [].
+
+not_pattern(not_pat(Pattern)) -->
+    "!",
+    ws,
+    not_pattern(Pattern),
+    !.
+not_pattern(Pattern) -->
+    "(",
+    ws,
+    or_pattern(Pattern),
+    ws,
+    ")",
+    !.
+not_pattern(Pattern) -->
+    base_pattern(Pattern).
+
+base_pattern(Pattern) -->
     prefix_pattern(Pattern),
     !.
-pattern(Pattern) -->
+base_pattern(Pattern) -->
     literal_pattern(Pattern),
     !.
-pattern(Pattern) -->
+base_pattern(Pattern) -->
     field_i64_cmp_pattern(Pattern),
     !.
-pattern(Pattern) -->
+base_pattern(Pattern) -->
     field_eq_pattern(Pattern).
 
 prefix_pattern(prefix(Prefix)) -->
@@ -393,10 +445,7 @@ if_action(if(Pattern, ThenActions, ElseActions)) -->
     action_block(ElseActions).
 
 condition_pattern(Pattern) -->
-    field_i64_cmp_pattern(Pattern),
-    !.
-condition_pattern(Pattern) -->
-    field_eq_pattern(Pattern).
+    or_pattern(Pattern).
 
 increment_action(inc_assoc(var(Name), KeyExpr)) -->
     identifier(Name),

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4463,6 +4463,66 @@ soh.close_all_fail:
   br label %soh.fail
 }
 
+define %Value @wam_stream_open_fd_value(i64 %fd64) {
+entry:
+  ; Wrap an already-open file descriptor (e.g. fd 0 for stdin) in a
+  ; buffered reader handle. The fd is not opened or validated here;
+  ; wam_stream_close_value closes it like any other stream. On
+  ; allocation failure the caller keeps ownership of the fd.
+  %sfd.fd_ok = icmp sge i64 %fd64, 0
+  br i1 %sfd.fd_ok, label %sfd.alloc_reader, label %sfd.fail
+
+sfd.fail:
+  %sfd.bad = call %Value @wam_stream_fail_value()
+  ret %Value %sfd.bad
+
+sfd.alloc_reader:
+  %sfd.fd = trunc i64 %fd64 to i32
+  %sfd.reader_size = ptrtoint %WamLineReader* getelementptr (%WamLineReader, %WamLineReader* null, i32 1) to i64
+  %sfd.reader_mem = call i8* @malloc(i64 %sfd.reader_size)
+  %sfd.reader_null = icmp eq i8* %sfd.reader_mem, null
+  br i1 %sfd.reader_null, label %sfd.fail, label %sfd.alloc_buf
+
+sfd.alloc_buf:
+  %sfd.buf = call i8* @malloc(i64 4096)
+  %sfd.buf_null = icmp eq i8* %sfd.buf, null
+  br i1 %sfd.buf_null, label %sfd.free_reader_fail, label %sfd.init
+
+sfd.free_reader_fail:
+  call void @free(i8* %sfd.reader_mem)
+  br label %sfd.fail
+
+sfd.init:
+  %sfd.reader = bitcast i8* %sfd.reader_mem to %WamLineReader*
+  %sfd.fd_slot = getelementptr %WamLineReader, %WamLineReader* %sfd.reader, i32 0, i32 0
+  store i32 %sfd.fd, i32* %sfd.fd_slot
+  %sfd.buf_slot = getelementptr %WamLineReader, %WamLineReader* %sfd.reader, i32 0, i32 1
+  store i8* %sfd.buf, i8** %sfd.buf_slot
+  %sfd.cap_slot = getelementptr %WamLineReader, %WamLineReader* %sfd.reader, i32 0, i32 2
+  store i64 4096, i64* %sfd.cap_slot
+  %sfd.len_slot = getelementptr %WamLineReader, %WamLineReader* %sfd.reader, i32 0, i32 3
+  store i64 0, i64* %sfd.len_slot
+  %sfd.pos_slot = getelementptr %WamLineReader, %WamLineReader* %sfd.reader, i32 0, i32 4
+  store i64 0, i64* %sfd.pos_slot
+  %sfd.count = load i32, i32* @wam_stream_handle_count
+  %sfd.next = add i32 %sfd.count, 1
+  %sfd.cap_ok = icmp ult i32 %sfd.next, 4096
+  br i1 %sfd.cap_ok, label %sfd.store_handle, label %sfd.free_all_fail
+
+sfd.store_handle:
+  %sfd.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %sfd.next
+  store %WamLineReader* %sfd.reader, %WamLineReader** %sfd.slot
+  store i32 %sfd.next, i32* @wam_stream_handle_count
+  %sfd.handle = zext i32 %sfd.next to i64
+  %sfd.v = call %Value @value_integer(i64 %sfd.handle)
+  ret %Value %sfd.v
+
+sfd.free_all_fail:
+  call void @free(i8* %sfd.buf)
+  call void @free(i8* %sfd.reader_mem)
+  br label %sfd.fail
+}
+
 define %Value @wam_stream_read_line_value(%Value %handle_value) {
 entry:
   %rhv.t = call i32 @value_tag(%Value %handle_value)
@@ -17185,6 +17245,12 @@ llvm_emit_printf0(FmtGlobal, FmtLen, FmtVar, PrintVar, [FmtPtr, PrintCall]) :-
 %  lowerers provide runtime globals, optional entry setup, loop-carried phis,
 %  per-record lowered IR, continuation phis, optional terminal-break close IR,
 %  and the close-success block.
+%
+%  InputPath is either a concrete path (compiled into the binary as a
+%  string global) or the atom `stdin_or_argv`, which emits a
+%  main(argc, argv) that opens argv[1] at runtime, treats "-" as stdin,
+%  and defaults to stdin (fd 0) when no argument is given -- the awk
+%  pipeline-filter convention.
 llvm_emit_stream_driver_ir(
     InputPath,
     driver_blocks(RuntimeGlobals, LoopPhiIR, LoweredLabel, RecordIR,
@@ -17206,6 +17272,108 @@ llvm_emit_stream_driver_ir(
         driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
             ContinueIR, '', CloseOkLabel, CloseOkIR),
         DriverIR).
+
+llvm_emit_stream_driver_ir(
+    stdin_or_argv,
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    !,
+    format(atom(DriverIR),
+'@.wam_stream_eof = private constant [12 x i8] c"end_of_file\\00"
+@.wam_stream_stdin_dash = private constant [2 x i8] c"-\\00"
+~w
+
+define i32 @main(i32 %argc, i8** %argv) {
+entry:
+~w
+  %have_arg = icmp sgt i32 %argc, 1
+  br i1 %have_arg, label %check_argv_path, label %use_stdin
+
+check_argv_path:
+  %argv1_ptr = getelementptr i8*, i8** %argv, i64 1
+  %argv1 = load i8*, i8** %argv1_ptr
+  %dash_ptr = getelementptr [2 x i8], [2 x i8]* @.wam_stream_stdin_dash, i32 0, i32 0
+  %dash_cmp = call i32 @strcmp(i8* %argv1, i8* %dash_ptr)
+  %is_dash = icmp eq i32 %dash_cmp, 0
+  br i1 %is_dash, label %use_stdin, label %open_argv_file
+
+open_argv_file:
+  %argv1_len = call i64 @strlen(i8* %argv1)
+  %path_id = call i64 @wam_intern_atom(i8* %argv1, i64 %argv1_len)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %file_handle = call %Value @wam_stream_open_value(%Value %path)
+  br label %have_handle
+
+use_stdin:
+  %stdin_handle = call %Value @wam_stream_open_fd_value(i64 0)
+  br label %have_handle
+
+have_handle:
+  %handle = phi %Value [ %file_handle, %open_argv_file ], [ %stdin_handle, %use_stdin ]
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+~w
+  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_payload = extractvalue %Value %line, 1
+  %line_is_int = icmp eq i32 %line_tag, 1
+  %line_bad_payload = icmp slt i64 %line_payload, 0
+  %line_bad = and i1 %line_is_int, %line_bad_payload
+  br i1 %line_bad, label %fail_read, label %check_line_atom
+
+check_line_atom:
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
+
+check_eof:
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %eof_s = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof, i32 0, i32 0
+  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
+  %is_eof = icmp eq i32 %eof_cmp, 0
+  br i1 %is_eof, label %close_stream, label %~w
+
+~w:
+~w
+
+continue_loop:
+~w
+  br label %loop
+
+~w
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %~w, label %fail_close
+
+~w
+
+fail_open:
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_line_tag:
+  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 12
+
+fail_close:
+  ret i32 16
+}
+',
+        [RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel,
+         LoweredLabel, RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR]).
 
 llvm_emit_stream_driver_ir(
     InputPath,

--- a/tests/test_plawk_surface_arith_exprs.pl
+++ b/tests/test_plawk_surface_arith_exprs.pl
@@ -1,0 +1,185 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_arith_marker/0.
+
+user:plawk_arith_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_arith_exprs, [condition(clang_available)]).
+
+test(parses_field_plus_field) :-
+    plawk_parse_string("{ print $2 + $3 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([add_i64(field(2), field(3))])])], [])).
+
+test(parses_multiplicative_precedence) :-
+    plawk_parse_string("{ print $2 + $3 * $4 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([add_i64(field(2), mul_i64(field(3), field(4)))])])], [])).
+
+test(parses_parenthesized_grouping) :-
+    plawk_parse_string("{ print ($2 + $3) * $4 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([mul_i64(add_i64(field(2), field(3)), field(4))])])], [])).
+
+test(parses_left_associative_subtraction) :-
+    plawk_parse_string("{ print $2 - $3 - $4 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([sub_i64(sub_i64(field(2), field(3)), field(4))])])], [])).
+
+test(parses_div_and_mod) :-
+    plawk_parse_string("{ print $2 / $3, $2 % $3 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([div_i64(field(2), field(3)),
+                mod_i64(field(2), field(3))])])], [])).
+
+test(parses_mixed_primary_arithmetic) :-
+    plawk_parse_string("$1 == \"ERROR\" { print NR * 10 + NF, length($2) * 2 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([add_i64(mul_i64(special('NR'), int(10)), special('NF')),
+                mul_i64(length(field(2)), int(2))])])], [])).
+
+test(parses_scalar_binary_update) :-
+    plawk_parse_string("{ sum += $2 * $3; last = $2 + $3 } END { print sum, last }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [add(var(sum), mul_i64(field(2), field(3))),
+         set(var(last), add_i64(field(2), field(3)))])],
+        [end([print([var(sum), var(last)])])])).
+
+test(parses_printf_binary_arg) :-
+    plawk_parse_string("{ printf \"%d\\n\", $2 + $3 * 2 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [printf(string("%d\n"),
+            [add_i64(field(2), mul_i64(field(3), int(2)))])])], [])).
+
+test(bare_fields_still_parse_as_slices) :-
+    plawk_parse_string("{ print $2, $3 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([field(2), field(3)])])], [])).
+
+test(legacy_primary_minus_constant_ast_unchanged) :-
+    plawk_parse_string("$1 == \"ERROR\" { print NR - 1, length($0) - 3 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([sub_i64(special('NR'), int(1)),
+                sub_i64(length(field(0)), int(3))])])], [])).
+
+test(arith_ir_guards_division) :-
+    plawk_parse_string("{ print $2 / $3 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_den_zero = icmp eq i64'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_lhs_min = icmp eq i64'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_safe_den = select i1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_raw = sdiv i64'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(arith_ir_nested_operands_get_unique_names) :-
+    plawk_parse_string("{ print index($2, \"a\") + index($3, \"b\") }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_lhs = call i64 @wam_atom_field_index_value(%Value %line, i64 2'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_rhs = call i64 @wam_atom_field_index_value(%Value %line, i64 3'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_prints_basic_binary_ops) :-
+    run_arith_print_smoke("{ print $2 + $3, $2 - $3, $2 * $3 }\n",
+        "x 7 2\ny 10 5\n",
+        "9 5 14\n15 5 50\n").
+
+test(surface_precedence_and_parens) :-
+    run_arith_print_smoke("{ print ($2 + $3) * $4, $2 + $3 * $4 }\n",
+        "x 2 3 4\n",
+        "20 14\n").
+
+test(surface_division_and_modulo) :-
+    run_arith_print_smoke("{ print $2 / $3, $2 % $3 }\n",
+        "a 7 2\nb -7 2\n",
+        "3 1\n-3 -1\n").
+
+test(surface_division_by_zero_yields_zero) :-
+    run_arith_print_smoke("{ print $2 / $3, $2 % $3 }\n",
+        "a 7 0\n",
+        "0 0\n").
+
+test(surface_int64_min_overflow_division_is_defined) :-
+    run_arith_print_smoke("{ print $2 / $3, $2 % $3 }\n",
+        "a -9223372036854775808 -1\n",
+        "-9223372036854775808 0\n").
+
+test(surface_nonnumeric_fields_coerce_to_zero) :-
+    run_arith_print_smoke("{ print $2 + $3 }\n",
+        "a nope 5\nb 3 4\n",
+        "5\n7\n").
+
+test(surface_scalar_accumulates_binary_expr) :-
+    run_arith_print_smoke("{ sum += $2 * $3 } END { print sum }\n",
+        "a 2 3\nb 4 5\n",
+        "26\n").
+
+test(surface_guarded_rule_prints_nr_nf_arithmetic) :-
+    run_arith_print_smoke("$1 == \"ERROR\" { print NR * 10 + NF }\n",
+        "INFO a\nERROR b c\n",
+        "23\n").
+
+test(surface_printf_binary_arg) :-
+    run_arith_print_smoke("{ printf \"%d;\", $2 + $3 * 2 }\n",
+        "x 1 2\ny 3 4\n",
+        "5;11;").
+
+test(surface_constant_operands_with_nf) :-
+    run_arith_print_smoke("{ print 100 / NF, NF % 2 }\n",
+        "a b c d\nx y z\n",
+        "25 0\n33 1\n").
+
+run_arith_print_smoke(Source, Input, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_arith_exprs', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_arith_exprs.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_arith_marker/0 ],
+        [module_name('plawk_surface_arith_exprs')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_arith_exprs_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[plawk surface arith exprs output]~n~w~n",
+              [OutStr]),
+       throw(plawk_surface_arith_exprs_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_surface_arith_exprs).

--- a/tests/test_plawk_surface_pattern_combinators.pl
+++ b/tests/test_plawk_surface_pattern_combinators.pl
@@ -1,0 +1,177 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_patcomb_marker/0.
+
+user:plawk_patcomb_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_pattern_combinators, [condition(clang_available)]).
+
+test(parses_and_pattern) :-
+    plawk_parse_string("$1 == \"ERROR\" && $3 > 100 { print $0 }\n", Program),
+    assertion(Program == program([], [rule(
+        and_pat(field_eq(1, "ERROR"), field_cmp(3, gt, 100)),
+        [print([field(0)])])], [])).
+
+test(parses_or_pattern) :-
+    plawk_parse_string("/^ERROR/ || /^WARN/ { print $1 }\n", Program),
+    assertion(Program == program([], [rule(
+        or_pat(prefix("ERROR"), prefix("WARN")),
+        [print([field(1)])])], [])).
+
+test(parses_not_pattern) :-
+    plawk_parse_string("!/disk/ { print $0 }\n", Program),
+    assertion(Program == program([], [rule(
+        not_pat(contains("disk")),
+        [print([field(0)])])], [])).
+
+test(parses_and_binds_tighter_than_or) :-
+    plawk_parse_string("$1 == \"A\" || $1 == \"B\" && $3 > 5 { h++ } END { print h }\n", Program),
+    assertion(Program == program([], [rule(
+        or_pat(field_eq(1, "A"), and_pat(field_eq(1, "B"), field_cmp(3, gt, 5))),
+        [inc(var(h))])],
+        [end([print([var(h)])])])).
+
+test(parses_parenthesized_grouping) :-
+    plawk_parse_string("($1 == \"A\" || $1 == \"B\") && $3 > 5 { h++ } END { print h }\n", Program),
+    assertion(Program == program([], [rule(
+        and_pat(or_pat(field_eq(1, "A"), field_eq(1, "B")), field_cmp(3, gt, 5)),
+        [inc(var(h))])],
+        [end([print([var(h)])])])).
+
+test(parses_not_parenthesized_pattern) :-
+    plawk_parse_string("!($1 == \"ERROR\") { ok++ } END { print ok }\n", Program),
+    assertion(Program == program([], [rule(
+        not_pat(field_eq(1, "ERROR")),
+        [inc(var(ok))])],
+        [end([print([var(ok)])])])).
+
+test(parses_left_associative_and_chain) :-
+    plawk_parse_string("$1 == \"A\" && $3 > 5 && $3 < 10 { h++ } END { print h }\n", Program),
+    assertion(Program == program([], [rule(
+        and_pat(and_pat(field_eq(1, "A"), field_cmp(3, gt, 5)), field_cmp(3, lt, 10)),
+        [inc(var(h))])],
+        [end([print([var(h)])])])).
+
+test(parses_combined_if_condition) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\" && $3 > 100) { big++ } else { small++ } } END { print big, small }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [if(and_pat(field_eq(1, "ERROR"), field_cmp(3, gt, 100)),
+            [inc(var(big))],
+            [inc(var(small))])])],
+        [end([print([var(big), var(small)])])])).
+
+test(combined_guard_ir_is_single_block) :-
+    plawk_parse_string("$1 == \"ERROR\" && $3 > 100 { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%is_match_l = call i1 @wam_atom_field_eq_value'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%is_match_r = call i1 @wam_atom_field_i64_cmp_value'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%is_match = and i1 %is_match_l, %is_match_r'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(not_guard_ir_uses_xor) :-
+    plawk_parse_string("!/disk/ { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%is_match = xor i1 %is_match_n, true'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_and_pattern_filters_records) :-
+    run_patcomb_print_smoke("$1 == \"ERROR\" && $3 > 100 { print $0 }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "ERROR net 200\n").
+
+test(surface_or_pattern_matches_either) :-
+    run_patcomb_print_smoke("/^ERROR/ || /^WARN/ { print $1, $3 }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "ERROR 50\nERROR 200\nWARN 300\n").
+
+test(surface_not_pattern_inverts_match) :-
+    run_patcomb_print_smoke("!/disk/ { print $1 }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "ERROR\nWARN\nINFO\n").
+
+test(surface_precedence_and_over_or) :-
+    % INFO 100 matches `INFO || (WARN && >250)` but not `(INFO || WARN) && >250`.
+    run_patcomb_print_smoke("$1 == \"INFO\" || $1 == \"WARN\" && $3 > 250 { hits++ } END { print hits }\n",
+        "ERROR disk 50\nWARN cpu 300\nINFO ok 100\nWARN io 200\n",
+        "2\n").
+
+test(surface_parens_group_or_before_and) :-
+    run_patcomb_print_smoke("($1 == \"INFO\" || $1 == \"WARN\") && $3 > 250 { hits++ } END { print hits }\n",
+        "ERROR disk 50\nWARN cpu 300\nINFO ok 100\nWARN io 200\n",
+        "1\n").
+
+test(surface_combined_if_condition_updates_slots) :-
+    run_patcomb_print_smoke("{ if ($1 == \"ERROR\" && $3 > 100) { big++ } else { small++ } } END { print big, small }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "1 3\n").
+
+test(surface_or_pattern_guards_assoc_counts) :-
+    run_patcomb_print_smoke("$1 == \"ERROR\" || $1 == \"WARN\" { counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "2 1\n").
+
+test(surface_not_field_eq_counts_others) :-
+    run_patcomb_print_smoke("!($1 == \"ERROR\") { ok++ } END { print ok }\n",
+        "ERROR disk 50\nERROR net 200\nWARN cpu 300\nINFO ok 400\n",
+        "2\n").
+
+test(surface_left_associative_and_chain_range) :-
+    run_patcomb_print_smoke("$1 == \"WARN\" && $3 > 100 && $3 < 250 { print $2 }\n",
+        "WARN cpu 300\nWARN io 200\nWARN net 50\nERROR disk 200\n",
+        "io\n").
+
+run_patcomb_print_smoke(Source, Input, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_pattern_combinators', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_pattern_combinators.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_patcomb_marker/0 ],
+        [module_name('plawk_surface_pattern_combinators')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_pattern_combinators_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[plawk surface pattern combinators output]~n~w~n",
+              [OutStr]),
+       throw(plawk_surface_pattern_combinators_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_surface_pattern_combinators).

--- a/tests/test_plawk_surface_stdin_input.pl
+++ b/tests/test_plawk_surface_stdin_input.pl
@@ -1,0 +1,178 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_stdin_marker/0.
+
+user:plawk_stdin_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_stdin_input, [condition(clang_available)]).
+
+test(stdin_driver_emits_argv_main) :-
+    plawk_parse_string("$1 == \"ERROR\" { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv, DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define i32 @main(i32 %argc, i8** %argv)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_stream_open_fd_value(i64 0)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.wam_stream_stdin_dash = private constant [2 x i8] c"-\\00"'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@.wam_stream_input_path')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(stdin_driver_keeps_check_handle_value_phi_predecessor) :-
+    % Scalar loop phis name %check_handle_value as the loop entry
+    % predecessor; the argv/stdin main must preserve that block label.
+    plawk_parse_string("$1 == \"ERROR\" { count++ } END { print count }\n", Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv, DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%slot_0 = phi i64 [0, %check_handle_value], [%next_slot_0, %continue_loop]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_stream_open_value(%Value %path)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_stream_open_fd_value(i64 0)'))),
+    !.
+
+test(concrete_path_driver_unchanged) :-
+    plawk_parse_string("$1 == \"ERROR\" { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define i32 @main() {'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.wam_stream_input_path'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_stream_open_fd_value')),
+    !.
+
+test(stdin_print_rule_reads_all_input_modes) :-
+    run_stdin_smoke("$1 == \"ERROR\" { print $0 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "ERROR disk full\nERROR net down\n").
+
+test(stdin_scalar_end_reads_all_input_modes) :-
+    run_stdin_smoke("$1 == \"ERROR\" { count++ } END { print count }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "2\n").
+
+test(stdin_assoc_end_reads_all_input_modes) :-
+    run_stdin_smoke("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "2 1\n").
+
+test(stdin_forin_end_reads_all_input_modes) :-
+    run_stdin_smoke_sorted("{ counts[$1]++ } END { for (k in counts) print k, counts[k] }\n",
+        "INFO boot ok\nERROR disk full\nERROR net down\n",
+        ["ERROR 2", "INFO 1"]).
+
+test(stdin_missing_file_exits_with_open_failure) :-
+    build_stdin_binary("$1 == \"ERROR\" { print $0 }\n", _Dir, BinPath),
+    format(atom(Cmd), '~w /nonexistent_plawk_input_file', [BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, Status),
+    assertion(Status == exit(10)),
+    !.
+
+build_stdin_binary(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_stdin_input', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_stdin_input.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_stdin_marker/0 ],
+        [module_name('plawk_surface_stdin_input')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_stdin_input_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk stdin input build output]~n~w~n", [BuildOut]),
+       throw(plawk_surface_stdin_input_build_failed(Status))
+    ).
+
+% One binary, four awk-style invocations: an argv path, stdin
+% redirection, the "-" stdin alias, and a shell pipe.
+run_stdin_smoke(Source, Input, ExpectedOutput) :-
+    build_stdin_binary(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    forall(member(Mode, [argv, redirect, dash, pipe]),
+        ( run_stdin_mode(Mode, BinPath, InputPath, OutStr),
+          ( OutStr == ExpectedOutput
+          -> true
+          ;  format(user_error,
+                 "~n[plawk stdin input ~w mode output]~nexpected: ~q~ngot: ~q~n",
+                 [Mode, ExpectedOutput, OutStr]),
+             throw(plawk_surface_stdin_input_mode_failed(Mode))
+          )
+        )),
+    !.
+
+run_stdin_smoke_sorted(Source, Input, ExpectedSortedLines) :-
+    build_stdin_binary(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    maplist(atom_string, ExpectedSortedLines, ExpectedStrings0),
+    msort(ExpectedStrings0, ExpectedStrings),
+    forall(member(Mode, [argv, redirect, dash, pipe]),
+        ( run_stdin_mode(Mode, BinPath, InputPath, OutStr),
+          split_string(OutStr, "\n", "", Lines0),
+          exclude(==(""), Lines0, Lines),
+          msort(Lines, SortedLines),
+          ( SortedLines == ExpectedStrings
+          -> true
+          ;  format(user_error,
+                 "~n[plawk stdin input ~w mode output]~nexpected: ~q~ngot: ~q~n",
+                 [Mode, ExpectedStrings, SortedLines]),
+             throw(plawk_surface_stdin_input_mode_failed(Mode))
+          )
+        )),
+    !.
+
+run_stdin_mode(Mode, BinPath, InputPath, OutStr) :-
+    stdin_mode_command(Mode, BinPath, InputPath, Cmd),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk stdin input ~w mode output]~n~w~n",
+              [Mode, OutStr]),
+       throw(plawk_surface_stdin_input_run_failed(Mode, Status))
+    ).
+
+stdin_mode_command(argv, BinPath, InputPath, Cmd) :-
+    format(atom(Cmd), '~w ~w', [BinPath, InputPath]).
+stdin_mode_command(redirect, BinPath, InputPath, Cmd) :-
+    format(atom(Cmd), '~w < ~w', [BinPath, InputPath]).
+stdin_mode_command(dash, BinPath, InputPath, Cmd) :-
+    format(atom(Cmd), '~w - < ~w', [BinPath, InputPath]).
+stdin_mode_command(pipe, BinPath, InputPath, Cmd) :-
+    format(atom(Cmd), 'cat ~w | ~w', [InputPath, BinPath]).
+
+:- end_tests(plawk_surface_stdin_input).


### PR DESCRIPTION
## Summary

**Consolidation PR — no new content, just delivery.** When the previous stack was merged, #3397, #3398, and #3399 merged into their stacked *base branches* before those bases were retargeted, so only #3396 (END for-in) actually reached `main`. This PR carries the remaining already-reviewed content to `main`:

- #3397 — plawk: runtime input path via argv with stdin default
- #3398 — plawk: general native i64 arithmetic with precedence
- #3399 — plawk: pattern combinators `&&` `||` `!` with awk precedence

The tree at this branch's tip is **byte-identical** to `claude/plawk-llvm-wam-hybrid-p9ujut-3` (the branch that accumulated the full stack), merged with current `main`. All suites passed on exactly this content: `test_plawk_surface_stdin_input` (8), `test_plawk_surface_arith_exprs` (22), `test_plawk_surface_pattern_combinators` (19), plus `test_plawk_surface_prefix_print`, `test_plawk_surface_forin_end_print`, and the 80-test `test_wam_llvm_target` suite.

The next feature series (ERE regex, END arithmetic, else-less if, Prolog foreign calls, doubles) will stack on top of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_