### PR TITLE
Add Product-Kalman table-to-NPZ input builder

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -370,10 +370,12 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    covariance block matrix, and all scalar channels must be passed as explicit `(n, 1)` row matrices rather than
    ambiguous 1-D arrays. Calibration splits must be node-disjoint from training data and from the final evaluation
    split.
-6. Use `product_kalman_evaluation.py` as the split-safe comparison harness: fit calibration blocks on one
-   split, score prior / zero-cross-covariance / correlated Product-Kalman predictions on a separate split,
-   and keep calibration/evaluation IDs disjoint. Its CLI writes JSON score summaries plus optional row-level NPZ
-   artifacts for later plotting/reanalysis. *(Synthetic harness added; real-corpus comparison pending.)*
+6. Use `product_kalman_table_to_npz.py` to turn explicit CSV/TSV calibration/evaluation rows into the
+   evaluator input NPZ, then use `product_kalman_evaluation.py` as the split-safe comparison harness: fit
+   calibration blocks on one split, score prior / zero-cross-covariance / correlated Product-Kalman predictions
+   on a separate split, and keep calibration/evaluation IDs disjoint. Its CLI writes JSON score summaries plus
+   optional row-level NPZ artifacts for later plotting/reanalysis. *(Synthetic harness added; real-corpus
+   comparison pending.)*
 7. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
    Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
    residuals that set `R_ell` as the comparison set.
@@ -396,6 +398,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   product-evidence coordinates, with residual covariance fitting and explicit prior-measurement cross-covariance.
 - `product_kalman_calibration.py` and `test_product_kalman_calibration.py` — calibration-split fitting of
   `P`, `R`, and cross-covariance blocks plus batch application and split-ID leakage guards.
+- `product_kalman_table_to_npz.py` and `test_product_kalman_table_to_npz.py` — CSV/TSV-to-NPZ builder for
+  evaluator input arrays with explicit split, ID, prior, measurement, and target columns.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including JSON summaries
   and row-level NPZ artifacts for reproducible corpus-run diagnostics.

