### PR TITLE
plawk/wam_llvm: bring #3429 (WAM fixes) + #3431 (foreach loop) to main

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -159,16 +159,16 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
 
 ## Known design debt
 
-- **WAM bug: constant-in-list clause heads never match.** A clause head
-  containing a constant inside a list cell — `p(..., [44|T], ...)` —
-  compiles (get_list/unify_constant path) but never matches at runtime;
-  the semantically identical `p(..., [C|T], ...) :- C == 44` works.
-  Found by the Tier-2 payload DCG (the first code to exercise that head
-  shape through the hybrid compiler); minimal reproducer: a predicate
-  counting leading commas of a code list returns failure on `",,,"`
-  with the constant head and 3 with the guard form. Needs a targeted
-  fix in the WAM head-compilation path; until then, write separators as
-  guards.
+- **(FIXED) WAM bug: constant-in-list clause heads never matched.**
+  `unify_constant` built its read-mode comparison value with a
+  hardcoded Atom tag (op2 was unused), so an integer constant in a
+  list/structure head — `p(..., [44|T], ...)` — compared `Atom(44)`
+  against the heap's `Integer(44)` and always failed. The fix packs
+  the tag into `op2 >> 16` (both encoders, mirroring `get_constant`)
+  and routes read mode through the general `wam_unify_value`, which
+  also closes a second hole: an unbound sub-arg used to "match"
+  without being bound; it now binds with trailing. The Tier-2 payload
+  DCG's comma clause is the standing regression test.
 
 
 - **`foreach` unrolling does not scale in code size.** The bounded-

--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -171,17 +171,19 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
   DCG's comma clause is the standing regression test.
 
 
-- **`foreach` unrolling does not scale in code size.** The bounded-
-  repetition surface unrolls its block Cap times (each copy guarded by
-  `count >= j`), which is ideal for small caps (4–8: straight-line,
-  branch-predictable, zero new phi machinery) but emits O(Cap × body)
-  IR — `rep1000` would be absurd. The fix is a real runtime loop:
-  an induction variable, loop-carried phis for the scalar slots, and
-  element addresses computed as `base + j*elemsize` instead of
-  constants. That is the one genuinely new piece of IR machinery the
-  emitter stack lacks (everything today is straight-line plus joins).
-  Plan: emit the loop above a small cap threshold and keep unrolling
-  as the small-cap optimization.
+- **(FIXED) `foreach` unrolling did not scale in code size.** The
+  original surface unrolled its block Cap times — O(Cap × body) IR.
+  It is now a real runtime loop, the one loop in the emitter stack:
+  an index phi, one loop-carried phi per scalar slot (typed i64 or
+  double), and a per-iteration `memcpy` of the current element into a
+  hidden staging group appended to the record buffer — so the body's
+  field accesses remain compile-time offsets and every existing
+  emitter (updates, doubles, prints, inner if/else, next/break) works
+  unchanged inside the loop. Code size is O(body) at any cap
+  (regression test: `rep64` emits one increment site), user-visible
+  field numbering and `NF` are untouched, and exit values are the
+  head phis themselves. The staging copy costs one small memcpy per
+  element — noise next to the per-element work itself.
 
 ## Why not a real DCG engine in the loop?
 

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -299,10 +299,12 @@ list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an
 ordinary i64 field, element slots are flat addressable fields
 (zero-filled past the count), and `foreach { ... }` runs its block once
