### PR TITLE
Score Product-Kalman grouped NPZ covariances

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -384,7 +384,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    `product_kalman_table_to_npz.py` records source-table hash, split counts, column groups, optional discrete
    group labels such as hop/regime buckets, dimensions, ID overlap/duplicate counts, and `H`
    shape/values; `product_kalman_evaluation.py` then fits calibration blocks on one split, scores prior /
-   zero-cross-covariance / correlated Product-Kalman predictions on a separate split, records aggregate NLL/MSE,
+   zero-cross-covariance / correlated Product-Kalman predictions on a separate split, optionally appends
+   grouped-covariance score variants when calibration/evaluation group labels are present, records aggregate NLL/MSE,
    Mahalanobis calibration-scale/tail diagnostics, row-level score vectors, and optional paired bootstrap intervals
    for NLL gains, and keeps calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison
    pending.)*
@@ -423,14 +424,14 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
 - `product_kalman_split_table.py` and `test_product_kalman_split_table.py` — split-label materializer for explicit
   Product-Kalman tables, with held-out unit sampling, strict boundary-row omission, and a split manifest.
 - `product_kalman_table_evaluation.py` and `test_product_kalman_table_evaluation.py` — one-command table-to-input-
-  artifacts-to-holdout-score/report runner, with optional split materialization and canonical `--output-dir` bundles
-  for real-corpus Product-Kalman comparisons.
+  artifacts-to-holdout-score/report runner, with optional split materialization, optional group-label carry-through into
+  grouped covariance scores, and canonical `--output-dir` bundles for real-corpus Product-Kalman comparisons.
 - `product_kalman_report.py` and `test_product_kalman_report.py` — descriptive Markdown report generator for
   Product-Kalman input manifests, optional split manifests, and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including NLL/MSE,
-  rowwise covariance scoring, grouped residual-covariance maps, and a grouped scorer for future
-  hop-conditioned `V(hop)` audits, Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, and
-  row-level NPZ score artifacts for reproducible bootstrap/tail diagnostics.
+  rowwise covariance scoring, grouped residual-covariance maps, automatic grouped score variants when NPZ group
+  labels are present, Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, and row-level NPZ score
+  artifacts for reproducible bootstrap/tail diagnostics.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -454,6 +454,7 @@ class ProductKalmanHoldoutEvaluation:
     independent_update: object
     scores: tuple
     score_vectors: tuple = ()
+    grouped_scores: tuple = ()
 
     def __post_init__(self):
         if not isinstance(self.calibration, ProductKalmanCalibration):
@@ -468,6 +469,7 @@ class ProductKalmanHoldoutEvaluation:
         if len(names) != len(set(names)):
             raise ValueError("score names must be unique")
         score_vectors = tuple(self.score_vectors)
+        vector_names = []
         if score_vectors:
             for vector in score_vectors:
                 if not isinstance(vector, GaussianScoreVectors):
@@ -478,8 +480,24 @@ class ProductKalmanHoldoutEvaluation:
             for score, vector in zip(scores, score_vectors):
                 if vector.n != score.n:
                     raise ValueError("score vector length must match score n")
+        grouped_scores = tuple(self.grouped_scores)
+        if grouped_scores:
+            grouped_names = []
+            score_name_set = set(names)
+            vector_name_set = set(vector_names)
+            for grouped in grouped_scores:
+                if not isinstance(grouped, GroupedGaussianScore):
+                    raise ValueError("grouped_scores must contain GroupedGaussianScore objects")
+                grouped_names.append(grouped.score.name)
+                if grouped.score.name not in score_name_set:
+                    raise ValueError("grouped score must also appear in scores")
+                if grouped.score_vectors.name not in vector_name_set:
+                    raise ValueError("grouped score vectors must also appear in score_vectors")
+            if len(grouped_names) != len(set(grouped_names)):
+                raise ValueError("grouped score names must be unique")
         object.__setattr__(self, "scores", scores)
         object.__setattr__(self, "score_vectors", score_vectors)
+        object.__setattr__(self, "grouped_scores", grouped_scores)
 
     def score(self, name):
         """Return the named `GaussianScore`."""
