### PR TITLE
WAM/LLVM: get_structure must compare the functor (fixes mis-dispatch)

### DIFF
--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -185,40 +185,40 @@ runs to `42`** end to end (the eval loop closes on a grammar-emitted object).
 **Deliverable — done:** a loaded grammar emits a valid `.wamo` from a
 hand-supplied instruction list; emitted object loads and runs.
 
-**Two loaded-runtime limitations Stage A surfaced (prerequisites for later
-stages, both routed around here):**
+**Two loaded-runtime bugs Stage A surfaced — both now FIXED (each its own PR):**
 
-1. **Register-file ceiling (correctness bug, affects AOT too).** The register
-   file is `[64 x %Value]` (16 args + 48 temps, indices 0–63). A clause holding
-   ~16+ call-spanning variables makes the tier-2 compiler emit register indices
-   ≥ 64, which write **past the register array** into the adjacent `%WamState`
+1. **Register-file ceiling (correctness bug, affected AOT too) — FIXED.** The
+   register file was `[64 x %Value]`, partitioned A1–16 / X1–32 / **Y1–16**
+   (48–63). A clause holding >16 permanent variables assigned Y17+ → array
+   index 64+, writing **past the register array** into the adjacent `%WamState`
    fields (the stack pointer) → memory corruption / segfault. Confirmed: a
-   clause with 16 accumulator variables reaches reg index 65 and crashes; 12
-   variables (reg ≤ 61) is fine. **Impact on self-host:** real codegen clauses
-   can easily exceed this. The serializer here is written as small
-   accumulator-threaded clauses (each ≤ ~12 call-spanning vars) to stay under
-   the ceiling — the "correctness over register reuse, small clauses" style this
-   doc already prescribes. **Before Stage C** (codegen with larger clauses) the
-   register file likely needs enlarging (a runtime change touching the register
-   array, the choice-point saved-register block, and the save/restore loops),
-   or the compiler needs a spill/environment strategy. Filed as a follow-up.
+   clause with 16+ call-spanning variables crashes; ≤12 is fine. Fixed by
+   enlarging the file to `[128 x %Value]` and widening the Y window to Y48
+   (formula unchanged, so Y1–16 keep identical slots), growing the
+   `allocate`/`deallocate` snapshot to match, and adding a compile-time guard
+   (`wam_too_many_permanent_vars`) so any future overflow is a clean error, not
+   corruption. The Stage A serializer's small-clause style is no longer forced,
+   but remains good practice.
 
-2. **Multi-way first-argument functor dispatch anomaly.** A predicate with ≥ 4
-   clauses dispatched by the first argument's functor (a tagged union like
-   `f(int(_))`, `f(atom(_))`, `f(nstr(_))`, `f(ins(_))`) **mis-dispatches** in
-   loaded objects when a list-carrying variant is present: calling it with one
-   variant returns a corrupted result. Confirmed by bisection — removing the
-   list-carrying variant fixes it; the same clause set works with ≤ 3 clauses.
-   Root cause is likely the loader's `switch_on_constant`/`switch_on_term`
-   nop-fallthrough interacting with the clause chain. **Impact on self-host:** a
-   natural codegen representation is a tagged token/AST union walked by functor
-   dispatch — exactly this shape. The serializer avoids it (only list `[]`/`[|]`
-   and `enc/4`-head dispatch, no polymorphic union). **Before Stage C** this
-   needs a real fix in the loader's indexing path. Filed as a follow-up.
+2. **`get_structure` did not compare the functor — FIXED.** The real bug behind
+   the "multi-way functor dispatch anomaly" was simpler and more fundamental
+   than first thought: `get_structure f/N` entered read mode for **any**
+   Compound (`tag == 3`) without comparing the functor name or arity against the
+   expected `f/N`. So `get_structure atom/1` on `ins(enc(...))` *succeeded* and
+   read `ins`'s arg as if it were `atom`'s. Multi-clause first-argument dispatch
+   therefore only worked by accident — the wrong clauses' **bodies** had to fail
+   (`atom_codes`/`number_codes` of a compound fails). A body that did not
+   cleanly fail (e.g. `length/2` on a compound) ran the wrong clause and
+   returned garbage; a first clause whose body *succeeded* on the wrong data
+   returned the wrong answer outright. This affected AOT and loaded objects
+   alike. Fixed by comparing arity, then functor (via `@wam_functor_eq` —
+   pointer-fast with a `strcmp` fallback for reader/`=..`-built compounds),
+   before entering read mode; a mismatch now fails as it should.
 
