### PR TITLE
plawk/JIT (roadmap #3): multi-entry .wamo objects (mechanism)

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -19,6 +19,8 @@ The dynamic-grammar surface is feature-complete for numeric work:
 | In-memory loader (`@wam_object_load_bytes`) | #3463 |
 | `dyncall_at(Source, args...)` (runtime-chosen source) + path cache (`on`/`mtime`/`off`) | #3465 |
 | `float(dyncall(...))` / `float(dyncall_at(...))` (double returns) | #3467 |
+| `blob(dyncall(...))` / `blob(dyncall_at(...))` (opaque byte returns) | #3470 |
+| Multi-entry objects — writer `wamo_entries([...])` + loader name resolution (`@wam_object_entry_index`) | this PR |
 
 A grammar is compiled ahead of time to a `.wamo`, loaded at runtime (from a
 fixed path, an in-memory buffer, or a per-call runtime source), cached with
@@ -77,14 +79,27 @@ for item 4.
 the same `(ptr,len)` shape and are the natural follow-on (each needs the
 blob node wired into that consumer's path).
 
-### 3. Multi-entry objects — *moderate, ergonomics*
+### 3. Multi-entry objects — *LANDED (mechanism); surface deferred*
 
-**What:** let one `.wamo` expose several entry predicates, selected by name
-at the call site — e.g. `dyncall@parse($1)` / `dyncall@classify($1)` over a
-single `DYNLOAD = "lib.wamo"`. Needs the writer to emit a name→label-index
-table, the loader to expose entry-by-name lookup, and a naming surface
-(binding entries at declaration rather than overloading `dyncall`'s arg
-list — a leading entry-name arg can't be told apart from a value).
+**What:** one `.wamo` can now expose several named entry predicates. The
+writer takes `wamo_entries([P/A, ...])` and emits a name→label-index table
+early in the stream (right after the default-entry index), so
+`@wam_object_load` steps past it with a tiny skip loop and pays nothing at
+call time. Two new loader primitives resolve a name to its label index:
+`@wam_object_entry_index_bytes(buf, total, name, namelen)` scans the table
+in an already-read buffer (reads only the early table, stops at the first
+match — never touches the code section), and `@wam_object_entry_index(path,
+name, namelen)` is the path convenience (reads the file, scans, frees).
+`@wam_label_pc` turns the returned label index into a PC to call against the
+loaded VM. Verified end to end: one object exposing `answer/1` and
+`answer_swapped/1` (both over a shared `sum3/3`), a host that loads it once
+and resolves each name to a distinct PC → `119` and `1020`; an unknown name
+resolves to `-1`.
+
+**Deferred to a follow-up:** the plawk *surface* — `dyncall@parse($1)` /
+`dyncall@classify($1)` over a single `DYNLOAD`. The naming fork noted below
+(binding entries at declaration vs. overloading `dyncall`'s arg list) still
+needs settling, but the loader mechanism it will ride is done.
 
 **Why:** today one `.wamo` = one entry, so a "grammar library" means one
 file per predicate. Multi-entry lets a related family ship as one object.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -19945,7 +19945,10 @@ build_llvm_arg_setup(Arity, Setup) :-
 %
 %     WAMO\n
 %     <version=1>
-%     <entry-label-index>
+%     <default-entry-label-index>
+%     <entry-count E>     then E records of (name-string, label-index) --
+%                         the named entries a multi-entry object exposes;
+%                         placed early so @wam_object_load skips it cheaply
 %     <atom-count N>      then N length-prefixed strings
 %     <functor-count M>   then M length-prefixed strings
 %     <label-count L>     then L ints (PC per label; index = position)
@@ -19978,7 +19981,11 @@ build_llvm_arg_setup(Arity, Setup) :-
 %
 %  Compile Predicates (plus their same-module helper closure) to a .wamo
 %  object and write it to OutFile. Options:
-%    wamo_entry(Pred/Arity) - entry predicate (default: first of Predicates)
+%    wamo_entry(Pred/Arity)    - default entry (bare dyncall); defaults to the
+%                                first of wamo_entries, else the first predicate
+%    wamo_entries([P/A, ...])  - the named entries this object exposes (for
+%                                multi-entry objects resolved by name at the
+%                                call site); the first is also the default entry
 %  Throws error(wamo_unsupported(_), _) if any instruction is outside the
 %  loadable subset, error(wamo_entry_not_found(_), _) if the entry label
 %  is missing, or error(wamo_uncompilable(_), _) on a WAM compile failure.
@@ -19997,6 +20004,7 @@ wam_object_encode(Predicates, Options, Codes) :-
     wamo_classify(Expanded, Options, 0, Records),
     build_merged_labels(Records, NamePCPairs, LabelMap),
     wamo_entry_index(Predicates, Options, LabelMap, EntryIndex),
+    wamo_entries_list(Predicates, Options, LabelMap, Entries),
     wamo_all_instr_parts(Records, AllParts),
     foldl(wamo_encode_step(LabelMap), AllParts,
           ws([], tab([], 0), tab([], 0)),
@@ -20005,7 +20013,7 @@ wam_object_encode(Predicates, Options, Codes) :-
     wamo_table_list(ATab, Atoms),
     wamo_table_list(FTab, Functors),
     findall(PC, member(_-PC, NamePCPairs), PCs),
-    wamo_serialize(EntryIndex, Atoms, Functors, PCs, EncInstrs, Codes).
+    wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs, Codes).
 
 %% wamo_classify(+Preds, +Options, +StartPC, -Records)
 %
@@ -20024,14 +20032,41 @@ wamo_classify([PI|Rest], Options, StartPC, [Rec|Recs]) :-
     ),
     wamo_classify(Rest, Options, NextPC, Recs).
 
+%% wamo_default_entry_pi(+Predicates, +Options, -Pred/Arity)
+%  The default entry (used by a bare dyncall): wamo_entry(P/A) if given,
+%  else the first of wamo_entries([...]), else the first predicate.
+wamo_default_entry_pi(_Predicates, Options, P/A) :-
+    option(wamo_entry(P/A), Options), !.
+wamo_default_entry_pi(_Predicates, Options, P/A) :-
+    option(wamo_entries([P/A | _]), Options), !.
+wamo_default_entry_pi(Predicates, _Options, P/A) :-
+    Predicates = [First|_],
+    ( First = _:P/A -> true ; First = P/A ).
+
 %% wamo_entry_index(+Predicates, +Options, +LabelMap, -Index)
+%  The default entry's label index.
 wamo_entry_index(Predicates, Options, LabelMap, Index) :-
-    (   option(wamo_entry(EP/EA), Options)
-    ->  P = EP, A = EA
-    ;   Predicates = [First|_],
-        ( First = _:P0/A0 -> P = P0, A = A0
-        ; First = P0/A0   -> P = P0, A = A0 )
+    wamo_default_entry_pi(Predicates, Options, P/A),
+    wamo_lookup_entry_index(P/A, LabelMap, Index).
+
+%% wamo_entries_list(+Predicates, +Options, +LabelMap, -Entries)
+%  The named-entry table: Name-Index pairs for every exposed entry. From
+%  wamo_entries([...]) if given, else just the default entry. Names are
+%  the "Pred/Arity" label form so the loader can resolve dyncall@name.
+wamo_entries_list(Predicates, Options, LabelMap, Entries) :-
+    (   option(wamo_entries(List), Options)
+    ->  EntryPIs = List
+    ;   wamo_default_entry_pi(Predicates, Options, DP),
+        EntryPIs = [DP]
     ),
+    findall(Name-Index,
+        ( member(EP/EA, EntryPIs),
+          format(string(Name), "~w/~w", [EP, EA]),
+          wamo_lookup_entry_index(EP/EA, LabelMap, Index)
+        ),
+        Entries).
+
+wamo_lookup_entry_index(P/A, LabelMap, Index) :-
     format(string(Name), "~w/~w", [P, A]),
     (   memberchk(Name-Index, LabelMap)
     ->  true
@@ -20235,10 +20270,14 @@ wamo_reloc_id(atom, 1).
 wamo_reloc_id(functor, 2).
 wamo_reloc_id(float, 3).
 
-wamo_serialize(EntryIndex, Atoms, Functors, PCs, EncInstrs, Codes) :-
-    length(Atoms, NA), length(Functors, NF),
+wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs, Codes) :-
+    length(Entries, NE), length(Atoms, NA), length(Functors, NF),
     length(PCs, NL), length(EncInstrs, NC),
-    format(codes(Head), "WAMO\n1\n~w\n~w\n", [EntryIndex, NA]),
+    % header: magic, version, default-entry index, then the named-entry
+    % table (early, so @wam_object_load can skip it without a full parse).
+    format(codes(Head), "WAMO\n1\n~w\n~w\n", [EntryIndex, NE]),
+    maplist(wamo_entry_codes, Entries, EntryChunks),
+    format(codes(AHdr), "~w\n", [NA]),
     maplist(wamo_string_codes, Atoms, AtomChunks),
     format(codes(FHdr), "~w\n", [NF]),
     maplist(wamo_string_codes, Functors, FunChunks),
@@ -20246,9 +20285,16 @@ wamo_serialize(EntryIndex, Atoms, Functors, PCs, EncInstrs, Codes) :-
     maplist([PC, Cs]>>format(codes(Cs), "~w\n", [PC]), PCs, PCChunks),
     format(codes(CHdr), "~w\n", [NC]),
     maplist(wamo_instr_codes, EncInstrs, InstrChunks),
-    append([[Head], AtomChunks, [FHdr], FunChunks, [LHdr], PCChunks,
-            [CHdr], InstrChunks], Lists),
+    append([[Head], EntryChunks, [AHdr], AtomChunks, [FHdr], FunChunks,
+            [LHdr], PCChunks, [CHdr], InstrChunks], Lists),
     append(Lists, Codes).
+
+%% wamo_entry_codes(+Name-Index, -Codes)
+%  One named-entry record: length-prefixed name string then its label index.
+wamo_entry_codes(Name-Index, Codes) :-
+    wamo_string_codes(Name, NameCodes),
+    format(codes(IdxCodes), "~w\n", [Index]),
+    append(NameCodes, IdxCodes, Codes).
 
 wamo_instr_codes(enc(T, O1, O2, R), Cs) :-
     wamo_reloc_id(R, RI),
@@ -20301,6 +20347,10 @@ wamo_utf8_bytes([C|Cs], Bytes) :-
 %    @wam_object_load    - read a .wamo file, relocate, build a %WamState
 %    @wam_object_call_i64 - call the object's entry with N %Value args and
 %                           read back an Integer result ({value, ok})
+%    @wam_object_entry_index / @wam_object_entry_index_bytes
+%                        - resolve a named entry to its label index (or -1)
+%                          for multi-entry objects; @wam_label_pc turns that
+%                          into a PC to call against the loaded VM
 %
 %  Emitted into a host module when write_wam_llvm_project/3 is called with
 %  emit_wamo_loader(true). References only runtime helpers already present
@@ -20450,8 +20500,31 @@ parse:
   %pe = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %cur_v)
   %entry_idx64 = extractvalue { i64, i64 } %pe, 0
   %cur_e = extractvalue { i64, i64 } %pe, 1
+  ; named-entry table: skip it (name-string, label-index) x E. The table is
+  ; placed early so this loader can step past it without a full parse; the
+  ; separate @wam_object_entries_load reads it when a call site names an entry.
+  %pne = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %cur_e)
+  %nentries = extractvalue { i64, i64 } %pne, 0
+  %cur_ne = extractvalue { i64, i64 } %pne, 1
+  br label %eskip_loop
+eskip_loop:
+  %ei = phi i64 [ 0, %parse ], [ %ei1, %eskip_step ]
+  %ecur = phi i64 [ %cur_ne, %parse ], [ %ecur2, %eskip_step ]
+  %edone = icmp uge i64 %ei, %nentries
+  br i1 %edone, label %after_entries, label %eskip_step
+eskip_step:
+  %elen_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %ecur)
+  %elen = extractvalue { i64, i64 } %elen_r, 0
+  %ecur_d = extractvalue { i64, i64 } %elen_r, 1
+  %estr_off = add i64 %ecur_d, 1
+  %eafter_str = add i64 %estr_off, %elen
+  %eidx_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %eafter_str)
+  %ecur2 = extractvalue { i64, i64 } %eidx_r, 1
+  %ei1 = add i64 %ei, 1
+  br label %eskip_loop
+after_entries:
   ; atom count
