### PR TITLE
plawk: fixed-layout binary typed records (Phase 3 first slice)

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -446,6 +446,24 @@ produces correct output on standard awk test cases.
 
 **Goal:** replace text records with binary structures; add DCG-based readers.
 
+**First slice landed:** `BEGIN { BINFMT = "i64 i64 f64" }` selects
+fixed-layout binary records: one 8-byte native-endian field per type,
+`$1..$N`, record size 8*N. The runtime gained
+`@wam_stream_read_record(handle, size, dst)` (1 = record, 0 = clean EOF at
+a record boundary, -1 = error or trailing partial record) and the target a
+binary sibling of the stream driver skeleton
+(`llvm_emit_binary_stream_driver_ir/4`, same block labels so loop phis are
+unchanged, both concrete-path and stdin_or_argv). Codegen threads a record
+descriptor through the existing `FieldSeparator` position — `binfmt(Types)`
+clauses ahead of the text clauses lower `$N` guards/arithmetic/prints to a
+typed load at a compile-time offset, `NF` to a constant, and `float($N)` to
+a double load; a whitelist validator rejects text-shaped programs in binary
+mode instead of letting them reach text emitters. Measured on 2M records
+(`$1 > 100 { sum += $2 }`): binary 0.040s vs mawk-on-text 0.225s (5.6x)
+vs plawk text mode 0.156s — the no-parsing thesis, demonstrated.
+Remaining Phase 3 items below (DCG readers, richer ABIs, string fields,
+binary writers) are unchanged.
+
 1. Binary record ABI: struct layout, alignment, (de)serialisation convention.
 2. DCG grammar for parsing binary records into terms.
 3. Compile the DCG through UnifyWeaver to LLVM.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -83,6 +83,7 @@ swipl -q -s tests/test_plawk_surface_prolog_calls.pl -g "setenv('UW_SMOKE_TMPDIR
 swipl -q -s tests/test_plawk_surface_float_exprs.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_wam_llvm_atom_intern_scaling.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_transient_line_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_binary_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -237,6 +238,23 @@ dispatch). Programs with foreign calls use
 `plawk_program_native_driver_ir/4` with `wam_vm(InstrCount, LabelCount)`
 from `wam_llvm_last_compile_counts/2` after `write_wam_llvm_project/3`
 compiled the predicates into the module.
+
+The first binary/typed-record slice is in:
+`BEGIN { BINFMT = "i64 i64 f64" }` switches the program to fixed-layout
+binary records (one 8-byte native-endian field per declared type, `$1..$N`,
+record size 8*N). Field access compiles to a typed load at a compile-time
+offset — no field splitting, no numeric parsing, no interning — so
+`BEGIN { BINFMT = "i64 i64" } $1 > 100 { sum += $2 } END { print sum }`
+is a load-compare-add loop. `i64` fields work in guards, arithmetic,
+scalar updates, and prints; `f64` fields load as native doubles for
+prints and `float($N)` double expressions. `NF` is a compile-time
+constant; `NR`, `if/else`, `next`/`break`, `printf`, and END reports
+compose unchanged. Text-shaped forms ($0, regex, string equality,
+substr/length/index/case, associative arrays, foreign calls) are rejected
+at codegen in binary mode. A trailing partial record exits with the read
+error code. Measured on 2M records: 0.040s for the binary program vs
+0.225s for mawk on the equivalent text (5.6x) and 0.156s for plawk's own
+text mode.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -7,6 +7,8 @@
     plawk_program_foreign_specs/3
 ]).
 
+:- discontiguous plawk_pattern_guard_ir/5.
+
 :- use_module('../../../src/unifyweaver/targets/wam_llvm_target',
     [llvm_emit_atom_prefix_guard/5,
      llvm_emit_atom_field_eq_guard/7,
@@ -25,6 +27,7 @@
      llvm_emit_printf_string/6,
      llvm_emit_printf0/5,
      llvm_emit_stream_driver_ir/3,
+     llvm_emit_binary_stream_driver_ir/4,
      llvm_emit_ascii_case_slice_print/5]).
 
 %% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
@@ -75,7 +78,8 @@ plawk_program_native_driver_ir(
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
-    plawk_field_separator(BeginClauses, FieldSeparator),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_record_program_ok(FieldSeparator, [rule(Pattern, [Action])], []),
     plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardGlobalIR-GuardCallIR),
     plawk_print_record_counter_ir(Exprs, LoopPhiIR, RecordCounterIR),
     plawk_output_action_ir(Action, FieldSeparator, OutputSeparator, PrintGlobalIR-PrintActionIR),
@@ -100,7 +104,7 @@ print_line:
 ~w
 ',
         [BeginGlobalIR, GuardGlobalIR, PrintGlobalIR]),
-    llvm_emit_stream_driver_ir(InputPath,
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR, '',
             success, 'success:\n  ret i32 0'),
         DriverIR).
@@ -110,6 +114,7 @@ plawk_program_native_driver_ir(
     InputPath,
     DriverIR
 ) :-
+    \+ plawk_begin_has_binfmt(BeginClauses),
     plawk_mixed_state_plan(Rules, PrintFields, MixedPlan),
     MixedPlan = mixed_plan(ScalarPlan, AssocPlan, _PlannedRules),
     plawk_output_separator(BeginClauses, OutputSeparator),
