### PR TITLE
Add Product-Kalman Markdown report generator

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -377,10 +377,13 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
    zero-cross-covariance / correlated Product-Kalman predictions on a separate split, and keeps
    calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison pending.)*
-7. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
+7. Use `product_kalman_report.py` to render the input manifest plus score JSON into a descriptive Markdown run
+   note. The report is an audit artifact only: it records scores and provenance, but does not encode a decision
+   rule or promote Product-Kalman without comparison against registered baselines.
+8. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
    Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
    residuals that set `R_ell` as the comparison set.
-8. Only after the held-out comparison, decide whether this belongs in the training objective.
+9. Only after the held-out comparison, decide whether this belongs in the training objective.
 
 ## Related local artifacts
 
@@ -404,6 +407,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   manifests for real-corpus provenance checks.
 - `product_kalman_table_evaluation.py` and `test_product_kalman_table_evaluation.py` — one-command table-to-input-artifacts-to-holdout-score
   runner for real-corpus Product-Kalman comparisons.
+- `product_kalman_report.py` and `test_product_kalman_report.py` — descriptive Markdown report generator for
+  Product-Kalman input manifests and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including JSON summaries
   and row-level NPZ artifacts for reproducible corpus-run diagnostics.

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Build a Markdown report from Product-Kalman evaluation artifacts.
+
+The report is deliberately descriptive. It records the input manifest and score
+summary in a human-readable form, but it does not encode a decision rule or
+claim that Product-Kalman has won.
+"""
+
+import argparse
+import json
+import sys
+
+
+__all__ = [
+    "build_product_kalman_markdown_report",
+    "load_json",
+    "write_markdown_report",
+]
+
+
+def load_json(path):
+    """Load a JSON file."""
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _fmt(value):
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def _markdown_table(headers, rows):
+    out = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join(["---"] * len(headers)) + " |",
+    ]
+    for row in rows:
+        out.append("| " + " | ".join(_fmt(value) for value in row) + " |")
+    return "\n".join(out)
+
+
+def _score_rows(scores_json):
+    scores = scores_json.get("scores", {})
+    order = scores_json.get("score_order") or sorted(scores)
+    rows = []
+    for name in order:
+        score = scores[name]
+        rows.append([
+            name,
+            score.get("mean_nll"),
+            score.get("mse"),
+            score.get("n"),
+            score.get("covariance_trace"),
+        ])
+    return rows
+
+
+def _improvement_rows(scores_json):
+    rows = []
+    for baseline_key, label in (
+        ("nll_improvement_vs_prior", "prior"),
+        ("nll_improvement_vs_independent_kalman", "independent_kalman"),
+    ):
+        for candidate, gain in sorted(scores_json.get(baseline_key, {}).items()):
+            rows.append([label, candidate, gain])
+    return rows
+
+
+def _input_rows(scores_json, manifest):
+    inputs = scores_json.get("inputs", {})
+    rows = [
+        ["source_table", inputs.get("source_table")],
+        ["input_npz", inputs.get("input_npz")],
+        ["input_manifest", inputs.get("input_manifest")],
+        ["evaluation_npz", inputs.get("evaluation_npz")],
+    ]
+    if manifest:
+        source = manifest.get("source_table", {})
+        rows.append(["source_table_sha256", source.get("sha256")])
+        rows.append(["delimiter", repr(source.get("delimiter"))])
+    return rows
+
+
+def _manifest_rows(manifest):
+    if not manifest:
+        return []
+    splits = manifest.get("splits", {})
+    dims = manifest.get("dimensions", {})
+    ids = manifest.get("ids", {})
+    H = manifest.get("H", {})
+    return [
+        ["calibration_rows", splits.get("calibration_rows")],
+        ["evaluation_rows", splits.get("evaluation_rows")],
+        ["state_dim", dims.get("state_dim")],
+        ["prior_dim", dims.get("prior_dim")],
+        ["observation_dim", dims.get("observation_dim")],
+        ["ids_disjoint_and_unique", ids.get("disjoint_and_unique")],
+        ["id_overlap_count", ids.get("overlap_count")],
+        ["calibration_duplicate_count", ids.get("calibration_duplicate_count")],
+        ["evaluation_duplicate_count", ids.get("evaluation_duplicate_count")],
+        ["H_present", H.get("present")],
+        ["H_shape", H.get("shape")],
+    ]
+
+
+def _column_rows(manifest):
+    if not manifest:
+        return []
+    columns = manifest.get("columns", {})
+    return [
+        ["prior", ", ".join(columns.get("prior", []))],
+        ["measurement", ", ".join(columns.get("measurement", []))],
+        ["target_state", ", ".join(columns.get("target_state", []))],
+    ]
+
+
+def _calibration_rows(scores_json):
+    calibration = scores_json.get("calibration", {})
+    return [
+        ["n_samples", calibration.get("n_samples")],
+        ["state_dim", calibration.get("state_dim")],
+        ["observation_dim", calibration.get("observation_dim")],
+        ["ddof", calibration.get("ddof")],
+        ["shrinkage", calibration.get("shrinkage")],
+        ["shrinkage_target", calibration.get("shrinkage_target")],
+    ]
+
+
+def build_product_kalman_markdown_report(scores_json, input_manifest=None, title="Product-Kalman Holdout Report"):
+    """Return a descriptive Markdown report for one Product-Kalman evaluation."""
+    lines = [
+        f"# {title}",
+        "",
+        "This report is descriptive: it records held-out scores and provenance artifacts, but it does not encode a decision rule.",
+        "",
+        "## Inputs",
+        "",
+        _markdown_table(["item", "value"], _input_rows(scores_json, input_manifest)),
+        "",
+    ]
+    if input_manifest:
+        lines.extend([
+            "## Split And Schema",
+            "",
+            _markdown_table(["item", "value"], _manifest_rows(input_manifest)),
+            "",
+            "## Column Groups",
+            "",
+            _markdown_table(["group", "columns"], _column_rows(input_manifest)),
+            "",
+        ])
+    lines.extend([
+        "## Scores",
+        "",
+        _markdown_table(["model", "mean_nll", "mse", "n", "covariance_trace"], _score_rows(scores_json)),
+        "",
+        "## NLL Improvements",
+        "",
+        _markdown_table(["baseline", "candidate", "mean_nll_gain"], _improvement_rows(scores_json)),
+        "",
+        "## Calibration Settings",
+        "",
+        _markdown_table(["item", "value"], _calibration_rows(scores_json)),
+        "",
+        "## Guardrails",
+        "",
+        "- Positive NLL gain means the candidate had lower held-out mean NLL than the named baseline.",
+        "- Treat this as a held-out comparison artifact, not as a training-objective decision.",
+        "- Product-Kalman should be compared against the registered joint-posterior and Sigma-conditioned baselines before promotion.",
+        "- Calibration rows and evaluation rows must remain disjoint; any ID overlap or duplicate count above zero should block interpretation.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def write_markdown_report(path, text):
+    """Write a Markdown report."""
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+def _build_arg_parser():
+    ap = argparse.ArgumentParser(description="Build a Markdown report from Product-Kalman JSON artifacts.")
+    ap.add_argument("scores_json", help="JSON score summary from product_kalman_evaluation/table_evaluation")
+    ap.add_argument("--input-manifest", help="optional input manifest JSON from product_kalman_table_to_npz")
+    ap.add_argument("--output-md", help="write Markdown report here instead of stdout")
+    ap.add_argument("--title", default="Product-Kalman Holdout Report")
+    return ap
+
+
+def main(argv=None):
+    ap = _build_arg_parser()
+    args = ap.parse_args(argv)
+    scores = load_json(args.scores_json)
+    manifest = load_json(args.input_manifest) if args.input_manifest else None
+    text = build_product_kalman_markdown_report(scores, manifest, title=args.title)
+    if args.output_md:
+        write_markdown_report(args.output_md, text)
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Tests for Product-Kalman Markdown report generation.
+
+Run: `python3 test_product_kalman_report.py`.
+"""
+
+import csv
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np
+
+from product_kalman_report import build_product_kalman_markdown_report, main
+from product_kalman_table_evaluation import run_product_kalman_table_evaluation
+
+
+def synthetic_identity_split(n_cal=80, n_eval=40, seed=23):
+    rng = np.random.default_rng(seed)
+    n = n_cal + n_eval
+    target = rng.normal(size=(n, 1))
+    error_covariance = np.array([[1.0, 0.4], [0.4, 0.4]])
+    errors = rng.multivariate_normal([0.0, 0.0], error_covariance, size=n)
+    prior = target - errors[:, :1]
+    measurement = target + errors[:, 1:]
+    return prior, measurement, target, n_cal
+
+
+def write_table(path):
+    prior, measurement, target, n_cal = synthetic_identity_split()
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["split", "id", "prior", "measurement", "target"])
+        writer.writeheader()
+        for i in range(len(target)):
+            split = "calibration" if i < n_cal else "evaluation"
+            writer.writerow({
+                "split": split,
+                "id": f"{split}-{i}",
+                "prior": f"{prior[i, 0]:.17g}",
+                "measurement": f"{measurement[i, 0]:.17g}",
+                "target": f"{target[i, 0]:.17g}",
+            })
+
+
+def make_artifacts(tmp):
+    table = Path(tmp) / "holdout.csv"
+    input_npz = Path(tmp) / "input.npz"
+    input_manifest = Path(tmp) / "input.manifest.json"
+    scores_json = Path(tmp) / "scores.json"
+    eval_npz = Path(tmp) / "eval_artifacts.npz"
+    write_table(table)
+    run_product_kalman_table_evaluation(
+        table,
+        input_npz,
+        prior_cols=["prior"],
+        measurement_cols=["measurement"],
+        target_cols=["target"],
+        input_manifest=input_manifest,
+        output_json=scores_json,
+        output_npz=eval_npz,
+        jitter=1e-8,
+    )
+    return input_manifest, scores_json
+
+
+def test_markdown_report_records_scores_and_guardrails():
+    with tempfile.TemporaryDirectory() as tmp:
+        input_manifest, scores_json = make_artifacts(tmp)
+        scores = json.loads(scores_json.read_text())
+        manifest = json.loads(input_manifest.read_text())
+        report = build_product_kalman_markdown_report(scores, manifest, title="Synthetic Product-Kalman Report")
+
+        assert report.startswith("# Synthetic Product-Kalman Report\n")
+        assert "This report is descriptive" in report
+        assert "| product_kalman |" in report
+        assert "| prior | product_kalman |" in report
+        assert "| calibration_rows | 80 |" in report
+        assert "| evaluation_rows | 40 |" in report
+        assert "| ids_disjoint_and_unique | True |" in report
+        assert "| prior | prior |" in report
+        assert "does not encode a decision rule" in report
+        assert "should be compared against the registered joint-posterior" in report
+
+
+def test_markdown_report_cli_writes_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        input_manifest, scores_json = make_artifacts(tmp)
+        output_md = Path(tmp) / "report.md"
+        rc = main([
+            str(scores_json),
+            "--input-manifest",
+            str(input_manifest),
+            "--output-md",
+            str(output_md),
+            "--title",
+            "CLI Product-Kalman Report",
+        ])
+        assert rc == 0
+        text = output_md.read_text()
+        assert "# CLI Product-Kalman Report" in text
+        assert "## Scores" in text
+        assert "## NLL Improvements" in text
+        assert "source_table_sha256" in text
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} product-kalman report tests passed")


### PR DESCRIPTION
## Summary
- add `product_kalman_report.py` to render score JSON plus optional input manifest into a descriptive Markdown run report
- include score tables, NLL improvement tables, split/schema details, column groups, calibration settings, and guardrails
- keep the report explicitly descriptive: it does not encode a decision rule or claim Product-Kalman has won
- add synthetic tests that generate real table-evaluation artifacts and verify function/CLI report output
- update the Product-Kalman design note to include the report step

## Tests
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_report.py prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/product_kalman_report.py --help`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `python3 prototypes/mu_cosine/test_product_space_monte_carlo.py`
- `git diff --cached --check`