### PR TITLE
plawk/JIT (roadmap #5, start): lift clause indexing into the loadable subset + eval-bootstrap design

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -1,0 +1,121 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2026 John William Creighton (@s243a)
+-->
+
+# plawk eval bootstrap (JIT roadmap item 5)
+
+Compiling a grammar from **source text at runtime** — the endgame of the
+dynamic-grammar arc. This is the plan and the milestone sequence; it is a
+multi-PR effort, not a single change.
+
+## The goal
+
+```awk
+BEGIN { DYNLOAD = "..." }
+{ g = compile($1) ; total += dyncall_at(g, $2) }
+```
+
+`eval(Source)` / `compile(Source)` = compile a grammar from a source string
+**inside the running binary**, then load and call it. Concretely:
+
+1. Ship the WAM compiler itself as a `.wamo` object (`compiler.wamo`).
+2. `eval(src)` loads `compiler.wamo` (once, lazily — the pay-for-what-you-use
+   invariant: the compiler object only loads when an `eval` surface is used).
+3. Run the compiler object on the source string → it returns the compiled
+   grammar's **`.wamo` bytes** (a blob — the byte-return bridge from item 2).
+4. Load those bytes with the **in-memory loader** `@wam_object_load_bytes`
+   (#3463) → a `%WamState*` + entry PC.
+5. Call the freshly compiled grammar like any `dyncall`.
+
+Steps 3–5 already have their primitives: `@wam_object_call_bytes` returns a
+byte slice, and `@wam_object_load_bytes` + `@wam_object_call_i64` load and run
+a buffer. The `mtime` cache-invalidation path (#3465) is the natural home for
+"recompile when the source changes." **The hard part is step 1**: getting the
+compiler to run *as a loaded object*, which needs the loadable WAM subset
+expanded to cover what the compiler leans on.
+
+## Why it is genuinely last
+
+The compiler is ordinary Prolog compiled to WAM, but it uses constructs the
+`.wamo` loadable subset does not yet cover. Until the subset reaches the
+compiler's needs, the compiler can be compiled *ahead of time* (as the host
+does today) but not *loaded and run* from a `.wamo`. So item 5 is really a
+**subset-expansion campaign** with the bootstrap as its payoff.
+
+The loadable subset today (post item 1–4): `try_me_else`/`retry_me_else`
+chains, `get`/`put`/`set`/`unify` variable+value+constant (integer, atom,
+float), `get`/`put_list`, `get`/`put_structure`, `allocate`/`deallocate`,
+`call`/`execute`, `proceed`, `builtin_call`, `cut`/`get_level`/`cut_ite`,
+`jump`, and — as of this PR — **all clause-indexing dispatch**
+(`switch_on_term`, `switch_on_structure`, `switch_on_constant`,
+`switch_on_constant_a2`) as nop-fallthroughs.
+
+### Why indexing dispatch is a safe nop
+
+The tier-2 compiler emits every indexing instruction **inline at the head of
+the predicate**, immediately before the `try_me_else` chain, e.g. for an
+atom-keyed `col/2`:
+
+```
+switch_on_constant red:default green:L_col_2_2_body blue:L_col_2_3_body
+try_me_else L_col_2_2
+get_constant red, A1
+...
+L_col_2_2: retry_me_else L_col_2_3
+...
+L_col_2_3: trust_me
+...
+```
+
+The switch is an *optimization*: its entries only point deeper into the same
+`try_me_else`/`retry`/`trust` chain that follows it inline. Dropping the
+switch and falling through runs every clause in order — correct, just
+unindexed. The loader already did this for `switch_on_term`; extending it to
+`switch_on_constant`/`_a2` (this PR) means grammars with atom-keyed clauses —
+pervasive in the compiler — now load. Cost: unindexed dispatch in loaded
+objects (an optimization gap, not a correctness one).
+
+## Milestones (subset expansion → bootstrap)
+
+Rough dependency order. Each is its own PR(s); the earlier ones are
+independently useful (richer hand-written grammars load sooner).
+
+1. **Clause indexing** — *LANDED (this PR).* `switch_on_constant`/`_a2` as
+   nop-fallthroughs. Atom-keyed multi-clause predicates load.
+2. **`call/N` meta-call in objects.** The loader's `call`/`execute` handle a
+   label index; a meta-call encodes `op1 = -1` and dispatches through
+   `@wam_dispatch_meta_call` (which the host already has). The `.wamo` writer
+   rejects meta-calls today (the label lookup fails). Needed for any grammar
+   that calls a goal built at runtime — the spine of an interpreter/compiler.
+3. **The builtin closure the compiler needs.** `builtin_call` is already in
+   the subset, so a builtin works in a loaded object *if the host runtime
+   provides it*. Audit the compiler's builtin use (`findall`/`bagof`,
+   `assert`/`retract`, `read_term`/`term_to_atom`, `=..`, `functor`/`arg`,
+   `atom_codes`/`number_codes`, list ops) and confirm each is host-provided
+   and loader-safe; add any that are missing. `assert`/`retract` against a
+   loaded object's own dynamic predicates is the subtle one (mutable state in
+   an arena-rewound VM).
+4. **Byte-buffer output from a grammar.** The compiler object must *emit*
+   `.wamo` bytes. It returns them as an Atom/byte string (the item-2 blob
+   bridge already carries bytes out); building that byte string inside the
+   grammar needs the string/codes builtins from milestone 3.
+5. **The `eval` / `compile` surface + pipeline.** Wire the plawk surface:
+   `compile(src)` → run `compiler.wamo` on `src` (blob out) →
+   `@wam_object_load_bytes` → a handle usable by `dyncall_at`. Lazy-load the
+   compiler object; cache per `DYNCACHE`.
+6. **Self-host.** Compile the actual WAM compiler to a `.wamo` and run the
+   whole pipeline from source text end to end. The capstone.
+
+## Cross-cutting notes
+
+- **Pay-for-what-you-use holds:** the compiler object (large) loads only when
+  an `eval`/`compile` surface is compiled into the program, riding
+  `emit_wamo_loader(true)` like every other dynamic capability.
+- **Correctness-first, speed-later:** loaded objects run unindexed (milestone
+  1). If the eval loop becomes hot, a real switch-table in the loader is a
+  later optimization — the format already carries the switch operands we
+  currently drop.
+- **Milestones 1–4 are the long pole**; 5–6 are plumbing over primitives that
+  already exist (`@wam_object_load_bytes`, `@wam_object_call_bytes`, the
+  `mtime` cache).

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -280,7 +280,7 @@ byte-return primitive and the "output is a term, not a scalar" plumbing),
 and benefits from item 1 (float constants) for grammars that build float
 fields.
 
