### PR TITLE
Add configurable Product-Kalman NLL baselines

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -387,8 +387,8 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
    zero-cross-covariance / correlated Product-Kalman predictions on a separate split, optionally appends
    grouped-covariance score variants when calibration/evaluation group labels are present, records aggregate NLL/MSE,
    Mahalanobis calibration-scale/tail diagnostics, row-level score vectors, and optional paired bootstrap intervals
-   for NLL gains, and keeps calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison
-   pending.)*
+   for NLL gains against configurable baselines such as ungrouped `product_kalman`, and keeps
+   calibration/evaluation IDs disjoint. *(Synthetic harness added; real-corpus comparison pending.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
    descriptive Markdown run note. When row-level `eval_artifacts.npz` exists, the report CLI can add paired bootstrap
    NLL intervals post hoc without rerunning scoring, verifies the row artifact against the score summary, records the
@@ -425,13 +425,15 @@ calibration against both the naive-PoE controls and the additive/joint covarianc
   Product-Kalman tables, with held-out unit sampling, strict boundary-row omission, and a split manifest.
 - `product_kalman_table_evaluation.py` and `test_product_kalman_table_evaluation.py` — one-command table-to-input-
   artifacts-to-holdout-score/report runner, with optional split materialization, optional group-label carry-through into
-  grouped covariance scores, and canonical `--output-dir` bundles for real-corpus Product-Kalman comparisons.
+  grouped covariance scores, configurable NLL-gain baselines, and canonical `--output-dir` bundles for real-corpus
+  Product-Kalman comparisons.
 - `product_kalman_report.py` and `test_product_kalman_report.py` — descriptive Markdown report generator for
   Product-Kalman input manifests, optional split manifests, and score JSON artifacts.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including NLL/MSE,
   rowwise covariance scoring, grouped residual-covariance maps, automatic grouped score variants when NPZ group
-  labels are present, Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, and row-level NPZ score
-  artifacts for reproducible bootstrap/tail diagnostics.
+  labels are present, Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, configurable paired
+  bootstrap baselines for direct grouped-vs-ungrouped comparisons, and row-level NPZ score artifacts for reproducible
+  bootstrap/tail diagnostics.
 - `REPORT_sigma_hop_confirmatory.md` and `PAPER_sigma_hop_confirmatory.md` — confirmatory Sigma(hop) result and
   publication scaffold.

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -37,6 +37,9 @@ except ImportError:  # direct script execution from prototypes/mu_cosine
     )
 
 
+DEFAULT_NLL_BASELINES = ("prior", "independent_kalman")
+
+
 __all__ = [
     "GaussianScore",
     "GaussianScoreVectors",
@@ -518,6 +521,28 @@ class ProductKalmanHoldoutEvaluation:
         return self.score(baseline).mean_nll - self.score(candidate).mean_nll
 
 
+def _parse_name_list(text):
+    names = [part.strip() for part in str(text).split(",") if part.strip()]
+    if not names:
+        raise ValueError("name list must contain at least one name")
+    if len(names) != len(set(names)):
+        raise ValueError(f"name list contains duplicates: {text!r}")
+    return tuple(names)
+
+
+def _normalize_baselines(baselines):
+    if baselines is None:
+        baselines = DEFAULT_NLL_BASELINES
+    if isinstance(baselines, str):
+        return _parse_name_list(baselines)
+    names = tuple(str(name).strip() for name in baselines if str(name).strip())
+    if not names:
+        raise ValueError("nll_baselines must contain at least one score name")
+    if len(names) != len(set(names)):
+        raise ValueError(f"nll_baselines contains duplicates: {names!r}")
+    return names
+
+
 def _bootstrap_settings(n_boot, seed, confidence):
     if isinstance(n_boot, bool) or not isinstance(n_boot, (int, np.integer)):
         raise ValueError("n_boot must be a nonnegative integer")
@@ -639,10 +664,11 @@ def bootstrap_nll_improvements_from_score_rows(
     n_boot=1000,
     seed=0,
     confidence=0.95,
-    baselines=("prior", "independent_kalman"),
+    baselines=DEFAULT_NLL_BASELINES,
 ):
     """Return JSON-ready paired bootstrap maps from stored row-level NLL artifacts."""
     names, rows = _score_row_nll_inputs(score_names, score_row_nll)
+    baselines = _normalize_baselines(baselines)
     out = {}
     for baseline in baselines:
         if baseline not in names:
@@ -1122,7 +1148,7 @@ def bootstrap_nll_improvements_from_evaluation_npz(
     n_boot=1000,
     seed=0,
     confidence=0.95,
-    baselines=("prior", "independent_kalman"),
+    baselines=DEFAULT_NLL_BASELINES,
 ):
     """Return JSON-ready paired NLL bootstrap maps from an evaluation artifact NPZ."""
     path = str(artifact_npz)
@@ -1167,20 +1193,63 @@ def _bootstrap_improvement_map(result, baseline, n_boot, seed, confidence):
     }
 
 
