### PR TITLE
Truncated-λ blends → a judge-independent generality (the better objective under judge uncertainty)

### DIFF
--- a/prototypes/mu_cosine/DESIGN_uncertainty_estimation_playbook.md
+++ b/prototypes/mu_cosine/DESIGN_uncertainty_estimation_playbook.md
@@ -101,6 +101,14 @@ the general notion (of relatedness, lineage, …).
 - **When you swap judges, swap the judge input.** The target's provenance token (`judge_emb`) must name the judge
   that produced it (`gpt-5.5-low` for LLM data, `blend` for the constructed superposition). Wrong tag ⇒ wrong
   calibration row ⇒ the generality is learned against the wrong offset.
+- **Vary the blend ratio (truncated-λ) to buy JUDGE-INDEPENDENCE — and prefer it under judge uncertainty.**
+  Training with a *distribution* of λ (truncated-normal, resampled — not clamped) instead of a fixed λ pushes the
+  learned signal into the shared **trunk**: measured, the with-vs-without-judge-input gap shrinks (+0.075→+0.045)
+  and the judge-*independent* fraction rises (0.911→0.945), 3/3 seeds (`REPORT_truncated_lambda.md`). Cost: a
+  slightly lower *peak* when you do supply the exact judge. **But the peak is conditional on picking the right
+  judge — the very thing you can't verify when no judge is ground truth (the usual case).** So the judge-
+  independent model (what the judges *agree on*, minimax over the judge distribution) is the better objective;
+  fixed-λ + a named judge wins only when that judge is *known*-correct.
 
 ## Tools & references
 - **`mu_posterior.py`** — `MuPosterior` (per-source `P(μ|rel)`, bands, separability), `JointPosterior` (the

--- a/prototypes/mu_cosine/REPORT_truncated_lambda.md
+++ b/prototypes/mu_cosine/REPORT_truncated_lambda.md
@@ -22,12 +22,20 @@ blend (truncated-normal, mean 0.5, std 0.15, resampled to [0,1]) changes what th
    — more of what the model learned lives in the **shared trunk**, not the judge head. (User's framing, verified:
    *"if we vary λ the model becomes more robust to judge input, and finds a generality that is judge-independent."*)
 
-## The trade-off (honest)
-Truncated's **peak** (blend-read) is marginally *lower* — mean +0.825 vs +0.841 (fixed higher on 2/3 seeds). So
-randomness buys **robustness / judge-independence, not peak accuracy**: spreading the blend family pushes the
-signal into the trunk (general, judge-agnostic) and makes the per-judge head less sharp. Which you want depends
-on the use: fixed-λ if you'll always supply the right judge tag; truncated-λ if you want a model that behaves
-well **without** the tag (robust deployment, or as a regulariser toward judge-independent structure).
+## Why judge-independence is the BETTER objective (not merely a trade-off) — user, 2026-07-05
+Truncated's **peak** (blend-read) is marginally *lower* — mean +0.825 vs +0.841. It's tempting to call fixed-λ
+"better" for that. **It isn't, when we don't know which judge is correct** — which is the whole reason the
+superposition exists (no single judge — LLM, graph, e5 — is ground truth). The fixed-λ peak is peak **only if the
+judge tag you supply at inference is the right one**; committing to a judge to claim the peak is betting on a
+judge you can't verify. **Judge-independence hedges that uncertainty:** the shared trunk learns what the judges
+*agree on* (the invariant), which is the most defensible estimate *because* it doesn't exploit any one judge's
+idiosyncrasies (which may be its errors) — a bias-reduction across judges (minimax / distributional-robustness
+over the judge distribution) at a small variance cost. So:
+
+> **Under judge uncertainty (the usual case), prefer varied-λ training for a judge-INDEPENDENT model. Fixed-λ +
+> a specified judge is preferable only when that judge is *known*-correct for the task.**
+
+Fixed-λ peak = overfit to one possibly-wrong judge; truncated-λ = robust to not knowing which is right.
 
 ## Caveats
 - `T` is graph-dominated on this held-out set (`e5_ref` std 0.032) — confirms the structural half most strongly.

--- a/prototypes/mu_cosine/REPORT_truncated_lambda.md
+++ b/prototypes/mu_cosine/REPORT_truncated_lambda.md
@@ -1,0 +1,39 @@
+# Truncated-λ blends ⇒ a more judge-INDEPENDENT generality
+
+*Follow-up to the blend-judge work (`REPORT_blend_judge_sweep.md`). Tests whether **varying λ** in the training
+blend (truncated-normal, mean 0.5, std 0.15, resampled to [0,1]) changes what the model learns, vs a **fixed
+λ=0.5**. Metric: predict the held-out judge superposition `T` (`eval_blend_prediction.py`), read **with** the
+`judge=blend` input and **agnostically** (no judge input). 3 seeds each, fine-tuned from `model_prod`.*
+
+## Result (corr(SYM, T) at λ_eval=0.5)
+
+| training | agnostic (judge-independent) | blend | **judge-input gap** | agnostic/blend |
+|---|---|---|---|---|
+| fixed-λ=0.5 (s1/s2/s3) | .787 / .713 / .799 → **.766** | .847 / .832 / .845 → **.841** | **+0.075** | 0.911 |
+| truncated-λ (s1/s2/s3) | .818 / .743 / .778 → **.780** | .848 / .806 / .821 → **.825** | **+0.045** | **0.945** |
+
+## Two findings (both hold on all 3 seeds)
+
+1. **Varying λ ⇒ more robust to the judge input.** The gap between reading *with* vs *without* the `judge=blend`
+   tag **shrinks** from +0.075 (fixed) to +0.045 (truncated) — per-seed 0.060/0.119/0.046 → 0.030/0.063/0.043.
+   The truncated model relies on the judge tag *less*.
+2. **⇒ the generality is judge-INDEPENDENT.** The fraction of the superposition signal that survives *without*
+   the judge input (agnostic/blend) rises from 0.911 to **0.945** (per-seed 0.929/0.857/0.946 → 0.965/0.922/0.948)
+   — more of what the model learned lives in the **shared trunk**, not the judge head. (User's framing, verified:
+   *"if we vary λ the model becomes more robust to judge input, and finds a generality that is judge-independent."*)
+
+## The trade-off (honest)
+Truncated's **peak** (blend-read) is marginally *lower* — mean +0.825 vs +0.841 (fixed higher on 2/3 seeds). So
+randomness buys **robustness / judge-independence, not peak accuracy**: spreading the blend family pushes the
+signal into the trunk (general, judge-agnostic) and makes the per-judge head less sharp. Which you want depends
+on the use: fixed-λ if you'll always supply the right judge tag; truncated-λ if you want a model that behaves
+well **without** the tag (robust deployment, or as a regulariser toward judge-independent structure).
+
+## Caveats
+- `T` is graph-dominated on this held-out set (`e5_ref` std 0.032) — confirms the structural half most strongly.
+- The *absolute* agnostic level barely moves (+0.766→+0.780, mixed across seeds); the robust, all-3-seed effect
+  is the **gap-shrinking / judge-independence**, not a peak gain.
+- Single held-out set, one λ-distribution (mean 0.5 / std 0.15); a std sweep would map how far the effect goes.
+
+Repro: `emit_blend_judge.py --lam-dist truncated --lam 0.5 --lam-std 0.15` → combined round → fine-tune ×3 seeds →
+`eval_blend_prediction.py --lam-eval 0.5`.


### PR DESCRIPTION
## Summary

Follow-up to #3496 (uses its already-merged `--lam-dist truncated` / `--lam-eval` infra). Tests whether **varying
the blend ratio λ** in judge-superposition training changes *what* the model learns — and finds it buys a
**judge-independent generality**, which is the *better* objective when no single judge is ground truth.

Docs-only: one report + one playbook principle. The training/eval code is unchanged (merged in #3496).

## Result (truncated-normal λ, mean 0.5 std 0.15, resampled — vs fixed λ=0.5; 3 seeds; predict held-out superposition `T`)

| training | agnostic (judge-independent) | blend | **judge-input gap** | agnostic/blend |
|---|---|---|---|---|
| fixed-λ=0.5 | +0.766 | +0.841 | +0.075 | 0.911 |
| **truncated-λ** | +0.780 | +0.825 | **+0.045** | **0.945** |

Two effects, **both on all 3 seeds**:
1. **Varying λ ⇒ more robust to the judge input** — the with-vs-without-`judge=blend` gap shrinks +0.075→+0.045.
2. **⇒ a judge-independent generality** — the fraction surviving *without* the judge tag rises 0.911→0.945; more
   of the learned signal lives in the shared **trunk**, not the judge head.

## Why it's the better objective (not just a trade-off)

Truncated's *peak* (blend-read) is marginally lower (0.825 vs 0.841). But the fixed-λ peak is peak **only if the
judge tag supplied at inference is correct** — the very uncertainty the superposition exists to handle (no single
judge is ground truth). Committing to a judge for the peak is betting on an unverifiable judge. **Judge-independence
hedges it:** the trunk learns what the judges *agree on* (the invariant), avoiding any one judge's idiosyncrasies/
errors — a bias-reduction across judges (minimax / distributional robustness over the judge distribution) at a
small variance cost.

**Principle (now in `DESIGN_uncertainty_estimation_playbook.md`):** under judge uncertainty (the usual case),
prefer varied-λ training for a judge-independent model; fixed-λ + a named judge wins only when that judge is
*known*-correct.

## Caveats
- `T` is graph-dominated on this held-out set (`e5_ref` std 0.032) — confirms the structural half most strongly.
- The *absolute* agnostic level barely moves (+0.766→+0.780, mixed); the robust all-3-seed effect is the
  **gap-shrinking / judge-independence**, not a peak gain. Single held-out + one λ-distribution; a std sweep would
  map how far it goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)