### PR TITLE
plawk: sN string slots in OUTFMT

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -494,7 +494,11 @@ binary inputs, so plawk-to-plawk binary pipelines (converter |
 aggregator) run with no text serialization between stages. The END
 for-in loop composes with writebin: `for (k in counts) writebin k,
 counts[k]` iterates the group table and emits one binary record per
-group (binary input mode only -- text keys are atom ids). Remaining
+group (binary input mode only -- text keys are atom ids). OUTFMT
+accepts `sN` string slots: literals, `sM` input fields (`M <= N`), and
+text-mode slices clamped to the width lower to memset + memcpy against
+the record buffer, so string-carrying binary pipelines work in both
+directions. Remaining
 Phase 3 items below (DCG readers, richer ABIs) are unchanged.
 
 **Second slice landed (typed associative arrays):** in binary mode

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -89,6 +89,7 @@ swipl -q -s tests/test_plawk_float_slots.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/
 swipl -q -s tests/test_plawk_binfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_binary_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_forin_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_outfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -295,9 +296,14 @@ stages. Group-by results can also leave as binary:
 `END { for (k in counts) writebin k, counts[k] }` walks the table and
 emits one record per group (raw i64 keys, table values, or literals;
 i64 values promote into f64 output slots) - binary input mode only,
-since text-mode keys are interned atom ids. Rejected: writebin without OUTFMT, argument/layout arity
-mismatch, `sN` output fields (later slice), and double expressions into
-i64 slots. A trailing partial record exits with the read
+since text-mode keys are interned atom ids. OUTFMT also takes `sN` string slots: sources are string
+literals that fit the width, `sM` binary input fields with `M <= N`
+(memcpy + zero-fill), or text-mode field slices clamped to the width
+(a missing field writes all zeros) - so text-to-binary converters
+carry names alongside numbers. Rejected: writebin without OUTFMT,
+argument/layout arity mismatch, oversized literals or source fields,
+numeric fields into string slots, and double expressions into i64
+slots. A trailing partial record exits with the read
 error code. Measured on 2M records: 0.040s for the binary program vs
 0.225s for mawk on the equivalent text (5.6x) and 0.156s for plawk's own
 text mode.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1729,6 +1729,17 @@ plawk_binfmt_writebin_args_ok(Descriptor, [f64 | Types], [Field | Fields]) :-
     ;  plawk_binfmt_i64_expr_ok(Descriptor, Field)
     ),
     plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+plawk_binfmt_writebin_args_ok(Descriptor, [s(Width) | Types], [Field | Fields]) :-
+    plawk_binfmt_writebin_str_ok(Descriptor, Field, Width),
+    plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+
+plawk_binfmt_writebin_str_ok(_Descriptor, string(Value), Width) :-
+    !,
+    string_length(Value, Length),
+    Length =< Width.
+plawk_binfmt_writebin_str_ok(Descriptor, field(FieldIndex), Width) :-
+    plawk_binfmt_field_type(Descriptor, FieldIndex, s(SourceWidth)),
+    SourceWidth =< Width.
 
 plawk_binfmt_print_field_ok(_Descriptor, string(_Value)) :- !.
 plawk_binfmt_print_field_ok(_Descriptor, special('NR')) :- !.
@@ -1872,11 +1883,13 @@ plawk_binfmt_record_size(binfmt(Types), Size) :-
 %  (writebin_out(Types, Fields)) so downstream validation and emission
 %  are self-contained; it fails (rejecting the program) when writebin
 %  appears without OUTFMT, an argument count mismatches the layout, or
-%  the layout contains non-numeric fields (sN output is a later slice).
+%  the layout contains an unknown field type (i64, f64, and sN are
+%  supported).
 plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules, WritebinPlan) :-
     ( plawk_rules_have_writebin(Rules0)
     ->  plawk_begin_outfmt_types(BeginClauses, Types),
-        forall(member(Type, Types), memberchk(Type, [i64, f64])),
+        forall(member(Type, Types),
+            ( memberchk(Type, [i64, f64]) ; Type = s(_Width) )),
         plawk_binfmt_record_size(binfmt(Types), Size),
         WritebinPlan = outfmt(Types, Size),
         maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules)