@@ -812,6 +830,17 @@ def _check_split_ids(calibration_ids, evaluation_ids, n_calibration, n_evaluatio
     assert_disjoint_ids(calibration_ids, evaluation_ids)
 
 
+def _check_group_labels(calibration_groups, evaluation_groups, n_calibration, n_evaluation):
+    if calibration_groups is None and evaluation_groups is None:
+        return None, None
+    if calibration_groups is None or evaluation_groups is None:
+        raise ValueError("calibration_groups and evaluation_groups must be provided together")
+    return (
+        _as_group_labels("calibration_groups", calibration_groups, n=n_calibration),
+        _as_group_labels("evaluation_groups", evaluation_groups, n=n_evaluation),
+    )
+
+
 def _zero_cross_calibration(calibration):
     return ProductKalmanCalibration(
         state_covariance=calibration.state_covariance,
@@ -841,6 +870,9 @@ def evaluate_product_kalman_holdout(
     H=None,
     calibration_ids=None,
     evaluation_ids=None,
+    calibration_groups=None,
+    evaluation_groups=None,
+    min_group_rows=None,
     shrinkage=0.0,
     jitter=1e-9,
     ddof=1,
@@ -865,6 +897,12 @@ def evaluate_product_kalman_holdout(
     eval_measure = _as_2d("evaluation_measurement", evaluation_measurement)
     eval_target = _as_2d("evaluation_target_state", evaluation_target_state)
     _check_split_ids(calibration_ids, evaluation_ids, cal_target.shape[0], eval_target.shape[0])
+    cal_groups, eval_groups = _check_group_labels(
+        calibration_groups,
+        evaluation_groups,
+        cal_target.shape[0],
+        eval_target.shape[0],
+    )
 
     calibration = fit_product_kalman_calibration(
         cal_prior,
@@ -885,7 +923,8 @@ def evaluate_product_kalman_holdout(
         ("independent_kalman", independent_update.mean, independent_update.covariance),
         ("product_kalman", correlated_update.mean, correlated_update.covariance),
     ]
-    if _has_identity_observation(calibration):
+    identity_observation = _has_identity_observation(calibration)
+    if identity_observation:
         score_inputs.insert(1, ("measurement", eval_measure, calibration.observation_covariance))
 
     score_vectors = [
@@ -897,6 +936,37 @@ def evaluate_product_kalman_holdout(
         for vectors, (_, _, covariance) in zip(score_vectors, score_inputs)
     ]
 
+    grouped_scores = []
+    if cal_groups is not None:
+        cal_correlated_update = apply_product_kalman_calibration(calibration, cal_prior, cal_measure, jitter=jitter)
+        cal_independent_update = apply_product_kalman_calibration(independent, cal_prior, cal_measure, jitter=jitter)
+        grouped_inputs = [
+            ("prior_grouped", cal_prior, eval_prior),
+            ("independent_kalman_grouped", cal_independent_update.mean, independent_update.mean),
+            ("product_kalman_grouped", cal_correlated_update.mean, correlated_update.mean),
+        ]
+        if identity_observation:
+            grouped_inputs.insert(1, ("measurement_grouped", cal_measure, eval_measure))
+        grouped_scores = [
+            score_gaussian_predictions_grouped(
+                name,
+                cal_target,
+                cal_mean,
+                cal_groups,
+                eval_target,
+                eval_mean,
+                eval_groups,
+                min_group_rows=min_group_rows,
+                shrinkage=shrinkage,
+                jitter=jitter,
+                ddof=ddof,
+                shrinkage_target=shrinkage_target,
+            )
+            for name, cal_mean, eval_mean in grouped_inputs
+        ]
+        scores.extend(grouped.score for grouped in grouped_scores)
+        score_vectors.extend(grouped.score_vectors for grouped in grouped_scores)
+
     return ProductKalmanHoldoutEvaluation(
         calibration=calibration,
         independent_calibration=independent,
@@ -904,6 +974,7 @@ def evaluate_product_kalman_holdout(
         independent_update=independent_update,
         scores=tuple(scores),
         score_vectors=tuple(score_vectors),
+        grouped_scores=tuple(grouped_scores),
     )
 
 
@@ -914,6 +985,32 @@ def _prefix_update_arrays(prefix, update):
         f"{prefix}_gain": update.gain,
         f"{prefix}_innovation": update.innovation,
         f"{prefix}_innovation_covariance": update.innovation_covariance,
+    }
+
+
+def _string_keyed_mapping(name, mapping, value_fn):
+    out = {}
+    for label, value in mapping.items():
+        key = str(label)
+        if key in out:
+            raise ValueError(f"{name} has duplicate stringified group label {key!r}")
+        out[key] = value_fn(value)
+    return dict(sorted(out.items()))
+
+
+def _grouped_covariance_to_json_dict(grouped):
+    residuals = grouped.residual_covariances
+    return {
+        "score": grouped.score.name,
+        "min_group_rows": residuals.min_group_rows,
+        "group_counts": _string_keyed_mapping("group_counts", residuals.group_counts, int),
+        "fallback_covariance": residuals.fallback_covariance.tolist(),
+        "covariance_by_group": _string_keyed_mapping(
+            "covariance_by_group",
+            residuals.covariance_by_group,
+            lambda cov: np.asarray(cov, dtype=float).tolist(),
+        ),
+        "row_covariance_shape": [int(v) for v in grouped.row_covariances.shape],
     }
 
 
@@ -964,6 +1061,18 @@ def evaluation_artifact_arrays(result):
             "score_row_squared_mahalanobis": np.vstack([
                 vectors.squared_mahalanobis
                 for vectors in result.score_vectors
+            ]),
+        })
+    if result.grouped_scores:
+        arrays.update({
+            "grouped_score_names": np.array([grouped.score.name for grouped in result.grouped_scores]),
+            "grouped_score_row_covariances": np.stack([
+                grouped.row_covariances
+                for grouped in result.grouped_scores
+            ]),
+            "grouped_score_summary_json": np.array([
+                json.dumps(_grouped_covariance_to_json_dict(grouped), sort_keys=True)
+                for grouped in result.grouped_scores
             ]),
         })
     arrays.update(_prefix_update_arrays("product_kalman", result.correlated_update))
@@ -1092,6 +1201,11 @@ def evaluation_to_json_dict(result, bootstrap_nll=0, bootstrap_seed=0, bootstrap
             for name, score in scores.items()
             if name != "independent_kalman"
         }
+    if result.grouped_scores:
+        out["grouped_covariances"] = {
+            grouped.score.name: _grouped_covariance_to_json_dict(grouped)
+            for grouped in result.grouped_scores
+        }
     if bootstrap_nll:
         out["nll_improvement_bootstrap_vs_prior"] = _bootstrap_improvement_map(
             result,
@@ -1122,6 +1236,9 @@ def run_product_kalman_holdout_npz(
     H_key="H",
     calibration_ids_key="calibration_ids",
     evaluation_ids_key="evaluation_ids",
+    calibration_groups_key="calibration_groups",
+    evaluation_groups_key="evaluation_groups",
+    min_group_rows=None,
     shrinkage=0.0,
     jitter=1e-9,
     ddof=1,
@@ -1130,14 +1247,16 @@ def run_product_kalman_holdout_npz(
     """Load a single NPZ fixture and run `evaluate_product_kalman_holdout`.
 
     Required arrays default to the key names in the argument list. Optional `H`,
-    `calibration_ids`, and `evaluation_ids` arrays are used when present. Store
-    scalar channels as explicit `(n, 1)` matrices, matching the calibration API.
+    split-ID arrays, and group-label arrays are used when present. Store scalar
+    channels as explicit `(n, 1)` matrices, matching the calibration API.
     """
     path = str(input_npz)
     with np.load(path, allow_pickle=False) as data:
         H = _optional_npz_array(data, H_key) if H_key else None
         calibration_ids = _optional_npz_array(data, calibration_ids_key) if calibration_ids_key else None
         evaluation_ids = _optional_npz_array(data, evaluation_ids_key) if evaluation_ids_key else None
+        calibration_groups = _optional_npz_array(data, calibration_groups_key) if calibration_groups_key else None
+        evaluation_groups = _optional_npz_array(data, evaluation_groups_key) if evaluation_groups_key else None
         return evaluate_product_kalman_holdout(
             _require_npz_array(data, path, calibration_prior_key),
             _require_npz_array(data, path, calibration_measurement_key),
@@ -1148,6 +1267,9 @@ def run_product_kalman_holdout_npz(
             H=H,
             calibration_ids=calibration_ids,
             evaluation_ids=evaluation_ids,
+            calibration_groups=calibration_groups,
+            evaluation_groups=evaluation_groups,
+            min_group_rows=min_group_rows,
             shrinkage=shrinkage,
             jitter=jitter,
             ddof=ddof,
@@ -1179,6 +1301,17 @@ def _build_arg_parser():
         default="evaluation_ids",
         help="optional evaluation ID key; use '' to disable",
     )
+    ap.add_argument(
+        "--calibration-groups-key",
+        default="calibration_groups",
+        help="optional calibration group-label key; use '' to disable grouped covariance scores",
+    )
+    ap.add_argument(
+        "--evaluation-groups-key",
+        default="evaluation_groups",
+        help="optional evaluation group-label key; use '' to disable grouped covariance scores",
+    )
+    ap.add_argument("--min-group-rows", type=int, help="minimum calibration rows before fitting a group covariance")
     ap.add_argument("--shrinkage", type=float, default=0.0)
     ap.add_argument("--jitter", type=float, default=1e-9)
     ap.add_argument("--ddof", type=int, default=1)
@@ -1205,6 +1338,9 @@ def main(argv=None):
             H_key=args.H_key or None,
             calibration_ids_key=args.calibration_ids_key or None,
             evaluation_ids_key=args.evaluation_ids_key or None,
+            calibration_groups_key=args.calibration_groups_key or None,
+            evaluation_groups_key=args.evaluation_groups_key or None,
+            min_group_rows=args.min_group_rows,
             shrinkage=args.shrinkage,
             jitter=args.jitter,
             ddof=args.ddof,

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -197,6 +197,19 @@ def _calibration_rows(scores_json):
     ]
 
 
+def _grouped_covariance_rows(scores_json):
+    rows = []
+    for name, item in sorted(scores_json.get("grouped_covariances", {}).items()):
+        counts = item.get("group_counts", {})
+        rows.append([
+            name,
+            item.get("min_group_rows"),
+            ", ".join(f"{label}:{count}" for label, count in sorted(counts.items())),
+            item.get("row_covariance_shape"),
+        ])
+    return rows
+
+
 def _artifact_path(scores_json, evaluation_npz=None):
     artifact_path = evaluation_npz or scores_json.get("inputs", {}).get("evaluation_npz")
     if not artifact_path:
@@ -332,6 +345,17 @@ def build_product_kalman_markdown_report(
         ])
     bootstrap_rows = _bootstrap_rows(scores_json)
     bootstrap_artifact_rows = _bootstrap_artifact_rows(scores_json)
+    grouped_covariance_rows = _grouped_covariance_rows(scores_json)
+    if grouped_covariance_rows:
+        lines.extend([
+            "## Grouped Covariances",
+            "",
+            _markdown_table(
+                ["score", "min_group_rows", "group_counts", "row_covariance_shape"],
+                grouped_covariance_rows,
+            ),
+            "",
+        ])
     lines.extend([
         "## Scores",
         "",

--- a/prototypes/mu_cosine/product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_table_evaluation.py
@@ -173,6 +173,7 @@ def run_product_kalman_table_evaluation(
     delimiter=None,
     H=None,
     group_cols=None,
+    min_group_rows=None,
     shrinkage=0.0,
     jitter=1e-9,
     ddof=1,
@@ -200,6 +201,7 @@ def run_product_kalman_table_evaluation(
     )
     result = run_product_kalman_holdout_npz(
         input_npz,
+        min_group_rows=min_group_rows,
         shrinkage=shrinkage,
         jitter=jitter,
         ddof=ddof,
@@ -279,6 +281,7 @@ def _build_arg_parser():
     ap.add_argument("--delimiter", help="input delimiter; defaults to tab for .tsv/.tab, comma otherwise")
     ap.add_argument("--H", help="optional observation matrix literal, e.g. '1,0;0,1'")
     ap.add_argument("--group-cols", help="optional comma-separated discrete group columns to carry into NPZ")
+    ap.add_argument("--min-group-rows", type=int, help="minimum calibration rows before fitting a group covariance")
     ap.add_argument("--shrinkage", type=float, default=0.0)
     ap.add_argument("--jitter", type=float, default=1e-9)
     ap.add_argument("--ddof", type=int, default=1)
@@ -338,6 +341,7 @@ def main(argv=None):
             delimiter=args.delimiter,
             H=args.H,
             group_cols=parse_column_list(args.group_cols) if args.group_cols else None,
+            min_group_rows=args.min_group_rows,
             shrinkage=args.shrinkage,
             jitter=args.jitter,
             ddof=args.ddof,

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -141,6 +141,27 @@ def test_split_ids_are_checked_before_scoring():
         calibration_ids=["dup", "dup"] + [f"cal-{i}" for i in range(8)],
         evaluation_ids=[f"eval-{i}" for i in range(6)],
     )
+    assert_raises(
+        evaluate_product_kalman_holdout,
+        cal_prior,
+        cal_measure,
+        cal_target,
+        eval_prior,
+        eval_measure,
+        eval_target,
+        calibration_groups=["g"] * len(cal_target),
+    )
+    assert_raises(
+        evaluate_product_kalman_holdout,
+        cal_prior,
+        cal_measure,
+        cal_target,
+        eval_prior,
+        eval_measure,
+        eval_target,
+        calibration_groups=["g"] * (len(cal_target) - 1),
+        evaluation_groups=["g"] * len(eval_target),
+    )
 
 
 def write_identity_npz(path, n_cal=8000, n_eval=4000):
@@ -272,6 +293,83 @@ def test_evaluation_artifact_arrays_are_npz_ready():
         with np.load(artifact_path, allow_pickle=False) as artifact:
             assert set(arrays).issubset(set(artifact.files))
             np.testing.assert_allclose(artifact["score_mean_nll"], arrays["score_mean_nll"])
+
+
+def test_npz_runner_scores_grouped_covariances_when_group_labels_present():
+    rng = np.random.default_rng(41)
+    n_cal_per_group = 600
+    n_eval_per_group = 300
+    cal_groups = np.array(["tight"] * n_cal_per_group + ["wide"] * n_cal_per_group)
+    eval_groups = np.array(["tight"] * n_eval_per_group + ["wide"] * n_eval_per_group)
+    n_cal = cal_groups.size
+    n_eval = eval_groups.size
+    cal_target = rng.normal(size=(n_cal, 1))
+    eval_target = rng.normal(size=(n_eval, 1))
+
+    def draw_errors(groups):
+        errors = []
+        for group in groups:
+            if group == "tight":
+                cov = np.array([[0.05, 0.015], [0.015, 0.04]])
+            else:
+                cov = np.array([[1.20, 0.45], [0.45, 0.55]])
+            errors.append(rng.multivariate_normal([0.0, 0.0], cov))
+        return np.asarray(errors)
+
+    cal_errors = draw_errors(cal_groups)
+    eval_errors = draw_errors(eval_groups)
+    cal_prior = cal_target - cal_errors[:, :1]
+    cal_measure = cal_target + cal_errors[:, 1:]
+    eval_prior = eval_target - eval_errors[:, :1]
+    eval_measure = eval_target + eval_errors[:, 1:]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        input_path = Path(tmp) / "grouped_holdout.npz"
+        artifact_path = Path(tmp) / "grouped_artifacts.npz"
+        np.savez(
+            input_path,
+            calibration_prior_mean=cal_prior,
+            calibration_measurement=cal_measure,
+            calibration_target_state=cal_target,
+            evaluation_prior_mean=eval_prior,
+            evaluation_measurement=eval_measure,
+            evaluation_target_state=eval_target,
+            calibration_groups=cal_groups,
+            evaluation_groups=eval_groups,
+        )
+        result = run_product_kalman_holdout_npz(input_path, min_group_rows=50, jitter=1e-8)
+        assert [grouped.score.name for grouped in result.grouped_scores] == [
+            "prior_grouped",
+            "measurement_grouped",
+            "independent_kalman_grouped",
+            "product_kalman_grouped",
+        ]
+        assert "product_kalman_grouped" in [score.name for score in result.scores]
+        assert result.score("product_kalman_grouped").n == n_eval
+        assert result.score("prior_grouped").mean_nll < result.score("prior").mean_nll
+        assert result.score("product_kalman_grouped").mean_nll < result.score("product_kalman").mean_nll
+
+        data = evaluation_to_json_dict(result, bootstrap_nll=20, bootstrap_seed=4)
+        assert data["score_order"][-1] == "product_kalman_grouped"
+        grouped = data["grouped_covariances"]["product_kalman_grouped"]
+        assert grouped["min_group_rows"] == 50
+        assert grouped["group_counts"] == {"tight": n_cal_per_group, "wide": n_cal_per_group}
+        assert grouped["row_covariance_shape"] == [n_eval, 1, 1]
+        assert "product_kalman_grouped" in data["nll_improvement_bootstrap_vs_independent_kalman"]
+
+        write_evaluation_npz(artifact_path, result)
+        with np.load(artifact_path, allow_pickle=False) as artifact:
+            assert artifact["score_names"].shape == (8,)
+            assert artifact["score_row_nll"].shape == (8, n_eval)
+            assert artifact["grouped_score_names"].tolist() == [
+                "prior_grouped",
+                "measurement_grouped",
+                "independent_kalman_grouped",
+                "product_kalman_grouped",
+            ]
+            assert artifact["grouped_score_row_covariances"].shape == (4, n_eval, 1, 1)
+            summary = json.loads(str(artifact["grouped_score_summary_json"][-1]))
+            assert summary["score"] == "product_kalman_grouped"
 
 
 def test_npz_runner_validates_required_keys():

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -119,9 +119,19 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert summary["inputs"]["input_manifest"] == str(input_manifest)
         assert summary["inputs"]["evaluation_npz"] == str(output_npz)
         assert summary["inputs"]["report_md"] == str(output_md)
-        assert summary["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
+        assert summary["score_order"] == [
+            "prior",
+            "measurement",
+            "independent_kalman",
+            "product_kalman",
+            "prior_grouped",
+            "measurement_grouped",
+            "independent_kalman_grouped",
+            "product_kalman_grouped",
+        ]
         assert "mahalanobis_per_dim" in summary["scores"]["product_kalman"]
         assert "squared_mahalanobis_q95" in summary["scores"]["product_kalman"]
+        assert "product_kalman_grouped" in summary["grouped_covariances"]
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
         boot = summary["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"]
         assert boot["n_boot"] == 50
@@ -145,17 +155,20 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert "## Scores" in report
         assert "mahalanobis_per_dim" in report
         assert "sq_mahalanobis_q95" in report
+        assert "## Grouped Covariances" in report
+        assert "product_kalman_grouped" in report
         assert "## NLL Improvement Bootstrap Intervals" in report
         assert "source_table_sha256" in report
 
         with np.load(output_npz, allow_pickle=False) as artifact:
             assert artifact["product_kalman_mean"].shape == (40, 1)
             assert artifact["score_names"].tolist() == summary["score_order"]
-            assert artifact["score_mahalanobis_per_dim"].shape == (4,)
-            assert artifact["score_squared_mahalanobis_q95"].shape == (4,)
-            assert artifact["score_row_nll"].shape == (4, 40)
-            assert artifact["score_row_squared_error"].shape == (4, 40)
-            assert artifact["score_row_squared_mahalanobis"].shape == (4, 40)
+            assert artifact["score_mahalanobis_per_dim"].shape == (8,)
+            assert artifact["score_squared_mahalanobis_q95"].shape == (8,)
+            assert artifact["score_row_nll"].shape == (8, 40)
+            assert artifact["score_row_squared_error"].shape == (8, 40)
+            assert artifact["score_row_squared_mahalanobis"].shape == (8, 40)
+            assert artifact["grouped_score_row_covariances"].shape == (4, 40, 1, 1)
 
 
 def test_table_runner_output_dir_writes_canonical_bundle():
@@ -192,6 +205,8 @@ def test_table_runner_output_dir_writes_canonical_bundle():
         assert summary["inputs"]["evaluation_npz"] == str(paths["output_npz"])
         assert summary["inputs"]["report_md"] == str(paths["output_md"])
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
+        assert "product_kalman_grouped" in summary["score_order"]
+        assert "product_kalman_grouped" in summary["grouped_covariances"]
         with np.load(paths["input_npz"], allow_pickle=False) as data:
             assert data["calibration_groups"].shape == (80,)
             assert data["evaluation_groups"].shape == (40,)
@@ -341,6 +356,8 @@ def test_table_runner_cli_roundtrips_against_npz_evaluator():
         assert manifest["source_table"]["delimiter"] == "\t"
         assert manifest["ids"]["overlap_count"] == 0
         assert manifest["groups"]["columns"] == ["hop"]
+        assert "product_kalman_grouped" in from_table["score_order"]
+        assert "product_kalman_grouped" in from_table["grouped_covariances"]
         assert from_table["inputs"]["report_md"] == str(output_md)
 
 


### PR DESCRIPTION
## Summary
- Automatically append grouped-covariance score variants when an evaluator NPZ includes `calibration_groups` and `evaluation_groups`.
- Add grouped score families such as `prior_grouped`, `measurement_grouped`, and `product_kalman_grouped`.
- Store grouped covariance provenance in JSON summaries and evaluation NPZ artifacts.
- Add a compact grouped-covariance section to Markdown reports.
- Thread `--min-group-rows` through the NPZ and table runners.

## Tests
- `python3 -m py_compile ...`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `git diff --check`