### PR TITLE
plawk: bring round 4 (#3438 f64 bridge, #3439/#3440 union writebin+assoc, #3441 rep writer) to main

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -165,10 +165,15 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    no interning) and marshals it as the transient atom, which the
    compiled predicate reads with `atom_codes/2` and parses with an
    ordinary WAM DCG — real choice points and all. i64 fields marshal
-   as WAM integers (a typed load, no text). Constraints: one blob
-   argument per call (one shared buffer), NUL-free payloads (the
-   transient atom is a C string), f64 marshaling and blob output are
-   later slices.
+   as WAM integers and f64 fields as WAM floats (typed loads, no text;
+   the f64 packs its bits under the Float tag via `@value_float`).
+   Double-returning calls (landed) are spelled `float(name(args))`:
+   the site calls a `{double, ok}` wrapper that accepts an Integer or
+   Float output and promotes via `@value_to_double`; a failed call
+   contributes 0.0, and the written scalar types as a double through
+   the ordinary slot-type fixpoint. Constraints: one blob argument per
+   call (one shared buffer), NUL-free payloads (the transient atom is
+   a C string), blob output is a later slice.
 
 ## Known design debt
 

--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -135,8 +135,14 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    program-wide (one output layout regardless of arm) while each
    rule's source fields type against its own arm, so a union stream
    normalizes into one fixed layout; a pure normalizer (every rule
-   just writebins) needs no END and no scalar state. Not yet inside
-   case blocks: assoc arrays and union (tagged) output.
+   just writebins) needs no END and no scalar state. Assoc arrays
+   inside case blocks (landed): rules are assoc increments whose keys
+   are raw i64 field values typed per arm, all arms updating one
+   shared table per array name; both END report shapes (for-in print,
+   integer lookups) work, and the assoc rule chain resolves guards and
+   key loads through the same per-rule arm descriptor as the scalar
+   chain. Not yet inside case blocks: union (tagged) output, and
+   for-in writebin over a union input.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region

--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -131,8 +131,12 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    `foreach` inside a case block resolves against that arm's own
    layout, per-arm staging rides the same access-type expansion, and
    the union buffer (max record size across arms) covers it
-   automatically. Not yet inside case blocks: assoc arrays, writebin,
-   and union output.
+   automatically. writebin inside case blocks (landed): OUTFMT is
+   program-wide (one output layout regardless of arm) while each
+   rule's source fields type against its own arm, so a union stream
+   normalizes into one fixed layout; a pure normalizer (every rule
+   just writebins) needs no END and no scalar state. Not yet inside
+   case blocks: assoc arrays and union (tagged) output.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region

--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -165,7 +165,13 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    the cap. Records with an lps slot switch from the single-buffer
    fwrite to per-slot fwrites emitted left to right (buffered in libc,
    so still memcpy cost per record). Writer output is byte-compatible
