### PR TITLE
WAM/LLVM (roadmap #5, milestone 6): GEN 3 — the compiler compiles a compiler

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -399,7 +399,12 @@ loadable along the way.
   source of its own Stage A serializer, and the doubly-compiled serializer
   reproduced the golden `.wamo` byte stream exactly (checksum 2263 = byte sum
   + length, matched against the Stage A implementation). The compiler has
-  compiled its own back end. The remaining campaign extends this toward
+  compiled its own back end. **GEN 3 LANDED** — the loaded compiler compiled
+  a mini-COMPILER (reader as a compiled goal, `=..` clause decomposition, a
+  dispatching ITE codegen decision, atom-table emission), and the
+  doubly-compiled compiler compiled two golden programs byte-exactly
+  (combined checksum 4676): source text in, correct object bytes out, two
+  compile generations deep. The remaining campaign extends this toward
   `compile(SelfSource)` — the full fixpoint.
   The compile budget for the full self-compile is closed: the **chained
   arena** removed the memory cliff (blocks link on exhaustion and never

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -584,14 +584,45 @@ var-bound through `wam_bind_reg`; the append seed uses the keep-var
 deref. Regression test `get_value_var_var_and_append_var_seed` drives
 both paths through a loaded object.
 
-**Remaining toward the full fixpoint:** the serializer was the back end; the
-front/middle (the reader call, `group_clauses`, the codegen walkers) use the
-same constructs plus `keysort`/`pairs_values` (already whitelisted) — but
-compiling the *whole* cgfull source also needs bare cut restated as ITE
-throughout and the `s(At,Fn)` state pair (structures — supported). The
-compile budget — both memory (chained arena) and time (difference lists) —
-is solved. The capstone (`compile(SelfSource)` yielding a working compiler
-object) remains open, now with a demonstrated path.
+**GEN 3 LANDED — the compiler compiles a compiler.** The next slice after
+the serializer: the loaded `cgfull` (gen 1) compiled a mini-COMPILER
+(gen 2, `fixpoint_compiler_source/1`), and the doubly-compiled compiler
+compiled TWO golden programs byte-exactly (combined checksum 4676,
+verified against the Stage A serializers computed in SWI). Where the
+serializer slice started from a hard-coded instruction list, gen 2 starts
+from **source text**: it runs the runtime reader as a compiled goal
+(`read_term_from_atom/2`), decomposes the clause with `=../2`, makes a
+**dispatching** codegen decision — `( integer(V) -> ` int `get_constant`
+`; ` atom `get_constant` with an **atom-table row emitted from the
+compiled program** (reloc class 1) `)` — assembles the entry-name codes,
+and serializes with the difference-list wz chain. Front-end ground proven
+for the capstone: the embedded program sources are quoted atoms with
+spaces and operators (`'ea(R2) :- R2 = 42'`) that survive collection into
+gen 2's atom table, relocation at load, and re-parsing by the loaded
+reader — two compile generations deep. One representational constraint
+surfaced: control functors (`:-`, `,`, …) are excluded from the data
+tables by design, so a compiler in the subset decomposes clauses with
+`=../2` instead of matching a `(H :- B)` pattern literal.
+
+*Diagnosability note (the round's real lesson):* the first attempt wrote
+`R is S1 + L1 + S2 + L2` in gen 2 — a NESTED arithmetic expression, the
+known deferred gap. In SWI that fails cleanly; **loaded, the codegen
+failure exploded into catastrophic backtracking** through the compile's
+stale choice points (loaded objects run unindexed, cut-free clause
+chains) — a silent multi-minute hang, not an error. Flattening the
+expression (`T1 is S1 + L1, T2 is S2 + L2, R is T1 + T2`) routes around
+it. The nested-arithmetic lift and a compile-failure diagnostic (fail
+fast instead of backtracking into the walkers) are both good next
+increments.
+
+**Remaining toward the full fixpoint:** the serializer and a source-to-
+object mini-compiler are now self-compiled; the full cgfull front/middle
+(`group_clauses`, `collect_tables`, the codegen walkers) additionally
+needs bare cut restated as ITE throughout and the `s(At,Fn)` state pair
+(structures — supported). The compile budget — both memory (chained
+arena) and time (difference lists) — is solved. The capstone
+(`compile(SelfSource)` yielding a working compiler object) remains open,
+with the front end now demonstrated end to end.
 
 **Deliverable:** the demonstrable self-host — the compiler compiles itself,
 and `compile(SelfSource)` yields a working compiler object.

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -939,6 +939,23 @@ wza_serialize(EI, NC, LI, Atoms, Fs, PCs, Is, Out) :-
 % and append/3 in construct mode with a partial second argument.
 fixpoint_serializer_source('[(main0(R) :- serz(Cs), sum_list(Cs, S), length(Cs, L), R is S + L), (serz(Out) :- atom_codes(''ea/1'', NC), wzs(0, NC, 0, 0, 0, [0], [enc(0,42,65536,0), enc(20,0,0,0)], Out)), (wzi(N, A0, A1) :- number_codes(N, Cs), append(Cs, [10|A1], A0)), (wza(X, A0, A1) :- atom_codes(X, Cs), append(Cs, [10|A1], A0)), (wzn(Cs, A0, A1) :- length(Cs, L), number_codes(L, LC), append(LC, [32|Mid], A0), append(Cs, [10|A1], Mid)), (wzsi(N, A0, A1) :- number_codes(N, Cs), append([32|Cs], A1, A0)), (wzs(EI, NC, LI, NA, NF, PCs, Is, Out) :- wzh(EI, NC, LI, NA, NF, Out, H), wzb(PCs, Is, H, [])), (wzh(EI, NC, LI, NA, NF, A0, Out) :- wza(''WAMO'', A0, A1), wzi(2, A1, A2), wzi(EI, A2, A3), wzi(1, A3, A4), wzh2(NC, LI, NA, NF, A4, Out)), (wzh2(NC, LI, NA, NF, A0, Out) :- wzn(NC, A0, A1), wzi(LI, A1, A2), wzi(NA, A2, A3), wzi(NF, A3, Out)), (wzb(PCs, Is, A0, Out) :- wzp(PCs, A0, A1), wzc(Is, A1, A2), wzi(0, A2, Out)), (wzp(PCs, A0, A2) :- length(PCs, NL), wzi(NL, A0, A1), wzpr(PCs, A1, A2)), wzpr([], A, A), (wzpr([P|Ps], A0, A2) :- wzi(P, A0, A1), wzpr(Ps, A1, A2)), (wzc(Is, A0, A2) :- length(Is, NC2), wzi(NC2, A0, A1), wzcr(Is, A1, A2)), wzcr([], A, A), (wzcr([enc(T,O1,O2,Rl)|Is], A0, A2) :- wzr(T, O1, O2, Rl, A0, A1), wzcr(Is, A1, A2)), (wzr(T, O1, O2, Rl, A0, A5) :- number_codes(T, Tc), append(Tc, A1, A0), wzsi(O1, A1, A2), wzsi(O2, A2, A3), wzsi(Rl, A3, A4), A4 = [10|A5])]').
 
+% The GEN-3 source: a mini-COMPILER (not just a serializer) in the accepted
+% subset. Where the serializer source above starts from a hard-coded
+% instruction list, cmp2/2 starts from SOURCE TEXT: it runs the runtime
+% reader as a compiled goal (read_term_from_atom/2, builtin id 174),
+% decomposes the clause with =../2 (avoiding a (H :- B) pattern literal --
+% control functors are excluded from the data tables by design), makes a
+% DISPATCHING codegen decision -- ( integer(V) -> int get_constant ; atom
+% get_constant with an ATOM TABLE row emitted from the compiled program,
+% reloc class 1 ) -- assembles the entry name codes ("<pred>/1"), and
+% serializes with the same difference-list wz chain (wzs here takes the
+% atom LIST and emits NA + its rows via wzat). Three generations: the
+% AOT-compiled cgfull (gen 1) compiles THIS source into gen 2; gen 2
+% compiles TWO golden programs (quoted atoms below, which must survive
+% collection into the atom table, relocation, and re-parsing by the
+% loaded reader) into exactly the bytes the Stage A serializer yields.
+fixpoint_compiler_source('[(main0(R) :- cmp2(''ea(R2) :- R2 = 42'', Cs1), cmp2(''eb(R2) :- R2 = foo'', Cs2), sum_list(Cs1, S1), length(Cs1, L1), sum_list(Cs2, S2), length(Cs2, L2), T1 is S1 + L1, T2 is S2 + L2, R is T1 + T2), (cmp2(Src, Out) :- read_term_from_atom(Src, C), C =.. [_, H, B], functor(H, P, 1), B =.. [_, _, V], atom_codes(P, PC), append(PC, [47, 49], NC), (integer(V) -> As = [], Is1 = [enc(0, V, 65536, 0)] ; As = [V], Is1 = [enc(0, 0, 0, 1)]), append(Is1, [enc(20, 0, 0, 0)], Is), wzs(0, NC, 0, As, [0], Is, Out)), (wzi(N, A0, A1) :- number_codes(N, Cs), append(Cs, [10|A1], A0)), (wza(X, A0, A1) :- atom_codes(X, Cs), append(Cs, [10|A1], A0)), (wzn(Cs, A0, A1) :- length(Cs, L), number_codes(L, LC), append(LC, [32|Mid], A0), append(Cs, [10|A1], Mid)), (wzsi(N, A0, A1) :- number_codes(N, Cs), append([32|Cs], A1, A0)), (wzs(EI, NC, LI, As, PCs, Is, Out) :- wzh(EI, NC, LI, Out, A6), length(As, NA), wzi(NA, A6, A7), wzat(As, A7, A8), wzi(0, A8, A9), wzp(PCs, A9, A10), wzc(Is, A10, A11), wzi(0, A11, [])), (wzh(EI, NC, LI, A0, Out) :- wza(''WAMO'', A0, A1), wzi(2, A1, A2), wzi(EI, A2, A3), wzi(1, A3, A4), wzn(NC, A4, A5), wzi(LI, A5, Out)), wzat([], A, A), (wzat([X|Xs], A0, A2) :- atom_codes(X, Cs), wzn(Cs, A0, A1), wzat(Xs, A1, A2)), (wzp(PCs, A0, A2) :- length(PCs, NL), wzi(NL, A0, A1), wzpr(PCs, A1, A2)), wzpr([], A, A), (wzpr([P|Ps], A0, A2) :- wzi(P, A0, A1), wzpr(Ps, A1, A2)), (wzc(Is, A0, A2) :- length(Is, NC2), wzi(NC2, A0, A1), wzcr(Is, A1, A2)), wzcr([], A, A), (wzcr([enc(T,O1,O2,Rl)|Is], A0, A2) :- wzr(T, O1, O2, Rl, A0, A1), wzcr(Is, A1, A2)), (wzr(T, O1, O2, Rl, A0, A5) :- number_codes(T, Tc), append(Tc, A1, A0), wzsi(O1, A1, A2), wzsi(O2, A2, A3), wzsi(Rl, A3, A4), A4 = [10|A5])]').
+
 % Register-file ceiling regression: manyperm/1 has 20 variables all live
 % across the mp_barrier call, so the compiler assigns them Y1..Y20. Before
 % the register file was enlarged from [64 x %Value] to [128 x %Value], Y17+
@@ -1859,6 +1876,41 @@ test(selfhost_codegen_stage_d_fixpoint, [condition(clang_available)]) :-
     format(string(Expected), "~w\n", [ExpectedN]),
     fixpoint_serializer_source(Source),
     directory_file_path(Dir, 'cgfp_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, Source), close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == Expected),
+    !.
+
+% GEN 3: the loaded compiler compiles a COMPILER, and the doubly-compiled
+% compiler compiles TWO golden programs byte-exactly. gen 1 = AOT cgfull;
+% gen 2 = cmp2 (reader + =.. decomposition + a dispatching ITE codegen
+% decision + atom-table emission + wz chain), compiled by gen 1 inside the
+% eval host; gen 3 = gen 2 run on 'ea(R2) :- R2 = 42' (int constant, no
+% tables) and 'eb(R2) :- R2 = foo' (atom constant, one atom-table row,
+% reloc class 1). The combined byte checksum must equal what the Stage A
+% serializers yield in-process (wamoserz for ea; wza_serialize for eb).
+test(selfhost_codegen_stage_d_gen3, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    wamoserz(x, W), atom_codes(W, WCs),
+    sum_list(WCs, WSum), length(WCs, WLen),
+    atom_codes('eb/1', EbName),
+    wza_serialize(0, EbName, 0, [foo], [], [0],
+        [enc(0,0,0,1), enc(20,0,0,0)], W2Cs),
+    sum_list(W2Cs, W2Sum), length(W2Cs, W2Len),
+    ExpectedN is WSum + WLen + W2Sum + W2Len,
+    format(string(Expected), "~w\n", [ExpectedN]),
+    fixpoint_compiler_source(Source),
+    directory_file_path(Dir, 'cgc2_src.txt', SrcPath),
     setup_call_cleanup(open(SrcPath, write, S0),
         write(S0, Source), close(S0)),
     process_create(Host, [CompWamo, SrcPath],


### PR DESCRIPTION
## Summary

The next fixpoint slice after the serializer: the loaded `cgfull` (**gen 1**) compiles a mini-**compiler** (**gen 2**, `fixpoint_compiler_source/1`), and the doubly-compiled compiler compiles **two golden programs byte-exactly** (**gen 3**) — source text in, correct `.wamo` bytes out, two compile generations deep. Combined checksum **4676**, computed in-test from the Stage A serializers (`wamoserz` + `wza_serialize`) in SWI.

Where the serializer slice started from a hard-coded instruction list, gen 2 starts from **source text**:
- runs the runtime reader as a **compiled goal** (`read_term_from_atom/2`, builtin 174) inside a doubly-compiled program;
- decomposes the clause with `=../2` — control functors (`:-`, `,`) are excluded from the data tables by design, so a compiler in the subset can't match a `(H :- B)` pattern literal; univ is the route;
- makes a **dispatching** codegen decision: `( integer(V) ->` int `get_constant` encoding `;` atom `get_constant` with an **atom-table row emitted from the compiled program**, reloc class 1 `)`;
- assembles the entry-name codes and serializes with the difference-list wz chain (`wzs` takes the atom list; `wzat` emits rows).

Gen 3 = gen 2 run on `'ea(R2) :- R2 = 42'` (int, no tables) and `'eb(R2) :- R2 = foo'` (atom, one table row). The embedded program sources are quoted atoms with spaces and operators that survive collection into gen 2's atom table, relocation at load, and re-parsing by the loaded reader.

## Diagnosability lesson (documented)

The first attempt wrote `R is S1 + L1 + S2 + L2` — a **nested** arithmetic expression, the known deferred subset gap. In SWI that fails cleanly; **loaded, the codegen failure exploded into catastrophic backtracking** through the compile's stale choice points (unindexed, cut-free clause chains) — a silent multi-minute hang, not an error. Flattened to `T1 is S1 + L1, T2 is S2 + L2, R is T1 + T2`. The nested-arithmetic lift and a fail-fast compile diagnostic are noted in `PLAWK_SELFHOST.md` as good next increments.

## Testing

- New self-checking test `selfhost_codegen_stage_d_gen3` (expected checksum computed from the SWI-side serializers at test time).
- Fresh host caches: full `wam_object` suite passes; LLVM target suite 0 failures; `test_plawk_dyncall` + `test_plawk_compiled_stream_core` pass.
- No runtime changes in this PR — test-file sources + docs only.

## Docs

- `PLAWK_SELFHOST.md`: GEN 3 section (what the slice proves for the capstone front end), the nested-arithmetic diagnosability note, and the updated remaining-work list (cut-as-ITE restatement + full front/middle; compile budget already solved).
- `PLAWK_JIT_ROADMAP.md`: milestone 6 entry updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_