### PR TITLE
plawk: bring round 5 (#3443 float print, #3444 union for-in writebin, #3446 lps rep writer, #3447 tagged output) to main

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -143,8 +143,18 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    key loads through the same per-rule arm descriptor as the scalar
    chain. for-in writebin over a union input (landed): the END table
    walk writebins one fixed-layout (key, count, ...) record per group,
-   mirroring the plain binary group-by-to-binary-output clause. Not
-   yet inside case blocks: union (tagged) output.
+   mirroring the plain binary group-by-to-binary-output clause. Union
+   (tagged) output (landed): `OUTFMT = "case(arm0 | arm1)"` (same
+   spelling as BINFMT), and each writebin site statically targets one
+   arm -- `writebin case K, args` emits the 8-byte tag K then arm K's
+   slots through the per-slot varlen writer (the shared buffer sizes
+   to the widest arm; its element pointer is resolved once in the
+   entry block). Output is byte-compatible with the union reader, so
+   tagged plawk-to-plawk pipelines round-trip; works from flat or
+   union inputs and in the single-rule endless shape. Arm slots are
+   i64/f64/sN/lpsN (a tagged rep write is a later slice); plain
+   writebin with a union OUTFMT, arm writes against a flat OUTFMT,
+   out-of-range arms, and arity mismatches all reject the program.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region

--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -141,8 +141,10 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    shared table per array name; both END report shapes (for-in print,
    integer lookups) work, and the assoc rule chain resolves guards and
    key loads through the same per-rule arm descriptor as the scalar
-   chain. Not yet inside case blocks: union (tagged) output, and
-   for-in writebin over a union input.
+   chain. for-in writebin over a union input (landed): the END table
+   walk writebins one fixed-layout (key, count, ...) record per group,
+   mirroring the plain binary group-by-to-binary-output clause. Not
+   yet inside case blocks: union (tagged) output.
 2. **Bounded repetition (landed):** `repK(elem types)` — an 8-byte
    count (≤ K) then that many elements. Fixed-width elements read as
    one bulk count×elemsize read after a memset of the element region

--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -169,11 +169,15 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    so still memcpy cost per record). Writer output is byte-compatible
    with the `lpsN` reader. `repK(elems)` in OUTFMT (landed) is a
    passthrough slot: the argument names the input rep's count field,
-   and the writer emits the live count plus one bulk fwrite of
-   count×elemsize bytes from the input's element region (fixed-width
-   elements only, so in-memory layout == wire layout; caps and element
-   layouts must match the input rep exactly). Guarded rules therefore
-   make byte-exact stream filters, in plain and union input modes.
+   and the writer emits the live count plus the live elements — one
+   bulk fwrite of count×elemsize bytes when the elements are all
+   fixed-width (in-memory layout == wire layout), or a writer-side
+   loop when they contain `lpsN` strings (each iteration recovers the
+   live length from the NUL-padded slot with strnlen and emits the
+   prefix plus exactly those bytes, mirroring the reader loop). Caps
+   and element layouts must match the input rep exactly. Guarded rules
+   therefore make byte-exact stream filters, in plain and union input
+   modes.
 4. **Tier-2 composition sugar (landed):** `blobN` — a length-prefixed
    binary payload whose only consumer is a compiled-Prolog foreign
    call. The record loop frames natively (length read, cap check, bulk

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -101,6 +101,7 @@ swipl -q -s tests/test_plawk_f64_foreign.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/
 swipl -q -s tests/test_plawk_union_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_rep_writer.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_union_out.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -358,7 +359,12 @@ elements - so guarded rules make byte-exact stream filters. Elements
 with `lpsN` strings pass through too: the writer loops over the live
 elements, recovering each string's live length from its NUL-padded
 slot and emitting the length prefix plus exactly those bytes. The
-input rep's cap and element layout must match the output slot exactly. See
+input rep's cap and element layout must match the output slot exactly.
+Output can be tagged too: `OUTFMT = "case(i64 | i64 lps8)"` declares a
+union output, and `writebin case K, args` emits the 8-byte tag K then
+arm K's slots -- byte-compatible with the union reader, so a plawk
+program can split, retag, or normalize a stream that another plawk
+program consumes directly. See
 [`docs/design/PLAWK_DCG_BINARY_READERS.md`](../../docs/design/PLAWK_DCG_BINARY_READERS.md)
 for the grammar-to-native-reader lowering design this is the first
 slice of. Fixed-width string fields are in: with

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -303,7 +303,8 @@ foreign guards and calls work over binary records generally; a
 double-returning call is spelled `wsum += float(score($1, $2))` (the
 float(...) wrapper selects a {double, ok} bridge that accepts Integer
 or Float results, keeping fractions that the i64 spelling would
-truncate; a failed call contributes 0.0). One blob argument per call;
+truncate; a failed call contributes 0.0); the same spelling works in
+print position (`print $1, float(score($1, $2))`). One blob argument per call;
 payloads are NUL-free byte strings. Bounded repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -354,9 +354,11 @@ varlen plawk-to-plawk pipelines round-trip. `repK(...)` works in
 OUTFMT as a passthrough: the writebin argument names the input rep's
 count field (`OUTFMT = "i64 rep4(i64 f64)"` with `writebin $1, $2`),
 and the writer emits the live count plus one bulk copy of the live
