### PR TITLE
Add LMDB title-layer support for sigma-hop fresh sampling

### DIFF
--- a/prototypes/mu_cosine/lmdb_id.py
+++ b/prototypes/mu_cosine/lmdb_id.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Shared MediaWiki category LMDB id encoding helpers.
+
+MediaWiki page IDs are unsigned 32-bit integers. Existing fixtures currently sit below
+2**31, so this remains byte-compatible with earlier signed-int helpers while avoiding
+latent failures for larger page-id spaces.
+"""
+
+import struct
+
+ID32 = struct.Struct("<I")
+
+
+def enc_id(value):
+    return ID32.pack(int(value))
+
+
+def dec_id(value):
+    return ID32.unpack(bytes(value))[0]
+
+
+def looks_int(text):
+    try:
+        int(text)
+    except (TypeError, ValueError):
+        return False
+    return True

--- a/prototypes/mu_cosine/materialize_lmdb_title_layer.py
+++ b/prototypes/mu_cosine/materialize_lmdb_title_layer.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Materialize real category-title lookup sub-dbs inside a Phase-1 category LMDB.
+
+The graph sub-dbs (`category_parent`, `category_child`) stay unsigned int32 page/category IDs for fast traversal. This
+adds separate title lookup tables for human-readable consumers:
+
+  title_i2s  uint32_le page_id -> UTF-8 category title
+  title_s2i  UTF-8 category title -> uint32_le page_id
+
+It reads a gzip-compressed MediaWiki `page` SQL dump, keeps namespace 14 rows whose page_id already appears in the
+LMDB graph, and writes only the title layer. Existing graph data is not rewritten. `--map-size-gib` is LMDB's maximum
+map size; on sparse-file filesystems it does not immediately allocate that much disk, but Windows filesystems may be
+less forgiving, so increase it only as needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from lmdb_id import dec_id, enc_id
+
+CATEGORY_NS = 14
+
+
+def parse_values(sql_values):
+    i, n = 0, len(sql_values)
+    while i < n:
+        if sql_values[i] != "(":
+            i += 1
+            continue
+        i += 1
+        fields, cur, in_str = [], [], False
+        while i < n:
+            ch = sql_values[i]
+            if in_str:
+                if ch == "\\":
+                    cur.append(sql_values[i + 1] if i + 1 < n else "")
+                    i += 2
+                    continue
+                if ch == "'":
+                    if i + 1 < n and sql_values[i + 1] == "'":
+                        cur.append("'")
+                        i += 2
+                        continue
+                    in_str = False
+                    i += 1
+                    continue
+                cur.append(ch)
+                i += 1
+            else:
+                if ch == "'":
+                    in_str = True
+                    i += 1
+                elif ch == ",":
+                    fields.append("".join(cur))
+                    cur = []
+                    i += 1
+                elif ch == ")":
+                    fields.append("".join(cur))
+                    i += 1
+                    break
+                else:
+                    cur.append(ch)
+                    i += 1
+        yield fields
+        while i < n and sql_values[i] != "(":
+            i += 1
+
+
+def iter_page_titles(page_dump):
+    try:
+        with gzip.open(page_dump, "rt", encoding="utf-8", errors="strict") as f:
+            for line in f:
+                if not line.startswith("INSERT INTO"):
+                    continue
+                pos = line.find("VALUES")
+                if pos < 0:
+                    continue
+                for row in parse_values(line[pos + 6:]):
+                    if len(row) < 3:
+                        continue
+                    try:
+                        page_id = int(row[0])
+                        ns = int(row[1])
+                    except ValueError:
+                        continue
+                    if ns == CATEGORY_NS and row[2]:
+                        yield page_id, row[2]
+    except gzip.BadGzipFile as exc:
+        raise ValueError(f"--page-dump must be a gzip-compressed MediaWiki page SQL dump: {page_dump}") from exc
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"--page-dump is not valid UTF-8 at byte {exc.start}: {page_dump}") from exc
+
+
+def graph_node_ids(env, cp_db):
+    """Return every node appearing as either child key or any duplicate parent value."""
+    nodes = set()
+    with env.begin(buffers=True) as txn:
+        cur = txn.cursor(db=cp_db)
+        try:
+            if not cur.first():
+                return nodes
+            while True:
+                nodes.add(dec_id(cur.key()))
+                nodes.add(dec_id(cur.value()))
+                for value in cur.iternext_dup(keys=False, values=True):
+                    nodes.add(dec_id(value))
+                if not cur.next_nodup():
+                    break
+        finally:
+            close = getattr(cur, "close", None)
+            if close is not None:
+                close()
+    return nodes
+
+
+def write_manifest(path, manifest):
+    out_dir = path.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(out_dir))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def abort_quietly(txn):
+    if txn is None:
+        return
+    try:
+        txn.abort()
+    except Exception:
+        pass
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--lmdb-dir", required=True, type=Path)
+    ap.add_argument("--page-dump", required=True, type=Path)
+    ap.add_argument("--title-i2s-db", default="title_i2s")
+    ap.add_argument("--title-s2i-db", default="title_s2i")
+    ap.add_argument("--manifest", type=Path)
+    ap.add_argument("--map-size-gib", type=float, default=16.0)
+    args = ap.parse_args()
+
+    try:
+        import lmdb
+    except ImportError as exc:
+        raise SystemExit("python-lmdb is required") from exc
+
+    env = lmdb.open(str(args.lmdb_dir), max_dbs=32, map_size=int(args.map_size_gib * 1024**3), subdir=True)
+    cp = env.open_db(b"category_parent", create=False)
+    title_i2s = env.open_db(args.title_i2s_db.encode("utf-8"), create=True)
+    title_s2i = env.open_db(args.title_s2i_db.encode("utf-8"), create=True)
+    meta = env.open_db(b"meta", create=True)
+
+    with env.begin(write=True) as txn:
+        txn.drop(title_i2s, delete=False)
+        txn.drop(title_s2i, delete=False)
+
+    nodes = graph_node_ids(env, cp)
+    matched = 0
+    category_title_rows_scanned = 0
+    collisions = []
+    txn = None
+    try:
+        txn = env.begin(write=True)
+        for page_id, title in iter_page_titles(args.page_dump):
+            category_title_rows_scanned += 1
+            if page_id not in nodes:
+                continue
+            title_bytes = title.encode("utf-8")
+            page_bytes = enc_id(page_id)
+            existing = txn.get(title_bytes, db=title_s2i)
+            if existing is not None and bytes(existing) != page_bytes:
+                collisions.append((title, dec_id(existing), page_id))
+                if len(collisions) >= 10:
+                    break
+                continue
+            txn.put(page_bytes, title_bytes, db=title_i2s)
+            txn.put(title_bytes, page_bytes, db=title_s2i)
+            matched += 1
+            if matched % 500_000 == 0:
+                txn.commit()
+                txn = None
+                print(f"materialized {matched} category titles")
+                txn = env.begin(write=True)
+        if collisions:
+            examples = "; ".join(f"{title}: {old_id} vs {new_id}" for title, old_id, new_id in collisions[:5])
+            raise ValueError(f"duplicate category titles with different page IDs in page dump: {examples}")
+        txn.put(b"title_layer_kind", b"mediawiki_page_titles", db=meta)
+        txn.put(b"title_i2s_db", args.title_i2s_db.encode("utf-8"), db=meta)
+        txn.put(b"title_s2i_db", args.title_s2i_db.encode("utf-8"), db=meta)
+        txn.put(b"title_layer_count", str(matched).encode("ascii"), db=meta)
+        txn.put(b"title_layer_refreshed", b"1", db=meta)
+        txn.commit()
+        txn = None
+    except lmdb.MapFullError as exc:
+        abort_quietly(txn)
+        txn = None
+        raise SystemExit("LMDB map is full while writing title tables; rerun with a larger --map-size-gib") from exc
+    except BaseException:
+        abort_quietly(txn)
+        txn = None
+        raise
+    finally:
+        env.sync()
+        env.close()
+
+    manifest = {
+        "lmdb_dir": str(args.lmdb_dir),
+        "page_dump": str(args.page_dump),
+        "graph_node_count": len(nodes),
+        "category_title_rows_scanned": category_title_rows_scanned,
+        "title_layer_count": matched,
+        "title_i2s_db": args.title_i2s_db,
+        "title_s2i_db": args.title_s2i_db,
+        "refreshed": True,
+    }
+    manifest_path = args.manifest or (args.lmdb_dir.parent / "title_layer_manifest.json")
+    write_manifest(manifest_path, manifest)
+    print(f"materialized {matched} real category titles into {args.lmdb_dir}")
+    print(f"manifest -> {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/sample_sigma_hop_fresh_corpus.py
+++ b/prototypes/mu_cosine/sample_sigma_hop_fresh_corpus.py
@@ -6,20 +6,22 @@ exploratory graph, selects a category slice, and samples balanced shortest-hop d
 `transitive_h{hop}` label expected by `sigma_hop_confirmatory.py`. Here "hop" means the minimum upward graph
 distance found by BFS inside the retained slice, not every possible path length through a DAG.
 
-The output is a comment-header score-input TSV matching existing score_in readers, not a scored dataset. Running
-this script does not create labels.
+Candidate graph structure can come from a child<TAB>parent TSV or from the repository's Phase-1 category LMDB layout.
+The LMDB path keeps graph traversal on unsigned int32 IDs and uses a separate real-title layer only at the score-input boundary.
+Running this script does not create labels.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 import random
 import re
 import tempfile
 from collections import Counter, deque
+
+from lmdb_id import dec_id, enc_id, looks_int
 
 
 ADMIN = re.compile(
@@ -34,6 +36,10 @@ PREREGISTERED_SEED = 0
 
 class FreshCorpusError(ValueError):
     pass
+
+
+def is_identity_numeric_title(node_id, title):
+    return looks_int(title) and int(title) == int(node_id)
 
 
 def load_edges(path, stats=None):
@@ -111,7 +117,7 @@ def descendants_within(children, roots, max_depth=None):
         node = queue.popleft()
         if max_depth is not None and depth[node] >= max_depth:
             continue
-        for child in sorted(children.get(node, ())):
+        for child in sorted(children.get(node, ()), key=sort_key):
             if child not in kept:
                 kept.add(child)
                 depth[child] = depth[node] + 1
@@ -130,7 +136,7 @@ def ancestors_by_hop(parents, start, hmax):
         hop = seen[node]
         if hop >= hmax:
             continue
-        for parent in sorted(parents.get(node, ())):
+        for parent in sorted(parents.get(node, ()), key=sort_key):
             if parent not in seen:
                 seen[parent] = hop + 1
                 by_hop.setdefault(hop + 1, []).append(parent)
@@ -138,22 +144,31 @@ def ancestors_by_hop(parents, start, hmax):
     return by_hop
 
 
-def pair_pool_for_roots(parents, children, roots, hmax, slice_depth=None):
-    slice_nodes = descendants_within(children, roots, max_depth=slice_depth)
+def pair_pool_for_slice_nodes(parents, slice_nodes, hmax):
     slice_parents = restrict_parents(parents, slice_nodes)
     pool = {hop: [] for hop in range(1, hmax + 1)}
-    for desc in sorted(slice_nodes):
+    for desc in sorted(slice_nodes, key=sort_key):
         by_hop = ancestors_by_hop(slice_parents, desc, hmax)
         for hop in range(1, hmax + 1):
             for anc in by_hop.get(hop, []):
                 if desc != anc:
                     pool[hop].append((desc, anc))
-    return slice_nodes, pool
+    return pool
+
+
+def pair_pool_for_roots(parents, children, roots, hmax, slice_depth=None):
+    slice_nodes = descendants_within(children, roots, max_depth=slice_depth)
+    return slice_nodes, pair_pool_for_slice_nodes(parents, slice_nodes, hmax)
 
 
 def hop_targets(total_pairs, hmax):
+    # Remainders are assigned to lower hops deterministically; the manifest records this frozen policy.
     base, rem = divmod(total_pairs, hmax)
     return {hop: base + (1 if hop <= rem else 0) for hop in range(1, hmax + 1)}
+
+
+def string_key_counts(counts):
+    return {str(key): counts[key] for key in sorted(counts)}
 
 
 def can_satisfy_targets(pool, targets):
@@ -175,17 +190,29 @@ def first_eligible_roots(parents, children, roots, excluded_roots, blocked_roots
     if slice_depth is not None and slice_depth < hmax:
         raise FreshCorpusError(f"--slice-depth {slice_depth} < --hmax {hmax}: hop-{hmax} pairs are impossible")
     candidates = sorted(roots or children.keys(), key=sort_key)
+    attempts = []
     for root in candidates:
         if root in excluded_roots or root in blocked_roots:
             continue
         if root not in children or ADMIN.search(root):
             continue
-        slice_nodes, pool = pair_pool_for_roots(parents, children, (root,), hmax, slice_depth=slice_depth)
+        slice_nodes = descendants_within(children, (root,), max_depth=slice_depth)
         if len(slice_nodes) < min_descendants:
+            attempts.append({
+                "root": root,
+                "slice_nodes": len(slice_nodes),
+                "available_hop_counts": string_key_counts({hop: 0 for hop in targets}),
+            })
             continue
-        ok, _ = can_satisfy_targets(pool, targets)
+        pool = pair_pool_for_slice_nodes(parents, slice_nodes, hmax)
+        ok, available = can_satisfy_targets(pool, targets)
+        attempts.append({
+            "root": root,
+            "slice_nodes": len(slice_nodes),
+            "available_hop_counts": string_key_counts(available),
+        })
         if ok:
-            return (root,), slice_nodes, pool
+            return (root,), slice_nodes, pool, {"candidate_root_attempts": attempts}
     raise FreshCorpusError("no eligible root slice supplied enough no-overlap pairs for every hop")
 
 
@@ -211,6 +238,265 @@ def sample_balanced_pairs(pool, total_pairs, hmax, seed):
             raise FreshCorpusError(f"hop {hop} has only {counts[hop]} unique pairs; need {targets[hop]}")
     random.Random(seed ^ 0x5EED5EED).shuffle(rows)
     return rows, counts
+
+
+def iter_dups(txn, db, key):
+    cursor = txn.cursor(db=db)
+    try:
+        if not cursor.set_key(enc_id(key)):
+            return []
+        return [dec_id(value) for value in cursor.iternext_dup(keys=False, values=True)]
+    finally:
+        close = getattr(cursor, "close", None)
+        if close is not None:
+            close()
+
+
+class LmdbTitleGraph:
+    """Read Phase-1 graph edges plus a separate real-title layer.
+
+    The sampler keeps one read transaction open for a short-lived CLI run so all graph and title reads share one
+    snapshot. Run the title materializer before this sampler, not concurrently with it; use --lmdb-no-lock only for
+    immutable fixtures where stale lock files are a bigger operational risk than concurrent writers.
+    """
+
+    def __init__(self, lmdb_dir, title_i2s_db="title_i2s", title_s2i_db="title_s2i", lock=True):
+        try:
+            import lmdb
+        except ImportError as exc:
+            raise FreshCorpusError("python-lmdb is required for --candidate-lmdb") from exc
+
+        self.lmdb = lmdb
+        self.lmdb_dir = lmdb_dir
+        self.env = lmdb.open(str(lmdb_dir), readonly=True, lock=lock, max_dbs=32, subdir=True)
+        self.txn = self.env.begin(buffers=True)
+        self.category_parent = self.env.open_db(b"category_parent", txn=self.txn, create=False)
+        self.category_child = self.env.open_db(b"category_child", txn=self.txn, create=False)
+        self.meta = self._open_optional_db("meta")
+        self.title_i2s_name, self.title_i2s = self._open_title_db(title_i2s_db, "title_i2s_db", "i2s")
+        self.title_s2i_name, self.title_s2i = self._open_title_db(title_s2i_db, "title_s2i_db", "s2i")
+        self._title_cache = {}
+        self._id_cache = {}
+        self._parents = {}
+        self._children = {}
+
+    def _open_optional_db(self, name):
+        try:
+            return self.env.open_db(name.encode("utf-8"), txn=self.txn, create=False)
+        except self.lmdb.NotFoundError:
+            return None
+
+    def _open_title_db(self, preferred, meta_key, fallback):
+        for name in (preferred, self.meta_text(meta_key), fallback):
+            if not name:
+                continue
+            db = self._open_optional_db(name)
+            if db is not None:
+                return name, db
+        raise FreshCorpusError(
+            f"candidate LMDB has no real title layer: missing `{preferred}`, meta `{meta_key}`, and legacy `{fallback}` sub-dbs"
+        )
+
+    def close(self):
+        try:
+            txn = getattr(self, "txn", None)
+            if txn is not None:
+                try:
+                    txn.abort()
+                except Exception:
+                    pass
+                self.txn = None
+        finally:
+            self.env.close()
+
+    def meta_text(self, key):
+        if self.meta is None:
+            return None
+        raw = self.txn.get(key.encode("utf-8"), db=self.meta)
+        if raw is None:
+            return None
+        return bytes(raw).decode("utf-8")
+
+    def meta_int(self, key):
+        text = self.meta_text(key)
+        if text is None or not looks_int(text):
+            return None
+        return int(text)
+
+    def title(self, node_id):
+        node_id = int(node_id)
+        if node_id in self._title_cache:
+            return self._title_cache[node_id]
+        raw = self.txn.get(enc_id(node_id), db=self.title_i2s)
+        if raw is None:
+            raise FreshCorpusError(f"candidate LMDB title layer lacks node id {node_id}")
+        title = bytes(raw).decode("utf-8")
+        if is_identity_numeric_title(node_id, title):
+            raise FreshCorpusError(
+                "candidate LMDB title layer is identity numeric; materialize real titles into "
+                "separate `title_i2s`/`title_s2i` sub-dbs before producing score-input rows"
+            )
+        self._title_cache[node_id] = title
+        self._id_cache.setdefault(title, node_id)
+        return title
+
+    def node_id(self, title_or_id):
+        if title_or_id in self._id_cache:
+            return self._id_cache[title_or_id]
+        candidates = [title_or_id]
+        if title_or_id.startswith("Category:"):
+            candidates.append(title_or_id[len("Category:"):])
+        for title in candidates:
+            raw = self.txn.get(title.encode("utf-8"), db=self.title_s2i)
+            if raw is not None:
+                node_id = dec_id(raw)
+                self._id_cache[title_or_id] = node_id
+                self._id_cache.setdefault(title, node_id)
+                return node_id
+        if looks_int(title_or_id):
+            node_id = int(title_or_id)
+            self.title(node_id)
+            return node_id
+        raise FreshCorpusError(f"candidate LMDB title layer cannot resolve category title `{title_or_id}`")
+
+    def parents(self, node_id):
+        node_id = int(node_id)
+        if node_id not in self._parents:
+            self._parents[node_id] = iter_dups(self.txn, self.category_parent, node_id)
+        return self._parents[node_id]
+
+    def children(self, node_id):
+        node_id = int(node_id)
+        if node_id not in self._children:
+            self._children[node_id] = iter_dups(self.txn, self.category_child, node_id)
+        return self._children[node_id]
+
+
+def title_block_reason(title, exploratory_nodes):
+    if title in exploratory_nodes:
+        return "overlap_node"
+    if ADMIN.search(title):
+        return "admin_node"
+    return None
+
+
+def load_lmdb_slice_maps(graph, root_id, exploratory_nodes, slice_depth=None):
+    stats = Counter()
+
+    def title_for(node_id):
+        stats["title_lookups"] += 1
+        return graph.title(node_id)
+
+    root_title = title_for(root_id)
+    reason = title_block_reason(root_title, exploratory_nodes)
+    if reason:
+        stats[reason] += 1
+        return root_title, set(), {}, {}, stats
+
+    kept_ids = {root_id}
+    depth = {root_id: 0}
+    queue = deque([root_id])
+    while queue:
+        node = queue.popleft()
+        if slice_depth is not None and depth[node] >= slice_depth:
+            continue
+        child_ids = graph.children(node)
+        stats["child_edges_examined"] += len(child_ids)
+        child_records = []
+        for child_id in child_ids:
+            child_title = title_for(child_id)
+            reason = title_block_reason(child_title, exploratory_nodes)
+            if reason:
+                stats[reason] += 1
+                continue
+            child_records.append((sort_key(child_title), child_id))
+        for _key, child_id in sorted(child_records):
+            if child_id not in kept_ids:
+                kept_ids.add(child_id)
+                depth[child_id] = depth[node] + 1
+                queue.append(child_id)
+
+    parents, children = {}, {}
+    for node_id in kept_ids:
+        title = title_for(node_id)
+        parents.setdefault(title, set())
+        children.setdefault(title, set())
+
+    for child_id in sorted(kept_ids, key=lambda nid: sort_key(title_for(nid))):
+        child_title = title_for(child_id)
+        parent_ids = graph.parents(child_id)
+        stats["parent_edges_examined"] += len(parent_ids)
+        for parent_id in parent_ids:
+            if parent_id not in kept_ids:
+                continue
+            parent_title = title_for(parent_id)
+            parents[child_title].add(parent_title)
+            children[parent_title].add(child_title)
+            stats["retained_edges"] += 1
+    return root_title, {title_for(node_id) for node_id in kept_ids}, parents, children, stats
+
+
+def lmdb_candidate_root_ids(graph, roots, scope_root):
+    if roots:
+        return [graph.node_id(root) for root in roots], "user-supplied root validation", None
+
+    scope_id = None
+    scope_title = scope_root
+    if scope_root:
+        scope_id = graph.node_id(scope_root)
+        scope_title = graph.title(scope_id)
+    else:
+        scope_id = graph.meta_int("scoped_root")
+        if scope_id is None:
+            scope_id = graph.meta_int("metric_min_dist_to_root.root")
+        if scope_id is not None:
+            scope_title = graph.title(scope_id)
+    if scope_id is None:
+        raise FreshCorpusError("--candidate-lmdb requires --root, --scope-root, or LMDB meta.scoped_root")
+
+    children = graph.children(scope_id)
+    if not children:
+        raise FreshCorpusError(f"scope root `{scope_title}` has no candidate child roots in LMDB")
+    return children, "casefold-lexicographically smallest eligible direct child of scope root", {
+        "scope_root": scope_title,
+        "scope_root_id": scope_id,
+        "scope_child_roots": len(children),
+    }
+
+
+def first_eligible_lmdb_roots(graph, root_ids, exploratory_nodes, excluded_roots, hmax, targets, min_descendants, slice_depth):
+    candidates = sorted(root_ids, key=lambda nid: sort_key(graph.title(nid)))
+    attempts = []
+    for root_id in candidates:
+        root_title = graph.title(root_id)
+        if root_title in excluded_roots or ADMIN.search(root_title):
+            continue
+        root_title, slice_nodes, parents, children, stats = load_lmdb_slice_maps(
+            graph, root_id, exploratory_nodes, slice_depth=slice_depth
+        )
+        pool = {hop: [] for hop in range(1, hmax + 1)}
+        available = {hop: 0 for hop in range(1, hmax + 1)}
+        ok = False
+        if len(slice_nodes) >= min_descendants:
+            # `slice_nodes` was already BFS-limited by the LMDB traversal above; do not reapply a second depth cap.
+            pool = pair_pool_for_slice_nodes(parents, slice_nodes, hmax)
+            ok, available = can_satisfy_targets(pool, targets)
+        attempts.append({
+            "root": root_title,
+            "root_id": root_id,
+            "slice_nodes": len(slice_nodes),
+            "available_hop_counts": string_key_counts(available),
+            "lmdb_slice_stats": dict(sorted(stats.items())),
+        })
+        if len(slice_nodes) < min_descendants:
+            continue
+        if ok:
+            return (root_title,), slice_nodes, pool, {
+                "candidate_root_attempts": attempts,
+                "selected_root_id": root_id,
+                "selected_lmdb_slice_stats": dict(sorted(stats.items())),
+            }
+    raise FreshCorpusError("no eligible LMDB root slice supplied enough no-overlap pairs for every hop")
 
 
 def write_score_in(rows, out):
@@ -239,24 +525,17 @@ def write_manifest(path, manifest):
             os.unlink(tmp)
 
 
-def main():
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--candidate-graph", required=True, help="fresh/later Wikipedia category child<TAB>parent graph")
-    ap.add_argument("--exploratory-graph", required=True, help="PR #3517 exploratory 100k_cats/category_parent.tsv")
-    ap.add_argument("--root", action="append", default=[], help="candidate root slice to validate/sample")
-    ap.add_argument("--exclude-root", action="append", default=[], help="exploratory seed/root category to disallow")
-    ap.add_argument("--pairs", type=int, default=250)
-    ap.add_argument("--hmax", type=int, default=5)
-    ap.add_argument("--min-descendants", type=int, default=300)
-    ap.add_argument("--slice-depth", type=int, default=None, help="optional downward closure cap from selected root")
-    ap.add_argument("--seed", type=int, default=0)
-    ap.add_argument("--out", required=True)
-    ap.add_argument("--manifest", required=True)
-    ap.add_argument("--allow-small-sample", action="store_true", help="permit non-confirmatory toy/dry-run sizes")
-    args = ap.parse_args()
-
-    if os.path.realpath(args.candidate_graph) == os.path.realpath(args.exploratory_graph):
+def validate_args(args):
+    if args.candidate_graph and os.path.realpath(args.candidate_graph) == os.path.realpath(args.exploratory_graph):
         raise FreshCorpusError("--candidate-graph and --exploratory-graph must be different files")
+    if args.pairs <= 0:
+        raise FreshCorpusError("--pairs must be positive")
+    if args.hmax <= 0:
+        raise FreshCorpusError("--hmax must be positive")
+    if args.min_descendants <= 0:
+        raise FreshCorpusError("--min-descendants must be positive")
+    if args.root and args.scope_root:
+        raise FreshCorpusError("--root and --scope-root are mutually exclusive; pass one concrete root or one broad scope")
     if args.hmax != 5:
         raise FreshCorpusError("the preregistered confirmatory sampler requires --hmax 5")
     if args.slice_depth is not None and args.slice_depth < args.hmax:
@@ -270,18 +549,22 @@ def main():
     if not args.allow_small_sample and args.seed != PREREGISTERED_SEED:
         raise FreshCorpusError(f"the preregistered confirmatory sampler requires --seed {PREREGISTERED_SEED}")
 
-    exploratory_stats, candidate_stats = {}, {}
-    exploratory_edges = load_edges(args.exploratory_graph, stats=exploratory_stats)
-    exploratory_nodes = node_block(exploratory_edges)
+
+def sample_from_tsv(args, exploratory_nodes, candidate_stats, targets):
     candidate_edges = load_edges(args.candidate_graph, stats=candidate_stats)
     filtered_edges, removed, blocked_roots = filter_candidate_edges(candidate_edges, exploratory_nodes)
     parents, children = build_maps(filtered_edges)
-    targets = hop_targets(args.pairs, args.hmax)
     excluded_roots = set(args.exclude_root)
     roots = tuple(root for root in args.root if root not in excluded_roots)
     if args.root and not roots:
         raise FreshCorpusError("all supplied --root values were excluded by --exclude-root")
-    selected_roots, slice_nodes, pool = first_eligible_roots(
+    selection_rule = "user-supplied root validation" if args.root else "casefold-lexicographically smallest eligible root after no-overlap/admin filtering"
+    if args.scope_root and not args.root:
+        if args.scope_root not in children:
+            raise FreshCorpusError(f"--scope-root `{args.scope_root}` is absent after TSV filtering")
+        roots = tuple(sorted(children[args.scope_root], key=sort_key))
+        selection_rule = "casefold-lexicographically smallest eligible direct child of scope root"
+    selected_roots, slice_nodes, pool, extra = first_eligible_roots(
         parents,
         children,
         roots,
@@ -292,6 +575,96 @@ def main():
         args.min_descendants,
         args.slice_depth,
     )
+    source_manifest = {
+        "candidate_source_kind": "tsv",
+        "candidate_graph": args.candidate_graph,
+        "candidate_lmdb": None,
+        "candidate_edges": len(candidate_edges),
+        "filtered_edges": len(filtered_edges),
+        "removed_edges": removed,
+        "blocked_root_candidates": len(blocked_roots),
+        "edge_file_stats": {"candidate": candidate_stats},
+        "selection_rule": selection_rule,
+        "node_filter_semantics": "drop every retained node whose title is exploratory-overlap or admin; retain only edges with both endpoints kept",
+        "traversal_order": "casefold-title order for candidate roots, descendants, and ancestors",
+    }
+    source_manifest.update(extra)
+    return selected_roots, slice_nodes, pool, source_manifest
+
+
+def sample_from_lmdb(args, exploratory_nodes, targets):
+    excluded_roots = set(args.exclude_root)
+    graph = LmdbTitleGraph(args.candidate_lmdb, args.title_i2s_db, args.title_s2i_db, lock=not args.lmdb_no_lock)
+    try:
+        root_ids, selection_rule, scope_info = lmdb_candidate_root_ids(graph, args.root, args.scope_root)
+        selected_roots, slice_nodes, pool, extra = first_eligible_lmdb_roots(
+            graph,
+            root_ids,
+            exploratory_nodes,
+            excluded_roots,
+            args.hmax,
+            targets,
+            args.min_descendants,
+            args.slice_depth,
+        )
+        source_manifest = {
+            "candidate_source_kind": "lmdb",
+            "candidate_graph": None,
+            "candidate_lmdb": args.candidate_lmdb,
+            "candidate_edges": None,
+            "filtered_edges": None,
+            "removed_edges": None,
+            "blocked_root_candidates": None,
+            "edge_file_stats": {"candidate": {}},
+            "selection_rule": selection_rule,
+            "node_filter_semantics": "drop every retained node whose title is exploratory-overlap or admin; retain only edges with both endpoints kept",
+            "traversal_order": "casefold-title order for candidate roots, descendants, and ancestors",
+            "lmdb_lock": not args.lmdb_no_lock,
+            "title_i2s_db": graph.title_i2s_name,
+            "title_s2i_db": graph.title_s2i_name,
+            "title_layer_kind": graph.meta_text("title_layer_kind"),
+        }
+        if scope_info:
+            source_manifest.update(scope_info)
+        source_manifest.update(extra)
+        return selected_roots, slice_nodes, pool, source_manifest
+    finally:
+        graph.close()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    source = ap.add_mutually_exclusive_group(required=True)
+    source.add_argument("--candidate-graph", help="fresh/later Wikipedia category child<TAB>parent graph")
+    source.add_argument("--candidate-lmdb", help="fresh/later Phase-1 category LMDB with category_parent/category_child")
+    ap.add_argument("--exploratory-graph", required=True, help="PR #3517 exploratory 100k_cats/category_parent.tsv")
+    ap.add_argument("--root", action="append", default=[], help="candidate root slice to validate/sample")
+    ap.add_argument("--scope-root", help="broad LMDB/TSV root whose direct children are candidate root slices")
+    ap.add_argument("--exclude-root", action="append", default=[], help="exploratory seed/root category to disallow")
+    ap.add_argument("--title-i2s-db", default="title_i2s", help="LMDB uint32 id -> real category title sub-db; meta.title_i2s_db is also honored")
+    ap.add_argument("--title-s2i-db", default="title_s2i", help="LMDB real category title -> uint32 id sub-db; meta.title_s2i_db is also honored")
+    ap.add_argument("--lmdb-no-lock", action="store_true", help="open candidate LMDB with lock=False; use only for immutable fixtures")
+    ap.add_argument("--pairs", type=int, default=250)
+    ap.add_argument("--hmax", type=int, default=5)
+    ap.add_argument("--min-descendants", type=int, default=300)
+    ap.add_argument("--slice-depth", type=int, default=None, help="optional downward closure cap from selected root")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--allow-small-sample", action="store_true", help="permit non-confirmatory toy/dry-run sizes")
+    args = ap.parse_args()
+
+    validate_args(args)
+
+    targets = hop_targets(args.pairs, args.hmax)
+    exploratory_stats, candidate_stats = {}, {}
+    exploratory_edges = load_edges(args.exploratory_graph, stats=exploratory_stats)
+    exploratory_nodes = node_block(exploratory_edges)
+    if args.candidate_lmdb:
+        selected_roots, slice_nodes, pool, source_manifest = sample_from_lmdb(args, exploratory_nodes, targets)
+    else:
+        selected_roots, slice_nodes, pool, source_manifest = sample_from_tsv(args, exploratory_nodes, candidate_stats, targets)
+
     rows, counts = sample_balanced_pairs(pool, args.pairs, args.hmax, args.seed)
     overlap = node_block((desc, anc) for desc, anc, _ in rows) & exploratory_nodes
     overlap_count = len(overlap)
@@ -299,29 +672,30 @@ def main():
         raise FreshCorpusError(f"sampled pairs overlap exploratory nodes: {sorted(overlap)[:10]}")
     write_score_in(rows, args.out)
     manifest = {
-        "candidate_graph": args.candidate_graph,
         "exploratory_graph": args.exploratory_graph,
         "selected_roots": list(selected_roots),
         "excluded_roots": sorted(args.exclude_root),
-        "selection_rule": "casefold-lexicographically smallest eligible root after no-overlap/admin filtering" if not args.root else "user-supplied root validation",
+        "scope_root": args.scope_root,
         "seed": args.seed,
         "hmax": args.hmax,
         "allow_small_sample": args.allow_small_sample,
         "requested_pairs": args.pairs,
         "written_pairs": len(rows),
         "target_hop_counts": {str(h): targets[h] for h in range(1, args.hmax + 1)},
+        "hop_targeting": "deterministic balanced counts; any remainder is assigned to lower hop numbers",
         "hop_counts": {str(h): counts[h] for h in range(1, args.hmax + 1)},
         "hop_semantics": "shortest upward graph distance within retained slice",
         "row_shuffle_seed": args.seed ^ 0x5EED5EED,
         "slice_nodes": len(slice_nodes),
-        "candidate_edges": len(candidate_edges),
-        "filtered_edges": len(filtered_edges),
-        "removed_edges": removed,
-        "blocked_root_candidates": len(blocked_roots),
-        "edge_file_stats": {"candidate": candidate_stats, "exploratory": exploratory_stats},
+        "edge_file_stats": {"exploratory": exploratory_stats},
         "node_overlap_with_exploratory": overlap_count,
         "output": args.out,
     }
+    manifest.update(source_manifest)
+    if source_manifest.get("edge_file_stats"):
+        merged_stats = dict(source_manifest["edge_file_stats"])
+        merged_stats["exploratory"] = exploratory_stats
+        manifest["edge_file_stats"] = merged_stats
     write_manifest(args.manifest, manifest)
     print(f"selected root(s): {', '.join(selected_roots)}")
     print(f"wrote {len(rows)} no-overlap score-in pairs -> {args.out}")

--- a/prototypes/mu_cosine/test_materialize_lmdb_title_layer.py
+++ b/prototypes/mu_cosine/test_materialize_lmdb_title_layer.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Synthetic checks for LMDB title-layer materialization."""
+
+import gzip
+import json
+import os
+import tempfile
+from unittest import mock
+
+from lmdb_id import dec_id, enc_id
+from materialize_lmdb_title_layer import main, parse_values
+
+
+def _run_cli(argv):
+    with mock.patch("sys.argv", argv):
+        return main()
+
+
+def test_parse_values_handles_quoted_commas_and_parens():
+    rows = list(parse_values("(1,14,'A,B'),(2,14,'C)D'),(3,0,'Article');"))
+    assert rows == [["1", "14", "A,B"], ["2", "14", "C)D"], ["3", "0", "Article"]]
+
+
+def test_materializer_writes_real_titles_and_refreshes_stale_keys():
+    try:
+        import lmdb
+    except ImportError:
+        print("  skip test_materializer_writes_real_titles_and_refreshes_stale_keys (python-lmdb unavailable)")
+        return
+
+    with tempfile.TemporaryDirectory() as td:
+        lmdb_dir = os.path.join(td, "graph.lmdb")
+        page_dump = os.path.join(td, "page.sql.gz")
+        manifest = os.path.join(td, "manifest.json")
+        env = lmdb.open(lmdb_dir, max_dbs=16, map_size=64 * 1024 * 1024, subdir=True)
+        cp = env.open_db(b"category_parent", dupsort=True, create=True)
+        title_i2s = env.open_db(b"title_i2s", create=True)
+        title_s2i = env.open_db(b"title_s2i", create=True)
+        with env.begin(write=True) as txn:
+            txn.put(enc_id(2), enc_id(1), db=cp, dupdata=True)
+            txn.put(enc_id(2), enc_id(4), db=cp, dupdata=True)
+            txn.put(enc_id(3), enc_id(1), db=cp, dupdata=True)
+            txn.put(enc_id(99), b"Stale", db=title_i2s)
+            txn.put(b"Stale", enc_id(99), db=title_s2i)
+        env.sync()
+        env.close()
+
+        with gzip.open(page_dump, "wt", encoding="utf-8") as f:
+            f.write(
+                "INSERT INTO `page` VALUES "
+                "(1,14,'Root'),(2,14,'Child'),(3,0,'Article'),(4,14,'Second_dup_parent'),"
+                "(999,14,'Out_of_graph');\n"
+            )
+
+        _run_cli([
+            "materialize_lmdb_title_layer.py",
+            "--lmdb-dir", lmdb_dir,
+            "--page-dump", page_dump,
+            "--manifest", manifest,
+            "--map-size-gib", "0.1",
+        ])
+
+        env = lmdb.open(lmdb_dir, max_dbs=16, readonly=True, lock=False, subdir=True)
+        title_i2s = env.open_db(b"title_i2s", create=False)
+        title_s2i = env.open_db(b"title_s2i", create=False)
+        meta = env.open_db(b"meta", create=False)
+        with env.begin() as txn:
+            assert txn.get(enc_id(1), db=title_i2s) == b"Root"
+            assert txn.get(enc_id(2), db=title_i2s) == b"Child"
+            assert txn.get(enc_id(3), db=title_i2s) is None
+            assert txn.get(enc_id(4), db=title_i2s) == b"Second_dup_parent"
+            assert txn.get(enc_id(99), db=title_i2s) is None
+            assert dec_id(txn.get(b"Root", db=title_s2i)) == 1
+            assert dec_id(txn.get(b"Second_dup_parent", db=title_s2i)) == 4
+            assert txn.get(b"Stale", db=title_s2i) is None
+            assert txn.get(b"title_layer_kind", db=meta) == b"mediawiki_page_titles"
+            assert txn.get(b"title_layer_count", db=meta) == b"3"
+        env.close()
+
+        with open(manifest, encoding="utf-8") as f:
+            m = json.load(f)
+        assert m["graph_node_count"] == 4
+        assert m["category_title_rows_scanned"] == 4
+        assert m["title_layer_count"] == 3
+        assert m["refreshed"] is True
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} LMDB title-layer tests passed")

