### PR TITLE
Render Product-Kalman split manifests in reports

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -384,9 +384,9 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
    zero-cross-covariance / correlated Product-Kalman predictions on a separate split, and keeps
    calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison pending.)*
-8. Use `product_kalman_report.py` to render the input manifest plus score JSON into a descriptive Markdown run
-   note. The report is an audit artifact only: it records scores and provenance, but does not encode a decision
-   rule or promote Product-Kalman without comparison against registered baselines.
+8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
+   descriptive Markdown run note. The report is an audit artifact only: it records scores and provenance, but does
+   not encode a decision rule or promote Product-Kalman without comparison against registered baselines.
 9. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
    Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
    residuals that set `R_ell` as the comparison set.
@@ -418,7 +418,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   artifacts-to-holdout-score/report runner, with optional split materialization and canonical `--output-dir` bundles
   for real-corpus Product-Kalman comparisons.
 - `product_kalman_report.py` and `test_product_kalman_report.py` — descriptive Markdown report generator for
-  Product-Kalman input manifests and score JSON artifacts.
+  Product-Kalman input manifests, optional split manifests, and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including JSON summaries
   and row-level NPZ artifacts for reproducible corpus-run diagnostics.

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -73,6 +73,8 @@ def _input_rows(scores_json, manifest):
     inputs = scores_json.get("inputs", {})
     rows = [
         ["source_table", inputs.get("source_table")],
+        ["original_table", inputs.get("original_table")],
+        ["split_manifest", inputs.get("split_manifest")],
         ["input_npz", inputs.get("input_npz")],
         ["input_manifest", inputs.get("input_manifest")],
         ["evaluation_npz", inputs.get("evaluation_npz")],
@@ -129,7 +131,37 @@ def _calibration_rows(scores_json):
     ]
 
 
