### PR TITLE
Add Product-Kalman holdout evaluation harness

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -370,10 +370,13 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    covariance block matrix, and all scalar channels must be passed as explicit `(n, 1)` row matrices rather than
    ambiguous 1-D arrays. Calibration splits must be node-disjoint from training data and from the final evaluation
    split.
-6. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
+6. Use `product_kalman_evaluation.py` as the split-safe comparison harness: fit calibration blocks on one
+   split, score prior / zero-cross-covariance / correlated Product-Kalman predictions on a separate split,
+   and keep calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison pending.)*
+7. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
    Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
    residuals that set `R_ell` as the comparison set.
-7. Only after the held-out comparison, decide whether this belongs in the training objective.
+8. Only after the held-out comparison, decide whether this belongs in the training objective.
 
 ## Related local artifacts
 
@@ -392,5 +395,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   product-evidence coordinates, with residual covariance fitting and explicit prior-measurement cross-covariance.
 - `product_kalman_calibration.py` and `test_product_kalman_calibration.py` — calibration-split fitting of
   `P`, `R`, and cross-covariance blocks plus batch application and split-ID leakage guards.
+- `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
+  prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Holdout evaluation helpers for Product-Kalman calibration prototypes.
+
+This module is the bridge between the covariance-fitting helpers and later real
+corpus experiments. It fits Product-Kalman covariance blocks on a calibration
+split, applies them to a separate evaluation split, and reports comparable
+Gaussian NLL/MSE scores for the prior, a zero-cross-covariance update, and the
+correlated Product-Kalman update.
+
+The helpers are deliberately numpy-only and require caller-supplied split rows.
+They do not sample data, train a model, or decide that a Product-Kalman variant
+has won; they make the held-out comparison auditable.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+try:
+    from .product_kalman import gaussian_nll
+    from .product_kalman_calibration import (
+        ProductKalmanCalibration,
+        apply_product_kalman_calibration,
+        assert_disjoint_ids,
+        fit_product_kalman_calibration,
+    )
+except ImportError:  # direct script execution from prototypes/mu_cosine
+    from product_kalman import gaussian_nll
+    from product_kalman_calibration import (
+        ProductKalmanCalibration,
+        apply_product_kalman_calibration,
+        assert_disjoint_ids,
+        fit_product_kalman_calibration,
+    )
+
+
+__all__ = [
+    "GaussianScore",
+    "ProductKalmanHoldoutEvaluation",
+    "evaluate_product_kalman_holdout",
+    "score_gaussian_predictions",
+]
+
+
+def _as_2d(name, value):
+    arr = np.asarray(value, dtype=float)
+    if arr.ndim != 2:
+        raise ValueError(f"{name} must be a 2-D row matrix; use shape (n, 1) for scalar channels")
+    if arr.shape[0] == 0 or arr.shape[1] == 0:
+        raise ValueError(f"{name} must be nonempty")
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} must be finite")
+    return arr
+
+
+def _as_covariance(name, value, dim):
+    cov = np.asarray(value, dtype=float)
+    if cov.shape != (dim, dim):
+        raise ValueError(f"{name} shape {cov.shape} must be ({dim}, {dim})")
+    if not np.isfinite(cov).all():
+        raise ValueError(f"{name} must be finite")
+    return 0.5 * (cov + cov.T)
+
+
+@dataclass(frozen=True)
+class GaussianScore:
+    """Scalar summary for one Gaussian prediction family on one held-out split."""
+
+    name: str
+    mean_nll: float
+    mse: float
+    n: int
+    covariance_trace: float
+
+    def __post_init__(self):
+        name = str(self.name)
+        n = int(self.n)
+        mean_nll = float(self.mean_nll)
+        mse = float(self.mse)
+        covariance_trace = float(self.covariance_trace)
+        if not name:
+            raise ValueError("score name must be nonempty")
+        if n <= 0:
+            raise ValueError("score n must be positive")
+        for field, value in (("mean_nll", mean_nll), ("mse", mse), ("covariance_trace", covariance_trace)):
+            if not np.isfinite(value):
+                raise ValueError(f"{field} must be finite")
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "n", n)
+        object.__setattr__(self, "mean_nll", mean_nll)
+        object.__setattr__(self, "mse", mse)
+        object.__setattr__(self, "covariance_trace", covariance_trace)
+
+
+@dataclass(frozen=True)
+class ProductKalmanHoldoutEvaluation:
+    """One calibration/evaluation split comparison.
+
+    `calibration` contains the fitted correlated covariance blocks. `independent`
+    is the same fit with `cross_covariance=0`, used as the explicit no-correlation
+    control. The two batch updates are retained so callers can inspect row-level
+    posterior means after reading the aggregate scores.
+    """
+
+    calibration: ProductKalmanCalibration
+    independent_calibration: ProductKalmanCalibration
+    correlated_update: object
+    independent_update: object
+    scores: tuple
+
+    def __post_init__(self):
+        if not isinstance(self.calibration, ProductKalmanCalibration):
+            raise ValueError("calibration must be a ProductKalmanCalibration")
+        if not isinstance(self.independent_calibration, ProductKalmanCalibration):
+            raise ValueError("independent_calibration must be a ProductKalmanCalibration")
+        scores = tuple(self.scores)
+        names = [s.name for s in scores]
+        if len(names) != len(set(names)):
+            raise ValueError("score names must be unique")
+        object.__setattr__(self, "scores", scores)
+
+    def score(self, name):
+        """Return the named `GaussianScore`."""
+        for score in self.scores:
+            if score.name == name:
+                return score
+        raise KeyError(name)
+
+    def nll_improvement(self, baseline, candidate):
+        """Positive means `candidate` has lower mean NLL than `baseline`."""
+        return self.score(baseline).mean_nll - self.score(candidate).mean_nll
+
+
+def score_gaussian_predictions(name, target_state, mean, covariance, jitter=1e-9):
+    """Score row-wise Gaussian predictions against held-out target states.
+
+    `target_state` and `mean` must be `(n, d)` row matrices. `covariance` is one
+    shared `(d, d)` covariance for the prediction family, matching the current
+    Product-Kalman calibration/update contract.
+    """
+    target = _as_2d("target_state", target_state)
+    pred = _as_2d("mean", mean)
+    if pred.shape != target.shape:
+        raise ValueError(f"mean shape {pred.shape} must match target_state shape {target.shape}")
+    cov = _as_covariance("covariance", covariance, target.shape[1])
+    nll = [gaussian_nll(target[i], pred[i], cov, jitter=jitter) for i in range(target.shape[0])]
+    residual = target - pred
+    mse = float(np.mean(np.sum(residual * residual, axis=1)))
+    return GaussianScore(
+        name=name,
+        mean_nll=float(np.mean(nll)),
+        mse=mse,
+        n=int(target.shape[0]),
+        covariance_trace=float(np.trace(cov)),
+    )
+
+
+def _check_split_ids(calibration_ids, evaluation_ids, n_calibration, n_evaluation):
+    if calibration_ids is None and evaluation_ids is None:
+        return
+    if calibration_ids is None or evaluation_ids is None:
+        raise ValueError("calibration_ids and evaluation_ids must be provided together")
+    calibration_ids = list(calibration_ids)
+    evaluation_ids = list(evaluation_ids)
+    if len(calibration_ids) != n_calibration:
+        raise ValueError("calibration_ids length must match calibration rows")
+    if len(evaluation_ids) != n_evaluation:
+        raise ValueError("evaluation_ids length must match evaluation rows")
+    assert_disjoint_ids(calibration_ids, evaluation_ids)
+
+
+def _zero_cross_calibration(calibration):
+    return ProductKalmanCalibration(
+        state_covariance=calibration.state_covariance,
+        observation_covariance=calibration.observation_covariance,
+        cross_covariance=np.zeros_like(calibration.cross_covariance),
+        H=calibration.H,
+        n_samples=calibration.n_samples,
+        ddof=calibration.ddof,
+        shrinkage=calibration.shrinkage,
+        shrinkage_target=calibration.shrinkage_target,
+    )
+
+
+def _has_identity_observation(calibration):
+    if calibration.state_dim != calibration.observation_dim:
+        return False
+    return bool(np.allclose(calibration.H, np.eye(calibration.state_dim), atol=1e-12, rtol=1e-12))
+
+
+def evaluate_product_kalman_holdout(
+    calibration_prior_mean,
+    calibration_measurement,
+    calibration_target_state,
+    evaluation_prior_mean,
+    evaluation_measurement,
+    evaluation_target_state,
+    H=None,
+    calibration_ids=None,
+    evaluation_ids=None,
+    shrinkage=0.0,
+    jitter=1e-9,
+    ddof=1,
+    shrinkage_target="diagonal",
+):
+    """Fit calibration blocks on one split and score updates on a held-out split.
+
+    The returned scores always include:
+    - `prior`: evaluation prior mean with fitted prior-error covariance;
+    - `independent_kalman`: same fitted `P`/`R`, but `C=0`;
+    - `product_kalman`: fitted correlated Product-Kalman update.
+
+    If `H` is identity and observation/state dimensions match, a `measurement`
+    baseline is also scored. Non-identity observations are not directly target-
+    coordinate predictions, so the measurement baseline is omitted rather than
+    silently applying an inverse map.
+    """
+    cal_prior = _as_2d("calibration_prior_mean", calibration_prior_mean)
+    cal_measure = _as_2d("calibration_measurement", calibration_measurement)
+    cal_target = _as_2d("calibration_target_state", calibration_target_state)
+    eval_prior = _as_2d("evaluation_prior_mean", evaluation_prior_mean)
+    eval_measure = _as_2d("evaluation_measurement", evaluation_measurement)
+    eval_target = _as_2d("evaluation_target_state", evaluation_target_state)
+    _check_split_ids(calibration_ids, evaluation_ids, cal_target.shape[0], eval_target.shape[0])
+
+    calibration = fit_product_kalman_calibration(
+        cal_prior,
+        cal_measure,
+        cal_target,
+        H=H,
+        shrinkage=shrinkage,
+        jitter=jitter,
+        ddof=ddof,
+        shrinkage_target=shrinkage_target,
+    )
+    independent = _zero_cross_calibration(calibration)
+    correlated_update = apply_product_kalman_calibration(calibration, eval_prior, eval_measure, jitter=jitter)
+    independent_update = apply_product_kalman_calibration(independent, eval_prior, eval_measure, jitter=jitter)
+
+    scores = [
+        score_gaussian_predictions("prior", eval_target, eval_prior, calibration.state_covariance, jitter=jitter),
+        score_gaussian_predictions(
+            "independent_kalman",
+            eval_target,
+            independent_update.mean,
+            independent_update.covariance,
+            jitter=jitter,
+        ),
+        score_gaussian_predictions(
+            "product_kalman",
+            eval_target,
+            correlated_update.mean,
+            correlated_update.covariance,
+            jitter=jitter,
+        ),
+    ]
+    if _has_identity_observation(calibration):
+        scores.insert(
+            1,
+            score_gaussian_predictions(
+                "measurement",
+                eval_target,
+                eval_measure,
+                calibration.observation_covariance,
+                jitter=jitter,
+            ),
+        )
+
+    return ProductKalmanHoldoutEvaluation(
+        calibration=calibration,
+        independent_calibration=independent,
+        correlated_update=correlated_update,
+        independent_update=independent_update,
+        scores=tuple(scores),
+    )

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Tests for Product-Kalman holdout evaluation helpers.
+
+Run: `python3 test_product_kalman_evaluation.py`.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np
+
+from product_kalman_evaluation import (
+    evaluate_product_kalman_holdout,
+    score_gaussian_predictions,
+)
+
+
+def assert_raises(fn, *args, **kwargs):
+    try:
+        fn(*args, **kwargs)
+    except (KeyError, ValueError):
+        return
+    raise AssertionError(f"{fn.__name__} should have raised")
+
+
+def synthetic_identity_split(n_cal=8000, n_eval=4000, seed=23):
+    rng = np.random.default_rng(seed)
+    n = n_cal + n_eval
+    target = rng.normal(size=(n, 1))
+    error_covariance = np.array([[1.0, 0.4], [0.4, 0.4]])
+    errors = rng.multivariate_normal([0.0, 0.0], error_covariance, size=n)
+    prior = target - errors[:, :1]
+    measurement = target + errors[:, 1:]
+    return (
+        prior[:n_cal],
+        measurement[:n_cal],
+        target[:n_cal],
+        prior[n_cal:],
+        measurement[n_cal:],
+        target[n_cal:],
+    )
+
+
+def test_correlated_product_kalman_beats_zero_cross_control_on_heldout_nll():
+    cal_prior, cal_measure, cal_target, eval_prior, eval_measure, eval_target = synthetic_identity_split()
+    result = evaluate_product_kalman_holdout(
+        cal_prior,
+        cal_measure,
+        cal_target,
+        eval_prior,
+        eval_measure,
+        eval_target,
+        calibration_ids=[f"cal-{i}" for i in range(len(cal_target))],
+        evaluation_ids=[f"eval-{i}" for i in range(len(eval_target))],
+        jitter=1e-9,
+    )
+    names = [score.name for score in result.scores]
+    assert names == ["prior", "measurement", "independent_kalman", "product_kalman"]
+    assert abs(result.calibration.cross_covariance[0, 0] - 0.4) < 0.035
+    assert result.nll_improvement("prior", "product_kalman") > 0.85
+    assert result.nll_improvement("independent_kalman", "product_kalman") > 0.12
+    assert result.score("product_kalman").mse < result.score("independent_kalman").mse
+    assert result.correlated_update.mean.flags.writeable is False
+    assert result.independent_update.mean.flags.writeable is False
+
+
+def test_split_ids_are_checked_before_scoring():
+    cal_prior, cal_measure, cal_target, eval_prior, eval_measure, eval_target = synthetic_identity_split(
+        n_cal=10,
+        n_eval=6,
+    )
+    assert_raises(
+        evaluate_product_kalman_holdout,
+        cal_prior,
+        cal_measure,
+        cal_target,
+        eval_prior,
+        eval_measure,
+        eval_target,
+        calibration_ids=["shared"] + [f"cal-{i}" for i in range(9)],
+        evaluation_ids=["shared"] + [f"eval-{i}" for i in range(5)],
+    )
+    assert_raises(
+        evaluate_product_kalman_holdout,
+        cal_prior,
+        cal_measure,
+        cal_target,
+        eval_prior,
+        eval_measure,
+        eval_target,
+        calibration_ids=[f"cal-{i}" for i in range(9)],
+        evaluation_ids=[f"eval-{i}" for i in range(6)],
+    )
+    assert_raises(
+        evaluate_product_kalman_holdout,
+        cal_prior,
+        cal_measure,
+        cal_target,
+        eval_prior,
+        eval_measure,
+        eval_target,
+        calibration_ids=["dup", "dup"] + [f"cal-{i}" for i in range(8)],
+        evaluation_ids=[f"eval-{i}" for i in range(6)],
+    )
+
+
+def test_nonidentity_observation_omits_measurement_baseline():
+    rng = np.random.default_rng(5)
+    n_cal = 200
+    n_eval = 80
+    n = n_cal + n_eval
+    target = rng.normal(size=(n, 2))
+    H = np.array([[1.0, -0.4]])
+    prior_error = rng.multivariate_normal([0.0, 0.0], [[0.7, 0.1], [0.1, 0.5]], size=n)
+    measurement_error = rng.normal(scale=0.25, size=(n, 1))
+    prior = target - prior_error
+    measurement = target @ H.T + measurement_error
+    result = evaluate_product_kalman_holdout(
+        prior[:n_cal],
+        measurement[:n_cal],
+        target[:n_cal],
+        prior[n_cal:],
+        measurement[n_cal:],
+        target[n_cal:],
+        H=H,
+        jitter=1e-8,
+    )
+    names = [score.name for score in result.scores]
+    assert names == ["prior", "independent_kalman", "product_kalman"]
+    assert result.correlated_update.mean.shape == (n_eval, 2)
+    assert_raises(result.score, "measurement")
+
+
+def test_score_gaussian_predictions_validates_shapes_and_reports_mse():
+    target = np.array([[1.0], [2.0]])
+    mean = np.array([[1.5], [1.5]])
+    score = score_gaussian_predictions("toy", target, mean, [[0.25]], jitter=1e-9)
+    assert score.name == "toy"
+    assert score.n == 2
+    assert abs(score.mse - 0.25) < 1e-12
+    assert score.covariance_trace == 0.25
+    assert_raises(score_gaussian_predictions, "bad", target[:, 0], mean, [[1.0]])
+    assert_raises(score_gaussian_predictions, "bad", target, mean, [[1.0, 0.0]])
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} product-kalman evaluation tests passed")


### PR DESCRIPTION
Adds a split-safe evaluation scaffold for Product-Kalman calibration work.

- Adds `product_kalman_evaluation.py` to fit calibration blocks on one split and score held-out prior, zero-cross-covariance, and correlated Product-Kalman predictions.
- Enforces calibration/evaluation ID disjointness before scoring.
- Reports Gaussian NLL, MSE, row count, and covariance trace for comparable prediction families.
- Includes identity-observation measurement baseline only when the measurement is actually in target coordinates.
- Adds deterministic synthetic tests showing correlated Product-Kalman beats the zero-cross control when prior and measurement errors share evidence.
- Updates `DESIGN_product_kalman_poe.md` to mark the synthetic comparison harness as added, with real-corpus comparison still pending.

Verification:
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_evaluation.py prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `git diff --check`