### PR TITLE
WAM/LLVM (roadmap #5, milestone 3b): read_term_from_atom/2 — term reader, first increment (atomic terms)

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -125,9 +125,24 @@ independently useful (richer hand-written grammars load sooner).
    separately, and not a blocker since compiler-style `findall` iterates over
    predicates, not `member`.
 
-   **Remaining (3b/3c):** `assert`/`retract`/`term_to_atom`/`read_term` runtime
-   builtins, and `catch`/`throw` predicate linkage. These are the true long
-   pole for self-hosting the compiler.
+   **Reader, first increment (milestone 3b):** `read_term_from_atom/2` parses
+   **atomic** canonical terms — integers (optional leading `-`) and unquoted
+   atoms — via `@wam_parse_atomic`, returning a real Integer/Atom `%Value`.
+   Verified in a loaded object (parse `"40"`, add 2 → 42). Compounds, lists,
+   floats, variables and operators are follow-up increments: they need the
+   recursive descent parser **plus functor-pointer canonicalization** —
+   unification compares compound functors by pointer (`icmp eq i8*`), so a
+   reader-built functor must resolve to the same pointer the rest of the
+   runtime uses. `=..` compose mode wrestles with the same problem (a trail of
+   fixes: "did not compare equal to a literal"); the analogous *atom* case
+   (a dynamically-interned atom vs a source-baked literal) already shows up
+   under `==`/`atom_concat`, independent of the reader. Resolving that
+   canonicalization is the gating design task for the compound reader.
+
+   **Remaining (3b/3c):** the compound/list/operator reader (with functor
+   canonicalization), `assert`/`retract` (a dynamic clause store), and
+   `catch`/`throw` predicate linkage. These are the true long pole for
+   self-hosting the compiler.
 4. **Byte-buffer output from a grammar.** The compiler object must *emit*
    `.wamo` bytes. It returns them as an Atom/byte string (the item-2 blob
    bridge already carries bytes out); building that byte string inside the

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -6180,6 +6180,120 @@ usp.done:
 ;   10 = !/0, 11 = write/1, 12 = nl/0
 ;   13 = atom/1, 14 = integer/1, 15 = float/1, 16 = number/1
 ;   17 = compound/1, 18 = var/1, 19 = nonvar/1, 20 = is_list/1
+; === read_term_from_atom/2 support (the term reader, first increment) ===
+; Parses ATOMIC canonical terms only -- integers (optional leading -) and
+; unquoted atoms. Compounds, lists, floats, variables and operators are
+; follow-up increments: they need the recursive parser plus functor-pointer
+; canonicalization (unification compares compound functors by pointer, so a
+; reader-built functor must resolve to the same pointer the rest of the
+; runtime uses -- the same problem =.. compose mode wrestles with). Atomic
+; terms carry no functor pointer, so this slice is unambiguously correct.
+
+define i1 @wam_byte_is_ws(i8 %c) {
+entry:
+  %a = icmp eq i8 %c, 32
+  %b = icmp eq i8 %c, 9
+  %d = icmp eq i8 %c, 10
+  %e = icmp eq i8 %c, 13
+  %ab = or i1 %a, %b
+  %de = or i1 %d, %e
+  %r = or i1 %ab, %de
+  ret i1 %r
+}
+
+; Parse the first whitespace-delimited token of %s as an atomic term. Returns
+; an Integer or Atom %Value, or an Unbound %Value (tag 6) to signal failure.
+define %Value @wam_parse_atomic(i8* %s) {
+entry:
+  br label %len_loop
+len_loop:
+  %li = phi i64 [ 0, %entry ], [ %li1, %len_step ]
+  %lp = getelementptr i8, i8* %s, i64 %li
+  %lc = load i8, i8* %lp
+  %lz = icmp eq i8 %lc, 0
+  br i1 %lz, label %skip_ws, label %len_step
+len_step:
+  %li1 = add i64 %li, 1
+  br label %len_loop
+skip_ws:
+  br label %sw_loop
+sw_loop:
+  %start = phi i64 [ 0, %skip_ws ], [ %start1, %sw_step ]
+  %sw_end = icmp uge i64 %start, %li
+  br i1 %sw_end, label %pfail, label %sw_check
+sw_check:
+  %sp = getelementptr i8, i8* %s, i64 %start
+  %sc = load i8, i8* %sp
+  %sws = call i1 @wam_byte_is_ws(i8 %sc)
+  br i1 %sws, label %sw_step, label %find_end
+sw_step:
+  %start1 = add i64 %start, 1
+  br label %sw_loop
+find_end:
+  br label %fe_loop
+fe_loop:
+  %tend = phi i64 [ %start, %find_end ], [ %tend1, %fe_step ]
+  %fe_at_end = icmp uge i64 %tend, %li
+  br i1 %fe_at_end, label %classify, label %fe_check
+fe_check:
+  %tp = getelementptr i8, i8* %s, i64 %tend
+  %tc = load i8, i8* %tp
+  %tws = call i1 @wam_byte_is_ws(i8 %tc)
+  br i1 %tws, label %classify, label %fe_step
+fe_step:
+  %tend1 = add i64 %tend, 1
+  br label %fe_loop
+classify:
+  %tlen = sub i64 %tend, %start
+  %tlen0 = icmp eq i64 %tlen, 0
+  br i1 %tlen0, label %pfail, label %chk_int
+chk_int:
+  %fp = getelementptr i8, i8* %s, i64 %start
+  %fc = load i8, i8* %fp
+  %is_minus = icmp eq i8 %fc, 45
+  %ds0 = zext i1 %is_minus to i64
+  %dstart = add i64 %start, %ds0
+  %minus_only = icmp uge i64 %dstart, %tend
+  br i1 %minus_only, label %as_atom, label %int_scan
+int_scan:
+  br label %is_loop
+is_loop:
+  %isi = phi i64 [ %dstart, %int_scan ], [ %isi1, %is_step ]
+  %acc = phi i64 [ 0, %int_scan ], [ %acc1, %is_step ]
+  %is_done = icmp uge i64 %isi, %tend
+  br i1 %is_done, label %make_int, label %is_check
+is_check:
+  %isp = getelementptr i8, i8* %s, i64 %isi
+  %isc = load i8, i8* %isp
+  %ge0 = icmp uge i8 %isc, 48
+  %le9 = icmp ule i8 %isc, 57
+  %isd = and i1 %ge0, %le9
+  br i1 %isd, label %is_step, label %as_atom
+is_step:
+  %dig = sub i8 %isc, 48
+  %dig64 = zext i8 %dig to i64
+  %acc10 = mul i64 %acc, 10
+  %acc1 = add i64 %acc10, %dig64
+  %isi1 = add i64 %isi, 1
+  br label %is_loop
+make_int:
+  %neg = sub i64 0, %acc
+  %val_i = select i1 %is_minus, i64 %neg, i64 %acc
+  %iv0 = insertvalue %Value undef, i32 1, 0
+  %iv = insertvalue %Value %iv0, i64 %val_i, 1
+  ret %Value %iv
+as_atom:
+  %astart = getelementptr i8, i8* %s, i64 %start
+  %aid = call i64 @wam_intern_atom(i8* %astart, i64 %tlen)
+  %av0 = insertvalue %Value undef, i32 0, 0
+  %av = insertvalue %Value %av0, i64 %aid, 1
+  ret %Value %av
+pfail:
+  %uv0 = insertvalue %Value undef, i32 6, 0
+  %uv = insertvalue %Value %uv0, i64 0, 1
+  ret %Value %uv
+}
+
 define i1 @execute_builtin(%WamState* %vm, i32 %op, i32 %arity) {
 entry:
   switch i32 %op, label %unknown [
@@ -6259,6 +6373,7 @@ entry:
     i32 74, label %builtin_atomic_list_concat3
     i32 75, label %builtin_char_type
     i32 172, label %builtin_code_type
+    i32 174, label %builtin_read_term_from_atom
     i32 76, label %builtin_compare
     i32 77, label %builtin_must_be
     i32 78, label %builtin_write
@@ -15628,6 +15743,30 @@ mb.bool_full_cmp:
 mb.bool_no:
   ret i1 false
 
+builtin_read_term_from_atom:
+  ; read_term_from_atom(+Atom, -Term): parse the atom text (atomic terms only
+  ; in this increment) and unify the result with A2.
+  %rta.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %rta.tag = extractvalue %Value %rta.a1, 0
+  %rta.is_atom = icmp eq i32 %rta.tag, 0
+  br i1 %rta.is_atom, label %rta.go, label %rta.fail
+rta.go:
+  %rta.aid = extractvalue %Value %rta.a1, 1
+  %rta.str = call i8* @wam_atom_to_string(i64 %rta.aid)
+  %rta.snull = icmp eq i8* %rta.str, null
+  br i1 %rta.snull, label %rta.fail, label %rta.parse
+rta.parse:
+  %rta.val = call %Value @wam_parse_atomic(i8* %rta.str)
+  %rta.vtag = extractvalue %Value %rta.val, 0
+  %rta.pfail = icmp eq i32 %rta.vtag, 6
+  br i1 %rta.pfail, label %rta.fail, label %rta.unify
+rta.unify:
+  %rta.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %rta.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %rta.raw2, %Value %rta.val)
+  ret i1 %rta.ok
+rta.fail:
+  ret i1 false
+
 unknown:
   ret i1 false
 }',
@@ -19258,6 +19397,7 @@ builtin_op_to_id('atom_starts_with/2', 169).  % prefix check via memcmp.
 builtin_op_to_id('atom_ends_with/2', 170).    % suffix check via memcmp.
 builtin_op_to_id('atom_contains/2', 171).     % substring check via strstr.
 builtin_op_to_id('code_type/2', 172).        % ASCII class check; shares char_type's classifier.
+builtin_op_to_id('read_term_from_atom/2', 174). % parse an atom's text into a term (atomic terms only, for now).
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2756,6 +2756,7 @@ is_builtin_pred(split_string, 4). % split string by separator chars.
 is_builtin_pred(term_to_atom, 2). % bidirectional canonical-form term ↔ atom.
 is_builtin_pred(read, 1).         % stdin: read a term terminated by `.`.
 is_builtin_pred(read_term, 1).    % alias for read/1.
+is_builtin_pred(read_term_from_atom, 2). % parse an atom's text into a term (WAM/LLVM: atomic terms).
 is_builtin_pred(get_char, 1).     % stdin: read one char as atom.
 is_builtin_pred(get_char, 2).     % stream: read one char as atom.
 is_builtin_pred(get_code, 1).     % stdin: read one char as int code.

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -74,6 +74,12 @@ bagcard(N)    :- bagof(X, agnum(X), L), length(L, N).      % 4 solutions -> 4
 noagg(_) :- fail.
 emptycount(N) :- findall(X, noagg(X), L), length(L, N).    % [] -> 0
 
+% read_term_from_atom/2 (eval bootstrap milestone 3b, reader -- first
+% increment: atomic terms). Parse an integer from text at runtime and use it
+% arithmetically -- proving the parse yields a real Integer, in a loaded
+% object. Compounds/lists/floats/operators are follow-up increments.
+readint_obj(R) :- read_term_from_atom('40', T), R is T + 2.  % -> 42
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -325,6 +331,19 @@ test(empty_aggregate_terminates,
     ( exists_file(Host) -> true ; build_host(Dir, Host) ),
     run_host(Host, Wamo, Out, 0),
     assertion(Out == "0\n"),
+    !.
+
+% read_term_from_atom in a loaded object: parse "40" at runtime, add 2 -> 42.
+% Proves the parse yields a genuine Integer usable in arithmetic.
+test(read_term_from_atom_in_object,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'readint.wamo', Wamo),
+    write_wam_object([user:readint_obj/1], [wamo_entry(readint_obj/1)], Wamo),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "42\n"),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
Begins the **term reader** — the eval bootstrap's genuine long pole (the compiler must parse source text). First increment: `read_term_from_atom(+Atom, -Term)` parses **atomic** canonical terms — integers (optional leading `-`) and unquoted atoms — into a real Integer/Atom `%Value`.

## Mechanism

- `@wam_byte_is_ws` + `@wam_parse_atomic` scan the first whitespace-delimited token, classify it as `-?[0-9]+` (Integer) or otherwise an Atom (interned via `@wam_intern_atom`), and return an Unbound sentinel on empty input.
- Builtin id 174 dispatches to it; `read_term_from_atom/2` is whitelisted in `wam_target:is_builtin_pred` so the compiler emits `builtin_call` for it (unlike `term_to_atom/2`, SWI's real `read_term_from_atom` is arity 3, so it isn't auto-recognized).

## Scope — atomic terms only, and why

Compounds, lists, floats, variables and operators are deliberate follow-ups. Investigating them surfaced the **gating design task** for the compound reader:

> Unification compares compound functors by **pointer** (`icmp eq i8*`), so a reader-built compound's functor must be canonicalized to the same pointer the rest of the runtime uses.

`=..` compose mode already wrestles with exactly this (a trail of fixes: *"did not compare equal to a literal"*). The analogous **atom** case — a dynamically-interned atom vs a source-baked literal — already fails under `==`/`atom_concat`, **independent of the reader** (I verified: `atom_concat(gr,een,T), T==green` exhibits the same behavior). So it's a pre-existing representation matter, not something this increment introduces.

Atomic terms carry no functor pointer, so this slice is unambiguously correct and fully testable. Resolving the functor/atom canonicalization is the next reader increment's central task.

## Changes

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@wam_byte_is_ws`, `@wam_parse_atomic`, the `builtin_read_term_from_atom` case + switch entry (id 174), and `builtin_op_to_id('read_term_from_atom/2', 174)`.
- `src/unifyweaver/targets/wam_target.pl` — whitelist `read_term_from_atom/2`.
- `tests/test_wam_object.pl` — `read_term_from_atom_in_object`: parse `"40"` in a loaded object, add 2 → 42.
- docs — reader first increment + the functor-canonicalization gating note.

## Testing

- AOT: `read_term_from_atom('42',T), T+100` → 142; `'-7'` negated → 7; `'hello'` → `atom_length` 5.
- Loaded object: `'40'`+2 → 42.
- Full `wam_object`, `wam_llvm_target`, `wam_llvm_meta_call_runtime`, `plawk_functions`, `dyncall` suites pass.

Note: id 174 is used here (173 is `term_to_atom/2` on the sibling milestone-3b PR) so the two don't collide when both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_