### PR TITLE
plawk: per-element write loop for lps-element rep passthrough

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -169,11 +169,15 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    so still memcpy cost per record). Writer output is byte-compatible
    with the `lpsN` reader. `repK(elems)` in OUTFMT (landed) is a
    passthrough slot: the argument names the input rep's count field,
-   and the writer emits the live count plus one bulk fwrite of
-   count×elemsize bytes from the input's element region (fixed-width
-   elements only, so in-memory layout == wire layout; caps and element
-   layouts must match the input rep exactly). Guarded rules therefore
-   make byte-exact stream filters, in plain and union input modes.
+   and the writer emits the live count plus the live elements — one
+   bulk fwrite of count×elemsize bytes when the elements are all
+   fixed-width (in-memory layout == wire layout), or a writer-side
+   loop when they contain `lpsN` strings (each iteration recovers the
+   live length from the NUL-padded slot with strnlen and emits the
+   prefix plus exactly those bytes, mirroring the reader loop). Caps
+   and element layouts must match the input rep exactly. Guarded rules
+   therefore make byte-exact stream filters, in plain and union input
+   modes.
 4. **Tier-2 composition sugar (landed):** `blobN` — a length-prefixed
    binary payload whose only consumer is a compiled-Prolog foreign
    call. The record loop frames natively (length read, cap check, bulk

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -354,9 +354,11 @@ varlen plawk-to-plawk pipelines round-trip. `repK(...)` works in
 OUTFMT as a passthrough: the writebin argument names the input rep's
 count field (`OUTFMT = "i64 rep4(i64 f64)"` with `writebin $1, $2`),
 and the writer emits the live count plus one bulk copy of the live
-elements - so guarded rules make byte-exact stream filters.
-Fixed-width elements only; the input rep's cap and element layout must
-match the output slot exactly. See
+elements - so guarded rules make byte-exact stream filters. Elements
+with `lpsN` strings pass through too: the writer loops over the live
+elements, recovering each string's live length from its NUL-padded
+slot and emitting the length prefix plus exactly those bytes. The
+input rep's cap and element layout must match the output slot exactly. See
 [`docs/design/PLAWK_DCG_BINARY_READERS.md`](../../docs/design/PLAWK_DCG_BINARY_READERS.md)
 for the grammar-to-native-reader lowering design this is the first
 slice of. Fixed-width string fields are in: with

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2592,7 +2592,9 @@ plawk_outfmt_type_ok(s(_W)) :- !.
 plawk_outfmt_type_ok(lps(_C)) :- !.
 plawk_outfmt_type_ok(rep(_K, ElemTypes)) :-
     forall(member(ElemType, ElemTypes),
-        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_) )).
+        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_)
+        ; ElemType = lps(_)
+        )).
 
 % sN output slots take string literals that fit the width, or field
 % reads (validated against the input layout separately in binary mode;
@@ -2703,6 +2705,73 @@ plawk_writebin_varlen_slot_lines(lps(Cap), Field, FieldSeparator, Base,
         '  %~w_pwr = call i64 @fwrite(i8* ~w, i64 ~w, i64 1, i8* ~w)',
         [Base, PtrIR, LenIR, Stdout]),
     append(SourceLines, [LenStore, PayloadWrite], Lines).
+% rep passthrough whose elements contain lps strings: each element's
+% wire size varies (a length prefix plus the live payload, recovered
+% with strnlen from the NUL-padded slot), so the writer loops over the
+% live elements, emitting each field left to right. The loop gets its
+% own labeled blocks; the fragment enters through a br so the head phi
+% has a named predecessor.
+plawk_writebin_varlen_slot_lines(rep(_Cap, ElemTypes), field(CountIndex),
+        binfmt(InTypes), Base, BasePtr, Stdout, Lines, []) :-
+    memberchk(lps(_ECap), ElemTypes),
+    !,
+    maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
+    sum_list(ElemWidths, ElemSize),
+    plawk_binfmt_field_offset(binfmt(InTypes), CountIndex, CountOff),
+    ElemsOff is CountOff + 8,
+    format(atom(HeaderIR),
+'  br label %~w_pre
+
+~w_pre:
+  %~w_cfp = getelementptr i8, i8* %rec, i64 ~w
+  %~w_ctp = bitcast i8* %~w_cfp to i64*
+  %~w_n = load i64, i64* %~w_ctp, align 1
+  %~w_csp = bitcast i8* ~w to i64*
+  store i64 %~w_n, i64* %~w_csp, align 1
+  %~w_cwr = call i64 @fwrite(i8* ~w, i64 8, i64 1, i8* ~w)
+  br label %~w_lh
+
+~w_lh:
+  %~w_j = phi i64 [ 1, %~w_pre ], [ %~w_jn, %~w_ld ]
+  %~w_cont = icmp sle i64 %~w_j, %~w_n
+  br i1 %~w_cont, label %~w_lb, label %~w_after
+
+~w_lb:
+  %~w_jm1 = sub i64 %~w_j, 1
+  %~w_rel = mul i64 %~w_jm1, ~w
+  %~w_efp = getelementptr i8, i8* %rec, i64 ~w
+  %~w_eb = getelementptr i8, i8* %~w_efp, i64 %~w_rel',
+        [Base,
+         Base,
+         Base, CountOff,
+         Base, Base,
+         Base, Base,
+         Base, BasePtr,
+         Base, Base,
+         Base, BasePtr, Stdout,
+         Base,
+         Base,
+         Base, Base, Base, Base,
+         Base, Base, Base,
+         Base, Base, Base,
+         Base,
+         Base, Base,
+         Base, Base, ElemSize,
+         Base, ElemsOff,
+         Base, Base, Base]),
+    format(atom(ElemBase), '%~w_eb', [Base]),
+    plawk_writebin_rep_elem_lines(ElemTypes, Base, ElemBase, BasePtr, Stdout,
+        0, 0, ElemLines),
+    format(atom(FooterIR),
+'  br label %~w_ld
+
+~w_ld:
+  %~w_jn = add i64 %~w_j, 1
+  br label %~w_lh
+
+~w_after:',
+        [Base, Base, Base, Base, Base, Base]),
+    append([[HeaderIR], ElemLines, [FooterIR]], Lines).
 plawk_writebin_varlen_slot_lines(rep(_Cap, ElemTypes), field(CountIndex),
         binfmt(InTypes), Base, BasePtr, Stdout, Lines, []) :-
     !,
@@ -2752,6 +2821,49 @@ plawk_writebin_varlen_slot_lines(Type, Field, FieldSeparator, Base, BasePtr,
         [Base, BasePtr, LLVMType, LLVMType, ValueIR, LLVMType, Base,
          Base, BasePtr, Stdout]),
     append(SetupParts, [StoreWrite], Lines).
+
+%% plawk_writebin_rep_elem_lines(+ElemTypes, +Base, +ElemBase, +BasePtr,
+%%     +Stdout, +Index, +Offset, -Lines)
+%
+%  Loop-body field writes for one rep element based at ElemBase.
+%  Fixed-width fields pass through directly; lps fields recover the
+%  live length from the NUL-padded slot with strnlen, then emit the
+%  8-byte prefix and exactly that many payload bytes.
+plawk_writebin_rep_elem_lines([], _Base, _ElemBase, _BasePtr, _Stdout,
+        _Index, _Offset, []).
+plawk_writebin_rep_elem_lines([lps(Cap) | Types], Base, ElemBase, BasePtr,
+        Stdout, Index, Offset, [IR | Lines]) :-
+    !,
+    format(atom(IR),
+'  %~w_e~w_sp = getelementptr i8, i8* ~w, i64 ~w
+  %~w_e~w_len = call i64 @strnlen(i8* %~w_e~w_sp, i64 ~w)
+  %~w_e~w_lsp = bitcast i8* ~w to i64*
+  store i64 %~w_e~w_len, i64* %~w_e~w_lsp, align 1
+  %~w_e~w_lwr = call i64 @fwrite(i8* ~w, i64 8, i64 1, i8* ~w)
+  %~w_e~w_pwr = call i64 @fwrite(i8* %~w_e~w_sp, i64 %~w_e~w_len, i64 1, i8* ~w)',
+        [Base, Index, ElemBase, Offset,
+         Base, Index, Base, Index, Cap,
+         Base, Index, BasePtr,
+         Base, Index, Base, Index,
+         Base, Index, BasePtr, Stdout,
+         Base, Index, Base, Index, Base, Index, Stdout]),
+    plawk_binfmt_type_width(lps(Cap), Width),
+    NextOffset is Offset + Width,
+    NextIndex is Index + 1,
+    plawk_writebin_rep_elem_lines(Types, Base, ElemBase, BasePtr, Stdout,
+        NextIndex, NextOffset, Lines).
+plawk_writebin_rep_elem_lines([Type | Types], Base, ElemBase, BasePtr,
+        Stdout, Index, Offset, [IR | Lines]) :-
+    plawk_binfmt_type_width(Type, Width),
+    format(atom(IR),
+'  %~w_e~w_sp = getelementptr i8, i8* ~w, i64 ~w
+  %~w_e~w_wr = call i64 @fwrite(i8* %~w_e~w_sp, i64 ~w, i64 1, i8* ~w)',
+        [Base, Index, ElemBase, Offset,
+         Base, Index, Base, Index, Width, Stdout]),
+    NextOffset is Offset + Width,
+    NextIndex is Index + 1,
+    plawk_writebin_rep_elem_lines(Types, Base, ElemBase, BasePtr, Stdout,
+        NextIndex, NextOffset, Lines).
 
 %% plawk_writebin_lps_source_lines(+Field, +FieldSeparator, +Cap, +Base,
 %%     +BasePtr, -PtrIR, -LenIR, -Lines, -GlobalParts)

--- a/tests/test_plawk_rep_writer.pl
+++ b/tests/test_plawk_rep_writer.pl
@@ -40,8 +40,9 @@ test(rep_outfmt_rejections) :-
         "BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64)\" } { writebin $1, $2 }\n",
         % the rep argument must be the input rep's count field
         "BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64 f64)\" } { writebin $1, $1 }\n",
-        % lps elements are not bulk-copyable (wire differs per element)
-        "BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" ; OUTFMT = \"i64 rep4(lps8 i64)\" } { writebin $1, $2 }\n"
+        % element layouts must match even in loop mode (input s8 vs
+        % output lps8 differ on the wire)
+        "BEGIN { BINFMT = \"i64 rep4(s8 i64)\" ; OUTFMT = \"i64 rep4(lps8 i64)\" } { writebin $1, $2 }\n"
     ],
     forall(member(Source, Rejects),
         ( plawk_parse_string(Source, Program)
@@ -61,6 +62,28 @@ test(surface_rep_filter_is_byte_exact) :-
     records_bytes(Drop, DropBytes),
     assertion(OutBytes == ExpectedBytes),
     assertion(OutBytes \== DropBytes).
+
+test(rep_lps_elements_write_in_a_loop) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" ; OUTFMT = \"i64 rep4(lps8 i64)\" } $1 > 0 { writebin $1, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % a writer-side loop: head phi, live length via strnlen, per-field
+    % fwrites -- and no bulk element write
+    assertion(once(sub_atom(DriverIR, _, _, _, '_j = phi i64 [ 1, %'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@strnlen(i8* %'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_pwr = call i64 @fwrite'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '_ewr = call i64 @fwrite')),
+    !.
+
+test(surface_rep_lps_filter_is_byte_exact) :-
+    % Same byte-exact filter contract as the fixed-element case, with
+    % variable-size elements: name lengths 3, 0, and the full cap 8.
+    Keep = [rec2(1, [f("hot", 5), f("", 7)]), rec2(4, [f("full8chr", 2)])],
+    Input = [rec2(1, [f("hot", 5), f("", 7)]), rec2(-9, [f("drop", 1)]),
+             rec2(4, [f("full8chr", 2)])],
+    run_rpw2_smoke("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" ; OUTFMT = \"i64 rep4(lps8 i64)\" } $1 > 0 { writebin $1, $2 }\n",
+        Input, OutBytes),
+    records2_bytes(Keep, ExpectedBytes),
+    assertion(OutBytes == ExpectedBytes).
 
 test(surface_rep_passthrough_in_union_arm) :-
     % Composes with case blocks: arm 0 carries the rep, its rule
@@ -99,6 +122,69 @@ write_rpw_stream(Out, Recs) :-
               ( write_i64_le(Out, V),
                 double_bits(F, Bits),
                 write_i64_le(Out, Bits) )) )).
+
+% rec2(Id, Elems): i64 id, i64 count, then per element lps8 + i64
+write_rpw2_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec2(Id, Elems), Recs),
+            ( write_i64_le(Out, Id),
+              length(Elems, Count),
+              write_i64_le(Out, Count),
+              forall(member(f(S, V), Elems),
+                  ( string_codes(S, Codes),
+                    length(Codes, Len),
+                    write_i64_le(Out, Len),
+                    forall(member(C, Codes), put_byte(Out, C)),
+                    write_i64_le(Out, V) )) )),
+        close(Out)).
+
+records2_bytes(Recs, Bytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_rep_writer_expect2.bin', Path),
+    write_rpw2_records(Path, Recs),
+    setup_call_cleanup(
+        open(Path, read, In, [type(binary)]),
+        read_string(In, _, Bytes),
+        close(In)).
+
+run_rpw2_smoke(Source, Recs, OutBytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_rep_writer2', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_rpw_marker/0 ],
+        [module_name('plawk_rep_writer2')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(BuildOutS)), stderr(std), process(BuildPid)]),
+    read_string(BuildOutS, _, BuildOut),
+    close(BuildOutS),
+    process_wait(BuildPid, BuildStatus),
+    ( BuildStatus == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk rep writer2 build output]~n~w~n", [BuildOut]),
+       throw(plawk_rep_writer2_build_failed(BuildStatus))
+    ),
+    write_rpw2_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, OutBytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    !.
 
 % the byte string a record list occupies on the wire
 records_bytes(Recs, Bytes) :-


