### PR TITLE
plawk: END arithmetic and scalar variable reads

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -311,6 +311,13 @@ those scalar arithmetic contexts. That coercion is emitted through the
 target-side `llvm_emit_atom_field_i64_or_default/7` helper so future native
 numeric consumers can share the parse-plus-default lowering instead of
 rebuilding it in PLAWK-specific code.
+Scalar variables are readable inside rule-body update expressions and END
+prints: codegen substitutes `var(Name)` leaves with the current SSA slot
+value (an `ssa/1` leaf the shared emitters print verbatim) before emission,
+so `{ avg = $2 / 2; total += avg }` folds in source order with no extra
+state. END expressions substitute final slot values and map `NR` to
+`%plawk_nr`, the loop-head record phi (which dominates `end_print`), so
+`END { print sum / NR }` averages lower natively with guarded division.
 The scalar counter
 path threads a native `i64` loop variable and prints it from the `END` action. Multiple scalar counters
 become parallel `i64` phi slots in the native streaming loop.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -77,6 +77,7 @@ swipl -q -s tests/test_plawk_surface_stdin_input.pl -g "setenv('UW_SMOKE_TMPDIR'
 swipl -q -s tests/test_plawk_surface_arith_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_pattern_combinators.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_regex_match.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_end_scalar_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -181,6 +182,15 @@ Mixed scalar/associative state is
 supported in the same native loop, e.g. `{ total++; counts[$1]++ }` with an
 `END` print of both `total` and `counts["ERROR"]`. `END` print fields can also
 include literal labels such as `print "total", total, "errors", counts["ERROR"]`.
+`END` prints also take native `i64` arithmetic over final scalar values, `NR`
+(the final record count), and integer literals, so canonical reports such as
+`{ sum += $2 } END { print "avg", sum / NR }` lower natively; `NR` reads the
+loop-head record phi, and empty input divides to `0` through the shared
+guarded division. Scalar variables can also be read inside rule-body update
+expressions, e.g. `{ avg = $2 / 2; total += avg }` or `{ x = x + 2 }`;
+assignments apply in source order, a read before any write sees `0` (awk's
+uninitialized-variable semantics), and reads work across rules within the
+same record.
 `END` can also iterate an associative array with the canonical awk report
 idiom, e.g. `{ counts[$1]++ } END { for (k in counts) print k, counts[k] }`.
 The loop lowers to a native walk over the runtime table's occupied slots via

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1321,6 +1321,17 @@ plawk_mixed_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], ScalarP
     },
     [KeyPtr, KeyId, Value, FmtPtr, PrintCall],
     plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
