### PR TITLE
WAM/LLVM (roadmap #5, milestone 6): difference-list serializer + finding #9 — the compile budget is closed

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -412,8 +412,11 @@ loadable along the way.
   `=../2` compose mode broken three ways (no deref of Ref-linked list
   spines, id-based atom payload used as a functor pointer, result bound to
   the register instead of through the Ref); and quadratic accumulator-append
-  allocation exhausting the 16 MiB arena (bumped to 256 MiB virtual; chained
-  arena deferred). See
+  allocation exhausting the 16 MiB arena — fixed for real with the **chained
+  arena** (blocks link on exhaustion and never move; marks are virtual
+  offsets so mark/rewind work across growth; initial block back to 16 MiB
+  with no practical ceiling), covered by a dedicated native driver suite and
+  exercised in production by the fixpoint compile itself. See
   [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md).
 
 ## The binary-return question, specifically

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -401,8 +401,14 @@ loadable along the way.
   + length, matched against the Stage A implementation). The compiler has
   compiled its own back end. The remaining campaign extends this toward
   `compile(SelfSource)` — the full fixpoint.
-  The campaign keeps surfacing and fixing latent runtime bugs — **eight found so
-  far**: a 64-register-file ceiling corrupting memory for large clauses;
+  The compile budget for the full self-compile is closed: the **chained
+  arena** removed the memory cliff (blocks link on exhaustion and never
+  move; marks are virtual offsets so mark/rewind work across growth), and
+  the serializer's **difference-list linearisation** removed the quadratic
+  time/allocation (an 11.9 KB source compiles loaded in 40 ms / 35 MB where
+  the quadratic style took 20 s / 3.7 GB at half that size).
+  The campaign keeps surfacing and fixing latent runtime bugs — **nine found
+  so far**: a 64-register-file ceiling corrupting memory for large clauses;
   `get_structure` not comparing the functor; the choice-point saved-register
   block not widened with the register file (failed clause bodies leaked Y17+
   across backtrack); and `copy_term/2` aliasing instead of copying (Refs
@@ -412,11 +418,12 @@ loadable along the way.
   `=../2` compose mode broken three ways (no deref of Ref-linked list
   spines, id-based atom payload used as a functor pointer, result bound to
   the register instead of through the Ref); and quadratic accumulator-append
-  allocation exhausting the 16 MiB arena — fixed for real with the **chained
-  arena** (blocks link on exhaustion and never move; marks are virtual
-  offsets so mark/rewind work across growth; initial block back to 16 MiB
-  with no practical ceiling), covered by a dedicated native driver suite and
-  exercised in production by the fixpoint compile itself. See
+  allocation exhausting the 16 MiB arena (the chained arena above); and a
+  variable-identity collapse in two paths — `get_value` var-var left the
+  two variables unlinked (a silent no-op unification), and `builtin_append`
+  seeded its result tail with the collapsed Unbound sentinel when the second
+  argument was a bare unbound variable — both fixed via
+  `@wam_deref_keep_var`. See
   [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md).
 
 ## The binary-return question, specifically

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -513,21 +513,42 @@ build path (the tail variable is staged directly as the final `set_*` slot).
 accumulator-style grammars (`append` onto a growing list per emitted byte)
 allocate **quadratically** in their output size, and the fixpoint compile
 segfaulted at exactly the 16 MiB boundary (a `%Value` store to the null
-`wam_arena_alloc` result, pinned by gdb). Bumped to 256 MiB (virtual; Linux
-commits lazily, so resident memory only grows with use). The honest fix — a
-chained arena that links a new block instead of returning null (blocks must
-not move; `%Value`s hold raw pointers) — is noted as deferred work, as is
-linearising the accumulator style (difference lists) in the bootstrap
-compiler itself.
+`wam_arena_alloc` result, pinned by gdb). First mitigated by bumping to
+256 MiB virtual; then fixed for real with the **chained arena** (below).
+
+**Chained arena LANDED** (the honest fix for finding no. 8). The bump arena
+now links a new block on exhaustion instead of returning null: each block
+carries a 32-byte header (previous-block pointer, data capacity, virtual
+base offset), the allocation slow path mallocs `max(cap × 2, requested)`
+and chains it, and blocks **never move** — `%Value`s hold raw pointers into
+them, so live terms stay valid across growth. Marks became virtual offsets
+(`base + pos`), globally monotonic across links, so the graph kernels'
+mark/rewind pairs keep working even when the arena grew in between: rewind
+pops (frees) every block newer than the mark and restores the bump position
+in the survivor. `@wam_arena_reset` (per-query cleanup) rewinds to virtual
+offset 0, handing growth blocks back to malloc while keeping the initial
+block mapped. The initial block dropped back to 16 MiB — the default query
+never chains; the self-hosted compiler's quadratic appends now hit growth,
+not a segfault, with no practical ceiling. Covered by a dedicated native
+driver suite (`test_wam_llvm_arena_chain_runtime.pl`): a 64-byte first
+block forced through two links with mark checks at every step, cross-block
+rewinds, block-stability sentinels, first-block reuse after reset, destroy
++ ensure re-init; plus a ~100 MB growth-stress loop through a 1 KiB initial
+block. The fixpoint compile itself (needs > 16 MiB) now exercises chaining
+in production on every suite run. Linearising the accumulator style
+(difference lists) in the bootstrap compiler remains the compile-*time*
+fix — memory is no longer the cliff, but the quadratic work still costs
+seconds as sources grow.
 
 **Remaining toward the full fixpoint:** the serializer was the back end; the
 front/middle (the reader call, `group_clauses`, the codegen walkers) use the
 same constructs plus `keysort`/`pairs_values` (already whitelisted) — but
 compiling the *whole* cgfull source also needs bare cut restated as ITE
-throughout, the `s(At,Fn)` state pair (structures — supported), and above
-all a workable compile-time budget for the quadratic-append behavior. The
-capstone (`compile(SelfSource)` yielding a working compiler object) remains
-open, now with a demonstrated path.
+throughout, the `s(At,Fn)` state pair (structures — supported), and a
+workable compile-time budget for the quadratic-append behavior (the memory
+side is solved by the chained arena; the time side wants difference lists).
+The capstone (`compile(SelfSource)` yielding a working compiler object)
+remains open, now with a demonstrated path.
 
 **Deliverable:** the demonstrable self-host — the compiler compiles itself,
 and `compile(SelfSource)` yields a working compiler object.

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -534,21 +534,64 @@ driver suite (`test_wam_llvm_arena_chain_runtime.pl`): a 64-byte first
 block forced through two links with mark checks at every step, cross-block
 rewinds, block-stability sentinels, first-block reuse after reset, destroy
 + ensure re-init; plus a ~100 MB growth-stress loop through a 1 KiB initial
