### PR TITLE
Add Product-Kalman update core

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -363,10 +363,12 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    Product-Kalman implementation depends on it enough to promote into CI.)*
 4. Keep `product_kalman.py` as the scalar/vector Gaussian-conditioning core in product-evidence coordinates:
    estimate residual covariances from calibration residuals, pass cross-covariance when channels share evidence,
-   and use Joseph-equivalent conditioning rather than independent precision summation.
+   and use the Gaussian-conditioning covariance `P - Cov(x,y) S^-1 Cov(y,x)` rather than independent precision
+   summation. *(Core helper added in PR #3530.)*
 5. Fit empirical Product-Kalman variants with `P_ell`, `R_ell`, and prior-measurement cross-covariance on
-   held-out node-disjoint calibration splits.
-6. Compare against `JointPosterior` and Sigma-conditioned covariance on held-out node-disjoint splits.
+   calibration splits that are node-disjoint from training data and from the final evaluation split.
+6. Compare against `JointPosterior` and Sigma-conditioned covariance on a separate node-disjoint evaluation split;
+   do not reuse the calibration residuals that set `R_ell` as the comparison set.
 7. Only after the held-out comparison, decide whether this belongs in the training objective.
 
 ## Related local artifacts

--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -361,9 +361,13 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 3. Use `test_product_space_monte_carlo.py` as the local nonlinear-statistics sanity check: CPU by default,
    optional CUDA for larger Monte Carlo runs. *(Completed in PR #3529; keep as a prototype diagnostic until a
    Product-Kalman implementation depends on it enough to promote into CI.)*
-4. Fit scalar/vector product-Kalman updates with learned `P_ell` and `R_ell`.
-5. Compare against `JointPosterior` and Sigma-conditioned covariance on held-out node-disjoint splits.
-6. Only after the held-out comparison, decide whether this belongs in the training objective.
+4. Keep `product_kalman.py` as the scalar/vector Gaussian-conditioning core in product-evidence coordinates:
+   estimate residual covariances from calibration residuals, pass cross-covariance when channels share evidence,
+   and use Joseph-equivalent conditioning rather than independent precision summation.
+5. Fit empirical Product-Kalman variants with `P_ell`, `R_ell`, and prior-measurement cross-covariance on
+   held-out node-disjoint calibration splits.
+6. Compare against `JointPosterior` and Sigma-conditioned covariance on held-out node-disjoint splits.
+7. Only after the held-out comparison, decide whether this belongs in the training objective.
 
 ## Related local artifacts
 
@@ -378,5 +382,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   Gaussian PoE overconfident unless the full covariance is modeled.
 - `product_space.py`, `test_product_space.py`, and `test_product_space_monte_carlo.py` — finite product-space
   transform helpers, closed-form Jacobian tests, and CPU/CUDA Monte Carlo checks for nonlinear covariance propagation.
+- `product_kalman.py` and `test_product_kalman.py` — Gaussian conditioning/update core for scalar/vector
+  product-evidence coordinates, with residual covariance fitting and explicit prior-measurement cross-covariance.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/product_kalman.py
+++ b/prototypes/mu_cosine/product_kalman.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Gaussian conditioning core for Product-Kalman / correlated-PoE prototypes.
+
+The functions here operate in an already chosen evidence coordinate, such as
+`log(mu_lower)`, `logit(mu_direct)`, or another finite product-space link. They do
+not construct product proxies themselves; use `product_space.py` for that layer.
+
+This module deliberately exposes cross-covariance between the prior state error and
+measurement noise. When prior and measurement channels share evidence, treating that
+cross term as zero is an assumption, not a default fact.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+__all__ = [
+    "GaussianUpdate",
+    "fit_error_covariance",
+    "fit_residual_covariance",
+    "gaussian_condition_update",
+    "gaussian_nll",
+    "regularize_covariance",
+    "scalar_product_kalman_update",
+]
+
+
+@dataclass(frozen=True)
+class GaussianUpdate:
+    """Result of one Gaussian conditioning / Kalman-style update."""
+
+    mean: np.ndarray
+    covariance: np.ndarray
+    gain: np.ndarray
+    innovation: np.ndarray
+    innovation_covariance: np.ndarray
+    cross_covariance: np.ndarray
+
+
+def _as_vector(name, value):
+    arr = np.asarray(value, dtype=float)
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+    if arr.ndim != 1:
+        raise ValueError(f"{name} must be a 1-D vector or scalar")
+    if arr.size == 0:
+        raise ValueError(f"{name} must be nonempty")
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} must be finite")
+    return arr
+
+
+def _as_matrix(name, value, rows=None, cols=None):
+    arr = np.asarray(value, dtype=float)
+    if arr.ndim == 0:
+        arr = arr.reshape(1, 1)
+    if arr.ndim != 2:
+        raise ValueError(f"{name} must be a 2-D matrix or scalar")
+    if rows is not None and arr.shape[0] != rows:
+        raise ValueError(f"{name} has {arr.shape[0]} rows, expected {rows}")
+    if cols is not None and arr.shape[1] != cols:
+        raise ValueError(f"{name} has {arr.shape[1]} columns, expected {cols}")
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} must be finite")
+    return arr
+
+
+def _square_covariance(name, value, dim):
+    cov = _as_matrix(name, value, dim, dim)
+    return 0.5 * (cov + cov.T)
+
+
+def regularize_covariance(covariance, jitter=1e-9, name="covariance"):
+    """Return a symmetric positive-definite covariance with diagonal jitter.
+
+    Small negative eigenvalues from floating-point symmetry error are lifted. A
+    materially negative eigenvalue raises instead of silently accepting an invalid
+    covariance model.
+    """
+    if jitter < 0:
+        raise ValueError("jitter must be nonnegative")
+    cov = _as_matrix(name, covariance)
+    if cov.shape[0] != cov.shape[1]:
+        raise ValueError(f"{name} must be square")
+    cov = 0.5 * (cov + cov.T)
+    eig = np.linalg.eigvalsh(cov)
+    min_eig = float(eig[0])
+    floor = max(float(jitter), 1e-12)
+    if min_eig < -100.0 * floor:
+        raise ValueError(f"{name} is not positive semidefinite; min eigenvalue={min_eig:g}")
+    lift = max(float(jitter) - min_eig, 0.0)
+    if lift:
+        cov = cov + np.eye(cov.shape[0]) * lift
+    return cov
+
+
+def fit_residual_covariance(residuals, shrinkage=0.0, jitter=1e-9):
+    """Estimate residual covariance from rows of calibration residuals.
+
+    `shrinkage=1` keeps only the diagonal; `shrinkage=0` keeps the empirical full
+    covariance. Use residuals from an appropriate calibration split, not the data
+    used for the claimed evaluation.
+    """
+    if not 0.0 <= shrinkage <= 1.0:
+        raise ValueError("shrinkage must be in [0, 1]")
+    r = np.asarray(residuals, dtype=float)
+    if r.ndim == 1:
+        r = r.reshape(-1, 1)
+    if r.ndim != 2:
+        raise ValueError("residuals must be a 1-D or 2-D array")
+    if r.shape[0] < 2:
+        raise ValueError("at least two residual rows are required")
+    if not np.isfinite(r).all():
+        raise ValueError("residuals must be finite")
+    centered = r - r.mean(axis=0, keepdims=True)
+    cov = centered.T @ centered / float(r.shape[0] - 1)
+    if shrinkage:
+        diag = np.diag(np.diag(cov))
+        cov = (1.0 - shrinkage) * cov + shrinkage * diag
+    return regularize_covariance(cov, jitter=jitter, name="residual covariance")
+
+
+def fit_error_covariance(predicted, observed, shrinkage=0.0, jitter=1e-9):
+    """Estimate covariance of `observed - predicted` calibration errors."""
+    pred = np.asarray(predicted, dtype=float)
+    obs = np.asarray(observed, dtype=float)
+    if pred.shape != obs.shape:
+        raise ValueError(f"predicted shape {pred.shape} must match observed shape {obs.shape}")
+    return fit_residual_covariance(obs - pred, shrinkage=shrinkage, jitter=jitter)
+
+
+def gaussian_condition_update(mean, covariance, observation, observation_covariance, H=None, cross_covariance=None,
+                              jitter=1e-9):
+    """Condition a Gaussian state on a linear noisy observation.
+
+    State prior:
+        x ~ N(mean, covariance)
+    Observation:
+        y = H x + v
+
+    `observation_covariance` is Cov(v). `cross_covariance` is Cov(x - mean, v),
+    with shape `(state_dim, obs_dim)`. If omitted, it is treated as zero; callers
+    should pass it explicitly when prior and measurement channels share evidence.
+    """
+    m = _as_vector("mean", mean)
+    y = _as_vector("observation", observation)
+    n = m.size
+    k = y.size
+    P = regularize_covariance(_square_covariance("covariance", covariance, n), jitter=jitter, name="covariance")
+    R = regularize_covariance(
+        _square_covariance("observation_covariance", observation_covariance, k),
+        jitter=jitter,
+        name="observation covariance",
+    )
+    Hm = np.eye(n) if H is None else _as_matrix("H", H, k, n)
+    C = np.zeros((n, k)) if cross_covariance is None else _as_matrix("cross_covariance", cross_covariance, n, k)
+
+    innovation = y - Hm @ m
+    innovation_cov = Hm @ P @ Hm.T + Hm @ C + C.T @ Hm.T + R
+    innovation_cov = regularize_covariance(innovation_cov, jitter=jitter, name="innovation covariance")
+    state_innovation_cov = P @ Hm.T + C
+    gain = np.linalg.solve(innovation_cov.T, state_innovation_cov.T).T
+    posterior_mean = m + gain @ innovation
+    posterior_cov = P - gain @ innovation_cov @ gain.T
+    posterior_cov = regularize_covariance(posterior_cov, jitter=jitter, name="posterior covariance")
+
+    return GaussianUpdate(
+        mean=posterior_mean,
+        covariance=posterior_cov,
+        gain=gain,
+        innovation=innovation,
+        innovation_covariance=innovation_cov,
+        cross_covariance=C,
+    )
+
+
+def scalar_product_kalman_update(ell_prior, ell_measurement, prior_var, measurement_var, cross_covariance=0.0,
+                                 jitter=1e-9):
+    """Scalar Product-Kalman update in one log/link evidence coordinate."""
+    return gaussian_condition_update(
+        [ell_prior],
+        [[prior_var]],
+        [ell_measurement],
+        [[measurement_var]],
+        H=[[1.0]],
+        cross_covariance=[[cross_covariance]],
+        jitter=jitter,
+    )
+
+
+def gaussian_nll(observed, mean, covariance, jitter=1e-9, include_constant=True):
+    """Negative log likelihood of one Gaussian observation."""
+    y = _as_vector("observed", observed)
+    m = _as_vector("mean", mean)
+    if y.shape != m.shape:
+        raise ValueError(f"observed shape {y.shape} must match mean shape {m.shape}")
+    cov = regularize_covariance(_square_covariance("covariance", covariance, y.size), jitter=jitter, name="covariance")
+    residual = y - m
+    solved = np.linalg.solve(cov, residual)
+    sign, logdet = np.linalg.slogdet(cov)
+    if sign <= 0:
+        raise ValueError("covariance must have positive determinant")
+    constant = y.size * np.log(2.0 * np.pi) if include_constant else 0.0
+    return float(0.5 * (residual @ solved + logdet + constant))

