### PR TITLE
plawk: POSIX ERE matching via ~ and !~ with libc regcomp

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -296,6 +296,14 @@ group) in both rule guards and `if` conditions. The base guards are
 side-effect-free straight-line native checks, so combined guards lower to
 bitwise `i1` `and`/`or`/`xor` over per-subpattern `_l`/`_r`/`_n` suffixed
 names, keeping the whole guard a single block with no extra branches.
+POSIX ERE matching (`$N ~ /re/`, `$N !~ /re/`, and bare `/re/` with
+metacharacters, AST `field_match(Index, Regex)`) lowers through the
+`@wam_regex_field_match` runtime helper: each match site owns a string
+global plus a cache slot holding a lazily `regcomp`ed (`REG_EXTENDED`)
+`regex_t`; field slices are copied into a growable NUL-terminated scratch
+buffer for `regexec`, and `$0` matches use the atom's C string directly.
+Metacharacter-free bare patterns keep the prefix/contains fast paths, so
+existing programs lower unchanged.
 The parser itself is factored as `@wam_atom_field_i64_value`, returning a value
 plus success flag, so the same machinery also feeds scalar expressions such as
 `bytes += $3` and `last = $3`; PLAWK uses zero for failed numeric coercions in

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -76,6 +76,7 @@ swipl -q -s tests/test_plawk_surface_forin_end_print.pl -g "setenv('UW_SMOKE_TMP
 swipl -q -s tests/test_plawk_surface_stdin_input.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_arith_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_pattern_combinators.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_regex_match.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -113,6 +114,15 @@ streaming loop. Patterns compose with `&&`, `||`, and `!` using awk precedence
 and `!/disk/ { print $0 }`. Combined guards lower to straight-line bitwise
 `i1` ops over the existing native guard helpers — no extra branches — and the
 same combinators work in `if (...)` conditions.