-  %pa = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %cur_e)
+  %pa = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %ecur)
   %natoms = extractvalue { i64, i64 } %pa, 0
   %cur_a0 = extractvalue { i64, i64 } %pa, 1
   %atom_bytes = mul i64 %natoms, 8
@@ -20459,8 +20532,8 @@ parse:
   %atomIds = bitcast i8* %atom_mem to i64*
   br label %aloop
 aloop:
-  %ai = phi i64 [ 0, %parse ], [ %ai1, %astep ]
-  %acur = phi i64 [ %cur_a0, %parse ], [ %acur2, %astep ]
+  %ai = phi i64 [ 0, %after_entries ], [ %ai1, %astep ]
+  %acur = phi i64 [ %cur_a0, %after_entries ], [ %acur2, %astep ]
   %adone = icmp uge i64 %ai, %natoms
   br i1 %adone, label %fdr_init, label %astep
 astep:
@@ -20780,4 +20853,115 @@ fail:
   %f1 = insertvalue { i8*, i64, i1 } %f0, i64 0, 1
   %f2 = insertvalue { i8*, i64, i1 } %f1, i1 false, 2
   ret { i8*, i64, i1 } %f2
+}
+
+; Read a whole file into a fresh malloc''d buffer, writing the byte count to
+; *out_total. Returns the buffer (caller frees) or null on open failure. Same
+; grow-and-read loop as @wam_object_load, factored so entry-name lookup can
+; read the object without a second copy of the loop.
+define i8* @wamo_read_file(i8* %path, i64* %out_total) {
+entry:
+  %fd = call i32 @open(i8* %path, i32 0, i32 0)
+  %fd_bad = icmp slt i32 %fd, 0
+  br i1 %fd_bad, label %fail, label %read_init
+read_init:
+  %buf0 = call i8* @malloc(i64 65536)
+  br label %read_loop
+read_loop:
+  %buf = phi i8* [ %buf0, %read_init ], [ %bufc, %after_read ]
+  %cap = phi i64 [ 65536, %read_init ], [ %capc, %after_read ]
+  %total = phi i64 [ 0, %read_init ], [ %total3, %after_read ]
+  %free = sub i64 %cap, %total
+  %low = icmp ult i64 %free, 32768
+  br i1 %low, label %do_grow, label %do_read
+do_grow:
+  %cap.d = mul i64 %cap, 2
+  %buf.d = call i8* @realloc(i8* %buf, i64 %cap.d)
+  br label %do_read
+do_read:
+  %bufc = phi i8* [ %buf.d, %do_grow ], [ %buf, %read_loop ]
+  %capc = phi i64 [ %cap.d, %do_grow ], [ %cap, %read_loop ]
+  %freec = sub i64 %capc, %total
+  %dst = getelementptr i8, i8* %bufc, i64 %total
+  %n = call i64 @read(i32 %fd, i8* %dst, i64 %freec)
+  %eof = icmp sle i64 %n, 0
+  br i1 %eof, label %read_done, label %after_read
+after_read:
+  %total3 = add i64 %total, %n
+  br label %read_loop
+read_done:
+  %close_ignore = call i32 @close(i32 %fd)
+  store i64 %total, i64* %out_total
+  ret i8* %bufc
+fail:
+  store i64 0, i64* %out_total
+  ret i8* null
+}
+
+; Scan the named-entry table (in a buffer already read into memory) for the
+; entry named `name` (namelen bytes) and return its label index, or -1 if the
+; name is absent or the buffer is too small. Reads only the early table --
+; version, default-entry index, entry count, then E x (name-string, index) --
+; and stops at the first match, so it never parses the code section.
+define i32 @wam_object_entry_index_bytes(i8* %bufc, i64 %total, i8* %name, i64 %namelen) {
+entry:
+  %too_small = icmp ult i64 %total, 5
+  br i1 %too_small, label %notfound, label %parse
+parse:
+  %pv = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 4)
+  %cur_v = extractvalue { i64, i64 } %pv, 1
+  %pe = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %cur_v)
+  %cur_e = extractvalue { i64, i64 } %pe, 1
+  %pne = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %cur_e)
+  %nentries = extractvalue { i64, i64 } %pne, 0
+  %cur_ne = extractvalue { i64, i64 } %pne, 1
+  br label %loop
+loop:
+  %i = phi i64 [ 0, %parse ], [ %i1, %next ]
+  %cur = phi i64 [ %cur_ne, %parse ], [ %cur2, %next ]
+  %done = icmp uge i64 %i, %nentries
+  br i1 %done, label %notfound, label %step
+step:
+  %len_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %cur)
+  %len = extractvalue { i64, i64 } %len_r, 0
+  %cur_d = extractvalue { i64, i64 } %len_r, 1
+  %str_off = add i64 %cur_d, 1
+  %str = getelementptr i8, i8* %bufc, i64 %str_off
+  %after_str = add i64 %str_off, %len
+  %idx_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %after_str)
+  %idx = extractvalue { i64, i64 } %idx_r, 0
+  %cur2 = extractvalue { i64, i64 } %idx_r, 1
+  %i1 = add i64 %i, 1
+  %lenmatch = icmp eq i64 %len, %namelen
+  br i1 %lenmatch, label %cmp, label %next
+cmp:
+  %cmpres = call i32 @memcmp(i8* %str, i8* %name, i64 %len)
+  %eq = icmp eq i32 %cmpres, 0
+  br i1 %eq, label %hit, label %next
+next:
+  br label %loop
+hit:
+  %idx32 = trunc i64 %idx to i32
+  ret i32 %idx32
+notfound:
+  ret i32 -1
+}
+
+; Path convenience: read the file, scan its entry table for `name`, free.
+; Returns the label index or -1. For the fixed-DYNLOAD call sites that name
+; an entry, resolve the label index once at startup, then @wam_label_pc it
+; against the loaded VM to get a PC to call.
+define i32 @wam_object_entry_index(i8* %path, i8* %name, i64 %namelen) {
+entry:
+  %totp = alloca i64
+  %bufc = call i8* @wamo_read_file(i8* %path, i64* %totp)
+  %isnull = icmp eq i8* %bufc, null
+  br i1 %isnull, label %fail, label %ok
+ok:
+  %total = load i64, i64* %totp
+  %idx = call i32 @wam_object_entry_index_bytes(i8* %bufc, i64 %total, i8* %name, i64 %namelen)
+  call void @free(i8* %bufc)
+  ret i32 %idx
+fail:
+  ret i32 -1
 }').

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -104,6 +104,50 @@ test(load_bytes_from_memory, [condition(clang_available)]) :-
     assertion(Out == "119\n"),
     !.
 
