### PR TITLE
plawk: bring the dynamic-grammar slices (#3463 in-memory loader, #3465 dyncall_at) to main

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -357,6 +357,38 @@ at declaration (e.g. a named-entry directive) rather than overloading
 `dyncall`'s argument list, since a leading entry-name arg can't be told
 apart from a value.
 
+**Dynamic source (`dyncall_at`).** Where `dyncall` binds one fixed object
+at compile time, `dyncall_at(Source, args...)` chooses the object *per
+call* from a runtime value: `Source` is a field or string literal naming a
+`.wamo` path, `args...` are the entry inputs. The source is marshalled to
+a NUL-terminated path (a field slice is copied into a stack buffer, capped
+at 4095 bytes; a literal becomes a constant global) and everything else
+mirrors `dyncall`. Object management is set by `BEGIN { DYNCACHE = "..." }`
+— a compile-time constant, so the mode is baked into the emitted shim, not
+dispatched at runtime:
+
+- **`on`** (default) — a fixed-capacity (64) cache keyed by the interned
+  path id. Each distinct grammar loads once via `@wam_object_load` and is
+  reused; per-call cost is one intern + a linear scan, and memory grows
+  only with the number of *distinct* grammars (beyond 64, load without
+  caching). Ideal for "pick one of N grammars by a tag."
+- **`mtime`** — like `on`, but the cache also keys on the file's
+  modification time (`st_mtim` at offset 88/96, combined to nanoseconds,
+  matching `time_file/2`). Recompiling the `.wamo` bumps its mtime, which
+  busts the cached entry (freeing the stale VM via `@wam_state_free`) and
+  reloads — so a query/userspace **redefinition** takes effect with no
+  reload-per-call tax and no rebuild of the host binary. The nanosecond
+  key catches sub-second edits.
+- **`off`** — no cache: load fresh and `@wam_state_free` after every call.
+  Always current, correct for genuinely-changing sources, but pays a full
+  parse+relocate+build per call (fine when calls are rare, wrong in a hot
+  loop).
+
+`tests/test_plawk_dyncall_at.pl` covers all three: `on` picks the grammar
+by a filename column and reuses a repeated file (sum 30 = 7+9+7+7), `off`
+reloads each call, and `mtime` returns 7, then 11 after `g.wamo` is
+redefined — same binary, no rebuild.
+
 ## Why not a real DCG engine in the loop?
 
 Because the loop's performance contract is the whole point of PLAWK:

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -397,7 +397,16 @@ the JIT boundary. A grammar predicate has arity N+1 (N inputs read as
 `A0..A_{N-1}`, output in `A_N`). Example:
 `BEGIN { BINFMT = "i64" ; DYNLOAD = "square.wamo" } { total += dyncall($1) } END { print total }`
 sums `X*X` over i64 records; overwrite `square.wamo` with a doubling
-grammar and the same binary sums `X*2`. Bounded repetition handles records containing a
+grammar and the same binary sums `X*2`.
+`dyncall_at(Source, args...)` is the dynamic-source form: `Source` (a
+field or string) names the `.wamo` at runtime, so a program chooses its
+grammar per record — e.g. `{ total += dyncall_at($1) }` picks the grammar
+named in column 1 of each line. Object management is set by
+`BEGIN { DYNCACHE = "on" | "mtime" | "off" }` (default `on`): `on` caches
+each distinct grammar (load once, reuse); `mtime` also keys on the file's
+modification time, so recompiling a `.wamo` busts the cache and the new
+definition takes effect with no rebuild (query/userspace redefinition);
+`off` reloads and frees every call (always current, no cache). Bounded repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an
 ordinary i64 field, element slots are flat addressable fields

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -110,9 +110,12 @@ build(File, Out0, KeepLL) :-
     check_foreign_calls(File, Program, Preds),
     ll_path(Out, KeepLL, LLPath),
     file_base_name(Out, OutBase),
-    % A program that uses dyncall(...) needs the .wamo loader emitted into
-    % the host module so it can load and run a runtime object.
-    (   plawk_program_dyncall_arities(Program, DynArities), DynArities \== []
+    % A program that uses dyncall(...) or dyncall_at(...) needs the .wamo
+    % loader emitted into the host module so it can load and run a runtime
+    % object.
+    (   ( plawk_program_dyncall_arities(Program, DynArities), DynArities \== []
+        ; plawk_program_dyncall_at_arities(Program, DynAtArities), DynAtArities \== []
+        )
     ->  ProjectOptions = [module_name(OutBase), emit_wamo_loader(true)]
     ;   ProjectOptions = [module_name(OutBase)]
     ),

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -7,6 +7,8 @@
     plawk_program_foreign_specs/3,
     plawk_program_foreign_specs/4,
     plawk_program_dyncall_arities/2,
+    plawk_program_dyncall_at_arities/2,
+    plawk_program_dyncache_mode/2,
     plawk_program_dynload_path/2,
     plawk_prolog_block_preds/2
 ]).
@@ -617,10 +619,12 @@ plawk_program_native_driver_ir(
 plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs, FCallSpecs),
     plawk_program_dyncall_arities(Program, DynArities),
+    plawk_program_dyncall_at_arities(Program, DynAtArities),
     (   GuardSpecs == [],
         CallSpecs == [],
         FCallSpecs == [],
-        DynArities == []
+        DynArities == [],
+        DynAtArities == []
     ->  plawk_program_native_driver_ir(Program, InputPath, DriverIR)
     ;   % Compiled-foreign support (shared VM + per-predicate wrappers)
         % only when the program actually calls a compiled predicate; it
@@ -643,8 +647,16 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
             ),
             plawk_dyncall_support_ir(DynPath, DynArities, DyncallSupportIR)
         ),
