### PR TITLE
Support variable_names in Rust WAM read_term_from_atom

### DIFF
--- a/docs/WAM_RUNTIME_PARSER_STATUS.md
+++ b/docs/WAM_RUNTIME_PARSER_STATUS.md
@@ -71,7 +71,7 @@ each WAM instruction).
 | **C++**      | ✅ | ✅ | ✅ | `native(parse_term)` | partial — codegen tests in `test_wam_cpp_generator.pl`, one `'42'` parse verified end-to-end during the audit |
 | **R**        | ✅ | ✅ | ✅ | `native(parse_term)` | codegen tests; runtime end-to-end via the R smoke harness |
 | **Elixir**   | ✅ | — | — | `none` | n/a — `runtime_parser(compiled)` correctly throws `domain_error` (since Elixir isn't in the capability table); guarded by `test_runtime_parser_compiled_request_errors` |
-| **Rust**     | ✅ | — | ✅ | `none` | partial — capability and project-expansion wiring; runtime builtin bridge still pending |
+| **Rust**     | ✅ | — | ✅ | `none` | yes — generated-runtime tests cover parser calls, buffered reads, term/atom round-trips, and `variable_names/1` |
 | **Haskell**  | ✅ | — | ✅ | `none` | partial — capability and project-expansion wiring; generated parser E2E is noted as slow in `docs/SESSION_HASKELL_PARITY_SUMMARY.md` |
 | **Go**       | ✅ | — | — | `none` | n/a (no parser-mode wiring) |
 | **Clojure**  | ✅ | — | — | `none` | n/a (no parser-mode wiring) |

--- a/src/unifyweaver/core/cpp_runtime_parser_wrappers.pl
+++ b/src/unifyweaver/core/cpp_runtime_parser_wrappers.pl
@@ -45,10 +45,11 @@ read_term_from_atom(Atom, Term) :-
 
 %% read_term_from_atom(+Atom, -Term, +Options) is semidet.
 %
-% Options are silently ignored in v1 -- the portable parser does
-% not yet support variable_names/1, character_escapes/1, etc.
-% Documenting this here so the wrapper has a stable surface and
-% the option-handling work has an obvious home for a follow-up.
+% This portable wrapper silently ignores options. Targets may intercept the
+% builtin before wrapper dispatch and implement options around the parser's
+% /4 environment result; the Rust runtime currently supports
+% variable_names/1 this way. Keeping the fallback wrapper permissive preserves
+% a stable surface for targets that have not adopted option handling yet.
 read_term_from_atom(Atom, Term, _Options) :-
     read_term_from_atom(Atom, Term).
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1730,12 +1730,15 @@ compile_execute_term_builtin_to_rust(Code) :-
         }
     }
 
