### PR TITLE
plawk: awk-style function definitions (sugar over the foreign bridge)

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -222,6 +222,16 @@ bridge does everything (guards, i64/f64/blob marshaling,
 `float(name(args))`). One source file now carries the whole Tier-2
 story: native framing above, the payload grammar below.
 
+awk-style expression functions are sugar over the same bridge:
+`function scale(a, b) { return a * b + 1 }` desugars at parse time to
+`scale(A, B, R) :- R is A * B + 1` (awk precedence, `%` → mod, float
+literals allowed; every identifier in the body must be a parameter)
+and installs through the identical clause path. Full imperative awk
+functions (locals, loops, early returns) are deliberately out of
+scope: between `foreach`, `if/else`, and Prolog blocks they don't earn
+their native-codegen complexity, and a hot expression function can be
+inlined natively later without changing the surface.
+
 ## Known design debt
 
 - **(OPEN) WAM lowering of if-then-else/cut in compiled DCG bodies.**

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -104,6 +104,7 @@ swipl -q -s tests/test_plawk_rep_writer.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c
 swipl -q -s tests/test_plawk_union_out.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_multiline.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_prolog_blocks.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_functions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -140,7 +141,13 @@ Markers sit alone on their line; the heredoc-style tagged form
 (`@prolog-TAG ... @end-TAG`, exact tag match) fences Prolog text that
 itself contains an `@end`-shaped line. `plawk_parse_source/3` returns
 program + clauses, and `plawk_prolog_block_preds/2` installs them for
-`write_wam_llvm_project/3`.
+`write_wam_llvm_project/3`. awk-style expression functions are sugar
+over the same bridge: `function scale(a, b) { return a * b + 1 }`
+desugars at parse time to the Prolog clause
+`scale(A, B, R) :- R is A * B + 1` (awk precedence, `%` maps to mod,
+float literals allowed) and is called like any bridged predicate --
+`scale($1, $2)` as an integer expression, `float(scale($1, $2))` to
+keep fractions.
 Arithmetic expressions support general `+`, `-`, `*`, `/`, and `%` between
 native `i64` operands with awk precedence (`* / %` bind tighter than `+ -`,
 both associate left) and parentheses, e.g.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -63,9 +63,10 @@ plawk_parse_source(Source, Program, PrologClauses) :-
     string(Source),
     plawk_split_prolog_blocks(Source, Stripped, BlockTexts),
     maplist(plawk_read_block_clauses, BlockTexts, ClausesNested),
-    append(ClausesNested, PrologClauses),
+    append(ClausesNested, BlockClauses),
     string_codes(Stripped, Codes),
-    phrase(plawk_program(Program), Codes).
+    phrase(plawk_program(Program, FunctionClauses), Codes),
+    append(BlockClauses, FunctionClauses, PrologClauses).
 
 plawk_split_prolog_blocks(Source, Stripped, BlockTexts) :-
     split_string(Source, "\n", "", Lines),
@@ -117,12 +118,140 @@ plawk_read_stream_clauses(Stream, Clauses) :-
         plawk_read_stream_clauses(Stream, Rest)
     ).
 
-plawk_program(program(BeginClauses, Rules, EndClauses)) -->
+plawk_program(Program) -->
+    plawk_program(Program, _FunctionClauses).
+
+plawk_program(program(BeginClauses, Rules, EndClauses), FunctionClauses) -->
     ws,
     begin_clauses(BeginClauses),
+    function_defs(FunctionClauses),
     program_rules(Rules),
     end_clauses(EndClauses),
     eos.
