### PR TITLE
plawk: bounded repetition (repK + foreach)

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -37,7 +37,7 @@ handles) maps to an **access type** (what consumers see):
 | `sN` | N | `sN` | N bytes |
 | `lpsN` (landed) | 8 + len, len ≤ N | `sN` | N bytes, NUL-padded |
 | tagged union (landed) | 8-byte tag + arm | per-arm `$1..$N` via `case` blocks | widest arm (tag in SSA only) |
-| bounded repetition (planned) | 8-byte count + count×elem, count ≤ K | count `i64` + K elems | count slot + K elem slots |
+| bounded repetition (landed) | 8-byte count + count×elem, count ≤ K | count `i64` + K flat elem fields; `foreach` | count slot + K elem slots, zeroed past count |
 
 ## The lowering spectrum
 
@@ -125,9 +125,17 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    framed. The tag-guard spelling (`$0 == K && ...`) can later be
    accepted as sugar that desugars into a case block. Not yet inside
    case blocks: assoc arrays, writebin, and union output.
-2. **Bounded repetition:** `count` header + up to K fixed elements;
-   access layout is a count slot plus K element slots; `for` over
-   elements in rule bodies is the surface question.
+2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
+   count (≤ K) then that many fixed-width elements, read as one bulk
+   count×elemsize read after a memset of the element region (element
+   slots past the count are deterministic zeros). Access layout
+   flattens: the count is an i64 field and each element's fields are
+   plain record fields. The surface answer to "for over elements" is
+   `foreach { actions }`: inside the block `$1..$M` are the current
+   element's fields, and the block unrolls at compile time into K
+   count-guarded ifs (`count >= j`), reusing the existing if/join-phi
+   machinery — no loop-carried phis were added. One rep per layout,
+   fixed-width elements only, no nesting; those are later extensions.
 3. **Varlen writers (landed):** `lpsN` in OUTFMT emits the 8-byte
    length plus exactly the payload bytes, sourced from literals,
    `sM`/`lpsM` input fields (`M ≤ cap`), or text-mode slices clamped to

--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -508,8 +508,9 @@ general approach (Tier 1: LL(1)-over-fields grammars with compile-time
 caps compile to native field-by-field read sequences; Tier 2: native
 framing + WAM-bytecode payload parsing via the foreign bridge; Tier 3:
 full DCG fallback, the Phase 5 JIT target). Landed since: varlen
-writers (lpsN in OUTFMT) and tagged unions (case-block surface, native
-tag switch); bounded repetition remains. Remaining Phase 3
+writers (lpsN in OUTFMT), tagged unions (case-block surface, native
+tag switch), and bounded repetition (repK(...) + foreach, compile-time
+unrolled); Tier-2 composition sugar remains. Remaining Phase 3
 items below (richer ABIs) are otherwise unchanged.
 
 **Second slice landed (typed associative arrays):** in binary mode

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -93,6 +93,7 @@ swipl -q -s tests/test_plawk_outfmt_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_varlen_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_varlen_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tagged_unions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_bounded_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -284,6 +285,15 @@ that materializes each record into the same fixed access layout, so an
 guards, `sN` OUTFMT passthrough) while numeric fields keep guards,
 arithmetic, and assoc keys. Clean EOF is only legal at a record
 boundary; oversized lengths, truncated payloads, and mid-record EOF
+exit with the read-error code. Bounded repetition handles records containing a
+list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
+(at most 4) followed by that many (i64, f64) elements. The count is an
+ordinary i64 field, element slots are flat addressable fields
+(zero-filled past the count), and `foreach { ... }` runs its block once
+per element with `$1..$M` meaning the current element's fields - it
+unrolls at compile time into count-guarded ifs, so the loop machinery
+is the existing if/join emitters and the wire read is one bulk
+count*elemsize read. Oversized counts and truncated element regions
 exit with the read-error code. Tagged unions let one stream carry several
 record kinds: `BINFMT = "case(i64 f64 | lps16 i64)"` declares that
 every record starts with an 8-byte tag selecting an arm layout, and

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -601,3 +601,31 @@ No interpreter, no allocation; a malformed record (unknown tag,
 truncated bytes) exits with the read-error code, and record kinds you
 wrote no block for are still read and skipped, so the stream never
 loses its framing.
