### PR TITLE
WAM/LLVM (roadmap #5, milestone 3b-db, PR 1): dynamic clause store

### DIFF
--- a/docs/design/PLAWK_DYNAMIC_DB.md
+++ b/docs/design/PLAWK_DYNAMIC_DB.md
@@ -1,0 +1,151 @@
+# Dynamic clause store (assert / retract) for the WAM/LLVM target
+
+Status: **PR 1 landed — ground dynamic facts, called via `call/1`.** This is
+milestone **3b-db** of the eval bootstrap (see PLAWK_EVAL_BOOTSTRAP.md). It is
+the last genuinely-new runtime machinery before the eval/compile surface: a
+mutable clause database in a VM whose term arena is rewound between queries.
+
+## Why it is the subtle one
+
+Every other term the VM builds lives in the **arena** — a bump allocator that
+`@wam_arena_reset`/`@wam_arena_rewind` roll back between queries and on
+backtrack. A clause you `assertz` must outlive all of that: it has to survive
+the arena rewind, later backtracks, and any number of subsequent queries.
+`@wam_copy_term_value` (the existing deep-copier) allocates from the arena, so
+it is *not* durable — an asserted clause copied that way would be freed under
+the next query. The store therefore needs its own **malloc-backed, durable**
+storage, following the same growable-global-table idiom the runtime-interned
+atom table uses (`@wam_atom_dyn_ptr` / `_count` / `_cap`, realloc-doubling,
+per-entry malloc that the table owns).
+
+## Storage model
+
+A single process-global table (in `state.ll.mustache`, alongside the atom
+table):
+
+```
+@wam_dyn_ptr   = global %WamDynClause* null   ; the growable array
+@wam_dyn_count = global i32 0
+@wam_dyn_cap   = global i32 0
+```
+
+with one row per asserted clause:
+
+```
+%WamDynClause = type { i8*, i32, i32, %Value* }  ; functor, arity, live, args
+```
+
+- **functor**: a malloc'd copy of the predicate's functor name (so the row does
+  not depend on the lifetime or provenance of the source functor pointer —
+  AOT `@.fn_*` global, atom-table entry, or reader-built are all fine). Matching
+  uses `@wam_functor_eq` (pointer fast-path + `strcmp` fallback), so a
+  goal built from any source unifies against the stored copy.
+- **arity**: base arity of the head.
+- **live**: 1 = present, 0 = retracted. Retraction is a **lazy tombstone** —
+  the row stays in the array (so a `retract` mid-iteration does not shift the
+  indices the consult iterator is walking) and is skipped on scan.
+- **args**: a malloc'd array of `arity` durably-copied argument `%Value`s.
+  `@wam_dyn_copy_durable` recurses: atomic values are self-contained and copied
+  by value; compounds get a fresh malloc'd `%Compound` + args with the functor
+  string duplicated and each arg copied recursively.
+
+### Scope of PR 1 — ground facts
+
+Asserted terms are treated as **facts** (the head is the whole term) and are
+expected to be **ground** — which is exactly what a self-hosting compiler's
+dynamic tables are (gensym counters, symbol tables, collected clauses become
+ground once fully built). Concretely, in PR 1:
+
+- `assertz(T)` / `asserta(T)` store `T` as a fact. A `T` of the form `(H :- B)`
+  is stored verbatim as a `:-`/2 fact (not interpreted as a rule) — calling a
+  rule body is milestone 3b-db-rules, a separate follow-up that needs a body
+  interpreter.
+- Unbound variables in an asserted term are copied as fresh `Unbound`
+  sentinels with **no variable-map sharing** — the same documented limitation
+  the existing `@wam_copy_term_value` carries. Ground facts are unaffected;
+  non-ground asserts are a documented follow-up (a var-map durable copy).
+
+## Calling a dynamic predicate
+
+The probe that motivated the split: `getc(N) :- counter(N)` lowers to
+`execute counter/1` with an **unresolved label** (no compiled clauses for
+`counter/1`), which today silently defaults to label index 0. Routing that
+*direct* call to the store needs compile-time `:- dynamic` tracking plus a new
+runtime dispatch — that is **PR 2**.
+
+PR 1 reaches the store through the path that already resolves runtime-built
+goals: the `call/1` meta-call. `G = counter(X), call(G)` lowers to
+`call call/1` (label index −1), handled by `@wam_dispatch_meta_call`, which
+resolves the goal's functor/arity against the compiled meta-call table and
+`fail`s when nothing matches. That `fail` is the hook: on a miss we consult the
+dynamic store instead of failing.
+
+```
+@wam_dispatch_meta_call:
+    atom goal, meta table miss  ─▶ @wam_dyn_consult(vm, atom_string,  0,        after_pc)
+    compound goal, table miss   ─▶ @wam_dyn_consult(vm, functor,      base_arity, after_pc)
+```
+
+(PR 1 consults only when the goal in reg 0 is the *complete* goal — i.e. no
+`call/N` closure extra-args — since the iterator reads the goal's arguments
+straight out of reg 0. `call(foo, A, B)`-style partial application is a
+follow-up.)
+
+### The consult iterator (a new choice-point kind)
+
+Backtracking over the matching clauses reuses the choice-point machinery, with
+a new `agg_type = -3` ("dynamic clause iterator"), modelled on the existing
+foreign-result iterator (`agg_type = -2`). `@backtrack` dispatches `-3` to
+`@wam_dyn_iter_next` just as it dispatches `-2` to `@wam_foreign_iter_next`.
+
+`@wam_dyn_consult` pushes the CP (saving regs/trail/heap, and stashing the
+functor pointer, arity, a cursor = 0, and the return PC in the repurposed
+aggregate fields) and immediately calls `@wam_dyn_iter_next` for the first
+solution. Each `@wam_dyn_iter_next`:
+
+1. scans the store from `cursor` for the next **live** row whose functor
+   (`@wam_functor_eq`) and arity match;
+2. restores the saved registers and unwinds the trail to the CP's mark (so the
+   previous attempt's bindings are gone);
+3. unifies each goal argument (from reg 0) against the stored row's args with
+   `@wam_unify_value` (which trails the goal-side bindings);
+4. on full success: advances `cursor` past this row, sets PC to the return PC,
+   returns true — the fact "ran", its (empty) body is `true`, execution
+   continues at the caller's continuation;
+5. on unify failure: continues the scan (re-unwinding for the next row);
+6. on exhaustion: unwinds to the mark, pops the CP, returns false — genuine
+   goal failure / no (more) matching clauses.
+
+The scan is O(n) per step (re-scanned each backtrack) — fine for the small
+tables a compiler keeps; a functor+arity index is a later optimization if a
+hot eval loop needs it.
+
+## Builtins
+
+`assertz/1`, `asserta/1` and `retractall/1` are in `is_builtin_pred`
+(`wam_target.pl`), so the tier-2 compiler lowers them to `builtin_call`. PR 1
+adds their `@execute_builtin` cases, `builtin_op_to_id` entries, switch arms,
+and `wamo_enc` loadable-subset entries (so a loaded `.wamo` can build its own
+database — the eval-bootstrap need):
+
+| builtin | id | runtime |
+|---|---|---|
+| `assertz/1` | 175 | `@wam_dyn_assert(vm, A1, /*prepend*/ false)` |
+| `asserta/1` | 176 | `@wam_dyn_assert(vm, A1, /*prepend*/ true)` |
+| `retractall/1` | 177 | `@wam_dyn_retractall(vm, A1)` — tombstone every live row whose head unifies with the pattern (pattern bindings unwound after each test); always succeeds |
+
+`retract/1` lowers to `call retract/1` (nondet, dispatched as a choice-point
+iterator per `wam_target.pl`), so it lands with the dispatch work in **PR 2**.
+
+## Roadmap
+
+- **PR 1 (this):** durable store; `assertz`/`asserta`/`retractall`; calling
+  ground dynamic facts via `call/1`. AOT + loaded-object tests.
+- **PR 2:** compile-time `:- dynamic P/N` tracking so direct calls
+  (`counter(N)`) resolve to the store; nondet `retract/1` as a CP iterator;
+  `call/N` partial-application consult.
+- **PR 3 (later):** rule bodies (`assertz((H :- B))`) — a body interpreter for
+  asserted clauses. The true long pole; likely unneeded for the eval bootstrap
+  if the compiler's dynamic predicates are all fact tables.
+- Optimizations: functor+arity index over the store; variable-map durable copy
+  for non-ground asserts.

--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -114,7 +114,9 @@ independently useful (richer hand-written grammars load sooner).
    | `is`/`=`/`==`/comparison, `functor`/`arg`/`=..`, `copy_term`, `atom_codes`/`number_codes`/`char_code`, `sub_atom`/`atom_concat`, `sort`/`msort`/`keysort`, `length`/`append`/`nth`/`reverse`, `sum_list` … | `builtin_call <id>` (id in `builtin_op_to_id`, host-implemented) | **yes** — already in the subset and loader-safe (operate on VM regs/heap + libc) |
    | `findall`/`aggregate_all`, `setof`/`bagof` | `begin_aggregate`/`end_aggregate` (tags 28/29) | **yes, this PR** — opcodes lifted into the subset; setof/bagof additionally need `inline_bagof_setof(true)`, now the `.wamo` default |
    | `term_to_atom/2` (write direction) | `builtin_call term_to_atom/2` (id 173) → `@wam_term_to_sb` | **yes, milestone 3b** — a recursive term→text writer into a growable buffer, interned as an atom. Works in loaded objects too: cons detection is by functor *bytes*, not pointer identity. Unquoted (write semantics), so it does not yet round-trip through a reader |
-   | `assert`/`asserta`/`assertz`/`retract`, `read_term`/`read_term_from_atom`, `term_to_atom/2` (read direction) | `builtin_call <name>` with **no `builtin_op_to_id` entry and no host runtime impl** | **no** — needs new runtime machinery. The reader (`read_term`) is a tokenizer + operator-precedence parser (milestone 3b-read). `assert`/`retract` against a loaded object's own clauses is the subtle one — mutable clause state in an arena-rewound VM (milestone 3b-db) |
+   | `assertz`/`asserta`/`retractall` | `builtin_call <name>` (ids 175/176/177) → `@wam_dyn_assert` / `@wam_dyn_retractall` | **yes, milestone 3b-db (PR 1)** — a process-global, malloc-backed clause store that survives the arena rewind. Ground facts; calling them goes through the `call/1` meta-call, whose meta-table miss consults the store with unification + backtracking (`agg_type = -3` choice point). See PLAWK_DYNAMIC_DB.md |
+   | `retract/1` (nondet), direct calls to `:- dynamic` predicates | `call retract/1` / `execute <dyn>/N` with an unresolved label | **PR 2** — nondet `retract` as a CP iterator; compile-time `:- dynamic` tracking so `counter(N)` (not just `call(counter(N))`) resolves to the store |
+   | `read_term`/`read_term_from_atom` | `builtin_call read_term_from_atom/2` (id 174) → the reader | **yes, milestone 3b** — a tokenizer + operator-precedence recursive-descent parser (done: canonical + operator surface, variables, control ops, floats, quoted atoms) |
    | `catch`/`throw` | `execute catch/3` — a call to a runtime *library predicate*, not a builtin | **no** — the loaded object references `catch/3`, which lives in the host, not the object; needs cross-object/host predicate linkage (milestone 3c) |
 
    **Landed here:** the aggregate opcodes, verified end-to-end — `findall`,
@@ -189,13 +191,28 @@ independently useful (richer hand-written grammars load sooner).
    the next quote; no escape handling yet). Verified in loaded objects:
    `3.5 + 1.5` → 5, negative/compound floats, and `'hello world'` → length 11.
 
