### PR TITLE
Add Product-Kalman evaluation NPZ CLI

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -372,7 +372,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    split.
 6. Use `product_kalman_evaluation.py` as the split-safe comparison harness: fit calibration blocks on one
    split, score prior / zero-cross-covariance / correlated Product-Kalman predictions on a separate split,
-   and keep calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison pending.)*
+   and keep calibration/evaluation IDs disjoint. Its NPZ/JSON CLI is the durable artifact interface for
+   later corpus runs. *(Synthetic harness added; real-corpus comparison pending.)*
 7. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
    Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
    residuals that set `R_ell` as the comparison set.
@@ -396,6 +397,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 - `product_kalman_calibration.py` and `test_product_kalman_calibration.py` — calibration-split fitting of
   `P`, `R`, and cross-covariance blocks plus batch application and split-ID leakage guards.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
-  prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits.
+  prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including an NPZ/JSON
+  command-line path for reproducible run artifacts.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -12,7 +12,10 @@ They do not sample data, train a model, or decide that a Product-Kalman variant
 has won; they make the held-out comparison auditable.
 """
 
+import argparse
 from dataclasses import dataclass
+import json
+import sys
 
 import numpy as np
 
@@ -38,6 +41,8 @@ __all__ = [
     "GaussianScore",
     "ProductKalmanHoldoutEvaluation",
     "evaluate_product_kalman_holdout",
+    "evaluation_to_json_dict",
+    "run_product_kalman_holdout_npz",
     "score_gaussian_predictions",
 ]
 
@@ -273,3 +278,167 @@ def evaluate_product_kalman_holdout(
         independent_update=independent_update,
         scores=tuple(scores),
     )
+
+
+def _require_npz_array(npz, path, key):
+    if key not in npz.files:
+        raise ValueError(f"{path} is missing required array {key!r}")
+    return npz[key]
+
+
+def _optional_npz_array(npz, key):
+    return npz[key] if key in npz.files else None
+
+
+def _score_to_json_dict(score):
+    return {
+        "name": score.name,
+        "mean_nll": score.mean_nll,
+        "mse": score.mse,
+        "n": score.n,
+        "covariance_trace": score.covariance_trace,
+    }
+
+
+def evaluation_to_json_dict(result):
+    """Return a JSON-serializable summary for a holdout evaluation result."""
+    scores = {score.name: _score_to_json_dict(score) for score in result.scores}
+    prior = result.score("prior").mean_nll
+    improvements = {name: prior - score["mean_nll"] for name, score in scores.items() if name != "prior"}
+    out = {
+        "score_order": [score.name for score in result.scores],
+        "scores": scores,
+        "nll_improvement_vs_prior": improvements,
+        "calibration": {
+            "n_samples": result.calibration.n_samples,
+            "state_dim": result.calibration.state_dim,
+            "observation_dim": result.calibration.observation_dim,
+            "ddof": result.calibration.ddof,
+            "shrinkage": result.calibration.shrinkage,
+            "shrinkage_target": result.calibration.shrinkage_target,
+            "H": result.calibration.H.tolist(),
+            "state_covariance": result.calibration.state_covariance.tolist(),
+            "observation_covariance": result.calibration.observation_covariance.tolist(),
+            "cross_covariance": result.calibration.cross_covariance.tolist(),
+        },
+    }
+    if "independent_kalman" in scores:
+        independent = scores["independent_kalman"]["mean_nll"]
+        out["nll_improvement_vs_independent_kalman"] = {
+            name: independent - score["mean_nll"]
+            for name, score in scores.items()
+            if name != "independent_kalman"
+        }
+    return out
+
+
+def run_product_kalman_holdout_npz(
+    input_npz,
+    calibration_prior_key="calibration_prior_mean",
+    calibration_measurement_key="calibration_measurement",
+    calibration_target_key="calibration_target_state",
+    evaluation_prior_key="evaluation_prior_mean",
+    evaluation_measurement_key="evaluation_measurement",
+    evaluation_target_key="evaluation_target_state",
+    H_key="H",
+    calibration_ids_key="calibration_ids",
+    evaluation_ids_key="evaluation_ids",
+    shrinkage=0.0,
+    jitter=1e-9,
+    ddof=1,
+    shrinkage_target="diagonal",
+):
+    """Load a single NPZ fixture and run `evaluate_product_kalman_holdout`.
+
+    Required arrays default to the key names in the argument list. Optional `H`,
+    `calibration_ids`, and `evaluation_ids` arrays are used when present. Store
+    scalar channels as explicit `(n, 1)` matrices, matching the calibration API.
+    """
+    path = str(input_npz)
+    with np.load(path, allow_pickle=False) as data:
+        H = _optional_npz_array(data, H_key) if H_key else None
+        calibration_ids = _optional_npz_array(data, calibration_ids_key) if calibration_ids_key else None
+        evaluation_ids = _optional_npz_array(data, evaluation_ids_key) if evaluation_ids_key else None
+        return evaluate_product_kalman_holdout(
+            _require_npz_array(data, path, calibration_prior_key),
+            _require_npz_array(data, path, calibration_measurement_key),
+            _require_npz_array(data, path, calibration_target_key),
+            _require_npz_array(data, path, evaluation_prior_key),
+            _require_npz_array(data, path, evaluation_measurement_key),
+            _require_npz_array(data, path, evaluation_target_key),
+            H=H,
+            calibration_ids=calibration_ids,
+            evaluation_ids=evaluation_ids,
+            shrinkage=shrinkage,
+            jitter=jitter,
+            ddof=ddof,
+            shrinkage_target=shrinkage_target,
+        )
+
+
+def _build_arg_parser():
+    ap = argparse.ArgumentParser(
+        description="Run a split-safe Product-Kalman holdout evaluation from one NPZ fixture.",
+    )
+    ap.add_argument("input_npz", help="NPZ with calibration/evaluation row matrices")
+    ap.add_argument("--output-json", help="write JSON summary to this path instead of stdout")
+    ap.add_argument("--calibration-prior-key", default="calibration_prior_mean")
+    ap.add_argument("--calibration-measurement-key", default="calibration_measurement")
+    ap.add_argument("--calibration-target-key", default="calibration_target_state")
+    ap.add_argument("--evaluation-prior-key", default="evaluation_prior_mean")
+    ap.add_argument("--evaluation-measurement-key", default="evaluation_measurement")
+    ap.add_argument("--evaluation-target-key", default="evaluation_target_state")
+    ap.add_argument("--H-key", default="H", help="optional observation-matrix key; use '' to disable")
+    ap.add_argument(
+        "--calibration-ids-key",
+        default="calibration_ids",
+        help="optional calibration ID key; use '' to disable",
+    )
+    ap.add_argument(
+        "--evaluation-ids-key",
+        default="evaluation_ids",
+        help="optional evaluation ID key; use '' to disable",
+    )
+    ap.add_argument("--shrinkage", type=float, default=0.0)
+    ap.add_argument("--jitter", type=float, default=1e-9)
+    ap.add_argument("--ddof", type=int, default=1)
+    ap.add_argument("--shrinkage-target", default="diagonal", choices=("diagonal", "scaled_identity"))
+    ap.add_argument("--indent", type=int, default=2, help="JSON indentation; use 0 for compact output")
+    return ap
+
+
+def main(argv=None):
+    ap = _build_arg_parser()
+    args = ap.parse_args(argv)
+    try:
+        result = run_product_kalman_holdout_npz(
+            args.input_npz,
+            calibration_prior_key=args.calibration_prior_key,
+            calibration_measurement_key=args.calibration_measurement_key,
+            calibration_target_key=args.calibration_target_key,
+            evaluation_prior_key=args.evaluation_prior_key,
+            evaluation_measurement_key=args.evaluation_measurement_key,
+            evaluation_target_key=args.evaluation_target_key,
+            H_key=args.H_key or None,
+            calibration_ids_key=args.calibration_ids_key or None,
+            evaluation_ids_key=args.evaluation_ids_key or None,
+            shrinkage=args.shrinkage,
+            jitter=args.jitter,
+            ddof=args.ddof,
+            shrinkage_target=args.shrinkage_target,
+        )
+    except ValueError as exc:
+        ap.error(str(exc))
+    data = evaluation_to_json_dict(result)
+    indent = None if args.indent == 0 else args.indent
+    text = json.dumps(data, indent=indent, sort_keys=True) + "\n"
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as f:
+            f.write(text)
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -4,7 +4,9 @@
 Run: `python3 test_product_kalman_evaluation.py`.
 """
 
