### PR TITLE
plawk: writebin inside tagged-union case blocks

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -131,8 +131,12 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    `foreach` inside a case block resolves against that arm's own
    layout, per-arm staging rides the same access-type expansion, and
    the union buffer (max record size across arms) covers it
-   automatically. Not yet inside case blocks: assoc arrays, writebin,
-   and union output.
+   automatically. writebin inside case blocks (landed): OUTFMT is
+   program-wide (one output layout regardless of arm) while each
+   rule's source fields type against its own arm, so a union stream
+   normalizes into one fixed layout; a pure normalizer (every rule
+   just writebins) needs no END and no scalar state. Not yet inside
+   case blocks: assoc arrays and union (tagged) output.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -98,6 +98,7 @@ swipl -q -s tests/test_plawk_rep_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/
 swipl -q -s tests/test_plawk_union_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_f64_foreign.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_union_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -333,8 +334,12 @@ or in non-leftmost position are rejected. Arms can carry their own
 repetition: `BINFMT = "case(i64 rep4(lps8 i64) | i64)"` gives arm 0 an
 element list, and `foreach` inside that arm's rules (either spelling)
 iterates it -- element types, staging, and buffer sizing all resolve
-per arm. (Assoc
-arrays and writebin inside case blocks are later slices.)
+per arm. writebin also works inside case blocks: OUTFMT stays
+program-wide (one output layout regardless of arm) while each rule's
+source fields type against its own arm, so a two-arm stream can be
+normalized into one fixed layout -- a pure per-arm normalizer needs no
+END and no scalars at all. (Assoc arrays inside case blocks are a
+later slice.)
 `lpsN` also works in OUTFMT: writebin emits the
 8-byte length plus exactly the payload bytes (no padding), sourcing
 from literals, `sM`/`lpsM` input fields, or text-mode slices clamped to

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -238,13 +238,17 @@ plawk_program_native_driver_ir(
 % chain where each rule's guard checks the record tag before its own
 % pattern, and each rule's fields type against its arm's layout. The
 % END print block is optional (a pure per-arm printer needs none).
+% writebin works inside case blocks: OUTFMT is program-wide, source
+% fields type against each rule's arm.
 plawk_program_native_driver_ir(
-    program(BeginClauses, case_blocks(CaseBlocks), EndClauses),
+    program(BeginClauses, case_blocks(CaseBlocks0), EndClauses),
     InputPath,
     DriverIR
 ) :-
     plawk_record_descriptor(BeginClauses, Descriptor),
     Descriptor = binfmt_union(Arms),
+    plawk_resolve_union_writebin_blocks(BeginClauses, CaseBlocks0, CaseBlocks,
+        WritebinPlan),
     plawk_union_program_ok(Arms, CaseBlocks),
     plawk_union_flatten_rules(CaseBlocks, Arms, Rules),
     (   EndClauses = [end([print(PrintFields)])]
@@ -253,16 +257,27 @@ plawk_program_native_driver_ir(
         PrintFields = [],
         HasEnd = false
     ),
-    plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
+    (   plawk_scalar_state_plan(Rules, PrintFields, StatePlan)
+    ->  true
+    ;   % a pure normalizer: every rule just writebins its arm into
+        % the shared output layout -- no scalar state at all
+        WritebinPlan = outfmt(_OutTypes, _OutSize),
+        PrintFields == [],
+        StatePlan = state_plan([])
+    ),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
-    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR0),
+    plawk_writebin_entry_lines(WritebinPlan, WritebinEntryIR),
+    plawk_join_nonempty_ir([BeginIR0, WritebinEntryIR], BeginIR),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, Descriptor, OutputSeparator,
         RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
     plawk_rules_body_print_fields(Rules, BodyPrintFields),
     plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
-    append(PrintFields, BodyPrintFields, PrintExprs),
+    plawk_rules_writebin_exprs(Rules, WritebinExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs0),
+    append(PrintExprs0, WritebinExprs, PrintExprs),
     append(PrintExprs, ScalarExprs, RecordCounterExprs),
     plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
     plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
@@ -276,8 +291,9 @@ plawk_program_native_driver_ir(
     ->  plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, EndPrintIR)
     ;   EndPrintIR = ''
     ),
