### PR TITLE
feat(wam-clojure): default inline bagof/setof compilation

### DIFF
--- a/PR_DRAFT.md
+++ b/PR_DRAFT.md
@@ -1,0 +1,29 @@
+# PR Title
+
+feat(wam-clojure): default inline bagof/setof compilation
+
+# Description
+
+## Summary
+
+- Makes Clojure WAM project compilation default to `inline_bagof_setof(true)`.
+- Preserves explicit opt-out with `inline_bagof_setof(false)`.
+- Removes the runtime smoke test's explicit inline option so it validates the target default.
+- Adds generator regressions for default inline aggregate emission and opt-out fallback emission.
+
+## Why
+
+- The Clojure WAM runtime now supports inline `bagof/3` and `setof/3`, including witness grouping and backtracking across groups.
+- Leaving inline support opt-in would keep normal Clojure WAM project generation on the old `execute bagof/3`/`setof/3` path.
+- This change makes the merged runtime capability the default Clojure target behavior while retaining a conservative escape hatch.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
+- `swipl -q -s tests/test_wam_clojure_lowered_t4.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_lowered_ite_exec.pl`
+- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -99,6 +99,7 @@ write_text_file(Path, Text) :-
 %  - runtime namespace containing instruction resolution helpers
 %  - core namespace containing shared code/labels and predicate wrappers
 write_wam_clojure_project(Predicates, Options, ProjectDir) :-
+    clojure_wam_compile_options(Options, CompileOptions),
     option(namespace(BaseNamespace), Options, 'generated.wam'),
     option(module_name(ModuleName), Options, 'wam-clojure-generated'),
     atom_concat(BaseNamespace, '.runtime', RuntimeNamespace),
@@ -110,9 +111,14 @@ write_wam_clojure_project(Predicates, Options, ProjectDir) :-
     write_project_clj(ModuleName, CoreNamespace, ProjectDir),
     write_runtime_namespace(RuntimeNamespace, Date, ProjectDir),
     maybe_prepare_wam_clojure_lmdb_runtime_support(ProjectDir, Options),
-    compile_predicates_for_project(Predicates, Options, CoreNamespace, RuntimeNamespace, CoreCode),
+    compile_predicates_for_project(Predicates, CompileOptions, CoreNamespace, RuntimeNamespace, CoreCode),
     write_namespace_file(ProjectDir, CoreNamespace, CoreCode),
     format(user_error, '[WAM-Clojure] Generated project at: ~w~n', [ProjectDir]).
+
+clojure_wam_compile_options(Options, Options) :-
+    option(inline_bagof_setof(_), Options),
+    !.
+clojure_wam_compile_options(Options, [inline_bagof_setof(true)|Options]).
 
 write_deps_edn(ModuleName, CoreNamespace, ProjectDir) :-
     read_template_file('templates/targets/clojure_wam/deps.edn.mustache', Template),

--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -20,6 +20,7 @@
 :- dynamic user:wam_list_fact/1.
 :- dynamic user:wam_use_struct/1.
 :- dynamic user:wam_use_list/1.
+:- dynamic user:wam_bagof_default/1.
 :- dynamic user:category_parent/2.
 :- dynamic user:wam_parent_lookup/2.
 :- dynamic user:max_depth/1.
@@ -42,6 +43,7 @@ user:wam_struct_fact(f(a)).
 user:wam_list_fact([a,b]).
 user:wam_use_struct(X) :- user:wam_struct_fact(X).
 user:wam_use_list(X) :- user:wam_list_fact(X).
+user:wam_bagof_default(L) :- bagof(X, member(X, [a,b,a]), L).
 user:category_parent(_, _) :- fail.
 user:wam_parent_lookup(X, Y) :- user:category_parent(X, Y).
 user:max_depth(_) :- fail.
@@ -192,6 +194,32 @@ test(aggregate_instructions_emit_runtime_ops) :-
         assertion(BeginLiteral == '{:op :begin-aggregate :kind "collect" :template "Y1" :bag "X2" :witnesses []}'),
         assertion(BeginWitnessLiteral == '{:op :begin-aggregate :kind "bagof" :template "Y1" :bag "X2" :witnesses ["Y3" "Y4"]}'),
         assertion(EndLiteral == '{:op :end-aggregate :template "Y1"}')
+    )).
+
+test(clojure_defaults_inline_bagof_setof) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_default_bagof', TmpDir),
+        write_wam_clojure_project([user:wam_bagof_default/1],
+                                  [namespace('generated.wam_default_bagof_test')], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_default_bagof_test/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :begin-aggregate :kind "bagof"')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '{:op :execute :pred "bagof/3"}')),
+        delete_directory_and_contents(TmpDir)
+    )).
+
+test(clojure_can_opt_out_of_inline_bagof_setof) :-
+    once((
+        unique_tmp_dir('tmp_wam_clojure_no_inline_bagof', TmpDir),
+        write_wam_clojure_project([user:wam_bagof_default/1],
+                                  [ namespace('generated.wam_no_inline_bagof_test'),
+                                    inline_bagof_setof(false)
+                                  ], TmpDir),
+        directory_file_path(TmpDir, 'src/generated/wam_no_inline_bagof_test/core.clj', CorePath),
+        read_file_to_string(CorePath, CoreCode, []),
+        assertion(sub_string(CoreCode, _, _, _, '{:op :execute :pred "bagof/3"}')),
+        assertion(\+ sub_string(CoreCode, _, _, _, '{:op :begin-aggregate :kind "bagof"')),
+        delete_directory_and_contents(TmpDir)
     )).
 
 test(foreign_predicates_emit_call_foreign_stub) :-

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -1231,7 +1231,6 @@ run_smoke :-
         ],
         [ namespace('generated.wam_exec_test'),
           module_name('wam-clojure-exec-test'),
-          inline_bagof_setof(true),
           foreign_predicates([wam_fact/1, wam_foreign_pair/2, wam_foreign_stream_pair/2]),
           clojure_foreign_handlers([
               handler(wam_fact/1, "(fn [args] (= (first args) \"a\"))"),


### PR DESCRIPTION
## Summary

- Makes Clojure WAM project compilation default to `inline_bagof_setof(true)`.
- Preserves explicit opt-out with `inline_bagof_setof(false)`.
- Removes the runtime smoke test's explicit inline option so it validates the target default.
- Adds generator regressions for default inline aggregate emission and opt-out fallback emission.

## Why

- The Clojure WAM runtime now supports inline `bagof/3` and `setof/3`, including witness grouping and backtracking across groups.
- Leaving inline support opt-in would keep normal Clojure WAM project generation on the old `execute bagof/3`/`setof/3` path.
- This change makes the merged runtime capability the default Clojure target behavior while retaining a conservative escape hatch.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `swipl -q -s tests/test_wam_clojure_lowered_t4.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_lowered_ite_exec.pl`
- `swipl -q -g run_tests -t halt tests/core/test_clojure_native_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_benchmark_generator.pl`
