### PR TITLE
plawk: benchmark harness + first honest numbers

### DIFF
--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -80,6 +80,30 @@ error, 3 compile error (including a program that calls a predicate no
 propagates the program's own exit status. Compilation uses
 `clang -O2`.
 
+## Benchmarks
+
+`examples/plawk/bench/bench.sh` generates text and binary workloads,
+verifies plawk's output is byte-identical to the system awk on every
+text job (a hard gate before any timing), then reports best-of-3 wall
+times. One run on this repository's CI-like container (4-core Xeon
+2.80GHz, mawk 1.3.4 -- the fast awk -- as the baseline, `clang -O2`),
+N = 2,000,000 records (~29MB text / 32MB binary):
+
+| workload | plawk | mawk | speedup |
+|---|---|---|---|
+| W1 filter-count (text) | 104 ms | 180 ms | 1.7x |
+| W2 aggregate (text) | 139 ms | 309 ms | 2.2x |
+| W3 aggregate (binary records) | 17 ms | 234 ms | 13.8x |
+| W4 group-by (text) | 117 ms | 186 ms | 1.6x |
+
+W3 is the thesis workload: the same aggregation over `i64 f64` binary
+records instead of their text encoding -- no field splitting, no
+number parsing, just typed loads at fixed offsets. Text-mode wins are
+honest but modest (mawk is very fast at what it does); the binary
+representation is where the design pays. Numbers are
+environment-relative; rerun the script for yours (`N=... sh
+examples/plawk/bench/bench.sh`).
+
 ## Run the Phase 0 prototype
 
 ```bash
@@ -127,6 +151,7 @@ swipl -q -s tests/test_plawk_multiline.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/
 swipl -q -s tests/test_plawk_prolog_blocks.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_functions.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_cli.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_bench_smoke.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.

--- a/examples/plawk/bench/bench.sh
+++ b/examples/plawk/bench/bench.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 John William Creighton (s243a)
+#
+# plawk benchmark harness. Generates text and binary workloads, checks
+# that plawk and the system awk produce IDENTICAL output on each text
+# job (a correctness gate before any timing), then reports best-of-3
+# wall times.
+#
+#   sh examples/plawk/bench/bench.sh            # N=2000000 records
+#   N=100000 sh examples/plawk/bench/bench.sh   # smaller run
+#
+# Workloads:
+#   W1 filter-count (text):   $1 == "ERROR" { e++ } { t++ }
+#   W2 aggregate (text):      $3 > 500 { s += $3 ; n++ }
+#   W3 aggregate (binary):    same job over i64+f64 records (plawk
+#                             binary reader vs the system awk parsing
+#                             the text encoding of the SAME data)
+#   W4 group-by (text):       counts[$1]++ + for-in report
+set -eu
+
+N="${N:-2000000}"
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=$(cd "$HERE/../../.." && pwd)
+PLAWK="$ROOT/examples/plawk/bin/plawk"
+AWK="${AWK:-awk}"
+WORK="${BENCH_DIR:-${TMPDIR:-/tmp}/plawk_bench_$$}"
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "# plawk bench: N=$N records, awk=$($AWK -W version 2>&1 | head -1 || true)"
+echo "# workdir: $WORK"
+
+# --- data ------------------------------------------------------------------
+python3 - "$N" "$WORK" <<'PYEOF'
+import random, struct, sys
+n, work = int(sys.argv[1]), sys.argv[2]
+random.seed(42)
+levels = ["INFO", "ERROR", "WARN", "DEBUG"]
+with open(f"{work}/data.txt", "w") as t, \
+     open(f"{work}/nums.txt", "w") as x, \
+     open(f"{work}/data.bin", "wb") as b:
+    tl, xl = [], []
+    for i in range(n):
+        lvl = levels[random.randrange(4)]
+        num = random.randrange(1000)
+        val = num / 8.0
+        tl.append(f"{lvl} disk {num}\n")
+        xl.append(f"{num} {val}\n")
+        b.write(struct.pack("<qd", num, val))
+        if len(tl) >= 65536:
+            t.write("".join(tl)); x.write("".join(xl)); tl, xl = [], []
+    t.write("".join(tl)); x.write("".join(xl))
+PYEOF
+ls -l "$WORK"/data.txt "$WORK"/data.bin | awk '{print "#", $NF, $5, "bytes"}'
+
+# --- programs ----------------------------------------------------------------
+cat > "$WORK/w1.plawk" <<'EOF'
+$1 == "ERROR" { e++ }
+{ t++ }
+END { print e, t }
+EOF
+W1_AWK='$1 == "ERROR" { e++ } { t++ } END { print e, t }'
+
+cat > "$WORK/w2.plawk" <<'EOF'
+$3 > 500 { s += $3 ; n++ }
+END { print n, s }
+EOF
+W2_AWK='$3 > 500 { s += $3 ; n++ } END { print n, s }'
+
+cat > "$WORK/w3.plawk" <<'EOF'
+BEGIN { BINFMT = "i64 f64" }
+$1 > 500 { n++ }
+END { print n }
+EOF
+W3_AWK='$1 > 500 { n++ } END { print n }'
+
+cat > "$WORK/w4.plawk" <<'EOF'
+{ counts[$1]++ }
+END { for (k in counts) print k, counts[k] }
+EOF
+W4_AWK='{ counts[$1]++ } END { for (k in counts) print k, counts[k] }'
+
+# --- build -------------------------------------------------------------------
+for w in w1 w2 w3 w4; do
+    swipl "$PLAWK" build "$WORK/$w.plawk" -o "$WORK/${w}_bin" 2>/dev/null
+done
+
+# --- correctness gate ----------------------------------------------------------
+sorted() { sort "$@"; }
+"$WORK/w1_bin" "$WORK/data.txt" > "$WORK/w1.plawk.out"
+$AWK "$W1_AWK" "$WORK/data.txt" > "$WORK/w1.awk.out"
+cmp -s "$WORK/w1.plawk.out" "$WORK/w1.awk.out" || { echo "W1 OUTPUT MISMATCH"; exit 1; }
+"$WORK/w2_bin" "$WORK/data.txt" > "$WORK/w2.plawk.out"
+$AWK "$W2_AWK" "$WORK/data.txt" > "$WORK/w2.awk.out"
+cmp -s "$WORK/w2.plawk.out" "$WORK/w2.awk.out" || { echo "W2 OUTPUT MISMATCH"; exit 1; }
+"$WORK/w3_bin" "$WORK/data.bin" > "$WORK/w3.plawk.out"
+$AWK "$W3_AWK" "$WORK/nums.txt" > "$WORK/w3.awk.out"
+cmp -s "$WORK/w3.plawk.out" "$WORK/w3.awk.out" || { echo "W3 OUTPUT MISMATCH"; exit 1; }
+"$WORK/w4_bin" "$WORK/data.txt" | sorted > "$WORK/w4.plawk.out"
+$AWK "$W4_AWK" "$WORK/data.txt" | sorted > "$WORK/w4.awk.out"
+cmp -s "$WORK/w4.plawk.out" "$WORK/w4.awk.out" || { echo "W4 OUTPUT MISMATCH"; exit 1; }
+echo "# correctness gate: all outputs identical"
+
+# --- timing --------------------------------------------------------------------
+best_of_3() {
+    best=""
+    for _i in 1 2 3; do
+        start=$(date +%s%N)
+        "$@" > /dev/null
+        end=$(date +%s%N)
+        ms=$(( (end - start) / 1000000 ))
+        if [ -z "$best" ] || [ "$ms" -lt "$best" ]; then best=$ms; fi
+    done
+    echo "$best"
+}
+
+report() { printf "%-28s %8s ms %8s ms   %sx\n" "$1" "$2" "$3" \
+    "$(python3 -c "print(f'{$3/$2:.2f}')" 2>/dev/null || echo '?')"; }
+
+printf "%-28s %11s %11s   %s\n" "workload" "plawk" "$AWK" "awk/plawk"
+P=$(best_of_3 "$WORK/w1_bin" "$WORK/data.txt")
+A=$(best_of_3 $AWK "$W1_AWK" "$WORK/data.txt")
+report "W1 filter-count (text)" "$P" "$A"
+P=$(best_of_3 "$WORK/w2_bin" "$WORK/data.txt")
+A=$(best_of_3 $AWK "$W2_AWK" "$WORK/data.txt")
+report "W2 aggregate (text)" "$P" "$A"
+P=$(best_of_3 "$WORK/w3_bin" "$WORK/data.bin")
+A=$(best_of_3 $AWK "$W3_AWK" "$WORK/nums.txt")
+report "W3 aggregate (binary)" "$P" "$A"
+P=$(best_of_3 "$WORK/w4_bin" "$WORK/data.txt")
+A=$(best_of_3 $AWK "$W4_AWK" "$WORK/data.txt")
+report "W4 group-by (text)" "$P" "$A"

--- a/tests/test_plawk_bench_smoke.pl
+++ b/tests/test_plawk_bench_smoke.pl
@@ -1,0 +1,32 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Keeps the benchmark harness from rotting: a tiny-N run must pass its
+% own correctness gate (plawk output identical to the system awk on
+% every text workload) and produce the report table. Timings at this
+% size are meaningless and are not asserted.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_bench_smoke, [condition(clang_available)]).
+
+test(bench_harness_runs_and_gates_correctness) :-
+    process_create(path(sh), ['examples/plawk/bench/bench.sh'],
+        [environment(['N'='2000']), stdout(pipe(S)), stderr(std),
+         process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(sub_string(Out, _, _, _, "correctness gate: all outputs identical")),
+    assertion(sub_string(Out, _, _, _, "W4 group-by")),
+    !.
+
+:- end_tests(plawk_bench_smoke).


### PR DESCRIPTION
## Summary

The credibility check: plawk's first honest performance numbers, produced by a checked-in harness with a hard correctness gate.

## The harness

`examples/plawk/bench/bench.sh` generates matched text and binary workloads, **verifies plawk's output is byte-identical to the system awk on every text job before any timing**, then reports best-of-3 wall times. Programs build through the new CLI (`clang -O2`). Four workloads: filter-count, numeric aggregation (text), the *same* aggregation over `i64 f64` binary records, and an assoc group-by with a for-in report.

## The numbers

This container (4-core Xeon 2.80GHz), **mawk 1.3.4** as the baseline — the fast awk, a deliberately tough comparison — N = 2,000,000 records (~29MB text / 32MB binary):

| workload | plawk | mawk | speedup |
|---|---|---|---|
| W1 filter-count (text) | 104 ms | 180 ms | 1.7× |
| W2 aggregate (text) | 139 ms | 309 ms | 2.2× |
| **W3 aggregate (binary records)** | **17 ms** | **234 ms** | **13.8×** |
| W4 group-by (text) | 117 ms | 186 ms | 1.6× |

W3 is the thesis workload: the identical aggregation over binary records instead of their text encoding — no field splitting, no number parsing, typed loads at fixed offsets. The text-mode wins are honest but modest (mawk is very fast at text); the binary representation is where the design pays, by an order of magnitude.

## Tests

`tests/test_plawk_bench_smoke.pl` runs the harness at N=2000 and asserts the correctness gate and report render (timings at that size are meaningless and not asserted), so the harness can't rot. Full sweep: **all 54 suites green.**

## Merge order (whole round, bottom-up)

1. #3454 (consolidation → main)
2. #3455 (failed-predicate hardening) → designated branch
3. #3456 (CLI driver) → the #3455 branch
4. this PR → the #3456 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_