### PR TITLE
Add grouped Gaussian scoring helper

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -429,8 +429,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   Product-Kalman input manifests, optional split manifests, and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including NLL/MSE,
-  rowwise covariance scoring and grouped residual-covariance maps for future hop-conditioned `V(hop)` audits,
-  Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, and row-level NPZ score artifacts for
-  reproducible bootstrap/tail diagnostics.
+  rowwise covariance scoring, grouped residual-covariance maps, and a grouped scorer for future
+  hop-conditioned `V(hop)` audits, Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, and
+  row-level NPZ score artifacts for reproducible bootstrap/tail diagnostics.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -40,6 +40,7 @@ except ImportError:  # direct script execution from prototypes/mu_cosine
 __all__ = [
     "GaussianScore",
     "GaussianScoreVectors",
+    "GroupedGaussianScore",
     "GroupResidualCovariances",
     "ProductKalmanHoldoutEvaluation",
     "bootstrap_nll_improvements_from_evaluation_npz",
@@ -55,6 +56,7 @@ __all__ = [
     "run_product_kalman_holdout_npz",
     "score_gaussian_prediction_vectors_rowwise",
     "score_gaussian_prediction_vectors",
+    "score_gaussian_predictions_grouped",
     "score_gaussian_predictions_rowwise",
     "score_gaussian_predictions",
     "write_evaluation_npz",
@@ -403,6 +405,40 @@ class GaussianScoreVectors:
 
 
 @dataclass(frozen=True)
+class GroupedGaussianScore:
+    """Gaussian score plus grouped residual-covariance provenance.
+
+    This bundles the fitted calibration-side group covariance map with the
+    evaluation row covariances actually used by rowwise scoring.
+    """
+
+    score: GaussianScore
+    score_vectors: GaussianScoreVectors
+    residual_covariances: GroupResidualCovariances
+    row_covariances: np.ndarray
+
+    def __post_init__(self):
+        if not isinstance(self.score, GaussianScore):
+            raise ValueError("score must be a GaussianScore")
+        if not isinstance(self.score_vectors, GaussianScoreVectors):
+            raise ValueError("score_vectors must be a GaussianScoreVectors")
+        if not isinstance(self.residual_covariances, GroupResidualCovariances):
+            raise ValueError("residual_covariances must be a GroupResidualCovariances")
+        if self.score.name != self.score_vectors.name:
+            raise ValueError("score and score_vectors names must match")
+        if self.score.n != self.score_vectors.n:
+            raise ValueError("score n must match score_vectors n")
+        row_covariances = _as_row_covariances(
+            "row_covariances",
+            self.row_covariances,
+            self.score_vectors.n,
+            self.score_vectors.dimension,
+        )
+        row_covariances.setflags(write=False)
+        object.__setattr__(self, "row_covariances", row_covariances)
+
+
+@dataclass(frozen=True)
 class ProductKalmanHoldoutEvaluation:
     """One calibration/evaluation split comparison.
 
@@ -713,6 +749,53 @@ def score_gaussian_predictions_rowwise(name, target_state, mean, covariances, ji
     """
     vectors = score_gaussian_prediction_vectors_rowwise(name, target_state, mean, covariances, jitter=jitter)
     return _score_from_vectors_rowwise(vectors, covariances)
+
+
+def score_gaussian_predictions_grouped(
+    name,
+    calibration_target_state,
+    calibration_mean,
+    calibration_groups,
+    evaluation_target_state,
+    evaluation_mean,
+    evaluation_groups,
+    min_group_rows=None,
+    shrinkage=0.0,
+    jitter=1e-9,
+    ddof=1,
+    shrinkage_target="diagonal",
+):
+    """Fit grouped residual covariances on calibration rows and score evaluation rows.
+
+    Means are supplied by the caller. This helper only replaces the shared
+    Gaussian covariance with calibration-fitted group covariances, making it the
+    direct bridge from discrete contexts such as hop labels to rowwise NLL and
+    Mahalanobis diagnostics.
+    """
+    residual_covariances = fit_group_residual_covariances(
+        calibration_mean,
+        calibration_target_state,
+        calibration_groups,
+        min_group_rows=min_group_rows,
+        shrinkage=shrinkage,
+        jitter=jitter,
+        ddof=ddof,
+        shrinkage_target=shrinkage_target,
+    )
+    row_covariances = residual_covariances.row_covariances(evaluation_groups)
+    vectors = score_gaussian_prediction_vectors_rowwise(
+        name,
+        evaluation_target_state,
+        evaluation_mean,
+        row_covariances,
+        jitter=jitter,
+    )
+    return GroupedGaussianScore(
+        score=_score_from_vectors_rowwise(vectors, row_covariances),
+        score_vectors=vectors,
+        residual_covariances=residual_covariances,
+        row_covariances=row_covariances,
+    )
 
 
 def _check_split_ids(calibration_ids, evaluation_ids, n_calibration, n_evaluation):

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -26,6 +26,7 @@ from product_kalman_evaluation import (
     run_product_kalman_holdout_npz,
     score_gaussian_prediction_vectors_rowwise,
     score_gaussian_prediction_vectors,
+    score_gaussian_predictions_grouped,
     score_gaussian_predictions_rowwise,
     score_gaussian_predictions,
     write_evaluation_npz,
@@ -337,6 +338,62 @@ def test_group_residual_covariances_feed_rowwise_scores():
     grouped_score = score_gaussian_predictions_rowwise("grouped", eval_obs, eval_pred, row_covariances, jitter=1e-8)
     assert grouped_score.mean_nll < global_score.mean_nll
     assert grouped_score.covariance_trace == np.mean(np.trace(row_covariances, axis1=1, axis2=2))
+
+
+def test_grouped_gaussian_scorer_matches_manual_grouped_path():
+    rng = np.random.default_rng(19)
+    n_cal_per_group = 180
+    n_eval_per_group = 90
+    cal_groups = np.array([1] * n_cal_per_group + [2] * n_cal_per_group)
+    eval_groups = np.array([1] * n_eval_per_group + [2] * n_eval_per_group)
+    cal_pred = np.zeros((2 * n_cal_per_group, 1))
+    eval_pred = np.zeros((2 * n_eval_per_group, 1))
+    cal_obs = np.concatenate([
+        rng.normal(scale=0.25, size=n_cal_per_group),
+        rng.normal(scale=0.95, size=n_cal_per_group),
+    ])[:, None]
+    eval_obs = np.concatenate([
+        rng.normal(scale=0.25, size=n_eval_per_group),
+        rng.normal(scale=0.95, size=n_eval_per_group),
+    ])[:, None]
+
+    grouped = score_gaussian_predictions_grouped(
+        "hop_grouped",
+        cal_obs,
+        cal_pred,
+        cal_groups,
+        eval_obs,
+        eval_pred,
+        eval_groups,
+        min_group_rows=20,
+        jitter=1e-8,
+    )
+    manual_rows = grouped.residual_covariances.row_covariances(eval_groups)
+    manual_score = score_gaussian_predictions_rowwise("hop_grouped", eval_obs, eval_pred, manual_rows, jitter=1e-8)
+    np.testing.assert_allclose(grouped.row_covariances, manual_rows)
+    assert grouped.row_covariances.flags.writeable is False
+    assert grouped.score.name == "hop_grouped"
+    assert grouped.score_vectors.name == "hop_grouped"
+    assert grouped.score.n == len(eval_obs)
+    assert grouped.score_vectors.n == len(eval_obs)
+    assert abs(grouped.score.mean_nll - manual_score.mean_nll) < 1e-12
+    assert grouped.score.mean_nll < score_gaussian_predictions(
+        "global",
+        eval_obs,
+        eval_pred,
+        grouped.residual_covariances.fallback_covariance,
+        jitter=1e-8,
+    ).mean_nll
+    assert_raises(
+        score_gaussian_predictions_grouped,
+        "bad",
+        cal_obs,
+        cal_pred,
+        cal_groups[:-1],
+        eval_obs,
+        eval_pred,
+        eval_groups,
+    )
 
 
 def test_group_residual_covariance_fallbacks_and_validation():


### PR DESCRIPTION
## Summary
- Add `GroupedGaussianScore`, bundling aggregate score, row score vectors, fitted grouped residual covariances, and the evaluation row covariance tensor.
- Add `score_gaussian_predictions_grouped()` to fit grouped residual covariances on calibration rows and score held-out rows with rowwise covariances.
- Add tests proving the helper matches the manual fit → row-covariance → rowwise-score path and improves NLL on a synthetic heteroscedastic split.
- Update the Product-Kalman design note to name the grouped scorer as the future bridge for hop-conditioned `V(hop)` audits.

## Tests
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_evaluation.py prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `git diff --check`