### PR TITLE
plawk/JIT (roadmap #4): assoc-return surface (arr = … as assoc)

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -28,7 +28,8 @@ The dynamic-grammar surface is feature-complete for numeric work:
 | Record-view surface — `dyncall[@name](args) as (i64 f64) { … $1 $2 … }` reads the return like the current record | #3477 |
 | String/atom record fields (mechanism) — `@wam_object_call_record` typecode 2 → `(ptr,len)` via `out_slots`+`out_lens` | #3478 |
 | String fields in the record view — `... as (i64 string) { print $2 }` (slice from hidden ptr/len temps) | #3479 |
-| Assoc-return (mechanism) — `@wam_object_call_assoc` walks `[K-V,...]` into an i64 assoc table | this PR |
+| Assoc-return (mechanism) — `@wam_object_call_assoc` walks `[K-V,...]` into an i64 assoc table | #3481 |
+| Assoc-return surface — `arr = dyncall@name(...) as assoc` populates a plawk assoc array; END `arr[k]` reads it | this PR |
 
 A grammar is compiled ahead of time to a `.wamo`, loaded at runtime (from a
 fixed path, an in-memory buffer, or a per-call runtime source), cached with
@@ -216,20 +217,24 @@ different plawk containers — this is the through-line for the rest of item 4:
   such field). Recurses into if-branches; a view nested in a for-in body is a
   follow-on. Verified: `dyncall@rec($1) as (i64 f64) { total += $1 }` sums
   the i64 field to 30; `{ sum += $2 }` sums the f64 field to 31.
-- **Associative array** (`arr = ... as assoc`) — *mechanism LANDED.* A
-  grammar returning a list of pairs (`[K1-V1, K2-V2, ...]`) materializes into
-  an i64 assoc table via `@wam_object_call_assoc(vm, pc, nargs, args,
-  out_reg, %WamAssocI64Table*)`: it walks the cons list (functor `[|]`,
-  identified by `strcmp` against the module's cons-functor string, since the
-  loaded object's functor pointers are its own malloc'd copies), takes each
-  arity-2 element's (Integer key, Integer value), and `@wam_assoc_i64_inc`s
-  it into the caller's table — before the arena rewind, like the record
-  primitive. `@wam_assoc_i64_*` is always in the module (WAM helpers), so no
-  new runtime coupling. Verified: `tally -> [1-100, 2-200, 3-30]` populates a
-  table read back as 100/200/30. **Deferred surface:** `arr = <call> as
-  assoc` binding + integrating the grammar-populated table into plawk's assoc
-  plan so `arr[k]` lookups / END iteration see it (atom/string keys need
-  interning — an extension of the integer-key mechanism here).
+- **Associative array** (`arr = dyncall@name(...) as assoc`) — *mechanism +
+  surface LANDED (named entry, integer keys).* A grammar returning a list of
+  pairs (`[K1-V1, K2-V2, ...]`) materializes into an i64 assoc table via
+  `@wam_object_call_assoc(vm, pc, nargs, args, out_reg, %WamAssocI64Table*)`:
+  it walks the cons list (functor `[|]`, identified by `strcmp` against the
+  module's cons-functor string, since the loaded object's functor pointers
+  are its own malloc'd copies), takes each arity-2 element's (Integer key,
+  Integer value), and `@wam_assoc_i64_inc`s it into the caller's table —
+  before the arena rewind, like the record primitive. `@wam_assoc_i64_*` is
+  always in the module (WAM helpers), so no new runtime coupling. **Surface:**
+  the desugar `dynassoc_bind(var(arr), Call)` becomes a per-record assoc
+  action in the BINFMT assoc driver — a `@plawk_dyncall_assoc_<Sym>` shim
+  fills `arr`'s table each record, keyed into the same assoc plan as
+  `arr[k]++`, so END `arr[k]` lookups see the accumulated result. Verified:
+  `tally($1) -> [1-$1, 2-100]` over inputs 5,7 gives `arr[1]=12`,
+  `arr[2]=200`. **Deferred:** the default-entry `dyncall(...) as assoc` (named
+  only for now), for-in iteration over a grammar-populated table, and
+  atom/string keys (interned — an extension of the integer-key mechanism).
 - **Positional array** — fields by numeric index into one array value.
 
 Each target reuses one marshaller over the same walked compound; they differ

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -433,7 +433,11 @@ field 1 to the f64 scalar `half` (a failed call yields zeros). The awk-like
 `$2` the returned record's fields for that block. A field may be typed
 `string` in a view —
 `{ dyncall@info($1) as (i64 string) { total += $1 ; print $2 } }` reads
-field 2 as a byte string, printed like a blob. Bounded
+field 2 as a byte string, printed like a blob. A grammar returning a list
+of integer key-value pairs can populate an associative array:
+`{ arr = dyncall@tally($1) as assoc }` inserts each `[K-V, ...]` pair into
+`arr`'s table per record (accumulating), so END `arr[k]` lookups read the
+result. Bounded
 repetition handles records containing a
 list: `BINFMT = "i64 rep4(i64 f64)"` declares an 8-byte element count
 (at most 4) followed by that many (i64, f64) elements. The count is an

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -124,6 +124,7 @@ build(File, Out0, KeepLL) :-
         ; plawk_program_dyncall_at_float_arities(Program, DynAtFArities), DynAtFArities \== []
         ; plawk_program_dyncall_blob_arities(Program, DynBArities), DynBArities \== []
         ; plawk_program_dyncall_at_blob_arities(Program, DynAtBArities), DynAtBArities \== []
+        ; plawk_program_dyncall_named_assoc_entries(Program, DynNamedAssoc), DynNamedAssoc \== []
         )
     ->  ProjectOptions = [module_name(OutBase), emit_wamo_loader(true)]
     ;   ProjectOptions = [module_name(OutBase)]

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -12,6 +12,7 @@
     plawk_program_dyncall_named_blob_entries/2,
     plawk_program_dyncall_rec_arities/2,
     plawk_program_dyncall_named_rec_entries/2,
