### PR TITLE
plawk: bring round 6 (#3449 multi-line, #3450 @prolog blocks, #3451 function sugar) to main

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -222,6 +222,16 @@ bridge does everything (guards, i64/f64/blob marshaling,
 `float(name(args))`). One source file now carries the whole Tier-2
 story: native framing above, the payload grammar below.
 
+awk-style expression functions are sugar over the same bridge:
+`function scale(a, b) { return a * b + 1 }` desugars at parse time to
+`scale(A, B, R) :- R is A * B + 1` (awk precedence, `%` → mod, float
+literals allowed; every identifier in the body must be a parameter)
+and installs through the identical clause path. Full imperative awk
+functions (locals, loops, early returns) are deliberately out of
+scope: between `foreach`, `if/else`, and Prolog blocks they don't earn
+their native-codegen complexity, and a hot expression function can be
+inlined natively later without changing the surface.
+
 ## Known design debt
 
 - **(OPEN) WAM lowering of if-then-else/cut in compiled DCG bodies.**

--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -207,8 +207,29 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    call (one shared buffer), NUL-free payloads (the transient atom is
    a C string), blob output is a later slice.
 
+## Embedded Prolog blocks (landed)
+
+`@prolog ... @end` blocks in the plawk source hold ordinary Prolog
+clauses (including DCG rules, which expand on the way in). Markers sit
+alone on their line; a heredoc-style tag (`@prolog-TAG ... @end-TAG`,
+exact tag match) makes the fence unambiguous when the Prolog text
+itself contains an `@end`-shaped line. `plawk_parse_source/3` lifts
+the blocks before the awk grammar runs and term-reads them;
+`plawk_prolog_block_preds/2` installs the clauses (reset-then-assert,
+so recompiles replace) and returns the `user:Name/Arity` list that
+`write_wam_llvm_project/3` takes — from there the existing foreign
+bridge does everything (guards, i64/f64/blob marshaling,
+`float(name(args))`). One source file now carries the whole Tier-2
+story: native framing above, the payload grammar below.
+
 ## Known design debt
 
+- **(OPEN) WAM lowering of if-then-else/cut in compiled DCG bodies.**
+  An embedded grammar written with `( "," -> ... ; ... )` and a cut in
+  the digits rule compiled but returned 0 at runtime; the same grammar
+  respelled as plain clause alternation (greedy clause before stop
+  clause, tier2 style) works. Needs a minimal WAM-target reproduction;
+  until then, prefer clause alternation in embedded grammars.
 - **(FIXED) WAM bug: constant-in-list clause heads never matched.**
   `unify_constant` built its read-mode comparison value with a
   hardcoded Atom tag (op2 was unused), so an integer constant in a

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -103,6 +103,7 @@ swipl -q -s tests/test_plawk_union_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/
 swipl -q -s tests/test_plawk_rep_writer.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_out.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_multiline.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_prolog_blocks.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -120,7 +121,26 @@ Explicit numeric field coercion is available as `int($N)`, e.g.
 Programs are multi-line awk: `#` comments run to end of line,
 statements separate on newlines as well as `;` (with awk/C semantics
 after a compound statement's closing brace -- no separator needed),
-and trailing separators before `}` are harmless.
+and trailing separators before `}` are harmless. A program can carry
+its Prolog with it: `@prolog ... @end` blocks hold ordinary clauses
+(DCG rules included) that compile into the same binary and are
+callable through the foreign bridge --
+
+```awk
+@prolog
+weight(I, F, R) :- R is I * F.
+hot(X) :- X > 100.
+@end
+BEGIN { BINFMT = "i64 f64" }
+hot($1) { wsum += float(weight($1, $2)) }
+END { print wsum }
+```
+
+Markers sit alone on their line; the heredoc-style tagged form
+(`@prolog-TAG ... @end-TAG`, exact tag match) fences Prolog text that
+itself contains an `@end`-shaped line. `plawk_parse_source/3` returns
+program + clauses, and `plawk_prolog_block_preds/2` installs them for
+`write_wam_llvm_project/3`.
 Arithmetic expressions support general `+`, `-`, `*`, `/`, and `%` between
 native `i64` operands with awk precedence (`* / %` bind tighter than `+ -`,
 both associate left) and parentheses, e.g.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -102,6 +102,7 @@ swipl -q -s tests/test_plawk_union_writebin.pl -g "setenv('UW_SMOKE_TMPDIR', '/m
 swipl -q -s tests/test_plawk_union_assoc.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_rep_writer.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_union_out.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_multiline.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -116,6 +117,10 @@ as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
 case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0) }`.
 Explicit numeric field coercion is available as `int($N)`, e.g.
 `$1 == "ERROR" { print $3, int($3) }`; failed numeric parses print `0`.
+Programs are multi-line awk: `#` comments run to end of line,
+statements separate on newlines as well as `;` (with awk/C semantics
+after a compound statement's closing brace -- no separator needed),
+and trailing separators before `}` are harmless.
 Arithmetic expressions support general `+`, `-`, `*`, `/`, and `%` between
 native `i64` operands with awk precedence (`* / %` bind tighter than `+ -`,
 both associate left) and parentheses, e.g.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -104,6 +104,7 @@ swipl -q -s tests/test_plawk_rep_writer.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c
 swipl -q -s tests/test_plawk_union_out.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_multiline.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_prolog_blocks.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_functions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
@@ -140,7 +141,13 @@ Markers sit alone on their line; the heredoc-style tagged form
 (`@prolog-TAG ... @end-TAG`, exact tag match) fences Prolog text that
 itself contains an `@end`-shaped line. `plawk_parse_source/3` returns
 program + clauses, and `plawk_prolog_block_preds/2` installs them for
-`write_wam_llvm_project/3`.
+`write_wam_llvm_project/3`. awk-style expression functions are sugar
+over the same bridge: `function scale(a, b) { return a * b + 1 }`
+desugars at parse time to the Prolog clause
+`scale(A, B, R) :- R is A * B + 1` (awk precedence, `%` maps to mod,
+float literals allowed) and is called like any bridged predicate --
+`scale($1, $2)` as an integer expression, `float(scale($1, $2))` to
+keep fractions.
 Arithmetic expressions support general `+`, `-`, `*`, `/`, and `%` between
 native `i64` operands with awk precedence (`* / %` bind tighter than `+ -`,
 both associate left) and parentheses, e.g.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5,10 +5,60 @@
     plawk_program_native_driver_ir/3,
     plawk_program_native_driver_ir/4,
     plawk_program_foreign_specs/3,
-    plawk_program_foreign_specs/4
+    plawk_program_foreign_specs/4,
+    plawk_prolog_block_preds/2
 ]).
 
 :- discontiguous plawk_pattern_guard_ir/5.
