### PR TITLE
plawk: lps string fields inside rep elements

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -126,16 +126,21 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    accepted as sugar that desugars into a case block. Not yet inside
    case blocks: assoc arrays, writebin, and union output.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
-   count (≤ K) then that many fixed-width elements, read as one bulk
-   count×elemsize read after a memset of the element region (element
-   slots past the count are deterministic zeros). Access layout
-   flattens: the count is an i64 field and each element's fields are
-   plain record fields. The surface answer to "for over elements" is
-   `foreach { actions }`: inside the block `$1..$M` are the current
-   element's fields, and the block unrolls at compile time into K
-   count-guarded ifs (`count >= j`), reusing the existing if/join-phi
-   machinery — no loop-carried phis were added. One rep per layout,
-   fixed-width elements only, no nesting; those are later extensions.
+   count (≤ K) then that many elements. Fixed-width elements read as
+   one bulk count×elemsize read after a memset of the element region
+   (element slots past the count are deterministic zeros); elements
+   containing `lpsN` strings have per-element wire sizes, so the reader
+   emits a runtime loop that parses one element at a time into its
+   fixed in-memory slot group (the lps materializes as an NUL-padded
+   `sN` slot, same as at top level). Access layout flattens: the count
+   is an i64 field and each element's fields are plain record fields.
+   The surface answer to "for over elements" is `foreach { actions }`:
+   inside the block `$1..$M` are the current element's fields, and the
+   compiler emits a genuine runtime loop — the current element is
+   memcpy'd into a hidden staging slot group appended to the record
+   buffer and every scalar slot rides a loop-carried typed phi, so code
+   size is O(body) at any cap. One rep per layout, no rep/blob nesting;
+   those are later extensions.
 3. **Varlen writers (landed):** `lpsN` in OUTFMT emits the 8-byte
    length plus exactly the payload bytes, sourced from literals,
    `sM`/`lpsM` input fields (`M ≤ cap`), or text-mode slices clamped to

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -94,6 +94,7 @@ swipl -q -s tests/test_plawk_varlen_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_varlen_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tagged_unions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_bounded_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_rep_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
@@ -304,8 +305,12 @@ real runtime loop (loop-carried phis per scalar slot; the current
 element is staged into a hidden slot at the end of the record buffer
 so field accesses stay compile-time offsets), so code size is
 independent of the cap and rep64 costs the same IR as rep4. The wire
-read is one bulk count*elemsize read. Oversized counts and truncated element regions
-exit with the read-error code. Tagged unions let one stream carry several
+read is one bulk count*elemsize read for fixed-width elements; elements
+may also contain `lpsN` strings (`BINFMT = "i64 rep4(lps8 i64)"`), in
+which case the reader loops, parsing one variable-length element at a
+time into its fixed in-memory slot group, so `foreach` string guards
+and prints work unchanged. Oversized counts, oversized element strings,
+and truncated element regions exit with the read-error code. Tagged unions let one stream carry several
 record kinds: `BINFMT = "case(i64 f64 | lps16 i64)"` declares that
 every record starts with an 8-byte tag selecting an arm layout, and
 `case K { ... }` blocks hold ordinary pattern-action rules whose

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -631,6 +631,19 @@ carrying your counters around the loop in registers. Constant memory,
 and the code size does not depend on the cap — `rep64` compiles to
 the same loop as `rep4`.
 
+Elements can carry strings too. `BINFMT = "i64 rep4(lps8 i64)"`
+declares elements that each start with a length-prefixed name of up to
+8 bytes. On the wire every element can be a different size, so the
+reader parses them one at a time (each string lands in a fixed 8-byte
+slot, NUL-padded, exactly like a top-level `lps` field); inside
+`foreach`, string fields guard and print like any other:
+
+```awk
+BEGIN { BINFMT = "i64 rep4(lps8 i64)" }
+{ foreach { if ($1 == "hot") { hits++ }; total += $2 } }
+END { print hits, total }
+```
+
 ### Handing payloads to Prolog
 
 Everything so far was compiled to plain native code. But PLAWK lives

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2040,10 +2040,14 @@ plawk_binfmt_type(Part, rep(Cap, ElemTypes)) :-
     exclude(==(""), ElemParts0, ElemParts),
     ElemParts \== [],
     maplist(plawk_binfmt_type, ElemParts, ElemTypes),
