### PR TITLE
plawk/JIT (roadmap #5, milestone 3): builtin audit + aggregate control (findall/setof/bagof) in loaded objects

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -47,9 +47,11 @@ The loadable subset today: `try_me_else`/`retry_me_else` chains,
 `get`/`put`/`set`/`unify` variable+value+constant (integer, atom, float),
 `get`/`put_list`, `get`/`put_structure`, `allocate`/`deallocate`,
 `call`/`execute` (**including `call/N` meta-calls** — milestone 2, landed),
-`proceed`, `builtin_call`, `cut`/`get_level`/`cut_ite`, `jump`, and **all
+`proceed`, `builtin_call`, `cut`/`get_level`/`cut_ite`, `jump`, **all
 clause-indexing dispatch** — every `switch_on_*` variant, matched by prefix
-so the `_fallthrough` and `_a2` forms are covered too — as nop-fallthroughs.
+so the `_fallthrough` and `_a2` forms are covered too — as nop-fallthroughs,
+and **aggregate control** `begin_aggregate`/`end_aggregate` (milestone 3 —
+`findall`/`setof`/`bagof`/`aggregate_all`).
 
 ### Why indexing dispatch is a safe nop
 
@@ -100,14 +102,32 @@ independently useful (richer hand-written grammars load sooner).
    object. The table is only emitted for objects that actually contain a
    meta-call (pay-for-what-you-use). This is the spine of any grammar that
    calls a goal built at runtime — an interpreter or compiler.
-3. **The builtin closure the compiler needs.** `builtin_call` is already in
-   the subset, so a builtin works in a loaded object *if the host runtime
-   provides it*. Audit the compiler's builtin use (`findall`/`bagof`,
-   `assert`/`retract`, `read_term`/`term_to_atom`, `=..`, `functor`/`arg`,
-   `atom_codes`/`number_codes`, list ops) and confirm each is host-provided
-   and loader-safe; add any that are missing. `assert`/`retract` against a
-   loaded object's own dynamic predicates is the subtle one (mutable state in
-   an arena-rewound VM).
+3. **The builtin closure the compiler needs** — *audit done; aggregates
+   landed.* `builtin_call` is already in the subset, so a builtin works in a
+   loaded object *if the host runtime provides it AND the construct is in the
+   loadable subset*. The audit sorted the compiler's constructs into four
+   buckets by **how the tier-2 compiler lowers them**, which decides what
+   "make it loadable" means:
+
+   | Construct | Lowers to | Loadable now? |
+   |---|---|---|
+   | `is`/`=`/`==`/comparison, `functor`/`arg`/`=..`, `copy_term`, `atom_codes`/`number_codes`/`char_code`, `sub_atom`/`atom_concat`, `sort`/`msort`/`keysort`, `length`/`append`/`nth`/`reverse`, `sum_list` … | `builtin_call <id>` (id in `builtin_op_to_id`, host-implemented) | **yes** — already in the subset and loader-safe (operate on VM regs/heap + libc) |
+   | `findall`/`aggregate_all`, `setof`/`bagof` | `begin_aggregate`/`end_aggregate` (tags 28/29) | **yes, this PR** — opcodes lifted into the subset; setof/bagof additionally need `inline_bagof_setof(true)`, now the `.wamo` default |
+   | `assert`/`asserta`/`assertz`/`retract`, `term_to_atom`/`read_term`/`read_term_from_atom` | `builtin_call <name>` with **no `builtin_op_to_id` entry and no host runtime impl** (writer would emit the unknown-id 200) | **no** — genuinely unimplemented; needs new runtime builtins (milestone 3b). `assert`/`retract` against a loaded object's own clauses is the subtle one — mutable clause state in an arena-rewound VM |
+   | `catch`/`throw` | `execute catch/3` — a call to a runtime *library predicate*, not a builtin | **no** — the loaded object references `catch/3`, which lives in the host, not the object; needs cross-object/host predicate linkage (milestone 3c) |
+
+   **Landed here:** the aggregate opcodes, verified end-to-end — `findall`,
+   `setof`, `bagof` over a *user predicate* goal load and run from a `.wamo`
+   (the case a compiler actually hits, iterating over clauses). Also note a
+   **pre-existing host bug** surfaced by the audit: a *backtracking list
+   builtin as a findall goal* (e.g. `findall(X, member(X, L), _)`) segfaults
+   even in AOT-compiled host code — orthogonal to the loader, filed
+   separately, and not a blocker since compiler-style `findall` iterates over
+   predicates, not `member`.
+
+   **Remaining (3b/3c):** `assert`/`retract`/`term_to_atom`/`read_term` runtime
+   builtins, and `catch`/`throw` predicate linkage. These are the true long
+   pole for self-hosting the compiler.
 4. **Byte-buffer output from a grammar.** The compiler object must *emit*
    `.wamo` bytes. It returns them as an Atom/byte string (the item-2 blob
    bridge already carries bytes out); building that byte string inside the

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -317,8 +317,18 @@ loadable along the way.
   `%WamState` fields, so a loaded object can `call/N` its own predicates —
   atom goals and compound (partial-application) goals alike. Falls back to the
   host-global table for host VMs. The spine of any runtime-built goal.
