### PR TITLE
Add product-space transform diagnostics

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -356,8 +356,10 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 
 1. Keep the synthetic overconfidence check in `test_product_kalman_poe_synthetic.py` as the first guardrail:
    shared expert noise should make naive independent PoE report variance below empirical error.
-2. Implement a product-space transform that exposes `log_mu`, `logit_mu`, or likelihood-ratio coordinates explicitly.
-3. Add the noisy-OR upper proxy and track the width `mu_upper - mu_lower` as a disagreement diagnostic.
+2. Keep finite product-space transforms in `product_space.py`: clipped `log_mu`/`logit_mu`, lower/upper
+   product proxies, interval width, and first-order Jacobians for covariance propagation.
+3. Use `test_product_space_monte_carlo.py` as the local nonlinear-statistics sanity check: CPU by default,
+   optional CUDA for larger Monte Carlo runs.
 4. Fit scalar/vector product-Kalman updates with learned `P_ell` and `R_ell`.
 5. Compare against `JointPosterior` and Sigma-conditioned covariance on held-out node-disjoint splits.
 6. Only after the held-out comparison, decide whether this belongs in the training objective.
@@ -373,5 +375,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 - `DESIGN_transitive_relations.md` — predicted-distribution loss for transitive relations and covariance caveats.
 - `test_product_kalman_poe_synthetic.py` — runnable synthetic check that shared expert noise makes independent
   Gaussian PoE overconfident unless the full covariance is modeled.
+- `product_space.py`, `test_product_space.py`, and `test_product_space_monte_carlo.py` — finite product-space
+  transform helpers, closed-form Jacobian tests, and CPU/CUDA Monte Carlo checks for nonlinear covariance propagation.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -357,9 +357,10 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 1. Keep the synthetic overconfidence check in `test_product_kalman_poe_synthetic.py` as the first guardrail:
    shared expert noise should make naive independent PoE report variance below empirical error.
 2. Keep finite product-space transforms in `product_space.py`: clipped `log_mu`/`logit_mu`, lower/upper
