### PR TITLE
plawk: lpsN in OUTFMT (varlen writers)

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -119,9 +119,13 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
 2. **Bounded repetition:** `count` header + up to K fixed elements;
    access layout is a count slot plus K element slots; `for` over
    elements in rule bodies is the surface question.
-3. **Varlen writers:** `lpsN` in OUTFMT emitting length + payload from
-   `sN`/`lpsN` sources — closing the varlen pipeline loop the same way
-   fixed writers did.
+3. **Varlen writers (landed):** `lpsN` in OUTFMT emits the 8-byte
+   length plus exactly the payload bytes, sourced from literals,
+   `sM`/`lpsM` input fields (`M ≤ cap`), or text-mode slices clamped to
+   the cap. Records with an lps slot switch from the single-buffer
+   fwrite to per-slot fwrites emitted left to right (buffered in libc,
+   so still memcpy cost per record). Writer output is byte-compatible
+   with the `lpsN` reader.
 4. **Tier-2 composition sugar:** a declared payload type whose slice is
    passed to a compiled Prolog DCG via the foreign bridge without
    hand-written glue.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -91,6 +91,7 @@ swipl -q -s tests/test_plawk_binary_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_forin_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_outfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_varlen_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_varlen_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -282,7 +283,11 @@ that materializes each record into the same fixed access layout, so an
 guards, `sN` OUTFMT passthrough) while numeric fields keep guards,
 arithmetic, and assoc keys. Clean EOF is only legal at a record
 boundary; oversized lengths, truncated payloads, and mid-record EOF
-exit with the read-error code. See
+exit with the read-error code. `lpsN` also works in OUTFMT: writebin emits the
+8-byte length plus exactly the payload bytes (no padding), sourcing
+from literals, `sM`/`lpsM` input fields, or text-mode slices clamped to
+the cap - writer output is byte-compatible with the `lpsN` reader, so
+varlen plawk-to-plawk pipelines round-trip. See
 [`docs/design/PLAWK_DCG_BINARY_READERS.md`](../../docs/design/PLAWK_DCG_BINARY_READERS.md)
 for the grammar-to-native-reader lowering design this is the first
 slice of. Fixed-width string fields are in: with

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1733,6 +1733,9 @@ plawk_binfmt_writebin_args_ok(Descriptor, [f64 | Types], [Field | Fields]) :-
 plawk_binfmt_writebin_args_ok(Descriptor, [s(Width) | Types], [Field | Fields]) :-
     plawk_binfmt_writebin_str_ok(Descriptor, Field, Width),
     plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+plawk_binfmt_writebin_args_ok(Descriptor, [lps(Cap) | Types], [Field | Fields]) :-
+    plawk_binfmt_writebin_str_ok(Descriptor, Field, Cap),
+    plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
 
 plawk_binfmt_writebin_str_ok(_Descriptor, string(Value), Width) :-
     !,
@@ -1914,7 +1917,7 @@ plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules, WritebinPlan) :-
     ( plawk_rules_have_writebin(Rules0)
     ->  plawk_begin_outfmt_types(BeginClauses, Types),
         forall(member(Type, Types),
-            ( memberchk(Type, [i64, f64]) ; Type = s(_Width) )),
+            ( memberchk(Type, [i64, f64]) ; Type = s(_W) ; Type = lps(_C) )),
         plawk_binfmt_record_size(binfmt(Types), Size),
         WritebinPlan = outfmt(Types, Size),
         maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules)
@@ -1997,6 +2000,8 @@ plawk_writebin_args_ok([Type | Types], [Field | Fields]) :-
     -> plawk_writebin_i64_arg(Field)
     ;  Type = s(Width)
     -> plawk_writebin_str_arg(Field, Width)
+    ;  Type = lps(Cap)
+    -> plawk_writebin_str_arg(Field, Cap)
     ;  plawk_writebin_f64_arg(Field)
     ),
     plawk_writebin_args_ok(Types, Fields).
