### PR TITLE
Add Product-Kalman PIT coverage diagnostics

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -416,8 +416,9 @@ remaining D-channel shape defect as model-side relation-class structure rather t
    grouped-covariance score variants when calibration/evaluation group labels are present, records aggregate NLL/MSE,
    Mahalanobis calibration-scale/tail diagnostics, row-level score vectors, and optional paired bootstrap intervals
    for NLL gains against configurable baselines such as ungrouped `product_kalman`, and keeps
-   calibration/evaluation IDs disjoint. *(Harness complete; dedicated real-corpus exploratory runs are recorded in
-   the reports listed below.)*
+   calibration/evaluation IDs disjoint. PIT diagnostics include marginal KS-vs-uniform and central-interval
+   coverage summaries so interval under/over-coverage is visible without changing score selection. *(Harness
+   complete; dedicated real-corpus exploratory runs are recorded in the reports listed below.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
    descriptive Markdown run note. When row-level `eval_artifacts.npz` exists, the report CLI can add paired bootstrap
    NLL intervals post hoc without rerunning scoring, verifies the row artifact against the score summary, records the
@@ -463,13 +464,13 @@ remaining D-channel shape defect as model-side relation-class structure rather t
   Product-Kalman comparisons.
 - `product_kalman_report.py` and `test_product_kalman_report.py` — descriptive Markdown report generator for
   Product-Kalman input manifests, optional split manifests, score JSON artifacts, and optional PIT calibration
-  diagnostics.
+  diagnostics including central-interval coverage tables.
 - `product_kalman_evaluation.py` and `test_product_kalman_evaluation.py` — holdout comparison harness for
   prior, zero-cross-covariance, and correlated Product-Kalman scoring on disjoint splits, including NLL/MSE,
   rowwise covariance scoring, grouped residual-covariance maps, automatic grouped score variants when NPZ group
   labels are present, Mahalanobis predicted-error scale/tail diagnostics, JSON summaries, configurable paired
-  bootstrap baselines for direct grouped-vs-ungrouped comparisons, reusable PIT/KS marginal calibration helpers, and
-  row-level NPZ score artifacts for reproducible bootstrap/tail diagnostics.
+  bootstrap baselines for direct grouped-vs-ungrouped comparisons, reusable PIT/KS marginal calibration helpers,
+  central PIT coverage summaries, and row-level NPZ score artifacts for reproducible bootstrap/tail diagnostics.
 - `run_product_kalman_realdata.py` and `REPORT_product_kalman_realdata.md` — exploratory real-corpus run showing
   correlated Product-Kalman beats the prior and that independent/PoE fusion becomes overconfident when correlated
   product channels are stacked; the same report records Sigma(hop) blocks inside the Kalman gain as rung (a).

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -39,6 +39,7 @@ except ImportError:  # direct script execution from prototypes/mu_cosine
 
 
 DEFAULT_NLL_BASELINES = ("prior", "independent_kalman")
+DEFAULT_PIT_COVERAGE_LEVELS = (0.50, 0.80, 0.90, 0.95)
 
 
 __all__ = [
@@ -46,6 +47,7 @@ __all__ = [
     "GaussianScoreVectors",
     "GroupedGaussianScore",
     "PITDiagnostics",
+    "DEFAULT_PIT_COVERAGE_LEVELS",
     "GroupResidualCovariances",
     "ProductKalmanHoldoutEvaluation",
     "bootstrap_nll_improvements_from_evaluation_npz",
@@ -59,6 +61,7 @@ __all__ = [
     "paired_bootstrap_nll_improvement_from_score_rows",
     "gaussian_marginal_pit_diagnostics",
     "gaussian_marginal_pit_values",
+    "pit_central_interval_coverage",
     "pit_diagnostics_from_values",
     "pit_uniform_ks_statistic",
     "row_covariances_from_groups",
@@ -420,12 +423,17 @@ class PITDiagnostics:
     `pit` must contain CDF values in `[0, 1]` with shape `(n, d)`. A calibrated
     predictive marginal should have PIT values close to uniform; `channel_ks` is
     the one-sample Kolmogorov-Smirnov distance to `U(0, 1)` for each channel.
+    `central_interval_coverage` reports empirical coverage for central PIT
+    intervals, so under/over-confident marginals are visible in report tables.
     """
 
     name: str
     pit: np.ndarray
     channel_names: tuple = ()
+    coverage_levels: tuple = DEFAULT_PIT_COVERAGE_LEVELS
     channel_ks: np.ndarray = field(init=False)
+    central_interval_coverage: np.ndarray = field(init=False)
+    central_interval_error: np.ndarray = field(init=False)
 
     def __post_init__(self):
         name = str(self.name)
@@ -439,12 +447,19 @@ class PITDiagnostics:
         channel_names = tuple(str(item) for item in self.channel_names)
         if channel_names and len(channel_names) != pit.shape[1]:
             raise ValueError("channel_names length must match pit dimension")
+        coverage_levels = _as_pit_coverage_levels(self.coverage_levels)
         channel_ks = np.array([pit_uniform_ks_statistic(pit[:, j]) for j in range(pit.shape[1])], dtype=float)
         channel_ks.setflags(write=False)
+        central_coverage = pit_central_interval_coverage(pit, coverage_levels=coverage_levels)
+        coverage_error = central_coverage - coverage_levels[:, None]
+        coverage_error.setflags(write=False)
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "pit", pit)
         object.__setattr__(self, "channel_names", channel_names)
+        object.__setattr__(self, "coverage_levels", tuple(float(level) for level in coverage_levels))
         object.__setattr__(self, "channel_ks", channel_ks)
+        object.__setattr__(self, "central_interval_coverage", central_coverage)
+        object.__setattr__(self, "central_interval_error", coverage_error)
 
     @property
     def n(self):
@@ -460,6 +475,9 @@ class PITDiagnostics:
             "dimension": self.dimension,
             "channel_names": list(self.channel_names),
             "channel_ks": [float(value) for value in self.channel_ks],
+            "coverage_levels": [float(value) for value in self.coverage_levels],
+            "central_interval_coverage": self.central_interval_coverage.tolist(),
+            "central_interval_error": self.central_interval_error.tolist(),
             "method": "marginal_pit_uniform_ks",
         }
 
@@ -486,13 +504,49 @@ def pit_uniform_ks_statistic(values):
     return float(max(np.max(empirical_hi - x), np.max(x - empirical_lo)))
 
 
-def pit_diagnostics_from_values(name, pit, channel_names=()):
+def _as_pit_coverage_levels(coverage_levels):
+    levels = np.asarray(tuple(coverage_levels), dtype=float)
+    if levels.ndim != 1 or levels.size == 0:
+        raise ValueError("coverage_levels must be a nonempty 1-D sequence")
+    if not np.isfinite(levels).all():
+        raise ValueError("coverage_levels must be finite")
+    if ((levels <= 0.0) | (levels >= 1.0)).any():
+        raise ValueError("coverage_levels must lie strictly between 0 and 1")
+    if len(set(float(level) for level in levels)) != levels.size:
+        raise ValueError("coverage_levels must be unique")
+    levels = np.array(levels, dtype=float, copy=True)
+    levels.setflags(write=False)
+    return levels
+
+
+def pit_central_interval_coverage(pit, coverage_levels=DEFAULT_PIT_COVERAGE_LEVELS):
+    """Return empirical central PIT interval coverage with shape `(levels, d)`."""
+    values = _as_2d("pit", pit)
+    if ((values < 0.0) | (values > 1.0)).any():
+        raise ValueError("pit values must be in [0, 1]")
+    levels = _as_pit_coverage_levels(coverage_levels)
+    coverage = []
+    for level in levels:
+        tail = (1.0 - float(level)) / 2.0
+        inside = (values >= tail) & (values <= 1.0 - tail)
+        coverage.append(np.mean(inside, axis=0))
+    out = np.asarray(coverage, dtype=float)
+    out.setflags(write=False)
+    return out
+
+
+def pit_diagnostics_from_values(name, pit, channel_names=(), coverage_levels=DEFAULT_PIT_COVERAGE_LEVELS):
     """Build JSON-ready PIT calibration diagnostics from precomputed PIT values.
 
     This is the generic path for mixtures: callers can compute mixture CDF values
     row by row, then use this helper for the common validation and KS summary.
     """
-    return PITDiagnostics(name=name, pit=pit, channel_names=tuple(channel_names))
+    return PITDiagnostics(
+        name=name,
+        pit=pit,
+        channel_names=tuple(channel_names),
+        coverage_levels=tuple(coverage_levels),
+    )
 
 
 def _covariance_diagonal_rows(covariance, n, dim, jitter=0.0):
@@ -528,10 +582,18 @@ def gaussian_marginal_pit_values(target_state, mean, covariance, jitter=0.0):
     return pit
 
 
-def gaussian_marginal_pit_diagnostics(name, target_state, mean, covariance, jitter=0.0, channel_names=()):
+def gaussian_marginal_pit_diagnostics(
+    name,
+    target_state,
+    mean,
+    covariance,
+    jitter=0.0,
+    channel_names=(),
+    coverage_levels=DEFAULT_PIT_COVERAGE_LEVELS,
+):
     """Build PIT/KS diagnostics for Gaussian predictive marginals."""
     pit = gaussian_marginal_pit_values(target_state, mean, covariance, jitter=jitter)
-    return pit_diagnostics_from_values(name, pit, channel_names=channel_names)
+    return pit_diagnostics_from_values(name, pit, channel_names=channel_names, coverage_levels=coverage_levels)
 
 
 @dataclass(frozen=True)
@@ -631,6 +693,7 @@ class ProductKalmanHoldoutEvaluation:
             score_by_name = {score.name: score for score in scores}
             vector_by_name = {vector.name: vector for vector in score_vectors}
             pit_names = []
+            pit_coverage_levels = None
             for diagnostic in pit_diagnostics:
                 if not isinstance(diagnostic, PITDiagnostics):
                     raise ValueError("pit_diagnostics must contain PITDiagnostics objects")
@@ -643,6 +706,10 @@ class ProductKalmanHoldoutEvaluation:
                 vector = vector_by_name.get(diagnostic.name)
                 if vector is not None and diagnostic.dimension != vector.dimension:
                     raise ValueError("PIT diagnostic dimension must match score-vector dimension")
+                if pit_coverage_levels is None:
+                    pit_coverage_levels = diagnostic.coverage_levels
+                elif diagnostic.coverage_levels != pit_coverage_levels:
+                    raise ValueError("PIT diagnostics must share coverage_levels for artifact serialization")
             if len(pit_names) != len(set(pit_names)):
                 raise ValueError("PIT diagnostic names must be unique")
         object.__setattr__(self, "scores", scores)
@@ -1265,6 +1332,15 @@ def evaluation_artifact_arrays(result):
             "pit_names": np.array([diagnostic.name for diagnostic in result.pit_diagnostics]),
             "pit_values": np.stack([diagnostic.pit for diagnostic in result.pit_diagnostics]),
             "pit_channel_ks": np.vstack([diagnostic.channel_ks for diagnostic in result.pit_diagnostics]),
+            "pit_coverage_levels": np.array(result.pit_diagnostics[0].coverage_levels, dtype=float),
+            "pit_central_interval_coverage": np.stack([
+                diagnostic.central_interval_coverage
+                for diagnostic in result.pit_diagnostics
+            ]),
+            "pit_central_interval_error": np.stack([
+                diagnostic.central_interval_error
+                for diagnostic in result.pit_diagnostics
+            ]),
             "pit_summary_json": np.array([
                 json.dumps(diagnostic.to_json_dict(), sort_keys=True)
                 for diagnostic in result.pit_diagnostics

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -179,6 +179,32 @@ def _pit_rows(scores_json):
     return rows
 
 
+def _pit_coverage_rows(scores_json):
+    rows = []
+    diagnostics = scores_json.get("pit_diagnostics", {})
+    if not diagnostics:
+        return rows
+    if not isinstance(diagnostics, dict):
+        raise ValueError("pit_diagnostics must be a mapping")
+    for model, item in sorted(diagnostics.items()):
+        if not isinstance(item, dict):
+            raise ValueError("pit_diagnostics entries must be mappings")
+        levels = list(item.get("coverage_levels", []))
+        coverage = item.get("central_interval_coverage", [])
+        errors = item.get("central_interval_error", [])
+        channel_names = list(item.get("channel_names", []))
+        if not levels or not coverage:
+            continue
+        for level_idx, level in enumerate(levels):
+            row_coverage = coverage[level_idx] if level_idx < len(coverage) else []
+            row_errors = errors[level_idx] if level_idx < len(errors) else []
+            for channel_idx, observed in enumerate(row_coverage):
+                channel = channel_names[channel_idx] if channel_idx < len(channel_names) else channel_idx
+                error = row_errors[channel_idx] if channel_idx < len(row_errors) else None
+                rows.append([model, channel, level, observed, error, item.get("n")])
+    return rows
+
+
 def _input_rows(scores_json, manifest):
     inputs = scores_json.get("inputs", {})
     rows = [
@@ -416,6 +442,7 @@ def build_product_kalman_markdown_report(
     bootstrap_rows = _bootstrap_rows(scores_json)
     bootstrap_artifact_rows = _bootstrap_artifact_rows(scores_json)
     pit_rows = _pit_rows(scores_json)
+    pit_coverage_rows = _pit_coverage_rows(scores_json)
     grouped_covariance_rows = _grouped_covariance_rows(scores_json)
     if grouped_covariance_rows:
         lines.extend([
@@ -458,6 +485,13 @@ def build_product_kalman_markdown_report(
             _markdown_table(["model", "channel", "ks_uniform", "n", "dimension", "method"], pit_rows),
             "",
         ])
+    if pit_coverage_rows:
+        lines.extend([
+            "## PIT Central Coverage",
+            "",
+            _markdown_table(["model", "channel", "nominal", "observed", "error", "n"], pit_coverage_rows),
+            "",
+        ])
     if bootstrap_rows:
         lines.extend([
             "## NLL Improvement Bootstrap Intervals",
@@ -495,7 +529,7 @@ def build_product_kalman_markdown_report(
         "",
         "- Positive NLL gain means the candidate had lower held-out mean NLL than the named baseline.",
         "- For a well-scaled d-dimensional Gaussian prediction, mean squared Mahalanobis should be near d; the per-dimension value should be near 1, with tail quantiles read as empirical diagnostics rather than a decision rule.",
-        "- PIT diagnostics, when present, summarize marginal CDF calibration; lower KS-vs-uniform is better, but it is still an exploratory shape diagnostic.",
+        "- PIT diagnostics, when present, summarize marginal CDF calibration; lower KS-vs-uniform and smaller absolute central-coverage error are better, but they are still exploratory shape diagnostics.",
         "- Bootstrap intervals, when present, are paired row-resampling diagnostics for NLL gains; they are not a preregistered decision rule.",
         "- Treat this as a held-out comparison artifact, not as a training-objective decision.",
         "- Product-Kalman should be compared against the registered joint-posterior and Sigma-conditioned baselines before promotion.",

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -24,6 +24,7 @@ from product_kalman_evaluation import (
     gaussian_marginal_pit_diagnostics,
     gaussian_marginal_pit_values,
     paired_bootstrap_nll_improvement,
+    pit_central_interval_coverage,
     pit_diagnostics_from_values,
     pit_uniform_ks_statistic,
     row_covariances_from_groups,
@@ -94,9 +95,14 @@ def test_correlated_product_kalman_beats_zero_cross_control_on_heldout_nll():
     assert product_pit.dimension == 1
     assert product_pit.pit.shape == (len(eval_target), 1)
     assert product_pit.channel_ks.shape == (1,)
+    assert product_pit.coverage_levels == (0.5, 0.8, 0.9, 0.95)
+    assert product_pit.central_interval_coverage.shape == (4, 1)
+    assert product_pit.central_interval_error.shape == (4, 1)
     assert 0.0 <= product_pit.channel_ks[0] <= 1.0
     assert product_pit.pit.flags.writeable is False
     assert product_pit.channel_ks.flags.writeable is False
+    assert product_pit.central_interval_coverage.flags.writeable is False
+    assert product_pit.central_interval_error.flags.writeable is False
     assert_raises(result.pit_diagnostic, "missing")
     assert result.correlated_update.mean.flags.writeable is False
     assert result.independent_update.mean.flags.writeable is False
@@ -211,7 +217,10 @@ def test_npz_runner_and_json_cli_roundtrip():
         assert data["pit_diagnostics"]["product_kalman"]["n"] == 4000
         assert data["pit_diagnostics"]["product_kalman"]["dimension"] == 1
         assert data["pit_diagnostics"]["product_kalman"]["method"] == "marginal_pit_uniform_ks"
+        assert data["pit_diagnostics"]["product_kalman"]["coverage_levels"] == [0.5, 0.8, 0.9, 0.95]
         assert len(data["pit_diagnostics"]["product_kalman"]["channel_ks"]) == 1
+        assert len(data["pit_diagnostics"]["product_kalman"]["central_interval_coverage"]) == 4
+        assert len(data["pit_diagnostics"]["product_kalman"]["central_interval_coverage"][0]) == 1
         assert "mean_squared_mahalanobis" in data["scores"]["product_kalman"]
         assert "squared_mahalanobis_q95" in data["scores"]["product_kalman"]
         assert 0.85 < data["scores"]["product_kalman"]["mahalanobis_per_dim"] < 1.15
@@ -275,6 +284,9 @@ def test_npz_runner_and_json_cli_roundtrip():
             assert artifact["pit_names"].tolist() == data["score_order"]
             assert artifact["pit_values"].shape == (4, 4000, 1)
             assert artifact["pit_channel_ks"].shape == (4, 1)
+            np.testing.assert_allclose(artifact["pit_coverage_levels"], [0.5, 0.8, 0.9, 0.95])
+            assert artifact["pit_central_interval_coverage"].shape == (4, 4, 1)
+            assert artifact["pit_central_interval_error"].shape == (4, 4, 1)
             assert artifact["product_kalman_mean"].shape == result.correlated_update.mean.shape
             np.testing.assert_allclose(artifact["product_kalman_mean"], result.correlated_update.mean)
             np.testing.assert_allclose(artifact["independent_kalman_mean"], result.independent_update.mean)
@@ -308,6 +320,9 @@ def test_evaluation_artifact_arrays_are_npz_ready():
     assert arrays["pit_names"].tolist() == ["prior", "measurement", "independent_kalman", "product_kalman"]
     assert arrays["pit_values"].shape == (4, 20, 1)
     assert arrays["pit_channel_ks"].shape == (4, 1)
+    np.testing.assert_allclose(arrays["pit_coverage_levels"], [0.5, 0.8, 0.9, 0.95])
+    assert arrays["pit_central_interval_coverage"].shape == (4, 4, 1)
+    assert arrays["pit_central_interval_error"].shape == (4, 4, 1)
     assert arrays["pit_summary_json"].shape == (4,)
     np.testing.assert_allclose(arrays["score_row_nll"].mean(axis=1), arrays["score_mean_nll"])
     assert np.isfinite(arrays["score_mahalanobis_per_dim"]).all()
@@ -400,6 +415,9 @@ def test_npz_runner_scores_grouped_covariances_when_group_labels_present():
             assert artifact["pit_names"].shape == (8,)
             assert artifact["pit_values"].shape == (8, n_eval, 1)
             assert artifact["pit_channel_ks"].shape == (8, 1)
+            np.testing.assert_allclose(artifact["pit_coverage_levels"], [0.5, 0.8, 0.9, 0.95])
+            assert artifact["pit_central_interval_coverage"].shape == (8, 4, 1)
+            assert artifact["pit_central_interval_error"].shape == (8, 4, 1)
             assert artifact["grouped_score_names"].tolist() == [
                 "prior_grouped",
                 "measurement_grouped",
@@ -611,19 +629,29 @@ def test_pit_diagnostics_validate_uniform_ks_and_json_shape():
     pit = np.array([[0.25, 0.10], [0.75, 0.90]])
     diag = pit_diagnostics_from_values("mix", pit, channel_names=("D", "S"))
     np.testing.assert_allclose(diag.channel_ks, [0.25, 0.40])
+    np.testing.assert_allclose(diag.central_interval_coverage, [[1.0, 0.0], [1.0, 1.0], [1.0, 1.0], [1.0, 1.0]])
+    np.testing.assert_allclose(diag.central_interval_error[0], [0.5, -0.5])
     assert diag.pit.flags.writeable is False
     assert diag.channel_ks.flags.writeable is False
-    assert diag.to_json_dict() == {
-        "n": 2,
-        "dimension": 2,
-        "channel_names": ["D", "S"],
-        "channel_ks": [0.25, 0.4],
-        "method": "marginal_pit_uniform_ks",
-    }
+    assert diag.central_interval_coverage.flags.writeable is False
+    assert diag.central_interval_error.flags.writeable is False
+    payload = diag.to_json_dict()
+    assert payload["n"] == 2
+    assert payload["dimension"] == 2
+    assert payload["channel_names"] == ["D", "S"]
+    assert payload["channel_ks"] == [0.25, 0.4]
+    assert payload["coverage_levels"] == [0.5, 0.8, 0.9, 0.95]
+    assert payload["method"] == "marginal_pit_uniform_ks"
+    np.testing.assert_allclose(payload["central_interval_coverage"], diag.central_interval_coverage)
+    np.testing.assert_allclose(payload["central_interval_error"], diag.central_interval_error)
+    custom = pit_central_interval_coverage(pit, coverage_levels=(0.5, 0.8))
+    np.testing.assert_allclose(custom, [[1.0, 0.0], [1.0, 1.0]])
     assert abs(pit_uniform_ks_statistic([0.25, 0.75]) - 0.25) < 1e-12
     assert_raises(pit_diagnostics_from_values, "bad", np.array([0.5, 0.6]))
     assert_raises(pit_diagnostics_from_values, "bad", np.array([[1.2]]))
     assert_raises(pit_diagnostics_from_values, "bad", np.array([[0.5]]), channel_names=("D", "S"))
+    assert_raises(pit_central_interval_coverage, pit, coverage_levels=(0.5, 0.5))
+    assert_raises(pit_central_interval_coverage, pit, coverage_levels=(0.0,))
 
 def test_gaussian_marginal_pit_values_support_fixed_and_rowwise_covariances():
     target = np.array([[0.0], [1.0], [-1.0]])

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -133,7 +133,9 @@ def test_markdown_report_records_scores_and_guardrails():
         assert "| product_kalman | independent_kalman |" in report
         assert "## NLL Improvement Bootstrap Intervals" in report
         assert "## PIT Diagnostics" in report
+        assert "## PIT Central Coverage" in report
         assert "marginal_pit_uniform_ks" in report
+        assert "absolute central-coverage error" in report
         assert "observed_gain" in report
         assert "paired row-resampling" in report
         assert "| calibration_rows | 80 |" in report
@@ -154,14 +156,20 @@ def test_markdown_report_records_pit_diagnostics_when_present():
                 "dimension": 2,
                 "channel_names": ["D", "S"],
                 "channel_ks": [0.08, 0.12],
+                "coverage_levels": [0.8, 0.9],
+                "central_interval_coverage": [[0.70, 0.75], [0.88, 0.91]],
+                "central_interval_error": [[-0.10, -0.05], [-0.02, 0.01]],
                 "method": "marginal_pit_uniform_ks",
             }
         }
         report = build_product_kalman_markdown_report(scores, manifest)
 
         assert "## PIT Diagnostics" in report
+        assert "## PIT Central Coverage" in report
         assert "| mix | D | 0.08 | 40 | 2 | marginal_pit_uniform_ks |" in report
         assert "| mix | S | 0.12 | 40 | 2 | marginal_pit_uniform_ks |" in report
+        assert "| mix | D | 0.8 | 0.7 | -0.1 | 40 |" in report
+        assert "| mix | S | 0.9 | 0.91 | 0.01 | 40 |" in report
         assert "PIT diagnostics, when present" in report
 
 def test_markdown_report_records_split_materialization_manifest():


### PR DESCRIPTION
Adds central-interval coverage summaries to Product-Kalman PIT diagnostics.

- Records default PIT central coverage at 50%, 80%, 90%, and 95%.
- Emits observed coverage and observed-minus-nominal error in JSON and NPZ artifacts.
- Adds a `PIT Central Coverage` table to Markdown reports.
- Updates the Product-Kalman design note so the diagnostic artifact inventory stays current.
- Extends evaluation/report tests for coverage arrays, JSON summaries, NPZ serialization, and report rendering.

Verification:
- `python3 -m py_compile ...`
- `python3 prototypes/mu_cosine/test_product_kalman_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_report.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_evaluation.py`
- `python3 prototypes/mu_cosine/test_product_kalman_table_to_npz.py`
- `git diff --check`