### PR TITLE
Add Product-Kalman table evaluation runner

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -370,13 +370,13 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    covariance block matrix, and all scalar channels must be passed as explicit `(n, 1)` row matrices rather than
    ambiguous 1-D arrays. Calibration splits must be node-disjoint from training data and from the final evaluation
    split.
-6. Use `product_kalman_table_to_npz.py` to turn explicit CSV/TSV calibration/evaluation rows into the
-   evaluator input NPZ, optionally with a JSON input manifest recording source-table hash, split counts, column
-   groups, dimensions, ID overlap/duplicate counts, and `H` shape/values. Then use `product_kalman_evaluation.py`
-   as the split-safe comparison harness: fit calibration blocks on one split, score prior / zero-cross-covariance
-   / correlated Product-Kalman predictions on a separate split, and keep calibration/evaluation IDs disjoint. Its
-   CLI writes JSON score summaries plus optional row-level NPZ artifacts for later plotting/reanalysis. *(Synthetic
-   harness added; real-corpus comparison pending.)*
+6. Use `product_kalman_table_evaluation.py` as the real-corpus entry point when starting from explicit CSV/TSV
+   calibration/evaluation rows: it writes the evaluator input NPZ, optional JSON input manifest, JSON score summary,
+   and optional row-level evaluation NPZ in one auditable command. Under the hood, `product_kalman_table_to_npz.py`
+   records source-table hash, split counts, column groups, dimensions, ID overlap/duplicate counts, and `H`
+   shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
+   zero-cross-covariance / correlated Product-Kalman predictions on a separate split, and keeps
+   calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison pending.)*
 7. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
    Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
    residuals that set `R_ell` as the comparison set.
@@ -402,6 +402,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 - `product_kalman_table_to_npz.py` and `test_product_kalman_table_to_npz.py` — CSV/TSV-to-NPZ builder for
   evaluator input arrays with explicit split, ID, prior, measurement, and target columns, plus optional JSON input
   manifests for real-corpus provenance checks.
+- `product_kalman_table_evaluation.py` and `test_product_kalman_table_evaluation.py` — one-command table-to-input-artifacts-to-holdout-score
+  runner for real-corpus Product-Kalman comparisons.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including JSON summaries
   and row-level NPZ artifacts for reproducible corpus-run diagnostics.