-    % elements must be fixed-width (no nested lps/rep) so the element
-    % region is one bulk read and one flat access layout
+    % Elements may be fixed-width (i64/f64/sN -> one bulk read of the
+    % whole region) or contain lpsN strings (variable wire size per
+    % element -> the reader loops, parsing one element at a time into
+    % its fixed in-memory slot group). Nested rep/blob stay out: the
+    % access layout must remain one flat fixed-offset slot group per
+    % element.
     forall(member(ElemType, ElemTypes),
-        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_) )).
+        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_) ; ElemType = lps(_) )).
 % blobN: a length-prefixed binary payload (8-byte length, then up to N
 % payload bytes) whose ONLY consumer is a compiled-Prolog foreign call:
 % the record loop stays native for framing and hands the payload to a
@@ -2778,7 +2782,7 @@ vr_tag_switch:
         ( nth0(Index, Arms, ArmTypes),
           format(atom(ArmPrefix), 'vr_a~w', [Index]),
           plawk_varlen_field_sections(ArmTypes, LoweredLabel, ArmPrefix,
-              no_eof, 0, 0, Sections),
+              no_eof, 0, rec, 0, Sections),
           atomic_list_concat(Sections, '\n', ArmBodyIR),
           format(atom(ArmIR), '~w:~n~w', [ArmPrefix, ArmBodyIR])
         ),
@@ -2860,14 +2864,17 @@ plawk_normalize_driver_blocks(Blocks, Blocks).
 %  zero the slot, then read the payload (a zero length reads nothing:
 %  @wam_stream_read_record returns 1 immediately for size 0).
 plawk_varlen_read_ir(Types, LoweredLabel, ReadIR) :-
-    plawk_varlen_field_sections(Types, LoweredLabel, vr, eof_first, 0, 0,
+    plawk_varlen_field_sections(Types, LoweredLabel, vr, eof_first, 0, rec, 0,
         Sections),
     atomic_list_concat(Sections, '\n', ReadIR).
 
+%  Base is the LLVM pointer register destinations gep from: 'rec' for
+%  record-level fields, or a rep loop's current-element base pointer
+%  (Offset is then relative to the element start).
 plawk_varlen_field_sections([], _LoweredLabel, _Prefix, _EofPolicy, _Index,
-        _Offset, []).
+        _Base, _Offset, []).
 plawk_varlen_field_sections([Type | Types], LoweredLabel, Prefix, EofPolicy,
-        Index, Offset, [Section | Sections]) :-
+        Index, Base, Offset, [Section | Sections]) :-
     ( Types == []
     -> NextLabel = LoweredLabel
     ;  NextIndex0 is Index + 1,
@@ -2882,20 +2889,22 @@ plawk_varlen_field_sections([Type | Types], LoweredLabel, Prefix, EofPolicy,
     -> FieldEof = eof
     ;  FieldEof = no_eof
     ),
-    plawk_varlen_field_body(Type, FBase, FieldEof, Offset, NextLabel, BodyIR),
+    plawk_varlen_field_body(Type, FBase, FieldEof, Base, Offset, NextLabel,
+        BodyIR),
     format(atom(Section), '~w~w', [LabelIR, BodyIR]),
     plawk_binfmt_type_width(Type, Width),
     NextOffset is Offset + Width,
     NextIndex is Index + 1,
     plawk_varlen_field_sections(Types, LoweredLabel, Prefix, EofPolicy,
-        NextIndex, NextOffset, Sections).
+        NextIndex, Base, NextOffset, Sections).
 
