### PR TITLE
WAM/LLVM (roadmap #5, milestone 3b): term_to_atom/2 runtime builtin (write direction)

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -113,7 +113,8 @@ independently useful (richer hand-written grammars load sooner).
    |---|---|---|
    | `is`/`=`/`==`/comparison, `functor`/`arg`/`=..`, `copy_term`, `atom_codes`/`number_codes`/`char_code`, `sub_atom`/`atom_concat`, `sort`/`msort`/`keysort`, `length`/`append`/`nth`/`reverse`, `sum_list` … | `builtin_call <id>` (id in `builtin_op_to_id`, host-implemented) | **yes** — already in the subset and loader-safe (operate on VM regs/heap + libc) |
    | `findall`/`aggregate_all`, `setof`/`bagof` | `begin_aggregate`/`end_aggregate` (tags 28/29) | **yes, this PR** — opcodes lifted into the subset; setof/bagof additionally need `inline_bagof_setof(true)`, now the `.wamo` default |
-   | `assert`/`asserta`/`assertz`/`retract`, `term_to_atom`/`read_term`/`read_term_from_atom` | `builtin_call <name>` with **no `builtin_op_to_id` entry and no host runtime impl** (writer would emit the unknown-id 200) | **no** — genuinely unimplemented; needs new runtime builtins (milestone 3b). `assert`/`retract` against a loaded object's own clauses is the subtle one — mutable clause state in an arena-rewound VM |
+   | `term_to_atom/2` (write direction) | `builtin_call term_to_atom/2` (id 173) → `@wam_term_to_sb` | **yes, milestone 3b** — a recursive term→text writer into a growable buffer, interned as an atom. Works in loaded objects too: cons detection is by functor *bytes*, not pointer identity. Unquoted (write semantics), so it does not yet round-trip through a reader |
+   | `assert`/`asserta`/`assertz`/`retract`, `read_term`/`read_term_from_atom`, `term_to_atom/2` (read direction) | `builtin_call <name>` with **no `builtin_op_to_id` entry and no host runtime impl** | **no** — needs new runtime machinery. The reader (`read_term`) is a tokenizer + operator-precedence parser (milestone 3b-read). `assert`/`retract` against a loaded object's own clauses is the subtle one — mutable clause state in an arena-rewound VM (milestone 3b-db) |
    | `catch`/`throw` | `execute catch/3` — a call to a runtime *library predicate*, not a builtin | **no** — the loaded object references `catch/3`, which lives in the host, not the object; needs cross-object/host predicate linkage (milestone 3c) |
 
    **Landed here:** the aggregate opcodes, verified end-to-end — `findall`,
@@ -125,9 +126,17 @@ independently useful (richer hand-written grammars load sooner).
    separately, and not a blocker since compiler-style `findall` iterates over
    predicates, not `member`.
 
-   **Remaining (3b/3c):** `assert`/`retract`/`term_to_atom`/`read_term` runtime
-   builtins, and `catch`/`throw` predicate linkage. These are the true long
-   pole for self-hosting the compiler.
+   **Also landed (milestone 3b):** `term_to_atom/2` in the *write* direction —
+   a recursive term→text writer (`@wam_term_to_sb`) into a growable buffer,
+   interned as an atom. Verified in both AOT and loaded objects; the byte-based
+   cons detection (`@wam_functor_is_cons`) makes list rendering correct across
+   the loader boundary despite each object carrying its own functor copies.
+
+   **Remaining:** the *reader* — `read_term` / `term_to_atom` read direction, a
+   tokenizer + operator-precedence parser (3b-read); `assert`/`retract` with a
+   dynamic clause store (3b-db); and `catch`/`throw` predicate linkage (3c).
+   These are the true long pole for self-hosting the compiler — each is its own
+   substantial effort, not a subset lift.
 4. **Byte-buffer output from a grammar.** The compiler object must *emit*
    `.wamo` bytes. It returns them as an Atom/byte string (the item-2 blob
    bridge already carries bytes out); building that byte string inside the

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -323,10 +323,12 @@ loadable along the way.
   builtins, library-predicate calls). Landed this PR: **aggregate control**
   `begin_aggregate`/`end_aggregate` into the loadable subset, so `findall`,
   `setof` and `bagof` over user-predicate goals load and run from a `.wamo`