-elements - so guarded rules make byte-exact stream filters.
-Fixed-width elements only; the input rep's cap and element layout must
-match the output slot exactly. See
+elements - so guarded rules make byte-exact stream filters. Elements
+with `lpsN` strings pass through too: the writer loops over the live
+elements, recovering each string's live length from its NUL-padded
+slot and emitting the length prefix plus exactly those bytes. The
+input rep's cap and element layout must match the output slot exactly. See
 [`docs/design/PLAWK_DCG_BINARY_READERS.md`](../../docs/design/PLAWK_DCG_BINARY_READERS.md)
 for the grammar-to-native-reader lowering design this is the first
 slice of. Fixed-width string fields are in: with

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -423,6 +423,53 @@ plawk_program_native_driver_ir(
             RecordIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% Tagged-union group-by to binary output: case-block rules count per
+% arm, END iterates the table and writebins one fixed-layout record
+% per group.
+plawk_program_native_driver_ir(
+    program(BeginClauses, case_blocks(CaseBlocks), [end([for_in(var(LoopVar), var(ArrayName), [writebin(Fields)])])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_record_descriptor(BeginClauses, Descriptor),
+    Descriptor = binfmt_union(Arms),
+    plawk_union_flatten_rules(CaseBlocks, Arms, Rules),
+    plawk_begin_outfmt_types(BeginClauses, OutTypes),
+    forall(member(OutType, OutTypes), memberchk(OutType, [i64, f64])),
+    length(OutTypes, ArgCount),
+    length(Fields, ArgCount),
+    maplist(plawk_forin_writebin_field(LoopVar), Fields),
+    findall(LookupArrayName,
+        member(assoc(var(LookupArrayName), var(LoopVar)), Fields),
+        LookupArrays),
+    plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays, AssocPlan),
+    plawk_assoc_record_program_ok(Descriptor, Rules, []),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_binfmt_record_size(binfmt(OutTypes), OutRecordSize),
+    plawk_writebin_entry_lines(outfmt(OutTypes, OutRecordSize), WritebinEntryIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, Descriptor, AssocRuleGlobalIR, AssocChainIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_forin_end_writebin_ir(LoopVar, ArrayName, OutTypes, Fields, AssocPlan,
+        EndPrintIR),
+    plawk_writebin_globals(outfmt(OutTypes, OutRecordSize), WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, AssocRuleGlobalIR, WritebinGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR0),
+    plawk_combine_entry_ir(CombinedEntrySetupIR0, WritebinEntryIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w',
+        [EndPrintIR]),
+    plawk_emit_record_driver_ir(Descriptor, InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
+            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 % Binary group-by to binary output: iterate the table and writebin one
 % fixed-layout record per group. Binary input mode only -- text-mode
 % keys are interned atom ids, which would be meaningless bytes in the

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -79,6 +79,8 @@ plawk_program_native_driver_ir(
         [rule(Pattern, [Action])], WritebinPlan),
     ( Action = writebin_out(WritebinTypes, WritebinFields)
     -> plawk_writebin_args_ok(WritebinTypes, WritebinFields)
+    ;  Action = writebin_arm_out(_Tag, ArmTypes, ArmFields)
+    -> plawk_writebin_args_ok(ArmTypes, ArmFields)
     ;  plawk_rule_body_print_action(Action)
     ),
     plawk_output_action_exprs(Action, Exprs),
@@ -261,7 +263,7 @@ plawk_program_native_driver_ir(
     ->  true
     ;   % a pure normalizer: every rule just writebins its arm into
         % the shared output layout -- no scalar state at all
-        WritebinPlan = outfmt(_OutTypes, _OutSize),
+        WritebinPlan \== none,
         PrintFields == [],
         StatePlan = state_plan([])
     ),
@@ -2075,6 +2077,9 @@ plawk_binfmt_action_ok(Descriptor, if(Pattern, ThenActions, ElseActions)) :-
 plawk_binfmt_action_ok(Descriptor, writebin_out(Types, Fields)) :-
     !,
     plawk_binfmt_writebin_args_ok(Descriptor, Types, Fields).
+plawk_binfmt_action_ok(Descriptor, writebin_arm_out(_Tag, ArmTypes, Fields)) :-
+    !,
+    plawk_binfmt_writebin_args_ok(Descriptor, ArmTypes, Fields).
 plawk_binfmt_action_ok(Descriptor, foreach_loop(_Layout, Body)) :-
     !,
     plawk_binfmt_actions_ok(Descriptor, Body).
@@ -2464,14 +2469,50 @@ plawk_binfmt_record_size(binfmt(Types), Size) :-
 %  supported).
 plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules, WritebinPlan) :-
     ( plawk_rules_have_writebin(Rules0)
-    ->  plawk_begin_outfmt_types(BeginClauses, Types),
-        forall(member(Type, Types), plawk_outfmt_type_ok(Type)),
-        plawk_binfmt_record_size(binfmt(Types), Size),
-        WritebinPlan = outfmt(Types, Size),
-        maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules)
+    ->  plawk_begin_out_spec(BeginClauses, OutSpec),
+        plawk_writebin_plan(OutSpec, WritebinPlan),
+        maplist(plawk_resolve_writebin_rule(OutSpec), Rules0, Rules)
     ;   WritebinPlan = none,
         Rules = Rules0
     ).
+
+%% plawk_begin_out_spec(+BeginClauses, -OutSpec)
+%
+%  OUTFMT is either one flat layout or a tagged union of arm layouts
+%  (`OUTFMT = "case(arm0 | arm1)"`, same spelling as BINFMT). With a
+%  union, every writebin site statically targets one arm via
+%  `writebin case K, args`.
+plawk_begin_out_spec(BeginClauses, union(Arms)) :-
+    plawk_begin_outfmt_union_arms(BeginClauses, Arms),
+    !.
+plawk_begin_out_spec(BeginClauses, flat(Types)) :-
+    plawk_begin_outfmt_types(BeginClauses, Types).
+
+plawk_begin_outfmt_union_arms(BeginClauses, Arms) :-
+    member(begin(Actions), BeginClauses),
+    member(set(var('OUTFMT'), string(Fmt)), Actions),
+    string_concat("case(", Rest, Fmt),
+    string_concat(Body, ")", Rest),
+    split_string(Body, "|", " ", ArmStrs),
+    ArmStrs \== [],
+    maplist(plawk_union_arm_types, ArmStrs, Arms).
+
+plawk_writebin_plan(flat(Types), outfmt(Types, Size)) :-
+    forall(member(Type, Types), plawk_outfmt_type_ok(Type)),
+    plawk_binfmt_record_size(binfmt(Types), Size).
+plawk_writebin_plan(union(Arms), outfmt_union(Arms, BufSize)) :-
+    % arm slots: the varlen writer set minus rep (a tagged rep write
+    % is a later slice); the shared buffer holds the tag or any one
+    % staged slot, so size it to the widest arm (at least 8)
+    forall(member(ArmTypes, Arms),
+        forall(member(Type, ArmTypes),
+            ( memberchk(Type, [i64, f64]) ; Type = s(_) ; Type = lps(_) ))),
+    findall(Size,
+        ( member(ArmTypes, Arms),
+          plawk_binfmt_record_size(binfmt(ArmTypes), Size)
+        ),
+        Sizes),
+    max_list([8 | Sizes], BufSize).
 
 plawk_rules_have_writebin(Rules) :-
     member(rule(_Pattern, Actions), Rules),
@@ -2490,23 +2531,22 @@ plawk_resolve_union_writebin_blocks(BeginClauses, CaseBlocks0, CaseBlocks,
         WritebinPlan) :-
     ( member(case_arm(_I, ArmRules), CaseBlocks0),
       plawk_rules_have_writebin(ArmRules)
-    ->  plawk_begin_outfmt_types(BeginClauses, Types),
-        forall(member(Type, Types), plawk_outfmt_type_ok(Type)),
-        plawk_binfmt_record_size(binfmt(Types), Size),
-        WritebinPlan = outfmt(Types, Size),
-        maplist(plawk_resolve_union_writebin_block(Types), CaseBlocks0,
+    ->  plawk_begin_out_spec(BeginClauses, OutSpec),
+        plawk_writebin_plan(OutSpec, WritebinPlan),
+        maplist(plawk_resolve_union_writebin_block(OutSpec), CaseBlocks0,
             CaseBlocks)
     ;   WritebinPlan = none,
         CaseBlocks = CaseBlocks0
     ).
 
-plawk_resolve_union_writebin_block(Types, case_arm(Index, Rules0),
+plawk_resolve_union_writebin_block(OutSpec, case_arm(Index, Rules0),
         case_arm(Index, Rules)) :-
-    maplist(plawk_resolve_writebin_rule(Types), Rules0, Rules).
+    maplist(plawk_resolve_writebin_rule(OutSpec), Rules0, Rules).
 
 plawk_actions_have_writebin(Actions) :-
     member(Action, Actions),
     ( Action = writebin(_Fields)
+    ; Action = writebin_arm(_Index, _AFields)
     ; Action = if(_Pattern, ThenActions, ElseActions),
       ( plawk_actions_have_writebin(ThenActions)
       ; plawk_actions_have_writebin(ElseActions)
@@ -2514,18 +2554,33 @@ plawk_actions_have_writebin(Actions) :-
     ),
     !.
 
-plawk_resolve_writebin_rule(Types, rule(Pattern, Actions0), rule(Pattern, Actions)) :-
-    maplist(plawk_resolve_writebin_action(Types), Actions0, Actions).
+plawk_resolve_writebin_rule(OutSpec, rule(Pattern, Actions0), rule(Pattern, Actions)) :-
+    maplist(plawk_resolve_writebin_action(OutSpec), Actions0, Actions).
 
-plawk_resolve_writebin_action(Types, writebin(Fields), writebin_out(Types, Fields)) :-
+plawk_resolve_writebin_action(flat(Types), writebin(Fields),
+        writebin_out(Types, Fields)) :-
     !,
     length(Types, N),
     length(Fields, N).
-plawk_resolve_writebin_action(Types, if(Pattern, Then0, Else0), if(Pattern, Then, Else)) :-
+% a plain writebin cannot pick an arm, and an arm-targeted writebin is
+% meaningless against a flat layout -- both reject the program
+plawk_resolve_writebin_action(union(_Arms), writebin(_Fields), _) :-
     !,
-    maplist(plawk_resolve_writebin_action(Types), Then0, Then),
-    maplist(plawk_resolve_writebin_action(Types), Else0, Else).
-plawk_resolve_writebin_action(_Types, Action, Action).
+    fail.
+plawk_resolve_writebin_action(flat(_Types), writebin_arm(_Index, _Fields), _) :-
+    !,
+    fail.
+plawk_resolve_writebin_action(union(Arms), writebin_arm(Index, Fields),
+        writebin_arm_out(Index, ArmTypes, Fields)) :-
+    !,
+    nth0(Index, Arms, ArmTypes),
+    length(ArmTypes, N),
+    length(Fields, N).
+plawk_resolve_writebin_action(OutSpec, if(Pattern, Then0, Else0), if(Pattern, Then, Else)) :-
+    !,
+    maplist(plawk_resolve_writebin_action(OutSpec), Then0, Then),
+    maplist(plawk_resolve_writebin_action(OutSpec), Else0, Else).
+plawk_resolve_writebin_action(_OutSpec, Action, Action).
 
 plawk_begin_outfmt_types(BeginClauses, Types) :-
     member(begin(Actions), BeginClauses),
@@ -2537,15 +2592,23 @@ plawk_begin_outfmt_types(BeginClauses, Types) :-
     maplist(plawk_binfmt_type, Parts, Types).
 
 % Entry-block record buffer: one alloca reused by every writebin call
-% (a loop-body alloca would grow the stack per record).
+% (a loop-body alloca would grow the stack per record). The union plan
+% also resolves the buffer's element pointer once, so per-site tagged
+% emitters need no knowledge of the buffer's alloca size.
 plawk_writebin_entry_lines(none, '').
 plawk_writebin_entry_lines(outfmt(_Types, Size), IR) :-
     format(atom(IR), '  %plawk_wbuf = alloca [~w x i8], align 8~n', [Size]).
+plawk_writebin_entry_lines(outfmt_union(_Arms, BufSize), IR) :-
+    format(atom(IR),
+'  %plawk_wbuf = alloca [~w x i8], align 8
+  %plawk_wbuf_p = getelementptr inbounds [~w x i8], [~w x i8]* %plawk_wbuf, i32 0, i32 0~n',
+        [BufSize, BufSize, BufSize]).
 
 % fwrite(buf, size, 1, stdout) buffers in libc; the normal return from
 % main flushes it.
 plawk_writebin_globals(none, '').
 plawk_writebin_globals(outfmt(_Types, _Size), '@stdout = external global i8*').
+plawk_writebin_globals(outfmt_union(_Arms, _BufSize), '@stdout = external global i8*').
 
 plawk_rules_writebin_exprs(Rules, Exprs) :-
     findall(Expr,
@@ -2558,6 +2621,8 @@ plawk_actions_writebin_expr(Actions, Expr) :-
     member(Action, Actions),
     ( Action = writebin_out(_Types, Fields),
       member(Expr, Fields)
+    ; Action = writebin_arm_out(_Tag, _ArmTypes, AFields),
+      member(Expr, AFields)
     ; Action = if(_Pattern, ThenActions, ElseActions),
       ( plawk_actions_writebin_expr(ThenActions, Expr)
       ; plawk_actions_writebin_expr(ElseActions, Expr)
@@ -2672,6 +2737,30 @@ plawk_writebin_varlen_record_ir(Types, Fields, Slots, Values, FieldSeparator,
     plawk_writebin_varlen_field_lines(Types, Fields, Slots, Values,
         FieldSeparator, Prefix, BasePtr, StdoutVar, 0, FieldLines, GlobalParts),
     append([[BaseLine, StdoutLoad], FieldLines], AllLines),
+    atomic_list_concat(AllLines, '\n', IR),
+    atomic_list_concat(GlobalParts, '\n', GlobalIR).
+
+%% plawk_writebin_union_record_ir(+Tag, +ArmTypes, +Fields, +Slots,
+%%     +Values, +FieldSeparator, +Prefix, -Pair)
+%
+%  One tagged output record: the 8-byte arm tag, then the arm's slots
+%  through the per-slot varlen writer. The shared buffer pointer
+%  (%plawk_wbuf_p) was resolved once in the entry block by the
+%  outfmt_union plan, so sites need no knowledge of the buffer size.
+plawk_writebin_union_record_ir(Tag, ArmTypes, Fields, Slots, Values,
+        FieldSeparator, Prefix, GlobalIR-IR) :-
+    format(atom(StdoutLoad),
+        '  %~w_stdout = load i8*, i8** @stdout', [Prefix]),
+    format(atom(StdoutVar), '%~w_stdout', [Prefix]),
+    format(atom(TagIR),
+'  %~w_tsp = bitcast i8* %plawk_wbuf_p to i64*
+  store i64 ~w, i64* %~w_tsp, align 1
+  %~w_twr = call i64 @fwrite(i8* %plawk_wbuf_p, i64 8, i64 1, i8* ~w)',
+        [Prefix, Tag, Prefix, Prefix, StdoutVar]),
+    plawk_writebin_varlen_field_lines(ArmTypes, Fields, Slots, Values,
+        FieldSeparator, Prefix, '%plawk_wbuf_p', StdoutVar, 0, FieldLines,
+        GlobalParts),
+    append([[StdoutLoad, TagIR], FieldLines], AllLines),
     atomic_list_concat(AllLines, '\n', IR),
     atomic_list_concat(GlobalParts, '\n', GlobalIR).
 
@@ -4115,6 +4204,8 @@ plawk_scalar_rule_body_action(Action) :-
     plawk_rule_body_print_action(Action).
 plawk_scalar_rule_body_action(writebin_out(Types, Fields)) :-
     plawk_writebin_args_ok(Types, Fields).
+plawk_scalar_rule_body_action(writebin_arm_out(_Tag, ArmTypes, Fields)) :-
+    plawk_writebin_args_ok(ArmTypes, Fields).
 plawk_scalar_rule_body_action(foreach_loop(_Layout, Body)) :-
     plawk_scalar_branch_body_actions(Body).
 plawk_scalar_rule_body_action(if(_Pattern, ThenActions, ElseActions)) :-
@@ -4133,6 +4224,8 @@ plawk_scalar_rule_body_plain_action(Action) :-
     plawk_rule_body_print_action(Action).
 plawk_scalar_rule_body_plain_action(writebin_out(Types, Fields)) :-
     plawk_writebin_args_ok(Types, Fields).
+plawk_scalar_rule_body_plain_action(writebin_arm_out(_Tag, ArmTypes, Fields)) :-
+    plawk_writebin_args_ok(ArmTypes, Fields).
 % else-if chains nest an if inside a branch body; the sequence walker
 % lowers nested ifs recursively, so validation recurses the same way.
 plawk_scalar_rule_body_plain_action(if(Pattern, ThenActions, ElseActions)) :-
@@ -4450,6 +4543,16 @@ plawk_scalar_action_sequence_pairs([writebin_out(Types, Fields) | Rest], Slots, 
     { format(atom(WbPrefix), '~w_wb_~w', [Prefix, OpIndex]),
       plawk_writebin_record_ir(Types, Fields, Slots, Values0, FieldSeparator,
           WbPrefix, Pair),
+      NextOpIndex is OpIndex + 1
+    },
+    [Pair],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits).
+plawk_scalar_action_sequence_pairs([writebin_arm_out(Tag, ArmTypes, Fields) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { format(atom(WbPrefix), '~w_wba_~w', [Prefix, OpIndex]),
+      plawk_writebin_union_record_ir(Tag, ArmTypes, Fields, Slots, Values0,
+          FieldSeparator, WbPrefix, Pair),
       NextOpIndex is OpIndex + 1
     },
     [Pair],
@@ -5712,6 +5815,7 @@ plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, GlobalIR-IR) :-
 plawk_output_action_exprs(print(Fields), Fields).
 plawk_output_action_exprs(printf(string(_Format), Args), Args).
 plawk_output_action_exprs(writebin_out(_Types, Fields), Fields).
+plawk_output_action_exprs(writebin_arm_out(_Tag, _ArmTypes, Fields), Fields).
 
 plawk_output_action_ir(print(Fields), FieldSeparator, OutputSeparator, Pair) :-
     plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, Pair).
@@ -5723,6 +5827,10 @@ plawk_output_action_ir(writebin_out(Types, Fields), FieldSeparator, _OutputSepar
     % the state-plan drivers.
     plawk_writebin_record_ir(Types, Fields, [], [], FieldSeparator,
         plawk_writebin, Pair).
+plawk_output_action_ir(writebin_arm_out(Tag, ArmTypes, Fields), FieldSeparator,
+        _OutputSeparator, Pair) :-
+    plawk_writebin_union_record_ir(Tag, ArmTypes, Fields, [], [],
+        FieldSeparator, plawk_writebin, Pair).
 
 plawk_prefixed_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, Prefix, ''-IR) :-
     !,

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -2592,7 +2592,9 @@ plawk_outfmt_type_ok(s(_W)) :- !.
 plawk_outfmt_type_ok(lps(_C)) :- !.
 plawk_outfmt_type_ok(rep(_K, ElemTypes)) :-
     forall(member(ElemType, ElemTypes),
-        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_) )).
+        ( memberchk(ElemType, [i64, f64]) ; ElemType = s(_)
+        ; ElemType = lps(_)
+        )).
 
 % sN output slots take string literals that fit the width, or field
 % reads (validated against the input layout separately in binary mode;
@@ -2703,6 +2705,73 @@ plawk_writebin_varlen_slot_lines(lps(Cap), Field, FieldSeparator, Base,
         '  %~w_pwr = call i64 @fwrite(i8* ~w, i64 ~w, i64 1, i8* ~w)',
         [Base, PtrIR, LenIR, Stdout]),
     append(SourceLines, [LenStore, PayloadWrite], Lines).
+% rep passthrough whose elements contain lps strings: each element's
+% wire size varies (a length prefix plus the live payload, recovered
+% with strnlen from the NUL-padded slot), so the writer loops over the
+% live elements, emitting each field left to right. The loop gets its
+% own labeled blocks; the fragment enters through a br so the head phi
+% has a named predecessor.
+plawk_writebin_varlen_slot_lines(rep(_Cap, ElemTypes), field(CountIndex),
+        binfmt(InTypes), Base, BasePtr, Stdout, Lines, []) :-
+    memberchk(lps(_ECap), ElemTypes),
+    !,
+    maplist(plawk_binfmt_type_width, ElemTypes, ElemWidths),
+    sum_list(ElemWidths, ElemSize),
+    plawk_binfmt_field_offset(binfmt(InTypes), CountIndex, CountOff),
+    ElemsOff is CountOff + 8,
+    format(atom(HeaderIR),
+'  br label %~w_pre
+
+~w_pre:
+  %~w_cfp = getelementptr i8, i8* %rec, i64 ~w
+  %~w_ctp = bitcast i8* %~w_cfp to i64*
+  %~w_n = load i64, i64* %~w_ctp, align 1
+  %~w_csp = bitcast i8* ~w to i64*
+  store i64 %~w_n, i64* %~w_csp, align 1
+  %~w_cwr = call i64 @fwrite(i8* ~w, i64 8, i64 1, i8* ~w)
+  br label %~w_lh
+
+~w_lh:
+  %~w_j = phi i64 [ 1, %~w_pre ], [ %~w_jn, %~w_ld ]
+  %~w_cont = icmp sle i64 %~w_j, %~w_n
+  br i1 %~w_cont, label %~w_lb, label %~w_after
+
+~w_lb:
+  %~w_jm1 = sub i64 %~w_j, 1
+  %~w_rel = mul i64 %~w_jm1, ~w
+  %~w_efp = getelementptr i8, i8* %rec, i64 ~w
+  %~w_eb = getelementptr i8, i8* %~w_efp, i64 %~w_rel',
+        [Base,
+         Base,
+         Base, CountOff,
+         Base, Base,
+         Base, Base,
+         Base, BasePtr,
+         Base, Base,
+         Base, BasePtr, Stdout,
+         Base,
+         Base,
+         Base, Base, Base, Base,
+         Base, Base, Base,
+         Base, Base, Base,
+         Base,
+         Base, Base,
+         Base, Base, ElemSize,
+         Base, ElemsOff,
+         Base, Base, Base]),
+    format(atom(ElemBase), '%~w_eb', [Base]),
+    plawk_writebin_rep_elem_lines(ElemTypes, Base, ElemBase, BasePtr, Stdout,
+        0, 0, ElemLines),
+    format(atom(FooterIR),
+'  br label %~w_ld
+
+~w_ld:
+  %~w_jn = add i64 %~w_j, 1
+  br label %~w_lh
+
+~w_after:',
+        [Base, Base, Base, Base, Base, Base]),
+    append([[HeaderIR], ElemLines, [FooterIR]], Lines).
 plawk_writebin_varlen_slot_lines(rep(_Cap, ElemTypes), field(CountIndex),
         binfmt(InTypes), Base, BasePtr, Stdout, Lines, []) :-
     !,
@@ -2752,6 +2821,49 @@ plawk_writebin_varlen_slot_lines(Type, Field, FieldSeparator, Base, BasePtr,
         [Base, BasePtr, LLVMType, LLVMType, ValueIR, LLVMType, Base,
          Base, BasePtr, Stdout]),
     append(SetupParts, [StoreWrite], Lines).
+
+%% plawk_writebin_rep_elem_lines(+ElemTypes, +Base, +ElemBase, +BasePtr,
+%%     +Stdout, +Index, +Offset, -Lines)
+%
+%  Loop-body field writes for one rep element based at ElemBase.
+%  Fixed-width fields pass through directly; lps fields recover the
+%  live length from the NUL-padded slot with strnlen, then emit the
+%  8-byte prefix and exactly that many payload bytes.
+plawk_writebin_rep_elem_lines([], _Base, _ElemBase, _BasePtr, _Stdout,
+        _Index, _Offset, []).
+plawk_writebin_rep_elem_lines([lps(Cap) | Types], Base, ElemBase, BasePtr,
+        Stdout, Index, Offset, [IR | Lines]) :-
+    !,
+    format(atom(IR),
+'  %~w_e~w_sp = getelementptr i8, i8* ~w, i64 ~w
+  %~w_e~w_len = call i64 @strnlen(i8* %~w_e~w_sp, i64 ~w)
+  %~w_e~w_lsp = bitcast i8* ~w to i64*
+  store i64 %~w_e~w_len, i64* %~w_e~w_lsp, align 1
+  %~w_e~w_lwr = call i64 @fwrite(i8* ~w, i64 8, i64 1, i8* ~w)
+  %~w_e~w_pwr = call i64 @fwrite(i8* %~w_e~w_sp, i64 %~w_e~w_len, i64 1, i8* ~w)',
+        [Base, Index, ElemBase, Offset,
+         Base, Index, Base, Index, Cap,
+         Base, Index, BasePtr,
+         Base, Index, Base, Index,
+         Base, Index, BasePtr, Stdout,
+         Base, Index, Base, Index, Base, Index, Stdout]),
+    plawk_binfmt_type_width(lps(Cap), Width),
+    NextOffset is Offset + Width,
+    NextIndex is Index + 1,
+    plawk_writebin_rep_elem_lines(Types, Base, ElemBase, BasePtr, Stdout,
+        NextIndex, NextOffset, Lines).
+plawk_writebin_rep_elem_lines([Type | Types], Base, ElemBase, BasePtr,
+        Stdout, Index, Offset, [IR | Lines]) :-
+    plawk_binfmt_type_width(Type, Width),
+    format(atom(IR),
+'  %~w_e~w_sp = getelementptr i8, i8* ~w, i64 ~w
+  %~w_e~w_wr = call i64 @fwrite(i8* %~w_e~w_sp, i64 ~w, i64 1, i8* ~w)',
+        [Base, Index, ElemBase, Offset,
+         Base, Index, Base, Index, Width, Stdout]),
+    NextOffset is Offset + Width,
+    NextIndex is Index + 1,
+    plawk_writebin_rep_elem_lines(Types, Base, ElemBase, BasePtr, Stdout,
+        NextIndex, NextOffset, Lines).
 
 %% plawk_writebin_lps_source_lines(+Field, +FieldSeparator, +Cap, +Base,
 %%     +BasePtr, -PtrIR, -LenIR, -Lines, -GlobalParts)

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4717,6 +4717,8 @@ plawk_f64_operand_expr(float_const(Mantissa, Denominator)) :-
 plawk_f64_operand_expr(float_field(Index)) :-
     integer(Index),
     Index >= 0.
+plawk_f64_operand_expr(float_call(Name, Args)) :-
+    plawk_prolog_call_expr(prolog_call(Name, Args)).
 plawk_f64_operand_expr(Expr) :-
     plawk_i64_operand_expr(Expr).
 plawk_f64_operand_expr(Expr) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -872,6 +872,9 @@ field_expr(Expr) -->
     float_field_expr(Expr),
     !.
 field_expr(Expr) -->
+    float_call_expr(Expr),
+    !.
+field_expr(Expr) -->
     float_literal_expr(Expr),
     !.
 field_expr(Expr) -->

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -738,7 +738,26 @@ foreach_action(foreach(Actions)) -->
 %% writebin_action(-Action)//
 %
 %  writebin expr, expr, ... - emit one fixed-layout binary record on
-%  stdout, laid out per BEGIN { OUTFMT = "..." }.
+%  stdout, laid out per BEGIN { OUTFMT = "..." }. With a tagged-union
+%  OUTFMT (`OUTFMT = "case(arm0 | arm1)"`), each site statically
+%  targets one arm: `writebin case K, expr, ...` emits the 8-byte tag
+%  K then arm K's slots.
+writebin_action(writebin_arm(Index, Fields)) -->
+    "writebin",
+    required_ws,
+    "case",
+    identifier_boundary,
+    ws,
+    integer_codes(IndexCodes),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    },
+    ws,
+    ",",
+    !,
+    ws,
+    print_fields(Fields).
 writebin_action(writebin(Fields)) -->
     "writebin",
     required_ws,

--- a/tests/test_plawk_f64_foreign.pl
+++ b/tests/test_plawk_f64_foreign.pl
@@ -63,6 +63,18 @@ test(surface_float_call_and_float_guard) :-
         [rec(2, 1.5), rec(3, 0.25), rec(1, 2.5)],
         "2 6.25\n").
 
+test(float_call_in_print_position_uses_double_wrapper) :-
+    build_ff_ir("BEGIN { BINFMT = \"i64 f64\" } $1 > 0 { print $1, float(plawk_ff_wf($1, $2)) } END { print done }\n", DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define { double, i1 } @plawk_foreign_fcall_plawk_ff_wf_2'))),
+    !.
+
+test(surface_float_call_prints_per_record) :-
+    % wf(I, F) = I * F printed per matching record; %g drops trailing
+    % zeros (3.0 prints as 3).
+    run_ff_smoke("BEGIN { BINFMT = \"i64 f64\" } $1 > 0 { print $1, float(plawk_ff_wf($1, $2)) } END { print done }\n",
+        [rec(2, 1.5), rec(-1, 2.5), rec(3, 0.25)],
+        "2 3\n3 0.75\n0\n").
+
 test(surface_failed_float_call_contributes_zero) :-
     % posval fails on non-positive inputs: those records add 0.0.
     % (1,1.5) (2,-2.5) (3,0.25): wsum = 3.0 + 0.0 + 0.5.

--- a/tests/test_plawk_rep_writer.pl
+++ b/tests/test_plawk_rep_writer.pl
@@ -40,8 +40,9 @@ test(rep_outfmt_rejections) :-
         "BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64)\" } { writebin $1, $2 }\n",
         % the rep argument must be the input rep's count field
         "BEGIN { BINFMT = \"i64 rep4(i64 f64)\" ; OUTFMT = \"i64 rep4(i64 f64)\" } { writebin $1, $1 }\n",
-        % lps elements are not bulk-copyable (wire differs per element)
-        "BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" ; OUTFMT = \"i64 rep4(lps8 i64)\" } { writebin $1, $2 }\n"
+        % element layouts must match even in loop mode (input s8 vs
+        % output lps8 differ on the wire)
+        "BEGIN { BINFMT = \"i64 rep4(s8 i64)\" ; OUTFMT = \"i64 rep4(lps8 i64)\" } { writebin $1, $2 }\n"
     ],
     forall(member(Source, Rejects),
         ( plawk_parse_string(Source, Program)
@@ -61,6 +62,28 @@ test(surface_rep_filter_is_byte_exact) :-
     records_bytes(Drop, DropBytes),
     assertion(OutBytes == ExpectedBytes),
     assertion(OutBytes \== DropBytes).
+
+test(rep_lps_elements_write_in_a_loop) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" ; OUTFMT = \"i64 rep4(lps8 i64)\" } $1 > 0 { writebin $1, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % a writer-side loop: head phi, live length via strnlen, per-field
+    % fwrites -- and no bulk element write
+    assertion(once(sub_atom(DriverIR, _, _, _, '_j = phi i64 [ 1, %'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@strnlen(i8* %'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_pwr = call i64 @fwrite'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '_ewr = call i64 @fwrite')),
+    !.
+
+test(surface_rep_lps_filter_is_byte_exact) :-
+    % Same byte-exact filter contract as the fixed-element case, with
+    % variable-size elements: name lengths 3, 0, and the full cap 8.
+    Keep = [rec2(1, [f("hot", 5), f("", 7)]), rec2(4, [f("full8chr", 2)])],
+    Input = [rec2(1, [f("hot", 5), f("", 7)]), rec2(-9, [f("drop", 1)]),
+             rec2(4, [f("full8chr", 2)])],
+    run_rpw2_smoke("BEGIN { BINFMT = \"i64 rep4(lps8 i64)\" ; OUTFMT = \"i64 rep4(lps8 i64)\" } $1 > 0 { writebin $1, $2 }\n",
+        Input, OutBytes),
+    records2_bytes(Keep, ExpectedBytes),
+    assertion(OutBytes == ExpectedBytes).
 
 test(surface_rep_passthrough_in_union_arm) :-
     % Composes with case blocks: arm 0 carries the rep, its rule
@@ -99,6 +122,69 @@ write_rpw_stream(Out, Recs) :-
               ( write_i64_le(Out, V),
                 double_bits(F, Bits),
                 write_i64_le(Out, Bits) )) )).
+
+% rec2(Id, Elems): i64 id, i64 count, then per element lps8 + i64
+write_rpw2_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec2(Id, Elems), Recs),
+            ( write_i64_le(Out, Id),
+              length(Elems, Count),
+              write_i64_le(Out, Count),
+              forall(member(f(S, V), Elems),
+                  ( string_codes(S, Codes),
+                    length(Codes, Len),
+                    write_i64_le(Out, Len),
+                    forall(member(C, Codes), put_byte(Out, C)),
+                    write_i64_le(Out, V) )) )),
+        close(Out)).
+
+records2_bytes(Recs, Bytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_rep_writer_expect2.bin', Path),
+    write_rpw2_records(Path, Recs),
+    setup_call_cleanup(
+        open(Path, read, In, [type(binary)]),
+        read_string(In, _, Bytes),
+        close(In)).
+
+run_rpw2_smoke(Source, Recs, OutBytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_rep_writer2', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_rpw_marker/0 ],
+        [module_name('plawk_rep_writer2')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(BuildOutS)), stderr(std), process(BuildPid)]),
+    read_string(BuildOutS, _, BuildOut),
+    close(BuildOutS),
+    process_wait(BuildPid, BuildStatus),
+    ( BuildStatus == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk rep writer2 build output]~n~w~n", [BuildOut]),
+       throw(plawk_rep_writer2_build_failed(BuildStatus))
+    ),
+    write_rpw2_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, OutBytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    !.
 
 % the byte string a record list occupies on the wire
 records_bytes(Recs, Bytes) :-

--- a/tests/test_plawk_union_assoc.pl
+++ b/tests/test_plawk_union_assoc.pl
@@ -61,6 +61,25 @@ test(surface_union_groupby_tag_guards_and_lookup) :-
         [m(20, 1.5), e("a", 20), m(5, 2.5), m(20, 1.5), e("b", 5)],
         "3 1\n").
 
+test(surface_union_groupby_forin_writebin) :-
+    % Group-by to BINARY output over a union stream: one (key, count)
+    % record per group.
+    build_uas_probe("BEGIN { BINFMT = \"case(i64 f64 | lps16 i64)\" ; OUTFMT = \"i64 i64\" } case 0 { { counts[$1]++ } } case 1 { { counts[$2]++ } } END { for (k in counts) writebin k, counts[k] }\n",
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_uas_records(InputPath, [m(5, 1.5), e("x", 9), m(5, 2.5), e("y", 5), m(9, 1.5)]),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    decode_i64_pairs(Bytes, Records0),
+    msort(Records0, Records),
+    assertion(Records == [5-3, 9-2]),
+    !.
+
 :- end_tests(plawk_union_assoc).
 
 % --- helpers ---------------------------------------------------------------
@@ -93,6 +112,26 @@ write_uas_record(Out, e(S, C)) :-
     write_i64_le(Out, Len),
     forall(member(Code, Codes), put_byte(Out, Code)),
     write_i64_le(Out, C).
+
+le_i64(Bytes, Value) :-
+    foldl([B, I0-V0, I-V]>>( V is V0 + (B << (8 * I0)), I is I0 + 1 ),
+        Bytes, 0-0, _-Unsigned),
+    ( Unsigned >= 0x8000000000000000
+    -> Value is Unsigned - 0x10000000000000000
+    ;  Value = Unsigned
+    ).
+
+decode_i64_pairs(Bytes, Records) :-
+    string_codes(Bytes, Codes),
+    decode_i64_pairs_codes(Codes, Records).
+
+decode_i64_pairs_codes([], []).
+decode_i64_pairs_codes(Codes, [A-B | Records]) :-
+    length(ABytes, 8), length(BBytes, 8),
+    append(ABytes, Rest0, Codes), append(BBytes, Rest, Rest0),
+    le_i64(ABytes, A),
+    le_i64(BBytes, B),
+    decode_i64_pairs_codes(Rest, Records).
 
 build_uas_probe(Source, Dir, BinPath) :-
     tmp_root(Root),

--- a/tests/test_plawk_union_out.pl
+++ b/tests/test_plawk_union_out.pl
@@ -1,0 +1,182 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_uot_marker/0.
+
+user:plawk_uot_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_union_out, [condition(clang_available)]).
+
+test(union_outfmt_writes_tag_then_arm_slots) :-
+    plawk_parse_string("BEGIN { BINFMT = \"case(i64 f64)\" ; OUTFMT = \"case(i64 | i64 lps8)\" } TAG == 0 && $1 > 100 { writebin case 0, $1 ; next } TAG == 0 { writebin case 1, $1, \"low\" }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.bin', DriverIR),
+    % shared buffer sized to the widest arm (i64 + lps8 slot = 16),
+    % element pointer resolved once in entry
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_wbuf = alloca [16 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_wbuf_p = getelementptr inbounds [16 x i8]'))),
+    % each site stores its constant tag and writes 8 bytes first
+    assertion(once(sub_atom(DriverIR, _, _, _, 'store i64 0, i64* %'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'store i64 1, i64* %'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(union_outfmt_rejections) :-
+    Rejects = [
+        % arm index beyond the declared arms
+        "BEGIN { BINFMT = \"i64 f64\" ; OUTFMT = \"case(i64 | i64)\" } { writebin case 2, $1 }\n",
+        % a plain writebin cannot pick an arm
+        "BEGIN { BINFMT = \"i64 f64\" ; OUTFMT = \"case(i64 | i64)\" } { writebin $1 }\n",
+        % an arm-targeted writebin is meaningless against a flat layout
+        "BEGIN { BINFMT = \"i64 f64\" ; OUTFMT = \"i64\" } { writebin case 0, $1 }\n",
+        % argument count must match the arm
+        "BEGIN { BINFMT = \"i64 f64\" ; OUTFMT = \"case(i64 i64)\" } { writebin case 0, $1 }\n"
+    ],
+    forall(member(Source, Rejects),
+        ( plawk_parse_string(Source, Program)
+        -> assertion(\+ plawk_program_native_driver_ir(Program, 'input.bin', _))
+        ;  true
+        )).
+
+test(surface_split_stream_into_tagged_output) :-
+    % Records split into a tagged stream: big ids to arm 0, everything
+    % else to arm 1 with a label. A pure retagger: no END, no scalars.
+    run_uot_writer("BEGIN { BINFMT = \"case(i64 f64)\" ; OUTFMT = \"case(i64 | i64 lps8)\" } TAG == 0 && $1 > 100 { writebin case 0, $1 ; next } TAG == 0 { writebin case 1, $1, \"low\" }\n",
+        [rec(200, 1.5), rec(5, 2.5), rec(300, 0.25)],
+        OutBytes),
+    expected_bytes([i64(0), i64(200),
+                    i64(1), i64(5), i64(3), bytes("low"),
+                    i64(0), i64(300)],
+        Expected),
+    assertion(OutBytes == Expected),
+    !.
+
+test(surface_tagged_output_roundtrips_through_union_reader) :-
+    % The capstone: the tagged writer's output is byte-compatible with
+    % the union READER, so a second plawk program consumes it directly.
+    run_uot_writer("BEGIN { BINFMT = \"case(i64 f64)\" ; OUTFMT = \"case(i64 | i64 lps8)\" } TAG == 0 && $1 > 100 { writebin case 0, $1 ; next } TAG == 0 { writebin case 1, $1, \"low\" }\n",
+        [rec(200, 1.5), rec(5, 2.5), rec(300, 0.25)],
+        OutBytes),
+    run_uot_reader("BEGIN { BINFMT = \"case(i64 | i64 lps8)\" } TAG == 0 { bigsum += $1 } TAG == 1 && $2 == \"low\" { lows++ } END { print bigsum, lows }\n",
+        OutBytes, ReaderOut),
+    assertion(ReaderOut == "500 1\n"),
+    !.
+
+:- end_tests(plawk_union_out).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,  0x3FF8000000000000).
+double_bits(2.5,  0x4004000000000000).
+double_bits(0.25, 0x3FD0000000000000).
+
+write_items(Path, Items) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Item, Items), write_item(Out, Item)),
+        close(Out)).
+
+write_item(Out, i64(V)) :-
+    write_i64_le(Out, V).
+write_item(Out, f64(F)) :-
+    double_bits(F, Bits),
+    write_i64_le(Out, Bits).
+write_item(Out, bytes(S)) :-
+    string_codes(S, Cs),
+    forall(member(C, Cs), put_byte(Out, C)).
+
+expected_bytes(Items, Bytes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_union_out_expect.bin', Path),
+    write_items(Path, Items),
+    setup_call_cleanup(
+        open(Path, read, In, [type(binary)]),
+        read_string(In, _, Bytes),
+        close(In)).
+
+build_uot_probe(Source, SubDir, ModuleName, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, SubDir, Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_uot_marker/0 ],
+        [module_name(ModuleName)], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk union out build output]~n~w~n", [BuildOut]),
+       throw(plawk_union_out_build_failed(Status))
+    ).
+
+run_capture_binary(BinPath, Bytes) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    set_stream(Stdout, type(binary)),
+    read_string(Stdout, _, Bytes),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)).
+
+% rec(I64, F64) input records for the single-arm-union writer programs
+% (each on the wire as tag 0, i64, f64)
+run_uot_writer(Source, Recs, OutBytes) :-
+    build_uot_probe(Source, 'uw_plawk_union_out_w', 'plawk_union_out_w',
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    findall(Item,
+        ( member(rec(I, F), Recs),
+          member(Item, [i64(0), i64(I), f64(F)])
+        ),
+        Items),
+    write_items(InputPath, Items),
+    run_capture_binary(BinPath, OutBytes).
+
+run_uot_reader(Source, InputBytes, OutStr) :-
+    build_uot_probe(Source, 'uw_plawk_union_out_r', 'plawk_union_out_r',
+        Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, Out, [type(binary)]),
+        ( string_codes(InputBytes, Codes),
+          forall(member(C, Codes), put_byte(Out, C)) ),
+        close(Out)),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)).


### PR DESCRIPTION
## Why

The round-5 stack merged branch-to-branch: only #3443 reached this branch, while #3444, #3446, and #3447 landed on their respective base branches. This reassembles all four on the designated branch (plus a sync merge of main) and carries them the last step. No new content. **Merge first** — the next round's feature PRs stack on top.

Contents: float(name(args)) in print position, for-in writebin over union input, per-element write loop for lps-element reps, tagged output (union OUTFMT). Full regression sweep re-run on the assembled branch: all 49 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_