### PR TITLE
WAM/LLVM (roadmap #5, milestone 6): Stage D -- multi-clause predicates + two runtime fixes

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -377,12 +377,18 @@ loadable along the way.
   labels + register allocation + conjunction + arithmetic + `call(Label,arity)`
   goals; a call whose callee computes, `main0` calls `add1(41,V)` with
   `add1(X,Y):-Y is X+1` → `42`; also enlarged the transient arena 1→16 MiB, which
-  an allocation-heavy compiler grammar needs). Nested expressions and last-call
-  optimization remain — Stage C's mechanisms are all in place; (D) widen toward
-  the compiler's own subset — the self-host fixpoint. Stage A surfaced two
-  loaded-runtime bugs, **both since fixed** (a 64-register-file ceiling that
-  corrupted memory for large clauses; `get_structure` not comparing the functor),
-  so large clauses and tagged-union dispatch both work now. See
+  an allocation-heavy compiler grammar needs); **(D) STARTED — multi-clause
+  predicates LANDED**: clause grouping + `try_me_else`/`retry_me_else`/`trust_me`
+  chains with per-alternative labels, so backtracking dispatch and **recursion**
+  compile from source (two-clause dispatch needing the second clause → `42`;
+  recursive factorial `fact(3)` → `6`). The remaining Stage D campaign widens the
+  subset toward the compiler compiling its own source — the self-host fixpoint.
+  The campaign keeps surfacing and fixing latent runtime bugs — **four fixed so
+  far**: a 64-register-file ceiling corrupting memory for large clauses;
+  `get_structure` not comparing the functor; the choice-point saved-register
+  block not widened with the register file (failed clause bodies leaked Y17+
+  across backtrack); and `copy_term/2` aliasing instead of copying (Refs
+  returned unchanged, no sharing preservation). See
   [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md).
 
 ## The binary-return question, specifically

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -342,6 +342,55 @@ compiler grammar can compile a source copy of itself and the re-compiled
 object behaves identically. This is the self-host fixpoint. It is a campaign,
 not a single PR — each construct added is a small, tested increment.
 