-def build_product_kalman_markdown_report(scores_json, input_manifest=None, title="Product-Kalman Holdout Report"):
+def _split_materialization_rows(split_manifest):
+    if not split_manifest:
+        return []
+    source = split_manifest.get("source_table", {})
+    output = split_manifest.get("output_table", {})
+    split = split_manifest.get("split", {})
+    return [
+        ["source_table", source.get("path")],
+        ["source_table_sha256", source.get("sha256")],
+        ["output_table", output.get("path")],
+        ["output_table_sha256", output.get("sha256")],
+        ["seed", split.get("seed")],
+        ["evaluation_unit_frac", split.get("evaluation_unit_frac")],
+        ["unit_columns", ", ".join(split.get("unit_columns", []))],
+        ["sampled_evaluation_unit_count", split.get("sampled_evaluation_unit_count")],
+        ["observed_calibration_unit_count", split.get("observed_calibration_unit_count")],
+        ["observed_evaluation_unit_count", split.get("observed_evaluation_unit_count")],
+        ["observed_unit_overlap_count", split.get("observed_unit_overlap_count")],
+        ["disjoint_observed_units", split.get("disjoint_observed_units")],
+        ["calibration_rows", split.get("calibration_rows")],
+        ["evaluation_rows", split.get("evaluation_rows")],
+        ["omitted_crossing_rows", split.get("omitted_crossing_rows")],
+    ]
+
+
+def build_product_kalman_markdown_report(
+    scores_json,
+    input_manifest=None,
+    split_manifest=None,
+    title="Product-Kalman Holdout Report",
+):
     """Return a descriptive Markdown report for one Product-Kalman evaluation."""
     lines = [
         f"# {title}",
@@ -150,6 +182,13 @@ def build_product_kalman_markdown_report(scores_json, input_manifest=None, title
             "## Column Groups",
             "",
             _markdown_table(["group", "columns"], _column_rows(input_manifest)),
+            "",
+        ])
+    if split_manifest:
+        lines.extend([
+            "## Split Materialization",
+            "",
+            _markdown_table(["item", "value"], _split_materialization_rows(split_manifest)),
             "",
         ])
     lines.extend([
@@ -186,6 +225,7 @@ def _build_arg_parser():
     ap = argparse.ArgumentParser(description="Build a Markdown report from Product-Kalman JSON artifacts.")
     ap.add_argument("scores_json", help="JSON score summary from product_kalman_evaluation/table_evaluation")
     ap.add_argument("--input-manifest", help="optional input manifest JSON from product_kalman_table_to_npz")
+    ap.add_argument("--split-manifest", help="optional split manifest JSON from product_kalman_split_table")
     ap.add_argument("--output-md", help="write Markdown report here instead of stdout")
     ap.add_argument("--title", default="Product-Kalman Holdout Report")
     return ap
@@ -196,7 +236,8 @@ def main(argv=None):
     args = ap.parse_args(argv)
     scores = load_json(args.scores_json)
     manifest = load_json(args.input_manifest) if args.input_manifest else None
-    text = build_product_kalman_markdown_report(scores, manifest, title=args.title)
+    split_manifest = load_json(args.split_manifest) if args.split_manifest else None
+    text = build_product_kalman_markdown_report(scores, manifest, split_manifest=split_manifest, title=args.title)
     if args.output_md:
         write_markdown_report(args.output_md, text)
     else:

--- a/prototypes/mu_cosine/product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_table_evaluation.py
@@ -215,7 +215,13 @@ def run_product_kalman_table_evaluation(
     report_text = ""
     if output_md:
         manifest = load_json(input_manifest) if input_manifest else None
-        report_text = build_product_kalman_markdown_report(summary, manifest, title=report_title)
+        split_data = load_json(split_manifest) if split_manifest else None
+        report_text = build_product_kalman_markdown_report(
+            summary,
+            manifest,
+            split_manifest=split_data,
+            title=report_title,
+        )
         write_markdown_report(output_md, report_text)
     if output_json:
         _write_json(output_json, summary, indent=indent)

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -65,6 +65,34 @@ def make_artifacts(tmp):
     )
     return input_manifest, scores_json
 
+def split_manifest_fixture():
+    return {
+        "source_table": {
+            "path": "raw.tsv",
+            "sha256": "a" * 64,
+            "delimiter": "\t",
+            "rows": 120,
+        },
+        "output_table": {
+            "path": "split_table.tsv",
+            "sha256": "b" * 64,
+            "rows": 120,
+        },
+        "split": {
+            "seed": 5,
+            "evaluation_unit_frac": 0.25,
+            "unit_columns": ["unit"],
+            "sampled_evaluation_unit_count": 30,
+            "observed_calibration_unit_count": 90,
+            "observed_evaluation_unit_count": 30,
+            "observed_unit_overlap_count": 0,
+            "disjoint_observed_units": True,
+            "calibration_rows": 90,
+            "evaluation_rows": 30,
+            "omitted_crossing_rows": 0,
+        },
+    }
+
 
 def test_markdown_report_records_scores_and_guardrails():
     with tempfile.TemporaryDirectory() as tmp:
@@ -84,15 +112,41 @@ def test_markdown_report_records_scores_and_guardrails():
         assert "does not encode a decision rule" in report
         assert "should be compared against the registered joint-posterior" in report
 
+def test_markdown_report_records_split_materialization_manifest():
+    with tempfile.TemporaryDirectory() as tmp:
+        input_manifest, scores_json = make_artifacts(tmp)
+        scores = json.loads(scores_json.read_text())
+        manifest = json.loads(input_manifest.read_text())
+        scores["inputs"]["original_table"] = "raw.tsv"
+        scores["inputs"]["split_manifest"] = "split.manifest.json"
+        report = build_product_kalman_markdown_report(
+            scores,
+            manifest,
+            split_manifest=split_manifest_fixture(),
+            title="Split Product-Kalman Report",
+        )
+
+        assert "## Split Materialization" in report
+        assert "| original_table | raw.tsv |" in report
+        assert "| split_manifest | split.manifest.json |" in report
+        assert "| unit_columns | unit |" in report
+        assert "| observed_unit_overlap_count | 0 |" in report
+        assert "| disjoint_observed_units | True |" in report
+        assert "| omitted_crossing_rows | 0 |" in report
+
 
 def test_markdown_report_cli_writes_file():
     with tempfile.TemporaryDirectory() as tmp:
         input_manifest, scores_json = make_artifacts(tmp)
         output_md = Path(tmp) / "report.md"
+        split_manifest = Path(tmp) / "split.manifest.json"
+        split_manifest.write_text(json.dumps(split_manifest_fixture()), encoding="utf-8")
         rc = main([
             str(scores_json),
             "--input-manifest",
             str(input_manifest),
+            "--split-manifest",
+            str(split_manifest),
             "--output-md",
             str(output_md),
             "--title",
@@ -103,6 +157,7 @@ def test_markdown_report_cli_writes_file():
         assert "# CLI Product-Kalman Report" in text
         assert "## Scores" in text
         assert "## NLL Improvements" in text
+        assert "## Split Materialization" in text
         assert "source_table_sha256" in text
 
 

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -211,6 +211,11 @@ def test_table_runner_output_dir_can_materialize_split_before_evaluation():
         input_manifest = json.loads(paths["input_manifest"].read_text())
         assert input_manifest["source_table"]["path"] == str(split_paths["split_table"])
         assert input_manifest["source_table"]["delimiter"] == "	"
+        report = paths["output_md"].read_text()
+        assert "## Split Materialization" in report
+        assert "| original_table |" in report
+        assert "| split_manifest |" in report
+        assert "| omitted_crossing_rows | 0 |" in report
 
 
 def test_table_runner_output_dir_allows_explicit_path_overrides():


### PR DESCRIPTION
## Summary

- Add optional split-manifest support to `product_kalman_report.py`
- Include original table, split manifest path, split hashes, unit columns, disjointness, row counts, and omitted crossing rows in generated Markdown reports
- Thread split-manifest data through `product_kalman_table_evaluation.py` so canonical `--output-dir` runs render the split materialization audit trail
- Update Product-Kalman design notes and tests for the new report surface

## Tests

- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_report.py prototypes/mu_cosine/test_product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_split_table.py prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `git diff --cached --check`