### PR TITLE
plawk/JIT (roadmap #5, milestone 2): call/N meta-call inside loaded .wamo objects

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -43,13 +43,13 @@ compiler's needs, the compiler can be compiled *ahead of time* (as the host
 does today) but not *loaded and run* from a `.wamo`. So item 5 is really a
 **subset-expansion campaign** with the bootstrap as its payoff.
 
-The loadable subset today (post item 1–4): `try_me_else`/`retry_me_else`
-chains, `get`/`put`/`set`/`unify` variable+value+constant (integer, atom,
-float), `get`/`put_list`, `get`/`put_structure`, `allocate`/`deallocate`,
-`call`/`execute`, `proceed`, `builtin_call`, `cut`/`get_level`/`cut_ite`,
-`jump`, and — as of this PR — **all clause-indexing dispatch**
-(`switch_on_term`, `switch_on_structure`, `switch_on_constant`,
-`switch_on_constant_a2`) as nop-fallthroughs.
+The loadable subset today: `try_me_else`/`retry_me_else` chains,
+`get`/`put`/`set`/`unify` variable+value+constant (integer, atom, float),
+`get`/`put_list`, `get`/`put_structure`, `allocate`/`deallocate`,
+`call`/`execute` (**including `call/N` meta-calls** — milestone 2, landed),
+`proceed`, `builtin_call`, `cut`/`get_level`/`cut_ite`, `jump`, and **all
+clause-indexing dispatch** — every `switch_on_*` variant, matched by prefix
+so the `_fallthrough` and `_a2` forms are covered too — as nop-fallthroughs.
 
 ### Why indexing dispatch is a safe nop
 
@@ -83,11 +83,23 @@ independently useful (richer hand-written grammars load sooner).
 
 1. **Clause indexing** — *LANDED (this PR).* `switch_on_constant`/`_a2` as
    nop-fallthroughs. Atom-keyed multi-clause predicates load.
-2. **`call/N` meta-call in objects.** The loader's `call`/`execute` handle a
-   label index; a meta-call encodes `op1 = -1` and dispatches through
-   `@wam_dispatch_meta_call` (which the host already has). The `.wamo` writer
-   rejects meta-calls today (the label lookup fails). Needed for any grammar
-   that calls a goal built at runtime — the spine of an interpreter/compiler.
+2. **`call/N` meta-call in objects** — *LANDED.* A meta-call encodes
+   `op1 = -1` (`op2` = total arity), exactly as the host AOT path does, and
+   dispatches through `@wam_dispatch_meta_call`. The subtlety is that
+   dispatch resolves a *goal* (atom/functor + arity) to a *label index*, and
+   a loaded object's predicates are not in the host's compile-time dispatch
+   table. So the format grew a **per-object meta-call table** (version 2): a
+   trailing section listing each predicate as `(atomIdx, funIdx, arity,
+   labelIdx)` into the object's own atom/functor tables. The loader
+   materializes it into a `%WamMetaRow` array hung off two new `%WamState`
+   fields (25/26); `@wam_dispatch_meta_call` consults the VM's table when
+   present (via `@wam_meta_find_atom` / `@wam_meta_find_compound`) and falls
+   back to the host-global arrays otherwise. Compound-goal matching works
+   because a loaded object's runtime functor pointers are its own malloc'd
+   copies — the very pointers the table stores — so identity holds within one
+   object. The table is only emitted for objects that actually contain a
+   meta-call (pay-for-what-you-use). This is the spine of any grammar that
+   calls a goal built at runtime — an interpreter or compiler.
 3. **The builtin closure the compiler needs.** `builtin_call` is already in
    the subset, so a builtin works in a loaded object *if the host runtime
    provides it*. Audit the compiler's builtin use (`findall`/`bagof`,

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -303,17 +303,22 @@ Item 5 is a **subset-expansion campaign** with the bootstrap as its payoff;
 each milestone is its own PR(s) and richer hand-written grammars become
 loadable along the way.
 
