### PR TITLE
plawk/JIT (roadmap #2): binary-data returns, opaque bytes (blob(dyncall...))

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -52,28 +52,30 @@ a grammar could only *reach* a Float by computation (`R is X / 2`), not by
 writing one. This closes that gap and is the first step of the subset
 expansion that item 5 (source-eval) needs.
 
-### 2. Binary-data returns — opaque bytes — *moderate, high value*
+### 2. Binary-data returns — opaque bytes — *LANDED (print position)*
 
-**What:** let a grammar return a **byte string**, read by a new
-`blob(dyncall(...))` / `blob(dyncall_at(...))` form. The grammar binds its
-output to an Atom whose interned string is the payload (atoms in this
-runtime are byte strings); a `@wam_object_call_bytes` primitive checks the
-output tag is Atom, reads `@wam_atom_to_string` + length, and returns
-`{ i8* ptr, i64 len, i1 ok }`. The atom lives in the (persistent) atom
-table, so the pointer survives the arena rewind. In plawk the result is a
-byte **slice** — exactly the `%WamSlice` (ptr,len) shape that
-`llvm_emit_atom_field_slice` already produces — so it plugs into the
-existing consumers: `print` (`%.*s`), `writebin` into an `sN`/`lpsN` slot,
-equality guards, assoc keys.
+**What:** a grammar returns a **byte string** (its entry binds the output
+to an Atom, a byte string here), read by `blob(dyncall(...))` /
+`blob(dyncall_at(...))`. The `@wam_object_call_bytes` primitive checks the
+output tag is Atom, reads `@wam_atom_to_string` + `strlen`, and returns
+`{ i8* ptr, i64 len, i1 ok }` — the pointer is into the persistent atom
+table, so it survives the arena rewind. In plawk the result is a byte
+**slice** (`%Base_ptr`/`%Base_len`), printed via `%.*s` (empty on
+failure). `blob(dyncall($1))` echoing a text field, and
+`blob(dyncall_at($1))` over a dynamic source returning `hello`, both
+verified. NUL-free by the blob convention. Also lifted `jump` (tag 32, a
+self-relative label) into the loadable subset so if-then-else grammars
+compile.
 
-**Why:** this is the "binary data return" you raised, in its
-**no-deserialization** form — the bytes are opaque to plawk, consumed as a
-string/blob. It opens grammars that *emit* encoded or textual output (a
-formatter, an encoder, a template filler) rather than a single number. It
-reuses the slice machinery, so it's mostly a new call primitive + surface,
-not new consumer code. It is also the foundation for item 4.
+**Why:** the "binary data return" in its **no-deserialization** form — the
+bytes are opaque, consumed as a string/blob. Opens grammars that *emit*
+encoded/textual output rather than a single number, and is the foundation
+for item 4.
 
-**Effort:** moderate. **Depends on:** nothing (independent of item 1).
+**Still to do within item 2:** the slice currently plugs into `print`;
+`writebin` into an `sN`/`lpsN` slot, equality guards, and assoc keys reuse
+the same `(ptr,len)` shape and are the natural follow-on (each needs the
+blob node wired into that consumer's path).
 
 ### 3. Multi-entry objects — *moderate, ergonomics*
 

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -410,7 +410,11 @@ definition takes effect with no rebuild (query/userspace redefinition);
 `float(dyncall(...))` / `float(dyncall_at(...))` read the grammar's output
 as a double (keeping fractions), mirroring `float(name(args))` for
 compiled predicates — needed when a grammar returns a Float (e.g.
-`R is X / 2`), which the integer form cannot read (it yields 0). Bounded repetition handles records containing a
+`R is X / 2`), which the integer form cannot read (it yields 0).
+`blob(dyncall(...))` / `blob(dyncall_at(...))` read an Atom output as
+**opaque bytes** (a byte slice) for `print` — a grammar that emits text or
+encoded output rather than a number, e.g.
+`{ print blob(dyncall($1)) }`. Bounded repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an
 ordinary i64 field, element slots are flat addressable fields

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -117,6 +117,8 @@ build(File, Out0, KeepLL) :-
         ; plawk_program_dyncall_at_arities(Program, DynAtArities), DynAtArities \== []
         ; plawk_program_dyncall_float_arities(Program, DynFArities), DynFArities \== []
         ; plawk_program_dyncall_at_float_arities(Program, DynAtFArities), DynAtFArities \== []
+        ; plawk_program_dyncall_blob_arities(Program, DynBArities), DynBArities \== []
+        ; plawk_program_dyncall_at_blob_arities(Program, DynAtBArities), DynAtBArities \== []
         )
     ->  ProjectOptions = [module_name(OutBase), emit_wamo_loader(true)]
     ;   ProjectOptions = [module_name(OutBase)]

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -10,6 +10,8 @@
     plawk_program_dyncall_at_arities/2,
     plawk_program_dyncall_float_arities/2,
     plawk_program_dyncall_at_float_arities/2,