+% Multi-entry object: one .wamo exposes two named entries (answer/1 and
+% answer_swapped/1, both over the shared sum3/3). The writer emits a
+% name->label-index table; the encoded stream carries both names.
+test(multi_entry_encodes_name_table) :-
+    wam_object_encode([user:answer/1, user:answer_swapped/1, user:sum3/3],
+        [wamo_entries([answer/1, answer_swapped/1])], Codes),
+    string_codes(Text, Codes),
+    split_string(Text, "\n \t", "\n \t", Parts0),
+    exclude(==(""), Parts0, Parts),
+    % WAMO 1 <default-entry> <E=2> 8 answer/1 <idx> 16 answer_swapped/1 <idx> ...
+    Parts = ["WAMO", "1", _Default, "2" | _],
+    memberchk("answer/1", Parts),
+    memberchk("answer_swapped/1", Parts),
+    !.
+
+% Full round trip through the loader's name resolution: build one host that
+% loads a two-entry object, resolves each entry by name to a label index
+% (@wam_object_entry_index), turns each into a PC (@wam_label_pc) and calls
+% it. Distinct names -> distinct results from the SAME object.
+test(host_resolves_named_entries,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'multi.wamo', Wamo),
+    write_wam_object([user:answer/1, user:answer_swapped/1, user:sum3/3],
+        [wamo_entries([answer/1, answer_swapped/1])], Wamo),
+    build_multi_host(Dir, Host),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "119\n1020\n"),
+    !.
+
+% A name that no entry exposes resolves to -1; the host exits with the
+% resolve-fail code rather than calling a bogus PC.
+test(unknown_entry_name_resolves_to_minus_one,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'multi.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:answer/1, user:answer_swapped/1, user:sum3/3],
+          [wamo_entries([answer/1, answer_swapped/1])], Wamo) ),
+    directory_file_path(Dir, 'multi_miss_host', Host),
+    ( exists_file(Host) -> true ; build_multi_miss_host(Dir, Host) ),
+    run_host(Host, Wamo, _Out, 22),
+    !.
+
 :- end_tests(wam_object).
 
 % --- helpers ---------------------------------------------------------------
