### PR TITLE
plawk: bring round 3 (#3433 rep-lps, #3434 tag guards, #3435 union rep) to main

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -127,8 +127,12 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    (one single-rule block per rule, so source order is preserved and
    the two spellings compile to identical IR). Every rule must lead
    with a tag guard, and a tag test under `||`/`!` or in a non-leftmost
-   conjunct is rejected. Not yet inside case blocks: assoc arrays,
-   writebin, and union output.
+   conjunct is rejected. Arms may carry a `repK(...)` (landed):
+   `foreach` inside a case block resolves against that arm's own
+   layout, per-arm staging rides the same access-type expansion, and
+   the union buffer (max record size across arms) covers it
+   automatically. Not yet inside case blocks: assoc arrays, writebin,
+   and union output.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region
@@ -143,8 +147,8 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    compiler emits a genuine runtime loop — the current element is
    memcpy'd into a hidden staging slot group appended to the record
    buffer and every scalar slot rides a loop-carried typed phi, so code
-   size is O(body) at any cap. One rep per layout, no rep/blob nesting;
-   those are later extensions.
+   size is O(body) at any cap. One rep per layout (per arm in a
+   union), no rep/blob nesting; those are later extensions.
 3. **Varlen writers (landed):** `lpsN` in OUTFMT emits the 8-byte
    length plus exactly the payload bytes, sourced from literals,
    `sM`/`lpsM` input fields (`M ≤ cap`), or text-mode slices clamped to

--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -122,9 +122,13 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    it at runtime because the arm is static inside the block). Unknown
    tags and truncated arms are malformed input (`fail_read`); arms
    without a case block are still read and skipped so the stream stays
-   framed. The tag-guard spelling (`$0 == K && ...`) can later be
-   accepted as sugar that desugars into a case block. Not yet inside
-   case blocks: assoc arrays, writebin, and union output.
+   framed. The tag-guard spelling (landed) is accepted as sugar:
+   `TAG == K && P { actions }` desugars into `case K { P { actions } }`
+   (one single-rule block per rule, so source order is preserved and
+   the two spellings compile to identical IR). Every rule must lead
+   with a tag guard, and a tag test under `||`/`!` or in a non-leftmost
+   conjunct is rejected. Not yet inside case blocks: assoc arrays,
+   writebin, and union output.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region

--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -126,16 +126,21 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    accepted as sugar that desugars into a case block. Not yet inside
    case blocks: assoc arrays, writebin, and union output.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
-   count (≤ K) then that many fixed-width elements, read as one bulk
-   count×elemsize read after a memset of the element region (element
-   slots past the count are deterministic zeros). Access layout
-   flattens: the count is an i64 field and each element's fields are
-   plain record fields. The surface answer to "for over elements" is
-   `foreach { actions }`: inside the block `$1..$M` are the current
-   element's fields, and the block unrolls at compile time into K
-   count-guarded ifs (`count >= j`), reusing the existing if/join-phi
-   machinery — no loop-carried phis were added. One rep per layout,
-   fixed-width elements only, no nesting; those are later extensions.
+   count (≤ K) then that many elements. Fixed-width elements read as
+   one bulk count×elemsize read after a memset of the element region
+   (element slots past the count are deterministic zeros); elements
+   containing `lpsN` strings have per-element wire sizes, so the reader
+   emits a runtime loop that parses one element at a time into its
+   fixed in-memory slot group (the lps materializes as an NUL-padded
+   `sN` slot, same as at top level). Access layout flattens: the count
+   is an i64 field and each element's fields are plain record fields.
+   The surface answer to "for over elements" is `foreach { actions }`:
+   inside the block `$1..$M` are the current element's fields, and the
+   compiler emits a genuine runtime loop — the current element is
+   memcpy'd into a hidden staging slot group appended to the record
+   buffer and every scalar slot rides a loop-carried typed phi, so code
+   size is O(body) at any cap. One rep per layout, no rep/blob nesting;
+   those are later extensions.
 3. **Varlen writers (landed):** `lpsN` in OUTFMT emits the 8-byte
    length plus exactly the payload bytes, sourced from literals,
    `sM`/`lpsM` input fields (`M ≤ cap`), or text-mode slices clamped to

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -95,6 +95,7 @@ swipl -q -s tests/test_plawk_varlen_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_tagged_unions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_bounded_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_rep_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_union_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
@@ -323,7 +324,11 @@ block are still read and skipped, keeping the stream framed. Rules may
 also lead with a tag guard instead: `TAG == 1 && $1 == "boom" { events++ }`
 is pure sugar for the same rule inside `case 1 { ... }` (identical IR);
 every rule must then lead with `TAG == K`, and tag tests under `||`/`!`
