### PR TITLE
plawk: dyncall + DYNLOAD — runtime-loaded grammars in plawk programs (JIT PR B)

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -334,6 +334,29 @@ builds a host, writes a sum grammar, and the host computes `119` from an
 object it never saw at compile time; the swap test runs a *second*
 grammar (`1020`) through the *same* host binary with no rebuild.
 
+**plawk surface (`dyncall`).** A plawk program opts into a runtime object
+with `BEGIN { DYNLOAD = "file.wamo" }` and calls into it with
+`dyncall(args...)`, which yields the entry's integer result (or 0 on
+load/call failure). `dyncall` is a reserved call form that parses to its
+own AST node — it never touches the compiled-foreign-call machinery, so
+the spelling itself marks the runtime-JIT boundary (the object file can be
+absent or swapped, unlike a compiled call). Codegen emits one
+`@plawk_dyncall_N` shim per arity that boxes N `%Value` args and calls
+`@wam_object_call_i64`; the object loads lazily on the first `dyncall`
+(mirroring `@plawk_foreign_vm_get`) and is reused, so no driver-startup
+plumbing is needed. The CLI turns on `emit_wamo_loader(true)` whenever a
+program uses `dyncall`. The entry is read as `entry(A0..A_{N-1},
+out=A_N)`, so a grammar predicate has arity N+1 (N inputs + one output).
+`tests/test_plawk_dyncall.pl` builds a binary that sums `dyncall($1)` over
+i64 records (sum of squares = 150), then swaps `square.wamo` for a
+doubling grammar and reruns the *same binary* → 44, no rebuild.
+
+One thing kept open for later: a `.wamo` currently exposes a single
+entry, so `dyncall(args)` is unambiguous. Multiple entry points would bind
+at declaration (e.g. a named-entry directive) rather than overloading
+`dyncall`'s argument list, since a leading entry-name arg can't be told
+apart from a value.
+
 ## Why not a real DCG engine in the loop?
 
 Because the loop's performance contract is the whole point of PLAWK:

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -385,7 +385,19 @@ float(...) wrapper selects a {double, ok} bridge that accepts Integer
 or Float results, keeping fractions that the i64 spelling would
 truncate; a failed call contributes 0.0); the same spelling works in
 print position (`print $1, float(score($1, $2))`). One blob argument per call;
-payloads are NUL-free byte strings. Bounded repetition handles records containing a
+payloads are NUL-free byte strings.
+Runtime-loaded grammars (JIT) go one step further than the compiled
+bridge: `BEGIN { DYNLOAD = "file.wamo" }` names a WAM object built ahead
+of time with `write_wam_object/3`, and `dyncall(args...)` invokes its
+entry at runtime, yielding an i64 (0 on load/call failure). The object
+loads lazily on the first `dyncall` and is reused; swapping the `.wamo`
+file changes behaviour with **no rebuild of the plawk binary**. `dyncall`
+is a reserved form (never a compiled predicate), so the spelling marks
+the JIT boundary. A grammar predicate has arity N+1 (N inputs read as
+`A0..A_{N-1}`, output in `A_N`). Example:
+`BEGIN { BINFMT = "i64" ; DYNLOAD = "square.wamo" } { total += dyncall($1) } END { print total }`
+sums `X*X` over i64 records; overwrite `square.wamo` with a doubling
+grammar and the same binary sums `X*2`. Bounded repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an
 ordinary i64 field, element slots are flat addressable fields

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -110,11 +110,17 @@ build(File, Out0, KeepLL) :-
     check_foreign_calls(File, Program, Preds),
     ll_path(Out, KeepLL, LLPath),
     file_base_name(Out, OutBase),
