### PR TITLE
plawk: f64 marshaling across the foreign bridge

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -165,10 +165,15 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    no interning) and marshals it as the transient atom, which the
    compiled predicate reads with `atom_codes/2` and parses with an
    ordinary WAM DCG — real choice points and all. i64 fields marshal
-   as WAM integers (a typed load, no text). Constraints: one blob
-   argument per call (one shared buffer), NUL-free payloads (the
-   transient atom is a C string), f64 marshaling and blob output are
-   later slices.
+   as WAM integers and f64 fields as WAM floats (typed loads, no text;
+   the f64 packs its bits under the Float tag via `@value_float`).
+   Double-returning calls (landed) are spelled `float(name(args))`:
+   the site calls a `{double, ok}` wrapper that accepts an Integer or
+   Float output and promotes via `@value_to_double`; a failed call
+   contributes 0.0, and the written scalar types as a double through
+   the ordinary slot-type fixpoint. Constraints: one blob argument per
+   call (one shared buffer), NUL-free payloads (the transient atom is
+   a C string), blob output is a later slice.
 
 ## Known design debt
 

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -97,6 +97,7 @@ swipl -q -s tests/test_plawk_bounded_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/
 swipl -q -s tests/test_plawk_rep_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_f64_foreign.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -294,8 +295,12 @@ only consumer is a compiled Prolog predicate - the loop frames records
 natively, and `total += payload_sum($2)` hands the payload bytes to a
 WAM-compiled DCG through the ~0.2us foreign bridge (constant memory:
 the payload rides the shared transient atom, no interning). i64 fields
-marshal as WAM integers in binary mode, so foreign guards and calls now
-work over binary records generally. One blob argument per call;
+marshal as WAM integers and f64 fields as WAM floats in binary mode, so
+foreign guards and calls work over binary records generally; a
+double-returning call is spelled `wsum += float(score($1, $2))` (the
+float(...) wrapper selects a {double, ok} bridge that accepts Integer
+or Float results, keeping fractions that the i64 spelling would
+truncate; a failed call contributes 0.0). One blob argument per call;
 payloads are NUL-free byte strings. Bounded repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -687,3 +687,18 @@ the native loop does the framing (find each record, check lengths,
 skip what doesn't match), and Prolog does the understanding. The
 hand-off costs about 0.2 microseconds and no memory growth - the
 payload travels in a single reused buffer.
+
+Numbers cross the bridge in both directions and both widths: `i64`
+fields arrive in Prolog as integers, `f64` fields as floats. When the
+predicate's answer is itself fractional, wrap the call in `float(...)`:
+
+```awk
+BEGIN { BINFMT = "i64 f64" }
+{ wsum += float(weight($1, $2)) }
+END { print wsum }
+```
+
+Without the wrapper a call is an integer expression (fractions would
+be truncated); with it, the result stays a double - whether the
+predicate bound an integer or a float. A call that fails contributes
+`0.0`, mirroring awk's forgiving arithmetic.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4,7 +4,8 @@
 :- module(plawk_native_codegen, [
     plawk_program_native_driver_ir/3,
     plawk_program_native_driver_ir/4,
-    plawk_program_foreign_specs/3
+    plawk_program_foreign_specs/3,
+    plawk_program_foreign_specs/4
 ]).
 
 :- discontiguous plawk_pattern_guard_ir/5.
@@ -417,25 +418,32 @@ plawk_program_native_driver_ir(
 %  emitters need no VM plumbing. Programs with no foreign calls
 %  delegate to plawk_program_native_driver_ir/3 unchanged.
 plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
-    plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs),
+    plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs, FCallSpecs),
     (   GuardSpecs == [],
-        CallSpecs == []
+        CallSpecs == [],
+        FCallSpecs == []
     ->  plawk_program_native_driver_ir(Program, InputPath, DriverIR)
     ;   memberchk(wam_vm(InstrCount, LabelCount), Options),
-        plawk_foreign_support_ir(GuardSpecs, CallSpecs, InstrCount, LabelCount,
-            SupportIR),
+        plawk_foreign_support_ir(GuardSpecs, CallSpecs, FCallSpecs,
+            InstrCount, LabelCount, SupportIR),
         plawk_program_native_driver_ir(Program, InputPath, MainIR),
         format(atom(DriverIR), '~w~n~n~w', [SupportIR, MainIR])
     ).
 
 %% plawk_program_foreign_specs(+Program, -GuardSpecs, -CallSpecs)