+
+### Repetition: records that contain a list
+
+Some records carry a variable number of sub-items — an order with up
+to 4 line items, a reading with up to 8 samples. The wire convention
+mirrors `lps`: a count, then that many elements:
+
+```text
+            +--------+--------+--------+--------+--------+--------+
+            |  i64   | count=2| elem 1 (i64,f64)| elem 2 (i64,f64)|
+            +--------+--------+--------+--------+--------+--------+
+```
+
+Declared as `BINFMT = "i64 rep4(i64 f64)"` — "an i64, then up to 4
+(i64, f64) elements". To process the elements, `foreach { ... }` runs
+its block once per element, and inside the block `$1, $2` mean *the
+current element's* fields:
+
+```awk
+BEGIN { BINFMT = "i64 rep4(i64 f64)" }
+$1 > 0 { foreach { n++ ; wsum += float($2) } }
+END { print n, wsum }
+```
+
+Because the cap (4) is known at compile time, the compiler does not
+emit a loop at all — it writes the block out 4 times, each copy
+guarded by "does the record have at least j elements?". Constant
+memory, straight-line native code, same as everything else.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -168,14 +168,15 @@ plawk_program_native_driver_ir(
     InputPath,
     DriverIR
 ) :-
-    plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules, WritebinPlan),
+    plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules1, WritebinPlan),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_resolve_foreach_rules(FieldSeparator, Rules1, Rules),
     plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR0),
     plawk_writebin_entry_lines(WritebinPlan, WritebinEntryIR),
     plawk_join_nonempty_ir([BeginIR0, WritebinEntryIR], BeginIR),
-    plawk_record_descriptor(BeginClauses, FieldSeparator),
     plawk_record_program_ok(FieldSeparator, Rules, PrintFields),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator,
@@ -1927,10 +1928,37 @@ plawk_union_arm_types(ArmStr, Types) :-
 plawk_begin_binfmt_types(BeginClauses, Types) :-
     member(begin(Actions), BeginClauses),
     member(set(var('BINFMT'), string(Fmt)), Actions),
-    split_string(Fmt, " ", " ", Parts0),
-    exclude(==(""), Parts0, Parts),
+    plawk_binfmt_tokens(Fmt, Parts),
     Parts \== [],
     maplist(plawk_binfmt_type, Parts, Types).
+
+%% plawk_binfmt_tokens(+Fmt, -Parts)
+%
+%  Space-split, but a token containing "(" absorbs following tokens
+%  until its ")" closes, so "i64 rep4(i64 f64)" tokenizes as
+%  ["i64", "rep4(i64 f64)"].
+plawk_binfmt_tokens(Fmt, Parts) :-
+    split_string(Fmt, " ", " ", Parts0),
+    exclude(==(""), Parts0, Parts1),
+    plawk_binfmt_join_parens(Parts1, Parts).
+
+plawk_binfmt_join_parens([], []).
+plawk_binfmt_join_parens([Part | Rest], [Joined | Parts]) :-
+    sub_string(Part, _, _, _, "("),
+    \+ sub_string(Part, _, _, _, ")"),
+    !,
+    plawk_binfmt_take_until_close(Rest, Taken, Remaining),
+    atomic_list_concat([Part | Taken], ' ', JoinedAtom),
+    atom_string(JoinedAtom, Joined),
+    plawk_binfmt_join_parens(Remaining, Parts).
+plawk_binfmt_join_parens([Part | Rest], [Part | Parts]) :-
+    plawk_binfmt_join_parens(Rest, Parts).
+
+plawk_binfmt_take_until_close([Part | Rest], [Part], Rest) :-
+    sub_string(Part, _, _, _, ")"),
+    !.
+plawk_binfmt_take_until_close([Part | Rest], [Part | Taken], Remaining) :-
+    plawk_binfmt_take_until_close(Rest, Taken, Remaining).
 
 plawk_binfmt_type("i64", i64).
 plawk_binfmt_type("f64", f64).
