### PR TITLE
WAM/LLVM (roadmap #5, milestone 3b): variables in the term reader

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -160,11 +160,21 @@ independently useful (richer hand-written grammars load sooner).
    evaluator dispatches on the functor bytes (so it reads reader-built
    `+`/`*`/`-` compounds directly).
 
-   **Remaining (3b/3c):** control operators (`,` `;` `->` `:-`), floats,
-   variables (a per-parse var dictionary), and quoted atoms in the reader;
-   `assert`/`retract` (a dynamic clause store); and `catch`/`throw` predicate
-   linkage. Variables and `:-`/`,` are the next step toward parsing whole
-   clauses. These remain the long pole for self-hosting the compiler.
+   **Variables (milestone 3b):** a per-parse var-dictionary (a transient block
+   hung off `%WamState` field 27, set by `read_term_from_atom` while parsing).
+   A name led by an uppercase letter or `_` is a variable; `@wam_var_ref`
+   interns the name and looks it up in the dict so repeated occurrences share
+   one fresh heap cell (`X` in `p(X,X)`), while anonymous `_` is always a fresh,
+   unshared cell. Reader variables are bound by unifying the parsed *term* (they
+   have no connection to the surrounding clause's variables). Verified in loaded
+   objects: `p(X,X)` binds both from one unify (→9), shared var through
+   arithmetic (→42), anonymous `q(_,_) = q(3,4)` succeeds (distinct).
+
+   **Remaining (3b/3c):** control operators (`,` `;` `->` `:-` — the layer that
+   turns parsed goals into clause bodies), floats, and quoted atoms in the
+   reader; `assert`/`retract` (a dynamic clause store); and `catch`/`throw`
+   predicate linkage. With variables done, `:-`/`,` are the last reader piece
+   before a whole clause parses. These remain the long pole for self-hosting.
 4. **Byte-buffer output from a grammar.** The compiler object must *emit*
    `.wamo` bytes. It returns them as an Atom/byte string (the item-2 blob
    bridge already carries bytes out); building that byte string inside the

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -6666,9 +6666,70 @@ pfail:
 ; structure from the C++ hybrid target Parser. Compound functors come from
 ; the atom table; unification tolerates that via @wam_functor_eq. No operators,
 ; floats, variables or quoting yet -- follow-up increments.
+; Resolve a named variable to a Ref, using the reader var-dict on the VM (field
+; 27) so repeated occurrences of the same name within one term share a cell.
+; The dict block is [count:i64][ (atom_id:i64, heap_addr:i64) x N ]. A miss (or
+; a full/absent dict) pushes a fresh unbound heap cell. Anonymous "_" is handled
+; by the caller (always fresh, never recorded).
+define %Value @wam_var_ref(%WamState* %vm, i64 %atom_id) {
+entry:
+  %dp = getelementptr %WamState, %WamState* %vm, i32 0, i32 27
+  %dict = load i8*, i8** %dp
+  %dnull = icmp eq i8* %dict, null
+  br i1 %dnull, label %fresh, label %have_dict
+have_dict:
+  %cntp = bitcast i8* %dict to i64*
+  %cnt = load i64, i64* %cntp
+  %ebase = getelementptr i8, i8* %dict, i64 8
+  %entries = bitcast i8* %ebase to i64*
+  br label %scan
+scan:
+  %i = phi i64 [ 0, %have_dict ], [ %i1, %scan_next ]
+  %done = icmp uge i64 %i, %cnt
+  br i1 %done, label %add, label %check
+check:
+  %aidx = mul i64 %i, 2
+  %aslot = getelementptr i64, i64* %entries, i64 %aidx
+  %eaid = load i64, i64* %aslot
+  %match = icmp eq i64 %eaid, %atom_id
+  br i1 %match, label %found, label %scan_next
+found:
+  %addridx = add i64 %aidx, 1
+  %addrslot = getelementptr i64, i64* %entries, i64 %addridx
+  %eaddr64 = load i64, i64* %addrslot
+  %eaddr = trunc i64 %eaddr64 to i32
+  %frv = call %Value @value_ref(i32 %eaddr)
+  ret %Value %frv
+scan_next:
+  %i1 = add i64 %i, 1
+  br label %scan
+add:
+  %full = icmp uge i64 %cnt, 128
+  br i1 %full, label %fresh, label %record
+record:
+  %runb = call %Value @value_unbound(i8* null)
+  %raddr = call i32 @wam_heap_push(%WamState* %vm, %Value %runb)
+  %raddr64 = zext i32 %raddr to i64
+  %nidx = mul i64 %cnt, 2
+  %naslot = getelementptr i64, i64* %entries, i64 %nidx
+  store i64 %atom_id, i64* %naslot
+  %naddridx = add i64 %nidx, 1
+  %naddrslot = getelementptr i64, i64* %entries, i64 %naddridx
+  store i64 %raddr64, i64* %naddrslot
+  %cnt1 = add i64 %cnt, 1
+  store i64 %cnt1, i64* %cntp
+  %rrv = call %Value @value_ref(i32 %raddr)
+  ret %Value %rrv
+fresh:
+  %funb = call %Value @value_unbound(i8* null)
+  %faddr = call i32 @wam_heap_push(%WamState* %vm, %Value %funb)
+  %frv2 = call %Value @value_ref(i32 %faddr)
+  ret %Value %frv2
+}
+
 ; Parse a single primary: a parenthesised expression, a negative number, a
-; list, a compound name(args), or an atomic (integer / atom). The operator
-; layer (@wam_parse_expr) sits on top of this.
+; variable, a list, a compound name(args), or an atomic (integer / atom). The
+; operator layer (@wam_parse_expr) sits on top of this.
 define %Value @wam_parse_primary(%WamState* %vm, i8* %s, i64 %len, i64* %pos) {
 entry:
   call void @wam_skip_ws(i8* %s, i64 %len, i64* %pos)
@@ -6760,7 +6821,32 @@ id_done:
   store i64 %ie, i64* %pos
   %namelen = sub i64 %ie, %p0
   %namelen0 = icmp eq i64 %namelen, 0
-  br i1 %namelen0, label %pfail, label %peek_paren
+  br i1 %namelen0, label %pfail, label %chk_var
+chk_var:
+  ; A token led by an uppercase letter or underscore is a variable.
+  %fcp = getelementptr i8, i8* %s, i64 %p0
+  %fc = load i8, i8* %fcp
+  %fc_ge_A = icmp uge i8 %fc, 65
+  %fc_le_Z = icmp ule i8 %fc, 90
+  %fc_upper = and i1 %fc_ge_A, %fc_le_Z
+  %fc_us = icmp eq i8 %fc, 95
+  %fc_isvar = or i1 %fc_upper, %fc_us
+  br i1 %fc_isvar, label %do_var, label %peek_paren
+do_var:
+  ; "_" alone is anonymous (always a fresh, unshared variable).
+  %len_is_1 = icmp eq i64 %namelen, 1
+  %anon = and i1 %len_is_1, %fc_us
+  br i1 %anon, label %anon_var, label %named_var
+anon_var:
+  %aunb = call %Value @value_unbound(i8* null)
+  %aaddr = call i32 @wam_heap_push(%WamState* %vm, %Value %aunb)
+  %arv = call %Value @value_ref(i32 %aaddr)
+  ret %Value %arv
+named_var:
+  %vnameptr = getelementptr i8, i8* %s, i64 %p0
+  %vid = call i64 @wam_intern_atom(i8* %vnameptr, i64 %namelen)
+  %vrv = call %Value @wam_var_ref(%WamState* %vm, i64 %vid)
+  ret %Value %vrv
 peek_paren:
   call void @wam_skip_ws(i8* %s, i64 %len, i64* %pos)
   %pp = load i64, i64* %pos
@@ -16567,7 +16653,16 @@ rta.parse:
   %rta.len = call i64 @strlen(i8* %rta.str)
   %rta.pos = alloca i64
   store i64 0, i64* %rta.pos
+  ; Install a fresh var-dict on the VM: [count:i64][128 x (atom_id, addr)].
+  call void @wam_arena_ensure()
+  %rta.dict = call i8* @wam_arena_alloc(i64 2056)
+  %rta.dcntp = bitcast i8* %rta.dict to i64*
+  store i64 0, i64* %rta.dcntp
+  %rta.vdp = getelementptr %WamState, %WamState* %vm, i32 0, i32 27
+  store i8* %rta.dict, i8** %rta.vdp
   %rta.val = call %Value @wam_parse_expr(%WamState* %vm, i8* %rta.str, i64 %rta.len, i64* %rta.pos, i32 1200)
+  ; Clear the transient dict pointer (the arena block is reclaimed on rewind).
+  store i8* null, i8** %rta.vdp
   %rta.vtag = extractvalue %Value %rta.val, 0
   %rta.pfail = icmp eq i32 %rta.vtag, 6
   br i1 %rta.pfail, label %rta.fail, label %rta.unify

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -110,6 +110,10 @@ define %WamState* @wam_state_new(%Instruction* %code, i32 %code_len, i32* %label
   %objmetac_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 26
   store i32 0, i32* %objmetac_ptr
 
+  ; reader var-dict = null (set transiently by read_term_from_atom)
+  %vardict_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 27
+  store i8* null, i8** %vardict_ptr
+
   ret %WamState* %vm
 }
 

--- a/templates/targets/llvm_wam/types.ll.mustache
+++ b/templates/targets/llvm_wam/types.ll.mustache
@@ -113,7 +113,10 @@
     %WamMetaRow*,                          ; 25: obj_meta (loaded-object meta-call
                                            ;     table; null for host VMs -- see
                                            ;     PLAWK_EVAL_BOOTSTRAP.md milestone 2)
-    i32                                    ; 26: obj_meta_count
+    i32,                                   ; 26: obj_meta_count
+    i8*                                    ; 27: reader var-dict scratch (transient,
+                                           ;     set by read_term_from_atom while
+                                           ;     parsing; null otherwise)
 }
 
 ; One row of a loaded object's meta-call dispatch table: a predicate the

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -104,6 +104,14 @@ readop_prec(R)  :- read_term_from_atom('1+2*3', T), R is T.        % 7
 readop_paren(R) :- read_term_from_atom('(1+2)*3', T), R is T.      % 9
 readop_assoc(R) :- read_term_from_atom('100 - 2 * -3', T), R is T. % 106
 
+% Variable reader: a repeated variable name shares one cell within the term, so
+% binding it once via unification propagates to every occurrence. Anonymous _
+% are distinct. (Reader vars are bound by unifying the parsed TERM, not by the
+% surrounding clause's variables.)
+readvar_shared(R) :- read_term_from_atom('p(X,X)', T), T = p(9, Y), R is Y.   % 9
+readvar_arith(R)  :- read_term_from_atom('v(A,A)', T), T = v(6, X), R is X*7. % 42
+readvar_anon(R)   :- read_term_from_atom('q(_,_)', T), T = q(3,4), R is 1.    % 1 (distinct)
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -419,6 +427,24 @@ test(read_operators_in_object,
     run_host(Host, W1, O1, 0), assertion(O1 == "7\n"),
     run_host(Host, W2, O2, 0), assertion(O2 == "9\n"),
     run_host(Host, W3, O3, 0), assertion(O3 == "106\n"),
+    !.
+
+% Variable reader in a loaded object: shared variables share a cell (bind once,
+% see everywhere), anonymous _ are distinct.
+test(read_variables_in_object,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'readvar_shared.wamo', W1),
+    directory_file_path(Dir, 'readvar_arith.wamo', W2),
+    directory_file_path(Dir, 'readvar_anon.wamo', W3),
+    write_wam_object([user:readvar_shared/1], [wamo_entry(readvar_shared/1)], W1),
+    write_wam_object([user:readvar_arith/1], [wamo_entry(readvar_arith/1)], W2),
+    write_wam_object([user:readvar_anon/1], [wamo_entry(readvar_anon/1)], W3),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, W1, O1, 0), assertion(O1 == "9\n"),
+    run_host(Host, W2, O2, 0), assertion(O2 == "42\n"),
+    run_host(Host, W3, O3, 0), assertion(O3 == "1\n"),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
`read_term_from_atom/2` now parses **variables** — the piece that unlocks reading terms with logic variables, and the last major primitive before clause bodies (`:-`/`,`).

## Mechanism

- A token led by an **uppercase letter or `_`** is a variable.
- **Shared** variables: repeated occurrences of a name within one term share a single fresh heap cell — binding it once (by unifying the parsed term) propagates to every occurrence. `X` in `p(X,X)` is one cell.
- **Anonymous `_`**: always a fresh, unshared cell.
- **Per-parse var-dictionary**: a transient block `[count][128 × (atom_id, heap_addr)]` on the arena, hung off a new `%WamState` field (27), installed by the builtin around the parse and cleared after. `@wam_var_ref` interns the name and looks it up, pushing + recording a fresh unbound cell on a miss.

Hanging the dict off the VM (rather than threading a dict parameter through every parse function) keeps all the parser signatures unchanged — only `parse_primary` touches variables. Reader variables are ordinary WAM heap `Ref`s, so they unify and bind exactly like compiled `put_variable` cells.

**Contract note:** reader variables have no connection to the surrounding clause's variables (the reader mints fresh cells). They're bound by unifying the parsed *term* against a pattern — the normal `read_term` model.

## Testing (loaded objects)

- `p(X,X) = p(9,Y)` → **9** (shared: binding X once sets Y)
- `v(A,A) = v(6,X), X*7` → **42** (shared var through arithmetic)
- `q(_,_) = q(3,4)` → **1** (anonymous vars are distinct — would fail if shared)

Full `wam_object`, `wam_llvm_target`, `wam_llvm_meta_call_runtime`, and plawk suites pass (the field-27 append is behavior-preserving, same discipline as the earlier `obj_meta` fields).

## Changes

- `templates/targets/llvm_wam/types.ll.mustache` — `%WamState` field 27 (var-dict).
- `templates/targets/llvm_wam/state.ll.mustache` — init field 27 = null.
- `src/unifyweaver/targets/wam_llvm_target.pl` — `@wam_var_ref`; `parse_primary` variable detection (anonymous vs named); builtin installs a fresh dict.
- `tests/test_wam_object.pl` — `read_variables_in_object`.
- docs — variables marked landed.

**Remaining reader work:** control operators (`:-` `,` `;` `->` — turn parsed goals into clause bodies), floats, quoted atoms. With variables done, `:-`/`,` are the last reader piece before a whole clause parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_