-### 5. Source-`eval` via the compiler-as-`.wamo` bootstrap — *largest*
+### 5. Source-`eval` via the compiler-as-`.wamo` bootstrap — *largest, STARTED*
 
 **What:** compile a grammar from **source text at runtime** — `g =
 compile($1); total += dyncall_at(g, $2)` — by shipping the WAM compiler
@@ -296,6 +296,24 @@ you-use holds: the compiler-object only loads when an `eval` surface is used.
 subset — the compiler leans on `findall`/`assert`/`read_term`/meta-call,
 which are outside the subset today. Items 1 (float constants) and the
 broader builtin/subset work are stepping stones; this is genuinely last.
+
+**Status:** design + first subset increment landed. The full plan and its
+six milestones live in [PLAWK_EVAL_BOOTSTRAP.md](./PLAWK_EVAL_BOOTSTRAP.md).
+Item 5 is a **subset-expansion campaign** with the bootstrap as its payoff;
+each milestone is its own PR(s) and richer hand-written grammars become
+loadable along the way.
+
+- **Milestone 1 — clause indexing — LANDED.** All clause-indexing dispatch
+  (`switch_on_term`, `switch_on_structure`, `switch_on_constant`,
+  `switch_on_constant_a2`) is now in the loadable `.wamo` subset as
+  nop-fallthroughs. Safe because the tier-2 compiler emits every indexing
+  instruction *inline at the head of the predicate*, immediately before the
+  `try_me_else` chain it dispatches into; dropping the switch and falling
+  through runs every clause in order — correct, just unindexed. This lets
+  atom-keyed multi-clause predicates (pervasive in the compiler) load.
+- **Milestones 2–6** (meta-call in objects, the compiler's builtin closure,
+  byte-buffer output, the `eval`/`compile` surface, self-host) — see the
+  bootstrap doc.
 
 ## The binary-return question, specifically
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -20181,25 +20181,28 @@ wamo_enc(["retry_me_else", L], LabelMap, A, A, F, F, enc(23, Idx, 0, none)) :- !
 wamo_enc(["jump", L], LabelMap, A, A, F, F, enc(32, Idx, 0, none)) :- !,
     clean_comma(L, CL), lookup_label_index(CL, LabelMap, Idx).
 