@@ -159,6 +203,116 @@ load_fail:\n\c
   ret i32 20\n\c
 run_fail:\n\c
   ret i32 21\n\c
+}\n').
+
+% Build a host that loads argv[1], resolves "answer/1" and "answer_swapped/1"
+% by name against the object's entry table, and calls each in turn.
+build_multi_host(Dir, Host) :-
+    directory_file_path(Dir, 'multi_host.ll', LL),
+    with_output_to(string(_),
+        write_wam_llvm_project([user:answer/1],
+            [module_name(wam_object_multi_host), emit_wamo_loader(true)], LL)),
+    multi_host_main_ir(MainIR),
+    setup_call_cleanup(
+        open(LL, append, S, [encoding(utf8)]),
+        write(S, MainIR),
+        close(S)),
+    directory_file_path(Dir, 'multi_host_bin', Host),
+    clang_link(LL, Host).
+
+% A host that resolves a name absent from the table -> -1 -> resolve_fail (22).
+build_multi_miss_host(Dir, Host) :-
+    directory_file_path(Dir, 'multi_miss.ll', LL),
+    with_output_to(string(_),
+        write_wam_llvm_project([user:answer/1],
+            [module_name(wam_object_multi_miss), emit_wamo_loader(true)], LL)),
+    multi_miss_main_ir(MainIR),
+    setup_call_cleanup(
+        open(LL, append, S, [encoding(utf8)]),
+        write(S, MainIR),
+        close(S)),
+    clang_link(LL, Host).
+
+clang_link(LL, Bin) :-
+    format(atom(Cmd), 'clang -w -O2 ~w -o ~w -lm 2>&1', [LL, Bin]),
+    process_create(path(sh), ['-c', Cmd],
+        [stdout(pipe(CS)), stderr(std), process(Pid)]),
+    read_string(CS, _, ClangOut),
+    close(CS),
+    process_wait(Pid, Status),
+    ( Status == exit(0) -> true ; throw(error(clang_failed(ClangOut), _)) ).
+
+multi_host_main_ir(
+'\n@.me_fmt = private constant [6 x i8] c"%lld\\0A\\00"\n\c
+@.me_n1 = private constant [8 x i8] c"answer/1"\n\c
+@.me_n2 = private constant [16 x i8] c"answer_swapped/1"\n\n\c
+define i32 @main(i32 %argc, i8** %argv) {\n\c
+entry:\n\c
+  %p1 = getelementptr i8*, i8** %argv, i64 1\n\c
+  %path = load i8*, i8** %p1\n\c
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)\n\c
+  %vm = extractvalue { %WamState*, i32 } %obj, 0\n\c
+  %vm_null = icmp eq %WamState* %vm, null\n\c
+  br i1 %vm_null, label %load_fail, label %e1\n\c
+e1:\n\c
+  %n1 = getelementptr [8 x i8], [8 x i8]* @.me_n1, i32 0, i32 0\n\c
+  %idx1 = call i32 @wam_object_entry_index(i8* %path, i8* %n1, i64 8)\n\c
+  %bad1 = icmp slt i32 %idx1, 0\n\c
+  br i1 %bad1, label %resolve_fail, label %run1\n\c
+run1:\n\c
+  %pc1 = call i32 @wam_label_pc(%WamState* %vm, i32 %idx1)\n\c
+  %r1 = call { i64, i1 } @wam_object_call_i64(%WamState* %vm, i32 %pc1, i32 0, %Value* null, i32 0)\n\c
+  %v1 = extractvalue { i64, i1 } %r1, 0\n\c
+  %ok1 = extractvalue { i64, i1 } %r1, 1\n\c
+  br i1 %ok1, label %print1, label %run_fail\n\c
+print1:\n\c
+  %fmt1 = getelementptr [6 x i8], [6 x i8]* @.me_fmt, i32 0, i32 0\n\c
+  %pr1 = call i32 (i8*, ...) @printf(i8* %fmt1, i64 %v1)\n\c
+  br label %e2\n\c
+e2:\n\c
+  %n2 = getelementptr [16 x i8], [16 x i8]* @.me_n2, i32 0, i32 0\n\c
+  %idx2 = call i32 @wam_object_entry_index(i8* %path, i8* %n2, i64 16)\n\c
+  %bad2 = icmp slt i32 %idx2, 0\n\c
+  br i1 %bad2, label %resolve_fail, label %run2\n\c
+run2:\n\c
+  %pc2 = call i32 @wam_label_pc(%WamState* %vm, i32 %idx2)\n\c
+  %r2 = call { i64, i1 } @wam_object_call_i64(%WamState* %vm, i32 %pc2, i32 0, %Value* null, i32 0)\n\c
+  %v2 = extractvalue { i64, i1 } %r2, 0\n\c
+  %ok2 = extractvalue { i64, i1 } %r2, 1\n\c
+  br i1 %ok2, label %print2, label %run_fail\n\c
+print2:\n\c
+  %fmt2 = getelementptr [6 x i8], [6 x i8]* @.me_fmt, i32 0, i32 0\n\c
+  %pr2 = call i32 (i8*, ...) @printf(i8* %fmt2, i64 %v2)\n\c
+  ret i32 0\n\c
+load_fail:\n\c
+  ret i32 20\n\c
+run_fail:\n\c
+  ret i32 21\n\c
+resolve_fail:\n\c
+  ret i32 22\n\c
+}\n').
+
+multi_miss_main_ir(
+'\n@.mm_name = private constant [7 x i8] c"nope/99"\n\n\c
+define i32 @main(i32 %argc, i8** %argv) {\n\c
+entry:\n\c
+  %p1 = getelementptr i8*, i8** %argv, i64 1\n\c
+  %path = load i8*, i8** %p1\n\c
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)\n\c
+  %vm = extractvalue { %WamState*, i32 } %obj, 0\n\c
+  %vm_null = icmp eq %WamState* %vm, null\n\c
+  br i1 %vm_null, label %load_fail, label %resolve\n\c
+resolve:\n\c
+  %n = getelementptr [7 x i8], [7 x i8]* @.mm_name, i32 0, i32 0\n\c
+  %idx = call i32 @wam_object_entry_index(i8* %path, i8* %n, i64 7)\n\c
+  %bad = icmp slt i32 %idx, 0\n\c
+  br i1 %bad, label %resolve_fail, label %ok\n\c
+ok:\n\c
+  ret i32 0\n\c
+load_fail:\n\c
+  ret i32 20\n\c
+resolve_fail:\n\c
+  ret i32 22\n\c
 }\n').
 
 run_host(Host, Wamo, Out, ExpectedStatus) :-


