### PR TITLE
WAM/LLVM self-host capstone: the fixpoint runs (milestone 6 complete)

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -354,7 +354,7 @@ loadable along the way.
   and memoizes the compiler object (the `DYNCACHE` role). Verified end to end
   with a stand-in (echo) compiler: source text → emitted bytes → load → run →
   `42`. A real source-to-bytecode compiler is milestone 6.
-- **Milestone 6** (self-host) — *design landed.* A **minimal** Prolog→`.wamo`
+- **Milestone 6** (self-host) — **COMPLETE — the fixpoint runs.** A **minimal** Prolog→`.wamo`
   compiler written in the loadable subset (not the full ~22 000-line host
   compiler), run through the existing `@wam_object_eval` pipeline. The key
   enabler: `.wamo` is a **text** format, so emitting it is string assembly —
@@ -439,15 +439,21 @@ loadable along the way.
   invisible for tail-position fact calls (all earlier slices), fatal
   for the walkers' first non-tail fact call. Facts now allocate. The
   FULL walkers golden — deferral included — is byte-exact loaded
-  (35309). The remaining campaign: the capstone `compile(SelfSource)` —
-  the full fixpoint.
+  (35309). **THE CAPSTONE LANDED — the fixpoint runs**: the AOT-compiled
+  cgfull (gen1) compiles the compiler's own source (entry
+  `main2(Src, W)` — the source is a runtime argument, no quine needed)
+  to gen2 (36151 bytes); gen2, loaded, compiles the same source to
+  gen3; **gen2 == gen3 byte-identical** (F(F) = F), and gen3 compiles a
+  fresh golden byte-identically to the production `cgfull_term/2` —
+  the self-compiled compiler is behaviorally the compiler
+  (`selfhost_capstone_fixpoint`).
   The compile budget for the full self-compile is closed: the **chained
   arena** removed the memory cliff (blocks link on exhaustion and never
   move; marks are virtual offsets so mark/rewind work across growth), and
   the serializer's **difference-list linearisation** removed the quadratic
   time/allocation (an 11.9 KB source compiles loaded in 40 ms / 35 MB where
   the quadratic style took 20 s / 3.7 GB at half that size).
-  The campaign keeps surfacing and fixing latent runtime bugs — **eleven found
+  The campaign keeps surfacing and fixing latent runtime bugs — **thirteen found
   so far**: a 64-register-file ceiling corrupting memory for large clauses;
   `get_structure` not comparing the functor; the choice-point saved-register
   block not widened with the register file (failed clause bodies leaked Y17+
@@ -469,7 +475,13 @@ loadable along the way.
   explicit abort flag checked at backtrack entry; and the reader
   var-dict silently falling back to fresh-per-occurrence variables past
   128 distinct names (the self-hosted compiler miscompiled its own
-  serializer) — fixed with a growable dict. See
+  serializer) — fixed with a growable dict; plus the re-entry pair
+  above (no. 12: monotonic heap + fact environments), and the capstone
+  finding (no. 13): loaded arithmetic had **no error channel** — unknown
+  functors evaluated to a benign 0, and the first-byte dispatch let
+  unknown names *alias* real ops (`f(2)` ran as `floor(2)`) — fixed
+  with an arith-error flag failing `is/2` and the comparisons, plus a
+  full-name whitelist gate before dispatch. See
   [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md).
 
 ## The binary-return question, specifically

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -809,16 +809,52 @@ re-entry consistency is what must be fixed. First-argument indexing
 (deliberately NOPed in the loader) would mask most instances but is
 not the correctness fix.
 
-**Remaining toward the full fixpoint:** every compiler stage is now
-self-compiled AND byte-exact loaded — serializer, single-clause middle,
-grouping/label/chain front, generic table walk, and the complete
-walkers including both deferral directions. Finding no. 12 is closed
-(monotonic heap + fact environments). What is left is the capstone
-itself: stitch the slices into one `compile(SelfSource)` whose accepted
-subset covers its own source, and run the fixpoint.
+**THE CAPSTONE — the fixpoint runs (milestone 6 COMPLETE).** The
+self-source is the full walkers compiler with entry
+`main2(Src, W) :- cm3(Src, Cs), atom_codes(W, Cs)` — the source to
+compile arrives as a *runtime argument*, so no quine construction is
+needed; the same 12.7 KB text is both the program being compiled and
+the program doing the compiling. The chain
+(`selfhost_capstone_fixpoint`):
 