+        % Dynamic-source shims for dyncall_at(...) sites + the path cache.
+        (   DynAtArities == []
+        ->  DyncallAtSupportIR = ''
+        ;   plawk_program_dyncache_mode(Program, CacheMode),
+            plawk_dyncall_at_support_ir(CacheMode, DynAtArities, DyncallAtSupportIR)
+        ),
         plawk_program_native_driver_ir(Program, InputPath, MainIR),
-        exclude(==(''), [ForeignSupportIR, DyncallSupportIR, MainIR], Parts),
+        exclude(==(''),
+            [ForeignSupportIR, DyncallSupportIR, DyncallAtSupportIR, MainIR],
+            Parts),
         atomic_list_concat(Parts, '\n\n', DriverIR)
     ).
 
@@ -1090,6 +1102,327 @@ plawk_dyncall_store_lines(NArgs, Lines) :-
               [I, I, I, I])
         ),
         Lines).
+
+%% plawk_dyncall_at_support_ir(+Mode, +Arities, -IR)
+%
+%  Emit the dynamic-source runtime for dyncall_at(...). Mode is a
+%  compile-time string from BEGIN { DYNCACHE = "..." }:
+%    "on"    (default) -- a fixed-capacity cache keyed by the interned
+%                         path id; each distinct grammar loads once and is
+%                         reused. Constant memory per call (arena rewind in
+%                         @wam_object_call_i64).
+%    "mtime"           -- like "on" but the cache also keys on the file's
+%                         st_mtim.tv_sec (offset 88, matching time_file/2),
+%                         so recompiling the .wamo busts the entry (frees
+%                         the stale VM) and reloads -- for query/userspace
+%                         redefinition without reload-per-call.
+%    "off"             -- load fresh and @wam_state_free after every call;
+%                         always current, no cache, pays full load per call.
+%  Cache capacity is 64 distinct grammars; beyond that "on"/"mtime" load
+%  without caching (correct, just not reused).
+plawk_dyncall_at_support_ir(Mode, Arities, IR) :-
+    (   Mode == "off"
+    ->  Globals = '', GetIR = '',
+        findall(S, ( member(N, Arities), plawk_dyncall_at_shim_off_ir(N, S) ), Shims)
+    ;   Mode == "mtime"
+    ->  plawk_dyncache_globals_ir(mtime, Globals),
+        plawk_dyncall_at_get_mtime_ir(GetIR),
+        findall(S, ( member(N, Arities), plawk_dyncall_at_shim_cached_ir(N, S) ), Shims)
+    ;   plawk_dyncache_globals_ir(plain, Globals),
+        plawk_dyncall_at_get_on_ir(GetIR),
+        findall(S, ( member(N, Arities), plawk_dyncall_at_shim_cached_ir(N, S) ), Shims)
+    ),
+    exclude(==(''), [Globals, GetIR | Shims], Parts),
+    atomic_list_concat(Parts, '\n\n', IR).
+
+plawk_dyncache_globals_ir(Kind, IR) :-
+    ( Kind == mtime
+    -> MtimesLine = '@plawk_dyncache_mtimes = internal global [64 x i64] zeroinitializer\n'
+    ;  MtimesLine = '' ),
+    format(atom(IR),
+'@plawk_dyncache_ids = internal global [64 x i64] zeroinitializer
+@plawk_dyncache_vms = internal global [64 x %WamState*] zeroinitializer
+@plawk_dyncache_pcs = internal global [64 x i32] zeroinitializer
+~w@plawk_dyncache_n = internal global i32 0', [MtimesLine]).
+
+% path-id-keyed cache lookup (mode "on")
+plawk_dyncall_at_get_on_ir(
+'define { %WamState*, i32 } @plawk_dyncall_at_get(i8* %path, i64 %len) {
+entry:
+  %id = call i64 @wam_intern_atom(i8* %path, i64 %len)
+  %n = load i32, i32* @plawk_dyncache_n
+  br label %scan
+scan:
+  %i = phi i32 [ 0, %entry ], [ %i1, %next ]
+  %done = icmp sge i32 %i, %n
+  br i1 %done, label %miss, label %check
+check:
+  %idp = getelementptr [64 x i64], [64 x i64]* @plawk_dyncache_ids, i32 0, i32 %i
+  %cid = load i64, i64* %idp
+  %match = icmp eq i64 %cid, %id
+  br i1 %match, label %hit, label %next
+next:
+  %i1 = add i32 %i, 1
+  br label %scan
+hit:
+  %vmp = getelementptr [64 x %WamState*], [64 x %WamState*]* @plawk_dyncache_vms, i32 0, i32 %i
+  %vm = load %WamState*, %WamState** %vmp
+  %pcp = getelementptr [64 x i32], [64 x i32]* @plawk_dyncache_pcs, i32 0, i32 %i
+  %pc = load i32, i32* %pcp
+  %h0 = insertvalue { %WamState*, i32 } undef, %WamState* %vm, 0
+  %h1 = insertvalue { %WamState*, i32 } %h0, i32 %pc, 1
+  ret { %WamState*, i32 } %h1
+miss:
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)
+  %nvm = extractvalue { %WamState*, i32 } %obj, 0
+  %vm_ok = icmp ne %WamState* %nvm, null
+  %has_room = icmp slt i32 %n, 64
+  %can_cache = and i1 %vm_ok, %has_room
+  br i1 %can_cache, label %store, label %ret_obj
+store:
+  %npc = extractvalue { %WamState*, i32 } %obj, 1
+  %sidp = getelementptr [64 x i64], [64 x i64]* @plawk_dyncache_ids, i32 0, i32 %n
+  store i64 %id, i64* %sidp
+  %svmp = getelementptr [64 x %WamState*], [64 x %WamState*]* @plawk_dyncache_vms, i32 0, i32 %n
+  store %WamState* %nvm, %WamState** %svmp
+  %spcp = getelementptr [64 x i32], [64 x i32]* @plawk_dyncache_pcs, i32 0, i32 %n
+  store i32 %npc, i32* %spcp
+  %n1 = add i32 %n, 1
+  store i32 %n1, i32* @plawk_dyncache_n
+  br label %ret_obj
+ret_obj:
+  ret { %WamState*, i32 } %obj
+}').
+
+% path-id + st_mtime keyed cache lookup (mode "mtime")
+plawk_dyncall_at_get_mtime_ir(
+'define { %WamState*, i32 } @plawk_dyncall_at_get(i8* %path, i64 %len) {
+entry:
+  %id = call i64 @wam_intern_atom(i8* %path, i64 %len)
+  %statbuf = alloca [256 x i8]
+  %sbp = getelementptr [256 x i8], [256 x i8]* %statbuf, i32 0, i32 0
+  %sret = call i32 @stat(i8* %path, i8* %sbp)
+  %stat_ok = icmp eq i32 %sret, 0
+  br i1 %stat_ok, label %read_mtime, label %have_mtime
+read_mtime:
+  %secp_i8 = getelementptr i8, i8* %sbp, i64 88
+  %secp = bitcast i8* %secp_i8 to i64*
+  %sec = load i64, i64* %secp
+  %nsp_i8 = getelementptr i8, i8* %sbp, i64 96
+  %nsp = bitcast i8* %nsp_i8 to i64*
+  %nsec = load i64, i64* %nsp
+  %sec_ns = mul i64 %sec, 1000000000
+  %mtime_r = add i64 %sec_ns, %nsec
+  br label %have_mtime
+have_mtime:
+  %mtime = phi i64 [ %mtime_r, %read_mtime ], [ 0, %entry ]
+  %n = load i32, i32* @plawk_dyncache_n
+  br label %scan
+scan:
+  %i = phi i32 [ 0, %have_mtime ], [ %i1, %next ]
+  %done = icmp sge i32 %i, %n
+  br i1 %done, label %miss, label %check
+check:
+  %idp = getelementptr [64 x i64], [64 x i64]* @plawk_dyncache_ids, i32 0, i32 %i
+  %cid = load i64, i64* %idp
+  %idmatch = icmp eq i64 %cid, %id
+  br i1 %idmatch, label %check_mtime, label %next
+check_mtime:
+  %mtp = getelementptr [64 x i64], [64 x i64]* @plawk_dyncache_mtimes, i32 0, i32 %i
+  %cmt = load i64, i64* %mtp
+  %mtmatch = icmp eq i64 %cmt, %mtime
+  br i1 %mtmatch, label %hit, label %stale
+next:
+  %i1 = add i32 %i, 1
+  br label %scan
+hit:
+  %vmp = getelementptr [64 x %WamState*], [64 x %WamState*]* @plawk_dyncache_vms, i32 0, i32 %i
+  %vm = load %WamState*, %WamState** %vmp
+  %pcp = getelementptr [64 x i32], [64 x i32]* @plawk_dyncache_pcs, i32 0, i32 %i
+  %pc = load i32, i32* %pcp
+  %h0 = insertvalue { %WamState*, i32 } undef, %WamState* %vm, 0
+  %h1 = insertvalue { %WamState*, i32 } %h0, i32 %pc, 1
+  ret { %WamState*, i32 } %h1
+stale:
+  %ovmp = getelementptr [64 x %WamState*], [64 x %WamState*]* @plawk_dyncache_vms, i32 0, i32 %i
+  %ovm = load %WamState*, %WamState** %ovmp
+  %ovm_null = icmp eq %WamState* %ovm, null
+  br i1 %ovm_null, label %reload, label %free_old
+free_old:
+  call void @wam_state_free(%WamState* %ovm)
+  br label %reload
+reload:
+  %robj = call { %WamState*, i32 } @wam_object_load(i8* %path)
+  %rvm = extractvalue { %WamState*, i32 } %robj, 0
+  %rpc = extractvalue { %WamState*, i32 } %robj, 1
+  store %WamState* %rvm, %WamState** %ovmp
+  %rpcp = getelementptr [64 x i32], [64 x i32]* @plawk_dyncache_pcs, i32 0, i32 %i
+  store i32 %rpc, i32* %rpcp
+  store i64 %mtime, i64* %mtp
+  ret { %WamState*, i32 } %robj
+miss:
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)
+  %nvm = extractvalue { %WamState*, i32 } %obj, 0
+  %vm_ok = icmp ne %WamState* %nvm, null
+  %has_room = icmp slt i32 %n, 64
+  %can_cache = and i1 %vm_ok, %has_room
+  br i1 %can_cache, label %mstore, label %mret
+mstore:
+  %mnpc = extractvalue { %WamState*, i32 } %obj, 1
+  %msidp = getelementptr [64 x i64], [64 x i64]* @plawk_dyncache_ids, i32 0, i32 %n
+  store i64 %id, i64* %msidp
+  %msmtp = getelementptr [64 x i64], [64 x i64]* @plawk_dyncache_mtimes, i32 0, i32 %n
+  store i64 %mtime, i64* %msmtp
+  %msvmp = getelementptr [64 x %WamState*], [64 x %WamState*]* @plawk_dyncache_vms, i32 0, i32 %n
+  store %WamState* %nvm, %WamState** %msvmp
+  %mspcp = getelementptr [64 x i32], [64 x i32]* @plawk_dyncache_pcs, i32 0, i32 %n
+  store i32 %mnpc, i32* %mspcp
+  %mn1 = add i32 %n, 1
+  store i32 %mn1, i32* @plawk_dyncache_n
+  br label %mret
+mret:
+  ret { %WamState*, i32 } %obj
+}').
+
+% shim for cached modes (on / mtime): resolve via @plawk_dyncall_at_get
+plawk_dyncall_at_shim_cached_ir(NArgs, IR) :-
+    plawk_dyncall_at_params(NArgs, ParamsIR),
+    plawk_dyncall_at_argsetup(NArgs, ArgsPtrIR, ArgsSetupIR),
+    format(atom(IR),
+'define { i64, i1 } @plawk_dyncall_at_~w(~w) {
+entry:
+  %obj = call { %WamState*, i32 } @plawk_dyncall_at_get(i8* %path, i64 %len)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %pc = extractvalue { %WamState*, i32 } %obj, 1
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+~w
+  %r = call { i64, i1 } @wam_object_call_i64(%WamState* %vm, i32 %pc, i32 ~w, %Value* ~w, i32 ~w)
+  ret { i64, i1 } %r
+
+fail:
+  %f0 = insertvalue { i64, i1 } undef, i64 0, 0
+  %f1 = insertvalue { i64, i1 } %f0, i1 false, 1
+  ret { i64, i1 } %f1
+}',
+        [NArgs, ParamsIR, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
+
+% shim for "off" mode: load fresh, run, free every call
+plawk_dyncall_at_shim_off_ir(NArgs, IR) :-
+    plawk_dyncall_at_params(NArgs, ParamsIR),
+    plawk_dyncall_at_argsetup(NArgs, ArgsPtrIR, ArgsSetupIR),
+    format(atom(IR),
+'define { i64, i1 } @plawk_dyncall_at_~w(~w) {
+entry:
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %pc = extractvalue { %WamState*, i32 } %obj, 1
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+~w
+  %r = call { i64, i1 } @wam_object_call_i64(%WamState* %vm, i32 %pc, i32 ~w, %Value* ~w, i32 ~w)
+  call void @wam_state_free(%WamState* %vm)
+  ret { i64, i1 } %r
+
+fail:
+  %f0 = insertvalue { i64, i1 } undef, i64 0, 0
+  %f1 = insertvalue { i64, i1 } %f0, i1 false, 1
+  ret { i64, i1 } %f1
+}',
+        [NArgs, ParamsIR, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
+
+plawk_dyncall_at_params(0, 'i8* %path, i64 %len') :- !.
+plawk_dyncall_at_params(NArgs, ParamsIR) :-
+    plawk_foreign_wrapper_params(NArgs, ValParams),
+    format(atom(ParamsIR), 'i8* %path, i64 %len, ~w', [ValParams]).
+
+%% plawk_dyncall_source_ir(+Source, +FieldSeparator, +Base, +GlobalBase,
+%%     -PathPtrIR, -PathLenIR, -GlobalParts, -SetupParts)
+%
+%  Marshal a dyncall_at source into a NUL-terminated i8* path + i64 length.
+%  A field is sliced from the current line and copied into a stack buffer
+%  (paths cap at 4095 bytes); a string literal becomes a constant global.
+plawk_dyncall_source_ir(field(FieldIndex), FieldSeparator, Base, _GlobalBase,
+        PathPtrIR, PathLenIR, [], [SliceIR, CopyIR]) :-
+    integer(FieldIndex),
+    FieldIndex >= 0,
+    format(atom(SrcBase), '~w_src', [Base]),
+    llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, SrcBase, SliceIR),
+    format(atom(PathPtrIR), '%~w_pathp', [Base]),
+    format(atom(PathLenIR), '%~w_clamped', [Base]),
+    format(atom(CopyIR),
+'  %~w_path = alloca [4096 x i8]
+  %~w_pathp = getelementptr [4096 x i8], [4096 x i8]* %~w_path, i32 0, i32 0
+  %~w_lt = icmp ult i64 %~w_src_len64, 4095
+  %~w_clamped = select i1 %~w_lt, i64 %~w_src_len64, i64 4095
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %~w_pathp, i8* %~w_src_ptr, i64 %~w_clamped, i1 false)
+  %~w_nulp = getelementptr i8, i8* %~w_pathp, i64 %~w_clamped
+  store i8 0, i8* %~w_nulp',
+        [Base, Base, Base, Base, Base, Base, Base, Base,
+         Base, Base, Base, Base, Base, Base, Base]).
+plawk_dyncall_source_ir(string(Str), _FieldSeparator, Base, _GlobalBase,
+        PathPtrIR, PathLenIR, [GlobalIR], []) :-
+    format(atom(GName), 'plawk_dyncall_at_path_~w', [Base]),
+    llvm_emit_c_string_global(GName, Str, GlobalIR, StrLen, BytesLen),
+    format(atom(PathPtrIR),
+        'getelementptr ([~w x i8], [~w x i8]* @.~w, i32 0, i32 0)',
+        [BytesLen, BytesLen, GName]),
+    PathLenIR = StrLen.
+
+plawk_dyncall_at_argsetup(0, 'null', '') :- !.
+plawk_dyncall_at_argsetup(NArgs, '%args', SetupIR) :-
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(SetupIR), '  %args = alloca %Value, i32 ~w\n~w', [NArgs, StoreIR]).
+
+%% plawk_program_dyncall_at_arities(+Program, -Arities)
+%  Deduplicated call-arg counts (NOT counting the source) across dyncall_at
+%  sites; one @plawk_dyncall_at_N shim per arity.
+plawk_program_dyncall_at_arities(program(_Begin, Rules, EndClauses), Arities) :-
+    findall(NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          plawk_actions_dyncall_at(Actions, _Source, Args),
+          length(Args, NArgs)
+        ),
+        Arities0),
+    sort(Arities0, Arities).
+
+%% plawk_program_dyncache_mode(+Program, -Mode)
+%  DYNCACHE mode string ("on" | "mtime" | "off"); default "on".
+plawk_program_dyncache_mode(program(BeginClauses, _Rules, _End), Mode) :-
+    (   member(begin(Actions), BeginClauses),
+        member(set(var('DYNCACHE'), string(M)), Actions)
+    ->  Mode = M
+    ;   Mode = "on"
+    ).
+
+plawk_actions_dyncall_at(Actions, Source, Args) :-
+    member(Action, Actions),
+    plawk_action_dyncall_at(Action, Source, Args).
+plawk_action_dyncall_at(add(_Var, Expr), S, A) :- plawk_expr_dyncall_at(Expr, S, A).
+plawk_action_dyncall_at(set(_Var, Expr), S, A) :- plawk_expr_dyncall_at(Expr, S, A).
+plawk_action_dyncall_at(print(Fields), S, A) :-
+    member(Field, Fields),
+    plawk_expr_dyncall_at(Field, S, A).
+plawk_action_dyncall_at(printf(_Format, PrintfArgs), S, A) :-
+    member(Field, PrintfArgs),
+    plawk_expr_dyncall_at(Field, S, A).
+plawk_action_dyncall_at(if(_Pattern, ThenActions, ElseActions), S, A) :-
+    ( plawk_actions_dyncall_at(ThenActions, S, A)
+    ; plawk_actions_dyncall_at(ElseActions, S, A)
+    ).
+plawk_expr_dyncall_at(dyncall_at(Source, Args), Source, Args).
+plawk_expr_dyncall_at(Expr, S, A) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_dyncall_at(Left, S, A)
+    ; plawk_expr_dyncall_at(Right, S, A)
+    ).
 
 %% plawk_forin_end_plan(+Rules, +LoopVar, +ArrayName, +BodyActions, -AssocPlan, -PrintFields)
 %
