### PR TITLE
plawk/JIT (roadmap #1): float constants in the loadable WAM object subset

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -400,9 +400,14 @@ runtime `/` yields float) is **unreadable by the integer form**, which
 demands tag=1 and returns 0. `tests/test_plawk_dyncall_float.pl` pins the
 contrast: for a `half(X,R):-R is X/2` grammar and input 7, `dyncall($1)`
 yields `0` while `float(dyncall($1))` yields `3.5`; `float(dyncall_at($1))`
-does the same over a dynamic source. (Float *constants* in a grammar are
-still outside the loadable subset — a grammar reaches a Float via
-computation, not a literal, until that restriction is lifted.)
+does the same over a dynamic source.
+
+**Float constants in grammars (landed).** `put_constant`/`set_constant`
+now accept float literals, so a grammar may write one directly (`R is X *
+1.5`), not only reach a Float by computation. The object stores the float's
+decimal text (C-string table, reloc class `float`) and the loader `strtod`s
+it, reproducing the exact double the AOT `bitcast` would. `scale(3)` via
+`float(dyncall($1))` yields `4.5`.
 
 ## Why not a real DCG engine in the loop?
 

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -36,23 +36,21 @@ Items 1–3 are largely independent; the ordering reflects value-per-effort
 and the fact that each earlier item feeds the later ones. Items 4–5 have
 real dependencies on the earlier subset work.
 
-### 1. Lift float constants into the loadable subset — *small, quick win*
+### 1. Lift float constants into the loadable subset — *LANDED*
 
-**What:** allow a grammar clause like `scale(X, R) :- R is X * 1.5` (a
-`float` constant, tag 2) to compile into a `.wamo`. Today `write_wam_object`
-rejects float literals; the object encoding for `get`/`put`/`set_constant`
-already has a tag lane and `set_constant_literal_parts` knows how to emit a
-`bitcast (double c to i64)`, so this is mostly relaxing the writer's
-`wamo_const` guard and carrying the float payload through the relocation
-(no relocation needed — a float constant is self-contained).
+**What:** a grammar clause like `scale(X, R) :- R is X * 1.5` (a `float`
+constant, tag 2) now compiles into a `.wamo`. `put_constant`/`set_constant`
+accept floats (matching AOT `set_constant_literal_parts`); the object stores
+the float's decimal text in the C-string table (reloc class `float`, id 3)
+and the loader `strtod`s it at load, writing the i64 bit pattern into op1 —
+the same double the AOT `bitcast (double c to i64)` yields.
+`get_constant`/`unify_constant` stay integer/atom only (AOT never emits a
+float there). Verified: `scale(3)` via `float(dyncall($1))` yields `4.5`.
 
-**Why:** `float(dyncall(...))` (just landed) makes float-returning grammars
-first-class, but a grammar can currently only *reach* a Float by
-computation (`R is X / 2`), not by writing one (`R is X * 1.5`). This closes
-that gap. It is also the first, smallest step of the subset expansion that
-item 5 (source-eval) ultimately needs.
-
-**Effort:** small. **Depends on:** nothing.
+**Why:** `float(dyncall(...))` made float-returning grammars first-class, but
+a grammar could only *reach* a Float by computation (`R is X / 2`), not by
+writing one. This closes that gap and is the first step of the subset
+expansion that item 5 (source-eval) needs.
 
 ### 2. Binary-data returns — opaque bytes — *moderate, high value*
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -19962,12 +19962,17 @@ build_llvm_arg_setup(Arity, Setup) :-
 %                  get/put_structure unification correct (functor comparison
 %                  is by pointer); arithmetic is content-based so the copy is
 %                  also fine for `is`/comparison operators.
+%     3 float    - op1 is an index into the C-string table (shared with
+%                  functor names); the loader strtod's the stored decimal
+%                  text and writes its i64 bit pattern into op1 -- the same
+%                  double the AOT `bitcast (double c to i64)` yields. Used by
+%                  put_constant / set_constant with a tag=2 float literal.
 %
 % call/execute/try_me_else/retry_me_else operands are indexes into the
 % object's OWN labels array -- @wam_label_pc reads the VM's installed labels
 % array, so they are already self-relative. builtin_call ids are host-stable