@@ -1943,6 +1971,29 @@ plawk_binfmt_type(Part, lps(Cap)) :-
     number_string(Cap, CapStr),
     integer(Cap),
     Cap > 0.
+% repK(elem types): bounded repetition -- an 8-byte native-endian
+% element count C (0 <= C <= K), then C elements each laid out per the
+% parenthesized fixed-width types. Access layout: the count as an i64
+% field, then K flattened element field groups (zero-filled past C).
+plawk_binfmt_type(Part, rep(Cap, ElemTypes)) :-
+    string_concat("rep", Rest0, Part),
+    sub_string(Rest0, Before, 1, _, "("),
+    !,
+    sub_string(Rest0, 0, Before, _, CapStr),
+    number_string(Cap, CapStr),
+    integer(Cap),
+    Cap > 0,
+    Skip is Before + 1,
+    sub_string(Rest0, Skip, _, 0, Rest1),
+    string_concat(Body, ")", Rest1),
+    split_string(Body, " ", " ", ElemParts0),
+    exclude(==(""), ElemParts0, ElemParts),
+    ElemParts \== [],
+    maplist(plawk_binfmt_type, ElemParts, ElemTypes),
+    % elements must be fixed-width (no nested lps/rep) so the element
+    % region is one bulk read and one flat access layout
+    forall(member(ElemType, ElemTypes),
+        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_) )).
 % sN: a fixed-width string field of N bytes. Values shorter than N are
 % NUL-terminated inside the field; a full-width value has no NUL.
 plawk_binfmt_type(Part, s(Width)) :-
@@ -1960,30 +2011,57 @@ plawk_binfmt_type(Part, s(Width)) :-
 plawk_binfmt_field_type(binfmt(Types), Index, Type) :-
     integer(Index),
     Index >= 1,
-    nth1(Index, Types, StoredType),
-    plawk_binfmt_access_type(StoredType, Type).
+    plawk_binfmt_access_types(Types, AccessTypes),
+    nth1(Index, AccessTypes, Type).
 
 plawk_binfmt_access_type(lps(Cap), s(Cap)) :- !.
 plawk_binfmt_access_type(Type, Type).
+
+%% plawk_binfmt_access_types(+StoredTypes, -AccessTypes)
+%
+%  Expand stored types into the flat per-field access list: a
+%  rep(K, Elems) contributes its i64 count field followed by K copies
+%  of the element fields; everything else is one field.
+plawk_binfmt_access_types([], []).
+plawk_binfmt_access_types([rep(Cap, ElemTypes) | Rest], AccessTypes) :-
+    !,
+    maplist(plawk_binfmt_access_type, ElemTypes, ElemAccess),
+    findall(ElemField,
+        ( between(1, Cap, _), member(ElemField, ElemAccess) ),
+        Repeated),
+    plawk_binfmt_access_types(Rest, RestAccess),
+    append([i64 | Repeated], RestAccess, AccessTypes).
+plawk_binfmt_access_types([StoredType | Rest], [Type | RestAccess]) :-
+    plawk_binfmt_access_type(StoredType, Type),
+    plawk_binfmt_access_types(Rest, RestAccess).
 
 plawk_binfmt_type_width(i64, 8).
 plawk_binfmt_type_width(f64, 8).
 plawk_binfmt_type_width(s(Width), Width).
 % in-memory width of the materialized slot, not the wire size
 plawk_binfmt_type_width(lps(Cap), Cap).
