### PR TITLE
plawk/JIT: float-returning dyncall / dyncall_at

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -389,6 +389,21 @@ by a filename column and reuses a repeated file (sum 30 = 7+9+7+7), `off`
 reloads each call, and `mtime` returns 7, then 11 after `g.wamo` is
 redefined — same binary, no rebuild.
 
+**Float returns (`float(dyncall(...))`).** `dyncall`/`dyncall_at` read the
+entry output as an Integer; `float(dyncall(...))` and
+`float(dyncall_at(...))` read it as a double via a `@wam_object_call_f64`
+primitive (`@value_is_number` + `@value_to_double`), exactly like the
+compiled bridge's `float(name(args))`. This matters two ways: it puts an
+integer result into the f64 lane so plawk-side float math applies, and —
+crucially — a grammar whose output is a *Float* (e.g. `R is X / 2`, since
+runtime `/` yields float) is **unreadable by the integer form**, which
+demands tag=1 and returns 0. `tests/test_plawk_dyncall_float.pl` pins the
+contrast: for a `half(X,R):-R is X/2` grammar and input 7, `dyncall($1)`
+yields `0` while `float(dyncall($1))` yields `3.5`; `float(dyncall_at($1))`
+does the same over a dynamic source. (Float *constants* in a grammar are
+still outside the loadable subset — a grammar reaches a Float via
+computation, not a literal, until that restriction is lifted.)
+
 ## Why not a real DCG engine in the loop?
 
 Because the loop's performance contract is the whole point of PLAWK:

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -406,7 +406,11 @@ named in column 1 of each line. Object management is set by
 each distinct grammar (load once, reuse); `mtime` also keys on the file's
 modification time, so recompiling a `.wamo` busts the cache and the new
 definition takes effect with no rebuild (query/userspace redefinition);
-`off` reloads and frees every call (always current, no cache). Bounded repetition handles records containing a
+`off` reloads and frees every call (always current, no cache).
+`float(dyncall(...))` / `float(dyncall_at(...))` read the grammar's output
+as a double (keeping fractions), mirroring `float(name(args))` for
+compiled predicates — needed when a grammar returns a Float (e.g.
+`R is X / 2`), which the integer form cannot read (it yields 0). Bounded repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an
 ordinary i64 field, element slots are flat addressable fields

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -115,6 +115,8 @@ build(File, Out0, KeepLL) :-
     % object.
     (   ( plawk_program_dyncall_arities(Program, DynArities), DynArities \== []
         ; plawk_program_dyncall_at_arities(Program, DynAtArities), DynAtArities \== []
+        ; plawk_program_dyncall_float_arities(Program, DynFArities), DynFArities \== []
+        ; plawk_program_dyncall_at_float_arities(Program, DynAtFArities), DynAtFArities \== []
         )
     ->  ProjectOptions = [module_name(OutBase), emit_wamo_loader(true)]
     ;   ProjectOptions = [module_name(OutBase)]

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -8,6 +8,8 @@
     plawk_program_foreign_specs/4,
     plawk_program_dyncall_arities/2,
     plawk_program_dyncall_at_arities/2,
+    plawk_program_dyncall_float_arities/2,
+    plawk_program_dyncall_at_float_arities/2,
     plawk_program_dyncache_mode/2,
     plawk_program_dynload_path/2,
     plawk_prolog_block_preds/2
@@ -620,11 +622,15 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs, FCallSpecs),
     plawk_program_dyncall_arities(Program, DynArities),
     plawk_program_dyncall_at_arities(Program, DynAtArities),
+    plawk_program_dyncall_float_arities(Program, DynFArities),
+    plawk_program_dyncall_at_float_arities(Program, DynAtFArities),
     (   GuardSpecs == [],
         CallSpecs == [],
         FCallSpecs == [],
         DynArities == [],
-        DynAtArities == []
+        DynAtArities == [],
+        DynFArities == [],
+        DynAtFArities == []
     ->  plawk_program_native_driver_ir(Program, InputPath, DriverIR)
     ;   % Compiled-foreign support (shared VM + per-predicate wrappers)
         % only when the program actually calls a compiled predicate; it
@@ -635,9 +641,9 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
             plawk_foreign_support_ir(GuardSpecs, CallSpecs, FCallSpecs,
                 InstrCount, LabelCount, ForeignSupportIR)
         ),
