### PR TITLE
Add Rust WAM dynamic database builtins

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -671,6 +671,8 @@ wam_instruction_arm('Instruction::Call(p, _arity)', Body) :-
                     self.cp = self.pc + 1;
                     self.pc = target_pc;
                     true
+                } else if p == "retract/1" {
+                    self.dynamic_retract_call(self.pc + 1)
                 } else if self.foreign_predicates.contains(p) {
                     self.cp = self.pc + 1;
                     if self.execute_foreign_predicate(p, *_arity) {
@@ -682,6 +684,8 @@ wam_instruction_arm('Instruction::Call(p, _arity)', Body) :-
                     // continuation is the next instruction; the fact enumerator
                     // sets pc/cp and leaves a choice point for further rows.
                     __ftr
+                } else if self.dynamic_call(p, self.pc + 1) {
+                    true
                 } else if Self::is_iso_meta_builtin(p) {
                     // ISO meta-builtins (catch/3, throw/1, succ/2) are
                     // emitted by the shared WAM compiler as Call rather
@@ -738,12 +742,16 @@ wam_instruction_arm('Instruction::Execute(p)', Body) :-
     Body = '                if let Some(&target_pc) = self.labels.get(p) {
                     self.pc = target_pc;
                     true
+                } else if p == "retract/1" {
+                    self.dynamic_retract_call(self.cp)
                 } else if self.foreign_predicates.contains(p) {
                     self.execute_foreign_predicate(p, 0)
                 } else if let Some(__ftr) = crate::fact_table_call(self, p, self.cp) {
                     // T9 fact table in tail position: continuation is the saved
                     // cp (the caller resumes there when the fact pred succeeds).
                     __ftr
+                } else if self.dynamic_call(p, self.cp) {
+                    true
                 } else if Self::is_iso_meta_builtin(p) {
                     // Tail-position ISO meta-builtin: dispatch, then honor
                     // return semantics by jumping to the continuation.
@@ -1581,6 +1589,9 @@ compile_execute_term_builtin_to_rust(Code) :-
             "term_to_atom/2" => { self.execute_term_to_atom_builtin() }
             "read_term_from_atom/2" => { self.execute_read_term_from_atom_builtin(2) }
             "read_term_from_atom/3" => { self.execute_read_term_from_atom_builtin(3) }
+            "read/1" | "read_term/1" => { self.execute_read_term_builtin() }
+            "assertz/1" | "asserta/1" => { self.execute_assert_builtin(op) }
+            "retractall/1" => { self.execute_retractall_builtin() }
             _ => false,
         }
     }
@@ -1881,7 +1892,14 @@ compile_execute_term_builtin_to_rust(Code) :-
             }
         }
         name.to_string()
-    }'.
+    }
+
+    '.
+
+
+compile_dynamic_db_helpers_to_rust(Code) :-
+    read_template_file('templates/targets/rust_wam/dynamic_db_methods.rs.mustache', Template),
+    render_template(Template, [], Code).
 
 compile_execute_foreign_predicate_to_rust(Code) :-
     Code = '    /// Execute a registered foreign predicate by name/arity.
@@ -3517,6 +3535,40 @@ compile_resume_builtin_to_rust(Code) :-
                 if self.unify(&a2, &Value::Atom(values[idx].clone())) {
                     self.pc += 1; true
                 } else { false }