@@ -157,7 +162,8 @@ plawk_program_native_driver_ir(
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
-    plawk_field_separator(BeginClauses, FieldSeparator),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_record_program_ok(FieldSeparator, Rules, PrintFields),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator,
         RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
@@ -182,7 +188,7 @@ plawk_program_native_driver_ir(
 ~w~w
   ret i32 0',
         [FinalStatePhiIR, EndPrintIR]),
-    llvm_emit_stream_driver_ir(InputPath,
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
@@ -192,6 +198,7 @@ plawk_program_native_driver_ir(
     InputPath,
     DriverIR
 ) :-
+    \+ plawk_begin_has_binfmt(BeginClauses),
     plawk_assoc_runtime_count_plan(Rules, PrintFields, AssocPlan),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
@@ -229,6 +236,7 @@ plawk_program_native_driver_ir(
     InputPath,
     DriverIR
 ) :-
+    \+ plawk_begin_has_binfmt(BeginClauses),
     plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions, AssocPlan, PrintFields),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
@@ -1330,12 +1338,192 @@ plawk_assoc_rule_action_blocks(RuleIndex, [assoc_action(Index, _ArrayName, Table
     [Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, KeyId, Inc, Next, ''],
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
 
+%% plawk_record_program_ok(+Descriptor, +Rules, +EndPrintFields) is semidet.
+%
+%  Text mode accepts everything. Binary mode whitelists the record
+%  representation's supported surface: numeric guards and arithmetic on
+%  i64 fields, float($N) on f64 fields, prints of either, NR/NF, scalar
+%  state, if/else, next/break, and representation-free END prints.
+%  Text-shaped forms (regex, string equality, substr/index/length/case,
+%  $0, assoc arrays, foreign calls) fail the whole driver clause.
+plawk_record_program_ok(binfmt(Types), Rules, _EndPrintFields) :-
+    !,
+    forall(member(rule(Pattern, Actions), Rules),
+        ( plawk_binfmt_pattern_ok(binfmt(Types), Pattern),
+          plawk_binfmt_actions_ok(binfmt(Types), Actions)
+        )).
+plawk_record_program_ok(_FieldSeparator, _Rules, _EndPrintFields).
+
+plawk_binfmt_pattern_ok(_Descriptor, always) :- !.
+plawk_binfmt_pattern_ok(Descriptor, field_cmp(Index, _Op, _Value)) :-
+    !,
+    plawk_binfmt_field_type(Descriptor, Index, i64).
+plawk_binfmt_pattern_ok(Descriptor, and_pat(Left, Right)) :-
+    !,
+    plawk_binfmt_pattern_ok(Descriptor, Left),
+    plawk_binfmt_pattern_ok(Descriptor, Right).
+plawk_binfmt_pattern_ok(Descriptor, or_pat(Left, Right)) :-
+    !,
+    plawk_binfmt_pattern_ok(Descriptor, Left),
+    plawk_binfmt_pattern_ok(Descriptor, Right).
+plawk_binfmt_pattern_ok(Descriptor, not_pat(Pattern)) :-
+    !,
+    plawk_binfmt_pattern_ok(Descriptor, Pattern).
+
+plawk_binfmt_actions_ok(Descriptor, Actions) :-
+    forall(member(Action, Actions),
+        plawk_binfmt_action_ok(Descriptor, Action)).
+
+plawk_binfmt_action_ok(_Descriptor, next) :- !.
+plawk_binfmt_action_ok(_Descriptor, break) :- !.
+plawk_binfmt_action_ok(Descriptor, inc(var(_Name))) :- !,
+    Descriptor = binfmt(_).
+plawk_binfmt_action_ok(Descriptor, add(var(_Name), Expr)) :-
+    !,
+    plawk_binfmt_i64_expr_ok(Descriptor, Expr).
+plawk_binfmt_action_ok(Descriptor, set(var(_Name), Expr)) :-
+    !,
+    plawk_binfmt_i64_expr_ok(Descriptor, Expr).
+plawk_binfmt_action_ok(Descriptor, print(Fields)) :-
+    !,
+    forall(member(Field, Fields),
+        plawk_binfmt_print_field_ok(Descriptor, Field)).
+plawk_binfmt_action_ok(Descriptor, printf(string(_Format), Args)) :-
+    !,
+    forall(member(Arg, Args),
+        plawk_binfmt_print_field_ok(Descriptor, Arg)).
+plawk_binfmt_action_ok(Descriptor, if(Pattern, ThenActions, ElseActions)) :-
+    !,
+    plawk_binfmt_pattern_ok(Descriptor, Pattern),
+    plawk_binfmt_actions_ok(Descriptor, ThenActions),
+    plawk_binfmt_actions_ok(Descriptor, ElseActions).
+
+plawk_binfmt_print_field_ok(_Descriptor, string(_Value)) :- !.
+plawk_binfmt_print_field_ok(_Descriptor, special('NR')) :- !.
+plawk_binfmt_print_field_ok(_Descriptor, special('NF')) :- !.
+plawk_binfmt_print_field_ok(Descriptor, field(Index)) :-
+    !,
+    plawk_binfmt_field_type(Descriptor, Index, _Type).
+plawk_binfmt_print_field_ok(Descriptor, float_field(Index)) :-
+    !,
+    plawk_binfmt_field_type(Descriptor, Index, f64).
+plawk_binfmt_print_field_ok(Descriptor, Expr) :-
+    plawk_expr_is_double(Expr),
+    !,
+    plawk_binfmt_f64_expr_ok(Descriptor, Expr).
+plawk_binfmt_print_field_ok(Descriptor, Expr) :-
+    plawk_binfmt_i64_expr_ok(Descriptor, Expr).
+
+plawk_binfmt_i64_expr_ok(_Descriptor, int(Value)) :-
+    integer(Value),
+    !.
+plawk_binfmt_i64_expr_ok(_Descriptor, var(Name)) :-
+    atom(Name),
+    !.
+plawk_binfmt_i64_expr_ok(_Descriptor, special('NR')) :- !.
+plawk_binfmt_i64_expr_ok(_Descriptor, special('NF')) :- !.
+plawk_binfmt_i64_expr_ok(Descriptor, field(Index)) :-
+    !,
+    plawk_binfmt_field_type(Descriptor, Index, i64).
+plawk_binfmt_i64_expr_ok(Descriptor, int(field(Index))) :-
+    !,
+    plawk_binfmt_field_type(Descriptor, Index, i64).
+plawk_binfmt_i64_expr_ok(Descriptor, Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    plawk_binfmt_i64_expr_ok(Descriptor, Left),
+    plawk_binfmt_i64_expr_ok(Descriptor, Right).
+
+plawk_binfmt_f64_expr_ok(Descriptor, float_field(Index)) :-
+    !,
+    plawk_binfmt_field_type(Descriptor, Index, f64).
+plawk_binfmt_f64_expr_ok(_Descriptor, float_const(_Mantissa, _Denominator)) :- !.
+plawk_binfmt_f64_expr_ok(Descriptor, Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    !,
+    plawk_binfmt_f64_expr_ok(Descriptor, Left),
+    plawk_binfmt_f64_expr_ok(Descriptor, Right).
+plawk_binfmt_f64_expr_ok(Descriptor, Expr) :-
+    plawk_binfmt_i64_expr_ok(Descriptor, Expr).
+
+%% plawk_binfmt_field_load_lines(+Descriptor, +Index, +Base, -ValueIR, -Lines)
+%
+%  Typed field access on a fixed-layout binary record: a load at the
+%  compile-time offset from the %rec buffer. No parsing, no separators.
+plawk_binfmt_field_load_lines(Descriptor, Index, Base, ValueIR, Lines) :-
+    plawk_binfmt_field_type(Descriptor, Index, Type),
+    plawk_binfmt_field_offset(Index, Offset),
+    plawk_binfmt_llvm_type(Type, LLVMType),
+    format(atom(ValueIR), '%~w', [Base]),
+    format(atom(GepIR),
+        '  %~w_fp = getelementptr i8, i8* %rec, i64 ~w', [Base, Offset]),
+    format(atom(CastIR),
+        '  %~w_tp = bitcast i8* %~w_fp to ~w*', [Base, Base, LLVMType]),
+    format(atom(LoadIR),
+        '  ~w = load ~w, ~w* %~w_tp, align 1', [ValueIR, LLVMType, LLVMType, Base]),
+    Lines = [GepIR, CastIR, LoadIR].
+
+plawk_binfmt_llvm_type(i64, i64).
+plawk_binfmt_llvm_type(f64, double).
+
+plawk_binfmt_icmp_op(eq, eq).
+plawk_binfmt_icmp_op(ne, ne).
+plawk_binfmt_icmp_op(lt, slt).
+plawk_binfmt_icmp_op(le, sle).
+plawk_binfmt_icmp_op(gt, sgt).
+plawk_binfmt_icmp_op(ge, sge).
+
 plawk_field_separator(BeginClauses, FieldSeparator) :-
     (   member(begin(Actions), BeginClauses),
         member(set(var('FS'), string(Value)), Actions)
     ->  string_codes(Value, [FieldSeparator])
     ;   FieldSeparator = 32
     ).
+
+%% plawk_record_descriptor(+BeginClauses, -Descriptor)
+%
+%  Text mode yields the single-byte field separator code as before;
+%  BEGIN { BINFMT = "i64 i64 f64" } yields binfmt(Types) for fixed-
+%  layout binary records: one 8-byte native-endian field per type,
+%  fields numbered $1..$N, record size 8 * N.
+plawk_record_descriptor(BeginClauses, binfmt(Types)) :-
+    plawk_begin_binfmt_types(BeginClauses, Types),
+    !.
+plawk_record_descriptor(BeginClauses, FieldSeparator) :-
+    plawk_field_separator(BeginClauses, FieldSeparator).
+
+plawk_begin_has_binfmt(BeginClauses) :-
+    plawk_begin_binfmt_types(BeginClauses, _Types).
+
+plawk_begin_binfmt_types(BeginClauses, Types) :-
+    member(begin(Actions), BeginClauses),
+    member(set(var('BINFMT'), string(Fmt)), Actions),
+    split_string(Fmt, " ", " ", Parts0),
+    exclude(==(""), Parts0, Parts),
+    Parts \== [],
+    maplist(plawk_binfmt_type, Parts, Types).
+
+plawk_binfmt_type("i64", i64).
+plawk_binfmt_type("f64", f64).
+
+plawk_binfmt_field_type(binfmt(Types), Index, Type) :-
+    integer(Index),
+    Index >= 1,
+    nth1(Index, Types, Type).
+
+plawk_binfmt_field_offset(Index, Offset) :-
+    Offset is (Index - 1) * 8.
+
+%% plawk_emit_record_driver_ir(+Descriptor, +InputPath, +Blocks, -DriverIR)
+%
+%  Pick the stream skeleton by record representation: text lines or
+%  fixed-size binary records.
+plawk_emit_record_driver_ir(binfmt(Types), InputPath, Blocks, DriverIR) :-
+    !,
+    length(Types, NFields),
+    RecordSize is NFields * 8,
+    llvm_emit_binary_stream_driver_ir(InputPath, RecordSize, Blocks, DriverIR).
+plawk_emit_record_driver_ir(_FieldSeparator, InputPath, Blocks, DriverIR) :-
+    llvm_emit_stream_driver_ir(InputPath, Blocks, DriverIR).
 
 plawk_output_separator(BeginClauses, OutputSeparator) :-
     (   member(begin(Actions), BeginClauses),
@@ -2216,6 +2404,10 @@ plawk_i64_expr_ir(field(FieldIndex), FieldSeparator, Base, GlobalBase,
     plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts).
 plawk_i64_expr_ir(nr, _FieldSeparator, _Base, _GlobalBase, '%current_nr', [], []).
+plawk_i64_expr_ir(nf, binfmt(Types), _Base, _GlobalBase, ValueIR, [], []) :-
+    !,
+    length(Types, NFields),
+    format(atom(ValueIR), '~w', [NFields]).
 plawk_i64_expr_ir(nf, FieldSeparator, Base, _GlobalBase, ValueIR, [], [CountIR]) :-
     llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
     format(atom(ValueIR), '%~w', [Base]).
@@ -2238,6 +2430,11 @@ plawk_i64_expr_ir(int(field(FieldIndex)), FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts) :-
     plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts).
+plawk_i64_expr_ir(field_i64(FieldIndex), binfmt(Types), Base, _GlobalBase,
+        ValueIR, [], LoadLines) :-
+    !,
+    plawk_binfmt_field_load_lines(binfmt(Types), FieldIndex, Base, ValueIR,
+        LoadLines).
 plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, _GlobalBase, ValueIR, [], [ParseIR]) :-
     format(atom(ValueIR), '%~w_value_or_default', [Base]),
     llvm_emit_atom_field_i64_or_default('%line', FieldIndex, FieldSeparator, 0,
@@ -2330,6 +2527,11 @@ plawk_f64_expr_ir(float_const(Mantissa, Denominator), _FieldSeparator, Base,
     format(atom(ValueIR), '%~w', [Base]),
     format(atom(ConstIR), '  ~w = fdiv double ~w.0, ~w.0',
         [ValueIR, Mantissa, Denominator]).
+plawk_f64_expr_ir(float_field(Index), binfmt(Types), Base, _GlobalBase,
+        ValueIR, [], LoadLines) :-
+    !,
+    plawk_binfmt_field_load_lines(binfmt(Types), Index, Base, ValueIR,
+        LoadLines).
 plawk_f64_expr_ir(float_field(Index), FieldSeparator, Base, _GlobalBase,
         ValueIR, [], [CallIR]) :-
     format(atom(ValueIR), '%~w', [Base]),
@@ -2641,6 +2843,10 @@ plawk_pattern_guard_ir(contains(Needle), FieldSeparator, GuardIR) :-
 plawk_pattern_guard_ir(field_eq(Index, Value), FieldSeparator, GuardIR) :-
     llvm_emit_atom_field_eq_guard(plawk_surface_field_eq, '%line', Index, Value,
         FieldSeparator, '%is_match', GuardIR).
+plawk_pattern_guard_ir(field_cmp(Index, Op, Value), binfmt(Types), GuardIR) :-
+    !,
+    plawk_binfmt_field_cmp_guard_ir(binfmt(Types), field_cmp(Index, Op, Value),
+        plawk_surface_bincmp, '%is_match', GuardIR).
 plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, ''-GuardCallIR) :-
     plawk_field_cmp_op_code(Op, OpCode),
     llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
@@ -2683,10 +2889,24 @@ plawk_pattern_guard_ir(contains(Needle), FieldSeparator, GlobalBase, MatchValue,
 plawk_pattern_guard_ir(field_eq(Index, Value), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     llvm_emit_atom_field_eq_guard(GlobalBase, '%line', Index, Value, FieldSeparator,
         MatchValue, GuardIR).
+plawk_pattern_guard_ir(field_cmp(Index, Op, Value), binfmt(Types), GlobalBase, MatchValue, GuardIR) :-
+    !,
+    plawk_binfmt_field_cmp_guard_ir(binfmt(Types), field_cmp(Index, Op, Value),
+        GlobalBase, MatchValue, GuardIR).
 plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, _GlobalBase, MatchValue, ''-GuardCallIR) :-
     plawk_field_cmp_op_code(Op, OpCode),
     llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
         FieldSeparator, MatchValue, GuardCallIR).
+
+plawk_binfmt_field_cmp_guard_ir(Descriptor, field_cmp(Index, Op, Value),
+        GlobalBase, MatchValue, ''-GuardCallIR) :-
+    format(atom(Base), '~w_binf~w', [GlobalBase, Index]),
+    plawk_binfmt_field_load_lines(Descriptor, Index, Base, ValueIR, LoadLines),
+    plawk_binfmt_icmp_op(Op, ICmpOp),
+    format(atom(CmpIR), '  ~w = icmp ~w i64 ~w, ~w',
+        [MatchValue, ICmpOp, ValueIR, Value]),
+    append(LoadLines, [CmpIR], Lines),
+    atomic_list_concat(Lines, '\n', GuardCallIR).
 plawk_pattern_guard_ir(field_match(Index, Regex), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     llvm_emit_regex_field_match_guard(GlobalBase, '%line', Index, Regex,
         FieldSeparator, MatchValue, GuardIR).
@@ -3228,6 +3448,19 @@ plawk_emit_print_expr_for_context(toupper(field(FieldIndex)), FieldSeparator, Co
     plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, UpperBase, LenIR, PtrIR,
         SetupParts).
 
+plawk_emit_print_expr_for_context(field(FieldIndex), binfmt(Types), Context,
+        PrintType, [], LoadLines) :-
+    plawk_binfmt_field_type(binfmt(Types), FieldIndex, Type),
+    !,
+    plawk_print_expr_value_base(Context, binfield, Base),
+    plawk_print_expr_output_names(Context, binfield, FmtPrefix, PrintPrefix),
+    plawk_binfmt_field_load_lines(binfmt(Types), FieldIndex, Base, ValueIR,
+        LoadLines),
+    (   Type == i64
+    ->  PrintType = i64(FmtPrefix, PrintPrefix, ValueIR)
+    ;   PrintType = f64(FmtPrefix, PrintPrefix, ValueIR)
+    ).
+
 plawk_emit_print_expr_for_context(field(0), _FieldSeparator, Context,
         slice(FmtPrefix, PrintPrefix, LenIR, '%line_s'), [], [LineLen64, LineLen]) :-
     plawk_print_expr_output_names(Context, line, FmtPrefix, PrintPrefix),
@@ -3265,6 +3498,8 @@ plawk_normal_print_expr_value_base(prolog_call, Index, Base) :-
     format(atom(Base), 'plawk_prolog_call_~w', [Index]).
 plawk_normal_print_expr_value_base(f64, Index, Base) :-
     format(atom(Base), 'plawk_f64_~w', [Index]).
+plawk_normal_print_expr_value_base(binfield, Index, Base) :-
+    format(atom(Base), 'plawk_binfield_~w', [Index]).
 plawk_normal_print_expr_value_base(length, Index, Base) :-
     format(atom(Base), 'plawk_length_~w', [Index]).
 plawk_normal_print_expr_value_base(substr, Index, Base) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -427,6 +427,8 @@ begin_assignment(set(var(Name), string(Value))) -->
     quoted_string(ValueCodes),
     { string_codes(Value, ValueCodes) }.
 
+begin_assignment_name('BINFMT') -->
+    "BINFMT".
 begin_assignment_name('FS') -->
     "FS".
 begin_assignment_name('OFS') -->

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -63,6 +63,7 @@
     llvm_emit_printf_string/6,           % +FmtGlobal, +FmtLen, +FmtVar, +PrintVar, +PtrIR, -Parts
     llvm_emit_printf0/5,                 % +FmtGlobal, +FmtLen, +FmtVar, +PrintVar, -Parts
     llvm_emit_stream_driver_ir/3,        % +InputPath, +DriverBlocks, -DriverIR
+    llvm_emit_binary_stream_driver_ir/4, % +InputPath, +RecordSize, +DriverBlocks, -DriverIR
     llvm_emit_ascii_case_slice_print/5   % +Mode, +PtrIR, +LenIR, +PrintBase, -CallIR
 ]).
 
@@ -5002,6 +5003,94 @@ rtv.eof:
   %rtv.eof_v0 = insertvalue %Value undef, i32 0, 0
   %rtv.eof_v = insertvalue %Value %rtv.eof_v0, i64 %rtv.eof_aid, 1
   ret %Value %rtv.eof_v
+}
+
+; Fixed-size binary record reader over the buffered stream: copies
+; exactly %size bytes into %dst through the reader buffer. Returns
+; 1 for a full record, 0 for clean EOF at a record boundary, and -1
+; for a read error or a trailing partial record.
+define i64 @wam_stream_read_record(%Value %handle_value, i64 %size, i8* %dst) {
+entry:
+  %rrv.t = call i32 @value_tag(%Value %handle_value)
+  %rrv.is_int = icmp eq i32 %rrv.t, 1
+  br i1 %rrv.is_int, label %rrv.lookup_handle, label %rrv.fail
+
+rrv.fail:
+  ret i64 -1
+
+rrv.lookup_handle:
+  %rrv.handle64 = call i64 @value_payload(%Value %handle_value)
+  %rrv.handle = trunc i64 %rrv.handle64 to i32
+  %rrv.handle_min = icmp sgt i32 %rrv.handle, 0
+  %rrv.handle_max = icmp ult i32 %rrv.handle, 4096
+  %rrv.handle_ok = and i1 %rrv.handle_min, %rrv.handle_max
+  br i1 %rrv.handle_ok, label %rrv.load_handle, label %rrv.fail
+
+rrv.load_handle:
+  %rrv.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %rrv.handle
+  %rrv.reader = load %WamLineReader*, %WamLineReader** %rrv.slot
+  %rrv.reader_null = icmp eq %WamLineReader* %rrv.reader, null
+  br i1 %rrv.reader_null, label %rrv.fail, label %rrv.have_handle
+
+rrv.have_handle:
+  %rrv.fd_slot = getelementptr %WamLineReader, %WamLineReader* %rrv.reader, i32 0, i32 0
+  %rrv.fd = load i32, i32* %rrv.fd_slot
+  %rrv.fd_ok = icmp sge i32 %rrv.fd, 0
+  br i1 %rrv.fd_ok, label %rrv.loop, label %rrv.fail
+
+rrv.loop:
+  %rrv.copied = phi i64 [ 0, %rrv.have_handle ], [ %rrv.copied_next, %rrv.chunk ], [ %rrv.copied, %rrv.after_read ]
+  %rrv.done = icmp uge i64 %rrv.copied, %size
+  br i1 %rrv.done, label %rrv.full, label %rrv.need_bytes
+
+rrv.full:
+  ret i64 1
+
+rrv.need_bytes:
+  %rrv.buf_slot = getelementptr %WamLineReader, %WamLineReader* %rrv.reader, i32 0, i32 1
+  %rrv.buf = load i8*, i8** %rrv.buf_slot
+  %rrv.len_slot = getelementptr %WamLineReader, %WamLineReader* %rrv.reader, i32 0, i32 3
+  %rrv.len = load i64, i64* %rrv.len_slot
+  %rrv.pos_slot = getelementptr %WamLineReader, %WamLineReader* %rrv.reader, i32 0, i32 4
+  %rrv.pos = load i64, i64* %rrv.pos_slot
+  %rrv.have_byte = icmp slt i64 %rrv.pos, %rrv.len
+  br i1 %rrv.have_byte, label %rrv.chunk, label %rrv.fill
+
+rrv.chunk:
+  %rrv.avail = sub i64 %rrv.len, %rrv.pos
+  %rrv.want = sub i64 %size, %rrv.copied
+  %rrv.avail_smaller = icmp ult i64 %rrv.avail, %rrv.want
+  %rrv.n_copy = select i1 %rrv.avail_smaller, i64 %rrv.avail, i64 %rrv.want
+  %rrv.src = getelementptr i8, i8* %rrv.buf, i64 %rrv.pos
+  %rrv.dstp = getelementptr i8, i8* %dst, i64 %rrv.copied
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %rrv.dstp, i8* %rrv.src, i64 %rrv.n_copy, i1 false)
+  %rrv.pos_next = add i64 %rrv.pos, %rrv.n_copy
+  store i64 %rrv.pos_next, i64* %rrv.pos_slot
+  %rrv.copied_next = add i64 %rrv.copied, %rrv.n_copy
+  br label %rrv.loop
+
+rrv.fill:
+  %rrv.cap_slot = getelementptr %WamLineReader, %WamLineReader* %rrv.reader, i32 0, i32 2
+  %rrv.cap = load i64, i64* %rrv.cap_slot
+  %rrv.n = call i64 @read(i32 %rrv.fd, i8* %rrv.buf, i64 %rrv.cap)
+  %rrv.n_neg = icmp slt i64 %rrv.n, 0
+  br i1 %rrv.n_neg, label %rrv.fail, label %rrv.check_eof
+
+rrv.check_eof:
+  %rrv.n_zero = icmp eq i64 %rrv.n, 0
+  br i1 %rrv.n_zero, label %rrv.eof, label %rrv.after_read
+
+rrv.after_read:
+  store i64 %rrv.n, i64* %rrv.len_slot
+  store i64 0, i64* %rrv.pos_slot
+  br label %rrv.loop
+
+rrv.eof:
+  ; Clean EOF only at a record boundary; a trailing partial record is
+  ; an error.
+  %rrv.at_boundary = icmp eq i64 %rrv.copied, 0
+  %rrv.eof_status = select i1 %rrv.at_boundary, i64 0, i64 -1
+  ret i64 %rrv.eof_status
 }
 
 define i1 @wam_stream_close_value(%Value %handle_value) {
@@ -18015,6 +18104,209 @@ fail_close:
         [PathGlobalIR, RuntimeGlobals,
          BytesLen, BytesLen, PathLen, EntrySetupIR, LoopPhiIR, LoweredLabel,
          LoweredLabel, RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR]).
+
+%% llvm_emit_binary_stream_driver_ir(+InputPath, +RecordSize, +DriverBlocks, -DriverIR)
+%
+%  Binary sibling of llvm_emit_stream_driver_ir: the loop reads
+%  fixed-size RecordSize-byte records into a reusable %rec buffer with
+%  @wam_stream_read_record instead of interning text lines. There is no
+%  %line/%line_s; lowered blocks read typed fields directly from %rec.
+%  Block labels (%check_handle_value, %continue_loop, close labels)
+%  match the text skeleton so loop-carried phis work unchanged. A
+%  trailing partial record fails with the read error exit code.
+%  InputPath is a concrete path or the stdin_or_argv sentinel.
+llvm_emit_binary_stream_driver_ir(
+    InputPath,
+    RecordSize,
+    driver_blocks(RuntimeGlobals, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    !,
+    llvm_emit_binary_stream_driver_ir(InputPath, RecordSize,
+        driver_blocks(RuntimeGlobals, '', LoopPhiIR, LoweredLabel, RecordIR,
+            ContinueIR, '', CloseOkLabel, CloseOkIR),
+        DriverIR).
+
+llvm_emit_binary_stream_driver_ir(
+    InputPath,
+    RecordSize,
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    !,
+    llvm_emit_binary_stream_driver_ir(InputPath, RecordSize,
+        driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+            ContinueIR, '', CloseOkLabel, CloseOkIR),
+        DriverIR).
+
+llvm_emit_binary_stream_driver_ir(
+    stdin_or_argv,
+    RecordSize,
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    !,
+    format(atom(DriverIR),
+'@.wam_stream_stdin_dash = private constant [2 x i8] c"-\00"
+~w
+
+define i32 @main(i32 %argc, i8** %argv) {
+entry:
+~w
+  %rec = call i8* @malloc(i64 ~w)
+  %rec_null = icmp eq i8* %rec, null
+  br i1 %rec_null, label %fail_open, label %pick_input
+
+pick_input:
+  %have_arg = icmp sgt i32 %argc, 1
+  br i1 %have_arg, label %check_argv_path, label %use_stdin
+
+check_argv_path:
+  %argv1_ptr = getelementptr i8*, i8** %argv, i64 1
+  %argv1 = load i8*, i8** %argv1_ptr
+  %dash_ptr = getelementptr [2 x i8], [2 x i8]* @.wam_stream_stdin_dash, i32 0, i32 0
+  %dash_cmp = call i32 @strcmp(i8* %argv1, i8* %dash_ptr)
+  %is_dash = icmp eq i32 %dash_cmp, 0
+  br i1 %is_dash, label %use_stdin, label %open_argv_file
+
+open_argv_file:
+  %argv1_len = call i64 @strlen(i8* %argv1)
+  %path_id = call i64 @wam_intern_atom(i8* %argv1, i64 %argv1_len)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %file_handle = call %Value @wam_stream_open_value(%Value %path)
+  br label %have_handle
+
+use_stdin:
+  %stdin_handle = call %Value @wam_stream_open_fd_value(i64 0)
+  br label %have_handle
+
+have_handle:
+  %handle = phi %Value [ %file_handle, %open_argv_file ], [ %stdin_handle, %use_stdin ]
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+~w
+  %rec_status = call i64 @wam_stream_read_record(%Value %handle, i64 ~w, i8* %rec)
+  %rec_eof = icmp eq i64 %rec_status, 0
+  br i1 %rec_eof, label %close_stream, label %check_record
+
+check_record:
+  %rec_ok = icmp eq i64 %rec_status, 1
+  br i1 %rec_ok, label %~w, label %fail_read
+
+~w:
+~w
+
+continue_loop:
+~w
+  br label %loop
+
+~w
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %~w, label %fail_close
+
+~w
+
+fail_open:
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_close:
+  ret i32 16
+}
+',
+        [RuntimeGlobals, EntrySetupIR, RecordSize, LoopPhiIR, RecordSize,
+         LoweredLabel, LoweredLabel, RecordIR, ContinueIR, BreakCloseIR,
+         CloseOkLabel, CloseOkIR]).
+
+llvm_emit_binary_stream_driver_ir(
+    InputPath,
+    RecordSize,
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    llvm_emit_c_string_global(wam_stream_input_path, InputPath, PathGlobalIR, PathLen, BytesLen),
+    format(atom(DriverIR),
+'~w
+~w
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.wam_stream_input_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+~w
+  %rec = call i8* @malloc(i64 ~w)
+  %rec_null = icmp eq i8* %rec, null
+  br i1 %rec_null, label %fail_open, label %open_stream
+
+open_stream:
+  %handle = call %Value @wam_stream_open_value(%Value %path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+~w
+  %rec_status = call i64 @wam_stream_read_record(%Value %handle, i64 ~w, i8* %rec)
+  %rec_eof = icmp eq i64 %rec_status, 0
+  br i1 %rec_eof, label %close_stream, label %check_record
+
+check_record:
+  %rec_ok = icmp eq i64 %rec_status, 1
+  br i1 %rec_ok, label %~w, label %fail_read
+
+~w:
+~w
+
+continue_loop:
+~w
+  br label %loop
+
+~w
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %~w, label %fail_close
+
+~w
+
+fail_open:
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_close:
+  ret i32 16
+}
+',
+        [PathGlobalIR, RuntimeGlobals,
+         BytesLen, BytesLen, PathLen, EntrySetupIR, RecordSize, LoopPhiIR,
+         RecordSize, LoweredLabel, LoweredLabel, RecordIR, ContinueIR,
+         BreakCloseIR, CloseOkLabel, CloseOkIR]).
 
 %% llvm_emit_ascii_case_slice_print(+Mode, +PtrIR, +LenIR, +PrintBase, -CallIR)
 %

--- a/tests/test_plawk_binary_records.pl
+++ b/tests/test_plawk_binary_records.pl
@@ -1,0 +1,217 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_binrec_marker/0.
+
+user:plawk_binrec_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_binary_records, [condition(clang_available)]).
+
+test(parses_binfmt_begin_assignment) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" } $1 > 100 { sum += $2 } END { print sum }\n", Program),
+    assertion(Program == program([begin([set(var('BINFMT'), string("i64 i64"))])],
+        [rule(field_cmp(1, gt, 100), [add(var(sum), field(2))])],
+        [end([print([var(sum)])])])).
+
+test(binary_ir_loads_fields_without_parsing) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" } $1 > 100 { sum += $2 } END { print sum }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_stream_read_record(%Value %handle, i64 16, i8* %rec)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_fp = getelementptr i8, i8* %rec, i64 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_fp = getelementptr i8, i8* %rec, i64 8'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_field_i64_cmp_value')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'read_line')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(binary_ir_f64_field_uses_double_load) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } { print $1, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'bitcast i8* %plawk_binfield_1_fp to double*'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@printf(i8* %binfield_fmt_1, double %plawk_binfield_1)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_field_f64_value')),
+    !.
+
+test(binary_mode_rejects_text_shaped_programs) :-
+    Rejects = [
+        "BEGIN { BINFMT = \"i64 i64\" } { print $0 }\n",
+        "BEGIN { BINFMT = \"i64 i64\" } /^ERR/ { c++ } END { print c }\n",
+        "BEGIN { BINFMT = \"i64 i64\" } $1 == \"x\" { c++ } END { print c }\n",
+        "BEGIN { BINFMT = \"i64 f64\" } { sum += $2 } END { print sum }\n",
+        "BEGIN { BINFMT = \"i64 i64\" } { c += $3 } END { print c }\n",
+        "BEGIN { BINFMT = \"i64 i64\" } { counts[$1]++ } END { print counts[\"x\"] }\n",
+        "BEGIN { BINFMT = \"i64 i64\" } { print length($1) }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_binary_guard_and_sum) :-
+    run_binary_smoke("BEGIN { BINFMT = \"i64 i64\" } $1 > 100 { hits++; sum += $2 } END { print hits, sum }\n",
+        i64_pairs([50-1, 200-2, 300-3]),
+        "2 5\n").
+
+test(surface_binary_prints_i64_and_f64_fields) :-
+    run_binary_smoke("BEGIN { BINFMT = \"i64 f64\" } { print $1, $2 }\n",
+        i64_f64_pairs([1-2.5, 2-0.5]),
+        "1 2.5\n2 0.5\n").
+
+test(surface_binary_f64_arithmetic) :-
+    run_binary_smoke("BEGIN { BINFMT = \"i64 f64\" } { print float($2) * 2.0 }\n",
+        i64_f64_pairs([1-2.5, 2-0.5]),
+        "5\n1\n").
+
+test(surface_binary_negative_values_and_nf) :-
+    run_binary_smoke("BEGIN { BINFMT = \"i64 i64\" } { print NR, NF, $1 * $2 + 1 }\n",
+        i64_pairs([(-7)-4]),
+        "1 2 -27\n").
+
+test(surface_binary_combined_guard) :-
+    run_binary_smoke("BEGIN { BINFMT = \"i64 i64\" } $1 > 100 && $2 < 3 { c++ } END { print c }\n",
+        i64_pairs([50-1, 200-2, 300-3]),
+        "1\n").
+
+test(surface_binary_empty_input_runs_end) :-
+    run_binary_smoke("BEGIN { BINFMT = \"i64 i64\" } { total += $2 } END { print total }\n",
+        i64_pairs([]),
+        "0\n").
+
+test(surface_binary_printf) :-
+    run_binary_smoke("BEGIN { BINFMT = \"i64 i64\" } { printf \"%d;%d\\n\", $1, $2 }\n",
+        i64_pairs([50-1, 200-2]),
+        "50;1\n200;2\n").
+
+test(surface_binary_if_else_and_next) :-
+    run_binary_smoke("BEGIN { BINFMT = \"i64 i64\" } $2 == 9 { skipped++; next } { if ($1 > 100) { big++ } else { small++ } } END { print big, small, skipped }\n",
+        i64_pairs([50-1, 200-2, 5-9, 300-3]),
+        "2 1 1\n").
+
+test(surface_binary_trailing_partial_record_fails) :-
+    build_binary_probe("BEGIN { BINFMT = \"i64 i64\" } { total += $2 } END { print total }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, Out, [type(binary)]),
+        ( write_i64_le(Out, 1), write_i64_le(Out, 2),
+          write_i64_le(Out, 3) ),   % half a record trails
+        close(Out)),
+    process_create(BinPath, [],
+                   [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, Status),
+    assertion(Status == exit(11)),
+    !.
+
+test(surface_binary_reads_stdin) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_binary_records', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" } $1 > 100 { sum += $2 } END { print sum }\n", Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_records(InputPath, i64_pairs([50-1, 200-2, 300-3])),
+    format(atom(Cmd), '~w < ~w', [BinPath, InputPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == "5\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% IEEE-754 bit patterns for the dyadic doubles used in these tests.
+double_bits(2.5, 0x4004000000000000).
+double_bits(0.5, 0x3FE0000000000000).
+
+write_f64_le(Out, V) :-
+    double_bits(V, Bits),
+    write_i64_le(Out, Bits).
+
+write_records(Path, i64_pairs(Pairs)) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(A-B, Pairs),
+            ( write_i64_le(Out, A), write_i64_le(Out, B) )),
+        close(Out)).
+write_records(Path, i64_f64_pairs(Pairs)) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(A-B, Pairs),
+            ( write_i64_le(Out, A), write_f64_le(Out, B) )),
+        close(Out)).
+
+build_binary_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_binary_records', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_binrec_marker/0 ],
+        [module_name('plawk_binary_records')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk binary records build output]~n~w~n", [BuildOut]),
+       throw(plawk_binary_records_build_failed(Status))
+    ).
+
+run_binary_smoke(Source, Records, ExpectedOutput) :-
+    build_binary_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_records(InputPath, Records),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[plawk binary records run output]~n~w~n", [OutStr]),
+       throw(plawk_binary_records_run_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_binary_records).


### PR DESCRIPTION
## Summary

**Stacked on #3408** (→ #3407 → the feature series). This is the payoff PR — the "faster than awk via numeric/binary datatypes" thesis, demonstrated with numbers.

```awk
BEGIN { BINFMT = "i64 i64" } $1 > 100 { sum += $2 } END { print sum }
```

`BINFMT` switches the program to fixed-layout binary records: one 8-byte native-endian field per declared type (`$1..$N`, record size 8×N). Field access compiles to a **typed load at a compile-time offset** — no field splitting, no numeric parsing, no interning. The per-record loop is a buffered read, loads, a compare, and an add.

## Measured (2M records; 32 MB binary vs equivalent text)

| | time |
|---|---|
| **plawk, binary records** | **0.040s** |
| mawk on the text equivalent | 0.225s (**5.6× slower**) |
| plawk text mode, same text | 0.156s |

mawk cannot compete here because it must still parse text; the binary program does no parsing at all. (Note plawk's *text* mode also beats mawk on this numeric-guard workload after #3407/#3408.)

## Changes

**Runtime** — `@wam_stream_read_record(handle, size, dst)` copies exactly `size` bytes through the existing buffered reader: `1` = full record, `0` = clean EOF at a record boundary, `-1` = read error or trailing partial record (tested: exits 11).

**Driver** — `llvm_emit_binary_stream_driver_ir/4` is the binary sibling of the stream skeleton with identical block labels, so loop-carried phis, rule chains, `if/else`, `next`/`break`, NR, and END machinery compose **unchanged**; concrete paths and `stdin_or_argv` both work.

**Codegen** — a record descriptor (single-byte separator or `binfmt(Types)`) threads through the existing `FieldSeparator` position, so `binfmt(_)` clauses placed ahead of the text clauses lower: field guards → `load` + `icmp`, `$N` arithmetic → i64 loads, `float($N)` → double loads, `NF` → a compile-time constant, field prints → typed printf (`%ld`/`%g`). A **whitelist validator** keeps binary mode honest — `$0`, regex, string equality, `substr`/`length`/`index`/case, associative arrays, and foreign calls fail the driver clause cleanly instead of reaching text emitters.

**Slice boundary** — `i64`/`f64` field types; `f64` fields usable in prints and double expressions (scalar slots stay i64 per the doubles slice). Noted follow-ups: assoc tables keyed by i64 field values (no interning needed — the table is already i64-keyed), string fields, binary writers, and DCG readers per the rest of Phase 3.

**Tests** — 15 tests: BINFMT AST, no-parsing IR assertions (typed loads at offsets 0/8, *no* field helpers, *no* `read_line`, no `run_loop`), a 7-program reject list, and e2e binaries over Prolog-generated binary data (guards+sums, i64/f64 prints, f64 arithmetic, negative values, NF/NR, combined guards, if/else with `next`, printf, empty input, trailing-partial-record exit code, and stdin mode).

## Testing (honest exit codes)

All 14 suites pass: binary_records, transient_line_records, the ten plawk surface suites, intern scaling, and the 80-test `test_wam_llvm_target`.

**Merge order:** … → #3407 → #3408 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_