### PR TITLE
WAM: fix findall/aggregate over a call/1 meta-call goal

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -209,10 +209,13 @@ independently useful (richer hand-written grammars load sooner).
    now parse whole clauses from source text — and the dynamic store gives a
    grammar mutable state.
 
-   (Aside: `findall/setof/bagof` over a `call/1` meta-call goal — e.g.
-   `findall(X, call(G), L)` — is a pre-existing limitation independent of the
-   store: the meta-call inside the aggregate collects nothing. Dynamic facts
-   are exercised via direct `call/1` + backtracking instead. A separate fix.)
+   (Aside: `findall(X, call(G), L)` — an aggregate over a `call/1` meta-call
+   goal — is now fixed. It used to collect nothing: the tier-2 compiler
+   re-initialised the aggregate template variable with a fresh cell, breaking
+   the sharing with the copy embedded in the pre-built goal `G`, so the goal
+   bound one cell while the aggregate collected another. The fix skips that
+   re-initialisation when the template var already has a register. Works for
+   both object-compiled predicates and dynamic-store facts.)
 4. **Byte-buffer output from a grammar. — landed.** The compiler object must
    *emit* `.wamo` bytes. It returns them as an Atom/byte string (the item-2
    blob bridge already carries bytes out); building that byte string inside the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1868,8 +1868,19 @@ compile_aggregate_all(Template, InnerGoal, Result, V0, Vf, Code) :-
         InitResultCode = ""
     ),
     % Compile the Value register (what gets collected per solution)
-    (   var(ValueVar)
-    ->  % ValueVar is a Prolog variable — allocate a Y-register for it
+    (   var(ValueVar), get_var_reg(ValueVar, V1, ValueReg)
+    ->  % The template var already has a register: it is shared with a term
+        % constructed BEFORE this aggregate -- e.g. findall(X, call(G), L)
+        % where an earlier `G = pc(X)` built X''s cell -- or it is a head
+        % variable. Do NOT re-initialize it. The existing cell IS the
+        % template, and backtracking refreshes it each solution. Emitting
+        % `put_variable ValueReg, ValueReg` here would allocate a FRESH cell
+        % disconnected from the goal, so the inner goal binds one cell while
+        % end_aggregate collects another -- the findall/call/1 case that used
+        % to collect nothing. (Mirrors the Result-register logic above.)
+        V2 = V1, InitValueCode = "", ConstructionCode = ""
+    ;   var(ValueVar)
+    ->  % ValueVar is a fresh Prolog variable — allocate a Y-register for it
         allocate_var(ValueVar, V1, V2, ValueReg),
         % Emit put_variable to actually create the Y-register in the env
         % frame. Use the SELF-INIT form (put_variable Y_n, Y_n) rather

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -166,6 +166,18 @@ dret(R) :- assertz(k(1)), assertz(k(2)), retractall(k(_)),
 dretp(R) :- assertz(k2(1,10)), assertz(k2(2,20)), retractall(k2(2,_)),
             G = k2(A,B), call(G), R is A*100+B.                               % 110
 
+% findall over a call/1 meta-call goal. This used to collect nothing: the
+% tier-2 compiler re-initialised the aggregate template variable with a fresh
+% cell (put_variable), disconnecting it from the copy embedded in the
+% pre-built goal G, so the goal bound one cell while the aggregate collected
+% another. Fixed by not re-initialising a template var that already has a
+% register (it is shared with G; backtracking refreshes it). Two flavours:
+% a predicate compiled into the object, and dynamically asserted facts.
+fanum(1). fanum(2). fanum(3).
+faobjc(S)  :- G = fanum(X), findall(X, call(G), L), sum_list(L, S).           % 6
+fadynsum(S) :- assertz(dv(10)), assertz(dv(20)), assertz(dv(30)),
+               G = dv(X), findall(X, call(G), L), sum_list(L, S).             % 60
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -583,6 +595,23 @@ test(dynamic_clause_store_in_object,
              write_wam_object([user:PI], [wamo_entry(PI)], W),
              run_host(Host, W, Out, 0),
              assertion(Out == Expected) )),
+    !.
+
+% Regression: findall/3 over a call/1 meta-call goal now collects correctly
+% (was a template-variable aliasing bug in the aggregate lowering). Covers
+% both a predicate compiled into the object (fanum/1 must be included so the
+% meta table resolves it) and dynamically asserted facts consulted through
+% the store.
+test(findall_over_meta_call, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'faobjc.wamo', W1),
+    directory_file_path(Dir, 'fadynsum.wamo', W2),
+    write_wam_object([user:faobjc/1, user:fanum/1], [wamo_entry(faobjc/1)], W1),
+    write_wam_object([user:fadynsum/1], [wamo_entry(fadynsum/1)], W2),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, W1, O1, 0), assertion(O1 == "6\n"),
+    run_host(Host, W2, O2, 0), assertion(O2 == "60\n"),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
## Summary

Fixes a tier-2 compiler bug where **`findall(X, call(G), L)`** (and any aggregate whose template variable is shared with a goal term built *before* the aggregate) collected nothing. This is the "pre-existing limitation" flagged in the dynamic-clause-store PR (#3498) — doing it first so `findall` over dynamically-asserted facts works before PR 2's dispatch work lands on top.

## Root cause

`compile_aggregate_all` always emitted a self-init `put_variable ValueReg, ValueReg` for a variable template. The WAM lowering of `G = pc(X), findall(X, call(G), L)` showed the problem:

```
put_structure pc/1, A2
set_variable Y1          ; Y1 = X, embedded in G = pc(X)
builtin_call =/2, 2      ; G := pc(Y1)
put_variable Y1, Y1      ; <-- RESET Y1 to a fresh cell, disconnecting it from G
begin_aggregate collect, Y1, Y3
put_value Y2, A1         ; A1 = G = pc(old Y1)
call call/1, 1           ; binds old Y1 ... but the aggregate collects the new Y1
```

So the inner goal bound one cell and `end_aggregate` collected another, which stayed unbound → empty result.

## Fix

Mirror the existing `Result`-register logic: if the template variable **already has a register** (`get_var_reg` succeeds — it's shared with a pre-built term, or head-bound), don't re-initialise it. The existing cell *is* the template, and backtracking refreshes it each solution. Genuinely fresh templates are unchanged (`get_var_reg` fails → allocate + self-init as before), so the change only touches the previously-broken shared-template case.

One targeted change in `src/unifyweaver/targets/wam_target.pl` (shared by all WAM backends).

## Tests

`tests/test_wam_object.pl` — new `findall_over_meta_call`: `findall` over `call/1` of both an object-compiled predicate (`fanum` → 6) and dynamically-asserted store facts (`dv` → 60).

No regressions:

| suite | result |
|---|---|
| `wam_object` | 28 pass |
| `wam_target` | all pass |
| `wam_llvm_target` | 82 pass |
| `wam_llvm_meta_call_runtime` | pass |
| `wam_cross_target_consistency` | 22 pass |
| `wam_c_target` | pass (UTF-8) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_