### PR TITLE
Add Product-Kalman input manifest support

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -371,11 +371,12 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    ambiguous 1-D arrays. Calibration splits must be node-disjoint from training data and from the final evaluation
    split.
 6. Use `product_kalman_table_to_npz.py` to turn explicit CSV/TSV calibration/evaluation rows into the
-   evaluator input NPZ, then use `product_kalman_evaluation.py` as the split-safe comparison harness: fit
-   calibration blocks on one split, score prior / zero-cross-covariance / correlated Product-Kalman predictions
-   on a separate split, and keep calibration/evaluation IDs disjoint. Its CLI writes JSON score summaries plus
-   optional row-level NPZ artifacts for later plotting/reanalysis. *(Synthetic harness added; real-corpus
-   comparison pending.)*
+   evaluator input NPZ, optionally with a JSON input manifest recording source-table hash, split counts, column
+   groups, dimensions, ID overlap/duplicate counts, and `H` shape/values. Then use `product_kalman_evaluation.py`
+   as the split-safe comparison harness: fit calibration blocks on one split, score prior / zero-cross-covariance
+   / correlated Product-Kalman predictions on a separate split, and keep calibration/evaluation IDs disjoint. Its
+   CLI writes JSON score summaries plus optional row-level NPZ artifacts for later plotting/reanalysis. *(Synthetic
+   harness added; real-corpus comparison pending.)*
 7. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
    Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
    residuals that set `R_ell` as the comparison set.
@@ -399,7 +400,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 - `product_kalman_calibration.py` and `test_product_kalman_calibration.py` — calibration-split fitting of
   `P`, `R`, and cross-covariance blocks plus batch application and split-ID leakage guards.
 - `product_kalman_table_to_npz.py` and `test_product_kalman_table_to_npz.py` — CSV/TSV-to-NPZ builder for
-  evaluator input arrays with explicit split, ID, prior, measurement, and target columns.
+  evaluator input arrays with explicit split, ID, prior, measurement, and target columns, plus optional JSON input
+  manifests for real-corpus provenance checks.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including JSON summaries
   and row-level NPZ artifacts for reproducible corpus-run diagnostics.

--- a/prototypes/mu_cosine/product_kalman_table_to_npz.py
+++ b/prototypes/mu_cosine/product_kalman_table_to_npz.py
@@ -8,16 +8,23 @@ that NPZ format without hand-written Python snippets.
 
 import argparse
 import csv
-import sys
+import hashlib
+import json
 
 import numpy as np
 
 
+TABLE_INPUT_MANIFEST_SCHEMA_VERSION = 1
+
+
 __all__ = [
+    "TABLE_INPUT_MANIFEST_SCHEMA_VERSION",
+    "build_product_kalman_input_manifest",
     "build_product_kalman_npz_from_table",
     "parse_column_list",
     "parse_matrix_literal",
     "read_product_kalman_table",
+    "write_product_kalman_manifest",
     "write_product_kalman_npz",
 ]
 
@@ -102,6 +109,123 @@ def _normalize_split_value(value):
     return str(value).strip().lower()
 
 
