### PR TITLE
Add confirmatory Σ(hop) runner

### DIFF
--- a/prototypes/mu_cosine/sigma_hop_confirmatory.py
+++ b/prototypes/mu_cosine/sigma_hop_confirmatory.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import os
 import sys
+import warnings
 from dataclasses import dataclass
 
 import numpy as np
@@ -27,11 +28,21 @@ from mu_attention import OPS, Tokenizer, load_dag
 
 DIR = ["subcategory", "subtopic", "element_of", "super_category"]
 SYM = ["see_also", "assoc"]
+SCHEMA_VERSION = 1
+EXPECTED_HOPS = {1, 2, 3, 4, 5}
 
 
-@dataclass
+class ConfirmatoryInputError(ValueError):
+    pass
+
+
+class OverlapError(ConfirmatoryInputError):
+    pass
+
+
+@dataclass(frozen=True)
 class ConfirmatoryData:
-    pairs: list[tuple[str, str]]
+    pairs: tuple[tuple[str, str], ...]
     hop: np.ndarray
     D: np.ndarray
     S: np.ndarray
@@ -45,6 +56,7 @@ def sigma_of_hop(params, hop):
 
 
 def biv_nll(rD, rS, sD, sS, rho):
+    # Apply the same numerical boundary to sample-rho baselines and tanh-parametrized smooth rhos.
     rho = np.clip(rho, -0.98, 0.98)
     sD = np.maximum(sD, 1e-6)
     sS = np.maximum(sS, 1e-6)
@@ -70,12 +82,15 @@ def fit_sigma_of_hop(rD, rS, hop):
         sD, sS, rho = sigma_of_hop(params, hop)
         return biv_nll(rD, rS, sD, sS, rho).mean()
 
-    return minimize(
+    result = minimize(
         objective,
         p0,
         method="Nelder-Mead",
         options={"maxiter": 5000, "xatol": 1e-5, "fatol": 1e-7},
-    ).x
+    )
+    if not result.success:
+        warnings.warn(f"Nelder-Mead did not converge while fitting Sigma(hop): {result.message}")
+    return result.x
 
 
 def descendant_disjoint_split(pairs, seed, held_frac=0.30):
@@ -89,6 +104,12 @@ def descendant_disjoint_split(pairs, seed, held_frac=0.30):
 
 
 def residuals_for_split(D, S, X, train, held):
+    rank = np.linalg.matrix_rank(X[train])
+    if rank < X.shape[1]:
+        warnings.warn(
+            f"rank-deficient residual mean design on split: rank {rank} < {X.shape[1]}; "
+            "using numpy lstsq minimum-norm solution"
+        )
     out = []
     for y in (D, S):
         beta, *_ = np.linalg.lstsq(X[train], y[train], rcond=None)
@@ -143,20 +164,27 @@ def mean_gain(data, splits, hop_for_sigma):
     }
 
 
-def permutation_test(data, splits, k=1000, seed=1):
+def permutation_test(data, splits, k=1000, seed=1, allow_small_k=False):
+    if k < 1000 and not allow_small_k:
+        raise ValueError("permutation_test requires k >= 1000 for confirmatory use")
     observed = mean_gain(data, splits, data.hop)
     rng = np.random.default_rng(seed)
+    # Sequential RNG use is intentional: it gives a reproducible ordered stream of hop shuffles for the audit log.
     null = np.array(
         [mean_gain(data, splits, data.hop[rng.permutation(len(data.hop))])["mean_gain"] for _ in range(k)]
     )
     p = (1 + int(np.sum(null >= observed["mean_gain"]))) / (k + 1)
+    confirmed = bool(observed["mean_gain"] > 0 and p < 0.01)
     return {
         **observed,
         "null_mean": float(null.mean()),
         "null_p95": float(np.percentile(null, 95)),
         "permutation_k": int(k),
         "permutation_p": float(p),
-        "confirmed": bool(observed["mean_gain"] > 0 and p < 0.01),
+        "decision_inputs": {"mean_gain": float(observed["mean_gain"]), "permutation_p": float(p)},
+        # The positive-gain check repeats the preregistered direction even though the p-value is upper-tail.
+        "confirmed": confirmed,
+        "decision": "confirmed" if confirmed else "not confirmed",
     }
 
 
@@ -166,17 +194,45 @@ def gmu(obj, rel):
 
 
 def load_scored_pairs(score_in, responses, prefix="transitive_h"):
-    rows = [ln.rstrip("\n").split("\t") for ln in open(score_in, encoding="utf-8") if not ln.startswith("#")]
+    with open(score_in, encoding="utf-8") as fh:
+        rows = [ln.rstrip("\n").split("\t") for ln in fh if not ln.startswith("#")]
     byid = parse_responses(responses)
     pairs, hop, D, S = [], [], [], []