-def evaluation_to_json_dict(result, bootstrap_nll=0, bootstrap_seed=0, bootstrap_confidence=0.95):
+def _score_names(result):
+    return {score.name for score in result.scores}
+
+
+def _validate_result_baselines(result, baselines):
+    baselines = _normalize_baselines(baselines)
+    names = _score_names(result)
+    missing = [baseline for baseline in baselines if baseline not in names]
+    if missing:
+        raise ValueError(f"nll_baselines are not present in scores: {missing!r}")
+    return baselines
+
+
+def _nll_improvement_maps(result, baselines):
+    out = {}
+    for baseline in _validate_result_baselines(result, baselines):
+        baseline_nll = result.score(baseline).mean_nll
+        out[f"nll_improvement_vs_{baseline}"] = {
+            score.name: baseline_nll - score.mean_nll
+            for score in result.scores
+            if score.name != baseline
+        }
+    return out
+
+
+def _bootstrap_improvement_maps(result, baselines, n_boot, seed, confidence):
+    return {
+        f"nll_improvement_bootstrap_vs_{baseline}": _bootstrap_improvement_map(
+            result,
+            baseline,
+            n_boot,
+            seed,
+            confidence,
+        )
+        for baseline in _validate_result_baselines(result, baselines)
+    }
+
+
+def evaluation_to_json_dict(
+    result,
+    bootstrap_nll=0,
+    bootstrap_seed=0,
+    bootstrap_confidence=0.95,
+    nll_baselines=DEFAULT_NLL_BASELINES,
+):
     """Return a JSON-serializable summary for a holdout evaluation result."""
     bootstrap_nll, bootstrap_seed, bootstrap_confidence = _bootstrap_settings(
         bootstrap_nll,
         bootstrap_seed,
         bootstrap_confidence,
     )
+    nll_baselines = _validate_result_baselines(result, nll_baselines)
     scores = {score.name: _score_to_json_dict(score) for score in result.scores}
-    prior = result.score("prior").mean_nll
-    improvements = {name: prior - score["mean_nll"] for name, score in scores.items() if name != "prior"}
     out = {
         "score_order": [score.name for score in result.scores],
         "scores": scores,
-        "nll_improvement_vs_prior": improvements,
+        "nll_baselines": list(nll_baselines),
         "calibration": {
             "n_samples": result.calibration.n_samples,
             "state_dim": result.calibration.state_dim,
@@ -1194,34 +1263,20 @@ def evaluation_to_json_dict(result, bootstrap_nll=0, bootstrap_seed=0, bootstrap
             "cross_covariance": result.calibration.cross_covariance.tolist(),
         },
     }
-    if "independent_kalman" in scores:
-        independent = scores["independent_kalman"]["mean_nll"]
-        out["nll_improvement_vs_independent_kalman"] = {
-            name: independent - score["mean_nll"]
-            for name, score in scores.items()
-            if name != "independent_kalman"
-        }
+    out.update(_nll_improvement_maps(result, nll_baselines))
     if result.grouped_scores:
         out["grouped_covariances"] = {
             grouped.score.name: _grouped_covariance_to_json_dict(grouped)
             for grouped in result.grouped_scores
         }
     if bootstrap_nll:
-        out["nll_improvement_bootstrap_vs_prior"] = _bootstrap_improvement_map(
+        out.update(_bootstrap_improvement_maps(
             result,
-            "prior",
+            nll_baselines,
             bootstrap_nll,
             bootstrap_seed,
             bootstrap_confidence,
-        )
-        if "independent_kalman" in scores:
-            out["nll_improvement_bootstrap_vs_independent_kalman"] = _bootstrap_improvement_map(
-                result,
-                "independent_kalman",
-                bootstrap_nll,
-                bootstrap_seed,
-                bootstrap_confidence,
-            )
+        ))
     return out
 
 
@@ -1316,6 +1371,11 @@ def _build_arg_parser():
     ap.add_argument("--jitter", type=float, default=1e-9)
     ap.add_argument("--ddof", type=int, default=1)
     ap.add_argument("--shrinkage-target", default="diagonal", choices=("diagonal", "scaled_identity"))
+    ap.add_argument(
+        "--nll-baselines",
+        default=",".join(DEFAULT_NLL_BASELINES),
+        help="comma-separated score names used as NLL-gain baselines",
+    )
     ap.add_argument("--bootstrap-nll", type=int, default=0, help="paired bootstrap replicates for NLL gains; 0 disables")
     ap.add_argument("--bootstrap-seed", type=int, default=0)
     ap.add_argument("--bootstrap-confidence", type=float, default=0.95)
@@ -1354,6 +1414,7 @@ def main(argv=None):
             bootstrap_nll=args.bootstrap_nll,
             bootstrap_seed=args.bootstrap_seed,
             bootstrap_confidence=args.bootstrap_confidence,
+            nll_baselines=_parse_name_list(args.nll_baselines),
         )
     except ValueError as exc:
         ap.error(str(exc))

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -86,12 +86,24 @@ def _score_rows(scores_json):
     return rows
 
 
