### PR TITLE
WAM/LLVM (roadmap #5, milestone 6): self-host Stage C -- predicate calls

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -363,8 +363,12 @@ loadable along the way.
   (`cgcompile/2` parses source text with the reader, walks the clause to
   instructions, and serializes; `p(R) :- R = 42` and `p(R) :- R is 6*7` compile
   from source and run to `42` end to end via `@wam_object_eval` — the first
-  source→bytecode compile); (C) multi-goal bodies + predicate calls; (D) widen
-  toward the compiler's own subset — the self-host fixpoint. Stage A surfaced two
+  source→bytecode compile); **(C) predicate calls — LANDED** (`cgcprog/2`
+  compiles a multi-clause program — a list of clauses — into a multi-predicate
+  `.wamo` with per-clause labels and `execute(CalleeLabel)` tail calls, so one
+  clause calls another; `[(main0(R):-helper(R)), helper(42)]` → `42`. Conjunction
+  with register allocation is a Stage C follow-on); (D) widen toward the
+  compiler's own subset — the self-host fixpoint. Stage A surfaced two
   loaded-runtime bugs, **both since fixed** (a 64-register-file ceiling that
   corrupted memory for large clauses; `get_structure` not comparing the functor),
   so large clauses and tagged-union dispatch both work now. See

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -250,13 +250,36 @@ loaded compiler object and run to `42`. Codegen logic also checked byte-identica
 to the host writer's golden `.wamo`. This is the first source→bytecode compile:
 reader + codegen + serializer composed into one loadable object.
 
-### Stage C — multi-goal bodies and predicate calls
+### Stage C — multi-goal bodies and predicate calls — *predicate calls LANDED*
 
 Extend codegen to conjunctions (`,`/2), calls to other predicates
 (`call`/`execute` + the meta-call table from M2), and multi-argument heads
-with register allocation. Add the named-entry table so a compiled object
-exposes its entry by name. Test: a two-clause source program where one
+with register allocation. Test: a two-clause source program where one
 clause calls the other.
+
+**Predicate calls — LANDED.** `cgcprog/2` compiles a **multi-clause** program
+(source parses in one reader call to a *list of clauses*,
+`[(main0(R):-helper(R)), helper(42)]`) into a **multi-predicate `.wamo`**. Each
+clause gets a label (its index); a single-goal predicate-call body compiles to
+`[allocate, deallocate, execute(CalleeLabel)]` (a tail call), with the callee
+resolved through a name/arity→label map built in a first pass. `execute`
+references the label **directly** (tag 19, op1 = label index), so no meta-call
+table is needed (`NM = 0`). The label→PC table is exactly the PC list the Stage
+A serializer already accepts — so the serializer was unchanged; all the new work
+is codegen (label assignment, PC computation, call resolution). Facts `P(Int)`
+and the Stage B body forms (`=`/`is`) still lower to
+`[get_constant(V,A1), proceed]`. Verified end to end
+(`tests/test_wam_object.pl:selfhost_codegen_stage_c`): `main0` tail-calls
+`helper` → `42`; the codegen is byte-identical to the host writer's golden for
+the same program.
+
+**Still to do in Stage C (follow-on):** conjunction (`,`/2) with **register
+allocation** for temporaries that span goals (e.g. `p(R) :- X is 6*7, R = X`),
+non-tail calls (`call` + `proceed`), and multi-argument heads with argument
+setup (`put_value`/`put_constant` before the call). These need a real (if
+simple, sequential) register allocator — the piece the design flags as
+"correctness over reuse". The register-file and `get_structure` fixes mean
+large clauses and tagged-union walkers already work, so this is codegen-only.
 
 **Deliverable:** the compiler handles the clause shapes a small hand-written
 grammar uses — the point at which "compile a grammar at runtime from source"

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -335,6 +335,61 @@ pred_name_codes(Pred, Arity, Codes) :-
     atom_codes(Pred, PC), number_codes(Arity, AC),
     append(PC, [0'/ | AC], Codes).
 
+% Milestone 6 (self-host) Stage C: multi-clause programs with predicate calls.
+% cgcprog/2 is the eval entry compile(Src,Wamo): Src parses (one reader call)
+% to a LIST of clauses -- e.g. "[(main0(R):-helper(R)), helper(42)]" -- and the
+% program compiles to a multi-predicate .wamo. Each clause gets a label (its
+% index); a predicate-call body becomes execute(CalleeLabel) resolved through
+% a name/arity->label map (execute references the label directly, so no
+% meta-call table is needed). The label->PC table (PCs, one entry per clause)
+% is exactly what the Stage A serializer already accepts. Facts P(Int) and the
+% Stage B body forms (= / is) still lower to [get_constant(V,A1), proceed].
+% A single-goal predicate-call body is a tail call: [allocate, deallocate,
+% execute] -- matching the host writer (verified byte-identical). Register
+% allocation for temporaries across conjoined goals is a Stage C follow-on.
+cgcprog(Src, Wamo) :-
+    read_term_from_atom(Src, Clauses),
+    cgc_clauses(Clauses, EntryName, PCs, Instrs),
+    wz_serialize(0, EntryName, 0, 0, 0, PCs, Instrs, Codes),
+    atom_codes(Wamo, Codes).
+
+cgc_clauses(Clauses, EntryName, PCs, AllInstrs) :-
+    assign_labels(Clauses, 0, PL),
+    codegen_all(Clauses, PL, 0, AllInstrs, PCs),
+    Clauses = [First|_], cgc_head(First, H0), functor(H0, P0, A0),
+    pred_name_codes(P0, A0, EntryName).
+
+cgc_head((H :- _), H) :- !.
+cgc_head(H, H).
+
+assign_labels([], _, []).
+assign_labels([C|Cs], L, [key(P,A)-L | Rest]) :-
+    cgc_head(C, H), functor(H, P, A), L1 is L + 1,
+    assign_labels(Cs, L1, Rest).
+
+codegen_all([], _, _, [], []).
+codegen_all([C|Cs], PL, PC, All, [PC|PCs]) :-
+    codegen_clause(C, PL, Instrs),
+    length(Instrs, N), PC1 is PC + N,
+    codegen_all(Cs, PL, PC1, Rest, PCs),
+    append(Instrs, Rest, All).
+
+codegen_clause((_ :- Body), PL, Instrs) :- !, codegen_body(Body, PL, Instrs).
+codegen_clause(Fact, _, [enc(0,V,65536,0), enc(20,0,0,0)]) :-   % fact P(Int)
+    Fact =.. [_, V], integer(V).
+
+codegen_body(Body, PL, Instrs) :-
+    (   Body = (_ = V), integer(V)
+    ->  Instrs = [enc(0,V,65536,0), enc(20,0,0,0)]
+    ;   Body = (_ is Expr)
+    ->  V is Expr, Instrs = [enc(0,V,65536,0), enc(20,0,0,0)]
+    ;   functor(Body, P, A), lookup_label(P, A, PL, Label)
+    ->  Instrs = [enc(16,0,0,0), enc(17,0,0,0), enc(19,Label,0,0)]  % allocate,deallocate,execute
+    ).
+
+lookup_label(P, A, [key(P,A)-L|_], L) :- !.
+lookup_label(P, A, [_|R], L) :- lookup_label(P, A, R, L).
+
 % Register-file ceiling regression: manyperm/1 has 20 variables all live
 % across the mp_barrier call, so the compiler assigns them Y1..Y20. Before
 % the register file was enlarged from [64 x %Value] to [128 x %Value], Y17+
@@ -962,6 +1017,31 @@ test(selfhost_codegen_stage_b, [condition(clang_available)]) :-
           process_wait(Pid, exit(Status)),
           assertion(Status == 0),
           assertion(Out == "42\n") )),