+%% plawk_program_foreign_specs(+Program, -GuardSpecs, -CallSpecs, -FCallSpecs)
 %
 %  Collect the deduplicated foreign predicate call shapes used by the
 %  program. GuardSpecs are Name-NArgs pairs called as rule guards
 %  (predicate arity NArgs); CallSpecs are Name-NArgs pairs called as
-%  i64 expressions (predicate arity NArgs + 1 for the output).
+%  i64 expressions and FCallSpecs Name-NArgs pairs called as double
+%  expressions via float(name(args)) (predicate arity NArgs + 1 for
+%  the output in both).
+plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs) :-
+    plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs, _FCallSpecs).
+
 plawk_program_foreign_specs(program(_BeginClauses, Rules, EndClauses),
-        GuardSpecs, CallSpecs) :-
+        GuardSpecs, CallSpecs, FCallSpecs) :-
     findall(Name-NArgs,
         ( member(rule(Pattern, _Actions), Rules),
           plawk_pattern_prolog_guard(Pattern, Name, Args),
@@ -451,6 +459,14 @@ plawk_program_foreign_specs(program(_BeginClauses, Rules, EndClauses),
         ),
         CallSpecs0),
     findall(Name-NArgs,
+        ( ( member(rule(_PatternF, FActions), Rules)
+          ; member(end(FActions), EndClauses)
+          ),
+          plawk_actions_prolog_fcall(FActions, Name, Args),
+          length(Args, NArgs)
+        ),
+        FCallSpecs0),
+    findall(Name-NArgs,
         ( member(rule(_Pattern2, Actions2), Rules),
           member(if(CondPattern, _Then, _Else), Actions2),
           plawk_pattern_prolog_guard(CondPattern, Name, Args),
@@ -459,7 +475,8 @@ plawk_program_foreign_specs(program(_BeginClauses, Rules, EndClauses),
         CondGuardSpecs0),
     append(GuardSpecs0, CondGuardSpecs0, AllGuardSpecs),
     sort(AllGuardSpecs, GuardSpecs),
-    sort(CallSpecs0, CallSpecs).
+    sort(CallSpecs0, CallSpecs),
+    sort(FCallSpecs0, FCallSpecs).
 
 plawk_pattern_prolog_guard(prolog_guard(Name, Args), Name, Args).
 plawk_pattern_prolog_guard(and_pat(Left, Right), Name, Args) :-
@@ -499,17 +516,48 @@ plawk_expr_prolog_call(Expr, Name, Args) :-
     ; plawk_expr_prolog_call(Right, Name, Args)
     ).
 
-%% plawk_foreign_support_ir(+GuardSpecs, +CallSpecs, +InstrCount, +LabelCount, -IR)
+% float(name(args)) call sites -- same walk, double-returning wrappers.
+plawk_actions_prolog_fcall(Actions, Name, Args) :-
+    member(Action, Actions),
+    plawk_action_prolog_fcall(Action, Name, Args).
+
+plawk_action_prolog_fcall(add(_Var, Expr), Name, Args) :-
+    plawk_expr_prolog_fcall(Expr, Name, Args).
+plawk_action_prolog_fcall(set(_Var, Expr), Name, Args) :-
+    plawk_expr_prolog_fcall(Expr, Name, Args).
+plawk_action_prolog_fcall(print(Fields), Name, Args) :-
+    member(Field, Fields),
+    plawk_expr_prolog_fcall(Field, Name, Args).
+plawk_action_prolog_fcall(printf(_Format, PrintfArgs), Name, Args) :-
+    member(Field, PrintfArgs),
+    plawk_expr_prolog_fcall(Field, Name, Args).
+plawk_action_prolog_fcall(if(_Pattern, ThenActions, ElseActions), Name, Args) :-
+    ( plawk_actions_prolog_fcall(ThenActions, Name, Args)
+    ; plawk_actions_prolog_fcall(ElseActions, Name, Args)
+    ).
+
+plawk_expr_prolog_fcall(float_call(Name, Args), Name, Args).
+plawk_expr_prolog_fcall(Expr, Name, Args) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_prolog_fcall(Left, Name, Args)
+    ; plawk_expr_prolog_fcall(Right, Name, Args)
+    ).
+
+%% plawk_foreign_support_ir(+GuardSpecs, +CallSpecs, +FCallSpecs,
+%%     +InstrCount, +LabelCount, -IR)
 %
 %  Emit the shared foreign-call support section: a lazily initialized
 %  process-wide %WamState plus one wrapper per called predicate. Guard
 %  wrappers return run_loop's success directly. Call wrappers push one
 %  unbound output cell, run the predicate, and return {value, ok};
-%  failure or a non-integer binding yields {0, false}. Both wrappers
+%  failure or a non-integer binding yields {0, false}. Float-call
+%  wrappers (float(name(args)) sites) accept an Integer or Float
+%  output and return {double, ok} via @value_to_double. All wrappers
 %  save and restore the VM heap top (WamState field 6) and rewind the
 %  arena via @wam_cleanup, so per-record foreign calls run in constant
 %  memory -- nothing WAM-side persists between plawk calls.
-plawk_foreign_support_ir(GuardSpecs, CallSpecs, InstrCount, LabelCount, IR) :-
+plawk_foreign_support_ir(GuardSpecs, CallSpecs, FCallSpecs, InstrCount,
+        LabelCount, IR) :-
     format(atom(VmIR),
 '@plawk_foreign_vm = internal global %WamState* null
 
@@ -543,7 +591,12 @@ make:
           plawk_foreign_call_wrapper_ir(Name, NArgs, CallIR)
         ),
         CallIRs),
