### PR TITLE
plawk: @prolog blocks — a program carries its Prolog with it

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -207,8 +207,29 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    call (one shared buffer), NUL-free payloads (the transient atom is
    a C string), blob output is a later slice.
 
+## Embedded Prolog blocks (landed)
+
+`@prolog ... @end` blocks in the plawk source hold ordinary Prolog
+clauses (including DCG rules, which expand on the way in). Markers sit
+alone on their line; a heredoc-style tag (`@prolog-TAG ... @end-TAG`,
+exact tag match) makes the fence unambiguous when the Prolog text
+itself contains an `@end`-shaped line. `plawk_parse_source/3` lifts
+the blocks before the awk grammar runs and term-reads them;
+`plawk_prolog_block_preds/2` installs the clauses (reset-then-assert,
+so recompiles replace) and returns the `user:Name/Arity` list that
+`write_wam_llvm_project/3` takes — from there the existing foreign
+bridge does everything (guards, i64/f64/blob marshaling,
+`float(name(args))`). One source file now carries the whole Tier-2
+story: native framing above, the payload grammar below.
+
 ## Known design debt
 
+- **(OPEN) WAM lowering of if-then-else/cut in compiled DCG bodies.**
+  An embedded grammar written with `( "," -> ... ; ... )` and a cut in
+  the digits rule compiled but returned 0 at runtime; the same grammar
+  respelled as plain clause alternation (greedy clause before stop
+  clause, tier2 style) works. Needs a minimal WAM-target reproduction;
+  until then, prefer clause alternation in embedded grammars.
 - **(FIXED) WAM bug: constant-in-list clause heads never matched.**
   `unify_constant` built its read-mode comparison value with a
   hardcoded Atom tag (op2 was unused), so an integer constant in a

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -103,6 +103,7 @@ swipl -q -s tests/test_plawk_union_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/
 swipl -q -s tests/test_plawk_rep_writer.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_out.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_multiline.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_prolog_blocks.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -120,7 +121,26 @@ Explicit numeric field coercion is available as `int($N)`, e.g.
 Programs are multi-line awk: `#` comments run to end of line,
 statements separate on newlines as well as `;` (with awk/C semantics
 after a compound statement's closing brace -- no separator needed),
-and trailing separators before `}` are harmless.
+and trailing separators before `}` are harmless. A program can carry
+its Prolog with it: `@prolog ... @end` blocks hold ordinary clauses
+(DCG rules included) that compile into the same binary and are
+callable through the foreign bridge --
+
+```awk
+@prolog
+weight(I, F, R) :- R is I * F.
+hot(X) :- X > 100.
+@end
+BEGIN { BINFMT = "i64 f64" }
+hot($1) { wsum += float(weight($1, $2)) }
+END { print wsum }
+```
+
+Markers sit alone on their line; the heredoc-style tagged form
+(`@prolog-TAG ... @end-TAG`, exact tag match) fences Prolog text that
+itself contains an `@end`-shaped line. `plawk_parse_source/3` returns
+program + clauses, and `plawk_prolog_block_preds/2` installs them for
+`write_wam_llvm_project/3`.
 Arithmetic expressions support general `+`, `-`, `*`, `/`, and `%` between
 native `i64` operands with awk precedence (`* / %` bind tighter than `+ -`,
 both associate left) and parentheses, e.g.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5,10 +5,60 @@
     plawk_program_native_driver_ir/3,
     plawk_program_native_driver_ir/4,
     plawk_program_foreign_specs/3,
-    plawk_program_foreign_specs/4
+    plawk_program_foreign_specs/4,
+    plawk_prolog_block_preds/2
 ]).
 
 :- discontiguous plawk_pattern_guard_ir/5.
