### PR TITLE
plawk/JIT (roadmap #4): structured-return destructure surface

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -23,7 +23,8 @@ The dynamic-grammar surface is feature-complete for numeric work:
 | Multi-entry objects — writer `wamo_entries([...])` + loader name resolution (`@wam_object_entry_index`) | #3471 |
 | plawk surface A — `dyncall@name(...)` (named entry, compile-time-fixed, cached PC) | #3473 |
 | `float(dyncall@name(...))` / `blob(dyncall@name(...))` (named double / byte returns, shared resolver) | #3474 |
-| Structured returns — `@wam_object_call_record` (deserialize a returned Compound's args into typed i64/f64 slots) | this PR |
+| Structured returns — `@wam_object_call_record` (deserialize a returned Compound's args into typed i64/f64 slots) | #3475 |
+| Destructure surface — `(a, b) = dyncall[@name](args) as (i64 f64)` binds fields to typed scalars | this PR |
 
 A grammar is compiled ahead of time to a `.wamo`, loaded at runtime (from a
 fixed path, an in-memory buffer, or a per-call runtime source), cached with
@@ -165,15 +166,16 @@ Purely additive; no dependency on the other items.
 **Effort:** A landed. B is moderate (declaration table + a resolution pass +
 the reserved-name check). **Depends on:** nothing.
 
-### 4. Binary-data returns — structured records (deserialization) — *mechanism LANDED (numeric fields); surface + string fields deferred*
+### 4. Binary-data returns — structured records (deserialization) — *mechanism + destructure surface LANDED (numeric fields)*
 
 **What:** let a grammar return a **compound term** (e.g. `rec(42, 3.14,
 "name")`) that plawk **deserializes** into typed fields against a declared
-return shape — `dyncall(...) as (i64 f64 s16)` → walk the compound's args,
-type each (arg0 Integer→i64, arg1 Float→f64, arg2 Atom→sN), and materialize
-into a record buffer so `$1`,`$2`,`$3` address it like any binary record.
+return shape. Because deserialization means *choosing the target type*, the
+same walked compound can materialize into more than one plawk container
+(see "Target containers" below) — the first shipped target is a set of
+typed scalar variables.
 
-**Mechanism landed (this PR):** the native primitive
+**Mechanism landed:** the native primitive
 `@wam_object_call_record(vm, pc, nargs, args, out_reg, nfields, typecodes,
 out_slots)`. It runs the entry, requires the output cell to deref to a
 **Compound** of arity `nfields`, and deserializes each arg into `out_slots[i]`
@@ -181,18 +183,41 @@ per `typecodes[i]` (`0` → i64, arg must be Integer; `1` → f64, arg must be a
 number, stored as double bits) — **before** the arena rewind, since the
 compound and its arg cells live in the arena (atoms survive; a plain
 `@wam_object_call_*` would rewind them away). Same heap-save/rewind discipline
-as the scalar variants, so a per-record call stays constant-memory. Verified
-end to end: a grammar returning `rec2f(10, 10.5)` → `10` (i64) + `10.5` (f64)
-via a host that calls the primitive with typecodes `[0,1]`. This is the
-"output is a term, not a scalar" plumbing item 2 anticipated.
+as the scalar variants, so a per-record call stays constant-memory. This is
+the "output is a term, not a scalar" plumbing item 2 anticipated.
 
-**Deferred:** (a) **string/atom fields** — the bytes survive the rewind via
-the persistent atom table, but a field needs a `(ptr,len)` slot pair rather
-than one i64, so the typecode set and slot layout grow; (b) the plawk
-`dyncall(...) as (shape)` **surface** — a return-shape parser, wiring the
-`out_slots` into a synthesized `BINFMT`-style record so `$1`,`$2`,`$3` address
-it, and a `dyncache`-style lifetime for the record buffer. Mechanism-first,
-surface-second — the same split used for every earlier item.
+**Destructure surface landed:** `(v1, ..., vn) = dyncall[@name](args) as
+(T1 ... Tn)` binds each returned field to a typed scalar variable — field i
+lands in `vi`, an i64 scalar for `T=i64` or an f64 scalar for `T=f64`. The
+record shims (`@plawk_dyncall_rec_N` / `@plawk_dyncall_named_rec_<Sym>`)
+forward the call-site typecodes + a stack slot array to the primitive, then
+each field is loaded and threaded into the variable's scalar slot like any
+assignment (so `total += n` after a bind works). A failed call zeroes the
+slots. Verified end to end: `rec(X) -> pair(X, X+0.5)`, `(n, half) =
+dyncall@rec($1) as (i64 f64)` over 10,20 → `total=30`, `sum=31.0`. Rides
+`emit_wamo_loader(true)` + per-site collection (no IR when unused).
+
+**Target containers (the "choose the type" generalization):** a return shape
+is really a *marshalling target*, and the walked compound can land in
+different plawk containers — this is the through-line for the rest of item 4:
+
+- **Typed scalars** (`(a,b) = ... as (i64 f64)`) — *landed*.
+- **Record view / field reindex** (`... as (i64 f64) { $1 $2 ... }`) — the
+  more awk-like target: the returned record becomes the current record for a
+  scoped block so `$1`,`$2` read it like a `BINFMT` line, reusing the typed
+  field-read machinery. The maintainer's preferred long-term surface;
+  next phase.
+- **Associative array** (`arr = ... as assoc`) — a grammar returning keyed
+  pairs (`[k1-v1, k2-v2]` or a keyed compound) materializes into plawk's
+  existing assoc-array table, addressed `arr["k"]`.
+- **Positional array** — fields by numeric index into one array value.
+
+Each target reuses one marshaller over the same walked compound; they differ
+only in where fields are written (scalar slots, the line record, an assoc
+table). String/atom fields are the cross-cutting extension: their bytes
+survive the rewind via the persistent atom table, but a field needs a
+`(ptr,len)` slot pair rather than one i64, so the typecode set and slot
+layout grow — add once, and every target gains string fields.
 
 **Why:** this is the *other half* of your binary-return idea — the case
 that **does** need deserialization. It is also the endgame that closes the

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -423,7 +423,12 @@ one `DYNLOAD` object. The `@name` is fixed at compile time, so the entry's
 address is resolved once at startup and reused (a name no entry exposes
 yields 0). `float(dyncall@name(...))` and `blob(dyncall@name(...))` read a
 named entry's output as a double or a byte slice, just like the bare
-`float`/`blob` forms. Bounded repetition handles records containing a
+`float`/`blob` forms. When a grammar returns a **compound record** rather
+than a scalar, destructure it into typed variables:
+`{ (n, half) = dyncall@rec($1) as (i64 f64) }` calls `rec`, expects its
+output to be a 2-arg compound, and binds field 0 to the i64 scalar `n` and
+field 1 to the f64 scalar `half` (a failed call yields zeros). Bounded
+repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an
 ordinary i64 field, element slots are flat addressable fields

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -117,6 +117,8 @@ build(File, Out0, KeepLL) :-
         ; plawk_program_dyncall_named_entries(Program, DynNamed), DynNamed \== []
         ; plawk_program_dyncall_named_float_entries(Program, DynNamedF), DynNamedF \== []
         ; plawk_program_dyncall_named_blob_entries(Program, DynNamedB), DynNamedB \== []
+        ; plawk_program_dyncall_rec_arities(Program, DynRecArities), DynRecArities \== []
+        ; plawk_program_dyncall_named_rec_entries(Program, DynNamedRec), DynNamedRec \== []
         ; plawk_program_dyncall_at_arities(Program, DynAtArities), DynAtArities \== []
         ; plawk_program_dyncall_float_arities(Program, DynFArities), DynFArities \== []
         ; plawk_program_dyncall_at_float_arities(Program, DynAtFArities), DynAtFArities \== []

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -10,6 +10,8 @@
     plawk_program_dyncall_named_entries/2,
     plawk_program_dyncall_named_float_entries/2,
     plawk_program_dyncall_named_blob_entries/2,
+    plawk_program_dyncall_rec_arities/2,
+    plawk_program_dyncall_named_rec_entries/2,
     plawk_program_dyncall_at_arities/2,
     plawk_program_dyncall_float_arities/2,
     plawk_program_dyncall_at_float_arities/2,
@@ -629,6 +631,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_dyncall_named_entries(Program, DynNamed),
     plawk_program_dyncall_named_float_entries(Program, DynNamedF),
     plawk_program_dyncall_named_blob_entries(Program, DynNamedB),
+    plawk_program_dyncall_rec_arities(Program, DynRecArities),
+    plawk_program_dyncall_named_rec_entries(Program, DynNamedRec),
     plawk_program_dyncall_at_arities(Program, DynAtArities),
     plawk_program_dyncall_float_arities(Program, DynFArities),
     plawk_program_dyncall_at_float_arities(Program, DynAtFArities),
@@ -641,6 +645,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         DynNamed == [],
         DynNamedF == [],
         DynNamedB == [],
+        DynRecArities == [],
+        DynNamedRec == [],
         DynAtArities == [],
         DynFArities == [],
         DynAtFArities == [],
@@ -659,7 +665,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         % Object-call shims for dyncall(...) / float(dyncall(...)) /
         % blob(dyncall(...)) sites, plus the shared .wamo object handle.
         (   DynArities == [], DynFArities == [], DynBArities == [],
-            DynNamed == [], DynNamedF == [], DynNamedB == []
+            DynNamed == [], DynNamedF == [], DynNamedB == [],
+            DynRecArities == [], DynNamedRec == []
         ->  DyncallSupportIR = ''
         ;   ( plawk_program_dynload_path(Program, DynPath)
             ->  true
@@ -668,7 +675,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
                         'dyncall(...) requires BEGIN { DYNLOAD = "file.wamo" }')))
             ),
             plawk_dyncall_support_ir(DynPath, DynArities, DynFArities,
-                DynBArities, DynNamed, DynNamedF, DynNamedB, DyncallSupportIR)
+                DynBArities, DynNamed, DynNamedF, DynNamedB,
+                DynRecArities, DynNamedRec, DyncallSupportIR)
         ),
         % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...)) /
         % blob(dyncall_at(...)) sites + the shared path cache.
