### PR TITLE
Add Rust WAM read-term variable metadata

### DIFF
--- a/docs/WAM_RUNTIME_PARSER_STATUS.md
+++ b/docs/WAM_RUNTIME_PARSER_STATUS.md
@@ -71,7 +71,7 @@ each WAM instruction).
 | **C++**      | ✅ | ✅ | ✅ | `native(parse_term)` | partial — codegen tests in `test_wam_cpp_generator.pl`, one `'42'` parse verified end-to-end during the audit |
 | **R**        | ✅ | ✅ | ✅ | `native(parse_term)` | codegen tests; runtime end-to-end via the R smoke harness |
 | **Elixir**   | ✅ | — | — | `none` | n/a — `runtime_parser(compiled)` correctly throws `domain_error` (since Elixir isn't in the capability table); guarded by `test_runtime_parser_compiled_request_errors` |
-| **Rust**     | ✅ | — | ✅ | `none` | yes — generated-runtime tests cover parser calls, buffered reads, term/atom round-trips, and `variable_names/1` |
+| **Rust**     | ✅ | — | ✅ | `none` | yes — generated-runtime tests cover parser calls, buffered reads, term/atom round-trips, and variable metadata options |
 | **Haskell**  | ✅ | — | ✅ | `none` | partial — capability and project-expansion wiring; generated parser E2E is noted as slow in `docs/SESSION_HASKELL_PARITY_SUMMARY.md` |
 | **Go**       | ✅ | — | — | `none` | n/a (no parser-mode wiring) |
 | **Clojure**  | ✅ | — | — | `none` | n/a (no parser-mode wiring) |

--- a/src/unifyweaver/core/cpp_runtime_parser_wrappers.pl
+++ b/src/unifyweaver/core/cpp_runtime_parser_wrappers.pl
@@ -48,8 +48,9 @@ read_term_from_atom(Atom, Term) :-
 % This portable wrapper silently ignores options. Targets may intercept the
 % builtin before wrapper dispatch and implement options around the parser's
 % /4 environment result; the Rust runtime currently supports
-% variable_names/1 this way. Keeping the fallback wrapper permissive preserves
-% a stable surface for targets that have not adopted option handling yet.
+% variable_names/1, variables/1, and singletons/1 this way.
+% Keeping the fallback wrapper permissive preserves a stable surface for targets
+% that have not adopted option handling yet.
 read_term_from_atom(Atom, Term, _Options) :-
     read_term_from_atom(Atom, Term).
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1757,7 +1757,12 @@ compile_execute_term_builtin_to_rust(Code) :-
     ) -> bool {
         let variable_names = options
             .and_then(|value| self.read_term_option_arg(value, "variable_names"));
-        let parser_entry = if variable_names.is_some() {
+        let variables = options
+            .and_then(|value| self.read_term_option_arg(value, "variables"));
+        let singletons = options
+            .and_then(|value| self.read_term_option_arg(value, "singletons"));
+        let wants_env = variable_names.is_some() || variables.is_some() || singletons.is_some();
+        let parser_entry = if wants_env {
             "parse_term_from_atom/4"
         } else {
             "parse_term_from_atom/3"
@@ -1781,7 +1786,7 @@ compile_execute_term_builtin_to_rust(Code) :-
         parser.set_reg_str("A2", ops);
         parser.set_reg_str("A3", parsed_var.clone());
         let var_env = Value::Unbound("_RP_env".to_string());
-        if variable_names.is_some() {
+        if wants_env {
             parser.set_reg_str("A4", var_env.clone());
         }
         if !parser.run_named_label(parser_entry) {
@@ -1800,10 +1805,24 @@ compile_execute_term_builtin_to_rust(Code) :-
         }
         if let Some(names_target) = variable_names {
             let names = self.copy_variable_names_from_env(&parser, &var_env, &mut var_map);
-            self.unify(&names_target, &names)
-        } else {
-            true
+            if !self.unify(&names_target, &names) {
+                return false;
+            }
         }
+        if let Some(variables_target) = variables {
+            let variable_list = self.variables_from_term(&copied);
+            if !self.unify(&variables_target, &variable_list) {
+                return false;
+            }
+        }
+        if let Some(singletons_target) = singletons {
+            let singleton_list =
+                self.singletons_from_term(&copied, &parser, &var_env, &mut var_map);
+            if !self.unify(&singletons_target, &singleton_list) {
+                return false;
+            }
+        }
+        true
     }
 
     fn run_named_label(&mut self, label: &str) -> bool {

--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -100,16 +100,16 @@
         None
     }
 
-    fn copy_variable_names_from_env(
+    fn copy_named_variables_from_env(
         &mut self,
         source: &WamState,
         env: &Value,
         var_map: &mut std::collections::HashMap<String, String>,
-    ) -> Value {
+    ) -> Vec<(String, Value)> {
         let mut pairs = Vec::new();
         let entries = match source.value_as_list(env) {
             Some(entries) => entries,
-            None => return Value::List(pairs),
+            None => return pairs,
         };
         for entry in entries {
             let entry = source.deref_heap(&source.deref_var(&entry));
@@ -122,12 +122,109 @@
                 _ => continue,
             };
             let variable = self.copy_external_term_from(source, &args[1], var_map);
-            pairs.push(Value::Str(
-                "=".to_string(),
-                vec![Value::Atom(name), variable],
-            ));
+            pairs.push((name, variable));
         }
         pairs.reverse();
+        pairs
+    }
+
+    fn copy_variable_names_from_env(
+        &mut self,
+        source: &WamState,
+        env: &Value,
+        var_map: &mut std::collections::HashMap<String, String>,
+    ) -> Value {
+        Value::List(
+            self.copy_named_variables_from_env(source, env, var_map)
+                .into_iter()
+                .map(|(name, variable)| {
+                    Value::Str(
+                        "=".to_string(),
+                        vec![Value::Atom(name), variable],
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    fn collect_term_variable_names(&self, term: &Value, out: &mut Vec<String>) {
+        let term = self.deref_heap(&self.deref_var(term));
+        match term {
+            Value::Unbound(name) => out.push(name),
+            Value::Str(_, args) => {
+                for arg in args {
+                    self.collect_term_variable_names(&arg, out);
+                }
+            }
+            Value::List(items) => {
+                for item in items {
+                    self.collect_term_variable_names(&item, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn variables_from_term(&self, term: &Value) -> Value {
+        let mut occurrences = Vec::new();
+        self.collect_term_variable_names(term, &mut occurrences);
+        let mut seen = std::collections::HashSet::new();
+        Value::List(
+            occurrences
+                .into_iter()
+                .filter(|name| seen.insert(name.clone()))
+                .map(Value::Unbound)
+                .collect(),
+        )
+    }
+
+    fn copied_variable_source_names(
+        &mut self,
+        source: &WamState,
+        env: &Value,
+        var_map: &mut std::collections::HashMap<String, String>,
+    ) -> std::collections::HashMap<String, String> {
+        self.copy_named_variables_from_env(source, env, var_map)
+            .into_iter()
+            .filter_map(|(source_name, variable)| match variable {
+                Value::Unbound(runtime_name) => Some((runtime_name, source_name)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn singletons_from_term(
+        &mut self,
+        term: &Value,
+        source: &WamState,
+        env: &Value,
+        var_map: &mut std::collections::HashMap<String, String>,
+    ) -> Value {
+        let mut occurrences = Vec::new();
+        self.collect_term_variable_names(term, &mut occurrences);
+        let mut counts = std::collections::HashMap::new();
+        for name in &occurrences {
+            *counts.entry(name.clone()).or_insert(0usize) += 1;
+        }
+        let source_names = self.copied_variable_source_names(source, env, var_map);
+        let mut emitted = std::collections::HashSet::new();
+        let mut pairs = Vec::new();
+        for runtime_name in occurrences {
+            if counts.get(&runtime_name).copied() != Some(1) ||
+               !emitted.insert(runtime_name.clone()) {
+                continue;
+            }
+            let source_name = source_names.get(&runtime_name)
+                .cloned()
+                .unwrap_or_else(|| "_".to_string());
+            if source_name != "_" && source_name.starts_with('_') {
+                continue;
+            }
+            pairs.push(Value::Str(
+                "=".to_string(),
+                vec![Value::Atom(source_name), Value::Unbound(runtime_name)],
+            ));
+        }
         Value::List(pairs)
     }
 

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -274,14 +274,18 @@ fn term_to_atom_quotes_and_roundtrips_non_bare_atoms() {
 }
 
 #[test]
-fn read_term_from_atom_returns_variable_names_with_shared_variables() {
+fn read_term_from_atom_returns_variable_metadata_with_shared_variables() {
     let (code, labels) = shared_wam_program();
     let mut vm = WamState::new(code, labels);
-    vm.set_reg_str("A1", at("p(A, B, A, _)"));
+    vm.set_reg_str("A1", at("p(A, B, A, _, _C, _C, D)"));
     vm.set_reg_str("A2", ub("Term"));
     vm.set_reg_str(
         "A3",
-        Value::List(vec![fact("variable_names", vec![ub("Names")])]),
+        Value::List(vec![
+            fact("variables", vec![ub("Variables")]),
+            fact("variable_names", vec![ub("Names")]),
+            fact("singletons", vec![ub("Singletons")]),
+        ]),
     );
 
     assert!(vm.execute_builtin("read_term_from_atom/3", 3));
@@ -291,8 +295,22 @@ fn read_term_from_atom_returns_variable_names_with_shared_variables() {
         other => panic!("unexpected parsed term: {:?}", other),
     };
     assert_eq!(args[0], args[2]);
+    assert_eq!(args[4], args[5]);
     assert_ne!(args[0], args[1]);
     assert_ne!(args[0], args[3]);
+
+    let variables_raw = vm.bindings.get("Variables").cloned().expect("Variables bound");
+    let variables = vm.deref_heap(&vm.deref_var(&variables_raw));
+    assert_eq!(
+        variables,
+        Value::List(vec![
+            args[0].clone(),
+            args[1].clone(),
+            args[3].clone(),
+            args[4].clone(),
+            args[6].clone(),
+        ]),
+    );
 
     let names_raw = vm.bindings.get("Names").cloned().expect("Names bound");
     let names = vm.deref_heap(&vm.deref_var(&names_raw));
@@ -301,6 +319,19 @@ fn read_term_from_atom_returns_variable_names_with_shared_variables() {
         Value::List(vec![
             fact("=", vec![at("A"), args[0].clone()]),
             fact("=", vec![at("B"), args[1].clone()]),
+            fact("=", vec![at("_C"), args[4].clone()]),
+            fact("=", vec![at("D"), args[6].clone()]),
+        ]),
+    );
+
+    let singletons_raw = vm.bindings.get("Singletons").cloned().expect("Singletons bound");
+    let singletons = vm.deref_heap(&vm.deref_var(&singletons_raw));
+    assert_eq!(
+        singletons,
+        Value::List(vec![
+            fact("=", vec![at("B"), args[1].clone()]),
+            fact("=", vec![at("_"), args[3].clone()]),
+            fact("=", vec![at("D"), args[6].clone()]),
         ]),
     );
 }


### PR DESCRIPTION
## Summary

- support `variables/1` and `singletons/1` in `read_term_from_atom/3`
- return distinct variables in first-occurrence order
- preserve identity between metadata lists and the parsed term
- report anonymous `_` singletons while suppressing named underscore variables
- share parser environment processing across all variable metadata options
- update Rust runtime-parser status documentation

## Testing

- focused generated Rust dynamic-builtin crate
- complete Rust WAM target suite
- Rust WAM target syntax load