### PR TITLE
Record Product-Kalman bootstrap artifact provenance

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -390,8 +390,9 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    pending.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
    descriptive Markdown run note. When row-level `eval_artifacts.npz` exists, the report CLI can add paired bootstrap
-   NLL intervals post hoc without rerunning scoring, verifies the row artifact against the score summary, and can write
-   the enriched score JSON beside the Markdown report. The report is an audit artifact only: it records scores and
+   NLL intervals post hoc without rerunning scoring, verifies the row artifact against the score summary, records the
+   artifact hash, and can write the enriched score JSON beside the Markdown report. The report is an audit artifact
+   only: it records scores and
    provenance, but does not encode a decision rule or promote Product-Kalman without comparison against registered
    baselines.
 9. Fit empirical Product-Kalman variants on those calibration blocks, then compare against `JointPosterior` and

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -7,6 +7,7 @@ claim that Product-Kalman has won.
 """
 
 import argparse
+import hashlib
 import json
 import sys
 
@@ -36,6 +37,14 @@ def load_json(path):
     """Load a JSON file."""
     with open(path, encoding="utf-8") as f:
         return json.load(f)
+
+
+def _sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _fmt(value):
@@ -108,6 +117,22 @@ def _bootstrap_rows(scores_json):
                 item.get("n"),
             ])
     return rows
+
+
+def _bootstrap_artifact_rows(scores_json):
+    artifact = scores_json.get("bootstrap_artifact", {})
+    if not artifact:
+        return []
+    return [
+        ["evaluation_npz", artifact.get("evaluation_npz")],
+        ["evaluation_npz_sha256", artifact.get("evaluation_npz_sha256")],
+        ["validated_against_scores", artifact.get("validated_against_scores")],
+        ["score_order", ", ".join(artifact.get("score_order", []))],
+        ["n_boot", artifact.get("n_boot")],
+        ["seed", artifact.get("seed")],
+        ["confidence", artifact.get("confidence")],
+        ["method", artifact.get("method")],
+    ]
 
 
 def _input_rows(scores_json, manifest):
@@ -217,9 +242,11 @@ def add_artifact_bootstrap_intervals(
     if not n_boot:
         return scores_json
     artifact_path = _artifact_path(scores_json, evaluation_npz=evaluation_npz)
+    artifact_summary = evaluation_npz_score_summary(artifact_path)
     if validate_artifact:
-        validate_artifact_score_consistency(scores_json, evaluation_npz=artifact_path)
+        artifact_summary = validate_artifact_score_consistency(scores_json, evaluation_npz=artifact_path)
     out = dict(scores_json)
+    changed = False
     for key, value in bootstrap_nll_improvements_from_evaluation_npz(
         artifact_path,
         n_boot=n_boot,
@@ -228,6 +255,18 @@ def add_artifact_bootstrap_intervals(
     ).items():
         if overwrite or key not in out:
             out[key] = value
+            changed = True
+    if changed:
+        out["bootstrap_artifact"] = {
+            "evaluation_npz": str(artifact_path),
+            "evaluation_npz_sha256": _sha256_file(artifact_path),
+            "validated_against_scores": bool(validate_artifact),
+            "score_order": artifact_summary["score_order"],
+            "n_boot": int(n_boot),
+            "seed": int(seed),
+            "confidence": float(confidence),
+            "method": "paired_row_resample",
+        }
     return out
 
 
@@ -292,6 +331,7 @@ def build_product_kalman_markdown_report(
             "",
         ])
     bootstrap_rows = _bootstrap_rows(scores_json)
+    bootstrap_artifact_rows = _bootstrap_artifact_rows(scores_json)
     lines.extend([
         "## Scores",
         "",
@@ -335,6 +375,13 @@ def build_product_kalman_markdown_report(
                 ],
                 bootstrap_rows,
             ),
+            "",
+        ])
+    if bootstrap_artifact_rows:
+        lines.extend([
+            "## Bootstrap Artifact",
+            "",
+            _markdown_table(["item", "value"], bootstrap_artifact_rows),
             "",
         ])
     lines.extend([

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -184,6 +184,13 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
             confidence=0.90,
         )
         assert "nll_improvement_bootstrap_vs_prior" in recorded_path_enriched
+        artifact_meta = enriched["bootstrap_artifact"]
+        assert artifact_meta["evaluation_npz"] == str(eval_npz)
+        assert len(artifact_meta["evaluation_npz_sha256"]) == 64
+        assert artifact_meta["validated_against_scores"] is True
+        assert artifact_meta["score_order"] == scores["score_order"]
+        assert artifact_meta["n_boot"] == 50
+        assert artifact_meta["method"] == "paired_row_resample"
 
         bad_order = dict(scores)
         bad_order["score_order"] = list(reversed(scores["score_order"]))
@@ -218,9 +225,12 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
         assert rc == 0
         text = output_md.read_text()
         assert "## NLL Improvement Bootstrap Intervals" in text
+        assert "## Bootstrap Artifact" in text
+        assert "evaluation_npz_sha256" in text
         assert "| independent_kalman | product_kalman |" in text
         enriched_json = json.loads(output_json.read_text())
         assert enriched_json["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"] == boot
+        assert enriched_json["bootstrap_artifact"] == artifact_meta
 
 
 def test_markdown_report_cli_writes_file():


### PR DESCRIPTION
Adds provenance metadata when Product-Kalman reports enrich score JSON from row-level evaluation artifacts.

Changes:
- Record the `eval_artifacts.npz` path and SHA-256 hash in enriched score JSON.
- Render a `Bootstrap Artifact` table in Markdown reports when provenance is present.
- Record bootstrap parameters and score order alongside the artifact hash.
- Avoid stamping provenance metadata when existing bootstrap intervals are preserved without overwrite.
- Update the Product-Kalman design note and report tests.

Validation:
- `python3 -m py_compile ...`
- direct report test
- focused pytest suite: 25 passed
- calibration smoke tests: 12 passed
- Product-Kalman core smoke tests: 16 passed
- `git diff --check`