@@ -812,6 +820,42 @@ plawk_program_dyncall_named_float_entries(Program, Entries) :-
     plawk_program_named_entries_of(float_dyncall_named, Program, Entries).
 plawk_program_dyncall_named_blob_entries(Program, Entries) :-
     plawk_program_named_entries_of(blob_dyncall_named, Program, Entries).
+
+%% plawk_program_dyncall_rec_arities(+Program, -Arities)
+%% plawk_program_dyncall_named_rec_entries(+Program, -Entries)
+%  Structured-return destructure sites -- `(...) = dyncall(...) as (...)`
+%  (default entry, keyed by arg count) and `(...) = dyncall@name(...) as
+%  (...)` (named entry, keyed by Name-NArgs). Each gets a record shim that
+%  fills the caller's typed slots via @wam_object_call_record.
+plawk_program_dyncall_rec_arities(program(_Begin, Rules, EndClauses), Arities) :-
+    findall(NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          member(Action, Actions),
+          plawk_subterm_dynrec_call(Action, dyncall(Args)),
+          length(Args, NArgs)
+        ),
+        Arities0),
+    sort(Arities0, Arities).
+plawk_program_dyncall_named_rec_entries(program(_Begin, Rules, EndClauses),
+        Entries) :-
+    findall(Name-NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          member(Action, Actions),
+          plawk_subterm_dynrec_call(Action, dyncall_named(Name, Args)),
+          length(Args, NArgs)
+        ),
+        Entries0),
+    sort(Entries0, Entries).
+
+plawk_subterm_dynrec_call(dynrec_bind(_Vars, Call, _Types), Call).
+plawk_subterm_dynrec_call(Term, Call) :-
+    compound(Term),
+    arg(_, Term, Sub),
+    plawk_subterm_dynrec_call(Sub, Call).
 
 %% plawk_program_named_entries_of(+Functor, +Program, -Entries)
 %  Deduplicated Name-NArgs pairs for every Functor(Name, Args) node across