-        % Object-call shims for dyncall(...) sites, plus the lazily
-        % loaded .wamo object handle.
-        (   DynArities == []
+        % Object-call shims for dyncall(...) / float(dyncall(...)) sites,
+        % plus the lazily loaded .wamo object handle they share.
+        (   DynArities == [], DynFArities == []
         ->  DyncallSupportIR = ''
         ;   ( plawk_program_dynload_path(Program, DynPath)
             ->  true
@@ -645,13 +651,16 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
                     context(plawk_program_native_driver_ir,
                         'dyncall(...) requires BEGIN { DYNLOAD = "file.wamo" }')))
             ),
-            plawk_dyncall_support_ir(DynPath, DynArities, DyncallSupportIR)
+            plawk_dyncall_support_ir(DynPath, DynArities, DynFArities,
+                DyncallSupportIR)
         ),
-        % Dynamic-source shims for dyncall_at(...) sites + the path cache.
-        (   DynAtArities == []
+        % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...))
+        % sites + the shared path cache.
+        (   DynAtArities == [], DynAtFArities == []
         ->  DyncallAtSupportIR = ''
         ;   plawk_program_dyncache_mode(Program, CacheMode),
-            plawk_dyncall_at_support_ir(CacheMode, DynAtArities, DyncallAtSupportIR)
+            plawk_dyncall_at_support_ir(CacheMode, DynAtArities, DynAtFArities,
+                DyncallAtSupportIR)
         ),
         plawk_program_native_driver_ir(Program, InputPath, MainIR),
         exclude(==(''),
@@ -1037,6 +1046,13 @@ fail:
 %  run -- the object-call primitive rewinds the arena per call, so this
 %  stays constant-memory just like the compiled foreign bridge.
 plawk_dyncall_support_ir(Path, Arities, IR) :-
+    plawk_dyncall_support_ir(Path, Arities, [], IR).
+
+%% plawk_dyncall_support_ir(+Path, +IArities, +FArities, -IR)
+%  IArities gets one i64 @plawk_dyncall_N shim each; FArities gets one
+%  double @plawk_dyncall_f_N shim each (float(dyncall(...))). Both share
+%  the single lazily loaded object handle + @plawk_dyncall_get.
+plawk_dyncall_support_ir(Path, IArities, FArities, IR) :-
     llvm_emit_c_string_global('plawk_dyncall_path', Path, PathGlobal,
         _StrLen, BytesLen),
     format(atom(GetterIR),
@@ -1063,9 +1079,40 @@ load:
 }',
         [BytesLen, BytesLen]),
     findall(ShimIR,
-        ( member(N, Arities), plawk_dyncall_shim_ir(N, ShimIR) ),
-        Shims),
-    atomic_list_concat([PathGlobal, GetterIR | Shims], '\n\n', IR).
+        ( member(N, IArities), plawk_dyncall_shim_ir(N, ShimIR) ),
+        IShims),
+    findall(FShimIR,
+        ( member(FN, FArities), plawk_dyncall_shim_f_ir(FN, FShimIR) ),
+        FShims),
+    append([[PathGlobal, GetterIR], IShims, FShims], Parts),
+    atomic_list_concat(Parts, '\n\n', IR).
+
+% double-returning dyncall shim (float(dyncall(...))): same object handle,
+% reads the entry output as a double via @wam_object_call_f64.
+plawk_dyncall_shim_f_ir(NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define { double, i1 } @plawk_dyncall_f_~w(~w) {
+entry:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %pc = load i32, i32* @plawk_dyncall_pc
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call { double, i1 } @wam_object_call_f64(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w)
+  ret { double, i1 } %r
+
+fail:
+  %f0 = insertvalue { double, i1 } undef, double 0.0, 0
+  %f1 = insertvalue { double, i1 } %f0, i1 false, 1
+  ret { double, i1 } %f1
+}',
+        [NArgs, ParamsIR, NArgs, StoreIR, NArgs, NArgs]).
 
 plawk_dyncall_shim_ir(NArgs, IR) :-
     plawk_foreign_wrapper_params(NArgs, ParamsIR),
@@ -1121,18 +1168,29 @@ plawk_dyncall_store_lines(NArgs, Lines) :-
 %  Cache capacity is 64 distinct grammars; beyond that "on"/"mtime" load
 %  without caching (correct, just not reused).
 plawk_dyncall_at_support_ir(Mode, Arities, IR) :-
