### PR TITLE
mu_cosine: Product-Kalman on real data + Sigma(hop) in the gain — fusion validated, calibration target hit

### DIFF
--- a/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
+++ b/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
@@ -172,3 +172,29 @@ Kalman: treat 0/1 labels as censored observations of a latent logit-normal) = th
 also revives the geometric flavor properly dressed: interior fusion in logit space is the multiplying-Bayes-
 factors update. Next-rung list is now: (a) hop-conditioned V(hop) into the gain; (b) Tobit-logit Kalman vs
 mu-space fusion, scored in one space via the change-of-variables density.
+
+### Boundary atoms via Jacobian weighting — simpler than Tobit (user, 2026-07-08)
+
+*User: we can't be 100% certain a point is on the boundary (the label is itself an uncertain estimate); let the
+weighting/measure live in logit space, so a boundary point carries zero weight.* Formalized — and it supersedes
+the Tobit sketch above:
+
+- Treat the judge label as a noisy μ-estimate with uncertainty `σ_μ` (at minimum the quantization half-step: a
+  reported 0.0 means "≤ 0.025", not certainty). Propagate through the link Jacobian:
+  `σ_logit ≈ σ_μ / (μ(1−μ))` ⇒ logit-space precision `∝ (μ(1−μ))²` — full weight at μ=0.5, **vanishing at the
+  boundary**. The boundary point self-downweights INSIDE the ordinary Kalman update; no censored likelihood.
+- **Rigorous form (classical identity):** the Fisher information a Bernoulli-type observation carries about its
+  own log-odds is exactly `μ(1−μ)` — near-deterministic observations are nearly uninformative about their logit.
+  The GLM variance function for the canonical logistic link, rederived from the filing problem.
+- vs Tobit: censoring reads "0.0" as one-sided info (latent ≤ boundary) — more efficient IF the censoring model
+  is true; Jacobian weighting reads it as ~zero info — robust to quantization junk, and implementable with plain
+  per-row heteroscedastic `R_j = (σ_μ/(μ_j(1−μ_j)))²` (`gaussian_condition_update` already takes per-call
+  observation covariance).
+- **Practical middle: de-quantize the boundary** — place a reported 0.0 at the half-step (0.025) with its
+  large-but-finite logit variance, so boundary labels keep a small weight (they still whisper "low") rather than
+  exactly zero. This also keeps the likelihood fully continuous (no discrete/continuous mixture density), which
+  makes fair cross-space NLL comparison via change-of-variables straightforward.
+
+**Next-rung (b), updated spec:** logit-space fusion with Jacobian-weighted per-row R + boundary de-quantization,
+vs the μ-space fusion above, scored in one space via the change-of-variables density. (Rung (a) unchanged:
+hop-conditioned V(hop) into the gain.)

--- a/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
+++ b/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
@@ -76,3 +76,23 @@ Inputs: the committed loaders (`sigma_hop_confirmatory.py`) over the run artifac
 (multihop_score_in.tsv / multihop_resp.txt / multihop_e5.pt; sigma_hop_fresh_pairs.tsv /
 sigma_hop_fresh_responses_gpt55low.txt / sigma_hop_behavior_slice_e5.pt), `model_prod.pt`, the 100k_cats TSV
 graph and the enwiki_cats_correct scoped LMDB (root Behavior).
+
+## Which mean does "PoE" take? (user question, 2026-07-08)
+
+Two different products are in play and they take DIFFERENT means — the harness's PoE is *not* the lower estimate:
+
+- **Product of DENSITIES (Gaussian PoE = `independent_kalman` here):** multiplying Gaussian densities over the
+  same latent yields the precision-weighted **arithmetic** mean `(Λ1μ1+Λ2μ2)/(Λ1+Λ2)` — a convex combination
+  that INTERPOLATES between experts, never below the min. Semantics: fusion of noisy estimates of one quantity.
+- **Product of VALUES (`mu_lower = Π μi^wi`):** multiplying memberships themselves. Unnormalized (w=1) = strict
+  AND ≤ min; normalized (Σw=1) = weighted **geometric** mean (≤ arithmetic by AM–GM, ≥ min — conservative
+  consensus, not a strict bound). Semantics: conjunction of independent requirements — this is the lower estimate.
+
+**Bridge — it is a choice of coordinates:** density-PoE fused in μ-space → arithmetic mean; in **log-μ** space →
+**geometric** mean; in logit space → geometric mean of odds (multiplying Bayes factors). The DESIGN's log-space
+product-Kalman (`K_ell = P/(P+R)`) IS the geometric-mean fusion with learned precision weights.
+
+In this run: the fusion rule was μ-space density-PoE (arithmetic); config B's lo/hi channels were value-products
+used as features. NOT yet tested: the fusion itself in log/logit coordinates (the geometric-flavor Kalman) —
+`product_space.py` has the links; the comparison needs the change-of-variables Jacobian so NLLs stay comparable
+across coordinate systems. Candidate next rung alongside hop-conditioned V(hop).

--- a/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
+++ b/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
@@ -198,3 +198,37 @@ the Tobit sketch above:
 **Next-rung (b), updated spec:** logit-space fusion with Jacobian-weighted per-row R + boundary de-quantization,
 vs the μ-space fusion above, scored in one space via the change-of-variables density. (Rung (a) unchanged:
 hop-conditioned V(hop) into the gain.)
+
+## Rung (a) BUILT: Sigma(hop) inside the Kalman gain — calibration target hit (2026-07-09)
+
+`run_product_kalman_sigma_hop.py`: the JOINT trivariate error covariance (prior-error D, prior-error S,
+measurement-error) fit as a smooth function of hop via a hop-dependent Cholesky factor (diag `exp(a+b·h)`,
+off-diag `c+d·h`, 12 params, SPD by construction, MLE on the calibration split), driving a per-row correlated
+update with `P(h), R(h), C(h)`. Same splits/protocol as above. (NLL here includes the 2π constant — compare
+within this table, not against the earlier one.)
+
+| corpus | rung | NLL ↓ | Mahal/dim | q95 (ref 5.99) |
+|---|---|---|---|---|
+| exploratory | prior/const | +0.566 | 1.59 | 7.35 |
+| exploratory | prior/hop | +0.297 | **1.00** | 5.07 |
+| exploratory | kalman/const | −0.323 | 1.18 | 6.11 |
+| exploratory | **kalman/hop** | **−0.450** | **1.02** | **5.12** |
+| fresh | prior/const | +0.407 | 1.42 | 8.21 |
+| fresh | prior/hop | +0.278 | 1.08 | 7.03 |
+| fresh | kalman/const | −0.008 | 1.40 | 8.55 |
+| fresh | **kalman/hop** | **−0.172** | **1.09** | 7.06 |
+
+- **The measured overconfidence is eaten, as designed:** kalman Mahal/dim 1.18→1.02 (exploratory) and
+  **1.40→1.09 (fresh — the 1.39→1 target)**. Hop-conditioning the blocks fixes the error bars where the
+  constant blocks were most miscalibrated.
+- **NLL improves too, and MORE on fresh** (+0.164) than exploratory (+0.127): the hop-conditioning matters most
+  exactly where constant covariance was most wrong — consistent with the fresh slice's stronger residual
+  heteroscedasticity.
+- **The two effects compose ~additively:** fusion (prior→kalman at fixed blocks) and hop-conditioning
+  (const→hop at fixed rung) stack to +1.02 (exploratory) / +0.58 (fresh) total NLL gain over the raw prior.
+- Residual q95 ≈ 7 on fresh (ref 5.99): the remaining tail is the boundary-atom / non-Gaussian residue — rung
+  (b)'s Jacobian weighting + de-quantization is the designed treatment.
+
+This closes the designed loop: confirmed `Sigma(hop)` (license) → measured calibration gap under constant
+blocks (motivation) → hop-conditioned blocks in the gain (build) → gap closed (verification). Exploratory
+protocol; same caveats as the rest of this report.

