### PR TITLE
Round-trip quoted atoms in Rust WAM term_to_atom/2

### DIFF
--- a/src/unifyweaver/core/prolog_term_parser.pl
+++ b/src/unifyweaver/core/prolog_term_parser.pl
@@ -250,11 +250,14 @@ take_digits([C|R], [], [C|R])    :- \+ digit_code(C).
 % Quoted atom body. ' ends the literal; \ acts as a one-char escape so '\''
 % and '\\' both round-trip.
 take_quoted([39|R], Cs, Cs, R) :- !.
-take_quoted([92, C | R], Acc, Out, Rest) :-
+take_quoted([92|R], Acc, Out, Rest) :-
     !,
+    take_quoted_escape(R, Acc, Out, Rest).
+take_quoted([C|R], Acc, Out, Rest) :-
     append(Acc, [C], Acc1),
     take_quoted(R, Acc1, Out, Rest).
-take_quoted([C|R], Acc, Out, Rest) :-
+
+take_quoted_escape([C|R], Acc, Out, Rest) :-
     append(Acc, [C], Acc1),
     take_quoted(R, Acc1, Out, Rest).
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1858,7 +1858,7 @@ compile_execute_term_builtin_to_rust(Code) :-
     fn term_to_atom_text(&self, value: &Value) -> String {
         let derefed = self.deref_heap(&self.deref_var(value));
         match derefed {
-            Value::Atom(s) => s,
+            Value::Atom(s) => Self::term_atom_text(&s),
             Value::Integer(n) => n.to_string(),
             Value::Float(f) => f.to_string(),
             Value::Bool(b) => b.to_string(),
@@ -1874,7 +1874,7 @@ compile_execute_term_builtin_to_rust(Code) :-
                 let rendered: Vec<String> = args.iter()
                     .map(|a| self.term_to_atom_text(a))
                     .collect();
-                format!("{}({})", name, rendered.join(", "))
+                format!("{}({})", Self::term_atom_text(&name), rendered.join(", "))
             }
             Value::Ref(_) => format!("{}", derefed),
             Value::Uninit => "_".to_string(),

--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -62,6 +62,31 @@
         Some((body.trim().to_string(), input.len()))
     }
 
+    fn term_atom_text(atom: &str) -> String {
+        let mut chars = atom.chars();
+        let plain = match chars.next() {
+            Some(first) if first.is_ascii_lowercase() => {
+                chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+            }
+            _ => false,
+        };
+        if plain || atom == "!" || atom == "[]" {
+            return atom.to_string();
+        }
+
+        let mut quoted = String::with_capacity(atom.len() + 2);
+        quoted.push('\'');
+        for ch in atom.chars() {
+            match ch {
+                '\\' => quoted.push_str("\\\\"),
+                '\'' => quoted.push_str("\\'"),
+                _ => quoted.push(ch),
+            }
+        }
+        quoted.push('\'');
+        quoted
+    }
+
     fn execute_assert_builtin(&mut self, op: &str) -> bool {
         let raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
         let term = self.deref_heap(&self.deref_var(&raw));

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -232,3 +232,43 @@ fn read_consumes_buffered_terms_before_end_of_file() {
     assert!(vm.execute_builtin("read/1", 1));
     assert_eq!(vm.bindings.get("End"), Some(&at("end_of_file")));
 }
+
+#[test]
+fn term_to_atom_quotes_and_roundtrips_non_bare_atoms() {
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code, labels);
+    let term = fact(
+        "odd functor",
+        vec![
+            at("hello world"),
+            at("42"),
+            at("can't"),
+            at("a\\b"),
+        ],
+    );
+
+    vm.set_reg_str("A1", term.clone());
+    vm.set_reg_str("A2", ub("Text"));
+    assert!(vm.execute_builtin("term_to_atom/2", 2));
+    let rendered = at("'odd functor'('hello world', '42', 'can\\'t', 'a\\\\b')");
+    assert_eq!(vm.bindings.get("Text"), Some(&rendered));
+
+    for (text, expected) in [
+        ("'hello world'", at("hello world")),
+        ("'42'", at("42")),
+        ("'can\\'t'", at("can't")),
+        ("'a\\\\b'", at("a\\b")),
+    ] {
+        vm.reset_query();
+        vm.set_reg_str("A1", ub("Quoted"));
+        vm.set_reg_str("A2", at(text));
+        assert!(vm.execute_builtin("term_to_atom/2", 2), "failed to parse {}", text);
+        assert_eq!(vm.bindings.get("Quoted"), Some(&expected));
+    }
+
+    vm.reset_query();
+    vm.set_reg_str("A1", ub("Parsed"));
+    vm.set_reg_str("A2", rendered);
+    assert!(vm.execute_builtin("term_to_atom/2", 2));
+    assert_eq!(vm.bindings.get("Parsed"), Some(&term));
+}

--- a/tests/test_prolog_term_parser.pl
+++ b/tests/test_prolog_term_parser.pl
@@ -28,6 +28,18 @@ test(atom_quoted_with_space) :-
     canon_parse_atom('\'hello world\'', T),
     T == 'hello world'.
 
+test(atom_quoted_with_apostrophe_escape) :-
+    atom_codes(Input, [39, 99, 97, 110, 92, 39, 116, 39]),
+    atom_codes(Expected, [99, 97, 110, 39, 116]),
+    canon_parse_atom(Input, T),
+    T == Expected.
+
+test(atom_quoted_with_backslash_escape) :-
+    atom_codes(Input, [39, 97, 92, 92, 98, 39]),
+    atom_codes(Expected, [97, 92, 98]),
+    canon_parse_atom(Input, T),
+    T == Expected.
+
 test(int_unsigned) :-
     canon_parse_atom('42', T),
     T == 42.


### PR DESCRIPTION
## Summary

- quote atom and functor names that cannot safely use bare Prolog syntax
- escape apostrophes and backslashes in generated atom text
- support reverse `term_to_atom/2` parsing of those escaped atoms
- reshape the portable parser escape clause for reliable WAM compilation
- test complete compound-term round-tripping through the compiled Rust parser

## Testing

- 34 portable Prolog parser tests
- focused generated Rust dynamic-builtin crate
- complete Rust WAM target suite
- portable parser WAM-R compile-and-run suite