### PR TITLE
plawk/JIT: in-memory object loading (@wam_object_load_bytes) — foundation for dynamic sources

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -20383,9 +20383,25 @@ after_read:
   br label %read_loop
 read_done:
   %close_ignore = call i32 @close(i32 %fd)
+  %r = call { %WamState*, i32 } @wam_object_load_bytes(i8* %bufc, i64 %total)
+  call void @free(i8* %bufc)
+  ret { %WamState*, i32 } %r
+fail:
+  %fnull = insertvalue { %WamState*, i32 } undef, %WamState* null, 0
+  %fret = insertvalue { %WamState*, i32 } %fnull, i32 0, 1
+  ret { %WamState*, i32 } %fret
+}
+
+; Parse a .wamo object from an in-memory buffer. Does NOT free %bufc --
+; the caller owns it (the file loader above frees it after; an
+; eval-from-value caller keeps its own bytes alive). Re-interns atoms,
+; copies functor strings, patches operands, builds the VM. Returns
+; { vm, entry_pc }; null vm on a short or bad-magic buffer.
+define { %WamState*, i32 } @wam_object_load_bytes(i8* %bufc, i64 %total) {
+entry:
   ; magic check: need >= 5 bytes and buf[0..3] == "WAMO"
   %too_small = icmp ult i64 %total, 5
-  br i1 %too_small, label %fail_free, label %magic
+  br i1 %too_small, label %fail, label %magic
 magic:
   %m0p = getelementptr i8, i8* %bufc, i64 0
   %m0 = load i8, i8* %m0p
@@ -20402,7 +20418,7 @@ magic:
   %okA = and i1 %ok0, %ok1
   %okB = and i1 %ok2, %ok3
   %magic_ok = and i1 %okA, %okB
-  br i1 %magic_ok, label %parse, label %fail_free
+  br i1 %magic_ok, label %parse, label %fail
 parse:
   ; version
   %pv = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 4)
@@ -20547,9 +20563,9 @@ build_vm:
   ; entry pc = labels[entry_idx]
   %eslot = getelementptr i32, i32* %labels, i64 %entry_idx64
   %entry_pc = load i32, i32* %eslot
-  ; scratch buffers no longer needed (atom strings copied by intern; functor
-  ; string copies are referenced by %code, so only the pointer arrays free)
-  call void @free(i8* %bufc)
+  ; scratch pointer arrays no longer needed: atom strings were copied by
+  ; @wam_intern_atom, functor string copies are owned by %code, and the
+  ; source buffer belongs to the caller.
   call void @free(i8* %atom_mem)
   call void @free(i8* %fun_mem)
   %ncode32 = trunc i64 %ncode to i32
@@ -20558,9 +20574,6 @@ build_vm:
   %ret0 = insertvalue { %WamState*, i32 } undef, %WamState* %vm, 0
   %ret1 = insertvalue { %WamState*, i32 } %ret0, i32 %entry_pc, 1
   ret { %WamState*, i32 } %ret1
