### PR TITLE
plawk: assoc arrays inside tagged-union case blocks

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -135,8 +135,14 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    program-wide (one output layout regardless of arm) while each
    rule's source fields type against its own arm, so a union stream
    normalizes into one fixed layout; a pure normalizer (every rule
-   just writebins) needs no END and no scalar state. Not yet inside
-   case blocks: assoc arrays and union (tagged) output.
+   just writebins) needs no END and no scalar state. Assoc arrays
+   inside case blocks (landed): rules are assoc increments whose keys
+   are raw i64 field values typed per arm, all arms updating one
+   shared table per array name; both END report shapes (for-in print,
+   integer lookups) work, and the assoc rule chain resolves guards and
+   key loads through the same per-rule arm descriptor as the scalar
+   chain. Not yet inside case blocks: union (tagged) output, and
+   for-in writebin over a union input.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -99,6 +99,7 @@ swipl -q -s tests/test_plawk_union_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/
 swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_f64_foreign.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_union_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -338,8 +339,11 @@ per arm. writebin also works inside case blocks: OUTFMT stays
 program-wide (one output layout regardless of arm) while each rule's
 source fields type against its own arm, so a two-arm stream can be
 normalized into one fixed layout -- a pure per-arm normalizer needs no
-END and no scalars at all. (Assoc arrays inside case blocks are a
-later slice.)
+END and no scalars at all. Assoc group-bys work across arms too:
+`case 0 { { counts[$1]++ } } case 1 { { counts[$2]++ } }` counts into
+one shared table (keys are raw i64 field values typed per arm), with
+the usual END reports -- `for (k in counts) print k, counts[k]` or
+integer lookups.
 `lpsN` also works in OUTFMT: writebin emits the
 8-byte length plus exactly the payload bytes (no padding), sourcing
 from literals, `sM`/`lpsM` input fields, or text-mode slices clamped to

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -305,6 +305,86 @@ plawk_program_native_driver_ir(
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% Tagged-union group-by: case-block (or TAG-guarded) rules whose
+% actions are assoc increments, with the shared END report. Keys are
+% the raw i64 field values of each rule's own arm; every arm updates
+% the same table per array name (as in awk, counts[k] is one array no
+% matter which rule touched it).
+plawk_program_native_driver_ir(
+    program(BeginClauses, case_blocks(CaseBlocks), [end([print(PrintFields)])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_record_descriptor(BeginClauses, Descriptor),
+    Descriptor = binfmt_union(Arms),
+    plawk_union_flatten_rules(CaseBlocks, Arms, Rules),
+    plawk_assoc_runtime_count_plan(Rules, PrintFields, AssocPlan),
+    plawk_assoc_record_program_ok(Descriptor, Rules, PrintFields),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, Descriptor, AssocRuleGlobalIR, AssocChainIR),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs),
+    append(PrintExprs, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_join_nonempty_ir([RecordCounterIR, AssocChainIR], RecordIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_assoc_end_print_ir(PrintFields, AssocPlan, Descriptor, OutputSeparator, EndPrintIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, AssocRuleGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w
+  ret i32 0',
+        [EndPrintIR]),
+    plawk_emit_record_driver_ir(Descriptor, InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, RecordLoopPhiIR, lowered_assoc,
+            RecordIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
+% ... and the canonical group-by report: END { for (k in counts)
+% print k, counts[k] } over a tagged-union stream.
+plawk_program_native_driver_ir(
+    program(BeginClauses, case_blocks(CaseBlocks), [end([for_in(var(LoopVar), var(ArrayName), BodyActions)])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_record_descriptor(BeginClauses, Descriptor),
+    Descriptor = binfmt_union(Arms),
+    plawk_union_flatten_rules(CaseBlocks, Arms, Rules),
+    plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions, AssocPlan, PrintFields),
+    plawk_assoc_record_program_ok(Descriptor, Rules, PrintFields),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, Descriptor, AssocRuleGlobalIR, AssocChainIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_forin_end_print_ir(LoopVar, ArrayName, PrintFields, AssocPlan,
+        Descriptor, OutputSeparator, EndPrintIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, AssocRuleGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w',
+        [EndPrintIR]),
+    plawk_emit_record_driver_ir(Descriptor, InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
+            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 plawk_program_native_driver_ir(
     program(BeginClauses, Rules, [end([print(PrintFields)])]),
     InputPath,
@@ -942,7 +1022,8 @@ plawk_forin_body_print_lines([], _LoopVar, _ArrayName, _TableIndex, _AssocPlan,
         _Descriptor, _OutputSeparator, _) -->
     [].
 plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
-        TableIndex, AssocPlan, binfmt(Types), OutputSeparator, PrintIndex) -->
+        TableIndex, AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
+    { plawk_descriptor_is_binary(Descriptor) },
     % Binary mode: keys are raw i64 field values, printed numerically.
     plawk_forin_separator_lines(PrintIndex, OutputSeparator),
     { format(atom(FmtVar), 'forin_key_fmt_~w', [PrintIndex]),
@@ -953,7 +1034,7 @@ plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
     },
     [FmtPtr, PrintCall],
     plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
-        binfmt(Types), OutputSeparator, NextPrintIndex).
+        Descriptor, OutputSeparator, NextPrintIndex).
 plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
         TableIndex, AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_forin_separator_lines(PrintIndex, OutputSeparator),
@@ -1710,13 +1791,15 @@ plawk_assoc_rule_chain_lines([assoc_rule(Index, Pattern, Actions, Control) | Res
       format(atom(RuleLabel), 'assoc_rule_~w_match', [Index]),
       format(atom(ApplyLabel), 'assoc_rule_~w_apply', [Index]),
       plawk_rule_target(Control, NextLabel, RuleTargetLabel),
-      plawk_assoc_rule_apply_ir(Index, Actions, RuleTargetLabel, FieldSeparator, ApplyIR),
+      % tagged-union rules carry their arm's field types with them
+      plawk_rule_descriptor(Pattern, FieldSeparator, RuleDescriptor),
+      plawk_assoc_rule_apply_ir(Index, Actions, RuleTargetLabel, RuleDescriptor, ApplyIR),
       ( Index =:= 0
       -> EntryIR = '  br label %assoc_rule_0_match\n\n'
       ;  EntryIR = ''
       ),
       plawk_assoc_rule_guard_ir(Pattern, Index, RuleLabel, ApplyLabel,
-          NextLabel, EntryIR, FieldSeparator, GuardGlobalIR, BranchIR),
+          NextLabel, EntryIR, RuleDescriptor, GuardGlobalIR, BranchIR),
       format(atom(RuleIR),
 '~w
 
@@ -1848,6 +1931,21 @@ plawk_assoc_record_program_ok(binfmt(Types), Rules, EndPrintFields) :-
            ),
         % Integer literals in END lookups; the loop variable inside a
         % for-in body (the key is already the raw i64 slot key there).
+        ( Key = int(_) ; Key = var(_) )).
+% Tagged-union rules (already flattened): guards and counted keys type
+% against each rule's own arm; keys from every arm land in one shared
+% i64 keyspace, as in awk where counts[k] is one array no matter which
+% rule updated it.
+plawk_assoc_record_program_ok(binfmt_union(_Arms), Rules, EndPrintFields) :-
+    !,
+    forall(member(rule(arm_pat(_Tag, ArmTypes, Pattern), Actions), Rules),
+        ( plawk_binfmt_pattern_ok(binfmt(ArmTypes), Pattern),
+          forall(member(Action, Actions),
+              plawk_binfmt_assoc_action_ok(binfmt(ArmTypes), Action))
+        )),
+    forall(( member(Field, EndPrintFields),
+             Field = assoc(_Array, Key)
+           ),
         ( Key = int(_) ; Key = var(_) )).
 plawk_assoc_record_program_ok(_FieldSeparator, _Rules, EndPrintFields) :-
     % Text mode: integer assoc keys would collide with atom ids, so
@@ -3482,7 +3580,7 @@ plawk_assoc_end_print_lines([], AssocPlan, _Descriptor, _OutputSeparator, _) -->
     plawk_assoc_free_lines(AssocPlan).
 plawk_assoc_end_print_lines([assoc(var(ArrayName), int(Key)) | Rest], AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
-    { Descriptor = binfmt(_Types),
+    { plawk_descriptor_is_binary(Descriptor),
       plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
       format(atom(Value),
           '  %assoc_end_value_~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 ~w)',
@@ -3528,6 +3626,11 @@ plawk_assoc_end_print_lines([string(Value) | Rest], AssocPlan, Descriptor, Outpu
 
 plawk_assoc_table_index(assoc_plan(Tables, _Actions), ArrayName, TableIndex) :-
     nth0(TableIndex, Tables, ArrayName).
+
+% Binary record modes: assoc keys are raw i64 field values (no
+% interning), so END key handling prints them numerically.
+plawk_descriptor_is_binary(binfmt(_Types)).
+plawk_descriptor_is_binary(binfmt_union(_Arms)).
 
 plawk_assoc_free_lines(assoc_plan(Tables, _Actions)) -->
     plawk_assoc_free_lines(Tables, 0).

--- a/tests/test_plawk_tagged_unions.pl
+++ b/tests/test_plawk_tagged_unions.pl
@@ -50,8 +50,9 @@ test(union_rejections) :-
         "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { $1 == \"x\" { c++ } } END { print c }\n",
         % numeric compare on an lps field
         "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 1 { $1 > 5 { c++ } } END { print c }\n",
-        % assoc arrays are not in the union slice
-        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { { counts[$1]++ } } END { print counts[5] }\n",
+        % assoc keys must be raw i64 fields of their arm ($1 in arm 1
+        % is a string)
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 1 { { counts[$1]++ } } END { print counts[5] }\n",
         % case blocks demand a union BINFMT
         "case 0 { { c++ } } END { print c }\n",
         "BEGIN { BINFMT = \"i64 i64\" } case 0 { { c++ } } END { print c }\n"

--- a/tests/test_plawk_union_assoc.pl
+++ b/tests/test_plawk_union_assoc.pl
@@ -1,0 +1,152 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_uas_marker/0.
+
+user:plawk_uas_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_union_assoc, [condition(clang_available)]).
+
+test(union_assoc_ir_keys_are_arm_relative_loads) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 | lps8 i64)\" } case 0 { { counts[$1]++ } } case 1 { { counts[$2]++ } } END { for (k in counts) print k, counts[k] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % the union reader's tag switch feeds one shared table; arm 0's key
+    % loads at offset 0, arm 1's i64 key after its 8-byte string slot
+    assertion(once(sub_atom(DriverIR, _, _, _, 'switch i64 %vr_tag'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_new'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%assoc_rule_0_action_0_key_fp = getelementptr i8, i8* %rec, i64 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%assoc_rule_1_action_0_key_fp = getelementptr i8, i8* %rec, i64 8'))),
+    % raw i64 keys: no interning anywhere in the update path
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'assoc_rule_0_action_0_key_id')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(union_assoc_rejections) :-
+    Rejects = [
+        % arm 1's $1 is a string: not a raw-i64 key
+        "BEGIN { BINFMT = \"case(i64 | lps8 i64)\" } case 1 { { counts[$1]++ } } END { print counts[5] }\n",
+        % string lookups stay text-mode-only
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { { counts[$1]++ } } END { print counts[\"x\"] }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_union_groupby_forin) :-
+    % One shared keyspace across arms: metric ids and event values
+    % count into the same table.
+    run_uas_sorted_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { { counts[$1]++ } } case 1 { { counts[$2]++ } } END { for (k in counts) print k, counts[k] }\n",
+        [m(5, 1.5), e("x", 9), m(5, 2.5), e("y", 5), m(9, 1.5)],
+        ["5 3", "9 2"]).
+
+test(surface_union_groupby_tag_guards_and_lookup) :-
+    % Tag-guard spelling with a residual guard, END int lookup.
+    run_uas_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } TAG == 0 && $1 > 10 { counts[$1]++ } TAG == 1 { counts[$2]++ } END { print counts[20], counts[5] }\n",
+        [m(20, 1.5), e("a", 20), m(5, 2.5), m(20, 1.5), e("b", 5)],
+        "3 1\n").
+
+:- end_tests(plawk_union_assoc).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5, 0x3FF8000000000000).
+double_bits(2.5, 0x4004000000000000).
+
+% m(V, F): tag 0, i64, f64.  e(S, C): tag 1, lps16, i64.
+write_uas_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Rec, Recs), write_uas_record(Out, Rec)),
+        close(Out)).
+
+write_uas_record(Out, m(V, F)) :-
+    write_i64_le(Out, 0),
+    write_i64_le(Out, V),
+    double_bits(F, Bits),
+    write_i64_le(Out, Bits).
+write_uas_record(Out, e(S, C)) :-
+    write_i64_le(Out, 1),
+    string_codes(S, Codes),
+    length(Codes, Len),
+    write_i64_le(Out, Len),
+    forall(member(Code, Codes), put_byte(Out, Code)),
+    write_i64_le(Out, C).
+
+build_uas_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_union_assoc', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_uas_marker/0 ],
+        [module_name('plawk_union_assoc')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk union assoc build output]~n~w~n", [BuildOut]),
+       throw(plawk_union_assoc_build_failed(Status))
+    ).
+
+run_capture(BinPath, OutStr) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)).
+
+run_uas_smoke(Source, Recs, ExpectedOutput) :-
+    build_uas_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_uas_records(InputPath, Recs),
+    run_capture(BinPath, OutStr),
+    assertion(OutStr == ExpectedOutput),
+    !.
+
+run_uas_sorted_smoke(Source, Recs, ExpectedLines) :-
+    build_uas_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_uas_records(InputPath, Recs),
+    run_capture(BinPath, OutStr),
+    split_string(OutStr, "\n", "", Split0),
+    exclude(==(""), Split0, Lines0),
+    msort(Lines0, SortedLines),
+    msort(ExpectedLines, SortedExpected),
+    assertion(SortedLines == SortedExpected),
+    !.


### PR DESCRIPTION
## Summary

Third slice: group-bys work across a union stream — the last feature that was excluded from case blocks.

```awk
BEGIN { BINFMT = "case(i64 f64 | lps16 i64)" }
case 0 { { counts[$1]++ } }
case 1 { { counts[$2]++ } }
END { for (k in counts) print k, counts[k] }
```

Every arm updates the same table per array name — one shared i64 keyspace, matching awk semantics where `counts[k]` is one array no matter which rule touched it. Keys are raw i64 field values typed against each rule's own arm.

## Design

- The assoc rule chain resolves each rule's guard **and key loads** through the same per-rule arm descriptor the scalar chain uses, so arm-typed key offsets come from the existing binfmt field-load machinery (no new key emission code).
- Two new driver clauses mirror the binary assoc clauses for case-block programs, covering both END shapes: integer lookups (`print counts[5]`) and the canonical for-in report.
- Validation gains a union variant: guards and counted keys check per arm; a string-typed arm field as a key rejects the program.
- END key printing now keys off `plawk_descriptor_is_binary/1` (binfmt or binfmt_union) instead of matching `binfmt(_)` directly — union keys are raw i64s and must print numerically, not as interned atoms.
- Composes with the tag-guard sugar (`TAG == 0 && $1 > 10 { counts[$1]++ }`), which desugars before any of this runs.

## Tests

New `tests/test_plawk_union_assoc.pl` (4 tests): IR shape (tag switch + one shared table + arm-relative key offsets 0 and 8, and **no** interning in the update path); rejections; e2e cross-arm group-by with for-in report (`5 3` / `9 2` sorted-exact); e2e tag-guard spelling with residual guard + integer END lookups (`3 1` exact). The tagged-unions rejection list swaps its "assoc not in the union slice" entry (now a feature) for the string-key case.

Full sweep: **all 47 suites green.**

## Merge order (whole round, bottom-up)

1. #3437 (consolidation → main)
2. #3438 (f64 bridge) → designated branch
3. #3439 (union writebin) → the #3438 branch
4. this PR → the #3439 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_