### PR TITLE
plawk: bring Tier-2 payloads (#3427) to main

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -143,9 +143,45 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    fwrite to per-slot fwrites emitted left to right (buffered in libc,
    so still memcpy cost per record). Writer output is byte-compatible
    with the `lpsN` reader.
-4. **Tier-2 composition sugar:** a declared payload type whose slice is
-   passed to a compiled Prolog DCG via the foreign bridge without
-   hand-written glue.
+4. **Tier-2 composition sugar (landed):** `blobN` — a length-prefixed
+   binary payload whose only consumer is a compiled-Prolog foreign
+   call. The record loop frames natively (length read, cap check, bulk
+   payload read into the record buffer); passing `$K` to a
+   `prolog_call`/`prolog_guard` copies the payload into the shared
+   transient buffer (`@wam_transient_atom_from_bytes`, constant memory,
+   no interning) and marshals it as the transient atom, which the
+   compiled predicate reads with `atom_codes/2` and parses with an
+   ordinary WAM DCG — real choice points and all. i64 fields marshal
+   as WAM integers (a typed load, no text). Constraints: one blob
+   argument per call (one shared buffer), NUL-free payloads (the
+   transient atom is a C string), f64 marshaling and blob output are
+   later slices.
+
+## Known design debt
+
+- **WAM bug: constant-in-list clause heads never match.** A clause head
+  containing a constant inside a list cell — `p(..., [44|T], ...)` —
+  compiles (get_list/unify_constant path) but never matches at runtime;
+  the semantically identical `p(..., [C|T], ...) :- C == 44` works.
+  Found by the Tier-2 payload DCG (the first code to exercise that head
+  shape through the hybrid compiler); minimal reproducer: a predicate
+  counting leading commas of a code list returns failure on `",,,"`
+  with the constant head and 3 with the guard form. Needs a targeted
+  fix in the WAM head-compilation path; until then, write separators as
+  guards.
+
+
+- **`foreach` unrolling does not scale in code size.** The bounded-
+  repetition surface unrolls its block Cap times (each copy guarded by
+  `count >= j`), which is ideal for small caps (4–8: straight-line,
+  branch-predictable, zero new phi machinery) but emits O(Cap × body)
+  IR — `rep1000` would be absurd. The fix is a real runtime loop:
+  an induction variable, loop-carried phis for the scalar slots, and
+  element addresses computed as `base + j*elemsize` instead of
+  constants. That is the one genuinely new piece of IR machinery the
+  emitter stack lacks (everything today is straight-line plus joins).
+  Plan: emit the loop above a small cap threshold and keep unrolling
+  as the small-cap optimization.
 
 ## Why not a real DCG engine in the loop?
 

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -94,6 +94,7 @@ swipl -q -s tests/test_plawk_varlen_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_varlen_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tagged_unions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_bounded_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -285,7 +286,15 @@ that materializes each record into the same fixed access layout, so an
 guards, `sN` OUTFMT passthrough) while numeric fields keep guards,
 arithmetic, and assoc keys. Clean EOF is only legal at a record
 boundary; oversized lengths, truncated payloads, and mid-record EOF
-exit with the read-error code. Bounded repetition handles records containing a
+exit with the read-error code. Tier-2 payloads connect the two worlds:
+`BINFMT = "i64 blob32"` declares a length-prefixed binary payload whose
+only consumer is a compiled Prolog predicate - the loop frames records
+natively, and `total += payload_sum($2)` hands the payload bytes to a
+WAM-compiled DCG through the ~0.2us foreign bridge (constant memory:
+the payload rides the shared transient atom, no interning). i64 fields
+marshal as WAM integers in binary mode, so foreign guards and calls now
+work over binary records generally. One blob argument per call;
+payloads are NUL-free byte strings. Bounded repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an
 ordinary i64 field, element slots are flat addressable fields

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -629,3 +629,25 @@ Because the cap (4) is known at compile time, the compiler does not
 emit a loop at all — it writes the block out 4 times, each copy
 guarded by "does the record have at least j elements?". Constant
 memory, straight-line native code, same as everything else.
