### PR TITLE
Allow Product-Kalman reports to write enriched JSON

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -390,7 +390,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    pending.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
    descriptive Markdown run note. When row-level `eval_artifacts.npz` exists, the report CLI can add paired bootstrap
-   NLL intervals post hoc without rerunning scoring. The report is an audit artifact only: it records scores and
+   NLL intervals post hoc without rerunning scoring and can write the enriched score JSON beside the Markdown report.
+   The report is an audit artifact only: it records scores and
    provenance, but does not encode a decision rule or promote Product-Kalman without comparison against registered
    baselines.
 9. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -20,6 +20,7 @@ __all__ = [
     "add_artifact_bootstrap_intervals",
     "build_product_kalman_markdown_report",
     "load_json",
+    "write_json",
     "write_markdown_report",
 ]
 
@@ -317,6 +318,13 @@ def build_product_kalman_markdown_report(
     return "\n".join(lines)
 
 
+def write_json(path, data, indent=2):
+    """Write a JSON artifact with stable key ordering."""
+    text = json.dumps(data, indent=None if indent == 0 else indent, sort_keys=True) + "\n"
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
 def write_markdown_report(path, text):
     """Write a Markdown report."""
     with open(path, "w", encoding="utf-8") as f:
@@ -329,12 +337,14 @@ def _build_arg_parser():
     ap.add_argument("--input-manifest", help="optional input manifest JSON from product_kalman_table_to_npz")
     ap.add_argument("--split-manifest", help="optional split manifest JSON from product_kalman_split_table")
     ap.add_argument("--output-md", help="write Markdown report here instead of stdout")
+    ap.add_argument("--output-json", help="write enriched score JSON here")
     ap.add_argument("--title", default="Product-Kalman Holdout Report")
     ap.add_argument("--evaluation-npz", help="optional row-level evaluation artifact NPZ for post-hoc bootstrap intervals")
     ap.add_argument("--bootstrap-nll", type=int, default=0, help="paired bootstrap replicates for NLL gains; 0 disables")
     ap.add_argument("--bootstrap-seed", type=int, default=0)
     ap.add_argument("--bootstrap-confidence", type=float, default=0.95)
     ap.add_argument("--overwrite-bootstrap", action="store_true", help="replace existing bootstrap sections in scores JSON")
+    ap.add_argument("--indent", type=int, default=2, help="JSON indentation for --output-json; use 0 for compact output")
     return ap
 
 
@@ -356,6 +366,8 @@ def main(argv=None):
     manifest = load_json(args.input_manifest) if args.input_manifest else None
     split_manifest = load_json(args.split_manifest) if args.split_manifest else None
     text = build_product_kalman_markdown_report(scores, manifest, split_manifest=split_manifest, title=args.title)
+    if args.output_json:
+        write_json(args.output_json, scores, indent=args.indent)
     if args.output_md:
         write_markdown_report(args.output_md, text)
     else:

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -175,6 +175,7 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
         assert boot["confidence"] == 0.90
 
         output_md = Path(tmp) / "posthoc.md"
+        output_json = Path(tmp) / "posthoc.scores.json"
         rc = main([
             str(scores_json),
             "--input-manifest",
@@ -189,11 +190,15 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
             "0.90",
             "--output-md",
             str(output_md),
+            "--output-json",
+            str(output_json),
         ])
         assert rc == 0
         text = output_md.read_text()
         assert "## NLL Improvement Bootstrap Intervals" in text
         assert "| independent_kalman | product_kalman |" in text
+        enriched_json = json.loads(output_json.read_text())
+        assert enriched_json["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"] == boot
 
 
 def test_markdown_report_cli_writes_file():


### PR DESCRIPTION
Adds a machine-readable output path for Product-Kalman report enrichment.

Changes:
- Add `--output-json` to `product_kalman_report.py`.
- Write the post-hoc bootstrap-enriched score summary with stable JSON key ordering.
- Keep Markdown behavior unchanged.
- Update the Product-Kalman design note and report test coverage.

Validation:
- `python3 -m py_compile ...`
- direct report test
- focused pytest suite: 25 passed
- calibration smoke tests: 12 passed
- Product-Kalman core smoke tests: 16 passed
- `git diff --check`