### PR TITLE
WAM/LLVM: fix register-file ceiling (permanent-var overflow → corruption)

### DIFF
--- a/src/unifyweaver/bindings/llvm_wam_bindings.pl
+++ b/src/unifyweaver/bindings/llvm_wam_bindings.pl
@@ -66,14 +66,14 @@ llvm_wam_type_map(wam_state, '%WamState*').
 % ============================================================================
 
 %% reg_name_to_index(+Name, -Index)
-%  Maps WAM register names to fixed array indices in the [64 x %Value] array.
+%  Maps WAM register names to fixed array indices in the [128 x %Value] array.
 %  Register ABI (M10): disjoint X and Y windows so a callee clause
 %  without `allocate` cannot corrupt the caller's permanent vars by
 %  writing to a "temporary" with the same slot index.
 %
 %    A1..A16  -> 0..15   (argument registers, caller-saved)
 %    X1..X32  -> 16..47  (temporaries, do not survive calls in canonical WAM)
-%    Y1..Y16  -> 48..63  (permanents, snapshotted by allocate)
+%    Y1..Y48  -> 48..95  (permanents, snapshotted by allocate; 96..127 slack)
 %
 %  Pre-M10 used X1..X48 -> 16..63 AND Y1..Y48 -> 16..63 (same slots).
 %  A callee clause with no allocate would write to e.g. X1=slot 16,
@@ -82,9 +82,15 @@ llvm_wam_type_map(wam_state, '%WamState*').
 %  exactly when it was about to be used. The disjoint layout makes
 %  this category of bug impossible.
 %
-%  Trade-off: callers limited to Y16 permanents and X32 temporaries
-%  per clause. Existing tests fit (max X seen in the corpus is X11
-%  on an 8-element list build; Y rarely exceeds Y4).
+%  The register file was [64 x %Value] with Y limited to Y16 (48..63):
+%  a clause needing >16 permanents assigned Y17+ -> index 64+, writing
+%  past the register array into the adjacent %WamState fields (memory
+%  corruption). Enlarged to [128 x %Value] so the full Y1..Y48 window
+%  has real backing; the allocate/deallocate snapshot copies 48 Values
+%  (768 bytes, matching the [48 x %Value] env y_save). Y1..Y16 map to
+%  the same slots as before, so existing behavior is unchanged. Trade-off:
+%  callers now limited to Y48 permanents and X32 temporaries per clause;
+%  the compiler errors if a clause exceeds Y48 rather than corrupting.
 reg_name_to_index(Name, Index) :-
     atom_string(Name, Str),
     (   string_concat("A", NumStr, Str)

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3464,17 +3464,18 @@ wam_llvm_case('allocate',
   %alloc.le_cpn = load i32, i32* %alloc.le_ptr
   store i32 %alloc.le_cpn, i32* %alloc.cb_ptr
 
-  ; M10: snapshot regs[48..63] (the Y-reg window) into the env frame.
-  ; Y1..Y16 map to 48..63 under the disjoint X/Y ABI -- see
+  ; M10: snapshot regs[48..95] (the Y-reg window) into the env frame.
+  ; Y1..Y48 map to 48..95 under the disjoint X/Y ABI -- see
   ; bindings/llvm_wam_bindings.pl reg_name_to_index. Pre-M10 the
   ; snapshot covered 16..63 (X and Y mixed); now only Y space needs
-  ; protection (X space dies at calls per canonical WAM).
+  ; protection (X space dies at calls per canonical WAM). The register
+  ; file is [128 x %Value] and y_save holds 48 permanents.
   %alloc.y_src = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 48
   %alloc.y_dst = getelementptr %StackEntry, %StackEntry* %alloc.entry, i32 0, i32 3, i32 0
   %alloc.y_src_i8 = bitcast %Value* %alloc.y_src to i8*
   %alloc.y_dst_i8 = bitcast %Value* %alloc.y_dst to i8*
-  ; 16 Values * 16 bytes = 256 bytes.
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %alloc.y_dst_i8, i8* %alloc.y_src_i8, i64 256, i1 false)
+  ; 48 Values * 16 bytes = 768 bytes.
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %alloc.y_dst_i8, i8* %alloc.y_src_i8, i64 768, i1 false)
   ; Increment stack size
   %alloc.new_ss = add i32 %alloc.ss, 1
   store i32 %alloc.new_ss, i32* %alloc.ss_ptr
@@ -3523,13 +3524,13 @@ dealloc.restore:
   %dealloc.cb_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 23
   store i32 %dealloc.saved_cb, i32* %dealloc.cb_ptr
 
