### PR TITLE
WAM/LLVM (roadmap #5, milestone 3b-db, PR 2): direct dynamic calls + nondet retract

### DIFF
--- a/docs/design/PLAWK_DYNAMIC_DB.md
+++ b/docs/design/PLAWK_DYNAMIC_DB.md
@@ -1,9 +1,11 @@
 # Dynamic clause store (assert / retract) for the WAM/LLVM target
 
-Status: **PR 1 landed — ground dynamic facts, called via `call/1`.** This is
-milestone **3b-db** of the eval bootstrap (see PLAWK_EVAL_BOOTSTRAP.md). It is
-the last genuinely-new runtime machinery before the eval/compile surface: a
-mutable clause database in a VM whose term arena is rewound between queries.
+Status: **PR 1 + PR 2 landed.** PR 1: the store + `assertz`/`asserta`/
+`retractall` + ground facts called via `call/1`. PR 2: **direct** calls to
+`:- dynamic` predicates (no explicit `call/1`) and **nondet `retract/1`**.
+This is milestone **3b-db** of the eval bootstrap (see PLAWK_EVAL_BOOTSTRAP.md):
+a mutable clause database in a VM whose term arena is rewound between queries —
+the last genuinely-new runtime machinery before the eval/compile surface.
 
 ## Why it is the subtle one
 
@@ -67,14 +69,21 @@ ground once fully built). Concretely, in PR 1:
 
 ## Calling a dynamic predicate
 
-The probe that motivated the split: `getc(N) :- counter(N)` lowers to
-`execute counter/1` with an **unresolved label** (no compiled clauses for
-`counter/1`), which today silently defaults to label index 0. Routing that
-*direct* call to the store needs compile-time `:- dynamic` tracking plus a new
-runtime dispatch — that is **PR 2**.
+`getc(N) :- counter(N)` lowers to `execute counter/1` with an **unresolved
+label** (no compiled clauses for `counter/1`), which used to silently default
+to label index 0. **PR 2** routes such *direct* calls to the store without any
+new runtime dispatch: the tier-2 compiler (`dynamic_store_goal/1` in
+`wam_target.pl`) detects a body goal calling a `:- dynamic` predicate that has
+no compiled clauses and **rewrites it to a `call/1` meta-call** —
+`counter(N)` → `call(counter(N))`, which lowers to `execute call/1` and flows
+through the exact path below. Detection is `predicate_property(Mod:Head,
+dynamic)` + no `clause/2` (the compile module is recorded in `b_setval`); a
+dynamic predicate that also has compiled clauses is left as a static call
+(mixing compiled + asserted clauses for one predicate is out of scope).
 
-PR 1 reaches the store through the path that already resolves runtime-built
-goals: the `call/1` meta-call. `G = counter(X), call(G)` lowers to
+Both PR 1's explicit `call/1` and PR 2's rewritten direct calls reach the store
+through the path that resolves runtime-built goals: the `call/1` meta-call.
+`G = counter(X), call(G)` lowers to
 `call call/1` (label index −1), handled by `@wam_dispatch_meta_call`, which
 resolves the goal's functor/arity against the compiled meta-call table and
 `fail`s when nothing matches. That `fail` is the hook: on a miss we consult the
@@ -134,18 +143,32 @@ database — the eval-bootstrap need):
 | `asserta/1` | 176 | `@wam_dyn_assert(vm, A1, /*prepend*/ true)` |
 | `retractall/1` | 177 | `@wam_dyn_retractall(vm, A1)` — tombstone every live row whose head unifies with the pattern (pattern bindings unwound after each test); always succeeds |
 
-`retract/1` lowers to `call retract/1` (nondet, dispatched as a choice-point
-iterator per `wam_target.pl`), so it lands with the dispatch work in **PR 2**.
+### retract/1 — nondet (PR 2)
+
+`retract/1` is NOT in `is_builtin_pred`, so it lowers to `call retract/1` /
+`execute retract/1` (a nondet operation, not a plain builtin). PR 2 recognises
+`"retract/1"` in the LLVM call/execute lowering and emits the op1 sentinel
+**−3** (alongside −1 for meta-call), which the `do_call` / `do_execute` opcode
+handlers route to `@wam_dyn_retract_consult`. That reads the pattern from
+reg 0, extracts its functor/arity, and pushes a **new `agg_type = −4`
+choice point** — a retract iterator (`@wam_dyn_retract_iter_next`, dispatched
+from `@backtrack` next to −2/−3). It is the consult iterator plus one step: on
+a matching unify it **tombstones the row** (`live = 0`) before yielding, so
+each solution removes one clause and backtracking removes the next. Works in
+call position (`retract(X), More`) and last-call position, and drives cleanly
+under `findall(X, retract(p(X)), L)` to remove every match.
 
 ## Roadmap
 
