### PR TITLE
WAM/LLVM (roadmap #5, milestone 6): self-host Stage C -- conjunction + register allocation

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -366,8 +366,12 @@ loadable along the way.
   source→bytecode compile); **(C) predicate calls — LANDED** (`cgcprog/2`
   compiles a multi-clause program — a list of clauses — into a multi-predicate
   `.wamo` with per-clause labels and `execute(CalleeLabel)` tail calls, so one
-  clause calls another; `[(main0(R):-helper(R)), helper(42)]` → `42`. Conjunction
-  with register allocation is a Stage C follow-on); (D) widen toward the
+  clause calls another; `[(main0(R):-helper(R)), helper(42)]` → `42`), plus
+  **conjunction + register allocation — LANDED** (`cgconj/2`: `numbervars`→
+  Y-registers, first/subsequent occurrence → `put_variable`/`put_value`,
+  `builtin_call =/2`; `pconj(R):-Y=42,R=Y` → `42`, byte-identical to the host).
+  Runtime arithmetic (`is/2` via `put_structure`) and non-tail calls remain;
+  (D) widen toward the
   compiler's own subset — the self-host fixpoint. Stage A surfaced two
   loaded-runtime bugs, **both since fixed** (a 64-register-file ceiling that
   corrupted memory for large clauses; `get_structure` not comparing the functor),

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -273,13 +273,26 @@ and the Stage B body forms (`=`/`is`) still lower to
 `helper` → `42`; the codegen is byte-identical to the host writer's golden for
 the same program.
 
-**Still to do in Stage C (follow-on):** conjunction (`,`/2) with **register
-allocation** for temporaries that span goals (e.g. `p(R) :- X is 6*7, R = X`),
-non-tail calls (`call` + `proceed`), and multi-argument heads with argument
-setup (`put_value`/`put_constant` before the call). These need a real (if
-simple, sequential) register allocator — the piece the design flags as
-"correctness over reuse". The register-file and `get_structure` fixes mean
-large clauses and tagged-union walkers already work, so this is codegen-only.
+**Conjunction + register allocation — LANDED.** `cgconj/2` compiles a clause
+whose body is a conjunction of unification goals (`X = Y`, `X = Int`) with a
+real (simple) register allocator: `numbervars/3` binds each source variable to
+`'$VAR'(N)`, mapped to permanent register Y(N+1); an initialized-Y set is
+threaded through so a variable's **first** occurrence emits
+`put_variable`/`get_variable` and **later** occurrences `put_value`. Head
+arguments are saved with `get_variable`; each `=` goal stages A1/A2
+(`put_variable`/`put_value`/`put_constant`) then `builtin_call =/2` (id 24).
+This is the WAM register-allocation core. Verified byte-identical to the host
+writer for `pconj(R) :- Y = 42, R = Y` (Y a temporary shared across both goals),
+and end to end (`tests/test_wam_object.pl:selfhost_codegen_stage_c_conjunction`):
+compiles from source and runs to `42`.
+
+**Still to do in Stage C (follow-on):** runtime arithmetic — `is/2` where an
+operand is a variable (`Y is X + 1`) builds the expression term on the heap
+(`put_structure` + a functor table, `NF > 0`) and calls `builtin_call is/2`;
+and non-tail predicate calls (`call` + `proceed`) with a permanent holding the
+result across the call, plus multi-argument argument setup. These extend the
+same allocator with `put_structure`/`call` and the functor-table section of the
+serializer.
 
 **Deliverable:** the compiler handles the clause shapes a small hand-written
 grammar uses — the point at which "compile a grammar at runtime from source"

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -390,6 +390,66 @@ codegen_body(Body, PL, Instrs) :-
 lookup_label(P, A, [key(P,A)-L|_], L) :- !.
 lookup_label(P, A, [_|R], L) :- lookup_label(P, A, R, L).
 