+    % A program that uses dyncall(...) needs the .wamo loader emitted into
+    % the host module so it can load and run a runtime object.
+    (   plawk_program_dyncall_arities(Program, DynArities), DynArities \== []
+    ->  ProjectOptions = [module_name(OutBase), emit_wamo_loader(true)]
+    ;   ProjectOptions = [module_name(OutBase)]
+    ),
     (   catch(
             ( % the compiler narrates on user_output; keep the CLI's
               % stdout clean for the compiled program's own output
               with_output_to(string(_CompilerChatter),
-                  write_wam_llvm_project(Preds, [module_name(OutBase)], LLPath)),
+                  write_wam_llvm_project(Preds, ProjectOptions, LLPath)),
               wam_llvm_last_compile_counts(InstrCount, LabelCount),
               (   plawk_program_native_driver_ir(Program, stdin_or_argv,
                       [wam_vm(InstrCount, LabelCount)], DriverIR)

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -6,6 +6,8 @@
     plawk_program_native_driver_ir/4,
     plawk_program_foreign_specs/3,
     plawk_program_foreign_specs/4,
+    plawk_program_dyncall_arities/2,
+    plawk_program_dynload_path/2,
     plawk_prolog_block_preds/2
 ]).
 
@@ -614,15 +616,36 @@ plawk_program_native_driver_ir(
 %  delegate to plawk_program_native_driver_ir/3 unchanged.
 plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs, FCallSpecs),
+    plawk_program_dyncall_arities(Program, DynArities),
     (   GuardSpecs == [],
         CallSpecs == [],
-        FCallSpecs == []
+        FCallSpecs == [],
+        DynArities == []
     ->  plawk_program_native_driver_ir(Program, InputPath, DriverIR)
-    ;   memberchk(wam_vm(InstrCount, LabelCount), Options),
-        plawk_foreign_support_ir(GuardSpecs, CallSpecs, FCallSpecs,
-            InstrCount, LabelCount, SupportIR),
+    ;   % Compiled-foreign support (shared VM + per-predicate wrappers)
+        % only when the program actually calls a compiled predicate; it
+        % needs the module's instruction/label counts. dyncall does not.
+        (   GuardSpecs == [], CallSpecs == [], FCallSpecs == []
+        ->  ForeignSupportIR = ''
+        ;   memberchk(wam_vm(InstrCount, LabelCount), Options),
+            plawk_foreign_support_ir(GuardSpecs, CallSpecs, FCallSpecs,
+                InstrCount, LabelCount, ForeignSupportIR)
+        ),
+        % Object-call shims for dyncall(...) sites, plus the lazily
+        % loaded .wamo object handle.
+        (   DynArities == []
+        ->  DyncallSupportIR = ''
+        ;   ( plawk_program_dynload_path(Program, DynPath)
+            ->  true
+            ;   throw(error(plawk_dyncall_without_dynload,
+                    context(plawk_program_native_driver_ir,
+                        'dyncall(...) requires BEGIN { DYNLOAD = "file.wamo" }')))
+            ),
+            plawk_dyncall_support_ir(DynPath, DynArities, DyncallSupportIR)
+        ),
         plawk_program_native_driver_ir(Program, InputPath, MainIR),
-        format(atom(DriverIR), '~w~n~n~w', [SupportIR, MainIR])
+        exclude(==(''), [ForeignSupportIR, DyncallSupportIR, MainIR], Parts),
+        atomic_list_concat(Parts, '\n\n', DriverIR)
     ).
 
 %% plawk_program_foreign_specs(+Program, -GuardSpecs, -CallSpecs)
@@ -684,6 +707,51 @@ plawk_pattern_prolog_guard(or_pat(Left, Right), Name, Args) :-
     ).
 plawk_pattern_prolog_guard(not_pat(Pattern), Name, Args) :-
     plawk_pattern_prolog_guard(Pattern, Name, Args).
