### PR TITLE
plawk: float(name(args)) in print position

### DIFF
--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -303,7 +303,8 @@ foreign guards and calls work over binary records generally; a
 double-returning call is spelled `wsum += float(score($1, $2))` (the
 float(...) wrapper selects a {double, ok} bridge that accepts Integer
 or Float results, keeping fractions that the i64 spelling would
-truncate; a failed call contributes 0.0). One blob argument per call;
+truncate; a failed call contributes 0.0); the same spelling works in
+print position (`print $1, float(score($1, $2))`). One blob argument per call;
 payloads are NUL-free byte strings. Bounded repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4717,6 +4717,8 @@ plawk_f64_operand_expr(float_const(Mantissa, Denominator)) :-
 plawk_f64_operand_expr(float_field(Index)) :-
     integer(Index),
     Index >= 0.
+plawk_f64_operand_expr(float_call(Name, Args)) :-
+    plawk_prolog_call_expr(prolog_call(Name, Args)).
 plawk_f64_operand_expr(Expr) :-
     plawk_i64_operand_expr(Expr).
 plawk_f64_operand_expr(Expr) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -872,6 +872,9 @@ field_expr(Expr) -->
     float_field_expr(Expr),
     !.
 field_expr(Expr) -->
+    float_call_expr(Expr),
+    !.
+field_expr(Expr) -->
     float_literal_expr(Expr),
     !.
 field_expr(Expr) -->

--- a/tests/test_plawk_f64_foreign.pl
+++ b/tests/test_plawk_f64_foreign.pl
@@ -63,6 +63,18 @@ test(surface_float_call_and_float_guard) :-
         [rec(2, 1.5), rec(3, 0.25), rec(1, 2.5)],
         "2 6.25\n").
 
+test(float_call_in_print_position_uses_double_wrapper) :-
+    build_ff_ir("BEGIN { BINFMT = \"i64 f64\" } $1 > 0 { print $1, float(plawk_ff_wf($1, $2)) } END { print done }\n", DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define { double, i1 } @plawk_foreign_fcall_plawk_ff_wf_2'))),
+    !.
+
+test(surface_float_call_prints_per_record) :-
+    % wf(I, F) = I * F printed per matching record; %g drops trailing
+    % zeros (3.0 prints as 3).
+    run_ff_smoke("BEGIN { BINFMT = \"i64 f64\" } $1 > 0 { print $1, float(plawk_ff_wf($1, $2)) } END { print done }\n",
+        [rec(2, 1.5), rec(-1, 2.5), rec(3, 0.25)],
+        "2 3\n3 0.75\n0\n").
+
 test(surface_failed_float_call_contributes_zero) :-
     % posval fails on non-positive inputs: those records add 0.0.
     % (1,1.5) (2,-2.5) (3,0.25): wsum = 3.0 + 0.0 + 0.5.


### PR DESCRIPTION
## Summary

First (smallest) slice of the round: the double-returning foreign-call spelling from the f64 bridge works as a print field:

```awk
BEGIN { BINFMT = "i64 f64" }
$1 > 0 { print $1, float(score($1, $2)) }
```

## Design

Two one-line gaps closed: the parser's print-field grammar gains the `float_call` alternative (next to `float($N)`), and `float_call` joins the f64 print-operand whitelist. Everything downstream already composed — the print emitters route any valid double expression through the f64 emitter (which learned `float_call` in #3438), `%g` formatting handles the value, validation reuses the existing f64-expr check, and spec collection already walked print fields for float calls.

## Tests

f64 foreign suite grows 5 → 7: the `{double, i1}` wrapper is emitted for a print-position call, and a per-record e2e prints `I*F` with `%g` formatting (`2 3\n3 0.75\n0\n` exact — `%g` drops the trailing zero of 3.0). Full sweep: **all 48 suites green.**

## Merge order

1. #3442 (consolidation → main) first
2. then this PR into `claude/plawk-llvm-wam-hybrid-p9ujut`; the rest of the round stacks on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_