### PR TITLE
WAM/LLVM (roadmap #5, milestone 6): Stage D -- builtin goals + univ compose fixes

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -391,17 +391,23 @@ loadable along the way.
   `trust_me` with mid-clause else/join labels (codegen is now PC- and
   label-aware; max-of-two exercises both branches → `42`); **general structure
   patterns LANDED**: arbitrary compounds in heads and call args — flat, nested
-  (X-temp deferral), pairs, and the compiler's own `enc/4` shape — all → `42`.
+  (X-temp deferral), pairs, and the compiler's own `enc/4` shape — all → `42`;
+  **builtin goals LANDED**: ~37 whitelisted builtins (term inspection, text,
+  lists, type checks) as staged-args + `builtin_call`, `=/2` upgraded to
+  full-term operands, data atoms collected into the atom table.
   The remaining Stage D campaign widens the
   subset toward the compiler compiling its own source — the self-host fixpoint.
-  The campaign keeps surfacing and fixing latent runtime bugs — **five fixed so
+  The campaign keeps surfacing and fixing latent runtime bugs — **seven fixed so
   far**: a 64-register-file ceiling corrupting memory for large clauses;
   `get_structure` not comparing the functor; the choice-point saved-register
   block not widened with the register file (failed clause bodies leaked Y17+
   across backtrack); and `copy_term/2` aliasing instead of copying (Refs
   returned unchanged, no sharing preservation); and `get_list` read mode
   accepting any compound (no cons/arity check — `[H|T]` wrongly matched
-  `foo(A,B)`). See
+  `foo(A,B)`); the loaded reader missing `=..`/`=\=`/`\==` operators; and
+  `=../2` compose mode broken three ways (no deref of Ref-linked list
+  spines, id-based atom payload used as a functor pointer, result bound to
+  the register instead of through the Ref). See
   [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md).
 
 ## The binary-return question, specifically

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -462,6 +462,42 @@ verify `@wam_functor_is_cons` (byte compare, so reader-built lists match) and
 arity 2 before pushing the UnifyCtx — the fifth latent runtime bug the
 self-host campaign has found and fixed.
 