-% per UnifyWeaver version. Float constants (tag 2), switch-on-constant tables
-% and call/N meta-calls are outside slice 1 and rejected at write time.
+% per UnifyWeaver version. switch-on-constant tables and call/N meta-calls
+% are still outside the loadable subset and rejected at write time.
 
 %% write_wam_object(+Predicates, +Options, +OutFile) is det.
 %
@@ -20067,24 +20072,26 @@ wamo_encode_step(LabelMap, Parts, ws(E0, A0, F0), ws([Enc|E0], A1, F1)) :-
 %  Encode one parsed WAM instruction into the object's triple form,
 %  threading the atom (A) and functor (F) interning tables.
 
-% constants
-wamo_enc(["get_constant", C, Ai], _, A0, A1, F, F, enc(0, Op1, Op2, R)) :- !,
+% constants. put_constant / set_constant support float literals (tag 2),
+% matching AOT set_constant_literal_parts; get_constant / unify_constant
+% stay integer/atom only (AOT itself never emits a float there).
+wamo_enc(["get_constant", C, Ai], _, A0, A1, F0, F1, enc(0, Op1, Op2, R)) :- !,
     clean_comma(C, CC), clean_comma(Ai, CAi),
     atom_string(CAiA, CAi), reg_name_to_index(CAiA, Reg),
-    wamo_const(CC, A0, A1, Op1, Tag, R),
+    wamo_const(no_float, CC, A0, A1, F0, F1, Op1, Tag, R),
     Op2 is (Tag << 16) \/ Reg.
-wamo_enc(["unify_constant", C], _, A0, A1, F, F, enc(7, Op1, Op2, R)) :- !,
+wamo_enc(["unify_constant", C], _, A0, A1, F0, F1, enc(7, Op1, Op2, R)) :- !,
     clean_comma(C, CC),
-    wamo_const(CC, A0, A1, Op1, Tag, R),
+    wamo_const(no_float, CC, A0, A1, F0, F1, Op1, Tag, R),
     Op2 is Tag << 16.
-wamo_enc(["put_constant", C, Ai], _, A0, A1, F, F, enc(8, Op1, Op2, R)) :- !,
+wamo_enc(["put_constant", C, Ai], _, A0, A1, F0, F1, enc(8, Op1, Op2, R)) :- !,
     clean_comma(C, CC), clean_comma(Ai, CAi),
     atom_string(CAiA, CAi), reg_name_to_index(CAiA, Reg),
-    wamo_const(CC, A0, A1, Op1, Tag, R),
+    wamo_const(float, CC, A0, A1, F0, F1, Op1, Tag, R),
     Op2 is (Tag << 16) \/ Reg.
-wamo_enc(["set_constant", C], _, A0, A1, F, F, enc(15, Op1, Tag, R)) :- !,
+wamo_enc(["set_constant", C], _, A0, A1, F0, F1, enc(15, Op1, Tag, R)) :- !,
     clean_comma(C, CC),
-    wamo_const(CC, A0, A1, Op1, Tag, R).
+    wamo_const(float, CC, A0, A1, F0, F1, Op1, Tag, R).
 
 % structures
 wamo_enc(["get_structure", FN, Ai], _, A, A, F0, F1, enc(3, Idx, Op2, functor)) :- !,
@@ -20159,22 +20166,33 @@ wamo_enc(Parts, _, _, _, _, _, _) :-
         context(write_wam_object,
             'instruction is outside the loadable WAM object subset'))).
 
