### PR TITLE
Add numeric LMDB topology audit

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_cross_corpus_campaign.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_cross_corpus_campaign.md
@@ -122,6 +122,12 @@ Record per corpus and graph view:
 These measurements can explain associations but do not identify causes by themselves. A claim that tree-likeness
 offsets title noise requires a within-corpus graph-view or title-view ablation, not only a difference between corpora.
 
+For numeric category LMDBs, run `audit_product_kalman_lmdb_topology.py`. It streams the sorted unique key ranges
+from `category_parent` and `category_child`, uses LMDB duplicate counts for degree, and merges those streams to
+include roots and leaves as degree-zero nodes without materializing an ID set. It joins only the requested scope-root
+title for provenance. The resulting multi-parent fraction is descriptive tree-likeness metadata; node degree must
+not be passed to Product-Kalman or interpreted as calibrated confidence.
+
 ## Fixed Models And Measurements
 
 Use the same model checkpoint, graph-channel construction, judge model, and prompt template across corpora. Compare:
@@ -156,7 +162,8 @@ counts, root IDs, graph-view rules, correction-manifest hash, model/judge identi
 
 1. Use `sample_product_kalman_enwiki_campaign.py` for deterministic branch-stratified sampling against the titled
    scoped LMDB. It traverses numeric IDs, verifies exact shortest upward hop, and joins titles at the output boundary.
-2. Materialize its pair, topology, and title-audit manifests before scoring.
+2. Run `audit_product_kalman_lmdb_topology.py` on the same LMDB snapshot, then materialize the sampler's pair/source
+   and title-audit manifests before scoring.
 3. Add Pearltrees principal-containment and SimpleMind cleaned within-map adapters with the same output schema.
 4. Freeze any title-correction manifests.
 5. Score all raw-title views with the same judge and model, then run matched audited-title sensitivities.

--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -447,6 +447,9 @@ remaining D-channel shape defect as model-side relation-class structure rather t
   sensitivity analyses.
 - `sample_product_kalman_enwiki_campaign.py` and `test_product_kalman_enwiki_campaign.py` - deterministic numeric
   Main-topic branch sampler, endpoint title join, exact shortest-hop verification, and campaign provenance audit.
+- `audit_product_kalman_lmdb_topology.py` and `test_product_kalman_lmdb_topology.py` - streaming numeric LMDB
+  degree audit with exact all-node denominators; topology is descriptive and is never used as a confidence input.
+- `REPORT_product_kalman_enwiki_topology.md` - durable pre-scoring enwiki topology summary and source fingerprint.
 - `DESIGN_uncertainty_estimation_playbook.md` — current rule: learned calibrated combiner, held-out node-disjoint,
   margin gate, and PoE as a control rather than an independence assumption.
 - `REPORT_mu_posterior.md` — empirical evidence that joint heads beat factored PoE under correlated readouts.

