### PR TITLE
wam_llvm: hash-indexed atom interning (fixes O(n²) streaming)

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -416,11 +416,16 @@ wrapper functions around a lazily created shared `%WamState`; wrappers save
 and restore the VM heap top and rewind the arena via `@wam_cleanup`, so
 foreign calls run in constant memory (~5µs/call, bytecode-interpreted).
 `plawk_program_native_driver_ir/4` takes `wam_vm(InstrCount, LabelCount)`
-for the `wam_state_new` geps. Known pre-existing scalability note exposed
-by soak-testing this feature: `read_line`'s per-line `wam_intern_atom` is a
-linear scan over the dynamic atom table, so streams with many unique lines
-pay O(n^2) interning regardless of foreign calls — a hashed atom table (or
-slice-based records) is the fix and is independent of this surface.
+for the `wam_state_new` geps. Soak-testing this feature exposed that
+`read_line`'s per-line `wam_intern_atom` was a linear scan over the atom
+tables, so streams with many unique lines paid O(n^2) interning — fixed:
+`wam_intern_atom` now goes through an FNV-1a hash index over the static +
+dynamic atom tables (slots hold atom id + 1, built lazily on first intern,
+grown at 50% load), making interning O(1) amortized. Measured on a
+200k-unique-line stream: 2m8s before, 0.1s after, ~4x of mawk on the same
+program. The remaining per-record cost is the malloc+copy of each unique
+line into the dynamic atom table; slice-based records (Phase 3 binary-record
+territory) remove it entirely.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -81,6 +81,7 @@ swipl -q -s tests/test_plawk_surface_end_scalar_exprs.pl -g "setenv('UW_SMOKE_TM
 swipl -q -s tests/test_plawk_surface_else_if.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_prolog_calls.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_float_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_wam_llvm_atom_intern_scaling.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -17027,6 +17027,17 @@ define i64 @wam_intern_atom(i8* %str, i64 %len) {
 @wam_atom_dyn_count = global i32 0
 @wam_atom_dyn_cap   = global i32 0
 
+; FNV-1a hash index over the atom tables: maps string -> atom id so
+; wam_intern_atom is O(1) amortized instead of a linear scan over
+; every atom (previously O(table size) per intern, which made streams
+; that intern many unique lines through read_line quadratic). Slots
+; hold atom_id + 1; 0 marks an empty slot. Built lazily on the first
+; intern, seeded with every existing static and dynamic atom, and
+; grown at 50 percent load by rehashing all ids.
+@wam_atom_hash_slots = global i64* null
+@wam_atom_hash_cap   = global i64 0
+@wam_atom_hash_count = global i64 0
+
 define i8* @wam_atom_to_string(i64 %id) {
 entry:
   %cnt = load i32, i32* @wam_atom_string_count
@@ -17094,57 +17105,195 @@ check_term:
   ret i1 %term
 }
 
-; M29: intern an atom by (str, len). Linear scan over static then
-; dynamic table; if found, return existing id. If not found, copy
-; the string into a malloc''d block, append to the dynamic table
-; (growing via realloc as needed), and return the new id.
+; FNV-1a over the raw bytes. The 64-bit offset basis
+; 14695981039346656037 is written in two-s complement signed form
+; because LLVM textual IR rejects unsigned constants above 2^63 - 1.
+define i64 @wam_atom_hash_value(i8* %str, i64 %len) {
+entry:
+  br label %loop
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i1, %step ]
+  %h = phi i64 [ -3750763034362895579, %entry ], [ %h1, %step ]
+  %done = icmp uge i64 %i, %len
+  br i1 %done, label %ret, label %step
+step:
+  %bp = getelementptr i8, i8* %str, i64 %i
+  %b = load i8, i8* %bp
+  %b64 = zext i8 %b to i64
+  %hx = xor i64 %h, %b64
+  %h1 = mul i64 %hx, 1099511628211
+  %i1 = add i64 %i, 1
+  br label %loop
+ret:
+  ret i64 %h
+}
+
+; Probe for (str, len): returns the index of the matching occupied
+; slot, or of the empty slot where the string belongs. Requires
+; cap > 0 with load factor below 1, which the grow-at-50-percent rule
+; guarantees, so the probe always terminates.
+define i64 @wam_atom_hash_find_slot(i8* %str, i64 %len) {
+entry:
+  %cap = load i64, i64* @wam_atom_hash_cap
+  %slots = load i64*, i64** @wam_atom_hash_slots
+  %h = call i64 @wam_atom_hash_value(i8* %str, i64 %len)
+  %start = urem i64 %h, %cap
+  br label %probe
+probe:
+  %idx = phi i64 [ %start, %entry ], [ %next, %miss ]
+  %slot_p = getelementptr i64, i64* %slots, i64 %idx
+  %v = load i64, i64* %slot_p
+  %empty = icmp eq i64 %v, 0
+  br i1 %empty, label %found, label %check
+check:
+  %cand_id = sub i64 %v, 1
+  %cand_s = call i8* @wam_atom_to_string(i64 %cand_id)
+  %cand_null = icmp eq i8* %cand_s, null
+  br i1 %cand_null, label %miss, label %cmp
+cmp:
+  %eq = call i1 @wam_str_eq_n(i8* %str, i64 %len, i8* %cand_s)
+  br i1 %eq, label %found, label %miss
+miss:
+  %idx1 = add i64 %idx, 1
+  %wrap = icmp uge i64 %idx1, %cap
+  %next = select i1 %wrap, i64 0, i64 %idx1
+  br label %probe
+found:
+  ret i64 %idx
+}
+
+; Insert an existing atom id into the hash by its string. When the
+; same string appears under two ids (duplicate static entries), the
+; first id inserted wins, mirroring the old first-match linear scan.
+define i1 @wam_atom_hash_insert_id(i64 %id) {
+entry:
+  %s = call i8* @wam_atom_to_string(i64 %id)
+  %s_null = icmp eq i8* %s, null
+  br i1 %s_null, label %skip, label %measure
+measure:
+  br label %len_loop
+len_loop:
+  %li = phi i64 [ 0, %measure ], [ %li1, %len_step ]
+  %lp = getelementptr i8, i8* %s, i64 %li
+  %lb = load i8, i8* %lp
+  %lz = icmp eq i8 %lb, 0
+  br i1 %lz, label %have_len, label %len_step
+len_step:
+  %li1 = add i64 %li, 1
+  br label %len_loop
+have_len:
+  %slot_idx = call i64 @wam_atom_hash_find_slot(i8* %s, i64 %li)
+  %slots = load i64*, i64** @wam_atom_hash_slots
+  %slot_p = getelementptr i64, i64* %slots, i64 %slot_idx
+  %v = load i64, i64* %slot_p
+  %empty = icmp eq i64 %v, 0
+  br i1 %empty, label %fill, label %skip
+fill:
+  %idp1 = add i64 %id, 1
+  store i64 %idp1, i64* %slot_p
+  %cnt = load i64, i64* @wam_atom_hash_count
+  %cnt1 = add i64 %cnt, 1
+  store i64 %cnt1, i64* @wam_atom_hash_count
+  ret i1 true
+skip:
+  ret i1 false
+}
+
+; Allocate a zeroed slot array of new_cap entries and reinsert every
+; atom id currently in the static + dynamic tables. Used for both
+; lazy init and growth. Fails only if malloc fails, in which case the
+; previous table (if any) is left untouched and still valid.
+define i1 @wam_atom_hash_rebuild(i64 %new_cap) {
+entry:
+  %bytes = shl i64 %new_cap, 3
+  %mem = call i8* @malloc(i64 %bytes)
+  %mem_null = icmp eq i8* %mem, null
+  br i1 %mem_null, label %fail, label %zero_init
+zero_init:
+  %new_slots = bitcast i8* %mem to i64*
+  br label %zloop
+zloop:
+  %zi = phi i64 [ 0, %zero_init ], [ %zi1, %zstep ]
+  %zdone = icmp uge i64 %zi, %new_cap
+  br i1 %zdone, label %swap, label %zstep
+zstep:
+  %zp = getelementptr i64, i64* %new_slots, i64 %zi
+  store i64 0, i64* %zp
+  %zi1 = add i64 %zi, 1
+  br label %zloop
+swap:
+  %old = load i64*, i64** @wam_atom_hash_slots
+  store i64* %new_slots, i64** @wam_atom_hash_slots
+  store i64 %new_cap, i64* @wam_atom_hash_cap
+  store i64 0, i64* @wam_atom_hash_count
+  %old_null = icmp eq i64* %old, null
+  br i1 %old_null, label %reinsert_init, label %free_old
+free_old:
+  %old_i8 = bitcast i64* %old to i8*
+  call void @free(i8* %old_i8)
+  br label %reinsert_init
+reinsert_init:
+  ; Total ids = static count + dynamic count. Id 0 and any null static
+  ; slots resolve to null strings and are skipped by insert.
+  %st_cnt = load i32, i32* @wam_atom_string_count
+  %st_64 = zext i32 %st_cnt to i64
+  %dy_cnt = load i32, i32* @wam_atom_dyn_count
+  %dy_64 = zext i32 %dy_cnt to i64
+  %total = add i64 %st_64, %dy_64
+  br label %riloop
+riloop:
+  %ri = phi i64 [ 0, %reinsert_init ], [ %ri1, %ristep ]
+  %ridone = icmp uge i64 %ri, %total
+  br i1 %ridone, label %ok, label %ristep
+ristep:
+  %ins_ignored = call i1 @wam_atom_hash_insert_id(i64 %ri)
+  %ri1 = add i64 %ri, 1
+  br label %riloop
+ok:
+  ret i1 true
+fail:
+  ret i1 false
+}
+
+; Intern an atom by (str, len) through the hash index: hit returns the
+; existing id in O(1) amortized; miss copies the string, appends it to
+; the dynamic table (growing via realloc as needed), and records the
+; new id in the hash.
 define i64 @wam_intern_atom(i8* %str, i64 %len) {
 entry:
-  ; Scan static table.
+  %cap0 = load i64, i64* @wam_atom_hash_cap
+  %uninit = icmp eq i64 %cap0, 0
+  br i1 %uninit, label %init_hash, label %lookup
+
+init_hash:
+  ; First intern: size the table to keep the static atoms below
+  ; 50 percent load, minimum 4096 slots.
+  %st_cnt0 = load i32, i32* @wam_atom_string_count
+  %st0_64 = zext i32 %st_cnt0 to i64
+  %seed_need = shl i64 %st0_64, 2
+  %small = icmp ult i64 %seed_need, 4096
+  %init_cap = select i1 %small, i64 4096, i64 %seed_need
+  %init_ok = call i1 @wam_atom_hash_rebuild(i64 %init_cap)
+  br i1 %init_ok, label %lookup, label %intern_fail
+
+lookup:
+  %slot_idx = call i64 @wam_atom_hash_find_slot(i8* %str, i64 %len)
+  %slots = load i64*, i64** @wam_atom_hash_slots
+  %slot_p = getelementptr i64, i64* %slots, i64 %slot_idx
+  %v = load i64, i64* %slot_p
+  %hit = icmp ne i64 %v, 0
+  br i1 %hit, label %ret_hit, label %do_intern
+
+ret_hit:
+  %hit_id = sub i64 %v, 1
+  ret i64 %hit_id
+
+do_intern:
   %st_cnt = load i32, i32* @wam_atom_string_count
   %st_cnt_64 = zext i32 %st_cnt to i64
-  br label %scan_static
-scan_static:
-  %s_i = phi i64 [ 0, %entry ], [ %s_i1, %scan_static_step ]
-  %s_done = icmp uge i64 %s_i, %st_cnt_64
-  br i1 %s_done, label %scan_dyn_init, label %scan_static_check
-scan_static_check:
-  %st_slot_ptr = getelementptr [~w x i8*], [~w x i8*]* @wam_atom_strings, i32 0, i64 %s_i
-  %st_cand = load i8*, i8** %st_slot_ptr
-  %st_null = icmp eq i8* %st_cand, null
-  br i1 %st_null, label %scan_static_step, label %scan_static_cmp
-scan_static_cmp:
-  %st_eq = call i1 @wam_str_eq_n(i8* %str, i64 %len, i8* %st_cand)
-  br i1 %st_eq, label %ret_static_id, label %scan_static_step
-ret_static_id:
-  ret i64 %s_i
-scan_static_step:
-  %s_i1 = add i64 %s_i, 1
-  br label %scan_static
-
-scan_dyn_init:
   %dyn_cnt = load i32, i32* @wam_atom_dyn_count
   %dyn_cnt_64 = zext i32 %dyn_cnt to i64
   %dyn_ptr_0 = load i8**, i8*** @wam_atom_dyn_ptr
-  br label %scan_dyn
-scan_dyn:
-  %d_i = phi i64 [ 0, %scan_dyn_init ], [ %d_i1, %scan_dyn_step ]
-  %d_done = icmp uge i64 %d_i, %dyn_cnt_64
-  br i1 %d_done, label %do_intern, label %scan_dyn_check
-scan_dyn_check:
-  %d_slot_ptr = getelementptr i8*, i8** %dyn_ptr_0, i64 %d_i
-  %d_cand = load i8*, i8** %d_slot_ptr
-  %d_eq = call i1 @wam_str_eq_n(i8* %str, i64 %len, i8* %d_cand)
-  br i1 %d_eq, label %ret_dyn_id, label %scan_dyn_step
-ret_dyn_id:
-  %dyn_id = add i64 %st_cnt_64, %d_i
-  ret i64 %dyn_id
-scan_dyn_step:
-  %d_i1 = add i64 %d_i, 1
-  br label %scan_dyn
-
-do_intern:
-  ; Need to append. First, ensure capacity.
   %dyn_cap = load i32, i32* @wam_atom_dyn_cap
   %need_grow = icmp uge i32 %dyn_cnt, %dyn_cap
   br i1 %need_grow, label %do_grow, label %do_alloc_str
@@ -17186,9 +17335,26 @@ do_copy:
   %new_cnt = add i32 %dyn_cnt, 1
   store i32 %new_cnt, i32* @wam_atom_dyn_count
   %new_id = add i64 %st_cnt_64, %dyn_cnt_64
+  ; Record the new id in the hash, then grow past 50 percent load.
+  %idp1 = add i64 %new_id, 1
+  store i64 %idp1, i64* %slot_p
+  %hcnt = load i64, i64* @wam_atom_hash_count
+  %hcnt1 = add i64 %hcnt, 1
+  store i64 %hcnt1, i64* @wam_atom_hash_count
+  %hcap = load i64, i64* @wam_atom_hash_cap
+  %half = lshr i64 %hcap, 1
+  %needs_hash_grow = icmp ugt i64 %hcnt1, %half
+  br i1 %needs_hash_grow, label %grow_hash, label %ret_new
+grow_hash:
+  ; On rebuild failure the old table stays valid, only fuller; the
+  ; intern itself already succeeded.
+  %gcap = shl i64 %hcap, 1
+  %grow_ignored = call i1 @wam_atom_hash_rebuild(i64 %gcap)
+  br label %ret_new
+ret_new:
   ret i64 %new_id
 }',
