### PR TITLE
plawk: tagged unions via case blocks

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -36,7 +36,7 @@ handles) maps to an **access type** (what consumers see):
 | `f64` | 8 | `f64` | 8 bytes |
 | `sN` | N | `sN` | N bytes |
 | `lpsN` (landed) | 8 + len, len ≤ N | `sN` | N bytes, NUL-padded |
-| tagged union (planned) | 8-byte tag + arm | tag `i64` + widest arm | tag slot + max-arm slot |
+| tagged union (landed) | 8-byte tag + arm | per-arm `$1..$N` via `case` blocks | widest arm (tag in SSA only) |
 | bounded repetition (planned) | 8-byte count + count×elem, count ≤ K | count `i64` + K elems | count slot + K elem slots |
 
 ## The lowering spectrum
@@ -110,12 +110,21 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
 
 ## Planned slices
 
-1. **Tagged unions:** `BINFMT = "i64 union(0: i64 i64 | 1: lps16)"`
-   style — an 8-byte discriminator selects one of several arm layouts;
-   the access layout reserves the widest arm plus the tag as `$K`;
-   guards on the tag route rules per arm. Requires surface syntax
-   design (the awk-flavored form is the open question, e.g. rule
-   patterns like `$tag == 1 { ... }` with per-arm field numbering).
+1. **Tagged unions (landed):** `BINFMT = "case(i64 f64 | lps16 i64)"`
+   — an 8-byte discriminator selects an arm layout. The chosen surface
+   is per-arm blocks (`case K { rules }`): the arm is lexically scoped,
+   so every rule's field types are decided by the parser, not by
+   guard-shape analysis. Case blocks flatten into one scalar rule chain
+   whose guards prepend a tag check (`arm_pat/3`); the reader is a
+   native `switch` on the tag dispatching per-arm field-read sequences
+   that all materialize at offset 0 of a buffer sized to the widest arm
+   (the tag lives only in the `%vr_tag` SSA value — no case block needs
+   it at runtime because the arm is static inside the block). Unknown
+   tags and truncated arms are malformed input (`fail_read`); arms
+   without a case block are still read and skipped so the stream stays
+   framed. The tag-guard spelling (`$0 == K && ...`) can later be
+   accepted as sugar that desugars into a case block. Not yet inside
+   case blocks: assoc arrays, writebin, and union output.
 2. **Bounded repetition:** `count` header + up to K fixed elements;
    access layout is a count slot plus K element slots; `for` over
    elements in rule bodies is the surface question.

--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -507,8 +507,9 @@ while keeping the fixed access layout in memory -- the design document
 general approach (Tier 1: LL(1)-over-fields grammars with compile-time
 caps compile to native field-by-field read sequences; Tier 2: native
 framing + WAM-bytecode payload parsing via the foreign bridge; Tier 3:
-full DCG fallback, the Phase 5 JIT target). Planned next slices there:
-tagged unions, bounded repetition, varlen writers. Remaining Phase 3
+full DCG fallback, the Phase 5 JIT target). Landed since: varlen
+writers (lpsN in OUTFMT) and tagged unions (case-block surface, native
+tag switch); bounded repetition remains. Remaining Phase 3
 items below (richer ABIs) are otherwise unchanged.
 
 **Second slice landed (typed associative arrays):** in binary mode

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -92,6 +92,7 @@ swipl -q -s tests/test_plawk_forin_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_outfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_varlen_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_varlen_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_tagged_unions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -283,7 +284,18 @@ that materializes each record into the same fixed access layout, so an
 guards, `sN` OUTFMT passthrough) while numeric fields keep guards,
 arithmetic, and assoc keys. Clean EOF is only legal at a record
 boundary; oversized lengths, truncated payloads, and mid-record EOF
