### PR TITLE
Emit Product-Kalman PIT diagnostics

### DIFF
--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -585,6 +585,7 @@ class ProductKalmanHoldoutEvaluation:
     scores: tuple
     score_vectors: tuple = ()
     grouped_scores: tuple = ()
+    pit_diagnostics: tuple = ()
 
     def __post_init__(self):
         if not isinstance(self.calibration, ProductKalmanCalibration):
@@ -625,9 +626,29 @@ class ProductKalmanHoldoutEvaluation:
                     raise ValueError("grouped score vectors must also appear in score_vectors")
             if len(grouped_names) != len(set(grouped_names)):
                 raise ValueError("grouped score names must be unique")
+        pit_diagnostics = tuple(self.pit_diagnostics)
+        if pit_diagnostics:
+            score_by_name = {score.name: score for score in scores}
+            vector_by_name = {vector.name: vector for vector in score_vectors}
+            pit_names = []
+            for diagnostic in pit_diagnostics:
+                if not isinstance(diagnostic, PITDiagnostics):
+                    raise ValueError("pit_diagnostics must contain PITDiagnostics objects")
+                pit_names.append(diagnostic.name)
+                if diagnostic.name not in score_by_name:
+                    raise ValueError("PIT diagnostic name must also appear in scores")
+                score = score_by_name[diagnostic.name]
+                if diagnostic.n != score.n:
+                    raise ValueError("PIT diagnostic row count must match score n")
+                vector = vector_by_name.get(diagnostic.name)
+                if vector is not None and diagnostic.dimension != vector.dimension:
+                    raise ValueError("PIT diagnostic dimension must match score-vector dimension")
+            if len(pit_names) != len(set(pit_names)):
+                raise ValueError("PIT diagnostic names must be unique")
         object.__setattr__(self, "scores", scores)
         object.__setattr__(self, "score_vectors", score_vectors)
         object.__setattr__(self, "grouped_scores", grouped_scores)
+        object.__setattr__(self, "pit_diagnostics", pit_diagnostics)
 
     def score(self, name):
         """Return the named `GaussianScore`."""
@@ -641,6 +662,13 @@ class ProductKalmanHoldoutEvaluation:
         for vector in self.score_vectors:
             if vector.name == name:
                 return vector
+        raise KeyError(name)
+
+    def pit_diagnostic(self, name):
+        """Return the named PIT calibration diagnostic."""
+        for diagnostic in self.pit_diagnostics:
+            if diagnostic.name == name:
+                return diagnostic
         raise KeyError(name)
 
     def nll_improvement(self, baseline, candidate):
@@ -1088,6 +1116,10 @@ def evaluate_product_kalman_holdout(
         _score_from_vectors(vectors, covariance)
         for vectors, (_, _, covariance) in zip(score_vectors, score_inputs)
     ]
+    pit_diagnostics = [
+        gaussian_marginal_pit_diagnostics(name, eval_target, mean, covariance, jitter=jitter)
+        for name, mean, covariance in score_inputs
+    ]
 
     grouped_scores = []
     if cal_groups is not None:
@@ -1119,6 +1151,17 @@ def evaluate_product_kalman_holdout(
         ]
         scores.extend(grouped.score for grouped in grouped_scores)
         score_vectors.extend(grouped.score_vectors for grouped in grouped_scores)
+        grouped_eval_means = {name: eval_mean for name, _cal_mean, eval_mean in grouped_inputs}
+        for grouped in grouped_scores:
+            pit_diagnostics.append(
+                gaussian_marginal_pit_diagnostics(
+                    grouped.score.name,
+                    eval_target,
+                    grouped_eval_means[grouped.score.name],
+                    grouped.row_covariances,
+                    jitter=jitter,
+                )
+            )
 
     return ProductKalmanHoldoutEvaluation(
         calibration=calibration,
@@ -1128,6 +1171,7 @@ def evaluate_product_kalman_holdout(
         scores=tuple(scores),
         score_vectors=tuple(score_vectors),
         grouped_scores=tuple(grouped_scores),
+        pit_diagnostics=tuple(pit_diagnostics),
     )
 
 
@@ -1214,6 +1258,16 @@ def evaluation_artifact_arrays(result):
             "score_row_squared_mahalanobis": np.vstack([
                 vectors.squared_mahalanobis
                 for vectors in result.score_vectors
+            ]),
+        })
+    if result.pit_diagnostics:
+        arrays.update({
+            "pit_names": np.array([diagnostic.name for diagnostic in result.pit_diagnostics]),
+            "pit_values": np.stack([diagnostic.pit for diagnostic in result.pit_diagnostics]),
+            "pit_channel_ks": np.vstack([diagnostic.channel_ks for diagnostic in result.pit_diagnostics]),
+            "pit_summary_json": np.array([
+                json.dumps(diagnostic.to_json_dict(), sort_keys=True)
+                for diagnostic in result.pit_diagnostics
             ]),
         })
     if result.grouped_scores:
@@ -1395,6 +1449,11 @@ def evaluation_to_json_dict(
         out["grouped_covariances"] = {
             grouped.score.name: _grouped_covariance_to_json_dict(grouped)
             for grouped in result.grouped_scores
+        }
+    if result.pit_diagnostics:
+        out["pit_diagnostics"] = {
+            diagnostic.name: diagnostic.to_json_dict()
+            for diagnostic in result.pit_diagnostics
         }
     if bootstrap_nll:
         out.update(_bootstrap_improvement_maps(

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -89,6 +89,15 @@ def test_correlated_product_kalman_beats_zero_cross_control_on_heldout_nll():
     assert product_vectors.nll.shape == (len(eval_target),)
     assert abs(float(product_vectors.nll.mean()) - product_score.mean_nll) < 1e-12
     assert product_vectors.nll.flags.writeable is False
+    product_pit = result.pit_diagnostic("product_kalman")
+    assert product_pit.n == len(eval_target)
+    assert product_pit.dimension == 1
+    assert product_pit.pit.shape == (len(eval_target), 1)
+    assert product_pit.channel_ks.shape == (1,)
+    assert 0.0 <= product_pit.channel_ks[0] <= 1.0
+    assert product_pit.pit.flags.writeable is False
+    assert product_pit.channel_ks.flags.writeable is False
+    assert_raises(result.pit_diagnostic, "missing")
     assert result.correlated_update.mean.flags.writeable is False
     assert result.independent_update.mean.flags.writeable is False
     boot = paired_bootstrap_nll_improvement(
@@ -199,6 +208,10 @@ def test_npz_runner_and_json_cli_roundtrip():
         assert data["score_order"] == ["prior", "measurement", "independent_kalman", "product_kalman"]
         assert data["nll_baselines"] == ["prior", "independent_kalman"]
         assert data["calibration"]["state_dim"] == 1
+        assert data["pit_diagnostics"]["product_kalman"]["n"] == 4000
+        assert data["pit_diagnostics"]["product_kalman"]["dimension"] == 1
+        assert data["pit_diagnostics"]["product_kalman"]["method"] == "marginal_pit_uniform_ks"
+        assert len(data["pit_diagnostics"]["product_kalman"]["channel_ks"]) == 1
         assert "mean_squared_mahalanobis" in data["scores"]["product_kalman"]
         assert "squared_mahalanobis_q95" in data["scores"]["product_kalman"]
         assert 0.85 < data["scores"]["product_kalman"]["mahalanobis_per_dim"] < 1.15
@@ -234,6 +247,7 @@ def test_npz_runner_and_json_cli_roundtrip():
         from_cli = json.loads(output_path.read_text())
         assert from_cli["score_order"] == data["score_order"]
         assert from_cli["nll_baselines"] == ["prior", "independent_kalman", "product_kalman"]
+        assert from_cli["pit_diagnostics"]["product_kalman"] == data["pit_diagnostics"]["product_kalman"]
         assert "nll_improvement_vs_product_kalman" in from_cli
         assert "nll_improvement_bootstrap_vs_product_kalman" in from_cli
         assert abs(
@@ -258,6 +272,9 @@ def test_npz_runner_and_json_cli_roundtrip():
             assert artifact["score_row_nll"].shape == (4, 4000)
             assert artifact["score_row_squared_error"].shape == (4, 4000)
             assert artifact["score_row_squared_mahalanobis"].shape == (4, 4000)
+            assert artifact["pit_names"].tolist() == data["score_order"]
+            assert artifact["pit_values"].shape == (4, 4000, 1)
+            assert artifact["pit_channel_ks"].shape == (4, 1)
             assert artifact["product_kalman_mean"].shape == result.correlated_update.mean.shape
             np.testing.assert_allclose(artifact["product_kalman_mean"], result.correlated_update.mean)
             np.testing.assert_allclose(artifact["independent_kalman_mean"], result.independent_update.mean)
@@ -288,6 +305,10 @@ def test_evaluation_artifact_arrays_are_npz_ready():
     assert arrays["score_row_nll"].shape == (4, 20)
     assert arrays["score_row_squared_error"].shape == (4, 20)
     assert arrays["score_row_squared_mahalanobis"].shape == (4, 20)
+    assert arrays["pit_names"].tolist() == ["prior", "measurement", "independent_kalman", "product_kalman"]
+    assert arrays["pit_values"].shape == (4, 20, 1)
+    assert arrays["pit_channel_ks"].shape == (4, 1)
+    assert arrays["pit_summary_json"].shape == (4,)
     np.testing.assert_allclose(arrays["score_row_nll"].mean(axis=1), arrays["score_mean_nll"])
     assert np.isfinite(arrays["score_mahalanobis_per_dim"]).all()
     assert arrays["product_kalman_innovation"].shape == eval_target.shape
@@ -367,6 +388,8 @@ def test_npz_runner_scores_grouped_covariances_when_group_labels_present():
         assert grouped["group_counts"] == {"tight": n_cal_per_group, "wide": n_cal_per_group}
         assert grouped["row_covariance_shape"] == [n_eval, 1, 1]
         assert data["nll_improvement_vs_product_kalman"]["product_kalman_grouped"] > 0.0
+        assert "product_kalman_grouped" in data["pit_diagnostics"]
+        assert data["pit_diagnostics"]["product_kalman_grouped"]["n"] == n_eval
         assert "product_kalman_grouped" in data["nll_improvement_bootstrap_vs_independent_kalman"]
         assert "product_kalman_grouped" in data["nll_improvement_bootstrap_vs_product_kalman"]
 
@@ -374,6 +397,9 @@ def test_npz_runner_scores_grouped_covariances_when_group_labels_present():
         with np.load(artifact_path, allow_pickle=False) as artifact:
             assert artifact["score_names"].shape == (8,)
             assert artifact["score_row_nll"].shape == (8, n_eval)
+            assert artifact["pit_names"].shape == (8,)
+            assert artifact["pit_values"].shape == (8, n_eval, 1)
+            assert artifact["pit_channel_ks"].shape == (8, 1)
             assert artifact["grouped_score_names"].tolist() == [
                 "prior_grouped",
                 "measurement_grouped",

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -132,6 +132,8 @@ def test_markdown_report_records_scores_and_guardrails():
         assert "| prior | product_kalman |" in report
         assert "| product_kalman | independent_kalman |" in report
         assert "## NLL Improvement Bootstrap Intervals" in report
+        assert "## PIT Diagnostics" in report
+        assert "marginal_pit_uniform_ks" in report
         assert "observed_gain" in report
         assert "paired row-resampling" in report
         assert "| calibration_rows | 80 |" in report


### PR DESCRIPTION
Adds automatic marginal PIT diagnostics to Product-Kalman holdout evaluations.

- Computes PIT diagnostics for shared-covariance and grouped-covariance score paths.
- Exposes diagnostics in evaluation JSON and NPZ artifacts via `pit_diagnostics`, `pit_values`, `pit_channel_ks`, and `pit_summary_json`.
- Threads the diagnostics into report rendering so calibration checks appear alongside NLL and improvement summaries.
- Adds tests for PIT lookup, artifact serialization, CLI/API JSON parity, grouped covariance diagnostics, and report output.

Verification:
- `python3 -m py_compile prototypes/mu_cosine/product_kalman_evaluation.py prototypes/mu_cosine/product_kalman_report.py prototypes/mu_cosine/test_product_kalman_evaluation.py prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `python3 prototypes/mu_cosine/test_product_kalman.py`
- `python3 prototypes/mu_cosine/test_product_kalman_calibration.py`
- `git diff --check`