### PR TITLE
Add Product-Kalman evaluation artifact output

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -372,8 +372,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    split.
 6. Use `product_kalman_evaluation.py` as the split-safe comparison harness: fit calibration blocks on one
    split, score prior / zero-cross-covariance / correlated Product-Kalman predictions on a separate split,
-   and keep calibration/evaluation IDs disjoint. Its NPZ/JSON CLI is the durable artifact interface for
-   later corpus runs. *(Synthetic harness added; real-corpus comparison pending.)*
+   and keep calibration/evaluation IDs disjoint. Its CLI writes JSON score summaries plus optional row-level NPZ
+   artifacts for later plotting/reanalysis. *(Synthetic harness added; real-corpus comparison pending.)*
 7. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
    Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
    residuals that set `R_ell` as the comparison set.
@@ -397,7 +397,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 - `product_kalman_calibration.py` and `test_product_kalman_calibration.py` — calibration-split fitting of
   `P`, `R`, and cross-covariance blocks plus batch application and split-ID leakage guards.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
-  prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including an NPZ/JSON
-  command-line path for reproducible run artifacts.
+  prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including JSON summaries
+  and row-level NPZ artifacts for reproducible corpus-run diagnostics.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -41,9 +41,11 @@ __all__ = [
     "GaussianScore",
     "ProductKalmanHoldoutEvaluation",
     "evaluate_product_kalman_holdout",
+    "evaluation_artifact_arrays",
     "evaluation_to_json_dict",
     "run_product_kalman_holdout_npz",
     "score_gaussian_predictions",
+    "write_evaluation_npz",
 ]
 
 
@@ -280,6 +282,49 @@ def evaluate_product_kalman_holdout(
     )
 
 
+def _prefix_update_arrays(prefix, update):
+    return {
+        f"{prefix}_mean": update.mean,
+        f"{prefix}_covariance": update.covariance,
+        f"{prefix}_gain": update.gain,
+        f"{prefix}_innovation": update.innovation,
+        f"{prefix}_innovation_covariance": update.innovation_covariance,
+    }
+
+
+def evaluation_artifact_arrays(result):
+    """Return compact NPZ-ready arrays for row-level evaluation diagnostics.
+
+    The artifact intentionally stores result-side data: fitted covariance blocks,
+    row-level posterior means/innovations, shared gains/covariances, and score
+    vectors. The original input NPZ remains the source of the held-out targets,
+    prior rows, and measurement rows.
+    """
+    score_names = np.array([score.name for score in result.scores])
+    arrays = {
+        "schema_version": np.array(1, dtype=np.int64),
+        "score_names": score_names,
+        "score_mean_nll": np.array([score.mean_nll for score in result.scores], dtype=float),
+        "score_mse": np.array([score.mse for score in result.scores], dtype=float),
+        "score_n": np.array([score.n for score in result.scores], dtype=np.int64),
+        "score_covariance_trace": np.array([score.covariance_trace for score in result.scores], dtype=float),
+        "calibration_n_samples": np.array(result.calibration.n_samples, dtype=np.int64),
+        "calibration_state_covariance": result.calibration.state_covariance,
+        "calibration_observation_covariance": result.calibration.observation_covariance,
+        "calibration_cross_covariance": result.calibration.cross_covariance,
+        "calibration_H": result.calibration.H,
+        "independent_cross_covariance": result.independent_calibration.cross_covariance,
+    }
+    arrays.update(_prefix_update_arrays("product_kalman", result.correlated_update))
+    arrays.update(_prefix_update_arrays("independent_kalman", result.independent_update))
+    return arrays
+
+
+def write_evaluation_npz(path, result):
+    """Write row-level Product-Kalman evaluation artifacts to an NPZ file."""
+    np.savez(path, **evaluation_artifact_arrays(result))
+
+
 def _require_npz_array(npz, path, key):
     if key not in npz.files:
         raise ValueError(f"{path} is missing required array {key!r}")
@@ -382,6 +427,7 @@ def _build_arg_parser():
     )
     ap.add_argument("input_npz", help="NPZ with calibration/evaluation row matrices")
     ap.add_argument("--output-json", help="write JSON summary to this path instead of stdout")
+    ap.add_argument("--output-npz", help="write row-level prediction/covariance artifacts to this NPZ path")
     ap.add_argument("--calibration-prior-key", default="calibration_prior_mean")
     ap.add_argument("--calibration-measurement-key", default="calibration_measurement")
     ap.add_argument("--calibration-target-key", default="calibration_target_state")
@@ -437,6 +483,8 @@ def main(argv=None):
             f.write(text)
     else:
         sys.stdout.write(text)