+    plawk_dyncall_at_support_ir(Mode, Arities, [], IR).
+
+%% plawk_dyncall_at_support_ir(+Mode, +IArities, +FArities, -IR)
+%  IArities gets i64 @plawk_dyncall_at_N shims; FArities gets double
+%  @plawk_dyncall_at_f_N shims (float(dyncall_at(...))). Both share the
+%  cache + @plawk_dyncall_at_get emitted per Mode.
+plawk_dyncall_at_support_ir(Mode, IArities, FArities, IR) :-
     (   Mode == "off"
     ->  Globals = '', GetIR = '',
-        findall(S, ( member(N, Arities), plawk_dyncall_at_shim_off_ir(N, S) ), Shims)
+        findall(S, ( member(N, IArities), plawk_dyncall_at_shim_off_ir(N, S) ), IShims),
+        findall(FS, ( member(FN, FArities), plawk_dyncall_at_shim_off_f_ir(FN, FS) ), FShims)
     ;   Mode == "mtime"
     ->  plawk_dyncache_globals_ir(mtime, Globals),
         plawk_dyncall_at_get_mtime_ir(GetIR),
-        findall(S, ( member(N, Arities), plawk_dyncall_at_shim_cached_ir(N, S) ), Shims)
+        findall(S, ( member(N, IArities), plawk_dyncall_at_shim_cached_ir(N, S) ), IShims),
+        findall(FS, ( member(FN, FArities), plawk_dyncall_at_shim_cached_f_ir(FN, FS) ), FShims)
     ;   plawk_dyncache_globals_ir(plain, Globals),
         plawk_dyncall_at_get_on_ir(GetIR),
-        findall(S, ( member(N, Arities), plawk_dyncall_at_shim_cached_ir(N, S) ), Shims)
+        findall(S, ( member(N, IArities), plawk_dyncall_at_shim_cached_ir(N, S) ), IShims),
+        findall(FS, ( member(FN, FArities), plawk_dyncall_at_shim_cached_f_ir(FN, FS) ), FShims)
     ),
-    exclude(==(''), [Globals, GetIR | Shims], Parts),
+    append([[Globals, GetIR], IShims, FShims], Parts0),
+    exclude(==(''), Parts0, Parts),
     atomic_list_concat(Parts, '\n\n', IR).
 
 plawk_dyncache_globals_ir(Kind, IR) :-
