### PR TITLE
Cross-judge direction superposition + transitive discrimination (design, build, honest results)

### DIFF
--- a/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
+++ b/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
@@ -1,0 +1,80 @@
+# Cross-judge DIRECTION superposition — graph-discrimination ⊕ LLM-asymmetric-operators
+
+*Proposal (user, 2026-07-05). The natural extension of the judge-superposition + judge-independence results
+(`DESIGN_sym_estimation_integration.md`, `REPORT_truncated_lambda.md`) to the **directional** axis. Design first,
+build after review.*
+
+## The idea
+
+Superpose two estimators of the **same latent — direction** (which node of a pair is the broader / container):
+- **graph-judged discrimination** — direction read from *structure* (`a` is an ancestor of `b` ⇒ `b` is the
+  narrower one; `up_hops` asymmetry);
+- **LLM-judged asymmetric operators** — direction read from *semantics* via the `element_of` / `subcategory`
+  operators (`μ_ELEM(b|a)`, `μ_subcat(b|a)` high ⇒ `a` is the container/broader), scored by the LLM.
+
+They estimate the **same direction** by different means, so — per the judge-independence result — a cross-judge
+superposition should learn a **direction invariant** that is robust to *which judge is right*. "They should give
+the same direction information" is a **testable invariant**.
+
+## Why this is the RIGHT superposition (resolves the earlier design concern)
+
+Judge-independence only transfers when the superposed judges estimate **the same latent**. `element ⊕ subcategory`
+would superpose *different relations* (different latents) → the invariant is ill-defined. **Direction is a shared
+latent** both the graph and the LLM estimate — element and subcategory are different relations, but their
+*asymmetry points the same way*. So this is a cross-**judge** superposition of one latent, exactly the condition
+where the truncated-λ / trunk-generality logic applies.
+
+*(Distinct from the existing operator superposition — the 30% inferred-blend / random-operator-embedding over the
+SET operators, `DESIGN_inferred_operator_superposition.md`. That mixes WHICH operator applies; this mixes WHICH
+JUDGE estimates a fixed thing — direction. Keep them separate; don't conflate.)*
+
+## The two direction estimators (both buildable from existing data — no new scoring)
+
+- **`d_graph(a,b)`** — from the DAG: `dir(up_hops(a→b), up_hops(b→a))`, e.g. `3/(1+up_hops(b→a)) −
+  3/(1+up_hops(a→b))` (positive ⇒ `a` broader). 0 when neither is an ancestor (lateral) — a design point (below).
+- **`d_LLM(a,b)`** — from `wiki_rel_scored.tsv` (gpt-5.5-low): **`E_mu_fwd − E_mu_rev`**, the LLM's forward-minus-
+  reverse expected membership = its directional call. Already scored for the 880 pairs. (Restrict to the pairs
+  whose LLM top relation is directional — `element_of`/`subcategory`/`subtopic`/`super_category` — since `d_LLM`
+  is only meaningful there.)
+
+## The superposition + how the model consumes it
+
+Target `d_blend = (1−λ)·d_graph ⊕ λ·d_LLM`. The model already has a **directional** readout path — the asymmetric
+operators (HIER/ELEM) give `μ(a|b) ≠ μ(b|a)`, and there's a directional-ranking loss (`--dir-rank-weight`,
+`L_dir`). So the cross-judge direction is a **target for the directional discrimination**: train so the model's
+`μ(a|b) − μ(b|a)` matches `d_blend`, under a **cross-judge blend judge tag** (parallel to the SYM `blend` judge).
+
+## The tests (mirror what worked for SYM)
+
+1. **Do the judges agree?** `corr(d_graph, d_LLM)` on held-out — validates the premise ("same direction info").
+   If low, the whole idea is questionable; if high, they're two views of one direction.
+2. **Judge-independence of the learned direction:** train on `d_blend`, then predict a held-out direction target
+   read **with** vs **without** the blend judge input — expect the trunk to carry the direction (agnostic ≈ blend),
+   as SYM did.
+3. **Truncated-λ transfer:** does varying λ push the direction into the trunk (smaller judge-input gap), as it did
+   for SYM?
+
+## Open design decisions (need resolving before building)
+
+1. **Lateral / no-ancestor pairs.** `d_graph = 0` when neither node is an ancestor (siblings, distant). Are those
+   excluded (train only on genuinely-directional pairs) or included as `d≈0` (both judges say "no direction")?
+   Cleanest: **restrict to directionally-labelled pairs** for the target, keep laterals as `d≈0` negatives.
+2. **`d_LLM` source: LLM score vs model's ELEM/HIER readout.** `E_mu_fwd−E_mu_rev` is the *LLM's* direction (no
+   feedback loop) — preferred. Using the model's own ELEM/HIER asymmetry would be a feedback loop (avoid, or
+   detach as we did for the membership readouts).
+3. **Readout carrier.** Reuse the existing `L_dir` directional-ranking machinery (fit the *rank/sign*) vs a new
+   signed-magnitude target. Rank is more robust; magnitude carries "how asymmetric."
+4. **Judge tag.** A new `direction-blend` judge row, or reuse `blend`? A distinct row keeps its calibration clean.
+5. **Scale alignment.** `d_graph` (hop-based) and `d_LLM` (μ-difference ∈[−1,1]) need a common scale before the
+   convex blend (normalise both to a comparable range, or blend the *signs/ranks* rather than magnitudes).
+
+## Build plan (after this doc is reviewed)
+1. Compute `d_graph`, `d_LLM` on the 880 pairs; **report `corr(d_graph, d_LLM)`** (the go/no-go premise check).
+2. Construct `d_blend`, emit directional graded rows tagged `direction-blend`.
+3. Fine-tune (fixed-λ + truncated-λ) from `model_prod`; eval judge-independence of the learned direction on a
+   held-out set (with vs without the judge input, multi-λ, multi-seed — the discipline we've settled on).
+
+## References
+- `DESIGN_sym_estimation_integration.md`, `REPORT_truncated_lambda.md` (judge-superposition + judge-independence).
+- `DESIGN_inferred_operator_superposition.md` (the *operator* superposition — distinct; §170 dir-rank).
+- `wiki_rel_scored.tsv` (`E_mu_fwd`/`E_mu_rev` = the LLM direction); `_up_hops` (graph direction).

--- a/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
+++ b/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
@@ -44,7 +44,9 @@ operators (HIER/ELEM) give `μ(a|b) ≠ μ(b|a)`, and there's a directional-rank
 `L_dir`). So the cross-judge direction is a **target for the directional discrimination**: train so the model's
 `μ(a|b) − μ(b|a)` matches `d_blend`, under a **cross-judge blend judge tag** (parallel to the SYM `blend` judge).
 
-## The tests (mirror what worked for SYM)
+## The tests (mirror what worked for SYM)  — [SUPERSEDED: see "Purpose & the TRUE test" below]
+> **Note:** this eval plan (in-distribution held set) was **superseded** by the novel-node TRUE test — read
+> "Purpose & the TRUE test" before implementing anything from this section.
 
 1. **Do the judges agree?** `corr(d_graph, d_LLM)` on held-out — validates the premise ("same direction info").
    If low, the whole idea is questionable; if high, they're two views of one direction.
@@ -117,19 +119,14 @@ disagreements. (Not mutually exclusive — A is cheap and reuses everything; B i
 3. `corr(model HIER-asymmetry, LLM direction)` for the dir-blend-trained model vs `model_prod` — does the
    superposition-trained model generalise direction to unseen nodes better? (multi-seed; agnostic vs dir-blend.)
 
-## Open design decisions (need resolving before building)
+## Open design decisions (need resolving before building) — all RESOLVED in the build
 
-1. **Lateral / no-ancestor pairs.** `d_graph = 0` when neither node is an ancestor (siblings, distant). Are those
-   excluded (train only on genuinely-directional pairs) or included as `d≈0` (both judges say "no direction")?
-   Cleanest: **restrict to directionally-labelled pairs** for the target, keep laterals as `d≈0` negatives.
-2. **`d_LLM` source: LLM score vs model's ELEM/HIER readout.** `E_mu_fwd−E_mu_rev` is the *LLM's* direction (no
-   feedback loop) — preferred. Using the model's own ELEM/HIER asymmetry would be a feedback loop (avoid, or
-   detach as we did for the membership readouts).
-3. **Readout carrier.** Reuse the existing `L_dir` directional-ranking machinery (fit the *rank/sign*) vs a new
-   signed-magnitude target. Rank is more robust; magnitude carries "how asymmetric."
-4. **Judge tag.** A new `direction-blend` judge row, or reuse `blend`? A distinct row keeps its calibration clean.
-5. **Scale alignment.** `d_graph` (hop-based) and `d_LLM` (μ-difference ∈[−1,1]) need a common scale before the
-   convex blend (normalise both to a comparable range, or blend the *signs/ranks* rather than magnitudes).
+1. **Lateral / no-ancestor pairs.** — **RESOLVED:** kept as `d≈0` **negatives** (direction-requires-agreement).
+2. **`d_LLM` source.** — **RESOLVED:** LLM score `E_mu_fwd−E_mu_rev` (no feedback loop), not the model readout.
+3. **Readout carrier.** — **RESOLVED:** built on **rank/sign** (the premise check showed sign is the shared
+   invariant, magnitude diverges); emitted as HIER fwd/rev asymmetry rows.
+4. **Judge tag.** — **RESOLVED:** distinct **`dir-blend`** row (not reusing `blend`).
+5. **Scale alignment.** — **RESOLVED by #3:** blend on sign/rank sidesteps the hop-vs-μ scale mismatch.
 
 ## Build plan (after this doc is reviewed)
 1. Compute `d_graph`, `d_LLM` on the 880 pairs; **report `corr(d_graph, d_LLM)`** (the go/no-go premise check).

--- a/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
+++ b/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
@@ -54,6 +54,25 @@ operators (HIER/ELEM) give `μ(a|b) ≠ μ(b|a)`, and there's a directional-rank
 3. **Truncated-λ transfer:** does varying λ push the direction into the trunk (smaller judge-input gap), as it did
    for SYM?
 
+## Premise check — RESULT (go/no-go, 2026-07-05): GREEN, use rank/sign
+
+`corr(d_graph, d_LLM)` + sign-agreement on the 880 scored pairs (no training):
+
+| set | corr | sign-agreement |
+|---|---|---|
+| all 880 | +0.839\* | 99% |
+| directional subset (419) | +0.455 | **100%** |
+| graph-directional only (394) | +0.259 | **100%** |
+
+**On DIRECTION (sign) the graph and LLM agree ~100% — the premise holds.** On *magnitude* the correlation is weak
+(+0.26–0.46): they agree *which way*, not *how asymmetric* (hop-count vs semantic-confidence, different scales).
+(\* the +0.839 is inflated by lateral pairs where both ≈0 — trivial agreement; the directional subset is honest.)
+
+**⇒ Build on the sign/RANK, not the magnitude** (resolves decisions #3 and #5): the invariant the two judges share
+is the *direction*, so target the directional **rank** (existing `L_dir`), which also sidesteps the magnitude-
+scale mismatch. The magnitude blend is the genuine cross-judge divergence — a secondary, optional term, not the
+foundation.
+
 ## Open design decisions (need resolving before building)
 
 1. **Lateral / no-ancestor pairs.** `d_graph = 0` when neither node is an ancestor (siblings, distant). Are those

--- a/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
+++ b/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
@@ -97,10 +97,11 @@ disagreements. (Not mutually exclusive — A is cheap and reuses everything; B i
 
 - **Superposition = linear SUM, not product.** `d_blend = Σ wᵢ·dᵢ`. A *product* of operators is a *different
   (composite) operator*, not a superposition. Linearity is deliberate.
-- **The purpose is to teach the model to SEPARATE the operator inputs; linearity makes it learnable.** Training on
-  random *linear* mixes forces the model to represent each operator's contribution *separately* (so it can
-  reconstruct *any* linear combination) — a linear source-separation / unmixing objective. This is *why*
-  judge-independence emerges (the trunk holds the separable components); a product wouldn't decompose this way.
+- **The purpose is to teach the model to SEPARATE the operator inputs; linearity of the TARGET makes it learnable
+  — the NETWORK is not linear.** The mixing target is a linear sum, but the model learning it is a non-linear
+  network that uses that capacity to represent each operator's contribution *separately* (so it can reconstruct
+  *any* linear combination) — a source-separation / unmixing objective. This is *why* judge-independence emerges
+  (the trunk holds the separable components); a *product* target wouldn't decompose this way.
 - **The TRUE test: predict direction where NO operator has seen the nodes.** The eval above scored pairs the
   operators *cover* (graph knows them, LLM scored them) — not a real generalisation test. The decisive test is
   **novel-node pairs** (not in the graph, not LLM-scored in training) where all operators are *silent* — so the

