### PR TITLE
WAM/LLVM (roadmap #5, 3b-db PR 3 follow-up): control constructs in rule bodies

### DIFF
--- a/docs/design/PLAWK_DYNAMIC_DB.md
+++ b/docs/design/PLAWK_DYNAMIC_DB.md
@@ -225,8 +225,15 @@ goal's choice points are cut (deterministic). A dynamic body goal is run inline
 by the consult during dispatch (it halts), so `solve_pred` must not clear
 `halted` before `run_loop`; a compiled body goal leaves `halted` false and
 `run_loop` drives it. Nested rules work (a rule body may call another rule).
-Not yet: `;`/`->`/`!` inside bodies, and cross-goal backtracking (first
-solution only).
+
+**Control constructs** are handled structurally in `@wam_dyn_run_body`, staying
+within the first-solution model: `;`/2 is if-then-else when its left arg is
+`->`/2 (run the condition, commit to Then, else Else) and otherwise a
+first-solution disjunction; `->`/2 alone is if-then (fail if the condition
+fails); `\+`/1 is negation-as-failure. A failing branch's bindings are unwound
+to a trail mark before the alternative runs, and `\+` always unwinds (it is a
+test). Not yet: `!` (cut, needs barrier semantics) and cross-goal backtracking
+(first solution only).
 
 (This PR also fixed a latent tail-position bug: a consulted goal whose
 continuation is the top-level `cp = 0` must **halt** rather than jump to PC 0 —
@@ -243,7 +250,9 @@ the consult/retract `success` blocks now mirror `proceed`.)
   sentinels −5/−6).
 - **PR 3:** rule bodies (`assertz((H :- B))`) — var-preserving clause copy +
   a deterministic body interpreter. Landed.
-- Follow-ups / optimizations: `;`/`->`/`!` and cross-goal backtracking in
-  bodies; retract of rules; `call/N` partial-application consult; a
-  functor+arity index over the store (the scan is O(n) per backtrack); mixing
-  compiled + asserted clauses for one predicate.
+- **PR 3 follow-up:** `;`/`->`/`\+` control constructs in bodies (deterministic
+  if-then-else / disjunction / negation). Landed.
+- Follow-ups / optimizations: `!` (cut) and cross-goal backtracking in bodies;
+  retract of rules; `call/N` partial-application consult; a functor+arity index
+  over the store (the scan is O(n) per backtrack); mixing compiled + asserted
+  clauses for one predicate.

--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -202,8 +202,9 @@ independently useful (richer hand-written grammars load sooner).
    bodies** (`assertz((H :- B))`): a var-preserving clause copy (head↔body
    variable sharing, fresh vars per call) plus a deterministic body interpreter
    handling `,`/2, builtins, and predicate calls (including nested rules).
-   Works in loaded objects — the store is process-global. See
-   **PLAWK_DYNAMIC_DB.md**. Remaining there: `;`/`->`/`!` and cross-goal
+   Works in loaded objects — the store is process-global. Body `;`/`->`/`\+`
+   (deterministic if-then-else / disjunction / negation) are handled too. See
+   **PLAWK_DYNAMIC_DB.md**. Remaining there: `!` (cut) and cross-goal
    backtracking in bodies, retract of rules, and `call/N` partial application.
 
    **`catch`/`throw` (milestone 3c) — landed.** A process-global side stack of

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -5240,45 +5240,161 @@ ret_eq:  ret i32 24
 nf:      ret i32 -1
 }
 
