### PR TITLE
plawk: call compiled Prolog predicates from rules

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -397,6 +397,21 @@ separator used by comma-separated `print` fields in `BEGIN`, rule, and `END`
 actions. Native separator emission uses direct byte output rather than
 passing the separator through `printf` as a format string.
 
+PLAWK programs can now call compiled Prolog predicates in the same binary:
+`prolog_guard` patterns (`pred(args...)` as a rule guard or `if` condition,
+match = success) and `prolog_call` i64 expressions (`pred(args...)` with a
+trailing output register, integer result, `0` on failure). Call sites
+marshal field atoms / string atoms / integers and invoke per-predicate
+wrapper functions around a lazily created shared `%WamState`; wrappers save
+and restore the VM heap top and rewind the arena via `@wam_cleanup`, so
+foreign calls run in constant memory (~5µs/call, bytecode-interpreted).
+`plawk_program_native_driver_ir/4` takes `wam_vm(InstrCount, LabelCount)`
+for the `wam_state_new` geps. Known pre-existing scalability note exposed
+by soak-testing this feature: `read_line`'s per-line `wam_intern_atom` is a
+linear scan over the dynamic atom table, so streams with many unique lines
+pay O(n^2) interning regardless of foreign calls — a hashed atom table (or
+slice-based records) is the fix and is independent of this surface.
+
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.
 

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -79,6 +79,7 @@ swipl -q -s tests/test_plawk_surface_pattern_combinators.pl -g "setenv('UW_SMOKE
 swipl -q -s tests/test_plawk_surface_regex_match.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_end_scalar_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_else_if.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_prolog_calls.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -204,6 +205,23 @@ The loop lowers to a native walk over the runtime table's occupied slots via
 reads), other-array lookups such as `errs[k]` (hash lookups, `0` for missing
 keys), and string literal labels. Iteration order follows the hash table's
 slot order and, as in awk, is unspecified.