+    !.
+
+% Milestone 6 (self-host) Stage C: multi-clause program with a predicate call.
+% cgcprog/2 compiles a list-of-clauses source into a multi-predicate .wamo: the
+% entry clause tail-calls a second clause. Exercises label assignment, the
+% label->PC table, and execute(CalleeLabel). "[(main0(R):-helper(R)),
+% helper(42)]" compiles so main0 calls helper -> 42, end to end via the eval
+% host. The codegen is also verified byte-identical to the host writer's golden
+% for the same program (in SWI, where the /3 reader is available).
+test(selfhost_codegen_stage_c, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgcprog.wamo', CompWamo),
+    write_wam_object([user:cgcprog/2], [wamo_entry(cgcprog/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgc_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R):-helper(R)), helper(42)]'), close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "42\n"),
     !.
 
 % Register-file ceiling fix: a clause with 20 permanent variables (Y1..Y20)


### PR DESCRIPTION
## What

Stage C's **predicate-call slice**: compile a **multi-clause** program into a multi-predicate `.wamo` where one clause calls another — the point where "compile a grammar at runtime" starts to mean real programs, not single clauses.

`cgcprog/2` (the eval entry) takes a source that parses in **one** `read_term_from_atom` call to a **list of clauses** — `[(main0(R):-helper(R)), helper(42)]` — sidestepping nondeterministic string-splitting (loaded-object bodies are deterministic).

## Codegen (all new work — the Stage A serializer was unchanged)

- **`assign_labels`** (first pass): each clause gets a label = its index, recorded in a name/arity→label map.
- **`codegen_all`**: per-clause instructions concatenated, tracking a label→PC list — exactly the PC list `wz_serialize` already accepts (so multi-label needed zero serializer changes).
- A single-goal **predicate-call body** → `[allocate, deallocate, execute(Label)]` (tail call). `execute` references the callee label **directly** (tag 19, op1 = label index), so **no meta-call table** is needed (`NM=0`). Callee resolved via the name/arity→label map.
- Facts `P(Int)` and the Stage B body forms (`=`/`is`) still lower to `[get_constant(V,A1), proceed]`.

## Testing

- New test **`selfhost_codegen_stage_c`**: `[(main0(R):-helper(R)), helper(42)]` compiles so `main0` tail-calls `helper` → **42**, end to end via the eval host.
- Codegen verified **byte-identical** to the host writer's golden `.wamo` for the same program (in SWI).
- Full `wam_object` suite: 0 failures.

## Deferred to a Stage C follow-on

Conjunction (`,`/2) with **register allocation** for temporaries that span goals (`p(R) :- X is 6*7, R = X`), non-tail calls (`call` + `proceed`), and multi-argument argument setup (`put_value`/`put_constant`). These need a simple sequential register allocator — the piece the design flags as "correctness over reuse". The register-file and `get_structure` fixes mean large clauses and tagged-union walkers already work, so this is codegen-only.

## Docs

`PLAWK_SELFHOST.md` and the JIT roadmap mark Stage C's predicate calls landed, with the conjunction/register-allocation follow-on noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_