### PR TITLE
wam_llvm: a requested predicate that fails to compile fails the build

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -2160,6 +2160,19 @@ pass2_emit_merged(Classified, LabelMap, NamePCPairs, Options,
                   NativeParts, WamParts) :-
     partition_classified(Classified,
         NativeRecords, WamRecords, HybridRecords, FailedRecords),
+    % A predicate that failed every compilation route used to become
+    % an IR comment inside a "successful" module -- the caller thought
+    % it compiled. Fail loudly instead (wam_allow_failed(true) keeps
+    % the old comment-and-continue behaviour).
+    (   FailedRecords == []
+    ->  true
+    ;   option(wam_allow_failed(true), Options)
+    ->  true
+    ;   findall(PI, member(failed(PI, _A), FailedRecords), FailedPIs),
+        throw(error(existence_error(procedures, FailedPIs),
+            context(wam_llvm_codegen,
+                'these predicates could not be compiled (no clauses or no supported route); check the name/arity -- a DCG rule adds 2 to the visible arity -- or pass wam_allow_failed(true) to emit the module with them omitted')))
+    ),
     % Native records' PredCode already includes both the lowered
     % function AND the @<pred> wrapper. Hybrid records contribute
     % their LoweredCode (just the @lowered_*_* fn); the matching

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -569,4 +569,29 @@ test(lookup_label_lenient_optout_defaults_to_zero, [true]) :-
         'nonexistent_label', [], [wam_strict_labels(false)], Index),
     assertion(Index == 0).
 
+:- dynamic user:uw_failedreq_ok/2.
+user:uw_failedreq_ok(X, R) :- R is X + 1.
+
+test(requested_predicate_that_fails_to_compile_throws,
+        [throws(error(existence_error(procedures, [user:uw_no_such_pred/3]), _)),
+         setup(tmp_failedreq_path(Path)), cleanup(catch(delete_file(Path), _, true))]) :-
+    % A predicate in the request list with no clauses used to become an
+    % IR comment inside a "successful" module. It is now a compile-time
+    % error (the message also flags the DCG +2-arity gotcha, which is
+    % how this trap was originally sprung).
+    tmp_failedreq_path(Path),
+    write_wam_llvm_project([user:uw_failedreq_ok/2, user:uw_no_such_pred/3],
+        [module_name(uw_failedreq)], Path).
+
+test(wam_allow_failed_keeps_comment_and_continue,
+        [setup(tmp_failedreq_path(Path)), cleanup(catch(delete_file(Path), _, true))]) :-
+    tmp_failedreq_path(Path),
+    write_wam_llvm_project([user:uw_failedreq_ok/2, user:uw_no_such_pred/3],
+        [module_name(uw_failedreq2), wam_allow_failed(true)], Path),
+    exists_file(Path).
+
+tmp_failedreq_path(Path) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_failedreq_probe.ll', Path).
+
 :- end_tests(wam_llvm_target).


### PR DESCRIPTION
## Summary

Resolves the loose thread from the `code_type` investigation — with a twist.

## The diagnosis

**The suspected "stale state across repeated compiles" does not exist.** A minimal two- and three-compile reproduction is completely clean, and the original symptom reproduces identically on a *fresh first* compile. The actual cause was a wrong-arity predicate indicator in the investigation's own repro script: `uw_c_digits/4` for a DCG rule whose visible arity is 3 (the `-->`-adds-2 gotcha). The compiler then surfaced it in the worst possible way — two stderr lines, a "compilation failed" note, a `failed/2` record turned into an **IR comment**, and a successfully written module. The run even produced correct output, because dependency discovery had separately compiled the real `/3` predicate.

## The fix

The papercut is that surfacing, and it's the same silent-trap species as the last two fixes: `pass2_emit_merged` now **throws** `existence_error(procedures, FailedPIs)` when any predicate ends up in the failed partition, naming the offenders and flagging the DCG arity gotcha explicitly in the message. `wam_allow_failed(true)` keeps the legacy comment-and-continue behaviour.

This closes the last silent path through `write_wam_llvm_project`: an uncompiled **callee** already threw at label resolution (#3453); now an uncompiled **requested predicate** throws too.

## Tests

`wam_llvm_target` suite grows 80 → 82: the throw carries the exact failed indicator list, and the opt-out still emits a module. Full sweep: **all 52 suites green** — nothing in the tree relied on comment-and-continue.

## Merge order

1. #3454 (consolidation → main) first
2. then this PR into `claude/plawk-llvm-wam-hybrid-p9ujut`; the CLI-driver and benchmark PRs stack on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_