@@ -1113,29 +1157,37 @@ fail:
 %  run -- the object-call primitive rewinds the arena per call, so this
 %  stays constant-memory just like the compiled foreign bridge.
 plawk_dyncall_support_ir(Path, Arities, IR) :-
-    plawk_dyncall_support_ir(Path, Arities, [], [], [], [], [], IR).
+    plawk_dyncall_support_ir(Path, Arities, [], [], [], [], [], [], [], IR).
 plawk_dyncall_support_ir(Path, IArities, FArities, IR) :-
-    plawk_dyncall_support_ir(Path, IArities, FArities, [], [], [], [], IR).
+    plawk_dyncall_support_ir(Path, IArities, FArities, [], [], [], [], [], [], IR).
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities, IR) :-
-    plawk_dyncall_support_ir(Path, IArities, FArities, BArities, [], [], [], IR).
+    plawk_dyncall_support_ir(Path, IArities, FArities, BArities, [], [], [], [], [], IR).
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities, NamedEntries, IR) :-
     plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
-        NamedEntries, [], [], IR).
+        NamedEntries, [], [], [], [], IR).
+plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
+        NamedI, NamedF, NamedB, IR) :-
+    plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
+        NamedI, NamedF, NamedB, [], [], IR).
 
 %% plawk_dyncall_support_ir(+Path, +IArities, +FArities, +BArities,
-%%                          +NamedI, +NamedF, +NamedB, -IR)
+%%                          +NamedI, +NamedF, +NamedB, +RecArities,
+%%                          +NamedRec, -IR)
 %  IArities -> i64 @plawk_dyncall_N shims; FArities -> double
 %  @plawk_dyncall_f_N shims (float(dyncall(...))); BArities -> byte-slice
 %  @plawk_dyncall_b_N shims (blob(dyncall(...))). NamedI/NamedF/NamedB are
 %  Name-NArgs lists for dyncall@name / float(dyncall@name) /