@@ -1335,6 +1393,57 @@ fail:
 }',
         [NArgs, ParamsIR, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
 
+% double-returning dyncall_at shims (float(dyncall_at(...))): same cache /
+% load, read the entry output as a double via @wam_object_call_f64.
+plawk_dyncall_at_shim_cached_f_ir(NArgs, IR) :-
+    plawk_dyncall_at_params(NArgs, ParamsIR),
+    plawk_dyncall_at_argsetup(NArgs, ArgsPtrIR, ArgsSetupIR),
+    format(atom(IR),
+'define { double, i1 } @plawk_dyncall_at_f_~w(~w) {
+entry:
+  %obj = call { %WamState*, i32 } @plawk_dyncall_at_get(i8* %path, i64 %len)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %pc = extractvalue { %WamState*, i32 } %obj, 1
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+~w
+  %r = call { double, i1 } @wam_object_call_f64(%WamState* %vm, i32 %pc, i32 ~w, %Value* ~w, i32 ~w)
+  ret { double, i1 } %r
+
+fail:
+  %f0 = insertvalue { double, i1 } undef, double 0.0, 0
+  %f1 = insertvalue { double, i1 } %f0, i1 false, 1
+  ret { double, i1 } %f1
+}',
+        [NArgs, ParamsIR, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
+
+plawk_dyncall_at_shim_off_f_ir(NArgs, IR) :-
+    plawk_dyncall_at_params(NArgs, ParamsIR),
+    plawk_dyncall_at_argsetup(NArgs, ArgsPtrIR, ArgsSetupIR),
+    format(atom(IR),
+'define { double, i1 } @plawk_dyncall_at_f_~w(~w) {
+entry:
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %pc = extractvalue { %WamState*, i32 } %obj, 1
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+~w
+  %r = call { double, i1 } @wam_object_call_f64(%WamState* %vm, i32 %pc, i32 ~w, %Value* ~w, i32 ~w)
+  call void @wam_state_free(%WamState* %vm)
+  ret { double, i1 } %r
+
+fail:
+  %f0 = insertvalue { double, i1 } undef, double 0.0, 0
+  %f1 = insertvalue { double, i1 } %f0, i1 false, 1
+  ret { double, i1 } %f1
+}',
+        [NArgs, ParamsIR, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
+
 plawk_dyncall_at_params(0, 'i8* %path, i64 %len') :- !.
 plawk_dyncall_at_params(NArgs, ParamsIR) :-
     plawk_foreign_wrapper_params(NArgs, ValParams),
@@ -1422,6 +1531,70 @@ plawk_expr_dyncall_at(Expr, S, A) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
     ( plawk_expr_dyncall_at(Left, S, A)
     ; plawk_expr_dyncall_at(Right, S, A)
+    ).
+
+%% float(dyncall(...)) / float(dyncall_at(...)) arity collectors -- one
+%  double-returning shim per distinct call-arg count.
+plawk_program_dyncall_float_arities(program(_Begin, Rules, EndClauses), Arities) :-
+    findall(NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          plawk_actions_float_dyncall(Actions, Args),
+          length(Args, NArgs)
+        ),
+        Arities0),
+    sort(Arities0, Arities).
+
+plawk_program_dyncall_at_float_arities(program(_Begin, Rules, EndClauses), Arities) :-
+    findall(NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          plawk_actions_float_dyncall_at(Actions, _Source, Args),
+          length(Args, NArgs)
+        ),
+        Arities0),
+    sort(Arities0, Arities).
+
+plawk_actions_float_dyncall(Actions, Args) :-
+    member(Action, Actions),
+    plawk_action_float_dyncall(Action, Args).
+plawk_action_float_dyncall(add(_Var, Expr), Args) :- plawk_expr_float_dyncall(Expr, Args).
+plawk_action_float_dyncall(set(_Var, Expr), Args) :- plawk_expr_float_dyncall(Expr, Args).
+plawk_action_float_dyncall(print(Fields), Args) :-
+    member(Field, Fields), plawk_expr_float_dyncall(Field, Args).
+plawk_action_float_dyncall(printf(_Format, PrintfArgs), Args) :-
+    member(Field, PrintfArgs), plawk_expr_float_dyncall(Field, Args).
+plawk_action_float_dyncall(if(_Pattern, ThenActions, ElseActions), Args) :-
+    ( plawk_actions_float_dyncall(ThenActions, Args)
+    ; plawk_actions_float_dyncall(ElseActions, Args)
+    ).
+plawk_expr_float_dyncall(float_dyncall(Args), Args).
+plawk_expr_float_dyncall(Expr, Args) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_float_dyncall(Left, Args)
+    ; plawk_expr_float_dyncall(Right, Args)
+    ).
+
+plawk_actions_float_dyncall_at(Actions, Source, Args) :-
+    member(Action, Actions),
+    plawk_action_float_dyncall_at(Action, Source, Args).
+plawk_action_float_dyncall_at(add(_Var, Expr), S, A) :- plawk_expr_float_dyncall_at(Expr, S, A).
+plawk_action_float_dyncall_at(set(_Var, Expr), S, A) :- plawk_expr_float_dyncall_at(Expr, S, A).
+plawk_action_float_dyncall_at(print(Fields), S, A) :-
+    member(Field, Fields), plawk_expr_float_dyncall_at(Field, S, A).
+plawk_action_float_dyncall_at(printf(_Format, PrintfArgs), S, A) :-
+    member(Field, PrintfArgs), plawk_expr_float_dyncall_at(Field, S, A).
+plawk_action_float_dyncall_at(if(_Pattern, ThenActions, ElseActions), S, A) :-
+    ( plawk_actions_float_dyncall_at(ThenActions, S, A)
+    ; plawk_actions_float_dyncall_at(ElseActions, S, A)
+    ).
+plawk_expr_float_dyncall_at(float_dyncall_at(Source, Args), Source, Args).
+plawk_expr_float_dyncall_at(Expr, S, A) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_float_dyncall_at(Left, S, A)
+    ; plawk_expr_float_dyncall_at(Right, S, A)
     ).
 
 %% plawk_forin_end_plan(+Rules, +LoopVar, +ArrayName, +BodyActions, -AssocPlan, -PrintFields)