-   product proxies, interval width, and first-order Jacobians for covariance propagation.
+   product proxies, interval width, and first-order Jacobians for covariance propagation. *(Completed in PR #3529.)*
 3. Use `test_product_space_monte_carlo.py` as the local nonlinear-statistics sanity check: CPU by default,
-   optional CUDA for larger Monte Carlo runs.
+   optional CUDA for larger Monte Carlo runs. *(Completed in PR #3529; keep as a prototype diagnostic until a
+   Product-Kalman implementation depends on it enough to promote into CI.)*
 4. Fit scalar/vector product-Kalman updates with learned `P_ell` and `R_ell`.
 5. Compare against `JointPosterior` and Sigma-conditioned covariance on held-out node-disjoint splits.
 6. Only after the held-out comparison, decide whether this belongs in the training objective.

--- a/prototypes/mu_cosine/product_space.py
+++ b/prototypes/mu_cosine/product_space.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Finite product-space transforms for Product-Kalman / correlated-PoE prototypes.
+
+These helpers implement the clipping convention from `DESIGN_product_kalman_poe.md`.
+They are intentionally small and numpy-only: they expose stable log/logit coordinates,
+lower/upper product proxies, and link Jacobians without committing to a Kalman model.
+"""
+
+import numpy as np
+
+
+DEFAULT_EPS = 1e-6
+
+
+def clip_mu(mu, eps=DEFAULT_EPS):
+    """Clip membership values into the finite open interval used by log/logit links."""
+    if not 0.0 < eps < 0.5:
+        raise ValueError("eps must be in (0, 0.5)")
+    return np.clip(np.asarray(mu, dtype=float), eps, 1.0 - eps)
+
+
+def log_mu(mu, eps=DEFAULT_EPS):
+    """Finite log-membership evidence, `log(clip(mu))`."""
+    return np.log(clip_mu(mu, eps))
+
+
+def logit_mu(mu, eps=DEFAULT_EPS):
+    """Finite logit-membership evidence, `log(clip(mu)/(1-clip(mu)))`."""
+    m = clip_mu(mu, eps)
+    return np.log(m) - np.log1p(-m)
+
+
+def link_jacobian(mu, link="logit", eps=DEFAULT_EPS):
+    """Derivative d link(mu) / d mu at clipped `mu`.
+
+    Supported links:
+    - `log`:   d log(mu) / d mu = 1 / mu
+    - `logit`: d logit(mu) / d mu = 1 / (mu * (1 - mu))
+    """
+    m = clip_mu(mu, eps)
+    if link == "log":
+        return 1.0 / m
+    if link == "logit":
+        return 1.0 / (m * (1.0 - m))
+    raise ValueError(f"unknown link {link!r}; expected 'log' or 'logit'")
+
+
+def _weights_like(mu, weights):
+    m = np.asarray(mu, dtype=float)
+    if weights is None:
+        return np.ones_like(m, dtype=float)
+    w = np.asarray(weights, dtype=float)
+    if w.shape != m.shape:
+        raise ValueError(f"weights shape {w.shape} must match mu shape {m.shape}")
+    if np.any(w < 0):
+        raise ValueError("weights must be nonnegative")
+    return w
+
+
+def product_lower(mu, weights=None, eps=DEFAULT_EPS):
+    """AND-style lower-support proxy, `prod_i clip(mu_i)^w_i`."""
+    m = clip_mu(mu, eps)
+    w = _weights_like(m, weights)
+    return float(np.exp(np.sum(w * np.log(m))))
+
+
+def product_upper(mu, weights=None, eps=DEFAULT_EPS):
+    """Noisy-OR upper-support proxy, `1 - prod_i (1 - clip(mu_i))^w_i`."""
+    m = clip_mu(mu, eps)
+    w = _weights_like(m, weights)
+    return float(1.0 - np.exp(np.sum(w * np.log1p(-m))))
+
+
+def product_interval(mu, weights=None, eps=DEFAULT_EPS):
+    """Return `(lower, upper, width)` product proxies for a source vector."""
+    lo = product_lower(mu, weights, eps)
+    hi = product_upper(mu, weights, eps)
+    return lo, hi, hi - lo
+
+
+def product_lower_jacobian(mu, weights=None, eps=DEFAULT_EPS):
+    """Derivative of the lower product proxy with respect to clipped `mu`."""
+    m = clip_mu(mu, eps)
+    w = _weights_like(m, weights)
+    return product_lower(m, w, eps) * w / m
+
+
+def product_upper_jacobian(mu, weights=None, eps=DEFAULT_EPS):
+    """Derivative of the upper noisy-OR proxy with respect to clipped `mu`."""
+    m = clip_mu(mu, eps)
+    w = _weights_like(m, weights)
+    complement = np.exp(np.sum(w * np.log1p(-m)))
+    return complement * w / (1.0 - m)
+
+
+def product_interval_jacobian(mu, weights=None, eps=DEFAULT_EPS):
+    """Return Jacobian rows for `(lower, upper, width)` in clipped product space."""
+    lo_j = product_lower_jacobian(mu, weights, eps)
+    hi_j = product_upper_jacobian(mu, weights, eps)
+    return np.vstack([lo_j, hi_j, hi_j - lo_j])
+
+
+def normalized_geometric_weights(n):
+    """Equal exponents summing to one for softened geometric product proxies."""
+    if n <= 0:
+        raise ValueError("n must be positive")
+    return np.full(int(n), 1.0 / float(n))

--- a/prototypes/mu_cosine/product_space.py
+++ b/prototypes/mu_cosine/product_space.py
@@ -4,12 +4,40 @@
 These helpers implement the clipping convention from `DESIGN_product_kalman_poe.md`.
 They are intentionally small and numpy-only: they expose stable log/logit coordinates,
 lower/upper product proxies, and link Jacobians without committing to a Kalman model.
+
+Example:
+
+    mu = [0.25, 0.8]
+    weights = normalized_geometric_weights(len(mu))
+    lower, upper, width = product_interval(mu, weights)
+    J = product_interval_jacobian(mu, weights)
+
+The product proxies are AND/noisy-OR style diagnostics, not calibrated confidence
+intervals. Under correlated experts the true posterior can fall outside the proxy
+interval unless a downstream model calibrates the dependence structure.
 """
 
 import numpy as np
 
 
 DEFAULT_EPS = 1e-6
+
+__all__ = [
+    "DEFAULT_EPS",
+    "clip_mu",
+    "link_jacobian",
+    "log_mu",
+    "logit_mu",
+    "normalized_geometric_weights",
+    "product_interval",
+    "product_interval_jacobian",
+    "product_lower",
+    "product_lower_jacobian",
+    "product_lower_log",
+    "product_upper",
+    "product_upper_complement_log",
+    "product_upper_jacobian",
+]
 
 
 def clip_mu(mu, eps=DEFAULT_EPS):
@@ -45,8 +73,17 @@ def link_jacobian(mu, link="logit", eps=DEFAULT_EPS):
     raise ValueError(f"unknown link {link!r}; expected 'log' or 'logit'")
 
 
-def _weights_like(mu, weights):
+def _source_vector(mu):
     m = np.asarray(mu, dtype=float)
+    if m.ndim != 1:
+        raise ValueError("product proxies expect a 1-D source vector; batch matrices are not supported")
+    if m.size == 0:
+        raise ValueError("product proxies require at least one source")
+    return m
+
+
+def _weights_like(mu, weights):
+    m = _source_vector(mu)
     if weights is None:
         return np.ones_like(m, dtype=float)
     w = np.asarray(weights, dtype=float)
@@ -57,22 +94,47 @@ def _weights_like(mu, weights):
     return w
 
 
+def _clipped_source_and_weights(mu, weights, eps):
+    m = clip_mu(_source_vector(mu), eps)
+    return m, _weights_like(m, weights)
+
+
+def _product_lower_log_from_clipped(m, weights):
+    return float(np.sum(weights * np.log(m)))
+
+
+def _product_upper_complement_log_from_clipped(m, weights):
+    return float(np.sum(weights * np.log1p(-m)))
+
+
+def product_lower_log(mu, weights=None, eps=DEFAULT_EPS):
+    """Log of the AND-style lower-support proxy, stable for high-dimensional products."""
+    m, w = _clipped_source_and_weights(mu, weights, eps)
+    return _product_lower_log_from_clipped(m, w)
+
+
+def product_upper_complement_log(mu, weights=None, eps=DEFAULT_EPS):
+    """Log complement of the noisy-OR upper proxy, `log(prod_i (1-mu_i)^w_i)`."""
+    m, w = _clipped_source_and_weights(mu, weights, eps)
+    return _product_upper_complement_log_from_clipped(m, w)
+
+
 def product_lower(mu, weights=None, eps=DEFAULT_EPS):
-    """AND-style lower-support proxy, `prod_i clip(mu_i)^w_i`."""
-    m = clip_mu(mu, eps)
-    w = _weights_like(m, weights)
-    return float(np.exp(np.sum(w * np.log(m))))
+    """AND-style lower-support proxy, `prod_i clip(mu_i)^w_i`.
+
+    The regular-space value can underflow for many small inputs; use
+    `product_lower_log` when the log-evidence value is the meaningful quantity.
+    """
+    return float(np.exp(product_lower_log(mu, weights, eps)))
 
 
 def product_upper(mu, weights=None, eps=DEFAULT_EPS):
     """Noisy-OR upper-support proxy, `1 - prod_i (1 - clip(mu_i))^w_i`."""
-    m = clip_mu(mu, eps)
-    w = _weights_like(m, weights)
-    return float(1.0 - np.exp(np.sum(w * np.log1p(-m))))
+    return float(1.0 - np.exp(product_upper_complement_log(mu, weights, eps)))
 
 
 def product_interval(mu, weights=None, eps=DEFAULT_EPS):
-    """Return `(lower, upper, width)` product proxies for a source vector."""
+    """Return `(lower, upper, width)` product proxies for one source vector."""
     lo = product_lower(mu, weights, eps)
     hi = product_upper(mu, weights, eps)
     return lo, hi, hi - lo
@@ -80,28 +142,33 @@ def product_interval(mu, weights=None, eps=DEFAULT_EPS):
 
 def product_lower_jacobian(mu, weights=None, eps=DEFAULT_EPS):
     """Derivative of the lower product proxy with respect to clipped `mu`."""
-    m = clip_mu(mu, eps)
-    w = _weights_like(m, weights)
-    return product_lower(m, w, eps) * w / m
+    m, w = _clipped_source_and_weights(mu, weights, eps)
+    lower = np.exp(_product_lower_log_from_clipped(m, w))
+    return lower * w / m
 
 
 def product_upper_jacobian(mu, weights=None, eps=DEFAULT_EPS):
     """Derivative of the upper noisy-OR proxy with respect to clipped `mu`."""
-    m = clip_mu(mu, eps)
-    w = _weights_like(m, weights)
-    complement = np.exp(np.sum(w * np.log1p(-m)))
+    m, w = _clipped_source_and_weights(mu, weights, eps)
+    complement = np.exp(_product_upper_complement_log_from_clipped(m, w))
     return complement * w / (1.0 - m)
 
 
 def product_interval_jacobian(mu, weights=None, eps=DEFAULT_EPS):
-    """Return Jacobian rows for `(lower, upper, width)` in clipped product space."""
+    """Return Jacobian rows for `(lower, upper, width)` in clipped product space.
+
+    The width row is `d(upper-lower)/dmu`; individual entries may be negative,
+    because raising one source can narrow the lower/upper proxy interval.
+    """
     lo_j = product_lower_jacobian(mu, weights, eps)
     hi_j = product_upper_jacobian(mu, weights, eps)
     return np.vstack([lo_j, hi_j, hi_j - lo_j])
 
 
 def normalized_geometric_weights(n):
-    """Equal exponents summing to one for softened geometric product proxies."""
+    """Equal product exponents normalized to sum to one for geometric-mean proxies."""
+    if isinstance(n, (bool, np.bool_)) or not isinstance(n, (int, np.integer)):
+        raise ValueError("n must be a positive integer")
     if n <= 0:
         raise ValueError("n must be positive")
     return np.full(int(n), 1.0 / float(n))

--- a/prototypes/mu_cosine/test_product_space.py
+++ b/prototypes/mu_cosine/test_product_space.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for finite product-space transforms.
+
+Run: `python3 test_product_space.py`.
+"""
+
+import math
+
+import numpy as np
+
+from product_space import (
+    clip_mu,
+    link_jacobian,
+    log_mu,
+    logit_mu,
+    normalized_geometric_weights,
+    product_interval,
+    product_interval_jacobian,
+    product_lower,
+    product_lower_jacobian,
+    product_upper,
+    product_upper_jacobian,
+)
+
+
+def test_clip_mu_keeps_log_links_finite():
+    clipped = clip_mu([0.0, 0.5, 1.0], eps=1e-4)
+    assert np.allclose(clipped, [1e-4, 0.5, 1.0 - 1e-4])
+    assert np.isfinite(log_mu([0.0, 1.0], eps=1e-4)).all()
+    assert np.isfinite(logit_mu([0.0, 1.0], eps=1e-4)).all()
+
+
+def test_product_lower_and_upper_match_manual_formulas():
+    mu = np.array([0.2, 0.5, 0.8])
+    assert abs(product_lower(mu) - (0.2 * 0.5 * 0.8)) < 1e-12
+    assert abs(product_upper(mu) - (1.0 - 0.8 * 0.5 * 0.2)) < 1e-12
+    lo, hi, width = product_interval(mu)
+    assert lo < hi
+    assert abs(width - (hi - lo)) < 1e-12
+
+
+def test_weighted_product_proxies_support_geometric_mean():
+    mu = np.array([0.25, 1.0])
+    weights = normalized_geometric_weights(len(mu))
+    assert np.allclose(weights, [0.5, 0.5])
+    assert abs(product_lower(mu, weights, eps=1e-9) - 0.5) < 1e-9
+    assert abs(product_upper(mu, weights, eps=1e-9) - 1.0) < 5e-5
+
+
+def test_link_jacobians_match_closed_forms_after_clipping():
+    mu = np.array([0.25, 0.5])
+    assert np.allclose(link_jacobian(mu, "log"), [4.0, 2.0])
+    assert np.allclose(link_jacobian(mu, "logit"), [1.0 / (0.25 * 0.75), 4.0])
+    edge = link_jacobian([0.0], "logit", eps=1e-3)[0]
+    assert math.isfinite(edge)
+    assert abs(edge - 1.0 / (1e-3 * (1.0 - 1e-3))) < 1e-9
+
+
+def test_product_jacobians_match_closed_forms():
+    mu = np.array([0.2, 0.5, 0.8])
+    lower = 0.2 * 0.5 * 0.8
+    upper_complement = 0.8 * 0.5 * 0.2
+    assert np.allclose(product_lower_jacobian(mu), lower / mu)
+    assert np.allclose(product_upper_jacobian(mu), upper_complement / (1.0 - mu))
+
+    J = product_interval_jacobian(mu)
+    assert J.shape == (3, 3)
+    assert np.allclose(J[0], product_lower_jacobian(mu))
+    assert np.allclose(J[1], product_upper_jacobian(mu))
+    assert np.allclose(J[2], J[1] - J[0])
+
+
+def test_invalid_weights_and_links_fail_fast():
+    try:
+        product_lower([0.2, 0.3], weights=[1.0])
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("shape-mismatched weights should fail")
+
+    try:
+        product_upper([0.2, 0.3], weights=[1.0, -1.0])
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("negative weights should fail")
+
+    try:
+        link_jacobian([0.5], "odds")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("unknown link should fail")
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} product-space tests passed")

--- a/prototypes/mu_cosine/test_product_space.py
+++ b/prototypes/mu_cosine/test_product_space.py
@@ -5,10 +5,15 @@ Run: `python3 test_product_space.py`.
 """
 
 import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import numpy as np
 
 from product_space import (
+    __all__,
     clip_mu,
     link_jacobian,
     log_mu,
@@ -18,9 +23,25 @@ from product_space import (
     product_interval_jacobian,
     product_lower,
     product_lower_jacobian,
+    product_lower_log,
     product_upper,
+    product_upper_complement_log,
     product_upper_jacobian,
 )
+
+
+def assert_raises(fn, *args, **kwargs):
+    try:
+        fn(*args, **kwargs)
+    except ValueError:
+        return
+    raise AssertionError(f"{fn.__name__} should have raised ValueError")
+
+
+def test_public_api_keeps_internal_helpers_private():
+    assert "product_lower" in __all__
+    assert "product_lower_log" in __all__
+    assert "_weights_like" not in __all__
 
 
 def test_clip_mu_keeps_log_links_finite():
@@ -28,23 +49,44 @@ def test_clip_mu_keeps_log_links_finite():
     assert np.allclose(clipped, [1e-4, 0.5, 1.0 - 1e-4])
     assert np.isfinite(log_mu([0.0, 1.0], eps=1e-4)).all()
     assert np.isfinite(logit_mu([0.0, 1.0], eps=1e-4)).all()
+    assert_raises(clip_mu, [0.5], eps=0.0)
+    assert_raises(clip_mu, [0.5], eps=0.5)
 
 
 def test_product_lower_and_upper_match_manual_formulas():
     mu = np.array([0.2, 0.5, 0.8])
     assert abs(product_lower(mu) - (0.2 * 0.5 * 0.8)) < 1e-12
     assert abs(product_upper(mu) - (1.0 - 0.8 * 0.5 * 0.2)) < 1e-12
+    assert abs(product_lower_log(mu) - math.log(0.2 * 0.5 * 0.8)) < 1e-12
+    assert abs(product_upper_complement_log(mu) - math.log(0.8 * 0.5 * 0.2)) < 1e-12
     lo, hi, width = product_interval(mu)
     assert lo < hi
     assert abs(width - (hi - lo)) < 1e-12
 
 
+def test_product_proxies_exercise_clip_active_path():
+    eps = 1e-4
+    assert abs(product_lower([0.0, 1.0], eps=eps) - eps * (1.0 - eps)) < 1e-12
+    assert abs(product_upper([0.0, 1.0], eps=eps) - (1.0 - (1.0 - eps) * eps)) < 1e-12
+
+
 def test_weighted_product_proxies_support_geometric_mean():
     mu = np.array([0.25, 1.0])
+    eps = 1e-9
     weights = normalized_geometric_weights(len(mu))
     assert np.allclose(weights, [0.5, 0.5])
-    assert abs(product_lower(mu, weights, eps=1e-9) - 0.5) < 1e-9
-    assert abs(product_upper(mu, weights, eps=1e-9) - 1.0) < 5e-5
+    expected_lower = math.sqrt(0.25 * (1.0 - eps))
+    expected_upper = 1.0 - math.sqrt(0.75 * eps)
+    assert abs(product_lower(mu, weights, eps=eps) - expected_lower) < 1e-12
+    assert abs(product_upper(mu, weights, eps=eps) - expected_upper) < 1e-12
+
+
+def test_normalized_geometric_weights_require_positive_integer_count():
+    assert np.allclose(normalized_geometric_weights(1), [1.0])
+    assert np.allclose(normalized_geometric_weights(np.int64(2)), [0.5, 0.5])
+    assert_raises(normalized_geometric_weights, 0)
+    assert_raises(normalized_geometric_weights, 2.7)
+    assert_raises(normalized_geometric_weights, True)
 
 
 def test_link_jacobians_match_closed_forms_after_clipping():
@@ -68,29 +110,24 @@ def test_product_jacobians_match_closed_forms():
     assert np.allclose(J[0], product_lower_jacobian(mu))
     assert np.allclose(J[1], product_upper_jacobian(mu))
     assert np.allclose(J[2], J[1] - J[0])
+    assert np.any(J[2] < 0.0)
 
 
-def test_invalid_weights_and_links_fail_fast():
-    try:
-        product_lower([0.2, 0.3], weights=[1.0])
-    except ValueError:
-        pass
-    else:
-        raise AssertionError("shape-mismatched weights should fail")
+def test_weighted_product_jacobians_match_closed_forms():
+    mu = np.array([0.4, 0.7])
+    weights = np.array([0.25, 0.75])
+    lower = np.prod(mu**weights)
+    upper_complement = np.prod((1.0 - mu) ** weights)
+    assert np.allclose(product_lower_jacobian(mu, weights), lower * weights / mu)
+    assert np.allclose(product_upper_jacobian(mu, weights), upper_complement * weights / (1.0 - mu))
 
-    try:
-        product_upper([0.2, 0.3], weights=[1.0, -1.0])
-    except ValueError:
-        pass
-    else:
-        raise AssertionError("negative weights should fail")
 
-    try:
-        link_jacobian([0.5], "odds")
-    except ValueError:
-        pass
-    else:
-        raise AssertionError("unknown link should fail")
+def test_invalid_weights_links_and_batch_inputs_fail_fast():
+    assert_raises(product_lower, [0.2, 0.3], weights=[1.0])
+    assert_raises(product_upper, [0.2, 0.3], weights=[1.0, -1.0])
+    assert_raises(link_jacobian, [0.5], "odds")
+    assert_raises(product_lower, [[0.2, 0.3], [0.4, 0.5]])
+    assert_raises(product_interval_jacobian, np.array([[0.2, 0.3]]))
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/test_product_space_monte_carlo.py
+++ b/prototypes/mu_cosine/test_product_space_monte_carlo.py
@@ -9,31 +9,40 @@ For larger runs on a machine with CUDA:
 
     python3 test_product_space_monte_carlo.py --device cuda --samples 200000
 
-This is a local sanity check for the small-noise regime where first-order covariance
-propagation should be accurate. It is not a calibration claim for real graph/judge data.
+This is a reproducible local sanity check for the small-noise regime where first-order
+covariance propagation should be accurate. It is not a calibration claim for real
+graph/judge data, and a single seed is not a robustness study.
 """
 
 import argparse
-import sys
 
 try:
     import torch
-except ModuleNotFoundError:
-    print("skipped: torch is not installed")
-    sys.exit(0)
+except ModuleNotFoundError as exc:
+    torch = None
+    TORCH_IMPORT_ERROR = exc
+else:
+    TORCH_IMPORT_ERROR = None
+
+
+EPS = 1e-6
 
 
 def resolve_device(name):
     if name == "auto":
         return torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    if name.startswith("cuda") and not torch.cuda.is_available():
-        raise SystemExit("cuda requested but torch.cuda.is_available() is false")
-    return torch.device(name)
+    if name == "cuda" or name.startswith("cuda:"):
+        if not torch.cuda.is_available():
+            raise SystemExit("cuda requested but torch.cuda.is_available() is false")
+    try:
+        return torch.device(name)
+    except RuntimeError as exc:
+        raise SystemExit(f"invalid torch device {name!r}") from exc
 
 
 def empirical_cov(x):
     centered = x - x.mean(dim=0, keepdim=True)
-    return centered.T @ centered / float(x.shape[0] - 1)
+    return centered.T @ centered / float(x.shape[0])
 
 
 def source_covariance(sigmas, rho):
@@ -55,27 +64,24 @@ def assert_delta_cov(name, empirical, predicted, rel_tol):
         raise AssertionError(f"{name} delta covariance error {rel:.4f} exceeds {rel_tol:.4f}")
 
 
-def run(samples, device, seed, rel_tol):
+def run_scenario(label, mean_values, sigma_values, rho, samples, device, rel_tol):
     dtype = torch.float64
-    torch.manual_seed(seed)
-    if device.type == "cuda":
-        torch.cuda.manual_seed_all(seed)
-
-    mean = torch.tensor([0.31, 0.55, 0.74], dtype=dtype, device=device)
-    sigmas = torch.tensor([0.018, 0.015, 0.012], dtype=dtype, device=device)
-    cov = source_covariance(sigmas, rho=0.35)
+    mean = torch.tensor(mean_values, dtype=dtype, device=device).clamp(EPS, 1.0 - EPS)
+    sigmas = torch.tensor(sigma_values, dtype=dtype, device=device)
+    cov = source_covariance(sigmas, rho=rho)
     chol = torch.linalg.cholesky(cov)
     mu = mean + torch.randn(samples, mean.numel(), dtype=dtype, device=device) @ chol.T
-    mu = mu.clamp(1e-6, 1.0 - 1e-6)
+    mu = mu.clamp(EPS, 1.0 - EPS)
 
+    print(f"scenario={label} rho={rho}")
     log_j = 1.0 / mean
     log_pred = log_j[:, None] * cov * log_j[None, :]
-    assert_delta_cov("log(mu)", empirical_cov(torch.log(mu)), log_pred, rel_tol)
+    assert_delta_cov("  log(mu)", empirical_cov(torch.log(mu)), log_pred, rel_tol)
 
     logit = torch.log(mu) - torch.log1p(-mu)
     logit_j = 1.0 / (mean * (1.0 - mean))
     logit_pred = logit_j[:, None] * cov * logit_j[None, :]
-    assert_delta_cov("logit(mu)", empirical_cov(logit), logit_pred, rel_tol)
+    assert_delta_cov("  logit(mu)", empirical_cov(logit), logit_pred, rel_tol)
 
     lower = mu.prod(dim=1)
     upper_complement = (1.0 - mu).prod(dim=1)
@@ -88,18 +94,42 @@ def run(samples, device, seed, rel_tol):
     upper_j = upper_complement0 / (1.0 - mean)
     interval_j = torch.stack([lower_j, upper_j, upper_j - lower_j])
     interval_pred = interval_j @ cov @ interval_j.T
-    assert_delta_cov("lower/upper/width product proxies", empirical_cov(interval), interval_pred, rel_tol)
+    assert_delta_cov("  lower/upper/width product proxies", empirical_cov(interval), interval_pred, rel_tol)
 
+
+def run(samples, device, seed, rel_tol):
+    torch.manual_seed(seed)
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(seed)
+
+    scenarios = [
+        ("interior", [0.31, 0.55, 0.74], [0.018, 0.015, 0.012], 0.35),
+        ("high-correlation", [0.31, 0.55, 0.74], [0.012, 0.010, 0.008], 0.90),
+    ]
+    for scenario in scenarios:
+        run_scenario(*scenario, samples=samples, device=device, rel_tol=rel_tol)
     print(f"all product-space Monte Carlo checks passed on {device} with {samples} samples")
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--device", default="cpu", help="cpu, cuda, cuda:0, or auto; default: cpu")
+    ap.add_argument(
+        "--device",
+        default="cpu",
+        help="cpu, cuda, cuda:0, or auto (auto chooses cuda when available); default: cpu",
+    )
     ap.add_argument("--samples", type=int, default=30000)
-    ap.add_argument("--seed", type=int, default=17)
-    ap.add_argument("--rel-tol", type=float, default=0.18)
+    ap.add_argument("--seed", type=int, default=17, help="single reproducibility seed, not a robustness sweep")
+    ap.add_argument(
+        "--rel-tol",
+        type=float,
+        default=0.05,
+        help="maximum elementwise relative covariance error allowed for each delta-method check",
+    )
     args = ap.parse_args()
+    if torch is None:
+        print(f"skipped: torch is not installed ({TORCH_IMPORT_ERROR})")
+        return
     if args.samples < 1000:
         raise SystemExit("--samples should be at least 1000 for a meaningful covariance check")
     run(args.samples, resolve_device(args.device), args.seed, args.rel_tol)

--- a/prototypes/mu_cosine/test_product_space_monte_carlo.py
+++ b/prototypes/mu_cosine/test_product_space_monte_carlo.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Monte Carlo checks for product-space nonlinear covariance propagation.
+
+CPU is the default so the diagnostic is easy to run anywhere:
+
+    python3 test_product_space_monte_carlo.py
+
+For larger runs on a machine with CUDA:
+
+    python3 test_product_space_monte_carlo.py --device cuda --samples 200000
+
+This is a local sanity check for the small-noise regime where first-order covariance
+propagation should be accurate. It is not a calibration claim for real graph/judge data.
+"""
+
+import argparse
+import sys
+
+try:
+    import torch
+except ModuleNotFoundError:
+    print("skipped: torch is not installed")
+    sys.exit(0)
+
+
+def resolve_device(name):
+    if name == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if name.startswith("cuda") and not torch.cuda.is_available():
+        raise SystemExit("cuda requested but torch.cuda.is_available() is false")
+    return torch.device(name)
+
+
+def empirical_cov(x):
+    centered = x - x.mean(dim=0, keepdim=True)
+    return centered.T @ centered / float(x.shape[0] - 1)
+
+
+def source_covariance(sigmas, rho):
+    d = sigmas.numel()
+    corr = torch.full((d, d), float(rho), dtype=sigmas.dtype, device=sigmas.device)
+    corr.fill_diagonal_(1.0)
+    return corr * sigmas[:, None] * sigmas[None, :]
+
+
+def max_relative_error(empirical, predicted, floor=1e-10):
+    scale = torch.clamp(predicted.abs(), min=floor)
+    return float(((empirical - predicted).abs() / scale).max().cpu())
+
+
+def assert_delta_cov(name, empirical, predicted, rel_tol):
+    rel = max_relative_error(empirical, predicted)
+    print(f"{name}: max relative covariance error = {rel:.4f}")
+    if rel > rel_tol:
+        raise AssertionError(f"{name} delta covariance error {rel:.4f} exceeds {rel_tol:.4f}")
+
+
+def run(samples, device, seed, rel_tol):
+    dtype = torch.float64
+    torch.manual_seed(seed)
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(seed)
+
+    mean = torch.tensor([0.31, 0.55, 0.74], dtype=dtype, device=device)
+    sigmas = torch.tensor([0.018, 0.015, 0.012], dtype=dtype, device=device)
+    cov = source_covariance(sigmas, rho=0.35)
+    chol = torch.linalg.cholesky(cov)
+    mu = mean + torch.randn(samples, mean.numel(), dtype=dtype, device=device) @ chol.T
+    mu = mu.clamp(1e-6, 1.0 - 1e-6)
+
+    log_j = 1.0 / mean
+    log_pred = log_j[:, None] * cov * log_j[None, :]
+    assert_delta_cov("log(mu)", empirical_cov(torch.log(mu)), log_pred, rel_tol)
+
+    logit = torch.log(mu) - torch.log1p(-mu)
+    logit_j = 1.0 / (mean * (1.0 - mean))
+    logit_pred = logit_j[:, None] * cov * logit_j[None, :]
+    assert_delta_cov("logit(mu)", empirical_cov(logit), logit_pred, rel_tol)
+
+    lower = mu.prod(dim=1)
+    upper_complement = (1.0 - mu).prod(dim=1)
+    upper = 1.0 - upper_complement
+    interval = torch.stack([lower, upper, upper - lower], dim=1)
+
+    lower0 = mean.prod()
+    upper_complement0 = (1.0 - mean).prod()
+    lower_j = lower0 / mean
+    upper_j = upper_complement0 / (1.0 - mean)
+    interval_j = torch.stack([lower_j, upper_j, upper_j - lower_j])
+    interval_pred = interval_j @ cov @ interval_j.T
+    assert_delta_cov("lower/upper/width product proxies", empirical_cov(interval), interval_pred, rel_tol)
+
+    print(f"all product-space Monte Carlo checks passed on {device} with {samples} samples")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--device", default="cpu", help="cpu, cuda, cuda:0, or auto; default: cpu")
+    ap.add_argument("--samples", type=int, default=30000)
+    ap.add_argument("--seed", type=int, default=17)
+    ap.add_argument("--rel-tol", type=float, default=0.18)
+    args = ap.parse_args()
+    if args.samples < 1000:
+        raise SystemExit("--samples should be at least 1000 for a meaningful covariance check")
+    run(args.samples, resolve_device(args.device), args.seed, args.rel_tol)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the finite product-space transform checkpoint for the Product-Kalman / correlated-PoE design path.

Changes:
- Add `product_space.py` with clipped log/logit coordinates, lower/upper product proxies, interval width, and first-order Jacobians.
- Add `test_product_space.py` for closed-form transform and Jacobian checks.
- Add `test_product_space_monte_carlo.py`, a CPU-default diagnostic with `--device cuda` / `--device auto` support for larger Monte Carlo checks.
- Update `DESIGN_product_kalman_poe.md` to record this as the nonlinear-statistics sanity-check step.

Validation:
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_space_monte_carlo.py`
- `python3 prototypes/mu_cosine/test_product_space_monte_carlo.py --device auto --samples 5000`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `python3 -m py_compile prototypes/mu_cosine/product_space.py prototypes/mu_cosine/test_product_space.py prototypes/mu_cosine/test_product_space_monte_carlo.py`
- `git diff --check`