### PR TITLE
plawk/JIT (roadmap #4): structured returns — @wam_object_call_record

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -22,7 +22,8 @@ The dynamic-grammar surface is feature-complete for numeric work:
 | `blob(dyncall(...))` / `blob(dyncall_at(...))` (opaque byte returns) | #3470 |
 | Multi-entry objects — writer `wamo_entries([...])` + loader name resolution (`@wam_object_entry_index`) | #3471 |
 | plawk surface A — `dyncall@name(...)` (named entry, compile-time-fixed, cached PC) | #3473 |
-| `float(dyncall@name(...))` / `blob(dyncall@name(...))` (named double / byte returns, shared resolver) | this PR |
+| `float(dyncall@name(...))` / `blob(dyncall@name(...))` (named double / byte returns, shared resolver) | #3474 |
+| Structured returns — `@wam_object_call_record` (deserialize a returned Compound's args into typed i64/f64 slots) | this PR |
 
 A grammar is compiled ahead of time to a `.wamo`, loaded at runtime (from a
 fixed path, an in-memory buffer, or a per-call runtime source), cached with
@@ -164,13 +165,34 @@ Purely additive; no dependency on the other items.
 **Effort:** A landed. B is moderate (declaration table + a resolution pass +
 the reserved-name check). **Depends on:** nothing.
 
-### 4. Binary-data returns — structured records (deserialization) — *large, capstone*
+### 4. Binary-data returns — structured records (deserialization) — *mechanism LANDED (numeric fields); surface + string fields deferred*
 
 **What:** let a grammar return a **compound term** (e.g. `rec(42, 3.14,
 "name")`) that plawk **deserializes** into typed fields against a declared
 return shape — `dyncall(...) as (i64 f64 s16)` → walk the compound's args,
 type each (arg0 Integer→i64, arg1 Float→f64, arg2 Atom→sN), and materialize
 into a record buffer so `$1`,`$2`,`$3` address it like any binary record.
+
+**Mechanism landed (this PR):** the native primitive
+`@wam_object_call_record(vm, pc, nargs, args, out_reg, nfields, typecodes,
+out_slots)`. It runs the entry, requires the output cell to deref to a
+**Compound** of arity `nfields`, and deserializes each arg into `out_slots[i]`
+per `typecodes[i]` (`0` → i64, arg must be Integer; `1` → f64, arg must be a
+number, stored as double bits) — **before** the arena rewind, since the
+compound and its arg cells live in the arena (atoms survive; a plain
+`@wam_object_call_*` would rewind them away). Same heap-save/rewind discipline
+as the scalar variants, so a per-record call stays constant-memory. Verified
+end to end: a grammar returning `rec2f(10, 10.5)` → `10` (i64) + `10.5` (f64)
+via a host that calls the primitive with typecodes `[0,1]`. This is the
+"output is a term, not a scalar" plumbing item 2 anticipated.
+
+**Deferred:** (a) **string/atom fields** — the bytes survive the rewind via
+the persistent atom table, but a field needs a `(ptr,len)` slot pair rather
+than one i64, so the typecode set and slot layout grow; (b) the plawk
+`dyncall(...) as (shape)` **surface** — a return-shape parser, wiring the
+`out_slots` into a synthesized `BINFMT`-style record so `$1`,`$2`,`$3` address
+it, and a `dyncache`-style lifetime for the record buffer. Mechanism-first,
+surface-second — the same split used for every earlier item.
 
 **Why:** this is the *other half* of your binary-return idea — the case
 that **does** need deserialization. It is also the endgame that closes the

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -20347,6 +20347,9 @@ wamo_utf8_bytes([C|Cs], Bytes) :-
 %    @wam_object_load    - read a .wamo file, relocate, build a %WamState
 %    @wam_object_call_i64 - call the object's entry with N %Value args and
 %                           read back an Integer result ({value, ok})
+%    @wam_object_call_record - call the entry and deserialize a returned
+%                           Compound's args into typed i64/f64 slots (the
+%                           "output is a term" primitive)
 %    @wam_object_entry_index / @wam_object_entry_index_bytes
 %                        - resolve a named entry to its label index (or -1)
 %                          for multi-entry objects; @wam_label_pc turns that
@@ -20853,6 +20856,112 @@ fail:
   %f1 = insertvalue { i8*, i64, i1 } %f0, i64 0, 1
   %f2 = insertvalue { i8*, i64, i1 } %f1, i1 false, 2
   ret { i8*, i64, i1 } %f2
+}
+
+; Structured-record variant (JIT roadmap #4): the entry output cell must bind
+; to a Compound term whose arity equals %nfields; each arg is deserialized
+; into out_slots[i] per typecodes[i] BEFORE the arena is rewound (the compound
+; and its arg cells live in the arena -- only atoms survive a rewind). This is
+; the "output is a term, not a scalar" primitive: a grammar returns e.g.
+; rec(42, 3.14) and the caller lays the fields into a record buffer.
+;   typecodes[i] = 0  -> i64  : arg i must be Integer; out_slots[i] = its i64
+;   typecodes[i] = 1  -> f64  : arg i must be a number; out_slots[i] = the
+;                               double bits (value_to_double promotes Integer)
+; out_slots is an i64[nfields]; f64 fields are stored as bitcast double bits,
+; so the caller reads slot i as i64 or bitcasts to double per its own shape.
+; Returns i1 ok; false on call failure, a non-Compound output, an arity
+; mismatch, or an arg whose type does not satisfy its typecode. Same
+; heap-save / arena-rewind discipline as the scalar variants, so a per-record
+; call stays constant-memory. (String/atom fields are a planned follow-on:
+; their bytes survive the rewind via the persistent atom table, but need a
+; (ptr,len) slot pair rather than one i64.)
+define i1 @wam_object_call_record(%WamState* %vm, i32 %entry_pc, i32 %nargs, %Value* %args, i32 %out_reg, i32 %nfields, i8* %typecodes, i64* %out_slots) {
+entry:
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+do_call:
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs_saved = load i32, i32* %hs_ptr
+  %unb = call %Value @value_unbound(i8* null)
+  %out_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %out_ref = call %Value @value_ref(i32 %out_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %entry_pc)
+  br label %argloop
+argloop:
+  %ai = phi i32 [ 0, %do_call ], [ %ai1, %argstep ]
+  %adone = icmp sge i32 %ai, %nargs
+  br i1 %adone, label %args_done, label %argstep
+argstep:
+  %aidx64 = sext i32 %ai to i64
+  %ap = getelementptr %Value, %Value* %args, i64 %aidx64
+  %av = load %Value, %Value* %ap
+  call void @wam_set_reg(%WamState* %vm, i32 %ai, %Value %av)
+  %ai1 = add i32 %ai, 1
+  br label %argloop
+args_done:
+  call void @wam_set_reg(%WamState* %vm, i32 %out_reg, %Value %out_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %read_out, label %rewind_fail
+read_out:
+  %out = call %Value @wam_deref_value(%WamState* %vm, %Value %out_ref)
+  %out_tag = call i32 @value_tag(%Value %out)
+  %is_compound = icmp eq i32 %out_tag, 3
+  br i1 %is_compound, label %have_compound, label %rewind_fail
+have_compound:
+  %cp_bits = call i64 @value_payload(%Value %out)
+  %cp = inttoptr i64 %cp_bits to %Compound*
+  %ar_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 1
+  %arity = load i32, i32* %ar_slot
+  %arity_ok = icmp eq i32 %arity, %nfields
+  br i1 %arity_ok, label %fields_init, label %rewind_fail
+fields_init:
+  %cargs_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 2
+  %cargs = load %Value*, %Value** %cargs_slot
+  br label %floop
+floop:
+  %fi = phi i32 [ 0, %fields_init ], [ %fi1, %fstep_ok ]
+  %fdone = icmp sge i32 %fi, %nfields
+  br i1 %fdone, label %ok_rewind, label %fstep
+fstep:
+  %fi64 = sext i32 %fi to i64
+  %farg_ptr = getelementptr %Value, %Value* %cargs, i64 %fi64
+  %farg_raw = load %Value, %Value* %farg_ptr
+  %farg = call %Value @wam_deref_value(%WamState* %vm, %Value %farg_raw)
+  %ftag = call i32 @value_tag(%Value %farg)
+  %tc_ptr = getelementptr i8, i8* %typecodes, i64 %fi64
+  %tc = load i8, i8* %tc_ptr
+  %is_f64 = icmp eq i8 %tc, 1
+  br i1 %is_f64, label %field_f64, label %field_i64
+field_i64:
+  %is_int = icmp eq i32 %ftag, 1
+  br i1 %is_int, label %store_i64, label %rewind_fail
+store_i64:
+  %ival = call i64 @value_payload(%Value %farg)
+  %slot_i = getelementptr i64, i64* %out_slots, i64 %fi64
+  store i64 %ival, i64* %slot_i
+  br label %fstep_ok
+field_f64:
+  %is_num = call i1 @value_is_number(%Value %farg)
+  br i1 %is_num, label %store_f64, label %rewind_fail
+store_f64:
+  %dval = call double @value_to_double(%Value %farg)
+  %dbits = bitcast double %dval to i64
+  %slot_f = getelementptr i64, i64* %out_slots, i64 %fi64
+  store i64 %dbits, i64* %slot_f
+  br label %fstep_ok
+fstep_ok:
+  %fi1 = add i32 %fi, 1
+  br label %floop
+ok_rewind:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  ret i1 true
+rewind_fail:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  br label %fail
+fail:
+  ret i1 false
 }
 
 ; Read a whole file into a fresh malloc''d buffer, writing the byte count to

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -23,6 +23,10 @@ answer_swapped(R) :- sum3([7, 8, 5, 1000], 0, R). % -> 1020
 
 uses_float(X) :- X is 1.5 + 2.5.                % float constant -> rejected
 
+% returns a compound record rather than a scalar: rec2f(Integer, Float).
+% Exercises the structured-return primitive (@wam_object_call_record).
+makerec(R) :- X = 10, Y is X + 0.5, R = rec2f(X, Y).   % -> rec2f(10, 10.5)
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -148,6 +152,21 @@ test(unknown_entry_name_resolves_to_minus_one,
     run_host(Host, Wamo, _Out, 22),
     !.
 
+% A grammar can return a Compound record; @wam_object_call_record
+% deserializes its args into typed slots. makerec/1 returns
+% rec2f(10, 10.5): field 0 as i64 (typecode 0) -> 10, field 1 as f64
+% (typecode 1) -> 10.5. The compound + its arg cells are read before the
+% arena rewind.
+test(struct_return_deserializes_fields,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'rec.wamo', Wamo),
+    write_wam_object([user:makerec/1], [wamo_entry(makerec/1)], Wamo),
+    build_record_host(Dir, Host),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "10\n10.5\n"),
+    !.
+
 :- end_tests(wam_object).
 
 % --- helpers ---------------------------------------------------------------
@@ -232,6 +251,57 @@ build_multi_miss_host(Dir, Host) :-
         write(S, MainIR),
         close(S)),
     clang_link(LL, Host).
+
+% Build a host that loads argv[1], calls the entry via
+% @wam_object_call_record with a 2-field shape (i64, f64), and prints the
+% deserialized fields.
+build_record_host(Dir, Host) :-
+    directory_file_path(Dir, 'record_host.ll', LL),
+    with_output_to(string(_),
+        write_wam_llvm_project([user:answer/1],
+            [module_name(wam_object_record_host), emit_wamo_loader(true)], LL)),
+    record_host_main_ir(MainIR),
+    setup_call_cleanup(
+        open(LL, append, S, [encoding(utf8)]),
+        write(S, MainIR),
+        close(S)),
+    directory_file_path(Dir, 'record_host_bin', Host),
+    clang_link(LL, Host).
+
+record_host_main_ir(
+'\n@.rec_ifmt = private constant [6 x i8] c"%lld\\0A\\00"\n\c
+@.rec_ffmt = private constant [6 x i8] c"%.1f\\0A\\00"\n\c
+@.rec_types = private constant [2 x i8] c"\\00\\01"\n\n\c
+define i32 @main(i32 %argc, i8** %argv) {\n\c
+entry:\n\c
+  %p1 = getelementptr i8*, i8** %argv, i64 1\n\c
+  %path = load i8*, i8** %p1\n\c
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)\n\c
+  %vm = extractvalue { %WamState*, i32 } %obj, 0\n\c
+  %pc = extractvalue { %WamState*, i32 } %obj, 1\n\c
+  %vm_null = icmp eq %WamState* %vm, null\n\c
+  br i1 %vm_null, label %load_fail, label %run\n\c
+run:\n\c
+  %slots = alloca i64, i32 2\n\c
+  %tc = getelementptr [2 x i8], [2 x i8]* @.rec_types, i32 0, i32 0\n\c
+  %ok = call i1 @wam_object_call_record(%WamState* %vm, i32 %pc, i32 0, %Value* null, i32 0, i32 2, i8* %tc, i64* %slots)\n\c
+  br i1 %ok, label %print, label %run_fail\n\c
+print:\n\c
+  %s0 = getelementptr i64, i64* %slots, i64 0\n\c
+  %v0 = load i64, i64* %s0\n\c
+  %ifmt = getelementptr [6 x i8], [6 x i8]* @.rec_ifmt, i32 0, i32 0\n\c
+  %pi = call i32 (i8*, ...) @printf(i8* %ifmt, i64 %v0)\n\c
+  %s1 = getelementptr i64, i64* %slots, i64 1\n\c
+  %v1bits = load i64, i64* %s1\n\c
+  %v1 = bitcast i64 %v1bits to double\n\c
+  %ffmt = getelementptr [6 x i8], [6 x i8]* @.rec_ffmt, i32 0, i32 0\n\c
+  %pf = call i32 (i8*, ...) @printf(i8* %ffmt, double %v1)\n\c
+  ret i32 0\n\c
+load_fail:\n\c
+  ret i32 20\n\c
+run_fail:\n\c
+  ret i32 21\n\c
+}\n').
 
 clang_link(LL, Bin) :-
     format(atom(Cmd), 'clang -w -O2 ~w -o ~w -lm 2>&1', [LL, Bin]),


### PR DESCRIPTION
## What

Roadmap item #4 (structured/deserialized returns), **mechanism-first**: the "output is a term, not a scalar" primitive that item 2 anticipated. A grammar whose entry binds its output to a **Compound** term can now have that term deserialized into typed record fields.

```llvm
@wam_object_call_record(vm, pc, nargs, args, out_reg,
                        i32 nfields, i8* typecodes, i64* out_slots) -> i1 ok
```

It runs the entry, requires the output cell to deref to a Compound of arity `nfields`, and writes each arg into `out_slots[i]` per `typecodes[i]`:

- `0` → **i64**: arg must be Integer; slot gets its i64.
- `1` → **f64**: arg must be a number; slot gets the double bits (`value_to_double` promotes Integer → double).

`ok=false` on call failure, a non-Compound output, an arity mismatch, or an arg whose type doesn't satisfy its typecode.

## The lifetime point

Deserialization happens **before** the arena rewind, because the compound and its arg cells live in the arena — a plain `@wam_object_call_*` would rewind them away. (Atoms survive the rewind via the persistent atom table, which is exactly why the string-field case is a separate follow-on rather than free here.) Same heap-save / arena-rewind discipline as the scalar variants, so a per-record call stays constant-memory.

## Tests

New case in `tests/test_wam_object.pl`: a grammar returning `rec2f(10, 10.5)`, a host that calls the primitive with typecodes `[0,1]`, reads slot 0 as i64 (`10`) and slot 1 bitcast to double (`10.5`), prints `10\n10.5\n`. Full `wam_object` + `dyncall` / `dyncall_named` / `dyncall_named_fb` / `dyncall_at` / `float` / `blob` suites pass.

## Deferred (noted in the roadmap)

- **String/atom fields** — the bytes survive the rewind via the atom table, but a field needs a `(ptr,len)` slot pair rather than one i64, so the typecode set and slot layout grow.
- **The plawk `dyncall(...) as (shape)` surface** — a return-shape parser, wiring `out_slots` into a synthesized `BINFMT`-style record so `$1`,`$2`,`$3` address it, and a lifetime for the record buffer. This is the larger half; mechanism-first, surface-second, as with every earlier item.

This is where the JIT arc and the DCG-binary-readers design meet: bytes-in (the blob bridge, item 2) + record-out (this primitive) = a grammar-driven reader for formats too irregular for the native Tier-1 reader, without leaving the compiled loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_