-           [ArrSize, SlotsStr, ArrSize, CharSlotsStr, ArrSize, ArrSize, ArrSize, ArrSize]),
+           [ArrSize, SlotsStr, ArrSize, CharSlotsStr, ArrSize, ArrSize]),
        atomic_list_concat(StrGlobals, '\n', StrGlobalsStr),
        atomic_list_concat([StrGlobalsStr, LookupTable], '\n\n', IR)
     ).

--- a/tests/test_wam_llvm_atom_intern_scaling.pl
+++ b/tests/test_wam_llvm_atom_intern_scaling.pl
@@ -1,0 +1,117 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_intern_marker/0.
+
+user:plawk_intern_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_atom_intern_scaling, [condition(clang_available)]).
+
+% Regression guard for the O(n^2) intern scan: read_line interns every
+% record, so before the FNV hash index a 200k-unique-line stream took
+% over two minutes; with it, well under a second. The 60-second bound
+% is deliberately loose for slow CI while still catching a quadratic
+% relapse (which lands at minutes, not seconds).
+test(unique_line_stream_interning_is_not_quadratic) :-
+    build_sum_binary(Dir, BinPath),
+    directory_file_path(Dir, 'unique.txt', InputPath),
+    write_numbered_lines(InputPath, 200000),
+    get_time(T0),
+    run_binary(BinPath, InputPath, OutStr),
+    get_time(T1),
+    Elapsed is T1 - T0,
+    % sum of 0..199999
+    assertion(OutStr == "19999900000\n"),
+    ( Elapsed < 60
+    -> true
+    ;  throw(atom_intern_scaling_regressed(seconds(Elapsed)))
+    ),
+    !.
+
+% Interning must still deduplicate: repeated lines reuse one dynamic
+% atom, and keys equal to statically interned atoms resolve to the
+% static ids (counted correctly through the assoc table).
+test(repeated_and_static_atoms_still_deduplicate) :-
+    build_count_binary(Dir, BinPath),
+    directory_file_path(Dir, 'mixed.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, Out, [type(binary)]),
+        forall(between(1, 500, _),
+            format(Out, 'ERROR disk 1~nWARN cpu 2~n', [])),
+        close(Out)),
+    run_binary(BinPath, InputPath, OutStr),
+    assertion(OutStr == "500 500\n"),
+    !.
+
+build_sum_binary(Dir, BinPath) :-
+    build_probe_binary("{ total += $3 } END { print total }\n",
+        'intern_sum', Dir, BinPath).
+
+build_count_binary(Dir, BinPath) :-
+    build_probe_binary("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        'intern_count', Dir, BinPath).
+
+build_probe_binary(Source, Name, Dir, BinPath) :-
+    tmp_root(Root),
+    atom_concat('uw_wam_llvm_atom_intern_', Name, DirName),
+    directory_file_path(Root, DirName, Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_intern_marker/0 ],
+        [module_name(Name)], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[atom intern scaling build output]~n~w~n", [BuildOut]),
+       throw(atom_intern_scaling_build_failed(Status))
+    ).
+
+write_numbered_lines(Path, Count) :-
+    Limit is Count - 1,
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(between(0, Limit, I),
+            format(Out, 'k~w comp ~w~n', [I, I])),
+        close(Out)).
+
+run_binary(BinPath, InputPath, OutStr) :-
+    format(atom(Cmd), '~w ~w', [BinPath, InputPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  throw(atom_intern_scaling_run_failed(Status))
+    ).
+
+:- end_tests(wam_llvm_atom_intern_scaling).


### PR DESCRIPTION
## Summary

**Stacked on #3406** (→ #3405 → #3404 → #3403 → #3402 → #3401). Fixes the O(n²) exposed by the foreign-call soak: `wam_intern_atom` linearly scanned the static then dynamic atom tables on every call, and `read_line` interns every record — so each unique line scanned all previously interned lines. A 200k-unique-line stream took **2m8s regardless of what the program did**. Streaming must be O(n); now it is.

## Measured

| Program (200k records, unique lines) | Before | After |
|---|---|---|
| `{ total += $3 } END { print total }` | 2m8.4s | **0.098s** (~1300×) |
| same + a Prolog predicate call per record | 2m9.5s | **0.134s** |
| mawk, same program (reference) | 0.024s | 0.024s |

Two corollaries worth noting:
- This **corrects the foreign-call overhead estimate from #3405**: with interning no longer dominating both sides of the measurement, a small compiled-predicate call costs **~0.2µs**, not ~5µs.
- The remaining ~4× gap to mawk is the per-line malloc+copy of every unique line into the dynamic atom table — pure overhead for programs that never revisit the line atom. Slice-based records (Phase 3 binary-record territory) remove it entirely; that's the next step on the "faster than awk via numeric/binary datatypes" path, now recorded in the plan doc.

## Design

An **FNV-1a hash index** over both atom tables, in the same shared IR template:

- `@wam_atom_hash_slots` holds `atom_id + 1` per slot (`0` = empty). Built lazily on the first intern, seeded with every existing static and dynamic atom, grown at 50% load by rehashing all ids (rebuild allocates before swapping, so a failed grow leaves the previous table valid).
- Probing resolves candidate strings through the existing `wam_atom_to_string`, so one index covers static and runtime-interned atoms uniformly, and duplicate static strings keep the old first-match semantics (first id wins).
- The miss path is the previous append-to-dynamic-table code unchanged, plus recording the new id in the already-probed slot.
- No new libc dependencies (string lengths scan inline), so the WASM/native template split is untouched. The FNV offset basis is written in two's-complement form because LLVM's textual IR rejects unsigned constants above 2⁶³−1.

## Tests

`tests/test_wam_llvm_atom_intern_scaling.pl`:
- **Scaling guard**: builds a plawk binary, streams 200k unique lines, asserts correct output and a loose 60s wall-clock bound — a quadratic relapse lands at minutes, so the bound is CI-tolerant yet discriminating.
- **Dedup correctness**: repeated lines reuse one dynamic atom and keys equal to statically-interned atoms resolve to static ids, verified through assoc-table counts.

## Testing (honest exit codes)

- New scaling suite — 2/2 pass
- Full regression: all ten plawk surface suites, the 80-test `test_wam_llvm_target` suite, and `test_plawk_compiled_stream_core` (interning is load-bearing for assoc keys, regex scratch, foreign-call args, and quoted atoms throughout) — all pass

**Merge order:** #3401 → #3402 → #3403 → #3404 → #3405 → #3406 → this (retarget each to `main` after its base merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_