### PR TITLE
Add Product-Kalman covariance calibration diagnostics

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -331,6 +331,7 @@ Treat this as a modeling hypothesis, not a paper claim. Compare on held-out node
 Report:
 
 - held-out log loss / NLL;
+- predicted-error scale diagnostics such as mean squared Mahalanobis and Mahalanobis-per-dimension;
 - ECE with stated bins;
 - AURC using margin gating with bootstrap confidence intervals;
 - ablations for model, graph, judge, product, and covariance terms;
@@ -382,8 +383,9 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    `product_kalman_table_to_npz.py` records source-table hash, split counts, column groups, dimensions, ID
    overlap/duplicate counts, and `H`
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
-   zero-cross-covariance / correlated Product-Kalman predictions on a separate split, and keeps
-   calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison pending.)*
+   zero-cross-covariance / correlated Product-Kalman predictions on a separate split, records NLL/MSE plus
+   Mahalanobis calibration-scale diagnostics, and keeps calibration/evaluation IDs disjoint. *(Synthetic harness
+   added; real-corpus comparison pending.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
    descriptive Markdown run note. The report is an audit artifact only: it records scores and provenance, but does
    not encode a decision rule or promote Product-Kalman without comparison against registered baselines.
@@ -420,7 +422,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 - `product_kalman_report.py` and `test_product_kalman_report.py` — descriptive Markdown report generator for
   Product-Kalman input manifests, optional split manifests, and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
-  prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including JSON summaries
-  and row-level NPZ artifacts for reproducible corpus-run diagnostics.
+  prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including NLL/MSE,
+  Mahalanobis predicted-error scale diagnostics, JSON summaries, and row-level NPZ artifacts for reproducible
+  corpus-run diagnostics.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -20,7 +20,7 @@ import sys
 import numpy as np
 
 try:
-    from .product_kalman import gaussian_nll
+    from .product_kalman import gaussian_nll, regularize_covariance
     from .product_kalman_calibration import (
         ProductKalmanCalibration,
         apply_product_kalman_calibration,
@@ -28,7 +28,7 @@ try:
         fit_product_kalman_calibration,
     )
 except ImportError:  # direct script execution from prototypes/mu_cosine
-    from product_kalman import gaussian_nll
+    from product_kalman import gaussian_nll, regularize_covariance
     from product_kalman_calibration import (
         ProductKalmanCalibration,
         apply_product_kalman_calibration,
@@ -78,6 +78,8 @@ class GaussianScore:
     mse: float
     n: int
     covariance_trace: float
+    mean_squared_mahalanobis: float
+    mahalanobis_per_dim: float
 
     def __post_init__(self):
         name = str(self.name)
@@ -85,18 +87,30 @@ class GaussianScore:
         mean_nll = float(self.mean_nll)
         mse = float(self.mse)
         covariance_trace = float(self.covariance_trace)
+        mean_squared_mahalanobis = float(self.mean_squared_mahalanobis)
+        mahalanobis_per_dim = float(self.mahalanobis_per_dim)
         if not name:
             raise ValueError("score name must be nonempty")
         if n <= 0:
             raise ValueError("score n must be positive")
-        for field, value in (("mean_nll", mean_nll), ("mse", mse), ("covariance_trace", covariance_trace)):
+        for field, value in (
+            ("mean_nll", mean_nll),
+            ("mse", mse),
+            ("covariance_trace", covariance_trace),
+            ("mean_squared_mahalanobis", mean_squared_mahalanobis),
+            ("mahalanobis_per_dim", mahalanobis_per_dim),
+        ):
             if not np.isfinite(value):
                 raise ValueError(f"{field} must be finite")
+        if mean_squared_mahalanobis < 0.0 or mahalanobis_per_dim < 0.0:
+            raise ValueError("Mahalanobis diagnostics must be nonnegative")
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "n", n)
         object.__setattr__(self, "mean_nll", mean_nll)
         object.__setattr__(self, "mse", mse)
         object.__setattr__(self, "covariance_trace", covariance_trace)
+        object.__setattr__(self, "mean_squared_mahalanobis", mean_squared_mahalanobis)
+        object.__setattr__(self, "mahalanobis_per_dim", mahalanobis_per_dim)
 
 
 @dataclass(frozen=True)
@@ -152,13 +166,19 @@ def score_gaussian_predictions(name, target_state, mean, covariance, jitter=1e-9
     cov = _as_covariance("covariance", covariance, target.shape[1])
     nll = [gaussian_nll(target[i], pred[i], cov, jitter=jitter) for i in range(target.shape[0])]
     residual = target - pred
+    score_cov = regularize_covariance(cov, jitter=jitter, name=f"{name} score covariance")
+    solved = np.linalg.solve(score_cov, residual.T).T
+    squared_mahalanobis = np.sum(residual * solved, axis=1)
     mse = float(np.mean(np.sum(residual * residual, axis=1)))
+    mean_squared_mahalanobis = float(np.mean(squared_mahalanobis))
     return GaussianScore(
         name=name,
         mean_nll=float(np.mean(nll)),
         mse=mse,
         n=int(target.shape[0]),
         covariance_trace=float(np.trace(cov)),
+        mean_squared_mahalanobis=mean_squared_mahalanobis,
+        mahalanobis_per_dim=mean_squared_mahalanobis / float(target.shape[1]),
     )
 
 
@@ -308,6 +328,11 @@ def evaluation_artifact_arrays(result):
         "score_mse": np.array([score.mse for score in result.scores], dtype=float),
         "score_n": np.array([score.n for score in result.scores], dtype=np.int64),
         "score_covariance_trace": np.array([score.covariance_trace for score in result.scores], dtype=float),
+        "score_mean_squared_mahalanobis": np.array(
+            [score.mean_squared_mahalanobis for score in result.scores],
+            dtype=float,
+        ),
+        "score_mahalanobis_per_dim": np.array([score.mahalanobis_per_dim for score in result.scores], dtype=float),
         "calibration_n_samples": np.array(result.calibration.n_samples, dtype=np.int64),
         "calibration_state_covariance": result.calibration.state_covariance,
         "calibration_observation_covariance": result.calibration.observation_covariance,
@@ -342,6 +367,8 @@ def _score_to_json_dict(score):
         "mse": score.mse,
         "n": score.n,
         "covariance_trace": score.covariance_trace,
+        "mean_squared_mahalanobis": score.mean_squared_mahalanobis,
+        "mahalanobis_per_dim": score.mahalanobis_per_dim,
     }
 
 

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -54,6 +54,8 @@ def _score_rows(scores_json):
             score.get("mse"),
             score.get("n"),
             score.get("covariance_trace"),
+            score.get("mean_squared_mahalanobis"),
+            score.get("mahalanobis_per_dim"),
         ])
     return rows
 