-**Deliverable:** the demonstrable self-host — the compiler compiles itself,
-and `compile(SelfSource)` yields a working compiler object.
+1. **gen1** — the AOT-compiled `cgfull.wamo` (production
+   `wam_llvm_target` output) — compiles the self-source → **gen2**
+   (36151 bytes, ~54 ms/generation);
+2. **gen2**, loaded through `@wam_object_eval`, compiles the *same*
+   self-source → **gen3**;
+3. `gen2 == gen3` **byte-identical** — F(F) = F, the fixpoint;
+4. the triangle closes: **gen3** compiles a fresh golden (ITE +
+   comparison guard, library builtins, repeated-variable structure
+   head, nested-pattern and nested-expression deferral) byte-identical
+   to the production `cgfull_term/2` on the same clauses.
+
+*Capstone finding (campaign no. 13) — the arithmetic error channel.*
+The first fixpoint attempt drifted by one instruction per
+numbervarred-marker clause (gen3 emitted `get_variable` where gen2 had
+`get_structure '$VAR'/1`). The loaded `eval_arith_value` had **no
+failure channel**: unknown functors returned a benign Integer 0, so the
+walkers' `Y is 48 + N` guard *succeeded* with 48 when `N` was the term
+`'$VAR'(0)` — where SWI raises a type error and the dispatch clause
+fails through. Two layers:
+
+- **ev_zero is now an error, not a zero:** a `@wam_arith_err` flag set
+  on every unknown/failing evaluation path, cleared and checked by
+  `is/2` and all six arithmetic comparisons, which fail cleanly when
+  it is raised.
+- **first-byte dispatch aliasing:** the evaluator routed on the first
+  functor byte (plus second/third-byte splits), so unknown functors
+  sharing a prefix with a real op silently *aliased* it — `f(2)`
+  evaluated as `floor(2)`, `g(5, 6)` as `gcd(5, 6)` — bypassing
+  ev_zero entirely. A whitelist gate (`wam_arith_name_ok`) now strcmps
+  the full functor name against the exact implemented-op set per arity
+  before dispatch; unknown names fail through the error flag.
+  Regression: `selfhost_arith_error_fails_cleanly`
+  (`X is 1 + f(2)` must fail into the else branch, as in SWI).
+
+**Deliverable (met):** the demonstrable self-host — the compiler
+compiles itself, the self-compiled compiler compiles itself to the
+byte, and the object it produces compiles fresh programs identically
+to the production compiler.
 
 ## Risks and open questions
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -7755,7 +7755,15 @@ builtin_is:
   ; of the integer eval_arith''s 0. Everything else still routes
   ; through integer eval_arith (boxed via value_integer).
   %is.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  store i1 0, i1* @wam_arith_err
   %is.result_val = call %Value @eval_arith_value(%WamState* %vm, %Value %is.a2)
+  %is.err = load i1, i1* @wam_arith_err
+  br i1 %is.err, label %is.eval_failed, label %is.eval_ok
+
+is.eval_failed:
+  ret i1 false
+
+is.eval_ok:
   %is.a1d = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
   %is.a1_unb = call i1 @value_is_unbound(%Value %is.a1d)
   br i1 %is.a1_unb, label %is.do_bind, label %is.check_eq
@@ -7777,8 +7785,14 @@ builtin_gt:
   ; otherwise compare integer payloads with icmp.
   %gt.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %gt.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  store i1 0, i1* @wam_arith_err
   %gt.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %gt.a1)
   %gt.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %gt.a2)
+  %gt.aerr = load i1, i1* @wam_arith_err
+  br i1 %gt.aerr, label %gt.arith_failed, label %gt.arith_ok
+gt.arith_failed:
+  ret i1 false
+gt.arith_ok:
   %gt.t1 = extractvalue %Value %gt.e1, 0
   %gt.t2 = extractvalue %Value %gt.e2, 0
   %gt.f1 = icmp eq i32 %gt.t1, 2
@@ -7799,8 +7813,14 @@ gt.float:
 builtin_lt:
   %lt.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %lt.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  store i1 0, i1* @wam_arith_err
   %lt.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %lt.a1)
   %lt.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %lt.a2)
+  %lt.aerr = load i1, i1* @wam_arith_err
+  br i1 %lt.aerr, label %lt.arith_failed, label %lt.arith_ok
+lt.arith_failed:
+  ret i1 false
+lt.arith_ok:
   %lt.t1 = extractvalue %Value %lt.e1, 0
   %lt.t2 = extractvalue %Value %lt.e2, 0
   %lt.f1 = icmp eq i32 %lt.t1, 2
@@ -7821,8 +7841,14 @@ lt.float:
 builtin_ge:
   %ge.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %ge.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  store i1 0, i1* @wam_arith_err
   %ge.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %ge.a1)
   %ge.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %ge.a2)