--- a/prototypes/mu_cosine/product_kalman_table_to_npz.py
+++ b/prototypes/mu_cosine/product_kalman_table_to_npz.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Build Product-Kalman holdout-evaluation NPZ inputs from CSV/TSV tables.
+
+The evaluator consumes NPZ arrays with separate calibration/evaluation matrices.
+This utility gives later corpus runs a reproducible bridge from a row table to
+that NPZ format without hand-written Python snippets.
+"""
+
+import argparse
+import csv
+import sys
+
+import numpy as np
+
+
+__all__ = [
+    "build_product_kalman_npz_from_table",
+    "parse_column_list",
+    "parse_matrix_literal",
+    "read_product_kalman_table",
+    "write_product_kalman_npz",
+]
+
+
+DEFAULT_SPLIT_VALUES = ("calibration", "evaluation")
+
+
+def parse_column_list(text):
+    """Parse comma-separated column names."""
+    cols = [part.strip() for part in str(text).split(",") if part.strip()]
+    if not cols:
+        raise ValueError("column list must contain at least one column")
+    if len(cols) != len(set(cols)):
+        raise ValueError(f"column list contains duplicates: {text!r}")
+    return cols
+
+
+def parse_matrix_literal(text):
+    """Parse a small semicolon/comma matrix literal such as `1,0;0,1`."""
+    if text is None or str(text).strip() == "":
+        return None
+    rows = []
+    for raw_row in str(text).split(";"):
+        row = [part.strip() for part in raw_row.split(",") if part.strip()]
+        if not row:
+            raise ValueError(f"empty H row in {text!r}")
+        try:
+            rows.append([float(part) for part in row])
+        except ValueError as exc:
+            raise ValueError(f"H contains nonnumeric value in {text!r}") from exc
+    width = len(rows[0])
+    if any(len(row) != width for row in rows):
+        raise ValueError(f"H rows must have equal length: {text!r}")
+    return np.asarray(rows, dtype=float)
+
+
+def _infer_delimiter(path, explicit):
+    if explicit is not None:
+        return explicit
+    lower = str(path).lower()
+    if lower.endswith(".tsv") or lower.endswith(".tab"):
+        return "	"
+    return ","
+
+
+def _required_columns(split_col, id_col, prior_cols, measurement_cols, target_cols):
+    cols = [split_col]
+    if id_col:
+        cols.append(id_col)
+    cols.extend(prior_cols)
+    cols.extend(measurement_cols)
+    cols.extend(target_cols)
+    return cols
+
+
+def _row_vector(row, cols, row_num):
+    values = []
+    for col in cols:
+        value = row.get(col)
+        if value is None or str(value).strip() == "":
+            raise ValueError(f"row {row_num}: missing numeric value for column {col!r}")
+        try:
+            parsed = float(value)
+        except ValueError as exc:
+            raise ValueError(f"row {row_num}: nonnumeric value {value!r} for column {col!r}") from exc
+        if not np.isfinite(parsed):
+            raise ValueError(f"row {row_num}: nonfinite value {value!r} for column {col!r}")
+        values.append(parsed)
+    return values
+
+
+def _as_2d_rows(name, rows, width):
+    if not rows:
+        raise ValueError(f"{name} split has no rows")
+    arr = np.asarray(rows, dtype=float)
+    if arr.shape != (len(rows), width):
+        raise ValueError(f"{name} array shape {arr.shape} must be ({len(rows)}, {width})")
+    return arr
+
+
+def _normalize_split_value(value):
+    return str(value).strip().lower()
+
+
+def read_product_kalman_table(
+    path,
+    prior_cols,
+    measurement_cols,
+    target_cols,
+    split_col="split",
+    id_col="id",
+    calibration_value="calibration",
+    evaluation_value="evaluation",
+    delimiter=None,
+    H=None,
+):
+    """Read a CSV/TSV table into evaluator-ready arrays.
+
+    Required columns are: split, prior columns, measurement columns, target
+    columns, plus an optional ID column. Split labels are compared
+    case-insensitively after trimming whitespace.
+    """
+    prior_cols = parse_column_list(prior_cols) if isinstance(prior_cols, str) else list(prior_cols)
+    measurement_cols = parse_column_list(measurement_cols) if isinstance(measurement_cols, str) else list(measurement_cols)
+    target_cols = parse_column_list(target_cols) if isinstance(target_cols, str) else list(target_cols)
+    calibration_value = _normalize_split_value(calibration_value)
+    evaluation_value = _normalize_split_value(evaluation_value)
+    if calibration_value == evaluation_value:
+        raise ValueError("calibration and evaluation split labels must differ")
+    H = parse_matrix_literal(H) if isinstance(H, str) else H
+
+    split_rows = {
+        calibration_value: {"prior": [], "measurement": [], "target": [], "ids": []},
+        evaluation_value: {"prior": [], "measurement": [], "target": [], "ids": []},
+    }
+    delim = _infer_delimiter(path, delimiter)
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=delim)
+        if reader.fieldnames is None:
+            raise ValueError(f"{path} has no header row")
+        missing = [col for col in _required_columns(split_col, id_col, prior_cols, measurement_cols, target_cols)
+                   if col not in reader.fieldnames]
+        if missing:
+            raise ValueError(f"{path} missing required columns: {', '.join(missing)}")
+        for row_num, row in enumerate(reader, start=2):
+            label = _normalize_split_value(row.get(split_col, ""))
+            if label not in split_rows:
+                raise ValueError(
+                    f"row {row_num}: split {row.get(split_col)!r} must be {calibration_value!r} or {evaluation_value!r}"
+                )
+            bucket = split_rows[label]
+            bucket["prior"].append(_row_vector(row, prior_cols, row_num))
+            bucket["measurement"].append(_row_vector(row, measurement_cols, row_num))
+            bucket["target"].append(_row_vector(row, target_cols, row_num))
+            if id_col:
+                raw_id = row.get(id_col)
+                if raw_id is None or str(raw_id).strip() == "":
+                    raise ValueError(f"row {row_num}: missing ID value for column {id_col!r}")
+                bucket["ids"].append(str(raw_id))
+
+    cal = split_rows[calibration_value]
+    ev = split_rows[evaluation_value]
+    arrays = {
+        "calibration_prior_mean": _as_2d_rows("calibration_prior_mean", cal["prior"], len(prior_cols)),
+        "calibration_measurement": _as_2d_rows("calibration_measurement", cal["measurement"], len(measurement_cols)),
+        "calibration_target_state": _as_2d_rows("calibration_target_state", cal["target"], len(target_cols)),
+        "evaluation_prior_mean": _as_2d_rows("evaluation_prior_mean", ev["prior"], len(prior_cols)),
+        "evaluation_measurement": _as_2d_rows("evaluation_measurement", ev["measurement"], len(measurement_cols)),
+        "evaluation_target_state": _as_2d_rows("evaluation_target_state", ev["target"], len(target_cols)),
+    }
+    if id_col:
+        arrays["calibration_ids"] = np.asarray(cal["ids"], dtype=str)
+        arrays["evaluation_ids"] = np.asarray(ev["ids"], dtype=str)
+    if H is not None:
+        H = np.asarray(H, dtype=float)
+        if H.shape != (len(measurement_cols), len(target_cols)):
+            raise ValueError(f"H shape {H.shape} must be ({len(measurement_cols)}, {len(target_cols)})")
+        if not np.isfinite(H).all():
+            raise ValueError("H must be finite")
+        arrays["H"] = H
+    return arrays
+
+
+def write_product_kalman_npz(path, arrays):
+    """Write evaluator input arrays to NPZ."""
+    np.savez(path, **arrays)
+
+
+def build_product_kalman_npz_from_table(path, output_npz, **kwargs):
+    """Read a table and write evaluator-ready NPZ arrays."""
+    arrays = read_product_kalman_table(path, **kwargs)
+    write_product_kalman_npz(output_npz, arrays)
+    return arrays
+
+
+def _build_arg_parser():
+    ap = argparse.ArgumentParser(description="Build Product-Kalman evaluator NPZ input from a CSV/TSV table.")
+    ap.add_argument("input_table", help="CSV/TSV table with split, prior, measurement, and target columns")
+    ap.add_argument("--output-npz", required=True, help="write evaluator-ready NPZ here")
+    ap.add_argument("--prior-cols", required=True, help="comma-separated prior mean columns")
+    ap.add_argument("--measurement-cols", required=True, help="comma-separated measurement columns")
+    ap.add_argument("--target-cols", required=True, help="comma-separated target-state columns")
+    ap.add_argument("--split-col", default="split")
+    ap.add_argument("--id-col", default="id", help="ID column to carry into NPZ; use '' to omit IDs")
+    ap.add_argument("--calibration-value", default="calibration")
+    ap.add_argument("--evaluation-value", default="evaluation")
+    ap.add_argument("--delimiter", help="input delimiter; defaults to tab for .tsv/.tab, comma otherwise")
+    ap.add_argument("--H", help="optional observation matrix literal, e.g. '1,0;0,1'")
+    return ap
+
+
+def main(argv=None):
+    ap = _build_arg_parser()
+    args = ap.parse_args(argv)
+    try:
+        build_product_kalman_npz_from_table(
+            args.input_table,
+            args.output_npz,
+            prior_cols=parse_column_list(args.prior_cols),
+            measurement_cols=parse_column_list(args.measurement_cols),
+            target_cols=parse_column_list(args.target_cols),
+            split_col=args.split_col,
+            id_col=args.id_col or None,
+            calibration_value=args.calibration_value,
+            evaluation_value=args.evaluation_value,
+            delimiter=args.delimiter,
+            H=args.H,
+        )
+    except ValueError as exc:
+        ap.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_product_kalman_table_to_npz.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_to_npz.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Tests for Product-Kalman CSV/TSV table-to-NPZ input builder.
+
+Run: `python3 test_product_kalman_table_to_npz.py`.
+"""
+
+import csv
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np
+
+from product_kalman_evaluation import run_product_kalman_holdout_npz
+from product_kalman_table_to_npz import (
+    build_product_kalman_npz_from_table,
+    main,
+    parse_column_list,
+    parse_matrix_literal,
+    read_product_kalman_table,
+)
+
+
+def assert_raises(fn, *args, **kwargs):
+    try:
+        fn(*args, **kwargs)
+    except ValueError:
+        return
+    raise AssertionError(f"{fn.__name__} should have raised ValueError")
+
+
+def synthetic_identity_split(n_cal=80, n_eval=40, seed=23):
+    rng = np.random.default_rng(seed)
+    n = n_cal + n_eval
+    target = rng.normal(size=(n, 1))
+    error_covariance = np.array([[1.0, 0.4], [0.4, 0.4]])
+    errors = rng.multivariate_normal([0.0, 0.0], error_covariance, size=n)
+    prior = target - errors[:, :1]
+    measurement = target + errors[:, 1:]
+    return prior, measurement, target, n_cal
+
+
+def write_table(path, delimiter=","):
+    prior, measurement, target, n_cal = synthetic_identity_split()
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["split", "id", "prior", "measurement", "target"], delimiter=delimiter)
+        writer.writeheader()
+        for i in range(len(target)):
+            split = "calibration" if i < n_cal else "evaluation"
+            writer.writerow({
+                "split": split,
+                "id": f"{split}-{i}",
+                "prior": f"{prior[i, 0]:.17g}",
+                "measurement": f"{measurement[i, 0]:.17g}",
+                "target": f"{target[i, 0]:.17g}",
+            })
+
+
+def test_column_and_matrix_parsers():
+    assert parse_column_list("a,b, c") == ["a", "b", "c"]
+    assert_raises(parse_column_list, "a,a")
+    np.testing.assert_allclose(parse_matrix_literal("1,0;0,1"), np.eye(2))
+    assert parse_matrix_literal("") is None
+    assert_raises(parse_matrix_literal, "1,0;2")
+    assert_raises(parse_matrix_literal, "1,x")
+
+
+def test_table_builder_roundtrips_into_evaluator():
+    with tempfile.TemporaryDirectory() as tmp:
+        table = Path(tmp) / "holdout.csv"
+        npz = Path(tmp) / "holdout.npz"
+        write_table(table)
+        arrays = build_product_kalman_npz_from_table(
+            table,
+            npz,
+            prior_cols=["prior"],
+            measurement_cols=["measurement"],
+            target_cols=["target"],
+        )
+        assert arrays["calibration_prior_mean"].shape == (80, 1)
+        assert arrays["evaluation_prior_mean"].shape == (40, 1)
+        assert arrays["calibration_ids"].shape == (80,)
+        assert npz.exists()
+
+        result = run_product_kalman_holdout_npz(npz, jitter=1e-8)
+        assert result.nll_improvement("prior", "product_kalman") > 0.65
+        assert result.nll_improvement("independent_kalman", "product_kalman") > 0.05
+
+
+def test_tsv_delimiter_inference_and_cli():
+    with tempfile.TemporaryDirectory() as tmp:
+        table = Path(tmp) / "holdout.tsv"
+        npz = Path(tmp) / "holdout.npz"
+        write_table(table, delimiter="	")
+        rc = main([
+            str(table),
+            "--output-npz",
+            str(npz),
+            "--prior-cols",
+            "prior",
+            "--measurement-cols",
+            "measurement",
+            "--target-cols",
+            "target",
+        ])
+        assert rc == 0
+        with np.load(npz, allow_pickle=False) as data:
+            assert data["calibration_prior_mean"].shape == (80, 1)
+            assert data["evaluation_ids"].shape == (40,)
+
+
+def test_nonidentity_H_is_stored_and_shape_checked():
+    with tempfile.TemporaryDirectory() as tmp:
+        table = Path(tmp) / "holdout.csv"
+        with open(table, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(
+                f,
+                fieldnames=["split", "id", "p0", "p1", "m0", "t0", "t1"],
+            )
+            writer.writeheader()
+            for i in range(8):
+                split = "calibration" if i < 5 else "evaluation"
+                writer.writerow({
+                    "split": split,
+                    "id": f"row-{i}",
+                    "p0": i * 0.1,
+                    "p1": i * -0.2,
+                    "m0": i * 0.3,
+                    "t0": i * 0.1 + 0.01,
+                    "t1": i * -0.2 - 0.02,
+                })
+        arrays = read_product_kalman_table(
+            table,
+            prior_cols=["p0", "p1"],
+            measurement_cols=["m0"],
+            target_cols=["t0", "t1"],
+            H="1,-0.4",
+        )
+        np.testing.assert_allclose(arrays["H"], [[1.0, -0.4]])
+        assert_raises(
+            read_product_kalman_table,
+            table,
+            prior_cols=["p0", "p1"],
+            measurement_cols=["m0"],
+            target_cols=["t0", "t1"],
+            H="1,0;0,1",
+        )
+
+
+def test_table_builder_rejects_bad_input():
+    with tempfile.TemporaryDirectory() as tmp:
+        missing = Path(tmp) / "missing.csv"
+        missing.write_text("split,id,prior,target\ncalibration,a,1,1\n", encoding="utf-8")
+        assert_raises(
+            read_product_kalman_table,
+            missing,
+            prior_cols=["prior"],
+            measurement_cols=["measurement"],
+            target_cols=["target"],
+        )
+
+        bad_split = Path(tmp) / "bad_split.csv"
+        bad_split.write_text("split,id,prior,measurement,target\ntrain,a,1,1,1\n", encoding="utf-8")
+        assert_raises(
+            read_product_kalman_table,
+            bad_split,
+            prior_cols=["prior"],
+            measurement_cols=["measurement"],
+            target_cols=["target"],
+        )
+
+        bad_value = Path(tmp) / "bad_value.csv"
+        bad_value.write_text("split,id,prior,measurement,target\ncalibration,a,nope,1,1\n", encoding="utf-8")
+        assert_raises(
+            read_product_kalman_table,
+            bad_value,
+            prior_cols=["prior"],
+            measurement_cols=["measurement"],
+            target_cols=["target"],
+        )
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} product-kalman table-to-NPZ tests passed")


### PR DESCRIPTION
## Summary
- add `product_kalman_table_to_npz.py` to convert explicit CSV/TSV calibration/evaluation rows into Product-Kalman evaluator NPZ inputs
- support split labels, IDs, scalar/vector prior/measurement/target columns, delimiter inference, and optional `H` matrix literals
- add tests covering parser behavior, CLI roundtrip, evaluator compatibility, TSV inference, non-identity `H`, and bad inputs
- update the Product-Kalman design note to include the table-to-NPZ step before holdout evaluation

## Tests
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_table_to_npz.py prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/product_kalman_table_to_npz.py --help`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `git diff --cached --check`