### PR TITLE
Mindmap LINEAGE sampler + graph/LLM judge methodology

### DIFF
--- a/prototypes/mu_cosine/DESIGN_calibrated_judges.md
+++ b/prototypes/mu_cosine/DESIGN_calibrated_judges.md
@@ -383,3 +383,23 @@ parser + a small fixture). Everything stays in `prototypes/mu_cosine/`; nothing 
 - **Node-type as a token vs separate embedding tables** — one factored `NODETYPE` token (cheap, lets the
   model interpolate) vs a per-type encoder (more capacity, no cold-start sharing). Token first; revisit if
   pages and categories turn out to need different encoders.
+
+## Judge registry + tagging policy (JUDGES)
+
+`JUDGES` in `mu_attention.py` maps a judge name → an index into the learned `judge_emb`
+(`nn.Embedding(n_judge, d_model)`), carried on the factored provenance token `corpus_emb + judge_emb`.
+Current: `{haiku:0, graph:1, human:2, sonnet:3, opus:4, gemini:5, gpt-5.5-low:6}`.
+
+- **Each (model, reasoning-effort) is its own row.** Calibration is per-model *and* per-effort — e.g.
+  `gpt-5.5` at `low` vs `xhigh` disagreed on labels on a pilot, so they must not share a row. Naming encodes
+  both: `gpt-5.5-low` = `codex exec -m gpt-5.5 -c model_reasoning_effort=low`. Cheaper future judges
+  (`gpt-5.3-low`, `gpt-5.4-low`, …) take the next free indices.
+- **Tag every scored pair by the exact judge that produced it — never default to `haiku`.** Mis-tagging
+  conflates calibrations and corrupts training.
+- **`graph` is a first-class judge** (a structural heuristic `μ = decay(distance-to-truth)`, not an LLM). Graph-
+  and LLM-scored rows are stored separately and reconciled ONLY by `judge_emb` — never averaged into one μ
+  (they are not on the same scale; see `DESIGN_mindmap_lineage.md` §3b/§6).
+- **Table-based today; open-ended later.** The index table has no cross-judge transfer (a new judge starts from a
+  blank row needing its own data). The future direction is an attribute/attention-derived judge embedding
+  (model family, effort, provider) so unseen judges get a prior by proximity — the same index→superposition path
+  the operators took.