-; Solve a rule body deterministically (first solution). Handles ,/2 recursion
-; and single goals.
+; Solve a rule body deterministically (first solution). Handles ,/2, ;/2
+; (disjunction and, when the left arg is ->/2, if-then-else), ->/2 (if-then),
+; \+/1 (negation as failure), and single goals. Control constructs stay within
+; the first-solution model: a failing branch's bindings are unwound (trail
+; mark) before the alternative runs.
 define i1 @wam_dyn_run_body(%WamState* %vm, %Value %body) {
 entry:
   %b = call %Value @wam_deref_value(%WamState* %vm, %Value %body)
   %tag = call i32 @value_tag(%Value %b)
   %is_comp = icmp eq i32 %tag, 3
-  br i1 %is_comp, label %maybe_conj, label %single
-maybe_conj:
+  br i1 %is_comp, label %comp, label %single
+comp:
   %pl = call i64 @value_payload(%Value %b)
   %cp = inttoptr i64 %pl to %Compound*
   %ar_s = getelementptr %Compound, %Compound* %cp, i32 0, i32 1
   %ar = load i32, i32* %ar_s
   %fn_s = getelementptr %Compound, %Compound* %cp, i32 0, i32 0
   %fn = load i8*, i8** %fn_s
-  %c0 = load i8, i8* %fn
-  %is_comma_c = icmp eq i8 %c0, 44
-  %ar2 = icmp eq i32 %ar, 2
-  %isconj0 = and i1 %is_comma_c, %ar2
-  br i1 %isconj0, label %conj_check2, label %single
-conj_check2:
-  %p1 = getelementptr i8, i8* %fn, i64 1
-  %c1 = load i8, i8* %p1
-  %c1nul = icmp eq i8 %c1, 0
-  br i1 %c1nul, label %conj, label %single
-conj:
   %args_s = getelementptr %Compound, %Compound* %cp, i32 0, i32 2
   %cargs = load %Value*, %Value** %args_s
-  %a0p = getelementptr %Value, %Value* %cargs, i32 0
-  %a0 = load %Value, %Value* %a0p
-  %ok1 = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %a0)
-  br i1 %ok1, label %conj_rest, label %cfalse
+  %c0 = load i8, i8* %fn
+  switch i8 %c0, label %single [
+    i8 44, label %try_comma
+    i8 59, label %try_semi
+    i8 45, label %try_arrow
+    i8 92, label %try_naf
+  ]
+try_comma:
+  %tc_ar2 = icmp eq i32 %ar, 2
+  %tc_p1 = getelementptr i8, i8* %fn, i64 1
+  %tc_c1 = load i8, i8* %tc_p1
+  %tc_nul = icmp eq i8 %tc_c1, 0
+  %is_comma = and i1 %tc_ar2, %tc_nul
+  br i1 %is_comma, label %conj, label %single
+try_semi:
+  %ts_ar2 = icmp eq i32 %ar, 2
+  %ts_p1 = getelementptr i8, i8* %fn, i64 1
+  %ts_c1 = load i8, i8* %ts_p1
+  %ts_nul = icmp eq i8 %ts_c1, 0
+  %is_semi = and i1 %ts_ar2, %ts_nul
+  br i1 %is_semi, label %semi, label %single
+try_arrow:
+  %ta_ar2 = icmp eq i32 %ar, 2
+  %ta_p1 = getelementptr i8, i8* %fn, i64 1
+  %ta_c1 = load i8, i8* %ta_p1
+  %ta_gt = icmp eq i8 %ta_c1, 62
+  %ta_p2 = getelementptr i8, i8* %fn, i64 2
+  %ta_c2 = load i8, i8* %ta_p2
+  %ta_nul = icmp eq i8 %ta_c2, 0
+  %ta_ok0 = and i1 %ta_ar2, %ta_gt
+  %is_arrow = and i1 %ta_ok0, %ta_nul
+  br i1 %is_arrow, label %if_then, label %single
+try_naf:
+  %tn_ar1 = icmp eq i32 %ar, 1
+  %tn_p1 = getelementptr i8, i8* %fn, i64 1
+  %tn_c1 = load i8, i8* %tn_p1
+  %tn_plus = icmp eq i8 %tn_c1, 43
+  %tn_p2 = getelementptr i8, i8* %fn, i64 2
+  %tn_c2 = load i8, i8* %tn_p2
+  %tn_nul = icmp eq i8 %tn_c2, 0
+  %tn_ok0 = and i1 %tn_ar1, %tn_plus
+  %is_naf = and i1 %tn_ok0, %tn_nul
+  br i1 %is_naf, label %naf, label %single
+conj:
+  %cj_a0p = getelementptr %Value, %Value* %cargs, i32 0
+  %cj_a0 = load %Value, %Value* %cj_a0p
+  %cj_ok1 = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %cj_a0)
+  br i1 %cj_ok1, label %conj_rest, label %cfalse
 conj_rest:
-  %a1p = getelementptr %Value, %Value* %cargs, i32 1
-  %a1 = load %Value, %Value* %a1p
-  %ok2 = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %a1)
-  ret i1 %ok2
+  %cj_a1p = getelementptr %Value, %Value* %cargs, i32 1
+  %cj_a1 = load %Value, %Value* %cj_a1p
+  %cj_ok2 = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %cj_a1)
+  ret i1 %cj_ok2
 cfalse:
   ret i1 false