+
+%% plawk_prolog_block_preds(+Clauses, -Preds)
+%
+%  Install the embedded @prolog clauses a plawk_parse_source/3 parse
+%  returned, so write_wam_llvm_project/3 can compile them into the
+%  same binary as the driver. DCG rules expand; each defined predicate
+%  is reset (retractall) before its clauses assert, so recompiling a
+%  program replaces rather than accumulates definitions. Preds is the
+%  deduplicated user:Name/Arity list in first-definition order --
+%  exactly the predicate list write_wam_llvm_project/3 takes.
+%  Directives are not clauses and reject the program.
+plawk_prolog_block_preds(Clauses0, Preds) :-
+    \+ member((:- _Directive), Clauses0),
+    maplist(plawk_expand_block_clause, Clauses0, ClausesNested),
+    append(ClausesNested, Clauses),
+    findall(Name/Arity,
+        ( member(Clause, Clauses),
+          plawk_block_clause_head(Clause, Head),
+          functor(Head, Name, Arity)
+        ),
+        PIs0),
+    plawk_dedupe_keep_order(PIs0, PIs),
+    forall(member(Name/Arity, PIs),
+        ( functor(Head, Name, Arity),
+          retractall(user:Head)
+        )),
+    forall(member(Clause, Clauses), assertz(user:Clause)),
+    findall(user:PI, member(PI, PIs), Preds).
+
+% expand_term/2 may return one clause or a list, and DCG expansion can
+% interleave compile-time directives (e.g. discontiguous hints) with
+% the clauses -- keep only the clauses.
+plawk_expand_block_clause(Clause0, Clauses) :-
+    expand_term(Clause0, Expanded),
+    ( is_list(Expanded)
+    ->  Expanded1 = Expanded
+    ;   Expanded1 = [Expanded]
+    ),
+    exclude(plawk_block_directive, Expanded1, Clauses).
+
+plawk_block_directive((:- _Goal)).
+
+plawk_block_clause_head((Head :- _Body), Head) :- !.
+plawk_block_clause_head(Head, Head).
+
+plawk_dedupe_keep_order([], []).
+plawk_dedupe_keep_order([PI | Rest0], [PI | Deduped]) :-
+    exclude(==(PI), Rest0, Rest),
+    plawk_dedupe_keep_order(Rest, Deduped).
 
 :- use_module('../../../src/unifyweaver/targets/wam_llvm_target',
     [llvm_emit_atom_prefix_guard/5,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2,7 +2,8 @@
 % Copyright (c) 2026 John William Creighton (s243a)
 
 :- module(plawk_parser, [
-    plawk_parse_string/2
+    plawk_parse_string/2,
+    plawk_parse_source/3
 ]).
 
 %% plawk_parse_string(+Source, -Program) is semidet.
@@ -40,9 +41,81 @@
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
 plawk_parse_string(Source, Program) :-
+    plawk_parse_source(Source, Program, _PrologClauses).
+
+%% plawk_parse_source(+Source, -Program, -PrologClauses) is semidet.
+%
+%  Like plawk_parse_string/2, but also lifts embedded Prolog blocks:
+%
+%      @prolog
+%      weight(I, F, R) :- R is I * F.
+%      @end
+%
+%  Block markers sit alone on their line (leading/trailing blanks ok).
+%  A heredoc-style tag makes the fence unambiguous when the Prolog
+%  text itself contains an @end-shaped line: `@prolog-TAG` closes only
+%  at `@end-TAG` with the exact same tag. Blocks may appear anywhere
+%  between top-level program parts; their text never routes through
+%  the awk grammar -- it is term-read as ordinary Prolog and returned
+%  as PrologClauses for the compile driver to hand to
+%  write_wam_llvm_project alongside the program.
+plawk_parse_source(Source, Program, PrologClauses) :-
     string(Source),
-    string_codes(Source, Codes),
+    plawk_split_prolog_blocks(Source, Stripped, BlockTexts),
+    maplist(plawk_read_block_clauses, BlockTexts, ClausesNested),
+    append(ClausesNested, PrologClauses),
+    string_codes(Stripped, Codes),
     phrase(plawk_program(Program), Codes).
+
+plawk_split_prolog_blocks(Source, Stripped, BlockTexts) :-
+    split_string(Source, "\n", "", Lines),
+    plawk_split_block_lines(Lines, KeptLines, BlockTexts),
+    atomic_list_concat(KeptLines, '\n', StrippedAtom),
+    atom_string(StrippedAtom, Stripped).
+
+plawk_split_block_lines([], [], []).
+plawk_split_block_lines([Line | Lines], KeptLines, [BlockText | BlockTexts]) :-
+    plawk_prolog_open_marker(Line, EndMarker),
+    !,
+    plawk_take_block_lines(Lines, EndMarker, BlockLines, Rest),
+    atomic_list_concat(BlockLines, '\n', BlockAtom),
+    atom_string(BlockAtom, BlockText),
+    plawk_split_block_lines(Rest, KeptLines, BlockTexts).
+plawk_split_block_lines([Line | Lines], [Line | KeptLines], BlockTexts) :-
+    plawk_split_block_lines(Lines, KeptLines, BlockTexts).
+
+plawk_prolog_open_marker(Line, EndMarker) :-
+    split_string(Line, "", " \t", [Trimmed]),
+    ( Trimmed == "@prolog"
+    ->  EndMarker = "@end"
+    ;   string_concat("@prolog-", Tag, Trimmed),
+        Tag \== "",
+        string_concat("@end-", Tag, EndMarker)
+    ).
+
+% an unterminated block fails the parse (no clause for [])
+plawk_take_block_lines([Line | Lines], EndMarker, BlockLines, Rest) :-
+    split_string(Line, "", " \t", [Trimmed]),
+    ( Trimmed == EndMarker
+    ->  BlockLines = [],
+        Rest = Lines
+    ;   BlockLines = [Line | BlockLines1],
+        plawk_take_block_lines(Lines, EndMarker, BlockLines1, Rest)
+    ).
+
+plawk_read_block_clauses(BlockText, Clauses) :-
+    setup_call_cleanup(
+        open_string(BlockText, Stream),
+        plawk_read_stream_clauses(Stream, Clauses),
+        close(Stream)).
+
+plawk_read_stream_clauses(Stream, Clauses) :-
+    read_term(Stream, Term, []),
+    ( Term == end_of_file
+    ->  Clauses = []
+    ;   Clauses = [Term | Rest],
+        plawk_read_stream_clauses(Stream, Rest)
+    ).
 
 plawk_program(program(BeginClauses, Rules, EndClauses)) -->
     ws,

--- a/tests/test_plawk_prolog_blocks.pl
+++ b/tests/test_plawk_prolog_blocks.pl
@@ -1,0 +1,145 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_prolog_blocks, [condition(clang_available)]).
+
+test(blocks_lift_out_of_the_awk_surface) :-
+    Src = "@prolog\nplawk_pbt_w(I, F, R) :- R is I * F.\n@end\nBEGIN { BINFMT = \"i64 f64\" }\n{ wsum += float(plawk_pbt_w($1, $2)) }\nEND { print wsum }\n",
+    plawk_parse_source(Src, Program, Clauses),
+    assertion(Clauses = [(plawk_pbt_w(_, _, _) :- _)]),
+    Program = program(_, [rule(always, _)], _),
+    % the same source parses through the 2-arity entry too
+    plawk_parse_string(Src, _).
+
+test(tagged_markers_and_rejections) :-
+    % heredoc-style tags close only on the exact same tag
+    plawk_parse_source("@prolog-x9\nplawk_pbt_t(1).\n@end-x9\nBEGIN { BINFMT = \"i64\" } { n++ } END { print n }\n",
+        _, [plawk_pbt_t(1)]),
+    % a mismatched tag leaves the block unterminated
+    assertion(\+ plawk_parse_source("@prolog-a\nfoo(1).\n@end-b\nBEGIN { BINFMT = \"i64\" } { n++ } END { print n }\n", _, _)),
+    % ... as does a missing @end
+    assertion(\+ plawk_parse_source("@prolog\nfoo(1).\nBEGIN { BINFMT = \"i64\" } { n++ } END { print n }\n", _, _)),
+    % directives are not clauses
+    plawk_parse_source("@prolog\n:- dynamic foo/1.\nfoo(1).\n@end\nBEGIN { BINFMT = \"i64\" } { n++ } END { print n }\n",
+        _, DirClauses),
+    assertion(\+ plawk_prolog_block_preds(DirClauses, _)).
+
+test(surface_embedded_predicates_end_to_end) :-
+    % Guard and expression functions defined in the program text.
+    Src = "# weights, with the logic in Prolog\n@prolog\nplawk_pbt_weight(I, F, R) :- R is I * F.\nplawk_pbt_hot(X) :- X > 100.\n@end\n\nBEGIN { BINFMT = \"i64 f64\" }\nplawk_pbt_hot($1) {\n  wsum += float(plawk_pbt_weight($1, $2))\n}\nEND { print wsum }\n",
+    run_pb_smoke(Src,
+        [rec(200, 1.5), rec(5, 2.5), rec(300, 0.25)],
+        "375\n").
+
+test(surface_embedded_dcg_parses_blob_payloads) :-
+    % The Tier-2 story in ONE file: the record loop frames natively,
+    % and a DCG defined in the @prolog block parses each payload.
+    % backtracking-based grammar (greedy digit clause before the stop
+    % clause, a constant-in-list head), with the leaf rules in -->
+    % form to exercise DCG expansion of embedded clauses
+    Src = "@prolog-t2\nplawk_pbt_sum(Payload, Sum) :- atom_codes(Payload, Codes), plawk_pbt_nums(Sum, Codes, []).\nplawk_pbt_nums(Sum, S0, S) :- plawk_pbt_num(N, S0, S1), plawk_pbt_rest(N, Sum, S1, S).\nplawk_pbt_rest(Acc, Sum, [0', | S0], S) :- plawk_pbt_num(N, S0, S1), Acc2 is Acc + N, plawk_pbt_rest(Acc2, Sum, S1, S).\nplawk_pbt_rest(Sum, Sum, S, S).\nplawk_pbt_num(N) --> plawk_pbt_digit(D), plawk_pbt_digits(D, N).\nplawk_pbt_digits(Acc, N) --> plawk_pbt_digit(D), { Acc2 is Acc * 10 + D }, plawk_pbt_digits(Acc2, N).\nplawk_pbt_digits(N, N) --> [].\nplawk_pbt_digit(D) --> [C], { C >= 48, C =< 57, D is C - 48 }.\n@end-t2\nBEGIN { BINFMT = \"i64 blob32\" }\n$1 > 0 { total += plawk_pbt_sum($2) }\nEND { print total }\n",
+    run_pb_blob_smoke(Src,
+        [brec(1, "12,7"), brec(2, "100"), brec(-5, "9")],
+        "119\n").
+
+:- end_tests(plawk_prolog_blocks).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,  0x3FF8000000000000).
+double_bits(2.5,  0x4004000000000000).
+double_bits(0.25, 0x3FD0000000000000).
+
+write_pb_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Rec, Recs), write_pb_record(Out, Rec)),
+        close(Out)).
+
+write_pb_record(Out, rec(I, F)) :-
+    write_i64_le(Out, I),
+    double_bits(F, Bits),
+    write_i64_le(Out, Bits).
+write_pb_record(Out, brec(I, Payload)) :-
+    write_i64_le(Out, I),
+    string_codes(Payload, Codes),
+    length(Codes, Len),
+    write_i64_le(Out, Len),
+    forall(member(C, Codes), put_byte(Out, C)).
+
+% The whole pipeline from ONE source string: lift @prolog clauses,
+% install them, compile them with the WAM target, then append the
+% driver built with the vm counts.
+build_pb_probe(Src, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_prolog_blocks', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_source(Src, Program, Clauses),
+    plawk_prolog_block_preds(Clauses, Preds),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(Preds, [module_name('plawk_prolog_blocks')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_program_native_driver_ir(Program, InputPath,
+        [wam_vm(InstrCount, LabelCount)], DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk prolog blocks build output]~n~w~n", [BuildOut]),
+       throw(plawk_prolog_blocks_build_failed(Status))
+    ).
+
+run_pb(BinPath, OutStr) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)).
+
+run_pb_smoke(Src, Recs, ExpectedOutput) :-
+    build_pb_probe(Src, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_pb_records(InputPath, Recs),
+    run_pb(BinPath, OutStr),
+    assertion(OutStr == ExpectedOutput),
+    !.
+
+run_pb_blob_smoke(Src, Recs, ExpectedOutput) :-
+    build_pb_probe(Src, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_pb_records(InputPath, Recs),
+    run_pb(BinPath, OutStr),
+    assertion(OutStr == ExpectedOutput),
+    !.


### PR DESCRIPTION
## Summary

Second slice: a plawk program carries its Prolog with it —

```awk
@prolog
weight(I, F, R) :- R is I * F.
hot(X) :- X > 100.
@end
BEGIN { BINFMT = "i64 f64" }
hot($1) { wsum += float(weight($1, $2)) }
END { print wsum }
```

Blocks hold ordinary Prolog clauses (DCG rules included) that compile into the same binary and are callable through the existing foreign bridge. One source file now carries the whole Tier-2 story: native framing above, payload grammar below.

## Design

- **Fencing:** markers sit alone on their line. The heredoc-style tagged form (`@prolog-TAG ... @end-TAG`, exact tag match — the syntax you suggested) fences Prolog text that itself contains an `@end`-shaped line; a mismatched or missing terminator fails the parse.
- **Extraction is a line-based pre-pass** before the awk grammar runs — Prolog text never routes through the DCG; the block text is term-read as ordinary Prolog.
- **API:** new `plawk_parse_source/3` returns program + clauses (`plawk_parse_string/2` delegates, so blocks are legal everywhere); new `plawk_prolog_block_preds/2` expands DCG rules (normalizing `expand_term`'s one-or-list results and dropping interleaved directives), resets-then-asserts each defined predicate (recompiles replace, never accumulate), and returns exactly the `user:Name/Arity` list `write_wam_llvm_project/3` takes.

## Tests

New `tests/test_plawk_prolog_blocks.pl` (4 tests): extraction shapes; tagged fences plus mismatch/missing-end/directive rejections; an e2e with guard + expression functions defined in-source (`375` exact); and the capstone — a self-contained blob program whose `@prolog` block defines the payload grammar with `-->` rules, compiled and run (`119` exact).

Full sweep: **all 51 suites green.**

## Honest note

Along the way I found that a grammar spelled with if-then-else and cut compiled but returned 0 at runtime, while the same grammar as plain clause alternation works. Recorded as an OPEN debt entry in the design doc — it needs a minimal WAM-target reproduction; until then embedded grammars should prefer clause alternation (as the tutorial example does).

## Merge order

1. #3448 (consolidation → main)
2. #3449 (multi-line) → designated branch
3. this PR → the #3449 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_