+def _normalize_columns(prior_cols, measurement_cols, target_cols):
+    prior_cols = parse_column_list(prior_cols) if isinstance(prior_cols, str) else list(prior_cols)
+    measurement_cols = parse_column_list(measurement_cols) if isinstance(measurement_cols, str) else list(measurement_cols)
+    target_cols = parse_column_list(target_cols) if isinstance(target_cols, str) else list(target_cols)
+    for name, cols in (("prior_cols", prior_cols), ("measurement_cols", measurement_cols), ("target_cols", target_cols)):
+        if not cols:
+            raise ValueError(f"{name} must contain at least one column")
+        if len(cols) != len(set(cols)):
+            raise ValueError(f"{name} contains duplicates: {cols!r}")
+    return prior_cols, measurement_cols, target_cols
+
+
+def _validate_schema_dimensions(prior_cols, measurement_cols, target_cols, H):
+    state_dim = len(target_cols)
+    if len(prior_cols) != state_dim:
+        raise ValueError("prior column count must match target-state column count")
+    if H is None and len(measurement_cols) != state_dim:
+        raise ValueError("H is required when measurement column count differs from target-state column count")
+
+
+def _sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _array_manifest(arr):
+    arr = np.asarray(arr)
+    return {"shape": [int(v) for v in arr.shape], "dtype": str(arr.dtype)}
+
+
+def _duplicate_count(values):
+    seen = set()
+    duplicates = set()
+    for value in values:
+        if value in seen:
+            duplicates.add(value)
+        seen.add(value)
+    return len(duplicates)
+
+
+def _id_manifest(arrays, id_col):
+    if not id_col or "calibration_ids" not in arrays or "evaluation_ids" not in arrays:
+        return {"present": False, "column": id_col}
+    calibration_ids = [str(v) for v in arrays["calibration_ids"].tolist()]
+    evaluation_ids = [str(v) for v in arrays["evaluation_ids"].tolist()]
+    overlap = set(calibration_ids) & set(evaluation_ids)
+    cal_dupes = _duplicate_count(calibration_ids)
+    eval_dupes = _duplicate_count(evaluation_ids)
+    return {
+        "present": True,
+        "column": id_col,
+        "calibration_count": len(calibration_ids),
+        "evaluation_count": len(evaluation_ids),
+        "calibration_duplicate_count": cal_dupes,
+        "evaluation_duplicate_count": eval_dupes,
+        "overlap_count": len(overlap),
+        "disjoint_and_unique": len(overlap) == 0 and cal_dupes == 0 and eval_dupes == 0,
+    }
+
+
+def build_product_kalman_input_manifest(
+    path,
+    arrays,
+    prior_cols,
+    measurement_cols,
+    target_cols,
+    split_col="split",
+    id_col="id",
+    calibration_value="calibration",
+    evaluation_value="evaluation",
+    delimiter=None,
+    H=None,
+):
+    """Build a JSON-serializable manifest for a table-derived evaluator NPZ."""
+    prior_cols, measurement_cols, target_cols = _normalize_columns(prior_cols, measurement_cols, target_cols)
+    delim = _infer_delimiter(path, delimiter)
+    cal_rows = int(arrays["calibration_target_state"].shape[0])
+    eval_rows = int(arrays["evaluation_target_state"].shape[0])
+    H = arrays.get("H")
+    manifest = {
+        "schema_version": TABLE_INPUT_MANIFEST_SCHEMA_VERSION,
+        "source_table": {
+            "path": str(path),
+            "sha256": _sha256_file(path),
+            "delimiter": delim,
+        },
+        "splits": {
+            "column": split_col,
+            "calibration_value": calibration_value,
+            "evaluation_value": evaluation_value,
+            "calibration_rows": cal_rows,
+            "evaluation_rows": eval_rows,
+        },
+        "columns": {
+            "prior": list(prior_cols),
+            "measurement": list(measurement_cols),
+            "target_state": list(target_cols),
+        },
+        "dimensions": {
+            "state_dim": len(target_cols),
+            "prior_dim": len(prior_cols),
+            "observation_dim": len(measurement_cols),
+        },
+        "ids": _id_manifest(arrays, id_col),
+        "arrays": {name: _array_manifest(value) for name, value in sorted(arrays.items())},
+        "H": {
+            "present": H is not None,
+            "shape": None if H is None else [int(v) for v in np.asarray(H).shape],
+            "values": None if H is None else np.asarray(H, dtype=float).tolist(),
+        },
+    }
+    return manifest
+
+
 def read_product_kalman_table(
     path,
     prior_cols,
@@ -120,14 +244,13 @@ def read_product_kalman_table(
     columns, plus an optional ID column. Split labels are compared
     case-insensitively after trimming whitespace.
     """
-    prior_cols = parse_column_list(prior_cols) if isinstance(prior_cols, str) else list(prior_cols)
-    measurement_cols = parse_column_list(measurement_cols) if isinstance(measurement_cols, str) else list(measurement_cols)
-    target_cols = parse_column_list(target_cols) if isinstance(target_cols, str) else list(target_cols)
+    prior_cols, measurement_cols, target_cols = _normalize_columns(prior_cols, measurement_cols, target_cols)
     calibration_value = _normalize_split_value(calibration_value)
     evaluation_value = _normalize_split_value(evaluation_value)
     if calibration_value == evaluation_value:
         raise ValueError("calibration and evaluation split labels must differ")
     H = parse_matrix_literal(H) if isinstance(H, str) else H
+    _validate_schema_dimensions(prior_cols, measurement_cols, target_cols, H)
 
     split_rows = {
         calibration_value: {"prior": [], "measurement": [], "target": [], "ids": []},
@@ -186,10 +309,20 @@ def write_product_kalman_npz(path, arrays):
     np.savez(path, **arrays)
 
 
-def build_product_kalman_npz_from_table(path, output_npz, **kwargs):
+def write_product_kalman_manifest(path, manifest):
+    """Write a JSON manifest for a table-derived Product-Kalman NPZ."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def build_product_kalman_npz_from_table(path, output_npz, output_manifest=None, **kwargs):
     """Read a table and write evaluator-ready NPZ arrays."""
     arrays = read_product_kalman_table(path, **kwargs)
     write_product_kalman_npz(output_npz, arrays)
+    if output_manifest is not None:
+        manifest = build_product_kalman_input_manifest(path, arrays, **kwargs)
+        write_product_kalman_manifest(output_manifest, manifest)
     return arrays
 
 
@@ -197,6 +330,7 @@ def _build_arg_parser():
     ap = argparse.ArgumentParser(description="Build Product-Kalman evaluator NPZ input from a CSV/TSV table.")
     ap.add_argument("input_table", help="CSV/TSV table with split, prior, measurement, and target columns")
     ap.add_argument("--output-npz", required=True, help="write evaluator-ready NPZ here")
+    ap.add_argument("--output-manifest", help="optional JSON manifest describing the input table and NPZ schema")
     ap.add_argument("--prior-cols", required=True, help="comma-separated prior mean columns")
     ap.add_argument("--measurement-cols", required=True, help="comma-separated measurement columns")
     ap.add_argument("--target-cols", required=True, help="comma-separated target-state columns")
@@ -216,6 +350,7 @@ def main(argv=None):
         build_product_kalman_npz_from_table(
             args.input_table,
             args.output_npz,
+            output_manifest=args.output_manifest,
             prior_cols=parse_column_list(args.prior_cols),
             measurement_cols=parse_column_list(args.measurement_cols),
             target_cols=parse_column_list(args.target_cols),

--- a/prototypes/mu_cosine/test_product_kalman_table_to_npz.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_to_npz.py
@@ -5,6 +5,7 @@ Run: `python3 test_product_kalman_table_to_npz.py`.
 """
 
 import csv
+import json
 import sys
 import tempfile
 from pathlib import Path
@@ -15,11 +16,14 @@ import numpy as np
 
 from product_kalman_evaluation import run_product_kalman_holdout_npz
 from product_kalman_table_to_npz import (
+    TABLE_INPUT_MANIFEST_SCHEMA_VERSION,
+    build_product_kalman_input_manifest,
     build_product_kalman_npz_from_table,
     main,
     parse_column_list,
     parse_matrix_literal,
     read_product_kalman_table,
+    write_product_kalman_manifest,
 )
 
 
@@ -89,15 +93,50 @@ def test_table_builder_roundtrips_into_evaluator():
         assert result.nll_improvement("independent_kalman", "product_kalman") > 0.05
 
 
+def test_input_manifest_records_schema_and_id_audit():
+    with tempfile.TemporaryDirectory() as tmp:
+        table = Path(tmp) / "holdout.csv"
+        manifest_path = Path(tmp) / "manifest.json"
+        write_table(table)
+        arrays = read_product_kalman_table(
+            table,
+            prior_cols=["prior"],
+            measurement_cols=["measurement"],
+            target_cols=["target"],
+        )
+        manifest = build_product_kalman_input_manifest(
+            table,
+            arrays,
+            prior_cols=["prior"],
+            measurement_cols=["measurement"],
+            target_cols=["target"],
+        )
+        assert manifest["schema_version"] == TABLE_INPUT_MANIFEST_SCHEMA_VERSION
+        assert len(manifest["source_table"]["sha256"]) == 64
+        assert manifest["splits"]["calibration_rows"] == 80
+        assert manifest["splits"]["evaluation_rows"] == 40
+        assert manifest["columns"]["prior"] == ["prior"]
+        assert manifest["dimensions"] == {"state_dim": 1, "prior_dim": 1, "observation_dim": 1}
+        assert manifest["ids"]["disjoint_and_unique"] is True
+        assert manifest["arrays"]["calibration_prior_mean"]["shape"] == [80, 1]
+        assert manifest["H"]["present"] is False
+        write_product_kalman_manifest(manifest_path, manifest)
+        loaded = json.loads(manifest_path.read_text())
+        assert loaded["source_table"]["sha256"] == manifest["source_table"]["sha256"]
+
+
 def test_tsv_delimiter_inference_and_cli():
     with tempfile.TemporaryDirectory() as tmp:
         table = Path(tmp) / "holdout.tsv"
         npz = Path(tmp) / "holdout.npz"
+        manifest = Path(tmp) / "holdout.manifest.json"
         write_table(table, delimiter="	")
         rc = main([
             str(table),
             "--output-npz",
             str(npz),
+            "--output-manifest",
+            str(manifest),
             "--prior-cols",
             "prior",
             "--measurement-cols",
@@ -109,6 +148,9 @@ def test_tsv_delimiter_inference_and_cli():
         with np.load(npz, allow_pickle=False) as data:
             assert data["calibration_prior_mean"].shape == (80, 1)
             assert data["evaluation_ids"].shape == (40,)
+        manifest_data = json.loads(manifest.read_text())
+        assert manifest_data["source_table"]["delimiter"] == "	"
+        assert manifest_data["ids"]["overlap_count"] == 0
 
 
 def test_nonidentity_H_is_stored_and_shape_checked():
@@ -139,6 +181,16 @@ def test_nonidentity_H_is_stored_and_shape_checked():
             H="1,-0.4",
         )
         np.testing.assert_allclose(arrays["H"], [[1.0, -0.4]])
+        manifest = build_product_kalman_input_manifest(
+            table,
+            arrays,
+            prior_cols=["p0", "p1"],
+            measurement_cols=["m0"],
+            target_cols=["t0", "t1"],
+        )
+        assert manifest["H"]["present"] is True
+        assert manifest["H"]["shape"] == [1, 2]
+        assert manifest["H"]["values"] == [[1.0, -0.4]]
         assert_raises(
             read_product_kalman_table,
             table,
@@ -146,6 +198,13 @@ def test_nonidentity_H_is_stored_and_shape_checked():
             measurement_cols=["m0"],
             target_cols=["t0", "t1"],
             H="1,0;0,1",
+        )
+        assert_raises(
+            read_product_kalman_table,
+            table,
+            prior_cols=["p0", "p1"],
+            measurement_cols=["m0"],
+            target_cols=["t0", "t1"],
         )
 
 
@@ -177,6 +236,16 @@ def test_table_builder_rejects_bad_input():
             read_product_kalman_table,
             bad_value,
             prior_cols=["prior"],
+            measurement_cols=["measurement"],
+            target_cols=["target"],
+        )
+
+        bad_prior_dim = Path(tmp) / "bad_prior_dim.csv"
+        bad_prior_dim.write_text("split,id,p0,measurement,target\ncalibration,a,1,1,1\n", encoding="utf-8")
+        assert_raises(
+            read_product_kalman_table,
+            bad_prior_dim,
+            prior_cols=["p0", "missing_prior"],
             measurement_cols=["measurement"],
             target_cols=["target"],
         )


### PR DESCRIPTION
## Summary
- add optional `--output-manifest` JSON output to `product_kalman_table_to_npz.py`
- record source-table SHA-256, delimiter, split counts, column groups, dimensions, ID duplicate/overlap audit, array schema, and optional `H` values
- add early schema checks for prior/target dimension mismatch and missing `H` when measurement dimension differs
- update tests and the Product-Kalman design note for the manifest path

## Tests
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_table_to_npz.py prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/product_kalman_table_to_npz.py --help`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `python3 prototypes/mu_cosine/test_product_space_monte_carlo.py`
- `git diff --cached --check`