+plawk_binfmt_type_width(rep(Cap, ElemTypes), Width) :-
+    maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
+    sum_list(ElemWidths, ElemSize),
+    Width is 8 + Cap * ElemSize.
 
 plawk_binfmt_has_varlen(Types) :-
-    memberchk(lps(_Cap), Types).
+    ( memberchk(lps(_Cap), Types)
+    ; memberchk(rep(_K, _Elems), Types)
+    ),
+    !.
 
 plawk_binfmt_field_offset(binfmt(Types), Index, Offset) :-
+    plawk_binfmt_access_types(Types, AccessTypes),
     PrefixLen is Index - 1,
     length(PrefixTypes, PrefixLen),
-    append(PrefixTypes, _, Types),
+    append(PrefixTypes, _, AccessTypes),
     maplist(plawk_binfmt_type_width, PrefixTypes, Widths),
     sum_list(Widths, Offset).
 
 plawk_binfmt_record_size(binfmt(Types), Size) :-
-    maplist(plawk_binfmt_type_width, Types, Widths),
+    plawk_binfmt_access_types(Types, AccessTypes),
+    maplist(plawk_binfmt_type_width, AccessTypes, Widths),
     sum_list(Widths, Size).
 
 %% plawk_resolve_writebin_rules(+BeginClauses, +Rules0, -Rules, -WritebinPlan)