+
+### Handing payloads to Prolog
+
+Everything so far was compiled to plain native code. But PLAWK lives
+inside a Prolog compiler, and some payloads deserve a real parser. A
+`blob32` field is a length-prefixed chunk of bytes that PLAWK itself
+never interprets - its only use is as an argument to a compiled Prolog
+predicate:
+
+```awk
+BEGIN { BINFMT = "i64 blob32" }
+$1 > 0 { total += payload_sum($2) }
+END { print total }
+```
+
+Here `payload_sum/2` is ordinary Prolog compiled into the same binary -
+typically `atom_codes` on the payload followed by a DCG over the byte
+list, with unification and backtracking intact. The division of labor:
+the native loop does the framing (find each record, check lengths,
+skip what doesn't match), and Prolog does the understanding. The
+hand-off costs about 0.2 microseconds and no memory growth - the
+payload travels in a single reused buffer.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1728,6 +1728,10 @@ plawk_binfmt_pattern_ok(Descriptor, field_cmp(Index, _Op, _Value)) :-
 plawk_binfmt_pattern_ok(Descriptor, field_eq(Index, _Value)) :-
     !,
     plawk_binfmt_field_type(Descriptor, Index, s(_Width)).
+plawk_binfmt_pattern_ok(Descriptor, prolog_guard(Name, Args)) :-
+    !,
+    atom(Name),
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
 plawk_binfmt_pattern_ok(Descriptor, and_pat(Left, Right)) :-
     !,
     plawk_binfmt_pattern_ok(Descriptor, Left),
@@ -1832,10 +1836,46 @@ plawk_binfmt_i64_expr_ok(Descriptor, field(Index)) :-
 plawk_binfmt_i64_expr_ok(Descriptor, int(field(Index))) :-
     !,
     plawk_binfmt_field_type(Descriptor, Index, i64).
+plawk_binfmt_i64_expr_ok(Descriptor, prolog_call(Name, Args)) :-
+    !,
+    atom(Name),
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
 plawk_binfmt_i64_expr_ok(Descriptor, Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
     plawk_binfmt_i64_expr_ok(Descriptor, Left),
     plawk_binfmt_i64_expr_ok(Descriptor, Right).
+
+%% plawk_binfmt_foreign_args_ok(+Descriptor, +Args)
+%
+%  Foreign-call arguments in binary mode: integer and string literals,
+%  i64 fields (marshaled as WAM integers), and blob fields (marshaled
+%  as the transient payload atom). At most one blob per call -- all
+%  blobs share the one transient buffer, so a second would overwrite
+%  the first before the call.
+plawk_binfmt_foreign_args_ok(Descriptor, Args) :-
+    Args = [_ | _],
+    forall(member(Arg, Args),
+        plawk_binfmt_foreign_arg_ok(Descriptor, Arg)),
+    findall(F,
+        ( member(field(F), Args),
+          plawk_binfmt_field_type(Descriptor, F, blob(_))
+        ),
+        Blobs),
+    length(Blobs, BlobCount),
+    BlobCount =< 1.
+
+plawk_binfmt_foreign_arg_ok(_Descriptor, int(Value)) :-
+    integer(Value),
+    !.
+plawk_binfmt_foreign_arg_ok(_Descriptor, string(Value)) :-
+    string(Value),
+    !.
+plawk_binfmt_foreign_arg_ok(Descriptor, field(Index)) :-
+    integer(Index),
+    Index >= 1,
+    plawk_binfmt_field_type(Descriptor, Index, Type),
+    ( Type == i64 ; Type = blob(_Cap) ),
+    !.
 
 plawk_binfmt_f64_expr_ok(Descriptor, float_field(Index)) :-
     !,
@@ -1994,6 +2034,18 @@ plawk_binfmt_type(Part, rep(Cap, ElemTypes)) :-
     % region is one bulk read and one flat access layout
     forall(member(ElemType, ElemTypes),
         ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_) )).