### PR DESCRIPTION
## What

Roadmap item #3 (multi-entry objects), **mechanism-first**: one `.wamo` can now expose several named entry predicates. The plawk `dyncall@name` surface is deferred to a follow-up (the naming fork still needs settling), but the loader mechanism it will ride is done and verified end to end.

## Writer

- `write_wam_object`/`wam_object_encode` accept a new option `wamo_entries([P/A, ...])` — the named entries the object exposes. The first is also the default entry (bare `dyncall`); `wamo_entry(P/A)` still overrides the default.
- `wamo_serialize/7` emits a name→label-index table **early** in the stream, right after the default-entry index (`WAMO\n1\n<default>\n<E>\n` then `E×(name-string, label-index)`), so the existing loader steps past it cheaply.
- New helpers: `wamo_default_entry_pi/3`, `wamo_entries_list/4`, `wamo_lookup_entry_index/3`, `wamo_entry_codes/2`.

## Loader

- `@wam_object_load_bytes` gained a small skip loop over the entry table between the default-entry read and the atom count — it pays nothing at call time.
- `@wam_object_entry_index_bytes(buf, total, name, namelen)` scans the table in an already-read buffer, reading **only** the early table and stopping at the first match — it never touches the code section. Returns the label index or `-1`.
- `@wam_object_entry_index(path, name, namelen)` is the path convenience (reads the file via a factored `@wamo_read_file`, scans, frees).
- `@wam_label_pc` turns the returned label index into a PC to call against the loaded VM.

All loader IR still rides `emit_wamo_loader(true)`, so a program with no dynamic calls emits zero extra IR (performance invariant preserved).

## Tests

Three new cases in `tests/test_wam_object.pl`:
- `multi_entry_encodes_name_table` — the writer emits both names + `E=2` in the stream.
- `host_resolves_named_entries` — one object exposing `answer/1` and `answer_swapped/1` (both over a shared `sum3/3`), a host that loads it **once** and resolves each name to a distinct PC → `119` and `1020`.
- `unknown_entry_name_resolves_to_minus_one` — an absent name resolves to `-1` and the host bails rather than calling a bogus PC.

Full `wam_object` suite plus `dyncall`/`dyncall_at`/`float`/`blob` suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_