### PR TITLE
plawk: double-typed expressions in print and printf

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -311,6 +311,16 @@ those scalar arithmetic contexts. That coercion is emitted through the
 target-side `llvm_emit_atom_field_i64_or_default/7` helper so future native
 numeric consumers can share the parse-plus-default lowering instead of
 rebuilding it in PLAWK-specific code.
+Double-typed expressions are available in prints and printf arguments:
+an expression containing a float literal (`float_const(Mantissa, 10^k)`,
+emitted as an exact `fdiv` ratio so LLVM's exact-decimal-FP rule is
+satisfied and rounding matches strtod) or a `float($N)` strtod coercion
+(`@wam_atom_field_f64_value`) lowers through a parallel `plawk_f64_expr_ir`
+emitter with `fadd/fsub/fmul/fdiv/frem` and `sitofp` promotion of `i64`
+subtrees. Output is `%g` for `print` and `%f`/`%g`/`%e` (optional
+precision) for `printf`. Scalar slots remain `i64` in this slice; typed
+double slots (state-plan slot types threaded through the loop/branch/final
+phi emitters) are the follow-up that unlocks `{ sum += $2 * 1.5 }`.
 Scalar variables are readable inside rule-body update expressions and END
 prints: codegen substitutes `var(Name)` leaves with the current SSA slot
 value (an `ssa/1` leaf the shared emitters print verbatim) before emission,

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -80,6 +80,7 @@ swipl -q -s tests/test_plawk_surface_regex_match.pl -g "setenv('UW_SMOKE_TMPDIR'
 swipl -q -s tests/test_plawk_surface_end_scalar_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_else_if.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_prolog_calls.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_float_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -103,6 +104,18 @@ fields such as `$3`, which coerce like `int($3)` inside arithmetic (a bare
 `$N` on its own still prints as a byte slice). Division and modulo are
 guarded: a zero divisor yields `0`, and `INT64_MIN / -1` wraps to
 `INT64_MIN` (`% -1` yields `0`) instead of trapping.
+Expressions become double-typed when any operand is a float literal or a
+`float($N)` coercion: `{ print $2 / 2.0 }` prints `3.5` where
+`{ print $2 / 2 }` prints `3`. Float literals are kept exact as integer
+ratios (`1.5` emits `fdiv double 15.0, 10.0`, giving the correctly rounded
+double), `float($N)` parses with `strtod` semantics (leading number,
+trailing text ignored, `0` when non-numeric), and `i64` operands promote
+with `sitofp`. Double results print with `%g` (so `2.0 * 10` prints `20`)
+and `printf` accepts `%f`/`%g`/`%e` with optional precision such as `%.2f`.
+IEEE semantics apply to float division (no zero-divisor guard). Doubles are
+expression-level only in this slice: scalar slots, guards, and `END`
+expressions stay `i64`, and assigning a double expression to a scalar is
+rejected at codegen; typed double slots are the documented follow-up.
 Rule actions can also use basic `printf` forms, e.g.
 `$1 == "ERROR" { printf "%s=%s\n", $2, $3 }`. `printf` does not add `OFS` or
 an implicit newline; supported native formats are `%%`, `%s` for strings and

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -94,6 +94,7 @@ print_line:
 @.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 @.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
+@.plawk_surface_print_f64 = private constant [3 x i8] c"%g\\00"
 ~w
 ~w
 ~w
@@ -633,6 +634,7 @@ plawk_i64_end_print_globals(SurfaceGlobals, RuntimeGlobals) :-
 @.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 @.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
+@.plawk_surface_print_f64 = private constant [3 x i8] c"%g\\00"
 ~w
 
 ',
@@ -1795,6 +1797,8 @@ plawk_rule_body_print_field(Expr) :-
     plawk_i64_general_binary_expr(Expr).
 plawk_rule_body_print_field(Expr) :-
     plawk_prolog_call_expr(Expr).
+plawk_rule_body_print_field(Expr) :-
+    plawk_f64_print_expr(Expr).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
 plawk_rule_body_print_field(index(field(_), string(_))).
@@ -2278,6 +2282,96 @@ plawk_i64_binary_op_lines(srem, Base, LeftIR, RightIR, Lines) :-
 plawk_i64_binary_op_lines(LLVMOp, Base, LeftIR, RightIR, [Line]) :-
     format(atom(Line), '  %~w = ~w i64 ~w, ~w',
         [Base, LLVMOp, LeftIR, RightIR]).