-or in non-leftmost position are rejected. (Assoc
+or in non-leftmost position are rejected. Arms can carry their own
+repetition: `BINFMT = "case(i64 rep4(lps8 i64) | i64)"` gives arm 0 an
+element list, and `foreach` inside that arm's rules (either spelling)
+iterates it -- element types, staging, and buffer sizing all resolve
+per arm. (Assoc
 arrays and writebin inside case blocks are later slices.)
 `lpsN` also works in OUTFMT: writebin emits the
 8-byte length plus exactly the payload bytes (no padding), sourcing

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -319,7 +319,11 @@ every record starts with an 8-byte tag selecting an arm layout, and
 arms; the reader is a native tag switch dispatching per-arm field
 reads into one record buffer sized to the widest arm. Unknown tags
 and truncated arms exit with the read-error code; arms with no case
-block are still read and skipped, keeping the stream framed. (Assoc
+block are still read and skipped, keeping the stream framed. Rules may
+also lead with a tag guard instead: `TAG == 1 && $1 == "boom" { events++ }`
+is pure sugar for the same rule inside `case 1 { ... }` (identical IR);
+every rule must then lead with `TAG == K`, and tag tests under `||`/`!`
+or in non-leftmost position are rejected. (Assoc
 arrays and writebin inside case blocks are later slices.)
 `lpsN` also works in OUTFMT: writebin emits the
 8-byte length plus exactly the payload bytes (no padding), sourcing

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -94,6 +94,7 @@ swipl -q -s tests/test_plawk_varlen_records.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_varlen_writers.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tagged_unions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_bounded_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_rep_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
@@ -304,8 +305,12 @@ real runtime loop (loop-carried phis per scalar slot; the current
 element is staged into a hidden slot at the end of the record buffer
 so field accesses stay compile-time offsets), so code size is
 independent of the cap and rep64 costs the same IR as rep4. The wire
-read is one bulk count*elemsize read. Oversized counts and truncated element regions
-exit with the read-error code. Tagged unions let one stream carry several
+read is one bulk count*elemsize read for fixed-width elements; elements
+may also contain `lpsN` strings (`BINFMT = "i64 rep4(lps8 i64)"`), in
+which case the reader loops, parsing one variable-length element at a
+time into its fixed in-memory slot group, so `foreach` string guards
+and prints work unchanged. Oversized counts, oversized element strings,
+and truncated element regions exit with the read-error code. Tagged unions let one stream carry several
 record kinds: `BINFMT = "case(i64 f64 | lps16 i64)"` declares that
 every record starts with an 8-byte tag selecting an arm layout, and
 `case K { ... }` blocks hold ordinary pattern-action rules whose

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -631,6 +631,19 @@ carrying your counters around the loop in registers. Constant memory,
 and the code size does not depend on the cap — `rep64` compiles to
 the same loop as `rep4`.
 
+Elements can carry strings too. `BINFMT = "i64 rep4(lps8 i64)"`
+declares elements that each start with a length-prefixed name of up to
+8 bytes. On the wire every element can be a different size, so the
+reader parses them one at a time (each string lands in a fixed 8-byte
+slot, NUL-padded, exactly like a top-level `lps` field); inside
+`foreach`, string fields guard and print like any other:
+
+```awk
+BEGIN { BINFMT = "i64 rep4(lps8 i64)" }
+{ foreach { if ($1 == "hot") { hits++ }; total += $2 } }
+END { print hits, total }
+```
+
 ### Handing payloads to Prolog
 
 Everything so far was compiled to plain native code. But PLAWK lives

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -662,6 +662,10 @@ BEGIN { BINFMT = "i64 rep4(lps8 i64)" }
 END { print hits, total }
 ```
 
+Repetition also composes with tagged unions: an arm of a `case(...)`
+layout may carry its own `repK(...)`, and `foreach` inside that arm's
+rules (block or `TAG == K` spelling) iterates that arm's elements.
+
 ### Handing payloads to Prolog
 
 Everything so far was compiled to plain native code. But PLAWK lives

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -584,13 +584,31 @@ those." Scalars like `msum` and `events`, plus `NR`, `next`, `break`,
 and the END report, are shared across the blocks — there is still only
 one stream and one loop.
 
-Why blocks rather than writing the tag into each guard
-(`$0 == 1 && $1 == "boom"`)? Because the *types* of `$1, $2` depend on
-the arm: the compiler must know which arm a rule belongs to before it
-can decide whether `$1 == "boom"` is a string comparison or nonsense.
-With a block, that is decided by where the rule sits on the page. (The
-guard spelling can be added later as a shorthand that expands to a
-block.)
+Why blocks rather than writing the tag into each guard? Because the
+*types* of `$1, $2` depend on the arm: the compiler must know which arm
+a rule belongs to before it can decide whether `$1 == "boom"` is a
+string comparison or nonsense. With a block, that is decided by where
+the rule sits on the page.
+
+That said, for a program with only a rule or two per arm, a block per
+arm is ceremony. So the guard spelling exists as **shorthand**: a rule
+may lead with `TAG == K`, and it means exactly the same as putting the
+rest of the rule inside `case K { ... }`:
+
+```awk
+BEGIN { BINFMT = "case(i64 f64 | lps16 i64)" }
+TAG == 0 && $1 > 100 { msum += float($2) }
+TAG == 1 && $1 == "boom" { events++ }
+END { print msum, events }
+```
+
+This compiles to *identical* code as the block version — it is pure
+sugar, not a second mechanism. The one rule: the `TAG == K` test must
+come first in the guard (and every rule must have one), because it is
+what tells the compiler which arm's types the rest of the rule is
+checked against. `TAG == 0 || TAG == 1` is rejected for the same
+reason — such a rule would need two different type checks at once.
+Pick whichever spelling reads better; don't mix both in one program.
 
 ### What the compiled program actually does
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2040,10 +2040,14 @@ plawk_binfmt_type(Part, rep(Cap, ElemTypes)) :-
     exclude(==(""), ElemParts0, ElemParts),
     ElemParts \== [],
     maplist(plawk_binfmt_type, ElemParts, ElemTypes),
-    % elements must be fixed-width (no nested lps/rep) so the element
-    % region is one bulk read and one flat access layout
+    % Elements may be fixed-width (i64/f64/sN -> one bulk read of the
+    % whole region) or contain lpsN strings (variable wire size per
+    % element -> the reader loops, parsing one element at a time into
+    % its fixed in-memory slot group). Nested rep/blob stay out: the
+    % access layout must remain one flat fixed-offset slot group per
+    % element.
     forall(member(ElemType, ElemTypes),
-        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_) )).
+        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_) ; ElemType = lps(_) )).
 % blobN: a length-prefixed binary payload (8-byte length, then up to N
 % payload bytes) whose ONLY consumer is a compiled-Prolog foreign call:
 % the record loop stays native for framing and hands the payload to a
@@ -2778,7 +2782,7 @@ vr_tag_switch:
         ( nth0(Index, Arms, ArmTypes),
           format(atom(ArmPrefix), 'vr_a~w', [Index]),
           plawk_varlen_field_sections(ArmTypes, LoweredLabel, ArmPrefix,
-              no_eof, 0, 0, Sections),
+              no_eof, 0, rec, 0, Sections),
           atomic_list_concat(Sections, '\n', ArmBodyIR),
           format(atom(ArmIR), '~w:~n~w', [ArmPrefix, ArmBodyIR])
         ),
@@ -2860,14 +2864,17 @@ plawk_normalize_driver_blocks(Blocks, Blocks).
 %  zero the slot, then read the payload (a zero length reads nothing:
 %  @wam_stream_read_record returns 1 immediately for size 0).
 plawk_varlen_read_ir(Types, LoweredLabel, ReadIR) :-
-    plawk_varlen_field_sections(Types, LoweredLabel, vr, eof_first, 0, 0,
+    plawk_varlen_field_sections(Types, LoweredLabel, vr, eof_first, 0, rec, 0,
         Sections),
     atomic_list_concat(Sections, '\n', ReadIR).
 
+%  Base is the LLVM pointer register destinations gep from: 'rec' for
+%  record-level fields, or a rep loop's current-element base pointer
+%  (Offset is then relative to the element start).
 plawk_varlen_field_sections([], _LoweredLabel, _Prefix, _EofPolicy, _Index,
-        _Offset, []).
+        _Base, _Offset, []).
 plawk_varlen_field_sections([Type | Types], LoweredLabel, Prefix, EofPolicy,
-        Index, Offset, [Section | Sections]) :-
+        Index, Base, Offset, [Section | Sections]) :-
     ( Types == []
     -> NextLabel = LoweredLabel
     ;  NextIndex0 is Index + 1,
@@ -2882,20 +2889,22 @@ plawk_varlen_field_sections([Type | Types], LoweredLabel, Prefix, EofPolicy,
     -> FieldEof = eof
     ;  FieldEof = no_eof
     ),
-    plawk_varlen_field_body(Type, FBase, FieldEof, Offset, NextLabel, BodyIR),
+    plawk_varlen_field_body(Type, FBase, FieldEof, Base, Offset, NextLabel,
+        BodyIR),
     format(atom(Section), '~w~w', [LabelIR, BodyIR]),
     plawk_binfmt_type_width(Type, Width),
     NextOffset is Offset + Width,
     NextIndex is Index + 1,
     plawk_varlen_field_sections(Types, LoweredLabel, Prefix, EofPolicy,
-        NextIndex, NextOffset, Sections).
+        NextIndex, Base, NextOffset, Sections).
 
-plawk_varlen_field_body(blob(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+plawk_varlen_field_body(blob(Cap), FBase, FieldEof, Base, Offset, NextLabel,
+        BodyIR) :-
     !,
     PayloadOffset is Offset + 8,
     plawk_varlen_eof_check_ir(FieldEof, FBase, cstatus, BodyPrefixIR),
     format(atom(BodyIR),
-'  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+'  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
   %~w_cstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
 ~w  %~w_cok = icmp eq i64 %~w_cstatus, 1
   br i1 %~w_cok, label %~w_len, label %fail_read
@@ -2907,13 +2916,13 @@ plawk_varlen_field_body(blob(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :
   br i1 %~w_fits, label %~w_read, label %fail_read
 
 ~w_read:
-  %~w_pdst = getelementptr i8, i8* %rec, i64 ~w
+  %~w_pdst = getelementptr i8, i8* %~w, i64 ~w
   call void @llvm.memset.p0i8.i64(i8* %~w_pdst, i8 0, i64 ~w, i1 false)
   %~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %~w_n, i8* %~w_pdst)
   %~w_pok = icmp eq i64 %~w_pstatus, 1
   br i1 %~w_pok, label %~w, label %fail_read
 ',
-        [FBase, Offset,
+        [FBase, Base, Offset,
          FBase, FBase,
          BodyPrefixIR, FBase, FBase,
          FBase, FBase,
@@ -2923,12 +2932,90 @@ plawk_varlen_field_body(blob(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :
          FBase, FBase, Cap,
          FBase, FBase,
          FBase,
-         FBase, PayloadOffset,
+         FBase, Base, PayloadOffset,
          FBase, Cap,
          FBase, FBase, FBase,
          FBase, FBase,
          FBase, NextLabel]).
-plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+% rep whose elements contain lps strings: the wire size varies per
+% element, so the region cannot be one bulk read. Read the count, then
+% loop: each iteration parses one element's fields (through the same
+% field-body emitters, based at the current element's slot group), so
+% in-memory layout is identical to the fixed-element case and
+% everything downstream (field access, foreach staging) is unchanged.
+% Elements past the count stay zero from the region memset.
+plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Base, Offset,
+        NextLabel, BodyIR) :-
+    memberchk(lps(_ECap), ElemTypes),
+    !,
+    maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
+    sum_list(ElemWidths, ElemSize),
+    RegionSize is Cap * ElemSize,
+    ElemOffset is Offset + 8,
+    plawk_varlen_eof_check_ir(FieldEof, FBase, cstatus, BodyPrefixIR),
+    format(atom(HeaderIR),
+'  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
+  %~w_cstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
+~w  %~w_cok = icmp eq i64 %~w_cstatus, 1
+  br i1 %~w_cok, label %~w_len, label %fail_read
+
+~w_len:
+  %~w_ctp = bitcast i8* %~w_dst to i64*
+  %~w_n = load i64, i64* %~w_ctp
+  %~w_fits = icmp ule i64 %~w_n, ~w
+  br i1 %~w_fits, label %~w_read, label %fail_read
+
+~w_read:
+  %~w_edst = getelementptr i8, i8* %~w, i64 ~w
+  call void @llvm.memset.p0i8.i64(i8* %~w_edst, i8 0, i64 ~w, i1 false)
+  br label %~w_lh
+
+~w_lh:
+  %~w_j = phi i64 [ 1, %~w_read ], [ %~w_jn, %~w_ld ]
+  %~w_cont = icmp sle i64 %~w_j, %~w_n
+  br i1 %~w_cont, label %~w_lb, label %~w
+
+~w_lb:
+  %~w_jm1 = sub i64 %~w_j, 1
+  %~w_rel = mul i64 %~w_jm1, ~w
+  %~w_eb = getelementptr i8, i8* %~w_edst, i64 %~w_rel
+',
+        [FBase, Base, Offset,
+         FBase, FBase,
+         BodyPrefixIR, FBase, FBase,
+         FBase, FBase,
+         FBase,
+         FBase, FBase,
+         FBase, FBase,
+         FBase, FBase, Cap,
+         FBase, FBase,
+         FBase,
+         FBase, Base, ElemOffset,
+         FBase, RegionSize,
+         FBase,
+         FBase,
+         FBase, FBase, FBase, FBase,
+         FBase, FBase, FBase,
+         FBase, FBase, NextLabel,
+         FBase,
+         FBase, FBase,
+         FBase, FBase, ElemSize,
+         FBase, FBase, FBase]),
+    format(atom(ElemPrefix), '~w_e', [FBase]),
+    format(atom(ElemBase), '~w_eb', [FBase]),
+    format(atom(DoneLabel), '~w_ld', [FBase]),
+    plawk_varlen_field_sections(ElemTypes, DoneLabel, ElemPrefix, no_eof, 0,
+        ElemBase, 0, ElemSections),
+    atomic_list_concat(ElemSections, '\n', ElemsIR),
+    format(atom(FooterIR),
+'~w_ld:
+  %~w_jn = add i64 %~w_j, 1
+  br label %~w_lh
+',
+        [FBase, FBase, FBase, FBase]),
+    atomic_list_concat([HeaderIR, ElemsIR, FooterIR], '\n', BodyIR).
+plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Base, Offset,
+        NextLabel, BodyIR) :-
     !,
     maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
     sum_list(ElemWidths, ElemSize),
@@ -2936,7 +3023,7 @@ plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Offset, NextLabel,
     ElemOffset is Offset + 8,
     plawk_varlen_eof_check_ir(FieldEof, FBase, cstatus, BodyPrefixIR),
     format(atom(BodyIR),
-'  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+'  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
   %~w_cstatus = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
 ~w  %~w_cok = icmp eq i64 %~w_cstatus, 1
   br i1 %~w_cok, label %~w_len, label %fail_read
@@ -2948,14 +3035,14 @@ plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Offset, NextLabel,
   br i1 %~w_fits, label %~w_read, label %fail_read
 
 ~w_read:
-  %~w_edst = getelementptr i8, i8* %rec, i64 ~w
+  %~w_edst = getelementptr i8, i8* %~w, i64 ~w
   call void @llvm.memset.p0i8.i64(i8* %~w_edst, i8 0, i64 ~w, i1 false)
   %~w_bytes = mul i64 %~w_n, ~w
   %~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %~w_bytes, i8* %~w_edst)
   %~w_pok = icmp eq i64 %~w_pstatus, 1
   br i1 %~w_pok, label %~w, label %fail_read
 ',
-        [FBase, Offset,
+        [FBase, Base, Offset,
          FBase, FBase,
          BodyPrefixIR, FBase, FBase,
          FBase, FBase,
@@ -2965,13 +3052,14 @@ plawk_varlen_field_body(rep(Cap, ElemTypes), FBase, FieldEof, Offset, NextLabel,
          FBase, FBase, Cap,
          FBase, FBase,
          FBase,
-         FBase, ElemOffset,
+         FBase, Base, ElemOffset,
          FBase, RegionSize,
          FBase, FBase, ElemSize,
          FBase, FBase, FBase,
          FBase, FBase,
          FBase, NextLabel]).
-plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Base, Offset, NextLabel,
+        BodyIR) :-
     !,
     plawk_varlen_eof_check_ir(FieldEof, FBase, lstatus, BodyPrefixIR),
     format(atom(BodyIR),
@@ -2985,7 +3073,7 @@ plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
   br i1 %~w_fits, label %~w_read, label %fail_read
 
 ~w_read:
-  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
   call void @llvm.memset.p0i8.i64(i8* %~w_dst, i8 0, i64 ~w, i1 false)
   %~w_pstatus = call i64 @wam_stream_read_record(%Value %handle, i64 %~w_n, i8* %~w_dst)
   %~w_pok = icmp eq i64 %~w_pstatus, 1
@@ -2999,20 +3087,37 @@ plawk_varlen_field_body(lps(Cap), FBase, FieldEof, Offset, NextLabel, BodyIR) :-
          FBase, FBase, Cap,
          FBase, FBase,
          FBase,
-         FBase, Offset,
+         FBase, Base, Offset,
          FBase, Cap,
          FBase, FBase, FBase,
          FBase, FBase,
          FBase, NextLabel]).
-plawk_varlen_field_body(_NumericType, FBase, FieldEof, Offset, NextLabel, BodyIR) :-
+% sN is fixed on the wire (exactly N bytes, NUL-padded by the writer),
+% so it reads straight into its slot.
+plawk_varlen_field_body(s(Width), FBase, FieldEof, Base, Offset, NextLabel,
+        BodyIR) :-
+    !,
     plawk_varlen_eof_check_ir(FieldEof, FBase, status, BodyPrefixIR),
     format(atom(BodyIR),
-'  %~w_dst = getelementptr i8, i8* %rec, i64 ~w
+'  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
+  %~w_status = call i64 @wam_stream_read_record(%Value %handle, i64 ~w, i8* %~w_dst)
+~w  %~w_ok = icmp eq i64 %~w_status, 1
+  br i1 %~w_ok, label %~w, label %fail_read
+',
+        [FBase, Base, Offset,
+         FBase, Width, FBase,
+         BodyPrefixIR, FBase, FBase,
+         FBase, NextLabel]).
+plawk_varlen_field_body(_NumericType, FBase, FieldEof, Base, Offset, NextLabel,
+        BodyIR) :-
+    plawk_varlen_eof_check_ir(FieldEof, FBase, status, BodyPrefixIR),
+    format(atom(BodyIR),
+'  %~w_dst = getelementptr i8, i8* %~w, i64 ~w
   %~w_status = call i64 @wam_stream_read_record(%Value %handle, i64 8, i8* %~w_dst)
 ~w  %~w_ok = icmp eq i64 %~w_status, 1
   br i1 %~w_ok, label %~w, label %fail_read
 ',
-        [FBase, Offset,
+        [FBase, Base, Offset,
          FBase, FBase,
          BodyPrefixIR, FBase, FBase,
          FBase, NextLabel]).

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1992,8 +1992,9 @@ plawk_begin_union_arms(BeginClauses, Arms) :-
     maplist(plawk_union_arm_types, ArmStrs, Arms).
 
 plawk_union_arm_types(ArmStr, Types) :-
-    split_string(ArmStr, " ", " ", Parts0),
-    exclude(==(""), Parts0, Parts),
+    % the shared tokenizer joins parenthesized types, so an arm can
+    % carry a rep: "case(i64 rep4(lps8 i64) | lps16 i64)"
+    plawk_binfmt_tokens(ArmStr, Parts),
     Parts \== [],
     maplist(plawk_binfmt_type, Parts, Types).
 
@@ -2775,12 +2776,16 @@ plawk_pattern_strip_tag(and_pat(Left0, Right), Tag, and_pat(Left, Right)) :-
 %
 %  Flatten case blocks into one rule chain, stamping each rule with
 %  arm_pat(Tag, ArmTypes, Pattern) so guards check the record tag and
-%  everything downstream types fields against the right arm.
+%  everything downstream types fields against the right arm. foreach
+%  resolves per arm against that arm's own layout (each arm may carry
+%  its own rep), so a case block iterates its arm's elements.
 plawk_union_flatten_rules(CaseBlocks, Arms, Rules) :-
     findall(rule(arm_pat(Index, ArmTypes, Pattern), Actions),
         ( member(case_arm(Index, ArmRules), CaseBlocks),
           nth0(Index, Arms, ArmTypes),
-          member(rule(Pattern, Actions), ArmRules)
+          plawk_resolve_foreach_rules(binfmt(ArmTypes), ArmRules,
+              ResolvedRules),
+          member(rule(Pattern, Actions), ResolvedRules)
         ),
         Rules),
     Rules \== [].
@@ -2792,7 +2797,9 @@ plawk_union_program_ok(Arms, CaseBlocks) :-
           Index >= 0,
           Index < ArmCount,
           nth0(Index, Arms, ArmTypes),
-          forall(member(rule(Pattern, Actions), ArmRules),
+          plawk_resolve_foreach_rules(binfmt(ArmTypes), ArmRules,
+              ResolvedRules),
+          forall(member(rule(Pattern, Actions), ResolvedRules),
               ( plawk_binfmt_pattern_ok(binfmt(ArmTypes), Pattern),
                 plawk_binfmt_actions_ok(binfmt(ArmTypes), Actions)
               ))

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -210,6 +210,28 @@ plawk_program_native_driver_ir(
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% Tag-guard sugar: with a union BINFMT, plain rules whose patterns lead
+% with TAG == K are shorthand for case blocks -- the tag test selects
+% the arm and the rest of the pattern stays as the rule's own guard, so
+%   TAG == 0 && $1 > 10 { hits++ }
+% means exactly
+%   case 0 { $1 > 10 { hits++ } }.
+% Every rule must lead with a tag guard (an unguarded rule has no arm
+% to type its fields against), and the tag test may appear nowhere
+% else; otherwise the program is rejected.
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules, EndClauses),
+    InputPath,
+    DriverIR
+) :-
+    is_list(Rules),
+    plawk_record_descriptor(BeginClauses, binfmt_union(_Arms)),
+    plawk_tag_rules_case_blocks(Rules, CaseBlocks),
+    !,
+    plawk_program_native_driver_ir(
+        program(BeginClauses, case_blocks(CaseBlocks), EndClauses),
+        InputPath, DriverIR).
+
 % Tagged-union programs: BINFMT = "case(arm0 | arm1 | ...)" plus
 % case K { rules } blocks. Case blocks flatten into one scalar rule
 % chain where each rule's guard checks the record tag before its own
@@ -2722,6 +2744,32 @@ plawk_foreach_shift_term(Base, Term, Shifted) :-
     maplist(plawk_foreach_shift_term(Base), Args, ShiftedArgs),
     Shifted =.. [Functor | ShiftedArgs].
 plawk_foreach_shift_term(_Base, Term, Term).
+
+%% plawk_tag_rules_case_blocks(+Rules, -CaseBlocks)
+%
+%  Desugar TAG-guarded rules into case blocks, one single-rule arm
+%  block per rule (duplicate arm indexes are fine: flattening walks the
+%  blocks in order, so source rule order is preserved). Fails -- and
+%  the program is rejected -- when any rule lacks a leading tag guard
+%  or mentions TAG anywhere else in its pattern.
+plawk_tag_rules_case_blocks(Rules, CaseBlocks) :-
+    Rules = [_ | _],
+    maplist(plawk_tag_rule_case_arm, Rules, CaseBlocks).
+
+plawk_tag_rule_case_arm(rule(Pattern0, Actions),
+        case_arm(Tag, [rule(Pattern, Actions)])) :-
+    plawk_pattern_strip_tag(Pattern0, Tag, Pattern),
+    \+ ( sub_term(Sub, Pattern), nonvar(Sub), Sub = tag_pat(_) ).
+
+% The tag test must be the leftmost conjunct of a left-associated &&
+% chain: TAG == K alone selects the arm (residual guard `always`), and
+% TAG == K && P keeps P as the rule's own guard. A tag test under ||,
+% !, or anywhere deeper has no single-arm meaning and is rejected.
+plawk_pattern_strip_tag(tag_pat(Tag), Tag, always).
+plawk_pattern_strip_tag(and_pat(tag_pat(Tag), Residual), Tag, Residual) :-
+    !.
+plawk_pattern_strip_tag(and_pat(Left0, Right), Tag, and_pat(Left, Right)) :-
+    plawk_pattern_strip_tag(Left0, Tag, Left).
 
 %% plawk_union_flatten_rules(+CaseBlocks, +Arms, -Rules)
 %

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -178,7 +178,28 @@ base_pattern(Pattern) -->
     field_eq_pattern(Pattern),
     !.
 base_pattern(Pattern) -->
+    tag_eq_pattern(Pattern),
+    !.
+base_pattern(Pattern) -->
     prolog_guard_pattern(Pattern).
+
+%% tag_eq_pattern(-Pattern)//
+%
+%  TAG == K guards a rule by the record tag of a tagged-union layout.
+%  Surface sugar: the codegen groups TAG-guarded rules into the same
+%  per-arm case blocks that `case K { ... }` produces, so the tag test
+%  must be the leftmost conjunct of the rule's pattern.
+tag_eq_pattern(tag_pat(Tag)) -->
+    "TAG",
+    identifier_boundary,
+    ws,
+    "==",
+    ws,
+    integer_codes(TagCodes),
+    { TagCodes \== [],
+      number_codes(Tag, TagCodes),
+      Tag >= 0
+    }.
 
 %% prolog_guard_pattern(-Pattern)//
 %

--- a/tests/test_plawk_bounded_rep.pl
+++ b/tests/test_plawk_bounded_rep.pl
@@ -57,8 +57,8 @@ test(rep_rejections) :-
         "BEGIN { BINFMT = \"i64 rep4(i64)\" } { foreach { s += $2 } } END { print s }\n",
         % one rep per layout in this slice
         "BEGIN { BINFMT = \"rep2(i64) rep2(i64)\" } { foreach { n++ } } END { print n }\n",
-        % elements must be fixed-width
-        "BEGIN { BINFMT = \"rep2(lps8)\" } { foreach { n++ } } END { print n }\n"
+        % no blob elements (a blob's only consumer is a foreign call)
+        "BEGIN { BINFMT = \"rep2(blob8)\" } { foreach { n++ } } END { print n }\n"
     ],
     forall(member(Source, Rejects),
         ( plawk_parse_string(Source, Program)

--- a/tests/test_plawk_rep_strings.pl
+++ b/tests/test_plawk_rep_strings.pl
@@ -1,0 +1,181 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_rls_marker/0.
+
+user:plawk_rls_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_rep_strings, [condition(clang_available)]).
+
+test(rep_with_lps_elements_reads_element_by_element) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" } { foreach { total += $2 } } END { print total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % 8 id + 8 count + 4*16 elements + 16 staging
+    assertion(once(sub_atom(DriverIR, _, _, _, 'malloc(i64 96)'))),
+    % a per-element read loop, not one bulk region read
+    assertion(once(sub_atom(DriverIR, _, _, _, 'vr_f1_lh:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_f1_j = phi i64 [ 1, %vr_f1_read ]'))),
+    % the element's lps string parses through the shared length scratch
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_f1_e_f0_lstatus'))),
+    % and its i64 sibling reads relative to the current element base
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i8* %vr_f1_eb, i64 8'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '_bytes = mul')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(rep_with_fixed_elements_keeps_bulk_read) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(s8 i64)\" } { foreach { total += $2 } } END { print total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_bytes = mul'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'vr_f1_lh:')),
+    !.
+
+test(toplevel_s_field_reads_its_exact_width) :-
+    plawk_parse_string("BEGIN { BINFMT = \"s4 lps8\" } $1 == \"abcd\" { c++ } END { print c }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % 4 wire bytes for s4, not a hardcoded 8
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 4, i8* %vr_f0_dst'))),
+    !.
+
+test(surface_foreach_string_guard_aggregates) :-
+    run_rls_smoke("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" } $1 > 0 { recs++ } { foreach { if ($1 == \"hot\") { hits++ }; total += $2 } } END { print recs, hits, total }\n",
+        [rec(1, [e("hot", 5), e("cold", 7)]),
+         rec(2, []),
+         rec(3, [e("warm", 1), e("hot", 2), e("hotx", 3), e("full8chr", 4)])],
+        "3 2 22\n").
+
+test(surface_foreach_prints_element_strings) :-
+    run_rls_smoke("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" } { foreach { print $1, $2 } } END { print done }\n",
+        [rec(1, [e("hot", 5), e("", 7), e("full8chr", 9)])],
+        "hot 5\n 7\nfull8chr 9\n0\n").
+
+test(surface_toplevel_s_field_equality) :-
+    build_rls_probe("BEGIN { BINFMT = \"s4 lps8\" } $1 == \"abcd\" { c++ } END { print c }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_raw(InputPath, [bytes("abcd"), i64(1), bytes("x"),
+                          bytes("efgh"), i64(2), bytes("yy")]),
+    run_capture_raw(BinPath, Out, exit(0)),
+    assertion(Out == "1\n"),
+    !.
+
+test(surface_rep_lps_error_paths) :-
+    build_rls_probe("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" } { foreach { total += $2 } } END { print total }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    % element string longer than its cap (9 > 8)
+    write_raw(InputPath, [i64(1), i64(1), i64(9), bytes("ninechars"), i64(5)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % count above the rep cap (5 > 4)
+    write_raw(InputPath, [i64(1), i64(5)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % truncated element payload (claims 6, has 2)
+    write_raw(InputPath, [i64(1), i64(1), i64(6), bytes("ab")]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % EOF between elements (count 2, one element present)
+    write_raw(InputPath, [i64(1), i64(2), i64(3), bytes("abc"), i64(5)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % empty input is a clean EOF: END runs
+    write_raw(InputPath, []),
+    run_capture_raw(BinPath, Out, exit(0)),
+    assertion(Out == "0\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_raw(Path, Items) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Item, Items),
+            ( Item = i64(V) -> write_i64_le(Out, V)
+            ; Item = bytes(S) -> ( string_codes(S, Cs),
+                                   forall(member(C, Cs), put_byte(Out, C)) )
+            )),
+        close(Out)).
+
+% one record: i64 id, i64 count, then per element an lps8 (i64 length +
+% payload) and an i64 value
+write_rls_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(Id, Elems), Recs),
+            ( write_i64_le(Out, Id),
+              length(Elems, Count),
+              write_i64_le(Out, Count),
+              forall(member(e(S, V), Elems),
+                  ( string_codes(S, Codes),
+                    length(Codes, Len),
+                    write_i64_le(Out, Len),
+                    forall(member(C, Codes), put_byte(Out, C)),
+                    write_i64_le(Out, V) )) )),
+        close(Out)).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_rls_marker/0 ],
+        [module_name('plawk_rep_strings')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk rep strings build output]~n~w~n", [BuildOut]),
+       throw(plawk_rep_strings_build_failed(Status))
+    ).
+
+build_rls_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_rep_strings', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_capture_raw(BinPath, Bytes, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+run_rls_smoke(Source, Recs, ExpectedOutput) :-
+    build_rls_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_rls_records(InputPath, Recs),
+    run_capture_raw(BinPath, OutStr, exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.
+
+:- end_tests(plawk_rep_strings).

--- a/tests/test_plawk_tagged_unions.pl
+++ b/tests/test_plawk_tagged_unions.pl
@@ -87,6 +87,43 @@ test(surface_union_endless_program) :-
         [m(1, 1.0), e("aa", 5), e("bb", 6)],
         "aa 5\nbb 6\n").
 
+test(tag_guard_sugar_matches_case_blocks_exactly) :-
+    % TAG == K && P is pure sugar: it must compile to byte-identical IR
+    % as the case-block spelling.
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } TAG == 1 && $2 > 5 { b++ } END { print b }\n", Sugar),
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 1 { $2 > 5 { b++ } } END { print b }\n", Blocks),
+    plawk_program_native_driver_ir(Sugar, 'input.bin', SugarIR),
+    plawk_program_native_driver_ir(Blocks, 'input.bin', BlocksIR),
+    assertion(SugarIR == BlocksIR),
+    !.
+
+test(tag_guard_rejections) :-
+    Rejects = [
+        % every rule must lead with a tag guard (an unguarded rule has
+        % no arm to type its fields against)
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } TAG == 0 { a++ } { b++ } END { print a, b }\n",
+        % a tag test under || has no single-arm meaning
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } TAG == 0 || TAG == 1 { a++ } END { print a }\n",
+        % ... nor one that is not the leftmost conjunct
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } $1 > 3 && TAG == 0 { a++ } END { print a }\n",
+        % tag beyond the declared arms
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } TAG == 5 { a++ } END { print a }\n",
+        % TAG guards demand a union BINFMT
+        "BEGIN { BINFMT = \"i64 i64\" } TAG == 0 { a++ } END { print a }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_tag_guard_dispatch) :-
+    % The case-block dispatch test, respelled with tag guards --
+    % including rules for different arms interleaved in source order.
+    run_tun_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } TAG == 0 && $1 > 100 { msum += float($2) ; mhits++ } TAG == 1 && $2 == 7 { print $1 } TAG == 1 && $1 == \"boom\" { events++ } END { print mhits, msum, events }\n",
+        [m(50, 1.5), e("hello", 7), m(200, 2.5), e("boom", 3), m(300, 0.25), e("boom", 7)],
+        "hello\nboom\n2 2.75 2\n").
+
 test(surface_union_error_paths) :-
     build_tun_probe("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { { c++ } } END { print c }\n",
         Dir, BinPath),

--- a/tests/test_plawk_union_rep.pl
+++ b/tests/test_plawk_union_rep.pl
@@ -1,0 +1,166 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_urp_marker/0.
+
+user:plawk_urp_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_union_rep, [condition(clang_available)]).
+
+test(rep_arm_sizes_buffer_and_reads_in_arm) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 rep4(i64 f64) | lps16 i64)\" } case 0 { { foreach { n++ } } } END { print n }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % widest arm: 8 id + 8 count + 4*16 elems + 16 staging = 96
+    assertion(once(sub_atom(DriverIR, _, _, _, 'malloc(i64 96)'))),
+    % the rep reads inside arm 0's field sequence (bulk read: fixed
+    % elements), and foreach is the runtime loop
+    assertion(once(sub_atom(DriverIR, _, _, _, '%vr_a0_f1_bytes = mul i64 %vr_a0_f1_n, 16'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_j = phi i64 [1, %'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(rep_arm_rejections) :-
+    Rejects = [
+        % foreach needs a rep in ITS arm (arm 1 has none)
+        "BEGIN { BINFMT = \"case(i64 rep4(i64) | lps16 i64)\" } case 1 { { foreach { n++ } } } END { print n }\n",
+        % element arity still checked per arm ($3 in a 2-field element)
+        "BEGIN { BINFMT = \"case(i64 rep4(i64 f64) | i64)\" } case 0 { { foreach { s += $3 } } } END { print s }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_rep_arm_foreach_dispatch) :-
+    % Arm 0 records carry element lists that foreach aggregates; arm 1
+    % events are guarded per record -- one loop, shared END.
+    run_urp_smoke("BEGIN { BINFMT = \"case(i64 rep4(i64 f64) | lps16 i64)\" } case 0 { $1 > 0 { foreach { n++ ; wsum += float($2) } } } case 1 { $1 == \"boom\" { events++ } } END { print n, wsum, events }\n",
+        [ [i64(0), i64(1), i64(2), i64(5), f64(1.5), i64(20), f64(2.5)],
+          [i64(1), i64(4), bytes("boom"), i64(3)],
+          [i64(0), i64(2), i64(0)],
+          [i64(1), i64(1), bytes("x"), i64(7)],
+          [i64(0), i64(3), i64(1), i64(30), f64(0.25)] ],
+        "3 4.25 1\n").
+
+test(surface_rep_lps_arm_with_tag_guards) :-
+    % All three slices composed: tag-guard sugar, a rep arm, and lps
+    % strings inside the rep's elements.
+    run_urp_smoke("BEGIN { BINFMT = \"case(rep4(lps8 i64) | i64)\" } TAG == 0 { foreach { if ($1 == \"hot\") { hits++ }; total += $2 } } TAG == 1 { other++ } END { print hits, total, other }\n",
+        [ [i64(0), i64(2), i64(3), bytes("hot"), i64(5), i64(4), bytes("cool"), i64(7)],
+          [i64(1), i64(99)],
+          [i64(0), i64(1), i64(3), bytes("hot"), i64(2)] ],
+        "2 14 1\n").
+
+test(surface_rep_arm_error_paths) :-
+    build_urp_probe("BEGIN { BINFMT = \"case(i64 rep4(i64 f64) | lps16 i64)\" } case 0 { { foreach { n++ } } } END { print n }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    % count above the rep cap inside arm 0
+    write_items(InputPath, [i64(0), i64(1), i64(5)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % truncated element region (count 2, one element present)
+    write_items(InputPath, [i64(0), i64(1), i64(2), i64(5), f64(1.5)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % unknown tag
+    write_items(InputPath, [i64(9)]),
+    run_capture_raw(BinPath, _, exit(11)),
+    % clean EOF at a record boundary runs END
+    write_items(InputPath, []),
+    run_capture_raw(BinPath, Out, exit(0)),
+    assertion(Out == "0\n"),
+    !.
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,  0x3FF8000000000000).
+double_bits(2.5,  0x4004000000000000).
+double_bits(0.25, 0x3FD0000000000000).
+
+write_items(Path, Items) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Item, Items), write_item(Out, Item)),
+        close(Out)).
+
+write_item(Out, i64(V)) :-
+    write_i64_le(Out, V).
+write_item(Out, f64(F)) :-
+    double_bits(F, Bits),
+    write_i64_le(Out, Bits).
+write_item(Out, bytes(S)) :-
+    string_codes(S, Cs),
+    forall(member(C, Cs), put_byte(Out, C)).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_urp_marker/0 ],
+        [module_name('plawk_union_rep')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk union rep build output]~n~w~n", [BuildOut]),
+       throw(plawk_union_rep_build_failed(Status))
+    ).
+
+build_urp_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_union_rep', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath).
+
+run_capture_raw(BinPath, Bytes, ExpectedStatus) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == ExpectedStatus).
+
+% each record is spelled as a flat item list (tag first)
+run_urp_smoke(Source, Records, ExpectedOutput) :-
+    build_urp_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    append(Records, Items),
+    write_items(InputPath, Items),
+    run_capture_raw(BinPath, OutStr, exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.
+
+:- end_tests(plawk_union_rep).


### PR DESCRIPTION
## Why

The round-3 stack merged branch-to-branch rather than reaching main: #3433 landed on this branch, #3434 landed on the #3433 branch, and #3435 landed on the #3434 branch. This PR reassembles all three on the designated branch (plus a sync merge of main) and carries them the last step. No new content. **Merge first** — this round's feature PRs stack on top.

Contents: lps strings inside rep elements (per-element read loop), TAG == K guard sugar for case blocks, rep inside tagged-union arms. Full regression sweep re-run on the assembled branch: all 44 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_