+  %ge.aerr = load i1, i1* @wam_arith_err
+  br i1 %ge.aerr, label %ge.arith_failed, label %ge.arith_ok
+ge.arith_failed:
+  ret i1 false
+ge.arith_ok:
   %ge.t1 = extractvalue %Value %ge.e1, 0
   %ge.t2 = extractvalue %Value %ge.e2, 0
   %ge.f1 = icmp eq i32 %ge.t1, 2
@@ -7843,8 +7869,14 @@ ge.float:
 builtin_le:
   %le.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %le.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  store i1 0, i1* @wam_arith_err
   %le.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %le.a1)
   %le.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %le.a2)
+  %le.aerr = load i1, i1* @wam_arith_err
+  br i1 %le.aerr, label %le.arith_failed, label %le.arith_ok
+le.arith_failed:
+  ret i1 false
+le.arith_ok:
   %le.t1 = extractvalue %Value %le.e1, 0
   %le.t2 = extractvalue %Value %le.e2, 0
   %le.f1 = icmp eq i32 %le.t1, 2
@@ -7865,8 +7897,14 @@ le.float:
 builtin_arith_eq:
   %aeq.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %aeq.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  store i1 0, i1* @wam_arith_err
   %aeq.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %aeq.a1)
   %aeq.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %aeq.a2)
+  %aeq.aerr = load i1, i1* @wam_arith_err
+  br i1 %aeq.aerr, label %aeq.arith_failed, label %aeq.arith_ok
+aeq.arith_failed:
+  ret i1 false
+aeq.arith_ok:
   %aeq.t1 = extractvalue %Value %aeq.e1, 0
   %aeq.t2 = extractvalue %Value %aeq.e2, 0
   %aeq.f1 = icmp eq i32 %aeq.t1, 2
@@ -7887,8 +7925,14 @@ aeq.float:
 builtin_arith_ne:
   %ane.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %ane.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  store i1 0, i1* @wam_arith_err
   %ane.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %ane.a1)
   %ane.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %ane.a2)
+  %ane.aerr = load i1, i1* @wam_arith_err
+  br i1 %ane.aerr, label %ane.arith_failed, label %ane.arith_ok
+ane.arith_failed:
+  ret i1 false
+ane.arith_ok:
   %ane.t1 = extractvalue %Value %ane.e1, 0
   %ane.t2 = extractvalue %Value %ane.e2, 0
   %ane.f1 = icmp eq i32 %ane.t1, 2
@@ -17339,6 +17383,201 @@ fail:
 ; the result is Float. The legacy integer-only @eval_arith is kept
 ; for paths that still need an i64 directly (currently none in the
 ; merged tree).