-%  blob(dyncall@name): each named entry (across all three kinds) gets ONE
-%  shared PC resolver @plawk_dyncall_resolve_<Name>_<N> that resolves
-%  "Name/(N+1)" to a label index against the DYNLOAD object once and caches
-%  the PC (sentinel -1 = unresolved); the i64/double/byte shims call the
-%  resolver then the matching @wam_object_call_*. All share the single
-%  lazily loaded object handle + @plawk_dyncall_get.
+%  blob(dyncall@name): each named entry (across all kinds) gets ONE shared
+%  PC resolver @plawk_dyncall_resolve_<Name>_<N> that resolves "Name/(N+1)"
+%  to a label index against the DYNLOAD object once and caches the PC
+%  (sentinel -1 = unresolved); the shims call the resolver then the matching
+%  @wam_object_call_*. RecArities -> i1 @plawk_dyncall_rec_N record shims
+%  (default entry) and NamedRec -> @plawk_dyncall_named_rec_<Name>_<N>
+%  record shims, both forwarding to @wam_object_call_record for structured
+%  destructure binds (they also feed the resolver union). All share the
+%  single lazily loaded object handle + @plawk_dyncall_get.
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
-        NamedI, NamedF, NamedB, IR) :-
+        NamedI, NamedF, NamedB, RecArities, NamedRec, IR) :-
     llvm_emit_c_string_global('plawk_dyncall_path', Path, PathGlobal,
         _StrLen, BytesLen),
     format(atom(GetterIR),
@@ -1171,7 +1223,9 @@ load:
         ( member(BN, BArities), plawk_dyncall_shim_b_ir(BN, BShimIR) ),
         BShims),
     % one shared resolver per named entry, over the union of the kinds
-    append([NamedI, NamedF, NamedB], NamedAll0),
+    % (record binds that name an entry feed the union too, so their
+    % resolver exists even when the entry is used nowhere else)
+    append([NamedI, NamedF, NamedB, NamedRec], NamedAll0),
     sort(NamedAll0, NamedAll),
     findall(ResIR,
         ( member(REName-RENArgs, NamedAll),
@@ -1189,9 +1243,71 @@ load:
         ( member(NBName-NBNArgs, NamedB),
           plawk_dyncall_named_shim_b_ir(NBName, NBNArgs, NBShim) ),
         NBShims),
+    findall(RecShim,
+        ( member(RN, RecArities), plawk_dyncall_rec_shim_ir(RN, RecShim) ),
+        RecShims),
+    findall(NRecShim,
+        ( member(NRName-NRNArgs, NamedRec),
+          plawk_dyncall_named_rec_shim_ir(NRName, NRNArgs, NRecShim) ),
+        NRecShims),
     append([[PathGlobal, GetterIR], IShims, FShims, BShims,
-            Resolvers, NIShims, NFShims, NBShims], Parts),
+            Resolvers, NIShims, NFShims, NBShims, RecShims, NRecShims], Parts),
     atomic_list_concat(Parts, '\n\n', IR).
+
+%% plawk_dyncall_rec_shim_ir(+NArgs, -IR)
+%  Record shim for a default-entry destructure bind: resolve vm/pc from the
+%  shared object handle, box the N call args, and forward the caller's
+%  (nfields, typecodes, slots) to @wam_object_call_record. Returns i1 ok.
+plawk_dyncall_rec_shim_ir(NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define i1 @plawk_dyncall_rec_~w(~w, i32 %nfields, i8* %tc, i64* %slots) {
+entry:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %pc = load i32, i32* @plawk_dyncall_pc
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call i1 @wam_object_call_record(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, i32 %nfields, i8* %tc, i64* %slots)
+  ret i1 %r
+
+fail:
+  ret i1 false
+}',
+        [NArgs, ParamsIR, NArgs, StoreIR, NArgs, NArgs]).
+
+%% plawk_dyncall_named_rec_shim_ir(+Name, +NArgs, -IR)
+%  Record shim for a named-entry destructure bind: resolve the PC via the
+%  shared @plawk_dyncall_resolve_<Sym>, box args, forward to
+%  @wam_object_call_record. Returns i1 ok ({slots} untouched on failure).
+plawk_dyncall_named_rec_shim_ir(Name, NArgs, IR) :-
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define i1 @plawk_dyncall_named_rec_~w(~w, i32 %nfields, i8* %tc, i64* %slots) {
+entry:
+  %pc = call i32 @plawk_dyncall_resolve_~w()
+  %bad = icmp slt i32 %pc, 0
+  br i1 %bad, label %fail, label %do_call
+
+do_call:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call i1 @wam_object_call_record(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, i32 %nfields, i8* %tc, i64* %slots)
+  ret i1 %r
+
+fail:
+  ret i1 false
+}',
+        [Sym, ParamsIR, Sym, NArgs, StoreIR, NArgs, NArgs]).
 
 %% plawk_dyncall_named_symbol(+Name, +NArgs, -Sym)
 %  The LLVM symbol suffix for a named-entry shim: <Name>_<NArgs>. Name is
@@ -2528,6 +2644,13 @@ plawk_scalar_typed_slots(Rules, Names, Slots) :-
 plawk_scalar_update_name_expr(Action, Name, Expr) :-
     plawk_scalar_action_update(Action, Name, Operation),
     plawk_scalar_operation_expr(Operation, Expr).