@@ -4449,6 +4782,8 @@ plawk_rule_body_print_field(Expr) :-
 plawk_rule_body_print_field(Expr) :-
     plawk_dyncall_expr(Expr).
 plawk_rule_body_print_field(Expr) :-
+    plawk_dyncall_at_expr(Expr).
+plawk_rule_body_print_field(Expr) :-
     plawk_f64_print_expr(Expr).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
@@ -4476,6 +4811,8 @@ plawk_i64_operand_expr(prolog_call(Name, Args)) :-
     plawk_prolog_call_expr(prolog_call(Name, Args)).
 plawk_i64_operand_expr(dyncall(Args)) :-
     plawk_dyncall_expr(dyncall(Args)).
+plawk_i64_operand_expr(dyncall_at(Source, Args)) :-
+    plawk_dyncall_at_expr(dyncall_at(Source, Args)).
 plawk_i64_operand_expr(Expr) :-
     plawk_i64_general_binary_expr(Expr).
 
@@ -4493,6 +4830,15 @@ plawk_prolog_call_expr(prolog_call(Name, Args)) :-
 %  compiled @<name>_start_pc.
 plawk_dyncall_expr(dyncall(Args)) :-
     Args = [_ | _],
+    maplist(plawk_foreign_arg, Args).
+
+%% plawk_dyncall_at_expr(+Expr) is semidet.
+%
+%  dyncall_at(Source, args...) is the dynamic-source form: Source (a
+%  field or string literal) names the .wamo object at runtime, args... are
+%  the entry inputs. Same yield semantics as dyncall (i64, 0 on failure).
+plawk_dyncall_at_expr(dyncall_at(Source, Args)) :-
+    plawk_foreign_arg(Source),
     maplist(plawk_foreign_arg, Args).
 
 plawk_foreign_arg(field(Index)) :-
