### PR TITLE
plawk: binary record writers (OUTFMT + writebin)

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -479,8 +479,17 @@ straight from the record buffer, and `$N == "key"` lowers to memcmp
 plus a NUL check at the key length (elided for full-width keys;
 oversized keys fold to constant false). String fields are
 print/equality-only; arithmetic, `float()`, numeric compares, and assoc
-keys on them are rejected. Remaining Phase 3 items below (DCG readers,
-richer ABIs, binary writers) are unchanged.
+keys on them are rejected. **Fourth slice landed (binary writers):** `BEGIN { OUTFMT = "..." }`
+plus the `writebin expr, ...` action write fixed-layout binary records
+to stdout: a resolve pre-pass stamps each writebin with the layout
+types (failing on missing OUTFMT, arity mismatch, or sN output), the
+entry block allocates one reused record buffer, each argument lowers
+through the i64/f64 expression emitters into a typed store at its
+layout offset, and a buffered `fwrite(buf, size, 1, stdout)` emits the
+record (libc flushes on normal main return). Works from both text and
+binary inputs, so plawk-to-plawk binary pipelines (converter |
+aggregator) run with no text serialization between stages. Remaining
+Phase 3 items below (DCG readers, richer ABIs) are unchanged.
 
 **Second slice landed (typed associative arrays):** in binary mode
 `{ counts[$1]++ }` keys the existing `%WamAssocI64Table` runtime with the

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -87,6 +87,7 @@ swipl -q -s tests/test_plawk_binary_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_binary_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_float_slots.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_binfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_binary_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -275,7 +276,20 @@ full-width keys; oversized keys fold to constant false). String fields
 are print/equality only: arithmetic, `float()`, numeric compares, and
 assoc keys on `sN` fields are rejected. Remaining text-shaped forms
 ($0, regex, substr/length/index/case, string assoc keys, foreign calls)
-are rejected at codegen in binary mode. A trailing partial record exits with the read
+are rejected at codegen in binary mode.
+
+Binary *writers* close the pipeline loop: `BEGIN { OUTFMT = "i64 f64" }
+{ writebin $1, float($2) }` emits one fixed-layout binary record on
+stdout per call (typed stores into a reused entry-block buffer, then a
+buffered `fwrite`). writebin works in text mode (a text-to-binary
+converter) and binary mode (a binary-to-binary transform), takes i64
+expressions, NR/NF, scalar reads, and double expressions per the OUTFMT
+slot types (i64 arguments promote into f64 slots), and composes with
+guards, scalar updates, and `if`/`else`. A plawk-to-plawk pipeline -
+converter | aggregator - runs with no text serialization between
+stages. Rejected: writebin without OUTFMT, argument/layout arity
+mismatch, `sN` output fields (later slice), and double expressions into
+i64 slots. A trailing partial record exits with the read
 error code. Measured on 2M records: 0.040s for the binary program vs
 0.225s for mawk on the equivalent text (5.6x) and 0.156s for plawk's own
 text mode.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -69,20 +69,28 @@
 %  function emits the target-specific native main that streams the file, lowers
 %  the deterministic guard, and prints matching records.
 plawk_program_native_driver_ir(
-    program(BeginClauses, [rule(Pattern, [Action])], []),
+    program(BeginClauses, [rule(Pattern, [Action0])], []),
     InputPath,
     DriverIR
 ) :-
-    plawk_rule_body_print_action(Action),
+    plawk_resolve_writebin_rules(BeginClauses, [rule(Pattern, [Action0])],
+        [rule(Pattern, [Action])], WritebinPlan),
+    ( Action = writebin_out(WritebinTypes, WritebinFields)
+    -> plawk_writebin_args_ok(WritebinTypes, WritebinFields)
+    ;  plawk_rule_body_print_action(Action)
+    ),
     plawk_output_action_exprs(Action, Exprs),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
