### PR TITLE
plawk: consolidate writebin follow-ups to main (#3415–#3417)

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -494,7 +494,11 @@ binary inputs, so plawk-to-plawk binary pipelines (converter |
 aggregator) run with no text serialization between stages. The END
 for-in loop composes with writebin: `for (k in counts) writebin k,
 counts[k]` iterates the group table and emits one binary record per
-group (binary input mode only -- text keys are atom ids). Remaining
+group (binary input mode only -- text keys are atom ids). OUTFMT
+accepts `sN` string slots: literals, `sM` input fields (`M <= N`), and
+text-mode slices clamped to the width lower to memset + memcpy against
+the record buffer, so string-carrying binary pipelines work in both
+directions. Remaining
 Phase 3 items below (DCG readers, richer ABIs) are unchanged.
 
 **Second slice landed (typed associative arrays):** in binary mode

--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -330,8 +330,10 @@ slot's LLVM type; double updates lower the RHS through
 leaves, i64 operands promote via `sitofp`) into `fadd`, and END prints
 of double slots use `%g`. `{ sum += $2 * 1.5 }` and
 `{ sum += float($2) }` now accumulate natively in both text and binary
-record modes; END *arithmetic* on double slots stays i64-only and is
-rejected (the next f64 slice).
+record modes; END *arithmetic* composes too:
+an END expression that reads a double slot or contains a float literal
+promotes wholesale to double (`END { print sum / NR }` is an IEEE
+`fdiv` with a `%g` print; i64 END expressions keep guarded `sdiv`).
 Scalar variables are readable inside rule-body update expressions and END
 prints: codegen substitutes `var(Name)` leaves with the current SSA slot
 value (an `ssa/1` leaf the shared emitters print verbatim) before emission,

--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -489,7 +489,10 @@ through the i64/f64 expression emitters into a typed store at its
 layout offset, and a buffered `fwrite(buf, size, 1, stdout)` emits the
 record (libc flushes on normal main return). Works from both text and
 binary inputs, so plawk-to-plawk binary pipelines (converter |
-aggregator) run with no text serialization between stages. Remaining
+aggregator) run with no text serialization between stages. The END
+for-in loop composes with writebin: `for (k in counts) writebin k,
+counts[k]` iterates the group table and emits one binary record per
+group (binary input mode only -- text keys are atom ids). Remaining
 Phase 3 items below (DCG readers, richer ABIs) are unchanged.
 
 **Second slice landed (typed associative arrays):** in binary mode

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -88,6 +88,7 @@ swipl -q -s tests/test_plawk_binary_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt
 swipl -q -s tests/test_plawk_float_slots.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_binfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_binary_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_forin_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -287,7 +288,11 @@ expressions, NR/NF, scalar reads, and double expressions per the OUTFMT
 slot types (i64 arguments promote into f64 slots), and composes with
 guards, scalar updates, and `if`/`else`. A plawk-to-plawk pipeline -
 converter | aggregator - runs with no text serialization between
-stages. Rejected: writebin without OUTFMT, argument/layout arity
+stages. Group-by results can also leave as binary:
+`END { for (k in counts) writebin k, counts[k] }` walks the table and
+emits one record per group (raw i64 keys, table values, or literals;
+i64 values promote into f64 output slots) - binary input mode only,
+since text-mode keys are interned atom ids. Rejected: writebin without OUTFMT, argument/layout arity
 mismatch, `sN` output fields (later slice), and double expressions into
 i64 slots. A trailing partial record exits with the read
 error code. Measured on 2M records: 0.040s for the binary program vs

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -89,6 +89,7 @@ swipl -q -s tests/test_plawk_float_slots.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/
 swipl -q -s tests/test_plawk_binfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_binary_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_forin_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_outfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -295,9 +296,14 @@ stages. Group-by results can also leave as binary:
 `END { for (k in counts) writebin k, counts[k] }` walks the table and
 emits one record per group (raw i64 keys, table values, or literals;
 i64 values promote into f64 output slots) - binary input mode only,
-since text-mode keys are interned atom ids. Rejected: writebin without OUTFMT, argument/layout arity
-mismatch, `sN` output fields (later slice), and double expressions into
-i64 slots. A trailing partial record exits with the read
+since text-mode keys are interned atom ids. OUTFMT also takes `sN` string slots: sources are string
+literals that fit the width, `sM` binary input fields with `M <= N`
+(memcpy + zero-fill), or text-mode field slices clamped to the width
+(a missing field writes all zeros) - so text-to-binary converters
+carry names alongside numbers. Rejected: writebin without OUTFMT,
+argument/layout arity mismatch, oversized literals or source fields,
+numeric fields into string slots, and double expressions into i64
+slots. A trailing partial record exits with the read
 error code. Measured on 2M records: 0.040s for the binary program vs
 0.225s for mawk on the equivalent text (5.6x) and 0.156s for plawk's own
 text mode.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -261,7 +261,10 @@ assigns it a float-typed expression or reads an already-double scalar
 (fixpoint), and i64 operands promote via `sitofp` at the update site.
 This works in text mode (`float($N)` = strtod) and binary mode
 (`float($N)` = native f64 field load), through `if`/`else`,