@@ -1957,9 +1970,21 @@ plawk_writebin_args_ok([], []).
 plawk_writebin_args_ok([Type | Types], [Field | Fields]) :-
     ( Type == i64
     -> plawk_writebin_i64_arg(Field)
+    ;  Type = s(Width)
+    -> plawk_writebin_str_arg(Field, Width)
     ;  plawk_writebin_f64_arg(Field)
     ),
     plawk_writebin_args_ok(Types, Fields).
+
+% sN output slots take string literals that fit the width, or field
+% reads (validated against the input layout separately in binary mode;
+% any field slice in text mode, clamped to the width at emission).
+plawk_writebin_str_arg(string(Value), Width) :-
+    string_length(Value, Length),
+    Length =< Width.
+plawk_writebin_str_arg(field(FieldIndex), _Width) :-
+    integer(FieldIndex),
+    FieldIndex >= 1.
 
 plawk_writebin_i64_arg(special('NR')).
 plawk_writebin_i64_arg(special('NF')).
@@ -2002,27 +2027,118 @@ plawk_writebin_field_lines([Type | Types], [Field0 | Fields], Slots, Values,
         FieldSeparator, Prefix, BasePtr, Index, Offset, Lines, GlobalParts) :-
     plawk_substitute_scalar_reads(Field0, Slots, Values, Field),
     format(atom(Base), '~w_f~w', [Prefix, Index]),
