### PR TITLE
Validate Product-Kalman artifact schemas

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -418,7 +418,8 @@ remaining D-channel shape defect as model-side relation-class structure rather t
    for NLL gains against configurable baselines such as ungrouped `product_kalman`, and keeps
    calibration/evaluation IDs disjoint. When the runner writes `eval_artifacts.npz`, it validates the artifact's
    score ordering, row counts, mean NLL, and PIT summaries against the score JSON before writing the canonical
-   `scores.json` and `report.md`, and records the artifact hash plus validation dimensions in both outputs. PIT
+   `scores.json` and `report.md`, rejects unsupported artifact schema versions, and records the schema version,
+   artifact hash, and validation dimensions in both outputs. PIT
    diagnostics include marginal KS-vs-uniform and central-interval coverage summaries so interval
    under/over-coverage is visible without changing score selection. *(Harness complete; dedicated real-corpus
    exploratory runs are recorded in the reports listed below.)*

--- a/prototypes/mu_cosine/product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/product_kalman_evaluation.py
@@ -40,6 +40,7 @@ except ImportError:  # direct script execution from prototypes/mu_cosine
 
 DEFAULT_NLL_BASELINES = ("prior", "independent_kalman")
 DEFAULT_PIT_COVERAGE_LEVELS = (0.50, 0.80, 0.90, 0.95)
