### PR TITLE
Add Rust WAM assert/1 alias

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -673,6 +673,8 @@ wam_instruction_arm('Instruction::Call(p, _arity)', Body) :-
                     true
                 } else if p == "retract/1" {
                     self.dynamic_retract_call(self.pc + 1)
+                } else if p == "assert/1" {
+                    self.execute_assert_builtin("assert/1")
                 } else if self.foreign_predicates.contains(p) {
                     self.cp = self.pc + 1;
                     if self.execute_foreign_predicate(p, *_arity) {
@@ -744,6 +746,11 @@ wam_instruction_arm('Instruction::Execute(p)', Body) :-
                     true
                 } else if p == "retract/1" {
                     self.dynamic_retract_call(self.cp)
+                } else if p == "assert/1" {
+                    if self.execute_assert_builtin("assert/1") {
+                        self.pc = self.cp;
+                        true
+                    } else { false }
                 } else if self.foreign_predicates.contains(p) {
                     self.execute_foreign_predicate(p, 0)
                 } else if let Some(__ftr) = crate::fact_table_call(self, p, self.cp) {

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -51,6 +51,17 @@ fn second_values(vm: &mut WamState, pred: &str, first: Value) -> Vec<Value> {
 }
 
 #[test]
+fn generated_assert_alias_appends_a_dynamic_fact() {
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code, labels);
+    vm.pc = *vm.labels
+        .get("rust_assert_alias_demo/0")
+        .expect("generated assert alias label");
+    assert!(vm.run());
+    assert_eq!(dyn_values(&mut vm), vec![at("alias")]);
+}
+
+#[test]
 fn assertz_asserta_query_order_and_retractall() {
     let mut vm = WamState::new(vec![], HashMap::new());
     assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("red")]));

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -9,6 +9,9 @@
 :- dynamic rust_dyn_dummy/0.
 rust_dyn_dummy.
 
+:- dynamic rust_assert_alias_demo/0.
+rust_assert_alias_demo :- assert(dyn(alias)).
+
 cargo_ok :-
     catch(( process_create(path(cargo), ['--version'],
                            [stdout(null), stderr(null), process(P)]),
@@ -24,7 +27,7 @@ test(assert_retract_dynamic_db,
     Dir = 'output/test_wam_rust_dynamic_builtins',
     safe_rmdir(Dir),
     once(write_wam_rust_project(
-        [user:rust_dyn_dummy/0],
+        [user:rust_dyn_dummy/0, user:rust_assert_alias_demo/0],
         [module_name(dynrt), no_kernels(true), runtime_parser(compiled)],
         Dir)),
     atom_concat(Dir, '/tests', TestsDir),


### PR DESCRIPTION
## Summary

- support `assert/1` as an `assertz/1` alias in Rust WAM
- intercept ordinary `Call` and `Execute` instructions locally
- avoid changing the shared builtin registry or other WAM targets
- verify execution through a genuinely generated Rust predicate

## Testing

- focused generated Rust dynamic-builtin crate
- Rust WAM target syntax load