--- a/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
+++ b/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
@@ -1,0 +1,114 @@
+# Mindmap LINEAGE → filing training data (design + methodology)
+
+Status: lineage sampler built (`gen_mindmap_lineage.py`); negative-generation + judge-scoring specified here,
+prototype next. Non-enwiki data from SimpleMind `.smmx` maps; prep for fusion with Pearltrees once harvested.
+
+## 0. Why mindmaps, why lineage first
+
+The SimpleMind maps are the user's own systems-theory domain — structurally and topically the closest proxy we
+have to the Pearltrees filing target, and **not** present in enwiki. We build **LINEAGE first, then the 70/30
+split on top of it** (directional/superposition — see `feedback_enwiki_sampling_strategy`). Lineage is
+well-defined here because a mindmap node hangs off exactly one structural parent — the same property that made us
+choose single-path LINEAGE for Pearltrees (`project_mu_cosine_path_multipath_result`).
+
+## 1. Positives — complete, and graded by distance
+
+The dataset is small (491 lineage chains over 6 maps), so we take **complete coverage of positives**: every
+(descendant, ancestor) pair along each materialized path. They are **not binary** — μ is **graded by lineage
+distance**: direct parent = strong, grandparent = weaker, great-grandparent = weaker still. The depth gives
+calibrated positives for free.
+
+Materialized paths are cleaned (`gen_mindmap_lineage.py`): the shared sentinel `Root Node` (in folder `root`,
+a generic placeholder to which all maps link up) is dropped, `via link` nav nodes filtered, cross-map join
+echoes (consecutive duplicate titles) collapsed. Privacy is scrubbed upstream by `parse_smmx.py`
+(`privacy.py::is_private_title`: a "private" node drops itself + subtree, a private root drops the whole map).
+
+## 2. Negatives — sampled, typed, graded (not enumerated)
+
+The negative complement is ~O(N²) and would swamp the positives, so we **sample** (enwiki uses 3:1). Three types
+in increasing value:
+
+1. **Directional-reverse** (ancestor | descendant) — free; drives the directional margin μ(desc|anc) ≫ μ(anc|desc).
+2. **Cross-branch** (different subtrees) — the easy "unrelated" tail.
+3. **Hard negatives — siblings / cousins** (same parent/grandparent, *not* ancestor-descendant). The valuable
+   ones: they teach μ that *same branch ≠ lineage*, the confusion a hierarchy model must resolve.
+
+**Key subtlety — no pair is truly unrelated.** Because every node shares the global `Root Node`, even
+cross-domain pairs share distant ancestry. So a "negative" means *"not a direct lineage link,"* and μ should
+**fall off gradually with tree-distance**, not snap to 0. This graded fall-off is the signal we want, and it is
+why hard sibling/cousin negatives matter more than random cross-map ones (the shared root already makes those
+mildly positive).
+
+### 2a. Candidate generation — substitution, e5-stratified
+
+Generate hard negatives by **substituting** a node in a true path with an alternative (an alternate parent/path
+— exactly the filing question "could it go here instead?"). **Permutation** (scrambling path order) mostly
+yields obviously-broken hierarchies — kept only as a cheap easy-negative floor.
+
+Control hardness with **e5 distance of the substituted node vs the original**: e5-near = sibling/cousin = hard
+negative; e5-far = easy. **e5 distance is used to *stratify candidates*, not as μ** — semantic distance ≠ filing
+plausibility (a sibling can be e5-close yet filing-wrong; a valid alternate parent can be e5-far). The μ comes
+from a judge (§3).
+
+## 3. Judge scoring
+
+Remove the last hop of a path → (path-minus-leaf = folder, leaf = item to file). Each example is thus **actual
+filing training data** — more target-aligned than raw lineage pairs, and buildable now without the harvester.
+Present the judge ≥2 candidate filings (2 = cheapest; 3–4 = better-shaped curve), scored **pointwise and
+independently — μ does NOT sum to 1** (matches the §14 prompt and the model's per-pair μ).
+
+### 3a. LLM judge (codex `gpt-5.5-low`, or Haiku)
+
+- **Max-normalize to the model's top pick = 1**, then a scoring curve: **linear first** (preserves the graded
+  middle); a **temperature-controlled sigmoid** only if raw scores come back too bunched to separate hard-from-easy
+  (a *steep* sigmoid discards the grading — avoid).
+- **Multi-parent guard:** anchoring to the model's top (not the ground-truth) honors genuine second parents
+  (Pearltrees supercategories, cross-map links) — a valid substituted path *should* be allowed near 1. But keep
+  the **ground-truth as a sanity floor**: if the true filing scores *low*, flag it (judge error or a genuinely
+  ambiguous node), don't silently train on it.
+- Tag `judge=gpt-5.5-low` (its own calibration row; see `DESIGN_calibrated_judges.md`, `JUDGES` in
+  `mu_attention.py`). Cost/latency: `gpt-5.5-low` ≈ 5 s/pair, non-Anthropic.
+
+### 3b. Graph judge (nearly free) — `μ = decay( distance-to-truth )`
+
+Score a candidate by its **graph distance to the true filing**, decayed to μ (truth at distance 0 → **1**;
+1 hop = sibling/uncle → high; far → low). This is the **structural** analogue of the e5 idea, and unlike e5 it
+maps to μ **directly and honestly** — distance-to-truth *is* a plausibility. Tag `judge=graph`
+(`JUDGES["graph"] = 1`, already defined).
+
+**Decay choice — alternatives (we pick a default; these are the project's existing metrics).** The decay is
+exactly a flux/cost-function over the tree; see `docs/design/COST_FUNCTION_PHILOSOPHY.md` and
+`docs/design/SCAN_STRATEGY_SPECIFICATION.md`:
+
+| variant | form | note |
+|---|---|---|
+| **hop / shortest-path** (our default) | `μ = γ^d`, or `1/(1+d)` | simplest; no flux interpretation |
+| exponential-decay flux | `Σ_paths (decay/branching)^|p|` | our `exp(-λd)` is the single-path case |
+| power-law / inverse-radial | `1/r^N` (log-flux `= −N·log r`) | N-dim source model; heavier tail |
+| PPR / Markov walk | stationary dist. biased by the node seed | probabilistic dual; handles multi-path |
+| LCA depth | depth of lowest common ancestor | tree-native; "shares-only-Root ⇒ ~0" |
+
+Default: **hop-distance with geometric/exp decay + LCA depth as the tie-breaker** (cheap, tree-native). The
+power-law and PPR variants are the natural upgrades if the graded fall-off needs a heavier tail or multi-path
+mass — they are already specified in `COST_FUNCTION_PHILOSOPHY.md` and left as alternatives.
+
+## 4. Two judges, complementary — and a cost-smart split
+
+Graph judge = cheap, structural, but **blind to a semantically-valid parent that is structurally distant**
+(a cross-domain-but-correct filing). LLM judge = semantic, catches those, but costs. Their **disagreement is the
+useful part**: agree → confident μ; diverge → the ambiguous, probably-multi-parent cases.
+
+**Cost-smart pipeline:** run the **graph judge over everything (free, `judge=graph`)**, then spend LLM
+(`gpt-5.5-low`) calls **only where graph-μ is uncertain** — near-ties and structurally-distant candidates. The
+model's judge axis learns both calibrations side-by-side (`corpus_emb + judge_emb` provenance token).
+
+## 5. Integration + status
+
+- Feeds the graded round (`build_graded_round.py` → `load_graded`) as `corpus=mindmap` rows with per-row operator
+  + calibrated μ + judge tag.
+- SimpleMind is **most useful once fused with Pearltrees** (`fuse_corpus.py` needs the PT cache) — this is prep;
+  full value lands with the harvester.
+- **Built:** `gen_mindmap_lineage.py` (491 chains). **Next:** substitution+e5 candidate gen → graph judge →
+  targeted LLM judge → graded-round rows.
+
+See also: `DESIGN_path_operator.md`, `DESIGN_calibrated_judges.md`, `feedback_enwiki_sampling_strategy`.

--- a/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
+++ b/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
@@ -83,15 +83,13 @@ accounts for the **full materialized-path prefix**, via two complementary whole-
 
 - **LCA depth (structural):** how deep the *shared* prefix runs (shares-only-Root ⇒ ~0) — a topological measure
   of common ancestry.
-- **e5-of-prefix (semantic) — a TIE-BREAKER, not a multiplied factor.** A deep shared prefix (high LCA depth)
-  is *already* e5-similar, so multiplying both double-counts (review, critical #3). Instead, LCA-depth carries
-  the whole-lineage weight, and e5-of-prefix **only breaks ties among structurally-equivalent candidates** — two
-  paths with the same LCA depth / hop distance but different divergent tails (`Math/Calculus/…` vs
-  `Math/Analysis/…`) get separated by prefix e5-similarity. This keeps e5 as a *tie-breaker inside* the graph
-  heuristic, not e5 alone as μ (§2a caution); the LLM judge arbitrates the hard semantic cases.
+- **LCA-depth carries the whole-lineage *structural* weight** in `μ_graph` (below). e5-of-prefix does **not**
+  enter `μ_graph` — multiplying it against LCA-depth double-counts, since a deep shared prefix is *already*
+  e5-similar (review, critical #3). Instead **e5 is routed to a separate `lineage-rank` operator** (§3c), where
+  it is a *ranking* signal (cross-entropy), not a regression factor.
 
-So `μ_graph = decay(hops) · lca_depth_frac`, with **e5-prefix distance breaking ties** among structurally
-equivalent candidates (decay variant per the table below; exact tie-break margin TBD by the prototype).
+So `μ_graph = decay(hops) · lca_depth_frac` (pure structural; decay variant per the table below) — the regression
+target of the **`lineage`** operator. The semantic e5 signal goes to **`lineage-rank`** (§3c).
 
 **Decay choice — alternatives (we pick a default; these are the project's existing metrics).** The decay is
 exactly a flux/cost-function over the tree; see `docs/design/COST_FUNCTION_PHILOSOPHY.md` and
@@ -105,9 +103,47 @@ exactly a flux/cost-function over the tree; see `docs/design/COST_FUNCTION_PHILO
 | PPR / Markov walk | stationary dist. biased by the node seed | probabilistic dual; handles multi-path |
 | LCA depth | depth of lowest common ancestor | tree-native; "shares-only-Root ⇒ ~0" |
 
-Default: **hop-distance with geometric/exp decay + LCA depth as the tie-breaker** (cheap, tree-native). The
-power-law and PPR variants are the natural upgrades if the graded fall-off needs a heavier tail or multi-path
-mass — they are already specified in `COST_FUNCTION_PHILOSOPHY.md` and left as alternatives.
+Default: **hop-distance with geometric/exp decay + LCA depth** (cheap, tree-native). The power-law and PPR
+variants are the natural upgrades if the graded fall-off needs a heavier tail or multi-path mass — already
+specified in `COST_FUNCTION_PHILOSOPHY.md` and left as alternatives.
+
+### 3c. Two operators — `lineage` (MSE) and `lineage-rank` (CE)
+
+How e5 enters determines the loss: as a **scoring factor** it implies regression (error/MSE); as a **ranking**
+signal it implies cross-entropy. Rather than choose, split into two operators (two `op_emb` entries, routed
+per-operator like SYM/HIER/ELEM), each with its own loss — which also keeps e5 out of the regressed magnitude:
+
+- **`lineage` → MSE / regression.** Target = the pure structural `μ_graph = decay(hops) · lca_depth_frac`.
+  Learns the graded *magnitude* (parent > grandparent > far). No e5 → no LCA double-count.
+- **`lineage-rank` → cross-entropy / ranking.** Target = an *ordering* over a node's candidate parents, from a
+  **teacher** score (NOT the model's own output — self-referential bootstrapping drifts/collapses):
+
+  ```
+  rank_score(c) = μ_graph(c)  +  β · e5_sim_prefix(c)         # additive soft margin (dense e5 signal)
+  ```
+
+  Candidates are ordered by `rank_score`; `lineage-rank` is trained by softmax-CE to reproduce that order.
+  Because CE is **scale-invariant**, `lineage-rank` carries order information the MSE head can't — notably in
+  the flat graded-middle where the regression targets bunch. **This is the filing-primary operator** (filing =
+  rank the candidate folders); `lineage` supplies graded confidence / fall-off.
+
+**e5 is on the GRANDPARENT lineage (the prefix), not the immediate parent.** The immediate parent is the
+decision the structural `decay(hops)` already makes; e5 compares the *ancestral context above it* — so
+`e5_sim_prefix(c)` = e5 similarity of the `root … grandparent` prefix of candidate `c` vs the truth's. (`Math/
+Calculus/…` stays close to `Math/Analysis/…` because their grandparent prefixes match.)
+
+**β scales e5 by how much prefix there is to compare** (user):
+
+  ```
+  β = ( G / (L + G) ) · k
+      G = grandparent-prefix length (root … grandparent),   L = total path length (root … node),   k = tuned blend const
+  ```
+
+  So a shallow node with no grandparent (`G=0`) → **β=0**, e5 contributes nothing (nothing to compare); deeper
+  nodes → more ancestral context → larger β, up to `~0.5·k`. `k` is tuned on the pilot.
+
+**Losses:** `lineage` → the existing graded-MSE head; `lineage-rank` → a candidate-softmax CE (same family as
+the model's transitive/directional margins). Both are weighted like the other operators.
 
 ## 4. Two judges, complementary — and a cost-smart split
 

--- a/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
+++ b/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
@@ -119,28 +119,41 @@ per-operator like SYM/HIER/ELEM), each with its own loss — which also keeps e5
   **teacher** score (NOT the model's own output — self-referential bootstrapping drifts/collapses):
 
   ```
-  rank_score(c) = μ_graph(c)  +  β · e5_sim_prefix(c)         # additive soft margin (dense e5 signal)
+  rank_score(c) = (1 − β)·μ_graph(c)  +  β · e5_sim_prefix_norm(c)      # CONVEX combo — bounded [0,1]
+      e5_sim_prefix_norm = (cos_prefix + 1) / 2   ∈ [0,1]              # normalize cosine BEFORE mixing (review r2)
   ```
 
-  Candidates are ordered by `rank_score`; `lineage-rank` is trained by softmax-CE to reproduce that order.
-  Because CE is **scale-invariant**, `lineage-rank` carries order information the MSE head can't — notably in
-  the flat graded-middle where the regression targets bunch. **This is the filing-primary operator** (filing =
-  rank the candidate folders); `lineage` supplies graded confidence / fall-off.
+  **Convex, not additive (review round 2):** `μ_graph ∈ [floor,1]` and a raw cosine `∈ [−1,1]` have no shared
+  unit — an additive `μ_graph + β·cos` can go negative / exceed 1. The convex form keeps `rank_score ∈ [0,1]`,
+  makes **β an interpretable weight fraction** (requires `k ≤ 1`), and the `(cos+1)/2` normalization fixes the
+  sign. Candidates are ordered by `rank_score`; `lineage-rank` is trained by softmax-CE to reproduce that order.
+  Because CE is **scale-invariant**, `lineage-rank` carries order info the MSE head can't — notably in the flat
+  graded-middle where regression targets bunch (weakest, conversely, for deep trees with diverse `μ_graph`, where
+  MSE already has a strong gradient). **Filing-primary operator** (filing = rank the folders); `lineage` supplies
+  graded confidence. The "filing-primary" dominance belongs in the **`op_emb` routing** at inference, not just
+  this narrative. **Pilot diagnostics:** log per-example **teacher softmax entropy** (near-uniform ⇒ tiny CE
+  gradient — the real collapse risk, from *flat teacher distributions*, not operator correlation) and per-depth
+  MSE-gradient-vs-CE-entropy.
 
 **e5 is on the GRANDPARENT lineage (the prefix), not the immediate parent.** The immediate parent is the
 decision the structural `decay(hops)` already makes; e5 compares the *ancestral context above it* — so
 `e5_sim_prefix(c)` = e5 similarity of the `root … grandparent` prefix of candidate `c` vs the truth's. (`Math/
-Calculus/…` stays close to `Math/Analysis/…` because their grandparent prefixes match.)
+Calculus/…` stays close to `Math/Analysis/…` because their grandparent prefixes match.) Since LCA-depth (in
+`lineage`, MSE) and e5-prefix (in `lineage-rank`, CE) now live in **different operators with different losses**,
+their correlation is **redundancy, not double-count** (review r2). *Degenerate case:* when the candidate's
+grandparent **is** the LCA, both CE inputs coincide → zero CE gradient — log its frequency in the pilot.
 
 **β scales e5 by how much prefix there is to compare** (user):
 
   ```
   β = ( G / (L + G) ) · k
-      G = grandparent-prefix length (root … grandparent),   L = total path length (root … node),   k = tuned blend const
+      G = grandparent-prefix length in NODES (root … grandparent, node count — same unit as lca_depth_frac)
+      L = total path length in nodes (root … node)          k = tuned blend const, k ≤ 1 (convex ⇒ β ≤ 0.5)
   ```
 
-  So a shallow node with no grandparent (`G=0`) → **β=0**, e5 contributes nothing (nothing to compare); deeper
-  nodes → more ancestral context → larger β, up to `~0.5·k`. `k` is tuned on the pilot.
+  `G=0` (shallow node, no grandparent) → **β=0**: `lineage-rank` adds no signal over `lineage` there (fine —
+  state it). Deeper nodes → more ancestral context → larger β, asymptoting at `~0.5·k`; `k ≤ 1` keeps `β ≤ 0.5`
+  (and `rank_score` a proper convex mix). `k` tuned on the pilot.
 
 **Losses:** `lineage` → the existing graded-MSE head; `lineage-rank` → a candidate-softmax CE (same family as
 the model's transitive/directional margins). Both are weighted like the other operators.
@@ -162,12 +175,15 @@ model's judge axis learns both calibrations side-by-side (`corpus_emb + judge_em
 - SimpleMind is **most useful once fused with Pearltrees** (`fuse_corpus.py` needs the PT cache) — this is prep;
   full value lands with the harvester.
 - **Built:** `gen_mindmap_lineage.py` (491 chains); `prototype_graph_judge.py` — graph-μ validated on Chaos
-  theory: true parent = 1.0, ancestors graded up the chain (2 hops ≈ 0.36, 3 ≈ 0.22 at γ=0.6), far → floor 0.02.
-  **Finding:** a single-map parse is **fragmented** (many candidate `hops=99`), so the graph judge needs the
-  **connected cross-map / fused graph** for real candidate connectivity — another reason SimpleMind pairs with
-  Pearltrees (`fuse_corpus.py`). Nav (`via link`) nodes are now bypassed in the *structure* (not just display).
-  **Next:** run on the fused graph → substitution candidate gen → targeted LLM judge on uncertain cases →
-  graded-round rows.
+  theory: true parent = 1.0, siblings/near graded (1 hop ≈ 0.60, 2 ≈ 0.36 at γ=0.6), far → floor 0.02.
+  Candidate pool excludes **ancestors of n** (they're graded positives, not negatives — review r2).
+  **Finding:** a single-map parse is **fragmented** (117 unreachable candidates on Chaos theory), so the graph
+  judge needs the **connected cross-map / fused graph** for real candidate connectivity — another reason
+  SimpleMind pairs with Pearltrees (`fuse_corpus.py`). **Interim single-map fallback (review r2):** unreachable
+  candidates get `hops = D_max + 1` (not a sentinel), so `decay(hops)·lca_frac` still degrades gracefully —
+  `lca_frac` differentiates them by shared ancestry while the harvester is pending. Nav (`via link`) nodes are
+  bypassed in the *structure* (not just display). **Next:** run on the fused graph → substitution candidate gen
+  → targeted LLM judge on uncertain cases → graded-round rows.
 
 ## 6. Review responses (PR #3426)
 
@@ -178,7 +194,9 @@ one alternative (heavier tail). Pinned to one family, not two.
 **Depth bias (methodology-2):** complete enumeration gives C(8,2)=28 pairs for a depth-8 chain vs 1 for depth-2,
 so deep systems-theory nodes would dominate. Mitigation: **per-chain pair weighting** (down-weight each pair by
 `1/(#pairs in its chain)` so every chain contributes equal mass), OR cap transitive pairs (keep all adjacent +
-sample K transitive). The pair generator will emit **pair-count-by-depth** and apply the weight.
+sample K transitive). The pair generator will emit **pair-count-by-depth** and apply the weight. NB per-chain
+weighting shifts the *effective* negative type-ratio by depth, so log the **weighted** negative-type
+distribution, not just raw counts (review r2).
 
 **Negative μ-floor (methodology-3):** since all nodes share the global root, **negatives are NOT μ=0.**
 Directional-reverse (ancestor|descendant) → `μ_rev ≈ 0.05–0.15` (residual membership); cross-branch →
@@ -199,8 +217,10 @@ hard negatives + judge-calibrated μ *on top of* the lineage positives, it does 
 
 **Multi-parent, operationalized (D3):** graded-round schema adds `gt_rank` (rank of the ground-truth filing
 among candidates by judge μ) + `gt_mu`. Disposition: `gt_rank==1` → normal; `gt_rank==2 & spread<τ_tie` → **keep
-both** (multi-parent); `gt_rank≥3` OR `gt_mu<τ_low` → **flag + exclude from training**. `τ_tie≈0.1`, `τ_low≈0.3`
-(μ scale), tuned on the pilot.
+both** (multi-parent); `gt_rank≥3` OR `gt_mu<τ_low` → **flag + exclude from training**. `τ_tie≈0.1`; **`τ_low` =
+the 10th percentile of the true-parent μ distribution from the prototype run, NOT a fixed 0.3** (review r2 —
+a fixed 0.3 would wrongly flag legitimate weak-but-correct parents, e.g. 2-hop with moderate lca_frac). Tuned on
+the pilot.
 
 **Cost-split + judge_agreement (D4, methodology-7):** output stores `mu_graph`, `mu_llm`, and
 `judge_agreement = abs(mu_graph − mu_llm)`. LLM spent only where graph-μ is uncertain: **near-tie** = top-two

--- a/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
+++ b/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
@@ -125,8 +125,13 @@ model's judge axis learns both calibrations side-by-side (`corpus_emb + judge_em
   + calibrated μ + judge tag.
 - SimpleMind is **most useful once fused with Pearltrees** (`fuse_corpus.py` needs the PT cache) — this is prep;
   full value lands with the harvester.
-- **Built:** `gen_mindmap_lineage.py` (491 chains). **Next:** substitution+e5 candidate gen → graph judge →
-  targeted LLM judge → graded-round rows.
+- **Built:** `gen_mindmap_lineage.py` (491 chains); `prototype_graph_judge.py` — graph-μ validated on Chaos
+  theory: true parent = 1.0, ancestors graded up the chain (2 hops ≈ 0.36, 3 ≈ 0.22 at γ=0.6), far → floor 0.02.
+  **Finding:** a single-map parse is **fragmented** (many candidate `hops=99`), so the graph judge needs the
+  **connected cross-map / fused graph** for real candidate connectivity — another reason SimpleMind pairs with
+  Pearltrees (`fuse_corpus.py`). Nav (`via link`) nodes are now bypassed in the *structure* (not just display).
+  **Next:** run on the fused graph → substitution candidate gen → targeted LLM judge on uncertain cases →
+  graded-round rows.
 
 ## 6. Review responses (PR #3426)
 

--- a/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
+++ b/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
@@ -76,6 +76,20 @@ Score a candidate by its **graph distance to the true filing**, decayed to μ (t
 maps to μ **directly and honestly** — distance-to-truth *is* a plausibility. Tag `judge=graph`
 (`JUDGES["graph"] = 1`, already defined).
 
+**Whole-lineage, not just the immediate parent.** A bare parent-to-parent hop is myopic: two candidates can be
+equidistant from the true parent yet sit in very different lineages (`Math/Calculus/X` vs `Math/Analysis/X` — one
+leaf-hop apart but nearly the same folder path — versus one hop into an unrelated subtree). So the graph-μ
+accounts for the **full materialized-path prefix**, via two complementary whole-lineage factors:
+
+- **LCA depth (structural):** how deep the *shared* prefix runs (shares-only-Root ⇒ ~0) — a topological measure
+  of common ancestry.
+- **e5-of-prefix (semantic):** e5-embed the candidate's path prefix (`root / … / parent`) and the truth's, and
+  factor in their e5 distance — so `Math/Calculus/…` stays close to `Math/Analysis/…` despite the differing
+  immediate parent. This keeps e5 as **one factor inside the graph heuristic**, not e5 alone as μ (§2a caution);
+  the LLM judge still arbitrates the hard semantic cases.
+
+So `μ_graph ≈ decay(hops) · lca_depth_frac · f(e5_prefix_dist)` (exact combination TBD by the prototype).
+
 **Decay choice — alternatives (we pick a default; these are the project's existing metrics).** The decay is
 exactly a flux/cost-function over the tree; see `docs/design/COST_FUNCTION_PHILOSOPHY.md` and
 `docs/design/SCAN_STRATEGY_SPECIFICATION.md`:

--- a/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
+++ b/prototypes/mu_cosine/DESIGN_mindmap_lineage.md
@@ -83,12 +83,15 @@ accounts for the **full materialized-path prefix**, via two complementary whole-
 
 - **LCA depth (structural):** how deep the *shared* prefix runs (shares-only-Root ⇒ ~0) — a topological measure
   of common ancestry.
-- **e5-of-prefix (semantic):** e5-embed the candidate's path prefix (`root / … / parent`) and the truth's, and
-  factor in their e5 distance — so `Math/Calculus/…` stays close to `Math/Analysis/…` despite the differing
-  immediate parent. This keeps e5 as **one factor inside the graph heuristic**, not e5 alone as μ (§2a caution);
-  the LLM judge still arbitrates the hard semantic cases.
+- **e5-of-prefix (semantic) — a TIE-BREAKER, not a multiplied factor.** A deep shared prefix (high LCA depth)
+  is *already* e5-similar, so multiplying both double-counts (review, critical #3). Instead, LCA-depth carries
+  the whole-lineage weight, and e5-of-prefix **only breaks ties among structurally-equivalent candidates** — two
+  paths with the same LCA depth / hop distance but different divergent tails (`Math/Calculus/…` vs
+  `Math/Analysis/…`) get separated by prefix e5-similarity. This keeps e5 as a *tie-breaker inside* the graph
+  heuristic, not e5 alone as μ (§2a caution); the LLM judge arbitrates the hard semantic cases.
 
-So `μ_graph ≈ decay(hops) · lca_depth_frac · f(e5_prefix_dist)` (exact combination TBD by the prototype).
+So `μ_graph = decay(hops) · lca_depth_frac`, with **e5-prefix distance breaking ties** among structurally
+equivalent candidates (decay variant per the table below; exact tie-break margin TBD by the prototype).
 
 **Decay choice — alternatives (we pick a default; these are the project's existing metrics).** The decay is
 exactly a flux/cost-function over the tree; see `docs/design/COST_FUNCTION_PHILOSOPHY.md` and
@@ -124,5 +127,54 @@ model's judge axis learns both calibrations side-by-side (`corpus_emb + judge_em
   full value lands with the harvester.
 - **Built:** `gen_mindmap_lineage.py` (491 chains). **Next:** substitution+e5 candidate gen → graph judge →
   targeted LLM judge → graded-round rows.
+
+## 6. Review responses (PR #3426)
+
+**Positive decay (D1):** graded-positive μ uses the SAME family as the graph judge — `μ = γ^d` (geometric in
+lineage distance `d`), γ tuned so a direct parent ≈ 0.9, a depth-5 ancestor ≈ 0.35. Harmonic `1/(1+d)` is the
+one alternative (heavier tail). Pinned to one family, not two.
+
+**Depth bias (methodology-2):** complete enumeration gives C(8,2)=28 pairs for a depth-8 chain vs 1 for depth-2,
+so deep systems-theory nodes would dominate. Mitigation: **per-chain pair weighting** (down-weight each pair by
+`1/(#pairs in its chain)` so every chain contributes equal mass), OR cap transitive pairs (keep all adjacent +
+sample K transitive). The pair generator will emit **pair-count-by-depth** and apply the weight.
+
+**Negative μ-floor (methodology-3):** since all nodes share the global root, **negatives are NOT μ=0.**
+Directional-reverse (ancestor|descendant) → `μ_rev ≈ 0.05–0.15` (residual membership); cross-branch →
+`decay(tree-distance)` down to `μ_floor ≈ 0.02` at shares-only-Root; only truly out-of-forest pairs get 0.
+
+**Negative ratio by type (D2):** the 3:1 budget is split, weighted to hard — per positive ≈ 1.5 hard
+(sibling/cousin, e5-near) + 1.0 cross-branch (medium) + 0.5 easy (permutation/far), logged by type.
+
+**70/30 semantics on a lineage (methodology-1):** unlike enwiki's distinct downward-vs-bidirectional EDGE types,
+on a lineage the 70/30 is a **query role**: 70% directional = μ(descendant|ancestor) [downward membership]; 30%
+"superposition" = **ancestor-as-query** / symmetric μ(anc,desc) fed both orders (SYM operator). Same operators,
+different query construction — will state this in §0.
+
+**Multi-hop vs remove-last-hop (methodology-4):** **complementary, not competing.** The multi-hop
+ancestor-descendant pairs (graded by distance) train the μ operators directly (LINEAGE positives). Remove-last-hop
+generates the **filing-candidate** examples (true parent + substituted alternates) the judges score — it *adds*
+hard negatives + judge-calibrated μ *on top of* the lineage positives, it does not replace them.
+
+**Multi-parent, operationalized (D3):** graded-round schema adds `gt_rank` (rank of the ground-truth filing
+among candidates by judge μ) + `gt_mu`. Disposition: `gt_rank==1` → normal; `gt_rank==2 & spread<τ_tie` → **keep
+both** (multi-parent); `gt_rank≥3` OR `gt_mu<τ_low` → **flag + exclude from training**. `τ_tie≈0.1`, `τ_low≈0.3`
+(μ scale), tuned on the pilot.
+
+**Cost-split + judge_agreement (D4, methodology-7):** output stores `mu_graph`, `mu_llm`, and
+`judge_agreement = abs(mu_graph − mu_llm)`. LLM spent only where graph-μ is uncertain: **near-tie** = top-two
+graph-μ within `τ_tie`; **structurally-distant** = candidate hop-distance `≥3` OR shares-only-Root. Else free
+graph-μ alone.
+
+**Judge fusion — DON'T (methodology-6):** graph-μ is truth=1 *by construction*; LLM-μ is *discovered* and can
+prefer a better parent — **not the same scale.** Stored as **separate judge-tagged rows** (`judge=graph`,
+`judge=gpt-5.5-low`), never averaged; the model's `judge_emb` is the only place they reconcile. `judge_agreement`
+is diagnostic, not a fused target.
+
+**Judge confidence spread (methodology-5):** the LLM pass logs `raw_top`, `raw_runner_up`, `spread` alongside the
+normalized μ, so the training loop can down-weight low-spread (uncertain) calls.
+
+**e5 hard/easy boundary (nit):** TBD from the pilot — set at the **median e5 distance of in-map sibling pairs**
+(empirical, per-map), not a fixed constant.
 
 See also: `DESIGN_path_operator.md`, `DESIGN_calibrated_judges.md`, `feedback_enwiki_sampling_strategy`.

--- a/prototypes/mu_cosine/gen_mindmap_lineage.py
+++ b/prototypes/mu_cosine/gen_mindmap_lineage.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""LINEAGE from SimpleMind mindmaps (do this BEFORE the 70/30 split — user direction).
+
+For each node, navigate parent links UP to the root and emit the materialized path of TITLES
+(root / … / node). This is the mindmap analogue of Pearltrees single-path LINEAGE — a mindmap node
+hangs off one structural parent, so lineage is well-defined. Yields data NOT in enwiki.
+
+Privacy: parse_smmx.py already scrubs (privacy.py::is_private_title drops a "private" node + its subtree,
+a private root drops the whole map) at parse time — so this builds on already-clean output. As a belt-and-
+suspenders check we ALSO skip any lineage whose path contains a "private"-labelled title.
+
+Edges from parse_smmx are src(parent)→dst(child):relation. Parent map:
+  subtopic / subcategory : parent[dst] = src   (dst is under src)
+  super_category         : parent[src] = dst   (dst is broader than src)  — only if no structural parent
+Then materialized_path(node) = titles(root … node). 70/30 directional/superposition sampling comes AFTER.
+
+  python3 gen_mindmap_lineage.py --maps context/*.smmx --out mindmap_lineage.tsv
+"""
+import argparse, glob, os, subprocess, sys
+from collections import Counter
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+try:
+    from privacy import is_private_title
+except Exception:
+    def is_private_title(t): return "private" in (t or "").lower()
+
+
+def parse_map(smmx, tmp):
+    pref = os.path.join(tmp, os.path.basename(smmx).replace(".smmx", "").replace(" ", "_"))
+    r = subprocess.run([sys.executable, os.path.join(ROOT, "parse_smmx.py"), smmx, "--out-prefix", pref],
+                       capture_output=True, text=True)
+    if not os.path.exists(pref + "_nodes.tsv"):
+        return {}, {}, r.stderr
+    title = {}
+    for ln in open(pref + "_nodes.tsv", encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        c = ln.rstrip("\n").split("\t")
+        if c and c[0]:
+            title[c[0]] = c[2] if len(c) > 2 and c[2] else c[0]
+    struct_parent, broader = {}, {}      # keep structural (subtopic) separate from super_category fallback
+    for ln in open(pref + "_edges.tsv", encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        c = ln.rstrip("\n").split("\t")
+        if len(c) < 3:
+            continue
+        src, dst, rel = c[0], c[1], c[2]
+        if rel in ("subtopic", "subcategory"):
+            struct_parent.setdefault(dst, src)          # first structural parent wins (principal)
+        elif rel == "super_category":
+            broader.setdefault(src, dst)
+    parent = dict(broader); parent.update(struct_parent)  # structural parent takes precedence
+    return title, parent, ""
+
+
+def lineage(node, parent):
+    chain, seen = [node], {node}
+    while node in parent and parent[node] not in seen:
+        node = parent[node]; chain.append(node); seen.add(node)
+    return list(reversed(chain))                          # root first
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--maps", nargs="+", default=sorted(glob.glob(os.path.join(ROOT, "context", "*.smmx"))))
+    ap.add_argument("--tmp", default="/tmp/mu_data/mm_parse")
+    ap.add_argument("--out", default=os.path.join(ROOT, "mindmap_lineage.tsv"))
+    a = ap.parse_args()
+    os.makedirs(a.tmp, exist_ok=True)
+
+    rows, skipped_private, per_map = [], 0, {}
+    for smmx in a.maps:
+        title, parent, err = parse_map(smmx, a.tmp)
+        mapname = os.path.basename(smmx).replace(".smmx", "")
+        if not title:
+            print(f"  SKIP {mapname}: {err.strip()[:80] or 'no nodes (private root?)'}"); continue
+        n_map = 0
+        for node in title:
+            chain = lineage(node, parent)
+            if len(chain) < 2:
+                continue                                  # roots/orphans — no lineage
+            titles = [title.get(k, k) for k in chain]
+            if any(is_private_title(t) for t in titles):  # belt-and-suspenders
+                skipped_private += 1; continue
+            # CLEAN: drop the "Root Node" sentinel (in folder "root", a generic placeholder), drop nav
+            # artifacts ("via link"), and collapse consecutive duplicate titles (cross-map join echoes).
+            clean = []
+            for t in titles:
+                tl = t.strip().lower()
+                if tl in ("root node", "root_node") or tl == "via link":
+                    continue
+                if clean and clean[-1] == t:
+                    continue
+                clean.append(t)
+            if len(clean) < 2:
+                continue
+            rows.append((mapname, node, clean[-1], " / ".join(clean), len(clean)))
+            n_map += 1
+        per_map[mapname] = n_map
+
+    with open(a.out, "w", encoding="utf-8") as f:
+        f.write("map\tnode_key\tnode_title\tmaterialized_path\tdepth\n")
+        for r in rows:
+            f.write("\t".join(str(x) for x in r) + "\n")
+    print(f"\nwrote {len(rows)} lineage chains from {len(a.maps)} maps → {a.out}")
+    print(f"  per-map: {per_map}")
+    print(f"  depth distribution: {dict(sorted(Counter(r[4] for r in rows).items()))}")
+    print(f"  private lineages skipped (belt-and-suspenders): {skipped_private}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/gen_mindmap_lineage.py
+++ b/prototypes/mu_cosine/gen_mindmap_lineage.py
@@ -6,12 +6,12 @@ For each node, navigate parent links UP to the root and emit the materialized pa
 hangs off one structural parent, so lineage is well-defined. Yields data NOT in enwiki.
 
 Privacy: parse_smmx.py already scrubs (privacy.py::is_private_title drops a "private" node + its subtree,
-a private root drops the whole map) at parse time — so this builds on already-clean output. As a belt-and-
-suspenders check we ALSO skip any lineage whose path contains a "private"-labelled title.
+a private root drops the whole map) at parse time — so this builds on already-clean output. Belt-and-
+suspenders: we re-check both the RAW and the CLEANED path titles here.
 
 Edges from parse_smmx are src(parent)→dst(child):relation. Parent map:
   subtopic / subcategory : parent[dst] = src   (dst is under src)
-  super_category         : parent[src] = dst   (dst is broader than src)  — only if no structural parent
+  super_category         : parent[src] = dst   (dst is broader than src)  — fallback only, counted+logged
 Then materialized_path(node) = titles(root … node). 70/30 directional/superposition sampling comes AFTER.
 
   python3 gen_mindmap_lineage.py --maps context/*.smmx --out mindmap_lineage.tsv
@@ -25,34 +25,40 @@ try:
 except Exception:
     def is_private_title(t): return "private" in (t or "").lower()
 
+SENTINELS = ("root node", "root_node")   # shared top placeholder (folder "root"); dropped from paths
+NAV = ("via link",)                       # navigation artifacts
+
 
 def parse_map(smmx, tmp):
     pref = os.path.join(tmp, os.path.basename(smmx).replace(".smmx", "").replace(" ", "_"))
     r = subprocess.run([sys.executable, os.path.join(ROOT, "parse_smmx.py"), smmx, "--out-prefix", pref],
                        capture_output=True, text=True)
     if not os.path.exists(pref + "_nodes.tsv"):
-        return {}, {}, r.stderr
+        return {}, {}, set(), r.stderr
     title = {}
-    for ln in open(pref + "_nodes.tsv", encoding="utf-8"):
-        if ln.startswith("#"):
-            continue
-        c = ln.rstrip("\n").split("\t")
-        if c and c[0]:
-            title[c[0]] = c[2] if len(c) > 2 and c[2] else c[0]
-    struct_parent, broader = {}, {}      # keep structural (subtopic) separate from super_category fallback
-    for ln in open(pref + "_edges.tsv", encoding="utf-8"):
-        if ln.startswith("#"):
-            continue
-        c = ln.rstrip("\n").split("\t")
-        if len(c) < 3:
-            continue
-        src, dst, rel = c[0], c[1], c[2]
-        if rel in ("subtopic", "subcategory"):
-            struct_parent.setdefault(dst, src)          # first structural parent wins (principal)
-        elif rel == "super_category":
-            broader.setdefault(src, dst)
+    with open(pref + "_nodes.tsv", encoding="utf-8") as f:
+        for ln in f:
+            if ln.startswith("#"):
+                continue
+            c = ln.rstrip("\n").split("\t")
+            if c and c[0]:
+                title[c[0]] = c[2] if len(c) > 2 and c[2] else c[0]
+    struct_parent, broader = {}, {}       # structural (subtopic) vs super_category fallback
+    with open(pref + "_edges.tsv", encoding="utf-8") as f:
+        for ln in f:
+            if ln.startswith("#"):
+                continue
+            c = ln.rstrip("\n").split("\t")
+            if len(c) < 3:
+                continue
+            src, dst, rel = c[0], c[1], c[2]
+            if rel in ("subtopic", "subcategory"):
+                struct_parent.setdefault(dst, src)        # first structural parent wins (principal)
+            elif rel == "super_category":
+                broader.setdefault(src, dst)
     parent = dict(broader); parent.update(struct_parent)  # structural parent takes precedence
-    return title, parent, ""
+    fallback = set(broader) - set(struct_parent)          # parent came ONLY from super_category
+    return title, parent, fallback, ""
 
 
 def lineage(node, parent):
@@ -60,6 +66,18 @@ def lineage(node, parent):
     while node in parent and parent[node] not in seen:
         node = parent[node]; chain.append(node); seen.add(node)
     return list(reversed(chain))                          # root first
+
+
+def clean_titles(titles):
+    out = []
+    for t in titles:
+        tl = t.strip().lower()
+        if tl in SENTINELS or tl in NAV:
+            continue
+        if out and out[-1] == t:                          # collapse cross-map join echoes
+            continue
+        out.append(t)
+    return out
 
 
 def main():
@@ -70,30 +88,23 @@ def main():
     a = ap.parse_args()
     os.makedirs(a.tmp, exist_ok=True)
 
-    rows, skipped_private, per_map = [], 0, {}
+    rows, skipped_private, fb_total, per_map = [], 0, 0, {}
     for smmx in a.maps:
-        title, parent, err = parse_map(smmx, a.tmp)
+        title, parent, fallback, err = parse_map(smmx, a.tmp)
         mapname = os.path.basename(smmx).replace(".smmx", "")
         if not title:
             print(f"  SKIP {mapname}: {err.strip()[:80] or 'no nodes (private root?)'}"); continue
+        fb_total += len(fallback)
         n_map = 0
         for node in title:
             chain = lineage(node, parent)
             if len(chain) < 2:
                 continue                                  # roots/orphans — no lineage
-            titles = [title.get(k, k) for k in chain]
-            if any(is_private_title(t) for t in titles):  # belt-and-suspenders
+            raw = [title.get(k, k) for k in chain]
+            clean = clean_titles(raw)
+            # belt-and-suspenders: privacy on BOTH raw and cleaned titles (review #9)
+            if any(is_private_title(t) for t in raw) or any(is_private_title(t) for t in clean):
                 skipped_private += 1; continue
-            # CLEAN: drop the "Root Node" sentinel (in folder "root", a generic placeholder), drop nav
-            # artifacts ("via link"), and collapse consecutive duplicate titles (cross-map join echoes).
-            clean = []
-            for t in titles:
-                tl = t.strip().lower()
-                if tl in ("root node", "root_node") or tl == "via link":
-                    continue
-                if clean and clean[-1] == t:
-                    continue
-                clean.append(t)
             if len(clean) < 2:
                 continue
             rows.append((mapname, node, clean[-1], " / ".join(clean), len(clean)))
@@ -107,6 +118,7 @@ def main():
     print(f"\nwrote {len(rows)} lineage chains from {len(a.maps)} maps → {a.out}")
     print(f"  per-map: {per_map}")
     print(f"  depth distribution: {dict(sorted(Counter(r[4] for r in rows).items()))}")
+    print(f"  super_category-fallback parents (no structural parent): {fb_total}")
     print(f"  private lineages skipped (belt-and-suspenders): {skipped_private}")
 
 

--- a/prototypes/mu_cosine/gen_mindmap_lineage.py
+++ b/prototypes/mu_cosine/gen_mindmap_lineage.py
@@ -58,6 +58,21 @@ def parse_map(smmx, tmp):
                 broader.setdefault(src, dst)
     parent = dict(broader); parent.update(struct_parent)  # structural parent takes precedence
     fallback = set(broader) - set(struct_parent)          # parent came ONLY from super_category
+    # BYPASS nav nodes in the STRUCTURE (not just the display path): if a node's parent is a nav node,
+    # reconnect it to the nav node's parent, then drop nav nodes entirely. Fixes "via link" appearing as a
+    # true parent in the graph judge + reconnects chains the nav node was breaking.
+    nav_keys = {k for k, t in title.items() if t.strip().lower() in NAV}
+    if nav_keys:
+        def real_parent(n):
+            p, seen = parent.get(n), set()
+            while p in nav_keys and p not in seen:
+                seen.add(p); p = parent.get(p)
+            return p
+        parent = {n: real_parent(n) for n in parent}
+        parent = {n: p for n, p in parent.items() if p is not None and p not in nav_keys and n not in nav_keys}
+        fallback -= nav_keys
+        for k in nav_keys:
+            title.pop(k, None)
     return title, parent, fallback, ""
 
 

--- a/prototypes/mu_cosine/gen_mindmap_lineage.py
+++ b/prototypes/mu_cosine/gen_mindmap_lineage.py
@@ -63,12 +63,13 @@ def parse_map(smmx, tmp):
     # true parent in the graph judge + reconnects chains the nav node was breaking.
     nav_keys = {k for k, t in title.items() if t.strip().lower() in NAV}
     if nav_keys:
+        _orig = dict(parent)                                  # snapshot: real_parent reads the PRE-mutation map
         def real_parent(n):
-            p, seen = parent.get(n), set()
+            p, seen = _orig.get(n), set()
             while p in nav_keys and p not in seen:
-                seen.add(p); p = parent.get(p)
+                seen.add(p); p = _orig.get(p)
             return p
-        parent = {n: real_parent(n) for n in parent}
+        parent = {n: real_parent(n) for n in _orig}
         parent = {n: p for n, p in parent.items() if p is not None and p not in nav_keys and n not in nav_keys}
         fallback -= nav_keys
         for k in nav_keys:

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -55,7 +55,7 @@ OPS = {"SYM": 0, "HIER": 1, "_DEPRECATED_LLM": 2, "ELEM": 3}   # index 2 kept fo
 # (off-manifold noise, exactly like an absent ancestor slot); masking ⇒ provenance-AGNOSTIC μ, which is
 # the DEFAULT inference path (marginalize over sources). Reserved entries (enwiki) are for later corpora.
 CORPORA = {"simplewiki": 0, "enwiki": 1, "pearltrees": 2, "mindmap": 3}
-JUDGES = {"haiku": 0, "graph": 1, "human": 2, "sonnet": 3, "opus": 4, "gemini": 5, "gpt-5.5-low": 6}    # judge_emb is a LEARNED table (nn.Embedding, ~line 329), keyed by these indices — each (MODEL, reasoning-EFFORT) = own calibration row → own tag (low≠xhigh; they disagreed on labels). gpt-5.5-low = `codex exec -m gpt-5.5 -c model_reasoning_effort=low`. Cheaper future judges (gpt-5.3-low, gpt-5.4-low, …) get 7,8,… Tag pairs by the exact judge that scored them, NEVER default to haiku.
+JUDGES = {"haiku": 0, "graph": 1, "human": 2, "sonnet": 3, "opus": 4, "gemini": 5, "gpt-5.5-low": 6}    # learned judge_emb; each (model,effort) = own calibration row, tagged by the exact judge that scored it. Rationale/policy in DESIGN_calibrated_judges.md.
                                          # (SYM/LLM); graph = a Wikipedia edge / non-edge (WIKI, free μ=0 SYM
                                          # negatives); human = a hand-curated edge (mindmap/pearltrees);
                                          # sonnet/opus = stronger-model judgments (escalated tie-breaks, §14)

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -55,7 +55,7 @@ OPS = {"SYM": 0, "HIER": 1, "_DEPRECATED_LLM": 2, "ELEM": 3}   # index 2 kept fo
 # (off-manifold noise, exactly like an absent ancestor slot); masking ⇒ provenance-AGNOSTIC μ, which is
 # the DEFAULT inference path (marginalize over sources). Reserved entries (enwiki) are for later corpora.
 CORPORA = {"simplewiki": 0, "enwiki": 1, "pearltrees": 2, "mindmap": 3}
-JUDGES = {"haiku": 0, "graph": 1, "human": 2, "sonnet": 3, "opus": 4}    # haiku = a bought LLM judgment
+JUDGES = {"haiku": 0, "graph": 1, "human": 2, "sonnet": 3, "opus": 4, "gemini": 5, "gpt-5.5-low": 6}    # judge_emb is a LEARNED table (nn.Embedding, ~line 329), keyed by these indices — each (MODEL, reasoning-EFFORT) = own calibration row → own tag (low≠xhigh; they disagreed on labels). gpt-5.5-low = `codex exec -m gpt-5.5 -c model_reasoning_effort=low`. Cheaper future judges (gpt-5.3-low, gpt-5.4-low, …) get 7,8,… Tag pairs by the exact judge that scored them, NEVER default to haiku.
                                          # (SYM/LLM); graph = a Wikipedia edge / non-edge (WIKI, free μ=0 SYM
                                          # negatives); human = a hand-curated edge (mindmap/pearltrees);
                                          # sonnet/opus = stronger-model judgments (escalated tie-breaks, §14)

--- a/prototypes/mu_cosine/prototype_graph_judge.py
+++ b/prototypes/mu_cosine/prototype_graph_judge.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Prototype the GRAPH judge (DESIGN_mindmap_lineage.md §3b) on one mindmap.
+
+For each node (the item to file) with a true structural parent p, score candidate parents by
+    mu_graph = max(floor, gamma^hops(c,p) * lca_frac(c,p))
+where hops = undirected graph distance, lca_frac = shared-prefix depth of lineage(c) vs lineage(p) over
+len(lineage(p)) (the whole-lineage structural factor). Truth (c==p) -> hops 0, lca_frac 1 -> mu 1.
+e5-of-prefix is only a TIE-BREAKER among structurally-equal candidates (not multiplied) -- shown as a hook.
+
+Eyeball: true parent should rank #1 at mu=1; siblings/uncles moderate; far subtrees -> floor.
+
+  python3 prototype_graph_judge.py --map "context/Chaos theory.smmx"
+"""
+import argparse, os, random, sys
+from collections import defaultdict, deque
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from gen_mindmap_lineage import parse_map, lineage
+
+
+def undirected_adj(parent):
+    adj = defaultdict(set)
+    for c, p in parent.items():
+        adj[c].add(p); adj[p].add(c)
+    return adj
+
+
+def bfs_dist(adj, src):
+    dist, q = {src: 0}, deque([src])
+    while q:
+        u = q.popleft()
+        for v in adj[u]:
+            if v not in dist:
+                dist[v] = dist[u] + 1; q.append(v)
+    return dist
+
+
+def common_prefix_len(a, b):
+    n = 0
+    for x, y in zip(a, b):
+        if x != y:
+            break
+        n += 1
+    return n
+
+
+def descendants(node, children):
+    seen, stack = set(), [node]
+    while stack:
+        for c in children.get(stack.pop(), ()):
+            if c not in seen:
+                seen.add(c); stack.append(c)
+    return seen
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--map", default=os.path.join(os.path.dirname(__file__), "context", "Chaos theory.smmx"))
+    ap.add_argument("--gamma", type=float, default=0.6, help="decay base gamma^hops")
+    ap.add_argument("--floor", type=float, default=0.02, help="mu floor (shares-only-root, never 0)")
+    ap.add_argument("--k", type=int, default=6, help="sampled candidate parents per node (besides the true one)")
+    ap.add_argument("--show", type=int, default=6)
+    ap.add_argument("--tmp", default="/tmp/mu_data/mm_parse")
+    a = ap.parse_args()
+    os.makedirs(a.tmp, exist_ok=True)
+    rng = random.Random(0)
+
+    title, parent, fallback, err = parse_map(a.map, a.tmp)
+    if not title:
+        print("parse failed:", err[:120]); return
+    children = defaultdict(set)
+    for c, p in parent.items():
+        children[p].add(c)
+
+    filed = [n for n in title if n in parent]
+    true_is_top, true_mu1, shown, all_mu = 0, 0, 0, []
+    for n in filed:
+        p = parent[n]
+        lin_p = lineage(p, parent)
+        dist = bfs_dist(undirected_adj(parent), p)
+        forbidden = descendants(n, children) | {n, p}          # can't file under self/descendant; p added separately
+        pool = [m for m in title if m not in forbidden]
+        cands = [p] + rng.sample(pool, min(a.k, len(pool)))
+        scored = []
+        for c in cands:
+            hops = dist.get(c, 99)
+            lca = common_prefix_len(lineage(c, parent), lin_p)
+            frac = lca / max(1, len(lin_p))
+            mu = max(a.floor, (a.gamma ** hops) * frac)
+            scored.append((mu, hops, round(frac, 2), c))
+        scored.sort(key=lambda x: -x[0])
+        true_mu = next(m for m, h, f, c in scored if c == p)
+        all_mu.append(true_mu)
+        if scored[0][3] == p:
+            true_is_top += 1
+        if abs(true_mu - 1.0) < 1e-9:
+            true_mu1 += 1
+        if shown < a.show:
+            print(f"\nfile '{title[n]}'  (true parent: '{title[p]}')")
+            for mu, hops, frac, c in scored:
+                print(f"    mu={mu:.3f}  hops={hops:>2}  lcaFrac={frac:<4}  {title.get(c, c)}"
+                      + ("   <- TRUE" if c == p else ""))
+            shown += 1
+
+    N = len(filed)
+    print(f"\n=== summary ({N} filable nodes, gamma={a.gamma}, floor={a.floor}) ===")
+    print(f"  true parent ranked #1: {true_is_top}/{N} ({100*true_is_top/max(1,N):.0f}%)")
+    print(f"  true parent mu == 1.0: {true_mu1}/{N}")
+    print(f"  mean/min true-parent mu: {sum(all_mu)/max(1,N):.3f} / {min(all_mu):.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/prototype_graph_judge.py
+++ b/prototypes/mu_cosine/prototype_graph_judge.py
@@ -4,10 +4,14 @@
 For each node (the item to file) with a true structural parent p, score candidate parents by
     mu_graph = max(floor, gamma^hops(c,p) * lca_frac(c,p))
 where hops = undirected graph distance, lca_frac = shared-prefix depth of lineage(c) vs lineage(p) over
-len(lineage(p)) (the whole-lineage structural factor). Truth (c==p) -> hops 0, lca_frac 1 -> mu 1.
-e5-of-prefix is only a TIE-BREAKER among structurally-equal candidates (not multiplied) -- shown as a hook.
+len(lineage(p)) -- i.e. "how much of the TRUTH's ancestry the candidate shares" (whole-lineage structural
+factor). Truth (c==p) -> hops 0, lca_frac 1 -> mu 1.
 
-Eyeball: true parent should rank #1 at mu=1; siblings/uncles moderate; far subtrees -> floor.
+Candidate pool = NEGATIVES only: excludes n, its descendants, AND its ancestors (ancestors are graded
+POSITIVES, not negatives -- review round 2). Unreachable candidates get hops = D_max+1 (graceful fallback
+for a single-map parse, not a sentinel) so lca_frac still differentiates them by shared ancestry.
+
+Eyeball: true parent should be #1 at mu=1; ancestors excluded; near subtrees moderate; far -> floor.
 
   python3 prototype_graph_judge.py --map "context/Chaos theory.smmx"
 """
@@ -72,20 +76,28 @@ def main():
     for c, p in parent.items():
         children[p].add(c)
 
+    adj = undirected_adj(parent)                              # build ONCE (review: was per-node O(N^2))
+    D_max = max((len(lineage(n, parent)) for n in title), default=1)
+    dist_cache = {}                                           # bfs from each true parent, cached by key
+
     filed = [n for n in title if n in parent]
-    true_is_top, true_mu1, shown, all_mu = 0, 0, 0, []
+    true_is_top, true_mu1, shown, all_mu, unreachable = 0, 0, 0, [], 0
     for n in filed:
         p = parent[n]
         lin_p = lineage(p, parent)
-        dist = bfs_dist(undirected_adj(parent), p)
-        forbidden = descendants(n, children) | {n, p}          # can't file under self/descendant; p added separately
+        if p not in dist_cache:
+            dist_cache[p] = bfs_dist(adj, p)
+        dist = dist_cache[p]
+        ancestors = set(lineage(n, parent)[:-1])              # graded POSITIVES, not negatives -> exclude
+        forbidden = descendants(n, children) | ancestors | {n}
         pool = [m for m in title if m not in forbidden]
         cands = [p] + rng.sample(pool, min(a.k, len(pool)))
         scored = []
         for c in cands:
-            hops = dist.get(c, 99)
-            lca = common_prefix_len(lineage(c, parent), lin_p)
-            frac = lca / max(1, len(lin_p))
+            hops = dist.get(c, D_max + 1)                     # graceful fallback, not a sentinel
+            if c not in dist:
+                unreachable += 1
+            frac = common_prefix_len(lineage(c, parent), lin_p) / max(1, len(lin_p))
             mu = max(a.floor, (a.gamma ** hops) * frac)
             scored.append((mu, hops, round(frac, 2), c))
         scored.sort(key=lambda x: -x[0])
@@ -103,10 +115,11 @@ def main():
             shown += 1
 
     N = len(filed)
-    print(f"\n=== summary ({N} filable nodes, gamma={a.gamma}, floor={a.floor}) ===")
+    print(f"\n=== summary ({N} filable nodes, gamma={a.gamma}, floor={a.floor}, D_max={D_max}) ===")
     print(f"  true parent ranked #1: {true_is_top}/{N} ({100*true_is_top/max(1,N):.0f}%)")
     print(f"  true parent mu == 1.0: {true_mu1}/{N}")
     print(f"  mean/min true-parent mu: {sum(all_mu)/max(1,N):.3f} / {min(all_mu):.3f}")
+    print(f"  unreachable candidates (single-map fragmentation, hops=D_max+1): {unreachable}")
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/score_with_codex.py
+++ b/prototypes/mu_cosine/score_with_codex.py
@@ -6,30 +6,48 @@ Judge tag = 'gpt-5.5-low' (its own learned calibration row; see JUDGES in mu_att
   source ~/.nvm/nvm.sh && nvm use 22            # codex needs node 22
   python3 score_with_codex.py --pairs inferred_tail_pilot.tsv --batch 10 --out /tmp/mu_data/pilot_scored_gpt55low.tsv
 """
-import argparse, os, re, subprocess, sys, time
+import argparse, json, os, subprocess, sys, tempfile, time
+
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from score_inferred_tail import build_prompts, ingest
 
 JUDGE = "gpt-5.5-low"
-CODEX = ["codex", "exec", "-s", "read-only", "-m", "gpt-5.5", "-c", "model_reasoning_effort=low"]
 
 
-def load_pairs(path):
-    return [ln.rstrip("\n").split("\t") for ln in open(path, encoding="utf-8") if not ln.startswith("#")]
+def load_pair_lines(path):
+    """Return (data_lines_without_newline, header_comment_lines) preserving order; data = non-# lines."""
+    data, header = [], []
+    for ln in open(path, encoding="utf-8"):
+        (header if ln.startswith("#") else data).append(ln.rstrip("\n"))
+    return data, header
 
 
-def call_codex(prompt, timeout):
+def call_codex(prompt, model, effort, sandbox, timeout):
     try:
-        p = subprocess.run(CODEX, input=prompt, capture_output=True, text=True, timeout=timeout)
+        p = subprocess.run(
+            ["codex", "exec", "-s", sandbox, "-m", model, "-c", "model_reasoning_effort=%s" % effort],
+            input=prompt, capture_output=True, text=True, timeout=timeout)
         return p.stdout + p.stderr
     except subprocess.TimeoutExpired:
         return ""
 
 
 def first_json_array(txt):
-    # codex double-prints (echo + response); take the FIRST complete [ {...} ] array
-    m = re.search(r'\[\s*\{.*?\}\s*\]', txt, re.S)
-    return m.group(0) if m else None
+    """Robustly extract the FIRST complete top-level JSON array (codex double-prints; objects nest, so a
+    regex is unsafe — review #1). Scan for '[' and let json.raw_decode consume a full, balanced value."""
+    dec = json.JSONDecoder()
+    i = 0
+    while True:
+        j = txt.find("[", i)
+        if j < 0:
+            return None
+        try:
+            val, end = dec.raw_decode(txt, j)
+            if isinstance(val, list):
+                return txt[j:end]
+        except json.JSONDecodeError:
+            pass
+        i = j + 1
 
 
 def main():
@@ -38,34 +56,51 @@ def main():
     ap.add_argument("--batch", type=int, default=10)
     ap.add_argument("--limit", type=int, default=0, help="0 = all pairs")
     ap.add_argument("--timeout", type=int, default=180)
+    ap.add_argument("--model", default="gpt-5.5")
+    ap.add_argument("--effort", default="low", help="model_reasoning_effort (minimal blocked via codex image_gen)")
+    ap.add_argument("--sandbox", default="read-only", help="codex -s sandbox mode (review #10)")
     ap.add_argument("--out", required=True)
     ap.add_argument("--responses", default="/tmp/mu_data/codex_responses.txt")
     a = ap.parse_args()
     os.makedirs(os.path.dirname(a.responses) or ".", exist_ok=True)
 
-    pairs = load_pairs(a.pairs)
+    data, header = load_pair_lines(a.pairs)
     if a.limit:
-        pairs = pairs[:a.limit]
+        data = data[:a.limit]
+    pairs = [ln.split("\t") for ln in data]
     prompts = build_prompts(pairs, a.batch)
-    print(f"scoring {len(pairs)} pairs in {len(prompts)} batches of {a.batch} via codex {JUDGE}", flush=True)
+    print("scoring %d pairs in %d batches of %d via codex %s (effort=%s, sandbox=%s)"
+          % (len(pairs), len(prompts), a.batch, a.model, a.effort, a.sandbox), flush=True)
 
-    arrays, ok, t0 = [], 0, time.time()
+    arrays, ok, fail, t0 = [], 0, 0, time.time()
     for i, pr in enumerate(prompts):
         t = time.time()
-        arr = first_json_array(call_codex(pr, a.timeout))
+        arr = first_json_array(call_codex(pr, a.model, a.effort, a.sandbox, a.timeout))
         dt = time.time() - t
         if arr:
-            arrays.append(arr); ok += 1
-            status = "ok"
+            arrays.append(arr); ok += 1; status = "ok"
         else:
-            status = "FAIL(no-json/timeout)"
-        rate = (ok * a.batch) / max(1e-9, time.time() - t0)
-        print(f"  batch {i+1:3d}/{len(prompts)}  {dt:5.1f}s  {status}  | cum {time.time()-t0:5.0f}s  ~{rate:.2f} pairs/s", flush=True)
+            fail += 1; status = "FAIL(no-json/timeout)"
+        done = ok + fail
+        rate = (ok * a.batch) / max(1e-9, time.time() - t0)     # scored pairs/s (successful only, by design)
+        print("  batch %3d/%d  %5.1fs  %-20s | cum %5.0fs  fail %d/%d (%.0f%%)  ~%.2f pairs/s"
+              % (i + 1, len(prompts), dt, status, time.time() - t0, fail, done, 100.0 * fail / done, rate),
+              flush=True)
 
     with open(a.responses, "w", encoding="utf-8") as f:
         f.write("\n".join(arrays))
-    ingest(a.pairs if not a.limit else a.pairs, a.responses, a.out, judge=JUDGE)
-    print(f"DONE: {ok}/{len(prompts)} batches scored ({time.time()-t0:.0f}s total) → {a.out}  (judge={JUDGE})", flush=True)
+
+    # ingest against the SAME (possibly limited) pair set — write a temp pairs file so ids align 1:1 (review #2)
+    if a.limit:
+        fd, ing_path = tempfile.mkstemp(suffix="_limited.tsv", dir=os.path.dirname(a.responses) or ".")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write("\n".join(header + data) + "\n")
+    else:
+        ing_path = a.pairs
+    ingest(ing_path, a.responses, a.out, judge=JUDGE)
+    print("DONE: %d/%d batches scored, %d failed (%.0f%%), %.0fs total → %s  (judge=%s)"
+          % (ok, len(prompts), fail, 100.0 * fail / max(1, len(prompts)), time.time() - t0, a.out, JUDGE),
+          flush=True)
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/score_with_codex.py
+++ b/prototypes/mu_cosine/score_with_codex.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Batch-score concept pairs with the codex judge (gpt-5.5, low thinking) → §14 JSON → ingest.
+Reuses score_inferred_tail.build_prompts + ingest. Logs per-batch timing so usage thresholds can be estimated.
+Judge tag = 'gpt-5.5-low' (its own learned calibration row; see JUDGES in mu_attention.py).
+
+  source ~/.nvm/nvm.sh && nvm use 22            # codex needs node 22
+  python3 score_with_codex.py --pairs inferred_tail_pilot.tsv --batch 10 --out /tmp/mu_data/pilot_scored_gpt55low.tsv
+"""
+import argparse, os, re, subprocess, sys, time
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from score_inferred_tail import build_prompts, ingest
+
+JUDGE = "gpt-5.5-low"
+CODEX = ["codex", "exec", "-s", "read-only", "-m", "gpt-5.5", "-c", "model_reasoning_effort=low"]
+
+
+def load_pairs(path):
+    return [ln.rstrip("\n").split("\t") for ln in open(path, encoding="utf-8") if not ln.startswith("#")]
+
+
+def call_codex(prompt, timeout):
+    try:
+        p = subprocess.run(CODEX, input=prompt, capture_output=True, text=True, timeout=timeout)
+        return p.stdout + p.stderr
+    except subprocess.TimeoutExpired:
+        return ""
+
+
+def first_json_array(txt):
+    # codex double-prints (echo + response); take the FIRST complete [ {...} ] array
+    m = re.search(r'\[\s*\{.*?\}\s*\]', txt, re.S)
+    return m.group(0) if m else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pairs", required=True)
+    ap.add_argument("--batch", type=int, default=10)
+    ap.add_argument("--limit", type=int, default=0, help="0 = all pairs")
+    ap.add_argument("--timeout", type=int, default=180)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--responses", default="/tmp/mu_data/codex_responses.txt")
+    a = ap.parse_args()
+    os.makedirs(os.path.dirname(a.responses) or ".", exist_ok=True)
+
+    pairs = load_pairs(a.pairs)
+    if a.limit:
+        pairs = pairs[:a.limit]
+    prompts = build_prompts(pairs, a.batch)
+    print(f"scoring {len(pairs)} pairs in {len(prompts)} batches of {a.batch} via codex {JUDGE}", flush=True)
+
+    arrays, ok, t0 = [], 0, time.time()
+    for i, pr in enumerate(prompts):
+        t = time.time()
+        arr = first_json_array(call_codex(pr, a.timeout))
+        dt = time.time() - t
+        if arr:
+            arrays.append(arr); ok += 1
+            status = "ok"
+        else:
+            status = "FAIL(no-json/timeout)"
+        rate = (ok * a.batch) / max(1e-9, time.time() - t0)
+        print(f"  batch {i+1:3d}/{len(prompts)}  {dt:5.1f}s  {status}  | cum {time.time()-t0:5.0f}s  ~{rate:.2f} pairs/s", flush=True)
+
+    with open(a.responses, "w", encoding="utf-8") as f:
+        f.write("\n".join(arrays))
+    ingest(a.pairs if not a.limit else a.pairs, a.responses, a.out, judge=JUDGE)
+    print(f"DONE: {ok}/{len(prompts)} batches scored ({time.time()-t0:.0f}s total) → {a.out}  (judge={JUDGE})", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Builds the SimpleMind mindmap **LINEAGE** sampler and documents the methodology for turning
mindmap hierarchies into **filing training data** for the μ model — non-enwiki data that is the
closest available proxy to the (still-harvesting) Pearltrees filing target.

**Built:** `gen_mindmap_lineage.py` — parses `.smmx` maps → materialized-path lineages
(491 chains, 6 systems-theory maps). Handles the shared `Root Node` sentinel (folder `root`,
to which all maps link up), filters `via link` nav nodes, collapses cross-map echoes; privacy is
scrubbed upstream by `parse_smmx.py` (`is_private_title`: a "private" node drops itself + subtree,
a private root drops the whole map).

**Documented (design, prototype next):** `DESIGN_mindmap_lineage.md` — the negative-generation
and judge-scoring methodology.

## Methodology (the part to review)

- **LINEAGE first, then 70/30 split.** A mindmap node hangs off one structural parent, so single-path
  lineage is well-defined (same reasoning as the Pearltrees single-path decision).
- **Positives: complete + graded by distance.** Small dataset → enumerate every (descendant, ancestor)
  pair; μ graded by lineage depth (parent > grandparent > …), not binary.
- **Negatives: sampled, typed, graded.** Substitution (alternate parent) over permutation; hardness
  **stratified by e5 distance of the substituted node** (near = sibling/cousin hard negative). Key point:
  because all nodes share the global root, **no pair is truly unrelated** — μ falls off *gradually* with
  tree-distance rather than snapping to 0, so sibling/cousin hard negatives matter most.
- **e5 distance stratifies candidates; it is NOT used as μ** (semantic distance ≠ filing plausibility).
- **Judge scoring:** remove the last hop → each example is real filing data. Score **pointwise,
  independently (μ does not sum to 1)**, ≥2 candidates; **max-normalize to the model's top pick = 1**
  with a **linear** curve (sigmoid only as a temperature-controlled sharpness knob). **Multi-parent guard:**
  anchoring to the model's top honors genuine second parents, but the ground-truth filing is kept as a
  sanity floor (flag if it scores low).
- **Two complementary judges:**
  - **LLM** (codex `gpt-5.5-low`, non-Anthropic) — semantic plausibility.
  - **GRAPH** — `μ = decay(distance-to-truth)`, tagged `judge=graph` (already a defined judge). Cheap,
    structural, maps distance→μ honestly.
  - **Whole-lineage graph-μ (not just the immediate parent):** a bare parent-to-parent hop is myopic
    (equidistant candidates can sit in very different lineages). `μ_graph` factors in the full
    materialized-path prefix via **LCA depth** (structural shared-prefix) and **e5-of-prefix distance**
    (semantic — `Math/Calculus/…` stays close to `Math/Analysis/…`). e5 remains a *factor inside the
    graph heuristic*, not e5-alone-as-μ. `μ_graph ≈ decay(hops) · lca_depth_frac · f(e5_prefix_dist)`
    (exact combination TBD by prototype — a good spot to review for weighting / double-counting between
    LCA-depth and e5-prefix).
  - **Cost-smart split:** run the free graph judge over everything, spend LLM calls only where graph-μ is
    uncertain (near-ties, structurally-distant candidates). Disagreement between judges = the ambiguous /
    multi-parent signal.

## Graph-distance alternatives (per reviewer note)

The graph judge's distance→μ decay is one choice among the project's existing cost-function variants —
referenced as alternatives in the design doc and `docs/design/COST_FUNCTION_PHILOSOPHY.md`:
**hop/shortest-path** (default, `γ^d`), **exponential-decay flux**, **power-law / inverse-radial** (`1/r^N`),
**PPR / Markov-walk** (multi-path), and **LCA depth** (tree-native tie-breaker). Default = hop-distance +
LCA tie-break; power-law / PPR are the natural upgrades for heavier tails / multi-path mass.

## Also in this PR
- `mu_attention.py`: `JUDGES += {gemini, gpt-5.5-low}` — each (model, reasoning-effort) gets its own
  learned calibration row (table-based `judge_emb`; open-ended attribute-based judge input is future work).
- `score_with_codex.py`: batch judge scorer via `codex exec` (`gpt-5.5-low`).

## Status / next
Lineage built; **next** = substitution+e5 candidate generation → graph judge → targeted LLM judge →
graded-round rows (`corpus=mindmap`). Full value once fused with Pearltrees (`fuse_corpus.py` needs the
harvested PT cache).

## Scope notes
- This PR is the **mindmap/judge methodology** only. The **enwiki fine-tune** thread
  (`build_broad_graph.py`, the `model_broad_ft2.pt` run) is intentionally *not* here — it still has an
  unresolved **SYM baseline question** (whether `model_prod.pt` itself scores ~0 SYM on that held-out set,
  i.e. is the "regression" even real).
- Negative-generation + judge scoring is **designed and documented but not yet coded** — this PR is the
  sampler + the methodology, so the review is of the *plan* for negatives/judges, not an implementation.