### PR TITLE
plawk/JIT (roadmap #4): string/atom fields in @wam_object_call_record

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -25,7 +25,8 @@ The dynamic-grammar surface is feature-complete for numeric work:
 | `float(dyncall@name(...))` / `blob(dyncall@name(...))` (named double / byte returns, shared resolver) | #3474 |
 | Structured returns — `@wam_object_call_record` (deserialize a returned Compound's args into typed i64/f64 slots) | #3475 |
 | Destructure surface — `(a, b) = dyncall[@name](args) as (i64 f64)` binds fields to typed scalars | #3476 |
-| Record-view surface — `dyncall[@name](args) as (i64 f64) { … $1 $2 … }` reads the return like the current record | this PR |
+| Record-view surface — `dyncall[@name](args) as (i64 f64) { … $1 $2 … }` reads the return like the current record | #3477 |
+| String/atom record fields (mechanism) — `@wam_object_call_record` typecode 2 → `(ptr,len)` via `out_slots`+`out_lens` | this PR |
 
 A grammar is compiled ahead of time to a `.wamo`, loaded at runtime (from a
 fixed path, an in-memory buffer, or a per-call runtime source), cached with
@@ -220,10 +221,22 @@ different plawk containers — this is the through-line for the rest of item 4:
 
 Each target reuses one marshaller over the same walked compound; they differ
 only in where fields are written (scalar slots, the line record, an assoc
-table). String/atom fields are the cross-cutting extension: their bytes
-survive the rewind via the persistent atom table, but a field needs a
-`(ptr,len)` slot pair rather than one i64, so the typecode set and slot
-layout grow — add once, and every target gains string fields.
+table).
+
+**String/atom fields — mechanism LANDED:** the cross-cutting field type.
+`@wam_object_call_record` gained typecode `2` (string) and an `out_lens`
+array: a string field's atom is read as `@wam_atom_to_string` + `strlen`,
+`out_slots[i]` gets the pointer (into the persistent atom table, so it
+survives the arena rewind, like `blob`) and `out_lens[i]` gets the length —
+a `(ptr,len)` byte slice per field. Numeric fields set `out_lens[i]=0`.
+Verified: a grammar returning `rs(7, hello)` deserializes field 0 → i64 `7`
+and field 1 → the slice `hello` (printed `%.*s` after rewind). The **surface**
+for string fields is the remaining piece and forces a design choice, because
+plawk scalars are numeric-only: a string field can't bind to a scalar
+variable (so the destructure target needs a string/slice binding) — it fits
+the record-view target naturally (a `blob`-style slice `$k` printed via
+`%.*s`), and the assoc target (string values, or interned string keys). That
+surface fork is the next decision.
 
 **Why:** this is the *other half* of your binary-return idea — the case
 that **does** need deserialization. It is also the endgame that closes the

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1274,8 +1274,9 @@ entry:
 do_call:
   %pc = load i32, i32* @plawk_dyncall_pc
   %args = alloca %Value, i32 ~w
+  %lens = alloca i64, i32 %nfields
 ~w
-  %r = call i1 @wam_object_call_record(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, i32 %nfields, i8* %tc, i64* %slots)
+  %r = call i1 @wam_object_call_record(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, i32 %nfields, i8* %tc, i64* %slots, i64* %lens)
   ret i1 %r
 
 fail:
@@ -1302,8 +1303,9 @@ entry:
 do_call:
   %vm = call %WamState* @plawk_dyncall_get()
   %args = alloca %Value, i32 ~w
+  %lens = alloca i64, i32 %nfields
 ~w
-  %r = call i1 @wam_object_call_record(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, i32 %nfields, i8* %tc, i64* %slots)
+  %r = call i1 @wam_object_call_record(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, i32 %nfields, i8* %tc, i64* %slots, i64* %lens)
   ret i1 %r
 
 fail:

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -20348,8 +20348,9 @@ wamo_utf8_bytes([C|Cs], Bytes) :-
 %    @wam_object_call_i64 - call the object's entry with N %Value args and
 %                           read back an Integer result ({value, ok})
 %    @wam_object_call_record - call the entry and deserialize a returned
-%                           Compound's args into typed i64/f64 slots (the
-%                           "output is a term" primitive)
+%                           Compound's args into typed i64/f64/string slots
+%                           (the "output is a term" primitive; string fields
+%                           yield a (ptr,len) pair via out_slots + out_lens)
 %    @wam_object_entry_index / @wam_object_entry_index_bytes
 %                        - resolve a named entry to its label index (or -1)
 %                          for multi-entry objects; @wam_label_pc turns that