+% blobN: a length-prefixed binary payload (8-byte length, then up to N
+% payload bytes) whose ONLY consumer is a compiled-Prolog foreign call:
+% the record loop stays native for framing and hands the payload to a
+% WAM-compiled predicate (a DCG over the bytes) through the foreign
+% bridge -- the Tier-2 composition of PLAWK_DCG_BINARY_READERS.md.
+% Payload bytes must be NUL-free (the transient atom carrying them to
+% Prolog is a C string).
+plawk_binfmt_type(Part, blob(Cap)) :-
+    string_concat("blob", CapStr, Part),
+    number_string(Cap, CapStr),
+    integer(Cap),
+    Cap > 0.
 % sN: a fixed-width string field of N bytes. Values shorter than N are
 % NUL-terminated inside the field; a full-width value has no NUL.
 plawk_binfmt_type(Part, s(Width)) :-
@@ -2044,10 +2096,14 @@ plawk_binfmt_type_width(rep(Cap, ElemTypes), Width) :-
     maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
     sum_list(ElemWidths, ElemSize),
     Width is 8 + Cap * ElemSize.
+% in-memory: the actual length (i64), then the payload bytes
+plawk_binfmt_type_width(blob(Cap), Width) :-
+    Width is 8 + Cap.
 
 plawk_binfmt_has_varlen(Types) :-
     ( memberchk(lps(_Cap), Types)
     ; memberchk(rep(_K, _Elems), Types)
+    ; memberchk(blob(_C), Types)
     ),
     !.
 