--- a/prototypes/mu_cosine/REPORT_product_kalman_enwiki_topology.md
+++ b/prototypes/mu_cosine/REPORT_product_kalman_enwiki_topology.md
@@ -1,0 +1,79 @@
+# Enwiki Product-Kalman Campaign Topology Audit
+
+Status: pre-scoring descriptive audit. These measurements are not model inputs, confidence estimates, or causal
+evidence for a calibration outcome.
+
+## Source
+
+The audit used the semantic-ready scoped category store:
+
+    data/benchmark/enwiki_cats_correct/lmdb_scoped
+    scope root: Main_topic_classifications (page ID 7345184)
+    data.mdb size: 1,319,403,520 bytes
+    data.mdb mtime_ns: 1783430413932204744
+    graph tables: category_parent, category_child
+    title tables: title_i2s, title_s2i
+    title layer kind: mediawiki_page_titles
+
+Command:
+
+```bash
+python3 prototypes/mu_cosine/audit_product_kalman_lmdb_topology.py \
+  --lmdb-dir data/benchmark/enwiki_cats_correct/lmdb_scoped \
+  --scope-root Main_topic_classifications \
+  --corpus enwiki \
+  --graph-view category_dag \
+  --output /tmp/mu_data/enwiki_campaign_topology_audit.json
+```
+
+The JSON is an ephemeral local artifact whose SHA-256 for this run is
+`522863dce41808ae5282cda402dc71391688747a833710d810d2d4e99378b7b7`. The committed audit code and the source
+fingerprint above are the durable regeneration anchors.
+
+## Results
+
+| measurement | value |
+| --- | ---: |
+| graph nodes (union of numeric adjacency keys) | 2,248,538 |
+| category-parent entries | 6,706,581 |
+| category-child entries | 6,706,581 |
+| reciprocal table entry counts match | yes |
+| title_i2s rows | 2,245,288 |
+| direct children of scope root | 35 |
+
+Parent count uses all graph nodes as its denominator, including the root's zero:
+
+| parent-count statistic | value |
+| --- | ---: |
+| zero parents | 1 |
+| more than one parent | 2,076,218 (92.3364%) |
+| mean | 2.9826 |
+| median | 3 |
+| p95 | 5 |
+| p99 | 7 |
+| maximum | 202 |
+
+Child count also uses all graph nodes, including leaves:
+
+| child-count statistic | value |
+| --- | ---: |
+| zero children | 1,103,713 |
+| more than one child | 768,996 (34.1998%) |
+| mean | 2.9826 |
+| median | 1 |
+| p95 | 12 |
+| p99 | 36 |
+| maximum | 25,053 |
+
+## Interpretation
+
+The scoped enwiki category view is strongly multi-parent: it should be treated as a DAG, not approximated as a
+principal-parent tree for the primary campaign. That creates a useful structural contrast with the proposed
+principal-parent Pearltrees and SimpleMind views.
+
+This does not establish that tree-likeness improves Product-Kalman calibration, nor that it offsets title noise.
+Those claims require held-out within-corpus graph-view/title-view ablations. In particular, node degree is not a
+proxy for trained-neighbor density and must not be used as a confidence feature.
+
+The streaming audit checks equality of the two reciprocal table entry counts, not every reciprocal edge pair, and
+does not test graph acyclicity. Those limitations are recorded in the JSON output.