+    plawk_program_dyncall_named_assoc_entries/2,
     plawk_program_dyncall_at_arities/2,
     plawk_program_dyncall_float_arities/2,
     plawk_program_dyncall_at_float_arities/2,
@@ -634,6 +635,7 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_dyncall_named_blob_entries(Program, DynNamedB),
     plawk_program_dyncall_rec_arities(Program, DynRecArities),
     plawk_program_dyncall_named_rec_entries(Program, DynNamedRec),
+    plawk_program_dyncall_named_assoc_entries(Program, DynNamedAssoc),
     plawk_program_dyncall_at_arities(Program, DynAtArities),
     plawk_program_dyncall_float_arities(Program, DynFArities),
     plawk_program_dyncall_at_float_arities(Program, DynAtFArities),
@@ -648,6 +650,7 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         DynNamedB == [],
         DynRecArities == [],
         DynNamedRec == [],
+        DynNamedAssoc == [],
         DynAtArities == [],
         DynFArities == [],
         DynAtFArities == [],
@@ -667,7 +670,7 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         % blob(dyncall(...)) sites, plus the shared .wamo object handle.
         (   DynArities == [], DynFArities == [], DynBArities == [],
             DynNamed == [], DynNamedF == [], DynNamedB == [],
-            DynRecArities == [], DynNamedRec == []
+            DynRecArities == [], DynNamedRec == [], DynNamedAssoc == []
         ->  DyncallSupportIR = ''
         ;   ( plawk_program_dynload_path(Program, DynPath)
             ->  true
@@ -677,7 +680,7 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
             ),
             plawk_dyncall_support_ir(DynPath, DynArities, DynFArities,
                 DynBArities, DynNamed, DynNamedF, DynNamedB,
-                DynRecArities, DynNamedRec, DyncallSupportIR)
+                DynRecArities, DynNamedRec, DynNamedAssoc, DyncallSupportIR)
         ),
         % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...)) /
         % blob(dyncall_at(...)) sites + the shared path cache.
@@ -851,6 +854,29 @@ plawk_program_dyncall_named_rec_entries(program(_Begin, Rules, EndClauses),
         ),
         Entries0),
     sort(Entries0, Entries).
+
+%% plawk_program_dyncall_named_assoc_entries(+Program, -Entries)
+%  Named entries used in `arr = dyncall@name(args) as assoc` sites -- each
+%  gets a @plawk_dyncall_assoc_<Name>_<N> shim that populates a caller table
+%  via @wam_object_call_assoc.
+plawk_program_dyncall_named_assoc_entries(program(_Begin, Rules, EndClauses),
+        Entries) :-
+    findall(Name-NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          member(Action, Actions),
+          plawk_subterm_dynassoc_call(Action, dyncall_named(Name, Args)),
+          length(Args, NArgs)
+        ),
+        Entries0),
+    sort(Entries0, Entries).
+
+plawk_subterm_dynassoc_call(dynassoc_bind(_Var, Call), Call).
+plawk_subterm_dynassoc_call(Term, Call) :-
+    compound(Term),
+    arg(_, Term, Sub),
+    plawk_subterm_dynassoc_call(Sub, Call).
 
 plawk_subterm_dynrec_call(dynrec_bind(_Vars, Call, _Types), Call).
 plawk_subterm_dynrec_call(dynrec_view(Call, _Types, _Body), Call).
