### PR TITLE
Carry Product-Kalman group labels through table artifacts

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -381,8 +381,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    `scores.json`, `eval_artifacts.npz`, and `report.md`) in one auditable command. If given `--split-unit-cols`,
    it first writes `split_table.csv`/`split_table.tsv` and `split.manifest.json` in the same run directory, then
    evaluates that split-labeled table. Explicit artifact paths may override those defaults. Under the hood,
-   `product_kalman_table_to_npz.py` records source-table hash, split counts, column groups, dimensions, ID
-   overlap/duplicate counts, and `H`
+   `product_kalman_table_to_npz.py` records source-table hash, split counts, column groups, optional discrete
+   group labels such as hop/regime buckets, dimensions, ID overlap/duplicate counts, and `H`
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
    zero-cross-covariance / correlated Product-Kalman predictions on a separate split, records aggregate NLL/MSE,
    Mahalanobis calibration-scale/tail diagnostics, row-level score vectors, and optional paired bootstrap intervals
@@ -419,7 +419,7 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   `P`, `R`, and cross-covariance blocks plus batch application and split-ID leakage guards.
 - `product_kalman_table_to_npz.py` and `test_product_kalman_table_to_npz.py` — CSV/TSV-to-NPZ builder for
   evaluator input arrays with explicit split, ID, prior, measurement, and target columns, plus optional JSON input
-  manifests for real-corpus provenance checks.
+  manifests and carried-through discrete group labels for real-corpus provenance checks.
 - `product_kalman_split_table.py` and `test_product_kalman_split_table.py` — split-label materializer for explicit
   Product-Kalman tables, with held-out unit sampling, strict boundary-row omission, and a split manifest.
 - `product_kalman_table_evaluation.py` and `test_product_kalman_table_evaluation.py` — one-command table-to-input-

