### PR TITLE
WAM/LLVM eval payoff: plawk compile() runs the shipped bootstrap compiler

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -6,8 +6,8 @@ Copyright (c) 2026 John William Creighton (@s243a)
 # plawk eval bootstrap (JIT roadmap item 5)
 
 Compiling a grammar from **source text at runtime** — the endgame of the
-dynamic-grammar arc. This is the plan and the milestone sequence; it is a
-multi-PR effort, not a single change.
+dynamic-grammar arc. This was the plan and the milestone sequence; **the
+payoff has landed** (see "The landed surface" below).
 
 ## The goal
 
@@ -34,6 +34,51 @@ a buffer. The `mtime` cache-invalidation path (#3465) is the natural home for
 "recompile when the source changes." **The hard part is step 1**: getting the
 compiler to run *as a loaded object*, which needs the loadable WAM subset
 expanded to cover what the compiler leans on.
+
+## The landed surface
+
+```awk
+{ total += dyncall_at(compile("[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2)]"), $1) }
+END { print total }
+```
+
+`compile(field-or-string)` in the **dyncall_at source position** compiles
+the Prolog source text at runtime and yields a grammar HANDLE. It is the
+goal snippet minus the intermediate variable: `compile` **deduplicates by
+source text** (interned atom id), so a per-record `compile(...)` compiles
+each distinct grammar once and reuses the loaded VM thereafter — the
+two-step `g = compile(...)` form adds only variable plumbing (plawk
+scalars are numeric; a handle-in-scalar surface is a possible follow-up).
+
+How it works:
+
+- The CLI ships the **bootstrap compiler** — the self-hosted `cgfull`
+  (see PLAWK_SELFHOST.md; it lives in
+  `src/unifyweaver/targets/wam_bootstrap_compiler.pl`) — as
+  `<bin>.evalc.wamo` next to the output binary, ONLY when the program has
+  compile sites (pay-for-what-you-use). `BEGIN { EVALC = "path.wamo" }`
+  points at an existing compiler object instead and skips the emission.
+- `@plawk_compile(src, len)` interns the source, dedups against the
+  dyncall_at cache registry, and on miss runs
+  `@wam_object_load_cached(evalc)` → `@wam_object_eval(cvm, cpc, src,
+  len)` (compiler entry `cgfull(Src, Wamo)`; the emitted `.wamo` bytes
+  load into a fresh VM) and records the grammar under the source id.
+  The handle is the 1-based registry index; 0 means compile failure.
+- The handle reaches the existing `@plawk_dyncall_at_N` shims as
+  `(null path, handle)` — a null path is the discriminator
+  `@plawk_dyncall_at_get` uses to resolve from the registry instead of
+  the filesystem. All three shim families (i64 / float / blob) accept
+  handles for free.
+- `DYNCACHE "off"` cannot carry a handle (no registry), so compile sites
+  under it are a **build error**, not a silent miscompile.
+- Text-mode fields marshal as ATOMS (awk strings), so a numeric grammar
+  converts with `atom_number/2` before arithmetic — the loaded runtime,
+  like SWI, fails (rather than coerces) arithmetic on atoms.
+
+End-to-end tests: `tests/test_plawk_eval_compile.pl` — a grammar compiled
+from source text inside the binary sums `sq(x)` over input records; two
+distinct runtime-compiled grammars coexist with per-source dedup; the
+cache-off build error.
 
 ## Why it is genuinely last
 

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -280,7 +280,7 @@ byte-return primitive and the "output is a term, not a scalar" plumbing),
 and benefits from item 1 (float constants) for grammars that build float
 fields.
 
-### 5. Source-`eval` via the compiler-as-`.wamo` bootstrap — *largest, STARTED*
+### 5. Source-`eval` via the compiler-as-`.wamo` bootstrap — **LANDED (the payoff runs)**
 
 **What:** compile a grammar from **source text at runtime** — `g =
 compile($1); total += dyncall_at(g, $2)` — by shipping the WAM compiler
@@ -297,11 +297,19 @@ subset — the compiler leans on `findall`/`assert`/`read_term`/meta-call,
 which are outside the subset today. Items 1 (float constants) and the
 broader builtin/subset work are stepping stones; this is genuinely last.
 
-**Status:** design + first subset increment landed. The full plan and its
-six milestones live in [PLAWK_EVAL_BOOTSTRAP.md](./PLAWK_EVAL_BOOTSTRAP.md).
-Item 5 is a **subset-expansion campaign** with the bootstrap as its payoff;
-each milestone is its own PR(s) and richer hand-written grammars become
-loadable along the way.
+**Status:** ALL SIX MILESTONES LANDED, and the payoff surface runs:
+`dyncall_at(compile("<prolog source>"), $1)` compiles a grammar from
+source text INSIDE the running binary — the CLI ships the self-hosted
+bootstrap compiler (promoted to
+`src/unifyweaver/targets/wam_bootstrap_compiler.pl`) as
+`<bin>.evalc.wamo` when a program has compile sites, `@plawk_compile`
+dedups by source text and hands out registry handles, and the existing
+dyncall_at shims consume them as `(null, handle)`. See
+[PLAWK_EVAL_BOOTSTRAP.md](./PLAWK_EVAL_BOOTSTRAP.md) ("The landed
+surface") and `tests/test_plawk_eval_compile.pl`. The full plan and its
+six milestones live in the same doc; item 5 was a **subset-expansion
+campaign** with the bootstrap as its payoff, and each milestone was its
+own PR(s).
 
 - **Milestone 1 — clause indexing — LANDED.** Every `switch_on_*` dispatch
   variant (matched by prefix, so the `_fallthrough` and `_a2` forms are

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -856,6 +856,15 @@ compiles itself, the self-compiled compiler compiles itself to the
 byte, and the object it produces compiles fresh programs identically
 to the production compiler.
 
+**Shipped (the payoff):** the bootstrap compiler is promoted out of the
+test file into `src/unifyweaver/targets/wam_bootstrap_compiler.pl`
+(module `wam_bootstrap_compiler`, staged history intact; the tests
+import it), and the plawk CLI ships it as `<bin>.evalc.wamo` for the
+eval surface — `dyncall_at(compile("<source>"), $1)` compiles a grammar
+from source text inside the running binary. See
+PLAWK_EVAL_BOOTSTRAP.md ("The landed surface") and
+`tests/test_plawk_eval_compile.pl`.
+
 ## Risks and open questions
 
 - **Operand encoding is the crux.** The register/argument packing (the

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -25,6 +25,7 @@
 :- use_module('../parser/plawk_parser').
 :- use_module('../codegen/plawk_native_codegen').
 :- use_module('../../../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../../../src/unifyweaver/targets/wam_bootstrap_compiler').
 
 % keeps write_wam_llvm_project fed when a program has no embedded
 % Prolog at all (the module wants at least one predicate)
@@ -129,6 +130,24 @@ build(File, Out0, KeepLL) :-
     ->  ProjectOptions = [module_name(OutBase), emit_wamo_loader(true)]
     ;   ProjectOptions = [module_name(OutBase)]
     ),
+    % A program using the eval surface -- compile(...) inside a
+    % dyncall_at -- needs the bootstrap-compiler object shipped next to
+    % the binary (pay-for-what-you-use: emitted only when compile sites
+    % exist). BEGIN { EVALC = "..." } points at an existing object
+    % instead and skips the emission.
+    (   plawk_program_compile_sites(Program, CompileSites),
+        CompileSites \== [],
+        \+ plawk_program_evalc_path(Program, _)
+    ->  absolute_file_name(Out, OutAbs),
+        atom_concat(OutAbs, '.evalc.wamo', EvalcPath),
+        catch(
+            write_wam_object([wam_bootstrap_compiler:cgfull/2],
+                [wamo_entry(cgfull/2)], EvalcPath),
+            EvalcErr,
+            ( report_error('compile error', File, EvalcErr), halt(3) )),
+        EvalcOptions = [evalc_path(EvalcPath)]
+    ;   EvalcOptions = []
+    ),
     (   catch(
             ( % the compiler narrates on user_output; keep the CLI's
               % stdout clean for the compiled program's own output
@@ -136,7 +155,7 @@ build(File, Out0, KeepLL) :-
                   write_wam_llvm_project(Preds, ProjectOptions, LLPath)),
               wam_llvm_last_compile_counts(InstrCount, LabelCount),
               (   plawk_program_native_driver_ir(Program, stdin_or_argv,
-                      [wam_vm(InstrCount, LabelCount)], DriverIR)
+                      [wam_vm(InstrCount, LabelCount) | EvalcOptions], DriverIR)
               ->  true
               ;   format(user_error,
                       'plawk: ~w parses but is outside the compilable surface~n',

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -20,6 +20,8 @@
     plawk_program_dyncall_at_blob_arities/2,
     plawk_program_dyncache_mode/2,
     plawk_program_dynload_path/2,
+    plawk_program_evalc_path/2,
+    plawk_program_compile_sites/2,
     plawk_prolog_block_preds/2
 ]).
 
@@ -690,9 +692,34 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
             plawk_dyncall_at_support_ir(CacheMode, DynAtArities, DynAtFArities,
                 DynAtBArities, DyncallAtSupportIR)
         ),
+        % The eval surface: compile(...) sites need @plawk_compile plus
+        % the bootstrap-compiler object path (BEGIN { EVALC = "..." }
+        % or the CLI-provided evalc_path option). The handle lives in
+        % the dyncall_at cache registry, so mode "off" cannot carry it.
+        (   plawk_program_compile_sites(Program, CompileSites),
+            CompileSites \== []
+        ->  plawk_program_dyncache_mode(Program, CMode),
+            (   CMode == "off"
+            ->  throw(error(plawk_compile_requires_cache,
+                    context(plawk_program_native_driver_ir,
+                        'compile(...) requires DYNCACHE "on" or "mtime" (the grammar handle lives in the cache)')))
+            ;   true
+            ),
+            (   plawk_program_evalc_path(Program, EvalcPath)
+            ->  true
+            ;   memberchk(evalc_path(EvalcPath), Options)
+            ->  true
+            ;   throw(error(plawk_compile_without_evalc,
+                    context(plawk_program_native_driver_ir,
+                        'compile(...) needs a compiler object: BEGIN { EVALC = "file.wamo" } or the CLI evalc_path option')))
+            ),
+            plawk_compile_support_ir(EvalcPath, CompileSupportIR)
+        ;   CompileSupportIR = ''
+        ),
         plawk_program_native_driver_ir(Program, InputPath, MainIR),
         exclude(==(''),
-            [ForeignSupportIR, DyncallSupportIR, DyncallAtSupportIR, MainIR],
+            [ForeignSupportIR, DyncallSupportIR, DyncallAtSupportIR,
+             CompileSupportIR, MainIR],
             Parts),
         atomic_list_concat(Parts, '\n\n', DriverIR)
     ).
@@ -1679,11 +1706,37 @@ plawk_dyncache_globals_ir(Kind, IR) :-
 plawk_dyncall_at_get_on_ir(
 'define { %WamState*, i32 } @plawk_dyncall_at_get(i8* %path, i64 %len) {
 entry:
+  ; compile(...) handles travel as (null, handle-id): a null path is the
+  ; discriminator -- resolve the 1-based cache index directly, with no
+  ; interning and no filesystem. See @plawk_compile.
+  %is_h = icmp eq i8* %path, null
+  br i1 %is_h, label %hentry, label %pentry
+hentry:
+  %hid = trunc i64 %len to i32
+  %hn = load i32, i32* @plawk_dyncache_n
+  %h_lo = icmp sge i32 %hid, 1
+  %h_hi = icmp sle i32 %hid, %hn
+  %h_ok = and i1 %h_lo, %h_hi
+  br i1 %h_ok, label %hload, label %hfail
+hload:
+  %hix = sub i32 %hid, 1
+  %hvmp = getelementptr [64 x %WamState*], [64 x %WamState*]* @plawk_dyncache_vms, i32 0, i32 %hix
+  %hvm = load %WamState*, %WamState** %hvmp
+  %hpcp = getelementptr [64 x i32], [64 x i32]* @plawk_dyncache_pcs, i32 0, i32 %hix
+  %hpc = load i32, i32* %hpcp
+  %hh0 = insertvalue { %WamState*, i32 } undef, %WamState* %hvm, 0
+  %hh1 = insertvalue { %WamState*, i32 } %hh0, i32 %hpc, 1
+  ret { %WamState*, i32 } %hh1
+hfail:
+  %hf0 = insertvalue { %WamState*, i32 } undef, %WamState* null, 0
+  %hf1 = insertvalue { %WamState*, i32 } %hf0, i32 0, 1
+  ret { %WamState*, i32 } %hf1
+pentry:
   %id = call i64 @wam_intern_atom(i8* %path, i64 %len)
   %n = load i32, i32* @plawk_dyncache_n
   br label %scan
 scan:
-  %i = phi i32 [ 0, %entry ], [ %i1, %next ]
+  %i = phi i32 [ 0, %pentry ], [ %i1, %next ]
   %done = icmp sge i32 %i, %n
   br i1 %done, label %miss, label %check
 check:
@@ -1728,6 +1781,32 @@ ret_obj:
 plawk_dyncall_at_get_mtime_ir(
 'define { %WamState*, i32 } @plawk_dyncall_at_get(i8* %path, i64 %len) {
 entry:
+  ; compile(...) handles travel as (null, handle-id) -- resolved from
+  ; the cache index directly, never stat-ed (a handle has no file, so
+  ; the mtime-bust path does not apply). See @plawk_compile.
+  %is_h = icmp eq i8* %path, null
+  br i1 %is_h, label %hentry, label %pentry
+hentry:
+  %hid = trunc i64 %len to i32
+  %hn = load i32, i32* @plawk_dyncache_n
+  %h_lo = icmp sge i32 %hid, 1
+  %h_hi = icmp sle i32 %hid, %hn
+  %h_ok = and i1 %h_lo, %h_hi
+  br i1 %h_ok, label %hload, label %hfail
+hload:
+  %hix = sub i32 %hid, 1
+  %hvmp = getelementptr [64 x %WamState*], [64 x %WamState*]* @plawk_dyncache_vms, i32 0, i32 %hix
+  %hvm = load %WamState*, %WamState** %hvmp
+  %hpcp = getelementptr [64 x i32], [64 x i32]* @plawk_dyncache_pcs, i32 0, i32 %hix
+  %hpc = load i32, i32* %hpcp
+  %hh0 = insertvalue { %WamState*, i32 } undef, %WamState* %hvm, 0
+  %hh1 = insertvalue { %WamState*, i32 } %hh0, i32 %hpc, 1
+  ret { %WamState*, i32 } %hh1
+hfail:
+  %hf0 = insertvalue { %WamState*, i32 } undef, %WamState* null, 0
+  %hf1 = insertvalue { %WamState*, i32 } %hf0, i32 0, 1
+  ret { %WamState*, i32 } %hf1
+pentry:
   %id = call i64 @wam_intern_atom(i8* %path, i64 %len)
   %statbuf = alloca [256 x i8]
   %sbp = getelementptr [256 x i8], [256 x i8]* %statbuf, i32 0, i32 0
@@ -1745,7 +1824,7 @@ read_mtime:
   %mtime_r = add i64 %sec_ns, %nsec
   br label %have_mtime
 have_mtime:
-  %mtime = phi i64 [ %mtime_r, %read_mtime ], [ 0, %entry ]
+  %mtime = phi i64 [ %mtime_r, %read_mtime ], [ 0, %pentry ]
   %n = load i32, i32* @plawk_dyncache_n
   br label %scan
 scan:
@@ -1813,6 +1892,84 @@ mstore:
 mret:
   ret { %WamState*, i32 } %obj
 }').
+
+%% plawk_compile_support_ir(+EvalcPath, -IR)
+%
+%  The eval-surface runtime (JIT roadmap item 5 payoff):
+%  @plawk_compile(src, len) compiles Prolog source text through the
+%  shipped bootstrap-compiler object and returns a HANDLE (1-based
+%  index into the dyncall_at cache registry; 0 on failure). Flow:
+%    1. intern the source text; scan the cache for that id -- same
+%       source compiles ONCE, later calls are a registry hit;
+%    2. miss: lazy-load the compiler object (@wam_object_load_cached,
+%       its own one-shot cache -- the DYNCACHE role), run it on the
+%       source via @wam_object_eval (compiler entry cgfull(Src, Wamo);
+%       the emitted .wamo bytes load into a fresh VM), and record the
+%       loaded grammar in the registry under the source id.
+%  The handle is consumed by @plawk_dyncall_at_get as (null, handle).
+%  Requires the dyncache globals (any compile(...) site lives inside a
+%  dyncall_at, so they are always emitted together) and cache mode
+%  on/mtime -- mode "off" has no registry and is rejected at codegen.
+plawk_compile_support_ir(EvalcPath, IR) :-
+    llvm_emit_c_string_global(plawk_evalc_path, EvalcPath, PathGlobal,
+        _StrLen, BytesLen),
+    format(atom(IR),
+'~w
+
+define i64 @plawk_compile(i8* %src, i64 %len) {
+entry:
+  %id = call i64 @wam_intern_atom(i8* %src, i64 %len)
+  %n = load i32, i32* @plawk_dyncache_n
+  br label %scan
+scan:
+  %i = phi i32 [ 0, %entry ], [ %i1, %next ]
+  %done = icmp sge i32 %i, %n
+  br i1 %done, label %miss, label %check
+check:
+  %idp = getelementptr [64 x i64], [64 x i64]* @plawk_dyncache_ids, i32 0, i32 %i
+  %cid = load i64, i64* %idp
+  %match = icmp eq i64 %cid, %id
+  br i1 %match, label %hit, label %next
+next:
+  %i1 = add i32 %i, 1
+  br label %scan
+hit:
+  %h = add i32 %i, 1
+  %h64 = sext i32 %h to i64
+  ret i64 %h64
+miss:
+  ; a full registry cannot hand out a stable handle -- fail rather
+  ; than hand back an index that later loads would shift under
+  %room = icmp slt i32 %n, 64
+  br i1 %room, label %doload, label %fail
+doload:
+  %cpath = getelementptr [~w x i8], [~w x i8]* @.plawk_evalc_path, i32 0, i32 0
+  %comp = call { %WamState*, i32 } @wam_object_load_cached(i8* %cpath)
+  %cvm = extractvalue { %WamState*, i32 } %comp, 0
+  %cvm_ok = icmp ne %WamState* %cvm, null
+  br i1 %cvm_ok, label %doeval, label %fail
+doeval:
+  %cpc = extractvalue { %WamState*, i32 } %comp, 1
+  %g = call { %WamState*, i32 } @wam_object_eval(%WamState* %cvm, i32 %cpc, i8* %src, i64 %len)
+  %gvm = extractvalue { %WamState*, i32 } %g, 0
+  %gok = icmp ne %WamState* %gvm, null
+  br i1 %gok, label %record, label %fail
+record:
+  %gpc = extractvalue { %WamState*, i32 } %g, 1
+  %sidp = getelementptr [64 x i64], [64 x i64]* @plawk_dyncache_ids, i32 0, i32 %n
+  store i64 %id, i64* %sidp
+  %svmp = getelementptr [64 x %WamState*], [64 x %WamState*]* @plawk_dyncache_vms, i32 0, i32 %n
+  store %WamState* %gvm, %WamState** %svmp
+  %spcp = getelementptr [64 x i32], [64 x i32]* @plawk_dyncache_pcs, i32 0, i32 %n
+  store i32 %gpc, i32* %spcp
+  %n1 = add i32 %n, 1
+  store i32 %n1, i32* @plawk_dyncache_n
+  %h64m = sext i32 %n1 to i64
+  ret i64 %h64m
+fail:
+  ret i64 0
+}',
+        [PathGlobal, BytesLen, BytesLen]).
 
 % shim for cached modes (on / mtime): resolve via @plawk_dyncall_at_get
 plawk_dyncall_at_shim_cached_ir(NArgs, IR) :-
@@ -2006,6 +2163,24 @@ plawk_dyncall_source_ir(string(Str), _FieldSeparator, Base, _GlobalBase,
         'getelementptr ([~w x i8], [~w x i8]* @.~w, i32 0, i32 0)',
         [BytesLen, BytesLen, GName]),
     PathLenIR = StrLen.
+% compile(field-or-string): marshal the Prolog source text exactly like
+% a path (the two clauses above), then run it through @plawk_compile --
+% the shipped bootstrap-compiler object compiles it and the freshly
+% loaded grammar is cached, deduplicated by source text. The resulting
+% HANDLE travels to the shim as (null path, handle id); the null
+% pointer is the discriminator @plawk_dyncall_at_get uses to resolve
+% from the cache registry instead of the filesystem.
+plawk_dyncall_source_ir(compile_src(Arg), FieldSeparator, Base, GlobalBase,
+        PathPtrIR, PathLenIR, GlobalParts, SetupParts) :-
+    format(atom(CBase), '~w_csrc', [Base]),
+    plawk_dyncall_source_ir(Arg, FieldSeparator, CBase, GlobalBase,
+        SrcPtrIR, SrcLenIR, GlobalParts, SrcSetup),
+    format(atom(CallIR),
+        '  %~w_h = call i64 @plawk_compile(i8* ~w, i64 ~w)',
+        [Base, SrcPtrIR, SrcLenIR]),
+    PathPtrIR = null,
+    format(atom(PathLenIR), '%~w_h', [Base]),
+    append(SrcSetup, [CallIR], SetupParts).
 
 %% plawk_blob_expr_ir(+Expr, +FieldSeparator, +Base, -LenIR, -PtrIR,
 %%     -GlobalParts, -SetupParts)
@@ -2099,6 +2274,34 @@ plawk_program_dyncache_mode(program(BeginClauses, _Rules, _End), Mode) :-
     ->  Mode = M
     ;   Mode = "on"
     ).
+
+%% plawk_program_evalc_path(+Program, -Path)
+%  The bootstrap-compiler .wamo path from BEGIN { EVALC = "..." }, or
+%  fails if absent (the CLI then ships its own compiler object next to
+%  the binary and passes the path through the evalc_path/1 option).
+plawk_program_evalc_path(program(BeginClauses, _Rules, _End), Path) :-
+    member(begin(Actions), BeginClauses),
+    member(set(var('EVALC'), string(Path)), Actions),
+    !.
+
+%% plawk_program_compile_sites(+Program, -Sources)
+%  The deduplicated compile(...) source args across every dyncall_at
+%  variant (i64 / float / blob). Non-empty means the program uses the
+%  eval surface: @plawk_compile must be emitted and a bootstrap-compiler
+%  object must exist at the evalc path when the binary runs.
+plawk_program_compile_sites(program(_Begin, Rules, EndClauses), Sites) :-
+    findall(Arg,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          ( plawk_actions_dyncall_at(Actions, compile_src(Arg), _)
+          ; plawk_actions_float_dyncall_at(Actions, compile_src(Arg), _)
+          ; member(Action, Actions),
+            plawk_action_blob_field(Action, blob_dyncall_at(compile_src(Arg), _))
+          )
+        ),
+        Sites0),
+    sort(Sites0, Sites).
 
 plawk_actions_dyncall_at(Actions, Source, Args) :-
     member(Action, Actions),