-Neither blocks Stage A, but both are on the critical path for Stage C and are
-recorded here so they are fixed (or explicitly designed around) before codegen
-produces large clauses and tagged-union walkers.
+**Consequence for later stages:** a tagged token/AST union walked by
+first-argument functor dispatch — the natural codegen representation for Stages
+B–D — now dispatches correctly in loaded objects. The serializer here still uses
+list `[]`/`[|]` + `enc/4` dispatch, but that is no longer a requirement.
 
 *Aside:* the byte-return path (`atom_codes` interning) strips **trailing**
 newlines from an atom, so the loaded serializer's object is 1 byte shorter than

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -2993,9 +2993,34 @@ gs.write:
   ret i1 true
 
 gs.read:
-  ; Read mode: extract args from Compound and push UnifyCtx
+  ; Read mode: the register holds a Compound. It only matches if its
+  ; functor name AND arity equal the expected op1/arity -- otherwise this
+  ; get_structure must FAIL. Historically this block accepted ANY compound
+  ; (tag == 3) without comparing the functor, so `get_structure f/N` on a
+  ; compound g/M succeeded and read g''s args as if they were f''s. Multi-
+  ; clause first-argument dispatch then only worked by accident, relying on
+  ; the wrong clauses'' BODIES failing; a body that did not cleanly fail
+  ; (e.g. length/2 on a compound) ran the wrong clause and returned garbage.
   %gs.cp_bits = extractvalue %Value %gs.val, 1
   %gs.cp_ptr = inttoptr i64 %gs.cp_bits to %Compound*
+  ; arity must match
+  %gs.car_slot = getelementptr %Compound, %Compound* %gs.cp_ptr, i32 0, i32 1
+  %gs.car = load i32, i32* %gs.car_slot
+  %gs.arity_ok = icmp eq i32 %gs.car, %gs.arity
+  br i1 %gs.arity_ok, label %gs.check_fn, label %gs.fail
+
+gs.check_fn:
+  ; functor name must match (op1 is the expected functor string pointer;
+  ; wam_functor_eq is pointer-fast with a strcmp fallback for dynamically
+  ; built compounds whose functor came from the atom table).
+  %gs.cfn_slot = getelementptr %Compound, %Compound* %gs.cp_ptr, i32 0, i32 0
+  %gs.cfn = load i8*, i8** %gs.cfn_slot
+  %gs.exp_fn = inttoptr i64 %op1 to i8*
+  %gs.fn_ok = call i1 @wam_functor_eq(i8* %gs.cfn, i8* %gs.exp_fn)
+  br i1 %gs.fn_ok, label %gs.read_ok, label %gs.fail
+
+gs.read_ok:
+  ; extract args from the Compound and push UnifyCtx
   %gs.args_slot = getelementptr %Compound, %Compound* %gs.cp_ptr, i32 0, i32 2
   %gs.args = load %Value*, %Value** %gs.args_slot
   call void @wam_push_unify_ctx(%WamState* %vm, %Value* %gs.args, i32 %gs.arity)

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -43,6 +43,19 @@ coltab(green, 2).
 coltab(blue, 3).
 pick(R) :- coltab(green, R).          % -> 2
 