+def _baseline_from_improvement_key(key):
+    prefix = "nll_improvement_vs_"
+    if key.startswith(prefix) and not key.startswith("nll_improvement_bootstrap_vs_"):
+        return key[len(prefix):]
+    return None
+
+
+def _baseline_from_bootstrap_key(key):
+    prefix = "nll_improvement_bootstrap_vs_"
+    return key[len(prefix):] if key.startswith(prefix) else None
+
+
 def _improvement_rows(scores_json):
     rows = []
-    for baseline_key, label in (
-        ("nll_improvement_vs_prior", "prior"),
-        ("nll_improvement_vs_independent_kalman", "independent_kalman"),
-    ):
+    for baseline_key in sorted(scores_json):
+        label = _baseline_from_improvement_key(baseline_key)
+        if label is None:
+            continue
         for candidate, gain in sorted(scores_json.get(baseline_key, {}).items()):
             rows.append([label, candidate, gain])
     return rows
@@ -99,10 +111,10 @@ def _improvement_rows(scores_json):
 
 def _bootstrap_rows(scores_json):
     rows = []
-    for baseline_key, label in (
-        ("nll_improvement_bootstrap_vs_prior", "prior"),
-        ("nll_improvement_bootstrap_vs_independent_kalman", "independent_kalman"),
-    ):
+    for baseline_key in sorted(scores_json):
+        label = _baseline_from_bootstrap_key(baseline_key)
+        if label is None:
+            continue
         for candidate, item in sorted(scores_json.get(baseline_key, {}).items()):
             rows.append([
                 label,
@@ -132,6 +144,7 @@ def _bootstrap_artifact_rows(scores_json):
         ["seed", artifact.get("seed")],
         ["confidence", artifact.get("confidence")],
         ["method", artifact.get("method")],
+        ["baselines", ", ".join(artifact.get("baselines", []))],
     ]
 
 
@@ -242,18 +255,42 @@ def validate_artifact_score_consistency(scores_json, evaluation_npz=None, atol=1
     return artifact
 
 
+def _parse_name_list(text):
+    names = [part.strip() for part in str(text).split(",") if part.strip()]
+    if not names:
+        raise ValueError("name list must contain at least one name")
+    if len(names) != len(set(names)):
+        raise ValueError(f"name list contains duplicates: {text!r}")
+    return tuple(names)
+
+
+def _normalize_baselines(baselines):
+    if baselines is None:
+        baselines = ("prior", "independent_kalman")
+    if isinstance(baselines, str):
+        return _parse_name_list(baselines)
+    names = tuple(str(name).strip() for name in baselines if str(name).strip())
+    if not names:
+        raise ValueError("baselines must contain at least one score name")
+    if len(names) != len(set(names)):
+        raise ValueError(f"baselines contains duplicates: {names!r}")
+    return names
+
+
 def add_artifact_bootstrap_intervals(
     scores_json,
     evaluation_npz=None,
     n_boot=0,
     seed=0,
     confidence=0.95,
+    baselines=("prior", "independent_kalman"),
     overwrite=False,
     validate_artifact=True,
 ):
     """Return `scores_json` enriched with post-hoc bootstrap intervals from row artifacts."""
     if not n_boot:
         return scores_json
+    baselines = _normalize_baselines(baselines)
     artifact_path = _artifact_path(scores_json, evaluation_npz=evaluation_npz)
     artifact_summary = evaluation_npz_score_summary(artifact_path)
     if validate_artifact:
@@ -265,6 +302,7 @@ def add_artifact_bootstrap_intervals(
         n_boot=n_boot,
         seed=seed,
         confidence=confidence,
+        baselines=baselines,
     ).items():
         if overwrite or key not in out:
             out[key] = value
@@ -279,6 +317,7 @@ def add_artifact_bootstrap_intervals(
             "seed": int(seed),
             "confidence": float(confidence),
             "method": "paired_row_resample",
+            "baselines": list(baselines),
         }
     return out
 
@@ -449,6 +488,11 @@ def _build_arg_parser():
     ap.add_argument("--title", default="Product-Kalman Holdout Report")
     ap.add_argument("--evaluation-npz", help="optional row-level evaluation artifact NPZ for post-hoc bootstrap intervals")
     ap.add_argument("--bootstrap-nll", type=int, default=0, help="paired bootstrap replicates for NLL gains; 0 disables")
+    ap.add_argument(
+        "--bootstrap-baselines",
+        default="prior,independent_kalman",
+        help="comma-separated score names used as post-hoc bootstrap baselines",
+    )
     ap.add_argument("--bootstrap-seed", type=int, default=0)
     ap.add_argument("--bootstrap-confidence", type=float, default=0.95)
     ap.add_argument("--overwrite-bootstrap", action="store_true", help="replace existing bootstrap sections in scores JSON")
@@ -467,6 +511,7 @@ def main(argv=None):
             n_boot=args.bootstrap_nll,
             seed=args.bootstrap_seed,
             confidence=args.bootstrap_confidence,
+            baselines=_parse_name_list(args.bootstrap_baselines),
             overwrite=args.overwrite_bootstrap,
         )
     except (OSError, ValueError) as exc:

--- a/prototypes/mu_cosine/product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_table_evaluation.py
@@ -178,6 +178,7 @@ def run_product_kalman_table_evaluation(
     jitter=1e-9,
     ddof=1,
     shrinkage_target="diagonal",
+    nll_baselines=("prior", "independent_kalman"),
     bootstrap_nll=0,
     bootstrap_seed=0,
     bootstrap_confidence=0.95,
@@ -215,6 +216,7 @@ def run_product_kalman_table_evaluation(
             bootstrap_nll=bootstrap_nll,
             bootstrap_seed=bootstrap_seed,
             bootstrap_confidence=bootstrap_confidence,
+            nll_baselines=nll_baselines,
         ),
         input_table,
         input_npz,
@@ -287,6 +289,11 @@ def _build_arg_parser():
     ap.add_argument("--ddof", type=int, default=1)
     ap.add_argument("--shrinkage-target", default="diagonal", choices=("diagonal", "scaled_identity"))
     ap.add_argument(
+        "--nll-baselines",
+        default="prior,independent_kalman",
+        help="comma-separated score names used as NLL-gain baselines",
+    )
+    ap.add_argument(
         "--bootstrap-nll",
         type=int,
         default=0,
@@ -346,6 +353,7 @@ def main(argv=None):
             jitter=args.jitter,
             ddof=args.ddof,
             shrinkage_target=args.shrinkage_target,
+            nll_baselines=parse_column_list(args.nll_baselines),
             bootstrap_nll=args.bootstrap_nll,
             bootstrap_seed=args.bootstrap_seed,
             bootstrap_confidence=args.bootstrap_confidence,

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -196,6 +196,7 @@ def test_npz_runner_and_json_cli_roundtrip():
             bootstrap_confidence=0.90,
         )
         assert data["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
+        assert data["nll_baselines"] == ["prior", "independent_kalman"]
         assert data["calibration"]["state_dim"] == 1
         assert "mean_squared_mahalanobis" in data["scores"]["product_kalman"]
         assert "squared_mahalanobis_q95" in data["scores"]["product_kalman"]
@@ -223,12 +224,17 @@ def test_npz_runner_and_json_cli_roundtrip():
             "3",
             "--bootstrap-confidence",
             "0.90",
+            "--nll-baselines",
+            "prior,independent_kalman,product_kalman",
             "--indent",
             "0",
         ])
         assert rc == 0
         from_cli = json.loads(output_path.read_text())
         assert from_cli["score_order"] == data["score_order"]
+        assert from_cli["nll_baselines"] == ["prior", "independent_kalman", "product_kalman"]
+        assert "nll_improvement_vs_product_kalman" in from_cli
+        assert "nll_improvement_bootstrap_vs_product_kalman" in from_cli
         assert abs(
             from_cli["scores"]["product_kalman"]["mean_nll"]
             - data["scores"]["product_kalman"]["mean_nll"]
@@ -338,6 +344,7 @@ def test_npz_runner_scores_grouped_covariances_when_group_labels_present():
             evaluation_groups=eval_groups,
         )
         result = run_product_kalman_holdout_npz(input_path, min_group_rows=50, jitter=1e-8)
+        assert_raises(evaluation_to_json_dict, result, nll_baselines=["missing_baseline"])
         assert [grouped.score.name for grouped in result.grouped_scores] == [
             "prior_grouped",
             "measurement_grouped",
@@ -349,13 +356,20 @@ def test_npz_runner_scores_grouped_covariances_when_group_labels_present():
         assert result.score("prior_grouped").mean_nll < result.score("prior").mean_nll
         assert result.score("product_kalman_grouped").mean_nll < result.score("product_kalman").mean_nll
 
-        data = evaluation_to_json_dict(result, bootstrap_nll=20, bootstrap_seed=4)
+        data = evaluation_to_json_dict(
+            result,
+            bootstrap_nll=20,
+            bootstrap_seed=4,
+            nll_baselines=("prior", "independent_kalman", "product_kalman"),
+        )
         assert data["score_order"][-1] == "product_kalman_grouped"
         grouped = data["grouped_covariances"]["product_kalman_grouped"]
         assert grouped["min_group_rows"] == 50
         assert grouped["group_counts"] == {"tight": n_cal_per_group, "wide": n_cal_per_group}
         assert grouped["row_covariance_shape"] == [n_eval, 1, 1]
+        assert data["nll_improvement_vs_product_kalman"]["product_kalman_grouped"] > 0.0
         assert "product_kalman_grouped" in data["nll_improvement_bootstrap_vs_independent_kalman"]
+        assert "product_kalman_grouped" in data["nll_improvement_bootstrap_vs_product_kalman"]
 
         write_evaluation_npz(artifact_path, result)
         with np.load(artifact_path, allow_pickle=False) as artifact:

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -81,6 +81,7 @@ def make_artifacts(tmp, bootstrap_nll=50):
         input_manifest=input_manifest,
         output_json=scores_json,
         output_npz=eval_npz,
+        nll_baselines=["prior", "independent_kalman", "product_kalman"],
         jitter=1e-8,
         **kwargs,
     )
@@ -130,6 +131,7 @@ def test_markdown_report_records_scores_and_guardrails():
         assert "mean_sq_mahalanobis" in report
         assert "sq_mahalanobis_q95" in report
         assert "| prior | product_kalman |" in report
+        assert "| product_kalman | independent_kalman |" in report
         assert "## NLL Improvement Bootstrap Intervals" in report
         assert "observed_gain" in report
         assert "paired row-resampling" in report
@@ -174,6 +176,7 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
             n_boot=50,
             seed=7,
             confidence=0.90,
+            baselines=("prior", "independent_kalman", "product_kalman"),
         )
         artifact_summary = validate_artifact_score_consistency(scores, evaluation_npz=eval_npz)
         assert artifact_summary["score_order"] == scores["score_order"]