-plawk_varlen_field_body(blob(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+plawk_varlen_field_body(blob(Cap), FBase, FieldEof, Base, Offset, NextLabel,
+        BodyIR) :-
     !,
     PayloadOffset is Offset + 8,
     plawk_varlen_eof_check_ir(FieldEof, FBase, cstatus, BodyPrefixIR),
     format(atom(BodyIR),
-'  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+'  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
   %~w_cstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
 ~w  %~w_cok = icmp eq i64 %~w_cstatus, 1
   br i1 %~w_cok, label %~w_len, label %fail_read
@@ -2907,13 +2916,13 @@ plawk_varlen_field_body(blob(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :
   br i1 %~w_fits, label %~w_read, label %fail_read
 
 ~w_read:
-  %~w_pdst = getelementptr i8, i8* %rec, i64 ~w
+  %~w_pdst = getelementptr i8, i8* %~w, i64 ~w
   call void @llvm.memset.p0i8.i64(i8* %~w_pdst, i8 0, i64 ~w, i1 false)
   %~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %~w_n, i8* %~w_pdst)
   %~w_pok = icmp eq i64 %~w_pstatus, 1
   br i1 %~w_pok, label %~w, label %fail_read
 ',
-        [FBase, Offset,
+        [FBase, Base, Offset,
          FBase, FBase,
          BodyPrefixIR, FBase, FBase,
          FBase, FBase,
@@ -2923,12 +2932,90 @@ plawk_varlen_field_body(blob(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :
          FBase, FBase, Cap,
          FBase, FBase,
          FBase,
-         FBase, PayloadOffset,
+         FBase, Base, PayloadOffset,
          FBase, Cap,
          FBase, FBase, FBase,
          FBase, FBase,
          FBase, NextLabel]).
-plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+% rep whose elements contain lps strings: the wire size varies per
+% element, so the region cannot be one bulk read. Read the count, then
+% loop: each iteration parses one element's fields (through the same
+% field-body emitters, based at the current element's slot group), so
+% in-memory layout is identical to the fixed-element case and
+% everything downstream (field access, foreach staging) is unchanged.
+% Elements past the count stay zero from the region memset.
+plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Base, Offset,
+        NextLabel, BodyIR) :-
+    memberchk(lps(_ECap), ElemTypes),
+    !,
+    maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
+    sum_list(ElemWidths, ElemSize),
+    RegionSize is Cap * ElemSize,
+    ElemOffset is Offset + 8,
+    plawk_varlen_eof_check_ir(FieldEof, FBase, cstatus, BodyPrefixIR),
+    format(atom(HeaderIR),
+'  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
+  %~w_cstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
+~w  %~w_cok = icmp eq i64 %~w_cstatus, 1
+  br i1 %~w_cok, label %~w_len, label %fail_read
+
+~w_len:
+  %~w_ctp = bitcast i8* %~w_dst to i64*
+  %~w_n = load i64, i64* %~w_ctp
+  %~w_fits = icmp ule i64 %~w_n, ~w
+  br i1 %~w_fits, label %~w_read, label %fail_read
+
+~w_read:
+  %~w_edst = getelementptr i8, i8* %~w, i64 ~w
+  call void @llvm.memset.p0i8.i64(i8* %~w_edst, i8 0, i64 ~w, i1 false)
+  br label %~w_lh
+
+~w_lh:
+  %~w_j = phi i64 [ 1, %~w_read ], [ %~w_jn, %~w_ld ]
+  %~w_cont = icmp sle i64 %~w_j, %~w_n
+  br i1 %~w_cont, label %~w_lb, label %~w
+
+~w_lb:
+  %~w_jm1 = sub i64 %~w_j, 1
+  %~w_rel = mul i64 %~w_jm1, ~w
+  %~w_eb = getelementptr i8, i8* %~w_edst, i64 %~w_rel
+',
+        [FBase, Base, Offset,
+         FBase, FBase,
+         BodyPrefixIR, FBase, FBase,
+         FBase, FBase,
+         FBase,
+         FBase, FBase,
+         FBase, FBase,
+         FBase, FBase, Cap,
+         FBase, FBase,
+         FBase,
+         FBase, Base, ElemOffset,
+         FBase, RegionSize,
+         FBase,
+         FBase,
+         FBase, FBase, FBase, FBase,
+         FBase, FBase, FBase,
+         FBase, FBase, NextLabel,
+         FBase,
+         FBase, FBase,
+         FBase, FBase, ElemSize,
+         FBase, FBase, FBase]),
+    format(atom(ElemPrefix), '~w_e', [FBase]),
+    format(atom(ElemBase), '~w_eb', [FBase]),
+    format(atom(DoneLabel), '~w_ld', [FBase]),
+    plawk_varlen_field_sections(ElemTypes, DoneLabel, ElemPrefix, no_eof, 0,
+        ElemBase, 0, ElemSections),
+    atomic_list_concat(ElemSections, '\n', ElemsIR),
+    format(atom(FooterIR),
+'~w_ld:
+  %~w_jn = add i64 %~w_j, 1
+  br label %~w_lh
+',
+        [FBase, FBase, FBase, FBase]),
+    atomic_list_concat([HeaderIR, ElemsIR, FooterIR], '\n', BodyIR).
+plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Base, Offset,
+        NextLabel, BodyIR) :-
     !,
     maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
     sum_list(ElemWidths, ElemSize),
@@ -2936,7 +3023,7 @@ plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Offset, NextLabel,
     ElemOffset is Offset + 8,
     plawk_varlen_eof_check_ir(FieldEof, FBase, cstatus, BodyPrefixIR),
     format(atom(BodyIR),
-'  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+'  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
   %~w_cstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
 ~w  %~w_cok = icmp eq i64 %~w_cstatus, 1
   br i1 %~w_cok, label %~w_len, label %fail_read
@@ -2948,14 +3035,14 @@ plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Offset, NextLabel,
   br i1 %~w_fits, label %~w_read, label %fail_read
 
 ~w_read:
-  %~w_edst = getelementptr i8, i8* %rec, i64 ~w
+  %~w_edst = getelementptr i8, i8* %~w, i64 ~w
   call void @llvm.memset.p0i8.i64(i8* %~w_edst, i8 0, i64 ~w, i1 false)
   %~w_bytes = mul i64 %~w_n, ~w
   %~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %~w_bytes, i8* %~w_edst)
   %~w_pok = icmp eq i64 %~w_pstatus, 1
   br i1 %~w_pok, label %~w, label %fail_read
 ',
-        [FBase, Offset,
+        [FBase, Base, Offset,
          FBase, FBase,
          BodyPrefixIR, FBase, FBase,
          FBase, FBase,
@@ -2965,13 +3052,14 @@ plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Offset, NextLabel,
          FBase, FBase, Cap,
          FBase, FBase,
          FBase,
-         FBase, ElemOffset,
+         FBase, Base, ElemOffset,
          FBase, RegionSize,
          FBase, FBase, ElemSize,
          FBase, FBase, FBase,
          FBase, FBase,
          FBase, NextLabel]).
-plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Base, Offset, NextLabel,
+        BodyIR) :-
     !,
     plawk_varlen_eof_check_ir(FieldEof, FBase, lstatus, BodyPrefixIR),
     format(atom(BodyIR),
@@ -2985,7 +3073,7 @@ plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
   br i1 %~w_fits, label %~w_read, label %fail_read
 
 ~w_read:
-  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
   call void @llvm.memset.p0i8.i64(i8* %~w_dst, i8 0, i64 ~w, i1 false)
   %~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %~w_n, i8* %~w_dst)
   %~w_pok = icmp eq i64 %~w_pstatus, 1
@@ -2999,20 +3087,37 @@ plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
          FBase, FBase, Cap,
          FBase, FBase,
          FBase,
-         FBase, Offset,
+         FBase, Base, Offset,
          FBase, Cap,
          FBase, FBase, FBase,
          FBase, FBase,
          FBase, NextLabel]).
-plawk_varlen_field_body(_NumericType, FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+% sN is fixed on the wire (exactly N bytes, NUL-padded by the writer),
+% so it reads straight into its slot.
+plawk_varlen_field_body(s(Width), FBase, FieldEof, Base, Offset, NextLabel,
+        BodyIR) :-
+    !,
     plawk_varlen_eof_check_ir(FieldEof, FBase, status, BodyPrefixIR),
     format(atom(BodyIR),
-'  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+'  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
+  %~w_status = call i64 @wam_stream_read_record(%Value %handle, i64 ~w, i8* %~w_dst)
+~w  %~w_ok = icmp eq i64 %~w_status, 1
+  br i1 %~w_ok, label %~w, label %fail_read
+',
+        [FBase, Base, Offset,
+         FBase, Width, FBase,
+         BodyPrefixIR, FBase, FBase,
+         FBase, NextLabel]).
+plawk_varlen_field_body(_NumericType, FBase, FieldEof, Base, Offset, NextLabel,
+        BodyIR) :-
+    plawk_varlen_eof_check_ir(FieldEof, FBase, status, BodyPrefixIR),
+    format(atom(BodyIR),
+'  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
   %~w_status = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
 ~w  %~w_ok = icmp eq i64 %~w_status, 1
   br i1 %~w_ok, label %~w, label %fail_read
 ',
-        [FBase, Offset,
+        [FBase, Base, Offset,
          FBase, FBase,
          BodyPrefixIR, FBase, FBase,
          FBase, NextLabel]).

--- a/tests/test_plawk_bounded_rep.pl
+++ b/tests/test_plawk_bounded_rep.pl
@@ -57,8 +57,8 @@ test(rep_rejections) :-
         "BEGIN { BINFMT = \"i64 rep4(i64)\" } { foreach { s += $2 } } END { print s }\n",
         % one rep per layout in this slice
         "BEGIN { BINFMT = \"rep2(i64) rep2(i64)\" } { foreach { n++ } } END { print n }\n",
-        % elements must be fixed-width
-        "BEGIN { BINFMT = \"rep2(lps8)\" } { foreach { n++ } } END { print n }\n"
+        % no blob elements (a blob's only consumer is a foreign call)
+        "BEGIN { BINFMT = \"rep2(blob8)\" } { foreach { n++ } } END { print n }\n"
     ],
     forall(member(Source, Rejects),
         ( plawk_parse_string(Source, Program)

--- a/tests/test_plawk_rep_strings.pl
+++ b/tests/test_plawk_rep_strings.pl
@@ -1,0 +1,181 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_rls_marker/0.
+
+user:plawk_rls_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_rep_strings, [condition(clang_available)]).
+
+test(rep_with_lps_elements_reads_element_by_element) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" } { foreach { total += $2 } } END { print total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % 8 id + 8 count + 4*16 elements + 16 staging
+    assertion(once(sub_atom(DriverIR, _, _, _, 'malloc(i64 96)'))),
+    % a per-element read loop, not one bulk region read
+    assertion(once(sub_atom(DriverIR, _, _, _, 'vr_f1_lh:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_f1_j = phi i64 [ 1, %vr_f1_read ]'))),
+    % the element's lps string parses through the shared length scratch
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_f1_e_f0_lstatus'))),
+    % and its i64 sibling reads relative to the current element base
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i8* %vr_f1_eb, i64 8'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '_bytes = mul')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(rep_with_fixed_elements_keeps_bulk_read) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(s8 i64)\" } { foreach { total += $2 } } END { print total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_bytes = mul'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'vr_f1_lh:')),
+    !.
+
+test(toplevel_s_field_reads_its_exact_width) :-
+    plawk_parse_string("BEGIN { BINFMT = \"s4 lps8\" } $1 == \"abcd\" { c++ } END { print c }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % 4 wire bytes for s4, not a hardcoded 8
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 4, i8* %vr_f0_dst'))),
+    !.
+
+test(surface_foreach_string_guard_aggregates) :-
+    run_rls_smoke("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" } $1 > 0 { recs++ } { foreach { if ($1 == \"hot\") { hits++ }; total += $2 } } END { print recs, hits, total }\n",
+        [rec(1, [e("hot", 5), e("cold", 7)]),
+         rec(2, []),
+         rec(3, [e("warm", 1), e("hot", 2), e("hotx", 3), e("full8chr", 4)])],
+        "3 2 22\n").
+
+test(surface_foreach_prints_element_strings) :-
+    run_rls_smoke("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" } { foreach { print $1, $2 } } END { print done }\n",
+        [rec(1, [e("hot", 5), e("", 7), e("full8chr", 9)])],
+        "hot 5\n 7\nfull8chr 9\n0\n").
+
+test(surface_toplevel_s_field_equality) :-
+    build_rls_probe("BEGIN { BINFMT = \"s4 lps8\" } $1 == \"abcd\" { c++ } END { print c }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_raw(InputPath, [bytes("abcd"), i64(1), bytes("x"),
+                          bytes("efgh"), i64(2), bytes("yy")]),
+    run_capture_raw(BinPath, Out, exit(0)),
+    assertion(Out == "1\n"),
+    !.
+
+test(surface_rep_lps_error_paths) :-
+    build_rls_probe("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" } { foreach { total += $2 } } END { print total }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    % element string longer than its cap (9 > 8)
+    write_raw(InputPath, [i64(1), i64(1), i64(9), bytes("ninechars"), i64(5)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % count above the rep cap (5 > 4)
+    write_raw(InputPath, [i64(1), i64(5)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % truncated element payload (claims 6, has 2)
+    write_raw(InputPath, [i64(1), i64(1), i64(6), bytes("ab")]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % EOF between elements (count 2, one element present)
+    write_raw(InputPath, [i64(1), i64(2), i64(3), bytes("abc"), i64(5)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % empty input is a clean EOF: END runs
+    write_raw(InputPath, []),
+    run_capture_raw(BinPath, Out, exit(0)),
+    assertion(Out == "0\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_raw(Path, Items) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Item, Items),
+            ( Item = i64(V) -> write_i64_le(Out, V)
+            ; Item = bytes(S) -> ( string_codes(S, Cs),
+                                   forall(member(C, Cs), put_byte(Out, C)) )
+            )),
+        close(Out)).
+
+% one record: i64 id, i64 count, then per element an lps8 (i64 length +
+% payload) and an i64 value
+write_rls_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(Id, Elems), Recs),
+            ( write_i64_le(Out, Id),
+              length(Elems, Count),
+              write_i64_le(Out, Count),
+              forall(member(e(S, V), Elems),
+                  ( string_codes(S, Codes),
+                    length(Codes, Len),
+                    write_i64_le(Out, Len),
+                    forall(member(C, Codes), put_byte(Out, C)),
+                    write_i64_le(Out, V) )) )),
+        close(Out)).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_rls_marker/0 ],
+        [module_name('plawk_rep_strings')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk rep strings build output]~n~w~n", [BuildOut]),
+       throw(plawk_rep_strings_build_failed(Status))
+    ).
+
+build_rls_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_rep_strings', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_capture_raw(BinPath, Bytes, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+run_rls_smoke(Source, Recs, ExpectedOutput) :-
+    build_rls_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_rls_records(InputPath, Recs),
+    run_capture_raw(BinPath, OutStr, exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.
+
+:- end_tests(plawk_rep_strings).


### PR DESCRIPTION
## Summary

First of this round's queued extensions: `rep` elements may now contain `lpsN` strings — `BINFMT = "i64 rep4(lps8 i64)"` declares up to 4 elements each carrying a length-prefixed name and an i64 value, and `foreach` bodies can guard and print those strings like any other field.

## Design

- **Why a new read shape:** fixed-width elements read as one bulk `count×elemsize` read. With an `lps` inside, every element has a different wire size, so the reader now emits a **runtime loop**: read the count, memset the element region (slots past the count stay deterministic zeros), then parse one element per iteration into its fixed in-memory slot group. The `lps` materializes as a NUL-padded `sN` slot exactly like at top level, so in-memory layout — and therefore field access, guards, prints, and the foreach staging memcpy — is unchanged.
- **Mechanics:** the varlen field emitters (`plawk_varlen_field_sections` / `plawk_varlen_field_body`) take a base-pointer register: `rec` for record-level fields, or the loop's current-element pointer with element-relative offsets. Fixed-width reps keep the bulk read (an IR test locks both shapes in).
- **Bonus correctness fix:** a proper `s(Width)` wire clause reads exactly `Width` bytes — previously a top-level `sN` in a varlen layout would have fallen through to the 8-byte numeric read (no test exercised that mix; now one does).

## Tests

- New `tests/test_plawk_rep_strings.pl` (7 tests): IR shape (per-element loop with index phi for lps elements; bulk read preserved for fixed elements; `s4` reads 4 wire bytes), e2e foreach with string-equality guards (`if ($1 == "hot")`) and element-string prints, and error paths (oversized element string, count above cap, truncated payload, EOF mid-elements, clean empty input → END runs).
- `test_plawk_bounded_rep`'s rejection list drops `rep(lps…)` (now a feature) and gains `rep(blob…)`.
- Full regression sweep: **all 43 plawk/WAM suites green.**

## Merge order

1. #3430 (consolidation → main) first
2. this PR into `claude/plawk-llvm-wam-hybrid-p9ujut`
3. then the follow-up PRs of this round (tag-guard sugar, rep-in-union-arms) stack on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_