### PR TITLE
Add Product-Kalman paired NLL bootstrap intervals

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -384,9 +384,9 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    `product_kalman_table_to_npz.py` records source-table hash, split counts, column groups, dimensions, ID
    overlap/duplicate counts, and `H`
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
-   zero-cross-covariance / correlated Product-Kalman predictions on a separate split, records NLL/MSE plus
-   Mahalanobis calibration-scale and tail diagnostics, and keeps calibration/evaluation IDs disjoint. *(Synthetic
-   harness added; real-corpus comparison pending.)*
+   zero-cross-covariance / correlated Product-Kalman predictions on a separate split, records aggregate NLL/MSE,
+   Mahalanobis calibration-scale/tail diagnostics, and row-level score vectors for bootstrap or plot diagnostics, and
+   keeps calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison pending.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
    descriptive Markdown run note. The report is an audit artifact only: it records scores and provenance, but does
    not encode a decision rule or promote Product-Kalman without comparison against registered baselines.
@@ -424,7 +424,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   Product-Kalman input manifests, optional split manifests, and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including NLL/MSE,
-  Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, and row-level NPZ artifacts for reproducible
-  corpus-run diagnostics.
+  Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, and row-level NPZ score artifacts for
+  reproducible bootstrap/tail diagnostics.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -330,7 +330,7 @@ Treat this as a modeling hypothesis, not a paper claim. Compare on held-out node
 
 Report:
 
-- held-out log loss / NLL;
+- held-out log loss / NLL, with paired row-resampling intervals when row-score artifacts are available;
 - predicted-error scale diagnostics such as mean squared Mahalanobis, Mahalanobis-per-dimension, and empirical
   squared-Mahalanobis tail quantiles;
 - ECE with stated bins;
@@ -385,8 +385,9 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    overlap/duplicate counts, and `H`
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
    zero-cross-covariance / correlated Product-Kalman predictions on a separate split, records aggregate NLL/MSE,
-   Mahalanobis calibration-scale/tail diagnostics, and row-level score vectors for bootstrap or plot diagnostics, and
-   keeps calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison pending.)*
+   Mahalanobis calibration-scale/tail diagnostics, row-level score vectors, and optional paired bootstrap intervals
+   for NLL gains, and keeps calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison
+   pending.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
    descriptive Markdown run note. The report is an audit artifact only: it records scores and provenance, but does
    not encode a decision rule or promote Product-Kalman without comparison against registered baselines.

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -39,11 +39,13 @@ except ImportError:  # direct script execution from prototypes/mu_cosine
 
 __all__ = [
     "GaussianScore",
+    "GaussianScoreVectors",
     "ProductKalmanHoldoutEvaluation",
     "evaluate_product_kalman_holdout",
     "evaluation_artifact_arrays",
     "evaluation_to_json_dict",
     "run_product_kalman_holdout_npz",
+    "score_gaussian_prediction_vectors",
     "score_gaussian_predictions",
     "write_evaluation_npz",
 ]
@@ -67,6 +69,20 @@ def _as_covariance(name, value, dim):
     if not np.isfinite(cov).all():
         raise ValueError(f"{name} must be finite")
     return 0.5 * (cov + cov.T)
+
+
+def _readonly_vector(name, value, n=None):
+    arr = np.array(value, dtype=float, copy=True)
+    if arr.ndim != 1:
+        raise ValueError(f"{name} must be a 1-D row-score vector")
+    if arr.size == 0:
+        raise ValueError(f"{name} must be nonempty")
+    if n is not None and arr.size != n:
+        raise ValueError(f"{name} length {arr.size} must match {n}")
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} must be finite")
+    arr.setflags(write=False)
+    return arr
 
 
 @dataclass(frozen=True)
@@ -137,6 +153,43 @@ class GaussianScore:
 
 
 @dataclass(frozen=True)