@@ -182,6 +185,7 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
             n_boot=50,
             seed=7,
             confidence=0.90,
+            baselines=("prior", "independent_kalman", "product_kalman"),
         )
         assert "nll_improvement_bootstrap_vs_prior" in recorded_path_enriched
         artifact_meta = enriched["bootstrap_artifact"]
@@ -191,6 +195,8 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
         assert artifact_meta["score_order"] == scores["score_order"]
         assert artifact_meta["n_boot"] == 50
         assert artifact_meta["method"] == "paired_row_resample"
+        assert artifact_meta["baselines"] == ["prior", "independent_kalman", "product_kalman"]
+        assert "nll_improvement_bootstrap_vs_product_kalman" in enriched
 
         bad_order = dict(scores)
         bad_order["score_order"] = list(reversed(scores["score_order"]))
@@ -217,6 +223,8 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
             "7",
             "--bootstrap-confidence",
             "0.90",
+            "--bootstrap-baselines",
+            "prior,independent_kalman,product_kalman",
             "--output-md",
             str(output_md),
             "--output-json",
@@ -228,8 +236,10 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
         assert "## Bootstrap Artifact" in text
         assert "evaluation_npz_sha256" in text
         assert "| independent_kalman | product_kalman |" in text
+        assert "| product_kalman | independent_kalman |" in text
         enriched_json = json.loads(output_json.read_text())
         assert enriched_json["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"] == boot