-- **PR 1 (this):** durable store; `assertz`/`asserta`/`retractall`; calling
-  ground dynamic facts via `call/1`. AOT + loaded-object tests.
-- **PR 2:** compile-time `:- dynamic P/N` tracking so direct calls
-  (`counter(N)`) resolve to the store; nondet `retract/1` as a CP iterator;
-  `call/N` partial-application consult.
+- **PR 1:** durable store; `assertz`/`asserta`/`retractall`; calling ground
+  dynamic facts via `call/1`.
+- **PR 2:** compiler rewrite of direct `:- dynamic` calls to `call/1`
+  (`dynamic_store_goal/1`); nondet `retract/1` as an `agg_type = −4` CP
+  iterator (op1 = −3 sentinel). AOT + loaded-object tests.
 - **PR 3 (later):** rule bodies (`assertz((H :- B))`) — a body interpreter for
   asserted clauses. The true long pole; likely unneeded for the eval bootstrap
   if the compiler's dynamic predicates are all fact tables.
-- Optimizations: functor+arity index over the store; variable-map durable copy
-  for non-ground asserts.
+- Follow-ups / optimizations: `call/N` partial-application consult (the
+  iterator currently reads the complete goal from reg 0); a functor+arity index
+  over the store (the scan is O(n) per backtrack); a variable-map durable copy
+  for non-ground asserts; mixing compiled + asserted clauses for one predicate.

--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -115,7 +115,7 @@ independently useful (richer hand-written grammars load sooner).
    | `findall`/`aggregate_all`, `setof`/`bagof` | `begin_aggregate`/`end_aggregate` (tags 28/29) | **yes, this PR** — opcodes lifted into the subset; setof/bagof additionally need `inline_bagof_setof(true)`, now the `.wamo` default |
    | `term_to_atom/2` (write direction) | `builtin_call term_to_atom/2` (id 173) → `@wam_term_to_sb` | **yes, milestone 3b** — a recursive term→text writer into a growable buffer, interned as an atom. Works in loaded objects too: cons detection is by functor *bytes*, not pointer identity. Unquoted (write semantics), so it does not yet round-trip through a reader |
    | `assertz`/`asserta`/`retractall` | `builtin_call <name>` (ids 175/176/177) → `@wam_dyn_assert` / `@wam_dyn_retractall` | **yes, milestone 3b-db (PR 1)** — a process-global, malloc-backed clause store that survives the arena rewind. Ground facts; calling them goes through the `call/1` meta-call, whose meta-table miss consults the store with unification + backtracking (`agg_type = -3` choice point). See PLAWK_DYNAMIC_DB.md |
-   | `retract/1` (nondet), direct calls to `:- dynamic` predicates | `call retract/1` / `execute <dyn>/N` with an unresolved label | **PR 2** — nondet `retract` as a CP iterator; compile-time `:- dynamic` tracking so `counter(N)` (not just `call(counter(N))`) resolves to the store |
+   | `retract/1` (nondet), direct calls to `:- dynamic` predicates | `call retract/1` / `execute <dyn>/N` | **yes, milestone 3b-db (PR 2)** — direct dynamic calls are rewritten to a `call/1` store consult (`dynamic_store_goal/1`); nondet `retract/1` is an `agg_type = -4` remove+unify+backtrack iterator (op1 = -3 sentinel). See PLAWK_DYNAMIC_DB.md |
    | `read_term`/`read_term_from_atom` | `builtin_call read_term_from_atom/2` (id 174) → the reader | **yes, milestone 3b** — a tokenizer + operator-precedence recursive-descent parser (done: canonical + operator surface, variables, control ops, floats, quoted atoms) |
    | `catch`/`throw` | `execute catch/3` — a call to a runtime *library predicate*, not a builtin | **no** — the loaded object references `catch/3`, which lives in the host, not the object; needs cross-object/host predicate linkage (milestone 3c) |
 
@@ -191,15 +191,17 @@ independently useful (richer hand-written grammars load sooner).
    the next quote; no escape handling yet). Verified in loaded objects:
    `3.5 + 1.5` → 5, negative/compound floats, and `'hello world'` → length 11.
 