-% type-based dispatch: nop fallthrough (tag 26), matching the interpreter's
-% runtime semantics. The try_me_else / retry_me_else chain still runs, so
-% the predicate is correct (just unindexed). No switch table is needed.
-wamo_enc(["switch_on_term" | _],      _, A, A, F, F, enc(26, 0, 0, none)) :- !.
-wamo_enc(["switch_on_term_a2" | _],   _, A, A, F, F, enc(26, 0, 0, none)) :- !.
-wamo_enc(["switch_on_structure" | _], _, A, A, F, F, enc(26, 0, 0, none)) :- !.
+% Indexing dispatch: nop fallthrough (tag 26), matching the interpreter's
+% runtime semantics. Every indexing instruction the tier-2 compiler emits
+% sits INLINE at the head of the predicate, immediately before the
+% try_me_else / retry_me_else clause chain (see the layout in
+% PLAWK_EVAL_BOOTSTRAP.md); the switch entries only point deeper into that
+% same chain. So dropping the switch and falling through to try_me_else
+% runs every clause in order -- correct, just unindexed. This includes
+% switch_on_constant / _a2 (first/second-argument constant indexing): a
+% loaded object runs them unindexed, exactly as it already does for
+% switch_on_term. Lifting these is the first subset-expansion step toward
+% the eval bootstrap (item 5) -- the WAM compiler's own predicates lean
+% heavily on atom-keyed clause indexing.
+wamo_enc(["switch_on_term" | _],         _, A, A, F, F, enc(26, 0, 0, none)) :- !.
+wamo_enc(["switch_on_term_a2" | _],      _, A, A, F, F, enc(26, 0, 0, none)) :- !.
+wamo_enc(["switch_on_structure" | _],    _, A, A, F, F, enc(26, 0, 0, none)) :- !.
+wamo_enc(["switch_on_constant" | _],     _, A, A, F, F, enc(26, 0, 0, none)) :- !.
+wamo_enc(["switch_on_constant_a2" | _],  _, A, A, F, F, enc(26, 0, 0, none)) :- !.
 wamo_enc(["try" | _],   _, A, A, F, F, enc(26, 0, 0, none)) :- !.
 wamo_enc(["retry" | _], _, A, A, F, F, enc(26, 0, 0, none)) :- !.
 wamo_enc(["trust" | _], _, A, A, F, F, enc(26, 0, 0, none)) :- !.
 