-    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
-        [BeginGlobalIR, StringGlobalIR, RuleGlobalIR]),
+    plawk_writebin_globals(WritebinPlan, WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, RuleGlobalIR, WritebinGlobalIR]),
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
@@ -2305,6 +2321,33 @@ plawk_rules_have_writebin(Rules) :-
     member(rule(_Pattern, Actions), Rules),
     plawk_actions_have_writebin(Actions),
     !.
+
+%% plawk_resolve_union_writebin_blocks(+BeginClauses, +CaseBlocks0,
+%%     -CaseBlocks, -WritebinPlan)
+%
+%  The case-block variant of the writebin pre-pass: OUTFMT is
+%  program-wide (one output layout regardless of which arm produced
+%  the record), so the plan is built once and every arm's rules are
+%  stamped with it. Source-field typing against each rule's own arm
+%  happens downstream via the per-rule descriptor.
+plawk_resolve_union_writebin_blocks(BeginClauses, CaseBlocks0, CaseBlocks,
+        WritebinPlan) :-
+    ( member(case_arm(_I, ArmRules), CaseBlocks0),
+      plawk_rules_have_writebin(ArmRules)
+    ->  plawk_begin_outfmt_types(BeginClauses, Types),
+        forall(member(Type, Types),
+            ( memberchk(Type, [i64, f64]) ; Type = s(_W) ; Type = lps(_C) )),
+        plawk_binfmt_record_size(binfmt(Types), Size),
+        WritebinPlan = outfmt(Types, Size),
+        maplist(plawk_resolve_union_writebin_block(Types), CaseBlocks0,
+            CaseBlocks)
+    ;   WritebinPlan = none,
+        CaseBlocks = CaseBlocks0
+    ).
+
+plawk_resolve_union_writebin_block(Types, case_arm(Index, Rules0),
+        case_arm(Index, Rules)) :-
+    maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules).
 
 plawk_actions_have_writebin(Actions) :-
     member(Action, Actions),