--- a/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
+++ b/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
@@ -1,0 +1,78 @@
+# Product-Kalman on real data: fusion is large, the correlation term is real, independent PoE is fragile
+
+*First real-data run of the Product-Kalman holdout harness (`run_product_kalman_realdata.py`, 2026-07-08) —
+build step 1 of `DESIGN_amortized_fusion_heads.md`. EXPLORATORY comparison, not preregistered. Two corpora:
+250 exploratory multihop pairs (100k_cats) and the 250 fresh Behavior-slice pairs from the confirmatory run;
+40 descendant-disjoint splits each; shrinkage 0.05; graph channel affine-calibrated to D on train only.*
+
+## Setup
+
+State/target = continuous LLM labels `(D, S)`. Prior = model readouts `(mu_D, mu_S)`. The harness scores, per
+split: `prior` (fitted P), `independent_kalman` (cross-covariance C=0), `product_kalman` (learned C).
+**Identification: Gaussian PoE ≡ the independent Kalman update** (product of Gaussian experts = precision
+summation = fusion with C=0), so independent-vs-product IS "raw PoE vs correlated Kalman".
+
+**How "beats" is measured (user question):** three axes — held-out **NLL** (proper score, mean+bars jointly);
+**MSE** (mean alone); **Mahalanobis/dim** (error bars alone: ≈1 calibrated, >1 overconfident; squared-Mahalanobis
+q95 vs the chi2_2 reference 5.99). Theory predicts the correlation term shows up mostly in the ERROR BARS
+(independent fusion double-counts correlated evidence → too-confident bars), not the means.
+
+## Results
+
+**Config [graph] — fuse prior with the calibrated walk channel (H=[1,0]):**
+
+| corpus | variant | NLL ↓ | MSE ↓ | Mahal/dim | q95 (ref 5.99) |
+|---|---|---|---|---|---|
+| exploratory | prior | +0.570 | 0.271 | 1.59 | 7.15 |
+| exploratory | independent (=PoE) | +0.012 | 0.116 | 1.51 | 7.00 |
+| exploratory | **product (correlated)** | **−0.306** | **0.099** | **1.18** | **5.70** |
+| fresh | prior | +0.408 | 0.188 | 1.42 | 7.93 |
+| fresh | independent (=PoE) | +0.038 | 0.111 | 1.49 | 8.05 |
+| fresh | **product (correlated)** | **−0.010** | **0.107** | 1.39 | 8.00 |
+
+**Config [graph+poe] — add PoE-lower/noisy-OR-upper channels (deliberately correlated with the prior):**
+
+| corpus | variant | NLL ↓ | Mahal/dim | q95 |
+|---|---|---|---|---|
+| exploratory | independent (=PoE) | +0.381 *(worse than without!)* | **1.95** | **10.11** |
+| exploratory | product (correlated) | −0.257 | 1.24 | 6.14 |
+| fresh | independent (=PoE) | +0.221 *(worse than without!)* | **1.79** | **10.36** |
+| fresh | product (correlated) | +0.070 | 1.49 | 8.34 |
+
+## Findings
+
+1. **Fusion is the big win, on both corpora:** prior→product NLL gain +0.88 (exploratory) / +0.42 (fresh),
+   positive on 40/40 splits each; MSE roughly halves. Any covariance-aware use of the graph channel beats the
+   model alone — the fast-timescale hybrid earns its keep immediately.
+2. **The correlation term (product vs independent = "Kalman vs PoE") is real but corpus-dependent:**
+   +0.32 NLL (40/40 splits) on exploratory vs +0.05 (35/40) on fresh. Direction replicates; magnitude tracks
+   how correlated the corpus's channels are. As predicted, the win is mostly in the ERROR BARS: at similar MSE,
+   Mahal/dim 1.18 vs 1.51 (exploratory).
+3. **Independent PoE is FRAGILE to adding correlated evidence — the double-counting failure mode, measured, on
+   BOTH corpora:** adding the PoE lower/upper channels under independence makes things *worse than not adding
+   them* (NLL +0.01→+0.38 exploratory, +0.04→+0.22 fresh) and inflates overconfidence (Mahal/dim 1.95/1.79,
+   q95 ≈ 10 vs the 5.99 reference — error bars ~sqrt(2) too small). The correlated update absorbs the same
+   channels harmlessly. **Correlated fusion is not just better, it is robust to channel-stacking; independent
+   fusion anti-scales with evidence.**
+4. **Residual mis-calibration on fresh points at Sigma(hop):** even the correlated update stays overconfident
+   on the fresh slice (Mahal/dim 1.39–1.49). This harness fits CONSTANT covariances — and we know (confirmed,
+   p=0.001) the residual covariance varies with hop. The designed synthesis (hop-conditioned `V(hop)` feeding
+   the Kalman gain) is exactly what should eat this residual; that is the natural next rung.
+
+## Caveats
+
+Exploratory, not preregistered; split-SE is stability-only (splits share one dataset); two corpora; single LLM
+judge; the PoE channels here are constructed features (membership-space products), not independent evidence;
+constant covariance blocks (no hop conditioning yet); the fresh slice was already used for the Sigma(hop)
+confirmatory test, so it is fresh relative to model development but not never-touched.
+
+## Repro
+
+```
+python3 run_product_kalman_realdata.py --dataset exploratory
+python3 run_product_kalman_realdata.py --dataset fresh
+```
+Inputs: the committed loaders (`sigma_hop_confirmatory.py`) over the run artifacts in `/tmp/mu_data/`
+(multihop_score_in.tsv / multihop_resp.txt / multihop_e5.pt; sigma_hop_fresh_pairs.tsv /
+sigma_hop_fresh_responses_gpt55low.txt / sigma_hop_behavior_slice_e5.pt), `model_prod.pt`, the 100k_cats TSV
+graph and the enwiki_cats_correct scoped LMDB (root Behavior).

--- a/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
+++ b/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
@@ -147,3 +147,28 @@ linear differential or difference equation.* Sharpened, and it explains why the 
   diagnostic above certifies that upgrade for mu-space (JB 2–34 ≈ near-exact-Bayes, Mahalanobis ≈ coverage);
   in log space the same algebra would run but `P` would degrade to second-moment bookkeeping with non-Gaussian
   tails (kurtosis +56).