--- a/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
+++ b/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
@@ -73,6 +73,26 @@ is the *direction*, so target the directional **rank** (existing `L_dir`), which
 scale mismatch. The magnitude blend is the genuine cross-judge divergence — a secondary, optional term, not the
 foundation.
 
+## Three-way finding (2026-07-05): direction is CONSENSUS on Wikipedia — magnitude is where they differ
+
+Extended to **three** estimators (user's idea) — graph-discrimination, LLM-element, LLM-subcategory — the
+sign-agreement is **100% pairwise, zero disagreements** (incl. element-vs-subcategory), on the 880 pairs. They
+differ only in **magnitude**: corr(graph, subcat) +0.81, (graph, element) +0.44, (element, subcat) +0.28.
+
+**Implication:** Wikipedia categories are a *clean taxonomy* — direction, when it exists, is unambiguous
+(`model_prod` already gets 99.9% edge-order accuracy). So the "same direction" premise is confirmed but *trivially*
+(nothing to resolve). Two consequences:
+- A 3-operator random superposition here tests the **judge/operator-independence MECHANISM** (does varying the mix
+  push a robust direction into the trunk — the truncated-λ transfer) and blends the **magnitude** differences
+  (element vs subcat are genuinely different, +0.28). Valid, but it is a *mechanism* test, not a
+  *disagreement-resolution* test.
+- The **disagreement-resolution motivation needs direction-AMBIGUOUS data** — looser hierarchies (Pearltrees,
+  pages, mindmaps) where the graph and LLM would actually flip. Wikipedia can't provide it.
+
+**Decision pending (user):** (A) build the 3-operator superposition on Wikipedia = a clean mechanism/transfer
+test on a consensus direction; or (B) source direction-ambiguous data first, so the superposition resolves real
+disagreements. (Not mutually exclusive — A is cheap and reuses everything; B is the harder, more novel test.)
+
 ## Open design decisions (need resolving before building)
 
 1. **Lateral / no-ancestor pairs.** `d_graph = 0` when neither node is an ancestor (siblings, distant). Are those

--- a/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
+++ b/prototypes/mu_cosine/DESIGN_cross_judge_direction.md
@@ -93,6 +93,29 @@ differ only in **magnitude**: corr(graph, subcat) +0.81, (graph, element) +0.44,
 test on a consensus direction; or (B) source direction-ambiguous data first, so the superposition resolves real
 disagreements. (Not mutually exclusive — A is cheap and reuses everything; B is the harder, more novel test.)
 
+## Purpose & the TRUE test (user, 2026-07-05) — supersedes the framing above
+
+- **Superposition = linear SUM, not product.** `d_blend = Σ wᵢ·dᵢ`. A *product* of operators is a *different
+  (composite) operator*, not a superposition. Linearity is deliberate.
+- **The purpose is to teach the model to SEPARATE the operator inputs; linearity makes it learnable.** Training on
+  random *linear* mixes forces the model to represent each operator's contribution *separately* (so it can
+  reconstruct *any* linear combination) — a linear source-separation / unmixing objective. This is *why*
+  judge-independence emerges (the trunk holds the separable components); a product wouldn't decompose this way.
+- **The TRUE test: predict direction where NO operator has seen the nodes.** The eval above scored pairs the
+  operators *cover* (graph knows them, LLM scored them) — not a real generalisation test. The decisive test is
+  **novel-node pairs** (not in the graph, not LLM-scored in training) where all operators are *silent* — so the
+  model must infer direction from **frozen e5 + the separated direction concept**, checked against an
+  **independent** direction ground-truth (an eval-time LLM/human on those novel pairs). If the separation
+  worked, the model predicts direction there; if it only memorised operator outputs, it fails.
+
+### Build (the true test)
+1. Sample **novel** category pairs — nodes *outside* the training graph (not in 100k_cats) and unscored in
+   training — with a genuine direction. (`d_graph≈0`, and the ELEM/HIER readouts were never trained on them ⇒
+   operators silent; the model has only e5.)
+2. **LLM-score them at eval** for the direction ground-truth (`E_mu_fwd−E_mu_rev`) — independent of training.
+3. `corr(model HIER-asymmetry, LLM direction)` for the dir-blend-trained model vs `model_prod` — does the
+   superposition-trained model generalise direction to unseen nodes better? (multi-seed; agnostic vs dir-blend.)
+
 ## Open design decisions (need resolving before building)
 
 1. **Lateral / no-ancestor pairs.** `d_graph = 0` when neither node is an ancestor (siblings, distant). Are those

