### PR TITLE
wam_llvm: fix unify_constant tag bug; make write_wam_llvm_project deterministic

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -159,16 +159,16 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
 
 ## Known design debt
 
-- **WAM bug: constant-in-list clause heads never match.** A clause head
-  containing a constant inside a list cell — `p(..., [44|T], ...)` —
-  compiles (get_list/unify_constant path) but never matches at runtime;
-  the semantically identical `p(..., [C|T], ...) :- C == 44` works.
-  Found by the Tier-2 payload DCG (the first code to exercise that head
-  shape through the hybrid compiler); minimal reproducer: a predicate
-  counting leading commas of a code list returns failure on `",,,"`
-  with the constant head and 3 with the guard form. Needs a targeted
-  fix in the WAM head-compilation path; until then, write separators as
-  guards.
+- **(FIXED) WAM bug: constant-in-list clause heads never matched.**
+  `unify_constant` built its read-mode comparison value with a
+  hardcoded Atom tag (op2 was unused), so an integer constant in a
+  list/structure head — `p(..., [44|T], ...)` — compared `Atom(44)`
+  against the heap's `Integer(44)` and always failed. The fix packs
+  the tag into `op2 >> 16` (both encoders, mirroring `get_constant`)
+  and routes read mode through the general `wam_unify_value`, which
+  also closes a second hole: an unbound sub-arg used to "match"
+  without being bound; it now binds with trailing. The Tier-2 payload
+  DCG's comma clause is the standing regression test.
 
 
 - **`foreach` unrolling does not scale in code size.** The bounded-

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1166,9 +1166,18 @@ string_replace(Haystack, Needle, Replacement, Result) :-
 % PHASE 5: Hybrid Module Assembly
 % ============================================================================
 
-%% write_wam_llvm_project(+Predicates, +Options, +OutputFile)
+%% write_wam_llvm_project(+Predicates, +Options, +OutputFile) is det.
+%
 %  Generates a complete LLVM IR module for the given predicates.
+%  Deterministic by contract: the body's compilation pipeline leaves
+%  internal choice points, and a caller that backtracks into them
+%  (e.g. a test negating a goal that contains this call) re-runs the
+%  whole compiler search -- one such \+ burned 45 CPU-minutes before
+%  this fence existed.
 write_wam_llvm_project(Predicates, Options, OutputFile) :-