-  (setof/bagof via `inline_bagof_setof`, now the `.wamo` default). Remaining:
-  `assert`/`retract`/`term_to_atom`/`read_term` runtime builtins (3b) and
-  `catch`/`throw` predicate linkage (3c) — the true long pole. See the
-  bootstrap doc for the full loadability matrix.
+  (setof/bagof via `inline_bagof_setof`, now the `.wamo` default). Milestone 3b
+  adds `term_to_atom/2` (write direction) — a recursive term→text writer that
+  works in loaded objects (byte-based cons detection). Remaining: the reader
+  (`read_term` / `term_to_atom` read direction — a parser), `assert`/`retract`
+  (a dynamic clause store), and `catch`/`throw` predicate linkage (3c) — the
+  true long pole. See the bootstrap doc for the full loadability matrix.
 - **Milestones 4–6** (byte-buffer output, the `eval`/`compile` surface,
   self-host) — see the bootstrap doc.
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -6180,6 +6180,243 @@ usp.done:
 ;   10 = !/0, 11 = write/1, 12 = nl/0
 ;   13 = atom/1, 14 = integer/1, 15 = float/1, 16 = number/1
 ;   17 = compound/1, 18 = var/1, 19 = nonvar/1, 20 = is_list/1
+; === term_to_atom/2 support ===
+; A malloc-backed growable string buffer and a recursive term writer. The
+; writer renders a %Value with write/1 (unquoted) semantics; term_to_atom
+; then interns the buffer as an Atom. Unquoted means atoms needing quotes do
+; not yet round-trip through a reader -- the reader (read_term) is a separate
+; milestone; canonical output for the common case (foo(1,[a,b])) is correct.
+
+define void @wam_sb_reserve(%WamStrBuf* %sb, i64 %need) {
+entry:
+  %len_ptr = getelementptr %WamStrBuf, %WamStrBuf* %sb, i32 0, i32 1
+  %len = load i64, i64* %len_ptr
+  %cap_ptr = getelementptr %WamStrBuf, %WamStrBuf* %sb, i32 0, i32 2
+  %cap = load i64, i64* %cap_ptr
+  %want = add i64 %len, %need
+  %ok = icmp ule i64 %want, %cap
+  br i1 %ok, label %done, label %grow
+grow:
+  %cap2 = mul i64 %cap, 2
+  %use2 = icmp ugt i64 %cap2, %want
+  %newcap = select i1 %use2, i64 %cap2, i64 %want
+  %data_ptr = getelementptr %WamStrBuf, %WamStrBuf* %sb, i32 0, i32 0
+  %data = load i8*, i8** %data_ptr
+  %ndata = call i8* @realloc(i8* %data, i64 %newcap)
+  store i8* %ndata, i8** %data_ptr
+  store i64 %newcap, i64* %cap_ptr
+  br label %done
+done:
+  ret void
+}
+
+define void @wam_sb_putc(%WamStrBuf* %sb, i8 %c) {
+entry:
+  call void @wam_sb_reserve(%WamStrBuf* %sb, i64 1)
+  %data_ptr = getelementptr %WamStrBuf, %WamStrBuf* %sb, i32 0, i32 0
+  %data = load i8*, i8** %data_ptr
+  %len_ptr = getelementptr %WamStrBuf, %WamStrBuf* %sb, i32 0, i32 1
+  %len = load i64, i64* %len_ptr
+  %dst = getelementptr i8, i8* %data, i64 %len
+  store i8 %c, i8* %dst
+  %len1 = add i64 %len, 1
+  store i64 %len1, i64* %len_ptr
+  ret void
+}
+
+define void @wam_sb_puts(%WamStrBuf* %sb, i8* %s) {
+entry:
+  br label %measure
+measure:
+  %n = phi i64 [ 0, %entry ], [ %n1, %mstep ]
+  %p = getelementptr i8, i8* %s, i64 %n
+  %ch = load i8, i8* %p
+  %z = icmp eq i8 %ch, 0
+  br i1 %z, label %copy, label %mstep
+mstep:
+  %n1 = add i64 %n, 1
+  br label %measure
+copy:
+  call void @wam_sb_reserve(%WamStrBuf* %sb, i64 %n)
+  %data_ptr = getelementptr %WamStrBuf, %WamStrBuf* %sb, i32 0, i32 0
+  %data = load i8*, i8** %data_ptr
+  %len_ptr = getelementptr %WamStrBuf, %WamStrBuf* %sb, i32 0, i32 1
+  %len = load i64, i64* %len_ptr
+  %dst = getelementptr i8, i8* %data, i64 %len
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dst, i8* %s, i64 %n, i1 false)
+  %len1 = add i64 %len, %n
+  store i64 %len1, i64* %len_ptr
+  ret void
+}
+
+; True iff the functor name is the cons functor "[|]". Compares by bytes, not
+; pointer identity: a loaded .wamo object builds list cells with its OWN
+; malloc''d "[|]" copy, distinct from the host @.fn__5B_7C_5D global, so a
+; pointer compare would misclassify lists in loaded objects as ordinary
+; compounds and render [a,b] as [|](a,[|](b,[])).
+define i1 @wam_functor_is_cons(i8* %fn) {
+entry:
+  %isnull = icmp eq i8* %fn, null
+  br i1 %isnull, label %no, label %c0
+c0:
+  %p0 = getelementptr i8, i8* %fn, i64 0
+  %b0 = load i8, i8* %p0
+  %e0 = icmp eq i8 %b0, 91
+  br i1 %e0, label %c1, label %no
+c1:
+  %p1 = getelementptr i8, i8* %fn, i64 1
+  %b1 = load i8, i8* %p1
+  %e1 = icmp eq i8 %b1, 124
+  br i1 %e1, label %c2, label %no
+c2:
+  %p2 = getelementptr i8, i8* %fn, i64 2
+  %b2 = load i8, i8* %p2
+  %e2 = icmp eq i8 %b2, 93
+  br i1 %e2, label %c3, label %no
+c3:
+  %p3 = getelementptr i8, i8* %fn, i64 3
+  %b3 = load i8, i8* %p3
+  %e3 = icmp eq i8 %b3, 0
+  br i1 %e3, label %yes, label %no
+yes:
+  ret i1 true
+no:
+  ret i1 false
+}
+
+define void @wam_term_to_sb(%WamState* %vm, %Value %v, %WamStrBuf* %sb) {
+entry:
+  %d = call %Value @wam_deref_value(%WamState* %vm, %Value %v)
+  %tag = extractvalue %Value %d, 0
+  switch i32 %tag, label %t_unbound [
+    i32 0, label %t_atom
+    i32 1, label %t_int
+    i32 2, label %t_float
+    i32 3, label %t_compound
+  ]
+t_int:
+  %iv = extractvalue %Value %d, 1
+  %iscr = alloca [32 x i8]
+  %iscr0 = getelementptr [32 x i8], [32 x i8]* %iscr, i32 0, i32 0
+  %ifmt = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
+  call i32 (i8*, i64, i8*, ...) @snprintf(i8* %iscr0, i64 32, i8* %ifmt, i64 %iv)
+  call void @wam_sb_puts(%WamStrBuf* %sb, i8* %iscr0)
+  ret void
+t_float:
+  %fb = extractvalue %Value %d, 1
+  %fv = bitcast i64 %fb to double
+  %fscr = alloca [32 x i8]
+  %fscr0 = getelementptr [32 x i8], [32 x i8]* %fscr, i32 0, i32 0
+  %ffmt = getelementptr [3 x i8], [3 x i8]* @.fmt_dbl, i32 0, i32 0
+  call i32 (i8*, i64, i8*, ...) @snprintf(i8* %fscr0, i64 32, i8* %ffmt, double %fv)
+  call void @wam_sb_puts(%WamStrBuf* %sb, i8* %fscr0)
+  ret void
+t_atom:
+  %aid = extractvalue %Value %d, 1
+  %eid = load i64, i64* @wam_empty_list_atom_id
+  %is_empty = icmp eq i64 %aid, %eid
+  br i1 %is_empty, label %t_atom_empty, label %t_atom_str
+t_atom_empty:
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 91)
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 93)
+  ret void
+t_atom_str:
+  %astr = call i8* @wam_atom_to_string(i64 %aid)
+  %anull = icmp eq i8* %astr, null
+  br i1 %anull, label %t_atom_q, label %t_atom_go
+t_atom_go:
+  call void @wam_sb_puts(%WamStrBuf* %sb, i8* %astr)
+  ret void
+t_atom_q:
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 63)
+  ret void
+t_unbound:
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 95)
+  ret void
+t_compound:
+  %cpb = extractvalue %Value %d, 1
+  %cp = inttoptr i64 %cpb to %Compound*
+  %fn_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 0
+  %fn = load i8*, i8** %fn_slot
+  %ar_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 1
+  %ar = load i32, i32* %ar_slot
+  %args_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 2
+  %args = load %Value*, %Value** %args_slot
+  %is_list = call i1 @wam_functor_is_cons(i8* %fn)
+  br i1 %is_list, label %t_list, label %t_functor
+t_functor:
+  call void @wam_sb_puts(%WamStrBuf* %sb, i8* %fn)
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 40)
+  br label %t_arg_loop
+t_arg_loop:
+  %ai = phi i32 [ 0, %t_functor ], [ %ai1, %t_arg_next ]
+  %adone = icmp sge i32 %ai, %ar
+  br i1 %adone, label %t_functor_end, label %t_arg_body
+t_arg_body:
+  %first = icmp eq i32 %ai, 0
+  br i1 %first, label %t_arg_write, label %t_arg_comma
+t_arg_comma:
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 44)
+  br label %t_arg_write
+t_arg_write:
+  %ap = getelementptr %Value, %Value* %args, i32 %ai
+  %av = load %Value, %Value* %ap
+  call void @wam_term_to_sb(%WamState* %vm, %Value %av, %WamStrBuf* %sb)
+  br label %t_arg_next
+t_arg_next:
+  %ai1 = add i32 %ai, 1
+  br label %t_arg_loop
+t_functor_end:
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 41)
+  ret void
+t_list:
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 91)
+  %h0p = getelementptr %Value, %Value* %args, i32 0
+  %h0 = load %Value, %Value* %h0p
+  call void @wam_term_to_sb(%WamState* %vm, %Value %h0, %WamStrBuf* %sb)
+  %t0p = getelementptr %Value, %Value* %args, i32 1
+  %t0 = load %Value, %Value* %t0p
+  br label %t_list_walk
+t_list_walk:
+  %cur = phi %Value [ %t0, %t_list ], [ %curnext, %t_list_step ]
+  %curd = call %Value @wam_deref_value(%WamState* %vm, %Value %cur)
+  %curtag = extractvalue %Value %curd, 0
+  %cur_is_atom = icmp eq i32 %curtag, 0
+  br i1 %cur_is_atom, label %t_list_end_chk, label %t_list_cons_chk
+t_list_end_chk:
+  %curaid = extractvalue %Value %curd, 1
+  %eid2 = load i64, i64* @wam_empty_list_atom_id
+  %is_end = icmp eq i64 %curaid, %eid2
+  br i1 %is_end, label %t_list_done, label %t_list_improper
+t_list_cons_chk:
+  %cur_is_cmp = icmp eq i32 %curtag, 3
+  br i1 %cur_is_cmp, label %t_list_cons_chk2, label %t_list_improper
+t_list_cons_chk2:
+  %curcpb = extractvalue %Value %curd, 1
+  %curcp = inttoptr i64 %curcpb to %Compound*
+  %curfn_slot = getelementptr %Compound, %Compound* %curcp, i32 0, i32 0
+  %curfn = load i8*, i8** %curfn_slot
+  %cur_is_list = call i1 @wam_functor_is_cons(i8* %curfn)
+  br i1 %cur_is_list, label %t_list_step, label %t_list_improper
+t_list_step:
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 44)
+  %curargs_slot = getelementptr %Compound, %Compound* %curcp, i32 0, i32 2
+  %curargs = load %Value*, %Value** %curargs_slot
+  %curhp = getelementptr %Value, %Value* %curargs, i32 0
+  %curh = load %Value, %Value* %curhp
+  call void @wam_term_to_sb(%WamState* %vm, %Value %curh, %WamStrBuf* %sb)
+  %curtp = getelementptr %Value, %Value* %curargs, i32 1
+  %curnext = load %Value, %Value* %curtp
+  br label %t_list_walk
+t_list_improper:
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 124)
+  call void @wam_term_to_sb(%WamState* %vm, %Value %curd, %WamStrBuf* %sb)
+  br label %t_list_done
+t_list_done:
+  call void @wam_sb_putc(%WamStrBuf* %sb, i8 93)
+  ret void
+}
+
 define i1 @execute_builtin(%WamState* %vm, i32 %op, i32 %arity) {
 entry:
   switch i32 %op, label %unknown [
@@ -6259,6 +6496,7 @@ entry:
     i32 74, label %builtin_atomic_list_concat3
     i32 75, label %builtin_char_type
     i32 172, label %builtin_code_type
+    i32 173, label %builtin_term_to_atom
     i32 76, label %builtin_compare
     i32 77, label %builtin_must_be
     i32 78, label %builtin_write
@@ -15628,6 +15866,29 @@ mb.bool_full_cmp:
 mb.bool_no:
   ret i1 false
 
+builtin_term_to_atom:
+  ; term_to_atom(+Term, ?Atom): render Term (write semantics) into a growable
+  ; buffer, intern it, and unify the result Atom with A2.
+  %tta.term = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %tta.sb = alloca %WamStrBuf
+  %tta.init = call i8* @malloc(i64 64)
+  %tta.data_ptr = getelementptr %WamStrBuf, %WamStrBuf* %tta.sb, i32 0, i32 0
+  store i8* %tta.init, i8** %tta.data_ptr
+  %tta.len_ptr = getelementptr %WamStrBuf, %WamStrBuf* %tta.sb, i32 0, i32 1
+  store i64 0, i64* %tta.len_ptr
+  %tta.cap_ptr = getelementptr %WamStrBuf, %WamStrBuf* %tta.sb, i32 0, i32 2
+  store i64 64, i64* %tta.cap_ptr
+  call void @wam_term_to_sb(%WamState* %vm, %Value %tta.term, %WamStrBuf* %tta.sb)
+  %tta.data = load i8*, i8** %tta.data_ptr
+  %tta.len = load i64, i64* %tta.len_ptr
+  %tta.id = call i64 @wam_intern_atom(i8* %tta.data, i64 %tta.len)
+  call void @free(i8* %tta.data)
+  %tta.v0 = insertvalue %Value undef, i32 0, 0
+  %tta.v = insertvalue %Value %tta.v0, i64 %tta.id, 1
+  %tta.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %tta.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %tta.raw2, %Value %tta.v)
+  ret i1 %tta.ok
+
 unknown:
   ret i1 false
 }',