-    append([[VmIR], GuardIRs, CallIRs], Parts),
+    findall(FCallIR,
+        ( member(Name-NArgs, FCallSpecs),
+          plawk_foreign_fcall_wrapper_ir(Name, NArgs, FCallIR)
+        ),
+        FCallIRs),
+    append([[VmIR], GuardIRs, CallIRs, FCallIRs], Parts),
     atomic_list_concat(Parts, '\n\n', IR).
 
 plawk_foreign_wrapper_params(NArgs, ParamsIR) :-
@@ -642,6 +695,58 @@ fail:
   %f0 = insertvalue { i64, i1 } undef, i64 0, 0
   %f1 = insertvalue { i64, i1 } %f0, i1 false, 1
   ret { i64, i1 } %f1
+}',
+        [Name, NArgs, ParamsIR, Name, SetRegIR, NArgs]).
+
+% The double-returning variant behind float(name(args)): identical
+% shape, but the output cell may bind to an Integer or a Float --
+% @value_to_double promotes either to double.
+plawk_foreign_fcall_wrapper_ir(Name, NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_foreign_set_reg_lines(NArgs, SetRegLines),
+    atomic_list_concat(SetRegLines, '\n', SetRegIR),
+    format(atom(IR),
+'define { double, i1 } @plawk_foreign_fcall_~w_~w(~w) {
+entry:
+  %vm = call %WamState* @plawk_foreign_vm_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs_saved = load i32, i32* %hs_ptr
+  %pc = load i32, i32* @~w_start_pc
+  %unb = call %Value @value_unbound(i8* null)
+  %out_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %out_ref = call %Value @value_ref(i32 %out_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %pc)
+~w
+  call void @wam_set_reg(%WamState* %vm, i32 ~w, %Value %out_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %read_out, label %rewind_fail
+
+read_out:
+  %out = call %Value @wam_deref_value(%WamState* %vm, %Value %out_ref)
+  %out_is_num = call i1 @value_is_number(%Value %out)
+  br i1 %out_is_num, label %good, label %rewind_fail
+
+good:
+  %fval = call double @value_to_double(%Value %out)
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  %r0 = insertvalue { double, i1 } undef, double %fval, 0
+  %r1 = insertvalue { double, i1 } %r0, i1 true, 1
+  ret { double, i1 } %r1
+
+rewind_fail:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  br label %fail
+
+fail:
+  %f0 = insertvalue { double, i1 } undef, double 0.0, 0
+  %f1 = insertvalue { double, i1 } %f0, i1 false, 1
+  ret { double, i1 } %f1
 }',
         [Name, NArgs, ParamsIR, Name, SetRegIR, NArgs]).
 
@@ -1906,13 +2011,17 @@ plawk_binfmt_foreign_arg_ok(Descriptor, field(Index)) :-
     integer(Index),
     Index >= 1,
     plawk_binfmt_field_type(Descriptor, Index, Type),
-    ( Type == i64 ; Type = blob(_Cap) ),
+    ( Type == i64 ; Type == f64 ; Type = blob(_Cap) ),
     !.
 
 plawk_binfmt_f64_expr_ok(Descriptor, float_field(Index)) :-
     !,
     plawk_binfmt_field_type(Descriptor, Index, f64).
 plawk_binfmt_f64_expr_ok(_Descriptor, float_const(_Mantissa, _Denominator)) :- !.
+plawk_binfmt_f64_expr_ok(Descriptor, float_call(Name, Args)) :-
+    !,
+    atom(Name),
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
 plawk_binfmt_f64_expr_ok(Descriptor, Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
     !,
@@ -3938,6 +4047,8 @@ plawk_f64_scalar_read_operand_expr(float_const(Mantissa, Denominator)) :-
 plawk_f64_scalar_read_operand_expr(float_field(Index)) :-
     integer(Index),
     Index >= 0.
+plawk_f64_scalar_read_operand_expr(float_call(Name, Args)) :-
+    plawk_prolog_call_expr(prolog_call(Name, Args)).
 plawk_f64_scalar_read_operand_expr(Expr) :-
     plawk_i64_operand_expr(Expr).
 plawk_f64_scalar_read_operand_expr(Expr) :-
@@ -4381,6 +4492,7 @@ plawk_i64_binary_op_lines(LLVMOp, Base, LeftIR, RightIR, [Line]) :-
 %  sitofp at emission time.
 plawk_expr_is_double(float_const(_Mantissa, _Denominator)).
 plawk_expr_is_double(float_field(_Index)).
+plawk_expr_is_double(float_call(_Name, _Args)).
 % A substituted read of a double scalar slot (see
 % plawk_substitute_scalar_reads/4).
 plawk_expr_is_double(ssa_f64(_Value)).
@@ -4438,6 +4550,27 @@ plawk_f64_expr_ir(float_field(Index), FieldSeparator, Base, _GlobalBase,
     format(atom(CallIR),
         '  ~w = call double @wam_atom_field_f64_value(%Value %line, i64 ~w, i8 ~w)',
         [ValueIR, Index, FieldSeparator]).
+% float(name(args)): the double-returning foreign call. A failed call
+% contributes 0.0, mirroring the i64 prolog_call contract.
+plawk_f64_expr_ir(float_call(Name, Args), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    !,
+    length(Args, NArgs),
+    plawk_foreign_args_ir(Args, FieldSeparator, GlobalBase, ArgValueIRs,
+        GlobalParts, ArgSetupParts),
+    plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
+    format(atom(ResIR),
+        '  %~w_res = call { double, i1 } @plawk_foreign_fcall_~w_~w(~w)',
+        [Base, Name, NArgs, CallArgsIR]),
+    format(atom(ValIR),
+        '  %~w_val = extractvalue { double, i1 } %~w_res, 0', [Base, Base]),
+    format(atom(OkIR),
+        '  %~w_ok = extractvalue { double, i1 } %~w_res, 1', [Base, Base]),
+    format(atom(SelIR),
+        '  %~w = select i1 %~w_ok, double %~w_val, double 0.0',
+        [Base, Base, Base]),
+    format(atom(ValueIR), '%~w', [Base]),
+    append(ArgSetupParts, [ResIR, ValIR, OkIR, SelIR], SetupParts).
 plawk_f64_expr_ir(Expr, FieldSeparator, Base, GlobalBase, ValueIR,
         GlobalParts, SetupParts) :-
     plawk_expr_is_double(Expr),
@@ -5020,6 +5153,21 @@ plawk_foreign_arg_ir(field(FieldIndex), binfmt(Types), ArgBase, ArgValueIR,
         LoadedIR, LoadLines),
     format(atom(ValueLine),
         '  %~w_v = call %Value @value_integer(i64 ~w)', [ArgBase, LoadedIR]),
+    format(atom(ArgValueIR), '%~w_v', [ArgBase]),
+    append(LoadLines, [ValueLine], SetupParts).
+% f64 fields marshal as WAM floats: a typed double load, then
+% @value_float packs the bits under the Float tag.
+plawk_foreign_arg_ir(field(FieldIndex), binfmt(Types), ArgBase, ArgValueIR,
+        [], SetupParts) :-
+    integer(FieldIndex),
+    FieldIndex >= 1,
+    plawk_binfmt_field_type(binfmt(Types), FieldIndex, f64),
+    !,
+    format(atom(LoadBase), '~w_bf', [ArgBase]),
+    plawk_binfmt_field_load_lines(binfmt(Types), FieldIndex, LoadBase,
+        LoadedIR, LoadLines),
+    format(atom(ValueLine),
+        '  %~w_v = call %Value @value_float(double ~w)', [ArgBase, LoadedIR]),
     format(atom(ArgValueIR), '%~w_v', [ArgBase]),
     append(LoadLines, [ValueLine], SetupParts).
 plawk_foreign_arg_ir(field(FieldIndex), binfmt(Types), ArgBase, ArgValueIR,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -662,6 +662,8 @@ scalar_delta_expr(Expr) -->
 scalar_delta_expr(Expr) -->
     float_field_expr(Expr).
 scalar_delta_expr(Expr) -->
+    float_call_expr(Expr).
+scalar_delta_expr(Expr) -->
     float_literal_expr(Expr).
 scalar_delta_expr(int(Value)) -->
     integer_codes(ValueCodes),
@@ -1015,6 +1017,22 @@ float_literal_expr(float_const(Mantissa, Denominator)) -->
       length(FracCodes, FracLen),
       Denominator is 10 ** FracLen
     }.
+
+%% float_call_expr(-Expr)//
+%
+%  float(name(args)): a compiled-Prolog call whose output argument is
+%  numeric and lands in a double context -- Float results keep their
+%  fraction (an i64-context call would truncate the surface to
+%  integers). The float(...) wrapper is what selects the
+%  double-returning wrapper at codegen time.
+float_call_expr(float_call(Name, Args)) -->
+    "float",
+    ws,
+    "(",
+    ws,
+    prolog_call_expr(prolog_call(Name, Args)),
+    ws,
+    ")".
 
 %% float_field_expr(-Expr)//
 %

--- a/tests/test_plawk_f64_foreign.pl
+++ b/tests/test_plawk_f64_foreign.pl
@@ -1,0 +1,160 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+% Compiled into the probe binary alongside the plawk driver.
+plawk_ff_wf(I, F, R) :- R is I * F.
+plawk_ff_bigf(F) :- F > 1.
+plawk_ff_posval(F, R) :- F > 0.0, R is F + F.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_f64_foreign, [condition(clang_available)]).
+
+test(f64_field_arg_marshals_as_wam_float) :-
+    build_ff_ir("BEGIN { BINFMT = \"i64 f64\" } plawk_ff_bigf($2) { hits++ } END { print hits }\n", DriverIR),
+    % a typed double load, then the Float constructor -- no text, no
+    % interning anywhere near the argument
+    assertion(once(sub_atom(DriverIR, _, _, _, '@value_float(double %'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value')),
+    !.
+
+test(float_call_uses_double_wrapper) :-
+    build_ff_ir("BEGIN { BINFMT = \"i64 f64\" } { wsum += float(plawk_ff_wf($1, $2)) } END { print wsum }\n", DriverIR),
+    % the double-returning wrapper: numeric-output check, promote via
+    % @value_to_double, {double, i1} contract, 0.0 on failure
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define { double, i1 } @plawk_foreign_fcall_plawk_ff_wf_2'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@value_is_number'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@value_to_double'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'double %'))),
+    % and the site selects 0.0 when the call fails
+    assertion(once(sub_atom(DriverIR, _, _, _, ', double 0.0'))),
+    !.
+
+test(f64_foreign_rejections) :-
+    Rejects = [
+        % $3 does not exist in the layout
+        "BEGIN { BINFMT = \"i64 f64\" } { wsum += float(plawk_ff_wf($1, $3)) } END { print wsum }\n",
+        % string fields still do not marshal in binary mode
+        "BEGIN { BINFMT = \"s8 f64\" } { wsum += float(plawk_ff_wf($1, $2)) } END { print wsum }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ build_ff_ir_for(Program, _))
+        ;  true
+        )).
+
+test(surface_float_call_and_float_guard) :-
+    % wf multiplies the i64 by the f64 in WAM arithmetic (Float
+    % result); bigf compares the f64 against an integer.
+    % (2,1.5) (3,0.25) (1,2.5): wsum = 3.0+0.75+2.5, hits = 2.
+    run_ff_smoke("BEGIN { BINFMT = \"i64 f64\" } { wsum += float(plawk_ff_wf($1, $2)) } plawk_ff_bigf($2) { hits++ } END { print hits, wsum }\n",
+        [rec(2, 1.5), rec(3, 0.25), rec(1, 2.5)],
+        "2 6.25\n").
+
+test(surface_failed_float_call_contributes_zero) :-
+    % posval fails on non-positive inputs: those records add 0.0.
+    % (1,1.5) (2,-2.5) (3,0.25): wsum = 3.0 + 0.0 + 0.5.
+    run_ff_smoke("BEGIN { BINFMT = \"i64 f64\" } { wsum += float(plawk_ff_posval($2)) } END { print wsum }\n",
+        [rec(1, 1.5), rec(2, -2.5), rec(3, 0.25)],
+        "3.5\n").
+
+:- end_tests(plawk_f64_foreign).
+
+% --- helpers ---------------------------------------------------------------
+
+ff_preds([ user:plawk_ff_wf/3,
+           user:plawk_ff_bigf/1,
+           user:plawk_ff_posval/2
+         ]).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,   0x3FF8000000000000).
+double_bits(0.25,  0x3FD0000000000000).
+double_bits(2.5,   0x4004000000000000).
+double_bits(-2.5,  0xC004000000000000).
+
+% rec(I64, F64)
+write_ff_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(I, F), Recs),
+            ( write_i64_le(Out, I),
+              double_bits(F, Bits),
+              write_i64_le(Out, Bits) )),
+        close(Out)).
+
+build_ff_ir(Source, DriverIR) :-
+    plawk_parse_string(Source, Program),
+    build_ff_ir_for(Program, DriverIR).
+
+build_ff_ir_for(Program, DriverIR) :-
+    once(( tmp_root(Root),
+           directory_file_path(Root, 'uw_plawk_f64_foreign_ir', Dir),
+           clean_dir(Dir),
+           make_directory_path(Dir),
+           directory_file_path(Dir, 'ir_probe.ll', LLPath),
+           ff_preds(Preds),
+           write_wam_llvm_project(Preds, [module_name('plawk_ff_ir')], LLPath),
+           wam_llvm_last_compile_counts(InstrCount, LabelCount) )),
+    plawk_program_native_driver_ir(Program, 'input.bin',
+        [wam_vm(InstrCount, LabelCount)], DriverIR).
+
+build_ff_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_f64_foreign', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    ff_preds(Preds),
+    write_wam_llvm_project(Preds, [module_name('plawk_f64_foreign')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_program_native_driver_ir(Program, InputPath,
+        [wam_vm(InstrCount, LabelCount)], DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk f64 foreign build output]~n~w~n", [BuildOut]),
+       throw(plawk_f64_foreign_build_failed(Status))
+    ).
+
+run_ff_smoke(Source, Recs, ExpectedOutput) :-
+    build_ff_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_ff_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.

--- a/tests/test_plawk_tier2_blob.pl
+++ b/tests/test_plawk_tier2_blob.pl
@@ -89,8 +89,8 @@ test(binfmt_i64_foreign_arg_is_value_integer) :-
 
 test(tier2_rejections) :-
     Rejects = [
-        % f64 fields are not marshalable in this slice
-        "BEGIN { BINFMT = \"f64 blob32\" } { t += plawk_payload_sum($1) } END { print t }\n",
+        % string fields are not marshalable in binary mode
+        "BEGIN { BINFMT = \"s8 blob32\" } { t += plawk_payload_sum($1) } END { print t }\n",
         % blob fields have no print/guard/arithmetic role
         "BEGIN { BINFMT = \"i64 blob32\" } { print $2 }\n",
         "BEGIN { BINFMT = \"i64 blob32\" } $2 == \"x\" { c++ } END { print c }\n",


### PR DESCRIPTION
## Summary

First slice of this round: numbers cross the WAM bridge in both directions and both widths. Previously only i64 fields (and blobs) could reach compiled Prolog; f64 fields were rejected, and a predicate binding a Float couldn't return it.

```awk
BEGIN { BINFMT = "i64 f64" }
{ wsum += float(weight($1, $2)) }   # f64 arg in, Float result back
bigf($2) { hits++ }                 # f64 arg in a guard
END { print hits, wsum }
```

## Design

- **Arguments:** f64 fields marshal as WAM floats — a typed double load, then the existing `@value_float` packs the bits under the Float tag (exactly mirroring the i64 `@value_integer` clause). Works in guards and call expressions.
- **Returns:** `float(name(args))` selects a new `{double, i1}` wrapper (`@plawk_foreign_fcall_*`) that accepts an Integer **or** Float output cell and promotes via the existing `@value_to_double`; a failed call contributes `0.0`, mirroring the i64 contract. Without the wrapper a call stays an i64 expression (fractions truncate) — the spelling is what picks the bridge, so nothing changes under existing programs.
- The written scalar types as a double through the ordinary slot-type fixpoint, and foreign spec collection gains a third list (`plawk_program_foreign_specs/4`; `/3` kept as a delegating wrapper).
- No runtime changes needed: `@value_float`, `@value_is_number`, and `@value_to_double` were already in the WAM runtime; WAM arithmetic (`R is I * F`) and comparisons (`F > 1`) handle floats.

## Tests

New `tests/test_plawk_f64_foreign.pl` (5 tests): `@value_float` in the arg IR; the fcall wrapper shape (`value_is_number` + `value_to_double` + the 0.0 failure select); rejections (field out of range, `sN` args still rejected); and two e2e runs with WAM-compiled predicates — mixed-arithmetic float call + float guard (`2 6.25` exact) and failing-calls-contribute-0.0 (`3.5` exact). `tier2_rejections` swaps its f64-arg entry (now a feature) for an s8-arg entry. Full sweep: **all 45 suites green.**

## Merge order

1. #3437 (consolidation → main) first
2. then this PR into `claude/plawk-llvm-wam-hybrid-p9ujut`; the rest of this round stacks on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_