+    plawk_program_dyncall_blob_arities/2,
+    plawk_program_dyncall_at_blob_arities/2,
     plawk_program_dyncache_mode/2,
     plawk_program_dynload_path/2,
     plawk_prolog_block_preds/2
@@ -624,13 +626,17 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_dyncall_at_arities(Program, DynAtArities),
     plawk_program_dyncall_float_arities(Program, DynFArities),
     plawk_program_dyncall_at_float_arities(Program, DynAtFArities),
+    plawk_program_dyncall_blob_arities(Program, DynBArities),
+    plawk_program_dyncall_at_blob_arities(Program, DynAtBArities),
     (   GuardSpecs == [],
         CallSpecs == [],
         FCallSpecs == [],
         DynArities == [],
         DynAtArities == [],
         DynFArities == [],
-        DynAtFArities == []
+        DynAtFArities == [],
+        DynBArities == [],
+        DynAtBArities == []
     ->  plawk_program_native_driver_ir(Program, InputPath, DriverIR)
     ;   % Compiled-foreign support (shared VM + per-predicate wrappers)
         % only when the program actually calls a compiled predicate; it
@@ -641,9 +647,9 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
             plawk_foreign_support_ir(GuardSpecs, CallSpecs, FCallSpecs,
                 InstrCount, LabelCount, ForeignSupportIR)
         ),
-        % Object-call shims for dyncall(...) / float(dyncall(...)) sites,
-        % plus the lazily loaded .wamo object handle they share.
-        (   DynArities == [], DynFArities == []
+        % Object-call shims for dyncall(...) / float(dyncall(...)) /
+        % blob(dyncall(...)) sites, plus the shared .wamo object handle.
+        (   DynArities == [], DynFArities == [], DynBArities == []
         ->  DyncallSupportIR = ''
         ;   ( plawk_program_dynload_path(Program, DynPath)
             ->  true
@@ -652,15 +658,15 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
                         'dyncall(...) requires BEGIN { DYNLOAD = "file.wamo" }')))
             ),
             plawk_dyncall_support_ir(DynPath, DynArities, DynFArities,
-                DyncallSupportIR)
+                DynBArities, DyncallSupportIR)
         ),
-        % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...))
-        % sites + the shared path cache.
-        (   DynAtArities == [], DynAtFArities == []
+        % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...)) /
+        % blob(dyncall_at(...)) sites + the shared path cache.
+        (   DynAtArities == [], DynAtFArities == [], DynAtBArities == []
         ->  DyncallAtSupportIR = ''
         ;   plawk_program_dyncache_mode(Program, CacheMode),
             plawk_dyncall_at_support_ir(CacheMode, DynAtArities, DynAtFArities,
-                DyncallAtSupportIR)
+                DynAtBArities, DyncallAtSupportIR)
         ),
         plawk_program_native_driver_ir(Program, InputPath, MainIR),
         exclude(==(''),
@@ -1046,13 +1052,16 @@ fail:
 %  run -- the object-call primitive rewinds the arena per call, so this
 %  stays constant-memory just like the compiled foreign bridge.
 plawk_dyncall_support_ir(Path, Arities, IR) :-
-    plawk_dyncall_support_ir(Path, Arities, [], IR).
-
-%% plawk_dyncall_support_ir(+Path, +IArities, +FArities, -IR)
-%  IArities gets one i64 @plawk_dyncall_N shim each; FArities gets one
-%  double @plawk_dyncall_f_N shim each (float(dyncall(...))). Both share
-%  the single lazily loaded object handle + @plawk_dyncall_get.
+    plawk_dyncall_support_ir(Path, Arities, [], [], IR).
 plawk_dyncall_support_ir(Path, IArities, FArities, IR) :-
+    plawk_dyncall_support_ir(Path, IArities, FArities, [], IR).
+
+%% plawk_dyncall_support_ir(+Path, +IArities, +FArities, +BArities, -IR)
+%  IArities -> i64 @plawk_dyncall_N shims; FArities -> double
+%  @plawk_dyncall_f_N shims (float(dyncall(...))); BArities -> byte-slice
+%  @plawk_dyncall_b_N shims (blob(dyncall(...))). All share the single
+%  lazily loaded object handle + @plawk_dyncall_get.
+plawk_dyncall_support_ir(Path, IArities, FArities, BArities, IR) :-
     llvm_emit_c_string_global('plawk_dyncall_path', Path, PathGlobal,
         _StrLen, BytesLen),
     format(atom(GetterIR),
@@ -1084,7 +1093,10 @@ load:
     findall(FShimIR,
         ( member(FN, FArities), plawk_dyncall_shim_f_ir(FN, FShimIR) ),
         FShims),
-    append([[PathGlobal, GetterIR], IShims, FShims], Parts),
+    findall(BShimIR,
+        ( member(BN, BArities), plawk_dyncall_shim_b_ir(BN, BShimIR) ),
+        BShims),
+    append([[PathGlobal, GetterIR], IShims, FShims, BShims], Parts),
     atomic_list_concat(Parts, '\n\n', IR).
 
 % double-returning dyncall shim (float(dyncall(...))): same object handle,
@@ -1111,6 +1123,34 @@ fail:
   %f0 = insertvalue { double, i1 } undef, double 0.0, 0
   %f1 = insertvalue { double, i1 } %f0, i1 false, 1
   ret { double, i1 } %f1
+}',
+        [NArgs, ParamsIR, NArgs, StoreIR, NArgs, NArgs]).
+
+% byte-slice dyncall shim (blob(dyncall(...))): reads the object entry's
+% Atom output as { ptr, len, ok } via @wam_object_call_bytes.
+plawk_dyncall_shim_b_ir(NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define { i8*, i64, i1 } @plawk_dyncall_b_~w(~w) {
+entry:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %pc = load i32, i32* @plawk_dyncall_pc
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call { i8*, i64, i1 } @wam_object_call_bytes(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w)
+  ret { i8*, i64, i1 } %r
+
+fail:
+  %f0 = insertvalue { i8*, i64, i1 } undef, i8* null, 0
+  %f1 = insertvalue { i8*, i64, i1 } %f0, i64 0, 1
+  %f2 = insertvalue { i8*, i64, i1 } %f1, i1 false, 2
+  ret { i8*, i64, i1 } %f2
 }',
         [NArgs, ParamsIR, NArgs, StoreIR, NArgs, NArgs]).
 