+
+%% plawk_program_dyncall_arities(+Program, -Arities)
+%
+%  Deduplicated set of argument counts used by dyncall(...) sites across
+%  rule and END bodies. One object-call shim @plawk_dyncall_N is emitted
+%  per arity.
+plawk_program_dyncall_arities(program(_Begin, Rules, EndClauses), Arities) :-
+    findall(NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          plawk_actions_dyncall(Actions, Args),
+          length(Args, NArgs)
+        ),
+        Arities0),
+    sort(Arities0, Arities).
+
+%% plawk_program_dynload_path(+Program, -Path)
+%  The .wamo path from BEGIN { DYNLOAD = "..." }, or fails if absent.
+plawk_program_dynload_path(program(BeginClauses, _Rules, _End), Path) :-
+    member(begin(Actions), BeginClauses),
+    member(set(var('DYNLOAD'), string(Path)), Actions),
+    !.
+
+plawk_actions_dyncall(Actions, Args) :-
+    member(Action, Actions),
+    plawk_action_dyncall(Action, Args).
+plawk_action_dyncall(add(_Var, Expr), Args) :- plawk_expr_dyncall(Expr, Args).
+plawk_action_dyncall(set(_Var, Expr), Args) :- plawk_expr_dyncall(Expr, Args).
+plawk_action_dyncall(print(Fields), Args) :-
+    member(Field, Fields),
+    plawk_expr_dyncall(Field, Args).
+plawk_action_dyncall(printf(_Format, PrintfArgs), Args) :-
+    member(Field, PrintfArgs),
+    plawk_expr_dyncall(Field, Args).
+plawk_action_dyncall(if(_Pattern, ThenActions, ElseActions), Args) :-
+    ( plawk_actions_dyncall(ThenActions, Args)
+    ; plawk_actions_dyncall(ElseActions, Args)
+    ).
+plawk_expr_dyncall(dyncall(Args), Args).
+plawk_expr_dyncall(Expr, Args) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_dyncall(Left, Args)
+    ; plawk_expr_dyncall(Right, Args)
+    ).
 
 plawk_actions_prolog_call(Actions, Name, Args) :-
     member(Action, Actions),
@@ -944,6 +1012,84 @@ fail:
   ret { double, i1 } %f1
 }',
         [Name, NArgs, ParamsIR, Name, SetRegIR, NArgs]).
+
+%% plawk_dyncall_support_ir(+Path, +Arities, -IR)
+%
+%  Emit the dyncall runtime for a program: the .wamo path string, a
+%  lazily loaded object handle (%WamState* + entry PC), and one
+%  @plawk_dyncall_N shim per arity. The shim boxes N %Value args into a
+%  stack array and calls @wam_object_call_i64 (emitted into the host
+%  module by write_wam_llvm_project/3 with emit_wamo_loader(true)),
+%  reading the object's entry as `entry(A0..A_{N-1}, out=A_N)`. The
+%  object loads on the first dyncall and is reused for the rest of the
+%  run -- the object-call primitive rewinds the arena per call, so this
+%  stays constant-memory just like the compiled foreign bridge.
+plawk_dyncall_support_ir(Path, Arities, IR) :-
+    llvm_emit_c_string_global('plawk_dyncall_path', Path, PathGlobal,
+        _StrLen, BytesLen),
+    format(atom(GetterIR),
+'@plawk_dyncall_vm = internal global %WamState* null
+@plawk_dyncall_pc = internal global i32 0
+
+define %WamState* @plawk_dyncall_get() {
+entry:
+  %cur = load %WamState*, %WamState** @plawk_dyncall_vm
+  %have = icmp ne %WamState* %cur, null
+  br i1 %have, label %ret_cur, label %load
+
+ret_cur:
+  ret %WamState* %cur
+
+load:
+  %pathp = getelementptr [~w x i8], [~w x i8]* @.plawk_dyncall_path, i32 0, i32 0
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %pathp)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %pc = extractvalue { %WamState*, i32 } %obj, 1
+  store %WamState* %vm, %WamState** @plawk_dyncall_vm
+  store i32 %pc, i32* @plawk_dyncall_pc
+  ret %WamState* %vm
+}',
+        [BytesLen, BytesLen]),
+    findall(ShimIR,
+        ( member(N, Arities), plawk_dyncall_shim_ir(N, ShimIR) ),
+        Shims),
+    atomic_list_concat([PathGlobal, GetterIR | Shims], '\n\n', IR).
+
+plawk_dyncall_shim_ir(NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define { i64, i1 } @plawk_dyncall_~w(~w) {
+entry:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %pc = load i32, i32* @plawk_dyncall_pc
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call { i64, i1 } @wam_object_call_i64(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w)
+  ret { i64, i1 } %r
+
+fail:
+  %f0 = insertvalue { i64, i1 } undef, i64 0, 0
+  %f1 = insertvalue { i64, i1 } %f0, i1 false, 1
+  ret { i64, i1 } %f1
+}',
+        [NArgs, ParamsIR, NArgs, StoreIR, NArgs, NArgs]).
+
+plawk_dyncall_store_lines(NArgs, Lines) :-
+    NArgs1 is NArgs - 1,
+    numlist(0, NArgs1, Ns),
+    findall(Line,
+        ( member(I, Ns),
+          format(atom(Line),
+              '  %args_~w = getelementptr %Value, %Value* %args, i32 ~w\n  store %Value %a~w, %Value* %args_~w',
+              [I, I, I, I])
+        ),
+        Lines).
 
 %% plawk_forin_end_plan(+Rules, +LoopVar, +ArrayName, +BodyActions, -AssocPlan, -PrintFields)
 %
