### PR TITLE
Add Product-Kalman PIT diagnostics helpers

### DIFF
--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -13,8 +13,9 @@ has won; they make the held-out comparison auditable.
 """
 
 import argparse
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
+import math
 import sys
 
 import numpy as np
@@ -44,6 +45,7 @@ __all__ = [
     "GaussianScore",
     "GaussianScoreVectors",
     "GroupedGaussianScore",
+    "PITDiagnostics",
     "GroupResidualCovariances",
     "ProductKalmanHoldoutEvaluation",
     "bootstrap_nll_improvements_from_evaluation_npz",
@@ -55,6 +57,10 @@ __all__ = [
     "evaluation_to_json_dict",
     "paired_bootstrap_nll_improvement",
     "paired_bootstrap_nll_improvement_from_score_rows",
+    "gaussian_marginal_pit_diagnostics",
+    "gaussian_marginal_pit_values",
+    "pit_diagnostics_from_values",
+    "pit_uniform_ks_statistic",
     "row_covariances_from_groups",
     "run_product_kalman_holdout_npz",
     "score_gaussian_prediction_vectors_rowwise",
@@ -405,6 +411,127 @@ class GaussianScoreVectors:
     @property
     def n(self):
         return int(self.nll.size)
+
+
+@dataclass(frozen=True)
+class PITDiagnostics:
+    """Per-channel probability integral transform diagnostics.
+
+    `pit` must contain CDF values in `[0, 1]` with shape `(n, d)`. A calibrated
+    predictive marginal should have PIT values close to uniform; `channel_ks` is
+    the one-sample Kolmogorov-Smirnov distance to `U(0, 1)` for each channel.
+    """
+
+    name: str
+    pit: np.ndarray
+    channel_names: tuple = ()
+    channel_ks: np.ndarray = field(init=False)
+
+    def __post_init__(self):
+        name = str(self.name)
+        if not name:
+            raise ValueError("PIT diagnostic name must be nonempty")
+        pit = _as_2d("pit", self.pit)
+        if ((pit < 0.0) | (pit > 1.0)).any():
+            raise ValueError("pit values must be in [0, 1]")
+        pit = np.array(pit, dtype=float, copy=True)
+        pit.setflags(write=False)
+        channel_names = tuple(str(item) for item in self.channel_names)
+        if channel_names and len(channel_names) != pit.shape[1]:
+            raise ValueError("channel_names length must match pit dimension")
+        channel_ks = np.array([pit_uniform_ks_statistic(pit[:, j]) for j in range(pit.shape[1])], dtype=float)
+        channel_ks.setflags(write=False)
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "pit", pit)
+        object.__setattr__(self, "channel_names", channel_names)
+        object.__setattr__(self, "channel_ks", channel_ks)
+
+    @property
+    def n(self):
+        return int(self.pit.shape[0])
+
+    @property
+    def dimension(self):
+        return int(self.pit.shape[1])
+
+    def to_json_dict(self):
+        return {
+            "n": self.n,
+            "dimension": self.dimension,
+            "channel_names": list(self.channel_names),
+            "channel_ks": [float(value) for value in self.channel_ks],
+            "method": "marginal_pit_uniform_ks",
+        }
+
+
+def _normal_cdf(value):
+    arr = np.asarray(value, dtype=float)
+    erf = np.vectorize(math.erf, otypes=[float])
+    return 0.5 * (1.0 + erf(arr / math.sqrt(2.0)))
+
+
+def pit_uniform_ks_statistic(values):
+    """Return the one-sample KS distance between PIT values and `U(0, 1)`."""
+    arr = np.asarray(values, dtype=float)
+    if arr.ndim != 1 or arr.size == 0:
+        raise ValueError("PIT values must be a nonempty 1-D array")
+    if not np.isfinite(arr).all():
+        raise ValueError("PIT values must be finite")
+    if ((arr < 0.0) | (arr > 1.0)).any():
+        raise ValueError("PIT values must be in [0, 1]")
+    x = np.sort(arr)
+    n = float(x.size)
+    empirical_hi = np.arange(1, x.size + 1, dtype=float) / n
+    empirical_lo = np.arange(0, x.size, dtype=float) / n
+    return float(max(np.max(empirical_hi - x), np.max(x - empirical_lo)))
+
+
+def pit_diagnostics_from_values(name, pit, channel_names=()):
+    """Build JSON-ready PIT calibration diagnostics from precomputed PIT values.
+
+    This is the generic path for mixtures: callers can compute mixture CDF values
+    row by row, then use this helper for the common validation and KS summary.
+    """
+    return PITDiagnostics(name=name, pit=pit, channel_names=tuple(channel_names))
+
+
+def _covariance_diagonal_rows(covariance, n, dim, jitter=0.0):
+    jitter = float(jitter)
+    if not np.isfinite(jitter) or jitter < 0.0:
+        raise ValueError("jitter must be finite and nonnegative")
+    cov = np.asarray(covariance, dtype=float)
+    if cov.ndim == 2:
+        diag = np.diag(_as_covariance("covariance", cov, dim))[None, :]
+        diag = np.repeat(diag, n, axis=0)
+    elif cov.ndim == 3:
+        diag = np.diagonal(_as_row_covariances("covariances", cov, n, dim), axis1=1, axis2=2)
+    else:
+        raise ValueError("covariance must be a covariance matrix or row-covariance array")
+    diag = np.array(diag, dtype=float, copy=True)
+    if jitter:
+        diag += jitter
+    if (diag <= 0.0).any():
+        raise ValueError("marginal covariance variances must be positive")
+    return diag
+
+
+def gaussian_marginal_pit_values(target_state, mean, covariance, jitter=0.0):
+    """Return per-row, per-channel PIT values for Gaussian predictive marginals."""
+    target = _as_2d("target_state", target_state)
+    pred = _as_2d("mean", mean)
+    if pred.shape != target.shape:
+        raise ValueError(f"mean shape {pred.shape} must match target_state shape {target.shape}")
+    variances = _covariance_diagonal_rows(covariance, target.shape[0], target.shape[1], jitter=jitter)
+    z = (target - pred) / np.sqrt(variances)
+    pit = _normal_cdf(z)
+    pit.setflags(write=False)
+    return pit
+
+
+def gaussian_marginal_pit_diagnostics(name, target_state, mean, covariance, jitter=0.0, channel_names=()):
+    """Build PIT/KS diagnostics for Gaussian predictive marginals."""
+    pit = gaussian_marginal_pit_values(target_state, mean, covariance, jitter=jitter)
+    return pit_diagnostics_from_values(name, pit, channel_names=channel_names)
 
 
 @dataclass(frozen=True)

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -148,6 +148,37 @@ def _bootstrap_artifact_rows(scores_json):
     ]
 
 
+def _pit_rows(scores_json):
+    rows = []
+    diagnostics = scores_json.get("pit_diagnostics", {})
+    if not diagnostics:
+        return rows
+    if not isinstance(diagnostics, dict):
+        raise ValueError("pit_diagnostics must be a mapping")
+    for model, item in sorted(diagnostics.items()):
+        if not isinstance(item, dict):
+            raise ValueError("pit_diagnostics entries must be mappings")
+        channel_ks = item.get("channel_ks", [])
+        channel_names = list(item.get("channel_names", []))
+        if isinstance(channel_ks, dict):
+            pairs = sorted(channel_ks.items())
+        else:
+            pairs = []
+            for idx, value in enumerate(channel_ks):
+                channel = channel_names[idx] if idx < len(channel_names) else idx
+                pairs.append((channel, value))
+        for channel, ks in pairs:
+            rows.append([
+                model,
+                channel,
+                ks,
+                item.get("n"),
+                item.get("dimension"),
+                item.get("method"),
+            ])
+    return rows
+
+
 def _input_rows(scores_json, manifest):
     inputs = scores_json.get("inputs", {})
     rows = [
@@ -384,6 +415,7 @@ def build_product_kalman_markdown_report(
         ])
     bootstrap_rows = _bootstrap_rows(scores_json)
     bootstrap_artifact_rows = _bootstrap_artifact_rows(scores_json)
+    pit_rows = _pit_rows(scores_json)
     grouped_covariance_rows = _grouped_covariance_rows(scores_json)
     if grouped_covariance_rows:
         lines.extend([
@@ -419,6 +451,13 @@ def build_product_kalman_markdown_report(
         _markdown_table(["baseline", "candidate", "mean_nll_gain"], _improvement_rows(scores_json)),
         "",
     ])
+    if pit_rows:
+        lines.extend([
+            "## PIT Diagnostics",
+            "",
+            _markdown_table(["model", "channel", "ks_uniform", "n", "dimension", "method"], pit_rows),
+            "",
+        ])
     if bootstrap_rows:
         lines.extend([
             "## NLL Improvement Bootstrap Intervals",
@@ -456,6 +495,7 @@ def build_product_kalman_markdown_report(
         "",
         "- Positive NLL gain means the candidate had lower held-out mean NLL than the named baseline.",
         "- For a well-scaled d-dimensional Gaussian prediction, mean squared Mahalanobis should be near d; the per-dimension value should be near 1, with tail quantiles read as empirical diagnostics rather than a decision rule.",
+        "- PIT diagnostics, when present, summarize marginal CDF calibration; lower KS-vs-uniform is better, but it is still an exploratory shape diagnostic.",
         "- Bootstrap intervals, when present, are paired row-resampling diagnostics for NLL gains; they are not a preregistered decision rule.",
         "- Treat this as a held-out comparison artifact, not as a training-objective decision.",
         "- Product-Kalman should be compared against the registered joint-posterior and Sigma-conditioned baselines before promotion.",

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -21,7 +21,11 @@ from product_kalman_evaluation import (
     evaluation_to_json_dict,
     fit_group_residual_covariances,
     main,
+    gaussian_marginal_pit_diagnostics,
+    gaussian_marginal_pit_values,
     paired_bootstrap_nll_improvement,
+    pit_diagnostics_from_values,
+    pit_uniform_ks_statistic,
     row_covariances_from_groups,
     run_product_kalman_holdout_npz,
     score_gaussian_prediction_vectors_rowwise,
@@ -57,7 +61,6 @@ def synthetic_identity_split(n_cal=8000, n_eval=4000, seed=23):
         measurement[n_cal:],
         target[n_cal:],
     )
-
 
 def test_correlated_product_kalman_beats_zero_cross_control_on_heldout_nll():
     cal_prior, cal_measure, cal_target, eval_prior, eval_measure, eval_target = synthetic_identity_split()
@@ -101,7 +104,6 @@ def test_correlated_product_kalman_beats_zero_cross_control_on_heldout_nll():
     assert boot["ci_low"] < boot["observed_mean_gain"] < boot["ci_high"]
     assert boot["method"] == "paired_row_resample"
     assert boot["confidence"] == 0.90
-
 
 def test_split_ids_are_checked_before_scoring():
     cal_prior, cal_measure, cal_target, eval_prior, eval_measure, eval_target = synthetic_identity_split(
@@ -180,7 +182,6 @@ def write_identity_npz(path, n_cal=8000, n_eval=4000):
         calibration_ids=np.array([f"cal-{i}" for i in range(n_cal)]),
         evaluation_ids=np.array([f"eval-{i}" for i in range(n_eval)]),
     )
-
 
 def test_npz_runner_and_json_cli_roundtrip():
     with tempfile.TemporaryDirectory() as tmp:
@@ -263,7 +264,6 @@ def test_npz_runner_and_json_cli_roundtrip():
             np.testing.assert_allclose(artifact["calibration_cross_covariance"], result.calibration.cross_covariance)
             np.testing.assert_allclose(artifact["independent_cross_covariance"], 0.0)
 
-
 def test_evaluation_artifact_arrays_are_npz_ready():
     cal_prior, cal_measure, cal_target, eval_prior, eval_measure, eval_target = synthetic_identity_split(
         n_cal=80,
@@ -299,7 +299,6 @@ def test_evaluation_artifact_arrays_are_npz_ready():
         with np.load(artifact_path, allow_pickle=False) as artifact:
             assert set(arrays).issubset(set(artifact.files))
             np.testing.assert_allclose(artifact["score_mean_nll"], arrays["score_mean_nll"])
-
 
 def test_npz_runner_scores_grouped_covariances_when_group_labels_present():
     rng = np.random.default_rng(41)
@@ -385,14 +384,12 @@ def test_npz_runner_scores_grouped_covariances_when_group_labels_present():
             summary = json.loads(str(artifact["grouped_score_summary_json"][-1]))
             assert summary["score"] == "product_kalman_grouped"
 
-
 def test_npz_runner_validates_required_keys():
     with tempfile.TemporaryDirectory() as tmp:
         input_path = Path(tmp) / "missing.npz"
         np.savez(input_path, calibration_prior_mean=np.zeros((4, 1)))
         assert_raises(run_product_kalman_holdout_npz, input_path)
         assert_raises(bootstrap_nll_improvements_from_evaluation_npz, input_path, n_boot=10)
-
 
 def test_nonidentity_observation_omits_measurement_baseline():
     rng = np.random.default_rng(5)
@@ -419,7 +416,6 @@ def test_nonidentity_observation_omits_measurement_baseline():
     assert names == ["prior", "independent_kalman", "product_kalman"]
     assert result.correlated_update.mean.shape == (n_eval, 2)
     assert_raises(result.score, "measurement")
-
 
 def test_group_residual_covariances_feed_rowwise_scores():
     rng = np.random.default_rng(17)
@@ -450,7 +446,6 @@ def test_group_residual_covariances_feed_rowwise_scores():
     grouped_score = score_gaussian_predictions_rowwise("grouped", eval_obs, eval_pred, row_covariances, jitter=1e-8)
     assert grouped_score.mean_nll < global_score.mean_nll
     assert grouped_score.covariance_trace == np.mean(np.trace(row_covariances, axis1=1, axis2=2))
-
 
 def test_grouped_gaussian_scorer_matches_manual_grouped_path():
     rng = np.random.default_rng(19)
@@ -507,7 +502,6 @@ def test_grouped_gaussian_scorer_matches_manual_grouped_path():
         eval_groups,
     )
 
-
 def test_group_residual_covariance_fallbacks_and_validation():
     pred = np.zeros((8, 1))
     obs = np.array([[0.0], [0.2], [-0.1], [0.1], [1.0], [-1.1], [0.9], [0.05]])
@@ -533,7 +527,6 @@ def test_group_residual_covariance_fallbacks_and_validation():
         min_group_rows=2,
     )
 
-
 def test_score_gaussian_predictions_validates_shapes_and_reports_mse():
     target = np.array([[1.0], [2.0]])
     mean = np.array([[1.5], [1.5]])
@@ -554,7 +547,6 @@ def test_score_gaussian_predictions_validates_shapes_and_reports_mse():
     assert abs(score.squared_mahalanobis_q95 - 1.0) < 1e-12
     assert_raises(score_gaussian_predictions, "bad", target[:, 0], mean, [[1.0]])
     assert_raises(score_gaussian_predictions, "bad", target, mean, [[1.0, 0.0]])
-
 
 def test_rowwise_gaussian_scoring_supports_variable_covariances():
     target = np.array([[1.0], [2.0]])
@@ -589,6 +581,37 @@ def test_rowwise_gaussian_scoring_supports_variable_covariances():
     bad_covariances[1, 0, 0] = np.nan
     assert_raises(score_gaussian_predictions_rowwise, "bad", target, mean, bad_covariances)
 
+def test_pit_diagnostics_validate_uniform_ks_and_json_shape():
+    pit = np.array([[0.25, 0.10], [0.75, 0.90]])
+    diag = pit_diagnostics_from_values("mix", pit, channel_names=("D", "S"))
+    np.testing.assert_allclose(diag.channel_ks, [0.25, 0.40])
+    assert diag.pit.flags.writeable is False
+    assert diag.channel_ks.flags.writeable is False
+    assert diag.to_json_dict() == {
+        "n": 2,
+        "dimension": 2,
+        "channel_names": ["D", "S"],
+        "channel_ks": [0.25, 0.4],
+        "method": "marginal_pit_uniform_ks",
+    }
+    assert abs(pit_uniform_ks_statistic([0.25, 0.75]) - 0.25) < 1e-12
+    assert_raises(pit_diagnostics_from_values, "bad", np.array([0.5, 0.6]))
+    assert_raises(pit_diagnostics_from_values, "bad", np.array([[1.2]]))
+    assert_raises(pit_diagnostics_from_values, "bad", np.array([[0.5]]), channel_names=("D", "S"))
+
+def test_gaussian_marginal_pit_values_support_fixed_and_rowwise_covariances():
+    target = np.array([[0.0], [1.0], [-1.0]])
+    mean = np.zeros((3, 1))
+    fixed = gaussian_marginal_pit_values(target, mean, np.array([[1.0]]))
+    np.testing.assert_allclose(fixed[:, 0], [0.5, 0.841344746, 0.158655254], atol=1e-8)
+    rowwise_cov = np.array([[[1.0]], [[4.0]], [[4.0]]])
+    rowwise = gaussian_marginal_pit_values(target, mean, rowwise_cov)
+    np.testing.assert_allclose(rowwise[:, 0], [0.5, 0.691462461, 0.308537539], atol=1e-8)
+    diag = gaussian_marginal_pit_diagnostics("gaussian", target, mean, rowwise_cov, channel_names=("D",))
+    assert diag.to_json_dict()["channel_names"] == ["D"]
+    assert diag.to_json_dict()["n"] == 3
+    assert_raises(gaussian_marginal_pit_values, target, mean[:, :0], np.array([[1.0]]))
+    assert_raises(gaussian_marginal_pit_values, target, mean, np.array([[0.0]]))
 
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -116,7 +116,6 @@ def split_manifest_fixture():
         },
     }
 
-
 def test_markdown_report_records_scores_and_guardrails():
     with tempfile.TemporaryDirectory() as tmp:
         input_manifest, scores_json, _ = make_artifacts(tmp)
@@ -142,6 +141,27 @@ def test_markdown_report_records_scores_and_guardrails():
         assert "does not encode a decision rule" in report
         assert "should be compared against the registered joint-posterior" in report
 
+def test_markdown_report_records_pit_diagnostics_when_present():
+    with tempfile.TemporaryDirectory() as tmp:
+        input_manifest, scores_json, _ = make_artifacts(tmp)
+        scores = json.loads(scores_json.read_text())
+        manifest = json.loads(input_manifest.read_text())
+        scores["pit_diagnostics"] = {
+            "mix": {
+                "n": 40,
+                "dimension": 2,
+                "channel_names": ["D", "S"],
+                "channel_ks": [0.08, 0.12],
+                "method": "marginal_pit_uniform_ks",
+            }
+        }
+        report = build_product_kalman_markdown_report(scores, manifest)
+
+        assert "## PIT Diagnostics" in report
+        assert "| mix | D | 0.08 | 40 | 2 | marginal_pit_uniform_ks |" in report
+        assert "| mix | S | 0.12 | 40 | 2 | marginal_pit_uniform_ks |" in report
+        assert "PIT diagnostics, when present" in report
+
 def test_markdown_report_records_split_materialization_manifest():
     with tempfile.TemporaryDirectory() as tmp:
         input_manifest, scores_json, _ = make_artifacts(tmp)
@@ -163,7 +183,6 @@ def test_markdown_report_records_split_materialization_manifest():
         assert "| observed_unit_overlap_count | 0 |" in report
         assert "| disjoint_observed_units | True |" in report
         assert "| omitted_crossing_rows | 0 |" in report
-
 
 def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
     with tempfile.TemporaryDirectory() as tmp:
@@ -242,7 +261,6 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
         assert "nll_improvement_bootstrap_vs_product_kalman" in enriched_json
         assert enriched_json["bootstrap_artifact"] == artifact_meta
 
-
 def test_markdown_report_cli_writes_file():
     with tempfile.TemporaryDirectory() as tmp:
         input_manifest, scores_json, _ = make_artifacts(tmp)
@@ -270,7 +288,6 @@ def test_markdown_report_cli_writes_file():
         assert "## NLL Improvement Bootstrap Intervals" in text
         assert "## Split Materialization" in text
         assert "source_table_sha256" in text
-
 
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]


### PR DESCRIPTION
Adds reusable PIT/KS calibration diagnostics for Product-Kalman evaluation artifacts and report rendering.

Changes:
- Add generic PIT-from-values diagnostics for mixture models.
- Add Gaussian marginal PIT helpers for fixed and rowwise covariance predictions.
- Compute per-channel KS distance against `U(0,1)`.
- Render optional `pit_diagnostics` blocks in Product-Kalman Markdown reports.
- Add tests for PIT validation, Gaussian PIT values, read-only arrays, JSON shape, and report output.

Verification:
- `python3 -m py_compile ...`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `git diff --check`