-   **Remaining (3b/3c):** `assert`/`retract` (a dynamic clause store); and
-   `catch`/`throw` predicate linkage. A minor loadable-subset gap also surfaced:
-   `arg/3` with a constant index compiles to a specialised `arg` opcode outside
-   the `.wamo` subset (so loaded objects decompose reader terms via unification
-   / `functor/3`, not `arg/3`) — a candidate subset lift. These remain the long
-   pole for self-hosting; the **reader itself is done** — a grammar object can
-   now parse whole clauses from source text.
+   **Dynamic clause store (milestone 3b-db) — PR 1 landed.** A process-global,
+   malloc-backed clause store (survives the arena rewind) with `assertz` /
+   `asserta` / `retractall` builtins, and calling ground dynamic facts via the
+   `call/1` meta-call (its meta-table miss consults the store, with unification
+   and backtracking through a new `agg_type = -3` choice point). Works in loaded
+   objects — the store is process-global. See **PLAWK_DYNAMIC_DB.md** for the
+   full design and the PR breakdown. Remaining there: direct calls to `:-
+   dynamic` predicates (`counter(N)` rather than `call(counter(N))`) + nondet
+   `retract/1` (PR 2), and rule bodies (PR 3).
+
+   **Remaining (3b/3c):** `catch`/`throw` predicate linkage. A minor
+   loadable-subset gap also surfaced: `arg/3` with a constant index compiles to
+   a specialised `arg` opcode outside the `.wamo` subset (so loaded objects
+   decompose reader terms via unification / `functor/3`, not `arg/3`) — a
+   candidate subset lift. The **reader itself is done** — a grammar object can
+   now parse whole clauses from source text — and the dynamic store gives a
+   grammar mutable state.
+
+   (Aside: `findall/setof/bagof` over a `call/1` meta-call goal — e.g.
+   `findall(X, call(G), L)` — is a pre-existing limitation independent of the
+   store: the meta-call inside the aggregate collects nothing. Dynamic facts
+   are exercised via direct `call/1` + backtracking instead. A separate fix.)
 4. **Byte-buffer output from a grammar. — landed.** The compiler object must
    *emit* `.wamo` bytes. It returns them as an Atom/byte string (the item-2
    blob bridge already carries bytes out); building that byte string inside the

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -328,10 +328,14 @@ loadable along the way.
   works in loaded objects (byte-based cons detection) — and the **reader**
   (`read_term_from_atom/2`): a recursive-descent parser with operator
   precedence, variables, control operators, floats and quoted atoms. A loaded