+**Multi-clause predicates — LANDED (the Stage D opener).** The biggest
+structural gap between `cgfull` and real Prolog was one-clause-per-predicate.
+Now consecutive clauses with the same name/arity group into a predicate
+(`group_clauses`); the predicate owns the entry label, clauses 2..k get
+**alternative labels** (laid out after all entry labels, so the label→PC table
+is simply `EntryPCs ++ AltPCs`), and a multi-clause predicate compiles to a
+`try_me_else(Alt1)` / `retry_me_else(Alt_k+1)` / `trust_me` chain (tags
+22/23/24) around the per-clause code. A failing head match backtracks to the
+next clause — **backtracking dispatch and recursion now compile from source**.
+Verified end to end
+(`tests/test_wam_object.pl:selfhost_codegen_stage_d_multiclause`): a two-clause
+dispatch whose caller needs the *second* clause (→ 42), and **recursive
+factorial** (base clause + recursive clause with arithmetic and a self-call by
+label; `fact(3)` → 6), both compiled inside a loaded compiler object.
+
+**Two more runtime bugs this stage surfaced — both FIXED:**
+
+1. **Choice-point saved-register block not widened with the register file.**
+   The register-file fix (PR #3510) grew the file to `[128 x %Value]` and the
+   env `y_save` to 48 permanents, but the `%ChoicePoint` register block stayed
+   `[64 x %Value]` — so `try_me_else` saved and `backtrack` restored only regs
+   0–63. A **failed clause body** writes its own Y registers and never reaches
+   `deallocate` (the env snapshot is bypassed); backtrack restored Y1–Y16
+   (48–63) from the CP but left Y17–Y48 (64–95) holding the failed clause's
+   junk — corrupting the backtracked-to alternative's permanents. The
+   multi-clause compiler was the first backtracking-heavy client with clauses
+   big enough (the new `cgfull/2` entry holds 17 permanents) to hit it.
+   Fixed: CP block `[128 x %Value]`, save/restore copies 2048 bytes (the
+   deliberate 512-byte *iterator* restores are untouched).
+
+2. **`copy_term/2` aliased instead of copying.** The runtime
+   `@wam_copy_term_value` was documented as naive: a `Ref` fell into the
+   atomic default and was returned **unchanged**, so the "copy" shared the
+   source heap cells — `numbervars`/unification on the copy bound the
+   *original* through them — and unbound sharing was not preserved
+   (`p(X,X)` copied to `p(_A,_B)`). The compiler grammar hit this squarely:
+   clauses parsed from one source string share variables by name, and
+   `numbervars` on clause 1's "copy" contaminated clause 3, making two
+   different variables compile to the same Y register. Fixed with a
+   var-mapped deep copy (the `@wam_dyn_copy_var` technique):
+   `@wam_deref_keep_var` keys each distinct unbound cell by heap address,
+   each maps to exactly one fresh heap cell — sharing preserved, zero
+   aliasing.
+
+**Remaining for the fixpoint:** first-arg **indexed** dispatch is not needed
+(chains suffice, correctness-first), but the compiler's own source also uses
+list patterns in heads (`[C|Cs]`), cut, `==`/`=:=` guards, if-then-else — the
+next Stage D increments, in whatever order the fixpoint attempt surfaces them.
+
 **Deliverable:** the demonstrable self-host — the compiler compiles itself,
 and `compile(SelfSource)` yields a working compiler object.
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3731,12 +3731,13 @@ wam_llvm_case('try_me_else',
   ; Set next_pc
   %tme.npc_ptr = getelementptr %ChoicePoint, %ChoicePoint* %tme.cp_slot, i32 0, i32 0
   store i32 %tme.next_pc, i32* %tme.npc_ptr
-  ; Save registers (copy 32 x %Value)
+  ; Save the FULL register file (128 x %Value = 2048 bytes) so backtrack
+  ; can restore Y17..Y48 (regs 64..95) clobbered by a failed clause body
   %tme.dst_regs = getelementptr %ChoicePoint, %ChoicePoint* %tme.cp_slot, i32 0, i32 1, i32 0
   %tme.src_regs = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
   %tme.dst_raw = bitcast %Value* %tme.dst_regs to i8*
   %tme.src_raw = bitcast %Value* %tme.src_regs to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %tme.dst_raw, i8* %tme.src_raw, i64 1024, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %tme.dst_raw, i8* %tme.src_raw, i64 2048, i1 false)
   ; Save trail mark
   %tme.ts_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
   %tme.ts = load i32, i32* %tme.ts_ptr
@@ -3958,7 +3959,7 @@ ba.setup:
   %ba.src_regs = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
   %ba.dst_raw = bitcast %Value* %ba.dst_regs to i8*
   %ba.src_raw = bitcast %Value* %ba.src_regs to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %ba.dst_raw, i8* %ba.src_raw, i64 1024, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %ba.dst_raw, i8* %ba.src_raw, i64 2048, i1 false)
 
   ; Save trail mark
   %ba.ts_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
@@ -4235,7 +4236,7 @@ restore:
   %src_regs = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 1, i32 0
   %dst_raw = bitcast %Value* %dst_regs to i8*
   %src_raw = bitcast %Value* %src_regs to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dst_raw, i8* %src_raw, i64 1024, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dst_raw, i8* %src_raw, i64 2048, i1 false)
 
   ; Restore PC from choice point next_pc
   %npc_ptr = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 0
@@ -17798,31 +17799,91 @@ ev_zero:
 }'.
 
 compile_copy_term_to_llvm(Code) :-