@@ -194,7 +196,18 @@ def build_product_kalman_markdown_report(
     lines.extend([
         "## Scores",
         "",
-        _markdown_table(["model", "mean_nll", "mse", "n", "covariance_trace"], _score_rows(scores_json)),
+        _markdown_table(
+            [
+                "model",
+                "mean_nll",
+                "mse",
+                "n",
+                "covariance_trace",
+                "mean_sq_mahalanobis",
+                "mahalanobis_per_dim",
+            ],
+            _score_rows(scores_json),
+        ),
         "",
         "## NLL Improvements",
         "",
@@ -207,6 +220,7 @@ def build_product_kalman_markdown_report(
         "## Guardrails",
         "",
         "- Positive NLL gain means the candidate had lower held-out mean NLL than the named baseline.",
+        "- For a well-scaled d-dimensional Gaussian prediction, mean squared Mahalanobis should be near d; the per-dimension value should be near 1.",
         "- Treat this as a held-out comparison artifact, not as a training-objective decision.",
         "- Product-Kalman should be compared against the registered joint-posterior and Sigma-conditioned baselines before promotion.",
         "- Calibration rows and evaluation rows must remain disjoint; any ID overlap or duplicate count above zero should block interpretation.",

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -69,6 +69,7 @@ def test_correlated_product_kalman_beats_zero_cross_control_on_heldout_nll():
     assert result.nll_improvement("prior", "product_kalman") > 0.85
     assert result.nll_improvement("independent_kalman", "product_kalman") > 0.12
     assert result.score("product_kalman").mse < result.score("independent_kalman").mse
+    assert 0.85 < result.score("product_kalman").mahalanobis_per_dim < 1.15
     assert result.correlated_update.mean.flags.writeable is False
     assert result.independent_update.mean.flags.writeable is False
 
@@ -141,6 +142,8 @@ def test_npz_runner_and_json_cli_roundtrip():
         data = evaluation_to_json_dict(result)
         assert data["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
         assert data["calibration"]["state_dim"] == 1
+        assert "mean_squared_mahalanobis" in data["scores"]["product_kalman"]
+        assert 0.85 < data["scores"]["product_kalman"]["mahalanobis_per_dim"] < 1.15
         assert data["nll_improvement_vs_prior"]["product_kalman"] > 0.85
         assert data["nll_improvement_vs_independent_kalman"]["product_kalman"] > 0.12
 
@@ -164,6 +167,7 @@ def test_npz_runner_and_json_cli_roundtrip():
         with np.load(artifact_path, allow_pickle=False) as artifact:
             assert int(artifact["schema_version"]) == 1
             assert artifact["score_names"].tolist() == data["score_order"]
+            assert artifact["score_mahalanobis_per_dim"].shape == (4,)
             assert artifact["product_kalman_mean"].shape == result.correlated_update.mean.shape
             np.testing.assert_allclose(artifact["product_kalman_mean"], result.correlated_update.mean)
             np.testing.assert_allclose(artifact["independent_kalman_mean"], result.independent_update.mean)
@@ -188,6 +192,8 @@ def test_evaluation_artifact_arrays_are_npz_ready():
     arrays = evaluation_artifact_arrays(result)
     assert arrays["score_names"].tolist() == ["prior", "measurement", "independent_kalman", "product_kalman"]
     assert arrays["score_mean_nll"].shape == (4,)
+    assert arrays["score_mean_squared_mahalanobis"].shape == (4,)
+    assert np.isfinite(arrays["score_mahalanobis_per_dim"]).all()
     assert arrays["product_kalman_innovation"].shape == eval_target.shape
     assert arrays["product_kalman_covariance"].shape == (1, 1)
     assert arrays["independent_kalman_gain"].shape == (1, 1)
@@ -241,6 +247,8 @@ def test_score_gaussian_predictions_validates_shapes_and_reports_mse():
     assert score.n == 2
     assert abs(score.mse - 0.25) < 1e-12
     assert score.covariance_trace == 0.25
+    assert abs(score.mean_squared_mahalanobis - 1.0) < 1e-12
+    assert abs(score.mahalanobis_per_dim - 1.0) < 1e-12
     assert_raises(score_gaussian_predictions, "bad", target[:, 0], mean, [[1.0]])
     assert_raises(score_gaussian_predictions, "bad", target, mean, [[1.0, 0.0]])
 

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -104,6 +104,8 @@ def test_markdown_report_records_scores_and_guardrails():
         assert report.startswith("# Synthetic Product-Kalman Report\n")
         assert "This report is descriptive" in report
         assert "| product_kalman |" in report
+        assert "mahalanobis_per_dim" in report
+        assert "mean_sq_mahalanobis" in report
         assert "| prior | product_kalman |" in report
         assert "| calibration_rows | 80 |" in report
         assert "| evaluation_rows | 40 |" in report
@@ -156,6 +158,7 @@ def test_markdown_report_cli_writes_file():
         text = output_md.read_text()
         assert "# CLI Product-Kalman Report" in text
         assert "## Scores" in text
+        assert "mahalanobis_per_dim" in text
         assert "## NLL Improvements" in text
         assert "## Split Materialization" in text
         assert "source_table_sha256" in text

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -109,6 +109,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert summary["inputs"]["evaluation_npz"] == str(output_npz)
         assert summary["inputs"]["report_md"] == str(output_md)
         assert summary["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
+        assert "mahalanobis_per_dim" in summary["scores"]["product_kalman"]
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
 
         manifest = json.loads(input_manifest.read_text())
@@ -119,11 +120,13 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert report == run.report_text
         assert "# Synthetic Table Product-Kalman Report" in report
         assert "## Scores" in report
+        assert "mahalanobis_per_dim" in report
         assert "source_table_sha256" in report
 
         with np.load(output_npz, allow_pickle=False) as artifact:
             assert artifact["product_kalman_mean"].shape == (40, 1)
             assert artifact["score_names"].tolist() == summary["score_order"]
+            assert artifact["score_mahalanobis_per_dim"].shape == (4,)
 
 
 def test_table_runner_output_dir_writes_canonical_bundle():


### PR DESCRIPTION
## Summary

- Add mean squared Mahalanobis and per-dimension Mahalanobis diagnostics to Product-Kalman Gaussian scores
- Expose the diagnostics in JSON summaries, NPZ evaluation artifacts, and Markdown reports
- Document the diagnostic as a predicted-error scale check, not a promotion criterion
- Extend evaluation/report/table-runner tests for the new score fields

## Tests

- `python3 -m py_compile prototypes/mu_cosine/product_kalman_evaluation.py prototypes/mu_cosine/product_kalman_report.py prototypes/mu_cosine/test_product_kalman_evaluation.py prototypes/mu_cosine/test_product_kalman_report.py prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_evaluation.py prototypes/mu_cosine/test_product_kalman_report.py prototypes/mu_cosine/test_product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_table_to_npz.py prototypes/mu_cosine/test_product_kalman_split_table.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `git diff --check`