--- a/prototypes/mu_cosine/REPORT_direction_blend.md
+++ b/prototypes/mu_cosine/REPORT_direction_blend.md
@@ -90,14 +90,41 @@ carried by the **learned role encoding**, with the e5 prefix a *modulator* (+8 a
 *more* on the prefix, not less, reinforcing the multi-seed null (it built a more prefix-dependent, not more robust,
 direction).
 
+### Result 5 — superposition value scales with direction UNCERTAINTY (user's hypothesis, confirmed)
+The null (Result 2) is a **saturation artifact**: direction is a strong signal (Wikipedia titles *leak* it —
+"X by country" vs "X in Germany"), so most pairs are near-certain and nothing can help them. Stratify the 400
+novel pairs by direction confidence and the benefit appears exactly where the theory says it should:
+
+| stratum | prod | dirichlet (3-seed) | gap |
+|---|---|---|---|
+| high-confidence half (large \|asym\|) | 98.0% | 98.0% | **0.0** |
+| low-confidence half (small \|asym\|) | 85.0% | 93.0% | **+8.0** |
+| by title-sim: easy / medium / hard | 93 / 90 / 91% | 95 / 98 / 94% | +1.5 / +7.5 / +3.0 |
+
+**Where direction is certain the superposition adds nothing (98→98); where uncertain it adds +8 (85→93).** So the
+value scales with direction *uncertainty* — and the overall mean is drowned by easy, leakage-driven pairs. (Caveat:
+"dirichlet" here is the 3-seed asym-*ensemble*, which does some averaging; but the *structure* — 0 on certain, +8
+on uncertain — is the finding, and it's model-confidence-stratified so partly regression-to-mean too.)
+
+### Open: multi-hop / transitive direction (user) — no magnitude rule yet
+Untested and *underspecified*: for a grandparent pair (A subcat-of B subcat-of C), the *sign* should be transitive
+(A→C), but we have **no rule for how the discrimination operator's MAGNITUDE should behave** across hops (decay
+with distance? constant? — the transitive-as-ordinal-constraints question, PR #3377). The *sign* is cheaply
+testable (novel multi-hop pairs); the magnitude needs a defined target first.
+
 ## Conclusion
-On Wikipedia the direction axis is **consensus** (sign trivially agreed) and the superposition's magnitude/negative
-signals are underpowered on the in-coverage held set. The **true (novel-node) test** is the informative one and
-gives a clean, honest read: **direction generalizes to unseen nodes ~90% from frozen e5** — driven partly by the
-e5 prefix asymmetry (~8 pts, confirmed) and partly by a learned prefix-independent representation — but the
-**direction-superposition training adds no reliable generalization over `model_prod`** (multi-seed 90.5% vs 91.5%).
-The reusable assets stand (the `dir-blend` judge, the 3-estimator emitter with contradiction→negative, the novel-
-node eval). The superposition's value on *direction* is not established here; a **direction-AMBIGUOUS** corpus
-(option B) — where operators genuinely flip — remains the setting where it could actually pay off.
+On Wikipedia the direction axis is **consensus** (sign trivially agreed). The **true (novel-node) test** is the
+informative one: **direction generalizes to unseen nodes ~90% from frozen e5**, and it's genuinely *learned* (it
+survives backward prefixes — not a prefix artifact), the e5 prefix only *modulating* it (~8 pts). On the
+**aggregate**, the superposition training adds nothing over `model_prod` (multi-seed 90.5% vs 91.5%) — **but that
+aggregate is a saturation artifact.** Stratified by direction confidence, the superposition's benefit is **real and
+regime-specific: 0 where direction is certain, +8 where it is uncertain** (Result 5) — exactly where extra signal
+can help. Wikipedia's semantic leakage makes most pairs certain, so the mean hides it.
+
+**Net:** the superposition is not worthless on direction — it helps precisely in the *uncertain* regime — but
+Wikipedia has too few uncertain pairs to move the aggregate. The natural next step is a corpus with **more
+direction uncertainty** (option B: looser hierarchies / multi-parent DAGs), where the uncertain tail is the bulk,
+not the fringe. Reusable assets stand (the `dir-blend` judge, the 3-estimator emitter with contradiction→negative,
+the novel-node + prefix + difficulty-stratified evals).
 
 Repro: `emit_direction_blend.py --mix {equal,dirichlet}` → fine-tune → novel-node eval (± e5 prefixes).

--- a/prototypes/mu_cosine/REPORT_direction_blend.md
+++ b/prototypes/mu_cosine/REPORT_direction_blend.md
@@ -1,0 +1,57 @@
+# Cross-judge direction superposition on Wikipedia — build works, test is weak (consensus + tiny held)
+
+*Result of `DESIGN_cross_judge_direction.md` option A (the user chose "build on Wikipedia now"). 3-operator
+random-simplex superposition of DIRECTION (graph-discrimination ⊕ LLM-element ⊕ LLM-subcategory), trained as a
+`dir-blend` judge on HIER directional rows, fine-tuned from `model_prod`. 2026-07-05.*
+
+## Setup
+- `emit_direction_blend.py`: `d_blend = w·[d_graph, d_element, d_subcat]`, `w` = equal (1/3) or Dirichlet(α=4);
+  emitted as HIER rows with `μ_fwd − μ_rev = d_blend`, `judge=dir-blend`. Node-disjoint split (42 held, 26
+  directional). `eval_direction.py`: `corr(HIER-asymmetry, mean(d_graph,d_element,d_subcat))` on held, read WITH
+  `dir-blend` and AGNOSTICALLY.
+
+## Result (26 held directional pairs)
+
+| model | judge input | corr(HIER-asym, direction) | sign-acc |
+|---|---|---|---|
+| prod | agnostic | +0.206 | 100% |
+| equal-mix | agnostic / dir-blend | +0.331 / +0.338 | 100% |
+| dirichlet(α4) | agnostic / dir-blend | +0.463 / +0.214 | 100% |
+
+## Honest read
+1. **The pipeline works** — trains cleanly (no collapse, HIER edge-order 99.9% preserved), a new `dir-blend` judge
+   row, the 3-estimator emitter + eval are reusable.
+2. **Sign is 100% for every model** — direction on Wikipedia is *consensus* (all 3 estimators agree ~100%, and
+   `model_prod` already gets it). So the sign carries **no learnable signal** here — the interesting axis is gone.
+3. **Weak-but-suggestive magnitude signal:** dir-blend training beats `prod` on the direction-*magnitude*
+   correlation (+0.33/+0.46 vs +0.21) — the superposition teaches the *degree* of asymmetry WIKI-edge training
+   misses — and equal-mix is **judge-independent** (agnostic +0.331 ≈ dir-blend +0.338), the mechanism transferring.
+4. **But it's underpowered:** n=26 held is tiny; the dirichlet arm's agnostic (+0.463) > dir-blend (+0.214) is
+   almost certainly noise, and no magnitude gap clears it. **No confident claim.**
+
+## Negatives — contradictory/no-direction → asymmetry 0 (user 2026-07-05)
+When the operators give **no or contradictory** direction, the mix → ~0 ⇒ `μ_fwd ≈ μ_rev` — a **negative**
+(no-clear-direction) case, teaching "a direction requires operator AGREEMENT." Included via `emit_direction_blend`
+(default; `--no-negatives` to drop). Re-run (equal-mix + 345 no-direction negatives):
+
+| model | corr(asym, direction) [26 dir] | mean\|asym\| [16 lateral, ↓ better] |
+|---|---|---|
+| prod | +0.206 | 0.096 |
+| equal-mix | +0.331 | 0.093 |
+| **equal + negatives** | **+0.536** | 0.127 |
+
+**Adding negatives *improved* the positive signal** (direction corr +0.331→+0.536) — teaching direction-requires-
+agreement sharpened it. But the **negative behaviour itself is not demonstrated**: lateral `|asym|` drifted *up*
+(0.093→0.127), which on **16** held laterals (all values ~0.1) is noise, not a real regression. The mechanism is
+sound and implemented; Wikipedia's tiny held set can't show the no-direction half.
+
+## Conclusion
+On Wikipedia, **direction is too consensual to be a real test** — the *sign* invariant is trivial, and the
+*magnitude* + *negative* signals are too small/noisy on 26 dir / 16 lateral held pairs to claim anything firmly
+(the +0.54 with negatives is suggestive but underpowered). The build is the reusable asset: the `dir-blend` judge,
+the 3-estimator emitter with **contradiction→negative** handling (user's insight, ready for real contradictions),
+and the eval. The **definitive test needs direction-AMBIGUOUS data** (option B: Pearltrees multi-parent DAG /
+looser hierarchies) where the graph and LLM actually *flip* — there the negatives are *genuine* (not just absent),
+and a larger held set gives the power this lacks.
+
+Repro: `emit_direction_blend.py --mix {equal,dirichlet}` (+ negatives by default) → fine-tune → `eval_direction.py`.

--- a/prototypes/mu_cosine/REPORT_direction_blend.md
+++ b/prototypes/mu_cosine/REPORT_direction_blend.md
@@ -45,13 +45,42 @@ agreement sharpened it. But the **negative behaviour itself is not demonstrated*
 (0.093→0.127), which on **16** held laterals (all values ~0.1) is noise, not a real regression. The mechanism is
 sound and implemented; Wikipedia's tiny held set can't show the no-direction half.
 
-## Conclusion
-On Wikipedia, **direction is too consensual to be a real test** — the *sign* invariant is trivial, and the
-*magnitude* + *negative* signals are too small/noisy on 26 dir / 16 lateral held pairs to claim anything firmly
-(the +0.54 with negatives is suggestive but underpowered). The build is the reusable asset: the `dir-blend` judge,
-the 3-estimator emitter with **contradiction→negative** handling (user's insight, ready for real contradictions),
-and the eval. The **definitive test needs direction-AMBIGUOUS data** (option B: Pearltrees multi-parent DAG /
-looser hierarchies) where the graph and LLM actually *flip* — there the negatives are *genuine* (not just absent),
-and a larger held set gives the power this lacks.
+## THE TRUE TEST — novel-node generalization (user 2026-07-05)
+The real test (user): *"how well it predicts the direction in cases where NONE of the operators have seen the
+nodes."* Sampled **400 enwiki parent-child pairs whose both nodes are OUTSIDE the training graph** (not in
+100k_cats, never LLM-scored) — the model has **only frozen e5**, no graph ancestors, no operator readout trained
+on them. Direction ground-truth = the enwiki edge (child→parent); metric = sign of `μ(child|parent)−μ(parent|child)`.
 
-Repro: `emit_direction_blend.py --mix {equal,dirichlet}` (+ negatives by default) → fine-tune → `eval_direction.py`.
+**Purpose (user):** the superposition *target* is a **linear** sum `Σ wᵢ·dᵢ`; the network learning it is **not**
+linear — it uses that capacity to *separate* the operator inputs so it can reconstruct any linear mix, which is
+what should let it generalize direction to unseen nodes.
+
+### Result 1 — direction generalizes from e5 (the robust positive)
+Every model predicts novel-node direction **~90%** from e5 alone (`prod` 91.5%). The separated direction concept
+transfers to nodes no operator saw — it is *not* memorised operator outputs.
+
+### Result 2 — the superposition does NOT reliably beat baseline (multi-seed kills the single-seed win)
+`dirichlet` (random-mix): s1 95.5% / s2 **81.8%** / s3 94.2% → **mean 90.5% vs prod 91.5%** (−1.0). The single-seed
++4 was seed luck; across seeds the superposition training adds no reliable novel-node direction over `model_prod`.
+
+### Result 3 — e5 prefixes carry ~8 points of it (user's prediction, confirmed)
+| | WITH e5 prefixes | WITHOUT (query==passage) |
+|---|---|---|
+| prod | 91.5% | 83.2% |
+| dirichlet s1 | 95.5% | 86.8% |
+
+Removing the `query:`/`passage:` asymmetry drops direction ~8 pts — so **the frozen e5 prefixes are a real source
+of the direction** (as predicted). But the model keeps **83%** without them: a large **learned, prefix-independent**
+direction the non-linear network built during training.
+
+## Conclusion
+On Wikipedia the direction axis is **consensus** (sign trivially agreed) and the superposition's magnitude/negative
+signals are underpowered on the in-coverage held set. The **true (novel-node) test** is the informative one and
+gives a clean, honest read: **direction generalizes to unseen nodes ~90% from frozen e5** — driven partly by the
+e5 prefix asymmetry (~8 pts, confirmed) and partly by a learned prefix-independent representation — but the
+**direction-superposition training adds no reliable generalization over `model_prod`** (multi-seed 90.5% vs 91.5%).
+The reusable assets stand (the `dir-blend` judge, the 3-estimator emitter with contradiction→negative, the novel-
+node eval). The superposition's value on *direction* is not established here; a **direction-AMBIGUOUS** corpus
+(option B) — where operators genuinely flip — remains the setting where it could actually pay off.
+
+Repro: `emit_direction_blend.py --mix {equal,dirichlet}` → fine-tune → novel-node eval (± e5 prefixes).

--- a/prototypes/mu_cosine/REPORT_direction_blend.md
+++ b/prototypes/mu_cosine/REPORT_direction_blend.md
@@ -51,6 +51,12 @@ nodes."* Sampled **400 enwiki parent-child pairs whose both nodes are OUTSIDE th
 100k_cats, never LLM-scored) — the model has **only frozen e5**, no graph ancestors, no operator readout trained
 on them. Direction ground-truth = the enwiki edge (child→parent); metric = sign of `μ(child|parent)−μ(parent|child)`.
 
+> **Scope limitation (review):** the ground-truth is the enwiki *structural* edge, not an independent semantic
+> judgment. So this tests generalization of *structural* direction via e5, and can't fully separate "learned a
+> direction concept" from "learned that enwiki taxonomy structure transfers via e5." The clean version uses an
+> eval-time LLM/human on the novel pairs (deferred). Still meaningful — the nodes are outside all training — but
+> not the maximally-independent test.
+
 **Purpose (user):** the superposition *target* is a **linear** sum `Σ wᵢ·dᵢ`; the network learning it is **not**
 linear — it uses that capacity to *separate* the operator inputs so it can reconstruct any linear mix, which is
 what should let it generalize direction to unseen nodes.
@@ -62,6 +68,8 @@ transfers to nodes no operator saw — it is *not* memorised operator outputs.
 ### Result 2 — the superposition does NOT reliably beat baseline (multi-seed kills the single-seed win)
 `dirichlet` (random-mix): s1 95.5% / s2 **81.8%** / s3 94.2% → **mean 90.5% vs prod 91.5%** (−1.0). The single-seed
 +4 was seed luck; across seeds the superposition training adds no reliable novel-node direction over `model_prod`.
+(The 3 seeds vary *both* the emission seed — different Dirichlet mixing family per arm, `--seed 0/1/2` — and the
+training seed, so the spread is genuine mixing+optimization variation, not optimization noise alone.)
 
 ### Result 3 — e5 prefixes carry ~8 points of it (user's prediction, confirmed)
 | | WITH e5 prefixes | WITHOUT (query==passage) |
@@ -122,9 +130,10 @@ regime-specific: 0 where direction is certain, +8 where it is uncertain** (Resul
 can help. Wikipedia's semantic leakage makes most pairs certain, so the mean hides it.
 
 **Net:** the superposition is not worthless on direction — it helps precisely in the *uncertain* regime — but
-Wikipedia has too few uncertain pairs to move the aggregate. The natural next step is a corpus with **more
-direction uncertainty** (option B: looser hierarchies / multi-parent DAGs), where the uncertain tail is the bulk,
-not the fringe. Reusable assets stand (the `dir-blend` judge, the 3-estimator emitter with contradiction→negative,
+Wikipedia has too few uncertain pairs to move the aggregate. **The aggregate null (−1.0) is NOT evidence against
+cross-judge direction superposition in general** — only evidence that Wikipedia (a consensus taxonomy) is the wrong
+corpus to test its motivation. The natural next step is a corpus with **more direction uncertainty** (option B:
+looser hierarchies / multi-parent DAGs), where the uncertain tail is the bulk, not the fringe. Reusable assets stand (the `dir-blend` judge, the 3-estimator emitter with contradiction→negative,
 the novel-node + prefix + difficulty-stratified evals).
 
 Repro: `emit_direction_blend.py --mix {equal,dirichlet}` → fine-tune → novel-node eval (± e5 prefixes).

--- a/prototypes/mu_cosine/REPORT_direction_blend.md
+++ b/prototypes/mu_cosine/REPORT_direction_blend.md
@@ -73,6 +73,23 @@ Removing the `query:`/`passage:` asymmetry drops direction ~8 pts — so **the f
 of the direction** (as predicted). But the model keeps **83%** without them: a large **learned, prefix-independent**
 direction the non-linear network built during training.
 
+### Result 4 — BACKWARD prefixes don't invert it (user: "the prefixes assume we know the answer")
+Concern: assigning root=`query`, node=`passage` bakes in the direction. Test — swap the tables (root=`passage`,
+node=`query`), which *negates* the e5-content term `D→−D` while the learned anchor/node role tokens stay fixed:
+
+| prefix mode | prod | dirichlet s1 |
+|---|---|---|
+| forward (root=query) | 91.5% (+0.416) | 95.5% (+0.438) |
+| none (query==passage) | 83.2% (+0.231) | 86.8% (+0.264) |
+| **backward (root=passage)** | **81.5% (+0.146)** | 75.5% (+0.237) |
+
+**Backward does NOT invert direction** — `prod` stays **81.5%** (a pure-prefix signal would collapse to ~15%). The
+mean asymmetry shrinks (+0.416→+0.146) but the *sign* survives. So the direction is **not** a prefix artifact: it's
+carried by the **learned role encoding**, with the e5 prefix a *modulator* (+8 aligned, −2 fought). Subtlety:
+`dirichlet` swings more (95.5→75.5, 20 pts) than `prod` (91.5→81.5, 10 pts) — the superposition-trained model leaned
+*more* on the prefix, not less, reinforcing the multi-seed null (it built a more prefix-dependent, not more robust,
+direction).
+
 ## Conclusion
 On Wikipedia the direction axis is **consensus** (sign trivially agreed) and the superposition's magnitude/negative
 signals are underpowered on the in-coverage held set. The **true (novel-node) test** is the informative one and

--- a/prototypes/mu_cosine/REPORT_direction_blend.md
+++ b/prototypes/mu_cosine/REPORT_direction_blend.md
@@ -103,7 +103,7 @@ The null (Result 2) is a **saturation artifact**: direction is a strong signal (
 "X by country" vs "X in Germany"), so most pairs are near-certain and nothing can help them. Stratify the 400
 novel pairs by direction confidence and the benefit appears exactly where the theory says it should:
 
-| stratum | prod | dirichlet (3-seed) | gap |
+| stratum | prod (single model) | dirichlet (3-model ensemble) | gap |
 |---|---|---|---|
 | high-confidence half (large \|asym\|) | 98.0% | 98.0% | **0.0** |
 | low-confidence half (small \|asym\|) | 85.0% | 93.0% | **+8.0** |
@@ -133,7 +133,9 @@ can help. Wikipedia's semantic leakage makes most pairs certain, so the mean hid
 Wikipedia has too few uncertain pairs to move the aggregate. **The aggregate null (−1.0) is NOT evidence against
 cross-judge direction superposition in general** — only evidence that Wikipedia (a consensus taxonomy) is the wrong
 corpus to test its motivation. The natural next step is a corpus with **more direction uncertainty** (option B:
-looser hierarchies / multi-parent DAGs), where the uncertain tail is the bulk, not the fringe. Reusable assets stand (the `dir-blend` judge, the 3-estimator emitter with contradiction→negative,
-the novel-node + prefix + difficulty-stratified evals).
+looser hierarchies / multi-parent DAGs), where the uncertain tail is the bulk, not the fringe.
+
+Reusable assets stand (the `dir-blend` judge, the 3-estimator emitter with contradiction→negative, the novel-node
++ prefix + difficulty-stratified evals).
 
 Repro: `emit_direction_blend.py --mix {equal,dirichlet}` → fine-tune → novel-node eval (± e5 prefixes).

--- a/prototypes/mu_cosine/REPORT_multihop_direction.md
+++ b/prototypes/mu_cosine/REPORT_multihop_direction.md
@@ -45,6 +45,30 @@ uncertain) — and the gap *grows* with h (up>down on 49% → 77% of pairs). Rea
 is (very slightly) harder. Both stay high (~0.8) because Wikipedia titles are semantically clustered overall — the
 leakage is *large* in both directions, with a small, systematic upward tilt.
 
+## (c) Training on transitive hops → the operator becomes CONTINUOUS (user's fix, works)
+Emitted transitive HIER targets (`emit_transitive_hops.py`): μ_fwd(desc|anc)=p^h, μ_rev(anc|desc)=1−p^h,
+p=0.9, h=1..5, node-disjoint held. Fine-tuned from `model_prod` (+ the h=1 element/subcat superposition).
+
+| h | target 0.9^h | prod μ_fwd | transitive μ_fwd | transitive sign-acc |
+|---|---|---|---|---|
+| 1 | 0.900 | 0.878 | 0.810 | 100.0% |
+| 2 | 0.810 | 0.314 | 0.635 | 99.3% |
+| 3 | 0.729 | 0.074 | 0.465 | 100.0% |
+| 4 | 0.656 | 0.007 | 0.328 | 97.3% |
+| 5 | 0.590 | 0.003 | 0.258 | 93.7% |
+
+`prod` collapses to ~0 by h=3 (direct-only); the **transitive model decays smoothly** (0.81→0.26) and keeps
+**direction correct 94% at h=5 vs prod's 51% (chance)**. It undershoots the exact p^h target (direct WIKI edges,
+μ≈1 at h=1, pull the curve down), but the operator is now **continuous across hops** — the goal. A cleaner match to
+p^h would come from down-weighting the direct edges or a larger transitive round.
+
+## Open: LLM judges can score transitive pairs DIRECTLY (user 2026-07-05)
+The graph side needs a *mathematical* transitive rule (p^h) because the graph has only direct edges. The **LLM
+side does not** — it can judge a multi-hop pair *directly* ("is `1941_songs` ultimately under `Sound`?"). So the
+transitive superposition should use **direct LLM scores** on the multi-hop pairs (no composition), and — bonus —
+those scores **validate p^h**: does the LLM's transitive membership actually decay like 0.9^h? (Needs a scoring
+run on the multi-hop chains; see §(d) below.)
+
 ## Takeaways
 - The discrimination operator as trained is **direct-membership** (μ collapses by h=3); transitive `p^h` behaviour
   is a **design target requiring explicit training**, with p a measurable per-source leakage base (≈0.88 here).