-   with the `lpsN` reader.
+   with the `lpsN` reader. `repK(elems)` in OUTFMT (landed) is a
+   passthrough slot: the argument names the input rep's count field,
+   and the writer emits the live count plus one bulk fwrite of
+   count×elemsize bytes from the input's element region (fixed-width
+   elements only, so in-memory layout == wire layout; caps and element
+   layouts must match the input rep exactly). Guarded rules therefore
+   make byte-exact stream filters, in plain and union input modes.
 4. **Tier-2 composition sugar (landed):** `blobN` — a length-prefixed
    binary payload whose only consumer is a compiled-Prolog foreign
    call. The record loop frames natively (length read, cap check, bulk

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -98,6 +98,7 @@ swipl -q -s tests/test_plawk_rep_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/
 swipl -q -s tests/test_plawk_union_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_f64_foreign.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_union_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -333,8 +334,12 @@ or in non-leftmost position are rejected. Arms can carry their own
 repetition: `BINFMT = "case(i64 rep4(lps8 i64) | i64)"` gives arm 0 an
 element list, and `foreach` inside that arm's rules (either spelling)
 iterates it -- element types, staging, and buffer sizing all resolve
-per arm. (Assoc
-arrays and writebin inside case blocks are later slices.)
+per arm. writebin also works inside case blocks: OUTFMT stays
+program-wide (one output layout regardless of arm) while each rule's
+source fields type against its own arm, so a two-arm stream can be
+normalized into one fixed layout -- a pure per-arm normalizer needs no
+END and no scalars at all. (Assoc arrays inside case blocks are a
+later slice.)
 `lpsN` also works in OUTFMT: writebin emits the
 8-byte length plus exactly the payload bytes (no padding), sourcing
 from literals, `sM`/`lpsM` input fields, or text-mode slices clamped to

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -99,6 +99,7 @@ swipl -q -s tests/test_plawk_union_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/
 swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_f64_foreign.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_union_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -338,8 +339,11 @@ per arm. writebin also works inside case blocks: OUTFMT stays
 program-wide (one output layout regardless of arm) while each rule's
 source fields type against its own arm, so a two-arm stream can be
 normalized into one fixed layout -- a pure per-arm normalizer needs no
-END and no scalars at all. (Assoc arrays inside case blocks are a
-later slice.)
+END and no scalars at all. Assoc group-bys work across arms too:
+`case 0 { { counts[$1]++ } } case 1 { { counts[$2]++ } }` counts into
+one shared table (keys are raw i64 field values typed per arm), with
+the usual END reports -- `for (k in counts) print k, counts[k]` or
+integer lookups.
 `lpsN` also works in OUTFMT: writebin emits the
 8-byte length plus exactly the payload bytes (no padding), sourcing
 from literals, `sM`/`lpsM` input fields, or text-mode slices clamped to

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -100,6 +100,7 @@ swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c
 swipl -q -s tests/test_plawk_f64_foreign.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_rep_writer.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -348,7 +349,13 @@ integer lookups.
 8-byte length plus exactly the payload bytes (no padding), sourcing
 from literals, `sM`/`lpsM` input fields, or text-mode slices clamped to
 the cap - writer output is byte-compatible with the `lpsN` reader, so
-varlen plawk-to-plawk pipelines round-trip. See
+varlen plawk-to-plawk pipelines round-trip. `repK(...)` works in
+OUTFMT as a passthrough: the writebin argument names the input rep's
+count field (`OUTFMT = "i64 rep4(i64 f64)"` with `writebin $1, $2`),
+and the writer emits the live count plus one bulk copy of the live
+elements - so guarded rules make byte-exact stream filters.
+Fixed-width elements only; the input rep's cap and element layout must
+match the output slot exactly. See
 [`docs/design/PLAWK_DCG_BINARY_READERS.md`](../../docs/design/PLAWK_DCG_BINARY_READERS.md)
 for the grammar-to-native-reader lowering design this is the first
 slice of. Fixed-width string fields are in: with

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -97,6 +97,7 @@ swipl -q -s tests/test_plawk_bounded_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/
 swipl -q -s tests/test_plawk_rep_strings.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_rep.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_tier2_blob.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_f64_foreign.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -294,8 +295,12 @@ only consumer is a compiled Prolog predicate - the loop frames records
 natively, and `total += payload_sum($2)` hands the payload bytes to a
 WAM-compiled DCG through the ~0.2us foreign bridge (constant memory:
 the payload rides the shared transient atom, no interning). i64 fields
-marshal as WAM integers in binary mode, so foreign guards and calls now
-work over binary records generally. One blob argument per call;
+marshal as WAM integers and f64 fields as WAM floats in binary mode, so
+foreign guards and calls work over binary records generally; a
+double-returning call is spelled `wsum += float(score($1, $2))` (the
+float(...) wrapper selects a {double, ok} bridge that accepts Integer
+or Float results, keeping fractions that the i64 spelling would
+truncate; a failed call contributes 0.0). One blob argument per call;
 payloads are NUL-free byte strings. Bounded repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -687,3 +687,18 @@ the native loop does the framing (find each record, check lengths,
 skip what doesn't match), and Prolog does the understanding. The
 hand-off costs about 0.2 microseconds and no memory growth - the
 payload travels in a single reused buffer.
+
+Numbers cross the bridge in both directions and both widths: `i64`
+fields arrive in Prolog as integers, `f64` fields as floats. When the
+predicate's answer is itself fractional, wrap the call in `float(...)`:
+
+```awk
+BEGIN { BINFMT = "i64 f64" }
+{ wsum += float(weight($1, $2)) }
+END { print wsum }
+```
+
+Without the wrapper a call is an integer expression (fractions would
+be truncated); with it, the result stays a double - whether the
+predicate bound an integer or a float. A call that fails contributes
+`0.0`, mirroring awk's forgiving arithmetic.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4,7 +4,8 @@
 :- module(plawk_native_codegen, [
     plawk_program_native_driver_ir/3,
     plawk_program_native_driver_ir/4,
-    plawk_program_foreign_specs/3
+    plawk_program_foreign_specs/3,
+    plawk_program_foreign_specs/4
 ]).
 
 :- discontiguous plawk_pattern_guard_ir/5.
@@ -417,25 +418,32 @@ plawk_program_native_driver_ir(
 %  emitters need no VM plumbing. Programs with no foreign calls
 %  delegate to plawk_program_native_driver_ir/3 unchanged.
 plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
-    plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs),
+    plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs, FCallSpecs),
     (   GuardSpecs == [],
-        CallSpecs == []
+        CallSpecs == [],
+        FCallSpecs == []
     ->  plawk_program_native_driver_ir(Program, InputPath, DriverIR)
     ;   memberchk(wam_vm(InstrCount, LabelCount), Options),
-        plawk_foreign_support_ir(GuardSpecs, CallSpecs, InstrCount, LabelCount,
-            SupportIR),
+        plawk_foreign_support_ir(GuardSpecs, CallSpecs, FCallSpecs,
+            InstrCount, LabelCount, SupportIR),
         plawk_program_native_driver_ir(Program, InputPath, MainIR),
         format(atom(DriverIR), '~w~n~n~w', [SupportIR, MainIR])
     ).
 
 %% plawk_program_foreign_specs(+Program, -GuardSpecs, -CallSpecs)
+%% plawk_program_foreign_specs(+Program, -GuardSpecs, -CallSpecs, -FCallSpecs)
 %
 %  Collect the deduplicated foreign predicate call shapes used by the
 %  program. GuardSpecs are Name-NArgs pairs called as rule guards
 %  (predicate arity NArgs); CallSpecs are Name-NArgs pairs called as
-%  i64 expressions (predicate arity NArgs + 1 for the output).
+%  i64 expressions and FCallSpecs Name-NArgs pairs called as double
+%  expressions via float(name(args)) (predicate arity NArgs + 1 for
+%  the output in both).
+plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs) :-
+    plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs, _FCallSpecs).
+
 plawk_program_foreign_specs(program(_BeginClauses, Rules, EndClauses),
-        GuardSpecs, CallSpecs) :-
+        GuardSpecs, CallSpecs, FCallSpecs) :-
     findall(Name-NArgs,
         ( member(rule(Pattern, _Actions), Rules),
           plawk_pattern_prolog_guard(Pattern, Name, Args),
@@ -451,6 +459,14 @@ plawk_program_foreign_specs(program(_BeginClauses, Rules, EndClauses),
         ),
         CallSpecs0),
     findall(Name-NArgs,
+        ( ( member(rule(_PatternF, FActions), Rules)
+          ; member(end(FActions), EndClauses)
+          ),
+          plawk_actions_prolog_fcall(FActions, Name, Args),
+          length(Args, NArgs)
+        ),
+        FCallSpecs0),
+    findall(Name-NArgs,
         ( member(rule(_Pattern2, Actions2), Rules),
           member(if(CondPattern, _Then, _Else), Actions2),
           plawk_pattern_prolog_guard(CondPattern, Name, Args),
@@ -459,7 +475,8 @@ plawk_program_foreign_specs(program(_BeginClauses, Rules, EndClauses),
         CondGuardSpecs0),
     append(GuardSpecs0, CondGuardSpecs0, AllGuardSpecs),
     sort(AllGuardSpecs, GuardSpecs),
-    sort(CallSpecs0, CallSpecs).
+    sort(CallSpecs0, CallSpecs),
+    sort(FCallSpecs0, FCallSpecs).
 
 plawk_pattern_prolog_guard(prolog_guard(Name, Args), Name, Args).
 plawk_pattern_prolog_guard(and_pat(Left, Right), Name, Args) :-
@@ -499,17 +516,48 @@ plawk_expr_prolog_call(Expr, Name, Args) :-
     ; plawk_expr_prolog_call(Right, Name, Args)
     ).
 
-%% plawk_foreign_support_ir(+GuardSpecs, +CallSpecs, +InstrCount, +LabelCount, -IR)
+% float(name(args)) call sites -- same walk, double-returning wrappers.
+plawk_actions_prolog_fcall(Actions, Name, Args) :-
+    member(Action, Actions),
+    plawk_action_prolog_fcall(Action, Name, Args).
+
+plawk_action_prolog_fcall(add(_Var, Expr), Name, Args) :-
+    plawk_expr_prolog_fcall(Expr, Name, Args).
+plawk_action_prolog_fcall(set(_Var, Expr), Name, Args) :-
+    plawk_expr_prolog_fcall(Expr, Name, Args).
+plawk_action_prolog_fcall(print(Fields), Name, Args) :-
+    member(Field, Fields),
+    plawk_expr_prolog_fcall(Field, Name, Args).
+plawk_action_prolog_fcall(printf(_Format, PrintfArgs), Name, Args) :-
+    member(Field, PrintfArgs),
+    plawk_expr_prolog_fcall(Field, Name, Args).
+plawk_action_prolog_fcall(if(_Pattern, ThenActions, ElseActions), Name, Args) :-
+    ( plawk_actions_prolog_fcall(ThenActions, Name, Args)
+    ; plawk_actions_prolog_fcall(ElseActions, Name, Args)
+    ).
+
+plawk_expr_prolog_fcall(float_call(Name, Args), Name, Args).
+plawk_expr_prolog_fcall(Expr, Name, Args) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_prolog_fcall(Left, Name, Args)
+    ; plawk_expr_prolog_fcall(Right, Name, Args)
+    ).
+
+%% plawk_foreign_support_ir(+GuardSpecs, +CallSpecs, +FCallSpecs,
+%%     +InstrCount, +LabelCount, -IR)
 %
 %  Emit the shared foreign-call support section: a lazily initialized
 %  process-wide %WamState plus one wrapper per called predicate. Guard
 %  wrappers return run_loop's success directly. Call wrappers push one
 %  unbound output cell, run the predicate, and return {value, ok};
-%  failure or a non-integer binding yields {0, false}. Both wrappers
+%  failure or a non-integer binding yields {0, false}. Float-call
+%  wrappers (float(name(args)) sites) accept an Integer or Float
+%  output and return {double, ok} via @value_to_double. All wrappers
 %  save and restore the VM heap top (WamState field 6) and rewind the
 %  arena via @wam_cleanup, so per-record foreign calls run in constant
 %  memory -- nothing WAM-side persists between plawk calls.
-plawk_foreign_support_ir(GuardSpecs, CallSpecs, InstrCount, LabelCount, IR) :-
+plawk_foreign_support_ir(GuardSpecs, CallSpecs, FCallSpecs, InstrCount,
+        LabelCount, IR) :-
     format(atom(VmIR),
 '@plawk_foreign_vm = internal global %WamState* null
 
@@ -543,7 +591,12 @@ make:
           plawk_foreign_call_wrapper_ir(Name, NArgs, CallIR)
         ),
         CallIRs),
-    append([[VmIR], GuardIRs, CallIRs], Parts),
+    findall(FCallIR,
+        ( member(Name-NArgs, FCallSpecs),
+          plawk_foreign_fcall_wrapper_ir(Name, NArgs, FCallIR)
+        ),
+        FCallIRs),
+    append([[VmIR], GuardIRs, CallIRs, FCallIRs], Parts),
     atomic_list_concat(Parts, '\n\n', IR).
 
 plawk_foreign_wrapper_params(NArgs, ParamsIR) :-