+    dropped_no_response = 0
+    dropped_malformed = 0
     for idx, row in enumerate(rows):
-        if idx not in byid or len(row) < 5 or not row[4].startswith(prefix):
+        if len(row) < 5:
+            dropped_malformed += 1
             continue
+        if not row[4].startswith(prefix):
+            continue
+        if idx not in byid:
+            dropped_no_response += 1
+            continue
+        raw_hop = row[4][len(prefix) :]
+        try:
+            h = int(raw_hop)
+        except ValueError as exc:
+            raise ConfirmatoryInputError(
+                f"cannot parse hop count {raw_hop!r} from row {idx} in {score_in}"
+            ) from exc
         pairs.append((row[0], row[1]))
-        hop.append(int(row[4][len(prefix) :]))
-        D.append(max(gmu(byid[idx], rel) for rel in DIR))
-        S.append(max(gmu(byid[idx], rel) for rel in SYM))
-    return pairs, np.array(hop), np.array(D), np.array(S)
+        hop.append(h)
+        D.append(max((gmu(byid[idx], rel) for rel in DIR), default=0.0))
+        S.append(max((gmu(byid[idx], rel) for rel in SYM), default=0.0))
+    if dropped_malformed:
+        warnings.warn(f"{dropped_malformed} malformed score rows ignored in {score_in}")
+    if dropped_no_response:
+        warnings.warn(f"{dropped_no_response} {prefix} rows dropped: no LLM response found in {responses}")
+    if not pairs:
+        raise ConfirmatoryInputError(f"no scored {prefix} pairs with responses found in {score_in}")
+    return tuple(pairs), np.array(hop), np.array(D), np.array(S)
+
+
+def validate_hop_range(hop):
+    got = {int(h) for h in set(hop)}
+    if got != EXPECTED_HOPS:
+        raise ConfirmatoryInputError(f"expected hop levels {sorted(EXPECTED_HOPS)}, got {sorted(got)}")
 
 
 def load_exploratory_nodes(graph_path):
@@ -194,28 +250,38 @@ def load_exploratory_nodes(graph_path):
 
 def assert_no_node_overlap(pairs, exploratory_graph):
     if not exploratory_graph:
-        return []
+        raise ConfirmatoryInputError("--exploratory-graph is required for the preregistered no-overlap check")
     exploratory_nodes = load_exploratory_nodes(exploratory_graph)
     confirmatory_nodes = {n for pair in pairs for n in pair}
     overlap = sorted(confirmatory_nodes & exploratory_nodes)
     if overlap:
         preview = ", ".join(overlap[:10])
-        raise SystemExit(
-            f"confirmatory pairs overlap exploratory graph nodes ({len(overlap)} total): {preview}"
-        )
+        raise OverlapError(f"confirmatory pairs overlap exploratory graph nodes ({len(overlap)} total): {preview}")
     return overlap
 
 
-def build_confirmatory_data(score_in, responses, e5_cache, graph, model_path, device, prefix, exploratory_graph=None):
+def load_confirmatory_labels(score_in, responses, prefix, exploratory_graph):
     pairs, hop, D, S = load_scored_pairs(score_in, responses, prefix=prefix)
     assert_no_node_overlap(pairs, exploratory_graph)
+    validate_hop_range(hop)
+    return pairs, hop, D, S
 
+
+def load_e5_cache_and_filter(pairs, hop, D, S, e5_cache):
+    # This project cache is a trusted local torch pickle produced by the scoring pipeline. Do not use untrusted caches.
     cache = torch.load(e5_cache, weights_only=False)
     idx = {name: i for i, name in enumerate(cache["names"])}
-    keep = [i for i, (x, y) in enumerate(pairs) if x in idx and y in idx]
-    pairs = [pairs[i] for i in keep]
-    hop, D, S = hop[keep], D[keep], S[keep]
+    keep = np.array([i for i, (x, y) in enumerate(pairs) if x in idx and y in idx], dtype=int)
+    dropped = len(pairs) - len(keep)
+    if dropped:
+        warnings.warn(f"{dropped}/{len(pairs)} scored pairs dropped: endpoint missing from e5 cache {e5_cache}")
+    if len(keep) == 0:
+        raise ConfirmatoryInputError("no scored pairs survived the e5-cache endpoint filter")
+    filtered_pairs = tuple(pairs[i] for i in keep)
+    return cache, idx, filtered_pairs, hop[keep], D[keep], S[keep]
 
+
+def build_confirmatory_features(pairs, cache, idx, graph, model_path, device):
     parents, _, deg = load_dag(graph)
     tokenizer = Tokenizer(cache["query"], cache["passage"], idx, parents, deg)
     model = build_model(model_path, device)