+% Type inference for a destructure bind: field Ti gives Vi a double-typed
+% sentinel (f64) or an i64-typed one, so the scalar_double fixpoint types
+% each slot correctly without a real RHS expression.
+plawk_scalar_update_name_expr(dynrec_bind(Vars, _Call, Types), Name, Expr) :-
+    nth0(I, Vars, Name),
+    nth0(I, Types, Type),
+    ( Type == f64 -> Expr = float_const(0, 1) ; Expr = int(0) ).
 plawk_scalar_update_name_expr(if(_Pattern, ThenActions, ElseActions), Name, Expr) :-
     ( member(Action, ThenActions)
     ; member(Action, ElseActions)
@@ -3187,6 +3310,11 @@ plawk_binfmt_actions_ok(Descriptor, Actions) :-
 
 plawk_binfmt_action_ok(_Descriptor, next) :- !.
 plawk_binfmt_action_ok(_Descriptor, break) :- !.
+plawk_binfmt_action_ok(Descriptor, dynrec_bind(Vars, Call, Types)) :-
+    !,
+    plawk_dynrec_bind_ok(dynrec_bind(Vars, Call, Types)),
+    plawk_dynrec_call_parts(Call, Args, _ShimName),
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
 plawk_binfmt_action_ok(Descriptor, inc(var(_Name))) :- !,
     Descriptor = binfmt(_).
 plawk_binfmt_action_ok(Descriptor, add(var(_Name), Expr)) :-
@@ -5352,9 +5480,13 @@ plawk_scalar_update_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
 plawk_scalar_update_action(Action) :-
     plawk_scalar_conditional_action(Action).
+plawk_scalar_update_action(Action) :-
+    plawk_dynrec_bind_ok(Action).
 
 plawk_scalar_rule_body_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
+plawk_scalar_rule_body_action(Action) :-
+    plawk_dynrec_bind_ok(Action).
 plawk_scalar_rule_body_action(Action) :-
     plawk_rule_body_print_action(Action).
 plawk_scalar_rule_body_action(writebin_out(Types, Fields)) :-
@@ -5496,6 +5628,116 @@ plawk_float_dyncall_named_expr(float_dyncall_named(Name, Args)) :-
 plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)) :-
     plawk_foreign_arg(Source),
     maplist(plawk_foreign_arg, Args).