@@ -5735,9 +5938,17 @@ plawk_dyncall_named_expr(dyncall_named(Name, Args)) :-
 %  dyncall_at(Source, args...) is the dynamic-source form: Source (a
 %  field or string literal) names the .wamo object at runtime, args... are
 %  the entry inputs. Same yield semantics as dyncall (i64, 0 on failure).
+%  Source may also be compile_src(field-or-string) -- the eval surface:
+%  the Prolog source text compiles at runtime to a grammar handle.
 plawk_dyncall_at_expr(dyncall_at(Source, Args)) :-
-    plawk_foreign_arg(Source),
+    plawk_dyncall_at_source_ok(Source),
     maplist(plawk_foreign_arg, Args).
+
+plawk_dyncall_at_source_ok(compile_src(Arg)) :-
+    !,
+    plawk_foreign_arg(Arg).
+plawk_dyncall_at_source_ok(Source) :-
+    plawk_foreign_arg(Source).
 
 %% float(dyncall(...)) / float(dyncall_at(...)) -- double-returning
 %  runtime-object calls: the grammar's numeric output keeps its fraction.
@@ -5749,7 +5960,7 @@ plawk_float_dyncall_named_expr(float_dyncall_named(Name, Args)) :-
     Args = [_ | _],
     maplist(plawk_foreign_arg, Args).
 plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)) :-
-    plawk_foreign_arg(Source),
+    plawk_dyncall_at_source_ok(Source),
     maplist(plawk_foreign_arg, Args).
 
 %% plawk_dynrec_bind_ok(+Action) is semidet.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -440,6 +440,28 @@ foreign_args_rest([Arg | Args]) -->
 foreign_args_rest([]) -->
     [].
 
+%% dyncall_at_source(-Source)//
+%
+%  The first argument of dyncall_at(...): either a path (field / string
+%  literal, as before), or compile(field-or-string) -- the eval surface.
+%  compile(Src) runs the shipped bootstrap-compiler .wamo on the Prolog
+%  source text Src at runtime and yields a HANDLE to the freshly
+%  compiled grammar (deduplicated by source text, so repeated compiles
+%  of the same source reuse one loaded grammar). "compile" is reserved
+%  in this position only; elsewhere it still parses as an ordinary
+%  identifier.
+dyncall_at_source(compile_src(Arg)) -->
+    "compile",
+    ws,
+    "(",
+    ws,
+    foreign_arg(Arg),
+    ws,
+    ")",
+    !.
+dyncall_at_source(Source) -->
+    foreign_arg(Source).
+
 foreign_arg(field(Index)) -->
     "$",
     integer_codes(IndexCodes),
@@ -1391,12 +1413,18 @@ i64_factor_expr(var(Name)) -->
 % or string literal) names the .wamo object at runtime, chosen per call,
 % and args... are the entry's inputs. Reserved like dyncall; parsed before
 % it so the longer keyword wins.
+% The source may also be compile(field-or-string): compile the Prolog
+% source text through the shipped bootstrap-compiler object at runtime
+% (the eval surface -- JIT roadmap item 5 payoff) and dyncall the
+% freshly compiled grammar. compile() dedups by source text, so a
+% per-record `dyncall_at(compile($1), $2)` compiles each distinct
+% grammar once and reuses it from the cache thereafter.
 prolog_call_expr(dyncall_at(Source, Args)) -->
     "dyncall_at",
     ws,
     "(",
     ws,
-    foreign_arg(Source),
+    dyncall_at_source(Source),
     foreign_args_rest(Args),
     ws,
     ")",
@@ -1475,7 +1503,7 @@ float_call_expr(float_dyncall_at(Source, Args)) -->
     ws,
     "(",
     ws,
-    foreign_arg(Source),
+    dyncall_at_source(Source),
     foreign_args_rest(Args),
     ws,
     ")",
@@ -1536,7 +1564,7 @@ blob_call_expr(blob_dyncall_at(Source, Args)) -->
     ws,
     "(",
     ws,
-    foreign_arg(Source),
+    dyncall_at_source(Source),
     foreign_args_rest(Args),
     ws,
     ")",