@@ -2029,6 +2034,15 @@ plawk_writebin_f64_arg(Field) :-
 %  Evaluate each argument, store it at its layout offset in the shared
 %  %plawk_wbuf buffer, then fwrite the record to stdout.
 plawk_writebin_record_ir(Types, Fields, Slots, Values, FieldSeparator,
+        Prefix, Pair) :-
+    ( plawk_binfmt_has_varlen(Types)
+    ->  plawk_writebin_varlen_record_ir(Types, Fields, Slots, Values,
+            FieldSeparator, Prefix, Pair)
+    ;   plawk_writebin_fixed_record_ir(Types, Fields, Slots, Values,
+            FieldSeparator, Prefix, Pair)
+    ).
+
+plawk_writebin_fixed_record_ir(Types, Fields, Slots, Values, FieldSeparator,
         Prefix, GlobalIR-IR) :-
     plawk_binfmt_record_size(binfmt(Types), Size),
     format(atom(BasePtr), '%~w_base', [Prefix]),
@@ -2045,6 +2059,129 @@ plawk_writebin_record_ir(Types, Fields, Slots, Values, FieldSeparator,
     append([[BaseLine], FieldLines, [StdoutLoad, WriteCall]], AllLines),
     atomic_list_concat(AllLines, '\n', IR),
     atomic_list_concat(GlobalParts, '\n', GlobalIR).
+
+%% plawk_writebin_varlen_record_ir(+Types, +Fields, +Slots, +Values,
+%%     +FieldSeparator, +Prefix, -Pair)
+%
+%  Records whose OUTFMT contains an lps slot are variable-length on the
+%  wire, so the single-buffer fwrite becomes per-slot fwrites emitted
+%  strictly left to right (fwrite buffers in libc, so this is memcpy
+%  cost, not syscall cost). Numeric slots stage their value in the
+%  first 8 bytes of %plawk_wbuf; lps slots write their runtime length
+%  the same way, then the payload straight from its source bytes.
+plawk_writebin_varlen_record_ir(Types, Fields, Slots, Values, FieldSeparator,
+        Prefix, GlobalIR-IR) :-
+    plawk_binfmt_record_size(binfmt(Types), Size),
+    format(atom(BasePtr), '%~w_base', [Prefix]),
+    format(atom(BaseLine),
+        '  ~w = getelementptr inbounds [~w x i8], [~w x i8]* %plawk_wbuf, i32 0, i32 0',
+        [BasePtr, Size, Size]),
+    format(atom(StdoutLoad),
+        '  %~w_stdout = load i8*, i8** @stdout', [Prefix]),
+    format(atom(StdoutVar), '%~w_stdout', [Prefix]),
+    plawk_writebin_varlen_field_lines(Types, Fields, Slots, Values,
+        FieldSeparator, Prefix, BasePtr, StdoutVar, 0, FieldLines, GlobalParts),
+    append([[BaseLine, StdoutLoad], FieldLines], AllLines),
+    atomic_list_concat(AllLines, '\n', IR),
+    atomic_list_concat(GlobalParts, '\n', GlobalIR).
+
+plawk_writebin_varlen_field_lines([], [], _Slots, _Values, _FieldSeparator,
+        _Prefix, _BasePtr, _Stdout, _Index, [], []).
+plawk_writebin_varlen_field_lines([Type | Types], [Field0 | Fields], Slots,
+        Values, FieldSeparator, Prefix, BasePtr, Stdout, Index, Lines,
+        GlobalParts) :-
+    plawk_substitute_scalar_reads(Field0, Slots, Values, Field),
+    format(atom(Base), '~w_f~w', [Prefix, Index]),
+    plawk_writebin_varlen_slot_lines(Type, Field, FieldSeparator, Base,
+        BasePtr, Stdout, SlotLines, GParts),
+    NextIndex is Index + 1,
+    plawk_writebin_varlen_field_lines(Types, Fields, Slots, Values,
+        FieldSeparator, Prefix, BasePtr, Stdout, NextIndex, RestLines,
+        RestGlobals),
+    append(SlotLines, RestLines, Lines),
+    append(GParts, RestGlobals, GlobalParts).
+
+plawk_writebin_varlen_slot_lines(lps(Cap), Field, FieldSeparator, Base,
+        BasePtr, Stdout, Lines, GParts) :-
+    !,
+    plawk_writebin_lps_source_lines(Field, FieldSeparator, Cap, Base,
+        BasePtr, PtrIR, LenIR, SourceLines, GParts),
+    format(atom(LenStore),
+'  %~w_lensp = bitcast i8* ~w to i64*
+  store i64 ~w, i64* %~w_lensp, align 1
+  %~w_lwr = call i64 @fwrite(i8* ~w, i64 8, i64 1, i8* ~w)',
+        [Base, BasePtr, LenIR, Base, Base, BasePtr, Stdout]),
+    format(atom(PayloadWrite),
+        '  %~w_pwr = call i64 @fwrite(i8* ~w, i64 ~w, i64 1, i8* ~w)',
+        [Base, PtrIR, LenIR, Stdout]),
+    append(SourceLines, [LenStore, PayloadWrite], Lines).
+plawk_writebin_varlen_slot_lines(Type, Field, FieldSeparator, Base, BasePtr,
+        Stdout, Lines, GParts) :-
+    % numeric slot: stage the value in the scratch buffer, write 8 bytes
+    ( Type == i64
+    ->  plawk_i64_expr_ir(Field, FieldSeparator, Base, Base, ValueIR,
+            GParts, SetupParts),
+        LLVMType = i64
+    ;   plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
+            GParts, SetupParts),
+        LLVMType = double
+    ),
+    format(atom(StoreWrite),
+'  %~w_sp = bitcast i8* ~w to ~w*
+  store ~w ~w, ~w* %~w_sp, align 1
+  %~w_wr = call i64 @fwrite(i8* ~w, i64 8, i64 1, i8* ~w)',
+        [Base, BasePtr, LLVMType, LLVMType, ValueIR, LLVMType, Base,
+         Base, BasePtr, Stdout]),
+    append(SetupParts, [StoreWrite], Lines).
+
+%% plawk_writebin_lps_source_lines(+Field, +FieldSeparator, +Cap, +Base,
+%%     +BasePtr, -PtrIR, -LenIR, -Lines, -GlobalParts)
+%
+%  Resolve an lps payload source to a (pointer, runtime length) pair.
+%  lps payloads are string-valued: source bytes run to the first NUL or
+%  the source bound, clamped to the slot cap.
+plawk_writebin_lps_source_lines(string(Value), _FieldSeparator, Cap, Base,
+        _BasePtr, PtrIR, StringLen, [PtrLine], [GlobalLine]) :-
+    !,
+    format(atom(LitGlobal), '~w_lit', [Base]),
+    llvm_emit_c_string_global(LitGlobal, Value, GlobalLine, StringLen, BytesLen),
+    StringLen =< Cap,
+    format(atom(PtrIR), '%~w_src', [Base]),
+    format(atom(PtrLine),
+        '  ~w = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
+        [PtrIR, BytesLen, BytesLen, LitGlobal]).
+plawk_writebin_lps_source_lines(field(FieldIndex), binfmt(Types), Cap, Base,
+        _BasePtr, PtrIR, LenIR, [PtrLine, LenLine], []) :-
+    !,
+    plawk_binfmt_field_type(binfmt(Types), FieldIndex, s(SourceWidth)),
+    SourceWidth =< Cap,
+    plawk_binfmt_field_offset(binfmt(Types), FieldIndex, SourceOffset),
+    format(atom(PtrIR), '%~w_src', [Base]),
+    format(atom(LenIR), '%~w_len', [Base]),
+    format(atom(PtrLine),
+        '  ~w = getelementptr i8, i8* %rec, i64 ~w', [PtrIR, SourceOffset]),
+    format(atom(LenLine),
+        '  ~w = call i64 @strnlen(i8* ~w, i64 ~w)',
+        [LenIR, PtrIR, SourceWidth]).
+plawk_writebin_lps_source_lines(field(FieldIndex), FieldSeparator, Cap, Base,
+        BasePtr, PtrIR, LenIR, [SliceIR, ClampIR], []) :-
+    FieldIndex >= 1,
+    llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base,
+        SliceIR),
+    format(atom(PtrIR), '%~w_srcp', [Base]),
+    format(atom(LenIR), '%~w_srclen', [Base]),
+    % a missing field (null slice) writes length 0 with a safe pointer
+    format(atom(ClampIR),
+'  %~w_null = icmp eq i8* %~w_ptr, null
+  %~w_len0 = select i1 %~w_null, i64 0, i64 %~w_len64
+  %~w_over = icmp ugt i64 %~w_len0, ~w
+  ~w = select i1 %~w_over, i64 ~w, i64 %~w_len0
+  ~w = select i1 %~w_null, i8* ~w, i8* %~w_ptr',
+        [Base, Base,
+         Base, Base, Base,
+         Base, Base, Cap,
+         LenIR, Base, Cap, Base,
+         PtrIR, Base, BasePtr, Base]).
 
 plawk_writebin_field_lines([], [], _Slots, _Values, _FieldSeparator, _Prefix,
         _BasePtr, _Index, _Offset, [], []).