-- **Milestone 1 — clause indexing — LANDED.** All clause-indexing dispatch
-  (`switch_on_term`, `switch_on_structure`, `switch_on_constant`,
-  `switch_on_constant_a2`) is now in the loadable `.wamo` subset as
-  nop-fallthroughs. Safe because the tier-2 compiler emits every indexing
-  instruction *inline at the head of the predicate*, immediately before the
-  `try_me_else` chain it dispatches into; dropping the switch and falling
-  through runs every clause in order — correct, just unindexed. This lets
-  atom-keyed multi-clause predicates (pervasive in the compiler) load.
-- **Milestones 2–6** (meta-call in objects, the compiler's builtin closure,
-  byte-buffer output, the `eval`/`compile` surface, self-host) — see the
-  bootstrap doc.
+- **Milestone 1 — clause indexing — LANDED.** Every `switch_on_*` dispatch
+  variant (matched by prefix, so the `_fallthrough` and `_a2` forms are
+  covered) is now in the loadable `.wamo` subset as a nop-fallthrough. Safe
+  because the tier-2 compiler emits every indexing instruction *inline at the
+  head of the predicate*, immediately before the `try_me_else` chain it
+  dispatches into; dropping the switch and falling through runs every clause
+  in order — correct, just unindexed. Lets atom-keyed multi-clause predicates
+  (pervasive in the compiler) load.
+- **Milestone 2 — `call/N` meta-call in objects — LANDED.** A meta-call
+  encodes `op1 = -1`; dispatch resolves the runtime goal through a new
+  **per-object meta-call table** (format version 2) hung off two new
+  `%WamState` fields, so a loaded object can `call/N` its own predicates —
+  atom goals and compound (partial-application) goals alike. Falls back to the
+  host-global table for host VMs. The spine of any runtime-built goal.
+- **Milestones 3–6** (the compiler's builtin closure, byte-buffer output, the
+  `eval`/`compile` surface, self-host) — see the bootstrap doc.
 
 ## The binary-return question, specifically
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -2341,6 +2341,10 @@ emit_meta_call_dispatch(LabelMap, IR) :-
     ),
     format(string(IR),
 "; === Meta-call dispatch table: atom/functor + arity -> label index ===
+; Host-global table, built at compile time from the host''s own predicates.
+; A loaded .wamo object carries its OWN table on the VM (fields 25/26); the
+; two find helpers below consult that table when present so an object can
+; meta-call its own predicates (eval bootstrap milestone 2).
 @wam_meta_call_atom_ids = private constant [~w x i64] [
 ~w
 ]
@@ -2353,6 +2357,127 @@ emit_meta_call_dispatch(LabelMap, IR) :-
 @wam_meta_call_label_indexes = private constant [~w x i32] [
 ~w
 ]
+
+; Resolve an atom goal (atom_id + target_arity) to a predicate label index,
+; or -1 if none matches. Uses the VM''s object meta-call table when installed
+; (loaded .wamo), else the host-global arrays.
+define i32 @wam_meta_find_atom(%WamState* %vm, i64 %atom_id, i32 %target_arity) {
+entry:
+  %om_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 25
+  %om = load %WamMetaRow*, %WamMetaRow** %om_ptr
+  %om_null = icmp eq %WamMetaRow* %om, null
+  br i1 %om_null, label %global, label %obj
+obj:
+  %omc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 26
+  %omc = load i32, i32* %omc_ptr
+  br label %oloop
+oloop:
+  %oi = phi i32 [ 0, %obj ], [ %oi1, %onext ]
+  %odone = icmp sge i32 %oi, %omc
+  br i1 %odone, label %notfound, label %ocheck
+ocheck:
+  %orow = getelementptr %WamMetaRow, %WamMetaRow* %om, i32 %oi
+  %oa_ptr = getelementptr %WamMetaRow, %WamMetaRow* %orow, i32 0, i32 0
+  %oa = load i64, i64* %oa_ptr
+  %oa_match = icmp eq i64 %oa, %atom_id
+  %oar_ptr = getelementptr %WamMetaRow, %WamMetaRow* %orow, i32 0, i32 2
+  %oar = load i32, i32* %oar_ptr
+  %oar_match = icmp eq i32 %oar, %target_arity
+  %o_match = and i1 %oa_match, %oar_match
+  br i1 %o_match, label %ofound, label %onext
+onext:
+  %oi1 = add i32 %oi, 1
+  br label %oloop
+ofound:
+  %ol_ptr = getelementptr %WamMetaRow, %WamMetaRow* %orow, i32 0, i32 3
+  %ol = load i32, i32* %ol_ptr
+  ret i32 %ol
+global:
+  br label %gloop
+gloop:
+  %gi = phi i32 [ 0, %global ], [ %gi1, %gnext ]
+  %gdone = icmp sge i32 %gi, ~w
+  br i1 %gdone, label %notfound, label %gcheck
+gcheck:
+  %gap = getelementptr [~w x i64], [~w x i64]* @wam_meta_call_atom_ids, i32 0, i32 %gi
+  %ga = load i64, i64* %gap
+  %ga_match = icmp eq i64 %ga, %atom_id
+  %grp = getelementptr [~w x i32], [~w x i32]* @wam_meta_call_arities, i32 0, i32 %gi
+  %gr = load i32, i32* %grp
+  %gr_match = icmp eq i32 %gr, %target_arity
+  %g_match = and i1 %ga_match, %gr_match
+  br i1 %g_match, label %gfound, label %gnext
+gnext:
+  %gi1 = add i32 %gi, 1
+  br label %gloop
+gfound:
+  %glp = getelementptr [~w x i32], [~w x i32]* @wam_meta_call_label_indexes, i32 0, i32 %gi
+  %gl = load i32, i32* %glp
+  ret i32 %gl
+notfound:
+  ret i32 -1
+}
+
+; Resolve a compound goal (functor pointer + target_arity) to a label index,
+; or -1. Functor matching is by pointer identity; a loaded object''s compound
+; goals carry its own functor copies, which is exactly what its object table
+; stores (see the loader), so identity holds within one object.
+define i32 @wam_meta_find_compound(%WamState* %vm, i8* %functor, i32 %target_arity) {
+entry:
+  %om_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 25
+  %om = load %WamMetaRow*, %WamMetaRow** %om_ptr
+  %om_null = icmp eq %WamMetaRow* %om, null
+  br i1 %om_null, label %global, label %obj
+obj:
+  %omc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 26
+  %omc = load i32, i32* %omc_ptr
+  br label %oloop
+oloop:
+  %oi = phi i32 [ 0, %obj ], [ %oi1, %onext ]
+  %odone = icmp sge i32 %oi, %omc
+  br i1 %odone, label %notfound, label %ocheck
+ocheck:
+  %orow = getelementptr %WamMetaRow, %WamMetaRow* %om, i32 %oi
+  %of_ptr = getelementptr %WamMetaRow, %WamMetaRow* %orow, i32 0, i32 1
+  %of = load i8*, i8** %of_ptr
+  %of_match = icmp eq i8* %of, %functor
+  %oar_ptr = getelementptr %WamMetaRow, %WamMetaRow* %orow, i32 0, i32 2
+  %oar = load i32, i32* %oar_ptr
+  %oar_match = icmp eq i32 %oar, %target_arity
+  %o_match = and i1 %of_match, %oar_match
+  br i1 %o_match, label %ofound, label %onext
+onext:
+  %oi1 = add i32 %oi, 1
+  br label %oloop
+ofound:
+  %ol_ptr = getelementptr %WamMetaRow, %WamMetaRow* %orow, i32 0, i32 3
+  %ol = load i32, i32* %ol_ptr
+  ret i32 %ol
+global:
+  br label %gloop
+gloop:
+  %gi = phi i32 [ 0, %global ], [ %gi1, %gnext ]
+  %gdone = icmp sge i32 %gi, ~w
+  br i1 %gdone, label %notfound, label %gcheck
+gcheck:
+  %gfp = getelementptr [~w x i8*], [~w x i8*]* @wam_meta_call_functors, i32 0, i32 %gi
+  %gf = load i8*, i8** %gfp
+  %gf_match = icmp eq i8* %gf, %functor
+  %grp = getelementptr [~w x i32], [~w x i32]* @wam_meta_call_arities, i32 0, i32 %gi
+  %gr = load i32, i32* %grp
+  %gr_match = icmp eq i32 %gr, %target_arity
+  %g_match = and i1 %gf_match, %gr_match
+  br i1 %g_match, label %gfound, label %gnext
+gnext:
+  %gi1 = add i32 %gi, 1
+  br label %gloop
+gfound:
+  %glp = getelementptr [~w x i32], [~w x i32]* @wam_meta_call_label_indexes, i32 0, i32 %gi
+  %gl = load i32, i32* %glp
+  ret i32 %gl
+notfound:
+  ret i32 -1
+}
 
 define i1 @wam_dispatch_meta_call(%WamState* %vm, i32 %total_arity, i32 %after_pc) {
 entry:
@@ -2372,30 +2497,11 @@ maybe_compound:
 atom_goal:
   %atom_id = extractvalue %Value %goal, 1
   %target_arity = sub i32 %total_arity, 1
-  br label %loop
+  %label_idx = call i32 @wam_meta_find_atom(%WamState* %vm, i64 %atom_id, i32 %target_arity)
+  %atom_found = icmp sge i32 %label_idx, 0
+  br i1 %atom_found, label %atom_resolve, label %fail
 
-loop:
-  %i = phi i32 [ 0, %atom_goal ], [ %next_i, %next ]
-  %done = icmp sge i32 %i, ~w
-  br i1 %done, label %fail, label %check
-
-check:
-  %atom_ptr = getelementptr [~w x i64], [~w x i64]* @wam_meta_call_atom_ids, i32 0, i32 %i
-  %cand_atom = load i64, i64* %atom_ptr
-  %atom_match = icmp eq i64 %atom_id, %cand_atom
-  %arity_ptr = getelementptr [~w x i32], [~w x i32]* @wam_meta_call_arities, i32 0, i32 %i
-  %cand_arity = load i32, i32* %arity_ptr
-  %arity_match = icmp eq i32 %target_arity, %cand_arity
-  %match = and i1 %atom_match, %arity_match
-  br i1 %match, label %dispatch, label %next
-
-next:
-  %next_i = add i32 %i, 1
-  br label %loop
-
-dispatch:
-  %label_ptr = getelementptr [~w x i32], [~w x i32]* @wam_meta_call_label_indexes, i32 0, i32 %i
-  %label_idx = load i32, i32* %label_ptr
+atom_resolve:
   %target_pc = call i32 @wam_label_pc(%WamState* %vm, i32 %label_idx)
   %valid = icmp sge i32 %target_pc, 0
   br i1 %valid, label %prepare_atom_args, label %fail
@@ -2424,30 +2530,11 @@ compound_goal:
   %compound_args = load %Value*, %Value** %compound_args_slot
   %compound_extra_arity = sub i32 %total_arity, 1
   %compound_target_arity = add i32 %compound_base_arity, %compound_extra_arity
-  br label %compound_loop
+  %clabel_idx = call i32 @wam_meta_find_compound(%WamState* %vm, i8* %compound_functor, i32 %compound_target_arity)
+  %comp_found = icmp sge i32 %clabel_idx, 0
+  br i1 %comp_found, label %compound_resolve, label %fail
 
-compound_loop:
-  %ci = phi i32 [ 0, %compound_goal ], [ %cnext_i, %compound_next ]
-  %cdone = icmp sge i32 %ci, ~w
-  br i1 %cdone, label %fail, label %compound_check
-
-compound_check:
-  %functor_ptr = getelementptr [~w x i8*], [~w x i8*]* @wam_meta_call_functors, i32 0, i32 %ci
-  %cand_functor = load i8*, i8** %functor_ptr
-  %functor_match = icmp eq i8* %compound_functor, %cand_functor
-  %carity_ptr = getelementptr [~w x i32], [~w x i32]* @wam_meta_call_arities, i32 0, i32 %ci
-  %cand_carity = load i32, i32* %carity_ptr
-  %carity_match = icmp eq i32 %compound_target_arity, %cand_carity
-  %cmatch = and i1 %functor_match, %carity_match
-  br i1 %cmatch, label %dispatch_compound, label %compound_next
-
-compound_next:
-  %cnext_i = add i32 %ci, 1
-  br label %compound_loop
-
-dispatch_compound:
-  %clabel_ptr = getelementptr [~w x i32], [~w x i32]* @wam_meta_call_label_indexes, i32 0, i32 %ci
-  %clabel_idx = load i32, i32* %clabel_ptr
+compound_resolve:
   %ctarget_pc = call i32 @wam_label_pc(%WamState* %vm, i32 %clabel_idx)
   %cvalid = icmp sge i32 %ctarget_pc, 0
   br i1 %cvalid, label %prepare_compound_extra, label %fail
@@ -20008,12 +20095,55 @@ wam_object_encode(Predicates, Options, Codes) :-
     wamo_all_instr_parts(Records, AllParts),
     foldl(wamo_encode_step(LabelMap), AllParts,
           ws([], tab([], 0), tab([], 0)),
-          ws(RevEnc, ATab, FTab)),
+          ws(RevEnc, ATab0, FTab)),
     reverse(RevEnc, EncInstrs),
+    % A meta-call table is only needed if the object actually contains a
+    % call/N meta-call (op1 = -1); interning predicate names for objects that
+    % never meta-call would bloat them for no benefit (pay-for-what-you-use).
+    (   wamo_has_meta_call(EncInstrs)
+    ->  wamo_meta_rows(LabelMap, ATab0, ATab, FTab, MetaRows)
+    ;   ATab = ATab0, MetaRows = []
+    ),
     wamo_table_list(ATab, Atoms),
     wamo_table_list(FTab, Functors),
     findall(PC, member(_-PC, NamePCPairs), PCs),
-    wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs, Codes).
+    wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs,
+                   MetaRows, Codes).
+
+%% wamo_has_meta_call(+EncInstrs) is semidet.
+%  True if any encoded call/execute is a meta-call (op1 = -1).
+wamo_has_meta_call(EncInstrs) :-
+    member(enc(T, -1, _, _), EncInstrs),
+    ( T =:= 18 ; T =:= 19 ), !.
+
+%% wamo_meta_rows(+LabelMap, +ATab0, -ATab1, +FTab, -Rows)
+%  Build the object's meta-call dispatch rows: one per predicate head label
+%  (Name/Arity), mirroring the host's @wam_dispatch_meta_call table but with
+%  indices into the object's OWN atom/functor tables so the loader can
+%  resolve them after relocation. Each row is
+%      row(AtomIdx, FunIdx, Arity, LabelIdx)
+%  where AtomIdx interns the predicate name (extending ATab), FunIdx is the
+%  functor-table index of that name (or -1 if the object builds no such
+%  compound), and LabelIdx is the object-relative label of the predicate.
+wamo_meta_rows(LabelMap, ATab0, ATab1, tab(FPairs, _), Rows) :-
+    findall(mpred(NameStr, Arity, LabelIdx),
+        ( member(Label-LabelIdx, LabelMap),
+          catch(split_functor_arity(Label, Name0, Arity), _, fail),
+          Arity >= 0,
+          % split_functor_arity returns an atom; the atom/functor interning
+          % tables key on strings, so coerce or dedup fails and the functor
+          % lookup (needed for compound meta-calls) silently misses.
+          wamo_to_string(Name0, NameStr)
+        ),
+        Preds0),
+    sort(Preds0, Preds),
+    foldl(wamo_meta_row_step(FPairs), Preds, ATab0-[], ATab1-RevRows),
+    reverse(RevRows, Rows).
+
+wamo_meta_row_step(FPairs, mpred(NameStr, Arity, LabelIdx),
+                   A0-R0, A1-[row(AtomIdx, FunIdx, Arity, LabelIdx)|R0]) :-
+    tab_intern(NameStr, A0, AtomIdx, A1),
+    ( wamo_tab_lookup(FPairs, NameStr, FI) -> FunIdx = FI ; FunIdx = -1 ).
 
 %% wamo_classify(+Preds, +Options, +StartPC, -Records)
 %
