### PR TITLE
plawk: for-in writebin over a tagged-union input

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -141,8 +141,10 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    shared table per array name; both END report shapes (for-in print,
    integer lookups) work, and the assoc rule chain resolves guards and
    key loads through the same per-rule arm descriptor as the scalar
-   chain. Not yet inside case blocks: union (tagged) output, and
-   for-in writebin over a union input.
+   chain. for-in writebin over a union input (landed): the END table
+   walk writebins one fixed-layout (key, count, ...) record per group,
+   mirroring the plain binary group-by-to-binary-output clause. Not
+   yet inside case blocks: union (tagged) output.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -423,6 +423,53 @@ plawk_program_native_driver_ir(
             RecordIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% Tagged-union group-by to binary output: case-block rules count per
+% arm, END iterates the table and writebins one fixed-layout record
+% per group.
+plawk_program_native_driver_ir(
+    program(BeginClauses, case_blocks(CaseBlocks), [end([for_in(var(LoopVar), var(ArrayName), [writebin(Fields)])])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_record_descriptor(BeginClauses, Descriptor),
+    Descriptor = binfmt_union(Arms),
+    plawk_union_flatten_rules(CaseBlocks, Arms, Rules),
+    plawk_begin_outfmt_types(BeginClauses, OutTypes),
+    forall(member(OutType, OutTypes), memberchk(OutType, [i64, f64])),
+    length(OutTypes, ArgCount),
+    length(Fields, ArgCount),
+    maplist(plawk_forin_writebin_field(LoopVar), Fields),
+    findall(LookupArrayName,
+        member(assoc(var(LookupArrayName), var(LoopVar)), Fields),
+        LookupArrays),
+    plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays, AssocPlan),
+    plawk_assoc_record_program_ok(Descriptor, Rules, []),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_binfmt_record_size(binfmt(OutTypes), OutRecordSize),
+    plawk_writebin_entry_lines(outfmt(OutTypes, OutRecordSize), WritebinEntryIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, Descriptor, AssocRuleGlobalIR, AssocChainIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_forin_end_writebin_ir(LoopVar, ArrayName, OutTypes, Fields, AssocPlan,
+        EndPrintIR),
+    plawk_writebin_globals(outfmt(OutTypes, OutRecordSize), WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, AssocRuleGlobalIR, WritebinGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR0),
+    plawk_combine_entry_ir(CombinedEntrySetupIR0, WritebinEntryIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w',
+        [EndPrintIR]),
+    plawk_emit_record_driver_ir(Descriptor, InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
+            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 % Binary group-by to binary output: iterate the table and writebin one
 % fixed-layout record per group. Binary input mode only -- text-mode
 % keys are interned atom ids, which would be meaningless bytes in the

--- a/tests/test_plawk_union_assoc.pl
+++ b/tests/test_plawk_union_assoc.pl
@@ -61,6 +61,25 @@ test(surface_union_groupby_tag_guards_and_lookup) :-
         [m(20, 1.5), e("a", 20), m(5, 2.5), m(20, 1.5), e("b", 5)],
         "3 1\n").
 
+test(surface_union_groupby_forin_writebin) :-
+    % Group-by to BINARY output over a union stream: one (key, count)
+    % record per group.
+    build_uas_probe("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" ; OUTFMT = \"i64 i64\" } case 0 { { counts[$1]++ } } case 1 { { counts[$2]++ } } END { for (k in counts) writebin k, counts[k] }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_uas_records(InputPath, [m(5, 1.5), e("x", 9), m(5, 2.5), e("y", 5), m(9, 1.5)]),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    decode_i64_pairs(Bytes, Records0),
+    msort(Records0, Records),
+    assertion(Records == [5-3, 9-2]),
+    !.
+
 :- end_tests(plawk_union_assoc).
 
 % --- helpers ---------------------------------------------------------------
@@ -93,6 +112,26 @@ write_uas_record(Out, e(S, C)) :-
     write_i64_le(Out, Len),
     forall(member(Code, Codes), put_byte(Out, Code)),
     write_i64_le(Out, C).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+decode_i64_pairs(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_i64_pairs_codes(Codes, Records).
+
+decode_i64_pairs_codes([], []).
+decode_i64_pairs_codes(Codes, [A-B | Records]) :-
+    length(ABytes, 8), length(BBytes, 8),
+    append(ABytes, Rest0, Codes), append(BBytes, Rest, Rest0),
+    le_i64(ABytes, A),
+    le_i64(BBytes, B),
+    decode_i64_pairs_codes(Rest, Records).
 
 build_uas_probe(Source, Dir, BinPath) :-
     tmp_root(Root),


### PR DESCRIPTION
## Summary

Second slice: the group-by-to-binary-output shape accepts a union stream —

```awk
BEGIN { BINFMT = "case(i64 f64 | lps16 i64)" ; OUTFMT = "i64 i64" }
case 0 { { counts[$1]++ } }
case 1 { { counts[$2]++ } }
END { for (k in counts) writebin k, counts[k] }
```

## Design

One new driver clause mirrors the plain binary group-by-to-binary-output clause for case-block programs: flatten the blocks, build the for-in assoc plan, validate through the union-aware assoc check from #3440, and emit the same table-walk writebin END. The assoc rule chain was already per-rule-descriptor aware, so arm-typed keys compose unchanged — as does the `TAG == K` spelling.

## Tests

Union assoc suite grows 4 → 5 with a byte-decoded e2e: the cross-arm group-by emits exactly the `(key, count)` records `[5-3, 9-2]`. Rejections (string-typed arm keys, non-i64 OUTFMT slots) fall out of existing validation and were probe-verified. Full sweep: **all 48 suites green.**

## Merge order

1. #3442 (consolidation → main)
2. #3443 (float print) → designated branch
3. this PR → the #3443 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_