+
+### CORRECTION: on the interior, logit IS the more natural Gaussian home (user, 2026-07-08)
+
+*User: logit space is defined on (−∞,∞), so it might be the more natural space for a Gaussian.* The a priori
+argument is right — μ∈[0,1] can never be exactly Gaussian (truncated support); logit-normal is the only
+self-consistent family of the three — and the interior-only test VINDICATES it. The earlier "mu wins" verdict
+was driven entirely by boundary ATOMS (LLM labels emit exactly-0/quantized-boundary values, ~7% of D labels;
+the logit link blows atoms into ±logit(eps) spikes, and that kurtosis is partly a clip-eps artifact).
+
+Interior only (labels in [0.05, 0.95]; JB lower = more Gaussian):
+
+| corpus | ch | n_int | JB mu | JB logit | winner |
+|---|---|---|---|---|---|
+| exploratory | D | 233 | 10.2 | 7.7 | logit |
+| exploratory | S | 249 | 35.6 | **0.1** | **logit — textbook Gaussian** (skew +0.01, kurt +0.07) |
+| fresh | D | 233 | 6.3 | 2.6 | logit |
+| fresh | S | 245 | 4.5 | 7.3 | mu (mild) |
+
+**Refined verdict (supersedes "geometric-flavor rung retired"):** the label distribution is a MIXTURE —
+~93% continuous interior (logit-Gaussian) + ~7% boundary atoms. So: naive logit fusion = worst (atoms);
+mu-space fusion = robust compromise (what this report ran); **logit-Gaussian + boundary censoring (Tobit-style
+Kalman: treat 0/1 labels as censored observations of a latent logit-normal) = the principled candidate.** This
+also revives the geometric flavor properly dressed: interior fusion in logit space is the multiplying-Bayes-
+factors update. Next-rung list is now: (a) hop-conditioned V(hop) into the gain; (b) Tobit-logit Kalman vs
+mu-space fusion, scored in one space via the change-of-variables density.

--- a/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
+++ b/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
@@ -124,3 +124,26 @@ itself non-Gaussian in ANY unbounded space (mu just keeps it finite); and explor
 (JB 2 vs 34) — the best space can be per-channel/per-corpus, consistent with the corpus-specificity theme. This
 retires the "geometric-flavor Kalman" rung for this data; the space question is settled empirically, not by
 convention.
+
+### Why Gaussianity matters to the FILTER specifically: autonomous covariance propagation (user, 2026-07-08)
+
+*User: Gaussian statistics are relevant to the Kalman filter because the covariance can then be propagated as a
+linear differential or difference equation.* Sharpened, and it explains why the architecture is possible:
+
+- **Closure:** linear + Gaussian ⇒ the posterior stays Gaussian, two moments suffice, and `P` evolves by its own
+  autonomous matrix equation (`P_{k+1} = A P A^T + Q`, `P+ = (I−KH)P`; continuous: the Riccati ODE).
+- **The key consequence: `P`'s evolution is DATA-INDEPENDENT** — measurements never appear in it; only structure
+  (`A, H, Q, R`) does. Error bars follow a deterministic, precomputable schedule (classically: steady-state
+  Riccati/gain); only the mean is data-driven.
+- **That is the license for the `Sigma(hop)` head:** covariance-as-a-function-of-structure is a precomputed
+  Riccati trajectory along the hop axis — predictable from graph position without seeing labels, BECAUSE
+  covariance propagates autonomously in the linear-Gaussian regime. The confirmed Sigma(hop) result is an
+  empirical instance. Conversely, where autonomy breaks (adaptive `R` from innovations, the metastable drift
+  layer, EKF-style state-dependent linearization) is exactly what stays with the ONLINE filter. **The
+  two-timescale split follows the mathematical fault line: precomputable covariance schedule → model head;
+  data-dependent statistics tracking → filter.**
+- **Precision:** the covariance difference equation needs only linearity + second moments (Kalman = LMMSE for
+  any noise). Gaussianity upgrades best-linear to EXACT BAYES, making `P` an honest credible region. The JB
+  diagnostic above certifies that upgrade for mu-space (JB 2–34 ≈ near-exact-Bayes, Mahalanobis ≈ coverage);
+  in log space the same algebra would run but `P` would degrade to second-moment bookkeeping with non-Gaussian
+  tails (kurtosis +56).

--- a/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
+++ b/prototypes/mu_cosine/REPORT_product_kalman_realdata.md
@@ -96,3 +96,31 @@ In this run: the fusion rule was μ-space density-PoE (arithmetic); config B's l
 used as features. NOT yet tested: the fusion itself in log/logit coordinates (the geometric-flavor Kalman) —
 `product_space.py` has the links; the comparison needs the change-of-variables Jacobian so NLLs stay comparable
 across coordinate systems. Candidate next rung alongside hop-conditioned V(hop).
+
+### Which space are the errors actually Gaussian in? (user refinement + measurement, 2026-07-08)
+
+*User: it's only a coordinate change if the error statistics are defined in a different coordinate system than
+the fuse space — and the Kalman filter runs in any of these spaces.* Both right: exact Bayes is
+reparameterization-invariant, the GAUSSIAN ASSUMPTION is not; a Gaussian in mu is not Gaussian in log-mu. So the
+fuse-space choice = where you assert the noise is Gaussian (mu = additive noise, log = multiplicative, logit =
+noise on odds) — a modeling decision, and empirically decidable: fuse where the residuals ARE most Gaussian.
+
+Measured (affine mean model per space; Jarque–Bera, lower = more Gaussian):
+
+| corpus | space | D skew/kurt/JB | S skew/kurt/JB |
+|---|---|---|---|
+| exploratory | **mu** | **−0.3 / −0.7 / 10** | +0.8 / +0.8 / 34 |
+| exploratory | log | −6.5 / +56 / 34448 | −0.6 / +0.7 / 21 |
+| exploratory | logit | −3.2 / +21 / 4905 | −0.1 / +0.4 / **2** |
+| fresh | **mu** | **+0.2 / −0.6 / 6** | **+0.1 / −0.4 / 2** |
+| fresh | log | −4.7 / +26 / 8208 | −2.2 / +8.2 / 915 |
+| fresh | logit | −3.1 / +15 / 2663 | −1.4 / +4.2 / 261 |
+
+**Verdict: the errors are approximately ADDITIVE — mu-space is the right fuse space for this data** (JB 2–34 vs
+10^2–10^4 elsewhere); the arithmetic fusion above was correctly placed, and a geometric-flavor (log-space) Kalman
+would spend its Gaussianity where it is most violated. Mechanism: fuzzy labels pile up AT the 0/1 boundaries and
+the log/logit links blow those into extreme tails (1/mu, 1/(mu(1−mu)) Jacobians). Nuances: boundary pile-up is
+itself non-Gaussian in ANY unbounded space (mu just keeps it finite); and exploratory-S is mildly better in logit
+(JB 2 vs 34) — the best space can be per-channel/per-corpus, consistent with the corpus-specificity theme. This
+retires the "geometric-flavor Kalman" rung for this data; the space question is settled empirically, not by
+convention.

