### PR TITLE
plawk: typed associative arrays over binary records

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -464,6 +464,20 @@ vs plawk text mode 0.156s — the no-parsing thesis, demonstrated.
 Remaining Phase 3 items below (DCG readers, richer ABIs, string fields,
 binary writers) are unchanged.
 
+**Second slice landed (typed associative arrays):** in binary mode
+`{ counts[$1]++ }` keys the existing `%WamAssocI64Table` runtime with the
+raw i64 field value — the record loop performs zero interning (the only
+`wam_intern_atom` call left is the one-shot input-path atom in the entry
+block). `END { for (k in counts) print k, counts[k] }` prints keys
+numerically straight from `wam_assoc_i64_key_at`, and END lookups accept
+signed integer literals (`print counts[5], counts[-3]`). A
+binary-mode validator (`plawk_assoc_record_program_ok/3`) requires counted
+keys to be i64 fields and END lookup keys to be integers; text mode
+rejects integer keys outright since raw integers would collide with atom
+ids in the shared i64 table. This delivers the associative-array note
+below for the group-by shape: a fully native, allocation-free aggregation
+loop over binary records.
+
 1. Binary record ABI: struct layout, alignment, (de)serialisation convention.
 2. DCG grammar for parsing binary records into terms.
 3. Compile the DCG through UnifyWeaver to LLVM.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -84,6 +84,7 @@ swipl -q -s tests/test_plawk_surface_float_exprs.pl -g "setenv('UW_SMOKE_TMPDIR'
 swipl -q -s tests/test_wam_llvm_atom_intern_scaling.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_transient_line_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_binary_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_binary_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -249,8 +250,14 @@ is a load-compare-add loop. `i64` fields work in guards, arithmetic,
 scalar updates, and prints; `f64` fields load as native doubles for
 prints and `float($N)` double expressions. `NF` is a compile-time
 constant; `NR`, `if/else`, `next`/`break`, `printf`, and END reports
-compose unchanged. Text-shaped forms ($0, regex, string equality,
-substr/length/index/case, associative arrays, foreign calls) are rejected
+compose unchanged. Associative arrays keyed by i64 fields work in
+binary mode: `{ counts[$1]++ }` uses the raw field value as the table key
+(no interning anywhere in the record loop), `END { for (k in counts) print
+k, counts[k] }` prints keys numerically, and END lookups take integer
+literals (`print counts[5], counts[-3]`); integer keys are binary-only
+(in text mode they would collide with atom ids, so they are rejected
+there). Remaining text-shaped forms ($0, regex, string equality,
+substr/length/index/case, string assoc keys, foreign calls) are rejected
 at codegen in binary mode. A trailing partial record exits with the read
 error code. Measured on 2M records: 0.040s for the binary program vs
 0.225s for mawk on the equivalent text (5.6x) and 0.156s for plawk's own

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -198,12 +198,12 @@ plawk_program_native_driver_ir(
     InputPath,
     DriverIR
 ) :-
-    \+ plawk_begin_has_binfmt(BeginClauses),
     plawk_assoc_runtime_count_plan(Rules, PrintFields, AssocPlan),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
-    plawk_field_separator(BeginClauses, FieldSeparator),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_assoc_record_program_ok(FieldSeparator, Rules, PrintFields),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
@@ -216,7 +216,7 @@ plawk_program_native_driver_ir(
     plawk_join_nonempty_ir([RecordCounterIR, AssocChainIR], RecordIR),
     plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
     plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
-    plawk_assoc_end_print_ir(PrintFields, AssocPlan, OutputSeparator, EndPrintIR),
+    plawk_assoc_end_print_ir(PrintFields, AssocPlan, FieldSeparator, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, AssocRuleGlobalIR]),
     plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
@@ -226,7 +226,7 @@ plawk_program_native_driver_ir(
 ~w
   ret i32 0',
         [EndPrintIR]),
-    llvm_emit_stream_driver_ir(InputPath,
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, RecordLoopPhiIR, lowered_assoc,
             RecordIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
@@ -236,19 +236,19 @@ plawk_program_native_driver_ir(
     InputPath,
     DriverIR
 ) :-
-    \+ plawk_begin_has_binfmt(BeginClauses),
     plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions, AssocPlan, PrintFields),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
