### PR TITLE
plawk/JIT (roadmap #4): record-view target for structured returns

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -24,7 +24,8 @@ The dynamic-grammar surface is feature-complete for numeric work:
 | plawk surface A — `dyncall@name(...)` (named entry, compile-time-fixed, cached PC) | #3473 |
 | `float(dyncall@name(...))` / `blob(dyncall@name(...))` (named double / byte returns, shared resolver) | #3474 |
 | Structured returns — `@wam_object_call_record` (deserialize a returned Compound's args into typed i64/f64 slots) | #3475 |
-| Destructure surface — `(a, b) = dyncall[@name](args) as (i64 f64)` binds fields to typed scalars | this PR |
+| Destructure surface — `(a, b) = dyncall[@name](args) as (i64 f64)` binds fields to typed scalars | #3476 |
+| Record-view surface — `dyncall[@name](args) as (i64 f64) { … $1 $2 … }` reads the return like the current record | this PR |
 
 A grammar is compiled ahead of time to a `.wamo`, loaded at runtime (from a
 fixed path, an in-memory buffer, or a per-call runtime source), cached with
@@ -202,11 +203,16 @@ is really a *marshalling target*, and the walked compound can land in
 different plawk containers — this is the through-line for the rest of item 4:
 
 - **Typed scalars** (`(a,b) = ... as (i64 f64)`) — *landed*.
-- **Record view / field reindex** (`... as (i64 f64) { $1 $2 ... }`) — the
-  more awk-like target: the returned record becomes the current record for a
-  scoped block so `$1`,`$2` read it like a `BINFMT` line, reusing the typed
-  field-read machinery. The maintainer's preferred long-term surface;
-  next phase.
+- **Record view / field reindex** (`... as (i64 f64) { $1 $2 ... }`) —
+  *landed*. The returned compound reads like the current record inside the
+  block: `$k` accesses field k. Implemented by **desugaring** to a
+  destructure into hidden per-site temporaries plus the block body with
+  every `$k` (1≤k≤nfields) rewritten to the k-th temporary — so it rides the
+  destructure machinery with no field-pointer repoint. A body field outside
+  1..nfields (including `$0`) leaves the view uncompilable (the record has no
+  such field). Recurses into if-branches; a view nested in a for-in body is a
+  follow-on. Verified: `dyncall@rec($1) as (i64 f64) { total += $1 }` sums
+  the i64 field to 30; `{ sum += $2 }` sums the f64 field to 31.
 - **Associative array** (`arr = ... as assoc`) — a grammar returning keyed
   pairs (`[k1-v1, k2-v2]` or a keyed compound) materializes into plawk's
   existing assoc-array table, addressed `arr["k"]`.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -427,7 +427,10 @@ named entry's output as a double or a byte slice, just like the bare
 than a scalar, destructure it into typed variables:
 `{ (n, half) = dyncall@rec($1) as (i64 f64) }` calls `rec`, expects its
 output to be a 2-arg compound, and binds field 0 to the i64 scalar `n` and
-field 1 to the f64 scalar `half` (a failed call yields zeros). Bounded
+field 1 to the f64 scalar `half` (a failed call yields zeros). The awk-like
+**record view** reads the return like the current record inside a block:
+`{ dyncall@rec($1) as (i64 f64) { total += $1 ; sum += $2 } }` makes `$1`,
+`$2` the returned record's fields for that block. Bounded
 repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -236,7 +236,8 @@ plawk_program_native_driver_ir(
 ) :-
     plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules1, WritebinPlan),
     plawk_record_descriptor(BeginClauses, FieldSeparator),
-    plawk_resolve_foreach_rules(FieldSeparator, Rules1, Rules),
+    plawk_resolve_dynrec_view_rules(Rules1, Rules1b),
+    plawk_resolve_foreach_rules(FieldSeparator, Rules1b, Rules),
     plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
@@ -852,6 +853,7 @@ plawk_program_dyncall_named_rec_entries(program(_Begin, Rules, EndClauses),
     sort(Entries0, Entries).
 
 plawk_subterm_dynrec_call(dynrec_bind(_Vars, Call, _Types), Call).
+plawk_subterm_dynrec_call(dynrec_view(Call, _Types, _Body), Call).
 plawk_subterm_dynrec_call(Term, Call) :-
     compound(Term),
     arg(_, Term, Sub),
@@ -5659,6 +5661,77 @@ plawk_dynrec_call_ok(dyncall_named(Name, Args)) :-
 %% plawk_dynrec_type_code(+Type, -Byte)  i64 -> 0, f64 -> 1 (typecodes byte).
 plawk_dynrec_type_code(i64, 0).
 plawk_dynrec_type_code(f64, 1).
+
+%% plawk_resolve_dynrec_view_rules(+Rules0, -Rules)
+%
+%  Desugar record-view blocks. `dyncall[@name](args) as (T1..Tn) { Body }`
+%  becomes a destructure into fresh hidden temporaries followed by Body with
+%  every `$k` (field(k) / float_field(k), 1<=k<=n) rewritten to the k-th
+%  temporary -- so the returned record reads like the current record inside
+%  the block, riding the destructure machinery with no field-pointer
+%  repoint. A per-site counter keeps temp names unique; if the body
+%  references a field outside 1..n (including $0), it does not rewrite and
+%  the view is left uncompilable (the record has no such field). Recurses
+%  into if-branches; a view nested in a for-in body is a follow-on.
+plawk_resolve_dynrec_view_rules(Rules0, Rules) :-
+    plawk_resolve_dynrec_view_rules(Rules0, 0, Rules).
+
+plawk_resolve_dynrec_view_rules([], _, []).
+plawk_resolve_dynrec_view_rules([rule(Pattern, Actions0) | Rest], K0,
+        [rule(Pattern, Actions) | RestOut]) :-
+    !,
+    plawk_resolve_dynrec_view_actions(Actions0, K0, K1, Actions),
+    plawk_resolve_dynrec_view_rules(Rest, K1, RestOut).
+plawk_resolve_dynrec_view_rules([Other | Rest], K0, [Other | RestOut]) :-
+    plawk_resolve_dynrec_view_rules(Rest, K0, RestOut).
+
+plawk_resolve_dynrec_view_actions([], K, K, []).
+plawk_resolve_dynrec_view_actions([A0 | As0], K0, K, Out) :-
+    plawk_resolve_dynrec_view_action(A0, K0, K1, Expanded),
+    plawk_resolve_dynrec_view_actions(As0, K1, K, RestOut),
+    append(Expanded, RestOut, Out).
+
+plawk_resolve_dynrec_view_action(dynrec_view(Call, Types, Body0), K0, K,
+        [dynrec_bind(Temps, Call, Types) | Body]) :-
+    !,
+    length(Types, NFields),
+    plawk_dynrec_temp_names(K0, NFields, Temps),
+    K1 is K0 + 1,
+    plawk_resolve_dynrec_view_actions(Body0, K1, K, Body1),
+    maplist(plawk_dynrec_rewrite_field_refs(Temps, NFields), Body1, Body),
+    \+ plawk_term_has_field_ref(Body).
+plawk_resolve_dynrec_view_action(if(Pattern, Then0, Else0), K0, K,
+        [if(Pattern, Then, Else)]) :-
+    !,
+    plawk_resolve_dynrec_view_actions(Then0, K0, K1, Then),
+    plawk_resolve_dynrec_view_actions(Else0, K1, K, Else).
+plawk_resolve_dynrec_view_action(Action, K, K, [Action]).
+
+plawk_dynrec_temp_names(K, NFields, Temps) :-
+    numlist(1, NFields, Is),
+    findall(T,
+        ( member(I, Is), format(atom(T), '__dynrec_~w_~w', [K, I]) ),
+        Temps).
+
+% Rewrite $k field references (1..NF) to the k-th destructure temporary.
+plawk_dynrec_rewrite_field_refs(Temps, NF, field(N), var(T)) :-
+    integer(N), N >= 1, N =< NF, !, nth1(N, Temps, T).
+plawk_dynrec_rewrite_field_refs(Temps, NF, float_field(N), var(T)) :-
+    integer(N), N >= 1, N =< NF, !, nth1(N, Temps, T).
+plawk_dynrec_rewrite_field_refs(_Temps, _NF, Term, Term) :-
+    ( var(Term) ; atomic(Term) ), !.
+plawk_dynrec_rewrite_field_refs(Temps, NF, Term0, Term) :-
+    Term0 =.. [F | Args0],
+    maplist(plawk_dynrec_rewrite_field_refs(Temps, NF), Args0, Args),
+    Term =.. [F | Args].
+
+plawk_term_has_field_ref(Term) :-
+    ( Term = field(_) ; Term = float_field(_) ),
+    !.
+plawk_term_has_field_ref(Term) :-
+    compound(Term),
+    arg(_, Term, Sub),
+    plawk_term_has_field_ref(Sub).
 
 %% plawk_dynrec_bind_pair(+Vars, +Call, +Types, +FieldSeparator, +Base,
 %%                        +Slots, +Values0, -Values, -GlobalIR-LineIR)

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -824,6 +824,9 @@ action(Action) -->
     break_action(Action),
     !.
 action(Action) -->
+    dynrec_view_action(Action),
+    !.
+action(Action) -->
     dynrec_bind_action(Action),
     !.
 action(Action) -->
@@ -906,6 +909,31 @@ break_action(break) -->
 %  scalar half. The call is a bare dyncall(...) (default entry) or a
 %  dyncall@name(...) (named entry); the type list is whitespace-separated
 %  i64 / f64 tokens (one per bound variable).
+%% dynrec_view_action(-Action)//
+%
+%  Structured-return record view: the returned compound becomes the current
+%  record for a scoped block, so `$1`,`$2` read its fields like a BINFMT
+%  line.
+%
+%      dyncall@rec($1) as (i64 f64) { total += $1 ; sum += $2 }
+%
+%  desugars (in codegen) to a destructure into hidden temporaries plus the
+%  block body with `$N` rewritten to the Nth temporary -- so it rides the
+%  same machinery as the explicit destructure, no field-pointer repoint.
+dynrec_view_action(dynrec_view(Call, Types, Body)) -->
+    dynrec_call_expr(Call),
+    ws,
+    "as",
+    identifier_boundary,
+    ws,
+    "(",
+    ws,
+    dynrec_type_list(Types),
+    ws,
+    ")",
+    ws,
+    action_block(Body).
+
 dynrec_bind_action(dynrec_bind(Vars, Call, Types)) -->
     "(",
     ws,

--- a/tests/test_plawk_dyncall_record_view.pl
+++ b/tests/test_plawk_dyncall_record_view.pl
@@ -1,0 +1,134 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Phase 5 (JIT) roadmap item 4, record-view target: the awk-like surface
+% for structured returns. `dyncall[@name](args) as (T1 ... Tn) { Body }`
+% makes the returned compound the current record inside Body, so `$1`,`$2`
+% read its fields. It desugars to a destructure into hidden temporaries
+% plus Body with `$k` rewritten to the k-th temporary -- no field-pointer
+% repoint, riding the destructure machinery landed earlier.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% rec(X) returns a 2-field compound pair(X, X+0.5): field 0 i64, field 1 f64.
+rec(X, R) :- H is X + 0.5, R = pair(X, H).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_record_view).
+
+% The view block parses to its own node with the body carrying $1/$2.
+test(view_parse) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         { dyncall@rec($1) as (i64 f64) { total += $1 ; sum += $2 } }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(dynrec_view(dyncall_named(rec, [field(1)]), [i64, f64],
+        [add(var(total), field(1)), add(var(sum), field(2))]), Actions),
+    !.
+
+% The desugar rewrites $k in the body to per-site temporaries and prepends
+% the destructure bind; no field references survive.
+test(view_desugars_to_bind) :-
+    Rules = [rule(always, [dynrec_view(dyncall_named(rec, [field(1)]),
+        [i64, f64], [add(var(total), field(1)), add(var(sum), field(2))])])],
+    plawk_native_codegen:plawk_resolve_dynrec_view_rules(Rules, [rule(always, Out)]),
+    Out = [dynrec_bind(Temps, dyncall_named(rec, [field(1)]), [i64, f64]),
+           add(var(total), var(T1)), add(var(sum), var(T2))],
+    Temps = [T1, T2],
+    % the body no longer references $1/$2 (only the bind's call arg does)
+    \+ plawk_native_codegen:plawk_term_has_field_ref(
+        [add(var(total), var(T1)), add(var(sum), var(T2))]),
+    !.
+
+% A view whose body reads a field outside 1..nfields does not desugar
+% (the record has no such field) -> the pass leaves it uncompilable.
+test(view_out_of_range_field_rejected) :-
+    Rules = [rule(always, [dynrec_view(dyncall(_), [i64],
+        [add(var(t), field(3))])])],
+    \+ plawk_native_codegen:plawk_resolve_dynrec_view_rules(Rules, _),
+    !.
+
+% Full round trip, i64 field via $1: sum field 0 over inputs 10, 20 -> 30.
+test(view_i64_field_runs, [condition(clang_available)]) :-
+    rv_dir(Dir),
+    directory_file_path(Dir, 'lib.wamo', Wamo),
+    write_wam_object([user:rec/2], [wamo_entries([rec/2])], Wamo),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { dyncall@rec($1) as (i64 f64) { total += $1 } }\n\c
+         END { print total }\n", [Wamo]),
+    build_run(Dir, 'rvi', Src, [10, 20], Out),
+    assertion(Out == "30\n"),
+    !.
+
+% Full round trip, f64 field via $2: sum field 1 (X+0.5) over 10, 20 ->
+% 10.5 + 20.5 = 31.
+test(view_f64_field_runs, [condition(clang_available)]) :-
+    rv_dir(Dir),
+    directory_file_path(Dir, 'lib.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:rec/2], [wamo_entries([rec/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { dyncall@rec($1) as (i64 f64) { sum += $2 } }\n\c
+         END { print sum }\n", [Wamo]),
+    build_run(Dir, 'rvf', Src, [10, 20], Out),
+    assertion(Out == "31\n"),
+    !.
+
+:- end_tests(plawk_dyncall_record_view).
+
+% --- helpers ---------------------------------------------------------------
+
+rv_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_dyncall_rview', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Values, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'in.bin', Input),
+    write_i64_records(Input, Values),
+    run_bin(Bin, [Input], Out, 0).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_i64_records(Path, Values) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(V, Values), write_i64_le(Out, V)),
+        close(Out)).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(null), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## What

The **awk-like record-view target** for structured returns (item 4). The returned compound reads like the current record inside a scoped block:

```awk
BEGIN { BINFMT = "i64" ; DYNLOAD = "lib.wamo" }
{ dyncall@rec($1) as (i64 f64) { total += $1 ; sum += $2 } }
END { print total }
```

Inside the block, `$1`/`$2` are the **returned record's** fields, not the input line.

## How — desugaring, not a field-pointer repoint

The BINFMT field-read core hardcodes the record base pointer (`%rec`), so repointing it per-block would be deeply invasive. Instead the view **desugars** to the destructure landed in #3476:

`<call> as (T1..Tn) { Body }` → a destructure into fresh per-site temporaries `__dynrec_<k>_<i>`, followed by `Body` with every `$k` (`field(k)`/`float_field(k)`, 1≤k≤n) rewritten to the k-th temporary.

So it rides the destructure machinery with **zero changes** to the field-read core. A body field outside `1..nfields` (including `$0`) is left un-rewritten and the pass then rejects the view — the record has no such field, so it falls outside the compilable surface rather than silently leaking the input line. The desugar recurses into `if`-branches; a view nested in a `for-in` body is a noted follow-on.

The rec-shim collectors also match `dynrec_view` (the desugar runs inside the driver, *after* collection), so the record shim + loader are emitted and `emit_wamo_loader` triggers.

## Tests

New `tests/test_plawk_dyncall_record_view.pl` (5): parse, the desugar (view → bind + `$k`-rewritten body, no surviving field refs), out-of-range-field rejection, and two end-to-end round trips — `dyncall@rec($1) as (i64 f64)` over inputs 10,20: `{ total += $1 }` sums the i64 field to `30`, `{ sum += $2 }` sums the f64 field (X+0.5) to `31`. Full `wam_object` / `dyncall*` / CLI / surface suites pass.

## Roadmap

Record-view marked landed. Item 4's target menu now has **typed scalars** (#3476) and **record view** (this PR) done; remaining are the **associative-array** / **positional-array** targets and the cross-cutting **string/atom fields** (a `(ptr,len)` slot pair every target shares).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_