### PR TITLE
WAM/LLVM (roadmap #5, milestone 3b): control operators in the reader — whole clauses parse

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -170,11 +170,24 @@ independently useful (richer hand-written grammars load sooner).
    objects: `p(X,X)` binds both from one unify (→9), shared var through
    arithmetic (→42), anonymous `q(_,_) = q(3,4)` succeeds (distinct).
 
-   **Remaining (3b/3c):** control operators (`,` `;` `->` `:-` — the layer that
-   turns parsed goals into clause bodies), floats, and quoted atoms in the
-   reader; `assert`/`retract` (a dynamic clause store); and `catch`/`throw`
-   predicate linkage. With variables done, `:-`/`,` are the last reader piece
-   before a whole clause parses. These remain the long pole for self-hosting.
+   **Control operators (milestone 3b):** `:-` (1200 xfx), `,` (1000 xfy), `;`
+   (1100 xfy), `->` (1050 xfy) — added as `@wam_infix_op` table entries over the
+   precedence-climbing machinery. `,` and `;` are single punctuation chars
+   (neither symbol nor alnum), so `parse_expr` gains explicit solo-token
+   handling for them; `:-`/`->` tokenize as symbol runs. With variables +
+   these, **a whole clause parses**: `read_term_from_atom("foo(X) :- bar(X),
+   baz(X)", T)` yields `:-(foo(X), ,(bar(X),baz(X)))` with `X` shared across
+   head and body (verified in a loaded object: binding X once is visible in the
+   body goal → 7; right-assoc conjunction `1,2,3` → 123; disjunction → 33).
+   The reader now covers the term shapes a clause is made of.
+
+   **Remaining (3b/3c):** floats and quoted atoms in the reader (both
+   token-level); `assert`/`retract` (a dynamic clause store); and `catch`/`throw`
+   predicate linkage. A minor loadable-subset gap also surfaced: `arg/3` with a
+   constant index compiles to a specialised `arg` opcode outside the `.wamo`
+   subset (so loaded objects decompose reader terms via unification /
+   `functor/3`, not `arg/3`) — a candidate subset lift. These remain the long
+   pole for self-hosting.
 4. **Byte-buffer output from a grammar.** The compiler object must *emit*
    `.wamo` bytes. It returns them as an Atom/byte string (the item-2 blob
    bridge already carries bytes out); building that byte string inside the

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -6398,6 +6398,8 @@ len1:
     i8 60, label %r_xfx700
     i8 62, label %r_xfx700
     i8 61, label %r_xfx700
+    i8 44, label %r_xfy1000
+    i8 59, label %r_xfy1100
   ]
 chk2:
   %is2 = icmp eq i64 %len, 2
@@ -6429,7 +6431,17 @@ len2e:
   %sl1 = icmp eq i8 %p0, 47
   %sl2 = icmp eq i8 %p1, 47
   %is_idiv = and i1 %sl1, %sl2
-  br i1 %is_idiv, label %r_yfx400, label %none
+  br i1 %is_idiv, label %r_yfx400, label %len2f
+len2f:
+  %cl = icmp eq i8 %p0, 58
+  %mn = icmp eq i8 %p1, 45
+  %is_neck = and i1 %cl, %mn
+  br i1 %is_neck, label %r_xfx1200, label %len2g
+len2g:
+  %ar0 = icmp eq i8 %p0, 45
+  %ar1 = icmp eq i8 %p1, 62
+  %is_arrow = and i1 %ar0, %ar1
+  br i1 %is_arrow, label %r_xfy1050, label %none
 chk3:
   %is3 = icmp eq i64 %len, 3
   br i1 %is3, label %len3, label %none
@@ -6465,6 +6477,14 @@ r_yfx400:
   ret i32 6402
 r_xfx700:
   ret i32 11200
+r_xfy1000:
+  ret i32 16001
+r_xfy1100:
+  ret i32 17601
+r_xfy1050:
+  ret i32 16801
+r_xfx1200:
+  ret i32 19200
 none:
   ret i32 0
 }
@@ -6517,12 +6537,24 @@ loop:
 read_op:
   %ocp = getelementptr i8, i8* %s, i64 %opstart
   %occ = load i8, i8* %ocp
+  ; comma (44) and semicolon (59) are single-char operators that are neither
+  ; symbol nor alnum chars, so they need explicit solo-token handling. Other
+  ; operators are symbol runs (:- -> and the comparisons) or alnum runs
+  ; (is / mod / rem).
+  %is_comma = icmp eq i8 %occ, 44
+  %is_semi = icmp eq i8 %occ, 59
+  %is_solo = or i1 %is_comma, %is_semi
+  br i1 %is_solo, label %solo_op, label %chk_name
+solo_op:
+  %oe_solo = add i64 %opstart, 1
+  br label %op_done
+chk_name:
   %o_sym = call i1 @wam_is_symbol_char(i8 %occ)
   %o_aln = call i1 @wam_is_alnum(i8 %occ)
   %o_isname = or i1 %o_sym, %o_aln
   br i1 %o_isname, label %op_loop, label %restore
 op_loop:
-  %oe = phi i64 [ %opstart, %read_op ], [ %oe1, %op_step ]
+  %oe = phi i64 [ %opstart, %chk_name ], [ %oe1, %op_step ]
   %oe_end = icmp uge i64 %oe, %len
   br i1 %oe_end, label %op_done, label %op_check
 op_check:
@@ -6536,7 +6568,8 @@ op_step:
   %oe1 = add i64 %oe, 1
   br label %op_loop
 op_done:
-  %oplen = sub i64 %oe, %opstart
+  %oe_final = phi i64 [ %oe, %op_loop ], [ %oe, %op_check ], [ %oe_solo, %solo_op ]
+  %oplen = sub i64 %oe_final, %opstart
   %optokptr = getelementptr i8, i8* %s, i64 %opstart
   %opcode = call i32 @wam_infix_op(i8* %optokptr, i64 %oplen)
   %notop = icmp eq i32 %opcode, 0
@@ -6547,7 +6580,7 @@ check_prec:
   %too_high = icmp sgt i32 %prio, %maxprec
   br i1 %too_high, label %restore, label %apply
 apply:
-  store i64 %oe, i64* %pos
+  store i64 %oe_final, i64* %pos
   %is_xfy = icmp eq i32 %type, 1
   %prio_m1 = sub i32 %prio, 1
   %rmax = select i1 %is_xfy, i32 %prio, i32 %prio_m1

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -112,6 +112,17 @@ readvar_shared(R) :- read_term_from_atom('p(X,X)', T), T = p(9, Y), R is Y.   % 
 readvar_arith(R)  :- read_term_from_atom('v(A,A)', T), T = v(6, X), R is X*7. % 42
 readvar_anon(R)   :- read_term_from_atom('q(_,_)', T), T = q(3,4), R is 1.    % 1 (distinct)
 
+% Control operators: :- (1200), , (1000), ; (1100), -> (1050). With variables
+% and these, a whole clause parses. readclause parses "foo(X) :- bar(X), baz(X)"
+% into :-(foo(X), ,(bar(X),baz(X))) with X shared across head and body: binding
+% X once (via V) is visible in the body goal (W).
+readclause(R) :- read_term_from_atom('foo(X) :- bar(X), baz(X)', T),
+                 T = (H :- B), H = foo(V), B = (G1, _), G1 = bar(W),
+                 V = 7, R is W.                                  % 7
+% Right-associative conjunction: 1,2,3 = ,(1,,(2,3)).
+readconj(R)  :- read_term_from_atom('1,2,3', T), T = (A,Bc,C), R is A*100+Bc*10+C. % 123
+readsemi(R)  :- read_term_from_atom('11;22', T), T = (A;Bd), R is A+Bd.            % 33
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -445,6 +456,24 @@ test(read_variables_in_object,
     run_host(Host, W1, O1, 0), assertion(O1 == "9\n"),
     run_host(Host, W2, O2, 0), assertion(O2 == "42\n"),
     run_host(Host, W3, O3, 0), assertion(O3 == "1\n"),
+    !.
+
+% Control operators in a loaded object: a whole clause parses (:- , with a
+% variable shared head-to-body), right-associative conjunction, and disjunction.
+test(read_control_operators_in_object,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'readclause.wamo', W1),
+    directory_file_path(Dir, 'readconj.wamo', W2),
+    directory_file_path(Dir, 'readsemi.wamo', W3),
+    write_wam_object([user:readclause/1], [wamo_entry(readclause/1)], W1),
+    write_wam_object([user:readconj/1], [wamo_entry(readconj/1)], W2),
+    write_wam_object([user:readsemi/1], [wamo_entry(readsemi/1)], W3),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, W1, O1, 0), assertion(O1 == "7\n"),
+    run_host(Host, W2, O2, 0), assertion(O2 == "123\n"),
+    run_host(Host, W3, O3, 0), assertion(O3 == "33\n"),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
Adds the control operators to `read_term_from_atom/2` — `:-` (1200 xfx), `,` (1000 xfy), `;` (1100 xfy), `->` (1050 xfy). **With variables plus these, a whole Prolog clause parses** — the term shape the compiler-as-`.wamo` consumes.

## Mechanism

- `@wam_infix_op` gains the four entries over the existing precedence-climbing machinery — table-driven, as designed.
- `,` and `;` are single punctuation chars (neither symbol nor alnum), so `parse_expr` grows explicit **solo-token** handling: `read_op` recognises them as 1-char operator tokens and converges with the symbol/alnum run path at `op_done` (via an `oe_final` phi). `:-` and `->` tokenize as ordinary symbol runs, so they needed only table entries.

## The headline

```
read_term_from_atom("foo(X) :- bar(X), baz(X)", T)
  →  :-(foo(X), ,(bar(X), baz(X)))     with X shared across head and body
```
Verified in a loaded object: binding `X` via the head is visible in the body goal → **7**; right-associative conjunction `1,2,3` → **123**; disjunction `11;22` → **33**; `4->5` → **9**.

## Two findings while testing

- **A stray single quote in a comment** (`',' and ';'`) split the IR template string and corrupted the `@execute_builtin` clause — it surfaced as a runtime `Unknown procedure ' and '` error, *not* a consult error (so `use_module` passed but the host wouldn't build). Reworded to avoid quote chars. (Caught and fixed before shipping.)
- **`arg/3` with a constant index** compiles to a specialised `arg` WAM opcode that is outside the loadable `.wamo` subset (write fails with `wamo_unsupported`). So loaded objects decompose reader terms via **unification / `functor/3`**, not `arg/3`. Orthogonal to the reader (affects any loaded object); noted as a candidate subset lift.

## Changes

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@wam_infix_op` entries for `:-` `,` `;` `->`; `parse_expr` solo-token handling.
- `tests/test_wam_object.pl` — `read_control_operators_in_object` (clause → 7, conjunction → 123, disjunction → 33, all in loaded objects).
- docs — control operators landed; remaining reader = floats, quoted atoms; noted the `arg/3` opcode gap.

Full `wam_object`, `wam_llvm_meta_call_runtime`, and `plawk_functions` suites pass; `parse_expr`/`infix_op` are reachable only through `read_term_from_atom`, so the change is isolated.

**Remaining reader work:** floats and quoted atoms (both token-level). After those, the reader parses the full canonical + operator Prolog surface the compiler needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_