@@ -2793,6 +2849,44 @@ plawk_varlen_field_sections([Type | Types], LoweredLabel, Prefix, EofPolicy,
     plawk_varlen_field_sections(Types, LoweredLabel, Prefix, EofPolicy,
         NextIndex, NextOffset, Sections).
 
+plawk_varlen_field_body(blob(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+    !,
+    PayloadOffset is Offset + 8,
+    plawk_varlen_eof_check_ir(FieldEof, FBase, cstatus, BodyPrefixIR),
+    format(atom(BodyIR),
+'  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  %~w_cstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
+~w  %~w_cok = icmp eq i64 %~w_cstatus, 1
+  br i1 %~w_cok, label %~w_len, label %fail_read
+
+~w_len:
+  %~w_ctp = bitcast i8* %~w_dst to i64*
+  %~w_n = load i64, i64* %~w_ctp
+  %~w_fits = icmp ule i64 %~w_n, ~w
+  br i1 %~w_fits, label %~w_read, label %fail_read
+
+~w_read:
+  %~w_pdst = getelementptr i8, i8* %rec, i64 ~w
+  call void @llvm.memset.p0i8.i64(i8* %~w_pdst, i8 0, i64 ~w, i1 false)
+  %~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %~w_n, i8* %~w_pdst)
+  %~w_pok = icmp eq i64 %~w_pstatus, 1
+  br i1 %~w_pok, label %~w, label %fail_read
+',
+        [FBase, Offset,
+         FBase, FBase,
+         BodyPrefixIR, FBase, FBase,
+         FBase, FBase,
+         FBase,
+         FBase, FBase,
+         FBase, FBase,
+         FBase, FBase, Cap,
+         FBase, FBase,
+         FBase,
+         FBase, PayloadOffset,
+         FBase, Cap,
+         FBase, FBase, FBase,
+         FBase, FBase,
+         FBase, NextLabel]).
 plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
     !,
     maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
@@ -4595,6 +4689,48 @@ plawk_foreign_args_ir([Arg | Rest], FieldSeparator, BasePrefix, Index,
     plawk_foreign_args_ir(Rest, FieldSeparator, BasePrefix, NextIndex,
         ArgValueIRs, GlobalPartsRest, SetupPartsRest).
 
+% Binary mode: i64 fields marshal as WAM integers (a typed load, no
+% text anywhere); blob fields copy their payload into the shared
+% transient buffer and marshal as the transient atom -- constant
+% memory, no interning, readable Prolog-side via atom_codes/2.
+plawk_foreign_arg_ir(field(FieldIndex), binfmt(Types), ArgBase, ArgValueIR,
+        [], SetupParts) :-
+    integer(FieldIndex),
+    FieldIndex >= 1,
+    plawk_binfmt_field_type(binfmt(Types), FieldIndex, i64),
+    !,
+    format(atom(LoadBase), '~w_bf', [ArgBase]),
+    plawk_binfmt_field_load_lines(binfmt(Types), FieldIndex, LoadBase,
+        LoadedIR, LoadLines),
+    format(atom(ValueLine),
+        '  %~w_v = call %Value @value_integer(i64 ~w)', [ArgBase, LoadedIR]),
+    format(atom(ArgValueIR), '%~w_v', [ArgBase]),
+    append(LoadLines, [ValueLine], SetupParts).
+plawk_foreign_arg_ir(field(FieldIndex), binfmt(Types), ArgBase, ArgValueIR,
+        [], SetupParts) :-
+    integer(FieldIndex),
+    FieldIndex >= 1,
+    plawk_binfmt_field_type(binfmt(Types), FieldIndex, blob(_Cap)),
+    !,
+    plawk_binfmt_field_offset(binfmt(Types), FieldIndex, Offset),
+    PayloadOffset is Offset + 8,
+    format(atom(SetupIR),
+'  %~w_lp = getelementptr i8, i8* %rec, i64 ~w
+  %~w_ltp = bitcast i8* %~w_lp to i64*
+  %~w_len = load i64, i64* %~w_ltp
+  %~w_ptr = getelementptr i8, i8* %rec, i64 ~w
+  %~w_id = call i64 @wam_transient_atom_from_bytes(i8* %~w_ptr, i64 %~w_len)
+  %~w_v0 = insertvalue %Value undef, i32 0, 0
+  %~w_v = insertvalue %Value %~w_v0, i64 %~w_id, 1',
+        [ArgBase, Offset,
+         ArgBase, ArgBase,
+         ArgBase, ArgBase,
+         ArgBase, PayloadOffset,
+         ArgBase, ArgBase, ArgBase,
+         ArgBase,
+         ArgBase, ArgBase, ArgBase]),
+    format(atom(ArgValueIR), '%~w_v', [ArgBase]),
+    SetupParts = [SetupIR].
 plawk_foreign_arg_ir(field(0), _FieldSeparator, ArgBase, ArgValueIR,
         [], SetupParts) :-
     !,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -17216,7 +17216,40 @@ define i1 @wam_str_eq_n(i8* %str, i64 %len, i8* %cand) {
 
 define i64 @wam_intern_atom(i8* %str, i64 %len) {
   ret i64 0
-}'
+}
+
+; Tier-2 payload marshaling: copy Len bytes into the shared transient
+; buffer (grown geometrically, NUL-terminated) and return the transient
+; atom id (2^62). Constant memory: one buffer for the process, valid
+; until the next transient write/read. At most one live payload at a
+; time -- callers pass at most one blob argument per foreign call.
+define i64 @wam_transient_atom_from_bytes(i8* %src, i64 %len) {
+entry:
+  %need = add i64 %len, 1
+  %cap = load i64, i64* @wam_transient_line_cap
+  %fits = icmp ule i64 %need, %cap
+  br i1 %fits, label %copy, label %grow
+grow:
+  %small = icmp ult i64 %need, 4096
+  %newcap = select i1 %small, i64 4096, i64 %need
+  %old = load i8*, i8** @wam_transient_line_buf
+  %newbuf = call i8* @realloc(i8* %old, i64 %newcap)
+  %newnull = icmp eq i8* %newbuf, null
+  br i1 %newnull, label %fail, label %store_new
+store_new:
+  store i8* %newbuf, i8** @wam_transient_line_buf
+  store i64 %newcap, i64* @wam_transient_line_cap
+  br label %copy
+copy:
+  %buf = load i8*, i8** @wam_transient_line_buf
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %buf, i8* %src, i64 %len, i1 false)
+  %endp = getelementptr i8, i8* %buf, i64 %len
+  store i8 0, i8* %endp
+  ret i64 4611686018427387904
+fail:
+  ret i64 -1
+}
+'
     ;  sort(Pairs0, Pairs),   % sort by id
        last(Pairs, MaxId-_),
        ArrSize is MaxId + 1,
@@ -17346,6 +17379,39 @@ get:
   ret i64 %id
 zret:
   ret i64 0
+}
+
+
+; Tier-2 payload marshaling: copy Len bytes into the shared transient
+; buffer (grown geometrically, NUL-terminated) and return the transient
+; atom id (2^62). Constant memory: one buffer for the process, valid
+; until the next transient write/read. At most one live payload at a
+; time -- callers pass at most one blob argument per foreign call.
+define i64 @wam_transient_atom_from_bytes(i8* %src, i64 %len) {
+entry:
+  %need = add i64 %len, 1
+  %cap = load i64, i64* @wam_transient_line_cap
+  %fits = icmp ule i64 %need, %cap
+  br i1 %fits, label %copy, label %grow
+grow:
+  %small = icmp ult i64 %need, 4096
+  %newcap = select i1 %small, i64 4096, i64 %need
+  %old = load i8*, i8** @wam_transient_line_buf
+  %newbuf = call i8* @realloc(i8* %old, i64 %newcap)
+  %newnull = icmp eq i8* %newbuf, null
+  br i1 %newnull, label %fail, label %store_new
+store_new:
+  store i8* %newbuf, i8** @wam_transient_line_buf
+  store i64 %newcap, i64* @wam_transient_line_cap
+  br label %copy
+copy:
+  %buf = load i8*, i8** @wam_transient_line_buf
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %buf, i8* %src, i64 %len, i1 false)
+  %endp = getelementptr i8, i8* %buf, i64 %len
+  store i8 0, i8* %endp
+  ret i64 4611686018427387904
+fail:
+  ret i64 -1
 }
 
 ; M29: case-sensitive string equality of (str, len) against a