@@ -19258,6 +19519,7 @@ builtin_op_to_id('atom_starts_with/2', 169).  % prefix check via memcmp.
 builtin_op_to_id('atom_ends_with/2', 170).    % suffix check via memcmp.
 builtin_op_to_id('atom_contains/2', 171).     % substring check via strstr.
 builtin_op_to_id('code_type/2', 172).        % ASCII class check; shares char_type's classifier.
+builtin_op_to_id('term_to_atom/2', 173).     % render a term to its text (write semantics) and intern as an atom.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/templates/targets/llvm_wam/types.ll.mustache
+++ b/templates/targets/llvm_wam/types.ll.mustache
@@ -10,6 +10,10 @@
 %WamSlice = type { i8*, i64 }             ; pointer, length
 %WamI64Parse = type { i64, i1 }           ; parsed value, success flag
 
+; === Growable string buffer ===
+; Used by term_to_atom/2 to render a term's text before interning it.
+%WamStrBuf = type { i8*, i64, i64 }       ; data, len, cap
+
 ; === Compound and List (heap-allocated) ===
 %Compound = type { i8*, i32, %Value* }    ; functor, arity, args
 %List = type { i32, %Value* }             ; length, elements

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -74,6 +74,12 @@ bagcard(N)    :- bagof(X, agnum(X), L), length(L, N).      % 4 solutions -> 4
 noagg(_) :- fail.
 emptycount(N) :- findall(X, noagg(X), L), length(L, N).    % [] -> 0
 
