### PR TITLE
WAM/LLVM (roadmap #5, milestone 5): eval/compile pipeline

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -248,10 +248,31 @@ independently useful (richer hand-written grammars load sooner).
    (`atom_codes(S,[104,105])` → `"hi"`). The byte-return path is the same one
    the eventual `eval`/`compile` surface (milestone 5) hands assembled `.wamo`
    text back across.
-5. **The `eval` / `compile` surface + pipeline.** Wire the plawk surface:
+5. **The `eval` / `compile` surface + pipeline. — landed (runtime).**
    `compile(src)` → run `compiler.wamo` on `src` (blob out) →
    `@wam_object_load_bytes` → a handle usable by `dyncall_at`. Lazy-load the
    compiler object; cache per `DYNCACHE`.
+
+   **What landed:** two runtime primitives that compose the existing pieces
+   into the eval loop, in `wam_object_support_ir` (emitted with
+   `emit_wamo_loader(true)`):
+   - `@wam_object_eval(cvm, cpc, src, srclen)` — interns `src` as an atom, runs
+     the compiler entry `compile(Src, Wamo)` via `@wam_object_call_bytes`
+     (`Src` in A1, emitted bytes read from A2), then feeds those bytes straight
+     to `@wam_object_load_bytes`, returning the fresh `{vm, entry_pc}`. The
+     emitted bytes live in the persistent atom table, so they survive the
+     compiler VM's arena rewind and need no buffer management.
+   - `@wam_object_load_cached(path)` — lazy-loads a compiler object once and
+     memoizes it in a small path-keyed cache, so repeated `compile` calls reuse
+     one compiler VM (the `DYNCACHE` role).
+
+   Verified end to end (`tests/test_wam_object.pl:eval_compile_pipeline`): a
+   loaded compiler object runs on source text, emits `.wamo` bytes,
+   `@wam_object_eval` loads them into a fresh VM in the same process, and
+   running its entry yields `42`. The stand-in compiler echoes its source (so
+   the "source" is itself a valid `.wamo`); a real source-to-bytecode compiler
+   is milestone 6. This closes the eval loop at the runtime layer: **emit bytes
+   → load → run**, all in one process.
 6. **Self-host.** Compile the actual WAM compiler to a `.wamo` and run the
    whole pipeline from source text end to end. The capstone.
 
@@ -264,8 +285,9 @@ independently useful (richer hand-written grammars load sooner).
   1). If the eval loop becomes hot, a real switch-table in the loader is a
   later optimization — the format already carries the switch operands we
   currently drop.
-- **Milestones 1–4 have landed**; 5–6 are plumbing over primitives that
-  already exist (`@wam_object_load_bytes`, `@wam_object_call_bytes`, the
-  `mtime` cache). The reader (3b) and byte-buffer output (4) together mean a
-  loaded object can now both parse source text into terms *and* emit assembled
-  bytes back out — the two halves the eval loop threads together.
+- **Milestones 1–5 have landed** (3b-db PR 3, rule bodies, is the one open
+  runtime item); milestone 6 is self-host. The reader (3b), byte-buffer output
+  (4), dynamic store + catch/throw (3b-db/3c), and the eval pipeline (5) mean a
+  loaded object can parse source text into terms, keep mutable state, handle
+  errors, emit assembled bytes, and load+run those bytes in the same process —
+  the whole eval loop, wanting only a real compiler grammar to fill it (6).

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -344,8 +344,15 @@ loadable along the way.
   `@wam_object_call_bytes` (`{ptr, len, ok}`). No new target IR — it composes
   existing primitives. This is the path the `eval`/`compile` surface hands
   assembled `.wamo` text back across.
-- **Milestones 5–6** (the `eval`/`compile` surface, self-host) — see the
-  bootstrap doc.
+- **Milestone 5 — eval/compile pipeline — LANDED (runtime).**
+  `@wam_object_eval` chains the compiler run (`@wam_object_call_bytes` on a
+  source arg) into `@wam_object_load_bytes`, so a grammar's emitted `.wamo`
+  bytes load and run in the same process; `@wam_object_load_cached` lazy-loads
+  and memoizes the compiler object (the `DYNCACHE` role). Verified end to end
+  with a stand-in (echo) compiler: source text → emitted bytes → load → run →
+  `42`. A real source-to-bytecode compiler is milestone 6.
+- **Milestone 6** (self-host) — compile the actual WAM compiler to a `.wamo`
+  and run the whole pipeline from source text end to end. See the bootstrap doc.
 
 ## The binary-return question, specifically
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -22846,4 +22846,94 @@ ok:
   ret i32 %idx
 fail:
   ret i32 -1
