### PR TITLE
Allow Product-Kalman runner to materialize splits

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -376,9 +376,10 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    instead of relying on an ad hoc row split.
 7. Use `product_kalman_table_evaluation.py` as the real-corpus entry point when starting from explicit CSV/TSV
    calibration/evaluation rows: `--output-dir` writes a canonical bundle (`input.npz`, `input.manifest.json`,
-   `scores.json`, `eval_artifacts.npz`, and `report.md`) in one auditable command. Explicit artifact paths may
-   override those defaults. Under the hood, `product_kalman_table_to_npz.py` records source-table hash, split counts,
-   column groups, dimensions, ID
+   `scores.json`, `eval_artifacts.npz`, and `report.md`) in one auditable command. If given `--split-unit-cols`,
+   it first writes `split_table.csv`/`split_table.tsv` and `split.manifest.json` in the same run directory, then
+   evaluates that split-labeled table. Explicit artifact paths may override those defaults. Under the hood,
+   `product_kalman_table_to_npz.py` records source-table hash, split counts, column groups, dimensions, ID
    overlap/duplicate counts, and `H`
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
    zero-cross-covariance / correlated Product-Kalman predictions on a separate split, and keeps
@@ -414,8 +415,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 - `product_kalman_split_table.py` and `test_product_kalman_split_table.py` — split-label materializer for explicit
   Product-Kalman tables, with held-out unit sampling, strict boundary-row omission, and a split manifest.
 - `product_kalman_table_evaluation.py` and `test_product_kalman_table_evaluation.py` — one-command table-to-input-
-  artifacts-to-holdout-score/report runner, with canonical `--output-dir` bundles for real-corpus Product-Kalman
-  comparisons.
+  artifacts-to-holdout-score/report runner, with optional split materialization and canonical `--output-dir` bundles
+  for real-corpus Product-Kalman comparisons.
 - `product_kalman_report.py` and `test_product_kalman_report.py` — descriptive Markdown report generator for
   Product-Kalman input manifests and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for

--- a/prototypes/mu_cosine/product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_table_evaluation.py
@@ -24,6 +24,7 @@ try:
         load_json,
         write_markdown_report,
     )
+    from .product_kalman_split_table import split_product_kalman_table
     from .product_kalman_table_to_npz import build_product_kalman_npz_from_table, parse_column_list
 except ImportError:  # direct script execution from prototypes/mu_cosine
     from product_kalman_evaluation import (
@@ -36,12 +37,14 @@ except ImportError:  # direct script execution from prototypes/mu_cosine
         load_json,
         write_markdown_report,
     )
+    from product_kalman_split_table import split_product_kalman_table
     from product_kalman_table_to_npz import build_product_kalman_npz_from_table, parse_column_list
 
 
 __all__ = [
     "ProductKalmanTableEvaluation",
     "default_product_kalman_run_paths",
+    "default_product_kalman_split_paths",
     "run_product_kalman_table_evaluation",
 ]
 
@@ -52,6 +55,12 @@ RUN_DIR_FILENAMES = {
     "output_json": "scores.json",
     "output_npz": "eval_artifacts.npz",
     "output_md": "report.md",
+}
+
+
+SPLIT_RUN_DIR_FILENAMES = {
+    "split_table": "split_table.csv",
+    "split_manifest": "split.manifest.json",
 }
 
 
@@ -71,10 +80,21 @@ def _write_json(path, data, indent=2):
         f.write(text)
 
 
