### PR TITLE
Add Product-Kalman run directory output

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -371,9 +371,10 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    ambiguous 1-D arrays. Calibration splits must be node-disjoint from training data and from the final evaluation
    split.
 6. Use `product_kalman_table_evaluation.py` as the real-corpus entry point when starting from explicit CSV/TSV
-   calibration/evaluation rows: it writes the evaluator input NPZ, optional JSON input manifest, JSON score summary,
-   optional row-level evaluation NPZ, and optional Markdown report in one auditable command. Under the hood,
-   `product_kalman_table_to_npz.py` records source-table hash, split counts, column groups, dimensions, ID
+   calibration/evaluation rows: `--output-dir` writes a canonical bundle (`input.npz`, `input.manifest.json`,
+   `scores.json`, `eval_artifacts.npz`, and `report.md`) in one auditable command. Explicit artifact paths may
+   override those defaults. Under the hood, `product_kalman_table_to_npz.py` records source-table hash, split counts,
+   column groups, dimensions, ID
    overlap/duplicate counts, and `H`
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
    zero-cross-covariance / correlated Product-Kalman predictions on a separate split, and keeps
@@ -407,7 +408,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   evaluator input arrays with explicit split, ID, prior, measurement, and target columns, plus optional JSON input
   manifests for real-corpus provenance checks.
 - `product_kalman_table_evaluation.py` and `test_product_kalman_table_evaluation.py` — one-command table-to-input-
-  artifacts-to-holdout-score/report runner for real-corpus Product-Kalman comparisons.
+  artifacts-to-holdout-score/report runner, with canonical `--output-dir` bundles for real-corpus Product-Kalman
+  comparisons.
 - `product_kalman_report.py` and `test_product_kalman_report.py` — descriptive Markdown report generator for
   Product-Kalman input manifests and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for

--- a/prototypes/mu_cosine/product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_table_evaluation.py
@@ -10,6 +10,7 @@ row-level evaluation artifacts, and optional Markdown report from one command.
 import argparse
 from dataclasses import dataclass
 import json
+from pathlib import Path
 import sys
 
 try:
@@ -40,8 +41,18 @@ except ImportError:  # direct script execution from prototypes/mu_cosine
 
 __all__ = [
     "ProductKalmanTableEvaluation",
+    "default_product_kalman_run_paths",
     "run_product_kalman_table_evaluation",
 ]
+
+
+RUN_DIR_FILENAMES = {
+    "input_npz": "input.npz",
+    "input_manifest": "input.manifest.json",
+    "output_json": "scores.json",
+    "output_npz": "eval_artifacts.npz",
+    "output_md": "report.md",
+}
 
 
 @dataclass(frozen=True)
@@ -70,6 +81,34 @@ def _attach_input_paths(summary, input_table, input_npz, input_manifest=None, ou
         "report_md": None if output_md is None else str(output_md),
     }
     return enriched
+
+
+def default_product_kalman_run_paths(output_dir):
+    """Return canonical artifact paths for one Product-Kalman table run directory."""
+    root = Path(output_dir)
+    return {name: root / filename for name, filename in RUN_DIR_FILENAMES.items()}
+
+
+def _resolve_cli_output_paths(ap, args):
+    if args.output_dir:
+        defaults = default_product_kalman_run_paths(args.output_dir)
+        Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+        return {
+            "input_npz": args.input_npz or defaults["input_npz"],
+            "input_manifest": args.input_manifest or defaults["input_manifest"],
+            "output_json": args.output_json or defaults["output_json"],
+            "output_npz": args.output_npz or defaults["output_npz"],
+            "output_md": args.output_md or defaults["output_md"],
+        }
+    if not args.input_npz:
+        ap.error("--input-npz is required unless --output-dir is given")
+    return {
+        "input_npz": args.input_npz,
+        "input_manifest": args.input_manifest,
+        "output_json": args.output_json,
+        "output_npz": args.output_npz,
+        "output_md": args.output_md,
+    }
 
 
 def run_product_kalman_table_evaluation(
@@ -147,7 +186,11 @@ def _build_arg_parser():
         description="Build Product-Kalman input artifacts from a table and run the holdout evaluator.",
     )
     ap.add_argument("input_table", help="CSV/TSV table with split, prior, measurement, and target columns")
-    ap.add_argument("--input-npz", required=True, help="write intermediate evaluator input NPZ here")
+    ap.add_argument(
+        "--output-dir",
+        help="write a canonical artifact bundle here; explicit artifact paths override defaults",
+    )
+    ap.add_argument("--input-npz", help="write intermediate evaluator input NPZ here")
     ap.add_argument("--input-manifest", help="write optional input-provenance JSON manifest here")
     ap.add_argument("--output-json", help="write evaluation JSON summary here instead of stdout")
     ap.add_argument("--output-npz", help="write row-level prediction/covariance artifacts to this NPZ path")
@@ -173,17 +216,18 @@ def _build_arg_parser():
 def main(argv=None):
     ap = _build_arg_parser()
     args = ap.parse_args(argv)