-`next`/`break`, and rule chains. `NF` is a compile-time
+`next`/`break`, and rule chains. END arithmetic composes with double
+slots: `END { print sum / NR }` promotes the whole expression to double
+(IEEE `fdiv`, no divide-by-zero guard, `%g` print), and float literals
+in END expressions (`print n * 1.5`) do the same. `NF` is a compile-time
 constant; `NR`, `if/else`, `next`/`break`, `printf`, and END reports
 compose unchanged. Associative arrays keyed by i64 fields work in
 binary mode: `{ counts[$1]++ }` uses the raw field value as the table key

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1729,6 +1729,17 @@ plawk_binfmt_writebin_args_ok(Descriptor, [f64 | Types], [Field | Fields]) :-
     ;  plawk_binfmt_i64_expr_ok(Descriptor, Field)
     ),
     plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+plawk_binfmt_writebin_args_ok(Descriptor, [s(Width) | Types], [Field | Fields]) :-
+    plawk_binfmt_writebin_str_ok(Descriptor, Field, Width),
+    plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+
+plawk_binfmt_writebin_str_ok(_Descriptor, string(Value), Width) :-
+    !,
+    string_length(Value, Length),
+    Length =< Width.
+plawk_binfmt_writebin_str_ok(Descriptor, field(FieldIndex), Width) :-
+    plawk_binfmt_field_type(Descriptor, FieldIndex, s(SourceWidth)),
+    SourceWidth =< Width.
 
 plawk_binfmt_print_field_ok(_Descriptor, string(_Value)) :- !.
 plawk_binfmt_print_field_ok(_Descriptor, special('NR')) :- !.
@@ -1872,11 +1883,13 @@ plawk_binfmt_record_size(binfmt(Types), Size) :-
 %  (writebin_out(Types, Fields)) so downstream validation and emission
 %  are self-contained; it fails (rejecting the program) when writebin
 %  appears without OUTFMT, an argument count mismatches the layout, or
-%  the layout contains non-numeric fields (sN output is a later slice).
+%  the layout contains an unknown field type (i64, f64, and sN are
+%  supported).
 plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules, WritebinPlan) :-
     ( plawk_rules_have_writebin(Rules0)
     ->  plawk_begin_outfmt_types(BeginClauses, Types),
-        forall(member(Type, Types), memberchk(Type, [i64, f64])),
+        forall(member(Type, Types),
+            ( memberchk(Type, [i64, f64]) ; Type = s(_Width) )),
         plawk_binfmt_record_size(binfmt(Types), Size),
         WritebinPlan = outfmt(Types, Size),
         maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules)
@@ -1957,9 +1970,21 @@ plawk_writebin_args_ok([], []).
 plawk_writebin_args_ok([Type | Types], [Field | Fields]) :-
     ( Type == i64
     -> plawk_writebin_i64_arg(Field)
+    ;  Type = s(Width)
+    -> plawk_writebin_str_arg(Field, Width)
     ;  plawk_writebin_f64_arg(Field)
     ),
     plawk_writebin_args_ok(Types, Fields).
+
+% sN output slots take string literals that fit the width, or field
+% reads (validated against the input layout separately in binary mode;
+% any field slice in text mode, clamped to the width at emission).
+plawk_writebin_str_arg(string(Value), Width) :-
+    string_length(Value, Length),
+    Length =< Width.
+plawk_writebin_str_arg(field(FieldIndex), _Width) :-
+    integer(FieldIndex),
+    FieldIndex >= 1.
 
 plawk_writebin_i64_arg(special('NR')).
 plawk_writebin_i64_arg(special('NF')).
@@ -2002,27 +2027,118 @@ plawk_writebin_field_lines([Type | Types], [Field0 | Fields], Slots, Values,
         FieldSeparator, Prefix, BasePtr, Index, Offset, Lines, GlobalParts) :-
     plawk_substitute_scalar_reads(Field0, Slots, Values, Field),
     format(atom(Base), '~w_f~w', [Prefix, Index]),