-    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR0),
+    plawk_writebin_entry_lines(WritebinPlan, WritebinEntryIR),
+    plawk_join_nonempty_ir([BeginIR0, WritebinEntryIR], BeginIR),
     plawk_record_descriptor(BeginClauses, FieldSeparator),
     plawk_record_program_ok(FieldSeparator, [rule(Pattern, [Action])], []),
     plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardGlobalIR-GuardCallIR),
     plawk_print_record_counter_ir(Exprs, LoopPhiIR, RecordCounterIR),
     plawk_output_action_ir(Action, FieldSeparator, OutputSeparator, PrintGlobalIR-PrintActionIR),
+    plawk_writebin_globals(WritebinPlan, WritebinGlobalIR),
     format(atom(RecordIR),
 '~w
 ~w
@@ -102,8 +110,9 @@ print_line:
 ~w
 ~w
 ~w
+~w
 ',
-        [BeginGlobalIR, GuardGlobalIR, PrintGlobalIR]),
+        [BeginGlobalIR, GuardGlobalIR, PrintGlobalIR, WritebinGlobalIR]),
     plawk_emit_record_driver_ir(FieldSeparator, InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR, '',
             success, 'success:\n  ret i32 0'),
@@ -154,14 +163,17 @@ plawk_program_native_driver_ir(
         DriverIR).
 
 plawk_program_native_driver_ir(
-    program(BeginClauses, Rules, [end([print(PrintFields)])]),
+    program(BeginClauses, Rules0, [end([print(PrintFields)])]),
     InputPath,
     DriverIR
 ) :-
+    plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules, WritebinPlan),
     plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
-    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR0),
+    plawk_writebin_entry_lines(WritebinPlan, WritebinEntryIR),
+    plawk_join_nonempty_ir([BeginIR0, WritebinEntryIR], BeginIR),
     plawk_record_descriptor(BeginClauses, FieldSeparator),
     plawk_record_program_ok(FieldSeparator, Rules, PrintFields),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
@@ -169,7 +181,9 @@ plawk_program_native_driver_ir(
         RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
     plawk_rules_body_print_fields(Rules, BodyPrintFields),
     plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
-    append(PrintFields, BodyPrintFields, PrintExprs),
+    plawk_rules_writebin_exprs(Rules, WritebinExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs0),
+    append(PrintExprs0, WritebinExprs, PrintExprs),
     append(PrintExprs, ScalarExprs, RecordCounterExprs),
     plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
     plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
@@ -180,8 +194,9 @@ plawk_program_native_driver_ir(
     plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, done,
         BreakCloseIR, FinalStatePhiIR),
     plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, EndPrintIR),
-    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
-        [BeginGlobalIR, StringGlobalIR, RuleGlobalIR]),
+    plawk_writebin_globals(WritebinPlan, WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, RuleGlobalIR, WritebinGlobalIR]),
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
@@ -1547,6 +1562,20 @@ plawk_binfmt_action_ok(Descriptor, if(Pattern, ThenActions, ElseActions)) :-
     plawk_binfmt_pattern_ok(Descriptor, Pattern),
     plawk_binfmt_actions_ok(Descriptor, ThenActions),
     plawk_binfmt_actions_ok(Descriptor, ElseActions).
+plawk_binfmt_action_ok(Descriptor, writebin_out(Types, Fields)) :-
+    !,
+    plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+
+plawk_binfmt_writebin_args_ok(_Descriptor, [], []).
+plawk_binfmt_writebin_args_ok(Descriptor, [i64 | Types], [Field | Fields]) :-
+    plawk_binfmt_i64_expr_ok(Descriptor, Field),
+    plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+plawk_binfmt_writebin_args_ok(Descriptor, [f64 | Types], [Field | Fields]) :-
+    ( plawk_expr_is_double(Field)
+    -> plawk_binfmt_f64_expr_ok(Descriptor, Field)
+    ;  plawk_binfmt_i64_expr_ok(Descriptor, Field)
+    ),
+    plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
 
 plawk_binfmt_print_field_ok(_Descriptor, string(_Value)) :- !.
 plawk_binfmt_print_field_ok(_Descriptor, special('NR')) :- !.