+% Milestone 6 (self-host) Stage C (rest): conjunction + register allocation.
+% cgconj/2 compiles a clause whose body is a conjunction of unification goals
+% (X = Y, X = Int) with a real (simple) register allocator: numbervars binds
+% each source variable to '$VAR'(N), mapped to permanent register Y(N+1); the
+% initialized-Y set is threaded through so a variable's first occurrence emits
+% put_variable / get_variable and later occurrences put_value. Head arguments
+% are saved with get_variable; each `=` goal sets up A1/A2 (put_variable /
+% put_value / put_constant) then builtin_call =/2 (id 24). This is the WAM
+% register-allocation core -- verified byte-identical to the host writer for
+% `pconj(R):-Y=42,R=Y`. Runtime arithmetic (is/2 building expression terms via
+% put_structure) and non-tail calls are the remaining Stage C pieces.
+cgconj(Src, Wamo) :-
+    read_term_from_atom(Src, Clause),
+    numbervars(Clause, 0, _),
+    conj_instrs(Clause, NameCodes, Instrs),
+    wz_serialize(0, NameCodes, 0, 0, 0, [0], Instrs, Codes),
+    atom_codes(Wamo, Codes).
+
+conj_instrs(Clause, NameCodes, Instrs) :-
+    clause_hb(Clause, Head, Goals),
+    functor(Head, Pred, Arity), pred_name_codes(Pred, Arity, NameCodes),
+    head_args(Head, 1, Arity, [], Init1, HeadIs),
+    goals_instrs(Goals, Init1, _, GoalIs),
+    append([enc(16,0,0,0) | HeadIs], GoalIs, B0),          % allocate + head
+    append(B0, [enc(17,0,0,0), enc(20,0,0,0)], Instrs).     % deallocate, proceed
+
+clause_hb((H :- B), H, Goals) :- !, conj_list(B, Goals).
+clause_hb(H, H, []).
+conj_list((A,B), [A|Rest]) :- !, conj_list(B, Rest).
+conj_list(G, [G]).
+
+is_init(N, [N|_]) :- !.
+is_init(N, [_|T]) :- is_init(N, T).
+
+head_args(_, I, Arity, Init, Init, []) :- I > Arity, !.
+head_args(Head, I, Arity, Init0, Init, [Instr|Rest]) :-
+    arg(I, Head, Arg), AiIdx is I - 1,
+    head_arg_instr(Arg, AiIdx, Init0, Init1, Instr),
+    I1 is I + 1, head_args(Head, I1, Arity, Init1, Init, Rest).
+head_arg_instr('$VAR'(N), AiIdx, Init0, [N|Init0], enc(1, YIdx, AiIdx, 0)) :- YIdx is 48 + N.
+head_arg_instr(V, AiIdx, Init, Init, enc(0, V, Op2, 0)) :- integer(V), Op2 is (1 << 16) \/ AiIdx.
+
+operand_instr('$VAR'(N), AiIdx, Init0, Init1, [Instr]) :-
+    YIdx is 48 + N,
+    (   is_init(N, Init0)
+    ->  Instr = enc(10, YIdx, AiIdx, 0), Init1 = Init0     % put_value (subsequent)
+    ;   Instr = enc(9, YIdx, AiIdx, 0), Init1 = [N|Init0]  % put_variable (first)
+    ).
+operand_instr(V, AiIdx, Init, Init, [enc(8, V, Op2, 0)]) :- integer(V), Op2 is (1 << 16) \/ AiIdx.
+
+goal_instrs((L = R), Init0, Init2, Is) :-
+    operand_instr(L, 0, Init0, Init1, ILs),
+    operand_instr(R, 1, Init1, Init2, IRs),
+    append(ILs, IRs, LR), append(LR, [enc(21, 24, 2, 0)], Is).   % builtin_call =/2
+
+goals_instrs([], Init, Init, []).
+goals_instrs([G|Gs], Init0, Init, Is) :-
+    goal_instrs(G, Init0, Init1, GIs),
+    goals_instrs(Gs, Init1, Init, RestIs), append(GIs, RestIs, Is).
+
 % Register-file ceiling regression: manyperm/1 has 20 variables all live
 % across the mp_barrier call, so the compiler assigns them Y1..Y20. Before
 % the register file was enlarged from [64 x %Value] to [128 x %Value], Y17+
@@ -1035,6 +1095,29 @@ test(selfhost_codegen_stage_c, [condition(clang_available)]) :-
     directory_file_path(Dir, 'cgc_src.txt', SrcPath),
     setup_call_cleanup(open(SrcPath, write, S0),
         write(S0, '[(main0(R):-helper(R)), helper(42)]'), close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "42\n"),
+    !.
+
+% Milestone 6 (self-host) Stage C (rest): conjunction + register allocation.
+% cgconj/2 compiles a clause with a conjunction of unification goals, doing
+% real register allocation (numbervars -> Y-registers, first/subsequent
+% occurrence -> put_variable/put_value). "pconj(R) :- Y = 42, R = Y" -- Y is a
+% temporary shared across the two goals -- compiles from source and runs to 42.
+test(selfhost_codegen_stage_c_conjunction, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgconj.wamo', CompWamo),
+    write_wam_object([user:cgconj/2], [wamo_entry(cgconj/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgconj_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, 'pconj(R) :- Y = 42, R = Y'), close(S0)),
     process_create(Host, [CompWamo, SrcPath],
         [stdout(pipe(S)), stderr(std), process(Pid)]),
     read_string(S, _, Out),


### PR DESCRIPTION
## What

The **register-allocation core** of Stage C — conjunction with a real (if simple) register allocator. `cgconj/2` compiles a clause whose body is a conjunction of unification goals (`X = Y`, `X = Int`) into WAM code with permanent-register allocation:

- **`numbervars/3`** binds each source variable to `'$VAR'(N)`, mapped to permanent register **Y(N+1)**.
- An **initialized-Y set** is threaded through the head + goals so a variable's **first** occurrence emits `put_variable`/`get_variable` and **later** occurrences emit `put_value` — the classic WAM first-vs-subsequent distinction.
- Head arguments are saved with `get_variable`; each `=` goal stages A1/A2 (`put_variable`/`put_value`/`put_constant`) then `builtin_call =/2` (id 24).

## Testing

- New test **`selfhost_codegen_stage_c_conjunction`**: `pconj(R) :- Y = 42, R = Y` — where `Y` is a temporary shared across both goals — compiles from source in a loaded compiler object and runs to **42**.
- Codegen verified **byte-identical** to the host writer's golden for the same program (in SWI). Confirms the allocator's `get_variable`/`put_variable`/`put_value` scheme matches the host exactly.
- Confirms **`numbervars/3` works in loaded objects**.
- Full `wam_object` suite: 0 failures.

## Remaining Stage C pieces (follow-on)

- **Runtime arithmetic**: `is/2` with a *variable* operand (`Y is X + 1`) builds the expression term on the heap via `put_structure` + a functor table (`NF > 0`) and calls `builtin_call is/2`.
- **Non-tail predicate calls** (`call` + `proceed`) with a permanent holding the result across the call.

Both extend this allocator with `put_structure`/`call` plus the functor-table section of the serializer — a clean next increment.

## Docs

`PLAWK_SELFHOST.md` and the JIT roadmap mark conjunction + register allocation landed, with runtime-arithmetic / non-tail-calls noted as the remaining Stage C work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_