-    ( Type == i64
-    ->  plawk_i64_expr_ir(Field, FieldSeparator, Base, Base, ValueIR,
-            GParts, SetupParts),
-        LLVMType = i64
-    ;   plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
-            GParts, SetupParts),
-        LLVMType = double
-    ),
-    format(atom(Gep),
-        '  %~w_fp = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
-    format(atom(Cast),
-        '  %~w_tp = bitcast i8* %~w_fp to ~w*', [Base, Base, LLVMType]),
-    format(atom(Store),
-        '  store ~w ~w, ~w* %~w_tp, align 1', [LLVMType, ValueIR, LLVMType, Base]),
+    plawk_writebin_slot_lines(Type, Field, FieldSeparator, Base, BasePtr,
+        Offset, SlotLines, GParts),
     plawk_binfmt_type_width(Type, Width),
     NextOffset is Offset + Width,
     NextIndex is Index + 1,
     plawk_writebin_field_lines(Types, Fields, Slots, Values, FieldSeparator,
         Prefix, BasePtr, NextIndex, NextOffset, RestLines, RestGlobals),
-    append([SetupParts, [Gep, Cast, Store], RestLines], Lines),
+    append(SlotLines, RestLines, Lines),
     append(GParts, RestGlobals, GlobalParts).
+
+%% plawk_writebin_slot_lines(+Type, +Field, +FieldSeparator, +Base,
+%%     +BasePtr, +Offset, -Lines, -GlobalParts)
+%
+%  Store one writebin argument at its layout offset. Numeric slots are
+%  typed stores; sN slots memset the slot to zero and memcpy the source
+%  bytes (a literal's global, an sM binary input field, or a text-mode
+%  field slice clamped to the slot width).
+plawk_writebin_slot_lines(s(Width), string(Value), _FieldSeparator, Base,
+        BasePtr, Offset, Lines, [GlobalLine]) :-
+    !,
+    format(atom(LitGlobal), '~w_lit', [Base]),
+    llvm_emit_c_string_global(LitGlobal, Value, GlobalLine, StringLen, BytesLen),
+    StringLen =< Width,
+    format(atom(Dst),
+        '  %~w_dst = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Src),
+        '  %~w_src = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
+        [Base, BytesLen, BytesLen, LitGlobal]),
+    format(atom(Zero),
+        '  call void @llvm.memset.p0i8.i64(i8* %~w_dst, i8 0, i64 ~w, i1 false)',
+        [Base, Width]),
+    format(atom(Copy),
+        '  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %~w_dst, i8* %~w_src, i64 ~w, i1 false)',
+        [Base, Base, StringLen]),
+    Lines = [Dst, Src, Zero, Copy].
+plawk_writebin_slot_lines(s(Width), field(FieldIndex), binfmt(Types), Base,
+        BasePtr, Offset, Lines, []) :-
+    !,
+    plawk_binfmt_field_type(binfmt(Types), FieldIndex, s(SourceWidth)),
+    SourceWidth =< Width,
+    plawk_binfmt_field_offset(binfmt(Types), FieldIndex, SourceOffset),
+    format(atom(Dst),
+        '  %~w_dst = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Src),
+        '  %~w_src = getelementptr i8, i8* %rec, i64 ~w', [Base, SourceOffset]),
+    ( SourceWidth < Width
+    ->  format(atom(Zero),
+            '  call void @llvm.memset.p0i8.i64(i8* %~w_dst, i8 0, i64 ~w, i1 false)',
+            [Base, Width]),
+        ZeroLines = [Zero]
+    ;   ZeroLines = []
+    ),
+    format(atom(Copy),
+        '  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %~w_dst, i8* %~w_src, i64 ~w, i1 false)',
+        [Base, Base, SourceWidth]),
+    append([[Dst, Src], ZeroLines, [Copy]], Lines).
+plawk_writebin_slot_lines(s(Width), field(FieldIndex), FieldSeparator, Base,
+        BasePtr, Offset, Lines, []) :-
+    !,
+    % Text mode: slice the field, clamp to the slot width, zero-fill,
+    % and copy behind a null guard (a missing field writes all zeros).
+    FieldIndex >= 1,
+    llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base,
+        SliceIR),
+    format(atom(Dst),
+        '  %~w_dst = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Zero),
+        '  call void @llvm.memset.p0i8.i64(i8* %~w_dst, i8 0, i64 ~w, i1 false)',
+        [Base, Width]),
+    format(atom(Guard),
+'  %~w_null = icmp eq i8* %~w_ptr, null
+  %~w_over = icmp ugt i64 %~w_len64, ~w
+  %~w_cap = select i1 %~w_over, i64 ~w, i64 %~w_len64
+  br i1 %~w_null, label %~w_done, label %~w_copy
+
+~w_copy:
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %~w_dst, i8* %~w_ptr, i64 %~w_cap, i1 false)
+  br label %~w_done
+
+~w_done:',
+        [Base, Base,
+         Base, Base, Width,
+         Base, Base, Width, Base,
+         Base, Base, Base,
+         Base, Base, Base, Base, Base,
+         Base]),
+    Lines = [SliceIR, Dst, Zero, Guard].
+plawk_writebin_slot_lines(i64, Field, FieldSeparator, Base, BasePtr, Offset,
+        Lines, GParts) :-
+    !,
+    plawk_i64_expr_ir(Field, FieldSeparator, Base, Base, ValueIR,
+        GParts, SetupParts),
+    plawk_writebin_numeric_store_lines(i64, ValueIR, Base, BasePtr, Offset,
+        StoreLines),
+    append(SetupParts, StoreLines, Lines).
+plawk_writebin_slot_lines(f64, Field, FieldSeparator, Base, BasePtr, Offset,
+        Lines, GParts) :-
+    plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
+        GParts, SetupParts),
+    plawk_writebin_numeric_store_lines(double, ValueIR, Base, BasePtr, Offset,
+        StoreLines),
+    append(SetupParts, StoreLines, Lines).
+
+plawk_writebin_numeric_store_lines(LLVMType, ValueIR, Base, BasePtr, Offset,
+        [Gep, Cast, Store]) :-
+    format(atom(Gep),
+        '  %~w_fp = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Cast),
+        '  %~w_tp = bitcast i8* %~w_fp to ~w*', [Base, Base, LLVMType]),
+    format(atom(Store),
+        '  store ~w ~w, ~w* %~w_tp, align 1',
+        [LLVMType, ValueIR, LLVMType, Base]).
 
 plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
         GParts, SetupParts) :-

--- a/tests/test_plawk_binary_writers.pl
+++ b/tests/test_plawk_binary_writers.pl
@@ -44,8 +44,6 @@ test(writebin_rejections) :-
         "{ writebin $1, $2 }\n",
         % argument count does not match the layout
         "BEGIN { OUTFMT = \"i64 i64\" } { writebin $1 }\n",