@@ -1681,6 +1710,182 @@ plawk_binfmt_field_offset(binfmt(Types), Index, Offset) :-
 plawk_binfmt_record_size(binfmt(Types), Size) :-
     maplist(plawk_binfmt_type_width, Types, Widths),
     sum_list(Widths, Size).
+
+%% plawk_resolve_writebin_rules(+BeginClauses, +Rules0, -Rules, -WritebinPlan)
+%
+%  writebin actions write one fixed-layout binary record on stdout per
+%  call, laid out per BEGIN { OUTFMT = "i64 f64 ..." }. This pre-pass
+%  stamps each writebin(Fields) with the resolved output types
+%  (writebin_out(Types, Fields)) so downstream validation and emission
+%  are self-contained; it fails (rejecting the program) when writebin
+%  appears without OUTFMT, an argument count mismatches the layout, or
+%  the layout contains non-numeric fields (sN output is a later slice).
+plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules, WritebinPlan) :-
+    ( plawk_rules_have_writebin(Rules0)
+    ->  plawk_begin_outfmt_types(BeginClauses, Types),
+        forall(member(Type, Types), memberchk(Type, [i64, f64])),
+        plawk_binfmt_record_size(binfmt(Types), Size),
+        WritebinPlan = outfmt(Types, Size),
+        maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules)
+    ;   WritebinPlan = none,
+        Rules = Rules0
+    ).
+
+plawk_rules_have_writebin(Rules) :-
+    member(rule(_Pattern, Actions), Rules),
+    plawk_actions_have_writebin(Actions),
+    !.
+
+plawk_actions_have_writebin(Actions) :-
+    member(Action, Actions),
+    ( Action = writebin(_Fields)
+    ; Action = if(_Pattern, ThenActions, ElseActions),
+      ( plawk_actions_have_writebin(ThenActions)
+      ; plawk_actions_have_writebin(ElseActions)
+      )
+    ),
+    !.
+
+plawk_resolve_writebin_rule(Types, rule(Pattern, Actions0), rule(Pattern, Actions)) :-
+    maplist(plawk_resolve_writebin_action(Types), Actions0, Actions).
+
+plawk_resolve_writebin_action(Types, writebin(Fields), writebin_out(Types, Fields)) :-
+    !,
+    length(Types, N),
+    length(Fields, N).
+plawk_resolve_writebin_action(Types, if(Pattern, Then0, Else0), if(Pattern, Then, Else)) :-
+    !,
+    maplist(plawk_resolve_writebin_action(Types), Then0, Then),
+    maplist(plawk_resolve_writebin_action(Types), Else0, Else).
+plawk_resolve_writebin_action(_Types, Action, Action).
+
+plawk_begin_outfmt_types(BeginClauses, Types) :-
+    member(begin(Actions), BeginClauses),
+    member(set(var('OUTFMT'), string(Fmt)), Actions),
+    split_string(Fmt, " ", " ", Parts0),
+    exclude(==(""), Parts0, Parts),
+    Parts \== [],
+    maplist(plawk_binfmt_type, Parts, Types).
+
+% Entry-block record buffer: one alloca reused by every writebin call
+% (a loop-body alloca would grow the stack per record).
+plawk_writebin_entry_lines(none, '').
+plawk_writebin_entry_lines(outfmt(_Types, Size), IR) :-
+    format(atom(IR), '  %plawk_wbuf = alloca [~w x i8], align 8~n', [Size]).
+
+% fwrite(buf, size, 1, stdout) buffers in libc; the normal return from
+% main flushes it.
+plawk_writebin_globals(none, '').
+plawk_writebin_globals(outfmt(_Types, _Size), '@stdout = external global i8*').
+
+plawk_rules_writebin_exprs(Rules, Exprs) :-
+    findall(Expr,
+        ( member(rule(_Pattern, Actions), Rules),
+          plawk_actions_writebin_expr(Actions, Expr)
+        ),
+        Exprs).
+
+plawk_actions_writebin_expr(Actions, Expr) :-
+    member(Action, Actions),
+    ( Action = writebin_out(_Types, Fields),
+      member(Expr, Fields)
+    ; Action = if(_Pattern, ThenActions, ElseActions),
+      ( plawk_actions_writebin_expr(ThenActions, Expr)
+      ; plawk_actions_writebin_expr(ElseActions, Expr)
+      )
+    ).
+
+%% plawk_writebin_args_ok(+Types, +Fields) is semidet.
+%
+%  i64 output slots take i64-shaped expressions (fields, literals,
+%  NR/NF, scalar reads, binary trees); f64 slots additionally take
+%  double-typed expressions, with i64 shapes promoted at emission.
+plawk_writebin_args_ok([], []).
+plawk_writebin_args_ok([Type | Types], [Field | Fields]) :-
+    ( Type == i64
+    -> plawk_writebin_i64_arg(Field)
+    ;  plawk_writebin_f64_arg(Field)
+    ),
+    plawk_writebin_args_ok(Types, Fields).
+
+plawk_writebin_i64_arg(special('NR')).
+plawk_writebin_i64_arg(special('NF')).
+plawk_writebin_i64_arg(Field) :-
+    plawk_i64_scalar_read_operand_expr(Field).
+
+plawk_writebin_f64_arg(Field) :-
+    plawk_writebin_i64_arg(Field),
+    !.
+plawk_writebin_f64_arg(Field) :-
+    plawk_expr_is_double(Field),
+    plawk_f64_scalar_read_operand_expr(Field).
+
+%% plawk_writebin_record_ir(+Types, +Fields, +Slots, +Values,
+%%     +FieldSeparator, +Prefix, -Pair)
+%
+%  Evaluate each argument, store it at its layout offset in the shared
+%  %plawk_wbuf buffer, then fwrite the record to stdout.
+plawk_writebin_record_ir(Types, Fields, Slots, Values, FieldSeparator,
+        Prefix, GlobalIR-IR) :-
+    plawk_binfmt_record_size(binfmt(Types), Size),
+    format(atom(BasePtr), '%~w_base', [Prefix]),
+    format(atom(BaseLine),
+        '  ~w = getelementptr inbounds [~w x i8], [~w x i8]* %plawk_wbuf, i32 0, i32 0',
+        [BasePtr, Size, Size]),
+    plawk_writebin_field_lines(Types, Fields, Slots, Values, FieldSeparator,
+        Prefix, BasePtr, 0, 0, FieldLines, GlobalParts),
+    format(atom(StdoutLoad),
+        '  %~w_stdout = load i8*, i8** @stdout', [Prefix]),
+    format(atom(WriteCall),
+        '  %~w_wr = call i64 @fwrite(i8* ~w, i64 ~w, i64 1, i8* %~w_stdout)',
+        [Prefix, BasePtr, Size, Prefix]),
+    append([[BaseLine], FieldLines, [StdoutLoad, WriteCall]], AllLines),
+    atomic_list_concat(AllLines, '\n', IR),
+    atomic_list_concat(GlobalParts, '\n', GlobalIR).
+
+plawk_writebin_field_lines([], [], _Slots, _Values, _FieldSeparator, _Prefix,
+        _BasePtr, _Index, _Offset, [], []).
+plawk_writebin_field_lines([Type | Types], [Field0 | Fields], Slots, Values,
+        FieldSeparator, Prefix, BasePtr, Index, Offset, Lines, GlobalParts) :-
+    plawk_substitute_scalar_reads(Field0, Slots, Values, Field),
+    format(atom(Base), '~w_f~w', [Prefix, Index]),
+    ( Type == i64
+    ->  plawk_i64_expr_ir(Field, FieldSeparator, Base, Base, ValueIR,
+            GParts, SetupParts),
+        LLVMType = i64
+    ;   plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
+            GParts, SetupParts),
+        LLVMType = double
+    ),
+    format(atom(Gep),
+        '  %~w_fp = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Cast),
+        '  %~w_tp = bitcast i8* %~w_fp to ~w*', [Base, Base, LLVMType]),
+    format(atom(Store),
+        '  store ~w ~w, ~w* %~w_tp, align 1', [LLVMType, ValueIR, LLVMType, Base]),
+    plawk_binfmt_type_width(Type, Width),
+    NextOffset is Offset + Width,
+    NextIndex is Index + 1,
+    plawk_writebin_field_lines(Types, Fields, Slots, Values, FieldSeparator,
+        Prefix, BasePtr, NextIndex, NextOffset, RestLines, RestGlobals),
+    append([SetupParts, [Gep, Cast, Store], RestLines], Lines),
+    append(GParts, RestGlobals, GlobalParts).
+
+plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
+        GParts, SetupParts) :-
+    plawk_expr_is_double(Field),
+    !,
+    plawk_f64_expr_ir(Field, FieldSeparator, Base, Base, ValueIR,
+        GParts, SetupParts).
+plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
+        GParts, SetupParts) :-
+    format(atom(IntBase), '~w_int', [Base]),
+    plawk_i64_expr_ir(Field, FieldSeparator, IntBase, IntBase, IntValueIR,
+        GParts, IntSetupParts),
+    format(atom(ValueIR), '%~w', [Base]),
+    format(atom(Promote), '  ~w = sitofp i64 ~w to double',
+        [ValueIR, IntValueIR]),
+    append(IntSetupParts, [Promote], SetupParts).
 
 %% plawk_emit_record_driver_ir(+Descriptor, +InputPath, +Blocks, -DriverIR)
 %
