### PR TITLE
feat(wam-clojure): inline bagof setof witnesses

### DIFF
--- a/PR_WAM_CLOJURE_BAGOF_SETOF_INLINE.md
+++ b/PR_WAM_CLOJURE_BAGOF_SETOF_INLINE.md
@@ -1,0 +1,31 @@
+# PR Title
+
+feat(wam-clojure): inline bagof/setof aggregate witnesses
+
+# Description
+
+## Summary
+
+- Adds Clojure WAM support for the 4-argument `begin_aggregate` form emitted by inline `bagof/3` and `setof/3` compilation.
+- Emits aggregate witness registers into generated Clojure bytecode as `:witnesses [...]`.
+- Captures witness values per aggregate solution and groups `bagof`/`setof` results by witness using existing WAM term ordering.
+- Adds aggregate-result choicepoints so generated predicates can backtrack across witness groups.
+- Keeps witness aggregates runtime-mediated in the lowered Clojure emitter instead of accidentally dropping unsupported aggregate instructions.
+
+## Behavior Covered
+
+- No-witness `bagof/3` preserves duplicates and solution order.
+- No-witness `setof/3` sorts and deduplicates results.
+- Empty `bagof/3` fails, unlike `findall/3`.
+- Grouped `bagof/3` and `setof/3` produce one bag/set per witness group and allow backtracking to later groups.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
+- `swipl -q -s tests/test_wam_clojure_lowered_t4.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_lowered_ite_exec.pl`
+- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -100,6 +100,7 @@ instr_from_parts(["deallocate"], deallocate).
 instr_from_parts(["builtin_call", Op, Ar], builtin_call(Op, Ar)).
 instr_from_parts(["call_foreign", Pred, Ar], call_foreign(Pred, Ar)).
 instr_from_parts(["begin_aggregate", Kind, Template, Bag], begin_aggregate(Kind, Template, Bag)).
+instr_from_parts(["begin_aggregate", Kind, Template, Bag, Witnesses], begin_aggregate(Kind, Template, Bag, Witnesses)).
 instr_from_parts(["end_aggregate", Template], end_aggregate(Template)).
 instr_from_parts(["switch_on_constant"|Cases], switch_on_constant(Cases)).
 instr_from_parts(["try_me_else", L], try_me_else(L)).

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -662,8 +662,15 @@ wam_op_to_clojure_literal("begin_aggregate", [Kind, TemplateReg, BagReg], _, Lit
     clj_string_literal(Kind, KindLit),
     clj_string_literal(TemplateReg, TemplateLit),
     clj_string_literal(BagReg, BagLit),
-    format(atom(Literal), '{:op :begin-aggregate :kind ~w :template ~w :bag ~w}',
+    format(atom(Literal), '{:op :begin-aggregate :kind ~w :template ~w :bag ~w :witnesses []}',
            [KindLit, TemplateLit, BagLit]).
+wam_op_to_clojure_literal("begin_aggregate", [Kind, TemplateReg, BagReg, WitnessText], _, Literal) :-
+    clj_string_literal(Kind, KindLit),
+    clj_string_literal(TemplateReg, TemplateLit),
+    clj_string_literal(BagReg, BagLit),
+    aggregate_witness_vector_literal(WitnessText, WitnessLit),
+    format(atom(Literal), '{:op :begin-aggregate :kind ~w :template ~w :bag ~w :witnesses ~w}',
+           [KindLit, TemplateLit, BagLit, WitnessLit]).
 wam_op_to_clojure_literal("end_aggregate", [TemplateReg], _, Literal) :-
     clj_string_literal(TemplateReg, TemplateLit),
     format(atom(Literal), '{:op :end-aggregate :template ~w}', [TemplateLit]).
@@ -686,6 +693,14 @@ parse_switch_case(RawCase, Entry) :-
         clj_string_literal("malformed", LabelLit),
         format(atom(Entry), '{:value ~w :label ~w}', [ConstLit, LabelLit])
     ).
+
+aggregate_witness_vector_literal(WitnessText, WitnessLit) :-
+    clj_unquote_wam_atom_token(WitnessText, Unquoted),
+    (   Unquoted == ""
+    ->  Witnesses = []
+    ;   split_string(Unquoted, ";", "", Witnesses)
+    ),
+    emit_clojure_string_vector(Witnesses, WitnessLit).
 
 functor_arity_string(Functor, Arity) :-
     split_string(Functor, "/", "", [_Name, ArityStr]),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -231,7 +231,8 @@
          list->term
          parse-number-text
          reg-get-raw
-         sorted-unique-terms)
+         sorted-unique-terms
+         term-compare)
 
 (defn choice-snapshot [state target-pc]
   {:kind :wam
@@ -269,6 +270,7 @@
          :aggregate-kind (:kind instr)
          :aggregate-template-reg (:template instr)
          :aggregate-bag-reg (:bag instr)
+         :aggregate-witness-regs (vec (or (:witnesses instr) []))
          :aggregate-next-pc (inc end-pc)
          :aggregate-collected []))
 