-    ( Type == i64
-    ->  plawk_i64_expr_ir(Field, FieldSeparator, Base, Base, ValueIR,
-            GParts, SetupParts),
-        LLVMType = i64
-    ;   plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
-            GParts, SetupParts),
-        LLVMType = double
-    ),
-    format(atom(Gep),
-        '  %~w_fp = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
-    format(atom(Cast),
-        '  %~w_tp = bitcast i8* %~w_fp to ~w*', [Base, Base, LLVMType]),
-    format(atom(Store),
-        '  store ~w ~w, ~w* %~w_tp, align 1', [LLVMType, ValueIR, LLVMType, Base]),
+    plawk_writebin_slot_lines(Type, Field, FieldSeparator, Base, BasePtr,
+        Offset, SlotLines, GParts),
     plawk_binfmt_type_width(Type, Width),
     NextOffset is Offset + Width,
     NextIndex is Index + 1,
     plawk_writebin_field_lines(Types, Fields, Slots, Values, FieldSeparator,
         Prefix, BasePtr, NextIndex, NextOffset, RestLines, RestGlobals),
-    append([SetupParts, [Gep, Cast, Store], RestLines], Lines),
+    append(SlotLines, RestLines, Lines),
     append(GParts, RestGlobals, GlobalParts).
+
+%% plawk_writebin_slot_lines(+Type, +Field, +FieldSeparator, +Base,
+%%     +BasePtr, +Offset, -Lines, -GlobalParts)
+%
+%  Store one writebin argument at its layout offset. Numeric slots are
+%  typed stores; sN slots memset the slot to zero and memcpy the source
+%  bytes (a literal's global, an sM binary input field, or a text-mode
+%  field slice clamped to the slot width).
+plawk_writebin_slot_lines(s(Width), string(Value), _FieldSeparator, Base,
+        BasePtr, Offset, Lines, [GlobalLine]) :-
+    !,
+    format(atom(LitGlobal), '~w_lit', [Base]),
+    llvm_emit_c_string_global(LitGlobal, Value, GlobalLine, StringLen, BytesLen),
+    StringLen =< Width,
+    format(atom(Dst),
+        '  %~w_dst = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Src),
+        '  %~w_src = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
+        [Base, BytesLen, BytesLen, LitGlobal]),
+    format(atom(Zero),
+        '  call void @llvm.memset.p0i8.i64(i8* %~w_dst, i8 0, i64 ~w, i1 false)',
+        [Base, Width]),
+    format(atom(Copy),
+        '  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %~w_dst, i8* %~w_src, i64 ~w, i1 false)',
+        [Base, Base, StringLen]),
+    Lines = [Dst, Src, Zero, Copy].
+plawk_writebin_slot_lines(s(Width), field(FieldIndex), binfmt(Types), Base,
+        BasePtr, Offset, Lines, []) :-
+    !,
+    plawk_binfmt_field_type(binfmt(Types), FieldIndex, s(SourceWidth)),
+    SourceWidth =< Width,
+    plawk_binfmt_field_offset(binfmt(Types), FieldIndex, SourceOffset),
+    format(atom(Dst),
+        '  %~w_dst = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Src),
+        '  %~w_src = getelementptr i8, i8* %rec, i64 ~w', [Base, SourceOffset]),
+    ( SourceWidth < Width
+    ->  format(atom(Zero),
+            '  call void @llvm.memset.p0i8.i64(i8* %~w_dst, i8 0, i64 ~w, i1 false)',
+            [Base, Width]),
+        ZeroLines = [Zero]
+    ;   ZeroLines = []
+    ),
+    format(atom(Copy),
+        '  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %~w_dst, i8* %~w_src, i64 ~w, i1 false)',
+        [Base, Base, SourceWidth]),
+    append([[Dst, Src], ZeroLines, [Copy]], Lines).
+plawk_writebin_slot_lines(s(Width), field(FieldIndex), FieldSeparator, Base,
+        BasePtr, Offset, Lines, []) :-
+    !,
+    % Text mode: slice the field, clamp to the slot width, zero-fill,
+    % and copy behind a null guard (a missing field writes all zeros).
+    FieldIndex >= 1,
+    llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base,
+        SliceIR),
+    format(atom(Dst),
+        '  %~w_dst = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Zero),
+        '  call void @llvm.memset.p0i8.i64(i8* %~w_dst, i8 0, i64 ~w, i1 false)',
+        [Base, Width]),
+    format(atom(Guard),
+'  %~w_null = icmp eq i8* %~w_ptr, null
+  %~w_over = icmp ugt i64 %~w_len64, ~w
+  %~w_cap = select i1 %~w_over, i64 ~w, i64 %~w_len64
+  br i1 %~w_null, label %~w_done, label %~w_copy
+
+~w_copy:
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %~w_dst, i8* %~w_ptr, i64 %~w_cap, i1 false)
+  br label %~w_done
+
+~w_done:',
+        [Base, Base,
+         Base, Base, Width,
+         Base, Base, Width, Base,
+         Base, Base, Base,
+         Base, Base, Base, Base, Base,
+         Base]),
+    Lines = [SliceIR, Dst, Zero, Guard].
+plawk_writebin_slot_lines(i64, Field, FieldSeparator, Base, BasePtr, Offset,
+        Lines, GParts) :-
+    !,
+    plawk_i64_expr_ir(Field, FieldSeparator, Base, Base, ValueIR,
+        GParts, SetupParts),
+    plawk_writebin_numeric_store_lines(i64, ValueIR, Base, BasePtr, Offset,
+        StoreLines),
+    append(SetupParts, StoreLines, Lines).
+plawk_writebin_slot_lines(f64, Field, FieldSeparator, Base, BasePtr, Offset,
+        Lines, GParts) :-
+    plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
+        GParts, SetupParts),
+    plawk_writebin_numeric_store_lines(double, ValueIR, Base, BasePtr, Offset,
+        StoreLines),
+    append(SetupParts, StoreLines, Lines).
+
+plawk_writebin_numeric_store_lines(LLVMType, ValueIR, Base, BasePtr, Offset,
+        [Gep, Cast, Store]) :-
+    format(atom(Gep),
+        '  %~w_fp = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Cast),
+        '  %~w_tp = bitcast i8* %~w_fp to ~w*', [Base, Base, LLVMType]),
+    format(atom(Store),
+        '  store ~w ~w, ~w* %~w_tp, align 1',
+        [LLVMType, ValueIR, LLVMType, Base]).
 
 plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
         GParts, SetupParts) :-

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -246,6 +246,53 @@ plawk_program_native_driver_ir(
             RecordIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% Binary group-by to binary output: iterate the table and writebin one
+% fixed-layout record per group. Binary input mode only -- text-mode
+% keys are interned atom ids, which would be meaningless bytes in the
+% output stream.
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules, [end([for_in(var(LoopVar), var(ArrayName), [writebin(Fields)])])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    FieldSeparator = binfmt(_InputTypes),
+    plawk_begin_outfmt_types(BeginClauses, OutTypes),
+    forall(member(OutType, OutTypes), memberchk(OutType, [i64, f64])),
+    length(OutTypes, ArgCount),
+    length(Fields, ArgCount),
+    maplist(plawk_forin_writebin_field(LoopVar), Fields),
+    findall(LookupArrayName,
+        member(assoc(var(LookupArrayName), var(LoopVar)), Fields),
+        LookupArrays),
+    plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays, AssocPlan),
+    plawk_assoc_record_program_ok(FieldSeparator, Rules, []),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_binfmt_record_size(binfmt(OutTypes), OutRecordSize),
+    plawk_writebin_entry_lines(outfmt(OutTypes, OutRecordSize), WritebinEntryIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_forin_end_writebin_ir(LoopVar, ArrayName, OutTypes, Fields, AssocPlan,
+        EndPrintIR),
+    plawk_writebin_globals(outfmt(OutTypes, OutRecordSize), WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, AssocRuleGlobalIR, WritebinGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR0),
+    plawk_combine_entry_ir(CombinedEntrySetupIR0, WritebinEntryIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w',
+        [EndPrintIR]),
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
+            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 plawk_program_native_driver_ir(
     program(BeginClauses, Rules, [end([for_in(var(LoopVar), var(ArrayName), BodyActions)])]),
     InputPath,
@@ -524,10 +571,17 @@ fail:
 %  the loop body is one print whose fields are the loop key, associative
 %  lookups keyed by the loop variable, or string literals.
 plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions,
-        assoc_plan(Tables, PlannedRules), PrintFields) :-
+        AssocPlan, PrintFields) :-
     BodyActions = [print(PrintFields)],
     PrintFields = [_ | _],
     maplist(plawk_forin_print_field(LoopVar), PrintFields),
+    findall(LookupArrayName,
+        member(assoc(var(LookupArrayName), var(LoopVar)), PrintFields),
+        LookupArrays),
+    plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays, AssocPlan).
+
+plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays,
+        assoc_plan(Tables, PlannedRules)) :-
     maplist(plawk_assoc_rule_action_specs, Rules, RuleSpecs),
     RuleSpecs \== [],
     findall(RuleArrayName,
@@ -535,9 +589,6 @@ plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions,
           member(RuleArrayName-_KeyIndex, ActionSpecs)
         ),
         ActionArrays),