@@ -233,22 +299,39 @@ def build_confirmatory_data(score_in, responses, e5_cache, graph, model_path, de
     muD = np.maximum(mu("HIER", pairs), mu("HIER", [(y, x) for x, y in pairs]))
     muS = mu("SYM", pairs)
     gd = np.array([hit_prob(parents, x, y) for x, y in pairs])
-    X = np.column_stack([muD, muS, gd, np.ones(len(pairs))])
+    return np.column_stack([muD, muS, gd, np.ones(len(pairs))])
+
+
+def build_confirmatory_data_from_labels(pairs, hop, D, S, e5_cache, graph, model_path, device):
+    cache, idx, pairs, hop, D, S = load_e5_cache_and_filter(pairs, hop, D, S, e5_cache)
+    validate_hop_range(hop)
+    X = build_confirmatory_features(pairs, cache, idx, graph, model_path, device)
     return ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=X)
+
+
+def build_confirmatory_data(score_in, responses, e5_cache, graph, model_path, device, prefix, exploratory_graph):
+    pairs, hop, D, S = load_confirmatory_labels(score_in, responses, prefix, exploratory_graph)
+    return build_confirmatory_data_from_labels(pairs, hop, D, S, e5_cache, graph, model_path, device)
+
+
+def _one_line(value):
+    return str(value).replace("\r", " ").replace("\n", " ")
 
 
 def render_markdown(result, args, n_pairs, hop_counts, skipped):
     decision = "confirmed" if result["confirmed"] else "not confirmed"