+plawk_mixed_end_print_lines([special('NR') | Rest], ScalarPlan, AssocPlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
+    plawk_end_nr_print_lines(PrintIndex),
+    { NextPrintIndex is PrintIndex + 1 },
+    plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
+plawk_mixed_end_print_lines([Expr | Rest], ScalarPlan, AssocPlan, OutputSeparator, PrintIndex) -->
+    { plawk_end_scalar_expr(Expr) },
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
+    plawk_end_expr_print_lines(Expr, ScalarPlan, PrintIndex),
+    { NextPrintIndex is PrintIndex + 1 },
+    plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
 plawk_mixed_end_print_lines([string(Value) | Rest], ScalarPlan, AssocPlan, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     plawk_end_string_print_lines(Value, PrintIndex),
@@ -1328,6 +1339,9 @@ plawk_mixed_end_print_lines([string(Value) | Rest], ScalarPlan, AssocPlan, Outpu
     plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
 
 plawk_scalar_print_expr(var(Name), Name).
+plawk_scalar_print_expr(Expr, Name) :-
+    plawk_end_scalar_expr(Expr),
+    plawk_expr_scalar_read_name(Expr, Name).
 
 plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator,
         GlobalIR, ChainIR, RuleCount, BranchNextExits) :-
@@ -1557,6 +1571,87 @@ plawk_i64_operand_expr(Expr) :-
 plawk_i64_operand_expr(Expr) :-
     plawk_i64_general_binary_expr(Expr).
 
+%% plawk_i64_scalar_read_binary_expr(+Expr) is semidet.
+%
+%  Like plawk_i64_general_binary_expr but operands may also be scalar
+%  variable reads (var/1). Only usable where the emitter has the current
+%  slot values to substitute: scalar update expressions in rule bodies.
+plawk_i64_scalar_read_binary_expr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    plawk_i64_scalar_read_operand_expr(Left),
+    plawk_i64_scalar_read_operand_expr(Right).
+
+plawk_i64_scalar_read_operand_expr(var(Name)) :-
+    atom(Name).
+plawk_i64_scalar_read_operand_expr(Expr) :-
+    plawk_i64_operand_expr(Expr).
+plawk_i64_scalar_read_operand_expr(Expr) :-
+    plawk_i64_scalar_read_binary_expr(Expr).
+
+%% plawk_end_scalar_expr(+Expr) is semidet.
+%
+%  END-position i64 expression: a binary tree whose leaves are integer
+%  literals, scalar variables (final slot values), or NR (the final
+%  record count). Fields, NF, length etc. are meaningless after the
+%  stream closes and are rejected.
+plawk_end_scalar_expr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    plawk_end_scalar_operand_expr(Left),
+    plawk_end_scalar_operand_expr(Right).
+
+plawk_end_scalar_operand_expr(int(Value)) :-
+    integer(Value).
+plawk_end_scalar_operand_expr(var(Name)) :-
+    atom(Name).
+plawk_end_scalar_operand_expr(special('NR')).
+plawk_end_scalar_operand_expr(Expr) :-
+    plawk_end_scalar_expr(Expr).
+
+%% plawk_substitute_scalar_reads(+Expr0, +Slots, +Values, -Expr)
+%
+%  Replace var(Name) leaves with ssa(ValueIR) using the current scalar
+%  slot values, so the shared i64 emitters never see a variable read.
+plawk_substitute_operation_reads(add(Expr0), Slots, Values, add(Expr)) :-
+    !,
+    plawk_substitute_scalar_reads(Expr0, Slots, Values, Expr).
+plawk_substitute_operation_reads(set(Expr0), Slots, Values, set(Expr)) :-
+    !,
+    plawk_substitute_scalar_reads(Expr0, Slots, Values, Expr).
+plawk_substitute_operation_reads(Operation, _Slots, _Values, Operation).
+
+plawk_substitute_scalar_reads(var(Name), Slots, Values, ssa(Value)) :-
+    !,
+    nth0(SlotIndex, Slots, scalar_counter(Name)),
+    nth0(SlotIndex, Values, Value).
+plawk_substitute_scalar_reads(Expr0, Slots, Values, Expr) :-
+    plawk_i64_binary_expr(Expr0, _LLVMOp, _NamePart, Left0, Right0),
+    !,
+    plawk_substitute_scalar_reads(Left0, Slots, Values, Left),
+    plawk_substitute_scalar_reads(Right0, Slots, Values, Right),
+    Expr0 =.. [Functor, _, _],
+    Expr =.. [Functor, Left, Right].
+plawk_substitute_scalar_reads(Expr, _Slots, _Values, Expr).
+
+%% plawk_substitute_end_reads(+Expr0, +StatePlan, -Expr)
+%
+%  END-position substitution: var(Name) becomes the final slot value and
+%  NR becomes %plawk_nr, the loop-head record phi, which dominates
+%  end_print via close_stream / break_close_stream.
+plawk_substitute_end_reads(var(Name), StatePlan, ssa(Value)) :-
+    !,
+    plawk_state_slot_index(StatePlan, scalar_counter(Name), SlotIndex),
+    format(atom(Value), '%final_slot_~w', [SlotIndex]).
+plawk_substitute_end_reads(special('NR'), _StatePlan, ssa('%plawk_nr')) :-
+    !.
+plawk_substitute_end_reads(Expr0, StatePlan, Expr) :-
+    plawk_i64_binary_expr(Expr0, _LLVMOp, _NamePart, Left0, Right0),
+    !,
+    plawk_substitute_end_reads(Left0, StatePlan, Left),
+    plawk_substitute_end_reads(Right0, StatePlan, Right),
+    Expr0 =.. [Functor, _, _],
+    Expr =.. [Functor, Left, Right].
+plawk_substitute_end_reads(Expr, _StatePlan, Expr).
+
 plawk_i64_binary_primary_expr(special('NR')).
 plawk_i64_binary_primary_expr(special('NF')).
 plawk_i64_binary_primary_expr(int(field(FieldIndex))) :-
@@ -1589,13 +1684,26 @@ plawk_i64_binary_print_kind(mul, int_mul).
 plawk_i64_binary_print_kind(div, int_div).
 plawk_i64_binary_print_kind(mod, int_mod).
 
+% Reads count as slot names too: a variable read before any write gets a
+% zero-initialized slot, matching awk's uninitialized-variable semantics.
 plawk_scalar_update_action_name(Action, Name) :-
-    plawk_scalar_action_update(Action, Name, _Operation).
+    plawk_scalar_action_update(Action, WriteName, Operation),
+    (   Name = WriteName
+    ;   plawk_scalar_operation_expr(Operation, Expr),
+        plawk_expr_scalar_read_name(Expr, Name)
+    ).
 plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
     ( member(Action, ThenActions)
     ; member(Action, ElseActions)
     ),
-    plawk_scalar_action_update(Action, Name, _Operation).
+    plawk_scalar_update_action_name(Action, Name).
+
+plawk_expr_scalar_read_name(var(Name), Name).
+plawk_expr_scalar_read_name(Expr, Name) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_scalar_read_name(Left, Name)
+    ; plawk_expr_scalar_read_name(Right, Name)
+    ).
 
 plawk_scalar_action_update(inc(var(Name)), Name, add(const(1))).
 plawk_scalar_action_update(add(var(Name), int(Value)), Name, add(const(Value))) :-
@@ -1610,7 +1718,9 @@ plawk_scalar_action_update(add(var(Name), int(field(FieldIndex))), Name, add(fie
 plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
     plawk_i64_scalar_primary_expr(Expr).
 plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
-    plawk_i64_general_binary_expr(Expr).
+    plawk_i64_scalar_read_binary_expr(Expr).
+plawk_scalar_action_update(add(var(Name), var(Read)), Name, add(var(Read))) :-
+    atom(Read).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
@@ -1623,16 +1733,19 @@ plawk_scalar_action_update(set(var(Name), int(field(FieldIndex))), Name, set(fie
 plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
     plawk_i64_scalar_primary_expr(Expr).
 plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
-    plawk_i64_general_binary_expr(Expr).
+    plawk_i64_scalar_read_binary_expr(Expr).
+plawk_scalar_action_update(set(var(Name), var(Read)), Name, set(var(Read))) :-
+    atom(Read).
 
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, CurrentLabel, []) -->
     [].
 plawk_scalar_action_sequence_pairs([Action | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
         OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
-    { plawk_scalar_action_update(Action, Name, Operation),
+    { plawk_scalar_action_update(Action, Name, Operation0),
       nth0(SlotIndex, Slots, scalar_counter(Name)),
       nth0(SlotIndex, Values0, InputValue),
+      plawk_substitute_operation_reads(Operation0, Slots, Values0, Operation),
       plawk_scalar_update_operation_ir(Operation, FieldSeparator, Prefix, SlotIndex,
           OpIndex, InputValue, NextValue, Pair),
       replace_nth0(SlotIndex, Values0, NextValue, Values1),
@@ -1747,6 +1860,9 @@ plawk_scalar_update_operation_ir(set(Expr), FieldSeparator, Prefix, SlotIndex,
     format(atom(SetLine), '  ~w = add i64 0, ~w', [NextValue, ValueIR]),
     plawk_join_nonempty_ir([SetupIR, SetLine], IR).
 
+plawk_scalar_numeric_expr_ir(ssa(Value), _FieldSeparator, _Prefix, _SlotIndex,
+        _OpIndex, Value, '', '') :-
+    atom(Value).
 plawk_scalar_numeric_expr_ir(const(Value), _FieldSeparator, _Prefix, _SlotIndex,
         _OpIndex, ValueIR, GlobalIR, IR) :-
     plawk_i64_expr_ir_parts(const(Value), 0, scalar_const, scalar_const_global,
@@ -1795,6 +1911,8 @@ plawk_i64_expr_ir(const(Value), _FieldSeparator, _Base, _GlobalBase, ValueIR, []
 plawk_i64_expr_ir(int(Value), _FieldSeparator, _Base, _GlobalBase, ValueIR, [], []) :-
     integer(Value),
     format(atom(ValueIR), '~w', [Value]).
+plawk_i64_expr_ir(ssa(Value), _FieldSeparator, _Base, _GlobalBase, Value, [], []) :-
+    atom(Value).
 plawk_i64_expr_ir(field(FieldIndex), FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts) :-
     integer(FieldIndex),
@@ -2044,11 +2162,48 @@ plawk_scalar_end_print_lines([var(Name) | Rest], StatePlan, OutputSeparator, Pri
     },
     [FmtPtr, PrintCall],
     plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
+plawk_scalar_end_print_lines([special('NR') | Rest], StatePlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
+    plawk_end_nr_print_lines(PrintIndex),
+    { NextPrintIndex is PrintIndex + 1 },
+    plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
+plawk_scalar_end_print_lines([Expr | Rest], StatePlan, OutputSeparator, PrintIndex) -->
+    { plawk_end_scalar_expr(Expr) },
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
+    plawk_end_expr_print_lines(Expr, StatePlan, PrintIndex),
+    { NextPrintIndex is PrintIndex + 1 },
+    plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
 plawk_scalar_end_print_lines([string(Value) | Rest], StatePlan, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     plawk_end_string_print_lines(Value, PrintIndex),
     { NextPrintIndex is PrintIndex + 1 },
     plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
+
+plawk_end_nr_print_lines(PrintIndex) -->
+    { format(atom(FmtVar), 'end_nr_fmt_~w', [PrintIndex]),
+      format(atom(PrintVar), 'printed_end_nr_~w', [PrintIndex]),
+      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, '%plawk_nr',
+          [FmtPtr, PrintCall])
+    },
+    [FmtPtr, PrintCall].
+
+plawk_end_expr_print_lines(Expr, StatePlan, PrintIndex) -->
+    { plawk_substitute_end_reads(Expr, StatePlan, SubstitutedExpr),
+      format(atom(Base), 'plawk_end_expr_~w', [PrintIndex]),
+      plawk_i64_expr_ir(SubstitutedExpr, 32, Base, Base, ValueIR, [], SetupParts),
+      format(atom(FmtVar), 'end_expr_fmt_~w', [PrintIndex]),
+      format(atom(PrintVar), 'printed_end_expr_~w', [PrintIndex]),
+      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
+          [FmtPtr, PrintCall]),
+      append(SetupParts, [FmtPtr, PrintCall], Lines)
+    },
+    plawk_emit_lines(Lines).
+
+plawk_emit_lines([]) -->
+    [].
+plawk_emit_lines([Line | Rest]) -->
+    [Line],
+    plawk_emit_lines(Rest).
 
 plawk_end_string_print_lines(Value, PrintIndex) -->
     { string_codes(Value, Codes),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -566,6 +566,8 @@ scalar_delta_expr(index(Field, string(Needle))) -->
     { Field = field(_),
       NeedleCodes \== [],
       string_codes(Needle, NeedleCodes) }.
+scalar_delta_expr(var(Name)) -->
+    identifier(Name).
 
 print_action(print(Fields)) -->
     "print",
@@ -794,10 +796,13 @@ i64_factor_expr(int(Value)) -->
 i64_factor_expr(field(Index)) -->
     "$",
     integer_codes(IndexCodes),
+    !,
     { IndexCodes \== [],
       number_codes(Index, IndexCodes),
       Index >= 0
     }.
+i64_factor_expr(var(Name)) -->
+    identifier(Name).
 
 i64_binary_primary_expr(special('NR')) -->
     "NR".

--- a/tests/test_plawk_surface_end_scalar_exprs.pl
+++ b/tests/test_plawk_surface_end_scalar_exprs.pl
@@ -1,0 +1,151 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_endexpr_marker/0.
+
+user:plawk_endexpr_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_end_scalar_exprs, [condition(clang_available)]).
+
+test(parses_end_scalar_division_by_nr) :-
+    plawk_parse_string("{ sum += $2 } END { print \"avg\", sum / NR }\n", Program),
+    assertion(Program == program([], [rule(always, [add(var(sum), field(2))])],
+        [end([print([string("avg"), div_i64(var(sum), special('NR'))])])])).
+
+test(parses_scalar_read_in_update) :-
+    plawk_parse_string("{ avg = $2 / 2; total += avg } END { print total }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [set(var(avg), div_i64(field(2), int(2))),
+         add(var(total), var(avg))])],
+        [end([print([var(total)])])])).
+
+test(parses_scalar_self_read) :-
+    plawk_parse_string("{ x = x + 2 } END { print x }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [set(var(x), add_i64(var(x), int(2)))])],
+        [end([print([var(x)])])])).
+
+test(parses_bare_nr_in_end_print) :-
+    plawk_parse_string("{ n++ } END { print \"records\", NR }\n", Program),
+    assertion(Program == program([], [rule(always, [inc(var(n))])],
+        [end([print([string("records"), special('NR')])])])).
+
+test(end_expr_ir_uses_final_slots_and_loop_nr_phi) :-
+    plawk_parse_string("{ sum += $2 } END { print sum / NR }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_nr = phi i64 [0, %check_handle_value], [%current_nr, %continue_loop]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_raw = sdiv i64 %final_slot_0, %plawk_end_expr_'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(scalar_read_ir_uses_current_slot_value) :-
+    plawk_parse_string("{ avg = $2 / 2; total += avg } END { print total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    % total's add reads avg's freshly assigned op value (%rule_0_body_
+    % slot_0_op_0), not avg's stale loop-phi input.
+    assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 %slot_1, %rule_0_body_slot_0_op_0'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_end_average_report) :-
+    run_endexpr_print_smoke("{ sum += $2 } END { print \"avg\", sum / NR }\n",
+        "a 10\nb 20\nc 30\n",
+        "avg 20\n").
+
+test(surface_scalar_read_accumulates_intermediate) :-
+    run_endexpr_print_smoke("{ avg = $2 / 2; total += avg } END { print total }\n",
+        "a 10\nb 20\n",
+        "15\n").
+
+test(surface_scalar_self_read_updates) :-
+    run_endexpr_print_smoke("{ x = x + 2 } END { print x }\n",
+        "a\nb\nc\n",
+        "6\n").
+
+test(surface_bare_nr_in_end) :-
+    run_endexpr_print_smoke("{ n++ } END { print \"records\", NR }\n",
+        "a\nb\n",
+        "records 2\n").
+
+test(surface_cross_rule_scalar_read) :-
+    run_endexpr_print_smoke("$1 == \"A\" { base = $2 } $1 == \"B\" { total += base } END { print total }\n",
+        "A 5\nB x\nA 7\nB y\nB z\n",
+        "19\n").
+
+test(surface_mixed_end_expr_with_assoc_lookup) :-
+    run_endexpr_print_smoke("{ total++; counts[$1]++ } END { print total * 2, counts[\"ERROR\"] }\n",
+        "ERROR a\nWARN b\nERROR c\n",
+        "6 2\n").
+
+test(surface_empty_input_average_is_guarded_zero) :-
+    run_endexpr_print_smoke("{ sum += $2 } END { print sum / NR }\n",
+        "",
+        "0\n").
+
+test(surface_assignments_apply_in_source_order) :-
+    run_endexpr_print_smoke("{ a = NR; b = a + 1; a = 100 } END { print a, b }\n",
+        "one row\n",
+        "100 2\n").
+
+test(surface_read_before_any_write_is_zero) :-
+    run_endexpr_print_smoke("{ first = seen + 1; seen = 5 } END { print first, seen }\n",
+        "only row\n",
+        "1 5\n").
+
+test(surface_end_expr_precedence_and_parens) :-
+    run_endexpr_print_smoke("{ hits++; total += 3 } END { print (hits + total) * 2, hits + total * 2 }\n",
+        "a\nb\n",
+        "16 14\n").
+
+run_endexpr_print_smoke(Source, Input, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_end_scalar_exprs', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_end_scalar_exprs.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_endexpr_marker/0 ],
+        [module_name('plawk_surface_end_scalar_exprs')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_end_scalar_exprs_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[plawk surface end scalar exprs output]~n~w~n",
+              [OutStr]),
+       throw(plawk_surface_end_scalar_exprs_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_surface_end_scalar_exprs).


### PR DESCRIPTION
## Summary

**Stacked on #3402** (→ #3401). Second feature of the series.

Scalars go from write-mostly to readable, unlocking the canonical average report and intermediate variables:

```awk
{ sum += $2 } END { print "avg", sum / NR }      # THE awk report
{ avg = $2 / 2; total += avg }                    # intermediate scalars
{ x = x + 2 }                                     # self-reads
$1 == "A" { base = $2 } $1 == "B" { total += base }  # reads across rules
{ n++ } END { print "records", NR }               # bare NR in END
```

## Design

Reads lower by **substitution, not new emitters**: before emission, `var(Name)` leaves in an expression are rewritten to a new `ssa/1` leaf carrying the variable's *current* SSA slot value; the shared i64 emitters print it verbatim. This keeps the whole feature out of the delicate expression-emitter clauses and gives correct source-order semantics for free (`{ a = NR; b = a + 1; a = 100 }` prints `100 2`).

- **Rule bodies**: the action-sequence walker already threads current slot values, so substitution happens right where updates fold. Reads work across rules within a record and inside `if` branches.
- **Uninitialized reads**: state plans now collect *read* names alongside write names, so a read before any write gets a zero-initialized slot — awk's uninitialized-variable semantics (`{ first = seen + 1; seen = 5 }` → `1 5`).
- **END expressions**: `var(Name)` substitutes to `%final_slot_K` and `NR` to `%plawk_nr` — the loop-head record phi, which dominates `end_print` via both the EOF and `break` close paths, so no extra state is threaded. Operands are restricted to scalars, `NR`, and integer literals (fields/`NF` are meaningless after the stream closes and are rejected).
- **Empty input**: `sum / NR` on zero records is `0 / 0`, which the existing guarded division resolves to `0`.

## Changes

- **Parser**: scalar identifiers join the i64 expression factors and the scalar-update RHS grammar.
- **Codegen**: `ssa/1` leaf in the shared emitters; substitution helpers for rule-body (current values) and END (final slots + `%plawk_nr`) contexts; read-name collection in the scalar and mixed state plans; new END print clauses for bare `NR` and i64 expressions in both the scalar and mixed emitters.
- **Tests** (`tests/test_plawk_surface_end_scalar_exprs.pl`): 16 tests — parse shapes, IR assertions (final-slot division, loop-phi NR), and e2e binaries covering source-order assignment, cross-rule reads, read-before-write zeroing, mixed scalar/assoc END expressions, END precedence/parens, and the empty-input guard.

## Testing

- `tests/test_plawk_surface_end_scalar_exprs.pl` — 16/16 pass
- Full regression: prefix_print, arith_exprs, pattern_combinators, regex_match, forin_end_print, stdin_input — all pass

**Merge order:** #3401 → #3402 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_