### PR TITLE
plawk: bring varlen records (#3419) to main

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -1,0 +1,138 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2026 John William Creighton (@s243a)
+-->
+
+# PLAWK DCG Binary Readers: Grammar-Driven Record Parsing
+
+Phase 3's remaining goal is reading binary formats whose layout is not
+one fixed-size struct: length-prefixed fields, tagged unions,
+repetition. In Prolog terms these are DCGs over byte lists; in PLAWK
+terms they must become **native readers in the AOT-compiled record
+loop** — no interpreter, no allocation per record, constant memory.
+This document fixes the design: which grammar shapes lower to native
+code, what the in-memory contract is, and where the WAM bytecode
+fallback begins.
+
+## The core idea: parse on the wire, fixed layout in memory
+
+The fixed-record pipeline works because every downstream consumer
+(guards, prints, scalar updates, assoc keys, writebin sources) reads
+typed values at compile-time offsets from one record buffer `%rec`.
+The DCG reader design keeps that invariant:
+
+> A grammar-driven reader may consume a *variable* number of bytes from
+> the stream, but it always **materializes the record into the same
+> fixed access layout** that `BINFMT` describes. Wire shape and access
+> shape are decoupled; only the reader knows the wire.
+
+This means the entire existing emitter stack works unchanged over
+grammar-read records. A field's **stored type** (what the reader
+handles) maps to an **access type** (what consumers see):
+
+| stored (wire) type | wire bytes | access type | in-memory slot |
+|---|---|---|---|
+| `i64` | 8 | `i64` | 8 bytes |
+| `f64` | 8 | `f64` | 8 bytes |
+| `sN` | N | `sN` | N bytes |
+| `lpsN` (landed) | 8 + len, len ≤ N | `sN` | N bytes, NUL-padded |
+| tagged union (planned) | 8-byte tag + arm | tag `i64` + widest arm | tag slot + max-arm slot |
+| bounded repetition (planned) | 8-byte count + count×elem, count ≤ K | count `i64` + K elems | count slot + K elem slots |
+
+## The lowering spectrum
+
+A general DCG can do things a streaming native reader cannot
+(unbounded lookahead, backtracking across records, building terms).
+The design splits grammar shapes into three tiers:
+
+**Tier 1 — native, streaming, constant memory (the PLAWK reader).**
+Grammars that are *LL(1) over field boundaries with compile-time size
+bounds*: each field's byte count is known either statically (`i64`,
+`sN`) or from an already-read header (`lpsN` length prefix, a union
+tag, a repetition count), and every variable quantity has a
+compile-time cap so the access layout is fixed. These lower to a
+field-by-field read sequence in the driver loop — straight-line native
+code with one branch per header check. No backtracking exists because
+the format is self-describing left to right. This tier is what PLAWK
+implements, slice by slice.
+
+**Tier 2 — native readers for *record framing*, WAM for interpretation.**
+Formats where the record boundary is Tier-1 but the payload needs real
+parsing (say, a length-prefixed blob containing a nested grammar). The
+loop stays native and hands the payload slice to a compiled Prolog
+predicate through the existing foreign-call bridge (~0.2µs, constant
+memory via heap-top save/restore). The DCG runs as WAM bytecode over
+the byte slice. This tier needs no new machinery — it composes the
+binary reader with `prolog_call`.
+
+**Tier 3 — full DCG fallback (future, Phase 5 adjacent).** Grammars
+with genuine nondeterminism or unbounded structure run entirely as WAM
+bytecode DCGs; the stream feeds them via buffered byte lists. This is
+correct but not streaming-fast, and it is also where the Phase 5
+runtime-DCG JIT would eventually apply: a grammar loaded at runtime
+compiles through the same WAM→LLVM path, promoting Tier-3 rules to
+Tier-1/2 readers on the fly.
+
+The design rule of thumb: **a format specification (`BINFMT`) is a
+degenerate grammar, and each new stored type is one production**
+added to the Tier-1 reader generator. There is no separate "DCG
+engine" in Tier 1 — the grammar is compiled away entirely.
+
+## Slice 1 (landed): length-prefixed strings, `lpsN`
+
+`BEGIN { BINFMT = "i64 lps16" }` declares a record that is 8 fixed
+bytes followed by one length-prefixed string: an 8-byte native-endian
+length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
+
+- **Reader:** records with any `lps` field switch the driver from the
+  one-shot fixed-size read to a *varlen read sequence*
+  (`llvm_emit_varlen_stream_driver_ir/5` + `plawk_varlen_read_ir/3`):
+  each numeric field reads its 8 bytes straight into `%rec` at its
+  access offset; each `lpsN` field reads its length into a shared
+  8-byte scratch alloca, bounds-checks it, zeroes the N-byte slot, and
+  reads the payload into it. Zero-length payloads are free
+  (`@wam_stream_read_record` returns 1 immediately for size 0).
+- **EOF discipline:** clean EOF is legal only before a record's first
+  read (→ END actions run, exit 0). A short read anywhere else in the
+  record — truncated payload, missing fields, an oversized length —
+  exits through `fail_read` (exit 11), exactly like a trailing partial
+  fixed record.
+- **Access:** `lpsN` maps to access type `sN`
+  (`plawk_binfmt_access_type/2`), so prints (`%.*s` via strnlen),
+  equality guards (memcmp + NUL check), and `sN` OUTFMT passthrough
+  work unchanged, and the record buffer size is the sum of *access*
+  widths. i64/f64 fields in the same record keep their arithmetic,
+  guards, assoc-key, and scalar-update roles.
+- **Not in this slice:** `lps` in OUTFMT (writers stay fixed-layout;
+  a varlen writer is the natural next writer slice), and `lps` caps
+  are mandatory — an unbounded string would break the fixed access
+  layout and constant-memory guarantee.
+
+## Planned slices
+
+1. **Tagged unions:** `BINFMT = "i64 union(0: i64 i64 | 1: lps16)"`
+   style — an 8-byte discriminator selects one of several arm layouts;
+   the access layout reserves the widest arm plus the tag as `$K`;
+   guards on the tag route rules per arm. Requires surface syntax
+   design (the awk-flavored form is the open question, e.g. rule
+   patterns like `$tag == 1 { ... }` with per-arm field numbering).
+2. **Bounded repetition:** `count` header + up to K fixed elements;
+   access layout is a count slot plus K element slots; `for` over
+   elements in rule bodies is the surface question.
+3. **Varlen writers:** `lpsN` in OUTFMT emitting length + payload from
+   `sN`/`lpsN` sources — closing the varlen pipeline loop the same way
+   fixed writers did.
+4. **Tier-2 composition sugar:** a declared payload type whose slice is
+   passed to a compiled Prolog DCG via the foreign bridge without
+   hand-written glue.
+
+## Why not a real DCG engine in the loop?
+
+Because the loop's performance contract is the whole point of PLAWK:
+the fixed-record loop measured 5.6× faster than mawk precisely because
+there is no dispatch, no allocation, and no interpretation per record.
+Tier-1 grammars compile to the same shape of code a C programmer would
+write by hand for that format. Anything that genuinely needs
+unification or backtracking already has a home — the WAM interpreter
+in the same binary — and the bridge between the tiers is a function
+call, not an architecture change.

