### PR TITLE
plawk: f64 END arithmetic (print sum / NR on double slots)

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -330,8 +330,10 @@ slot's LLVM type; double updates lower the RHS through
 leaves, i64 operands promote via `sitofp`) into `fadd`, and END prints
 of double slots use `%g`. `{ sum += $2 * 1.5 }` and
 `{ sum += float($2) }` now accumulate natively in both text and binary
-record modes; END *arithmetic* on double slots stays i64-only and is
-rejected (the next f64 slice).
+record modes; END *arithmetic* composes too:
+an END expression that reads a double slot or contains a float literal
+promotes wholesale to double (`END { print sum / NR }` is an IEEE
+`fdiv` with a `%g` print; i64 END expressions keep guarded `sdiv`).
 Scalar variables are readable inside rule-body update expressions and END
 prints: codegen substitutes `var(Name)` leaves with the current SSA slot
 value (an `ssa/1` leaf the shared emitters print verbatim) before emission,

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -261,7 +261,10 @@ assigns it a float-typed expression or reads an already-double scalar
 (fixpoint), and i64 operands promote via `sitofp` at the update site.
 This works in text mode (`float($N)` = strtod) and binary mode
 (`float($N)` = native f64 field load), through `if`/`else`,
-`next`/`break`, and rule chains. `NF` is a compile-time
+`next`/`break`, and rule chains. END arithmetic composes with double
+slots: `END { print sum / NR }` promotes the whole expression to double
+(IEEE `fdiv`, no divide-by-zero guard, `%g` print), and float literals
+in END expressions (`print n * 1.5`) do the same. `NF` is a compile-time
 constant; `NR`, `if/else`, `next`/`break`, `printf`, and END reports
 compose unchanged. Associative arrays keyed by i64 fields work in
 binary mode: `{ counts[$1]++ }` uses the raw field value as the table key

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2616,6 +2616,12 @@ plawk_end_scalar_operand_expr(int(Value)) :-
 plawk_end_scalar_operand_expr(var(Name)) :-
     atom(Name).
 plawk_end_scalar_operand_expr(special('NR')).
+% Float literals make the whole END expression double-typed (%g print,
+% IEEE fdiv), as does reading a double slot.
+plawk_end_scalar_operand_expr(float_const(Mantissa, Denominator)) :-
+    integer(Mantissa),
+    integer(Denominator),
+    Denominator > 0.
 plawk_end_scalar_operand_expr(Expr) :-
     plawk_end_scalar_expr(Expr).
 
@@ -2655,10 +2661,14 @@ plawk_substitute_scalar_reads(Expr, _Slots, _Values, Expr).
 %  END-position substitution: var(Name) becomes the final slot value and
 %  NR becomes %plawk_nr, the loop-head record phi, which dominates
 %  end_print via close_stream / break_close_stream.
-plawk_substitute_end_reads(var(Name), StatePlan, ssa(Value)) :-
+plawk_substitute_end_reads(var(Name), StatePlan, Substituted) :-
     !,
-    plawk_state_slot_index(StatePlan, scalar_counter(Name), SlotIndex),
-    format(atom(Value), '%final_slot_~w', [SlotIndex]).
+    plawk_state_slot_lookup(StatePlan, Name, SlotIndex, Slot),
+    format(atom(Value), '%final_slot_~w', [SlotIndex]),
+    ( Slot = scalar_double(_Name)
+    -> Substituted = ssa_f64(Value)
+    ;  Substituted = ssa(Value)
+    ).
 plawk_substitute_end_reads(special('NR'), _StatePlan, ssa('%plawk_nr')) :-
     !.
 plawk_substitute_end_reads(Expr0, StatePlan, Expr) :-
