### PR TITLE
Add Product-Kalman artifact bootstrap reporting

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -389,8 +389,10 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    for NLL gains, and keeps calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison
    pending.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
-   descriptive Markdown run note. The report is an audit artifact only: it records scores and provenance, but does
-   not encode a decision rule or promote Product-Kalman without comparison against registered baselines.
+   descriptive Markdown run note. When row-level `eval_artifacts.npz` exists, the report CLI can add paired bootstrap
+   NLL intervals post hoc without rerunning scoring. The report is an audit artifact only: it records scores and
+   provenance, but does not encode a decision rule or promote Product-Kalman without comparison against registered
+   baselines.
 9. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and
    Sigma-conditioned covariance on a separate node-disjoint evaluation split; do not reuse the calibration
    residuals that set `R_ell` as the comparison set.

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -41,10 +41,13 @@ __all__ = [
     "GaussianScore",
     "GaussianScoreVectors",
     "ProductKalmanHoldoutEvaluation",
+    "bootstrap_nll_improvements_from_evaluation_npz",
+    "bootstrap_nll_improvements_from_score_rows",
     "evaluate_product_kalman_holdout",
     "evaluation_artifact_arrays",
     "evaluation_to_json_dict",
     "paired_bootstrap_nll_improvement",
+    "paired_bootstrap_nll_improvement_from_score_rows",
     "run_product_kalman_holdout_npz",
     "score_gaussian_prediction_vectors",
     "score_gaussian_predictions",
@@ -267,21 +270,11 @@ def _bootstrap_settings(n_boot, seed, confidence):
     return n_boot, seed, confidence
 
 
-def paired_bootstrap_nll_improvement(result, baseline, candidate, n_boot=1000, seed=0, confidence=0.95):
-    """Paired bootstrap CI for mean NLL gain, `baseline - candidate`.
-
-    Rows are resampled with replacement from the shared evaluation split, preserving
-    the paired comparison between two prediction families. Positive gain means the
-    candidate has lower held-out NLL than the baseline.
-    """
+def _bootstrap_nll_diff(diff, baseline, candidate, n_boot, seed, confidence):
     n_boot, seed, confidence = _bootstrap_settings(n_boot, seed, confidence)
     if n_boot <= 0:
         raise ValueError("n_boot must be positive for a bootstrap interval")
-    baseline_vec = result.score_vector(baseline)
-    candidate_vec = result.score_vector(candidate)
-    if baseline_vec.n != candidate_vec.n:
-        raise ValueError("baseline and candidate row-score vectors must have the same length")
-    diff = baseline_vec.nll - candidate_vec.nll
+    diff = _readonly_vector("nll difference", diff)
     rng = np.random.default_rng(seed)
     boot = np.empty(n_boot, dtype=float)
     for i in range(n_boot):
@@ -302,6 +295,110 @@ def paired_bootstrap_nll_improvement(result, baseline, candidate, n_boot=1000, s
         "n": int(diff.size),
         "method": "paired_row_resample",
     }
+
+
+def paired_bootstrap_nll_improvement(result, baseline, candidate, n_boot=1000, seed=0, confidence=0.95):
+    """Paired bootstrap CI for mean NLL gain, `baseline - candidate`.
+
+    Rows are resampled with replacement from the shared evaluation split, preserving
+    the paired comparison between two prediction families. Positive gain means the
+    candidate has lower held-out NLL than the baseline.
+    """
+    baseline_vec = result.score_vector(baseline)
+    candidate_vec = result.score_vector(candidate)
+    if baseline_vec.n != candidate_vec.n:
+        raise ValueError("baseline and candidate row-score vectors must have the same length")
+    return _bootstrap_nll_diff(
+        baseline_vec.nll - candidate_vec.nll,
+        baseline,
+        candidate,
+        n_boot,
+        seed,
+        confidence,
+    )
+
+
+def _decode_score_names(value):
+    arr = np.asarray(value)
+    if arr.ndim != 1 or arr.size == 0:
+        raise ValueError("score_names must be a nonempty 1-D array")
+    names = []
+    for item in arr:
+        if isinstance(item, bytes):
+            name = item.decode("utf-8")
+        else:
+            name = str(item)
+        if not name:
+            raise ValueError("score_names must not contain empty names")
+        names.append(name)
+    if len(names) != len(set(names)):
+        raise ValueError("score_names must be unique")
+    return tuple(names)
+
+
+def _score_row_nll_inputs(score_names, score_row_nll):
+    names = _decode_score_names(score_names)
+    rows = np.asarray(score_row_nll, dtype=float)
+    if rows.ndim != 2:
+        raise ValueError("score_row_nll must be a 2-D array shaped (models, rows)")
+    if rows.shape[0] != len(names):
+        raise ValueError("score_row_nll first dimension must match score_names")
+    if rows.shape[1] == 0:
+        raise ValueError("score_row_nll must contain at least one held-out row")
+    if not np.isfinite(rows).all():
+        raise ValueError("score_row_nll must be finite")
+    return names, rows
+
+
+def paired_bootstrap_nll_improvement_from_score_rows(
+    score_names,
+    score_row_nll,
+    baseline,
+    candidate,
+    n_boot=1000,
+    seed=0,
+    confidence=0.95,
+):
+    """Paired bootstrap CI from stored row-level NLL artifacts."""
+    names, rows = _score_row_nll_inputs(score_names, score_row_nll)
+    name_to_idx = {name: i for i, name in enumerate(names)}
+    if baseline not in name_to_idx:
+        raise ValueError(f"baseline {baseline!r} is not present in score_names")
+    if candidate not in name_to_idx:
+        raise ValueError(f"candidate {candidate!r} is not present in score_names")
+    diff = rows[name_to_idx[baseline]] - rows[name_to_idx[candidate]]
+    return _bootstrap_nll_diff(diff, baseline, candidate, n_boot, seed, confidence)
+
+
+def bootstrap_nll_improvements_from_score_rows(
+    score_names,
+    score_row_nll,
+    n_boot=1000,
+    seed=0,
+    confidence=0.95,
+    baselines=("prior", "independent_kalman"),
+):
+    """Return JSON-ready paired bootstrap maps from stored row-level NLL artifacts."""
+    names, rows = _score_row_nll_inputs(score_names, score_row_nll)
+    out = {}
+    for baseline in baselines:
+        if baseline not in names:
+            continue
+        key = f"nll_improvement_bootstrap_vs_{baseline}"
+        out[key] = {
+            candidate: paired_bootstrap_nll_improvement_from_score_rows(
+                names,
+                rows,
+                baseline,
+                candidate,
+                n_boot=n_boot,
+                seed=seed,
+                confidence=confidence,
+            )
+            for candidate in names
+            if candidate != baseline
+        }
+    return out
 
 
 def score_gaussian_prediction_vectors(name, target_state, mean, covariance, jitter=1e-9):
@@ -539,6 +636,26 @@ def _require_npz_array(npz, path, key):
 
 def _optional_npz_array(npz, key):
     return npz[key] if key in npz.files else None
+
+
+def bootstrap_nll_improvements_from_evaluation_npz(
+    artifact_npz,
+    n_boot=1000,
+    seed=0,
+    confidence=0.95,
+    baselines=("prior", "independent_kalman"),
+):
+    """Return JSON-ready paired NLL bootstrap maps from an evaluation artifact NPZ."""
+    path = str(artifact_npz)
+    with np.load(path, allow_pickle=False) as data:
+        return bootstrap_nll_improvements_from_score_rows(
+            _require_npz_array(data, path, "score_names"),
+            _require_npz_array(data, path, "score_row_nll"),
+            n_boot=n_boot,
+            seed=seed,
+            confidence=confidence,
+            baselines=baselines,
+        )
 
 
 def _score_to_json_dict(score):

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -10,8 +10,14 @@ import argparse
 import json
 import sys
 
+try:
+    from .product_kalman_evaluation import bootstrap_nll_improvements_from_evaluation_npz
+except ImportError:  # direct script execution from prototypes/mu_cosine
+    from product_kalman_evaluation import bootstrap_nll_improvements_from_evaluation_npz
+
 
 __all__ = [
+    "add_artifact_bootstrap_intervals",
     "build_product_kalman_markdown_report",
     "load_json",
     "write_markdown_report",
@@ -158,6 +164,35 @@ def _calibration_rows(scores_json):
     ]
 
 
+def add_artifact_bootstrap_intervals(
+    scores_json,
+    evaluation_npz=None,
+    n_boot=0,
+    seed=0,
+    confidence=0.95,
+    overwrite=False,
+):
+    """Return `scores_json` enriched with post-hoc bootstrap intervals from row artifacts."""
+    if not n_boot:
+        return scores_json
+    artifact_path = evaluation_npz or scores_json.get("inputs", {}).get("evaluation_npz")
+    if not artifact_path:
+        raise ValueError(
+            "--evaluation-npz is required when --bootstrap-nll is set "
+            "and scores JSON has no evaluation_npz input"
+        )
+    out = dict(scores_json)
+    for key, value in bootstrap_nll_improvements_from_evaluation_npz(
+        artifact_path,
+        n_boot=n_boot,
+        seed=seed,
+        confidence=confidence,
+    ).items():
+        if overwrite or key not in out:
+            out[key] = value
+    return out
+
+
 def _split_materialization_rows(split_manifest):
     if not split_manifest:
         return []
@@ -295,6 +330,11 @@ def _build_arg_parser():
     ap.add_argument("--split-manifest", help="optional split manifest JSON from product_kalman_split_table")
     ap.add_argument("--output-md", help="write Markdown report here instead of stdout")
     ap.add_argument("--title", default="Product-Kalman Holdout Report")
+    ap.add_argument("--evaluation-npz", help="optional row-level evaluation artifact NPZ for post-hoc bootstrap intervals")
+    ap.add_argument("--bootstrap-nll", type=int, default=0, help="paired bootstrap replicates for NLL gains; 0 disables")
+    ap.add_argument("--bootstrap-seed", type=int, default=0)
+    ap.add_argument("--bootstrap-confidence", type=float, default=0.95)
+    ap.add_argument("--overwrite-bootstrap", action="store_true", help="replace existing bootstrap sections in scores JSON")
     return ap
 
 
@@ -302,6 +342,17 @@ def main(argv=None):
     ap = _build_arg_parser()
     args = ap.parse_args(argv)
     scores = load_json(args.scores_json)
+    try:
+        scores = add_artifact_bootstrap_intervals(
+            scores,
+            evaluation_npz=args.evaluation_npz,
+            n_boot=args.bootstrap_nll,
+            seed=args.bootstrap_seed,
+            confidence=args.bootstrap_confidence,
+            overwrite=args.overwrite_bootstrap,
+        )
+    except (OSError, ValueError) as exc:
+        ap.error(str(exc))
     manifest = load_json(args.input_manifest) if args.input_manifest else None
     split_manifest = load_json(args.split_manifest) if args.split_manifest else None
     text = build_product_kalman_markdown_report(scores, manifest, split_manifest=split_manifest, title=args.title)

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import numpy as np
 
 from product_kalman_evaluation import (
+    bootstrap_nll_improvements_from_evaluation_npz,
     evaluate_product_kalman_holdout,
     evaluation_artifact_arrays,
     evaluation_to_json_dict,
@@ -207,6 +208,14 @@ def test_npz_runner_and_json_cli_roundtrip():
         ) < 1e-12
         assert from_cli["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"] == boot
 
+        artifact_boot = bootstrap_nll_improvements_from_evaluation_npz(
+            artifact_path,
+            n_boot=200,
+            seed=3,
+            confidence=0.90,
+        )
+        assert artifact_boot["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"] == boot
+
         with np.load(artifact_path, allow_pickle=False) as artifact:
             assert int(artifact["schema_version"]) == 1
             assert artifact["score_names"].tolist() == data["score_order"]
@@ -264,6 +273,7 @@ def test_npz_runner_validates_required_keys():
         input_path = Path(tmp) / "missing.npz"
         np.savez(input_path, calibration_prior_mean=np.zeros((4, 1)))
         assert_raises(run_product_kalman_holdout_npz, input_path)
+        assert_raises(bootstrap_nll_improvements_from_evaluation_npz, input_path, n_boot=10)
 
 
 def test_nonidentity_observation_omits_measurement_baseline():

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import numpy as np
 
-from product_kalman_report import build_product_kalman_markdown_report, main
+from product_kalman_report import add_artifact_bootstrap_intervals, build_product_kalman_markdown_report, main
 from product_kalman_table_evaluation import run_product_kalman_table_evaluation
 
 
@@ -45,13 +45,20 @@ def write_table(path):
             })
 
 