@@ -1159,18 +1185,22 @@ fail:
 %  run -- the object-call primitive rewinds the arena per call, so this
 %  stays constant-memory just like the compiled foreign bridge.
 plawk_dyncall_support_ir(Path, Arities, IR) :-
-    plawk_dyncall_support_ir(Path, Arities, [], [], [], [], [], [], [], IR).
+    plawk_dyncall_support_ir(Path, Arities, [], [], [], [], [], [], [], [], IR).
 plawk_dyncall_support_ir(Path, IArities, FArities, IR) :-
-    plawk_dyncall_support_ir(Path, IArities, FArities, [], [], [], [], [], [], IR).
+    plawk_dyncall_support_ir(Path, IArities, FArities, [], [], [], [], [], [], [], IR).
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities, IR) :-
-    plawk_dyncall_support_ir(Path, IArities, FArities, BArities, [], [], [], [], [], IR).
+    plawk_dyncall_support_ir(Path, IArities, FArities, BArities, [], [], [], [], [], [], IR).
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities, NamedEntries, IR) :-
     plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
-        NamedEntries, [], [], [], [], IR).
+        NamedEntries, [], [], [], [], [], IR).
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
         NamedI, NamedF, NamedB, IR) :-
     plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
-        NamedI, NamedF, NamedB, [], [], IR).
+        NamedI, NamedF, NamedB, [], [], [], IR).
+plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
+        NamedI, NamedF, NamedB, RecArities, NamedRec, IR) :-
+    plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
+        NamedI, NamedF, NamedB, RecArities, NamedRec, [], IR).
 
 %% plawk_dyncall_support_ir(+Path, +IArities, +FArities, +BArities,
 %%                          +NamedI, +NamedF, +NamedB, +RecArities,
@@ -1189,7 +1219,7 @@ plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
 %  destructure binds (they also feed the resolver union). All share the
 %  single lazily loaded object handle + @plawk_dyncall_get.
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
-        NamedI, NamedF, NamedB, RecArities, NamedRec, IR) :-
+        NamedI, NamedF, NamedB, RecArities, NamedRec, NamedAssoc, IR) :-
     llvm_emit_c_string_global('plawk_dyncall_path', Path, PathGlobal,
         _StrLen, BytesLen),
     format(atom(GetterIR),
@@ -1227,7 +1257,7 @@ load:
     % one shared resolver per named entry, over the union of the kinds
     % (record binds that name an entry feed the union too, so their
     % resolver exists even when the entry is used nowhere else)
-    append([NamedI, NamedF, NamedB, NamedRec], NamedAll0),
+    append([NamedI, NamedF, NamedB, NamedRec, NamedAssoc], NamedAll0),
     sort(NamedAll0, NamedAll),
     findall(ResIR,
         ( member(REName-RENArgs, NamedAll),
@@ -1252,9 +1282,42 @@ load:
         ( member(NRName-NRNArgs, NamedRec),
           plawk_dyncall_named_rec_shim_ir(NRName, NRNArgs, NRecShim) ),
         NRecShims),
+    findall(NAShim,
+        ( member(NAName-NANArgs, NamedAssoc),
+          plawk_dyncall_named_assoc_shim_ir(NAName, NANArgs, NAShim) ),
+        NAShims),
     append([[PathGlobal, GetterIR], IShims, FShims, BShims,
-            Resolvers, NIShims, NFShims, NBShims, RecShims, NRecShims], Parts),
+            Resolvers, NIShims, NFShims, NBShims, RecShims, NRecShims,
+            NAShims], Parts),
     atomic_list_concat(Parts, '\n\n', IR).
