### PR TITLE
plawk: multi-line programs (# comments, newline statement separators)

### DIFF
--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -102,6 +102,7 @@ swipl -q -s tests/test_plawk_union_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_union_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_rep_writer.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_out.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_multiline.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -116,6 +117,10 @@ as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
 case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0) }`.
 Explicit numeric field coercion is available as `int($N)`, e.g.
 `$1 == "ERROR" { print $3, int($3) }`; failed numeric parses print `0`.
+Programs are multi-line awk: `#` comments run to end of line,
+statements separate on newlines as well as `;` (with awk/C semantics
+after a compound statement's closing brace -- no separator needed),
+and trailing separators before `}` are harmless.
 Arithmetic expressions support general `+`, `-`, `*`, `/`, and `%` between
 native `i64` operands with awk precedence (`* / %` bind tighter than `+ -`,
 both associate left) and parentheses, e.g.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -109,6 +109,15 @@ action_block(Actions) -->
     "{",
     ws,
     actions(Actions),
+    action_block_close.
+
+% a trailing `;` or newline before the closing brace is harmless
+action_block_close -->
+    action_sep,
+    !,
+    "}",
+    ws.
+action_block_close -->
     ws,
     "}",
     ws.
@@ -537,16 +546,54 @@ for_in_body([PrintAction]) -->
 
 actions([Action | Actions]) -->
     action(Action),
-    actions_rest(Actions).
+    actions_rest(Action, Actions).
 
-actions_rest([Action | Actions]) -->
-    ws,
-    ";",
-    ws,
-    !,
+actions_rest(_Prev, [Action | Actions]) -->
+    action_sep,
     action(Action),
-    actions_rest(Actions).
-actions_rest([]) -->
+    !,
+    actions_rest(Action, Actions).
+% as in awk/C, no separator is needed after a compound statement's
+% closing brace (whose trailing ws has already been consumed)
+actions_rest(Prev, [Action | Actions]) -->
+    { plawk_block_action(Prev) },
+    action(Action),
+    !,
+    actions_rest(Action, Actions).
+actions_rest(_Prev, []) -->
+    [].
+
+plawk_block_action(if(_Pattern, _Then, _Else)).
+plawk_block_action(foreach(_Body)).
+
+%% action_sep//0
+%
+%  One statement separator, as in awk: any run of blanks, comments,
+%  semicolons, and newlines containing at least one `;` or newline.
+%  (A trailing separator before `}` is harmless: the following
+%  action// fails and actions_rest backtracks to its empty clause.)
+action_sep -->
+    action_sep_scan(no).
+
+action_sep_scan(_Seen) -->
+    ";",
+    !,
+    action_sep_scan(yes).
+action_sep_scan(_Seen) -->
+    "\n",
+    !,
+    action_sep_scan(yes).
+action_sep_scan(Seen) -->
+    [Code],
+    { Code =\= 0'\n, code_type(Code, space) },
+    !,
+    action_sep_scan(Seen).
+action_sep_scan(Seen) -->
+    "#",
+    !,
+    comment_rest,
+    action_sep_scan(Seen).
+action_sep_scan(yes) -->
     [].
 
 action(Action) -->
@@ -1161,12 +1208,30 @@ required_ws -->
     { code_type(Code, space) },
     ws.
 
+% Whitespace, including newlines and awk-style # comments (a comment
+% runs to end of line; its terminating newline still counts as a
+% statement separator in action_sep//0). `#` is not a token anywhere
+% in the surface, and strings/regex bodies never route through ws//0,
+% so comments cannot be consumed inside literals.
 ws -->
     [Code],
     { code_type(Code, space) },
     !,
     ws.
 ws -->
+    "#",
+    !,
+    comment_rest,
+    ws.
+ws -->
+    [].
+
+comment_rest -->
+    [Code],
+    { Code =\= 0'\n },
+    !,
+    comment_rest.
+comment_rest -->
     [].
 
 eos([], []).

--- a/tests/test_plawk_multiline.pl
+++ b/tests/test_plawk_multiline.pl
@@ -1,0 +1,119 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_ml_marker/0.
+
+user:plawk_ml_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_multiline, [condition(clang_available)]).
+
+test(newlines_separate_statements) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" }\n{ a++\n  b++; c++\n}\nEND { print a, b, c }\n", Program),
+    Program = program(_, [rule(always, Actions)], _),
+    assertion(Actions == [inc(var(a)), inc(var(b)), inc(var(c))]).
+
+test(comments_run_to_end_of_line) :-
+    plawk_parse_string("# leading comment\nBEGIN { BINFMT = \"i64 f64\" }   # layout\n{ a++   # bump\n  b++ }\nEND { print a, b }   # report\n", Program),
+    Program = program(_, [rule(always, Actions)], _),
+    assertion(Actions == [inc(var(a)), inc(var(b))]),
+    % '#' inside a string literal is not a comment
+    plawk_parse_string("$1 == \"#x\" { n++ } END { print n }\n", P2),
+    P2 = program(_, [rule(field_eq(1, "#x"), _)], _).
+
+test(no_separator_needed_after_a_block) :-
+    % awk/C semantics: a compound statement's closing brace ends the
+    % statement, on the same line or not.
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } { if ($1 > 10) { h++ } w++ } END { print h, w }\n", P1),
+    P1 = program(_, [rule(always, [if(_, _, _), inc(var(w))])], _),
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } { if ($1 > 10) { h++ }\n  w++ } END { print h, w }\n", P2),
+    P2 = program(_, [rule(always, [if(_, _, _), inc(var(w))])], _).
+
+test(trailing_separators_are_harmless) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } { a++;\n } END { print a }\n", Program),
+    Program = program(_, [rule(always, [inc(var(a))])], _).
+
+test(adjacent_statements_still_need_a_separator) :-
+    assertion(\+ plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } { a++ b++ } END { print a }\n", _)).
+
+test(surface_multiline_program_end_to_end) :-
+    % A real multi-line program: comments, newline separators, a
+    % same-line statement after an if block, multi-line BEGIN.
+    Src = "# count big and small records\nBEGIN {\n  BINFMT = \"i64 f64\"   # binary layout\n}\n$1 > 100 {\n  big++\n  if ($1 > 1000) { huge++ }\n  wsum += float($2)   # weight\n}\n{ total++ }\nEND { print big, huge, total, wsum }\n",
+    run_ml_smoke(Src,
+        [rec(200, 1.5), rec(5, 2.5), rec(2000, 0.25)],
+        "2 1 3 1.75\n").
+
+:- end_tests(plawk_multiline).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,  0x3FF8000000000000).
+double_bits(2.5,  0x4004000000000000).
+double_bits(0.25, 0x3FD0000000000000).
+
+write_ml_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(I, F), Recs),
+            ( write_i64_le(Out, I),
+              double_bits(F, Bits),
+              write_i64_le(Out, Bits) )),
+        close(Out)).
+
+run_ml_smoke(Source, Recs, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_multiline', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_ml_marker/0 ],
+        [module_name('plawk_multiline')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(BuildS)), stderr(std), process(BuildPid)]),
+    read_string(BuildS, _, BuildOut),
+    close(BuildS),
+    process_wait(BuildPid, BuildStatus),
+    ( BuildStatus == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk multiline build output]~n~w~n", [BuildOut]),
+       throw(plawk_multiline_build_failed(BuildStatus))
+    ),
+    write_ml_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.