@@ -2144,6 +2349,8 @@ plawk_scalar_rule_body_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
 plawk_scalar_rule_body_action(Action) :-
     plawk_rule_body_print_action(Action).
+plawk_scalar_rule_body_action(writebin_out(Types, Fields)) :-
+    plawk_writebin_args_ok(Types, Fields).
 plawk_scalar_rule_body_action(if(_Pattern, ThenActions, ElseActions)) :-
     append(ThenActions, ElseActions, Actions),
     Actions \== [],
@@ -2158,6 +2365,8 @@ plawk_scalar_rule_body_plain_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
 plawk_scalar_rule_body_plain_action(Action) :-
     plawk_rule_body_print_action(Action).
+plawk_scalar_rule_body_plain_action(writebin_out(Types, Fields)) :-
+    plawk_writebin_args_ok(Types, Fields).
 % else-if chains nest an if inside a branch body; the sequence walker
 % lowers nested ifs recursively, so validation recurses the same way.
 plawk_scalar_rule_body_plain_action(if(Pattern, ThenActions, ElseActions)) :-
@@ -2454,6 +2663,16 @@ plawk_scalar_action_sequence_pairs([Action | Rest], Slots, AssocPlan, FieldSepar
     },
     [Pair],
     plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AssocExitLabel, RuleIndex,