--- a/prototypes/mu_cosine/test_sigma_hop_fresh_corpus.py
+++ b/prototypes/mu_cosine/test_sigma_hop_fresh_corpus.py
@@ -4,7 +4,9 @@
 import json
 import os
 import tempfile
+from unittest import mock
 
+from lmdb_id import enc_id
 from sample_sigma_hop_fresh_corpus import (
     FreshCorpusError,
     ancestors_by_hop,
@@ -15,6 +17,11 @@ from sample_sigma_hop_fresh_corpus import (
     node_block,
     sample_balanced_pairs,
 )
+
+
+def _run_cli(argv):
+    with mock.patch("sys.argv", argv):
+        return main()
 
 
 def _write(path, text):
@@ -54,6 +61,16 @@ def test_sample_balanced_pairs_excludes_duplicate_unordered_pairs():
     assert counts[2] == 2
 
 
+def test_sample_balanced_pairs_assigns_remainder_to_lower_hops():
+    pool = {
+        1: [(f"d1_{i}", f"a1_{i}") for i in range(5)],
+        2: [(f"d2_{i}", f"a2_{i}") for i in range(5)],
+        3: [(f"d3_{i}", f"a3_{i}") for i in range(5)],
+    }
+    _rows, counts = sample_balanced_pairs(pool, total_pairs=7, hmax=3, seed=0)
+    assert counts == {1: 3, 2: 2, 3: 2}
+
+
 def test_ancestors_by_hop_uses_shortest_path_in_dag():
     parents, _ = build_maps([("child", "mid"), ("mid", "root"), ("child", "root")])
     by_hop = ancestors_by_hop(parents, "child", hmax=2)
@@ -62,34 +79,41 @@ def test_ancestors_by_hop_uses_shortest_path_in_dag():
 
 
 def test_cli_rejects_toy_sample_without_explicit_opt_in():
-    import sys
-
-    old_argv = sys.argv
     try:
-        sys.argv = [
+        _run_cli([
             "sample_sigma_hop_fresh_corpus.py",
             "--candidate-graph", "candidate.tsv",
             "--exploratory-graph", "exploratory.tsv",
             "--pairs", "10",
             "--out", "pairs.tsv",
             "--manifest", "manifest.json",
-        ]
-        try:
-            main()
-        except FreshCorpusError as exc:
-            assert "at least 250 pairs" in str(exc)
-        else:
-            raise AssertionError("expected toy sample to require --allow-small-sample")
-    finally:
-        sys.argv = old_argv
+        ])
+    except FreshCorpusError as exc:
+        assert "at least 250 pairs" in str(exc)
+    else:
+        raise AssertionError("expected toy sample to require --allow-small-sample")
+
+
+def test_cli_rejects_nonpositive_pairs_even_for_small_sample():
+    try:
+        _run_cli([
+            "sample_sigma_hop_fresh_corpus.py",
+            "--candidate-graph", "candidate.tsv",
+            "--exploratory-graph", "exploratory.tsv",
+            "--pairs", "0",
+            "--out", "pairs.tsv",
+            "--manifest", "manifest.json",
+            "--allow-small-sample",
+        ])
+    except FreshCorpusError as exc:
+        assert "--pairs must be positive" in str(exc)
+    else:
+        raise AssertionError("expected nonpositive pair count to abort")
 
 
 def test_cli_rejects_slice_depth_less_than_hmax():
-    import sys
-
-    old_argv = sys.argv
     try:
-        sys.argv = [
+        _run_cli([
             "sample_sigma_hop_fresh_corpus.py",
             "--candidate-graph", "candidate.tsv",
             "--exploratory-graph", "exploratory.tsv",
@@ -97,41 +121,50 @@ def test_cli_rejects_slice_depth_less_than_hmax():
             "--slice-depth", "4",
             "--out", "pairs.tsv",
             "--manifest", "manifest.json",
-        ]
-        try:
-            main()
-        except FreshCorpusError as exc:
-            assert "slice-depth 4 < --hmax 5" in str(exc)
-        else:
-            raise AssertionError("expected impossible slice-depth/hmax combination to abort")
-    finally:
-        sys.argv = old_argv
+        ])
+    except FreshCorpusError as exc:
+        assert "slice-depth 4 < --hmax 5" in str(exc)
+    else:
+        raise AssertionError("expected impossible slice-depth/hmax combination to abort")
 
 
 def test_cli_rejects_same_candidate_and_exploratory_graph():
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as f:
         f.write("child\tparent\nx\ty\n")
         path = f.name
-    import sys
-
-    old_argv = sys.argv
     try:
-        sys.argv = [
-            "sample_sigma_hop_fresh_corpus.py",
-            "--candidate-graph", path,
-            "--exploratory-graph", path,
-            "--out", "pairs.tsv",
-            "--manifest", "manifest.json",
-        ]
         try:
-            main()
+            _run_cli([
+                "sample_sigma_hop_fresh_corpus.py",
+                "--candidate-graph", path,
+                "--exploratory-graph", path,
+                "--out", "pairs.tsv",
+                "--manifest", "manifest.json",
+            ])
         except FreshCorpusError as exc:
             assert "must be different files" in str(exc)
         else:
             raise AssertionError("expected identical graph paths to abort")
     finally:
-        sys.argv = old_argv
         os.unlink(path)
+
+
+def test_cli_rejects_scope_root_combined_with_root():
+    try:
+        _run_cli([
+            "sample_sigma_hop_fresh_corpus.py",
+            "--candidate-graph", "candidate.tsv",
+            "--exploratory-graph", "exploratory.tsv",
+            "--root", "Fresh_root",
+            "--scope-root", "Broad_root",
+            "--out", "pairs.tsv",
+            "--manifest", "manifest.json",
+            "--allow-small-sample",
+        ])
+    except FreshCorpusError as exc:
+        assert "--root and --scope-root are mutually exclusive" in str(exc)
+    else:
+        raise AssertionError("expected root/scope-root combination to abort")
 
 
 def test_cli_rejects_all_roots_excluded():
@@ -140,11 +173,8 @@ def test_cli_rejects_all_roots_excluded():
         exploratory = os.path.join(td, "exploratory.tsv")
         _write(candidate, _chain_graph(chains=8, depth=5))
         _write(exploratory, "child\tparent\nold_child\told_parent\n")
-        import sys
-
-        old_argv = sys.argv
         try:
-            sys.argv = [
+            _run_cli([
                 "sample_sigma_hop_fresh_corpus.py",
                 "--candidate-graph", candidate,
                 "--exploratory-graph", exploratory,
@@ -153,15 +183,11 @@ def test_cli_rejects_all_roots_excluded():
                 "--out", os.path.join(td, "pairs.tsv"),
                 "--manifest", os.path.join(td, "manifest.json"),
                 "--allow-small-sample",
-            ]
-            try:
-                main()
-            except FreshCorpusError as exc:
-                assert "all supplied --root values were excluded" in str(exc)
-            else:
-                raise AssertionError("expected all-roots-excluded config to abort")
-        finally:
-            sys.argv = old_argv
+            ])
+        except FreshCorpusError as exc:
+            assert "all supplied --root values were excluded" in str(exc)
+        else:
+            raise AssertionError("expected all-roots-excluded config to abort")
 
 
 def test_cli_writes_balanced_score_in_and_manifest():
@@ -173,25 +199,18 @@ def test_cli_writes_balanced_score_in_and_manifest():
         _write(candidate, _chain_graph(chains=8, depth=5))
         _write(exploratory, "child\tparent\nold_child\told_parent\n")
 
-        import sys
-
-        old_argv = sys.argv
-        try:
-            sys.argv = [
-                "sample_sigma_hop_fresh_corpus.py",
-                "--candidate-graph", candidate,
-                "--exploratory-graph", exploratory,
-                "--root", "Fresh_root",
-                "--pairs", "10",
-                "--hmax", "5",
-                "--min-descendants", "10",
-                "--out", out,
-                "--manifest", manifest,
-                "--allow-small-sample",
-            ]
-            main()
-        finally:
-            sys.argv = old_argv
+        _run_cli([
+            "sample_sigma_hop_fresh_corpus.py",
+            "--candidate-graph", candidate,
+            "--exploratory-graph", exploratory,
+            "--root", "Fresh_root",
+            "--pairs", "10",
+            "--hmax", "5",
+            "--min-descendants", "10",
+            "--out", out,
+            "--manifest", manifest,
+            "--allow-small-sample",
+        ])
 
         rows = [ln.rstrip("\n").split("\t") for ln in open(out, encoding="utf-8") if not ln.startswith("#")]
         assert len(rows) == 10
@@ -207,6 +226,8 @@ def test_cli_writes_balanced_score_in_and_manifest():
         assert m["target_hop_counts"] == {"1": 2, "2": 2, "3": 2, "4": 2, "5": 2}
         assert m["selection_rule"] == "user-supplied root validation"
         assert m["hop_semantics"] == "shortest upward graph distance within retained slice"
+        assert "node_filter_semantics" in m
+        assert "traversal_order" in m
 
 
 def test_load_edges_skips_header():
@@ -217,6 +238,151 @@ def test_load_edges_skips_header():
         assert load_edges(path) == [("x", "y")]
     finally:
         os.unlink(path)
+
+
+def _build_lmdb(path, edges, titles, meta=None):
+    try:
+        import lmdb
+    except ImportError:
+        return False
+    env = lmdb.open(path, max_dbs=16, map_size=64 * 1024 * 1024, subdir=True)
+    cp = env.open_db(b"category_parent", dupsort=True, create=True)
+    cc = env.open_db(b"category_child", dupsort=True, create=True)
+    title_i2s = env.open_db(b"title_i2s", create=True)
+    title_s2i = env.open_db(b"title_s2i", create=True)
+    meta_db = env.open_db(b"meta", create=True)
+    with env.begin(write=True) as txn:
+        for child, parent in edges:
+            txn.put(enc_id(child), enc_id(parent), db=cp, dupdata=True)
+            txn.put(enc_id(parent), enc_id(child), db=cc, dupdata=True)
+        for node_id, title in titles.items():
+            raw_title = title.encode("utf-8")
+            txn.put(enc_id(node_id), raw_title, db=title_i2s)
+            txn.put(raw_title, enc_id(node_id), db=title_s2i)
+        txn.put(b"title_layer_kind", b"test_real_titles", db=meta_db)
+        for key, value in (meta or {}).items():
+            txn.put(key.encode("utf-8"), str(value).encode("utf-8"), db=meta_db)
+    env.sync()
+    env.close()
+    return True
+
+
+def _lmdb_chain_fixture(path, identity_titles=False, scoped=False):
+    root = 1
+    edges = []
+    titles = {root: "Fresh_root"}
+    meta = {}
+    if scoped:
+        scope = 100
+        edges.append((root, scope))
+        titles[scope] = "Scope_root"
+        meta["scoped_root"] = scope
+    next_id = 2
+    for i in range(8):
+        parent = root
+        for d in range(5, 0, -1):
+            child = next_id
+            next_id += 1
+            edges.append((child, parent))
+            titles[child] = f"fresh_{i}_{d}"
+            parent = child
+    if identity_titles:
+        titles = {node_id: str(node_id) for node_id in titles}
+    return _build_lmdb(path, edges, titles, meta=meta)
+
+
+def test_cli_writes_from_lmdb_real_title_layer():
+    with tempfile.TemporaryDirectory() as td:
+        lmdb_dir = os.path.join(td, "candidate.lmdb")
+        if not _lmdb_chain_fixture(lmdb_dir):
+            print("  skip test_cli_writes_from_lmdb_real_title_layer (python-lmdb unavailable)")
+            return
+        exploratory = os.path.join(td, "exploratory.tsv")
+        out = os.path.join(td, "pairs.tsv")
+        manifest = os.path.join(td, "manifest.json")
+        _write(exploratory, "child\tparent\nold_child\told_parent\n")
+
+        _run_cli([
+            "sample_sigma_hop_fresh_corpus.py",
+            "--candidate-lmdb", lmdb_dir,
+            "--exploratory-graph", exploratory,
+            "--root", "Fresh_root",
+            "--pairs", "10",
+            "--hmax", "5",
+            "--min-descendants", "10",
+            "--out", out,
+            "--manifest", manifest,
+            "--allow-small-sample",
+        ])
+
+        rows = [ln.rstrip("\n").split("\t") for ln in open(out, encoding="utf-8") if not ln.startswith("#")]
+        assert len(rows) == 10
+        assert all(not row[0].isdigit() and not row[1].isdigit() for row in rows)
+        with open(manifest, encoding="utf-8") as f:
+            m = json.load(f)
+        assert m["candidate_source_kind"] == "lmdb"
+        assert m["selected_roots"] == ["Fresh_root"]
+        assert m["title_i2s_db"] == "title_i2s"
+        assert m["title_s2i_db"] == "title_s2i"
+        assert m["hop_counts"] == {"1": 2, "2": 2, "3": 2, "4": 2, "5": 2}
+
+
+def test_cli_uses_lmdb_meta_scoped_root_when_root_omitted():
+    with tempfile.TemporaryDirectory() as td:
+        lmdb_dir = os.path.join(td, "candidate.lmdb")
+        if not _lmdb_chain_fixture(lmdb_dir, scoped=True):
+            print("  skip test_cli_uses_lmdb_meta_scoped_root_when_root_omitted (python-lmdb unavailable)")
+            return
+        exploratory = os.path.join(td, "exploratory.tsv")
+        out = os.path.join(td, "pairs.tsv")
+        manifest = os.path.join(td, "manifest.json")
+        _write(exploratory, "child\tparent\nold_child\told_parent\n")
+
+        _run_cli([
+            "sample_sigma_hop_fresh_corpus.py",
+            "--candidate-lmdb", lmdb_dir,
+            "--exploratory-graph", exploratory,
+            "--pairs", "10",
+            "--hmax", "5",
+            "--min-descendants", "10",
+            "--out", out,
+            "--manifest", manifest,
+            "--allow-small-sample",
+        ])
+
+        with open(manifest, encoding="utf-8") as f:
+            m = json.load(f)
+        assert m["scope_root"] == "Scope_root"
+        assert m["scope_root_id"] == 100
+        assert m["selected_roots"] == ["Fresh_root"]
+
+
+def test_cli_rejects_lmdb_identity_numeric_title_layer():
+    with tempfile.TemporaryDirectory() as td:
+        lmdb_dir = os.path.join(td, "candidate.lmdb")
+        if not _lmdb_chain_fixture(lmdb_dir, identity_titles=True):
+            print("  skip test_cli_rejects_lmdb_identity_numeric_title_layer (python-lmdb unavailable)")
+            return
+        exploratory = os.path.join(td, "exploratory.tsv")
+        _write(exploratory, "child\tparent\nold_child\told_parent\n")
+
+        try:
+            _run_cli([
+                "sample_sigma_hop_fresh_corpus.py",
+                "--candidate-lmdb", lmdb_dir,
+                "--exploratory-graph", exploratory,
+                "--root", "1",
+                "--pairs", "10",
+                "--hmax", "5",
+                "--min-descendants", "10",
+                "--out", os.path.join(td, "pairs.tsv"),
+                "--manifest", os.path.join(td, "manifest.json"),
+                "--allow-small-sample",
+            ])
+        except FreshCorpusError as exc:
+            assert "identity numeric" in str(exc)
+        else:
+            raise AssertionError("expected identity numeric LMDB title layer to abort")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a materializer for real category-title lookup sub-dbs inside Phase-1 category LMDBs
- teach the sigma-hop fresh-corpus sampler to read candidate graph structure from LMDB
- require a real title layer for LMDB score-input output, rejecting identity numeric `i2s`
- keep existing TSV sampler behavior for compatibility

## Tests
- `python3 prototypes/mu_cosine/test_sigma_hop_fresh_corpus.py`
- `python3 prototypes/mu_cosine/test_materialize_lmdb_title_layer.py`
- `python3 -m py_compile prototypes/mu_cosine/sample_sigma_hop_fresh_corpus.py prototypes/mu_cosine/materialize_lmdb_title_layer.py prototypes/mu_cosine/test_sigma_hop_fresh_corpus.py prototypes/mu_cosine/test_materialize_lmdb_title_layer.py`