### PR TITLE
plawk: typed double scalar slots

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -318,9 +318,19 @@ satisfied and rounding matches strtod) or a `float($N)` strtod coercion
 (`@wam_atom_field_f64_value`) lowers through a parallel `plawk_f64_expr_ir`
 emitter with `fadd/fsub/fmul/fdiv/frem` and `sitofp` promotion of `i64`
 subtrees. Output is `%g` for `print` and `%f`/`%g`/`%e` (optional
-precision) for `printf`. Scalar slots remain `i64` in this slice; typed
-double slots (state-plan slot types threaded through the loop/branch/final
-phi emitters) are the follow-up that unlocks `{ sum += $2 * 1.5 }`.
+precision) for `printf`. Typed double scalar slots are in:
+state-plan slots carry an inferred type (`scalar_counter(Name)` = i64,
+`scalar_double(Name)` = double), computed by a fixpoint over update
+expressions — a scalar is double when any update assigns it a
+float-typed expression or reads an already-double scalar. Every phi
+emitter (loop head, rule input, next, break, final, if-join) formats the
+slot's LLVM type; double updates lower the RHS through
+`plawk_f64_expr_ir` (substituted double reads arrive as `ssa_f64/1`
+leaves, i64 operands promote via `sitofp`) into `fadd`, and END prints
+of double slots use `%g`. `{ sum += $2 * 1.5 }` and
+`{ sum += float($2) }` now accumulate natively in both text and binary
+record modes; END *arithmetic* on double slots stays i64-only and is
+rejected (the next f64 slice).
 Scalar variables are readable inside rule-body update expressions and END
 prints: codegen substitutes `var(Name)` leaves with the current SSA slot
 value (an `ssa/1` leaf the shared emitters print verbatim) before emission,

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -85,6 +85,7 @@ swipl -q -s tests/test_wam_llvm_atom_intern_scaling.pl -g "setenv('UW_SMOKE_TMPD
 swipl -q -s tests/test_plawk_transient_line_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_binary_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_binary_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_float_slots.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -248,7 +249,15 @@ offset — no field splitting, no numeric parsing, no interning — so
 `BEGIN { BINFMT = "i64 i64" } $1 > 100 { sum += $2 } END { print sum }`
 is a load-compare-add loop. `i64` fields work in guards, arithmetic,
 scalar updates, and prints; `f64` fields load as native doubles for
-prints and `float($N)` double expressions. `NF` is a compile-time
+prints and `float($N)` double expressions. Scalar accumulators are typed
+by inference: `sum += float($2) * 1.5` makes `sum` a native double slot
+(double loop phis, `fadd` updates, `%g` END prints) while `n++` in the
+same program stays i64 — a scalar becomes double when any update
+assigns it a float-typed expression or reads an already-double scalar
+(fixpoint), and i64 operands promote via `sitofp` at the update site.
+This works in text mode (`float($N)` = strtod) and binary mode
+(`float($N)` = native f64 field load), through `if`/`else`,
+`next`/`break`, and rule chains. `NF` is a compile-time
 constant; `NR`, `if/else`, `next`/`break`, `printf`, and END reports
 compose unchanged. Associative arrays keyed by i64 fields work in
 binary mode: `{ counts[$1]++ }` uses the raw field value as the table key

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -673,6 +673,25 @@ plawk_state_slot_index(StatePlan, Slot, Index) :-
     plawk_state_plan_slots(StatePlan, Slots),
     nth0(Index, Slots, Slot).
 
+% Scalar slots are typed: scalar_counter(Name) accumulates in an i64
+% register chain, scalar_double(Name) in a double chain. The type is
+% inferred from the program (see plawk_scalar_typed_slots/3), never
+% declared, matching awk's untyped surface.
+plawk_slot_name(scalar_counter(Name), Name).
+plawk_slot_name(scalar_double(Name), Name).
+
+plawk_slot_llvm_type(scalar_counter(_Name), i64).
+plawk_slot_llvm_type(scalar_double(_Name), double).
+
+plawk_slot_zero_ir(scalar_counter(_Name), '0').
+plawk_slot_zero_ir(scalar_double(_Name), '0.0').
+
+plawk_state_slot_lookup(StatePlan, Name, Index, Slot) :-
+    plawk_state_plan_slots(StatePlan, Slots),
+    nth0(Index, Slots, Slot),
+    plawk_slot_name(Slot, Name),
+    !.
+
 plawk_trim_control_tails([], []).
 plawk_trim_control_tails([next | _Rest], [next]) :-
     !.
@@ -770,7 +789,7 @@ plawk_break_close_ir(StatePlan, _RuleCount, _Controls, _BranchControlExits, _Bre
     ).
 plawk_break_slot_phi_lines([], _RuleCount, _Controls, _BranchControlExits, _BreakPredKind, _) -->
     [].