-    fn execute_read_term_from_atom_builtin(&mut self, _arity: usize) -> bool {
+    fn execute_read_term_from_atom_builtin(&mut self, arity: usize) -> bool {
         let atom = self.get_reg_raw("A1")
             .map(|v| self.deref_heap(&self.deref_var(&v)));
+        let options = if arity == 3 { self.get_reg_raw("A3") } else { None };
         match atom {
             Some(Value::Atom(text)) => {
-                if self.bind_compiled_parse_atom(&text, "A2") { self.pc += 1; true }
+                if self.bind_compiled_parse_atom_with_options(&text, "A2", options.as_ref()) {
+                    self.pc += 1; true
+                }
                 else { false }
             }
             _ => false,
@@ -1743,8 +1746,24 @@ compile_execute_term_builtin_to_rust(Code) :-
     }
 
     fn bind_compiled_parse_atom(&mut self, atom_text: &str, target_reg: &str) -> bool {
+        self.bind_compiled_parse_atom_with_options(atom_text, target_reg, None)
+    }
+
+    fn bind_compiled_parse_atom_with_options(
+        &mut self,
+        atom_text: &str,
+        target_reg: &str,
+        options: Option<&Value>,
+    ) -> bool {
+        let variable_names = options
+            .and_then(|value| self.read_term_option_arg(value, "variable_names"));
+        let parser_entry = if variable_names.is_some() {
+            "parse_term_from_atom/4"
+        } else {
+            "parse_term_from_atom/3"
+        };
         if !self.labels.contains_key("canonical_op_table/1") ||
-           !self.labels.contains_key("parse_term_from_atom/3") {
+           !self.labels.contains_key(parser_entry) {
             return false;
         }
         let mut parser = WamState::new(self.code.clone(), self.labels.clone());
@@ -1761,16 +1780,29 @@ compile_execute_term_builtin_to_rust(Code) :-
         parser.set_reg_str("A1", Value::Atom(atom_text.to_string()));
         parser.set_reg_str("A2", ops);
         parser.set_reg_str("A3", parsed_var.clone());
-        if !parser.run_named_label("parse_term_from_atom/3") {
+        let var_env = Value::Unbound("_RP_env".to_string());
+        if variable_names.is_some() {
+            parser.set_reg_str("A4", var_env.clone());
+        }
+        if !parser.run_named_label(parser_entry) {
             return false;
         }
 
         let parsed = parser.deref_heap(&parser.deref_var(&parsed_var));
         let mut var_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let copied = self.copy_external_term_from(&parser, &parsed, &mut var_map);
-        match self.get_reg_raw(target_reg) {
-            Some(target) => self.unify(&target, &copied),
-            None => false,
+        let target = match self.get_reg_raw(target_reg) {
+            Some(target) => target,
+            None => return false,
+        };
+        if !self.unify(&target, &copied) {
+            return false;
+        }
+        if let Some(names_target) = variable_names {
+            let names = self.copy_variable_names_from_env(&parser, &var_env, &mut var_map);
+            self.unify(&names_target, &names)
+        } else {
+            true
         }
     }
 

--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -87,6 +87,50 @@
         quoted
     }
 
+    fn read_term_option_arg(&self, options: &Value, name: &str) -> Option<Value> {
+        for option in self.value_as_list(options)? {
+            let option = self.deref_heap(&self.deref_var(&option));
+            if let Value::Str(functor, args) = option {
+                if args.len() == 1 &&
+                   Self::display_functor_name(&functor, 1) == name {
+                    return Some(args[0].clone());
+                }
+            }
+        }
+        None
+    }
+
+    fn copy_variable_names_from_env(
+        &mut self,
+        source: &WamState,
+        env: &Value,
+        var_map: &mut std::collections::HashMap<String, String>,
+    ) -> Value {
+        let mut pairs = Vec::new();
+        let entries = match source.value_as_list(env) {
+            Some(entries) => entries,
+            None => return Value::List(pairs),
+        };
+        for entry in entries {
+            let entry = source.deref_heap(&source.deref_var(&entry));
+            let args = match entry {
+                Value::Str(_, args) if args.len() == 2 => args,
+                _ => continue,
+            };
+            let name = match source.deref_heap(&source.deref_var(&args[0])) {
+                Value::Atom(name) if name != "_" => name,
+                _ => continue,
+            };
+            let variable = self.copy_external_term_from(source, &args[1], var_map);
+            pairs.push(Value::Str(
+                "=".to_string(),
+                vec![Value::Atom(name), variable],
+            ));
+        }
+        pairs.reverse();
+        Value::List(pairs)
+    }
+
     fn execute_assert_builtin(&mut self, op: &str) -> bool {
         let raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
         let term = self.deref_heap(&self.deref_var(&raw));

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -272,3 +272,35 @@ fn term_to_atom_quotes_and_roundtrips_non_bare_atoms() {
     assert!(vm.execute_builtin("term_to_atom/2", 2));
     assert_eq!(vm.bindings.get("Parsed"), Some(&term));
 }
+
+#[test]
+fn read_term_from_atom_returns_variable_names_with_shared_variables() {
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code, labels);
+    vm.set_reg_str("A1", at("p(A, B, A, _)"));
+    vm.set_reg_str("A2", ub("Term"));
+    vm.set_reg_str(
+        "A3",
+        Value::List(vec![fact("variable_names", vec![ub("Names")])]),
+    );
+
+    assert!(vm.execute_builtin("read_term_from_atom/3", 3));
+    let parsed = vm.bindings.get("Term").cloned().expect("Term bound");
+    let args = match parsed {
+        Value::Str(ref functor, ref args) if functor == "p" => args.clone(),
+        other => panic!("unexpected parsed term: {:?}", other),
+    };
+    assert_eq!(args[0], args[2]);
+    assert_ne!(args[0], args[1]);
+    assert_ne!(args[0], args[3]);
+
+    let names_raw = vm.bindings.get("Names").cloned().expect("Names bound");
+    let names = vm.deref_heap(&vm.deref_var(&names_raw));
+    assert_eq!(
+        names,
+        Value::List(vec![
+            fact("=", vec![at("A"), args[0].clone()]),
+            fact("=", vec![at("B"), args[1].clone()]),
+        ]),
+    );
+}


### PR DESCRIPTION
## Summary

- handle `variable_names/1` in `read_term_from_atom/3`
- use `parse_term_from_atom/4` only when the variable environment is needed
- preserve variable identity between the parsed term and returned name pairs
- retain source variable order and exclude anonymous `_`
- update runtime-parser status documentation for Rust

## Testing

- focused generated Rust dynamic-builtin crate
- complete Rust WAM target suite
- Rust WAM target syntax load