@@ -20165,13 +20295,23 @@ wamo_enc(["builtin_call", Op, N], _, A, A, F, F, enc(21, Id, Num, none)) :- !,
     builtin_op_to_id(OpA, Id).
 
 % control-flow with label operands (self-relative indexes into the object)
+% call/execute with op1 = -1 is a call/N meta-call (goal built at runtime);
+% op2 carries the total arity and @wam_dispatch_meta_call resolves the goal
+% through the loaded object's own meta-call table (see PLAWK_EVAL_BOOTSTRAP.md
+% milestone 2). A static target resolves its label index as usual.
 wamo_enc(["call", P, N], LabelMap, A, A, F, F, enc(18, Idx, Arity, none)) :- !,
     clean_comma(P, CP), clean_comma(N, CN),
     ( number_string(Arity, CN) -> true ; Arity = 0 ),
-    wamo_label(CP, LabelMap, Idx).
-wamo_enc(["execute", P], LabelMap, A, A, F, F, enc(19, Idx, 0, none)) :- !,
+    (   wam_meta_call_label(CP)
+    ->  Idx = -1
+    ;   wamo_label(CP, LabelMap, Idx)
+    ).
+wamo_enc(["execute", P], LabelMap, A, A, F, F, enc(19, Idx, Op2, none)) :- !,
     clean_comma(P, CP),
