### PR TITLE
SYM memberships: element + siblings, and a course-correction to the joint-posterior estimator

### DIFF
--- a/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
+++ b/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
@@ -45,6 +45,16 @@ Two axes, and the confidence principle (#3356) applies to **only one** of them:
   **`1/d` as the low-confidence fallback** (the role e5-text played in the anchored basis). Precision-weighted
   (inverse-variance) fusion of two estimators of different reliability.
 
+**Division of labor — `1/d` captures SIBLINGS (user 2026-07-04).** The membership operators are inherently
+**vertical** (ancestor↔descendant); **siblings have no directional membership** (neither is the other's
+ancestor) so all four membership terms → 0. But siblings are related (same parent, `d≈2` → high `1/d`), so
+**`1/d` is the dedicated LATERAL/sibling channel**, not a generic fallback. Measured (14 562 pairs, classified
+on the graph): sibling/cousin pairs are **37 %** of the set with real relatedness (target μ 0.13 vs distant
+0.00) and **0 % membership coverage**, yet `corr(1/d, SYM) = +0.136` there — `1/d` is the *sole* structural
+signal for that 37 %. Vertical pairs (11 %, μ 0.49) are where memberships lead. This is *why* the dual judge
+beats either judge alone: memberships cover the vertical axis, `1/d` covers the lateral/sibling axis, e5 covers
+semantics. (The old "lateral residual" intuition was this — right concept, wrong sign.)
+
 **The two confidences (each an error/agreement measurement, not a free knob):**
 - **`c_dist` — global, fixed.** The distance proxy's reliability = how well `1/d` **agrees with the LLM judge**
   on the two-judge data (corr or `1/MSE`). One number. (Gated on the §14 two-judge scoring — the LLM judge is

--- a/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
+++ b/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
@@ -27,7 +27,15 @@ Fit `μ_sym ≈ σ(w·features)` against the judge-scored SYM targets:
   **re-explains the SYM "regression"**: SYM is ~half structural, so when the broad fine-tune shifted the graph,
   the pure-e5 operator lost the structural half it never had.
 
-## Confidence architecture (LOCKED design, user 2026-07-04 — build pending)
+## Confidence architecture (hand-fusion — SUPERSEDED, see `DESIGN_sym_estimation_integration.md`)
+
+> **Course-correction (2026-07-05):** the hand-set inverse-variance fusion below is the wrong shape per the
+> project's own estimation PRs — the μ sources are correlated (e5↔model +0.75, #3357/#3359), subcat/elem are
+> anti-correlated (#3359), and confidence is a weak per-query signal that should *gate* not *weight* (margin not
+> level, #3391). The recommended path is the calibrated **`JointPosterior`** (`mu_posterior.py`, #3359) over the
+> full μ-vector, with `1/d` added as the one decorrelated (sibling/lateral) source, gated by margin. See
+> **`DESIGN_sym_estimation_integration.md`**. The design below stays as an A/B control / ablation.
+
 
 Two axes, and the confidence principle (#3356) applies to **only one** of them:
 

--- a/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
+++ b/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
@@ -78,6 +78,14 @@ elem_bwd}`, `c` grouped `{c_dist, c_subcat×2, c_elem×2}`. **Empirically decida
 `error_ELEM` (or `corr(signal, SYM judge)` — subcat's was +0.669); if close, **collapse to one combined `c_mem`**
 (the simple default — lose nothing); if they diverge, keep separate.
 
+*Measured (`measure_membership_confidence.py`, `model_prod.pt`, 2500 pairs).* Model readouts vs SYM judge:
+**`c_elem` = +0.815 > `c_subcat` = +0.715** (up_hops proxy was +0.669) — three findings: (1) **element is the
+STRONGEST membership signal** (validates including it — it's not just complementary, it's the best); (2) gap
+0.10 ⇒ **keep `c_subcat`/`c_elem` separate** (confirmed); (3) the model HIER readout (+0.715) beats the up_hops
+proxy (+0.669) ⇒ **use model readouts** (and element has no proxy anyway). *Caveat:* measured on model_prod's
+training pairs ⇒ absolute values likely inflated by leakage; the **relative ordering `elem ≥ subcat > dist`** is
+the robust takeaway — set the actual `c` buffers from **held-out** error / the two-judge round.
+
 ### Implementation (`--struct-blend precision`, BUILT)
 
 Theory → code mapping (`mu_attention.py`, `train_mu_attention.py`):

--- a/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
+++ b/prototypes/mu_cosine/DESIGN_sym_dual_judge.md
@@ -101,8 +101,10 @@ elem_bwd}`, `c` grouped `{c_dist, c_subcat×2, c_elem×2}`. **Empirically decida
 STRONGEST membership signal** (validates including it — it's not just complementary, it's the best); (2) gap
 0.10 ⇒ **keep `c_subcat`/`c_elem` separate** (confirmed); (3) the model HIER readout (+0.715) beats the up_hops
 proxy (+0.669) ⇒ **use model readouts** (and element has no proxy anyway). *Caveat:* measured on model_prod's
-training pairs ⇒ absolute values likely inflated by leakage; the **relative ordering `elem ≥ subcat > dist`** is
-the robust takeaway — set the actual `c` buffers from **held-out** error / the two-judge round.
+training pairs ⇒ absolute values likely inflated by leakage. Leakage is **not guaranteed rank-preserving** across
+operators (it can inflate one more than another), so the ordering `elem ≥ subcat > dist` is **the hypothesis to
+re-measure held-out**, not an established result — set the actual `c` buffers from **held-out** (node-disjoint)
+error / the two-judge round before relying on it.
 
 ### Implementation (`--struct-blend precision`, BUILT)
 

--- a/prototypes/mu_cosine/DESIGN_sym_estimation_integration.md
+++ b/prototypes/mu_cosine/DESIGN_sym_estimation_integration.md
@@ -1,0 +1,108 @@
+# Integrating the SYM dual judge into the μ-estimation architecture
+
+*(joint posterior + margin gate + the distance source — a course-correction, 2026-07-05)*
+
+## TL;DR
+
+The SYM dual-judge work (`DESIGN_sym_dual_judge.md`) built a **hand-set, inverse-variance precision fusion**
+of structural signals (`--struct-blend precision|membership`, fixed `c_dist/c_subcat/c_elem`). Reviewing the
+project's own estimation PRs (#3356, #3357, #3359, #3387, #3391) shows that fusion is the **wrong shape on
+three counts**. The project already has the right machinery — the **calibrated `JointPosterior`**
+(`mu_posterior.py`, #3359) over the full μ-readout vector, **gated by margin** (#3391). The genuinely new and
+non-redundant contribution of the dual-judge work is **one source**: the structural-embedding distance `1/d`,
+which is decorrelated from the model/e5 cluster and carries the **lateral / sibling** axis the model readouts
+structurally miss. **Plan: add `1/d` to the JointPosterior's source vector and let the calibrated head learn
+the combination; keep the hand-fusion modes only as A/B controls.**
+
+## Why the hand-set precision fusion is wrong (three findings)
+
+The fusion `μ_graph = Σ_s (c_s·region_s·value_s) / Σ_s (c_s·region_s)` is optimal only for **independent**
+estimators weighted by **reliable per-item confidences**. Neither holds:
+
+1. **The sources are correlated — inverse-variance over-confidences (#3357, #3359).** The model *consumes*
+   frozen e5, so `μ_SYM`, `μ_HIER`, `μ_ELEM` (all model readouts) share signal. #3359 *measured*
+   **e5↔model μ correlation = +0.751**. Combining correlated votes as if independent double-counts the shared
+   e5 signal — exactly the over-confidence #3357 §1 warns about. #3359 confirmed it: a **factored
+   product-of-marginals with equal weights scored 50.9%, *below* the 51.1% majority baseline**; even the
+   #3357 separability-weighted correction only reached 51.1%.
+2. **Subcategory and element are ANTI-correlated — their joint is the asymmetry (#3359, Finding 4).** I treated
+   `c_subcat` and `c_elem` as two independent *positive* confidences added together. But #3359 found subcat and
+   element **anti-correlated**, and *conditioning on both jointly IS the directional asymmetry* (realised from
+   data, no hand-built term). Additive independent weighting throws that structure away.
+3. **Confidence is a weak per-query signal — a GATE, not a per-item WEIGHT (#3391).** #3391 established the
+   confidence signal is **margin (top1−top2 μ), not level** (level is *anti-correlated* with correctness on
+   under-trained checkpoints; `AURC_margin < AURC_level` on all four checkpoints). And even margin is a **weak
+   per-query predictor** (Spearman ρ +0.03…+0.15, CI∋0 on 3/4 checkpoints) — good for **selective-risk gating**
+   (which source to trust, when to abstain), **not** for a precise per-pair `c·value` multiplier. My hand-set
+   per-pair confidences ask more of confidence than it can deliver.
+
+Corollary — the **data-limit accounting** was also off: my `region` used **graph degree** as a data-density
+proxy. #3356 did *not* use graph degree; its confidence was a **label-confidence tag + `P(μ|op)` calibration
+against the tagged (training) set** (re-estimated as the model evolves). Degree measures an endpoint's *own*
+training-edge count, not whether *nearby (e5-similar)* nodes were trained — which is what governs the readout's
+reliability, since the model generalises through e5.
+
+## The correct architecture (already in the project)
+
+```
+sources  →  JointPosterior (calibrated, held-out)  →  P(relation | μ-vector)  →  margin gate (selective risk)
+```
+
+- **`JointPosterior` (`mu_posterior.py`, #3359)** — a small discriminative head (logistic / 1-hidden MLP) over
+  the **whole** μ-readout vector, fit on **held-out tagged data**. It *learns* the combination, so it absorbs
+  the e5↔model correlation, the subcat↔element anti-correlation, and stays **calibrated** (confidence matches
+  accuracy). This is #3357's "calibrated log-linear combiner" recommendation, implemented and shown to beat the
+  product-of-marginals.
+- **Margin gate (#3391)** — use `top1−top2` of the posterior as the **selective-risk gate** (route / abstain),
+  not a per-pair weight. `--confidence-mode margin`.
+- **`model_readout_fn` (`mu_posterior.py`)** already extracts the full model readout vector (SYM + directionals)
+  and *already flags* that these are correlated and "should be down-weighted / decorrelated."
+
+## What is genuinely new: the distance (sibling) source
+
+The dual-judge work's lasting value is **not** the fusion mechanism — it's a **source**:
+
+- **`1/d` (structural-embedding distance) is the one input decorrelated from the model/e5 cluster.** It was
+  trained *separately* on graph distance (`structural_embedding.py`, reciprocal target), so it is not a
+  re-reading of e5.
+- **It carries the lateral / sibling axis the model readouts structurally cannot.** Membership operators are
+  vertical (ancestor↔descendant); *siblings have zero membership in either direction* yet are related. Measured
+  (14 562 pairs): **sibling/cousin = 37 % of pairs, 0 % membership coverage**, real relatedness (target μ 0.13
+  vs distant 0.00), and **`corr(1/d, SYM) = +0.136` there — `1/d` is the *sole* structural signal for that
+  37 %.** (See `DESIGN_sym_dual_judge.md` "Division of labor.")
+
+So `1/d` is precisely the kind of **non-redundant** source #3357 wants added to the vector — its whole point is
+to cover an axis the correlated model readouts miss.
+
+## Build plan
+
+1. **Add `1/d` as a source in `mu_posterior.py`.** A `struct_dist_fn(struct_emb)` → `readouts(pairs)` returning
+   `3/(1+‖Δ‖)`, alongside `e5_mu_fn` and `model_readout_fn`. Cheap (embedding lookup).
+2. **Fit `JointPosterior` over `{e5, μ_SYM, μ_HIER fwd/rev, μ_ELEM fwd/rev, 1/d}`** on held-out tagged pairs.
+   Report per-source **separability** and the **correlation matrix** (the tool already does this).
+3. **The honest test:** does adding `1/d` **raise held-out accuracy / lower AURC** over the correlated
+   model+e5 sources? Compare joint-with-`1/d` vs joint-without, and vs the current hand-fusion. Gate by margin;
+   report AURC (bootstrap CI, per #3391) + ECE.
+4. **Data-limit term, done right (#3356):** if a per-item confidence is still wanted on top of the joint head,
+   use **`P(μ|op)` calibration against the tagged set** (or a trained-neighbour-density in e5 space), **not**
+   graph degree — and use it as a **margin gate**, not a weight.
+
+## Status of the hand-fusion modes
+
+`--struct-blend inside | outside | precision | membership` and the fixed `c_dist/c_subcat/c_elem` buffers stay
+in the code as **A/B controls / ablations**, but are **superseded** as the recommended path by the JointPosterior
+route above. They are the naive/equal-weight PoE shape #3359 measured at/below majority; keep them only to
+quantify how much the calibrated joint head buys. `DESIGN_sym_dual_judge.md` is updated to point here.
+
+## References
+- `DESIGN_sym_dual_judge.md` — the dual-judge finding, the confidence architecture (now corrected here), the
+  sibling "division of labor," and the `c_dist`/`c_subcat`/`c_elem` measurements.
+- `DESIGN_mu_sources_and_estimation.md` (#3357) — sources not independent; down-weight / residual / calibrated
+  combiner; dual-vs-unified.
+- `mu_posterior.py`, `REPORT_mu_posterior.md` (#3359) — `JointPosterior`, e5↔model +0.751, subcat↔elem
+  anti-correlation, joint beats product-of-marginals.
+- `DESIGN_inferred_operator_superposition.md` (#3356) — label-confidence tag + `P(μ|op)` calibration; §3
+  four-source noise decomposition.
+- `DESIGN_model_applications.md`, PR #3391 — margin (not level) as the selective-risk gate; margin weak
+  per-query; AURC.
+- `REPORT_eval_methodology.md` (#3387) — what the learned layer adds over e5 is a widening *margin*.

--- a/prototypes/mu_cosine/DESIGN_sym_estimation_integration.md
+++ b/prototypes/mu_cosine/DESIGN_sym_estimation_integration.md
@@ -68,11 +68,14 @@ The dual-judge work's lasting value is **not** the fusion mechanism — it's a *
 - **It carries the lateral / sibling axis the model readouts structurally cannot.** Membership operators are
   vertical (ancestor↔descendant); *siblings have zero membership in either direction* yet are related. Measured
   (14 562 pairs): **sibling/cousin = 37 % of pairs, 0 % membership coverage**, real relatedness (target μ 0.13
-  vs distant 0.00), and **`corr(1/d, SYM) = +0.136` there — `1/d` is the *sole* structural signal for that
-  37 %.** (See `DESIGN_sym_dual_judge.md` "Division of labor.")
+  vs distant 0.00), and `corr(1/d, SYM) = +0.136` there — so `1/d` is the *sole* structural signal *covering*
+  that 37 % (a **coverage** claim). NB `+0.136` is **weak** (explains <2 % of variance): it justifies adding
+  `1/d` as a **candidate** source, and is *not* evidence that `1/d` alone does much work or will improve the
+  calibrated posterior. (See `DESIGN_sym_dual_judge.md` "Division of labor.")
 
-So `1/d` is precisely the kind of **non-redundant** source #3357 wants added to the vector — its whole point is
-to cover an axis the correlated model readouts miss.
+So `1/d` is a plausibly **non-redundant** source to add to the vector (#3357) — it covers an axis the correlated
+model readouts miss. **Whether it actually helps is the hypothesis this design's follow-up test decides** (joint
+head with vs without `1/d`, held-out, separability + AURC — below), not something established here.
 
 ## Build plan
 

--- a/prototypes/mu_cosine/eval_relatedness.py
+++ b/prototypes/mu_cosine/eval_relatedness.py
@@ -29,10 +29,16 @@ def build_model(ckpt, dev):
     m = MuAttention(d_model=cfg["d_model"], n_heads=cfg["heads"], n_layers=cfg["layers"],
                     n_ops=sz("op_emb.weight", len(OPS)), n_corpus=sz("corpus_emb.weight", 2),
                     n_judge=sz("judge_emb.weight", 2), n_nodetype=sz("nodetype_emb.weight", 4)).to(dev)
-    # allow keys absent from older checkpoints: account/prefix tags + the SYM dual-judge struct/precision params
-    # (sym_struct_w, struct_lambda, struct_g, struct_h, prec_g, prec_h, c_dist, c_mem_ceiling) — all zero-init/no-op.
-    _ok = ("account", "prefix", "struct", "prec_", "c_dist", "c_mem")
-    miss, unexp = m.load_state_dict(sd, strict=False); assert not unexp and all(any(t in k for t in _ok) for k in miss)
+    # Older checkpoints (e.g. model_prod.pt) predate the account/prefix tags and the SYM dual-judge
+    # struct/precision/confidence params+buffers; all are zero-init / no-op, so loading strict=False and ignoring
+    # EXACTLY these is safe. Explicit leaf-name allow-list (not broad substrings) so a genuinely-missing/renamed
+    # key in a future refactor still trips the assert (PR #3488 review, finding #9).
+    _NEW = ("account_emb.weight", "prefix_emb.weight", "sym_struct_w", "struct_lambda", "struct_g", "struct_h",
+            "prec_g", "prec_h", "c_dist", "c_mem_ceiling", "c_subcat", "c_elem")
+    miss, unexp = m.load_state_dict(sd, strict=False)
+    assert not unexp, f"unexpected keys loading {ckpt}: {unexp}"
+    bad = [k for k in miss if not any(k.endswith(n) for n in _NEW)]
+    assert not bad, f"unexpected MISSING keys loading {ckpt}: {bad}"
     m.eval(); return m
 
 

--- a/prototypes/mu_cosine/eval_relatedness.py
+++ b/prototypes/mu_cosine/eval_relatedness.py
@@ -29,7 +29,10 @@ def build_model(ckpt, dev):
     m = MuAttention(d_model=cfg["d_model"], n_heads=cfg["heads"], n_layers=cfg["layers"],
                     n_ops=sz("op_emb.weight", len(OPS)), n_corpus=sz("corpus_emb.weight", 2),
                     n_judge=sz("judge_emb.weight", 2), n_nodetype=sz("nodetype_emb.weight", 4)).to(dev)
-    miss, unexp = m.load_state_dict(sd, strict=False); assert not unexp and all(("account" in k or "prefix" in k) for k in miss)
+    # allow keys absent from older checkpoints: account/prefix tags + the SYM dual-judge struct/precision params
+    # (sym_struct_w, struct_lambda, struct_g, struct_h, prec_g, prec_h, c_dist, c_mem_ceiling) — all zero-init/no-op.
+    _ok = ("account", "prefix", "struct", "prec_", "c_dist", "c_mem")
+    miss, unexp = m.load_state_dict(sd, strict=False); assert not unexp and all(any(t in k for t in _ok) for k in miss)
     m.eval(); return m
 
 

--- a/prototypes/mu_cosine/measure_membership_confidence.py
+++ b/prototypes/mu_cosine/measure_membership_confidence.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""ELEM follow-up, step 0 — MEASURE the membership confidences before building.
+
+The precision graph judge weights each membership signal by its reliability c = corr(signal, SYM judge)
+(DESIGN_sym_dual_judge.md "Confidence architecture"). v1 used a subcategory-only up_hops proxy (c_mem +0.669).
+Here we score the MODEL's own membership readouts on model_prod.pt and correlate each with the SYM judge target:
+
+    c_subcat = corr( HIER-membership , SYM ),    c_elem = corr( ELEM-membership , SYM )
+
+membership(op) = combine( μ_op(a|b), μ_op(b|a) )   (max = "member in either direction"; mean also reported).
+
+Decision (user 2026-07-04): confidence is per-OPERATOR, shared across fwd/bwd. If c_subcat ≈ c_elem ⇒ collapse to
+one combined c_mem (simpler, lose nothing); if they diverge ⇒ keep them separate in the precision fusion.
+
+  python3 measure_membership_confidence.py --ckpt model_prod.pt --graph ../../data/benchmark/100k_cats/category_parent.tsv
+"""
+import argparse, os, sys
+from collections import deque
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mu_attention import build_e5_tables, Tokenizer, OPS, load_dag
+from eval_relatedness import build_model, score_pairs
+
+
+def load_pairs_with_target(path, cap):
+    rows = []
+    for ln in open(path, encoding="utf-8"):
+        if ln.startswith("#"):
+            continue
+        c = ln.rstrip("\n").split("\t")
+        if len(c) < 5:
+            continue
+        try:
+            mu = float(c[4])
+        except ValueError:
+            continue
+        rows.append((c[0], c[1], mu))          # (node, root, SYM target)
+    return rows[:cap] if cap else rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", default="model_prod.pt")
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--pairs", default="mu_pairs_scored_cumulative.tsv")
+    ap.add_argument("--cap-pairs", type=int, default=2500)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    a = ap.parse_args()
+    dev = torch.device(a.device)
+
+    parents, children, deg = load_dag(a.graph)
+    rows = load_pairs_with_target(a.pairs, a.cap_pairs)
+    print(f"pairs (before ancestor closure): {len(rows)}")
+
+    # names = pair endpoints + their ancestors (the tokenizer references them), like fit_sym_from_graph
+    def anc_of(nm, capd=10):
+        out, frontier, steps = set(), {nm}, 0
+        while frontier and steps < capd:
+            nxt = set()
+            for cur in frontier:
+                for pp in (parents.get(cur) or []):
+                    if pp not in out and pp != nm:
+                        out.add(pp); nxt.add(pp)
+            frontier = nxt; steps += 1
+        return out
+    names = {x for r in rows for x in r[:2]}
+    for nm in list(names):
+        names.update(anc_of(nm))
+    names = sorted(names)
+    q, p, idx = build_e5_tables(names, cache_path="/tmp/mu_data/elem_conf_e5.pt", device=str(dev))
+    # keep only pairs whose endpoints embedded
+    rows = [r for r in rows if r[0] in idx and r[1] in idx]
+    print(f"pairs scored: {len(rows)}  ({len(names)} names embedded)")
+    tok = Tokenizer(q, p, idx, parents, deg, k=8, beta=1.0, max_anc=8)
+
+    model = build_model(a.ckpt, dev)
+    n_ops = model.op_emb.num_embeddings
+    print(f"model ops: {n_ops}  (HIER={OPS['HIER']}, ELEM={OPS['ELEM']})")
+
+    def readout(op):
+        ow = torch.zeros(1, n_ops); ow[0, OPS[op]] = 1.0
+        fwd = np.array(score_pairs(model, tok, idx, [(x, y) for x, y, _ in rows], ow, dev))
+        bwd = np.array(score_pairs(model, tok, idx, [(y, x) for x, y, _ in rows], ow, dev))
+        return fwd, bwd
+
+    tgt = np.array([m for _, _, m in rows])
+    print(f"\nSYM target: mean {tgt.mean():.3f}  std {tgt.std():.3f}\n")
+    results = {}
+    for op, label in [("HIER", "subcat"), ("ELEM", "elem")]:
+        fwd, bwd = readout(op)
+        for combine, name in [(np.maximum(fwd, bwd), "max"), ((fwd + bwd) / 2, "mean")]:
+            c = float(np.corrcoef(combine, tgt)[0, 1])
+            results[(label, name)] = c
+            print(f"  c_{label:6s} ({name} fwd/bwd) = corr(μ_{op}, SYM) = {c:+.3f}   "
+                  f"(signal mean {combine.mean():.3f})")
+    # decision
+    cs, ce = results[("subcat", "max")], results[("elem", "max")]
+    gap = abs(cs - ce)
+    print(f"\n  c_subcat {cs:+.3f}  vs  c_elem {ce:+.3f}   |gap| {gap:.3f}")
+    print(f"  → {'COLLAPSE to one combined c_mem (close)' if gap < 0.10 else 'KEEP SEPARATE c_subcat / c_elem (diverge)'}")
+    print(f"  (v1 up_hops-proxy subcat c_mem was +0.669 — compare the model-HIER readout above)")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -369,7 +369,10 @@ class MuAttention(nn.Module):
     def __init__(self, d_model=384, n_ops=len(OPS), n_heads=4, n_layers=1, max_gen=5,
                  dim_ff=None, dropout=0.0, n_corpus=len(CORPORA), n_judge=len(JUDGES),
                  n_nodetype=len(NODETYPE), n_account=len(ACCOUNTS), struct_blend="inside", n_struct=1,
-                 c_dist=1.0, c_mem_ceiling=1.0, c_subcat=0.72, c_elem=0.82):
+                 c_dist=1.0, c_mem_ceiling=1.0, c_subcat=1.0, c_elem=1.0):
+        # NB c_subcat/c_elem default to a NEUTRAL 1.0 here — the measured +0.72/+0.82 are LEAKAGE-INFLATED
+        # (training-pair measurement, PR #3488 review) and are supplied ONLY via the CLI on the superseded
+        # `membership` ablation path (see DESIGN_sym_estimation_integration.md), not baked into the module.
         super().__init__()
         self.d = d_model
         self.struct_blend = struct_blend            # DUAL-JUDGE combine: "inside"|"outside"|"precision"|"membership"
@@ -480,6 +483,10 @@ class MuAttention(nn.Module):
                 mu = mu_e5 + sym_gate * self.struct_lambda * (mu_graph - mu_e5)  # λ=0 ⇒ pure e5 (no-op); ~0.5 learned
                 return mu.clamp(0.0, 1.0)
             if self.struct_blend == "membership":            # ELEM: fuse dist(siblings) + subcat + elem memberships
+                # ⚠ SUPERSEDED ABLATION (PR #3488 review): this hand-set fusion still gates the memberships by the
+                # graph-degree `region` proxy, which DESIGN_sym_estimation_integration.md argues is the wrong
+                # data-limit proxy (confidence should be learned/calibrated via JointPosterior, not a per-item
+                # weight). Kept only as an A/B control — NOT the recommended path; don't cite it as evidence for it.
                 dist, region = struct_feat[:, 0], struct_feat[:, 1]            # struct_feat = [dist, region]
                 ms = mem_subcat if mem_subcat is not None else torch.zeros_like(dist)   # detached μ_HIER (max fwd/bwd)
                 me = mem_elem if mem_elem is not None else torch.zeros_like(dist)        # detached μ_ELEM (max fwd/bwd)

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -338,13 +338,16 @@ class Tokenizer:
                "op_of": op_of, "pad": pad}
         if self.struct is not None:                          # DUAL-JUDGE: per-pair graph signal vector [B, K]
             mode = self.struct_mode
-            K = 1 if mode == "dist" else 3
+            K = {"dist": 1, "membership": 2}.get(mode, 3)    # membership: [dist, region] (mem from model kwargs)
             sf = torch.zeros(B, K)
             for bi, it in enumerate(items):
                 a, b = it[0], it[1]                          # (node, root)
                 va, vb = self.struct.get(a), self.struct.get(b)
                 sf[bi, 0] = float(3.0 / (1.0 + (va - vb).norm())) if (va is not None and vb is not None) else 0.0
-                if mode != "dist":
+                if mode == "membership":                     # [dist, region]; memberships arrive as detached kwargs
+                    mind = min(self.deg.get(a, 0), self.deg.get(b, 0))
+                    sf[bi, 1] = mind / (mind + self.deg_scale)   # per-region data-density factor ∈[0,1)
+                elif mode != "dist":
                     fh = self._up_hops(a, b, self.struct_cap)   # forward: b is an ancestor of a (a subcat_of b)
                     bh = self._up_hops(b, a, self.struct_cap)   # backward: a is an ancestor of b
                     fwd = 3.0 / (1.0 + fh) if fh is not None else 0.0
@@ -352,7 +355,7 @@ class Tokenizer:
                     if mode == "dir":                        # free-weight predictors [dist, fwd, bwd]
                         sf[bi, 1] = fwd; sf[bi, 2] = bwd
                     else:                                    # "precision": [dist, mem, region]
-                        sf[bi, 1] = (fwd + bwd) / 2.0        # membership signal (data-rich)
+                        sf[bi, 1] = (fwd + bwd) / 2.0        # membership signal (up_hops proxy)
                         mind = min(self.deg.get(a, 0), self.deg.get(b, 0))
                         sf[bi, 2] = mind / (mind + self.deg_scale)   # per-region c_mem factor ∈[0,1)
             out["struct_feat"] = sf
@@ -366,10 +369,10 @@ class MuAttention(nn.Module):
     def __init__(self, d_model=384, n_ops=len(OPS), n_heads=4, n_layers=1, max_gen=5,
                  dim_ff=None, dropout=0.0, n_corpus=len(CORPORA), n_judge=len(JUDGES),
                  n_nodetype=len(NODETYPE), n_account=len(ACCOUNTS), struct_blend="inside", n_struct=1,
-                 c_dist=1.0, c_mem_ceiling=1.0):
+                 c_dist=1.0, c_mem_ceiling=1.0, c_subcat=0.72, c_elem=0.82):
         super().__init__()
         self.d = d_model
-        self.struct_blend = struct_blend            # DUAL-JUDGE combine: "inside" | "outside" | "precision"
+        self.struct_blend = struct_blend            # DUAL-JUDGE combine: "inside"|"outside"|"precision"|"membership"
         self.op_emb = nn.Embedding(n_ops, d_model)
         # NODE-TYPE: per-endpoint structural-role token (category/page/mindmap/pearltrees). Zero-init so it
         # is a no-op at warm start (category=0 default) and the type signal is learned during fine-tuning.
@@ -413,6 +416,12 @@ class MuAttention(nn.Module):
         # struct_lambda (zero-init ⇒ warm-start no-op; learned ~0.5 as a COMPLEMENTARY superposition, not gated).
         self.register_buffer("c_dist", torch.tensor(float(c_dist)))
         self.register_buffer("c_mem_ceiling", torch.tensor(float(c_mem_ceiling)))
+        # "membership" mode (ELEM follow-up): the graph judge fuses THREE structural signals — distance (siblings/
+        # lateral) + subcategory membership + element membership — each weighted by its MEASURED reliability
+        # (register_buffers, not learned). μ_HIER/μ_ELEM come in as detached kwargs (mem_subcat/mem_elem). Per
+        # DESIGN §Confidence: c per OPERATOR (subcat vs elem separate), region (data density) modulates memberships.
+        self.register_buffer("c_subcat", torch.tensor(float(c_subcat)))
+        self.register_buffer("c_elem", torch.tensor(float(c_elem)))
         self.prec_g = nn.Parameter(torch.tensor(1.0))
         self.prec_h = nn.Parameter(torch.tensor(0.0))
         for emb in (self.op_emb, self.gen_emb, self.corpus_emb, self.judge_emb):
@@ -423,7 +432,7 @@ class MuAttention(nn.Module):
 
     def forward(self, content, gen_id, is_anchor, op_pos, op_of, pad,
                 is_prov=None, corpus_of=None, judge_of=None, account_of=None, nodetype_of=None,
-                prefix_of=None, op_weights=None, struct_feat=None):
+                prefix_of=None, op_weights=None, struct_feat=None, mem_subcat=None, mem_elem=None):
         # op_weights [B, n_ops] (optional): a BLENDED operator — a weight vector over operators that replaces
         # the one-hot op token AND the per-operator readout head (a random superposition for inferred rows;
         # a one-hot for tagged rows reproduces the indexed path exactly). See
@@ -470,6 +479,17 @@ class MuAttention(nn.Module):
                 mu_e5 = torch.sigmoid(logit)                                    # complementary e5 judge
                 mu = mu_e5 + sym_gate * self.struct_lambda * (mu_graph - mu_e5)  # λ=0 ⇒ pure e5 (no-op); ~0.5 learned
                 return mu.clamp(0.0, 1.0)
+            if self.struct_blend == "membership":            # ELEM: fuse dist(siblings) + subcat + elem memberships
+                dist, region = struct_feat[:, 0], struct_feat[:, 1]            # struct_feat = [dist, region]
+                ms = mem_subcat if mem_subcat is not None else torch.zeros_like(dist)   # detached μ_HIER (max fwd/bwd)
+                me = mem_elem if mem_elem is not None else torch.zeros_like(dist)        # detached μ_ELEM (max fwd/bwd)
+                cs, ce = region * self.c_subcat, region * self.c_elem          # per-region membership confidences
+                num = self.c_dist * dist + cs * ms + ce * me                   # precision (inverse-variance) fusion
+                pw = num / (self.c_dist + cs + ce + 1e-6)
+                mu_graph = torch.sigmoid(self.prec_g * pw + self.prec_h)
+                mu_e5 = torch.sigmoid(logit)
+                mu = mu_e5 + sym_gate * self.struct_lambda * (mu_graph - mu_e5)  # λ=0 ⇒ pure e5 (no-op)
+                return mu.clamp(0.0, 1.0)
             if self.struct_blend == "outside":               # blend two BOUNDED judges in μ-space (no outer sigmoid)
                 mu_e5 = torch.sigmoid(logit)                                     # e5 judge — already ∈[0,1]
                 mu_graph = torch.sigmoid((struct_feat * self.struct_g).sum(-1) + self.struct_h)  # squash the graph terms
@@ -477,6 +497,32 @@ class MuAttention(nn.Module):
                 return mu.clamp(0.0, 1.0)
             logit = logit + sym_gate * (struct_feat * self.sym_struct_w).sum(-1)  # INSIDE: Σ wₖ·featₖ, one sigmoid
         return torch.sigmoid(logit)
+
+
+@torch.no_grad()
+def membership_readouts(model, tok, pairs, dev, batch=512):
+    """Detached μ_HIER / μ_ELEM memberships for the 'membership' graph judge (DESIGN §ELEM follow-up).
+    pairs = [(a, b), ...] (node, root). Returns (mem_subcat, mem_elem) tensors [N] on `dev`:
+        mem_subcat = max(μ_HIER(a|b), μ_HIER(b|a)),   mem_elem = max(μ_ELEM(a|b), μ_ELEM(b|a))
+    STOP-GRAD (features, not targets): SYM training must not back-prop into / corrupt the HIER/ELEM operators.
+    Correct even in 'membership' blend mode: a non-SYM readout has sym_gate=0 ⇒ the struct branch returns μ_e5,
+    i.e. the plain operator readout."""
+    n_ops = model.op_emb.num_embeddings
+
+    def score(op, ordered):
+        ow = torch.zeros(1, n_ops, device=dev); ow[0, OPS[op]] = 1.0
+        out = []
+        for i in range(0, len(ordered), batch):
+            ch = ordered[i:i + batch]
+            bd = tok.build([(x, y, 0) for x, y in ch], train=False)
+            bd = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in bd.items()}
+            out.append(model(**bd, op_weights=ow.expand(len(ch), n_ops)))
+        return torch.cat(out) if out else torch.zeros(0, device=dev)
+
+    fwd = list(pairs); rev = [(b, a) for a, b in pairs]
+    ms = torch.maximum(score("HIER", fwd), score("HIER", rev))
+    me = torch.maximum(score("ELEM", fwd), score("ELEM", rev))
+    return ms.detach(), me.detach()
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/test_struct_blend.py
+++ b/prototypes/mu_cosine/test_struct_blend.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Unit tests for the SYM dual-judge struct-blend modes (PR #3488). Pytest-free (like test_infer_switch.py) —
+run directly: `python3 test_struct_blend.py`. Torch required.
+
+Asserts the safety properties the PR claims (the review asked these be committed, not just smoke-run):
+  1. WARM-START NO-OP — with zero-init blend weights, μ is EXACTLY equal to the no-struct path (all modes).
+  2. SYM-GATED — engaging the blend moves the SYM row and leaves non-SYM (HIER) rows numerically unchanged.
+  3. BOUNDED — output ∈ [0,1] even with the blend fully engaged.
+  4. membership_readouts is DETACHED (no grad).
+  5. PER-REGION shift — a data-rich pair gives 1/d a smaller weight share than a sparse pair (precision mode).
+"""
+import torch
+from mu_attention import MuAttention, Tokenizer, OPS, membership_readouts
+
+D = 384
+NAMES = ["A", "B", "C", "D", "E"]
+PARENTS = {"A": ["B"], "B": ["C"], "D": ["C"], "E": ["C"]}
+
+
+def _fixture(struct_mode, deg=None):
+    torch.manual_seed(0)
+    q, p = torch.randn(5, D), torch.randn(5, D)
+    idx = {n: i for i, n in enumerate(NAMES)}
+    deg = deg or {n: 10 for n in NAMES}
+    struct = {n: torch.randn(16) for n in NAMES}
+    tok = Tokenizer(q, p, idx, PARENTS, deg, struct_tbl=struct, struct_mode=struct_mode, deg_scale=5.0)
+    return tok
+
+
+def _channels_for(blend):
+    return {"inside": "dist", "outside": "dist", "precision": "precision", "membership": "membership"}[blend]
+
+
+def _n_struct_for(blend):
+    return {"inside": 1, "outside": 1, "precision": 3, "membership": 3}[blend]
+
+
+def _zero_weight_param(blend):
+    # the zero-init parameter whose non-zero value engages the blend, per mode
+    return {"inside": "sym_struct_w", "outside": "struct_lambda",
+            "precision": "struct_lambda", "membership": "struct_lambda"}[blend]
+
+
+def _forward(m, tok, items, **extra):
+    b = tok.build(items, train=False)
+    return m(**b, **extra)
+
+
+def _mem_kwargs(m, tok, items):
+    if m.struct_blend != "membership":
+        return {}
+    pairs = [(it[0], it[1]) for it in items]
+    ms, me = membership_readouts(m, tok, pairs, torch.device("cpu"))
+    # only the SYM row(s) should carry membership; gating zeroes the rest anyway
+    return {"mem_subcat": ms, "mem_elem": me}
+
+
+def test_warm_start_no_op_and_gating_and_bounds():
+    items = [("A", "B", OPS["SYM"]), ("A", "B", OPS["HIER"])]
+    for blend in ("inside", "outside", "precision", "membership"):
+        tok = _fixture(_channels_for(blend))
+        m = MuAttention(d_model=D, n_layers=1, struct_blend=blend, n_struct=_n_struct_for(blend),
+                        c_dist=0.35, c_mem_ceiling=0.67, c_subcat=0.72, c_elem=0.82)
+        m.eval()
+        with torch.no_grad():
+            b = tok.build(items, train=False)
+            base = m(**{k: v for k, v in b.items() if k != "struct_feat"})   # pure e5, no struct at all
+            mem = _mem_kwargs(m, tok, items)
+            out0 = m(**b, **mem)                                             # zero-init ⇒ must equal base EXACTLY
+            assert torch.equal(base, out0), f"[{blend}] warm-start NOT an exact no-op: {base} vs {out0}"
+
+            # engage the blend
+            getattr(m, _zero_weight_param(blend)).data.fill_(0.6)
+            out1 = m(**b, **mem)
+            assert not torch.allclose(out0[0], out1[0]), f"[{blend}] SYM row did not move when engaged"
+            assert torch.equal(out0[1], out1[1]), f"[{blend}] non-SYM (HIER) row changed — gating broken"
+            assert bool((out1 >= 0).all() and (out1 <= 1).all()), f"[{blend}] output out of [0,1]: {out1}"
+    print("PASS: warm-start no-op (exact) + SYM-gating + bounds, all 4 modes")
+
+
+def test_membership_readouts_detached():
+    tok = _fixture("membership")
+    m = MuAttention(d_model=D, n_layers=1, struct_blend="membership", n_struct=3); m.eval()
+    ms, me = membership_readouts(m, tok, [("A", "B")], torch.device("cpu"))
+    assert not ms.requires_grad and not me.requires_grad, "membership_readouts must be detached (stop-grad)"
+    assert bool((ms >= 0).all() and (ms <= 1).all() and (me >= 0).all() and (me <= 1).all()), "μ readouts ∉ [0,1]"
+    print("PASS: membership_readouts detached + bounded")
+
+
+def test_precision_per_region_shift():
+    # A,B well-connected (data-rich) → high region → memberships weighted more → SMALLER 1/d share.
+    # D,E sparse → low region → LARGER 1/d share. Check the region channel + the resulting weight share.
+    deg = {"A": 20, "B": 20, "C": 20, "D": 1, "E": 1}
+    tok = _fixture("precision", deg=deg)
+    b = tok.build([("A", "B", OPS["SYM"]), ("D", "E", OPS["SYM"])], train=False)
+    region_rich = float(b["struct_feat"][0, 2])
+    region_sparse = float(b["struct_feat"][1, 2])
+    assert region_rich > region_sparse, f"region should be higher for the data-rich pair: {region_rich} vs {region_sparse}"
+    c_dist, c_mem_ceiling = 0.35, 0.67
+    share_rich = c_dist / (c_mem_ceiling * region_rich + c_dist)
+    share_sparse = c_dist / (c_mem_ceiling * region_sparse + c_dist)
+    assert share_sparse > share_rich, f"sparse pair must give 1/d a larger share: {share_sparse} vs {share_rich}"
+    print(f"PASS: per-region shift (1/d share rich {share_rich:.2f} < sparse {share_sparse:.2f})")
+
+
+if __name__ == "__main__":
+    test_warm_start_no_op_and_gating_and_bounds()
+    test_membership_readouts_detached()
+    test_precision_per_region_shift()
+    print("ALL PASS")

--- a/prototypes/mu_cosine/test_struct_blend.py
+++ b/prototypes/mu_cosine/test_struct_blend.py
@@ -103,8 +103,35 @@ def test_precision_per_region_shift():
     print(f"PASS: per-region shift (1/d share rich {share_rich:.2f} < sparse {share_sparse:.2f})")
 
 
+def test_build_model_loads_old_checkpoint():
+    # Regression for PR #3488: build_model must load a PRE-PR checkpoint (missing the new struct/confidence
+    # buffers incl. c_subcat/c_elem) AND still reject a genuinely-missing key. Constructs a tiny old-style ckpt.
+    import os, tempfile
+    from eval_relatedness import build_model
+    NEW = ("sym_struct_w", "struct_lambda", "struct_g", "struct_h", "prec_g", "prec_h",
+           "c_dist", "c_mem_ceiling", "c_subcat", "c_elem", "account_emb.weight", "prefix_emb.weight")
+    m = MuAttention(d_model=32, n_heads=4, n_layers=1)
+    sd = m.state_dict()
+    old = {k: v for k, v in sd.items() if not any(k.endswith(n) for n in NEW)}   # simulate pre-PR checkpoint
+    cfg = {"d_model": 32, "heads": 4, "layers": 1}
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, "old_ckpt.pt")
+    torch.save({"state": old, "cfg": cfg}, path)
+    mm = build_model(path, torch.device("cpu"))                                 # must NOT raise
+    assert hasattr(mm, "c_subcat") and hasattr(mm, "c_elem"), "new buffers should exist at defaults"
+    broken = {k: v for k, v in old.items() if k != "op_emb.weight"}             # a genuinely-missing key
+    torch.save({"state": broken, "cfg": cfg}, path)
+    try:
+        build_model(path, torch.device("cpu")); raised = False
+    except AssertionError:
+        raised = True
+    assert raised, "build_model must still reject a genuinely-missing key (not swallow it)"
+    print("PASS: build_model loads pre-PR checkpoints (missing new buffers) + rejects genuine gaps")
+
+
 if __name__ == "__main__":
     test_warm_start_no_op_and_gating_and_bounds()
     test_membership_readouts_detached()
     test_precision_per_region_shift()
+    test_build_model_loads_old_checkpoint()
     print("ALL PASS")

--- a/prototypes/mu_cosine/train_mu_attention.py
+++ b/prototypes/mu_cosine/train_mu_attention.py
@@ -31,7 +31,7 @@ import torch
 import torch.nn.functional as F
 
 from mu_attention import (OPS, CORPORA, JUDGES, NODETYPE, GRAPH, load_dag, all_names, build_e5_tables,
-                          Tokenizer, MuAttention)
+                          Tokenizer, MuAttention, membership_readouts)
 
 # map the pair-file a_type/b_type strings to NODETYPE ids (category=0 default; pearltrees "collection" → 3)
 _NT = {"category": 0, "page": 1, "mindmap_node": 2, "collection": 3, "pearltrees_collection": 3}
@@ -219,10 +219,18 @@ def bfs_dist(adj, src):
 @torch.no_grad()
 def mu_batch(model, tok, items, bs=256):
     dev = next(model.parameters()).device
+    # membership mode: SYM readout needs the detached μ_HIER/μ_ELEM memberships (else eval sees the pure-e5 no-op).
+    # Only SYM-op batches need them (non-SYM ⇒ sym_gate=0 ⇒ ignored); gate to avoid needless readouts elsewhere.
+    memmode = (getattr(model, "struct_blend", None) == "membership"
+               and items and len(items[0]) > 2 and items[0][2] == OPS["SYM"])
     out = []
     for i in range(0, len(items), bs):
-        b = tok.build(items[i:i + bs], train=False)
+        ch = items[i:i + bs]
+        b = tok.build(ch, train=False)
         b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+        if memmode:
+            ms, me = membership_readouts(model, tok, [(it[0], it[1]) for it in ch], dev)
+            b["mem_subcat"] = ms; b["mem_elem"] = me
         out.append(model(**b).cpu())
     return torch.cat(out) if out else torch.zeros(0)
 
@@ -449,7 +457,8 @@ def train(args):
         struct_tbl = {n: v for n, v in zip(_se["nodes"], _se["emb"])}
         print(f"STRUCT-EMB (SYM dual judge): {len(struct_tbl)} nodes, {_se['dim']}d, from "
               f"{os.path.basename(args.struct_emb)}")
-    struct_mode = "precision" if args.struct_blend == "precision" else ("dir" if args.struct_dir else "dist")
+    struct_mode = (args.struct_blend if args.struct_blend in ("precision", "membership")
+                   else ("dir" if args.struct_dir else "dist"))
     tok = Tokenizer(q, p, idx, parents, deg, k=args.k, beta=1.0, max_anc=args.max_anc,
                     struct_tbl=struct_tbl, struct_mode=struct_mode, deg_scale=args.deg_scale)
 
@@ -554,7 +563,8 @@ def train(args):
     torch.manual_seed(args.seed)
     model = MuAttention(d_model=q.shape[1], n_heads=args.heads, n_layers=args.layers,
                         struct_blend=args.struct_blend, n_struct=(1 if struct_mode == "dist" else 3),
-                        c_dist=args.c_dist, c_mem_ceiling=args.c_mem_ceiling)
+                        c_dist=args.c_dist, c_mem_ceiling=args.c_mem_ceiling,
+                        c_subcat=args.c_subcat, c_elem=args.c_elem)
     if args.init_from:                                    # warm start — DON'T reinit the head (fine-tune)
         ck = torch.load(args.init_from, weights_only=False)
         sd, own = ck["state"], model.state_dict()
@@ -741,7 +751,11 @@ def train(args):
         sym_items = ([(it[0], it[1], OPS["SYM"], cid, j) for (it, cid), j in zip(sb, sb_j)] +
                      [(it[1], it[0], OPS["SYM"], cid, j) for (it, cid), j in zip(sb, sb_j)])
         tgt = torch.tensor([it[2] for it, _ in sb]).to(device)
-        mu_s = model(**bld(sym_items, train=True, rng=rng, p_mask_prov=args.prov_mask))
+        sym_batch = bld(sym_items, train=True, rng=rng, p_mask_prov=args.prov_mask)
+        if args.struct_blend == "membership":              # detached μ_HIER/μ_ELEM (max fwd/bwd is symmetric → tile)
+            _ms, _me = membership_readouts(model, tok, [(it[0], it[1]) for it, _ in sb], device)
+            sym_batch["mem_subcat"] = torch.cat([_ms, _ms]); sym_batch["mem_elem"] = torch.cat([_me, _me])
+        mu_s = model(**sym_batch)
         mu_ab, mu_ba = mu_s[:len(sb)], mu_s[len(sb):]
         L_sym = F.mse_loss(mu_ab, tgt) + F.mse_loss(mu_ba, tgt)
         # ELEM (element-of: directional + graded) — μ(page|category) toward the graded centrality target,
@@ -1301,11 +1315,12 @@ def main():
     ap.add_argument("--struct-emb", default=None, help="DUAL-JUDGE step 3: learned structural embedding "
                     "(structural_embedding.py .pt). When set, the SYM logit gets the O(1) structural channel "
                     "3/(1+‖Δ struct-emb‖); zero-init scale ⇒ warm-start no-op until SYM training learns it.")
-    ap.add_argument("--struct-blend", choices=["inside", "outside", "precision"], default="inside",
-                    help="DUAL-JUDGE combine mode: 'inside' = μ=σ(logit_e5 + w·struct) (logit-space); 'outside' = "
-                    "μ=μ_e5 + λ·(μ_graph−μ_e5), μ-space blend of two bounded judges; 'precision' (LOCKED design) = "
-                    "μ_graph is the precision-weighted (c_mem·mem + c_dist·(1/d))/(c_mem+c_dist), then the e5↔graph "
-                    "complementary superposition. λ zero-init ⇒ pure-e5 warm-start no-op in every mode.")
+    ap.add_argument("--struct-blend", choices=["inside", "outside", "precision", "membership"], default="inside",
+                    help="DUAL-JUDGE combine mode: 'inside' = μ=σ(logit_e5 + w·struct); 'outside' = μ_e5 + "
+                    "λ·(μ_graph−μ_e5); 'precision' = precision-weighted (c_mem·mem + c_dist·(1/d))/(c_mem+c_dist) with "
+                    "the up_hops subcat proxy; 'membership' (ELEM follow-up) = fuse dist(siblings) + SUBCAT + ELEMENT "
+                    "memberships (model μ_HIER/μ_ELEM readouts, detached) weighted by c_dist/c_subcat/c_elem. "
+                    "λ zero-init ⇒ pure-e5 warm-start no-op in every mode.")
     ap.add_argument("--c-dist", type=float, default=0.35, help="precision mode: GLOBAL distance-proxy confidence "
                     "= how well 1/d agrees with the SYM judge (corr). MEASURED +0.349 on the representative "
                     "cumulative mix (O(1) struct-emb proxy; true-BFS would be ~0.66). Re-measure on the two-judge round.")
@@ -1314,6 +1329,10 @@ def main():
                     "nonzero on only ~11% of pairs ⇒ region fallback essential). per-region c_mem = ceiling·region.")
     ap.add_argument("--deg-scale", type=float, default=5.0, help="precision mode: data-density scale for the "
                     "per-region c_mem factor min(deg)/(min(deg)+deg_scale) — larger ⇒ needs more edges for confidence.")
+    ap.add_argument("--c-subcat", type=float, default=0.72, help="membership mode: SUBCATEGORY (HIER) membership "
+                    "confidence = corr(μ_HIER, SYM). MEASURED +0.715 (model readout; leakage-inflated — re-measure held-out).")
+    ap.add_argument("--c-elem", type=float, default=0.82, help="membership mode: ELEMENT (ELEM) membership "
+                    "confidence = corr(μ_ELEM, SYM). MEASURED +0.815 — the STRONGEST membership signal; separate from c_subcat.")
     ap.add_argument("--struct-dir", action="store_true", help="DUAL-JUDGE: add the fwd/bwd membership PREDICTORS "
                     "as separate channels (K=3: [3/(1+‖Δ‖), 3/(1+up_hops(a→b)), 3/(1+up_hops(b→a))]) — each with "
                     "its own LEARNED weight (regression; equal-⅓ average is the fixed-weight case). up_hops = DAG "


### PR DESCRIPTION
  ## Summary

  Follow-up to the SYM dual judge (#3464). Two threads:

  1. **Element memberships** — extends the graph judge beyond subcategory-only, adds a `membership` blend mode that
     fuses distance + subcategory + **element** memberships from the model's own readouts.
  2. **A course-correction** — after reviewing the project's estimation PRs (#3356/#3357/#3359/#3387/#3391), the
     hand-set inverse-variance fusion is the wrong shape; the recommended path is the existing calibrated
     `JointPosterior`, with `1/d` as the one genuinely-new source. Captured as a design doc **before** more code.

  This PR is **measurements + a mode + a design decision** — it does not claim a validated model.

  ## What's in it

  **Measurement first (`measure_membership_confidence.py`).** Scored `model_prod.pt`'s HIER/ELEM readouts vs the
  SYM judge:
  - `c_elem = +0.815 > c_subcat = +0.715` (up_hops proxy was +0.669) → **element is the *strongest* membership
    signal**; the `c_subcat`/`c_elem` split is confirmed (gap 0.10); model readout > graph proxy.
  - Honest caveat: measured on training pairs → absolute values leakage-inflated; the *ordering* is the robust part.

  **Sibling finding (measured, documented).** Membership operators are vertical; **siblings have zero membership
  in either direction** yet are related. On 14 562 classified pairs: sibling/cousin = **37%** of pairs, **0%**
  membership coverage, real relatedness (μ 0.13 vs distant 0.00), and `corr(1/d, SYM) = +0.136` there. So `1/d`
  is the **dedicated lateral/sibling channel**, not a generic fallback — the reason the dual judge is complementary.

  **`--struct-blend membership` (the ELEM build).** Fuses `dist(siblings) + subcat + element`, where the
  memberships are the model's `μ_HIER`/`μ_ELEM` readouts (max fwd/bwd), **detached** (stop-grad, so SYM training
  can't corrupt the operators). `membership_readouts()` helper; injected in the SYM train step and `mu_batch` eval
  (gated to SYM). Per-operator confidences `c_subcat`/`c_elem`, region-modulated. λ zero-init ⇒ **exact warm-start
  no-op** (unit-tested); SYM-gated; bounded. Smoke (30 steps, full recipe, warm-start): **no collapse**, `[SYM]`
  held-out corr **+0.445** (baseline +0.41).

  **Course-correction (`DESIGN_sym_estimation_integration.md`).** The hand-set precision/membership fusion is wrong
  on three counts, per the project's own evidence:
  - sources are **correlated** (e5↔model +0.751, #3359) → independence-assuming fusion over-confidences (factored
    equal-weight PoE scored 50.9%, **below** the 51.1% majority);
  - subcat/element are **anti-correlated** (#3359) → their *joint* is the asymmetry, not two additive positives;
  - confidence is a **weak per-query signal** → **margin not level** (#3391), a **gate** not a per-item weight.

  Recommended path (already in-project): the calibrated **`JointPosterior`** (`mu_posterior.py`, #3359) over the
  full μ-vector, gated by margin. The dual-judge work's lasting value is **one source** — `1/d`, decorrelated from
  the model/e5 cluster, carrying the lateral/sibling axis. Build plan: add `1/d` to `mu_posterior.py` and test
  whether it raises held-out separability / lowers AURC.

  **Fix:** `eval_relatedness.build_model` whitelist widened for the merged SYM struct/precision params (so
  `model_prod.pt` loads).

  ## Status of the hand-fusion modes
  `--struct-blend inside|outside|precision|membership` stay as **A/B controls / ablations**, flagged **superseded**
  as the recommended path (`DESIGN_sym_dual_judge.md` now opens with a course-correction banner pointing to the new
  doc). The next PR is the JointPosterior integration.

  ## Testing
  - Unit: warm-start no-op (all modes incl. membership), SYM-gating, [0,1] bounds, per-region weight shift,
    detached memberships.
  - E2E smoke: membership-mode training runs clean, no collapse, `[SYM]` +0.445.

  ## Not in scope / follow-ups
  - The JointPosterior integration + the honest "does `1/d` earn its keep" test (design doc build plan).
  - Held-out re-measurement of the confidences (current numbers are leakage-inflated).
  - Data-limit term done right (#3356 `P(μ|op)` calibration / e5 trained-neighbour density, not graph degree).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)