### PR TITLE
Transitive cross-judge superposition (built + eval'd) + two-judge posterior design

### DIFF
--- a/prototypes/mu_cosine/DESIGN_two_judge_posterior.md
+++ b/prototypes/mu_cosine/DESIGN_two_judge_posterior.md
@@ -1,0 +1,101 @@
+# Two-judge operator posterior: P(op | d, LLM_op) — combiner ladder, soft constraints, pseudo-judges
+
+*Theory note from the 2026-07-05 pivot discussion (after the Wikipedia transitive-superposition arc showed the naive
+blend fails). Captures the reframing that the right combiner is a JOINT POSTERIOR over the operator conditioned on
+two judges — not a superposition of them — plus the soft-constraint / pseudo-judge modeling path. Design; not built.*
+
+## The problem the superposition hit
+`dir-blend` combined graph and LLM by **collapsing them into one blended target** (`μ_fwd = w_g·walk + w_e·llm…`).
+That's a *linear superposition*, and it failed for structural reasons: (a) it blends incommensurate SCALES (the
+branch-diluted walk probability, floor ~0.18, vs the LLM's fuzzy membership); (b) it conflates DIRECTIONAL and
+LATERAL relations into one number; (c) `μ_rev` had no principled value (`0` vs `1−p^h` was a symptom).
+
+## The reframe: two SEPARATE judges, one joint posterior
+`op(x,y)` is a **distribution over relations** {subcategory, subtopic, element_of, super_category, see_also, assoc,
+none}. Two judges condition it:
+- **`d(x,y)`** — the GRAPH judge (IS): walk hit-prob on a multi-parent DAG, hop count on a tree. Asymmetric ⇒ it
+  already carries direction. Free at inference.
+- **`LLM_op(x,y)`** — the LLM judge (OUGHT): the semantic relation reading. Expensive at inference.
+
+Combine by **conditioning, not blending**: `P(op | d, LLM_op)`. Nothing gets averaged, so nothing needs to be
+commensurate — the scale mismatch, the directional/lateral conflation, and the `μ_rev` puzzle all dissolve
+(`super_category`, `assoc` are just other coordinates of `op`). This IS `mu_posterior.py` / JointPosterior (#3359)
+with `d` and `LLM_op` added as features.
+
+## The combiner ladder (a moment expansion of the log-likelihood)
+For a log-linear posterior `log P(op|φ)=θ·φ−A(θ)`: the **gradient** `φ_obs−E[φ]` is LINEAR in features (1st order);
+the **Hessian** `−Cov(φ)` is the feature COVARIANCE — the `φᵢφⱼ` outer/cartesian products (2nd order = correlation).
+
+| rung | uses | drops | cost |
+|---|---|---|---|
+| linear superposition | main effects (1st order) | all (co)variance | cheap; also a TRAINING device (distills a judge into the trunk) |
+| confidence-weighted | + diagonal of Cov (each `σᵢ²`) | off-diagonal | needs the variances |
+| joint distribution | + off-diagonal `σᵢⱼ` (the products) | — | needs a head + calibration + both judges as features |
+
+The joint SUBSUMES the others (recovers them if the data supports it) and is the only rung that survives
+**correlated** judges (`e5↔graph ≈ +0.75`): the off-diagonal it keeps is exactly the term linear/PoE throw away.
+Superposition (`⊕`, a sum) cannot represent an interaction (`⊗`, a product) — correlation is rank-2, it lives in `⊗`.
+
+## Soft constraints = Mahalanobis fusion (the second-order structure IS a Lagrangian penalty)
+Fusing judges = minimizing `(estimate − judges)ᵀ Σ⁻¹ (estimate − judges)` — a quadratic objective whose metric is
+the inverse covariance. That's a soft-constraint/penalty form (`λ·g²`), with the correlation as the penalty metric.
+The **off-diagonal of Σ⁻¹ is a coupling constraint between judges** ("not free to disagree independently"). Its job
+is to **stop double-counting** correlated evidence — the over-confidence we hit when we hand-set inverse-variance
+weights. The same applies to OPERATOR correlations: `subcat↔element` anti-correlation is a mutual-exclusion soft
+constraint on the operator simplex.
+
+**Constraints must be SOFT, and crossing them is the mechanism, not a failure** (user): the correlation is itself
+estimated from a churning, randomly-sampled corpus, so it has a standard error. A hard constraint overfits the
+sample; the soft one is regularized, its stiffness tracking estimation/transfer certainty. The local likelihood
+should *cross* it where domains genuinely diverge — and the stochastic minibatch churn makes the fit orbit the
+boundary, enforcing it in expectation, not instantaneously.
+
+## The diffusion data (P(op | d), applies-mass vs hop h; 40–50 pairs/hop, gpt-5.5-low)
+| corpus | | h1 | h2 | h3 | h4 | h5 |
+|---|---|---|---|---|---|---|
+| SimpleMind | directional (sub+subtop) | 0.99 | 0.72 | 0.75 | 0.62 | 0.51 |
+| SimpleMind | symmetric (see+assoc) | 0.66 | 0.60 | 0.50 | 0.49 | 0.41 |
+| Wikipedia | directional | 1.36 | 1.16 | 0.94 | 0.74 | 0.60 |
+| Wikipedia | symmetric | 0.30 | 0.39 | 0.34 | 0.27 | 0.34 |
+| both | super_category | ~0.03 | ~0.01 | ~0.02 | ~0.00 | ~0.01 |
+
+Findings: directional decays at *similar* rates in both (not the "clean persists longer" I predicted). SimpleMind
+has **~2× the symmetric/`assoc` mass** — mindmap nodes are *concepts* (hierarchical AND associative); Wikipedia
+*categories* are purer taxonomy. `super_category≈0` confirms the reverse-directional is ~0 either way. The corpora
+have **different `P(op|d)`**, so a hard-transferred constraint would be violated — validating the soft/crossable view.
+
+**Large-n consequence (user):** directional and symmetric CO-OCCUR (both high at h2), so they are positively
+correlated — a real off-diagonal. At large n this is estimable and **must be modeled**; ignoring it (independent
+operators) reads co-occurring mass as competing mass. This RECONCILES the "SimpleMind should be cleaner than the
+LLM's marginals say" intuition: high `assoc` does NOT imply low directionality once the correlation is in — the
+graph edge stays directional and the `assoc` rides alongside. The marginals hide it; the off-diagonal shows it.
+(User disputes the LLM's high mindmap `assoc` on separate grounds — to revisit.)
+
+## Modeling proposal: PSEUDO-JUDGES for the second-order constraints (user)
+Represent each second-order structure (a correlation / soft constraint) as a **pseudo-judge** — a synthetic input
+added to the judge set — so the existing linear/superposition + `judge_emb` machinery captures it. Two flavors:
+- **Interaction pseudo-judge:** reading = a product of real judges (e.g. `readout_directional × readout_symmetric`,
+  or `d × LLM_op`). A linear model over [real judges + interaction pseudo-judges] is second-order — the polynomial-
+  feature / kernel trick. **This un-breaks linear superposition**: the product is non-linear in the original judge
+  space but LINEAR in the augmented space (lift the `⊗` term to a new `⊕` coordinate).
+- **Constraint pseudo-judge (virtual observation):** a fictitious observation encoding a KNOWN constraint (e.g. the
+  Wikipedia-measured `directional↔symmetric` off-diagonal) added as pseudo-data with precision = constraint
+  strength — the transferable soft prior, moved from the big messy corpus to the small clean one.
+
+Why this fits: it reuses `judge_emb` (each pseudo-judge gets its own calibration row), the readout vector, and
+superposition training — no new architecture. **Regularizing the pseudo-judge weights gives everything at once:**
+n-dependent complexity (interactions come online only when n licenses them), soft/crossable constraints (weights
+shrink under the prior, overridden by strong local data), and transfer (carry the pseudo-judge weight as a prior).
+
+## Deployment: teacher/student
+The joint `P(op | d, LLM_op)` needs `LLM_op` as a LIVE feature — expensive. So: **teacher** = the joint posterior
+(LLM in the loop, offline label-maker); **student** = the model distilled on the FREE features (e5 readouts + `d` +
+interaction pseudo-judges), superposition-style, for LLM-free serving. Joint-posterior quality, linear-deploy cost.
+This also bounds how much LLM scoring we need — only enough to fit the teacher.
+
+## Open questions / next
+- Is `d` the walk hit-prob everywhere (needs multi-parent — Pearltrees) or hops-on-trees (SimpleMind) / walk-on-DAGs?
+- Full non-parametric teacher vs a 2nd-order GLM with cartesian-product features (cheaper, interpretable — read off
+  which pseudo-judges carry weight). Lean GLM-with-interactions.
+- Fit the off-diagonal at Wikipedia scale; carry it as a constraint pseudo-judge to SimpleMind/Pearltrees.
+- Revisit whether the LLM over-assigns `assoc` to mindmap concepts (user's dispute) — a judge-calibration question.

--- a/prototypes/mu_cosine/DESIGN_two_judge_posterior.md
+++ b/prototypes/mu_cosine/DESIGN_two_judge_posterior.md
@@ -87,6 +87,47 @@ superposition training — no new architecture. **Regularizing the pseudo-judge 
 n-dependent complexity (interactions come online only when n licenses them), soft/crossable constraints (weights
 shrink under the prior, overridden by strong local data), and transfer (carry the pseudo-judge weight as a prior).
 
+### The smallest build target: 2 operators → 3 pseudo-judges
+Simplest case — a directional operator `D` and a symmetric operator `S`. The second-order structure is a symmetric
+2×2 matrix: 4 entries, `Σ_DS = Σ_SD`, so **3 unique terms → 3 pseudo-judges** (= the degree-2 monomials of `[D,S]`,
+= dim of a symmetric 2×2):
+
+| pseudo-judge | reading | matrix entry | role |
+|---|---|---|---|
+| self-`D` | `μ_D²` | `Σ_DD` (diagonal) | directional reliability/curvature → *confidence-weighted rung* |
+| self-`S` | `μ_S²` | `Σ_SS` (diagonal) | symmetric reliability/curvature → *confidence-weighted rung* |
+| cross | `μ_D·μ_S` | `Σ_DS` (off-diagonal) | directional↔symmetric **correlation** → *joint rung; the large-n term* |
+
+The two self-terms are the diagonal (the confidence-weighted rung); the one cross-term is the off-diagonal — the
+large-n directional↔symmetric correlation that carries the co-occurrence. Scaling: **k operators →
+`k(k+1)/2` pseudo-judges** (`k` self + `k(k−1)/2` cross). Start at k=2 (3 pseudo-judges): the smallest model that
+contains the one correlation term that matters; only switch on further cross-terms as `n` licenses them.
+
+### Two realizations of the pseudo-judges — GLM form and ATTENTION form
+Same 3 pseudo-judges, two ways to compute them:
+- **GLM form (append features):** add scalar columns `[μ_D², μ_S², μ_D·μ_S]` to the logistic feature vector; three
+  learned weights = the three unique `Σ⁻¹` entries. Cheap, convex, interpretable (read off which carries weight).
+- **ATTENTION form (compute the Gram matrix):** if the operator readouts are VECTORS, `μ_D·μ_S` is a *dot product*
+  — which **is** the (uncentered) correlation. The three pseudo-judges are then the three unique entries of the
+  **Gram matrix** `G = [⟨μ_D,μ_D⟩, ⟨μ_D,μ_S⟩; ·, ⟨μ_S,μ_S⟩]` (= `‖μ_D‖², ‖μ_S‖², μ_D·μ_S`), and `G` *is* the
+  second-moment/correlation matrix. So "3 unique covariance terms" and "3 unique Gram entries" are the same object.
+
+The closure: the model is **μ-attention** — its native op is the dot product (query·key). So the second-order
+correlation is computed the *same way the model computes everything*: the cross pseudo-judge is an **attention score
+between operators** (learned bilinear `μ_Dᵀ W μ_S`), the self-terms are operator self-attention (`‖μ_·‖²`), and a
+single small operator-attention head over the operator representation vectors *learns the whole second-order
+structure*. Two readings of the vectors:
+- **sample vectors over a region** (`μ_D=[μ_D(xᵢ,yᵢ)…]` across a neighborhood): `μ_D·μ_S` = the empirical regional
+  correlation — ties to per-region confidence (`c_mem`); the correlation is a neighborhood property, computed as a
+  dot product over that neighborhood.
+- **feature vectors per pair** (`μ_D∈Rᵏ`): `μ_Dᵀ W μ_S` = a learned bilinear alignment of the two operator
+  representations for that pair.
+
+This also tames the scaling: `k(k+1)/2` cross-terms is one `k×k` (or low-rank) `W` as a bilinear form — attention
+handles the quadratic count natively instead of enumerating features. **First build:** k=2 GLM form (3 scalar
+pseudo-judges) to validate the correlation term cheaply; then the operator-attention head as the architectural
+realization if it earns it.
+
 ## Deployment: teacher/student
 The joint `P(op | d, LLM_op)` needs `LLM_op` as a LIVE feature — expensive. So: **teacher** = the joint posterior
 (LLM in the loop, offline label-maker); **student** = the model distilled on the FREE features (e5 readouts + `d` +

--- a/prototypes/mu_cosine/DESIGN_two_judge_posterior.md
+++ b/prototypes/mu_cosine/DESIGN_two_judge_posterior.md
@@ -33,7 +33,8 @@ the **Hessian** `−Cov(φ)` is the feature COVARIANCE — the `φᵢφⱼ` oute
 | joint distribution | + off-diagonal `σᵢⱼ` (the products) | — | needs a head + calibration + both judges as features |
 
 The joint SUBSUMES the others (recovers them if the data supports it) and is the only rung that survives
-**correlated** judges (`e5↔graph ≈ +0.75`): the off-diagonal it keeps is exactly the term linear/PoE throw away.
+**correlated** judges (`e5↔graph/model ≈ +0.75`, measured in the JointPosterior work #3359 on the μ-readout
+vector — worth re-measuring per corpus): the off-diagonal it keeps is exactly the term linear/PoE throw away.
 Superposition (`⊕`, a sum) cannot represent an interaction (`⊗`, a product) — correlation is rank-2, it lives in `⊗`.
 
 ## Soft constraints = Mahalanobis fusion (the second-order structure IS a Lagrangian penalty)
@@ -44,13 +45,28 @@ is to **stop double-counting** correlated evidence — the over-confidence we hi
 weights. The same applies to OPERATOR correlations: `subcat↔element` anti-correlation is a mutual-exclusion soft
 constraint on the operator simplex.
 
-**Constraints must be SOFT, and crossing them is the mechanism, not a failure** (user): the correlation is itself
+**Some constraints are SOFT, and crossing them is the mechanism, not a failure** (user): a *sampled correlation* is
 estimated from a churning, randomly-sampled corpus, so it has a standard error. A hard constraint overfits the
 sample; the soft one is regularized, its stiffness tracking estimation/transfer certainty. The local likelihood
 should *cross* it where domains genuinely diverge — and the stochastic minibatch churn makes the fit orbit the
 boundary, enforcing it in expectation, not instantaneously.
 
-## The diffusion data (P(op | d), applies-mass vs hop h; 40–50 pairs/hop, gpt-5.5-low)
+**But not every constraint is soft — distinguish them (review):** `μ_rev = 0` is *not* a sampled correlation; it is
+a **structural identity** (up-walks can't descend, `μ_rev=0` by construction) **independently confirmed by the LLM**
+(0.007→0.000 at every hop). Two judges agreeing on a structural fact is a **hard** constraint — softening it just
+adds a free parameter the optimizer can abuse to trade direction for magnitude on the reverse (the very `1−p^h`
+failure the OUGHT refuted). Enforce it as a clamp/equality, not a penalty.
+
+| constraint | type | why |
+|---|---|---|
+| `μ_rev = 0` | **HARD** | structural (graph) + LLM-confirmed at every hop; no domain variance ⇒ clamp |
+| `directional↔symmetric` off-diagonal | soft | corpus-estimated (SimpleMind ≠ Wikipedia), transferable-as-prior, crossable |
+| `subcat↔element` anti-correlation | soft | corpus-dependent, crossable |
+
+## The diffusion data (relation MASS vs hop h; 40–50 pairs/hop, gpt-5.5-low)
+*These are **summed `applies`-mass over a relation GROUP** (e.g. `subcat + subtopic`), not a single probability —
+fuzzy memberships need not sum to 1, so a group's mass can exceed 1.0. Read them as `Σ_op∈group P(op|d)`, i.e. the
+shape of the diffusion, not calibrated probabilities.*
 | corpus | | h1 | h2 | h3 | h4 | h5 |
 |---|---|---|---|---|---|---|
 | SimpleMind | directional (sub+subtop) | 0.99 | 0.72 | 0.75 | 0.62 | 0.51 |
@@ -128,15 +144,33 @@ handles the quadratic count natively instead of enumerating features. **First bu
 pseudo-judges) to validate the correlation term cheaply; then the operator-attention head as the architectural
 realization if it earns it.
 
+**Two caveats for the attention form (review):**
+- **`W` symmetry.** The GLM's `μ_D·μ_S` is symmetric, so it estimates a proper (symmetric PSD) covariance. A *learned*
+  `W` in `μ_Dᵀ W μ_S` is not symmetric in general (`μ_Dᵀ W μ_S ≠ μ_Sᵀ W μ_D`), which is *more expressive but loses
+  the Mahalanobis/covariance interpretation*. Choose deliberately: constrain `W = (W+Wᵀ)/2` (or `W = LLᵀ`) to keep
+  the statistical reading, or allow asymmetry and treat it as a general bilinear head (expressivity over
+  interpretability). For the k=2 GLM first build this is moot; it matters only for the attention realization.
+- **The pseudo-judges are ENDOGENOUS (feedback loop).** In the student, `μ_D², μ_S², μ_D·μ_S` are computed from the
+  student's OWN operator readouts, not the teacher's — so as fine-tuning updates the readouts, the pseudo-judge
+  *inputs* shift with the model's *outputs*. Static one-shot distillation (readouts precomputed/frozen) is benign;
+  live fine-tuning is a self-referential loop that can destabilise. **Recommendation: freeze the operator readouts
+  when computing pseudo-judge features during distillation** (or add them as a late, low-LR head), and only unfreeze
+  once the main effects have settled.
+
 ## Deployment: teacher/student
 The joint `P(op | d, LLM_op)` needs `LLM_op` as a LIVE feature — expensive. So: **teacher** = the joint posterior
 (LLM in the loop, offline label-maker); **student** = the model distilled on the FREE features (e5 readouts + `d` +
 interaction pseudo-judges), superposition-style, for LLM-free serving. Joint-posterior quality, linear-deploy cost.
 This also bounds how much LLM scoring we need — only enough to fit the teacher.
 
-## Open questions / next
-- Is `d` the walk hit-prob everywhere (needs multi-parent — Pearltrees) or hops-on-trees (SimpleMind) / walk-on-DAGs?
-- Full non-parametric teacher vs a 2nd-order GLM with cartesian-product features (cheaper, interpretable — read off
-  which pseudo-judges carry weight). Lean GLM-with-interactions.
-- Fit the off-diagonal at Wikipedia scale; carry it as a constraint pseudo-judge to SimpleMind/Pearltrees.
-- Revisit whether the LLM over-assigns `assoc` to mindmap concepts (user's dispute) — a judge-calibration question.
+## Open questions / next (rough priority)
+- **[first build]** k=2 GLM: fit `P({D,S} | d, LLM_op)` with the 3 pseudo-judges at Wikipedia scale (where `n`
+  supports the cross-term), `μ_rev=0` clamped hard, held-out log-loss as the metric.
+- **[blocker for the continuous-`d` story]** Is `d` the walk hit-prob everywhere (needs multi-parent — Pearltrees)
+  or hops-on-trees (SimpleMind) / walk-on-DAGs? SimpleMind's tree makes `d` an integer (walk binary) — so Pearltrees
+  is where `d` earns its keep as a continuous judge.
+- **[design decision]** Full non-parametric teacher vs the 2nd-order GLM with cartesian-product features (cheaper,
+  interpretable). Lean GLM-with-interactions.
+- **[after first build]** Carry the fitted off-diagonal as a constraint pseudo-judge (soft prior) to SimpleMind/Pearltrees.
+- **[deferred, separate]** Revisit whether the LLM over-assigns `assoc` to mindmap concepts (user disputes the LLM
+  here) — a judge-calibration question, not a blocker for the posterior build.

--- a/prototypes/mu_cosine/REPORT_transitive_superposition.md
+++ b/prototypes/mu_cosine/REPORT_transitive_superposition.md
@@ -5,6 +5,11 @@ non-graph side is the deferred piece now built: the LLM scores multi-hop pairs *
 supplying element/subcategory transitive membership; the graph side is the walk hit-prob. 2026-07-05, branch
 `claude/transitive-superposition`.*
 
+> **⚠ Read the numbers with these caveats (review):** all magnitudes are **single-seed** on **250 LLM-scored
+> pairs (h≤5)**. The LLM OUGHT signal exists **only to h=5** — so every h≥6 row in §2 is an **extrapolation
+> regime** where one blend component was trained to zero. The walk-vs-superpos *margins* are single-seed and want
+> multi-seed before quantitative use; the qualitative direction of each effect is the finding.
+
 ## (1) VALIDATION — does the LLM's direct transitive judgment match the graph models?
 250 multi-hop pairs (50 chains × h=1..5) scored by gpt-5.5-low (element_of / subcategory, mu_fwd & mu_rev):
 
@@ -15,6 +20,9 @@ supplying element/subcategory transitive membership; the graph side is the walk 
 | 3 | 0.500 | 0.096 | 0.002 | 0.223 | 0.729 |
 | 4 | 0.360 | 0.121 | 0.000 | 0.185 | 0.656 |
 | 5 | 0.263 | 0.109 | 0.000 | 0.185 | 0.590 |
+
+*(The walk hit-prob plateaus at 0.185 for h=4 and h=5 — a branching-factor floor in this 50-chain sample, not a
+bug: at depth the up-walk from these descendants converges onto the same near-root ancestors.)*
 
 - **Transitive membership is real and continuous** — the LLM rates a grandchild ~0.60 a *subcategory* of the
   grandparent, decaying smoothly 0.77→0.26. Judging multi-hop pairs directly works (no math composition needed).
@@ -35,7 +43,12 @@ supplying element/subcategory transitive membership; the graph side is the walk 
 | 2 | 0.284 / 99% | 0.522 / 96% |
 | 3 | 0.153 / 99% | 0.253 / 92% |
 | 5 | 0.054 / 95% | 0.061 / 70% |
-| 8 | 0.028 / 81% | 0.018 / 36% |
+| *— beyond h=5: LLM OUGHT signal = 0 (extrapolation regime) —* | | |
+| 8 | 0.028 / 81% | 0.018 / **36%\*** |
+
+*\* h≥6 is OUT of the LLM's scoring horizon (h≤5) — the superposition's OUGHT component is extrapolated to zero
+there, so the 36% is partly "no OUGHT signal," not purely the blend failing. Do not cite it as the blend's h=8
+performance without that qualifier.*
 
 - **The OUGHT raises forward magnitude** at mid-hops (0.52 vs 0.28 @h2) — the blend is more semantically calibrated
   (the LLM thinks membership is stronger than the branch-diluted walk does).

--- a/prototypes/mu_cosine/REPORT_transitive_superposition.md
+++ b/prototypes/mu_cosine/REPORT_transitive_superposition.md
@@ -1,0 +1,59 @@
+# Transitive cross-judge superposition — graph-walk (IS) ⊕ LLM-direct (OUGHT)
+
+*Implements the two-part transitive architecture (REPORT_multihop_direction §e/f, the IS/OUGHT principle). The
+non-graph side is the deferred piece now built: the LLM scores multi-hop pairs **directly** (`score_with_codex`),
+supplying element/subcategory transitive membership; the graph side is the walk hit-prob. 2026-07-05, branch
+`claude/transitive-superposition`.*
+
+## (1) VALIDATION — does the LLM's direct transitive judgment match the graph models?
+250 multi-hop pairs (50 chains × h=1..5) scored by gpt-5.5-low (element_of / subcategory, mu_fwd & mu_rev):
+
+| h | LLM subcat_fwd | LLM element_fwd | LLM **rev** (e+s)/2 | walk hit-prob | 0.9^h |
+|---|---|---|---|---|---|
+| 1 | 0.768 | 0.258 | 0.007 | 0.517 | 0.900 |
+| 2 | 0.600 | 0.114 | 0.005 | 0.292 | 0.810 |
+| 3 | 0.500 | 0.096 | 0.002 | 0.223 | 0.729 |
+| 4 | 0.360 | 0.121 | 0.000 | 0.185 | 0.656 |
+| 5 | 0.263 | 0.109 | 0.000 | 0.185 | 0.590 |
+
+- **Transitive membership is real and continuous** — the LLM rates a grandchild ~0.60 a *subcategory* of the
+  grandparent, decaying smoothly 0.77→0.26. Judging multi-hop pairs directly works (no math composition needed).
+- **The LLM decay is a DISTINCT third signal** — it sits *between* the walk (0.29 @h2) and `p^h` (0.81 @h2), so
+  it's neither, which is exactly what makes superposing it worthwhile.
+- **`μ_rev ≈ 0` at every hop (0.007→0.000)** — the semantic **OUGHT** judge **agrees with the graph's structural
+  `μ_rev=0`** and flatly refutes `1−p^h` (which wanted 0.41 @h5). On the reverse, IS and OUGHT *concur*; the
+  interesting blend is entirely in the forward. (element_of is low/noisy — these are category-category pairs, so
+  *subcategory* is the right relation; element contributes a low view.)
+
+## (2) SUPERPOSITION — graph-walk ⊕ LLM, trained and eval'd vs walk-only
+`emit_transitive_superposition.py`: `μ_fwd = w_g·hit_prob + w_e·llm_elem_fwd + w_s·llm_subcat_fwd`,
+`μ_rev = w_g·0 + w_e·llm_elem_rev + w_s·llm_subcat_rev` (Dirichlet mix), judge=dir-blend. Trained from `model_prod`
+(+ walk transitive + h=1 anchor). Eval on deep held chains (h=1..8):
+
+| h | walk μ / dir% | superpos μ / dir% |
+|---|---|---|
+| 2 | 0.284 / 99% | 0.522 / 96% |
+| 3 | 0.153 / 99% | 0.253 / 92% |
+| 5 | 0.054 / 95% | 0.061 / 70% |
+| 8 | 0.028 / 81% | 0.018 / 36% |
+
+- **The OUGHT raises forward magnitude** at mid-hops (0.52 vs 0.28 @h2) — the blend is more semantically calibrated
+  (the LLM thinks membership is stronger than the branch-diluted walk does).
+- **…but it costs deep-hop DIRECTION** — superpos falls to 36% @h8 (below chance) vs walk's 81%. Two causes: the
+  LLM blend dilutes the clean structural signal the walk relies on for direction, and the **LLM was only scored to
+  h=5** so there is no OUGHT signal at h≥6.
+
+## Interpretation — the naive blend is a trade, not a free lunch
+The IS/OUGHT split is even sharper than expected: the **graph walk (IS) owns *direction at depth*** (crisp,
+root-converging, robust past where the LLM was scored), while the **LLM (OUGHT) owns *magnitude calibration***
+(a semantically-truer "how much" of membership). A single Dirichlet-blended target mixes them and **loses the
+graph's direction edge** to gain magnitude. So they shouldn't be flattened into one target naively.
+
+**Next (deferred):** (a) score deeper (h≥6) so the OUGHT doesn't vanish at depth; (b) **hop-dependent weighting** —
+lean graph for direction/at-depth, LLM for magnitude/near — instead of a uniform mix; (c) keep them as *separate
+operators* the model selects contextually rather than a pre-blended target (which is closer to the original
+"teach the model to separate the inputs" motivation). The clean win here is the **validation** (§1): the LLM
+confirms continuous transitive membership and `μ_rev≈0`, grounding the graph model and refuting `1−p^h`.
+
+Repro: `score_with_codex.py` on multi-hop pairs → `emit_transitive_superposition.py` → fine-tune → deep-hop eval.
+Caveat: single-seed; 250 LLM-scored pairs (h≤5); walk-vs-superpos margins want multi-seed before quantitative use.

--- a/prototypes/mu_cosine/emit_transitive_superposition.py
+++ b/prototypes/mu_cosine/emit_transitive_superposition.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Transitive cross-judge superposition (the two-part architecture, DESIGN_cross_judge_direction.md +
+REPORT_multihop_direction §e/f). At each hop h, superpose:
+  GRAPH part (IS)      — walk hit-prob P(up-walk desc→anc), μ_rev=0 (structural, no second model)
+  NON-GRAPH part(OUGHT)— LLM element_of / subcategory membership, scored DIRECTLY on the multi-hop pair
+                         (no math composition), carrying the epistemic uncertainty incl. a non-zero μ_rev.
+
+  μ_fwd = w_g·hit_prob + w_e·llm_elem_fwd + w_s·llm_subcat_fwd
+  μ_rev = w_g·0        + w_e·llm_elem_rev + w_s·llm_subcat_rev        (w ~ Dirichlet over the 3-simplex)
+
+So the graph supplies the crisp structural IS and the LLM supplies the OUGHT — the blended μ_rev is NOT 0.
+Emitted as HIER rows, judge=dir-blend.
+
+  python3 emit_transitive_superposition.py --score-in /tmp/mu_data/multihop_score_in.tsv \
+      --responses /tmp/mu_data/multihop_resp.txt --graph .../100k_cats/category_parent.tsv \
+      --mix dirichlet --alpha 4 --out /tmp/mu_data/transitive_superpos.tsv
+"""
+import argparse, os, sys
+import numpy as np
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mu_attention import load_dag
+from emit_transitive_hops import hit_prob
+from emit_direction_blend import parse_responses
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--score-in", required=True, help="the TSV fed to the scorer (id = row order)")
+    ap.add_argument("--responses", required=True, help="LLM §14 responses (id → per-relation mu_fwd/mu_rev)")
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--mix", choices=["equal", "dirichlet"], default="dirichlet")
+    ap.add_argument("--alpha", type=float, default=4.0)
+    ap.add_argument("--corpus", default="enwiki")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+    rng = np.random.default_rng(a.seed)
+    parents, _, _ = load_dag(a.graph)
+    byid = parse_responses(a.responses)
+
+    rows = [ln.rstrip("\n").split("\t") for ln in open(a.score_in, encoding="utf-8") if not ln.startswith("#")]
+
+    def d_of(o, rel, side):
+        return float((o.get(rel, {}) or {}).get(side, 0.0))
+
+    out, n = [], 0
+    for i, r in enumerate(rows):
+        if i not in byid:
+            continue
+        desc, anc = r[0], r[1]
+        g = hit_prob(parents, desc, anc)                                 # graph IS
+        ef, er = d_of(byid[i], "element_of", "mu_fwd"), d_of(byid[i], "element_of", "mu_rev")   # LLM OUGHT
+        sf, sr = d_of(byid[i], "subcategory", "mu_fwd"), d_of(byid[i], "subcategory", "mu_rev")
+        w = np.array([1/3, 1/3, 1/3]) if a.mix == "equal" else rng.dirichlet([a.alpha] * 3)
+        mu_f = max(0.0, min(1.0, w[0] * g + w[1] * ef + w[2] * sf))
+        mu_r = max(0.0, min(1.0, w[0] * 0.0 + w[1] * er + w[2] * sr))    # graph→0 (IS); LLM→ought reverse
+        out.append((desc, anc, mu_f)); out.append((anc, desc, mu_r)); n += 1
+
+    with open(a.out, "w", encoding="utf-8") as f:
+        f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\tconf\n")
+        for na, ro, mu in out:
+            f.write(f"{na}\t{ro}\t{mu:.3f}\tHIER\tsubcategory\tcategory\tcategory\t{a.corpus}\tdir-blend\t1.0\n")
+    print(f"wrote {len(out)} HIER rows ({n} transitive pairs, graph-walk IS ⊕ LLM OUGHT, mix={a.mix}) → {a.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/emit_transitive_superposition.py
+++ b/prototypes/mu_cosine/emit_transitive_superposition.py
@@ -6,7 +6,12 @@ REPORT_multihop_direction §e/f). At each hop h, superpose:
                          (no math composition), carrying the epistemic uncertainty incl. a non-zero μ_rev.
 
   μ_fwd = w_g·hit_prob + w_e·llm_elem_fwd + w_s·llm_subcat_fwd
-  μ_rev = w_g·0        + w_e·llm_elem_rev + w_s·llm_subcat_rev        (w ~ Dirichlet over the 3-simplex)
+  μ_rev = w_g·0        + w_e·llm_elem_rev + w_s·llm_subcat_rev        (w ~ Dirichlet, DRAWN PER PAIR)
+
+w is drawn PER PAIR (not one fixed vector) — deliberate augmentation, the 3-way analog of truncated-λ: spreading
+the mixing family teaches the model to SEPARATE the operators rather than fit one recipe. The formulas above show
+the STRUCTURE; each pair sees its own w. Reverse: the graph's μ_rev=0 is a HARD constraint (IS + the LLM confirms
+rev≈0 every hop), so in practice `mu_r ≈ 0` even through the blend.
 
 So the graph supplies the crisp structural IS and the LLM supplies the OUGHT — the blended μ_rev is NOT 0.
 Emitted as HIER rows, judge=dir-blend.
@@ -34,33 +39,50 @@ def main():
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--out", required=True)
     a = ap.parse_args()
-    rng = np.random.default_rng(a.seed)
     parents, _, _ = load_dag(a.graph)
     byid = parse_responses(a.responses)
 
-    rows = [ln.rstrip("\n").split("\t") for ln in open(a.score_in, encoding="utf-8") if not ln.startswith("#")]
+    with open(a.score_in, encoding="utf-8") as fh:
+        rows = [ln.rstrip("\n").split("\t") for ln in fh if not ln.startswith("#")]
+    # byid is keyed by the scorer's id = the Nth NON-COMMENT row; we strip comments the same way here, so id==index.
+    # Guard against a mismatched score_in/responses pairing (review): a stray id past the row count = wrong pairing.
+    if byid and max(byid) >= len(rows):
+        raise SystemExit(f"score_in/responses mismatch: max response id {max(byid)} >= {len(rows)} rows — "
+                         "were they produced from the same --pairs file?")
 
     def d_of(o, rel, side):
         return float((o.get(rel, {}) or {}).get(side, 0.0))
 
-    out, n = [], 0
+    out, n, n_missing = [], 0, 0
     for i, r in enumerate(rows):
         if i not in byid:
+            n_missing += 1                                                # partial/failed scoring run — count it
             continue
         desc, anc = r[0], r[1]
         g = hit_prob(parents, desc, anc)                                 # graph IS
         ef, er = d_of(byid[i], "element_of", "mu_fwd"), d_of(byid[i], "element_of", "mu_rev")   # LLM OUGHT
         sf, sr = d_of(byid[i], "subcategory", "mu_fwd"), d_of(byid[i], "subcategory", "mu_rev")
-        w = np.array([1/3, 1/3, 1/3]) if a.mix == "equal" else rng.dirichlet([a.alpha] * 3)
+        # PER-PAIR Dirichlet by design (the 3-way analog of truncated-λ — spreads the mixing family so the model
+        # learns to SEPARATE the operators, not one fixed recipe). Seeded per-row from (seed, i) so it's fully
+        # deterministic regardless of skip pattern or row order (review: was global-rng-in-loop, skip-sensitive).
+        w = np.array([1/3, 1/3, 1/3]) if a.mix == "equal" else np.random.default_rng([a.seed, i]).dirichlet([a.alpha] * 3)
         mu_f = max(0.0, min(1.0, w[0] * g + w[1] * ef + w[2] * sf))
-        mu_r = max(0.0, min(1.0, w[0] * 0.0 + w[1] * er + w[2] * sr))    # graph→0 (IS); LLM→ought reverse
+        # graph contributes 0 to the reverse BY DESIGN — μ_rev=0 is a HARD constraint (structural IS + the LLM
+        # confirms rev≈0 at every hop). So w[0] here anchors the reverse toward 0; it is not a wasted weight.
+        mu_r = max(0.0, min(1.0, w[0] * 0.0 + w[1] * er + w[2] * sr))
         out.append((desc, anc, mu_f)); out.append((anc, desc, mu_r)); n += 1
 
     with open(a.out, "w", encoding="utf-8") as f:
         f.write("# node\troot\tmu\top\trelation\tnode_type\troot_type\tcorpus\tjudge\tconf\n")
         for na, ro, mu in out:
+            # op=HIER, relation=subcategory, conf=1.0 are fixed for THIS corpus: cat-cat pairs where element_of is
+            # low/noisy so subcategory dominates (REPORT §1). Add a --relation/--conf arg before reusing on
+            # element-heavy corpora, else rows are silently mis-tagged / over-confident.
             f.write(f"{na}\t{ro}\t{mu:.3f}\tHIER\tsubcategory\tcategory\tcategory\t{a.corpus}\tdir-blend\t1.0\n")
-    print(f"wrote {len(out)} HIER rows ({n} transitive pairs, graph-walk IS ⊕ LLM OUGHT, mix={a.mix}) → {a.out}")
+    if n_missing:
+        print(f"WARNING: dropped {n_missing}/{len(rows)} pairs with no LLM response (partial scoring run?)",
+              file=sys.stderr)
+    print(f"wrote {len(out)} HIER rows ({n} transitive pairs, graph-walk IS ⊕ LLM OUGHT, per-pair mix={a.mix}) → {a.out}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Implements the deferred **non-graph side** of the transitive superposition (LLM scores multi-hop pairs *directly*),
evaluates the graph-walk ⊕ LLM blend honestly, and — from what that eval taught us — writes up the theory design
for the *correct* combiner (a two-judge joint posterior, not a superposition). Exploratory + documentation; no
existing behaviour changes (the only new code is one standalone emitter).

## What's here
- **`emit_transitive_superposition.py`** — blends the graph-walk (structural *IS*, `μ_rev=0`) with the LLM's direct
  transitive membership (semantic *OUGHT*, non-zero reverse) via a Dirichlet mix over `[walk, element, subcategory]`.
- **`REPORT_transitive_superposition.md`** — the build + two results.
- **`DESIGN_two_judge_posterior.md`** — the theory note the results pushed us toward.

## Results (honest)
**Validation (clean win):** the LLM, scoring multi-hop pairs directly, confirms transitive membership is **real and
continuous** (subcategory 0.77→0.26 over h=1..5), sits *between* the walk and `p^h` (a genuinely distinct third
signal), and reports **`μ_rev≈0` at every hop** — the semantic judge agrees with the graph's structural `μ_rev=0`
and **refutes `1−p^h`**. Also: the LLM distinguishes directional from lateral (`assoc`), which the walk cannot.

**Superposition (honest trade, not a win):** the naive blend **raises forward magnitude** (0.52 vs walk 0.28 @h2)
but **costs deep-hop direction** (36% vs walk's 81% @h8). Diagnosed causes: scale mismatch (branch-diluted walk vs
fuzzy LLM membership), directional-vs-lateral conflation, LLM scored only to h=5, and walk undertraining. So a
*uniform blend* trades direction for magnitude — the graph (IS) owns direction-at-depth, the LLM (OUGHT) owns
magnitude calibration.

## The design that follows (`DESIGN_two_judge_posterior.md`)
The superposition failed because it's the *wrong operation*: it collapses two judges into one blended target. The
right combiner **conditions** on both judges — `P(op | d, LLM_op)` — a joint posterior over the full relation
distribution (= `mu_posterior`/JointPosterior with `d`, `LLM_op` as features). The note captures:
- the combiner ladder as a moment expansion — linear (main effects) < confidence-weighted (diagonal Cov) < joint
  (off-diagonal = cartesian products = **correlation**); only the joint survives correlated judges (`e5↔graph +0.75`);
- soft constraints = **Mahalanobis fusion** (the second-order structure is a Lagrangian penalty; must be soft
  because the correlation is a churning sampled estimate — crossing it is how local data corrects a stale constraint);
- the `P(op|d)` **diffusion tables** (SimpleMind vs Wikipedia): directional decays similarly, SimpleMind carries ~2×
  the `assoc` mass — and at large n the **directional↔symmetric correlation must be modeled** (co-occurring ≠ competing);
- **pseudo-judges** as the modeling path — represent each second-order constraint as a synthetic judge (interaction
  feature that *un-breaks* linear superposition by lifting the product into a new coordinate; or a virtual observation
  that transfers a measured correlation as a soft prior);
- a **teacher/student** split — joint posterior (LLM in the loop, offline) as teacher; distill to an LLM-free student
  on the free features.

## Status
The transitive superposition is *built and honestly measured* (not a positive result on its own); the real
deliverable is the **corrected combiner design**, which the Wikipedia results earned. Deferred/tracked: fix walk
undertraining, score the LLM deeper (h≥6), and build the two-judge posterior with directional×symmetric + `d`×`LLM_op`
pseudo-judges — most cleanly on the **Pearltrees** DAG (deliberate directionality; walk gives continuous `d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)