+    corpus_note = _one_line(args.corpus_note)
+    judge_note = _one_line(args.judge_note)
     return f"""# Confirmatory Σ(hop) run
 
 Preregistration: `PREREG_sigma_hop_confirmatory.md`
 
 ```text
-fresh corpus dump/root: {args.corpus_note}
+fresh corpus dump/root: {corpus_note}
 node-overlap check with 100k_cats: passed
 n scored pairs: {n_pairs}
 hop counts: {hop_counts}
-judge/prompt/model: {args.judge_note}
+judge/prompt/model: {judge_note}
 valid descendant-disjoint splits: {result['valid_splits']}
 mean held pairs/split: {result['mean_held_pairs']:.1f}
 observed mean gain: {result['mean_gain']:+.6f}
@@ -302,39 +385,52 @@ def main():
     ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     ap.add_argument("--json-out", default=None)
     ap.add_argument("--md-out", default=None)
-    ap.add_argument("--corpus-note", default="TODO record dump/root before scoring")
-    ap.add_argument("--judge-note", default="gpt-5.5-low, PR #3517 prompt template")
+    ap.add_argument("--corpus-note", required=True, help="fresh corpus dump/root, recorded before scoring")
+    ap.add_argument("--judge-note", required=True, help="judge model, prompt template, and frozen predictor model provenance")
     args = ap.parse_args()
 
     validate_preregistered_cli(args)
     device = torch.device(args.device)
-    data = build_confirmatory_data(
-        args.score_in,
-        args.responses,
-        args.e5_cache,
-        args.graph,
-        args.model,
-        device,
-        args.prefix,
-        exploratory_graph=args.exploratory_graph,
-    )
-    splits, skipped = valid_splits(
-        data,
-        range(args.splits),
-        held_frac=args.held_frac,
-        min_train=args.min_train,
-        min_held=args.min_held,
-    )
-    if not splits:
-        raise SystemExit("no valid descendant-disjoint splits survived minimum-size guards")
+    try:
+        pairs, hop, D, S = load_confirmatory_labels(args.score_in, args.responses, args.prefix, args.exploratory_graph)
+        preflight = ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=np.ones((len(pairs), 1)))
+        splits, skipped = valid_splits(
+            preflight,
+            range(args.splits),
+            held_frac=args.held_frac,
+            min_train=args.min_train,
+            min_held=args.min_held,
+        )
+        if not splits:
+            raise ConfirmatoryInputError("no valid descendant-disjoint splits before model inference")
+
+        cache, idx, pairs, hop, D, S = load_e5_cache_and_filter(pairs, hop, D, S, args.e5_cache)
+        validate_hop_range(hop)
+        preflight = ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=np.ones((len(pairs), 1)))
+        splits, skipped = valid_splits(
+            preflight,
+            range(args.splits),
+            held_frac=args.held_frac,
+            min_train=args.min_train,
+            min_held=args.min_held,
+        )
+        if not splits:
+            raise ConfirmatoryInputError("no valid descendant-disjoint splits survived e5-cache filtering")
+
+        X = build_confirmatory_features(pairs, cache, idx, args.graph, args.model, device)
+        data = ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=X)
+    except ConfirmatoryInputError as exc:
+        raise SystemExit(str(exc)) from exc
 
     result = permutation_test(data, splits, k=args.permutations, seed=args.perm_seed)
     result.update(
         {
+            "schema_version": SCHEMA_VERSION,
             "n_pairs": len(data.pairs),
             "hop_counts": {int(h): int(np.sum(data.hop == h)) for h in sorted(set(data.hop))},
             "valid_splits": len(splits),
             "skipped_splits": skipped,
+            "split_weighting": "equal_by_split",
             "decision_rule": "confirmed iff mean_gain > 0 and one-sided hop-shuffle p < 0.01",
         }
     )

--- a/prototypes/mu_cosine/sigma_hop_confirmatory.py
+++ b/prototypes/mu_cosine/sigma_hop_confirmatory.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Run the pre-registered confirmatory Σ(hop) test.
+
+This is the implementation companion to `PREREG_sigma_hop_confirmatory.md`. It keeps the preregistered decision
+surface deliberately narrow: descendant-disjoint splits, constant-Σ baseline, smooth 6-parameter Σ(hop), and a
+one-sided hop-shuffle permutation test on the averaged held-out NLL gain.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from scipy.optimize import minimize
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from emit_direction_blend import parse_responses
+from emit_transitive_hops import hit_prob
+from eval_relatedness import build_model
+from mu_attention import OPS, Tokenizer, load_dag
+
+
+DIR = ["subcategory", "subtopic", "element_of", "super_category"]
+SYM = ["see_also", "assoc"]
+
+
+@dataclass
+class ConfirmatoryData:
+    pairs: list[tuple[str, str]]
+    hop: np.ndarray
+    D: np.ndarray
+    S: np.ndarray
+    X: np.ndarray
+
+
+def sigma_of_hop(params, hop):
+    """Pre-registered smooth covariance: log-linear sigmas and tanh correlation."""
+    aD, bD, aS, bS, c, e = params
+    return np.exp(aD + bD * hop), np.exp(aS + bS * hop), np.tanh(c + e * hop)
+
+
+def biv_nll(rD, rS, sD, sS, rho):
+    rho = np.clip(rho, -0.98, 0.98)
+    sD = np.maximum(sD, 1e-6)
+    sS = np.maximum(sS, 1e-6)
+    zD, zS = rD / sD, rS / sS
+    q = (zD**2 - 2 * rho * zD * zS + zS**2) / (1 - rho**2)
+    return np.log(2 * np.pi) + np.log(sD * sS) + 0.5 * np.log(1 - rho**2) + 0.5 * q
+
+
+def fit_sigma_of_hop(rD, rS, hop):
+    corr = np.corrcoef(rD, rS)[0, 1] if len(rD) > 1 else 0.0
+    if not np.isfinite(corr):
+        corr = 0.0
+    p0 = [
+        np.log(np.std(rD) + 1e-6),
+        0.0,
+        np.log(np.std(rS) + 1e-6),
+        0.0,
+        np.arctanh(np.clip(corr, -0.9, 0.9)),
+        0.0,
+    ]
+
+    def objective(params):
+        sD, sS, rho = sigma_of_hop(params, hop)
+        return biv_nll(rD, rS, sD, sS, rho).mean()
+
+    return minimize(
+        objective,
+        p0,
+        method="Nelder-Mead",
+        options={"maxiter": 5000, "xatol": 1e-5, "fatol": 1e-7},
+    ).x
+
+
+def descendant_disjoint_split(pairs, seed, held_frac=0.30):
+    rng = np.random.default_rng(seed)
+    descendants = sorted({x for x, _ in pairs})
+    rng.shuffle(descendants)
+    held_desc = set(descendants[: max(1, int(held_frac * len(descendants)))])
+    train = np.array([i for i, (x, _) in enumerate(pairs) if x not in held_desc], dtype=int)
+    held = np.array([i for i, (x, _) in enumerate(pairs) if x in held_desc], dtype=int)
+    return train, held
+
+
+def residuals_for_split(D, S, X, train, held):
+    out = []
+    for y in (D, S):
+        beta, *_ = np.linalg.lstsq(X[train], y[train], rcond=None)
+        out.append((y[train] - X[train] @ beta, y[held] - X[held] @ beta))
+    return out
+
+
+def split_gain(data, train, held, hop_for_sigma):
+    (rD_train, rD_held), (rS_train, rS_held) = residuals_for_split(data.D, data.S, data.X, train, held)
+    sD = np.std(rD_train) + 1e-6
+    sS = np.std(rS_train) + 1e-6
+    rho = np.corrcoef(rD_train, rS_train)[0, 1]
+    if not np.isfinite(rho):
+        rho = 0.0
+
+    const_nll = biv_nll(rD_held, rS_held, sD, sS, rho).mean()
+    params = fit_sigma_of_hop(rD_train, rS_train, hop_for_sigma[train].astype(float))
+    sDf, sSf, rhof = sigma_of_hop(params, hop_for_sigma[held].astype(float))
+    smooth_nll = biv_nll(rD_held, rS_held, sDf, sSf, rhof).mean()
+    return const_nll - smooth_nll, const_nll, smooth_nll
+
+
+def valid_splits(data, seeds, held_frac=0.30, min_train=30, min_held=12):
+    splits = []
+    skipped = []
+    for seed in seeds:
+        train, held = descendant_disjoint_split(data.pairs, seed, held_frac=held_frac)
+        if len(train) < min_train or len(held) < min_held:
+            skipped.append({"seed": seed, "train": len(train), "held": len(held)})
+            continue
+        splits.append((seed, train, held))
+    return splits, skipped
+
+
+def mean_gain(data, splits, hop_for_sigma):
+    gains = []
+    const_nll = []
+    smooth_nll = []
+    held_sizes = []
+    for _, train, held in splits:
+        gain, c_nll, s_nll = split_gain(data, train, held, hop_for_sigma)
+        gains.append(gain)
+        const_nll.append(c_nll)
+        smooth_nll.append(s_nll)
+        held_sizes.append(len(held))
+    return {
+        "mean_gain": float(np.mean(gains)),
+        "split_gains": [float(x) for x in gains],
+        "constant_nll": float(np.mean(const_nll)),
+        "sigma_hop_nll": float(np.mean(smooth_nll)),
+        "mean_held_pairs": float(np.mean(held_sizes)),
+    }
+
+
+def permutation_test(data, splits, k=1000, seed=1):
+    observed = mean_gain(data, splits, data.hop)
+    rng = np.random.default_rng(seed)
+    null = np.array(
+        [mean_gain(data, splits, data.hop[rng.permutation(len(data.hop))])["mean_gain"] for _ in range(k)]
+    )
+    p = (1 + int(np.sum(null >= observed["mean_gain"]))) / (k + 1)
+    return {
+        **observed,
+        "null_mean": float(null.mean()),
+        "null_p95": float(np.percentile(null, 95)),
+        "permutation_k": int(k),
+        "permutation_p": float(p),
+        "confirmed": bool(observed["mean_gain"] > 0 and p < 0.01),
+    }
+
+
+def gmu(obj, rel):
+    val = (obj.get(rel, {}) or {}).get("mu_fwd" if rel in DIR else "mu", 0)
+    return float(val)
+
+
+def load_scored_pairs(score_in, responses, prefix="transitive_h"):
+    rows = [ln.rstrip("\n").split("\t") for ln in open(score_in, encoding="utf-8") if not ln.startswith("#")]
+    byid = parse_responses(responses)
+    pairs, hop, D, S = [], [], [], []
+    for idx, row in enumerate(rows):
+        if idx not in byid or len(row) < 5 or not row[4].startswith(prefix):
+            continue
+        pairs.append((row[0], row[1]))
+        hop.append(int(row[4][len(prefix) :]))
+        D.append(max(gmu(byid[idx], rel) for rel in DIR))
+        S.append(max(gmu(byid[idx], rel) for rel in SYM))
+    return pairs, np.array(hop), np.array(D), np.array(S)
+
+
+def load_exploratory_nodes(graph_path):
+    nodes = set()
+    with open(graph_path, encoding="utf-8") as f:
+        for line in f:
+            if not line.strip() or line.startswith("#"):
+                continue
+            cols = line.rstrip("\n").split("\t")
+            if len(cols) >= 2:
+                nodes.add(cols[0])
+                nodes.add(cols[1])
+    return nodes
+
+
+def assert_no_node_overlap(pairs, exploratory_graph):
+    if not exploratory_graph:
+        return []
+    exploratory_nodes = load_exploratory_nodes(exploratory_graph)
+    confirmatory_nodes = {n for pair in pairs for n in pair}
+    overlap = sorted(confirmatory_nodes & exploratory_nodes)
+    if overlap:
+        preview = ", ".join(overlap[:10])
+        raise SystemExit(
+            f"confirmatory pairs overlap exploratory graph nodes ({len(overlap)} total): {preview}"
+        )
+    return overlap
+
+
+def build_confirmatory_data(score_in, responses, e5_cache, graph, model_path, device, prefix, exploratory_graph=None):
+    pairs, hop, D, S = load_scored_pairs(score_in, responses, prefix=prefix)
+    assert_no_node_overlap(pairs, exploratory_graph)
+
+    cache = torch.load(e5_cache, weights_only=False)
+    idx = {name: i for i, name in enumerate(cache["names"])}
+    keep = [i for i, (x, y) in enumerate(pairs) if x in idx and y in idx]
+    pairs = [pairs[i] for i in keep]
+    hop, D, S = hop[keep], D[keep], S[keep]
+
+    parents, _, deg = load_dag(graph)
+    tokenizer = Tokenizer(cache["query"], cache["passage"], idx, parents, deg)
+    model = build_model(model_path, device)
+
+    def mu(op, pair_batch):
+        rows = [(x, y, OPS[op]) for x, y in pair_batch]
+        out = []
+        for i in range(0, len(rows), 512):
+            batch = tokenizer.build(rows[i : i + 512], train=False)
+            batch = {k: (v.to(device) if torch.is_tensor(v) else v) for k, v in batch.items()}
+            with torch.no_grad():
+                out += model(**batch).cpu().tolist()
+        return np.array(out)
+
+    muD = np.maximum(mu("HIER", pairs), mu("HIER", [(y, x) for x, y in pairs]))
+    muS = mu("SYM", pairs)
+    gd = np.array([hit_prob(parents, x, y) for x, y in pairs])
+    X = np.column_stack([muD, muS, gd, np.ones(len(pairs))])
+    return ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=X)
+
+
+def render_markdown(result, args, n_pairs, hop_counts, skipped):
+    decision = "confirmed" if result["confirmed"] else "not confirmed"
+    return f"""# Confirmatory Σ(hop) run
+
+Preregistration: `PREREG_sigma_hop_confirmatory.md`
+
+```text
+fresh corpus dump/root: {args.corpus_note}
+node-overlap check with 100k_cats: passed
+n scored pairs: {n_pairs}
+hop counts: {hop_counts}
+judge/prompt/model: {args.judge_note}
+valid descendant-disjoint splits: {result['valid_splits']}
+mean held pairs/split: {result['mean_held_pairs']:.1f}
+observed mean gain: {result['mean_gain']:+.6f}
+constant-Σ NLL: {result['constant_nll']:.6f}
+Σ(hop) NLL: {result['sigma_hop_nll']:.6f}
+hop-shuffle null mean: {result['null_mean']:+.6f}
+hop-shuffle null 95%ile: {result['null_p95']:+.6f}
+K: {result['permutation_k']}
+permutation p: {result['permutation_p']:.6f}
+decision: {decision}
+skipped splits: {len(skipped)}
+```
+"""
+
+
+def validate_preregistered_cli(args):
+    expected = {
+        "splits": 40,
+        "held_frac": 0.30,
+        "min_train": 30,
+        "min_held": 12,
+    }
+    actual = {
+        "splits": args.splits,
+        "held_frac": args.held_frac,
+        "min_train": args.min_train,
+        "min_held": args.min_held,
+    }
+    mismatches = [f"{k}={actual[k]} (expected {v})" for k, v in expected.items() if actual[k] != v]
+    if mismatches:
+        raise SystemExit("non-preregistered split protocol: " + "; ".join(mismatches))
+    if args.permutations < 1000:
+        raise SystemExit("--permutations must be >= 1000 for the preregistered confirmatory test")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--score-in", required=True)
+    ap.add_argument("--responses", required=True)
+    ap.add_argument("--e5-cache", required=True)
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--model", default="model_prod.pt")
+    ap.add_argument("--prefix", default="transitive_h")
+    ap.add_argument("--exploratory-graph", required=True, help="PR #3517 100k_cats/category_parent.tsv for required no-overlap check")
+    ap.add_argument("--splits", type=int, default=40)
+    ap.add_argument("--held-frac", type=float, default=0.30)
+    ap.add_argument("--min-train", type=int, default=30)
+    ap.add_argument("--min-held", type=int, default=12)
+    ap.add_argument("--permutations", type=int, default=1000)
+    ap.add_argument("--perm-seed", type=int, default=1)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    ap.add_argument("--json-out", default=None)
+    ap.add_argument("--md-out", default=None)
+    ap.add_argument("--corpus-note", default="TODO record dump/root before scoring")
+    ap.add_argument("--judge-note", default="gpt-5.5-low, PR #3517 prompt template")
+    args = ap.parse_args()
+
+    validate_preregistered_cli(args)
+    device = torch.device(args.device)
+    data = build_confirmatory_data(
+        args.score_in,
+        args.responses,
+        args.e5_cache,
+        args.graph,
+        args.model,
+        device,
+        args.prefix,
+        exploratory_graph=args.exploratory_graph,
+    )
+    splits, skipped = valid_splits(
+        data,
+        range(args.splits),
+        held_frac=args.held_frac,
+        min_train=args.min_train,
+        min_held=args.min_held,
+    )
+    if not splits:
+        raise SystemExit("no valid descendant-disjoint splits survived minimum-size guards")
+
+    result = permutation_test(data, splits, k=args.permutations, seed=args.perm_seed)
+    result.update(
+        {
+            "n_pairs": len(data.pairs),
+            "hop_counts": {int(h): int(np.sum(data.hop == h)) for h in sorted(set(data.hop))},
+            "valid_splits": len(splits),
+            "skipped_splits": skipped,
+            "decision_rule": "confirmed iff mean_gain > 0 and one-sided hop-shuffle p < 0.01",
+        }
+    )
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as f:
+            json.dump(result, f, indent=2, sort_keys=True)
+            f.write("\n")
+    if args.md_out:
+        md = render_markdown(result, args, len(data.pairs), result["hop_counts"], skipped)
+        with open(args.md_out, "w", encoding="utf-8") as f:
+            f.write(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/test_sigma_hop_confirmatory.py
+++ b/prototypes/mu_cosine/test_sigma_hop_confirmatory.py
@@ -13,8 +13,11 @@ import numpy as np
 
 from sigma_hop_confirmatory import (
     ConfirmatoryData,
+    ConfirmatoryInputError,
+    OverlapError,
     assert_no_node_overlap,
     descendant_disjoint_split,
+    load_scored_pairs,
     permutation_test,
     validate_preregistered_cli,
     valid_splits,
@@ -35,8 +38,14 @@ def _synthetic_data(n_desc=24, seed=0):
     hop = np.array(hop)
     D = np.array(D)
     S = np.array(S)
-    X = np.ones((len(pairs), 1))
-    return ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=X)
+    n = len(pairs)
+    X = np.column_stack([
+        rng.uniform(0.1, 0.9, n),
+        rng.uniform(0.1, 0.9, n),
+        rng.uniform(0.0, 1.0, n),
+        np.ones(n),
+    ])
+    return ConfirmatoryData(pairs=tuple(pairs), hop=hop, D=D, S=S, X=X)
 
 
 def test_descendant_disjoint_split_keeps_all_hops_together():
@@ -55,10 +64,20 @@ def test_assert_no_node_overlap_blocks_exploratory_nodes():
     try:
         try:
             assert_no_node_overlap([("fresh_child", "old_parent")], path)
-        except SystemExit as exc:
+        except OverlapError as exc:
             assert "overlap exploratory graph nodes" in str(exc)
         else:
             raise AssertionError("expected overlap check to abort")
+    finally:
+        os.unlink(path)
+
+
+def test_assert_no_node_overlap_allows_clean_pairs():
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as f:
+        f.write("old_child\told_parent\n")
+        path = f.name
+    try:
+        assert assert_no_node_overlap((("fresh_child", "fresh_parent"),), path) == []
     finally:
         os.unlink(path)
 
@@ -68,7 +87,7 @@ def test_permutation_result_reports_preregistered_decision_fields():
     splits, skipped = valid_splits(data, range(4), min_train=30, min_held=12)
     assert len(splits) == 4
     assert skipped == []
-    result = permutation_test(data, splits, k=5, seed=2)
+    result = permutation_test(data, splits, k=5, seed=2, allow_small_k=True)
     for key in [
         "mean_gain",
         "constant_nll",
@@ -77,11 +96,46 @@ def test_permutation_result_reports_preregistered_decision_fields():
         "null_p95",
         "permutation_k",
         "permutation_p",
+        "decision_inputs",
         "confirmed",
+        "decision",
     ]:
         assert key in result
     assert result["permutation_k"] == 5
     assert 0 < result["permutation_p"] <= 1
+
+
+def test_permutation_test_rejects_small_k_by_default():
+    data = _synthetic_data()
+    splits, _ = valid_splits(data, range(4), min_train=30, min_held=12)
+    try:
+        permutation_test(data, splits, k=999, seed=2)
+    except ValueError as exc:
+        assert "k >= 1000" in str(exc)
+    else:
+        raise AssertionError("expected confirmatory permutation K guard to abort")
+
+
+def test_load_scored_pairs_reports_bad_hop_with_context():
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as score, tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", delete=False
+    ) as resp:
+        score.write("child\tparent\tx\ty\ttransitive_hx\n")
+        resp.write(
+            '[{"id": 0, "subcategory": {"mu_fwd": 0.7}, "assoc": {"mu": 0.2}}]'
+        )
+        score_path, resp_path = score.name, resp.name
+    try:
+        try:
+            load_scored_pairs(score_path, resp_path)
+        except ConfirmatoryInputError as exc:
+            assert "cannot parse hop count" in str(exc)
+            assert "row 0" in str(exc)
+        else:
+            raise AssertionError("expected malformed hop to abort")
+    finally:
+        os.unlink(score_path)
+        os.unlink(resp_path)
 
 
 def test_cli_guard_rejects_non_preregistered_split_protocol():
@@ -92,6 +146,16 @@ def test_cli_guard_rejects_non_preregistered_split_protocol():
         assert "non-preregistered split protocol" in str(exc)
     else:
         raise AssertionError("expected non-preregistered protocol to abort")
+
+
+def test_cli_guard_rejects_too_few_permutations():
+    args = Namespace(splits=40, held_frac=0.30, min_train=30, min_held=12, permutations=999)
+    try:
+        validate_preregistered_cli(args)
+    except SystemExit as exc:
+        assert "permutations must be >= 1000" in str(exc)
+    else:
+        raise AssertionError("expected too-few permutations to abort")
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/test_sigma_hop_confirmatory.py
+++ b/prototypes/mu_cosine/test_sigma_hop_confirmatory.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Unit checks for the preregistered Σ(hop) confirmatory runner.
+
+These tests stay synthetic: they validate the frozen mechanics without needing scored LLM data, e5 caches, or a
+torch model checkpoint.
+"""
+
+import os
+import tempfile
+from argparse import Namespace
+
+import numpy as np
+
+from sigma_hop_confirmatory import (
+    ConfirmatoryData,
+    assert_no_node_overlap,
+    descendant_disjoint_split,
+    permutation_test,
+    validate_preregistered_cli,
+    valid_splits,
+)
+
+
+def _synthetic_data(n_desc=24, seed=0):
+    rng = np.random.default_rng(seed)
+    pairs, hop, D, S = [], [], [], []
+    for d in range(n_desc):
+        desc = f"desc_{d}"
+        for h in range(1, 6):
+            pairs.append((desc, f"ancestor_{d}_{h}"))
+            hop.append(h)
+            scale = 0.05 + 0.025 * h
+            D.append(0.5 + rng.normal(0, scale))
+            S.append(0.4 + rng.normal(0, scale * (1.2 if h >= 4 else 0.8)))
+    hop = np.array(hop)
+    D = np.array(D)
+    S = np.array(S)
+    X = np.ones((len(pairs), 1))
+    return ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=X)
+
+
+def test_descendant_disjoint_split_keeps_all_hops_together():
+    data = _synthetic_data(n_desc=8)
+    train, held = descendant_disjoint_split(data.pairs, seed=3)
+    train_desc = {data.pairs[i][0] for i in train}
+    held_desc = {data.pairs[i][0] for i in held}
+    assert train_desc.isdisjoint(held_desc)
+    assert len(train) + len(held) == len(data.pairs)
+
+
+def test_assert_no_node_overlap_blocks_exploratory_nodes():
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as f:
+        f.write("old_child\told_parent\n")
+        path = f.name
+    try:
+        try:
+            assert_no_node_overlap([("fresh_child", "old_parent")], path)
+        except SystemExit as exc:
+            assert "overlap exploratory graph nodes" in str(exc)
+        else:
+            raise AssertionError("expected overlap check to abort")
+    finally:
+        os.unlink(path)
+
+
+def test_permutation_result_reports_preregistered_decision_fields():
+    data = _synthetic_data()
+    splits, skipped = valid_splits(data, range(4), min_train=30, min_held=12)
+    assert len(splits) == 4
+    assert skipped == []
+    result = permutation_test(data, splits, k=5, seed=2)
+    for key in [
+        "mean_gain",
+        "constant_nll",
+        "sigma_hop_nll",
+        "null_mean",
+        "null_p95",
+        "permutation_k",
+        "permutation_p",
+        "confirmed",
+    ]:
+        assert key in result
+    assert result["permutation_k"] == 5
+    assert 0 < result["permutation_p"] <= 1
+
+
+def test_cli_guard_rejects_non_preregistered_split_protocol():
+    args = Namespace(splits=20, held_frac=0.30, min_train=30, min_held=12, permutations=1000)
+    try:
+        validate_preregistered_cli(args)
+    except SystemExit as exc:
+        assert "non-preregistered split protocol" in str(exc)
+    else:
+        raise AssertionError("expected non-preregistered protocol to abort")
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} sigma-hop confirmatory tests passed")


