### PR TITLE
WAM/LLVM (roadmap #5, milestone 6): self-host Stage C -- non-tail calls (unified compiler)

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -373,8 +373,13 @@ loadable along the way.
   plus **runtime arithmetic — LANDED** (`cgarith/2`: `Var is op(A,B)` →
   `put_structure` + `set_value`/`set_constant` + `builtin_call is/2`, with a
   functor table `NF>0`; `ca(R):-X is 6*7, R=X` → `42`, byte-identical to the
-  host). Non-tail calls and nested expressions remain; (D) widen toward the
-  compiler's own subset — the self-host fixpoint. Stage A surfaced two
+  host), plus **non-tail calls — LANDED** (the unified `cgfull/2`: multi-clause +
+  labels + register allocation + conjunction + arithmetic + `call(Label,arity)`
+  goals; a call whose callee computes, `main0` calls `add1(41,V)` with
+  `add1(X,Y):-Y is X+1` → `42`; also enlarged the transient arena 1→16 MiB, which
+  an allocation-heavy compiler grammar needs). Nested expressions and last-call
+  optimization remain — Stage C's mechanisms are all in place; (D) widen toward
+  the compiler's own subset — the self-host fixpoint. Stage A surfaced two
   loaded-runtime bugs, **both since fixed** (a 64-register-file ceiling that
   corrupted memory for large clauses; `get_structure` not comparing the functor),
   so large clauses and tagged-union dispatch both work now. See

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -301,15 +301,38 @@ shared temporary, arithmetic, and unification — and end to end
 constant-operand (`6*7`) and variable-operand (`R is A+B` after `A=40, B=2`)
 forms compile from source and run to `42`.
 
-**Still to do in Stage C (follow-on):** non-tail predicate calls (`call` +
-`proceed`) with a permanent holding the result across the call, and nested
-arithmetic expressions (recursive `put_structure`). These extend the same
-allocator; the serializer (labels + functor table) already covers what they
-emit.
+**Non-tail predicate calls — LANDED (the unified compiler).** `cgfull/2` merges
+every Stage C piece into one multi-clause compiler: labels + PC table, per-clause
+register allocation, conjunction, runtime arithmetic + functor table, and now
+non-tail predicate-call goals. A call goal `p(Args)` stages A1.. with the args
+(`operand_instr`) then `call(CalleeLabel, arity)` (tag 18) — a *non-tail* call:
+`cp` = the next PC, so execution resumes after the call when the callee
+proceeds, and a permanent (any variable spanning the call, made a Y-register by
+the allocator) carries the result forward. Each clause is `copy_term`'d +
+`numbervars`'d so its variables are clause-local; facts emit head + `proceed`
+(no env). Verified byte-identical to the host writer for
+`[(mnt(R):-helper(A), R=A), helper(42)]`, and end to end
+(`tests/test_wam_object.pl:selfhost_codegen_stage_c_nontail_call`): a passthrough
+call (`mnt` → `helper` → 42) and a compute call whose callee does arithmetic
+(`main0` calls `add1(41,V)`, `add1(X,Y):-Y is X+1`, → 42) both run.
 
-**Deliverable:** the compiler handles the clause shapes a small hand-written
-grammar uses — the point at which "compile a grammar at runtime from source"
-becomes real for non-trivial grammars.
+*Runtime fix this surfaced:* the transient **arena** (put_structure / `=..` /
+reader workspace) was 1 MiB and grows monotonically within a top-level call;
+`wam_arena_alloc` returns null past the cap and callers do not check, so an
+allocation-heavy grammar — a compiler assembling instruction/code lists via
+`append` — silently exhausted it and segfaulted. Enlarged to 16 MiB (headroom
+for compiler workloads). This is why cgfull can now compile a program mixing
+calls *and* arithmetic (which crossed 1 MiB) rather than only one or the other.
+
+**Remaining:** nested arithmetic expressions (recursive `put_structure`) and
+last-call optimization (a tail call as `execute` rather than `call`+`proceed`).
+Both are codegen refinements; the mechanisms are all in place.
+
+**Deliverable — met:** the compiler handles the clause shapes a small
+hand-written grammar uses (multi-clause, conjunction, register allocation,
+unification, arithmetic, predicate calls) — "compile a grammar at runtime from
+source" is now real for non-trivial grammars. Stage D widens the accepted subset
+toward the compiler compiling itself.
 
 ### Stage D — widen toward the compiler's own subset (the fixpoint)
 

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -2554,13 +2554,19 @@ oom:
 }
 
 ; Convenience: init arena if not already initialized, with a default
