### PR TITLE
plawk: binary group-by results as binary records (for-in writebin)

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -489,7 +489,10 @@ through the i64/f64 expression emitters into a typed store at its
 layout offset, and a buffered `fwrite(buf, size, 1, stdout)` emits the
 record (libc flushes on normal main return). Works from both text and
 binary inputs, so plawk-to-plawk binary pipelines (converter |
-aggregator) run with no text serialization between stages. Remaining
+aggregator) run with no text serialization between stages. The END
+for-in loop composes with writebin: `for (k in counts) writebin k,
+counts[k]` iterates the group table and emits one binary record per
+group (binary input mode only -- text keys are atom ids). Remaining
 Phase 3 items below (DCG readers, richer ABIs) are unchanged.
 
 **Second slice landed (typed associative arrays):** in binary mode

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -88,6 +88,7 @@ swipl -q -s tests/test_plawk_binary_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt
 swipl -q -s tests/test_plawk_float_slots.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_binfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_binary_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_forin_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -287,7 +288,11 @@ expressions, NR/NF, scalar reads, and double expressions per the OUTFMT
 slot types (i64 arguments promote into f64 slots), and composes with
 guards, scalar updates, and `if`/`else`. A plawk-to-plawk pipeline -
 converter | aggregator - runs with no text serialization between
-stages. Rejected: writebin without OUTFMT, argument/layout arity
+stages. Group-by results can also leave as binary:
+`END { for (k in counts) writebin k, counts[k] }` walks the table and
+emits one record per group (raw i64 keys, table values, or literals;
+i64 values promote into f64 output slots) - binary input mode only,
+since text-mode keys are interned atom ids. Rejected: writebin without OUTFMT, argument/layout arity
 mismatch, `sN` output fields (later slice), and double expressions into
 i64 slots. A trailing partial record exits with the read
 error code. Measured on 2M records: 0.040s for the binary program vs

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -246,6 +246,53 @@ plawk_program_native_driver_ir(
             RecordIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% Binary group-by to binary output: iterate the table and writebin one
+% fixed-layout record per group. Binary input mode only -- text-mode
+% keys are interned atom ids, which would be meaningless bytes in the
+% output stream.
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules, [end([for_in(var(LoopVar), var(ArrayName), [writebin(Fields)])])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    FieldSeparator = binfmt(_InputTypes),
+    plawk_begin_outfmt_types(BeginClauses, OutTypes),
+    forall(member(OutType, OutTypes), memberchk(OutType, [i64, f64])),
+    length(OutTypes, ArgCount),
+    length(Fields, ArgCount),
+    maplist(plawk_forin_writebin_field(LoopVar), Fields),
+    findall(LookupArrayName,
+        member(assoc(var(LookupArrayName), var(LoopVar)), Fields),
+        LookupArrays),
+    plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays, AssocPlan),
+    plawk_assoc_record_program_ok(FieldSeparator, Rules, []),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_binfmt_record_size(binfmt(OutTypes), OutRecordSize),
+    plawk_writebin_entry_lines(outfmt(OutTypes, OutRecordSize), WritebinEntryIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_forin_end_writebin_ir(LoopVar, ArrayName, OutTypes, Fields, AssocPlan,
+        EndPrintIR),
+    plawk_writebin_globals(outfmt(OutTypes, OutRecordSize), WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, AssocRuleGlobalIR, WritebinGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR0),
+    plawk_combine_entry_ir(CombinedEntrySetupIR0, WritebinEntryIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w',
+        [EndPrintIR]),
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
+            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 plawk_program_native_driver_ir(
     program(BeginClauses, Rules, [end([for_in(var(LoopVar), var(ArrayName), BodyActions)])]),
     InputPath,
@@ -524,10 +571,17 @@ fail:
 %  the loop body is one print whose fields are the loop key, associative
 %  lookups keyed by the loop variable, or string literals.
 plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions,
-        assoc_plan(Tables, PlannedRules), PrintFields) :-
+        AssocPlan, PrintFields) :-
     BodyActions = [print(PrintFields)],
     PrintFields = [_ | _],
     maplist(plawk_forin_print_field(LoopVar), PrintFields),
+    findall(LookupArrayName,
+        member(assoc(var(LookupArrayName), var(LoopVar)), PrintFields),
+        LookupArrays),
+    plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays, AssocPlan).
+
+plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays,
+        assoc_plan(Tables, PlannedRules)) :-
     maplist(plawk_assoc_rule_action_specs, Rules, RuleSpecs),
     RuleSpecs \== [],
     findall(RuleArrayName,
@@ -535,9 +589,6 @@ plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions,
           member(RuleArrayName-_KeyIndex, ActionSpecs)
         ),
         ActionArrays),