-    plawk_field_separator(BeginClauses, FieldSeparator),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_assoc_record_program_ok(FieldSeparator, Rules, PrintFields),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
     plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
     plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
     plawk_forin_end_print_ir(LoopVar, ArrayName, PrintFields, AssocPlan,
-        OutputSeparator, EndPrintIR),
+        FieldSeparator, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, AssocRuleGlobalIR]),
     plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
@@ -257,7 +257,7 @@ plawk_program_native_driver_ir(
 'end_print:
 ~w',
         [EndPrintIR]),
-    llvm_emit_stream_driver_ir(InputPath,
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
             AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
@@ -538,10 +538,10 @@ plawk_forin_print_field(_LoopVar, string(_Value)).
 %  through @wam_assoc_i64_iter_next, print each record's fields, then free
 %  every table and return.
 plawk_forin_end_print_ir(LoopVar, ArrayName, PrintFields, AssocPlan,
-        OutputSeparator, IR) :-
+        Descriptor, OutputSeparator, IR) :-
     plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
     phrase(plawk_forin_body_print_lines(PrintFields, LoopVar, ArrayName,
-        TableIndex, AssocPlan, OutputSeparator, 0), BodyLines),
+        TableIndex, AssocPlan, Descriptor, OutputSeparator, 0), BodyLines),
     atomic_list_concat(BodyLines, '\n', BodyIR),
     phrase(plawk_assoc_free_lines(AssocPlan), FreeLines),
     atomic_list_concat(FreeLines, '\n', FreeIR),
@@ -570,10 +570,23 @@ forin_after:
         [TableIndex, TableIndex, BodyIR, FreeIR]).
 
 plawk_forin_body_print_lines([], _LoopVar, _ArrayName, _TableIndex, _AssocPlan,
-        _OutputSeparator, _) -->
+        _Descriptor, _OutputSeparator, _) -->
     [].
 plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
-        TableIndex, AssocPlan, OutputSeparator, PrintIndex) -->
+        TableIndex, AssocPlan, binfmt(Types), OutputSeparator, PrintIndex) -->
+    % Binary mode: keys are raw i64 field values, printed numerically.
+    plawk_forin_separator_lines(PrintIndex, OutputSeparator),
+    { format(atom(FmtVar), 'forin_key_fmt_~w', [PrintIndex]),
+      format(atom(PrintVar), 'forin_printed_key_~w', [PrintIndex]),
+      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+          '%forin_key_id', [FmtPtr, PrintCall]),
+      NextPrintIndex is PrintIndex + 1
+    },
+    [FmtPtr, PrintCall],
+    plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
+        binfmt(Types), OutputSeparator, NextPrintIndex).
+plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
+        TableIndex, AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_forin_separator_lines(PrintIndex, OutputSeparator),
     { format(atom(KeyString),
           '  %forin_key_s_~w = call i8* @wam_atom_to_string(i64 %forin_key_id)',
@@ -587,9 +600,9 @@ plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
     },
     [KeyString, FmtPtr, PrintCall],
     plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
-        OutputSeparator, NextPrintIndex).
+        Descriptor, OutputSeparator, NextPrintIndex).
 plawk_forin_body_print_lines([assoc(var(LookupArrayName), var(LoopVar)) | Rest],
-        LoopVar, ArrayName, TableIndex, AssocPlan, OutputSeparator, PrintIndex) -->
+        LoopVar, ArrayName, TableIndex, AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_forin_separator_lines(PrintIndex, OutputSeparator),
     { (   LookupArrayName == ArrayName
       ->  format(atom(Value),
@@ -609,14 +622,14 @@ plawk_forin_body_print_lines([assoc(var(LookupArrayName), var(LoopVar)) | Rest],
     },
     [Value, FmtPtr, PrintCall],
     plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
-        OutputSeparator, NextPrintIndex).
+        Descriptor, OutputSeparator, NextPrintIndex).
 plawk_forin_body_print_lines([string(Value) | Rest], LoopVar, ArrayName,
-        TableIndex, AssocPlan, OutputSeparator, PrintIndex) -->
+        TableIndex, AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_forin_separator_lines(PrintIndex, OutputSeparator),
     plawk_end_string_print_lines(Value, PrintIndex),
     { NextPrintIndex is PrintIndex + 1 },
     plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
-        OutputSeparator, NextPrintIndex).
+        Descriptor, OutputSeparator, NextPrintIndex).
 
 plawk_forin_separator_lines(0, _OutputSeparator) -->
     !,