+semi:
+  ; (A ; B): if A is (C -> T) this is if-then-else, else first-solution disjunction
+  %sm_a0p = getelementptr %Value, %Value* %cargs, i32 0
+  %sm_a0 = load %Value, %Value* %sm_a0p
+  %sm_a1p = getelementptr %Value, %Value* %cargs, i32 1
+  %sm_a1 = load %Value, %Value* %sm_a1p
+  %sm_a0d = call %Value @wam_deref_value(%WamState* %vm, %Value %sm_a0)
+  %sm_a0tag = call i32 @value_tag(%Value %sm_a0d)
+  %sm_a0comp = icmp eq i32 %sm_a0tag, 3
+  br i1 %sm_a0comp, label %semi_ite_check, label %disj
+semi_ite_check:
+  %sm_pl = call i64 @value_payload(%Value %sm_a0d)
+  %sm_cp = inttoptr i64 %sm_pl to %Compound*
+  %sm_ar_s = getelementptr %Compound, %Compound* %sm_cp, i32 0, i32 1
+  %sm_ar = load i32, i32* %sm_ar_s
+  %sm_fn_s = getelementptr %Compound, %Compound* %sm_cp, i32 0, i32 0
+  %sm_fn = load i8*, i8** %sm_fn_s
+  %sm_f0 = load i8, i8* %sm_fn
+  %sm_f0d = icmp eq i8 %sm_f0, 45
+  %sm_p1 = getelementptr i8, i8* %sm_fn, i64 1
+  %sm_f1 = load i8, i8* %sm_p1
+  %sm_f1gt = icmp eq i8 %sm_f1, 62
+  %sm_p2 = getelementptr i8, i8* %sm_fn, i64 2
+  %sm_f2 = load i8, i8* %sm_p2
+  %sm_f2n = icmp eq i8 %sm_f2, 0
+  %sm_ar2 = icmp eq i32 %sm_ar, 2
+  %sm_x0 = and i1 %sm_f0d, %sm_f1gt
+  %sm_x1 = and i1 %sm_x0, %sm_f2n
+  %sm_isarrow = and i1 %sm_x1, %sm_ar2
+  br i1 %sm_isarrow, label %ite, label %disj
+ite:
+  %ite_cargs_s = getelementptr %Compound, %Compound* %sm_cp, i32 0, i32 2
+  %ite_cargs = load %Value*, %Value** %ite_cargs_s
+  %ite_Cp = getelementptr %Value, %Value* %ite_cargs, i32 0
+  %ite_C = load %Value, %Value* %ite_Cp
+  %ite_Tp = getelementptr %Value, %Value* %ite_cargs, i32 1
+  %ite_T = load %Value, %Value* %ite_Tp
+  %ite_ts_p = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
+  %ite_mark = load i32, i32* %ite_ts_p
+  %ite_cok = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %ite_C)
+  br i1 %ite_cok, label %ite_then, label %ite_else
+ite_then:
+  %ite_tr = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %ite_T)
+  ret i1 %ite_tr
+ite_else:
+  call void @unwind_trail(%WamState* %vm, i32 %ite_mark)
+  %ite_er = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %sm_a1)
+  ret i1 %ite_er
+disj:
+  %dj_ts_p = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
+  %dj_mark = load i32, i32* %dj_ts_p
+  %dj_aok = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %sm_a0)
+  br i1 %dj_aok, label %disj_true, label %disj_else
+disj_true:
+  ret i1 true
+disj_else:
+  call void @unwind_trail(%WamState* %vm, i32 %dj_mark)
+  %dj_br = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %sm_a1)
+  ret i1 %dj_br
+if_then:
+  %it_Cp = getelementptr %Value, %Value* %cargs, i32 0
+  %it_C = load %Value, %Value* %it_Cp
+  %it_Tp = getelementptr %Value, %Value* %cargs, i32 1
+  %it_T = load %Value, %Value* %it_Tp
+  %it_cok = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %it_C)
+  br i1 %it_cok, label %if_then_do, label %if_then_fail
+if_then_do:
+  %it_tr = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %it_T)
+  ret i1 %it_tr
+if_then_fail:
+  ret i1 false
+naf:
+  %nf_Gp = getelementptr %Value, %Value* %cargs, i32 0
+  %nf_G = load %Value, %Value* %nf_Gp
+  %nf_ts_p = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
+  %nf_mark = load i32, i32* %nf_ts_p
+  %nf_gok = call i1 @wam_dyn_run_body(%WamState* %vm, %Value %nf_G)
+  call void @unwind_trail(%WamState* %vm, i32 %nf_mark)
+  %nf_res = xor i1 %nf_gok, true
+  ret i1 %nf_res
 single:
   %r = call i1 @wam_dyn_solve_goal(%WamState* %vm, %Value %b)
   ret i1 %r

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -237,6 +237,16 @@ rb_mix(R)    :- assertz(rbbase(10)),
                 assertz((rbcompute(Y) :- rbbase(B), Y is B+32)),
                 rbcompute(R).                                                % 42 (body: fact call + builtin)
 
