### PR TITLE
Add Product-Kalman calibration helpers

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -365,10 +365,12 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    estimate residual covariances from calibration residuals, pass cross-covariance when channels share evidence,
    and use the Gaussian-conditioning covariance `P - Cov(x,y) S^-1 Cov(y,x)` rather than independent precision
    summation. *(Core helper added in PR #3530.)*
-5. Fit empirical Product-Kalman variants with `P_ell`, `R_ell`, and prior-measurement cross-covariance on
-   calibration splits that are node-disjoint from training data and from the final evaluation split.
-6. Compare against `JointPosterior` and Sigma-conditioned covariance on a separate node-disjoint evaluation split;
-   do not reuse the calibration residuals that set `R_ell` as the comparison set.
+5. Use `product_kalman_calibration.py` to fit `P_ell`, `R_ell`, and prior-measurement cross-covariance
+   from calibration residuals in linked evidence coordinates. Calibration splits must be node-disjoint from
+   training data and from the final evaluation split.
+6. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
+   Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
+   residuals that set `R_ell` as the comparison set.
 7. Only after the held-out comparison, decide whether this belongs in the training objective.
 
 ## Related local artifacts
@@ -386,5 +388,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   transform helpers, closed-form Jacobian tests, and CPU/CUDA Monte Carlo checks for nonlinear covariance propagation.
 - `product_kalman.py` and `test_product_kalman.py` — Gaussian conditioning/update core for scalar/vector
   product-evidence coordinates, with residual covariance fitting and explicit prior-measurement cross-covariance.
+- `product_kalman_calibration.py` and `test_product_kalman_calibration.py` — calibration-split fitting of
+  `P`, `R`, and cross-covariance blocks plus batch application and split-ID leakage guards.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -366,8 +366,10 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    and use the Gaussian-conditioning covariance `P - Cov(x,y) S^-1 Cov(y,x)` rather than independent precision
    summation. *(Core helper added in PR #3530.)*
 5. Use `product_kalman_calibration.py` to fit `P_ell`, `R_ell`, and prior-measurement cross-covariance
-   from calibration residuals in linked evidence coordinates. Calibration splits must be node-disjoint from
-   training data and from the final evaluation split.
+   from calibration residuals in linked evidence coordinates. The calibration helper slices one regularized joint
+   covariance block matrix, and all scalar channels must be passed as explicit `(n, 1)` row matrices rather than
+   ambiguous 1-D arrays. Calibration splits must be node-disjoint from training data and from the final evaluation
+   split.
 6. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
    Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
    residuals that set `R_ell` as the comparison set.

--- a/prototypes/mu_cosine/product_kalman_calibration.py
+++ b/prototypes/mu_cosine/product_kalman_calibration.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Calibration helpers for Product-Kalman / correlated-PoE prototypes.
+
+This layer estimates the covariance blocks used by `product_kalman.py` from a
+calibration split with known target states in the chosen evidence coordinate:
+
+    prior_error       = target_state - prior_mean
+    measurement_error = measurement - H @ target_state
+
+The fitted blocks are:
+
+    P = Cov(prior_error)
+    R = Cov(measurement_error)
+    C = Cov(prior_error, measurement_error)
+
+Use calibration data that is node-disjoint from training data and from the final
+evaluation split. These helpers do not decide the split; they make leakage harder
+to miss once the split IDs are known.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+try:
+    from .product_kalman import fit_residual_covariance, gaussian_condition_update, regularize_covariance
+except ImportError:  # direct script execution from prototypes/mu_cosine
+    from product_kalman import fit_residual_covariance, gaussian_condition_update, regularize_covariance
+
+
+__all__ = [
+    "ProductKalmanBatchUpdate",
+    "ProductKalmanCalibration",
+    "assert_disjoint_ids",
+    "apply_product_kalman_calibration",
+    "fit_product_kalman_calibration",
+]
+
+
+def _readonly_array(value):
+    arr = np.array(value, dtype=float, copy=True)
+    arr.setflags(write=False)
+    return arr
+
+
+@dataclass(frozen=True)
+class ProductKalmanCalibration:
+    """Covariance blocks fitted on a calibration split."""
+
+    state_covariance: np.ndarray
+    observation_covariance: np.ndarray
+    cross_covariance: np.ndarray
+    H: np.ndarray
+    n_samples: int
+    ddof: int
+    shrinkage: float
+    shrinkage_target: str
+
+    def __post_init__(self):
+        for name in ("state_covariance", "observation_covariance", "cross_covariance", "H"):
+            object.__setattr__(self, name, _readonly_array(getattr(self, name)))
+
+    @property
+    def state_dim(self):
+        return int(self.state_covariance.shape[0])
+
+    @property
+    def observation_dim(self):
+        return int(self.observation_covariance.shape[0])
+
+
+@dataclass(frozen=True)
+class ProductKalmanBatchUpdate:
+    """Batch application of one Product-Kalman calibration."""
+
+    mean: np.ndarray
+    covariance: np.ndarray
+    gain: np.ndarray
+    innovation: np.ndarray
+    innovation_covariance: np.ndarray
+
+    def __post_init__(self):
+        for name in ("mean", "covariance", "gain", "innovation", "innovation_covariance"):
+            object.__setattr__(self, name, _readonly_array(getattr(self, name)))
+
+
+def _as_2d(name, value):
+    arr = np.asarray(value, dtype=float)
+    if arr.ndim == 1:
+        arr = arr.reshape(1, -1)
+    if arr.ndim != 2:
+        raise ValueError(f"{name} must be a 1-D row or 2-D array")
+    if arr.shape[0] == 0 or arr.shape[1] == 0:
+        raise ValueError(f"{name} must be nonempty")
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} must be finite")
+    return arr
+
+
+def _observation_matrix(H, state_dim, observation_dim):
+    if H is None:
+        if state_dim != observation_dim:
+            raise ValueError("H is required when target_state and measurement dimensions differ")
+        return np.eye(state_dim)
+    mat = np.asarray(H, dtype=float)
+    if mat.shape != (observation_dim, state_dim):
+        raise ValueError(f"H shape {mat.shape} must be ({observation_dim}, {state_dim})")
+    if not np.isfinite(mat).all():
+        raise ValueError("H must be finite")
+    return mat
+
+
+def assert_disjoint_ids(left_ids, right_ids, left_name="calibration", right_name="evaluation"):
+    """Raise if two split-ID collections overlap."""
+    left = set(left_ids)
+    right = set(right_ids)
+    overlap = sorted(left & right, key=lambda x: repr(x))
+    if overlap:
+        preview = ", ".join(repr(x) for x in overlap[:5])
+        suffix = "" if len(overlap) <= 5 else f", ... (+{len(overlap) - 5} more)"
+        raise ValueError(f"{left_name} and {right_name} IDs overlap: {preview}{suffix}")
+
+
+def fit_product_kalman_calibration(prior_mean, measurement, target_state, H=None, shrinkage=0.0, jitter=1e-9,
+                                   ddof=1, shrinkage_target="diagonal"):
+    """Fit Product-Kalman covariance blocks from calibration residuals.
+
+    `prior_mean` and `target_state` are rows in the state/evidence coordinate.
+    `measurement` rows are observations of `H @ target_state` in the same linked
+    coordinate system used by the update. `C` is estimated jointly with `P` and
+    `R`, so correlated prior/measurement errors are retained instead of silently
+    dropped.
+    """
+    prior = _as_2d("prior_mean", prior_mean)
+    target = _as_2d("target_state", target_state)
+    obs = _as_2d("measurement", measurement)
+    if prior.shape != target.shape:
+        raise ValueError(f"prior_mean shape {prior.shape} must match target_state shape {target.shape}")
+    if obs.shape[0] != target.shape[0]:
+        raise ValueError("measurement rows must match target_state rows")
+    Hm = _observation_matrix(H, target.shape[1], obs.shape[1])
+
+    prior_error = target - prior
+    measurement_error = obs - target @ Hm.T
+    joint_error = np.concatenate([prior_error, measurement_error], axis=1)
+    joint_cov = fit_residual_covariance(
+        joint_error,
+        shrinkage=shrinkage,
+        jitter=jitter,
+        ddof=ddof,
+        shrinkage_target=shrinkage_target,
+    )
+    state_dim = target.shape[1]
+    obs_dim = obs.shape[1]
+    P = joint_cov[:state_dim, :state_dim]
+    R = joint_cov[state_dim:, state_dim:]
+    C = joint_cov[:state_dim, state_dim:]
+    return ProductKalmanCalibration(
+        state_covariance=regularize_covariance(P, jitter=jitter, name="state covariance"),
+        observation_covariance=regularize_covariance(R, jitter=jitter, name="observation covariance"),
+        cross_covariance=C,
+        H=Hm,
+        n_samples=int(target.shape[0]),
+        ddof=int(ddof),
+        shrinkage=float(shrinkage),
+        shrinkage_target=str(shrinkage_target),
+    )
+
+
+def apply_product_kalman_calibration(calibration, prior_mean, measurement, jitter=1e-9):
+    """Apply one fitted calibration to a batch of prior/measurement rows."""
+    if not isinstance(calibration, ProductKalmanCalibration):
+        raise ValueError("calibration must be a ProductKalmanCalibration")
+    prior = _as_2d("prior_mean", prior_mean)
+    obs = _as_2d("measurement", measurement)
+    if prior.shape[1] != calibration.state_dim:
+        raise ValueError(f"prior_mean has {prior.shape[1]} columns, expected {calibration.state_dim}")
+    if obs.shape != (prior.shape[0], calibration.observation_dim):
+        raise ValueError(f"measurement shape {obs.shape} must be ({prior.shape[0]}, {calibration.observation_dim})")
+
+    template = gaussian_condition_update(
+        np.zeros(calibration.state_dim),
+        calibration.state_covariance,
+        np.zeros(calibration.observation_dim),
+        calibration.observation_covariance,
+        H=calibration.H,
+        cross_covariance=calibration.cross_covariance,
+        jitter=jitter,
+    )
+    innovation = obs - prior @ calibration.H.T
+    mean = prior + innovation @ template.gain.T
+    return ProductKalmanBatchUpdate(
+        mean=mean,
+        covariance=template.covariance,
+        gain=template.gain,
+        innovation=innovation,
+        innovation_covariance=template.innovation_covariance,
+    )

--- a/prototypes/mu_cosine/product_kalman_calibration.py
+++ b/prototypes/mu_cosine/product_kalman_calibration.py
@@ -7,14 +7,14 @@ calibration split with known target states in the chosen evidence coordinate:
     prior_error       = target_state - prior_mean
     measurement_error = measurement - H @ target_state
 
-The fitted blocks are:
+The fitted blocks are one regularized joint covariance sliced as:
 
-    P = Cov(prior_error)
-    R = Cov(measurement_error)
-    C = Cov(prior_error, measurement_error)
+    [[P, C],
+     [C.T, R]]
 
 Use calibration data that is node-disjoint from training data and from the final
-evaluation split. These helpers do not decide the split; they make leakage harder
+evaluation split. Inputs are row matrices: use shape `(n, 1)` for scalar states
+or measurements. These helpers do not decide the split; they make leakage harder
 to miss once the split IDs are known.
 """
 
@@ -23,9 +23,9 @@ from dataclasses import dataclass
 import numpy as np
 
 try:
-    from .product_kalman import fit_residual_covariance, gaussian_condition_update, regularize_covariance
+    from .product_kalman import fit_residual_covariance, gaussian_condition_update
 except ImportError:  # direct script execution from prototypes/mu_cosine
-    from product_kalman import fit_residual_covariance, gaussian_condition_update, regularize_covariance
+    from product_kalman import fit_residual_covariance, gaussian_condition_update
 
 
 __all__ = [
@@ -43,9 +43,27 @@ def _readonly_array(value):
     return arr
 
 
+def _check_finite(name, arr):
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} must be finite")
+
+
+def _check_square_covariance(name, arr):
+    if arr.ndim != 2 or arr.shape[0] != arr.shape[1] or arr.shape[0] == 0:
+        raise ValueError(f"{name} must be a nonempty square matrix")
+    _check_finite(name, arr)
+    if not np.allclose(arr, arr.T, atol=1e-10, rtol=1e-10):
+        raise ValueError(f"{name} must be symmetric")
+
+
 @dataclass(frozen=True)
 class ProductKalmanCalibration:
-    """Covariance blocks fitted on a calibration split."""
+    """Covariance blocks fitted on a calibration split.
+
+    `__post_init__` validates the public constructor and then replaces array
+    fields with read-only copies; `frozen=True` alone would not protect numpy
+    arrays from in-place mutation.
+    """
 
     state_covariance: np.ndarray
     observation_covariance: np.ndarray
@@ -57,8 +75,46 @@ class ProductKalmanCalibration:
     shrinkage_target: str
 
     def __post_init__(self):
-        for name in ("state_covariance", "observation_covariance", "cross_covariance", "H"):
-            object.__setattr__(self, name, _readonly_array(getattr(self, name)))
+        state_cov = np.asarray(self.state_covariance, dtype=float)
+        obs_cov = np.asarray(self.observation_covariance, dtype=float)
+        cross_cov = np.asarray(self.cross_covariance, dtype=float)
+        H = np.asarray(self.H, dtype=float)
+
+        _check_square_covariance("state_covariance", state_cov)
+        _check_square_covariance("observation_covariance", obs_cov)
+        state_dim = state_cov.shape[0]
+        obs_dim = obs_cov.shape[0]
+        if cross_cov.shape != (state_dim, obs_dim):
+            raise ValueError(f"cross_covariance shape {cross_cov.shape} must be ({state_dim}, {obs_dim})")
+        if H.shape != (obs_dim, state_dim):
+            raise ValueError(f"H shape {H.shape} must be ({obs_dim}, {state_dim})")
+        _check_finite("cross_covariance", cross_cov)
+        _check_finite("H", H)
+
+        n_samples = int(self.n_samples)
+        ddof = int(self.ddof)
+        shrinkage = float(self.shrinkage)
+        shrinkage_target = str(self.shrinkage_target)
+        if n_samples <= state_dim + obs_dim:
+            raise ValueError("n_samples must exceed state_dim + observation_dim for a full-rank calibration fit")
+        if ddof < 0 or n_samples <= ddof:
+            raise ValueError("n_samples must exceed nonnegative ddof")
+        if not 0.0 <= shrinkage <= 1.0:
+            raise ValueError("shrinkage must be in [0, 1]")
+        if shrinkage_target not in ("diagonal", "scaled_identity"):
+            raise ValueError("shrinkage_target must be 'diagonal' or 'scaled_identity'")
+
+        for name, value in (
+            ("state_covariance", state_cov),
+            ("observation_covariance", obs_cov),
+            ("cross_covariance", cross_cov),
+            ("H", H),
+        ):
+            object.__setattr__(self, name, _readonly_array(value))
+        object.__setattr__(self, "n_samples", n_samples)
+        object.__setattr__(self, "ddof", ddof)
+        object.__setattr__(self, "shrinkage", shrinkage)
+        object.__setattr__(self, "shrinkage_target", shrinkage_target)
 
     @property
     def state_dim(self):
@@ -68,10 +124,23 @@ class ProductKalmanCalibration:
     def observation_dim(self):
         return int(self.observation_covariance.shape[0])
 
+    @property
+    def joint_covariance(self):
+        """Reconstruct the regularized joint covariance block matrix."""
+        return _readonly_array(np.block([
+            [self.state_covariance, self.cross_covariance],
+            [self.cross_covariance.T, self.observation_covariance],
+        ]))
+
 
 @dataclass(frozen=True)
 class ProductKalmanBatchUpdate:
-    """Batch application of one Product-Kalman calibration."""
+    """Batch application of one Product-Kalman calibration.
+
+    The posterior covariance, gain, and innovation covariance are shared across
+    rows because the fitted linear-Gaussian calibration is shared; only `mean`
+    and `innovation` vary by row.
+    """
 
     mean: np.ndarray
     covariance: np.ndarray
@@ -80,20 +149,41 @@ class ProductKalmanBatchUpdate:
     innovation_covariance: np.ndarray
 
     def __post_init__(self):
-        for name in ("mean", "covariance", "gain", "innovation", "innovation_covariance"):
-            object.__setattr__(self, name, _readonly_array(getattr(self, name)))
+        mean = np.asarray(self.mean, dtype=float)
+        covariance = np.asarray(self.covariance, dtype=float)
+        gain = np.asarray(self.gain, dtype=float)
+        innovation = np.asarray(self.innovation, dtype=float)
+        innovation_covariance = np.asarray(self.innovation_covariance, dtype=float)
+        if mean.ndim != 2 or innovation.ndim != 2:
+            raise ValueError("mean and innovation must be 2-D row matrices")
+        _check_square_covariance("covariance", covariance)
+        _check_square_covariance("innovation_covariance", innovation_covariance)
+        if gain.shape != (mean.shape[1], innovation.shape[1]):
+            raise ValueError(f"gain shape {gain.shape} must be ({mean.shape[1]}, {innovation.shape[1]})")
+        if covariance.shape != (mean.shape[1], mean.shape[1]):
+            raise ValueError("covariance dimension must match mean columns")
+        if innovation_covariance.shape != (innovation.shape[1], innovation.shape[1]):
+            raise ValueError("innovation_covariance dimension must match innovation columns")
+        if mean.shape[0] != innovation.shape[0]:
+            raise ValueError("mean and innovation must have the same row count")
+        for name, value in (
+            ("mean", mean),
+            ("covariance", covariance),
+            ("gain", gain),
+            ("innovation", innovation),
+            ("innovation_covariance", innovation_covariance),
+        ):
+            _check_finite(name, value)
+            object.__setattr__(self, name, _readonly_array(value))
 
 
 def _as_2d(name, value):
     arr = np.asarray(value, dtype=float)
-    if arr.ndim == 1:
-        arr = arr.reshape(1, -1)
     if arr.ndim != 2:
-        raise ValueError(f"{name} must be a 1-D row or 2-D array")
+        raise ValueError(f"{name} must be a 2-D row matrix; use shape (n, 1) for scalar channels")
     if arr.shape[0] == 0 or arr.shape[1] == 0:
         raise ValueError(f"{name} must be nonempty")
-    if not np.isfinite(arr).all():
-        raise ValueError(f"{name} must be finite")
+    _check_finite(name, arr)
     return arr
 
 
@@ -105,15 +195,32 @@ def _observation_matrix(H, state_dim, observation_dim):
     mat = np.asarray(H, dtype=float)
     if mat.shape != (observation_dim, state_dim):
         raise ValueError(f"H shape {mat.shape} must be ({observation_dim}, {state_dim})")
-    if not np.isfinite(mat).all():
-        raise ValueError("H must be finite")
+    _check_finite("H", mat)
     return mat
 
 
+def _duplicates(values):
+    seen = set()
+    dup = []
+    for value in values:
+        if value in seen and value not in dup:
+            dup.append(value)
+        seen.add(value)
+    return dup
+
+
 def assert_disjoint_ids(left_ids, right_ids, left_name="calibration", right_name="evaluation"):
-    """Raise if two split-ID collections overlap."""
-    left = set(left_ids)
-    right = set(right_ids)
+    """Raise if split-ID collections overlap or contain duplicate IDs."""
+    left_values = list(left_ids)
+    right_values = list(right_ids)
+    for name, values in ((left_name, left_values), (right_name, right_values)):
+        dup = _duplicates(values)
+        if dup:
+            preview = ", ".join(repr(x) for x in dup[:5])
+            suffix = "" if len(dup) <= 5 else f", ... (+{len(dup) - 5} more)"
+            raise ValueError(f"{name} IDs contain duplicates: {preview}{suffix}")
+    left = set(left_values)
+    right = set(right_values)
     overlap = sorted(left & right, key=lambda x: repr(x))
     if overlap:
         preview = ", ".join(repr(x) for x in overlap[:5])
@@ -125,11 +232,12 @@ def fit_product_kalman_calibration(prior_mean, measurement, target_state, H=None
                                    ddof=1, shrinkage_target="diagonal"):
     """Fit Product-Kalman covariance blocks from calibration residuals.
 
-    `prior_mean` and `target_state` are rows in the state/evidence coordinate.
-    `measurement` rows are observations of `H @ target_state` in the same linked
-    coordinate system used by the update. `C` is estimated jointly with `P` and
-    `R`, so correlated prior/measurement errors are retained instead of silently
-    dropped.
+    `prior_mean` and `target_state` are row matrices in the state/evidence
+    coordinate. `measurement` rows are observations of `H @ target_state` in the
+    same linked coordinate system used by the update. `H` is shape-validated, but
+    its scientific meaning is caller-supplied. `C` is estimated jointly with `P`
+    and `R`, so correlated prior/measurement errors are retained instead of
+    silently dropped.
     """
     prior = _as_2d("prior_mean", prior_mean)
     target = _as_2d("target_state", target_state)
@@ -139,6 +247,11 @@ def fit_product_kalman_calibration(prior_mean, measurement, target_state, H=None
     if obs.shape[0] != target.shape[0]:
         raise ValueError("measurement rows must match target_state rows")
     Hm = _observation_matrix(H, target.shape[1], obs.shape[1])
+    state_dim = target.shape[1]
+    obs_dim = obs.shape[1]
+    total_dim = state_dim + obs_dim
+    if target.shape[0] <= total_dim:
+        raise ValueError("calibration rows must exceed state_dim + observation_dim")
 
     prior_error = target - prior
     measurement_error = obs - target @ Hm.T
@@ -150,14 +263,14 @@ def fit_product_kalman_calibration(prior_mean, measurement, target_state, H=None
         ddof=ddof,
         shrinkage_target=shrinkage_target,
     )
-    state_dim = target.shape[1]
-    obs_dim = obs.shape[1]
+    if joint_cov.shape != (total_dim, total_dim):
+        raise ValueError(f"joint covariance shape {joint_cov.shape} must be ({total_dim}, {total_dim})")
     P = joint_cov[:state_dim, :state_dim]
-    R = joint_cov[state_dim:, state_dim:]
-    C = joint_cov[:state_dim, state_dim:]
+    R = joint_cov[state_dim:total_dim, state_dim:total_dim]
+    C = joint_cov[:state_dim, state_dim:total_dim]
     return ProductKalmanCalibration(
-        state_covariance=regularize_covariance(P, jitter=jitter, name="state covariance"),
-        observation_covariance=regularize_covariance(R, jitter=jitter, name="observation covariance"),
+        state_covariance=P,
+        observation_covariance=R,
         cross_covariance=C,
         H=Hm,
         n_samples=int(target.shape[0]),
@@ -168,7 +281,12 @@ def fit_product_kalman_calibration(prior_mean, measurement, target_state, H=None
 
 
 def apply_product_kalman_calibration(calibration, prior_mean, measurement, jitter=1e-9):
-    """Apply one fitted calibration to a batch of prior/measurement rows."""
+    """Apply one fitted calibration to a batch of prior/measurement rows.
+
+    This uses one zero-mean template update because the Kalman gain, posterior
+    covariance, and innovation covariance are independent of row means in the
+    linear-Gaussian model. Tests assert equivalence with rowwise core updates.
+    """
     if not isinstance(calibration, ProductKalmanCalibration):
         raise ValueError("calibration must be a ProductKalmanCalibration")
     prior = _as_2d("prior_mean", prior_mean)

--- a/prototypes/mu_cosine/product_kalman_calibration.py
+++ b/prototypes/mu_cosine/product_kalman_calibration.py
@@ -44,16 +44,30 @@ def _readonly_array(value):
 
 
 def _check_finite(name, arr):
+    """Validate a pre-converted ndarray is finite."""
     if not np.isfinite(arr).all():
         raise ValueError(f"{name} must be finite")
 
 
+def _covariance_atol(arr):
+    return 1e-10 * max(1.0, float(np.linalg.norm(arr, ord=np.inf)))
+
+
 def _check_square_covariance(name, arr):
+    """Validate a pre-converted ndarray has covariance-matrix shape and symmetry."""
     if arr.ndim != 2 or arr.shape[0] != arr.shape[1] or arr.shape[0] == 0:
         raise ValueError(f"{name} must be a nonempty square matrix")
     _check_finite(name, arr)
-    if not np.allclose(arr, arr.T, atol=1e-10, rtol=1e-10):
+    if not np.allclose(arr, arr.T, atol=_covariance_atol(arr), rtol=1e-10):
         raise ValueError(f"{name} must be symmetric")
+
+
+def _check_positive_semidefinite(name, arr):
+    sym = 0.5 * (arr + arr.T)
+    floor = -1e-9 * max(1.0, float(np.linalg.norm(sym, ord=np.inf)))
+    min_eig = float(np.linalg.eigvalsh(sym).min())
+    if min_eig < floor:
+        raise ValueError(f"{name} must be positive semidefinite; min eigenvalue {min_eig:.3g}")
 
 
 @dataclass(frozen=True)
@@ -82,6 +96,8 @@ class ProductKalmanCalibration:
 
         _check_square_covariance("state_covariance", state_cov)
         _check_square_covariance("observation_covariance", obs_cov)
+        _check_positive_semidefinite("state_covariance", state_cov)
+        _check_positive_semidefinite("observation_covariance", obs_cov)
         state_dim = state_cov.shape[0]
         obs_dim = obs_cov.shape[0]
         if cross_cov.shape != (state_dim, obs_dim):
@@ -90,11 +106,15 @@ class ProductKalmanCalibration:
             raise ValueError(f"H shape {H.shape} must be ({obs_dim}, {state_dim})")
         _check_finite("cross_covariance", cross_cov)
         _check_finite("H", H)
+        joint_cov = np.block([[state_cov, cross_cov], [cross_cov.T, obs_cov]])
+        _check_positive_semidefinite("joint_covariance", joint_cov)
 
         n_samples = int(self.n_samples)
         ddof = int(self.ddof)
         shrinkage = float(self.shrinkage)
         shrinkage_target = str(self.shrinkage_target)
+        # This is a conservative policy guard on recorded fit metadata: jitter may make
+        # smaller fits invertible, but then rank is coming mostly from regularization.
         if n_samples <= state_dim + obs_dim:
             raise ValueError("n_samples must exceed state_dim + observation_dim for a full-rank calibration fit")
         if ddof < 0 or n_samples <= ddof:
@@ -203,14 +223,18 @@ def _duplicates(values):
     seen = set()
     dup = []
     for value in values:
-        if value in seen and value not in dup:
-            dup.append(value)
-        seen.add(value)
+        try:
+            already_seen = value in seen
+            if already_seen and value not in dup:
+                dup.append(value)
+            seen.add(value)
+        except TypeError as exc:
+            raise ValueError("split IDs must be hashable") from exc
     return dup
 
 
 def assert_disjoint_ids(left_ids, right_ids, left_name="calibration", right_name="evaluation"):
-    """Raise if split-ID collections overlap or contain duplicate IDs."""
+    """Raise if hashable split-ID collections overlap or contain duplicate IDs."""
     left_values = list(left_ids)
     right_values = list(right_ids)
     for name, values in ((left_name, left_values), (right_name, right_values)):
@@ -250,6 +274,8 @@ def fit_product_kalman_calibration(prior_mean, measurement, target_state, H=None
     state_dim = target.shape[1]
     obs_dim = obs.shape[1]
     total_dim = state_dim + obs_dim
+    # Policy guard: require enough rows that jitter stabilizes the empirical covariance
+    # rather than supplying all of its missing rank.
     if target.shape[0] <= total_dim:
         raise ValueError("calibration rows must exceed state_dim + observation_dim")
 
@@ -285,7 +311,9 @@ def apply_product_kalman_calibration(calibration, prior_mean, measurement, jitte
 
     This uses one zero-mean template update because the Kalman gain, posterior
     covariance, and innovation covariance are independent of row means in the
-    linear-Gaussian model. Tests assert equivalence with rowwise core updates.
+    linear-Gaussian model. The batch mean is equivalent to applying
+    `gaussian_condition_update` independently to each row with the same fitted
+    covariance blocks.
     """
     if not isinstance(calibration, ProductKalmanCalibration):
         raise ValueError("calibration must be a ProductKalmanCalibration")

--- a/prototypes/mu_cosine/test_product_kalman_calibration.py
+++ b/prototypes/mu_cosine/test_product_kalman_calibration.py
@@ -129,50 +129,48 @@ def test_calibration_and_batch_results_are_read_only():
         assert not arr.flags.writeable
 
 
+def calibration_kwargs(**overrides):
+    kwargs = dict(
+        state_covariance=np.eye(2),
+        observation_covariance=np.eye(1),
+        cross_covariance=np.zeros((2, 1)),
+        H=np.zeros((1, 2)),
+        n_samples=5,
+        ddof=1,
+        shrinkage=0.0,
+        shrinkage_target="diagonal",
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
 def test_constructor_invariants_fail_fast():
     assert_raises(
         ProductKalmanCalibration,
-        np.eye(2),
-        np.eye(1),
-        np.zeros((1, 1)),
-        np.zeros((1, 2)),
-        5,
-        1,
-        0.0,
-        "diagonal",
+        **calibration_kwargs(cross_covariance=np.zeros((1, 1))),
     )
     assert_raises(
         ProductKalmanCalibration,
-        np.eye(2),
-        np.eye(1),
-        np.zeros((2, 1)),
-        np.zeros((2, 2)),
-        5,
-        1,
-        0.0,
-        "diagonal",
+        **calibration_kwargs(H=np.zeros((2, 2))),
     )
     assert_raises(
         ProductKalmanCalibration,
-        [[1.0, 2.0]],
-        np.eye(1),
-        np.zeros((1, 1)),
-        np.zeros((1, 1)),
-        5,
-        1,
-        0.0,
-        "diagonal",
+        **calibration_kwargs(state_covariance=[[1.0, 2.0]]),
     )
     assert_raises(
         ProductKalmanCalibration,
-        np.eye(2),
-        np.eye(1),
-        np.zeros((2, 1)),
-        np.zeros((1, 2)),
-        3,
-        1,
-        0.0,
-        "diagonal",
+        **calibration_kwargs(n_samples=3),
+    )
+    assert_raises(
+        ProductKalmanCalibration,
+        state_covariance=[[1.0]],
+        observation_covariance=[[1.0]],
+        cross_covariance=[[1.5]],
+        H=[[1.0]],
+        n_samples=3,
+        ddof=1,
+        shrinkage=0.0,
+        shrinkage_target="diagonal",
     )
 
 
@@ -181,6 +179,7 @@ def test_assert_disjoint_ids_flags_leakage_and_duplicates():
     assert_raises(assert_disjoint_ids, ["a", "b"], ["b", "c"])
     assert_raises(assert_disjoint_ids, ["a", "a"], ["b", "c"])
     assert_raises(assert_disjoint_ids, ["a", "b"], ["c", "c"])
+    assert_raises(assert_disjoint_ids, [["a"]], ["b"])
 
 
 def test_shape_and_type_errors_fail_fast():
@@ -219,6 +218,31 @@ def test_shrinkage_path_handles_near_singular_joint_errors():
     out = apply_product_kalman_calibration(cal, prior[:2], measurement[:2])
     assert np.linalg.eigvalsh(cal.joint_covariance).min() > 0.0
     assert np.linalg.eigvalsh(out.innovation_covariance).min() > 0.0
+
+
+def test_shrinkage_targets_are_threaded_to_residual_fit():
+    prior, measurement, target, H, _, _ = toy_calibration_inputs()
+    diagonal = fit_product_kalman_calibration(
+        prior,
+        measurement,
+        target,
+        H=H,
+        shrinkage=0.5,
+        shrinkage_target="diagonal",
+        jitter=1e-8,
+    )
+    scaled = fit_product_kalman_calibration(
+        prior,
+        measurement,
+        target,
+        H=H,
+        shrinkage=0.5,
+        shrinkage_target="scaled_identity",
+        jitter=1e-8,
+    )
+    assert not np.allclose(diagonal.joint_covariance, scaled.joint_covariance)
+    assert np.linalg.eigvalsh(diagonal.joint_covariance).min() > 0.0
+    assert np.linalg.eigvalsh(scaled.joint_covariance).min() > 0.0
 
 
 def test_core_update_contract_used_by_batch_template():

--- a/prototypes/mu_cosine/test_product_kalman_calibration.py
+++ b/prototypes/mu_cosine/test_product_kalman_calibration.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import numpy as np
 
-from product_kalman import gaussian_condition_update, gaussian_nll
+from product_kalman import fit_residual_covariance, gaussian_condition_update, gaussian_nll
 from product_kalman_calibration import (
     ProductKalmanCalibration,
     apply_product_kalman_calibration,
@@ -60,7 +60,8 @@ def test_fit_calibration_splits_joint_covariance_into_blocks():
     prior, measurement, target, H, prior_error, measurement_error = toy_calibration_inputs()
     cal = fit_product_kalman_calibration(prior, measurement, target, H=H, jitter=0.0)
     joint = np.concatenate([prior_error, measurement_error], axis=1)
-    expected = np.cov(joint, rowvar=False, bias=False)
+    expected = fit_residual_covariance(joint, jitter=0.0)
+    np.testing.assert_allclose(cal.joint_covariance, expected, atol=1e-12)
     np.testing.assert_allclose(cal.state_covariance, expected[:2, :2], atol=1e-12)
     np.testing.assert_allclose(cal.observation_covariance, expected[2:, 2:], atol=1e-12)
     np.testing.assert_allclose(cal.cross_covariance, expected[:2, 2:], atol=1e-12)
@@ -69,53 +70,161 @@ def test_fit_calibration_splits_joint_covariance_into_blocks():
     assert cal.ddof == 1
 
 
-def test_apply_calibration_matches_core_update_rowwise():
+def test_jitter_is_applied_once_to_joint_covariance_before_slicing():
+    prior, measurement, target, H, prior_error, measurement_error = toy_calibration_inputs()
+    jitter = 0.05
+    cal = fit_product_kalman_calibration(prior, measurement, target, H=H, jitter=jitter)
+    joint = np.concatenate([prior_error, measurement_error], axis=1)
+    expected = fit_residual_covariance(joint, jitter=jitter)
+    np.testing.assert_allclose(cal.joint_covariance, expected, atol=1e-12)
+
+
+def test_apply_calibration_matches_core_update_for_every_row():
     prior, measurement, target, H, _, _ = toy_calibration_inputs()
     cal = fit_product_kalman_calibration(prior, measurement, target, H=H, jitter=0.0)
+    out = apply_product_kalman_calibration(cal, prior[:3], measurement[:3], jitter=0.0)
+    for i in range(3):
+        direct = gaussian_condition_update(
+            prior[i],
+            cal.state_covariance,
+            measurement[i],
+            cal.observation_covariance,
+            H=cal.H,
+            cross_covariance=cal.cross_covariance,
+            jitter=0.0,
+        )
+        np.testing.assert_allclose(out.mean[i], direct.mean, atol=1e-12)
+        np.testing.assert_allclose(out.covariance, direct.covariance, atol=1e-12)
+        np.testing.assert_allclose(out.gain, direct.gain, atol=1e-12)
+        np.testing.assert_allclose(out.innovation[i], direct.innovation, atol=1e-12)
+
+
+def test_identity_H_success_path_for_scalar_row_matrices():
+    target = np.array([[0.0], [1.0], [2.0], [3.0]])
+    prior = target - np.array([[0.2], [-0.1], [0.1], [-0.2]])
+    measurement = target + np.array([[0.05], [-0.05], [0.02], [-0.02]])
+    cal = fit_product_kalman_calibration(prior, measurement, target, H=None, jitter=0.0)
+    np.testing.assert_allclose(cal.H, [[1.0]], atol=1e-12)
     out = apply_product_kalman_calibration(cal, prior[:2], measurement[:2], jitter=0.0)
-    direct = gaussian_condition_update(
-        prior[0],
-        cal.state_covariance,
-        measurement[0],
-        cal.observation_covariance,
-        H=cal.H,
-        cross_covariance=cal.cross_covariance,
-        jitter=0.0,
-    )
-    np.testing.assert_allclose(out.mean[0], direct.mean, atol=1e-12)
-    np.testing.assert_allclose(out.covariance, direct.covariance, atol=1e-12)
-    np.testing.assert_allclose(out.gain, direct.gain, atol=1e-12)
-    np.testing.assert_allclose(out.innovation[0], direct.innovation, atol=1e-12)
+    assert out.mean.shape == (2, 1)
 
 
 def test_calibration_and_batch_results_are_read_only():
     prior, measurement, target, H, _, _ = toy_calibration_inputs()
     cal = fit_product_kalman_calibration(prior, measurement, target, H=H)
-    out = apply_product_kalman_calibration(cal, prior[:1], measurement[:1])
-    for arr in (cal.state_covariance, cal.observation_covariance, cal.cross_covariance, cal.H, out.mean, out.gain):
-        try:
-            arr.flat[0] = 99.0
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("calibration/update arrays should be read-only")
+    out = apply_product_kalman_calibration(cal, prior[:2], measurement[:2])
+    arrays = (
+        cal.state_covariance,
+        cal.observation_covariance,
+        cal.cross_covariance,
+        cal.H,
+        cal.joint_covariance,
+        out.mean,
+        out.covariance,
+        out.gain,
+        out.innovation,
+        out.innovation_covariance,
+    )
+    for arr in arrays:
+        assert not arr.flags.writeable
 
 
-def test_assert_disjoint_ids_flags_leakage():
+def test_constructor_invariants_fail_fast():
+    assert_raises(
+        ProductKalmanCalibration,
+        np.eye(2),
+        np.eye(1),
+        np.zeros((1, 1)),
+        np.zeros((1, 2)),
+        5,
+        1,
+        0.0,
+        "diagonal",
+    )
+    assert_raises(
+        ProductKalmanCalibration,
+        np.eye(2),
+        np.eye(1),
+        np.zeros((2, 1)),
+        np.zeros((2, 2)),
+        5,
+        1,
+        0.0,
+        "diagonal",
+    )
+    assert_raises(
+        ProductKalmanCalibration,
+        [[1.0, 2.0]],
+        np.eye(1),
+        np.zeros((1, 1)),
+        np.zeros((1, 1)),
+        5,
+        1,
+        0.0,
+        "diagonal",
+    )
+    assert_raises(
+        ProductKalmanCalibration,
+        np.eye(2),
+        np.eye(1),
+        np.zeros((2, 1)),
+        np.zeros((1, 2)),
+        3,
+        1,
+        0.0,
+        "diagonal",
+    )
+
+
+def test_assert_disjoint_ids_flags_leakage_and_duplicates():
     assert_disjoint_ids(["a", "b"], ["c", "d"])
     assert_raises(assert_disjoint_ids, ["a", "b"], ["b", "c"])
+    assert_raises(assert_disjoint_ids, ["a", "a"], ["b", "c"])
+    assert_raises(assert_disjoint_ids, ["a", "b"], ["c", "c"])
 
 
 def test_shape_and_type_errors_fail_fast():
     prior, measurement, target, H, _, _ = toy_calibration_inputs()
+    assert_raises(fit_product_kalman_calibration, prior[:, 0], measurement, target, H=H)
+    assert_raises(fit_product_kalman_calibration, prior, measurement[:, 0], target, H=H)
+    assert_raises(fit_product_kalman_calibration, prior, measurement, target[:, 0], H=H)
     assert_raises(fit_product_kalman_calibration, prior[:, :1], measurement, target, H=H)
     assert_raises(fit_product_kalman_calibration, prior, measurement[:-1], target, H=H)
     assert_raises(fit_product_kalman_calibration, prior, measurement, target, H=None)
     assert_raises(fit_product_kalman_calibration, prior, measurement, target, H=np.eye(2))
+    assert_raises(fit_product_kalman_calibration, prior[:3], measurement[:3], target[:3], H=H)
     cal = fit_product_kalman_calibration(prior, measurement, target, H=H)
     assert_raises(apply_product_kalman_calibration, "not-calibration", prior, measurement)
+    assert_raises(apply_product_kalman_calibration, cal, prior[0], measurement[:1])
     assert_raises(apply_product_kalman_calibration, cal, prior[:, :1], measurement)
     assert_raises(apply_product_kalman_calibration, cal, prior, np.hstack([measurement, measurement]))
+
+
+def test_shrinkage_path_handles_near_singular_joint_errors():
+    target = np.array([[i, 2.0 * i] for i in range(6)], dtype=float)
+    prior_error = np.array([[0.1 * i, 0.2 * i] for i in range(6)], dtype=float)
+    measurement_error = np.array([[0.05 * i] for i in range(6)], dtype=float)
+    H = np.array([[1.0, -0.25]])
+    prior = target - prior_error
+    measurement = target @ H.T + measurement_error
+    cal = fit_product_kalman_calibration(
+        prior,
+        measurement,
+        target,
+        H=H,
+        shrinkage=0.5,
+        shrinkage_target="scaled_identity",
+        jitter=1e-8,
+    )
+    out = apply_product_kalman_calibration(cal, prior[:2], measurement[:2])
+    assert np.linalg.eigvalsh(cal.joint_covariance).min() > 0.0
+    assert np.linalg.eigvalsh(out.innovation_covariance).min() > 0.0
+
+
+def test_core_update_contract_used_by_batch_template():
+    res = gaussian_condition_update([0.0], [[1.0]], [0.5], [[1.0]], cross_covariance=[[0.0]])
+    for name in ("mean", "covariance", "gain", "innovation", "innovation_covariance"):
+        assert hasattr(res, name)
 
 
 def test_synthetic_calibration_update_improves_eval_nll_over_prior():
@@ -137,6 +246,8 @@ def test_synthetic_calibration_update_improves_eval_nll_over_prior():
     prior_nll = np.mean([gaussian_nll(target[i], prior[i], cal.state_covariance) for i in range(n_cal, n)])
     post_nll = np.mean([gaussian_nll(target[n_cal + i], out.mean[i], out.covariance) for i in range(n_eval)])
     assert abs(cal.cross_covariance[0, 0] - error_cov[0, 1]) < 0.04
+    # The synthetic measurement channel is much cleaner than the prior channel; require a large enough NLL margin
+    # to catch regressions that accidentally drop the measurement or its cross-covariance.
     assert post_nll < prior_nll - 0.25
 
 

--- a/prototypes/mu_cosine/test_product_kalman_calibration.py
+++ b/prototypes/mu_cosine/test_product_kalman_calibration.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Tests for Product-Kalman calibration helpers.
+
+Run: `python3 test_product_kalman_calibration.py`.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np
+
+from product_kalman import gaussian_condition_update, gaussian_nll
+from product_kalman_calibration import (
+    ProductKalmanCalibration,
+    apply_product_kalman_calibration,
+    assert_disjoint_ids,
+    fit_product_kalman_calibration,
+)
+
+
+def assert_raises(fn, *args, **kwargs):
+    try:
+        fn(*args, **kwargs)
+    except ValueError:
+        return
+    raise AssertionError(f"{fn.__name__} should have raised ValueError")
+
+
+def toy_calibration_inputs():
+    target = np.array([
+        [0.0, 0.0],
+        [1.0, 0.5],
+        [2.0, -0.5],
+        [3.0, 1.0],
+        [4.0, 0.0],
+    ])
+    prior_error = np.array([
+        [0.2, -0.1],
+        [-0.3, 0.2],
+        [0.1, 0.0],
+        [0.4, -0.2],
+        [-0.4, 0.1],
+    ])
+    measurement_error = np.array([
+        [0.1],
+        [-0.2],
+        [0.3],
+        [-0.1],
+        [0.0],
+    ])
+    H = np.array([[1.0, 0.5]])
+    prior = target - prior_error
+    measurement = target @ H.T + measurement_error
+    return prior, measurement, target, H, prior_error, measurement_error
+
+
+def test_fit_calibration_splits_joint_covariance_into_blocks():
+    prior, measurement, target, H, prior_error, measurement_error = toy_calibration_inputs()
+    cal = fit_product_kalman_calibration(prior, measurement, target, H=H, jitter=0.0)
+    joint = np.concatenate([prior_error, measurement_error], axis=1)
+    expected = np.cov(joint, rowvar=False, bias=False)
+    np.testing.assert_allclose(cal.state_covariance, expected[:2, :2], atol=1e-12)
+    np.testing.assert_allclose(cal.observation_covariance, expected[2:, 2:], atol=1e-12)
+    np.testing.assert_allclose(cal.cross_covariance, expected[:2, 2:], atol=1e-12)
+    np.testing.assert_allclose(cal.H, H, atol=1e-12)
+    assert cal.n_samples == len(target)
+    assert cal.ddof == 1
+
+
+def test_apply_calibration_matches_core_update_rowwise():
+    prior, measurement, target, H, _, _ = toy_calibration_inputs()
+    cal = fit_product_kalman_calibration(prior, measurement, target, H=H, jitter=0.0)
+    out = apply_product_kalman_calibration(cal, prior[:2], measurement[:2], jitter=0.0)
+    direct = gaussian_condition_update(
+        prior[0],
+        cal.state_covariance,
+        measurement[0],
+        cal.observation_covariance,
+        H=cal.H,
+        cross_covariance=cal.cross_covariance,
+        jitter=0.0,
+    )
+    np.testing.assert_allclose(out.mean[0], direct.mean, atol=1e-12)
+    np.testing.assert_allclose(out.covariance, direct.covariance, atol=1e-12)
+    np.testing.assert_allclose(out.gain, direct.gain, atol=1e-12)
+    np.testing.assert_allclose(out.innovation[0], direct.innovation, atol=1e-12)
+
+
+def test_calibration_and_batch_results_are_read_only():
+    prior, measurement, target, H, _, _ = toy_calibration_inputs()
+    cal = fit_product_kalman_calibration(prior, measurement, target, H=H)
+    out = apply_product_kalman_calibration(cal, prior[:1], measurement[:1])
+    for arr in (cal.state_covariance, cal.observation_covariance, cal.cross_covariance, cal.H, out.mean, out.gain):
+        try:
+            arr.flat[0] = 99.0
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("calibration/update arrays should be read-only")
+
+
+def test_assert_disjoint_ids_flags_leakage():
+    assert_disjoint_ids(["a", "b"], ["c", "d"])
+    assert_raises(assert_disjoint_ids, ["a", "b"], ["b", "c"])
+
+
+def test_shape_and_type_errors_fail_fast():
+    prior, measurement, target, H, _, _ = toy_calibration_inputs()
+    assert_raises(fit_product_kalman_calibration, prior[:, :1], measurement, target, H=H)
+    assert_raises(fit_product_kalman_calibration, prior, measurement[:-1], target, H=H)
+    assert_raises(fit_product_kalman_calibration, prior, measurement, target, H=None)
+    assert_raises(fit_product_kalman_calibration, prior, measurement, target, H=np.eye(2))
+    cal = fit_product_kalman_calibration(prior, measurement, target, H=H)
+    assert_raises(apply_product_kalman_calibration, "not-calibration", prior, measurement)
+    assert_raises(apply_product_kalman_calibration, cal, prior[:, :1], measurement)
+    assert_raises(apply_product_kalman_calibration, cal, prior, np.hstack([measurement, measurement]))
+
+
+def test_synthetic_calibration_update_improves_eval_nll_over_prior():
+    rng = np.random.default_rng(11)
+    n_cal = 5000
+    n_eval = 2000
+    n = n_cal + n_eval
+    target = rng.normal(size=(n, 1))
+    error_cov = np.array([[0.9, 0.25], [0.25, 0.35]])
+    errors = rng.multivariate_normal([0.0, 0.0], error_cov, size=n)
+    prior_error = errors[:, :1]
+    measurement_error = errors[:, 1:]
+    prior = target - prior_error
+    measurement = target + measurement_error
+
+    cal = fit_product_kalman_calibration(prior[:n_cal], measurement[:n_cal], target[:n_cal], jitter=1e-9)
+    out = apply_product_kalman_calibration(cal, prior[n_cal:], measurement[n_cal:])
+
+    prior_nll = np.mean([gaussian_nll(target[i], prior[i], cal.state_covariance) for i in range(n_cal, n)])
+    post_nll = np.mean([gaussian_nll(target[n_cal + i], out.mean[i], out.covariance) for i in range(n_eval)])
+    assert abs(cal.cross_covariance[0, 0] - error_cov[0, 1]) < 0.04
+    assert post_nll < prior_nll - 0.25
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} product-kalman calibration tests passed")


### PR DESCRIPTION
Adds the calibration layer for Product-Kalman experiments, between the core Gaussian update primitive and any real-data held-out comparison.

Changes:
- Add `product_kalman_calibration.py` to estimate `P`, `R`, and prior-measurement cross-covariance from calibration residuals.
- Add batch application of a fitted Product-Kalman calibration.
- Add `assert_disjoint_ids` to catch calibration/evaluation split leakage.
- Add synthetic tests for covariance block fitting, rowwise equivalence to the core update, read-only result arrays, shape/type guards, and held-out synthetic NLL improvement over the prior.
- Update `DESIGN_product_kalman_poe.md` to record the calibration/evaluation split boundary.

Validation:
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 -m pytest -s prototypes/mu_cosine/test_product_kalman.py prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `python3 -m py_compile prototypes/mu_cosine/product_kalman.py prototypes/mu_cosine/product_kalman_calibration.py prototypes/mu_cosine/test_product_kalman.py prototypes/mu_cosine/test_product_kalman_calibration.py`
- `git diff --check`