-  object can now parse whole clauses from source text. Remaining: `assert`/
-  `retract` (a dynamic clause store) and `catch`/`throw` predicate linkage
-  (3c) — the true long pole. See the bootstrap doc for the full loadability
-  matrix.
+  object can now parse whole clauses from source text. Milestone 3b-db (PR 1)
+  adds a **dynamic clause store**: a process-global, malloc-backed clause
+  database (survives the arena rewind) with `assertz`/`asserta`/`retractall`
+  and calling ground dynamic facts via `call/1` (the meta-call consults the
+  store, with unification and backtracking). See PLAWK_DYNAMIC_DB.md. Remaining:
+  direct calls to `:- dynamic` predicates + nondet `retract/1` (3b-db PR 2),
+  rule bodies (PR 3), and `catch`/`throw` predicate linkage (3c) — the true
+  long pole. See the bootstrap doc for the full loadability matrix.
 - **Milestone 4 — byte-buffer output from a grammar — LANDED.** A loaded
   grammar assembles a byte string at runtime (via the milestone-3 string/codes
   builtins) and returns it as an Atom; the host reads it back through

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -2499,7 +2499,7 @@ atom_goal:
   %target_arity = sub i32 %total_arity, 1
   %label_idx = call i32 @wam_meta_find_atom(%WamState* %vm, i64 %atom_id, i32 %target_arity)
   %atom_found = icmp sge i32 %label_idx, 0
-  br i1 %atom_found, label %atom_resolve, label %fail
+  br i1 %atom_found, label %atom_resolve, label %atom_consult
 
 atom_resolve:
   %target_pc = call i32 @wam_label_pc(%WamState* %vm, i32 %label_idx)
@@ -2532,7 +2532,7 @@ compound_goal:
   %compound_target_arity = add i32 %compound_base_arity, %compound_extra_arity
   %clabel_idx = call i32 @wam_meta_find_compound(%WamState* %vm, i8* %compound_functor, i32 %compound_target_arity)
   %comp_found = icmp sge i32 %clabel_idx, 0
-  br i1 %comp_found, label %compound_resolve, label %fail
+  br i1 %comp_found, label %compound_resolve, label %compound_consult
 
 compound_resolve:
   %ctarget_pc = call i32 @wam_label_pc(%WamState* %vm, i32 %clabel_idx)
@@ -2579,6 +2579,28 @@ go:
   call void @wam_set_cp(%WamState* %vm, i32 %after_pc)
   call void @wam_set_pc(%WamState* %vm, i32 %target_pc)
   ret i1 true
+
+atom_consult:
+  ; Meta table missed an atom goal -- consult the dynamic clause store
+  ; for name/target_arity (see PLAWK_DYNAMIC_DB.md). target_arity > 0
+  ; here means a call/N closure the iterator cannot read from reg0, so
+  ; it simply finds no match and fails cleanly.
+  %ac_fn = call i8* @wam_atom_to_string(i64 %atom_id)
+  %ac_fn_null = icmp eq i8* %ac_fn, null
+  br i1 %ac_fn_null, label %fail, label %ac_go
+ac_go:
+  %ac_ok = call i1 @wam_dyn_consult(%WamState* %vm, i8* %ac_fn, i32 %target_arity, i32 %after_pc)
+  ret i1 %ac_ok
+
+compound_consult:
+  ; Meta table missed a compound goal -- consult the dynamic clause store.
+  ; Only when the goal in reg0 is the complete goal (no call/N closure
+  ; extra args); with extra args the iterator cannot see them, so fail.
+  %cc_no_extra = icmp eq i32 %compound_extra_arity, 0
+  br i1 %cc_no_extra, label %cc_go, label %fail
+cc_go:
+  %cc_ok = call i1 @wam_dyn_consult(%WamState* %vm, i8* %compound_functor, i32 %compound_base_arity, i32 %after_pc)
+  ret i1 %cc_ok
 
 fail:
   ret i1 false
@@ -4066,7 +4088,17 @@ check_foreign:
   ; If the top CP is a foreign-result iterator (agg_type == -2),
   ; advance the cursor and yield the next result.
   %is_foreign = icmp eq i32 %ca_at, -2
-  br i1 %is_foreign, label %do_foreign_yield, label %restore
+  br i1 %is_foreign, label %do_foreign_yield, label %check_dyn
+
+check_dyn:
+  ; If the top CP is a dynamic-clause iterator (agg_type == -3), advance
+  ; the store scan and yield the next matching asserted clause.
+  %is_dyn = icmp eq i32 %ca_at, -3
+  br i1 %is_dyn, label %do_dyn_yield, label %restore
+
+do_dyn_yield:
+  %dy_ok = call i1 @wam_dyn_iter_next(%WamState* %vm)
+  ret i1 %dy_ok
 
 do_foreign_yield:
   %fy_ok = call i1 @wam_foreign_iter_next(%WamState* %vm)
@@ -7349,6 +7381,9 @@ entry:
     i32 172, label %builtin_code_type
     i32 173, label %builtin_term_to_atom
     i32 174, label %builtin_read_term_from_atom
+    i32 175, label %builtin_assertz
+    i32 176, label %builtin_asserta
+    i32 177, label %builtin_retractall
     i32 76, label %builtin_compare
     i32 77, label %builtin_must_be
     i32 78, label %builtin_write