-block. The fixpoint compile itself (needs > 16 MiB) now exercises chaining
-in production on every suite run. Linearising the accumulator style
-(difference lists) in the bootstrap compiler remains the compile-*time*
-fix — memory is no longer the cliff, but the quadratic work still costs
-seconds as sources grow.
+block. The fixpoint compile itself (needs > 16 MiB before linearisation)
+exercised chaining in production on every suite run.
+
+**Difference-list serializer LANDED** (the compile-*time* fix). The `wz_*`
+emitters flipped from forward accumulators (`append(A0, Cs, B)` — copy the
+ENTIRE output so far, per emitted token) to difference lists: `A0` is the
+open list being built, `A1` its tail after the item, and each emission
+appends only its own codes (`append(Cs, [10|A1], A0)`). The threading
+predicates (`wz_header`/`wz_body`/`wz_funcs`/…) are direction-agnostic and
+did not change; only the leaf emitters and the top wrappers (which now
+close the tail with `[]`) know the representation. The fixpoint source
+restated its serializer the same way — the doubly-compiled serializer is
+linear too, and compiling it exercises open-tail call operands
+(`[10|A1]`, `[32|Mid]`) and `append/3` with partial/unbound tails in the
+loaded subset. Measured on the eval host (loaded `cgfull` compiling scaled
+copies of the fixpoint source):
+
+| source | quadratic (before) | difference lists (after) |
+|---|---|---|
+| 1.4 KB | 0.17 s / 246 MB | 0.01 s / 10 MB |
+| 2.9 KB | 4.5 s / 944 MB | 0.01 s / 10 MB |
+| 5.9 KB | 20.2 s / 3.7 GB | 0.02 s / 17 MB |
+| 11.9 KB | (est. ~15 GB — untested) | 0.04 s / 35 MB |
+
+The compile-time budget for the full self-compile is closed: an 11.9 KB
+source — larger than cgfull's own restated source will be — compiles
+loaded in 40 ms.
+
+*Runtime finding (campaign no. 9):* the difference-list style immediately
+exposed a variable-identity bug in **two** runtime paths, both the same
+shape: using the FULL deref on a value that can be an unbound variable
+collapses Ref-to-unbound-cell into the shared Unbound sentinel `{tag 6,
+payload 0}` — no cell address — so "binding" one side to it silently
+severs the link (the same collapse `wam_strict_eq` had already documented
+for `==`). (a) `get_value` var-var: a head like `wz_funcs([], A, A)`
+called with two unbound arguments left them UNLINKED — the unification
+was a no-op that still succeeded, and every later binding through one
+side was invisible through the other; the serialized output truncated at
+exactly that knot. (b) `builtin_append`'s result-tail seed:
+`append(Cs, T, L)` with `T` an unbound BARE variable seeded the built
+list's tail with the collapsed sentinel instead of `Ref{cell of T}`.
+Fixed via `@wam_deref_keep_var` (variables keep their cell identity):
+`get_value` now classifies each side as variable-with-cell / naked
+register variable / bound, links var-var pairs toward an existing heap
+cell (same-cell guard against the M139 self-reference hazard; a fresh
+shared cell if both sides are naked register variables), and binds
+var-bound through `wam_bind_reg`; the append seed uses the keep-var
+deref. Regression test `get_value_var_var_and_append_var_seed` drives
+both paths through a loaded object.
 
 **Remaining toward the full fixpoint:** the serializer was the back end; the
 front/middle (the reader call, `group_clauses`, the codegen walkers) use the
 same constructs plus `keysort`/`pairs_values` (already whitelisted) — but
 compiling the *whole* cgfull source also needs bare cut restated as ITE
-throughout, the `s(At,Fn)` state pair (structures — supported), and a
-workable compile-time budget for the quadratic-append behavior (the memory
-side is solved by the chained arena; the time side wants difference lists).
-The capstone (`compile(SelfSource)` yielding a working compiler object)
-remains open, now with a demonstrated path.
+throughout and the `s(At,Fn)` state pair (structures — supported). The
+compile budget — both memory (chained arena) and time (difference lists) —
+is solved. The capstone (`compile(SelfSource)` yielding a working compiler
+object) remains open, now with a demonstrated path.
 
 **Deliverable:** the demonstrable self-host — the compiler compiles itself,
 and `compile(SelfSource)` yields a working compiler object.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -2905,30 +2905,84 @@ wam_llvm_case('get_variable',
   ret i1 true').
 
 wam_llvm_case('get_value',
-'  ; op1 = Xn index, op2 = Ai index — unify. Deref both sides for the
-  ; is_unbound check; bind via wam_bind_reg to propagate through Refs.
+'  ; op1 = Xn index, op2 = Ai index -- full unification of two head
+  ; positions. Campaign finding no. 9: variables must be handled via
+  ; @wam_deref_keep_var, NOT the full deref. The full deref collapses a
+  ; Ref-to-unbound-cell into the shared Unbound sentinel (tag 6, no cell
+  ; address), so the old bind paths stored a detached Unbound instead of
+  ; linking the two variables -- a var-var get_value was a silent no-op
+  ; and every later binding through one side was invisible through the
+  ; other (the difference-list serializer of the self-host fixpoint lost
+  ; its open tail at exactly such a knot: wz_funcs([], A, A)).
+  ; keep_var stops at the last Ref whose cell is unbound, so tag 5 here
+  ; means variable-with-cell and tag 6 means naked register variable.
   %gval.ai = trunc i64 %op2 to i32
   %gval.xn = trunc i64 %op1 to i32
-  %gval.va = call %Value @wam_get_reg_deref(%WamState* %vm, i32 %gval.ai)
-  %gval.vx = call %Value @wam_get_reg_deref(%WamState* %vm, i32 %gval.xn)
-  %gval.a_unb = call i1 @value_is_unbound(%Value %gval.va)
-  br i1 %gval.a_unb, label %gval.bind_a, label %gval.check_x
+  %gval.rawa = call %Value @wam_get_reg(%WamState* %vm, i32 %gval.ai)
+  %gval.rawx = call %Value @wam_get_reg(%WamState* %vm, i32 %gval.xn)
+  %gval.ka = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %gval.rawa)
+  %gval.kx = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %gval.rawx)
+  %gval.ka_tag = extractvalue %Value %gval.ka, 0
+  %gval.kx_tag = extractvalue %Value %gval.kx, 0
+  %gval.ka_isref = icmp eq i32 %gval.ka_tag, 5
+  %gval.ka_isunb = icmp eq i32 %gval.ka_tag, 6
+  %gval.a_var = or i1 %gval.ka_isref, %gval.ka_isunb
+  %gval.kx_isref = icmp eq i32 %gval.kx_tag, 5
+  %gval.kx_isunb = icmp eq i32 %gval.kx_tag, 6
+  %gval.x_var = or i1 %gval.kx_isref, %gval.kx_isunb
+  br i1 %gval.a_var, label %gval.a_is_var, label %gval.a_bound
+
+gval.a_is_var:
+  br i1 %gval.x_var, label %gval.both_var, label %gval.bind_a
+
+gval.both_var:
+  ; same cell already? binding a cell to a Ref to itself would create a
+  ; self-referential cell (the M139 hazard) -- the sides already alias.
+  %gval.ka_pay = extractvalue %Value %gval.ka, 1
+  %gval.kx_pay = extractvalue %Value %gval.kx, 1
+  %gval.both_ref = and i1 %gval.ka_isref, %gval.kx_isref
+  %gval.same_pay = icmp eq i64 %gval.ka_pay, %gval.kx_pay
+  %gval.same_cell = and i1 %gval.both_ref, %gval.same_pay
+  br i1 %gval.same_cell, label %gval.match, label %gval.link
+
+gval.link:
+  ; link the two variables, preferring an existing heap cell as target
+  br i1 %gval.kx_isref, label %gval.link_a_to_x, label %gval.link_x
+
+gval.link_a_to_x:
+  call void @wam_bind_reg(%WamState* %vm, i32 %gval.ai, %Value %gval.kx)
+  br label %gval.match
+
+gval.link_x:
+  br i1 %gval.ka_isref, label %gval.link_x_to_a, label %gval.link_fresh
+
+gval.link_x_to_a:
+  call void @wam_bind_reg(%WamState* %vm, i32 %gval.xn, %Value %gval.ka)
+  br label %gval.match
+
+gval.link_fresh:
+  ; both sides are naked register variables (no heap cell): create a
+  ; shared cell and point both registers at it
+  %gval.unb0 = insertvalue %Value undef, i32 6, 0
+  %gval.unb = insertvalue %Value %gval.unb0, i64 0, 1
+  %gval.addr = call i32 @wam_heap_push(%WamState* %vm, %Value %gval.unb)
+  %gval.ref = call %Value @value_ref(i32 %gval.addr)
+  call void @wam_bind_reg(%WamState* %vm, i32 %gval.ai, %Value %gval.ref)
+  call void @wam_bind_reg(%WamState* %vm, i32 %gval.xn, %Value %gval.ref)
+  br label %gval.match
 
 gval.bind_a:
-  call void @wam_trail_binding(%WamState* %vm, i32 %gval.ai)
-  call void @wam_bind_reg(%WamState* %vm, i32 %gval.ai, %Value %gval.vx)
-  call void @wam_inc_pc(%WamState* %vm)
-  ret i1 true
+  ; A side variable, X side bound: bind through the A chain or register.
+  ; wam_bind_reg trails internally (heap or register as appropriate).
+  call void @wam_bind_reg(%WamState* %vm, i32 %gval.ai, %Value %gval.kx)
+  br label %gval.match
 
-gval.check_x:
-  %gval.x_unb = call i1 @value_is_unbound(%Value %gval.vx)
-  br i1 %gval.x_unb, label %gval.bind_x, label %gval.check_eq
+gval.a_bound:
+  br i1 %gval.x_var, label %gval.bind_x, label %gval.check_eq
 
 gval.bind_x:
-  call void @wam_trail_binding(%WamState* %vm, i32 %gval.xn)
-  call void @wam_bind_reg(%WamState* %vm, i32 %gval.xn, %Value %gval.va)
-  call void @wam_inc_pc(%WamState* %vm)
-  ret i1 true
+  call void @wam_bind_reg(%WamState* %vm, i32 %gval.xn, %Value %gval.ka)
+  br label %gval.match
 
 gval.check_eq:
   ; M138: get_value is a unify instruction, not an equality test.
@@ -2937,7 +2991,7 @@ gval.check_eq:
   ; compounds (binding any unbound args, with trailing). The previous
   ; @value_equals wrongly failed p(X, X) heads called with unifiable
   ; compounds like p(f(A), f(B)).
-  %gval.eq = call i1 @wam_unify_value(%WamState* %vm, %Value %gval.va, %Value %gval.vx)
+  %gval.eq = call i1 @wam_unify_value(%WamState* %vm, %Value %gval.ka, %Value %gval.kx)
   br i1 %gval.eq, label %gval.match, label %gval.fail
 
 gval.match:
@@ -14361,7 +14415,13 @@ builtin_append:
   ; append([], L, L) handled as the count=0 degenerate case (the
   ; build loop never runs, acc stays equal to A2).
   %app.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
-  %app.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  ; A2 seeds the result tail BY VALUE. Deref with keep_var, not the full
+  ; deref: append(Cs, T, L) with T an unbound variable must seed the tail
+  ; with Ref{cell of T} so later bindings of T are visible through L (the
+  ; full deref would collapse T into the detached Unbound sentinel and
+  ; silently sever the difference-list chain -- campaign finding no. 9).
+  %app.a2raw = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %app.a2 = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %app.a2raw)
   call void @wam_arena_ensure()
   br label %app.c_loop
 app.c_loop:

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -2472,68 +2472,150 @@ exit:
 ;   4 = transitive_distance3
 ;   5 = weighted_shortest_path3
 ;   6 = astar_shortest_path4
-; === M5.14: Bump arena allocator ===
+; === M5.14: Bump arena allocator (chained blocks since M6 self-host) ===
 ; WASM-portable arena for transient kernel allocations. Kernel helpers
 ; (BFS, Dijkstra, A*) allocate scratch buffers at the start and free
 ; everything at the end — a pattern that maps perfectly to bump allocation.
 ;
-; Native: the arena is backed by a single malloc'd buffer.
-; WASM:   swap @wam_arena_init/@wam_arena_destroy to use linear memory.
+; Native: the arena is a CHAIN of malloc'd blocks. Allocation bumps within
+; the current block; on exhaustion a new block (geometric doubling) is
+; LINKED rather than returning null. Blocks never move — %Values hold raw
+; pointers into them — so growth is safe for live terms. This removes the
+; hard capacity cliff that segfaulted the self-hosted compiler (runtime
+; finding no. 8): accumulator-style grammars allocate quadratically in
+; their output size, and unchecked callers dereferenced the null that the
+; single-block arena returned past its cap.
+;
+; Each block starts with a 32-byte header (data stays 16-aligned):
+;   +0  i8* prev   — previous block's header, or null for the first block
+;   +8  i64 cap    — data capacity of this block (excludes the header)
+;   +16 i64 base   — virtual offset of this block's data start
+;   +24 (reserved)
+; A block's virtual base is the previous block's base + its bump position
+; at link time, so marks (base + pos) are globally monotonic and
+; mark/rewind keep working across block boundaries: rewind pops (frees)
+; every block newer than the mark, then restores the bump position.
+;
+; WASM:   swap @wam_arena_init/@wam_arena_destroy to use linear memory
+;         (a single non-chaining block reproduces the old behavior).
 ;
 ; Usage:  mark → alloc … alloc → rewind (restores to mark).
 ; NOTE: The arena implementation below uses module-level global state
 ; and is NOT thread-safe. Multiple concurrent WamState instances
 ; will race on these globals.
 
-@wam_arena_buf = internal global i8* null
-@wam_arena_pos = internal global i64 0
-@wam_arena_cap = internal global i64 0
+@wam_arena_hdr  = internal global i8* null   ; current block header
+@wam_arena_buf  = internal global i8* null   ; current block data start (hdr+32)
+@wam_arena_pos  = internal global i64 0      ; bump position within current block
+@wam_arena_cap  = internal global i64 0      ; current block data capacity
+@wam_arena_base = internal global i64 0      ; virtual offset of current data start
 
 define void @wam_arena_init(i64 %cap) {
-  %buf = call i8* @malloc(i64 %cap)
-  store i8* %buf, i8** @wam_arena_buf
+  %alloc_sz = add i64 %cap, 32
+  %blk = call i8* @malloc(i64 %alloc_sz)
+  %prev_slot = bitcast i8* %blk to i8**
+  store i8* null, i8** %prev_slot
+  %cap_raw = getelementptr i8, i8* %blk, i64 8
+  %cap_slot = bitcast i8* %cap_raw to i64*
+  store i64 %cap, i64* %cap_slot
+  %base_raw = getelementptr i8, i8* %blk, i64 16
+  %base_slot = bitcast i8* %base_raw to i64*
+  store i64 0, i64* %base_slot
+  %data = getelementptr i8, i8* %blk, i64 32
+  store i8* %blk, i8** @wam_arena_hdr
+  store i8* %data, i8** @wam_arena_buf
   store i64 0, i64* @wam_arena_pos
   store i64 %cap, i64* @wam_arena_cap
+  store i64 0, i64* @wam_arena_base
   ret void
 }
 
 define void @wam_arena_destroy() {
-  %buf = load i8*, i8** @wam_arena_buf
-  %is_null = icmp eq i8* %buf, null
+entry:
+  %hdr0 = load i8*, i8** @wam_arena_hdr
+  br label %loop
+loop:
+  %hdr = phi i8* [ %hdr0, %entry ], [ %prev, %do_free ]
+  %is_null = icmp eq i8* %hdr, null
   br i1 %is_null, label %done, label %do_free
 do_free:
-  call void @free(i8* %buf)
+  %prev_slot = bitcast i8* %hdr to i8**
+  %prev = load i8*, i8** %prev_slot
+  call void @free(i8* %hdr)
+  br label %loop
+done:
+  store i8* null, i8** @wam_arena_hdr
   store i8* null, i8** @wam_arena_buf
   store i64 0, i64* @wam_arena_pos
   store i64 0, i64* @wam_arena_cap
-  br label %done
-done:
+  store i64 0, i64* @wam_arena_base
   ret void
 }
 