+        assert "nll_improvement_bootstrap_vs_product_kalman" in enriched_json
         assert enriched_json["bootstrap_artifact"] == artifact_meta
 
 

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -96,6 +96,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
             output_md=output_md,
             report_title="Synthetic Table Product-Kalman Report",
             group_cols=["hop"],
+            nll_baselines=["prior", "independent_kalman", "product_kalman"],
             jitter=1e-8,
             bootstrap_nll=50,
             bootstrap_seed=7,
@@ -119,6 +120,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert summary["inputs"]["input_manifest"] == str(input_manifest)
         assert summary["inputs"]["evaluation_npz"] == str(output_npz)
         assert summary["inputs"]["report_md"] == str(output_md)
+        assert summary["nll_baselines"] == ["prior", "independent_kalman", "product_kalman"]
         assert summary["score_order"] == [
             "prior",
             "measurement",
@@ -132,6 +134,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert "mahalanobis_per_dim" in summary["scores"]["product_kalman"]
         assert "squared_mahalanobis_q95" in summary["scores"]["product_kalman"]
         assert "product_kalman_grouped" in summary["grouped_covariances"]
+        assert "product_kalman_grouped" in summary["nll_improvement_vs_product_kalman"]
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
         boot = summary["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"]
         assert boot["n_boot"] == 50
@@ -189,6 +192,8 @@ def test_table_runner_output_dir_writes_canonical_bundle():
             "target",
             "--group-cols",
             "hop",
+            "--nll-baselines",
+            "prior,independent_kalman,product_kalman",
             "--jitter",
             "1e-8",
             "--indent",
@@ -205,8 +210,10 @@ def test_table_runner_output_dir_writes_canonical_bundle():
         assert summary["inputs"]["evaluation_npz"] == str(paths["output_npz"])
         assert summary["inputs"]["report_md"] == str(paths["output_md"])
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
+        assert summary["nll_baselines"] == ["prior", "independent_kalman", "product_kalman"]
         assert "product_kalman_grouped" in summary["score_order"]
         assert "product_kalman_grouped" in summary["grouped_covariances"]
+        assert "product_kalman_grouped" in summary["nll_improvement_vs_product_kalman"]
         with np.load(paths["input_npz"], allow_pickle=False) as data:
             assert data["calibration_groups"].shape == (80,)
             assert data["evaluation_groups"].shape == (40,)
@@ -337,6 +344,8 @@ def test_table_runner_cli_roundtrips_against_npz_evaluator():
             "target",
             "--group-cols",
             "hop",
+            "--nll-baselines",
+            "prior,independent_kalman,product_kalman",
             "--jitter",
             "1e-8",
             "--indent",
@@ -356,8 +365,10 @@ def test_table_runner_cli_roundtrips_against_npz_evaluator():
         assert manifest["source_table"]["delimiter"] == "\t"
         assert manifest["ids"]["overlap_count"] == 0
         assert manifest["groups"]["columns"] == ["hop"]
+        assert from_table["nll_baselines"] == ["prior", "independent_kalman", "product_kalman"]
         assert "product_kalman_grouped" in from_table["score_order"]
         assert "product_kalman_grouped" in from_table["grouped_covariances"]
+        assert "product_kalman_grouped" in from_table["nll_improvement_vs_product_kalman"]
         assert from_table["inputs"]["report_md"] == str(output_md)
 
 


### PR DESCRIPTION
Re-lands the configurable Product-Kalman NLL/bootstrap baseline plumbing on the latest `main`.

Changes:
- Add configurable NLL baselines to evaluator and table-evaluation output.
- Add configurable bootstrap baselines to report enrichment.
- Record `nll_baselines` in JSON artifacts.
- Generalize report tables for arbitrary `nll_improvement_vs_*` and bootstrap keys.
- Enable direct grouped-vs-ungrouped Product-Kalman comparisons using `product_kalman` as a baseline.
- Update tests and design notes for the configurable baseline workflow.

Verification:
- `python3 -m py_compile ...`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `git diff --check origin/main...HEAD`