+@wam_arith_err = internal global i1 0
+
+; Capstone finding (part 2): the arith dispatch below routes on the
+; FIRST BYTE of the functor name (plus second/third-byte splits), so
+; an UNKNOWN functor sharing a prefix with a real op silently aliased
+; it -- f(2) evaluated as floor(2), g(5,6) as gcd(5,6). SWI raises a
+; type error for these; parity requires they FAIL. This gate strcmps
+; the full functor name against the exact set of implemented op names
+; per arity BEFORE dispatch; unknown names go to ev_zero, which sets
+; @wam_arith_err so is/2 and the arithmetic comparisons fail cleanly.
+; Names are emitted as raw byte arrays to sidestep string escaping.
+@.aop_b0 = private constant [2 x i8] [i8 43, i8 0]
+@.aop_b1 = private constant [2 x i8] [i8 45, i8 0]
+@.aop_b2 = private constant [2 x i8] [i8 42, i8 0]
+@.aop_b3 = private constant [3 x i8] [i8 42, i8 42, i8 0]
+@.aop_b4 = private constant [2 x i8] [i8 47, i8 0]
+@.aop_b5 = private constant [3 x i8] [i8 47, i8 47, i8 0]
+@.aop_b6 = private constant [3 x i8] [i8 47, i8 92, i8 0]
+@.aop_b7 = private constant [3 x i8] [i8 60, i8 60, i8 0]
+@.aop_b8 = private constant [3 x i8] [i8 62, i8 62, i8 0]
+@.aop_b9 = private constant [3 x i8] [i8 92, i8 47, i8 0]
+@.aop_b10 = private constant [4 x i8] [i8 109, i8 111, i8 100, i8 0]
+@.aop_b11 = private constant [4 x i8] [i8 109, i8 97, i8 120, i8 0]
+@.aop_b12 = private constant [4 x i8] [i8 109, i8 105, i8 110, i8 0]
+@.aop_b13 = private constant [6 x i8] [i8 97, i8 116, i8 97, i8 110, i8 50, i8 0]
+@.aop_b14 = private constant [4 x i8] [i8 103, i8 99, i8 100, i8 0]
+@.aop_b15 = private constant [4 x i8] [i8 108, i8 111, i8 103, i8 0]
+@.aop_b16 = private constant [4 x i8] [i8 120, i8 111, i8 114, i8 0]
+@.aop_u0 = private constant [2 x i8] [i8 45, i8 0]
+@.aop_u1 = private constant [2 x i8] [i8 92, i8 0]
+@.aop_u2 = private constant [4 x i8] [i8 97, i8 98, i8 115, i8 0]
+@.aop_u3 = private constant [5 x i8] [i8 97, i8 115, i8 105, i8 110, i8 0]
+@.aop_u4 = private constant [5 x i8] [i8 97, i8 99, i8 111, i8 115, i8 0]
+@.aop_u5 = private constant [5 x i8] [i8 97, i8 116, i8 97, i8 110, i8 0]
+@.aop_u6 = private constant [6 x i8] [i8 114, i8 111, i8 117, i8 110, i8 100, i8 0]
+@.aop_u7 = private constant [6 x i8] [i8 102, i8 108, i8 111, i8 111, i8 114, i8 0]
+@.aop_u8 = private constant [8 x i8] [i8 99, i8 101, i8 105, i8 108, i8 105, i8 110, i8 103, i8 0]
+@.aop_u9 = private constant [4 x i8] [i8 99, i8 111, i8 115, i8 0]
+@.aop_u10 = private constant [5 x i8] [i8 115, i8 113, i8 114, i8 116, i8 0]
+@.aop_u11 = private constant [5 x i8] [i8 115, i8 105, i8 103, i8 110, i8 0]
+@.aop_u12 = private constant [4 x i8] [i8 115, i8 105, i8 110, i8 0]
+@.aop_u13 = private constant [9 x i8] [i8 116, i8 114, i8 117, i8 110, i8 99, i8 97, i8 116, i8 101, i8 0]
+@.aop_u14 = private constant [4 x i8] [i8 116, i8 97, i8 110, i8 0]
+@.aop_u15 = private constant [4 x i8] [i8 108, i8 111, i8 103, i8 0]
+@.aop_u16 = private constant [4 x i8] [i8 101, i8 120, i8 112, i8 0]
+
+define i1 @wam_arith_name_ok(i8* %fn, i32 %arity) {
+entry:
+  %is2 = icmp eq i32 %arity, 2
+  br i1 %is2, label %b0, label %chk1
+chk1:
+  %is1 = icmp eq i32 %arity, 1
+  br i1 %is1, label %u0, label %no
+b0:
+  %b0.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.aop_b0, i32 0, i32 0))
+  %b0.z = icmp eq i32 %b0.c, 0
+  br i1 %b0.z, label %yes, label %b1
+b1:
+  %b1.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.aop_b1, i32 0, i32 0))
+  %b1.z = icmp eq i32 %b1.c, 0
+  br i1 %b1.z, label %yes, label %b2
+b2:
+  %b2.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.aop_b2, i32 0, i32 0))
+  %b2.z = icmp eq i32 %b2.c, 0
+  br i1 %b2.z, label %yes, label %b3
+b3:
+  %b3.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @.aop_b3, i32 0, i32 0))
+  %b3.z = icmp eq i32 %b3.c, 0
+  br i1 %b3.z, label %yes, label %b4
+b4:
+  %b4.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.aop_b4, i32 0, i32 0))
+  %b4.z = icmp eq i32 %b4.c, 0
+  br i1 %b4.z, label %yes, label %b5
+b5:
+  %b5.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @.aop_b5, i32 0, i32 0))
+  %b5.z = icmp eq i32 %b5.c, 0
+  br i1 %b5.z, label %yes, label %b6
+b6:
+  %b6.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @.aop_b6, i32 0, i32 0))
+  %b6.z = icmp eq i32 %b6.c, 0
+  br i1 %b6.z, label %yes, label %b7
+b7:
+  %b7.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @.aop_b7, i32 0, i32 0))
+  %b7.z = icmp eq i32 %b7.c, 0
+  br i1 %b7.z, label %yes, label %b8
+b8:
+  %b8.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @.aop_b8, i32 0, i32 0))
+  %b8.z = icmp eq i32 %b8.c, 0
+  br i1 %b8.z, label %yes, label %b9
+b9:
+  %b9.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @.aop_b9, i32 0, i32 0))
+  %b9.z = icmp eq i32 %b9.c, 0
+  br i1 %b9.z, label %yes, label %b10
+b10:
+  %b10.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_b10, i32 0, i32 0))
+  %b10.z = icmp eq i32 %b10.c, 0
+  br i1 %b10.z, label %yes, label %b11
+b11:
+  %b11.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_b11, i32 0, i32 0))
+  %b11.z = icmp eq i32 %b11.c, 0
+  br i1 %b11.z, label %yes, label %b12
+b12:
+  %b12.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_b12, i32 0, i32 0))
+  %b12.z = icmp eq i32 %b12.c, 0
+  br i1 %b12.z, label %yes, label %b13
+b13:
+  %b13.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.aop_b13, i32 0, i32 0))
+  %b13.z = icmp eq i32 %b13.c, 0
+  br i1 %b13.z, label %yes, label %b14
+b14:
+  %b14.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_b14, i32 0, i32 0))
+  %b14.z = icmp eq i32 %b14.c, 0
+  br i1 %b14.z, label %yes, label %b15
+b15:
+  %b15.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_b15, i32 0, i32 0))
+  %b15.z = icmp eq i32 %b15.c, 0
+  br i1 %b15.z, label %yes, label %b16
+b16:
+  %b16.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_b16, i32 0, i32 0))
+  %b16.z = icmp eq i32 %b16.c, 0
+  br i1 %b16.z, label %yes, label %no
+u0:
+  %u0.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.aop_u0, i32 0, i32 0))
+  %u0.z = icmp eq i32 %u0.c, 0
+  br i1 %u0.z, label %yes, label %u1
+u1:
+  %u1.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.aop_u1, i32 0, i32 0))
+  %u1.z = icmp eq i32 %u1.c, 0
+  br i1 %u1.z, label %yes, label %u2
+u2:
+  %u2.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_u2, i32 0, i32 0))
+  %u2.z = icmp eq i32 %u2.c, 0
+  br i1 %u2.z, label %yes, label %u3
+u3:
+  %u3.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.aop_u3, i32 0, i32 0))
+  %u3.z = icmp eq i32 %u3.c, 0
+  br i1 %u3.z, label %yes, label %u4
+u4:
+  %u4.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.aop_u4, i32 0, i32 0))
+  %u4.z = icmp eq i32 %u4.c, 0
+  br i1 %u4.z, label %yes, label %u5
+u5:
+  %u5.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.aop_u5, i32 0, i32 0))
+  %u5.z = icmp eq i32 %u5.c, 0
+  br i1 %u5.z, label %yes, label %u6
+u6:
+  %u6.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.aop_u6, i32 0, i32 0))
+  %u6.z = icmp eq i32 %u6.c, 0
+  br i1 %u6.z, label %yes, label %u7
+u7:
+  %u7.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.aop_u7, i32 0, i32 0))
+  %u7.z = icmp eq i32 %u7.c, 0
+  br i1 %u7.z, label %yes, label %u8
+u8:
+  %u8.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @.aop_u8, i32 0, i32 0))
+  %u8.z = icmp eq i32 %u8.c, 0
+  br i1 %u8.z, label %yes, label %u9
+u9:
+  %u9.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_u9, i32 0, i32 0))
+  %u9.z = icmp eq i32 %u9.c, 0
+  br i1 %u9.z, label %yes, label %u10
+u10:
+  %u10.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.aop_u10, i32 0, i32 0))
+  %u10.z = icmp eq i32 %u10.c, 0
+  br i1 %u10.z, label %yes, label %u11
+u11:
+  %u11.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.aop_u11, i32 0, i32 0))
+  %u11.z = icmp eq i32 %u11.c, 0
+  br i1 %u11.z, label %yes, label %u12
+u12:
+  %u12.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_u12, i32 0, i32 0))
+  %u12.z = icmp eq i32 %u12.c, 0
+  br i1 %u12.z, label %yes, label %u13
+u13:
+  %u13.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.aop_u13, i32 0, i32 0))
+  %u13.z = icmp eq i32 %u13.c, 0
+  br i1 %u13.z, label %yes, label %u14
+u14:
+  %u14.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_u14, i32 0, i32 0))
+  %u14.z = icmp eq i32 %u14.c, 0
+  br i1 %u14.z, label %yes, label %u15
+u15:
+  %u15.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_u15, i32 0, i32 0))
+  %u15.z = icmp eq i32 %u15.c, 0
+  br i1 %u15.z, label %yes, label %u16
+u16:
+  %u16.c = call i32 @strcmp(i8* %fn, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.aop_u16, i32 0, i32 0))
+  %u16.z = icmp eq i32 %u16.c, 0
+  br i1 %u16.z, label %yes, label %no
+yes:
+  ret i1 1
+no:
+  ret i1 0
+}
+
 define %Value @eval_arith_value(%WamState* %vm, %Value %expr_raw) {
 entry:
   %expr = call %Value @wam_deref_value(%WamState* %vm, %Value %expr_raw)
@@ -17390,6 +17629,10 @@ ev_compound:
   %fn0 = load i8, i8* %fn_ptr
   %args_slot = getelementptr %Compound, %Compound* %cp_ptr, i32 0, i32 2
   %args = load %Value*, %Value** %args_slot
+  %aop_ok = call i1 @wam_arith_name_ok(i8* %fn_ptr, i32 %arity)
+  br i1 %aop_ok, label %ev_known_op, label %ev_zero
+
+ev_known_op:
   %is_binary = icmp eq i32 %arity, 2
   br i1 %is_binary, label %ev_eval_binary, label %ev_check_unary
 
@@ -17985,10 +18228,17 @@ ev_sign_f:
   ret %Value %sign_v_f
 
 ev_zero:
-  ; Unknown / fail -- return Integer 0 as a benign placeholder. The
-  ; legacy @eval_arith printed an error to stderr here; for the
-  ; tagged path we just box zero so callers don''t crash on an
-  ; unrecognized expression.
+  ; Unknown / fail -- box Integer 0 so callers do not crash, and SET
+  ; THE ARITHMETIC ERROR FLAG so is/2 and the comparisons FAIL like
+  ; SWI raises a type/evaluation error (capstone finding: without
+  ; this, Y is 48 + F with F a non-arithmetic compound silently
+  ; evaluated to 48, so the self-compiled compiler dispatch clause
+  ; guarded by that failure wrongly succeeded -- the numbervarred
+  ; marker pattern in its own source compiled as a plain variable and
+  ; the self-compile diverged from the production compiler by one
+  ; instruction per marker clause). The flag is cleared by each
+  ; consuming builtin before evaluation.
+  store i1 1, i1* @wam_arith_err
   %z_v = call %Value @value_integer(i64 0)
   ret %Value %z_v
 }'.

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -2215,6 +2215,81 @@ test(selfhost_finding12_no_heap_oob, [condition(clang_available)]) :-
     assertion(Out == "6\n"),
     !.
 