-    Code = '; Recursively copy a %Value, allocating fresh %Compound cells from
-; the arena for any compound encountered. Atomic values (Atom / Integer /
-; Float / Bool) are returned by value. Unbound values return a fresh
-; Unbound sentinel — a proper impl would use a variable-map to preserve
-; sharing and create fresh Refs, but the current bench corpus has no
-; shared unbound vars and this naive pass is enough for the flat and
-; nested compound cases. Cons-cell lists fall out automatically since
-; they are just compounds with functor "." / arity 2.
+    Code = '; Recursively copy a %Value with a variable map: fresh %Compound cells
+; (arena), fresh heap cells for variables, and sharing preserved -- each
+; distinct source variable maps to exactly ONE fresh cell. Atomic values
+; (Atom / Integer / Float / Bool) copy by value. Cons-cell lists fall out
+; automatically since they are just compounds with functor "." / arity 2.
 define %Value @wam_copy_term_value(%WamState* %vm, %Value %v) {
 entry:
-  %tag = call i32 @value_tag(%Value %v)
+  call void @wam_arena_ensure()
+  %map_mem = call i8* @wam_arena_alloc(i64 2048)
+  %map = bitcast i8* %map_mem to i64*
+  %fresh_mem = call i8* @wam_arena_alloc(i64 4096)
+  %freshes = bitcast i8* %fresh_mem to %Value*
+  %countp = alloca i32
+  store i32 0, i32* %countp
+  %r = call %Value @wam_copy_term_rec(%WamState* %vm, %Value %v, i64* %map, %Value* %freshes, i32* %countp)
+  ret %Value %r
+}
+
+; The recursive worker behind copy_term/2. Derefs via @wam_deref_keep_var
+; (follows Ref chains but keeps the final Ref, so an unbound variable has
+; an ADDRESS to key the map on). tag 5 Ref (an unbound var): look the heap
+; index up in the map; a hit reuses the fresh cell already made for that
+; source variable (sharing preserved: p(X,X) copies with ONE fresh var), a
+; miss pushes a fresh heap cell and records the pair (map capacity 256;
+; beyond it, extra vars copy fresh-but-unshared, never aliased). The OLD
+; implementation returned Refs unchanged (they fell into the atomic
+; default), so the "copy" aliased the source heap cells and numbervars /
+; unification on the copy bound the ORIGINAL term through them.
+define %Value @wam_copy_term_rec(%WamState* %vm, %Value %v, i64* %map, %Value* %freshes, i32* %countp) {
+entry:
+  %kv = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %v)
+  %tag = call i32 @value_tag(%Value %kv)
   switch i32 %tag, label %atomic [
     i32 3, label %ct_compound
+    i32 5, label %ct_var
     i32 6, label %ct_unbound
   ]
 
 atomic:
-  ret %Value %v
+  ret %Value %kv
 
 ct_unbound:
-  %fresh = call %Value @value_unbound(i8* null)
-  ret %Value %fresh
+  ; a bare Unbound value with no heap identity: cannot share, copy fresh.
+  %fresh_unb = call %Value @value_unbound(i8* null)
+  ret %Value %fresh_unb
+
+ct_var:
+  %addr = call i64 @value_payload(%Value %kv)
+  %count = load i32, i32* %countp
+  br label %scan
+scan:
+  %i = phi i32 [ 0, %ct_var ], [ %inext, %scan_cont ]
+  %seen_all = icmp sge i32 %i, %count
+  br i1 %seen_all, label %miss, label %probe
+probe:
+  %mp = getelementptr i64, i64* %map, i32 %i
+  %ma = load i64, i64* %mp
+  %hit = icmp eq i64 %ma, %addr
+  br i1 %hit, label %use, label %scan_cont
+scan_cont:
+  %inext = add i32 %i, 1
+  br label %scan
+use:
+  %fp = getelementptr %Value, %Value* %freshes, i32 %i
+  %fv0 = load %Value, %Value* %fp
+  ret %Value %fv0
+miss:
+  %unb = call %Value @value_unbound(i8* null)
+  %ha = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %fv = call %Value @value_ref(i32 %ha)
+  %room = icmp slt i32 %count, 256
+  br i1 %room, label %record, label %no_record
+record:
+  %mp2 = getelementptr i64, i64* %map, i32 %count
+  store i64 %addr, i64* %mp2
+  %fp2 = getelementptr %Value, %Value* %freshes, i32 %count
+  store %Value %fv, %Value* %fp2
+  %count1 = add i32 %count, 1
+  store i32 %count1, i32* %countp
+  br label %no_record
+no_record:
+  ret %Value %fv
 
 ct_compound:
-  %cp_bits = call i64 @value_payload(%Value %v)
+  %cp_bits = call i64 @value_payload(%Value %kv)
   %cp_ptr = inttoptr i64 %cp_bits to %Compound*
   %fn_slot = getelementptr %Compound, %Compound* %cp_ptr, i32 0, i32 0
   %fn_ptr = load i8*, i8** %fn_slot
@@ -17831,7 +17892,6 @@ ct_compound:
   %args_slot = getelementptr %Compound, %Compound* %cp_ptr, i32 0, i32 2
   %src_args = load %Value*, %Value** %args_slot
 
-  call void @wam_arena_ensure()
   %cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
   %new_mem = call i8* @wam_arena_alloc(i64 %cp_size)
   %new_cp = bitcast i8* %new_mem to %Compound*
@@ -17854,13 +17914,13 @@ ct_loop_entry:
   br label %ct_loop
 
 ct_loop:
-  %i = phi i32 [ 0, %ct_loop_entry ], [ %i_next, %ct_loop_step ]
-  %src_ptr = getelementptr %Value, %Value* %src_args, i32 %i
+  %i2 = phi i32 [ 0, %ct_loop_entry ], [ %i_next, %ct_loop_step ]
+  %src_ptr = getelementptr %Value, %Value* %src_args, i32 %i2
   %src_val = load %Value, %Value* %src_ptr
-  %dst_val = call %Value @wam_copy_term_value(%WamState* %vm, %Value %src_val)
-  %dst_ptr = getelementptr %Value, %Value* %new_args, i32 %i
+  %dst_val = call %Value @wam_copy_term_rec(%WamState* %vm, %Value %src_val, i64* %map, %Value* %freshes, i32* %countp)
+  %dst_ptr = getelementptr %Value, %Value* %new_args, i32 %i2
   store %Value %dst_val, %Value* %dst_ptr
-  %i_next = add i32 %i, 1
+  %i_next = add i32 %i2, 1
   %more = icmp slt i32 %i_next, %arity
   br i1 %more, label %ct_loop_step, label %ct_done
 