@@ -2416,6 +2494,134 @@ plawk_rule_descriptor(arm_pat(_Tag, ArmTypes, _Pattern), _Default,
     !.
 plawk_rule_descriptor(_Pattern, Default, Default).
 
+%% plawk_resolve_foreach_rules(+Descriptor, +Rules0, -Rules)
+%
+%  foreach { actions } iterates the record's repetition elements:
+%  inside the block, $1..$M are the CURRENT ELEMENT's fields. Because
+%  the element count is capped at compile time, the block unrolls into
+%  Cap guarded ifs -- if (count >= j) { actions with fields shifted to
+%  element j's flat slots } -- reusing the existing if machinery, so no
+%  new loop/phi mechanics exist at the IR level. Requires a binfmt
+%  layout with exactly one rep field; fails (rejecting the program)
+%  otherwise, on nested foreach, or on $F beyond the element arity.
+plawk_resolve_foreach_rules(Descriptor, Rules0, Rules) :-
+    ( plawk_rules_have_foreach(Rules0)
+    ->  Descriptor = binfmt(Types),
+        plawk_binfmt_rep_info(Types, CountIndex, Cap, ElemArity),
+        maplist(plawk_resolve_foreach_rule(CountIndex, Cap, ElemArity),
+            Rules0, Rules)
+    ;   Rules = Rules0
+    ).
+
+plawk_rules_have_foreach(Rules) :-
+    member(rule(_Pattern, Actions), Rules),
+    plawk_actions_have_foreach(Actions),
+    !.
+
+plawk_actions_have_foreach(Actions) :-
+    member(Action, Actions),
+    ( Action = foreach(_Body)
+    ; Action = if(_Pattern, ThenActions, ElseActions),
+      ( plawk_actions_have_foreach(ThenActions)
+      ; plawk_actions_have_foreach(ElseActions)
+      )
+    ),
+    !.
+
+plawk_binfmt_rep_info(Types, CountIndex, Cap, ElemArity) :-
+    findall(StoredIndex-rep(K, Elems),
+        nth1(StoredIndex, Types, rep(K, Elems)),
+        [RepStoredIndex-rep(Cap, ElemTypes)]),
+    length(ElemTypes, ElemArity),
+    PrefixLen is RepStoredIndex - 1,
+    length(PrefixTypes, PrefixLen),
+    append(PrefixTypes, _, Types),
+    plawk_binfmt_access_types(PrefixTypes, PrefixAccess),
+    length(PrefixAccess, PrefixCount),
+    CountIndex is PrefixCount + 1.
+
+plawk_resolve_foreach_rule(CountIndex, Cap, ElemArity,
+        rule(Pattern, Actions0), rule(Pattern, Actions)) :-
+    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity,
+        Actions0, Actions).
+
+plawk_resolve_foreach_actions(_CountIndex, _Cap, _ElemArity, [], []).
+plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity,
+        [foreach(Body) | Rest0], Actions) :-
+    !,
+    \+ plawk_actions_have_foreach(Body),
+    plawk_foreach_body_fields_ok(Body, ElemArity),
+    findall(if(field_cmp(CountIndex, ge, ElemIndex), ShiftedBody, []),
+        ( between(1, Cap, ElemIndex),
+          Base is CountIndex + (ElemIndex - 1) * ElemArity,
+          plawk_foreach_shift_actions(Body, Base, ShiftedBody)
+        ),
+        Unrolled),
+    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity, Rest0, Rest),
+    append(Unrolled, Rest, Actions).
+plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity,
+        [if(Pattern, Then0, Else0) | Rest0], [if(Pattern, Then, Else) | Rest]) :-
+    !,
+    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity, Then0, Then),
+    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity, Else0, Else),
+    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity, Rest0, Rest).
+plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity,
+        [Action | Rest0], [Action | Rest]) :-
+    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity, Rest0, Rest).
+
+plawk_foreach_body_fields_ok(Body, ElemArity) :-
+    forall(( sub_term(Sub, Body),
+             plawk_foreach_field_ref(Sub, F),
+             integer(F)
+           ),
+        ( F >= 1, F =< ElemArity )).
+
+% every AST shape that carries a field index, whether wrapped in
+% field/1 or stored raw (guard patterns)
+plawk_foreach_field_ref(field(F), F).
+plawk_foreach_field_ref(float_field(F), F).
+plawk_foreach_field_ref(field_cmp(F, _Op, _Value), F).
+plawk_foreach_field_ref(field_eq(F, _Value), F).
+plawk_foreach_field_ref(field_match(F, _Regex), F).
+
+plawk_foreach_shift_actions(Actions, Base, Shifted) :-
+    maplist(plawk_foreach_shift_term(Base), Actions, Shifted).
+
+plawk_foreach_shift_term(Base, field(F), field(Shifted)) :-
+    integer(F),
+    F >= 1,
+    !,
+    Shifted is Base + F.
+plawk_foreach_shift_term(Base, float_field(F), float_field(Shifted)) :-
+    integer(F),
+    F >= 1,
+    !,
+    Shifted is Base + F.
+% guard patterns carry the field index raw, so the generic walk would
+% miss it (and must not touch the comparison value)
+plawk_foreach_shift_term(Base, field_cmp(F, Op, Value), field_cmp(Shifted, Op, Value)) :-
+    integer(F),
+    F >= 1,
+    !,
+    Shifted is Base + F.
+plawk_foreach_shift_term(Base, field_eq(F, Value), field_eq(Shifted, Value)) :-
+    integer(F),
+    F >= 1,
+    !,
+    Shifted is Base + F.
+plawk_foreach_shift_term(Base, field_match(F, Regex), field_match(Shifted, Regex)) :-
+    integer(F),
+    F >= 1,
+    !,
+    Shifted is Base + F.
+plawk_foreach_shift_term(Base, Term, Shifted) :-
+    compound(Term),
+    !,
+    Term =.. [Functor | Args],
+    maplist(plawk_foreach_shift_term(Base), Args, ShiftedArgs),
+    Shifted =.. [Functor | ShiftedArgs].
+plawk_foreach_shift_term(_Base, Term, Term).
+
 %% plawk_union_flatten_rules(+CaseBlocks, +Arms, -Rules)
 %
 %  Flatten case blocks into one rule chain, stamping each rule with