-; capacity large enough for most kernel workloads (1 MiB).
+; capacity (16 MiB). The arena is transient term-building space for
+; put_structure / =.. / the reader; it grows monotonically within a single
+; top-level call (rewound only by the graph kernels), so an allocation-heavy
+; grammar -- e.g. a compiler grammar assembling instruction and code lists
+; via append -- can need well over the old 1 MiB before its call returns.
+; wam_arena_alloc returns null past the cap and most callers do not check, so
+; exhaustion segfaults; 16 MiB gives realistic compiler workloads headroom.
 define void @wam_arena_ensure() {
   %buf = load i8*, i8** @wam_arena_buf
   %need_init = icmp eq i8* %buf, null
   br i1 %need_init, label %do_init, label %done
 do_init:
-  call void @wam_arena_init(i64 1048576)
+  call void @wam_arena_init(i64 16777216)
   br label %done
 done:
   ret void

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -520,6 +520,72 @@ wz_fname(F, A0, A1) :- atom_codes(F, Cs), wz_n(Cs, A0, A1).
 wz_funcs([], A, A).
 wz_funcs([F|Fs], A0, A2) :- wz_fname(F, A0, A1), wz_funcs(Fs, A1, A2).
 
+% Milestone 6 (self-host) Stage C (non-tail calls): the UNIFIED compiler.
+% cgfull/2 merges every Stage C piece into one multi-clause compiler: labels +
+% PC table (from cgcprog), per-clause register allocation + conjunction (cgconj),
+% runtime arithmetic + functor table (cgarith), and now non-tail predicate-call
+% goals. A call goal p(Args) sets up A1.. with the args (operand_instr) then
+% call(CalleeLabel, arity) (tag 18) -- a non-tail call: cp = the next PC, so
+% execution resumes after the call when the callee proceeds. A permanent holds
+% the result across the call (register allocation makes any variable spanning
+% the call a Y-register). Each clause is copy_term'd + numbervars'd so its
+% variables are clause-local. Facts (no body) emit head + proceed (no env).
+% Verified byte-identical to the host writer for
+% [(mnt(R):-helper(A), R=A), helper(42)] -- a non-tail call whose result A is
+% used after the call.
+cgfull(Src, Wamo) :-
+    read_term_from_atom(Src, Clauses),
+    assign_labels(Clauses, 0, PL),
+    f_collect_all(Clauses, Functors),
+    f_codegen_all(Clauses, PL, Functors, 0, AllIs, PCs),
+    Clauses = [First|_], clause_hb(First, H0, _), functor(H0, P0, A0),
+    pred_name_codes(P0, A0, EntryName),
+    wzf_serialize(0, EntryName, 0, Functors, PCs, AllIs, Codes),
+    atom_codes(Wamo, Codes).
+
+% functor table across all clauses
+f_collect_all([], []).
+f_collect_all([C|Cs], FT) :-
+    ( C = (_ :- B) -> conj_list(B, Gs) ; Gs = [] ),
+    collect_functors(Gs, F1), f_collect_all(Cs, F2), f_merge(F1, F2, FT).
+f_merge([], FT, FT).
+f_merge([F|Fs], A0, FT) :- add_unique(F, A0, A1), f_merge(Fs, A1, FT).
+
+% per-clause codegen, tracking the label->PC list
+f_codegen_all([], _, _, _, [], []).
+f_codegen_all([C0|Cs], PL, FT, PC, All, [PC|PCs]) :-
+    copy_term(C0, C), numbervars(C, 0, _),
+    f_clause_instrs(C, PL, FT, Is), length(Is, N), PC1 is PC + N,
+    f_codegen_all(Cs, PL, FT, PC1, Rest, PCs), append(Is, Rest, All).
+
+f_clause_instrs(Clause, PL, FT, Instrs) :-
+    clause_hb(Clause, Head, Goals), functor(Head, _, Arity),
+    head_args(Head, 1, Arity, [], Init1, HeadIs),
+    (   Goals == []
+    ->  append(HeadIs, [enc(20,0,0,0)], Instrs)              % fact: head + proceed
+    ;   f_goals(Goals, PL, FT, Init1, _, GoalIs),
+        append([enc(16,0,0,0) | HeadIs], GoalIs, B0),
+        append(B0, [enc(17,0,0,0), enc(20,0,0,0)], Instrs)
+    ).
+
+f_goals([], _, _, In, In, []).
+f_goals([G|Gs], PL, FT, In0, In, Is) :-
+    f_goal(G, PL, FT, In0, In1, GI),
+    f_goals(Gs, PL, FT, In1, In, RI), append(GI, RI, Is).
+
+f_goal((L is E), _, FT, In0, In1, Is) :- !, a_goal_instrs((L is E), FT, In0, In1, Is).
+f_goal((L = R),  _, FT, In0, In1, Is) :- !, a_goal_instrs((L = R),  FT, In0, In1, Is).
+f_goal(Goal, PL, _, In0, In, Is) :-               % predicate call
+    functor(Goal, P, A), lookup_label(P, A, PL, Label),
+    call_args(Goal, 1, A, In0, In, SetupIs),
+    append(SetupIs, [enc(18, Label, A, 0)], Is).   % call(Label, arity)
+
+call_args(_, I, Ar, In, In, []) :- I > Ar, !.
+call_args(Goal, I, Ar, In0, In, Is) :-
+    arg(I, Goal, Arg), Ai is I - 1,
+    operand_instr(Arg, Ai, In0, In1, AI),
+    I1 is I + 1, call_args(Goal, I1, Ar, In1, In, R), append(AI, R, Is).
+
 % Register-file ceiling regression: manyperm/1 has 20 variables all live
 % across the mp_barrier call, so the compiler assigns them Y1..Y20. Before
 % the register file was enlarged from [64 x %Value] to [128 x %Value], Y17+
@@ -1212,6 +1278,33 @@ test(selfhost_codegen_stage_c_arithmetic, [condition(clang_available)]) :-
     forall(member(Source, ['ca(R) :- X is 6*7, R = X',
                            'add(R) :- A = 40, B = 2, R is A+B']),
         ( directory_file_path(Dir, 'cgarith_src.txt', SrcPath),
+          setup_call_cleanup(open(SrcPath, write, S0),
+              write(S0, Source), close(S0)),
+          process_create(Host, [CompWamo, SrcPath],
+              [stdout(pipe(S)), stderr(std), process(Pid)]),
+          read_string(S, _, Out),
+          close(S),
+          process_wait(Pid, exit(Status)),
+          assertion(Status == 0),
+          assertion(Out == "42\n") )),
+    !.
+
+% Milestone 6 (self-host) Stage C (non-tail calls): the unified compiler cgfull/2
+% merges labels + register allocation + conjunction + arithmetic + predicate
+% calls. Two multi-clause programs exercise a non-tail call whose result is used
+% after it returns: a passthrough (mnt calls helper, then unifies) and a compute
+% (main calls add1 with a computed arg, doubling via the callee). Both compile
+% from a list-of-clauses source in a loaded object and run to 42.
+test(selfhost_codegen_stage_c_nontail_call, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    forall(member(Source,
+               [ '[(mnt(R):-helper(A), R=A), helper(42)]',
+                 '[(main0(R):-add1(41,V), R=V), (add1(X,Y):-Y is X+1)]' ]),
+        ( directory_file_path(Dir, 'cgfull_src.txt', SrcPath),
           setup_call_cleanup(open(SrcPath, write, S0),
               write(S0, Source), close(S0)),
           process_create(Host, [CompWamo, SrcPath],


### PR DESCRIPTION
## What

Completes Stage C's codegen surface by **merging every piece into one multi-clause compiler**, `cgfull/2`: labels + PC table (cgcprog) + per-clause register allocation + conjunction (cgconj) + runtime arithmetic + functor table (cgarith) + **non-tail predicate-call goals**.

A call goal `p(Args)` stages A1.. with the args (`operand_instr`) then `call(CalleeLabel, arity)` (tag 18) — a **non-tail** call: the interpreter sets `cp` = the next PC, so execution resumes after the call when the callee proceeds, and a permanent (any variable spanning the call, which the allocator places in a Y-register) carries the result forward. Each clause is `copy_term`'d + `numbervars`'d so its variables are clause-local; facts emit head + `proceed` (no env).

## Runtime fix this surfaced (arena exhaustion → segfault)

While testing, a program mixing calls *and* arithmetic **segfaulted cgfull during compilation** — while calls-only or arithmetic-only worked. `gdb` pinned it: a `%Value` store to a **null arena pointer at the 1 MiB boundary**. The transient **arena** (put_structure / `=..` / reader workspace) grows monotonically within a top-level call, `wam_arena_alloc` returns null past the cap, and callers don't check — so an allocation-heavy grammar (a compiler assembling instruction/code lists via `append`) silently exhausted 1 MiB and crashed. The call+arith program crossed 1 MiB where either alone stayed under.

**Fix:** enlarged the arena 1 → 16 MiB (headroom for compiler workloads).

## Testing

- **Byte-identical** to the host writer's golden for `[(mnt(R):-helper(A), R=A), helper(42)]`.
- New test **`selfhost_codegen_stage_c_nontail_call`** (end to end via the eval host):
  - passthrough call: `mnt` → `helper` → **42**
  - compute call whose callee does arithmetic: `main0` calls `add1(41,V)`, `add1(X,Y):-Y is X+1` → **42**
- Full `wam_object`, `test_llvm_target`, and plawk execution suites: **0 failures** (the arena change is a runtime change, so all LLVM objects were re-exercised).

## Where Stage C stands

The compiler grammar now handles multi-clause programs with conjunction, register allocation, unification, arithmetic, and predicate calls — the deliverable for Stage C ("compile a grammar at runtime from source" is real for non-trivial grammars). Remaining refinements: nested arithmetic expressions (recursive `put_structure`) and last-call optimization (tail call as `execute`). The mechanisms are all in place.

## Docs

`PLAWK_SELFHOST.md` and the JIT roadmap updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_