-    wamo_label(CP, LabelMap, Idx).
+    (   wam_meta_call_label(CP)
+    ->  Idx = -1, wam_meta_call_total_arity(CP, Op2)
+    ;   wamo_label(CP, LabelMap, Idx), Op2 = 0
+    ).
 wamo_enc(["try_me_else", L], LabelMap, A, A, F, F, enc(22, Idx, 0, none)) :- !,
     clean_comma(L, CL), lookup_label_index(CL, LabelMap, Idx).
 wamo_enc(["retry_me_else", L], LabelMap, A, A, F, F, enc(23, Idx, 0, none)) :- !,
@@ -20193,11 +20333,12 @@ wamo_enc(["jump", L], LabelMap, A, A, F, F, enc(32, Idx, 0, none)) :- !,
 % switch_on_term. Lifting these is the first subset-expansion step toward
 % the eval bootstrap (item 5) -- the WAM compiler's own predicates lean
 % heavily on atom-keyed clause indexing.
-wamo_enc(["switch_on_term" | _],         _, A, A, F, F, enc(26, 0, 0, none)) :- !.
-wamo_enc(["switch_on_term_a2" | _],      _, A, A, F, F, enc(26, 0, 0, none)) :- !.
-wamo_enc(["switch_on_structure" | _],    _, A, A, F, F, enc(26, 0, 0, none)) :- !.
-wamo_enc(["switch_on_constant" | _],     _, A, A, F, F, enc(26, 0, 0, none)) :- !.
-wamo_enc(["switch_on_constant_a2" | _],  _, A, A, F, F, enc(26, 0, 0, none)) :- !.
+% Every switch_on_* variant is an indexing optimization sitting inline before
+% the clause chain -- including the *_fallthrough forms (no-match falls through
+% to the next clause) and the first/second-argument (_a2) variants. A prefix
+% match covers the whole family; the loader runs them all as nops.
+wamo_enc([Op | _], _, A, A, F, F, enc(26, 0, 0, none)) :-
+    string_concat("switch_on_", _, Op), !.
 wamo_enc(["try" | _],   _, A, A, F, F, enc(26, 0, 0, none)) :- !.
 wamo_enc(["retry" | _], _, A, A, F, F, enc(26, 0, 0, none)) :- !.
 wamo_enc(["trust" | _], _, A, A, F, F, enc(26, 0, 0, none)) :- !.