@@ -2587,6 +2793,49 @@ plawk_varlen_field_sections([Type | Types], LoweredLabel, Prefix, EofPolicy,
     plawk_varlen_field_sections(Types, LoweredLabel, Prefix, EofPolicy,
         NextIndex, NextOffset, Sections).
 
+plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+    !,
+    maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
+    sum_list(ElemWidths, ElemSize),
+    RegionSize is Cap * ElemSize,
+    ElemOffset is Offset + 8,
+    plawk_varlen_eof_check_ir(FieldEof, FBase, cstatus, BodyPrefixIR),
+    format(atom(BodyIR),
+'  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  %~w_cstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
+~w  %~w_cok = icmp eq i64 %~w_cstatus, 1
+  br i1 %~w_cok, label %~w_len, label %fail_read
+
+~w_len:
+  %~w_ctp = bitcast i8* %~w_dst to i64*
+  %~w_n = load i64, i64* %~w_ctp
+  %~w_fits = icmp ule i64 %~w_n, ~w
+  br i1 %~w_fits, label %~w_read, label %fail_read
+
+~w_read:
+  %~w_edst = getelementptr i8, i8* %rec, i64 ~w
+  call void @llvm.memset.p0i8.i64(i8* %~w_edst, i8 0, i64 ~w, i1 false)
+  %~w_bytes = mul i64 %~w_n, ~w
+  %~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %~w_bytes, i8* %~w_edst)
+  %~w_pok = icmp eq i64 %~w_pstatus, 1
+  br i1 %~w_pok, label %~w, label %fail_read
+',
+        [FBase, Offset,
+         FBase, FBase,
+         BodyPrefixIR, FBase, FBase,
+         FBase, FBase,
+         FBase,
+         FBase, FBase,
+         FBase, FBase,
+         FBase, FBase, Cap,
+         FBase, FBase,
+         FBase,
+         FBase, ElemOffset,
+         FBase, RegionSize,
+         FBase, FBase, ElemSize,
+         FBase, FBase, FBase,
+         FBase, FBase,
+         FBase, NextLabel]).
 plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
     !,
     plawk_varlen_eof_check_ir(FieldEof, FBase, lstatus, BodyPrefixIR),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -538,6 +538,9 @@ action(Action) -->
     writebin_action(Action),
     !.
 action(Action) -->
+    foreach_action(Action),
+    !.
+action(Action) -->
     print_action(Action),
     !.
 action(Action) -->
@@ -698,6 +701,16 @@ printf_action(printf(string(Format), Args)) -->
     quoted_string(FormatCodes),
     printf_args(Args),
     { string_codes(Format, FormatCodes) }.
+
+%% foreach_action(-Action)//
+%
+%  foreach { actions } - run the block once per repetition element of
+%  the current record; inside, $1..$M are the element's fields.
+foreach_action(foreach(Actions)) -->
+    "foreach",
+    identifier_boundary,
+    ws,
+    action_block(Actions).
 
 %% writebin_action(-Action)//
 %