+import json
 import sys
+import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -13,6 +15,9 @@ import numpy as np
 
 from product_kalman_evaluation import (
     evaluate_product_kalman_holdout,
+    evaluation_to_json_dict,
+    main,
+    run_product_kalman_holdout_npz,
     score_gaussian_predictions,
 )
 
@@ -104,6 +109,53 @@ def test_split_ids_are_checked_before_scoring():
         calibration_ids=["dup", "dup"] + [f"cal-{i}" for i in range(8)],
         evaluation_ids=[f"eval-{i}" for i in range(6)],
     )
+
+
+def write_identity_npz(path, n_cal=8000, n_eval=4000):
+    cal_prior, cal_measure, cal_target, eval_prior, eval_measure, eval_target = synthetic_identity_split(
+        n_cal=n_cal,
+        n_eval=n_eval,
+    )
+    np.savez(
+        path,
+        calibration_prior_mean=cal_prior,
+        calibration_measurement=cal_measure,
+        calibration_target_state=cal_target,
+        evaluation_prior_mean=eval_prior,
+        evaluation_measurement=eval_measure,
+        evaluation_target_state=eval_target,
+        calibration_ids=np.array([f"cal-{i}" for i in range(n_cal)]),
+        evaluation_ids=np.array([f"eval-{i}" for i in range(n_eval)]),
+    )
+
+
+def test_npz_runner_and_json_cli_roundtrip():
+    with tempfile.TemporaryDirectory() as tmp:
+        input_path = Path(tmp) / "holdout.npz"
+        output_path = Path(tmp) / "scores.json"
+        write_identity_npz(input_path)
+        result = run_product_kalman_holdout_npz(input_path)
+        data = evaluation_to_json_dict(result)
+        assert data["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
+        assert data["calibration"]["state_dim"] == 1
+        assert data["nll_improvement_vs_prior"]["product_kalman"] > 0.85
+        assert data["nll_improvement_vs_independent_kalman"]["product_kalman"] > 0.12
+
+        rc = main([str(input_path), "--output-json", str(output_path), "--indent", "0"])
+        assert rc == 0
+        from_cli = json.loads(output_path.read_text())
+        assert from_cli["score_order"] == data["score_order"]
+        assert abs(
+            from_cli["scores"]["product_kalman"]["mean_nll"]
+            - data["scores"]["product_kalman"]["mean_nll"]
+        ) < 1e-12
+
+
+def test_npz_runner_validates_required_keys():
+    with tempfile.TemporaryDirectory() as tmp:
+        input_path = Path(tmp) / "missing.npz"
+        np.savez(input_path, calibration_prior_mean=np.zeros((4, 1)))
+        assert_raises(run_product_kalman_holdout_npz, input_path)
 
 
 def test_nonidentity_observation_omits_measurement_baseline():


### PR DESCRIPTION
Adds a reproducible file-based interface for the Product-Kalman holdout evaluation harness.

- Adds an NPZ loader for calibration/evaluation row matrices.
- Adds a JSON summary format with scores, NLL improvements, and fitted calibration blocks.
- Adds a CLI entry point via `product_kalman_evaluation.py`.
- Covers NPZ loading, missing-key validation, and JSON round-trip output in tests.
- Updates the Product-Kalman design note to mark NPZ/JSON as the durable artifact interface for later corpus runs.

Verification:
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/product_kalman_evaluation.py --help`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_evaluation.py prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `git diff --check`