--- a/prototypes/mu_cosine/product_kalman.py
+++ b/prototypes/mu_cosine/product_kalman.py
@@ -8,15 +8,25 @@ not construct product proxies themselves; use `product_space.py` for that layer.
 This module deliberately exposes cross-covariance between the prior state error and
 measurement noise. When prior and measurement channels share evidence, treating that
 cross term as zero is an assumption, not a default fact.
+
+Prototype note: this module prioritizes correctness and auditability over speed. A
+full update regularizes several covariance matrices with eigendecompositions; a
+performance-sensitive path should use a Cholesky-specialized implementation.
 """
 
 from dataclasses import dataclass
+import warnings
 
 import numpy as np
 
 
+NUMERIC_EIGEN_FLOOR = 1e-12
+SEMIDEFINITE_TOL_MULTIPLIER = 100.0
+
 __all__ = [
     "GaussianUpdate",
+    "NUMERIC_EIGEN_FLOOR",
+    "SEMIDEFINITE_TOL_MULTIPLIER",
     "fit_error_covariance",
     "fit_residual_covariance",
     "gaussian_condition_update",
@@ -26,9 +36,19 @@ __all__ = [
 ]
 
 
+def _readonly_array(value):
+    arr = np.array(value, dtype=float, copy=True)
+    arr.setflags(write=False)
+    return arr
+
+
 @dataclass(frozen=True)
 class GaussianUpdate:
-    """Result of one Gaussian conditioning / Kalman-style update."""
+    """Result of one Gaussian conditioning / Kalman-style update.
+
+    Array fields are copied and marked read-only in `__post_init__`; `frozen=True`
+    alone would not prevent in-place mutation of numpy arrays.
+    """
 
     mean: np.ndarray
     covariance: np.ndarray
@@ -37,13 +57,19 @@ class GaussianUpdate:
     innovation_covariance: np.ndarray
     cross_covariance: np.ndarray
 
+    def __post_init__(self):
+        for name in ("mean", "covariance", "gain", "innovation", "innovation_covariance", "cross_covariance"):
+            object.__setattr__(self, name, _readonly_array(getattr(self, name)))
+
 
 def _as_vector(name, value):
     arr = np.asarray(value, dtype=float)
     if arr.ndim == 0:
         arr = arr.reshape(1)
+    elif arr.ndim == 2 and 1 in arr.shape:
+        arr = arr.reshape(-1)
     if arr.ndim != 1:
-        raise ValueError(f"{name} must be a 1-D vector or scalar")
+        raise ValueError(f"{name} must be a 1-D vector, column vector, row vector, or scalar")
     if arr.size == 0:
         raise ValueError(f"{name} must be nonempty")
     if not np.isfinite(arr).all():
@@ -76,7 +102,9 @@ def regularize_covariance(covariance, jitter=1e-9, name="covariance"):
 
     Small negative eigenvalues from floating-point symmetry error are lifted. A
     materially negative eigenvalue raises instead of silently accepting an invalid
-    covariance model.
+    covariance model. Even when `jitter=0`, exact semidefinite covariances are
+    lifted to `NUMERIC_EIGEN_FLOOR` so downstream solves see positive-definite
+    matrices rather than singular ones.
     """
     if jitter < 0:
         raise ValueError("jitter must be nonnegative")