-%% wamo_const(+Str, +A0, -A1, -Op1, -Tag, -Reloc)
-%  Encode a constant operand. Integers embed directly (Tag=1, no reloc);
-%  atoms intern into the object atom table (Tag=0, reloc=atom, Op1=index);
-%  floats are rejected (slice 1).
-wamo_const(CC, A0, A1, Op1, Tag, R) :-
+%% wamo_const(+AllowFloat, +Str, +A0, -A1, +F0, -F1, -Op1, -Tag, -Reloc)
+%  Encode a constant operand:
+%    integer      -> Tag=1, Op1=value, reloc=none.
+%    atom         -> Tag=0, reloc=atom, Op1=atom-table index (re-interned
+%                    by the loader).
+%    float        -> Tag=2, reloc=float, Op1=index into the C-string table
+%                    (shared with functor names); the loader strtod's the
+%                    stored decimal text and stores its i64 bit pattern.
+%                    Only when AllowFloat==float (put_constant/set_constant,
+%                    matching AOT); elsewhere a float is rejected.
+%  The decimal text is stored verbatim so strtod reproduces exactly the
+%  double the AOT `bitcast (double <c> to i64)` would have.
+wamo_const(AllowFloat, CC, A0, A1, F0, F1, Op1, Tag, R) :-
     (   number_string(N, CC)
     ->  (   integer(N)
-        ->  Op1 = N, Tag = 1, R = none, A1 = A0
+        ->  Op1 = N, Tag = 1, R = none, A1 = A0, F1 = F0
+        ;   AllowFloat == float
+        ->  tab_intern(CC, F0, Idx, F1),
+            Op1 = Idx, Tag = 2, R = float, A1 = A0
         ;   throw(error(wamo_unsupported(float_constant(CC)),
                 context(write_wam_object,
-                    'float constants are not in slice 1')))
+                    'float constants are only supported in put_constant / set_constant')))
         )
     ;   strip_quoted_atom(CC, Inner),
         wamo_to_string(Inner, InnerStr),
         tab_intern(InnerStr, A0, Idx, A1),
-        Op1 = Idx, Tag = 0, R = atom
+        Op1 = Idx, Tag = 0, R = atom, F1 = F0
     ).
 
 %% wamo_structure(+FN, +Ai, +F0, -F1, -FunctorIdx, -Op2)
@@ -20211,6 +20229,7 @@ wamo_label(CP, LabelMap, Idx) :-
 wamo_reloc_id(none, 0).
 wamo_reloc_id(atom, 1).
 wamo_reloc_id(functor, 2).
+wamo_reloc_id(float, 3).
 
 wamo_serialize(EntryIndex, Atoms, Functors, PCs, EncInstrs, Codes) :-
     length(Atoms, NA), length(Functors, NF),
@@ -20541,14 +20560,26 @@ patch_atom:
   br label %cstore
 chk_functor:
   %is_fun = icmp eq i64 %reloc, 2
-  br i1 %is_fun, label %patch_fun, label %cstore
+  br i1 %is_fun, label %patch_fun, label %chk_float
 patch_fun:
   %fp_slot = getelementptr i8*, i8** %funPtrs, i64 %op1
   %fp = load i8*, i8** %fp_slot
   %fpi = ptrtoint i8* %fp to i64
   br label %cstore
+chk_float:
+  %is_float = icmp eq i64 %reloc, 3
+  br i1 %is_float, label %patch_float, label %cstore
+patch_float:
+  ; float constant: op1 indexes the C-string table (shared with functor
+  ; names); parse the decimal text with strtod and store the i64 bit
+  ; pattern -- the same double the AOT `bitcast (double c to i64)` yields.
+  %flp_slot = getelementptr i8*, i8** %funPtrs, i64 %op1
+  %flp = load i8*, i8** %flp_slot
+  %fld = call double @strtod(i8* %flp, i8** null)
+  %flbits = bitcast double %fld to i64
+  br label %cstore
 cstore:
-  %op1_final = phi i64 [ %aid_p, %patch_atom ], [ %fpi, %patch_fun ], [ %op1, %chk_functor ]
+  %op1_final = phi i64 [ %aid_p, %patch_atom ], [ %fpi, %patch_fun ], [ %flbits, %patch_float ], [ %op1, %chk_float ]
   %tag32 = trunc i64 %tag64 to i32
   %ip = getelementptr %Instruction, %Instruction* %code, i64 %ci
   %ip_tag = getelementptr %Instruction, %Instruction* %ip, i32 0, i32 0