+        NextOpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits).
+plawk_scalar_action_sequence_pairs([writebin_out(Types, Fields) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { format(atom(WbPrefix), '~w_wb_~w', [Prefix, OpIndex]),
+      plawk_writebin_record_ir(Types, Fields, Slots, Values0, FieldSeparator,
+          WbPrefix, Pair),
+      NextOpIndex is OpIndex + 1
+    },
+    [Pair],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
         NextOpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits).
 plawk_scalar_action_sequence_pairs([print(Fields) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
         OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
@@ -3482,11 +3701,18 @@ plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, GlobalIR-IR) :-
 
 plawk_output_action_exprs(print(Fields), Fields).
 plawk_output_action_exprs(printf(string(_Format), Args), Args).
+plawk_output_action_exprs(writebin_out(_Types, Fields), Fields).
 
 plawk_output_action_ir(print(Fields), FieldSeparator, OutputSeparator, Pair) :-
     plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, Pair).
 plawk_output_action_ir(printf(string(Format), Args), FieldSeparator, _OutputSeparator, Pair) :-
     plawk_prefixed_printf_action_ir(Format, Args, FieldSeparator, plawk_printf, Pair).
+plawk_output_action_ir(writebin_out(Types, Fields), FieldSeparator, _OutputSeparator, Pair) :-
+    % No scalar slots exist in the single-action driver, so scalar reads
+    % in writebin arguments fail here and the program falls through to
+    % the state-plan drivers.
+    plawk_writebin_record_ir(Types, Fields, [], [], FieldSeparator,
+        plawk_writebin, Pair).
 
 plawk_prefixed_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, Prefix, ''-IR) :-
     !,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -429,6 +429,8 @@ begin_assignment(set(var(Name), string(Value))) -->
 
 begin_assignment_name('BINFMT') -->
     "BINFMT".