-    findall(LookupArrayName,
-        member(assoc(var(LookupArrayName), var(LoopVar)), PrintFields),
-        LookupArrays),
     append([ActionArrays, [ArrayName], LookupArrays], ArrayNames0),
     sort(ArrayNames0, Tables),
     phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, 0), PlannedRules).
@@ -545,6 +596,108 @@ plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions,
 plawk_forin_print_field(LoopVar, var(LoopVar)).
 plawk_forin_print_field(LoopVar, assoc(var(_ArrayName), var(LoopVar))).
 plawk_forin_print_field(_LoopVar, string(_Value)).
+
+plawk_forin_writebin_field(LoopVar, var(LoopVar)).
+plawk_forin_writebin_field(LoopVar, assoc(var(_ArrayName), var(LoopVar))).
+plawk_forin_writebin_field(_LoopVar, int(Value)) :-
+    integer(Value).
+
+%% plawk_forin_end_writebin_ir(+LoopVar, +ArrayName, +OutTypes, +Fields,
+%%     +AssocPlan, -IR)
+%
+%  writebin variant of the END for-in loop: walk the iterated table's
+%  occupied slots and emit one fixed-layout binary record per group
+%  (raw i64 keys, table values, or literals; i64 values promote via
+%  sitofp into f64 output slots), then free every table and return.
+plawk_forin_end_writebin_ir(LoopVar, ArrayName, OutTypes, Fields, AssocPlan, IR) :-
+    plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
+    plawk_binfmt_record_size(binfmt(OutTypes), Size),
+    format(atom(BasePtr), '%forin_wb_base', []),
+    format(atom(BaseLine),
+        '  ~w = getelementptr inbounds [~w x i8], [~w x i8]* %plawk_wbuf, i32 0, i32 0',
+        [BasePtr, Size, Size]),
+    plawk_forin_writebin_field_lines(OutTypes, Fields, LoopVar, ArrayName,
+        TableIndex, AssocPlan, BasePtr, 0, 0, FieldLines),
+    format(atom(StdoutLoad),
+        '  %forin_wb_stdout = load i8*, i8** @stdout', []),
+    format(atom(WriteCall),
+        '  %forin_wb_wr = call i64 @fwrite(i8* ~w, i64 ~w, i64 1, i8* %forin_wb_stdout)',
+        [BasePtr, Size]),
+    append([[BaseLine], FieldLines, [StdoutLoad, WriteCall]], BodyLines),
+    atomic_list_concat(BodyLines, '\n', BodyIR),
+    phrase(plawk_assoc_free_lines(AssocPlan), FreeLines),
+    atomic_list_concat(FreeLines, '\n', FreeIR),
+    format(atom(IR),
+'  br label %forin_head
+
+forin_head:
+  %forin_idx = phi i64 [0, %end_print], [%forin_next_idx, %forin_body_done]
+  %forin_slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_idx)
+  %forin_done = icmp slt i64 %forin_slot, 0
+  br i1 %forin_done, label %forin_after, label %forin_body
+
+forin_body:
+  %forin_key_id = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)
+~w
+  br label %forin_body_done
+
+forin_body_done:
+  %forin_next_idx = add i64 %forin_slot, 1
+  br label %forin_head
+
+forin_after:
+~w
+  ret i32 0',
+        [TableIndex, TableIndex, BodyIR, FreeIR]).
+
+plawk_forin_writebin_field_lines([], [], _LoopVar, _ArrayName, _TableIndex,
+        _AssocPlan, _BasePtr, _Index, _Offset, []).
+plawk_forin_writebin_field_lines([OutType | OutTypes], [Field | Fields], LoopVar,
+        ArrayName, TableIndex, AssocPlan, BasePtr, Index, Offset, Lines) :-
+    format(atom(Base), 'forin_wb_f~w', [Index]),
+    plawk_forin_writebin_value_lines(Field, LoopVar, ArrayName, TableIndex,
+        AssocPlan, Base, ValueIR, ValueLines),
+    ( OutType == i64
+    ->  StoreValueIR = ValueIR,
+        LLVMType = i64,
+        PromoteLines = []
+    ;   format(atom(StoreValueIR), '%~w_f64p', [Base]),
+        format(atom(Promote), '  ~w = sitofp i64 ~w to double',
+            [StoreValueIR, ValueIR]),
+        LLVMType = double,
+        PromoteLines = [Promote]
+    ),
+    format(atom(Gep),
+        '  %~w_fp = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+    format(atom(Cast),
+        '  %~w_tp = bitcast i8* %~w_fp to ~w*', [Base, Base, LLVMType]),
+    format(atom(Store),
+        '  store ~w ~w, ~w* %~w_tp, align 1',
+        [LLVMType, StoreValueIR, LLVMType, Base]),
+    plawk_binfmt_type_width(OutType, Width),
+    NextOffset is Offset + Width,
+    NextIndex is Index + 1,
+    plawk_forin_writebin_field_lines(OutTypes, Fields, LoopVar, ArrayName,
+        TableIndex, AssocPlan, BasePtr, NextIndex, NextOffset, RestLines),
+    append([ValueLines, PromoteLines, [Gep, Cast, Store], RestLines], Lines).
+
+plawk_forin_writebin_value_lines(var(LoopVar), LoopVar, _ArrayName, _TableIndex,
+        _AssocPlan, _Base, '%forin_key_id', []).
+plawk_forin_writebin_value_lines(assoc(var(LookupArrayName), var(LoopVar)),
+        LoopVar, ArrayName, TableIndex, AssocPlan, Base, ValueIR, [Line]) :-
+    format(atom(ValueIR), '%~w_val', [Base]),
+    (   LookupArrayName == ArrayName
+    ->  format(atom(Line),
+            '  ~w = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)',
+            [ValueIR, TableIndex])
+    ;   plawk_assoc_table_index(AssocPlan, LookupArrayName, LookupTableIndex),
+        format(atom(Line),
+            '  ~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_key_id)',
+            [ValueIR, LookupTableIndex])
+    ).
+plawk_forin_writebin_value_lines(int(Value), _LoopVar, _ArrayName, _TableIndex,
+        _AssocPlan, _Base, Value, []) :-
+    integer(Value).
 
 %% plawk_forin_end_print_ir(+LoopVar, +ArrayName, +PrintFields, +AssocPlan,
 %%     +OutputSeparator, -IR)

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2616,6 +2616,12 @@ plawk_end_scalar_operand_expr(int(Value)) :-
 plawk_end_scalar_operand_expr(var(Name)) :-
     atom(Name).
 plawk_end_scalar_operand_expr(special('NR')).