+
+%% plawk_dyncall_named_assoc_shim_ir(+Name, +NArgs, -IR)
+%  Assoc shim for `arr = dyncall@name(args) as assoc`: resolve the PC via
+%  the shared resolver, box args, and forward the caller's assoc table to
+%  @wam_object_call_assoc (which walks the returned [K-V,...] pairs into it).
+plawk_dyncall_named_assoc_shim_ir(Name, NArgs, IR) :-
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define i1 @plawk_dyncall_assoc_~w(~w, %WamAssocI64Table* %table) {
+entry:
+  %pc = call i32 @plawk_dyncall_resolve_~w()
+  %bad = icmp slt i32 %pc, 0
+  br i1 %bad, label %fail, label %do_call
+
+do_call:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call i1 @wam_object_call_assoc(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, %WamAssocI64Table* %table)
+  ret i1 %r
+
+fail:
+  ret i1 false
+}',
+        [Sym, ParamsIR, Sym, NArgs, StoreIR, NArgs, NArgs]).
 
 %% plawk_dyncall_rec_shim_ir(+NArgs, -IR)
 %  Record shim for a default-entry destructure bind: resolve vm/pc from the
@@ -3034,7 +3097,9 @@ plawk_assoc_runtime_count_plan(
     PrintArrays \== [],
     findall(ArrayName,
         ( member(rule(_Pattern, ActionSpecs, _Control), RuleSpecs),
-          member(ArrayName-_KeyIndex, ActionSpecs)
+          ( member(ArrayName-_KeyIndex, ActionSpecs)
+          ; member(dynassoc(ArrayName, _Call), ActionSpecs)
+          )
         ),
         ActionArrays),
     append(ActionArrays, PrintArrays, ArrayNames0),
@@ -3048,9 +3113,19 @@ plawk_assoc_rule_action_specs(rule(Pattern, Actions), rule(Pattern, ActionSpecs,
     plawk_split_terminal_control(Actions, BodyActions, Control),
     ( BodyActions == []
     -> ActionSpecs = []
-    ;  maplist(plawk_assoc_increment_action, BodyActions, ActionSpecs)
+    ;  maplist(plawk_assoc_body_action_spec, BodyActions, ActionSpecs)
     ),
     ( ActionSpecs \== [] ; memberchk(Control, [terminal_next, terminal_break]) ).
+
+% Per-record assoc actions: an increment (Array-KeyIndex) or a grammar
+% populate (dynassoc(Array, Call)) that fills Array's table from the
+% returned [K-V,...] pairs.
+plawk_assoc_body_action_spec(inc_assoc(var(ArrayName), field(KeyIndex)),
+        ArrayName-KeyIndex) :-
+    KeyIndex > 0.
+plawk_assoc_body_action_spec(dynassoc_bind(var(ArrayName), Call),
+        dynassoc(ArrayName, Call)) :-
+    plawk_dynrec_call_ok(Call).
 
 plawk_assoc_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), ArrayName-KeyIndex) :-
     KeyIndex > 0.
@@ -3074,6 +3149,12 @@ plawk_assoc_planned_actions([ArrayName-KeyIndex | Rest], Tables, Index) -->
       NextIndex is Index + 1
     },
     [assoc_action(Index, ArrayName, TableIndex, KeyIndex)],
+    plawk_assoc_planned_actions(Rest, Tables, NextIndex).
+plawk_assoc_planned_actions([dynassoc(ArrayName, Call) | Rest], Tables, Index) -->
+    { nth0(TableIndex, Tables, ArrayName),
+      NextIndex is Index + 1
+    },
+    [assoc_dyn_action(Index, ArrayName, TableIndex, Call)],
     plawk_assoc_planned_actions(Rest, Tables, NextIndex).
 
 plawk_assoc_entry_setup_ir(assoc_plan(Tables, _Actions), IR) :-
@@ -3166,6 +3247,31 @@ plawk_assoc_rule_action_lines(RuleIndex, Actions, NextLabel, FieldSeparator) -->
 
 plawk_assoc_rule_action_blocks(_RuleIndex, [], _NextLabel, _FieldSeparator) -->
     [].