@@ -339,17 +341,92 @@
     "setof" (if (seq collected) (aggregate-set-term state collected) ::aggregate-failure)
     (aggregate-list-term state collected)))
 
+(defn aggregate-entry? [entry]
+  (and (map? entry) (contains? entry :aggregate-template)))
+
+(defn aggregate-entry-template [entry]
+  (if (aggregate-entry? entry)
+    (:aggregate-template entry)
+    entry))
+
+(defn aggregate-entry-witnesses [entry]
+  (if (aggregate-entry? entry)
+    (:aggregate-witnesses entry)
+    []))
+
+(defn aggregate-witness-compare [state left right]
+  (loop [xs (seq left)
+         ys (seq right)]
+    (cond
+      (and (nil? xs) (nil? ys)) 0
+      (nil? xs) -1
+      (nil? ys) 1
+      :else
+      (let [c (term-compare state (first xs) (first ys))]
+        (if (zero? c)
+          (recur (next xs) (next ys))
+          c)))))
+
+(defn aggregate-same-witnesses? [state left right]
+  (zero? (aggregate-witness-compare state left right)))
+
+(defn aggregate-add-entry-group [state groups entry]
+  (let [witnesses (aggregate-entry-witnesses entry)]
+    (loop [remaining groups
+           out []]
+      (if-let [group (first remaining)]
+        (if (aggregate-same-witnesses? state witnesses (:witnesses group))
+          (vec (concat out [(update group :entries conj entry)] (rest remaining)))
+          (recur (rest remaining) (conj out group)))
+        (conj out {:witnesses witnesses :entries [entry]})))))
+
+(defn aggregate-groups [state collected]
+  (sort #(aggregate-witness-compare state (:witnesses %1) (:witnesses %2))
+        (reduce (fn [groups entry]
+                  (aggregate-add-entry-group state groups entry))
+                []
+                collected)))
+
+(defn aggregate-grouped-result-terms [state kind collected]
+  (mapv (fn [group]
+          (aggregate-result-term state kind (mapv aggregate-entry-template (:entries group))))
+        (aggregate-groups state collected)))
+
+(defn aggregate-result-terms [state kind collected witness-regs]
+  (if (and (seq witness-regs) (or (= kind "bagof") (= kind "setof")))
+    (aggregate-grouped-result-terms state kind collected)
+    (let [bag (aggregate-result-term state kind collected)]
+      (if (= bag ::aggregate-failure)
+        []
+        [bag]))))
+
 (defn aggregate-choice-index [choice-points]
   (some (fn [[idx cp]]
           (when (= :aggregate (:kind cp)) idx))
         (reverse (map-indexed vector choice-points))))
 
+(defn copy-register-terms [state regs]
+  (loop [s state
+         remaining (seq regs)
+         out []]
+    (if remaining
+      (let [[copied next-state] (copy-term s (or (reg-get-raw s (first remaining)) ::unbound))]
+        (recur next-state (next remaining) (conj out copied)))
+      [out s])))
+
 (defn collect-aggregate-template [state template-reg]
   (when-let [idx (aggregate-choice-index (:choice-points state))]
-    (let [[copied copy-state] (copy-term state (reg-get-raw state template-reg))]
+    (let [cp (get (:choice-points state) idx)
+          witness-regs (:aggregate-witness-regs cp)
+          [copied copy-state] (copy-term state (reg-get-raw state template-reg))
+          [witnesses witness-state] (copy-register-terms copy-state witness-regs)
+          entry (if (seq witness-regs)
+                  {:aggregate-template copied :aggregate-witnesses witnesses}
+                  copied)]
       (-> copy-state
-          (update-in [:choice-points idx :aggregate-collected] conj copied)
-          (assoc-in [:choice-points idx :next-var-id] (:next-var-id copy-state))))))
+          (assoc :next-var-id (:next-var-id witness-state))
+          (update-in [:choice-points idx :aggregate-collected] conj entry)
+          (assoc-in [:choice-points idx :next-var-id] (:next-var-id witness-state))))))
 
 (defn push-choice-point [state target-pc]
   (update state :choice-points conj (choice-snapshot state target-pc)))