-    findall(LookupArrayName,
-        member(assoc(var(LookupArrayName), var(LoopVar)), PrintFields),
-        LookupArrays),
     append([ActionArrays, [ArrayName], LookupArrays], ArrayNames0),
     sort(ArrayNames0, Tables),
     phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, 0), PlannedRules).
@@ -545,6 +596,108 @@ plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions,
 plawk_forin_print_field(LoopVar, var(LoopVar)).
 plawk_forin_print_field(LoopVar, assoc(var(_ArrayName), var(LoopVar))).
 plawk_forin_print_field(_LoopVar, string(_Value)).
+
+plawk_forin_writebin_field(LoopVar, var(LoopVar)).
+plawk_forin_writebin_field(LoopVar, assoc(var(_ArrayName), var(LoopVar))).
+plawk_forin_writebin_field(_LoopVar, int(Value)) :-
+    integer(Value).
+
+%% plawk_forin_end_writebin_ir(+LoopVar, +ArrayName, +OutTypes, +Fields,
+%%     +AssocPlan, -IR)
+%
+%  writebin variant of the END for-in loop: walk the iterated table's
+%  occupied slots and emit one fixed-layout binary record per group
+%  (raw i64 keys, table values, or literals; i64 values promote via
+%  sitofp into f64 output slots), then free every table and return.
+plawk_forin_end_writebin_ir(LoopVar, ArrayName, OutTypes, Fields, AssocPlan, IR) :-
+    plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
+    plawk_binfmt_record_size(binfmt(OutTypes), Size),
+    format(atom(BasePtr), '%forin_wb_base', []),
+    format(atom(BaseLine),
+        '  ~w = getelementptr inbounds [~w x i8], [~w x i8]* %plawk_wbuf, i32 0, i32 0',
+        [BasePtr, Size, Size]),
+    plawk_forin_writebin_field_lines(OutTypes, Fields, LoopVar, ArrayName,
+        TableIndex, AssocPlan, BasePtr, 0, 0, FieldLines),
+    format(atom(StdoutLoad),
+        '  %forin_wb_stdout = load i8*, i8** @stdout', []),
+    format(atom(WriteCall),
+        '  %forin_wb_wr = call i64 @fwrite(i8* ~w, i64 ~w, i64 1, i8* %forin_wb_stdout)',
+        [BasePtr, Size]),
+    append([[BaseLine], FieldLines, [StdoutLoad, WriteCall]], BodyLines),
+    atomic_list_concat(BodyLines, '\n', BodyIR),
+    phrase(plawk_assoc_free_lines(AssocPlan), FreeLines),
+    atomic_list_concat(FreeLines, '\n', FreeIR),
+    format(atom(IR),
+'  br label %forin_head
+
+forin_head:
+  %forin_idx = phi i64 [0, %end_print], [%forin_next_idx, %forin_body_done]
+  %forin_slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_idx)
+  %forin_done = icmp slt i64 %forin_slot, 0
+  br i1 %forin_done, label %forin_after, label %forin_body
+
+forin_body:
+  %forin_key_id = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)
+~w
+  br label %forin_body_done
+
+forin_body_done:
+  %forin_next_idx = add i64 %forin_slot, 1
+  br label %forin_head
+
+forin_after:
+~w
+  ret i32 0',
+        [TableIndex, TableIndex, BodyIR, FreeIR]).
+
+plawk_forin_writebin_field_lines([], [], _LoopVar, _ArrayName, _TableIndex,
+        _AssocPlan, _BasePtr, _Index, _Offset, []).
+plawk_forin_writebin_field_lines([OutType | OutTypes], [Field | Fields], LoopVar,
+        ArrayName, TableIndex, AssocPlan, BasePtr, Index, Offset, Lines) :-
+    format(atom(Base), 'forin_wb_f~w', [Index]),
+    plawk_forin_writebin_value_lines(Field, LoopVar, ArrayName, TableIndex,
+        AssocPlan, Base, ValueIR, ValueLines),
+    ( OutType == i64
+    ->  StoreValueIR = ValueIR,
+        LLVMType = i64,
+        PromoteLines = []
+    ;   format(atom(StoreValueIR), '%~w_f64p', [Base]),
+        format(atom(Promote), '  ~w = sitofp i64 ~w to double',
+            [StoreValueIR, ValueIR]),
+        LLVMType = double,
+        PromoteLines = [Promote]
+    ),
+    format(atom(Gep),
+        '  %~w_fp = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Cast),
+        '  %~w_tp = bitcast i8* %~w_fp to ~w*', [Base, Base, LLVMType]),
+    format(atom(Store),
+        '  store ~w ~w, ~w* %~w_tp, align 1',
+        [LLVMType, StoreValueIR, LLVMType, Base]),
+    plawk_binfmt_type_width(OutType, Width),
+    NextOffset is Offset + Width,
+    NextIndex is Index + 1,
+    plawk_forin_writebin_field_lines(OutTypes, Fields, LoopVar, ArrayName,
+        TableIndex, AssocPlan, BasePtr, NextIndex, NextOffset, RestLines),
+    append([ValueLines, PromoteLines, [Gep, Cast, Store], RestLines], Lines).
+
+plawk_forin_writebin_value_lines(var(LoopVar), LoopVar, _ArrayName, _TableIndex,
+        _AssocPlan, _Base, '%forin_key_id', []).
+plawk_forin_writebin_value_lines(assoc(var(LookupArrayName), var(LoopVar)),
+        LoopVar, ArrayName, TableIndex, AssocPlan, Base, ValueIR, [Line]) :-
+    format(atom(ValueIR), '%~w_val', [Base]),
+    (   LookupArrayName == ArrayName
+    ->  format(atom(Line),
+            '  ~w = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)',
+            [ValueIR, TableIndex])
+    ;   plawk_assoc_table_index(AssocPlan, LookupArrayName, LookupTableIndex),
+        format(atom(Line),
+            '  ~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_key_id)',
+            [ValueIR, LookupTableIndex])
+    ).
+plawk_forin_writebin_value_lines(int(Value), _LoopVar, _ArrayName, _TableIndex,
+        _AssocPlan, _Base, Value, []) :-
+    integer(Value).
 
 %% plawk_forin_end_print_ir(+LoopVar, +ArrayName, +PrintFields, +AssocPlan,
 %%     +OutputSeparator, -IR)

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -474,6 +474,9 @@ for_in_action(for_in(var(LoopVar), var(ArrayName), Body)) -->
 for_in_body(Actions) -->
     action_block(Actions),
     !.
