### PR TITLE
mu_cosine: Lever B probe — judge tokens don't route; the SYM head is a missing channel; B1–B3 plan

### DIFF
--- a/prototypes/mu_cosine/REPORT_channel_heads_probe.md
+++ b/prototypes/mu_cosine/REPORT_channel_heads_probe.md
@@ -1,0 +1,48 @@
+# Lever B opening probe: the judge tokens don't route — per-channel heads must be trained
+
+*`run_channel_heads_probe.py`, 2026-07-09. Before building `DESIGN_amortized_fusion_heads.md` step 2
+(per-channel heads mu_graph, mu_LLM), measure whether the existing checkpoint already carries them: the
+architecture has judge-conditioned provenance tokens (`JUDGES`), and `model_prod.pt` was trained with
+judge-tagged rows. Probe: query the checkpoint on both corpora under three conditionings and correlate each
+readout with each channel's ground truth.*
+
+## Facts found
+
+- `model_prod.pt` carries **5 judge rows** (haiku/graph/human/sonnet/opus) — it predates the gpt-5.5-low,
+  blend, and dir-blend rows; no local checkpoint has more than 5. The checkpoint's trained LLM judge is HAIKU.
+- **The judge tokens do not route.** All three conditionings (agnostic / judge=graph / judge=haiku) produce
+  nearly identical readouts: |Δ| ≈ 0.02–0.07, and the graph-Δ and llm-Δ are CORRELATED (+0.44 to +0.62) — a
+  shared shift, not channel differentiation. The graph-conditioned readout predicts the walk no better than
+  agnostic (fresh: 0.283 vs 0.277); the llm-conditioned predicts LLM labels no better (0.572 vs 0.567).
+  The judge rows learned calibration offsets, not channels. **Step 2 is NOT amortized; it must be trained.**
+- **The SYM readout has ~ZERO correlation with the LLM's S channel** (−0.06 to +0.02, both corpora) while
+  correlating +0.5 with D. The model's "symmetric" head tracks directionality, not the judge's associative
+  signal — the mu_S feature fed to the fusion arcs was never really the S channel (the covariance fits priced
+  this correctly, which is why fusion still worked). A trained S head is a MISSING CHANNEL, not a refinement —
+  likely the largest single amortization win available.
+
+## Build plan (next PRs)
+
+1. **B1 — per-channel heads:** resize judge_emb 5→9 (copy 5 rows, zero-init the rest), fine-tune from
+   model_prod.pt with channel-tagged rows: (pair, HIER, judge=gpt-5.5-low → D), (pair, SYM, judge=gpt-5.5-low
+   → S), (pair, HIER, judge=graph → walk hit_prob). Data: the ~1,380 scored pairs + free graph targets.
+   Descendant-disjoint eval: per-channel correlation under each conditioning (this probe re-run = the
+   acceptance test: routing must appear) + trunk non-degradation on the standard eval.
+2. **B2 — fused head:** distill the Lever-A fusion posteriors (judge token = a new "kalman" row) with the
+   stop-grad consistency prior + measured anchor recipe from the DESIGN.
+3. **B3 — class-mixture predictive** for the D-bimodality defect (acceptance gate in THEORY §11.5).
+
+## The escalation ladder (user, from the Lever-A discussion)
+
+The decision-flip signal generalizes beyond "call the judge": it prices an ESCALATION LADDER — more reasoning
+effort, a stronger model, a k-model consensus — each rung a measurement channel with its own (R, cost).
+Measured so far: R ≈ 0.004 at gpt-5.5-low; consensus of k gives R/k; higher effort presumably lower R per call.
+The Kalman machinery converts each rung's R into expected flip-probability per dollar: inference spend as a
+portfolio with computable marginals. Training-data generation for B1/B2 should use it (spend scoring budget
+where flips concentrate — the conflict policy).
+
+## Repro
+
+```
+python3 run_channel_heads_probe.py
+```