+; A mark is a virtual offset (base + pos): monotonic across block links,
+; so mark/rewind pairs stay valid even when the arena grew in between.
 define i64 @wam_arena_mark() alwaysinline nounwind {
   %pos = load i64, i64* @wam_arena_pos
-  ret i64 %pos
+  %base = load i64, i64* @wam_arena_base
+  %mark = add i64 %base, %pos
+  ret i64 %mark
 }
 
-define void @wam_arena_rewind(i64 %mark) alwaysinline nounwind {
-  store i64 %mark, i64* @wam_arena_pos
+; Pops (frees) every block whose data lies entirely past the mark, then
+; restores the bump position inside the surviving block. Everything
+; allocated after the mark is discarded, exactly as before chaining.
+define void @wam_arena_rewind(i64 %mark) nounwind {
+entry:
+  br label %check
+check:
+  %base = load i64, i64* @wam_arena_base
+  %in_block = icmp uge i64 %mark, %base
+  br i1 %in_block, label %set, label %pop
+set:
+  %pos = sub i64 %mark, %base
+  store i64 %pos, i64* @wam_arena_pos
   ret void
-}
-
-; Reset the bump pointer to 0 without releasing the underlying buffer.
-; Cheaper than @wam_arena_destroy + next-iteration @wam_arena_init pair
-; (which does free + malloc of a 1 MiB buffer per query). Used by
-; @wam_cleanup so callers that loop over queries don't pay the
-; per-iteration alloc/free.
-define void @wam_arena_reset() alwaysinline nounwind {
+pop:
+  %hdr = load i8*, i8** @wam_arena_hdr
+  %prev_slot = bitcast i8* %hdr to i8**
+  %prev = load i8*, i8** %prev_slot
+  ; Defensive: a mark below the first block's base (0) cannot happen; if
+  ; it somehow does, keep the first block and clamp to position 0.
+  %no_prev = icmp eq i8* %prev, null
+  br i1 %no_prev, label %clamp, label %do_pop
+clamp:
   store i64 0, i64* @wam_arena_pos
   ret void
+do_pop:
+  call void @free(i8* %hdr)
+  %pcap_raw = getelementptr i8, i8* %prev, i64 8
+  %pcap_slot = bitcast i8* %pcap_raw to i64*
+  %pcap = load i64, i64* %pcap_slot
+  %pbase_raw = getelementptr i8, i8* %prev, i64 16
+  %pbase_slot = bitcast i8* %pbase_raw to i64*
+  %pbase = load i64, i64* %pbase_slot
+  %pdata = getelementptr i8, i8* %prev, i64 32
+  store i8* %prev, i8** @wam_arena_hdr
+  store i8* %pdata, i8** @wam_arena_buf
+  store i64 %pcap, i64* @wam_arena_cap
+  store i64 %pbase, i64* @wam_arena_base
+  br label %check
 }
 
-; Bump-allocates %size bytes (8-byte aligned). Returns null if arena
-; is exhausted — callers that need more than the arena provides should
-; fall back to malloc (not yet implemented; current kernels fit easily).
+; Reset the arena to empty without releasing the first block. Frees any
+; chained growth blocks (so a query that ballooned the arena hands the
+; extra blocks back to malloc) but keeps the initial block mapped, so
+; callers that loop over queries don't pay a per-iteration alloc/free.
+; Used by @wam_cleanup. Equivalent to rewinding to virtual offset 0.
+define void @wam_arena_reset() alwaysinline nounwind {
+  call void @wam_arena_rewind(i64 0)
+  ret void
+}
+
+; Bump-allocates %size bytes (8-byte aligned). On block exhaustion, links
+; a new block of max(current cap * 2, requested size) — geometric growth
+; keeps the block count logarithmic and the total waste bounded. Returns
+; null only if malloc itself fails (true OOM).
 define i8* @wam_arena_alloc(i64 %size) {
 entry:
   ; Align size up to 8.
@@ -2543,33 +2625,59 @@ entry:
   %new_pos = add i64 %pos, %aligned
   %cap = load i64, i64* @wam_arena_cap
   %overflow = icmp ugt i64 %new_pos, %cap
-  br i1 %overflow, label %oom, label %ok
+  br i1 %overflow, label %grow, label %ok
 ok:
   store i64 %new_pos, i64* @wam_arena_pos
   %buf = load i8*, i8** @wam_arena_buf
   %ptr = getelementptr i8, i8* %buf, i64 %pos
   ret i8* %ptr
+grow:
+  ; Link a new block; the old block keeps its live terms (never moves).
+  %cap2 = shl i64 %cap, 1
+  %need_bigger = icmp ugt i64 %aligned, %cap2
+  %new_cap = select i1 %need_bigger, i64 %aligned, i64 %cap2
+  %alloc_sz = add i64 %new_cap, 32
+  %blk = call i8* @malloc(i64 %alloc_sz)
+  %malloc_failed = icmp eq i8* %blk, null
+  br i1 %malloc_failed, label %oom, label %link
+link:
+  %old_hdr = load i8*, i8** @wam_arena_hdr
+  %prev_slot = bitcast i8* %blk to i8**
+  store i8* %old_hdr, i8** %prev_slot
+  %cap_raw = getelementptr i8, i8* %blk, i64 8
+  %cap_slot = bitcast i8* %cap_raw to i64*
+  store i64 %new_cap, i64* %cap_slot
+  %old_base = load i64, i64* @wam_arena_base
+  %new_base = add i64 %old_base, %pos
+  %base_raw = getelementptr i8, i8* %blk, i64 16
+  %base_slot = bitcast i8* %base_raw to i64*
+  store i64 %new_base, i64* %base_slot
+  %data = getelementptr i8, i8* %blk, i64 32
+  store i8* %blk, i8** @wam_arena_hdr
+  store i8* %data, i8** @wam_arena_buf
+  store i64 %new_cap, i64* @wam_arena_cap
+  store i64 %new_base, i64* @wam_arena_base
+  store i64 %aligned, i64* @wam_arena_pos
+  ret i8* %data
 oom:
   ret i8* null
 }
 
-; Convenience: init arena if not already initialized, with a default
-; capacity (256 MiB, virtual -- Linux commits pages lazily, so RSS only
-; grows with actual use). The arena is transient term-building space for
-; put_structure / =.. / the reader; it grows monotonically within a single
-; top-level call (rewound only by the graph kernels). Accumulator-style
-; grammars (append onto a growing list per emitted byte) allocate
-; QUADRATICALLY in their output size, so a self-hosted compiler compiling a
-; ~1.5 KB source blows through the old 16 MiB. wam_arena_alloc returns null
-; past the cap and most callers do not check, so exhaustion segfaults; a
-; chained-arena (link a new block instead of returning null) is the real
-; fix, deferred -- blocks must not move, since %Values hold raw pointers.
+; Convenience: init arena if not already initialized. The initial block is
+; 16 MiB — enough for every normal query — and the chain grows on demand
+; (doubling), so the self-hosted compiler's quadratic accumulator-append
+; behavior (runtime finding no. 8) hits growth, not a segfault. The arena
+; is transient term-building space for put_structure / =.. / the reader;
+; it grows monotonically within a single top-level call (rewound only by
+; the graph kernels) and @wam_cleanup returns growth blocks to malloc.
+; Linearising the accumulator style in the bootstrap compiler (difference
+; lists) remains the compile-time fix; this makes memory a non-cliff.
 define void @wam_arena_ensure() {
   %buf = load i8*, i8** @wam_arena_buf
   %need_init = icmp eq i8* %buf, null
   br i1 %need_init, label %do_init, label %done
 do_init:
-  call void @wam_arena_init(i64 268435456)
+  call void @wam_arena_init(i64 16777216)
   br label %done
 done:
   ret void
@@ -2593,10 +2701,10 @@ define void @wam_cleanup() alwaysinline nounwind {
   ret void
 }
 
-; Full release: hands the arena buffer back to malloc. Idempotent —
-; a second call is a no-op because @wam_arena_destroy checks the
-; null sentinel. Use this on module unload or process shutdown for
-; long-running hosts that want to reclaim the 1 MiB arena.
+; Full release: hands the whole arena block chain back to malloc.
+; Idempotent — a second call is a no-op because @wam_arena_destroy checks
+; the null sentinel. Use this on module unload or process shutdown for
+; long-running hosts that want to reclaim the arena entirely.
 define void @wam_full_shutdown() nounwind {
   call void @wam_arena_destroy()
   ret void

--- a/tests/core/test_wam_llvm_arena_chain_runtime.pl
+++ b/tests/core/test_wam_llvm_arena_chain_runtime.pl
@@ -1,0 +1,274 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Chained-arena runtime tests (M6 self-host, runtime finding no. 8).
+% The bump arena links a new block on exhaustion instead of returning
+% null; blocks never move, and mark/rewind work across block boundaries
+% via virtual offsets. These drivers exercise the arena functions
+% directly in a native binary:
+%   1. Chain semantics: tiny first block, forced links, monotonic marks,
+%      cross-block rewind (pops + frees newer blocks), block stability
+%      (sentinels survive growth), first-block reuse after rewind(0),
+%      destroy + ensure re-init.
+%   2. Growth stress: ~100 MB through a 1 KiB initial block (many
+%      doublings), every allocation written and read back.
+
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module('../helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3]).
+
+:- dynamic user:arena_chain_marker/0.
+
+user:arena_chain_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_arena_chain_runtime, [condition(clang_available)]).
+
+test(arena_chain_marks_rewind_and_block_stability) :-
+    arena_chain_semantics_driver_ir(DriverIR),
+    run_arena_chain_smoke('uw_wam_arena_chain_semantics', DriverIR).
+
+test(arena_chain_growth_stress) :-
+    arena_chain_growth_driver_ir(DriverIR),
+    run_arena_chain_smoke('uw_wam_arena_chain_growth', DriverIR).
+
+run_arena_chain_smoke(Name, DriverIR) :-
+    tmp_root(Root),
+    directory_file_path(Root, Name, Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'arena_chain_runtime.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:arena_chain_marker/0 ],
+        [ module_name('arena_chain_runtime') ],
+        LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'arena_chain_runtime_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == "")
+    ;  format(user_error, "~n[arena chain runtime output]~n~w~n", [OutStr]),
+       throw(arena_chain_runtime_failed(Status))
+    ),
+    !.
+
+% Exit codes: 90 alloc returned null, 91-93 wrong mark after allocs,
+% 94 first-block sentinel lost (block moved or was clobbered by growth),
+% 95 second-block sentinel lost, 96/97 wrong mark after cross-block
+% rewind, 98 reset-to-zero mark wrong, 99 first block not reused in
+% place after rewind(0), 100 wrong mark after destroy + ensure re-init.
+arena_chain_semantics_driver_ir('
+define i32 @main() {
+entry:
+  ; Tiny first block: cap 64, so the second allocation must chain.
+  call void @wam_arena_init(i64 64)
+  %p1 = call i8* @wam_arena_alloc(i64 48)
+  %p1_null = icmp eq i8* %p1, null
+  br i1 %p1_null, label %alloc_fail, label %fill1
+
+fill1:
+  %p1_i64 = bitcast i8* %p1 to i64*
+  store i64 111, i64* %p1_i64
+  %p1_tail_raw = getelementptr i8, i8* %p1, i64 40
+  %p1_tail = bitcast i8* %p1_tail_raw to i64*
+  store i64 222, i64* %p1_tail
+  %m1 = call i64 @wam_arena_mark()
+  %m1_ok = icmp eq i64 %m1, 48
+  br i1 %m1_ok, label %chain1, label %bad_m1
+
+chain1:
+  ; 48 + 64 > 64: links a second block (cap max(128, 64) = 128, base 48).
+  %p2 = call i8* @wam_arena_alloc(i64 64)
+  %p2_null = icmp eq i8* %p2, null
+  br i1 %p2_null, label %alloc_fail, label %fill2
+
+fill2:
+  %p2_tail_raw = getelementptr i8, i8* %p2, i64 56
+  %p2_tail = bitcast i8* %p2_tail_raw to i64*
+  store i64 333, i64* %p2_tail
+  %m2 = call i64 @wam_arena_mark()
+  %m2_ok = icmp eq i64 %m2, 112
+  br i1 %m2_ok, label %chain2, label %bad_m2
+
+chain2:
+  ; 64 + 200 > 128: links a third block (cap max(256, 200) = 256, base 112).
+  %p3 = call i8* @wam_arena_alloc(i64 200)
+  %p3_null = icmp eq i8* %p3, null
+  br i1 %p3_null, label %alloc_fail, label %fill3
+
+fill3:
+  %p3_tail_raw = getelementptr i8, i8* %p3, i64 192
+  %p3_tail = bitcast i8* %p3_tail_raw to i64*
+  store i64 444, i64* %p3_tail
+  %m3 = call i64 @wam_arena_mark()
+  %m3_ok = icmp eq i64 %m3, 312
+  br i1 %m3_ok, label %stability, label %bad_m3
+
+stability:
+  ; Earlier blocks must be untouched by growth (blocks never move).
+  %r1 = load i64, i64* %p1_i64
+  %r1_ok = icmp eq i64 %r1, 111
+  %r1t = load i64, i64* %p1_tail
+  %r1t_ok = icmp eq i64 %r1t, 222
+  %b1_ok = and i1 %r1_ok, %r1t_ok
+  br i1 %b1_ok, label %stability2, label %bad_block1
+
+stability2:
+  %r2 = load i64, i64* %p2_tail
+  %r2_ok = icmp eq i64 %r2, 333
+  br i1 %r2_ok, label %rewind_mid, label %bad_block2
+
+rewind_mid:
+  ; Rewind to m2 (virtual 112): discards the 200-byte allocation.
+  call void @wam_arena_rewind(i64 112)
+  %mm2 = call i64 @wam_arena_mark()
+  %mm2_ok = icmp eq i64 %mm2, 112
+  br i1 %mm2_ok, label %rewind_far, label %bad_rw_mid
+
+rewind_far:
+  ; Rewind to m1 (virtual 48): pops across a block boundary.
+  call void @wam_arena_rewind(i64 48)
+  %mm1 = call i64 @wam_arena_mark()
+  %mm1_ok = icmp eq i64 %mm1, 48
+  br i1 %mm1_ok, label %check_survivor, label %bad_rw_far
+
+check_survivor:
+  ; The first block (below the mark) must still hold its data.
+  %r1b = load i64, i64* %p1_i64
+  %r1b_ok = icmp eq i64 %r1b, 111
+  br i1 %r1b_ok, label %reset_zero, label %bad_block1
+
+reset_zero:
+  call void @wam_arena_reset()
+  %mz = call i64 @wam_arena_mark()
+  %mz_ok = icmp eq i64 %mz, 0
+  br i1 %mz_ok, label %reuse, label %bad_reset
+
+reuse:
+  ; After reset the first block is reused in place: same data pointer.
+  %p5 = call i8* @wam_arena_alloc(i64 48)
+  %p5_null = icmp eq i8* %p5, null
+  br i1 %p5_null, label %alloc_fail, label %reuse_check
+
+reuse_check:
+  %same = icmp eq i8* %p5, %p1
+  br i1 %same, label %reinit, label %bad_reuse
+
+reinit:
+  ; Destroy releases the whole chain; ensure re-initializes lazily.
+  call void @wam_arena_destroy()
+  call void @wam_arena_ensure()
+  %p6 = call i8* @wam_arena_alloc(i64 16)
+  %p6_null = icmp eq i8* %p6, null
+  br i1 %p6_null, label %alloc_fail, label %reinit_check
+
+reinit_check:
+  %m6 = call i64 @wam_arena_mark()
+  %m6_ok = icmp eq i64 %m6, 16
+  call void @wam_arena_destroy()
+  br i1 %m6_ok, label %ok, label %bad_reinit
+
+ok:
+  ret i32 0
+alloc_fail:
+  ret i32 90
+bad_m1:
+  ret i32 91
+bad_m2:
+  ret i32 92
+bad_m3:
+  ret i32 93
+bad_block1:
+  ret i32 94
+bad_block2:
+  ret i32 95
+bad_rw_mid:
+  ret i32 96
+bad_rw_far:
+  ret i32 97
+bad_reset:
+  ret i32 98
+bad_reuse:
+  ret i32 99
+bad_reinit:
+  ret i32 100
+}
+').
+
+% Exit codes: 90 alloc returned null, 91 read-back mismatch (a growth
+% block clobbered an earlier one), 92 reset did not return to zero.
+arena_chain_growth_driver_ir('
+define i32 @main() {
+entry:
+  ; 1 KiB initial block; 100000 x 1000 bytes (~100 MB) forces many
+  ; doublings. Every allocation is stamped with its index and re-read
+  ; immediately (a fresh block clobbering live data would surface as a
+  ; mismatch on a later iteration via the mark checksum below).
+  call void @wam_arena_init(i64 1024)
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i_next, %step ]
+  %done = icmp uge i64 %i, 100000
+  br i1 %done, label %check_total, label %body
+
+body:
+  %p = call i8* @wam_arena_alloc(i64 1000)
+  %p_null = icmp eq i8* %p, null
+  br i1 %p_null, label %alloc_fail, label %stamp
+
+stamp:
+  %slot = bitcast i8* %p to i64*
+  store i64 %i, i64* %slot
+  %back = load i64, i64* %slot
+  %back_ok = icmp eq i64 %back, %i
+  br i1 %back_ok, label %step, label %bad_readback
+
+step:
+  %i_next = add i64 %i, 1
+  br label %loop
+
+check_total:
+  ; 1000 aligns to 1000 (already a multiple of 8): total = 100000000.
+  %m = call i64 @wam_arena_mark()
+  %m_ok = icmp eq i64 %m, 100000000
+  br i1 %m_ok, label %reset, label %bad_readback
+
+reset:
+  call void @wam_arena_reset()
+  %mz = call i64 @wam_arena_mark()
+  %mz_ok = icmp eq i64 %mz, 0
+  call void @wam_arena_destroy()
+  br i1 %mz_ok, label %ok, label %bad_reset
+
+ok:
+  ret i32 0
+alloc_fail:
+  ret i32 90
+bad_readback:
+  ret i32 91
+bad_reset:
+  ret i32 92
+}
+').
+
+:- end_tests(wam_llvm_arena_chain_runtime).
+
+:- initialization(run_tests, main).

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -262,17 +262,25 @@ wamoserz(_Src, Wamo) :-
         [enc(0,42,65536,0), enc(20,0,0,0)], Codes),
     atom_codes(Wamo, Codes).
 
-% accumulator appenders: each threads a code list, holding few call-spanning
-% vars. wz_i "<int>\n", wz_a "<atom>\n", wz_n "<len> <bytes>\n", wz_si " <int>".
-wz_i(N, A0, A1)  :- number_codes(N, Cs), append(A0, Cs, B), append(B, [10], A1).
-wz_a(X, A0, A1)  :- atom_codes(X, Cs), append(A0, Cs, B), append(B, [10], A1).
+% DIFFERENCE-LIST emitters: A0 is the open list being built, A1 its tail
+% after this item -- so each emission appends only its OWN codes (linear in
+% total output), never copying the accumulated prefix. The old accumulator
+% style (append(A0, Cs, B) -- copy everything emitted so far, per token) is
+% QUADRATIC in output size and was the entire compile-time/memory cliff of
+% the self-host fixpoint (246 MB arena for a 3.6 KB object). Threading
+% predicates (wz_header/wz_body/wz_pcs_rows/...) are direction-agnostic and
+% unchanged; only the leaf emitters and the top wrappers (which now close
+% the tail with []) know the representation.
+% wz_i "<int>\n", wz_a "<atom>\n", wz_n "<len> <bytes>\n", wz_si " <int>".
+wz_i(N, A0, A1)  :- number_codes(N, Cs), append(Cs, [10|A1], A0).
+wz_a(X, A0, A1)  :- atom_codes(X, Cs), append(Cs, [10|A1], A0).
 wz_n(Cs, A0, A1) :- length(Cs, Len), number_codes(Len, LC),
-    append(A0, LC, B), append(B, [32|Cs], C), append(C, [10], A1).
-wz_si(N, A0, A1) :- number_codes(N, Cs), append(A0, [32|Cs], A1).
+    append(LC, [32|Mid], A0), append(Cs, [10|A1], Mid).
+wz_si(N, A0, A1) :- number_codes(N, Cs), append([32|Cs], A1, A0).
 
 wz_serialize(EntryIdx, NameCodes, LabelIdx, NA, NF, PCs, Instrs, Out) :-
-    wz_header(EntryIdx, NameCodes, LabelIdx, NA, NF, [], Hdr),
-    wz_body(PCs, Instrs, Hdr, Out).
+    wz_header(EntryIdx, NameCodes, LabelIdx, NA, NF, Out, Hdr),
+    wz_body(PCs, Instrs, Hdr, []).
 
 % header: WAMO / version 2 / entry index / NE=1 / name / label / NA / NF,
 % split across two clauses so neither holds too many call-spanning vars.
@@ -298,8 +306,8 @@ wz_instr_rows([], A, A).
 wz_instr_rows([enc(T,O1,O2,R)|Is], A0, A2) :-
     wz_row(T, O1, O2, R, A0, A1), wz_instr_rows(Is, A1, A2).
 wz_row(T, O1, O2, R, A0, A5) :-
-    number_codes(T, Tc), append(A0, Tc, A1),
-    wz_si(O1, A1, A2), wz_si(O2, A2, A3), wz_si(R, A3, A4), append(A4, [10], A5).
+    number_codes(T, Tc), append(Tc, A1, A0),
+    wz_si(O1, A1, A2), wz_si(O2, A2, A3), wz_si(R, A3, A4), A4 = [10|A5].
 
 % Milestone 6 (self-host) Stage B: minimal CODEGEN -- source text to a .wamo,
 % end to end. cgcompile/2 is the eval-pipeline entry compile(Src,Wamo): it
@@ -512,10 +520,10 @@ add_unique(Op, Acc, Acc1) :- append(Acc, [Op], Acc1).
 % functor-aware serializer: like wz_serialize but emits the functor table
 % (NF + NF length-prefixed functor name strings) after the (empty) atom table.
 wzf_serialize(EI, NC, LI, Functors, PCs, Instrs, Out) :-
-    wz_a('WAMO', [], A1), wz_i(2, A1, A2), wz_i(EI, A2, A3), wz_i(1, A3, A4),
+    wz_a('WAMO', Out, A1), wz_i(2, A1, A2), wz_i(EI, A2, A3), wz_i(1, A3, A4),
     wz_n(NC, A4, A5), wz_i(LI, A5, A6), wz_i(0, A6, A7),          % NA = 0
     length(Functors, NF), wz_i(NF, A7, A8), wz_funcs(Functors, A8, A9),
-    wz_pcs_sec(PCs, A9, A10), wz_instr_sec(Instrs, A10, A11), wz_i(0, A11, Out).
+    wz_pcs_sec(PCs, A9, A10), wz_instr_sec(Instrs, A10, A11), wz_i(0, A11, []).
 wz_fname(F, A0, A1) :- atom_codes(F, Cs), wz_n(Cs, A0, A1).
 wz_funcs([], A, A).
 wz_funcs([F|Fs], A0, A2) :- wz_fname(F, A0, A1), wz_funcs(Fs, A1, A2).
@@ -916,16 +924,20 @@ defer_builds([d(C,Reg)|Ds], At, FT, Xt0, Xt, In0, In, Is) :-
 % serializer with an atom table: NA + NA length-prefixed atom name strings
 % between the label index and the functor table
 wza_serialize(EI, NC, LI, Atoms, Fs, PCs, Is, Out) :-
-    wz_a('WAMO', [], A1), wz_i(2, A1, A2), wz_i(EI, A2, A3), wz_i(1, A3, A4),
+    wz_a('WAMO', Out, A1), wz_i(2, A1, A2), wz_i(EI, A2, A3), wz_i(1, A3, A4),
     wz_n(NC, A4, A5), wz_i(LI, A5, A6),
     length(Atoms, NA), wz_i(NA, A6, A7), wz_funcs(Atoms, A7, A8),
     length(Fs, NF), wz_i(NF, A8, A9), wz_funcs(Fs, A9, A10),
-    wz_pcs_sec(PCs, A10, A11), wz_instr_sec(Is, A11, A12), wz_i(0, A12, Out).
+    wz_pcs_sec(PCs, A10, A11), wz_instr_sec(Is, A11, A12), wz_i(0, A12, []).
 
 % The fixpoint source: the Stage A serializer (wz_* chain) restated in the
 % accepted subset (cut-free, builtins + calls + list/structure patterns).
-% The entry checksums its own output (byte sum + length).
-fixpoint_serializer_source('[(main0(R) :- serz(Cs), sum_list(Cs, S), length(Cs, L), R is S + L), (serz(Out) :- atom_codes(''ea/1'', NC), wzs(0, NC, 0, 0, 0, [0], [enc(0,42,65536,0), enc(20,0,0,0)], Out)), (wzi(N, A0, A1) :- number_codes(N, Cs), append(A0, Cs, B), append(B, [10], A1)), (wza(X, A0, A1) :- atom_codes(X, Cs), append(A0, Cs, B), append(B, [10], A1)), (wzn(Cs, A0, A1) :- length(Cs, L), number_codes(L, LC), append(A0, LC, B), append(B, [32|Cs], C), append(C, [10], A1)), (wzsi(N, A0, A1) :- number_codes(N, Cs), append(A0, [32|Cs], A1)), (wzs(EI, NC, LI, NA, NF, PCs, Is, Out) :- wzh(EI, NC, LI, NA, NF, [], H), wzb(PCs, Is, H, Out)), (wzh(EI, NC, LI, NA, NF, A0, Out) :- wza(''WAMO'', A0, A1), wzi(2, A1, A2), wzi(EI, A2, A3), wzi(1, A3, A4), wzh2(NC, LI, NA, NF, A4, Out)), (wzh2(NC, LI, NA, NF, A0, Out) :- wzn(NC, A0, A1), wzi(LI, A1, A2), wzi(NA, A2, A3), wzi(NF, A3, Out)), (wzb(PCs, Is, A0, Out) :- wzp(PCs, A0, A1), wzc(Is, A1, A2), wzi(0, A2, Out)), (wzp(PCs, A0, A2) :- length(PCs, NL), wzi(NL, A0, A1), wzpr(PCs, A1, A2)), wzpr([], A, A), (wzpr([P|Ps], A0, A2) :- wzi(P, A0, A1), wzpr(Ps, A1, A2)), (wzc(Is, A0, A2) :- length(Is, NC2), wzi(NC2, A0, A1), wzcr(Is, A1, A2)), wzcr([], A, A), (wzcr([enc(T,O1,O2,Rl)|Is], A0, A2) :- wzr(T, O1, O2, Rl, A0, A1), wzcr(Is, A1, A2)), (wzr(T, O1, O2, Rl, A0, A5) :- number_codes(T, Tc), append(A0, Tc, A1), wzsi(O1, A1, A2), wzsi(O2, A2, A3), wzsi(Rl, A3, A4), append(A4, [10], A5))]').
+% The entry checksums its own output (byte sum + length). Like the Stage A
+% chain above, the emitters are DIFFERENCE LISTS (A0 = open list, A1 = its
+% tail after the item), so the doubly-compiled serializer is linear too --
+% and compiling it exercises open-tail call operands ([10|A1], [32|Mid])
+% and append/3 in construct mode with a partial second argument.
+fixpoint_serializer_source('[(main0(R) :- serz(Cs), sum_list(Cs, S), length(Cs, L), R is S + L), (serz(Out) :- atom_codes(''ea/1'', NC), wzs(0, NC, 0, 0, 0, [0], [enc(0,42,65536,0), enc(20,0,0,0)], Out)), (wzi(N, A0, A1) :- number_codes(N, Cs), append(Cs, [10|A1], A0)), (wza(X, A0, A1) :- atom_codes(X, Cs), append(Cs, [10|A1], A0)), (wzn(Cs, A0, A1) :- length(Cs, L), number_codes(L, LC), append(LC, [32|Mid], A0), append(Cs, [10|A1], Mid)), (wzsi(N, A0, A1) :- number_codes(N, Cs), append([32|Cs], A1, A0)), (wzs(EI, NC, LI, NA, NF, PCs, Is, Out) :- wzh(EI, NC, LI, NA, NF, Out, H), wzb(PCs, Is, H, [])), (wzh(EI, NC, LI, NA, NF, A0, Out) :- wza(''WAMO'', A0, A1), wzi(2, A1, A2), wzi(EI, A2, A3), wzi(1, A3, A4), wzh2(NC, LI, NA, NF, A4, Out)), (wzh2(NC, LI, NA, NF, A0, Out) :- wzn(NC, A0, A1), wzi(LI, A1, A2), wzi(NA, A2, A3), wzi(NF, A3, Out)), (wzb(PCs, Is, A0, Out) :- wzp(PCs, A0, A1), wzc(Is, A1, A2), wzi(0, A2, Out)), (wzp(PCs, A0, A2) :- length(PCs, NL), wzi(NL, A0, A1), wzpr(PCs, A1, A2)), wzpr([], A, A), (wzpr([P|Ps], A0, A2) :- wzi(P, A0, A1), wzpr(Ps, A1, A2)), (wzc(Is, A0, A2) :- length(Is, NC2), wzi(NC2, A0, A1), wzcr(Is, A1, A2)), wzcr([], A, A), (wzcr([enc(T,O1,O2,Rl)|Is], A0, A2) :- wzr(T, O1, O2, Rl, A0, A1), wzcr(Is, A1, A2)), (wzr(T, O1, O2, Rl, A0, A5) :- number_codes(T, Tc), append(Tc, A1, A0), wzsi(O1, A1, A2), wzsi(O2, A2, A3), wzsi(Rl, A3, A4), A4 = [10|A5])]').
 
 % Register-file ceiling regression: manyperm/1 has 20 variables all live
 % across the mp_barrier call, so the compiler assigns them Y1..Y20. Before
@@ -943,6 +955,31 @@ manyperm(R) :-
     R is N1+N2+N3+N4+N5+N6+N7+N8+N9+N10
        + N11+N12+N13+N14+N15+N16+N17+N18+N19+N20.
 mp_barrier.
+
+% Campaign finding no. 9 regression: variable identity through get_value and
+% the append/3 seed. Two runtime paths used the FULL deref on a value that
+% could be an unbound variable, collapsing Ref-to-unbound-cell into the
+% detached Unbound sentinel (no cell address) and silently severing the link:
+%   (a) get_value var-var -- knot9(A, A) called with two unbound args left
+%       them UNLINKED (the head "unification" was a no-op that still
+%       succeeded), so a later binding through one side was invisible
+%       through the other;
+%   (b) builtin append(Cs, T, L) with T an unbound BARE variable seeded the
+%       result tail with the collapsed sentinel instead of Ref{cell of T}.
+% Both severed the difference-list serializer of the self-host fixpoint.
+% Here: L = [1,2,3|H], H knotted to T via get_value, T extended with 4 and
+% closed via the bare-var append seed; sum_list/length see the COMPLETE
+% list only if both links held. R must be 10*100 + 4 = 1004 (on the broken
+% runtime the entry FAILS: sum_list reaches an unbound tail).
+dlknot(R) :-
+    append([1,2], [3|H], L),
+    knot9(H, T),
+    em9(4, T, T2),
+    T2 = [],
+    sum_list(L, S), length(L, N),
+    R is S*100 + N.
+knot9(A, A).
+em9(V, A0, A1) :- append([V], A1, A0).
 
 % Milestone 3b-db PR 3: rule bodies. assertz((H :- B)) stores a rule; calling
 % its head runs the body (deterministic first solution). Bodies handle ,/2,
@@ -1844,6 +1881,20 @@ test(register_file_many_permanents, [condition(clang_available)]) :-
     write_wam_object([user:manyperm/1], [wamo_entry(manyperm/1)], W),
     run_host(Host, W, Out, 0),
     assertion(Out == "210\n"),
+    !.
+
+% Finding no. 9: get_value var-var linking + append bare-var tail seed
+% (see dlknot/1 above). 1004 proves both variable links held through the
+% difference-list chain; the broken runtime fails the entry instead.
+test(get_value_var_var_and_append_var_seed, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    directory_file_path(Dir, 'dlknot.wamo', W),
+    write_wam_object([user:dlknot/1, user:knot9/2, user:em9/3],
+                     [wamo_entry(dlknot/1)], W),
+    run_host(Host, W, Out, 0),
+    assertion(Out == "1004\n"),
     !.
 
 % Milestone 3b-db PR 3: rule bodies in a loaded object. asserted (H :- B)


### PR DESCRIPTION
## Summary

Two commits: this branch **carries the chained-arena commit from #3563** (it was merged into the fixpoint side branch *after* #3561 landed, so it never reached this base branch — cherry-picked here so nothing is stranded), plus the new round: **difference-list linearization of the bootstrap compiler's serializer**, which closed the compile-time budget for the full self-compile and immediately surfaced **runtime finding #9**.

### Difference-list serializer

The `wz_*` emitters flip from forward accumulators (`append(A0, Cs, B)` — copy the *entire output so far* per emitted token; quadratic in output size) to difference lists: `A0` is the open list being built, `A1` its tail after the item, each emission appends only its own codes (`append(Cs, [10|A1], A0)`). The threading predicates are direction-agnostic and unchanged; only the leaf emitters and top wrappers (which close the tail with `[]`) know the representation. The fixpoint source restates its serializer the same way, so the doubly-compiled serializer is linear too — and compiling it exercises open-tail call operands (`[10|A1]`, `[32|Mid]`) and `append/3` with partial/unbound tails in the loaded subset. Output bytes are identical (checksum 2263 preserved; Stage A golden tests unchanged).

**Measured** (loaded `cgfull` compiling scaled copies of the fixpoint source), before → after:

| source | quadratic | difference lists |
|---|---|---|
| 1.4 KB | 0.17 s / 246 MB | 0.01 s / 10 MB |
| 2.9 KB | 4.5 s / 944 MB | 0.01 s / 10 MB |
| 5.9 KB | 20.2 s / 3.7 GB | 0.02 s / 17 MB |
| 11.9 KB | (est. ~15 GB — untested) | **0.04 s / 35 MB** |

An 11.9 KB source — larger than cgfull's own restated source will be — compiles loaded in 40 ms. Together with the chained arena (memory), the compile budget for `compile(SelfSource)` is closed.

### Runtime finding #9 (exposed immediately by the difference-list style)

A variable-identity collapse in **two** paths, same shape: using the full deref on a value that can be an unbound variable collapses Ref-to-unbound-cell into the shared Unbound sentinel (tag 6, no cell address), so "binding" one side to it silently severs the link:

- **`get_value` var-var**: a head like `wz_funcs([], A, A)` called with two unbound arguments left them *unlinked* — a no-op unification that still succeeded; every later binding through one side was invisible through the other. The serialized output truncated at exactly that knot (bisected with three loaded knot variants: direct append bind worked, `=/2` worked, `get_value` lost the link).
- **`builtin_append` result-tail seed**: `append(Cs, T, L)` with `T` an unbound *bare* variable seeded the built list's tail with the collapsed sentinel instead of `Ref{cell of T}` (partial tails like `[10|A1]` were fine — which is why the header sections serialized and the instruction rows didn't).

Fixed via `@wam_deref_keep_var` (variables keep their cell identity): `get_value` now classifies each side as variable-with-cell / naked register variable / bound, links var-var pairs toward an existing heap cell (same-cell guard against the M139 self-reference hazard; a fresh shared heap cell if both sides are naked register variables), and binds var-bound through `wam_bind_reg`; the append seed uses the keep-var deref.

## Testing

- New regression `get_value_var_var_and_append_var_seed`: drives both broken paths through one loaded object (must print 1004; the broken runtime fails the entry).
- Fresh host caches: full `wam_object` suite passes (fixpoint test now runs through the linear serializer), LLVM target suite 0 failures, `test_plawk_dyncall` + `test_plawk_compiled_stream_core` pass.
- Runtime-sensitive suites all pass: choicepoint stack restore, meta-call runtime, lowered ITE exec, stream runtime, reentrant run loop, findall execution, arena-chain drivers.
- `tests/core/test_wam_llvm_builtin_execution.pl` fails identically on the base branch (pre-existing `setof/3` compile-route gap, unrelated — verified via stash).

## Docs

- `PLAWK_SELFHOST.md`: difference-list section with the measurement table; finding-#9 write-up; remaining-work list now reads: cut-as-ITE restatement + front/middle self-compile (budget solved).
- `PLAWK_JIT_ROADMAP.md`: bug list updated to nine; closed compile budget noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_