### PR TITLE
WAM/LLVM: fix zero-solution aggregate (empty findall/setof/bagof) infinite loop / crash

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3772,6 +3772,67 @@ wam_llvm_case('begin_aggregate',
   %ba.val_reg = lshr i32 %ba.op2_trunc, 16
   %ba.res_reg = and i32 %ba.op2_trunc, 65535
 
+  ; Compute the continuation PC = (matching end_aggregate PC) + 1 by scanning
+  ; forward from this instruction for the matching tag-29, tracking nesting so
+  ; inner aggregates are skipped. Doing this at begin time -- rather than
+  ; relying on end_aggregate to set agg_return_pc -- keeps the return PC
+  ; correct even when the goal yields ZERO solutions and end_aggregate never
+  ; runs. Otherwise finalize jumps to the placeholder PC 0 and the predicate
+  ; re-executes forever (empty findall / setof / bagof).
+  %ba.code_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 15
+  %ba.code = load %Instruction*, %Instruction** %ba.code_ptr
+  %ba.clen_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 16
+  %ba.clen = load i32, i32* %ba.clen_ptr
+  %ba.begin_pc = call i32 @wam_get_pc(%WamState* %vm)
+  %ba.scan_start = add i32 %ba.begin_pc, 1
+  br label %ba.scan
+
+ba.scan:
+  %ba.si = phi i32 [ %ba.scan_start, %begin_aggregate ], [ %ba.si_next, %ba.scan_cont ]
+  %ba.depth = phi i32 [ 0, %begin_aggregate ], [ %ba.depth_next, %ba.scan_cont ]
+  %ba.oob = icmp sge i32 %ba.si, %ba.clen
+  br i1 %ba.oob, label %ba.scan_fallback, label %ba.scan_check
+
+ba.scan_check:
+  %ba.instr = getelementptr %Instruction, %Instruction* %ba.code, i32 %ba.si
+  %ba.tag_ptr = getelementptr %Instruction, %Instruction* %ba.instr, i32 0, i32 0
+  %ba.itag = load i32, i32* %ba.tag_ptr
+  %ba.is_begin = icmp eq i32 %ba.itag, 28
+  br i1 %ba.is_begin, label %ba.nest, label %ba.maybe_end
+
+ba.nest:
+  %ba.depth_inc = add i32 %ba.depth, 1
+  br label %ba.scan_cont
+
+ba.maybe_end:
+  %ba.is_end = icmp eq i32 %ba.itag, 29
+  br i1 %ba.is_end, label %ba.at_end, label %ba.scan_cont
+
+ba.at_end:
+  %ba.depth_zero = icmp eq i32 %ba.depth, 0
+  br i1 %ba.depth_zero, label %ba.found, label %ba.unnest
+
+ba.unnest:
+  %ba.depth_dec = sub i32 %ba.depth, 1
+  br label %ba.scan_cont
+
+ba.scan_cont:
+  %ba.depth_next = phi i32 [ %ba.depth_inc, %ba.nest ], [ %ba.depth, %ba.maybe_end ], [ %ba.depth_dec, %ba.unnest ]
+  %ba.si_next = add i32 %ba.si, 1
+  br label %ba.scan
+
+ba.found:
+  %ba.cont_pc = add i32 %ba.si, 1
+  br label %ba.setup
+
+ba.scan_fallback:
+  ; No matching end_aggregate found (should not happen for compiler output);
+  ; fall back to begin_pc+1 so we at least make forward progress.
+  br label %ba.setup
+
+ba.setup:
+  %ba.arpc_val = phi i32 [ %ba.cont_pc, %ba.found ], [ %ba.scan_start, %ba.scan_fallback ]
+
   ; M5: ensure CP array has room before reading its pointer.
   call void @wam_cp_ensure_capacity(%WamState* %vm)
   ; Push a choice point
@@ -3811,7 +3872,8 @@ wam_llvm_case('begin_aggregate',
   %ba.arr_ptr = getelementptr %ChoicePoint, %ChoicePoint* %ba.cp_slot, i32 0, i32 6
   store i32 %ba.res_reg, i32* %ba.arr_ptr
   %ba.arpc_ptr = getelementptr %ChoicePoint, %ChoicePoint* %ba.cp_slot, i32 0, i32 7
-  store i32 0, i32* %ba.arpc_ptr  ; placeholder, end_aggregate updates this
+  store i32 %ba.arpc_val, i32* %ba.arpc_ptr  ; continuation PC after end_aggregate
+                                             ; (correct even for zero solutions)
 
   ; Save heap_top so unwind via wam_finalize_aggregate can rewind.
   %ba.hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -65,6 +65,15 @@ collectsum(S) :- findall(X, agnum(X), L), sum_list(L, S).  % 30+10+20+10 -> 70
 setcard(N)    :- setof(X, agnum(X), L), length(L, N).      % {10,20,30} -> 3
 bagcard(N)    :- bagof(X, agnum(X), L), length(L, N).      % 4 solutions -> 4
 
+% Regression: an aggregate whose goal yields ZERO solutions. end_aggregate
+% never runs, so the aggregate frame's return PC must have been set at
+% begin_aggregate time (via the forward scan) rather than left at the
+% placeholder 0 -- otherwise finalize jumps to PC 0 and the predicate
+% re-executes forever (empty findall used to OOM / segfault). Exercises the
+% same @run_loop the host uses, so it covers the AOT path too.
+noagg(_) :- fail.
+emptycount(N) :- findall(X, noagg(X), L), length(L, N).    % [] -> 0
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -303,6 +312,19 @@ test(setof_and_bagof_in_object,
     assertion(SetOut == "3\n"),
     run_host(Host, WBag, BagOut, 0),
     assertion(BagOut == "4\n"),
+    !.
+
+% Regression for the zero-solution aggregate crash: findall over a goal that
+% never succeeds must finalize to the empty list and return, not loop forever.
+test(empty_aggregate_terminates,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'emptycount.wamo', Wamo),
+    write_wam_object([user:emptycount/1, user:noagg/1], [wamo_entry(emptycount/1)], Wamo),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "0\n"),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
Fixes the segfault surfaced by the milestone-3 audit. It turned out **not** to be about `member/2` specifically — it's a general **zero-solution aggregate** bug in the WAM run loop, hitting plain AOT-compiled host code as well as loaded `.wamo` objects (both run the same `@run_loop`).

## Root cause

An aggregate choice-point's return PC (`arpc`, CP field 7) tells `wam_finalize_aggregate` where to continue once the goal is exhausted. It's set by `end_aggregate` to "the instruction after `end_aggregate`", but `begin_aggregate` left it at the placeholder `0`.

When the collected goal yields **zero solutions**, `end_aggregate` never runs, so `arpc` stays `0`. On backtrack, finalize jumps to PC 0 → re-executes the predicate from the top → re-enters `begin_aggregate` → loops forever (OOM), or corrupts state (segfault).

`findall(X, member(X, L), _)` hit this because `member/2` is unimplemented (id 200 → fails), so the aggregate collected nothing — but any zero-solution `findall`/`setof`/`bagof` triggers it.

## Fix

`begin_aggregate` now computes the continuation PC up front: it scans forward from its own PC for the matching `end_aggregate` (tag 29), tracking nesting depth so inner aggregates are skipped, and stores *(that PC + 1)* as the frame's return PC. `end_aggregate` still updates it on each solution (to the same value), so the non-empty path is byte-for-byte unchanged; the empty path now finalizes to the empty list and returns.

Purely a **runtime** change — no instruction-format or compiler change — so it fixes AOT and JIT identically.

## Changes

- `src/unifyweaver/targets/wam_llvm_target.pl` — forward-scan preamble in the `begin_aggregate` run-loop case; `arpc` initialized to the scanned continuation instead of `0`.
- `tests/test_wam_object.pl` — `empty_aggregate_terminates`: `findall` over a failing goal returns `0` (was a hang/crash). Exercises the same `@run_loop` the host uses, covering the AOT path.

## Testing

- Empty `findall` → `0` (was OOM/segfault).
- Non-empty `findall`/`setof`/`bagof` still `70` / `3` / `4` — the scan doesn't change the happy path.
- Full `wam_object`, `dyncall`, `wam_llvm_meta_call_runtime`, `wam_llvm_target`, and forin/aggregate plawk suites pass.

Note: `member/2` remaining unimplemented (it's not a real builtin — id 56 is `memberchk/2`) is a separate, minor matter; it now simply fails instead of crashing, and compiler-style `findall` iterates over predicates, not `member`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_