### PR TITLE
WAM/LLVM (roadmap #5, milestone 6): chained arena — the honest fix for finding #8

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -412,8 +412,11 @@ loadable along the way.
   `=../2` compose mode broken three ways (no deref of Ref-linked list
   spines, id-based atom payload used as a functor pointer, result bound to
   the register instead of through the Ref); and quadratic accumulator-append
-  allocation exhausting the 16 MiB arena (bumped to 256 MiB virtual; chained
-  arena deferred). See
+  allocation exhausting the 16 MiB arena — fixed for real with the **chained
+  arena** (blocks link on exhaustion and never move; marks are virtual
+  offsets so mark/rewind work across growth; initial block back to 16 MiB
+  with no practical ceiling), covered by a dedicated native driver suite and
+  exercised in production by the fixpoint compile itself. See
   [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md).
 
 ## The binary-return question, specifically

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -513,21 +513,42 @@ build path (the tail variable is staged directly as the final `set_*` slot).
 accumulator-style grammars (`append` onto a growing list per emitted byte)
 allocate **quadratically** in their output size, and the fixpoint compile
 segfaulted at exactly the 16 MiB boundary (a `%Value` store to the null
-`wam_arena_alloc` result, pinned by gdb). Bumped to 256 MiB (virtual; Linux
-commits lazily, so resident memory only grows with use). The honest fix — a
-chained arena that links a new block instead of returning null (blocks must
-not move; `%Value`s hold raw pointers) — is noted as deferred work, as is
-linearising the accumulator style (difference lists) in the bootstrap
-compiler itself.
+`wam_arena_alloc` result, pinned by gdb). First mitigated by bumping to
+256 MiB virtual; then fixed for real with the **chained arena** (below).
+
+**Chained arena LANDED** (the honest fix for finding no. 8). The bump arena
+now links a new block on exhaustion instead of returning null: each block
+carries a 32-byte header (previous-block pointer, data capacity, virtual
+base offset), the allocation slow path mallocs `max(cap × 2, requested)`
+and chains it, and blocks **never move** — `%Value`s hold raw pointers into
+them, so live terms stay valid across growth. Marks became virtual offsets
+(`base + pos`), globally monotonic across links, so the graph kernels'
+mark/rewind pairs keep working even when the arena grew in between: rewind
+pops (frees) every block newer than the mark and restores the bump position
+in the survivor. `@wam_arena_reset` (per-query cleanup) rewinds to virtual
+offset 0, handing growth blocks back to malloc while keeping the initial
+block mapped. The initial block dropped back to 16 MiB — the default query
+never chains; the self-hosted compiler's quadratic appends now hit growth,
+not a segfault, with no practical ceiling. Covered by a dedicated native
+driver suite (`test_wam_llvm_arena_chain_runtime.pl`): a 64-byte first
+block forced through two links with mark checks at every step, cross-block
+rewinds, block-stability sentinels, first-block reuse after reset, destroy
++ ensure re-init; plus a ~100 MB growth-stress loop through a 1 KiB initial
+block. The fixpoint compile itself (needs > 16 MiB) now exercises chaining
+in production on every suite run. Linearising the accumulator style
+(difference lists) in the bootstrap compiler remains the compile-*time*
+fix — memory is no longer the cliff, but the quadratic work still costs
+seconds as sources grow.
 
 **Remaining toward the full fixpoint:** the serializer was the back end; the
 front/middle (the reader call, `group_clauses`, the codegen walkers) use the
 same constructs plus `keysort`/`pairs_values` (already whitelisted) — but
 compiling the *whole* cgfull source also needs bare cut restated as ITE
-throughout, the `s(At,Fn)` state pair (structures — supported), and above
-all a workable compile-time budget for the quadratic-append behavior. The
-capstone (`compile(SelfSource)` yielding a working compiler object) remains
-open, now with a demonstrated path.
+throughout, the `s(At,Fn)` state pair (structures — supported), and a
+workable compile-time budget for the quadratic-append behavior (the memory
+side is solved by the chained arena; the time side wants difference lists).
+The capstone (`compile(SelfSource)` yielding a working compiler object)
+remains open, now with a demonstrated path.
 
 **Deliverable:** the demonstrable self-host — the compiler compiles itself,
 and `compile(SelfSource)` yields a working compiler object.

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -2472,68 +2472,150 @@ exit:
 ;   4 = transitive_distance3
 ;   5 = weighted_shortest_path3
 ;   6 = astar_shortest_path4