--- a/prototypes/mu_cosine/product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_table_evaluation.py
@@ -172,6 +172,7 @@ def run_product_kalman_table_evaluation(
     evaluation_value="evaluation",
     delimiter=None,
     H=None,
+    group_cols=None,
     shrinkage=0.0,
     jitter=1e-9,
     ddof=1,
@@ -195,6 +196,7 @@ def run_product_kalman_table_evaluation(
         evaluation_value=evaluation_value,
         delimiter=delimiter,
         H=H,
+        group_cols=group_cols,
     )
     result = run_product_kalman_holdout_npz(
         input_npz,
@@ -276,6 +278,7 @@ def _build_arg_parser():
     ap.add_argument("--evaluation-value", default="evaluation")
     ap.add_argument("--delimiter", help="input delimiter; defaults to tab for .tsv/.tab, comma otherwise")
     ap.add_argument("--H", help="optional observation matrix literal, e.g. '1,0;0,1'")
+    ap.add_argument("--group-cols", help="optional comma-separated discrete group columns to carry into NPZ")
     ap.add_argument("--shrinkage", type=float, default=0.0)
     ap.add_argument("--jitter", type=float, default=1e-9)
     ap.add_argument("--ddof", type=int, default=1)
@@ -334,6 +337,7 @@ def main(argv=None):
             evaluation_value=args.evaluation_value,
             delimiter=args.delimiter,
             H=args.H,
+            group_cols=parse_column_list(args.group_cols) if args.group_cols else None,
             shrinkage=args.shrinkage,
             jitter=args.jitter,
             ddof=args.ddof,

--- a/prototypes/mu_cosine/product_kalman_table_to_npz.py
+++ b/prototypes/mu_cosine/product_kalman_table_to_npz.py
@@ -70,13 +70,14 @@ def _infer_delimiter(path, explicit):
     return ","
 
 
-def _required_columns(split_col, id_col, prior_cols, measurement_cols, target_cols):
+def _required_columns(split_col, id_col, prior_cols, measurement_cols, target_cols, group_cols=()):
     cols = [split_col]
     if id_col:
         cols.append(id_col)
     cols.extend(prior_cols)
     cols.extend(measurement_cols)
     cols.extend(target_cols)
+    cols.extend(group_cols or [])
     return cols
 
 
@@ -94,6 +95,18 @@ def _row_vector(row, cols, row_num):
             raise ValueError(f"row {row_num}: nonfinite value {value!r} for column {col!r}")
         values.append(parsed)
     return values
+
+
+def _row_group_label(row, cols, row_num):
+    values = []
+    for col in cols:
+        value = row.get(col)
+        if value is None or str(value).strip() == "":
+            raise ValueError(f"row {row_num}: missing group value for column {col!r}")
+        values.append(str(value).strip())
+    if len(values) == 1:
+        return values[0]
+    return json.dumps(values, separators=(",", ":"))
 
 
 def _as_2d_rows(name, rows, width):
@@ -119,6 +132,15 @@ def _normalize_columns(prior_cols, measurement_cols, target_cols):
         if len(cols) != len(set(cols)):
             raise ValueError(f"{name} contains duplicates: {cols!r}")
     return prior_cols, measurement_cols, target_cols
+
+
+def _normalize_group_columns(group_cols):
+    if group_cols is None or group_cols == "":
+        return []
+    group_cols = parse_column_list(group_cols) if isinstance(group_cols, str) else list(group_cols)
+    if len(group_cols) != len(set(group_cols)):
+        raise ValueError(f"group_cols contains duplicates: {group_cols!r}")
+    return group_cols
 
 
 def _validate_schema_dimensions(prior_cols, measurement_cols, target_cols, H):
@@ -172,6 +194,30 @@ def _id_manifest(arrays, id_col):
     }
 
 
+def _label_counts(values):
+    counts = {}
+    for value in values:
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _group_manifest(arrays, group_cols):
+    group_cols = _normalize_group_columns(group_cols)
+    if not group_cols or "calibration_groups" not in arrays or "evaluation_groups" not in arrays:
+        return {"present": False, "columns": group_cols}
+    calibration_groups = [str(v) for v in arrays["calibration_groups"].tolist()]
+    evaluation_groups = [str(v) for v in arrays["evaluation_groups"].tolist()]
+    return {
+        "present": True,
+        "columns": group_cols,
+        "calibration_unique_count": len(set(calibration_groups)),
+        "evaluation_unique_count": len(set(evaluation_groups)),
+        "calibration_counts": _label_counts(calibration_groups),
+        "evaluation_counts": _label_counts(evaluation_groups),
+    }
+
+
 def build_product_kalman_input_manifest(
     path,
     arrays,
@@ -184,9 +230,11 @@ def build_product_kalman_input_manifest(
     evaluation_value="evaluation",
     delimiter=None,
     H=None,
+    group_cols=None,
 ):
     """Build a JSON-serializable manifest for a table-derived evaluator NPZ."""
     prior_cols, measurement_cols, target_cols = _normalize_columns(prior_cols, measurement_cols, target_cols)
+    group_cols = _normalize_group_columns(group_cols)
     delim = _infer_delimiter(path, delimiter)
     cal_rows = int(arrays["calibration_target_state"].shape[0])
     eval_rows = int(arrays["evaluation_target_state"].shape[0])
@@ -216,6 +264,7 @@ def build_product_kalman_input_manifest(
             "observation_dim": len(measurement_cols),
         },
         "ids": _id_manifest(arrays, id_col),
+        "groups": _group_manifest(arrays, group_cols),
         "arrays": {name: _array_manifest(value) for name, value in sorted(arrays.items())},
         "H": {
             "present": H is not None,
@@ -237,14 +286,16 @@ def read_product_kalman_table(
     evaluation_value="evaluation",
     delimiter=None,
     H=None,
+    group_cols=None,
 ):
     """Read a CSV/TSV table into evaluator-ready arrays.
 
     Required columns are: split, prior columns, measurement columns, target
-    columns, plus an optional ID column. Split labels are compared
-    case-insensitively after trimming whitespace.
+    columns, optional group columns, plus an optional ID column. Split labels
+    are compared case-insensitively after trimming whitespace.
     """
     prior_cols, measurement_cols, target_cols = _normalize_columns(prior_cols, measurement_cols, target_cols)
+    group_cols = _normalize_group_columns(group_cols)
     calibration_value = _normalize_split_value(calibration_value)
     evaluation_value = _normalize_split_value(evaluation_value)
     if calibration_value == evaluation_value:
@@ -253,16 +304,19 @@ def read_product_kalman_table(
     _validate_schema_dimensions(prior_cols, measurement_cols, target_cols, H)
 
     split_rows = {
-        calibration_value: {"prior": [], "measurement": [], "target": [], "ids": []},
-        evaluation_value: {"prior": [], "measurement": [], "target": [], "ids": []},
+        calibration_value: {"prior": [], "measurement": [], "target": [], "ids": [], "groups": []},
+        evaluation_value: {"prior": [], "measurement": [], "target": [], "ids": [], "groups": []},
     }
     delim = _infer_delimiter(path, delimiter)
     with open(path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=delim)
         if reader.fieldnames is None:
             raise ValueError(f"{path} has no header row")
-        missing = [col for col in _required_columns(split_col, id_col, prior_cols, measurement_cols, target_cols)
-                   if col not in reader.fieldnames]
+        missing = [
+            col
+            for col in _required_columns(split_col, id_col, prior_cols, measurement_cols, target_cols, group_cols)
+            if col not in reader.fieldnames
+        ]
         if missing:
             raise ValueError(f"{path} missing required columns: {', '.join(missing)}")
         for row_num, row in enumerate(reader, start=2):
@@ -280,6 +334,8 @@ def read_product_kalman_table(
                 if raw_id is None or str(raw_id).strip() == "":
                     raise ValueError(f"row {row_num}: missing ID value for column {id_col!r}")
                 bucket["ids"].append(str(raw_id))
+            if group_cols:
+                bucket["groups"].append(_row_group_label(row, group_cols, row_num))
 
     cal = split_rows[calibration_value]
     ev = split_rows[evaluation_value]
@@ -294,6 +350,9 @@ def read_product_kalman_table(
     if id_col:
         arrays["calibration_ids"] = np.asarray(cal["ids"], dtype=str)
         arrays["evaluation_ids"] = np.asarray(ev["ids"], dtype=str)
+    if group_cols:
+        arrays["calibration_groups"] = np.asarray(cal["groups"], dtype=str)
+        arrays["evaluation_groups"] = np.asarray(ev["groups"], dtype=str)
     if H is not None:
         H = np.asarray(H, dtype=float)
         if H.shape != (len(measurement_cols), len(target_cols)):
@@ -340,6 +399,7 @@ def _build_arg_parser():
     ap.add_argument("--evaluation-value", default="evaluation")
     ap.add_argument("--delimiter", help="input delimiter; defaults to tab for .tsv/.tab, comma otherwise")
     ap.add_argument("--H", help="optional observation matrix literal, e.g. '1,0;0,1'")
+    ap.add_argument("--group-cols", help="optional comma-separated discrete group columns to carry into NPZ")
     return ap
 
 
@@ -360,6 +420,7 @@ def main(argv=None):
             evaluation_value=args.evaluation_value,
             delimiter=args.delimiter,
             H=args.H,
+            group_cols=parse_column_list(args.group_cols) if args.group_cols else None,
         )
     except ValueError as exc:
         ap.error(str(exc))

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -37,7 +37,11 @@ def synthetic_identity_split(n_cal=80, n_eval=40, seed=23):
 def write_table(path, delimiter=","):
     prior, measurement, target, n_cal = synthetic_identity_split()
     with open(path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=["split", "id", "prior", "measurement", "target"], delimiter=delimiter)
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["split", "id", "prior", "measurement", "target", "hop"],
+            delimiter=delimiter,
+        )
         writer.writeheader()
         for i in range(len(target)):
             split = "calibration" if i < n_cal else "evaluation"
@@ -47,6 +51,7 @@ def write_table(path, delimiter=","):
                 "prior": f"{prior[i, 0]:.17g}",
                 "measurement": f"{measurement[i, 0]:.17g}",
                 "target": f"{target[i, 0]:.17g}",
+                "hop": str(1 + i % 2),
             })
 
 
@@ -90,6 +95,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
             output_npz=output_npz,
             output_md=output_md,
             report_title="Synthetic Table Product-Kalman Report",
+            group_cols=["hop"],
             jitter=1e-8,
             bootstrap_nll=50,
             bootstrap_seed=7,
@@ -102,6 +108,8 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert output_npz.exists()
         assert output_md.exists()
         assert run.input_arrays["calibration_prior_mean"].shape == (80, 1)
+        assert run.input_arrays["calibration_groups"].shape == (80,)
+        assert run.input_arrays["evaluation_groups"].shape == (40,)
         assert run.result.nll_improvement("prior", "product_kalman") > 0.65
         assert run.result.nll_improvement("independent_kalman", "product_kalman") > 0.05
 
@@ -128,6 +136,9 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert manifest["splits"]["calibration_rows"] == 80
         assert manifest["splits"]["evaluation_rows"] == 40
         assert manifest["ids"]["disjoint_and_unique"] is True
+        assert manifest["groups"]["present"] is True
+        assert manifest["groups"]["columns"] == ["hop"]
+        assert manifest["groups"]["calibration_counts"] == {"1": 40, "2": 40}
         report = output_md.read_text()
         assert report == run.report_text
         assert "# Synthetic Table Product-Kalman Report" in report
@@ -163,6 +174,8 @@ def test_table_runner_output_dir_writes_canonical_bundle():
             "measurement",
             "--target-cols",
             "target",
+            "--group-cols",
+            "hop",
             "--jitter",
             "1e-8",
             "--indent",
@@ -179,6 +192,12 @@ def test_table_runner_output_dir_writes_canonical_bundle():
         assert summary["inputs"]["evaluation_npz"] == str(paths["output_npz"])
         assert summary["inputs"]["report_md"] == str(paths["output_md"])
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
+        with np.load(paths["input_npz"], allow_pickle=False) as data:
+            assert data["calibration_groups"].shape == (80,)
+            assert data["evaluation_groups"].shape == (40,)
+        manifest = json.loads(paths["input_manifest"].read_text())
+        assert manifest["groups"]["present"] is True
+        assert manifest["groups"]["columns"] == ["hop"]
         assert "# Product-Kalman Holdout Report" in paths["output_md"].read_text()
 
 
@@ -301,6 +320,8 @@ def test_table_runner_cli_roundtrips_against_npz_evaluator():
             "measurement",
             "--target-cols",
             "target",
+            "--group-cols",
+            "hop",
             "--jitter",
             "1e-8",
             "--indent",
@@ -319,6 +340,7 @@ def test_table_runner_cli_roundtrips_against_npz_evaluator():
         manifest = json.loads(input_manifest.read_text())
         assert manifest["source_table"]["delimiter"] == "\t"
         assert manifest["ids"]["overlap_count"] == 0
+        assert manifest["groups"]["columns"] == ["hop"]
         assert from_table["inputs"]["report_md"] == str(output_md)
 
 

--- a/prototypes/mu_cosine/test_product_kalman_table_to_npz.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_to_npz.py
@@ -49,7 +49,11 @@ def synthetic_identity_split(n_cal=80, n_eval=40, seed=23):
 def write_table(path, delimiter=","):
     prior, measurement, target, n_cal = synthetic_identity_split()
     with open(path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=["split", "id", "prior", "measurement", "target"], delimiter=delimiter)
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["split", "id", "prior", "measurement", "target", "hop"],
+            delimiter=delimiter,
+        )
         writer.writeheader()
         for i in range(len(target)):
             split = "calibration" if i < n_cal else "evaluation"
@@ -59,6 +63,7 @@ def write_table(path, delimiter=","):
                 "prior": f"{prior[i, 0]:.17g}",
                 "measurement": f"{measurement[i, 0]:.17g}",
                 "target": f"{target[i, 0]:.17g}",
+                "hop": str(1 + i % 3),
             })
 
 
