### PR TITLE
plawk/JIT (roadmap #3, surface A): dyncall@name named entries

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -20,7 +20,8 @@ The dynamic-grammar surface is feature-complete for numeric work:
 | `dyncall_at(Source, args...)` (runtime-chosen source) + path cache (`on`/`mtime`/`off`) | #3465 |
 | `float(dyncall(...))` / `float(dyncall_at(...))` (double returns) | #3467 |
 | `blob(dyncall(...))` / `blob(dyncall_at(...))` (opaque byte returns) | #3470 |
-| Multi-entry objects — writer `wamo_entries([...])` + loader name resolution (`@wam_object_entry_index`) | this PR |
+| Multi-entry objects — writer `wamo_entries([...])` + loader name resolution (`@wam_object_entry_index`) | #3471 |
+| plawk surface A — `dyncall@name(...)` (named entry, compile-time-fixed, cached PC) | this PR |
 
 A grammar is compiled ahead of time to a `.wamo`, loaded at runtime (from a
 fixed path, an in-memory buffer, or a per-call runtime source), cached with
@@ -79,33 +80,70 @@ for item 4.
 the same `(ptr,len)` shape and are the natural follow-on (each needs the
 blob node wired into that consumer's path).
 
-### 3. Multi-entry objects — *LANDED (mechanism); surface deferred*
+### 3. Multi-entry objects — *LANDED (mechanism + surface A)*
 
-**What:** one `.wamo` can now expose several named entry predicates. The
-writer takes `wamo_entries([P/A, ...])` and emits a name→label-index table
-early in the stream (right after the default-entry index), so
-`@wam_object_load` steps past it with a tiny skip loop and pays nothing at
-call time. Two new loader primitives resolve a name to its label index:
-`@wam_object_entry_index_bytes(buf, total, name, namelen)` scans the table
-in an already-read buffer (reads only the early table, stops at the first
-match — never touches the code section), and `@wam_object_entry_index(path,
-name, namelen)` is the path convenience (reads the file, scans, frees).
-`@wam_label_pc` turns the returned label index into a PC to call against the
-loaded VM. Verified end to end: one object exposing `answer/1` and
-`answer_swapped/1` (both over a shared `sum3/3`), a host that loads it once
-and resolves each name to a distinct PC → `119` and `1020`; an unknown name
-resolves to `-1`.
+**What (mechanism):** one `.wamo` can expose several named entry
+predicates. The writer takes `wamo_entries([P/A, ...])` and emits a
+name→label-index table early in the stream (right after the default-entry
+index), so `@wam_object_load` steps past it with a tiny skip loop and pays
+nothing at call time. Two loader primitives resolve a name to its label
+index: `@wam_object_entry_index_bytes(buf, total, name, namelen)` scans the
+table in an already-read buffer (reads only the early table, stops at the
+first match — never touches the code section), and
+`@wam_object_entry_index(path, name, namelen)` is the path convenience
+(reads the file, scans, frees). `@wam_label_pc` turns the returned label
+index into a PC to call against the loaded VM.
 
-**Deferred to a follow-up:** the plawk *surface* — `dyncall@parse($1)` /
-`dyncall@classify($1)` over a single `DYNLOAD`. The naming fork noted below
-(binding entries at declaration vs. overloading `dyncall`'s arg list) still
-needs settling, but the loader mechanism it will ride is done.
+**What (surface A — `dyncall@name`):** `dyncall@square($1)` /
+`dyncall@cube($1)` over a single `DYNLOAD` selects a named entry at the
+call site. The `@name` is a compile-time token, so the shim
+(`@plawk_dyncall_named_<name>_<N>`) resolves the entry's label index once
+at startup via `@wam_object_entry_index`, caches the PC in a per-entry
+global (sentinel `-1` = unresolved), and every later call skips straight to
+the object call — no per-call dispatch. A name no entry exposes yields `0`
+(the shim's resolve-fail path). Rides `emit_wamo_loader(true)` + per-site
+entry collection, so a program with no named calls emits none of this IR.
+Verified end to end: one object exposing `square/2` and `cube/2`, summed by
+name in one binary → `c - s = 22` (reachable only if both resolved).
+
+**Deferred follow-ons:** `float(dyncall@name(...))` / `blob(dyncall@name(...))`
+(the named form is i64-only today; the float/blob wrappers reuse the same
+resolver — mechanical), and `dyncall_at@name(Src, ...)` (named entry on a
+*runtime* source, which needs the PC cached per (object, name) pair rather
+than per entry). And surface **B** below.
+
+**Surface B — declaration-bound library names (planned):** for a fixed
+`DYNLOAD` shipping a known family, bind entries once at declaration and call
+them like ordinary functions: `DYNENTRY parse` → `parse($1)`. Cleaner call
+sites than A, and resolution stays static (baked PC) because the object is
+compile-time-fixed. **A is for the userspace/dynamic case (call site says
+`@name`, cost is visible); B is for the pre-compiled library case (bare
+call, cost read from the declaration).** The rule that makes B coherent:
+*entry resolution inherits the object's sourcing* — fixed `DYNLOAD` ⇒ static
+PC bake; a runtime source ⇒ per-load resolution. Build B when a real
+multi-entry library exists and A's `@name` call sites feel noisy.
+
+**Namespace rule for B (settled):** `DYNENTRY name` **reserves** `name` for
+the compiled object — it removes that identifier from userspace, so the two
+name sets are disjoint *by construction*. A bare `name(...)` call resolves
+by set membership: in the `DYNENTRY` set → compiled entry; otherwise →
+userspace (foreign call / builtin / user function). A rule freely mixes both
+(`parse($1)` compiled, `score($2)` userspace) with no per-call ambiguity.
+Declaring `DYNENTRY` over a name that is already a builtin/foreign name is a
+**compile error**, never silent shadowing — so B never calls a userspace
+name. **Optional guaranteed-no-shadow prefix:** allow a sigil/namespace
+prefix (e.g. `dyn::parse($1)` or a configurable `DYNPREFIX`) so a program can
+force compiled-space names into their own lexical zone and *statically*
+guarantee no collision with userspace, at the cost of slightly noisier call
+sites — the same static-safety-vs-brevity trade B itself makes, offered per
+program.
 
 **Why:** today one `.wamo` = one entry, so a "grammar library" means one
 file per predicate. Multi-entry lets a related family ship as one object.
 Purely additive; no dependency on the other items.
 
-**Effort:** moderate (there's a surface fork to settle). **Depends on:** nothing.
+**Effort:** A landed. B is moderate (declaration table + a resolution pass +
+the reserved-name check). **Depends on:** nothing.
 
 ### 4. Binary-data returns — structured records (deserialization) — *large, capstone*
 

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -414,7 +414,14 @@ compiled predicates — needed when a grammar returns a Float (e.g.
 `blob(dyncall(...))` / `blob(dyncall_at(...))` read an Atom output as
 **opaque bytes** (a byte slice) for `print` — a grammar that emits text or
 encoded output rather than a number, e.g.
-`{ print blob(dyncall($1)) }`. Bounded repetition handles records containing a
+`{ print blob(dyncall($1)) }`.
+A single `.wamo` can expose several named entries (built with
+`write_wam_object(Preds, [wamo_entries([P/A, ...])], File)`);
+`dyncall@name(args...)` selects one by name at the call site — e.g.
+`{ s += dyncall@square($1) ; c += dyncall@cube($1) }` calls two entries of
+one `DYNLOAD` object. The `@name` is fixed at compile time, so the entry's
+address is resolved once at startup and reused (a name no entry exposes
+yields 0). Bounded repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an
 ordinary i64 field, element slots are flat addressable fields

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -114,6 +114,7 @@ build(File, Out0, KeepLL) :-
     % loader emitted into the host module so it can load and run a runtime
     % object.
     (   ( plawk_program_dyncall_arities(Program, DynArities), DynArities \== []
+        ; plawk_program_dyncall_named_entries(Program, DynNamed), DynNamed \== []
         ; plawk_program_dyncall_at_arities(Program, DynAtArities), DynAtArities \== []
         ; plawk_program_dyncall_float_arities(Program, DynFArities), DynFArities \== []
         ; plawk_program_dyncall_at_float_arities(Program, DynAtFArities), DynAtFArities \== []

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -7,6 +7,7 @@
     plawk_program_foreign_specs/3,
     plawk_program_foreign_specs/4,
     plawk_program_dyncall_arities/2,
+    plawk_program_dyncall_named_entries/2,
     plawk_program_dyncall_at_arities/2,
     plawk_program_dyncall_float_arities/2,
     plawk_program_dyncall_at_float_arities/2,
@@ -623,6 +624,7 @@ plawk_program_native_driver_ir(
 plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_foreign_specs(Program, GuardSpecs, CallSpecs, FCallSpecs),
     plawk_program_dyncall_arities(Program, DynArities),
+    plawk_program_dyncall_named_entries(Program, DynNamed),
     plawk_program_dyncall_at_arities(Program, DynAtArities),
     plawk_program_dyncall_float_arities(Program, DynFArities),
     plawk_program_dyncall_at_float_arities(Program, DynAtFArities),
@@ -632,6 +634,7 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         CallSpecs == [],
         FCallSpecs == [],
         DynArities == [],
+        DynNamed == [],
         DynAtArities == [],
         DynFArities == [],
         DynAtFArities == [],
@@ -649,7 +652,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         ),
         % Object-call shims for dyncall(...) / float(dyncall(...)) /
         % blob(dyncall(...)) sites, plus the shared .wamo object handle.
-        (   DynArities == [], DynFArities == [], DynBArities == []
+        (   DynArities == [], DynFArities == [], DynBArities == [],
+            DynNamed == []
         ->  DyncallSupportIR = ''
         ;   ( plawk_program_dynload_path(Program, DynPath)
             ->  true
@@ -658,7 +662,7 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
                         'dyncall(...) requires BEGIN { DYNLOAD = "file.wamo" }')))
             ),
             plawk_dyncall_support_ir(DynPath, DynArities, DynFArities,
-                DynBArities, DyncallSupportIR)
+                DynBArities, DynNamed, DyncallSupportIR)
         ),
         % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...)) /
         % blob(dyncall_at(...)) sites + the shared path cache.
@@ -779,6 +783,38 @@ plawk_expr_dyncall(Expr, Args) :-
     ( plawk_expr_dyncall(Left, Args)
     ; plawk_expr_dyncall(Right, Args)
     ).
+
+%% plawk_program_dyncall_named_entries(+Program, -Entries)
+%
+%  Deduplicated set of Name-NArgs pairs for every dyncall@name(...) site
+%  across rule and END bodies. One resolver+shim
+%  @plawk_dyncall_named_<Name>_<NArgs> is emitted per distinct (name,
+%  arity); it resolves the named entry's label index against the DYNLOAD
+%  object once (via @wam_object_entry_index) and caches the PC. NArgs is
+%  the call's argument count; the entry predicate's arity is NArgs+1 (the
+%  inputs plus the output cell), which is the arity in the "Name/Arity"
+%  string the loader matches.
+plawk_program_dyncall_named_entries(program(_Begin, Rules, EndClauses),
+        Entries) :-
+    findall(Name-NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          member(Action, Actions),
+          plawk_subterm_dyncall_named(Action, Name, Args),
+          length(Args, NArgs)
+        ),
+        Entries0),
+    sort(Entries0, Entries).
+
+% Find every dyncall_named(Name, Args) node anywhere within a term (print
+% fields, accumulator updates, if-branches, binary sub-expressions), so the
+% collector need not mirror each structural walker.
+plawk_subterm_dyncall_named(dyncall_named(Name, Args), Name, Args).
+plawk_subterm_dyncall_named(Term, Name, Args) :-
+    compound(Term),
+    arg(_, Term, Sub),
+    plawk_subterm_dyncall_named(Sub, Name, Args).
 
 plawk_actions_prolog_call(Actions, Name, Args) :-
     member(Action, Actions),
@@ -1052,16 +1088,22 @@ fail:
 %  run -- the object-call primitive rewinds the arena per call, so this
 %  stays constant-memory just like the compiled foreign bridge.
 plawk_dyncall_support_ir(Path, Arities, IR) :-
-    plawk_dyncall_support_ir(Path, Arities, [], [], IR).
+    plawk_dyncall_support_ir(Path, Arities, [], [], [], IR).
 plawk_dyncall_support_ir(Path, IArities, FArities, IR) :-
-    plawk_dyncall_support_ir(Path, IArities, FArities, [], IR).
+    plawk_dyncall_support_ir(Path, IArities, FArities, [], [], IR).
+plawk_dyncall_support_ir(Path, IArities, FArities, BArities, IR) :-
+    plawk_dyncall_support_ir(Path, IArities, FArities, BArities, [], IR).
 
-%% plawk_dyncall_support_ir(+Path, +IArities, +FArities, +BArities, -IR)
+%% plawk_dyncall_support_ir(+Path, +IArities, +FArities, +BArities,
+%%                          +NamedEntries, -IR)
 %  IArities -> i64 @plawk_dyncall_N shims; FArities -> double
 %  @plawk_dyncall_f_N shims (float(dyncall(...))); BArities -> byte-slice
-%  @plawk_dyncall_b_N shims (blob(dyncall(...))). All share the single
-%  lazily loaded object handle + @plawk_dyncall_get.
-plawk_dyncall_support_ir(Path, IArities, FArities, BArities, IR) :-
+%  @plawk_dyncall_b_N shims (blob(dyncall(...))). NamedEntries -> a
+%  Name-NArgs list, one i64 resolver+shim @plawk_dyncall_named_<Name>_<N>
+%  each: it resolves "Name/(N+1)" to a label index against the DYNLOAD
+%  object once (caching the PC) and calls it. All share the single lazily
+%  loaded object handle + @plawk_dyncall_get.
+plawk_dyncall_support_ir(Path, IArities, FArities, BArities, NamedEntries, IR) :-
     llvm_emit_c_string_global('plawk_dyncall_path', Path, PathGlobal,
         _StrLen, BytesLen),
     format(atom(GetterIR),
@@ -1096,8 +1138,78 @@ load:
     findall(BShimIR,
         ( member(BN, BArities), plawk_dyncall_shim_b_ir(BN, BShimIR) ),
         BShims),
-    append([[PathGlobal, GetterIR], IShims, FShims, BShims], Parts),
+    findall(NShimIR,
+        ( member(EName-ENArgs, NamedEntries),
+          plawk_dyncall_named_shim_ir(EName, ENArgs, BytesLen, NShimIR) ),
+        NShims),
+    append([[PathGlobal, GetterIR], IShims, FShims, BShims, NShims], Parts),
     atomic_list_concat(Parts, '\n\n', IR).
+
+%% plawk_dyncall_named_symbol(+Name, +NArgs, -Sym)
+%  The LLVM symbol suffix for a named-entry shim: <Name>_<NArgs>. Name is
+%  a plawk identifier (alnum + underscore), so it is a valid symbol part.
+plawk_dyncall_named_symbol(Name, NArgs, Sym) :-
+    format(atom(Sym), '~w_~w', [Name, NArgs]).
+
+%% plawk_dyncall_named_shim_ir(+Name, +NArgs, +PathBytesLen, -IR)
+%  A named-entry resolver+shim over the shared DYNLOAD object. The entry
+%  name string is "Name/(NArgs+1)" (arity = inputs + output cell), matched
+%  against the object's entry table. The label index -> PC is resolved
+%  once via @wam_object_entry_index + @wam_label_pc and cached in a per-
+%  entry global (sentinel -1 = unresolved); later calls skip straight to
+%  the call. Returns { i64, i1 } like the bare i64 shim.
+plawk_dyncall_named_shim_ir(Name, NArgs, PathBytesLen, IR) :-
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    EntryArity is NArgs + 1,
+    format(atom(EntryName), '~w/~w', [Name, EntryArity]),
+    format(atom(ENameGlobal), 'plawk_dyncall_ename_~w', [Sym]),
+    llvm_emit_c_string_global(ENameGlobal, EntryName, ENameGlobalIR,
+        ENameLen, ENameBytesLen),
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'~w
+@plawk_dyncall_pc_~w = internal global i32 -1
+
+define { i64, i1 } @plawk_dyncall_named_~w(~w) {
+entry:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %resolve
+
+resolve:
+  %pc0 = load i32, i32* @plawk_dyncall_pc_~w
+  %need = icmp slt i32 %pc0, 0
+  br i1 %need, label %do_resolve, label %do_call
+
+do_resolve:
+  %namep = getelementptr [~w x i8], [~w x i8]* @.plawk_dyncall_ename_~w, i32 0, i32 0
+  %pathp = getelementptr [~w x i8], [~w x i8]* @.plawk_dyncall_path, i32 0, i32 0
+  %idx = call i32 @wam_object_entry_index(i8* %pathp, i8* %namep, i64 ~w)
+  %bad = icmp slt i32 %idx, 0
+  br i1 %bad, label %fail, label %store_pc
+
+store_pc:
+  %rpc = call i32 @wam_label_pc(%WamState* %vm, i32 %idx)
+  store i32 %rpc, i32* @plawk_dyncall_pc_~w
+  br label %do_call
+
+do_call:
+  %pc = phi i32 [ %pc0, %resolve ], [ %rpc, %store_pc ]
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call { i64, i1 } @wam_object_call_i64(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w)
+  ret { i64, i1 } %r
+
+fail:
+  %f0 = insertvalue { i64, i1 } undef, i64 0, 0
+  %f1 = insertvalue { i64, i1 } %f0, i1 false, 1
+  ret { i64, i1 } %f1
+}',
+        [ENameGlobalIR, Sym, Sym, ParamsIR, Sym,
+         ENameBytesLen, ENameBytesLen, Sym, PathBytesLen, PathBytesLen,
+         ENameLen, Sym, NArgs, StoreIR, NArgs, NArgs]).
 
 % double-returning dyncall shim (float(dyncall(...))): same object handle,
 % reads the entry output as a double via @wam_object_call_f64.
@@ -3043,6 +3155,9 @@ plawk_binfmt_i64_expr_ok(Descriptor, prolog_call(Name, Args)) :-
     atom(Name),
     plawk_binfmt_foreign_args_ok(Descriptor, Args).
 plawk_binfmt_i64_expr_ok(Descriptor, dyncall(Args)) :-
+    !,
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
+plawk_binfmt_i64_expr_ok(Descriptor, dyncall_named(_Name, Args)) :-
     !,
     plawk_binfmt_foreign_args_ok(Descriptor, Args).
 plawk_binfmt_i64_expr_ok(Descriptor, Expr) :-
@@ -5146,6 +5261,8 @@ plawk_rule_body_print_field(Expr) :-
 plawk_rule_body_print_field(Expr) :-
     plawk_dyncall_expr(Expr).
 plawk_rule_body_print_field(Expr) :-
+    plawk_dyncall_named_expr(Expr).
+plawk_rule_body_print_field(Expr) :-
     plawk_dyncall_at_expr(Expr).
 plawk_rule_body_print_field(blob_dyncall(Args)) :-
     plawk_float_dyncall_expr(float_dyncall(Args)).   % same arg shape check
@@ -5179,6 +5296,8 @@ plawk_i64_operand_expr(prolog_call(Name, Args)) :-
     plawk_prolog_call_expr(prolog_call(Name, Args)).
 plawk_i64_operand_expr(dyncall(Args)) :-
     plawk_dyncall_expr(dyncall(Args)).
+plawk_i64_operand_expr(dyncall_named(Name, Args)) :-
+    plawk_dyncall_named_expr(dyncall_named(Name, Args)).
 plawk_i64_operand_expr(dyncall_at(Source, Args)) :-
     plawk_dyncall_at_expr(dyncall_at(Source, Args)).
 plawk_i64_operand_expr(Expr) :-
@@ -5197,6 +5316,16 @@ plawk_prolog_call_expr(prolog_call(Name, Args)) :-
 %  foreign i64 call; it just targets the object-call shim instead of a
 %  compiled @<name>_start_pc.
 plawk_dyncall_expr(dyncall(Args)) :-
+    Args = [_ | _],
+    maplist(plawk_foreign_arg, Args).
+
+%% plawk_dyncall_named_expr(+Expr) is semidet.
+%
+%  dyncall@name(args...) routes to a named entry of the DYNLOAD object
+%  (a multi-entry .wamo). Same arg shapes as bare dyncall; the entry Name
+%  is a compile-time atom, resolved to a label index once at startup.
+plawk_dyncall_named_expr(dyncall_named(Name, Args)) :-
+    atom(Name),
     Args = [_ | _],
     maplist(plawk_foreign_arg, Args).
 
@@ -5414,6 +5543,9 @@ plawk_scalar_action_update(add(var(Name), prolog_call(Pred, Args)), Name,
 plawk_scalar_action_update(add(var(Name), dyncall(Args)), Name,
         add(dyncall(Args))) :-
     plawk_dyncall_expr(dyncall(Args)).
+plawk_scalar_action_update(add(var(Name), dyncall_named(E, Args)), Name,
+        add(dyncall_named(E, Args))) :-
+    plawk_dyncall_named_expr(dyncall_named(E, Args)).
 plawk_scalar_action_update(add(var(Name), dyncall_at(Source, Args)), Name,
         add(dyncall_at(Source, Args))) :-
     plawk_dyncall_at_expr(dyncall_at(Source, Args)).
@@ -5438,6 +5570,9 @@ plawk_scalar_action_update(set(var(Name), prolog_call(Pred, Args)), Name,
 plawk_scalar_action_update(set(var(Name), dyncall(Args)), Name,
         set(dyncall(Args))) :-
     plawk_dyncall_expr(dyncall(Args)).
+plawk_scalar_action_update(set(var(Name), dyncall_named(E, Args)), Name,
+        set(dyncall_named(E, Args))) :-
+    plawk_dyncall_named_expr(dyncall_named(E, Args)).
 plawk_scalar_action_update(set(var(Name), dyncall_at(Source, Args)), Name,
         set(dyncall_at(Source, Args))) :-
     plawk_dyncall_at_expr(dyncall_at(Source, Args)).
@@ -5771,6 +5906,12 @@ plawk_scalar_numeric_expr_ir(dyncall(Args), FieldSeparator, Prefix,
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(dyncall(Args), FieldSeparator, DynBase,
         DynBase, ValueIR, GlobalIR, IR).
+plawk_scalar_numeric_expr_ir(dyncall_named(Name, Args), FieldSeparator, Prefix,
+        SlotIndex, OpIndex, ValueIR, GlobalIR, IR) :-
+    format(atom(DynBase), '~w_slot_~w_op_~w_dyncall_named',
+        [Prefix, SlotIndex, OpIndex]),
+    plawk_i64_expr_ir_parts(dyncall_named(Name, Args), FieldSeparator, DynBase,
+        DynBase, ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(dyncall_at(Source, Args), FieldSeparator, Prefix,
         SlotIndex, OpIndex, ValueIR, GlobalIR, IR) :-
     format(atom(DynAtBase), '~w_slot_~w_op_~w_dyncall_at',
@@ -5853,6 +5994,24 @@ plawk_i64_expr_ir(dyncall(Args), FieldSeparator, Base, GlobalBase,
     format(atom(ResIR),
         '  %~w_res = call { i64, i1 } @plawk_dyncall_~w(~w)',
         [Base, NArgs, CallArgsIR]),
+    format(atom(ValIR),
+        '  %~w_val = extractvalue { i64, i1 } %~w_res, 0', [Base, Base]),
+    format(atom(OkIR),
+        '  %~w_ok = extractvalue { i64, i1 } %~w_res, 1', [Base, Base]),
+    format(atom(SelIR),
+        '  %~w = select i1 %~w_ok, i64 %~w_val, i64 0', [Base, Base, Base]),
+    format(atom(ValueIR), '%~w', [Base]),
+    append(ArgSetupParts, [ResIR, ValIR, OkIR, SelIR], SetupParts).
+plawk_i64_expr_ir(dyncall_named(Name, Args), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    length(Args, NArgs),
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    plawk_foreign_args_ir(Args, FieldSeparator, GlobalBase, ArgValueIRs,
+        GlobalParts, ArgSetupParts),
+    plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
+    format(atom(ResIR),
+        '  %~w_res = call { i64, i1 } @plawk_dyncall_named_~w(~w)',
+        [Base, Sym, CallArgsIR]),
     format(atom(ValIR),
         '  %~w_val = extractvalue { i64, i1 } %~w_res, 0', [Base, Base]),
     format(atom(OkIR),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1289,6 +1289,23 @@ prolog_call_expr(dyncall_at(Source, Args)) -->
     ws,
     ")",
     !.
+% dyncall@name(args...) selects a named entry of the runtime object (a
+% multi-entry .wamo, one file exposing several predicates via
+% wamo_entries([...])). The @name is a compile-time token -- the entry
+% name is fixed in the source, so the shim resolves its label index once
+% at startup (via @wam_object_entry_index) and caches the PC. Parsed
+% before the bare `dyncall(...)` so the `@` form wins; a plain
+% `dyncall(...)` still falls through to the clause below.
+prolog_call_expr(dyncall_named(Name, Args)) -->
+    "dyncall@",
+    identifier(Name),
+    ws,
+    "(",
+    ws,
+    foreign_args(Args),
+    ws,
+    ")",
+    !.
 prolog_call_expr(dyncall(Args)) -->
     "dyncall",
     ws,

--- a/tests/test_plawk_dyncall_named.pl
+++ b/tests/test_plawk_dyncall_named.pl
@@ -1,0 +1,163 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Phase 5 (JIT) roadmap item 3, surface A: dyncall@name(...). One
+% DYNLOAD object exposes several named entries (a multi-entry .wamo via
+% wamo_entries([...])); dyncall@square($1) / dyncall@cube($1) select an
+% entry by name at the call site. The @name is a compile-time token, so
+% the shim resolves the entry's label index once at startup (via
+% @wam_object_entry_index) and caches the PC -- no per-call dispatch.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammar predicates compiled into one multi-entry .wamo (arity = inputs + 1)
+square(X, R) :- R is X * X.
+cube(X, R)   :- R is X * X * X.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_named).
+
+% dyncall@name(...) parses to its own node, distinct from bare dyncall.
+test(named_parses) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n{ print dyncall@square($1) }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(print([dyncall_named(square, [field(1)])]), Actions),
+    !.
+
+% Each dyncall@name site is collected as a Name-NArgs entry (deduped,
+% sorted); the entry-predicate arity the loader matches is NArgs+1.
+test(named_entries_collected) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"lib.wamo\" }\n\c
+         { s += dyncall@square($1) ; c += dyncall@cube($1) }\n\c
+         END { print c - s }\n",
+        Program),
+    plawk_program_dyncall_named_entries(Program, Entries),
+    assertion(Entries == [cube-1, square-1]),
+    !.
+
+% The named shim + entry-name string + cached-PC global are emitted, and
+% only when a named site exists (performance invariant: bare programs get
+% none of this).
+test(named_shim_ir_emitted) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"lib.wamo\" }\n\c
+         { s += dyncall@square($1) }\nEND { print s }\n",
+        Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv,
+        [wam_vm(10, 10)], IR),
+    sub_atom(IR, _, _, _, '@plawk_dyncall_named_square_1'),
+    sub_atom(IR, _, _, _, '@plawk_dyncall_pc_square_1'),
+    sub_atom(IR, _, _, _, 'square/2'),
+    sub_atom(IR, _, _, _, '@wam_object_entry_index'),
+    !.
+
+test(bare_program_has_no_named_ir) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"lib.wamo\" }\n\c
+         { total += dyncall($1) }\nEND { print total }\n",
+        Program),
+    plawk_program_native_driver_ir(Program, stdin_or_argv,
+        [wam_vm(10, 10)], IR),
+    \+ sub_atom(IR, _, _, _, 'plawk_dyncall_named'),
+    !.
+
+% Full round trip: one .wamo exposes square/2 and cube/2; the program
+% sums each by name over the same input. Distinct names -> distinct sums
+% from the SAME loaded object.
+test(named_entries_run_from_one_object, [condition(clang_available)]) :-
+    dyn_dir(Dir),
+    directory_file_path(Dir, 'lib.wamo', Wamo),
+    write_wam_object([user:square/2, user:cube/2],
+        [wamo_entries([square/2, cube/2])], Wamo),
+    % squares 4+9=13 into s, cubes 8+27=35 into c; print c-s = 22, a value
+    % reachable only if BOTH named entries resolved (a missing entry
+    % contributes 0, giving 35 or -13 instead).
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { s += dyncall@square($1) ; c += dyncall@cube($1) }\n\c
+         END { print c - s }\n", [Wamo]),
+    write_prog(Dir, 'named.plawk', Src),
+    directory_file_path(Dir, 'named.plawk', Prog),
+    directory_file_path(Dir, 'named_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'in.bin', Input),
+    write_i64_records(Input, [2, 3]),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "22\n"),
+    !.
+
+% A name no entry exposes yields 0 (the shim's resolve-fail path), not a
+% crash or a link error.
+test(unknown_named_entry_yields_zero, [condition(clang_available)]) :-
+    dyn_dir(Dir),
+    directory_file_path(Dir, 'lib.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:square/2, user:cube/2],
+          [wamo_entries([square/2, cube/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { t += dyncall@nosuch($1) }\nEND { print t }\n", [Wamo]),
+    write_prog(Dir, 'miss.plawk', Src),
+    directory_file_path(Dir, 'miss.plawk', Prog),
+    directory_file_path(Dir, 'miss_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'in.bin', Input),
+    write_i64_records(Input, [2, 3]),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "0\n"),
+    !.
+
+:- end_tests(plawk_dyncall_named).
+
+% --- helpers ---------------------------------------------------------------
+
+dyn_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_dyncall_named', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Text) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(
+        open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text),
+        close(Out)).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_i64_records(Path, Values) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(V, Values), write_i64_le(Out, V)),
+        close(Out)).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(null), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## What

Surface **A** over the multi-entry `.wamo` mechanism (#3471): `dyncall@name(args)` selects a named entry of the `DYNLOAD` object at the call site.

```awk
BEGIN { BINFMT = "i64" ; DYNLOAD = "lib.wamo" }
{ s += dyncall@square($1) ; c += dyncall@cube($1) }
END { print c - s }
```

The `@name` is a **compile-time token**, so the shim `@plawk_dyncall_named_<name>_<N>` resolves the entry's label index once at startup via `@wam_object_entry_index`, caches the PC in a per-entry global (sentinel `-1` = unresolved), and every later call skips straight to the object call — **no per-call dispatch**. A name no entry exposes yields `0` (the resolve-fail path).

## Changes

- **Parser** (`plawk_parser.pl`): `dyncall@ident(args)` → `dyncall_named(Name, Args)`, parsed before the bare `dyncall` so the `@` form wins; a plain `dyncall(...)` still falls through unchanged.
- **Codegen** (`plawk_native_codegen.pl`):
  - Collector `plawk_program_dyncall_named_entries/2` (a generic subterm walk, so it need not mirror every structural walker), exported.
  - Validator `plawk_dyncall_named_expr/1` wired into the i64-operand, print-field, scalar-accumulator (`+=`/`=`), and `BINFMT` i64 paths.
  - An `i64` emitter clause + a `plawk_scalar_numeric_expr_ir` clause.
  - A per-entry resolver+shim in `plawk_dyncall_support_ir` (new `/6` taking the `Name-NArgs` list); it emits the `"Name/Arity"` entry-name string, the cached-PC global, and the resolve-once-then-call body.
- **CLI** (`bin/plawk`): named sites also trigger `emit_wamo_loader(true)`.

## Performance invariant

All of the above rides `emit_wamo_loader(true)` + per-site entry collection, so a program with **no** named calls emits none of this IR (verified by `bare_program_has_no_named_ir`).

## Tests

New `tests/test_plawk_dyncall_named.pl` (6 cases): parse, entry collection, shim-IR presence, the no-named-IR invariant, the end-to-end round trip (one object exposing `square/2` + `cube/2`, summed by name in one binary → `c - s = 22`, reachable only if both entries resolved), and an unknown name yielding `0`. Full `wam_object` + `dyncall` / `dyncall_at` / `float` / `blob` / `named` suites pass, as do the CLI / prolog-call / binary-record surface suites.

## Design (in `PLAWK_JIT_ROADMAP.md`)

Records the long-term plan discussed with the maintainer: **A** is the userspace/dynamic surface (call site says `@name`, cost visible); **B** (planned) is `DYNENTRY parse` → `parse($1)` for the pre-compiled library case, resolution inheriting the object's sourcing. B's namespace rule is settled — `DYNENTRY` **reserves** a name (disjoint from userspace by construction; overlap is a compile error, never silent shadowing) — plus an **optional guaranteed-no-shadow prefix** (e.g. `dyn::parse(...)` / `DYNPREFIX`) so a program can statically force compiled-space names into their own lexical zone.

## Deferred follow-ons (noted in the roadmap)

- `float(dyncall@name(...))` / `blob(dyncall@name(...))` — the named form is i64-only today; the float/blob wrappers reuse the same resolver (mechanical).
- `dyncall_at@name(Src, ...)` — named entry on a *runtime* source, which needs the PC cached per `(object, name)` pair rather than per entry.
- Surface **B**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_