@@ -2728,6 +2901,12 @@ plawk_binfmt_f64_expr_ok(Descriptor, float_field(Index)) :-
     !,
     plawk_binfmt_field_type(Descriptor, Index, f64).
 plawk_binfmt_f64_expr_ok(_Descriptor, float_const(_Mantissa, _Denominator)) :- !.
+plawk_binfmt_f64_expr_ok(Descriptor, float_dyncall(Args)) :-
+    !,
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
+plawk_binfmt_f64_expr_ok(Descriptor, float_dyncall_at(_Source, Args)) :-
+    !,
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
 plawk_binfmt_f64_expr_ok(Descriptor, float_call(Name, Args)) :-
     !,
     atom(Name),
@@ -4841,6 +5020,28 @@ plawk_dyncall_at_expr(dyncall_at(Source, Args)) :-
     plawk_foreign_arg(Source),
     maplist(plawk_foreign_arg, Args).
 
+%% float(dyncall(...)) / float(dyncall_at(...)) -- double-returning
+%  runtime-object calls: the grammar's numeric output keeps its fraction.
+plawk_float_dyncall_expr(float_dyncall(Args)) :-
+    Args = [_ | _],
+    maplist(plawk_foreign_arg, Args).
+plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)) :-
+    plawk_foreign_arg(Source),
+    maplist(plawk_foreign_arg, Args).
+
+%% plawk_f64_call_tail_ir(+Base, +ResIR, +PreSetup, -ValueIR, -SetupParts)
+%  Shared {double,i1} call tail: unpack value/ok and select 0.0 on failure.
+plawk_f64_call_tail_ir(Base, ResIR, PreSetup, ValueIR, SetupParts) :-
+    format(atom(ValIR),
+        '  %~w_val = extractvalue { double, i1 } %~w_res, 0', [Base, Base]),
+    format(atom(OkIR),
+        '  %~w_ok = extractvalue { double, i1 } %~w_res, 1', [Base, Base]),
+    format(atom(SelIR),
+        '  %~w = select i1 %~w_ok, double %~w_val, double 0.0',
+        [Base, Base, Base]),
+    format(atom(ValueIR), '%~w', [Base]),
+    append(PreSetup, [ResIR, ValIR, OkIR, SelIR], SetupParts).
+
 plawk_foreign_arg(field(Index)) :-
     integer(Index),
     Index >= 0.
@@ -5074,6 +5275,10 @@ plawk_f64_scalar_read_operand_expr(float_field(Index)) :-
     Index >= 0.
 plawk_f64_scalar_read_operand_expr(float_call(Name, Args)) :-
     plawk_prolog_call_expr(prolog_call(Name, Args)).
+plawk_f64_scalar_read_operand_expr(float_dyncall(Args)) :-
+    plawk_float_dyncall_expr(float_dyncall(Args)).
+plawk_f64_scalar_read_operand_expr(float_dyncall_at(Source, Args)) :-
+    plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)).
 plawk_f64_scalar_read_operand_expr(Expr) :-
     plawk_i64_operand_expr(Expr).
 plawk_f64_scalar_read_operand_expr(Expr) :-
@@ -5582,6 +5787,8 @@ plawk_i64_binary_op_lines(LLVMOp, Base, LeftIR, RightIR, [Line]) :-
 plawk_expr_is_double(float_const(_Mantissa, _Denominator)).
 plawk_expr_is_double(float_field(_Index)).
 plawk_expr_is_double(float_call(_Name, _Args)).
+plawk_expr_is_double(float_dyncall(_Args)).
+plawk_expr_is_double(float_dyncall_at(_Source, _Args)).
 % A substituted read of a double scalar slot (see
 % plawk_substitute_scalar_reads/4).
 plawk_expr_is_double(ssa_f64(_Value)).
@@ -5607,6 +5814,10 @@ plawk_f64_operand_expr(float_field(Index)) :-
     Index >= 0.
 plawk_f64_operand_expr(float_call(Name, Args)) :-
     plawk_prolog_call_expr(prolog_call(Name, Args)).
+plawk_f64_operand_expr(float_dyncall(Args)) :-
+    plawk_float_dyncall_expr(float_dyncall(Args)).
+plawk_f64_operand_expr(float_dyncall_at(Source, Args)) :-
+    plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)).
 plawk_f64_operand_expr(Expr) :-
     plawk_i64_operand_expr(Expr).
 plawk_f64_operand_expr(Expr) :-