@@ -20257,12 +20398,14 @@ wamo_reg2(Xn, Ai, X, Y) :-
     reg_name_to_index(CXnA, X), reg_name_to_index(CAiA, Y).
 
 %% wamo_label(+P, +LabelMap, -Idx)
-%  Resolve a call/execute target. call/N meta-calls are outside slice 1.
+%  Resolve a static call/execute target to its object label index. call/N
+%  meta-calls are handled by the caller (op1 = -1) and never reach here; the
+%  guard stays as a defensive assertion should that ever change.
 wamo_label(CP, _, _) :-
     wam_meta_call_label(CP), !,
     throw(error(wamo_unsupported(meta_call(CP)),
         context(write_wam_object,
-            'call/N meta-calls need the apply machinery (not in slice 1)'))).
+            'meta-call reached wamo_label; should have been encoded as op1=-1'))).
 wamo_label(CP, LabelMap, Idx) :-
     lookup_label_index(CP, LabelMap, Idx).
 
@@ -20273,12 +20416,14 @@ wamo_reloc_id(atom, 1).
 wamo_reloc_id(functor, 2).
 wamo_reloc_id(float, 3).
 
-wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs, Codes) :-
+wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs, MetaRows, Codes) :-
     length(Entries, NE), length(Atoms, NA), length(Functors, NF),
-    length(PCs, NL), length(EncInstrs, NC),
+    length(PCs, NL), length(EncInstrs, NC), length(MetaRows, NM),
     % header: magic, version, default-entry index, then the named-entry
     % table (early, so @wam_object_load can skip it without a full parse).
-    format(codes(Head), "WAMO\n1\n~w\n~w\n", [EntryIndex, NE]),
+    % Version 2 adds a trailing meta-call table section (milestone 2 of the
+    % eval bootstrap) so loaded objects can call/N their own predicates.
+    format(codes(Head), "WAMO\n2\n~w\n~w\n", [EntryIndex, NE]),
     maplist(wamo_entry_codes, Entries, EntryChunks),
     format(codes(AHdr), "~w\n", [NA]),
     maplist(wamo_string_codes, Atoms, AtomChunks),
@@ -20288,9 +20433,16 @@ wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs, Codes) :-
     maplist([PC, Cs]>>format(codes(Cs), "~w\n", [PC]), PCs, PCChunks),
     format(codes(CHdr), "~w\n", [NC]),
     maplist(wamo_instr_codes, EncInstrs, InstrChunks),
+    % meta-call table: <count>\n then <atomIdx> <funIdx> <arity> <labelIdx>\n
+    format(codes(MHdr), "~w\n", [NM]),
+    maplist(wamo_meta_row_codes, MetaRows, MetaChunks),
     append([[Head], EntryChunks, [AHdr], AtomChunks, [FHdr], FunChunks,
-            [LHdr], PCChunks, [CHdr], InstrChunks], Lists),
+            [LHdr], PCChunks, [CHdr], InstrChunks, [MHdr], MetaChunks], Lists),
     append(Lists, Codes).