+    once(write_wam_llvm_project_(Predicates, Options, OutputFile)).
+
+write_wam_llvm_project_(Predicates, Options, OutputFile) :-
     option(module_name(ModuleName), Options, 'wam_generated'),
     option(target_triple(Triple), Options, 'x86_64-pc-linux-gnu'),
     option(target_datalayout(DataLayout), Options,
@@ -2988,21 +2997,25 @@ uvl.fail:
   ret i1 false').
 
 wam_llvm_case('unify_constant',
-'  ; unify_constant: op1 = constant value (packed)
-  ; Read mode: check next arg equals constant
-  ; Write mode: push constant onto heap
+'  ; unify_constant: op1 = constant value (packed), op2 = tag << 16.
+  ; The tag (0 = Atom, 1 = Integer) was historically missing: the
+  ; comparison value was always built Atom-tagged, so an integer
+  ; constant in a list/structure head (p([44|T])) compared Atom(44)
+  ; against the heap Integer(44) and never matched. Read mode now
+  ; also goes through the general unifier, so an unbound sub-arg is
+  ; BOUND to the constant (with trailing) instead of silently
+  ; "matching" while staying unbound.
   %uc.stype = call i32 @wam_peek_stack_type(%WamState* %vm)
   %uc.is_read = icmp eq i32 %uc.stype, 1
-  %uc.val = insertvalue %Value undef, i32 0, 0
+  %uc.op2_32 = trunc i64 %op2 to i32
+  %uc.tag = lshr i32 %uc.op2_32, 16
+  %uc.val = insertvalue %Value undef, i32 %uc.tag, 0
   %uc.val2 = insertvalue %Value %uc.val, i64 %op1, 1
   br i1 %uc.is_read, label %uc.read, label %uc.write
 
 uc.read:
-  ; Read mode: get expected, check equality
   %uc.expected = call %Value @wam_unify_ctx_next(%WamState* %vm)
-  %uc.eq = call i1 @value_equals(%Value %uc.expected, %Value %uc.val2)
-  %uc.exp_unb = call i1 @value_is_unbound(%Value %uc.expected)
-  %uc.ok = or i1 %uc.eq, %uc.exp_unb
+  %uc.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %uc.expected, %Value %uc.val2)
   br i1 %uc.ok, label %uc.read_ok, label %uc.fail
 
 uc.read_ok:
@@ -16961,7 +16974,7 @@ compile_wam_runtime_to_llvm(Options, LLVMCode) :-
 wam_instruction_to_llvm_literal(get_constant(C, Ai), Lit) :-
     llvm_pack_value(C, PackedVal),
     reg_name_to_index(Ai, RegIdx),
-    ( integer(C) -> Tag = 1 ; Tag = 0 ),
+    llvm_constant_tag(C, Tag),
     Op2 is (Tag << 16) \/ RegIdx,
     format(atom(Lit), '{ i32 0, i64 ~w, i64 ~w }', [PackedVal, Op2]).
 wam_instruction_to_llvm_literal(get_variable(Xn, Ai), Lit) :-
@@ -16995,7 +17008,9 @@ wam_instruction_to_llvm_literal(unify_value(Xn), Lit) :-
     format(atom(Lit), '{ i32 6, i64 ~w, i64 0 }', [XnIdx]).
 wam_instruction_to_llvm_literal(unify_constant(C), Lit) :-
     llvm_pack_value(C, PackedVal),
-    format(atom(Lit), '{ i32 7, i64 ~w, i64 0 }', [PackedVal]).
+    llvm_constant_tag(C, Tag),
+    Op2 is Tag << 16,
+    format(atom(Lit), '{ i32 7, i64 ~w, i64 ~w }', [PackedVal, Op2]).
 
 wam_instruction_to_llvm_literal(put_constant(C, Ai), Lit) :-
     llvm_pack_value(C, PackedVal),
@@ -18823,6 +18838,14 @@ target_struct_tm_gmtoff_offset(_, 40).
 
 % --- Value packing helpers ---
 
+% %Value tag for a head constant: integers (raw or integer/1-wrapped)
+% are tag 1, everything else interns as an atom (tag 0). get_constant
+% and unify_constant share this so integer constants in heads compare
+% against heap Integers, not same-payload Atoms.
+llvm_constant_tag(C, 1) :- integer(C), !.
+llvm_constant_tag(integer(_), 1) :- !.
+llvm_constant_tag(_, 0).
+
 llvm_pack_value(atom(A0), Packed) :- !,
     llvm_normalize_atom_token(A0, A),
     intern_atom(A, Packed).
@@ -19523,7 +19546,9 @@ wam_line_to_llvm_literal(["unify_value", Xn], Lit) :-
 wam_line_to_llvm_literal(["unify_constant", C], Lit) :-
     clean_comma(C, CC),
     llvm_pack_value_str(CC, PackedVal),
-    format(atom(Lit), '%Instruction { i32 7, i64 ~w, i64 0 }', [PackedVal]).
+    ( number_string(_, CC) -> Tag = 1 ; Tag = 0 ),
+    Op2 is Tag << 16,
+    format(atom(Lit), '%Instruction { i32 7, i64 ~w, i64 ~w }', [PackedVal, Op2]).
 
 wam_line_to_llvm_literal(["put_constant", C, Ai], Lit) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),

--- a/tests/test_plawk_tier2_blob.pl
+++ b/tests/test_plawk_tier2_blob.pl
@@ -36,14 +36,11 @@ user:plawk_nums(Sum, S0, S) :-
     user:plawk_num(N, S0, S1),
     user:plawk_nums_rest(N, Sum, S1, S).
 