@@ -16778,6 +16813,26 @@ builtin_term_to_atom:
   %tta.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %tta.raw2, %Value %tta.v)
   ret i1 %tta.ok
 
+builtin_assertz:
+  ; assertz(+Clause): store A1 as a ground fact at the end of the store.
+  ; See PLAWK_DYNAMIC_DB.md (dynamic clause store, milestone 3b-db).
+  %az.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %az.ok = call i1 @wam_dyn_assert(%WamState* %vm, %Value %az.a1, i1 false)
+  ret i1 %az.ok
+
+builtin_asserta:
+  ; asserta(+Clause): store A1 as a ground fact at the front of the store.
+  %aa.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %aa.ok = call i1 @wam_dyn_assert(%WamState* %vm, %Value %aa.a1, i1 true)
+  ret i1 %aa.ok
+
+builtin_retractall:
+  ; retractall(+Pattern): tombstone every live clause whose head unifies
+  ; with A1. Always succeeds.
+  %ra.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %ra.ok = call i1 @wam_dyn_retractall(%WamState* %vm, %Value %ra.a1)
+  ret i1 %ra.ok
+
 unknown:
   ret i1 false
 }',
@@ -20410,6 +20465,9 @@ builtin_op_to_id('atom_contains/2', 171).     % substring check via strstr.
 builtin_op_to_id('code_type/2', 172).        % ASCII class check; shares char_type's classifier.
 builtin_op_to_id('term_to_atom/2', 173).     % render a term to its text (write semantics) and intern as an atom.
 builtin_op_to_id('read_term_from_atom/2', 174). % parse an atom's text into a term (atomic terms only, for now).
+builtin_op_to_id('assertz/1', 175).          % dynamic clause store: append a ground fact.
+builtin_op_to_id('asserta/1', 176).          % dynamic clause store: prepend a ground fact.
+builtin_op_to_id('retractall/1', 177).       % dynamic clause store: tombstone matching clauses.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/templates/targets/llvm_wam/module.ll.mustache
+++ b/templates/targets/llvm_wam/module.ll.mustache
@@ -11,6 +11,7 @@ target triple = "{{target_triple}}"
 ; === External Declarations ===
 {{external_declarations}}
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)
+declare void @llvm.memmove.p0i8.p0i8.i64(i8*, i8*, i64, i1)
 declare void @llvm.memset.p0i8.i64(i8*, i8, i64, i1)
 declare double @llvm.fabs.f64(double)
 declare double @llvm.trunc.f64(double)

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -4741,3 +4741,428 @@ pop_restore:
   %pop_retry = call i1 @backtrack(%WamState* %vm)
   ret i1 %pop_retry
 }