@@ -1168,28 +1208,37 @@ plawk_dyncall_store_lines(NArgs, Lines) :-
 %  Cache capacity is 64 distinct grammars; beyond that "on"/"mtime" load
 %  without caching (correct, just not reused).
 plawk_dyncall_at_support_ir(Mode, Arities, IR) :-
-    plawk_dyncall_at_support_ir(Mode, Arities, [], IR).
-
-%% plawk_dyncall_at_support_ir(+Mode, +IArities, +FArities, -IR)
-%  IArities gets i64 @plawk_dyncall_at_N shims; FArities gets double
-%  @plawk_dyncall_at_f_N shims (float(dyncall_at(...))). Both share the
-%  cache + @plawk_dyncall_at_get emitted per Mode.
+    plawk_dyncall_at_support_ir(Mode, Arities, [], [], IR).
 plawk_dyncall_at_support_ir(Mode, IArities, FArities, IR) :-
+    plawk_dyncall_at_support_ir(Mode, IArities, FArities, [], IR).
+
+%% plawk_dyncall_at_support_ir(+Mode, +IArities, +FArities, +BArities, -IR)
+%  IArities -> i64 @plawk_dyncall_at_N shims; FArities -> double
+%  @plawk_dyncall_at_f_N shims (float(dyncall_at(...))); BArities ->
+%  byte-slice @plawk_dyncall_at_b_N shims (blob(dyncall_at(...))). All
+%  share the cache + @plawk_dyncall_at_get emitted per Mode.
+plawk_dyncall_at_support_ir(Mode, IArities, FArities, BArities, IR) :-
     (   Mode == "off"
     ->  Globals = '', GetIR = '',
-        findall(S, ( member(N, IArities), plawk_dyncall_at_shim_off_ir(N, S) ), IShims),
-        findall(FS, ( member(FN, FArities), plawk_dyncall_at_shim_off_f_ir(FN, FS) ), FShims)
+        ICShim = plawk_dyncall_at_shim_off_ir,
+        FCShim = plawk_dyncall_at_shim_off_f_ir,
+        BCShim = plawk_dyncall_at_shim_off_b_ir
     ;   Mode == "mtime"
     ->  plawk_dyncache_globals_ir(mtime, Globals),
         plawk_dyncall_at_get_mtime_ir(GetIR),
-        findall(S, ( member(N, IArities), plawk_dyncall_at_shim_cached_ir(N, S) ), IShims),
-        findall(FS, ( member(FN, FArities), plawk_dyncall_at_shim_cached_f_ir(FN, FS) ), FShims)
+        ICShim = plawk_dyncall_at_shim_cached_ir,
+        FCShim = plawk_dyncall_at_shim_cached_f_ir,
+        BCShim = plawk_dyncall_at_shim_cached_b_ir
     ;   plawk_dyncache_globals_ir(plain, Globals),
         plawk_dyncall_at_get_on_ir(GetIR),
-        findall(S, ( member(N, IArities), plawk_dyncall_at_shim_cached_ir(N, S) ), IShims),
-        findall(FS, ( member(FN, FArities), plawk_dyncall_at_shim_cached_f_ir(FN, FS) ), FShims)
+        ICShim = plawk_dyncall_at_shim_cached_ir,
+        FCShim = plawk_dyncall_at_shim_cached_f_ir,
+        BCShim = plawk_dyncall_at_shim_cached_b_ir
     ),
