### PR TITLE
feat(wam): emit native items for A2 constant indexes

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -16,10 +16,10 @@ The first implementation step is intentionally conservative:
   compound body arguments with default args-first `set_*` ordering, and
   conjunctions of those simple shapes directly as items. The same native path
   also emits non-indexed linear multi-clause predicates when every clause has one
-  of those supported simple shapes, plus the simplest A1 `switch_on_constant`
-  and `switch_on_constant_fallthrough` indexed variants when no extra dispatch
-  chains are needed. It falls back to the existing text generator plus
-  `wam_text_to_items/2` for A2 indexing, structure/term indexing,
+  of those supported simple shapes, plus the simplest A1/A2
+  `switch_on_constant` and `switch_on_constant_fallthrough` indexed variants
+  when no extra dispatch chains are needed. It falls back to the existing text
+  generator plus `wam_text_to_items/2` for structure/term indexing,
   dispatch-chain indexes, aggregates, lowered builtins, control flow, legacy
   interleaved compound-argument emission via `args_first_emission(false)`, and
   other complex shapes.

--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -56,13 +56,13 @@ the shared `compile_predicate_to_wam_items/3` producer now skips WAM text for
 single-clause facts, simple user-predicate calls, generic builtin calls, and
 compound body arguments with default args-first `set_*` ordering. It also skips
 WAM text for non-indexed linear multi-clause predicates made from the same
-simple clause shapes, and for the simplest A1 `switch_on_constant` and
+simple clause shapes, and for the simplest A1/A2 `switch_on_constant` and
 `switch_on_constant_fallthrough` indexed variants when no extra dispatch chains
-are needed. A2 indexing, structure/term indexing, dispatch-chain indexes, more
-complex predicate shapes, and the legacy `args_first_emission(false)`
-compound-argument order still use the text-to-items bridge. As the native
-producer expands, the same explicit Python mode will skip WAM text for more
-predicates without changing the Python emitter.
+are needed. Structure/term indexing, dispatch-chain indexes, more complex
+predicate shapes, and the legacy `args_first_emission(false)` compound-argument
+order still use the text-to-items bridge. As the native producer expands, the
+same explicit Python mode will skip WAM text for more predicates without
+changing the Python emitter.
 
 Lua, R, and Elixir follow the same partial migration shape as Python:
 interpreter-mode generated predicates consume common WAM items through the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -207,7 +207,7 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
 %  slice covers facts, simple user calls, generic builtin calls, compound body
 %  arguments using the default args-first set_* ordering, conjunctions of those
 %  shapes, non-indexed linear multi-clause predicates composed of the same
-%  clause shapes, and the simplest A1 switch_on_constant / fallthrough indexed
+%  clause shapes, and the simplest A1/A2 switch_on_constant / fallthrough indexed
 %  variants. Aggregates, dispatch-chain indexing, lowered builtins, control flow, legacy
 %  interleaved compound-arg emission, and other peephole-sensitive shapes
 %  intentionally fall back to the text bridge.
@@ -227,6 +227,22 @@ compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items) :-
 compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items) :-
     Clauses = [_,_|_],
     native_first_arg_constant_fallthrough_index_item(Pred, Arity, Clauses, SwitchItem),
+    length(Clauses, N),
+    compile_multi_clause_items_linear(Clauses, 1, N, Pred, Arity, Options, ClauseItems),
+    !,
+    format(string(Label), "~w/~w", [Pred, Arity]),
+    Items = [label(Label), SwitchItem|ClauseItems].
+compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items) :-
+    Clauses = [_,_|_],
+    native_second_arg_constant_index_item(Pred, Arity, Clauses, SwitchItem),
+    length(Clauses, N),
+    compile_multi_clause_items_linear(Clauses, 1, N, Pred, Arity, Options, ClauseItems),
+    !,
+    format(string(Label), "~w/~w", [Pred, Arity]),
+    Items = [label(Label), SwitchItem|ClauseItems].
+compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items) :-
+    Clauses = [_,_|_],
+    native_second_arg_constant_fallthrough_index_item(Pred, Arity, Clauses, SwitchItem),
     length(Clauses, N),
     compile_multi_clause_items_linear(Clauses, 1, N, Pred, Arity, Options, ClauseItems),
     !,