+
+%% function_defs(-Clauses)//
+%
+%  awk-style expression functions, pure sugar over the foreign bridge:
+%
+%      function scale(a, b) { return a * b + 1 }
+%
+%  desugars at parse time into the Prolog clause
+%
+%      scale(A, B, R) :- R is A * B + 1.
+%
+%  and is called like any bridged predicate: `scale($1, $2)` as an
+%  integer expression, `float(scale($1, $2))` to keep fractions. The
+%  body is one `return` of an arithmetic expression over the
+%  parameters (awk precedence; % maps to Prolog mod); an identifier
+%  that is not a parameter fails the parse.
+function_defs([Clause | Clauses]) -->
+    function_def(Clause),
+    !,
+    function_defs(Clauses).
+function_defs([]) -->
+    [].
+
+function_def((Head :- Body)) -->
+    "function",
+    identifier_boundary,
+    ws,
+    identifier(Name),
+    ws,
+    "(",
+    ws,
+    function_params(Params),
+    ws,
+    ")",
+    ws,
+    "{",
+    ws,
+    "return",
+    identifier_boundary,
+    ws,
+    function_expr(Params, Pairs, ArithTerm),
+    action_block_close,
+    { pairs_values(Pairs, Vars),
+      append(Vars, [Result], HeadArgs),
+      Head =.. [Name | HeadArgs],
+      Body = (Result is ArithTerm)
+    }.
+
+function_params([Param | Params]) -->
+    identifier(Param),
+    function_params_rest(Params).
+
+function_params_rest([Param | Params]) -->
+    ws,
+    ",",
+    ws,
+    !,
+    identifier(Param),
+    function_params_rest(Params).
+function_params_rest([]) -->
+    [].
+
+% arithmetic over the parameters, with awk precedence: * / % bind
+% tighter than + -, both associate left, parentheses group
+function_expr(Params, Pairs, Term) -->
+    { pairs_keys(Pairs, Params) },
+    function_additive(Pairs, Term).
+
+function_additive(Pairs, Term) -->
+    function_multiplicative(Pairs, First),
+    function_additive_chain(Pairs, First, Term).
+
+function_additive_chain(Pairs, Acc, Term) -->
+    ws,
+    function_add_op(Op),
+    ws,
+    !,
+    function_multiplicative(Pairs, Right),
+    { Acc1 =.. [Op, Acc, Right] },
+    function_additive_chain(Pairs, Acc1, Term).
+function_additive_chain(_Pairs, Term, Term) -->
+    [].
+
+function_add_op(+) --> "+".
+function_add_op(-) --> "-".
+
+function_multiplicative(Pairs, Term) -->
+    function_factor(Pairs, First),
+    function_multiplicative_chain(Pairs, First, Term).
+
+function_multiplicative_chain(Pairs, Acc, Term) -->
+    ws,
+    function_mul_op(Op),
+    ws,
+    !,
+    function_factor(Pairs, Right),
+    { Acc1 =.. [Op, Acc, Right] },
+    function_multiplicative_chain(Pairs, Acc1, Term).
+function_multiplicative_chain(_Pairs, Term, Term) -->
+    [].
+
+function_mul_op(*) --> "*".
+function_mul_op(/) --> "/".
+function_mul_op(mod) --> "%".
+
+function_factor(Pairs, Term) -->
+    "(",
+    ws,
+    !,
+    function_additive(Pairs, Term),
+    ws,
+    ")".
+function_factor(_Pairs, Value) -->
+    float_literal_expr(float_const(Mantissa, Denominator)),
+    !,
+    { Value is Mantissa / Denominator }.
+function_factor(_Pairs, Value) -->
+    integer_codes(ValueCodes),
+    { ValueCodes \== [] },
+    !,
+    { number_codes(Value, ValueCodes) }.
+function_factor(Pairs, Var) -->
+    identifier(Param),
+    { memberchk(Param-Var, Pairs) }.
 
 % Tagged-union programs route rules through per-arm case blocks: the
 % arm index scopes the field types of every rule inside the block.