-exit with the read-error code. `lpsN` also works in OUTFMT: writebin emits the
+exit with the read-error code. Tagged unions let one stream carry several
+record kinds: `BINFMT = "case(i64 f64 | lps16 i64)"` declares that
+every record starts with an 8-byte tag selecting an arm layout, and
+`case K { ... }` blocks hold ordinary pattern-action rules whose
+`$1..$N` are typed by arm K. Scalars (including doubles), `NR`,
+`next`/`break`, `if`/`else`, and the END report are shared across
+arms; the reader is a native tag switch dispatching per-arm field
+reads into one record buffer sized to the widest arm. Unknown tags
+and truncated arms exit with the read-error code; arms with no case
+block are still read and skipped, keeping the stream framed. (Assoc
+arrays and writebin inside case blocks are later slices.)
+`lpsN` also works in OUTFMT: writebin emits the
 8-byte length plus exactly the payload bytes (no padding), sourcing
 from literals, `sM`/`lpsM` input fields, or text-mode slices clamped to
 the cap - writer output is byte-compatible with the `lpsN` reader, so

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -209,6 +209,62 @@ plawk_program_native_driver_ir(
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% Tagged-union programs: BINFMT = "case(arm0 | arm1 | ...)" plus
+% case K { rules } blocks. Case blocks flatten into one scalar rule
+% chain where each rule's guard checks the record tag before its own
+% pattern, and each rule's fields type against its arm's layout. The
+% END print block is optional (a pure per-arm printer needs none).
+plawk_program_native_driver_ir(
+    program(BeginClauses, case_blocks(CaseBlocks), EndClauses),
+    InputPath,
+    DriverIR
+) :-
+    plawk_record_descriptor(BeginClauses, Descriptor),
+    Descriptor = binfmt_union(Arms),
+    plawk_union_program_ok(Arms, CaseBlocks),
+    plawk_union_flatten_rules(CaseBlocks, Arms, Rules),
+    (   EndClauses = [end([print(PrintFields)])]
+    ->  HasEnd = true
+    ;   EndClauses == [],
+        PrintFields = [],
+        HasEnd = false
+    ),
+    plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_scalar_rule_chain_ir(Rules, StatePlan, Descriptor, OutputSeparator,
+        RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs),
+    append(PrintExprs, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
+    plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
+    plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
+    plawk_scalar_rule_controls(Rules, ScalarRuleControls),
+    plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, NextPhiIR),
+    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, done,
+        BreakCloseIR, FinalStatePhiIR),
+    (   HasEnd == true
+    ->  plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, EndPrintIR)
+    ;   EndPrintIR = ''
+    ),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, RuleGlobalIR]),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w~w
+  ret i32 0',
+        [FinalStatePhiIR, EndPrintIR]),
+    plawk_emit_record_driver_ir(Descriptor, InputPath,
+        driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
+            NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 plawk_program_native_driver_ir(
     program(BeginClauses, Rules, [end([print(PrintFields)])]),
     InputPath,
@@ -1832,6 +1888,9 @@ plawk_field_separator(BeginClauses, FieldSeparator) :-
 %  BEGIN { BINFMT = "i64 i64 f64" } yields binfmt(Types) for fixed-
 %  layout binary records: one 8-byte native-endian field per type,
 %  fields numbered $1..$N, record size 8 * N.
+plawk_record_descriptor(BeginClauses, binfmt_union(Arms)) :-
+    plawk_begin_union_arms(BeginClauses, Arms),
+    !.
 plawk_record_descriptor(BeginClauses, binfmt(Types)) :-
     plawk_begin_binfmt_types(BeginClauses, Types),
     !.
@@ -1839,7 +1898,31 @@ plawk_record_descriptor(BeginClauses, FieldSeparator) :-
     plawk_field_separator(BeginClauses, FieldSeparator).
 
 plawk_begin_has_binfmt(BeginClauses) :-
-    plawk_begin_binfmt_types(BeginClauses, _Types).
+    plawk_begin_binfmt_types(BeginClauses, _Types),
+    !.
+plawk_begin_has_binfmt(BeginClauses) :-
+    plawk_begin_union_arms(BeginClauses, _Arms).
+
+%% plawk_begin_union_arms(+BeginClauses, -Arms)
+%
+%  BINFMT = "case(i64 f64 | lps16 i64)" declares a tagged union: every
+%  record starts with an 8-byte native-endian tag selecting one of the
+%  |-separated arm layouts (arm indices are 0-based, in declaration
+%  order). Arms is a list of type lists.
+plawk_begin_union_arms(BeginClauses, Arms) :-
+    member(begin(Actions), BeginClauses),
+    member(set(var('BINFMT'), string(Fmt)), Actions),
+    string_concat("case(", Rest, Fmt),
+    string_concat(Body, ")", Rest),
+    split_string(Body, "|", " ", ArmStrs),
+    ArmStrs \== [],
+    maplist(plawk_union_arm_types, ArmStrs, Arms).
+
+plawk_union_arm_types(ArmStr, Types) :-
+    split_string(ArmStr, " ", " ", Parts0),
+    exclude(==(""), Parts0, Parts),
+    Parts \== [],
+    maplist(plawk_binfmt_type, Parts, Types).
 
 plawk_begin_binfmt_types(BeginClauses, Types) :-
     member(begin(Actions), BeginClauses),
@@ -2324,6 +2407,106 @@ plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
 %
 %  Pick the stream skeleton by record representation: text lines or
 %  fixed-size binary records.
+%% plawk_rule_descriptor(+Pattern, +Default, -Descriptor)
+%
+%  Rules inside a case block see their arm's field layout; everything
+%  else uses the program-wide descriptor.
+plawk_rule_descriptor(arm_pat(_Tag, ArmTypes, _Pattern), _Default,
+        binfmt(ArmTypes)) :-
+    !.
+plawk_rule_descriptor(_Pattern, Default, Default).
+
+%% plawk_union_flatten_rules(+CaseBlocks, +Arms, -Rules)
+%
+%  Flatten case blocks into one rule chain, stamping each rule with
+%  arm_pat(Tag, ArmTypes, Pattern) so guards check the record tag and
+%  everything downstream types fields against the right arm.
+plawk_union_flatten_rules(CaseBlocks, Arms, Rules) :-
+    findall(rule(arm_pat(Index, ArmTypes, Pattern), Actions),
+        ( member(case_arm(Index, ArmRules), CaseBlocks),
+          nth0(Index, Arms, ArmTypes),
+          member(rule(Pattern, Actions), ArmRules)
+        ),
+        Rules),
+    Rules \== [].
+
+plawk_union_program_ok(Arms, CaseBlocks) :-
+    length(Arms, ArmCount),
+    forall(member(case_arm(Index, ArmRules), CaseBlocks),
+        ( integer(Index),
+          Index >= 0,
+          Index < ArmCount,
+          nth0(Index, Arms, ArmTypes),
+          forall(member(rule(Pattern, Actions), ArmRules),
+              ( plawk_binfmt_pattern_ok(binfmt(ArmTypes), Pattern),
+                plawk_binfmt_actions_ok(binfmt(ArmTypes), Actions)
+              ))
+        )).
+
+%% plawk_union_read_ir(+Arms, +LoweredLabel, -ReadIR)
+%
+%  Read the 8-byte tag (the only place clean EOF is legal), switch on
+%  it, and run the selected arm's field-by-field read sequence. Every
+%  arm materializes its fields at offset 0 of %rec (the tag itself
+%  lives only in %vr_tag), so each arm's access layout is a plain
+%  binfmt(ArmTypes). An unknown tag is malformed input -> fail_read.
+plawk_union_read_ir(Arms, LoweredLabel, ReadIR) :-
+    findall(SwitchEntry,
+        ( nth0(Index, Arms, _),
+          format(atom(SwitchEntry), 'i64 ~w, label %vr_a~w', [Index, Index])
+        ),
+        SwitchEntries),
+    atomic_list_concat(SwitchEntries, ' ', SwitchBody),
+    format(atom(TagIR),
+'  %vr_tag_status = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %vr_len_i8)
+  %vr_tag_eof = icmp eq i64 %vr_tag_status, 0
+  br i1 %vr_tag_eof, label %close_stream, label %vr_tag_chk
+
+vr_tag_chk:
+  %vr_tag_ok = icmp eq i64 %vr_tag_status, 1
+  br i1 %vr_tag_ok, label %vr_tag_switch, label %fail_read
+
+vr_tag_switch:
+  %vr_tag = load i64, i64* %vr_len_scratch
+  switch i64 %vr_tag, label %fail_read [ ~w ]
+',
+        [SwitchBody]),
+    findall(ArmIR,
+        ( nth0(Index, Arms, ArmTypes),
+          format(atom(ArmPrefix), 'vr_a~w', [Index]),
+          plawk_varlen_field_sections(ArmTypes, LoweredLabel, ArmPrefix,
+              no_eof, 0, 0, Sections),
+          atomic_list_concat(Sections, '\n', ArmBodyIR),
+          format(atom(ArmIR), '~w:~n~w', [ArmPrefix, ArmBodyIR])
+        ),
+        ArmIRs),
+    atomic_list_concat([TagIR | ArmIRs], '\n', ReadIR).
+
+plawk_union_buf_size(Arms, BufSize) :-
+    findall(Size,
+        ( member(ArmTypes, Arms),
+          plawk_binfmt_record_size(binfmt(ArmTypes), Size)
+        ),
+        Sizes),
+    max_list(Sizes, BufSize).
+
+plawk_emit_record_driver_ir(binfmt_union(Arms), InputPath, Blocks, DriverIR) :-
+    !,
+    plawk_union_buf_size(Arms, BufSize),
+    plawk_normalize_driver_blocks(Blocks,
+        driver_blocks(RuntimeGlobals, EntrySetupIR0, LoopPhiIR, LoweredLabel,
+            RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR)),
+    % the 8-byte scratch holds the tag, then any lps length prefixes
+    plawk_combine_entry_ir(EntrySetupIR0,
+'  %vr_len_scratch = alloca i64, align 8
+  %vr_len_i8 = bitcast i64* %vr_len_scratch to i8*',
+        EntrySetupIR),
+    plawk_union_read_ir(Arms, LoweredLabel, ReadIR),
+    llvm_emit_varlen_stream_driver_ir(InputPath, BufSize, ReadIR,
+        driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel,
+            RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
+        DriverIR).
+
 plawk_emit_record_driver_ir(binfmt(Types), InputPath, Blocks, DriverIR) :-
     plawk_binfmt_has_varlen(Types),
     !,
@@ -2374,89 +2557,95 @@ plawk_normalize_driver_blocks(Blocks, Blocks).
 %  zero the slot, then read the payload (a zero length reads nothing:
 %  @wam_stream_read_record returns 1 immediately for size 0).
 plawk_varlen_read_ir(Types, LoweredLabel, ReadIR) :-
-    plawk_varlen_field_sections(Types, LoweredLabel, 0, 0, Sections),
+    plawk_varlen_field_sections(Types, LoweredLabel, vr, eof_first, 0, 0,
+        Sections),
     atomic_list_concat(Sections, '\n', ReadIR).
 
-plawk_varlen_field_sections([], _LoweredLabel, _Index, _Offset, []).
-plawk_varlen_field_sections([Type | Types], LoweredLabel, Index, Offset,
-        [Section | Sections]) :-
+plawk_varlen_field_sections([], _LoweredLabel, _Prefix, _EofPolicy, _Index,
+        _Offset, []).
+plawk_varlen_field_sections([Type | Types], LoweredLabel, Prefix, EofPolicy,
+        Index, Offset, [Section | Sections]) :-
     ( Types == []
     -> NextLabel = LoweredLabel
     ;  NextIndex0 is Index + 1,
-       format(atom(NextLabel), 'vr_f~w', [NextIndex0])
+       format(atom(NextLabel), '~w_f~w', [Prefix, NextIndex0])
     ),
     ( Index =:= 0
     -> LabelIR = ''
-    ;  format(atom(LabelIR), 'vr_f~w:~n', [Index])
+    ;  format(atom(LabelIR), '~w_f~w:~n', [Prefix, Index])
     ),
-    plawk_varlen_field_body(Type, Index, Offset, NextLabel, BodyIR),
+    format(atom(FBase), '~w_f~w', [Prefix, Index]),
+    ( Index =:= 0, EofPolicy == eof_first
+    -> FieldEof = eof
+    ;  FieldEof = no_eof
+    ),
+    plawk_varlen_field_body(Type, FBase, FieldEof, Offset, NextLabel, BodyIR),
     format(atom(Section), '~w~w', [LabelIR, BodyIR]),
     plawk_binfmt_type_width(Type, Width),
     NextOffset is Offset + Width,
     NextIndex is Index + 1,
-    plawk_varlen_field_sections(Types, LoweredLabel, NextIndex, NextOffset,
-        Sections).
+    plawk_varlen_field_sections(Types, LoweredLabel, Prefix, EofPolicy,
+        NextIndex, NextOffset, Sections).
 
-plawk_varlen_field_body(lps(Cap), Index, Offset, NextLabel, BodyIR) :-
+plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
     !,
-    plawk_varlen_eof_check_ir(Index, lstatus, BodyPrefixIR, OkLabelIR),
+    plawk_varlen_eof_check_ir(FieldEof, FBase, lstatus, BodyPrefixIR),
     format(atom(BodyIR),
-'  %vr_f~w_lstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %vr_len_i8)
-~w~w  %vr_f~w_lok = icmp eq i64 %vr_f~w_lstatus, 1
-  br i1 %vr_f~w_lok, label %vr_f~w_len, label %fail_read
+'  %~w_lstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %vr_len_i8)
+~w  %~w_lok = icmp eq i64 %~w_lstatus, 1
+  br i1 %~w_lok, label %~w_len, label %fail_read
 
-vr_f~w_len:
-  %vr_f~w_n = load i64, i64* %vr_len_scratch
-  %vr_f~w_fits = icmp ule i64 %vr_f~w_n, ~w
-  br i1 %vr_f~w_fits, label %vr_f~w_read, label %fail_read
+~w_len:
+  %~w_n = load i64, i64* %vr_len_scratch
+  %~w_fits = icmp ule i64 %~w_n, ~w
+  br i1 %~w_fits, label %~w_read, label %fail_read
 
-vr_f~w_read:
-  %vr_f~w_dst = getelementptr i8, i8* %rec, i64 ~w
-  call void @llvm.memset.p0i8.i64(i8* %vr_f~w_dst, i8 0, i64 ~w, i1 false)
-  %vr_f~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %vr_f~w_n, i8* %vr_f~w_dst)
-  %vr_f~w_pok = icmp eq i64 %vr_f~w_pstatus, 1
-  br i1 %vr_f~w_pok, label %~w, label %fail_read
+~w_read:
+  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  call void @llvm.memset.p0i8.i64(i8* %~w_dst, i8 0, i64 ~w, i1 false)
+  %~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %~w_n, i8* %~w_dst)
+  %~w_pok = icmp eq i64 %~w_pstatus, 1
+  br i1 %~w_pok, label %~w, label %fail_read
 ',
-        [Index,
-         BodyPrefixIR, OkLabelIR, Index, Index,
-         Index, Index,
-         Index,
-         Index,
-         Index, Index, Cap,
-         Index, Index,
-         Index,
-         Index, Offset,
-         Index, Cap,
-         Index, Index, Index,
-         Index, Index,
-         Index, NextLabel]).
-plawk_varlen_field_body(_NumericType, Index, Offset, NextLabel, BodyIR) :-
-    plawk_varlen_eof_check_ir(Index, status, BodyPrefixIR, OkLabelIR),
+        [FBase,
+         BodyPrefixIR, FBase, FBase,
+         FBase, FBase,
+         FBase,
+         FBase,
+         FBase, FBase, Cap,
+         FBase, FBase,
+         FBase,
+         FBase, Offset,
+         FBase, Cap,
+         FBase, FBase, FBase,
+         FBase, FBase,
+         FBase, NextLabel]).
+plawk_varlen_field_body(_NumericType, FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+    plawk_varlen_eof_check_ir(FieldEof, FBase, status, BodyPrefixIR),
     format(atom(BodyIR),
-'  %vr_f~w_dst = getelementptr i8, i8* %rec, i64 ~w
-  %vr_f~w_status = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %vr_f~w_dst)
-~w~w  %vr_f~w_ok = icmp eq i64 %vr_f~w_status, 1
-  br i1 %vr_f~w_ok, label %~w, label %fail_read
+'  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  %~w_status = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
+~w  %~w_ok = icmp eq i64 %~w_status, 1
+  br i1 %~w_ok, label %~w, label %fail_read
 ',
-        [Index, Offset,
-         Index, Index,
-         BodyPrefixIR, OkLabelIR, Index, Index,
-         Index, NextLabel]).
+        [FBase, Offset,
+         FBase, FBase,
+         BodyPrefixIR, FBase, FBase,
+         FBase, NextLabel]).
 
 % Only the record's first read may see clean EOF (status 0). Later
 % fields fall straight through to the 1/other check, where 0 lands in
 % fail_read like any short read.