@@ -1193,6 +1206,7 @@ plawk_assoc_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), ArrayNa
     KeyIndex > 0.
 
 plawk_assoc_print_array(assoc(var(ArrayName), string(_Key)), ArrayName).
+plawk_assoc_print_array(assoc(var(ArrayName), int(_Key)), ArrayName).
 
 plawk_assoc_planned_rules([], _Tables, _Index) -->
     [].
@@ -1300,6 +1314,26 @@ plawk_assoc_rule_action_lines(RuleIndex, Actions, NextLabel, FieldSeparator) -->
 
 plawk_assoc_rule_action_blocks(_RuleIndex, [], _NextLabel, _FieldSeparator) -->
     [].
+plawk_assoc_rule_action_blocks(RuleIndex, [assoc_action(Index, _ArrayName, TableIndex, KeyIndex) | Rest], NextLabel, binfmt(Types)) -->
+    { !,
+      ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(KeyBase), 'assoc_rule_~w_action_~w_key', [RuleIndex, Index]),
+      plawk_binfmt_field_load_lines(binfmt(Types), KeyIndex, KeyBase, KeyValueIR,
+          LoadLines),
+      format(atom(Inc),
+          '  %assoc_rule_~w_action_~w_count = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %plawk_assoc_table_~w, i64 ~w, i64 1)',
+          [RuleIndex, Index, TableIndex, KeyValueIR]),
+      format(atom(Next), '  br label %~w', [ActionNextLabel]),
+      append([[Label], LoadLines, [Inc, Next, '']], Lines)
+    },
+    plawk_emit_lines(Lines),
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, binfmt(Types)).
 plawk_assoc_rule_action_blocks(RuleIndex, [assoc_action(Index, _ArrayName, TableIndex, KeyIndex) | Rest], NextLabel, FieldSeparator) -->
     { ( Rest == []
       -> ActionNextLabel = NextLabel
@@ -1346,6 +1380,39 @@ plawk_assoc_rule_action_blocks(RuleIndex, [assoc_action(Index, _ArrayName, Table
 %  state, if/else, next/break, and representation-free END prints.
 %  Text-shaped forms (regex, string equality, substr/index/length/case,
 %  $0, assoc arrays, foreign calls) fail the whole driver clause.
+%% plawk_assoc_record_program_ok(+Descriptor, +Rules, +EndPrintFields)
+%
+%  Binary-mode whitelist for associative programs: guards must be
+%  binfmt-compatible, every counted key must be an i64 field (the raw
+%  field value is the table key -- no interning), and END lookups use
+%  integer keys. Text mode accepts everything as before.
+plawk_assoc_record_program_ok(binfmt(Types), Rules, EndPrintFields) :-
+    !,
+    forall(member(rule(Pattern, Actions), Rules),
+        ( plawk_binfmt_pattern_ok(binfmt(Types), Pattern),
+          forall(member(Action, Actions),
+              plawk_binfmt_assoc_action_ok(binfmt(Types), Action))
+        )),
+    forall(( member(Field, EndPrintFields),
+             Field = assoc(_Array, Key)
+           ),
+        % Integer literals in END lookups; the loop variable inside a
+        % for-in body (the key is already the raw i64 slot key there).
+        ( Key = int(_) ; Key = var(_) )).
+plawk_assoc_record_program_ok(_FieldSeparator, _Rules, EndPrintFields) :-
+    % Text mode: integer assoc keys would collide with atom ids, so
+    % they stay binary-only.
+    forall(( member(Field, EndPrintFields),
+             Field = assoc(_Array, Key)
+           ),
+        Key \= int(_)).
+
+plawk_binfmt_assoc_action_ok(_Descriptor, next) :- !.
+plawk_binfmt_assoc_action_ok(_Descriptor, break) :- !.
+plawk_binfmt_assoc_action_ok(Descriptor, inc_assoc(var(_Name), field(Index))) :-
+    !,
+    plawk_binfmt_field_type(Descriptor, Index, i64).
+
 plawk_record_program_ok(binfmt(Types), Rules, _EndPrintFields) :-
     !,
     forall(member(rule(Pattern, Actions), Rules),
@@ -1651,17 +1718,34 @@ plawk_assoc_key_codes(Key, Codes) :-
 plawk_assoc_key_codes(Key, Codes) :-
     atom_codes(Key, Codes).
 
-plawk_assoc_end_print_ir(PrintFields, AssocPlan, OutputSeparator, IR) :-
-    phrase(plawk_assoc_end_print_lines(PrintFields, AssocPlan, OutputSeparator, 0), Lines),
+plawk_assoc_end_print_ir(PrintFields, AssocPlan, Descriptor, OutputSeparator, IR) :-
+    phrase(plawk_assoc_end_print_lines(PrintFields, AssocPlan, Descriptor,
+        OutputSeparator, 0), Lines),
     atomic_list_concat(Lines, '\n', IR).
 
-plawk_assoc_end_print_lines([], AssocPlan, _OutputSeparator, _) -->
+plawk_assoc_end_print_lines([], AssocPlan, _Descriptor, _OutputSeparator, _) -->
     { llvm_emit_printf0(plawk_surface_print_newline, 2,
           end_newline_fmt, printed_end_newline, [FmtPtr, PrintCall])
     },
     [FmtPtr, PrintCall],
     plawk_assoc_free_lines(AssocPlan).
-plawk_assoc_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], AssocPlan, OutputSeparator, PrintIndex) -->
+plawk_assoc_end_print_lines([assoc(var(ArrayName), int(Key)) | Rest], AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
+    { Descriptor = binfmt(_Types),
+      plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
+      format(atom(Value),
+          '  %assoc_end_value_~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 ~w)',
+          [PrintIndex, TableIndex, Key]),
+      format(atom(FmtVar), 'assoc_end_i64_fmt_~w', [PrintIndex]),
+      format(atom(PrintVar), 'printed_assoc_end_i64_~w', [PrintIndex]),
+      format(atom(ValueIR), '%assoc_end_value_~w', [PrintIndex]),
+      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
+          [FmtPtr, PrintCall]),
+      NextPrintIndex is PrintIndex + 1
+    },
+    [Value, FmtPtr, PrintCall],
+    plawk_assoc_end_print_lines(Rest, AssocPlan, Descriptor, OutputSeparator, NextPrintIndex).
+plawk_assoc_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     { plawk_assoc_key_codes(Key, Codes),
       length(Codes, KeyLen),
@@ -1684,12 +1768,12 @@ plawk_assoc_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], AssocPl
       NextPrintIndex is PrintIndex + 1
     },
     [KeyPtr, KeyId, Value, FmtPtr, PrintCall],
-    plawk_assoc_end_print_lines(Rest, AssocPlan, OutputSeparator, NextPrintIndex).
-plawk_assoc_end_print_lines([string(Value) | Rest], AssocPlan, OutputSeparator, PrintIndex) -->
+    plawk_assoc_end_print_lines(Rest, AssocPlan, Descriptor, OutputSeparator, NextPrintIndex).
+plawk_assoc_end_print_lines([string(Value) | Rest], AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     plawk_end_string_print_lines(Value, PrintIndex),
     { NextPrintIndex is PrintIndex + 1 },
-    plawk_assoc_end_print_lines(Rest, AssocPlan, OutputSeparator, NextPrintIndex).
+    plawk_assoc_end_print_lines(Rest, AssocPlan, Descriptor, OutputSeparator, NextPrintIndex).
 
 plawk_assoc_table_index(assoc_plan(Tables, _Actions), ArrayName, TableIndex) :-
     nth0(TableIndex, Tables, ArrayName).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -988,6 +988,9 @@ assoc_key_expr(field(Index)) -->
       number_codes(Index, IndexCodes),
       Index >= 0
     }.
+assoc_key_expr(int(Value)) -->
+    signed_integer_value(Value),
+    !.
 assoc_key_expr(string(Value)) -->
     quoted_string(ValueCodes),
     { ValueCodes \== [],

--- a/tests/test_plawk_binary_assoc.pl
+++ b/tests/test_plawk_binary_assoc.pl
@@ -1,0 +1,187 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_binassoc_marker/0.
+
+user:plawk_binassoc_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_binary_assoc, [condition(clang_available)]).
+
+test(parses_int_assoc_keys) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" } { counts[$1]++ } END { print counts[5], counts[-3] }\n", Program),
+    assertion(Program == program([begin([set(var('BINFMT'), string("i64 i64"))])],
+        [rule(always, [inc_assoc(var(counts), field(1))])],
+        [end([print([assoc(var(counts), int(5)), assoc(var(counts), int(-3))])])])).
+
+test(binary_groupby_ir_keys_are_raw_fields) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) print k, counts[k] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % The table key is the raw i64 field load, not an interned atom id.
+    assertion(once(sub_atom(DriverIR, _, _, _,
+        '%assoc_rule_0_action_0_key = load i64, i64* %assoc_rule_0_action_0_key_tp, align 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _,
+        '@wam_assoc_i64_inc(%WamAssocI64Table* %plawk_assoc_table_0, i64 %assoc_rule_0_action_0_key, i64 1)'))),
+    % for-in keys print numerically without atom-table round trips.
+    assertion(once(sub_atom(DriverIR, _, _, _,
+        '@printf(i8* %forin_key_fmt_0, i64 %forin_key_id)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_to_string')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'read_line')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    % The only interning left is the one-shot input-path atom in entry.
+    findall(Before, sub_atom(DriverIR, Before, _, _, '@wam_intern_atom('), InternSites),
+    assertion(InternSites = [_]),
+    !.
+
+test(binary_assoc_int_key_lookup_ir) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" } $2 > 100 { counts[$1]++ } END { print counts[5], counts[-3] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _,
+        '@wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_0, i64 5)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _,
+        '@wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_0, i64 -3)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value')),
+    !.
+
+test(binary_assoc_rejects_text_shaped_programs) :-
+    Rejects = [
+        % string keys need interning -- not available in binary mode
+        "BEGIN { BINFMT = \"i64 i64\" } { counts[$1]++ } END { print counts[\"x\"] }\n",
+        % f64 fields cannot key an i64 table
+        "BEGIN { BINFMT = \"i64 f64\" } { counts[$2]++ } END { for (k in counts) print k, counts[k] }\n",
+        % key field out of range for the record layout
+        "BEGIN { BINFMT = \"i64 i64\" } { counts[$3]++ } END { for (k in counts) print k, counts[k] }\n",
+        % regex guards are text-only
+        "BEGIN { BINFMT = \"i64 i64\" } /^ERR/ { counts[$1]++ } END { for (k in counts) print k, counts[k] }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(text_mode_rejects_int_assoc_keys) :-
+    % In text mode assoc keys are atom ids; a literal integer key would
+    % silently collide with them, so it must be refused.
+    plawk_parse_string("{ counts[$1]++ } END { print counts[5] }\n", Program),
+    assertion(\+ plawk_program_native_driver_ir(Program, 'input.txt', _)).
+
+test(text_mode_string_assoc_still_works) :-
+    plawk_parse_string("{ counts[$1]++ } END { print counts[\"alpha\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_get'))),
+    !.
+
+test(surface_binary_groupby_forin) :-
+    run_binassoc_smoke_sorted("BEGIN { BINFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) print k, counts[k] }\n",
+        [5-0, (-3)-0, 5-0, 9-0, (-3)-0, 5-0],
+        ["-3 2", "5 3", "9 1"]).
+
+test(surface_binary_guarded_groupby_int_lookup) :-
+    run_binassoc_smoke("BEGIN { BINFMT = \"i64 i64\" } $2 > 100 { counts[$1]++ } END { print counts[5], counts[-3] }\n",
+        [5-200, 5-50, (-3)-300, 5-150, 9-999, (-3)-50],
+        "2 1\n").
+
+test(surface_binary_missing_key_reads_zero) :-
+    run_binassoc_smoke("BEGIN { BINFMT = \"i64 i64\" } { counts[$1]++ } END { print counts[42] }\n",
+        [5-0, 9-0],
+        "0\n").
+
+test(surface_binary_groupby_second_field_key) :-
+    run_binassoc_smoke_sorted("BEGIN { BINFMT = \"i64 i64\" } { counts[$2]++ } END { for (k in counts) print k, counts[k] }\n",
+        [1-7, 2-7, 3-8],
+        ["7 2", "8 1"]).
+
+test(surface_binary_groupby_empty_input) :-
+    run_binassoc_smoke("BEGIN { BINFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) print k, counts[k] }\n",
+        [],
+        "").
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_pairs(Path, Pairs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(A-B, Pairs),
+            ( write_i64_le(Out, A), write_i64_le(Out, B) )),
+        close(Out)).
+
+build_binassoc_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_binary_assoc', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_binassoc_marker/0 ],
+        [module_name('plawk_binary_assoc')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk binary assoc build output]~n~w~n", [BuildOut]),
+       throw(plawk_binary_assoc_build_failed(Status))
+    ).
+
+run_binassoc_probe(Source, Pairs, OutStr) :-
+    build_binassoc_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_pairs(InputPath, Pairs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk binary assoc run output]~n~w~n", [OutStr]),
+       throw(plawk_binary_assoc_run_failed(Status))
+    ).
+
+run_binassoc_smoke(Source, Pairs, ExpectedOutput) :-
+    run_binassoc_probe(Source, Pairs, OutStr),
+    assertion(OutStr == ExpectedOutput),
+    !.
+
+% for-in iteration order follows the hash table, so compare sorted lines.
+run_binassoc_smoke_sorted(Source, Pairs, ExpectedLines) :-
+    run_binassoc_probe(Source, Pairs, OutStr),
+    split_string(OutStr, "\n", "", Split0),
+    exclude(==(""), Split0, Lines0),
+    msort(Lines0, SortedLines),
+    msort(ExpectedLines, SortedExpected),
+    assertion(SortedLines == SortedExpected),
+    !.
+
+:- end_tests(plawk_binary_assoc).