+}
+
+; --- eval/compile pipeline (JIT roadmap #5) ---
+
+; Run a loaded compiler object on a source string, then load the .wamo bytes
+; it emits into a fresh VM -- the "compile(Src)" primitive. The compiler entry
+; is compile(Src, Wamo): the source text (interned as an atom) goes in A1 and
+; the emitted byte-string atom binds A2 (out_reg = 1). The emitted bytes live
+; in the persistent atom table (they survive the compiler VM''s arena rewind),
+; and @wam_object_load_bytes copies what it needs, so there is no buffer to
+; manage here. Returns { vm, entry_pc } for the freshly compiled object, or
+; { null, 0 } if the compiler is null, fails, or yields a non-atom output.
+define { %WamState*, i32 } @wam_object_eval(%WamState* %cvm, i32 %cpc, i8* %src, i64 %srclen) {
+entry:
+  %cvm_null = icmp eq %WamState* %cvm, null
+  br i1 %cvm_null, label %fail, label %run
+run:
+  %srcid = call i64 @wam_intern_atom(i8* %src, i64 %srclen)
+  %sv0 = insertvalue %Value undef, i32 0, 0
+  %srcval = insertvalue %Value %sv0, i64 %srcid, 1
+  %args = alloca %Value, i32 1
+  store %Value %srcval, %Value* %args
+  %r = call { i8*, i64, i1 } @wam_object_call_bytes(%WamState* %cvm, i32 %cpc, i32 1, %Value* %args, i32 1)
+  %ptr = extractvalue { i8*, i64, i1 } %r, 0
+  %len = extractvalue { i8*, i64, i1 } %r, 1
+  %ok = extractvalue { i8*, i64, i1 } %r, 2
+  br i1 %ok, label %load, label %fail
+load:
+  %obj = call { %WamState*, i32 } @wam_object_load_bytes(i8* %ptr, i64 %len)
+  ret { %WamState*, i32 } %obj
+fail:
+  %f0 = insertvalue { %WamState*, i32 } undef, %WamState* null, 0
+  %f1 = insertvalue { %WamState*, i32 } %f0, i32 0, 1
+  ret { %WamState*, i32 } %f1
+}
+
+; Lazy-load a compiler object from a file path and cache it, so repeated
+; eval/compile calls reuse one loaded compiler VM (roadmap #5 DYNCACHE). A
+; small fixed cache keyed by path string; a cache miss loads via
+; @wam_object_load and records the result (paths are strdup''d). Beyond the
+; cache capacity, later paths load uncached rather than evict.
+@wam_compiler_cache_paths = internal global [16 x i8*] zeroinitializer
+@wam_compiler_cache_vms = internal global [16 x %WamState*] zeroinitializer
+@wam_compiler_cache_pcs = internal global [16 x i32] zeroinitializer
+@wam_compiler_cache_count = internal global i32 0
+
+define { %WamState*, i32 } @wam_object_load_cached(i8* %path) {
+entry:
+  %count = load i32, i32* @wam_compiler_cache_count
+  br label %scan
+scan:
+  %i = phi i32 [ 0, %entry ], [ %inext, %scan_cont ]
+  %done = icmp sge i32 %i, %count
+  br i1 %done, label %miss, label %probe
+probe:
+  %pp = getelementptr [16 x i8*], [16 x i8*]* @wam_compiler_cache_paths, i32 0, i32 %i
+  %cpath = load i8*, i8** %pp
+  %cmp = call i32 @strcmp(i8* %cpath, i8* %path)
+  %eq = icmp eq i32 %cmp, 0
+  br i1 %eq, label %hit, label %scan_cont
+scan_cont:
+  %inext = add i32 %i, 1
+  br label %scan
+hit:
+  %hvmp = getelementptr [16 x %WamState*], [16 x %WamState*]* @wam_compiler_cache_vms, i32 0, i32 %i
+  %hvm = load %WamState*, %WamState** %hvmp
+  %hpcp = getelementptr [16 x i32], [16 x i32]* @wam_compiler_cache_pcs, i32 0, i32 %i
+  %hpc = load i32, i32* %hpcp
+  %h0 = insertvalue { %WamState*, i32 } undef, %WamState* %hvm, 0
+  %h1 = insertvalue { %WamState*, i32 } %h0, i32 %hpc, 1
+  ret { %WamState*, i32 } %h1
+miss:
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)
+  %ovm = extractvalue { %WamState*, i32 } %obj, 0
+  %opc = extractvalue { %WamState*, i32 } %obj, 1
+  %space = icmp slt i32 %count, 16
+  br i1 %space, label %record, label %ret_obj
+record:
+  %dup = call i8* @wam_dyn_dup_functor(i8* %path)
+  %spp = getelementptr [16 x i8*], [16 x i8*]* @wam_compiler_cache_paths, i32 0, i32 %count
+  store i8* %dup, i8** %spp
+  %svmp = getelementptr [16 x %WamState*], [16 x %WamState*]* @wam_compiler_cache_vms, i32 0, i32 %count
+  store %WamState* %ovm, %WamState** %svmp
+  %spcp = getelementptr [16 x i32], [16 x i32]* @wam_compiler_cache_pcs, i32 0, i32 %count
+  store i32 %opc, i32* %spcp
+  %ncount = add i32 %count, 1
+  store i32 %ncount, i32* @wam_compiler_cache_count
+  br label %ret_obj
+ret_obj:
+  ret { %WamState*, i32 } %obj
 }').

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -215,6 +215,14 @@ ctgrab(V, V).
 ct_ball(R)    :- catch(ctcompute(R), result(V), ctgrab(V, R)).               % 42 (recovery uses ball)
 ct_uncaught(R) :- throw(oops), R = 1.                                        % uncaught -> fails
 
+% Milestone 5 (eval/compile pipeline): a loaded compiler object runs on source
+% text and emits .wamo bytes, which @wam_object_eval loads into a fresh VM in
+% the same process; running the result closes the eval loop. ea/1 is the
+% "program" that gets compiled+loaded+run; echocompile/2 is a stand-in compiler
+% (echoes its source as the emitted object -- a real compiler is milestone 6).
+ea(R) :- R = 42.
+echocompile(Src, Wamo) :- Wamo = Src.
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -696,6 +704,29 @@ test(catch_and_throw_in_object, [condition(clang_available)]) :-
              assertion(Out == Expected) )),
     !.
 