+% ============================ THE CAPSTONE ============================
+% compile(SelfSource): the fixpoint. gen 1 = the AOT-compiled cgfull.
+% The SELF-SOURCE is the walkers compiler itself, re-entered through
+% main2(Src, W) :- cm3(Src, Cs), atom_codes(W, Cs) -- the source text
+% arrives as a runtime argument, so no quine trick is needed. gen 2 =
+% gen 1 compiling the self-source (a working compiler object, proven
+% byte-exact against cgfull all campaign). gen 3 = GEN 2 COMPILING ITS
+% OWN SOURCE. Because gen 2 reproduces cgfull's bytes exactly, gen 3
+% must equal gen 2 BYTE-FOR-BYTE: F(F) = F -- the compiler compiles
+% itself and the self-compiled compiler is the same object. The
+% triangle is closed by gen 3 compiling the full walkers golden
+% byte-identically to the production cgfull middle.
+test(selfhost_capstone_fixpoint, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'dump_host_bin', Dump),
+    ( exists_file(Dump) -> true ; build_dump_host(Dir, Dump) ),
+    fixpoint_walkers_source(Walkers),
+    once(sub_atom(Walkers, BPos, _, _, '), (cm3(')),
+    Skip is BPos + 2,
+    sub_atom(Walkers, Skip, _, 0, Rest),
+    atom_concat('[(main2(Src2, W2) :- cm3(Src2, Cs2), atom_codes(W2, Cs2)),',
+                Rest, SelfSrc),
+    directory_file_path(Dir, 'self_src.txt', SelfPath),
+    setup_call_cleanup(open(SelfPath, write, S0),
+        write(S0, SelfSrc), close(S0)),
+    run_dump(Dump, CompWamo, SelfPath, Gen2Bytes),
+    directory_file_path(Dir, 'gen2.wamo', Gen2Path),
+    setup_call_cleanup(open(Gen2Path, write, S1),
+        write(S1, Gen2Bytes), close(S1)),
+    run_dump(Dump, Gen2Path, SelfPath, Gen3Bytes),
+    assertion(Gen2Bytes == Gen3Bytes),
+    directory_file_path(Dir, 'gen3.wamo', Gen3Path),
+    setup_call_cleanup(open(Gen3Path, write, S2),
+        write(S2, Gen3Bytes), close(S2)),
+    directory_file_path(Dir, 'cap_gold.txt', GoldPath),
+    setup_call_cleanup(open(GoldPath, write, S3),
+        write(S3, '[(cls(N, R2) :- (N >= 10 -> R2 = big ; R2 = small)), (sum2(Xs, R3) :- append(Xs, [7], Ys), sum_list(Ys, R3)), swap(p(X, Y), p(Y, X)), w(f(g(Z)), Z), (tot([A, B], R4) :- R4 is (A + B) * 2)]'),
+        close(S3)),
+    run_dump(Dump, Gen3Path, GoldPath, GoldBytes),
+    cgfull_term([(cls(N, R2) :- (N >= 10 -> R2 = big ; R2 = small)),
+                 (sum2(Xs, R3) :- append(Xs, [7], Ys), sum_list(Ys, R3)),
+                 swap(p(X, Y), p(Y, X)),
+                 w(f(g(Z)), Z),
+                 (tot([A, B], R4) :- R4 is (A + B) * 2)], WGold),
+    atom_string(GoldAtom, GoldBytes),
+    assertion(GoldAtom == WGold),
+    !.
+
+% Capstone finding regression: loaded arithmetic on a NON-ARITHMETIC
+% compound must FAIL (SWI raises a type error) rather than silently
+% evaluating the unknown functor to 0. Before the @wam_arith_err flag,
+% X is 1 + f(2) succeeded with X = 1, so any dispatch clause guarded by
+% an is-failure wrongly committed -- the self-compile diverged from the
+% production compiler at exactly its numbervarred-marker clauses.
+test(selfhost_arith_error_fails_cleanly, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgae_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- (X is 1 + f(2) -> R = X ; R = 2))]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "2\n"),
+    !.
+
 % Nested arithmetic in the loaded compiler: the is-expression is staged
 % with c_operand (build_struct + X-temp deferral), so arbitrarily nested
 % expressions compile. (X + Y) * (X - 1) + 100 with X=3, Y=4 -> 114.