-   **Dynamic clause store (milestone 3b-db) — PR 1 landed.** A process-global,
-   malloc-backed clause store (survives the arena rewind) with `assertz` /
-   `asserta` / `retractall` builtins, and calling ground dynamic facts via the
-   `call/1` meta-call (its meta-table miss consults the store, with unification
-   and backtracking through a new `agg_type = -3` choice point). Works in loaded
-   objects — the store is process-global. See **PLAWK_DYNAMIC_DB.md** for the
-   full design and the PR breakdown. Remaining there: direct calls to `:-
-   dynamic` predicates (`counter(N)` rather than `call(counter(N))`) + nondet
-   `retract/1` (PR 2), and rule bodies (PR 3).
+   **Dynamic clause store (milestone 3b-db) — PR 1 + PR 2 landed.** A
+   process-global, malloc-backed clause store (survives the arena rewind) with
+   `assertz` / `asserta` / `retractall` builtins. Calling a dynamic fact goes
+   through the `call/1` meta-call (its meta-table miss consults the store, with
+   unification and backtracking through an `agg_type = -3` choice point), and
+   PR 2 makes **direct** calls (`counter(N)`, not just `call(counter(N))`) reach
+   it by rewriting them to `call/1` at compile time, plus **nondet `retract/1`**
+   as an `agg_type = -4` remove+unify+backtrack iterator. Works in loaded
+   objects — the store is process-global. See **PLAWK_DYNAMIC_DB.md**.
+   Remaining there: rule bodies (`assertz((H :- B))`, PR 3) and `call/N`
+   partial-application consult.
 
    **Remaining (3b/3c):** `catch`/`throw` predicate linkage. A minor
    loadable-subset gap also surfaced: `arg/3` with a constant index compiles to

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -328,14 +328,14 @@ loadable along the way.
   works in loaded objects (byte-based cons detection) — and the **reader**
   (`read_term_from_atom/2`): a recursive-descent parser with operator
   precedence, variables, control operators, floats and quoted atoms. A loaded