+
+%% wamo_meta_row_codes(+row(AtomIdx,FunIdx,Arity,LabelIdx), -Codes)
+wamo_meta_row_codes(row(AtomIdx, FunIdx, Arity, LabelIdx), Cs) :-
+    format(codes(Cs), "~w ~w ~w ~w\n", [AtomIdx, FunIdx, Arity, LabelIdx]).
 
 %% wamo_entry_codes(+Name-Index, -Codes)
 %  One named-entry record: length-prefixed name string then its label index.
@@ -20625,7 +20777,7 @@ cloop:
   %ci = phi i64 [ 0, %code_init ], [ %ci1, %cstore ]
   %ccur = phi i64 [ %cur_c0, %code_init ], [ %ccur4, %cstore ]
   %cdone = icmp uge i64 %ci, %ncode
-  br i1 %cdone, label %build_vm, label %cstep
+  br i1 %cdone, label %meta_init, label %cstep
 cstep:
   %tag_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %ccur)
   %tag64 = extractvalue { i64, i64 } %tag_r, 0
@@ -20677,18 +20829,84 @@ cstore:
   store i64 %op2, i64* %ip_op2
   %ci1 = add i64 %ci, 1
   br label %cloop
+meta_init:
+  ; --- meta-call table (format v2) ---------------------------------------
+  ; A trailing table of the object''s meta-callable predicates so a loaded
+  ; object can call/N its own goals (@wam_dispatch_meta_call consults the VM
+  ; field when present). Rows: <atomIdx> <funIdx> <arity> <labelIdx>, where
+  ; atomIdx / funIdx index the object''s own (relocated) atom / functor
+  ; tables so we resolve them here, before the scratch arrays are freed.
+  ; Count is 0 for objects the writer saw contain no meta-call.
+  %pm = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %ccur)
+  %nmeta = extractvalue { i64, i64 } %pm, 0
+  %cur_m0 = extractvalue { i64, i64 } %pm, 1
+  %meta_row_sz = ptrtoint %WamMetaRow* getelementptr (%WamMetaRow, %WamMetaRow* null, i32 1) to i64
+  %meta_bytes = mul i64 %nmeta, %meta_row_sz
+  %meta_mem = call i8* @malloc(i64 %meta_bytes)
+  %metaRows = bitcast i8* %meta_mem to %WamMetaRow*
+  br label %mloop
+mloop:
+  %mi = phi i64 [ 0, %meta_init ], [ %mi1, %mstore ]
+  %mcur = phi i64 [ %cur_m0, %meta_init ], [ %mcur4, %mstore ]
+  %mdone = icmp uge i64 %mi, %nmeta
+  br i1 %mdone, label %build_vm, label %mstep
+mstep:
+  %matom_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %mcur)
+  %matomIdx = extractvalue { i64, i64 } %matom_r, 0
+  %mcur1 = extractvalue { i64, i64 } %matom_r, 1
+  %mfun_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %mcur1)
+  %mfunIdx = extractvalue { i64, i64 } %mfun_r, 0
+  %mcur2 = extractvalue { i64, i64 } %mfun_r, 1
+  %mar_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %mcur2)
+  %marity = extractvalue { i64, i64 } %mar_r, 0
+  %mcur3 = extractvalue { i64, i64 } %mar_r, 1
+  %mlbl_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %mcur3)
+  %mlabel = extractvalue { i64, i64 } %mlbl_r, 0
+  %mcur4 = extractvalue { i64, i64 } %mlbl_r, 1
+  ; atom_id = atomIds[atomIdx] (already re-interned)
+  %maslot = getelementptr i64, i64* %atomIds, i64 %matomIdx
+  %matom_id = load i64, i64* %maslot
+  ; functor_ptr = funIdx < 0 ? null : funPtrs[funIdx] (object''s own copy)
+  %mfun_neg = icmp slt i64 %mfunIdx, 0
+  br i1 %mfun_neg, label %mstore, label %mfun_load
+mfun_load:
+  %mfslot = getelementptr i8*, i8** %funPtrs, i64 %mfunIdx
+  %mfp = load i8*, i8** %mfslot
+  br label %mstore
+mstore:
+  %mfp_final = phi i8* [ null, %mstep ], [ %mfp, %mfun_load ]
+  %mrow = getelementptr %WamMetaRow, %WamMetaRow* %metaRows, i64 %mi
+  %mrow_atom = getelementptr %WamMetaRow, %WamMetaRow* %mrow, i32 0, i32 0
+  store i64 %matom_id, i64* %mrow_atom
+  %mrow_fun = getelementptr %WamMetaRow, %WamMetaRow* %mrow, i32 0, i32 1
+  store i8* %mfp_final, i8** %mrow_fun
+  %mrow_ar = getelementptr %WamMetaRow, %WamMetaRow* %mrow, i32 0, i32 2
+  %marity32 = trunc i64 %marity to i32
+  store i32 %marity32, i32* %mrow_ar
+  %mrow_lbl = getelementptr %WamMetaRow, %WamMetaRow* %mrow, i32 0, i32 3
+  %mlabel32 = trunc i64 %mlabel to i32
+  store i32 %mlabel32, i32* %mrow_lbl
+  %mi1 = add i64 %mi, 1
+  br label %mloop
 build_vm:
   ; entry pc = labels[entry_idx]
   %eslot = getelementptr i32, i32* %labels, i64 %entry_idx64
   %entry_pc = load i32, i32* %eslot
   ; scratch pointer arrays no longer needed: atom strings were copied by