+**Builtin goals — LANDED.** A whitelist of ~37 builtins the compiler's own
+source uses now compiles as goals: term inspection (`functor/3`, `arg/3`,
+`=../2`, `copy_term/2`), text (`atom_codes`, `number_codes`, `atom_concat`,
+`char_code`, `term_to_atom`, `read_term_from_atom`, …), lists (`length`,
+`append`, `reverse`, `nth0/1`, `msort`, `sort`, `keysort`, `pairs_*`,
+`memberchk`, `between`), type checks (`atom`, `integer`, `var`, `compound`,
+…), `numbervars/3` and `\=`. Each stages its args like a call (`c_operand`
+per arg) and emits `builtin_call(Id, Arity)`. Notably the grammar emits
+`builtin_call arg/3` even for a constant index — the host compiler's
+specialised-`arg` subset gap simply never arises in self-compiled code.
+`=/2` upgraded to full-term operands (either side may be a structure or list
+literal), and the table walk collects data atoms into the atom table.
+Verified end to end (`selfhost_codegen_stage_d_builtins`): functor+arg,
+`=..` construct + structure unify, atom_codes+length over a data atom, and a
+type-check ITE condition — all → `42`.
+
+**Runtime fixes this surfaced (nos. 6–7 of the campaign):**
+
+1. **The loaded reader lacked `=..`, `=\=`, `\==`** in its operator table
+   (`@wam_infix_op`) — `T =.. L` would not even parse in a loaded object.
+   Added as xfx 700 length-3 symbol operators (`.` was already a symbol
+   char, so `=..` tokenizes as one run).
+2. **`=../2` compose mode had never worked** ("most benchmarks only exercise
+   decompose"). Three distinct defects, found by printf-instrumenting the
+   generated IR: (a) the list walk **never dereferenced** — compiled list
+   spines link conses through Refs (`set_variable` tail + write-mode
+   `put_structure`), so the walk bailed at the first tag-5 tail; (b) the
+   functor element was converted by `inttoptr` of its payload — but atoms
+   are id-based since M100, so the built compound carried a garbage functor
+   pointer (the decompose/functor/3 fix had missed compose); (c) the result
+   was bound with `wam_set_reg` — overwriting register A1 only, never
+   binding **through** the Ref shared with the caller's permanent register
+   (the M9 aggregate-result bug, resurfaced in univ), so the constructed
+   term vanished for later goals. All three fixed; construct mode now works
+   in AOT and loaded objects alike.
+
 **Deliverable:** the demonstrable self-host — the compiler compiles itself,
 and `compile(SelfSource)` yields a working compiler object.
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -6622,7 +6622,31 @@ len3c:
   %c2 = icmp eq i8 %q2, 61
   %cc = and i1 %c0, %c1
   %is_aeq = and i1 %cc, %c2
-  br i1 %is_aeq, label %r_xfx700, label %none
+  br i1 %is_aeq, label %r_xfx700, label %len3d
+len3d:
+  ; =.. (univ, xfx 700): bytes 61 46 46
+  %d0 = icmp eq i8 %q0, 61
+  %d1 = icmp eq i8 %q1, 46
+  %d2 = icmp eq i8 %q2, 46
+  %dd = and i1 %d0, %d1
+  %is_univ = and i1 %dd, %d2
+  br i1 %is_univ, label %r_xfx700, label %len3e
+len3e:
+  ; arith not-equal (eq backslash eq, xfx 700): bytes 61 92 61
+  %e0 = icmp eq i8 %q0, 61
+  %e1 = icmp eq i8 %q1, 92
+  %e2 = icmp eq i8 %q2, 61
+  %ee = and i1 %e0, %e1
+  %is_aneq = and i1 %ee, %e2
+  br i1 %is_aneq, label %r_xfx700, label %len3f
+len3f:
+  ; term not-equal (backslash eq eq, xfx 700): bytes 92 61 61
+  %f0 = icmp eq i8 %q0, 92
+  %f1 = icmp eq i8 %q1, 61
+  %f2 = icmp eq i8 %q2, 61
+  %ff = and i1 %f0, %f1
+  %is_tneq = and i1 %ff, %f2
+  br i1 %is_tneq, label %r_xfx700, label %none
 r_yfx500:
   ret i32 8002
 r_yfx400:
@@ -12383,8 +12407,13 @@ u.c.walk_init:
   br label %u.c.count_loop
 
 u.c.count_loop:
+  ; deref each spine value: a compiled list links conses through Refs
+  ; (set_variable tail slot + write-mode put_structure binds the fresh
+  ; cell), so raw tail slots are tag-5 Refs, not direct Compounds. The
+  ; old walk never derefed and bailed at the first Ref tail.
   %u.c.count = phi i32 [ 0, %u.c.walk_init ], [ %u.c.count_next, %u.c.count_step ]
-  %u.c.cur = phi %Value [ %u.c.a2, %u.c.walk_init ], [ %u.c.next_tail, %u.c.count_step ]
+  %u.c.cur0 = phi %Value [ %u.c.a2, %u.c.walk_init ], [ %u.c.next_tail, %u.c.count_step ]
+  %u.c.cur = call %Value @wam_deref_value(%WamState* %vm, %Value %u.c.cur0)
   %u.c.cur_tag = call i32 @value_tag(%Value %u.c.cur)
   %u.c.is_cons = icmp eq i32 %u.c.cur_tag, 3
   br i1 %u.c.is_cons, label %u.c.count_body, label %u.c.count_done
@@ -12430,7 +12459,8 @@ u.c.nonempty:
 
 u.c.collect_loop:
   %u.c.ci = phi i32 [ 0, %u.c.nonempty ], [ %u.c.ci_next, %u.c.collect_step ]
-  %u.c.cc = phi %Value [ %u.c.a2, %u.c.nonempty ], [ %u.c.cc_tail, %u.c.collect_step ]
+  %u.c.cc0 = phi %Value [ %u.c.a2, %u.c.nonempty ], [ %u.c.cc_tail, %u.c.collect_step ]
+  %u.c.cc = call %Value @wam_deref_value(%WamState* %vm, %Value %u.c.cc0)
   %u.c.done_c = icmp sge i32 %u.c.ci, %u.c.count
   br i1 %u.c.done_c, label %u.c.build, label %u.c.collect_step
 
@@ -12453,25 +12483,36 @@ u.c.build:
   br i1 %u.c.is_one, label %u.c.bind_atomic, label %u.c.build_compound
 
 u.c.bind_atomic:
-  ; Single-element list → bind A1 directly to element[0].
+  ; Single-element list → bind A1 directly to element[0]. Bind via
+  ; wam_bind_reg, NOT wam_set_reg: when A1 was staged by put_variable it
+  ; holds a Ref shared with a caller permanent register, and the
+  ; binding must write THROUGH the Ref to the heap cell or the caller
+  ; never sees the result (the M9 aggregate-result bug, here in univ).
   %u.c.elem0_ptr = getelementptr %Value, %Value* %u.c.buf, i32 0
-  %u.c.elem0 = load %Value, %Value* %u.c.elem0_ptr
+  %u.c.elem0r = load %Value, %Value* %u.c.elem0_ptr
+  %u.c.elem0 = call %Value @wam_deref_value(%WamState* %vm, %Value %u.c.elem0r)
   call void @wam_trail_binding(%WamState* %vm, i32 0)
-  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %u.c.elem0)
+  call void @wam_bind_reg(%WamState* %vm, i32 0, %Value %u.c.elem0)
   ret i1 true
 
 u.c.build_compound:
-  ; element[0] must be an Atom (tag 0). Arity = count - 1.
+  ; element[0] must be an Atom (tag 0). Arity = count - 1. Deref: the
+  ; head slot may hold a Ref to the atom cell.
   %u.c.f_ptr = getelementptr %Value, %Value* %u.c.buf, i32 0
-  %u.c.f = load %Value, %Value* %u.c.f_ptr
+  %u.c.f0 = load %Value, %Value* %u.c.f_ptr
+  %u.c.f = call %Value @wam_deref_value(%WamState* %vm, %Value %u.c.f0)
   %u.c.f_tag = call i32 @value_tag(%Value %u.c.f)
   %u.c.f_is_atom = icmp eq i32 %u.c.f_tag, 0
   br i1 %u.c.f_is_atom, label %u.c.alloc_compound, label %u.fail
 
 u.c.alloc_compound:
+  ; M100: atoms are id-based -- the payload is an interned atom id, not a
+  ; string pointer. Convert via wam_atom_to_string (the same fix decompose
+  ; and functor/3 received; compose was missed, so it stored a garbage
+  ; functor pointer built by inttoptr of a small id).
   %u.c.new_arity = sub i32 %u.c.count, 1
   %u.c.f_payload = call i64 @value_payload(%Value %u.c.f)
-  %u.c.f_ptr_i8 = inttoptr i64 %u.c.f_payload to i8*
+  %u.c.f_ptr_i8 = call i8* @wam_atom_to_string(i64 %u.c.f_payload)
   %u.c.cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
   %u.c.new_mem = call i8* @wam_arena_alloc(i64 %u.c.cp_size)
   %u.c.new_cp = bitcast i8* %u.c.new_mem to %Compound*
@@ -12502,11 +12543,15 @@ u.c.copy_step:
   br label %u.c.copy_loop
 
 u.c.bind_compound:
+  ; Bind through the Ref (wam_bind_reg, not wam_set_reg) -- see
+  ; u.c.bind_atomic. Overwriting only register A1 left the caller
+  ; aliased permanent register holding the still-unbound cell, so the
+  ; constructed term vanished for every later use of the output var.
   %u.c.new_i64 = ptrtoint %Compound* %u.c.new_cp to i64
   %u.c.new_val0 = insertvalue %Value undef, i32 3, 0
   %u.c.new_val = insertvalue %Value %u.c.new_val0, i64 %u.c.new_i64, 1
   call void @wam_trail_binding(%WamState* %vm, i32 0)
-  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %u.c.new_val)
+  call void @wam_bind_reg(%WamState* %vm, i32 0, %Value %u.c.new_val)
   ret i1 true
 
 builtin_copy_term:

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -625,6 +625,8 @@ walk_term(T, S0, S) :- compound(T), !, T =.. [F|Args],
 skip_fn(':-'). skip_fn(','). skip_fn(';'). skip_fn('->'). skip_fn(is).
 skip_fn(=). skip_fn(>). skip_fn(<). skip_fn(>=). skip_fn(=<).
 skip_fn(=:=). skip_fn(=\=). skip_fn(==). skip_fn(\==).
+walk_term(T, S0, S) :- atom(T), !,          % data atom -> atom table
+    S0 = s(At0, Fn0), add_unique(T, At0, At1), S = s(At1, Fn0).
 walk_term(_, S, S).
 walk_list([], S, S).
 walk_list([A|As], S0, S) :- walk_term(A, S0, S1), walk_list(As, S1, S).
@@ -769,8 +771,13 @@ f_goal(( C -> T ; E ), PL, At, FT, PC0, PC, L0, L, Prs0, Prs, In0, In, Is) :- !,
     append(Front, [enc(32,JoinL,0,0), enc(24,0,0,0)|ElseIs], Is).
 f_goal((L is E), _, _, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In1, Is) :- !,
     a_goal_instrs((L is E), FT, In0, In1, Is), length(Is, N), PC is PC0 + N.