-  ; M10: restore regs[48..63] (Y-reg window) from the env frame
-  ; snapshot. See allocate for the save side.
+  ; M10: restore regs[48..95] (Y-reg window) from the env frame
+  ; snapshot. See allocate for the save side (48 Values = 768 bytes).
   %dealloc.y_src = getelementptr %StackEntry, %StackEntry* %dealloc.entry, i32 0, i32 3, i32 0
   %dealloc.y_dst = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 48
   %dealloc.y_src_i8 = bitcast %Value* %dealloc.y_src to i8*
   %dealloc.y_dst_i8 = bitcast %Value* %dealloc.y_dst to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dealloc.y_dst_i8, i8* %dealloc.y_src_i8, i64 256, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dealloc.y_dst_i8, i8* %dealloc.y_src_i8, i64 768, i1 false)
   ; Pop stack down to this frame (exclusive)
   store i32 %dealloc.prev_idx, i32* %dealloc.ss_ptr
   br label %dealloc.done

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1538,12 +1538,20 @@ pre_assign_permanent_vars(Goals, vmap(Bindings, X), vmap(NewBindings, XOut)) :-
     find_permanent_vars(GoalVarSets, PermVars),
     reassign_to_yi(Bindings, PermVars, 1, ReassignedBindings, NextY),
     pre_bind_unbound_yi(PermVars, ReassignedBindings, NextY, NewBindings),
-    %% Bump the X register counter past all allocated Yi indices.
-    %% Yi and Xi share the same register-file range (both map to
-    %% N + 31 in reg_name_to_index), so a subsequent next_x_reg
-    %% must not hand out an Xi that collides with an allocated Yi.
+    %% M10: Xi and Yi occupy DISJOINT register-file windows (X1..X32 ->
+    %% 16..47, Y1..Y48 -> 48..95 in reg_name_to_index), so the X counter is
+    %% independent of the Yi indices -- no bump needed (the pre-M10 shared
+    %% layout required one). Guard the Y window instead: a clause needing
+    %% more than Y48 permanents would assign Y49+ -> index 96+, overflowing
+    %% the [128 x %Value] register file. Fail with a clear error rather than
+    %% emit a corrupting index.
     max_yi_index(NewBindings, 0, MaxY),