@@ -2511,6 +2588,32 @@
           (recur (next remaining))))
       (backtrack base-state))))
 
+(defn aggregate-result-choice-snapshot [state bag-reg results]
+  (assoc (choice-snapshot state (:pc state))
+         :kind :aggregate-result
+         :aggregate-bag-reg bag-reg
+         :aggregate-results (vec results)))
+
+(defn push-aggregate-result-choice-point [state bag-reg results]
+  (if (seq results)
+    (update state :choice-points conj
+            (aggregate-result-choice-snapshot state bag-reg results))
+    state))
+
+(defn apply-aggregate-results [state bag-reg results]
+  (if-let [remaining (seq results)]
+    (let [bag (first remaining)
+          alternatives (next remaining)
+          choice-state (push-aggregate-result-choice-point state bag-reg alternatives)
+          current (or (reg-get-raw choice-state bag-reg) ::unbound)
+          [ok next-state] (if (= current ::unbound)
+                            [true (reg-set-raw choice-state bag-reg bag)]
+                            (unify-values choice-state current bag))]
+      (if ok
+        next-state
+        (backtrack choice-state)))
+    (backtrack state)))
+
 (defn activate-choice [state cp]
   (case (:kind cp)
     :foreign
@@ -2521,19 +2624,16 @@
     :member
     (apply-member-solution state (:pc cp) (:member-elem cp) (:member-rest cp))
 
+    :aggregate-result
+    (apply-aggregate-results state (:aggregate-bag-reg cp) (:aggregate-results cp))
+
     :aggregate
-    (let [bag (aggregate-result-term state (:aggregate-kind cp) (:aggregate-collected cp))]
-      (if (= bag ::aggregate-failure)
-        (backtrack state)
-        (let [bag-reg (:aggregate-bag-reg cp)
-              current (or (reg-get-raw state bag-reg) ::unbound)
-              resumed-state (assoc state :pc (:aggregate-next-pc cp))
-              [ok next-state] (if (= current ::unbound)
-                                [true (reg-set-raw resumed-state bag-reg bag)]
-                                (unify-values resumed-state current bag))]
-          (if ok
-            next-state
-            (backtrack resumed-state)))))
+    (let [results (aggregate-result-terms state
+                                          (:aggregate-kind cp)
+                                          (:aggregate-collected cp)
+                                          (:aggregate-witness-regs cp))
+          resumed-state (assoc state :pc (:aggregate-next-pc cp))]
+      (apply-aggregate-results resumed-state (:aggregate-bag-reg cp) results))
 
     (assoc state :status :running)))
 

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -187,8 +187,10 @@ test(numeric_wam_constants_preserve_number_vs_atom_tokens) :-
 test(aggregate_instructions_emit_runtime_ops) :-
     once((
         wam_clojure_target:wam_op_to_clojure_literal("begin_aggregate", ["collect", "Y1", "X2"], _, BeginLiteral),
+        wam_clojure_target:wam_op_to_clojure_literal("begin_aggregate", ["bagof", "Y1", "X2", "'Y3;Y4'"], _, BeginWitnessLiteral),
         wam_clojure_target:wam_op_to_clojure_literal("end_aggregate", ["Y1"], _, EndLiteral),
-        assertion(BeginLiteral == '{:op :begin-aggregate :kind "collect" :template "Y1" :bag "X2"}'),
+        assertion(BeginLiteral == '{:op :begin-aggregate :kind "collect" :template "Y1" :bag "X2" :witnesses []}'),
+        assertion(BeginWitnessLiteral == '{:op :begin-aggregate :kind "bagof" :template "Y1" :bag "X2" :witnesses ["Y3" "Y4"]}'),
         assertion(EndLiteral == '{:op :end-aggregate :template "Y1"}')
     )).
 

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -15,6 +15,8 @@ unsupported_wam("test_switch/1:\nswitch_on_constant a:test_a, default:test_defau
 
 aggregate_wam("test_findall/1:\nallocate\nget_variable X2, A1\nput_variable Y1, Y1\nbegin_aggregate collect, Y1, X2\nput_value Y1, A1\ncall fact/1, 1\nend_aggregate Y1\ndeallocate\nproceed\n").
 
+aggregate_witness_wam("test_bagof/1:\nallocate\nget_variable X2, A1\nput_variable Y1, Y1\nbegin_aggregate bagof, Y1, X2, 'Y3'\nput_value Y1, A1\ncall fact/1, 1\nend_aggregate Y1\ndeallocate\nproceed\n").
+
 test(deterministic_predicate_is_lowerable) :-
     simple_fact_wam(WamCode),
     wam_clojure_lowerable(test_fact/1, WamCode, Reason),
@@ -31,6 +33,10 @@ test(multi_clause_all_clauses_lowerable) :-
 test(aggregate_predicates_remain_runtime_mediated) :-
     aggregate_wam(WamCode),
     assertion(\+ wam_clojure_lowerable(test_findall/1, WamCode, _)).
+
+test(aggregate_witness_predicates_remain_runtime_mediated) :-
+    aggregate_witness_wam(WamCode),
+    assertion(\+ wam_clojure_lowerable(test_bagof/1, WamCode, _)).
 
 test(multi_clause_emits_empty_lowered_prefix) :-
     once((

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -25,6 +25,12 @@
 :- dynamic user:wam_agg_min/1.
 :- dynamic user:wam_agg_max/1.
 :- dynamic user:wam_agg_min_empty/1.
+:- dynamic user:wam_bagof_pair/2.
+:- dynamic user:wam_bagof_inline/1.
+:- dynamic user:wam_setof_inline/1.
+:- dynamic user:wam_bagof_empty/1.
+:- dynamic user:wam_bagof_group/1.
+:- dynamic user:wam_setof_group/1.
 :- dynamic user:wam_bind_then_fact/1.
 :- dynamic user:wam_bind_after_call/1.
 :- dynamic user:wam_bind_before_execute/1.
@@ -429,6 +435,15 @@ user:wam_agg_set(L) :- aggregate_all(set(X), member(X, [b,a,b]), L).
 user:wam_agg_min(M) :- aggregate_all(min(X), member(X, [3,1,2]), M).
 user:wam_agg_max(M) :- aggregate_all(max(X), member(X, [3,1,2]), M).
 user:wam_agg_min_empty(M) :- aggregate_all(min(X), member(X, []), M).
+user:wam_bagof_pair(b, 3).
+user:wam_bagof_pair(a, 2).
+user:wam_bagof_pair(a, 1).
+user:wam_bagof_pair(a, 2).
+user:wam_bagof_inline(L) :- bagof(X, member(X, [a,b,a]), L).
+user:wam_setof_inline(L) :- setof(X, member(X, [b,a,b]), L).
+user:wam_bagof_empty(L) :- bagof(X, member(X, []), L).
+user:wam_bagof_group(L) :- bagof(X, user:wam_bagof_pair(_Y, X), L).
+user:wam_setof_group(L) :- setof(X, user:wam_bagof_pair(_Y, X), L).
 user:wam_bind_then_fact(X) :- Y = X, user:wam_fact(Y).
 user:wam_bind_after_call(X) :- user:wam_fact(X), X = a.
 user:wam_bind_before_execute(X) :- X = a, user:wam_fact(X).
@@ -834,6 +849,12 @@ run_smoke :-
           user:wam_agg_min/1,
           user:wam_agg_max/1,
           user:wam_agg_min_empty/1,
+          user:wam_bagof_pair/2,
+          user:wam_bagof_inline/1,
+          user:wam_setof_inline/1,
+          user:wam_bagof_empty/1,
+          user:wam_bagof_group/1,
+          user:wam_setof_group/1,
           user:wam_bind_then_fact/1,
           user:wam_bind_after_call/1,
           user:wam_bind_before_execute/1,
@@ -1210,6 +1231,7 @@ run_smoke :-
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
+          inline_bagof_setof(true),
           foreign_predicates([wam_fact/1, wam_foreign_pair/2, wam_foreign_stream_pair/2]),
           clojure_foreign_handlers([
               handler(wam_fact/1, "(fn [args] (= (first args) \"a\"))"),
@@ -1315,6 +1337,17 @@ smoke_cases([
     case('wam_agg_max/1', 3, "true"),
     case('wam_agg_max/1', 2, "false"),
     case('wam_agg_min_empty/1', 0, "false"),
+    case('wam_bagof_inline/1', '[a,b,a]', "true"),
+    case('wam_bagof_inline/1', '[a,b]', "false"),
+    case('wam_setof_inline/1', '[a,b]', "true"),
+    case('wam_setof_inline/1', '[b,a]', "false"),
+    case('wam_bagof_empty/1', '[]', "false"),
+    case('wam_bagof_group/1', '[2,1,2]', "true"),
+    case('wam_bagof_group/1', '[3]', "true"),
+    case('wam_bagof_group/1', '[1,2,3]', "false"),
+    case('wam_setof_group/1', '[1,2]', "true"),
+    case('wam_setof_group/1', '[3]', "true"),
+    case('wam_setof_group/1', '[2,1]', "false"),
     case('wam_bind_then_fact/1', 'a', "true"),
     case('wam_bind_then_fact/1', 'b', "false"),
     case('wam_bind_after_call/1', 'a', "true"),
@@ -2578,9 +2611,12 @@ prolog_term_string_to_edn('[52,50]', "{:tag :struct :functor \"[|]/2\" :args [52
 prolog_term_string_to_edn('[102,111]', "{:tag :struct :functor \"[|]/2\" :args [102 {:tag :struct :functor \"[|]/2\" :args [111 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[102,111,111]', "{:tag :struct :functor \"[|]/2\" :args [102 {:tag :struct :functor \"[|]/2\" :args [111 {:tag :struct :functor \"[|]/2\" :args [111 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[1,2,3]', "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[1,2]', "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[1,3]', "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[2,3]', "{:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[3]', "{:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}") :- !.
 prolog_term_string_to_edn('[2]', "{:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}") :- !.
+prolog_term_string_to_edn('[2,1,2]', "{:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[3-a,1-b,2-c]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[1-b,2-c,3-a]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[1-b,3-a,2-c]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} \"[]\"]}]}]}") :- !.
@@ -2620,8 +2656,11 @@ prolog_term_string_to_edn("[52,50]", "{:tag :struct :functor \"[|]/2\" :args [52
 prolog_term_string_to_edn("[102,111]", "{:tag :struct :functor \"[|]/2\" :args [102 {:tag :struct :functor \"[|]/2\" :args [111 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[102,111,111]", "{:tag :struct :functor \"[|]/2\" :args [102 {:tag :struct :functor \"[|]/2\" :args [111 {:tag :struct :functor \"[|]/2\" :args [111 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[1,2,3]", "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[1,2]", "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[1,3]", "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
+prolog_term_string_to_edn("[3]", "{:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}") :- !.
 prolog_term_string_to_edn("[2]", "{:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}") :- !.
+prolog_term_string_to_edn("[2,1,2]", "{:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[3-a,1-b,2-c]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[1-b,2-c,3-a]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[1-b,3-a,2-c]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} \"[]\"]}]}]}") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for the 4-argument `begin_aggregate` form emitted by inline `bagof/3` and `setof/3` compilation.
- Emits aggregate witness registers into generated Clojure bytecode as `:witnesses [...]`.
- Captures witness values per aggregate solution and groups `bagof`/`setof` results by witness using existing WAM term ordering.
- Adds aggregate-result choicepoints so generated predicates can backtrack across witness groups.
- Keeps witness aggregates runtime-mediated in the lowered Clojure emitter instead of accidentally dropping unsupported aggregate instructions.

## Behavior Covered

- No-witness `bagof/3` preserves duplicates and solution order.
- No-witness `setof/3` sorts and deduplicates results.
- Empty `bagof/3` fails, unlike `findall/3`.
- Grouped `bagof/3` and `setof/3` produce one bag/set per witness group and allow backtracking to later groups.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `swipl -q -s tests/test_wam_clojure_lowered_t4.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_lowered_ite_exec.pl`
- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
