### PR TITLE
plawk: rep inside tagged-union arms (foreach in case blocks)

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -127,8 +127,12 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    (one single-rule block per rule, so source order is preserved and
    the two spellings compile to identical IR). Every rule must lead
    with a tag guard, and a tag test under `||`/`!` or in a non-leftmost
-   conjunct is rejected. Not yet inside case blocks: assoc arrays,
-   writebin, and union output.
+   conjunct is rejected. Arms may carry a `repK(...)` (landed):
+   `foreach` inside a case block resolves against that arm's own
+   layout, per-arm staging rides the same access-type expansion, and
+   the union buffer (max record size across arms) covers it
+   automatically. Not yet inside case blocks: assoc arrays, writebin,
+   and union output.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region
@@ -143,8 +147,8 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    compiler emits a genuine runtime loop — the current element is
    memcpy'd into a hidden staging slot group appended to the record
    buffer and every scalar slot rides a loop-carried typed phi, so code
-   size is O(body) at any cap. One rep per layout, no rep/blob nesting;
-   those are later extensions.
+   size is O(body) at any cap. One rep per layout (per arm in a
+   union), no rep/blob nesting; those are later extensions.
 3. **Varlen writers (landed):** `lpsN` in OUTFMT emits the 8-byte
    length plus exactly the payload bytes, sourced from literals,
    `sM`/`lpsM` input fields (`M ≤ cap`), or text-mode slices clamped to

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -95,6 +95,7 @@ swipl -q -s tests/test_plawk_varlen_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_tagged_unions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_bounded_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_rep_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_union_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
@@ -323,7 +324,11 @@ block are still read and skipped, keeping the stream framed. Rules may
 also lead with a tag guard instead: `TAG == 1 && $1 == "boom" { events++ }`
 is pure sugar for the same rule inside `case 1 { ... }` (identical IR);
 every rule must then lead with `TAG == K`, and tag tests under `||`/`!`