-- **Milestones 3–6** (the compiler's builtin closure, byte-buffer output, the
-  `eval`/`compile` surface, self-host) — see the bootstrap doc.
+- **Milestone 3 — the compiler's builtin closure — audit done, aggregates
+  landed.** The audit sorted the compiler's constructs by how the tier-2
+  compiler lowers them (`builtin_call`, aggregate opcodes, unimplemented
+  builtins, library-predicate calls). Landed this PR: **aggregate control**
+  `begin_aggregate`/`end_aggregate` into the loadable subset, so `findall`,
+  `setof` and `bagof` over user-predicate goals load and run from a `.wamo`
+  (setof/bagof via `inline_bagof_setof`, now the `.wamo` default). Remaining:
+  `assert`/`retract`/`term_to_atom`/`read_term` runtime builtins (3b) and
+  `catch`/`throw` predicate linkage (3c) — the true long pole. See the
+  bootstrap doc for the full loadability matrix.
+- **Milestones 4–6** (byte-buffer output, the `eval`/`compile` surface,
+  self-host) — see the bootstrap doc.
 
 ## The binary-return question, specifically
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -20086,7 +20086,17 @@ write_wam_object(Predicates, Options, OutFile) :-
 %% wam_object_encode(+Predicates, +Options, -Codes) is det.
 %
 %  Produce the .wamo byte stream (a list of 0..255 codes) in memory.
-wam_object_encode(Predicates, Options, Codes) :-
+wam_object_encode(Predicates, Options0, Codes) :-
+    % Lower bagof/setof through the aggregate path (begin_aggregate/
+    % end_aggregate) rather than as calls to a setof/3 library predicate --
+    % the same default write_wam_llvm_project uses. Without it, closure
+    % expansion tries to compile the (clause-less) setof/3 and the object
+    % fails to build; with it, and now that the aggregate opcodes are in the
+    % loadable subset, setof/bagof load and run like findall.
+    ( memberchk(inline_bagof_setof(_), Options0)
+    -> Options = Options0
+    ;  Options = [inline_bagof_setof(true) | Options0]
+    ),
     expand_wam_llvm_project_predicates(Predicates, Options, Expanded),
     wamo_classify(Expanded, Options, 0, Records),
     build_merged_labels(Records, NamePCPairs, LabelMap),
@@ -20320,6 +20330,25 @@ wamo_enc(["retry_me_else", L], LabelMap, A, A, F, F, enc(23, Idx, 0, none)) :- !
 % after the then/else arm). Self-relative label index, like try_me_else.
 wamo_enc(["jump", L], LabelMap, A, A, F, F, enc(32, Idx, 0, none)) :- !,
     clean_comma(L, CL), lookup_label_index(CL, LabelMap, Idx).
+
+% Aggregate control: findall / bagof / setof / aggregate_all. The tier-2
+% compiler brackets the collected goal with begin_aggregate/end_aggregate
+% (tags 28/29). Both operate purely on the VM's own choice-point stack,
+% registers, trail and aggregate accumulator -- no relocation, no
+% host-compile-time state -- and the shared @run_loop already dispatches
+% these tags, so a loaded object runs them exactly as the host does (no
+% loader change needed). op1 = agg-type id, op2 = (val_reg << 16) | res_reg,
+% mirroring begin_aggregate_lit/4. The 4-argument begin form carries a
+% setof/bagof witness that the encoding ignores, exactly as the AOT path does.
+wamo_enc(["begin_aggregate", TypeStr, ValRegStr, ResRegStr | _], _, A, A, F, F,
+         enc(28, TypeId, Op2, none)) :- !,
+    clean_comma(TypeStr, CT), clean_comma(ValRegStr, CV), clean_comma(ResRegStr, CR),
+    atom_string(CTAtom, CT), agg_type_id(CTAtom, TypeId),
+    atom_string(CVAtom, CV), reg_name_to_index(CVAtom, ValIdx),
+    atom_string(CRAtom, CR), reg_name_to_index(CRAtom, ResIdx),
+    Op2 is (ValIdx << 16) \/ ResIdx.
+wamo_enc(["end_aggregate", ValRegStr], _, A, A, F, F, enc(29, ValIdx, 0, none)) :- !,
+    clean_comma(ValRegStr, CV), atom_string(CVAtom, CV), reg_name_to_index(CVAtom, ValIdx).
 
 % Indexing dispatch: nop fallthrough (tag 26), matching the interpreter's
 % runtime semantics. Every indexing instruction the tier-2 compiler emits

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -51,6 +51,20 @@ metaatom(R) :- G = mfoo, call(G, R).  % atom goal -> mfoo(R) -> 100
 maddk(X, R) :- R is X + 32.
 metacomp(R) :- G = maddk(10), call(G, R). % compound goal -> maddk(10,R) -> 42
 