+
+%% plawk_prolog_block_preds(+Clauses, -Preds)
+%
+%  Install the embedded @prolog clauses a plawk_parse_source/3 parse
+%  returned, so write_wam_llvm_project/3 can compile them into the
+%  same binary as the driver. DCG rules expand; each defined predicate
+%  is reset (retractall) before its clauses assert, so recompiling a
+%  program replaces rather than accumulates definitions. Preds is the
+%  deduplicated user:Name/Arity list in first-definition order --
+%  exactly the predicate list write_wam_llvm_project/3 takes.
+%  Directives are not clauses and reject the program.
+plawk_prolog_block_preds(Clauses0, Preds) :-
+    \+ member((:- _Directive), Clauses0),
+    maplist(plawk_expand_block_clause, Clauses0, ClausesNested),
+    append(ClausesNested, Clauses),
+    findall(Name/Arity,
+        ( member(Clause, Clauses),
+          plawk_block_clause_head(Clause, Head),
+          functor(Head, Name, Arity)
+        ),
+        PIs0),
+    plawk_dedupe_keep_order(PIs0, PIs),
+    forall(member(Name/Arity, PIs),
+        ( functor(Head, Name, Arity),
+          retractall(user:Head)
+        )),
+    forall(member(Clause, Clauses), assertz(user:Clause)),
+    findall(user:PI, member(PI, PIs), Preds).
+
+% expand_term/2 may return one clause or a list, and DCG expansion can
+% interleave compile-time directives (e.g. discontiguous hints) with
+% the clauses -- keep only the clauses.
+plawk_expand_block_clause(Clause0, Clauses) :-
+    expand_term(Clause0, Expanded),
+    ( is_list(Expanded)
+    ->  Expanded1 = Expanded
+    ;   Expanded1 = [Expanded]
+    ),
+    exclude(plawk_block_directive, Expanded1, Clauses).
+
+plawk_block_directive((:- _Goal)).
+
+plawk_block_clause_head((Head :- _Body), Head) :- !.
+plawk_block_clause_head(Head, Head).
+
+plawk_dedupe_keep_order([], []).
+plawk_dedupe_keep_order([PI | Rest0], [PI | Deduped]) :-
+    exclude(==(PI), Rest0, Rest),
+    plawk_dedupe_keep_order(Rest, Deduped).
 
 :- use_module('../../../src/unifyweaver/targets/wam_llvm_target',
     [llvm_emit_atom_prefix_guard/5,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -109,6 +109,15 @@ action_block(Actions) -->
     "{",
     ws,
     actions(Actions),
+    action_block_close.
+
+% a trailing `;` or newline before the closing brace is harmless
+action_block_close -->
+    action_sep,
+    !,
+    "}",
+    ws.
+action_block_close -->
     ws,
     "}",
     ws.
@@ -537,16 +546,54 @@ for_in_body([PrintAction]) -->
 
 actions([Action | Actions]) -->
     action(Action),
-    actions_rest(Actions).
+    actions_rest(Action, Actions).
 
-actions_rest([Action | Actions]) -->
-    ws,
-    ";",
-    ws,
-    !,
+actions_rest(_Prev, [Action | Actions]) -->
+    action_sep,
     action(Action),
-    actions_rest(Actions).
-actions_rest([]) -->
+    !,
+    actions_rest(Action, Actions).
+% as in awk/C, no separator is needed after a compound statement's
+% closing brace (whose trailing ws has already been consumed)
+actions_rest(Prev, [Action | Actions]) -->
+    { plawk_block_action(Prev) },
+    action(Action),
+    !,
+    actions_rest(Action, Actions).
+actions_rest(_Prev, []) -->
+    [].
+
+plawk_block_action(if(_Pattern, _Then, _Else)).
+plawk_block_action(foreach(_Body)).
+
+%% action_sep//0
+%
+%  One statement separator, as in awk: any run of blanks, comments,
+%  semicolons, and newlines containing at least one `;` or newline.
+%  (A trailing separator before `}` is harmless: the following
+%  action// fails and actions_rest backtracks to its empty clause.)
+action_sep -->
+    action_sep_scan(no).
+
+action_sep_scan(_Seen) -->
+    ";",
+    !,
+    action_sep_scan(yes).
+action_sep_scan(_Seen) -->
+    "\n",
+    !,
+    action_sep_scan(yes).
+action_sep_scan(Seen) -->
+    [Code],
+    { Code =\= 0'\n, code_type(Code, space) },
+    !,
+    action_sep_scan(Seen).
+action_sep_scan(Seen) -->
+    "#",
+    !,
+    comment_rest,
+    action_sep_scan(Seen).
+action_sep_scan(yes) -->
     [].
 
 action(Action) -->
@@ -1161,12 +1208,30 @@ required_ws -->
     { code_type(Code, space) },
     ws.
 
+% Whitespace, including newlines and awk-style # comments (a comment
+% runs to end of line; its terminating newline still counts as a
+% statement separator in action_sep//0). `#` is not a token anywhere
+% in the surface, and strings/regex bodies never route through ws//0,
+% so comments cannot be consumed inside literals.
 ws -->
     [Code],
     { code_type(Code, space) },
     !,
     ws.
 ws -->
+    "#",
+    !,
+    comment_rest,
+    ws.
+ws -->
+    [].
+
+comment_rest -->
+    [Code],
+    { Code =\= 0'\n },
+    !,
+    comment_rest.
+comment_rest -->
     [].
 
 eos([], []).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -63,9 +63,10 @@ plawk_parse_source(Source, Program, PrologClauses) :-
     string(Source),
     plawk_split_prolog_blocks(Source, Stripped, BlockTexts),
     maplist(plawk_read_block_clauses, BlockTexts, ClausesNested),
-    append(ClausesNested, PrologClauses),
+    append(ClausesNested, BlockClauses),
     string_codes(Stripped, Codes),
-    phrase(plawk_program(Program), Codes).
+    phrase(plawk_program(Program, FunctionClauses), Codes),
+    append(BlockClauses, FunctionClauses, PrologClauses).
 
 plawk_split_prolog_blocks(Source, Stripped, BlockTexts) :-
     split_string(Source, "\n", "", Lines),
@@ -117,12 +118,140 @@ plawk_read_stream_clauses(Stream, Clauses) :-
         plawk_read_stream_clauses(Stream, Rest)
     ).
 
-plawk_program(program(BeginClauses, Rules, EndClauses)) -->
+plawk_program(Program) -->
+    plawk_program(Program, _FunctionClauses).
+
+plawk_program(program(BeginClauses, Rules, EndClauses), FunctionClauses) -->
     ws,
     begin_clauses(BeginClauses),
+    function_defs(FunctionClauses),
     program_rules(Rules),
     end_clauses(EndClauses),
     eos.
+
+%% function_defs(-Clauses)//
+%
+%  awk-style expression functions, pure sugar over the foreign bridge:
+%
+%      function scale(a, b) { return a * b + 1 }
+%
+%  desugars at parse time into the Prolog clause
+%
+%      scale(A, B, R) :- R is A * B + 1.
+%
+%  and is called like any bridged predicate: `scale($1, $2)` as an
+%  integer expression, `float(scale($1, $2))` to keep fractions. The
+%  body is one `return` of an arithmetic expression over the
+%  parameters (awk precedence; % maps to Prolog mod); an identifier
+%  that is not a parameter fails the parse.
+function_defs([Clause | Clauses]) -->
+    function_def(Clause),
+    !,
+    function_defs(Clauses).
+function_defs([]) -->
+    [].
+
+function_def((Head :- Body)) -->
+    "function",
+    identifier_boundary,
+    ws,
+    identifier(Name),
+    ws,
+    "(",
+    ws,
+    function_params(Params),
+    ws,
+    ")",
+    ws,
+    "{",
+    ws,
+    "return",
+    identifier_boundary,
+    ws,
+    function_expr(Params, Pairs, ArithTerm),
+    action_block_close,
+    { pairs_values(Pairs, Vars),
+      append(Vars, [Result], HeadArgs),
+      Head =.. [Name | HeadArgs],
+      Body = (Result is ArithTerm)
+    }.
+
+function_params([Param | Params]) -->
+    identifier(Param),
+    function_params_rest(Params).
+
+function_params_rest([Param | Params]) -->
+    ws,
+    ",",
+    ws,
+    !,
+    identifier(Param),
+    function_params_rest(Params).
+function_params_rest([]) -->
+    [].
+
+% arithmetic over the parameters, with awk precedence: * / % bind
+% tighter than + -, both associate left, parentheses group
+function_expr(Params, Pairs, Term) -->
+    { pairs_keys(Pairs, Params) },
+    function_additive(Pairs, Term).
+
+function_additive(Pairs, Term) -->
+    function_multiplicative(Pairs, First),
+    function_additive_chain(Pairs, First, Term).
+
+function_additive_chain(Pairs, Acc, Term) -->
+    ws,
+    function_add_op(Op),
+    ws,
+    !,
+    function_multiplicative(Pairs, Right),
+    { Acc1 =.. [Op, Acc, Right] },
+    function_additive_chain(Pairs, Acc1, Term).
+function_additive_chain(_Pairs, Term, Term) -->
+    [].
+
+function_add_op(+) --> "+".
+function_add_op(-) --> "-".
+
+function_multiplicative(Pairs, Term) -->
+    function_factor(Pairs, First),
+    function_multiplicative_chain(Pairs, First, Term).
+
+function_multiplicative_chain(Pairs, Acc, Term) -->
+    ws,
+    function_mul_op(Op),
+    ws,
+    !,
+    function_factor(Pairs, Right),
+    { Acc1 =.. [Op, Acc, Right] },
+    function_multiplicative_chain(Pairs, Acc1, Term).
+function_multiplicative_chain(_Pairs, Term, Term) -->
+    [].
+
+function_mul_op(*) --> "*".
+function_mul_op(/) --> "/".
+function_mul_op(mod) --> "%".
+
+function_factor(Pairs, Term) -->
+    "(",
+    ws,
+    !,
+    function_additive(Pairs, Term),
+    ws,
+    ")".
+function_factor(_Pairs, Value) -->
+    float_literal_expr(float_const(Mantissa, Denominator)),
+    !,
+    { Value is Mantissa / Denominator }.
+function_factor(_Pairs, Value) -->
+    integer_codes(ValueCodes),
+    { ValueCodes \== [] },
+    !,
+    { number_codes(Value, ValueCodes) }.
+function_factor(Pairs, Var) -->
+    identifier(Param),
+    { memberchk(Param-Var, Pairs) }.
 
 % Tagged-union programs route rules through per-arm case blocks: the
 % arm index scopes the field types of every rule inside the block.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2,7 +2,8 @@
 % Copyright (c) 2026 John William Creighton (s243a)
 
 :- module(plawk_parser, [
-    plawk_parse_string/2
+    plawk_parse_string/2,
+    plawk_parse_source/3
 ]).
 
 %% plawk_parse_string(+Source, -Program) is semidet.
@@ -40,9 +41,81 @@
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
 plawk_parse_string(Source, Program) :-
+    plawk_parse_source(Source, Program, _PrologClauses).
+
+%% plawk_parse_source(+Source, -Program, -PrologClauses) is semidet.
+%
+%  Like plawk_parse_string/2, but also lifts embedded Prolog blocks:
+%
+%      @prolog
+%      weight(I, F, R) :- R is I * F.
+%      @end
+%
+%  Block markers sit alone on their line (leading/trailing blanks ok).
+%  A heredoc-style tag makes the fence unambiguous when the Prolog
+%  text itself contains an @end-shaped line: `@prolog-TAG` closes only
+%  at `@end-TAG` with the exact same tag. Blocks may appear anywhere
+%  between top-level program parts; their text never routes through
+%  the awk grammar -- it is term-read as ordinary Prolog and returned
+%  as PrologClauses for the compile driver to hand to
+%  write_wam_llvm_project alongside the program.
+plawk_parse_source(Source, Program, PrologClauses) :-
     string(Source),
-    string_codes(Source, Codes),
+    plawk_split_prolog_blocks(Source, Stripped, BlockTexts),
+    maplist(plawk_read_block_clauses, BlockTexts, ClausesNested),
+    append(ClausesNested, PrologClauses),
+    string_codes(Stripped, Codes),
     phrase(plawk_program(Program), Codes).
+
+plawk_split_prolog_blocks(Source, Stripped, BlockTexts) :-
+    split_string(Source, "\n", "", Lines),
+    plawk_split_block_lines(Lines, KeptLines, BlockTexts),
+    atomic_list_concat(KeptLines, '\n', StrippedAtom),
+    atom_string(StrippedAtom, Stripped).
+
+plawk_split_block_lines([], [], []).
+plawk_split_block_lines([Line | Lines], KeptLines, [BlockText | BlockTexts]) :-
+    plawk_prolog_open_marker(Line, EndMarker),
+    !,
+    plawk_take_block_lines(Lines, EndMarker, BlockLines, Rest),
+    atomic_list_concat(BlockLines, '\n', BlockAtom),
+    atom_string(BlockAtom, BlockText),
+    plawk_split_block_lines(Rest, KeptLines, BlockTexts).
+plawk_split_block_lines([Line | Lines], [Line | KeptLines], BlockTexts) :-
+    plawk_split_block_lines(Lines, KeptLines, BlockTexts).
+
+plawk_prolog_open_marker(Line, EndMarker) :-
+    split_string(Line, "", " \t", [Trimmed]),
+    ( Trimmed == "@prolog"
+    ->  EndMarker = "@end"
+    ;   string_concat("@prolog-", Tag, Trimmed),
+        Tag \== "",
+        string_concat("@end-", Tag, EndMarker)
+    ).
+
+% an unterminated block fails the parse (no clause for [])
+plawk_take_block_lines([Line | Lines], EndMarker, BlockLines, Rest) :-
+    split_string(Line, "", " \t", [Trimmed]),
+    ( Trimmed == EndMarker
+    ->  BlockLines = [],
+        Rest = Lines
+    ;   BlockLines = [Line | BlockLines1],
+        plawk_take_block_lines(Lines, EndMarker, BlockLines1, Rest)
+    ).
+
+plawk_read_block_clauses(BlockText, Clauses) :-
+    setup_call_cleanup(
+        open_string(BlockText, Stream),
+        plawk_read_stream_clauses(Stream, Clauses),
+        close(Stream)).
+
+plawk_read_stream_clauses(Stream, Clauses) :-
+    read_term(Stream, Term, []),
+    ( Term == end_of_file
+    ->  Clauses = []
+    ;   Clauses = [Term | Rest],
+        plawk_read_stream_clauses(Stream, Rest)
+    ).
 
 plawk_program(program(BeginClauses, Rules, EndClauses)) -->
     ws,

--- a/tests/test_plawk_functions.pl
+++ b/tests/test_plawk_functions.pl
@@ -1,0 +1,109 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_functions, [condition(clang_available)]).
+
+test(functions_desugar_to_prolog_clauses) :-
+    plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction f(a, b) { return a + b * 2 }\n{ n++ }\nEND { print n }\n",
+        _, [Clause]),
+    % awk precedence: * binds tighter than +
+    assertion(Clause = (f(_A, _B, R) :- R is _ + _ * 2)),
+    Clause = (f(3, 4, Result) :- Goal),
+    call(Goal),
+    assertion(Result =:= 11).
+
+test(percent_maps_to_mod_and_parens_group) :-
+    plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction g(a, b) { return (a + b) % 7 }\n{ n++ }\nEND { print n }\n",
+        _, [(g(A, B, R) :- R is Goal)]),
+    assertion(Goal == mod(A + B, 7)),
+    ( A = 5, B = 9, V is Goal, assertion(V =:= 0) ).
+
+test(function_rejections) :-
+    % identifiers must be parameters
+    assertion(\+ plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction bad(a) { return a + q }\n{ n++ }\nEND { print n }\n", _, _)),
+    % the body is a single return expression
+    assertion(\+ plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction bad(a) { x = a }\n{ n++ }\nEND { print n }\n", _, _)).
+
+test(surface_functions_end_to_end) :-
+    % integer function in i64 context, float-constant function through
+    % float(...): s = (3*3+1) + (5*5+1) = 36, w = 1.5 + 2.5 = 4.
+    Src = "BEGIN { BINFMT = \"i64 f64\" }\nfunction plawk_fnt_scale(a, b) { return a * b + 1 }\nfunction plawk_fnt_half(x) { return x * 0.5 }\n{ s += plawk_fnt_scale($1, $1)\n  w += float(plawk_fnt_half($1)) }\nEND { print s, w }\n",
+    run_fn_smoke(Src, [rec(3, 0.25), rec(5, 0.25)], "36 4\n").
+
+test(surface_functions_mix_with_prolog_blocks) :-
+    % sugar and explicit clauses share one clause list and one bridge
+    Src = "@prolog\nplawk_fnt_hot(X) :- X > 10.\n@end\nBEGIN { BINFMT = \"i64 f64\" }\nfunction plawk_fnt_twice(a) { return a * 2 }\nplawk_fnt_hot($1) { s += plawk_fnt_twice($1) }\nEND { print s }\n",
+    run_fn_smoke(Src, [rec(3, 0.25), rec(20, 0.25), rec(11, 0.25)], "62\n").
+
+:- end_tests(plawk_functions).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+double_bits(0.25, 0x3FD0000000000000).
+
+write_fn_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(I, F), Recs),
+            ( write_i64_le(Out, I),
+              double_bits(F, Bits),
+              write_i64_le(Out, Bits) )),
+        close(Out)).
+
+run_fn_smoke(Src, Recs, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_functions', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_source(Src, Program, Clauses),
+    plawk_prolog_block_preds(Clauses, Preds),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(Preds, [module_name('plawk_functions')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_program_native_driver_ir(Program, InputPath,
+        [wam_vm(InstrCount, LabelCount)], DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(BuildS)), stderr(std), process(BuildPid)]),
+    read_string(BuildS, _, BuildOut),
+    close(BuildS),
+    process_wait(BuildPid, BuildStatus),
+    ( BuildStatus == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk functions build output]~n~w~n", [BuildOut]),
+       throw(plawk_functions_build_failed(BuildStatus))
+    ),
+    write_fn_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.