+% Rule-body control constructs (follow-up): if-then-else, disjunction, and
+% negation-as-failure, all within the deterministic first-solution model.
+:- dynamic rcsgn/2, rcpk/1, rcdj/1, rcnz/2.
+rc_ite_t(R) :- assertz((rcsgn(N,X) :- (N > 0 -> X = 1 ; X = 0))), rcsgn(7, R).   % 1 (cond true)
+rc_ite_f(R) :- assertz((rcsgn(N,X) :- (N > 0 -> X = 1 ; X = 0))), rcsgn(-7, R).  % 0 (cond false)
+rc_disj1(R) :- assertz((rcpk(X) :- (X = 11 ; X = 22))), rcpk(R).                 % 11 (first branch)
+rc_disj2(R) :- assertz((rcdj(X) :- (fail ; X = 22))), rcdj(R).                   % 22 (second branch)
+rc_naf1(R)  :- assertz((rcnz(N,X) :- (\+ (N =:= 0) -> X = 1 ; X = 0))), rcnz(5, R). % 1
+rc_naf0(R)  :- assertz((rcnz(N,X) :- (\+ (N =:= 0) -> X = 1 ; X = 0))), rcnz(0, R). % 0
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -757,6 +767,27 @@ test(rule_bodies_in_object, [condition(clang_available)]) :-
              write_wam_object([user:PI], [wamo_entry(PI)], W),
              run_host(Host, W, Out, 0),
              assertion(Out == "42\n") )),
+    !.
+
+% Rule-body control constructs: if-then-else (both directions), disjunction
+% (both branches), and negation-as-failure (both ways), deterministic.
+test(rule_body_control_in_object, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    forall(member(Name-Expected,
+               [ rc_ite_t-"1\n",   % if-then-else, condition true
+                 rc_ite_f-"0\n",   % if-then-else, condition false -> else
+                 rc_disj1-"11\n",  % disjunction, first branch
+                 rc_disj2-"22\n",  % disjunction, first fails -> second
+                 rc_naf1-"1\n",    % \+ of a false goal -> succeeds
+                 rc_naf0-"0\n" ]), % \+ of a true goal -> else
+           ( PI = Name/1,
+             directory_file_path(Dir, Name, Base),
+             atom_concat(Base, '.wamo', W),
+             write_wam_object([user:PI], [wamo_entry(PI)], W),
+             run_host(Host, W, Out, 0),
+             assertion(Out == Expected) )),
     !.
 
 :- end_tests(wam_object).


### PR DESCRIPTION
## Summary

A bounded follow-up to rule bodies (PR #3505): control constructs in rule bodies. I chose this over diving into milestone 6 (self-host) — that's a large piece that deserves careful scoping, whereas this fits the existing deterministic body interpreter cleanly (structural recursion + trail marks, no new backtracking machinery) and rules commonly use if-then-else.

`@wam_dyn_run_body` now dispatches on the body functor (a `switch` on its first byte) and handles:

- **`;`/2** — if-then-else when the left arg is `->`/2 (run the condition, commit to Then, else Else); otherwise a first-solution disjunction (the first branch that succeeds).
- **`->`/2** — if-then (fail if the condition fails).
- **`\+`/1** — negation as failure (succeed iff the goal fails; always unwinds, since it's a test).

A failing branch's bindings are unwound to a trail mark before the alternative runs. **Cut (`!`) stays deferred** (it needs barrier/cut-barrier semantics); cross-goal backtracking remains first-solution.

## Tests

`tests/test_wam_object.pl:rule_body_control_in_object` (loaded-object round trip):

| grammar | checks | result |
|---|---|---|
| `rc_ite_t` | if-then-else, condition true | 1 |
| `rc_ite_f` | if-then-else, condition false → else | 0 |
| `rc_disj1` | disjunction, first branch | 11 |
| `rc_disj2` | disjunction, first fails → second | 22 |
| `rc_naf1` | `\+` of a false goal → succeeds | 1 |
| `rc_naf0` | `\+` of a true goal → else | 0 |

**33/33** in `wam_object`; no regressions (`wam_llvm_target` 82). Purely additive — the `,`/2 and single-goal paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_