+            }
+            "dynamic_call" => {
+                let key = match state.args.get(0) {
+                    Some(Value::Atom(key)) => key.clone(),
+                    _ => return false,
+                };
+                let start_idx = match state.data.get(0) {
+                    Some(Value::Integer(n)) => *n as usize,
+                    _ => return false,
+                };
+                let cont_pc = match state.data.get(1) {
+                    Some(Value::Integer(n)) => *n as usize,
+                    _ => return false,
+                };
+                self.dynamic_call_attempt(key, start_idx, cont_pc)
+            }
+            "dynamic_retract" => {
+                let key = match state.args.get(0) {
+                    Some(Value::Atom(key)) => key.clone(),
+                    _ => return false,
+                };
+                let pattern = match state.args.get(1) {
+                    Some(pattern) => pattern.clone(),
+                    _ => return false,
+                };
+                let start_idx = match state.data.get(0) {
+                    Some(Value::Integer(n)) => *n as usize,
+                    _ => return false,
+                };
+                let cont_pc = match state.data.get(1) {
+                    Some(Value::Integer(n)) => *n as usize,
+                    _ => return false,
+                };
+                self.dynamic_retract_attempt(key, start_idx, pattern, cont_pc)
             }
             "foreign_results" => {
                 let pred_key = match state.args.get(0) {
@@ -6298,7 +6350,11 @@ write_wam_rust_project(Predicates, Options, ProjectDir) :-
     % Generate state.rs: template + transpiled runtime methods
     option(include_runtime(IncludeRuntime), Options, true),
     read_template_file('templates/targets/rust_wam/state.rs.mustache', StateTemplate),
-    render_template(StateTemplate, [date=Date], StateBase),
+    (   IncludeRuntime == true
+    ->  compile_dynamic_db_helpers_to_rust(DynamicDbCode)
+    ;   DynamicDbCode = ''
+    ),
+    render_template(StateTemplate, [date=Date, dynamic_db_methods=DynamicDbCode], StateBase),
     (   IncludeRuntime == true
     ->  compile_wam_runtime_to_rust(Options, RuntimeCode),
         format(string(StateCode), "~w\n\n~w", [StateBase, RuntimeCode])

--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -1,0 +1,269 @@
+// Dynamic database and source-term input helpers for WamState.
+// Included inside `impl WamState` by wam_rust_target.pl.
+
+    fn execute_read_term_builtin(&mut self) -> bool {
+        use std::io::Read;
+        let mut input = String::new();
+        if std::io::stdin().read_to_string(&mut input).is_err() {
+            return false;
+        }
+        let text = match Self::first_dotted_term_text(&input) {
+            Some(text) => text,
+            None => {
+                let eof = Value::Atom("end_of_file".to_string());
+                let target = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+                return if self.unify(&target, &eof) { self.pc += 1; true } else { false };
+            }
+        };
+        if self.bind_compiled_parse_atom(&text, "A1") { self.pc += 1; true }
+        else { false }
+    }
+
+    fn first_dotted_term_text(input: &str) -> Option<String> {
+        let trimmed = input.trim_start();
+        if trimmed.is_empty() { return None; }
+        let bytes = trimmed.as_bytes();
+        let mut in_quote = false;
+        let mut escaped = false;
+        for (idx, &b) in bytes.iter().enumerate() {
+            if in_quote {
+                if escaped { escaped = false; continue; }
+                if b == 92 { escaped = true; continue; }
+                if b == 39 { in_quote = false; }
+                continue;
+            }
+            if b == 39 { in_quote = true; continue; }
+            if b == 46 {
+                let next_is_term_end = bytes.get(idx + 1)
+                    .map(|c| c.is_ascii_whitespace())
+                    .unwrap_or(true);
+                if next_is_term_end {
+                    return Some(trimmed[..idx].trim().to_string());
+                }
+            }
+        }
+        let body = trimmed.trim_end();
+        let body = body.strip_suffix(".").unwrap_or(body);
+        Some(body.trim().to_string())
+    }
+
+    fn execute_assert_builtin(&mut self, op: &str) -> bool {
+        let raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let term = self.deref_heap(&self.deref_var(&raw));
+        if matches!(term, Value::Unbound(_) | Value::Uninit) { return false; }
+        let key = match self.dynamic_clause_key(&term) {
+            Some(key) => key,
+            None => return false,
+        };
+        let mut var_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let stored = Self::copy_term_walk(&mut self.var_counter, &mut var_map, &term);
+        let bucket = self.dynamic_db.entry(key).or_default();
+        if op == "asserta/1" { bucket.insert(0, stored); }
+        else { bucket.push(stored); }
+        self.pc += 1;
+        true
+    }
+
+    fn execute_retractall_builtin(&mut self) -> bool {
+        let raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let pattern = self.deref_heap(&self.deref_var(&raw));
+        if matches!(pattern, Value::Unbound(_) | Value::Uninit) { return false; }
+        let key = match self.dynamic_clause_key(&pattern) {
+            Some(key) => key,
+            None => return false,
+        };
+        let clauses = self.dynamic_db.remove(&key).unwrap_or_default();
+        let mut kept = Vec::new();
+        for clause in clauses {
+            if !self.dynamic_clause_matches_pattern(&pattern, &clause) {
+                kept.push(clause);
+            }
+        }
+        if !kept.is_empty() {
+            self.dynamic_db.insert(key, kept);
+        }
+        self.pc += 1;
+        true
+    }
+
+    fn dynamic_clause_key(&self, clause: &Value) -> Option<String> {
+        let head = self.dynamic_clause_head(clause)?;
+        self.dynamic_head_key(&head)
+    }
+
+    fn dynamic_clause_head(&self, clause: &Value) -> Option<Value> {
+        match clause {
+            Value::Str(f, args) if (f == ":-" || f == ":-/2") && args.len() == 2 => {
+                Some(args[0].clone())
+            }
+            other => Some(other.clone()),
+        }
+    }
+
+    fn dynamic_clause_head_body(&self, clause: &Value) -> Option<(Value, Option<Value>)> {
+        match clause {
+            Value::Str(f, args) if (f == ":-" || f == ":-/2") && args.len() == 2 => {
+                Some((args[0].clone(), Some(args[1].clone())))
+            }
+            other => Some((other.clone(), None)),
+        }
+    }
+
+    fn dynamic_head_key(&self, head: &Value) -> Option<String> {
+        match head {
+            Value::Atom(name) => Some(format!("{}/0", name)),
+            Value::Str(f, args) => {
+                let name = Self::display_functor_name(f, args.len());
+                Some(format!("{}/{}", name, args.len()))
+            }
+            _ => None,
+        }
+    }
+
+    fn dynamic_clause_matches_pattern(&mut self, pattern: &Value, clause: &Value) -> bool {
+        let mark = self.trail.len();
+        let heap_mark = self.heap.len();
+        let mut pattern_vars = std::collections::HashMap::new();
+        let mut clause_vars = std::collections::HashMap::new();
+        let p = Self::copy_term_walk(&mut self.var_counter, &mut pattern_vars, pattern);
+        let head = match self.dynamic_clause_head(clause) {
+            Some(head) => Self::copy_term_walk(&mut self.var_counter, &mut clause_vars, &head),
+            None => return false,
+        };
+        let ok = self.unify(&p, &head);
+        self.unwind_trail_to(mark);
+        self.heap.truncate(heap_mark);
+        ok
+    }
+
+    fn dynamic_call(&mut self, key: &str, cont_pc: usize) -> bool {
+        if !self.dynamic_db.contains_key(key) { return false; }
+        self.dynamic_call_attempt(key.to_string(), 0, cont_pc)
+    }
+
+    fn dynamic_call_attempt(&mut self, key: String, start_idx: usize, cont_pc: usize) -> bool {
+        let clauses = match self.dynamic_db.get(&key) {
+            Some(clauses) => clauses.clone(),
+            None => return false,
+        };
+        for idx in start_idx..clauses.len() {
+            let cp_trail = self.trail.len();
+            let cp_heap = self.heap.len();
+            let cp_regs = self.save_regs();
+            let cp_stack = self.stack.clone();
+            let mut var_map = std::collections::HashMap::new();
+            let clause = Self::copy_term_walk(&mut self.var_counter, &mut var_map, &clauses[idx]);
+            if self.dynamic_apply_clause(&clause) {
+                if idx + 1 < clauses.len() {
+                    self.choice_points.push(ChoicePoint {
+                        next_pc: cont_pc,
+                        saved_args: cp_regs,
+                        stack: cp_stack,
+                        cp: self.cp,
+                        trail_len: cp_trail,
+                        heap_len: cp_heap,
+                        builtin_state: Some(BuiltinState {
+                            name: "dynamic_call".to_string(),
+                            args: vec![Value::Atom(key.clone())],
+                            data: vec![Value::Integer((idx + 1) as i64), Value::Integer(cont_pc as i64)],
+                        }),
+                        cut_barrier: self.cut_barrier,
+                    });
+                }
+                self.pc = cont_pc;
+                return true;
+            }
+            self.unwind_trail_to(cp_trail);
+            self.heap.truncate(cp_heap);
+            self.restore_regs(&cp_regs);
+            self.stack = cp_stack;
+        }
+        false
+    }
+
+    fn dynamic_apply_clause(&mut self, clause: &Value) -> bool {
+        let (head, body) = match self.dynamic_clause_head_body(clause) {
+            Some(parts) => parts,
+            None => return false,
+        };
+        if !self.dynamic_unify_head_args(&head) { return false; }
+        match body {
+            None => true,
+            Some(Value::Atom(ref s)) if s == "true" => true,
+            _ => false,
+        }
+    }
+
+    fn dynamic_unify_head_args(&mut self, head: &Value) -> bool {
+        match head {
+            Value::Atom(_) => true,
+            Value::Str(_, args) => {
+                for (idx, arg) in args.iter().enumerate() {
+                    let reg = format!("A{}", idx + 1);
+                    let raw = self.get_reg_raw(&reg).unwrap_or(Value::Uninit);
+                    if !self.unify(&raw, arg) { return false; }
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn dynamic_retract_call(&mut self, cont_pc: usize) -> bool {
+        let raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let pattern = self.deref_heap(&self.deref_var(&raw));
+        if matches!(pattern, Value::Unbound(_) | Value::Uninit) { return false; }
+        let key = match self.dynamic_clause_key(&pattern) {
+            Some(key) => key,
+            None => return false,
+        };
+        self.dynamic_retract_attempt(key, 0, pattern, cont_pc)
+    }
+
+    fn dynamic_retract_attempt(&mut self, key: String, start_idx: usize, pattern: Value, cont_pc: usize) -> bool {
+        let clauses = match self.dynamic_db.get(&key) {
+            Some(clauses) => clauses.clone(),
+            None => return false,
+        };
+        for idx in start_idx..clauses.len() {
+            let cp_trail = self.trail.len();
+            let cp_heap = self.heap.len();
+            let cp_regs = self.save_regs();
+            let cp_stack = self.stack.clone();
+            let mut clause_vars = std::collections::HashMap::new();
+            let p = pattern.clone();
+            let head = match self.dynamic_clause_head(&clauses[idx]) {
+                Some(head) => Self::copy_term_walk(&mut self.var_counter, &mut clause_vars, &head),
+                None => continue,
+            };
+            if self.unify(&p, &head) {
+                if let Some(bucket) = self.dynamic_db.get_mut(&key) {
+                    if idx < bucket.len() { bucket.remove(idx); }
+                    if bucket.is_empty() { self.dynamic_db.remove(&key); }
+                }
+                if self.dynamic_db.get(&key).map(|b| idx < b.len()).unwrap_or(false) {
+                    self.choice_points.push(ChoicePoint {
+                        next_pc: cont_pc,
+                        saved_args: cp_regs,
+                        stack: cp_stack,
+                        cp: self.cp,
+                        trail_len: cp_trail,
+                        heap_len: cp_heap,
+                        builtin_state: Some(BuiltinState {
+                            name: "dynamic_retract".to_string(),
+                            args: vec![Value::Atom(key.clone()), pattern.clone()],
+                            data: vec![Value::Integer(idx as i64), Value::Integer(cont_pc as i64)],
+                        }),
+                        cut_barrier: self.cut_barrier,
+                    });
+                }
+                self.pc = cont_pc;
+                return true;
+            }
+            self.unwind_trail_to(cp_trail);
+            self.heap.truncate(cp_heap);
+            self.restore_regs(&cp_regs);
+            self.stack = cp_stack;
+        }
+        false
+    }

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -453,6 +453,12 @@ pub struct WamState {
     pub code: Vec<Instruction>,
     /// Label -> PC mapping.
     pub labels: HashMap<String, usize>,
+    /// Runtime-extensible dynamic clause store populated by asserta/assertz.
+    /// Keys are predicate indicators such as "edge/2"; values are fact terms
+    /// or ":-/2" rule terms. Dynamic DB mutations intentionally live outside
+    /// choice point snapshots, matching Prolog's logical update behavior for
+    /// assert/retract side effects.
+    pub dynamic_db: HashMap<String, Vec<Value>>,
     /// Pre-indexed 2-column atom facts keyed by predicate then first argument.
     pub indexed_atom_fact2: HashMap<String, HashMap<String, Vec<String>>>,
     /// Pre-indexed weighted 3-column edge facts keyed by predicate then source node.
@@ -679,6 +685,7 @@ impl WamState {
             choice_points: Vec::new(),
             code,
             labels,
+            dynamic_db: HashMap::new(),
             indexed_atom_fact2: HashMap::new(),
             indexed_weighted_edge: HashMap::new(),
             atom_intern: HashMap::new(),
@@ -2717,6 +2724,8 @@ impl WamState {
     pub fn resolve_label(&self, label: &str) -> Option<usize> {
         self.labels.get(label).copied()
     }
+
+{{dynamic_db_methods}}
 
     /// Fetch the current instruction.
     pub fn fetch(&self) -> Option<&Instruction> {

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -1,0 +1,65 @@
+use dynrt::instructions::Instruction;
+use dynrt::state::WamState;
+use dynrt::value::Value;
+use std::collections::HashMap;
+
+fn at(s: &str) -> Value { Value::Atom(s.to_string()) }
+fn ub(s: &str) -> Value { Value::Unbound(s.to_string()) }
+fn fact(name: &str, args: Vec<Value>) -> Value { Value::Str(name.to_string(), args) }
+
+fn assert_clause(vm: &mut WamState, op: &str, clause: Value) {
+    vm.set_reg_str("A1", clause);
+    assert!(vm.execute_builtin(op, 1), "{} should succeed", op);
+}
+
+fn dyn_values(vm: &mut WamState) -> Vec<Value> {
+    vm.reset_query();
+    vm.code = vec![Instruction::Call("dyn/1".to_string(), 1), Instruction::Proceed];
+    vm.labels = HashMap::new();
+    vm.set_reg_str("A1", ub("X"));
+    vm.pc = 1;
+    let mut out = Vec::new();
+    if vm.run() {
+        loop {
+            out.push(vm.bindings.get("X").cloned().expect("X bound"));
+            if !vm.backtrack() { break; }
+        }
+    }
+    out
+}
+
+#[test]
+fn assertz_asserta_query_order_and_retractall() {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("red")]));
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("blue")]));
+    assert_clause(&mut vm, "asserta/1", fact("dyn", vec![at("first")]));
+    assert_eq!(dyn_values(&mut vm), vec![at("first"), at("red"), at("blue")]);
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("dyn", vec![at("red")]));
+    assert!(vm.execute_builtin("retractall/1", 1));
+    assert_eq!(dyn_values(&mut vm), vec![at("first"), at("blue")]);
+}
+
+#[test]
+fn retract_removes_one_match_and_binds_pattern() {
+    let mut vm = WamState::new(vec![Instruction::Call("retract/1".to_string(), 1), Instruction::Proceed], HashMap::new());
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("red")]));
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("blue")]));
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("dyn", vec![ub("X")]));
+    vm.pc = 1;
+    assert!(vm.run());
+    assert_eq!(vm.bindings.get("X"), Some(&at("red")));
+    assert_eq!(dyn_values(&mut vm), vec![at("blue")]);
+}
+
+#[test]
+fn read_eof_binds_end_of_file() {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    vm.set_reg_str("A1", ub("T"));
+    assert!(vm.execute_builtin("read/1", 1));
+    assert_eq!(vm.bindings.get("T"), Some(&at("end_of_file")));
+}

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -1,0 +1,46 @@
+:- encoding(utf8).
+% Rust WAM runtime dynamic database builtins.
+% Usage: swipl -q -s tests/test_wam_rust_dynamic_builtins.pl -g run_tests -t halt
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+:- use_module(library(process)).
+:- use_module(library(filesex)).
+
+:- dynamic rust_dyn_dummy/0.
+rust_dyn_dummy.
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :-
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_dynamic_builtins).
+
+test(assert_retract_dynamic_db,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_wam_rust_dynamic_builtins'))]) :-
+    Dir = 'output/test_wam_rust_dynamic_builtins',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project(
+        [user:rust_dyn_dummy/0],
+        [module_name(dynrt), no_kernels(true)], Dir)),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/dynamic_builtins.rs', TestPath),
+    read_file_to_string('tests/fixtures/wam_rust_dynamic_builtins.rs', TestSrc, []),
+    setup_call_cleanup(open(TestPath, write, S), format(S, '~s', [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test dynamic_builtins -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[WAM Rust dynamic builtins FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_dynamic_builtins).


### PR DESCRIPTION
## Summary
- Add Rust WAM runtime support for `asserta/1`, `assertz/1`, `retract/1`, `retractall/1`, `read/1`, and `read_term/1`.
- Add a runtime `dynamic_db` store to `WamState` and route dynamic predicate calls through it.
- Move the larger dynamic database/runtime helper implementation into a Rust WAM Mustache template.
- Add focused Rust-generation coverage for dynamic assert/retract/query behavior and `read/1` EOF handling.

## Testing
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `swipl -q -t halt -s tests/test_wam_rust_dynamic_builtins.pl`
- `swipl -q -s tests/test_wam_rust_dynamic_builtins.pl -g run_tests -t halt`