+% Milestone 5: the eval/compile pipeline end to end. A compiler object runs on
+% source text and emits .wamo bytes; @wam_object_eval loads those bytes into a
+% fresh VM in the SAME process; running its entry yields the answer. The
+% stand-in compiler (echocompile/2) echoes its source, so the "source" here is
+% itself a valid .wamo (ea/1 -> 42); a real source-to-bytecode compiler is
+% milestone 6. This closes the eval loop: emit bytes -> load -> run.
+test(eval_compile_pipeline, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'ea.wamo', EaWamo),
+    write_wam_object([user:ea/1], [wamo_entry(ea/1)], EaWamo),
+    directory_file_path(Dir, 'compiler.wamo', CompWamo),
+    write_wam_object([user:echocompile/2], [wamo_entry(echocompile/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    process_create(Host, [CompWamo, EaWamo],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "42\n"),
+    !.
+
 :- end_tests(wam_object).
 
 % --- helpers ---------------------------------------------------------------
@@ -977,6 +1008,52 @@ load_fail:\n\c
 run_fail:\n\c
   ret i32 21\n\c
 }\n').
+
+% Build a host for the eval/compile pipeline: argv[1] = compiler .wamo,
+% argv[2] = source (here itself a .wamo). It lazy-loads the compiler
+% (@wam_object_load_cached), reads the source, runs @wam_object_eval to
+% compile+load it, then runs the resulting object and prints the integer.
+build_eval_host(Dir, Host) :-
+    directory_file_path(Dir, 'eval_host.ll', LL),
+    with_output_to(string(_),
+        write_wam_llvm_project([user:answer/1],
+            [module_name(wam_object_eval_host), emit_wamo_loader(true)], LL)),
+    eval_host_main_ir(MainIR),
+    setup_call_cleanup(
+        open(LL, append, S, [encoding(utf8)]),
+        write(S, MainIR),
+        close(S)),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    clang_link(LL, Host).
+
+eval_host_main_ir(
+'\n@.ev_fmt = private constant [6 x i8] c"%lld\\0A\\00"\n\n\c
+define i32 @main(i32 %argc, i8** %argv) {\n\c
+entry:\n\c
+  %p1 = getelementptr i8*, i8** %argv, i64 1\n  %cpath = load i8*, i8** %p1\n\c
+  %p2 = getelementptr i8*, i8** %argv, i64 2\n  %spath = load i8*, i8** %p2\n\c
+  %cobj = call { %WamState*, i32 } @wam_object_load_cached(i8* %cpath)\n\c
+  %cvm = extractvalue { %WamState*, i32 } %cobj, 0\n\c
+  %cpc = extractvalue { %WamState*, i32 } %cobj, 1\n\c
+  %cnull = icmp eq %WamState* %cvm, null\n  br i1 %cnull, label %fail, label %readsrc\n\c
+readsrc:\n\c
+  %totp = alloca i64\n\c
+  %sbuf = call i8* @wamo_read_file(i8* %spath, i64* %totp)\n\c
+  %sbnull = icmp eq i8* %sbuf, null\n  br i1 %sbnull, label %fail, label %doeval\n\c
+doeval:\n\c
+  %slen = load i64, i64* %totp\n\c
+  %robj = call { %WamState*, i32 } @wam_object_eval(%WamState* %cvm, i32 %cpc, i8* %sbuf, i64 %slen)\n\c
+  %rvm = extractvalue { %WamState*, i32 } %robj, 0\n\c
+  %rpc = extractvalue { %WamState*, i32 } %robj, 1\n\c
+  %rnull = icmp eq %WamState* %rvm, null\n  br i1 %rnull, label %fail, label %runit\n\c
+runit:\n\c
+  %res = call { i64, i1 } @wam_object_call_i64(%WamState* %rvm, i32 %rpc, i32 0, %Value* null, i32 0)\n\c
+  %val = extractvalue { i64, i1 } %res, 0\n\c
+  %ok = extractvalue { i64, i1 } %res, 1\n  br i1 %ok, label %prn, label %fail\n\c
+prn:\n\c
+  %fmt = getelementptr [6 x i8], [6 x i8]* @.ev_fmt, i32 0, i32 0\n\c
+  %pr = call i32 (i8*, ...) @printf(i8* %fmt, i64 %val)\n  ret i32 0\n\c
+fail:\n  ret i32 21\n}\n').
 
 clang_link(LL, Bin) :-
     format(atom(Cmd), 'clang -w -O2 ~w -o ~w -lm 2>&1', [LL, Bin]),


### PR DESCRIPTION
## Summary

Milestone **5** of the eval bootstrap: the eval/compile pipeline. Composes the object primitives that already exist (`@wam_object_call_bytes`, `@wam_object_load_bytes`) into the eval loop — **a grammar's emitted `.wamo` bytes are loaded and run in the same process**.

Two runtime functions added to `wam_object_support_ir` (emitted with `emit_wamo_loader(true)`):

- **`@wam_object_eval(cvm, cpc, src, srclen)`** — interns `src` as an atom, runs the compiler entry `compile(Src, Wamo)` via `@wam_object_call_bytes` (`Src` in A1, emitted bytes read from A2), then feeds those bytes straight to `@wam_object_load_bytes`, returning the fresh `{vm, entry_pc}`. The emitted bytes live in the persistent atom table, so they survive the compiler VM's arena rewind — no buffer management needed.
- **`@wam_object_load_cached(path)`** — lazy-loads a compiler object once and memoizes it in a small path-keyed cache, so repeated `compile` calls reuse one compiler VM (the `DYNCACHE` role).

This is purely additive — no existing code paths change.

## Test

`tests/test_wam_object.pl:eval_compile_pipeline` — a compiler object runs on source text, emits `.wamo` bytes, `@wam_object_eval` loads them into a fresh VM in the same process, and running its entry yields **42**.

The stand-in compiler (`echocompile/2`) echoes its source, so the "source" here is itself a valid `.wamo` (`ea/1 → 42`). This deliberately isolates the *pipeline* (emit → load → run) from the *compiler* — a real source-to-bytecode compiler is milestone 6. **31/31** in `wam_object`; no regressions (`wam_llvm_target` 82).

## Where this leaves the bootstrap

The runtime layer is now complete for the eval loop: **reader** (text→terms), **dynamic store** + **catch/throw** (mutable state + error handling), **byte output**, and now **eval** (emit→load→run in one process). The only open items are **milestone 6** (compile the real WAM compiler to a `.wamo` and run the whole thing from source text — the capstone/self-host) and the deferred **rule bodies** (`assertz((H :- B))`, a body meta-interpreter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_