-or in non-leftmost position are rejected. (Assoc
+or in non-leftmost position are rejected. Arms can carry their own
+repetition: `BINFMT = "case(i64 rep4(lps8 i64) | i64)"` gives arm 0 an
+element list, and `foreach` inside that arm's rules (either spelling)
+iterates it -- element types, staging, and buffer sizing all resolve
+per arm. (Assoc
 arrays and writebin inside case blocks are later slices.)
 `lpsN` also works in OUTFMT: writebin emits the
 8-byte length plus exactly the payload bytes (no padding), sourcing

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -662,6 +662,10 @@ BEGIN { BINFMT = "i64 rep4(lps8 i64)" }
 END { print hits, total }
 ```
 
+Repetition also composes with tagged unions: an arm of a `case(...)`
+layout may carry its own `repK(...)`, and `foreach` inside that arm's
+rules (block or `TAG == K` spelling) iterates that arm's elements.
+
 ### Handing payloads to Prolog
 
 Everything so far was compiled to plain native code. But PLAWK lives

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1992,8 +1992,9 @@ plawk_begin_union_arms(BeginClauses, Arms) :-
     maplist(plawk_union_arm_types, ArmStrs, Arms).
 
 plawk_union_arm_types(ArmStr, Types) :-
-    split_string(ArmStr, " ", " ", Parts0),
-    exclude(==(""), Parts0, Parts),
+    % the shared tokenizer joins parenthesized types, so an arm can
+    % carry a rep: "case(i64 rep4(lps8 i64) | lps16 i64)"
+    plawk_binfmt_tokens(ArmStr, Parts),
     Parts \== [],
     maplist(plawk_binfmt_type, Parts, Types).
 
@@ -2775,12 +2776,16 @@ plawk_pattern_strip_tag(and_pat(Left0, Right), Tag, and_pat(Left, Right)) :-
 %
 %  Flatten case blocks into one rule chain, stamping each rule with
 %  arm_pat(Tag, ArmTypes, Pattern) so guards check the record tag and
-%  everything downstream types fields against the right arm.
+%  everything downstream types fields against the right arm. foreach
+%  resolves per arm against that arm's own layout (each arm may carry
+%  its own rep), so a case block iterates its arm's elements.
 plawk_union_flatten_rules(CaseBlocks, Arms, Rules) :-
     findall(rule(arm_pat(Index, ArmTypes, Pattern), Actions),
         ( member(case_arm(Index, ArmRules), CaseBlocks),
           nth0(Index, Arms, ArmTypes),
-          member(rule(Pattern, Actions), ArmRules)
+          plawk_resolve_foreach_rules(binfmt(ArmTypes), ArmRules,
+              ResolvedRules),
+          member(rule(Pattern, Actions), ResolvedRules)
         ),
         Rules),
     Rules \== [].
@@ -2792,7 +2797,9 @@ plawk_union_program_ok(Arms, CaseBlocks) :-
           Index >= 0,
           Index < ArmCount,
           nth0(Index, Arms, ArmTypes),
-          forall(member(rule(Pattern, Actions), ArmRules),
+          plawk_resolve_foreach_rules(binfmt(ArmTypes), ArmRules,
+              ResolvedRules),
+          forall(member(rule(Pattern, Actions), ResolvedRules),
               ( plawk_binfmt_pattern_ok(binfmt(ArmTypes), Pattern),
                 plawk_binfmt_actions_ok(binfmt(ArmTypes), Actions)
               ))

--- a/tests/test_plawk_union_rep.pl
+++ b/tests/test_plawk_union_rep.pl
@@ -1,0 +1,166 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_urp_marker/0.
+
+user:plawk_urp_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_union_rep, [condition(clang_available)]).
+
+test(rep_arm_sizes_buffer_and_reads_in_arm) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 rep4(i64 f64) | lps16 i64)\" } case 0 { { foreach { n++ } } } END { print n }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % widest arm: 8 id + 8 count + 4*16 elems + 16 staging = 96
+    assertion(once(sub_atom(DriverIR, _, _, _, 'malloc(i64 96)'))),
+    % the rep reads inside arm 0's field sequence (bulk read: fixed
+    % elements), and foreach is the runtime loop
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_a0_f1_bytes = mul i64 %vr_a0_f1_n, 16'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_j = phi i64 [1, %'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(rep_arm_rejections) :-
+    Rejects = [
+        % foreach needs a rep in ITS arm (arm 1 has none)
+        "BEGIN { BINFMT = \"case(i64 rep4(i64) | lps16 i64)\" } case 1 { { foreach { n++ } } } END { print n }\n",
+        % element arity still checked per arm ($3 in a 2-field element)
+        "BEGIN { BINFMT = \"case(i64 rep4(i64 f64) | i64)\" } case 0 { { foreach { s += $3 } } } END { print s }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_rep_arm_foreach_dispatch) :-
+    % Arm 0 records carry element lists that foreach aggregates; arm 1
+    % events are guarded per record -- one loop, shared END.
+    run_urp_smoke("BEGIN { BINFMT = \"case(i64 rep4(i64 f64) | lps16 i64)\" } case 0 { $1 > 0 { foreach { n++ ; wsum += float($2) } } } case 1 { $1 == \"boom\" { events++ } } END { print n, wsum, events }\n",
+        [ [i64(0), i64(1), i64(2), i64(5), f64(1.5), i64(20), f64(2.5)],
+          [i64(1), i64(4), bytes("boom"), i64(3)],
+          [i64(0), i64(2), i64(0)],
+          [i64(1), i64(1), bytes("x"), i64(7)],
+          [i64(0), i64(3), i64(1), i64(30), f64(0.25)] ],
+        "3 4.25 1\n").
+
+test(surface_rep_lps_arm_with_tag_guards) :-
+    % All three slices composed: tag-guard sugar, a rep arm, and lps
+    % strings inside the rep's elements.
+    run_urp_smoke("BEGIN { BINFMT = \"case(rep4(lps8 i64) | i64)\" } TAG == 0 { foreach { if ($1 == \"hot\") { hits++ }; total += $2 } } TAG == 1 { other++ } END { print hits, total, other }\n",
+        [ [i64(0), i64(2), i64(3), bytes("hot"), i64(5), i64(4), bytes("cool"), i64(7)],
+          [i64(1), i64(99)],
+          [i64(0), i64(1), i64(3), bytes("hot"), i64(2)] ],
+        "2 14 1\n").
+
+test(surface_rep_arm_error_paths) :-
+    build_urp_probe("BEGIN { BINFMT = \"case(i64 rep4(i64 f64) | lps16 i64)\" } case 0 { { foreach { n++ } } } END { print n }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    % count above the rep cap inside arm 0
+    write_items(InputPath, [i64(0), i64(1), i64(5)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % truncated element region (count 2, one element present)
+    write_items(InputPath, [i64(0), i64(1), i64(2), i64(5), f64(1.5)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % unknown tag
+    write_items(InputPath, [i64(9)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % clean EOF at a record boundary runs END
+    write_items(InputPath, []),
+    run_capture_raw(BinPath, Out, exit(0)),
+    assertion(Out == "0\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,  0x3FF8000000000000).
+double_bits(2.5,  0x4004000000000000).
+double_bits(0.25, 0x3FD0000000000000).
+
+write_items(Path, Items) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Item, Items), write_item(Out, Item)),
+        close(Out)).
+
+write_item(Out, i64(V)) :-
+    write_i64_le(Out, V).
+write_item(Out, f64(F)) :-
+    double_bits(F, Bits),
+    write_i64_le(Out, Bits).
+write_item(Out, bytes(S)) :-
+    string_codes(S, Cs),
+    forall(member(C, Cs), put_byte(Out, C)).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_urp_marker/0 ],
+        [module_name('plawk_union_rep')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk union rep build output]~n~w~n", [BuildOut]),
+       throw(plawk_union_rep_build_failed(Status))
+    ).
+
+build_urp_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_union_rep', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_capture_raw(BinPath, Bytes, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+% each record is spelled as a flat item list (tag first)
+run_urp_smoke(Source, Records, ExpectedOutput) :-
+    build_urp_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    append(Records, Items),
+    write_items(InputPath, Items),
+    run_capture_raw(BinPath, OutStr, exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.
+
+:- end_tests(plawk_union_rep).


### PR DESCRIPTION
## Summary

Third slice of the round: an arm of a `case(...)` layout may carry its own `repK(...)`, and `foreach` inside that arm's rules iterates that arm's elements:

```awk
BEGIN { BINFMT = "case(i64 rep4(i64 f64) | lps16 i64)" }
case 0 { $1 > 0 { foreach { n++ ; wsum += float($2) } } }
case 1 { $1 == "boom" { events++ } }
END { print n, wsum, events }
```

## Design

Two small changes make the existing machinery compose:

- **Arm tokenization** goes through the shared paren-joining tokenizer, so `rep4(i64 f64)` survives the space split inside an arm string (previously the only real blocker).
- **foreach resolves per arm**: `plawk_union_flatten_rules` and `plawk_union_program_ok` run foreach resolution against each arm's own `binfmt(ArmTypes)` before flattening/validating. Each arm may have its own rep; `foreach` in a rep-less arm is rejected; element-arity checks apply per arm.

Everything else already composed: per-arm staging comes from the access-type expansion, the union buffer (max record size across arms, staging included) covers every arm's staging region, the union reader reuses the varlen field emitters (bulk read for fixed elements, the per-element loop from #3433 when an arm's elements carry lps strings), the `foreach_loop` emitter is guard-agnostic, and the `TAG == K` sugar from #3434 desugars before any of this runs.

## Tests

New `tests/test_plawk_union_rep.pl` (5 tests):
- IR: union buffer sized to the rep arm incl. staging (96 bytes), rep bulk read inside arm 0's field sequence, foreach loop phi present.
- Rejections: foreach in a rep-less arm; element arity per arm.
- e2e dispatch: rep arm aggregates while the other arm guards — `3 4.25 1` exact.
- e2e composing **all three of this round's slices** (tag guards + rep arm + lps elements): `TAG == 0 { foreach { if ($1 == "hot") ... } }` over `case(rep4(lps8 i64) | i64)` — `2 14 1` exact.
- Error paths: count above cap, truncated elements, unknown tag → exit 11; clean EOF runs END.

Full regression sweep: **all 44 suites green.**

## Merge order (whole round, bottom-up)

1. #3430 (consolidation → main)
2. #3433 (lps inside rep elements) → designated branch
3. #3434 (TAG == K sugar) → the #3433 branch
4. this PR → the #3434 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_