--- a/prototypes/mu_cosine/REPORT_multihop_direction.md
+++ b/prototypes/mu_cosine/REPORT_multihop_direction.md
@@ -147,6 +147,14 @@ holds **79% at h=8**, p^h 66%, both far above chance. `prod` (no transitive trai
 deep hop** (79 vs 66% at h=8): the graph-native mean-reverting/root-converging target teaches a *more robust*
 deep-hop direction than the exponential `p^h`, and needs no second model to define it.
 
+**DECISION (user 2026-07-05): the WALK target is the graph side of the transitive superposition.** The deciding
+reason is *architectural, not the accuracy margin*: the walk needs **only the graph** — the same definition on
+every corpus — so it **avoids the "which model/embedding measures effective distance?" question** that §(d)'s
+effective-h forces (pick an embedding, verify it separates hops on that corpus — e5 barely does past ~3 hops here,
+§d — then re-tune). §(d) effective-h and the `p^h` rule (§c) are demoted to **deferred alternatives** kept for
+comparison. (The walk-beats-p^h deep-hop margin is single-seed and a bonus; the decision stands on self-sufficiency
++ the confirmed direction floor.)
+
 ## Takeaways
 - The discrimination operator as trained is **direct-membership** (μ collapses by h=3); transitive `p^h` behaviour
   is a **design target requiring explicit training**, with p a measurable per-source leakage base (≈0.88 here).

--- a/prototypes/mu_cosine/REPORT_multihop_direction.md
+++ b/prototypes/mu_cosine/REPORT_multihop_direction.md
@@ -70,6 +70,8 @@ those scores **validate p^h**: does the LLM's transitive membership actually dec
 run on the multi-hop chains; see §(d) below.)
 
 ## (d) Effective-h from semantic distance (user 2026-07-05) — calibration
+> **Superseded:** §(e) gives a graph-native alternative that needs no embedding, and the DECISION at §(f) adopts it.
+> This section is retained for comparison; skip to §(e) for the chosen approach.
 Make the operator continuous *within* a hop: measure avg semantic distance per h, calibrate it, and use a
 continuous **effective-h** (blending graph hops with an external-judge distance) in μ=p^(effective_h).
 
@@ -118,6 +120,15 @@ Can the *graph alone* give a continuous effective-h (avoiding the embedding/seco
 - **Within-hop variance grows with h** (0.48×→1.21×) — refines exactly where integer-h is coarsest.
 - **Direction encoded for free** — `P(up-walk anc→desc)=0` structurally (up-walks never descend), so `μ_rev=0`
   automatically; the fwd/rev asymmetry needs no `1−p^h` construction, and it converges toward the common root.
+  **Two distinct "reverses" (user):** (a) *invert the arguments* → `μ(anc|desc)=hit_prob(anc,desc)=0` — the correct
+  reverse *membership* (an ancestor is genuinely not under its descendant); this is the right `μ_rev`, and it shows
+  why `1−p^h` was wrong (it conflated direction-*uncertainty* with reverse-*membership*, inflating μ_rev to 0.41).
+  (b) *reverse the walk direction* → a **down**-walk `P(anc→desc)` is small-nonzero but is still a *forward*
+  containment viewed top-down (fan-out-diluted: a broad ancestor "reaches" any one member weakly) — a useful
+  *specificity-weighted* second direction signal, **not** the reverse.
+- **Path-agnostic** — `hit_prob` sums over *all* routes, so a pair sampled at shortest-path h via BFS may read a
+  hit-prob for a *shorter effective distance* if alternate short paths exist (part of why h=1 mean is 0.53 not 0.9:
+  branching, not distance). This is intended (effective, not shortest-path, membership).
 - Caveat: **+0.27 corr with e5 cos** — *complementary* to semantic distance, not a replacement; at h=1 it's 0.53
   (not 0.9) because branching dilutes membership when a node has many parents (arguably *correct* for effective
   membership — each of many parents is a weaker container).
@@ -145,7 +156,9 @@ consistently the ancestor, so even where the *magnitude* floors near the base ra
 holds **79% at h=8**, p^h 66%, both far above chance. `prod` (no transitive training) instead falls **below** chance
 (25% at h=8) — its μ collapses to 0 and noise dominates, so it's actively wrong deep down. **Walk beats p^h at every
 deep hop** (79 vs 66% at h=8): the graph-native mean-reverting/root-converging target teaches a *more robust*
-deep-hop direction than the exponential `p^h`, and needs no second model to define it.
+deep-hop direction than the exponential `p^h`, and needs no second model to define it. **Single-seed — the
+walk-vs-p^h *margin* should be validated multi-seed before it is cited as a quantitative claim** (the direction
+*floor* trend and the `μ_rev=0` structure are robust; the exact margin is not yet).
 
 **DECISION (user 2026-07-05): the WALK target is the graph side of the transitive superposition.** The deciding
 reason is *architectural, not the accuracy margin*: the walk needs **only the graph** — the same definition on

--- a/prototypes/mu_cosine/REPORT_multihop_direction.md
+++ b/prototypes/mu_cosine/REPORT_multihop_direction.md
@@ -69,6 +69,35 @@ transitive superposition should use **direct LLM scores** on the multi-hop pairs
 those scores **validate p^h**: does the LLM's transitive membership actually decay like 0.9^h? (Needs a scoring
 run on the multi-hop chains; see §(d) below.)
 
+## (d) Effective-h from semantic distance (user 2026-07-05) — calibration
+Make the operator continuous *within* a hop: measure avg semantic distance per h, calibrate it, and use a
+continuous **effective-h** (blending graph hops with an external-judge distance) in μ=p^(effective_h).
+
+| h | mean e5 cos (query·query) | dist=1−cos | 0.9^h | adjacent-hop Cohen's d |
+|---|---|---|---|---|
+| 1 | **0.902** | 0.098 | 0.900 | h1–h2: 1.01 |
+| 2 | 0.855 | 0.145 | 0.810 | h2–h3: 0.77 |
+| 3 | 0.820 | 0.180 | 0.729 | h3–h4: 0.66 |
+| 4 | 0.792 | 0.208 | 0.656 | h4–h5: 0.41 |
+| 5 | 0.777 | 0.223 | 0.590 | |
+
+Findings: (i) **mean h=1 cos = 0.902 ≈ p=0.9** — the base rate *is* the average h=1 semantic similarity, a clean
+interpretation. (ii) distance is **smooth & monotonic** in h ⇒ calibratable to effective-h. (iii) **separable at
+low h** (d≈1.0) but **poor at high h** (d=0.41, h4–h5) — leakage compresses distant nodes (e5 cos decays *slower*
+than 0.9^h, 0.78 at h=5 vs 0.59). ⇒ effective-h refines within ~3 hops on Wikipedia; a **lower-leakage corpus or a
+better embedding** extends the resolution. Construction: `effective_h = blend(graph_hops, embedding_distance)`,
+μ=p^effective_h — connects to the reciprocal-target struct embedding (`structural_embedding.py`, `1/d = 3/(1+‖Δ‖)`).
+
+### The two-part architecture (user 2026-07-05) — each side gets the transitive treatment it needs
+The transitive superposition has **two distinct parts**, and the two ideas map to them 1:1:
+- **GRAPH part** (discrimination operator): continuous via **effective-h** — integer hops refined by an
+  **embedding** distance, `μ = p^(effective_h)`. Structure is only direct-edged, so it needs the calibrated rule.
+- **NON-GRAPH part** (element / subcategory operators): **direct LLM** scores on the transitive pairs — the LLM
+  judges any pair directly, so *no* mathematical composition is needed (and those scores also validate `p^h`).
+
+So the LLM is the judge for the *non-graph* operators; the *embedding* is the distance for the *graph* effective-h.
+*Deferred: (graph) build effective-h target + train; (non-graph) LLM-score the multi-hop chains, then superpose.*
+
 ## Takeaways
 - The discrimination operator as trained is **direct-membership** (μ collapses by h=3); transitive `p^h` behaviour
   is a **design target requiring explicit training**, with p a measurable per-source leakage base (≈0.88 here).

