### PR TITLE
SYM is a dual judge (e5 ⊕ graph) — diagnostic + finding

### DIFF
--- a/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
+++ b/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
@@ -1,0 +1,45 @@
+# SYM is a dual judge: superposition of e5-semantic ⊕ graph-structural
+
+Empirical finding (`fit_sym_from_graph.py`, on 1500 judge-scored SYM positives, `model_prod.pt`, 100k_cats graph).
+
+## Result
+
+Fit `μ_sym ≈ σ(w·features)` against the judge-scored SYM targets:
+
+| features | R² | corr |
+|---|---|---|
+| **graph judge** `3/dist` (inverse-radial, `1/r`) | +0.43 | +0.66 |
+| **e5 judge** (the model's SYM operator readout) | +0.34 | +0.60 |
+| **DUAL** `3/dist` ⊕ e5-SYM | **+0.57** | **+0.75** |
+| struct-embed only (16–64 landmark BFS, `3/‖Δvec‖`) | +0.14 | +0.40 |
+| DUAL (struct-embed ⊕ e5-SYM) | +0.39 | +0.63 |
+
+## What it means
+
+- **SYM is a superposition of two judges, and they're complementary.** The dual (+0.75) beats *either* alone
+  (graph +0.66, e5 +0.60) by a real margin — they capture different residuals. Not "e5 OR graph"; **e5 ⊕ graph.**
+- **The graph judge = `3/dist`** (inverse-radial `1/r`, the power-law variant in `COST_FUNCTION_PHILOSOPHY.md`),
+  and it **dominates the directionals** — `μ(a|b)`, `μ(b|a)` add ~nothing (recip-only ≈ full fit). The residual
+  form `σ(3/dist − μab − μba)` is *order*-correct (corr +0.61) but needs one fitted scale on `3/dist` for
+  calibrated magnitude (R²<0 unfitted).
+- **Graph distance alone beats the trained e5 SYM operator** (+0.66 vs +0.60/+0.41-baseline) — the structural
+  signal is not something e5 already knows. This is why a **pure-e5 distillation of SYM is lossy**, and it
+  **re-explains the SYM "regression"**: SYM is ~half structural, so when the broad fine-tune shifted the graph,
+  the pure-e5 operator lost the structural half it never had.
+
+## Architecture
+
+`μ_sym = blend( judge=graph [3/dist], judge=e5 [SYM operator] )` — exactly the **calibrated-judges /
+operator-superposition** machinery (`judge_emb`, the blend regularizer). SYM is its first real use.
+- **Inference:** e5 is free (model input); the graph half must be a **cheap O(1) structural signal**, not a BFS.
+- **Open:** the naive landmark-L2 structural embedding is too weak (recovers +0.63, not +0.75; more landmarks
+  didn't help — L2-of-landmark-distance-vectors is a poor proxy). Needs a **proper structural embedding**
+  (node2vec / DeepWalk / spectral, or a tighter landmark distance *estimator* rather than L2) to reproduce the
+  `3/dist` half at O(1) inference. That's the remaining piece for a cheap dual-judge SYM.
+
+## Caveats
+- R²≈0.43 for the graph half is *moderate* — `3/dist` explains ~half of SYM; the rest is semantic nuance +
+  judge noise + the fact that 100k_cats may not be the exact graph the pairs were scored on (true corr could be
+  higher on the right structure).
+
+See `DESIGN_calibrated_judges.md`, `COST_FUNCTION_PHILOSOPHY.md`, `fit_sym_from_graph.py`.

--- a/prototypes/mu_cosine/fit_sym_from_graph.py
+++ b/prototypes/mu_cosine/fit_sym_from_graph.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Is SYM derivable from the directionals + graph distance? (the 'graph judge for SYM').
+
+Fit, on the judge-scored SYM positives:
+    μ_sym ≈ σ( w0 + w1·decay(dist) + w2·μ(a|b) + w3·μ(b|a) )        (logistic; residual intuition: w1>0, w2,w3<0)
+- High R² ⇒ SYM is derivable → teacher/student (distill into the SYM op, e5-only at inference), regression moot.
+- Low  R² ⇒ the judge (30% superposition scoring) genuinely earns its keep.
+
+  python3 fit_sym_from_graph.py --ckpt model_prod.pt --graph ../../data/benchmark/100k_cats/category_parent.tsv
+"""
+import argparse, math, os, sys
+from collections import deque
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mu_attention import build_e5_tables, Tokenizer, OPS, load_dag
+from eval_relatedness import build_model, score_pairs
+
+
+def load_sym_positives(path, cap):
+    pos = []
+    for ln in open(path, encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        c = ln.rstrip("\n").split("\t")
+        if len(c) < 5:
+            continue
+        a, b, stratum, mu = c[0], c[1], c[2], c[4]
+        try:
+            mu = float(mu)
+        except ValueError:
+            continue
+        if stratum != "neg" and mu > 0:                 # SYM positives
+            pos.append((a, b, mu))
+    return pos[:cap] if cap else pos
+
+
+def undirected_adj(parents, children):
+    adj = {}
+    for c, ps in parents.items():
+        for p in (ps if isinstance(ps, (set, list, tuple)) else [ps]):
+            adj.setdefault(c, set()).add(p); adj.setdefault(p, set()).add(c)
+    return adj
+
+
+def bfs_from(adj, src, wanted, cap):
+    dist, q = {src: 0}, deque([src])
+    need = set(wanted)
+    while q and need:
+        u = q.popleft()
+        if dist[u] >= cap:
+            continue
+        for v in adj.get(u, ()):
+            if v not in dist:
+                dist[v] = dist[u] + 1; q.append(v); need.discard(v)
+    return dist
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", default="model_prod.pt")
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--pairs", default="mu_pairs_scored_cumulative.tsv")
+    ap.add_argument("--cap-pairs", type=int, default=1500)
+    ap.add_argument("--bfs-cap", type=int, default=10)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    a = ap.parse_args()
+    dev = torch.device(a.device)
+
+    parents, children, deg = load_dag(a.graph)
+    adj = undirected_adj(parents, children)
+    present = set(parents) | set(children)
+    for v in children.values():
+        present.update(v if isinstance(v, (set, list, tuple)) else [v])
+
+    sym = load_sym_positives(a.pairs, a.cap_pairs)
+    sym = [(x, y, m) for x, y, m in sym if x in present and y in present]
+    print(f"SYM positives with both nodes in graph: {len(sym)}")
+    if len(sym) < 30:
+        print("too few in-graph pairs — try --graph enwiki_named/category_parent.tsv"); return
+
+    # model directionals μ(a|b), μ(b|a) via the HIER operator
+    model = build_model(a.ckpt, dev)
+
+    def anc_of(nm, capd=12):                              # ALL ancestors (multi-parent BFS-up) the tokenizer refs
+        out, frontier, steps = set(), {nm}, 0
+        while frontier and steps < capd:
+            nxt = set()
+            for cur in frontier:
+                ps = parents.get(cur)
+                if not ps:
+                    continue
+                for pp in (ps if isinstance(ps, (set, list, tuple)) else [ps]):
+                    if pp not in out and pp != nm:
+                        out.add(pp); nxt.add(pp)
+            frontier = nxt; steps += 1
+        return out
+    allnames = {x for pr in sym for x in pr[:2]}
+    for nm in list(allnames):
+        allnames.update(anc_of(nm))
+    names = sorted(allnames)
+    q, p, idx = build_e5_tables(names, cache_path="/tmp/mu_data/sym_fit_e5.pt", device=str(dev))
+    tok = Tokenizer(q, p, idx, parents, deg, k=8, beta=1.0, max_anc=8)
+    n_ops = model.op_emb.num_embeddings
+    ow = torch.zeros(1, n_ops); ow[0, OPS["HIER"]] = 1.0
+    mu_ab = score_pairs(model, tok, idx, [(x, y) for x, y, _ in sym], ow, dev)
+    mu_ba = score_pairs(model, tok, idx, [(y, x) for x, y, _ in sym], ow, dev)
+    ow_sym = torch.zeros(1, n_ops); ow_sym[0, OPS["SYM"]] = 1.0          # the e5-semantic SYM judge
+    mu_sym_model = np.array(score_pairs(model, tok, idx, [(x, y) for x, y, _ in sym], ow_sym, dev))
+
+    # graph distances (BFS per unique source)
+    by_src = {}
+    for x, y, _ in sym:
+        by_src.setdefault(x, []).append(y)
+    dist_of = {}
+    for s, ys in by_src.items():
+        d = bfs_from(adj, s, ys, a.bfs_cap)
+        for y in ys:
+            dist_of[(s, y)] = d.get(y, a.bfs_cap + 1)
+
+    dists = np.array([dist_of[(x, y)] for x, y, _ in sym], float)
+    reach = dists <= a.bfs_cap
+    recip = 3.0 / np.maximum(dists, 1.0)                  # 3/distance — inverse-radial (1/r); the graph-judge input
+    mab, mba = np.array(mu_ab), np.array(mu_ba)
+    X = np.column_stack([np.ones(len(sym)), recip, mab, mba])
+    y = np.clip(np.array([m for _, _, m in sym], float), 1e-4, 1 - 1e-4)
+    z = np.log(y / (1 - y))                               # logit target — linear least squares in logit space
+
+    w, *_ = np.linalg.lstsq(X, z, rcond=None)
+    zp = X @ w
+    yp = 1 / (1 + np.exp(-zp))
+    ss_res = float(((y - yp) ** 2).sum()); ss_tot = float(((y - y.mean()) ** 2).sum())
+    r2 = 1 - ss_res / ss_tot
+    corr = float(np.corrcoef(yp, y)[0, 1])
+    print(f"\nlogistic fit  μ_sym ≈ σ(w0 + w1·(3/dist) + w2·μ(a|b) + w3·μ(b|a)):")
+    print(f"  weights: w0={w[0]:+.3f}  w1·(3/dist)={w[1]:+.3f}  w2·μ(a|b)={w[2]:+.3f}  w3·μ(b|a)={w[3]:+.3f}")
+    print(f"  R² {r2:+.3f}   pred-vs-target corr {corr:+.3f}   ({len(sym)} pairs, {reach.mean()*100:.0f}% reachable)")
+    print(f"  mean μ_sym target {y.mean():.3f}  |  mean μ(a|b) {np.mean(mab):.3f}  μ(b|a) {np.mean(mba):.3f}")
+    # FIXED residual form (no fitted weights): μ_sym ≈ σ(3/dist − μab − μba)
+    fixed = 1 / (1 + np.exp(-(recip - mab - mba)))
+    print(f"  [FIXED σ(3/dist − μab − μba)]  corr {np.corrcoef(fixed, y)[0,1]:+.3f}  "
+          f"R² {1 - ((y-fixed)**2).sum()/ss_tot:+.3f}")
+    # STRUCTURAL EMBEDDING (landmark BFS) — the cheap O(1)-inference proxy for graph distance
+    sym_nodes = {x for x, _, _ in sym} | {y for _, y, _ in sym}
+    landmarks = sorted(present, key=lambda n: -len(adj.get(n, ())))[:64]   # high-degree, well-spread
+    LMCAP = a.bfs_cap * 3
+    lm_dist = {l: bfs_from(adj, l, sym_nodes, LMCAP) for l in landmarks}
+    def svec(n):
+        return np.array([lm_dist[l].get(n, LMCAP + 1) for l in landmarks], float)
+    struct_l2 = np.array([np.linalg.norm(svec(x) - svec(y)) for x, y, _ in sym])
+    struct_feat = 3.0 / (1.0 + struct_l2)                 # 3/‖Δ landmark-vec‖ — precomputed, O(1) at inference
+    print(f"  struct-embed({len(landmarks)} landmarks) vs true 3/dist corr: {np.corrcoef(struct_feat, recip)[0, 1]:+.3f}")
+
+    print(f"  --- dual judge (superposition test) ---")
+    for name, feats in [("graph only  (3/dist true)", [recip]),
+                        ("e5-SYM only (operator)", [mu_sym_model]),
+                        ("DUAL  (3/dist true + e5-SYM)", [recip, mu_sym_model]),
+                        ("struct-embed only", [struct_feat]),
+                        ("DUAL  (struct-embed + e5-SYM)", [struct_feat, mu_sym_model])]:
+        Xd = np.column_stack([np.ones(len(sym))] + feats)
+        wd, *_ = np.linalg.lstsq(Xd, z, rcond=None)
+        ypd = 1 / (1 + np.exp(-(Xd @ wd)))
+        print(f"    [{name:29s}] R² {1 - ((y-ypd)**2).sum()/ss_tot:+.3f}  corr {np.corrcoef(ypd, y)[0, 1]:+.3f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

An empirical finding that reframes the symmetric (SYM) operator: **SYM is a superposition of two
complementary judges** — a *semantic* judge (e5) and a *structural* judge (graph distance) — and combining
them beats either alone. This PR is the **diagnostic + the write-up**, no model change yet (that's the
follow-up build).

## What's here
- **`fit_sym_from_graph.py`** — fits the judge-scored SYM positives (1500 pairs, `model_prod.pt`, 100k_cats
  graph) against the graph judge (`3/dist`, inverse-radial `1/r`) and the model's own e5 SYM-operator readout.
- **`DESIGN_sym_dual_judge.md`** — the finding + the architectural implication.

## Result

| features | R² | corr |
|---|---|---|
| **graph judge** `3/dist` | +0.43 | +0.66 |
| **e5 judge** (SYM operator readout) | +0.34 | +0.60 |
| **DUAL** `3/dist` ⊕ e5-SYM | **+0.57** | **+0.75** |
| struct-embed only (landmark BFS) | +0.14 | +0.40 |
| DUAL (struct-embed ⊕ e5-SYM) | +0.39 | +0.63 |

## What it means
- **SYM = e5 ⊕ graph, genuinely complementary.** The dual (+0.75) beats both judges alone (+0.66 / +0.60) by a
  real margin — they explain *different residuals*. Not "e5 OR graph."
- **`3/dist` is the structural half and dominates the directionals** (`μ(a|b)`/`μ(b|a)` add ~nothing). The
  residual form `σ(3/dist − μab − μba)` is *order*-correct (corr +0.61) but needs one fitted scale for
  calibrated magnitude.
- **Graph distance alone beats the trained e5 SYM operator** (+0.66 vs +0.41 baseline) → **pure-e5 distillation
  of SYM is lossy**, and this **re-explains the SYM "regression"**: SYM is ~half structural, so when the broad
  enwiki fine-tune shifted the graph, the pure-e5 operator lost the structural half it never had access to.

## Architecture (the plan this feeds)
`μ_sym = blend( judge=graph [3/dist], judge=e5 [SYM operator] )` — precisely the **calibrated-judges /
operator-superposition** machinery (`judge_emb`, the blend regularizer). SYM is its first real use.
- Roadmap: **(1) this finding → (2) build a cheap O(1)-inference structural embedding → (3) wire the dual-input
  SYM blend into the model.**

## Open / caveats
- **Cheap structural signal is unsolved:** raw BFS gives +0.75 but is expensive; the naive landmark-L2 embedding
  recovers only +0.63 (more landmarks didn't help — L2-of-landmark-vectors is a poor proxy). Step 2 is a proper
  structural embedding (node2vec / spectral / a tighter landmark distance-estimator).
- **R²≈0.43 for the graph half is moderate** — `3/dist` explains ~half of SYM; the rest is semantic nuance +
  judge noise + 100k_cats possibly not being the exact graph the pairs were scored on (true corr may be higher).

## For the reviewer
- Is `3/dist` (inverse-radial) the right structural kernel, vs exp-decay (fit slightly higher, +0.46) or PPR?
- Is deriving SYM from a *learned structural embedding* sound, or should SYM stay a judge-scored operator and the
  graph signal just *regularize* it?
- The dual is measured with a *linear logistic* combiner — would a small MLP over `[3/dist, e5-SYM]` capture
  interaction the linear misses (or overfit 1500 pairs)?