-; === M5.14: Bump arena allocator ===
+; === M5.14: Bump arena allocator (chained blocks since M6 self-host) ===
 ; WASM-portable arena for transient kernel allocations. Kernel helpers
 ; (BFS, Dijkstra, A*) allocate scratch buffers at the start and free
 ; everything at the end — a pattern that maps perfectly to bump allocation.
 ;
-; Native: the arena is backed by a single malloc'd buffer.
-; WASM:   swap @wam_arena_init/@wam_arena_destroy to use linear memory.
+; Native: the arena is a CHAIN of malloc'd blocks. Allocation bumps within
+; the current block; on exhaustion a new block (geometric doubling) is
+; LINKED rather than returning null. Blocks never move — %Values hold raw
+; pointers into them — so growth is safe for live terms. This removes the
+; hard capacity cliff that segfaulted the self-hosted compiler (runtime
+; finding no. 8): accumulator-style grammars allocate quadratically in
+; their output size, and unchecked callers dereferenced the null that the
+; single-block arena returned past its cap.
+;
+; Each block starts with a 32-byte header (data stays 16-aligned):
+;   +0  i8* prev   — previous block's header, or null for the first block
+;   +8  i64 cap    — data capacity of this block (excludes the header)
+;   +16 i64 base   — virtual offset of this block's data start
+;   +24 (reserved)
+; A block's virtual base is the previous block's base + its bump position
+; at link time, so marks (base + pos) are globally monotonic and
+; mark/rewind keep working across block boundaries: rewind pops (frees)
+; every block newer than the mark, then restores the bump position.
+;
+; WASM:   swap @wam_arena_init/@wam_arena_destroy to use linear memory
+;         (a single non-chaining block reproduces the old behavior).
 ;
 ; Usage:  mark → alloc … alloc → rewind (restores to mark).
 ; NOTE: The arena implementation below uses module-level global state
 ; and is NOT thread-safe. Multiple concurrent WamState instances
 ; will race on these globals.
 
-@wam_arena_buf = internal global i8* null
-@wam_arena_pos = internal global i64 0
-@wam_arena_cap = internal global i64 0
+@wam_arena_hdr  = internal global i8* null   ; current block header
+@wam_arena_buf  = internal global i8* null   ; current block data start (hdr+32)
+@wam_arena_pos  = internal global i64 0      ; bump position within current block
+@wam_arena_cap  = internal global i64 0      ; current block data capacity
+@wam_arena_base = internal global i64 0      ; virtual offset of current data start
 
 define void @wam_arena_init(i64 %cap) {
-  %buf = call i8* @malloc(i64 %cap)
-  store i8* %buf, i8** @wam_arena_buf
+  %alloc_sz = add i64 %cap, 32
+  %blk = call i8* @malloc(i64 %alloc_sz)
+  %prev_slot = bitcast i8* %blk to i8**
+  store i8* null, i8** %prev_slot
+  %cap_raw = getelementptr i8, i8* %blk, i64 8
+  %cap_slot = bitcast i8* %cap_raw to i64*
+  store i64 %cap, i64* %cap_slot
+  %base_raw = getelementptr i8, i8* %blk, i64 16
+  %base_slot = bitcast i8* %base_raw to i64*
+  store i64 0, i64* %base_slot
+  %data = getelementptr i8, i8* %blk, i64 32
+  store i8* %blk, i8** @wam_arena_hdr
+  store i8* %data, i8** @wam_arena_buf
   store i64 0, i64* @wam_arena_pos
   store i64 %cap, i64* @wam_arena_cap
+  store i64 0, i64* @wam_arena_base
   ret void
 }
 
 define void @wam_arena_destroy() {
-  %buf = load i8*, i8** @wam_arena_buf
-  %is_null = icmp eq i8* %buf, null
+entry:
+  %hdr0 = load i8*, i8** @wam_arena_hdr
+  br label %loop
+loop:
+  %hdr = phi i8* [ %hdr0, %entry ], [ %prev, %do_free ]
+  %is_null = icmp eq i8* %hdr, null
   br i1 %is_null, label %done, label %do_free
 do_free:
-  call void @free(i8* %buf)
+  %prev_slot = bitcast i8* %hdr to i8**
+  %prev = load i8*, i8** %prev_slot
+  call void @free(i8* %hdr)
+  br label %loop
+done:
+  store i8* null, i8** @wam_arena_hdr
   store i8* null, i8** @wam_arena_buf
   store i64 0, i64* @wam_arena_pos
   store i64 0, i64* @wam_arena_cap
-  br label %done
-done:
+  store i64 0, i64* @wam_arena_base
   ret void
 }
 