--- a/tests/test_plawk_multiline.pl
+++ b/tests/test_plawk_multiline.pl
@@ -1,0 +1,119 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_ml_marker/0.
+
+user:plawk_ml_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_multiline, [condition(clang_available)]).
+
+test(newlines_separate_statements) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" }\n{ a++\n  b++; c++\n}\nEND { print a, b, c }\n", Program),
+    Program = program(_, [rule(always, Actions)], _),
+    assertion(Actions == [inc(var(a)), inc(var(b)), inc(var(c))]).
+
+test(comments_run_to_end_of_line) :-
+    plawk_parse_string("# leading comment\nBEGIN { BINFMT = \"i64 f64\" }   # layout\n{ a++   # bump\n  b++ }\nEND { print a, b }   # report\n", Program),
+    Program = program(_, [rule(always, Actions)], _),
+    assertion(Actions == [inc(var(a)), inc(var(b))]),
+    % '#' inside a string literal is not a comment
+    plawk_parse_string("$1 == \"#x\" { n++ } END { print n }\n", P2),
+    P2 = program(_, [rule(field_eq(1, "#x"), _)], _).
+
+test(no_separator_needed_after_a_block) :-
+    % awk/C semantics: a compound statement's closing brace ends the
+    % statement, on the same line or not.
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } { if ($1 > 10) { h++ } w++ } END { print h, w }\n", P1),
+    P1 = program(_, [rule(always, [if(_, _, _), inc(var(w))])], _),
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } { if ($1 > 10) { h++ }\n  w++ } END { print h, w }\n", P2),
+    P2 = program(_, [rule(always, [if(_, _, _), inc(var(w))])], _).
+
+test(trailing_separators_are_harmless) :-
+    plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } { a++;\n } END { print a }\n", Program),
+    Program = program(_, [rule(always, [inc(var(a))])], _).
+
+test(adjacent_statements_still_need_a_separator) :-
+    assertion(\+ plawk_parse_string("BEGIN { BINFMT = \"i64 f64\" } { a++ b++ } END { print a }\n", _)).
+
+test(surface_multiline_program_end_to_end) :-
+    % A real multi-line program: comments, newline separators, a
+    % same-line statement after an if block, multi-line BEGIN.
+    Src = "# count big and small records\nBEGIN {\n  BINFMT = \"i64 f64\"   # binary layout\n}\n$1 > 100 {\n  big++\n  if ($1 > 1000) { huge++ }\n  wsum += float($2)   # weight\n}\n{ total++ }\nEND { print big, huge, total, wsum }\n",
+    run_ml_smoke(Src,
+        [rec(200, 1.5), rec(5, 2.5), rec(2000, 0.25)],
+        "2 1 3 1.75\n").
+
+:- end_tests(plawk_multiline).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,  0x3FF8000000000000).
+double_bits(2.5,  0x4004000000000000).
+double_bits(0.25, 0x3FD0000000000000).
+
+write_ml_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(I, F), Recs),
+            ( write_i64_le(Out, I),
+              double_bits(F, Bits),
+              write_i64_le(Out, Bits) )),
+        close(Out)).
+
+run_ml_smoke(Source, Recs, ExpectedOutput) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_multiline', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_string(Source, Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_ml_marker/0 ],
+        [module_name('plawk_multiline')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(BuildS)), stderr(std), process(BuildPid)]),
+    read_string(BuildS, _, BuildOut),
+    close(BuildS),
+    process_wait(BuildPid, BuildStatus),
+    ( BuildStatus == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk multiline build output]~n~w~n", [BuildOut]),
+       throw(plawk_multiline_build_failed(BuildStatus))
+    ),
+    write_ml_records(InputPath, Recs),
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)),
+    assertion(OutStr == ExpectedOutput),
+    !.