-f_goal((L = R), _, _, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In1, Is) :- !,
-    a_goal_instrs((L = R), FT, In0, In1, Is), length(Is, N), PC is PC0 + N.
+f_goal((L = R), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In2, Is) :- !,
+    % full-term unification: either side may be a variable, constant, list
+    % or structure literal (c_operand builds it) -- then builtin =/2
+    c_operand(L, 0, At, FT, In0, In1, IL),
+    c_operand(R, 1, At, FT, In1, In2, IR),
+    append(IL, IR, LR), append(LR, [enc(21,24,2,0)], Is),
+    length(Is, N), PC is PC0 + N.
 f_goal(Cmp, _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-
     functor(Cmp, Op, 2), cmp_id(Op, Id), !,            % comparison guard
     arg(1, Cmp, A1), arg(2, Cmp, A2),
@@ -778,11 +785,60 @@ f_goal(Cmp, _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-
     c_operand(A2, 1, At, FT, In1, In, IR),
     append(IL, IR, LR), append(LR, [enc(21,Id,2,0)], Is),
     length(Is, N), PC is PC0 + N.
+f_goal(Goal, _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-
+    functor(Goal, P, A), bi_id(P, A, Id), !,           % builtin goal
+    call_args(Goal, 1, A, At, FT, In0, In, SetupIs),
+    append(SetupIs, [enc(21, Id, A, 0)], Is),          % builtin_call(Id, A)
+    length(Is, N), PC is PC0 + N.
 f_goal(Goal, PL, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-  % predicate call
     functor(Goal, P, A), lookup_label(P, A, PL, Label),
     call_args(Goal, 1, A, At, FT, In0, In, SetupIs),
     append(SetupIs, [enc(18, Label, A, 0)], Is),       % call(Label, arity)
     length(Is, N), PC is PC0 + N.
+
+% builtin goals the grammar can emit directly: name/arity -> builtin id (the
+% host runtime's builtin_op_to_id table). Staged like a call (c_operand per
+% arg into A1..An) then builtin_call(Id, Arity). NB: the grammar emits
+% builtin_call for arg/3 even with a constant index -- the host tier-2
+% compiler's specialised arg opcode (the known subset gap) is simply never
+% generated here, so loaded objects get the loadable builtin form.
+bi_id(functor, 3, 26).
+bi_id(arg, 3, 27).
+bi_id(=.., 2, 28).
+bi_id(copy_term, 2, 29).
+bi_id(atom_codes, 2, 36).
+bi_id(atom_chars, 2, 38).
+bi_id(char_code, 2, 37).
+bi_id(number_codes, 2, 43).
+bi_id(atom_number, 2, 42).
+bi_id(atom_length, 2, 35).
+bi_id(atom_concat, 3, 40).
+bi_id(length, 2, 31).
+bi_id(append, 3, 55).
+bi_id(reverse, 2, 54).
+bi_id(nth0, 3, 51).
+bi_id(nth1, 3, 52).
+bi_id(last, 2, 53).
+bi_id(memberchk, 2, 56).
+bi_id(between, 3, 39).
+bi_id(msort, 2, 30).
+bi_id(sort, 2, 81).
+bi_id(keysort, 2, 80).
+bi_id(pairs_keys, 2, 70).
+bi_id(pairs_values, 2, 71).
+bi_id(atom, 1, 13).
+bi_id(integer, 1, 14).
+bi_id(number, 1, 16).
+bi_id(compound, 1, 17).
+bi_id(var, 1, 18).
+bi_id(nonvar, 1, 19).
+bi_id(is_list, 1, 20).
+bi_id(ground, 1, 132).
+bi_id(succ, 2, 22).
+bi_id(\=, 2, 25).
+bi_id(numbervars, 3, 124).
+bi_id(term_to_atom, 2, 173).
+bi_id(read_term_from_atom, 2, 174).
 
 call_args(_, I, Ar, _, _, In, In, []) :- I > Ar, !.
 call_args(Goal, I, Ar, At, FT, In0, In, Is) :-
@@ -1693,6 +1749,37 @@ test(selfhost_codegen_stage_d_structures, [condition(clang_available)]) :-
                  '[(main0(R):- p(40-2,R)), (p(A-B,R):- R is A+B)]' - "42\n",
                  '[(main0(R):- d(enc(20,10,7,5),R)), (d(enc(T,O1,O2,Rl),R):- A is T+O1, B is O2+Rl, R is A+B)]' - "42\n" ]),
         ( directory_file_path(Dir, 'cgs_src.txt', SrcPath),
+          setup_call_cleanup(open(SrcPath, write, S0),
+              write(S0, Source), close(S0)),
+          process_create(Host, [CompWamo, SrcPath],
+              [stdout(pipe(S)), stderr(std), process(Pid)]),
+          read_string(S, _, Out),
+          close(S),
+          process_wait(Pid, exit(Status)),
+          assertion(Status == 0),
+          assertion(Out == Expected) )),
+    !.
+
+% Milestone 6 (self-host) Stage D (builtin goals): the whitelisted builtins
+% compile as staged-args + builtin_call. Four programs: (1) functor/3 + arg/3
+% -- NB the grammar emits builtin_call arg/3 even for a constant index, so the
+% host compiler's specialised-arg subset gap never arises; (2) =../2 building
+% a term then unifying against a structure literal (the upgraded =/2 with
+% full-term operands); (3) atom_codes/2 + length/2 over a data atom (exercises
+% atoms-as-data in the atom table); (4) a type-check builtin (integer/1) as an
+% if-then-else condition.
+test(selfhost_codegen_stage_d_builtins, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    forall(member(Source-Expected,
+               [ '[(main0(R):- T = pt(40,2), functor(T,_,N), arg(1,T,X), R is X+N)]' - "42\n",
+                 '[(main0(R):- T =.. [f,40,2], T = f(A,B), R is A+B)]' - "42\n",
+                 '[(main0(R):- atom_codes(abc,Cs), length(Cs,N), R is N+39)]' - "42\n",
+                 '[(main0(R):- T = 42, ( integer(T) -> R = T ; R = 0 ))]' - "42\n" ]),
+        ( directory_file_path(Dir, 'cgb_src.txt', SrcPath),
           setup_call_cleanup(open(SrcPath, write, S0),
               write(S0, Source), close(S0)),
           process_create(Host, [CompWamo, SrcPath],


### PR DESCRIPTION
## What

The **builtin-goals batch**: ~37 whitelisted builtins the compiler's own source uses now compile as goals — term inspection (`functor/3`, `arg/3`, `=../2`, `copy_term/2`), text (`atom_codes`, `number_codes`, `atom_concat`, `term_to_atom`, `read_term_from_atom`, …), lists (`length`, `append`, `reverse`, `msort`, `sort`, `keysort`, `pairs_*`, `memberchk`, `between`, …), type checks, `numbervars/3`, `\=`. Each stages its args like a call (`c_operand` per arg) and emits `builtin_call(Id, Arity)`.

Two supporting upgrades: `=/2` now takes **full-term operands** (either side may be a structure or list literal), and the table walk collects **data atoms** into the atom table.

Notable: the grammar emits `builtin_call arg/3` even for a constant index — the host compiler's specialised-`arg` subset gap simply **never arises in self-compiled code**.

## Runtime fixes this surfaced (campaign bugs #6 and #7)

**6. The loaded reader lacked `=..`, `=\=`, `\==`** in its operator table — `T =.. L` didn't even *parse* in a loaded object. Added as xfx-700 length-3 symbol operators (`.` was already a symbol char, so `=..` tokenizes as one run).

**7. `=../2` compose mode had never worked** (the code comment admits "most benchmarks only exercise decompose"). Found by printf-instrumenting the generated IR — markers showed the walk dying at `count_done`. **Three distinct defects**:
- the list walk **never dereferenced** — compiled list spines link conses through Refs (`set_variable` tail + write-mode `put_structure`), so the walk bailed at the first tag-5 tail;
- the functor element was converted by `inttoptr` of its payload — but atoms are **id-based** since M100, so the built compound carried a garbage functor pointer (the decompose/`functor/3` fix had missed compose);
- the result was bound with `wam_set_reg` — overwriting register A1 only, never binding **through** the Ref shared with the caller's permanent register (the M9 aggregate-result bug resurfaced in univ), so the constructed term vanished for later goals.

All three fixed; construct mode now works in AOT and loaded objects alike (verified with host-compiled probes *and* the loaded compiler).

## Testing

- New test **`selfhost_codegen_stage_d_builtins`**, four programs, all → **42**: `functor/3`+`arg/3`; `=..` construct followed by structure unification; `atom_codes/2`+`length/2` over a data atom; `integer/1` as an ITE condition.
- Full `wam_object`, `test_llvm_target`, and plawk execution suites: **0 failures** (host caches cleared — runtime changes).

## Docs

`PLAWK_SELFHOST.md` and the roadmap updated — **seven** latent runtime bugs found and fixed by the self-host campaign so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_