@@ -82,10 +87,14 @@ def test_table_builder_roundtrips_into_evaluator():
             prior_cols=["prior"],
             measurement_cols=["measurement"],
             target_cols=["target"],
+            group_cols=["hop"],
         )
         assert arrays["calibration_prior_mean"].shape == (80, 1)
         assert arrays["evaluation_prior_mean"].shape == (40, 1)
         assert arrays["calibration_ids"].shape == (80,)
+        assert arrays["calibration_groups"].shape == (80,)
+        assert arrays["evaluation_groups"].shape == (40,)
+        assert set(arrays["calibration_groups"].tolist()) == {"1", "2", "3"}
         assert npz.exists()
 
         result = run_product_kalman_holdout_npz(npz, jitter=1e-8)
@@ -103,6 +112,7 @@ def test_input_manifest_records_schema_and_id_audit():
             prior_cols=["prior"],
             measurement_cols=["measurement"],
             target_cols=["target"],
+            group_cols=["hop"],
         )
         manifest = build_product_kalman_input_manifest(
             table,
@@ -110,6 +120,7 @@ def test_input_manifest_records_schema_and_id_audit():
             prior_cols=["prior"],
             measurement_cols=["measurement"],
             target_cols=["target"],
+            group_cols=["hop"],
         )
         assert manifest["schema_version"] == TABLE_INPUT_MANIFEST_SCHEMA_VERSION
         assert len(manifest["source_table"]["sha256"]) == 64
