### PR TITLE
plawk: TAG == K guard sugar for tagged-union case blocks

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -122,9 +122,13 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    it at runtime because the arm is static inside the block). Unknown
    tags and truncated arms are malformed input (`fail_read`); arms
    without a case block are still read and skipped so the stream stays
-   framed. The tag-guard spelling (`$0 == K && ...`) can later be
-   accepted as sugar that desugars into a case block. Not yet inside
-   case blocks: assoc arrays, writebin, and union output.
+   framed. The tag-guard spelling (landed) is accepted as sugar:
+   `TAG == K && P { actions }` desugars into `case K { P { actions } }`
+   (one single-rule block per rule, so source order is preserved and
+   the two spellings compile to identical IR). Every rule must lead
+   with a tag guard, and a tag test under `||`/`!` or in a non-leftmost
+   conjunct is rejected. Not yet inside case blocks: assoc arrays,
+   writebin, and union output.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -319,7 +319,11 @@ every record starts with an 8-byte tag selecting an arm layout, and
 arms; the reader is a native tag switch dispatching per-arm field
 reads into one record buffer sized to the widest arm. Unknown tags
 and truncated arms exit with the read-error code; arms with no case
-block are still read and skipped, keeping the stream framed. (Assoc
+block are still read and skipped, keeping the stream framed. Rules may
+also lead with a tag guard instead: `TAG == 1 && $1 == "boom" { events++ }`
+is pure sugar for the same rule inside `case 1 { ... }` (identical IR);
+every rule must then lead with `TAG == K`, and tag tests under `||`/`!`
+or in non-leftmost position are rejected. (Assoc
 arrays and writebin inside case blocks are later slices.)
 `lpsN` also works in OUTFMT: writebin emits the
 8-byte length plus exactly the payload bytes (no padding), sourcing

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -584,13 +584,31 @@ those." Scalars like `msum` and `events`, plus `NR`, `next`, `break`,
 and the END report, are shared across the blocks — there is still only
 one stream and one loop.
 
-Why blocks rather than writing the tag into each guard
-(`$0 == 1 && $1 == "boom"`)? Because the *types* of `$1, $2` depend on
-the arm: the compiler must know which arm a rule belongs to before it
-can decide whether `$1 == "boom"` is a string comparison or nonsense.
-With a block, that is decided by where the rule sits on the page. (The
-guard spelling can be added later as a shorthand that expands to a
-block.)
+Why blocks rather than writing the tag into each guard? Because the
+*types* of `$1, $2` depend on the arm: the compiler must know which arm
+a rule belongs to before it can decide whether `$1 == "boom"` is a
+string comparison or nonsense. With a block, that is decided by where
+the rule sits on the page.
+
+That said, for a program with only a rule or two per arm, a block per
+arm is ceremony. So the guard spelling exists as **shorthand**: a rule
+may lead with `TAG == K`, and it means exactly the same as putting the
+rest of the rule inside `case K { ... }`:
+
+```awk
+BEGIN { BINFMT = "case(i64 f64 | lps16 i64)" }
+TAG == 0 && $1 > 100 { msum += float($2) }
+TAG == 1 && $1 == "boom" { events++ }
+END { print msum, events }
+```
+
+This compiles to *identical* code as the block version — it is pure
+sugar, not a second mechanism. The one rule: the `TAG == K` test must
+come first in the guard (and every rule must have one), because it is
+what tells the compiler which arm's types the rest of the rule is
+checked against. `TAG == 0 || TAG == 1` is rejected for the same
+reason — such a rule would need two different type checks at once.
+Pick whichever spelling reads better; don't mix both in one program.
 
 ### What the compiled program actually does
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -210,6 +210,28 @@ plawk_program_native_driver_ir(
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% Tag-guard sugar: with a union BINFMT, plain rules whose patterns lead
+% with TAG == K are shorthand for case blocks -- the tag test selects
+% the arm and the rest of the pattern stays as the rule's own guard, so
+%   TAG == 0 && $1 > 10 { hits++ }
+% means exactly
+%   case 0 { $1 > 10 { hits++ } }.
+% Every rule must lead with a tag guard (an unguarded rule has no arm
+% to type its fields against), and the tag test may appear nowhere
+% else; otherwise the program is rejected.
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules, EndClauses),
+    InputPath,
+    DriverIR
+) :-
+    is_list(Rules),
+    plawk_record_descriptor(BeginClauses, binfmt_union(_Arms)),
+    plawk_tag_rules_case_blocks(Rules, CaseBlocks),
+    !,
+    plawk_program_native_driver_ir(
+        program(BeginClauses, case_blocks(CaseBlocks), EndClauses),
+        InputPath, DriverIR).
+
 % Tagged-union programs: BINFMT = "case(arm0 | arm1 | ...)" plus
 % case K { rules } blocks. Case blocks flatten into one scalar rule
 % chain where each rule's guard checks the record tag before its own