-def _attach_input_paths(summary, input_table, input_npz, input_manifest=None, output_npz=None, output_md=None):
+def _attach_input_paths(
+    summary,
+    input_table,
+    input_npz,
+    input_manifest=None,
+    output_npz=None,
+    output_md=None,
+    original_table=None,
+    split_manifest=None,
+):
     enriched = dict(summary)
     enriched["inputs"] = {
         "source_table": str(input_table),
+        "original_table": None if original_table is None else str(original_table),
+        "split_manifest": None if split_manifest is None else str(split_manifest),
         "input_npz": str(input_npz),
         "input_manifest": None if input_manifest is None else str(input_manifest),
         "evaluation_npz": None if output_npz is None else str(output_npz),
@@ -89,9 +109,24 @@ def default_product_kalman_run_paths(output_dir):
     return {name: root / filename for name, filename in RUN_DIR_FILENAMES.items()}
 
 
+def default_product_kalman_split_paths(output_dir, input_table=None):
+    """Return canonical optional split-materialization paths for one run directory."""
+    root = Path(output_dir)
+    table_name = SPLIT_RUN_DIR_FILENAMES["split_table"]
+    if input_table is not None and str(input_table).lower().endswith((".tsv", ".tab")):
+        table_name = "split_table.tsv"
+    return {
+        "split_table": root / table_name,
+        "split_manifest": root / SPLIT_RUN_DIR_FILENAMES["split_manifest"],
+    }
+
+
 def _resolve_cli_output_paths(ap, args):
+    if (args.split_output_table or args.split_output_manifest) and not args.split_unit_cols:
+        ap.error("--split-output-table and --split-output-manifest require --split-unit-cols")
     if args.output_dir:
         defaults = default_product_kalman_run_paths(args.output_dir)
+        split_defaults = default_product_kalman_split_paths(args.output_dir, input_table=args.input_table)
         Path(args.output_dir).mkdir(parents=True, exist_ok=True)
         return {
             "input_npz": args.input_npz or defaults["input_npz"],
@@ -99,7 +134,12 @@ def _resolve_cli_output_paths(ap, args):
             "output_json": args.output_json or defaults["output_json"],
             "output_npz": args.output_npz or defaults["output_npz"],
             "output_md": args.output_md or defaults["output_md"],
+            "split_table": args.split_output_table or (split_defaults["split_table"] if args.split_unit_cols else None),
+            "split_manifest": args.split_output_manifest
+            or (split_defaults["split_manifest"] if args.split_unit_cols else None),
         }
+    if args.split_unit_cols and not args.split_output_table:
+        ap.error("--split-output-table is required with --split-unit-cols unless --output-dir is given")
     if not args.input_npz:
         ap.error("--input-npz is required unless --output-dir is given")
     return {
@@ -108,6 +148,8 @@ def _resolve_cli_output_paths(ap, args):
         "output_json": args.output_json,
         "output_npz": args.output_npz,
         "output_md": args.output_md,
+        "split_table": args.split_output_table,
+        "split_manifest": args.split_output_manifest,
     }
 
 
@@ -121,6 +163,8 @@ def run_product_kalman_table_evaluation(
     output_json=None,
     output_npz=None,
     output_md=None,
+    original_table=None,
+    split_manifest=None,
     report_title="Product-Kalman Holdout Report",
     split_col="split",
     id_col="id",
@@ -165,6 +209,8 @@ def run_product_kalman_table_evaluation(
         input_manifest=input_manifest,
         output_npz=output_npz,
         output_md=output_md,
+        original_table=original_table,
+        split_manifest=split_manifest,
     )
     report_text = ""
     if output_md:
@@ -185,7 +231,10 @@ def _build_arg_parser():
     ap = argparse.ArgumentParser(
         description="Build Product-Kalman input artifacts from a table and run the holdout evaluator.",
     )
-    ap.add_argument("input_table", help="CSV/TSV table with split, prior, measurement, and target columns")
+    ap.add_argument(
+        "input_table",
+        help="CSV/TSV table with prior, measurement, target columns and either split labels or --split-unit-cols",
+    )
     ap.add_argument(
         "--output-dir",
         help="write a canonical artifact bundle here; explicit artifact paths override defaults",
@@ -196,6 +245,14 @@ def _build_arg_parser():
     ap.add_argument("--output-npz", help="write row-level prediction/covariance artifacts to this NPZ path")
     ap.add_argument("--output-md", help="write optional descriptive Markdown report here")
     ap.add_argument("--report-title", default="Product-Kalman Holdout Report")
+    ap.add_argument("--split-unit-cols", help="comma-separated columns whose values must not cross splits")
+    ap.add_argument("--split-output-table", help="write split-labeled table here before evaluation")
+    ap.add_argument("--split-output-manifest", help="write optional split-materialization manifest here")
+    ap.add_argument("--evaluation-unit-frac", type=float, default=0.30)
+    ap.add_argument("--split-seed", type=int, default=0)
+    ap.add_argument("--overwrite-split", action="store_true")
+    ap.add_argument("--min-calibration-rows", type=int, default=1)
+    ap.add_argument("--min-evaluation-rows", type=int, default=1)
     ap.add_argument("--prior-cols", required=True, help="comma-separated prior mean columns")
     ap.add_argument("--measurement-cols", required=True, help="comma-separated measurement columns")
     ap.add_argument("--target-cols", required=True, help="comma-separated target-state columns")
@@ -218,8 +275,26 @@ def main(argv=None):
     args = ap.parse_args(argv)
     paths = _resolve_cli_output_paths(ap, args)
     try:
+        input_table = args.input_table
+        if args.split_unit_cols:
+            split_product_kalman_table(
+                args.input_table,
+                paths["split_table"],
+                unit_cols=parse_column_list(args.split_unit_cols),
+                output_manifest=paths["split_manifest"],
+                split_col=args.split_col,
+                calibration_value=args.calibration_value,
+                evaluation_value=args.evaluation_value,
+                evaluation_unit_frac=args.evaluation_unit_frac,
+                seed=args.split_seed,
+                delimiter=args.delimiter,
+                overwrite_split=args.overwrite_split,
+                min_calibration_rows=args.min_calibration_rows,
+                min_evaluation_rows=args.min_evaluation_rows,
+            )
+            input_table = paths["split_table"]
         run = run_product_kalman_table_evaluation(
-            args.input_table,
+            input_table,
             paths["input_npz"],
             prior_cols=parse_column_list(args.prior_cols),
             measurement_cols=parse_column_list(args.measurement_cols),
@@ -228,6 +303,8 @@ def main(argv=None):
             output_json=paths["output_json"],
             output_npz=paths["output_npz"],
             output_md=paths["output_md"],
+            original_table=args.input_table if args.split_unit_cols else None,
+            split_manifest=paths["split_manifest"] if args.split_unit_cols else None,
             report_title=args.report_title,
             split_col=args.split_col,
             id_col=args.id_col or None,

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -17,6 +17,7 @@ import numpy as np
 from product_kalman_evaluation import run_product_kalman_holdout_npz
 from product_kalman_table_evaluation import (
     default_product_kalman_run_paths,
+    default_product_kalman_split_paths,
     main,
     run_product_kalman_table_evaluation,
 )
@@ -43,6 +44,25 @@ def write_table(path, delimiter=","):
             writer.writerow({
                 "split": split,
                 "id": f"{split}-{i}",
+                "prior": f"{prior[i, 0]:.17g}",
+                "measurement": f"{measurement[i, 0]:.17g}",
+                "target": f"{target[i, 0]:.17g}",
+            })
+
+
+def write_unsplit_unit_table(path, delimiter="	"):
+    prior, measurement, target, _ = synthetic_identity_split(n_cal=90, n_eval=30)
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["id", "unit", "prior", "measurement", "target"],
+            delimiter=delimiter,
+        )
+        writer.writeheader()
+        for i in range(len(target)):
+            writer.writerow({
+                "id": f"row-{i}",
+                "unit": f"unit-{i}",
                 "prior": f"{prior[i, 0]:.17g}",
                 "measurement": f"{measurement[i, 0]:.17g}",
                 "target": f"{target[i, 0]:.17g}",
@@ -139,6 +159,58 @@ def test_table_runner_output_dir_writes_canonical_bundle():
         assert summary["inputs"]["report_md"] == str(paths["output_md"])
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
         assert "# Product-Kalman Holdout Report" in paths["output_md"].read_text()
+
+
+def test_table_runner_output_dir_can_materialize_split_before_evaluation():
+    with tempfile.TemporaryDirectory() as tmp:
+        table = Path(tmp) / "unsplit.tsv"
+        output_dir = Path(tmp) / "product_kalman_run"
+        write_unsplit_unit_table(table, delimiter="	")
+
+        rc = main([
+            str(table),
+            "--output-dir",
+            str(output_dir),
+            "--split-unit-cols",
+            "unit",
+            "--evaluation-unit-frac",
+            "0.25",
+            "--split-seed",
+            "5",
+            "--prior-cols",
+            "prior",
+            "--measurement-cols",
+            "measurement",
+            "--target-cols",
+            "target",
+            "--jitter",
+            "1e-8",
+        ])
+
+        assert rc == 0
+        paths = default_product_kalman_run_paths(output_dir)
+        split_paths = default_product_kalman_split_paths(output_dir, input_table=table)
+        for path in list(paths.values()) + list(split_paths.values()):
+            assert path.exists(), path
+        assert split_paths["split_table"].name == "split_table.tsv"
+
+        summary = json.loads(paths["output_json"].read_text())
+        assert summary["inputs"]["source_table"] == str(split_paths["split_table"])
+        assert summary["inputs"]["original_table"] == str(table)
+        assert summary["inputs"]["split_manifest"] == str(split_paths["split_manifest"])
+        assert summary["inputs"]["input_manifest"] == str(paths["input_manifest"])
+        assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
+
+        split_manifest = json.loads(split_paths["split_manifest"].read_text())
+        assert split_manifest["source_table"]["path"] == str(table)
+        assert split_manifest["source_table"]["delimiter"] == "	"
+        assert split_manifest["output_table"]["path"] == str(split_paths["split_table"])
+        assert split_manifest["split"]["omitted_crossing_rows"] == 0
+        assert split_manifest["split"]["disjoint_observed_units"] is True
+        assert split_manifest["split"]["evaluation_rows"] == 30
+        input_manifest = json.loads(paths["input_manifest"].read_text())
+        assert input_manifest["source_table"]["path"] == str(split_paths["split_table"])
+        assert input_manifest["source_table"]["delimiter"] == "	"
 
 
 def test_table_runner_output_dir_allows_explicit_path_overrides():


### PR DESCRIPTION
## Summary
- add optional `--split-unit-cols` support to `product_kalman_table_evaluation.py`
- when used with `--output-dir`, write split artifacts into the run bundle:
  - `split_table.csv` or `split_table.tsv`
  - `split.manifest.json`
- evaluate the generated split table through the existing NPZ/report/scoring path
- record `original_table` and `split_manifest` in the score summary inputs
- keep explicit split artifact path overrides available for non-`--output-dir` usage
- update the Product-Kalman design note for the split-and-evaluate flow

## Tests
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/product_kalman_table_evaluation.py --help`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_split_table.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_split_table.py prototypes/mu_cosine/test_product_kalman_table_to_npz.py prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `git diff --check`