### PR TITLE
WAM/LLVM (roadmap #5, milestone 6): THE FRONT — grouping, labels, and chains self-compiled

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -416,15 +416,20 @@ loadable along the way.
   the production compiler's bytes exactly on an arithmetic clause
   (checksum 8755). The reader gained quoted functor applications, and the
   `'$VAR'` marker clauses now guard on integer arguments so source-level
-  `'$VAR'` patterns compile as ordinary structures. The remaining
-  campaign extends this toward `compile(SelfSource)` — the full fixpoint.
+  `'$VAR'` patterns compile as ordinary structures. **THE FRONT LANDED** —
+  clause grouping, labels, and try/retry/trust chain building
+  self-compiled; the doubly-compiled compiler compiled a multi-predicate
+  program (facts, a two-clause chain, a predicate call, constants,
+  arithmetic) byte-identically to the production cgfull (checksum
+  13679). The remaining campaign extends this toward
+  `compile(SelfSource)` — the full fixpoint.
   The compile budget for the full self-compile is closed: the **chained
   arena** removed the memory cliff (blocks link on exhaustion and never
   move; marks are virtual offsets so mark/rewind work across growth), and
   the serializer's **difference-list linearisation** removed the quadratic
   time/allocation (an 11.9 KB source compiles loaded in 40 ms / 35 MB where
   the quadratic style took 20 s / 3.7 GB at half that size).
-  The campaign keeps surfacing and fixing latent runtime bugs — **ten found
+  The campaign keeps surfacing and fixing latent runtime bugs — **eleven found
   so far**: a 64-register-file ceiling corrupting memory for large clauses;
   `get_structure` not comparing the functor; the choice-point saved-register
   block not widened with the register file (failed clause bodies leaked Y17+
@@ -443,7 +448,10 @@ loadable along the way.
   `@wam_deref_keep_var`; and an uncaught throw behaving as a plain failure
   (`@backtrack` resumed into live choice points over the half-unwound
   state, spinning inside append on corrupted terms) — fixed with an
-  explicit abort flag checked at backtrack entry. See
+  explicit abort flag checked at backtrack entry; and the reader
+  var-dict silently falling back to fresh-per-occurrence variables past
+  128 distinct names (the self-hosted compiler miscompiled its own
+  serializer) — fixed with a growable dict. See
   [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md).
 
 ## The binary-return question, specifically

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -680,15 +680,47 @@ Getting there surfaced three more items:
   ambiguity — a literal `'$VAR'(3)` in user source is still read as a
   marker — is inherent to the numbervars encoding and documented here.
 
-**Remaining toward the full fixpoint:** the serializer, a mini-compiler
-front end, and the single-clause codegen middle are now self-compiled.
-What is left of cgfull: the clause grouping/label front (`group_clauses`,
-`group_labels`, try/retry/trust chains), the general table walk
-(`collect_tables`), the structure-pattern and list codegen (u_seq/s_seq
-deferral), ITE codegen, and the builtin/comparison goal dispatch — plus
-stitching those into one `compile(SelfSource)`. The compile budget —
-memory (chained arena) and time (difference lists) — is solved, and the
-`'$VAR'` convention now permits the walkers themselves to be compiled.
+**THE FRONT LANDED — the compiler compiles its clause-grouping and chains.**
+The loaded cgfull compiled `fixpoint_front_source/1`: the middle plus
+cgfull's whole front restated cut-free — facts vs rules (`mhb` tags facts
+with body `true`), the generic table walk mirroring
+`collect_tables`/`walk_term` (var/nil/integer/atom/compound dispatch with
+the control-functor skip list), `group_clauses`/`take_same`,
+`group_labels` + label lookup, and the `try_me_else`/`retry_me_else`/
+`trust_me` chain builders with PC threading and Label-PC pair collection
+(`keysort` + `pairs_values` close the PC table exactly like cgfull), plus
+integer/atom head constants, predicate-call goals, and `=/2` goals. The
+doubly-compiled compiler compiled a **multi-predicate program** — a rule
+with arithmetic, a rule calling it, and a two-clause fact predicate with
+a try/trust chain — **byte-identically to the production cgfull**
+(checksum 13679). Test `selfhost_codegen_stage_d_front`.
+
+*Runtime finding (campaign no. 11):* compiling the front source tripped
+the **reader variable-dictionary cap**. The var-dict was a fixed
+128-name block; past it, `wam_var_ref` fell back to a FRESH heap cell
+per occurrence — repeated occurrences of the same variable name in later
+clauses silently stopped sharing. The self-hosted compiler thus
+**miscompiled its own serializer**: in `wzr`, the second occurrence of
+the codes list variable became a fresh unbound, `append` copied nothing,
+and every emitted instruction lost its opcode digits (the object stayed
+structurally plausible — headers, tables, and PC rows intact — which
+made the corruption look like a serializer bug rather than a reader
+bug; the emitted-object diff of two near-identical sources pinned it:
+`put_value Y54` in the good compile vs `put_variable Y55` in the bad
+one). Fixed by making the dict growable (`[count][cap][pairs…]`,
+doubling; entries are plain ids/addresses so relocating the block is
+safe). Regression `reader_var_dict_grows_past_128` (130 names, repeated
+variable in the last clause).
+
+**Remaining toward the full fixpoint:** the serializer, the single-clause
+codegen middle, and now the grouping/label/chain front and generic table
+walk are all self-compiled. What is left of cgfull: the
+structure-pattern and list codegen (u_seq/s_seq deferral both
+directions), ITE codegen, the builtin/comparison goal dispatch (the
+whitelist table), and stitching everything into one
+`compile(SelfSource)` whose accepted subset covers its own source. The
+compile budget is solved, the `'$VAR'` convention permits the walkers to
+be compiled, and the front slice proves the chain builders compile.
 
 **Deliverable:** the demonstrable self-host — the compiler compiles itself,
 and `compile(SelfSource)` yields a working compiler object.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -6941,23 +6941,35 @@ pfail:
 ; floats, variables or quoting yet -- follow-up increments.
 ; Resolve a named variable to a Ref, using the reader var-dict on the VM (field
 ; 27) so repeated occurrences of the same name within one term share a cell.
-; The dict block is [count:i64][ (atom_id:i64, heap_addr:i64) x N ]. A miss (or
-; a full/absent dict) pushes a fresh unbound heap cell. Anonymous "_" is handled
-; by the caller (always fresh, never recorded).
+; The dict block is [count:i64][cap:i64][ (atom_id:i64, heap_addr:i64) x cap ].
+; A miss pushes a fresh unbound heap cell and records it; a FULL dict GROWS
+; (doubling; entries are plain ids/addresses, so relocating the block is
+; safe). Campaign finding no. 11: the old fixed 128-name cap fell back to
+; a FRESH variable per occurrence once the source exceeded 128 distinct
+; names -- repeated occurrences of the same variable in later clauses
+; silently stopped sharing, and the self-hosted compiler MISCOMPILED its
+; own serializer (append received a fresh unbound instead of the bound
+; code list; every emitted instruction lost its opcode digits). An absent
+; dict still yields a fresh cell. Anonymous "_" is handled by the caller
+; (always fresh, never recorded).
 define %Value @wam_var_ref(%WamState* %vm, i64 %atom_id) {
 entry:
   %dp = getelementptr %WamState, %WamState* %vm, i32 0, i32 27
+  %dict0 = load i8*, i8** %dp
+  %dnull = icmp eq i8* %dict0, null
+  br i1 %dnull, label %fresh, label %reload
+reload:
   %dict = load i8*, i8** %dp
-  %dnull = icmp eq i8* %dict, null
-  br i1 %dnull, label %fresh, label %have_dict
-have_dict:
   %cntp = bitcast i8* %dict to i64*
   %cnt = load i64, i64* %cntp
-  %ebase = getelementptr i8, i8* %dict, i64 8
+  %capbp = getelementptr i8, i8* %dict, i64 8
+  %capp = bitcast i8* %capbp to i64*
+  %cap = load i64, i64* %capp
+  %ebase = getelementptr i8, i8* %dict, i64 16
   %entries = bitcast i8* %ebase to i64*
   br label %scan
 scan:
-  %i = phi i64 [ 0, %have_dict ], [ %i1, %scan_next ]
+  %i = phi i64 [ 0, %reload ], [ %i1, %scan_next ]
   %done = icmp uge i64 %i, %cnt
   br i1 %done, label %add, label %check
 check:
@@ -6977,8 +6989,21 @@ scan_next:
   %i1 = add i64 %i, 1
   br label %scan
 add:
-  %full = icmp uge i64 %cnt, 128
-  br i1 %full, label %fresh, label %record
+  %full = icmp uge i64 %cnt, %cap
+  br i1 %full, label %grow, label %record
+grow:
+  %newcap = mul i64 %cap, 2
+  %pairbytes = mul i64 %newcap, 16
+  %newsz = add i64 %pairbytes, 16
+  %nd = call i8* @wam_arena_alloc(i64 %newsz)
+  %oldbytes0 = mul i64 %cnt, 16
+  %oldbytes = add i64 %oldbytes0, 16
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %nd, i8* %dict, i64 %oldbytes, i1 false)
+  %ncapbp = getelementptr i8, i8* %nd, i64 8
+  %ncapp = bitcast i8* %ncapbp to i64*
+  store i64 %newcap, i64* %ncapp
+  store i8* %nd, i8** %dp
+  br label %reload
 record:
   %runb = call %Value @value_unbound(i8* null)
   %raddr = call i32 @wam_heap_push(%WamState* %vm, %Value %runb)
@@ -17026,11 +17051,15 @@ rta.parse:
   %rta.len = call i64 @strlen(i8* %rta.str)
   %rta.pos = alloca i64
   store i64 0, i64* %rta.pos
-  ; Install a fresh var-dict on the VM: [count:i64][128 x (atom_id, addr)].
+  ; Install a fresh var-dict on the VM: [count:i64][cap:i64][cap pairs].
+  ; Initial capacity 128 names; @wam_var_ref grows it by doubling.
   call void @wam_arena_ensure()
-  %rta.dict = call i8* @wam_arena_alloc(i64 2056)
+  %rta.dict = call i8* @wam_arena_alloc(i64 2064)
   %rta.dcntp = bitcast i8* %rta.dict to i64*
   store i64 0, i64* %rta.dcntp
+  %rta.dcapb = getelementptr i8, i8* %rta.dict, i64 8
+  %rta.dcapp = bitcast i8* %rta.dcapb to i64*
+  store i64 128, i64* %rta.dcapp
   %rta.vdp = getelementptr %WamState, %WamState* %vm, i32 0, i32 27
   store i8* %rta.dict, i8** %rta.vdp
   %rta.val = call %Value @wam_parse_expr(%WamState* %vm, i8* %rta.str, i64 %rta.len, i64* %rta.pos, i32 1200)

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -1006,6 +1006,24 @@ fixpoint_compiler_source('[(main0(R) :- cmp2(''ea(R2) :- R2 = 42'', Cs1), cmp2('
 % dispatch is an ITE -- no cuts anywhere.
 fixpoint_middle_source('[(main0(R) :- cm2(''sum3(A, B, R2) :- T is A + B, R2 is T + 1'', Cs), sum_list(Cs, S), length(Cs, L), R is S + L), (cm2(Src, Out) :- read_term_from_atom(Src, C0), copy_term(C0, C1), numbervars(C1, 0, _), C1 =.. [_, H, B], mgl(B, Gs), functor(H, P, Ar), madd(P, [], FT0), mcol(Gs, FT0, FT), mname(P, Ar, NC), mhead(1, Ar, H, [], In1, HIs), mgoals(Gs, FT, In1, _, GIs), append(HIs, GIs, Body), append([enc(16, 0, 0, 0)|Body], [enc(17, 0, 0, 0), enc(20, 0, 0, 0)], Is), wzs(0, NC, 0, [], FT, [0], Is, Out)), (mgl(G, L) :- (G =.. [F, X, Y], F == '','' -> mgl(X, L1), mgl(Y, L2), append(L1, L2, L) ; L = [G])), mcol([], A, A), (mcol([G|Gs], A0, A2) :- (G =.. [F, _, E], F == is, functor(E, Op, 2) -> madd(Op, A0, A1) ; A1 = A0), mcol(Gs, A1, A2)), (madd(Op, A0, A1) :- (memberchk(Op, A0) -> A1 = A0 ; append(A0, [Op], A1))), (mname(P, Ar, NC) :- atom_codes(P, PC), number_codes(Ar, AC), append(PC, [47|AC], NC)), (mhead(I, Ar, H, In0, In, Is) :- (I > Ar -> In = In0, Is = [] ; arg(I, H, A), mharg(A, I, In0, In1, AI), I1 is I + 1, mhead(I1, Ar, H, In1, In, RIs), append(AI, RIs, Is))), (mharg(''$VAR''(N), I, In0, In1, [enc(T, Y, Ai, 0)]) :- Y is 48 + N, Ai is I - 1, (memberchk(N, In0) -> T = 2, In1 = In0 ; T = 1, In1 = [N|In0])), mgoals([], _, In, In, []), (mgoals([G|Gs], FT, In0, In, Is) :- mgoal(G, FT, In0, In1, GI), mgoals(Gs, FT, In1, In, RI), append(GI, RI, Is)), (mgoal(G, FT, In0, In2, Is) :- G =.. [_, L, E], mop(L, 0, In0, In1, IL), mexpr(E, FT, In1, In2, IE), append(IL, IE, LE), append(LE, [enc(21, 0, 2, 0)], Is)), (mop(''$VAR''(N), Ai, In0, In1, [enc(T, Y, Ai, 0)]) :- Y is 48 + N, (memberchk(N, In0) -> T = 10, In1 = In0 ; T = 9, In1 = [N|In0])), (mexpr(E, FT, In0, In1, Is) :- functor(E, Op, 2), fidx(Op, FT, FI), arg(1, E, X), arg(2, E, Y), mset(X, In0, Ina, SX), mset(Y, Ina, In1, SY), append([enc(11, FI, 131073, 2)|SX], SY, Is)), (mset(''$VAR''(N), In0, In1, [enc(T, Y, 0, 0)]) :- Y is 48 + N, (memberchk(N, In0) -> T = 14, In1 = In0 ; T = 13, In1 = [N|In0])), (mset(V, In, In, [enc(15, V, 1, 0)]) :- integer(V)), (fidx(Op, [F|Fs], I) :- (Op == F -> I = 0 ; fidx(Op, Fs, I1), I is I1 + 1)), (wzi(N, A0, A1) :- number_codes(N, Cs), append(Cs, [10|A1], A0)), (wza(X, A0, A1) :- atom_codes(X, Cs), append(Cs, [10|A1], A0)), (wzn(Cs, A0, A1) :- length(Cs, L), number_codes(L, LC), append(LC, [32|Mid], A0), append(Cs, [10|A1], Mid)), (wzsi(N, A0, A1) :- number_codes(N, Cs), append([32|Cs], A1, A0)), (wzs(EI, NC, LI, As, Fs, PCs, Is, Out) :- wzh(EI, NC, LI, Out, A6), length(As, NA), wzi(NA, A6, A7), wzat(As, A7, A8), length(Fs, NF), wzi(NF, A8, A9), wzat(Fs, A9, A10), wzp(PCs, A10, A11), wzc(Is, A11, A12), wzi(0, A12, [])), (wzh(EI, NC, LI, A0, Out) :- wza(''WAMO'', A0, A1), wzi(2, A1, A2), wzi(EI, A2, A3), wzi(1, A3, A4), wzn(NC, A4, A5), wzi(LI, A5, Out)), wzat([], A, A), (wzat([X|Xs], A0, A2) :- atom_codes(X, Cs), wzn(Cs, A0, A1), wzat(Xs, A1, A2)), (wzp(PCs, A0, A2) :- length(PCs, NL), wzi(NL, A0, A1), wzpr(PCs, A1, A2)), wzpr([], A, A), (wzpr([P|Ps], A0, A2) :- wzi(P, A0, A1), wzpr(Ps, A1, A2)), (wzc(Is, A0, A2) :- length(Is, NC2), wzi(NC2, A0, A1), wzcr(Is, A1, A2)), wzcr([], A, A), (wzcr([enc(T,O1,O2,Rl)|Is], A0, A2) :- wzr(T, O1, O2, Rl, A0, A1), wzcr(Is, A1, A2)), (wzr(T, O1, O2, Rl, A0, A5) :- number_codes(T, Tc), append(Tc, A1, A0), wzsi(O1, A1, A2), wzsi(O2, A2, A3), wzsi(Rl, A3, A4), A4 = [10|A5])]').
 
+% The FRONT source (fixpoint, next slice): cgfull's clause-grouping,
+% label, and chain machinery restated cut-free, on top of the middle.
+% New over fixpoint_middle_source: facts vs rules (mhb tags facts with
+% body atom true), the GENERIC table walk mwt/mwl mirroring
+% collect_tables/walk_term (var/nil/integer/atom/compound dispatch with
+% the control-functor skip list), group_clauses/take_same (mgrp/mtks),
+% group_labels + label lookup (mlbl/mlook), the try_me_else /
+% retry_me_else / trust_me chain builders with PC threading and
+% Label-PC pair collection (mggs/mprd/malt -- keysort + pairs_values
+% close the PC table exactly like cgfull), integer/atom head constants,
+% predicate-call goals (mlook + call), and =/2 goals. The serializer
+% emits BOTH tables. Compiling THIS source is also the regression that
+% found the reader var-dict cap (campaign finding no. 11): it has more
+% than 128 distinct variable names, so before the growable dict the
+% later clauses (the wz chain) silently lost variable sharing and the
+% doubly-compiled serializer dropped every instruction opcode.
+fixpoint_front_source('[(main0(R) :- cm3(''[(dbl(X, Y) :- Y is X + X), (tst(R2) :- dbl(4, R2)), pick(1, a), pick(2, b)]'', Cs), sum_list(Cs, S), length(Cs, L), R is S + L), (cm3(Src, Out) :- read_term_from_atom(Src, Cls), mwl(Cls, [], [], At, FT), mgrp(Cls, Gs), mlbl(Gs, 0, PL), length(Gs, NP0), mggs(Gs, PL, At, FT, 0, NP0, AllIs, EPCs, Prs), keysort(Prs, SPrs), pairs_values(SPrs, XPCs), append(EPCs, XPCs, PCs), Cls = [C1|_], mhb(C1, H1, _), functor(H1, P1, A1), mname(P1, A1, NC), wzs(0, NC, 0, At, FT, PCs, AllIs, Out)), (mhb(C, H, B) :- (C =.. [F, X, Y], F == '':-'' -> H = X, B = Y ; H = C, B = true)), mwl([], A, F, A, F), (mwl([T|Ts], A0, F0, A, F) :- mwt(T, A0, F0, A1, F1), mwl(Ts, A1, F1, A, F)), (mwt(T, A0, F0, A, F) :- (var(T) -> A = A0, F = F0 ; T == [] -> madd(''[]'', A0, A1), A = A1, F = F0 ; integer(T) -> A = A0, F = F0 ; atom(T) -> madd(T, A0, A1), A = A1, F = F0 ; T =.. [Fn|Args], mwf(Fn, F0, F1), mwl(Args, A0, F1, A, F))), (mwf(Fn, F0, F1) :- (mskip(Fn) -> F1 = F0 ; madd(Fn, F0, F1))), (mskip(F) :- memberchk(F, ['':-'', '','', '';'', ''->'', ''is'', ''='', ''>'', ''<'', ''>='', ''=<'', ''=:='', ''=\\='', ''=='', ''\\==''])), (madd(X, L0, L1) :- (memberchk(X, L0) -> L1 = L0 ; append(L0, [X], L1))), mgrp([], []), (mgrp([C|Cs], [g(P, Ar, [C|Same])|Gs]) :- mhb(C, H, _), functor(H, P, Ar), mtks(Cs, P, Ar, Same, Rest), mgrp(Rest, Gs)), mtks([], _, _, [], []), (mtks([C|Cs], P, Ar, Same, Rest) :- mhb(C, H, _), functor(H, P2, A2), (P2 == P, A2 =:= Ar -> Same = [C|S1], mtks(Cs, P, Ar, S1, Rest) ; Same = [], Rest = [C|Cs])), mlbl([], _, []), (mlbl([g(P, Ar, _)|Gs], I, [pl(P, Ar, I)|R]) :- I1 is I + 1, mlbl(Gs, I1, R)), (mlook(P, Ar, [pl(P2, A2, L2)|Ps], L) :- (P == P2, Ar =:= A2 -> L = L2 ; mlook(P, Ar, Ps, L))), mggs([], _, _, _, _, _, [], [], []), (mggs([g(_, _, Cls)|Gs], PL, At, FT, PC, NPin, AllIs, [PC|EPCs], Prs) :- mprd(Cls, PL, At, FT, PC, NPin, Is, PC1, L1, Prs1), mggs(Gs, PL, At, FT, PC1, L1, RestIs, EPCs, Prs2), append(Is, RestIs, AllIs), append(Prs1, Prs2, Prs)), (mprd([C], PL, At, FT, PC, L0, Is, PCout, L, Prs) :- mone(C, PL, At, FT, PC, L0, L, Prs, Is), length(Is, N), PCout is PC + N), (mprd([C1, C2|Rest], PL, At, FT, PC, L0, Is, PCout, L, Prs) :- ChainL = L0, L1 is L0 + 1, PCc is PC + 1, mone(C1, PL, At, FT, PCc, L1, L2, Prs1, C1Is), length(C1Is, N1), PC1 is PCc + N1, malt([C2|Rest], PL, At, FT, PC1, ChainL, L2, AltIs, PCout, L, Prs2), append(Prs1, Prs2, Prs), append([enc(22, ChainL, 0, 0)|C1Is], AltIs, Is)), (malt([C], PL, At, FT, PC, MyL, L0, Is, PCout, L, [MyL-PC|Prs]) :- PCc is PC + 1, mone(C, PL, At, FT, PCc, L0, L, Prs, CIs), Is = [enc(24, 0, 0, 0)|CIs], length(Is, N), PCout is PC + N), (malt([C1, C2|Rest], PL, At, FT, PC, MyL, L0, Is, PCout, L, Prs) :- NextL = L0, L1 is L0 + 1, PCc is PC + 1, mone(C1, PL, At, FT, PCc, L1, L2, Prs1, C1Is), length(C1Is, N1), PC1 is PCc + N1, malt([C2|Rest], PL, At, FT, PC1, NextL, L2, RestIs, PCout, L, Prs2), append([MyL-PC|Prs1], Prs2, Prs), append([enc(23, NextL, 0, 0)|C1Is], RestIs, Is)), (mone(C, PL, At, FT, _, L0, L, Prs, Is) :- copy_term(C, C2), numbervars(C2, 0, _), mhb(C2, H, B), functor(H, _, Ar), mhead(1, Ar, H, At, [], In1, HIs), L = L0, Prs = [], (B == true -> append(HIs, [enc(20, 0, 0, 0)], Is) ; mgl(B, Gs), mgoals(Gs, PL, At, FT, In1, _, GIs), append([enc(16, 0, 0, 0)|HIs], GIs, B0), append(B0, [enc(17, 0, 0, 0), enc(20, 0, 0, 0)], Is))), (mgl(G, L) :- (G =.. [F, X, Y], F == '','' -> mgl(X, L1), mgl(Y, L2), append(L1, L2, L) ; L = [G])), (mhead(I, Ar, H, At, In0, In, Is) :- (I > Ar -> In = In0, Is = [] ; arg(I, H, A), mharg(A, I, At, In0, In1, AI), I1 is I + 1, mhead(I1, Ar, H, At, In1, In, RIs), append(AI, RIs, Is))), (mharg(''$VAR''(N), I, _, In0, In1, [enc(T, Y, Ai, 0)]) :- Y is 48 + N, Ai is I - 1, (memberchk(N, In0) -> T = 2, In1 = In0 ; T = 1, In1 = [N|In0])), (mharg(V, I, _, In, In, [enc(0, V, O2, 0)]) :- integer(V), O2 is 65536 + I - 1), (mharg(A2, I, At, In, In, [enc(0, Idx, Ai, 1)]) :- atom(A2), Ai is I - 1, fidx(A2, At, Idx)), mgoals([], _, _, _, In, In, []), (mgoals([G|Gs], PL, At, FT, In0, In, Is) :- mgoal(G, PL, At, FT, In0, In1, GI), mgoals(Gs, PL, At, FT, In1, In, RI), append(GI, RI, Is)), (mgoal(G, PL, At, FT, In0, In2, Is) :- (G =.. [F, L1a, E1], F == is -> mopd(L1a, 0, At, In0, In1, IL), mexpr(E1, FT, In1, In2, IE), append(IL, IE, LE), append(LE, [enc(21, 0, 2, 0)], Is) ; G =.. [F2, L2a, R2a], F2 == ''='' -> mopd(L2a, 0, At, In0, Inb, IL2), mopd(R2a, 1, At, Inb, In2, IR2), append(IL2, IR2, LR), append(LR, [enc(21, 24, 2, 0)], Is) ; functor(G, P, Ar), mlook(P, Ar, PL, Lbl), mcargs(1, Ar, G, At, In0, In2, SIs), append(SIs, [enc(18, Lbl, Ar, 0)], Is))), (mcargs(I, Ar, G, At, In0, In, Is) :- (I > Ar -> In = In0, Is = [] ; arg(I, G, A), Ai is I - 1, mopd(A, Ai, At, In0, In1, AI), I1 is I + 1, mcargs(I1, Ar, G, At, In1, In, R), append(AI, R, Is))), (mopd(''$VAR''(N), Ai, _, In0, In1, [enc(T, Y, Ai, 0)]) :- Y is 48 + N, (memberchk(N, In0) -> T = 10, In1 = In0 ; T = 9, In1 = [N|In0])), (mopd(V, Ai, _, In, In, [enc(8, V, O2, 0)]) :- integer(V), O2 is 65536 + Ai), (mopd(A2, Ai, At, In, In, [enc(8, Idx, Ai, 1)]) :- atom(A2), fidx(A2, At, Idx)), (mexpr(E, FT, In0, In1, Is) :- functor(E, Op, 2), fidx(Op, FT, FI), arg(1, E, X), arg(2, E, Y), mset(X, In0, Ina, SX), mset(Y, Ina, In1, SY), append([enc(11, FI, 131073, 2)|SX], SY, Is)), (mset(''$VAR''(N), In0, In1, [enc(T, Y, 0, 0)]) :- Y is 48 + N, (memberchk(N, In0) -> T = 14, In1 = In0 ; T = 13, In1 = [N|In0])), (mset(V, In, In, [enc(15, V, 1, 0)]) :- integer(V)), (fidx(Op, [F|Fs], I) :- (Op == F -> I = 0 ; fidx(Op, Fs, I1), I is I1 + 1)), (mname(P, Ar, NC) :- atom_codes(P, PC), number_codes(Ar, AC), append(PC, [47|AC], NC)), (wzi(N, A0, A1) :- number_codes(N, Cs), append(Cs, [10|A1], A0)), (wza(X, A0, A1) :- atom_codes(X, Cs), append(Cs, [10|A1], A0)), (wzn(Cs, A0, A1) :- length(Cs, L), number_codes(L, LC), append(LC, [32|Mid], A0), append(Cs, [10|A1], Mid)), (wzsi(N, A0, A1) :- number_codes(N, Cs), append([32|Cs], A1, A0)), (wzs(EI, NC, LI, As, Fs, PCs, Is, Out) :- wzh(EI, NC, LI, Out, A6), length(As, NA), wzi(NA, A6, A7), wzat(As, A7, A8), length(Fs, NF), wzi(NF, A8, A9), wzat(Fs, A9, A10), wzp(PCs, A10, A11), wzc(Is, A11, A12), wzi(0, A12, [])), (wzh(EI, NC, LI, A0, Out) :- wza(''WAMO'', A0, A1), wzi(2, A1, A2), wzi(EI, A2, A3), wzi(1, A3, A4), wzn(NC, A4, A5), wzi(LI, A5, Out)), wzat([], A, A), (wzat([X|Xs], A0, A2) :- atom_codes(X, Cs), wzn(Cs, A0, A1), wzat(Xs, A1, A2)), (wzp(PCs, A0, A2) :- length(PCs, NL), wzi(NL, A0, A1), wzpr(PCs, A1, A2)), wzpr([], A, A), (wzpr([P|Ps], A0, A2) :- wzi(P, A0, A1), wzpr(Ps, A1, A2)), (wzc(Is, A0, A2) :- length(Is, NC2), wzi(NC2, A0, A1), wzcr(Is, A1, A2)), wzcr([], A, A), (wzcr([enc(T,O1,O2,Rl)|Is], A0, A2) :- wzr(T, O1, O2, Rl, A0, A1), wzcr(Is, A1, A2)), (wzr(T, O1, O2, Rl, A0, A5) :- number_codes(T, Tc), append(Tc, A1, A0), wzsi(O1, A1, A2), wzsi(O2, A2, A3), wzsi(Rl, A3, A4), A4 = [10|A5])]').
+
 % Register-file ceiling regression: manyperm/1 has 20 variables all live
 % across the mp_barrier call, so the compiler assigns them Y1..Y20. Before
 % the register file was enlarged from [64 x %Value] to [128 x %Value], Y17+
@@ -2003,6 +2021,67 @@ test(selfhost_codegen_stage_d_middle, [condition(clang_available)]) :-
     process_wait(Pid, exit(Status)),
     assertion(Status == 0),
     assertion(Out == Expected),
+    !.
+
+% THE FRONT: the loaded compiler compiles its own clause-grouping, label,
+% and chain machinery (plus the middle), and the doubly-compiled compiler
+% compiles a MULTI-PREDICATE program -- facts, a two-clause chain with
+% try/trust and a Label-PC pair, a predicate call, integer/atom head
+% constants, and arithmetic -- byte-identically to the production cgfull.
+test(selfhost_codegen_stage_d_front, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    cgfull_term([(dbl(X, Y) :- Y is X + X),
+                 (tst(R2) :- dbl(4, R2)),
+                 pick(1, a), pick(2, b)], W),
+    atom_codes(W, WCs),
+    sum_list(WCs, WSum), length(WCs, WLen),
+    ExpectedN is WSum + WLen,
+    format(string(Expected), "~w\n", [ExpectedN]),
+    fixpoint_front_source(Source),
+    directory_file_path(Dir, 'cgfront_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, Source), close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == Expected),
+    !.
+
+% Finding no. 11 regression: the reader var-dict must GROW past 128
+% distinct names. The source below has 130 names: main0's R, 128 filler
+% facts d1(V1)..d128(V128), then eq(Z, Z) whose repeated Z is the 130th.
+% With the old fixed cap, Z stopped being deduplicated -- eq compiled as
+% eq(_, _) with two independent variables -- and main0 printed an
+% unbound result instead of 5.
+test(reader_var_dict_grows_past_128, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    numlist(1, 128, Ns),
+    findall(F, ( member(I, Ns),
+                 format(atom(F), 'd~w(V~w)', [I, I]) ), Fillers),
+    atomic_list_concat(Fillers, ', ', FillerText),
+    format(atom(Src), '[(main0(R) :- eq(5, R)), ~w, eq(Z, Z)]',
+           [FillerText]),
+    directory_file_path(Dir, 'cgvd_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, Src), close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "5\n"),
     !.
 
 % Nested arithmetic in the loaded compiler: the is-expression is staged


### PR DESCRIPTION
## Summary

The loaded `cgfull` compiled `fixpoint_front_source/1`: the middle plus **cgfull's whole front restated cut-free** — facts vs rules (`mhb` tags facts with body `true`), the generic table walk mirroring `collect_tables`/`walk_term` (var/nil/integer/atom/compound dispatch with the control-functor skip list), `group_clauses`/`take_same`, `group_labels` + label lookup, and the `try_me_else`/`retry_me_else`/`trust_me` **chain builders** with PC threading and Label-PC pair collection (`keysort` + `pairs_values` close the PC table exactly like cgfull), plus integer/atom head constants, predicate-call goals, and `=/2` goals.

The doubly-compiled compiler compiled a **multi-predicate program** — a rule with arithmetic, a rule calling it, and a two-clause fact predicate with a try/trust chain — **byte-identically to the production cgfull** (checksum 13679, computed from `cgfull_term/2` in SWI at test time).

## Runtime finding #11 — the reader var-dict cap silently miscompiled

Compiling the ~6.8 KB front source tripped the reader's **fixed 128-name variable dictionary**: past the cap, `wam_var_ref` fell back to a fresh heap cell *per occurrence*, so repeated occurrences of the same variable name in later clauses silently stopped sharing. The self-hosted compiler thus **miscompiled its own serializer** — in `wzr`, the second occurrence of the codes-list variable became a fresh unbound, `append` copied nothing, and every emitted instruction lost its opcode digits, while headers, tables, and PC rows stayed intact (which made it look like a serializer bug). Diffing the emitted objects of two near-identical sources pinned it: `put_value Y54` in the good compile vs `put_variable Y55` in the bad one — one source variable compiled as two.

Fixed by making the dict **growable** (`[count][cap][pairs…]`, doubling; entries are plain ids/addresses so relocating the block is safe).

## Testing

- `selfhost_codegen_stage_d_front`: byte-exact vs the production compiler on the multi-predicate program, self-checking.
- `reader_var_dict_grows_past_128`: 130 distinct names with a repeated variable in the last clause — compiled as two independent variables before the fix.
- Fresh host caches: full `wam_object` suite passes; LLVM target 0 failures; plawk dyncall + compiled-stream-core pass; meta-call / quoted-atom / reentrant-run-loop suites pass.

## Docs

- `PLAWK_SELFHOST.md`: front-slice section + finding #11 write-up (including the diagnosis story — the corruption looked like a serializer bug until the emitted-object diff).
- `PLAWK_JIT_ROADMAP.md`: bug list to **eleven**; milestone entry updated.

Remaining toward `compile(SelfSource)`: structure/list deferral codegen, ITE codegen, the builtin whitelist dispatch, and the final stitching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_