--- a/prototypes/mu_cosine/THEORY_evidence_fusion.md
+++ b/prototypes/mu_cosine/THEORY_evidence_fusion.md
@@ -1,0 +1,210 @@
+# Evidence fusion for fuzzy membership: the theory, and how we arrived at it
+
+*Consolidated theory note, 2026-07-08. This document collects the theoretical framework developed across the
+two-judge posterior arc (PR #3517), the Sigma(hop) confirmatory arc, the Product-Kalman arc, and the fusion-heads
+design discussions (user + Claude, with Codex infrastructure) — including the corrections that shaped it, because
+the corrections carry as much information as the results. Detailed numbers live in the linked reports; this is
+the map.*
+
+Companion docs: `REPORT_two_judge_posterior.md`, `PAPER_sigma_hop_confirmatory.md`, `DESIGN_product_kalman_poe.md`,
+`DESIGN_amortized_fusion_heads.md`, `REPORT_product_kalman_realdata.md`.
+
+---
+
+## 1. The problem
+
+Estimate fuzzy relation memberships `mu(op(x,y))` between concept nodes (for a bookmark-filing assistant), given
+several **evidence channels** of very different character:
+
+- the **model** (mu-attention over frozen e5): amortized, cheap, always available;
+- the **graph** (walk hit-probability, hop distance): free but only for already-filed structure;
+- the **LLM judge**: rich but expensive, usually absent at inference.
+
+The recurring question in every arc: **how should correlated, partially-available, differently-priced evidence be
+combined — and how confident should the combination be?**
+
+## 2. The combiner ladder (a moment expansion)
+
+For a log-linear posterior, the gradient depends on features linearly (1st moment) and the Hessian is the feature
+covariance (2nd moment). This yields a ladder of combiners, each keeping one more moment:
+
+| rung | keeps | drops |
+|---|---|---|
+| linear superposition / blending | main effects | all covariance |
+| confidence-weighted | + variances (diagonal) | correlations |
+| joint / covariance-aware | + off-diagonal | — |
+
+**Path.** We started at the bottom (blended targets, `dir-blend`), found the naive blend trades direction for
+magnitude, and reframed: *condition, don't blend* — `P(op | d, LLM_op)` (the two-judge posterior). Two structural
+insights arrived from the user en route:
+- **Soft constraints:** the second-order structure acts like Lagrangian penalties; sampled correlations are SOFT
+  constraints (churn crosses them; that is the mechanism, not a failure), while structural facts (`mu_rev = 0`,
+  graph + LLM agreeing) are HARD (clamp, don't penalize).
+- **Pseudo-judges:** second-order constraints can be represented as synthetic judges (products of real readouts) —
+  k operators need k(k+1)/2 of them (the unique entries of a Gram matrix) — lifting the interaction `⊗` into a new
+  linear `⊕` coordinate.
+
+## 3. The statistical journey (and its three corrections)
+
+The empirical path to the covariance result was shaped by three user-driven corrections, each of which REVERSED a
+conclusion:
+
+1. **Binarization destroyed the signal.** Per-hop correlations on binarized labels looked random ("those numbers
+   look random"); bootstrap CIs confirmed nothing. Redone on CONTINUOUS fuzzy mu, Wikipedia showed a strong
+   heteroscedastic trend (`corr(mu_D, mu_S)`: −0.83 at h1 → +0.25 at h5). *Lesson: measure fuzzy sets on the
+   continuous membership, never thresholded.* (The same lesson later demoted the "joint beats product-of-marginals"
+   headline: it is a discrete co-occurrence effect that does not replicate on continuous mu.)
+2. **Confidence, not correlation.** Measuring only `rho(hop)` gave nothing significant. The user's redirection —
+   "for low hop counts you can be much more confident the relationship is directional... if the learning rate is
+   small enough, this difference gets washed out" — pointed at the DIAGONAL: `sigma(hop)` is the effective example
+   weight. Neither `sigma(hop)` nor `rho(hop)` alone clears noise; the FULL `Sigma(hop)` does. The mechanism is
+   geometric (user's prediction, verified): the covariance's condition number reduces with hop (11 → 5.3) and the
+   decoupling rotation swings −40° → +8°, so a constant Sigma is a bad average of incompatible geometries.
+3. **Calibrated inference.** Review (model council) found two real defects: pair-level splits leaked nodes, and
+   `mean/√n` over correlated resamples is not a significance level. Fixed with descendant-disjoint splits and a
+   hop-shuffle permutation test — the effect SURVIVED (p = 0.001), and then a **pre-registered confirmation on a
+   fresh, zero-overlap corpus passed at the permutation floor** (gain +0.060, p < 0.001). The correlation-geometry
+   trend even replicated qualitatively across the two independent corpora.
+
+**Landed theory:** the residual covariance of directional/symmetric memberships is a *smooth function of graph
+position*, `Sigma(hop)`; a 6-parameter head (log-linear sigmas, tanh rho) beats per-hop empirical bins because it
+POOLS — the expected shrinkage result (Ledoit–Wolf lineage), not a surprise.
+
+## 4. PoE vs covariance: a type distinction
+
+`DESIGN_product_kalman_poe.md` fixed a type error we kept circling: **PoE is a mean mechanism; the joint covariance
+is the error geometry around the mean.** A weighted sum `λ·L_PoE + (1−λ)·L_joint` conflates them; the clean form is
+one likelihood, `L = ½(y−mu)ᵀV⁻¹(y−mu) + ½log|V|`, where PoE-style aggregation may propose `mu` and `Sigma(hop)`
+supplies `V`. Corollaries:
+- `λ` is never set from a p-value; a bounded `λ∈[0,1]` is a convex shrinkage gate (PoE is then the CEILING); an
+  additive `λ>1` is a temperature needing calibration. If dependence should be as strong as data supports, don't
+  make `λ` the limiter — learn `Sigma` directly, regularized toward diagonal/PoE.
+- The **bound lattice** (user): `mu_lower = Π mu_i^w` (PoE, AND-like) ≤ `mu_mid = Σ w·mu` (mixture) ≤
+  `mu_upper = 1 − Π(1−mu_i)^w` (noisy-OR). `[lower, upper]` is a disagreement diagnostic → routing/abstention.
+
+## 5. The architecture: amortized fusion heads, two timescales
+
+**Question:** does the model SUBSUME the fusion intelligence, or is it a HYBRID with an explicit filter? Answer
+(user's three-way learn): **both, at different timescales.**
+
+- Heads `mu_graph`, `mu_LLM`, `mu_PoE`: the model amortizes each judge separately (channels stay exposed) plus the
+  fusion itself. The fused head is trained on measured-data fusions (anchor) and regularized toward the product of
+  its own readouts (stop-gradient — else the tautology/feedback trap); its VALUE is where it deviates from the
+  naive product: the learned correlated-PoE correction.
+- **Fast timescale:** model readout = prior; graph/judge = measurement channels fused by an explicit Kalman update
+  when present. **Slow timescale:** distill the fused posteriors back into the model.
+- **Function-name embeddings** (user): condition readouts on `W·e5("descriptive function name")` — one open-vocabulary
+  mechanism unifying operators, judges, and fusion functions.
+
+**Division of labor with the filter (user question, sharpened):** the Kalman filter does not learn — it is the
+closed-form algebra that USES what the model learned. Prior mean = mu heads; prior covariance P = Sigma(hop) head;
+measurement noise R = residual calibration; gain K = COMPUTED, never learned. The bet: *learn the uncertainty,
+derive the fusion weights for free* (vs learning gate weights directly). The filter's *recursion* lives in the
+filing DB: stored `(mu, P)` per relation, updated incrementally as evidence arrives — RLS (`P ~ 1/n`) when static,
+exponential forgetting under drift.
+
+## 6. The epistemic limit — why the hybrid is necessary, not convenient
+
+User: *"means and correlations are something the model could also learn — but perhaps not the means and
+correlations of the error."* Confirmed and sharpened into the deepest constraint:
+
+- The **error mean is unlearnable from inside**: any predictable component of a model's error gets absorbed into
+  its mean estimate and ceases to be error; the in-distribution error mean is ~0 by construction, and the
+  out-of-distribution bias is nonzero exactly where the model cannot know it (Kalman: bias states are unobservable
+  without measurements).
+- The **error covariance is learnable only from outside the training loop**: held-out residuals (training residuals
+  are optimistically small; joint mean+variance NLL has the variance-eats-the-loss pathology), and in-distribution
+  only (error statistics are the first casualty of shift — which is why the fresh-corpus confirmation mattered most
+  for the ERROR model).
+
+**Crisp form: signal statistics are statistics of the world; error statistics are statistics OF THE MODEL —
+estimating them requires standing outside it.** Adaptive Kalman filtering does exactly this (R/Q from the
+innovation sequence). Hence: distillation can absorb everything EXCEPT the role of standing outside; the
+innovation loop is the only mechanism that can see the model's bias. Subsume-vs-hybrid closes epistemically.
+
+**The online closure (user):** the error statistics themselves can be modeled as **metastable states with drift**
+— promote them into the state vector with random-walk dynamics (bias augmentation; stochastic volatility for
+log-sigma; rho likewise). Timescale hierarchy: L0 relation state (fast) / L1 error statistics (slow walk) /
+L2 drift rates (quasi-fixed). `Sigma(hop, corpus)` is the ATTRACTOR MAP: the model learns the metastable
+attractors from pooled history; the filter random-walks around the current one; distillation updates the map —
+*the model holds the climate, the filter tracks the weather.* Jumps (judge version changes = step in R_LLM;
+category reorganizations = step in corpus Sigma) exceed diffusion: heavy-tailed process noise, innovation
+chi-square with adaptive fading, or a switching state-space model — and a switching Kalman filter IS a mixture of
+experts over regimes (the user's MoE hunch, in its natural home).
+
+## 7. Why Gaussianity, specifically (user)
+
+Gaussianity matters to the FILTER because of **closure**: linear + Gaussian ⇒ the posterior stays Gaussian, two
+moments suffice, and the covariance evolves by its own autonomous matrix difference/Riccati equation — in which
+**the measurements never appear**. Error bars follow a deterministic, precomputable schedule; only the mean is
+data-driven. Two consequences:
+
+- **This is the license for the Sigma(hop) head**: covariance-as-a-function-of-structure is a precomputed Riccati
+  trajectory along the hop axis — predictable without labels because covariance propagates autonomously. The
+  confirmed result is an empirical instance.
+- **The two-timescale split follows the mathematical fault line**: the precomputable covariance schedule went to
+  the model; the data-dependent statistics tracking (adaptive R, metastable drift) stayed with the filter. The
+  engineering split and the theory split coincide.
+
+Precision: covariance propagation needs only linearity + second moments (Kalman = best LINEAR estimator for any
+noise); Gaussianity upgrades LMMSE to EXACT BAYES, making P an honest credible region rather than second-moment
+bookkeeping.
+
+## 8. Products, means, and measures (the coordinate arc)
+
+A three-step exchange resolved what "PoE" even averages:
+
+1. **Two different products** (user question): a product of DENSITIES (Gaussian PoE — what `independent_kalman`
+   computes) has a precision-weighted **arithmetic** mean; it interpolates (fusion-of-estimates semantics). A
+   product of VALUES (`mu_lower`) is AND-like ≤ min unnormalized, a **geometric** mean normalized (conjunction
+   semantics) — that one is the lower estimate.
+2. **Fuse-space = noise-model choice** (user correction): exact Bayes is reparameterization-invariant; the
+   GAUSSIAN ASSUMPTION is not. Fusing in mu-space assumes additive noise; in log space, multiplicative
+   (geometric mean); in logit space, noise on odds (multiplying Bayes factors). "The filter runs in any of these
+   spaces" (user) — the choice is where to spend the Gaussian approximation, and it is empirically decidable.
+3. **Measured, then corrected** (user's prior beat the aggregate statistic): on aggregate the residuals looked far
+   more Gaussian in mu-space — but that was driven ENTIRELY by boundary atoms (~7% of labels at/near exact 0/1,
+   which the logit link blows into spikes). On the INTERIOR, logit is the more natural Gaussian home (3 of 4
+   corpus×channel cells; one at Jarque–Bera 0.1 — textbook). Logit's a priori advantage — support on all of R,
+   the only self-consistent Gaussian family of the three — is real once the atoms are handled.
+4. **Boundary atoms via Jacobian weighting** (user): a reported 0.0 is an uncertain, quantized estimate, not
+   certainty. Give the label mu-space noise `sigma_mu` (≥ the quantization half-step) and propagate through the
+   link: logit-precision `∝ (mu(1−mu))²` — boundary points SELF-DOWNWEIGHT inside the plain Kalman update. The
+   rigorous form is a classical identity: the Fisher information a Bernoulli-type observation carries about its
+   own log-odds IS `mu(1−mu)` (the logistic GLM variance function). Simpler and more junk-robust than Tobit
+   censoring; with boundary DE-QUANTIZATION (0.0 → 0.025 at large-but-finite variance) the labels keep a whisper
+   of "low" and the likelihood stays continuous.
+
+## 9. Empirical state (what is measured vs designed)
+
+**Measured:**
+- `Sigma(hop)` — exploratory +0.094 (permutation p=0.001), **pre-registered confirmation on a fresh zero-overlap
+  corpus: +0.060, p < 0.001** (the one confirmatory result in the program).
+- Fusion (model prior + graph channel, covariance-aware): +0.4 to +0.9 held-out NLL over the model alone, 40/40
+  splits, both corpora; MSE halves.
+- The correlation term (correlated vs independent fusion = "Kalman vs Gaussian PoE"): real, corpus-dependent
+  (+0.32 vs +0.05), and it lives mostly in the ERROR BARS (Mahal/dim 1.18 vs 1.51 at similar MSE), as predicted.
+- **Independent PoE anti-scales with evidence**: adding correlated channels under an independence assumption is
+  worse than not adding them (both corpora; error bars ~√2 too small); the correlated update absorbs the same
+  channels harmlessly. Correlated fusion is not just better — it is what makes adding evidence SAFE.
+- Interior residuals are logit-Gaussian; boundary atoms are quantization artifacts.
+
+**Designed, not yet built:** the three heads + bound lattice + name embeddings; hop-conditioned V(hop) inside the
+Kalman gain (target: the measured Mahal/dim 1.39 residual overconfidence → 1); logit-space fusion with
+Jacobian-weighted per-row R + de-quantization (target: the interior-Gaussianity advantage → held-out NLL); the
+metastable/adaptive layer.
+
+## 10. Method lessons (portable beyond this project)
+
+1. Measure fuzzy quantities on the continuous membership; binarization can destroy or invert the signal.
+2. The confidence axis (diagonal) can carry the effect when the correlation axis (off-diagonal) alone does not —
+   check the FULL covariance before declaring a null.
+3. Repeated-split `mean/√n` is stability, not significance; permutation tests calibrate; node/entity-disjoint
+   splits are the floor for graph data; pre-register before touching fresh data.
+4. Post-exploratory p-values are conditional on the search path — say so, then confirm fresh.
+5. Smooth-parametric beating per-bin empirical is shrinkage, not magic — frame it as regularization value.
+6. When an aggregate diagnostic and a strong prior disagree, decompose the data (interior vs boundary) before
+   trusting either.
+7. Error statistics must be estimated from outside the model (held-out residuals, innovations, fresh corpora) —
+   and the parts of a system that CAN be precomputed (autonomous covariance) vs MUST be tracked online
+   (innovations, drift) tell you where to put the model/filter boundary.

--- a/prototypes/mu_cosine/run_product_kalman_realdata.py
+++ b/prototypes/mu_cosine/run_product_kalman_realdata.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""First REAL-DATA run of the Product-Kalman holdout harness (DESIGN_amortized_fusion_heads build step 1).
+
+Wires the already-scored corpora into `evaluate_product_kalman_holdout`, which scores the fusion ladder per
+descendant-disjoint split:
+  prior              — model readouts (mu_D, mu_S) with fitted prior-error covariance P
+  independent_kalman — Kalman update with the cross-covariance C zeroed (independent-experts fusion)
+  product_kalman     — the correlated fusion (learned C)
+
+State/target = continuous LLM labels (D, S). Prior = model readouts. Measurement channels:
+  config "graph"     — the walk hit-prob, affine-calibrated to D on the calibration split, H=[1,0]
+  config "graph+poe" — graph channel + PoE lower / noisy-OR upper channels (product_space) built from
+                       (mu_D, graph) — deliberately correlated with the prior; the learned C must handle it
+                       (DESIGN_product_kalman_poe variant 6-lite vs variant 1/3).
+
+EXPLORATORY comparison (not preregistered): mean NLL over splits + split-level stability. Datasets:
+  exploratory — 250 multihop pairs, 100k_cats TSV graph
+  fresh       — 250 Behavior-slice pairs, enwiki_cats_correct scoped LMDB (same retained slice as the
+                confirmatory run; features rebuilt with the confirmatory runner's own loaders)
+
+  python3 run_product_kalman_realdata.py --dataset exploratory
+  python3 run_product_kalman_realdata.py --dataset fresh
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from product_kalman_evaluation import evaluate_product_kalman_holdout
+from product_space import product_lower, product_upper
+from sigma_hop_confirmatory import (
+    FeatureGraphConfig,
+    build_confirmatory_data_from_labels,
+    descendant_disjoint_split,
+    load_scored_pairs,
+)
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(ROOT, "..", ".."))
+
+DATASETS = {
+    "exploratory": dict(
+        score_in="/tmp/mu_data/multihop_score_in.tsv",
+        responses="/tmp/mu_data/multihop_resp.txt",
+        e5_cache="/tmp/mu_data/multihop_e5.pt",
+        graph=dict(graph=os.path.join(REPO, "data", "benchmark", "100k_cats", "category_parent.tsv")),
+    ),
+    "fresh": dict(
+        score_in="/tmp/mu_data/sigma_hop_fresh_pairs.tsv",
+        responses="/tmp/mu_data/sigma_hop_fresh_responses_gpt55low.txt",
+        e5_cache="/tmp/mu_data/sigma_hop_behavior_slice_e5.pt",
+        graph=dict(
+            graph=None,
+            candidate_lmdb=os.path.join(REPO, "data", "benchmark", "enwiki_cats_correct", "lmdb_scoped"),
+            lmdb_root="Behavior",
+            exploratory_graph=os.path.join(REPO, "data", "benchmark", "100k_cats", "category_parent.tsv"),
+        ),
+    ),
+}
+
+
+def affine_calibrate(d_cal, target_cal, d_all):
+    """1-dim affine map d -> E[D] fit on the calibration split only (removes the walk's scale/floor bias so the
+    harness's zero-mean measurement-error model applies; without it the bias skews every update)."""
+    A = np.column_stack([d_cal, np.ones(len(d_cal))])
+    beta, *_ = np.linalg.lstsq(A, target_cal, rcond=None)
+    return np.clip(beta[0] * d_all + beta[1], 0.0, 1.0)
+
+
+def poe_channels(muD, m):
+    """PoE lower / noisy-OR upper channels over the two D-estimates (model readout, calibrated graph).
+    Uses codex's product_space definitions row-wise."""
+    lo = np.array([product_lower([a, b]) for a, b in zip(muD, m)])
+    hi = np.array([product_upper([a, b]) for a, b in zip(muD, m)])
+    return lo, hi
+
+
+def run_dataset(name, seeds, shrinkage, held_frac=0.30, min_train=30, min_held=12):
+    cfg = DATASETS[name]
+    # load_scored_pairs + from_labels (not build_confirmatory_data): this is an EXPLORATORY comparison, the
+    # preregistered no-overlap gate does not apply (the "exploratory" dataset IS the exploratory graph).
+    pairs, hop, D, S = load_scored_pairs(cfg["score_in"], cfg["responses"], prefix="transitive_h")
+    data = build_confirmatory_data_from_labels(
+        pairs, hop, D, S, cfg["e5_cache"],
+        FeatureGraphConfig(**cfg["graph"]), os.path.join(ROOT, "model_prod.pt"), "cpu",
+    )
+    prior = data.X[:, :2]                                   # (mu_D, mu_S) model readouts
+    target = np.column_stack([data.D, data.S])              # continuous LLM labels
+    d = data.X[:, 2]                                        # walk hit-prob
+    print(f"\n=== {name}: n={len(data.pairs)} pairs, hops {sorted(set(data.hop.tolist()))} ===")
+
+    configs = {
+        "graph": dict(H=np.array([[1.0, 0.0]])),
+        "graph+poe": dict(H=np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]])),
+    }
+    results = {c: {} for c in configs}
+    used = 0
+    for seed in range(seeds):
+        tr, he = descendant_disjoint_split(data.pairs, seed, held_frac=held_frac)
+        if len(tr) < min_train or len(he) < min_held:
+            continue
+        used += 1
+        m = affine_calibrate(d[tr], data.D[tr], d)          # calibrated graph channel (fit on train only)
+        lo, hi = poe_channels(prior[:, 0], m)
+        meas = {"graph": m[:, None], "graph+poe": np.column_stack([m, lo, hi])}
+        for cname, ccfg in configs.items():
+            ev = evaluate_product_kalman_holdout(
+                prior[tr], meas[cname][tr], target[tr],
+                prior[he], meas[cname][he], target[he],
+                H=ccfg["H"], shrinkage=shrinkage,
+            )
+            for s in ev.scores:
+                results[cname].setdefault(s.name, []).append(
+                    (s.mean_nll, s.mse, s.mahalanobis_per_dim, s.squared_mahalanobis_q95))
+    print(f"splits used: {used}/{seeds} (descendant-disjoint, held_frac={held_frac}, shrinkage={shrinkage})")
+
+    summary = {}
+    for cname, per_variant in results.items():
+        print(f"\n  config [{cname}] — over {used} splits (NLL lower better; Mahal/dim ≈ 1 = calibrated error bars,")
+        print(f"  >1 overconfident; msM q95 vs chi2_2 ref 5.99):")
+        print(f"    {'variant':22s} {'NLL':>8s} {'MSE':>8s} {'Mahal/dim':>10s} {'msM q95':>8s}")
+        for vname, vals in per_variant.items():
+            nll = np.array([v[0] for v in vals]); mse = np.array([v[1] for v in vals])
+            mpd = np.array([v[2] for v in vals]); q95 = np.array([v[3] for v in vals])
+            print(f"    {vname:22s} {nll.mean():+8.4f} {mse.mean():8.4f} {mpd.mean():10.2f} {q95.mean():8.2f}")
+            summary[(cname, vname)] = nll
+        pr = summary[(cname, "prior")]
+        for cand in ("independent_kalman", "product_kalman"):
+            g = pr - summary[(cname, cand)]
+            print(f"    NLL gain prior→{cand}: {g.mean():+.4f} (split-SE {g.std()/np.sqrt(len(g)):.4f} — stability "
+                  f"only)  positive splits {int((g > 0).sum())}/{len(g)}")
+        gi = summary[(cname, "independent_kalman")] - summary[(cname, "product_kalman")]
+        print(f"    NLL gain independent(=Gaussian PoE)→product(correlated): {gi.mean():+.4f} "
+              f"(split-SE {gi.std()/np.sqrt(len(gi)):.4f})  positive splits {int((gi > 0).sum())}/{len(gi)}")
+    return summary
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", choices=[*DATASETS, "all"], default="all")
+    ap.add_argument("--seeds", type=int, default=40)
+    ap.add_argument("--shrinkage", type=float, default=0.05)
+    a = ap.parse_args()
+    names = list(DATASETS) if a.dataset == "all" else [a.dataset]
+    for n in names:                                          # sequential — consumer hardware
+        run_dataset(n, a.seeds, a.shrinkage)
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/run_product_kalman_sigma_hop.py
+++ b/prototypes/mu_cosine/run_product_kalman_sigma_hop.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Rung (a): hop-conditioned covariance blocks INSIDE the Kalman gain (the designed Sigma(hop) x fusion synthesis).
+
+Yesterday's real-data run (`run_product_kalman_realdata.py`) fit CONSTANT covariance blocks and left a measured
+residual overconfidence (Mahal/dim 1.39 on fresh). The confirmed Sigma(hop) result says the error covariance is
+predictable from hop — so here the JOINT trivariate error covariance (prior-error D, prior-error S,
+measurement-error) is fit as a SMOOTH function of hop and its blocks P(h), R(h), C(h) drive a per-row correlated
+update. Parametrization: hop-dependent Cholesky factor L(h) (diag exp(a+b·h), off-diag c+d·h; 12 params) so
+Sigma(h) = L(h)L(h)^T is SPD by construction; MLE via Nelder-Mead on the calibration split.
+
+Ladder (per descendant-disjoint split):
+  prior/const     — model readouts, constant P            (yesterday's baseline)
+  prior/hop       — model readouts, P(h)                  (the confirmatory result restated in this harness)
+  kalman/const    — correlated update, constant P,R,C     (yesterday's winner)
+  kalman/hop      — correlated update, P(h),R(h),C(h)     (the new rung)
+
+Target: kalman/hop drops Mahal/dim toward 1 (esp. fresh) and beats kalman/const on held-out NLL.
+NLL includes the 2*pi constant — compare within this run, not against yesterday's table.
+
+  python3 run_product_kalman_sigma_hop.py --dataset exploratory
+  python3 run_product_kalman_sigma_hop.py --dataset fresh
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+from scipy.optimize import minimize
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from run_product_kalman_realdata import DATASETS, affine_calibrate
+from sigma_hop_confirmatory import (
+    FeatureGraphConfig,
+    build_confirmatory_data_from_labels,
+    descendant_disjoint_split,
+    load_scored_pairs,
+)
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+H = np.array([[1.0, 0.0]])                                  # graph channel observes the D component
+LOG2PI = np.log(2 * np.pi)
+
+
+def chol_of_hop(params, h):
+    """Hop-dependent lower-triangular factor: diag exp(a+b·h), off-diag c+d·h. Sigma(h)=L L^T is SPD always."""
+    a = params[:3]; b = params[3:6]; c = params[6:9]; d = params[9:12]
+    L = np.zeros((3, 3))
+    L[0, 0], L[1, 1], L[2, 2] = np.exp(a + b * h)
+    L[1, 0] = c[0] + d[0] * h; L[2, 0] = c[1] + d[1] * h; L[2, 1] = c[2] + d[2] * h
+    return L
+
+
+def fit_joint_sigma_of_hop(E, hop):
+    """MLE of the smooth trivariate Sigma(h) on calibration joint errors E (n x 3)."""
+    C0 = np.cov(E.T) + 1e-6 * np.eye(3)
+    L0 = np.linalg.cholesky(C0)
+    p0 = np.concatenate([np.log(np.diag(L0)), np.zeros(3), [L0[1, 0], L0[2, 0], L0[2, 1]], np.zeros(3)])
+    hs = sorted(set(hop.tolist()))
+
+    def nll(p):
+        tot = 0.0
+        for h in hs:
+            m = hop == h
+            L = chol_of_hop(p, h)
+            z = np.linalg.solve(L, E[m].T)                   # whiten
+            tot += 0.5 * np.sum(z * z) + m.sum() * (np.log(np.abs(np.diag(L))).sum() + 1.5 * LOG2PI)
+        return tot / len(E)
+
+    r = minimize(nll, p0, method="Nelder-Mead", options={"maxiter": 20000, "xatol": 1e-5, "fatol": 1e-7})
+    return r.x
+
+
+def biv_nll_mahal(r, V):
+    """Per-row bivariate Gaussian NLL and squared Mahalanobis."""
+    Vi = np.linalg.inv(V)
+    m2 = float(r @ Vi @ r)
+    return 0.5 * m2 + 0.5 * np.log(np.linalg.det(V)) + LOG2PI, m2
+
+
+def correlated_update(x, P, y, R, C):
+    """Kalman update with correlated prior/measurement errors: y = H z + v, C = Cov(prior_err, v)."""
+    S = H @ P @ H.T + R + H @ C + (H @ C).T
+    K = (P @ H.T + C) @ np.linalg.inv(S)
+    x_post = x + (K @ (y - H @ x)).ravel()
+    P_post = P - K @ S @ K.T
+    return x_post, P_post
+
+
+def run_dataset(name, seeds, held_frac=0.30, min_train=30, min_held=12):
+    cfg = DATASETS[name]
+    pairs, hop, D, S = load_scored_pairs(cfg["score_in"], cfg["responses"], prefix="transitive_h")
+    data = build_confirmatory_data_from_labels(
+        pairs, hop, D, S, cfg["e5_cache"], FeatureGraphConfig(**cfg["graph"]),
+        os.path.join(ROOT, "model_prod.pt"), "cpu",
+    )
+    prior = data.X[:, :2]; target = np.column_stack([data.D, data.S]); d = data.X[:, 2]
+    print(f"\n=== {name}: n={len(data.pairs)} pairs ===")
+
+    rungs = ["prior/const", "prior/hop", "kalman/const", "kalman/hop"]
+    acc = {r: {"nll": [], "m2": []} for r in rungs}
+    used = 0
+    for seed in range(seeds):
+        tr, he = descendant_disjoint_split(data.pairs, seed, held_frac=held_frac)
+        if len(tr) < min_train or len(he) < min_held:
+            continue
+        used += 1
+        m = affine_calibrate(d[tr], data.D[tr], d)
+        eP = target - prior                                  # prior error (z - x_hat), rows
+        eM = m - target[:, 0]                                # measurement error (v = y - H z)
+        E_tr = np.column_stack([eP[:, 0], eP[:, 1], eM])[tr]
+        Cc = np.cov(E_tr.T) + 1e-9 * np.eye(3)               # constant joint covariance
+        pj = fit_joint_sigma_of_hop(E_tr, data.hop[tr])      # smooth Sigma(h)
+
+        for i in he:
+            h = float(data.hop[i]); x = prior[i]; y = np.array([m[i]]); t = target[i]
+            Lh = chol_of_hop(pj, h); Ch = Lh @ Lh.T
+            blocks = {"const": (Cc[:2, :2], Cc[2:, 2:], Cc[:2, 2:]),
+                      "hop": (Ch[:2, :2], Ch[2:, 2:], Ch[:2, 2:])}
+            for kind, (P, R, C) in blocks.items():
+                nll, m2 = biv_nll_mahal(t - x, P)
+                acc[f"prior/{kind}"]["nll"].append(nll); acc[f"prior/{kind}"]["m2"].append(m2)
+                xp, Pp = correlated_update(x, P, y, R, C)
+                nll, m2 = biv_nll_mahal(t - xp, Pp)
+                acc[f"kalman/{kind}"]["nll"].append(nll); acc[f"kalman/{kind}"]["m2"].append(m2)
+
+    print(f"splits used: {used}/{seeds}; per-row pooled over splits (NLL lower better; Mahal/dim ≈ 1 calibrated,")
+    print(f">1 overconfident; q95 vs chi2_2 ref 5.99):")
+    print(f"    {'rung':14s} {'NLL':>8s} {'Mahal/dim':>10s} {'q95':>7s}")
+    out = {}
+    for r in rungs:
+        nll = np.array(acc[r]["nll"]); m2 = np.array(acc[r]["m2"])
+        out[r] = nll
+        print(f"    {r:14s} {nll.mean():+8.4f} {m2.mean()/2:10.2f} {np.quantile(m2, 0.95):7.2f}")
+    for base, cand in [("prior/const", "prior/hop"), ("kalman/const", "kalman/hop"), ("prior/hop", "kalman/hop")]:
+        g = out[base] - out[cand]
+        print(f"    gain {base}→{cand}: {g.mean():+.4f} (row-SE {g.std()/np.sqrt(len(g)):.4f} — stability only)")
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", choices=[*DATASETS, "all"], default="all")
+    ap.add_argument("--seeds", type=int, default=40)
+    a = ap.parse_args()
+    for n in (list(DATASETS) if a.dataset == "all" else [a.dataset]):
+        run_dataset(n, a.seeds)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Executes build step 1 of `DESIGN_amortized_fusion_heads.md` — the first REAL-DATA runs of the Product-Kalman
harness (the missing empirical answer for the merged infra arc) — then builds rung (a), wiring the confirmed
`Sigma(hop)` result into the Kalman gain. Also adds the consolidated theory document. Exploratory protocol
(not preregistered); caveats in the report.

## Empirical results (`run_product_kalman_realdata.py`, `run_product_kalman_sigma_hop.py`, REPORT)
Two corpora (250 exploratory multihop + 250 fresh Behavior pairs), 40 descendant-disjoint splits each.
Identification: Gaussian PoE ≡ independent Kalman (C=0), so independent-vs-product IS "PoE vs correlated Kalman".

1. **Fusion is the big win:** model prior + graph channel beats the model alone by +0.4–0.9 held-out NLL
   (40/40 splits, both corpora); MSE halves.
2. **The correlation term is real and lives in the ERROR BARS:** correlated beats independent fusion
   (+0.32 / +0.05 NLL), with the gain showing as calibration (Mahal/dim 1.18 vs 1.51) at similar MSE.
3. **Independent PoE anti-scales with evidence:** adding correlated PoE-lower/upper channels under an
   independence assumption is WORSE than not adding them (both corpora; error bars ~√2 too small, q95 ≈ 10 vs
   χ²₂ ref 5.99); the correlated update absorbs the same channels harmlessly.
4. **Rung (a) — `Sigma(hop)` inside the gain (hop-dependent Cholesky blocks, 12 params, SPD by construction):
   the measured overconfidence is eaten** — Mahal/dim 1.18→1.02 (exploratory), **1.40→1.09 (fresh — the
   motivating 1.39→1 target)**; NLL improves more on fresh (+0.16) than exploratory (+0.13); fusion and
   hop-conditioning compose ~additively. Closes the designed loop: confirmed Sigma(hop) (license) → measured
   gap (motivation) → build → gap closed (verification).

## Theory (discussion-driven addenda + consolidation)
- `THEORY_evidence_fusion.md` — the consolidated framework and the path to it (combiner ladder, PoE-mean vs
  covariance-geometry type distinction, two-timescale architecture, epistemic limit of self-estimated error,
  metastable random-walk closure, autonomous covariance propagation as the license for Sigma(hop), the
  coordinate/measure arc, method lessons).
- Report addenda: which mean PoE takes (densities interpolate/arithmetic vs values lower/geometric);
  fuse-space = noise-model choice (measured: interior residuals are logit-Gaussian — JB 0.1 in the best cell —
  and the earlier mu-space verdict was a boundary-atom artifact); boundary atoms via Jacobian weighting
  (Fisher information mu(1−mu) does the censoring; de-quantization keeps a whisper of "low").

## Scope
New standalone scripts + reports/docs; no shared library or pipeline code modified.

## Next (specced, separate PR)
Rung (b): logit-space fusion with Jacobian-weighted per-row R + boundary de-quantization, scored fairly via
change-of-variables — targets the remaining fresh-tail residue (q95 ≈ 7 vs 5.99).

🤖 Generated with [Claude Code](https://claude.com/claude-code)