--- a/templates/targets/llvm_wam/types.ll.mustache
+++ b/templates/targets/llvm_wam/types.ll.mustache
@@ -68,7 +68,11 @@
 ;                  0 = sum, 1 = count, 2 = min, 3 = max, 4 = collect, 5 = bag
 %ChoicePoint = type {
     i32,                                   ; 0: next_pc
-    [64 x %Value],                         ; 1: saved registers
+    [128 x %Value],                        ; 1: saved registers (full register file
+                                           ;    incl. Y17..Y48 at 64..95 -- a failed
+                                           ;    clause body writes its own Y regs and
+                                           ;    never reaches deallocate, so backtrack
+                                           ;    must restore the WHOLE file, not 0..63)
     i32,                                   ; 2: trail mark
     i32,                                   ; 3: saved cp
     i32,                                   ; 4: agg_type (-1=normal, -2=foreign iter)

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -520,28 +520,85 @@ wz_fname(F, A0, A1) :- atom_codes(F, Cs), wz_n(Cs, A0, A1).
 wz_funcs([], A, A).
 wz_funcs([F|Fs], A0, A2) :- wz_fname(F, A0, A1), wz_funcs(Fs, A1, A2).
 
-% Milestone 6 (self-host) Stage C (non-tail calls): the UNIFIED compiler.
-% cgfull/2 merges every Stage C piece into one multi-clause compiler: labels +
-% PC table (from cgcprog), per-clause register allocation + conjunction (cgconj),
-% runtime arithmetic + functor table (cgarith), and now non-tail predicate-call
-% goals. A call goal p(Args) sets up A1.. with the args (operand_instr) then
+% Milestone 6 (self-host) Stage C (non-tail calls) + Stage D (multi-clause):
+% the UNIFIED compiler. cgfull/2 merges every piece: labels + PC table
+% (from cgcprog), per-clause register allocation + conjunction (cgconj),
+% runtime arithmetic + functor table (cgarith), non-tail predicate-call
+% goals -- and now MULTIPLE CLAUSES PER PREDICATE. Consecutive clauses with
+% the same name/arity group into one predicate (group_clauses); the predicate
+% gets the entry label (its group index), and clauses 2..k get alternative
+% labels laid out after all entry labels. A multi-clause predicate compiles
+% to a try_me_else(Alt1) / retry_me_else(Alt_k+1) / trust_me chain (tags
+% 22/23/24) around the per-clause code, so a failing head match backtracks to
+% the next clause -- backtracking dispatch AND recursion now compile.
+% A call goal p(Args) sets up A1.. with the args (operand_instr) then
 % call(CalleeLabel, arity) (tag 18) -- a non-tail call: cp = the next PC, so
 % execution resumes after the call when the callee proceeds. A permanent holds
-% the result across the call (register allocation makes any variable spanning
-% the call a Y-register). Each clause is copy_term'd + numbervars'd so its
+% the result across the call. Each clause is copy_term'd + numbervars'd so its
 % variables are clause-local. Facts (no body) emit head + proceed (no env).
-% Verified byte-identical to the host writer for
-% [(mnt(R):-helper(A), R=A), helper(42)] -- a non-tail call whose result A is
-% used after the call.
+% Single-clause predicates emit no chain, so the Stage C output (verified
+% byte-identical to the host writer for the mnt program) is unchanged.
 cgfull(Src, Wamo) :-
     read_term_from_atom(Src, Clauses),
-    assign_labels(Clauses, 0, PL),
+    group_clauses(Clauses, Groups),
+    group_labels(Groups, 0, PL),
+    length(Groups, NP),
     f_collect_all(Clauses, Functors),
-    f_codegen_all(Clauses, PL, Functors, 0, AllIs, PCs),
+    g_groups(Groups, PL, Functors, 0, NP, AllIs, EntryPCs, AltPCs),
+    append(EntryPCs, AltPCs, PCs),
     Clauses = [First|_], clause_hb(First, H0, _), functor(H0, P0, A0),
     pred_name_codes(P0, A0, EntryName),
     wzf_serialize(0, EntryName, 0, Functors, PCs, AllIs, Codes),
     atom_codes(Wamo, Codes).
+
+% group consecutive clauses with the same name/arity into pred(P,A,Clauses)
+group_clauses([], []).
+group_clauses([C|Cs], [pred(P,A,[C|Same])|Gs]) :-
+    clause_hb(C, H, _), functor(H, P, A),
+    take_same(Cs, P, A, Same, Rest),
+    group_clauses(Rest, Gs).
+take_same([], _, _, [], []).
+take_same([C|Cs], P, A, Same, Rest) :-
+    clause_hb(C, H, _), functor(H, P2, A2),
+    (   P2 == P, A2 =:= A
+    ->  Same = [C|Same1], take_same(Cs, P, A, Same1, Rest)
+    ;   Same = [], Rest = [C|Cs]
+    ).
+group_labels([], _, []).
+group_labels([pred(P,A,_)|Gs], I, [key(P,A)-I|R]) :- I1 is I+1, group_labels(Gs, I1, R).
+
+% per-group codegen; threads PC and the next alternative-label number, and
+% collects alternative PCs in assignment order (so EntryPCs ++ AltPCs is the
+% label->PC table with labels positional).
+g_groups([], _, _, _, _, [], [], []).
+g_groups([pred(_,_,Cls)|Gs], PL, FT, PC, Alt0, AllIs, [PC|EPCs], AltPCs) :-
+    g_pred(Cls, PL, FT, PC, Alt0, Is, PC1, Alt1, APCs1),
+    g_groups(Gs, PL, FT, PC1, Alt1, RestIs, EPCs, APCs2),
+    append(Is, RestIs, AllIs), append(APCs1, APCs2, AltPCs).
+
+g_pred([C], PL, FT, PC, Alt, Is, PC1, Alt, []) :-      % single clause: no chain
+    g_one(C, PL, FT, Is), length(Is, N), PC1 is PC + N.
+g_pred([C1,C2|Rest], PL, FT, PC, Alt0, Is, PCout, AltOut, AltPCs) :-
+    g_one(C1, PL, FT, C1Is),
+    length(C1Is, N1), PC1 is PC + 1 + N1,
+    Alt1 is Alt0 + 1,
+    g_alts([C2|Rest], PL, FT, PC1, Alt1, AltIs, PCout, AltOut, AltPCs),
+    append([enc(22,Alt0,0,0)|C1Is], AltIs, Is).         % try_me_else(Alt0)
+
+g_alts([C], PL, FT, PC, Alt, Is, PCout, Alt, [PC]) :-   % last alternative
+    g_one(C, PL, FT, CIs),
+    Is = [enc(24,0,0,0)|CIs],                           % trust_me
+    length(Is, N), PCout is PC + N.
+g_alts([C1,C2|Rest], PL, FT, PC, Alt, Is, PCout, AltOut, [PC|AltPCs]) :-
+    g_one(C1, PL, FT, C1Is),
+    length(C1Is, N1), PC1 is PC + 1 + N1,
+    Alt1 is Alt + 1,
+    g_alts([C2|Rest], PL, FT, PC1, Alt1, RestIs, PCout, AltOut, AltPCs),
+    append([enc(23,Alt,0,0)|C1Is], RestIs, Is).         % retry_me_else(Alt)
+
+g_one(C0, PL, FT, Is) :-
+    copy_term(C0, C), numbervars(C, 0, _),
+    f_clause_instrs(C, PL, FT, Is).
 
 % functor table across all clauses
 f_collect_all([], []).
@@ -550,13 +607,6 @@ f_collect_all([C|Cs], FT) :-
     collect_functors(Gs, F1), f_collect_all(Cs, F2), f_merge(F1, F2, FT).
 f_merge([], FT, FT).
 f_merge([F|Fs], A0, FT) :- add_unique(F, A0, A1), f_merge(Fs, A1, FT).
-
-% per-clause codegen, tracking the label->PC list
-f_codegen_all([], _, _, _, [], []).
-f_codegen_all([C0|Cs], PL, FT, PC, All, [PC|PCs]) :-
-    copy_term(C0, C), numbervars(C, 0, _),
-    f_clause_instrs(C, PL, FT, Is), length(Is, N), PC1 is PC + N,
-    f_codegen_all(Cs, PL, FT, PC1, Rest, PCs), append(Is, Rest, All).
 
 f_clause_instrs(Clause, PL, FT, Instrs) :-
     clause_hb(Clause, Head, Goals), functor(Head, _, Arity),
@@ -1314,6 +1364,35 @@ test(selfhost_codegen_stage_c_nontail_call, [condition(clang_available)]) :-
           process_wait(Pid, exit(Status)),
           assertion(Status == 0),
           assertion(Out == "42\n") )),
