### PR TITLE
Codex/sigma hop confirmatory run

### DIFF
--- a/prototypes/mu_cosine/REPORT_sigma_hop_confirmatory.md
+++ b/prototypes/mu_cosine/REPORT_sigma_hop_confirmatory.md
@@ -44,6 +44,9 @@ rendered run report: /tmp/mu_data/sigma_hop_confirmatory_REPORT.md
 runner commit: 98efc2fdc Add LMDB graph support to sigma-hop confirmatory runner
 ```
 
+The `/tmp/mu_data/...` paths above are local run artifacts, not durable repository records. The durable record in this
+PR is this committed report plus the runner change needed to consume the LMDB feature graph.
+
 The selected root was `Behavior`. The retained LMDB slice had 75,901 nodes after the preregistered no-overlap and
 admin-title filtering. Sampling produced exactly 50 pairs at each shortest upward hop 1..5.
 

--- a/prototypes/mu_cosine/REPORT_sigma_hop_confirmatory.md
+++ b/prototypes/mu_cosine/REPORT_sigma_hop_confirmatory.md
@@ -1,0 +1,71 @@
+# Confirmatory Sigma(hop) run: confirmed on a fresh Behavior slice
+
+*Run 2026-07-07 against `PREREG_sigma_hop_confirmatory.md`, after sampling and scoring a fresh Wikipedia category
+slice that shares no category nodes with the exploratory `100k_cats` graph.*
+
+## Decision
+
+The preregistered confirmatory decision is **confirmed**: smooth `Sigma(hop)` beat constant-Sigma on held-out
+continuous-mu residual likelihood, and the one-sided hop-shuffle permutation test passed the frozen `p < 0.01`
+threshold.
+
+```text
+fresh corpus dump/root: enwiki_cats_correct scoped LMDB; title layer mediawiki_page_titles; scope Main_topic_classifications; selected root Behavior
+node-overlap check with 100k_cats: passed, 0 overlapping category titles
+n scored pairs: 250
+hop counts: {1: 50, 2: 50, 3: 50, 4: 50, 5: 50}
+judge/prompt/model: gpt-5.5 with model_reasoning_effort=low via score_with_codex.py / score_inferred_tail.py prompt
+valid descendant-disjoint splits: 40
+mean held pairs/split: 75.0
+observed mean gain: +0.059799
+constant-Sigma NLL: -0.604010
+Sigma(hop) NLL: -0.663809
+hop-shuffle null mean: -0.009487
+hop-shuffle null 95%ile: +0.000456
+K: 1000
+permutation p: 0.000999
+decision: confirmed
+skipped splits: 0
+```
+
+At `K=1000`, `p=0.000999` is the finite-permutation floor `(1 + 0) / (1000 + 1)`: no shuffled-hop null run reached
+the observed mean gain.
+
+## Artifacts
+
+```text
+score input: /tmp/mu_data/sigma_hop_fresh_pairs.tsv
+sampling manifest: /tmp/mu_data/sigma_hop_fresh_manifest.json
+raw judge responses: /tmp/mu_data/sigma_hop_fresh_responses_gpt55low.txt
+ingested judge scores: /tmp/mu_data/sigma_hop_fresh_scored_gpt55low.tsv
+retained-slice e5 cache: /tmp/mu_data/sigma_hop_behavior_slice_e5.pt
+result JSON: /tmp/mu_data/sigma_hop_confirmatory_result.json
+rendered run report: /tmp/mu_data/sigma_hop_confirmatory_REPORT.md
+runner commit: 98efc2fdc Add LMDB graph support to sigma-hop confirmatory runner
+```
+
+The selected root was `Behavior`. The retained LMDB slice had 75,901 nodes after the preregistered no-overlap and
+admin-title filtering. Sampling produced exactly 50 pairs at each shortest upward hop 1..5.
+
+## Implementation Notes
+
+Two mechanical issues were fixed before any gain/permutation result was computed:
+
+- The confirmatory runner was originally TSV-only for feature-graph loading, while the fresh corpus came from the
+  LMDB title graph. Commit `98efc2fdc` added an LMDB feature-graph adapter that reuses the sampler's retained-slice
+  traversal. This changed no labels, model family, split protocol, permutation null, threshold, or decision rule.
+- An endpoint-only e5 cache was insufficient because `Tokenizer` also embeds retained-slice ancestors. The final run
+  used `/tmp/mu_data/sigma_hop_behavior_slice_e5.pt`, built over all 75,901 retained `Behavior` slice nodes with the
+  same `intfloat/e5-small-v2` query/passage prefixes.
+
+Two earlier run attempts stopped before producing a statistic: first because the clean worktree lacked the local
+`model_prod.pt` artifact, then because the endpoint-only e5 cache lacked ancestor tokens. The completed run used the
+exact local checkpoint at `/home/s243a/Projects/UnifyWeaver/prototypes/mu_cosine/model_prod.pt`.
+
+## Interpretation
+
+This closes the main post-exploratory caveat for the Wikipedia-category regime tested here: the smooth hop-conditional
+covariance result transferred to a fresh, descendant-disjoint, no-overlap category slice under the frozen test. The
+carry-forward limitations from the preregistration still apply: single LLM judge, descendant-not-both-endpoint split,
+functional form as regularization, graph-topological dependence, and one Wikipedia slice rather than universality
+across other concept graphs.

--- a/prototypes/mu_cosine/sigma_hop_confirmatory.py
+++ b/prototypes/mu_cosine/sigma_hop_confirmatory.py
@@ -24,6 +24,7 @@ from emit_direction_blend import parse_responses
 from emit_transitive_hops import hit_prob
 from eval_relatedness import build_model
 from mu_attention import OPS, Tokenizer, load_dag
+from sample_sigma_hop_fresh_corpus import FreshCorpusError, LmdbTitleGraph, load_lmdb_slice_maps
 
 
 DIR = ["subcategory", "subtopic", "element_of", "super_category"]
@@ -260,6 +261,63 @@ def assert_no_node_overlap(pairs, exploratory_graph):
     return overlap
 
 
+def degree_from_maps(parents, children):
+    nodes = set(parents) | set(children)
+    return {
+        node: len(parents.get(node, ())) + len(children.get(node, ()))
+        for node in nodes
+    }
+
+
+def load_feature_graph(
+    graph,
+    candidate_lmdb,
+    lmdb_root,
+    exploratory_graph,
+    title_i2s_db="title_i2s",
+    title_s2i_db="title_s2i",
+    lmdb_no_lock=False,
+):
+    """Return parents/children/degree maps for confirmatory feature construction.
+
+    TSV keeps backward compatibility with the exploratory runner. LMDB reuses the sampler's retained-slice
+    traversal so `hit_prob` is computed on the same no-overlap/admin-filtered graph that produced the fresh pairs.
+    """
+    if graph:
+        parents, children, deg = load_dag(graph)
+        return parents, children, deg, {}
+
+    if not candidate_lmdb:
+        raise ConfirmatoryInputError("one of --graph or --candidate-lmdb is required")
+    if not lmdb_root:
+        raise ConfirmatoryInputError("--candidate-lmdb requires --lmdb-root for confirmatory feature construction")
+    if not exploratory_graph:
+        raise ConfirmatoryInputError("--exploratory-graph is required for LMDB no-overlap graph filtering")
+
+    exploratory_nodes = load_exploratory_nodes(exploratory_graph)
+    lmdb_graph = LmdbTitleGraph(candidate_lmdb, title_i2s_db, title_s2i_db, lock=not lmdb_no_lock)
+    try:
+        root_id = lmdb_graph.node_id(lmdb_root)
+        root_title, slice_nodes, parents, children, stats = load_lmdb_slice_maps(
+            lmdb_graph, root_id, exploratory_nodes
+        )
+    except FreshCorpusError as exc:
+        raise ConfirmatoryInputError(str(exc)) from exc
+    finally:
+        lmdb_graph.close()
+
+    if not slice_nodes:
+        raise ConfirmatoryInputError(f"LMDB root `{lmdb_root}` produced an empty retained feature graph")
+    deg = degree_from_maps(parents, children)
+    return parents, children, deg, {
+        "feature_graph_source": "lmdb",
+        "feature_graph_lmdb": candidate_lmdb,
+        "feature_graph_root": root_title,
+        "feature_graph_slice_nodes": len(slice_nodes),
+        "feature_graph_lmdb_stats": dict(sorted(stats.items())),
+    }
+
+
 def load_confirmatory_labels(score_in, responses, prefix, exploratory_graph):
     pairs, hop, D, S = load_scored_pairs(score_in, responses, prefix=prefix)
     assert_no_node_overlap(pairs, exploratory_graph)
@@ -281,8 +339,8 @@ def load_e5_cache_and_filter(pairs, hop, D, S, e5_cache):
     return cache, idx, filtered_pairs, hop[keep], D[keep], S[keep]
 
 
-def build_confirmatory_features(pairs, cache, idx, graph, model_path, device):
-    parents, _, deg = load_dag(graph)
+def build_confirmatory_features(pairs, cache, idx, graph, model_path, device, **feature_graph_kwargs):
+    parents, _, deg, _ = load_feature_graph(graph=graph, **feature_graph_kwargs)
     tokenizer = Tokenizer(cache["query"], cache["passage"], idx, parents, deg)
     model = build_model(model_path, device)
 
@@ -302,16 +360,20 @@ def build_confirmatory_features(pairs, cache, idx, graph, model_path, device):
     return np.column_stack([muD, muS, gd, np.ones(len(pairs))])
 
 
-def build_confirmatory_data_from_labels(pairs, hop, D, S, e5_cache, graph, model_path, device):
+def build_confirmatory_data_from_labels(pairs, hop, D, S, e5_cache, graph, model_path, device, **feature_graph_kwargs):
     cache, idx, pairs, hop, D, S = load_e5_cache_and_filter(pairs, hop, D, S, e5_cache)
     validate_hop_range(hop)
-    X = build_confirmatory_features(pairs, cache, idx, graph, model_path, device)
+    X = build_confirmatory_features(pairs, cache, idx, graph, model_path, device, **feature_graph_kwargs)
     return ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=X)
 
 
-def build_confirmatory_data(score_in, responses, e5_cache, graph, model_path, device, prefix, exploratory_graph):
+def build_confirmatory_data(
+    score_in, responses, e5_cache, graph, model_path, device, prefix, exploratory_graph, **feature_graph_kwargs
+):
     pairs, hop, D, S = load_confirmatory_labels(score_in, responses, prefix, exploratory_graph)
-    return build_confirmatory_data_from_labels(pairs, hop, D, S, e5_cache, graph, model_path, device)
+    return build_confirmatory_data_from_labels(
+        pairs, hop, D, S, e5_cache, graph, model_path, device, **feature_graph_kwargs
+    )
 
 
 def _one_line(value):
@@ -372,7 +434,13 @@ def main():
     ap.add_argument("--score-in", required=True)
     ap.add_argument("--responses", required=True)
     ap.add_argument("--e5-cache", required=True)
-    ap.add_argument("--graph", required=True)
+    graph_source = ap.add_mutually_exclusive_group(required=True)
+    graph_source.add_argument("--graph", help="child<TAB>parent TSV graph for feature construction")
+    graph_source.add_argument("--candidate-lmdb", help="Phase-1 category LMDB graph for feature construction")
+    ap.add_argument("--lmdb-root", help="selected retained LMDB slice root, e.g. the sampled root recorded in the manifest")
+    ap.add_argument("--title-i2s-db", default="title_i2s", help="LMDB uint32 id -> real category title sub-db")
+    ap.add_argument("--title-s2i-db", default="title_s2i", help="LMDB real category title -> uint32 id sub-db")
+    ap.add_argument("--lmdb-no-lock", action="store_true", help="open candidate LMDB with lock=False; use only for immutable fixtures")
     ap.add_argument("--model", default="model_prod.pt")
     ap.add_argument("--prefix", default="transitive_h")
     ap.add_argument("--exploratory-graph", required=True, help="PR #3517 100k_cats/category_parent.tsv for required no-overlap check")
@@ -417,7 +485,15 @@ def main():
         if not splits:
             raise ConfirmatoryInputError("no valid descendant-disjoint splits survived e5-cache filtering")
 
-        X = build_confirmatory_features(pairs, cache, idx, args.graph, args.model, device)
+        feature_graph_kwargs = {
+            "candidate_lmdb": args.candidate_lmdb,
+            "lmdb_root": args.lmdb_root,
+            "exploratory_graph": args.exploratory_graph,
+            "title_i2s_db": args.title_i2s_db,
+            "title_s2i_db": args.title_s2i_db,
+            "lmdb_no_lock": args.lmdb_no_lock,
+        }
+        X = build_confirmatory_features(pairs, cache, idx, args.graph, args.model, device, **feature_graph_kwargs)
         data = ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=X)
     except ConfirmatoryInputError as exc:
         raise SystemExit(str(exc)) from exc

--- a/prototypes/mu_cosine/sigma_hop_confirmatory.py
+++ b/prototypes/mu_cosine/sigma_hop_confirmatory.py
@@ -13,7 +13,9 @@ import json
 import os
 import sys
 import warnings
+from contextlib import closing
 from dataclasses import dataclass
+from typing import Optional
 
 import numpy as np
 import torch
@@ -39,6 +41,17 @@ class ConfirmatoryInputError(ValueError):
 
 class OverlapError(ConfirmatoryInputError):
     pass
+
+
+@dataclass(frozen=True)
+class FeatureGraphConfig:
+    graph: Optional[str]
+    candidate_lmdb: Optional[str] = None
+    lmdb_root: Optional[str] = None
+    exploratory_graph: Optional[str] = None
+    title_i2s_db: str = "title_i2s"
+    title_s2i_db: str = "title_s2i"
+    lmdb_no_lock: bool = False
 
 
 @dataclass(frozen=True)
@@ -263,55 +276,54 @@ def assert_no_node_overlap(pairs, exploratory_graph):
 
 def degree_from_maps(parents, children):
     nodes = set(parents) | set(children)
+    for values in parents.values():
+        nodes.update(values)
+    for values in children.values():
+        nodes.update(values)
     return {
         node: len(parents.get(node, ())) + len(children.get(node, ()))
         for node in nodes
     }
 
 
-def load_feature_graph(
-    graph,
-    candidate_lmdb,
-    lmdb_root,
-    exploratory_graph,
-    title_i2s_db="title_i2s",
-    title_s2i_db="title_s2i",
-    lmdb_no_lock=False,
-):
+def load_feature_graph(config):
     """Return parents/children/degree maps for confirmatory feature construction.
 
     TSV keeps backward compatibility with the exploratory runner. LMDB reuses the sampler's retained-slice
     traversal so `hit_prob` is computed on the same no-overlap/admin-filtered graph that produced the fresh pairs.
     """
-    if graph:
-        parents, children, deg = load_dag(graph)
+    if config.graph:
+        parents, children, deg = load_dag(config.graph)
         return parents, children, deg, {}
 
-    if not candidate_lmdb:
+    if not config.candidate_lmdb:
         raise ConfirmatoryInputError("one of --graph or --candidate-lmdb is required")
-    if not lmdb_root:
+    if not config.lmdb_root:
         raise ConfirmatoryInputError("--candidate-lmdb requires --lmdb-root for confirmatory feature construction")
-    if not exploratory_graph:
+    if not config.exploratory_graph:
         raise ConfirmatoryInputError("--exploratory-graph is required for LMDB no-overlap graph filtering")
 
-    exploratory_nodes = load_exploratory_nodes(exploratory_graph)
-    lmdb_graph = LmdbTitleGraph(candidate_lmdb, title_i2s_db, title_s2i_db, lock=not lmdb_no_lock)
+    exploratory_nodes = load_exploratory_nodes(config.exploratory_graph)
     try:
-        root_id = lmdb_graph.node_id(lmdb_root)
-        root_title, slice_nodes, parents, children, stats = load_lmdb_slice_maps(
-            lmdb_graph, root_id, exploratory_nodes
-        )
+        with closing(LmdbTitleGraph(
+            config.candidate_lmdb,
+            config.title_i2s_db,
+            config.title_s2i_db,
+            lock=not config.lmdb_no_lock,
+        )) as lmdb_graph:
+            root_id = lmdb_graph.node_id(config.lmdb_root)
+            root_title, slice_nodes, parents, children, stats = load_lmdb_slice_maps(
+                lmdb_graph, root_id, exploratory_nodes
+            )
     except FreshCorpusError as exc:
         raise ConfirmatoryInputError(str(exc)) from exc
-    finally:
-        lmdb_graph.close()
 
     if not slice_nodes:
-        raise ConfirmatoryInputError(f"LMDB root `{lmdb_root}` produced an empty retained feature graph")
+        raise ConfirmatoryInputError(f"LMDB root `{config.lmdb_root}` produced an empty retained feature graph")
     deg = degree_from_maps(parents, children)
     return parents, children, deg, {
         "feature_graph_source": "lmdb",
-        "feature_graph_lmdb": candidate_lmdb,
+        "feature_graph_lmdb": config.candidate_lmdb,
         "feature_graph_root": root_title,
         "feature_graph_slice_nodes": len(slice_nodes),
         "feature_graph_lmdb_stats": dict(sorted(stats.items())),
@@ -339,8 +351,8 @@ def load_e5_cache_and_filter(pairs, hop, D, S, e5_cache):
     return cache, idx, filtered_pairs, hop[keep], D[keep], S[keep]
 
 
-def build_confirmatory_features(pairs, cache, idx, graph, model_path, device, **feature_graph_kwargs):
-    parents, _, deg, _ = load_feature_graph(graph=graph, **feature_graph_kwargs)
+def build_confirmatory_features(pairs, cache, idx, feature_graph_config, model_path, device):
+    parents, _, deg, _ = load_feature_graph(feature_graph_config)
     tokenizer = Tokenizer(cache["query"], cache["passage"], idx, parents, deg)
     model = build_model(model_path, device)
 
@@ -360,19 +372,19 @@ def build_confirmatory_features(pairs, cache, idx, graph, model_path, device, **
     return np.column_stack([muD, muS, gd, np.ones(len(pairs))])
 
 
-def build_confirmatory_data_from_labels(pairs, hop, D, S, e5_cache, graph, model_path, device, **feature_graph_kwargs):
+def build_confirmatory_data_from_labels(pairs, hop, D, S, e5_cache, feature_graph_config, model_path, device):
     cache, idx, pairs, hop, D, S = load_e5_cache_and_filter(pairs, hop, D, S, e5_cache)
     validate_hop_range(hop)
-    X = build_confirmatory_features(pairs, cache, idx, graph, model_path, device, **feature_graph_kwargs)
+    X = build_confirmatory_features(pairs, cache, idx, feature_graph_config, model_path, device)
     return ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=X)
 
 
 def build_confirmatory_data(
-    score_in, responses, e5_cache, graph, model_path, device, prefix, exploratory_graph, **feature_graph_kwargs
+    score_in, responses, e5_cache, feature_graph_config, model_path, device, prefix, exploratory_graph
 ):
     pairs, hop, D, S = load_confirmatory_labels(score_in, responses, prefix, exploratory_graph)
     return build_confirmatory_data_from_labels(
-        pairs, hop, D, S, e5_cache, graph, model_path, device, **feature_graph_kwargs
+        pairs, hop, D, S, e5_cache, feature_graph_config, model_path, device
     )
 
 
@@ -456,6 +468,10 @@ def main():
     ap.add_argument("--corpus-note", required=True, help="fresh corpus dump/root, recorded before scoring")
     ap.add_argument("--judge-note", required=True, help="judge model, prompt template, and frozen predictor model provenance")
     args = ap.parse_args()
+    if args.candidate_lmdb and not args.lmdb_root:
+        ap.error("--lmdb-root is required when --candidate-lmdb is given")
+    if args.lmdb_root and not args.candidate_lmdb:
+        ap.error("--lmdb-root requires --candidate-lmdb")
 
     validate_preregistered_cli(args)
     device = torch.device(args.device)
@@ -485,15 +501,16 @@ def main():
         if not splits:
             raise ConfirmatoryInputError("no valid descendant-disjoint splits survived e5-cache filtering")
 
-        feature_graph_kwargs = {
-            "candidate_lmdb": args.candidate_lmdb,
-            "lmdb_root": args.lmdb_root,
-            "exploratory_graph": args.exploratory_graph,
-            "title_i2s_db": args.title_i2s_db,
-            "title_s2i_db": args.title_s2i_db,
-            "lmdb_no_lock": args.lmdb_no_lock,
-        }
-        X = build_confirmatory_features(pairs, cache, idx, args.graph, args.model, device, **feature_graph_kwargs)
+        feature_graph_config = FeatureGraphConfig(
+            graph=args.graph,
+            candidate_lmdb=args.candidate_lmdb,
+            lmdb_root=args.lmdb_root,
+            exploratory_graph=args.exploratory_graph,
+            title_i2s_db=args.title_i2s_db,
+            title_s2i_db=args.title_s2i_db,
+            lmdb_no_lock=args.lmdb_no_lock,
+        )
+        X = build_confirmatory_features(pairs, cache, idx, feature_graph_config, args.model, device)
         data = ConfirmatoryData(pairs=pairs, hop=hop, D=D, S=S, X=X)
     except ConfirmatoryInputError as exc:
         raise SystemExit(str(exc)) from exc

--- a/prototypes/mu_cosine/test_sigma_hop_confirmatory.py
+++ b/prototypes/mu_cosine/test_sigma_hop_confirmatory.py
@@ -16,6 +16,7 @@ from sigma_hop_confirmatory import (
     ConfirmatoryInputError,
     OverlapError,
     assert_no_node_overlap,
+    degree_from_maps,
     descendant_disjoint_split,
     load_scored_pairs,
     permutation_test,
@@ -80,6 +81,13 @@ def test_assert_no_node_overlap_allows_clean_pairs():
         assert assert_no_node_overlap((("fresh_child", "fresh_parent"),), path) == []
     finally:
         os.unlink(path)
+
+
+def test_degree_from_maps_includes_value_only_nodes():
+    deg = degree_from_maps({"child": {"parent"}}, {"parent": {"child"}, "orphan_parent": {"leaf_only"}})
+    assert deg["child"] == 1
+    assert deg["parent"] == 1
+    assert deg["leaf_only"] == 0
 
 
 def test_permutation_result_reports_preregistered_decision_fields():


### PR DESCRIPTION
# Report confirmatory Sigma(hop) result

## Summary
- add LMDB feature-graph support to the Sigma(hop) confirmatory runner
- run the preregistered fresh-corpus test on the `Behavior` LMDB slice
- report the confirmed result: mean gain `+0.059799`, `K=1000`, permutation `p=0.000999`

## Tests
- `python3 prototypes/mu_cosine/test_sigma_hop_confirmatory.py`
- `python3 -m py_compile prototypes/mu_cosine/sigma_hop_confirmatory.py prototypes/mu_cosine/sample_sigma_hop_fresh_corpus.py`
- full preregistered confirmatory run, `K=1000`