-  ; @wam_intern_atom, functor string copies are owned by %code, and the
-  ; source buffer belongs to the caller.
+  ; @wam_intern_atom, functor string copies are owned by %code, the meta
+  ; rows already captured the ids/pointers they need, and the source buffer
+  ; belongs to the caller.
   call void @free(i8* %atom_mem)
   call void @free(i8* %fun_mem)
   %ncode32 = trunc i64 %ncode to i32
   %nlbl32 = trunc i64 %nlbl to i32
   %vm = call %WamState* @wam_state_new(%Instruction* %code, i32 %ncode32, i32* %labels, i32 %nlbl32)
+  ; install the object''s meta-call table (fields 25/26)
+  %vm_meta_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 25
+  store %WamMetaRow* %metaRows, %WamMetaRow** %vm_meta_ptr
+  %vm_metac_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 26
+  %nmeta32 = trunc i64 %nmeta to i32
+  store i32 %nmeta32, i32* %vm_metac_ptr
   %ret0 = insertvalue { %WamState*, i32 } undef, %WamState* %vm, 0
   %ret1 = insertvalue { %WamState*, i32 } %ret0, i32 %entry_pc, 1
   ret { %WamState*, i32 } %ret1

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -103,6 +103,13 @@ define %WamState* @wam_state_new(%Instruction* %code, i32 %code_len, i32* %label
   %lcpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 24
   store i32 0, i32* %lcpn_ptr
 
+  ; obj_meta = null, obj_meta_count = 0. Host VMs never carry an object
+  ; meta-call table; the .wamo loader installs one after wam_state_new.
+  %objmeta_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 25
+  store %WamMetaRow* null, %WamMetaRow** %objmeta_ptr
+  %objmetac_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 26
+  store i32 0, i32* %objmetac_ptr
+
   ret %WamState* %vm
 }
 
@@ -170,6 +177,13 @@ cp_done_label:
   %agg = load %Value*, %Value** %agg_ptr
   %agg_i8 = bitcast %Value* %agg to i8*
   call void @free(i8* %agg_i8)
+
+  ; Free the loaded-object meta-call table, if any (null for host VMs;
+  ; @free(null) is a no-op so no guard needed).
+  %objmeta_fp = getelementptr %WamState, %WamState* %vm, i32 0, i32 25
+  %objmeta = load %WamMetaRow*, %WamMetaRow** %objmeta_fp
+  %objmeta_i8 = bitcast %WamMetaRow* %objmeta to i8*
+  call void @free(i8* %objmeta_i8)
 
   %vm_i8 = bitcast %WamState* %vm to i8*
   call void @free(i8* %vm_i8)

--- a/templates/targets/llvm_wam/types.ll.mustache
+++ b/templates/targets/llvm_wam/types.ll.mustache
@@ -105,5 +105,21 @@
     i32,                                   ; 21: agg_count
     i32,                                   ; 22: agg_cap
     i32,                                   ; 23: cut_barrier
-    i32                                    ; 24: last_entry_cpn
+    i32,                                   ; 24: last_entry_cpn
+    %WamMetaRow*,                          ; 25: obj_meta (loaded-object meta-call
+                                           ;     table; null for host VMs -- see
+                                           ;     PLAWK_EVAL_BOOTSTRAP.md milestone 2)
+    i32                                    ; 26: obj_meta_count
+}
+
+; One row of a loaded object's meta-call dispatch table: a predicate the
+; object can reach via call/N built at runtime. atom_id + arity match an
+; atom goal; functor_ptr (the object's own malloc'd functor copy, or null)
+; + arity match a compound goal. label_index resolves through the VM's own
+; labels array (@wam_label_pc) to the predicate's PC.
+%WamMetaRow = type {
+    i64,                                   ; 0: atom_id (re-interned at load)
+    i8*,                                   ; 1: functor_ptr (object copy, or null)
+    i32,                                   ; 2: arity
+    i32                                    ; 3: label_index (object-relative)
 }

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -43,6 +43,14 @@ coltab(green, 2).
 coltab(blue, 3).
 pick(R) :- coltab(green, R).          % -> 2
 
+% call/N meta-call inside a loaded object (eval bootstrap milestone 2). The
+% goal is built at runtime and dispatched through the object's OWN meta-call
+% table, so a loaded .wamo can call its own predicates.
+mfoo(100).
+metaatom(R) :- G = mfoo, call(G, R).  % atom goal -> mfoo(R) -> 100
+maddk(X, R) :- R is X + 32.
+metacomp(R) :- G = maddk(10), call(G, R). % compound goal -> maddk(10,R) -> 42
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -51,7 +59,7 @@ clang_available :-
 :- begin_tests(wam_object).
 
 % The writer emits a well-formed .wamo byte stream: "WAMO" magic, version
-% 1, and the section counts we can recover by re-parsing the tokens.
+% 2, and the section counts we can recover by re-parsing the tokens.
 test(encode_produces_well_formed_stream) :-
     wam_object_encode([user:answer/1, user:sum3/3],
         [wamo_entry(answer/1)], Codes),
@@ -59,8 +67,8 @@ test(encode_produces_well_formed_stream) :-
     sub_string(Text, 0, 4, _, "WAMO"),
     split_string(Text, "\n \t", "\n \t", Parts0),
     exclude(==(""), Parts0, Parts),