-  object can now parse whole clauses from source text. Milestone 3b-db (PR 1)
-  adds a **dynamic clause store**: a process-global, malloc-backed clause
-  database (survives the arena rewind) with `assertz`/`asserta`/`retractall`
-  and calling ground dynamic facts via `call/1` (the meta-call consults the
-  store, with unification and backtracking). See PLAWK_DYNAMIC_DB.md. Remaining:
-  direct calls to `:- dynamic` predicates + nondet `retract/1` (3b-db PR 2),
-  rule bodies (PR 3), and `catch`/`throw` predicate linkage (3c) — the true
-  long pole. See the bootstrap doc for the full loadability matrix.
+  object can now parse whole clauses from source text. Milestone 3b-db (PR 1 +
+  PR 2) adds a **dynamic clause store**: a process-global, malloc-backed clause
+  database (survives the arena rewind) with `assertz`/`asserta`/`retractall`;
+  calling dynamic facts via `call/1` AND via direct calls (`counter(N)`,
+  rewritten to `call/1` at compile time); and nondet `retract/1` (a
+  remove+unify+backtrack iterator). See PLAWK_DYNAMIC_DB.md. Remaining: rule
+  bodies (`assertz((H :- B))`, PR 3) and `catch`/`throw` predicate linkage (3c)
+  — the true long pole. See the bootstrap doc for the full loadability matrix.
 - **Milestone 4 — byte-buffer output from a grammar — LANDED.** A loaded
   grammar assembles a byte string at runtime (via the milestone-3 string/codes
   builtins) and returns it as an Atom; the host reads it back through

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3534,10 +3534,19 @@ dealloc.done:
   ret i1 true').
 
 wam_llvm_case('do_call',
-'  ; op1 = label index or -1 for meta-call, op2 = arity
+'  ; op1 = label index, -1 for meta-call, or -3 for retract/1; op2 = arity
   %call.label = trunc i64 %op1 to i32
   %call.pc = call i32 @wam_get_pc(%WamState* %vm)
   %call.next = add i32 %call.pc, 1
+  %call.is_retract = icmp eq i32 %call.label, -3
+  br i1 %call.is_retract, label %call.retract, label %call.check_meta
+
+call.retract:
+  ; retract/1: the pattern is in reg 0; consult + remove + backtrack.
+  %call.retract_ok = call i1 @wam_dyn_retract_consult(%WamState* %vm, i32 %call.next)
+  br i1 %call.retract_ok, label %call.meta_done, label %call.fail
+
+call.check_meta:
   %call.is_meta = icmp slt i32 %call.label, 0
   br i1 %call.is_meta, label %call.meta, label %call.static
 
@@ -3569,8 +3578,18 @@ call.fail:
   ret i1 false').
 
 wam_llvm_case('do_execute',
-'  ; op1 = label index or -1 for meta-call, op2 = total arity for meta-call
+'  ; op1 = label index, -1 for meta-call, or -3 for retract/1
   %exec.label = trunc i64 %op1 to i32
+  %exec.is_retract = icmp eq i32 %exec.label, -3
+  br i1 %exec.is_retract, label %exec.retract, label %exec.check_meta
+
+exec.retract:
+  ; retract/1 in last-call position: continuation is the current CP.
+  %exec.rpc = call i32 @wam_get_cp(%WamState* %vm)
+  %exec.retract_ok = call i1 @wam_dyn_retract_consult(%WamState* %vm, i32 %exec.rpc)
+  br i1 %exec.retract_ok, label %exec.meta_done, label %exec.fail
+
+exec.check_meta:
   %exec.is_meta = icmp slt i32 %exec.label, 0
   br i1 %exec.is_meta, label %exec.meta, label %exec.static
 
@@ -4094,7 +4113,17 @@ check_dyn:
   ; If the top CP is a dynamic-clause iterator (agg_type == -3), advance
   ; the store scan and yield the next matching asserted clause.
   %is_dyn = icmp eq i32 %ca_at, -3
-  br i1 %is_dyn, label %do_dyn_yield, label %restore
+  br i1 %is_dyn, label %do_dyn_yield, label %check_retract
+
+check_retract:
+  ; agg_type == -4: a retract/1 iterator -- advance the scan, remove and
+  ; yield the next matching clause.
+  %is_ret = icmp eq i32 %ca_at, -4
+  br i1 %is_ret, label %do_retract_yield, label %restore
+
+do_retract_yield:
+  %ry_ok = call i1 @wam_dyn_retract_iter_next(%WamState* %vm)
+  ret i1 %ry_ok
 
 do_dyn_yield:
   %dy_ok = call i1 @wam_dyn_iter_next(%WamState* %vm)
@@ -18495,6 +18524,15 @@ wam_instruction_to_llvm_literal(retry_me_else(L), _) :-
 wam_meta_call_label(Label) :-
     wam_meta_call_total_arity(Label, _).
 
+%% wam_retract_call_label(+Label) is semidet.
+%  retract/1 lowers to a call/execute whose op1 is the sentinel -3, which the
+%  runtime routes to the nondet retract iterator (@wam_dyn_retract_consult).
+%  Recognised here so "retract/1" is not treated as an unknown static label
+%  (which would warn / default to index 0). See PLAWK_DYNAMIC_DB.md.
+wam_retract_call_label(Label) :-
+    ( atom(Label) -> atom_string(Label, S) ; S = Label ),
+    S == "retract/1".
+
 wam_meta_call_total_arity(Label, Arity) :-
     (   atom(Label)
     ->  atom_string(Label, LabelString)
@@ -18512,13 +18550,18 @@ wam_meta_call_total_arity(Label, Arity) :-
 %  line comment to end-of-line, which eats the comma separator in array
 %  constants and produces a parser error.
 wam_instruction_to_llvm_literal(call(P, N), LabelMap, Lit) :- !,
-    (   wam_meta_call_label(P)
+    (   wam_retract_call_label(P)
+    ->  LabelIdx = -3
+    ;   wam_meta_call_label(P)
     ->  LabelIdx = -1
     ;   lookup_label_index(P, LabelMap, LabelIdx)
     ),
     format(atom(Lit), '{ i32 18, i64 ~w, i64 ~w }', [LabelIdx, N]).
 wam_instruction_to_llvm_literal(execute(P), LabelMap, Lit) :- !,
-    (   wam_meta_call_label(P)
+    (   wam_retract_call_label(P)
+    ->  LabelIdx = -3,
+        Arity = 1
+    ;   wam_meta_call_label(P)
     ->  LabelIdx = -1,
         wam_meta_call_total_arity(P, Arity)
     ;   lookup_label_index(P, LabelMap, LabelIdx),
@@ -20819,14 +20862,18 @@ lookup_label_index(LabelName, LabelMap, Options, Index) :-
 wam_line_to_llvm_literal_resolved(["call", P, N], LabelMap, Lit) :- !,
     clean_comma(P, CP), clean_comma(N, CN),
     (   number_string(Arity, CN) -> true ; Arity = 0 ),
-    (   wam_meta_call_label(CP)
+    (   wam_retract_call_label(CP)
+    ->  LabelIdx = -3
+    ;   wam_meta_call_label(CP)
     ->  LabelIdx = -1
     ;   lookup_label_index(CP, LabelMap, LabelIdx)
     ),
     format(atom(Lit), '%Instruction { i32 18, i64 ~w, i64 ~w }', [LabelIdx, Arity]).
 wam_line_to_llvm_literal_resolved(["execute", P], LabelMap, Lit) :- !,
     clean_comma(P, CP),
-    (   wam_meta_call_label(CP)
+    (   wam_retract_call_label(CP)
+    ->  LabelIdx = -3, Arity = 1
+    ;   wam_meta_call_label(CP)
     ->  LabelIdx = -1,
         wam_meta_call_total_arity(CP, Arity)
     ;   lookup_label_index(CP, LabelMap, LabelIdx),
@@ -21584,13 +21631,17 @@ wamo_enc(["builtin_call", Op, N], _, A, A, F, F, enc(21, Id, Num, none)) :- !,
 wamo_enc(["call", P, N], LabelMap, A, A, F, F, enc(18, Idx, Arity, none)) :- !,
     clean_comma(P, CP), clean_comma(N, CN),
     ( number_string(Arity, CN) -> true ; Arity = 0 ),
-    (   wam_meta_call_label(CP)
+    (   wam_retract_call_label(CP)
+    ->  Idx = -3
+    ;   wam_meta_call_label(CP)
     ->  Idx = -1
     ;   wamo_label(CP, LabelMap, Idx)
     ).
 wamo_enc(["execute", P], LabelMap, A, A, F, F, enc(19, Idx, Op2, none)) :- !,
     clean_comma(P, CP),
-    (   wam_meta_call_label(CP)
+    (   wam_retract_call_label(CP)
+    ->  Idx = -3, Op2 = 1
+    ;   wam_meta_call_label(CP)
     ->  Idx = -1, wam_meta_call_total_arity(CP, Op2)
     ;   wamo_label(CP, LabelMap, Idx), Op2 = 0
     ).

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -74,6 +74,9 @@ resolve_wam_predicate_indicator(PredIndicator, Options, Module, Pred, Arity) :-
 %  predicate resolution and missing-predicate behaviour.
 wam_predicate_clauses(PredIndicator, Options, Pred, Arity, Clauses) :-
     resolve_wam_predicate_indicator(PredIndicator, Options, Module, Pred, Arity),
+    % Record the module so the body-goal compiler can detect direct calls to
+    % :- dynamic predicates (routed to the runtime clause store via call/1).
+    b_setval(wam_compile_module, Module),
     functor(Head, Pred, Arity),
     findall(Head-Body, clause(Module:Head, Body), Clauses),
     (   Clauses = []
@@ -1613,8 +1616,44 @@ pre_bind_unbound_yi([Var|Rest], Bindings, YI, NewBindings) :-
         pre_bind_unbound_yi(Rest, [y_alloc(Var, YReg)|Bindings], NYI, NewBindings)
     ).
 
+%% dynamic_store_goal(+Goal) is semidet.
+%  True when Goal is a direct call to a user predicate that is declared
+%  `:- dynamic` and has NO compiled clauses in the compilation module -- i.e.
+%  it lives only in the runtime clause store. Such a goal has no label to
+%  compile a static call to, so compile_goals rewrites it to `call(Goal)`.
+%  Excludes builtins, control constructs, call/N (already a meta-call), and
+%  predicates that DO have clauses (those compile normally; mixing compiled
+%  and asserted clauses for one predicate is out of scope -- see
+%  PLAWK_DYNAMIC_DB.md).
+dynamic_store_goal(Goal) :-
+    nonvar(Goal),
+    Goal \= (_ , _),
+    Goal \= (_ ; _),
+    Goal \= (_ -> _),
+    Goal \= (_ : _),
+    Goal \= \+(_),
+    functor(Goal, Pred, Arity),
+    Pred \== call,
+    \+ is_builtin_pred(Pred, Arity),
+    ( catch(b_getval(wam_compile_module, Mod), _, fail) -> true ; Mod = user ),
+    functor(Head, Pred, Arity),
+    catch(predicate_property(Mod:Head, dynamic), _, fail),
+    \+ clause(Mod:Head, _).
+
 %% compile_goals(+Goals, +VarMap, +HasEnv, -Vf, -Code)
 compile_goals([], V, _, V, "").
+compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
+    % Direct call to a :- dynamic predicate with no compiled clauses (e.g.
+    % `counter(N)` where counter/1 lives only in the runtime clause store).
+    % There is no compiled label to jump to, so rewrite it to a call/1
+    % meta-call: `counter(N)` -> `call(counter(N))`. That lowers to
+    % `call call/1` / `execute call/1`, and the meta-call dispatch consults
+    % the dynamic store on a table miss (WAM/LLVM target; other targets get
+    % a clean meta-call failure instead of a jump to label 0). See
+    % PLAWK_DYNAMIC_DB.md.
+    dynamic_store_goal(Goal),
+    !,
+    compile_goals([call(Goal)|Rest], V0, HasEnv, Vf, Code).
 compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
     % Check for aggregate_all/findall/bagof/setof first — these are
     % always compiled inline.

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -5166,3 +5166,175 @@ pop:
   %retry = call i1 @backtrack(%WamState* %vm)
   ret i1 %retry
 }
+
+; retract/1 (nondet): find a live clause whose head unifies with the pattern
+; (reg 0), remove it (tombstone), unify, and yield; on backtrack find the next
+; match. The pattern's functor/arity are read from reg 0 here and stashed on a
+; new agg_type = -4 choice point; @wam_dyn_retract_iter_next advances the scan.
+define i1 @wam_dyn_retract_consult(%WamState* %vm, i32 %return_pc) {
+entry:
+  %pat = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %ptag = call i32 @value_tag(%Value %pat)
+  %is_atom = icmp eq i32 %ptag, 0
+  br i1 %is_atom, label %pat_atom, label %pat_maybe_comp
+pat_atom:
+  %aid = call i64 @value_payload(%Value %pat)
+  %astr = call i8* @wam_atom_to_string(i64 %aid)
+  br label %have_id
+pat_maybe_comp:
+  %is_comp = icmp eq i32 %ptag, 3
+  br i1 %is_comp, label %pat_comp, label %rc_fail
+pat_comp:
+  %cpl = call i64 @value_payload(%Value %pat)
+  %ccp = inttoptr i64 %cpl to %Compound*
+  %cfn_s = getelementptr %Compound, %Compound* %ccp, i32 0, i32 0
+  %cfn = load i8*, i8** %cfn_s
+  %car_s = getelementptr %Compound, %Compound* %ccp, i32 0, i32 1
+  %car = load i32, i32* %car_s
+  br label %have_id
+have_id:
+  %pfn = phi i8* [ %astr, %pat_atom ], [ %cfn, %pat_comp ]
+  %par = phi i32 [ 0, %pat_atom ], [ %car, %pat_comp ]
+  call void @wam_cp_ensure_capacity(%WamState* %vm)
+  %cpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
+  %cpn = load i32, i32* %cpn_ptr
+  %cps_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 12
+  %cps = load %ChoicePoint*, %ChoicePoint** %cps_ptr
+  %cp = getelementptr %ChoicePoint, %ChoicePoint* %cps, i32 %cpn
+  %npc_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 0
+  store i32 0, i32* %npc_s
+  %dst = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 1, i32 0
+  %src = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
+  %dstr = bitcast %Value* %dst to i8*
+  %srcr = bitcast %Value* %src to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dstr, i8* %srcr, i64 512, i1 false)
+  %ts_p = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
+  %ts = load i32, i32* %ts_p
+  %tm_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 2
+  store i32 %ts, i32* %tm_s
+  %cpv_p = getelementptr %WamState, %WamState* %vm, i32 0, i32 11
+  %cpv = load i32, i32* %cpv_p
+  %scp_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 3
+  store i32 %cpv, i32* %scp_s
+  %at_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 4
+  store i32 -4, i32* %at_s
+  %fn_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 8
+  store i8* %pfn, i8** %fn_s
+  %ar_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 9
+  store i32 %par, i32* %ar_s
+  %cur_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 10
+  store i32 0, i32* %cur_s
+  %rpc_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 7
+  store i32 %return_pc, i32* %rpc_s
+  %hs_p = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs = load i32, i32* %hs_p
+  %sht_s = getelementptr %ChoicePoint, %ChoicePoint* %cp, i32 0, i32 11
+  store i32 %hs, i32* %sht_s
+  %ncpn = add i32 %cpn, 1
+  store i32 %ncpn, i32* %cpn_ptr
+  %r = call i1 @wam_dyn_retract_iter_next(%WamState* %vm)
+  ret i1 %r
+rc_fail:
+  ret i1 false
+}
+
+; Advance the retract iterator (agg_type -4). Like @wam_dyn_iter_next but it
+; TOMBSTONES the matched row before yielding, so each solution removes one
+; clause. Called by @backtrack when it sees agg_type == -4.
+define i1 @wam_dyn_retract_iter_next(%WamState* %vm) {
+entry:
+  %cpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
+  %cpn = load i32, i32* %cpn_ptr
+  %top_idx = sub i32 %cpn, 1
+  %cps_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 12
+  %cps = load %ChoicePoint*, %ChoicePoint** %cps_ptr
+  %top = getelementptr %ChoicePoint, %ChoicePoint* %cps, i32 %top_idx
+  %fn_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 8
+  %fn = load i8*, i8** %fn_s
+  %ar_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 9
+  %ar = load i32, i32* %ar_s
+  %cur_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 10
+  %cur0 = load i32, i32* %cur_s
+  %tm_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 2
+  %mark = load i32, i32* %tm_s
+  %count = load i32, i32* @wam_dyn_count
+  %store = load %WamDynClause*, %WamDynClause** @wam_dyn_ptr
+  br label %scan
+scan:
+  %ri = phi i32 [ %cur0, %entry ], [ %rinext, %scan_cont ]
+  %exhausted = icmp sge i32 %ri, %count
+  br i1 %exhausted, label %pop, label %row
+row:
+  %row_ptr = getelementptr %WamDynClause, %WamDynClause* %store, i32 %ri
+  %lv_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 2
+  %lv = load i32, i32* %lv_s
+  %islive = icmp ne i32 %lv, 0
+  br i1 %islive, label %row_live, label %scan_cont
+row_live:
+  %rar_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 1
+  %rar = load i32, i32* %rar_s
+  %ar_eq = icmp eq i32 %rar, %ar
+  br i1 %ar_eq, label %row_fn, label %scan_cont
+row_fn:
+  %rfn_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 0
+  %rfn = load i8*, i8** %rfn_s
+  %fn_eq = call i1 @wam_functor_eq(i8* %rfn, i8* %fn)
+  br i1 %fn_eq, label %candidate, label %scan_cont
+candidate:
+  %dst = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
+  %csrc = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 1, i32 0
+  %dstr = bitcast %Value* %dst to i8*
+  %csrcr = bitcast %Value* %csrc to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dstr, i8* %csrcr, i64 512, i1 false)
+  call void @unwind_trail(%WamState* %vm, i32 %mark)
+  %has_args = icmp sgt i32 %ar, 0
+  br i1 %has_args, label %get_goal, label %success
+get_goal:
+  %goal = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %gtag = call i32 @value_tag(%Value %goal)
+  %g_is_comp = icmp eq i32 %gtag, 3
+  br i1 %g_is_comp, label %goal_comp, label %scan_cont
+goal_comp:
+  %gpl = call i64 @value_payload(%Value %goal)
+  %gcp = inttoptr i64 %gpl to %Compound*
+  %gargs_s = getelementptr %Compound, %Compound* %gcp, i32 0, i32 2
+  %gargs = load %Value*, %Value** %gargs_s
+  %crargs_s = getelementptr %WamDynClause, %WamDynClause* %row_ptr, i32 0, i32 3
+  %crargs = load %Value*, %Value** %crargs_s
+  br label %uloop
+uloop:
+  %ui = phi i32 [ 0, %goal_comp ], [ %uinext, %ucont ]
+  %uidone = icmp sge i32 %ui, %ar
+  br i1 %uidone, label %success, label %ustep
+ustep:
+  %gap = getelementptr %Value, %Value* %gargs, i32 %ui
+  %gav = load %Value, %Value* %gap
+  %rap = getelementptr %Value, %Value* %crargs, i32 %ui
+  %rav = load %Value, %Value* %rap
+  %uok = call i1 @wam_unify_value(%WamState* %vm, %Value %gav, %Value %rav)
+  br i1 %uok, label %ucont, label %unify_fail
+ucont:
+  %uinext = add i32 %ui, 1
+  br label %uloop
+unify_fail:
+  call void @unwind_trail(%WamState* %vm, i32 %mark)
+  br label %scan_cont
+success:
+  ; Remove the matched clause (tombstone) before yielding.
+  store i32 0, i32* %lv_s
+  %next = add i32 %ri, 1
+  store i32 %next, i32* %cur_s
+  %rpc_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 7
+  %rpc = load i32, i32* %rpc_s
+  call void @wam_set_pc(%WamState* %vm, i32 %rpc)
+  call void @wam_set_halted(%WamState* %vm, i1 false)
+  ret i1 true
+scan_cont:
+  %rinext = add i32 %ri, 1
+  br label %scan
+pop:
+  call void @unwind_trail(%WamState* %vm, i32 %mark)
+  store i32 %top_idx, i32* %cpn_ptr
+  %retry = call i1 @backtrack(%WamState* %vm)
+  ret i1 %retry
+}

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -178,6 +178,23 @@ faobjc(S)  :- G = fanum(X), findall(X, call(G), L), sum_list(L, S).           % 
 fadynsum(S) :- assertz(dv(10)), assertz(dv(20)), assertz(dv(30)),
                G = dv(X), findall(X, call(G), L), sum_list(L, S).             % 60
 
+% Milestone 3b-db PR 2: DIRECT calls to :- dynamic predicates (no explicit
+% call/1) and nondet retract/1. A body goal calling a dynamic predicate with
+% no compiled clauses is rewritten to a call/1 meta-call, which consults the
+% store; retract/1 lowers to a dedicated remove+unify+backtrack iterator.
+% The :- dynamic declarations let the compiler detect the direct-call case.
+:- dynamic w/1, nn/1, ee/2, cc/1.
+ddirect(R)  :- assertz(w(5)), w(X), R = X.                                    % 5 (direct call)
+ddirbt(R)   :- assertz(nn(1)), assertz(nn(2)), nn(X), X >= 2, R = X.          % 2 (direct + backtrack)
+dtwoarg(R)  :- assertz(ee(a,10)), assertz(ee(b,20)), ee(b,V), R = V.          % 20 (2-arg direct)
+dretract(R) :- assertz(cc(1)), assertz(cc(2)), assertz(cc(3)), retract(cc(X)), R = X.  % 1
+dretbt(R)   :- assertz(cc(1)), assertz(cc(2)), assertz(cc(3)),
+               retract(cc(X)), X >= 2, R = X.                                 % 2 (retract + backtrack)
+dretgone(R) :- assertz(cc(1)), assertz(cc(2)), retract(cc(_)), retract(cc(_)),
+               ( retract(cc(_)) -> R = 1 ; R = 0 ).                           % 0 (both removed)
+dretcount(N) :- assertz(cc(1)), assertz(cc(2)), assertz(cc(3)),
+                findall(X, retract(cc(X)), L), length(L, N).                  % 3 (nondet retract)
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -612,6 +629,29 @@ test(findall_over_meta_call, [condition(clang_available)]) :-
     ( exists_file(Host) -> true ; build_host(Dir, Host) ),
     run_host(Host, W1, O1, 0), assertion(O1 == "6\n"),
     run_host(Host, W2, O2, 0), assertion(O2 == "60\n"),
+    !.
+
+% Milestone 3b-db PR 2: direct calls to :- dynamic predicates (rewritten to a
+% call/1 store consult) and nondet retract/1 (a remove+unify+backtrack
+% iterator). Each grammar runs in a fresh host process, so the store is empty.
+test(dynamic_direct_calls_and_retract, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    forall(member(Name-Expected,
+               [ ddirect-"5\n",    % direct call to a dynamic predicate
+                 ddirbt-"2\n",     % direct call + choice-point backtracking
+                 dtwoarg-"20\n",   % 2-arg direct call, argument-directed
+                 dretract-"1\n",   % nondet retract, first match
+                 dretbt-"2\n",     % retract + backtrack to the next clause
+                 dretgone-"0\n",   % clauses actually removed
+                 dretcount-"3\n" ]), % findall drives retract to remove all
+           ( PI = Name/1,
+             directory_file_path(Dir, Name, Base),
+             atom_concat(Base, '.wamo', W),
+             write_wam_object([user:PI], [wamo_entry(PI)], W),
+             run_host(Host, W, Out, 0),
+             assertion(Out == Expected) )),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
## Summary

Completes the dynamic clause store (milestone **3b-db**): **direct calls** to `:- dynamic` predicates (no explicit `call/1`) and **nondet `retract/1`**. Builds on PR 1's store + consult.

## Direct dynamic calls

A body goal calling a `:- dynamic` predicate with no compiled clauses (`counter(N)`) lowers to `execute counter/1` with an unresolved label — no target to jump to. The tier-2 compiler now detects this (`dynamic_store_goal/1`: `predicate_property(dynamic)` + no `clause/2`, with the compile module recorded via `b_setval`) and **rewrites the goal to a `call/1` meta-call** — `counter(N)` → `call(counter(N))` — which lowers to `execute call/1` and flows through PR 1's meta-call store-consult. **No new runtime.** A dynamic predicate that *also* has compiled clauses is left as a static call (mixing is out of scope). This is a shared-compiler change; other backends get a clean meta-call failure instead of a jump to label 0.

## Nondet `retract/1`

`retract/1` isn't in `is_builtin_pred`, so it lowers to `call retract/1` / `execute retract/1`. The LLVM lowering now recognises `"retract/1"` and emits the **op1 sentinel −3** (alongside −1 for meta-call), which `do_call`/`do_execute` route to `@wam_dyn_retract_consult`. That reads the pattern from reg 0 and pushes a new **`agg_type = −4`** choice point. The retract iterator (`@wam_dyn_retract_iter_next`, dispatched from `@backtrack` next to −2/−3) is the consult iterator plus one step: it **tombstones the matched row before yielding**, so each solution removes one clause and backtracking removes the next. Works in call and last-call position, and under `findall`.

## Tests

`tests/test_wam_object.pl` — new `dynamic_direct_calls_and_retract` (loaded-object round trip):

| grammar | checks | result |
|---|---|---|
| `ddirect` | direct call to a dynamic predicate | `5` |
| `ddirbt` | direct call + choice-point backtracking | `2` |
| `dtwoarg` | 2-arg direct call, argument-directed | `20` |
| `dretract` | nondet `retract`, first match | `1` |
| `dretbt` | `retract` + backtrack to next clause | `2` |
| `dretgone` | clauses actually removed (3rd retract fails) | `0` |
| `dretcount` | `findall` drives `retract` to remove all | `3` |

**29/29** in `wam_object`; no regressions in `wam_target`, `wam_llvm_target` (82), meta-call, cross-target consistency (22), or the C target.

## Deferred (see PLAWK_DYNAMIC_DB.md)

- **PR 3:** rule bodies (`assertz((H :- B))`) — a body interpreter; the true long pole.
- `call/N` partial-application consult; a functor+arity index over the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_