+begin_assignment_name('OUTFMT') -->
+    "OUTFMT".
 begin_assignment_name('FS') -->
     "FS".
 begin_assignment_name('OFS') -->
@@ -494,6 +496,9 @@ action(Action) -->
     !.
 action(Action) -->
     printf_action(Action),
+    !.
+action(Action) -->
+    writebin_action(Action),
     !.
 action(Action) -->
     print_action(Action),
@@ -656,6 +661,15 @@ printf_action(printf(string(Format), Args)) -->
     quoted_string(FormatCodes),
     printf_args(Args),
     { string_codes(Format, FormatCodes) }.
+
+%% writebin_action(-Action)//
+%
+%  writebin expr, expr, ... - emit one fixed-layout binary record on
+%  stdout, laid out per BEGIN { OUTFMT = "..." }.
+writebin_action(writebin(Fields)) -->
+    "writebin",
+    required_ws,
+    print_fields(Fields).
 
 printf_args([Arg | Args]) -->
     ws,

--- a/tests/test_plawk_binary_writers.pl
+++ b/tests/test_plawk_binary_writers.pl
@@ -1,0 +1,226 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_binwr_marker/0.
+
+user:plawk_binwr_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_binary_writers, [condition(clang_available)]).
+
+test(parses_writebin_action) :-
+    plawk_parse_string("BEGIN { OUTFMT = \"i64 i64\" } { writebin $1, $2 }\n", Program),
+    assertion(Program == program([begin([set(var('OUTFMT'), string("i64 i64"))])],
+        [rule(always, [writebin([field(1), field(2)])])],
+        [])).
+
+test(writebin_ir_stores_and_fwrites) :-
+    plawk_parse_string("BEGIN { OUTFMT = \"i64 f64\" } { writebin $1, float($2) }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_wbuf = alloca [16 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'store i64 '))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'store double '))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@fwrite('))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@stdout = external global i8*'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(writebin_rejections) :-
+    Rejects = [
+        % no OUTFMT declared
+        "{ writebin $1, $2 }\n",
+        % argument count does not match the layout
+        "BEGIN { OUTFMT = \"i64 i64\" } { writebin $1 }\n",
+        % sN output fields are a later slice
+        "BEGIN { OUTFMT = \"s8 i64\" } { writebin $1, $2 }\n",
+        % double expression into an i64 slot
+        "BEGIN { OUTFMT = \"i64\" } { writebin 1.5 }\n",
+        % string field into an i64 slot in binary input mode
+        "BEGIN { BINFMT = \"s8 i64\" ; OUTFMT = \"i64\" } { writebin $1 }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.txt', _))
+        ;  true
+        )).
+
+test(surface_text_to_binary_converter) :-
+    % Single-action driver: convert text lines to binary records.
+    build_writer_probe("BEGIN { OUTFMT = \"i64 f64\" } { writebin $1, float($2) }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    write_text(InputPath, "5 2.5\n20 4.5\n30 1.25\n"),
+    run_capture_raw(BinPath, [], Bytes),
+    decode_i64_f64(Bytes, Records),
+    assertion(Records == [5-2.5, 20-4.5, 30-1.25]),
+    !.
+
+test(surface_binary_transform_with_guard_and_scalars) :-
+    % Scalar driver: binary in, guarded binary out, END count as trailer.
+    build_writer_probe("BEGIN { BINFMT = \"i64 f64\" ; OUTFMT = \"i64 f64\" } $1 > 10 { n++ ; writebin $1 * 10, float($2) * 0.5 } END { print n }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    encode_i64_f64(InputPath, [5-2.5, 20-4.5, 30-1.25]),
+    run_capture_raw(BinPath, [], Bytes),
+    string_length(Bytes, Len),
+    RecBytes is Len - 2,
+    sub_string(Bytes, 0, RecBytes, _, RecStr),
+    sub_string(Bytes, RecBytes, 2, 0, Trailer),
+    assertion(Trailer == "2\n"),
+    decode_i64_f64(RecStr, Records),
+    assertion(Records == [200-2.25, 300-0.625]),
+    !.
+
+test(surface_writebin_nr_and_expr_args) :-
+    build_writer_probe("BEGIN { OUTFMT = \"i64 i64\" } { writebin NR, $1 + 1 }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    write_text(InputPath, "10\n20\n"),
+    run_capture_raw(BinPath, [], Bytes),
+    decode_i64_i64(Bytes, Records),
+    assertion(Records == [1-11, 2-21]),
+    !.
+
+test(surface_plawk_to_plawk_pipeline) :-
+    % Program A converts text to binary; program B consumes A's binary
+    % output and aggregates natively - no text in between.
+    build_writer_probe("BEGIN { OUTFMT = \"i64 f64\" } { writebin $1, float($2) }\n",
+        DirA, BinA),
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_binary_writers_b', DirB),
+    clean_dir(DirB),
+    make_directory_path(DirB),
+    directory_file_path(DirB, 'stage.bin', StagePath),
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } $1 > 10 { sum += float($2) } END { print sum }\n", ProgramB),
+    plawk_program_native_driver_ir(ProgramB, StagePath, DriverB),
+    emit_probe(DirB, DriverB, BinB),
+    directory_file_path(DirA, 'input.txt', InputPath),
+    write_text(InputPath, "5 2.5\n20 4.5\n30 1.25\n"),
+    format(atom(Cmd), '~w > ~w && ~w', [BinA, StagePath, BinB]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == "5.75\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_text(Path, Text) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text),
+        close(Out)).
+
+i64_bytes(V, Bytes) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    findall(B, ( between(0, 7, I), B is (V64 >> (8 * I)) /\ 0xFF ), Bytes).
+
+% dyadic doubles used in these tests, as IEEE-754 bit patterns
+double_bits(2.5,   0x4004000000000000).
+double_bits(4.5,   0x4012000000000000).
+double_bits(1.25,  0x3FF4000000000000).
+double_bits(2.25,  0x4002000000000000).
+double_bits(0.625, 0x3FE4000000000000).
+
+encode_i64_f64(Path, Pairs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(A-F, Pairs),
+            ( i64_bytes(A, ABytes), forall(member(B, ABytes), put_byte(Out, B)),
+              double_bits(F, Bits),
+              i64_bytes(Bits, FBytes), forall(member(B, FBytes), put_byte(Out, B)) )),
+        close(Out)).
+
+decode_i64_f64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_i64_f64_codes(Codes, Records).
+
+decode_i64_f64_codes([], []).
+decode_i64_f64_codes(Codes, [A-F | Records]) :-
+    length(ABytes, 8), length(FBytes, 8),
+    append(ABytes, Rest0, Codes), append(FBytes, Rest, Rest0),
+    le_i64(ABytes, A),
+    le_i64(FBytes, Bits),
+    double_bits(F, Bits),
+    decode_i64_f64_codes(Rest, Records).
+
+decode_i64_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_i64_i64_codes(Codes, Records).
+
+decode_i64_i64_codes([], []).
+decode_i64_i64_codes(Codes, [A-B | Records]) :-
+    length(ABytes, 8), length(BBytes, 8),
+    append(ABytes, Rest0, Codes), append(BBytes, Rest, Rest0),
+    le_i64(ABytes, A), le_i64(BBytes, B),
+    decode_i64_i64_codes(Rest, Records).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_binwr_marker/0 ],
+        [module_name('plawk_binary_writers')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk binary writers build output]~n~w~n", [BuildOut]),
+       throw(plawk_binary_writers_build_failed(Status))
+    ).
+
+build_writer_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_binary_writers', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    plawk_parse_string(Source, Program),
+    ( sub_string(Source, _, _, _, "BINFMT")
+    -> directory_file_path(Dir, 'input.bin', InputPath)
+    ;  directory_file_path(Dir, 'input.txt', InputPath)
+    ),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_capture_raw(BinPath, Args, Bytes) :-
+    process_create(BinPath, Args,
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)).
+
+:- end_tests(plawk_binary_writers).


