### PR TITLE
Report Product-Kalman Mahalanobis tail diagnostics

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -331,7 +331,8 @@ Treat this as a modeling hypothesis, not a paper claim. Compare on held-out node
 Report:
 
 - held-out log loss / NLL;
-- predicted-error scale diagnostics such as mean squared Mahalanobis and Mahalanobis-per-dimension;
+- predicted-error scale diagnostics such as mean squared Mahalanobis, Mahalanobis-per-dimension, and empirical
+  squared-Mahalanobis tail quantiles;
 - ECE with stated bins;
 - AURC using margin gating with bootstrap confidence intervals;
 - ablations for model, graph, judge, product, and covariance terms;
@@ -384,8 +385,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    overlap/duplicate counts, and `H`
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
    zero-cross-covariance / correlated Product-Kalman predictions on a separate split, records NLL/MSE plus
-   Mahalanobis calibration-scale diagnostics, and keeps calibration/evaluation IDs disjoint. *(Synthetic harness
-   added; real-corpus comparison pending.)*
+   Mahalanobis calibration-scale and tail diagnostics, and keeps calibration/evaluation IDs disjoint. *(Synthetic
+   harness added; real-corpus comparison pending.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
    descriptive Markdown run note. The report is an audit artifact only: it records scores and provenance, but does
    not encode a decision rule or promote Product-Kalman without comparison against registered baselines.
@@ -423,7 +424,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   Product-Kalman input manifests, optional split manifests, and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including NLL/MSE,
-  Mahalanobis predicted-error scale diagnostics, JSON summaries, and row-level NPZ artifacts for reproducible
+  Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, and row-level NPZ artifacts for reproducible
   corpus-run diagnostics.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -80,6 +80,9 @@ class GaussianScore:
     covariance_trace: float
     mean_squared_mahalanobis: float
     mahalanobis_per_dim: float
+    squared_mahalanobis_q50: float
+    squared_mahalanobis_q90: float
+    squared_mahalanobis_q95: float
 
     def __post_init__(self):
         name = str(self.name)
@@ -89,6 +92,9 @@ class GaussianScore:
         covariance_trace = float(self.covariance_trace)
         mean_squared_mahalanobis = float(self.mean_squared_mahalanobis)
         mahalanobis_per_dim = float(self.mahalanobis_per_dim)
+        squared_mahalanobis_q50 = float(self.squared_mahalanobis_q50)
+        squared_mahalanobis_q90 = float(self.squared_mahalanobis_q90)
+        squared_mahalanobis_q95 = float(self.squared_mahalanobis_q95)
         if not name:
             raise ValueError("score name must be nonempty")
         if n <= 0:
@@ -99,11 +105,25 @@ class GaussianScore:
             ("covariance_trace", covariance_trace),
             ("mean_squared_mahalanobis", mean_squared_mahalanobis),
             ("mahalanobis_per_dim", mahalanobis_per_dim),
+            ("squared_mahalanobis_q50", squared_mahalanobis_q50),
+            ("squared_mahalanobis_q90", squared_mahalanobis_q90),
+            ("squared_mahalanobis_q95", squared_mahalanobis_q95),
         ):
             if not np.isfinite(value):
                 raise ValueError(f"{field} must be finite")
-        if mean_squared_mahalanobis < 0.0 or mahalanobis_per_dim < 0.0:
+        if any(
+            value < 0.0
+            for value in (
+                mean_squared_mahalanobis,
+                mahalanobis_per_dim,
+                squared_mahalanobis_q50,
+                squared_mahalanobis_q90,
+                squared_mahalanobis_q95,
+            )
+        ):
             raise ValueError("Mahalanobis diagnostics must be nonnegative")
+        if not squared_mahalanobis_q50 <= squared_mahalanobis_q90 <= squared_mahalanobis_q95:
+            raise ValueError("Mahalanobis quantiles must be ordered")
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "n", n)
         object.__setattr__(self, "mean_nll", mean_nll)
@@ -111,6 +131,9 @@ class GaussianScore:
         object.__setattr__(self, "covariance_trace", covariance_trace)
         object.__setattr__(self, "mean_squared_mahalanobis", mean_squared_mahalanobis)
         object.__setattr__(self, "mahalanobis_per_dim", mahalanobis_per_dim)
+        object.__setattr__(self, "squared_mahalanobis_q50", squared_mahalanobis_q50)
+        object.__setattr__(self, "squared_mahalanobis_q90", squared_mahalanobis_q90)
+        object.__setattr__(self, "squared_mahalanobis_q95", squared_mahalanobis_q95)
 
 
 @dataclass(frozen=True)
