### PR TITLE
Add Markdown report output to Product-Kalman table runner

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -372,8 +372,9 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    split.
 6. Use `product_kalman_table_evaluation.py` as the real-corpus entry point when starting from explicit CSV/TSV
    calibration/evaluation rows: it writes the evaluator input NPZ, optional JSON input manifest, JSON score summary,
-   and optional row-level evaluation NPZ in one auditable command. Under the hood, `product_kalman_table_to_npz.py`
-   records source-table hash, split counts, column groups, dimensions, ID overlap/duplicate counts, and `H`
+   optional row-level evaluation NPZ, and optional Markdown report in one auditable command. Under the hood,
+   `product_kalman_table_to_npz.py` records source-table hash, split counts, column groups, dimensions, ID
+   overlap/duplicate counts, and `H`
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
    zero-cross-covariance / correlated Product-Kalman predictions on a separate split, and keeps
    calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison pending.)*
@@ -405,8 +406,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 - `product_kalman_table_to_npz.py` and `test_product_kalman_table_to_npz.py` — CSV/TSV-to-NPZ builder for
   evaluator input arrays with explicit split, ID, prior, measurement, and target columns, plus optional JSON input
   manifests for real-corpus provenance checks.
-- `product_kalman_table_evaluation.py` and `test_product_kalman_table_evaluation.py` — one-command table-to-input-artifacts-to-holdout-score
-  runner for real-corpus Product-Kalman comparisons.
+- `product_kalman_table_evaluation.py` and `test_product_kalman_table_evaluation.py` — one-command table-to-input-
+  artifacts-to-holdout-score/report runner for real-corpus Product-Kalman comparisons.
 - `product_kalman_report.py` and `test_product_kalman_report.py` — descriptive Markdown report generator for
   Product-Kalman input manifests and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for

--- a/prototypes/mu_cosine/product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_table_evaluation.py
@@ -3,8 +3,8 @@
 
 This is a thin orchestration layer over `product_kalman_table_to_npz.py` and
 `product_kalman_evaluation.py`. It keeps real-corpus runs reproducible by