@@ -86,48 +114,70 @@ def regularize_covariance(covariance, jitter=1e-9, name="covariance"):
     cov = 0.5 * (cov + cov.T)
     eig = np.linalg.eigvalsh(cov)
     min_eig = float(eig[0])
-    floor = max(float(jitter), 1e-12)
-    if min_eig < -100.0 * floor:
+    floor = max(float(jitter), NUMERIC_EIGEN_FLOOR)
+    if min_eig < -SEMIDEFINITE_TOL_MULTIPLIER * floor:
         raise ValueError(f"{name} is not positive semidefinite; min eigenvalue={min_eig:g}")
-    lift = max(float(jitter) - min_eig, 0.0)
+    lift = max(floor - min_eig, 0.0)
     if lift:
         cov = cov + np.eye(cov.shape[0]) * lift
     return cov
 
 
-def fit_residual_covariance(residuals, shrinkage=0.0, jitter=1e-9):
+def _shrinkage_target(cov, target):
+    if target == "diagonal":
+        return np.diag(np.diag(cov))
+    if target == "scaled_identity":
+        return np.eye(cov.shape[0]) * float(np.trace(cov) / cov.shape[0])
+    raise ValueError("shrinkage_target must be 'diagonal' or 'scaled_identity'")
+
+
+def fit_residual_covariance(residuals, shrinkage=0.0, jitter=1e-9, ddof=1, shrinkage_target="diagonal"):
     """Estimate residual covariance from rows of calibration residuals.
 
-    `shrinkage=1` keeps only the diagonal; `shrinkage=0` keeps the empirical full
-    covariance. Use residuals from an appropriate calibration split, not the data
-    used for the claimed evaluation.
+    `ddof=1` gives the unbiased sample covariance; use `ddof=0` for an MLE
+    covariance estimate. `shrinkage=1` keeps only the selected target covariance:
+    sample `diagonal` by default, or `scaled_identity` for a Ledoit-Wolf-style
+    isotropic target. Use residuals from an appropriate calibration split, not the
+    data used for the claimed evaluation.
     """
     if not 0.0 <= shrinkage <= 1.0:
         raise ValueError("shrinkage must be in [0, 1]")
