### PR TITLE
plawk: repK in OUTFMT (rep passthrough writer)

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -165,7 +165,13 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    the cap. Records with an lps slot switch from the single-buffer
    fwrite to per-slot fwrites emitted left to right (buffered in libc,
    so still memcpy cost per record). Writer output is byte-compatible
-   with the `lpsN` reader.
+   with the `lpsN` reader. `repK(elems)` in OUTFMT (landed) is a
+   passthrough slot: the argument names the input rep's count field,
+   and the writer emits the live count plus one bulk fwrite of
+   count×elemsize bytes from the input's element region (fixed-width
+   elements only, so in-memory layout == wire layout; caps and element
+   layouts must match the input rep exactly). Guarded rules therefore
+   make byte-exact stream filters, in plain and union input modes.
 4. **Tier-2 composition sugar (landed):** `blobN` — a length-prefixed
    binary payload whose only consumer is a compiled-Prolog foreign
    call. The record loop frames natively (length read, cap check, bulk

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -100,6 +100,7 @@ swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c
 swipl -q -s tests/test_plawk_f64_foreign.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_rep_writer.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -348,7 +349,13 @@ integer lookups.
 8-byte length plus exactly the payload bytes (no padding), sourcing
 from literals, `sM`/`lpsM` input fields, or text-mode slices clamped to
 the cap - writer output is byte-compatible with the `lpsN` reader, so
-varlen plawk-to-plawk pipelines round-trip. See
+varlen plawk-to-plawk pipelines round-trip. `repK(...)` works in
+OUTFMT as a passthrough: the writebin argument names the input rep's
+count field (`OUTFMT = "i64 rep4(i64 f64)"` with `writebin $1, $2`),
+and the writer emits the live count plus one bulk copy of the live
+elements - so guarded rules make byte-exact stream filters.
+Fixed-width elements only; the input rep's cap and element layout must
+match the output slot exactly. See
 [`docs/design/PLAWK_DCG_BINARY_READERS.md`](../../docs/design/PLAWK_DCG_BINARY_READERS.md)
 for the grammar-to-native-reader lowering design this is the first
 slice of. Fixed-width string fields are in: with

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2048,6 +2048,18 @@ plawk_binfmt_writebin_args_ok(Descriptor, [s(Width) | Types], [Field | Fields]) 
 plawk_binfmt_writebin_args_ok(Descriptor, [lps(Cap) | Types], [Field | Fields]) :-
     plawk_binfmt_writebin_str_ok(Descriptor, Field, Cap),
     plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+plawk_binfmt_writebin_args_ok(Descriptor, [rep(Cap, ElemTypes) | Types],
+        [Field | Fields]) :-
+    plawk_binfmt_writebin_rep_ok(Descriptor, rep(Cap, ElemTypes), Field),
+    plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+
+% rep passthrough: the argument names the input rep's COUNT field, and
+% the input rep must match the output slot exactly (same cap, same
+% element layout) -- count and live elements copy through unchanged.
+plawk_binfmt_writebin_rep_ok(binfmt(InTypes), rep(Cap, ElemTypes),
+        field(CountIndex)) :-
+    plawk_binfmt_rep_info(InTypes, CountIndex, Cap, _ElemArity),
+    memberchk(rep(Cap, ElemTypes), InTypes).
 
 plawk_binfmt_writebin_str_ok(_Descriptor, string(Value), Width) :-
     !,
@@ -2406,8 +2418,7 @@ plawk_binfmt_record_size(binfmt(Types), Size) :-
 plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules, WritebinPlan) :-
     ( plawk_rules_have_writebin(Rules0)
     ->  plawk_begin_outfmt_types(BeginClauses, Types),
-        forall(member(Type, Types),
-            ( memberchk(Type, [i64, f64]) ; Type = s(_W) ; Type = lps(_C) )),
+        forall(member(Type, Types), plawk_outfmt_type_ok(Type)),
         plawk_binfmt_record_size(binfmt(Types), Size),
         WritebinPlan = outfmt(Types, Size),
         maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules)