--- a/tests/test_plawk_bounded_rep.pl
+++ b/tests/test_plawk_bounded_rep.pl
@@ -1,0 +1,199 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_brep_marker/0.
+
+user:plawk_brep_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_bounded_rep, [condition(clang_available)]).
+
+test(parses_foreach_action) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(i64 f64)\" } { foreach { n++ } } END { print n }\n", Program),
+    Program = program(_, [rule(always, [foreach(Body)])], _),
+    assertion(Body == [inc(var(n))]).
+
+test(rep_ir_reads_count_then_bulk_elements) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(i64 f64)\" } { foreach { n++ } } END { print n }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % buffer: 8 (id) + 8 (count) + 4*16 (elems) = 80
+    assertion(once(sub_atom(DriverIR, _, _, _, 'malloc(i64 80)'))),
+    % count read into its record slot, bounded by the cap
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_f1_fits = icmp ule i64 %vr_f1_n, 4'))),
+    % one memset of the element region + one bulk read of count*16 bytes
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i8 0, i64 64, i1 false'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'mul i64 %vr_f1_n, 16'))),
+    % foreach unrolled into count-guarded ifs on the count field ($2)
+    assertion(once(sub_atom(DriverIR, _, _, _, 'icmp sge i64 %'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(rep_rejections) :-
+    Rejects = [
+        % foreach demands a rep layout
+        "BEGIN { BINFMT = \"i64 i64\" } { foreach { n++ } } END { print n }\n",
+        % ... and binary mode
+        "{ foreach { n++ } } END { print n }\n",
+        % no nesting
+        "BEGIN { BINFMT = \"i64 rep4(i64)\" } { foreach { foreach { n++ } } } END { print n }\n",
+        % $2 does not exist in a 1-field element
+        "BEGIN { BINFMT = \"i64 rep4(i64)\" } { foreach { s += $2 } } END { print s }\n",
+        % one rep per layout in this slice
+        "BEGIN { BINFMT = \"rep2(i64) rep2(i64)\" } { foreach { n++ } } END { print n }\n",
+        % elements must be fixed-width
+        "BEGIN { BINFMT = \"rep2(lps8)\" } { foreach { n++ } } END { print n }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_foreach_aggregation) :-
+    % 4 records with 2, 0, 4, and 1 elements; the guarded record ($1>0)
+    % set has 6 elements, weight sum 6.5, three with value > 10.
+    run_brep_smoke("BEGIN { BINFMT = \"i64 rep4(i64 f64)\" } $1 > 0 { foreach { n++ ; wsum += float($2) ; if ($1 > 10) { big++ } } } END { print n, wsum, big }\n",
+        [rec(1, [e(5, 1.5), e(20, 2.5)]),
+         rec(2, []),
+         rec(3, [e(30, 0.25), e(4, 0.5), e(11, 1.0), e(2, 0.75)]),
+         rec(-1, [e(99, 9.0)])],
+        "6 6.5 3\n").
+
+test(surface_count_field_and_direct_access) :-
+    % The count is an ordinary i64 field ($2); element slots are
+    % directly addressable as flat fields ($3 = elem 1's first field),
+    % zero-filled beyond the count.
+    run_brep_smoke("BEGIN { BINFMT = \"i64 rep2(i64 f64)\" } { csum += $2 ; s += $3 } END { print csum, s }\n",
+        [rec(1, [e(10, 1.0), e(20, 2.0)]),
+         rec(2, []),
+         rec(3, [e(7, 0.5)])],
+        "3 17\n").
+
+test(surface_foreach_empty_records_only) :-
+    run_brep_smoke("BEGIN { BINFMT = \"i64 rep4(i64 f64)\" } { foreach { n++ } } END { print n }\n",
+        [rec(1, []), rec(2, [])],
+        "0\n").
+
+test(surface_rep_error_paths) :-
+    build_brep_probe("BEGIN { BINFMT = \"i64 rep4(i64 f64)\" } { foreach { n++ } } END { print n }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    % count exceeds the cap
+    write_raw(InputPath, [i64(1), i64(5), pad(80)]),
+    run_status(BinPath, exit(11)),
+    % truncated element region (count 2, one element present)
+    write_raw(InputPath, [i64(1), i64(2), i64(7), f64bits(0x3FF0000000000000)]),
+    run_status(BinPath, exit(11)),
+    % clean EOF runs END
+    write_raw(InputPath, []),
+    run_expect(BinPath, "0\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+double_bits(1.5,  0x3FF8000000000000).
+double_bits(2.5,  0x4004000000000000).
+double_bits(0.25, 0x3FD0000000000000).
+double_bits(0.5,  0x3FE0000000000000).
+double_bits(1.0,  0x3FF0000000000000).
+double_bits(0.75, 0x3FE8000000000000).
+double_bits(9.0,  0x4022000000000000).
+double_bits(2.0,  0x4000000000000000).
+
+% rec(Id, Elems) with e(V, W): i64 id, i64 count, count x (i64, f64)
+write_rep_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(Id, Elems), Recs),
+            ( write_i64_le(Out, Id),
+              length(Elems, Count),
+              write_i64_le(Out, Count),
+              forall(member(e(V, W), Elems),
+                  ( write_i64_le(Out, V),
+                    double_bits(W, Bits),
+                    write_i64_le(Out, Bits) )) )),
+        close(Out)).
+
+write_raw(Path, Items) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Item, Items),
+            ( Item = i64(V) -> write_i64_le(Out, V)
+            ; Item = f64bits(B) -> write_i64_le(Out, B)
+            ; Item = pad(N) -> forall(between(1, N, _), put_byte(Out, 0))
+            )),
+        close(Out)).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_brep_marker/0 ],
+        [module_name('plawk_bounded_rep')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk bounded rep build output]~n~w~n", [BuildOut]),
+       throw(plawk_bounded_rep_build_failed(Status))
+    ).
+
+build_brep_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_bounded_rep', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_status(BinPath, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(null), stderr(std), process(Pid)]),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+run_expect(BinPath, ExpectedOutput) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == ExpectedOutput).
+
+run_brep_smoke(Source, Recs, ExpectedOutput) :-
+    build_brep_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_rep_records(InputPath, Recs),
+    run_expect(BinPath, ExpectedOutput),
+    !.
+
+:- end_tests(plawk_bounded_rep).