--- a/tests/test_plawk_tier2_blob.pl
+++ b/tests/test_plawk_tier2_blob.pl
@@ -1,0 +1,252 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+% A DCG over payload bytes, written as its difference-list expansion so
+% the WAM compiler sees plain clauses: parses "12,7,100"-style
+% comma-separated decimal numbers and sums them. Backtracking between
+% plawk_digits/4's greedy and stop clauses exercises real WAM choice
+% points over the payload.
+:- dynamic user:plawk_payload_sum/2.
+:- dynamic user:plawk_payload_ok/1.
+:- dynamic user:plawk_nums/3.
+:- dynamic user:plawk_nums_rest/4.
+:- dynamic user:plawk_num/3.
+:- dynamic user:plawk_digits/4.
+:- dynamic user:plawk_digit/3.
+
+user:plawk_payload_sum(Blob, Sum) :-
+    atom_codes(Blob, Codes),
+    user:plawk_nums(Sum, Codes, []).
+
+% guard flavor: payload parses to a sum above 50
+user:plawk_payload_ok(Blob) :-
+    user:plawk_payload_sum(Blob, Sum),
+    Sum > 50.
+
+user:plawk_nums(Sum, S0, S) :-
+    user:plawk_num(N, S0, S1),
+    user:plawk_nums_rest(N, Sum, S1, S).
+
+% NOTE: the separator is matched with a variable head plus an ==/2
+% guard rather than the natural [0', | S0] head: the hybrid WAM
+% compiler currently miscompiles clause heads with a constant inside a
+% list cell (the get_list/unify_constant path never matches at
+% runtime). Known upstream bug -- see the PR notes; this formulation is
+% semantically identical.
+user:plawk_nums_rest(Acc, Sum, [C | S0], S) :-
+    C == 0',,
+    user:plawk_num(N, S0, S1),
+    Acc2 is Acc + N,
+    user:plawk_nums_rest(Acc2, Sum, S1, S).
+user:plawk_nums_rest(Sum, Sum, S, S).
+
+user:plawk_num(N, S0, S) :-
+    user:plawk_digit(D, S0, S1),
+    user:plawk_digits(D, N, S1, S).
+
+user:plawk_digits(Acc, N, S0, S) :-
+    user:plawk_digit(D, S0, S1),
+    Acc2 is Acc * 10 + D,
+    user:plawk_digits(Acc2, N, S1, S).
+user:plawk_digits(N, N, S, S).
+
+user:plawk_digit(D, [C | S], S) :-
+    C >= 48,
+    C =< 57,
+    D is C - 48.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_tier2_blob, [condition(clang_available)]).
+
+test(blob_ir_marshals_transient_atom_and_int_field) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 blob32\" } { total += plawk_payload_sum($2) ; wsum += plawk_payload_sum($2) * $1 } END { print total }\n", Program),
+    build_tier2_ir(Program, DriverIR),
+    % blob payload: length load + transient copy, marshaled as an atom Value
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_transient_atom_from_bytes('))),
+    % the payload region sits after the 8-byte length at offset 8+8
+    assertion(once(sub_atom(DriverIR, _, _, _, 'getelementptr i8, i8* %rec, i64 16'))),
+    % no interning anywhere in the record loop
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'wam_intern_atom(i8* %rec')),
+    !.
+
+test(binfmt_i64_foreign_arg_is_value_integer) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 i64\" } { total += plawk_payload_sum($1) } END { print total }\n", Program),
+    % (arg typing only: an i64 field marshals as a WAM integer)
+    build_tier2_ir(Program, DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@value_integer(i64 %'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value')),
+    !.
+
+test(tier2_rejections) :-
+    Rejects = [
+        % f64 fields are not marshalable in this slice
+        "BEGIN { BINFMT = \"f64 blob32\" } { t += plawk_payload_sum($1) } END { print t }\n",
+        % blob fields have no print/guard/arithmetic role
+        "BEGIN { BINFMT = \"i64 blob32\" } { print $2 }\n",
+        "BEGIN { BINFMT = \"i64 blob32\" } $2 == \"x\" { c++ } END { print c }\n",
+        "BEGIN { BINFMT = \"i64 blob32\" } { t += $2 } END { print t }\n",
+        % at most one blob argument per call (shared transient buffer)
+        "BEGIN { BINFMT = \"blob8 blob8\" } { t += plawk_payload_sum($1, $2) } END { print t }\n",
+        % blob is input-only
+        "BEGIN { BINFMT = \"i64 blob32\" ; OUTFMT = \"blob32\" } { writebin $2 }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ build_tier2_ir(Program, _))
+        ;  true
+        )).
+
+test(surface_blob_payload_dcg_sum) :-
+    % The record loop frames natively; the payload is parsed by the
+    % compiled Prolog DCG through the bridge. Guarded records only.
+    run_tier2_smoke("BEGIN { BINFMT = \"i64 blob32\" } $1 > 0 { total += plawk_payload_sum($2) } END { print total }\n",
+        [rec(1, "12,7"), rec(2, "100"), rec(-5, "9")],
+        "119\n").
+
+test(surface_blob_prolog_guard) :-
+    run_tier2_smoke("BEGIN { BINFMT = \"i64 blob32\" } plawk_payload_ok($2) { hits++ } END { print hits }\n",
+        [rec(1, "12,7"), rec(2, "100"), rec(3, "40,41")],
+        "2\n").
+
+test(surface_blob_with_i64_arg_mix) :-
+    % i64 field marshaled as a WAM integer alongside the payload sum.
+    run_tier2_smoke("BEGIN { BINFMT = \"i64 blob32\" } { total += plawk_payload_sum($2) * $1 } END { print total }\n",
+        [rec(2, "10"), rec(3, "5")],
+        "35\n").
+
+test(surface_blob_error_paths) :-
+    build_tier2_probe("BEGIN { BINFMT = \"i64 blob32\" } { total += plawk_payload_sum($2) } END { print total }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    % oversized payload length
+    write_raw(InputPath, [i64(1), i64(33), pad(33)]),
+    run_status(BinPath, exit(11)),
+    % truncated payload
+    write_raw(InputPath, [i64(1), i64(5), bytes("12")]),
+    run_status(BinPath, exit(11)),
+    % clean EOF runs END
+    write_raw(InputPath, []),
+    run_expect(BinPath, "0\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+tier2_preds([ user:plawk_payload_sum/2,
+              user:plawk_payload_ok/1,
+              user:plawk_nums/3,
+              user:plawk_nums_rest/4,
+              user:plawk_num/3,
+              user:plawk_digits/4,
+              user:plawk_digit/3
+            ]).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% rec(Id, PayloadString): i64 id, i64 payload length, payload bytes
+write_blob_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(Id, Payload), Recs),
+            ( write_i64_le(Out, Id),
+              string_codes(Payload, Codes),
+              length(Codes, Len),
+              write_i64_le(Out, Len),
+              forall(member(C, Codes), put_byte(Out, C)) )),
+        close(Out)).
+
+write_raw(Path, Items) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Item, Items),
+            ( Item = i64(V) -> write_i64_le(Out, V)
+            ; Item = bytes(S) -> ( string_codes(S, Cs),
+                                   forall(member(C, Cs), put_byte(Out, C)) )
+            ; Item = pad(N) -> forall(between(1, N, _), put_byte(Out, 0))
+            )),
+        close(Out)).
+
+% IR-only build (throwaway module compile for the vm counts). The
+% compile is fenced with once/1: rejection tests negate this goal, and
+% without the fence \+ would backtrack into write_wam_llvm_project's
+% internal choice points and re-run the whole compiler search.
+build_tier2_ir(Program, DriverIR) :-
+    once(( tmp_root(Root),
+           directory_file_path(Root, 'uw_plawk_tier2_blob_ir', Dir),
+           clean_dir(Dir),
+           make_directory_path(Dir),
+           directory_file_path(Dir, 'ir_probe.ll', LLPath),
+           tier2_preds(Preds),
+           write_wam_llvm_project(Preds, [module_name('plawk_tier2_ir')], LLPath),
+           wam_llvm_last_compile_counts(InstrCount, LabelCount) )),
+    plawk_program_native_driver_ir(Program, 'input.bin',
+        [wam_vm(InstrCount, LabelCount)], DriverIR).
+
+build_tier2_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_tier2_blob', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    tier2_preds(Preds),
+    write_wam_llvm_project(Preds, [module_name('plawk_tier2_blob')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_program_native_driver_ir(Program, InputPath,
+        [wam_vm(InstrCount, LabelCount)], DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk tier2 blob build output]~n~w~n", [BuildOut]),
+       throw(plawk_tier2_blob_build_failed(Status))
+    ).
+
+run_status(BinPath, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(null), stderr(std), process(Pid)]),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+run_expect(BinPath, ExpectedOutput) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == ExpectedOutput).
+
+run_tier2_smoke(Source, Recs, ExpectedOutput) :-
+    build_tier2_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_blob_records(InputPath, Recs),
+    run_expect(BinPath, ExpectedOutput),
+    !.
+
+:- end_tests(plawk_tier2_blob).


### PR DESCRIPTION
## Why

#3427 (Tier-2 blob payloads) merged into this branch rather than main. Carries it the last step; no new content. **Merge first** — the compiler-bug/harness-trap fix PR stacks on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_