### PR TITLE
wam_llvm: transient line records for constant-memory streaming

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -423,9 +423,19 @@ tables, so streams with many unique lines paid O(n^2) interning — fixed:
 dynamic atom tables (slots hold atom id + 1, built lazily on first intern,
 grown at 50% load), making interning O(1) amortized. Measured on a
 200k-unique-line stream: 2m8s before, 0.1s after, ~4x of mawk on the same
-program. The remaining per-record cost is the malloc+copy of each unique
-line into the dynamic atom table; slice-based records (Phase 3 binary-record
-territory) remove it entirely.
+program. Follow-up landed: the plawk surface
+drivers now read records with `wam_stream_read_line_transient_value`, which
+builds each line in a shared reusable buffer behind the reserved transient
+atom id 2^62 (special-cased in `wam_atom_to_string`, never entered into the
+intern hash or dynamic table). No malloc, hash, or atom-table append per
+record, and memory is constant on unbounded unique-line streams (verified:
+500k unique ~100-byte lines under a 60 MB ulimit). Contract: the line Value
+is valid until the next read; anything persisted past the record interns
+explicitly -- field-slice assoc keys already did, and $0 foreign-call
+arguments now intern the current line so Prolog-side atom identity is
+preserved. Measured: 200k short records 0.098s -> 0.029s (mawk parity);
+long-line streams remain ~4x behind mawk on the reader's byte-at-a-time
+copy loop, which binary records bypass entirely.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -82,6 +82,7 @@ swipl -q -s tests/test_plawk_surface_else_if.pl -g "setenv('UW_SMOKE_TMPDIR', '/
 swipl -q -s tests/test_plawk_surface_prolog_calls.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_surface_float_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_wam_llvm_atom_intern_scaling.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_transient_line_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2762,8 +2762,27 @@ plawk_foreign_args_ir([Arg | Rest], FieldSeparator, BasePrefix, Index,
     plawk_foreign_args_ir(Rest, FieldSeparator, BasePrefix, NextIndex,
         ArgValueIRs, GlobalPartsRest, SetupPartsRest).
 
-plawk_foreign_arg_ir(field(0), _FieldSeparator, _ArgBase, '%line', [], []) :-
-    !.
+plawk_foreign_arg_ir(field(0), _FieldSeparator, ArgBase, ArgValueIR,
+        [], SetupParts) :-
+    !,
+    % The record Value is the transient line atom whose buffer mutates
+    % on the next read; Prolog-side atom identity (X == 'ERROR') and
+    % anything the predicate might persist need a real atom, so $0
+    % interns the current line text. %line_s is the C string the
+    % driver's EOF check already resolved.
+    SafeBase = ArgBase,
+    format(atom(LenIR),
+        '  %~w_len = call i64 @strlen(i8* %line_s)', [SafeBase]),
+    format(atom(InternIR),
+        '  %~w_id = call i64 @wam_intern_atom(i8* %line_s, i64 %~w_len)',
+        [SafeBase, SafeBase]),
+    format(atom(Value0IR),
+        '  %~w_v0 = insertvalue %Value undef, i32 0, 0', [SafeBase]),
+    format(atom(ValueIR),
+        '  %~w_v = insertvalue %Value %~w_v0, i64 %~w_id, 1',
+        [SafeBase, SafeBase, SafeBase]),
+    format(atom(ArgValueIR), '%~w_v', [SafeBase]),
+    SetupParts = [LenIR, InternIR, Value0IR, ValueIR].
 plawk_foreign_arg_ir(field(FieldIndex), FieldSeparator, ArgBase, ArgValueIR,
         [EmptyGlobalIR], SetupParts) :-
     integer(FieldIndex),

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4844,6 +4844,166 @@ rhv.free_out_fail:
   br label %rhv.fail
 }
 