+% Aggregate control (findall / setof / bagof) inside a loaded object (eval
+% bootstrap milestone 3). The tier-2 compiler brackets the collected goal
+% with begin_aggregate/end_aggregate; those opcodes operate purely on VM
+% state, so a loaded object runs them like the host. The goal is a user
+% predicate (agnum/1) -- the case a compiler actually hits (iterating over
+% clauses), as opposed to a backtracking list builtin.
+agnum(30).
+agnum(10).
+agnum(20).
+agnum(10).
+collectsum(S) :- findall(X, agnum(X), L), sum_list(L, S).  % 30+10+20+10 -> 70
+setcard(N)    :- setof(X, agnum(X), L), length(L, N).      % {10,20,30} -> 3
+bagcard(N)    :- bagof(X, agnum(X), L), length(L, N).      % 4 solutions -> 4
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -259,6 +273,36 @@ test(meta_call_compound_goal_in_object,
     ( exists_file(Host) -> true ; build_host(Dir, Host) ),
     run_host(Host, Wamo, Out, 0),
     assertion(Out == "42\n"),
+    !.
+
+% findall over a user predicate loads and runs: begin_aggregate/end_aggregate
+% are now in the loadable subset. collectsum sums agnum/1's four solutions.
+test(findall_in_object,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'collectsum.wamo', Wamo),
+    write_wam_object([user:collectsum/1, user:agnum/1], [wamo_entry(collectsum/1)], Wamo),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "70\n"),
+    !.
+
+% setof (sort + dedup) and bagof (keep dups) load and run: the .wamo writer
+% lowers them through the same aggregate path as findall (inline_bagof_setof).
+test(setof_and_bagof_in_object,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'setcard.wamo', WSet),
+    directory_file_path(Dir, 'bagcard.wamo', WBag),
+    write_wam_object([user:setcard/1, user:agnum/1], [wamo_entry(setcard/1)], WSet),
+    write_wam_object([user:bagcard/1, user:agnum/1], [wamo_entry(bagcard/1)], WBag),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, WSet, SetOut, 0),
+    assertion(SetOut == "3\n"),
+    run_host(Host, WBag, BagOut, 0),
+    assertion(BagOut == "4\n"),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
Milestone 3 of JIT roadmap **item 5** (eval bootstrap): the builtin-closure audit, plus its highest-value landable piece — **aggregate control** (`findall`/`setof`/`bagof`) in loaded objects.

## The audit

The compiler's constructs sort into four buckets by **how the tier-2 compiler lowers them** — which decides what "make it loadable" means:

| Construct | Lowers to | Loadable now? |
|---|---|---|
| `is`/`=`/comparisons, `functor`/`arg`/`=..`, `copy_term`, `atom_codes`/`number_codes`, `sub_atom`/`atom_concat`, `sort`/`msort`/`keysort`, `length`/`append`/`nth`/`reverse`, `sum_list`… | `builtin_call <id>` (id present, host-implemented) | **yes** — already in the subset, loader-safe |
| `findall`/`aggregate_all`, `setof`/`bagof` | `begin_aggregate`/`end_aggregate` (tags 28/29) | **yes, this PR** |
| `assert`/`retract`, `term_to_atom`/`read_term` | `builtin_call` with **no id and no host impl** (unknown-id 200) | **no** — unimplemented (milestone 3b) |
| `catch`/`throw` | `execute catch/3` — a call to a runtime *library predicate* | **no** — the object references `catch/3`, which lives in the host (milestone 3c) |

## Landed here — aggregate control

- `wamo_enc` encodes `begin_aggregate` (tag 28: `op1`=agg-type, `op2`=`(val<<16)|res`) and `end_aggregate` (tag 29). Both operate purely on the VM's own choice-point stack, registers, trail and aggregate accumulator — no relocation, no host-compile-time state — and the shared `@run_loop` already dispatches these tags. So **no loader or runtime change is needed**; a loaded object runs them exactly as the host does.
- `wam_object_encode` now defaults `inline_bagof_setof(true)` (matching `write_wam_llvm_project`), so setof/bagof lower through the aggregate path instead of calling a clause-less `setof/3` library predicate that closure expansion can't compile.

**Verified end-to-end** (built, loaded, run): `findall` over a user predicate sums to 70, `setof` dedups to 3, `bagof` keeps 4 — the case a compiler actually hits (iterating over clauses).

## A pre-existing bug the audit surfaced (not introduced here, not a loader regression)

A *backtracking list builtin as a findall goal* — `findall(X, member(X, L), _)` — segfaults **even in AOT-compiled host code**. It's orthogonal to the JIT arc (the AOT path never touches the `.wamo` writer) and doesn't block this milestone, since compiler-style `findall` iterates over predicates, not `member`. Flagged for separate follow-up.

## Changes

- `src/unifyweaver/targets/wam_llvm_target.pl` — `begin_aggregate`/`end_aggregate` `wamo_enc` clauses; `inline_bagof_setof(true)` default in `wam_object_encode`.
- `tests/test_wam_object.pl` — `findall_in_object` (→ 70) and `setof_and_bagof_in_object` (→ 3, 4).
- docs — loadability matrix in the bootstrap doc; roadmap updated.

## Testing

Full `wam_object`, all nine `dyncall`, and the host `wam_llvm_meta_call_runtime` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_