@@ -2722,6 +2744,32 @@ plawk_foreach_shift_term(Base, Term, Shifted) :-
     maplist(plawk_foreach_shift_term(Base), Args, ShiftedArgs),
     Shifted =.. [Functor | ShiftedArgs].
 plawk_foreach_shift_term(_Base, Term, Term).
+
+%% plawk_tag_rules_case_blocks(+Rules, -CaseBlocks)
+%
+%  Desugar TAG-guarded rules into case blocks, one single-rule arm
+%  block per rule (duplicate arm indexes are fine: flattening walks the
+%  blocks in order, so source rule order is preserved). Fails -- and
+%  the program is rejected -- when any rule lacks a leading tag guard
+%  or mentions TAG anywhere else in its pattern.
+plawk_tag_rules_case_blocks(Rules, CaseBlocks) :-
+    Rules = [_ | _],
+    maplist(plawk_tag_rule_case_arm, Rules, CaseBlocks).
+
+plawk_tag_rule_case_arm(rule(Pattern0, Actions),
+        case_arm(Tag, [rule(Pattern, Actions)])) :-
+    plawk_pattern_strip_tag(Pattern0, Tag, Pattern),
+    \+ ( sub_term(Sub, Pattern), nonvar(Sub), Sub = tag_pat(_) ).
+
+% The tag test must be the leftmost conjunct of a left-associated &&
+% chain: TAG == K alone selects the arm (residual guard `always`), and
+% TAG == K && P keeps P as the rule's own guard. A tag test under ||,
+% !, or anywhere deeper has no single-arm meaning and is rejected.
+plawk_pattern_strip_tag(tag_pat(Tag), Tag, always).
+plawk_pattern_strip_tag(and_pat(tag_pat(Tag), Residual), Tag, Residual) :-
+    !.
+plawk_pattern_strip_tag(and_pat(Left0, Right), Tag, and_pat(Left, Right)) :-
+    plawk_pattern_strip_tag(Left0, Tag, Left).
 
 %% plawk_union_flatten_rules(+CaseBlocks, +Arms, -Rules)
 %

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -178,7 +178,28 @@ base_pattern(Pattern) -->
     field_eq_pattern(Pattern),
     !.
 base_pattern(Pattern) -->
+    tag_eq_pattern(Pattern),
+    !.
+base_pattern(Pattern) -->
     prolog_guard_pattern(Pattern).
+
+%% tag_eq_pattern(-Pattern)//
+%
+%  TAG == K guards a rule by the record tag of a tagged-union layout.
+%  Surface sugar: the codegen groups TAG-guarded rules into the same
+%  per-arm case blocks that `case K { ... }` produces, so the tag test
+%  must be the leftmost conjunct of the rule's pattern.
+tag_eq_pattern(tag_pat(Tag)) -->
+    "TAG",
+    identifier_boundary,
+    ws,
+    "==",
+    ws,
+    integer_codes(TagCodes),
+    { TagCodes \== [],
+      number_codes(Tag, TagCodes),
+      Tag >= 0
+    }.
 
 %% prolog_guard_pattern(-Pattern)//
 %

--- a/tests/test_plawk_tagged_unions.pl
+++ b/tests/test_plawk_tagged_unions.pl
@@ -87,6 +87,43 @@ test(surface_union_endless_program) :-
         [m(1, 1.0), e("aa", 5), e("bb", 6)],
         "aa 5\nbb 6\n").
 