+% Float literals make the whole END expression double-typed (%g print,
+% IEEE fdiv), as does reading a double slot.
+plawk_end_scalar_operand_expr(float_const(Mantissa, Denominator)) :-
+    integer(Mantissa),
+    integer(Denominator),
+    Denominator > 0.
 plawk_end_scalar_operand_expr(Expr) :-
     plawk_end_scalar_expr(Expr).
 
@@ -2655,10 +2661,14 @@ plawk_substitute_scalar_reads(Expr, _Slots, _Values, Expr).
 %  END-position substitution: var(Name) becomes the final slot value and
 %  NR becomes %plawk_nr, the loop-head record phi, which dominates
 %  end_print via close_stream / break_close_stream.
-plawk_substitute_end_reads(var(Name), StatePlan, ssa(Value)) :-
+plawk_substitute_end_reads(var(Name), StatePlan, Substituted) :-
     !,
-    plawk_state_slot_index(StatePlan, scalar_counter(Name), SlotIndex),
-    format(atom(Value), '%final_slot_~w', [SlotIndex]).
+    plawk_state_slot_lookup(StatePlan, Name, SlotIndex, Slot),
+    format(atom(Value), '%final_slot_~w', [SlotIndex]),
+    ( Slot = scalar_double(_Name)
+    -> Substituted = ssa_f64(Value)
+    ;  Substituted = ssa(Value)
+    ).
 plawk_substitute_end_reads(special('NR'), _StatePlan, ssa('%plawk_nr')) :-
     !.
 plawk_substitute_end_reads(Expr0, StatePlan, Expr) :-