@@ -289,6 +305,29 @@ native_first_arg_constant_fallthrough_index_item(Pred, Arity, Clauses,
     PrefixClauses = [_|_],
     forall(member(Type, PrefixTypes), Type = constant),
     build_constant_index(PrefixClauses, 1, Pred, Arity, Entries),
+    Entries = [_|_],
+    index_entries_to_item_entries(Entries, ItemEntries).
+
+native_second_arg_constant_index_item(Pred, Arity, Clauses, switch_on_constant_a2(ItemEntries)) :-
+    Arity >= 2,
+    \+ build_first_arg_index(Pred, Arity, Clauses, _IndexHeader, _DispatchChains),
+    classify_second_args(Clauses, Types),
+    Types = [_|_],
+    forall(member(Type, Types), Type = constant),
+    build_constant_index_on(Clauses, 2, 1, Pred, Arity, Entries),
+    Entries = [_|_],
+    index_entries_to_item_entries(Entries, ItemEntries).
+
+native_second_arg_constant_fallthrough_index_item(Pred, Arity, Clauses,
+                                                 switch_on_constant_a2_fallthrough(ItemEntries)) :-
+    Arity >= 2,
+    \+ build_first_arg_index(Pred, Arity, Clauses, _IndexHeader, _DispatchChains),
+    classify_second_args(Clauses, Types),
+    member(variable, Types),
+    indexed_prefix(Types, Clauses, PrefixTypes, PrefixClauses),
+    PrefixClauses = [_|_],
+    forall(member(Type, PrefixTypes), Type = constant),
+    build_constant_index_on(PrefixClauses, 2, 1, Pred, Arity, Entries),
     Entries = [_|_],
     index_entries_to_item_entries(Entries, ItemEntries).
 

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -641,24 +641,106 @@ test_wam_items_native_switch_on_constant_fallthrough_index :-
     ;   fail_test(Test, 'Native switch_on_constant_fallthrough items do not match canonical WAM text shape')
     ).
 