-fail_free:
-  call void @free(i8* %bufc)
-  br label %fail
 fail:
   %fnull = insertvalue { %WamState*, i32 } undef, %WamState* null, 0
   %fret = insertvalue { %WamState*, i32 } %fnull, i32 0, 1

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -83,6 +83,22 @@ test(same_host_runs_a_swapped_grammar,
     assertion(Out == "1020\n"),
     !.
 
+% The loader has an in-memory entry point: @wam_object_load_bytes parses a
+% buffer directly, with no file. Embed a grammar's .wamo bytes as an LLVM
+% constant in the host and load from memory -- this is the primitive that
+% lets a grammar travel as a value rather than a path.
+test(load_bytes_from_memory, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'embed.wamo', Wamo),
+    write_wam_object([user:answer/1, user:sum3/3],
+        [wamo_entry(answer/1)], Wamo),
+    read_file_to_bytes(Wamo, Bytes),
+    length(Bytes, NBytes),
+    build_embed_host(Dir, Bytes, NBytes, Host),
+    run_embed_host(Host, Out),
+    assertion(Out == "119\n"),
+    !.
+
 :- end_tests(wam_object).
 
 % --- helpers ---------------------------------------------------------------
@@ -147,3 +163,81 @@ run_host(Host, Wamo, Out, ExpectedStatus) :-
     close(S),
     process_wait(Pid, exit(Status)),
     assertion(Status == ExpectedStatus).
+
+% Build a host whose main() embeds the .wamo bytes as a constant and loads
+% them via @wam_object_load_bytes (no file open), then runs the entry.
+build_embed_host(Dir, Bytes, NBytes, Host) :-
+    directory_file_path(Dir, 'embed_host.ll', LL),
+    with_output_to(string(_),
+        write_wam_llvm_project([user:answer/1],
+            [module_name(wam_object_embed_host), emit_wamo_loader(true)], LL)),
+    llvm_bytes_escape(Bytes, Escaped),
+    format(atom(MainIR),
+'\n@.embedded_wamo = private constant [~w x i8] c"~w"\n\n\c
+define i32 @main() {\n\c
+entry:\n\c
+  %p = getelementptr [~w x i8], [~w x i8]* @.embedded_wamo, i32 0, i32 0\n\c
+  %obj = call { %WamState*, i32 } @wam_object_load_bytes(i8* %p, i64 ~w)\n\c
+  %vm = extractvalue { %WamState*, i32 } %obj, 0\n\c
+  %pc = extractvalue { %WamState*, i32 } %obj, 1\n\c
+  %vm_null = icmp eq %WamState* %vm, null\n\c
+  br i1 %vm_null, label %load_fail, label %run\n\c
+run:\n\c
+  %r = call { i64, i1 } @wam_object_call_i64(%WamState* %vm, i32 %pc, i32 0, %Value* null, i32 0)\n\c
+  %val = extractvalue { i64, i1 } %r, 0\n\c
+  %fmt = getelementptr [6 x i8], [6 x i8]* @.wam_object_embed_fmt, i32 0, i32 0\n\c
+  %pr = call i32 (i8*, ...) @printf(i8* %fmt, i64 %val)\n\c
+  ret i32 0\n\c
+load_fail:\n\c
+  ret i32 20\n\c
+}\n@.wam_object_embed_fmt = private constant [6 x i8] c"%lld\\0A\\00"\n',
+        [NBytes, Escaped, NBytes, NBytes, NBytes]),
+    setup_call_cleanup(
+        open(LL, append, S, [encoding(utf8)]),
+        write(S, MainIR),
+        close(S)),
+    directory_file_path(Dir, 'embed_host_bin', Host),
+    format(atom(Cmd), 'clang -w -O2 ~w -o ~w -lm 2>&1', [LL, Host]),
+    process_create(path(sh), ['-c', Cmd],
+        [stdout(pipe(CS)), stderr(std), process(Pid)]),
+    read_string(CS, _, ClangOut),
+    close(CS),
+    process_wait(Pid, Status),
+    ( Status == exit(0) -> true ; throw(error(clang_failed(ClangOut), _)) ).
+
+run_embed_host(Host, Out) :-
+    process_create(Host, [],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0).
+
+read_file_to_bytes(Path, Bytes) :-
+    setup_call_cleanup(
+        open(Path, read, S, [type(binary)]),
+        read_stream_bytes(S, Bytes),
+        close(S)).
+
+read_stream_bytes(S, Bytes) :-
+    get_byte(S, B),
+    ( B == -1 -> Bytes = []
+    ; Bytes = [B | Rest], read_stream_bytes(S, Rest) ).
+
+% Escape a byte list for an LLVM c"..." string constant: printable ASCII
+% (except " and backslash) verbatim, everything else as \XX hex.
+llvm_bytes_escape(Bytes, Escaped) :-
+    foldl(llvm_byte_escape, Bytes, [], RevCodes),
+    reverse(RevCodes, Codes),
+    string_codes(Escaped, Codes).
+
+llvm_byte_escape(B, Acc, NewAcc) :-
+    (   B >= 32, B =< 126, B =\= 0'", B =\= 0'\\
+    ->  NewAcc = [B | Acc]
+    ;   Hi is B >> 4, Lo is B /\ 0xF,
+        hex_digit(Hi, HiC), hex_digit(Lo, LoC),
+        NewAcc = [LoC, HiC, 0'\\ | Acc]
+    ).
+
+hex_digit(N, C) :- N < 10, !, C is 0'0 + N.
+hex_digit(N, C) :- C is 0'A + (N - 10).


### PR DESCRIPTION
Step #2 of the dynamic-grammar arc (from the "string approach" discussion):
factor the loader so a grammar can come from **memory**, not just a file
path. This is the primitive that later lets a grammar travel as a value or
be chosen at runtime.

### What lands
- `@wam_object_load` split into a thin file wrapper + a new
  `@wam_object_load_bytes(buf, len)`. The parse/relocate/build work now
  runs on any in-memory buffer and does **not** free it — the caller owns
  the bytes. `@wam_object_load(path)` = read file → `load_bytes` → free
  buffer. The file path behaves exactly as before.
- Internal to the loader IR, which is emitted only under
  `emit_wamo_loader(true)`, so **a program with no dynamic calls gets zero
  extra IR** — the non-dynamic case is untouched (your constraint).

### Test — `tests/test_wam_object.pl` (now 6)
New `load_bytes_from_memory`: a grammar's `.wamo` bytes are embedded as an
LLVM constant in the host and loaded with **no file open**, computing 119.

### What's next (its own round)
The dynamic-source *surface* is a full feature and I'd rather build it
tested than rush it here. With the caching policy you just picked
(**cache by default, opt-in reload via `DYNCACHE = "off"`**), the plan is:
- `dyncall_at(Source, args...)` — `Source` is a runtime path (field or
  string), loaded through a path-id-keyed cache (`@wam_object_load` on a
  miss, reuse on a hit); `DYNCACHE = "off"` switches to reload+free.
- Source marshalling (field slice → NUL-terminated path) is the one
  genuinely new piece; everything else mirrors the existing `dyncall`
  scaffolding.

Stacks on the current designated branch (which has #3460 + #3461).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_