@@ -3441,11 +3451,25 @@ plawk_end_nr_print_lines(PrintIndex) -->
 plawk_end_expr_print_lines(Expr, StatePlan, PrintIndex) -->
     { plawk_substitute_end_reads(Expr, StatePlan, SubstitutedExpr),
       format(atom(Base), 'plawk_end_expr_~w', [PrintIndex]),
-      plawk_i64_expr_ir(SubstitutedExpr, 32, Base, Base, ValueIR, [], SetupParts),
       format(atom(FmtVar), 'end_expr_fmt_~w', [PrintIndex]),
-      format(atom(PrintVar), 'printed_end_expr_~w', [PrintIndex]),
-      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
-          [FmtPtr, PrintCall]),
+      ( plawk_expr_is_double(SubstitutedExpr)
+      -> % A double-typed END expression (float literal leaf or a read of
+         % a double slot): whole tree promotes to double, prints as %g,
+         % and division is IEEE fdiv rather than guarded sdiv.
+         plawk_f64_expr_ir(SubstitutedExpr, 32, Base, Base, ValueIR,
+             [], SetupParts),
+         format(atom(FmtPtr),
+             '  %~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_f64, i32 0, i32 0',
+             [FmtVar]),
+         format(atom(PrintCall),
+             '  %printed_end_expr_f64_~w = call i32 (i8*, ...) @printf(i8* %~w, double ~w)',
+             [PrintIndex, FmtVar, ValueIR])
+      ;  plawk_i64_expr_ir(SubstitutedExpr, 32, Base, Base, ValueIR,
+             [], SetupParts),
+         format(atom(PrintVar), 'printed_end_expr_~w', [PrintIndex]),
+         llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+             ValueIR, [FmtPtr, PrintCall])
+      ),
       append(SetupParts, [FmtPtr, PrintCall], Lines)
     },
     plawk_emit_lines(Lines).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -474,6 +474,9 @@ for_in_action(for_in(var(LoopVar), var(ArrayName), Body)) -->
 for_in_body(Actions) -->
     action_block(Actions),
     !.
+for_in_body([WritebinAction]) -->
+    writebin_action(WritebinAction),
+    !.
 for_in_body([PrintAction]) -->
     print_action(PrintAction).
 

--- a/tests/test_plawk_binary_writers.pl
+++ b/tests/test_plawk_binary_writers.pl
@@ -44,8 +44,6 @@ test(writebin_rejections) :-
         "{ writebin $1, $2 }\n",
         % argument count does not match the layout
         "BEGIN { OUTFMT = \"i64 i64\" } { writebin $1 }\n",
-        % sN output fields are a later slice
-        "BEGIN { OUTFMT = \"s8 i64\" } { writebin $1, $2 }\n",
         % double expression into an i64 slot
         "BEGIN { OUTFMT = \"i64\" } { writebin 1.5 }\n",
         % string field into an i64 slot in binary input mode

--- a/tests/test_plawk_float_slots.pl
+++ b/tests/test_plawk_float_slots.pl
@@ -60,10 +60,25 @@ test(fixpoint_promotes_transitive_reads) :-
         '@printf(i8* %end_f64_fmt_0, double %final_slot_'))),
     !.
 
-test(end_arith_on_double_slot_is_rejected) :-
-    % END i64 arithmetic cannot consume a double slot.
+test(end_arith_on_double_slot_promotes_to_f64) :-
+    % END arithmetic reading a double slot promotes the whole expression
+    % to double and prints %g (was rejected before the f64 END slice).
     plawk_parse_string("{ sum += 0.5 } END { print sum + 1 }\n", Program),