-per element with `$1..$M` meaning the current element's fields - it
-unrolls at compile time into count-guarded ifs, so the loop machinery
-is the existing if/join emitters and the wire read is one bulk
-count*elemsize read. Oversized counts and truncated element regions
+per element with `$1..$M` meaning the current element's fields - a
+real runtime loop (loop-carried phis per scalar slot; the current
+element is staged into a hidden slot at the end of the record buffer
+so field accesses stay compile-time offsets), so code size is
+independent of the cap and rep64 costs the same IR as rep4. The wire
+read is one bulk count*elemsize read. Oversized counts and truncated element regions
 exit with the read-error code. Tagged unions let one stream carry several
 record kinds: `BINFMT = "case(i64 f64 | lps16 i64)"` declares that
 every record starts with an 8-byte tag selecting an arm layout, and

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -625,10 +625,11 @@ $1 > 0 { foreach { n++ ; wsum += float($2) } }
 END { print n, wsum }
 ```
 
-Because the cap (4) is known at compile time, the compiler does not
-emit a loop at all — it writes the block out 4 times, each copy
-guarded by "does the record have at least j elements?". Constant
-memory, straight-line native code, same as everything else.
+The compiler emits a genuine native loop: each iteration copies the
+current element into a fixed scratch slot and runs the block over it,
+carrying your counters around the loop in registers. Constant memory,
+and the code size does not depend on the cap — `rep64` compiles to
+the same loop as `rep4`.
 
 ### Handing payloads to Prolog
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -957,6 +957,8 @@ plawk_action_has_control(if(_Pattern, ThenActions, ElseActions)) :-
     ( plawk_branch_actions_have_unsupported_control(ThenActions)
     ; plawk_branch_actions_have_unsupported_control(ElseActions)
     ).
+plawk_action_has_control(foreach_loop(_Layout, Body)) :-
+    plawk_branch_actions_have_unsupported_control(Body).
 
 plawk_branch_actions_have_unsupported_control(Actions) :-
     plawk_trim_control_tails(Actions, TrimmedActions),
@@ -1118,6 +1120,9 @@ plawk_scalar_update_name_expr(if(_Pattern, ThenActions, ElseActions), Name, Expr
     ; member(Action, ElseActions)
     ),
     plawk_scalar_update_name_expr(Action, Name, Expr).
+plawk_scalar_update_name_expr(foreach_loop(_Layout, Body), Name, Expr) :-
+    member(Action, Body),
+    plawk_scalar_update_name_expr(Action, Name, Expr).
 
 plawk_scalar_double_fixpoint(Updates, Doubles0, Doubles) :-
     findall(Name,
@@ -1243,6 +1248,8 @@ plawk_action_body_print_field(if(_Pattern, ThenActions, ElseActions), Field) :-
     (   plawk_actions_body_print_field(ThenActions, Field)
     ;   plawk_actions_body_print_field(ElseActions, Field)
     ).
+plawk_action_body_print_field(foreach_loop(_Layout, Body), Field) :-
+    plawk_actions_body_print_field(Body, Field).
 
 plawk_mixed_planned_rules([], _AssocPlan, _Index) -->
     [].
@@ -1780,6 +1787,9 @@ plawk_binfmt_action_ok(Descriptor, if(Pattern, ThenActions, ElseActions)) :-
 plawk_binfmt_action_ok(Descriptor, writebin_out(Types, Fields)) :-
     !,
     plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+plawk_binfmt_action_ok(Descriptor, foreach_loop(_Layout, Body)) :-
+    !,
+    plawk_binfmt_actions_ok(Descriptor, Body).
 
 plawk_binfmt_writebin_args_ok(_Descriptor, [], []).
 plawk_binfmt_writebin_args_ok(Descriptor, [i64 | Types], [Field | Fields]) :-
@@ -2074,18 +2084,31 @@ plawk_binfmt_access_type(Type, Type).
 %  Expand stored types into the flat per-field access list: a
 %  rep(K, Elems) contributes its i64 count field followed by K copies
 %  of the element fields; everything else is one field.
-plawk_binfmt_access_types([], []).
-plawk_binfmt_access_types([rep(Cap, ElemTypes) | Rest], AccessTypes) :-
+plawk_binfmt_access_types(Types, AccessTypes) :-
+    plawk_binfmt_declared_access_types(Types, Declared),
+    % A rep layout appends one hidden staging element group at the very
+    % end of the record buffer: the foreach runtime loop memcpys the
+    % current element there so the body's field accesses stay
+    % compile-time offsets. Appending after all declared fields keeps
+    % user-visible numbering and offsets unchanged.
+    ( memberchk(rep(_Cap, ElemTypes), Types)
+    ->  maplist(plawk_binfmt_access_type, ElemTypes, StageAccess),
+        append(Declared, StageAccess, AccessTypes)
+    ;   AccessTypes = Declared
+    ).
+
+plawk_binfmt_declared_access_types([], []).
+plawk_binfmt_declared_access_types([rep(Cap, ElemTypes) | Rest], AccessTypes) :-
     !,
     maplist(plawk_binfmt_access_type, ElemTypes, ElemAccess),
     findall(ElemField,
         ( between(1, Cap, _), member(ElemField, ElemAccess) ),
         Repeated),
-    plawk_binfmt_access_types(Rest, RestAccess),
+    plawk_binfmt_declared_access_types(Rest, RestAccess),
     append([i64 | Repeated], RestAccess, AccessTypes).
-plawk_binfmt_access_types([StoredType | Rest], [Type | RestAccess]) :-
+plawk_binfmt_declared_access_types([StoredType | Rest], [Type | RestAccess]) :-
     plawk_binfmt_access_type(StoredType, Type),
-    plawk_binfmt_access_types(Rest, RestAccess).
+    plawk_binfmt_declared_access_types(Rest, RestAccess).
 
 plawk_binfmt_type_width(i64, 8).
 plawk_binfmt_type_width(f64, 8).
@@ -2563,11 +2586,30 @@ plawk_rule_descriptor(_Pattern, Default, Default).
 plawk_resolve_foreach_rules(Descriptor, Rules0, Rules) :-
     ( plawk_rules_have_foreach(Rules0)
     ->  Descriptor = binfmt(Types),
-        plawk_binfmt_rep_info(Types, CountIndex, Cap, ElemArity),
-        maplist(plawk_resolve_foreach_rule(CountIndex, Cap, ElemArity),
-            Rules0, Rules)
+        plawk_binfmt_rep_info(Types, CountIndex, _Cap, ElemArity),
+        plawk_binfmt_foreach_layout(Types, CountIndex, ElemArity, Layout),
+        maplist(plawk_resolve_foreach_rule(Layout, ElemArity), Rules0, Rules)
     ;   Rules = Rules0
     ).
+
+%% plawk_binfmt_foreach_layout(+Types, +CountIndex, +ElemArity, -Layout)
+%
+%  Byte/field geometry the runtime loop needs: the count field's byte
+%  offset, the first element's byte offset, the element size, the
+%  staging area's byte offset (end of the declared layout), and the
+%  access index of the first staging field minus one (the shift base
+%  for body field references).
+plawk_binfmt_foreach_layout(Types, CountIndex, _ElemArity,
+        foreach_layout(CountOff, ElemsOff, ElemSize, StageOff, StageBase)) :-
+    plawk_binfmt_field_offset(binfmt(Types), CountIndex, CountOff),
+    ElemsOff is CountOff + 8,
+    memberchk(rep(_Cap, ElemTypes), Types),
+    maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
+    sum_list(ElemWidths, ElemSize),
+    plawk_binfmt_declared_access_types(Types, Declared),
+    length(Declared, StageBase),
+    maplist(plawk_binfmt_type_width, Declared, DeclaredWidths),
+    sum_list(DeclaredWidths, StageOff).
 
 plawk_rules_have_foreach(Rules) :-
     member(rule(_Pattern, Actions), Rules),
@@ -2596,34 +2638,33 @@ plawk_binfmt_rep_info(Types, CountIndex, Cap, ElemArity) :-
     length(PrefixAccess, PrefixCount),
     CountIndex is PrefixCount + 1.
 
-plawk_resolve_foreach_rule(CountIndex, Cap, ElemArity,
+plawk_resolve_foreach_rule(Layout, ElemArity,
         rule(Pattern, Actions0), rule(Pattern, Actions)) :-
-    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity,
-        Actions0, Actions).
+    plawk_resolve_foreach_actions(Layout, ElemArity, Actions0, Actions).
 
-plawk_resolve_foreach_actions(_CountIndex, _Cap, _ElemArity, [], []).
-plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity,
-        [foreach(Body) | Rest0], Actions) :-
+% foreach { Body } becomes one foreach_loop/2 term: a RUNTIME loop over
+% the elements (code size O(body), any cap), whose body reads the
+% current element from the fixed staging area -- field references are
+% shifted once to the staging indexes, so every existing field emitter
+% works unchanged.
+plawk_resolve_foreach_actions(_Layout, _ElemArity, [], []).
+plawk_resolve_foreach_actions(Layout, ElemArity,
+        [foreach(Body) | Rest0], [foreach_loop(Layout, ShiftedBody) | Rest]) :-
     !,
     \+ plawk_actions_have_foreach(Body),
     plawk_foreach_body_fields_ok(Body, ElemArity),
-    findall(if(field_cmp(CountIndex, ge, ElemIndex), ShiftedBody, []),
-        ( between(1, Cap, ElemIndex),
-          Base is CountIndex + (ElemIndex - 1) * ElemArity,
-          plawk_foreach_shift_actions(Body, Base, ShiftedBody)
-        ),
-        Unrolled),
-    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity, Rest0, Rest),
-    append(Unrolled, Rest, Actions).
-plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity,
+    Layout = foreach_layout(_CountOff, _ElemsOff, _ElemSize, _StageOff, StageBase),
+    plawk_foreach_shift_actions(Body, StageBase, ShiftedBody),
+    plawk_resolve_foreach_actions(Layout, ElemArity, Rest0, Rest).
+plawk_resolve_foreach_actions(Layout, ElemArity,
         [if(Pattern, Then0, Else0) | Rest0], [if(Pattern, Then, Else) | Rest]) :-
     !,
-    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity, Then0, Then),
-    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity, Else0, Else),
-    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity, Rest0, Rest).
-plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity,
+    plawk_resolve_foreach_actions(Layout, ElemArity, Then0, Then),
+    plawk_resolve_foreach_actions(Layout, ElemArity, Else0, Else),
+    plawk_resolve_foreach_actions(Layout, ElemArity, Rest0, Rest).
+plawk_resolve_foreach_actions(Layout, ElemArity,
         [Action | Rest0], [Action | Rest]) :-
-    plawk_resolve_foreach_actions(CountIndex, Cap, ElemArity, Rest0, Rest).
+    plawk_resolve_foreach_actions(Layout, ElemArity, Rest0, Rest).
 
 plawk_foreach_body_fields_ok(Body, ElemArity) :-
     forall(( sub_term(Sub, Body),
@@ -3445,6 +3486,8 @@ plawk_scalar_rule_body_action(Action) :-
     plawk_rule_body_print_action(Action).
 plawk_scalar_rule_body_action(writebin_out(Types, Fields)) :-
     plawk_writebin_args_ok(Types, Fields).
+plawk_scalar_rule_body_action(foreach_loop(_Layout, Body)) :-
+    plawk_scalar_branch_body_actions(Body).
 plawk_scalar_rule_body_action(if(_Pattern, ThenActions, ElseActions)) :-
     append(ThenActions, ElseActions, Actions),
     Actions \== [],
@@ -3666,6 +3709,9 @@ plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
     ; member(Action, ElseActions)
     ),
     plawk_scalar_update_action_name(Action, Name).
+plawk_scalar_update_action_name(foreach_loop(_Layout, Body), Name) :-
+    member(Action, Body),
+    plawk_scalar_update_action_name(Action, Name).
 
 plawk_expr_scalar_read_name(var(Name), Name).
 plawk_expr_scalar_read_name(Expr, Name) :-
@@ -3805,6 +3851,98 @@ plawk_scalar_action_sequence_pairs([next], _Slots, _AssocPlan, _FieldSeparator, 
 plawk_scalar_action_sequence_pairs([break], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, break, [branch_break(CurrentLabel, Values)]) -->
     [].
+% foreach_loop: the one loop in the emitter stack. Loop-carried phis
+% for the element index and every scalar slot; the body memcpys the
+% current element into the staging area and runs one copy of the
+% actions (inner ifs, prints, updates, next/break all reuse the
+% existing machinery). Exit values are the head phis themselves.
+plawk_scalar_action_sequence_pairs([foreach_loop(Layout, Body) | Rest],
+        Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { Layout = foreach_layout(CountOff, ElemsOff, ElemSize, StageOff, _StageBase),
+      format(atom(FeBase), '~w_fe_~w', [Prefix, OpIndex]),
+      format(atom(EntryLabel), '~w_entry', [FeBase]),
+      format(atom(HeadLabel), '~w_head', [FeBase]),
+      format(atom(BodyLabel), '~w_body', [FeBase]),
+      format(atom(BodyDoneLabel), '~w_body_done', [FeBase]),
+      format(atom(AfterLabel), '~w_after', [FeBase]),
+      % head phi names double as the slot values inside and after the loop
+      findall(PhiValue,
+          ( nth0(SlotIndex, Slots, _Slot),
+            format(atom(PhiValue), '%~w_slot_~w', [FeBase, SlotIndex])
+          ),
+          HeadValues),
+      phrase(plawk_scalar_action_sequence_pairs(Body, Slots, AssocPlan,
+          FieldSeparator, OutputSeparator, FeBase, BodyLabel, RuleIndex, 0,
+          HeadValues, BodyOutValues, _InnerOpIndex, InnerExitLabel,
+          InnerNextExits), BodyPairs),
+      pairs_keys_values(BodyPairs, BodyGlobalParts, BodyLineParts),
+      atomic_list_concat(BodyGlobalParts, '\n', GlobalIR),
+      atomic_list_concat(BodyLineParts, '\n', BodyIR),
+      plawk_branch_to_done_ir(InnerExitLabel, BodyDoneLabel, BodyDoneBrIR),
+      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BodyOutValues,
+          FeBase, EntryLabel, BodyDoneLabel, 0), HeadPhiLines),
+      atomic_list_concat(HeadPhiLines, '\n', HeadPhiIR),
+      format(atom(IR),
+'  br label %~w
+
+~w:
+  %~w_count_p = getelementptr i8, i8* %rec, i64 ~w
+  %~w_count_tp = bitcast i8* %~w_count_p to i64*
+  %~w_count = load i64, i64* %~w_count_tp
+  br label %~w
+
+~w:
+  %~w_j = phi i64 [1, %~w], [%~w_j_next, %~w]
+~w
+  %~w_cont = icmp sle i64 %~w_j, %~w_count
+  br i1 %~w_cont, label %~w, label %~w
+
+~w:
+  %~w_jm1 = add i64 %~w_j, -1
+  %~w_rel = mul i64 %~w_jm1, ~w
+  %~w_off = add i64 %~w_rel, ~w
+  %~w_src = getelementptr i8, i8* %rec, i64 %~w_off
+  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %~w_dst, i8* %~w_src, i64 ~w, i1 false)
+~w
+~w
+
+~w:
+  %~w_j_next = add i64 %~w_j, 1
+  br label %~w
+
+~w:',
+          [EntryLabel,
+           EntryLabel,
+           FeBase, CountOff,
+           FeBase, FeBase,
+           FeBase, FeBase,
+           HeadLabel,
+           HeadLabel,
+           FeBase, EntryLabel, FeBase, BodyDoneLabel,
+           HeadPhiIR,
+           FeBase, FeBase, FeBase,
+           FeBase, BodyLabel, AfterLabel,
+           BodyLabel,
+           FeBase, FeBase,
+           FeBase, FeBase, ElemSize,
+           FeBase, FeBase, ElemsOff,
+           FeBase, FeBase,
+           FeBase, StageOff,
+           FeBase, FeBase, ElemSize,
+           BodyIR,
+           BodyDoneBrIR,
+           BodyDoneLabel,
+           FeBase, FeBase,
+           HeadLabel,
+           AfterLabel]),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
+        NextOpIndex, HeadValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
+    { append(InnerNextExits, RestNextExits, NextExits) }.
 plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest],
         Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex, OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
     { format(atom(GlobalBase), '~w_if_~w', [Prefix, OpIndex]),
@@ -4284,6 +4422,24 @@ plawk_scalar_if_phi_lines([ThenValue | ThenRest], [ElseValue | ElseRest],
     },
     [PhiValue-Line],
     plawk_scalar_if_phi_lines(ThenRest, ElseRest, Slots, Prefix, OpIndex, ThenLabel, ElseLabel, NextSlotIndex).
+
+%% plawk_foreach_head_phi_lines(+Slots, +InValues, +OutValues, +FeBase,
+%%     +EntryLabel, +BodyDoneLabel, +Index)//
+%
+%  One loop-carried phi per scalar slot, typed by the slot.
+plawk_foreach_head_phi_lines([], [], [], _FeBase, _EntryLabel, _DoneLabel, _) -->
+    [].
+plawk_foreach_head_phi_lines([Slot | Slots], [InValue | InValues],
+        [OutValue | OutValues], FeBase, EntryLabel, DoneLabel, Index) -->
+    { plawk_slot_llvm_type(Slot, Type),
+      format(atom(Line),
+          '  %~w_slot_~w = phi ~w [~w, %~w], [~w, %~w]',
+          [FeBase, Index, Type, InValue, EntryLabel, OutValue, DoneLabel]),
+      NextIndex is Index + 1
+    },
+    [Line],
+    plawk_foreach_head_phi_lines(Slots, InValues, OutValues, FeBase,
+        EntryLabel, DoneLabel, NextIndex).
 
 replace_nth0(0, [_Old | Rest], Value, [Value | Rest]) :-
     !.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1166,9 +1166,18 @@ string_replace(Haystack, Needle, Replacement, Result) :-
 % PHASE 5: Hybrid Module Assembly
 % ============================================================================
 
-%% write_wam_llvm_project(+Predicates, +Options, +OutputFile)
+%% write_wam_llvm_project(+Predicates, +Options, +OutputFile) is det.
+%
 %  Generates a complete LLVM IR module for the given predicates.
+%  Deterministic by contract: the body's compilation pipeline leaves
+%  internal choice points, and a caller that backtracks into them
+%  (e.g. a test negating a goal that contains this call) re-runs the
+%  whole compiler search -- one such \+ burned 45 CPU-minutes before
+%  this fence existed.
 write_wam_llvm_project(Predicates, Options, OutputFile) :-
+    once(write_wam_llvm_project_(Predicates, Options, OutputFile)).
+
+write_wam_llvm_project_(Predicates, Options, OutputFile) :-
     option(module_name(ModuleName), Options, 'wam_generated'),
     option(target_triple(Triple), Options, 'x86_64-pc-linux-gnu'),
     option(target_datalayout(DataLayout), Options,
@@ -2988,21 +2997,25 @@ uvl.fail:
   ret i1 false').
 
 wam_llvm_case('unify_constant',
-'  ; unify_constant: op1 = constant value (packed)
-  ; Read mode: check next arg equals constant
-  ; Write mode: push constant onto heap
+'  ; unify_constant: op1 = constant value (packed), op2 = tag << 16.
+  ; The tag (0 = Atom, 1 = Integer) was historically missing: the
+  ; comparison value was always built Atom-tagged, so an integer
+  ; constant in a list/structure head (p([44|T])) compared Atom(44)
+  ; against the heap Integer(44) and never matched. Read mode now
+  ; also goes through the general unifier, so an unbound sub-arg is
+  ; BOUND to the constant (with trailing) instead of silently
+  ; "matching" while staying unbound.
   %uc.stype = call i32 @wam_peek_stack_type(%WamState* %vm)
   %uc.is_read = icmp eq i32 %uc.stype, 1
-  %uc.val = insertvalue %Value undef, i32 0, 0
+  %uc.op2_32 = trunc i64 %op2 to i32
+  %uc.tag = lshr i32 %uc.op2_32, 16
+  %uc.val = insertvalue %Value undef, i32 %uc.tag, 0
   %uc.val2 = insertvalue %Value %uc.val, i64 %op1, 1
   br i1 %uc.is_read, label %uc.read, label %uc.write
 
 uc.read:
-  ; Read mode: get expected, check equality
   %uc.expected = call %Value @wam_unify_ctx_next(%WamState* %vm)
-  %uc.eq = call i1 @value_equals(%Value %uc.expected, %Value %uc.val2)
-  %uc.exp_unb = call i1 @value_is_unbound(%Value %uc.expected)
-  %uc.ok = or i1 %uc.eq, %uc.exp_unb
+  %uc.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %uc.expected, %Value %uc.val2)
   br i1 %uc.ok, label %uc.read_ok, label %uc.fail
 
 uc.read_ok:
@@ -16961,7 +16974,7 @@ compile_wam_runtime_to_llvm(Options, LLVMCode) :-
 wam_instruction_to_llvm_literal(get_constant(C, Ai), Lit) :-
     llvm_pack_value(C, PackedVal),
     reg_name_to_index(Ai, RegIdx),
-    ( integer(C) -> Tag = 1 ; Tag = 0 ),
+    llvm_constant_tag(C, Tag),
     Op2 is (Tag << 16) \/ RegIdx,
     format(atom(Lit), '{ i32 0, i64 ~w, i64 ~w }', [PackedVal, Op2]).
 wam_instruction_to_llvm_literal(get_variable(Xn, Ai), Lit) :-
@@ -16995,7 +17008,9 @@ wam_instruction_to_llvm_literal(unify_value(Xn), Lit) :-
     format(atom(Lit), '{ i32 6, i64 ~w, i64 0 }', [XnIdx]).
 wam_instruction_to_llvm_literal(unify_constant(C), Lit) :-
     llvm_pack_value(C, PackedVal),
-    format(atom(Lit), '{ i32 7, i64 ~w, i64 0 }', [PackedVal]).
+    llvm_constant_tag(C, Tag),
+    Op2 is Tag << 16,
+    format(atom(Lit), '{ i32 7, i64 ~w, i64 ~w }', [PackedVal, Op2]).
 
 wam_instruction_to_llvm_literal(put_constant(C, Ai), Lit) :-
     llvm_pack_value(C, PackedVal),
@@ -18823,6 +18838,14 @@ target_struct_tm_gmtoff_offset(_, 40).
 
 % --- Value packing helpers ---
 
+% %Value tag for a head constant: integers (raw or integer/1-wrapped)
+% are tag 1, everything else interns as an atom (tag 0). get_constant
+% and unify_constant share this so integer constants in heads compare
+% against heap Integers, not same-payload Atoms.
+llvm_constant_tag(C, 1) :- integer(C), !.
+llvm_constant_tag(integer(_), 1) :- !.
+llvm_constant_tag(_, 0).
+
 llvm_pack_value(atom(A0), Packed) :- !,
     llvm_normalize_atom_token(A0, A),
     intern_atom(A, Packed).
@@ -19523,7 +19546,9 @@ wam_line_to_llvm_literal(["unify_value", Xn], Lit) :-
 wam_line_to_llvm_literal(["unify_constant", C], Lit) :-
     clean_comma(C, CC),
     llvm_pack_value_str(CC, PackedVal),
-    format(atom(Lit), '%Instruction { i32 7, i64 ~w, i64 0 }', [PackedVal]).
+    ( number_string(_, CC) -> Tag = 1 ; Tag = 0 ),
+    Op2 is Tag << 16,
+    format(atom(Lit), '%Instruction { i32 7, i64 ~w, i64 ~w }', [PackedVal, Op2]).
 
 wam_line_to_llvm_literal(["put_constant", C, Ai], Lit) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),

--- a/tests/test_plawk_bounded_rep.pl
+++ b/tests/test_plawk_bounded_rep.pl
@@ -29,15 +29,19 @@ test(parses_foreach_action) :-
 test(rep_ir_reads_count_then_bulk_elements) :-
     plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(i64 f64)\" } { foreach { n++ } } END { print n }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
-    % buffer: 8 (id) + 8 (count) + 4*16 (elems) = 80
-    assertion(once(sub_atom(DriverIR, _, _, _, 'malloc(i64 80)'))),
+    % buffer: 8 (id) + 8 (count) + 4*16 (elems) + 16 (staging) = 96
+    assertion(once(sub_atom(DriverIR, _, _, _, 'malloc(i64 96)'))),
     % count read into its record slot, bounded by the cap
     assertion(once(sub_atom(DriverIR, _, _, _, '%vr_f1_fits = icmp ule i64 %vr_f1_n, 4'))),
     % one memset of the element region + one bulk read of count*16 bytes
     assertion(once(sub_atom(DriverIR, _, _, _, 'i8 0, i64 64, i1 false'))),
     assertion(once(sub_atom(DriverIR, _, _, _, 'mul i64 %vr_f1_n, 16'))),
-    % foreach unrolled into count-guarded ifs on the count field ($2)
-    assertion(once(sub_atom(DriverIR, _, _, _, 'icmp sge i64 %'))),
+    % foreach is a RUNTIME loop: index phi, per-iteration staging
+    % memcpy, back edge -- one body copy regardless of cap
+    assertion(once(sub_atom(DriverIR, _, _, _, '_j = phi i64 [1, %'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_cont = icmp sle i64 '))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_dst, i8* %rule_0_body_fe_0_src, i64 16'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'icmp sge i64 %')),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
@@ -61,6 +65,15 @@ test(rep_rejections) :-
         -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
         ;  true
         )).
+
+test(foreach_code_size_is_cap_independent) :-
+    % The scaling property: rep64 emits the same single loop body as
+    % rep4 -- one increment site, not 64.
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep64(i64 f64)\" } { foreach { n++ } } END { print n }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    findall(B, sub_atom(DriverIR, B, _, _, '_slot_0_op_0 = add i64 '), IncSites),
+    assertion(IncSites = [_]),
+    !.
 
 test(surface_foreach_aggregation) :-
     % 4 records with 2, 0, 4, and 1 elements; the guarded record ($1>0)

--- a/tests/test_plawk_tier2_blob.pl
+++ b/tests/test_plawk_tier2_blob.pl
@@ -36,14 +36,11 @@ user:plawk_nums(Sum, S0, S) :-
     user:plawk_num(N, S0, S1),
     user:plawk_nums_rest(N, Sum, S1, S).
 
-% NOTE: the separator is matched with a variable head plus an ==/2
-% guard rather than the natural [0', | S0] head: the hybrid WAM
-% compiler currently miscompiles clause heads with a constant inside a
-% list cell (the get_list/unify_constant path never matches at
-% runtime). Known upstream bug -- see the PR notes; this formulation is
-% semantically identical.
-user:plawk_nums_rest(Acc, Sum, [C | S0], S) :-
-    C == 0',,
+% The natural constant-in-list head. This shape is ALSO the regression
+% test for the unify_constant tag bug: the instruction used to build
+% its comparison value Atom-tagged, so Integer(44) on the heap never
+% matched and every comma-separated payload summed to failure.
+user:plawk_nums_rest(Acc, Sum, [0', | S0], S) :-
     user:plawk_num(N, S0, S1),
     Acc2 is Acc + N,
     user:plawk_nums_rest(Acc2, Sum, S1, S).
@@ -108,6 +105,21 @@ test(tier2_rejections) :-
         -> assertion(\+ build_tier2_ir(Program, _))
         ;  true
         )).
+
+test(compile_is_deterministic) :-
+    % write_wam_llvm_project is det by contract: a caller backtracking
+    % into it (e.g. \+ over a goal containing the compile) must not
+    % re-run the compiler search.
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_tier2_det', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'det.ll', LLPath),
+    tier2_preds(Preds),
+    write_wam_llvm_project(Preds, [module_name('plawk_tier2_det')], LLPath),
+    deterministic(Det),
+    assertion(Det == true),
+    !.
 
 test(surface_blob_payload_dcg_sum) :-
     % The record loop frames natively; the payload is parsed by the
@@ -182,9 +194,8 @@ write_raw(Path, Items) :-
         close(Out)).
 
 % IR-only build (throwaway module compile for the vm counts). The
-% compile is fenced with once/1: rejection tests negate this goal, and
-% without the fence \+ would backtrack into write_wam_llvm_project's
-% internal choice points and re-run the whole compiler search.
+% once/1 fence predates write_wam_llvm_project being made det; kept as
+% belt and braces for the rest of the conjunction.
 build_tier2_ir(Program, DriverIR) :-
     once(( tmp_root(Root),
            directory_file_path(Root, 'uw_plawk_tier2_blob_ir', Dir),


### PR DESCRIPTION
## Why

#3429 (unify_constant + determinism fixes) and #3431 (foreach as a real runtime loop) merged into this branch rather than main. This carries both the last step; no new content beyond a sync merge of main. **Merge first** — this round's feature PRs stack on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn