### PR TITLE
plawk: bring #3421–#3422 to main + tutorial for binary records and tagged unions

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -119,9 +119,13 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
 2. **Bounded repetition:** `count` header + up to K fixed elements;
    access layout is a count slot plus K element slots; `for` over
    elements in rule bodies is the surface question.
-3. **Varlen writers:** `lpsN` in OUTFMT emitting length + payload from
-   `sN`/`lpsN` sources — closing the varlen pipeline loop the same way
-   fixed writers did.
+3. **Varlen writers (landed):** `lpsN` in OUTFMT emits the 8-byte
+   length plus exactly the payload bytes, sourced from literals,
+   `sM`/`lpsM` input fields (`M ≤ cap`), or text-mode slices clamped to
+   the cap. Records with an lps slot switch from the single-buffer
+   fwrite to per-slot fwrites emitted left to right (buffered in libc,
+   so still memcpy cost per record). Writer output is byte-compatible
+   with the `lpsN` reader.
 4. **Tier-2 composition sugar:** a declared payload type whose slice is
    passed to a compiled Prolog DCG via the foreign bridge without
    hand-written glue.

--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -36,7 +36,7 @@ handles) maps to an **access type** (what consumers see):
 | `f64` | 8 | `f64` | 8 bytes |
 | `sN` | N | `sN` | N bytes |
 | `lpsN` (landed) | 8 + len, len ≤ N | `sN` | N bytes, NUL-padded |
-| tagged union (planned) | 8-byte tag + arm | tag `i64` + widest arm | tag slot + max-arm slot |
+| tagged union (landed) | 8-byte tag + arm | per-arm `$1..$N` via `case` blocks | widest arm (tag in SSA only) |
 | bounded repetition (planned) | 8-byte count + count×elem, count ≤ K | count `i64` + K elems | count slot + K elem slots |
 
 ## The lowering spectrum
@@ -110,12 +110,21 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
 
 ## Planned slices
 
-1. **Tagged unions:** `BINFMT = "i64 union(0: i64 i64 | 1: lps16)"`
-   style — an 8-byte discriminator selects one of several arm layouts;
-   the access layout reserves the widest arm plus the tag as `$K`;
-   guards on the tag route rules per arm. Requires surface syntax
-   design (the awk-flavored form is the open question, e.g. rule
-   patterns like `$tag == 1 { ... }` with per-arm field numbering).
+1. **Tagged unions (landed):** `BINFMT = "case(i64 f64 | lps16 i64)"`
+   — an 8-byte discriminator selects an arm layout. The chosen surface
+   is per-arm blocks (`case K { rules }`): the arm is lexically scoped,
+   so every rule's field types are decided by the parser, not by
+   guard-shape analysis. Case blocks flatten into one scalar rule chain
+   whose guards prepend a tag check (`arm_pat/3`); the reader is a
+   native `switch` on the tag dispatching per-arm field-read sequences
+   that all materialize at offset 0 of a buffer sized to the widest arm
+   (the tag lives only in the `%vr_tag` SSA value — no case block needs
+   it at runtime because the arm is static inside the block). Unknown
+   tags and truncated arms are malformed input (`fail_read`); arms
+   without a case block are still read and skipped so the stream stays
+   framed. The tag-guard spelling (`$0 == K && ...`) can later be
+   accepted as sugar that desugars into a case block. Not yet inside
+   case blocks: assoc arrays, writebin, and union output.
 2. **Bounded repetition:** `count` header + up to K fixed elements;
    access layout is a count slot plus K element slots; `for` over
    elements in rule bodies is the surface question.

--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -507,8 +507,9 @@ while keeping the fixed access layout in memory -- the design document
 general approach (Tier 1: LL(1)-over-fields grammars with compile-time
 caps compile to native field-by-field read sequences; Tier 2: native
 framing + WAM-bytecode payload parsing via the foreign bridge; Tier 3:
-full DCG fallback, the Phase 5 JIT target). Planned next slices there:
-tagged unions, bounded repetition, varlen writers. Remaining Phase 3
+full DCG fallback, the Phase 5 JIT target). Landed since: varlen
+writers (lpsN in OUTFMT) and tagged unions (case-block surface, native
+tag switch); bounded repetition remains. Remaining Phase 3
 items below (richer ABIs) are otherwise unchanged.
 
 **Second slice landed (typed associative arrays):** in binary mode

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -91,6 +91,7 @@ swipl -q -s tests/test_plawk_binary_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_forin_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_outfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_varlen_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_varlen_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -282,7 +283,11 @@ that materializes each record into the same fixed access layout, so an
 guards, `sN` OUTFMT passthrough) while numeric fields keep guards,
 arithmetic, and assoc keys. Clean EOF is only legal at a record
 boundary; oversized lengths, truncated payloads, and mid-record EOF
-exit with the read-error code. See
+exit with the read-error code. `lpsN` also works in OUTFMT: writebin emits the
+8-byte length plus exactly the payload bytes (no padding), sourcing
+from literals, `sM`/`lpsM` input fields, or text-mode slices clamped to
+the cap - writer output is byte-compatible with the `lpsN` reader, so
+varlen plawk-to-plawk pipelines round-trip. See
 [`docs/design/PLAWK_DCG_BINARY_READERS.md`](../../docs/design/PLAWK_DCG_BINARY_READERS.md)
 for the grammar-to-native-reader lowering design this is the first
 slice of. Fixed-width string fields are in: with

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -92,6 +92,7 @@ swipl -q -s tests/test_plawk_forin_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_outfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_varlen_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_varlen_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_tagged_unions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -283,7 +284,18 @@ that materializes each record into the same fixed access layout, so an
 guards, `sN` OUTFMT passthrough) while numeric fields keep guards,
 arithmetic, and assoc keys. Clean EOF is only legal at a record
 boundary; oversized lengths, truncated payloads, and mid-record EOF