+% term_to_atom/2 (eval bootstrap milestone 3b): render a term to its text and
+% intern it. Exercises nested compound + list rendering; list detection is by
+% functor bytes, not pointer identity, so it works with the loaded object's
+% own functor copies (a pointer compare would mis-render [x,y,z]).
+ttalen(N) :- term_to_atom(pt(3, [x,y,z]), A), atom_length(A, N).  % "pt(3,[x,y,z])" -> 13
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -325,6 +331,19 @@ test(empty_aggregate_terminates,
     ( exists_file(Host) -> true ; build_host(Dir, Host) ),
     run_host(Host, Wamo, Out, 0),
     assertion(Out == "0\n"),
+    !.
+
+% term_to_atom in a loaded object renders pt(3,[x,y,z]) -> 13 chars. Verifies
+% the byte-based cons detection works with the object's own functor copies.
+test(term_to_atom_in_object,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'ttalen.wamo', Wamo),
+    write_wam_object([user:ttalen/1], [wamo_entry(ttalen/1)], Wamo),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "13\n"),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
First of the milestone-3b builtins the compiler-as-`.wamo` bootstrap needs: **`term_to_atom/2` in the write direction** — render a term to its canonical text (write/1 semantics) and intern it as an atom. Added to the WAM/LLVM runtime, so it works both AOT and in loaded `.wamo` objects.