--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -12,6 +12,7 @@ Copyright (c) 2026 John William Creighton (s243a)
 > **Companion docs:** [Philosophy](PLAWK_PHILOSOPHY.md) ·
 > [Specification](PLAWK_SPECIFICATION.md) ·
 > [Execution Architecture](PLAWK_EXECUTION_ARCHITECTURE.md) ·
+> [DCG Binary Readers](PLAWK_DCG_BINARY_READERS.md) ·
 > [Submodule README](../../examples/plawk/README.md)
 
 ---
@@ -498,8 +499,17 @@ group (binary input mode only -- text keys are atom ids). OUTFMT
 accepts `sN` string slots: literals, `sM` input fields (`M <= N`), and
 text-mode slices clamped to the width lower to memset + memcpy against
 the record buffer, so string-carrying binary pipelines work in both
-directions. Remaining
-Phase 3 items below (DCG readers, richer ABIs) are unchanged.
+directions. **Fifth
+slice landed (varlen records / first DCG-reader slice):** `lpsN`
+length-prefixed string fields make records variable-length on the wire
+while keeping the fixed access layout in memory -- the design document
+[PLAWK_DCG_BINARY_READERS.md](PLAWK_DCG_BINARY_READERS.md) fixes the
+general approach (Tier 1: LL(1)-over-fields grammars with compile-time
+caps compile to native field-by-field read sequences; Tier 2: native
+framing + WAM-bytecode payload parsing via the foreign bridge; Tier 3:
+full DCG fallback, the Phase 5 JIT target). Planned next slices there:
+tagged unions, bounded repetition, varlen writers. Remaining Phase 3
+items below (richer ABIs) are otherwise unchanged.
 
 **Second slice landed (typed associative arrays):** in binary mode
 `{ counts[$1]++ }` keys the existing `%WamAssocI64Table` runtime with the

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -90,6 +90,7 @@ swipl -q -s tests/test_plawk_binfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_binary_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_forin_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_outfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_varlen_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -273,7 +274,18 @@ binary mode: `{ counts[$1]++ }` uses the raw field value as the table key
 k, counts[k] }` prints keys numerically, and END lookups take integer
 literals (`print counts[5], counts[-3]`); integer keys are binary-only
 (in text mode they would collide with atom ids, so they are rejected
-there). Fixed-width string fields are in: with
+there). Variable-length records are in via `lpsN`
+(length-prefixed string, 8-byte length + up to N payload bytes):
+`BINFMT = "i64 lps16"` switches to a field-by-field varlen read loop
+that materializes each record into the same fixed access layout, so an
+`lpsN` field behaves exactly like `sN` downstream (prints, equality
+guards, `sN` OUTFMT passthrough) while numeric fields keep guards,
+arithmetic, and assoc keys. Clean EOF is only legal at a record
+boundary; oversized lengths, truncated payloads, and mid-record EOF
+exit with the read-error code. See
+[`docs/design/PLAWK_DCG_BINARY_READERS.md`](../../docs/design/PLAWK_DCG_BINARY_READERS.md)
+for the grammar-to-native-reader lowering design this is the first
+slice of. Fixed-width string fields are in: with
 `BINFMT = "s8 i64"`, `print $1` emits the bytes up to the first NUL or
 the field width (strnlen + `%.*s`, no copying), and `$1 == "ERR"`
 compiles to a memcmp plus a NUL check at the key length (skipped for
@@ -318,6 +330,9 @@ concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see
 - [`docs/design/PLAWK_SPECIFICATION.md`](../../docs/design/PLAWK_SPECIFICATION.md)
 - [`docs/design/PLAWK_IMPLEMENTATION_PLAN.md`](../../docs/design/PLAWK_IMPLEMENTATION_PLAN.md)
 - [`docs/design/PLAWK_EXECUTION_ARCHITECTURE.md`](../../docs/design/PLAWK_EXECUTION_ARCHITECTURE.md)
+- [`docs/design/PLAWK_DCG_BINARY_READERS.md`](../../docs/design/PLAWK_DCG_BINARY_READERS.md)
+  — grammar-driven binary readers: the native/WAM lowering spectrum and
+  the varlen (`lpsN`) reader design.
   — where the system sits on the compiled/JIT/interpreted spectrum: PLAWK
   loops are AOT native code, transpiled Prolog is WAM bytecode on a
   natively compiled interpreter in the same binary, and there is no JIT

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -28,6 +28,7 @@
      llvm_emit_printf0/5,
      llvm_emit_stream_driver_ir/3,
      llvm_emit_binary_stream_driver_ir/4,
+     llvm_emit_varlen_stream_driver_ir/5,
      llvm_emit_ascii_case_slice_print/5]).
 
 %% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
@@ -1847,6 +1848,15 @@ plawk_begin_binfmt_types(BeginClauses, Types) :-
 
 plawk_binfmt_type("i64", i64).
 plawk_binfmt_type("f64", f64).
+% lpsN: a length-prefixed string on the wire (8-byte native-endian
+% length, then that many payload bytes, at most N). The varlen reader
+% materializes it into the record buffer as a fixed NUL-padded N-byte
+% slot, so downstream consumers see it exactly like an sN field.
+plawk_binfmt_type(Part, lps(Cap)) :-
+    string_concat("lps", CapStr, Part),
+    number_string(Cap, CapStr),
+    integer(Cap),
+    Cap > 0.
 % sN: a fixed-width string field of N bytes. Values shorter than N are
 % NUL-terminated inside the field; a full-width value has no NUL.
 plawk_binfmt_type(Part, s(Width)) :-
@@ -1855,14 +1865,29 @@ plawk_binfmt_type(Part, s(Width)) :-
     integer(Width),
     Width > 0.
 
+%% plawk_binfmt_field_type(+Descriptor, +Index, -Type)
+%
+%  The ACCESS type of a field: what guards, prints, assoc keys, and
+%  writers see. lps(Cap) fields access as s(Cap) -- the varlen reader
+%  has already materialized them as fixed NUL-padded slots in the
+%  record buffer.
 plawk_binfmt_field_type(binfmt(Types), Index, Type) :-
     integer(Index),
     Index >= 1,
-    nth1(Index, Types, Type).
+    nth1(Index, Types, StoredType),
+    plawk_binfmt_access_type(StoredType, Type).
+
+plawk_binfmt_access_type(lps(Cap), s(Cap)) :- !.
+plawk_binfmt_access_type(Type, Type).
 
 plawk_binfmt_type_width(i64, 8).
 plawk_binfmt_type_width(f64, 8).
 plawk_binfmt_type_width(s(Width), Width).
+% in-memory width of the materialized slot, not the wire size
+plawk_binfmt_type_width(lps(Cap), Cap).
+
+plawk_binfmt_has_varlen(Types) :-
+    memberchk(lps(_Cap), Types).
 
 plawk_binfmt_field_offset(binfmt(Types), Index, Offset) :-
     PrefixLen is Index - 1,
@@ -2132,12 +2157,14 @@ plawk_writebin_slot_lines(f64, Field, FieldSeparator, Base, BasePtr, Offset,
 
 plawk_writebin_numeric_store_lines(LLVMType, ValueIR, Base, BasePtr, Offset,
         [Gep, Cast, Store]) :-
+    % _sp/_stp, not _fp/_tp: a bare $N argument's binfmt field LOAD
+    % already claims Base_fp/Base_tp for the read from %rec.
     format(atom(Gep),
-        '  %~w_fp = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
+        '  %~w_sp = getelementptr i8, i8* ~w, i64 ~w', [Base, BasePtr, Offset]),
     format(atom(Cast),
-        '  %~w_tp = bitcast i8* %~w_fp to ~w*', [Base, Base, LLVMType]),
+        '  %~w_stp = bitcast i8* %~w_sp to ~w*', [Base, Base, LLVMType]),
     format(atom(Store),
-        '  store ~w ~w, ~w* %~w_tp, align 1',
+        '  store ~w ~w, ~w* %~w_stp, align 1',
         [LLVMType, ValueIR, LLVMType, Base]).
 
 plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
@@ -2161,11 +2188,138 @@ plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
 %  Pick the stream skeleton by record representation: text lines or
 %  fixed-size binary records.
 plawk_emit_record_driver_ir(binfmt(Types), InputPath, Blocks, DriverIR) :-
+    plawk_binfmt_has_varlen(Types),
+    !,
+    plawk_binfmt_record_size(binfmt(Types), BufSize),
+    plawk_normalize_driver_blocks(Blocks,
+        driver_blocks(RuntimeGlobals, EntrySetupIR0, LoopPhiIR, LoweredLabel,
+            RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR)),
+    % one shared 8-byte scratch for every lps length prefix
+    plawk_combine_entry_ir(EntrySetupIR0,
+'  %vr_len_scratch = alloca i64, align 8
+  %vr_len_i8 = bitcast i64* %vr_len_scratch to i8*',
+        EntrySetupIR),
+    plawk_varlen_read_ir(Types, LoweredLabel, ReadIR),
+    llvm_emit_varlen_stream_driver_ir(InputPath, BufSize, ReadIR,
+        driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel,
+            RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
+        DriverIR).
+plawk_emit_record_driver_ir(binfmt(Types), InputPath, Blocks, DriverIR) :-
     !,
     plawk_binfmt_record_size(binfmt(Types), RecordSize),
     llvm_emit_binary_stream_driver_ir(InputPath, RecordSize, Blocks, DriverIR).
 plawk_emit_record_driver_ir(_FieldSeparator, InputPath, Blocks, DriverIR) :-
     llvm_emit_stream_driver_ir(InputPath, Blocks, DriverIR).
+
+plawk_normalize_driver_blocks(
+    driver_blocks(RuntimeGlobals, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, CloseOkLabel, CloseOkIR),
+    driver_blocks(RuntimeGlobals, '', LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, '', CloseOkLabel, CloseOkIR)) :-
+    !.
+plawk_normalize_driver_blocks(
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel,
+        RecordIR, ContinueIR, CloseOkLabel, CloseOkIR),
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel,
+        RecordIR, ContinueIR, '', CloseOkLabel, CloseOkIR)) :-
+    !.
+plawk_normalize_driver_blocks(Blocks, Blocks).
+
+%% plawk_varlen_read_ir(+Types, +LoweredLabel, -ReadIR)
+%
+%  Field-by-field read sequence for variable-length records. The first
+%  read of a record is the only place clean EOF is legal (branching to
+%  close_stream); running out of bytes anywhere later in the record is
+%  a partial record and exits through fail_read, matching the
+%  fixed-record skeleton's trailing-partial semantics. Numeric fields
+%  read their 8 bytes straight into the record buffer; lps(Cap) fields
+%  read the 8-byte length into the shared scratch, bound it by Cap,
+%  zero the slot, then read the payload (a zero length reads nothing:
+%  @wam_stream_read_record returns 1 immediately for size 0).
+plawk_varlen_read_ir(Types, LoweredLabel, ReadIR) :-
+    plawk_varlen_field_sections(Types, LoweredLabel, 0, 0, Sections),
+    atomic_list_concat(Sections, '\n', ReadIR).
+
+plawk_varlen_field_sections([], _LoweredLabel, _Index, _Offset, []).
+plawk_varlen_field_sections([Type | Types], LoweredLabel, Index, Offset,
+        [Section | Sections]) :-
+    ( Types == []
+    -> NextLabel = LoweredLabel
+    ;  NextIndex0 is Index + 1,
+       format(atom(NextLabel), 'vr_f~w', [NextIndex0])
+    ),
+    ( Index =:= 0
+    -> LabelIR = ''
+    ;  format(atom(LabelIR), 'vr_f~w:~n', [Index])
+    ),
+    plawk_varlen_field_body(Type, Index, Offset, NextLabel, BodyIR),
+    format(atom(Section), '~w~w', [LabelIR, BodyIR]),
+    plawk_binfmt_type_width(Type, Width),
+    NextOffset is Offset + Width,
+    NextIndex is Index + 1,
+    plawk_varlen_field_sections(Types, LoweredLabel, NextIndex, NextOffset,
+        Sections).
+
+plawk_varlen_field_body(lps(Cap), Index, Offset, NextLabel, BodyIR) :-
+    !,
+    plawk_varlen_eof_check_ir(Index, lstatus, BodyPrefixIR, OkLabelIR),
+    format(atom(BodyIR),
+'  %vr_f~w_lstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %vr_len_i8)
+~w~w  %vr_f~w_lok = icmp eq i64 %vr_f~w_lstatus, 1
+  br i1 %vr_f~w_lok, label %vr_f~w_len, label %fail_read
+
+vr_f~w_len:
+  %vr_f~w_n = load i64, i64* %vr_len_scratch
+  %vr_f~w_fits = icmp ule i64 %vr_f~w_n, ~w
+  br i1 %vr_f~w_fits, label %vr_f~w_read, label %fail_read
+
+vr_f~w_read:
+  %vr_f~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  call void @llvm.memset.p0i8.i64(i8* %vr_f~w_dst, i8 0, i64 ~w, i1 false)
+  %vr_f~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %vr_f~w_n, i8* %vr_f~w_dst)
+  %vr_f~w_pok = icmp eq i64 %vr_f~w_pstatus, 1
+  br i1 %vr_f~w_pok, label %~w, label %fail_read
+',
+        [Index,
+         BodyPrefixIR, OkLabelIR, Index, Index,
+         Index, Index,
+         Index,
+         Index,
+         Index, Index, Cap,
+         Index, Index,
+         Index,
+         Index, Offset,
+         Index, Cap,
+         Index, Index, Index,
+         Index, Index,
+         Index, NextLabel]).
+plawk_varlen_field_body(_NumericType, Index, Offset, NextLabel, BodyIR) :-
+    plawk_varlen_eof_check_ir(Index, status, BodyPrefixIR, OkLabelIR),
+    format(atom(BodyIR),
+'  %vr_f~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  %vr_f~w_status = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %vr_f~w_dst)
+~w~w  %vr_f~w_ok = icmp eq i64 %vr_f~w_status, 1
+  br i1 %vr_f~w_ok, label %~w, label %fail_read
+',
+        [Index, Offset,
+         Index, Index,
+         BodyPrefixIR, OkLabelIR, Index, Index,
+         Index, NextLabel]).
+
+% Only the record's first read may see clean EOF (status 0). Later
+% fields fall straight through to the 1/other check, where 0 lands in
+% fail_read like any short read.
+plawk_varlen_eof_check_ir(0, StatusSuffix, BodyPrefixIR, OkLabelIR) :-
+    !,
+    format(atom(BodyPrefixIR),
+'  %vr_f0_eof = icmp eq i64 %vr_f0_~w, 0
+  br i1 %vr_f0_eof, label %close_stream, label %vr_f0_chk
+
+vr_f0_chk:
+',
+        [StatusSuffix]),
+    OkLabelIR = ''.
+plawk_varlen_eof_check_ir(_Index, _StatusSuffix, '', '').
 
 plawk_output_separator(BeginClauses, OutputSeparator) :-
     (   member(begin(Actions), BeginClauses),

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -64,6 +64,7 @@
     llvm_emit_printf0/5,                 % +FmtGlobal, +FmtLen, +FmtVar, +PrintVar, -Parts
     llvm_emit_stream_driver_ir/3,        % +InputPath, +DriverBlocks, -DriverIR
     llvm_emit_binary_stream_driver_ir/4, % +InputPath, +RecordSize, +DriverBlocks, -DriverIR
+    llvm_emit_varlen_stream_driver_ir/5, % +InputPath, +BufSize, +ReadIR, +DriverBlocks, -DriverIR
     llvm_emit_ascii_case_slice_print/5   % +Mode, +PtrIR, +LenIR, +PrintBase, -CallIR
 ]).
 
@@ -18307,6 +18308,173 @@ fail_close:
         [PathGlobalIR, RuntimeGlobals,
          BytesLen, BytesLen, PathLen, EntrySetupIR, RecordSize, LoopPhiIR,
          RecordSize, LoweredLabel, LoweredLabel, RecordIR, ContinueIR,
+         BreakCloseIR, CloseOkLabel, CloseOkIR]).
+
+%% llvm_emit_varlen_stream_driver_ir(+InputPath, +BufSize, +ReadIR,
+%%     +DriverBlocks, -DriverIR)
+%
+%  Variable-length sibling of llvm_emit_binary_stream_driver_ir: instead
+%  of one fixed-size @wam_stream_read_record call, the caller supplies
+%  ReadIR -- a field-by-field read sequence that materializes one record
+%  into the BufSize-byte %rec buffer and ends by branching to the
+%  lowered label (or %close_stream on clean EOF at a record boundary /
+%  %fail_read on a short read). Block labels match the fixed skeletons
+%  so loop phis and lowered blocks work unchanged.
+llvm_emit_varlen_stream_driver_ir(
+    stdin_or_argv,
+    BufSize,
+    ReadIR,
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel,
+        RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    !,
+    format(atom(DriverIR),
+'@.wam_stream_stdin_dash = private constant [2 x i8] c"-\00"
+~w
+
+define i32 @main(i32 %argc, i8** %argv) {
+entry:
+~w
+  %rec = call i8* @malloc(i64 ~w)
+  %rec_null = icmp eq i8* %rec, null
+  br i1 %rec_null, label %fail_open, label %pick_input
+
+pick_input:
+  %have_arg = icmp sgt i32 %argc, 1
+  br i1 %have_arg, label %check_argv_path, label %use_stdin
+
+check_argv_path:
+  %argv1_ptr = getelementptr i8*, i8** %argv, i64 1
+  %argv1 = load i8*, i8** %argv1_ptr
+  %dash_ptr = getelementptr [2 x i8], [2 x i8]* @.wam_stream_stdin_dash, i32 0, i32 0
+  %dash_cmp = call i32 @strcmp(i8* %argv1, i8* %dash_ptr)
+  %is_dash = icmp eq i32 %dash_cmp, 0
+  br i1 %is_dash, label %use_stdin, label %open_argv_file
+
+open_argv_file:
+  %argv1_len = call i64 @strlen(i8* %argv1)
+  %path_id = call i64 @wam_intern_atom(i8* %argv1, i64 %argv1_len)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %file_handle = call %Value @wam_stream_open_value(%Value %path)
+  br label %have_handle
+
+use_stdin:
+  %stdin_handle = call %Value @wam_stream_open_fd_value(i64 0)
+  br label %have_handle
+
+have_handle:
+  %handle = phi %Value [ %file_handle, %open_argv_file ], [ %stdin_handle, %use_stdin ]
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+~w
+~w
+
+~w:
+~w
+
+continue_loop:
+~w
+  br label %loop
+
+~w
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %~w, label %fail_close
+
+~w
+
+fail_open:
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_close:
+  ret i32 16
+}
+',
+        [RuntimeGlobals, EntrySetupIR, BufSize, LoopPhiIR, ReadIR,
+         LoweredLabel, RecordIR, ContinueIR, BreakCloseIR,
+         CloseOkLabel, CloseOkIR]).
+
+llvm_emit_varlen_stream_driver_ir(
+    InputPath,
+    BufSize,
+    ReadIR,
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel,
+        RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    llvm_emit_c_string_global(wam_stream_input_path, InputPath, PathGlobalIR, PathLen, BytesLen),
+    format(atom(DriverIR),
+'~w
+~w
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.wam_stream_input_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+~w
+  %rec = call i8* @malloc(i64 ~w)
+  %rec_null = icmp eq i8* %rec, null
+  br i1 %rec_null, label %fail_open, label %open_stream
+
+open_stream:
+  %handle = call %Value @wam_stream_open_value(%Value %path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+~w
+~w
+
+~w:
+~w
+
+continue_loop:
+~w
+  br label %loop
+
+~w
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %~w, label %fail_close
+
+~w
+
+fail_open:
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_close:
+  ret i32 16
+}
+',
+        [PathGlobalIR, RuntimeGlobals,
+         BytesLen, BytesLen, PathLen, EntrySetupIR, BufSize, LoopPhiIR,
+         ReadIR, LoweredLabel, RecordIR, ContinueIR,
          BreakCloseIR, CloseOkLabel, CloseOkIR]).
 
 %% llvm_emit_ascii_case_slice_print(+Mode, +PtrIR, +LenIR, +PrintBase, -CallIR)

--- a/tests/test_plawk_varlen_records.pl
+++ b/tests/test_plawk_varlen_records.pl
@@ -1,0 +1,209 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_vlr_marker/0.
+
+user:plawk_vlr_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_varlen_records, [condition(clang_available)]).
+
+test(varlen_ir_uses_field_by_field_reads) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 lps16\" } $1 > 10 { c++ } END { print c }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % access layout: 8 + 16 = 24-byte buffer
+    assertion(once(sub_atom(DriverIR, _, _, _, 'malloc(i64 24)'))),
+    % shared length scratch + per-field reads instead of one fixed read
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_len_scratch = alloca i64'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 8, i8* %vr_f0_dst'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 8, i8* %vr_len_i8'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_f1_fits = icmp ule i64 %vr_f1_n, 16'))),
+    % only the record's first read may hit clean EOF
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_f0_eof'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '%vr_f1_eof')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(fixed_layouts_keep_single_read_skeleton) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 s16\" } $1 > 10 { c++ } END { print c }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 24, i8* %rec'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'vr_len_scratch')),
+    !.
+
+test(surface_varlen_guard_print_equality) :-
+    run_vlr_smoke("BEGIN { BINFMT = \"i64 lps16\" } $1 > 10 { hits++ ; print $2, $1 } $2 == \"skipme\" { skips++ } END { print hits, skips }\n",
+        [rec(5, "small"), rec(20, "hello"), rec(30, ""), rec(40, "exactly16bytes!!"), rec(7, "skipme")],
+        "hello 20\n 30\nexactly16bytes!! 40\n3 1\n").
+
+test(surface_varlen_groupby) :-
+    run_vlr_sorted_smoke("BEGIN { BINFMT = \"i64 lps8\" } { counts[$1]++ } END { for (k in counts) print k, counts[k] }\n",
+        [rec(5, "a"), rec(9, "bb"), rec(5, "ccc"), rec(5, "")],
+        ["5 3", "9 1"]).
+
+test(surface_varlen_to_fixed_binary_writer) :-
+    % lps input accesses as sN, so it flows into a fixed sN output slot.
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_varlen_records', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string("BEGIN { BINFMT = \"i64 lps8\" ; OUTFMT = \"s8 i64\" } $1 > 10 { writebin $2, $1 }\n", Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath),
+    write_vlr_records(InputPath, [rec(5, "aa"), rec(20, "bee"), rec(40, "longnam8")]),
+    run_capture_raw(BinPath, Bytes, exit(0)),
+    decode_s8_i64(Bytes, Records),
+    assertion(Records == ["bee"-20, "longnam8"-40]),
+    !.
+
+test(surface_varlen_error_paths) :-
+    build_vlr_probe("BEGIN { BINFMT = \"i64 lps16\" } { c++ } END { print c }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    % oversized length prefix (17 > 16)
+    write_raw(InputPath, [i64(20), i64(17), bytes("xxxxxxxxxxxxxxxxx")]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % truncated payload (claims 10, has 4)
+    write_raw(InputPath, [i64(20), i64(10), bytes("abcd")]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % EOF mid-record (numeric field then nothing)
+    write_raw(InputPath, [i64(20)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % empty input is a clean EOF: END runs
+    write_raw(InputPath, []),
+    run_capture_raw(BinPath, Out, exit(0)),
+    assertion(Out == "0\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_raw(Path, Items) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Item, Items),
+            ( Item = i64(V) -> write_i64_le(Out, V)
+            ; Item = bytes(S) -> ( string_codes(S, Cs),
+                                   forall(member(C, Cs), put_byte(Out, C)) )
+            )),
+        close(Out)).
+
+% one record: 8-byte i64, 8-byte length, payload
+write_vlr_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(V, S), Recs),
+            ( write_i64_le(Out, V),
+              string_codes(S, Codes),
+              length(Codes, Len),
+              write_i64_le(Out, Len),
+              forall(member(C, Codes), put_byte(Out, C)) )),
+        close(Out)).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+sfield_string(Codes, String) :-
+    append(Prefix, Suffix, Codes),
+    ( Suffix = [0 | _] ; Suffix = [] ),
+    \+ member(0, Prefix),
+    !,
+    string_codes(String, Prefix).
+
+decode_s8_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_s8_i64_codes(Codes, Records).
+
+decode_s8_i64_codes([], []).
+decode_s8_i64_codes(Codes, [S-V | Records]) :-
+    length(SBytes, 8), length(VBytes, 8),
+    append(SBytes, Rest0, Codes), append(VBytes, Rest, Rest0),
+    sfield_string(SBytes, S),
+    le_i64(VBytes, V),
+    decode_s8_i64_codes(Rest, Records).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_vlr_marker/0 ],
+        [module_name('plawk_varlen_records')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk varlen records build output]~n~w~n", [BuildOut]),
+       throw(plawk_varlen_records_build_failed(Status))
+    ).
+
+build_vlr_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_varlen_records', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_capture_raw(BinPath, Bytes, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+run_vlr_smoke(Source, Recs, ExpectedOutput) :-
+    build_vlr_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_vlr_records(InputPath, Recs),
+    run_capture_raw(BinPath, OutStr, exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.
+
+run_vlr_sorted_smoke(Source, Recs, ExpectedLines) :-
+    build_vlr_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_vlr_records(InputPath, Recs),
+    run_capture_raw(BinPath, OutStr, exit(0)),
+    split_string(OutStr, "\n", "", Split0),
+    exclude(==(""), Split0, Lines0),
+    msort(Lines0, SortedLines),
+    msort(ExpectedLines, SortedExpected),
+    assertion(SortedLines == SortedExpected),
+    !.
+
+:- end_tests(plawk_varlen_records).


### PR DESCRIPTION
## Why

#3419 (variable-length `lpsN` records + the DCG binary readers design doc) merged into this branch rather than main — one level short of the cascade again. This PR carries exactly that content to main; no new work.

**Merge this first**; the varlen-writers and tagged-union PRs stack on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_