@@ -171,6 +194,7 @@ def score_gaussian_predictions(name, target_state, mean, covariance, jitter=1e-9
     squared_mahalanobis = np.sum(residual * solved, axis=1)
     mse = float(np.mean(np.sum(residual * residual, axis=1)))
     mean_squared_mahalanobis = float(np.mean(squared_mahalanobis))
+    q50, q90, q95 = [float(q) for q in np.quantile(squared_mahalanobis, [0.50, 0.90, 0.95])]
     return GaussianScore(
         name=name,
         mean_nll=float(np.mean(nll)),
@@ -179,6 +203,9 @@ def score_gaussian_predictions(name, target_state, mean, covariance, jitter=1e-9
         covariance_trace=float(np.trace(cov)),
         mean_squared_mahalanobis=mean_squared_mahalanobis,
         mahalanobis_per_dim=mean_squared_mahalanobis / float(target.shape[1]),
+        squared_mahalanobis_q50=q50,
+        squared_mahalanobis_q90=q90,
+        squared_mahalanobis_q95=q95,
     )
 
 
@@ -333,6 +360,18 @@ def evaluation_artifact_arrays(result):
             dtype=float,
         ),
         "score_mahalanobis_per_dim": np.array([score.mahalanobis_per_dim for score in result.scores], dtype=float),
+        "score_squared_mahalanobis_q50": np.array(
+            [score.squared_mahalanobis_q50 for score in result.scores],
+            dtype=float,
+        ),
+        "score_squared_mahalanobis_q90": np.array(
+            [score.squared_mahalanobis_q90 for score in result.scores],
+            dtype=float,
+        ),
+        "score_squared_mahalanobis_q95": np.array(
+            [score.squared_mahalanobis_q95 for score in result.scores],
+            dtype=float,
+        ),
         "calibration_n_samples": np.array(result.calibration.n_samples, dtype=np.int64),
         "calibration_state_covariance": result.calibration.state_covariance,
         "calibration_observation_covariance": result.calibration.observation_covariance,
@@ -369,6 +408,9 @@ def _score_to_json_dict(score):
         "covariance_trace": score.covariance_trace,
         "mean_squared_mahalanobis": score.mean_squared_mahalanobis,
         "mahalanobis_per_dim": score.mahalanobis_per_dim,
+        "squared_mahalanobis_q50": score.squared_mahalanobis_q50,
+        "squared_mahalanobis_q90": score.squared_mahalanobis_q90,
+        "squared_mahalanobis_q95": score.squared_mahalanobis_q95,
     }
 
 

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -56,6 +56,9 @@ def _score_rows(scores_json):
             score.get("covariance_trace"),
             score.get("mean_squared_mahalanobis"),
             score.get("mahalanobis_per_dim"),
+            score.get("squared_mahalanobis_q50"),
+            score.get("squared_mahalanobis_q90"),
+            score.get("squared_mahalanobis_q95"),
         ])
     return rows
 
@@ -205,6 +208,9 @@ def build_product_kalman_markdown_report(
                 "covariance_trace",
                 "mean_sq_mahalanobis",
                 "mahalanobis_per_dim",
+                "sq_mahalanobis_q50",
+                "sq_mahalanobis_q90",
+                "sq_mahalanobis_q95",
             ],
             _score_rows(scores_json),
         ),