@@ -2204,6 +2350,9 @@ plawk_binfmt_i64_expr_ok(Descriptor, int(field(Index))) :-
 plawk_binfmt_i64_expr_ok(Descriptor, prolog_call(Name, Args)) :-
     !,
     atom(Name),
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
+plawk_binfmt_i64_expr_ok(Descriptor, dyncall(Args)) :-
+    !,
     plawk_binfmt_foreign_args_ok(Descriptor, Args).
 plawk_binfmt_i64_expr_ok(Descriptor, Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
@@ -4298,6 +4447,8 @@ plawk_rule_body_print_field(Expr) :-
 plawk_rule_body_print_field(Expr) :-
     plawk_prolog_call_expr(Expr).
 plawk_rule_body_print_field(Expr) :-
+    plawk_dyncall_expr(Expr).
+plawk_rule_body_print_field(Expr) :-
     plawk_f64_print_expr(Expr).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
@@ -4323,11 +4474,24 @@ plawk_i64_operand_expr(Expr) :-
     plawk_i64_binary_primary_expr(Expr).
 plawk_i64_operand_expr(prolog_call(Name, Args)) :-
     plawk_prolog_call_expr(prolog_call(Name, Args)).
+plawk_i64_operand_expr(dyncall(Args)) :-
+    plawk_dyncall_expr(dyncall(Args)).
 plawk_i64_operand_expr(Expr) :-
     plawk_i64_general_binary_expr(Expr).
 
 plawk_prolog_call_expr(prolog_call(Name, Args)) :-
     atom(Name),
+    Args = [_ | _],
+    maplist(plawk_foreign_arg, Args).
+
+%% plawk_dyncall_expr(+Expr) is semidet.
+%
+%  dyncall(args...) routes to a runtime-loaded .wamo object's entry
+%  (declared by BEGIN { DYNLOAD = "..." }) and yields its integer
+%  binding, or 0 on load/call failure. Same arg shapes as a compiled
+%  foreign i64 call; it just targets the object-call shim instead of a
+%  compiled @<name>_start_pc.
+plawk_dyncall_expr(dyncall(Args)) :-
     Args = [_ | _],
     maplist(plawk_foreign_arg, Args).
 
@@ -4511,6 +4675,9 @@ plawk_scalar_action_update(add(var(Name), var(Read)), Name, add(var(Read))) :-
 plawk_scalar_action_update(add(var(Name), prolog_call(Pred, Args)), Name,
         add(prolog_call(Pred, Args))) :-
     plawk_prolog_call_expr(prolog_call(Pred, Args)).
+plawk_scalar_action_update(add(var(Name), dyncall(Args)), Name,
+        add(dyncall(Args))) :-
+    plawk_dyncall_expr(dyncall(Args)).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
@@ -4529,6 +4696,9 @@ plawk_scalar_action_update(set(var(Name), var(Read)), Name, set(var(Read))) :-
 plawk_scalar_action_update(set(var(Name), prolog_call(Pred, Args)), Name,
         set(prolog_call(Pred, Args))) :-
     plawk_prolog_call_expr(prolog_call(Pred, Args)).
+plawk_scalar_action_update(set(var(Name), dyncall(Args)), Name,
+        set(dyncall(Args))) :-
+    plawk_dyncall_expr(dyncall(Args)).
 % Double-typed update expressions: float literals, float($N), and
 % binary trees mixing them with i64 operands or scalar reads. The
 % written slot becomes a double via plawk_scalar_typed_slots/3.
@@ -4849,6 +5019,12 @@ plawk_scalar_numeric_expr_ir(prolog_call(Name, Args), FieldSeparator, Prefix,
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(prolog_call(Name, Args), FieldSeparator, CallBase,
         CallBase, ValueIR, GlobalIR, IR).
+plawk_scalar_numeric_expr_ir(dyncall(Args), FieldSeparator, Prefix,
+        SlotIndex, OpIndex, ValueIR, GlobalIR, IR) :-
+    format(atom(DynBase), '~w_slot_~w_op_~w_dyncall',
+        [Prefix, SlotIndex, OpIndex]),
+    plawk_i64_expr_ir_parts(dyncall(Args), FieldSeparator, DynBase,
+        DynBase, ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(const(Value), _FieldSeparator, _Prefix, _SlotIndex,
         _OpIndex, ValueIR, GlobalIR, IR) :-
     plawk_i64_expr_ir_parts(const(Value), 0, scalar_const, scalar_const_global,
@@ -4908,6 +5084,23 @@ plawk_i64_expr_ir(prolog_call(Name, Args), FieldSeparator, Base, GlobalBase,
     format(atom(ResIR),
         '  %~w_res = call { i64, i1 } @plawk_foreign_call_~w_~w(~w)',
         [Base, Name, NArgs, CallArgsIR]),
+    format(atom(ValIR),
+        '  %~w_val = extractvalue { i64, i1 } %~w_res, 0', [Base, Base]),
+    format(atom(OkIR),
+        '  %~w_ok = extractvalue { i64, i1 } %~w_res, 1', [Base, Base]),
+    format(atom(SelIR),
+        '  %~w = select i1 %~w_ok, i64 %~w_val, i64 0', [Base, Base, Base]),
+    format(atom(ValueIR), '%~w', [Base]),
+    append(ArgSetupParts, [ResIR, ValIR, OkIR, SelIR], SetupParts).
+plawk_i64_expr_ir(dyncall(Args), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    length(Args, NArgs),
+    plawk_foreign_args_ir(Args, FieldSeparator, GlobalBase, ArgValueIRs,
+        GlobalParts, ArgSetupParts),
+    plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
+    format(atom(ResIR),
+        '  %~w_res = call { i64, i1 } @plawk_dyncall_~w(~w)',
+        [Base, NArgs, CallArgsIR]),
     format(atom(ValIR),
         '  %~w_val = extractvalue { i64, i1 } %~w_res, 0', [Base, Base]),
     format(atom(OkIR),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -697,6 +697,8 @@ begin_assignment_name('BINFMT') -->
     "BINFMT".
 begin_assignment_name('OUTFMT') -->
     "OUTFMT".
+begin_assignment_name('DYNLOAD') -->
+    "DYNLOAD".
 begin_assignment_name('FS') -->
     "FS".
 begin_assignment_name('OFS') -->
@@ -1262,6 +1264,21 @@ i64_factor_expr(var(Name)) -->
 %  the compiled predicate with one extra trailing output argument and
 %  yields its integer binding, or 0 when the call fails or binds a
 %  non-integer.
+% dyncall(args...) is reserved: it routes to a runtime-loaded .wamo
+% object's entry (BEGIN { DYNLOAD = "file.wamo" }) rather than a
+% compiled predicate, so it parses to its own node and never touches the
+% compiled-foreign-call machinery. The cut fires only after a full
+% `dyncall(...)`, so an identifier like `dyncalls(...)` still falls
+% through to the generic prolog call below.
+prolog_call_expr(dyncall(Args)) -->
+    "dyncall",
+    ws,
+    "(",
+    ws,
+    foreign_args(Args),
+    ws,
+    ")",
+    !.
 prolog_call_expr(prolog_call(Name, Args)) -->
     identifier(Name),
     ws,

--- a/tests/test_plawk_dyncall.pl
+++ b/tests/test_plawk_dyncall.pl
@@ -1,0 +1,145 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Phase 5 (JIT) slice: the plawk DYNLOAD / dyncall surface. A program
+% declares BEGIN { DYNLOAD = "file.wamo" } and calls dyncall(args), which
+% routes to the runtime-loaded object's entry. The object is loaded once
+% at the first dyncall and reused; swapping the .wamo file changes program
+% behaviour with no rebuild.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammar predicates compiled into .wamo objects (arity = inputs + 1 out)
+square(X, R) :- R is X * X.
+twice(X, R)  :- R is X * 2.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall).
+
+% dyncall parses to its own node (never the compiled-foreign path) and
+% DYNLOAD is a recognized BEGIN directive.
+test(dyncall_and_dynload_parse) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"g.wamo\" }\n{ t += dyncall($1) }\nEND { print t }\n",
+        program(Begin, Rules, _End)),
+    memberchk(begin(BActions), Begin),
+    memberchk(set(var('DYNLOAD'), string("g.wamo")), BActions),
+    Rules = [rule(_, Actions)],
+    memberchk(add(var(t), dyncall([field(1)])), Actions),
+    !.
+
+% dyncall is recognized as a scalar-accumulator update over a binary i64
+% program (drives emit_wamo_loader in the CLI).
+test(dyncall_arity_collected) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"g.wamo\" }\n\c
+         { t += dyncall($1) }\nEND { print t }\n",
+        Program),
+    plawk_program_dyncall_arities(Program, Arities),
+    assertion(Arities == [1]),
+    plawk_program_dynload_path(Program, Path),
+    assertion(Path == "g.wamo"),
+    !.
+
+% Full round trip: build a plawk binary that dyncalls a squaring grammar
+% over binary i64 records, and check the sum of squares.
+test(dyncall_runs_loaded_grammar, [condition(clang_available)]) :-
+    dyn_dir(Dir),
+    directory_file_path(Dir, 'square.wamo', Wamo),
+    write_wam_object([user:square/2], [wamo_entry(square/2)], Wamo),
+    build_dyncall_prog(Dir, Wamo, Bin),
+    directory_file_path(Dir, 'nums.bin', Input),
+    write_i64_records(Input, [3, 4, 5, 10]),        % 9+16+25+100 = 150
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "150\n"),
+    !.
+
+% Swap the object file for a different grammar and rerun the SAME binary:
+% behaviour changes with no rebuild. This is the point of dyncall.
+test(swapped_grammar_changes_result_no_rebuild, [condition(clang_available)]) :-
+    dyn_dir(Dir),
+    directory_file_path(Dir, 'square.wamo', Wamo),
+    directory_file_path(Dir, 'prog_bin', Bin),
+    ( exists_file(Bin) -> true ; build_dyncall_prog(Dir, Wamo, Bin) ),
+    % overwrite the object with a doubling grammar (different entry name,
+    % same input+output arity)
+    write_wam_object([user:twice/2], [wamo_entry(twice/2)], Wamo),
+    directory_file_path(Dir, 'nums.bin', Input),
+    ( exists_file(Input) -> true ; write_i64_records(Input, [3, 4, 5, 10]) ),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "44\n"),                        % 6+8+10+20 = 44
+    !.
+
+% dyncall without a DYNLOAD declaration is a compile error (exit 3), not a
+% silent miscompile.
+test(dyncall_without_dynload_fails_build, [condition(clang_available)]) :-
+    dyn_dir(Dir),
+    write_prog(Dir, 'no_dynload.plawk',
+        "BEGIN { BINFMT = \"i64\" }\n{ t += dyncall($1) }\nEND { print t }\n"),
+    directory_file_path(Dir, 'no_dynload.plawk', Prog),
+    cli([build, Prog, '-o', '/dev/null'], _, 3),
+    !.
+
+:- end_tests(plawk_dyncall).
+
+% --- helpers ---------------------------------------------------------------
+
+dyn_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_dyncall', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Text) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(
+        open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text),
+        close(Out)).
+
+% write a plawk program that sums dyncall($1) over binary i64 records
+% loaded from the given .wamo path, then build it with the CLI.
+build_dyncall_prog(Dir, Wamo, Bin) :-
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { total += dyncall($1) }\nEND { print total }\n", [Wamo]),
+    write_prog(Dir, 'prog.plawk', Src),
+    directory_file_path(Dir, 'prog.plawk', Prog),
+    directory_file_path(Dir, 'prog_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_i64_records(Path, Values) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(V, Values), write_i64_le(Out, V)),
+        close(Out)).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(null), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
**Phase 5 (JIT) slice 2**, on top of the `.wamo` objects from #3460. A
plawk program declares a runtime grammar with `BEGIN { DYNLOAD =
"file.wamo" }` and invokes it with `dyncall(args...)`, which yields the
entry's `i64` result (0 on load/call failure). **Swapping the `.wamo` file
changes behaviour with no rebuild of the plawk binary.**