@@ -642,6 +695,58 @@ fail:
   %f0 = insertvalue { i64, i1 } undef, i64 0, 0
   %f1 = insertvalue { i64, i1 } %f0, i1 false, 1
   ret { i64, i1 } %f1
+}',
+        [Name, NArgs, ParamsIR, Name, SetRegIR, NArgs]).
+
+% The double-returning variant behind float(name(args)): identical
+% shape, but the output cell may bind to an Integer or a Float --
+% @value_to_double promotes either to double.
+plawk_foreign_fcall_wrapper_ir(Name, NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_foreign_set_reg_lines(NArgs, SetRegLines),
+    atomic_list_concat(SetRegLines, '\n', SetRegIR),
+    format(atom(IR),
+'define { double, i1 } @plawk_foreign_fcall_~w_~w(~w) {
+entry:
+  %vm = call %WamState* @plawk_foreign_vm_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs_saved = load i32, i32* %hs_ptr
+  %pc = load i32, i32* @~w_start_pc
+  %unb = call %Value @value_unbound(i8* null)
+  %out_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %out_ref = call %Value @value_ref(i32 %out_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %pc)
+~w
+  call void @wam_set_reg(%WamState* %vm, i32 ~w, %Value %out_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %read_out, label %rewind_fail
+
+read_out:
+  %out = call %Value @wam_deref_value(%WamState* %vm, %Value %out_ref)
+  %out_is_num = call i1 @value_is_number(%Value %out)
+  br i1 %out_is_num, label %good, label %rewind_fail
+
+good:
+  %fval = call double @value_to_double(%Value %out)
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  %r0 = insertvalue { double, i1 } undef, double %fval, 0
+  %r1 = insertvalue { double, i1 } %r0, i1 true, 1
+  ret { double, i1 } %r1
+
+rewind_fail:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  br label %fail
+
+fail:
+  %f0 = insertvalue { double, i1 } undef, double 0.0, 0
+  %f1 = insertvalue { double, i1 } %f0, i1 false, 1
+  ret { double, i1 } %f1
 }',
         [Name, NArgs, ParamsIR, Name, SetRegIR, NArgs]).
 
@@ -1906,13 +2011,17 @@ plawk_binfmt_foreign_arg_ok(Descriptor, field(Index)) :-
     integer(Index),
     Index >= 1,
     plawk_binfmt_field_type(Descriptor, Index, Type),
-    ( Type == i64 ; Type = blob(_Cap) ),
+    ( Type == i64 ; Type == f64 ; Type = blob(_Cap) ),
     !.
 
 plawk_binfmt_f64_expr_ok(Descriptor, float_field(Index)) :-
     !,
     plawk_binfmt_field_type(Descriptor, Index, f64).
 plawk_binfmt_f64_expr_ok(_Descriptor, float_const(_Mantissa, _Denominator)) :- !.
+plawk_binfmt_f64_expr_ok(Descriptor, float_call(Name, Args)) :-
+    !,
+    atom(Name),
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
 plawk_binfmt_f64_expr_ok(Descriptor, Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
     !,
@@ -3938,6 +4047,8 @@ plawk_f64_scalar_read_operand_expr(float_const(Mantissa, Denominator)) :-
 plawk_f64_scalar_read_operand_expr(float_field(Index)) :-
     integer(Index),
     Index >= 0.
+plawk_f64_scalar_read_operand_expr(float_call(Name, Args)) :-
+    plawk_prolog_call_expr(prolog_call(Name, Args)).
 plawk_f64_scalar_read_operand_expr(Expr) :-
     plawk_i64_operand_expr(Expr).
 plawk_f64_scalar_read_operand_expr(Expr) :-
@@ -4381,6 +4492,7 @@ plawk_i64_binary_op_lines(LLVMOp, Base, LeftIR, RightIR, [Line]) :-
 %  sitofp at emission time.
 plawk_expr_is_double(float_const(_Mantissa, _Denominator)).
 plawk_expr_is_double(float_field(_Index)).
+plawk_expr_is_double(float_call(_Name, _Args)).
 % A substituted read of a double scalar slot (see
 % plawk_substitute_scalar_reads/4).
 plawk_expr_is_double(ssa_f64(_Value)).
@@ -4438,6 +4550,27 @@ plawk_f64_expr_ir(float_field(Index), FieldSeparator, Base, _GlobalBase,
     format(atom(CallIR),
         '  ~w = call double @wam_atom_field_f64_value(%Value %line, i64 ~w, i8 ~w)',
         [ValueIR, Index, FieldSeparator]).
+% float(name(args)): the double-returning foreign call. A failed call
+% contributes 0.0, mirroring the i64 prolog_call contract.
+plawk_f64_expr_ir(float_call(Name, Args), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    !,
+    length(Args, NArgs),
+    plawk_foreign_args_ir(Args, FieldSeparator, GlobalBase, ArgValueIRs,
+        GlobalParts, ArgSetupParts),
+    plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
+    format(atom(ResIR),
+        '  %~w_res = call { double, i1 } @plawk_foreign_fcall_~w_~w(~w)',
+        [Base, Name, NArgs, CallArgsIR]),
+    format(atom(ValIR),
+        '  %~w_val = extractvalue { double, i1 } %~w_res, 0', [Base, Base]),
+    format(atom(OkIR),
+        '  %~w_ok = extractvalue { double, i1 } %~w_res, 1', [Base, Base]),
+    format(atom(SelIR),
+        '  %~w = select i1 %~w_ok, double %~w_val, double 0.0',
+        [Base, Base, Base]),
+    format(atom(ValueIR), '%~w', [Base]),
+    append(ArgSetupParts, [ResIR, ValIR, OkIR, SelIR], SetupParts).
 plawk_f64_expr_ir(Expr, FieldSeparator, Base, GlobalBase, ValueIR,
         GlobalParts, SetupParts) :-
     plawk_expr_is_double(Expr),
@@ -5020,6 +5153,21 @@ plawk_foreign_arg_ir(field(FieldIndex), binfmt(Types), ArgBase, ArgValueIR,
         LoadedIR, LoadLines),
     format(atom(ValueLine),
         '  %~w_v = call %Value @value_integer(i64 ~w)', [ArgBase, LoadedIR]),
+    format(atom(ArgValueIR), '%~w_v', [ArgBase]),
+    append(LoadLines, [ValueLine], SetupParts).
+% f64 fields marshal as WAM floats: a typed double load, then
+% @value_float packs the bits under the Float tag.
+plawk_foreign_arg_ir(field(FieldIndex), binfmt(Types), ArgBase, ArgValueIR,
+        [], SetupParts) :-
+    integer(FieldIndex),
+    FieldIndex >= 1,
+    plawk_binfmt_field_type(binfmt(Types), FieldIndex, f64),
+    !,
+    format(atom(LoadBase), '~w_bf', [ArgBase]),
+    plawk_binfmt_field_load_lines(binfmt(Types), FieldIndex, LoadBase,
+        LoadedIR, LoadLines),
+    format(atom(ValueLine),
+        '  %~w_v = call %Value @value_float(double ~w)', [ArgBase, LoadedIR]),
     format(atom(ArgValueIR), '%~w_v', [ArgBase]),
     append(LoadLines, [ValueLine], SetupParts).
 plawk_foreign_arg_ir(field(FieldIndex), binfmt(Types), ArgBase, ArgValueIR,

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2048,6 +2048,18 @@ plawk_binfmt_writebin_args_ok(Descriptor, [s(Width) | Types], [Field | Fields]) 
 plawk_binfmt_writebin_args_ok(Descriptor, [lps(Cap) | Types], [Field | Fields]) :-
     plawk_binfmt_writebin_str_ok(Descriptor, Field, Cap),
     plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+plawk_binfmt_writebin_args_ok(Descriptor, [rep(Cap, ElemTypes) | Types],
+        [Field | Fields]) :-
+    plawk_binfmt_writebin_rep_ok(Descriptor, rep(Cap, ElemTypes), Field),
+    plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+
+% rep passthrough: the argument names the input rep's COUNT field, and
+% the input rep must match the output slot exactly (same cap, same
+% element layout) -- count and live elements copy through unchanged.
+plawk_binfmt_writebin_rep_ok(binfmt(InTypes), rep(Cap, ElemTypes),
+        field(CountIndex)) :-
+    plawk_binfmt_rep_info(InTypes, CountIndex, Cap, _ElemArity),
+    memberchk(rep(Cap, ElemTypes), InTypes).
 
 plawk_binfmt_writebin_str_ok(_Descriptor, string(Value), Width) :-
     !,
@@ -2406,8 +2418,7 @@ plawk_binfmt_record_size(binfmt(Types), Size) :-
 plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules, WritebinPlan) :-
     ( plawk_rules_have_writebin(Rules0)
     ->  plawk_begin_outfmt_types(BeginClauses, Types),
-        forall(member(Type, Types),
-            ( memberchk(Type, [i64, f64]) ; Type = s(_W) ; Type = lps(_C) )),
+        forall(member(Type, Types), plawk_outfmt_type_ok(Type)),
         plawk_binfmt_record_size(binfmt(Types), Size),
         WritebinPlan = outfmt(Types, Size),
         maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules)
@@ -2433,8 +2444,7 @@ plawk_resolve_union_writebin_blocks(BeginClauses, CaseBlocks0, CaseBlocks,
     ( member(case_arm(_I, ArmRules), CaseBlocks0),
       plawk_rules_have_writebin(ArmRules)
     ->  plawk_begin_outfmt_types(BeginClauses, Types),
-        forall(member(Type, Types),
-            ( memberchk(Type, [i64, f64]) ; Type = s(_W) ; Type = lps(_C) )),
+        forall(member(Type, Types), plawk_outfmt_type_ok(Type)),
         plawk_binfmt_record_size(binfmt(Types), Size),
         WritebinPlan = outfmt(Types, Size),
         maplist(plawk_resolve_union_writebin_block(Types), CaseBlocks0,
@@ -2473,8 +2483,9 @@ plawk_resolve_writebin_action(_Types, Action, Action).
 plawk_begin_outfmt_types(BeginClauses, Types) :-
     member(begin(Actions), BeginClauses),
     member(set(var('OUTFMT'), string(Fmt)), Actions),
-    split_string(Fmt, " ", " ", Parts0),
-    exclude(==(""), Parts0, Parts),
+    % the shared tokenizer joins parenthesized types, so OUTFMT can
+    % carry a rep: "i64 rep4(i64 f64)"
+    plawk_binfmt_tokens(Fmt, Parts),
     Parts \== [],
     maplist(plawk_binfmt_type, Parts, Types).
 
@@ -2519,9 +2530,22 @@ plawk_writebin_args_ok([Type | Types], [Field | Fields]) :-
     -> plawk_writebin_str_arg(Field, Width)
     ;  Type = lps(Cap)
     -> plawk_writebin_str_arg(Field, Cap)
+    ;  Type = rep(_K, _Elems)
+    -> Field = field(_CountIndex)
     ;  plawk_writebin_f64_arg(Field)
     ),
     plawk_writebin_args_ok(Types, Fields).
+
+% OUTFMT slot types: i64/f64/sN/lpsN as before, plus rep passthrough
+% (fixed-width elements only -- the element region is copied as one
+% bulk write, which requires in-memory layout == wire layout).
+plawk_outfmt_type_ok(i64) :- !.
+plawk_outfmt_type_ok(f64) :- !.
+plawk_outfmt_type_ok(s(_W)) :- !.
+plawk_outfmt_type_ok(lps(_C)) :- !.
+plawk_outfmt_type_ok(rep(_K, ElemTypes)) :-
+    forall(member(ElemType, ElemTypes),
+        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_) )).
 
 % sN output slots take string literals that fit the width, or field
 % reads (validated against the input layout separately in binary mode;
@@ -2632,6 +2656,37 @@ plawk_writebin_varlen_slot_lines(lps(Cap), Field, FieldSeparator, Base,
         '  %~w_pwr = call i64 @fwrite(i8* ~w, i64 ~w, i64 1, i8* ~w)',
         [Base, PtrIR, LenIR, Stdout]),
     append(SourceLines, [LenStore, PayloadWrite], Lines).
+plawk_writebin_varlen_slot_lines(rep(_Cap, ElemTypes), field(CountIndex),
+        binfmt(InTypes), Base, BasePtr, Stdout, Lines, []) :-
+    !,
+    % rep passthrough: write the live count, then the live elements as
+    % one bulk write straight from the input record's element region
+    % (fixed-width elements, so in-memory layout == wire layout; a
+    % zero count writes nothing -- fwrite with size 0 is a no-op).
+    maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
+    sum_list(ElemWidths, ElemSize),
+    plawk_binfmt_field_offset(binfmt(InTypes), CountIndex, CountOff),
+    ElemsOff is CountOff + 8,
+    format(atom(RepIR),
+'  %~w_cfp = getelementptr i8, i8* %rec, i64 ~w
+  %~w_ctp = bitcast i8* %~w_cfp to i64*
+  %~w_n = load i64, i64* %~w_ctp, align 1
+  %~w_csp = bitcast i8* ~w to i64*
+  store i64 %~w_n, i64* %~w_csp, align 1
+  %~w_cwr = call i64 @fwrite(i8* ~w, i64 8, i64 1, i8* ~w)
+  %~w_efp = getelementptr i8, i8* %rec, i64 ~w
+  %~w_bytes = mul i64 %~w_n, ~w
+  %~w_ewr = call i64 @fwrite(i8* %~w_efp, i64 %~w_bytes, i64 1, i8* ~w)',
+        [Base, CountOff,
+         Base, Base,
+         Base, Base,
+         Base, BasePtr,
+         Base, Base,
+         Base, BasePtr, Stdout,
+         Base, ElemsOff,
+         Base, Base, ElemSize,
+         Base, Base, Base, Stdout]),
+    Lines = [RepIR].
 plawk_writebin_varlen_slot_lines(Type, Field, FieldSeparator, Base, BasePtr,
         Stdout, Lines, GParts) :-
     % numeric slot: stage the value in the scratch buffer, write 8 bytes

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -238,13 +238,17 @@ plawk_program_native_driver_ir(
 % chain where each rule's guard checks the record tag before its own
 % pattern, and each rule's fields type against its arm's layout. The
 % END print block is optional (a pure per-arm printer needs none).
+% writebin works inside case blocks: OUTFMT is program-wide, source
+% fields type against each rule's arm.
 plawk_program_native_driver_ir(
-    program(BeginClauses, case_blocks(CaseBlocks), EndClauses),
+    program(BeginClauses, case_blocks(CaseBlocks0), EndClauses),
     InputPath,
     DriverIR
 ) :-
     plawk_record_descriptor(BeginClauses, Descriptor),
     Descriptor = binfmt_union(Arms),
+    plawk_resolve_union_writebin_blocks(BeginClauses, CaseBlocks0, CaseBlocks,
+        WritebinPlan),
     plawk_union_program_ok(Arms, CaseBlocks),
     plawk_union_flatten_rules(CaseBlocks, Arms, Rules),
     (   EndClauses = [end([print(PrintFields)])]
@@ -253,16 +257,27 @@ plawk_program_native_driver_ir(
         PrintFields = [],
         HasEnd = false
     ),
-    plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
+    (   plawk_scalar_state_plan(Rules, PrintFields, StatePlan)
+    ->  true
+    ;   % a pure normalizer: every rule just writebins its arm into
+        % the shared output layout -- no scalar state at all
+        WritebinPlan = outfmt(_OutTypes, _OutSize),
+        PrintFields == [],
+        StatePlan = state_plan([])
+    ),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
-    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR0),
+    plawk_writebin_entry_lines(WritebinPlan, WritebinEntryIR),
+    plawk_join_nonempty_ir([BeginIR0, WritebinEntryIR], BeginIR),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, Descriptor, OutputSeparator,
         RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
     plawk_rules_body_print_fields(Rules, BodyPrintFields),
     plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
-    append(PrintFields, BodyPrintFields, PrintExprs),
+    plawk_rules_writebin_exprs(Rules, WritebinExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs0),
+    append(PrintExprs0, WritebinExprs, PrintExprs),
     append(PrintExprs, ScalarExprs, RecordCounterExprs),
     plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
     plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
@@ -276,8 +291,9 @@ plawk_program_native_driver_ir(
     ->  plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, EndPrintIR)
     ;   EndPrintIR = ''
     ),
-    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
-        [BeginGlobalIR, StringGlobalIR, RuleGlobalIR]),
+    plawk_writebin_globals(WritebinPlan, WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, RuleGlobalIR, WritebinGlobalIR]),
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
@@ -2305,6 +2321,33 @@ plawk_rules_have_writebin(Rules) :-
     member(rule(_Pattern, Actions), Rules),
     plawk_actions_have_writebin(Actions),
     !.
+
+%% plawk_resolve_union_writebin_blocks(+BeginClauses, +CaseBlocks0,
+%%     -CaseBlocks, -WritebinPlan)
+%
+%  The case-block variant of the writebin pre-pass: OUTFMT is
+%  program-wide (one output layout regardless of which arm produced
+%  the record), so the plan is built once and every arm's rules are
+%  stamped with it. Source-field typing against each rule's own arm
+%  happens downstream via the per-rule descriptor.
+plawk_resolve_union_writebin_blocks(BeginClauses, CaseBlocks0, CaseBlocks,
+        WritebinPlan) :-
+    ( member(case_arm(_I, ArmRules), CaseBlocks0),
+      plawk_rules_have_writebin(ArmRules)
+    ->  plawk_begin_outfmt_types(BeginClauses, Types),
+        forall(member(Type, Types),
+            ( memberchk(Type, [i64, f64]) ; Type = s(_W) ; Type = lps(_C) )),
+        plawk_binfmt_record_size(binfmt(Types), Size),
+        WritebinPlan = outfmt(Types, Size),
+        maplist(plawk_resolve_union_writebin_block(Types), CaseBlocks0,
+            CaseBlocks)
+    ;   WritebinPlan = none,
+        CaseBlocks = CaseBlocks0
+    ).
+
+plawk_resolve_union_writebin_block(Types, case_arm(Index, Rules0),
+        case_arm(Index, Rules)) :-
+    maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules).
 
 plawk_actions_have_writebin(Actions) :-
     member(Action, Actions),

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -305,6 +305,86 @@ plawk_program_native_driver_ir(
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% Tagged-union group-by: case-block (or TAG-guarded) rules whose
+% actions are assoc increments, with the shared END report. Keys are
+% the raw i64 field values of each rule's own arm; every arm updates
+% the same table per array name (as in awk, counts[k] is one array no
+% matter which rule touched it).
+plawk_program_native_driver_ir(
+    program(BeginClauses, case_blocks(CaseBlocks), [end([print(PrintFields)])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_record_descriptor(BeginClauses, Descriptor),
+    Descriptor = binfmt_union(Arms),
+    plawk_union_flatten_rules(CaseBlocks, Arms, Rules),
+    plawk_assoc_runtime_count_plan(Rules, PrintFields, AssocPlan),
+    plawk_assoc_record_program_ok(Descriptor, Rules, PrintFields),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, Descriptor, AssocRuleGlobalIR, AssocChainIR),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs),
+    append(PrintExprs, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_join_nonempty_ir([RecordCounterIR, AssocChainIR], RecordIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_assoc_end_print_ir(PrintFields, AssocPlan, Descriptor, OutputSeparator, EndPrintIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, AssocRuleGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w
+  ret i32 0',
+        [EndPrintIR]),
+    plawk_emit_record_driver_ir(Descriptor, InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, RecordLoopPhiIR, lowered_assoc,
+            RecordIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
+% ... and the canonical group-by report: END { for (k in counts)
+% print k, counts[k] } over a tagged-union stream.
+plawk_program_native_driver_ir(
+    program(BeginClauses, case_blocks(CaseBlocks), [end([for_in(var(LoopVar), var(ArrayName), BodyActions)])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_record_descriptor(BeginClauses, Descriptor),
+    Descriptor = binfmt_union(Arms),
+    plawk_union_flatten_rules(CaseBlocks, Arms, Rules),
+    plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions, AssocPlan, PrintFields),
+    plawk_assoc_record_program_ok(Descriptor, Rules, PrintFields),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, Descriptor, AssocRuleGlobalIR, AssocChainIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_forin_end_print_ir(LoopVar, ArrayName, PrintFields, AssocPlan,
+        Descriptor, OutputSeparator, EndPrintIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, AssocRuleGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w',
+        [EndPrintIR]),
+    plawk_emit_record_driver_ir(Descriptor, InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
+            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 plawk_program_native_driver_ir(
     program(BeginClauses, Rules, [end([print(PrintFields)])]),
     InputPath,
@@ -942,7 +1022,8 @@ plawk_forin_body_print_lines([], _LoopVar, _ArrayName, _TableIndex, _AssocPlan,
         _Descriptor, _OutputSeparator, _) -->
     [].
 plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
-        TableIndex, AssocPlan, binfmt(Types), OutputSeparator, PrintIndex) -->
+        TableIndex, AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
+    { plawk_descriptor_is_binary(Descriptor) },
     % Binary mode: keys are raw i64 field values, printed numerically.
     plawk_forin_separator_lines(PrintIndex, OutputSeparator),
     { format(atom(FmtVar), 'forin_key_fmt_~w', [PrintIndex]),
@@ -953,7 +1034,7 @@ plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
     },
     [FmtPtr, PrintCall],
     plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
-        binfmt(Types), OutputSeparator, NextPrintIndex).
+        Descriptor, OutputSeparator, NextPrintIndex).
 plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
         TableIndex, AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_forin_separator_lines(PrintIndex, OutputSeparator),
@@ -1710,13 +1791,15 @@ plawk_assoc_rule_chain_lines([assoc_rule(Index, Pattern, Actions, Control) | Res
       format(atom(RuleLabel), 'assoc_rule_~w_match', [Index]),
       format(atom(ApplyLabel), 'assoc_rule_~w_apply', [Index]),
       plawk_rule_target(Control, NextLabel, RuleTargetLabel),
-      plawk_assoc_rule_apply_ir(Index, Actions, RuleTargetLabel, FieldSeparator, ApplyIR),
+      % tagged-union rules carry their arm's field types with them
+      plawk_rule_descriptor(Pattern, FieldSeparator, RuleDescriptor),
+      plawk_assoc_rule_apply_ir(Index, Actions, RuleTargetLabel, RuleDescriptor, ApplyIR),
       ( Index =:= 0
       -> EntryIR = '  br label %assoc_rule_0_match\n\n'
       ;  EntryIR = ''
       ),
       plawk_assoc_rule_guard_ir(Pattern, Index, RuleLabel, ApplyLabel,
-          NextLabel, EntryIR, FieldSeparator, GuardGlobalIR, BranchIR),
+          NextLabel, EntryIR, RuleDescriptor, GuardGlobalIR, BranchIR),
       format(atom(RuleIR),
 '~w
 
@@ -1848,6 +1931,21 @@ plawk_assoc_record_program_ok(binfmt(Types), Rules, EndPrintFields) :-
            ),
         % Integer literals in END lookups; the loop variable inside a
         % for-in body (the key is already the raw i64 slot key there).
+        ( Key = int(_) ; Key = var(_) )).
+% Tagged-union rules (already flattened): guards and counted keys type
+% against each rule's own arm; keys from every arm land in one shared
+% i64 keyspace, as in awk where counts[k] is one array no matter which
+% rule updated it.
+plawk_assoc_record_program_ok(binfmt_union(_Arms), Rules, EndPrintFields) :-
+    !,
+    forall(member(rule(arm_pat(_Tag, ArmTypes, Pattern), Actions), Rules),
+        ( plawk_binfmt_pattern_ok(binfmt(ArmTypes), Pattern),
+          forall(member(Action, Actions),
+              plawk_binfmt_assoc_action_ok(binfmt(ArmTypes), Action))
+        )),
+    forall(( member(Field, EndPrintFields),
+             Field = assoc(_Array, Key)
+           ),
         ( Key = int(_) ; Key = var(_) )).
 plawk_assoc_record_program_ok(_FieldSeparator, _Rules, EndPrintFields) :-
     % Text mode: integer assoc keys would collide with atom ids, so
@@ -3482,7 +3580,7 @@ plawk_assoc_end_print_lines([], AssocPlan, _Descriptor, _OutputSeparator, _) -->
     plawk_assoc_free_lines(AssocPlan).
 plawk_assoc_end_print_lines([assoc(var(ArrayName), int(Key)) | Rest], AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
-    { Descriptor = binfmt(_Types),
+    { plawk_descriptor_is_binary(Descriptor),
       plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
       format(atom(Value),
           '  %assoc_end_value_~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 ~w)',
@@ -3528,6 +3626,11 @@ plawk_assoc_end_print_lines([string(Value) | Rest], AssocPlan, Descriptor, Outpu
 
 plawk_assoc_table_index(assoc_plan(Tables, _Actions), ArrayName, TableIndex) :-
     nth0(TableIndex, Tables, ArrayName).
+
+% Binary record modes: assoc keys are raw i64 field values (no
+% interning), so END key handling prints them numerically.
+plawk_descriptor_is_binary(binfmt(_Types)).
+plawk_descriptor_is_binary(binfmt_union(_Arms)).
 
 plawk_assoc_free_lines(assoc_plan(Tables, _Actions)) -->
     plawk_assoc_free_lines(Tables, 0).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -662,6 +662,8 @@ scalar_delta_expr(Expr) -->
 scalar_delta_expr(Expr) -->
     float_field_expr(Expr).
 scalar_delta_expr(Expr) -->
+    float_call_expr(Expr).
+scalar_delta_expr(Expr) -->
     float_literal_expr(Expr).
 scalar_delta_expr(int(Value)) -->
     integer_codes(ValueCodes),
@@ -1015,6 +1017,22 @@ float_literal_expr(float_const(Mantissa, Denominator)) -->
       length(FracCodes, FracLen),
       Denominator is 10 ** FracLen
     }.
+
+%% float_call_expr(-Expr)//
+%
+%  float(name(args)): a compiled-Prolog call whose output argument is
+%  numeric and lands in a double context -- Float results keep their
+%  fraction (an i64-context call would truncate the surface to
+%  integers). The float(...) wrapper is what selects the
+%  double-returning wrapper at codegen time.
+float_call_expr(float_call(Name, Args)) -->
+    "float",
+    ws,
+    "(",
+    ws,
+    prolog_call_expr(prolog_call(Name, Args)),
+    ws,
+    ")".
 
 %% float_field_expr(-Expr)//
 %

--- a/tests/test_plawk_f64_foreign.pl
+++ b/tests/test_plawk_f64_foreign.pl
@@ -1,0 +1,160 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+% Compiled into the probe binary alongside the plawk driver.
+plawk_ff_wf(I, F, R) :- R is I * F.
+plawk_ff_bigf(F) :- F > 1.
+plawk_ff_posval(F, R) :- F > 0.0, R is F + F.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_f64_foreign, [condition(clang_available)]).
+
+test(f64_field_arg_marshals_as_wam_float) :-
+    build_ff_ir("BEGIN { BINFMT = \"i64 f64\" } plawk_ff_bigf($2) { hits++ } END { print hits }\n", DriverIR),
+    % a typed double load, then the Float constructor -- no text, no
+    % interning anywhere near the argument
+    assertion(once(sub_atom(DriverIR, _, _, _, '@value_float(double %'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value')),
+    !.
+
+test(float_call_uses_double_wrapper) :-
+    build_ff_ir("BEGIN { BINFMT = \"i64 f64\" } { wsum += float(plawk_ff_wf($1, $2)) } END { print wsum }\n", DriverIR),
+    % the double-returning wrapper: numeric-output check, promote via
+    % @value_to_double, {double, i1} contract, 0.0 on failure
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define { double, i1 } @plawk_foreign_fcall_plawk_ff_wf_2'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@value_is_number'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@value_to_double'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'double %'))),
+    % and the site selects 0.0 when the call fails
+    assertion(once(sub_atom(DriverIR, _, _, _, ', double 0.0'))),
+    !.
+
+test(f64_foreign_rejections) :-
+    Rejects = [
+        % $3 does not exist in the layout
+        "BEGIN { BINFMT = \"i64 f64\" } { wsum += float(plawk_ff_wf($1, $3)) } END { print wsum }\n",
+        % string fields still do not marshal in binary mode
+        "BEGIN { BINFMT = \"s8 f64\" } { wsum += float(plawk_ff_wf($1, $2)) } END { print wsum }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ build_ff_ir_for(Program, _))
+        ;  true
+        )).
+
+test(surface_float_call_and_float_guard) :-
+    % wf multiplies the i64 by the f64 in WAM arithmetic (Float
+    % result); bigf compares the f64 against an integer.
+    % (2,1.5) (3,0.25) (1,2.5): wsum = 3.0+0.75+2.5, hits = 2.
+    run_ff_smoke("BEGIN { BINFMT = \"i64 f64\" } { wsum += float(plawk_ff_wf($1, $2)) } plawk_ff_bigf($2) { hits++ } END { print hits, wsum }\n",
+        [rec(2, 1.5), rec(3, 0.25), rec(1, 2.5)],
+        "2 6.25\n").
+
+test(surface_failed_float_call_contributes_zero) :-
+    % posval fails on non-positive inputs: those records add 0.0.
+    % (1,1.5) (2,-2.5) (3,0.25): wsum = 3.0 + 0.0 + 0.5.
+    run_ff_smoke("BEGIN { BINFMT = \"i64 f64\" } { wsum += float(plawk_ff_posval($2)) } END { print wsum }\n",
+        [rec(1, 1.5), rec(2, -2.5), rec(3, 0.25)],
+        "3.5\n").
+
+:- end_tests(plawk_f64_foreign).
+
+% --- helpers ---------------------------------------------------------------
+
+ff_preds([ user:plawk_ff_wf/3,
+           user:plawk_ff_bigf/1,
+           user:plawk_ff_posval/2
+         ]).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,   0x3FF8000000000000).
+double_bits(0.25,  0x3FD0000000000000).
+double_bits(2.5,   0x4004000000000000).
+double_bits(-2.5,  0xC004000000000000).
+
+% rec(I64, F64)
+write_ff_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(I, F), Recs),
+            ( write_i64_le(Out, I),
+              double_bits(F, Bits),
+              write_i64_le(Out, Bits) )),
+        close(Out)).
+
+build_ff_ir(Source, DriverIR) :-
+    plawk_parse_string(Source, Program),
+    build_ff_ir_for(Program, DriverIR).
+
+build_ff_ir_for(Program, DriverIR) :-
+    once(( tmp_root(Root),
+           directory_file_path(Root, 'uw_plawk_f64_foreign_ir', Dir),
+           clean_dir(Dir),
+           make_directory_path(Dir),
+           directory_file_path(Dir, 'ir_probe.ll', LLPath),
+           ff_preds(Preds),
+           write_wam_llvm_project(Preds, [module_name('plawk_ff_ir')], LLPath),
+           wam_llvm_last_compile_counts(InstrCount, LabelCount) )),
+    plawk_program_native_driver_ir(Program, 'input.bin',
+        [wam_vm(InstrCount, LabelCount)], DriverIR).
+
+build_ff_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_f64_foreign', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    ff_preds(Preds),
+    write_wam_llvm_project(Preds, [module_name('plawk_f64_foreign')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_program_native_driver_ir(Program, InputPath,
+        [wam_vm(InstrCount, LabelCount)], DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk f64 foreign build output]~n~w~n", [BuildOut]),
+       throw(plawk_f64_foreign_build_failed(Status))
+    ).
+
+run_ff_smoke(Source, Recs, ExpectedOutput) :-
+    build_ff_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_ff_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.

--- a/tests/test_plawk_rep_writer.pl
+++ b/tests/test_plawk_rep_writer.pl
@@ -1,0 +1,149 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_rpw_marker/0.
+
+user:plawk_rpw_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_rep_writer, [condition(clang_available)]).
+
+test(rep_outfmt_writes_count_then_bulk_elements) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64 f64)\" } $1 > 0 { writebin $1, $2 ; kept++ } END { print kept }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % the rep slot: live count staged + written (8 bytes), then one
+    % bulk fwrite of count*16 element bytes straight from %rec
+    assertion(once(sub_atom(DriverIR, _, _, _, '_cwr = call i64 @fwrite(i8* %'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_ewr = call i64 @fwrite(i8* %'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(rep_outfmt_rejections) :-
+    Rejects = [
+        % caps must match (a bigger output cap cannot invent elements,
+        % a smaller one could not hold the count)
+        "BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep8(i64 f64)\" } { writebin $1, $2 }\n",
+        % element layouts must match exactly
+        "BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64)\" } { writebin $1, $2 }\n",
+        % the rep argument must be the input rep's count field
+        "BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64 f64)\" } { writebin $1, $1 }\n",
+        % lps elements are not bulk-copyable (wire differs per element)
+        "BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" ; OUTFMT = \"i64 rep4(lps8 i64)\" } { writebin $1, $2 }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_rep_filter_is_byte_exact) :-
+    % A stream filter: guarded records pass through byte-identical
+    % (count + live elements only -- the writer never pads).
+    Keep = [rec(1, [e(5, 1.5), e(20, 2.5)]), rec(3, [])],
+    Drop = [rec(-2, [e(9, 1.5)])],
+    Input = [rec(1, [e(5, 1.5), e(20, 2.5)]), rec(-2, [e(9, 1.5)]), rec(3, [])],
+    run_rpw_smoke("BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64 f64)\" } $1 > 0 { writebin $1, $2 }\n",
+        Input, OutBytes),
+    records_bytes(Keep, ExpectedBytes),
+    records_bytes(Drop, DropBytes),
+    assertion(OutBytes == ExpectedBytes),
+    assertion(OutBytes \== DropBytes).
+
+test(surface_rep_passthrough_in_union_arm) :-
+    % Composes with case blocks: arm 0 carries the rep, its rule
+    % passes it through with a rewritten leading field.
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 rep2(i64) | i64)\" ; OUTFMT = \"i64 rep2(i64)\" } TAG == 0 { writebin NR, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_ewr = call i64 @fwrite(i8* %'))),
+    !.
+
+:- end_tests(plawk_rep_writer).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5, 0x3FF8000000000000).
+double_bits(2.5, 0x4004000000000000).
+
+% rec(Id, Elems): i64 id, i64 count, then per element i64 + f64
+write_rpw_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        write_rpw_stream(Out, Recs),
+        close(Out)).
+
+write_rpw_stream(Out, Recs) :-
+    forall(member(rec(Id, Elems), Recs),
+        ( write_i64_le(Out, Id),
+          length(Elems, Count),
+          write_i64_le(Out, Count),
+          forall(member(e(V, F), Elems),
+              ( write_i64_le(Out, V),
+                double_bits(F, Bits),
+                write_i64_le(Out, Bits) )) )).
+
+% the byte string a record list occupies on the wire
+records_bytes(Recs, Bytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_rep_writer_expect.bin', Path),
+    write_rpw_records(Path, Recs),
+    setup_call_cleanup(
+        open(Path, read, In, [type(binary)]),
+        read_string(In, _, Bytes),
+        close(In)).
+
+run_rpw_smoke(Source, Recs, OutBytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_rep_writer', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_rpw_marker/0 ],
+        [module_name('plawk_rep_writer')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(BuildOutS)), stderr(std), process(BuildPid)]),
+    read_string(BuildOutS, _, BuildOut),
+    close(BuildOutS),
+    process_wait(BuildPid, BuildStatus),
+    ( BuildStatus == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk rep writer build output]~n~w~n", [BuildOut]),
+       throw(plawk_rep_writer_build_failed(BuildStatus))
+    ),
+    write_rpw_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, OutBytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    !.

--- a/tests/test_plawk_tagged_unions.pl
+++ b/tests/test_plawk_tagged_unions.pl
@@ -50,8 +50,9 @@ test(union_rejections) :-
         "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { $1 == \"x\" { c++ } } END { print c }\n",
         % numeric compare on an lps field
         "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 1 { $1 > 5 { c++ } } END { print c }\n",
-        % assoc arrays are not in the union slice
-        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { { counts[$1]++ } } END { print counts[5] }\n",
+        % assoc keys must be raw i64 fields of their arm ($1 in arm 1
+        % is a string)
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 1 { { counts[$1]++ } } END { print counts[5] }\n",
         % case blocks demand a union BINFMT
         "case 0 { { c++ } } END { print c }\n",
         "BEGIN { BINFMT = \"i64 i64\" } case 0 { { c++ } } END { print c }\n"

--- a/tests/test_plawk_tier2_blob.pl
+++ b/tests/test_plawk_tier2_blob.pl
@@ -89,8 +89,8 @@ test(binfmt_i64_foreign_arg_is_value_integer) :-
 
 test(tier2_rejections) :-
     Rejects = [
-        % f64 fields are not marshalable in this slice
-        "BEGIN { BINFMT = \"f64 blob32\" } { t += plawk_payload_sum($1) } END { print t }\n",
+        % string fields are not marshalable in binary mode
+        "BEGIN { BINFMT = \"s8 blob32\" } { t += plawk_payload_sum($1) } END { print t }\n",
         % blob fields have no print/guard/arithmetic role
         "BEGIN { BINFMT = \"i64 blob32\" } { print $2 }\n",
         "BEGIN { BINFMT = \"i64 blob32\" } $2 == \"x\" { c++ } END { print c }\n",

--- a/tests/test_plawk_union_assoc.pl
+++ b/tests/test_plawk_union_assoc.pl
@@ -1,0 +1,152 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_uas_marker/0.
+
+user:plawk_uas_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_union_assoc, [condition(clang_available)]).
+
+test(union_assoc_ir_keys_are_arm_relative_loads) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 | lps8 i64)\" } case 0 { { counts[$1]++ } } case 1 { { counts[$2]++ } } END { for (k in counts) print k, counts[k] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % the union reader's tag switch feeds one shared table; arm 0's key
+    % loads at offset 0, arm 1's i64 key after its 8-byte string slot
+    assertion(once(sub_atom(DriverIR, _, _, _, 'switch i64 %vr_tag'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_new'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%assoc_rule_0_action_0_key_fp = getelementptr i8, i8* %rec, i64 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%assoc_rule_1_action_0_key_fp = getelementptr i8, i8* %rec, i64 8'))),
+    % raw i64 keys: no interning anywhere in the update path
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'assoc_rule_0_action_0_key_id')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(union_assoc_rejections) :-
+    Rejects = [
+        % arm 1's $1 is a string: not a raw-i64 key
+        "BEGIN { BINFMT = \"case(i64 | lps8 i64)\" } case 1 { { counts[$1]++ } } END { print counts[5] }\n",
+        % string lookups stay text-mode-only
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { { counts[$1]++ } } END { print counts[\"x\"] }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_union_groupby_forin) :-
+    % One shared keyspace across arms: metric ids and event values
+    % count into the same table.
+    run_uas_sorted_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } case 0 { { counts[$1]++ } } case 1 { { counts[$2]++ } } END { for (k in counts) print k, counts[k] }\n",
+        [m(5, 1.5), e("x", 9), m(5, 2.5), e("y", 5), m(9, 1.5)],
+        ["5 3", "9 2"]).
+
+test(surface_union_groupby_tag_guards_and_lookup) :-
+    % Tag-guard spelling with a residual guard, END int lookup.
+    run_uas_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" } TAG == 0 && $1 > 10 { counts[$1]++ } TAG == 1 { counts[$2]++ } END { print counts[20], counts[5] }\n",
+        [m(20, 1.5), e("a", 20), m(5, 2.5), m(20, 1.5), e("b", 5)],
+        "3 1\n").
+
+:- end_tests(plawk_union_assoc).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5, 0x3FF8000000000000).
+double_bits(2.5, 0x4004000000000000).
+
+% m(V, F): tag 0, i64, f64.  e(S, C): tag 1, lps16, i64.
+write_uas_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Rec, Recs), write_uas_record(Out, Rec)),
+        close(Out)).
+
+write_uas_record(Out, m(V, F)) :-
+    write_i64_le(Out, 0),
+    write_i64_le(Out, V),
+    double_bits(F, Bits),
+    write_i64_le(Out, Bits).
+write_uas_record(Out, e(S, C)) :-
+    write_i64_le(Out, 1),
+    string_codes(S, Codes),
+    length(Codes, Len),
+    write_i64_le(Out, Len),
+    forall(member(Code, Codes), put_byte(Out, Code)),
+    write_i64_le(Out, C).
+
+build_uas_probe(Source, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_union_assoc', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_uas_marker/0 ],
+        [module_name('plawk_union_assoc')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk union assoc build output]~n~w~n", [BuildOut]),
+       throw(plawk_union_assoc_build_failed(Status))
+    ).
+
+run_capture(BinPath, OutStr) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)).
+
+run_uas_smoke(Source, Recs, ExpectedOutput) :-
+    build_uas_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_uas_records(InputPath, Recs),
+    run_capture(BinPath, OutStr),
+    assertion(OutStr == ExpectedOutput),
+    !.
+
+run_uas_sorted_smoke(Source, Recs, ExpectedLines) :-
+    build_uas_probe(Source, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_uas_records(InputPath, Recs),
+    run_capture(BinPath, OutStr),
+    split_string(OutStr, "\n", "", Split0),
+    exclude(==(""), Split0, Lines0),
+    msort(Lines0, SortedLines),
+    msort(ExpectedLines, SortedExpected),
+    assertion(SortedLines == SortedExpected),
+    !.

--- a/tests/test_plawk_union_writebin.pl
+++ b/tests/test_plawk_union_writebin.pl
@@ -1,0 +1,178 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_uwb_marker/0.
+
+user:plawk_uwb_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_union_writebin, [condition(clang_available)]).
+
+test(union_writebin_ir_shape) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" ; OUTFMT = \"i64 i64\" } case 0 { { writebin $1, NR } } case 1 { { writebin $2, NR } }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % shared output buffer in the entry block, one write per rule
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_wbuf = alloca [16 x i8]'))),
+    % arm 1's source is its i64 at offset 16 (after the lps16 slot)
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i8* %rec, i64 16'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(union_writebin_rejections) :-
+    Rejects = [
+        % writebin still demands OUTFMT
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" } case 0 { { writebin $1 } }\n",
+        % arm 1's $1 is a string; the output slot is i64
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" ; OUTFMT = \"i64\" } case 1 { { writebin $1 } }\n",
+        % argument count must match the output layout
+        "BEGIN { BINFMT = \"case(i64 | lps8)\" ; OUTFMT = \"i64 i64\" } case 0 { { writebin $1 } }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_union_normalizer) :-
+    % A pure normalizer: two record kinds in, one fixed layout out
+    % (value, NR). No END, no scalars -- just per-arm writebin.
+    run_uwb_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" ; OUTFMT = \"i64 i64\" } case 0 { { writebin $1, NR } } case 1 { { writebin $2, NR } }\n",
+        [m(50, 1.5), e("boom", 7), m(200, 2.5)],
+        Bytes),
+    decode_i64_pairs(Bytes, Records),
+    assertion(Records == [50-1, 7-2, 200-3]),
+    !.
+
+test(surface_union_lps_passthrough_with_tag_guards) :-
+    % Tag-guard spelling; arm 1's lps16 flows into an lps16 output
+    % slot; arm-0 records have no rule and are read + skipped.
+    run_uwb_smoke("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" ; OUTFMT = \"lps16 i64\" } TAG == 1 && $2 > 5 { writebin $1, $2 }\n",
+        [e("boom", 7), m(50, 1.5), e("skip", 2), e("full16bytes4sure", 9)],
+        Bytes),
+    decode_lps_i64(Bytes, Records),
+    assertion(Records == ["boom"-7, "full16bytes4sure"-9]),
+    !.
+
+:- end_tests(plawk_union_writebin).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5, 0x3FF8000000000000).
+double_bits(2.5, 0x4004000000000000).
+
+% m(V, F): tag 0, i64, f64.  e(S, C): tag 1, lps16, i64.
+write_uwb_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Rec, Recs), write_uwb_record(Out, Rec)),
+        close(Out)).
+
+write_uwb_record(Out, m(V, F)) :-
+    write_i64_le(Out, 0),
+    write_i64_le(Out, V),
+    double_bits(F, Bits),
+    write_i64_le(Out, Bits).
+write_uwb_record(Out, e(S, C)) :-
+    write_i64_le(Out, 1),
+    string_codes(S, Codes),
+    length(Codes, Len),
+    write_i64_le(Out, Len),
+    forall(member(Code, Codes), put_byte(Out, Code)),
+    write_i64_le(Out, C).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+decode_i64_pairs(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_i64_pairs_codes(Codes, Records).
+
+decode_i64_pairs_codes([], []).
+decode_i64_pairs_codes(Codes, [A-B | Records]) :-
+    length(ABytes, 8), length(BBytes, 8),
+    append(ABytes, Rest0, Codes), append(BBytes, Rest, Rest0),
+    le_i64(ABytes, A),
+    le_i64(BBytes, B),
+    decode_i64_pairs_codes(Rest, Records).
+
+decode_lps_i64(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_lps_i64_codes(Codes, Records).
+
+decode_lps_i64_codes([], []).
+decode_lps_i64_codes(Codes, [S-V | Records]) :-
+    length(LenBytes, 8),
+    append(LenBytes, Rest0, Codes),
+    le_i64(LenBytes, Len),
+    length(SBytes, Len),
+    append(SBytes, Rest1, Rest0),
+    string_codes(S, SBytes),
+    length(VBytes, 8),
+    append(VBytes, Rest, Rest1),
+    le_i64(VBytes, V),
+    decode_lps_i64_codes(Rest, Records).
+
+emit_probe(Dir, DriverIR, BinPath) :-
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_uwb_marker/0 ],
+        [module_name('plawk_union_writebin')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk union writebin build output]~n~w~n", [BuildOut]),
+       throw(plawk_union_writebin_build_failed(Status))
+    ).
+
+run_uwb_smoke(Source, Recs, Bytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_union_writebin', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    emit_probe(Dir, DriverIR, BinPath),
+    write_uwb_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    !.


### PR DESCRIPTION
## Why

The round-4 stack merged branch-to-branch: only #3438 reached this branch, while #3439, #3440, and #3441 landed on their respective base branches. This reassembles all four on the designated branch (plus a sync merge of main) and carries them the last step. No new content. **Merge first** — this round's feature PRs stack on top.

Contents: f64 marshaling across the foreign bridge, writebin inside case blocks, assoc arrays inside case blocks, repK in OUTFMT (byte-exact stream filters). Full regression sweep re-run on the assembled branch: all 48 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_