-    XOut is max(X, MaxY + 1).
+    (   MaxY > 48
+    ->  throw(error(wam_too_many_permanent_vars(MaxY, 48),
+                    context(pre_assign_permanent_vars/3, _)))
+    ;   true
+    ),
+    XOut = X.
 
 %% max_yi_index(+Bindings, +Acc, -Max)
 %  Finds the highest Y-register number among b(_, Yi) and y_alloc(_, Yi)

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -19,7 +19,7 @@ define %WamState* @wam_state_new(%Instruction* %code, i32 %code_len, i32* %label
   ; accept the bogus IR without complaint.
   %regs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
   %regs_raw = bitcast %Value* %regs_ptr to i8*
-  %regs_size = mul i64 64, 16  ; 64 x sizeof(%Value) = 64 x {i32, i64}
+  %regs_size = mul i64 128, 16  ; 128 x sizeof(%Value) = 128 x {i32, i64}
   call void @llvm.memset.p0i8.i64(i8* %regs_raw, i8 0, i64 %regs_size, i1 false)
 
   ; Allocate stack (initial capacity 1024 entries)

--- a/templates/targets/llvm_wam/types.ll.mustache
+++ b/templates/targets/llvm_wam/types.ll.mustache
@@ -86,7 +86,7 @@
 ; === WAM State ===
 %WamState = type {
     i32,                                   ; 0: pc
-    [64 x %Value],                         ; 1: regs (A1..A16 → 0..15, X1..X48 → 16..63)
+    [128 x %Value],                        ; 1: regs (A1..A16 → 0..15, X1..X32 → 16..47, Y1..Y48 → 48..95; 96..127 slack)
     %StackEntry*,                          ; 2: stack
     i32,                                   ; 3: stack_size
     i32,                                   ; 4: stack_cap

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -288,6 +288,23 @@ wz_row(T, O1, O2, R, A0, A5) :-
     number_codes(T, Tc), append(A0, Tc, A1),
     wz_si(O1, A1, A2), wz_si(O2, A2, A3), wz_si(R, A3, A4), append(A4, [10], A5).
 
+% Register-file ceiling regression: manyperm/1 has 20 variables all live
+% across the mp_barrier call, so the compiler assigns them Y1..Y20. Before
+% the register file was enlarged from [64 x %Value] to [128 x %Value], Y17+
+% mapped to array index 64+ and wrote past the register array into adjacent
+% %WamState fields -> memory corruption / segfault in loaded objects (and
+% AOT). With the fix Y1..Y48 (48..95) have real backing; this must run to
+% 1+2+...+20 = 210.
+manyperm(R) :-
+    N1 is 1, N2 is 2, N3 is 3, N4 is 4, N5 is 5,
+    N6 is 6, N7 is 7, N8 is 8, N9 is 9, N10 is 10,
+    N11 is 11, N12 is 12, N13 is 13, N14 is 14, N15 is 15,
+    N16 is 16, N17 is 17, N18 is 18, N19 is 19, N20 is 20,
+    mp_barrier,
+    R is N1+N2+N3+N4+N5+N6+N7+N8+N9+N10
+       + N11+N12+N13+N14+N15+N16+N17+N18+N19+N20.
+mp_barrier.
+
 % Milestone 3b-db PR 3: rule bodies. assertz((H :- B)) stores a rule; calling
 % its head runs the body (deterministic first solution). Bodies handle ,/2,
 % builtins (is/2, comparisons, =/2), and predicate calls; head<->body variable
@@ -854,6 +871,19 @@ test(selfhost_serializer_stage_a, [condition(clang_available)]) :-
     process_wait(Pid, exit(Status)),
     assertion(Status == 0),
     assertion(Out == "42\n"),
+    !.
+
+% Register-file ceiling fix: a clause with 20 permanent variables (Y1..Y20)
+% loads and runs. Before enlarging the register file to [128 x %Value], Y17+
+% overflowed the 64-slot array and corrupted memory. Must yield 210.
+test(register_file_many_permanents, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    directory_file_path(Dir, 'manyperm.wamo', W),
+    write_wam_object([user:manyperm/1], [wamo_entry(manyperm/1)], W),
+    run_host(Host, W, Out, 0),
+    assertion(Out == "210\n"),
     !.
 
 % Milestone 3b-db PR 3: rule bodies in a loaded object. asserted (H :- B)


### PR DESCRIPTION
## What

Fixes the first of the two loaded-runtime bugs surfaced by self-host Stage A: the **register-file ceiling**. This is a latent correctness bug that **also affects AOT-compiled code**, not just loaded objects.

## The bug

The WAM register file was `[64 x %Value]`, partitioned by the M10 disjoint-window ABI:
- `A1..A16` → 0..15
- `X1..X32` → 16..47
- `Y1..Y16` → 48..63

A clause holding **more than 16 permanent variables** made the tier-2 compiler assign `Y17+` → array index 64+, writing **past the register array** into the adjacent `%WamState` fields (the stack pointer) → silent memory corruption / segfault. Confirmed by bisection: a clause with ~16+ call-spanning variables crashes; the Stage A serializer had to be written in unnaturally small clauses to dodge it.

## The fix — enlarge the file, widen the Y window

- **`types.ll`**: `regs [64 x %Value]` → `[128 x %Value]`; **`state.ll`** init memset 64→128.
- **`reg_name_to_index`**: Y window widened from Y16 to **Y48** (slots 48..95). The formula (`Y_n → n+47`) is **unchanged**, so Y1..Y16 keep identical slots — existing behavior is byte-for-byte the same; only Y17..Y48 gain real backing.
- **`allocate`/`deallocate`**: the Y-register snapshot into the environment `y_save` grows from 16 Values (256 bytes) to 48 (768 bytes). `y_save` is already `[48 x %Value]`, so **`StackEntry` size and the stack malloc are unchanged**. Choice points still save only the low 32 registers (512 bytes); permanents survive via the environment snapshot + trail, exactly as before.
- **`pre_assign_permanent_vars`**: removed the now-incorrect X-counter bump (its comment described the *pre-M10* shared X/Y layout; under disjoint windows X and Y never collide, and the bump could push X into the Y window for large clauses). Added a guard that throws `wam_too_many_permanent_vars` if a clause needs more than Y48 — converting any future overflow into a **clean error instead of corruption**.

## Testing

- New regression test **`register_file_many_permanents`**: a clause with 20 permanent variables (Y1..Y20) loads and runs to 210 (previously segfaulted).
- Full **`wam_object`** suite: 0 failures.
- **`test_llvm_target`** suite: all pass.
- plawk execution suites (`dyncall`, `compiled_stream_core`, `binary_records`): 0 failures.

## Follow-up

The **second** Stage A bug — the multi-way first-argument functor dispatch anomaly (≥4 tagged clauses with a list-carrying variant mis-dispatch in loaded objects) — is a separate loader clause-indexing issue and will be a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_