### Surface — explicit `dyncall()`
You picked explicit `dyncall` over a named bridge: the spelling marks the
runtime-JIT boundary, since the object file can be absent or swapped —
unlike a compiled call. (Kept open for later: multi-entry objects would
bind at declaration rather than overloading `dyncall`'s arg list, since a
leading entry-name arg can't be told apart from a value.)

### What lands
- **Parser**: `DYNLOAD` joins `BINFMT`/`OUTFMT` as a BEGIN directive;
  `dyncall(args)` is a reserved call form parsed to its own node, so it
  never touches the compiled-foreign-call machinery (no `@<name>_start_pc`
  reference).
- **Codegen**: `dyncall(Args)` mirrors `prolog_call` across the i64
  expression path (operand / binfmt-ok / print / scalar-update recognizers
  + the call-site emitter), reusing the foreign arg-boxing. One
  `@plawk_dyncall_N` shim per arity boxes N `%Value` args and calls
  `@wam_object_call_i64`; the object loads lazily on the first `dyncall`
  (mirroring `@plawk_foreign_vm_get`) and is reused, so no driver-startup
  plumbing is needed. Entry is read as `entry(A0..A_{N-1}, out=A_N)` —
  grammar arity is N+1. `dyncall` without a `DYNLOAD` is a compile error,
  not a silent miscompile.
- **CLI**: `build` turns on `emit_wamo_loader(true)` when a program uses
  `dyncall` so the host module carries the loader.

The `/4` driver restructure is byte-identical for programs without
`dyncall` — they always take the same foreign-support-only branch.

### Tests — `tests/test_plawk_dyncall.pl` (5)
`dyncall`/`DYNLOAD` parse + arity collection; a clang-gated round trip
(sum of squares = **150** over i64 records via a loaded grammar); the
swap-the-grammar test (same binary, doubling grammar → **44**, no
rebuild); and `dyncall`-without-`DYNLOAD` failing the build (exit 3).
Design doc + plawk README updated.

Stacks on #3460 (`.wamo` writer/loader); merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_