@@ -118,7 +129,12 @@ def test_input_manifest_records_schema_and_id_audit():
         assert manifest["columns"]["prior"] == ["prior"]
         assert manifest["dimensions"] == {"state_dim": 1, "prior_dim": 1, "observation_dim": 1}
         assert manifest["ids"]["disjoint_and_unique"] is True
+        assert manifest["groups"]["present"] is True
+        assert manifest["groups"]["columns"] == ["hop"]
+        assert manifest["groups"]["calibration_unique_count"] == 3
+        assert manifest["groups"]["calibration_counts"]["1"] == 27
         assert manifest["arrays"]["calibration_prior_mean"]["shape"] == [80, 1]
+        assert manifest["arrays"]["calibration_groups"]["shape"] == [80]
         assert manifest["H"]["present"] is False
         write_product_kalman_manifest(manifest_path, manifest)
         loaded = json.loads(manifest_path.read_text())
@@ -143,14 +159,19 @@ def test_tsv_delimiter_inference_and_cli():
             "measurement",
             "--target-cols",
             "target",
+            "--group-cols",
+            "hop",
         ])
         assert rc == 0
         with np.load(npz, allow_pickle=False) as data:
             assert data["calibration_prior_mean"].shape == (80, 1)
             assert data["evaluation_ids"].shape == (40,)