-    assertion(\+ plawk_program_native_driver_ir(Program, 'input.txt', _)).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, ' = fadd double '))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'printed_end_expr_f64_0'))),
+    !.
+
+test(surface_end_f64_average) :-
+    % The classic average: double slot divided by NR, IEEE fdiv, %g print.
+    run_f64_smoke("{ sum += float($2) ; n++ } END { print sum / NR, n * 2, sum + 0.5 }\n",
+        "a 2.5\nb 0.5\nc 1.5\nd 3.5\n",
+        "2 8 8.5\n").
+
+test(surface_end_float_literal_expr) :-
+    run_f64_smoke("{ n++ } END { print n * 1.5 }\n",
+        "a\nb\nc\n",
+        "4.5\n").
 
 test(surface_double_accumulator_text) :-
     run_f64_smoke("{ sum += float($2) * 1.5 ; n++ } END { print n, sum }\n",

--- a/tests/test_plawk_forin_writebin.pl
+++ b/tests/test_plawk_forin_writebin.pl
@@ -1,0 +1,180 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_fwb_marker/0.
+
+user:plawk_fwb_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_forin_writebin, [condition(clang_available)]).
+
+test(parses_forin_writebin_body) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n", Program),
+    Program = program(_, _, [end([for_in(var(k), var(counts), Body)])]),
+    assertion(Body == [writebin([var(k), assoc(var(counts), var(k))])]).
+
+test(forin_writebin_ir_shape) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_wbuf = alloca [16 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_iter_next'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_value_at'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@fwrite('))),
+    % the group loop emits records, not text
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_to_string')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(forin_writebin_rejections) :-
+    Rejects = [
+        % text-mode keys are atom ids: binary input only
+        "BEGIN { OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        % arity mismatch against OUTFMT
+        "BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        % no OUTFMT at all
+        "BEGIN { BINFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        % sN output slice not supported
+        "BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"s8 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_groupby_to_binary_records) :-
+    run_fwb_smoke("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        [5-0, (-3)-0, 5-0, 9-0, (-3)-0, 5-0],
+        [(-3)-2, 5-3, 9-1]).
+
+test(surface_guarded_groupby_to_binary) :-
+    run_fwb_smoke("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } $2 > 100 { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        [5-200, 5-50, 9-300, 5-150],
+        [5-2, 9-1]).
+
+test(surface_groupby_empty_input_writes_nothing) :-
+    run_fwb_smoke("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        [],
+        []).
+
+test(surface_groupby_pipeline_two_stages) :-
+    % Stage 1 groups raw events into (key, count) binary records; stage 2
+    % consumes those records and sums the counts -- binary end to end.
+    build_fwb_probe("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"i64 i64\" } { counts[$1]++ } END { for (k in counts) writebin k, counts[k] }\n",
+        Dir1, Bin1),
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_forin_writebin_b', Dir2),
+    clean_dir(Dir2),
+    make_directory_path(Dir2),
+    directory_file_path(Dir2, 'stage.bin', StagePath),
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" } { total += $2 } END { print total }\n", Program2),
+    plawk_program_native_driver_ir(Program2, StagePath, Driver2),
+    emit_probe(Dir2, Driver2, Bin2),
+    directory_file_path(Dir1, 'input.bin', InputPath),
+    write_pairs(InputPath, [5-0, (-3)-0, 5-0, 9-0, (-3)-0, 5-0]),
+    format(atom(Cmd), '~w > ~w && ~w', [Bin1, StagePath, Bin2]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == "6\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_pairs(Path, Pairs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(A-B, Pairs),
+            ( write_i64_le(Out, A), write_i64_le(Out, B) )),
+        close(Out)).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+decode_pairs(Bytes, Pairs) :-
+    string_codes(Bytes, Codes),
+    decode_pair_codes(Codes, Pairs).
+
+decode_pair_codes([], []).
+decode_pair_codes(Codes, [A-B | Pairs]) :-
+    length(ABytes, 8), length(BBytes, 8),
+    append(ABytes, Rest0, Codes), append(BBytes, Rest, Rest0),
+    le_i64(ABytes, A), le_i64(BBytes, B),
+    decode_pair_codes(Rest, Pairs).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_fwb_marker/0 ],
+        [module_name('plawk_forin_writebin')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk forin writebin build output]~n~w~n", [BuildOut]),
+       throw(plawk_forin_writebin_build_failed(Status))
+    ).
+
+build_fwb_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_forin_writebin', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_fwb_smoke(Source, InputPairs, ExpectedSortedPairs) :-
+    build_fwb_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_pairs(InputPath, InputPairs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    decode_pairs(Bytes, Pairs),
+    msort(Pairs, SortedPairs),
+    msort(ExpectedSortedPairs, SortedExpected),
+    assertion(SortedPairs == SortedExpected),
+    !.
+
+:- end_tests(plawk_forin_writebin).

--- a/tests/test_plawk_outfmt_strings.pl
+++ b/tests/test_plawk_outfmt_strings.pl
@@ -1,0 +1,198 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_ostr_marker/0.
+
+user:plawk_ostr_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_outfmt_strings, [condition(clang_available)]).
+
+test(sN_output_ir_uses_memcpy_memset) :-
+    plawk_parse_string("BEGIN { OUTFMT = \"s8 i64\" } { writebin $1, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    % s8 + i64 = 16-byte records
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_wbuf = alloca [16 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@llvm.memset.p0i8.i64'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@llvm.memcpy.p0i8.p0i8.i64'))),
+    % text-mode source: slice + clamp guard
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_cap = select i1 '))),
+    !.
+
+test(sN_literal_source_ir) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"s4 i64\" } { writebin \"tag\", $1 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'c"tag\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 3, i1 false)'))),
+    !.
+
+test(sN_output_rejections) :-
+    Rejects = [
+        % literal longer than the slot
+        "BEGIN { OUTFMT = \"s4\" } { writebin \"toolong\" }\n",
+        % source field wider than the output slot
+        "BEGIN { BINFMT = \"s8 i64\" ; OUTFMT = \"s4\" } { writebin $1 }\n",
+        % numeric input field into a string slot
+        "BEGIN { BINFMT = \"s8 i64\" ; OUTFMT = \"s8\" } { writebin $2 }\n",
+        % string literal into an i64 slot
+        "BEGIN { OUTFMT = \"i64\" } { writebin \"x\" }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.txt', _))
+        ;  true
+        )).
+
+test(surface_text_to_binary_string_slot) :-
+    % Short values NUL-pad; a value longer than the slot clamps to width.
+    build_ostr_probe("BEGIN { OUTFMT = \"s8 i64\" } { writebin $1, $2 }\n",
+        text("alpha 5\nbee 7\nlongname12 9\n"), Dir, BinPath),
+    run_capture_raw(BinPath, Bytes),
+    decode_s8_i64(Bytes, Records),
+    assertion(Records == ["alpha"-5, "bee"-7, "longname"-9]),
+    assertion(Dir \== ''),
+    !.
+
+test(surface_binary_string_passthrough_with_tag) :-
+    build_ostr_probe("BEGIN { BINFMT = \"s8 i64\" ; OUTFMT = \"s4 s8 i64\" } $2 > 1 { writebin \"tag\", $1, $2 * 2 }\n",
+        s8_i64([rec("alpha", 5), rec("bee", 7)]), _Dir, BinPath),
+    run_capture_raw(BinPath, Bytes),
+    decode_s4_s8_i64(Bytes, Records),
+    assertion(Records == [t("tag", "alpha", 10), t("tag", "bee", 14)]),
+    !.
+
+test(surface_empty_field_writes_zero_slot) :-
+    % A record with fewer fields than referenced: the slot is all zeros.
+    build_ostr_probe("BEGIN { OUTFMT = \"s8 i64\" } { writebin $2, NR }\n",
+        text("one\nalpha beta\n"), _Dir, BinPath),
+    run_capture_raw(BinPath, Bytes),
+    decode_s8_i64(Bytes, Records),
+    assertion(Records == [""-1, "beta"-2]),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_sfield(Out, String, Width) :-
+    string_codes(String, Codes),
+    length(Codes, Len),
+    Len =< Width,
+    forall(member(C, Codes), put_byte(Out, C)),
+    Pad is Width - Len,
+    forall(between(1, Pad, _), put_byte(Out, 0)).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+sfield_string(Codes, String) :-
+    append(Prefix, Suffix, Codes),
+    ( Suffix = [0 | _] ; Suffix = [] ),
+    \+ member(0, Prefix),
+    !,
+    string_codes(String, Prefix).
+
+decode_s8_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_s8_i64_codes(Codes, Records).
+
+decode_s8_i64_codes([], []).
+decode_s8_i64_codes(Codes, [S-V | Records]) :-
+    length(SBytes, 8), length(VBytes, 8),
+    append(SBytes, Rest0, Codes), append(VBytes, Rest, Rest0),
+    sfield_string(SBytes, S),
+    le_i64(VBytes, V),
+    decode_s8_i64_codes(Rest, Records).
+
+decode_s4_s8_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_s4_s8_i64_codes(Codes, Records).
+
+decode_s4_s8_i64_codes([], []).
+decode_s4_s8_i64_codes(Codes, [t(A, B, V) | Records]) :-
+    length(ABytes, 4), length(BBytes, 8), length(VBytes, 8),
+    append(ABytes, Rest0, Codes),
+    append(BBytes, Rest1, Rest0),
+    append(VBytes, Rest, Rest1),
+    sfield_string(ABytes, A),
+    sfield_string(BBytes, B),
+    le_i64(VBytes, V),
+    decode_s4_s8_i64_codes(Rest, Records).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_ostr_marker/0 ],
+        [module_name('plawk_outfmt_strings')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk outfmt strings build output]~n~w~n", [BuildOut]),
+       throw(plawk_outfmt_strings_build_failed(Status))
+    ).
+
+build_ostr_probe(Source, Input, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_outfmt_strings', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    ( Input = text(Text)
+    ->  directory_file_path(Dir, 'input.txt', InputPath),
+        setup_call_cleanup(
+            open(InputPath, write, Out, [encoding(utf8)]),
+            write(Out, Text),
+            close(Out))
+    ;   Input = s8_i64(Recs),
+        directory_file_path(Dir, 'input.bin', InputPath),
+        setup_call_cleanup(
+            open(InputPath, write, Out, [type(binary)]),
+            forall(member(rec(S, V), Recs),
+                ( write_sfield(Out, S, 8), write_i64_le(Out, V) )),
+            close(Out))
+    ),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_capture_raw(BinPath, Bytes) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)).
+
+:- end_tests(plawk_outfmt_strings).


### PR DESCRIPTION
## Why

Same stacked-merge cascade as before: #3414 reached main, but #3415, #3416, and #3417 merged into each other's base branches. This PR brings their union to main in one clean merge — no new content beyond those three already-reviewed PRs:

- **#3415** — binary group-by results as binary records (`for (k in counts) writebin k, counts[k]`)
- **#3416** — f64 END arithmetic (`print sum / NR` on double slots)
- **#3417** — `sN` string slots in OUTFMT

**Merge this into main first**; the DCG binary readers PR stacks on top of it.

Tip for the future: merging the stack bottom-up (the PR based on `main` first, then each next one as GitHub retargets it) avoids these consolidation PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_