--- a/prototypes/mu_cosine/audit_product_kalman_lmdb_topology.py
+++ b/prototypes/mu_cosine/audit_product_kalman_lmdb_topology.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Stream a descriptive topology audit from numeric category LMDB tables.
+
+The graph scan touches only uint32 keys and duplicate counts. A title lookup is
+performed only for the requested scope root so graph-scale work stays numeric.
+Degree statistics describe corpus structure; they are not confidence features.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+from lmdb_id import dec_id, enc_id, looks_int
+
+
+SCHEMA_VERSION = 1
+QUANTILE_METHOD = "nearest-rank over all graph nodes, including degree zero"
+
+
+class TopologyAuditError(ValueError):
+    pass
+
+
+def _open_optional_db(env, txn, lmdb_module, name):
+    try:
+        return env.open_db(name.encode("utf-8"), txn=txn, create=False)
+    except lmdb_module.NotFoundError:
+        return None
+
+
+def _meta_text(txn, meta, key):
+    if meta is None:
+        return None
+    raw = txn.get(key.encode("utf-8"), db=meta)
+    return None if raw is None else bytes(raw).decode("utf-8")
+
+
+def _named_db(env, txn, lmdb_module, preferred, meta, meta_key, required):
+    candidates = []
+    for name in (preferred, _meta_text(txn, meta, meta_key)):
+        if name and name not in candidates:
+            candidates.append(name)
+    for name in candidates:
+        db = _open_optional_db(env, txn, lmdb_module, name)
+        if db is not None:
+            return name, db
+    if required:
+        raise TopologyAuditError(f"LMDB is missing required sub-db `{preferred}`")
+    return None, None
+
+
+def _iter_raw_key_counts(txn, db):
+    cursor = txn.cursor(db=db)
+    try:
+        present = cursor.first()
+        while present:
+            yield bytes(cursor.key()), cursor.count()
+            present = cursor.next_nodup()
+    finally:
+        cursor.close()
+
+
+def _next_or_none(iterator):
+    try:
+        return next(iterator)
+    except StopIteration:
+        return None
+
+
+def merged_degree_histograms(txn, category_parent, category_child):
+    """Return exact all-node parent/child degree histograms without ID sets."""
+    parent_items = iter(_iter_raw_key_counts(txn, category_parent))
+    child_items = iter(_iter_raw_key_counts(txn, category_child))
+    parent_item = _next_or_none(parent_items)
+    child_item = _next_or_none(child_items)
+    parent_hist = Counter()
+    child_hist = Counter()
+    node_count = 0
+
+    while parent_item is not None or child_item is not None:
+        if child_item is None or (parent_item is not None and parent_item[0] < child_item[0]):
+            parent_degree, child_degree = parent_item[1], 0
+            parent_item = _next_or_none(parent_items)
+        elif parent_item is None or child_item[0] < parent_item[0]:
+            parent_degree, child_degree = 0, child_item[1]
+            child_item = _next_or_none(child_items)
+        else:
+            parent_degree, child_degree = parent_item[1], child_item[1]
+            parent_item = _next_or_none(parent_items)
+            child_item = _next_or_none(child_items)
+        parent_hist[parent_degree] += 1
+        child_hist[child_degree] += 1
+        node_count += 1
+
+    return node_count, parent_hist, child_hist
+
+
+def nearest_rank(histogram, quantile):
+    count = sum(histogram.values())
+    if count == 0:
+        return None
+    rank = max(1, math.ceil(float(quantile) * count))
+    cumulative = 0
+    for value, frequency in sorted(histogram.items()):
+        cumulative += frequency
+        if cumulative >= rank:
+            return value
+    raise AssertionError("histogram rank exceeded total count")
+
+
+def summarize_degree(histogram, node_count, relation):
+    if sum(histogram.values()) != node_count:
+        raise TopologyAuditError(f"{relation} histogram does not cover every graph node")
+    edge_ends = sum(degree * count for degree, count in histogram.items())
+    multiple = sum(count for degree, count in histogram.items() if degree > 1)
+    return {
+        "relation": relation,
+        "denominator": "all graph nodes in the union of numeric adjacency keys",
+        "node_count": node_count,
+        "keyed_node_count": node_count - histogram.get(0, 0),
+        "zero_degree_nodes": histogram.get(0, 0),
+        "degree_gt_one_nodes": multiple,
+        "degree_gt_one_fraction": multiple / node_count if node_count else None,
+        "edge_end_count": edge_ends,
+        "mean": edge_ends / node_count if node_count else None,
+        "median": nearest_rank(histogram, 0.5),
+        "p95": nearest_rank(histogram, 0.95),
+        "p99": nearest_rank(histogram, 0.99),
+        "max": max(histogram, default=None),
+        "histogram": {str(degree): histogram[degree] for degree in sorted(histogram)},
+        "quantile_method": QUANTILE_METHOD,
+    }
+
+
+def _duplicate_count(txn, db, key):
+    cursor = txn.cursor(db=db)
+    try:
+        return cursor.count() if cursor.set_key(key) else 0
+    finally:
+        cursor.close()
+
+
+def _resolve_root(txn, scope_root, category_child, title_i2s, title_s2i):
+    if scope_root is None:
+        return None
+    if looks_int(scope_root):
+        root_id = int(scope_root)
+    else:
+        if title_s2i is None:
+            raise TopologyAuditError("a non-numeric --scope-root requires a title_s2i table")
+        raw = txn.get(scope_root.encode("utf-8"), db=title_s2i)
+        if raw is None and scope_root.startswith("Category:"):
+            raw = txn.get(scope_root[len("Category:"):].encode("utf-8"), db=title_s2i)
+        if raw is None:
+            raise TopologyAuditError(f"title_s2i cannot resolve scope root `{scope_root}`")
+        root_id = dec_id(raw)
+    raw_title = None if title_i2s is None else txn.get(enc_id(root_id), db=title_i2s)
+    return {
+        "requested": scope_root,
+        "id": root_id,
+        "title": None if raw_title is None else bytes(raw_title).decode("utf-8"),
+        "direct_child_count": _duplicate_count(txn, category_child, enc_id(root_id)),
+    }
+
+
+def audit_lmdb_topology(
+    lmdb_dir,
+    scope_root=None,
+    corpus=None,
+    graph_view=None,
+    category_parent_db="category_parent",
+    category_child_db="category_child",
+    title_i2s_db="title_i2s",
+    title_s2i_db="title_s2i",
+    lock=True,
+):
+    try:
+        import lmdb
+    except ImportError as exc:
+        raise TopologyAuditError("python-lmdb is required") from exc
+
+    lmdb_dir = Path(lmdb_dir)
+    env = lmdb.open(str(lmdb_dir), readonly=True, lock=lock, max_dbs=32, subdir=True)
+    try:
+        with env.begin(buffers=True) as txn:
+            meta = _open_optional_db(env, txn, lmdb, "meta")
+            parent_name, category_parent = _named_db(
+                env, txn, lmdb, category_parent_db, meta, "category_parent_db", required=True
+            )
+            child_name, category_child = _named_db(
+                env, txn, lmdb, category_child_db, meta, "category_child_db", required=True
+            )
+            title_i2s_name, title_i2s = _named_db(
+                env, txn, lmdb, title_i2s_db, meta, "title_i2s_db", required=False
+            )
+            title_s2i_name, title_s2i = _named_db(
+                env, txn, lmdb, title_s2i_db, meta, "title_s2i_db", required=False
+            )
+            parent_entries = txn.stat(category_parent)["entries"]
+            child_entries = txn.stat(category_child)["entries"]
+            node_count, parent_hist, child_hist = merged_degree_histograms(
+                txn, category_parent, category_child
+            )
+            root = _resolve_root(txn, scope_root, category_child, title_i2s, title_s2i)
+            title_entries = None if title_i2s is None else txn.stat(title_i2s)["entries"]
+
+            return {
+                "schema_version": SCHEMA_VERSION,
+                "audit_kind": "numeric_lmdb_topology",
+                "corpus": corpus,
+                "graph_view": graph_view,
+                "source": {
+                    "lmdb_dir": str(lmdb_dir),
+                    "data_size": (lmdb_dir / "data.mdb").stat().st_size,
+                    "data_mtime_ns": (lmdb_dir / "data.mdb").stat().st_mtime_ns,
+                    "category_parent_db": parent_name,
+                    "category_child_db": child_name,
+                    "title_i2s_db": title_i2s_name,
+                    "title_s2i_db": title_s2i_name,
+                    "id_encoding": "unsigned uint32 little-endian",
+                    "scan_boundary": "numeric adjacency keys and duplicate counts",
+                    "title_lookup_boundary": "optional scope-root provenance only",
+                    "title_layer_kind": _meta_text(txn, meta, "title_layer_kind"),
+                },
+                "root": root,
+                "integrity": {
+                    "category_parent_entries": parent_entries,
+                    "category_child_entries": child_entries,
+                    "reciprocal_entry_counts_match": parent_entries == child_entries,
+                    "note": "entry-count equality is checked; individual reciprocal edges are not re-materialized",
+                },
+                "nodes": {
+                    "graph_node_count": node_count,
+                    "title_i2s_entries": title_entries,
+                    "title_entries_per_graph_node": (
+                        title_entries / node_count if title_entries is not None and node_count else None
+                    ),
+                },
+                "parent_degree": summarize_degree(parent_hist, node_count, "number of parents per node"),
+                "child_degree": summarize_degree(child_hist, node_count, "number of children per node"),
+                "interpretation": {
+                    "purpose": "describe and compare corpus topology before calibration",
+                    "tree_likeness_proxy": "fraction of all graph nodes with more than one parent",
+                    "confidence_use": "forbidden: node degree is not trained-neighbor density or calibrated confidence",
+                    "causal_claims": "forbidden without within-corpus held-out ablations",
+                    "cycle_status": "not evaluated by this streaming degree audit",
+                },
+            }
+    finally:
+        env.close()
+
+
+def write_json_atomic(path, data):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--lmdb-dir", required=True, type=Path)
+    ap.add_argument("--scope-root", default=None)
+    ap.add_argument("--corpus", default=None)
+    ap.add_argument("--graph-view", default=None)
+    ap.add_argument("--category-parent-db", default="category_parent")
+    ap.add_argument("--category-child-db", default="category_child")
+    ap.add_argument("--title-i2s-db", default="title_i2s")
+    ap.add_argument("--title-s2i-db", default="title_s2i")
+    ap.add_argument("--output", required=True, type=Path)
+    ap.add_argument("--lmdb-no-lock", action="store_true")
+    args = ap.parse_args(argv)
+
+    report = audit_lmdb_topology(
+        args.lmdb_dir,
+        scope_root=args.scope_root,
+        corpus=args.corpus,
+        graph_view=args.graph_view,
+        category_parent_db=args.category_parent_db,
+        category_child_db=args.category_child_db,
+        title_i2s_db=args.title_i2s_db,
+        title_s2i_db=args.title_s2i_db,
+        lock=not args.lmdb_no_lock,
+    )
+    write_json_atomic(args.output, report)
+    print(f"audited {report['nodes']['graph_node_count']} numeric graph nodes")
+    print(f"report -> {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_product_kalman_lmdb_topology.py
+++ b/prototypes/mu_cosine/test_product_kalman_lmdb_topology.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Tests for the streaming numeric LMDB topology audit."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from audit_product_kalman_lmdb_topology import audit_lmdb_topology, main
+from lmdb_id import enc_id
+
+
+def build_topology_lmdb(path):
+    try:
+        import lmdb
+    except ImportError:
+        return False
+
+    edges = [(2, 1), (3, 1), (3, 2), (4, 2)]
+    titles = {
+        1: "Main_topic_classifications",
+        2: "Branch_A",
+        3: "Shared_child",
+        4: "Leaf",
+    }
+    env = lmdb.open(str(path), max_dbs=16, map_size=64 * 1024 * 1024, subdir=True)
+    category_parent = env.open_db(b"category_parent", dupsort=True, create=True)
+    category_child = env.open_db(b"category_child", dupsort=True, create=True)
+    title_i2s = env.open_db(b"title_i2s", create=True)
+    title_s2i = env.open_db(b"title_s2i", create=True)
+    meta = env.open_db(b"meta", create=True)
+    with env.begin(write=True) as txn:
+        for child, parent in edges:
+            txn.put(enc_id(child), enc_id(parent), db=category_parent, dupdata=True)
+            txn.put(enc_id(parent), enc_id(child), db=category_child, dupdata=True)
+        for node_id, title in titles.items():
+            encoded = title.encode("utf-8")
+            txn.put(enc_id(node_id), encoded, db=title_i2s)
+            txn.put(encoded, enc_id(node_id), db=title_s2i)
+        txn.put(b"title_layer_kind", b"test_mediawiki_titles", db=meta)
+    env.sync()
+    env.close()
+    return True
+
+
+def test_exact_all_node_degree_statistics_and_root_join():
+    with tempfile.TemporaryDirectory() as tmp:
+        lmdb_dir = Path(tmp) / "graph.lmdb"
+        if not build_topology_lmdb(lmdb_dir):
+            print("  skip test_exact_all_node_degree_statistics_and_root_join (python-lmdb unavailable)")
+            return
+
+        report = audit_lmdb_topology(
+            lmdb_dir,
+            scope_root="Main_topic_classifications",
+            corpus="enwiki",
+            graph_view="category_dag",
+        )
+        assert report["corpus"] == "enwiki"
+        assert report["graph_view"] == "category_dag"
+        assert report["nodes"]["graph_node_count"] == 4
+        assert report["nodes"]["title_i2s_entries"] == 4
+        assert report["nodes"]["title_entries_per_graph_node"] == 1.0
+        assert report["root"] == {
+            "requested": "Main_topic_classifications",
+            "id": 1,
+            "title": "Main_topic_classifications",
+            "direct_child_count": 2,
+        }
+        assert report["integrity"]["category_parent_entries"] == 4
+        assert report["integrity"]["category_child_entries"] == 4
+        assert report["integrity"]["reciprocal_entry_counts_match"] is True
+
+        parent = report["parent_degree"]
+        assert parent["histogram"] == {"0": 1, "1": 2, "2": 1}
+        assert parent["zero_degree_nodes"] == 1
+        assert parent["degree_gt_one_nodes"] == 1
+        assert parent["degree_gt_one_fraction"] == 0.25
+        assert parent["mean"] == 1.0
+        assert parent["median"] == 1
+        assert parent["p95"] == 2
+        assert parent["max"] == 2
+
+        child = report["child_degree"]
+        assert child["histogram"] == {"0": 2, "2": 2}
+        assert child["zero_degree_nodes"] == 2
+        assert child["mean"] == 1.0
+        assert child["median"] == 0
+        assert child["p95"] == 2
+        assert report["interpretation"]["confidence_use"].startswith("forbidden:")
+
+
+def test_numeric_root_does_not_require_title_tables():
+    with tempfile.TemporaryDirectory() as tmp:
+        lmdb_dir = Path(tmp) / "graph.lmdb"
+        if not build_topology_lmdb(lmdb_dir):
+            print("  skip test_numeric_root_does_not_require_title_tables (python-lmdb unavailable)")
+            return
+
+        report = audit_lmdb_topology(
+            lmdb_dir,
+            scope_root="1",
+            title_i2s_db="absent_i2s",
+            title_s2i_db="absent_s2i",
+        )
+        assert report["root"]["id"] == 1
+        assert report["root"]["title"] is None
+        assert report["root"]["direct_child_count"] == 2
+        assert report["nodes"]["title_i2s_entries"] is None
+        assert report["source"]["title_lookup_boundary"] == "optional scope-root provenance only"
+
+
+def test_cli_writes_stable_json_report():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        lmdb_dir = root / "graph.lmdb"
+        if not build_topology_lmdb(lmdb_dir):
+            print("  skip test_cli_writes_stable_json_report (python-lmdb unavailable)")
+            return
+        output = root / "audit.json"
+        args = [
+            "--lmdb-dir", str(lmdb_dir),
+            "--scope-root", "Main_topic_classifications",
+            "--corpus", "enwiki",
+            "--graph-view", "category_dag",
+            "--output", str(output),
+        ]
+        assert main(args) == 0
+        first = output.read_bytes()
+        assert main(args) == 0
+        assert output.read_bytes() == first
+        report = json.loads(first)
+        assert report["audit_kind"] == "numeric_lmdb_topology"
+        assert report["source"]["scan_boundary"] == "numeric adjacency keys and duplicate counts"
+
+
+if __name__ == "__main__":
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} LMDB topology audit tests passed")


### PR DESCRIPTION
## Summary

- add a streaming topology audit over numeric LMDB adjacency tables
- compute exact all-node parent and child degree distributions without materializing ID sets
- join the title tables only for scope-root provenance
- record explicit safeguards against treating degree as confidence
- add a durable pre-scoring report for the enwiki campaign

## Enwiki result

The scoped category graph contains:

- 2,248,538 graph nodes
- 6,706,581 reciprocal adjacency entries
- 92.3364% of nodes with more than one parent
- median parent count 3 and p95 parent count 5
- 1,103,713 leaf nodes
- 35 direct children under `Main_topic_classifications`

This establishes that the primary enwiki view is strongly multi-parent. It does not claim that tree-likeness affects calibration; that requires held-out within-corpus ablations.

## Verification

- `python3 -m py_compile prototypes/mu_cosine/audit_product_kalman_lmdb_topology.py prototypes/mu_cosine/test_product_kalman_lmdb_topology.py`
- `python3 prototypes/mu_cosine/test_product_kalman_lmdb_topology.py`
- `python3 prototypes/mu_cosine/test_product_kalman_enwiki_campaign.py`
- real read-only audit of the 6.7M-edge scoped enwiki LMDB
- `git diff origin/main...HEAD --check`