@@ -20864,18 +20865,24 @@ fail:
 ; and its arg cells live in the arena -- only atoms survive a rewind). This is
 ; the "output is a term, not a scalar" primitive: a grammar returns e.g.
 ; rec(42, 3.14) and the caller lays the fields into a record buffer.
-;   typecodes[i] = 0  -> i64  : arg i must be Integer; out_slots[i] = its i64
-;   typecodes[i] = 1  -> f64  : arg i must be a number; out_slots[i] = the
-;                               double bits (value_to_double promotes Integer)
+;   typecodes[i] = 0  -> i64    : arg i must be Integer; out_slots[i] = its i64
+;   typecodes[i] = 1  -> f64    : arg i must be a number; out_slots[i] = the
+;                                 double bits (value_to_double promotes Integer)
+;   typecodes[i] = 2  -> string : arg i must be an Atom; out_slots[i] = the
+;                                 atom string pointer (as i64), out_lens[i] =
+;                                 its strlen. The pointer is into the persistent
+;                                 atom table, so it survives the arena rewind
+;                                 (same as @wam_object_call_bytes). NUL-free by
+;                                 the blob convention.
 ; out_slots is an i64[nfields]; f64 fields are stored as bitcast double bits,
-; so the caller reads slot i as i64 or bitcasts to double per its own shape.
+; string fields as a ptrtoint. out_lens is an i64[nfields]; only string fields
+; write it (numeric fields set 0). So the caller reads slot i as i64, bitcasts
+; to double, or pairs (slot,len) into a byte slice per its own shape.
 ; Returns i1 ok; false on call failure, a non-Compound output, an arity
 ; mismatch, or an arg whose type does not satisfy its typecode. Same
 ; heap-save / arena-rewind discipline as the scalar variants, so a per-record