-% NOTE: the separator is matched with a variable head plus an ==/2
-% guard rather than the natural [0', | S0] head: the hybrid WAM
-% compiler currently miscompiles clause heads with a constant inside a
-% list cell (the get_list/unify_constant path never matches at
-% runtime). Known upstream bug -- see the PR notes; this formulation is
-% semantically identical.
-user:plawk_nums_rest(Acc, Sum, [C | S0], S) :-
-    C == 0',,
+% The natural constant-in-list head. This shape is ALSO the regression
+% test for the unify_constant tag bug: the instruction used to build
+% its comparison value Atom-tagged, so Integer(44) on the heap never
+% matched and every comma-separated payload summed to failure.
+user:plawk_nums_rest(Acc, Sum, [0', | S0], S) :-
     user:plawk_num(N, S0, S1),
     Acc2 is Acc + N,
     user:plawk_nums_rest(Acc2, Sum, S1, S).
@@ -108,6 +105,21 @@ test(tier2_rejections) :-
         -> assertion(\+ build_tier2_ir(Program, _))
         ;  true
         )).
+
+test(compile_is_deterministic) :-
+    % write_wam_llvm_project is det by contract: a caller backtracking
+    % into it (e.g. \+ over a goal containing the compile) must not
+    % re-run the compiler search.
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_tier2_det', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'det.ll', LLPath),
+    tier2_preds(Preds),
+    write_wam_llvm_project(Preds, [module_name('plawk_tier2_det')], LLPath),
+    deterministic(Det),
+    assertion(Det == true),
+    !.
 
 test(surface_blob_payload_dcg_sum) :-
     % The record loop frames natively; the payload is parsed by the
@@ -182,9 +194,8 @@ write_raw(Path, Items) :-
         close(Out)).
 
 % IR-only build (throwaway module compile for the vm counts). The
-% compile is fenced with once/1: rejection tests negate this goal, and
-% without the fence \+ would backtrack into write_wam_llvm_project's
-% internal choice points and re-run the whole compiler search.
+% once/1 fence predates write_wam_llvm_project being made det; kept as
+% belt and braces for the rest of the conjunction.
 build_tier2_ir(Program, DriverIR) :-
     once(( tmp_root(Root),
            directory_file_path(Root, 'uw_plawk_tier2_blob_ir', Dir),


### PR DESCRIPTION
## Summary

The two issues the Tier-2 slice flushed out, both fixed at the root.

### 1. The compiler bug: `unify_constant` had no tag

The instruction encoded its constant into `op1` and emitted `op2 = 0` — which the runtime never read, hardcoding the comparison value's tag to **Atom**. So an integer constant in a list or structure head — `p(..., [44|T], ...)` — compared `Atom(44)` against the heap's `Integer(44)` and failed on every record. Its sibling `get_constant` had the tag channel (`op2 >> 16`) all along; `unify_constant` just never got it.

**Fix**: both encoders (structured and textual bytecode paths) now pack the constant's `%Value` tag into `op2 >> 16`, through a shared `llvm_constant_tag/2` that also covers the `integer/1`-wrapped constant form `get_constant` previously misclassified. The runtime case extracts the tag and routes read mode through the general `@wam_unify_value` — which closes a **second soundness hole** discovered while fixing the first: an unbound sub-arg used to "match" the constant while silently staying unbound; it now binds with proper trailing, like every other unification site. Old bytecode (`op2 = 0`) keeps its old atom-tagged behavior, so nothing regresses.

**Regression coverage**: the Tier-2 payload DCG reverts from its `==/2`-guard workaround to the natural `[0', | S0]` constant head — every comma-payload test now exercises the fixed path end-to-end (verified: the standalone reproducer that returned failure on `",,,"` now counts 3).

### 2. The harness trap: nondeterministic compiles

`write_wam_llvm_project/3` succeeded but left internal choice points, so any caller that backtracked into it — like a test asserting `\+ build(...)` — re-ran the compiler's whole search space (one such negation burned 45 CPU-minutes). It is now **det by contract**: a `once/1` fence over the renamed `write_wam_llvm_project_/3` body. Verified with `deterministic/1` and by timing the exact negation shape that used to hang: 0.07s. A `compile_is_deterministic` test pins the contract.

The design doc's *Known design debt* entry for the head bug is marked FIXED with the mechanism; the `foreach` scaling note remains as the open item.

## Tests

Tier-2 suite grows to 8 tests (natural-head DCG + determinism check). Full regression sweep green: all 31 suites exit 0.

## Merge order

Stacked on #3428 (Tier-2 consolidation). **Merge #3428 into main first, then this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_