+
+%% plawk_dynrec_bind_ok(+Action) is semidet.
+%
+%  A structured-return destructuring bind
+%  `(V1, ..., Vn) = <dyncall> as (T1 ... Tn)` is compilable when: the
+%  variables are distinct atoms, the type list is the same length and
+%  every type is i64 or f64, and the call is a bare dyncall(...) (default
+%  entry) or dyncall@name(...) (named entry). Each Vi becomes a scalar
+%  slot typed by Ti (f64 -> double slot, i64 -> counter slot); the
+%  grammar's returned Compound is deserialized field-by-field into them
+%  via @wam_object_call_record. (dyncall_at sources and string fields are
+%  planned follow-ons.)
+plawk_dynrec_bind_ok(dynrec_bind(Vars, Call, Types)) :-
+    Vars = [_ | _],
+    maplist(atom, Vars),
+    sort(Vars, Sorted), same_length(Vars, Sorted),   % distinct
+    same_length(Vars, Types),
+    maplist(plawk_dynrec_type_ok, Types),
+    plawk_dynrec_call_ok(Call).
+
+plawk_dynrec_type_ok(i64).
+plawk_dynrec_type_ok(f64).
+
+plawk_dynrec_call_ok(dyncall(Args)) :-
+    plawk_dyncall_expr(dyncall(Args)).
+plawk_dynrec_call_ok(dyncall_named(Name, Args)) :-
+    plawk_dyncall_named_expr(dyncall_named(Name, Args)).
+
+%% plawk_dynrec_type_code(+Type, -Byte)  i64 -> 0, f64 -> 1 (typecodes byte).
+plawk_dynrec_type_code(i64, 0).
+plawk_dynrec_type_code(f64, 1).
+
+%% plawk_dynrec_bind_pair(+Vars, +Call, +Types, +FieldSeparator, +Base,
+%%                        +Slots, +Values0, -Values, -GlobalIR-LineIR)
+%
+%  Emit the IR for one destructure bind and thread the scalar slot values.
+%  Line IR: evaluate the call args, alloca an i64[nfields] slot array
+%  (zero-init so a failed call reads as 0/0.0), call the record shim
+%  (@plawk_dyncall_rec_<N> or @plawk_dyncall_named_rec_<Sym>) which fills
+%  the slots via @wam_object_call_record, then load each field (i64 direct,
+%  f64 as bitcast-from-bits). Each bound variable's threaded slot value is
+%  set to its loaded field SSA, so the surrounding scalar dataflow (loop
+%  phis, final slot copies) carries it like any other assignment.
+plawk_dynrec_bind_pair(Vars, Call, Types, FieldSeparator, Base, Slots,
+        Values0, Values, GlobalIR-LineIR) :-
+    length(Types, NFields),
+    maplist(plawk_dynrec_type_code, Types, Codes),
+    plawk_dynrec_typecodes_escaped(Codes, Escaped),
+    format(atom(TCGlobal),
+        '@.~w_tc = private constant [~w x i8] c"~w"', [Base, NFields, Escaped]),
+    plawk_dynrec_call_parts(Call, Args, ShimName),
+    plawk_foreign_args_ir(Args, FieldSeparator, Base, ArgValueIRs,
+        ArgGlobals, ArgSetup),
+    plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
+    NLast is NFields - 1,
+    numlist(0, NLast, Fields),
+    findall(ZLine,
+        ( member(FZ, Fields),
+          format(atom(ZLine),
+              '  %~w_z~wp = getelementptr i64, i64* %~w_slots, i64 ~w\n  store i64 0, i64* %~w_z~wp',
+              [Base, FZ, Base, FZ, Base, FZ]) ),
+        ZeroLines),
+    format(atom(AllocaIR), '  %~w_slots = alloca i64, i32 ~w', [Base, NFields]),
+    format(atom(TCPtrIR),
+        '  %~w_tcp = getelementptr [~w x i8], [~w x i8]* @.~w_tc, i32 0, i32 0',
+        [Base, NFields, NFields, Base]),
+    format(atom(CallIR),
+        '  %~w_ok = call i1 @~w(~w, i32 ~w, i8* %~w_tcp, i64* %~w_slots)',
+        [Base, ShimName, CallArgsIR, NFields, Base, Base]),
+    plawk_dynrec_field_load_lines(Fields, Types, Base, LoadLines),
+    append([ArgSetup, [AllocaIR], ZeroLines, [TCPtrIR, CallIR], LoadLines],
+        LineList),
+    atomic_list_concat(LineList, '\n', LineIR),
+    atomic_list_concat([TCGlobal | ArgGlobals], '\n', GlobalIR),
+    plawk_dynrec_update_slots(Vars, 0, Base, Slots, Values0, Values).
+
+plawk_dynrec_typecodes_escaped(Codes, Escaped) :-
+    findall(S, ( member(C, Codes), format(atom(S), '\\0~w', [C]) ), Parts),
+    atomic_list_concat(Parts, Escaped).
+
+plawk_dynrec_call_parts(dyncall(Args), Args, ShimName) :-
+    length(Args, NArgs),
+    format(atom(ShimName), 'plawk_dyncall_rec_~w', [NArgs]).
+plawk_dynrec_call_parts(dyncall_named(Name, Args), Args, ShimName) :-
+    length(Args, NArgs),
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    format(atom(ShimName), 'plawk_dyncall_named_rec_~w', [Sym]).
+
+plawk_dynrec_field_load_lines([], [], _Base, []).
+plawk_dynrec_field_load_lines([F | Fs], [Type | Ts], Base, [Line | Lines]) :-
+    (   Type == f64
+    ->  format(atom(Line),
+            '  %~w_s~wp = getelementptr i64, i64* %~w_slots, i64 ~w\n  %~w_f~wbits = load i64, i64* %~w_s~wp\n  %~w_f~w = bitcast i64 %~w_f~wbits to double',
+            [Base, F, Base, F, Base, F, Base, F, Base, F, Base, F])
+    ;   format(atom(Line),
+            '  %~w_s~wp = getelementptr i64, i64* %~w_slots, i64 ~w\n  %~w_f~w = load i64, i64* %~w_s~wp',
+            [Base, F, Base, F, Base, F, Base, F])
+    ),
+    plawk_dynrec_field_load_lines(Fs, Ts, Base, Lines).
+
+% Point each bound variable's threaded slot value at its loaded field SSA.
+plawk_dynrec_update_slots([], _I, _Base, _Slots, Values, Values).
+plawk_dynrec_update_slots([Var | Rest], I, Base, Slots, Values0, Values) :-
+    format(atom(SSA), '%~w_f~w', [Base, I]),
+    nth0(SlotIndex, Slots, Slot),
+    plawk_slot_name(Slot, Var),
+    !,
+    replace_nth0(SlotIndex, Values0, SSA, Values1),
+    I1 is I + 1,
+    plawk_dynrec_update_slots(Rest, I1, Base, Slots, Values1, Values).
 
 %% plawk_f64_call_tail_ir(+Base, +ResIR, +PreSetup, -ValueIR, -SetupParts)
 %  Shared {double,i1} call tail: unpack value/ok and select 0.0 on failure.
@@ -5655,6 +5897,8 @@ plawk_scalar_update_action_name(Action, Name) :-
     ;   plawk_scalar_operation_expr(Operation, Expr),
         plawk_expr_scalar_read_name(Expr, Name)
     ).
+plawk_scalar_update_action_name(dynrec_bind(Vars, _Call, _Types), Name) :-
+    member(Name, Vars).
 plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
     ( member(Action, ThenActions)
     ; member(Action, ElseActions)
@@ -5765,6 +6009,17 @@ plawk_f64_scalar_read_operand_expr(Expr) :-
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, CurrentLabel, []) -->
     [].