-        % sN output fields are a later slice
-        "BEGIN { OUTFMT = \"s8 i64\" } { writebin $1, $2 }\n",
         % double expression into an i64 slot
         "BEGIN { OUTFMT = \"i64\" } { writebin 1.5 }\n",
         % string field into an i64 slot in binary input mode

--- a/tests/test_plawk_outfmt_strings.pl
+++ b/tests/test_plawk_outfmt_strings.pl
@@ -1,0 +1,198 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_ostr_marker/0.
+
+user:plawk_ostr_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_outfmt_strings, [condition(clang_available)]).
+
+test(sN_output_ir_uses_memcpy_memset) :-
+    plawk_parse_string("BEGIN { OUTFMT = \"s8 i64\" } { writebin $1, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    % s8 + i64 = 16-byte records
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_wbuf = alloca [16 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@llvm.memset.p0i8.i64'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@llvm.memcpy.p0i8.p0i8.i64'))),
+    % text-mode source: slice + clamp guard
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_cap = select i1 '))),
+    !.
+
+test(sN_literal_source_ir) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"s4 i64\" } { writebin \"tag\", $1 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'c"tag\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 3, i1 false)'))),
+    !.
+
+test(sN_output_rejections) :-
+    Rejects = [
+        % literal longer than the slot
+        "BEGIN { OUTFMT = \"s4\" } { writebin \"toolong\" }\n",
+        % source field wider than the output slot
+        "BEGIN { BINFMT = \"s8 i64\" ; OUTFMT = \"s4\" } { writebin $1 }\n",
+        % numeric input field into a string slot
+        "BEGIN { BINFMT = \"s8 i64\" ; OUTFMT = \"s8\" } { writebin $2 }\n",
+        % string literal into an i64 slot
+        "BEGIN { OUTFMT = \"i64\" } { writebin \"x\" }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.txt', _))
+        ;  true
+        )).
+
+test(surface_text_to_binary_string_slot) :-
+    % Short values NUL-pad; a value longer than the slot clamps to width.
+    build_ostr_probe("BEGIN { OUTFMT = \"s8 i64\" } { writebin $1, $2 }\n",
+        text("alpha 5\nbee 7\nlongname12 9\n"), Dir, BinPath),
+    run_capture_raw(BinPath, Bytes),
+    decode_s8_i64(Bytes, Records),
+    assertion(Records == ["alpha"-5, "bee"-7, "longname"-9]),
+    assertion(Dir \== ''),
+    !.
+
+test(surface_binary_string_passthrough_with_tag) :-
+    build_ostr_probe("BEGIN { BINFMT = \"s8 i64\" ; OUTFMT = \"s4 s8 i64\" } $2 > 1 { writebin \"tag\", $1, $2 * 2 }\n",
+        s8_i64([rec("alpha", 5), rec("bee", 7)]), _Dir, BinPath),
+    run_capture_raw(BinPath, Bytes),
+    decode_s4_s8_i64(Bytes, Records),
+    assertion(Records == [t("tag", "alpha", 10), t("tag", "bee", 14)]),
+    !.
+
+test(surface_empty_field_writes_zero_slot) :-
+    % A record with fewer fields than referenced: the slot is all zeros.
+    build_ostr_probe("BEGIN { OUTFMT = \"s8 i64\" } { writebin $2, NR }\n",
+        text("one\nalpha beta\n"), _Dir, BinPath),
+    run_capture_raw(BinPath, Bytes),
+    decode_s8_i64(Bytes, Records),
+    assertion(Records == [""-1, "beta"-2]),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_sfield(Out, String, Width) :-
+    string_codes(String, Codes),
+    length(Codes, Len),
+    Len =< Width,
+    forall(member(C, Codes), put_byte(Out, C)),
+    Pad is Width - Len,
+    forall(between(1, Pad, _), put_byte(Out, 0)).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+sfield_string(Codes, String) :-
+    append(Prefix, Suffix, Codes),
+    ( Suffix = [0 | _] ; Suffix = [] ),
+    \+ member(0, Prefix),
+    !,
+    string_codes(String, Prefix).
+
+decode_s8_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_s8_i64_codes(Codes, Records).
+
+decode_s8_i64_codes([], []).
+decode_s8_i64_codes(Codes, [S-V | Records]) :-
+    length(SBytes, 8), length(VBytes, 8),
+    append(SBytes, Rest0, Codes), append(VBytes, Rest, Rest0),
+    sfield_string(SBytes, S),
+    le_i64(VBytes, V),
+    decode_s8_i64_codes(Rest, Records).
+
+decode_s4_s8_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_s4_s8_i64_codes(Codes, Records).
+
+decode_s4_s8_i64_codes([], []).
+decode_s4_s8_i64_codes(Codes, [t(A, B, V) | Records]) :-
+    length(ABytes, 4), length(BBytes, 8), length(VBytes, 8),
+    append(ABytes, Rest0, Codes),
+    append(BBytes, Rest1, Rest0),
+    append(VBytes, Rest, Rest1),
+    sfield_string(ABytes, A),
+    sfield_string(BBytes, B),
+    le_i64(VBytes, V),
+    decode_s4_s8_i64_codes(Rest, Records).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_ostr_marker/0 ],
+        [module_name('plawk_outfmt_strings')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk outfmt strings build output]~n~w~n", [BuildOut]),
+       throw(plawk_outfmt_strings_build_failed(Status))
+    ).
+
+build_ostr_probe(Source, Input, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_outfmt_strings', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    ( Input = text(Text)
+    ->  directory_file_path(Dir, 'input.txt', InputPath),
+        setup_call_cleanup(
+            open(InputPath, write, Out, [encoding(utf8)]),
+            write(Out, Text),
+            close(Out))
+    ;   Input = s8_i64(Recs),
+        directory_file_path(Dir, 'input.bin', InputPath),
+        setup_call_cleanup(
+            open(InputPath, write, Out, [type(binary)]),
+            forall(member(rec(S, V), Recs),
+                ( write_sfield(Out, S, 8), write_i64_le(Out, V) )),
+            close(Out))
+    ),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_capture_raw(BinPath, Bytes) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)).
+
+:- end_tests(plawk_outfmt_strings).