@@ -5643,6 +5854,36 @@ plawk_f64_expr_ir(float_field(Index), FieldSeparator, Base, _GlobalBase,
         [ValueIR, Index, FieldSeparator]).
 % float(name(args)): the double-returning foreign call. A failed call
 % contributes 0.0, mirroring the i64 prolog_call contract.
+plawk_f64_expr_ir(float_dyncall(Args), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    !,
+    length(Args, NArgs),
+    plawk_foreign_args_ir(Args, FieldSeparator, GlobalBase, ArgValueIRs,
+        GlobalParts, ArgSetupParts),
+    plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
+    format(atom(ResIR),
+        '  %~w_res = call { double, i1 } @plawk_dyncall_f_~w(~w)',
+        [Base, NArgs, CallArgsIR]),
+    plawk_f64_call_tail_ir(Base, ResIR, ArgSetupParts, ValueIR, SetupParts).
+plawk_f64_expr_ir(float_dyncall_at(Source, Args), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    !,
+    length(Args, NArgs),
+    plawk_dyncall_source_ir(Source, FieldSeparator, Base, GlobalBase,
+        PathPtrIR, PathLenIR, SrcGlobals, SrcSetup),
+    plawk_foreign_args_ir(Args, FieldSeparator, GlobalBase, ArgValueIRs,
+        ArgGlobals, ArgSetup),
+    ( ArgValueIRs == []
+    -> CallArgsSuffix = ''
+    ;  plawk_foreign_call_args_ir(ArgValueIRs, AV),
+       format(atom(CallArgsSuffix), ', ~w', [AV])
+    ),
+    format(atom(ResIR),
+        '  %~w_res = call { double, i1 } @plawk_dyncall_at_f_~w(i8* ~w, i64 ~w~w)',
+        [Base, NArgs, PathPtrIR, PathLenIR, CallArgsSuffix]),
+    append(SrcGlobals, ArgGlobals, GlobalParts),
+    append(SrcSetup, ArgSetup, PreSetup),
+    plawk_f64_call_tail_ir(Base, ResIR, PreSetup, ValueIR, SetupParts).
 plawk_f64_expr_ir(float_call(Name, Args), FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts) :-
     !,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1329,6 +1329,42 @@ float_literal_expr(float_const(Mantissa, Denominator)) -->
 %  fraction (an i64-context call would truncate the surface to
 %  integers). The float(...) wrapper is what selects the
 %  double-returning wrapper at codegen time.
+%
+%  float(dyncall(...)) / float(dyncall_at(...)) are the runtime-object
+%  variants: the loaded grammar's numeric output is read as a double.
+%  These must precede the generic clause, whose inner prolog_call_expr
+%  would otherwise parse `dyncall` as an ordinary identifier call.
+float_call_expr(float_dyncall_at(Source, Args)) -->
+    "float",
+    ws,
+    "(",
+    ws,
+    "dyncall_at",
+    ws,
+    "(",
+    ws,
+    foreign_arg(Source),
+    foreign_args_rest(Args),
+    ws,
+    ")",
+    ws,
+    ")",
+    !.
+float_call_expr(float_dyncall(Args)) -->
+    "float",
+    ws,
+    "(",
+    ws,
+    "dyncall",
+    ws,
+    "(",
+    ws,
+    foreign_args(Args),
+    ws,
+    ")",
+    ws,
+    ")",
+    !.
 float_call_expr(float_call(Name, Args)) -->
     "float",
     ws,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -20632,4 +20632,56 @@ fail:
   %f0 = insertvalue { i64, i1 } undef, i64 0, 0
   %f1 = insertvalue { i64, i1 } %f0, i1 false, 1
   ret { i64, i1 } %f1
+}
+
+; Double-returning variant of @wam_object_call_i64: the entry output cell
+; may bind to an Integer or a Float, and @value_to_double promotes either
+; to double. Returns { value, ok }; ok=false on failure or a non-numeric
+; binding. Same heap-save/arena-rewind discipline for constant memory.
+define { double, i1 } @wam_object_call_f64(%WamState* %vm, i32 %entry_pc, i32 %nargs, %Value* %args, i32 %out_reg) {
+entry:
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+do_call:
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs_saved = load i32, i32* %hs_ptr
+  %unb = call %Value @value_unbound(i8* null)
+  %out_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %out_ref = call %Value @value_ref(i32 %out_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %entry_pc)
+  br label %argloop
+argloop:
+  %ai = phi i32 [ 0, %do_call ], [ %ai1, %argstep ]
+  %adone = icmp sge i32 %ai, %nargs
+  br i1 %adone, label %args_done, label %argstep
+argstep:
+  %aidx64 = sext i32 %ai to i64
+  %ap = getelementptr %Value, %Value* %args, i64 %aidx64
+  %av = load %Value, %Value* %ap
+  call void @wam_set_reg(%WamState* %vm, i32 %ai, %Value %av)
+  %ai1 = add i32 %ai, 1
+  br label %argloop
+args_done:
+  call void @wam_set_reg(%WamState* %vm, i32 %out_reg, %Value %out_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %read_out, label %rewind_fail
+read_out:
+  %out = call %Value @wam_deref_value(%WamState* %vm, %Value %out_ref)
+  %out_is_num = call i1 @value_is_number(%Value %out)
+  br i1 %out_is_num, label %good, label %rewind_fail
+good:
+  %fval = call double @value_to_double(%Value %out)
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  %g0 = insertvalue { double, i1 } undef, double %fval, 0
+  %g1 = insertvalue { double, i1 } %g0, i1 true, 1
+  ret { double, i1 } %g1
+rewind_fail:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  br label %fail
+fail:
+  %f0 = insertvalue { double, i1 } undef, double 0.0, 0
+  %f1 = insertvalue { double, i1 } %f0, i1 false, 1
+  ret { double, i1 } %f1
 }').

--- a/tests/test_plawk_dyncall_float.pl
+++ b/tests/test_plawk_dyncall_float.pl
@@ -1,0 +1,141 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Phase 5 (JIT): float-returning runtime-object calls. float(dyncall(...))
+% and float(dyncall_at(...)) read the loaded grammar's numeric output as a
+% double via @wam_object_call_f64 (@value_to_double), keeping fractions
+% that the i64 form would lose -- or, for a Float-typed output, that the
+% i64 form cannot read at all (it demands an Integer).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammars whose output is a Float (division yields float in eval)
+half(X, R) :- R is X / 2.       % 7 -> 3.5   (dyncall, binary i64 arg)
+threehalf(R) :- R is 7 / 2.     % -> 3.5     (dyncall_at, nullary)
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_float).
+
+% float(dyncall(...)) / float(dyncall_at(...)) parse to their own nodes.
+test(float_dyncall_forms_parse) :-
+    plawk_parse_string("{ s += float(dyncall($1)) }\nEND { print s }\n",
+        program(_, [rule(_, A1)], _)),
+    memberchk(add(var(s), float_dyncall([field(1)])), A1),
+    plawk_parse_string("{ s += float(dyncall_at($1)) }\nEND { print s }\n",
+        program(_, [rule(_, A2)], _)),
+    memberchk(add(var(s), float_dyncall_at(field(1), [])), A2),
+    !.
+
+test(float_arities_collected) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"g.wamo\" }\n\c
+         { s += float(dyncall($1)) }\nEND { print s }\n",
+        Program),
+    plawk_program_dyncall_float_arities(Program, FArities),
+    assertion(FArities == [1]),
+    !.
+
+% float(dyncall($1)) reads a Float grammar output and keeps the fraction.
+test(float_dyncall_keeps_fraction, [condition(clang_available)]) :-
+    f_dir(Dir),
+    directory_file_path(Dir, 'half.wamo', Wamo),
+    write_wam_object([user:half/2], [wamo_entry(half/2)], Wamo),
+    binfmt_dynload_src(Wamo, "s += float(dyncall($1))", Src),
+    build_prog(Dir, 'pf.plawk', 'pf', Src, Bin),
+    write_i64(Dir, 'seven.bin', 7),
+    directory_file_path(Dir, 'seven.bin', Input),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "3.5\n"),
+    !.
+
+% The i64 form of the SAME grammar returns 0: a Float output fails the
+% integer read. This is why the float form is needed.
+test(i64_dyncall_of_float_output_is_zero, [condition(clang_available)]) :-
+    f_dir(Dir),
+    directory_file_path(Dir, 'half.wamo', Wamo),
+    ( exists_file(Wamo) -> true ; write_wam_object([user:half/2], [wamo_entry(half/2)], Wamo) ),
+    binfmt_dynload_src(Wamo, "s += dyncall($1)", Src),
+    build_prog(Dir, 'pi.plawk', 'pi', Src, Bin),
+    ( exists_file_in(Dir, 'seven.bin') -> true ; write_i64(Dir, 'seven.bin', 7) ),
+    directory_file_path(Dir, 'seven.bin', Input),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "0\n"),
+    !.
+
+% float(dyncall_at(...)) over a dynamic source, text mode: a nullary Float
+% grammar chosen by a filename column.
+test(float_dyncall_at_keeps_fraction, [condition(clang_available)]) :-
+    f_dir(Dir),
+    directory_file_path(Dir, 'threehalf.wamo', Wamo),
+    write_wam_object([user:threehalf/1], [wamo_entry(threehalf/1)], Wamo),
+    build_prog(Dir, 'pat.plawk', 'pat',
+        "{ w += float(dyncall_at($1)) }\nEND { print w }\n", Bin),
+    directory_file_path(Dir, 'in.txt', Input),
+    setup_call_cleanup(
+        open(Input, write, S, [encoding(utf8)]),
+        format(S, "~w~n", [Wamo]),
+        close(S)),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "3.5\n"),
+    !.
+
+:- end_tests(plawk_dyncall_float).
+
+% --- helpers ---------------------------------------------------------------
+
+f_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_dyncall_float', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+exists_file_in(Dir, Name) :-
+    directory_file_path(Dir, Name, Path), exists_file(Path).
+
+binfmt_dynload_src(Wamo, Body, Src) :-
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n{ ~w }\nEND { print s }\n",
+        [Wamo, Body]).
+
+build_prog(Dir, ProgName, BinName, Src, Bin) :-
+    directory_file_path(Dir, ProgName, Prog),
+    setup_call_cleanup(
+        open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src),
+        close(S)),
+    directory_file_path(Dir, BinName, Bin),
+    cli([build, Prog, '-o', Bin], _, 0).
+
+write_i64(Dir, Name, V) :-
+    directory_file_path(Dir, Name, Path),
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(between(0, 7, I),
+            ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )),
+        close(Out)).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(null), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
Completes the i64/float symmetry the compiled foreign bridge already has:
`dyncall`/`dyncall_at` read the entry output as `i64`; **`float(dyncall(...))`
and `float(dyncall_at(...))` read it as a `double`** — mirroring
`float(name(args))` for compiled predicates.