+class GaussianScoreVectors:
+    """Per-row Gaussian score diagnostics for one prediction family."""
+
+    name: str
+    nll: np.ndarray
+    squared_error: np.ndarray
+    squared_mahalanobis: np.ndarray
+    dimension: int
+
+    def __post_init__(self):
+        name = str(self.name)
+        if not name:
+            raise ValueError("score-vector name must be nonempty")
+        nll = _readonly_vector("nll", self.nll)
+        squared_error = _readonly_vector("squared_error", self.squared_error, n=nll.size)
+        squared_mahalanobis = _readonly_vector(
+            "squared_mahalanobis",
+            self.squared_mahalanobis,
+            n=nll.size,
+        )
+        dimension = int(self.dimension)
+        if dimension <= 0:
+            raise ValueError("score-vector dimension must be positive")
+        if (squared_error < 0.0).any() or (squared_mahalanobis < 0.0).any():
+            raise ValueError("row score diagnostics must be nonnegative except nll")
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "nll", nll)
+        object.__setattr__(self, "squared_error", squared_error)
+        object.__setattr__(self, "squared_mahalanobis", squared_mahalanobis)
+        object.__setattr__(self, "dimension", dimension)
+
+    @property
+    def n(self):
+        return int(self.nll.size)
+
+
+@dataclass(frozen=True)
 class ProductKalmanHoldoutEvaluation:
     """One calibration/evaluation split comparison.
 
@@ -151,6 +204,7 @@ class ProductKalmanHoldoutEvaluation:
     correlated_update: object
     independent_update: object
     scores: tuple
+    score_vectors: tuple = ()
 
     def __post_init__(self):
         if not isinstance(self.calibration, ProductKalmanCalibration):
@@ -158,10 +212,25 @@ class ProductKalmanHoldoutEvaluation:
         if not isinstance(self.independent_calibration, ProductKalmanCalibration):
             raise ValueError("independent_calibration must be a ProductKalmanCalibration")
         scores = tuple(self.scores)
+        for score in scores:
+            if not isinstance(score, GaussianScore):
+                raise ValueError("scores must contain GaussianScore objects")
         names = [s.name for s in scores]
         if len(names) != len(set(names)):
             raise ValueError("score names must be unique")
+        score_vectors = tuple(self.score_vectors)
+        if score_vectors:
+            for vector in score_vectors:
+                if not isinstance(vector, GaussianScoreVectors):
+                    raise ValueError("score_vectors must contain GaussianScoreVectors objects")
+            vector_names = [v.name for v in score_vectors]
+            if vector_names != names:
+                raise ValueError("score_vectors must appear in the same order as scores")
+            for score, vector in zip(scores, score_vectors):
+                if vector.n != score.n:
+                    raise ValueError("score vector length must match score n")
         object.__setattr__(self, "scores", scores)
+        object.__setattr__(self, "score_vectors", score_vectors)
 
     def score(self, name):
         """Return the named `GaussianScore`."""
@@ -170,13 +239,20 @@ class ProductKalmanHoldoutEvaluation:
                 return score
         raise KeyError(name)
 
+    def score_vector(self, name):
+        """Return the named per-row score vectors."""
+        for vector in self.score_vectors:
+            if vector.name == name:
+                return vector
+        raise KeyError(name)
+
     def nll_improvement(self, baseline, candidate):
         """Positive means `candidate` has lower mean NLL than `baseline`."""
         return self.score(baseline).mean_nll - self.score(candidate).mean_nll
 
 
-def score_gaussian_predictions(name, target_state, mean, covariance, jitter=1e-9):
-    """Score row-wise Gaussian predictions against held-out target states.
+def score_gaussian_prediction_vectors(name, target_state, mean, covariance, jitter=1e-9):
+    """Return per-row Gaussian score vectors against held-out target states.
 
     `target_state` and `mean` must be `(n, d)` row matrices. `covariance` is one
     shared `(d, d)` covariance for the prediction family, matching the current
@@ -187,26 +263,41 @@ def score_gaussian_predictions(name, target_state, mean, covariance, jitter=1e-9
     if pred.shape != target.shape:
         raise ValueError(f"mean shape {pred.shape} must match target_state shape {target.shape}")
     cov = _as_covariance("covariance", covariance, target.shape[1])
-    nll = [gaussian_nll(target[i], pred[i], cov, jitter=jitter) for i in range(target.shape[0])]
+    nll = np.array([gaussian_nll(target[i], pred[i], cov, jitter=jitter) for i in range(target.shape[0])])
     residual = target - pred
     score_cov = regularize_covariance(cov, jitter=jitter, name=f"{name} score covariance")
     solved = np.linalg.solve(score_cov, residual.T).T
-    squared_mahalanobis = np.sum(residual * solved, axis=1)
-    mse = float(np.mean(np.sum(residual * residual, axis=1)))
-    mean_squared_mahalanobis = float(np.mean(squared_mahalanobis))
-    q50, q90, q95 = [float(q) for q in np.quantile(squared_mahalanobis, [0.50, 0.90, 0.95])]
-    return GaussianScore(
+    return GaussianScoreVectors(
         name=name,
-        mean_nll=float(np.mean(nll)),
-        mse=mse,
-        n=int(target.shape[0]),
+        nll=nll,
+        squared_error=np.sum(residual * residual, axis=1),
+        squared_mahalanobis=np.sum(residual * solved, axis=1),
+        dimension=target.shape[1],
+    )
+
+
+def _score_from_vectors(vectors, covariance):
+    cov = _as_covariance("covariance", covariance, vectors.dimension)
+    mean_squared_mahalanobis = float(np.mean(vectors.squared_mahalanobis))
+    q50, q90, q95 = [float(q) for q in np.quantile(vectors.squared_mahalanobis, [0.50, 0.90, 0.95])]
+    return GaussianScore(
+        name=vectors.name,
+        mean_nll=float(np.mean(vectors.nll)),
+        mse=float(np.mean(vectors.squared_error)),
+        n=vectors.n,
         covariance_trace=float(np.trace(cov)),
         mean_squared_mahalanobis=mean_squared_mahalanobis,
-        mahalanobis_per_dim=mean_squared_mahalanobis / float(target.shape[1]),
+        mahalanobis_per_dim=mean_squared_mahalanobis / float(vectors.dimension),
         squared_mahalanobis_q50=q50,
         squared_mahalanobis_q90=q90,
         squared_mahalanobis_q95=q95,
     )
+
+
+def score_gaussian_predictions(name, target_state, mean, covariance, jitter=1e-9):
+    """Return aggregate Gaussian prediction scores for one held-out split."""
+    vectors = score_gaussian_prediction_vectors(name, target_state, mean, covariance, jitter=jitter)
+    return _score_from_vectors(vectors, covariance)
 
 
 def _check_split_ids(calibration_ids, evaluation_ids, n_calibration, n_evaluation):
@@ -291,34 +382,22 @@ def evaluate_product_kalman_holdout(
     correlated_update = apply_product_kalman_calibration(calibration, eval_prior, eval_measure, jitter=jitter)
     independent_update = apply_product_kalman_calibration(independent, eval_prior, eval_measure, jitter=jitter)
 
-    scores = [
-        score_gaussian_predictions("prior", eval_target, eval_prior, calibration.state_covariance, jitter=jitter),
-        score_gaussian_predictions(
-            "independent_kalman",
-            eval_target,
-            independent_update.mean,
-            independent_update.covariance,
-            jitter=jitter,
-        ),
-        score_gaussian_predictions(
-            "product_kalman",
-            eval_target,
-            correlated_update.mean,
-            correlated_update.covariance,
-            jitter=jitter,
-        ),
+    score_inputs = [
+        ("prior", eval_prior, calibration.state_covariance),
+        ("independent_kalman", independent_update.mean, independent_update.covariance),
+        ("product_kalman", correlated_update.mean, correlated_update.covariance),
     ]
     if _has_identity_observation(calibration):
-        scores.insert(
-            1,
-            score_gaussian_predictions(
-                "measurement",
-                eval_target,
-                eval_measure,
-                calibration.observation_covariance,
-                jitter=jitter,
-            ),
-        )
+        score_inputs.insert(1, ("measurement", eval_measure, calibration.observation_covariance))
+
+    score_vectors = [
+        score_gaussian_prediction_vectors(name, eval_target, mean, covariance, jitter=jitter)
+        for name, mean, covariance in score_inputs
+    ]
+    scores = [
+        _score_from_vectors(vectors, covariance)
+        for vectors, (_, _, covariance) in zip(score_vectors, score_inputs)
+    ]
 
     return ProductKalmanHoldoutEvaluation(
         calibration=calibration,
@@ -326,6 +405,7 @@ def evaluate_product_kalman_holdout(
         correlated_update=correlated_update,
         independent_update=independent_update,
         scores=tuple(scores),
+        score_vectors=tuple(score_vectors),
     )
 
 
@@ -379,6 +459,15 @@ def evaluation_artifact_arrays(result):
         "calibration_H": result.calibration.H,
         "independent_cross_covariance": result.independent_calibration.cross_covariance,
     }
+    if result.score_vectors:
+        arrays.update({
+            "score_row_nll": np.vstack([vectors.nll for vectors in result.score_vectors]),
+            "score_row_squared_error": np.vstack([vectors.squared_error for vectors in result.score_vectors]),
+            "score_row_squared_mahalanobis": np.vstack([
+                vectors.squared_mahalanobis
+                for vectors in result.score_vectors
+            ]),
+        })
     arrays.update(_prefix_update_arrays("product_kalman", result.correlated_update))
     arrays.update(_prefix_update_arrays("independent_kalman", result.independent_update))
     return arrays

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -44,6 +44,7 @@ __all__ = [
     "evaluate_product_kalman_holdout",
     "evaluation_artifact_arrays",
     "evaluation_to_json_dict",
+    "paired_bootstrap_nll_improvement",
     "run_product_kalman_holdout_npz",
     "score_gaussian_prediction_vectors",
     "score_gaussian_predictions",
@@ -249,6 +250,58 @@ class ProductKalmanHoldoutEvaluation:
     def nll_improvement(self, baseline, candidate):
         """Positive means `candidate` has lower mean NLL than `baseline`."""
         return self.score(baseline).mean_nll - self.score(candidate).mean_nll
+
+
+def _bootstrap_settings(n_boot, seed, confidence):
+    if isinstance(n_boot, bool) or not isinstance(n_boot, (int, np.integer)):
+        raise ValueError("n_boot must be a nonnegative integer")
+    n_boot = int(n_boot)
+    if n_boot < 0:
+        raise ValueError("n_boot must be nonnegative")
+    if isinstance(seed, bool) or not isinstance(seed, (int, np.integer)):
+        raise ValueError("seed must be an integer")
+    seed = int(seed)
+    confidence = float(confidence)
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be in (0, 1)")
+    return n_boot, seed, confidence
+
+
+def paired_bootstrap_nll_improvement(result, baseline, candidate, n_boot=1000, seed=0, confidence=0.95):
+    """Paired bootstrap CI for mean NLL gain, `baseline - candidate`.
+
+    Rows are resampled with replacement from the shared evaluation split, preserving
+    the paired comparison between two prediction families. Positive gain means the
+    candidate has lower held-out NLL than the baseline.
+    """
+    n_boot, seed, confidence = _bootstrap_settings(n_boot, seed, confidence)
+    if n_boot <= 0:
+        raise ValueError("n_boot must be positive for a bootstrap interval")
+    baseline_vec = result.score_vector(baseline)
+    candidate_vec = result.score_vector(candidate)
+    if baseline_vec.n != candidate_vec.n:
+        raise ValueError("baseline and candidate row-score vectors must have the same length")
+    diff = baseline_vec.nll - candidate_vec.nll
+    rng = np.random.default_rng(seed)
+    boot = np.empty(n_boot, dtype=float)
+    for i in range(n_boot):
+        idx = rng.integers(0, diff.size, size=diff.size)
+        boot[i] = float(np.mean(diff[idx]))
+    alpha = (1.0 - confidence) / 2.0
+    ci_low, ci_high = [float(x) for x in np.quantile(boot, [alpha, 1.0 - alpha])]
+    return {
+        "baseline": str(baseline),
+        "candidate": str(candidate),
+        "observed_mean_gain": float(np.mean(diff)),
+        "bootstrap_mean_gain": float(np.mean(boot)),
+        "ci_low": ci_low,
+        "ci_high": ci_high,
+        "confidence": confidence,
+        "n_boot": n_boot,
+        "seed": seed,
+        "n": int(diff.size),
+        "method": "paired_row_resample",
+    }
 
 
 def score_gaussian_prediction_vectors(name, target_state, mean, covariance, jitter=1e-9):
@@ -503,8 +556,28 @@ def _score_to_json_dict(score):
     }
 
 
-def evaluation_to_json_dict(result):
+def _bootstrap_improvement_map(result, baseline, n_boot, seed, confidence):
+    return {
+        score.name: paired_bootstrap_nll_improvement(
+            result,
+            baseline,
+            score.name,
+            n_boot=n_boot,
+            seed=seed,
+            confidence=confidence,
+        )
+        for score in result.scores
+        if score.name != baseline
+    }
+
+
+def evaluation_to_json_dict(result, bootstrap_nll=0, bootstrap_seed=0, bootstrap_confidence=0.95):
     """Return a JSON-serializable summary for a holdout evaluation result."""
+    bootstrap_nll, bootstrap_seed, bootstrap_confidence = _bootstrap_settings(
+        bootstrap_nll,
+        bootstrap_seed,
+        bootstrap_confidence,
+    )
     scores = {score.name: _score_to_json_dict(score) for score in result.scores}
     prior = result.score("prior").mean_nll
     improvements = {name: prior - score["mean_nll"] for name, score in scores.items() if name != "prior"}
@@ -532,6 +605,22 @@ def evaluation_to_json_dict(result):
             for name, score in scores.items()
             if name != "independent_kalman"
         }
+    if bootstrap_nll:
+        out["nll_improvement_bootstrap_vs_prior"] = _bootstrap_improvement_map(
+            result,
+            "prior",
+            bootstrap_nll,
+            bootstrap_seed,
+            bootstrap_confidence,
+        )
+        if "independent_kalman" in scores:
+            out["nll_improvement_bootstrap_vs_independent_kalman"] = _bootstrap_improvement_map(
+                result,
+                "independent_kalman",
+                bootstrap_nll,
+                bootstrap_seed,
+                bootstrap_confidence,
+            )
     return out
 
 
@@ -607,6 +696,9 @@ def _build_arg_parser():
     ap.add_argument("--jitter", type=float, default=1e-9)
     ap.add_argument("--ddof", type=int, default=1)
     ap.add_argument("--shrinkage-target", default="diagonal", choices=("diagonal", "scaled_identity"))
+    ap.add_argument("--bootstrap-nll", type=int, default=0, help="paired bootstrap replicates for NLL gains; 0 disables")
+    ap.add_argument("--bootstrap-seed", type=int, default=0)
+    ap.add_argument("--bootstrap-confidence", type=float, default=0.95)
     ap.add_argument("--indent", type=int, default=2, help="JSON indentation; use 0 for compact output")
     return ap
 
@@ -633,7 +725,15 @@ def main(argv=None):
         )
     except ValueError as exc:
         ap.error(str(exc))
-    data = evaluation_to_json_dict(result)
+    try:
+        data = evaluation_to_json_dict(
+            result,
+            bootstrap_nll=args.bootstrap_nll,
+            bootstrap_seed=args.bootstrap_seed,
+            bootstrap_confidence=args.bootstrap_confidence,
+        )
+    except ValueError as exc:
+        ap.error(str(exc))
     indent = None if args.indent == 0 else args.indent
     text = json.dumps(data, indent=indent, sort_keys=True) + "\n"
     if args.output_json:

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -74,6 +74,28 @@ def _improvement_rows(scores_json):
     return rows
 
 
+def _bootstrap_rows(scores_json):
+    rows = []
+    for baseline_key, label in (
+        ("nll_improvement_bootstrap_vs_prior", "prior"),
+        ("nll_improvement_bootstrap_vs_independent_kalman", "independent_kalman"),
+    ):
+        for candidate, item in sorted(scores_json.get(baseline_key, {}).items()):
+            rows.append([
+                label,
+                candidate,
+                item.get("observed_mean_gain"),
+                item.get("bootstrap_mean_gain"),
+                item.get("ci_low"),
+                item.get("ci_high"),
+                item.get("confidence"),
+                item.get("n_boot"),
+                item.get("seed"),
+                item.get("n"),
+            ])
+    return rows
+
+
 def _input_rows(scores_json, manifest):
     inputs = scores_json.get("inputs", {})
     rows = [
@@ -196,6 +218,7 @@ def build_product_kalman_markdown_report(
             _markdown_table(["item", "value"], _split_materialization_rows(split_manifest)),
             "",
         ])
+    bootstrap_rows = _bootstrap_rows(scores_json)
     lines.extend([
         "## Scores",
         "",
@@ -219,6 +242,29 @@ def build_product_kalman_markdown_report(
         "",
         _markdown_table(["baseline", "candidate", "mean_nll_gain"], _improvement_rows(scores_json)),
         "",
+    ])
+    if bootstrap_rows:
+        lines.extend([
+            "## NLL Improvement Bootstrap Intervals",
+            "",
+            _markdown_table(
+                [
+                    "baseline",
+                    "candidate",
+                    "observed_gain",
+                    "bootstrap_mean",
+                    "ci_low",
+                    "ci_high",
+                    "confidence",
+                    "n_boot",
+                    "seed",
+                    "n",
+                ],
+                bootstrap_rows,
+            ),
+            "",
+        ])
+    lines.extend([
         "## Calibration Settings",
         "",
         _markdown_table(["item", "value"], _calibration_rows(scores_json)),
@@ -227,6 +273,7 @@ def build_product_kalman_markdown_report(
         "",
         "- Positive NLL gain means the candidate had lower held-out mean NLL than the named baseline.",
         "- For a well-scaled d-dimensional Gaussian prediction, mean squared Mahalanobis should be near d; the per-dimension value should be near 1, with tail quantiles read as empirical diagnostics rather than a decision rule.",
+        "- Bootstrap intervals, when present, are paired row-resampling diagnostics for NLL gains; they are not a preregistered decision rule.",
         "- Treat this as a held-out comparison artifact, not as a training-objective decision.",
         "- Product-Kalman should be compared against the registered joint-posterior and Sigma-conditioned baselines before promotion.",
         "- Calibration rows and evaluation rows must remain disjoint; any ID overlap or duplicate count above zero should block interpretation.",

--- a/prototypes/mu_cosine/product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_table_evaluation.py
@@ -176,6 +176,9 @@ def run_product_kalman_table_evaluation(
     jitter=1e-9,
     ddof=1,
     shrinkage_target="diagonal",
+    bootstrap_nll=0,
+    bootstrap_seed=0,
+    bootstrap_confidence=0.95,
     indent=2,
 ):
     """Build evaluator input artifacts from a table and score the held-out split."""
@@ -203,7 +206,12 @@ def run_product_kalman_table_evaluation(
     if output_npz:
         write_evaluation_npz(output_npz, result)
     summary = _attach_input_paths(
-        evaluation_to_json_dict(result),
+        evaluation_to_json_dict(
+            result,
+            bootstrap_nll=bootstrap_nll,
+            bootstrap_seed=bootstrap_seed,
+            bootstrap_confidence=bootstrap_confidence,
+        ),
         input_table,
         input_npz,
         input_manifest=input_manifest,
@@ -272,6 +280,14 @@ def _build_arg_parser():
     ap.add_argument("--jitter", type=float, default=1e-9)
     ap.add_argument("--ddof", type=int, default=1)
     ap.add_argument("--shrinkage-target", default="diagonal", choices=("diagonal", "scaled_identity"))
+    ap.add_argument(
+        "--bootstrap-nll",
+        type=int,
+        default=0,
+        help="paired bootstrap replicates for NLL gains; 0 disables",
+    )
+    ap.add_argument("--bootstrap-seed", type=int, default=0)
+    ap.add_argument("--bootstrap-confidence", type=float, default=0.95)
     ap.add_argument("--indent", type=int, default=2, help="JSON indentation; use 0 for compact output")
     return ap
 
@@ -322,6 +338,9 @@ def main(argv=None):
             jitter=args.jitter,
             ddof=args.ddof,
             shrinkage_target=args.shrinkage_target,
+            bootstrap_nll=args.bootstrap_nll,
+            bootstrap_seed=args.bootstrap_seed,
+            bootstrap_confidence=args.bootstrap_confidence,
             indent=args.indent,
         )
     except ValueError as exc:

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -19,6 +19,7 @@ from product_kalman_evaluation import (
     evaluation_to_json_dict,
     main,
     run_product_kalman_holdout_npz,
+    score_gaussian_prediction_vectors,
     score_gaussian_predictions,
     write_evaluation_npz,
 )
@@ -73,6 +74,10 @@ def test_correlated_product_kalman_beats_zero_cross_control_on_heldout_nll():
     product_score = result.score("product_kalman")
     assert product_score.squared_mahalanobis_q50 <= product_score.squared_mahalanobis_q90
     assert product_score.squared_mahalanobis_q90 <= product_score.squared_mahalanobis_q95
+    product_vectors = result.score_vector("product_kalman")
+    assert product_vectors.nll.shape == (len(eval_target),)
+    assert abs(float(product_vectors.nll.mean()) - product_score.mean_nll) < 1e-12
+    assert product_vectors.nll.flags.writeable is False
     assert result.correlated_update.mean.flags.writeable is False
     assert result.independent_update.mean.flags.writeable is False
 
@@ -173,6 +178,9 @@ def test_npz_runner_and_json_cli_roundtrip():
             assert artifact["score_names"].tolist() == data["score_order"]
             assert artifact["score_mahalanobis_per_dim"].shape == (4,)
             assert artifact["score_squared_mahalanobis_q95"].shape == (4,)
+            assert artifact["score_row_nll"].shape == (4, 4000)
+            assert artifact["score_row_squared_error"].shape == (4, 4000)
+            assert artifact["score_row_squared_mahalanobis"].shape == (4, 4000)
             assert artifact["product_kalman_mean"].shape == result.correlated_update.mean.shape
             np.testing.assert_allclose(artifact["product_kalman_mean"], result.correlated_update.mean)
             np.testing.assert_allclose(artifact["independent_kalman_mean"], result.independent_update.mean)
@@ -201,6 +209,10 @@ def test_evaluation_artifact_arrays_are_npz_ready():
     assert arrays["score_squared_mahalanobis_q50"].shape == (4,)
     assert arrays["score_squared_mahalanobis_q90"].shape == (4,)
     assert arrays["score_squared_mahalanobis_q95"].shape == (4,)
+    assert arrays["score_row_nll"].shape == (4, 20)
+    assert arrays["score_row_squared_error"].shape == (4, 20)
+    assert arrays["score_row_squared_mahalanobis"].shape == (4, 20)
+    np.testing.assert_allclose(arrays["score_row_nll"].mean(axis=1), arrays["score_mean_nll"])
     assert np.isfinite(arrays["score_mahalanobis_per_dim"]).all()
     assert arrays["product_kalman_innovation"].shape == eval_target.shape
     assert arrays["product_kalman_covariance"].shape == (1, 1)
@@ -250,6 +262,11 @@ def test_nonidentity_observation_omits_measurement_baseline():
 def test_score_gaussian_predictions_validates_shapes_and_reports_mse():
     target = np.array([[1.0], [2.0]])
     mean = np.array([[1.5], [1.5]])
+    vectors = score_gaussian_prediction_vectors("toy", target, mean, [[0.25]], jitter=1e-9)
+    assert vectors.name == "toy"
+    assert np.allclose(vectors.squared_error, [0.25, 0.25])
+    assert np.allclose(vectors.squared_mahalanobis, [1.0, 1.0])
+    assert vectors.nll.flags.writeable is False
     score = score_gaussian_predictions("toy", target, mean, [[0.25]], jitter=1e-9)
     assert score.name == "toy"
     assert score.n == 2

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -18,6 +18,7 @@ from product_kalman_evaluation import (
     evaluation_artifact_arrays,
     evaluation_to_json_dict,
     main,
+    paired_bootstrap_nll_improvement,
     run_product_kalman_holdout_npz,
     score_gaussian_prediction_vectors,
     score_gaussian_predictions,
@@ -80,6 +81,19 @@ def test_correlated_product_kalman_beats_zero_cross_control_on_heldout_nll():
     assert product_vectors.nll.flags.writeable is False
     assert result.correlated_update.mean.flags.writeable is False
     assert result.independent_update.mean.flags.writeable is False
+    boot = paired_bootstrap_nll_improvement(
+        result,
+        "independent_kalman",
+        "product_kalman",
+        n_boot=200,
+        seed=11,
+        confidence=0.90,
+    )
+    observed_gain = result.nll_improvement("independent_kalman", "product_kalman")
+    assert abs(boot["observed_mean_gain"] - observed_gain) < 1e-12
+    assert boot["ci_low"] < boot["observed_mean_gain"] < boot["ci_high"]
+    assert boot["method"] == "paired_row_resample"
+    assert boot["confidence"] == 0.90
 
 
 def test_split_ids_are_checked_before_scoring():
@@ -147,7 +161,12 @@ def test_npz_runner_and_json_cli_roundtrip():
         artifact_path = Path(tmp) / "artifacts.npz"
         write_identity_npz(input_path)
         result = run_product_kalman_holdout_npz(input_path)
-        data = evaluation_to_json_dict(result)
+        data = evaluation_to_json_dict(
+            result,
+            bootstrap_nll=200,
+            bootstrap_seed=3,
+            bootstrap_confidence=0.90,
+        )
         assert data["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
         assert data["calibration"]["state_dim"] == 1
         assert "mean_squared_mahalanobis" in data["scores"]["product_kalman"]
@@ -155,6 +174,14 @@ def test_npz_runner_and_json_cli_roundtrip():
         assert 0.85 < data["scores"]["product_kalman"]["mahalanobis_per_dim"] < 1.15
         assert data["nll_improvement_vs_prior"]["product_kalman"] > 0.85
         assert data["nll_improvement_vs_independent_kalman"]["product_kalman"] > 0.12
+        boot = data["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"]
+        assert boot["n_boot"] == 200
+        assert boot["seed"] == 3
+        assert boot["confidence"] == 0.90
+        assert abs(
+            boot["observed_mean_gain"]
+            - data["nll_improvement_vs_independent_kalman"]["product_kalman"]
+        ) < 1e-12
 
         rc = main([
             str(input_path),
@@ -162,6 +189,12 @@ def test_npz_runner_and_json_cli_roundtrip():
             str(output_path),
             "--output-npz",
             str(artifact_path),
+            "--bootstrap-nll",
+            "200",
+            "--bootstrap-seed",
+            "3",
+            "--bootstrap-confidence",
+            "0.90",
             "--indent",
             "0",
         ])
@@ -172,6 +205,7 @@ def test_npz_runner_and_json_cli_roundtrip():
             from_cli["scores"]["product_kalman"]["mean_nll"]
             - data["scores"]["product_kalman"]["mean_nll"]
         ) < 1e-12
+        assert from_cli["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"] == boot
 
         with np.load(artifact_path, allow_pickle=False) as artifact:
             assert int(artifact["schema_version"]) == 1

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -62,6 +62,9 @@ def make_artifacts(tmp):
         output_json=scores_json,
         output_npz=eval_npz,
         jitter=1e-8,
+        bootstrap_nll=50,
+        bootstrap_seed=7,
+        bootstrap_confidence=0.90,
     )
     return input_manifest, scores_json
 
@@ -108,6 +111,9 @@ def test_markdown_report_records_scores_and_guardrails():
         assert "mean_sq_mahalanobis" in report
         assert "sq_mahalanobis_q95" in report
         assert "| prior | product_kalman |" in report
+        assert "## NLL Improvement Bootstrap Intervals" in report
+        assert "observed_gain" in report
+        assert "paired row-resampling" in report
         assert "| calibration_rows | 80 |" in report
         assert "| evaluation_rows | 40 |" in report
         assert "| ids_disjoint_and_unique | True |" in report
@@ -162,6 +168,7 @@ def test_markdown_report_cli_writes_file():
         assert "mahalanobis_per_dim" in text
         assert "sq_mahalanobis_q95" in text
         assert "## NLL Improvements" in text
+        assert "## NLL Improvement Bootstrap Intervals" in text
         assert "## Split Materialization" in text
         assert "source_table_sha256" in text
 

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -130,6 +130,9 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
             assert artifact["score_names"].tolist() == summary["score_order"]
             assert artifact["score_mahalanobis_per_dim"].shape == (4,)
             assert artifact["score_squared_mahalanobis_q95"].shape == (4,)
+            assert artifact["score_row_nll"].shape == (4, 40)
+            assert artifact["score_row_squared_error"].shape == (4, 40)
+            assert artifact["score_row_squared_mahalanobis"].shape == (4, 40)
 
 
 def test_table_runner_output_dir_writes_canonical_bundle():

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -91,6 +91,9 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
             output_md=output_md,
             report_title="Synthetic Table Product-Kalman Report",
             jitter=1e-8,
+            bootstrap_nll=50,
+            bootstrap_seed=7,
+            bootstrap_confidence=0.90,
         )
 
         assert input_npz.exists()
@@ -112,6 +115,14 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert "mahalanobis_per_dim" in summary["scores"]["product_kalman"]
         assert "squared_mahalanobis_q95" in summary["scores"]["product_kalman"]
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
+        boot = summary["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"]
+        assert boot["n_boot"] == 50
+        assert boot["seed"] == 7
+        assert boot["confidence"] == 0.90
+        assert abs(
+            boot["observed_mean_gain"]
+            - summary["nll_improvement_vs_independent_kalman"]["product_kalman"]
+        ) < 1e-12
 
         manifest = json.loads(input_manifest.read_text())
         assert manifest["splits"]["calibration_rows"] == 80
@@ -123,6 +134,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert "## Scores" in report
         assert "mahalanobis_per_dim" in report
         assert "sq_mahalanobis_q95" in report
+        assert "## NLL Improvement Bootstrap Intervals" in report
         assert "source_table_sha256" in report
 
         with np.load(output_npz, allow_pickle=False) as artifact:


### PR DESCRIPTION
Adds optional paired row-resampling bootstrap intervals for Product-Kalman held-out NLL gains.

Changes:
- Add `paired_bootstrap_nll_improvement(...)` for baseline-vs-candidate NLL gain intervals.
- Expose `--bootstrap-nll`, `--bootstrap-seed`, and `--bootstrap-confidence` in NPZ and table evaluation runners.
- Include bootstrap interval tables in Product-Kalman Markdown reports when requested.
- Update tests for JSON output, CLI roundtrip, table-runner artifacts, and report rendering.
- Update the Product-Kalman design note to name paired bootstrap intervals as diagnostic reporting only.

Validation:
- `python3 -m py_compile ...`
- direct Product-Kalman evaluation/report/table tests
- focused pytest suite: 24 passed
- calibration smoke tests: 12 passed
- Product-Kalman core smoke tests: 16 passed
- `git diff --check`