### PR DESCRIPTION
## Summary

`writebin` can now carry fixed-width strings, so binary pipelines keep names alongside numbers in both directions:

```awk
# text → binary: names survive the conversion
BEGIN { OUTFMT = "s8 i64" } { writebin $1, $2 }

# binary → binary: passthrough + literal tag + arithmetic
BEGIN { BINFMT = "s8 i64" ; OUTFMT = "s4 s8 i64" }
$2 > 1 { writebin "tag", $1, $2 * 2 }
```

## What's included

- The writebin field emitter is refactored into a per-slot dispatcher (`plawk_writebin_slot_lines/8`); numeric slots keep their typed stores unchanged.
- **Three `sN` slot sources**, all lowering to `llvm.memset` zero-fill plus `llvm.memcpy` (both intrinsics were already declared in the module template):
  - *string literals* that fit the width — copied from a private constant at a compile-time length;
  - *`sM` binary input fields* with `M ≤ N` — memcpy between compile-time offsets, no runtime length computation at all;
  - *text-mode field slices* — clamped to the slot width behind a null guard, so `"longname12"` lands as its first 8 bytes in an `s8` slot and a missing field writes all zeros.
- **Validation** (both the general and binfmt-input checkers): oversized literals, source fields wider than the output slot, and numeric fields aimed at string slots are all rejected. The writers suite's "sN output is a later slice" rejection test is superseded and removed — that program is the feature now.

## Tests

New suite `tests/test_plawk_outfmt_strings.pl` (6 tests): memset/memcpy + clamp-select IR shape, literal-source IR, four rejection shapes, text→binary end-to-end with NUL-padding and clamping decoded byte-exactly, binary passthrough with a literal tag, and the missing-field-writes-zeros edge case.

Full regression sweep green: all 26 suites exit 0.

## Merge order

Stacked on #3416 (f64 END arithmetic). Chain: #3414 → #3415 → #3416 → this PR. **Note from the last two rounds:** merging the chain top-down leaves main behind — merging #3414 into main first, then each PR in order (GitHub retargets each to main as its base merges), avoids another consolidation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_