-test_wam_items_a2_indexed_multi_clause_still_bridges :-
-    Test = 'WAM: A2 indexed multi-clause items still use bridge',
-    (   wam_target:wam_predicate_clauses(user:test_a2_const/2, [], Pred1, Arity1, Clauses1),
-        \+ wam_target:compile_clauses_to_wam_items_native(Pred1, Arity1, Clauses1, [], _NativeItems1),
-        wam_target:compile_predicate_to_wam_text(user:test_a2_const/2, [], TextCode),
+test_wam_items_native_switch_on_constant_a2_index :-
+    Test = 'WAM: native items API for switch_on_constant_a2 indexed clauses',
+    ExpectedItems = [
+        label("test_a2_const/2"),
+        switch_on_constant_a2(["alpha:default", "beta:L_test_a2_const_2_2", "gamma:L_test_a2_const_2_3"]),
+        try_me_else("L_test_a2_const_2_2"),
+        get_variable("X1", "A1"),
+        get_constant("alpha", "A2"),
+        proceed,
+        label("L_test_a2_const_2_2"),
+        retry_me_else("L_test_a2_const_2_3"),
+        label("L_test_a2_const_2_2_body"),
+        get_variable("X1", "A1"),
+        get_constant("beta", "A2"),
+        proceed,
+        label("L_test_a2_const_2_3"),
+        trust_me,
+        label("L_test_a2_const_2_3_body"),
+        get_variable("X1", "A1"),
+        get_constant("gamma", "A2"),
+        proceed
+    ],
+    (   wam_target:compile_predicate_to_wam_text(user:test_a2_const/2, [], TextCode),
         wam_text_to_items(TextCode, BridgeItems),
         wam_target:compile_predicate_to_wam_items(user:test_a2_const/2, [], Items),
+        wam_target:wam_predicate_clauses(user:test_a2_const/2, [], Pred, Arity, Clauses),
+        wam_target:compile_clauses_to_wam_items_native(Pred, Arity, Clauses, [], NativeItems),
+        NativeItems == ExpectedItems,
+        Items == ExpectedItems,
         Items == BridgeItems,
         member(switch_on_constant_a2(_), Items),
-        wam_target:wam_predicate_clauses(user:test_mma2_trailing/3, [], Pred2, Arity2, Clauses2),
-        \+ wam_target:compile_clauses_to_wam_items_native(Pred2, Arity2, Clauses2, [], _NativeItems2),
-        wam_target:compile_predicate_to_wam_text(user:test_mma2_trailing/3, [], TextCode2),
-        wam_text_to_items(TextCode2, BridgeItems2),
-        wam_target:compile_predicate_to_wam_items(user:test_mma2_trailing/3, [], Items2),
-        Items2 == BridgeItems2,
-        member(switch_on_constant_a2_fallthrough(_), Items2)
+        member(label("test_a2_const/2"), Items)
     ->  pass(Test)
-    ;   fail_test(Test, 'A2 indexed multi-clause predicate did not remain on bridge')
+    ;   fail_test(Test, 'Native switch_on_constant_a2 items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_native_switch_on_constant_a2_fallthrough_index :-
+    Test = 'WAM: native items API for switch_on_constant_a2_fallthrough indexed clauses',
+    ExpectedItems = [
+        label("test_mma2_trailing/3"),
+        switch_on_constant_a2_fallthrough(["error:default", "warn:L_test_mma2_trailing_3_2", "ok:L_test_mma2_trailing_3_3"]),
+        try_me_else("L_test_mma2_trailing_3_2"),
+        get_variable("X1", "A1"),
+        get_constant("error", "A2"),
+        get_constant("red", "A3"),
+        proceed,
+        label("L_test_mma2_trailing_3_2"),
+        retry_me_else("L_test_mma2_trailing_3_3"),
+        label("L_test_mma2_trailing_3_2_body"),
+        get_variable("X1", "A1"),
+        get_constant("warn", "A2"),
+        get_constant("yellow", "A3"),
+        proceed,
+        label("L_test_mma2_trailing_3_3"),
+        retry_me_else("L_test_mma2_trailing_3_4"),
+        label("L_test_mma2_trailing_3_3_body"),
+        get_variable("X1", "A1"),
+        get_constant("ok", "A2"),
+        get_constant("green", "A3"),
+        proceed,
+        label("L_test_mma2_trailing_3_4"),
+        trust_me,
+        label("L_test_mma2_trailing_3_4_body"),
+        get_variable("X1", "A1"),
+        get_variable("X2", "A2"),
+        get_constant("gray", "A3"),
+        proceed
+    ],
+    (   wam_target:compile_predicate_to_wam_text(user:test_mma2_trailing/3, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_mma2_trailing/3, [], Items),
+        wam_target:wam_predicate_clauses(user:test_mma2_trailing/3, [], Pred, Arity, Clauses),
+        wam_target:compile_clauses_to_wam_items_native(Pred, Arity, Clauses, [], NativeItems),
+        NativeItems == ExpectedItems,
+        Items == ExpectedItems,
+        Items == BridgeItems,
+        member(switch_on_constant_a2_fallthrough(_), Items),
+        member(label("test_mma2_trailing/3"), Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Native switch_on_constant_a2_fallthrough items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_a2_structure_term_indexes_still_bridge :-
+    Test = 'WAM: A2 structure/term indexed multi-clause items still use bridge',
+    (   wam_target:wam_predicate_clauses(user:test_a2_struct/2, [], Pred1, Arity1, Clauses1),
+        \+ wam_target:compile_clauses_to_wam_items_native(Pred1, Arity1, Clauses1, [], _NativeItems1),
+        wam_target:compile_predicate_to_wam_text(user:test_a2_struct/2, [], TextCode1),
+        wam_text_to_items(TextCode1, BridgeItems1),
+        wam_target:compile_predicate_to_wam_items(user:test_a2_struct/2, [], Items1),
+        Items1 == BridgeItems1,
+        member(switch_on_structure_a2(_), Items1),
+        wam_target:wam_predicate_clauses(user:test_a2_term/2, [], Pred2, Arity2, Clauses2),
+        \+ wam_target:compile_clauses_to_wam_items_native(Pred2, Arity2, Clauses2, [], _NativeItems2),
+        wam_target:compile_predicate_to_wam_text(user:test_a2_term/2, [], TextCode2),
+        wam_text_to_items(TextCode2, BridgeItems2),
+        wam_target:compile_predicate_to_wam_items(user:test_a2_term/2, [], Items2),
+        Items2 == BridgeItems2,
+        member(switch_on_term_a2(_), Items2)
+    ->  pass(Test)
+    ;   fail_test(Test, 'A2 structure/term indexed predicates did not remain on bridge')
     ).
 
 %% Run all tests
@@ -686,7 +768,9 @@ run_tests :-
     test_wam_items_native_linear_rule_clauses,
     test_wam_items_native_switch_on_constant_index,
     test_wam_items_native_switch_on_constant_fallthrough_index,
-    test_wam_items_a2_indexed_multi_clause_still_bridges,
+    test_wam_items_native_switch_on_constant_a2_index,
+    test_wam_items_native_switch_on_constant_a2_fallthrough_index,
+    test_wam_items_a2_structure_term_indexes_still_bridge,
     test_wam_multi_clause_findall_emits_allocate,
     test_wam_a2_indexing,
     test_wam_mixed_mode_a1_indexing,


### PR DESCRIPTION
## Summary

- extends the native WAM-items producer to emit A2 `switch_on_constant_a2` indexed predicates directly as items
- extends the same path to A2 `switch_on_constant_a2_fallthrough` constant-prefix indexes
- preserves text-to-items bridging for A2 structure/term indexes, dispatch-chain indexes, and complex predicate shapes
- guards A2 native emission so A1 indexing still has the same precedence as the canonical text compiler
- adds bridge-equivalence tests for `test_a2_const/2` and `test_mma2_trailing/3`, plus bridge-boundary tests for A2 structure/term indexes
- updates WAM items representation docs to describe the expanded native indexed slice

## Tests

- `swipl -q -f tests/test_wam_target.pl`
- `swipl -q -f tests/test_wam_ir_mode.pl`
- `swipl -q -f tests/test_wam_text_parser.pl -g run_tests -t halt`
- `swipl -q -f tests/test_wam_python_target.pl`
- `swipl -q -f tests/test_wam_lua_generator.pl`
- `swipl -q -f tests/test_wam_elixir_target.pl`
- `swipl -q -f tests/test_wam_r_generator.pl`
- `git diff --check`