### PR DESCRIPTION
## Summary

Extends binary typed records (`BINFMT`) to associative arrays: group-by aggregation now runs with **zero per-record interning** — the raw i64 field value is the hash-table key.

```awk
BEGIN { BINFMT = "i64 i64" }
{ counts[$1]++ }
END { for (k in counts) print k, counts[k] }
```

compiles to a native loop that reads a 16-byte record, loads the key field at its compile-time offset, and calls `wam_assoc_i64_inc` directly. The only `wam_intern_atom` call left in the whole program is the one-shot input-path atom in the entry block.

## What's included

- **Parser**: `assoc_key_expr` accepts signed integer literals, so END lookups can say `print counts[5], counts[-3]`.
- **Codegen**: the assoc and for-in driver clauses now thread the record descriptor (`binfmt(Types)` or text separator) through validation, rule action blocks, and END prints, dispatching to the binary or text stream skeleton via `plawk_emit_record_driver_ir`.
- **Binary-mode assoc actions**: `counts[$N]++` loads field N as a typed i64 and increments the table with that raw value — no field slicing, no interning, no atom table growth. Constant memory regardless of key cardinality beyond the table itself.
- **For-in END reports in binary mode** print keys numerically straight from `wam_assoc_i64_key_at` (no `wam_atom_to_string` round trip).
- **Validation** (`plawk_assoc_record_program_ok/3`): binary mode requires counted keys to be i64 fields and END lookup keys to be integer literals; text mode rejects integer keys outright, since a raw integer key would silently collide with atom ids in the shared i64 table.

## Tests

New suite `tests/test_plawk_binary_assoc.pl` (11 tests): AST for int keys; IR shape (key fed by a raw field load, exactly one intern site, no `wam_atom_to_string`/`wam_atom_field_slice_value`/`read_line`/`@run_loop`); int-key END lookups; rejection of string keys, f64 keys, out-of-range fields, and regex guards in binary mode; text-mode int-key rejection; text-mode string keys unchanged; end-to-end group-by with negative keys, guarded group-by, missing-key-reads-zero, and empty input.

Full regression sweep green: all 20 plawk/WAM-LLVM suites plus `test_wam_llvm_target` exit 0.

## Merge order

Stacked on #3409 (binary typed records). Merge chain: #3402 → #3403 → #3404 → #3405 → #3406 → #3407 → #3408 → #3409 → this PR. This PR's base is `claude/plawk-llvm-wam-hybrid-p9ujut-binary-records`; after #3409 merges, this can be re-based onto the default branch or merged as-is if GitHub retargets it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_