+% get_structure functor-check regression: dispatch over a tagged compound to
+% one of several clauses keyed by the first argument's functor. Before
+% get_structure compared the functor (it accepted ANY compound of the right
+% shape), calling dp_sel(three(7),R) wrongly matched the FIRST clause
+% (one/1) -- reading three(7)'s arg as if it were one(7) -- and returned 8
+% instead of 42. The dp_many clause has a list-typed permanent head-arg (the
+% shape whose body does not cleanly fail, which made the bug visible). With
+% the functor check, one/1 and many/1 fail cleanly and three/1 matches -> 42.
+dp_go(R)          :- dp_sel(three(7), R).
+dp_sel(one(X), R)   :- R is X + 1.
+dp_sel(many(L), R)  :- length(L, N), R is N * 100.
+dp_sel(three(X), R) :- R is X * 6.          % 7 * 6 = 42
+
 % call/N meta-call inside a loaded object (eval bootstrap milestone 2). The
 % goal is built at runtime and dispatched through the object's OWN meta-call
 % table, so a loaded .wamo can call its own predicates.
@@ -509,6 +522,23 @@ test(switch_on_constant_loads_and_runs,
     ( exists_file(Host) -> true ; build_host(Dir, Host) ),
     run_host(Host, Wamo, Out, 0),
     assertion(Out == "2\n"),
+    !.
+
+% get_structure functor-check regression: dispatch over a compound keyed by
+% first-argument functor. Before get_structure verified the functor, calling
+% dp_sel(three(7),R) mis-matched the first clause (one/1) and returned 8; now
+% it correctly falls through to three/1 -> 42. Also validates that a tagged-
+% union walker (a compiler's natural AST/token representation) dispatches
+% correctly in loaded objects.
+test(get_structure_functor_dispatch,
+        [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'dpgo.wamo', Wamo),
+    write_wam_object([user:dp_go/1, user:dp_sel/2], [wamo_entry(dp_go/1)], Wamo),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    run_host(Host, Wamo, Out, 0),
+    assertion(Out == "42\n"),
     !.
 
 % A loaded object meta-calls (call/N) one of its own predicates, the goal


### PR DESCRIPTION
## What

Fixes the second Stage-A loaded-runtime bug — and it turned out to be **more fundamental** than the initial "multi-way functor dispatch anomaly" framing: **`get_structure` never compared the functor.**

## The bug

`get_structure f/N` entered read mode for **any** Compound (`tag == 3`) without comparing the functor name or arity against the expected `f/N`. So `get_structure atom/1` on a value `ins(enc(...))` *succeeded* and read `ins`'s argument as if it were `atom`'s.

Multi-clause first-argument dispatch therefore only worked **by accident**: the wrong clauses' *bodies* had to fail (`atom_codes`/`number_codes` of a compound fails, so execution fell through to the right clause). A body that did **not** cleanly fail — e.g. `length/2` on a compound — ran the wrong clause and returned garbage; a first clause whose body *succeeded* on the wrong data returned the wrong answer outright.

This affected **AOT and loaded objects alike** — `get_structure` is core to every compound head match. It stayed hidden because most real predicates' wrong-clause bodies happen to fail.

## The fix

In read mode, before extracting args: compare the `%Compound`'s **arity**, then its **functor** (via `@wam_functor_eq` — pointer-fast identity with a `strcmp` fallback for reader-/`=..`-built compounds whose functor pointer comes from the atom table). A mismatch now **fails**, as canonical WAM `get_structure` requires.

## Diagnosis path

Bisection ruled out the functor *name* and lists per se; the register diff (X1 vs Y3) and a name-vs-body discriminator localized it to a sibling clause whose head-arg is a *permanent* with a body that doesn't cleanly fail. Reading the `get_structure` handler then showed the missing functor comparison — the true root cause.

## Testing

- New regression **`get_structure_functor_dispatch`**: `dp_sel(three(7),R)` dispatched over `one`/`many`/`three` clauses returns **42** (was **8** — the first clause wrongly matched).
- Minimal repros (`tb`/`ts3`, previously `"1 "`) now correct; the tagged-union token walker the self-host codegen stages will use dispatches correctly.
- Full **`wam_object`** suite: 0 failures. **`test_llvm_target`**: pass. plawk execution suites (`dyncall`, `binary_records`, `compiled_stream_core`, `binary_assoc`): 0 failures.

## Docs

`PLAWK_SELFHOST.md` updated: **both** Stage-A bugs are now fixed. A tagged AST/token union walked by first-argument functor dispatch — the natural codegen representation for Stages B–D — now works in loaded objects, unblocking them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_