### PR TITLE
Add rowwise Product-Kalman Gaussian scoring

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -429,6 +429,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   Product-Kalman input manifests, optional split manifests, and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including NLL/MSE,
+  rowwise covariance scoring for future hop-conditioned `V(hop)` audits,
   Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, and row-level NPZ score artifacts for
   reproducible bootstrap/tail diagnostics.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -50,7 +50,9 @@ __all__ = [
     "paired_bootstrap_nll_improvement",
     "paired_bootstrap_nll_improvement_from_score_rows",
     "run_product_kalman_holdout_npz",
+    "score_gaussian_prediction_vectors_rowwise",
     "score_gaussian_prediction_vectors",
+    "score_gaussian_predictions_rowwise",
     "score_gaussian_predictions",
     "write_evaluation_npz",
 ]
@@ -74,6 +76,15 @@ def _as_covariance(name, value, dim):
     if not np.isfinite(cov).all():
         raise ValueError(f"{name} must be finite")
     return 0.5 * (cov + cov.T)
+
+
+def _as_row_covariances(name, value, n, dim):
+    covariances = np.asarray(value, dtype=float)
+    if covariances.shape != (n, dim, dim):
+        raise ValueError(f"{name} shape {covariances.shape} must be ({n}, {dim}, {dim})")
+    if not np.isfinite(covariances).all():
+        raise ValueError(f"{name} must be finite")
+    return 0.5 * (covariances + np.swapaxes(covariances, 1, 2))
 
 
 def _readonly_vector(name, value, n=None):
@@ -427,6 +438,35 @@ def score_gaussian_prediction_vectors(name, target_state, mean, covariance, jitt
     )
 
 
+def score_gaussian_prediction_vectors_rowwise(name, target_state, mean, covariances, jitter=1e-9):
+    """Return per-row Gaussian score vectors with one covariance per row.
+
+    This is the scoring primitive needed by hop-conditioned or regime-conditioned
+    error models. `target_state` and `mean` must be `(n, d)` row matrices, and
+    `covariances` must be `(n, d, d)` in the same row order.
+    """
+    target = _as_2d("target_state", target_state)
+    pred = _as_2d("mean", mean)
+    if pred.shape != target.shape:
+        raise ValueError(f"mean shape {pred.shape} must match target_state shape {target.shape}")
+    covs = _as_row_covariances("covariances", covariances, target.shape[0], target.shape[1])
+    residual = target - pred
+    nll = np.empty(target.shape[0], dtype=float)
+    squared_mahalanobis = np.empty(target.shape[0], dtype=float)
+    for i in range(target.shape[0]):
+        nll[i] = gaussian_nll(target[i], pred[i], covs[i], jitter=jitter)
+        score_cov = regularize_covariance(covs[i], jitter=jitter, name=f"{name} row {i} score covariance")
+        solved = np.linalg.solve(score_cov, residual[i])
+        squared_mahalanobis[i] = float(residual[i] @ solved)
+    return GaussianScoreVectors(
+        name=name,
+        nll=nll,
+        squared_error=np.sum(residual * residual, axis=1),
+        squared_mahalanobis=squared_mahalanobis,
+        dimension=target.shape[1],
+    )
+
+
 def _score_from_vectors(vectors, covariance):
     cov = _as_covariance("covariance", covariance, vectors.dimension)
     mean_squared_mahalanobis = float(np.mean(vectors.squared_mahalanobis))
@@ -445,10 +485,37 @@ def _score_from_vectors(vectors, covariance):
     )
 
 
+def _score_from_vectors_rowwise(vectors, covariances):
+    covs = _as_row_covariances("covariances", covariances, vectors.n, vectors.dimension)
+    mean_squared_mahalanobis = float(np.mean(vectors.squared_mahalanobis))
+    q50, q90, q95 = [float(q) for q in np.quantile(vectors.squared_mahalanobis, [0.50, 0.90, 0.95])]
+    return GaussianScore(
+        name=vectors.name,
+        mean_nll=float(np.mean(vectors.nll)),
+        mse=float(np.mean(vectors.squared_error)),
+        n=vectors.n,
+        covariance_trace=float(np.mean(np.trace(covs, axis1=1, axis2=2))),
+        mean_squared_mahalanobis=mean_squared_mahalanobis,
+        mahalanobis_per_dim=mean_squared_mahalanobis / float(vectors.dimension),
+        squared_mahalanobis_q50=q50,
+        squared_mahalanobis_q90=q90,
+        squared_mahalanobis_q95=q95,
+    )
+
+
 def score_gaussian_predictions(name, target_state, mean, covariance, jitter=1e-9):
     """Return aggregate Gaussian prediction scores for one held-out split."""
     vectors = score_gaussian_prediction_vectors(name, target_state, mean, covariance, jitter=jitter)
     return _score_from_vectors(vectors, covariance)