-plawk_break_slot_phi_lines([_Slot | Rest], RuleCount, Controls, BranchControlExits, BreakPredKind, SlotIndex) -->
+plawk_break_slot_phi_lines([Slot | Rest], RuleCount, Controls, BranchControlExits, BreakPredKind, SlotIndex) -->
     { LastRuleIndex is RuleCount - 1,
       findall(Incoming,
           ( between(0, LastRuleIndex, RuleIndex),
@@ -784,7 +803,8 @@ plawk_break_slot_phi_lines([_Slot | Rest], RuleCount, Controls, BranchControlExi
       append(RuleIncomings, BranchIncomings, Incomings),
       Incomings \== [],
       atomic_list_concat(Incomings, ', ', IncomingIR),
-      format(atom(Line), '  %break_slot_~w = phi i64 ~w', [SlotIndex, IncomingIR]),
+      plawk_slot_llvm_type(Slot, Type),
+      format(atom(Line), '  %break_slot_~w = phi ~w ~w', [SlotIndex, Type, IncomingIR]),
       NextSlotIndex is SlotIndex + 1
     },
     [Line],
@@ -806,7 +826,7 @@ plawk_break_predecessor_label(done, RuleIndex, Label) :-
 
 plawk_final_state_phi_lines([], _HasBreak, _) -->
     [].
-plawk_final_state_phi_lines([_Slot | Rest], HasBreak, SlotIndex) -->
+plawk_final_state_phi_lines([Slot | Rest], HasBreak, SlotIndex) -->
     { format(atom(EofIncoming), '[%slot_~w, %close_stream]', [SlotIndex]),
       ( HasBreak == true
       -> format(atom(BreakIncoming), '[%break_slot_~w, %break_close_stream]', [SlotIndex]),
@@ -814,7 +834,8 @@ plawk_final_state_phi_lines([_Slot | Rest], HasBreak, SlotIndex) -->
       ;  Incomings = [EofIncoming]
       ),
       atomic_list_concat(Incomings, ', ', IncomingIR),
-      format(atom(Line), '  %final_slot_~w = phi i64 ~w', [SlotIndex, IncomingIR]),
+      plawk_slot_llvm_type(Slot, Type),
+      format(atom(Line), '  %final_slot_~w = phi ~w ~w', [SlotIndex, Type, IncomingIR]),
       NextSlotIndex is SlotIndex + 1
     },
     [Line],
@@ -844,9 +865,60 @@ plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
         PrintVars),
     append(ActionVars, PrintVars, Names0),
     sort(Names0, Names),
-    maplist(plawk_scalar_state_slot, Names, Slots).
+    plawk_scalar_typed_slots(Rules, Names, Slots).
 
-plawk_scalar_state_slot(Name, scalar_counter(Name)).
+%% plawk_scalar_typed_slots(+Rules, +Names, -Slots)
+%
+%  Fixpoint type inference: a scalar is double when any update assigns
+%  it a double-typed expression (float literal or float($N) leaf) or
+%  reads an already-double scalar; everything else stays i64. i64
+%  reads inside a double update promote via sitofp at emission.
+plawk_scalar_typed_slots(Rules, Names, Slots) :-
+    findall(Name-Expr,
+        ( member(rule(_Pattern, Actions0), Rules),
+          plawk_trim_control_tails(Actions0, Actions),
+          member(Action, Actions),
+          plawk_scalar_update_name_expr(Action, Name, Expr)
+        ),
+        Updates),
+    plawk_scalar_double_fixpoint(Updates, [], Doubles),
+    maplist(plawk_scalar_typed_slot(Doubles), Names, Slots).
+
+plawk_scalar_update_name_expr(Action, Name, Expr) :-
+    plawk_scalar_action_update(Action, Name, Operation),
+    plawk_scalar_operation_expr(Operation, Expr).
+plawk_scalar_update_name_expr(if(_Pattern, ThenActions, ElseActions), Name, Expr) :-
+    ( member(Action, ThenActions)
+    ; member(Action, ElseActions)
+    ),
+    plawk_scalar_update_name_expr(Action, Name, Expr).
+
+plawk_scalar_double_fixpoint(Updates, Doubles0, Doubles) :-
+    findall(Name,
+        ( member(Name-Expr, Updates),
+          \+ memberchk(Name, Doubles0),
+          plawk_update_expr_is_double(Expr, Doubles0)
+        ),
+        New0),
+    sort(New0, New),
+    ( New == []
+    -> Doubles = Doubles0
+    ;  append(Doubles0, New, Doubles1),
+       plawk_scalar_double_fixpoint(Updates, Doubles1, Doubles)
+    ).
+
+plawk_update_expr_is_double(Expr, _Doubles) :-
+    plawk_expr_is_double(Expr),
+    !.
+plawk_update_expr_is_double(Expr, Doubles) :-
+    plawk_expr_scalar_read_name(Expr, Name),
+    memberchk(Name, Doubles),
+    !.
+
+plawk_scalar_typed_slot(Doubles, Name, scalar_double(Name)) :-
+    memberchk(Name, Doubles),
+    !.
+plawk_scalar_typed_slot(_Doubles, Name, scalar_counter(Name)).
 
 plawk_mixed_state_plan(Rules, PrintFields, mixed_plan(ScalarPlan, AssocPlan, PlannedRules)) :-
     plawk_mixed_scalar_state_plan(Rules, PrintFields, ScalarPlan),
@@ -873,7 +945,7 @@ plawk_mixed_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
         PrintVars),
     append(ActionVars, PrintVars, Names0),
     sort(Names0, Names),
-    maplist(plawk_scalar_state_slot, Names, Slots).
+    plawk_scalar_typed_slots(Rules, Names, Slots).
 
 plawk_mixed_assoc_count_plan(Rules, PrintFields, assoc_plan(Tables, [])) :-
     findall(ArrayName,
@@ -1118,7 +1190,7 @@ plawk_mixed_scalar_rule_input_phi_ir(StatePlan, RuleIndex, Controls, IR) :-
 
 plawk_mixed_scalar_rule_input_phi_lines([], _RuleIndex, _Controls, _) -->
     [].
-plawk_mixed_scalar_rule_input_phi_lines([_Slot | Rest], RuleIndex, Controls, SlotIndex) -->
+plawk_mixed_scalar_rule_input_phi_lines([Slot | Rest], RuleIndex, Controls, SlotIndex) -->
     { PrevRuleIndex is RuleIndex - 1,
       plawk_scalar_rule_input_value(PrevRuleIndex, SlotIndex, PrevFalseValue),
       format(atom(FalseIncoming), '[~w, %rule_~w_match]',
@@ -1130,8 +1202,9 @@ plawk_mixed_scalar_rule_input_phi_lines([_Slot | Rest], RuleIndex, Controls, Slo
           Incomings = [FalseIncoming, ApplyIncoming]
       ),
       atomic_list_concat(Incomings, ', ', IncomingIR),
-      format(atom(Line), '  %rule_~w_in_slot_~w = phi i64 ~w',
-          [RuleIndex, SlotIndex, IncomingIR]),
+      plawk_slot_llvm_type(Slot, Type),
+      format(atom(Line), '  %rule_~w_in_slot_~w = phi ~w ~w',
+          [RuleIndex, SlotIndex, Type, IncomingIR]),
       NextSlotIndex is SlotIndex + 1
     },
     [Line],
@@ -1144,7 +1217,7 @@ plawk_mixed_scalar_next_phi_ir(StatePlan, RuleCount, Controls, BranchNextExits, 
 
 plawk_mixed_scalar_next_phi_lines([], _RuleCount, _Controls, _BranchNextExits, _) -->
     [].
-plawk_mixed_scalar_next_phi_lines([_Slot | Rest], RuleCount, Controls, BranchNextExits, Index) -->
+plawk_mixed_scalar_next_phi_lines([Slot | Rest], RuleCount, Controls, BranchNextExits, Index) -->
     { LastRuleIndex is RuleCount - 1,
       plawk_scalar_rule_input_value(LastRuleIndex, Index, FalseValue),
       format(atom(FalseIncoming), '[~w, %rule_~w_match]',
@@ -1163,7 +1236,8 @@ plawk_mixed_scalar_next_phi_lines([_Slot | Rest], RuleCount, Controls, BranchNex
       plawk_branch_next_phi_incomings(BranchNextExits, Index, BranchNextIncomings),
       append([FalseIncoming | ApplyIncomings], BranchNextIncomings, Incomings),
       atomic_list_concat(Incomings, ', ', IncomingIR),
-      format(atom(Line), '  %next_slot_~w = phi i64 ~w', [Index, IncomingIR]),
+      plawk_slot_llvm_type(Slot, Type),
+      format(atom(Line), '  %next_slot_~w = phi ~w ~w', [Index, Type, IncomingIR]),
       NextIndex is Index + 1
     },
     [Line],
@@ -1447,10 +1521,16 @@ plawk_binfmt_action_ok(Descriptor, inc(var(_Name))) :- !,
     Descriptor = binfmt(_).
 plawk_binfmt_action_ok(Descriptor, add(var(_Name), Expr)) :-
     !,
-    plawk_binfmt_i64_expr_ok(Descriptor, Expr).
+    ( plawk_expr_is_double(Expr)
+    -> plawk_binfmt_f64_expr_ok(Descriptor, Expr)
+    ;  plawk_binfmt_i64_expr_ok(Descriptor, Expr)
+    ).
 plawk_binfmt_action_ok(Descriptor, set(var(_Name), Expr)) :-
     !,
-    plawk_binfmt_i64_expr_ok(Descriptor, Expr).
+    ( plawk_expr_is_double(Expr)
+    -> plawk_binfmt_f64_expr_ok(Descriptor, Expr)
+    ;  plawk_binfmt_i64_expr_ok(Descriptor, Expr)
+    ).
 plawk_binfmt_action_ok(Descriptor, print(Fields)) :-
     !,
     forall(member(Field, Fields),
@@ -1940,7 +2020,7 @@ plawk_scalar_rule_input_phi_ir(StatePlan, RuleIndex, Controls, IR) :-
 
 plawk_scalar_rule_input_phi_lines([], _RuleIndex, _Controls, _) -->
     [].
-plawk_scalar_rule_input_phi_lines([_Name | Rest], RuleIndex, Controls, SlotIndex) -->
+plawk_scalar_rule_input_phi_lines([Slot | Rest], RuleIndex, Controls, SlotIndex) -->
     { PrevRuleIndex is RuleIndex - 1,
       plawk_scalar_rule_input_value(PrevRuleIndex, SlotIndex, PrevFalseValue),
       format(atom(FalseIncoming), '[~w, %rule_~w_match]',
@@ -1952,8 +2032,9 @@ plawk_scalar_rule_input_phi_lines([_Name | Rest], RuleIndex, Controls, SlotIndex
           Incomings = [FalseIncoming, ApplyIncoming]
       ),
       atomic_list_concat(Incomings, ', ', IncomingIR),
-      format(atom(Line), '  %rule_~w_in_slot_~w = phi i64 ~w',
-          [RuleIndex, SlotIndex, IncomingIR]),
+      plawk_slot_llvm_type(Slot, Type),
+      format(atom(Line), '  %rule_~w_in_slot_~w = phi ~w ~w',
+          [RuleIndex, SlotIndex, Type, IncomingIR]),
       NextSlotIndex is SlotIndex + 1
     },
     [Line],
@@ -1982,10 +2063,12 @@ plawk_state_loop_phi_ir(StatePlan, IR) :-
 
 plawk_scalar_loop_phi_lines([], _) -->
     [].
-plawk_scalar_loop_phi_lines([_Slot | Rest], Index) -->
-    { format(atom(Line),
-          '  %slot_~w = phi i64 [0, %check_handle_value], [%next_slot_~w, %continue_loop]',
-          [Index, Index]),
+plawk_scalar_loop_phi_lines([Slot | Rest], Index) -->
+    { plawk_slot_llvm_type(Slot, Type),
+      plawk_slot_zero_ir(Slot, Zero),
+      format(atom(Line),
+          '  %slot_~w = phi ~w [~w, %check_handle_value], [%next_slot_~w, %continue_loop]',
+          [Index, Type, Zero, Index]),
       NextIndex is Index + 1
     },
     [Line],
@@ -2000,7 +2083,7 @@ plawk_native_match_update_ir(StatePlan, AssocPlan, Actions, FieldSeparator, Outp
     format(atom(Prefix), 'rule_~w_body', [RuleIndex]),
     phrase(plawk_scalar_action_sequence_pairs(Actions, Slots, AssocPlan, FieldSeparator, OutputSeparator,
         Prefix, Prefix, RuleIndex, 0, InitialValues, FinalValues, _NextOpIndex, _ExitLabel, NextExits), Pairs0),
-    phrase(plawk_scalar_final_slot_pairs(FinalValues, RuleIndex, 0), FinalPairs),
+    phrase(plawk_scalar_final_slot_pairs(FinalValues, Slots, RuleIndex, 0), FinalPairs),
     append(Pairs0, FinalPairs, Pairs),
     pairs_keys_values(Pairs, GlobalParts, LineParts),
     atomic_list_concat(GlobalParts, '\n', GlobalIR),
@@ -2015,15 +2098,21 @@ plawk_scalar_initial_slot_values(RuleIndex, [_Slot | Rest], SlotIndex) -->
     [Value],
     plawk_scalar_initial_slot_values(RuleIndex, Rest, NextIndex).
 
-plawk_scalar_final_slot_pairs([], _RuleIndex, _) -->
+plawk_scalar_final_slot_pairs([], _Slots, _RuleIndex, _) -->
     [].
-plawk_scalar_final_slot_pairs([Value | Rest], RuleIndex, SlotIndex) -->
-    { format(atom(Line), '  %rule_~w_slot_~w = add i64 ~w, 0',
-          [RuleIndex, SlotIndex, Value]),
+plawk_scalar_final_slot_pairs([Value | Rest], [Slot | Slots], RuleIndex, SlotIndex) -->
+    { % SSA copy idiom: x + 0 for i64, -0.0 + x for double (IEEE identity
+      % that preserves the sign of zero, unlike x + 0.0).
+      ( Slot = scalar_double(_Name)
+      -> format(atom(Line), '  %rule_~w_slot_~w = fadd double -0.0, ~w',
+             [RuleIndex, SlotIndex, Value])
+      ;  format(atom(Line), '  %rule_~w_slot_~w = add i64 ~w, 0',
+             [RuleIndex, SlotIndex, Value])
+      ),
       NextSlotIndex is SlotIndex + 1
     },
     [''-Line],
-    plawk_scalar_final_slot_pairs(Rest, RuleIndex, NextSlotIndex).
+    plawk_scalar_final_slot_pairs(Rest, Slots, RuleIndex, NextSlotIndex).
 
 plawk_scalar_update_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
@@ -2159,10 +2248,16 @@ plawk_substitute_operation_reads(set(Expr0), Slots, Values, set(Expr)) :-
     plawk_substitute_scalar_reads(Expr0, Slots, Values, Expr).
 plawk_substitute_operation_reads(Operation, _Slots, _Values, Operation).
 
-plawk_substitute_scalar_reads(var(Name), Slots, Values, ssa(Value)) :-
+plawk_substitute_scalar_reads(var(Name), Slots, Values, Substituted) :-
     !,
-    nth0(SlotIndex, Slots, scalar_counter(Name)),
-    nth0(SlotIndex, Values, Value).
+    nth0(SlotIndex, Slots, Slot),
+    plawk_slot_name(Slot, Name),
+    !,
+    nth0(SlotIndex, Values, Value),
+    ( Slot = scalar_double(_Name)
+    -> Substituted = ssa_f64(Value)
+    ;  Substituted = ssa(Value)
+    ).
 plawk_substitute_scalar_reads(Expr0, Slots, Values, Expr) :-
     plawk_i64_binary_expr(Expr0, _LLVMOp, _NamePart, Left0, Right0),
     !,
@@ -2282,6 +2377,33 @@ plawk_scalar_action_update(set(var(Name), var(Read)), Name, set(var(Read))) :-
 plawk_scalar_action_update(set(var(Name), prolog_call(Pred, Args)), Name,
         set(prolog_call(Pred, Args))) :-
     plawk_prolog_call_expr(prolog_call(Pred, Args)).
+% Double-typed update expressions: float literals, float($N), and
+% binary trees mixing them with i64 operands or scalar reads. The
+% written slot becomes a double via plawk_scalar_typed_slots/3.
+plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
+    plawk_f64_scalar_update_expr(Expr).
+plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
+    plawk_f64_scalar_update_expr(Expr).
+
+plawk_f64_scalar_update_expr(Expr) :-
+    plawk_expr_is_double(Expr),
+    plawk_f64_scalar_read_operand_expr(Expr).
+
+plawk_f64_scalar_read_operand_expr(var(Name)) :-
+    atom(Name).
+plawk_f64_scalar_read_operand_expr(float_const(Mantissa, Denominator)) :-
+    integer(Mantissa),
+    integer(Denominator),
+    Denominator > 0.
+plawk_f64_scalar_read_operand_expr(float_field(Index)) :-
+    integer(Index),
+    Index >= 0.
+plawk_f64_scalar_read_operand_expr(Expr) :-
+    plawk_i64_operand_expr(Expr).
+plawk_f64_scalar_read_operand_expr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    plawk_f64_scalar_read_operand_expr(Left),
+    plawk_f64_scalar_read_operand_expr(Right).
 
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, CurrentLabel, []) -->
@@ -2289,10 +2411,11 @@ plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _Out
 plawk_scalar_action_sequence_pairs([Action | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
         OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
     { plawk_scalar_action_update(Action, Name, Operation0),
-      nth0(SlotIndex, Slots, scalar_counter(Name)),
+      nth0(SlotIndex, Slots, Slot),
+      plawk_slot_name(Slot, Name),
       nth0(SlotIndex, Values0, InputValue),
       plawk_substitute_operation_reads(Operation0, Slots, Values0, Operation),
-      plawk_scalar_update_operation_ir(Operation, FieldSeparator, Prefix, SlotIndex,
+      plawk_scalar_update_operation_ir(Operation, Slot, FieldSeparator, Prefix, SlotIndex,
           OpIndex, InputValue, NextValue, Pair),
       replace_nth0(SlotIndex, Values0, NextValue, Values1),
       NextOpIndex is OpIndex + 1
@@ -2359,7 +2482,7 @@ plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest
       plawk_branch_to_done_ir(ThenExitLabel, DoneLabel, ThenDoneIR),
       plawk_branch_to_done_ir(ElseExitLabel, DoneLabel, ElseDoneIR),
       plawk_scalar_if_join_pairs(ThenExitLabel, ThenValues, ElseExitLabel, ElseValues,
-          Prefix, OpIndex, PhiPairs),
+          Slots, Prefix, OpIndex, PhiPairs),
       pairs_keys_values(PhiPairs, _PhiGlobalParts, PhiLineParts),
       atomic_list_concat(PhiLineParts, '\n', PhiIR),
       pairs_keys(PhiPairs, Values1),
@@ -2390,7 +2513,25 @@ plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest
         NextOpIndex, Values1, Values, FinalOpIndex, ExitLabel, RestNextExits),
     { append(BranchNextExits, RestNextExits, NextExits) }.
 
-plawk_scalar_update_operation_ir(add(Expr), FieldSeparator, Prefix, SlotIndex,
+plawk_scalar_update_operation_ir(add(Expr), scalar_double(_Name), FieldSeparator,
+        Prefix, SlotIndex, OpIndex, InputValue, NextValue, GlobalIR-IR) :-
+    !,
+    plawk_scalar_f64_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, GlobalIR, SetupIR),
+    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
+    format(atom(AddLine), '  ~w = fadd double ~w, ~w',
+        [NextValue, InputValue, ValueIR]),
+    plawk_join_nonempty_ir([SetupIR, AddLine], IR).
+plawk_scalar_update_operation_ir(set(Expr), scalar_double(_Name), FieldSeparator,
+        Prefix, SlotIndex, OpIndex, _InputValue, NextValue, GlobalIR-IR) :-
+    !,
+    plawk_scalar_f64_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, GlobalIR, SetupIR),
+    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
+    % -0.0 + x is the IEEE identity copy (x + 0.0 would flip -0.0).
+    format(atom(SetLine), '  ~w = fadd double -0.0, ~w', [NextValue, ValueIR]),
+    plawk_join_nonempty_ir([SetupIR, SetLine], IR).
+plawk_scalar_update_operation_ir(add(Expr), _Slot, FieldSeparator, Prefix, SlotIndex,
         OpIndex, InputValue, NextValue, GlobalIR-IR) :-
     plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
         OpIndex, ValueIR, GlobalIR, SetupIR),
@@ -2398,13 +2539,40 @@ plawk_scalar_update_operation_ir(add(Expr), FieldSeparator, Prefix, SlotIndex,
     format(atom(AddLine), '  ~w = add i64 ~w, ~w',
         [NextValue, InputValue, ValueIR]),
     plawk_join_nonempty_ir([SetupIR, AddLine], IR).
-plawk_scalar_update_operation_ir(set(Expr), FieldSeparator, Prefix, SlotIndex,
+plawk_scalar_update_operation_ir(set(Expr), _Slot, FieldSeparator, Prefix, SlotIndex,
         OpIndex, _InputValue, NextValue, GlobalIR-IR) :-
     plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
         OpIndex, ValueIR, GlobalIR, SetupIR),
     format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
     format(atom(SetLine), '  ~w = add i64 0, ~w', [NextValue, ValueIR]),
     plawk_join_nonempty_ir([SetupIR, SetLine], IR).
+
+%% plawk_scalar_f64_numeric_expr_ir(+Expr, +FieldSeparator, +Prefix,
+%%     +SlotIndex, +OpIndex, -ValueIR, -GlobalIR, -SetupIR)
+%
+%  Update RHS for a double slot. Double-typed trees (and double scalar
+%  reads) emit through the f64 emitter; i64-shaped operands emit through
+%  the i64 path and promote with sitofp.
+plawk_scalar_f64_numeric_expr_ir(ssa_f64(Value), _FieldSeparator, _Prefix,
+        _SlotIndex, _OpIndex, Value, '', '') :-
+    !.
+plawk_scalar_f64_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, GlobalIR, SetupIR) :-
+    plawk_expr_is_double(Expr),
+    !,
+    format(atom(Base), '~w_slot_~w_op_~w_f64', [Prefix, SlotIndex, OpIndex]),
+    plawk_f64_expr_ir(Expr, FieldSeparator, Base, Base, ValueIR,
+        GlobalParts, SetupParts),
+    atomic_list_concat(GlobalParts, '\n', GlobalIR),
+    atomic_list_concat(SetupParts, '\n', SetupIR).
+plawk_scalar_f64_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, GlobalIR, SetupIR) :-
+    plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
+        OpIndex, IntValueIR, GlobalIR, IntSetupIR),
+    format(atom(ValueIR), '%~w_slot_~w_op_~w_f64p', [Prefix, SlotIndex, OpIndex]),
+    format(atom(PromoteIR), '  ~w = sitofp i64 ~w to double',
+        [ValueIR, IntValueIR]),
+    plawk_join_nonempty_ir([IntSetupIR, PromoteIR], SetupIR).
 
 plawk_scalar_numeric_expr_ir(ssa(Value), _FieldSeparator, _Prefix, _SlotIndex,
         _OpIndex, Value, '', '') :-
@@ -2571,6 +2739,9 @@ plawk_i64_binary_op_lines(LLVMOp, Base, LeftIR, RightIR, [Line]) :-
 %  sitofp at emission time.
 plawk_expr_is_double(float_const(_Mantissa, _Denominator)).
 plawk_expr_is_double(float_field(_Index)).
+% A substituted read of a double scalar slot (see
+% plawk_substitute_scalar_reads/4).
+plawk_expr_is_double(ssa_f64(_Value)).
 plawk_expr_is_double(Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
     ( plawk_expr_is_double(Left)
@@ -2606,6 +2777,9 @@ plawk_f64_operand_expr(Expr) :-
 %  rounded value, matching strtod). i64 subtrees emit through the i64
 %  emitter and promote with sitofp; IEEE semantics apply to / (no
 %  divide-by-zero guard: x/0.0 is inf, 0.0/0.0 is nan, as in awk).
+plawk_f64_expr_ir(ssa_f64(Value), _FieldSeparator, _Base, _GlobalBase,
+        Value, [], []) :-
+    !.
 plawk_f64_expr_ir(float_const(Mantissa, Denominator), _FieldSeparator, Base,
         _GlobalBase, ValueIR, [], [ConstIR]) :-
     format(atom(ValueIR), '%~w', [Base]),
@@ -2693,21 +2867,21 @@ plawk_branch_to_done_ir(ExitLabel, DoneLabel, IR) :-
 plawk_branch_terminal_exit(none).
 plawk_branch_terminal_exit(break).
 
-plawk_scalar_if_join_pairs(ThenExitLabel, _ThenValues, ElseExitLabel, _ElseValues, _Prefix, _OpIndex, _Pairs) :-
+plawk_scalar_if_join_pairs(ThenExitLabel, _ThenValues, ElseExitLabel, _ElseValues, _Slots, _Prefix, _OpIndex, _Pairs) :-
     plawk_branch_terminal_exit(ThenExitLabel),
     plawk_branch_terminal_exit(ElseExitLabel),
     !,
     fail.
-plawk_scalar_if_join_pairs(ThenExitLabel, _ThenValues, _ElseExitLabel, ElseValues, _Prefix, _OpIndex, Pairs) :-
+plawk_scalar_if_join_pairs(ThenExitLabel, _ThenValues, _ElseExitLabel, ElseValues, _Slots, _Prefix, _OpIndex, Pairs) :-
     plawk_branch_terminal_exit(ThenExitLabel),
     !,
     plawk_scalar_if_passthrough_pairs(ElseValues, Pairs).
-plawk_scalar_if_join_pairs(_ThenExitLabel, ThenValues, ElseExitLabel, _ElseValues, _Prefix, _OpIndex, Pairs) :-
+plawk_scalar_if_join_pairs(_ThenExitLabel, ThenValues, ElseExitLabel, _ElseValues, _Slots, _Prefix, _OpIndex, Pairs) :-
     plawk_branch_terminal_exit(ElseExitLabel),
     !,
     plawk_scalar_if_passthrough_pairs(ThenValues, Pairs).
-plawk_scalar_if_join_pairs(ThenExitLabel, ThenValues, ElseExitLabel, ElseValues, Prefix, OpIndex, Pairs) :-
-    phrase(plawk_scalar_if_phi_lines(ThenValues, ElseValues, Prefix, OpIndex,
+plawk_scalar_if_join_pairs(ThenExitLabel, ThenValues, ElseExitLabel, ElseValues, Slots, Prefix, OpIndex, Pairs) :-
+    phrase(plawk_scalar_if_phi_lines(ThenValues, ElseValues, Slots, Prefix, OpIndex,
         ThenExitLabel, ElseExitLabel, 0), Pairs).
 
 plawk_scalar_if_passthrough_pairs([], []).
@@ -2754,17 +2928,18 @@ plawk_assoc_update_operation_ir(Prefix, OpIndex, TableIndex, KeyIndex,
          DoneLabel,
          DoneLabel]).
 
-plawk_scalar_if_phi_lines([], [], _Prefix, _OpIndex, _ThenLabel, _ElseLabel, _) -->
+plawk_scalar_if_phi_lines([], [], _Slots, _Prefix, _OpIndex, _ThenLabel, _ElseLabel, _) -->
     [].
 plawk_scalar_if_phi_lines([ThenValue | ThenRest], [ElseValue | ElseRest],
-        Prefix, OpIndex, ThenLabel, ElseLabel, SlotIndex) -->
+        [Slot | Slots], Prefix, OpIndex, ThenLabel, ElseLabel, SlotIndex) -->
     { format(atom(PhiValue), '%~w_if_~w_slot_~w', [Prefix, OpIndex, SlotIndex]),
-      format(atom(Line), '  ~w = phi i64 [~w, %~w], [~w, %~w]',
-          [PhiValue, ThenValue, ThenLabel, ElseValue, ElseLabel]),
+      plawk_slot_llvm_type(Slot, Type),
+      format(atom(Line), '  ~w = phi ~w [~w, %~w], [~w, %~w]',
+          [PhiValue, Type, ThenValue, ThenLabel, ElseValue, ElseLabel]),
       NextSlotIndex is SlotIndex + 1
     },
     [PhiValue-Line],
-    plawk_scalar_if_phi_lines(ThenRest, ElseRest, Prefix, OpIndex, ThenLabel, ElseLabel, NextSlotIndex).
+    plawk_scalar_if_phi_lines(ThenRest, ElseRest, Slots, Prefix, OpIndex, ThenLabel, ElseLabel, NextSlotIndex).
 
 replace_nth0(0, [_Old | Rest], Value, [Value | Rest]) :-
     !.
@@ -2780,7 +2955,7 @@ plawk_scalar_next_phi_ir(StatePlan, RuleCount, Controls, BranchNextExits, IR) :-
 
 plawk_scalar_next_phi_lines([], _RuleCount, _Controls, _BranchNextExits, _) -->
     [].
-plawk_scalar_next_phi_lines([_Slot | Rest], RuleCount, Controls, BranchNextExits, Index) -->
+plawk_scalar_next_phi_lines([Slot | Rest], RuleCount, Controls, BranchNextExits, Index) -->
     { LastRuleIndex is RuleCount - 1,
       plawk_scalar_rule_input_value(LastRuleIndex, Index, FalseValue),
       format(atom(FalseIncoming), '[~w, %rule_~w_match]',
@@ -2799,7 +2974,8 @@ plawk_scalar_next_phi_lines([_Slot | Rest], RuleCount, Controls, BranchNextExits
       plawk_branch_next_phi_incomings(BranchNextExits, Index, BranchNextIncomings),
       append([FalseIncoming | ApplyIncomings], BranchNextIncomings, Incomings),
       atomic_list_concat(Incomings, ', ', IncomingIR),
-      format(atom(Line), '  %next_slot_~w = phi i64 ~w', [Index, IncomingIR]),
+      plawk_slot_llvm_type(Slot, Type),
+      format(atom(Line), '  %next_slot_~w = phi ~w ~w', [Index, Type, IncomingIR]),
       NextIndex is Index + 1
     },
     [Line],
@@ -2825,12 +3001,21 @@ plawk_scalar_end_print_lines([], _StatePlan, _OutputSeparator, _) -->
     [FmtPtr, PrintCall].
 plawk_scalar_end_print_lines([var(Name) | Rest], StatePlan, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
-    { plawk_state_slot_index(StatePlan, scalar_counter(Name), SlotIndex),
-      format(atom(FmtVar), 'end_i64_fmt_~w', [PrintIndex]),
-      format(atom(PrintVar), 'printed_end_i64_~w', [PrintIndex]),
+    { plawk_state_slot_lookup(StatePlan, Name, SlotIndex, Slot),
       format(atom(ValueIR), '%final_slot_~w', [SlotIndex]),
-      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
-          [FmtPtr, PrintCall]),
+      ( Slot = scalar_double(_Name)
+      -> format(atom(FmtVar), 'end_f64_fmt_~w', [PrintIndex]),
+         format(atom(FmtPtr),
+             '  %~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_f64, i32 0, i32 0',
+             [FmtVar]),
+         format(atom(PrintCall),
+             '  %printed_end_f64_~w = call i32 (i8*, ...) @printf(i8* %~w, double ~w)',
+             [PrintIndex, FmtVar, ValueIR])
+      ;  format(atom(FmtVar), 'end_i64_fmt_~w', [PrintIndex]),
+         format(atom(PrintVar), 'printed_end_i64_~w', [PrintIndex]),
+         llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
+             [FmtPtr, PrintCall])
+      ),
       NextPrintIndex is PrintIndex + 1
     },
     [FmtPtr, PrintCall],

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -591,6 +591,12 @@ scalar_value_expr(Value) -->
 
 scalar_delta_expr(Expr) -->
     i64_binary_surface_expr(Expr).
+% Bare float leaves before the integer clause: "0.5" must not stop at
+% the integer prefix "0".
+scalar_delta_expr(Expr) -->
+    float_field_expr(Expr).
+scalar_delta_expr(Expr) -->
+    float_literal_expr(Expr).
 scalar_delta_expr(int(Value)) -->
     integer_codes(ValueCodes),
     { ValueCodes \== [],

--- a/tests/test_plawk_float_slots.pl
+++ b/tests/test_plawk_float_slots.pl
@@ -1,0 +1,169 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_f64slot_marker/0.
+
+user:plawk_f64slot_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_float_slots, [condition(clang_available)]).
+
+test(parses_bare_float_delta) :-
+    plawk_parse_string("{ sum += 0.5 } END { print sum }\n", Program),
+    assertion(Program == program([],
+        [rule(always, [add(var(sum), float_const(5, 10))])],
+        [end([print([var(sum)])])])).
+
+test(parses_float_field_delta) :-
+    plawk_parse_string("{ sum += float($2) } END { print sum }\n", Program),
+    assertion(Program == program([],
+        [rule(always, [add(var(sum), float_field(2))])],
+        [end([print([var(sum)])])])).
+
+test(double_slot_ir_uses_double_phis_and_fadd) :-
+    plawk_parse_string("{ sum += $2 * 1.5 } END { print sum }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _,
+        '%slot_0 = phi double [0.0, %check_handle_value], [%next_slot_0, %continue_loop]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%next_slot_0 = phi double '))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%final_slot_0 = phi double '))),
+    assertion(once(sub_atom(DriverIR, _, _, _, ' = fadd double %slot_0, '))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@printf(i8* %end_f64_fmt_0, double %final_slot_0)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(i64_slots_stay_i64) :-
+    plawk_parse_string("{ n++ ; total += $2 } END { print n, total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'phi double')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'fadd')),
+    !.
+
+test(fixpoint_promotes_transitive_reads) :-
+    % b reads a; a is double, so b must become double too.
+    plawk_parse_string("{ a = 1.5 ; b = a + 1 } END { print b }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _,
+        '@printf(i8* %end_f64_fmt_0, double %final_slot_'))),
+    !.
+
+test(end_arith_on_double_slot_is_rejected) :-
+    % END i64 arithmetic cannot consume a double slot.
+    plawk_parse_string("{ sum += 0.5 } END { print sum + 1 }\n", Program),
+    assertion(\+ plawk_program_native_driver_ir(Program, 'input.txt', _)).
+
+test(surface_double_accumulator_text) :-
+    run_f64_smoke("{ sum += float($2) * 1.5 ; n++ } END { print n, sum }\n",
+        "a 2.5\nb 0.5\nc 1.0\n",
+        "3 6\n").
+
+test(surface_double_if_else_and_next) :-
+    run_f64_smoke("$1 == \"skip\" { next } { if ($2 > 2) { big += 0.5 } else { small += 0.25 } } END { print big, small }\n",
+        "x 5\nskip 9\nx 1\nx 3\n",
+        "1 0.25\n").
+
+test(surface_double_break) :-
+    run_f64_smoke("$1 == \"stop\" { break } { sum += 0.5 } END { print sum }\n",
+        "a 1\nb 2\nstop 0\nc 3\n",
+        "1\n").
+
+test(surface_double_set_overwrites) :-
+    run_f64_smoke("{ last = float($2) } END { print last }\n",
+        "a 2.5\nb 0.125\n",
+        "0.125\n").
+
+test(surface_binary_double_accumulator) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_float_slots', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } $1 > 10 { sum += float($2) } END { print sum }\n", Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_stream_read_record'))),
+    emit_probe(Dir, DriverIR, BinPath),
+    write_i64_f64_records(InputPath, [5-bits(0x4023800000000000),      % 9.75
+                                      20-bits(0x4004000000000000),     % 2.5
+                                      30-bits(0x3FD0000000000000)]),   % 0.25
+    process_create(BinPath, [], [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == "2.75\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_i64_f64_records(Path, Pairs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(A-bits(Bits), Pairs),
+            ( write_i64_le(Out, A), write_i64_le(Out, Bits) )),
+        close(Out)).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_f64slot_marker/0 ],
+        [module_name('plawk_float_slots')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk float slots build output]~n~w~n", [BuildOut]),
+       throw(plawk_float_slots_build_failed(Status))
+    ).
+
+run_f64_smoke(Source, InputText, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_float_slots', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, Out, [encoding(utf8)]),
+        write(Out, InputText),
+        close(Out)),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath),
+    process_create(BinPath, [], [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == ExpectedOutput)
+    ;  format(user_error, "~n[plawk float slots run output]~n~w~n", [OutStr]),
+       throw(plawk_float_slots_run_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_float_slots).


### PR DESCRIPTION
## Summary

Scalar accumulators are now **typed by inference**: 

```awk
{ sum += float($2) * 1.5 ; n++ }
END { print n, sum }
```

makes `sum` a native double slot — double loop phis, `fadd` updates, `%g` END print — while `n` in the same program stays a plain i64 counter. No declarations; the surface stays awk-untyped.

## How typing works

A fixpoint over update expressions decides each slot's type: a scalar becomes double when any update assigns it a float-typed expression (float literal or `float($N)` leaf) or reads an already-double scalar (`a = 1.5; b = a + 1` promotes `b` too). Everything else stays i64. Inside a double update, i64 operands (fields, NR, i64 scalar reads) promote via `sitofp` at the update site.

## What changed

- **State plan**: slots are `scalar_counter(Name)` (i64) or `scalar_double(Name)` (double); `plawk_scalar_typed_slots/3` runs the inference.
- **Phi emitters**: loop-head, rule-input, next, break, final, and if-join phis (both the scalar and mixed variants) now format the slot's LLVM type instead of hardcoding `i64`.
- **Updates**: double-slot RHS lowers through the existing `plawk_f64_expr_ir` emitter; substituted double scalar reads arrive as `ssa_f64/1` leaves; `set` uses the IEEE identity copy `fadd double -0.0, x` (plain `x + 0.0` would flip the sign of `-0.0`).
- **Parser**: `scalar_delta_expr` accepts bare float literals and `float($N)` (placed before the integer clause so `0.5` doesn't stop at the prefix `0`).
- **Binary mode**: `BEGIN { BINFMT = "i64 f64" } { sum += float($2) }` validates through `plawk_binfmt_f64_expr_ok` and accumulates from native f64 field loads — no strtod anywhere.
- **Boundaries**: END *arithmetic* on double slots (`print sum + 1`) is rejected — END expressions stay i64-only for now; mixed assoc+scalar programs with double slots are likewise rejected cleanly. Both are candidates for a later f64 slice.

## Tests

New suite `tests/test_plawk_float_slots.pl` (11 tests): parse shapes, IR shape (double phis at every join point, `fadd` update, `%g` END print, no `@run_loop`), i64-programs-stay-i64, transitive fixpoint promotion, END-arithmetic rejection, and end-to-end runs covering text mode, binary mode, `if`/`else`, `next`, `break`, and `set` overwrite.

Full regression sweep green: all 21 existing plawk/WAM-LLVM suites exit 0.

## Merge order

Stacked on #3410 (binary assoc). Chain: #3402 → … → #3409 → #3410 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_