-    append([[Globals, GetIR], IShims, FShims], Parts0),
+    findall(S,  ( member(N, IArities),  call(ICShim, N, S) ), IShims),
+    findall(FS, ( member(FN, FArities), call(FCShim, FN, FS) ), FShims),
+    findall(BS, ( member(BN, BArities), call(BCShim, BN, BS) ), BShims),
+    append([[Globals, GetIR], IShims, FShims, BShims], Parts0),
     exclude(==(''), Parts0, Parts),
     atomic_list_concat(Parts, '\n\n', IR).
 
@@ -1444,6 +1493,59 @@ fail:
 }',
         [NArgs, ParamsIR, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
 
+% byte-slice dyncall_at shims (blob(dyncall_at(...))): cached / off-mode
+% loads, reading the entry output as { ptr, len, ok }.
+plawk_dyncall_at_shim_cached_b_ir(NArgs, IR) :-
+    plawk_dyncall_at_params(NArgs, ParamsIR),
+    plawk_dyncall_at_argsetup(NArgs, ArgsPtrIR, ArgsSetupIR),
+    format(atom(IR),
+'define { i8*, i64, i1 } @plawk_dyncall_at_b_~w(~w) {
+entry:
+  %obj = call { %WamState*, i32 } @plawk_dyncall_at_get(i8* %path, i64 %len)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %pc = extractvalue { %WamState*, i32 } %obj, 1
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+~w
+  %r = call { i8*, i64, i1 } @wam_object_call_bytes(%WamState* %vm, i32 %pc, i32 ~w, %Value* ~w, i32 ~w)
+  ret { i8*, i64, i1 } %r
+
+fail:
+  %f0 = insertvalue { i8*, i64, i1 } undef, i8* null, 0
+  %f1 = insertvalue { i8*, i64, i1 } %f0, i64 0, 1
+  %f2 = insertvalue { i8*, i64, i1 } %f1, i1 false, 2
+  ret { i8*, i64, i1 } %f2
+}',
+        [NArgs, ParamsIR, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
+
+plawk_dyncall_at_shim_off_b_ir(NArgs, IR) :-
+    plawk_dyncall_at_params(NArgs, ParamsIR),
+    plawk_dyncall_at_argsetup(NArgs, ArgsPtrIR, ArgsSetupIR),
+    format(atom(IR),
+'define { i8*, i64, i1 } @plawk_dyncall_at_b_~w(~w) {
+entry:
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %pc = extractvalue { %WamState*, i32 } %obj, 1
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+~w
+  %r = call { i8*, i64, i1 } @wam_object_call_bytes(%WamState* %vm, i32 %pc, i32 ~w, %Value* ~w, i32 ~w)
+  call void @wam_state_free(%WamState* %vm)
+  ret { i8*, i64, i1 } %r
+
+fail:
+  %f0 = insertvalue { i8*, i64, i1 } undef, i8* null, 0
+  %f1 = insertvalue { i8*, i64, i1 } %f0, i64 0, 1
+  %f2 = insertvalue { i8*, i64, i1 } %f1, i1 false, 2
+  ret { i8*, i64, i1 } %f2
+}',
+        [NArgs, ParamsIR, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
+
 plawk_dyncall_at_params(0, 'i8* %path, i64 %len') :- !.
 plawk_dyncall_at_params(NArgs, ParamsIR) :-
     plawk_foreign_wrapper_params(NArgs, ValParams),
@@ -1481,6 +1583,59 @@ plawk_dyncall_source_ir(string(Str), _FieldSeparator, Base, _GlobalBase,
         'getelementptr ([~w x i8], [~w x i8]* @.~w, i32 0, i32 0)',
         [BytesLen, BytesLen, GName]),
     PathLenIR = StrLen.
+
+%% plawk_blob_expr_ir(+Expr, +FieldSeparator, +Base, -LenIR, -PtrIR,
+%%     -GlobalParts, -SetupParts)
+%  Emit a blob(dyncall(...)) / blob(dyncall_at(...)) byte-slice read: call
+%  the bytes shim ({ptr,len,ok}) and expose %Base_ptr (i8*) + %Base_len
+%  (i32), selecting null/0 on failure so a slice print of a failed call is
+%  empty.
+plawk_blob_expr_ir(blob_dyncall(Args), FieldSeparator, Base,
+        LenIR, PtrIR, GlobalParts, SetupParts) :-
+    length(Args, NArgs),
+    plawk_foreign_args_ir(Args, FieldSeparator, Base, ArgValueIRs,
+        GlobalParts, ArgSetup),
+    plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
+    format(atom(ResIR),
+        '  %~w_res = call { i8*, i64, i1 } @plawk_dyncall_b_~w(~w)',
+        [Base, NArgs, CallArgsIR]),
+    plawk_blob_tail_ir(Base, ResIR, ArgSetup, LenIR, PtrIR, SetupParts).
+plawk_blob_expr_ir(blob_dyncall_at(Source, Args), FieldSeparator, Base,
+        LenIR, PtrIR, GlobalParts, SetupParts) :-
+    length(Args, NArgs),
+    plawk_dyncall_source_ir(Source, FieldSeparator, Base, Base,
+        PathPtrIR, PathLenIR, SrcGlobals, SrcSetup),
+    plawk_foreign_args_ir(Args, FieldSeparator, Base, ArgValueIRs,
+        ArgGlobals, ArgSetup),
+    ( ArgValueIRs == []
+    -> CallArgsSuffix = ''
+    ;  plawk_foreign_call_args_ir(ArgValueIRs, AV),
+       format(atom(CallArgsSuffix), ', ~w', [AV])
+    ),
+    format(atom(ResIR),
+        '  %~w_res = call { i8*, i64, i1 } @plawk_dyncall_at_b_~w(i8* ~w, i64 ~w~w)',
+        [Base, NArgs, PathPtrIR, PathLenIR, CallArgsSuffix]),
+    append(SrcGlobals, ArgGlobals, GlobalParts),
+    append(SrcSetup, ArgSetup, PreSetup),
+    plawk_blob_tail_ir(Base, ResIR, PreSetup, LenIR, PtrIR, SetupParts).
+
+plawk_blob_tail_ir(Base, ResIR, PreSetup, LenIR, PtrIR, SetupParts) :-
+    format(atom(OkIR),
+        '  %~w_ok = extractvalue { i8*, i64, i1 } %~w_res, 2', [Base, Base]),
+    format(atom(RPtrIR),
+        '  %~w_rptr = extractvalue { i8*, i64, i1 } %~w_res, 0', [Base, Base]),
+    format(atom(RLenIR),
+        '  %~w_rlen = extractvalue { i8*, i64, i1 } %~w_res, 1', [Base, Base]),
+    format(atom(SelPtr),
+        '  %~w_ptr = select i1 %~w_ok, i8* %~w_rptr, i8* null', [Base, Base, Base]),
+    format(atom(SelLen),
+        '  %~w_len64 = select i1 %~w_ok, i64 %~w_rlen, i64 0', [Base, Base, Base]),
+    format(atom(TruncLen),
+        '  %~w_len = trunc i64 %~w_len64 to i32', [Base, Base]),
+    format(atom(PtrIR), '%~w_ptr', [Base]),
+    format(atom(LenIR), '%~w_len', [Base]),
+    append(PreSetup, [ResIR, OkIR, RPtrIR, RLenIR, SelPtr, SelLen, TruncLen],
+        SetupParts).
 
 plawk_dyncall_at_argsetup(0, 'null', '') :- !.
 plawk_dyncall_at_argsetup(NArgs, '%args', SetupIR) :-
@@ -1596,6 +1751,36 @@ plawk_expr_float_dyncall_at(Expr, S, A) :-
     ( plawk_expr_float_dyncall_at(Left, S, A)
     ; plawk_expr_float_dyncall_at(Right, S, A)
     ).
+
+%% blob(dyncall(...)) / blob(dyncall_at(...)) arity collectors -- one
+%  byte-slice shim per distinct call-arg count. blob only appears as a
+%  print/writebin field (not inside arithmetic), so the walkers scan
+%  print/printf fields directly.
+plawk_program_dyncall_blob_arities(program(_Begin, Rules, EndClauses), Arities) :-
+    findall(NArgs,
+        ( ( member(rule(_P, Actions), Rules) ; member(end(Actions), EndClauses) ),
+          member(Action, Actions),
+          plawk_action_blob_field(Action, blob_dyncall(Args)),
+          length(Args, NArgs)
+        ),
+        A0),
+    sort(A0, Arities).
+
+plawk_program_dyncall_at_blob_arities(program(_Begin, Rules, EndClauses), Arities) :-
+    findall(NArgs,
+        ( ( member(rule(_P, Actions), Rules) ; member(end(Actions), EndClauses) ),
+          member(Action, Actions),
+          plawk_action_blob_field(Action, blob_dyncall_at(_Source, Args)),
+          length(Args, NArgs)
+        ),
+        A0),
+    sort(A0, Arities).
+
+plawk_action_blob_field(print(Fields), Blob) :- member(Blob, Fields).
+plawk_action_blob_field(printf(_Format, PrintfArgs), Blob) :- member(Blob, PrintfArgs).
+plawk_action_blob_field(if(_Pattern, ThenActions, ElseActions), Blob) :-
+    ( member(A, ThenActions) ; member(A, ElseActions) ),
+    plawk_action_blob_field(A, Blob).
 
 %% plawk_forin_end_plan(+Rules, +LoopVar, +ArrayName, +BodyActions, -AssocPlan, -PrintFields)
 %
@@ -4962,6 +5147,10 @@ plawk_rule_body_print_field(Expr) :-
     plawk_dyncall_expr(Expr).
 plawk_rule_body_print_field(Expr) :-
     plawk_dyncall_at_expr(Expr).
+plawk_rule_body_print_field(blob_dyncall(Args)) :-
+    plawk_float_dyncall_expr(float_dyncall(Args)).   % same arg shape check
+plawk_rule_body_print_field(blob_dyncall_at(Source, Args)) :-
+    plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)).
 plawk_rule_body_print_field(Expr) :-
     plawk_f64_print_expr(Expr).
 plawk_rule_body_print_field(length(field(_))).
@@ -6970,6 +7159,19 @@ plawk_emit_print_expr_for_context(prolog_call(Name, Args), FieldSeparator, Conte
     plawk_i64_expr_ir(prolog_call(Name, Args), FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
 
+plawk_emit_print_expr_for_context(blob_dyncall(Args), FieldSeparator, Context,
+        slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, blob, Base),
+    plawk_print_expr_output_names(Context, blob, FmtPrefix, PrintPrefix),
+    plawk_blob_expr_ir(blob_dyncall(Args), FieldSeparator, Base,
+        LenIR, PtrIR, GlobalParts, SetupParts).
+plawk_emit_print_expr_for_context(blob_dyncall_at(Source, Args), FieldSeparator, Context,
+        slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, blob, Base),
+    plawk_print_expr_output_names(Context, blob, FmtPrefix, PrintPrefix),
+    plawk_blob_expr_ir(blob_dyncall_at(Source, Args), FieldSeparator, Base,
+        LenIR, PtrIR, GlobalParts, SetupParts).
+
 plawk_emit_print_expr_for_context(length(field(FieldIndex)), FieldSeparator, Context,
         i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
     plawk_print_expr_value_base(Context, length, Base),
@@ -7081,6 +7283,8 @@ plawk_normal_print_expr_value_base(length, Index, Base) :-
     format(atom(Base), 'plawk_length_~w', [Index]).
 plawk_normal_print_expr_value_base(substr, Index, Base) :-
     format(atom(Base), 'plawk_substr_~w', [Index]).
+plawk_normal_print_expr_value_base(blob, Index, Base) :-
+    format(atom(Base), 'plawk_blob_~w', [Index]).
 plawk_normal_print_expr_value_base(index, Index, Base) :-
     format(atom(Base), 'plawk_index_~w', [Index]).
 plawk_normal_print_expr_value_base(index_needle, Index, Base) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1147,6 +1147,9 @@ field_expr(Expr) -->
     float_call_expr(Expr),
     !.
 field_expr(Expr) -->
+    blob_call_expr(Expr),
+    !.
+field_expr(Expr) -->
     float_literal_expr(Expr),
     !.
 field_expr(Expr) -->
@@ -1373,6 +1376,43 @@ float_call_expr(float_call(Name, Args)) -->
     prolog_call_expr(prolog_call(Name, Args)),
     ws,
     ")".
+
+%% blob_call_expr(-Expr)//
+%
+%  blob(dyncall(...)) / blob(dyncall_at(...)): read the runtime grammar's
+%  Atom output as opaque bytes (a slice), for print / writebin positions.
+%  Reserved like the dyncall forms; the inner keyword disambiguates.
+blob_call_expr(blob_dyncall_at(Source, Args)) -->
+    "blob",
+    ws,
+    "(",
+    ws,
+    "dyncall_at",
+    ws,
+    "(",
+    ws,
+    foreign_arg(Source),
+    foreign_args_rest(Args),
+    ws,
+    ")",
+    ws,
+    ")",
+    !.
+blob_call_expr(blob_dyncall(Args)) -->
+    "blob",
+    ws,
+    "(",
+    ws,
+    "dyncall",
+    ws,
+    "(",
+    ws,
+    foreign_args(Args),
+    ws,
+    ")",
+    ws,
+    ")",
+    !.
 
 %% float_field_expr(-Expr)//
 %

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -20141,6 +20141,10 @@ wamo_enc(["try_me_else", L], LabelMap, A, A, F, F, enc(22, Idx, 0, none)) :- !,
     clean_comma(L, CL), lookup_label_index(CL, LabelMap, Idx).
 wamo_enc(["retry_me_else", L], LabelMap, A, A, F, F, enc(23, Idx, 0, none)) :- !,
     clean_comma(L, CL), lookup_label_index(CL, LabelMap, Idx).
+% jump L: unconditional branch (emitted by if-then-else to the continuation
+% after the then/else arm). Self-relative label index, like try_me_else.
+wamo_enc(["jump", L], LabelMap, A, A, F, F, enc(32, Idx, 0, none)) :- !,
+    clean_comma(L, CL), lookup_label_index(CL, LabelMap, Idx).
 
 % type-based dispatch: nop fallthrough (tag 26), matching the interpreter's
 % runtime semantics. The try_me_else / retry_me_else chain still runs, so
@@ -20715,4 +20719,65 @@ fail:
   %f0 = insertvalue { double, i1 } undef, double 0.0, 0
   %f1 = insertvalue { double, i1 } %f0, i1 false, 1
   ret { double, i1 } %f1
+}
+
+; Byte-string variant: the entry output cell must bind to an Atom whose
+; interned string is the payload (atoms are byte strings here; NUL-free by
+; the blob convention). Returns { ptr, len, ok } -- the pointer is into the
+; persistent atom table, so it survives the arena rewind. ok=false on
+; failure or a non-atom output.
+define { i8*, i64, i1 } @wam_object_call_bytes(%WamState* %vm, i32 %entry_pc, i32 %nargs, %Value* %args, i32 %out_reg) {
+entry:
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+do_call:
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs_saved = load i32, i32* %hs_ptr
+  %unb = call %Value @value_unbound(i8* null)
+  %out_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %out_ref = call %Value @value_ref(i32 %out_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %entry_pc)
+  br label %argloop
+argloop:
+  %ai = phi i32 [ 0, %do_call ], [ %ai1, %argstep ]
+  %adone = icmp sge i32 %ai, %nargs
+  br i1 %adone, label %args_done, label %argstep
+argstep:
+  %aidx64 = sext i32 %ai to i64
+  %ap = getelementptr %Value, %Value* %args, i64 %aidx64
+  %av = load %Value, %Value* %ap
+  call void @wam_set_reg(%WamState* %vm, i32 %ai, %Value %av)
+  %ai1 = add i32 %ai, 1
+  br label %argloop
+args_done:
+  call void @wam_set_reg(%WamState* %vm, i32 %out_reg, %Value %out_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %read_out, label %rewind_fail
+read_out:
+  %out = call %Value @wam_deref_value(%WamState* %vm, %Value %out_ref)
+  %out_tag = extractvalue %Value %out, 0
+  %out_is_atom = icmp eq i32 %out_tag, 0
+  br i1 %out_is_atom, label %good, label %rewind_fail
+good:
+  %aid = extractvalue %Value %out, 1
+  %sptr = call i8* @wam_atom_to_string(i64 %aid)
+  %sptr_null = icmp eq i8* %sptr, null
+  br i1 %sptr_null, label %rewind_fail, label %have_str
+have_str:
+  %slen = call i64 @strlen(i8* %sptr)
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  %g0 = insertvalue { i8*, i64, i1 } undef, i8* %sptr, 0
+  %g1 = insertvalue { i8*, i64, i1 } %g0, i64 %slen, 1
+  %g2 = insertvalue { i8*, i64, i1 } %g1, i1 true, 2
+  ret { i8*, i64, i1 } %g2
+rewind_fail:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  br label %fail
+fail:
+  %f0 = insertvalue { i8*, i64, i1 } undef, i8* null, 0
+  %f1 = insertvalue { i8*, i64, i1 } %f0, i64 0, 1
+  %f2 = insertvalue { i8*, i64, i1 } %f1, i1 false, 2
+  ret { i8*, i64, i1 } %f2
 }').

--- a/tests/test_plawk_dyncall_blob.pl
+++ b/tests/test_plawk_dyncall_blob.pl
@@ -1,0 +1,129 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Phase 5 (JIT) roadmap item 2: binary-data returns, opaque bytes. A
+% grammar whose entry binds its output to an Atom (a byte string) is read
+% as a byte slice by blob(dyncall(...)) / blob(dyncall_at(...)) via
+% @wam_object_call_bytes -- no deserialization, the bytes pass through to
+% a print (%.*s). NUL-free by the blob convention.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% atom-returning grammars
+echo(A, A).                                  % returns its input atom
+greeting(R) :- R = hello.                    % nullary, returns atom hello
+kind(X, R) :- ( X > 100 -> R = big ; R = small ).  % if-then-else -> jump
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_blob).
+
+% blob(dyncall(...)) / blob(dyncall_at(...)) parse to their own nodes.
+test(blob_forms_parse) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"g.wamo\" }\n{ print blob(dyncall($1)) }\n",
+        program(_, [rule(_, A1)], _)),
+    memberchk(print([blob_dyncall([field(1)])]), A1),
+    plawk_parse_string("{ print blob(dyncall_at($1)) }\n",
+        program(_, [rule(_, A2)], _)),
+    memberchk(print([blob_dyncall_at(field(1), [])]), A2),
+    !.
+
+test(blob_arities_collected) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"g.wamo\" }\n{ print blob(dyncall($1)) }\n",
+        Program),
+    plawk_program_dyncall_blob_arities(Program, BArities),
+    assertion(BArities == [1]),
+    !.
+
+% blob(dyncall($1)) reads the grammar's Atom output and prints its bytes:
+% echo/2 returns its input atom, so each line's field 1 is echoed.
+test(blob_dyncall_prints_bytes, [condition(clang_available)]) :-
+    blob_dir(Dir),
+    directory_file_path(Dir, 'echo.wamo', Wamo),
+    write_wam_object([user:echo/2], [wamo_entry(echo/2)], Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n{ print blob(dyncall($1)) }\n", [Wamo]),
+    build_prog(Dir, 'pe.plawk', 'pe', Src, Bin),
+    directory_file_path(Dir, 'in.txt', Input),
+    write_text(Input, "alpha\nbeta\ngamma\n"),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "alpha\nbeta\ngamma\n"),
+    !.
+
+% blob(dyncall_at($1)) over a dynamic source: a nullary grammar chosen by a
+% filename column returns the atom `hello`.
+test(blob_dyncall_at_prints_bytes, [condition(clang_available)]) :-
+    blob_dir(Dir),
+    directory_file_path(Dir, 'greeting.wamo', Wamo),
+    write_wam_object([user:greeting/1], [wamo_entry(greeting/1)], Wamo),
+    build_prog(Dir, 'pat.plawk', 'pat',
+        "{ print blob(dyncall_at($1)) }\n", Bin),
+    directory_file_path(Dir, 'at.txt', Input),
+    setup_call_cleanup(
+        open(Input, write, S, [encoding(utf8)]),
+        ( format(S, "~w~n", [Wamo]), format(S, "~w~n", [Wamo]) ),
+        close(S)),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "hello\nhello\n"),
+    !.
+
+% An if-then-else grammar (which lowers through `jump`, now in the loadable
+% subset) returning a per-branch atom compiles into a .wamo.
+test(if_then_else_atom_grammar_compiles) :-
+    wam_object_encode([user:kind/2], [wamo_entry(kind/2)], Codes),
+    string_codes(Text, Codes),
+    sub_string(Text, 0, 4, _, "WAMO"),
+    sub_string(Text, _, _, _, "big"),
+    sub_string(Text, _, _, _, "small"),
+    !.
+
+:- end_tests(plawk_dyncall_blob).
+
+% --- helpers ---------------------------------------------------------------
+
+blob_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_dyncall_blob', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_text(Path, Text) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text),
+        close(Out)).
+
+build_prog(Dir, ProgName, BinName, Src, Bin) :-
+    directory_file_path(Dir, ProgName, Prog),
+    setup_call_cleanup(
+        open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src),
+        close(S)),
+    directory_file_path(Dir, BinName, Bin),
+    cli([build, Prog, '-o', Bin], _, 0).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(null), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
**Roadmap item 2** — the "binary data return" idea in its
no-deserialization form. A grammar can return a **byte string**: its entry
binds the output to an Atom (a byte string here), read by
`blob(dyncall(...))` / `blob(dyncall_at(...))` as an opaque byte slice for
`print`. The bytes pass through unchanged to `%.*s` — no deserialization.