+    if args.output_npz:
+        write_evaluation_npz(args.output_npz, result)
     return 0
 
 

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -15,10 +15,12 @@ import numpy as np
 
 from product_kalman_evaluation import (
     evaluate_product_kalman_holdout,
+    evaluation_artifact_arrays,
     evaluation_to_json_dict,
     main,
     run_product_kalman_holdout_npz,
     score_gaussian_predictions,
+    write_evaluation_npz,
 )
 
 
@@ -133,6 +135,7 @@ def test_npz_runner_and_json_cli_roundtrip():
     with tempfile.TemporaryDirectory() as tmp:
         input_path = Path(tmp) / "holdout.npz"
         output_path = Path(tmp) / "scores.json"
+        artifact_path = Path(tmp) / "artifacts.npz"
         write_identity_npz(input_path)
         result = run_product_kalman_holdout_npz(input_path)
         data = evaluation_to_json_dict(result)
@@ -141,7 +144,15 @@ def test_npz_runner_and_json_cli_roundtrip():
         assert data["nll_improvement_vs_prior"]["product_kalman"] > 0.85
         assert data["nll_improvement_vs_independent_kalman"]["product_kalman"] > 0.12
 
-        rc = main([str(input_path), "--output-json", str(output_path), "--indent", "0"])
+        rc = main([
+            str(input_path),
+            "--output-json",
+            str(output_path),
+            "--output-npz",
+            str(artifact_path),
+            "--indent",
+            "0",
+        ])
         assert rc == 0
         from_cli = json.loads(output_path.read_text())
         assert from_cli["score_order"] == data["score_order"]
@@ -149,6 +160,43 @@ def test_npz_runner_and_json_cli_roundtrip():
             from_cli["scores"]["product_kalman"]["mean_nll"]
             - data["scores"]["product_kalman"]["mean_nll"]
         ) < 1e-12
+
+        with np.load(artifact_path, allow_pickle=False) as artifact:
+            assert int(artifact["schema_version"]) == 1
+            assert artifact["score_names"].tolist() == data["score_order"]
+            assert artifact["product_kalman_mean"].shape == result.correlated_update.mean.shape
+            np.testing.assert_allclose(artifact["product_kalman_mean"], result.correlated_update.mean)
+            np.testing.assert_allclose(artifact["independent_kalman_mean"], result.independent_update.mean)
+            np.testing.assert_allclose(artifact["calibration_cross_covariance"], result.calibration.cross_covariance)
+            np.testing.assert_allclose(artifact["independent_cross_covariance"], 0.0)
+
+
+def test_evaluation_artifact_arrays_are_npz_ready():
+    cal_prior, cal_measure, cal_target, eval_prior, eval_measure, eval_target = synthetic_identity_split(
+        n_cal=80,
+        n_eval=20,
+    )
+    result = evaluate_product_kalman_holdout(
+        cal_prior,
+        cal_measure,
+        cal_target,
+        eval_prior,
+        eval_measure,
+        eval_target,
+        jitter=1e-8,
+    )
+    arrays = evaluation_artifact_arrays(result)
+    assert arrays["score_names"].tolist() == ["prior", "measurement", "independent_kalman", "product_kalman"]
+    assert arrays["score_mean_nll"].shape == (4,)
+    assert arrays["product_kalman_innovation"].shape == eval_target.shape
+    assert arrays["product_kalman_covariance"].shape == (1, 1)
+    assert arrays["independent_kalman_gain"].shape == (1, 1)
+    with tempfile.TemporaryDirectory() as tmp:
+        artifact_path = Path(tmp) / "artifact.npz"
+        write_evaluation_npz(artifact_path, result)
+        with np.load(artifact_path, allow_pickle=False) as artifact:
+            assert set(arrays).issubset(set(artifact.files))
+            np.testing.assert_allclose(artifact["score_mean_nll"], arrays["score_mean_nll"])
 
 
 def test_npz_runner_validates_required_keys():


### PR DESCRIPTION
:Adds optional row-level NPZ artifact output for Product-Kalman holdout evaluations.

- Adds `evaluation_artifact_arrays()` and `write_evaluation_npz()`.
- Adds CLI support for `--output-npz`.
- Stores compact result-side artifacts: score vectors, fitted calibration blocks, correlated/independent posterior means, innovations, gains, and shared covariances.
- Keeps the original input NPZ as the source of target/prior/measurement rows.
- Extends tests to cover direct artifact writing and CLI JSON+NPZ round-trip.
- Updates the Product-Kalman design note to describe JSON summaries plus row-level NPZ diagnostics.

Verification:
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/product_kalman_evaluation.py --help`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_evaluation.py prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `git diff --check`