--- a/prototypes/mu_cosine/run_channel_heads_probe.py
+++ b/prototypes/mu_cosine/run_channel_heads_probe.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Lever B step 2 probe: does the EXISTING checkpoint already carry per-channel heads?
+
+`DESIGN_amortized_fusion_heads.md` step 2 calls for per-channel heads (mu_graph, mu_LLM). The architecture
+already has the machinery — JUDGES contains `graph` and `gpt-5.5-low` as learned provenance tokens, and the
+tokenizer accepts (node, root, op, corpus, judge) — so the training history may have partially amortized the
+channels already. Before training anything: MEASURE.
+
+Probe: query model_prod.pt on both corpora under three conditionings —
+  agnostic (3-tuple, provenance masked) | judge=graph | judge=gpt-5.5-low  (corpus=enwiki for both datasets)
+and correlate each readout (mu_HIER max-dir, mu_SYM) against each channel's ground truth
+(walk hit_prob d; LLM labels D, S). Success criterion for "step 2 already amortized": the graph-conditioned
+readout predicts the walk better than the other conditionings do, and the LLM-conditioned readout predicts the
+labels better — i.e., the judge tokens genuinely ROUTE, not just shift.
+
+  python3 run_channel_heads_probe.py
+"""
+import os
+import sys
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from eval_relatedness import build_model
+from mu_attention import CORPORA, JUDGES, OPS, Tokenizer
+from run_product_kalman_realdata import DATASETS
+from sigma_hop_confirmatory import FeatureGraphConfig, load_e5_cache_and_filter, load_feature_graph, load_scored_pairs
+from emit_transitive_hops import hit_prob
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+def readouts(model, tokenizer, pairs, device, conds):
+    """mu readouts per conditioning: {cond_name: {op_name: array}}. HIER is max over both directions."""
+    out = {}
+    for cname, cj in conds.items():
+        per_op = {}
+        for op in ("HIER", "SYM"):
+            def mu(batch_pairs):
+                if cj is None:
+                    rows = [(x, y, OPS[op]) for x, y in batch_pairs]
+                else:
+                    rows = [(x, y, OPS[op], CORPORA["enwiki"], JUDGES[cj]) for x, y in batch_pairs]
+                vals = []
+                for i in range(0, len(rows), 512):
+                    b = tokenizer.build(rows[i:i + 512], train=False)
+                    b = {k: (v.to(device) if torch.is_tensor(v) else v) for k, v in b.items()}
+                    with torch.no_grad():
+                        vals += model(**b).cpu().tolist()
+                return np.array(vals)
+            if op == "HIER":
+                per_op["HIER"] = np.maximum(mu(pairs), mu([(y, x) for x, y in pairs]))
+            else:
+                per_op["SYM"] = mu(pairs)
+        out[cname] = per_op
+    return out
+
+
+def run(name):
+    cfg = DATASETS[name]
+    pairs, hop, D, S = load_scored_pairs(cfg["score_in"], cfg["responses"], prefix="transitive_h")
+    cache, idx, pairs, hop, D, S = load_e5_cache_and_filter(pairs, hop, D, S, cfg["e5_cache"])
+    parents, _, deg, _ = load_feature_graph(FeatureGraphConfig(**cfg["graph"]))
+    tokenizer = Tokenizer(cache["query"], cache["passage"], idx, parents, deg)
+    model = build_model(os.path.join(ROOT, "model_prod.pt"), "cpu")
+    d = np.array([hit_prob(parents, x, y) for x, y in pairs])
+    targets = {"walk d": d, "LLM D": np.array(D), "LLM S": np.array(S)}
+
+    # model_prod.pt carries 5 judge rows (haiku/graph/human/sonnet/opus) — it predates the gpt-5.5-low row,
+    # so the checkpoint's trained LLM judge is HAIKU. Probe what exists.
+    conds = {"agnostic": None, "judge=graph": "graph", "judge=llm": "haiku"}
+    R = readouts(model, tokenizer, list(pairs), "cpu", conds)
+
+    print(f"\n=== {name}: n={len(pairs)} — corr(readout, channel ground truth) ===")
+    print(f"    {'conditioning':14s} {'readout':6s} | " + " ".join(f"{t:>8s}" for t in targets))
+    for cname in conds:
+        for op in ("HIER", "SYM"):
+            r = R[cname][op]
+            cs = [np.corrcoef(r, t)[0, 1] for t in targets.values()]
+            print(f"    {cname:14s} {op:6s} | " + " ".join(f"{c:+8.3f}" for c in cs))
+    # routing check: how different ARE the conditioned readouts?
+    for op in ("HIER", "SYM"):
+        dg = R["judge=graph"][op] - R["agnostic"][op]
+        dl = R["judge=llm"][op] - R["agnostic"][op]
+        print(f"    Δ{op}: |judge=graph − agnostic| mean {np.abs(dg).mean():.4f}; "
+              f"|judge=llm − agnostic| mean {np.abs(dl).mean():.4f}; corr(Δg, Δl) "
+              f"{np.corrcoef(dg, dl)[0, 1] if dg.std() > 0 and dl.std() > 0 else float('nan'):+.3f}")
+
+
+def main():
+    for n in ("exploratory", "fresh"):
+        run(n)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Opens Lever B by MEASURING before building: does `model_prod.pt` already carry the per-channel heads that
`DESIGN_amortized_fusion_heads.md` step 2 calls for? The architecture has judge-conditioned provenance tokens
and the checkpoint was trained with judge-tagged rows — so the probe queries it under three conditionings
(agnostic / judge=graph / judge=haiku) on both corpora and correlates each readout with each channel's ground
truth (walk hit-prob, LLM D, LLM S).

## Findings (`run_channel_heads_probe.py`, `REPORT_channel_heads_probe.md`)
1. **The judge tokens do not route.** All conditionings produce nearly identical readouts (|Δ| 0.02–0.07, and
   the per-judge deltas are correlated +0.44/+0.62 — a shared calibration shift, not channels). Step 2 is NOT
   amortized; it must be trained. (Also: `model_prod.pt` has 5 judge rows — its trained LLM judge is haiku;
   the gpt-5.5-low row doesn't exist yet in any local checkpoint.)
2. **The SYM readout has ~zero correlation with the LLM's S channel** (−0.06..+0.02 on both corpora) while
   correlating +0.5 with D. The model's symmetric head tracks directionality — the mu_S feature used throughout
   the fusion arcs was never really the S channel (the covariance fits priced this, which is why fusion worked
   anyway). A trained S head is a MISSING CHANNEL — likely the largest single amortization win available.
3. **Build plan:** B1 per-channel heads (judge_emb 5→9 resize, channel-tagged fine-tune from model_prod.pt;
   this probe re-run is the acceptance test, plus trunk non-degradation); B2 fused head distilling the Lever-A
   posteriors (stop-grad prior + measured anchor); B3 class-mixture predictive for the D-bimodality defect.
4. Records the **escalation ladder** (from discussion): the decision-flip signal prices effort/model/consensus
   rungs as measurement channels with (R, cost) — inference spend as a portfolio with computable marginals.

## Scope
One probe script + report; no training, no shared code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175Lx4bNRVaAv3hTDURCF69