### PR DESCRIPTION
## Summary

Third slice: reps whose elements carry `lpsN` strings pass through writers, so every rep shape the reader accepts can now be read, filtered, and re-emitted:

```awk
BEGIN { BINFMT = "i64 rep4(lps8 i64)" ; OUTFMT = "i64 rep4(lps8 i64)" }
$1 > 0 { writebin $1, $2 }
```

## Design

Each element's wire size varies (length prefix + live payload), so the bulk copy gives way to a **writer-side loop mirroring the reader loop**: write the live count, then per live element emit each field left to right — fixed-width fields `fwrite` straight from their slots; lps fields recover the live length from the NUL-padded slot with `strnlen` and emit the 8-byte prefix plus exactly that many payload bytes. The loop carries its own labeled blocks: the fragment enters through a `br` so the head phi has a named predecessor, and execution falls out at the `_after` label into the rest of the writebin sequence. Validation is unchanged — caps and element layouts must still match the input rep exactly.

## Tests

Rep writer suite grows 4 → 6: loop IR shape (head phi, `strnlen`, per-field fwrites, and **no** bulk element write), plus a byte-exact e2e filter over variable-size elements (name lengths 3, 0, and the full cap 8 — kept records byte-identical, dropped record absent). The old lps-elements rejection becomes an element-layout-mismatch rejection (input `s8` vs output `lps8`). Full sweep: **all 48 suites green.**

## Merge order

1. #3442 (consolidation → main)
2. #3443 (float print) → designated branch
3. #3444 (union for-in writebin) → the #3443 branch
4. this PR → the #3444 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_