+    if not isinstance(ddof, (int, np.integer)) or ddof < 0:
+        raise ValueError("ddof must be a nonnegative integer")
     r = np.asarray(residuals, dtype=float)
     if r.ndim == 1:
         r = r.reshape(-1, 1)
     if r.ndim != 2:
         raise ValueError("residuals must be a 1-D or 2-D array")
-    if r.shape[0] < 2:
-        raise ValueError("at least two residual rows are required")
+    if r.shape[0] <= ddof:
+        raise ValueError("residual rows must exceed ddof")
     if not np.isfinite(r).all():
         raise ValueError("residuals must be finite")
     centered = r - r.mean(axis=0, keepdims=True)
-    cov = centered.T @ centered / float(r.shape[0] - 1)
+    cov = centered.T @ centered / float(r.shape[0] - ddof)
     if shrinkage:
-        diag = np.diag(np.diag(cov))
-        cov = (1.0 - shrinkage) * cov + shrinkage * diag
+        target = _shrinkage_target(cov, shrinkage_target)
+        cov = (1.0 - shrinkage) * cov + shrinkage * target
     return regularize_covariance(cov, jitter=jitter, name="residual covariance")
 
 
-def fit_error_covariance(predicted, observed, shrinkage=0.0, jitter=1e-9):
+def fit_error_covariance(predicted, observed, shrinkage=0.0, jitter=1e-9, ddof=1, shrinkage_target="diagonal"):
     """Estimate covariance of `observed - predicted` calibration errors."""
     pred = np.asarray(predicted, dtype=float)
     obs = np.asarray(observed, dtype=float)
     if pred.shape != obs.shape:
         raise ValueError(f"predicted shape {pred.shape} must match observed shape {obs.shape}")