@@ -2683,6 +2758,64 @@ prn:\n\c
   %fmt = getelementptr [6 x i8], [6 x i8]* @.ev_fmt, i32 0, i32 0\n\c
   %pr = call i32 (i8*, ...) @printf(i8* %fmt, i64 %val)\n  ret i32 0\n\c
 fail:\n  ret i32 21\n}\n').
+
+run_dump(Dump, Comp, Src, Bytes) :-
+    process_create(Dump, [Comp, Src],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Bytes),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    Status == 0.
+
+% A bytes-dump host: load a compiler object, run it on a source file via
+% @wam_object_call_bytes, print the emitted object text. This is stage 1
+% of the eval host in isolation -- it lets the capstone test CHAIN
+% compilers: dump(gen_n, src) emits gen_{n+1}, which is itself loadable.
+build_dump_host(Dir, Host) :-
+    directory_file_path(Dir, 'dump_host.ll', LL),
+    with_output_to(string(_),
+        write_wam_llvm_project([user:answer/1],
+            [module_name(wam_object_dump_host), emit_wamo_loader(true)], LL)),
+    dump_host_main_ir(MainIR),
+    setup_call_cleanup(
+        open(LL, append, S, [encoding(utf8)]),
+        write(S, MainIR),
+        close(S)),
+    directory_file_path(Dir, 'dump_host_bin', Host),
+    clang_link(LL, Host).
+
+dump_host_main_ir(
+'\n@.dh_fmt = private constant [5 x i8] c"%.*s\\00"\n\n\c
+define i32 @main(i32 %argc, i8** %argv) {\n\c
+entry:\n\c
+  %p1 = getelementptr i8*, i8** %argv, i64 1\n  %cp = load i8*, i8** %p1\n\c
+  %p2 = getelementptr i8*, i8** %argv, i64 2\n  %sp = load i8*, i8** %p2\n\c
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %cp)\n\c
+  %vm = extractvalue { %WamState*, i32 } %obj, 0\n\c
+  %pc = extractvalue { %WamState*, i32 } %obj, 1\n\c
+  %vmn = icmp eq %WamState* %vm, null\n  br i1 %vmn, label %lf, label %rd\n\c
+rd:\n\c
+  %totp = alloca i64\n\c
+  %sbuf = call i8* @wamo_read_file(i8* %sp, i64* %totp)\n\c
+  %sbn = icmp eq i8* %sbuf, null\n  br i1 %sbn, label %lf, label %go\n\c
+go:\n\c
+  %slen = load i64, i64* %totp\n\c
+  %sid = call i64 @wam_intern_atom(i8* %sbuf, i64 %slen)\n\c
+  %v0 = insertvalue %Value undef, i32 0, 0\n\c
+  %sv = insertvalue %Value %v0, i64 %sid, 1\n\c
+  %args = alloca %Value, i32 1\n\c
+  store %Value %sv, %Value* %args\n\c
+  %r = call { i8*, i64, i1 } @wam_object_call_bytes(%WamState* %vm, i32 %pc, i32 1, %Value* %args, i32 1)\n\c
+  %ptr = extractvalue { i8*, i64, i1 } %r, 0\n\c
+  %len = extractvalue { i8*, i64, i1 } %r, 1\n\c
+  %ok = extractvalue { i8*, i64, i1 } %r, 2\n\c
+  br i1 %ok, label %pr, label %rf\n\c
+pr:\n\c
+  %l32 = trunc i64 %len to i32\n\c
+  %f = getelementptr [5 x i8], [5 x i8]* @.dh_fmt, i32 0, i32 0\n\c
+  %x = call i32 (i8*, ...) @printf(i8* %f, i32 %l32, i8* %ptr)\n  ret i32 0\n\c
+lf:\n  ret i32 20\n\c
+rf:\n  ret i32 21\n}\n').
 
 clang_link(LL, Bin) :-
     format(atom(Cmd), 'clang -w -O2 ~w -o ~w -lm 2>&1', [LL, Bin]),