--- a/prototypes/mu_cosine/product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_table_evaluation.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Run Product-Kalman holdout evaluation directly from a CSV/TSV row table.
+
+This is a thin orchestration layer over `product_kalman_table_to_npz.py` and
+`product_kalman_evaluation.py`. It keeps real-corpus runs reproducible by
+emitting the input NPZ, optional input manifest, JSON score summary, and optional
+row-level evaluation artifacts from one command.
+"""
+
+import argparse
+from dataclasses import dataclass
+import json
+import sys
+
+try:
+    from .product_kalman_evaluation import (
+        evaluation_to_json_dict,
+        run_product_kalman_holdout_npz,
+        write_evaluation_npz,
+    )
+    from .product_kalman_table_to_npz import build_product_kalman_npz_from_table, parse_column_list
+except ImportError:  # direct script execution from prototypes/mu_cosine
+    from product_kalman_evaluation import (
+        evaluation_to_json_dict,
+        run_product_kalman_holdout_npz,
+        write_evaluation_npz,
+    )
+    from product_kalman_table_to_npz import build_product_kalman_npz_from_table, parse_column_list
+
+
+__all__ = [
+    "ProductKalmanTableEvaluation",
+    "run_product_kalman_table_evaluation",
+]
+
+
+@dataclass(frozen=True)
+class ProductKalmanTableEvaluation:
+    """One table-to-NPZ-to-score run."""
+
+    input_arrays: dict
+    result: object
+    summary: dict
+
+
+def _write_json(path, data, indent=2):
+    text = json.dumps(data, indent=None if indent == 0 else indent, sort_keys=True) + "\n"
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+def _attach_input_paths(summary, input_table, input_npz, input_manifest=None, output_npz=None):
+    enriched = dict(summary)
+    enriched["inputs"] = {
+        "source_table": str(input_table),
+        "input_npz": str(input_npz),
+        "input_manifest": None if input_manifest is None else str(input_manifest),
+        "evaluation_npz": None if output_npz is None else str(output_npz),
+    }
+    return enriched
+
+
+def run_product_kalman_table_evaluation(
+    input_table,
+    input_npz,
+    prior_cols,
+    measurement_cols,
+    target_cols,
+    input_manifest=None,
+    output_json=None,
+    output_npz=None,
+    split_col="split",
+    id_col="id",
+    calibration_value="calibration",
+    evaluation_value="evaluation",
+    delimiter=None,
+    H=None,
+    shrinkage=0.0,
+    jitter=1e-9,
+    ddof=1,
+    shrinkage_target="diagonal",
+    indent=2,
+):
+    """Build evaluator input artifacts from a table and score the held-out split."""
+    arrays = build_product_kalman_npz_from_table(
+        input_table,
+        input_npz,
+        output_manifest=input_manifest,
+        prior_cols=prior_cols,
+        measurement_cols=measurement_cols,
+        target_cols=target_cols,
+        split_col=split_col,
+        id_col=id_col,
+        calibration_value=calibration_value,
+        evaluation_value=evaluation_value,
+        delimiter=delimiter,
+        H=H,
+    )
+    result = run_product_kalman_holdout_npz(
+        input_npz,
+        shrinkage=shrinkage,
+        jitter=jitter,
+        ddof=ddof,
+        shrinkage_target=shrinkage_target,
+    )
+    if output_npz:
+        write_evaluation_npz(output_npz, result)
+    summary = _attach_input_paths(
+        evaluation_to_json_dict(result),
+        input_table,
+        input_npz,
+        input_manifest=input_manifest,
+        output_npz=output_npz,
+    )
+    if output_json:
+        _write_json(output_json, summary, indent=indent)
+    return ProductKalmanTableEvaluation(
+        input_arrays=arrays,
+        result=result,
+        summary=summary,
+    )
+
+
+def _build_arg_parser():
+    ap = argparse.ArgumentParser(
+        description="Build Product-Kalman input artifacts from a table and run the holdout evaluator.",
+    )
+    ap.add_argument("input_table", help="CSV/TSV table with split, prior, measurement, and target columns")
+    ap.add_argument("--input-npz", required=True, help="write intermediate evaluator input NPZ here")
+    ap.add_argument("--input-manifest", help="write optional input-provenance JSON manifest here")
+    ap.add_argument("--output-json", help="write evaluation JSON summary here instead of stdout")
+    ap.add_argument("--output-npz", help="write row-level prediction/covariance artifacts to this NPZ path")
+    ap.add_argument("--prior-cols", required=True, help="comma-separated prior mean columns")
+    ap.add_argument("--measurement-cols", required=True, help="comma-separated measurement columns")
+    ap.add_argument("--target-cols", required=True, help="comma-separated target-state columns")
+    ap.add_argument("--split-col", default="split")
+    ap.add_argument("--id-col", default="id", help="ID column to carry into NPZ; use '' to omit IDs")
+    ap.add_argument("--calibration-value", default="calibration")
+    ap.add_argument("--evaluation-value", default="evaluation")
+    ap.add_argument("--delimiter", help="input delimiter; defaults to tab for .tsv/.tab, comma otherwise")
+    ap.add_argument("--H", help="optional observation matrix literal, e.g. '1,0;0,1'")
+    ap.add_argument("--shrinkage", type=float, default=0.0)
+    ap.add_argument("--jitter", type=float, default=1e-9)
+    ap.add_argument("--ddof", type=int, default=1)
+    ap.add_argument("--shrinkage-target", default="diagonal", choices=("diagonal", "scaled_identity"))
+    ap.add_argument("--indent", type=int, default=2, help="JSON indentation; use 0 for compact output")
+    return ap
+
+
+def main(argv=None):
+    ap = _build_arg_parser()
+    args = ap.parse_args(argv)
+    try:
+        run = run_product_kalman_table_evaluation(
+            args.input_table,
+            args.input_npz,
+            prior_cols=parse_column_list(args.prior_cols),
+            measurement_cols=parse_column_list(args.measurement_cols),
+            target_cols=parse_column_list(args.target_cols),
+            input_manifest=args.input_manifest,
+            output_json=args.output_json,
+            output_npz=args.output_npz,
+            split_col=args.split_col,
+            id_col=args.id_col or None,
+            calibration_value=args.calibration_value,
+            evaluation_value=args.evaluation_value,
+            delimiter=args.delimiter,
+            H=args.H,
+            shrinkage=args.shrinkage,
+            jitter=args.jitter,
+            ddof=args.ddof,
+            shrinkage_target=args.shrinkage_target,
+            indent=args.indent,
+        )
+    except ValueError as exc:
+        ap.error(str(exc))
+    if not args.output_json:
+        indent = None if args.indent == 0 else args.indent
+        sys.stdout.write(json.dumps(run.summary, indent=indent, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Tests for the Product-Kalman table-to-evaluation runner.
+
+Run: `python3 test_product_kalman_table_evaluation.py`.
+"""
+
+import csv
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np
+
+from product_kalman_evaluation import run_product_kalman_holdout_npz
+from product_kalman_table_evaluation import main, run_product_kalman_table_evaluation
+
+
+def synthetic_identity_split(n_cal=80, n_eval=40, seed=23):
+    rng = np.random.default_rng(seed)
+    n = n_cal + n_eval
+    target = rng.normal(size=(n, 1))
+    error_covariance = np.array([[1.0, 0.4], [0.4, 0.4]])
+    errors = rng.multivariate_normal([0.0, 0.0], error_covariance, size=n)
+    prior = target - errors[:, :1]
+    measurement = target + errors[:, 1:]
+    return prior, measurement, target, n_cal
+
+
+def write_table(path, delimiter=","):
+    prior, measurement, target, n_cal = synthetic_identity_split()
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["split", "id", "prior", "measurement", "target"], delimiter=delimiter)
+        writer.writeheader()
+        for i in range(len(target)):
+            split = "calibration" if i < n_cal else "evaluation"
+            writer.writerow({
+                "split": split,
+                "id": f"{split}-{i}",
+                "prior": f"{prior[i, 0]:.17g}",
+                "measurement": f"{measurement[i, 0]:.17g}",
+                "target": f"{target[i, 0]:.17g}",
+            })
+
+
+def test_table_runner_writes_input_and_evaluation_artifacts():
+    with tempfile.TemporaryDirectory() as tmp:
+        table = Path(tmp) / "holdout.csv"
+        input_npz = Path(tmp) / "input.npz"
+        input_manifest = Path(tmp) / "input.manifest.json"
+        output_json = Path(tmp) / "scores.json"
+        output_npz = Path(tmp) / "eval_artifacts.npz"
+        write_table(table)
+
+        run = run_product_kalman_table_evaluation(
+            table,
+            input_npz,
+            prior_cols=["prior"],
+            measurement_cols=["measurement"],
+            target_cols=["target"],
+            input_manifest=input_manifest,
+            output_json=output_json,
+            output_npz=output_npz,
+            jitter=1e-8,
+        )
+
+        assert input_npz.exists()
+        assert input_manifest.exists()
+        assert output_json.exists()
+        assert output_npz.exists()
+        assert run.input_arrays["calibration_prior_mean"].shape == (80, 1)
+        assert run.result.nll_improvement("prior", "product_kalman") > 0.65
+        assert run.result.nll_improvement("independent_kalman", "product_kalman") > 0.05
+
+        summary = json.loads(output_json.read_text())
+        assert summary["inputs"]["source_table"] == str(table)
+        assert summary["inputs"]["input_npz"] == str(input_npz)
+        assert summary["inputs"]["input_manifest"] == str(input_manifest)
+        assert summary["inputs"]["evaluation_npz"] == str(output_npz)
+        assert summary["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
+        assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
+
+        manifest = json.loads(input_manifest.read_text())
+        assert manifest["splits"]["calibration_rows"] == 80
+        assert manifest["splits"]["evaluation_rows"] == 40
+        assert manifest["ids"]["disjoint_and_unique"] is True
+
+        with np.load(output_npz, allow_pickle=False) as artifact:
+            assert artifact["product_kalman_mean"].shape == (40, 1)
+            assert artifact["score_names"].tolist() == summary["score_order"]
+
+
+def test_table_runner_cli_roundtrips_against_npz_evaluator():
+    with tempfile.TemporaryDirectory() as tmp:
+        table = Path(tmp) / "holdout.tsv"
+        input_npz = Path(tmp) / "input.npz"
+        input_manifest = Path(tmp) / "input.manifest.json"
+        output_json = Path(tmp) / "scores.json"
+        write_table(table, delimiter="\t")
+
+        rc = main([
+            str(table),
+            "--input-npz",
+            str(input_npz),
+            "--input-manifest",
+            str(input_manifest),
+            "--output-json",
+            str(output_json),
+            "--prior-cols",
+            "prior",
+            "--measurement-cols",
+            "measurement",
+            "--target-cols",
+            "target",
+            "--jitter",
+            "1e-8",
+            "--indent",
+            "0",
+        ])
+
+        assert rc == 0
+        from_table = json.loads(output_json.read_text())
+        from_npz = run_product_kalman_holdout_npz(input_npz, jitter=1e-8)
+        assert abs(
+            from_table["scores"]["product_kalman"]["mean_nll"]
+            - from_npz.score("product_kalman").mean_nll
+        ) < 1e-12
+        manifest = json.loads(input_manifest.read_text())
+        assert manifest["source_table"]["delimiter"] == "\t"
+        assert manifest["ids"]["overlap_count"] == 0
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} product-kalman table-evaluation tests passed")


### PR DESCRIPTION
## Summary
- add `product_kalman_table_evaluation.py`, a one-command runner from CSV/TSV table to Product-Kalman holdout evaluation
- write the evaluator input NPZ, optional input manifest, JSON score summary, and optional row-level evaluation NPZ from one CLI
- include synthetic roundtrip tests covering function and CLI behavior
- update the Product-Kalman design note to make this the real-corpus table-entry path

## Tests
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/product_kalman_table_evaluation.py --help`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `python3 prototypes/mu_cosine/test_product_space_monte_carlo.py`
- `git diff --cached --check`