--- a/tests/test_plawk_dyncall_float.pl
+++ b/tests/test_plawk_dyncall_float.pl
@@ -18,6 +18,7 @@
 % grammars whose output is a Float (division yields float in eval)
 half(X, R) :- R is X / 2.       % 7 -> 3.5   (dyncall, binary i64 arg)
 threehalf(R) :- R is 7 / 2.     % -> 3.5     (dyncall_at, nullary)
+scale(X, R) :- R is X * 1.5.    % 3 -> 4.5   (float LITERAL in the grammar)
 
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
@@ -87,6 +88,20 @@ test(float_dyncall_at_keeps_fraction, [condition(clang_available)]) :-
         close(S)),
     run_bin(Bin, [Input], Out, 0),
     assertion(Out == "3.5\n"),
+    !.
+
+% A grammar with a float LITERAL (R is X * 1.5) now compiles into a .wamo
+% (the loader strtod's the stored decimal text). scale(3) = 4.5.
+test(float_literal_grammar_runs, [condition(clang_available)]) :-
+    f_dir(Dir),
+    directory_file_path(Dir, 'scale.wamo', Wamo),
+    write_wam_object([user:scale/2], [wamo_entry(scale/2)], Wamo),
+    binfmt_dynload_src(Wamo, "s += float(dyncall($1))", Src),
+    build_prog(Dir, 'ps.plawk', 'ps', Src, Bin),
+    write_i64(Dir, 'three.bin', 3),
+    directory_file_path(Dir, 'three.bin', Input),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "4.5\n"),
     !.
 
 :- end_tests(plawk_dyncall_float).

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -43,11 +43,16 @@ test(encode_produces_well_formed_stream) :-
     Parts = ["WAMO", "1", "0" | _],
     !.
 
-% call/N meta-calls, float constants and switch-on-constant tables are
-% outside slice 1 -- the writer rejects them loudly.
-test(float_constant_is_rejected,
-        [throws(error(wamo_unsupported(float_constant(_)), _))]) :-
-    wam_object_encode([user:uses_float/1], [wamo_entry(uses_float/1)], _).
+% Float constants now compile in put/set_constant: the object carries the
+% decimal text (in the C-string table) and the loader strtod's it. uses_float
+% (X is 1.5 + 2.5) reaches both floats through set_constant.
+test(float_constant_compiles) :-
+    wam_object_encode([user:uses_float/1], [wamo_entry(uses_float/1)], Codes),
+    string_codes(Text, Codes),
+    sub_string(Text, 0, 4, _, "WAMO"),
+    sub_string(Text, _, _, _, "1.5"),
+    sub_string(Text, _, _, _, "2.5"),
+    !.
 
 % A requested entry predicate with no label is a hard error.
 test(missing_entry_is_rejected,


### PR DESCRIPTION
**Roadmap item 1.** A loadable grammar may now *write* a float literal
(`scale(X,R) :- R is X * 1.5`), not only reach a Float by computation
(`R is X / 2`). This completes what `float(dyncall(...))` set up.

### What lands
- `put_constant`/`set_constant` accept floats (matching AOT
  `set_constant_literal_parts`); `get_constant`/`unify_constant` stay
  integer/atom only (AOT never emits a float there).
- `wamo_const/9` gains an `AllowFloat` flag. A float interns its **decimal
  text** into the C-string table (shared with functor names) as a new
  reloc class **`float` (id 3)**, Tag=2.
- **Loader**: `reloc==3` → `strtod` the stored decimal text and write the
  i64 bit pattern into `op1` — the same double the AOT `bitcast (double c
  to i64)` yields (`@strtod` already declared). Text is stored verbatim so
  `strtod` reproduces the exact double.

### Tests
- `test_wam_object`: the old `float_constant_is_rejected` becomes
  `float_constant_compiles` — `uses_float` (`X is 1.5 + 2.5`) now encodes,
  and the stream carries `1.5`/`2.5`.
- `test_plawk_dyncall_float`: new `float_literal_grammar_runs` — `scale(3)`
  via `float(dyncall($1))` yields **4.5**.
- Regression: all dyncall / dyncall_at / wam_object suites green.

Roadmap + DCG-readers design docs updated (item 1 marked landed). Stacks on
the designated branch (roadmap doc #3468 merged). Next up: roadmap item 2,
binary-data returns (opaque bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_