### PR TITLE
Structural embedding for the SYM dual judge (step 2)

### DIFF
--- a/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
+++ b/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
@@ -32,10 +32,12 @@ Fit `μ_sym ≈ σ(w·features)` against the judge-scored SYM targets:
 `μ_sym = blend( judge=graph [3/dist], judge=e5 [SYM operator] )` — exactly the **calibrated-judges /
 operator-superposition** machinery (`judge_emb`, the blend regularizer). SYM is its first real use.
 - **Inference:** e5 is free (model input); the graph half must be a **cheap O(1) structural signal**, not a BFS.
-- **Open:** the naive landmark-L2 structural embedding is too weak (recovers +0.63, not +0.75; more landmarks
-  didn't help — L2-of-landmark-distance-vectors is a poor proxy). Needs a **proper structural embedding**
-  (node2vec / DeepWalk / spectral, or a tighter landmark distance *estimator* rather than L2) to reproduce the
-  `3/dist` half at O(1) inference. That's the remaining piece for a cheap dual-judge SYM.
+- **Structural embedding (step 2, `structural_embedding.py`):** landmark heuristics fail (corr ~+0.33). A
+  learned metric embedding trained on the **RECIPROCAL target** `3/d` (not distance — far pairs' small `3/d`
+  auto-weighs down, so capacity goes to the near scale where SYM lives; user's insight) recovers +0.405 corr
+  with true `3/dist` on the SYM pairs → **DUAL(struct-embed ⊕ e5) corr +0.652**, beating e5-only (+0.60) but
+  below the raw-BFS ceiling (+0.76). So the O(1) signal adds real value; residual fine-scale loss remains
+  (higher dim / better training / the exact scoring graph are the levers).
 
 ## Caveats
 - R²≈0.43 for the graph half is *moderate* — `3/dist` explains ~half of SYM; the rest is semantic nuance +

--- a/prototypes/mu_cosine/fit_sym_from_graph.py
+++ b/prototypes/mu_cosine/fit_sym_from_graph.py
@@ -64,6 +64,7 @@ def main():
     ap.add_argument("--pairs", default="mu_pairs_scored_cumulative.tsv")
     ap.add_argument("--cap-pairs", type=int, default=1500)
     ap.add_argument("--bfs-cap", type=int, default=10)
+    ap.add_argument("--struct-emb", default=None, help="learned structural embedding (structural_embedding.py .pt)")
     ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     a = ap.parse_args()
     dev = torch.device(a.device)
@@ -141,16 +142,14 @@ def main():
     fixed = 1 / (1 + np.exp(-(recip - mab - mba)))
     print(f"  [FIXED σ(3/dist − μab − μba)]  corr {np.corrcoef(fixed, y)[0,1]:+.3f}  "
           f"R² {1 - ((y-fixed)**2).sum()/ss_tot:+.3f}")
-    # STRUCTURAL EMBEDDING (landmark BFS) — the cheap O(1)-inference proxy for graph distance
-    sym_nodes = {x for x, _, _ in sym} | {y for _, y, _ in sym}
-    landmarks = sorted(present, key=lambda n: -len(adj.get(n, ())))[:64]   # high-degree, well-spread
-    LMCAP = a.bfs_cap * 3
-    lm_dist = {l: bfs_from(adj, l, sym_nodes, LMCAP) for l in landmarks}
-    def svec(n):
-        return np.array([lm_dist[l].get(n, LMCAP + 1) for l in landmarks], float)
-    struct_l2 = np.array([np.linalg.norm(svec(x) - svec(y)) for x, y, _ in sym])
-    struct_feat = 3.0 / (1.0 + struct_l2)                 # 3/‖Δ landmark-vec‖ — precomputed, O(1) at inference
-    print(f"  struct-embed({len(landmarks)} landmarks) vs true 3/dist corr: {np.corrcoef(struct_feat, recip)[0, 1]:+.3f}")
+    # STRUCTURAL EMBEDDING (learned metric emb) — the cheap O(1)-inference proxy: 3/‖emb(a)−emb(b)‖
+    se = torch.load(a.struct_emb)
+    svmap = {n: v for n, v in zip(se["nodes"], se["emb"].numpy())}
+    cap2 = se.get("cap", 6) + 2
+    def sdist(x, y):
+        return float(np.linalg.norm(svmap[x] - svmap[y])) if (x in svmap and y in svmap) else cap2
+    struct_feat = 3.0 / (1.0 + np.array([sdist(x, y) for x, y, _ in sym]))
+    print(f"  struct-embed (learned {se['dim']}d) vs true 3/dist corr: {np.corrcoef(struct_feat, recip)[0, 1]:+.3f}")
 
     print(f"  --- dual judge (superposition test) ---")
     for name, feats in [("graph only  (3/dist true)", [recip]),

--- a/prototypes/mu_cosine/structural_embedding.py
+++ b/prototypes/mu_cosine/structural_embedding.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Learned STRUCTURAL (metric) embedding — the cheap O(1)-inference proxy for the graph-judge `3/dist`
+(DESIGN_sym_dual_judge.md step 2). node2vec/gensim unavailable, so train per-node vectors in torch so that
+    ‖emb(a) − emb(b)‖  ≈  graph_dist(a, b)
+on BFS-sampled distance-labeled pairs. At inference, `3/‖emb(a)−emb(b)‖` replaces the BFS distance (embedding
+lookup + a subtraction — no traversal). Saves {node: vec} for the fit diagnostic / the SYM blend.
+
+  python3 structural_embedding.py --graph ../../data/benchmark/100k_cats/category_parent.tsv --dim 32 --out /tmp/mu_data/struct_emb.pt
+"""
+import argparse, os, random, sys
+from collections import deque, defaultdict
+import numpy as np
+import torch
+import torch.nn as nn
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mu_attention import load_dag
+
+
+def undirected_adj(parents, children):
+    adj = defaultdict(set)
+    for c, ps in parents.items():
+        for p in (ps if isinstance(ps, (set, list, tuple)) else [ps]):
+            adj[c].add(p); adj[p].add(c)
+    for p, cs in children.items():
+        for c in (cs if isinstance(cs, (set, list, tuple)) else [cs]):
+            adj[c].add(p); adj[p].add(c)
+    return adj
+
+
+def sample_pairs(adj, sources, cap, rng):
+    """BFS from each source → (src, node, dist) for dist 1..cap (all reachable within cap)."""
+    out = []
+    for s in sources:
+        dist, q = {s: 0}, deque([s])
+        while q:
+            u = q.popleft()
+            if dist[u] >= cap:
+                continue
+            for v in adj.get(u, ()):
+                if v not in dist:
+                    dist[v] = dist[u] + 1; q.append(v)
+        for n, d in dist.items():
+            if d > 0:
+                out.append((s, n, d))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--dim", type=int, default=32)
+    ap.add_argument("--cap", type=int, default=6, help="max BFS distance used as a training label")
+    ap.add_argument("--sources", type=int, default=4000, help="BFS source nodes (sampled)")
+    ap.add_argument("--far-frac", type=float, default=0.3, help="fraction of far random negatives (dist>cap ⇒ cap+2)")
+    ap.add_argument("--steps", type=int, default=3000)
+    ap.add_argument("--bs", type=int, default=8192)
+    ap.add_argument("--lr", type=float, default=0.05)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    ap.add_argument("--out", default="/tmp/mu_data/struct_emb.pt")
+    a = ap.parse_args()
+    dev = torch.device(a.device); rng = random.Random(0)
+    os.makedirs(os.path.dirname(a.out) or ".", exist_ok=True)
+
+    parents, children, deg = load_dag(a.graph)
+    adj = undirected_adj(parents, children)
+    nodes = sorted(adj)
+    nid = {n: i for i, n in enumerate(nodes)}
+    print(f"graph: {len(nodes)} nodes, {sum(len(v) for v in adj.values())//2} undirected edges")
+
+    srcs = rng.sample(nodes, min(a.sources, len(nodes)))
+    pairs = sample_pairs(adj, srcs, a.cap, rng)
+    # far negatives: random pairs (mostly disconnected/far) labelled dist = cap+2
+    nfar = int(len(pairs) * a.far_frac)
+    for _ in range(nfar):
+        pairs.append((rng.choice(nodes), rng.choice(nodes), a.cap + 2))
+    rng.shuffle(pairs)
+    A = torch.tensor([nid[s] for s, _, _ in pairs], device=dev)
+    B = torch.tensor([nid[n] for _, n, _ in pairs], device=dev)
+    D = torch.tensor([float(d) for _, _, d in pairs], device=dev)
+    print(f"training pairs: {len(pairs)} ({nfar} far negatives)  dist range 1..{a.cap+2}")
+
+    emb = nn.Embedding(len(nodes), a.dim).to(dev)
+    nn.init.normal_(emb.weight, std=0.1)
+    opt = torch.optim.Adam(emb.parameters(), lr=a.lr)
+    for step in range(a.steps):
+        idx = torch.randint(0, len(pairs), (a.bs,), device=dev)
+        ea, eb, d = emb(A[idx]), emb(B[idx]), D[idx]
+        pred = 3.0 / (1.0 + (ea - eb).norm(dim=1))          # closeness 3/(1+‖Δ‖) — matches inference use
+        target = 3.0 / d                                     # RECIPROCAL target: far pairs (small 3/d) weigh less
+        loss = ((pred - target) ** 2).mean()                 # so the embedding spends capacity on the near scale
+        opt.zero_grad(); loss.backward(); opt.step()
+        if (step + 1) % 500 == 0:
+            with torch.no_grad():
+                corr = float(np.corrcoef(pred.cpu().numpy(), target.cpu().numpy())[0, 1])
+            print(f"  step {step+1:5d}  MSE {float(loss):.4f}  pred-vs-(3/d) corr {corr:+.3f}")
+
+    W = emb.weight.detach().cpu()
+    torch.save({"nodes": nodes, "emb": W, "dim": a.dim, "cap": a.cap}, a.out)
+    print(f"saved {len(nodes)}×{a.dim} structural embedding → {a.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Step 2 of the SYM dual-judge plan (step 1 finding merged in the previous PR): a **cheap O(1)-inference
structural embedding** to replace the expensive BFS `3/dist` graph-judge signal. The dual-judge finding
showed `μ_sym = graph ⊕ e5` (corr +0.76 with true BFS distance); this PR makes the graph half **queryable at
inference without a graph traversal**.

## What's here
- **`structural_embedding.py`** — a learned metric embedding (torch, GPU; node2vec/gensim unavailable). Trains
  per-node vectors so a decay of `‖emb(a)−emb(b)‖` predicts the graph-judge signal, then saves `{node: vec}`.
  At inference the graph half is `3/(1+‖emb(a)−emb(b)‖)` — an embedding lookup + a subtraction.
- **`fit_sym_from_graph.py`** — `--struct-emb` to plug the learned embedding into the dual-judge diagnostic.
- **`DESIGN_sym_dual_judge.md`** — updated "open" section with the step-2 result.

## The key fix: reciprocal target

The first attempt trained `‖emb‖ ≈ distance` (MSE on distance) and **failed on the SYM pairs** (embedding-vs-true
`3/dist` corr only +0.21) — because MSE-on-distance weights all scales equally, so the 11M far-pair samples
dominated and blurred the near scale (1–4 hops) where the SYM pairs live.

Training on the **reciprocal target `3/d`** instead fixes it: far pairs have tiny `3/d`, so their errors
contribute little, and the embedding spends its capacity on the near scale. **Corr +0.21 → +0.405.**

## Result

```
DUAL (3/dist TRUE   ⊕ e5-SYM):  corr +0.76    ← ceiling (raw BFS)
DUAL (struct-embed  ⊕ e5-SYM):  corr +0.652   ← this PR, O(1) inference
e5-SYM only:                    corr +0.60    ← what the model has today
```

The O(1) structural signal **adds real value** (+0.652 > +0.60), so the dual-judge SYM beats the current
operator even with the cheap signal. It **doesn't fully recover the raw-BFS +0.76** — ~half the fine-scale
distance signal is still lost on these close pairs.

## Honest scope
- This is **infrastructure + a diagnostic result**, not a model change. It doesn't gate anything — it's the
  cheap-inference lever the dual-judge SYM needs, plus the measurement of how much it recovers.
- **Residual gap levers:** higher embedding dim, more training, or the exact graph the pairs were scored on
  (100k_cats may not be it — true corr could be higher).
- **Next (step 3, not here):** wire the dual-input SYM readout `e5 ⊕ struct-embed` into the model + retrain
  (a real multi-file model-architecture change; specced in `DESIGN_sym_dual_judge.md`).

## For the reviewer
- Reciprocal-target metric embedding vs a proper node2vec/spectral method (once a lib is available) — worth it?
- Is +0.652 (partial) enough to justify step 3, or should the embedding be improved first (dim/graph) so step 3
  starts from a stronger structural signal?
- The far-negative fraction + `cap` are tuning knobs — flag if a sweep is wanted before step 3.