--- a/tests/test_plawk_prolog_blocks.pl
+++ b/tests/test_plawk_prolog_blocks.pl
@@ -1,0 +1,145 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_prolog_blocks, [condition(clang_available)]).
+
+test(blocks_lift_out_of_the_awk_surface) :-
+    Src = "@prolog\nplawk_pbt_w(I, F, R) :- R is I * F.\n@end\nBEGIN { BINFMT = \"i64 f64\" }\n{ wsum += float(plawk_pbt_w($1, $2)) }\nEND { print wsum }\n",
+    plawk_parse_source(Src, Program, Clauses),
+    assertion(Clauses = [(plawk_pbt_w(_, _, _) :- _)]),
+    Program = program(_, [rule(always, _)], _),
+    % the same source parses through the 2-arity entry too
+    plawk_parse_string(Src, _).
+
+test(tagged_markers_and_rejections) :-
+    % heredoc-style tags close only on the exact same tag
+    plawk_parse_source("@prolog-x9\nplawk_pbt_t(1).\n@end-x9\nBEGIN { BINFMT = \"i64\" } { n++ } END { print n }\n",
+        _, [plawk_pbt_t(1)]),
+    % a mismatched tag leaves the block unterminated
+    assertion(\+ plawk_parse_source("@prolog-a\nfoo(1).\n@end-b\nBEGIN { BINFMT = \"i64\" } { n++ } END { print n }\n", _, _)),
+    % ... as does a missing @end
+    assertion(\+ plawk_parse_source("@prolog\nfoo(1).\nBEGIN { BINFMT = \"i64\" } { n++ } END { print n }\n", _, _)),
+    % directives are not clauses
+    plawk_parse_source("@prolog\n:- dynamic foo/1.\nfoo(1).\n@end\nBEGIN { BINFMT = \"i64\" } { n++ } END { print n }\n",
+        _, DirClauses),
+    assertion(\+ plawk_prolog_block_preds(DirClauses, _)).
+
+test(surface_embedded_predicates_end_to_end) :-
+    % Guard and expression functions defined in the program text.
+    Src = "# weights, with the logic in Prolog\n@prolog\nplawk_pbt_weight(I, F, R) :- R is I * F.\nplawk_pbt_hot(X) :- X > 100.\n@end\n\nBEGIN { BINFMT = \"i64 f64\" }\nplawk_pbt_hot($1) {\n  wsum += float(plawk_pbt_weight($1, $2))\n}\nEND { print wsum }\n",
+    run_pb_smoke(Src,
+        [rec(200, 1.5), rec(5, 2.5), rec(300, 0.25)],
+        "375\n").
+
+test(surface_embedded_dcg_parses_blob_payloads) :-
+    % The Tier-2 story in ONE file: the record loop frames natively,
+    % and a DCG defined in the @prolog block parses each payload.
+    % backtracking-based grammar (greedy digit clause before the stop
+    % clause, a constant-in-list head), with the leaf rules in -->
+    % form to exercise DCG expansion of embedded clauses
+    Src = "@prolog-t2\nplawk_pbt_sum(Payload, Sum) :- atom_codes(Payload, Codes), plawk_pbt_nums(Sum, Codes, []).\nplawk_pbt_nums(Sum, S0, S) :- plawk_pbt_num(N, S0, S1), plawk_pbt_rest(N, Sum, S1, S).\nplawk_pbt_rest(Acc, Sum, [0', | S0], S) :- plawk_pbt_num(N, S0, S1), Acc2 is Acc + N, plawk_pbt_rest(Acc2, Sum, S1, S).\nplawk_pbt_rest(Sum, Sum, S, S).\nplawk_pbt_num(N) --> plawk_pbt_digit(D), plawk_pbt_digits(D, N).\nplawk_pbt_digits(Acc, N) --> plawk_pbt_digit(D), { Acc2 is Acc * 10 + D }, plawk_pbt_digits(Acc2, N).\nplawk_pbt_digits(N, N) --> [].\nplawk_pbt_digit(D) --> [C], { C >= 48, C =< 57, D is C - 48 }.\n@end-t2\nBEGIN { BINFMT = \"i64 blob32\" }\n$1 > 0 { total += plawk_pbt_sum($2) }\nEND { print total }\n",
+    run_pb_blob_smoke(Src,
+        [brec(1, "12,7"), brec(2, "100"), brec(-5, "9")],
+        "119\n").
+
+:- end_tests(plawk_prolog_blocks).
+
+% --- helpers ---------------------------------------------------------------
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% dyadic doubles used by these tests
+double_bits(1.5,  0x3FF8000000000000).
+double_bits(2.5,  0x4004000000000000).
+double_bits(0.25, 0x3FD0000000000000).
+
+write_pb_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(Rec, Recs), write_pb_record(Out, Rec)),
+        close(Out)).
+
+write_pb_record(Out, rec(I, F)) :-
+    write_i64_le(Out, I),
+    double_bits(F, Bits),
+    write_i64_le(Out, Bits).
+write_pb_record(Out, brec(I, Payload)) :-
+    write_i64_le(Out, I),
+    string_codes(Payload, Codes),
+    length(Codes, Len),
+    write_i64_le(Out, Len),
+    forall(member(C, Codes), put_byte(Out, C)).
+
+% The whole pipeline from ONE source string: lift @prolog clauses,
+% install them, compile them with the WAM target, then append the
+% driver built with the vm counts.
+build_pb_probe(Src, Dir, BinPath) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_prolog_blocks', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    plawk_parse_source(Src, Program, Clauses),
+    plawk_prolog_block_preds(Clauses, Preds),
+    directory_file_path(Dir, 'probe.ll', LLPath),
+    write_wam_llvm_project(Preds, [module_name('plawk_prolog_blocks')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_program_native_driver_ir(Program, InputPath,
+        [wam_vm(InstrCount, LabelCount)], DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'probe_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1', [LLPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, BuildOut),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk prolog blocks build output]~n~w~n", [BuildOut]),
+       throw(plawk_prolog_blocks_build_failed(Status))
+    ).
+
+run_pb(BinPath, OutStr) :-
+    process_create(BinPath, [],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    assertion(Status == exit(0)).
+
+run_pb_smoke(Src, Recs, ExpectedOutput) :-
+    build_pb_probe(Src, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_pb_records(InputPath, Recs),
+    run_pb(BinPath, OutStr),
+    assertion(OutStr == ExpectedOutput),
+    !.
+
+run_pb_blob_smoke(Src, Recs, ExpectedOutput) :-
+    build_pb_probe(Src, Dir, BinPath),
+    directory_file_path(Dir, 'input.bin', InputPath),
+    write_pb_records(InputPath, Recs),
+    run_pb(BinPath, OutStr),
+    assertion(OutStr == ExpectedOutput),
+    !.


### PR DESCRIPTION
## Why

Round 6 merged branch-to-branch as usual: only #3449 reached this branch, while #3450 and #3451 landed on their base branches. This reassembles all three (plus a sync merge of main) and carries them the last step. No new content. **Merge first** — the WAM bug-fix PR stacks on top.

Contents: multi-line programs (# comments, newline separators), @prolog blocks, awk-style function sugar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_