### PR DESCRIPTION
## THE CAPSTONE — the self-host fixpoint runs

The loaded bootstrap compiler closes the fixpoint that the whole campaign was climbing toward:

1. **gen1** — the AOT-compiled `cgfull.wamo` (production `wam_llvm_target` output) — compiles the compiler's **own source** → **gen2** (36151 bytes, ~54 ms/generation).
2. **gen2**, loaded through `@wam_object_eval`, compiles the **same** source → **gen3**.
3. **`gen2 == gen3` byte-identical** — F(F) = F.
4. The triangle closes: **gen3** compiles a fresh golden (ITE + comparison guard, library builtins, repeated-variable structure head, both X-temp deferral directions) **byte-identically to the production `cgfull_term/2`** — the self-compiled compiler is behaviorally *the* compiler.

The self-source's entry is `main2(Src, W) :- cm3(Src, Cs), atom_codes(W, Cs)` — the source to compile arrives as a runtime argument, so no quine construction is needed; the same 12.7 KB text is both the program being compiled and the program doing the compiling.

## Capstone finding (campaign no. 13): loaded arithmetic had no error channel

The first fixpoint attempt drifted by one instruction per numbervarred-marker clause (gen3 emitted `get_variable` where gen2 had `get_structure '$VAR'/1`). Root cause, in two layers:

- **`ev_zero` returned a benign 0.** `eval_arith_value`'s unknown-functor path boxed Integer 0 with no failure signal, so the walkers' `Y is 48 + N` guard *succeeded* with 48 when `N` was the term `'$VAR'(0)` — where SWI raises a type error and the dispatch clause fails through. Fix: a `@wam_arith_err` flag set on every unknown/failing evaluation path, cleared and checked by `is/2` and all six arithmetic comparisons, which now fail cleanly.
- **First-byte dispatch aliasing.** The evaluator routed on the first functor byte (plus second/third-byte splits), so an unknown functor sharing a prefix with a real op silently *aliased* it — `f(2)` evaluated as `floor(2)`, `g(5, 6)` as `gcd(5, 6)` — bypassing `ev_zero` entirely. Fix: a full-name whitelist gate (`wam_arith_name_ok`, byte-array names + `strcmp`) verifies the functor name against the exact implemented-op set per arity *before* dispatch; unknown names fail through the error flag.

## Tests

- `selfhost_capstone_fixpoint` — the full chain (gen1 → gen2 → gen3, byte-equality assertion) plus the gen3-compiles-golden triangle, with new `run_dump/4` / `build_dump_host/2` helpers (a host that prints the compiled object bytes).
- `selfhost_arith_error_fails_cleanly` — `X is 1 + f(2)` must fail into the else branch, as in SWI (was: succeeded with 3 via the `floor` alias).
- Full battery fresh-cache: complete `wam_object` suite, `test_llvm_target` (FAIL count 0), `test_plawk_dyncall`, `test_plawk_compiled_stream_core`, and the arith-sensitive execution suites (countdown-sum, A*, Dijkstra, chained-arena runtime) all pass.

## Docs

- `PLAWK_SELFHOST.md` — THE CAPSTONE section; milestone 6 **COMPLETE**; deliverable marked met.
- `PLAWK_JIT_ROADMAP.md` — milestone 6 status, fixpoint summary, finding tally (thirteen runtime bugs surfaced and fixed by the campaign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_