+test(tag_guard_sugar_matches_case_blocks_exactly) :-
+    % TAG == K && P is pure sugar: it must compile to byte-identical IR
+    % as the case-block spelling.
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } TAG == 1 && $2 > 5 { b++ } END { print b }\n", Sugar),
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 1 { $2 > 5 { b++ } } END { print b }\n", Blocks),
+    plawk_program_native_driver_ir(Sugar, 'input.bin', SugarIR),
+    plawk_program_native_driver_ir(Blocks, 'input.bin', BlocksIR),
+    assertion(SugarIR == BlocksIR),
+    !.
+
+test(tag_guard_rejections) :-
+    Rejects = [
+        % every rule must lead with a tag guard (an unguarded rule has
+        % no arm to type its fields against)
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } TAG == 0 { a++ } { b++ } END { print a, b }\n",
+        % a tag test under || has no single-arm meaning
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } TAG == 0 || TAG == 1 { a++ } END { print a }\n",
+        % ... nor one that is not the leftmost conjunct
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } $1 > 3 && TAG == 0 { a++ } END { print a }\n",
+        % tag beyond the declared arms
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } TAG == 5 { a++ } END { print a }\n",
+        % TAG guards demand a union BINFMT
+        "BEGIN { BINFMT = \"i64 i64\" } TAG == 0 { a++ } END { print a }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_tag_guard_dispatch) :-
+    % The case-block dispatch test, respelled with tag guards --
+    % including rules for different arms interleaved in source order.
+    run_tun_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } TAG == 0 && $1 > 100 { msum += float($2) ; mhits++ } TAG == 1 && $2 == 7 { print $1 } TAG == 1 && $1 == \"boom\" { events++ } END { print mhits, msum, events }\n",
+        [m(50, 1.5), e("hello", 7), m(200, 2.5), e("boom", 3), m(300, 0.25), e("boom", 7)],
+        "hello\nboom\n2 2.75 2\n").
+
 test(surface_union_error_paths) :-
     build_tun_probe("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { { c++ } } END { print c }\n",
         Dir, BinPath),


### PR DESCRIPTION
## Summary

The "Option A" spelling we deferred when case blocks landed, now delivered as promised — pure sugar over Option B. With a union `BINFMT`, rules may lead with a tag guard instead of sitting inside a case block:

```awk
BEGIN { BINFMT = "case(i64 f64 | lps16 i64)" }
TAG == 0 && $1 > 100 { msum += float($2) }
TAG == 1 && $1 == "boom" { events++ }
END { print msum, events }
```

means exactly the same as the `case 0 { ... } case 1 { ... }` version.

## Design

- **Parser:** new base pattern `TAG == K` → `tag_pat(K)`. No grammar conflicts (field guards start with `$` or `/`, and Prolog guards require parentheses).
- **Codegen:** a front-door clause detects (plain rule list + union descriptor + every rule strips a leading tag guard), rewrites into case blocks — **one single-rule arm block per rule**, so source order is preserved even when arms interleave — and re-enters the existing union path. No second mechanism anywhere downstream; a test asserts the two spellings compile to **byte-identical IR**.
- **Rejections** (all program-rejecting, matching the "compiler must know the arm before it can type `$N`" rationale): a rule without a tag guard, `TAG` under `||`/`!`, `TAG` in a non-leftmost conjunct, tag beyond the declared arms, `TAG` without a union BINFMT.

## Tests

- `test_plawk_tagged_unions` grows 8 → 11: IR-equivalence test, the rejection matrix, and the union dispatch e2e respelled with interleaved tag guards (`hello\nboom\n2 2.75 2` exact).
- Full regression sweep: **all 43 suites green.**

## Docs

TUTORIAL union section introduces the shorthand and its one rule (tag test first, don't mix spellings); README paragraph; design-doc item flipped from "can later be accepted" to landed.

## Merge order

1. #3430 (consolidation → main)
2. #3433 (lps inside rep elements) into the designated branch
3. this PR into `claude/plawk-llvm-wam-hybrid-p9ujut-rep-lps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_