-% everything else is outside the slice-1 loadable subset
-wamo_enc(["switch_on_constant" | _], _, _, _, _, _, _) :-
-    throw(error(wamo_unsupported(switch_on_constant),
-        context(write_wam_object,
-            'first-argument constant indexing needs a switch table (not in slice 1)'))).
-wamo_enc(["switch_on_constant_a2" | _], _, _, _, _, _, _) :-
-    throw(error(wamo_unsupported(switch_on_constant_a2),
-        context(write_wam_object,
-            'second-argument constant indexing needs a switch table (not in slice 1)'))).
+% everything else is outside the loadable WAM object subset
 wamo_enc(Parts, _, _, _, _, _, _) :-
     throw(error(wamo_unsupported(instruction(Parts)),
         context(write_wam_object,

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -35,6 +35,14 @@ makerecs(R) :- R = rs(7, hello).
 % (@wam_object_call_assoc): each K-V is inserted into an i64 assoc table.
 tally(R) :- R = [1-100, 2-200, 3-30].
 
+% atom-first-argument clause indexing: coltab/2 compiles to a
+% switch_on_constant. pick/1 looks up `green`. The loader nops the switch
+% and runs the try_me_else chain (unindexed but correct) -> 2.
+coltab(red, 1).
+coltab(green, 2).
+coltab(blue, 3).
+pick(R) :- coltab(green, R).          % -> 2
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -200,6 +208,21 @@ test(assoc_return_populates_table,
     build_record_assoc_host(Dir, Host),
     run_host(Host, Wamo, Out, 0),
     assertion(Out == "100\n200\n30\n"),
+    !.
+
+% Atom-first-argument indexing (switch_on_constant) is now loadable: the
+% loader nops the switch and runs the clause chain unindexed. pick/1 over
+% the atom-keyed coltab/2 returns 2 -- the first subset-expansion step for
+% the eval bootstrap (item 5).
+test(switch_on_constant_loads_and_runs,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'pick.wamo', Wamo),
+    write_wam_object([user:pick/1, user:coltab/2], [wamo_entry(pick/1)], Wamo),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "2\n"),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
Begins JIT roadmap **item 5** (source-`eval` via the compiler-as-`.wamo` bootstrap) with its first subset-expansion increment plus the scoping design doc.

## Milestone 1 — clause indexing (LANDED here)

All clause-indexing dispatch instructions now encode into the loadable `.wamo` subset as nop-fallthroughs (tag 26) instead of throwing:

- `switch_on_term`, `switch_on_structure` — already nops
- `switch_on_constant`, `switch_on_constant_a2` — **newly lifted in this PR** (previously rejected the whole object)

### Why this is a safe nop

The tier-2 compiler emits every indexing instruction **inline at the head of the predicate**, immediately before the `try_me_else` chain it dispatches into. For an atom-keyed `col/2`:

```
switch_on_constant red:default green:L_col_2_2_body blue:L_col_2_3_body
try_me_else L_col_2_2
get_constant red, A1
...
L_col_2_2: retry_me_else L_col_2_3
...
L_col_2_3: trust_me
```

The switch is purely an optimization — its entries only point deeper into the same `try_me_else`/`retry`/`trust` chain that follows it inline. Dropping the switch and falling through runs every clause in order: **correct, just unindexed.** Verified against `col/2`'s actual WAM layout.

**Effect:** atom-keyed multi-clause predicates — pervasive in the WAM compiler itself — now load and run from a `.wamo`. The cost is an optimization gap (unindexed dispatch in loaded objects), not a correctness one; the format still carries the switch operands we currently drop, so a real switch-table in the loader remains a later optimization.

## Changes

- `src/unifyweaver/targets/wam_llvm_target.pl` — `switch_on_constant`/`_a2` `wamo_enc` clauses become tag-26 nop-fallthroughs; comment references the bootstrap doc.
- `tests/test_wam_object.pl` — `coltab/2` (atom clauses) + `pick/1` grammar and a `switch_on_constant_loads_and_runs` test (loads, runs, returns `2`).
- `docs/design/PLAWK_EVAL_BOOTSTRAP.md` — new item-5 scoping doc: the goal, why it is genuinely last, why indexing dispatch is a safe nop, and the six milestones (clause indexing LANDED → meta-call in objects → builtin closure → byte output → `eval` surface → self-host).
- `docs/design/PLAWK_JIT_ROADMAP.md` — item 5 marked STARTED, milestone 1 landed, links the bootstrap doc.

## Testing

Full `wam_object` suite and all nine `dyncall` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_