--- a/prototypes/mu_cosine/REPORT_multihop_direction.md
+++ b/prototypes/mu_cosine/REPORT_multihop_direction.md
@@ -98,6 +98,36 @@ The transitive superposition has **two distinct parts**, and the two ideas map t
 So the LLM is the judge for the *non-graph* operators; the *embedding* is the distance for the *graph* effective-h.
 *Deferred: (graph) build effective-h target + train; (non-graph) LLM-score the multi-hop chains, then superpose.*
 
+## (e) Graph-native effective-h via random walk — no second model (user 2026-07-05)
+Can the *graph alone* give a continuous effective-h (avoiding the embedding/second model for §d)? Yes — the
+**up-walk hitting probability** `P(uniform-random up-walk from desc visits anc)` (exact DP: `h(anc)=1`,
+`h(x)=mean over parents`, roots→0):
+
+| h | mean hit-prob | within-h CV | 0.9^h | mean e5 cos |
+|---|---|---|---|---|
+| 1 | 0.529 | 0.48× | 0.900 | 0.900 |
+| 2 | 0.327 | 0.83× | 0.810 | 0.851 |
+| 3 | 0.246 | 1.02× | 0.729 | 0.814 |
+| 4 | 0.201 | 1.12× | 0.656 | 0.775 |
+| 5 | 0.181 | 1.21× | 0.590 | 0.775 |
+
+- **Continuous** — 418 distinct values over 1500 pairs (vs 5 integer hops); graph-only.
+- **Mean-reverting** — flattens toward a base-rate floor (~0.18) instead of decaying to 0 like `p^h`. Fixes the
+  `p^h → 0` asymptote (a distant ancestor is a near-random pair) *for free* — the walk dilutes across branches, so
+  "the probability of drifting back rises the further you drift" (user) is intrinsic.
+- **Within-hop variance grows with h** (0.48×→1.21×) — refines exactly where integer-h is coarsest.
+- **Direction encoded for free** — `P(up-walk anc→desc)=0` structurally (up-walks never descend), so `μ_rev=0`
+  automatically; the fwd/rev asymmetry needs no `1−p^h` construction, and it converges toward the common root.
+- Caveat: **+0.27 corr with e5 cos** — *complementary* to semantic distance, not a replacement; at h=1 it's 0.53
+  (not 0.9) because branching dilutes membership when a node has many parents (arguably *correct* for effective
+  membership — each of many parents is a weaker container).
+
+**Implication:** a graph-native transitive target `μ_fwd(desc|anc)=hit_prob`, `μ_rev=0` needs **no embedding and no
+LLM** for the graph side of the superposition — it is continuous, mean-reverting, root-converging, and
+direction-correct by construction. Relative to §(d)'s effective-h, this *replaces* the second model rather than
+calibrating against it. (Next: train on hit-prob targets and compare the learned decay to §(c)'s p^h model;
+optionally normalise hit-prob against a random-pair base rate to recover a true direction-uncertainty at large h.)
+
 ## Takeaways
 - The discrimination operator as trained is **direct-membership** (μ collapses by h=3); transitive `p^h` behaviour
   is a **design target requiring explicit training**, with p a measurable per-source leakage base (≈0.88 here).