+; Transient-line variant of read_line for per-record streaming: the
+; line lands in the shared @wam_transient_line_buf (grown geometrically,
+; reused across reads, never freed) and the returned atom Value carries
+; the reserved transient id 2^62 that @wam_atom_to_string maps to that
+; buffer. No malloc/free, no hashing, no atom-table append per record,
+; and memory stays constant on unbounded streams. Contract: the Value
+; is valid only until the next transient read -- callers that persist
+; line-derived data past the record must intern it (field-slice assoc
+; keys and $0 foreign-call arguments already do). EOF still returns the
+; real interned end_of_file atom.
+define %Value @wam_stream_read_line_transient_value(%Value %handle_value) {
+entry:
+  %rtv.t = call i32 @value_tag(%Value %handle_value)
+  %rtv.is_int = icmp eq i32 %rtv.t, 1
+  br i1 %rtv.is_int, label %rtv.lookup_handle, label %rtv.fail
+
+rtv.fail:
+  %rtv.bad = call %Value @wam_stream_fail_value()
+  ret %Value %rtv.bad
+
+rtv.lookup_handle:
+  %rtv.handle64 = call i64 @value_payload(%Value %handle_value)
+  %rtv.handle = trunc i64 %rtv.handle64 to i32
+  %rtv.handle_min = icmp sgt i32 %rtv.handle, 0
+  %rtv.handle_max = icmp ult i32 %rtv.handle, 4096
+  %rtv.handle_ok = and i1 %rtv.handle_min, %rtv.handle_max
+  br i1 %rtv.handle_ok, label %rtv.load_handle, label %rtv.fail
+
+rtv.load_handle:
+  %rtv.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %rtv.handle
+  %rtv.reader = load %WamLineReader*, %WamLineReader** %rtv.slot
+  %rtv.reader_null = icmp eq %WamLineReader* %rtv.reader, null
+  br i1 %rtv.reader_null, label %rtv.fail, label %rtv.have_handle
+
+rtv.have_handle:
+  %rtv.fd_slot = getelementptr %WamLineReader, %WamLineReader* %rtv.reader, i32 0, i32 0
+  %rtv.fd = load i32, i32* %rtv.fd_slot
+  %rtv.fd_ok = icmp sge i32 %rtv.fd, 0
+  br i1 %rtv.fd_ok, label %rtv.ensure_out, label %rtv.fail
+
+rtv.ensure_out:
+  %rtv.cap0 = load i64, i64* @wam_transient_line_cap
+  %rtv.have_buf = icmp sgt i64 %rtv.cap0, 0
+  br i1 %rtv.have_buf, label %rtv.loop_pre, label %rtv.first_alloc
+
+rtv.first_alloc:
+  %rtv.first_buf = call i8* @malloc(i64 4096)
+  %rtv.first_null = icmp eq i8* %rtv.first_buf, null
+  br i1 %rtv.first_null, label %rtv.fail, label %rtv.first_store
+
+rtv.first_store:
+  store i8* %rtv.first_buf, i8** @wam_transient_line_buf
+  store i64 4096, i64* @wam_transient_line_cap
+  br label %rtv.loop_pre
+
+rtv.loop_pre:
+  %rtv.out0 = load i8*, i8** @wam_transient_line_buf
+  %rtv.cap1 = load i64, i64* @wam_transient_line_cap
+  br label %rtv.loop
+
+rtv.loop:
+  %rtv.out_len = phi i64 [ 0, %rtv.loop_pre ], [ %rtv.out_len, %rtv.after_read ], [ %rtv.next_out_len, %rtv.append_store ]
+  %rtv.out_cur = phi i8* [ %rtv.out0, %rtv.loop_pre ], [ %rtv.out_cur, %rtv.after_read ], [ %rtv.append_out, %rtv.append_store ]
+  %rtv.out_cap = phi i64 [ %rtv.cap1, %rtv.loop_pre ], [ %rtv.out_cap, %rtv.after_read ], [ %rtv.append_cap, %rtv.append_store ]
+  %rtv.buf_slot = getelementptr %WamLineReader, %WamLineReader* %rtv.reader, i32 0, i32 1
+  %rtv.buf = load i8*, i8** %rtv.buf_slot
+  %rtv.len_slot = getelementptr %WamLineReader, %WamLineReader* %rtv.reader, i32 0, i32 3
+  %rtv.len = load i64, i64* %rtv.len_slot
+  %rtv.pos_slot = getelementptr %WamLineReader, %WamLineReader* %rtv.reader, i32 0, i32 4
+  %rtv.pos = load i64, i64* %rtv.pos_slot
+  %rtv.have_byte = icmp slt i64 %rtv.pos, %rtv.len
+  br i1 %rtv.have_byte, label %rtv.consume, label %rtv.fill
+
+rtv.fill:
+  %rtv.cap_slot = getelementptr %WamLineReader, %WamLineReader* %rtv.reader, i32 0, i32 2
+  %rtv.rcap = load i64, i64* %rtv.cap_slot
+  %rtv.n = call i64 @read(i32 %rtv.fd, i8* %rtv.buf, i64 %rtv.rcap)
+  %rtv.n_neg = icmp slt i64 %rtv.n, 0
+  br i1 %rtv.n_neg, label %rtv.fail, label %rtv.check_eof
+
+rtv.check_eof:
+  %rtv.n_zero = icmp eq i64 %rtv.n, 0
+  br i1 %rtv.n_zero, label %rtv.eof_or_partial, label %rtv.after_read
+
+rtv.after_read:
+  store i64 %rtv.n, i64* %rtv.len_slot
+  store i64 0, i64* %rtv.pos_slot
+  br label %rtv.loop
+
+rtv.eof_or_partial:
+  %rtv.empty_line = icmp eq i64 %rtv.out_len, 0
+  br i1 %rtv.empty_line, label %rtv.eof, label %rtv.finalize
+
+rtv.consume:
+  %rtv.char_ptr = getelementptr i8, i8* %rtv.buf, i64 %rtv.pos
+  %rtv.ch = load i8, i8* %rtv.char_ptr
+  %rtv.pos_next = add i64 %rtv.pos, 1
+  store i64 %rtv.pos_next, i64* %rtv.pos_slot
+  %rtv.is_lf = icmp eq i8 %rtv.ch, 10
+  br i1 %rtv.is_lf, label %rtv.finalize, label %rtv.append
+
+rtv.append:
+  %rtv.next_out_len_pre = add i64 %rtv.out_len, 1
+  %rtv.has_room = icmp ult i64 %rtv.next_out_len_pre, %rtv.out_cap
+  br i1 %rtv.has_room, label %rtv.append_store, label %rtv.grow_out
+
+rtv.grow_out:
+  %rtv.new_out_cap = shl i64 %rtv.out_cap, 1
+  %rtv.cap_grew = icmp ugt i64 %rtv.new_out_cap, %rtv.out_cap
+  br i1 %rtv.cap_grew, label %rtv.grow_alloc, label %rtv.fail
+
+rtv.grow_alloc:
+  %rtv.grown_out = call i8* @realloc(i8* %rtv.out_cur, i64 %rtv.new_out_cap)
+  %rtv.grown_null = icmp eq i8* %rtv.grown_out, null
+  br i1 %rtv.grown_null, label %rtv.fail, label %rtv.grow_store
+
+rtv.grow_store:
+  store i8* %rtv.grown_out, i8** @wam_transient_line_buf
+  store i64 %rtv.new_out_cap, i64* @wam_transient_line_cap
+  br label %rtv.append_store
+
+rtv.append_store:
+  %rtv.append_out = phi i8* [ %rtv.out_cur, %rtv.append ], [ %rtv.grown_out, %rtv.grow_store ]
+  %rtv.append_cap = phi i64 [ %rtv.out_cap, %rtv.append ], [ %rtv.new_out_cap, %rtv.grow_store ]
+  %rtv.out_ptr = getelementptr i8, i8* %rtv.append_out, i64 %rtv.out_len
+  store i8 %rtv.ch, i8* %rtv.out_ptr
+  %rtv.next_out_len = add i64 %rtv.out_len, 1
+  br label %rtv.loop
+
+rtv.finalize:
+  %rtv.has_chars = icmp sgt i64 %rtv.out_len, 0
+  br i1 %rtv.has_chars, label %rtv.check_cr, label %rtv.terminate_empty
+
+rtv.check_cr:
+  %rtv.last_idx = sub i64 %rtv.out_len, 1
+  %rtv.last_ptr = getelementptr i8, i8* %rtv.out_cur, i64 %rtv.last_idx
+  %rtv.last = load i8, i8* %rtv.last_ptr
+  %rtv.last_is_cr = icmp eq i8 %rtv.last, 13
+  %rtv.trim_len = select i1 %rtv.last_is_cr, i64 %rtv.last_idx, i64 %rtv.out_len
+  br label %rtv.terminate
+
+rtv.terminate_empty:
+  br label %rtv.terminate
+
+rtv.terminate:
+  %rtv.final_len = phi i64 [ %rtv.trim_len, %rtv.check_cr ], [ 0, %rtv.terminate_empty ]
+  %rtv.term = getelementptr i8, i8* %rtv.out_cur, i64 %rtv.final_len
+  store i8 0, i8* %rtv.term
+  %rtv.v0 = insertvalue %Value undef, i32 0, 0
+  %rtv.v = insertvalue %Value %rtv.v0, i64 4611686018427387904, 1
+  ret %Value %rtv.v
+
+rtv.eof:
+  %rtv.eof_ptr = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof_atom, i32 0, i32 0
+  %rtv.eof_aid = call i64 @wam_intern_atom(i8* %rtv.eof_ptr, i64 11)
+  %rtv.eof_v0 = insertvalue %Value undef, i32 0, 0
+  %rtv.eof_v = insertvalue %Value %rtv.eof_v0, i64 %rtv.eof_aid, 1
+  ret %Value %rtv.eof_v
+}
+
 define i1 @wam_stream_close_value(%Value %handle_value) {
 entry:
   %sch.t = call i32 @value_tag(%Value %handle_value)
@@ -16948,6 +17108,8 @@ emit_atom_string_globals(IR) :-
 @wam_atom_dyn_ptr   = global i8** null
 @wam_atom_dyn_count = global i32 0
 @wam_atom_dyn_cap   = global i32 0
+@wam_transient_line_buf = global i8* null
+@wam_transient_line_cap = global i64 0
 
 define i8* @wam_atom_to_string(i64 %id) {
   ret i8* null
@@ -17038,8 +17200,25 @@ define i64 @wam_intern_atom(i8* %str, i64 %len) {
 @wam_atom_hash_cap   = global i64 0
 @wam_atom_hash_count = global i64 0
 
+; Shared buffer behind the transient line atom (id 2^62). Grown
+; geometrically, never freed; contents are valid until the next
+; transient read.
+@wam_transient_line_buf = global i8* null
+@wam_transient_line_cap = global i64 0
+
 define i8* @wam_atom_to_string(i64 %id) {
 entry:
+  ; Transient line atom: id 2^62 resolves to the shared line buffer
+  ; owned by @wam_stream_read_line_transient_value. The buffer mutates
+  ; on every read, so this id must never enter the intern hash or the
+  ; dynamic table; it exists so per-record consumers (field helpers,
+  ; regex, printing) work on the current record without interning it.
+  %is_transient = icmp eq i64 %id, 4611686018427387904
+  br i1 %is_transient, label %transient, label %check_static
+transient:
+  %tbuf = load i8*, i8** @wam_transient_line_buf
+  ret i8* %tbuf
+check_static:
   %cnt = load i32, i32* @wam_atom_string_count
   %cnt64 = zext i32 %cnt to i64
   %in_static = icmp ult i64 %id, %cnt64
@@ -17624,6 +17803,12 @@ llvm_emit_printf0(FmtGlobal, FmtLen, FmtVar, PrintVar, [FmtPtr, PrintCall]) :-
 %  main(argc, argv) that opens argv[1] at runtime, treats "-" as stdin,
 %  and defaults to stdin (fd 0) when no argument is given -- the awk
 %  pipeline-filter convention.
+%
+%  Records are read with @wam_stream_read_line_transient_value: %line
+%  is the reserved transient atom whose string lives in a shared buffer
+%  valid only until the next read, so per-record lowerings read it
+%  freely but anything persisted past the record must intern (field
+%  slices used as assoc keys and $0 foreign-call arguments do).
 llvm_emit_stream_driver_ir(
     InputPath,
     driver_blocks(RuntimeGlobals, LoopPhiIR, LoweredLabel, RecordIR,
@@ -17697,7 +17882,7 @@ check_handle_value:
 
 loop:
 ~w
-  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line = call %Value @wam_stream_read_line_transient_value(%Value %handle)
   %line_tag = extractvalue %Value %line, 0
   %line_payload = extractvalue %Value %line, 1
   %line_is_int = icmp eq i32 %line_tag, 1
@@ -17779,7 +17964,7 @@ check_handle_value:
 
 loop:
 ~w
-  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line = call %Value @wam_stream_read_line_transient_value(%Value %handle)
   %line_tag = extractvalue %Value %line, 0
   %line_payload = extractvalue %Value %line, 1
   %line_is_int = icmp eq i32 %line_tag, 1

--- a/tests/test_plawk_transient_line_records.pl
+++ b/tests/test_plawk_transient_line_records.pl
@@ -1,0 +1,190 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_transient_marker/0.
+:- dynamic user:plawk_whole_line_error/1.
+
+user:plawk_transient_marker.
+
+% Matches by atom identity against the whole record, so it only works
+% if $0 foreign-call arguments intern the transient line to a real atom.
+user:plawk_whole_line_error('ERROR disk full').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_transient_line_records, [condition(clang_available)]).
+
+test(driver_reads_records_transiently) :-
+    plawk_parse_string("$1 == \"ERROR\" { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_stream_read_line_transient_value(%Value %handle)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_stream_read_line_value(%Value %handle)')),
+    !.
+
+test(foreign_whole_record_arg_interns_line) :-
+    plawk_parse_string("plawk_whole_line_error($0) { hits++ } END { print hits }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', [wam_vm(100, 20)], DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_len = call i64 @strlen(i8* %line_s)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_id = call i64 @wam_intern_atom(i8* %line_s, i64 %'))),
+    !.
+
+% Long line followed by short lines: a stale NUL terminator or reused
+% buffer residue would corrupt the later prints.
+test(surface_line_buffer_reuse_prints_each_record_exactly) :-
+    run_transient_print_smoke("{ print $0 }\n",
+        "first-very-long-line-with-plenty-of-payload-bytes-here\nab\nlonger again\n",
+        "first-very-long-line-with-plenty-of-payload-bytes-here\nab\nlonger again\n").
+
+% Field-slice assoc keys intern real atoms, so counts keyed off the
+% mutating transient buffer must still deduplicate across records.
+test(surface_assoc_keys_survive_buffer_reuse) :-
+    run_transient_print_smoke("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        "ERROR disk\nWARN cpu\nERROR net\n",
+        "2 1\n").
+
+test(surface_foreign_dollar0_guard_matches_by_atom_identity) :-
+    run_transient_foreign_smoke("plawk_whole_line_error($0) { hits++ } END { print hits }\n",
+        "ERROR disk full\nWARN cpu hot\nERROR disk full\n",
+        "2\n").
+
+% 500k unique ~100-byte lines (~50 MB of line text) under a 60 MB
+% address-space cap: interning every line would blow the limit, the
+% transient buffer keeps memory constant.
+test(surface_unbounded_unique_stream_runs_in_constant_memory) :-
+    build_transient_binary("{ total += $3 } END { print total }\n", Dir, BinPath),
+    directory_file_path(Dir, 'unique_wide.txt', InputPath),
+    Count = 500000,
+    write_wide_lines(InputPath, Count),
+    format(atom(Cmd), 'ulimit -v 61440; exec ~w ~w', [BinPath, InputPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    Expected is Count * (Count - 1) // 2,
+    format(atom(ExpectedLine), '~w~n', [Expected]),
+    atom_string(ExpectedLine, ExpectedStr),
+    assertion(OutStr == ExpectedStr),
+    !.
+
+build_transient_binary(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_transient_line_records', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_transient_marker/0 ],
+        [module_name('plawk_transient_line_records')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    compile_probe(LLPath, BinPath).
+
+compile_probe(LLPath, BinPath) :-
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[transient line records build output]~n~w~n", [BuildOut]),
+       throw(plawk_transient_line_records_build_failed(Status))
+    ).
+
+write_wide_lines(Path, Count) :-
+    Limit is Count - 1,
+    length(PadCodes, 80),
+    maplist(=(0'x), PadCodes),
+    atom_codes(Pad, PadCodes),
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(between(0, Limit, I),
+            format(Out, 'k~w ~w ~w~n', [I, Pad, I])),
+        close(Out)).
+
+run_transient_print_smoke(Source, Input, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_transient_line_records', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_transient_marker/0 ],
+        [module_name('plawk_transient_line_records')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    compile_probe(LLPath, BinPath),
+    run_and_compare(BinPath, ExpectedOutput).
+
+run_transient_foreign_smoke(Source, Input, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_transient_line_records', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s', [Input]),
+        close(In)),
+    plawk_parse_string(Source, Program),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_whole_line_error/1,
+          user:plawk_transient_marker/0
+        ],
+        [module_name('plawk_transient_line_records')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_program_native_driver_ir(Program, InputPath,
+        [wam_vm(InstrCount, LabelCount)], DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    compile_probe(LLPath, BinPath),
+    run_and_compare(BinPath, ExpectedOutput).
+
+run_and_compare(BinPath, ExpectedOutput) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[transient line records run output]~n~w~n", [OutStr]),
+       throw(plawk_transient_line_records_run_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_transient_line_records).

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -333,7 +333,7 @@ test(stream_driver_emitter_compact_blocks) :-
     assertion(sub_atom(DriverIR, _, _, _, '@.wam_stream_input_path = private constant [10 x i8]')),
     assertion(sub_atom(DriverIR, _, _, _, '@.wam_stream_eof = private constant [12 x i8] c"end_of_file\\00"')),
     assertion(sub_atom(DriverIR, _, _, _, '@.fmt = private constant [2 x i8] c"\\0A\\00"')),
-    assertion(sub_atom(DriverIR, _, _, _, '%line = call %Value @wam_stream_read_line_value(%Value %handle)')),
+    assertion(sub_atom(DriverIR, _, _, _, '%line = call %Value @wam_stream_read_line_transient_value(%Value %handle)')),
     assertion(sub_atom(DriverIR, _, _, _, 'br i1 %is_eof, label %close_stream, label %lowered_test')),
     assertion(sub_atom(DriverIR, _, _, _, 'success:\n  ret i32 0')),
     assertion(\+ sub_atom(DriverIR, _, _, _, 'plawk_surface_path')),


### PR DESCRIPTION
## Summary

**Stacked on #3407.** Step 1 of the "faster than awk via typed data" path: plawk's streaming loop no longer interns (or even mallocs) each record.

Even with #3407's hash, every line still cost a malloc, an FNV hash, and a permanent copy into the atom table — pure overhead for records nothing revisits, and **unbounded memory** on unbounded unique-line streams. Now `read_line` has a transient variant: the line lands in one shared, geometrically-grown, reusable buffer behind a **reserved transient atom id (2⁶²)** that `wam_atom_to_string` special-cases. The id never enters the intern hash or the dynamic table, so its mutating buffer can't alias real atoms — all existing field/regex/print/coercion helpers work unchanged.

## Measured (`{ total += $3 } END { print total }`)

| | #3407 | this PR | mawk |
|---|---|---|---|
| 200k short unique lines | 0.098s | **0.029s** | 0.024s |
| + Prolog call per record | 0.134s | **0.063s** | — |
| memory, 2M unique ~100-byte lines | O(unique lines) heap | **constant** (runs under a 40 MB ulimit) | — |

That's **mawk parity on short records**. Long-line streams remain ~4× behind mawk (2M × ~97 B: 1.13s vs 0.29s) — the reader's byte-at-a-time copy loop, which the binary-records PR bypasses entirely.

## The persistence contract

The line Value is valid **until the next read**. Everything per-record reads it freely; anything persisted past the record must intern:
- **Field-slice assoc keys** already interned real atoms — unchanged.
- **`$0` foreign-call arguments** now intern the current line explicitly, so Prolog-side atom identity (`X == 'ERROR disk full'`) keeps working — verified by a new e2e test with a whole-line fact guard.
- The persistent `wam_stream_read_line_value` is **unchanged** for callers that thread line atoms across records (the Phase-1 native stream-loop smokes still pass on it).

## Tests

`tests/test_plawk_transient_line_records.pl` — 6 tests: driver/foreign-arg IR shapes, buffer-reuse print correctness (long line followed by short lines catches stale terminators), assoc-key dedup across buffer reuse, the `$0` atom-identity foreign guard e2e, and a 500k-wide-line run under a 60 MB address-space cap (interning would blow it; the transient buffer doesn't).

## Testing (honest exit codes)

All 15 suites pass: the ten plawk surface suites, transient records, intern scaling, the 80-test `test_wam_llvm_target`, `test_plawk_compiled_stream_core`, and `test_plawk_native_stream_loop_driver` (persistent-reader consumer).

**Merge order:** … → #3407 → this → (binary records, next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_