### What lands
- **Native primitive** `@wam_object_call_bytes`: output tag must be Atom;
  reads `@wam_atom_to_string` + `strlen` → `{ ptr, len, ok }`. The pointer
  is into the persistent atom table, so it survives the arena rewind.
- **Parser**: `blob(dyncall(...))` / `blob(dyncall_at(...))` → their own
  nodes (a print/writebin field form).
- **Codegen**: print-position emitter → a byte slice (`%Base_ptr` /
  `%Base_len`, empty on failure). `@plawk_dyncall_b_N` /
  `@plawk_dyncall_at_b_N` shims per arity (all cache modes) delegate to
  `@wam_object_call_bytes`, **sharing** the object handle / path cache with
  the i64 + float shims.
- Also lifted **`jump`** (tag 32, a self-relative label) into the loadable
  subset, so **if-then-else grammars** now compile into a `.wamo`.
- CLI enables `emit_wamo_loader` for blob variants.

### Tests — `tests/test_plawk_dyncall_blob.pl` (5)
Parse + arity collection, and clang-gated: `blob(dyncall($1))` echoes text
fields (alpha/beta/gamma), `blob(dyncall_at($1))` over a dynamic source
returns `hello`, and an if-then-else atom grammar compiles.

### Scope note
The byte slice currently plugs into `print`. `writebin` into an
`sN`/`lpsN` slot, equality guards, and assoc keys reuse the same
`(ptr,len)` shape and are the natural follow-on within item 2 (each needs
the blob node wired into that consumer's path). Roadmap + README updated.

Stacks on the designated branch (item 1 / #3469 merged). Next: item 3
(multi-entry objects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_