+% Grammar-populate action: evaluate the call args, then hand the whole
+% [K-V,...] result to the assoc shim, which walks it into this array's table.
+plawk_assoc_rule_action_blocks(RuleIndex,
+        [assoc_dyn_action(Index, _ArrayName, TableIndex, Call) | Rest],
+        NextLabel, FieldSeparator) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(Base), 'assoc_rule_~w_action_~w_dyn', [RuleIndex, Index]),
+      plawk_dynassoc_call_parts(Call, Args, ShimName),
+      plawk_foreign_args_ir(Args, FieldSeparator, Base, ArgValueIRs,
+          _Globals, Setup),
+      plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
+      format(atom(CallLine),
+          '  %~w_ok = call i1 @~w(~w, %WamAssocI64Table* %plawk_assoc_table_~w)',
+          [Base, ShimName, CallArgsIR, TableIndex]),
+      format(atom(Next), '  br label %~w', [ActionNextLabel]),
+      append([[Label], Setup, [CallLine, Next, '']], Lines)
+    },
+    plawk_emit_lines(Lines),
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
 plawk_assoc_rule_action_blocks(RuleIndex, [assoc_action(Index, _ArrayName, TableIndex, KeyIndex) | Rest], NextLabel, binfmt(Types)) -->
     { !,
       ( Rest == []
@@ -3279,6 +3385,10 @@ plawk_binfmt_assoc_action_ok(_Descriptor, break) :- !.
 plawk_binfmt_assoc_action_ok(Descriptor, inc_assoc(var(_Name), field(Index))) :-
     !,
     plawk_binfmt_field_type(Descriptor, Index, i64).
+plawk_binfmt_assoc_action_ok(Descriptor, dynassoc_bind(var(_Name), Call)) :-
+    !,
+    plawk_dynassoc_call_parts(Call, Args, _Shim),
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
 
 plawk_record_program_ok(binfmt(Types), Rules, _EndPrintFields) :-
     !,
@@ -5827,6 +5937,14 @@ plawk_dynrec_call_parts(dyncall_named(Name, Args), Args, ShimName) :-
     length(Args, NArgs),
     plawk_dyncall_named_symbol(Name, NArgs, Sym),
     format(atom(ShimName), 'plawk_dyncall_named_rec_~w', [Sym]).
+
+%% plawk_dynassoc_call_parts(+Call, -Args, -ShimName)
+%  The assoc shim for a named-entry `... as assoc` site (named entry only;
+%  a default-entry `dyncall(...) as assoc` is a follow-on).
+plawk_dynassoc_call_parts(dyncall_named(Name, Args), Args, ShimName) :-
+    length(Args, NArgs),
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    format(atom(ShimName), 'plawk_dyncall_assoc_~w', [Sym]).
 
 plawk_dynrec_field_load_lines([], [], _Base, []).
 plawk_dynrec_field_load_lines([F | Fs], [Type | Ts], Base, [Line | Lines]) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -827,6 +827,9 @@ action(Action) -->
     dynrec_view_action(Action),
     !.
 action(Action) -->
+    dynassoc_bind_action(Action),
+    !.
+action(Action) -->
     dynrec_bind_action(Action),
     !.
 action(Action) -->
@@ -920,6 +923,28 @@ break_action(break) -->
 %  desugars (in codegen) to a destructure into hidden temporaries plus the
 %  block body with `$N` rewritten to the Nth temporary -- so it rides the
 %  same machinery as the explicit destructure, no field-pointer repoint.
+%% dynassoc_bind_action(-Action)//
+%
+%  Associative-array return: a grammar returning a list of integer key-value
+%  pairs populates a plawk assoc array.
+%
+%      arr = dyncall@tally($1) as assoc
+%
+%  desugars to dynassoc_bind(var(arr), dyncall_named(tally, [field(1)])); per
+%  record the returned [K-V, ...] pairs are inserted into arr's i64 table, so
+%  END `arr[key]` lookups see the accumulated result.
+dynassoc_bind_action(dynassoc_bind(var(Name), Call)) -->
+    identifier(Name),
+    ws,
+    "=",
+    ws,
+    dynrec_call_expr(Call),
+    ws,
+    "as",
+    identifier_boundary,
+    ws,
+    "assoc".
+
 dynrec_view_action(dynrec_view(Call, Types, Body)) -->
     dynrec_call_expr(Call),
     ws,

--- a/tests/test_plawk_dyncall_assoc.pl
+++ b/tests/test_plawk_dyncall_assoc.pl
@@ -1,0 +1,112 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Phase 5 (JIT) roadmap item 4, assoc-return surface: a grammar returning a
+% list of integer key-value pairs populates a plawk associative array.
+%   arr = dyncall@tally($1) as assoc
+% Per record the returned [K-V, ...] pairs are inserted (accumulated) into
+% arr's i64 table via @wam_object_call_assoc; END arr[key] lookups see the
+% result. Named entry, integer keys/values (the mechanism's shape).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% tally(X) returns two pairs: bucket 1 gets X, bucket 2 gets a flat 100.
+tally(X, R) :- R = [1-X, 2-100].
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_assoc).
+
+% `arr = dyncall@name(...) as assoc` parses to its own node.
+test(assoc_bind_parses) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         { arr = dyncall@tally($1) as assoc }\nEND { print arr[1] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(dynassoc_bind(var(arr), dyncall_named(tally, [field(1)])),
+        Actions),
+    !.
+
+% The named-assoc entry is collected, and the shim + primitive are emitted.
+test(assoc_ir_emitted) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"lib.wamo\" }\n\c
+         { arr = dyncall@tally($1) as assoc }\nEND { print arr[1] }\n",
+        Program),
+    plawk_program_dyncall_named_assoc_entries(Program, Entries),
+    assertion(Entries == [tally-1]),
+    plawk_program_native_driver_ir(Program, stdin_or_argv,
+        [wam_vm(10, 10)], IR),
+    sub_atom(IR, _, _, _, '@plawk_dyncall_assoc_tally_1'),
+    sub_atom(IR, _, _, _, '@wam_object_call_assoc'),
+    !.
+
+% Full round trip: per record, tally($1) -> [1-$1, 2-100] accumulates into
+% arr. Over inputs 5, 7: arr[1] = 5+7 = 12, arr[2] = 100+100 = 200.
+test(assoc_populates_and_reads, [condition(clang_available)]) :-
+    da_dir(Dir),
+    directory_file_path(Dir, 'lib.wamo', Wamo),
+    write_wam_object([user:tally/2], [wamo_entries([tally/2])], Wamo),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@tally($1) as assoc }\n\c
+         END { print arr[1], arr[2] }\n", [Wamo]),
+    build_run(Dir, 'da', Src, [5, 7], Out),
+    assertion(Out == "12 200\n"),
+    !.
+
+:- end_tests(plawk_dyncall_assoc).
+
+% --- helpers ---------------------------------------------------------------
+
+da_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_dyncall_assoc', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Values, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'in.bin', Input),
+    write_i64_records(Input, Values),
+    run_bin(Bin, [Input], Out, 0).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_i64_records(Path, Values) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(V, Values), write_i64_le(Out, V)),
+        close(Out)).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(null), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## What