--- a/src/unifyweaver/targets/wam_bootstrap_compiler.pl
+++ b/src/unifyweaver/targets/wam_bootstrap_compiler.pl
@@ -1,0 +1,783 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% wam_bootstrap_compiler.pl - the self-hosted Prolog->.wamo bootstrap compiler
+%
+% A minimal Prolog->.wamo compiler written entirely in the LOADABLE WAM
+% subset, so that -- compiled ahead of time with write_wam_object/3 -- it
+% runs as a loaded object and compiles grammars from source text at
+% runtime (the eval/compile surface of the plawk JIT roadmap, item 5).
+% This is the compiler that closed the self-host fixpoint: compiled to
+% gen1, it compiles its own source to gen2; gen2 compiles the same
+% source to a byte-identical gen3 (F(F) = F); and the self-compiled
+% compiler compiles fresh programs byte-identically to cgfull_term/2.
+% See docs/design/PLAWK_SELFHOST.md and docs/design/PLAWK_EVAL_BOOTSTRAP.md.
+%
+% The file keeps the full STAGED history of the campaign -- each stage is
+% still compiled to an object and exercised by tests/test_wam_object.pl
+% (where this code lived until milestone 6 completed):
+%   Stage A  wamoserz/2   -- .wamo serializer (difference-list emitters)
+%   Stage B  cgcompile/2  -- one clause shape, source text in
+%   Stage C  cgcprog/2    -- multi-clause programs + predicate calls
+%            cgconj/2     -- conjunction + register allocation
+%            cgarith/2    -- runtime arithmetic + functor table
+%   Stage D  cgfull/2     -- the UNIFIED compiler: multi-clause predicates,
+%                            try/retry/trust chains, lists, structures with
+%                            X-temp deferral both directions, comparison
+%                            guards, if-then-else, ~37 whitelisted builtins
+% cgfull_term/2 is cgfull/2 minus the reader call (read_term_from_atom/2
+% exists only in the loaded runtime), so SWI can compute golden bytes from
+% clause TERMS -- the production-side oracle every self-compile is checked
+% against.
+%
+% Everything here must stay inside the loadable subset (no cuts in the
+% cgfull chain beyond first-argument commitment, ITE dispatch, =.. instead
+% of control-functor pattern literals, '$VAR'(integer) as the numbervars
+% marker) -- the compiler is its own test case.
+
+:- module(wam_bootstrap_compiler, [
+    wamoserz/2,        % +Src, -Wamo  (Stage A: fixed program, real serializer)
+    cgcompile/2,       % +Src, -Wamo  (Stage B: one clause shape)
+    cgcprog/2,         % +Src, -Wamo  (Stage C: multi-clause + calls)
+    cgconj/2,          % +Src, -Wamo  (Stage C: conjunction + registers)
+    cgarith/2,         % +Src, -Wamo  (Stage C: arithmetic + functor table)
+    cgfull/2,          % +Src, -Wamo  (Stage D: the unified compiler)
+    cgfull_term/2,     % +Clauses, -Wamo (cgfull minus the reader; SWI oracle)
+    wza_serialize/8    % low-level serializer (golden-byte construction)
+]).
+
+:- discontiguous walk_term/3.
+
+% Milestone 6 (self-host) Stage A: a .wamo serializer written in the loadable
+% subset. wamoserz/2 is a real eval-pipeline compiler entry -- compile(Src,
+% Wamo) -- but Stage A ignores Src and serializes a FIXED ground instruction
+% list for a 42-returning program (`ea(R):-R=42`), exercising the string-
+% assembly back end end to end. It reproduces wamo_serialize/8's byte format
+% using only loadable builtins (atom_codes/number_codes/append/length), so it
+% runs as a loaded object; the emitted bytes load via @wam_object_eval and run
+% to 42. NA/NF are 0 here (no atom/functor tables); the PC and instruction
+% lists drive the rest, so this is a genuine serializer, not a string literal.
+%
+% Written as SMALL accumulator-threaded clauses (a code list is threaded
+% through, each clause holding only a few call-spanning variables) with only
+% list / enc(...) head dispatch -- deliberately avoiding two loaded-runtime
+% limitations this stage surfaced: (1) a clause holding ~16+ call-spanning
+% variables emits register indices past the 64-slot register file and corrupts
+% memory; (2) multi-way first-argument functor dispatch across >=4 tagged
+% variants (with a list-carrying variant present) mis-dispatches in loaded
+% objects. Both are recorded in PLAWK_SELFHOST.md as prerequisites for later
+% stages; the "small clauses, correctness over register reuse" style the design
+% doc prescribes routes around both.
+wamoserz(_Src, Wamo) :-
+    atom_codes('ea/1', NameCodes),
+    wz_serialize(0, NameCodes, 0, 0, 0, [0],
+        [enc(0,42,65536,0), enc(20,0,0,0)], Codes),
+    atom_codes(Wamo, Codes).
+
+% DIFFERENCE-LIST emitters: A0 is the open list being built, A1 its tail
+% after this item -- so each emission appends only its OWN codes (linear in
+% total output), never copying the accumulated prefix. The old accumulator
+% style (append(A0, Cs, B) -- copy everything emitted so far, per token) is
+% QUADRATIC in output size and was the entire compile-time/memory cliff of
+% the self-host fixpoint (246 MB arena for a 3.6 KB object). Threading
+% predicates (wz_header/wz_body/wz_pcs_rows/...) are direction-agnostic and
+% unchanged; only the leaf emitters and the top wrappers (which now close
+% the tail with []) know the representation.
+% wz_i "<int>\n", wz_a "<atom>\n", wz_n "<len> <bytes>\n", wz_si " <int>".
+wz_i(N, A0, A1)  :- number_codes(N, Cs), append(Cs, [10|A1], A0).
+wz_a(X, A0, A1)  :- atom_codes(X, Cs), append(Cs, [10|A1], A0).
+wz_n(Cs, A0, A1) :- length(Cs, Len), number_codes(Len, LC),
+    append(LC, [32|Mid], A0), append(Cs, [10|A1], Mid).
+wz_si(N, A0, A1) :- number_codes(N, Cs), append([32|Cs], A1, A0).
+
+wz_serialize(EntryIdx, NameCodes, LabelIdx, NA, NF, PCs, Instrs, Out) :-
+    wz_header(EntryIdx, NameCodes, LabelIdx, NA, NF, Out, Hdr),
+    wz_body(PCs, Instrs, Hdr, []).
+
+% header: WAMO / version 2 / entry index / NE=1 / name / label / NA / NF,
+% split across two clauses so neither holds too many call-spanning vars.
+wz_header(EntryIdx, NameCodes, LabelIdx, NA, NF, A0, Out) :-
+    wz_a('WAMO', A0, A1), wz_i(2, A1, A2), wz_i(EntryIdx, A2, A3), wz_i(1, A3, A4),
+    wz_header2(NameCodes, LabelIdx, NA, NF, A4, Out).
+wz_header2(NameCodes, LabelIdx, NA, NF, A0, Out) :-
+    wz_n(NameCodes, A0, A1), wz_i(LabelIdx, A1, A2), wz_i(NA, A2, A3), wz_i(NF, A3, Out).
+
+% body: PC section, instruction section, then NM=0.
+wz_body(PCs, Instrs, A0, Out) :-
+    wz_pcs_sec(PCs, A0, A1),
+    wz_instr_sec(Instrs, A1, A2),
+    wz_i(0, A2, Out).
+
+wz_pcs_sec(PCs, A0, A2) :- length(PCs, NL), wz_i(NL, A0, A1), wz_pcs_rows(PCs, A1, A2).
+wz_pcs_rows([], A, A).
+wz_pcs_rows([P|Ps], A0, A2) :- wz_i(P, A0, A1), wz_pcs_rows(Ps, A1, A2).
+
+wz_instr_sec(Instrs, A0, A2) :-
+    length(Instrs, NC), wz_i(NC, A0, A1), wz_instr_rows(Instrs, A1, A2).
+wz_instr_rows([], A, A).
+wz_instr_rows([enc(T,O1,O2,R)|Is], A0, A2) :-
+    wz_row(T, O1, O2, R, A0, A1), wz_instr_rows(Is, A1, A2).
+wz_row(T, O1, O2, R, A0, A5) :-
+    number_codes(T, Tc), append(Tc, A1, A0),
+    wz_si(O1, A1, A2), wz_si(O2, A2, A3), wz_si(R, A3, A4), A4 = [10|A5].
+
+% Milestone 6 (self-host) Stage B: minimal CODEGEN -- source text to a .wamo,
+% end to end. cgcompile/2 is the eval-pipeline entry compile(Src,Wamo): it
+% parses Src with the runtime reader (read_term_from_atom/2, milestone 3b),
+% walks the clause to an instruction list (clause_to_instrs/3), and hands it to
+% the Stage A serializer (wz_serialize/8). The loadable subset for now: a
+% one-argument clause whose body binds the head variable to an integer, either
+% directly (`p(R) :- R = 42`) or by evaluating a ground arithmetic expression
+% (`p(R) :- R is 6*7`). Both lower to [get_constant(V,A1), proceed] -- the
+% golden shape from Stage A, parameterized by the computed value V.
+%
+% body_int/2 dispatches on the body's functor (=/2 vs is/2); this is exactly
+% the tagged first-argument dispatch that the get_structure functor-check fix
+% made correct in loaded objects. No constant-index arg/3 (the known subset
+% gap) -- functor/3 gives the predicate name and body_int gives the value.
+cgcompile(Src, Wamo) :-
+    read_term_from_atom(Src, Clause),
+    clause_to_instrs(Clause, Instrs, NameCodes),
+    wz_serialize(0, NameCodes, 0, 0, 0, [0], Instrs, Codes),
+    atom_codes(Wamo, Codes).
+
+clause_to_instrs((Head :- Body), Instrs, NameCodes) :-
+    body_int(Body, V),
+    functor(Head, Pred, Arity),
+    pred_name_codes(Pred, Arity, NameCodes),
+    % get_constant(V, A1): tag 0, op1 = V, op2 = (Integer-tag 1 << 16)|reg A1(0).
+    Instrs = [enc(0, V, 65536, 0), enc(20, 0, 0, 0)].
+
+body_int((_ = V), V)     :- integer(V).
+body_int((_ is Expr), V) :- V is Expr.
+
+pred_name_codes(Pred, Arity, Codes) :-
+    atom_codes(Pred, PC), number_codes(Arity, AC),
+    append(PC, [0'/ | AC], Codes).
+
+% Milestone 6 (self-host) Stage C: multi-clause programs with predicate calls.
+% cgcprog/2 is the eval entry compile(Src,Wamo): Src parses (one reader call)
+% to a LIST of clauses -- e.g. "[(main0(R):-helper(R)), helper(42)]" -- and the
+% program compiles to a multi-predicate .wamo. Each clause gets a label (its
+% index); a predicate-call body becomes execute(CalleeLabel) resolved through
+% a name/arity->label map (execute references the label directly, so no
+% meta-call table is needed). The label->PC table (PCs, one entry per clause)
+% is exactly what the Stage A serializer already accepts. Facts P(Int) and the
+% Stage B body forms (= / is) still lower to [get_constant(V,A1), proceed].
+% A single-goal predicate-call body is a tail call: [allocate, deallocate,
+% execute] -- matching the host writer (verified byte-identical). Register
+% allocation for temporaries across conjoined goals is a Stage C follow-on.
+cgcprog(Src, Wamo) :-
+    read_term_from_atom(Src, Clauses),
+    cgc_clauses(Clauses, EntryName, PCs, Instrs),
+    wz_serialize(0, EntryName, 0, 0, 0, PCs, Instrs, Codes),
+    atom_codes(Wamo, Codes).
+
+cgc_clauses(Clauses, EntryName, PCs, AllInstrs) :-
+    assign_labels(Clauses, 0, PL),
+    codegen_all(Clauses, PL, 0, AllInstrs, PCs),
+    Clauses = [First|_], cgc_head(First, H0), functor(H0, P0, A0),
+    pred_name_codes(P0, A0, EntryName).
+
+cgc_head((H :- _), H) :- !.
+cgc_head(H, H).
+
+assign_labels([], _, []).
+assign_labels([C|Cs], L, [key(P,A)-L | Rest]) :-
+    cgc_head(C, H), functor(H, P, A), L1 is L + 1,
+    assign_labels(Cs, L1, Rest).
+
+codegen_all([], _, _, [], []).
+codegen_all([C|Cs], PL, PC, All, [PC|PCs]) :-
+    codegen_clause(C, PL, Instrs),
+    length(Instrs, N), PC1 is PC + N,
+    codegen_all(Cs, PL, PC1, Rest, PCs),
+    append(Instrs, Rest, All).
+
+codegen_clause((_ :- Body), PL, Instrs) :- !, codegen_body(Body, PL, Instrs).
+codegen_clause(Fact, _, [enc(0,V,65536,0), enc(20,0,0,0)]) :-   % fact P(Int)
+    Fact =.. [_, V], integer(V).
+
+codegen_body(Body, PL, Instrs) :-
+    (   Body = (_ = V), integer(V)
+    ->  Instrs = [enc(0,V,65536,0), enc(20,0,0,0)]
+    ;   Body = (_ is Expr)
+    ->  V is Expr, Instrs = [enc(0,V,65536,0), enc(20,0,0,0)]
+    ;   functor(Body, P, A), lookup_label(P, A, PL, Label)
+    ->  Instrs = [enc(16,0,0,0), enc(17,0,0,0), enc(19,Label,0,0)]  % allocate,deallocate,execute
+    ).
+
+lookup_label(P, A, [key(P,A)-L|_], L) :- !.
+lookup_label(P, A, [_|R], L) :- lookup_label(P, A, R, L).
+
+% Milestone 6 (self-host) Stage C (rest): conjunction + register allocation.
+% cgconj/2 compiles a clause whose body is a conjunction of unification goals
+% (X = Y, X = Int) with a real (simple) register allocator: numbervars binds
+% each source variable to '$VAR'(N), mapped to permanent register Y(N+1); the
+% initialized-Y set is threaded through so a variable's first occurrence emits
+% put_variable / get_variable and later occurrences put_value. Head arguments
+% are saved with get_variable; each `=` goal sets up A1/A2 (put_variable /
+% put_value / put_constant) then builtin_call =/2 (id 24). This is the WAM
+% register-allocation core -- verified byte-identical to the host writer for
+% `pconj(R):-Y=42,R=Y`. Runtime arithmetic (is/2 building expression terms via
+% put_structure) and non-tail calls are the remaining Stage C pieces.
+cgconj(Src, Wamo) :-
+    read_term_from_atom(Src, Clause),
+    numbervars(Clause, 0, _),
+    conj_instrs(Clause, NameCodes, Instrs),
+    wz_serialize(0, NameCodes, 0, 0, 0, [0], Instrs, Codes),
+    atom_codes(Wamo, Codes).
+
+conj_instrs(Clause, NameCodes, Instrs) :-
+    clause_hb(Clause, Head, Goals),
+    functor(Head, Pred, Arity), pred_name_codes(Pred, Arity, NameCodes),
+    head_args(Head, 1, Arity, [], Init1, HeadIs),
+    goals_instrs(Goals, Init1, _, GoalIs),
+    append([enc(16,0,0,0) | HeadIs], GoalIs, B0),          % allocate + head
+    append(B0, [enc(17,0,0,0), enc(20,0,0,0)], Instrs).     % deallocate, proceed
+
+clause_hb((H :- B), H, Goals) :- !, conj_list(B, Goals).
+clause_hb(H, H, []).
+conj_list((A,B), [A|Rest]) :- !, conj_list(B, Rest).
+conj_list(G, [G]).
+
+is_init(N, [N|_]) :- !.
+is_init(N, [_|T]) :- is_init(N, T).
+
+head_args(_, I, Arity, Init, Init, []) :- I > Arity, !.
+head_args(Head, I, Arity, Init0, Init, [Instr|Rest]) :-
+    arg(I, Head, Arg), AiIdx is I - 1,
+    head_arg_instr(Arg, AiIdx, Init0, Init1, Instr),
+    I1 is I + 1, head_args(Head, I1, Arity, Init1, Init, Rest).
+head_arg_instr('$VAR'(N), AiIdx, Init0, [N|Init0], enc(1, YIdx, AiIdx, 0)) :- YIdx is 48 + N.
+head_arg_instr(V, AiIdx, Init, Init, enc(0, V, Op2, 0)) :- integer(V), Op2 is (1 << 16) \/ AiIdx.
+
+operand_instr('$VAR'(N), AiIdx, Init0, Init1, [Instr]) :-
+    YIdx is 48 + N,
+    (   is_init(N, Init0)
+    ->  Instr = enc(10, YIdx, AiIdx, 0), Init1 = Init0     % put_value (subsequent)
+    ;   Instr = enc(9, YIdx, AiIdx, 0), Init1 = [N|Init0]  % put_variable (first)
+    ).
+operand_instr(V, AiIdx, Init, Init, [enc(8, V, Op2, 0)]) :- integer(V), Op2 is (1 << 16) \/ AiIdx.
+
+goal_instrs((L = R), Init0, Init2, Is) :-
+    operand_instr(L, 0, Init0, Init1, ILs),
+    operand_instr(R, 1, Init1, Init2, IRs),
+    append(ILs, IRs, LR), append(LR, [enc(21, 24, 2, 0)], Is).   % builtin_call =/2
+
+goals_instrs([], Init, Init, []).
+goals_instrs([G|Gs], Init0, Init, Is) :-
+    goal_instrs(G, Init0, Init1, GIs),
+    goals_instrs(Gs, Init1, Init, RestIs), append(GIs, RestIs, Is).
+
+% Milestone 6 (self-host) Stage C (arithmetic): runtime is/2. cgarith/2 extends
+% the conjunction compiler with `Var is BinExpr` goals -- e.g. `X is 6*7`. A
+% binary expression op(A,B) builds a compound term on the heap: put_structure
+% op/2 into A2 (op1 = functor-table index, reloc 2), then set_value (a variable
+% arg) / set_constant (an integer arg) for each operand, then builtin_call is/2
+% (id 0). Functor names used across the clause are collected into the object's
+% functor table (NF>0, emitted by the functor-aware serializer wzf_serialize).
+% Reuses the cgconj register allocator (operand_instr / head_args / is_init).
+% Verified byte-identical to the host writer for `ca(R) :- X is 6*7, R = X`,
+% which combines conjunction, a shared temporary, arithmetic, and unification.
+cgarith(Src, Wamo) :-
+    read_term_from_atom(Src, Clause),
+    numbervars(Clause, 0, _),
+    a_conj_instrs(Clause, NameCodes, Functors, Instrs),
+    wzf_serialize(0, NameCodes, 0, Functors, [0], Instrs, Codes),
+    atom_codes(Wamo, Codes).
+
+a_conj_instrs(Clause, NameCodes, Functors, Instrs) :-
+    clause_hb(Clause, Head, Goals),
+    functor(Head, Pred, Arity), pred_name_codes(Pred, Arity, NameCodes),
+    collect_functors(Goals, Functors),
+    head_args(Head, 1, Arity, [], Init1, HeadIs),
+    a_goals_instrs(Goals, Functors, Init1, _, GoalIs),
+    append([enc(16,0,0,0) | HeadIs], GoalIs, B0),
+    append(B0, [enc(17,0,0,0), enc(20,0,0,0)], Instrs).
+
+a_goals_instrs([], _, Init, Init, []).
+a_goals_instrs([G|Gs], FT, Init0, Init, Is) :-
+    a_goal_instrs(G, FT, Init0, Init1, GIs),
+    a_goals_instrs(Gs, FT, Init1, Init, RestIs), append(GIs, RestIs, Is).
+
+a_goal_instrs((L is Expr), FT, Init0, Init1, Is) :- !,
+    operand_instr(L, 0, Init0, Init1, LhsIs),   % LHS var -> A1
+    expr_build(Expr, FT, ExprIs),               % put_structure + set args -> A2
+    append(LhsIs, ExprIs, LE), append(LE, [enc(21, 0, 2, 0)], Is).   % builtin is/2
+a_goal_instrs((L = R), _FT, Init0, Init2, Is) :-
+    operand_instr(L, 0, Init0, Init1, IL), operand_instr(R, 1, Init1, Init2, IR),
+    append(IL, IR, LR), append(LR, [enc(21, 24, 2, 0)], Is).         % builtin =/2
+
+expr_build(Expr, FT, [PutS, SA, SB]) :-
+    Expr =.. [Op, A, B], functor_index(Op, FT, FIdx),
+    Op2 is (2 << 16) \/ 1,                       % arity 2, reg A2(1)
+    PutS = enc(11, FIdx, Op2, 2),                % put_structure, reloc functor
+    arg_set(A, SA), arg_set(B, SB).
+arg_set('$VAR'(N), enc(14, YIdx, 0, 0)) :- YIdx is 48 + N.   % set_value Y
+arg_set(V, enc(15, V, 1, 0)) :- integer(V).                   % set_constant integer
+functor_index(Op, [Op|_], 0) :- !.
+functor_index(Op, [_|T], I) :- functor_index(Op, T, I0), I is I0 + 1.
+
+collect_functors(Goals, FT) :- collect_f(Goals, [], FT).
+collect_f([], Acc, Acc).
+collect_f([G|Gs], Acc0, FT) :-
+    ( G = (_ is E), functor(E, Op, 2) -> add_unique(Op, Acc0, Acc1) ; Acc1 = Acc0 ),
+    collect_f(Gs, Acc1, FT).
+memberchk_op(Op, [Op|_]) :- !.
+memberchk_op(Op, [_|T]) :- memberchk_op(Op, T).
+add_unique(Op, Acc, Acc) :- memberchk_op(Op, Acc), !.
+add_unique(Op, Acc, Acc1) :- append(Acc, [Op], Acc1).
+
+% functor-aware serializer: like wz_serialize but emits the functor table
+% (NF + NF length-prefixed functor name strings) after the (empty) atom table.
+wzf_serialize(EI, NC, LI, Functors, PCs, Instrs, Out) :-
+    wz_a('WAMO', Out, A1), wz_i(2, A1, A2), wz_i(EI, A2, A3), wz_i(1, A3, A4),
+    wz_n(NC, A4, A5), wz_i(LI, A5, A6), wz_i(0, A6, A7),          % NA = 0
+    length(Functors, NF), wz_i(NF, A7, A8), wz_funcs(Functors, A8, A9),
+    wz_pcs_sec(PCs, A9, A10), wz_instr_sec(Instrs, A10, A11), wz_i(0, A11, []).
+wz_fname(F, A0, A1) :- atom_codes(F, Cs), wz_n(Cs, A0, A1).
+wz_funcs([], A, A).
+wz_funcs([F|Fs], A0, A2) :- wz_fname(F, A0, A1), wz_funcs(Fs, A1, A2).
+
+% Milestone 6 (self-host) Stage C (non-tail calls) + Stage D (multi-clause):
+% the UNIFIED compiler. cgfull/2 merges every piece: labels + PC table
+% (from cgcprog), per-clause register allocation + conjunction (cgconj),
+% runtime arithmetic + functor table (cgarith), non-tail predicate-call
+% goals -- and now MULTIPLE CLAUSES PER PREDICATE. Consecutive clauses with
+% the same name/arity group into one predicate (group_clauses); the predicate
+% gets the entry label (its group index), and clauses 2..k get alternative
+% labels laid out after all entry labels. A multi-clause predicate compiles
+% to a try_me_else(Alt1) / retry_me_else(Alt_k+1) / trust_me chain (tags
+% 22/23/24) around the per-clause code, so a failing head match backtracks to
+% the next clause -- backtracking dispatch AND recursion now compile.
+% A call goal p(Args) sets up A1.. with the args (operand_instr) then
+% call(CalleeLabel, arity) (tag 18) -- a non-tail call: cp = the next PC, so
+% execution resumes after the call when the callee proceeds. A permanent holds
+% the result across the call. Each clause is copy_term'd + numbervars'd so its
+% variables are clause-local. Facts (no body) emit head + proceed (no env).
+% Single-clause predicates emit no chain, so the Stage C output (verified
+% byte-identical to the host writer for the mnt program) is unchanged.
+% Stage D (lists): cgfull also compiles LIST PATTERNS in heads, list literals
+% in call arguments, and atom constants -- so list-walking recursion (the shape
+% of every helper in the compiler's own source) compiles from source text.
+% - collect_tables walks every clause term (var-safe) gathering the ATOM table
+%   ('[]' and any atom constants) and every data functor incl. '[|]' and
+%   the arithmetic-operator functors. NB: in SWI, nil is NOT an atom
+%   (atom([]) fails), so nil gets dedicated clauses in each argument compiler;
+%   in the loaded runtime nil IS the atom "[]", and those clauses match it the
+%   same way (get_constant on the relocated atom id).
+% - head list pattern [H|T] -> get_list Ai (tag 4) + a unify_* per element:
+%   unify_variable (5) first occurrence / unify_value (6) later /
+%   unify_constant (7) for integers and atoms.
+% - a REPEATED head variable now emits get_value (tag 2), not a second
+%   get_variable (which would have overwritten the first binding unchecked).
+% - a list literal in a call argument builds top-down like the host: put_list
+%   TARGET (12), set_* for the head, set_variable Xtemp (13) for the tail,
+%   then put_structure cons/2 into the temp (write mode binds through the
+%   fresh cell) -- X temps start at reg 16 and live only within the build.
+% - atom constants carry the atom-table INDEX with reloc class 1; the loader
+%   relocates them to interned atom ids (matching the reader's atoms).
+% Stage D (guards): cgfull also compiles COMPARISON GUARDS and IF-THEN-ELSE.
+% A comparison goal (>, <, >=, =<, =:=, =\=, ==, \==) stages A1/A2 and emits
+% builtin_call with the comparison's id. ( Cond -> Then ; Else ) compiles to
+% the host's ITE shape: try_me_else(ElseLabel) pushes the guard CP; the Cond
+% goals run; cut_ite (tag 31, soft cut) pops the guard CP on success; the
+% Then goals run and jump(JoinLabel) (tag 32, label operand) skips the else;
+% at ElseLabel a trust_me pops the CP (reached by backtracking when Cond
+% fails, which also UNDOES Cond's bindings and register writes) and the Else
+% goals run to the join. Codegen is now PC- and label-aware: else/join labels
+% are allocated mid-clause from the same counter as clause-chain alternatives,
+% each recorded as a Label-PC pair; cgfull keysorts the pairs and appends
+% pairs_values after the predicate-entry PCs (labels stay positional).
+% Init-set rule: Then continues from Cond's set (bindings persist on the then
+% path); Else restarts from the pre-ITE set (backtracking undid Cond); after
+% the ITE the set is the INTERSECTION of the two branch out-sets (initialized
+% on both paths). Variables introduced inside one branch are branch-local.
+cgfull(Src, Wamo) :-
+    read_term_from_atom(Src, Clauses),
+    cgfull_term(Clauses, Wamo).
+% Split off the reader call so the middle+back end can run in SWI too
+% (read_term_from_atom/2 exists only in the loaded runtime): tests
+% compute expected golden bytes by feeding cgfull_term/2 clause TERMS.
+cgfull_term(Clauses, Wamo) :-
+    group_clauses(Clauses, Groups),
+    group_labels(Groups, 0, PL),
+    length(Groups, NP),
+    collect_tables(Clauses, s([],[]), s(Atoms, Functors)),
+    g_groups(Groups, PL, Atoms, Functors, 0, NP, AllIs, EntryPCs, Pairs),
+    keysort(Pairs, SortedPairs), pairs_values(SortedPairs, ExtraPCs),
+    append(EntryPCs, ExtraPCs, PCs),
+    Clauses = [First|_], clause_hb(First, H0, _), functor(H0, P0, A0),
+    pred_name_codes(P0, A0, EntryName),
+    wza_serialize(0, EntryName, 0, Atoms, Functors, PCs, AllIs, Codes),
+    atom_codes(Wamo, Codes).
+
+% comparison-guard builtin ids
+cmp_id(>, 1). cmp_id(<, 2). cmp_id(>=, 3). cmp_id(=<, 4).
+cmp_id(=:=, 5). cmp_id(=\=, 6). cmp_id(==, 7). cmp_id(\==, 21).
+
+inter([], _, []).
+inter([X|Xs], Ys, Out) :-
+    ( memberchk_op(X, Ys) -> Out = [X|R] ; Out = R ), inter(Xs, Ys, R).
+
+% group consecutive clauses with the same name/arity into pred(P,A,Clauses)
+group_clauses([], []).
+group_clauses([C|Cs], [pred(P,A,[C|Same])|Gs]) :-
+    clause_hb(C, H, _), functor(H, P, A),
+    take_same(Cs, P, A, Same, Rest),
+    group_clauses(Rest, Gs).
+take_same([], _, _, [], []).
+take_same([C|Cs], P, A, Same, Rest) :-
+    clause_hb(C, H, _), functor(H, P2, A2),
+    (   P2 == P, A2 =:= A
+    ->  Same = [C|Same1], take_same(Cs, P, A, Same1, Rest)
+    ;   Same = [], Rest = [C|Cs]
+    ).
+group_labels([], _, []).
+group_labels([pred(P,A,_)|Gs], I, [key(P,A)-I|R]) :- I1 is I+1, group_labels(Gs, I1, R).
+
+% atom + cons-functor collection: a var-safe walk over every clause term
+walk_term(T, S0, S) :- var(T), !, S = S0.
+walk_term([], S0, S) :- !, S0 = s(At0, Fn0), add_unique('[]', At0, At1), S = s(At1, Fn0).
+walk_term([H|T], S0, S) :- !, S0 = s(At0, Fn0), add_unique('[|]', Fn0, Fn1),
+    walk_term(H, s(At0,Fn1), S1), walk_term(T, S1, S).
+walk_term(T, S0, S) :- compound(T), !, T =.. [F|Args],
+    S0 = s(At0, Fn0),
+    ( skip_fn(F) -> Fn1 = Fn0 ; add_unique(F, Fn0, Fn1) ),
+    walk_list(Args, s(At0, Fn1), S).
+% control / goal functors never appear as data terms in instructions
+skip_fn(':-'). skip_fn(','). skip_fn(';'). skip_fn('->'). skip_fn(is).
+skip_fn(=). skip_fn(>). skip_fn(<). skip_fn(>=). skip_fn(=<).
+skip_fn(=:=). skip_fn(=\=). skip_fn(==). skip_fn(\==).
+walk_term(T, S0, S) :- atom(T), !,          % data atom -> atom table
+    S0 = s(At0, Fn0), add_unique(T, At0, At1), S = s(At1, Fn0).
+walk_term(_, S, S).
+walk_list([], S, S).
+walk_list([A|As], S0, S) :- walk_term(A, S0, S1), walk_list(As, S1, S).
+collect_tables([], S, S).
+collect_tables([C|Cs], S0, S) :- walk_term(C, S0, S1), collect_tables(Cs, S1, S).
+
+% per-group codegen; threads the absolute PC AND a label counter (chain
+% alternatives and mid-clause ITE labels share it, in codegen order), and
+% collects Label-PC pairs (keysorted by cgfull, so any assignment order works).
+g_groups([], _, _, _, _, _, [], [], []).
+g_groups([pred(_,_,Cls)|Gs], PL, At, FT, PC, L0, AllIs, [PC|EPCs], Prs) :-
+    g_pred(Cls, PL, At, FT, PC, L0, Is, PC1, L1, Prs1),
+    g_groups(Gs, PL, At, FT, PC1, L1, RestIs, EPCs, Prs2),
+    append(Is, RestIs, AllIs), append(Prs1, Prs2, Prs).
+
+g_pred([C], PL, At, FT, PC, L0, Is, PCout, L, Prs) :-   % single clause: no chain
+    g_one(C, PL, At, FT, PC, L0, L, Prs, Is), length(Is, N), PCout is PC + N.
+g_pred([C1,C2|Rest], PL, At, FT, PC, L0, Is, PCout, L, Prs) :-
+    ChainL = L0, L1 is L0 + 1,
+    PCc is PC + 1,
+    g_one(C1, PL, At, FT, PCc, L1, L2, Prs1, C1Is),
+    length(C1Is, N1), PC1 is PCc + N1,
+    g_alts([C2|Rest], PL, At, FT, PC1, ChainL, L2, AltIs, PCout, L, Prs2),
+    append(Prs1, Prs2, Prs),
+    append([enc(22,ChainL,0,0)|C1Is], AltIs, Is).       % try_me_else(ChainL)
+
+g_alts([C], PL, At, FT, PC, MyL, L0, Is, PCout, L, [MyL-PC|Prs]) :-  % last alt
+    PCc is PC + 1,
+    g_one(C, PL, At, FT, PCc, L0, L, Prs, CIs),
+    Is = [enc(24,0,0,0)|CIs],                           % trust_me
+    length(Is, N), PCout is PC + N.
+g_alts([C1,C2|Rest], PL, At, FT, PC, MyL, L0, Is, PCout, L, Prs) :-
+    NextL = L0, L1 is L0 + 1,
+    PCc is PC + 1,
+    g_one(C1, PL, At, FT, PCc, L1, L2, Prs1, C1Is),
+    length(C1Is, N1), PC1 is PCc + N1,
+    g_alts([C2|Rest], PL, At, FT, PC1, NextL, L2, RestIs, PCout, L, Prs2),
+    append([MyL-PC|Prs1], Prs2, Prs),
+    append([enc(23,NextL,0,0)|C1Is], RestIs, Is).       % retry_me_else(NextL)
+
+g_one(C0, PL, At, FT, StartPC, L0, L, Prs, Is) :-
+    copy_term(C0, C), numbervars(C, 0, _),
+    f_clause_instrs(C, PL, At, FT, StartPC, L0, L, Prs, Is).
+
+f_clause_instrs(Clause, PL, At, FT, StartPC, L0, L, Prs, Instrs) :-
+    clause_hb(Clause, Head, Goals), functor(Head, _, Arity),
+    h_args(Head, 1, Arity, At, FT, 16, [], Init1, HeadIs),
+    (   Goals == []
+    ->  % Facts wrap in allocate/deallocate too: cgfull assigns ALL clause
+        % variables to Y registers (the numbervars scheme), and without an
+        % environment a fact's get_variable Y-writes CLOBBER THE CALLER'S
+        % Y window -- observable whenever a fact is called in non-tail
+        % position (the caller's later goals read corrupted permanents).
+        % The host AOT compiler routes fact variables through X registers
+        % instead; cgfull buys correctness with an environment. Campaign
+        % finding: the walkers' deferred-reads nil fact, the first
+        % non-tail fact call in the self-host, silently corrupted its
+        % caller and sent the compile down a divergent re-satisfaction.
+        append([enc(16,0,0,0)|HeadIs], [enc(17,0,0,0), enc(20,0,0,0)], Instrs),
+        L = L0, Prs = []
+    ;   length(HeadIs, NH), PC0 is StartPC + 1 + NH,     % after allocate + head
+        f_goals(Goals, PL, At, FT, PC0, _, L0, L, [], Prs, Init1, _, GoalIs),
+        append([enc(16,0,0,0) | HeadIs], GoalIs, B0),
+        append(B0, [enc(17,0,0,0), enc(20,0,0,0)], Instrs)
+    ).
+
+% head-argument compilation: vars (first/repeated), integers, atoms, nil,
+% list patterns [H|T], and GENERAL STRUCTURE PATTERNS f(...). A compound or
+% list CHILD inside a pattern is deferred: unify_variable saves it into a
+% fresh X temp during the parent's unify sequence, and after the parent
+% completes the child is read out of the temp (get_structure / get_list into
+% the temp -- the host's canonical nesting shape). X temps thread from reg 16
+% through the whole head.
+h_args(_, I, Ar, _, _, _, In, In, []) :- I > Ar, !.
+h_args(H, I, Ar, At, Fn, Xt0, In0, In, Is) :-
+    arg(I, H, A), Ai is I - 1,
+    head_arg_instrs(A, Ai, At, Fn, Xt0, Xt1, In0, In1, AIs),
+    I1 is I + 1, h_args(H, I1, Ar, At, Fn, Xt1, In1, In, RIs),
+    append(AIs, RIs, Is).
+head_arg_instrs('$VAR'(N), Ai, _, _, Xt, Xt, In0, In1, [I]) :- integer(N), !,
+    Y is 48 + N,
+    (   is_init(N, In0)
+    ->  I = enc(2, Y, Ai, 0), In1 = In0                 % get_value (repeated var)
+    ;   I = enc(1, Y, Ai, 0), In1 = [N|In0]             % get_variable (first)
+    ).
+head_arg_instrs([], Ai, At, _, Xt, Xt, In, In, [enc(0,Idx,Ai,1)]) :- !,  % get_constant []
+    functor_index('[]', At, Idx).
+head_arg_instrs([H|T], Ai, At, Fn, Xt0, Xt, In0, In2, [enc(4,Ai,0,0)|Rest]) :- !,  % get_list
+    u_seq([H,T], At, Xt0, Xt1, In0, In1, UIs, [], Defs),
+    defer_reads(Defs, At, Fn, Xt1, Xt, In1, In2, DIs),
+    append(UIs, DIs, Rest).
+head_arg_instrs(V, Ai, _, _, Xt, Xt, In, In, [enc(0,V,Op2,0)]) :- integer(V), !, Op2 is (1<<16)\/Ai.
+head_arg_instrs(A, Ai, At, _, Xt, Xt, In, In, [enc(0,Idx,Ai,1)]) :- atom(A), !, functor_index(A, At, Idx).
+head_arg_instrs(T, Ai, At, Fn, Xt0, Xt, In0, In2, [enc(3,FI,Op2,2)|Rest]) :-
+    compound(T),                                        % general structure pattern
+    functor(T, F, N), functor_index(F, Fn, FI), Op2 is (N<<16)\/Ai,
+    T =.. [_|Args],
+    u_seq(Args, At, Xt0, Xt1, In0, In1, UIs, [], Defs),
+    defer_reads(Defs, At, Fn, Xt1, Xt, In1, In2, DIs),
+    append(UIs, DIs, Rest).
+% fail fast: unsupported head-argument kind (see the f_goal catch-all)
+head_arg_instrs(T, _, _, _, _, _, _, _, _) :- throw(cg_unsupported_head_arg(T)).
+% one unify_* per pattern arg; compound/list children deferred to X temps
+u_seq([], _, Xt, Xt, In, In, [], D, D).
+u_seq([A|As], At, Xt0, Xt, In0, In, Is, D0, D) :-
+    u_arg(A, At, Xt0, Xt1, In0, In1, AIs, D0, D1),
+    u_seq(As, At, Xt1, Xt, In1, In, RIs, D1, D), append(AIs, RIs, Is).
+u_arg('$VAR'(N), _, Xt, Xt, In0, In1, [I], D, D) :- integer(N), !,
+    Y is 48 + N,
+    (   is_init(N, In0)
+    ->  I = enc(6, Y, 0, 0), In1 = In0                  % unify_value
+    ;   I = enc(5, Y, 0, 0), In1 = [N|In0]              % unify_variable
+    ).
+u_arg([], At, Xt, Xt, In, In, [enc(7,Idx,0,1)], D, D) :- !, functor_index('[]', At, Idx).
+u_arg(V, _, Xt, Xt, In, In, [enc(7,V,65536,0)], D, D) :- integer(V), !.
+u_arg(A, At, Xt, Xt, In, In, [enc(7,Idx,0,1)], D, D) :- atom(A), !, functor_index(A, At, Idx).
+u_arg(C, _, Xt0, Xt1, In, In, [enc(5,Xt0,0,0)], D0, D) :-   % compound/list child
+    Xt1 is Xt0 + 1, append(D0, [d(C,Xt0)], D).
+defer_reads([], _, _, Xt, Xt, In, In, []).
+defer_reads([d(C,Reg)|Ds], At, Fn, Xt0, Xt, In0, In, Is) :-
+    (   C = [H|T]
+    ->  u_seq([H,T], At, Xt0, Xt1, In0, In1, UIs, [], Defs),
+        CIs = [enc(4,Reg,0,0)|UIs]                       % get_list Xtemp
+    ;   functor(C, F, N), functor_index(F, Fn, FI), Op2 is (N<<16)\/Reg,
+        C =.. [_|Args],
+        u_seq(Args, At, Xt0, Xt1, In0, In1, UIs, [], Defs),
+        CIs = [enc(3,FI,Op2,2)|UIs]                      % get_structure Xtemp
+    ),
+    defer_reads(Defs, At, Fn, Xt1, Xt2, In1, In2, DIs),
+    defer_reads(Ds, At, Fn, Xt2, Xt, In2, In, RIs),
+    append(CIs, DIs, A1s), append(A1s, RIs, Is).
+
+% goal codegen, PC- and label-aware:
+% f_goals(Goals, PL, At, FT, PC0,PC, L0,L, Prs0,Prs, In0,In, Is)
+f_goals([], _, _, _, PC, PC, L, L, Prs, Prs, In, In, []).
+f_goals([G|Gs], PL, At, FT, PC0, PC, L0, L, Prs0, Prs, In0, In, Is) :-
+    f_goal(G, PL, At, FT, PC0, PC1, L0, L1, Prs0, Prs1, In0, In1, GI),
+    f_goals(Gs, PL, At, FT, PC1, PC, L1, L, Prs1, Prs, In1, In, RI),
+    append(GI, RI, Is).
+
+f_goal(( C -> T ; E ), PL, At, FT, PC0, PC, L0, L, Prs0, Prs, In0, In, Is) :- !,
+    ElseL = L0, JoinL is L0 + 1, L1 is L0 + 2,
+    conj_list(C, CGs), conj_list(T, TGs), conj_list(E, EGs),
+    PC1 is PC0 + 1,                                    % try_me_else(ElseL)
+    f_goals(CGs, PL, At, FT, PC1, PC2, L1, L2, Prs0, Prs1, In0, InC, CondIs),
+    PC3 is PC2 + 1,                                    % cut_ite
+    f_goals(TGs, PL, At, FT, PC3, PC4, L2, L3, Prs1, Prs2, InC, InT, ThenIs),
+    ElsePC is PC4 + 1,                                 % after jump(JoinL)
+    PC5 is ElsePC + 1,                                 % after trust_me
+    f_goals(EGs, PL, At, FT, PC5, JoinPC, L3, L, Prs2, Prs3, In0, InE, ElseIs),
+    PC = JoinPC,
+    append(Prs3, [ElseL-ElsePC, JoinL-JoinPC], Prs),
+    inter(InT, InE, In),
+    append([enc(22,ElseL,0,0)|CondIs], [enc(31,0,0,0)|ThenIs], Front),
+    append(Front, [enc(32,JoinL,0,0), enc(24,0,0,0)|ElseIs], Is).
+f_goal((L is E), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In2, Is) :- !,
+    % NESTED arithmetic: the expression is just a term -- stage it with
+    % c_operand (build_struct + X-temp deferral handles arbitrary nesting,
+    % e.g. (X + Y) * (X - 1) + 100). The operators land in the functor
+    % table automatically: walk_term skips is/2 itself as a control
+    % functor but walks its argument tree, collecting + / * / ... as data
+    % functors. LHS -> A1, expression term -> A2, builtin is/2 (id 0).
+    c_operand(L, 0, At, FT, In0, In1, IL),
+    c_operand(E, 1, At, FT, In1, In2, IE),
+    append(IL, IE, LE), append(LE, [enc(21, 0, 2, 0)], Is),
+    length(Is, N), PC is PC0 + N.
+f_goal((L = R), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In2, Is) :- !,
+    % full-term unification: either side may be a variable, constant, list
+    % or structure literal (c_operand builds it) -- then builtin =/2
+    c_operand(L, 0, At, FT, In0, In1, IL),
+    c_operand(R, 1, At, FT, In1, In2, IR),
+    append(IL, IR, LR), append(LR, [enc(21,24,2,0)], Is),
+    length(Is, N), PC is PC0 + N.
+f_goal(Cmp, _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-
+    functor(Cmp, Op, 2), cmp_id(Op, Id), !,            % comparison guard
+    arg(1, Cmp, A1), arg(2, Cmp, A2),
+    c_operand(A1, 0, At, FT, In0, In1, IL),
+    c_operand(A2, 1, At, FT, In1, In, IR),
+    append(IL, IR, LR), append(LR, [enc(21,Id,2,0)], Is),
+    length(Is, N), PC is PC0 + N.
+f_goal(Goal, _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-
+    functor(Goal, P, A), bi_id(P, A, Id), !,           % builtin goal
+    call_args(Goal, 1, A, At, FT, In0, In, SetupIs),
+    append(SetupIs, [enc(21, Id, A, 0)], Is),          % builtin_call(Id, A)
+    length(Is, N), PC is PC0 + N.
+f_goal(Goal, PL, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-  % predicate call
+    functor(Goal, P, A), lookup_label(P, A, PL, Label),
+    call_args(Goal, 1, A, At, FT, In0, In, SetupIs),
+    append(SetupIs, [enc(18, Label, A, 0)], Is),       % call(Label, arity)
+    length(Is, N), PC is PC0 + N.
+% FAIL FAST on anything the subset does not cover. Without this, an
+% unsupported goal makes codegen FAIL, and in the loaded compiler that
+% failure explodes into catastrophic backtracking through the compile's
+% stale choice points (unindexed, cut-free clause chains) -- a silent
+% multi-minute hang instead of an error (the gen-3 round lost real time
+% to exactly this, via a nested `is` before the lift above). throw/1 is
+% loadable (call sentinel), so the loaded compiler aborts immediately.
+f_goal(Goal, _, _, _, _, _, _, _, _, _, _, _, _) :-
+    functor(Goal, P, A), throw(cg_unsupported_goal(P, A)).
+
+% builtin goals the grammar can emit directly: name/arity -> builtin id (the
+% host runtime's builtin_op_to_id table). Staged like a call (c_operand per
+% arg into A1..An) then builtin_call(Id, Arity). NB: the grammar emits
+% builtin_call for arg/3 even with a constant index -- the host tier-2
+% compiler's specialised arg opcode (the known subset gap) is simply never
+% generated here, so loaded objects get the loadable builtin form.
+bi_id(functor, 3, 26).
+bi_id(arg, 3, 27).
+bi_id(=.., 2, 28).
+bi_id(copy_term, 2, 29).
+bi_id(atom_codes, 2, 36).
+bi_id(atom_chars, 2, 38).
+bi_id(char_code, 2, 37).
+bi_id(number_codes, 2, 43).
+bi_id(atom_number, 2, 42).
+bi_id(atom_length, 2, 35).
+bi_id(atom_concat, 3, 40).
+bi_id(length, 2, 31).
+bi_id(append, 3, 55).
+bi_id(reverse, 2, 54).
+bi_id(nth0, 3, 51).
+bi_id(nth1, 3, 52).
+bi_id(last, 2, 53).
+bi_id(memberchk, 2, 56).
+bi_id(between, 3, 39).
+bi_id(msort, 2, 30).
+bi_id(sort, 2, 81).
+bi_id(keysort, 2, 80).
+bi_id(pairs_keys, 2, 70).
+bi_id(pairs_values, 2, 71).
+bi_id(atom, 1, 13).
+bi_id(integer, 1, 14).
+bi_id(number, 1, 16).
+bi_id(compound, 1, 17).
+bi_id(var, 1, 18).
+bi_id(nonvar, 1, 19).
+bi_id(is_list, 1, 20).
+bi_id(ground, 1, 132).
+bi_id(succ, 2, 22).
+bi_id(\=, 2, 25).
+bi_id(sum_list, 2, 59).
+bi_id(numbervars, 3, 124).
+bi_id(term_to_atom, 2, 173).
+bi_id(read_term_from_atom, 2, 174).
+
+call_args(_, I, Ar, _, _, In, In, []) :- I > Ar, !.
+call_args(Goal, I, Ar, At, FT, In0, In, Is) :-
+    arg(I, Goal, Arg), Ai is I - 1,
+    c_operand(Arg, Ai, At, FT, In0, In1, AI),
+    I1 is I + 1, call_args(Goal, I1, Ar, At, FT, In1, In, R), append(AI, R, Is).
+
+% call-argument staging: vars/ints via operand_instr; nil/atoms as atom
+% constants; list literals built on the heap
+c_operand('$VAR'(N), Ai, _, _, In0, In1, Is) :- integer(N), !, operand_instr('$VAR'(N), Ai, In0, In1, Is).
+c_operand(V, Ai, _, _, In, In, Is) :- integer(V), !, operand_instr(V, Ai, In, In, Is).
+c_operand([], Ai, At, _, In, In, [enc(8,Idx,Ai,1)]) :- !, functor_index('[]', At, Idx).
+c_operand([H|T], Ai, At, FT, In0, In1, Is) :- !,
+    build_list([H|T], Ai, first, At, FT, 16, _, In0, In1, Is).
+c_operand(A, Ai, At, _, In, In, [enc(8,Idx,Ai,1)]) :- atom(A), !, functor_index(A, At, Idx).
+c_operand(T, Ai, At, FT, In0, In1, Is) :- compound(T),   % structure literal
+    build_struct(T, Ai, At, FT, 16, _, In0, In1, Is).
+% fail fast: unsupported operand kind (e.g. a float literal), or a
+% build_struct failure (e.g. a functor missing from the table)
+c_operand(T, _, _, _, _, _, _) :- throw(cg_unsupported_operand(T)).
+
+% top-down term builds. Lists: the first cell is put_list TARGET; each nested
+% cons is put_structure cons/2 into a fresh X temp created by set_variable
+% (write mode binds through the fresh cell). Structures: put_structure F/N
+% into the target, one set_* per arg, with compound/list CHILDREN deferred to
+% X temps and built after the parent (the mirror of the head-side deferral).
+build_list([E|Rest], TR, Mode, At, FT, Xt0, Xt, In0, In2, Is) :-
+    (   Mode = first
+    ->  Head = [enc(12,TR,0,0)]                          % put_list
+    ;   functor_index('[|]', FT, CI), Op2 is (2<<16)\/TR,
+        Head = [enc(11,CI,Op2,2)]                        % put_structure cons/2
+    ),
+    s_arg(E, At, Xt0, Xta, In0, In1, SE, [], DefsE),
+    (   Rest == []
+    ->  functor_index('[]', At, NI), Tail = [enc(15,NI,0,1)],
+        In1b = In1, Xtb = Xta, RestIs = []
+    ;   Rest = '$VAR'(_)
+    ->  s_arg(Rest, At, Xta, Xtb, In1, In1b, Tail, [], []),  % var tail: [E|Var]
+        RestIs = []
+    ;   Tail = [enc(13,Xta,0,0)],                        % set_variable Xtemp
+        Xtc is Xta + 1,
+        build_list(Rest, Xta, nested, At, FT, Xtc, Xtb, In1, In1b, RestIs)
+    ),
+    defer_builds(DefsE, At, FT, Xtb, Xt, In1b, In2, DIs),
+    append(Head, SE, HS), append(HS, Tail, HST),
+    append(HST, RestIs, HSTR), append(HSTR, DIs, Is).
+build_struct(T, TR, At, FT, Xt0, Xt, In0, In2, [enc(11,FI,Op2,2)|Rest]) :-
+    functor(T, F, N), functor_index(F, FT, FI), Op2 is (N<<16)\/TR,
+    T =.. [_|Args],
+    s_seq(Args, At, Xt0, Xt1, In0, In1, SIs, [], Defs),
+    defer_builds(Defs, At, FT, Xt1, Xt, In1, In2, DIs),
+    append(SIs, DIs, Rest).
+s_seq([], _, Xt, Xt, In, In, [], D, D).
+s_seq([A|As], At, Xt0, Xt, In0, In, Is, D0, D) :-
+    s_arg(A, At, Xt0, Xt1, In0, In1, AIs, D0, D1),
+    s_seq(As, At, Xt1, Xt, In1, In, RIs, D1, D), append(AIs, RIs, Is).
+s_arg('$VAR'(N), _, Xt, Xt, In0, In1, [I], D, D) :- integer(N), !,
+    Y is 48 + N,
+    (   is_init(N, In0)
+    ->  I = enc(14, Y, 0, 0), In1 = In0                  % set_value
+    ;   I = enc(13, Y, 0, 0), In1 = [N|In0]              % set_variable
+    ).
+s_arg([], At, Xt, Xt, In, In, [enc(15,Idx,0,1)], D, D) :- !, functor_index('[]', At, Idx).
+s_arg(V, _, Xt, Xt, In, In, [enc(15,V,1,0)], D, D) :- integer(V), !.
+s_arg(A, At, Xt, Xt, In, In, [enc(15,Idx,0,1)], D, D) :- atom(A), !, functor_index(A, At, Idx).
+s_arg(C, _, Xt0, Xt1, In, In, [enc(13,Xt0,0,0)], D0, D) :-  % compound/list child
+    Xt1 is Xt0 + 1, append(D0, [d(C,Xt0)], D).
+defer_builds([], _, _, Xt, Xt, In, In, []).
+defer_builds([d(C,Reg)|Ds], At, FT, Xt0, Xt, In0, In, Is) :-
+    (   C = [_|_]
+    ->  build_list(C, Reg, nested, At, FT, Xt0, Xt1, In0, In1, CIs)
+    ;   build_struct(C, Reg, At, FT, Xt0, Xt1, In0, In1, CIs)
+    ),
+    defer_builds(Ds, At, FT, Xt1, Xt, In1, In, RIs),
+    append(CIs, RIs, Is).
+
+% serializer with an atom table: NA + NA length-prefixed atom name strings
+% between the label index and the functor table
+wza_serialize(EI, NC, LI, Atoms, Fs, PCs, Is, Out) :-
+    wz_a('WAMO', Out, A1), wz_i(2, A1, A2), wz_i(EI, A2, A3), wz_i(1, A3, A4),
+    wz_n(NC, A4, A5), wz_i(LI, A5, A6),
+    length(Atoms, NA), wz_i(NA, A6, A7), wz_funcs(Atoms, A7, A8),
+    length(Fs, NF), wz_i(NF, A8, A9), wz_funcs(Fs, A9, A10),
+    wz_pcs_sec(PCs, A10, A11), wz_instr_sec(Is, A11, A12), wz_i(0, A12, []).

--- a/tests/test_plawk_eval_compile.pl
+++ b/tests/test_plawk_eval_compile.pl
@@ -1,0 +1,152 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% The eval surface (JIT roadmap item 5, the payoff): compile a grammar
+% from SOURCE TEXT at runtime, inside the running binary, and call it.
+%
+%   { total += dyncall_at(compile("[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2)]"), $1) }
+%
+% compile(Src) runs the shipped bootstrap-compiler object (the
+% self-hosted cgfull, emitted as <bin>.evalc.wamo at build time) on the
+% Prolog source text via @wam_object_eval, loads the .wamo bytes it
+% emits into a fresh VM, and yields a HANDLE into the dyncall_at cache
+% registry -- deduplicated by source text, so a per-record compile of
+% the same grammar compiles once and reuses the loaded VM thereafter.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_eval_compile).
+
+% compile(...) in the dyncall_at source position parses to its own node
+% and is collected as a compile site (which is what makes the CLI ship
+% the compiler object and the codegen emit @plawk_compile).
+test(compile_source_parses_and_collects) :-
+    plawk_parse_source(
+        "{ t += dyncall_at(compile(\"[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2)]\"), $1) }\nEND { print t }\n",
+        Program, _Clauses),
+    Program = program(_, Rules, _),
+    memberchk(rule(_, Actions), Rules),
+    memberchk(add(var(t), dyncall_at(compile_src(string(Src)), [field(1)])),
+              Actions),
+    sub_string(Src, _, _, _, "sq(X2, R2)"),
+    plawk_program_compile_sites(Program, Sites),
+    assertion(Sites == [string(Src)]),
+    !.
+
+% A plain path source still parses as before (no compile site).
+test(plain_path_source_unchanged) :-
+    plawk_parse_source(
+        "{ t += dyncall_at($2, $1) }\nEND { print t }\n",
+        Program, _),
+    Program = program(_, Rules, _),
+    memberchk(rule(_, Actions), Rules),
+    memberchk(add(var(t), dyncall_at(field(2), [field(1)])), Actions),
+    plawk_program_compile_sites(Program, Sites),
+    assertion(Sites == []),
+    !.
+
+% THE PAYOFF: a grammar compiled from source text at runtime, inside
+% the running binary. The .plawk program carries only Prolog SOURCE for
+% the grammar; the binary compiles it on first use (through the shipped
+% bootstrap-compiler .wamo) and sums sq(x) over the input records.
+test(compile_runs_runtime_compiled_grammar, [condition(clang_available)]) :-
+    ev_dir(Dir),
+    build_eval_prog(Dir, Bin),
+    % the bootstrap-compiler object ships next to the binary
+    atom_concat(Bin, '.evalc.wamo', EvalcWamo),
+    assertion(exists_file(EvalcWamo)),
+    directory_file_path(Dir, 'nums.txt', Input),
+    write_num_lines(Input, [3, 4, 5, 10]),        % 9+16+25+100 = 150
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "150\n"),
+    !.
+
+% Two DIFFERENT grammars compiled at runtime coexist in the registry
+% (per-source dedup, distinct handles): x*x + 2*x summed over the same
+% records. 150 + 44 = 194.
+test(two_runtime_grammars_coexist, [condition(clang_available)]) :-
+    ev_dir(Dir),
+    format(string(Src),
+        "{ total += dyncall_at(compile(\"[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2)]\"), $1) + dyncall_at(compile(\"[(dbl(X3, R3) :- atom_number(X3, N3), R3 is N3 * 2)]\"), $1) }\n\c
+         END { print total }\n", []),
+    write_prog(Dir, 'two.plawk', Src),
+    directory_file_path(Dir, 'two.plawk', Prog),
+    directory_file_path(Dir, 'two_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'nums.txt', Input),
+    ( exists_file(Input) -> true ; write_num_lines(Input, [3, 4, 5, 10]) ),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "194\n"),
+    !.
+
+% compile(...) with the cache disabled is a build error (exit 3), not a
+% silent miscompile: the grammar handle lives in the cache registry.
+test(compile_with_cache_off_fails_build, [condition(clang_available)]) :-
+    ev_dir(Dir),
+    write_prog(Dir, 'nocache.plawk',
+        "BEGIN { DYNCACHE = \"off\" }\n{ t += dyncall_at(compile(\"[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2)]\"), $1) }\nEND { print t }\n"),
+    directory_file_path(Dir, 'nocache.plawk', Prog),
+    cli([build, Prog, '-o', '/dev/null'], _, 3),
+    !.
+
+:- end_tests(plawk_eval_compile).
+
+% --- helpers ---------------------------------------------------------------
+
+ev_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_eval', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Text) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(
+        open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text),
+        close(Out)).
+
+% the roadmap goal, minus the intermediate variable (the handle dedups
+% by source, so the nested form compiles once and reuses thereafter).
+% Text-mode fields marshal as ATOMS (awk strings), so the grammar
+% converts with atom_number/2 before the arithmetic -- same convention
+% as any dyncall grammar fed text fields.
+build_eval_prog(Dir, Bin) :-
+    format(string(Src),
+        "{ total += dyncall_at(compile(\"[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2)]\"), $1) }\n\c
+         END { print total }\n", []),
+    write_prog(Dir, 'eval.plawk', Src),
+    directory_file_path(Dir, 'eval.plawk', Prog),
+    directory_file_path(Dir, 'eval_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0).
+
+write_num_lines(Path, Values) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [encoding(utf8)]),
+        forall(member(V, Values), format(Out, "~w~n", [V])),
+        close(Out)).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -12,6 +12,7 @@
 :- use_module(library(filesex), [make_directory_path/1]).
 :- use_module('../src/unifyweaver/targets/wam_llvm_target').
 :- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_bootstrap_compiler').
 
 % --- grammar predicates the tests compile into objects ---------------------
 % Accumulator sum: exercises try_me_else / trust_me / get_list /
@@ -236,738 +237,12 @@ ct_uncaught(R) :- throw(oops), R = 1.                                        % u
 ea(R) :- R = 42.
 echocompile(Src, Wamo) :- Wamo = Src.
 
-% Milestone 6 (self-host) Stage A: a .wamo serializer written in the loadable
-% subset. wamoserz/2 is a real eval-pipeline compiler entry -- compile(Src,
-% Wamo) -- but Stage A ignores Src and serializes a FIXED ground instruction
-% list for a 42-returning program (`ea(R):-R=42`), exercising the string-
-% assembly back end end to end. It reproduces wamo_serialize/8's byte format
-% using only loadable builtins (atom_codes/number_codes/append/length), so it
-% runs as a loaded object; the emitted bytes load via @wam_object_eval and run
-% to 42. NA/NF are 0 here (no atom/functor tables); the PC and instruction
-% lists drive the rest, so this is a genuine serializer, not a string literal.
-%
-% Written as SMALL accumulator-threaded clauses (a code list is threaded
-% through, each clause holding only a few call-spanning variables) with only
-% list / enc(...) head dispatch -- deliberately avoiding two loaded-runtime
-% limitations this stage surfaced: (1) a clause holding ~16+ call-spanning
-% variables emits register indices past the 64-slot register file and corrupts
-% memory; (2) multi-way first-argument functor dispatch across >=4 tagged
-% variants (with a list-carrying variant present) mis-dispatches in loaded
-% objects. Both are recorded in PLAWK_SELFHOST.md as prerequisites for later
-% stages; the "small clauses, correctness over register reuse" style the design
-% doc prescribes routes around both.
-wamoserz(_Src, Wamo) :-
-    atom_codes('ea/1', NameCodes),
-    wz_serialize(0, NameCodes, 0, 0, 0, [0],
-        [enc(0,42,65536,0), enc(20,0,0,0)], Codes),
-    atom_codes(Wamo, Codes).
-
-% DIFFERENCE-LIST emitters: A0 is the open list being built, A1 its tail
-% after this item -- so each emission appends only its OWN codes (linear in
-% total output), never copying the accumulated prefix. The old accumulator
-% style (append(A0, Cs, B) -- copy everything emitted so far, per token) is
-% QUADRATIC in output size and was the entire compile-time/memory cliff of
-% the self-host fixpoint (246 MB arena for a 3.6 KB object). Threading
-% predicates (wz_header/wz_body/wz_pcs_rows/...) are direction-agnostic and
-% unchanged; only the leaf emitters and the top wrappers (which now close
-% the tail with []) know the representation.
-% wz_i "<int>\n", wz_a "<atom>\n", wz_n "<len> <bytes>\n", wz_si " <int>".
-wz_i(N, A0, A1)  :- number_codes(N, Cs), append(Cs, [10|A1], A0).
-wz_a(X, A0, A1)  :- atom_codes(X, Cs), append(Cs, [10|A1], A0).
-wz_n(Cs, A0, A1) :- length(Cs, Len), number_codes(Len, LC),
-    append(LC, [32|Mid], A0), append(Cs, [10|A1], Mid).
-wz_si(N, A0, A1) :- number_codes(N, Cs), append([32|Cs], A1, A0).
-
-wz_serialize(EntryIdx, NameCodes, LabelIdx, NA, NF, PCs, Instrs, Out) :-
-    wz_header(EntryIdx, NameCodes, LabelIdx, NA, NF, Out, Hdr),
-    wz_body(PCs, Instrs, Hdr, []).
-
-% header: WAMO / version 2 / entry index / NE=1 / name / label / NA / NF,
-% split across two clauses so neither holds too many call-spanning vars.
-wz_header(EntryIdx, NameCodes, LabelIdx, NA, NF, A0, Out) :-
-    wz_a('WAMO', A0, A1), wz_i(2, A1, A2), wz_i(EntryIdx, A2, A3), wz_i(1, A3, A4),
-    wz_header2(NameCodes, LabelIdx, NA, NF, A4, Out).
-wz_header2(NameCodes, LabelIdx, NA, NF, A0, Out) :-
-    wz_n(NameCodes, A0, A1), wz_i(LabelIdx, A1, A2), wz_i(NA, A2, A3), wz_i(NF, A3, Out).
-
-% body: PC section, instruction section, then NM=0.
-wz_body(PCs, Instrs, A0, Out) :-
-    wz_pcs_sec(PCs, A0, A1),
-    wz_instr_sec(Instrs, A1, A2),
-    wz_i(0, A2, Out).
-
-wz_pcs_sec(PCs, A0, A2) :- length(PCs, NL), wz_i(NL, A0, A1), wz_pcs_rows(PCs, A1, A2).
-wz_pcs_rows([], A, A).
-wz_pcs_rows([P|Ps], A0, A2) :- wz_i(P, A0, A1), wz_pcs_rows(Ps, A1, A2).
-
-wz_instr_sec(Instrs, A0, A2) :-
-    length(Instrs, NC), wz_i(NC, A0, A1), wz_instr_rows(Instrs, A1, A2).
-wz_instr_rows([], A, A).
-wz_instr_rows([enc(T,O1,O2,R)|Is], A0, A2) :-
-    wz_row(T, O1, O2, R, A0, A1), wz_instr_rows(Is, A1, A2).
-wz_row(T, O1, O2, R, A0, A5) :-
-    number_codes(T, Tc), append(Tc, A1, A0),
-    wz_si(O1, A1, A2), wz_si(O2, A2, A3), wz_si(R, A3, A4), A4 = [10|A5].
-
-% Milestone 6 (self-host) Stage B: minimal CODEGEN -- source text to a .wamo,
-% end to end. cgcompile/2 is the eval-pipeline entry compile(Src,Wamo): it
-% parses Src with the runtime reader (read_term_from_atom/2, milestone 3b),
-% walks the clause to an instruction list (clause_to_instrs/3), and hands it to
-% the Stage A serializer (wz_serialize/8). The loadable subset for now: a
-% one-argument clause whose body binds the head variable to an integer, either
-% directly (`p(R) :- R = 42`) or by evaluating a ground arithmetic expression
-% (`p(R) :- R is 6*7`). Both lower to [get_constant(V,A1), proceed] -- the
-% golden shape from Stage A, parameterized by the computed value V.
-%
-% body_int/2 dispatches on the body's functor (=/2 vs is/2); this is exactly
-% the tagged first-argument dispatch that the get_structure functor-check fix
-% made correct in loaded objects. No constant-index arg/3 (the known subset
-% gap) -- functor/3 gives the predicate name and body_int gives the value.
-cgcompile(Src, Wamo) :-
-    read_term_from_atom(Src, Clause),
-    clause_to_instrs(Clause, Instrs, NameCodes),
-    wz_serialize(0, NameCodes, 0, 0, 0, [0], Instrs, Codes),
-    atom_codes(Wamo, Codes).
-
-clause_to_instrs((Head :- Body), Instrs, NameCodes) :-
-    body_int(Body, V),
-    functor(Head, Pred, Arity),
-    pred_name_codes(Pred, Arity, NameCodes),
-    % get_constant(V, A1): tag 0, op1 = V, op2 = (Integer-tag 1 << 16)|reg A1(0).
-    Instrs = [enc(0, V, 65536, 0), enc(20, 0, 0, 0)].
-
-body_int((_ = V), V)     :- integer(V).
-body_int((_ is Expr), V) :- V is Expr.
-
-pred_name_codes(Pred, Arity, Codes) :-
-    atom_codes(Pred, PC), number_codes(Arity, AC),
-    append(PC, [0'/ | AC], Codes).
-
-% Milestone 6 (self-host) Stage C: multi-clause programs with predicate calls.
-% cgcprog/2 is the eval entry compile(Src,Wamo): Src parses (one reader call)
-% to a LIST of clauses -- e.g. "[(main0(R):-helper(R)), helper(42)]" -- and the
-% program compiles to a multi-predicate .wamo. Each clause gets a label (its
-% index); a predicate-call body becomes execute(CalleeLabel) resolved through
-% a name/arity->label map (execute references the label directly, so no
-% meta-call table is needed). The label->PC table (PCs, one entry per clause)
-% is exactly what the Stage A serializer already accepts. Facts P(Int) and the
-% Stage B body forms (= / is) still lower to [get_constant(V,A1), proceed].
-% A single-goal predicate-call body is a tail call: [allocate, deallocate,
-% execute] -- matching the host writer (verified byte-identical). Register
-% allocation for temporaries across conjoined goals is a Stage C follow-on.
-cgcprog(Src, Wamo) :-
-    read_term_from_atom(Src, Clauses),
-    cgc_clauses(Clauses, EntryName, PCs, Instrs),
-    wz_serialize(0, EntryName, 0, 0, 0, PCs, Instrs, Codes),
-    atom_codes(Wamo, Codes).
-
-cgc_clauses(Clauses, EntryName, PCs, AllInstrs) :-
-    assign_labels(Clauses, 0, PL),
-    codegen_all(Clauses, PL, 0, AllInstrs, PCs),
-    Clauses = [First|_], cgc_head(First, H0), functor(H0, P0, A0),
-    pred_name_codes(P0, A0, EntryName).
-
-cgc_head((H :- _), H) :- !.
-cgc_head(H, H).
-
-assign_labels([], _, []).
-assign_labels([C|Cs], L, [key(P,A)-L | Rest]) :-
-    cgc_head(C, H), functor(H, P, A), L1 is L + 1,
-    assign_labels(Cs, L1, Rest).
-
-codegen_all([], _, _, [], []).
-codegen_all([C|Cs], PL, PC, All, [PC|PCs]) :-
-    codegen_clause(C, PL, Instrs),
-    length(Instrs, N), PC1 is PC + N,
-    codegen_all(Cs, PL, PC1, Rest, PCs),
-    append(Instrs, Rest, All).
-
-codegen_clause((_ :- Body), PL, Instrs) :- !, codegen_body(Body, PL, Instrs).
-codegen_clause(Fact, _, [enc(0,V,65536,0), enc(20,0,0,0)]) :-   % fact P(Int)
-    Fact =.. [_, V], integer(V).
-
-codegen_body(Body, PL, Instrs) :-
-    (   Body = (_ = V), integer(V)
-    ->  Instrs = [enc(0,V,65536,0), enc(20,0,0,0)]
-    ;   Body = (_ is Expr)
-    ->  V is Expr, Instrs = [enc(0,V,65536,0), enc(20,0,0,0)]
-    ;   functor(Body, P, A), lookup_label(P, A, PL, Label)
-    ->  Instrs = [enc(16,0,0,0), enc(17,0,0,0), enc(19,Label,0,0)]  % allocate,deallocate,execute
-    ).
-
-lookup_label(P, A, [key(P,A)-L|_], L) :- !.
-lookup_label(P, A, [_|R], L) :- lookup_label(P, A, R, L).
-
-% Milestone 6 (self-host) Stage C (rest): conjunction + register allocation.
-% cgconj/2 compiles a clause whose body is a conjunction of unification goals
-% (X = Y, X = Int) with a real (simple) register allocator: numbervars binds
-% each source variable to '$VAR'(N), mapped to permanent register Y(N+1); the
-% initialized-Y set is threaded through so a variable's first occurrence emits
-% put_variable / get_variable and later occurrences put_value. Head arguments
-% are saved with get_variable; each `=` goal sets up A1/A2 (put_variable /
-% put_value / put_constant) then builtin_call =/2 (id 24). This is the WAM
-% register-allocation core -- verified byte-identical to the host writer for
-% `pconj(R):-Y=42,R=Y`. Runtime arithmetic (is/2 building expression terms via
-% put_structure) and non-tail calls are the remaining Stage C pieces.
-cgconj(Src, Wamo) :-
-    read_term_from_atom(Src, Clause),
-    numbervars(Clause, 0, _),
-    conj_instrs(Clause, NameCodes, Instrs),
-    wz_serialize(0, NameCodes, 0, 0, 0, [0], Instrs, Codes),
-    atom_codes(Wamo, Codes).
-
-conj_instrs(Clause, NameCodes, Instrs) :-
-    clause_hb(Clause, Head, Goals),
-    functor(Head, Pred, Arity), pred_name_codes(Pred, Arity, NameCodes),
-    head_args(Head, 1, Arity, [], Init1, HeadIs),
-    goals_instrs(Goals, Init1, _, GoalIs),
-    append([enc(16,0,0,0) | HeadIs], GoalIs, B0),          % allocate + head
-    append(B0, [enc(17,0,0,0), enc(20,0,0,0)], Instrs).     % deallocate, proceed
-
-clause_hb((H :- B), H, Goals) :- !, conj_list(B, Goals).
-clause_hb(H, H, []).
-conj_list((A,B), [A|Rest]) :- !, conj_list(B, Rest).
-conj_list(G, [G]).
-
-is_init(N, [N|_]) :- !.
-is_init(N, [_|T]) :- is_init(N, T).
-
-head_args(_, I, Arity, Init, Init, []) :- I > Arity, !.
-head_args(Head, I, Arity, Init0, Init, [Instr|Rest]) :-
-    arg(I, Head, Arg), AiIdx is I - 1,
-    head_arg_instr(Arg, AiIdx, Init0, Init1, Instr),
-    I1 is I + 1, head_args(Head, I1, Arity, Init1, Init, Rest).
-head_arg_instr('$VAR'(N), AiIdx, Init0, [N|Init0], enc(1, YIdx, AiIdx, 0)) :- YIdx is 48 + N.
-head_arg_instr(V, AiIdx, Init, Init, enc(0, V, Op2, 0)) :- integer(V), Op2 is (1 << 16) \/ AiIdx.
-
-operand_instr('$VAR'(N), AiIdx, Init0, Init1, [Instr]) :-
-    YIdx is 48 + N,
-    (   is_init(N, Init0)
-    ->  Instr = enc(10, YIdx, AiIdx, 0), Init1 = Init0     % put_value (subsequent)
-    ;   Instr = enc(9, YIdx, AiIdx, 0), Init1 = [N|Init0]  % put_variable (first)
-    ).
-operand_instr(V, AiIdx, Init, Init, [enc(8, V, Op2, 0)]) :- integer(V), Op2 is (1 << 16) \/ AiIdx.
-
-goal_instrs((L = R), Init0, Init2, Is) :-
-    operand_instr(L, 0, Init0, Init1, ILs),
-    operand_instr(R, 1, Init1, Init2, IRs),
-    append(ILs, IRs, LR), append(LR, [enc(21, 24, 2, 0)], Is).   % builtin_call =/2
-
-goals_instrs([], Init, Init, []).
-goals_instrs([G|Gs], Init0, Init, Is) :-
-    goal_instrs(G, Init0, Init1, GIs),
-    goals_instrs(Gs, Init1, Init, RestIs), append(GIs, RestIs, Is).
-
-% Milestone 6 (self-host) Stage C (arithmetic): runtime is/2. cgarith/2 extends
-% the conjunction compiler with `Var is BinExpr` goals -- e.g. `X is 6*7`. A
-% binary expression op(A,B) builds a compound term on the heap: put_structure
-% op/2 into A2 (op1 = functor-table index, reloc 2), then set_value (a variable
-% arg) / set_constant (an integer arg) for each operand, then builtin_call is/2
-% (id 0). Functor names used across the clause are collected into the object's
-% functor table (NF>0, emitted by the functor-aware serializer wzf_serialize).
-% Reuses the cgconj register allocator (operand_instr / head_args / is_init).
-% Verified byte-identical to the host writer for `ca(R) :- X is 6*7, R = X`,
-% which combines conjunction, a shared temporary, arithmetic, and unification.
-cgarith(Src, Wamo) :-
-    read_term_from_atom(Src, Clause),
-    numbervars(Clause, 0, _),
-    a_conj_instrs(Clause, NameCodes, Functors, Instrs),
-    wzf_serialize(0, NameCodes, 0, Functors, [0], Instrs, Codes),
-    atom_codes(Wamo, Codes).
-
-a_conj_instrs(Clause, NameCodes, Functors, Instrs) :-
-    clause_hb(Clause, Head, Goals),
-    functor(Head, Pred, Arity), pred_name_codes(Pred, Arity, NameCodes),
-    collect_functors(Goals, Functors),
-    head_args(Head, 1, Arity, [], Init1, HeadIs),
-    a_goals_instrs(Goals, Functors, Init1, _, GoalIs),
-    append([enc(16,0,0,0) | HeadIs], GoalIs, B0),
-    append(B0, [enc(17,0,0,0), enc(20,0,0,0)], Instrs).
-
-a_goals_instrs([], _, Init, Init, []).
-a_goals_instrs([G|Gs], FT, Init0, Init, Is) :-
-    a_goal_instrs(G, FT, Init0, Init1, GIs),
-    a_goals_instrs(Gs, FT, Init1, Init, RestIs), append(GIs, RestIs, Is).
-
-a_goal_instrs((L is Expr), FT, Init0, Init1, Is) :- !,
-    operand_instr(L, 0, Init0, Init1, LhsIs),   % LHS var -> A1
-    expr_build(Expr, FT, ExprIs),               % put_structure + set args -> A2
-    append(LhsIs, ExprIs, LE), append(LE, [enc(21, 0, 2, 0)], Is).   % builtin is/2
-a_goal_instrs((L = R), _FT, Init0, Init2, Is) :-
-    operand_instr(L, 0, Init0, Init1, IL), operand_instr(R, 1, Init1, Init2, IR),
-    append(IL, IR, LR), append(LR, [enc(21, 24, 2, 0)], Is).         % builtin =/2
-
-expr_build(Expr, FT, [PutS, SA, SB]) :-
-    Expr =.. [Op, A, B], functor_index(Op, FT, FIdx),
-    Op2 is (2 << 16) \/ 1,                       % arity 2, reg A2(1)
-    PutS = enc(11, FIdx, Op2, 2),                % put_structure, reloc functor
-    arg_set(A, SA), arg_set(B, SB).
-arg_set('$VAR'(N), enc(14, YIdx, 0, 0)) :- YIdx is 48 + N.   % set_value Y
-arg_set(V, enc(15, V, 1, 0)) :- integer(V).                   % set_constant integer
-functor_index(Op, [Op|_], 0) :- !.
-functor_index(Op, [_|T], I) :- functor_index(Op, T, I0), I is I0 + 1.
-
-collect_functors(Goals, FT) :- collect_f(Goals, [], FT).
-collect_f([], Acc, Acc).
-collect_f([G|Gs], Acc0, FT) :-
-    ( G = (_ is E), functor(E, Op, 2) -> add_unique(Op, Acc0, Acc1) ; Acc1 = Acc0 ),
-    collect_f(Gs, Acc1, FT).
-memberchk_op(Op, [Op|_]) :- !.
-memberchk_op(Op, [_|T]) :- memberchk_op(Op, T).
-add_unique(Op, Acc, Acc) :- memberchk_op(Op, Acc), !.
-add_unique(Op, Acc, Acc1) :- append(Acc, [Op], Acc1).
-
-% functor-aware serializer: like wz_serialize but emits the functor table
-% (NF + NF length-prefixed functor name strings) after the (empty) atom table.
-wzf_serialize(EI, NC, LI, Functors, PCs, Instrs, Out) :-
-    wz_a('WAMO', Out, A1), wz_i(2, A1, A2), wz_i(EI, A2, A3), wz_i(1, A3, A4),
-    wz_n(NC, A4, A5), wz_i(LI, A5, A6), wz_i(0, A6, A7),          % NA = 0
-    length(Functors, NF), wz_i(NF, A7, A8), wz_funcs(Functors, A8, A9),
-    wz_pcs_sec(PCs, A9, A10), wz_instr_sec(Instrs, A10, A11), wz_i(0, A11, []).
-wz_fname(F, A0, A1) :- atom_codes(F, Cs), wz_n(Cs, A0, A1).
-wz_funcs([], A, A).
-wz_funcs([F|Fs], A0, A2) :- wz_fname(F, A0, A1), wz_funcs(Fs, A1, A2).
-
-% Milestone 6 (self-host) Stage C (non-tail calls) + Stage D (multi-clause):
-% the UNIFIED compiler. cgfull/2 merges every piece: labels + PC table
-% (from cgcprog), per-clause register allocation + conjunction (cgconj),
-% runtime arithmetic + functor table (cgarith), non-tail predicate-call
-% goals -- and now MULTIPLE CLAUSES PER PREDICATE. Consecutive clauses with
-% the same name/arity group into one predicate (group_clauses); the predicate
-% gets the entry label (its group index), and clauses 2..k get alternative
-% labels laid out after all entry labels. A multi-clause predicate compiles
-% to a try_me_else(Alt1) / retry_me_else(Alt_k+1) / trust_me chain (tags
-% 22/23/24) around the per-clause code, so a failing head match backtracks to
-% the next clause -- backtracking dispatch AND recursion now compile.
-% A call goal p(Args) sets up A1.. with the args (operand_instr) then
-% call(CalleeLabel, arity) (tag 18) -- a non-tail call: cp = the next PC, so
-% execution resumes after the call when the callee proceeds. A permanent holds
-% the result across the call. Each clause is copy_term'd + numbervars'd so its
-% variables are clause-local. Facts (no body) emit head + proceed (no env).
-% Single-clause predicates emit no chain, so the Stage C output (verified
-% byte-identical to the host writer for the mnt program) is unchanged.
-% Stage D (lists): cgfull also compiles LIST PATTERNS in heads, list literals
-% in call arguments, and atom constants -- so list-walking recursion (the shape
-% of every helper in the compiler's own source) compiles from source text.
-% - collect_tables walks every clause term (var-safe) gathering the ATOM table
-%   ('[]' and any atom constants) and every data functor incl. '[|]' and
-%   the arithmetic-operator functors. NB: in SWI, nil is NOT an atom
-%   (atom([]) fails), so nil gets dedicated clauses in each argument compiler;
-%   in the loaded runtime nil IS the atom "[]", and those clauses match it the
-%   same way (get_constant on the relocated atom id).
-% - head list pattern [H|T] -> get_list Ai (tag 4) + a unify_* per element:
-%   unify_variable (5) first occurrence / unify_value (6) later /
-%   unify_constant (7) for integers and atoms.
-% - a REPEATED head variable now emits get_value (tag 2), not a second
-%   get_variable (which would have overwritten the first binding unchecked).
-% - a list literal in a call argument builds top-down like the host: put_list
-%   TARGET (12), set_* for the head, set_variable Xtemp (13) for the tail,
-%   then put_structure cons/2 into the temp (write mode binds through the
-%   fresh cell) -- X temps start at reg 16 and live only within the build.
-% - atom constants carry the atom-table INDEX with reloc class 1; the loader
-%   relocates them to interned atom ids (matching the reader's atoms).
-% Stage D (guards): cgfull also compiles COMPARISON GUARDS and IF-THEN-ELSE.
-% A comparison goal (>, <, >=, =<, =:=, =\=, ==, \==) stages A1/A2 and emits
-% builtin_call with the comparison's id. ( Cond -> Then ; Else ) compiles to
-% the host's ITE shape: try_me_else(ElseLabel) pushes the guard CP; the Cond
-% goals run; cut_ite (tag 31, soft cut) pops the guard CP on success; the
-% Then goals run and jump(JoinLabel) (tag 32, label operand) skips the else;
-% at ElseLabel a trust_me pops the CP (reached by backtracking when Cond
-% fails, which also UNDOES Cond's bindings and register writes) and the Else
-% goals run to the join. Codegen is now PC- and label-aware: else/join labels
-% are allocated mid-clause from the same counter as clause-chain alternatives,
-% each recorded as a Label-PC pair; cgfull keysorts the pairs and appends
-% pairs_values after the predicate-entry PCs (labels stay positional).
-% Init-set rule: Then continues from Cond's set (bindings persist on the then
-% path); Else restarts from the pre-ITE set (backtracking undid Cond); after
-% the ITE the set is the INTERSECTION of the two branch out-sets (initialized
-% on both paths). Variables introduced inside one branch are branch-local.
-cgfull(Src, Wamo) :-
-    read_term_from_atom(Src, Clauses),
-    cgfull_term(Clauses, Wamo).
-% Split off the reader call so the middle+back end can run in SWI too
-% (read_term_from_atom/2 exists only in the loaded runtime): tests
-% compute expected golden bytes by feeding cgfull_term/2 clause TERMS.
-cgfull_term(Clauses, Wamo) :-
-    group_clauses(Clauses, Groups),
-    group_labels(Groups, 0, PL),
-    length(Groups, NP),
-    collect_tables(Clauses, s([],[]), s(Atoms, Functors)),
-    g_groups(Groups, PL, Atoms, Functors, 0, NP, AllIs, EntryPCs, Pairs),
-    keysort(Pairs, SortedPairs), pairs_values(SortedPairs, ExtraPCs),
-    append(EntryPCs, ExtraPCs, PCs),
-    Clauses = [First|_], clause_hb(First, H0, _), functor(H0, P0, A0),
-    pred_name_codes(P0, A0, EntryName),
-    wza_serialize(0, EntryName, 0, Atoms, Functors, PCs, AllIs, Codes),
-    atom_codes(Wamo, Codes).
-
-% comparison-guard builtin ids
-cmp_id(>, 1). cmp_id(<, 2). cmp_id(>=, 3). cmp_id(=<, 4).
-cmp_id(=:=, 5). cmp_id(=\=, 6). cmp_id(==, 7). cmp_id(\==, 21).
-
-inter([], _, []).
-inter([X|Xs], Ys, Out) :-
-    ( memberchk_op(X, Ys) -> Out = [X|R] ; Out = R ), inter(Xs, Ys, R).
-
-% group consecutive clauses with the same name/arity into pred(P,A,Clauses)
-group_clauses([], []).
-group_clauses([C|Cs], [pred(P,A,[C|Same])|Gs]) :-
-    clause_hb(C, H, _), functor(H, P, A),
-    take_same(Cs, P, A, Same, Rest),
-    group_clauses(Rest, Gs).
-take_same([], _, _, [], []).
-take_same([C|Cs], P, A, Same, Rest) :-
-    clause_hb(C, H, _), functor(H, P2, A2),
-    (   P2 == P, A2 =:= A
-    ->  Same = [C|Same1], take_same(Cs, P, A, Same1, Rest)
-    ;   Same = [], Rest = [C|Cs]
-    ).
-group_labels([], _, []).
-group_labels([pred(P,A,_)|Gs], I, [key(P,A)-I|R]) :- I1 is I+1, group_labels(Gs, I1, R).
-
-% atom + cons-functor collection: a var-safe walk over every clause term
-walk_term(T, S0, S) :- var(T), !, S = S0.
-walk_term([], S0, S) :- !, S0 = s(At0, Fn0), add_unique('[]', At0, At1), S = s(At1, Fn0).
-walk_term([H|T], S0, S) :- !, S0 = s(At0, Fn0), add_unique('[|]', Fn0, Fn1),
-    walk_term(H, s(At0,Fn1), S1), walk_term(T, S1, S).
-walk_term(T, S0, S) :- compound(T), !, T =.. [F|Args],
-    S0 = s(At0, Fn0),
-    ( skip_fn(F) -> Fn1 = Fn0 ; add_unique(F, Fn0, Fn1) ),
-    walk_list(Args, s(At0, Fn1), S).
-% control / goal functors never appear as data terms in instructions
-skip_fn(':-'). skip_fn(','). skip_fn(';'). skip_fn('->'). skip_fn(is).
-skip_fn(=). skip_fn(>). skip_fn(<). skip_fn(>=). skip_fn(=<).
-skip_fn(=:=). skip_fn(=\=). skip_fn(==). skip_fn(\==).
-walk_term(T, S0, S) :- atom(T), !,          % data atom -> atom table
-    S0 = s(At0, Fn0), add_unique(T, At0, At1), S = s(At1, Fn0).
-walk_term(_, S, S).
-walk_list([], S, S).
-walk_list([A|As], S0, S) :- walk_term(A, S0, S1), walk_list(As, S1, S).
-collect_tables([], S, S).
-collect_tables([C|Cs], S0, S) :- walk_term(C, S0, S1), collect_tables(Cs, S1, S).
-
-% per-group codegen; threads the absolute PC AND a label counter (chain
-% alternatives and mid-clause ITE labels share it, in codegen order), and
-% collects Label-PC pairs (keysorted by cgfull, so any assignment order works).
-g_groups([], _, _, _, _, _, [], [], []).
-g_groups([pred(_,_,Cls)|Gs], PL, At, FT, PC, L0, AllIs, [PC|EPCs], Prs) :-
-    g_pred(Cls, PL, At, FT, PC, L0, Is, PC1, L1, Prs1),
-    g_groups(Gs, PL, At, FT, PC1, L1, RestIs, EPCs, Prs2),
-    append(Is, RestIs, AllIs), append(Prs1, Prs2, Prs).
-
-g_pred([C], PL, At, FT, PC, L0, Is, PCout, L, Prs) :-   % single clause: no chain
-    g_one(C, PL, At, FT, PC, L0, L, Prs, Is), length(Is, N), PCout is PC + N.
-g_pred([C1,C2|Rest], PL, At, FT, PC, L0, Is, PCout, L, Prs) :-
-    ChainL = L0, L1 is L0 + 1,
-    PCc is PC + 1,
-    g_one(C1, PL, At, FT, PCc, L1, L2, Prs1, C1Is),
-    length(C1Is, N1), PC1 is PCc + N1,
-    g_alts([C2|Rest], PL, At, FT, PC1, ChainL, L2, AltIs, PCout, L, Prs2),
-    append(Prs1, Prs2, Prs),
-    append([enc(22,ChainL,0,0)|C1Is], AltIs, Is).       % try_me_else(ChainL)
-
-g_alts([C], PL, At, FT, PC, MyL, L0, Is, PCout, L, [MyL-PC|Prs]) :-  % last alt
-    PCc is PC + 1,
-    g_one(C, PL, At, FT, PCc, L0, L, Prs, CIs),
-    Is = [enc(24,0,0,0)|CIs],                           % trust_me
-    length(Is, N), PCout is PC + N.
-g_alts([C1,C2|Rest], PL, At, FT, PC, MyL, L0, Is, PCout, L, Prs) :-
-    NextL = L0, L1 is L0 + 1,
-    PCc is PC + 1,
-    g_one(C1, PL, At, FT, PCc, L1, L2, Prs1, C1Is),
-    length(C1Is, N1), PC1 is PCc + N1,
-    g_alts([C2|Rest], PL, At, FT, PC1, NextL, L2, RestIs, PCout, L, Prs2),
-    append([MyL-PC|Prs1], Prs2, Prs),
-    append([enc(23,NextL,0,0)|C1Is], RestIs, Is).       % retry_me_else(NextL)
-
-g_one(C0, PL, At, FT, StartPC, L0, L, Prs, Is) :-
-    copy_term(C0, C), numbervars(C, 0, _),
-    f_clause_instrs(C, PL, At, FT, StartPC, L0, L, Prs, Is).
-
-f_clause_instrs(Clause, PL, At, FT, StartPC, L0, L, Prs, Instrs) :-
-    clause_hb(Clause, Head, Goals), functor(Head, _, Arity),
-    h_args(Head, 1, Arity, At, FT, 16, [], Init1, HeadIs),
-    (   Goals == []
-    ->  % Facts wrap in allocate/deallocate too: cgfull assigns ALL clause
-        % variables to Y registers (the numbervars scheme), and without an
-        % environment a fact's get_variable Y-writes CLOBBER THE CALLER'S
-        % Y window -- observable whenever a fact is called in non-tail
-        % position (the caller's later goals read corrupted permanents).
-        % The host AOT compiler routes fact variables through X registers
-        % instead; cgfull buys correctness with an environment. Campaign
-        % finding: the walkers' deferred-reads nil fact, the first
-        % non-tail fact call in the self-host, silently corrupted its
-        % caller and sent the compile down a divergent re-satisfaction.
-        append([enc(16,0,0,0)|HeadIs], [enc(17,0,0,0), enc(20,0,0,0)], Instrs),
-        L = L0, Prs = []
-    ;   length(HeadIs, NH), PC0 is StartPC + 1 + NH,     % after allocate + head
-        f_goals(Goals, PL, At, FT, PC0, _, L0, L, [], Prs, Init1, _, GoalIs),
-        append([enc(16,0,0,0) | HeadIs], GoalIs, B0),
-        append(B0, [enc(17,0,0,0), enc(20,0,0,0)], Instrs)
-    ).
-
-% head-argument compilation: vars (first/repeated), integers, atoms, nil,
-% list patterns [H|T], and GENERAL STRUCTURE PATTERNS f(...). A compound or
-% list CHILD inside a pattern is deferred: unify_variable saves it into a
-% fresh X temp during the parent's unify sequence, and after the parent
-% completes the child is read out of the temp (get_structure / get_list into
-% the temp -- the host's canonical nesting shape). X temps thread from reg 16
-% through the whole head.
-h_args(_, I, Ar, _, _, _, In, In, []) :- I > Ar, !.
-h_args(H, I, Ar, At, Fn, Xt0, In0, In, Is) :-
-    arg(I, H, A), Ai is I - 1,
-    head_arg_instrs(A, Ai, At, Fn, Xt0, Xt1, In0, In1, AIs),
-    I1 is I + 1, h_args(H, I1, Ar, At, Fn, Xt1, In1, In, RIs),
-    append(AIs, RIs, Is).
-head_arg_instrs('$VAR'(N), Ai, _, _, Xt, Xt, In0, In1, [I]) :- integer(N), !,
-    Y is 48 + N,
-    (   is_init(N, In0)
-    ->  I = enc(2, Y, Ai, 0), In1 = In0                 % get_value (repeated var)
-    ;   I = enc(1, Y, Ai, 0), In1 = [N|In0]             % get_variable (first)
-    ).
-head_arg_instrs([], Ai, At, _, Xt, Xt, In, In, [enc(0,Idx,Ai,1)]) :- !,  % get_constant []
-    functor_index('[]', At, Idx).
-head_arg_instrs([H|T], Ai, At, Fn, Xt0, Xt, In0, In2, [enc(4,Ai,0,0)|Rest]) :- !,  % get_list
-    u_seq([H,T], At, Xt0, Xt1, In0, In1, UIs, [], Defs),
-    defer_reads(Defs, At, Fn, Xt1, Xt, In1, In2, DIs),
-    append(UIs, DIs, Rest).
-head_arg_instrs(V, Ai, _, _, Xt, Xt, In, In, [enc(0,V,Op2,0)]) :- integer(V), !, Op2 is (1<<16)\/Ai.
-head_arg_instrs(A, Ai, At, _, Xt, Xt, In, In, [enc(0,Idx,Ai,1)]) :- atom(A), !, functor_index(A, At, Idx).
-head_arg_instrs(T, Ai, At, Fn, Xt0, Xt, In0, In2, [enc(3,FI,Op2,2)|Rest]) :-
-    compound(T),                                        % general structure pattern
-    functor(T, F, N), functor_index(F, Fn, FI), Op2 is (N<<16)\/Ai,
-    T =.. [_|Args],
-    u_seq(Args, At, Xt0, Xt1, In0, In1, UIs, [], Defs),
-    defer_reads(Defs, At, Fn, Xt1, Xt, In1, In2, DIs),
-    append(UIs, DIs, Rest).
-% fail fast: unsupported head-argument kind (see the f_goal catch-all)
-head_arg_instrs(T, _, _, _, _, _, _, _, _) :- throw(cg_unsupported_head_arg(T)).
-% one unify_* per pattern arg; compound/list children deferred to X temps
-u_seq([], _, Xt, Xt, In, In, [], D, D).
-u_seq([A|As], At, Xt0, Xt, In0, In, Is, D0, D) :-
-    u_arg(A, At, Xt0, Xt1, In0, In1, AIs, D0, D1),
-    u_seq(As, At, Xt1, Xt, In1, In, RIs, D1, D), append(AIs, RIs, Is).
-u_arg('$VAR'(N), _, Xt, Xt, In0, In1, [I], D, D) :- integer(N), !,
-    Y is 48 + N,
-    (   is_init(N, In0)
-    ->  I = enc(6, Y, 0, 0), In1 = In0                  % unify_value
-    ;   I = enc(5, Y, 0, 0), In1 = [N|In0]              % unify_variable
-    ).
-u_arg([], At, Xt, Xt, In, In, [enc(7,Idx,0,1)], D, D) :- !, functor_index('[]', At, Idx).
-u_arg(V, _, Xt, Xt, In, In, [enc(7,V,65536,0)], D, D) :- integer(V), !.
-u_arg(A, At, Xt, Xt, In, In, [enc(7,Idx,0,1)], D, D) :- atom(A), !, functor_index(A, At, Idx).
-u_arg(C, _, Xt0, Xt1, In, In, [enc(5,Xt0,0,0)], D0, D) :-   % compound/list child
-    Xt1 is Xt0 + 1, append(D0, [d(C,Xt0)], D).
-defer_reads([], _, _, Xt, Xt, In, In, []).
-defer_reads([d(C,Reg)|Ds], At, Fn, Xt0, Xt, In0, In, Is) :-
-    (   C = [H|T]
-    ->  u_seq([H,T], At, Xt0, Xt1, In0, In1, UIs, [], Defs),
-        CIs = [enc(4,Reg,0,0)|UIs]                       % get_list Xtemp
-    ;   functor(C, F, N), functor_index(F, Fn, FI), Op2 is (N<<16)\/Reg,
-        C =.. [_|Args],
-        u_seq(Args, At, Xt0, Xt1, In0, In1, UIs, [], Defs),
-        CIs = [enc(3,FI,Op2,2)|UIs]                      % get_structure Xtemp
-    ),
-    defer_reads(Defs, At, Fn, Xt1, Xt2, In1, In2, DIs),
-    defer_reads(Ds, At, Fn, Xt2, Xt, In2, In, RIs),
-    append(CIs, DIs, A1s), append(A1s, RIs, Is).
-
-% goal codegen, PC- and label-aware:
-% f_goals(Goals, PL, At, FT, PC0,PC, L0,L, Prs0,Prs, In0,In, Is)
-f_goals([], _, _, _, PC, PC, L, L, Prs, Prs, In, In, []).
-f_goals([G|Gs], PL, At, FT, PC0, PC, L0, L, Prs0, Prs, In0, In, Is) :-
-    f_goal(G, PL, At, FT, PC0, PC1, L0, L1, Prs0, Prs1, In0, In1, GI),
-    f_goals(Gs, PL, At, FT, PC1, PC, L1, L, Prs1, Prs, In1, In, RI),
-    append(GI, RI, Is).
-
-f_goal(( C -> T ; E ), PL, At, FT, PC0, PC, L0, L, Prs0, Prs, In0, In, Is) :- !,
-    ElseL = L0, JoinL is L0 + 1, L1 is L0 + 2,
-    conj_list(C, CGs), conj_list(T, TGs), conj_list(E, EGs),
-    PC1 is PC0 + 1,                                    % try_me_else(ElseL)
-    f_goals(CGs, PL, At, FT, PC1, PC2, L1, L2, Prs0, Prs1, In0, InC, CondIs),
-    PC3 is PC2 + 1,                                    % cut_ite
-    f_goals(TGs, PL, At, FT, PC3, PC4, L2, L3, Prs1, Prs2, InC, InT, ThenIs),
-    ElsePC is PC4 + 1,                                 % after jump(JoinL)
-    PC5 is ElsePC + 1,                                 % after trust_me
-    f_goals(EGs, PL, At, FT, PC5, JoinPC, L3, L, Prs2, Prs3, In0, InE, ElseIs),
-    PC = JoinPC,
-    append(Prs3, [ElseL-ElsePC, JoinL-JoinPC], Prs),
-    inter(InT, InE, In),
-    append([enc(22,ElseL,0,0)|CondIs], [enc(31,0,0,0)|ThenIs], Front),
-    append(Front, [enc(32,JoinL,0,0), enc(24,0,0,0)|ElseIs], Is).
-f_goal((L is E), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In2, Is) :- !,
-    % NESTED arithmetic: the expression is just a term -- stage it with
-    % c_operand (build_struct + X-temp deferral handles arbitrary nesting,
-    % e.g. (X + Y) * (X - 1) + 100). The operators land in the functor
-    % table automatically: walk_term skips is/2 itself as a control
-    % functor but walks its argument tree, collecting + / * / ... as data
-    % functors. LHS -> A1, expression term -> A2, builtin is/2 (id 0).
-    c_operand(L, 0, At, FT, In0, In1, IL),
-    c_operand(E, 1, At, FT, In1, In2, IE),
-    append(IL, IE, LE), append(LE, [enc(21, 0, 2, 0)], Is),
-    length(Is, N), PC is PC0 + N.
-f_goal((L = R), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In2, Is) :- !,
-    % full-term unification: either side may be a variable, constant, list
-    % or structure literal (c_operand builds it) -- then builtin =/2
-    c_operand(L, 0, At, FT, In0, In1, IL),
-    c_operand(R, 1, At, FT, In1, In2, IR),
-    append(IL, IR, LR), append(LR, [enc(21,24,2,0)], Is),
-    length(Is, N), PC is PC0 + N.
-f_goal(Cmp, _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-
-    functor(Cmp, Op, 2), cmp_id(Op, Id), !,            % comparison guard
-    arg(1, Cmp, A1), arg(2, Cmp, A2),
-    c_operand(A1, 0, At, FT, In0, In1, IL),
-    c_operand(A2, 1, At, FT, In1, In, IR),
-    append(IL, IR, LR), append(LR, [enc(21,Id,2,0)], Is),
-    length(Is, N), PC is PC0 + N.
-f_goal(Goal, _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-
-    functor(Goal, P, A), bi_id(P, A, Id), !,           % builtin goal
-    call_args(Goal, 1, A, At, FT, In0, In, SetupIs),
-    append(SetupIs, [enc(21, Id, A, 0)], Is),          % builtin_call(Id, A)
-    length(Is, N), PC is PC0 + N.
-f_goal(Goal, PL, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-  % predicate call
-    functor(Goal, P, A), lookup_label(P, A, PL, Label),
-    call_args(Goal, 1, A, At, FT, In0, In, SetupIs),
-    append(SetupIs, [enc(18, Label, A, 0)], Is),       % call(Label, arity)
-    length(Is, N), PC is PC0 + N.
-% FAIL FAST on anything the subset does not cover. Without this, an
-% unsupported goal makes codegen FAIL, and in the loaded compiler that
-% failure explodes into catastrophic backtracking through the compile's
-% stale choice points (unindexed, cut-free clause chains) -- a silent
-% multi-minute hang instead of an error (the gen-3 round lost real time
-% to exactly this, via a nested `is` before the lift above). throw/1 is
-% loadable (call sentinel), so the loaded compiler aborts immediately.
-f_goal(Goal, _, _, _, _, _, _, _, _, _, _, _, _) :-
-    functor(Goal, P, A), throw(cg_unsupported_goal(P, A)).
-
-% builtin goals the grammar can emit directly: name/arity -> builtin id (the
-% host runtime's builtin_op_to_id table). Staged like a call (c_operand per
-% arg into A1..An) then builtin_call(Id, Arity). NB: the grammar emits
-% builtin_call for arg/3 even with a constant index -- the host tier-2
-% compiler's specialised arg opcode (the known subset gap) is simply never
-% generated here, so loaded objects get the loadable builtin form.
-bi_id(functor, 3, 26).
-bi_id(arg, 3, 27).
-bi_id(=.., 2, 28).
-bi_id(copy_term, 2, 29).
-bi_id(atom_codes, 2, 36).
-bi_id(atom_chars, 2, 38).
-bi_id(char_code, 2, 37).
-bi_id(number_codes, 2, 43).
-bi_id(atom_number, 2, 42).
-bi_id(atom_length, 2, 35).
-bi_id(atom_concat, 3, 40).
-bi_id(length, 2, 31).
-bi_id(append, 3, 55).
-bi_id(reverse, 2, 54).
-bi_id(nth0, 3, 51).
-bi_id(nth1, 3, 52).
-bi_id(last, 2, 53).
-bi_id(memberchk, 2, 56).
-bi_id(between, 3, 39).
-bi_id(msort, 2, 30).
-bi_id(sort, 2, 81).
-bi_id(keysort, 2, 80).
-bi_id(pairs_keys, 2, 70).
-bi_id(pairs_values, 2, 71).
-bi_id(atom, 1, 13).
-bi_id(integer, 1, 14).
-bi_id(number, 1, 16).
-bi_id(compound, 1, 17).
-bi_id(var, 1, 18).
-bi_id(nonvar, 1, 19).
-bi_id(is_list, 1, 20).
-bi_id(ground, 1, 132).
-bi_id(succ, 2, 22).
-bi_id(\=, 2, 25).
-bi_id(sum_list, 2, 59).
-bi_id(numbervars, 3, 124).
-bi_id(term_to_atom, 2, 173).
-bi_id(read_term_from_atom, 2, 174).
-
-call_args(_, I, Ar, _, _, In, In, []) :- I > Ar, !.
-call_args(Goal, I, Ar, At, FT, In0, In, Is) :-
-    arg(I, Goal, Arg), Ai is I - 1,
-    c_operand(Arg, Ai, At, FT, In0, In1, AI),
-    I1 is I + 1, call_args(Goal, I1, Ar, At, FT, In1, In, R), append(AI, R, Is).
-
-% call-argument staging: vars/ints via operand_instr; nil/atoms as atom
-% constants; list literals built on the heap
-c_operand('$VAR'(N), Ai, _, _, In0, In1, Is) :- integer(N), !, operand_instr('$VAR'(N), Ai, In0, In1, Is).
-c_operand(V, Ai, _, _, In, In, Is) :- integer(V), !, operand_instr(V, Ai, In, In, Is).
-c_operand([], Ai, At, _, In, In, [enc(8,Idx,Ai,1)]) :- !, functor_index('[]', At, Idx).
-c_operand([H|T], Ai, At, FT, In0, In1, Is) :- !,
-    build_list([H|T], Ai, first, At, FT, 16, _, In0, In1, Is).
-c_operand(A, Ai, At, _, In, In, [enc(8,Idx,Ai,1)]) :- atom(A), !, functor_index(A, At, Idx).
-c_operand(T, Ai, At, FT, In0, In1, Is) :- compound(T),   % structure literal
-    build_struct(T, Ai, At, FT, 16, _, In0, In1, Is).
-% fail fast: unsupported operand kind (e.g. a float literal), or a
-% build_struct failure (e.g. a functor missing from the table)
-c_operand(T, _, _, _, _, _, _) :- throw(cg_unsupported_operand(T)).
-
-% top-down term builds. Lists: the first cell is put_list TARGET; each nested
-% cons is put_structure cons/2 into a fresh X temp created by set_variable
-% (write mode binds through the fresh cell). Structures: put_structure F/N
-% into the target, one set_* per arg, with compound/list CHILDREN deferred to
-% X temps and built after the parent (the mirror of the head-side deferral).
-build_list([E|Rest], TR, Mode, At, FT, Xt0, Xt, In0, In2, Is) :-
-    (   Mode = first
-    ->  Head = [enc(12,TR,0,0)]                          % put_list
-    ;   functor_index('[|]', FT, CI), Op2 is (2<<16)\/TR,
-        Head = [enc(11,CI,Op2,2)]                        % put_structure cons/2
-    ),
-    s_arg(E, At, Xt0, Xta, In0, In1, SE, [], DefsE),
-    (   Rest == []
-    ->  functor_index('[]', At, NI), Tail = [enc(15,NI,0,1)],
-        In1b = In1, Xtb = Xta, RestIs = []
-    ;   Rest = '$VAR'(_)
-    ->  s_arg(Rest, At, Xta, Xtb, In1, In1b, Tail, [], []),  % var tail: [E|Var]
-        RestIs = []
-    ;   Tail = [enc(13,Xta,0,0)],                        % set_variable Xtemp
-        Xtc is Xta + 1,
-        build_list(Rest, Xta, nested, At, FT, Xtc, Xtb, In1, In1b, RestIs)
-    ),
-    defer_builds(DefsE, At, FT, Xtb, Xt, In1b, In2, DIs),
-    append(Head, SE, HS), append(HS, Tail, HST),
-    append(HST, RestIs, HSTR), append(HSTR, DIs, Is).
-build_struct(T, TR, At, FT, Xt0, Xt, In0, In2, [enc(11,FI,Op2,2)|Rest]) :-
-    functor(T, F, N), functor_index(F, FT, FI), Op2 is (N<<16)\/TR,
-    T =.. [_|Args],
-    s_seq(Args, At, Xt0, Xt1, In0, In1, SIs, [], Defs),
-    defer_builds(Defs, At, FT, Xt1, Xt, In1, In2, DIs),
-    append(SIs, DIs, Rest).
-s_seq([], _, Xt, Xt, In, In, [], D, D).
-s_seq([A|As], At, Xt0, Xt, In0, In, Is, D0, D) :-
-    s_arg(A, At, Xt0, Xt1, In0, In1, AIs, D0, D1),
-    s_seq(As, At, Xt1, Xt, In1, In, RIs, D1, D), append(AIs, RIs, Is).
-s_arg('$VAR'(N), _, Xt, Xt, In0, In1, [I], D, D) :- integer(N), !,
-    Y is 48 + N,
-    (   is_init(N, In0)
-    ->  I = enc(14, Y, 0, 0), In1 = In0                  % set_value
-    ;   I = enc(13, Y, 0, 0), In1 = [N|In0]              % set_variable
-    ).
-s_arg([], At, Xt, Xt, In, In, [enc(15,Idx,0,1)], D, D) :- !, functor_index('[]', At, Idx).
-s_arg(V, _, Xt, Xt, In, In, [enc(15,V,1,0)], D, D) :- integer(V), !.
-s_arg(A, At, Xt, Xt, In, In, [enc(15,Idx,0,1)], D, D) :- atom(A), !, functor_index(A, At, Idx).
-s_arg(C, _, Xt0, Xt1, In, In, [enc(13,Xt0,0,0)], D0, D) :-  % compound/list child
-    Xt1 is Xt0 + 1, append(D0, [d(C,Xt0)], D).
-defer_builds([], _, _, Xt, Xt, In, In, []).
-defer_builds([d(C,Reg)|Ds], At, FT, Xt0, Xt, In0, In, Is) :-
-    (   C = [_|_]
-    ->  build_list(C, Reg, nested, At, FT, Xt0, Xt1, In0, In1, CIs)
-    ;   build_struct(C, Reg, At, FT, Xt0, Xt1, In0, In1, CIs)
-    ),
-    defer_builds(Ds, At, FT, Xt1, Xt, In1, In, RIs),
-    append(CIs, RIs, Is).
-
-% serializer with an atom table: NA + NA length-prefixed atom name strings
-% between the label index and the functor table
-wza_serialize(EI, NC, LI, Atoms, Fs, PCs, Is, Out) :-
-    wz_a('WAMO', Out, A1), wz_i(2, A1, A2), wz_i(EI, A2, A3), wz_i(1, A3, A4),
-    wz_n(NC, A4, A5), wz_i(LI, A5, A6),
-    length(Atoms, NA), wz_i(NA, A6, A7), wz_funcs(Atoms, A7, A8),
-    length(Fs, NF), wz_i(NF, A8, A9), wz_funcs(Fs, A9, A10),
-    wz_pcs_sec(PCs, A10, A11), wz_instr_sec(Is, A11, A12), wz_i(0, A12, []).
+% The bootstrap compiler itself (Stage A serializer through the unified
+% cgfull/cgfull_term chain) lives in src/unifyweaver/targets/
+% wam_bootstrap_compiler.pl since the self-host fixpoint closed --
+% it is a shippable artifact now, not test scaffolding. The tests
+% below compile it with write_wam_object/3 (roots qualified with the
+% wam_bootstrap_compiler module) and exercise every stage.
 
 % The fixpoint source: the Stage A serializer (wz_* chain) restated in the
 % accepted subset (cut-free, builtins + calls + list/structure patterns).
@@ -1664,7 +939,7 @@ test(selfhost_serializer_matches_golden) :-
 test(selfhost_serializer_stage_a, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'serz.wamo', SerzWamo),
-    write_wam_object([user:wamoserz/2], [wamo_entry(wamoserz/2)], SerzWamo),
+    write_wam_object([wam_bootstrap_compiler:wamoserz/2], [wamo_entry(wamoserz/2)], SerzWamo),
     % any source file works -- Stage A ignores its input
     directory_file_path(Dir, 'serz_src.txt', SrcPath),
     setup_call_cleanup(open(SrcPath, write, S0),
@@ -1691,7 +966,7 @@ test(selfhost_serializer_stage_a, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_b, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgcompile.wamo', CompWamo),
-    write_wam_object([user:cgcompile/2], [wamo_entry(cgcompile/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgcompile/2], [wamo_entry(cgcompile/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     forall(member(Source, ['p1(R) :- R = 42', 'p1(R) :- R is 6*7']),
@@ -1717,7 +992,7 @@ test(selfhost_codegen_stage_b, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_c, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgcprog.wamo', CompWamo),
-    write_wam_object([user:cgcprog/2], [wamo_entry(cgcprog/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgcprog/2], [wamo_entry(cgcprog/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     directory_file_path(Dir, 'cgc_src.txt', SrcPath),
@@ -1740,7 +1015,7 @@ test(selfhost_codegen_stage_c, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_c_conjunction, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgconj.wamo', CompWamo),
-    write_wam_object([user:cgconj/2], [wamo_entry(cgconj/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgconj/2], [wamo_entry(cgconj/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     directory_file_path(Dir, 'cgconj_src.txt', SrcPath),
@@ -1764,7 +1039,7 @@ test(selfhost_codegen_stage_c_conjunction, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_c_arithmetic, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgarith.wamo', CompWamo),
-    write_wam_object([user:cgarith/2], [wamo_entry(cgarith/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgarith/2], [wamo_entry(cgarith/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     forall(member(Source, ['ca(R) :- X is 6*7, R = X',
@@ -1790,7 +1065,7 @@ test(selfhost_codegen_stage_c_arithmetic, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_c_nontail_call, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     forall(member(Source,
@@ -1819,7 +1094,7 @@ test(selfhost_codegen_stage_c_nontail_call, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_multiclause, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     forall(member(Source-Expected,
@@ -1846,7 +1121,7 @@ test(selfhost_codegen_stage_d_multiclause, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_lists, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     directory_file_path(Dir, 'cgl_src.txt', SrcPath),
@@ -1870,7 +1145,7 @@ test(selfhost_codegen_stage_d_lists, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_guards, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     forall(member(Source-Expected,
@@ -1900,7 +1175,7 @@ test(selfhost_codegen_stage_d_guards, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_structures, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     forall(member(Source-Expected,
@@ -1931,7 +1206,7 @@ test(selfhost_codegen_stage_d_structures, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_builtins, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     forall(member(Source-Expected,
@@ -1963,7 +1238,7 @@ test(selfhost_codegen_stage_d_builtins, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_fixpoint, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     % expected checksum from the Stage A serializer, computed in-process
@@ -1995,7 +1270,7 @@ test(selfhost_codegen_stage_d_fixpoint, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_gen3, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     wamoserz(x, W), atom_codes(W, WCs),
@@ -2031,7 +1306,7 @@ test(selfhost_codegen_stage_d_gen3, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_middle, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     cgfull_term([(sum3(A, B, R2) :- T is A + B, R2 is T + 1)], W),
@@ -2060,7 +1335,7 @@ test(selfhost_codegen_stage_d_middle, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_front, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     cgfull_term([(dbl(X, Y) :- Y is X + X),
@@ -2092,7 +1367,7 @@ test(selfhost_codegen_stage_d_front, [condition(clang_available)]) :-
 test(reader_var_dict_grows_past_128, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     numlist(1, 128, Ns),
@@ -2124,7 +1399,7 @@ test(reader_var_dict_grows_past_128, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_walkers, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     cgfull_term([(cls(N, R2) :- (N >= 10 -> R2 = big ; R2 = small)),
@@ -2199,7 +1474,7 @@ test(selfhost_walkers_logic_in_swi) :-
 test(selfhost_finding12_no_heap_oob, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     directory_file_path(Dir, 'cgf12_src.txt', SrcPath),
@@ -2230,7 +1505,7 @@ test(selfhost_finding12_no_heap_oob, [condition(clang_available)]) :-
 test(selfhost_capstone_fixpoint, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'dump_host_bin', Dump),
     ( exists_file(Dump) -> true ; build_dump_host(Dir, Dump) ),
     fixpoint_walkers_source(Walkers),
@@ -2274,7 +1549,7 @@ test(selfhost_capstone_fixpoint, [condition(clang_available)]) :-
 test(selfhost_arith_error_fails_cleanly, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     directory_file_path(Dir, 'cgae_src.txt', SrcPath),
@@ -2296,7 +1571,7 @@ test(selfhost_arith_error_fails_cleanly, [condition(clang_available)]) :-
 test(selfhost_codegen_stage_d_nested_arith, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     directory_file_path(Dir, 'cgna_src.txt', SrcPath),
@@ -2321,7 +1596,7 @@ test(selfhost_codegen_stage_d_nested_arith, [condition(clang_available)]) :-
 test(selfhost_codegen_fail_fast_on_unsupported, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     directory_file_path(Dir, 'cgff_src.txt', SrcPath),
@@ -2349,7 +1624,7 @@ test(selfhost_codegen_fail_fast_on_unsupported, [condition(clang_available)]) :-
 test(selfhost_uncaught_throw_aborts, [condition(clang_available)]) :-
     obj_dir(Dir),
     directory_file_path(Dir, 'cgfull.wamo', CompWamo),
-    write_wam_object([user:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
     directory_file_path(Dir, 'eval_host_bin', Host),
     ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
     directory_file_path(Dir, 'cgut_src.txt', SrcPath),


### PR DESCRIPTION
## The payoff — JIT roadmap item 5 closes

A grammar compiled from **source text at runtime, inside the running binary**:

```awk
{ total += dyncall_at(compile("[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2)]"), $1) }
END { print total }
```

This is the goal snippet from PLAWK_EVAL_BOOTSTRAP.md minus the intermediate variable: `compile()` **deduplicates by source text**, so a per-record `compile(...)` compiles each distinct grammar once and reuses the loaded VM thereafter (plawk scalars are numeric; a handle-in-scalar surface is a possible follow-up).

Three pieces, in the order requested:

### 1. Bootstrap compiler promoted to `src/`

The self-hosted compiler moves out of `tests/test_wam_object.pl` into `src/unifyweaver/targets/wam_bootstrap_compiler.pl` (module `wam_bootstrap_compiler`) — the full staged history intact (`wamoserz`, `cgcompile`, `cgcprog`, `cgconj`, `cgarith`, `cgfull`/`cgfull_term`), ~730 lines. It's a shippable artifact now, not test scaffolding. The test file imports the module and qualifies its `write_wam_object` roots; the **whole `wam_object` suite passes unchanged fresh-cache** (the module-qualified closure expansion produces byte-identical objects).

### 2. The CLI ships `compiler.wamo`

When a program has `compile(...)` sites, `plawk build` emits `<bin>.evalc.wamo` (`write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], ...)`) next to the output binary — **pay-for-what-you-use**: no compile sites → no object, zero extra IR. `BEGIN { EVALC = "path.wamo" }` points at an existing compiler object instead and skips the emission.

### 3. The eval surface

`compile(field-or-string)` in the `dyncall_at` **source position**:

- `@plawk_compile(src, len)` interns the source text, dedups against the dyncall_at cache registry, and on miss chains `@wam_object_load_cached(evalc)` → `@wam_object_eval` (compiler entry `cgfull(Src, Wamo)`; the emitted `.wamo` bytes load into a fresh VM) → registry record. The handle is the 1-based registry index; 0 = compile failure.
- Handles travel to the **existing** shims as `(null path, handle id)` — a null path is the discriminator `@plawk_dyncall_at_get` uses to resolve from the registry instead of the filesystem, so the i64/float/blob shim families all accept handles for free.
- `DYNCACHE "off"` has no registry to carry a handle, so compile sites under it are a **build error** (exit 3), not a silent miscompile.

### Integration finding

The first end-to-end run returned 0: text-mode fields marshal as **atoms** (awk strings), and the loaded runtime — like SWI — fails arithmetic on atoms rather than coercing (the capstone arith-error channel from #3590 doing exactly its job; before it, `'3' * '3'` would have silently evaluated to 0). Numeric grammars convert with `atom_number/2`, which is in the bootstrap compiler's builtin whitelist.

### Tests

`tests/test_plawk_eval_compile.pl`:
- parse + compile-site collection (and the plain-path source unchanged),
- **the end-to-end payoff**: a runtime-compiled grammar sums `sq(x)` over input records (150), with the shipped `.evalc.wamo` asserted on disk,
- two distinct runtime grammars coexisting via per-source dedup (194),
- the cache-off build error.

Full battery green: `wam_object` suite fresh-cache, plawk `dyncall`/`dyncall_at`/`float`/`named`/`blob`/`stream-core`/`cli` suites.

### Docs

- `PLAWK_EVAL_BOOTSTRAP.md` — new "The landed surface" section.
- `PLAWK_JIT_ROADMAP.md` — item 5 marked **LANDED (the payoff runs)**.
- `PLAWK_SELFHOST.md` — promotion + shipping note under the capstone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_