+
+; ==========================================================================
+; Dynamic clause store (assert / retract) -- see PLAWK_DYNAMIC_DB.md.
+; A process-global, malloc-backed table of asserted clauses that survives
+; the arena rewind between queries. PR 1: ground facts, called via call/1.
+; ==========================================================================
+
+@wam_dyn_ptr = internal global %WamDynClause* null
+@wam_dyn_count = internal global i32 0
+@wam_dyn_cap = internal global i32 0
+
+; Duplicate a NUL-terminated functor name into malloc storage owned by the
+; store (so a row does not depend on the source pointer lifetime).
+define i8* @wam_dyn_dup_functor(i8* %src) {
+entry:
+  %len = call i64 @strlen(i8* %src)
+  %len1 = add i64 %len, 1
+  %mem = call i8* @malloc(i64 %len1)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %mem, i8* %src, i64 %len1, i1 false)
+  ret i8* %mem
+}
+
+; Deep-copy a %Value into durable malloc storage. Atomic values are returned
+; by value; compounds get a fresh malloc %Compound with a duplicated functor
+; and recursively-copied args. Unbound values become a fresh Unbound sentinel
+; with no var-map sharing (same naive limitation as @wam_copy_term_value;
+; ground facts are unaffected).
+define %Value @wam_dyn_copy_durable(%WamState* %vm, %Value %v) {
+entry:
+  %dv = call %Value @wam_deref_value(%WamState* %vm, %Value %v)
+  %tag = call i32 @value_tag(%Value %dv)
+  %is_compound = icmp eq i32 %tag, 3
+  br i1 %is_compound, label %compound, label %atomic
+atomic:
+  ret %Value %dv
+compound:
+  %pl = call i64 @value_payload(%Value %dv)
+  %cp = inttoptr i64 %pl to %Compound*
+  %fn_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 0
+  %fn = load i8*, i8** %fn_slot
+  %ar_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 1
+  %ar = load i32, i32* %ar_slot
+  %args_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 2
+  %src_args = load %Value*, %Value** %args_slot
+  %cpsize = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %newmem = call i8* @malloc(i64 %cpsize)
+  %newcp = bitcast i8* %newmem to %Compound*
+  %newfn = call i8* @wam_dyn_dup_functor(i8* %fn)
+  %nf_slot = getelementptr %Compound, %Compound* %newcp, i32 0, i32 0
+  store i8* %newfn, i8** %nf_slot
+  %na_slot = getelementptr %Compound, %Compound* %newcp, i32 0, i32 1
+  store i32 %ar, i32* %na_slot
+  %vsz = ptrtoint %Value* getelementptr (%Value, %Value* null, i32 1) to i64
+  %ar64 = sext i32 %ar to i64
+  %argbytes = mul i64 %vsz, %ar64
+  %argsmem = call i8* @malloc(i64 %argbytes)
+  %newargs = bitcast i8* %argsmem to %Value*
+  %nargs_slot = getelementptr %Compound, %Compound* %newcp, i32 0, i32 2
+  store %Value* %newargs, %Value** %nargs_slot
+  %has = icmp sgt i32 %ar, 0
+  br i1 %has, label %loop, label %done
+loop:
+  %i = phi i32 [ 0, %compound ], [ %inext, %loopstep ]
+  %sp = getelementptr %Value, %Value* %src_args, i32 %i
+  %sv = load %Value, %Value* %sp
+  %dvc = call %Value @wam_dyn_copy_durable(%WamState* %vm, %Value %sv)
+  %dp = getelementptr %Value, %Value* %newargs, i32 %i
+  store %Value %dvc, %Value* %dp
+  %inext = add i32 %i, 1
+  %more = icmp slt i32 %inext, %ar
+  br i1 %more, label %loopstep, label %done
+loopstep:
+  br label %loop
+done:
+  %ni = ptrtoint %Compound* %newcp to i64
+  %r0 = insertvalue %Value undef, i32 3, 0
+  %r1 = insertvalue %Value %r0, i64 %ni, 1
+  ret %Value %r1
+}
+
+; Append (prepend=false) or prepend (prepend=true) a row into the store,
+; growing the array by realloc-doubling.
+define void @wam_dyn_store(i8* %functor, i32 %arity, %Value* %args, i1 %prepend) {
+entry:
+  %count = load i32, i32* @wam_dyn_count
+  %cap = load i32, i32* @wam_dyn_cap
+  %need_grow = icmp sge i32 %count, %cap
+  br i1 %need_grow, label %grow, label %have_cap
+grow:
+  %cap2 = mul i32 %cap, 2
+  %small = icmp slt i32 %cap2, 8
+  %newcap = select i1 %small, i32 8, i32 %cap2
+  %oldptr = load %WamDynClause*, %WamDynClause** @wam_dyn_ptr
+  %oldraw = bitcast %WamDynClause* %oldptr to i8*
+  %elsz = ptrtoint %WamDynClause* getelementptr (%WamDynClause, %WamDynClause* null, i32 1) to i64
+  %newcap64 = sext i32 %newcap to i64
+  %newbytes = mul i64 %elsz, %newcap64
+  %newraw = call i8* @realloc(i8* %oldraw, i64 %newbytes)
+  %newptr = bitcast i8* %newraw to %WamDynClause*
+  store %WamDynClause* %newptr, %WamDynClause** @wam_dyn_ptr
+  store i32 %newcap, i32* @wam_dyn_cap
+  br label %have_cap
+have_cap:
+  %ptr = load %WamDynClause*, %WamDynClause** @wam_dyn_ptr
+  br i1 %prepend, label %do_prepend, label %do_append
+do_prepend:
+  %elsz2 = ptrtoint %WamDynClause* getelementptr (%WamDynClause, %WamDynClause* null, i32 1) to i64
+  %cnt64 = sext i32 %count to i64
+  %movebytes = mul i64 %elsz2, %cnt64
+  %dst1 = getelementptr %WamDynClause, %WamDynClause* %ptr, i32 1
+  %dst1raw = bitcast %WamDynClause* %dst1 to i8*
+  %src0raw = bitcast %WamDynClause* %ptr to i8*
+  call void @llvm.memmove.p0i8.p0i8.i64(i8* %dst1raw, i8* %src0raw, i64 %movebytes, i1 false)
+  %slot0 = getelementptr %WamDynClause, %WamDynClause* %ptr, i32 0
+  br label %fill
+do_append:
+  %slotN = getelementptr %WamDynClause, %WamDynClause* %ptr, i32 %count
+  br label %fill
+fill:
+  %slot = phi %WamDynClause* [ %slot0, %do_prepend ], [ %slotN, %do_append ]
+  %f_fn = getelementptr %WamDynClause, %WamDynClause* %slot, i32 0, i32 0
+  store i8* %functor, i8** %f_fn
+  %f_ar = getelementptr %WamDynClause, %WamDynClause* %slot, i32 0, i32 1
+  store i32 %arity, i32* %f_ar
+  %f_lv = getelementptr %WamDynClause, %WamDynClause* %slot, i32 0, i32 2
+  store i32 1, i32* %f_lv
+  %f_args = getelementptr %WamDynClause, %WamDynClause* %slot, i32 0, i32 3
+  store %Value* %args, %Value** %f_args
+  %newcount = add i32 %count, 1
+  store i32 %newcount, i32* @wam_dyn_count
+  ret void
+}
+
+; assertz (prepend=false) / asserta (prepend=true): store a clause term as a
+; ground fact. Returns false only for a non-callable term (a number/var).
+define i1 @wam_dyn_assert(%WamState* %vm, %Value %clause, i1 %prepend) {
+entry:
+  %dc = call %Value @wam_deref_value(%WamState* %vm, %Value %clause)
+  %tag = call i32 @value_tag(%Value %dc)
+  %is_atom = icmp eq i32 %tag, 0
+  br i1 %is_atom, label %atom_clause, label %maybe_compound
+atom_clause:
+  %aid = call i64 @value_payload(%Value %dc)
+  %astr = call i8* @wam_atom_to_string(i64 %aid)
+  %astr_null = icmp eq i8* %astr, null
+  br i1 %astr_null, label %fail, label %atom_store
+atom_store:
+  %afn = call i8* @wam_dyn_dup_functor(i8* %astr)
+  call void @wam_dyn_store(i8* %afn, i32 0, %Value* null, i1 %prepend)
+  ret i1 true
+maybe_compound:
+  %is_comp = icmp eq i32 %tag, 3
+  br i1 %is_comp, label %comp_clause, label %fail
+comp_clause:
+  %pl = call i64 @value_payload(%Value %dc)
+  %cp = inttoptr i64 %pl to %Compound*
+  %fn_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 0
+  %fn = load i8*, i8** %fn_slot
+  %ar_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 1
+  %ar = load i32, i32* %ar_slot
+  %args_slot = getelementptr %Compound, %Compound* %cp, i32 0, i32 2
+  %src_args = load %Value*, %Value** %args_slot
+  %dfn = call i8* @wam_dyn_dup_functor(i8* %fn)
+  %vsz = ptrtoint %Value* getelementptr (%Value, %Value* null, i32 1) to i64
+  %ar64 = sext i32 %ar to i64
+  %argbytes = mul i64 %vsz, %ar64
+  %argsmem = call i8* @malloc(i64 %argbytes)
+  %dargs = bitcast i8* %argsmem to %Value*
+  %has = icmp sgt i32 %ar, 0
+  br i1 %has, label %cloop, label %cstore
+cloop:
+  %i = phi i32 [ 0, %comp_clause ], [ %inext, %cloopstep ]
+  %sp = getelementptr %Value, %Value* %src_args, i32 %i
+  %sv = load %Value, %Value* %sp
+  %cvd = call %Value @wam_dyn_copy_durable(%WamState* %vm, %Value %sv)
+  %dp = getelementptr %Value, %Value* %dargs, i32 %i
+  store %Value %cvd, %Value* %dp
+  %inext = add i32 %i, 1
+  %more = icmp slt i32 %inext, %ar
+  br i1 %more, label %cloopstep, label %cstore
+cloopstep:
+  br label %cloop
+cstore:
+  call void @wam_dyn_store(i8* %dfn, i32 %ar, %Value* %dargs, i1 %prepend)
+  ret i1 true
+fail:
+  ret i1 false
+}
+
+; retractall(Pattern): tombstone every live row whose head unifies with the
+; pattern. Pattern-side bindings are unwound after each test so they do not
+; leak. Always succeeds.
+define i1 @wam_dyn_retractall(%WamState* %vm, %Value %pattern) {
+entry:
+  %dp = call %Value @wam_deref_value(%WamState* %vm, %Value %pattern)
+  %tag = call i32 @value_tag(%Value %dp)
+  %is_atom = icmp eq i32 %tag, 0
+  br i1 %is_atom, label %pat_atom, label %pat_maybe_comp
+pat_atom:
+  %aid = call i64 @value_payload(%Value %dp)
+  %astr = call i8* @wam_atom_to_string(i64 %aid)
+  br label %scan_init
+pat_maybe_comp:
+  %is_comp = icmp eq i32 %tag, 3
+  br i1 %is_comp, label %pat_comp, label %ra_done
+pat_comp:
+  %cpl = call i64 @value_payload(%Value %dp)
+  %ccp = inttoptr i64 %cpl to %Compound*
+  %cfn_s = getelementptr %Compound, %Compound* %ccp, i32 0, i32 0
+  %cfn = load i8*, i8** %cfn_s
+  %car_s = getelementptr %Compound, %Compound* %ccp, i32 0, i32 1
+  %car = load i32, i32* %car_s
+  %cargs_s = getelementptr %Compound, %Compound* %ccp, i32 0, i32 2
+  %cargs = load %Value*, %Value** %cargs_s
+  br label %scan_init
+scan_init:
+  %pfn = phi i8* [ %astr, %pat_atom ], [ %cfn, %pat_comp ]
+  %par = phi i32 [ 0, %pat_atom ], [ %car, %pat_comp ]
+  %pargs = phi %Value* [ null, %pat_atom ], [ %cargs, %pat_comp ]
+  %count = load i32, i32* @wam_dyn_count
+  %store = load %WamDynClause*, %WamDynClause** @wam_dyn_ptr
+  %ts_p = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
+  %mark = load i32, i32* %ts_p
+  br label %scan
+scan:
+  %ri = phi i32 [ 0, %scan_init ], [ %rinext, %scan_cont ]
+  %sdone = icmp sge i32 %ri, %count
+  br i1 %sdone, label %ra_done, label %row
+row:
+  %row_ptr = getelementptr %WamDynClause, %WamDynClause* %store, i32 %ri
+  %lv_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 2
+  %lv = load i32, i32* %lv_s
+  %islive = icmp ne i32 %lv, 0
+  br i1 %islive, label %row_live, label %scan_cont
+row_live:
+  %rar_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 1
+  %rar = load i32, i32* %rar_s
+  %ar_eq = icmp eq i32 %rar, %par
+  br i1 %ar_eq, label %row_fn, label %scan_cont
+row_fn:
+  %rfn_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 0
+  %rfn = load i8*, i8** %rfn_s
+  %fn_eq = call i1 @wam_functor_eq(i8* %rfn, i8* %pfn)
+  br i1 %fn_eq, label %row_args, label %scan_cont
+row_args:
+  %rargs_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 3
+  %rargs = load %Value*, %Value** %rargs_s
+  br label %uloop
+uloop:
+  %ui = phi i32 [ 0, %row_args ], [ %uinext, %ucont ]
+  %uidone = icmp sge i32 %ui, %par
+  br i1 %uidone, label %matched, label %ustep
+ustep:
+  %pap = getelementptr %Value, %Value* %pargs, i32 %ui
+  %pav = load %Value, %Value* %pap
+  %rap = getelementptr %Value, %Value* %rargs, i32 %ui
+  %rav = load %Value, %Value* %rap
+  %uok = call i1 @wam_unify_value(%WamState* %vm, %Value %pav, %Value %rav)
+  br i1 %uok, label %ucont, label %after_test
+ucont:
+  %uinext = add i32 %ui, 1
+  br label %uloop
+matched:
+  store i32 0, i32* %lv_s
+  br label %after_test
+after_test:
+  call void @unwind_trail(%WamState* %vm, i32 %mark)
+  br label %scan_cont
+scan_cont:
+  %rinext = add i32 %ri, 1
+  br label %scan
+ra_done:
+  ret i1 true
+}
+
+; Consult the store for a goal whose meta-call resolution missed. Pushes a
+; dynamic-clause choice point (agg_type = -3) and yields the first matching
+; clause; returns false if no clause matches. functor/arity identify the
+; predicate; the goal itself is read from reg 0 by the iterator.
+define i1 @wam_dyn_consult(%WamState* %vm, i8* %functor, i32 %arity, i32 %return_pc) {
+entry:
+  call void @wam_cp_ensure_capacity(%WamState* %vm)
+  %cpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
+  %cpn = load i32, i32* %cpn_ptr
+  %cps_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 12
+  %cps = load %ChoicePoint*, %ChoicePoint** %cps_ptr
+  %cp = getelementptr %ChoicePoint, %ChoicePoint* %cps, i32 %cpn
+  %npc_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 0
+  store i32 0, i32* %npc_s
+  %dst = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 1, i32 0
+  %src = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
+  %dstr = bitcast %Value* %dst to i8*
+  %srcr = bitcast %Value* %src to i8*
+  ; Save 32 registers (512 bytes), matching the foreign-result iterator:
+  ; the aggregate machinery keeps state in the high registers, which must
+  ; survive unchanged across the solutions this CP yields.
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dstr, i8* %srcr, i64 512, i1 false)
+  %ts_p = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
+  %ts = load i32, i32* %ts_p
+  %tm_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 2
+  store i32 %ts, i32* %tm_s
+  %cpv_p = getelementptr %WamState, %WamState* %vm, i32 0, i32 11
+  %cpv = load i32, i32* %cpv_p
+  %scp_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 3
+  store i32 %cpv, i32* %scp_s
+  %at_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 4
+  store i32 -3, i32* %at_s
+  %fn_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 8
+  store i8* %functor, i8** %fn_s
+  %ar_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 9
+  store i32 %arity, i32* %ar_s
+  %cur_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 10
+  store i32 0, i32* %cur_s
+  %rpc_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 7
+  store i32 %return_pc, i32* %rpc_s
+  %hs_p = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs = load i32, i32* %hs_p
+  %sht_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 11
+  store i32 %hs, i32* %sht_s
+  %ncpn = add i32 %cpn, 1
+  store i32 %ncpn, i32* %cpn_ptr
+  %r = call i1 @wam_dyn_iter_next(%WamState* %vm)
+  ret i1 %r
+}
+
+; Advance the dynamic-clause iterator on the top choice point (agg_type -3).
+; Scans the store from the saved cursor for the next live row matching the
+; functor/arity, unifies the goal (reg 0) args against the row args, and on
+; full success sets PC to the return PC. On exhaustion pops the CP and keeps
+; backtracking. Called by @backtrack when it sees agg_type == -3.
+define i1 @wam_dyn_iter_next(%WamState* %vm) {
+entry:
+  %cpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
+  %cpn = load i32, i32* %cpn_ptr
+  %top_idx = sub i32 %cpn, 1
+  %cps_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 12
+  %cps = load %ChoicePoint*, %ChoicePoint** %cps_ptr
+  %top = getelementptr %ChoicePoint, %ChoicePoint* %cps, i32 %top_idx
+  %fn_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 8
+  %fn = load i8*, i8** %fn_s
+  %ar_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 9
+  %ar = load i32, i32* %ar_s
+  %cur_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 10
+  %cur0 = load i32, i32* %cur_s
+  %tm_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 2
+  %mark = load i32, i32* %tm_s
+  %count = load i32, i32* @wam_dyn_count
+  %store = load %WamDynClause*, %WamDynClause** @wam_dyn_ptr
+  br label %scan
+scan:
+  %ri = phi i32 [ %cur0, %entry ], [ %rinext, %scan_cont ]
+  %exhausted = icmp sge i32 %ri, %count
+  br i1 %exhausted, label %pop, label %row
+row:
+  %row_ptr = getelementptr %WamDynClause, %WamDynClause* %store, i32 %ri
+  %lv_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 2
+  %lv = load i32, i32* %lv_s
+  %islive = icmp ne i32 %lv, 0
+  br i1 %islive, label %row_live, label %scan_cont
+row_live:
+  %rar_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 1
+  %rar = load i32, i32* %rar_s
+  %ar_eq = icmp eq i32 %rar, %ar
+  br i1 %ar_eq, label %row_fn, label %scan_cont
+row_fn:
+  %rfn_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 0
+  %rfn = load i8*, i8** %rfn_s
+  %fn_eq = call i1 @wam_functor_eq(i8* %rfn, i8* %fn)
+  br i1 %fn_eq, label %candidate, label %scan_cont
+candidate:
+  %dst = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
+  %csrc = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 1, i32 0
+  %dstr = bitcast %Value* %dst to i8*
+  %csrcr = bitcast %Value* %csrc to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dstr, i8* %csrcr, i64 512, i1 false)
+  call void @unwind_trail(%WamState* %vm, i32 %mark)
+  %has_args = icmp sgt i32 %ar, 0
+  br i1 %has_args, label %get_goal, label %success
+get_goal:
+  %goal = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %gtag = call i32 @value_tag(%Value %goal)
+  %g_is_comp = icmp eq i32 %gtag, 3
+  br i1 %g_is_comp, label %goal_comp, label %scan_cont
+goal_comp:
+  %gpl = call i64 @value_payload(%Value %goal)
+  %gcp = inttoptr i64 %gpl to %Compound*
+  %gargs_s = getelementptr %Compound, %Compound* %gcp, i32 0, i32 2
+  %gargs = load %Value*, %Value** %gargs_s
+  %crargs_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 3
+  %crargs = load %Value*, %Value** %crargs_s
+  br label %uloop
+uloop:
+  %ui = phi i32 [ 0, %goal_comp ], [ %uinext, %ucont ]
+  %uidone = icmp sge i32 %ui, %ar
+  br i1 %uidone, label %success, label %ustep
+ustep:
+  %gap = getelementptr %Value, %Value* %gargs, i32 %ui
+  %gav = load %Value, %Value* %gap
+  %rap = getelementptr %Value, %Value* %crargs, i32 %ui
+  %rav = load %Value, %Value* %rap
+  %uok = call i1 @wam_unify_value(%WamState* %vm, %Value %gav, %Value %rav)
+  br i1 %uok, label %ucont, label %unify_fail
+ucont:
+  %uinext = add i32 %ui, 1
+  br label %uloop
+unify_fail:
+  call void @unwind_trail(%WamState* %vm, i32 %mark)
+  br label %scan_cont
+success:
+  %next = add i32 %ri, 1
+  store i32 %next, i32* %cur_s
+  %rpc_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 7
+  %rpc = load i32, i32* %rpc_s
+  call void @wam_set_pc(%WamState* %vm, i32 %rpc)
+  call void @wam_set_halted(%WamState* %vm, i1 false)
+  ret i1 true
+scan_cont:
+  %rinext = add i32 %ri, 1
+  br label %scan
+pop:
+  call void @unwind_trail(%WamState* %vm, i32 %mark)
+  store i32 %top_idx, i32* %cpn_ptr
+  %retry = call i1 @backtrack(%WamState* %vm)
+  ret i1 %retry
+}