-exit with the read-error code. `lpsN` also works in OUTFMT: writebin emits the
+exit with the read-error code. Tagged unions let one stream carry several
+record kinds: `BINFMT = "case(i64 f64 | lps16 i64)"` declares that
+every record starts with an 8-byte tag selecting an arm layout, and
+`case K { ... }` blocks hold ordinary pattern-action rules whose
+`$1..$N` are typed by arm K. Scalars (including doubles), `NR`,
+`next`/`break`, `if`/`else`, and the END report are shared across
+arms; the reader is a native tag switch dispatching per-arm field
+reads into one record buffer sized to the widest arm. Unknown tags
+and truncated arms exit with the read-error code; arms with no case
+block are still read and skipped, keeping the stream framed. (Assoc
+arrays and writebin inside case blocks are later slices.)
+`lpsN` also works in OUTFMT: writebin emits the
 8-byte length plus exactly the payload bytes (no padding), sourcing
 from literals, `sM`/`lpsM` input fields, or text-mode slices clamped to
 the cap - writer output is byte-compatible with the `lpsN` reader, so

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -339,7 +339,11 @@ text mode.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see
-[`TUTORIAL.md`](TUTORIAL.md).
+[`TUTORIAL.md`](TUTORIAL.md) — which now ends with a
+from-first-principles walkthrough of binary records, `lps`
+length-prefixed strings, and tagged unions / `case` blocks (what a
+tag, an arm, and a discriminated record are, with byte-level
+diagrams).
 
 ## Design documents
 

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -476,3 +476,128 @@ records=4
 ERROR disk
 ERROR network
 ```
+
+## Binary records, from the beginning
+
+Everything above processed *text*: lines, split into fields by spaces.
+PLAWK can also process *binary* records — and since several binary
+concepts come from outside both awk and Prolog, this section builds
+them up from zero.
+
+### What a binary record is
+
+A text record says `200 2.5` and makes the machine parse "200" from
+digits every single time. A binary record stores the number 200 as the
+8 bytes a CPU register already uses, so reading it is one load
+instruction — no parsing. `BEGIN { BINFMT = "i64 f64" }` declares:
+every record is exactly 16 bytes — an 8-byte integer, then an 8-byte
+float:
+
+```text
+byte offset:   0        8        16
+              +--------+--------+
+              |  i64   |  f64   |     $1 = the i64, $2 = the f64
+              +--------+--------+
+```
+
+After that BEGIN line, the same awk you already write —
+`$1 > 100 { sum += float($2) }` — runs over these 16-byte records.
+The `$N` variables just mean "the Nth declared slot" instead of "the
+Nth space-separated word".
+
+### Strings in binary records
+
+Two flavors:
+
+- `s8` — a **fixed** 8-byte slot. Short values are padded with zero
+  bytes ("alpha" + three zeros). Simple, but always 8 bytes.
+- `lps16` — a **length-prefixed string** ("lps"): the wire carries an
+  8-byte length, then exactly that many bytes (up to the cap, 16).
+  `"bee"` costs 8+3 = 11 bytes instead of a padded 16:
+
+```text
+              +--------+---+
+              |   3    |bee|      an lps16 holding "bee"
+              +--------+---+
+```
+
+Records containing an `lps` field have different sizes on the wire —
+but PLAWK copies each one into a fixed-size buffer in memory, so to
+your program an `lps16` field looks exactly like an `s16`. That
+"variable on the wire, fixed in memory" trick is the foundation for
+everything below.
+
+### Tagged unions: one stream, several kinds of record
+
+The name comes from C, not from awk or Prolog (Prolog's analogue is
+different functors: `metric(Id,V)` vs `event(Name,Code)`; Rust calls
+them enums; type theory says sum types). The situation it solves is
+everyday, though: **a stream where not every record has the same
+shape.** A telemetry feed might interleave *metrics* (an id and a
+reading) with *events* (a name and a code). Different layouts, one
+pipe.
+
+The binary convention: every record starts with a small number — the
+**tag** (or *discriminator*) — announcing which layout follows. Each
+possible layout is called an **arm** (pattern-matching vocabulary:
+the arms of a match). On the wire:
+
+```text
+a metric:   +--------+--------+--------+
+            | tag=0  |  i64   |  f64   |
+            +--------+--------+--------+
+an event:   +--------+--------+-----------+--------+
+            | tag=1  | len    | name bytes|  i64   |
+            +--------+--------+-----------+--------+
+```
+
+In PLAWK you declare the arms in BINFMT, separated by `|`:
+
+```awk
+BEGIN { BINFMT = "case(i64 f64 | lps16 i64)" }
+```
+
+meaning: tag 0 → the record continues `i64 f64`; tag 1 → it continues
+`lps16 i64`.
+
+### case blocks: routing rules by record kind
+
+Here is the part that is genuinely new syntax (awk has no switch;
+gawk bolted one on later): you group your rules into one block per
+arm, and **inside a block, everything is ordinary awk** — the block
+only fixes what `$1, $2, …` mean there:
+
+```awk
+BEGIN { BINFMT = "case(i64 f64 | lps16 i64)" }
+case 0 {                               # metric records: $1=i64, $2=f64
+  $1 > 100 { msum += float($2) }
+}
+case 1 {                               # event records: $1=lps16, $2=i64
+  $1 == "boom" { events++ }
+}
+END { print msum, events }
+```
+
+Reading it aloud: "when a record's tag is 0, treat it as a metric and
+run these rules on it; when the tag is 1, treat it as an event and run
+those." Scalars like `msum` and `events`, plus `NR`, `next`, `break`,
+and the END report, are shared across the blocks — there is still only
+one stream and one loop.
+
+Why blocks rather than writing the tag into each guard
+(`$0 == 1 && $1 == "boom"`)? Because the *types* of `$1, $2` depend on
+the arm: the compiler must know which arm a rule belongs to before it
+can decide whether `$1 == "boom"` is a string comparison or nonsense.
+With a block, that is decided by where the rule sits on the page. (The
+guard spelling can be added later as a shorthand that expands to a
+block.)
+
+### What the compiled program actually does
+
+Per record: read 8 bytes (the tag) → a native `switch` jumps to that
+arm's reader → the arm's fields are copied to fixed positions in one
+buffer → the rules run, each first checking the tag matches its block.
+No interpreter, no allocation; a malformed record (unknown tag,
+truncated bytes) exits with the read-error code, and record kinds you
+wrote no block for are still read and skipped, so the stream never
+loses its framing.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1733,6 +1733,9 @@ plawk_binfmt_writebin_args_ok(Descriptor, [f64 | Types], [Field | Fields]) :-
 plawk_binfmt_writebin_args_ok(Descriptor, [s(Width) | Types], [Field | Fields]) :-
     plawk_binfmt_writebin_str_ok(Descriptor, Field, Width),
     plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+plawk_binfmt_writebin_args_ok(Descriptor, [lps(Cap) | Types], [Field | Fields]) :-
+    plawk_binfmt_writebin_str_ok(Descriptor, Field, Cap),
+    plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
 
 plawk_binfmt_writebin_str_ok(_Descriptor, string(Value), Width) :-
     !,
@@ -1914,7 +1917,7 @@ plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules, WritebinPlan) :-
     ( plawk_rules_have_writebin(Rules0)
     ->  plawk_begin_outfmt_types(BeginClauses, Types),
         forall(member(Type, Types),
-            ( memberchk(Type, [i64, f64]) ; Type = s(_Width) )),
+            ( memberchk(Type, [i64, f64]) ; Type = s(_W) ; Type = lps(_C) )),
         plawk_binfmt_record_size(binfmt(Types), Size),
         WritebinPlan = outfmt(Types, Size),
         maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules)
@@ -1997,6 +2000,8 @@ plawk_writebin_args_ok([Type | Types], [Field | Fields]) :-
     -> plawk_writebin_i64_arg(Field)
     ;  Type = s(Width)
     -> plawk_writebin_str_arg(Field, Width)
+    ;  Type = lps(Cap)
+    -> plawk_writebin_str_arg(Field, Cap)
     ;  plawk_writebin_f64_arg(Field)
     ),
     plawk_writebin_args_ok(Types, Fields).
@@ -2029,6 +2034,15 @@ plawk_writebin_f64_arg(Field) :-
 %  Evaluate each argument, store it at its layout offset in the shared
 %  %plawk_wbuf buffer, then fwrite the record to stdout.
 plawk_writebin_record_ir(Types, Fields, Slots, Values, FieldSeparator,
+        Prefix, Pair) :-
+    ( plawk_binfmt_has_varlen(Types)
+    ->  plawk_writebin_varlen_record_ir(Types, Fields, Slots, Values,
+            FieldSeparator, Prefix, Pair)
+    ;   plawk_writebin_fixed_record_ir(Types, Fields, Slots, Values,
+            FieldSeparator, Prefix, Pair)
+    ).
+
+plawk_writebin_fixed_record_ir(Types, Fields, Slots, Values, FieldSeparator,
         Prefix, GlobalIR-IR) :-
     plawk_binfmt_record_size(binfmt(Types), Size),
     format(atom(BasePtr), '%~w_base', [Prefix]),
@@ -2045,6 +2059,129 @@ plawk_writebin_record_ir(Types, Fields, Slots, Values, FieldSeparator,
     append([[BaseLine], FieldLines, [StdoutLoad, WriteCall]], AllLines),
     atomic_list_concat(AllLines, '\n', IR),
     atomic_list_concat(GlobalParts, '\n', GlobalIR).
+
+%% plawk_writebin_varlen_record_ir(+Types, +Fields, +Slots, +Values,
+%%     +FieldSeparator, +Prefix, -Pair)
+%
+%  Records whose OUTFMT contains an lps slot are variable-length on the
+%  wire, so the single-buffer fwrite becomes per-slot fwrites emitted
+%  strictly left to right (fwrite buffers in libc, so this is memcpy
+%  cost, not syscall cost). Numeric slots stage their value in the
+%  first 8 bytes of %plawk_wbuf; lps slots write their runtime length
+%  the same way, then the payload straight from its source bytes.
+plawk_writebin_varlen_record_ir(Types, Fields, Slots, Values, FieldSeparator,
+        Prefix, GlobalIR-IR) :-
+    plawk_binfmt_record_size(binfmt(Types), Size),
+    format(atom(BasePtr), '%~w_base', [Prefix]),
+    format(atom(BaseLine),
+        '  ~w = getelementptr inbounds [~w x i8], [~w x i8]* %plawk_wbuf, i32 0, i32 0',
+        [BasePtr, Size, Size]),
+    format(atom(StdoutLoad),
+        '  %~w_stdout = load i8*, i8** @stdout', [Prefix]),
+    format(atom(StdoutVar), '%~w_stdout', [Prefix]),
+    plawk_writebin_varlen_field_lines(Types, Fields, Slots, Values,
+        FieldSeparator, Prefix, BasePtr, StdoutVar, 0, FieldLines, GlobalParts),
+    append([[BaseLine, StdoutLoad], FieldLines], AllLines),
+    atomic_list_concat(AllLines, '\n', IR),
+    atomic_list_concat(GlobalParts, '\n', GlobalIR).
+
+plawk_writebin_varlen_field_lines([], [], _Slots, _Values, _FieldSeparator,
+        _Prefix, _BasePtr, _Stdout, _Index, [], []).
+plawk_writebin_varlen_field_lines([Type | Types], [Field0 | Fields], Slots,
+        Values, FieldSeparator, Prefix, BasePtr, Stdout, Index, Lines,
+        GlobalParts) :-
+    plawk_substitute_scalar_reads(Field0, Slots, Values, Field),
+    format(atom(Base), '~w_f~w', [Prefix, Index]),
+    plawk_writebin_varlen_slot_lines(Type, Field, FieldSeparator, Base,
+        BasePtr, Stdout, SlotLines, GParts),
+    NextIndex is Index + 1,
+    plawk_writebin_varlen_field_lines(Types, Fields, Slots, Values,
+        FieldSeparator, Prefix, BasePtr, Stdout, NextIndex, RestLines,
+        RestGlobals),
+    append(SlotLines, RestLines, Lines),
+    append(GParts, RestGlobals, GlobalParts).
+
+plawk_writebin_varlen_slot_lines(lps(Cap), Field, FieldSeparator, Base,
+        BasePtr, Stdout, Lines, GParts) :-
+    !,
+    plawk_writebin_lps_source_lines(Field, FieldSeparator, Cap, Base,
+        BasePtr, PtrIR, LenIR, SourceLines, GParts),
+    format(atom(LenStore),
+'  %~w_lensp = bitcast i8* ~w to i64*
+  store i64 ~w, i64* %~w_lensp, align 1
+  %~w_lwr = call i64 @fwrite(i8* ~w, i64 8, i64 1, i8* ~w)',
+        [Base, BasePtr, LenIR, Base, Base, BasePtr, Stdout]),
+    format(atom(PayloadWrite),
+        '  %~w_pwr = call i64 @fwrite(i8* ~w, i64 ~w, i64 1, i8* ~w)',
+        [Base, PtrIR, LenIR, Stdout]),
+    append(SourceLines, [LenStore, PayloadWrite], Lines).
+plawk_writebin_varlen_slot_lines(Type, Field, FieldSeparator, Base, BasePtr,
+        Stdout, Lines, GParts) :-
+    % numeric slot: stage the value in the scratch buffer, write 8 bytes
+    ( Type == i64
+    ->  plawk_i64_expr_ir(Field, FieldSeparator, Base, Base, ValueIR,
+            GParts, SetupParts),
+        LLVMType = i64
+    ;   plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
+            GParts, SetupParts),
+        LLVMType = double
+    ),
+    format(atom(StoreWrite),
+'  %~w_sp = bitcast i8* ~w to ~w*
+  store ~w ~w, ~w* %~w_sp, align 1
+  %~w_wr = call i64 @fwrite(i8* ~w, i64 8, i64 1, i8* ~w)',
+        [Base, BasePtr, LLVMType, LLVMType, ValueIR, LLVMType, Base,
+         Base, BasePtr, Stdout]),
+    append(SetupParts, [StoreWrite], Lines).
+
+%% plawk_writebin_lps_source_lines(+Field, +FieldSeparator, +Cap, +Base,
+%%     +BasePtr, -PtrIR, -LenIR, -Lines, -GlobalParts)
+%
+%  Resolve an lps payload source to a (pointer, runtime length) pair.
+%  lps payloads are string-valued: source bytes run to the first NUL or
+%  the source bound, clamped to the slot cap.
+plawk_writebin_lps_source_lines(string(Value), _FieldSeparator, Cap, Base,
+        _BasePtr, PtrIR, StringLen, [PtrLine], [GlobalLine]) :-
+    !,
+    format(atom(LitGlobal), '~w_lit', [Base]),
+    llvm_emit_c_string_global(LitGlobal, Value, GlobalLine, StringLen, BytesLen),
+    StringLen =< Cap,
+    format(atom(PtrIR), '%~w_src', [Base]),
+    format(atom(PtrLine),
+        '  ~w = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
+        [PtrIR, BytesLen, BytesLen, LitGlobal]).
+plawk_writebin_lps_source_lines(field(FieldIndex), binfmt(Types), Cap, Base,
+        _BasePtr, PtrIR, LenIR, [PtrLine, LenLine], []) :-
+    !,
+    plawk_binfmt_field_type(binfmt(Types), FieldIndex, s(SourceWidth)),
+    SourceWidth =< Cap,
+    plawk_binfmt_field_offset(binfmt(Types), FieldIndex, SourceOffset),
+    format(atom(PtrIR), '%~w_src', [Base]),
+    format(atom(LenIR), '%~w_len', [Base]),
+    format(atom(PtrLine),
+        '  ~w = getelementptr i8, i8* %rec, i64 ~w', [PtrIR, SourceOffset]),
+    format(atom(LenLine),
+        '  ~w = call i64 @strnlen(i8* ~w, i64 ~w)',
+        [LenIR, PtrIR, SourceWidth]).
+plawk_writebin_lps_source_lines(field(FieldIndex), FieldSeparator, Cap, Base,
+        BasePtr, PtrIR, LenIR, [SliceIR, ClampIR], []) :-
+    FieldIndex >= 1,
+    llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base,
+        SliceIR),
+    format(atom(PtrIR), '%~w_srcp', [Base]),
+    format(atom(LenIR), '%~w_srclen', [Base]),
+    % a missing field (null slice) writes length 0 with a safe pointer
+    format(atom(ClampIR),
+'  %~w_null = icmp eq i8* %~w_ptr, null
+  %~w_len0 = select i1 %~w_null, i64 0, i64 %~w_len64
+  %~w_over = icmp ugt i64 %~w_len0, ~w
+  ~w = select i1 %~w_over, i64 ~w, i64 %~w_len0
+  ~w = select i1 %~w_null, i8* ~w, i8* %~w_ptr',
+        [Base, Base,
+         Base, Base, Base,
+         Base, Base, Cap,
+         LenIR, Base, Cap, Base,
+         PtrIR, Base, BasePtr, Base]).
 
 plawk_writebin_field_lines([], [], _Slots, _Values, _FieldSeparator, _Prefix,
         _BasePtr, _Index, _Offset, [], []).

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -209,6 +209,62 @@ plawk_program_native_driver_ir(
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% Tagged-union programs: BINFMT = "case(arm0 | arm1 | ...)" plus
+% case K { rules } blocks. Case blocks flatten into one scalar rule
+% chain where each rule's guard checks the record tag before its own
+% pattern, and each rule's fields type against its arm's layout. The
+% END print block is optional (a pure per-arm printer needs none).
+plawk_program_native_driver_ir(
+    program(BeginClauses, case_blocks(CaseBlocks), EndClauses),
+    InputPath,
+    DriverIR
+) :-
+    plawk_record_descriptor(BeginClauses, Descriptor),
+    Descriptor = binfmt_union(Arms),
+    plawk_union_program_ok(Arms, CaseBlocks),
+    plawk_union_flatten_rules(CaseBlocks, Arms, Rules),
+    (   EndClauses = [end([print(PrintFields)])]
+    ->  HasEnd = true
+    ;   EndClauses == [],
+        PrintFields = [],
+        HasEnd = false
+    ),
+    plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_scalar_rule_chain_ir(Rules, StatePlan, Descriptor, OutputSeparator,
+        RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs),
+    append(PrintExprs, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
+    plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
+    plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
+    plawk_scalar_rule_controls(Rules, ScalarRuleControls),
+    plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, NextPhiIR),
+    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, done,
+        BreakCloseIR, FinalStatePhiIR),
+    (   HasEnd == true
+    ->  plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, EndPrintIR)
+    ;   EndPrintIR = ''
+    ),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, RuleGlobalIR]),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w~w
+  ret i32 0',
+        [FinalStatePhiIR, EndPrintIR]),
+    plawk_emit_record_driver_ir(Descriptor, InputPath,
+        driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
+            NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 plawk_program_native_driver_ir(
     program(BeginClauses, Rules, [end([print(PrintFields)])]),
     InputPath,
@@ -1832,6 +1888,9 @@ plawk_field_separator(BeginClauses, FieldSeparator) :-
 %  BEGIN { BINFMT = "i64 i64 f64" } yields binfmt(Types) for fixed-
 %  layout binary records: one 8-byte native-endian field per type,
 %  fields numbered $1..$N, record size 8 * N.
+plawk_record_descriptor(BeginClauses, binfmt_union(Arms)) :-
+    plawk_begin_union_arms(BeginClauses, Arms),
+    !.
 plawk_record_descriptor(BeginClauses, binfmt(Types)) :-
     plawk_begin_binfmt_types(BeginClauses, Types),
     !.
@@ -1839,7 +1898,31 @@ plawk_record_descriptor(BeginClauses, FieldSeparator) :-
     plawk_field_separator(BeginClauses, FieldSeparator).
 
 plawk_begin_has_binfmt(BeginClauses) :-
-    plawk_begin_binfmt_types(BeginClauses, _Types).
+    plawk_begin_binfmt_types(BeginClauses, _Types),
+    !.
+plawk_begin_has_binfmt(BeginClauses) :-
+    plawk_begin_union_arms(BeginClauses, _Arms).
+
+%% plawk_begin_union_arms(+BeginClauses, -Arms)
+%
+%  BINFMT = "case(i64 f64 | lps16 i64)" declares a tagged union: every
+%  record starts with an 8-byte native-endian tag selecting one of the
+%  |-separated arm layouts (arm indices are 0-based, in declaration
+%  order). Arms is a list of type lists.
+plawk_begin_union_arms(BeginClauses, Arms) :-
+    member(begin(Actions), BeginClauses),
+    member(set(var('BINFMT'), string(Fmt)), Actions),
+    string_concat("case(", Rest, Fmt),
+    string_concat(Body, ")", Rest),
+    split_string(Body, "|", " ", ArmStrs),
+    ArmStrs \== [],
+    maplist(plawk_union_arm_types, ArmStrs, Arms).
+
+plawk_union_arm_types(ArmStr, Types) :-
+    split_string(ArmStr, " ", " ", Parts0),
+    exclude(==(""), Parts0, Parts),
+    Parts \== [],
+    maplist(plawk_binfmt_type, Parts, Types).
 
 plawk_begin_binfmt_types(BeginClauses, Types) :-
     member(begin(Actions), BeginClauses),
@@ -2324,6 +2407,106 @@ plawk_writebin_f64_value_ir(Field, FieldSeparator, Base, ValueIR,
 %
 %  Pick the stream skeleton by record representation: text lines or
 %  fixed-size binary records.
+%% plawk_rule_descriptor(+Pattern, +Default, -Descriptor)
+%
+%  Rules inside a case block see their arm's field layout; everything
+%  else uses the program-wide descriptor.
+plawk_rule_descriptor(arm_pat(_Tag, ArmTypes, _Pattern), _Default,
+        binfmt(ArmTypes)) :-
+    !.
+plawk_rule_descriptor(_Pattern, Default, Default).
+
+%% plawk_union_flatten_rules(+CaseBlocks, +Arms, -Rules)
+%
+%  Flatten case blocks into one rule chain, stamping each rule with
+%  arm_pat(Tag, ArmTypes, Pattern) so guards check the record tag and
+%  everything downstream types fields against the right arm.
+plawk_union_flatten_rules(CaseBlocks, Arms, Rules) :-
+    findall(rule(arm_pat(Index, ArmTypes, Pattern), Actions),
+        ( member(case_arm(Index, ArmRules), CaseBlocks),
+          nth0(Index, Arms, ArmTypes),
+          member(rule(Pattern, Actions), ArmRules)
+        ),
+        Rules),
+    Rules \== [].
+
+plawk_union_program_ok(Arms, CaseBlocks) :-
+    length(Arms, ArmCount),
+    forall(member(case_arm(Index, ArmRules), CaseBlocks),
+        ( integer(Index),
+          Index >= 0,
+          Index < ArmCount,
+          nth0(Index, Arms, ArmTypes),
+          forall(member(rule(Pattern, Actions), ArmRules),
+              ( plawk_binfmt_pattern_ok(binfmt(ArmTypes), Pattern),
+                plawk_binfmt_actions_ok(binfmt(ArmTypes), Actions)
+              ))
+        )).
+
+%% plawk_union_read_ir(+Arms, +LoweredLabel, -ReadIR)
+%
+%  Read the 8-byte tag (the only place clean EOF is legal), switch on
+%  it, and run the selected arm's field-by-field read sequence. Every
+%  arm materializes its fields at offset 0 of %rec (the tag itself
+%  lives only in %vr_tag), so each arm's access layout is a plain
+%  binfmt(ArmTypes). An unknown tag is malformed input -> fail_read.
+plawk_union_read_ir(Arms, LoweredLabel, ReadIR) :-
+    findall(SwitchEntry,
+        ( nth0(Index, Arms, _),
+          format(atom(SwitchEntry), 'i64 ~w, label %vr_a~w', [Index, Index])
+        ),
+        SwitchEntries),
+    atomic_list_concat(SwitchEntries, ' ', SwitchBody),
+    format(atom(TagIR),
+'  %vr_tag_status = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %vr_len_i8)
+  %vr_tag_eof = icmp eq i64 %vr_tag_status, 0
+  br i1 %vr_tag_eof, label %close_stream, label %vr_tag_chk
+
+vr_tag_chk:
+  %vr_tag_ok = icmp eq i64 %vr_tag_status, 1
+  br i1 %vr_tag_ok, label %vr_tag_switch, label %fail_read
+
+vr_tag_switch:
+  %vr_tag = load i64, i64* %vr_len_scratch
+  switch i64 %vr_tag, label %fail_read [ ~w ]
+',
+        [SwitchBody]),
+    findall(ArmIR,
+        ( nth0(Index, Arms, ArmTypes),
+          format(atom(ArmPrefix), 'vr_a~w', [Index]),
+          plawk_varlen_field_sections(ArmTypes, LoweredLabel, ArmPrefix,
+              no_eof, 0, 0, Sections),
+          atomic_list_concat(Sections, '\n', ArmBodyIR),
+          format(atom(ArmIR), '~w:~n~w', [ArmPrefix, ArmBodyIR])
+        ),
+        ArmIRs),
+    atomic_list_concat([TagIR | ArmIRs], '\n', ReadIR).
+
+plawk_union_buf_size(Arms, BufSize) :-
+    findall(Size,
+        ( member(ArmTypes, Arms),
+          plawk_binfmt_record_size(binfmt(ArmTypes), Size)
+        ),
+        Sizes),
+    max_list(Sizes, BufSize).
+
+plawk_emit_record_driver_ir(binfmt_union(Arms), InputPath, Blocks, DriverIR) :-
+    !,
+    plawk_union_buf_size(Arms, BufSize),
+    plawk_normalize_driver_blocks(Blocks,
+        driver_blocks(RuntimeGlobals, EntrySetupIR0, LoopPhiIR, LoweredLabel,
+            RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR)),
+    % the 8-byte scratch holds the tag, then any lps length prefixes
+    plawk_combine_entry_ir(EntrySetupIR0,
+'  %vr_len_scratch = alloca i64, align 8
+  %vr_len_i8 = bitcast i64* %vr_len_scratch to i8*',
+        EntrySetupIR),
+    plawk_union_read_ir(Arms, LoweredLabel, ReadIR),
+    llvm_emit_varlen_stream_driver_ir(InputPath, BufSize, ReadIR,
+        driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel,
+            RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
+        DriverIR).
+
 plawk_emit_record_driver_ir(binfmt(Types), InputPath, Blocks, DriverIR) :-
     plawk_binfmt_has_varlen(Types),
     !,
@@ -2374,89 +2557,95 @@ plawk_normalize_driver_blocks(Blocks, Blocks).
 %  zero the slot, then read the payload (a zero length reads nothing:
 %  @wam_stream_read_record returns 1 immediately for size 0).
 plawk_varlen_read_ir(Types, LoweredLabel, ReadIR) :-
-    plawk_varlen_field_sections(Types, LoweredLabel, 0, 0, Sections),
+    plawk_varlen_field_sections(Types, LoweredLabel, vr, eof_first, 0, 0,
+        Sections),
     atomic_list_concat(Sections, '\n', ReadIR).
 
-plawk_varlen_field_sections([], _LoweredLabel, _Index, _Offset, []).
-plawk_varlen_field_sections([Type | Types], LoweredLabel, Index, Offset,
-        [Section | Sections]) :-
+plawk_varlen_field_sections([], _LoweredLabel, _Prefix, _EofPolicy, _Index,
+        _Offset, []).
+plawk_varlen_field_sections([Type | Types], LoweredLabel, Prefix, EofPolicy,
+        Index, Offset, [Section | Sections]) :-
     ( Types == []
     -> NextLabel = LoweredLabel
     ;  NextIndex0 is Index + 1,
-       format(atom(NextLabel), 'vr_f~w', [NextIndex0])
+       format(atom(NextLabel), '~w_f~w', [Prefix, NextIndex0])
     ),
     ( Index =:= 0
     -> LabelIR = ''
-    ;  format(atom(LabelIR), 'vr_f~w:~n', [Index])
+    ;  format(atom(LabelIR), '~w_f~w:~n', [Prefix, Index])
     ),
-    plawk_varlen_field_body(Type, Index, Offset, NextLabel, BodyIR),
+    format(atom(FBase), '~w_f~w', [Prefix, Index]),
+    ( Index =:= 0, EofPolicy == eof_first
+    -> FieldEof = eof
+    ;  FieldEof = no_eof
+    ),
+    plawk_varlen_field_body(Type, FBase, FieldEof, Offset, NextLabel, BodyIR),
     format(atom(Section), '~w~w', [LabelIR, BodyIR]),
     plawk_binfmt_type_width(Type, Width),
     NextOffset is Offset + Width,
     NextIndex is Index + 1,
-    plawk_varlen_field_sections(Types, LoweredLabel, NextIndex, NextOffset,
-        Sections).
+    plawk_varlen_field_sections(Types, LoweredLabel, Prefix, EofPolicy,
+        NextIndex, NextOffset, Sections).
 
-plawk_varlen_field_body(lps(Cap), Index, Offset, NextLabel, BodyIR) :-
+plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
     !,
-    plawk_varlen_eof_check_ir(Index, lstatus, BodyPrefixIR, OkLabelIR),
+    plawk_varlen_eof_check_ir(FieldEof, FBase, lstatus, BodyPrefixIR),
     format(atom(BodyIR),
-'  %vr_f~w_lstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %vr_len_i8)
-~w~w  %vr_f~w_lok = icmp eq i64 %vr_f~w_lstatus, 1
-  br i1 %vr_f~w_lok, label %vr_f~w_len, label %fail_read
+'  %~w_lstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %vr_len_i8)
+~w  %~w_lok = icmp eq i64 %~w_lstatus, 1
+  br i1 %~w_lok, label %~w_len, label %fail_read
 
-vr_f~w_len:
-  %vr_f~w_n = load i64, i64* %vr_len_scratch
-  %vr_f~w_fits = icmp ule i64 %vr_f~w_n, ~w
-  br i1 %vr_f~w_fits, label %vr_f~w_read, label %fail_read
+~w_len:
+  %~w_n = load i64, i64* %vr_len_scratch
+  %~w_fits = icmp ule i64 %~w_n, ~w
+  br i1 %~w_fits, label %~w_read, label %fail_read
 
-vr_f~w_read:
-  %vr_f~w_dst = getelementptr i8, i8* %rec, i64 ~w
-  call void @llvm.memset.p0i8.i64(i8* %vr_f~w_dst, i8 0, i64 ~w, i1 false)
-  %vr_f~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %vr_f~w_n, i8* %vr_f~w_dst)
-  %vr_f~w_pok = icmp eq i64 %vr_f~w_pstatus, 1
-  br i1 %vr_f~w_pok, label %~w, label %fail_read
+~w_read:
+  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  call void @llvm.memset.p0i8.i64(i8* %~w_dst, i8 0, i64 ~w, i1 false)
+  %~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %~w_n, i8* %~w_dst)
+  %~w_pok = icmp eq i64 %~w_pstatus, 1
+  br i1 %~w_pok, label %~w, label %fail_read
 ',
-        [Index,
-         BodyPrefixIR, OkLabelIR, Index, Index,
-         Index, Index,
-         Index,
-         Index,
-         Index, Index, Cap,
-         Index, Index,
-         Index,
-         Index, Offset,
-         Index, Cap,
-         Index, Index, Index,
-         Index, Index,
-         Index, NextLabel]).
-plawk_varlen_field_body(_NumericType, Index, Offset, NextLabel, BodyIR) :-
-    plawk_varlen_eof_check_ir(Index, status, BodyPrefixIR, OkLabelIR),
+        [FBase,
+         BodyPrefixIR, FBase, FBase,
+         FBase, FBase,
+         FBase,
+         FBase,
+         FBase, FBase, Cap,
+         FBase, FBase,
+         FBase,
+         FBase, Offset,
+         FBase, Cap,
+         FBase, FBase, FBase,
+         FBase, FBase,
+         FBase, NextLabel]).
+plawk_varlen_field_body(_NumericType, FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+    plawk_varlen_eof_check_ir(FieldEof, FBase, status, BodyPrefixIR),
     format(atom(BodyIR),
-'  %vr_f~w_dst = getelementptr i8, i8* %rec, i64 ~w
-  %vr_f~w_status = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %vr_f~w_dst)
-~w~w  %vr_f~w_ok = icmp eq i64 %vr_f~w_status, 1
-  br i1 %vr_f~w_ok, label %~w, label %fail_read
+'  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  %~w_status = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
+~w  %~w_ok = icmp eq i64 %~w_status, 1
+  br i1 %~w_ok, label %~w, label %fail_read
 ',
-        [Index, Offset,
-         Index, Index,
-         BodyPrefixIR, OkLabelIR, Index, Index,
-         Index, NextLabel]).
+        [FBase, Offset,
+         FBase, FBase,
+         BodyPrefixIR, FBase, FBase,
+         FBase, NextLabel]).
 
 % Only the record's first read may see clean EOF (status 0). Later
 % fields fall straight through to the 1/other check, where 0 lands in
 % fail_read like any short read.
-plawk_varlen_eof_check_ir(0, StatusSuffix, BodyPrefixIR, OkLabelIR) :-
+plawk_varlen_eof_check_ir(eof, FBase, StatusSuffix, BodyPrefixIR) :-
     !,
     format(atom(BodyPrefixIR),
-'  %vr_f0_eof = icmp eq i64 %vr_f0_~w, 0
-  br i1 %vr_f0_eof, label %close_stream, label %vr_f0_chk
+'  %~w_eof = icmp eq i64 %~w_~w, 0
+  br i1 %~w_eof, label %close_stream, label %~w_chk
 
-vr_f0_chk:
+~w_chk:
 ',
-        [StatusSuffix]),
-    OkLabelIR = ''.
-plawk_varlen_eof_check_ir(_Index, _StatusSuffix, '', '').
+        [FBase, FBase, StatusSuffix, FBase, FBase, FBase]).
+plawk_varlen_eof_check_ir(no_eof, _FBase, _StatusSuffix, '').
 
 plawk_output_separator(BeginClauses, OutputSeparator) :-
     (   member(begin(Actions), BeginClauses),
@@ -2764,13 +2953,15 @@ plawk_scalar_rule_chain_lines([scalar_rule(Index, Pattern, Actions, Control) | R
       format(atom(MatchVar), 'rule_~w_is_match', [Index]),
       format(atom(GlobalBase), 'plawk_surface_rule_~w', [Index]),
       format(atom(MatchValue), '%~w', [MatchVar]),
-      plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, MatchValue,
+      % tagged-union rules carry their arm's field types with them
+      plawk_rule_descriptor(Pattern, FieldSeparator, RuleDescriptor),
+      plawk_pattern_guard_ir(Pattern, RuleDescriptor, GlobalBase, MatchValue,
           GuardGlobalIR-GuardCallIR),
       plawk_rule_target(Control, NextLabel, RuleTargetLabel),
       maplist(plawk_scalar_rule_body_action, Actions),
       BodyActions = Actions,
       plawk_scalar_rule_input_phi_ir(StatePlan, Index, Controls, InputPhiIR),
-      plawk_scalar_match_update_ir(StatePlan, BodyActions, FieldSeparator, OutputSeparator, Index,
+      plawk_scalar_match_update_ir(StatePlan, BodyActions, RuleDescriptor, OutputSeparator, Index,
           BranchNextExits, MatchUpdateGlobalIR-MatchUpdateIR),
       ( Index =:= 0
       -> EntryIR = '  br label %rule_0_match\n\n'
@@ -3976,6 +4167,30 @@ plawk_pattern_guard_ir(field_cmp(Index, Op, Value), GlobalBase, MatchValue, Guar
     plawk_pattern_guard_ir(field_cmp(Index, Op, Value), 32, GlobalBase,
         MatchValue, GuardIR).
 
+% Tagged-union rule guard: the record tag must equal the rule's arm,
+% and the inner pattern (typed against the arm's layout) must match.
+% %vr_tag is loaded once per record in the union read sequence and
+% dominates every rule block. Field reads in the inner guard are safe
+% even when the tag check fails: the record buffer is always at least
+% as large as the widest arm, so a mismatched read sees stale-but-owned
+% bytes and its result is discarded by the and.
+plawk_pattern_guard_ir(arm_pat(Tag, ArmTypes, Pattern), _FieldSeparator,
+        GlobalBase, MatchValue, GuardIR) :-
+    !,
+    format(atom(TagOk), '%~w_tag_ok', [GlobalBase]),
+    format(atom(TagCheck), '  ~w = icmp eq i64 %vr_tag, ~w', [TagOk, Tag]),
+    ( Pattern == always
+    ->  format(atom(CallIR), '~w~n  ~w = and i1 ~w, true',
+            [TagCheck, MatchValue, TagOk]),
+        GuardIR = ''-CallIR
+    ;   format(atom(InnerBase), '~w_arm', [GlobalBase]),
+        format(atom(InnerValue), '~w_arm', [MatchValue]),
+        plawk_pattern_guard_ir(Pattern, binfmt(ArmTypes), InnerBase,
+            InnerValue, GlobalIR-InnerCallIR),
+        format(atom(CallIR), '~w~n~w~n  ~w = and i1 ~w, ~w',
+            [TagCheck, InnerCallIR, MatchValue, TagOk, InnerValue]),
+        GuardIR = GlobalIR-CallIR
+    ).
 plawk_pattern_guard_ir(always, _FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     plawk_pattern_guard_ir(always, GlobalBase, MatchValue, GuardIR).
 plawk_pattern_guard_ir(prefix(Prefix), _FieldSeparator, GlobalBase, MatchValue, GuardIR) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -47,9 +47,43 @@ plawk_parse_string(Source, Program) :-
 plawk_program(program(BeginClauses, Rules, EndClauses)) -->
     ws,
     begin_clauses(BeginClauses),
-    rules(Rules),
+    program_rules(Rules),
     end_clauses(EndClauses),
     eos.
+
+% Tagged-union programs route rules through per-arm case blocks: the
+% arm index scopes the field types of every rule inside the block.
+program_rules(case_blocks(Blocks)) -->
+    case_block(Block),
+    !,
+    case_blocks_rest(Blocks0),
+    { Blocks = [Block | Blocks0] }.
+program_rules(Rules) -->
+    rules(Rules).
+
+case_blocks_rest([Block | Blocks]) -->
+    ws,
+    case_block(Block),
+    !,
+    case_blocks_rest(Blocks).
+case_blocks_rest([]) -->
+    ws.
+
+case_block(case_arm(Index, Rules)) -->
+    "case",
+    identifier_boundary,
+    ws,
+    integer_codes(IndexCodes),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    },
+    ws,
+    "{",
+    ws,
+    rules(Rules),
+    ws,
+    "}".
 
 rules([Rule | Rules]) -->
     rule(Rule),

--- a/tests/test_plawk_tagged_unions.pl
+++ b/tests/test_plawk_tagged_unions.pl
@@ -1,0 +1,199 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_tun_marker/0.
+
+user:plawk_tun_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_tagged_unions, [condition(clang_available)]).
+
+test(parses_case_blocks) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { $1 > 100 { c++ } } case 1 { { d++ } } END { print c, d }\n", Program),
+    Program = program(_, case_blocks(Blocks), _),
+    assertion(Blocks == [case_arm(0, [rule(field_cmp(1, gt, 100), [inc(var(c))])]),
+                         case_arm(1, [rule(always, [inc(var(d))])])]).
+
+test(union_ir_has_tag_switch_and_arm_reads) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { $1 > 100 { c++ } } case 1 { { d++ } } END { print c, d }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % tag read + native switch dispatching per-arm read sequences
+    assertion(once(sub_atom(DriverIR, _, _, _, 'switch i64 %vr_tag, label %fail_read [ i64 0, label %vr_a0 i64 1, label %vr_a1 ]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_a0_f0_dst'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_a1_f0_fits'))),
+    % buffer = widest arm (lps16 + i64 = 24), tag lives only in %vr_tag
+    assertion(once(sub_atom(DriverIR, _, _, _, 'malloc(i64 24)'))),
+    % rule guards check the tag before their own pattern
+    assertion(once(sub_atom(DriverIR, _, _, _, '_tag_ok = icmp eq i64 %vr_tag, 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_tag_ok = icmp eq i64 %vr_tag, 1'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(union_rejections) :-
+    Rejects = [
+        % case index beyond the declared arms
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 2 { { c++ } } END { print c }\n",
+        % arm-typed field misuse: string equality on an i64 field
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { $1 == \"x\" { c++ } } END { print c }\n",
+        % numeric compare on an lps field
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 1 { $1 > 5 { c++ } } END { print c }\n",
+        % assoc arrays are not in the union slice
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { { counts[$1]++ } } END { print counts[5] }\n",
+        % case blocks demand a union BINFMT
+        "case 0 { { c++ } } END { print c }\n",
+        "BEGIN { BINFMT = \"i64 i64\" } case 0 { { c++ } } END { print c }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_union_dispatch_and_state) :-
+    % Two record kinds interleaved: metrics (i64 f64) aggregate, events
+    % (lps16 i64) print and count -- one native loop, shared END.
+    run_tun_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { $1 > 100 { msum += float($2) ; mhits++ } } case 1 { $2 == 7 { print $1 } $1 == \"boom\" { events++ } } END { print mhits, msum, events }\n",
+        [m(50, 1.5), e("hello", 7), m(200, 2.5), e("boom", 3), m(300, 0.25), e("boom", 7)],
+        "hello\nboom\n2 2.75 2\n").
+
+test(surface_union_unhandled_arm_still_reads) :-
+    % No case 0 block: metric records are read (and skipped) correctly,
+    % keeping stream framing intact for the events that follow.
+    run_tun_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 1 { { events++ } } END { print events }\n",
+        [m(50, 1.5), e("x", 1), m(200, 2.5), e("y", 2)],
+        "2\n").
+
+test(surface_union_next_and_nr) :-
+    % NR counts records of every arm; next works inside a case block.
+    run_tun_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 1 { $1 == \"skip\" { next } { events++ } } END { print NR, events }\n",
+        [m(1, 1.0), e("skip", 0), e("go", 0), m(2, 2.0)],
+        "4 1\n").
+
+test(surface_union_endless_program) :-
+    run_tun_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 1 { { print $1, $2 } }\n",
+        [m(1, 1.0), e("aa", 5), e("bb", 6)],
+        "aa 5\nbb 6\n").
+
+test(surface_union_error_paths) :-
+    build_tun_probe("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { { c++ } } END { print c }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    % unknown tag
+    write_bytes(InputPath, [i64(9), pad(16)]),
+    run_status(BinPath, exit(11)),
+    % truncated arm 0 (tag + i64, missing the f64)
+    write_bytes(InputPath, [i64(0), i64(5)]),
+    run_status(BinPath, exit(11)),
+    % clean EOF at a record boundary runs END
+    write_bytes(InputPath, []),
+    run_expect(BinPath, "0\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,  0x3FF8000000000000).
+double_bits(2.5,  0x4004000000000000).
+double_bits(0.25, 0x3FD0000000000000).
+double_bits(1.0,  0x3FF0000000000000).
+double_bits(2.0,  0x4000000000000000).
+
+% m(V, F): arm 0 = tag 0, i64 V, f64 F.  e(S, C): arm 1 = tag 1, lps16 S, i64 C.
+write_union_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Rec, Recs),
+            ( Rec = m(V, F)
+            -> ( write_i64_le(Out, 0), write_i64_le(Out, V),
+                 double_bits(F, Bits), write_i64_le(Out, Bits) )
+            ;  Rec = e(S, C),
+               string_codes(S, Codes),
+               length(Codes, Len),
+               write_i64_le(Out, 1), write_i64_le(Out, Len),
+               forall(member(Ch, Codes), put_byte(Out, Ch)),
+               write_i64_le(Out, C)
+            )),
+        close(Out)).
+
+write_bytes(Path, Items) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Item, Items),
+            ( Item = i64(V) -> write_i64_le(Out, V)
+            ; Item = pad(N) -> forall(between(1, N, _), put_byte(Out, 0))
+            )),
+        close(Out)).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_tun_marker/0 ],
+        [module_name('plawk_tagged_unions')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk tagged unions build output]~n~w~n", [BuildOut]),
+       throw(plawk_tagged_unions_build_failed(Status))
+    ).
+
+build_tun_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_tagged_unions', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_status(BinPath, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(null), stderr(std), process(Pid)]),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+run_expect(BinPath, ExpectedOutput) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == ExpectedOutput).
+
+run_tun_smoke(Source, Recs, ExpectedOutput) :-
+    build_tun_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_union_records(InputPath, Recs),
+    run_expect(BinPath, ExpectedOutput),
+    !.
+
+:- end_tests(plawk_tagged_unions).

--- a/tests/test_plawk_varlen_writers.pl
+++ b/tests/test_plawk_varlen_writers.pl
@@ -1,0 +1,215 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_vlw_marker/0.
+
+user:plawk_vlw_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_varlen_writers, [condition(clang_available)]).
+
+test(varlen_outfmt_ir_uses_per_slot_fwrites) :-
+    plawk_parse_string("BEGIN { OUTFMT = \"lps16 i64\" } { writebin $1, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    % lps slot: one fwrite for the length, one for the payload; numeric
+    % slot: one staged fwrite. No single whole-record fwrite.
+    assertion(once(sub_atom(DriverIR, _, _, _, '_lwr = call i64 @fwrite('))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_pwr = call i64 @fwrite('))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_wr = call i64 @fwrite('))),
+    % text-mode source: slice + null guard + cap clamp
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_over = icmp ugt i64 '))),
+    !.
+
+test(fixed_outfmt_keeps_single_record_fwrite) :-
+    plawk_parse_string("BEGIN { OUTFMT = \"s16 i64\" } { writebin $1, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 24, i64 1, i8*'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '_lwr = ')),
+    !.
+
+test(varlen_writer_rejections) :-
+    Rejects = [
+        % literal longer than the cap
+        "BEGIN { OUTFMT = \"lps4\" } { writebin \"toolong\" }\n",
+        % source cap wider than the output cap
+        "BEGIN { BINFMT = \"lps8 i64\" ; OUTFMT = \"lps4\" } { writebin $1 }\n",
+        % numeric input field into an lps slot
+        "BEGIN { BINFMT = \"i64 i64\" ; OUTFMT = \"lps8\" } { writebin $1 }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.txt', _))
+        ;  true
+        )).
+
+test(surface_text_to_varlen_exact_lengths) :-
+    % Wire lengths are exact: no padding for short values, no clamp
+    % needed at exactly the cap.
+    build_vlw_probe("BEGIN { OUTFMT = \"lps16 i64\" } { writebin $1, $2 }\n",
+        text("alpha 5\nverylongname1234 7\n"), _Dir, BinPath),
+    run_capture_raw(BinPath, Bytes, exit(0)),
+    decode_lps_i64(Bytes, Records),
+    assertion(Records == ["alpha"-5, "verylongname1234"-7]),
+    !.
+
+test(surface_text_clamps_to_cap) :-
+    build_vlw_probe("BEGIN { OUTFMT = \"lps4 i64\" } { writebin $1, NR }\n",
+        text("longvalue x\nab y\n"), _Dir, BinPath),
+    run_capture_raw(BinPath, Bytes, exit(0)),
+    decode_lps_i64(Bytes, Records),
+    assertion(Records == ["long"-1, "ab"-2]),
+    !.
+
+test(surface_varlen_transform_with_literal_and_empty) :-
+    build_vlw_probe("BEGIN { BINFMT = \"i64 lps8\" ; OUTFMT = \"lps4 lps8 i64\" } $1 > 10 { writebin \"tag\", $2, $1 * 2 }\n",
+        lps_recs([rec(5, "aa"), rec(20, "bee"), rec(40, "")]), _Dir, BinPath),
+    run_capture_raw(BinPath, Bytes, exit(0)),
+    decode_lps_lps_i64(Bytes, Records),
+    assertion(Records == [t("tag", "bee", 40), t("tag", "", 80)]),
+    !.
+
+test(surface_varlen_round_trip) :-
+    % Writer output is byte-compatible with the varlen READER: stage 1
+    % converts text to lps16 records, stage 2 reads them back with
+    % BINFMT and aggregates.
+    build_vlw_probe("BEGIN { OUTFMT = \"lps16 i64\" } { writebin $1, $2 }\n",
+        text("alpha 5\nbeta 7\nalpha 2\n"), Dir1, Bin1),
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_varlen_writers_b', Dir2),
+    clean_dir(Dir2),
+    make_directory_path(Dir2),
+    directory_file_path(Dir2, 'stage.bin', StagePath),
+    plawk_parse_string("BEGIN { BINFMT = \"lps16 i64\" } $1 == \"alpha\" { sum += $2 } END { print sum }\n", Program2),
+    plawk_program_native_driver_ir(Program2, StagePath, Driver2),
+    emit_probe(Dir2, Driver2, Bin2),
+    format(atom(Cmd), '~w > ~w && ~w', [Bin1, StagePath, Bin2]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == "7\n"),
+    assertion(Dir1 \== ''),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+take_i64(Codes, V, Rest) :-
+    length(Bytes, 8),
+    append(Bytes, Rest, Codes),
+    le_i64(Bytes, V).
+
+take_lps(Codes, S, Rest) :-
+    take_i64(Codes, Len, Rest0),
+    length(PayloadCodes, Len),
+    append(PayloadCodes, Rest, Rest0),
+    string_codes(S, PayloadCodes).
+
+decode_lps_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_lps_i64_codes(Codes, Records).
+
+decode_lps_i64_codes([], []).
+decode_lps_i64_codes(Codes, [S-V | Records]) :-
+    take_lps(Codes, S, Rest0),
+    take_i64(Rest0, V, Rest),
+    decode_lps_i64_codes(Rest, Records).
+
+decode_lps_lps_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_lps_lps_i64_codes(Codes, Records).
+
+decode_lps_lps_i64_codes([], []).
+decode_lps_lps_i64_codes(Codes, [t(A, B, V) | Records]) :-
+    take_lps(Codes, A, Rest0),
+    take_lps(Rest0, B, Rest1),
+    take_i64(Rest1, V, Rest),
+    decode_lps_lps_i64_codes(Rest, Records).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_vlw_marker/0 ],
+        [module_name('plawk_varlen_writers')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk varlen writers build output]~n~w~n", [BuildOut]),
+       throw(plawk_varlen_writers_build_failed(Status))
+    ).
+
+build_vlw_probe(Source, Input, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_varlen_writers', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    ( Input = text(Text)
+    ->  directory_file_path(Dir, 'input.txt', InputPath),
+        setup_call_cleanup(
+            open(InputPath, write, Out, [encoding(utf8)]),
+            write(Out, Text),
+            close(Out))
+    ;   Input = lps_recs(Recs),
+        directory_file_path(Dir, 'input.bin', InputPath),
+        setup_call_cleanup(
+            open(InputPath, write, Out, [type(binary)]),
+            forall(member(rec(V, S), Recs),
+                ( write_i64_le(Out, V),
+                  string_codes(S, Codes),
+                  length(Codes, Len),
+                  write_i64_le(Out, Len),
+                  forall(member(C, Codes), put_byte(Out, C)) )),
+            close(Out))
+    ),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_capture_raw(BinPath, Bytes, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+:- end_tests(plawk_varlen_writers).


### PR DESCRIPTION
## Why

The cascade again stopped short of main: #3420 landed, but #3421 (varlen writers) merged into this branch and #3422 (tagged unions) into the varlen-writers branch. This PR carries both to main, plus one new commit.

**Merge this first**; the bounded-repetition PR stacks on top.

## New: tutorial section on binary records and tagged unions

`examples/plawk/TUTORIAL.md` now ends with a from-first-principles walkthrough written for someone who knows awk but not C-style data layout:

- why binary records exist (a load instruction instead of parsing digits every record), with byte-offset diagrams of `i64 f64` layouts;
- fixed (`s8`) vs length-prefixed (`lps16`) strings, and the "variable on the wire, fixed in memory" trick that makes everything downstream work;
- what a **tagged union** is and where the vocabulary comes from — *tag*/*discriminator* and *arm* are C and pattern-matching concepts, not awk or Prolog (Prolog's analogue is different functors like `metric(Id,V)` vs `event(Name,Code)`);
- how `case K { ... }` blocks route ordinary awk rules by record kind, and why blocks rather than tag guards (the types of `$1, $2` depend on the arm, so the compiler must know the arm before it can type a rule);
- what the compiled loop actually does per record (tag read → native switch → arm reader → rules).

Linked from the plawk README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_