+plawk_scalar_action_sequence_pairs([dynrec_bind(Vars, Call, Types) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { plawk_dynrec_bind_ok(dynrec_bind(Vars, Call, Types)),
+      format(atom(Base), '~w_dynrec_~w', [Prefix, OpIndex]),
+      plawk_dynrec_bind_pair(Vars, Call, Types, FieldSeparator, Base, Slots,
+          Values0, Values1, Pair),
+      NextOpIndex is OpIndex + 1
+    },
+    [Pair],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values1, Values, FinalOpIndex, ExitLabel, NextExits).
 plawk_scalar_action_sequence_pairs([Action | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
         OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
     { plawk_scalar_action_update(Action, Name, Operation0),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -824,6 +824,9 @@ action(Action) -->
     break_action(Action),
     !.
 action(Action) -->
+    dynrec_bind_action(Action),
+    !.
+action(Action) -->
     add_assign_action(Action),
     !.
 action(Action) -->
@@ -890,6 +893,61 @@ next_action(next) -->
 break_action(break) -->
     "break",
     identifier_boundary.
+
+%% dynrec_bind_action(-Action)//
+%
+%  Structured-return destructuring: bind each field of a grammar's compound
+%  return to a scalar variable, typed by a return shape.
+%
+%      (n, half) = dyncall@rec($1) as (i64 f64)
+%
+%  desugars to dynrec_bind([n, half], dyncall_named(rec, [field(1)]),
+%  [i64, f64]); field 0 lands in the i64 scalar n, field 1 in the f64
+%  scalar half. The call is a bare dyncall(...) (default entry) or a
+%  dyncall@name(...) (named entry); the type list is whitespace-separated
+%  i64 / f64 tokens (one per bound variable).
+dynrec_bind_action(dynrec_bind(Vars, Call, Types)) -->
+    "(",
+    ws,
+    dynrec_var_list(Vars),
+    ws,
+    ")",
+    ws,
+    "=",
+    ws,
+    dynrec_call_expr(Call),
+    ws,
+    "as",
+    identifier_boundary,
+    ws,
+    "(",
+    ws,
+    dynrec_type_list(Types),
+    ws,
+    ")".
+
+dynrec_var_list([Name | Rest]) -->
+    identifier(Name),
+    dynrec_var_list_rest(Rest).
+dynrec_var_list_rest([Name | Rest]) -->
+    ws, ",", ws, identifier(Name), !, dynrec_var_list_rest(Rest).
+dynrec_var_list_rest([]) -->
+    [].
+
+dynrec_call_expr(Call) -->
+    prolog_call_expr(Call),
+    { ( Call = dyncall(_) ; Call = dyncall_named(_, _) ) }.
+
+dynrec_type_list([Type | Rest]) -->
+    dynrec_type(Type),
+    dynrec_type_list_rest(Rest).
+dynrec_type_list_rest([Type | Rest]) -->
+    ws, dynrec_type(Type), !, dynrec_type_list_rest(Rest).
+dynrec_type_list_rest([]) -->
+    [].
+
+dynrec_type(i64) --> "i64".
+dynrec_type(f64) --> "f64".
 
 add_assign_action(add(var(Name), Delta)) -->
     identifier(Name),

--- a/tests/test_plawk_dyncall_struct.pl
+++ b/tests/test_plawk_dyncall_struct.pl
@@ -1,0 +1,147 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Phase 5 (JIT) roadmap item 4, surface: structured-return destructuring.
+% `(v1, ..., vn) = dyncall[@name](args) as (T1 ... Tn)` calls a grammar
+% whose entry returns a Compound and deserializes each arg into a typed
+% scalar variable (i64 or f64), via @wam_object_call_record. Chosen surface
+% is "destructure to variables" (record-view $1.. reindex is a later phase).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammar predicates compiled into one multi-entry .wamo. Each returns a
+% Compound record (arity 2): an integer field and a float field.
+rec(X, R)  :- H is X + 0.5, R = pair(X, H).       % rec(10) -> pair(10, 10.5)
+rec2(X, R) :- D is X * 2, H is X / 4.0, R = pair(D, H). % rec2(10)-> pair(20,2.5)
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_struct).
+
+% The destructure statement parses to its own node.
+test(struct_parse) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         { (n, half) = dyncall@rec($1) as (i64 f64) }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(dynrec_bind([n, half], dyncall_named(rec, [field(1)]),
+        [i64, f64]), Actions),
+    !.
+
+% A malformed shape (arity mismatch) is not a valid destructure.
+test(struct_arity_mismatch_rejected) :-
+    \+ plawk_native_codegen:plawk_dynrec_bind_ok(
+        dynrec_bind([a, b], dyncall(_), [i64])),
+    !.
+
+% Record shim + primitive call are emitted (named entry here).
+test(struct_ir_emitted) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"lib.wamo\" }\n\c
+         { (n, half) = dyncall@rec($1) as (i64 f64) ; total += n }\n\c
+         END { print total }\n",
+        Program),
+    plawk_program_dyncall_named_rec_entries(Program, Entries),
+    assertion(Entries == [rec-1]),
+    plawk_program_native_driver_ir(Program, stdin_or_argv,
+        [wam_vm(10, 10)], IR),
+    sub_atom(IR, _, _, _, '@plawk_dyncall_named_rec_rec_1'),
+    sub_atom(IR, _, _, _, '@wam_object_call_record'),
+    !.
+
+% Full round trip: rec(X) returns pair(X, X+0.5). Destructure into an i64
+% (n) and an f64 (half); accumulate both. For inputs 10, 20:
+%   n:    10 + 20            = 30
+%   half: 10.5 + 20.5        = 31.0
+test(struct_destructure_runs, [condition(clang_available)]) :-
+    st_dir(Dir),
+    directory_file_path(Dir, 'lib.wamo', Wamo),
+    write_wam_object([user:rec/2, user:rec2/2],
+        [wamo_entries([rec/2, rec2/2])], Wamo),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { (n, half) = dyncall@rec($1) as (i64 f64) ; total += n ; sum += half }\n\c
+         END { print total }\n", [Wamo]),
+    write_prog(Dir, 'st.plawk', Src),
+    directory_file_path(Dir, 'st.plawk', Prog),
+    directory_file_path(Dir, 'st_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'in.bin', Input),
+    write_i64_records(Input, [10, 20]),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "30\n"),
+    !.
+
+% The float half of the same destructure: print the accumulated f64 sum
+% (10.5 + 20.5 = 31), proving the second field deserialized as a double.
+test(struct_destructure_float_field, [condition(clang_available)]) :-
+    st_dir(Dir),
+    directory_file_path(Dir, 'lib.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:rec/2, user:rec2/2],
+          [wamo_entries([rec/2, rec2/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { (n, half) = dyncall@rec($1) as (i64 f64) ; sum += half }\n\c
+         END { print sum }\n", [Wamo]),
+    write_prog(Dir, 'stf.plawk', Src),
+    directory_file_path(Dir, 'stf.plawk', Prog),
+    directory_file_path(Dir, 'stf_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'in.bin', Input),
+    write_i64_records(Input, [10, 20]),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "31\n"),
+    !.
+
+:- end_tests(plawk_dyncall_struct).
+
+% --- helpers ---------------------------------------------------------------
+
+st_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_dyncall_struct', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Text) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(
+        open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text),
+        close(Out)).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_i64_records(Path, Values) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(V, Values), write_i64_le(Out, V)),
+        close(Out)).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(null), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## What

The **plawk surface** for item 4's structured returns (mechanism landed in #3475). Chosen model: **destructure to typed variables** (the record-view `$1..` reindex is a planned later phase).

```awk
BEGIN { BINFMT = "i64" ; DYNLOAD = "lib.wamo" }
{ (n, half) = dyncall@rec($1) as (i64 f64) ; total += n ; sum += half }
END { print total }
```

`(v1, ..., vn) = dyncall[@name](args) as (T1 ... Tn)` calls a grammar whose entry returns a Compound and binds each field to a **typed scalar variable**: field *i* lands in `vi` — an i64 scalar for `T=i64`, an f64 scalar for `T=f64`. The bound variables are ordinary scalars afterward, so `total += n` composes normally. A failed call zeroes the slots.

## How it threads the scalar dataflow

plawk tracks scalars as SSA values through a per-rule slot dataflow (not mutable stores), so the bind integrates at each stage rather than bolting on:

- **Parser**: `dynrec_bind(Vars, Call, Types)`, `Call` ∈ `dyncall(...)` | `dyncall@name(...)`.
- **Discovery/typing**: vars are found as slots (`plawk_scalar_update_action_name`) and typed by their field type (`plawk_scalar_update_name_expr` feeds the existing double fixpoint → i64 vs f64 slot).
- **Validation**: recognized in the scalar / BINFMT / rule-body gates via `plawk_dynrec_bind_ok`.
- **Emission** (`plawk_dynrec_bind_pair`): alloca an `i64[nfields]` slot array (zero-init for failure), call a record shim, load each field (i64 direct, f64 via bitcast), thread each into its variable's slot.
- **Shims**: `@plawk_dyncall_rec_N` (default entry) / `@plawk_dyncall_named_rec_<Sym>` (named, reusing the shared PC resolver from #3474) forward the call-site typecodes + slots to `@wam_object_call_record`.

All gated on `emit_wamo_loader(true)` + per-site collection — unused programs emit none of it.

## Tests

New `tests/test_plawk_dyncall_struct.pl` (5): parse, arity-mismatch rejection, shim/primitive IR presence + entry collection, and two end-to-end round trips — `rec(X) -> pair(X, X+0.5)` over inputs 10,20 gives the i64 field summing to `total=30` and the f64 field to `sum=31`. Full `wam_object` / `dyncall*` / CLI / binary-record / float-slot / arith suites pass.

## Roadmap

Item 4 reframed around the maintainer's insight that **deserialization means choosing the target type** — the same walked compound can materialize into different plawk containers over one marshaller:

- **typed scalars** (this PR) — landed
- **record view** (`... as (i64 f64) { $1 $2 }`, `$1..` reindex) — the awk-like next phase
- **associative array** (`arr = ... as assoc`)
- **positional array**

String/atom fields (a `(ptr,len)` slot pair) are the cross-cutting extension every target shares — add once, all targets gain strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_