### PR DESCRIPTION
## Summary

plawk can now **write** typed binary streams, not just read them:

```awk
BEGIN { OUTFMT = "i64 f64" }
{ writebin $1, float($2) }
```

emits one fixed-layout binary record on stdout per call. Combined with `BINFMT` readers, this closes the pipeline loop — a plawk-to-plawk pipeline (text→binary converter piped into a binary aggregator) runs with **no text serialization between stages**:

```sh
./convert < data.txt | ./aggregate     # i64+f64 records over the pipe, never text
```

## How it works

- `BEGIN { OUTFMT = "..." }` declares the output layout (same type grammar as BINFMT; `i64`/`f64` for this slice).
- A resolve pre-pass stamps each `writebin(Fields)` with the layout types and rejects malformed programs up front: writebin without OUTFMT, argument count ≠ layout arity, `sN` output fields, or double expressions aimed at i64 slots.
- Emission: the entry block allocates **one** record buffer reused by every writebin call (never a loop-body alloca); each argument lowers through the existing i64/f64 expression emitters — scalar reads substitute exactly like update RHS, i64 arguments promote into f64 slots via `sitofp` — into a typed store at its compile-time layout offset; then `fwrite(buf, size, 1, stdout)`. fwrite buffers in libc and the normal return from main flushes, so per-record cost is a memcpy, not a syscall.
- Works in both drivers: the single-action driver (pure converters, stdin or file input) and the scalar driver (guarded transforms composing with scalar updates, `if`/`else`, `next`, and END reports). In binary input mode, writebin arguments are additionally validated against the input layout.

## Tests

New suite `tests/test_plawk_binary_writers.pl` (7 tests): parse shape, IR shape (single alloca, typed stores, fwrite, `@stdout` extern, no `@run_loop`), five rejection shapes, text→binary conversion verified by byte-exact decode, a guarded binary→binary transform (records `(200, 2.25), (300, 0.625)` plus the `2\n` END trailer), NR/expression arguments, and the two-stage plawk→plawk pipeline asserting `5.75` out the far end.

Full regression sweep green: all 24 suites exit 0.

## Merge order

Stacked on #3412 (BINFMT string fields). Chain: #3402 → … → #3410 → #3411 → #3412 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_