### PR TITLE
Validate canonical Product-Kalman artifacts

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -416,9 +416,12 @@ remaining D-channel shape defect as model-side relation-class structure rather t
    grouped-covariance score variants when calibration/evaluation group labels are present, records aggregate NLL/MSE,
    Mahalanobis calibration-scale/tail diagnostics, row-level score vectors, and optional paired bootstrap intervals
    for NLL gains against configurable baselines such as ungrouped `product_kalman`, and keeps
-   calibration/evaluation IDs disjoint. PIT diagnostics include marginal KS-vs-uniform and central-interval
-   coverage summaries so interval under/over-coverage is visible without changing score selection. *(Harness
-   complete; dedicated real-corpus exploratory runs are recorded in the reports listed below.)*
+   calibration/evaluation IDs disjoint. When the runner writes `eval_artifacts.npz`, it validates the artifact's
+   score ordering, row counts, mean NLL, and PIT summaries against the score JSON before writing the canonical
+   `scores.json` and `report.md`, and records the artifact hash plus validation dimensions in both outputs. PIT
+   diagnostics include marginal KS-vs-uniform and central-interval coverage summaries so interval
+   under/over-coverage is visible without changing score selection. *(Harness complete; dedicated real-corpus
+   exploratory runs are recorded in the reports listed below.)*
 8. Use `product_kalman_report.py` to render the input manifest, optional split manifest, and score JSON into a
    descriptive Markdown run note. When row-level `eval_artifacts.npz` exists, the report CLI can add paired bootstrap
    NLL intervals post hoc without rerunning scoring, verifies the row artifact against the score summary, records the

--- a/prototypes/mu_cosine/product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_table_evaluation.py
@@ -20,6 +20,7 @@ try:
         write_evaluation_npz,
     )
     from .product_kalman_report import (
+        add_artifact_validation_summary,
         build_product_kalman_markdown_report,
         load_json,
         write_markdown_report,
@@ -33,6 +34,7 @@ except ImportError:  # direct script execution from prototypes/mu_cosine
         write_evaluation_npz,
     )
     from product_kalman_report import (
+        add_artifact_validation_summary,
         build_product_kalman_markdown_report,
         load_json,
         write_markdown_report,
@@ -226,6 +228,12 @@ def run_product_kalman_table_evaluation(
         original_table=original_table,
         split_manifest=split_manifest,
     )
+    if output_npz:
+        summary = add_artifact_validation_summary(
+            summary,
+            evaluation_npz=output_npz,
+            overwrite=True,
+        )
     report_text = ""
     if output_md:
         manifest = load_json(input_manifest) if input_manifest else None

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -120,6 +120,17 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert summary["inputs"]["input_manifest"] == str(input_manifest)
         assert summary["inputs"]["evaluation_npz"] == str(output_npz)
         assert summary["inputs"]["report_md"] == str(output_md)
+        artifact_validation = summary["evaluation_artifact_validation"]
+        assert artifact_validation["evaluation_npz"] == str(output_npz)
+        assert len(artifact_validation["evaluation_npz_sha256"]) == 64
+        assert artifact_validation["validated_against_scores"] is True
+        assert artifact_validation["pit_diagnostics_validated"] is True
+        assert artifact_validation["score_order"] == summary["score_order"]
+        assert artifact_validation["score_count"] == len(summary["score_order"])
+        assert artifact_validation["score_rows"]["product_kalman"] == 40
+        assert artifact_validation["pit_names"] == summary["score_order"]
+        assert artifact_validation["pit_n"] == 40
+        assert artifact_validation["pit_dimension"] == 1
         assert summary["nll_baselines"] == ["prior", "independent_kalman", "product_kalman"]
         assert summary["score_order"] == [
             "prior",
@@ -161,6 +172,9 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         assert "## Grouped Covariances" in report
         assert "product_kalman_grouped" in report
         assert "## NLL Improvement Bootstrap Intervals" in report
+        assert "## Evaluation Artifact Validation" in report
+        assert "| validated_against_scores | True |" in report
+        assert "| pit_diagnostics_validated | True |" in report
         assert "source_table_sha256" in report
 
         with np.load(output_npz, allow_pickle=False) as artifact:
@@ -209,6 +223,9 @@ def test_table_runner_output_dir_writes_canonical_bundle():
         assert summary["inputs"]["input_manifest"] == str(paths["input_manifest"])
         assert summary["inputs"]["evaluation_npz"] == str(paths["output_npz"])
         assert summary["inputs"]["report_md"] == str(paths["output_md"])
+        assert summary["evaluation_artifact_validation"]["evaluation_npz"] == str(paths["output_npz"])
+        assert summary["evaluation_artifact_validation"]["validated_against_scores"] is True
+        assert summary["evaluation_artifact_validation"]["pit_diagnostics_validated"] is True
         assert summary["nll_improvement_vs_prior"]["product_kalman"] > 0.65
         assert summary["nll_baselines"] == ["prior", "independent_kalman", "product_kalman"]
         assert "product_kalman_grouped" in summary["score_order"]
@@ -220,7 +237,9 @@ def test_table_runner_output_dir_writes_canonical_bundle():
         manifest = json.loads(paths["input_manifest"].read_text())
         assert manifest["groups"]["present"] is True
         assert manifest["groups"]["columns"] == ["hop"]
-        assert "# Product-Kalman Holdout Report" in paths["output_md"].read_text()
+        report = paths["output_md"].read_text()
+        assert "# Product-Kalman Holdout Report" in report
+        assert "## Evaluation Artifact Validation" in report
 
 
 def test_table_runner_output_dir_can_materialize_split_before_evaluation():
@@ -370,6 +389,8 @@ def test_table_runner_cli_roundtrips_against_npz_evaluator():
         assert "product_kalman_grouped" in from_table["grouped_covariances"]
         assert "product_kalman_grouped" in from_table["nll_improvement_vs_product_kalman"]
         assert from_table["inputs"]["report_md"] == str(output_md)
+        assert "evaluation_artifact_validation" not in from_table
+        assert "## Evaluation Artifact Validation" not in output_md.read_text()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- validate each generated `eval_artifacts.npz` against the in-memory score summary
- record its SHA-256, score dimensions, row counts, and PIT validation metadata
- include the validation section in canonical `scores.json` and `report.md`
- preserve unchanged behavior when no evaluation NPZ is requested
- document the stronger canonical-bundle guarantee

## Verification

- 5 table-evaluation tests
- 6 report tests
- 14 underlying evaluation tests
- Python compilation and `git diff --check`