### PR DESCRIPTION
## Description

Adds a preregistration-faithful runner for the confirmatory `Σ(hop)` test described in `prototypes/mu_cosine/PREREG_sigma_hop_confirmatory.md`.

This PR does not edit the frozen preregistration doc. It adds:

- `prototypes/mu_cosine/sigma_hop_confirmatory.py`
  - loads scored fresh-corpus pairs and LLM responses
  - enforces the required no-overlap check against the exploratory `100k_cats` graph
  - computes the same continuous `D` / `S` targets and `[μ_D, μ_S, d, 1]` residual mean model
  - runs descendant-disjoint 40-split / 30% held-out evaluation
  - compares constant-Σ vs smooth 6-parameter `Σ(hop)`
  - runs the one-sided hop-shuffle permutation test with `K >= 1000`
  - emits JSON and optional markdown reporting output

- `prototypes/mu_cosine/test_sigma_hop_confirmatory.py`
  - synthetic checks for descendant-disjoint splitting
  - exploratory-node overlap blocking
  - permutation result fields
  - rejection of non-preregistered split settings

Checks run:

```text
python3 prototypes/mu_cosine/test_sigma_hop_confirmatory.py
python3 -m py_compile prototypes/mu_cosine/sigma_hop_confirmatory.py prototypes/mu_cosine/test_sigma_hop_confirmatory.py
python3 prototypes/mu_cosine/sigma_hop_confirmatory.py --help