@@ -2433,8 +2444,7 @@ plawk_resolve_union_writebin_blocks(BeginClauses, CaseBlocks0, CaseBlocks,
     ( member(case_arm(_I, ArmRules), CaseBlocks0),
       plawk_rules_have_writebin(ArmRules)
     ->  plawk_begin_outfmt_types(BeginClauses, Types),
-        forall(member(Type, Types),
-            ( memberchk(Type, [i64, f64]) ; Type = s(_W) ; Type = lps(_C) )),
+        forall(member(Type, Types), plawk_outfmt_type_ok(Type)),
         plawk_binfmt_record_size(binfmt(Types), Size),
         WritebinPlan = outfmt(Types, Size),
         maplist(plawk_resolve_union_writebin_block(Types), CaseBlocks0,
@@ -2473,8 +2483,9 @@ plawk_resolve_writebin_action(_Types, Action, Action).
 plawk_begin_outfmt_types(BeginClauses, Types) :-
     member(begin(Actions), BeginClauses),
     member(set(var('OUTFMT'), string(Fmt)), Actions),
-    split_string(Fmt, " ", " ", Parts0),
-    exclude(==(""), Parts0, Parts),
+    % the shared tokenizer joins parenthesized types, so OUTFMT can
+    % carry a rep: "i64 rep4(i64 f64)"
+    plawk_binfmt_tokens(Fmt, Parts),
     Parts \== [],
     maplist(plawk_binfmt_type, Parts, Types).
 
@@ -2519,9 +2530,22 @@ plawk_writebin_args_ok([Type | Types], [Field | Fields]) :-
     -> plawk_writebin_str_arg(Field, Width)
     ;  Type = lps(Cap)
     -> plawk_writebin_str_arg(Field, Cap)
+    ;  Type = rep(_K, _Elems)
+    -> Field = field(_CountIndex)
     ;  plawk_writebin_f64_arg(Field)
     ),
     plawk_writebin_args_ok(Types, Fields).
+
+% OUTFMT slot types: i64/f64/sN/lpsN as before, plus rep passthrough
+% (fixed-width elements only -- the element region is copied as one
+% bulk write, which requires in-memory layout == wire layout).
+plawk_outfmt_type_ok(i64) :- !.
+plawk_outfmt_type_ok(f64) :- !.
+plawk_outfmt_type_ok(s(_W)) :- !.
+plawk_outfmt_type_ok(lps(_C)) :- !.
+plawk_outfmt_type_ok(rep(_K, ElemTypes)) :-
+    forall(member(ElemType, ElemTypes),
+        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_) )).
 
 % sN output slots take string literals that fit the width, or field
 % reads (validated against the input layout separately in binary mode;
@@ -2632,6 +2656,37 @@ plawk_writebin_varlen_slot_lines(lps(Cap), Field, FieldSeparator, Base,
         '  %~w_pwr = call i64 @fwrite(i8* ~w, i64 ~w, i64 1, i8* ~w)',
         [Base, PtrIR, LenIR, Stdout]),
     append(SourceLines, [LenStore, PayloadWrite], Lines).
+plawk_writebin_varlen_slot_lines(rep(_Cap, ElemTypes), field(CountIndex),
+        binfmt(InTypes), Base, BasePtr, Stdout, Lines, []) :-
+    !,
+    % rep passthrough: write the live count, then the live elements as
+    % one bulk write straight from the input record's element region
+    % (fixed-width elements, so in-memory layout == wire layout; a
+    % zero count writes nothing -- fwrite with size 0 is a no-op).
+    maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
+    sum_list(ElemWidths, ElemSize),
+    plawk_binfmt_field_offset(binfmt(InTypes), CountIndex, CountOff),
+    ElemsOff is CountOff + 8,
+    format(atom(RepIR),
+'  %~w_cfp = getelementptr i8, i8* %rec, i64 ~w
+  %~w_ctp = bitcast i8* %~w_cfp to i64*
+  %~w_n = load i64, i64* %~w_ctp, align 1
+  %~w_csp = bitcast i8* ~w to i64*
+  store i64 %~w_n, i64* %~w_csp, align 1
+  %~w_cwr = call i64 @fwrite(i8* ~w, i64 8, i64 1, i8* ~w)
+  %~w_efp = getelementptr i8, i8* %rec, i64 ~w
+  %~w_bytes = mul i64 %~w_n, ~w
+  %~w_ewr = call i64 @fwrite(i8* %~w_efp, i64 %~w_bytes, i64 1, i8* ~w)',
+        [Base, CountOff,
+         Base, Base,
+         Base, Base,
+         Base, BasePtr,
+         Base, Base,
+         Base, BasePtr, Stdout,
+         Base, ElemsOff,
+         Base, Base, ElemSize,
+         Base, Base, Base, Stdout]),
+    Lines = [RepIR].
 plawk_writebin_varlen_slot_lines(Type, Field, FieldSeparator, Base, BasePtr,
         Stdout, Lines, GParts) :-
     % numeric slot: stage the value in the scratch buffer, write 8 bytes

--- a/tests/test_plawk_rep_writer.pl
+++ b/tests/test_plawk_rep_writer.pl
@@ -1,0 +1,149 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_rpw_marker/0.
+
+user:plawk_rpw_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_rep_writer, [condition(clang_available)]).
+
+test(rep_outfmt_writes_count_then_bulk_elements) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64 f64)\" } $1 > 0 { writebin $1, $2 ; kept++ } END { print kept }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % the rep slot: live count staged + written (8 bytes), then one
+    % bulk fwrite of count*16 element bytes straight from %rec
+    assertion(once(sub_atom(DriverIR, _, _, _, '_cwr = call i64 @fwrite(i8* %'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_ewr = call i64 @fwrite(i8* %'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(rep_outfmt_rejections) :-
+    Rejects = [
+        % caps must match (a bigger output cap cannot invent elements,
+        % a smaller one could not hold the count)
+        "BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep8(i64 f64)\" } { writebin $1, $2 }\n",
+        % element layouts must match exactly
+        "BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64)\" } { writebin $1, $2 }\n",
+        % the rep argument must be the input rep's count field
+        "BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64 f64)\" } { writebin $1, $1 }\n",
+        % lps elements are not bulk-copyable (wire differs per element)
+        "BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" ; OUTFMT = \"i64 rep4(lps8 i64)\" } { writebin $1, $2 }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_rep_filter_is_byte_exact) :-
+    % A stream filter: guarded records pass through byte-identical
+    % (count + live elements only -- the writer never pads).
+    Keep = [rec(1, [e(5, 1.5), e(20, 2.5)]), rec(3, [])],
+    Drop = [rec(-2, [e(9, 1.5)])],
+    Input = [rec(1, [e(5, 1.5), e(20, 2.5)]), rec(-2, [e(9, 1.5)]), rec(3, [])],
+    run_rpw_smoke("BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64 f64)\" } $1 > 0 { writebin $1, $2 }\n",
+        Input, OutBytes),
+    records_bytes(Keep, ExpectedBytes),
+    records_bytes(Drop, DropBytes),
+    assertion(OutBytes == ExpectedBytes),
+    assertion(OutBytes \== DropBytes).
+
+test(surface_rep_passthrough_in_union_arm) :-
+    % Composes with case blocks: arm 0 carries the rep, its rule
+    % passes it through with a rewritten leading field.
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 rep2(i64) | i64)\" ; OUTFMT = \"i64 rep2(i64)\" } TAG == 0 { writebin NR, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_ewr = call i64 @fwrite(i8* %'))),
+    !.
+
+:- end_tests(plawk_rep_writer).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5, 0x3FF8000000000000).
+double_bits(2.5, 0x4004000000000000).
+
+% rec(Id, Elems): i64 id, i64 count, then per element i64 + f64
+write_rpw_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        write_rpw_stream(Out, Recs),
+        close(Out)).
+
+write_rpw_stream(Out, Recs) :-
+    forall(member(rec(Id, Elems), Recs),
+        ( write_i64_le(Out, Id),
+          length(Elems, Count),
+          write_i64_le(Out, Count),
+          forall(member(e(V, F), Elems),
+              ( write_i64_le(Out, V),
+                double_bits(F, Bits),
+                write_i64_le(Out, Bits) )) )).
+
+% the byte string a record list occupies on the wire
+records_bytes(Recs, Bytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_rep_writer_expect.bin', Path),
+    write_rpw_records(Path, Recs),
+    setup_call_cleanup(
+        open(Path, read, In, [type(binary)]),
+        read_string(In, _, Bytes),
+        close(In)).
+
+run_rpw_smoke(Source, Recs, OutBytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_rep_writer', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_rpw_marker/0 ],
+        [module_name('plawk_rep_writer')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(BuildOutS)), stderr(std), process(BuildPid)]),
+    read_string(BuildOutS, _, BuildOut),
+    close(BuildOutS),
+    process_wait(BuildPid, BuildStatus),
+    ( BuildStatus == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk rep writer build output]~n~w~n", [BuildOut]),
+       throw(plawk_rep_writer_build_failed(BuildStatus))
+    ),
+    write_rpw_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, OutBytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    !.


### PR DESCRIPTION
## Summary

Final slice of the round: bounded repetition works on the writer side, closing the read → filter → write loop for rep records:

```awk
BEGIN { BINFMT = "i64 rep4(i64 f64)" ; OUTFMT = "i64 rep4(i64 f64)" }
$1 > 0 { writebin $1, $2 }
```

Guarded rules make **byte-exact stream filters** — the e2e test asserts the output equals the kept input records byte for byte.

## Design

- **Passthrough semantics:** the writebin argument for a rep slot names the input rep's **count field** (`$2` above). The writer emits the live count (8 bytes) then one bulk `fwrite` of `count×elemsize` bytes straight from the input record's element region. Fixed-width elements only (i64/f64/sN), so the in-memory layout equals the wire layout and the bulk copy is exact; a zero count writes nothing.
- **Validation:** the input rep's cap and element layout must match the output slot exactly; the argument must be the count field; lps elements reject (their wire size differs per element — a per-element write loop is the natural later extension). Works from a union arm too, via the per-rule arm descriptor.
- **Bug fixed on the way:** `plawk_begin_outfmt_types` split OUTFMT on bare spaces, so a parenthesized type could never have parsed — it now uses the shared paren-joining tokenizer.

## Tests

New `tests/test_plawk_rep_writer.pl` (4 tests): IR shape (count write + bulk element fwrite); rejection matrix (cap mismatch, element-layout mismatch, non-count argument, lps elements); the byte-exact filter e2e (kept records identical, dropped record absent); union-arm acceptance with a rewritten leading field.

Full sweep: **all 48 suites green.**

## Merge order (whole round, bottom-up)

1. #3437 (consolidation → main)
2. #3438 (f64 bridge) → designated branch
3. #3439 (union writebin) → the #3438 branch
4. #3440 (union assoc) → the #3439 branch
5. this PR → the #3440 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_