+; A mark is a virtual offset (base + pos): monotonic across block links,
+; so mark/rewind pairs stay valid even when the arena grew in between.
 define i64 @wam_arena_mark() alwaysinline nounwind {
   %pos = load i64, i64* @wam_arena_pos
-  ret i64 %pos
+  %base = load i64, i64* @wam_arena_base
+  %mark = add i64 %base, %pos
+  ret i64 %mark
 }
 
-define void @wam_arena_rewind(i64 %mark) alwaysinline nounwind {
-  store i64 %mark, i64* @wam_arena_pos
+; Pops (frees) every block whose data lies entirely past the mark, then
+; restores the bump position inside the surviving block. Everything
+; allocated after the mark is discarded, exactly as before chaining.
+define void @wam_arena_rewind(i64 %mark) nounwind {
+entry:
+  br label %check
+check:
+  %base = load i64, i64* @wam_arena_base
+  %in_block = icmp uge i64 %mark, %base
+  br i1 %in_block, label %set, label %pop
+set:
+  %pos = sub i64 %mark, %base
+  store i64 %pos, i64* @wam_arena_pos
   ret void
-}
-
-; Reset the bump pointer to 0 without releasing the underlying buffer.
-; Cheaper than @wam_arena_destroy + next-iteration @wam_arena_init pair
-; (which does free + malloc of a 1 MiB buffer per query). Used by
-; @wam_cleanup so callers that loop over queries don't pay the
-; per-iteration alloc/free.
-define void @wam_arena_reset() alwaysinline nounwind {
+pop:
+  %hdr = load i8*, i8** @wam_arena_hdr
+  %prev_slot = bitcast i8* %hdr to i8**
+  %prev = load i8*, i8** %prev_slot
+  ; Defensive: a mark below the first block's base (0) cannot happen; if
+  ; it somehow does, keep the first block and clamp to position 0.
+  %no_prev = icmp eq i8* %prev, null
+  br i1 %no_prev, label %clamp, label %do_pop
+clamp:
   store i64 0, i64* @wam_arena_pos
   ret void
+do_pop:
+  call void @free(i8* %hdr)
+  %pcap_raw = getelementptr i8, i8* %prev, i64 8
+  %pcap_slot = bitcast i8* %pcap_raw to i64*
+  %pcap = load i64, i64* %pcap_slot
+  %pbase_raw = getelementptr i8, i8* %prev, i64 16
+  %pbase_slot = bitcast i8* %pbase_raw to i64*
+  %pbase = load i64, i64* %pbase_slot
+  %pdata = getelementptr i8, i8* %prev, i64 32
+  store i8* %prev, i8** @wam_arena_hdr
+  store i8* %pdata, i8** @wam_arena_buf
+  store i64 %pcap, i64* @wam_arena_cap
+  store i64 %pbase, i64* @wam_arena_base
+  br label %check
 }
 
-; Bump-allocates %size bytes (8-byte aligned). Returns null if arena
-; is exhausted — callers that need more than the arena provides should
-; fall back to malloc (not yet implemented; current kernels fit easily).
+; Reset the arena to empty without releasing the first block. Frees any
+; chained growth blocks (so a query that ballooned the arena hands the
+; extra blocks back to malloc) but keeps the initial block mapped, so
+; callers that loop over queries don't pay a per-iteration alloc/free.
+; Used by @wam_cleanup. Equivalent to rewinding to virtual offset 0.
+define void @wam_arena_reset() alwaysinline nounwind {
+  call void @wam_arena_rewind(i64 0)
+  ret void
+}
+
+; Bump-allocates %size bytes (8-byte aligned). On block exhaustion, links
+; a new block of max(current cap * 2, requested size) — geometric growth
+; keeps the block count logarithmic and the total waste bounded. Returns
+; null only if malloc itself fails (true OOM).
 define i8* @wam_arena_alloc(i64 %size) {
 entry:
   ; Align size up to 8.
@@ -2543,33 +2625,59 @@ entry:
   %new_pos = add i64 %pos, %aligned
   %cap = load i64, i64* @wam_arena_cap
   %overflow = icmp ugt i64 %new_pos, %cap
-  br i1 %overflow, label %oom, label %ok
+  br i1 %overflow, label %grow, label %ok
 ok:
   store i64 %new_pos, i64* @wam_arena_pos
   %buf = load i8*, i8** @wam_arena_buf
   %ptr = getelementptr i8, i8* %buf, i64 %pos
   ret i8* %ptr
+grow:
+  ; Link a new block; the old block keeps its live terms (never moves).
+  %cap2 = shl i64 %cap, 1
+  %need_bigger = icmp ugt i64 %aligned, %cap2
+  %new_cap = select i1 %need_bigger, i64 %aligned, i64 %cap2
+  %alloc_sz = add i64 %new_cap, 32
+  %blk = call i8* @malloc(i64 %alloc_sz)
+  %malloc_failed = icmp eq i8* %blk, null
+  br i1 %malloc_failed, label %oom, label %link
+link:
+  %old_hdr = load i8*, i8** @wam_arena_hdr
+  %prev_slot = bitcast i8* %blk to i8**
+  store i8* %old_hdr, i8** %prev_slot
+  %cap_raw = getelementptr i8, i8* %blk, i64 8
+  %cap_slot = bitcast i8* %cap_raw to i64*
+  store i64 %new_cap, i64* %cap_slot
+  %old_base = load i64, i64* @wam_arena_base
+  %new_base = add i64 %old_base, %pos
+  %base_raw = getelementptr i8, i8* %blk, i64 16
+  %base_slot = bitcast i8* %base_raw to i64*
+  store i64 %new_base, i64* %base_slot
+  %data = getelementptr i8, i8* %blk, i64 32
+  store i8* %blk, i8** @wam_arena_hdr
+  store i8* %data, i8** @wam_arena_buf
+  store i64 %new_cap, i64* @wam_arena_cap
+  store i64 %new_base, i64* @wam_arena_base
+  store i64 %aligned, i64* @wam_arena_pos
+  ret i8* %data
 oom:
   ret i8* null
 }
 
-; Convenience: init arena if not already initialized, with a default
-; capacity (256 MiB, virtual -- Linux commits pages lazily, so RSS only
-; grows with actual use). The arena is transient term-building space for
-; put_structure / =.. / the reader; it grows monotonically within a single
-; top-level call (rewound only by the graph kernels). Accumulator-style
-; grammars (append onto a growing list per emitted byte) allocate
-; QUADRATICALLY in their output size, so a self-hosted compiler compiling a
-; ~1.5 KB source blows through the old 16 MiB. wam_arena_alloc returns null
-; past the cap and most callers do not check, so exhaustion segfaults; a
-; chained-arena (link a new block instead of returning null) is the real
-; fix, deferred -- blocks must not move, since %Values hold raw pointers.
+; Convenience: init arena if not already initialized. The initial block is
+; 16 MiB — enough for every normal query — and the chain grows on demand
+; (doubling), so the self-hosted compiler's quadratic accumulator-append
+; behavior (runtime finding no. 8) hits growth, not a segfault. The arena
+; is transient term-building space for put_structure / =.. / the reader;
+; it grows monotonically within a single top-level call (rewound only by
+; the graph kernels) and @wam_cleanup returns growth blocks to malloc.
+; Linearising the accumulator style in the bootstrap compiler (difference
+; lists) remains the compile-time fix; this makes memory a non-cliff.
 define void @wam_arena_ensure() {
   %buf = load i8*, i8** @wam_arena_buf
   %need_init = icmp eq i8* %buf, null
   br i1 %need_init, label %do_init, label %done
 do_init:
-  call void @wam_arena_init(i64 268435456)
+  call void @wam_arena_init(i64 16777216)
   br label %done
 done:
   ret void
@@ -2593,10 +2701,10 @@ define void @wam_cleanup() alwaysinline nounwind {
   ret void
 }
 
-; Full release: hands the arena buffer back to malloc. Idempotent —
-; a second call is a no-op because @wam_arena_destroy checks the
-; null sentinel. Use this on module unload or process shutdown for
-; long-running hosts that want to reclaim the 1 MiB arena.
+; Full release: hands the whole arena block chain back to malloc.
+; Idempotent — a second call is a no-op because @wam_arena_destroy checks
+; the null sentinel. Use this on module unload or process shutdown for
+; long-running hosts that want to reclaim the arena entirely.
 define void @wam_full_shutdown() nounwind {
   call void @wam_arena_destroy()
   ret void

--- a/tests/core/test_wam_llvm_arena_chain_runtime.pl
+++ b/tests/core/test_wam_llvm_arena_chain_runtime.pl
@@ -1,0 +1,274 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Chained-arena runtime tests (M6 self-host, runtime finding no. 8).
+% The bump arena links a new block on exhaustion instead of returning
+% null; blocks never move, and mark/rewind work across block boundaries
+% via virtual offsets. These drivers exercise the arena functions
+% directly in a native binary:
+%   1. Chain semantics: tiny first block, forced links, monotonic marks,
+%      cross-block rewind (pops + frees newer blocks), block stability
+%      (sentinels survive growth), first-block reuse after rewind(0),
+%      destroy + ensure re-init.
+%   2. Growth stress: ~100 MB through a 1 KiB initial block (many
+%      doublings), every allocation written and read back.
+
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module('../helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3]).
+
+:- dynamic user:arena_chain_marker/0.
+
+user:arena_chain_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_arena_chain_runtime, [condition(clang_available)]).
+
+test(arena_chain_marks_rewind_and_block_stability) :-
+    arena_chain_semantics_driver_ir(DriverIR),
+    run_arena_chain_smoke('uw_wam_arena_chain_semantics', DriverIR).
+
+test(arena_chain_growth_stress) :-
+    arena_chain_growth_driver_ir(DriverIR),
+    run_arena_chain_smoke('uw_wam_arena_chain_growth', DriverIR).
+
+run_arena_chain_smoke(Name, DriverIR) :-
+    tmp_root(Root),
+    directory_file_path(Root, Name, Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'arena_chain_runtime.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:arena_chain_marker/0 ],
+        [ module_name('arena_chain_runtime') ],
+        LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'arena_chain_runtime_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == "")
+    ;  format(user_error, "~n[arena chain runtime output]~n~w~n", [OutStr]),
+       throw(arena_chain_runtime_failed(Status))
+    ),
+    !.
+
+% Exit codes: 90 alloc returned null, 91-93 wrong mark after allocs,
+% 94 first-block sentinel lost (block moved or was clobbered by growth),
+% 95 second-block sentinel lost, 96/97 wrong mark after cross-block
+% rewind, 98 reset-to-zero mark wrong, 99 first block not reused in
+% place after rewind(0), 100 wrong mark after destroy + ensure re-init.
+arena_chain_semantics_driver_ir('
+define i32 @main() {
+entry:
+  ; Tiny first block: cap 64, so the second allocation must chain.
+  call void @wam_arena_init(i64 64)
+  %p1 = call i8* @wam_arena_alloc(i64 48)
+  %p1_null = icmp eq i8* %p1, null
+  br i1 %p1_null, label %alloc_fail, label %fill1
+
+fill1:
+  %p1_i64 = bitcast i8* %p1 to i64*
+  store i64 111, i64* %p1_i64
+  %p1_tail_raw = getelementptr i8, i8* %p1, i64 40
+  %p1_tail = bitcast i8* %p1_tail_raw to i64*
+  store i64 222, i64* %p1_tail
+  %m1 = call i64 @wam_arena_mark()
+  %m1_ok = icmp eq i64 %m1, 48
+  br i1 %m1_ok, label %chain1, label %bad_m1
+
+chain1:
+  ; 48 + 64 > 64: links a second block (cap max(128, 64) = 128, base 48).
+  %p2 = call i8* @wam_arena_alloc(i64 64)
+  %p2_null = icmp eq i8* %p2, null
+  br i1 %p2_null, label %alloc_fail, label %fill2
+
+fill2:
+  %p2_tail_raw = getelementptr i8, i8* %p2, i64 56
+  %p2_tail = bitcast i8* %p2_tail_raw to i64*
+  store i64 333, i64* %p2_tail
+  %m2 = call i64 @wam_arena_mark()
+  %m2_ok = icmp eq i64 %m2, 112
+  br i1 %m2_ok, label %chain2, label %bad_m2
+
+chain2:
+  ; 64 + 200 > 128: links a third block (cap max(256, 200) = 256, base 112).
+  %p3 = call i8* @wam_arena_alloc(i64 200)
+  %p3_null = icmp eq i8* %p3, null
+  br i1 %p3_null, label %alloc_fail, label %fill3
+
+fill3:
+  %p3_tail_raw = getelementptr i8, i8* %p3, i64 192
+  %p3_tail = bitcast i8* %p3_tail_raw to i64*
+  store i64 444, i64* %p3_tail
+  %m3 = call i64 @wam_arena_mark()
+  %m3_ok = icmp eq i64 %m3, 312
+  br i1 %m3_ok, label %stability, label %bad_m3
+
+stability:
+  ; Earlier blocks must be untouched by growth (blocks never move).
+  %r1 = load i64, i64* %p1_i64
+  %r1_ok = icmp eq i64 %r1, 111
+  %r1t = load i64, i64* %p1_tail
+  %r1t_ok = icmp eq i64 %r1t, 222
+  %b1_ok = and i1 %r1_ok, %r1t_ok
+  br i1 %b1_ok, label %stability2, label %bad_block1
+
+stability2:
+  %r2 = load i64, i64* %p2_tail
+  %r2_ok = icmp eq i64 %r2, 333
+  br i1 %r2_ok, label %rewind_mid, label %bad_block2
+
+rewind_mid:
+  ; Rewind to m2 (virtual 112): discards the 200-byte allocation.
+  call void @wam_arena_rewind(i64 112)
+  %mm2 = call i64 @wam_arena_mark()
+  %mm2_ok = icmp eq i64 %mm2, 112
+  br i1 %mm2_ok, label %rewind_far, label %bad_rw_mid
+
+rewind_far:
+  ; Rewind to m1 (virtual 48): pops across a block boundary.
+  call void @wam_arena_rewind(i64 48)
+  %mm1 = call i64 @wam_arena_mark()
+  %mm1_ok = icmp eq i64 %mm1, 48
+  br i1 %mm1_ok, label %check_survivor, label %bad_rw_far
+
+check_survivor:
+  ; The first block (below the mark) must still hold its data.
+  %r1b = load i64, i64* %p1_i64
+  %r1b_ok = icmp eq i64 %r1b, 111
+  br i1 %r1b_ok, label %reset_zero, label %bad_block1
+
+reset_zero:
+  call void @wam_arena_reset()
+  %mz = call i64 @wam_arena_mark()
+  %mz_ok = icmp eq i64 %mz, 0
+  br i1 %mz_ok, label %reuse, label %bad_reset
+
+reuse:
+  ; After reset the first block is reused in place: same data pointer.
+  %p5 = call i8* @wam_arena_alloc(i64 48)
+  %p5_null = icmp eq i8* %p5, null
+  br i1 %p5_null, label %alloc_fail, label %reuse_check
+
+reuse_check:
+  %same = icmp eq i8* %p5, %p1
+  br i1 %same, label %reinit, label %bad_reuse
+
+reinit:
+  ; Destroy releases the whole chain; ensure re-initializes lazily.
+  call void @wam_arena_destroy()
+  call void @wam_arena_ensure()
+  %p6 = call i8* @wam_arena_alloc(i64 16)
+  %p6_null = icmp eq i8* %p6, null
+  br i1 %p6_null, label %alloc_fail, label %reinit_check
+
+reinit_check:
+  %m6 = call i64 @wam_arena_mark()
+  %m6_ok = icmp eq i64 %m6, 16
+  call void @wam_arena_destroy()
+  br i1 %m6_ok, label %ok, label %bad_reinit
+
+ok:
+  ret i32 0
+alloc_fail:
+  ret i32 90
+bad_m1:
+  ret i32 91
+bad_m2:
+  ret i32 92
+bad_m3:
+  ret i32 93
+bad_block1:
+  ret i32 94
+bad_block2:
+  ret i32 95
+bad_rw_mid:
+  ret i32 96
+bad_rw_far:
+  ret i32 97
+bad_reset:
+  ret i32 98
+bad_reuse:
+  ret i32 99
+bad_reinit:
+  ret i32 100
+}
+').
+
+% Exit codes: 90 alloc returned null, 91 read-back mismatch (a growth
+% block clobbered an earlier one), 92 reset did not return to zero.
+arena_chain_growth_driver_ir('
+define i32 @main() {
+entry:
+  ; 1 KiB initial block; 100000 x 1000 bytes (~100 MB) forces many
+  ; doublings. Every allocation is stamped with its index and re-read
+  ; immediately (a fresh block clobbering live data would surface as a
+  ; mismatch on a later iteration via the mark checksum below).
+  call void @wam_arena_init(i64 1024)
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i_next, %step ]
+  %done = icmp uge i64 %i, 100000
+  br i1 %done, label %check_total, label %body
+
+body:
+  %p = call i8* @wam_arena_alloc(i64 1000)
+  %p_null = icmp eq i8* %p, null
+  br i1 %p_null, label %alloc_fail, label %stamp
+
+stamp:
+  %slot = bitcast i8* %p to i64*
+  store i64 %i, i64* %slot
+  %back = load i64, i64* %slot
+  %back_ok = icmp eq i64 %back, %i
+  br i1 %back_ok, label %step, label %bad_readback
+
+step:
+  %i_next = add i64 %i, 1
+  br label %loop
+
+check_total:
+  ; 1000 aligns to 1000 (already a multiple of 8): total = 100000000.
+  %m = call i64 @wam_arena_mark()
+  %m_ok = icmp eq i64 %m, 100000000
+  br i1 %m_ok, label %reset, label %bad_readback
+
+reset:
+  call void @wam_arena_reset()
+  %mz = call i64 @wam_arena_mark()
+  %mz_ok = icmp eq i64 %mz, 0
+  call void @wam_arena_destroy()
+  br i1 %mz_ok, label %ok, label %bad_reset
+
+ok:
+  ret i32 0
+alloc_fail:
+  ret i32 90
+bad_readback:
+  ret i32 91
+bad_reset:
+  ret i32 92
+}
+').
+
+:- end_tests(wam_llvm_arena_chain_runtime).
+
+:- initialization(run_tests, main).


### PR DESCRIPTION
## Summary

Stacked on #3561 (the fixpoint first slice). Runtime finding #8's stopgap was a 256 MiB arena; this lands the honest fix: the bump arena now **links a new block on exhaustion** instead of returning null (which unchecked callers dereferenced — the segfault that capped the self-hosted compiler at the arena size).

**Design** (`templates/targets/llvm_wam/state.ll.mustache`):
- Each block carries a 32-byte header: previous-block pointer, data capacity, and the block's virtual base offset (data stays 16-aligned).
- The allocation slow path mallocs `max(cap × 2, requested)` and chains it — geometric doubling keeps the block count logarithmic. Blocks **never move**: `%Value`s hold raw pointers into them, so live terms stay valid across growth. Null is returned only on true malloc failure.
- Marks became **virtual offsets** (`base + pos`), globally monotonic across links, so the graph kernels' mark/rewind pairs keep working even when the arena grew in between: rewind pops (frees) every block newer than the mark and restores the bump position in the survivor.
- `wam_arena_reset` (per-query cleanup) rewinds to virtual offset 0, handing growth blocks back to malloc while keeping the initial block mapped for reuse; `wam_arena_destroy` frees the whole chain.
- The initial block drops back from the 256 MiB stopgap to **16 MiB**: the default query never chains, and big compiles grow on demand with no practical ceiling.

## Testing

New native driver suite `tests/core/test_wam_llvm_arena_chain_runtime.pl` (same clang-driver pattern as the assoc-i64 runtime tests):
- **Chain semantics**: a 64-byte first block forced through two links, exact mark checks at every step (48 / 112 / 312), cross-block rewinds, block-stability sentinels proving earlier blocks are untouched by growth, first-block in-place reuse after reset, destroy + ensure re-init. Distinct exit codes per failure mode.
- **Growth stress**: ~100 MB through a 1 KiB initial block (many doublings), every allocation stamped and read back, final mark checked exactly.

Verified with fresh host caches (`rm -rf /tmp/uw_wam_object`):
- The arena-chain drivers pass.
- The full `wam_object` suite passes — the fixpoint compile needs > 16 MiB, so it now **exercises chaining in production** on every run.
- LLVM target suite: 0 failures. `test_plawk_dyncall` and `test_plawk_compiled_stream_core`: pass.
- WASM runtime tests skip in this container (no llc/wasm-ld/wasmtime); the chain uses the same malloc/free dependencies as before, so no new WASM surface.

## Docs

- `PLAWK_SELFHOST.md`: finding-#8 entry upgraded from deferred to LANDED with the design; remaining-work note now points only at the compile-*time* side (difference-list linearization of the bootstrap compiler's accumulator appends — memory is no longer the cliff, quadratic work still costs seconds as sources grow).
- `PLAWK_JIT_ROADMAP.md`: milestone 6 bug list updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_