--- a/tests/test_plawk_union_writebin.pl
+++ b/tests/test_plawk_union_writebin.pl
@@ -1,0 +1,178 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_uwb_marker/0.
+
+user:plawk_uwb_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_union_writebin, [condition(clang_available)]).
+
+test(union_writebin_ir_shape) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" ; OUTFMT = \"i64 i64\" } case 0 { { writebin $1, NR } } case 1 { { writebin $2, NR } }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % shared output buffer in the entry block, one write per rule
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_wbuf = alloca [16 x i8]'))),
+    % arm 1's source is its i64 at offset 16 (after the lps16 slot)
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i8* %rec, i64 16'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(union_writebin_rejections) :-
+    Rejects = [
+        % writebin still demands OUTFMT
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { { writebin $1 } }\n",
+        % arm 1's $1 is a string; the output slot is i64
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" ; OUTFMT = \"i64\" } case 1 { { writebin $1 } }\n",
+        % argument count must match the output layout
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" ; OUTFMT = \"i64 i64\" } case 0 { { writebin $1 } }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_union_normalizer) :-
+    % A pure normalizer: two record kinds in, one fixed layout out
+    % (value, NR). No END, no scalars -- just per-arm writebin.
+    run_uwb_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" ; OUTFMT = \"i64 i64\" } case 0 { { writebin $1, NR } } case 1 { { writebin $2, NR } }\n",
+        [m(50, 1.5), e("boom", 7), m(200, 2.5)],
+        Bytes),
+    decode_i64_pairs(Bytes, Records),
+    assertion(Records == [50-1, 7-2, 200-3]),
+    !.
+
+test(surface_union_lps_passthrough_with_tag_guards) :-
+    % Tag-guard spelling; arm 1's lps16 flows into an lps16 output
+    % slot; arm-0 records have no rule and are read + skipped.
+    run_uwb_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" ; OUTFMT = \"lps16 i64\" } TAG == 1 && $2 > 5 { writebin $1, $2 }\n",
+        [e("boom", 7), m(50, 1.5), e("skip", 2), e("full16bytes4sure", 9)],
+        Bytes),
+    decode_lps_i64(Bytes, Records),
+    assertion(Records == ["boom"-7, "full16bytes4sure"-9]),
+    !.
+
+:- end_tests(plawk_union_writebin).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5, 0x3FF8000000000000).
+double_bits(2.5, 0x4004000000000000).
+
+% m(V, F): tag 0, i64, f64.  e(S, C): tag 1, lps16, i64.
+write_uwb_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Rec, Recs), write_uwb_record(Out, Rec)),
+        close(Out)).
+
+write_uwb_record(Out, m(V, F)) :-
+    write_i64_le(Out, 0),
+    write_i64_le(Out, V),
+    double_bits(F, Bits),
+    write_i64_le(Out, Bits).
+write_uwb_record(Out, e(S, C)) :-
+    write_i64_le(Out, 1),
+    string_codes(S, Codes),
+    length(Codes, Len),
+    write_i64_le(Out, Len),
+    forall(member(Code, Codes), put_byte(Out, Code)),
+    write_i64_le(Out, C).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+decode_i64_pairs(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_i64_pairs_codes(Codes, Records).
+
+decode_i64_pairs_codes([], []).
+decode_i64_pairs_codes(Codes, [A-B | Records]) :-
+    length(ABytes, 8), length(BBytes, 8),
+    append(ABytes, Rest0, Codes), append(BBytes, Rest, Rest0),
+    le_i64(ABytes, A),
+    le_i64(BBytes, B),
+    decode_i64_pairs_codes(Rest, Records).
+
+decode_lps_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_lps_i64_codes(Codes, Records).
+
+decode_lps_i64_codes([], []).
+decode_lps_i64_codes(Codes, [S-V | Records]) :-
+    length(LenBytes, 8),
+    append(LenBytes, Rest0, Codes),
+    le_i64(LenBytes, Len),
+    length(SBytes, Len),
+    append(SBytes, Rest1, Rest0),
+    string_codes(S, SBytes),
+    length(VBytes, 8),
+    append(VBytes, Rest, Rest1),
+    le_i64(VBytes, V),
+    decode_lps_i64_codes(Rest, Records).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_uwb_marker/0 ],
+        [module_name('plawk_union_writebin')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk union writebin build output]~n~w~n", [BuildOut]),
+       throw(plawk_union_writebin_build_failed(Status))
+    ).
+
+run_uwb_smoke(Source, Recs, Bytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_union_writebin', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath),
+    write_uwb_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    !.


### PR DESCRIPTION
## Summary

Second slice of the round: `writebin` now works inside case blocks, so a tagged-union stream can be **normalized** into one fixed binary output layout:

```awk
BEGIN { BINFMT = "case(i64 f64 | lps16 i64)" ; OUTFMT = "i64 i64" }
case 0 { { writebin $1, NR } }
case 1 { { writebin $2, NR } }
```

## Design

- **OUTFMT stays program-wide** — one output layout regardless of which arm produced the record — while each rule's **source fields type against its own arm**. The writebin pre-pass gains a case-block variant that builds the plan once and stamps every arm's rules; per-arm source typing then falls out of the per-rule descriptor already flowing through the scalar chain, and validation runs through the existing per-arm `writebin_out` check. The union driver threads the plan's entry buffer, globals, and counter expressions exactly like the non-union scalar clause.
- **New program shape:** a *pure normalizer* (every rule just writebins — no END, no scalars) has no scalar state at all, so the union clause falls back to an empty state plan for that case instead of rejecting.
- Composes with the round's earlier slices: the tag-guard spelling desugars before any of this runs, and lps sources pass through per the existing writer rules.

## Tests

New `tests/test_plawk_union_writebin.pl` (4 tests):
- IR: shared 16-byte output buffer allocated once in entry; arm 1's source loads at its arm-relative offset.
- Rejections: writebin without OUTFMT; a string arm field into an i64 output slot; argument count vs layout.
- e2e, byte-decoded: the two-arm normalizer with no END emits exactly `[50-1, 7-2, 200-3]`; an lps16 passthrough spelled with tag guards (`TAG == 1 && $2 > 5 { writebin $1, $2 }`) where unhandled arm-0 records are read and skipped, including a full-width 16-byte string.

Full sweep: **all 46 suites green.**

## Merge order

1. #3437 (consolidation → main)
2. #3438 (f64 bridge) → designated branch
3. this PR → the #3438 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_