@@ -3441,11 +3451,25 @@ plawk_end_nr_print_lines(PrintIndex) -->
 plawk_end_expr_print_lines(Expr, StatePlan, PrintIndex) -->
     { plawk_substitute_end_reads(Expr, StatePlan, SubstitutedExpr),
       format(atom(Base), 'plawk_end_expr_~w', [PrintIndex]),
-      plawk_i64_expr_ir(SubstitutedExpr, 32, Base, Base, ValueIR, [], SetupParts),
       format(atom(FmtVar), 'end_expr_fmt_~w', [PrintIndex]),
-      format(atom(PrintVar), 'printed_end_expr_~w', [PrintIndex]),
-      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
-          [FmtPtr, PrintCall]),
+      ( plawk_expr_is_double(SubstitutedExpr)
+      -> % A double-typed END expression (float literal leaf or a read of
+         % a double slot): whole tree promotes to double, prints as %g,
+         % and division is IEEE fdiv rather than guarded sdiv.
+         plawk_f64_expr_ir(SubstitutedExpr, 32, Base, Base, ValueIR,
+             [], SetupParts),
+         format(atom(FmtPtr),
+             '  %~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_f64, i32 0, i32 0',
+             [FmtVar]),
+         format(atom(PrintCall),
+             '  %printed_end_expr_f64_~w = call i32 (i8*, ...) @printf(i8* %~w, double ~w)',
+             [PrintIndex, FmtVar, ValueIR])
+      ;  plawk_i64_expr_ir(SubstitutedExpr, 32, Base, Base, ValueIR,
+             [], SetupParts),
+         format(atom(PrintVar), 'printed_end_expr_~w', [PrintIndex]),
+         llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+             ValueIR, [FmtPtr, PrintCall])
+      ),
       append(SetupParts, [FmtPtr, PrintCall], Lines)
     },
     plawk_emit_lines(Lines).

--- a/tests/test_plawk_float_slots.pl
+++ b/tests/test_plawk_float_slots.pl
@@ -60,10 +60,25 @@ test(fixpoint_promotes_transitive_reads) :-
         '@printf(i8* %end_f64_fmt_0, double %final_slot_'))),
     !.
 
-test(end_arith_on_double_slot_is_rejected) :-
-    % END i64 arithmetic cannot consume a double slot.
+test(end_arith_on_double_slot_promotes_to_f64) :-
+    % END arithmetic reading a double slot promotes the whole expression
+    % to double and prints %g (was rejected before the f64 END slice).
     plawk_parse_string("{ sum += 0.5 } END { print sum + 1 }\n", Program),
-    assertion(\+ plawk_program_native_driver_ir(Program, 'input.txt', _)).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, ' = fadd double '))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'printed_end_expr_f64_0'))),
+    !.
+
+test(surface_end_f64_average) :-
+    % The classic average: double slot divided by NR, IEEE fdiv, %g print.
+    run_f64_smoke("{ sum += float($2) ; n++ } END { print sum / NR, n * 2, sum + 0.5 }\n",
+        "a 2.5\nb 0.5\nc 1.5\nd 3.5\n",
+        "2 8 8.5\n").
+
+test(surface_end_float_literal_expr) :-
+    run_f64_smoke("{ n++ } END { print n * 1.5 }\n",
+        "a\nb\nc\n",
+        "4.5\n").
 
 test(surface_double_accumulator_text) :-
     run_f64_smoke("{ sum += float($2) * 1.5 ; n++ } END { print n, sum }\n",


### PR DESCRIPTION
## Summary

Closes the one gap left in the doubles story: END arithmetic now composes with double scalar slots.

```awk
{ sum += float($2) ; n++ }
END { print sum / NR, n * 2, sum + 0.5 }
```

prints `2 8 8.5` — the first expression promotes wholesale to double (IEEE `fdiv`, no divide-by-zero guard, matching rule-body float semantics, `%g` print), the second stays a pure-i64 expression with the guarded `sdiv` path, and both coexist in one END print.

## How it works

- `plawk_substitute_end_reads` now types its substitutions: a read of a double slot becomes an `ssa_f64(%final_slot_N)` leaf, i64 slots stay `ssa/1`, and `NR` remains the i64 loop-head phi.
- The END expression printer dispatches on the substituted tree's type: double-typed trees (a double-slot read or a float literal anywhere in the tree) lower through the shared `plawk_f64_expr_ir` emitter — i64 subtrees promote via `sitofp` — and print `%g`; everything else keeps the existing i64 emitter unchanged.
- `float_const` joins the END operand whitelist, so `END { print n * 1.5 }` works even with no double slots in the program.

## Tests

The float-slots suite's `end_arith_on_double_slot_is_rejected` test — which pinned the old boundary — flips to `end_arith_on_double_slot_promotes_to_f64`, asserting the promotion in the IR. Two new end-to-end tests: the classic average (`sum / NR` alongside an i64 expression in the same print statement) and a float-literal END expression. Suite is now 13 tests; the pre-existing END-scalar-exprs suite confirms i64 END behavior is untouched.

Full regression sweep green: all 25 suites exit 0.

## Merge order

Stacked on #3415 (for-in writebin). Chain: #3414 → #3415 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_