@@ -4678,6 +5024,9 @@ plawk_scalar_action_update(add(var(Name), prolog_call(Pred, Args)), Name,
 plawk_scalar_action_update(add(var(Name), dyncall(Args)), Name,
         add(dyncall(Args))) :-
     plawk_dyncall_expr(dyncall(Args)).
+plawk_scalar_action_update(add(var(Name), dyncall_at(Source, Args)), Name,
+        add(dyncall_at(Source, Args))) :-
+    plawk_dyncall_at_expr(dyncall_at(Source, Args)).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
@@ -4699,6 +5048,9 @@ plawk_scalar_action_update(set(var(Name), prolog_call(Pred, Args)), Name,
 plawk_scalar_action_update(set(var(Name), dyncall(Args)), Name,
         set(dyncall(Args))) :-
     plawk_dyncall_expr(dyncall(Args)).
+plawk_scalar_action_update(set(var(Name), dyncall_at(Source, Args)), Name,
+        set(dyncall_at(Source, Args))) :-
+    plawk_dyncall_at_expr(dyncall_at(Source, Args)).
 % Double-typed update expressions: float literals, float($N), and
 % binary trees mixing them with i64 operands or scalar reads. The
 % written slot becomes a double via plawk_scalar_typed_slots/3.
@@ -5025,6 +5377,12 @@ plawk_scalar_numeric_expr_ir(dyncall(Args), FieldSeparator, Prefix,
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(dyncall(Args), FieldSeparator, DynBase,
         DynBase, ValueIR, GlobalIR, IR).
+plawk_scalar_numeric_expr_ir(dyncall_at(Source, Args), FieldSeparator, Prefix,
+        SlotIndex, OpIndex, ValueIR, GlobalIR, IR) :-
+    format(atom(DynAtBase), '~w_slot_~w_op_~w_dyncall_at',
+        [Prefix, SlotIndex, OpIndex]),
+    plawk_i64_expr_ir_parts(dyncall_at(Source, Args), FieldSeparator, DynAtBase,
+        DynAtBase, ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(const(Value), _FieldSeparator, _Prefix, _SlotIndex,
         _OpIndex, ValueIR, GlobalIR, IR) :-
     plawk_i64_expr_ir_parts(const(Value), 0, scalar_const, scalar_const_global,
@@ -5109,6 +5467,31 @@ plawk_i64_expr_ir(dyncall(Args), FieldSeparator, Base, GlobalBase,
         '  %~w = select i1 %~w_ok, i64 %~w_val, i64 0', [Base, Base, Base]),
     format(atom(ValueIR), '%~w', [Base]),
     append(ArgSetupParts, [ResIR, ValIR, OkIR, SelIR], SetupParts).
+plawk_i64_expr_ir(dyncall_at(Source, Args), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    length(Args, NArgs),
+    plawk_dyncall_source_ir(Source, FieldSeparator, Base, GlobalBase,
+        PathPtrIR, PathLenIR, SrcGlobals, SrcSetup),
+    plawk_foreign_args_ir(Args, FieldSeparator, GlobalBase, ArgValueIRs,
+        ArgGlobals, ArgSetup),
+    ( ArgValueIRs == []
+    -> CallArgsSuffix = ''
+    ;  plawk_foreign_call_args_ir(ArgValueIRs, AV),
+       format(atom(CallArgsSuffix), ', ~w', [AV])
+    ),
+    format(atom(ResIR),
+        '  %~w_res = call { i64, i1 } @plawk_dyncall_at_~w(i8* ~w, i64 ~w~w)',
+        [Base, NArgs, PathPtrIR, PathLenIR, CallArgsSuffix]),
+    format(atom(ValIR),
+        '  %~w_val = extractvalue { i64, i1 } %~w_res, 0', [Base, Base]),
+    format(atom(OkIR),
+        '  %~w_ok = extractvalue { i64, i1 } %~w_res, 1', [Base, Base]),
+    format(atom(SelIR),
+        '  %~w = select i1 %~w_ok, i64 %~w_val, i64 0', [Base, Base, Base]),
+    format(atom(ValueIR), '%~w', [Base]),
+    append(SrcGlobals, ArgGlobals, GlobalParts),
+    append(SrcSetup, ArgSetup, PreSetup),
+    append(PreSetup, [ResIR, ValIR, OkIR, SelIR], SetupParts).
 plawk_i64_expr_ir(field(FieldIndex), FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts) :-
     integer(FieldIndex),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -699,6 +699,8 @@ begin_assignment_name('OUTFMT') -->
     "OUTFMT".
 begin_assignment_name('DYNLOAD') -->
     "DYNLOAD".
+begin_assignment_name('DYNCACHE') -->
+    "DYNCACHE".
 begin_assignment_name('FS') -->
     "FS".
 begin_assignment_name('OFS') -->
@@ -1270,6 +1272,20 @@ i64_factor_expr(var(Name)) -->
 % compiled-foreign-call machinery. The cut fires only after a full
 % `dyncall(...)`, so an identifier like `dyncalls(...)` still falls
 % through to the generic prolog call below.
+% dyncall_at(Source, args...) is the dynamic-source form: Source (a field
+% or string literal) names the .wamo object at runtime, chosen per call,
+% and args... are the entry's inputs. Reserved like dyncall; parsed before
+% it so the longer keyword wins.
+prolog_call_expr(dyncall_at(Source, Args)) -->
+    "dyncall_at",
+    ws,
+    "(",
+    ws,
+    foreign_arg(Source),
+    foreign_args_rest(Args),
+    ws,
+    ")",
+    !.
 prolog_call_expr(dyncall(Args)) -->
     "dyncall",
     ws,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -20383,9 +20383,25 @@ after_read:
   br label %read_loop
 read_done:
   %close_ignore = call i32 @close(i32 %fd)
+  %r = call { %WamState*, i32 } @wam_object_load_bytes(i8* %bufc, i64 %total)
+  call void @free(i8* %bufc)
+  ret { %WamState*, i32 } %r
+fail:
+  %fnull = insertvalue { %WamState*, i32 } undef, %WamState* null, 0
+  %fret = insertvalue { %WamState*, i32 } %fnull, i32 0, 1
+  ret { %WamState*, i32 } %fret
+}
+
+; Parse a .wamo object from an in-memory buffer. Does NOT free %bufc --
+; the caller owns it (the file loader above frees it after; an
+; eval-from-value caller keeps its own bytes alive). Re-interns atoms,
+; copies functor strings, patches operands, builds the VM. Returns
+; { vm, entry_pc }; null vm on a short or bad-magic buffer.
+define { %WamState*, i32 } @wam_object_load_bytes(i8* %bufc, i64 %total) {
+entry:
   ; magic check: need >= 5 bytes and buf[0..3] == "WAMO"
   %too_small = icmp ult i64 %total, 5
-  br i1 %too_small, label %fail_free, label %magic
+  br i1 %too_small, label %fail, label %magic
 magic:
   %m0p = getelementptr i8, i8* %bufc, i64 0
   %m0 = load i8, i8* %m0p
@@ -20402,7 +20418,7 @@ magic:
   %okA = and i1 %ok0, %ok1
   %okB = and i1 %ok2, %ok3
   %magic_ok = and i1 %okA, %okB
-  br i1 %magic_ok, label %parse, label %fail_free
+  br i1 %magic_ok, label %parse, label %fail
 parse:
   ; version
   %pv = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 4)
@@ -20547,9 +20563,9 @@ build_vm:
   ; entry pc = labels[entry_idx]
   %eslot = getelementptr i32, i32* %labels, i64 %entry_idx64
   %entry_pc = load i32, i32* %eslot
-  ; scratch buffers no longer needed (atom strings copied by intern; functor
-  ; string copies are referenced by %code, so only the pointer arrays free)
-  call void @free(i8* %bufc)
+  ; scratch pointer arrays no longer needed: atom strings were copied by
+  ; @wam_intern_atom, functor string copies are owned by %code, and the
+  ; source buffer belongs to the caller.
   call void @free(i8* %atom_mem)
   call void @free(i8* %fun_mem)
   %ncode32 = trunc i64 %ncode to i32
@@ -20558,9 +20574,6 @@ build_vm:
   %ret0 = insertvalue { %WamState*, i32 } undef, %WamState* %vm, 0
   %ret1 = insertvalue { %WamState*, i32 } %ret0, i32 %entry_pc, 1
   ret { %WamState*, i32 } %ret1
-fail_free:
-  call void @free(i8* %bufc)
-  br label %fail
 fail:
   %fnull = insertvalue { %WamState*, i32 } undef, %WamState* null, 0
   %fret = insertvalue { %WamState*, i32 } %fnull, i32 0, 1

--- a/tests/test_plawk_dyncall_at.pl
+++ b/tests/test_plawk_dyncall_at.pl
@@ -1,0 +1,145 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Phase 5 (JIT): the dynamic-source dyncall_at surface. dyncall_at(Source,
+% args...) picks the .wamo object by a runtime value (a field or string),
+% so a program chooses its grammar per record. Object management is set by
+% BEGIN { DYNCACHE = "on" | "mtime" | "off" } (default "on").
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammar objects: nullary entry returning a constant (entry(out=A0))
+seven(R) :- R is 7.
+nine(R)  :- R is 9.
+eleven(R) :- R is 11.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_at).
+
+% dyncall_at parses to its own node with the source split from the args,
+% and DYNCACHE is a recognized directive.
+test(dyncall_at_parses) :-
+    plawk_parse_string(
+        "BEGIN { DYNCACHE = \"mtime\" }\n{ t += dyncall_at($1) }\nEND { print t }\n",
+        program(Begin, Rules, _)),
+    memberchk(begin(B), Begin),
+    memberchk(set(var('DYNCACHE'), string("mtime")), B),
+    Rules = [rule(_, Actions)],
+    memberchk(add(var(t), dyncall_at(field(1), [])), Actions),
+    !.
+
+test(dyncall_at_arities_and_mode_collected) :-
+    plawk_parse_string(
+        "BEGIN { DYNCACHE = \"off\" }\n{ t += dyncall_at($1, $2) }\nEND { print t }\n",
+        Program),
+    plawk_program_dyncall_at_arities(Program, Arities),
+    assertion(Arities == [1]),               % one call arg (source excluded)
+    plawk_program_dyncache_mode(Program, Mode),
+    assertion(Mode == "off"),
+    !.
+
+% Default (on) mode: pick the grammar by a filename column; a repeated file
+% loads once and is reused.
+test(on_mode_selects_grammar_by_field, [condition(clang_available)]) :-
+    at_dir(Dir),
+    make_grammar(Dir, 'seven.wamo', seven/1),
+    make_grammar(Dir, 'nine.wamo', nine/1),
+    build_at_prog(Dir, "on", Bin),
+    directory_file_path(Dir, 'in.txt', Input),
+    write_lines(Input, ['seven.wamo', 'nine.wamo', 'seven.wamo', 'seven.wamo'], Dir),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "30\n"),                % 7+9+7+7
+    !.
+
+% off mode: same answer, but each call reloads+frees (no cache).
+test(off_mode_reloads_each_call, [condition(clang_available)]) :-
+    at_dir(Dir),
+    ( exists_file_in(Dir, 'seven.wamo') -> true ; make_grammar(Dir, 'seven.wamo', seven/1) ),
+    ( exists_file_in(Dir, 'nine.wamo') -> true ; make_grammar(Dir, 'nine.wamo', nine/1) ),
+    build_at_prog(Dir, "off", Bin),
+    directory_file_path(Dir, 'in.txt', Input),
+    ( exists_file(Input) -> true ; write_lines(Input, ['seven.wamo', 'nine.wamo'], Dir) ),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "30\n"),
+    !.
+
+% mtime mode: a cached grammar is reused until the .wamo file changes, then
+% the entry is busted and reloaded -- redefinition takes effect with no
+% rebuild of the plawk binary.
+test(mtime_mode_picks_up_redefinition, [condition(clang_available)]) :-
+    at_dir(Dir),
+    make_grammar(Dir, 'g.wamo', seven/1),        % g returns 7
+    build_at_prog(Dir, "mtime", Bin),
+    directory_file_path(Dir, 'one.txt', Input),
+    write_lines(Input, ['g.wamo'], Dir),
+    run_bin(Bin, [Input], Out1, 0),
+    assertion(Out1 == "7\n"),
+    sleep(1.1),                                  % ensure a new mtime
+    make_grammar(Dir, 'g.wamo', eleven/1),       % redefine g -> 11
+    run_bin(Bin, [Input], Out2, 0),
+    assertion(Out2 == "11\n"),
+    !.
+
+:- end_tests(plawk_dyncall_at).
+
+% --- helpers ---------------------------------------------------------------
+
+at_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_dyncall_at', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+exists_file_in(Dir, Name) :-
+    directory_file_path(Dir, Name, Path),
+    exists_file(Path).
+
+make_grammar(Dir, Name, Pred/Arity) :-
+    directory_file_path(Dir, Name, Path),
+    write_wam_object([user:Pred/Arity], [wamo_entry(Pred/Arity)], Path).
+
+% one input line per grammar-file name (absolute path under Dir)
+write_lines(Path, Names, Dir) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [encoding(utf8)]),
+        forall(member(Name, Names),
+            ( directory_file_path(Dir, Name, Full), format(Out, "~w~n", [Full]) )),
+        close(Out)).
+
+% a text-mode program: sum dyncall_at($1) over lines naming grammar files
+build_at_prog(Dir, CacheMode, Bin) :-
+    format(string(Src),
+        "BEGIN { DYNCACHE = \"~w\" }\n{ total += dyncall_at($1) }\nEND { print total }\n",
+        [CacheMode]),
+    directory_file_path(Dir, 'prog.plawk', Prog),
+    setup_call_cleanup(
+        open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src),
+        close(S)),
+    directory_file_path(Dir, 'prog_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(null), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -83,6 +83,22 @@ test(same_host_runs_a_swapped_grammar,
     assertion(Out == "1020\n"),
     !.
 
+% The loader has an in-memory entry point: @wam_object_load_bytes parses a
+% buffer directly, with no file. Embed a grammar's .wamo bytes as an LLVM
+% constant in the host and load from memory -- this is the primitive that
+% lets a grammar travel as a value rather than a path.
+test(load_bytes_from_memory, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'embed.wamo', Wamo),
+    write_wam_object([user:answer/1, user:sum3/3],
+        [wamo_entry(answer/1)], Wamo),
+    read_file_to_bytes(Wamo, Bytes),
+    length(Bytes, NBytes),
+    build_embed_host(Dir, Bytes, NBytes, Host),
+    run_embed_host(Host, Out),
+    assertion(Out == "119\n"),
+    !.
+
 :- end_tests(wam_object).
 
 % --- helpers ---------------------------------------------------------------
@@ -147,3 +163,81 @@ run_host(Host, Wamo, Out, ExpectedStatus) :-
     close(S),
     process_wait(Pid, exit(Status)),
     assertion(Status == ExpectedStatus).
+
+% Build a host whose main() embeds the .wamo bytes as a constant and loads
+% them via @wam_object_load_bytes (no file open), then runs the entry.
+build_embed_host(Dir, Bytes, NBytes, Host) :-
+    directory_file_path(Dir, 'embed_host.ll', LL),
+    with_output_to(string(_),
+        write_wam_llvm_project([user:answer/1],
+            [module_name(wam_object_embed_host), emit_wamo_loader(true)], LL)),
+    llvm_bytes_escape(Bytes, Escaped),
+    format(atom(MainIR),
+'\n@.embedded_wamo = private constant [~w x i8] c"~w"\n\n\c
+define i32 @main() {\n\c
+entry:\n\c
+  %p = getelementptr [~w x i8], [~w x i8]* @.embedded_wamo, i32 0, i32 0\n\c
+  %obj = call { %WamState*, i32 } @wam_object_load_bytes(i8* %p, i64 ~w)\n\c
+  %vm = extractvalue { %WamState*, i32 } %obj, 0\n\c
+  %pc = extractvalue { %WamState*, i32 } %obj, 1\n\c
+  %vm_null = icmp eq %WamState* %vm, null\n\c
+  br i1 %vm_null, label %load_fail, label %run\n\c
+run:\n\c
+  %r = call { i64, i1 } @wam_object_call_i64(%WamState* %vm, i32 %pc, i32 0, %Value* null, i32 0)\n\c
+  %val = extractvalue { i64, i1 } %r, 0\n\c
+  %fmt = getelementptr [6 x i8], [6 x i8]* @.wam_object_embed_fmt, i32 0, i32 0\n\c
+  %pr = call i32 (i8*, ...) @printf(i8* %fmt, i64 %val)\n\c
+  ret i32 0\n\c
+load_fail:\n\c
+  ret i32 20\n\c
+}\n@.wam_object_embed_fmt = private constant [6 x i8] c"%lld\\0A\\00"\n',
+        [NBytes, Escaped, NBytes, NBytes, NBytes]),
+    setup_call_cleanup(
+        open(LL, append, S, [encoding(utf8)]),
+        write(S, MainIR),
+        close(S)),
+    directory_file_path(Dir, 'embed_host_bin', Host),
+    format(atom(Cmd), 'clang -w -O2 ~w -o ~w -lm 2>&1', [LL, Host]),
+    process_create(path(sh), ['-c', Cmd],
+        [stdout(pipe(CS)), stderr(std), process(Pid)]),
+    read_string(CS, _, ClangOut),
+    close(CS),
+    process_wait(Pid, Status),
+    ( Status == exit(0) -> true ; throw(error(clang_failed(ClangOut), _)) ).
+
+run_embed_host(Host, Out) :-
+    process_create(Host, [],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0).
+
+read_file_to_bytes(Path, Bytes) :-
+    setup_call_cleanup(
+        open(Path, read, S, [type(binary)]),
+        read_stream_bytes(S, Bytes),
+        close(S)).
+
+read_stream_bytes(S, Bytes) :-
+    get_byte(S, B),
+    ( B == -1 -> Bytes = []
+    ; Bytes = [B | Rest], read_stream_bytes(S, Rest) ).
+
+% Escape a byte list for an LLVM c"..." string constant: printable ASCII
+% (except " and backslash) verbatim, everything else as \XX hex.
+llvm_bytes_escape(Bytes, Escaped) :-
+    foldl(llvm_byte_escape, Bytes, [], RevCodes),
+    reverse(RevCodes, Codes),
+    string_codes(Escaped, Codes).
+
+llvm_byte_escape(B, Acc, NewAcc) :-
+    (   B >= 32, B =< 126, B =\= 0'", B =\= 0'\\
+    ->  NewAcc = [B | Acc]
+    ;   Hi is B >> 4, Lo is B /\ 0xF,
+        hex_digit(Hi, HiC), hex_digit(Lo, LoC),
+        NewAcc = [LoC, HiC, 0'\\ | Acc]
+    ).
+
+hex_digit(N, C) :- N < 10, !, C is 0'0 + N.
+hex_digit(N, C) :- C is 0'A + (N - 10).


### PR DESCRIPTION
## Why

Carries the dynamic-grammar work to `main`. Builds on the JIT core
(`.wamo` objects + `dyncall`) already on `main`.

**Merge order (bottom-up):**
1. **#3463** — in-memory object loading (`@wam_object_load_bytes`). Already
   merged into this branch.
2. **#3465** — `dyncall_at` dynamic-source surface + path cache
   (`on`/`mtime`/`off`). Stacks on #3463.
3. **This PR** — designated → `main`, once #3465 lands here.

## Contents
- **#3463** — split `@wam_object_load` into a file wrapper +
  `@wam_object_load_bytes(buf, len)` that parses/relocates/builds from any
  in-memory buffer. Zero extra IR when no dynamic calls are compiled.
  Test: a grammar loaded from an embedded byte constant (no file) computes
  119.
- **#3465** — `dyncall_at(Source, args...)` chooses the `.wamo` per call
  from a runtime field/string. `BEGIN { DYNCACHE = "on" | "mtime" | "off" }`
  sets object management: cache-by-path (default), mtime-invalidated cache
  for redefinition, or reload+free. Tests cover all three (on → 30 by
  filename column, off reloads, mtime returns 7 then 11 after the `.wamo`
  is redefined — same binary, no rebuild).

No new content beyond the two feature PRs. All plawk + wam_object suites
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_