+POSIX ERE matching is available through awk's match operators `$N ~ /re/` and
+`$N !~ /re/` (with `$0` for the whole record) and through bare `/re/` patterns
+containing ERE metacharacters, e.g. `$2 ~ /^d[io]sk$/ { print $0 }` and
+`/ERROR|WARN/ { print $1 }`. Bare patterns with no metacharacters keep their
+existing fast native lowerings (`/^ERROR/` stays a prefix check, `/disk/` a
+byte search); `\/` escapes a literal slash. Regexes are compile-time constants
+compiled once per match site with libc `regcomp` (`REG_EXTENDED`) and cached;
+a pattern that fails to compile never matches. Match operators work in rule
+guards, `if` conditions, and `&&`/`||`/`!` combinations.
 Scalar state works with `$1 ==
 "ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -8,6 +8,7 @@
 :- use_module('../../../src/unifyweaver/targets/wam_llvm_target',
     [llvm_emit_atom_prefix_guard/5,
      llvm_emit_atom_field_eq_guard/7,
+     llvm_emit_regex_field_match_guard/7,
      llvm_emit_atom_field_slice/5,
      llvm_emit_atom_field_count/4,
      llvm_emit_atom_field_length/5,
@@ -2102,6 +2103,9 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, ''-GuardCall
     plawk_field_cmp_op_code(Op, OpCode),
     llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
         FieldSeparator, '%is_match', GuardCallIR).
+plawk_pattern_guard_ir(field_match(Index, Regex), FieldSeparator, GuardIR) :-
+    llvm_emit_regex_field_match_guard(plawk_surface_regex, '%line', Index,
+        Regex, FieldSeparator, '%is_match', GuardIR).
 plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardIR) :-
     plawk_combined_pattern(Pattern),
     plawk_pattern_guard_ir(Pattern, FieldSeparator, plawk_surface_pattern,
@@ -2138,6 +2142,9 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, _GlobalBase,
     plawk_field_cmp_op_code(Op, OpCode),
     llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
         FieldSeparator, MatchValue, GuardCallIR).
+plawk_pattern_guard_ir(field_match(Index, Regex), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
+    llvm_emit_regex_field_match_guard(GlobalBase, '%line', Index, Regex,
+        FieldSeparator, MatchValue, GuardIR).
 plawk_pattern_guard_ir(and_pat(Left, Right), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     plawk_binary_pattern_guard_ir(and, Left, Right, FieldSeparator, GlobalBase,
         MatchValue, GuardIR).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -132,10 +132,10 @@ not_pattern(Pattern) -->
     base_pattern(Pattern).
 
 base_pattern(Pattern) -->
-    prefix_pattern(Pattern),
+    slash_regex_pattern(Pattern),
     !.
 base_pattern(Pattern) -->
-    literal_pattern(Pattern),
+    field_match_pattern(Pattern),
     !.
 base_pattern(Pattern) -->
     field_i64_cmp_pattern(Pattern),
@@ -143,20 +143,93 @@ base_pattern(Pattern) -->
 base_pattern(Pattern) -->
     field_eq_pattern(Pattern).
 
-prefix_pattern(prefix(Prefix)) -->
-    "/^",
-    prefix_codes(Codes),
+%% slash_regex_pattern(-Pattern)//
+%
+%  A bare /re/ pattern matches the whole record, as in awk. Bodies with
+%  no ERE metacharacters keep their existing fast native lowerings: a
+%  leading ^ plus a literal rest stays prefix/1 and an all-literal body
+%  stays contains/1. Anything else becomes field_match(0, Regex) and is
+%  matched with POSIX ERE at runtime.
+slash_regex_pattern(Pattern) -->
+    "/",
+    regex_body_codes(Codes),
     "/",
     { Codes \== [],
-      string_codes(Prefix, Codes)
+      classify_regex_codes(Codes, Pattern)
     }.
 
-literal_pattern(contains(Literal)) -->
+classify_regex_codes([0'^ | Rest], prefix(Prefix)) :-
+    Rest \== [],
+    \+ ere_metachar_in_codes(Rest),
+    !,
+    string_codes(Prefix, Rest).
+classify_regex_codes(Codes, contains(Literal)) :-
+    \+ ere_metachar_in_codes(Codes),
+    !,
+    string_codes(Literal, Codes).
+classify_regex_codes(Codes, field_match(0, Regex)) :-
+    string_codes(Regex, Codes).
+
+ere_metachar_in_codes(Codes) :-
+    member(Code, Codes),
+    memberchk(Code, [0'., 0'[, 0'], 0'(, 0'), 0'*, 0'+, 0'?,
+                     0'{, 0'}, 0'|, 0'^, 0'$, 0'\\]),
+    !.
+
+%% field_match_pattern(-Pattern)//
+%
+%  awk's match operators: $N ~ /re/ and $N !~ /re/. $0 works via
+%  field index 0. !~ reuses the combinator AST as not_pat(field_match).
+field_match_pattern(Pattern) -->
+    "$",
+    integer_codes(IndexCodes),
+    ws,
+    match_operator(Negated),
+    ws,
     "/",
-    literal_pattern_codes(Codes),
+    regex_body_codes(Codes),
     "/",
-    { Codes \== [],
-      string_codes(Literal, Codes)
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0,
+      Codes \== [],
+      string_codes(Regex, Codes),
+      (   Negated == false
+      ->  Pattern = field_match(Index, Regex)
+      ;   Pattern = not_pat(field_match(Index, Regex))
+      )
+    }.
+
+match_operator(true) -->
+    "!~".
+match_operator(false) -->
+    "~".
+
+%% regex_body_codes(-Codes)//
+%
+%  Codes between the pattern slashes. Backslash pairs pass through
+%  unchanged so ERE escapes like \. reach regcomp, except \/ which
+%  unescapes to a literal slash.
+regex_body_codes([Code | Codes]) -->
+    regex_body_code(Code),
+    regex_body_codes_rest(Codes).
+
+regex_body_codes_rest(Codes) -->
+    regex_body_code(Code),
+    !,
+    { Codes = [Code | Rest] },
+    regex_body_codes_rest(Rest).
+regex_body_codes_rest([]) -->
+    [].
+
+regex_body_code(0'/) -->
+    "\\/",
+    !.
+regex_body_code(Code) -->
+    [Code],
+    { Code =\= 0'/,
+      Code =\= 0'\n,
+      Code =\= 0'\r
     }.
 
 field_eq_pattern(field_eq(Index, Value)) -->
@@ -198,43 +271,6 @@ numeric_cmp_op(lt) -->
 numeric_cmp_op(gt) -->
     ">".
 
-prefix_codes([Code | Codes]) -->
-    [Code],
-    { Code =\= 0'/,
-      Code =\= 0'\n,
-      Code =\= 0'\r
-    },
-    prefix_codes_rest(Codes).
-
-prefix_codes_rest([Code | Codes]) -->
-    [Code],
-    { Code =\= 0'/,
-      Code =\= 0'\n,
-      Code =\= 0'\r
-    },
-    !,
-    prefix_codes_rest(Codes).
-prefix_codes_rest([]) -->
-    [].
-
-literal_pattern_codes([Code | Codes]) -->
-    [Code],
-    { Code =\= 0'/,
-      Code =\= 0'\n,
-      Code =\= 0'\r
-    },
-    literal_pattern_codes_rest(Codes).
-
-literal_pattern_codes_rest([Code | Codes]) -->
-    [Code],
-    { Code =\= 0'/,
-      Code =\= 0'\n,
-      Code =\= 0'\r
-    },
-    !,
-    literal_pattern_codes_rest(Codes).
-literal_pattern_codes_rest([]) -->
-    [].
 
 integer_codes([Code | Codes]) -->
     [Code],

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -47,6 +47,7 @@
     split_functor_arity/3,               % +Str, -Name, -Arity (handles `/` in name)
     llvm_emit_atom_prefix_guard/5,       % +GlobalBase, +ValueIR, +Prefix, +ResultIR, -GlobalIR-CallIR
     llvm_emit_atom_field_eq_guard/7,     % +GlobalBase, +ValueIR, +FieldIndex, +Expected, +SepCode, +ResultIR, -GlobalIR-CallIR
+    llvm_emit_regex_field_match_guard/7, % +GlobalBase, +ValueIR, +FieldIndex, +Regex, +SepCode, +ResultIR, -GlobalIR-CallIR
     llvm_emit_atom_field_slice/5,        % +ValueIR, +FieldIndex, +SepCode, +SliceBase, -CallIR
     llvm_emit_atom_field_count/4,        % +ValueIR, +SepCode, +CountBase, -CallIR
     llvm_emit_atom_field_length/5,       % +ValueIR, +FieldIndex, +SepCode, +LengthBase, -CallIR
@@ -1613,7 +1614,9 @@ declare i64 @mktime(i8*)
 declare double @asin(double)
 declare double @acos(double)
 declare double @atan(double)
-declare double @atan2(double, double)'
+declare double @atan2(double, double)
+declare i32 @regcomp(i8*, i8*, i32)
+declare i32 @regexec(i8*, i8*, i64, i8*, i32)'
     ).
 
 %% generate_wasm_exports(+Predicates, -ExportCode)
@@ -4382,6 +4385,110 @@ vat.read:
 
 vat.miss:
   ret i64 0
+}
+
+; POSIX ERE matching over atom-backed text records. Patterns are
+; compile-time constants; each match site owns a cache slot holding a
+; lazily regcomp()ed regex_t. The regex_t is malloc''d at 512 bytes,
+; comfortably above sizeof(regex_t) on glibc (64), musl, and the BSDs.
+; cflags is REG_EXTENDED (1 on all common libcs); REG_NOSUB is skipped
+; because its value differs across libcs and it is only an optimization.
+@wam_regex_field_buf = internal global i8* null
+@wam_regex_field_cap = internal global i64 0
+
+define i1 @wam_regex_field_match(%Value %line, i64 %field_index, i8 %sep, i8* %pattern, i8** %cache_slot) {
+entry:
+  %cached = load i8*, i8** %cache_slot
+  %have = icmp ne i8* %cached, null
+  br i1 %have, label %rgx.have_regex, label %rgx.compile
+
+rgx.compile:
+  %mem = call i8* @malloc(i64 512)
+  %mem_null = icmp eq i8* %mem, null
+  br i1 %mem_null, label %rgx.fail, label %rgx.do_comp
+
+rgx.do_comp:
+  %comp_rc = call i32 @regcomp(i8* %mem, i8* %pattern, i32 1)
+  %comp_ok = icmp eq i32 %comp_rc, 0
+  br i1 %comp_ok, label %rgx.store_regex, label %rgx.comp_fail
+
+rgx.comp_fail:
+  call void @free(i8* %mem)
+  br label %rgx.fail
+
+rgx.store_regex:
+  store i8* %mem, i8** %cache_slot
+  br label %rgx.have_regex
+
+rgx.have_regex:
+  %preg = load i8*, i8** %cache_slot
+  %is_whole = icmp eq i64 %field_index, 0
+  br i1 %is_whole, label %rgx.match_whole, label %rgx.match_field
+
+rgx.match_whole:
+  %aid = call i64 @value_payload(%Value %line)
+  %line_s = call i8* @wam_atom_to_string(i64 %aid)
+  %line_null = icmp eq i8* %line_s, null
+  br i1 %line_null, label %rgx.fail, label %rgx.exec_whole
+
+rgx.exec_whole:
+  %exec_rc_w = call i32 @regexec(i8* %preg, i8* %line_s, i64 0, i8* null, i32 0)
+  %match_w = icmp eq i32 %exec_rc_w, 0
+  ret i1 %match_w
+
+rgx.match_field:
+  %slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 %field_index, i8 %sep)
+  %fptr = extractvalue %WamSlice %slice, 0
+  %flen = extractvalue %WamSlice %slice, 1
+  %missing = icmp eq i8* %fptr, null
+  br i1 %missing, label %rgx.fail, label %rgx.ensure_buf
+
+rgx.ensure_buf:
+  ; Field slices are not NUL-terminated; copy into a growable scratch
+  ; buffer so regexec sees a C string.
+  %need = add i64 %flen, 1
+  %cap = load i64, i64* @wam_regex_field_cap
+  %fits = icmp ule i64 %need, %cap
+  br i1 %fits, label %rgx.copy, label %rgx.grow
+
+rgx.grow:
+  %old_buf = load i8*, i8** @wam_regex_field_buf
+  %new_cap = shl i64 %need, 1
+  %new_buf = call i8* @realloc(i8* %old_buf, i64 %new_cap)
+  %grow_null = icmp eq i8* %new_buf, null
+  br i1 %grow_null, label %rgx.fail, label %rgx.store_buf
+
+rgx.store_buf:
+  store i8* %new_buf, i8** @wam_regex_field_buf
+  store i64 %new_cap, i64* @wam_regex_field_cap
+  br label %rgx.copy
+
+rgx.copy:
+  %buf = load i8*, i8** @wam_regex_field_buf
+  br label %rgx.copy_loop
+
+rgx.copy_loop:
+  %ci = phi i64 [ 0, %rgx.copy ], [ %ci1, %rgx.copy_step ]
+  %copy_done = icmp uge i64 %ci, %flen
+  br i1 %copy_done, label %rgx.terminate, label %rgx.copy_step
+
+rgx.copy_step:
+  %src_p = getelementptr i8, i8* %fptr, i64 %ci
+  %dst_p = getelementptr i8, i8* %buf, i64 %ci
+  %byte = load i8, i8* %src_p
+  store i8 %byte, i8* %dst_p
+  %ci1 = add i64 %ci, 1
+  br label %rgx.copy_loop
+
+rgx.terminate:
+  %end_p = getelementptr i8, i8* %buf, i64 %flen
+  store i8 0, i8* %end_p
+  %exec_rc_f = call i32 @regexec(i8* %preg, i8* %buf, i64 0, i8* null, i32 0)
+  %match_f = icmp eq i32 %exec_rc_f, 0
+  ret i1 %match_f
+
+rgx.fail:
+  ret i1 false
 }
 
 define %Value @wam_stream_fail_value() alwaysinline nounwind {
@@ -17065,6 +17172,30 @@ llvm_emit_atom_field_eq_guard(GlobalBase, ValueIR, FieldIndex, Expected, SepCode
         '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0~n  ~w = call i1 @wam_atom_field_eq_value(%Value ~w, i64 ~w, i8* %~w_ptr, i64 ~w, i8 ~w)',
         [SafeBase, ArrLen, ArrLen, SafeBase,
          ResultIR, ValueIR, FieldIndex, SafeBase, ExpectedLen, SepCode]).
+
+%% llvm_emit_regex_field_match_guard(+GlobalBase, +ValueIR, +FieldIndex, +Regex, +SepCode, +ResultIR, -GlobalIR-CallIR)
+%
+%  Emit a native POSIX ERE guard over an atom-backed text record.
+%  FieldIndex 0 matches the whole record; positive indexes match the
+%  projected field slice. The pattern is emitted as a string global
+%  plus a per-site cache slot holding the lazily compiled regex_t;
+%  matching happens in the @wam_regex_field_match runtime helper. A
+%  pattern that fails to compile never matches.
+llvm_emit_regex_field_match_guard(GlobalBase, ValueIR, FieldIndex, Regex, SepCode, ResultIR, GlobalIR-CallIR) :-
+    integer(FieldIndex),
+    FieldIndex >= 0,
+    sanitize_functor_for_llvm(GlobalBase, SafeBase),
+    escape_llvm_string(Regex, EscapedRegex, RegexLen),
+    ArrLen is RegexLen + 1,
+    format(atom(GlobalIR),
+'@.~w = private constant [~w x i8] c"~w\\00"
+@~w_regex_cache = internal global i8* null',
+        [SafeBase, ArrLen, EscapedRegex, SafeBase]),
+    format(atom(CallIR),
+'  %~w_pat_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0
+  ~w = call i1 @wam_regex_field_match(%Value ~w, i64 ~w, i8 ~w, i8* %~w_pat_ptr, i8** @~w_regex_cache)',
+        [SafeBase, ArrLen, ArrLen, SafeBase,
+         ResultIR, ValueIR, FieldIndex, SepCode, SafeBase, SafeBase]).
 
 %% llvm_emit_atom_field_slice(+ValueIR, +FieldIndex, +SepCode, +SliceBase, -CallIR)
 %

--- a/tests/test_plawk_surface_regex_match.pl
+++ b/tests/test_plawk_surface_regex_match.pl
@@ -1,0 +1,176 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_regex_marker/0.
+
+user:plawk_regex_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_regex_match, [condition(clang_available)]).
+
+test(parses_field_match_pattern) :-
+    plawk_parse_string("$2 ~ /^d[io]sk$/ { print $0 }\n", Program),
+    assertion(Program == program([], [rule(field_match(2, "^d[io]sk$"),
+        [print([field(0)])])], [])).
+
+test(parses_negated_field_match_pattern) :-
+    plawk_parse_string("$2 !~ /^d/ { count++ } END { print count }\n", Program),
+    assertion(Program == program([], [rule(not_pat(field_match(2, "^d")),
+        [inc(var(count))])],
+        [end([print([var(count)])])])).
+
+test(parses_whole_record_match_via_field_zero) :-
+    plawk_parse_string("$0 ~ /E..OR/ { print $1 }\n", Program),
+    assertion(Program == program([], [rule(field_match(0, "E..OR"),
+        [print([field(1)])])], [])).
+
+test(bare_regex_with_metachars_becomes_field_match) :-
+    plawk_parse_string("/ERROR|WARN/ { print $1 }\n", Program),
+    assertion(Program == program([], [rule(field_match(0, "ERROR|WARN"),
+        [print([field(1)])])], [])).
+
+test(literal_prefix_pattern_keeps_fast_path_ast) :-
+    plawk_parse_string("/^ERROR/ { print $0 }\n", Program),
+    assertion(Program == program([], [rule(prefix("ERROR"),
+        [print([field(0)])])], [])).
+
+test(literal_contains_pattern_keeps_fast_path_ast) :-
+    plawk_parse_string("/disk/ { print $0 }\n", Program),
+    assertion(Program == program([], [rule(contains("disk"),
+        [print([field(0)])])], [])).
+
+test(anchored_prefix_with_metachars_becomes_regex) :-
+    plawk_parse_string("/^ERR.R/ { print $0 }\n", Program),
+    assertion(Program == program([], [rule(field_match(0, "^ERR.R"),
+        [print([field(0)])])], [])).
+
+test(escaped_slash_unescapes_into_literal) :-
+    plawk_parse_string("/a\\/b/ { print $0 }\n", Program),
+    assertion(Program == program([], [rule(contains("a/b"),
+        [print([field(0)])])], [])).
+
+test(parses_regex_in_combined_pattern) :-
+    plawk_parse_string("$1 == \"ERROR\" && $2 ~ /net|disk/ { hits++ } END { print hits }\n", Program),
+    assertion(Program == program([], [rule(
+        and_pat(field_eq(1, "ERROR"), field_match(2, "net|disk")),
+        [inc(var(hits))])],
+        [end([print([var(hits)])])])).
+
+test(parses_regex_in_if_condition) :-
+    plawk_parse_string("{ if ($2 ~ /^d/) { d++ } else { o++ } } END { print d, o }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [if(field_match(2, "^d"), [inc(var(d))], [inc(var(o))])])],
+        [end([print([var(d), var(o)])])])).
+
+test(regex_guard_ir_uses_runtime_matcher) :-
+    plawk_parse_string("$2 ~ /^d[io]sk$/ { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_regex_field_match(%Value %line, i64 2, i8 32'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_regex_cache = internal global i8* null'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(regex_guards_in_one_rule_get_unique_caches) :-
+    plawk_parse_string("$2 ~ /^d/ && $3 ~ /full/ { hits++ } END { print hits }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_5Fl_regex_cache = internal global i8* null'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_5Fr_regex_cache = internal global i8* null'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_field_regex_matches_character_class) :-
+    run_regex_print_smoke("$2 ~ /^d[io]sk$/ { print $0 }\n",
+        "ERROR disk full\nERROR dosk odd\nWARN desk hot\nINFO disks many\n",
+        "ERROR disk full\nERROR dosk odd\n").
+
+test(surface_negated_field_regex_counts_nonmatches) :-
+    run_regex_print_smoke("$2 !~ /^d/ { others++ } { total++ } END { print others, total }\n",
+        "ERROR disk a\nWARN cpu b\nINFO net c\n",
+        "2 3\n").
+
+test(surface_bare_regex_alternation_matches_whole_record) :-
+    run_regex_print_smoke("/ERROR|WARN/ { print $1 }\n",
+        "ERROR a\nWARN b\nINFO c\nERRORS d\n",
+        "ERROR\nWARN\nERRORS\n").
+
+test(surface_dot_metachar_matches_any_byte) :-
+    run_regex_print_smoke("$0 ~ /E..OR/ { print $1 }\n",
+        "ERROR a\nEXXOR b\nWARN c\n",
+        "ERROR\nEXXOR\n").
+
+test(surface_regex_composes_with_field_eq_guard) :-
+    run_regex_print_smoke("$1 == \"ERROR\" && $2 ~ /net|disk/ { hits++ } END { print hits }\n",
+        "ERROR disk 1\nERROR cpu 2\nWARN net 3\nERROR net 4\n",
+        "2\n").
+
+test(surface_regex_in_if_condition_updates_slots) :-
+    run_regex_print_smoke("{ if ($2 ~ /^d/) { d++ } else { o++ } } END { print d, o }\n",
+        "a disk\nb cpu\nc desk\n",
+        "2 1\n").
+
+test(surface_regex_respects_field_separator) :-
+    run_regex_print_smoke("BEGIN { FS = \":\" } $2 ~ /^[0-9]+$/ { nums++ } END { print nums }\n",
+        "a:123\nb:12x\nc:9\n",
+        "2\n").
+
+test(surface_escaped_slash_matches_literal_slash) :-
+    run_regex_print_smoke("/a\\/b/ { print $1 }\n",
+        "x a/b here\ny ab there\n",
+        "x\n").
+
+test(surface_repetition_and_anchors) :-
+    run_regex_print_smoke("$2 ~ /^ab+c?$/ { print NR }\n",
+        "r1 abbc\nr2 ac\nr3 ab\nr4 abbbb\n",
+        "1\n3\n4\n").
+
+run_regex_print_smoke(Source, Input, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_regex_match', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_regex_match.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_regex_marker/0 ],
+        [module_name('plawk_surface_regex_match')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_regex_match_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[plawk surface regex match output]~n~w~n",
+              [OutStr]),
+       throw(plawk_surface_regex_match_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_surface_regex_match).


### PR DESCRIPTION
## Summary

**Stacked on #3401** (the consolidation PR). First feature of the new series.

Closes plawk's biggest awk-compatibility gap: real regular expressions. Previously the only "regex" forms were the `^prefix` shortcut and literal contains.

```awk
$2 ~ /^d[io]sk$/ { print $0 }          # character classes, anchors
$2 !~ /^d/ { others++ }                 # negated match
/ERROR|WARN/ { print $1 }               # alternation on $0
$1 == "ERROR" && $2 ~ /net|disk/ { hits++ }   # composes with combinators
{ if ($2 ~ /^d/) { d++ } else { o++ } }       # and if conditions
BEGIN { FS = ":" } $2 ~ /^[0-9]+$/ { nums++ } # anchors apply within the field
```

## Design

The runtime already links libc, so **`regcomp`/`regexec` were right there** — no regex engine to write or vendor.

**Runtime (`src/unifyweaver/targets/wam_llvm_target.pl`)**
- New `@wam_regex_field_match(line, field_index, sep, pattern, cache_slot)` helper. Patterns are compile-time constants; each match site owns a cache slot holding a lazily `regcomp`ed (`REG_EXTENDED`) `regex_t`, so compilation happens once per site per process.
- `regex_t` storage is a 512-byte malloc — comfortably above `sizeof(regex_t)` on glibc (64), musl, and the BSDs. `REG_NOSUB` is deliberately skipped: its numeric value differs across libcs and it's only an optimization.
- Field slices aren't NUL-terminated, so field matches copy into a growable scratch buffer; `$0` matches use the atom's C string directly. A pattern that fails to compile never matches.

**Emitter** — `llvm_emit_regex_field_match_guard/7` emits the guard as a straight-line call, so regexes compose with `&&`/`||`/`!` and `if` conditions **for free** through the existing single-block combinator lowering (verified: two regexes in one `&&` guard get distinct `_l`/`_r` cache slots).

**Parser (`examples/plawk/parser/plawk_parser.pl`)**
- `$N ~ /re/` and `$N !~ /re/` (AST `field_match(Index, Regex)`, with `!~` reusing `not_pat`); `$0` works via field index 0.
- Bare `/re/` classification: bodies with **no ERE metacharacters keep their existing fast native lowerings** (`/^ERROR/` stays `prefix/1`, `/disk/` stays `contains/1` — byte-identical ASTs), anything else becomes `field_match(0, Regex)`. `\/` escapes a literal slash; other backslash escapes pass through to `regcomp`.

**Tests (`tests/test_plawk_surface_regex_match.pl`)**
- 21 tests: classification ASTs (fast paths preserved), IR assertions (runtime matcher called, per-site caches unique, no `@run_loop`), and e2e binaries covering character classes, alternation, `.`, anchors-within-field-slices, repetition (`+`/`?`), custom `FS`, escaped slash, negated match, combined guards, and `if` conditions.

## Testing

- `tests/test_plawk_surface_regex_match.pl` — 21/21 pass
- Full regression: `test_plawk_surface_prefix_print`, `test_plawk_surface_pattern_combinators`, `test_plawk_surface_forin_end_print`, `test_plawk_surface_stdin_input`, `test_plawk_surface_arith_exprs`, and the 80-test `test_wam_llvm_target` — all pass

**Merge order note:** merge #3401 first, then retarget this PR to `main` (or merge it into the base branch and fast-forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_