### PR TITLE
Validate Product-Kalman report artifacts before enrichment

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -390,8 +390,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    pending.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
    descriptive Markdown run note. When row-level `eval_artifacts.npz` exists, the report CLI can add paired bootstrap
-   NLL intervals post hoc without rerunning scoring and can write the enriched score JSON beside the Markdown report.
-   The report is an audit artifact only: it records scores and
+   NLL intervals post hoc without rerunning scoring, verifies the row artifact against the score summary, and can write
+   the enriched score JSON beside the Markdown report. The report is an audit artifact only: it records scores and
    provenance, but does not encode a decision rule or promote Product-Kalman without comparison against registered
    baselines.
 9. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -45,6 +45,7 @@ __all__ = [
     "bootstrap_nll_improvements_from_score_rows",
     "evaluate_product_kalman_holdout",
     "evaluation_artifact_arrays",
+    "evaluation_npz_score_summary",
     "evaluation_to_json_dict",
     "paired_bootstrap_nll_improvement",
     "paired_bootstrap_nll_improvement_from_score_rows",
@@ -636,6 +637,28 @@ def _require_npz_array(npz, path, key):
 
 def _optional_npz_array(npz, key):
     return npz[key] if key in npz.files else None
+
+
+def evaluation_npz_score_summary(artifact_npz):
+    """Return score-order, mean-NLL, and row-count summaries from an evaluation artifact NPZ."""
+    path = str(artifact_npz)
+    with np.load(path, allow_pickle=False) as data:
+        names = _decode_score_names(_require_npz_array(data, path, "score_names"))
+        mean_nll = np.asarray(_require_npz_array(data, path, "score_mean_nll"), dtype=float)
+        score_n = np.asarray(_require_npz_array(data, path, "score_n"), dtype=np.int64)
+    if mean_nll.shape != (len(names),):
+        raise ValueError("score_mean_nll length must match score_names")
+    if score_n.shape != (len(names),):
+        raise ValueError("score_n length must match score_names")
+    if not np.isfinite(mean_nll).all():
+        raise ValueError("score_mean_nll must be finite")
+    if (score_n <= 0).any():
+        raise ValueError("score_n values must be positive")
+    return {
+        "score_order": list(names),
+        "mean_nll": {name: float(mean_nll[i]) for i, name in enumerate(names)},
+        "n": {name: int(score_n[i]) for i, name in enumerate(names)},
+    }
 
 
 def bootstrap_nll_improvements_from_evaluation_npz(

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -11,15 +11,22 @@ import json
 import sys
 
 try:
-    from .product_kalman_evaluation import bootstrap_nll_improvements_from_evaluation_npz
+    from .product_kalman_evaluation import (
+        bootstrap_nll_improvements_from_evaluation_npz,
+        evaluation_npz_score_summary,
+    )
 except ImportError:  # direct script execution from prototypes/mu_cosine
-    from product_kalman_evaluation import bootstrap_nll_improvements_from_evaluation_npz
+    from product_kalman_evaluation import (
+        bootstrap_nll_improvements_from_evaluation_npz,
+        evaluation_npz_score_summary,
+    )
 
 
 __all__ = [
     "add_artifact_bootstrap_intervals",
     "build_product_kalman_markdown_report",
     "load_json",
+    "validate_artifact_score_consistency",
     "write_json",
     "write_markdown_report",
 ]
@@ -165,6 +172,38 @@ def _calibration_rows(scores_json):
     ]
 
 
+def _artifact_path(scores_json, evaluation_npz=None):
+    artifact_path = evaluation_npz or scores_json.get("inputs", {}).get("evaluation_npz")
+    if not artifact_path:
+        raise ValueError(
+            "--evaluation-npz is required when --bootstrap-nll is set "
+            "and scores JSON has no evaluation_npz input"
+        )
+    return artifact_path
+
+
+def validate_artifact_score_consistency(scores_json, evaluation_npz=None, atol=1e-10):
+    """Raise if a row-level evaluation artifact does not match the score JSON."""
+    artifact_path = _artifact_path(scores_json, evaluation_npz=evaluation_npz)
+    artifact = evaluation_npz_score_summary(artifact_path)
+    scores = scores_json.get("scores", {})
+    expected_order = list(scores_json.get("score_order") or sorted(scores))
+    if artifact["score_order"] != expected_order:
+        raise ValueError("evaluation artifact score_names do not match scores JSON score_order")
+    for name in expected_order:
+        if name not in scores:
+            raise ValueError(f"scores JSON is missing score {name!r}")
+        score = scores[name]
+        if "mean_nll" in score:
+            observed = float(score["mean_nll"])
+            artifact_value = artifact["mean_nll"][name]
+            if abs(observed - artifact_value) > atol:
+                raise ValueError(f"evaluation artifact mean_nll for {name!r} does not match scores JSON")
+        if "n" in score and int(score["n"]) != artifact["n"][name]:
+            raise ValueError(f"evaluation artifact n for {name!r} does not match scores JSON")
+    return artifact
+
+
 def add_artifact_bootstrap_intervals(
     scores_json,
     evaluation_npz=None,
@@ -172,16 +211,14 @@ def add_artifact_bootstrap_intervals(
     seed=0,
     confidence=0.95,
     overwrite=False,
+    validate_artifact=True,
 ):
     """Return `scores_json` enriched with post-hoc bootstrap intervals from row artifacts."""
     if not n_boot:
         return scores_json
-    artifact_path = evaluation_npz or scores_json.get("inputs", {}).get("evaluation_npz")
-    if not artifact_path:
-        raise ValueError(
-            "--evaluation-npz is required when --bootstrap-nll is set "
-            "and scores JSON has no evaluation_npz input"
-        )
+    artifact_path = _artifact_path(scores_json, evaluation_npz=evaluation_npz)
+    if validate_artifact:
+        validate_artifact_score_consistency(scores_json, evaluation_npz=artifact_path)
     out = dict(scores_json)
     for key, value in bootstrap_nll_improvements_from_evaluation_npz(
         artifact_path,

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -14,8 +14,21 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import numpy as np
 
-from product_kalman_report import add_artifact_bootstrap_intervals, build_product_kalman_markdown_report, main
+from product_kalman_report import (
+    add_artifact_bootstrap_intervals,
+    build_product_kalman_markdown_report,
+    main,
+    validate_artifact_score_consistency,
+)
 from product_kalman_table_evaluation import run_product_kalman_table_evaluation
+
+
+def assert_raises(fn, *args, **kwargs):
+    try:
+        fn(*args, **kwargs)
+    except (OSError, ValueError):
+        return
+    raise AssertionError(f"{fn.__name__} should have raised")
 
 
 def synthetic_identity_split(n_cal=80, n_eval=40, seed=23):
@@ -162,6 +175,8 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
             seed=7,
             confidence=0.90,
         )
+        artifact_summary = validate_artifact_score_consistency(scores, evaluation_npz=eval_npz)
+        assert artifact_summary["score_order"] == scores["score_order"]
         recorded_path_enriched = add_artifact_bootstrap_intervals(
             scores,
             n_boot=50,
@@ -169,6 +184,13 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
             confidence=0.90,
         )
         assert "nll_improvement_bootstrap_vs_prior" in recorded_path_enriched
+
+        bad_order = dict(scores)
+        bad_order["score_order"] = list(reversed(scores["score_order"]))
+        assert_raises(add_artifact_bootstrap_intervals, bad_order, evaluation_npz=eval_npz, n_boot=10)
+        bad_mean = json.loads(json.dumps(scores))
+        bad_mean["scores"]["product_kalman"]["mean_nll"] += 1.0
+        assert_raises(add_artifact_bootstrap_intervals, bad_mean, evaluation_npz=eval_npz, n_boot=10)
         boot = enriched["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"]
         assert boot["n_boot"] == 50
         assert boot["seed"] == 7


### PR DESCRIPTION
Adds a guard so post-hoc Product-Kalman bootstrap enrichment cannot silently pair a score JSON with the wrong `eval_artifacts.npz`.

Changes:
- Add `evaluation_npz_score_summary(...)` for reading score order, mean NLL, and row counts from artifact NPZs.
- Add `validate_artifact_score_consistency(...)` before report bootstrap enrichment.
- Reject mismatched score order, row counts, or aggregate mean NLLs.
- Update report tests for mismatched artifact/JSON failures.
- Update the Product-Kalman design note to document the consistency check.

Validation:
- `python3 -m py_compile ...`
- direct evaluation/report tests
- focused pytest suite: 25 passed
- calibration smoke tests: 12 passed
- Product-Kalman core smoke tests: 16 passed
- `git diff --check`