### PR TITLE
Support Rust WAM asserted rule bodies

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -4752,6 +4752,10 @@ compile_execute_meta_builtin_to_rust(Code) :-
             self.pc = saved_pc;
             return ok;
         }
+        if self.dynamic_call(key, saved_pc) {
+            self.pc = saved_pc;
+            return true;
+        }
         false
     }'.
 

--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -189,8 +189,20 @@
         if !self.dynamic_unify_head_args(&head) { return false; }
         match body {
             None => true,
-            Some(Value::Atom(ref s)) if s == "true" => true,
-            _ => false,
+            Some(body) => self.dynamic_eval_body(&body),
+        }
+    }
+
+    fn dynamic_eval_body(&mut self, body: &Value) -> bool {
+        let body = self.deref_heap(&self.deref_var(body));
+        match body {
+            Value::Atom(ref s) if s == "true" => true,
+            Value::Atom(ref s) if s == "fail" || s == "false" => false,
+            Value::Str(ref f, ref args) if (f == "," || f == ",/2") && args.len() == 2 => {
+                if !self.dynamic_eval_body(&args[0]) { return false; }
+                self.dynamic_eval_body(&args[1])
+            }
+            other => self.call_goal_value(&other),
         }
     }
 

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 fn at(s: &str) -> Value { Value::Atom(s.to_string()) }
 fn ub(s: &str) -> Value { Value::Unbound(s.to_string()) }
 fn fact(name: &str, args: Vec<Value>) -> Value { Value::Str(name.to_string(), args) }
+fn rule(head: Value, body: Value) -> Value { fact(":-", vec![head, body]) }
+fn conj(left: Value, right: Value) -> Value { fact(",", vec![left, right]) }
 
 fn assert_clause(vm: &mut WamState, op: &str, clause: Value) {
     vm.set_reg_str("A1", clause);
@@ -21,7 +23,26 @@ fn dyn_values(vm: &mut WamState) -> Vec<Value> {
     let mut out = Vec::new();
     if vm.run() {
         loop {
-            out.push(vm.bindings.get("X").cloned().expect("X bound"));
+            let x = vm.bindings.get("X").cloned().expect("X bound");
+            out.push(vm.deref_heap(&vm.deref_var(&x)));
+            if !vm.backtrack() { break; }
+        }
+    }
+    out
+}
+
+fn second_values(vm: &mut WamState, pred: &str, first: Value) -> Vec<Value> {
+    vm.reset_query();
+    vm.code = vec![Instruction::Call(pred.to_string(), 2), Instruction::Proceed];
+    vm.labels = HashMap::new();
+    vm.set_reg_str("A1", first);
+    vm.set_reg_str("A2", ub("Y"));
+    vm.pc = 1;
+    let mut out = Vec::new();
+    if vm.run() {
+        loop {
+            let y = vm.bindings.get("Y").cloned().expect("Y bound");
+            out.push(vm.deref_heap(&vm.deref_var(&y)));
             if !vm.backtrack() { break; }
         }
     }
@@ -54,6 +75,35 @@ fn retract_removes_one_match_and_binds_pattern() {
     assert!(vm.run());
     assert_eq!(vm.bindings.get("X"), Some(&at("red")));
     assert_eq!(dyn_values(&mut vm), vec![at("blue")]);
+}
+
+#[test]
+fn asserted_rule_body_calls_dynamic_predicates() {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    assert_clause(&mut vm, "assertz/1", fact("parent", vec![at("ann"), at("bob")]));
+    assert_clause(&mut vm, "assertz/1", fact("parent", vec![at("bob"), at("cid")]));
+    assert_clause(
+        &mut vm,
+        "assertz/1",
+        rule(
+            fact("ancestor", vec![ub("X"), ub("Y")]),
+            fact("parent", vec![ub("X"), ub("Y")]),
+        ),
+    );
+    assert_clause(
+        &mut vm,
+        "assertz/1",
+        rule(
+            fact("grandparent", vec![ub("X"), ub("Z")]),
+            conj(
+                fact("parent", vec![ub("X"), ub("Y")]),
+                fact("parent", vec![ub("Y"), ub("Z")]),
+            ),
+        ),
+    );
+
+    assert_eq!(second_values(&mut vm, "ancestor/2", at("ann")), vec![at("bob")]);
+    assert_eq!(second_values(&mut vm, "grandparent/2", at("ann")), vec![at("cid")]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Evaluate asserted dynamic rule bodies instead of only accepting facts and `true` bodies.
- Add body support for `true`, `fail`/`false`, conjunction `,/2`, and ordinary goal calls.
- Route Rust WAM meta-calls through the dynamic database so asserted rules can call asserted predicates.
- Extend the dynamic builtins Rust fixture to cover asserted rules and conjunction over dynamic predicates.

## Testing
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `swipl -q -t halt -s tests/test_wam_rust_dynamic_builtins.pl`
- `swipl -q -s tests/test_wam_rust_dynamic_builtins.pl -g run_tests -t halt`