--- a/prototypes/mu_cosine/REPORT_multihop_direction.md
+++ b/prototypes/mu_cosine/REPORT_multihop_direction.md
@@ -129,6 +129,15 @@ Can the *graph alone* give a continuous effective-h (avoiding the embedding/seco
 - **Path-agnostic** — `hit_prob` sums over *all* routes, so a pair sampled at shortest-path h via BFS may read a
   hit-prob for a *shorter effective distance* if alternate short paths exist (part of why h=1 mean is 0.53 not 0.9:
   branching, not distance). This is intended (effective, not shortest-path, membership).
+
+**Design principle — IS vs OUGHT (user 2026-07-05).** `μ_rev=0` answers *is* the ancestor structurally a member of
+its descendant (no — a descriptive graph fact). The `1−p^h` complement was reaching for *ought* it be uncertain at
+distance (an epistemic claim). Different questions — and the architecture assigns each to its right source: the
+**graph** component supplies the crisp structural **IS** (`μ_rev=0` — trains faster and keeps a clean basis for
+source-separation), and the epistemic **OUGHT** (confidence softening at distance) enters through the **judge we
+superpose with** (the LLM/semantic side). So the *blended* `μ_rev` is not 0 — it is the graph's structural 0 mixed
+with the partner's uncertainty. We deliberately keep the graph target factual and let the superposition carry the
+ought; baking ought into the graph would muddy the very basis the superposition needs to separate.
 - Caveat: **+0.27 corr with e5 cos** — *complementary* to semantic distance, not a replacement; at h=1 it's 0.53
   (not 0.9) because branching dilutes membership when a node has many parents (arguably *correct* for effective
   membership — each of many parents is a weaker container).

--- a/prototypes/mu_cosine/REPORT_multihop_direction.md
+++ b/prototypes/mu_cosine/REPORT_multihop_direction.md
@@ -1,0 +1,56 @@
+# Multi-hop direction: the 0.9^h transitive rule + upward/downward semantic leakage
+
+*Follow-up to `REPORT_direction_blend.md` (user, 2026-07-05). Two questions: (a) does the discrimination operator's
+magnitude decay like `p^h` (p≈0.9 base, h hops) in the transitive case? (b) is upward semantic leakage weaker than
+downward? 300 ancestor-descendant chains sampled at exact hop distances h=1..5 from 100k_cats; μ_HIER(desc|anc)
+from the trained model, plus frozen-e5 directional dot-products (model-independent leakage).*
+
+## (a) Transitive magnitude — the model is DIRECT-membership, not 0.9^h
+
+| h | μ_fwd(desc\|anc) | μ_rev(anc\|desc) | sign-acc | 0.9^h |
+|---|---|---|---|---|
+| 1 | 0.880 | 0.022 | 99.7% | 0.900 |
+| 2 | 0.363 | 0.003 | 97.0% | 0.810 |
+| 3 | 0.069 | 0.000 | 88.0% | 0.729 |
+| 4 | 0.010 | 0.003 | 73.3% | 0.656 |
+| 5 | 0.003 | 0.001 | 51.3% | 0.590 |
+
+The trained μ_HIER **collapses far faster than 0.9^h** (0.88 → 0.36 → 0.07 → ~0 by h=3): it learned membership ≈
+**direct edge**, because the WIKI training edges are direct parent-child. `0.9^h` is a sensible *target* but the
+model doesn't produce it for free — it would need **explicit transitive training** (emit μ=p^h targets at h hops).
+Note the **sign** (direction) degrades *gracefully* — correct to ~h=4, chance (51%) by h=5 — even as the magnitude
+collapses; so the model keeps *directional* information a couple hops past where it keeps *membership* magnitude.
+
+**Design implication (answers the open multi-hop question):** if we want the discrimination operator to be
+transitive, `p^h` is the rule to train toward, with **p a per-source leakage base** (Wikipedia ≈ 0.88 at h=1). A
+less-leaky corpus would have lower p ⇒ faster decay ⇒ more uncertain multi-hop direction ⇒ (per
+`REPORT_direction_blend.md` Result 5) more room for the superposition to help.
+
+## (b) Upward vs downward semantic leakage (frozen e5, model-independent)
+
+Leakage is a property of the frozen e5 (what titles reveal), not the trained model. e5's `query:`/`passage:`
+prefixes make it directional: UP = `passage:desc · query:anc` (narrow-as-content vs broad-as-query), DOWN reversed.
+
+| h | e5 UP (p:desc·q:anc) | e5 DOWN (p:anc·q:desc) | up>down |
+|---|---|---|---|
+| 1 | 0.852 | 0.851 | 48.7% |
+| 2 | 0.819 | 0.815 | 57.0% |
+| 3 | 0.794 | 0.786 | 65.7% |
+| 4 | 0.778 | 0.768 | 70.7% |
+| 5 | 0.768 | 0.756 | 77.0% |
+
+**Upward leakage is slightly HIGHER than downward** — the *opposite* of the hypothesis (which was flagged as
+uncertain) — and the gap *grows* with h (up>down on 49% → 77% of pairs). Reading: a specific descendant as a
+`passage` matched to a broad ancestor `query` scores marginally better than the reverse; broad-→narrow (downward)
+is (very slightly) harder. Both stay high (~0.8) because Wikipedia titles are semantically clustered overall — the
+leakage is *large* in both directions, with a small, systematic upward tilt.
+
+## Takeaways
+- The discrimination operator as trained is **direct-membership** (μ collapses by h=3); transitive `p^h` behaviour
+  is a **design target requiring explicit training**, with p a measurable per-source leakage base (≈0.88 here).
+- **Direction (sign) survives ~2 hops past membership magnitude** — a cheap transitive signal is there even without
+  a magnitude rule.
+- Semantic leakage is **large and slightly upward-tilted** on Wikipedia — consistent with why direction is "too
+  easy" here; a lower-leakage source is where transitive + superposition effects would actually show.
+
+Repro: sample chains from 100k_cats at h=1..5 → build e5 (with ancestor closure) → μ_HIER(desc|anc) vs h + frozen-e5 up/down dots.

--- a/prototypes/mu_cosine/REPORT_multihop_direction.md
+++ b/prototypes/mu_cosine/REPORT_multihop_direction.md
@@ -125,8 +125,27 @@ Can the *graph alone* give a continuous effective-h (avoiding the embedding/seco
 **Implication:** a graph-native transitive target `μ_fwd(desc|anc)=hit_prob`, `μ_rev=0` needs **no embedding and no
 LLM** for the graph side of the superposition — it is continuous, mean-reverting, root-converging, and
 direction-correct by construction. Relative to §(d)'s effective-h, this *replaces* the second model rather than
-calibrating against it. (Next: train on hit-prob targets and compare the learned decay to §(c)'s p^h model;
-optionally normalise hit-prob against a random-pair base rate to recover a true direction-uncertainty at large h.)
+calibrating against it.
+
+### (f) Walk-target TRAINING — direction FLOORS above 0.5 (user), and walk beats p^h at depth
+Trained a model on `--target walk` (`μ_fwd=hit_prob, μ_rev=0`, + the h=1 element/subcat superposition), evaluated
+`μ_fwd` and **direction sign-accuracy** vs h to h=8 on held nodes (n=200/hop):
+
+| h | prod μ / dir% | p^h μ / dir% | walk μ / dir% |
+|---|---|---|---|
+| 1 | 0.880 / 100% | 0.807 / 100% | 0.807 / 99% |
+| 3 | 0.065 / 88% | 0.446 / 98% | 0.166 / 98% |
+| 5 | 0.000 / 52% | 0.202 / 91% | 0.069 / 94% |
+| 6 | 0.001 / 40% | 0.144 / 86% | 0.050 / 90% |
+| 7 | 0.000 / 30% | 0.079 / 79% | 0.031 / 87% |
+| 8 | 0.000 / **25%** | 0.071 / 66% | 0.032 / **79%** |
+
+**Direction floors ABOVE 0.5 (user's prediction, confirmed):** root convergence makes the more-root-ward node
+consistently the ancestor, so even where the *magnitude* floors near the base rate the *direction* survives — walk
+holds **79% at h=8**, p^h 66%, both far above chance. `prod` (no transitive training) instead falls **below** chance
+(25% at h=8) — its μ collapses to 0 and noise dominates, so it's actively wrong deep down. **Walk beats p^h at every
+deep hop** (79 vs 66% at h=8): the graph-native mean-reverting/root-converging target teaches a *more robust*
+deep-hop direction than the exponential `p^h`, and needs no second model to define it.
 
 ## Takeaways
 - The discrimination operator as trained is **direct-membership** (μ collapses by h=3); transitive `p^h` behaviour

--- a/prototypes/mu_cosine/emit_direction_blend.py
+++ b/prototypes/mu_cosine/emit_direction_blend.py
@@ -53,7 +53,7 @@ def parse_responses(path):
             if isinstance(arr, list):
                 for o in arr:
                     if isinstance(o, dict) and "id" in o:
-                        byid[int(o["id"])] = o
+                        byid[int(o["id"])] = o          # last-wins on duplicate ids (restarted/concatenated runs)
             i = end
         except json.JSONDecodeError:
             i = j + 1
@@ -86,10 +86,12 @@ def main():
     def d_of(o, rel):
         e = o.get(rel, {}); return float(e.get("mu_fwd", 0)) - float(e.get("mu_rev", 0))
 
+    # held_ids are POSITIONAL indices into --pairs — valid because emit + eval read the SAME unmodified pairs
+    # file; if that file is ever reordered/filtered upstream, switch to hashing on (na, ro) (review).
     held = set(int(x) for x in open(a.held_ids).read().split()) if a.held_ids else set()
     rows, npos, nneg = [], 0, 0
     for idx, (na, ro) in enumerate(pairs):
-        if idx not in byid or idx in held:
+        if idx not in byid or idx in held or na == ro:      # skip self-pairs (up_hops(x,x)=0 would be ambiguous)
             continue
         uf, ur = up_hops(parents, na, ro), up_hops(parents, ro, na)
         dg = ((3 / (1 + uf) if uf is not None else 0.0) - (3 / (1 + ur) if ur is not None else 0.0)) / 3.0  # →[-1,1]

--- a/prototypes/mu_cosine/emit_direction_blend.py
+++ b/prototypes/mu_cosine/emit_direction_blend.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Cross-judge DIRECTION superposition (DESIGN_cross_judge_direction.md): mix THREE estimators of the same latent
+— direction (which node is broader/container) — and train it as a distinct calibrated judge `dir-blend`:
+
+    d_blend = w_g·d_graph  +  w_e·d_element  +  w_s·d_subcat        (w ~ mix over the 3-simplex)
+      d_graph   = (3/(1+up_hops(a→b)) − 3/(1+up_hops(b→a)))/3       structure (graph-judged discrimination)
+      d_element = μ_fwd − μ_rev  for element_of                     LLM-judged (raw §14 responses)
+      d_subcat  = μ_fwd − μ_rev  for subcategory                    LLM-judged
+
+Emitted as HIER directional rows (the direction carrier): per pair, (node,root)→μ_fwd and (root,node)→μ_rev with
+μ_fwd−μ_rev = d_blend, so the operator's asymmetry is trained toward the mixed direction. Mix: fixed-equal, or a
+random Dirichlet over the simplex (--mix dirichlet --alpha) — the 3-way analog of truncated-λ. All three agree on
+SIGN ~100% on Wikipedia (a clean taxonomy); the mixing content is the MAGNITUDE + the judge-independence test.
+
+  <out>: node root mu op=HIER relation=subcategory node_type root_type corpus judge=dir-blend conf
+  python3 emit_direction_blend.py --pairs /tmp/mu_data/wiki_rel_pairs.tsv --responses /tmp/mu_data/wiki_rel_resp.txt \
+      --graph ../../data/benchmark/100k_cats/category_parent.tsv --mix dirichlet --alpha 4 --out /tmp/mu_data/dir_blend_pairs.tsv
+"""
+import argparse, json, os, sys
+import numpy as np
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mu_attention import load_dag
+
+
+def up_hops(parents, x, y, cap=8):
+    if x == y:
+        return 0
+    fr, seen = {x}, {x}
+    for h in range(1, cap + 1):
+        nx = set()
+        for c in fr:
+            for p in (parents.get(c) or []):
+                if p == y:
+                    return h
+                if p not in seen:
+                    seen.add(p); nx.add(p)
+        if not nx:
+            break
+        fr = nx
+    return None
+
+
+def parse_responses(path):
+    """id → {relation: {mu_fwd, mu_rev}} from the concatenated §14 JSON arrays."""
+    txt = open(path, encoding="utf-8").read()
+    dec = json.JSONDecoder(); i = 0; byid = {}
+    while True:
+        j = txt.find("[", i)
+        if j < 0:
+            break
+        try:
+            arr, end = dec.raw_decode(txt, j)
+            if isinstance(arr, list):
+                for o in arr:
+                    if isinstance(o, dict) and "id" in o:
+                        byid[int(o["id"])] = o
+            i = end
+        except json.JSONDecodeError:
+            i = j + 1
+    return byid
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pairs", required=True)
+    ap.add_argument("--responses", required=True)
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--mix", choices=["equal", "dirichlet"], default="equal",
+                    help="3-simplex mix weights: equal (1/3 each) or a random Dirichlet per pair (the 3-way "
+                    "analog of truncated-λ — spreads the family for judge-independence)")
+    ap.add_argument("--alpha", type=float, default=4.0, help="Dirichlet concentration (large=near-equal centroid, "
+                    "small=peaky/one-operator-ish). 4 ≈ gentle spread, like truncated-normal std 0.15.")
+    ap.add_argument("--corpus", default="enwiki")
+    ap.add_argument("--no-negatives", action="store_true", help="drop no/contradictory-direction pairs instead of "
+                    "emitting them as asymmetry-0 negatives (default: include them — direction needs agreement)")
+    ap.add_argument("--held-ids", default=None, help="file of pair indices to EXCLUDE (held-out for the eval)")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+    rng = np.random.default_rng(a.seed)
+
+    parents, _, _ = load_dag(a.graph)
+    pairs = [ln.rstrip("\n").split("\t")[:2] for ln in open(a.pairs, encoding="utf-8") if not ln.startswith("#")]
+    byid = parse_responses(a.responses)
+
+    def d_of(o, rel):
+        e = o.get(rel, {}); return float(e.get("mu_fwd", 0)) - float(e.get("mu_rev", 0))
+
+    held = set(int(x) for x in open(a.held_ids).read().split()) if a.held_ids else set()
+    rows, npos, nneg = [], 0, 0
+    for idx, (na, ro) in enumerate(pairs):
+        if idx not in byid or idx in held:
+            continue
+        uf, ur = up_hops(parents, na, ro), up_hops(parents, ro, na)
+        dg = ((3 / (1 + uf) if uf is not None else 0.0) - (3 / (1 + ur) if ur is not None else 0.0)) / 3.0  # →[-1,1]
+        de, ds = d_of(byid[idx], "element_of"), d_of(byid[idx], "subcategory")
+        directional = not (abs(dg) < 1e-6 and abs(de) < 1e-6 and abs(ds) < 1e-6)
+        if not directional and a.no_negatives:
+            continue
+        # NEGATIVES (user 2026-07-05): when the operators give NO / contradictory direction, the mix → ~0 ⇒
+        # μ_fwd ≈ μ_rev (asymmetry 0). Trains "a direction requires operator AGREEMENT" — the framework handles
+        # contradictions gracefully as no-direction cases (matters most on direction-AMBIGUOUS data).
+        w = np.array([1/3, 1/3, 1/3]) if a.mix == "equal" else rng.dirichlet([a.alpha, a.alpha, a.alpha])
+        d = float(w[0] * dg + w[1] * de + w[2] * ds)        # mixed direction ∈ [-1,1]; ≈0 for no/contradictory dir
+        mu_f = max(0.0, min(1.0, 0.5 + d / 2.0))
+        mu_r = max(0.0, min(1.0, 0.5 - d / 2.0))            # μ_fwd − μ_rev = d
+        rows.append((na, ro, mu_f)); rows.append((ro, na, mu_r))
+        npos += directional; nneg += (not directional)
+
+    with open(a.out, "w", encoding="utf-8") as f:
+        f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\tconf\n")
+        for na, ro, mu in rows:
+            f.write(f"{na}\t{ro}\t{mu:.3f}\tHIER\tsubcategory\tcategory\tcategory\t{a.corpus}\tdir-blend\t1.0\n")
+    print(f"wrote {len(rows)} HIER dir-blend rows ({npos} directional + {nneg} no-direction negatives, ×fwd/rev) "
+          f"→ {a.out}  (mix={a.mix}{'' if a.mix=='equal' else f' α={a.alpha}'})")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/emit_transitive_hops.py
+++ b/prototypes/mu_cosine/emit_transitive_hops.py
@@ -35,10 +35,35 @@ def anc_by_hop(parents, start, hmax):
     return byh
 
 
+def hit_prob(parents, desc, anc, cap=40):
+    """P(uniform-random up-walk from desc visits anc) — a graph-native, CONTINUOUS, mean-reverting,
+    root-converging effective-membership (needs no embedding/LLM). μ_rev = hit_prob(anc→desc) = 0 structurally
+    (up-walks never descend), so direction is encoded for free. See REPORT_multihop_direction.md §(e)."""
+    memo = {}
+    def h(x, depth):
+        if x == anc:
+            return 1.0
+        if depth > cap:
+            return 0.0
+        if x in memo:
+            return memo[x]
+        ps = parents.get(x) or []
+        if not ps:
+            return 0.0
+        memo[x] = 0.0                                    # guard against DAG re-entry
+        v = sum(h(p, depth + 1) for p in ps) / len(ps)
+        memo[x] = v
+        return v
+    return h(desc, 0)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--graph", required=True)
-    ap.add_argument("--p", type=float, default=0.9, help="per-source leakage base for μ_fwd = p^h")
+    ap.add_argument("--target", choices=["ph", "walk"], default="ph",
+                    help="ph: μ_fwd=p^h, μ_rev=1−p^h (exponential, needs p). walk: μ_fwd=up-walk hit-prob, μ_rev=0 "
+                    "— graph-native, continuous, mean-reverting, no second model (REPORT_multihop_direction §e).")
+    ap.add_argument("--p", type=float, default=0.9, help="per-source leakage base for μ_fwd = p^h (--target ph)")
     ap.add_argument("--hmax", type=int, default=5)
     ap.add_argument("--chains", type=int, default=1500)
     ap.add_argument("--held-frac", type=float, default=0.15)
@@ -73,8 +98,12 @@ def main():
         f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\tconf\n")
         n = 0
         for h in range(1, a.hmax + 1):
-            mf, mr = a.p ** h, 1.0 - a.p ** h
+            ph_f, ph_r = a.p ** h, 1.0 - a.p ** h
             for desc, anc in train[h]:
+                if a.target == "walk":
+                    mf, mr = hit_prob(parents, desc, anc), 0.0     # graph-native; μ_rev=0 by construction
+                else:
+                    mf, mr = ph_f, ph_r
                 f.write(f"{desc}\t{anc}\t{mf:.3f}\tHIER\tsubcategory\tcategory\tcategory\t{a.corpus}\tgraph\t1.0\n")
                 f.write(f"{anc}\t{desc}\t{mr:.3f}\tHIER\tsubcategory\tcategory\tcategory\t{a.corpus}\tgraph\t1.0\n")
                 n += 2

--- a/prototypes/mu_cosine/emit_transitive_hops.py
+++ b/prototypes/mu_cosine/emit_transitive_hops.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Transitive discrimination target (user 2026-07-05): make the HIER discrimination operator CONTINUOUS across
+hops instead of direct-only. For an ancestor-descendant pair at h hops, target
+
+    μ_fwd(desc | anc) = p^h          (forward membership decays with distance)
+    μ_rev(anc | desc) = 1 − p^h      (direction confidence degrades toward ambiguous as h grows)
+
+p = per-source semantic-leakage base (≈0.9 on Wikipedia; LOWER leakage ⇒ HIGHER p, cleaner structural decay).
+Emitted as HIER rows tagged judge=graph (purely graph-structural). Sampled ancestor-descendant chains at exact
+hop distances via BFS-up; node-disjoint train/held split so the eval measures the LEARNED decay curve.
+
+  python3 emit_transitive_hops.py --graph .../100k_cats/category_parent.tsv --p 0.9 --hmax 5 --chains 1500 \
+      --out /tmp/mu_data/transitive_train.tsv --held-out /tmp/mu_data/transitive_held.json
+"""
+import argparse, json, os, random, sys
+from collections import deque
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mu_attention import load_dag
+
+
+def anc_by_hop(parents, start, hmax):
+    seen, q, byh = {start: 0}, deque([start]), {}
+    while q:
+        x = q.popleft(); h = seen[x]
+        if h >= hmax:
+            continue
+        for p in (parents.get(x) or []):
+            if p not in seen:
+                seen[p] = h + 1; byh.setdefault(h + 1, []).append(p); q.append(p)
+    return byh
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--p", type=float, default=0.9, help="per-source leakage base for μ_fwd = p^h")
+    ap.add_argument("--hmax", type=int, default=5)
+    ap.add_argument("--chains", type=int, default=1500)
+    ap.add_argument("--held-frac", type=float, default=0.15)
+    ap.add_argument("--corpus", default="enwiki")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--held-out", required=True, help="JSON of held chains for the eval")
+    a = ap.parse_args()
+
+    parents, _, _ = load_dag(a.graph)
+    rng = random.Random(a.seed)
+    nodes = list(parents.keys()); rng.shuffle(nodes)
+    held_nodes = set(nodes[:int(a.held_frac * len(nodes))])
+
+    train, held = {h: [] for h in range(1, a.hmax + 1)}, {h: [] for h in range(1, a.hmax + 1)}
+    for s in nodes:
+        byh = anc_by_hop(parents, s, a.hmax)
+        if not all(h in byh for h in range(1, a.hmax + 1)):
+            continue
+        chain = {h: rng.choice(byh[h]) for h in range(1, a.hmax + 1)}
+        bucket = held if (s in held_nodes) else train
+        for h in range(1, a.hmax + 1):
+            bucket[h].append((s, chain[h]))
+        if sum(len(v) for v in train.values()) >= a.chains * a.hmax:
+            break
+
+    with open(a.out, "w", encoding="utf-8") as f:
+        f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\tconf\n")
+        n = 0
+        for h in range(1, a.hmax + 1):
+            mf, mr = a.p ** h, 1.0 - a.p ** h
+            for desc, anc in train[h]:
+                f.write(f"{desc}\t{anc}\t{mf:.3f}\tHIER\tsubcategory\tcategory\tcategory\t{a.corpus}\tgraph\t1.0\n")
+                f.write(f"{anc}\t{desc}\t{mr:.3f}\tHIER\tsubcategory\tcategory\tcategory\t{a.corpus}\tgraph\t1.0\n")
+                n += 2
+    json.dump({str(h): held[h] for h in held}, open(a.held_out, "w"))
+    print(f"wrote {n} transitive HIER rows (p={a.p}, h=1..{a.hmax}, {sum(len(v) for v in train.values())} train "
+          f"chains) → {a.out}; held {sum(len(v) for v in held.values())} chains → {a.held_out}")
+    print("  targets μ_fwd=p^h:", {h: round(a.p ** h, 3) for h in range(1, a.hmax + 1)})
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/emit_transitive_hops.py
+++ b/prototypes/mu_cosine/emit_transitive_hops.py
@@ -5,7 +5,12 @@ hops instead of direct-only. For an ancestor-descendant pair at h hops, target
     μ_fwd(desc | anc) = p^h          (forward membership decays with distance)
     μ_rev(anc | desc) = 1 − p^h      (direction confidence degrades toward ambiguous as h grows)
 
-p = per-source semantic-leakage base (≈0.9 on Wikipedia; LOWER leakage ⇒ HIGHER p, cleaner structural decay).
+μ_rev = 1−p^h is a DELIBERATE, Wikipedia-calibrated choice: the reverse is the COMPLEMENT (a soft non-membership
+that rises toward 0.5 at large h), NOT p^h-in-reverse. A stricter hierarchy (formal ontology) may want reverse ≈ 0
+at h=1 — the general two-parameter form is μ_rev = r^h with a separate reverse base r (here r implicitly ties to p).
+p = per-source semantic-leakage base. Use p ≈ 0.90 = mean h=1 e5 cosine on enwiki (the geometric grounding); the
+trained model's actual h=1 output is ≈0.88, slightly below target from direct-edge (μ≈1) training pressure. LOWER
+leakage ⇒ HIGHER p (structure-led, cleaner decay).
 Emitted as HIER rows tagged judge=graph (purely graph-structural). Sampled ancestor-descendant chains at exact
 hop distances via BFS-up; node-disjoint train/held split so the eval measures the LEARNED decay curve.
 
@@ -48,17 +53,21 @@ def main():
     nodes = list(parents.keys()); rng.shuffle(nodes)
     held_nodes = set(nodes[:int(a.held_frac * len(nodes))])
 
-    train, held = {h: [] for h in range(1, a.hmax + 1)}, {h: [] for h in range(1, a.hmax + 1)}
+    # collect ALL full chains first, then downsample train to the cap — so the held set is NOT biased toward
+    # early-shuffle nodes (an earlier version broke out as soon as train filled, starving the held set; review).
+    train_src, held = [], {h: [] for h in range(1, a.hmax + 1)}
     for s in nodes:
         byh = anc_by_hop(parents, s, a.hmax)
         if not all(h in byh for h in range(1, a.hmax + 1)):
             continue
         chain = {h: rng.choice(byh[h]) for h in range(1, a.hmax + 1)}
-        bucket = held if (s in held_nodes) else train
-        for h in range(1, a.hmax + 1):
-            bucket[h].append((s, chain[h]))
-        if sum(len(v) for v in train.values()) >= a.chains * a.hmax:
-            break
+        if s in held_nodes:
+            for h in range(1, a.hmax + 1):
+                held[h].append((s, chain[h]))
+        else:
+            train_src.append((s, chain))
+    rng.shuffle(train_src)
+    train = {h: [(s, ch[h]) for s, ch in train_src[:a.chains]] for h in range(1, a.hmax + 1)}
 
     with open(a.out, "w", encoding="utf-8") as f:
         f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\tconf\n")
@@ -70,8 +79,8 @@ def main():
                 f.write(f"{anc}\t{desc}\t{mr:.3f}\tHIER\tsubcategory\tcategory\tcategory\t{a.corpus}\tgraph\t1.0\n")
                 n += 2
     json.dump({str(h): held[h] for h in held}, open(a.held_out, "w"))
-    print(f"wrote {n} transitive HIER rows (p={a.p}, h=1..{a.hmax}, {sum(len(v) for v in train.values())} train "
-          f"chains) → {a.out}; held {sum(len(v) for v in held.values())} chains → {a.held_out}")
+    print(f"wrote {n} transitive HIER rows (p={a.p}, h=1..{a.hmax}, {len(train_src[:a.chains])} train chains × "
+          f"{a.hmax} hops × fwd/rev) → {a.out}; held {len(held[1])} chains → {a.held_out}")
     print("  targets μ_fwd=p^h:", {h: round(a.p ** h, 3) for h in range(1, a.hmax + 1)})
 
 

--- a/prototypes/mu_cosine/emit_transitive_hops.py
+++ b/prototypes/mu_cosine/emit_transitive_hops.py
@@ -35,26 +35,29 @@ def anc_by_hop(parents, start, hmax):
     return byh
 
 
-def hit_prob(parents, desc, anc, cap=40):
-    """P(uniform-random up-walk from desc visits anc) — a graph-native, CONTINUOUS, mean-reverting,
-    root-converging effective-membership (needs no embedding/LLM). μ_rev = hit_prob(anc→desc) = 0 structurally
-    (up-walks never descend), so direction is encoded for free. See REPORT_multihop_direction.md §(e)."""
+def hit_prob(parents, desc, anc):
+    """P(uniform-random UP-walk from desc visits anc) — a graph-native, CONTINUOUS, mean-reverting,
+    root-converging effective-membership (needs no embedding/LLM). Two distinct "reverses" (user 2026-07-05):
+    (a) INVERT ARGS → μ(anc|desc)=hit_prob(anc,desc)=0 structurally (up-walks never descend) — the correct μ_rev
+    for direction; (b) REVERSE THE WALK → a DOWN-walk P(anc→desc) is small-nonzero but is still a *forward*
+    containment (top-down, fan-out-diluted), NOT the reverse. See REPORT_multihop_direction.md §(e).
+
+    Exact DP on the DAG (unconditional hitting prob, no depth budget): the memo double-serves as a cycle guard
+    (a node mid-computation returns 0). memo is per-(desc,anc) call — not cached across pairs."""
     memo = {}
-    def h(x, depth):
+    def h(x):
         if x == anc:
             return 1.0
-        if depth > cap:
-            return 0.0
         if x in memo:
             return memo[x]
         ps = parents.get(x) or []
         if not ps:
-            return 0.0
-        memo[x] = 0.0                                    # guard against DAG re-entry
-        v = sum(h(p, depth + 1) for p in ps) / len(ps)
+            return 0.0                                   # reached a root without hitting anc
+        memo[x] = 0.0                                    # cycle guard: node currently being computed → 0
+        v = sum(h(p) for p in ps) / len(ps)
         memo[x] = v
         return v
-    return h(desc, 0)
+    return h(desc)
 
 
 def main():
@@ -94,6 +97,9 @@ def main():
     rng.shuffle(train_src)
     train = {h: [(s, ch[h]) for s, ch in train_src[:a.chains]] for h in range(1, a.hmax + 1)}
 
+    # Rows are tagged judge=graph (they ARE graph-structural). This DELIBERATELY extends the graph judge's
+    # calibration from direct-edge to transitive membership; if you want to keep those separate, a `graph-transitive`
+    # judge row (analogous to dir-blend getting its own row) is the tracked alternative (review 2026-07-05).
     with open(a.out, "w", encoding="utf-8") as f:
         f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\tconf\n")
         n = 0
@@ -110,7 +116,10 @@ def main():
     json.dump({str(h): held[h] for h in held}, open(a.held_out, "w"))
     print(f"wrote {n} transitive HIER rows (p={a.p}, h=1..{a.hmax}, {len(train_src[:a.chains])} train chains × "
           f"{a.hmax} hops × fwd/rev) → {a.out}; held {len(held[1])} chains → {a.held_out}")
-    print("  targets μ_fwd=p^h:", {h: round(a.p ** h, 3) for h in range(1, a.hmax + 1)})
+    if a.target == "ph":
+        print("  targets μ_fwd=p^h:", {h: round(a.p ** h, 3) for h in range(1, a.hmax + 1)})
+    else:
+        print("  targets μ_fwd=hit_prob (per-pair up-walk); μ_rev=0")
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/eval_direction.py
+++ b/prototypes/mu_cosine/eval_direction.py
@@ -17,7 +17,10 @@ from eval_relatedness import build_model
 from emit_direction_blend import up_hops, parse_responses
 
 
-def corr(a, b): return float(np.corrcoef(a, b)[0, 1])
+def corr(a, b):
+    if np.std(a) < 1e-12 or np.std(b) < 1e-12:      # guard: corrcoef → nan on a constant array
+        return float("nan")
+    return float(np.corrcoef(a, b)[0, 1])
 
 
 def hier_dir(model, tok, pairs, dev, judge=None, corpus="enwiki"):
@@ -64,10 +67,10 @@ def main():
         dg, de, ds = dgraph(x, y), dllm(byid[i], "element_of"), dllm(byid[i], "subcategory")
         if abs(dg) < 1e-6 and abs(de) < 1e-6 and abs(ds) < 1e-6: continue      # no direction — skip
         pairs.append((x, y)); d_true.append((dg + de + ds) / 3.0)
-    d_true = np.array(d_true)
     d = torch.load(a.e5_cache, weights_only=False); idx = {n: i for i, n in enumerate(d["names"])}
-    pairs = [(x, y) for x, y in pairs if x in idx and y in idx]
-    d_true = d_true[:len(pairs)]
+    # paired filter — keep pairs and their targets in lockstep (was a fragile d_true[:len(pairs)] slice; review)
+    kept = [(p, t) for p, t in zip(pairs, d_true) if p[0] in idx and p[1] in idx]
+    pairs = [p for p, _ in kept]; d_true = np.array([t for _, t in kept])
     tok = Tokenizer(d["query"], d["passage"], idx, parents, load_dag(a.graph)[2])
     print(f"held directional pairs: {len(pairs)}  (target = mean(d_graph,d_element,d_subcat), sign-consensus)\n")
 

--- a/prototypes/mu_cosine/eval_direction.py
+++ b/prototypes/mu_cosine/eval_direction.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Direction eval for the cross-judge direction superposition (DESIGN_cross_judge_direction.md). On held-out
+pairs, correlate each model's HIER directional asymmetry μ(a|b)−μ(b|a) with the consensus direction target
+d_true = mean(d_graph, d_element, d_subcat), read WITH the `dir-blend` judge input and AGNOSTICALLY. The
+dir-blend-trained model should carry the direction in the trunk (agnostic) → judge-independent (the truncated-λ
+story, for direction).
+
+  python3 eval_direction.py --pairs /tmp/mu_data/wiki_rel_pairs.tsv --ids /tmp/mu_data/dir_held_ids.txt \
+      --responses /tmp/mu_data/wiki_rel_resp.txt --graph .../100k_cats/category_parent.tsv \
+      --e5-cache /tmp/mu_data/wiki_rel_e5.pt --models prod=model_prod.pt eq=... dir=...
+"""
+import argparse, json, os, sys
+import numpy as np, torch
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mu_attention import OPS, CORPORA, JUDGES, Tokenizer, load_dag
+from eval_relatedness import build_model
+from emit_direction_blend import up_hops, parse_responses
+
+
+def corr(a, b): return float(np.corrcoef(a, b)[0, 1])
+
+
+def hier_dir(model, tok, pairs, dev, judge=None, corpus="enwiki"):
+    """μ_HIER(a|b) − μ_HIER(b|a) per pair (the directional asymmetry)."""
+    def score(ps):
+        items = [((x, y, OPS["HIER"]) if judge is None else (x, y, OPS["HIER"], CORPORA[corpus], JUDGES[judge]))
+                 for x, y in ps]
+        out = []
+        for i in range(0, len(items), 512):
+            b = tok.build(items[i:i + 512], train=False)
+            b = {k: (v.to(dev) if torch.is_tensor(v) else v) for k, v in b.items()}
+            with torch.no_grad():
+                out += model(**b).cpu().tolist()
+        return np.array(out)
+    return score(pairs) - score([(y, x) for x, y in pairs])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pairs", required=True)
+    ap.add_argument("--ids", required=True, help="held pair-index file")
+    ap.add_argument("--responses", required=True)
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--e5-cache", required=True)
+    ap.add_argument("--models", nargs="+", required=True)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    a = ap.parse_args()
+    dev = torch.device(a.device)
+
+    allpairs = [ln.rstrip("\n").split("\t")[:2] for ln in open(a.pairs, encoding="utf-8") if not ln.startswith("#")]
+    held = [int(x) for x in open(a.ids).read().split()]
+    parents, _, _ = load_dag(a.graph)
+    byid = parse_responses(a.responses)
+
+    def dgraph(x, y):
+        uf, ur = up_hops(parents, x, y), up_hops(parents, y, x)
+        return ((3/(1+uf) if uf is not None else 0.0) - (3/(1+ur) if ur is not None else 0.0)) / 3.0
+
+    def dllm(o, rel): e = o.get(rel, {}); return float(e.get("mu_fwd", 0)) - float(e.get("mu_rev", 0))
+    pairs, d_true = [], []
+    for i in held:
+        if i not in byid: continue
+        x, y = allpairs[i]
+        dg, de, ds = dgraph(x, y), dllm(byid[i], "element_of"), dllm(byid[i], "subcategory")
+        if abs(dg) < 1e-6 and abs(de) < 1e-6 and abs(ds) < 1e-6: continue      # no direction — skip
+        pairs.append((x, y)); d_true.append((dg + de + ds) / 3.0)
+    d_true = np.array(d_true)
+    d = torch.load(a.e5_cache, weights_only=False); idx = {n: i for i, n in enumerate(d["names"])}
+    pairs = [(x, y) for x, y in pairs if x in idx and y in idx]
+    d_true = d_true[:len(pairs)]
+    tok = Tokenizer(d["query"], d["passage"], idx, parents, load_dag(a.graph)[2])
+    print(f"held directional pairs: {len(pairs)}  (target = mean(d_graph,d_element,d_subcat), sign-consensus)\n")
+
+    print(f"{'model':8s} {'judge input':11s}  corr(HIER-asym, direction)   sign-acc")
+    for spec in a.models:
+        name, path = spec.split("=", 1)
+        m = build_model(path, dev)
+        for judge in (None, "dir-blend"):
+            if judge == "dir-blend" and m.judge_emb.num_embeddings <= JUDGES["dir-blend"]:
+                continue
+            asym = hier_dir(m, tok, pairs, dev, judge=judge)
+            sacc = (np.sign(asym) == np.sign(d_true))[np.abs(d_true) > 1e-6].mean() * 100
+            print(f"{name:8s} {str(judge or 'agnostic'):11s}  {corr(asym, d_true):+.3f}                      {sacc:.0f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/eval_direction.py
+++ b/prototypes/mu_cosine/eval_direction.py
@@ -41,7 +41,8 @@ def hier_dir(model, tok, pairs, dev, judge=None, corpus="enwiki"):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--pairs", required=True)
-    ap.add_argument("--ids", required=True, help="held pair-index file")
+    ap.add_argument("--ids", "--held-ids", dest="ids", required=True,
+                    help="held pair-index file (same one emit_direction_blend.py took as --held-ids)")
     ap.add_argument("--responses", required=True)
     ap.add_argument("--graph", required=True)
     ap.add_argument("--e5-cache", required=True)

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -55,7 +55,7 @@ OPS = {"SYM": 0, "HIER": 1, "_DEPRECATED_LLM": 2, "ELEM": 3, "LINEAGE": 4, "LINE
 # (off-manifold noise, exactly like an absent ancestor slot); masking ⇒ provenance-AGNOSTIC μ, which is
 # the DEFAULT inference path (marginalize over sources). Reserved entries (enwiki) are for later corpora.
 CORPORA = {"simplewiki": 0, "enwiki": 1, "pearltrees": 2, "mindmap": 3}
-JUDGES = {"haiku": 0, "graph": 1, "human": 2, "sonnet": 3, "opus": 4, "gemini": 5, "gpt-5.5-low": 6, "blend": 7}    # learned judge_emb; each (model,effort) = own calibration row, tagged by the exact judge that scored it. "blend" = the constructed dual judge (1−λ)·e5 ⊕ λ·P(SYM|1/d,asym-ops) (emit_blend_judge.py). Rationale/policy in DESIGN_calibrated_judges.md.
+JUDGES = {"haiku": 0, "graph": 1, "human": 2, "sonnet": 3, "opus": 4, "gemini": 5, "gpt-5.5-low": 6, "blend": 7, "dir-blend": 8}    # learned judge_emb; each = own calibration row. "blend" = SYM dual judge (emit_blend_judge.py); "dir-blend" = cross-judge DIRECTION superposition (graph-discrim ⊕ LLM-element ⊕ LLM-subcat, emit_direction_blend.py). Rationale in DESIGN_calibrated_judges.md.
                                          # (SYM/LLM); graph = a Wikipedia edge / non-edge (WIKI, free μ=0 SYM
                                          # negatives); human = a hand-curated edge (mindmap/pearltrees);
                                          # sonnet/opus = stronger-model judgments (escalated tie-breaks, §14)

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -55,7 +55,7 @@ OPS = {"SYM": 0, "HIER": 1, "_DEPRECATED_LLM": 2, "ELEM": 3, "LINEAGE": 4, "LINE
 # (off-manifold noise, exactly like an absent ancestor slot); masking ⇒ provenance-AGNOSTIC μ, which is
 # the DEFAULT inference path (marginalize over sources). Reserved entries (enwiki) are for later corpora.
 CORPORA = {"simplewiki": 0, "enwiki": 1, "pearltrees": 2, "mindmap": 3}
-JUDGES = {"haiku": 0, "graph": 1, "human": 2, "sonnet": 3, "opus": 4, "gemini": 5, "gpt-5.5-low": 6, "blend": 7, "dir-blend": 8}    # learned judge_emb; each = own calibration row. "blend" = SYM dual judge (emit_blend_judge.py); "dir-blend" = cross-judge DIRECTION superposition (graph-discrim ⊕ LLM-element ⊕ LLM-subcat, emit_direction_blend.py). Rationale in DESIGN_calibrated_judges.md.
+JUDGES = {"haiku": 0, "graph": 1, "human": 2, "sonnet": 3, "opus": 4, "gemini": 5, "gpt-5.5-low": 6, "blend": 7, "dir-blend": 8}    # learned judge_emb; each = own calibration row. "blend" = SYM DUAL judge (2 inputs, emit_blend_judge.py); "dir-blend" = 3-ESTIMATOR cross-judge DIRECTION superposition (graph-discrim ⊕ LLM-element ⊕ LLM-subcat, emit_direction_blend.py). Checkpoints saved after this row expect judge_emb num_embeddings >= 9; older checkpoints load fine (new row is zero-init, unreferenced). Rationale in DESIGN_calibrated_judges.md.
                                          # (SYM/LLM); graph = a Wikipedia edge / non-edge (WIKI, free μ=0 SYM
                                          # negatives); human = a hand-curated edge (mindmap/pearltrees);
                                          # sonnet/opus = stronger-model judgments (escalated tie-breaks, §14)


### PR DESCRIPTION
## Summary
Explores the direction axis of the judge/operator superposition. A largely **exploratory + documentation** branch:
new tooling (`dir-blend` judge, transitive-hop trainer, several eval harnesses) plus a set of honest results —
some positive, one instructive null. No behaviour change to existing paths (the only `mu_attention.py` edit adds
`JUDGES["dir-blend"]`; zero-init, warm-start-safe).

## What's here
- **Cross-judge direction superposition** — `emit_direction_blend.py` (3 estimators: graph-discrimination ⊕
  LLM-element ⊕ LLM-subcategory, equal/dirichlet mix, contradiction→negative), `eval_direction.py`, `dir-blend`
  judge. Design + premise checks in `DESIGN_cross_judge_direction.md`.
- **Transitive discrimination** — `emit_transitive_hops.py` (μ_fwd=p^h, μ_rev=1−p^h).

## Findings (honest)
1. **Direction on Wikipedia is consensus** — all 3 estimators agree on sign ~100%; the superposition doesn't
   reliably beat baseline on the **aggregate** (multi-seed 90.5% vs 91.5%).
2. **…but it helps where direction is UNCERTAIN** — stratified: 0 benefit on certain pairs (98→98), **+8 on
   uncertain** (85→93). The null was a saturation artifact (semantic leakage → most pairs easy).
3. **Direction generalizes from e5 to unseen nodes (~90%) and is genuinely LEARNED** — survives backward prefixes
   (81.5%, not the ~15% a prefix artifact would give); e5 prefixes only *modulate* (~8 pts).
4. **Transitive training makes the operator CONTINUOUS** — μ decays smoothly 0.81→0.26 (vs prod's collapse to ~0
   by h=3) and keeps direction **94% correct at h=5** (vs prod 51% = chance).
5. **`p=0.9` grounded** — mean e5 cosine at h=1 = 0.902; effective-h calibration + the two-part transitive
   architecture (embedding→graph, LLM→non-graph) documented in `REPORT_multihop_direction.md`.

## Reusable assets
`dir-blend` judge, the 3-estimator emitter (+ contradiction→negative), the transitive-hop trainer, and the
novel-node / prefix-ablation / difficulty-stratified / multi-hop evals.

## Deferred (tracked)
Effective-h target + train (graph side); LLM-score the multi-hop chains (non-graph side; validates `p^h`); a
direction-ambiguous corpus where the uncertain tail is the bulk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)