+            assert data["calibration_groups"].shape == (80,)
+            assert data["evaluation_groups"].shape == (40,)
         manifest_data = json.loads(manifest.read_text())
         assert manifest_data["source_table"]["delimiter"] == "	"
         assert manifest_data["ids"]["overlap_count"] == 0
+        assert manifest_data["groups"]["columns"] == ["hop"]
 
 
 def test_nonidentity_H_is_stored_and_shape_checked():
@@ -238,6 +259,20 @@ def test_table_builder_rejects_bad_input():
             prior_cols=["prior"],
             measurement_cols=["measurement"],
             target_cols=["target"],
+        )
+
+        bad_group = Path(tmp) / "bad_group.csv"
+        bad_group.write_text(
+            "split,id,prior,measurement,target,hop\ncalibration,a,1,1,1,\n",
+            encoding="utf-8",
+        )
+        assert_raises(
+            read_product_kalman_table,
+            bad_group,
+            prior_cols=["prior"],
+            measurement_cols=["measurement"],
+            target_cols=["target"],
+            group_cols=["hop"],
         )
 
         bad_prior_dim = Path(tmp) / "bad_prior_dim.csv"


### PR DESCRIPTION
# Add Product-Kalman table group labels

## Summary
- Add optional `--group-cols` support to Product-Kalman table-to-NPZ inputs.
- Carry group labels into `calibration_groups` / `evaluation_groups` NPZ arrays.
- Record group columns and split-wise label counts in the input manifest.
- Thread group labels through the one-command table evaluation runner.
- Update tests and the Product-Kalman design note to mark this as a provenance hook for later hop/regime-conditioned scoring.

## Tests
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_table_to_npz.py prototypes/mu_cosine/product_kalman_table_evaluation.py prototypes/mu_cosine/test_product_kalman_table_to_npz.py prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `git diff --check`