+
+Compiled Prolog predicates in the same binary are callable from PLAWK — the
+hybrid's headline capability. A named predicate is a rule guard
+(`plawk_is_error($1) { print $0 }` matches when the predicate succeeds) or an
+`i64` expression (`{ total += severity_rank($1) }` calls `severity_rank/2`
+with a trailing output argument and yields its integer binding, `0` on
+failure). Arguments are field atoms (`$0` is the whole record), string
+literal atoms, and integers; guards compose with `&&`/`||`/`!` and `if`
+conditions, and calls compose with native arithmetic. Codegen collects the
+called predicates and emits one wrapper per shape around a lazily created
+shared `%WamState`; each wrapper runs `wam_prepare_call` + `run_loop`, then
+restores the VM heap top and rewinds the arena, so per-record foreign calls
+run in constant memory at roughly 5µs per call (bytecode-interpreted WAM
+dispatch). Programs with foreign calls use
+`plawk_program_native_driver_ir/4` with `wam_vm(InstrCount, LabelCount)`
+from `wam_llvm_last_compile_counts/2` after `write_wam_llvm_project/3`
+compiled the predicates into the module.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2,7 +2,9 @@
 % Copyright (c) 2026 John William Creighton (s243a)
 
 :- module(plawk_native_codegen, [
-    plawk_program_native_driver_ir/3
+    plawk_program_native_driver_ir/3,
+    plawk_program_native_driver_ir/4,
+    plawk_program_foreign_specs/3
 ]).
 
 :- use_module('../../../src/unifyweaver/targets/wam_llvm_target',
@@ -250,6 +252,247 @@ plawk_program_native_driver_ir(
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
             AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
+
+%% plawk_program_native_driver_ir(+Program, +InputPath, +Options, -DriverIR) is semidet.
+%
+%  Options-aware driver entry. Programs that call compiled Prolog
+%  predicates (prolog_guard patterns / prolog_call expressions) need
+%  Options to carry wam_vm(InstrCount, LabelCount) -- the counts
+%  reported by wam_llvm_last_compile_counts/2 after
+%  write_wam_llvm_project/3 compiled the predicates into the module.
+%  The emitted support section holds a lazily created shared %WamState
+%  and one wrapper function per called predicate; call sites marshal
+%  arguments and invoke the wrappers, so the shared guard/expression
+%  emitters need no VM plumbing. Programs with no foreign calls
+%  delegate to plawk_program_native_driver_ir/3 unchanged.
+plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
+    plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs),
+    (   GuardSpecs == [],
+        CallSpecs == []
+    ->  plawk_program_native_driver_ir(Program, InputPath, DriverIR)
+    ;   memberchk(wam_vm(InstrCount, LabelCount), Options),
+        plawk_foreign_support_ir(GuardSpecs, CallSpecs, InstrCount, LabelCount,
+            SupportIR),
+        plawk_program_native_driver_ir(Program, InputPath, MainIR),
+        format(atom(DriverIR), '~w~n~n~w', [SupportIR, MainIR])
+    ).
+
+%% plawk_program_foreign_specs(+Program, -GuardSpecs, -CallSpecs)
+%
+%  Collect the deduplicated foreign predicate call shapes used by the
+%  program. GuardSpecs are Name-NArgs pairs called as rule guards
+%  (predicate arity NArgs); CallSpecs are Name-NArgs pairs called as
+%  i64 expressions (predicate arity NArgs + 1 for the output).
+plawk_program_foreign_specs(program(_BeginClauses, Rules, EndClauses),
+        GuardSpecs, CallSpecs) :-
+    findall(Name-NArgs,
+        ( member(rule(Pattern, _Actions), Rules),
+          plawk_pattern_prolog_guard(Pattern, Name, Args),
+          length(Args, NArgs)
+        ),
+        GuardSpecs0),
+    findall(Name-NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          plawk_actions_prolog_call(Actions, Name, Args),
+          length(Args, NArgs)
+        ),
+        CallSpecs0),
+    findall(Name-NArgs,
+        ( member(rule(_Pattern2, Actions2), Rules),
+          member(if(CondPattern, _Then, _Else), Actions2),
+          plawk_pattern_prolog_guard(CondPattern, Name, Args),
+          length(Args, NArgs)
+        ),
+        CondGuardSpecs0),
+    append(GuardSpecs0, CondGuardSpecs0, AllGuardSpecs),
+    sort(AllGuardSpecs, GuardSpecs),
+    sort(CallSpecs0, CallSpecs).
+
+plawk_pattern_prolog_guard(prolog_guard(Name, Args), Name, Args).
+plawk_pattern_prolog_guard(and_pat(Left, Right), Name, Args) :-
+    ( plawk_pattern_prolog_guard(Left, Name, Args)
+    ; plawk_pattern_prolog_guard(Right, Name, Args)
+    ).
+plawk_pattern_prolog_guard(or_pat(Left, Right), Name, Args) :-
+    ( plawk_pattern_prolog_guard(Left, Name, Args)
+    ; plawk_pattern_prolog_guard(Right, Name, Args)
+    ).
+plawk_pattern_prolog_guard(not_pat(Pattern), Name, Args) :-
+    plawk_pattern_prolog_guard(Pattern, Name, Args).
+
+plawk_actions_prolog_call(Actions, Name, Args) :-
+    member(Action, Actions),
+    plawk_action_prolog_call(Action, Name, Args).
+
+plawk_action_prolog_call(add(_Var, Expr), Name, Args) :-
+    plawk_expr_prolog_call(Expr, Name, Args).
+plawk_action_prolog_call(set(_Var, Expr), Name, Args) :-
+    plawk_expr_prolog_call(Expr, Name, Args).
+plawk_action_prolog_call(print(Fields), Name, Args) :-
+    member(Field, Fields),
+    plawk_expr_prolog_call(Field, Name, Args).
+plawk_action_prolog_call(printf(_Format, PrintfArgs), Name, Args) :-
+    member(Field, PrintfArgs),
+    plawk_expr_prolog_call(Field, Name, Args).
+plawk_action_prolog_call(if(_Pattern, ThenActions, ElseActions), Name, Args) :-
+    ( plawk_actions_prolog_call(ThenActions, Name, Args)
+    ; plawk_actions_prolog_call(ElseActions, Name, Args)
+    ).
+
+plawk_expr_prolog_call(prolog_call(Name, Args), Name, Args).
+plawk_expr_prolog_call(Expr, Name, Args) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_prolog_call(Left, Name, Args)
+    ; plawk_expr_prolog_call(Right, Name, Args)
+    ).
+
+%% plawk_foreign_support_ir(+GuardSpecs, +CallSpecs, +InstrCount, +LabelCount, -IR)
+%
+%  Emit the shared foreign-call support section: a lazily initialized
+%  process-wide %WamState plus one wrapper per called predicate. Guard
+%  wrappers return run_loop's success directly. Call wrappers push one
+%  unbound output cell, run the predicate, and return {value, ok};
+%  failure or a non-integer binding yields {0, false}. Both wrappers
+%  save and restore the VM heap top (WamState field 6) and rewind the
+%  arena via @wam_cleanup, so per-record foreign calls run in constant
+%  memory -- nothing WAM-side persists between plawk calls.
+plawk_foreign_support_ir(GuardSpecs, CallSpecs, InstrCount, LabelCount, IR) :-
+    format(atom(VmIR),
+'@plawk_foreign_vm = internal global %WamState* null
+
+define %WamState* @plawk_foreign_vm_get() {
+entry:
+  %cur = load %WamState*, %WamState** @plawk_foreign_vm
+  %have = icmp ne %WamState* %cur, null
+  br i1 %have, label %ret_cur, label %make
+
+ret_cur:
+  ret %WamState* %cur
+
+make:
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  store %WamState* %vm, %WamState** @plawk_foreign_vm
+  ret %WamState* %vm
+}',
+        [InstrCount, InstrCount, InstrCount, LabelCount, LabelCount,
+         LabelCount]),
+    findall(GuardIR,
+        ( member(Name-NArgs, GuardSpecs),
+          plawk_foreign_guard_wrapper_ir(Name, NArgs, GuardIR)
+        ),
+        GuardIRs),
+    findall(CallIR,
+        ( member(Name-NArgs, CallSpecs),
+          plawk_foreign_call_wrapper_ir(Name, NArgs, CallIR)
+        ),
+        CallIRs),
+    append([[VmIR], GuardIRs, CallIRs], Parts),
+    atomic_list_concat(Parts, '\n\n', IR).
+
+plawk_foreign_wrapper_params(NArgs, ParamsIR) :-
+    NArgs >= 1,
+    NArgs1 is NArgs - 1,
+    numlist(0, NArgs1, Ns),
+    findall(Param,
+        ( member(N, Ns),
+          format(atom(Param), '%Value %a~w', [N])
+        ),
+        Params),
+    atomic_list_concat(Params, ', ', ParamsIR).
+
+plawk_foreign_set_reg_lines(NArgs, Lines) :-
+    NArgs1 is NArgs - 1,
+    numlist(0, NArgs1, Ns),
+    findall(Line,
+        ( member(N, Ns),
+          format(atom(Line),
+              '  call void @wam_set_reg(%WamState* %vm, i32 ~w, %Value %a~w)',
+              [N, N])
+        ),
+        Lines).
+
+plawk_foreign_guard_wrapper_ir(Name, NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_foreign_set_reg_lines(NArgs, SetRegLines),
+    atomic_list_concat(SetRegLines, '\n', SetRegIR),
+    format(atom(IR),
+'define i1 @plawk_foreign_guard_~w_~w(~w) {
+entry:
+  %vm = call %WamState* @plawk_foreign_vm_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs_saved = load i32, i32* %hs_ptr
+  %pc = load i32, i32* @~w_start_pc
+  call void @wam_prepare_call(%WamState* %vm, i32 %pc)
+~w
+  %ok = call i1 @run_loop(%WamState* %vm)
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  ret i1 %ok
+
+fail:
+  ret i1 false
+}',
+        [Name, NArgs, ParamsIR, Name, SetRegIR]).
+
+plawk_foreign_call_wrapper_ir(Name, NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_foreign_set_reg_lines(NArgs, SetRegLines),
+    atomic_list_concat(SetRegLines, '\n', SetRegIR),
+    format(atom(IR),
+'define { i64, i1 } @plawk_foreign_call_~w_~w(~w) {
+entry:
+  %vm = call %WamState* @plawk_foreign_vm_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs_saved = load i32, i32* %hs_ptr
+  %pc = load i32, i32* @~w_start_pc
+  %unb = call %Value @value_unbound(i8* null)
+  %out_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %out_ref = call %Value @value_ref(i32 %out_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %pc)
+~w
+  call void @wam_set_reg(%WamState* %vm, i32 ~w, %Value %out_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %read_out, label %rewind_fail
+
+read_out:
+  %out = call %Value @wam_deref_value(%WamState* %vm, %Value %out_ref)
+  %out_tag = extractvalue %Value %out, 0
+  %out_is_int = icmp eq i32 %out_tag, 1
+  br i1 %out_is_int, label %good, label %rewind_fail
+
+good:
+  %payload = extractvalue %Value %out, 1
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  %r0 = insertvalue { i64, i1 } undef, i64 %payload, 0
+  %r1 = insertvalue { i64, i1 } %r0, i1 true, 1
+  ret { i64, i1 } %r1
+
+rewind_fail:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  br label %fail
+
+fail:
+  %f0 = insertvalue { i64, i1 } undef, i64 0, 0
+  %f1 = insertvalue { i64, i1 } %f0, i1 false, 1
+  ret { i64, i1 } %f1
+}',
+        [Name, NArgs, ParamsIR, Name, SetRegIR, NArgs]).
 
 %% plawk_forin_end_plan(+Rules, +LoopVar, +ArrayName, +BodyActions, -AssocPlan, -PrintFields)
 %
@@ -1550,6 +1793,8 @@ plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(int(field(_))).
 plawk_rule_body_print_field(Expr) :-
     plawk_i64_general_binary_expr(Expr).
+plawk_rule_body_print_field(Expr) :-
+    plawk_prolog_call_expr(Expr).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
 plawk_rule_body_print_field(index(field(_), string(_))).
@@ -1572,8 +1817,23 @@ plawk_i64_operand_expr(field(FieldIndex)) :-
     FieldIndex >= 0.
 plawk_i64_operand_expr(Expr) :-
     plawk_i64_binary_primary_expr(Expr).
+plawk_i64_operand_expr(prolog_call(Name, Args)) :-
+    plawk_prolog_call_expr(prolog_call(Name, Args)).
 plawk_i64_operand_expr(Expr) :-
     plawk_i64_general_binary_expr(Expr).
+
+plawk_prolog_call_expr(prolog_call(Name, Args)) :-
+    atom(Name),
+    Args = [_ | _],
+    maplist(plawk_foreign_arg, Args).
+
+plawk_foreign_arg(field(Index)) :-
+    integer(Index),
+    Index >= 0.
+plawk_foreign_arg(string(String)) :-
+    string(String).
+plawk_foreign_arg(int(Value)) :-
+    integer(Value).
 
 %% plawk_i64_scalar_read_binary_expr(+Expr) is semidet.
 %
@@ -1725,6 +1985,9 @@ plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
     plawk_i64_scalar_read_binary_expr(Expr).
 plawk_scalar_action_update(add(var(Name), var(Read)), Name, add(var(Read))) :-
     atom(Read).
+plawk_scalar_action_update(add(var(Name), prolog_call(Pred, Args)), Name,
+        add(prolog_call(Pred, Args))) :-
+    plawk_prolog_call_expr(prolog_call(Pred, Args)).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
@@ -1740,6 +2003,9 @@ plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
     plawk_i64_scalar_read_binary_expr(Expr).
 plawk_scalar_action_update(set(var(Name), var(Read)), Name, set(var(Read))) :-
     atom(Read).
+plawk_scalar_action_update(set(var(Name), prolog_call(Pred, Args)), Name,
+        set(prolog_call(Pred, Args))) :-
+    plawk_prolog_call_expr(prolog_call(Pred, Args)).
 
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, CurrentLabel, []) -->
@@ -1867,6 +2133,12 @@ plawk_scalar_update_operation_ir(set(Expr), FieldSeparator, Prefix, SlotIndex,
 plawk_scalar_numeric_expr_ir(ssa(Value), _FieldSeparator, _Prefix, _SlotIndex,
         _OpIndex, Value, '', '') :-
     atom(Value).
+plawk_scalar_numeric_expr_ir(prolog_call(Name, Args), FieldSeparator, Prefix,
+        SlotIndex, OpIndex, ValueIR, GlobalIR, IR) :-
+    format(atom(CallBase), '~w_slot_~w_op_~w_prolog_call',
+        [Prefix, SlotIndex, OpIndex]),
+    plawk_i64_expr_ir_parts(prolog_call(Name, Args), FieldSeparator, CallBase,
+        CallBase, ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(const(Value), _FieldSeparator, _Prefix, _SlotIndex,
         _OpIndex, ValueIR, GlobalIR, IR) :-
     plawk_i64_expr_ir_parts(const(Value), 0, scalar_const, scalar_const_global,
@@ -1917,6 +2189,23 @@ plawk_i64_expr_ir(int(Value), _FieldSeparator, _Base, _GlobalBase, ValueIR, [], 
     format(atom(ValueIR), '~w', [Value]).
 plawk_i64_expr_ir(ssa(Value), _FieldSeparator, _Base, _GlobalBase, Value, [], []) :-
     atom(Value).
+plawk_i64_expr_ir(prolog_call(Name, Args), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    length(Args, NArgs),
+    plawk_foreign_args_ir(Args, FieldSeparator, GlobalBase, ArgValueIRs,
+        GlobalParts, ArgSetupParts),
+    plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
+    format(atom(ResIR),
+        '  %~w_res = call { i64, i1 } @plawk_foreign_call_~w_~w(~w)',
+        [Base, Name, NArgs, CallArgsIR]),
+    format(atom(ValIR),
+        '  %~w_val = extractvalue { i64, i1 } %~w_res, 0', [Base, Base]),
+    format(atom(OkIR),
+        '  %~w_ok = extractvalue { i64, i1 } %~w_res, 1', [Base, Base]),
+    format(atom(SelIR),
+        '  %~w = select i1 %~w_ok, i64 %~w_val, i64 0', [Base, Base, Base]),
+    format(atom(ValueIR), '%~w', [Base]),
+    append(ArgSetupParts, [ResIR, ValIR, OkIR, SelIR], SetupParts).
 plawk_i64_expr_ir(field(FieldIndex), FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts) :-
     integer(FieldIndex),
@@ -2265,6 +2554,9 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, ''-GuardCall
 plawk_pattern_guard_ir(field_match(Index, Regex), FieldSeparator, GuardIR) :-
     llvm_emit_regex_field_match_guard(plawk_surface_regex, '%line', Index,
         Regex, FieldSeparator, '%is_match', GuardIR).
+plawk_pattern_guard_ir(prolog_guard(Name, Args), FieldSeparator, GuardIR) :-
+    plawk_foreign_guard_call_ir(Name, Args, FieldSeparator,
+        plawk_surface_prolog_guard, '%is_match', GuardIR).
 plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardIR) :-
     plawk_combined_pattern(Pattern),
     plawk_pattern_guard_ir(Pattern, FieldSeparator, plawk_surface_pattern,
@@ -2304,6 +2596,9 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, _GlobalBase,
 plawk_pattern_guard_ir(field_match(Index, Regex), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     llvm_emit_regex_field_match_guard(GlobalBase, '%line', Index, Regex,
         FieldSeparator, MatchValue, GuardIR).
+plawk_pattern_guard_ir(prolog_guard(Name, Args), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
+    plawk_foreign_guard_call_ir(Name, Args, FieldSeparator, GlobalBase,
+        MatchValue, GuardIR).
 plawk_pattern_guard_ir(and_pat(Left, Right), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     plawk_binary_pattern_guard_ir(and, Left, Right, FieldSeparator, GlobalBase,
         MatchValue, GuardIR).
@@ -2347,6 +2642,118 @@ plawk_binary_pattern_guard_ir(Op, Left, Right, FieldSeparator, GlobalBase,
 ~w
   ~w = ~w i1 ~w, ~w',
         [LeftCallIR, RightCallIR, MatchValue, Op, LeftValue, RightValue]).
+
+%% plawk_foreign_args_ir(+Args, +FieldSeparator, +BasePrefix, -ArgValueIRs,
+%%     -GlobalParts, -SetupParts)
+%
+%  Marshal plawk foreign-call arguments into %Value SSA names. field(0)
+%  passes the record atom %line directly; positive fields intern the
+%  projected slice (missing fields intern the empty atom); string
+%  literals intern per-site globals; integers build integer values.
+plawk_foreign_args_ir(Args, FieldSeparator, BasePrefix, ArgValueIRs,
+        GlobalParts, SetupParts) :-
+    plawk_foreign_args_ir(Args, FieldSeparator, BasePrefix, 0, ArgValueIRs,
+        GlobalPartsNested, SetupPartsNested),
+    append(GlobalPartsNested, GlobalParts),
+    append(SetupPartsNested, SetupParts).
+
+plawk_foreign_args_ir([], _FieldSeparator, _BasePrefix, _Index, [], [], []).
+plawk_foreign_args_ir([Arg | Rest], FieldSeparator, BasePrefix, Index,
+        [ArgValueIR | ArgValueIRs], [GlobalParts | GlobalPartsRest],
+        [SetupParts | SetupPartsRest]) :-
+    format(atom(ArgBase), '~w_a~w', [BasePrefix, Index]),
+    plawk_foreign_arg_ir(Arg, FieldSeparator, ArgBase, ArgValueIR,
+        GlobalParts, SetupParts),
+    NextIndex is Index + 1,
+    plawk_foreign_args_ir(Rest, FieldSeparator, BasePrefix, NextIndex,
+        ArgValueIRs, GlobalPartsRest, SetupPartsRest).
+
+plawk_foreign_arg_ir(field(0), _FieldSeparator, _ArgBase, '%line', [], []) :-
+    !.
+plawk_foreign_arg_ir(field(FieldIndex), FieldSeparator, ArgBase, ArgValueIR,
+        [EmptyGlobalIR], SetupParts) :-
+    integer(FieldIndex),
+    FieldIndex > 0,
+    !,
+    SafeBase = ArgBase,
+    format(atom(EmptyGlobalIR),
+        '@.~w_empty = private constant [1 x i8] zeroinitializer', [SafeBase]),
+    format(atom(SliceIR),
+        '  %~w_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 ~w)',
+        [SafeBase, FieldIndex, FieldSeparator]),
+    format(atom(PtrIR),
+        '  %~w_ptr = extractvalue %WamSlice %~w_slice, 0', [SafeBase, SafeBase]),
+    format(atom(LenIR),
+        '  %~w_len = extractvalue %WamSlice %~w_slice, 1', [SafeBase, SafeBase]),
+    format(atom(NullIR),
+        '  %~w_null = icmp eq i8* %~w_ptr, null', [SafeBase, SafeBase]),
+    format(atom(SafePtrIR),
+        '  %~w_safe_ptr = select i1 %~w_null, i8* getelementptr ([1 x i8], [1 x i8]* @.~w_empty, i32 0, i32 0), i8* %~w_ptr',
+        [SafeBase, SafeBase, SafeBase, SafeBase]),
+    format(atom(SafeLenIR),
+        '  %~w_safe_len = select i1 %~w_null, i64 0, i64 %~w_len',
+        [SafeBase, SafeBase, SafeBase]),
+    format(atom(InternIR),
+        '  %~w_id = call i64 @wam_intern_atom(i8* %~w_safe_ptr, i64 %~w_safe_len)',
+        [SafeBase, SafeBase, SafeBase]),
+    format(atom(Value0IR),
+        '  %~w_v0 = insertvalue %Value undef, i32 0, 0', [SafeBase]),
+    format(atom(ValueIR),
+        '  %~w_v = insertvalue %Value %~w_v0, i64 %~w_id, 1',
+        [SafeBase, SafeBase, SafeBase]),
+    format(atom(ArgValueIR), '%~w_v', [SafeBase]),
+    SetupParts = [SliceIR, PtrIR, LenIR, NullIR, SafePtrIR, SafeLenIR,
+        InternIR, Value0IR, ValueIR].
+plawk_foreign_arg_ir(string(String), _FieldSeparator, ArgBase, ArgValueIR,
+        [StringGlobalIR], SetupParts) :-
+    !,
+    SafeBase = ArgBase,
+    format(atom(StringGlobalName), '~w_str', [SafeBase]),
+    llvm_emit_c_string_global(StringGlobalName, String, StringGlobalIR,
+        StringLen, BytesLen),
+    format(atom(PtrIR),
+        '  %~w_str_ptr = getelementptr [~w x i8], [~w x i8]* @.~w_str, i32 0, i32 0',
+        [SafeBase, BytesLen, BytesLen, SafeBase]),
+    format(atom(InternIR),
+        '  %~w_id = call i64 @wam_intern_atom(i8* %~w_str_ptr, i64 ~w)',
+        [SafeBase, SafeBase, StringLen]),
+    format(atom(Value0IR),
+        '  %~w_v0 = insertvalue %Value undef, i32 0, 0', [SafeBase]),
+    format(atom(ValueIR),
+        '  %~w_v = insertvalue %Value %~w_v0, i64 %~w_id, 1',
+        [SafeBase, SafeBase, SafeBase]),
+    format(atom(ArgValueIR), '%~w_v', [SafeBase]),
+    SetupParts = [PtrIR, InternIR, Value0IR, ValueIR].
+plawk_foreign_arg_ir(int(Value), _FieldSeparator, ArgBase, ArgValueIR,
+        [], [IntIR]) :-
+    integer(Value),
+    SafeBase = ArgBase,
+    format(atom(IntIR),
+        '  %~w_v = call %Value @value_integer(i64 ~w)', [SafeBase, Value]),
+    format(atom(ArgValueIR), '%~w_v', [SafeBase]).
+
+plawk_foreign_call_args_ir([], '').
+plawk_foreign_call_args_ir(ArgValueIRs, IR) :-
+    ArgValueIRs = [_ | _],
+    findall(Part,
+        ( member(ArgValueIR, ArgValueIRs),
+          format(atom(Part), '%Value ~w', [ArgValueIR])
+        ),
+        Parts),
+    atomic_list_concat(Parts, ', ', IR).
+
+plawk_foreign_guard_call_ir(Name, Args, FieldSeparator, GlobalBase, MatchValue,
+        GlobalIR-GuardCallIR) :-
+    length(Args, NArgs),
+    plawk_foreign_args_ir(Args, FieldSeparator, GlobalBase, ArgValueIRs,
+        GlobalParts, SetupParts),
+    plawk_join_nonempty_ir(GlobalParts, GlobalIR),
+    plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
+    format(atom(CallLine),
+        '  ~w = call i1 @plawk_foreign_guard_~w_~w(~w)',
+        [MatchValue, Name, NArgs, CallArgsIR]),
+    append(SetupParts, [CallLine], Lines),
+    atomic_list_concat(Lines, '\n', GuardCallIR).
 
 plawk_literal_contains_guard_ir(GlobalBase, Needle, FieldSeparator, MatchValue, GlobalIR-GuardCallIR) :-
     format(atom(IndexBase), '~w_contains_index', [GlobalBase]),
@@ -2627,6 +3034,14 @@ plawk_emit_print_expr_for_context(Expr, FieldSeparator, Context,
     plawk_i64_expr_ir(Expr, FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
 
+plawk_emit_print_expr_for_context(prolog_call(Name, Args), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_prolog_call_expr(prolog_call(Name, Args)),
+    plawk_print_expr_value_base(Context, prolog_call, Base),
+    plawk_print_expr_output_names(Context, prolog_call, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(prolog_call(Name, Args), FieldSeparator, Base, Base,
+        ValueIR, GlobalParts, SetupParts).
+
 plawk_emit_print_expr_for_context(length(field(FieldIndex)), FieldSeparator, Context,
         i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
     plawk_print_expr_value_base(Context, length, Base),
@@ -2695,6 +3110,8 @@ plawk_normal_print_expr_value_base(int_div, Index, Base) :-
     format(atom(Base), 'plawk_int_div_~w', [Index]).
 plawk_normal_print_expr_value_base(int_mod, Index, Base) :-
     format(atom(Base), 'plawk_int_mod_~w', [Index]).
+plawk_normal_print_expr_value_base(prolog_call, Index, Base) :-
+    format(atom(Base), 'plawk_prolog_call_~w', [Index]).
 plawk_normal_print_expr_value_base(length, Index, Base) :-
     format(atom(Base), 'plawk_length_~w', [Index]).
 plawk_normal_print_expr_value_base(substr, Index, Base) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -141,7 +141,53 @@ base_pattern(Pattern) -->
     field_i64_cmp_pattern(Pattern),
     !.
 base_pattern(Pattern) -->
-    field_eq_pattern(Pattern).
+    field_eq_pattern(Pattern),
+    !.
+base_pattern(Pattern) -->
+    prolog_guard_pattern(Pattern).
+
+%% prolog_guard_pattern(-Pattern)//
+%
+%  A named Prolog predicate as a rule guard: `pred(args...)` matches
+%  when the compiled predicate succeeds. Arguments are field atoms
+%  ($0 is the whole record), string literal atoms, or integers.
+prolog_guard_pattern(prolog_guard(Name, Args)) -->
+    identifier(Name),
+    ws,
+    "(",
+    ws,
+    foreign_args(Args),
+    ws,
+    ")".
+
+foreign_args([Arg | Args]) -->
+    foreign_arg(Arg),
+    foreign_args_rest(Args).
+
+foreign_args_rest([Arg | Args]) -->
+    ws,
+    ",",
+    ws,
+    !,
+    foreign_arg(Arg),
+    foreign_args_rest(Args).
+foreign_args_rest([]) -->
+    [].
+
+foreign_arg(field(Index)) -->
+    "$",
+    integer_codes(IndexCodes),
+    !,
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    }.
+foreign_arg(string(Value)) -->
+    quoted_string(ValueCodes),
+    !,
+    { string_codes(Value, ValueCodes) }.
+foreign_arg(int(Value)) -->
+    signed_integer_value(Value).
 
 %% slash_regex_pattern(-Pattern)//
 %
@@ -585,6 +631,9 @@ scalar_delta_expr(index(Field, string(Needle))) -->
     { Field = field(_),
       NeedleCodes \== [],
       string_codes(Needle, NeedleCodes) }.
+scalar_delta_expr(Expr) -->
+    prolog_call_expr(Expr),
+    !.
 scalar_delta_expr(var(Name)) -->
     identifier(Name).
 
@@ -724,6 +773,9 @@ field_expr(string(Value)) -->
     quoted_string(ValueCodes),
     { string_codes(Value, ValueCodes)
     }.
+field_expr(Expr) -->
+    prolog_call_expr(Expr),
+    !.
 field_expr(var(Name)) -->
     identifier(Name).
 
@@ -820,8 +872,26 @@ i64_factor_expr(field(Index)) -->
       number_codes(Index, IndexCodes),
       Index >= 0
     }.
+i64_factor_expr(Expr) -->
+    prolog_call_expr(Expr),
+    !.
 i64_factor_expr(var(Name)) -->
     identifier(Name).
+
+%% prolog_call_expr(-Expr)//
+%
+%  A named Prolog predicate as an i64 expression: `pred(args...)` calls
+%  the compiled predicate with one extra trailing output argument and
+%  yields its integer binding, or 0 when the call fails or binds a
+%  non-integer.
+prolog_call_expr(prolog_call(Name, Args)) -->
+    identifier(Name),
+    ws,
+    "(",
+    ws,
+    foreign_args(Args),
+    ws,
+    ")".
 
 i64_binary_primary_expr(special('NR')) -->
     "NR".

--- a/tests/test_plawk_surface_prolog_calls.pl
+++ b/tests/test_plawk_surface_prolog_calls.pl
@@ -1,0 +1,177 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_is_error/1.
+:- dynamic user:plawk_severity_rank/2.
+:- dynamic user:plawk_double_plus/2.
+
+% Fact-based guard: succeeds for the severities considered errors.
+user:plawk_is_error('ERROR').
+user:plawk_is_error('FATAL').
+
+% Deterministic classifier: atom in, integer rank out.
+user:plawk_severity_rank(Kind, Rank) :-
+    (   Kind == 'ERROR'
+    ->  Rank = 3
+    ;   Kind == 'WARN'
+    ->  Rank = 2
+    ;   Rank = 1
+    ).
+
+% Integer arithmetic through is/2.
+user:plawk_double_plus(N, M) :-
+    M is N * 2 + 1.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_prolog_calls, [condition(clang_available)]).
+
+test(parses_prolog_guard_pattern) :-
+    plawk_parse_string("plawk_is_error($1) { print $0 }\n", Program),
+    assertion(Program == program([], [rule(
+        prolog_guard(plawk_is_error, [field(1)]),
+        [print([field(0)])])], [])).
+
+test(parses_prolog_guard_in_combined_pattern) :-
+    plawk_parse_string("plawk_is_error($1) && $3 > 100 { hits++ } END { print hits }\n", Program),
+    assertion(Program == program([], [rule(
+        and_pat(prolog_guard(plawk_is_error, [field(1)]), field_cmp(3, gt, 100)),
+        [inc(var(hits))])],
+        [end([print([var(hits)])])])).
+
+test(parses_prolog_call_expression) :-
+    plawk_parse_string("{ rank = plawk_severity_rank($1); total += rank } END { print total }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [set(var(rank), prolog_call(plawk_severity_rank, [field(1)])),
+         add(var(total), var(rank))])],
+        [end([print([var(total)])])])).
+
+test(parses_prolog_call_with_mixed_args) :-
+    plawk_parse_string("check($0, \"limit\", -5) { hits++ } END { print hits }\n", Program),
+    assertion(Program == program([], [rule(
+        prolog_guard(check, [field(0), string("limit"), int(-5)]),
+        [inc(var(hits))])],
+        [end([print([var(hits)])])])).
+
+test(foreign_specs_collect_guards_and_calls) :-
+    plawk_parse_string("plawk_is_error($1) { total += plawk_severity_rank($1) } END { print total }\n", Program),
+    plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs),
+    assertion(GuardSpecs == [plawk_is_error-1]),
+    assertion(CallSpecs == [plawk_severity_rank-1]).
+
+test(foreign_driver_requires_vm_counts) :-
+    plawk_parse_string("plawk_is_error($1) { print $0 }\n", Program),
+    assertion(\+ plawk_program_native_driver_ir(Program, 'input.txt', [], _)),
+    !.
+
+test(plain_program_needs_no_vm_counts) :-
+    plawk_parse_string("$1 == \"ERROR\" { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', [], DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@plawk_foreign_vm')),
+    !.
+
+test(foreign_driver_ir_has_wrappers_and_lazy_vm) :-
+    plawk_parse_string("plawk_is_error($1) { total += plawk_severity_rank($1) } END { print total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', [wam_vm(100, 20)], DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define i1 @plawk_foreign_guard_plawk_is_error_1(%Value %a0)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define { i64, i1 } @plawk_foreign_call_plawk_severity_rank_1(%Value %a0)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@plawk_foreign_vm = internal global %WamState* null'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'load i32, i32* @plawk_is_error_start_pc'))),
+    % Wrappers rewind the heap top and arena after every call.
+    assertion(once(sub_atom(DriverIR, _, _, _, '%hs_saved = load i32, i32* %hs_ptr\n  %pc = load i32, i32* @plawk_is_error_start_pc'))),
+    !.
+
+test(surface_prolog_fact_guard_filters_records) :-
+    run_prolog_call_smoke("plawk_is_error($1) { print $0 }\n",
+        "ERROR disk 300\nWARN cpu 50\nINFO net 15\nFATAL mem 8\n",
+        "ERROR disk 300\nFATAL mem 8\n").
+
+test(surface_prolog_guard_composes_with_native_guard) :-
+    run_prolog_call_smoke("plawk_is_error($1) && $3 > 100 { hits++ } END { print hits }\n",
+        "ERROR disk 300\nWARN cpu 50\nINFO net 15\nFATAL mem 8\n",
+        "1\n").
+
+test(surface_prolog_call_accumulates_ranks) :-
+    run_prolog_call_smoke("{ total += plawk_severity_rank($1) } END { print total }\n",
+        "ERROR disk 300\nWARN cpu 50\nINFO net 15\nFATAL mem 8\n",
+        "7\n").
+
+test(surface_prolog_call_prints_per_record) :-
+    run_prolog_call_smoke("{ print $1, plawk_severity_rank($1) }\n",
+        "ERROR disk 300\nWARN cpu 50\nINFO net 15\nFATAL mem 8\n",
+        "ERROR 3\nWARN 2\nINFO 1\nFATAL 1\n").
+
+test(surface_prolog_call_with_integer_literal_arg) :-
+    run_prolog_call_smoke("{ print plawk_double_plus(21) }\n",
+        "one row\n",
+        "43\n").
+
+test(surface_prolog_guard_in_if_condition) :-
+    run_prolog_call_smoke("{ if (plawk_is_error($1)) { e++ } } END { print e }\n",
+        "ERROR disk 300\nWARN cpu 50\nINFO net 15\nFATAL mem 8\n",
+        "2\n").
+
+test(surface_prolog_call_composes_with_arithmetic) :-
+    run_prolog_call_smoke("{ r = plawk_severity_rank($1) * 10 + 1; total += r } END { print total }\n",
+        "ERROR disk 300\nWARN cpu 50\nINFO net 15\nFATAL mem 8\n",
+        "74\n").
+
+test(surface_negated_prolog_guard) :-
+    run_prolog_call_smoke("!plawk_is_error($1) { ok++ } END { print ok }\n",
+        "ERROR disk 300\nWARN cpu 50\nINFO net 15\nFATAL mem 8\n",
+        "2\n").
+
+run_prolog_call_smoke(Source, Input, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_prolog_calls', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    directory_file_path(Dir, 'plawk_surface_prolog_calls.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_is_error/1,
+          user:plawk_severity_rank/2,
+          user:plawk_double_plus/2
+        ],
+        [module_name('plawk_surface_prolog_calls')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_program_native_driver_ir(Program, InputPath,
+        [wam_vm(InstrCount, LabelCount)], DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_prolog_calls_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[plawk surface prolog calls output]~n~w~n",
+              [OutStr]),
+       throw(plawk_surface_prolog_calls_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_surface_prolog_calls).


### PR DESCRIPTION
## Summary

**Stacked on #3404** (→ #3403 → #3402 → #3401). Fourth feature — and the one the whole hybrid architecture exists for: plawk programs now **call Prolog predicates compiled into the same native binary**, with no text serialization between the streaming loop and the logic code.

```awk
plawk_is_error($1) { print $0 }                       # Prolog predicate as guard
plawk_is_error($1) && $3 > 100 { hits++ }             # composes with native guards
{ total += plawk_severity_rank($1) }                  # i64 expression call
{ r = plawk_severity_rank($1) * 10 + 1; total += r }  # composes with arithmetic
{ if (plawk_is_error($1)) { e++ } }                   # if conditions
!plawk_is_error($1) { ok++ }                          # negation
```

with the predicates written as ordinary Prolog and compiled by `write_wam_llvm_project/3`:

```prolog
plawk_is_error('ERROR').
plawk_is_error('FATAL').
plawk_severity_rank(K, R) :- ( K == 'ERROR' -> R = 3 ; K == 'WARN' -> R = 2 ; R = 1 ).
```

## Design

**Surface** — two shapes:
- `prolog_guard`: `pred(args...)` in pattern position; match = predicate success (arity = #args).
- `prolog_call`: `pred(args...)` as an i64 expression; the wrapper adds a trailing unbound output register (arity = #args + 1) and yields the integer binding, `0` on failure or a non-integer binding.
- Arguments: field atoms (`$0` = whole record — passed as the already-interned line atom; `$N` interns the projected slice, empty atom when missing), string literal atoms, integers.

**Codegen** — new `plawk_program_native_driver_ir/4` takes `Options` with `wam_vm(InstrCount, LabelCount)` (from `wam_llvm_last_compile_counts/2`) and emits a foreign-support section: a **lazily created shared `%WamState`** plus one wrapper function per called predicate shape, following the calling convention proven by the Phase-1 stream-loop smokes (`wam_prepare_call` → `wam_set_reg` → `run_loop` → `wam_deref_value`). Call sites only marshal arguments and invoke wrappers, so the shared guard/expression emitters carry **no VM plumbing** — which is why guards compose with `&&`/`||`/`!`, `if` conditions, and the whole expression grammar for free. Programs without foreign calls delegate to `/3` unchanged.

**Memory** — wrappers save/restore the VM heap top (`WamState` field 6) and rewind the arena via `@wam_cleanup` after every call, since nothing WAM-side persists between plawk calls. Verified: constant 2.6 MB RSS over a 200k-record soak.

**Performance, measured honestly** — the 200k soak with a foreign call per record ran ~1s slower than the identical program without the call: **~5µs per foreign call** (bytecode-interpreted `run_loop` dispatch). The soak also exposed a **pre-existing** bottleneck now recorded in the plan doc: `read_line` interns every line through the linear-scan atom table, so streams with many *unique* lines pay O(n²) interning with or without foreign calls (both variants took ~2m8s on 200k unique lines). A hashed atom table (or slice-based records) is the fix and is independent of this surface.

## Tests

`tests/test_plawk_surface_prolog_calls.pl` — 16 tests: guard/call/mixed-arg ASTs, foreign-spec collection, `wam_vm` option gating (plain programs emit no VM), wrapper + lazy-VM + heap-rewind IR shapes, and e2e binaries built from real compiled predicates: fact-based guard (multi-clause dispatch), if-then-else classifier, `is/2` arithmetic, negated guards, per-record prints, and arithmetic composition.

## Testing (honest exit codes)

- `tests/test_plawk_surface_prolog_calls.pl` — 16/16 pass
- Full regression: prefix_print, else_if, end_scalar_exprs, pattern_combinators, regex_match, arith_exprs, forin_end_print, stdin_input — all pass

**Merge order:** #3401 → #3402 → #3403 → #3404 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_