-; call stays constant-memory. (String/atom fields are a planned follow-on:
-; their bytes survive the rewind via the persistent atom table, but need a
-; (ptr,len) slot pair rather than one i64.)
-define i1 @wam_object_call_record(%WamState* %vm, i32 %entry_pc, i32 %nargs, %Value* %args, i32 %out_reg, i32 %nfields, i8* %typecodes, i64* %out_slots) {
+; call stays constant-memory.
+define i1 @wam_object_call_record(%WamState* %vm, i32 %entry_pc, i32 %nargs, %Value* %args, i32 %out_reg, i32 %nfields, i8* %typecodes, i64* %out_slots, i64* %out_lens) {
 entry:
   %vm_null = icmp eq %WamState* %vm, null
   br i1 %vm_null, label %fail, label %do_call
@@ -20930,6 +20937,10 @@ fstep:
   %ftag = call i32 @value_tag(%Value %farg)
   %tc_ptr = getelementptr i8, i8* %typecodes, i64 %fi64
   %tc = load i8, i8* %tc_ptr
+  %len_slot = getelementptr i64, i64* %out_lens, i64 %fi64
+  %is_str = icmp eq i8 %tc, 2
+  br i1 %is_str, label %field_str, label %field_num
+field_num:
   %is_f64 = icmp eq i8 %tc, 1
   br i1 %is_f64, label %field_f64, label %field_i64
 field_i64:
@@ -20939,6 +20950,7 @@ store_i64:
   %ival = call i64 @value_payload(%Value %farg)
   %slot_i = getelementptr i64, i64* %out_slots, i64 %fi64
   store i64 %ival, i64* %slot_i
+  store i64 0, i64* %len_slot
   br label %fstep_ok
 field_f64:
   %is_num = call i1 @value_is_number(%Value %farg)
@@ -20948,6 +20960,22 @@ store_f64:
   %dbits = bitcast double %dval to i64
   %slot_f = getelementptr i64, i64* %out_slots, i64 %fi64
   store i64 %dbits, i64* %slot_f
+  store i64 0, i64* %len_slot
+  br label %fstep_ok
+field_str:
+  %is_atom = icmp eq i32 %ftag, 0
+  br i1 %is_atom, label %store_str, label %rewind_fail
+store_str:
+  %said = call i64 @value_payload(%Value %farg)
+  %sptr = call i8* @wam_atom_to_string(i64 %said)
+  %sptr_null = icmp eq i8* %sptr, null
+  br i1 %sptr_null, label %rewind_fail, label %have_sptr
+have_sptr:
+  %slen = call i64 @strlen(i8* %sptr)
+  %sbits = ptrtoint i8* %sptr to i64
+  %slot_s = getelementptr i64, i64* %out_slots, i64 %fi64
+  store i64 %sbits, i64* %slot_s
+  store i64 %slen, i64* %len_slot
   br label %fstep_ok
 fstep_ok:
   %fi1 = add i32 %fi, 1

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -27,6 +27,10 @@ uses_float(X) :- X is 1.5 + 2.5.                % float constant -> rejected
 % Exercises the structured-return primitive (@wam_object_call_record).
 makerec(R) :- X = 10, Y is X + 0.5, R = rec2f(X, Y).   % -> rec2f(10, 10.5)
 
+% a record with an integer and an atom (string) field: rs(7, hello).
+% Exercises string fields (typecode 2 -> (ptr, len)).
+makerecs(R) :- R = rs(7, hello).
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -167,6 +171,20 @@ test(struct_return_deserializes_fields,
     assertion(Out == "10\n10.5\n"),
     !.
 
+% A string field (typecode 2): makerecs/1 returns rs(7, hello). The record
+% call writes field 0's i64 (7) into a slot and field 1's atom string into
+% (out_slots[1] = ptr, out_lens[1] = 5). The pointer is into the persistent
+% atom table, so it prints (%.*s) after the arena rewind.
+test(struct_return_string_field,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'recs.wamo', Wamo),
+    write_wam_object([user:makerecs/1], [wamo_entry(makerecs/1)], Wamo),
+    build_record_str_host(Dir, Host),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "7\nhello\n"),
+    !.
+
 :- end_tests(wam_object).
 
 % --- helpers ---------------------------------------------------------------
@@ -283,8 +301,9 @@ entry:\n\c
   br i1 %vm_null, label %load_fail, label %run\n\c
 run:\n\c
   %slots = alloca i64, i32 2\n\c
+  %lens = alloca i64, i32 2\n\c
   %tc = getelementptr [2 x i8], [2 x i8]* @.rec_types, i32 0, i32 0\n\c
-  %ok = call i1 @wam_object_call_record(%WamState* %vm, i32 %pc, i32 0, %Value* null, i32 0, i32 2, i8* %tc, i64* %slots)\n\c
+  %ok = call i1 @wam_object_call_record(%WamState* %vm, i32 %pc, i32 0, %Value* null, i32 0, i32 2, i8* %tc, i64* %slots, i64* %lens)\n\c
   br i1 %ok, label %print, label %run_fail\n\c
 print:\n\c
   %s0 = getelementptr i64, i64* %slots, i64 0\n\c
@@ -296,6 +315,61 @@ print:\n\c
   %v1 = bitcast i64 %v1bits to double\n\c
   %ffmt = getelementptr [6 x i8], [6 x i8]* @.rec_ffmt, i32 0, i32 0\n\c
   %pf = call i32 (i8*, ...) @printf(i8* %ffmt, double %v1)\n\c
+  ret i32 0\n\c
+load_fail:\n\c
+  ret i32 20\n\c
+run_fail:\n\c
+  ret i32 21\n\c
+}\n').
+
+% Build a host that calls @wam_object_call_record with a 2-field shape
+% (i64, string), then prints field 0 as an integer and field 1 as a
+% length-counted string (%.*s from out_slots[1] + out_lens[1]).
+build_record_str_host(Dir, Host) :-
+    directory_file_path(Dir, 'record_str_host.ll', LL),
+    with_output_to(string(_),
+        write_wam_llvm_project([user:answer/1],
+            [module_name(wam_object_record_str_host), emit_wamo_loader(true)], LL)),
+    record_str_host_main_ir(MainIR),
+    setup_call_cleanup(
+        open(LL, append, S, [encoding(utf8)]),
+        write(S, MainIR),
+        close(S)),
+    directory_file_path(Dir, 'record_str_host_bin', Host),
+    clang_link(LL, Host).
+
+record_str_host_main_ir(
+'\n@.rs_ifmt = private constant [6 x i8] c"%lld\\0A\\00"\n\c
+@.rs_sfmt = private constant [6 x i8] c"%.*s\\0A\\00"\n\c
+@.rs_types = private constant [2 x i8] c"\\00\\02"\n\n\c
+define i32 @main(i32 %argc, i8** %argv) {\n\c
+entry:\n\c
+  %p1 = getelementptr i8*, i8** %argv, i64 1\n\c
+  %path = load i8*, i8** %p1\n\c
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)\n\c
+  %vm = extractvalue { %WamState*, i32 } %obj, 0\n\c
+  %pc = extractvalue { %WamState*, i32 } %obj, 1\n\c
+  %vm_null = icmp eq %WamState* %vm, null\n\c
+  br i1 %vm_null, label %load_fail, label %run\n\c
+run:\n\c
+  %slots = alloca i64, i32 2\n\c
+  %lens = alloca i64, i32 2\n\c
+  %tc = getelementptr [2 x i8], [2 x i8]* @.rs_types, i32 0, i32 0\n\c
+  %ok = call i1 @wam_object_call_record(%WamState* %vm, i32 %pc, i32 0, %Value* null, i32 0, i32 2, i8* %tc, i64* %slots, i64* %lens)\n\c
+  br i1 %ok, label %print, label %run_fail\n\c
+print:\n\c
+  %s0 = getelementptr i64, i64* %slots, i64 0\n\c
+  %v0 = load i64, i64* %s0\n\c
+  %ifmt = getelementptr [6 x i8], [6 x i8]* @.rs_ifmt, i32 0, i32 0\n\c
+  %pi = call i32 (i8*, ...) @printf(i8* %ifmt, i64 %v0)\n\c
+  %s1 = getelementptr i64, i64* %slots, i64 1\n\c
+  %v1 = load i64, i64* %s1\n\c
+  %ptr = inttoptr i64 %v1 to i8*\n\c
+  %l1 = getelementptr i64, i64* %lens, i64 1\n\c
+  %len = load i64, i64* %l1\n\c
+  %len32 = trunc i64 %len to i32\n\c
+  %sfmt = getelementptr [6 x i8], [6 x i8]* @.rs_sfmt, i32 0, i32 0\n\c
+  %ps = call i32 (i8*, ...) @printf(i8* %sfmt, i32 %len32, i8* %ptr)\n\c
   ret i32 0\n\c
 load_fail:\n\c
   ret i32 20\n\c


### PR DESCRIPTION
## What

The cross-cutting field-type extension for structured returns, **mechanism-first**. `@wam_object_call_record` gains typecode `2` (string) and an `out_lens` array:

- `typecode 2` → arg *i* must be an **Atom**; `out_slots[i]` = the atom string pointer (`ptrtoint`), `out_lens[i]` = its `strlen`.

The pointer is into the **persistent atom table**, so it survives the arena rewind (same discipline as `@wam_object_call_bytes` / `blob`). Numeric fields set `out_lens[i] = 0`. So a caller reads field *i* as an i64, a bitcast double, or a `(ptr,len)` byte slice per its shape.

The three record shims allocate an internal `out_lens` (dynamic `alloca` on `%nfields`) and forward it, so the **numeric destructure / record-view surface is unchanged** — no signature change reaches the plawk-level callers.

## Tests

New case in `tests/test_wam_object.pl`: a grammar returning `rs(7, hello)`, a host that calls the primitive with typecodes `[i64, string]`, reads field 0 → i64 `7` and field 1 → the slice `hello` (printed `%.*s` after the rewind, proving the pointer survives). Full `wam_object` + numeric `dyncall_struct` / `record_view` / `dyncall*` suites pass.

## Why mechanism-only (the surface fork)

A *surface* for string fields forces a design choice, recorded in the roadmap: **plawk scalars are numeric-only**, so a string field can't bind to a scalar variable. It therefore does **not** fit the destructure-to-scalar target, but fits naturally into:

- the **record-view** target — a `blob`-style slice `$k` printed via `%.*s` (reuses item 2's slice plumbing), and
- the **assoc** target — string values, or interned string keys.

Shipping the mechanism now unblocks whichever surface we settle on, without prejudging that fork.

## Roadmap

String-field mechanism marked landed. Item 4's remaining work: the **string-field surface** (the fork above), and the **associative-array** / **positional-array** targets — all additive over the one marshaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_