+EVALUATION_ARTIFACT_SCHEMA_VERSION = 1
 
 
 __all__ = [
@@ -48,6 +49,7 @@ __all__ = [
     "GroupedGaussianScore",
     "PITDiagnostics",
     "DEFAULT_PIT_COVERAGE_LEVELS",
+    "EVALUATION_ARTIFACT_SCHEMA_VERSION",
     "GroupResidualCovariances",
     "ProductKalmanHoldoutEvaluation",
     "bootstrap_nll_improvements_from_evaluation_npz",
@@ -1288,7 +1290,7 @@ def evaluation_artifact_arrays(result):
     """
     score_names = np.array([score.name for score in result.scores])
     arrays = {
-        "schema_version": np.array(1, dtype=np.int64),
+        "schema_version": np.array(EVALUATION_ARTIFACT_SCHEMA_VERSION, dtype=np.int64),
         "score_names": score_names,
         "score_mean_nll": np.array([score.mean_nll for score in result.scores], dtype=float),
         "score_mse": np.array([score.mse for score in result.scores], dtype=float),
@@ -1378,10 +1380,24 @@ def _optional_npz_array(npz, key):
     return npz[key] if key in npz.files else None
 
 
+def _evaluation_npz_schema_version(npz, path):
+    value = np.asarray(_require_npz_array(npz, path, "schema_version"))
+    if value.shape != () or value.dtype.kind not in "iu":
+        raise ValueError("evaluation artifact schema_version must be a scalar integer")
+    version = int(value.item())
+    if version != EVALUATION_ARTIFACT_SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported evaluation artifact schema_version {version}; "
+            f"expected {EVALUATION_ARTIFACT_SCHEMA_VERSION}"
+        )
+    return version
+
+
 def evaluation_npz_score_summary(artifact_npz):
     """Return score-order, mean-NLL, and row-count summaries from an evaluation artifact NPZ."""
     path = str(artifact_npz)
     with np.load(path, allow_pickle=False) as data:
+        schema_version = _evaluation_npz_schema_version(data, path)
         names = _decode_score_names(_require_npz_array(data, path, "score_names"))
         mean_nll = np.asarray(_require_npz_array(data, path, "score_mean_nll"), dtype=float)
         score_n = np.asarray(_require_npz_array(data, path, "score_n"), dtype=np.int64)
@@ -1394,6 +1410,7 @@ def evaluation_npz_score_summary(artifact_npz):
     if (score_n <= 0).any():
         raise ValueError("score_n values must be positive")
     return {
+        "schema_version": schema_version,
         "score_order": list(names),
         "mean_nll": {name: float(mean_nll[i]) for i, name in enumerate(names)},
         "n": {name: int(score_n[i]) for i, name in enumerate(names)},
@@ -1410,6 +1427,7 @@ def bootstrap_nll_improvements_from_evaluation_npz(
     """Return JSON-ready paired NLL bootstrap maps from an evaluation artifact NPZ."""
     path = str(artifact_npz)
     with np.load(path, allow_pickle=False) as data:
+        _evaluation_npz_schema_version(data, path)
         return bootstrap_nll_improvements_from_score_rows(
             _require_npz_array(data, path, "score_names"),
             _require_npz_array(data, path, "score_row_nll"),

--- a/prototypes/mu_cosine/product_kalman_report.py
+++ b/prototypes/mu_cosine/product_kalman_report.py
@@ -142,6 +142,7 @@ def _bootstrap_artifact_rows(scores_json):
     return [
         ["evaluation_npz", artifact.get("evaluation_npz")],
         ["evaluation_npz_sha256", artifact.get("evaluation_npz_sha256")],
+        ["schema_version", artifact.get("schema_version")],
         ["validated_against_scores", artifact.get("validated_against_scores")],
         ["pit_diagnostics_validated", artifact.get("pit_diagnostics_validated")],
         ["score_order", ", ".join(artifact.get("score_order", []))],
@@ -160,6 +161,7 @@ def _artifact_validation_rows(scores_json):
     return [
         ["evaluation_npz", artifact.get("evaluation_npz")],
         ["evaluation_npz_sha256", artifact.get("evaluation_npz_sha256")],
+        ["schema_version", artifact.get("schema_version")],
         ["validated_against_scores", artifact.get("validated_against_scores")],
         ["pit_diagnostics_validated", artifact.get("pit_diagnostics_validated")],
         ["score_order", ", ".join(artifact.get("score_order", []))],
@@ -581,6 +583,7 @@ def _artifact_validation_metadata(artifact_path, artifact_summary):
     metadata = {
         "evaluation_npz": str(artifact_path),
         "evaluation_npz_sha256": _sha256_file(artifact_path),
+        "schema_version": artifact_summary["schema_version"],
         "validated_against_scores": True,
         "pit_diagnostics_validated": bool(pit.get("present")),
         "score_order": list(artifact_summary["score_order"]),
@@ -662,6 +665,7 @@ def add_artifact_bootstrap_intervals(
         out["bootstrap_artifact"] = {
             "evaluation_npz": str(artifact_path),
             "evaluation_npz_sha256": _sha256_file(artifact_path),
+            "schema_version": artifact_summary["schema_version"],
             "validated_against_scores": bool(validate_artifact),
             "pit_diagnostics_validated": bool(artifact_summary.get("pit_diagnostics", {}).get("present")),
             "score_order": artifact_summary["score_order"],

--- a/prototypes/mu_cosine/test_product_kalman_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_evaluation.py
@@ -14,10 +14,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import numpy as np
 
 from product_kalman_evaluation import (
+    EVALUATION_ARTIFACT_SCHEMA_VERSION,
     GroupResidualCovariances,
     bootstrap_nll_improvements_from_evaluation_npz,
     evaluate_product_kalman_holdout,
     evaluation_artifact_arrays,
+    evaluation_npz_score_summary,
     evaluation_to_json_dict,
     fit_group_residual_covariances,
     main,
@@ -274,7 +276,7 @@ def test_npz_runner_and_json_cli_roundtrip():
         assert artifact_boot["nll_improvement_bootstrap_vs_independent_kalman"]["product_kalman"] == boot
 
         with np.load(artifact_path, allow_pickle=False) as artifact:
-            assert int(artifact["schema_version"]) == 1
+            assert int(artifact["schema_version"]) == EVALUATION_ARTIFACT_SCHEMA_VERSION
             assert artifact["score_names"].tolist() == data["score_order"]
             assert artifact["score_mahalanobis_per_dim"].shape == (4,)
             assert artifact["score_squared_mahalanobis_q95"].shape == (4,)
@@ -308,6 +310,7 @@ def test_evaluation_artifact_arrays_are_npz_ready():
         jitter=1e-8,
     )
     arrays = evaluation_artifact_arrays(result)
+    assert int(arrays["schema_version"]) == EVALUATION_ARTIFACT_SCHEMA_VERSION
     assert arrays["score_names"].tolist() == ["prior", "measurement", "independent_kalman", "product_kalman"]
     assert arrays["score_mean_nll"].shape == (4,)
     assert arrays["score_mean_squared_mahalanobis"].shape == (4,)
@@ -335,6 +338,42 @@ def test_evaluation_artifact_arrays_are_npz_ready():
         with np.load(artifact_path, allow_pickle=False) as artifact:
             assert set(arrays).issubset(set(artifact.files))
             np.testing.assert_allclose(artifact["score_mean_nll"], arrays["score_mean_nll"])
+        summary = evaluation_npz_score_summary(artifact_path)
+        assert summary["schema_version"] == EVALUATION_ARTIFACT_SCHEMA_VERSION
+
+
+def test_evaluation_artifact_readers_reject_incompatible_schema():
+    cal_prior, cal_measure, cal_target, eval_prior, eval_measure, eval_target = synthetic_identity_split(
+        n_cal=80,
+        n_eval=20,
+    )
+    result = evaluate_product_kalman_holdout(
+        cal_prior,
+        cal_measure,
+        cal_target,
+        eval_prior,
+        eval_measure,
+        eval_target,
+        jitter=1e-8,
+    )
+    base = evaluation_artifact_arrays(result)
+    with tempfile.TemporaryDirectory() as tmp:
+        for name, schema_value in (
+            ("missing", None),
+            ("future", np.array(EVALUATION_ARTIFACT_SCHEMA_VERSION + 1, dtype=np.int64)),
+            ("vector", np.array([EVALUATION_ARTIFACT_SCHEMA_VERSION], dtype=np.int64)),
+            ("float", np.array(float(EVALUATION_ARTIFACT_SCHEMA_VERSION))),
+        ):
+            arrays = dict(base)
+            if schema_value is None:
+                del arrays["schema_version"]
+            else:
+                arrays["schema_version"] = schema_value
+            path = Path(tmp) / f"{name}.npz"
+            np.savez(path, **arrays)
+            assert_raises(evaluation_npz_score_summary, path)
+            assert_raises(bootstrap_nll_improvements_from_evaluation_npz, path, n_boot=10)
+
 
 def test_npz_runner_scores_grouped_covariances_when_group_labels_present():
     rng = np.random.default_rng(41)

--- a/prototypes/mu_cosine/test_product_kalman_report.py
+++ b/prototypes/mu_cosine/test_product_kalman_report.py
@@ -258,6 +258,7 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
         validation_meta = validated["evaluation_artifact_validation"]
         assert validation_meta["evaluation_npz"] == str(eval_npz)
         assert len(validation_meta["evaluation_npz_sha256"]) == 64
+        assert validation_meta["schema_version"] == 1
         assert validation_meta["validated_against_scores"] is True
         assert validation_meta["pit_diagnostics_validated"] is True
         assert validation_meta["score_order"] == scores["score_order"]
@@ -277,6 +278,7 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
         artifact_meta = enriched["bootstrap_artifact"]
         assert artifact_meta["evaluation_npz"] == str(eval_npz)
         assert len(artifact_meta["evaluation_npz_sha256"]) == 64
+        assert artifact_meta["schema_version"] == 1
         assert artifact_meta["validated_against_scores"] is True
         assert artifact_meta["pit_diagnostics_validated"] is True
         assert artifact_meta["score_order"] == scores["score_order"]
@@ -321,6 +323,7 @@ def test_posthoc_bootstrap_intervals_can_be_loaded_from_evaluation_npz():
         assert rc == 0
         validation_text = validation_md.read_text()
         assert "## Evaluation Artifact Validation" in validation_text
+        assert "| schema_version | 1 |" in validation_text
         assert "| validated_against_scores | True |" in validation_text
         assert "| pit_diagnostics_validated | True |" in validation_text
         validation_payload = json.loads(validation_json.read_text())

--- a/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
+++ b/prototypes/mu_cosine/test_product_kalman_table_evaluation.py
@@ -123,6 +123,7 @@ def test_table_runner_writes_input_and_evaluation_artifacts():
         artifact_validation = summary["evaluation_artifact_validation"]
         assert artifact_validation["evaluation_npz"] == str(output_npz)
         assert len(artifact_validation["evaluation_npz_sha256"]) == 64
+        assert artifact_validation["schema_version"] == 1
         assert artifact_validation["validated_against_scores"] is True
         assert artifact_validation["pit_diagnostics_validated"] is True
         assert artifact_validation["score_order"] == summary["score_order"]


### PR DESCRIPTION
## Summary

- define the evaluation NPZ schema version in one exported constant
- require a scalar integer schema version in score-summary and bootstrap readers
- reject missing, malformed, and unsupported future schemas
- record the validated schema version in JSON and Markdown artifact metadata
- document the fail-closed compatibility guarantee

## Verification

- 15 Product-Kalman evaluation tests
- 6 report tests
- 5 canonical table-runner tests
- Python compilation and `git diff --check`