Completes the associative-array target: a grammar returning a list of integer key-value pairs populates a plawk assoc array.

```awk
BEGIN { BINFMT = "i64" ; DYNLOAD = "lib.wamo" }
{ arr = dyncall@tally($1) as assoc }
END { print arr[1], arr[2] }
```

Per record, the returned `[K-V, …]` pairs are inserted (accumulated) into `arr`'s i64 table via `@wam_object_call_assoc` (mechanism landed in #3481); END `arr[k]` lookups read the result through the existing assoc plan.

## How

- **Parser**: `id = dyncall@name(args) as assoc` → `dynassoc_bind(var(arr), Call)`.
- **Codegen**: a named-assoc collector + a `@plawk_dyncall_assoc_<Sym>` shim (resolves vm/pc via the shared resolver, forwards the caller's `%WamAssocI64Table*` to `@wam_object_call_assoc`) threaded through `plawk_dyncall_support_ir`. The `dynassoc_bind` action is recognized by the **BINFMT assoc driver** as a per-record assoc action (`assoc_dyn_action`) whose array is allocated in the **same assoc plan** as `arr[k]++` — so END `arr[k]` reads the very same table. Validation added to `plawk_binfmt_assoc_action_ok`; the CLI triggers `emit_wamo_loader`.

The key integration point: rather than a parallel table, the grammar-populated array joins the existing assoc plan, so all the landed assoc machinery (allocation, END lookup) works unchanged.

## Tests

New `tests/test_plawk_dyncall_assoc.pl` (3): parse, shim/primitive IR + entry collection, and the end-to-end round trip — `tally($1) -> [1-$1, 2-100]` over inputs 5,7 gives `arr[1]=12`, `arr[2]=200`. The assoc-driver suites I touched (`binary_assoc`, `surface_forin_end_print`, `union_assoc`) plus `dyncall*` / `record_view` / `wam_object` pass.

## Deferred (roadmap)

Default-entry `dyncall(...) as assoc` (named only for now), for-in iteration over a grammar-populated table, and atom/string keys (interned — an extension of the integer-key mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_