-    % tokens: WAMO 1 <entry> <natoms> ... ; version must be "1", entry "0"
-    Parts = ["WAMO", "1", "0" | _],
+    % tokens: WAMO 2 <entry> <natoms> ... ; version must be "2", entry "0"
+    Parts = ["WAMO", "2", "0" | _],
     !.
 
 % Float constants now compile in put/set_constant: the object carries the
@@ -133,8 +141,8 @@ test(multi_entry_encodes_name_table) :-
     string_codes(Text, Codes),
     split_string(Text, "\n \t", "\n \t", Parts0),
     exclude(==(""), Parts0, Parts),
-    % WAMO 1 <default-entry> <E=2> 8 answer/1 <idx> 16 answer_swapped/1 <idx> ...
-    Parts = ["WAMO", "1", _Default, "2" | _],
+    % WAMO 2 <default-entry> <E=2> 8 answer/1 <idx> 16 answer_swapped/1 <idx> ...
+    Parts = ["WAMO", "2", _Default, "2" | _],
     memberchk("answer/1", Parts),
     memberchk("answer_swapped/1", Parts),
     !.
@@ -223,6 +231,34 @@ test(switch_on_constant_loads_and_runs,
     ( exists_file(Host) -> true ; build_host(Dir, Host) ),
     run_host(Host, Wamo, Out, 0),
     assertion(Out == "2\n"),
+    !.
+
+% A loaded object meta-calls (call/N) one of its own predicates, the goal
+% built at runtime. Atom goal: metaatom builds `mfoo` and calls it -> 100.
+% Dispatch runs through the object's own meta-call table (fields 25/26).
+test(meta_call_atom_goal_in_object,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'metaatom.wamo', Wamo),
+    write_wam_object([user:metaatom/1, user:mfoo/1], [wamo_entry(metaatom/1)], Wamo),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "100\n"),
+    !.
+
+% Compound goal: metacomp builds `maddk(10)` and calls it with one extra
+% argument -> maddk(10, R) -> 42. Exercises functor-pointer matching against
+% the object's own functor copies in the meta-call table.
+test(meta_call_compound_goal_in_object,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'metacomp.wamo', Wamo),
+    write_wam_object([user:metacomp/1, user:maddk/2], [wamo_entry(metacomp/1)], Wamo),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "42\n"),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
Milestone 2 of JIT roadmap **item 5** (eval bootstrap): a loaded `.wamo` object can now `call/N` its **own** predicates with a goal built at runtime — the spine of any interpreter or compiler running as an object.

## The problem

The writer already had the `try_me_else` chain and static `call`/`execute`. The missing piece was meta-call dispatch. A meta-call encodes `op1 = -1` (`op2` = total arity), matching the host AOT path — but dispatch has to resolve a *goal* (atom/functor + arity) to a *label index*, and **a loaded object's predicates are not in the host's compile-time dispatch table**. Pointer-equality on functor globals also can't match a loaded object's own malloc'd functor copies.

## The mechanism: a per-object meta-call table

**Format (version 1 → 2):** a trailing section lists each predicate head as `(atomIdx, funIdx, arity, labelIdx)` — indices into the object's *own* atom and functor tables, so the loader resolves them after relocation. Emitted **only** for objects that actually contain a meta-call, so non-dynamic objects stay lean (pay-for-what-you-use).

**Runtime:** two new `%WamState` fields (25 = `obj_meta` ptr, 26 = count) hold a `%WamMetaRow` array the loader materializes from the section; host VMs leave them null. `@wam_dispatch_meta_call` is refactored to resolve the label through `@wam_meta_find_atom` / `@wam_meta_find_compound`, each consulting the VM's own table when installed and falling back to the host-global arrays otherwise. The argument-shuffling tail is unchanged.

**Why compound goals work:** a loaded object's runtime functor pointers are its own malloc'd copies — exactly the pointers the table stores — so pointer identity holds within one object. Partial application (`G = maddk(10), call(G, R)` → `maddk(10, R)`) resolves correctly.

## Also

Generalized the `switch_on_*` nop-fallthrough clauses to a **prefix match**, covering the `_fallthrough` and `_a2` variants the tier-2 compiler emits for integer-keyed indexing (milestone 1 had only lifted the bare forms).

## Changes

- `src/unifyweaver/targets/wam_llvm_target.pl` — meta-call encoding (`op1=-1`); `wamo_meta_rows` gated on `wamo_has_meta_call`; version-2 serialize + meta section; loader parse & table install; dispatch split into per-VM find helpers; `switch_on_*` prefix nop.
- `templates/targets/llvm_wam/types.ll.mustache` — `%WamMetaRow` type; `%WamState` fields 25/26.
- `templates/targets/llvm_wam/state.ll.mustache` — init fields 25/26; free the table.
- `tests/test_wam_object.pl` — `metaatom/1` (atom goal → 100) and `metacomp/1` (compound goal → 42) round-trip tests; version assertions → 2.
- docs — milestone 2 marked LANDED.

## Testing

Verified end-to-end (objects built, loaded, run): atom-goal meta-call returns 100, compound-goal meta-call returns 42. Full `wam_object` suite, all nine `dyncall` suites, the host `wam_llvm_meta_call_runtime` suite (confirms the global-table path survived the dispatch refactor), and core WAM-LLVM execution suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_