-plawk_varlen_eof_check_ir(0, StatusSuffix, BodyPrefixIR, OkLabelIR) :-
+plawk_varlen_eof_check_ir(eof, FBase, StatusSuffix, BodyPrefixIR) :-
     !,
     format(atom(BodyPrefixIR),
-'  %vr_f0_eof = icmp eq i64 %vr_f0_~w, 0
-  br i1 %vr_f0_eof, label %close_stream, label %vr_f0_chk
+'  %~w_eof = icmp eq i64 %~w_~w, 0
+  br i1 %~w_eof, label %close_stream, label %~w_chk
 
-vr_f0_chk:
+~w_chk:
 ',
-        [StatusSuffix]),
-    OkLabelIR = ''.
-plawk_varlen_eof_check_ir(_Index, _StatusSuffix, '', '').
+        [FBase, FBase, StatusSuffix, FBase, FBase, FBase]).
+plawk_varlen_eof_check_ir(no_eof, _FBase, _StatusSuffix, '').
 
 plawk_output_separator(BeginClauses, OutputSeparator) :-
     (   member(begin(Actions), BeginClauses),
@@ -2764,13 +2953,15 @@ plawk_scalar_rule_chain_lines([scalar_rule(Index, Pattern, Actions, Control) | R
       format(atom(MatchVar), 'rule_~w_is_match', [Index]),
       format(atom(GlobalBase), 'plawk_surface_rule_~w', [Index]),
       format(atom(MatchValue), '%~w', [MatchVar]),
-      plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, MatchValue,
+      % tagged-union rules carry their arm's field types with them
+      plawk_rule_descriptor(Pattern, FieldSeparator, RuleDescriptor),
+      plawk_pattern_guard_ir(Pattern, RuleDescriptor, GlobalBase, MatchValue,
           GuardGlobalIR-GuardCallIR),
       plawk_rule_target(Control, NextLabel, RuleTargetLabel),
       maplist(plawk_scalar_rule_body_action, Actions),
       BodyActions = Actions,
       plawk_scalar_rule_input_phi_ir(StatePlan, Index, Controls, InputPhiIR),
-      plawk_scalar_match_update_ir(StatePlan, BodyActions, FieldSeparator, OutputSeparator, Index,
+      plawk_scalar_match_update_ir(StatePlan, BodyActions, RuleDescriptor, OutputSeparator, Index,
           BranchNextExits, MatchUpdateGlobalIR-MatchUpdateIR),
       ( Index =:= 0
       -> EntryIR = '  br label %rule_0_match\n\n'
@@ -3976,6 +4167,30 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), GlobalBase, MatchValue, Guar
     plawk_pattern_guard_ir(field_cmp(Index, Op, Value), 32, GlobalBase,
         MatchValue, GuardIR).
 
+% Tagged-union rule guard: the record tag must equal the rule's arm,
+% and the inner pattern (typed against the arm's layout) must match.
+% %vr_tag is loaded once per record in the union read sequence and
+% dominates every rule block. Field reads in the inner guard are safe
+% even when the tag check fails: the record buffer is always at least
+% as large as the widest arm, so a mismatched read sees stale-but-owned
+% bytes and its result is discarded by the and.
+plawk_pattern_guard_ir(arm_pat(Tag, ArmTypes, Pattern), _FieldSeparator,
+        GlobalBase, MatchValue, GuardIR) :-
+    !,
+    format(atom(TagOk), '%~w_tag_ok', [GlobalBase]),
+    format(atom(TagCheck), '  ~w = icmp eq i64 %vr_tag, ~w', [TagOk, Tag]),
+    ( Pattern == always
+    ->  format(atom(CallIR), '~w~n  ~w = and i1 ~w, true',
+            [TagCheck, MatchValue, TagOk]),
+        GuardIR = ''-CallIR
+    ;   format(atom(InnerBase), '~w_arm', [GlobalBase]),
+        format(atom(InnerValue), '~w_arm', [MatchValue]),
+        plawk_pattern_guard_ir(Pattern, binfmt(ArmTypes), InnerBase,
+            InnerValue, GlobalIR-InnerCallIR),
+        format(atom(CallIR), '~w~n~w~n  ~w = and i1 ~w, ~w',
+            [TagCheck, InnerCallIR, MatchValue, TagOk, InnerValue]),
+        GuardIR = GlobalIR-CallIR
+    ).
 plawk_pattern_guard_ir(always, _FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     plawk_pattern_guard_ir(always, GlobalBase, MatchValue, GuardIR).
 plawk_pattern_guard_ir(prefix(Prefix), _FieldSeparator, GlobalBase, MatchValue, GuardIR) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -47,9 +47,43 @@ plawk_parse_string(Source, Program) :-
 plawk_program(program(BeginClauses, Rules, EndClauses)) -->
     ws,
     begin_clauses(BeginClauses),
-    rules(Rules),
+    program_rules(Rules),
     end_clauses(EndClauses),
     eos.
+
+% Tagged-union programs route rules through per-arm case blocks: the
+% arm index scopes the field types of every rule inside the block.
+program_rules(case_blocks(Blocks)) -->
+    case_block(Block),
+    !,
+    case_blocks_rest(Blocks0),
+    { Blocks = [Block | Blocks0] }.
+program_rules(Rules) -->
+    rules(Rules).
+
+case_blocks_rest([Block | Blocks]) -->
+    ws,
+    case_block(Block),
+    !,
+    case_blocks_rest(Blocks).
+case_blocks_rest([]) -->
+    ws.
+
+case_block(case_arm(Index, Rules)) -->
+    "case",
+    identifier_boundary,
+    ws,
+    integer_codes(IndexCodes),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    },
+    ws,
+    "{",
+    ws,
+    rules(Rules),
+    ws,
+    "}".
 
 rules([Rule | Rules]) -->
     rule(Rule),

--- a/tests/test_plawk_tagged_unions.pl
+++ b/tests/test_plawk_tagged_unions.pl
@@ -1,0 +1,199 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_tun_marker/0.
+
+user:plawk_tun_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_tagged_unions, [condition(clang_available)]).
+
+test(parses_case_blocks) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { $1 > 100 { c++ } } case 1 { { d++ } } END { print c, d }\n", Program),
+    Program = program(_, case_blocks(Blocks), _),
+    assertion(Blocks == [case_arm(0, [rule(field_cmp(1, gt, 100), [inc(var(c))])]),
+                         case_arm(1, [rule(always, [inc(var(d))])])]).
+
+test(union_ir_has_tag_switch_and_arm_reads) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { $1 > 100 { c++ } } case 1 { { d++ } } END { print c, d }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % tag read + native switch dispatching per-arm read sequences
+    assertion(once(sub_atom(DriverIR, _, _, _, 'switch i64 %vr_tag, label %fail_read [ i64 0, label %vr_a0 i64 1, label %vr_a1 ]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_a0_f0_dst'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_a1_f0_fits'))),
+    % buffer = widest arm (lps16 + i64 = 24), tag lives only in %vr_tag
+    assertion(once(sub_atom(DriverIR, _, _, _, 'malloc(i64 24)'))),
+    % rule guards check the tag before their own pattern
+    assertion(once(sub_atom(DriverIR, _, _, _, '_tag_ok = icmp eq i64 %vr_tag, 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_tag_ok = icmp eq i64 %vr_tag, 1'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(union_rejections) :-
+    Rejects = [
+        % case index beyond the declared arms
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 2 { { c++ } } END { print c }\n",
+        % arm-typed field misuse: string equality on an i64 field
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { $1 == \"x\" { c++ } } END { print c }\n",
+        % numeric compare on an lps field
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 1 { $1 > 5 { c++ } } END { print c }\n",
+        % assoc arrays are not in the union slice
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { { counts[$1]++ } } END { print counts[5] }\n",
+        % case blocks demand a union BINFMT
+        "case 0 { { c++ } } END { print c }\n",
+        "BEGIN { BINFMT = \"i64 i64\" } case 0 { { c++ } } END { print c }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_union_dispatch_and_state) :-
+    % Two record kinds interleaved: metrics (i64 f64) aggregate, events
+    % (lps16 i64) print and count -- one native loop, shared END.
+    run_tun_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { $1 > 100 { msum += float($2) ; mhits++ } } case 1 { $2 == 7 { print $1 } $1 == \"boom\" { events++ } } END { print mhits, msum, events }\n",
+        [m(50, 1.5), e("hello", 7), m(200, 2.5), e("boom", 3), m(300, 0.25), e("boom", 7)],
+        "hello\nboom\n2 2.75 2\n").
+
+test(surface_union_unhandled_arm_still_reads) :-
+    % No case 0 block: metric records are read (and skipped) correctly,
+    % keeping stream framing intact for the events that follow.
+    run_tun_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 1 { { events++ } } END { print events }\n",
+        [m(50, 1.5), e("x", 1), m(200, 2.5), e("y", 2)],
+        "2\n").
+
+test(surface_union_next_and_nr) :-
+    % NR counts records of every arm; next works inside a case block.
+    run_tun_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 1 { $1 == \"skip\" { next } { events++ } } END { print NR, events }\n",
+        [m(1, 1.0), e("skip", 0), e("go", 0), m(2, 2.0)],
+        "4 1\n").
+
+test(surface_union_endless_program) :-
+    run_tun_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 1 { { print $1, $2 } }\n",
+        [m(1, 1.0), e("aa", 5), e("bb", 6)],
+        "aa 5\nbb 6\n").
+
+test(surface_union_error_paths) :-
+    build_tun_probe("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { { c++ } } END { print c }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    % unknown tag
+    write_bytes(InputPath, [i64(9), pad(16)]),
+    run_status(BinPath, exit(11)),
+    % truncated arm 0 (tag + i64, missing the f64)
+    write_bytes(InputPath, [i64(0), i64(5)]),
+    run_status(BinPath, exit(11)),
+    % clean EOF at a record boundary runs END
+    write_bytes(InputPath, []),
+    run_expect(BinPath, "0\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,  0x3FF8000000000000).
+double_bits(2.5,  0x4004000000000000).
+double_bits(0.25, 0x3FD0000000000000).
+double_bits(1.0,  0x3FF0000000000000).
+double_bits(2.0,  0x4000000000000000).
+
+% m(V, F): arm 0 = tag 0, i64 V, f64 F.  e(S, C): arm 1 = tag 1, lps16 S, i64 C.
+write_union_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Rec, Recs),
+            ( Rec = m(V, F)
+            -> ( write_i64_le(Out, 0), write_i64_le(Out, V),
+                 double_bits(F, Bits), write_i64_le(Out, Bits) )
+            ;  Rec = e(S, C),
+               string_codes(S, Codes),
+               length(Codes, Len),
+               write_i64_le(Out, 1), write_i64_le(Out, Len),
+               forall(member(Ch, Codes), put_byte(Out, Ch)),
+               write_i64_le(Out, C)
+            )),
+        close(Out)).
+
+write_bytes(Path, Items) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Item, Items),
+            ( Item = i64(V) -> write_i64_le(Out, V)
+            ; Item = pad(N) -> forall(between(1, N, _), put_byte(Out, 0))
+            )),
+        close(Out)).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_tun_marker/0 ],
+        [module_name('plawk_tagged_unions')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk tagged unions build output]~n~w~n", [BuildOut]),
+       throw(plawk_tagged_unions_build_failed(Status))
+    ).
+
+build_tun_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_tagged_unions', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_status(BinPath, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(null), stderr(std), process(Pid)]),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+run_expect(BinPath, ExpectedOutput) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == ExpectedOutput).
+
+run_tun_smoke(Source, Recs, ExpectedOutput) :-
+    build_tun_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_union_records(InputPath, Recs),
+    run_expect(BinPath, ExpectedOutput),
+    !.
+
+:- end_tests(plawk_tagged_unions).


### PR DESCRIPTION
## Summary

The Option-B tagged-union surface, as discussed: one stream carries several record kinds, each starting with an 8-byte tag that selects an arm layout, and `case K { ... }` blocks hold ordinary awk pattern–action rules whose `$1..$N` are typed by arm K.

```awk
BEGIN { BINFMT = "case(i64 f64 | lps16 i64)" }
case 0 {                                        # metrics: $1=i64, $2=f64
  $1 > 100 { msum += float($2) ; mhits++ }
}
case 1 {                                        # events: $1=lps16, $2=i64
  $2 == 7 { print $1 }
  $1 == "boom" { events++ }
}
END { print mhits, msum, events }
```

The arm is **lexically scoped** — field typing is decided by the parser, not by guard-shape analysis — which was the argument for B: trivially decidable typing, syntactic arm-bound checks, and a natural home for future nesting. The tag-guard spelling (`$0 == K && ...`) can be added later as sugar that desugars into a case block.

## How it works

- **Reader**: a native `switch` on the tag (its read is the only legal clean-EOF point) dispatches per-arm field-read sequences, built on the varlen section generator (generalized with a label prefix + EOF policy). Every arm materializes its fields at **offset 0** of one buffer sized to the widest arm — the tag lives only in the `%vr_tag` SSA value, since inside a case block the arm is static. Unknown tags and truncated arms exit `fail_read`; **arms without a case block are still read and skipped**, keeping the stream framed.
- **Rules**: case blocks flatten into the existing scalar rule chain; each rule is stamped `arm_pat(Tag, ArmTypes, Pattern)`, whose guard prepends `icmp eq i64 %vr_tag, K` before the arm-typed inner pattern (evaluating an inner guard against a mismatched record is memory-safe; the `and` discards its result). The chain resolves a per-rule descriptor, so actions type against the right arm — a two-line change to the chain emitter; every other emitter is reused as-is.
- **Shared across arms**: scalar state (including double slots), `NR`, `next`/`break`, `if`/`else`, `printf`, and the optional END report (END-less pure printers work too).
- **Rejected** (later slices): assoc arrays and `writebin` inside case blocks, out-of-range arm indices, arm-mistyped fields, and case blocks without a union BINFMT.

## Tests

`tests/test_plawk_tagged_unions.pl` (8 tests): parse shape, tag-switch + per-arm read IR, six rejection shapes, mixed-arm dispatch end-to-end with shared doubles state, unhandled-arm framing, `next` + `NR` across arms, END-less printers, and unknown-tag / truncated-arm / clean-EOF error paths.

Full regression sweep green: all 29 suites exit 0.

## Merge order

Stacked on #3421 (varlen writers). Chain: **#3420 → #3421 → this PR**, merged bottom-up so everything lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_