### PR DESCRIPTION
## Summary

First slice of the surface-ergonomics round: plawk programs are now genuinely multi-line awk —

```awk
# count big records
BEGIN {
  BINFMT = "i64 f64"   # binary layout
}
$1 > 100 {
  big++
  if ($1 > 1000) { huge++ }
  wsum += float($2)   # weight
}
END { print big, huge, total, wsum }
```

## Design

Three grammar changes, all in the parser:

- **`#` comments** run to end of line, skipped by the whitespace rule. `#` is not a token anywhere in the surface, and strings/regex bodies never route through whitespace, so literals are untouched.
- **Newlines separate statements** inside action blocks, alongside `;` — and, as in awk and C, **no separator is needed after a compound statement's closing brace**. That also retires the old "needs a `;` after an if block" quirk, which turned out to be exactly this rule missing.
- **Trailing separators before `}`** are harmless (`{ a++; }` is legal, as in awk).

Rules were already newline-separable (whitespace ate newlines); these pieces make bodies, comments, and BEGIN blocks match. This is the foundation for the next two slices (`@prolog` blocks and `function` sugar need room to breathe).

## Tests

New `tests/test_plawk_multiline.pl` (6 tests): the parse shapes above, adjacent statements without a separator still reject, `#` inside string literals is not a comment, and a genuinely multi-line program compiled and run e2e (`2 1 3 1.75` exact). Full sweep: **all 50 suites green** — every existing single-line program parses unchanged.

## Merge order

1. #3448 (consolidation → main) first
2. then this PR into `claude/plawk-llvm-wam-hybrid-p9ujut`; the round stacks on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_