### PR TITLE
Fix Rust WAM retract clause semantics

### DIFF
--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -308,6 +308,28 @@
         self.dynamic_retract_attempt(key, 0, pattern, cont_pc)
     }
 
+    fn dynamic_retract_candidate(&self, pattern: &Value, clause: &Value) -> Option<Value> {
+        let pattern_functor = match pattern {
+            Value::Str(f, args) if (f == ":-" || f == ":-/2") && args.len() == 2 => Some(f),
+            _ => None,
+        };
+        match pattern_functor {
+            Some(functor) => match clause {
+                Value::Str(f, args) if (f == ":-" || f == ":-/2") && args.len() == 2 => {
+                    Some(Value::Str(functor.clone(), args.clone()))
+                }
+                fact => Some(Value::Str(
+                    functor.clone(),
+                    vec![fact.clone(), Value::Atom("true".to_string())],
+                )),
+            },
+            None => match clause {
+                Value::Str(f, args) if (f == ":-" || f == ":-/2") && args.len() == 2 => None,
+                fact => Some(fact.clone()),
+            },
+        }
+    }
+
     fn dynamic_retract_attempt(&mut self, key: String, start_idx: usize, pattern: Value, cont_pc: usize) -> bool {
         let clauses = match self.dynamic_db.get(&key) {
             Some(clauses) => clauses.clone(),
@@ -320,11 +342,11 @@
             let cp_stack = self.stack.clone();
             let mut clause_vars = std::collections::HashMap::new();
             let p = pattern.clone();
-            let head = match self.dynamic_clause_head(&clauses[idx]) {
-                Some(head) => Self::copy_term_walk(&mut self.var_counter, &mut clause_vars, &head),
+            let candidate = match self.dynamic_retract_candidate(&pattern, &clauses[idx]) {
+                Some(candidate) => Self::copy_term_walk(&mut self.var_counter, &mut clause_vars, &candidate),
                 None => continue,
             };
-            if self.unify(&p, &head) {
+            if self.unify(&p, &candidate) {
                 if let Some(bucket) = self.dynamic_db.get_mut(&key) {
                     if idx < bucket.len() { bucket.remove(idx); }
                     if bucket.is_empty() { self.dynamic_db.remove(&key); }

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -78,6 +78,78 @@ fn retract_removes_one_match_and_binds_pattern() {
 }
 
 #[test]
+fn retract_backtracks_through_each_matching_fact() {
+    let mut vm = WamState::new(vec![Instruction::Call("retract/1".to_string(), 1), Instruction::Proceed], HashMap::new());
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("red")]));
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("blue")]));
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("green")]));
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("dyn", vec![ub("X")]));
+    vm.pc = 1;
+    let mut removed = Vec::new();
+    assert!(vm.run());
+    loop {
+        let x = vm.bindings.get("X").cloned().expect("X bound");
+        removed.push(vm.deref_heap(&vm.deref_var(&x)));
+        if !vm.backtrack() { break; }
+    }
+    assert_eq!(removed, vec![at("red"), at("blue"), at("green")]);
+    assert!(dyn_values(&mut vm).is_empty());
+}
+
+#[test]
+fn retract_distinguishes_fact_patterns_from_rule_patterns() {
+    let mut vm = WamState::new(vec![Instruction::Call("retract/1".to_string(), 1), Instruction::Proceed], HashMap::new());
+    assert_clause(&mut vm, "assertz/1", fact("marker", vec![at("rule")]));
+    assert_clause(
+        &mut vm,
+        "assertz/1",
+        rule(
+            fact("dyn", vec![at("rule")]),
+            fact("marker", vec![at("rule")]),
+        ),
+    );
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("fact")]));
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("dyn", vec![ub("X")]));
+    vm.pc = 1;
+    assert!(vm.run());
+    assert_eq!(vm.bindings.get("X"), Some(&at("fact")));
+    assert_eq!(dyn_values(&mut vm), vec![at("rule")]);
+
+    vm.reset_query();
+    vm.code = vec![Instruction::Call("retract/1".to_string(), 1), Instruction::Proceed];
+    vm.set_reg_str(
+        "A1",
+        rule(
+            fact("dyn", vec![ub("X")]),
+            fact("marker", vec![ub("X")]),
+        ),
+    );
+    vm.pc = 1;
+    assert!(vm.run());
+    assert_eq!(vm.bindings.get("X"), Some(&at("rule")));
+    assert!(dyn_values(&mut vm).is_empty());
+
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("normalized")]));
+    vm.reset_query();
+    vm.code = vec![Instruction::Call("retract/1".to_string(), 1), Instruction::Proceed];
+    vm.set_reg_str(
+        "A1",
+        rule(
+            fact("dyn", vec![ub("X")]),
+            at("true"),
+        ),
+    );
+    vm.pc = 1;
+    assert!(vm.run());
+    assert_eq!(vm.bindings.get("X"), Some(&at("normalized")));
+    assert!(dyn_values(&mut vm).is_empty());
+}
+
+#[test]
 fn asserted_rule_body_calls_dynamic_predicates() {
     let mut vm = WamState::new(vec![], HashMap::new());
     assert_clause(&mut vm, "assertz/1", fact("parent", vec![at("ann"), at("bob")]));


### PR DESCRIPTION
## Summary

- preserve nondeterministic `retract/1` behavior across backtracking
- prevent plain head patterns from retracting rules
- match explicit `(Head :- Body)` patterns against complete clauses
- expose stored facts as `Head :- true` during explicit rule matching
- add regressions covering repeated fact retraction and rule matching

## Testing

- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `swipl -q -s tests/test_wam_rust_dynamic_builtins.pl -g run_tests -t halt`