## Mechanism

- `%WamStrBuf` — a malloc-backed growable string buffer, with `@wam_sb_reserve`/`putc`/`puts` helpers.
- `@wam_term_to_sb` — a recursive term writer walking a `%Value`: atoms, integers (`snprintf %lld`), floats (`%g`), compounds as `functor(a,b,…)`, and proper/improper lists as `[a,b|t]`.
- `builtin_term_to_atom` (id 173) renders into the buffer, interns via `@wam_intern_atom`, and unifies the result atom with the second argument.

## The loaded-object subtlety (and fix)

List detection can't compare the functor pointer against the host's `@.fn__5B_7C_5D` global — a loaded object builds its list cells with its **own** malloc'd `"[|]"` copy (the same functor-identity issue as milestone 2). A pointer compare mis-renders `[x,y,z]` as `[|](x,[|](y,[|](z,[])))`.

Fix: `@wam_functor_is_cons` compares the functor by **bytes** (`"[|]"`), so list rendering is correct across the loader boundary. (Observed concretely: the loaded-object test returned length 29 before the byte-based fix, 13 after.)

## Scope

**This is the write direction only.** The remaining 3b work is larger and each piece is its own effort, not a subset lift:
- **The reader** (`read_term` / `term_to_atom` read direction) — a tokenizer + operator-precedence parser.
- **`assert`/`retract`** — a dynamic clause store (the subtle one: mutable clause state in an arena-rewound VM).
- **`catch`/`throw`** (3c) — cross-object/host predicate linkage.

Documented in the bootstrap doc's loadability matrix.

## Changes

- `templates/targets/llvm_wam/types.ll.mustache` — `%WamStrBuf`.
- `src/unifyweaver/targets/wam_llvm_target.pl` — `@wam_sb_*`, `@wam_functor_is_cons`, `@wam_term_to_sb`, the `builtin_term_to_atom` case + switch entry (id 173), and `builtin_op_to_id('term_to_atom/2', 173)`.
- `tests/test_wam_object.pl` — `term_to_atom_in_object`: `pt(3,[x,y,z])` → a 13-char atom in a loaded object.
- docs — milestone 3b in the roadmap and bootstrap doc.

## Testing

- AOT: `foo(1,[a,b],bar(2.5))` renders exactly.
- Loaded object: `pt(3,[x,y,z])` → length 13.
- Full `wam_object`, `wam_llvm_target`, `wam_llvm_meta_call_runtime`, `plawk_functions`, and `dyncall` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_