-    return fit_residual_covariance(obs - pred, shrinkage=shrinkage, jitter=jitter)
+    if not np.isfinite(pred).all():
+        raise ValueError("predicted must be finite")
+    if not np.isfinite(obs).all():
+        raise ValueError("observed must be finite")
+    return fit_residual_covariance(
+        obs - pred,
+        shrinkage=shrinkage,
+        jitter=jitter,
+        ddof=ddof,
+        shrinkage_target=shrinkage_target,
+    )
 
 
 def gaussian_condition_update(mean, covariance, observation, observation_covariance, H=None, cross_covariance=None,
@@ -142,6 +192,11 @@ def gaussian_condition_update(mean, covariance, observation, observation_covaria
     `observation_covariance` is Cov(v). `cross_covariance` is Cov(x - mean, v),
     with shape `(state_dim, obs_dim)`. If omitted, it is treated as zero; callers
     should pass it explicitly when prior and measurement channels share evidence.
+
+    The returned `innovation_covariance` is the regularized S used for the gain
+    computation; it may include a small diagonal lift for numerical positive
+    definiteness. The posterior covariance is the Gaussian-conditioning covariance
+    `P - Cov(x,y) S^-1 Cov(y,x)`, symmetrized/regularized after the update.
     """
     m = _as_vector("mean", mean)
     y = _as_vector("observation", observation)
@@ -153,14 +208,20 @@ def gaussian_condition_update(mean, covariance, observation, observation_covaria
         jitter=jitter,
         name="observation covariance",
     )
-    Hm = np.eye(n) if H is None else _as_matrix("H", H, k, n)
+    if H is None:
+        if k != n:
+            raise ValueError("H is required when observation dimension differs from state dimension")
+        Hm = np.eye(n)
+    else:
+        Hm = _as_matrix("H", H, k, n)
     C = np.zeros((n, k)) if cross_covariance is None else _as_matrix("cross_covariance", cross_covariance, n, k)
 
     innovation = y - Hm @ m
     innovation_cov = Hm @ P @ Hm.T + Hm @ C + C.T @ Hm.T + R
     innovation_cov = regularize_covariance(innovation_cov, jitter=jitter, name="innovation covariance")
     state_innovation_cov = P @ Hm.T + C
-    gain = np.linalg.solve(innovation_cov.T, state_innovation_cov.T).T
+    chol = np.linalg.cholesky(innovation_cov)
+    gain = np.linalg.solve(chol.T, np.linalg.solve(chol, state_innovation_cov.T)).T
     posterior_mean = m + gain @ innovation
     posterior_cov = P - gain @ innovation_cov @ gain.T
     posterior_cov = regularize_covariance(posterior_cov, jitter=jitter, name="posterior covariance")
@@ -175,9 +236,25 @@ def gaussian_condition_update(mean, covariance, observation, observation_covaria
     )
 
 
-def scalar_product_kalman_update(ell_prior, ell_measurement, prior_var, measurement_var, cross_covariance=0.0,
+def scalar_product_kalman_update(ell_prior, ell_measurement, prior_var, measurement_var, cross_covariance=None,
                                  jitter=1e-9):
-    """Scalar Product-Kalman update in one log/link evidence coordinate."""
+    """Scalar Product-Kalman update in one log/link evidence coordinate.
+
+    `cross_covariance=None` warns and assumes zero. Pass `0.0` explicitly only
+    when independence or negligible prior-measurement covariance is an intentional
+    modeling assumption.
+    """
+    if not np.isfinite(prior_var) or prior_var <= 0:
+        raise ValueError(f"prior_var must be finite and positive, got {prior_var}")
+    if not np.isfinite(measurement_var) or measurement_var <= 0:
+        raise ValueError(f"measurement_var must be finite and positive, got {measurement_var}")
+    if cross_covariance is None:
+        warnings.warn(
+            "assuming zero prior-measurement cross_covariance; pass 0.0 explicitly if this is intentional",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        cross_covariance = 0.0
     return gaussian_condition_update(
         [ell_prior],
         [[prior_var]],
@@ -190,7 +267,11 @@ def scalar_product_kalman_update(ell_prior, ell_measurement, prior_var, measurem
 
 
 def gaussian_nll(observed, mean, covariance, jitter=1e-9, include_constant=True):
-    """Negative log likelihood of one Gaussian observation."""
+    """Negative log likelihood of one Gaussian observation.
+
+    Argument order is `observed, mean, covariance`, matching residual notation
+    `observed - mean` used elsewhere in this prototype.
+    """
     y = _as_vector("observed", observed)
     m = _as_vector("mean", mean)
     if y.shape != m.shape:
@@ -199,7 +280,7 @@ def gaussian_nll(observed, mean, covariance, jitter=1e-9, include_constant=True)
     residual = y - m
     solved = np.linalg.solve(cov, residual)
     sign, logdet = np.linalg.slogdet(cov)
-    if sign <= 0:
+    if sign <= 0:  # Defensive guard after covariance regularization.
         raise ValueError("covariance must have positive determinant")
     constant = y.size * np.log(2.0 * np.pi) if include_constant else 0.0
     return float(0.5 * (residual @ solved + logdet + constant))

--- a/prototypes/mu_cosine/test_product_kalman.py
+++ b/prototypes/mu_cosine/test_product_kalman.py
@@ -6,6 +6,7 @@ Run: `python3 test_product_kalman.py`.
 
 import math
 import sys
+import warnings
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -31,21 +32,61 @@ def assert_raises(fn, *args, **kwargs):
 
 
 def test_scalar_product_update_matches_closed_form():
-    res = scalar_product_kalman_update(ell_prior=0.0, ell_measurement=10.0, prior_var=4.0, measurement_var=1.0,
-                                       jitter=0.0)
-    assert np.allclose(res.gain, [[0.8]])
-    assert abs(res.mean[0] - 8.0) < 1e-12
-    assert abs(res.covariance[0, 0] - 0.8) < 1e-12
-    assert abs(res.innovation[0] - 10.0) < 1e-12
-    assert abs(res.innovation_covariance[0, 0] - 5.0) < 1e-12
+    res = scalar_product_kalman_update(
+        ell_prior=0.0,
+        ell_measurement=10.0,
+        prior_var=4.0,
+        measurement_var=1.0,
+        cross_covariance=0.0,
+        jitter=0.0,
+    )
+    np.testing.assert_allclose(res.gain, [[0.8]], atol=1e-12)
+    np.testing.assert_allclose(res.mean, [8.0], atol=1e-12)
+    np.testing.assert_allclose(res.covariance, [[0.8]], atol=1e-12)
+    np.testing.assert_allclose(res.innovation, [10.0], atol=1e-12)
+    np.testing.assert_allclose(res.innovation_covariance, [[5.0]], atol=1e-12)
+
+
+def test_scalar_cross_covariance_default_warns():
+    with warnings.catch_warnings(record=True) as seen:
+        warnings.simplefilter("always")
+        scalar_product_kalman_update(0.0, 1.0, prior_var=1.0, measurement_var=1.0, jitter=0.0)
+    assert any("cross_covariance" in str(w.message) for w in seen)
+
+
+def test_gaussian_update_arrays_are_read_only():
+    res = scalar_product_kalman_update(0.0, 1.0, prior_var=1.0, measurement_var=1.0, cross_covariance=0.0)
+    try:
+        res.mean[0] = 3.0
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("GaussianUpdate arrays should be read-only")
 
 
 def test_scalar_gain_moves_toward_less_noisy_channel():
-    weak_measurement = scalar_product_kalman_update(0.0, 10.0, prior_var=1.0, measurement_var=99.0, jitter=0.0)
-    strong_measurement = scalar_product_kalman_update(0.0, 10.0, prior_var=99.0, measurement_var=1.0, jitter=0.0)
+    weak_measurement = scalar_product_kalman_update(
+        0.0, 10.0, prior_var=1.0, measurement_var=99.0, cross_covariance=0.0, jitter=0.0
+    )
+    strong_measurement = scalar_product_kalman_update(
+        0.0, 10.0, prior_var=99.0, measurement_var=1.0, cross_covariance=0.0, jitter=0.0
+    )
     assert weak_measurement.mean[0] < 0.2
     assert strong_measurement.mean[0] > 9.8
     assert weak_measurement.gain[0, 0] < strong_measurement.gain[0, 0]
+
+
+def test_scalar_limit_cases_approach_theory():
+    weak_prior = scalar_product_kalman_update(
+        0.0, 7.0, prior_var=1e12, measurement_var=1.0, cross_covariance=0.0, jitter=0.0
+    )
+    near_exact_measurement = scalar_product_kalman_update(
+        0.0, 7.0, prior_var=1.0, measurement_var=1e-12, cross_covariance=0.0, jitter=0.0
+    )
+    assert weak_prior.gain[0, 0] > 1.0 - 1e-10
+    assert abs(weak_prior.mean[0] - 7.0) < 1e-8
+    assert near_exact_measurement.gain[0, 0] > 1.0 - 1e-10
+    assert abs(near_exact_measurement.mean[0] - 7.0) < 1e-8
 
 
 def test_vector_update_matches_independent_coordinate_formula():
@@ -56,9 +97,28 @@ def test_vector_update_matches_independent_coordinate_formula():
         observation_covariance=[[1.0, 0.0], [0.0, 3.0]],
         jitter=0.0,
     )
-    assert np.allclose(res.gain, [[0.8, 0.0], [0.0, 0.25]])
-    assert np.allclose(res.mean, [8.0, 2.5])
-    assert np.allclose(np.diag(res.covariance), [0.8, 0.75])
+    np.testing.assert_allclose(res.gain, [[0.8, 0.0], [0.0, 0.25]], atol=1e-12)
+    np.testing.assert_allclose(res.mean, [8.0, 2.5], atol=1e-12)
+    np.testing.assert_allclose(np.diag(res.covariance), [0.8, 0.75], atol=1e-12)
+
+
+def test_dense_vector_update_with_nonidentity_observation_matrix():
+    mean = np.array([1.0, -1.0])
+    P = np.array([[2.0, 0.4], [0.4, 1.0]])
+    H = np.array([[1.0, 0.5]])
+    y = np.array([2.0])
+    R = np.array([[0.7]])
+    res = gaussian_condition_update(mean, P, y, R, H=H, jitter=0.0)
+
+    S = H @ P @ H.T + R
+    cov_xy = P @ H.T
+    expected_gain = cov_xy @ np.linalg.inv(S)
+    expected_mean = mean + (expected_gain @ (y - H @ mean)).reshape(-1)
+    expected_cov = P - expected_gain @ S @ expected_gain.T
+    np.testing.assert_allclose(res.gain, expected_gain, atol=1e-12)
+    np.testing.assert_allclose(res.mean, expected_mean, atol=1e-12)
+    np.testing.assert_allclose(res.covariance, expected_cov, atol=1e-12)
+    assert abs(res.gain[1, 0]) > 0.01
 
 
 def test_cross_covariance_matches_gaussian_conditioning_formula():
@@ -74,10 +134,27 @@ def test_cross_covariance_matches_gaussian_conditioning_formula():
     innovation_cov = 2.0 + 3.0 + 2.0 * 0.5
     state_innovation_cov = 2.0 + 0.5
     gain = state_innovation_cov / innovation_cov
-    assert np.allclose(res.gain, [[gain]])
+    np.testing.assert_allclose(res.gain, [[gain]], atol=1e-12)
     assert abs(res.mean[0] - (1.0 + gain * 3.0)) < 1e-12
     assert abs(res.covariance[0, 0] - (2.0 - state_innovation_cov**2 / innovation_cov)) < 1e-12
-    assert np.allclose(res.cross_covariance, [[0.5]])
+    np.testing.assert_allclose(res.cross_covariance, [[0.5]], atol=1e-12)
+
+
+def test_negative_cross_covariance_reduces_innovation_covariance():
+    no_cross = gaussian_condition_update([0.0], [[2.0]], [1.0], [[3.0]], cross_covariance=[[0.0]], jitter=0.0)
+    neg_cross = gaussian_condition_update([0.0], [[2.0]], [1.0], [[3.0]], cross_covariance=[[-0.4]], jitter=0.0)
+    assert neg_cross.innovation_covariance[0, 0] < no_cross.innovation_covariance[0, 0]
+    np.testing.assert_allclose(neg_cross.innovation_covariance, [[4.2]], atol=1e-12)
+
+
+def test_posterior_covariance_stays_symmetric_with_dense_cross_covariance():
+    P = np.array([[2.0, 0.3, 0.2], [0.3, 1.5, 0.1], [0.2, 0.1, 1.2]])
+    H = np.array([[1.0, 0.2, 0.0], [0.0, 0.3, 1.0]])
+    R = np.array([[0.8, 0.1], [0.1, 0.7]])
+    C = np.array([[0.05, -0.02], [0.03, 0.01], [-0.01, 0.04]])
+    res = gaussian_condition_update([0.1, -0.2, 0.3], P, [0.4, -0.1], R, H=H, cross_covariance=C)
+    np.testing.assert_allclose(res.covariance, res.covariance.T, atol=1e-12)
+    assert np.linalg.eigvalsh(res.covariance).min() > 0.0
 
 
 def test_invalid_cross_covariance_rejected_by_innovation_covariance():
@@ -93,40 +170,53 @@ def test_invalid_cross_covariance_rejected_by_innovation_covariance():
     )
 
 
-def test_residual_covariance_and_diagonal_shrinkage():
+def test_residual_covariance_and_shrinkage_targets():
     residuals = np.array([[1.0, 0.0], [-1.0, 2.0], [0.0, -2.0]])
     expected = np.cov(residuals, rowvar=False, bias=False)
     full = fit_residual_covariance(residuals, jitter=0.0)
     diagonal = fit_residual_covariance(residuals, shrinkage=1.0, jitter=0.0)
-    assert np.allclose(full, expected)
-    assert np.allclose(diagonal, np.diag(np.diag(expected)))
+    scaled_identity = fit_residual_covariance(residuals, shrinkage=1.0, shrinkage_target="scaled_identity", jitter=0.0)
+    mle = fit_residual_covariance(residuals, ddof=0, jitter=0.0)
+    np.testing.assert_allclose(full, expected, atol=1e-12)
+    np.testing.assert_allclose(diagonal, np.diag(np.diag(expected)), atol=1e-12)
+    np.testing.assert_allclose(scaled_identity, np.eye(2) * np.trace(expected) / 2.0, atol=1e-12)
+    np.testing.assert_allclose(mle, np.cov(residuals, rowvar=False, bias=True), atol=1e-12)
+    assert_raises(fit_residual_covariance, residuals, shrinkage=1.0, shrinkage_target="unknown")
 
 
-def test_error_covariance_uses_observed_minus_predicted():
+def test_error_covariance_uses_observed_minus_predicted_and_checks_inputs():
     predicted = np.array([[1.0], [2.0], [3.0]])
     observed = np.array([[1.5], [1.0], [3.5]])
     expected = np.cov((observed - predicted).reshape(-1), bias=False).reshape(1, 1)
-    assert np.allclose(fit_error_covariance(predicted, observed, jitter=0.0), expected)
+    np.testing.assert_allclose(fit_error_covariance(predicted, observed, jitter=0.0), expected, atol=1e-12)
     assert_raises(fit_error_covariance, predicted, observed.reshape(-1), jitter=0.0)
+    assert_raises(fit_error_covariance, [[float("nan")]], [[1.0]])
+    assert_raises(fit_error_covariance, [[1.0]], [[float("inf")]])
 
 
 def test_regularize_covariance_lifts_tiny_semidefinite_floor_only():
     lifted = regularize_covariance([[1.0, 0.0], [0.0, 0.0]], jitter=1e-6)
     assert np.linalg.eigvalsh(lifted).min() >= 1e-6 - 1e-12
     assert_raises(regularize_covariance, [[1.0, 0.0], [0.0, -0.1]], jitter=1e-9)
+    assert_raises(regularize_covariance, [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], jitter=0.0)
 
 
-def test_gaussian_nll_matches_unit_normal_constant():
-    assert abs(gaussian_nll([0.0], [0.0], [[1.0]], jitter=0.0) - 0.5 * math.log(2.0 * math.pi)) < 1e-12
+def test_gaussian_nll_matches_unit_normal_constant_and_accepts_column_vectors():
+    assert abs(gaussian_nll([[0.0]], [[0.0]], [[1.0]], jitter=0.0) - 0.5 * math.log(2.0 * math.pi)) < 1e-12
     assert abs(gaussian_nll([0.0], [0.0], [[1.0]], jitter=0.0, include_constant=False)) < 1e-12
     assert_raises(gaussian_nll, [0.0, 1.0], [0.0], [[1.0]], jitter=0.0)
 
 
-def test_shape_errors_fail_fast():
-    assert_raises(gaussian_condition_update, [0.0, 1.0], [[1.0]], [0.0], [[1.0]])
+def test_shape_errors_and_scalar_variance_guards_fail_fast():
+    assert_raises(gaussian_condition_update, [0.0, 1.0], [[1.0, 0.0], [0.0, 1.0]], [0.0], [[1.0]])
     assert_raises(fit_residual_covariance, [[1.0, 2.0]], jitter=0.0)
     assert_raises(fit_residual_covariance, [[1.0], [float("nan")]], jitter=0.0)
     assert_raises(fit_residual_covariance, [[1.0], [2.0]], shrinkage=1.5, jitter=0.0)
+    assert_raises(fit_residual_covariance, [[1.0], [2.0]], ddof=-1, jitter=0.0)
+    assert_raises(scalar_product_kalman_update, 0.0, 1.0, prior_var=0.0, measurement_var=1.0)
+    assert_raises(scalar_product_kalman_update, 0.0, 1.0, prior_var=float("nan"), measurement_var=1.0)
+    assert_raises(scalar_product_kalman_update, 0.0, 1.0, prior_var=1.0, measurement_var=-1.0)
+    assert_raises(scalar_product_kalman_update, 0.0, 1.0, prior_var=1.0, measurement_var=float("inf"))
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/test_product_kalman.py
+++ b/prototypes/mu_cosine/test_product_kalman.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Tests for Product-Kalman Gaussian conditioning helpers.
+
+Run: `python3 test_product_kalman.py`.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np
+
+from product_kalman import (
+    fit_error_covariance,
+    fit_residual_covariance,
+    gaussian_condition_update,
+    gaussian_nll,
+    regularize_covariance,
+    scalar_product_kalman_update,
+)
+
+
+def assert_raises(fn, *args, **kwargs):
+    try:
+        fn(*args, **kwargs)
+    except ValueError:
+        return
+    raise AssertionError(f"{fn.__name__} should have raised ValueError")
+
+
+def test_scalar_product_update_matches_closed_form():
+    res = scalar_product_kalman_update(ell_prior=0.0, ell_measurement=10.0, prior_var=4.0, measurement_var=1.0,
+                                       jitter=0.0)
+    assert np.allclose(res.gain, [[0.8]])
+    assert abs(res.mean[0] - 8.0) < 1e-12
+    assert abs(res.covariance[0, 0] - 0.8) < 1e-12
+    assert abs(res.innovation[0] - 10.0) < 1e-12
+    assert abs(res.innovation_covariance[0, 0] - 5.0) < 1e-12
+
+
+def test_scalar_gain_moves_toward_less_noisy_channel():
+    weak_measurement = scalar_product_kalman_update(0.0, 10.0, prior_var=1.0, measurement_var=99.0, jitter=0.0)
+    strong_measurement = scalar_product_kalman_update(0.0, 10.0, prior_var=99.0, measurement_var=1.0, jitter=0.0)
+    assert weak_measurement.mean[0] < 0.2
+    assert strong_measurement.mean[0] > 9.8
+    assert weak_measurement.gain[0, 0] < strong_measurement.gain[0, 0]
+
+
+def test_vector_update_matches_independent_coordinate_formula():
+    res = gaussian_condition_update(
+        mean=[0.0, 0.0],
+        covariance=[[4.0, 0.0], [0.0, 1.0]],
+        observation=[10.0, 10.0],
+        observation_covariance=[[1.0, 0.0], [0.0, 3.0]],
+        jitter=0.0,
+    )
+    assert np.allclose(res.gain, [[0.8, 0.0], [0.0, 0.25]])
+    assert np.allclose(res.mean, [8.0, 2.5])
+    assert np.allclose(np.diag(res.covariance), [0.8, 0.75])
+
+
+def test_cross_covariance_matches_gaussian_conditioning_formula():
+    res = gaussian_condition_update(
+        mean=[1.0],
+        covariance=[[2.0]],
+        observation=[4.0],
+        observation_covariance=[[3.0]],
+        H=[[1.0]],
+        cross_covariance=[[0.5]],
+        jitter=0.0,
+    )
+    innovation_cov = 2.0 + 3.0 + 2.0 * 0.5
+    state_innovation_cov = 2.0 + 0.5
+    gain = state_innovation_cov / innovation_cov
+    assert np.allclose(res.gain, [[gain]])
+    assert abs(res.mean[0] - (1.0 + gain * 3.0)) < 1e-12
+    assert abs(res.covariance[0, 0] - (2.0 - state_innovation_cov**2 / innovation_cov)) < 1e-12
+    assert np.allclose(res.cross_covariance, [[0.5]])
+
+
+def test_invalid_cross_covariance_rejected_by_innovation_covariance():
+    assert_raises(
+        gaussian_condition_update,
+        mean=[0.0],
+        covariance=[[1.0]],
+        observation=[1.0],
+        observation_covariance=[[1.0]],
+        H=[[1.0]],
+        cross_covariance=[[-2.0]],
+        jitter=0.0,
+    )
+
+
+def test_residual_covariance_and_diagonal_shrinkage():
+    residuals = np.array([[1.0, 0.0], [-1.0, 2.0], [0.0, -2.0]])
+    expected = np.cov(residuals, rowvar=False, bias=False)
+    full = fit_residual_covariance(residuals, jitter=0.0)
+    diagonal = fit_residual_covariance(residuals, shrinkage=1.0, jitter=0.0)
+    assert np.allclose(full, expected)
+    assert np.allclose(diagonal, np.diag(np.diag(expected)))
+
+
+def test_error_covariance_uses_observed_minus_predicted():
+    predicted = np.array([[1.0], [2.0], [3.0]])
+    observed = np.array([[1.5], [1.0], [3.5]])
+    expected = np.cov((observed - predicted).reshape(-1), bias=False).reshape(1, 1)
+    assert np.allclose(fit_error_covariance(predicted, observed, jitter=0.0), expected)
+    assert_raises(fit_error_covariance, predicted, observed.reshape(-1), jitter=0.0)
+
+
+def test_regularize_covariance_lifts_tiny_semidefinite_floor_only():
+    lifted = regularize_covariance([[1.0, 0.0], [0.0, 0.0]], jitter=1e-6)
+    assert np.linalg.eigvalsh(lifted).min() >= 1e-6 - 1e-12
+    assert_raises(regularize_covariance, [[1.0, 0.0], [0.0, -0.1]], jitter=1e-9)
+
+
+def test_gaussian_nll_matches_unit_normal_constant():
+    assert abs(gaussian_nll([0.0], [0.0], [[1.0]], jitter=0.0) - 0.5 * math.log(2.0 * math.pi)) < 1e-12
+    assert abs(gaussian_nll([0.0], [0.0], [[1.0]], jitter=0.0, include_constant=False)) < 1e-12
+    assert_raises(gaussian_nll, [0.0, 1.0], [0.0], [[1.0]], jitter=0.0)
+
+
+def test_shape_errors_fail_fast():
+    assert_raises(gaussian_condition_update, [0.0, 1.0], [[1.0]], [0.0], [[1.0]])
+    assert_raises(fit_residual_covariance, [[1.0, 2.0]], jitter=0.0)
+    assert_raises(fit_residual_covariance, [[1.0], [float("nan")]], jitter=0.0)
+    assert_raises(fit_residual_covariance, [[1.0], [2.0]], shrinkage=1.5, jitter=0.0)
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} product-kalman tests passed")


### PR DESCRIPTION
Adds the scalar/vector Gaussian-conditioning core for Product-Kalman experiments.

Changes:
- Add `product_kalman.py` with:
  - scalar Product-Kalman update in linked evidence coordinates
  - vector Gaussian conditioning with optional prior-measurement cross-covariance
  - residual/error covariance fitting from calibration residuals
  - Gaussian NLL helper for later held-out comparisons
- Add `test_product_kalman.py` covering scalar/vector gains, cross-covariance behavior, residual covariance fitting, invalid covariance rejection, and NLL sanity checks.
- Update `DESIGN_product_kalman_poe.md` to make this the core update primitive before empirical held-out comparisons.

Validation:
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 -m pytest -s prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `python3 -m py_compile prototypes/mu_cosine/product_kalman.py prototypes/mu_cosine/test_product_kalman.py`
- `git diff --check`