@@ -220,7 +226,7 @@ def build_product_kalman_markdown_report(
         "## Guardrails",
         "",
         "- Positive NLL gain means the candidate had lower held-out mean NLL than the named baseline.",
-        "- For a well-scaled d-dimensional Gaussian prediction, mean squared Mahalanobis should be near d; the per-dimension value should be near 1.",
+        "- For a well-scaled d-dimensional Gaussian prediction, mean squared Mahalanobis should be near d; the per-dimension value should be near 1, with tail quantiles read as empirical diagnostics rather than a decision rule.",
         "- Treat this as a held-out comparison artifact, not as a training-objective decision.",
         "- Product-Kalman should be compared against the registered joint-posterior and Sigma-conditioned baselines before promotion.",
         "- Calibration rows and evaluation rows must remain disjoint; any ID overlap or duplicate count above zero should block interpretation.",

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -70,6 +70,9 @@ def test_correlated_product_kalman_beats_zero_cross_control_on_heldout_nll():
     assert result.nll_improvement("independent_kalman", "product_kalman") > 0.12
     assert result.score("product_kalman").mse < result.score("independent_kalman").mse
     assert 0.85 < result.score("product_kalman").mahalanobis_per_dim < 1.15
+    product_score = result.score("product_kalman")
+    assert product_score.squared_mahalanobis_q50 <= product_score.squared_mahalanobis_q90
+    assert product_score.squared_mahalanobis_q90 <= product_score.squared_mahalanobis_q95
     assert result.correlated_update.mean.flags.writeable is False
     assert result.independent_update.mean.flags.writeable is False
 
@@ -143,6 +146,7 @@ def test_npz_runner_and_json_cli_roundtrip():
         assert data["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
         assert data["calibration"]["state_dim"] == 1
         assert "mean_squared_mahalanobis" in data["scores"]["product_kalman"]
+        assert "squared_mahalanobis_q95" in data["scores"]["product_kalman"]
         assert 0.85 < data["scores"]["product_kalman"]["mahalanobis_per_dim"] < 1.15
         assert data["nll_improvement_vs_prior"]["product_kalman"] > 0.85
         assert data["nll_improvement_vs_independent_kalman"]["product_kalman"] > 0.12
@@ -168,6 +172,7 @@ def test_npz_runner_and_json_cli_roundtrip():
             assert int(artifact["schema_version"]) == 1
             assert artifact["score_names"].tolist() == data["score_order"]
             assert artifact["score_mahalanobis_per_dim"].shape == (4,)
+            assert artifact["score_squared_mahalanobis_q95"].shape == (4,)
             assert artifact["product_kalman_mean"].shape == result.correlated_update.mean.shape
             np.testing.assert_allclose(artifact["product_kalman_mean"], result.correlated_update.mean)
             np.testing.assert_allclose(artifact["independent_kalman_mean"], result.independent_update.mean)
@@ -193,6 +198,9 @@ def test_evaluation_artifact_arrays_are_npz_ready():
     assert arrays["score_names"].tolist() == ["prior", "measurement", "independent_kalman", "product_kalman"]
     assert arrays["score_mean_nll"].shape == (4,)
     assert arrays["score_mean_squared_mahalanobis"].shape == (4,)
+    assert arrays["score_squared_mahalanobis_q50"].shape == (4,)
+    assert arrays["score_squared_mahalanobis_q90"].shape == (4,)
+    assert arrays["score_squared_mahalanobis_q95"].shape == (4,)
     assert np.isfinite(arrays["score_mahalanobis_per_dim"]).all()
     assert arrays["product_kalman_innovation"].shape == eval_target.shape
     assert arrays["product_kalman_covariance"].shape == (1, 1)
@@ -249,6 +257,9 @@ def test_score_gaussian_predictions_validates_shapes_and_reports_mse():
     assert score.covariance_trace == 0.25
     assert abs(score.mean_squared_mahalanobis - 1.0) < 1e-12
     assert abs(score.mahalanobis_per_dim - 1.0) < 1e-12
+    assert abs(score.squared_mahalanobis_q50 - 1.0) < 1e-12
+    assert abs(score.squared_mahalanobis_q90 - 1.0) < 1e-12
+    assert abs(score.squared_mahalanobis_q95 - 1.0) < 1e-12
     assert_raises(score_gaussian_predictions, "bad", target[:, 0], mean, [[1.0]])
     assert_raises(score_gaussian_predictions, "bad", target, mean, [[1.0, 0.0]])
 

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -106,6 +106,7 @@ def test_markdown_report_records_scores_and_guardrails():
         assert "| product_kalman |" in report
         assert "mahalanobis_per_dim" in report
         assert "mean_sq_mahalanobis" in report
+        assert "sq_mahalanobis_q95" in report
         assert "| prior | product_kalman |" in report
         assert "| calibration_rows | 80 |" in report
         assert "| evaluation_rows | 40 |" in report
@@ -159,6 +160,7 @@ def test_markdown_report_cli_writes_file():
         assert "# CLI Product-Kalman Report" in text
         assert "## Scores" in text
         assert "mahalanobis_per_dim" in text
+        assert "sq_mahalanobis_q95" in text
         assert "## NLL Improvements" in text
         assert "## Split Materialization" in text
         assert "source_table_sha256" in text

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -110,6 +110,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert summary["inputs"]["report_md"] == str(output_md)
         assert summary["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
         assert "mahalanobis_per_dim" in summary["scores"]["product_kalman"]
+        assert "squared_mahalanobis_q95" in summary["scores"]["product_kalman"]
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
 
         manifest = json.loads(input_manifest.read_text())
@@ -121,12 +122,14 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert "# Synthetic Table Product-Kalman Report" in report
         assert "## Scores" in report
         assert "mahalanobis_per_dim" in report
+        assert "sq_mahalanobis_q95" in report
         assert "source_table_sha256" in report
 
         with np.load(output_npz, allow_pickle=False) as artifact:
             assert artifact["product_kalman_mean"].shape == (40, 1)
             assert artifact["score_names"].tolist() == summary["score_order"]
             assert artifact["score_mahalanobis_per_dim"].shape == (4,)
+            assert artifact["score_squared_mahalanobis_q95"].shape == (4,)
 
 
 def test_table_runner_output_dir_writes_canonical_bundle():


### PR DESCRIPTION
## Summary

- Add empirical squared-Mahalanobis q50/q90/q95 fields to Product-Kalman Gaussian scores
- Expose the tail diagnostics in JSON summaries, NPZ score arrays, and Markdown reports
- Keep the report language descriptive: tail quantiles are diagnostics, not a decision rule
- Update Product-Kalman design notes and artifact-facing tests

## Tests

- `python3 -m py_compile prototypes/mu_cosine/product_kalman_evaluation.py prototypes/mu_cosine/product_kalman_report.py prototypes/mu_cosine/test_product_kalman_evaluation.py prototypes/mu_cosine/test_product_kalman_report.py prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 -m pytest -q -s prototypes/mu_cosine/test_product_kalman_evaluation.py prototypes/mu_cosine/test_product_kalman_report.py prototypes/mu_cosine/test_product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_table_to_npz.py prototypes/mu_cosine/test_product_kalman_split_table.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `git diff --check`