+    !.
+
+% Milestone 6 (self-host) Stage D (multi-clause predicates): cgfull compiles
+% predicates with MULTIPLE clauses into try_me_else/retry_me_else/trust_me
+% chains -- backtracking dispatch and recursion from source text. Two
+% programs: (1) dispatch -- picku/2 has two clauses; picku(2,R) must FAIL
+% clause 1's head (get_constant 1 vs 2), backtrack through the chain, and
+% match clause 2 -> 42. (2) recursion -- factorial with a base clause and a
+% recursive clause (self-call by label, arithmetic on the way down and up);
+% fact(3) -> 6. Both compile inside a loaded compiler object via the eval host.
+test(selfhost_codegen_stage_d_multiclause, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    forall(member(Source-Expected,
+               [ '[(main0(R):-picku(2,R)), picku(1,10), picku(2,42)]' - "42\n",
+                 '[(main0(R):-fact(3,R)), fact(0,1), (fact(N,R):- M is N-1, fact(M,F), R is N*F)]' - "6\n" ]),
+        ( directory_file_path(Dir, 'cgmc_src.txt', SrcPath),
+          setup_call_cleanup(open(SrcPath, write, S0),
+              write(S0, Source), close(S0)),
+          process_create(Host, [CompWamo, SrcPath],
+              [stdout(pipe(S)), stderr(std), process(Pid)]),
+          read_string(S, _, Out),
+          close(S),
+          process_wait(Pid, exit(Status)),
+          assertion(Status == 0),
+          assertion(Out == Expected) )),
     !.
 
 % Register-file ceiling fix: a clause with 20 permanent variables (Y1..Y20)


### PR DESCRIPTION
## What

The **Stage D opener**: `cgfull/2` now compiles predicates with **multiple clauses** — so backtracking dispatch and **recursion** compile from source text, the biggest structural gap between the bootstrap compiler and real Prolog.

- **`group_clauses`**: consecutive clauses with the same name/arity group into one predicate; the predicate owns the entry label, clauses 2..k get **alternative labels** laid out after all entry labels (label→PC table = `EntryPCs ++ AltPCs`, so labels stay positional).
- A multi-clause predicate compiles to a **`try_me_else(Alt1)` / `retry_me_else(Alt_k+1)` / `trust_me`** chain (tags 22/23/24) around the per-clause code. A failing head match backtracks to the next clause.
- Single-clause predicates emit no chain, so all Stage B/C output is byte-for-byte unchanged.

**Verified end to end** (`selfhost_codegen_stage_d_multiclause`): a two-clause dispatch whose caller needs the *second* clause → **42**, and **recursive factorial** (base + recursive clause, arithmetic down and up, self-call by label): `fact(3)` → **6** — both compiled inside a loaded compiler object.

## Two more latent runtime bugs surfaced and fixed (nos. 3 and 4 of the campaign)

**3. Choice-point saved-register block not widened with the register file.** PR #3510 grew the register file to `[128 x %Value]` and the env `y_save` to 48 permanents — but `%ChoicePoint` kept `[64 x %Value]`: `try_me_else` saved and `backtrack` restored only regs 0–63. A **failed clause body** writes its own Y registers and never reaches `deallocate` (env snapshot bypassed); backtrack restored Y1–Y16 from the CP but left **Y17–Y48 (regs 64–95) holding the failed clause's junk**, corrupting the backtracked-to alternative's permanents. The multi-clause compiler was the first backtracking-heavy client with big enough clauses (the new `cgfull/2` entry holds 17 permanents) to hit it. **Fix:** CP block `[128 x %Value]`; the three normal-CP save/restore memcpys widened 1024 → 2048 bytes (the deliberate 512-byte *iterator* restores untouched). Diagnosed by diffing the loaded compiler's emitted bytes against the known-good SWI output — a single `put_variable`-vs-`put_value` instruction pinpointed a corrupted `is_init` result.

**4. `copy_term/2` aliased instead of copying.** `@wam_copy_term_value` returned `Ref`s **unchanged** (they fell into the atomic default), so the "copy" shared the source heap cells — `numbervars`/unification on the copy bound the *original* through them — and unbound sharing wasn't preserved (`p(X,X)` → `p(_A,_B)`). The compiler grammar hit this squarely: clauses parsed from one source string share variables by name, and `numbervars` on clause 1's copy contaminated clause 3, making two different variables compile to the **same Y register** (visible as duplicate `get_variable Y48` in the emitted head). **Fix:** a var-mapped deep copy using the `@wam_dyn_copy_var` technique — `@wam_deref_keep_var` keys each distinct unbound cell by heap address, each maps to exactly one fresh heap cell. Sharing preserved, zero aliasing (map capacity 256, graceful fresh-unshared beyond).

## Testing

- New test `selfhost_codegen_stage_d_multiclause` (dispatch → 42, factorial → 6).
- Loaded compiler output verified **identical** to the known-good SWI prototype for both programs.
- Full `wam_object`, `test_llvm_target`, and plawk execution suites: **0 failures** (host cache cleared — both fixes are runtime changes).

## Docs

`PLAWK_SELFHOST.md` (Stage D section + both bug write-ups) and the JIT roadmap updated — the self-host campaign has now surfaced and fixed **four** latent runtime bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_