-def make_artifacts(tmp):
+def make_artifacts(tmp, bootstrap_nll=50):
     table = Path(tmp) / "holdout.csv"
     input_npz = Path(tmp) / "input.npz"
     input_manifest = Path(tmp) / "input.manifest.json"
     scores_json = Path(tmp) / "scores.json"
     eval_npz = Path(tmp) / "eval_artifacts.npz"
     write_table(table)
+    kwargs = {}
+    if bootstrap_nll:
+        kwargs.update({
+            "bootstrap_nll": bootstrap_nll,
+            "bootstrap_seed": 7,
+            "bootstrap_confidence": 0.90,
+        })
     run_product_kalman_table_evaluation(
         table,
         input_npz,
@@ -62,11 +69,10 @@ def make_artifacts(tmp):
         output_json=scores_json,
         output_npz=eval_npz,
         jitter=1e-8,
-        bootstrap_nll=50,
-        bootstrap_seed=7,
-        bootstrap_confidence=0.90,
+        **kwargs,
     )
-    return input_manifest, scores_json
+    return input_manifest, scores_json, eval_npz
+
 
 def split_manifest_fixture():
     return {
@@ -99,7 +105,7 @@ def split_manifest_fixture():
 
 def test_markdown_report_records_scores_and_guardrails():
     with tempfile.TemporaryDirectory() as tmp:
-        input_manifest, scores_json = make_artifacts(tmp)
+        input_manifest, scores_json, _ = make_artifacts(tmp)
         scores = json.loads(scores_json.read_text())
         manifest = json.loads(input_manifest.read_text())
         report = build_product_kalman_markdown_report(scores, manifest, title="Synthetic Product-Kalman Report")
@@ -123,7 +129,7 @@ def test_markdown_report_records_scores_and_guardrails():
 
 def test_markdown_report_records_split_materialization_manifest():
     with tempfile.TemporaryDirectory() as tmp:
-        input_manifest, scores_json = make_artifacts(tmp)
+        input_manifest, scores_json, _ = make_artifacts(tmp)
         scores = json.loads(scores_json.read_text())
         manifest = json.loads(input_manifest.read_text())
         scores["inputs"]["original_table"] = "raw.tsv"
@@ -144,9 +150,55 @@ def test_markdown_report_records_split_materialization_manifest():
         assert "| omitted_crossing_rows | 0 |" in report
 
 
+def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
+    with tempfile.TemporaryDirectory() as tmp:
+        input_manifest, scores_json, eval_npz = make_artifacts(tmp, bootstrap_nll=0)
+        scores = json.loads(scores_json.read_text())
+        assert "nll_improvement_bootstrap_vs_independent_kalman" not in scores
+        enriched = add_artifact_bootstrap_intervals(
+            scores,
+            evaluation_npz=eval_npz,
+            n_boot=50,
+            seed=7,
+            confidence=0.90,
+        )
+        recorded_path_enriched = add_artifact_bootstrap_intervals(
+            scores,
+            n_boot=50,
+            seed=7,
+            confidence=0.90,
+        )
+        assert "nll_improvement_bootstrap_vs_prior" in recorded_path_enriched
+        boot = enriched["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"]
+        assert boot["n_boot"] == 50
+        assert boot["seed"] == 7
+        assert boot["confidence"] == 0.90
+
+        output_md = Path(tmp) / "posthoc.md"
+        rc = main([
+            str(scores_json),
+            "--input-manifest",
+            str(input_manifest),
+            "--evaluation-npz",
+            str(eval_npz),
+            "--bootstrap-nll",
+            "50",
+            "--bootstrap-seed",
+            "7",
+            "--bootstrap-confidence",
+            "0.90",
+            "--output-md",
+            str(output_md),
+        ])
+        assert rc == 0
+        text = output_md.read_text()
+        assert "## NLL Improvement Bootstrap Intervals" in text
+        assert "| independent_kalman | product_kalman |" in text
+
+
 def test_markdown_report_cli_writes_file():
     with tempfile.TemporaryDirectory() as tmp:
-        input_manifest, scores_json = make_artifacts(tmp)
+        input_manifest, scores_json, _ = make_artifacts(tmp)
         output_md = Path(tmp) / "report.md"
         split_manifest = Path(tmp) / "split.manifest.json"
         split_manifest.write_text(json.dumps(split_manifest_fixture()), encoding="utf-8")


### PR DESCRIPTION
Adds post-hoc paired NLL bootstrap support from saved Product-Kalman row-level evaluation artifacts.

Changes:
- Add helpers to compute paired NLL bootstrap intervals from stored `score_row_nll` arrays in `eval_artifacts.npz`.
- Let `product_kalman_report.py` enrich reports with `--evaluation-npz --bootstrap-nll` without rerunning scoring.
- Preserve the existing default: no bootstrap intervals unless explicitly requested.
- Update the Product-Kalman design note to document post-hoc report enrichment from row artifacts.
- Add tests for artifact-based bootstrap parity and report CLI rendering.

Validation:
- `python3 -m py_compile ...`
- direct evaluation/report tests
- focused pytest suite: 25 passed
- calibration smoke tests: 12 passed
- Product-Kalman core smoke tests: 16 passed
- `git diff --check`