--- a/tests/test_plawk_varlen_writers.pl
+++ b/tests/test_plawk_varlen_writers.pl
@@ -1,0 +1,215 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_vlw_marker/0.
+
+user:plawk_vlw_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_varlen_writers, [condition(clang_available)]).
+
+test(varlen_outfmt_ir_uses_per_slot_fwrites) :-
+    plawk_parse_string("BEGIN { OUTFMT = \"lps16 i64\" } { writebin $1, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    % lps slot: one fwrite for the length, one for the payload; numeric
+    % slot: one staged fwrite. No single whole-record fwrite.
+    assertion(once(sub_atom(DriverIR, _, _, _, '_lwr = call i64 @fwrite('))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_pwr = call i64 @fwrite('))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_wr = call i64 @fwrite('))),
+    % text-mode source: slice + null guard + cap clamp
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_over = icmp ugt i64 '))),
+    !.
+
+test(fixed_outfmt_keeps_single_record_fwrite) :-
+    plawk_parse_string("BEGIN { OUTFMT = \"s16 i64\" } { writebin $1, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 24, i64 1, i8*'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '_lwr = ')),
+    !.
+
+test(varlen_writer_rejections) :-
+    Rejects = [
+        % literal longer than the cap
+        "BEGIN { OUTFMT = \"lps4\" } { writebin \"toolong\" }\n",
+        % source cap wider than the output cap
+        "BEGIN { BINFMT = \"lps8 i64\" ; OUTFMT = \"lps4\" } { writebin $1 }\n",
+        % numeric input field into an lps slot
+        "BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"lps8\" } { writebin $1 }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.txt', _))
+        ;  true
+        )).
+
+test(surface_text_to_varlen_exact_lengths) :-
+    % Wire lengths are exact: no padding for short values, no clamp
+    % needed at exactly the cap.
+    build_vlw_probe("BEGIN { OUTFMT = \"lps16 i64\" } { writebin $1, $2 }\n",
+        text("alpha 5\nverylongname1234 7\n"), _Dir, BinPath),
+    run_capture_raw(BinPath, Bytes, exit(0)),
+    decode_lps_i64(Bytes, Records),
+    assertion(Records == ["alpha"-5, "verylongname1234"-7]),
+    !.
+
+test(surface_text_clamps_to_cap) :-
+    build_vlw_probe("BEGIN { OUTFMT = \"lps4 i64\" } { writebin $1, NR }\n",
+        text("longvalue x\nab y\n"), _Dir, BinPath),
+    run_capture_raw(BinPath, Bytes, exit(0)),
+    decode_lps_i64(Bytes, Records),
+    assertion(Records == ["long"-1, "ab"-2]),
+    !.
+
+test(surface_varlen_transform_with_literal_and_empty) :-
+    build_vlw_probe("BEGIN { BINFMT = \"i64 lps8\" ; OUTFMT = \"lps4 lps8 i64\" } $1 > 10 { writebin \"tag\", $2, $1 * 2 }\n",
+        lps_recs([rec(5, "aa"), rec(20, "bee"), rec(40, "")]), _Dir, BinPath),
+    run_capture_raw(BinPath, Bytes, exit(0)),
+    decode_lps_lps_i64(Bytes, Records),
+    assertion(Records == [t("tag", "bee", 40), t("tag", "", 80)]),
+    !.
+
+test(surface_varlen_round_trip) :-
+    % Writer output is byte-compatible with the varlen READER: stage 1
+    % converts text to lps16 records, stage 2 reads them back with
+    % BINFMT and aggregates.
+    build_vlw_probe("BEGIN { OUTFMT = \"lps16 i64\" } { writebin $1, $2 }\n",
+        text("alpha 5\nbeta 7\nalpha 2\n"), Dir1, Bin1),
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_varlen_writers_b', Dir2),
+    clean_dir(Dir2),
+    make_directory_path(Dir2),
+    directory_file_path(Dir2, 'stage.bin', StagePath),
+    plawk_parse_string("BEGIN { BINFMT = \"lps16 i64\" } $1 == \"alpha\" { sum += $2 } END { print sum }\n", Program2),
+    plawk_program_native_driver_ir(Program2, StagePath, Driver2),
+    emit_probe(Dir2, Driver2, Bin2),
+    format(atom(Cmd), '~w > ~w && ~w', [Bin1, StagePath, Bin2]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == "7\n"),
+    assertion(Dir1 \== ''),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+take_i64(Codes, V, Rest) :-
+    length(Bytes, 8),
+    append(Bytes, Rest, Codes),
+    le_i64(Bytes, V).
+
+take_lps(Codes, S, Rest) :-
+    take_i64(Codes, Len, Rest0),
+    length(PayloadCodes, Len),
+    append(PayloadCodes, Rest, Rest0),
+    string_codes(S, PayloadCodes).
+
+decode_lps_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_lps_i64_codes(Codes, Records).
+
+decode_lps_i64_codes([], []).
+decode_lps_i64_codes(Codes, [S-V | Records]) :-
+    take_lps(Codes, S, Rest0),
+    take_i64(Rest0, V, Rest),
+    decode_lps_i64_codes(Rest, Records).
+
+decode_lps_lps_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_lps_lps_i64_codes(Codes, Records).
+
+decode_lps_lps_i64_codes([], []).
+decode_lps_lps_i64_codes(Codes, [t(A, B, V) | Records]) :-
+    take_lps(Codes, A, Rest0),
+    take_lps(Rest0, B, Rest1),
+    take_i64(Rest1, V, Rest),
+    decode_lps_lps_i64_codes(Rest, Records).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_vlw_marker/0 ],
+        [module_name('plawk_varlen_writers')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk varlen writers build output]~n~w~n", [BuildOut]),
+       throw(plawk_varlen_writers_build_failed(Status))
+    ).
+
+build_vlw_probe(Source, Input, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_varlen_writers', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    ( Input = text(Text)
+    ->  directory_file_path(Dir, 'input.txt', InputPath),
+        setup_call_cleanup(
+            open(InputPath, write, Out, [encoding(utf8)]),
+            write(Out, Text),
+            close(Out))
+    ;   Input = lps_recs(Recs),
+        directory_file_path(Dir, 'input.bin', InputPath),
+        setup_call_cleanup(
+            open(InputPath, write, Out, [type(binary)]),
+            forall(member(rec(V, S), Recs),
+                ( write_i64_le(Out, V),
+                  string_codes(S, Codes),
+                  length(Codes, Len),
+                  write_i64_le(Out, Len),
+                  forall(member(C, Codes), put_byte(Out, C)) )),
+            close(Out))
+    ),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_capture_raw(BinPath, Bytes, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+:- end_tests(plawk_varlen_writers).


### PR DESCRIPTION
## Summary

The first of the design doc's planned slices: `lpsN` works in OUTFMT, closing the variable-length pipeline loop. Writer output is **byte-compatible with the `lpsN` reader**, verified by a round-trip test (text → lps writer | lps reader → aggregate).

```awk
# text → varlen binary: exact lengths on the wire, no padding
BEGIN { OUTFMT = "lps16 i64" } { writebin $1, $2 }

# varlen → varlen transform: passthrough + literal tag + arithmetic
BEGIN { BINFMT = "i64 lps8" ; OUTFMT = "lps4 lps8 i64" }
$1 > 10 { writebin "tag", $2, $1 * 2 }
```

## How it works

- Records with an lps output slot switch from the single-buffer whole-record `fwrite` to **per-slot fwrites emitted strictly left to right** — numeric slots stage their value in the first 8 bytes of the existing `%plawk_wbuf` scratch, lps slots write their runtime length the same way and then the payload straight from its source bytes. fwrite buffers in libc, so per-record cost stays memcpy, not syscalls. Fixed OUTFMTs keep the single-record fwrite path untouched.
- **lps payload sources** mirror the `sN` slot sources: string literals (compile-time length), `sM`/`lpsM` input fields (`strnlen` against the source bound at a compile-time offset), and text-mode field slices clamped to the cap behind a null guard (a missing field writes length 0). Wire lengths are exact — short values carry no padding, which is the point of the format.
- **Validation** reuses the `sN` rules: oversized literals, source caps wider than the output slot, and numeric fields aimed at lps slots are rejected in both the general and binfmt-input checkers.

## Tests

`tests/test_plawk_varlen_writers.pl` (7 tests): per-slot fwrite IR shape (and fixed OUTFMTs keeping the single fwrite), three rejection shapes, exact wire lengths decoded byte-exactly, text clamping to the cap, a varlen→varlen transform with literal tags and empty payloads, and the byte-compatible round trip through the reader.

Full regression sweep green: all 28 suites exit 0.

## Merge order

Stacked on #3420 (varlen consolidation). **Merge #3420 into main first, then this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_