+for_in_body([WritebinAction]) -->
+    writebin_action(WritebinAction),
+    !.
 for_in_body([PrintAction]) -->
     print_action(PrintAction).
 

--- a/tests/test_plawk_forin_writebin.pl
+++ b/tests/test_plawk_forin_writebin.pl
@@ -1,0 +1,180 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_fwb_marker/0.
+
+user:plawk_fwb_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_forin_writebin, [condition(clang_available)]).
+
+test(parses_forin_writebin_body) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n", Program),
+    Program = program(_, _, [end([for_in(var(k), var(counts), Body)])]),
+    assertion(Body == [writebin([var(k), assoc(var(counts), var(k))])]).
+
+test(forin_writebin_ir_shape) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_wbuf = alloca [16 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_iter_next'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_value_at'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@fwrite('))),
+    % the group loop emits records, not text
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_to_string')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(forin_writebin_rejections) :-
+    Rejects = [
+        % text-mode keys are atom ids: binary input only
+        "BEGIN { OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        % arity mismatch against OUTFMT
+        "BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        % no OUTFMT at all
+        "BEGIN { BINFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        % sN output slice not supported
+        "BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"s8 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_groupby_to_binary_records) :-
+    run_fwb_smoke("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        [5-0, (-3)-0, 5-0, 9-0, (-3)-0, 5-0],
+        [(-3)-2, 5-3, 9-1]).
+
+test(surface_guarded_groupby_to_binary) :-
+    run_fwb_smoke("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } $2 > 100 { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        [5-200, 5-50, 9-300, 5-150],
+        [5-2, 9-1]).
+
+test(surface_groupby_empty_input_writes_nothing) :-
+    run_fwb_smoke("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        [],
+        []).
+
+test(surface_groupby_pipeline_two_stages) :-
+    % Stage 1 groups raw events into (key, count) binary records; stage 2
+    % consumes those records and sums the counts -- binary end to end.
+    build_fwb_probe("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        Dir1, Bin1),
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_forin_writebin_b', Dir2),
+    clean_dir(Dir2),
+    make_directory_path(Dir2),
+    directory_file_path(Dir2, 'stage.bin', StagePath),
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" } { total += $2 } END { print total }\n", Program2),
+    plawk_program_native_driver_ir(Program2, StagePath, Driver2),
+    emit_probe(Dir2, Driver2, Bin2),
+    directory_file_path(Dir1, 'input.bin', InputPath),
+    write_pairs(InputPath, [5-0, (-3)-0, 5-0, 9-0, (-3)-0, 5-0]),
+    format(atom(Cmd), '~w > ~w && ~w', [Bin1, StagePath, Bin2]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == "6\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_pairs(Path, Pairs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(A-B, Pairs),
+            ( write_i64_le(Out, A), write_i64_le(Out, B) )),
+        close(Out)).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+decode_pairs(Bytes, Pairs) :-
+    string_codes(Bytes, Codes),
+    decode_pair_codes(Codes, Pairs).
+
+decode_pair_codes([], []).
+decode_pair_codes(Codes, [A-B | Pairs]) :-
+    length(ABytes, 8), length(BBytes, 8),
+    append(ABytes, Rest0, Codes), append(BBytes, Rest, Rest0),
+    le_i64(ABytes, A), le_i64(BBytes, B),
+    decode_pair_codes(Rest, Pairs).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_fwb_marker/0 ],
+        [module_name('plawk_forin_writebin')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk forin writebin build output]~n~w~n", [BuildOut]),
+       throw(plawk_forin_writebin_build_failed(Status))
+    ).
+
+build_fwb_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_forin_writebin', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_fwb_smoke(Source, InputPairs, ExpectedSortedPairs) :-
+    build_fwb_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_pairs(InputPath, InputPairs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    decode_pairs(Bytes, Pairs),
+    msort(Pairs, SortedPairs),
+    msort(ExpectedSortedPairs, SortedExpected),
+    assertion(SortedPairs == SortedExpected),
+    !.
+
+:- end_tests(plawk_forin_writebin).


### PR DESCRIPTION
## Summary

Group-by aggregations can now leave plawk as binary, not text:

```awk
BEGIN { BINFMT = "i64 i64" ; OUTFMT = "i64 i64" }
{ counts[$1]++ }
END { for (k in counts) writebin k, counts[k] }
```

walks the group table and emits one fixed-layout `(key, count)` record per group. Combined with #3413's writers and #3410's binary assoc arrays, a full aggregation pipeline — raw events → group-by stage → downstream consumer — now runs binary end to end with zero interning and zero text serialization.

## What's included

- **Parser**: bare `writebin` bodies in for-in (`for (k in counts) writebin k, counts[k]`); block bodies (`{ writebin ... }`) already parsed via the action grammar.
- **Codegen**: a new for-in writebin driver clause sharing the table-planning machinery with the print variant (extracted as `plawk_forin_assoc_plan/4`). The loop body loads the raw i64 key (`wam_assoc_i64_key_at`), the iterated table's value (`wam_assoc_i64_value_at`) or secondary-table lookups (`wam_assoc_i64_get`), stores each at its OUTFMT offset in the shared entry-block buffer, and fwrites the record. i64 values promote via `sitofp` into `f64` output slots.
- **Binary input mode only**: text-mode assoc keys are interned atom ids — writing them as i64 bytes would be meaningless — so the driver requires `BINFMT`. Also rejected: missing OUTFMT, argument/layout arity mismatch, and `sN` output slots.

## Tests

New suite `tests/test_plawk_forin_writebin.pl` (7 tests): parse shape, IR shape (single alloca, iter/key/value calls, fwrite, no `wam_atom_to_string`/`@run_loop` in the group loop), four rejection shapes, group-by end-to-end with negative keys decoded byte-exactly, guarded group-by, empty input writing nothing, and a two-stage binary pipeline (group-by | sum) asserting `6` out the far end.

Full regression sweep green: all 25 suites exit 0.

## Merge order

Stacked on #3414 (consolidation + architecture docs). Merge #3414 into main first, then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_