+
+%% plawk_expr_is_double(+Expr) is semidet.
+%
+%  An expression tree is double-typed when any leaf is a float literal
+%  or a float($N) coercion; i64 leaves in a double tree promote via
+%  sitofp at emission time.
+plawk_expr_is_double(float_const(_Mantissa, _Denominator)).
+plawk_expr_is_double(float_field(_Index)).
+plawk_expr_is_double(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_is_double(Left)
+    ; plawk_expr_is_double(Right)
+    ).
+
+%% plawk_f64_print_expr(+Expr) is semidet.
+%
+%  Valid double print expression: double-typed with recognizable leaves.
+plawk_f64_print_expr(Expr) :-
+    plawk_expr_is_double(Expr),
+    plawk_f64_operand_expr(Expr).
+
+plawk_f64_operand_expr(float_const(Mantissa, Denominator)) :-
+    integer(Mantissa),
+    integer(Denominator),
+    Denominator > 0.
+plawk_f64_operand_expr(float_field(Index)) :-
+    integer(Index),
+    Index >= 0.
+plawk_f64_operand_expr(Expr) :-
+    plawk_i64_operand_expr(Expr).
+plawk_f64_operand_expr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    plawk_f64_operand_expr(Left),
+    plawk_f64_operand_expr(Right).
+
+%% plawk_f64_expr_ir(+Expr, +FieldSeparator, +Base, +GlobalBase, -ValueIR,
+%%     -GlobalParts, -SetupParts)
+%
+%  Double expression emitter. Float literals emit as an exact integer
+%  ratio (fdiv of two exactly representable doubles gives the correctly
+%  rounded value, matching strtod). i64 subtrees emit through the i64
+%  emitter and promote with sitofp; IEEE semantics apply to / (no
+%  divide-by-zero guard: x/0.0 is inf, 0.0/0.0 is nan, as in awk).
+plawk_f64_expr_ir(float_const(Mantissa, Denominator), _FieldSeparator, Base,
+        _GlobalBase, ValueIR, [], [ConstIR]) :-
+    format(atom(ValueIR), '%~w', [Base]),
+    format(atom(ConstIR), '  ~w = fdiv double ~w.0, ~w.0',
+        [ValueIR, Mantissa, Denominator]).
+plawk_f64_expr_ir(float_field(Index), FieldSeparator, Base, _GlobalBase,
+        ValueIR, [], [CallIR]) :-
+    format(atom(ValueIR), '%~w', [Base]),
+    format(atom(CallIR),
+        '  ~w = call double @wam_atom_field_f64_value(%Value %line, i64 ~w, i8 ~w)',
+        [ValueIR, Index, FieldSeparator]).
+plawk_f64_expr_ir(Expr, FieldSeparator, Base, GlobalBase, ValueIR,
+        GlobalParts, SetupParts) :-
+    plawk_expr_is_double(Expr),
+    plawk_i64_binary_expr(Expr, LLVMOp, _NamePart, Left, Right),
+    !,
+    plawk_f64_llvm_op(LLVMOp, F64Op),
+    format(atom(LeftBase), '~w_lhs', [Base]),
+    format(atom(LeftGlobalBase), '~w_lhs', [GlobalBase]),
+    plawk_f64_expr_ir(Left, FieldSeparator, LeftBase, LeftGlobalBase,
+        LeftValueIR, LeftGlobalParts, LeftSetupParts),
+    format(atom(RightBase), '~w_rhs', [Base]),
+    format(atom(RightGlobalBase), '~w_rhs', [GlobalBase]),
+    plawk_f64_expr_ir(Right, FieldSeparator, RightBase, RightGlobalBase,
+        RightValueIR, RightGlobalParts, RightSetupParts),
+    format(atom(ValueIR), '%~w', [Base]),
+    format(atom(OpIR), '  ~w = ~w double ~w, ~w',
+        [ValueIR, F64Op, LeftValueIR, RightValueIR]),
+    append(LeftGlobalParts, RightGlobalParts, GlobalParts),
+    append([LeftSetupParts, RightSetupParts, [OpIR]], SetupParts).
+plawk_f64_expr_ir(Expr, FieldSeparator, Base, GlobalBase, ValueIR,
+        GlobalParts, SetupParts) :-
+    % i64-typed subtree in a double context: emit as i64, then promote.
+    format(atom(IntBase), '~w_int', [Base]),
+    format(atom(IntGlobalBase), '~w_int', [GlobalBase]),
+    plawk_i64_expr_ir(Expr, FieldSeparator, IntBase, IntGlobalBase,
+        IntValueIR, GlobalParts, IntSetupParts),
+    format(atom(ValueIR), '%~w', [Base]),
+    format(atom(PromoteIR), '  ~w = sitofp i64 ~w to double',
+        [ValueIR, IntValueIR]),
+    append(IntSetupParts, [PromoteIR], SetupParts).
+
+plawk_f64_llvm_op(add, fadd).
+plawk_f64_llvm_op(sub, fsub).
+plawk_f64_llvm_op(mul, fmul).
+plawk_f64_llvm_op(sdiv, fdiv).
+plawk_f64_llvm_op(srem, frem).
 
 plawk_i64_guarded_div_lines(LLVMOp, Base, LeftIR, RightIR, Lines) :-
     format(atom(DenZero),
@@ -2865,11 +2959,13 @@ plawk_printf_arg_pairs([Arg | Args], FieldSeparator, Prefix, Index) -->
 plawk_printf_type_call_args(i64(_FmtPrefix, _PrintPrefix, ValueIR), [i64(ValueIR)]).
 plawk_printf_type_call_args(slice(_FmtPrefix, _PrintPrefix, LenIR, PtrIR), [slice_len(LenIR), slice_ptr(PtrIR)]).
 plawk_printf_type_call_args(string(_Base, PtrIR), [string_ptr(PtrIR)]).
+plawk_printf_type_call_args(f64(_FmtPrefix, _PrintPrefix, ValueIR), [f64(ValueIR)]).
 
 plawk_printf_call_arg_kind(i64(_ValueIR), i64).
 plawk_printf_call_arg_kind(slice_len(_LenIR), slice_len).
 plawk_printf_call_arg_kind(slice_ptr(_PtrIR), slice_ptr).
 plawk_printf_call_arg_kind(string_ptr(_PtrIR), string).
+plawk_printf_call_arg_kind(f64(_ValueIR), f64).
 
 plawk_printf_call_args_ir([], '') :-
     !.
@@ -2885,6 +2981,8 @@ plawk_printf_call_arg_ir(slice_ptr(PtrIR), IR) :-
     format(atom(IR), 'i8* ~w', [PtrIR]).
 plawk_printf_call_arg_ir(string_ptr(PtrIR), IR) :-
     format(atom(IR), 'i8* ~w', [PtrIR]).
+plawk_printf_call_arg_ir(f64(ValueIR), IR) :-
+    format(atom(IR), 'double ~w', [ValueIR]).
 
 plawk_printf_rewrite_format(Format, ArgKinds, RewrittenFormat) :-
     string_codes(Format, Codes),
@@ -2910,6 +3008,31 @@ plawk_printf_rewrite_codes([0'%, 0's | Rest], [slice_len, slice_ptr | Kinds],
         [0'%, 0'., 0'*, 0's | RewrittenRest]) :-
     !,
     plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
+plawk_printf_rewrite_codes([0'% | Rest], [f64 | Kinds], [0'% | RewrittenSpec]) :-
+    plawk_printf_f64_spec_codes(Rest, SpecCodes, RestAfterSpec),
+    !,
+    append(SpecCodes, RewrittenRest, RewrittenSpec),
+    plawk_printf_rewrite_codes(RestAfterSpec, Kinds, RewrittenRest).
+
+% %f / %g / %e with an optional .N precision pass through unchanged for
+% double arguments (C varargs receive the double directly).
+plawk_printf_f64_spec_codes([0'., Digit | Rest0], [0'., Digit | SpecRest], Rest) :-
+    code_type(Digit, digit),
+    !,
+    plawk_printf_f64_precision_codes(Rest0, SpecRest, Rest).
+plawk_printf_f64_spec_codes([Conv | Rest], [Conv], Rest) :-
+    plawk_printf_f64_conversion_code(Conv).
+
+plawk_printf_f64_precision_codes([Digit | Rest0], [Digit | SpecRest], Rest) :-
+    code_type(Digit, digit),
+    !,
+    plawk_printf_f64_precision_codes(Rest0, SpecRest, Rest).
+plawk_printf_f64_precision_codes([Conv | Rest], [Conv], Rest) :-
+    plawk_printf_f64_conversion_code(Conv).
+
+plawk_printf_f64_conversion_code(0'f).
+plawk_printf_f64_conversion_code(0'g).
+plawk_printf_f64_conversion_code(0'e).
 
 plawk_printf_i64_spec_codes([0'l, 0'd | Rest], Rest).
 plawk_printf_i64_spec_codes([0'd | Rest], Rest).
@@ -3026,6 +3149,15 @@ plawk_emit_print_expr_for_context(int(field(FieldIndex)), FieldSeparator, Contex
         ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(Expr, FieldSeparator, Context,
+        f64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_f64_print_expr(Expr),
+    !,
+    plawk_print_expr_value_base(Context, f64, Base),
+    plawk_print_expr_output_names(Context, f64, FmtPrefix, PrintPrefix),
+    plawk_f64_expr_ir(Expr, FieldSeparator, Base, Base, ValueIR,
+        GlobalParts, SetupParts).
+
+plawk_emit_print_expr_for_context(Expr, FieldSeparator, Context,
         i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, NamePart, _Left, _Right),
     plawk_i64_binary_print_kind(NamePart, Kind),
@@ -3112,6 +3244,8 @@ plawk_normal_print_expr_value_base(int_mod, Index, Base) :-
     format(atom(Base), 'plawk_int_mod_~w', [Index]).
 plawk_normal_print_expr_value_base(prolog_call, Index, Base) :-
     format(atom(Base), 'plawk_prolog_call_~w', [Index]).
+plawk_normal_print_expr_value_base(f64, Index, Base) :-
+    format(atom(Base), 'plawk_f64_~w', [Index]).
 plawk_normal_print_expr_value_base(length, Index, Base) :-
     format(atom(Base), 'plawk_length_~w', [Index]).
 plawk_normal_print_expr_value_base(substr, Index, Base) :-
@@ -3175,6 +3309,16 @@ plawk_print_expr_output_ir(slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), Index, P
     llvm_emit_printf_slice(plawk_surface_print_slice, FmtVar, PrintVar, LenIR, PtrIR,
         Parts).
 
+plawk_print_expr_output_ir(f64(FmtPrefix, PrintPrefix, ValueIR), Index, [FmtPtr, PrintCall]) :-
+    format(atom(FmtVar), '~w_fmt_~w', [FmtPrefix, Index]),
+    format(atom(PrintVar), 'printed_~w_~w', [PrintPrefix, Index]),
+    format(atom(FmtPtr),
+        '  %~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_f64, i32 0, i32 0',
+        [FmtVar]),
+    format(atom(PrintCall),
+        '  %~w = call i32 (i8*, ...) @printf(i8* %~w, double ~w)',
+        [PrintVar, FmtVar, ValueIR]).
+
 plawk_print_expr_output_ir(case_slice(Mode, PrintBase, LenIR, PtrIR), _Index, [PrintCall]) :-
     llvm_emit_ascii_case_slice_print(Mode, PtrIR, LenIR, PrintBase, PrintCall).
 
@@ -3183,6 +3327,9 @@ plawk_prefixed_print_expr_output_ir(i64(FmtPrefix, PrintPrefix, ValueIR), _Prefi
 
 plawk_prefixed_print_expr_output_ir(slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), _Prefix, Index, Parts) :-
     plawk_print_expr_output_ir(slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), Index, Parts).
+
+plawk_prefixed_print_expr_output_ir(f64(FmtPrefix, PrintPrefix, ValueIR), _Prefix, Index, Parts) :-
+    plawk_print_expr_output_ir(f64(FmtPrefix, PrintPrefix, ValueIR), Index, Parts).
 
 plawk_prefixed_print_expr_output_ir(case_slice(Mode, PrintBase, LenIR, PtrIR), _Prefix, _Index, [PrintCall]) :-
     llvm_emit_ascii_case_slice_print(Mode, PtrIR, LenIR, PrintBase, PrintCall).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -774,6 +774,12 @@ field_expr(string(Value)) -->
     { string_codes(Value, ValueCodes)
     }.
 field_expr(Expr) -->
+    float_field_expr(Expr),
+    !.
+field_expr(Expr) -->
+    float_literal_expr(Expr),
+    !.
+field_expr(Expr) -->
     prolog_call_expr(Expr),
     !.
 field_expr(var(Name)) -->
@@ -858,6 +864,12 @@ i64_factor_expr(Expr) -->
 i64_factor_expr(Expr) -->
     i64_binary_primary_expr(Expr),
     !.
+i64_factor_expr(Expr) -->
+    float_field_expr(Expr),
+    !.
+i64_factor_expr(Expr) -->
+    float_literal_expr(Expr),
+    !.
 i64_factor_expr(int(Value)) -->
     integer_codes(ValueCodes),
     !,
@@ -892,6 +904,43 @@ prolog_call_expr(prolog_call(Name, Args)) -->
     foreign_args(Args),
     ws,
     ")".
+
+%% float_literal_expr(-Expr)//
+%
+%  A decimal float literal such as 2.5 or 0.1, kept exact as
+%  float_const(Mantissa, Denominator) with Denominator = 10^k so
+%  codegen can emit a correctly rounded double without a lossy
+%  Prolog-float round trip (LLVM rejects inexact decimal FP text).
+float_literal_expr(float_const(Mantissa, Denominator)) -->
+    integer_codes(IntCodes),
+    ".",
+    integer_codes(FracCodes),
+    { IntCodes \== [],
+      FracCodes \== [],
+      append(IntCodes, FracCodes, AllCodes),
+      number_codes(Mantissa, AllCodes),
+      length(FracCodes, FracLen),
+      Denominator is 10 ** FracLen
+    }.
+
+%% float_field_expr(-Expr)//
+%
+%  awk-style numeric coercion to double: float($N) parses the field
+%  with strtod semantics (leading number, trailing text ignored, 0.0
+%  when non-numeric).
+float_field_expr(float_field(Index)) -->
+    "float",
+    ws,
+    "(",
+    ws,
+    "$",
+    integer_codes(IndexCodes),
+    ws,
+    ")",
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    }.
 
 i64_binary_primary_expr(special('NR')) -->
     "NR".

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1616,7 +1616,8 @@ declare double @acos(double)
 declare double @atan(double)
 declare double @atan2(double, double)
 declare i32 @regcomp(i8*, i8*, i32)
-declare i32 @regexec(i8*, i8*, i64, i8*, i32)'
+declare i32 @regexec(i8*, i8*, i64, i8*, i32)
+declare double @strtod(i8*, i8**)'
     ).
 
 %% generate_wasm_exports(+Predicates, -ExportCode)
@@ -4489,6 +4490,81 @@ rgx.terminate:
 
 rgx.fail:
   ret i1 false
+}
+
+; awk-style numeric coercion of a record or projected field to double:
+; strtod parses a leading number and ignores trailing text, so
+; "3.14abc" reads as 3.14 and non-numeric text reads as 0.0. Field
+; slices are copied into a growable NUL-terminated scratch buffer;
+; field 0 uses the record atom''s C string directly.
+@wam_f64_field_buf = internal global i8* null
+@wam_f64_field_cap = internal global i64 0
+
+define double @wam_atom_field_f64_value(%Value %line, i64 %field_index, i8 %sep) {
+entry:
+  %is_whole = icmp eq i64 %field_index, 0
+  br i1 %is_whole, label %f64.whole, label %f64.field
+
+f64.whole:
+  %aid = call i64 @value_payload(%Value %line)
+  %line_s = call i8* @wam_atom_to_string(i64 %aid)
+  %line_null = icmp eq i8* %line_s, null
+  br i1 %line_null, label %f64.zero, label %f64.parse_whole
+
+f64.parse_whole:
+  %whole_v = call double @strtod(i8* %line_s, i8** null)
+  ret double %whole_v
+
+f64.field:
+  %slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 %field_index, i8 %sep)
+  %fptr = extractvalue %WamSlice %slice, 0
+  %flen = extractvalue %WamSlice %slice, 1
+  %missing = icmp eq i8* %fptr, null
+  br i1 %missing, label %f64.zero, label %f64.ensure_buf
+
+f64.ensure_buf:
+  %need = add i64 %flen, 1
+  %cap = load i64, i64* @wam_f64_field_cap
+  %fits = icmp ule i64 %need, %cap
+  br i1 %fits, label %f64.copy, label %f64.grow
+
+f64.grow:
+  %old_buf = load i8*, i8** @wam_f64_field_buf
+  %new_cap = shl i64 %need, 1
+  %new_buf = call i8* @realloc(i8* %old_buf, i64 %new_cap)
+  %grow_null = icmp eq i8* %new_buf, null
+  br i1 %grow_null, label %f64.zero, label %f64.store_buf
+
+f64.store_buf:
+  store i8* %new_buf, i8** @wam_f64_field_buf
+  store i64 %new_cap, i64* @wam_f64_field_cap
+  br label %f64.copy
+
+f64.copy:
+  %buf = load i8*, i8** @wam_f64_field_buf
+  br label %f64.copy_loop
+
+f64.copy_loop:
+  %ci = phi i64 [ 0, %f64.copy ], [ %ci1, %f64.copy_step ]
+  %copy_done = icmp uge i64 %ci, %flen
+  br i1 %copy_done, label %f64.terminate, label %f64.copy_step
+
+f64.copy_step:
+  %src_p = getelementptr i8, i8* %fptr, i64 %ci
+  %dst_p = getelementptr i8, i8* %buf, i64 %ci
+  %byte = load i8, i8* %src_p
+  store i8 %byte, i8* %dst_p
+  %ci1 = add i64 %ci, 1
+  br label %f64.copy_loop
+
+f64.terminate:
+  %end_p = getelementptr i8, i8* %buf, i64 %flen
+  store i8 0, i8* %end_p
+  %field_v = call double @strtod(i8* %buf, i8** null)
+  ret double %field_v
+
+f64.zero:
+  ret double 0.000000e+00
 }
 
 define %Value @wam_stream_fail_value() alwaysinline nounwind {

--- a/tests/test_plawk_surface_float_exprs.pl
+++ b/tests/test_plawk_surface_float_exprs.pl
@@ -1,0 +1,155 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_float_marker/0.
+
+user:plawk_float_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_float_exprs, [condition(clang_available)]).
+
+test(parses_float_literal_as_exact_ratio) :-
+    plawk_parse_string("{ print $2 * 1.5 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([mul_i64(field(2), float_const(15, 10))])])], [])).
+
+test(parses_float_field_coercion) :-
+    plawk_parse_string("{ print float($2) }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([float_field(2)])])], [])).
+
+test(parses_float_in_printf_arg) :-
+    plawk_parse_string("{ printf \"%.2f;\", $2 / 3.0 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [printf(string("%.2f;"),
+            [div_i64(field(2), float_const(30, 10))])])], [])).
+
+test(integer_division_stays_integer) :-
+    plawk_parse_string("{ print $2 / 2.0, $2 / 2 }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [print([div_i64(field(2), float_const(20, 10)),
+                div_i64(field(2), int(2))])])], [])).
+
+test(float_expr_ir_uses_fdiv_ratio_and_promotion) :-
+    plawk_parse_string("{ print ($2 + 1) * 0.5 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= fdiv double 5.0, 10.0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= sitofp i64 '))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= fmul double '))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_f64 = private constant [3 x i8] c"%g\\00"'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(float_field_ir_uses_strtod_helper) :-
+    plawk_parse_string("{ print float($2) }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_f64_value(%Value %line, i64 2, i8 32)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_float_multiply_prints_g_format) :-
+    run_float_print_smoke("{ print $2 * 1.5 }\n",
+        "a 10\nb 3\n",
+        "15\n4.5\n").
+
+test(surface_int_and_float_division_differ) :-
+    run_float_print_smoke("{ print $2 / 2.0, $2 / 2 }\n",
+        "a 7\n",
+        "3.5 3\n").
+
+test(surface_float_field_uses_strtod_semantics) :-
+    run_float_print_smoke("{ print float($2) }\n",
+        "a 3.14\nb 2.5rest\nc abc\n",
+        "3.14\n2.5\n0\n").
+
+test(surface_printf_fixed_precision) :-
+    run_float_print_smoke("{ printf \"%.2f;\", $2 / 3.0 }\n",
+        "a 10\nb 1\n",
+        "3.33;0.33;").
+
+test(surface_parenthesized_int_subtree_promotes) :-
+    run_float_print_smoke("{ print ($2 + 1) * 0.5 }\n",
+        "a 9\n",
+        "5\n").
+
+test(surface_nr_promotes_to_double) :-
+    run_float_print_smoke("{ print NR * 0.5 }\n",
+        "a\nb\n",
+        "0.5\n1\n").
+
+test(surface_decimal_literals_round_correctly) :-
+    run_float_print_smoke("{ print 0.1 + 0.2 }\n",
+        "x\n",
+        "0.3\n").
+
+test(surface_integer_valued_double_prints_without_point) :-
+    run_float_print_smoke("{ print 2.0 * $2 }\n",
+        "a 10\n",
+        "20\n").
+
+test(surface_printf_g_and_e_formats) :-
+    run_float_print_smoke("{ printf \"%g|%e\\n\", float($2) * 2.0, float($2) }\n",
+        "a 1.25\n",
+        "2.5|1.250000e+00\n").
+
+test(surface_float_field_plus_int_field) :-
+    run_float_print_smoke("{ print float($2) + $3 }\n",
+        "a 0.5 2\n",
+        "2.5\n").
+
+test(surface_float_composes_with_guards) :-
+    run_float_print_smoke("$1 == \"ERROR\" { print $3 * 1.5 }\n",
+        "ERROR disk 10\nWARN cpu 4\nERROR net 3\n",
+        "15\n4.5\n").
+
+run_float_print_smoke(Source, Input, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_float_exprs', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_float_exprs.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_float_marker/0 ],
+        [module_name('plawk_surface_float_exprs')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_float_exprs_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[plawk surface float exprs output]~n~w~n",
+              [OutStr]),
+       throw(plawk_surface_float_exprs_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_surface_float_exprs).


### PR DESCRIPTION
## Summary

**Stacked on #3405** (→ #3404 → #3403 → #3402 → #3401). Final PR of the series — the first slice of float support, delivered design-first.

```awk
{ print $2 / 2.0, $2 / 2 }        # 3.5 3 — float vs integer division, explicit
{ print float($2) }               # strtod coercion: "2.5rest" → 2.5, "abc" → 0
{ printf "%.2f;", $2 / 3.0 }      # fixed precision
{ print ($2 + 1) * 0.5 }          # i64 subtrees promote via sitofp
{ print 0.1 + 0.2 }               # 0.3 (correctly rounded literals, %g output)
```

## Design decision

Full awk everything-is-a-double semantics would silently change every existing integer program (`$3 / 2`, `%d` printf, guarded division, END averages) — so this slice makes doubles **explicit and inference-driven**: an expression is double-typed when any operand is a float literal or a `float($N)` coercion; otherwise the established i64 semantics are untouched. `$2 / 2` still truncates; `$2 / 2.0` doesn't.

**Scope boundary (deliberate):** doubles are expression-level only. Scalar slots, guards, and `END` expressions stay `i64`, and assigning a double expression to a scalar is rejected at codegen. Typed double slots — slot types threaded through the ~8 loop/branch/final phi emitters — are the documented follow-up that unlocks `{ sum += $2 * 1.5 }`.

## Interesting bits

- **Exact float literals.** LLVM's textual IR rejects decimal FP constants that aren't exactly representable (`double 0.1` is an error). Instead of a lossy Prolog-float→hex round trip, the parser keeps literals exact as `float_const(Mantissa, 10^k)` and codegen emits `fdiv double 15.0, 10.0` — both operands exactly representable, and one correctly rounded IEEE division yields the same double `strtod` would produce.
- **`float($N)`** lowers to a new `@wam_atom_field_f64_value` runtime helper: `strtod` over a NUL-terminated scratch copy of the field slice (leading number, trailing text ignored, `0.0` for non-numeric/missing — awk's coercion semantics).
- **Emission** is a parallel `plawk_f64_expr_ir` mirroring the i64 emitter (`fadd/fsub/fmul/fdiv/frem`, `sitofp` promotion of i64 subtrees). Float division is IEEE — no zero-divisor guard, `x/0.0` is `inf` as in awk.
- **Output:** `print` uses a shared `%g` global (integer-valued doubles print as `20`, awk-style); `printf` passes doubles to the vararg call and accepts `%f`/`%g`/`%e` with optional precision.

## Testing (honest exit codes)

- `tests/test_plawk_surface_float_exprs.pl` — 17/17 pass: exact-ratio ASTs, `fdiv`/`sitofp`/`%g` IR shapes, int-vs-float division duality, strtod trailing-text semantics, `0.1 + 0.2` rounding, `%.2f`/`%g`/`%e`, promotion, guard composition
- Full regression: all nine plawk surface suites **plus** the 80-test `test_wam_llvm_target` suite (runtime touched) — all pass

**Merge order for the whole series:** #3401 → #3402 → #3403 → #3404 → #3405 → this. After each merge, retarget the next PR to `main` (or let GitHub do it if the base branch is deleted on merge) — last time the stacked PRs merged into each other's branches instead of `main`, which #3401 repairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_