+    paths = _resolve_cli_output_paths(ap, args)
     try:
         run = run_product_kalman_table_evaluation(
             args.input_table,
-            args.input_npz,
+            paths["input_npz"],
             prior_cols=parse_column_list(args.prior_cols),
             measurement_cols=parse_column_list(args.measurement_cols),
             target_cols=parse_column_list(args.target_cols),
-            input_manifest=args.input_manifest,
-            output_json=args.output_json,
-            output_npz=args.output_npz,
-            output_md=args.output_md,
+            input_manifest=paths["input_manifest"],
+            output_json=paths["output_json"],
+            output_npz=paths["output_npz"],
+            output_md=paths["output_md"],
             report_title=args.report_title,
             split_col=args.split_col,
             id_col=args.id_col or None,
@@ -199,7 +243,7 @@ def main(argv=None):
         )
     except ValueError as exc:
         ap.error(str(exc))
-    if not args.output_json:
+    if not paths["output_json"]:
         indent = None if args.indent == 0 else args.indent
         sys.stdout.write(json.dumps(run.summary, indent=indent, sort_keys=True) + "\n")
     return 0

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -15,7 +15,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import numpy as np
 
 from product_kalman_evaluation import run_product_kalman_holdout_npz
-from product_kalman_table_evaluation import main, run_product_kalman_table_evaluation
+from product_kalman_table_evaluation import (
+    default_product_kalman_run_paths,
+    main,
+    run_product_kalman_table_evaluation,
+)
 
 
 def synthetic_identity_split(n_cal=80, n_eval=40, seed=23):
@@ -100,6 +104,76 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         with np.load(output_npz, allow_pickle=False) as artifact:
             assert artifact["product_kalman_mean"].shape == (40, 1)
             assert artifact["score_names"].tolist() == summary["score_order"]
+
+
+def test_table_runner_output_dir_writes_canonical_bundle():
+    with tempfile.TemporaryDirectory() as tmp:
+        table = Path(tmp) / "holdout.csv"
+        output_dir = Path(tmp) / "product_kalman_run"
+        write_table(table)
+
+        rc = main([
+            str(table),
+            "--output-dir",
+            str(output_dir),
+            "--prior-cols",
+            "prior",
+            "--measurement-cols",
+            "measurement",
+            "--target-cols",
+            "target",
+            "--jitter",
+            "1e-8",
+            "--indent",
+            "0",
+        ])
+
+        assert rc == 0
+        paths = default_product_kalman_run_paths(output_dir)
+        for path in paths.values():
+            assert path.exists(), path
+        summary = json.loads(paths["output_json"].read_text())
+        assert summary["inputs"]["input_npz"] == str(paths["input_npz"])
+        assert summary["inputs"]["input_manifest"] == str(paths["input_manifest"])
+        assert summary["inputs"]["evaluation_npz"] == str(paths["output_npz"])
+        assert summary["inputs"]["report_md"] == str(paths["output_md"])
+        assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
+        assert "# Product-Kalman Holdout Report" in paths["output_md"].read_text()
+
+
+def test_table_runner_output_dir_allows_explicit_path_overrides():
+    with tempfile.TemporaryDirectory() as tmp:
+        table = Path(tmp) / "holdout.csv"
+        output_dir = Path(tmp) / "product_kalman_run"
+        custom_scores = Path(tmp) / "custom_scores.json"
+        write_table(table)
+
+        rc = main([
+            str(table),
+            "--output-dir",
+            str(output_dir),
+            "--output-json",
+            str(custom_scores),
+            "--prior-cols",
+            "prior",
+            "--measurement-cols",
+            "measurement",
+            "--target-cols",
+            "target",
+            "--jitter",
+            "1e-8",
+        ])
+
+        assert rc == 0
+        paths = default_product_kalman_run_paths(output_dir)
+        assert custom_scores.exists()
+        assert not paths["output_json"].exists()
+        assert paths["input_npz"].exists()
+        assert paths["input_manifest"].exists()
+        assert paths["output_npz"].exists()
+        assert paths["output_md"].exists()
+        summary = json.loads(custom_scores.read_text())
+        assert summary["inputs"]["report_md"] == str(paths["output_md"])
 
 
 def test_table_runner_cli_roundtrips_against_npz_evaluator():


### PR DESCRIPTION
## Summary
- add `--output-dir` to `product_kalman_table_evaluation.py`
- write a canonical run bundle by default:
  - `input.npz`
  - `input.manifest.json`
  - `scores.json`
  - `eval_artifacts.npz`
  - `report.md`
- allow explicit artifact paths to override individual `--output-dir` defaults
- document the canonical bundle flow in the Product-Kalman design note

## Tests
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/product_kalman_table_evaluation.py --help`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_report.py`
- Product-Kalman adjacent tests: table-to-NPZ, evaluation, calibration, core, product-space, synthetic PoE, Monte Carlo
- `git diff --check`