### What lands
- **Native primitive** `@wam_object_call_f64` (like `@wam_object_call_i64`
  but reads via `@value_is_number` + `@value_to_double`), emitted alongside
  `call_i64` under `emit_wamo_loader(true)`.
- **Parser**: `float(dyncall(...))` / `float(dyncall_at(...))` → their own
  nodes, placed before the generic `float_call` clause (whose inner
  `prolog_call_expr` would otherwise parse `dyncall` as an ordinary
  identifier).
- **Codegen**: the float variants join the f64 expression path (is-double,
  operand, scalar-read, binfmt-ok, and the f64 emitter, reusing the
  `dyncall_at` source marshalling). One `@plawk_dyncall_f_N` /
  `@plawk_dyncall_at_f_N` shim per arity delegates to `@wam_object_call_f64`;
  they **share** the DYNLOAD handle and the `dyncall_at` path cache with
  the i64 shims. CLI enables `emit_wamo_loader` for any float variant.

### Why it matters
A grammar whose output is a **Float** (e.g. `R is X / 2`, since runtime `/`
yields float) is **unreadable by the integer form** — `@wam_object_call_i64`
demands tag=1 and returns 0. The float form is required to read it, and
also lifts an integer result into the f64 lane for plawk float math.

### Tests — `tests/test_plawk_dyncall_float.pl` (5)
Parse + float-arity collection, and clang-gated: for `half(X,R):-R is X/2`
with input 7, `dyncall($1)` yields **0** while `float(dyncall($1))` yields
**3.5**; `float(dyncall_at($1))` does the same over a dynamic source.
Design doc + README updated.

(Note: float *constants* in a grammar remain outside the loadable subset —
a grammar reaches a Float via computation, not a literal. Lifting that is a
separate subset-extension slice.)

Stacks on #3465 (`dyncall_at`), which is on the designated branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_