--- a/templates/targets/llvm_wam/types.ll.mustache
+++ b/templates/targets/llvm_wam/types.ll.mustache
@@ -130,3 +130,15 @@
     i32,                                   ; 2: arity
     i32                                    ; 3: label_index (object-relative)
 }
+
+; One row of the process-global dynamic clause store (assert/retract). A
+; clause asserted at runtime must outlive the arena rewind, so functor and
+; args are malloc'd durable copies owned by the store (see
+; PLAWK_DYNAMIC_DB.md). live=0 is a lazy tombstone (retracted; skipped on
+; scan, row kept so a retract mid-iteration does not shift indices).
+%WamDynClause = type {
+    i8*,                                   ; 0: functor (malloc'd name copy)
+    i32,                                   ; 1: arity
+    i32,                                   ; 2: live (1=present, 0=retracted)
+    %Value*                                ; 3: args (malloc'd, arity cells)
+}

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -140,6 +140,32 @@ emitnum(S)   :- N is 6*7, number_codes(N, Cs), atom_codes(S, Cs).            % "
 emithdr(S)   :- number_codes(2, VC), atom_codes(V, VC), atom_concat('WAMO ', V, S). % "WAMO 2"
 emitcodes(S) :- atom_codes(S, [104,105]).                                   % "hi"
 
+% Dynamic clause store (eval bootstrap milestone 3b-db): assert facts at
+% runtime into the process-global store and call them back through the call/1
+% meta-call, which consults the store when the meta table misses (see
+% PLAWK_DYNAMIC_DB.md). Ground facts, PR 1. These run in a loaded object -- the
+% store is process-global, shared by the host and any loaded .wamo.
+% Deterministic call of an asserted fact.
+dsingle(R) :- assertz(fact(42)), G = fact(X), call(G), R = X.                  % 42
+% Argument-directed selection: the iterator scans past pair(a,_) (functor
+% matches, args do not) to unify pair(b,X).
+dselect(R) :- assertz(pair(a,1)), assertz(pair(b,2)), assertz(pair(c,3)),
+              G = pair(b,X), call(G), R = X.                                   % 2
+% Real choice-point backtracking (no findall): num(1) is yielded first, the
+% continuation X>=2 fails, backtrack re-enters the clause iterator, num(2)
+% succeeds. Proves the -3 choice point advances the store scan.
+dfirst(R) :- assertz(num(1)), assertz(num(2)),
+             G = num(X), call(G), X >= 2, R = X.                              % 2
+% asserta prepends: the prepended clause is the first solution.
+dorder(R) :- assertz(item(1)), assertz(item(2)), asserta(item(9)),
+             G = item(X), call(G), R = X.                                     % 9
+% retractall tombstones every match; the subsequent call then fails.
+dret(R) :- assertz(k(1)), assertz(k(2)), retractall(k(_)),
+           G = k(X), ( call(G) -> R = X ; R = 0 ).                            % 0
+% Partial retractall: only k2(2,_) is removed; k2(1,10) survives.
+dretp(R) :- assertz(k2(1,10)), assertz(k2(2,20)), retractall(k2(2,_)),
+            G = k2(A,B), call(G), R is A*100+B.                               % 110
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -532,6 +558,31 @@ test(emit_bytes_from_object,
     run_host(Host, W1, O1, 0), assertion(O1 == "42"),
     run_host(Host, W2, O2, 0), assertion(O2 == "WAMO 2"),
     run_host(Host, W3, O3, 0), assertion(O3 == "hi"),
+    !.
+
+% Dynamic clause store in a loaded object (eval bootstrap milestone 3b-db):
+% assertz/asserta/retractall build a process-global clause database at runtime,
+% and call/1 consults it (with unification and backtracking) when the meta
+% table misses. Each grammar runs in a fresh host process, so the store starts
+% empty. Ground facts, called via call/1 (PR 1). See PLAWK_DYNAMIC_DB.md.
+test(dynamic_clause_store_in_object,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    forall(member(Name-Expected,
+               [ dsingle-"42\n",   % deterministic assert + call
+                 dselect-"2\n",    % argument-directed clause selection
+                 dfirst-"2\n",     % choice-point backtracking (continuation fails)
+                 dorder-"9\n",     % asserta prepends
+                 dret-"0\n",       % retractall clears, call fails
+                 dretp-"110\n" ]), % partial retractall keeps the non-match
+           ( PI = Name/1,
+             directory_file_path(Dir, Name, Base),
+             atom_concat(Base, '.wamo', W),
+             write_wam_object([user:PI], [wamo_entry(PI)], W),
+             run_host(Host, W, Out, 0),
+             assertion(Out == Expected) )),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
## Summary

Adds a **mutable clause database** to the WAM/LLVM target — milestone **3b-db** of the eval bootstrap, the last genuinely-new runtime machinery before the eval/compile surface. This is **PR 1** of a planned three (design + scope in the new `docs/design/PLAWK_DYNAMIC_DB.md`).

The subtle part: every term the VM builds lives in the **arena**, which is rewound between queries and on backtrack. A clause you `assertz` must outlive all of that. So the store is a **process-global, malloc-backed table** (`%WamDynClause` = durable functor + arity + live flag + durably deep-copied args), following the same growable-global idiom as the runtime-interned atom table. Retraction is a **lazy tombstone**, so a `retract` mid-iteration doesn't shift the indices the consult iterator is walking.

## PR 1 scope — ground facts, called via `call/1`

- `assertz/1` (id 175), `asserta/1` (176), `retractall/1` (177) as `@execute_builtin` cases + `builtin_op_to_id` + `wamo_enc` loadable-subset entries — a loaded `.wamo` can build its **own** database (the eval-bootstrap need).
- **Calling** a dynamic fact goes through the `call/1` meta-call: when the compiled meta table misses, `@wam_dispatch_meta_call` now **consults the store** instead of failing. A new `agg_type = -3` choice point (`@wam_dyn_consult` / `@wam_dyn_iter_next`, dispatched from `@backtrack` alongside the `-2` foreign iterator) scans the store, unifies the goal args against each matching row with `@wam_unify_value`, and **backtracks** over solutions.

## Where the code lives

| Piece | File |
|---|---|
| Store globals + durable copy + assert/retractall + consult iterator | `templates/targets/llvm_wam/state.ll.mustache` (template file — no inline-IR quoting risk) |
| `%WamDynClause` type | `templates/targets/llvm_wam/types.ll.mustache` |
| Consult hook, `-3` backtrack dispatch, builtin cases + ids | `src/unifyweaver/targets/wam_llvm_target.pl` |
| `memmove` intrinsic (asserta prepend) | `templates/targets/llvm_wam/module.ll.mustache` |

## Tests

`tests/test_wam_object.pl` — a new `dynamic_clause_store_in_object` test (loaded-object round trip). Six grammars, each in a fresh host process (store starts empty):

| grammar | checks | result |
|---|---|---|
| `dsingle` | deterministic assert + call | `42` |
| `dselect` | argument-directed clause selection (scan past a non-matching row) | `2` |
| `dfirst` | **real choice-point backtracking, no findall** — `num(1)` yielded, continuation `X>=2` fails, iterator re-entered, `num(2)` found | `2` |
| `dorder` | `asserta` prepends | `9` |
| `dret` | `retractall` clears, call then fails | `0` |
| `dretp` | partial `retractall` keeps the non-match | `110` |

**27/27** in `wam_object`; no regressions across the `meta-call` / `choicepoint` / `wam_llvm_target` (82) suites.

## Deferred (see PLAWK_DYNAMIC_DB.md)

- **PR 2:** direct calls to `:- dynamic` predicates (`counter(N)` rather than `call(counter(N))`) — needs compile-time `:- dynamic` tracking + a new runtime dispatch — and nondet `retract/1` as a CP iterator.
- **PR 3:** rule bodies (`assertz((H :- B))`) — a body interpreter; the true long pole.
- Noted: `findall` over a `call/1` meta-call goal (`findall(X, call(G), L)`) is a **pre-existing** limitation, independent of this store (it affects compiled predicates too) — dynamic facts are exercised via direct `call/1` + backtracking instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_