### PR DESCRIPTION
## Summary

The last planned Tier-1 reader slice: **records that contain a list**.

```awk
BEGIN { BINFMT = "i64 rep4(i64 f64)" }      # an id, then up to 4 (value, weight) elements
$1 > 0 {
  foreach { n++ ; wsum += float($2) ; if ($1 > 10) { big++ } }
}
END { print n, wsum, big }
```

`rep4(i64 f64)` declares an 8-byte element count (≤ 4) followed by that many elements on the wire. `foreach { ... }` answers the design doc's "for over elements" surface question: inside the block, `$1..$M` mean *the current element's* fields, and ordinary awk (scalar updates, doubles, `if`/`else`) composes inside it.

## The design move: unroll, don't loop

Because the cap is a compile-time constant, `foreach` never becomes a runtime loop. It desugars into Cap **count-guarded ifs** — `if (count >= j) { body with field indexes shifted to element j's flat slots }` — reusing the existing if/join-phi machinery wholesale. No loop-carried phis were added anywhere in the emitter stack; the "new control-flow construct" costs zero new IR mechanics. Guard patterns carry field indexes raw (`field_cmp/3` etc.), so the shifter and the arity validator handle those shapes explicitly — caught by the end-to-end test when an inner `if ($1 > 10)` initially kept pointing at the record id.

## Layout and reader

Access layout flattens: the count is an ordinary i64 field (guards like `$2 >= 1` work), and each element's fields are plain record fields at compile-time offsets — direct `$N` access works even without `foreach`, and element slots past the count are deterministic zeros (memset before the read). The wire read is minimal: count into its record slot → unsigned cap check → memset → **one bulk `count × elemsize` read**. Oversized counts and truncated element regions exit with the read-error code; a zero-count record reads nothing.

**Slice bounds** (validated rejections): one `rep` per layout, fixed-width elements only (`i64`/`f64`/`sN`), no nested `foreach`, no `$F` beyond the element arity, binary mode only.

## Docs

The tutorial gains a "records that contain a list" section with a byte diagram, continuing the from-first-principles walkthrough added in #3423; the design doc marks repetition landed and records the unrolling design; README updated.

## Tests

`tests/test_plawk_bounded_rep.pl` (7 tests): parse, IR shape (bulk read, cap check, memset, unrolled guards), six rejections, guarded foreach aggregation with doubles and an inner if, count-as-field + direct flat element access, zero-element records, and oversized-count / truncated-region / clean-EOF error paths.

Full regression sweep green: all 30 suites exit 0.

## Merge order

Stacked on #3423 (consolidation + tutorial). **Merge #3423 into main first, then this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_