--- a/tests/test_plawk_functions.pl
+++ b/tests/test_plawk_functions.pl
@@ -1,0 +1,109 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_functions, [condition(clang_available)]).
+
+test(functions_desugar_to_prolog_clauses) :-
+    plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction f(a, b) { return a + b * 2 }\n{ n++ }\nEND { print n }\n",
+        _, [Clause]),
+    % awk precedence: * binds tighter than +
+    assertion(Clause = (f(_A, _B, R) :- R is _ + _ * 2)),
+    Clause = (f(3, 4, Result) :- Goal),
+    call(Goal),
+    assertion(Result =:= 11).
+
+test(percent_maps_to_mod_and_parens_group) :-
+    plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction g(a, b) { return (a + b) % 7 }\n{ n++ }\nEND { print n }\n",
+        _, [(g(A, B, R) :- R is Goal)]),
+    assertion(Goal == mod(A + B, 7)),
+    ( A = 5, B = 9, V is Goal, assertion(V =:= 0) ).
+
+test(function_rejections) :-
+    % identifiers must be parameters
+    assertion(\+ plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction bad(a) { return a + q }\n{ n++ }\nEND { print n }\n", _, _)),
+    % the body is a single return expression
+    assertion(\+ plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction bad(a) { x = a }\n{ n++ }\nEND { print n }\n", _, _)).
+
+test(surface_functions_end_to_end) :-
+    % integer function in i64 context, float-constant function through
+    % float(...): s = (3*3+1) + (5*5+1) = 36, w = 1.5 + 2.5 = 4.
+    Src = "BEGIN { BINFMT = \"i64 f64\" }\nfunction plawk_fnt_scale(a, b) { return a * b + 1 }\nfunction plawk_fnt_half(x) { return x * 0.5 }\n{ s += plawk_fnt_scale($1, $1)\n  w += float(plawk_fnt_half($1)) }\nEND { print s, w }\n",
+    run_fn_smoke(Src, [rec(3, 0.25), rec(5, 0.25)], "36 4\n").
+
+test(surface_functions_mix_with_prolog_blocks) :-
+    % sugar and explicit clauses share one clause list and one bridge
+    Src = "@prolog\nplawk_fnt_hot(X) :- X > 10.\n@end\nBEGIN { BINFMT = \"i64 f64\" }\nfunction plawk_fnt_twice(a) { return a * 2 }\nplawk_fnt_hot($1) { s += plawk_fnt_twice($1) }\nEND { print s }\n",
+    run_fn_smoke(Src, [rec(3, 0.25), rec(20, 0.25), rec(11, 0.25)], "62\n").
+
+:- end_tests(plawk_functions).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+double_bits(0.25, 0x3FD0000000000000).
+
+write_fn_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(I, F), Recs),
+            ( write_i64_le(Out, I),
+              double_bits(F, Bits),
+              write_i64_le(Out, Bits) )),
+        close(Out)).
+
+run_fn_smoke(Src, Recs, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_functions', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_source(Src, Program, Clauses),
+    plawk_prolog_block_preds(Clauses, Preds),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(Preds, [module_name('plawk_functions')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_program_native_driver_ir(Program, InputPath,
+        [wam_vm(InstrCount, LabelCount)], DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(BuildS)), stderr(std), process(BuildPid)]),
+    read_string(BuildS, _, BuildOut),
+    close(BuildS),
+    process_wait(BuildPid, BuildStatus),
+    ( BuildStatus == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk functions build output]~n~w~n", [BuildOut]),
+       throw(plawk_functions_build_failed(BuildStatus))
+    ),
+    write_fn_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.


### PR DESCRIPTION
## Summary

Final slice of the round: awk-style function definitions —

```awk
function scale(a, b) { return a * b + 1 }
{ s += scale($1, $1) }
```

desugars **at parse time** to the Prolog clause `scale(A, B, R) :- R is A * B + 1` and is called like any bridged predicate: `scale($1, $2)` as an integer expression, `float(scale($1, $2))` to keep fractions. No new call mechanism exists — the sugar rides the identical clause path as `@prolog` blocks (`plawk_parse_source/3` returns block clauses and function clauses in one list).

## Design

- **Surface:** `function name(params) { return expr }` between BEGIN and the rules. The body is one `return` of an arithmetic expression over the parameters with awk precedence (`* / %` bind tighter than `+ -`, parentheses group, `%` maps to `mod`, integer and float literals allowed). An identifier that is not a parameter fails the parse, as does anything but a single return.
- **Scope, deliberately:** full imperative awk functions (locals, loops, early returns) are out — between `foreach`, `if/else`, and `@prolog` blocks they don't earn their native-codegen complexity, and a hot expression function can be inlined natively later without touching the surface. Rationale recorded in the design doc.

## Tests

New `tests/test_plawk_functions.pl` (5 tests): desugar shape + precedence (the desugared clause computes `f(3,4) = 11`); `%` → `mod` with parens; rejections (unknown identifier, non-return body); an e2e mixing an integer function and a float-constant function (`36 4` exact — also proving float literals work in compiled WAM arithmetic); and a mixed program where a `function` and an `@prolog` guard share one bridge (`62` exact).

Full sweep: **all 52 suites green.**

## Merge order (whole round, bottom-up)

1. #3448 (consolidation → main)
2. #3449 (multi-line) → designated branch
3. #3450 (@prolog blocks) → the #3449 branch
4. this PR → the #3450 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_