+
+
+def score_gaussian_predictions_rowwise(name, target_state, mean, covariances, jitter=1e-9):
+    """Return aggregate Gaussian scores when each row has its own covariance.
+
+    `GaussianScore.covariance_trace` is the mean trace across row covariances.
+    """
+    vectors = score_gaussian_prediction_vectors_rowwise(name, target_state, mean, covariances, jitter=jitter)
+    return _score_from_vectors_rowwise(vectors, covariances)
 
 
 def _check_split_ids(calibration_ids, evaluation_ids, n_calibration, n_evaluation):

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -21,7 +21,9 @@ from product_kalman_evaluation import (
     main,
     paired_bootstrap_nll_improvement,
     run_product_kalman_holdout_npz,
+    score_gaussian_prediction_vectors_rowwise,
     score_gaussian_prediction_vectors,
+    score_gaussian_predictions_rowwise,
     score_gaussian_predictions,
     write_evaluation_npz,
 )
@@ -323,6 +325,40 @@ def test_score_gaussian_predictions_validates_shapes_and_reports_mse():
     assert abs(score.squared_mahalanobis_q95 - 1.0) < 1e-12
     assert_raises(score_gaussian_predictions, "bad", target[:, 0], mean, [[1.0]])
     assert_raises(score_gaussian_predictions, "bad", target, mean, [[1.0, 0.0]])
+
+
+def test_rowwise_gaussian_scoring_supports_variable_covariances():
+    target = np.array([[1.0], [2.0]])
+    mean = np.array([[1.5], [1.5]])
+    shared_covariances = np.array([[[0.25]], [[0.25]]])
+    shared_vectors = score_gaussian_prediction_vectors("shared", target, mean, [[0.25]], jitter=1e-9)
+    rowwise_shared = score_gaussian_prediction_vectors_rowwise(
+        "shared",
+        target,
+        mean,
+        shared_covariances,
+        jitter=1e-9,
+    )
+    np.testing.assert_allclose(rowwise_shared.nll, shared_vectors.nll)
+    np.testing.assert_allclose(rowwise_shared.squared_mahalanobis, shared_vectors.squared_mahalanobis)
+
+    row_covariances = np.array([[[0.25]], [[1.0]]])
+    row_vectors = score_gaussian_prediction_vectors_rowwise("rowwise", target, mean, row_covariances, jitter=1e-9)
+    assert row_vectors.name == "rowwise"
+    assert np.allclose(row_vectors.squared_error, [0.25, 0.25])
+    assert np.allclose(row_vectors.squared_mahalanobis, [1.0, 0.25])
+    assert row_vectors.nll.flags.writeable is False
+    row_score = score_gaussian_predictions_rowwise("rowwise", target, mean, row_covariances, jitter=1e-9)
+    assert row_score.n == 2
+    assert abs(row_score.mse - 0.25) < 1e-12
+    assert abs(row_score.covariance_trace - 0.625) < 1e-12
+    assert abs(row_score.mean_squared_mahalanobis - 0.625) < 1e-12
+    assert abs(row_score.mahalanobis_per_dim - 0.625) < 1e-12
+    assert_raises(score_gaussian_predictions_rowwise, "bad", target, mean, row_covariances[:1])
+    assert_raises(score_gaussian_predictions_rowwise, "bad", target, mean, row_covariances[:, :, 0])
+    bad_covariances = row_covariances.copy()
+    bad_covariances[1, 0, 0] = np.nan
+    assert_raises(score_gaussian_predictions_rowwise, "bad", target, mean, bad_covariances)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add rowwise Gaussian scoring helpers for Product-Kalman evaluation, accepting one covariance matrix per held-out row.
- Preserve existing shared-covariance scoring behavior unchanged.
- Add focused tests proving rowwise scoring matches the shared path when covariances are identical and supports variable per-row covariance diagnostics.
- Note the helper in the Product-Kalman design doc as support for future hop-conditioned `V(hop)` audits.

## Tests
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_evaluation.py prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `git diff --check`