-emitting the input NPZ, optional input manifest, JSON score summary, and optional
-row-level evaluation artifacts from one command.
+emitting the input NPZ, optional input manifest, JSON score summary, optional
+row-level evaluation artifacts, and optional Markdown report from one command.
 """
 
 import argparse
@@ -18,12 +18,22 @@ try:
         run_product_kalman_holdout_npz,
         write_evaluation_npz,
     )
+    from .product_kalman_report import (
+        build_product_kalman_markdown_report,
+        load_json,
+        write_markdown_report,
+    )
     from .product_kalman_table_to_npz import build_product_kalman_npz_from_table, parse_column_list
 except ImportError:  # direct script execution from prototypes/mu_cosine
     from product_kalman_evaluation import (
         evaluation_to_json_dict,
         run_product_kalman_holdout_npz,
         write_evaluation_npz,
+    )
+    from product_kalman_report import (
+        build_product_kalman_markdown_report,
+        load_json,
+        write_markdown_report,
     )
     from product_kalman_table_to_npz import build_product_kalman_npz_from_table, parse_column_list
 
@@ -41,6 +51,7 @@ class ProductKalmanTableEvaluation:
     input_arrays: dict
     result: object
     summary: dict
+    report_text: str = ""
 
 
 def _write_json(path, data, indent=2):
@@ -49,13 +60,14 @@ def _write_json(path, data, indent=2):
         f.write(text)
 
 
-def _attach_input_paths(summary, input_table, input_npz, input_manifest=None, output_npz=None):
+def _attach_input_paths(summary, input_table, input_npz, input_manifest=None, output_npz=None, output_md=None):
     enriched = dict(summary)
     enriched["inputs"] = {
         "source_table": str(input_table),
         "input_npz": str(input_npz),
         "input_manifest": None if input_manifest is None else str(input_manifest),
         "evaluation_npz": None if output_npz is None else str(output_npz),
+        "report_md": None if output_md is None else str(output_md),
     }
     return enriched
 
@@ -69,6 +81,8 @@ def run_product_kalman_table_evaluation(
     input_manifest=None,
     output_json=None,
     output_npz=None,
+    output_md=None,
+    report_title="Product-Kalman Holdout Report",
     split_col="split",
     id_col="id",
     calibration_value="calibration",
@@ -111,13 +125,20 @@ def run_product_kalman_table_evaluation(
         input_npz,
         input_manifest=input_manifest,
         output_npz=output_npz,
+        output_md=output_md,
     )
+    report_text = ""
+    if output_md:
+        manifest = load_json(input_manifest) if input_manifest else None
+        report_text = build_product_kalman_markdown_report(summary, manifest, title=report_title)
+        write_markdown_report(output_md, report_text)
     if output_json:
         _write_json(output_json, summary, indent=indent)
     return ProductKalmanTableEvaluation(
         input_arrays=arrays,
         result=result,
         summary=summary,
+        report_text=report_text,
     )
 
 
@@ -130,6 +151,8 @@ def _build_arg_parser():
     ap.add_argument("--input-manifest", help="write optional input-provenance JSON manifest here")
     ap.add_argument("--output-json", help="write evaluation JSON summary here instead of stdout")
     ap.add_argument("--output-npz", help="write row-level prediction/covariance artifacts to this NPZ path")
+    ap.add_argument("--output-md", help="write optional descriptive Markdown report here")
+    ap.add_argument("--report-title", default="Product-Kalman Holdout Report")
     ap.add_argument("--prior-cols", required=True, help="comma-separated prior mean columns")
     ap.add_argument("--measurement-cols", required=True, help="comma-separated measurement columns")
     ap.add_argument("--target-cols", required=True, help="comma-separated target-state columns")
@@ -160,6 +183,8 @@ def main(argv=None):
             input_manifest=args.input_manifest,
             output_json=args.output_json,
             output_npz=args.output_npz,
+            output_md=args.output_md,
+            report_title=args.report_title,
             split_col=args.split_col,
             id_col=args.id_col or None,
             calibration_value=args.calibration_value,

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -52,6 +52,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         input_manifest = Path(tmp) / "input.manifest.json"
         output_json = Path(tmp) / "scores.json"
         output_npz = Path(tmp) / "eval_artifacts.npz"
+        output_md = Path(tmp) / "report.md"
         write_table(table)
 
         run = run_product_kalman_table_evaluation(
@@ -63,6 +64,8 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
             input_manifest=input_manifest,
             output_json=output_json,
             output_npz=output_npz,
+            output_md=output_md,
+            report_title="Synthetic Table Product-Kalman Report",
             jitter=1e-8,
         )
 
@@ -70,6 +73,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert input_manifest.exists()
         assert output_json.exists()
         assert output_npz.exists()
+        assert output_md.exists()
         assert run.input_arrays["calibration_prior_mean"].shape == (80, 1)
         assert run.result.nll_improvement("prior", "product_kalman") > 0.65
         assert run.result.nll_improvement("independent_kalman", "product_kalman") > 0.05
@@ -79,6 +83,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert summary["inputs"]["input_npz"] == str(input_npz)
         assert summary["inputs"]["input_manifest"] == str(input_manifest)
         assert summary["inputs"]["evaluation_npz"] == str(output_npz)
+        assert summary["inputs"]["report_md"] == str(output_md)
         assert summary["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
 
@@ -86,6 +91,11 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert manifest["splits"]["calibration_rows"] == 80
         assert manifest["splits"]["evaluation_rows"] == 40
         assert manifest["ids"]["disjoint_and_unique"] is True
+        report = output_md.read_text()
+        assert report == run.report_text
+        assert "# Synthetic Table Product-Kalman Report" in report
+        assert "## Scores" in report
+        assert "source_table_sha256" in report
 
         with np.load(output_npz, allow_pickle=False) as artifact:
             assert artifact["product_kalman_mean"].shape == (40, 1)
@@ -98,6 +108,7 @@ def test_table_runner_cli_roundtrips_against_npz_evaluator():
         input_npz = Path(tmp) / "input.npz"
         input_manifest = Path(tmp) / "input.manifest.json"
         output_json = Path(tmp) / "scores.json"
+        output_md = Path(tmp) / "scores.md"
         write_table(table, delimiter="\t")
 
         rc = main([
@@ -108,6 +119,10 @@ def test_table_runner_cli_roundtrips_against_npz_evaluator():
             str(input_manifest),
             "--output-json",
             str(output_json),
+            "--output-md",
+            str(output_md),
+            "--report-title",
+            "CLI Table Product-Kalman Report",
             "--prior-cols",
             "prior",
             "--measurement-cols",
@@ -121,6 +136,8 @@ def test_table_runner_cli_roundtrips_against_npz_evaluator():
         ])
 
         assert rc == 0
+        assert output_md.exists()
+        assert "# CLI Table Product-Kalman Report" in output_md.read_text()
         from_table = json.loads(output_json.read_text())
         from_npz = run_product_kalman_holdout_npz(input_npz, jitter=1e-8)
         assert abs(
@@ -130,6 +147,7 @@ def test_table_runner_cli_roundtrips_against_npz_evaluator():
         manifest = json.loads(input_manifest.read_text())
         assert manifest["source_table"]["delimiter"] == "\t"
         assert manifest["ids"]["overlap_count"] == 0
+        assert from_table["inputs"]["report_md"] == str(output_md)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add optional `--output-md` and `--report-title` to `product_kalman_table_evaluation.py`
- generate the descriptive Product-Kalman Markdown report from the same score summary and input manifest produced by the table runner
- include the report path in the runner’s JSON `inputs` block
- extend table-runner tests to verify both API and CLI Markdown output
- update the Product-Kalman design note so the one-command runner lists the Markdown report artifact

## Tests
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/product_kalman_table_evaluation.py --help`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_space.py`
- `python3 prototypes/mu_cosine/test_product_kalman_poe_synthetic.py`
- `python3 prototypes/mu_cosine/test_product_space_monte_carlo.py`
- `git diff --cached --check`