### PR TITLE
Add Rust WAM read_term/2 options

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -675,6 +675,9 @@ wam_instruction_arm('Instruction::Call(p, _arity)', Body) :-
                     self.dynamic_retract_call(self.pc + 1)
                 } else if p == "assert/1" {
                     self.execute_assert_builtin("assert/1")
+                } else if p == "read_term/2" {
+                    let options = self.get_reg_raw("A2");
+                    self.execute_read_term_builtin(options.as_ref())
                 } else if self.foreign_predicates.contains(p) {
                     self.cp = self.pc + 1;
                     if self.execute_foreign_predicate(p, *_arity) {
@@ -748,6 +751,12 @@ wam_instruction_arm('Instruction::Execute(p)', Body) :-
                     self.dynamic_retract_call(self.cp)
                 } else if p == "assert/1" {
                     if self.execute_assert_builtin("assert/1") {
+                        self.pc = self.cp;
+                        true
+                    } else { false }
+                } else if p == "read_term/2" {
+                    let options = self.get_reg_raw("A2");
+                    if self.execute_read_term_builtin(options.as_ref()) {
                         self.pc = self.cp;
                         true
                     } else { false }
@@ -1596,7 +1605,7 @@ compile_execute_term_builtin_to_rust(Code) :-
             "term_to_atom/2" => { self.execute_term_to_atom_builtin() }
             "read_term_from_atom/2" => { self.execute_read_term_from_atom_builtin(2) }
             "read_term_from_atom/3" => { self.execute_read_term_from_atom_builtin(3) }
-            "read/1" | "read_term/1" => { self.execute_read_term_builtin() }
+            "read/1" | "read_term/1" => { self.execute_read_term_builtin(None) }
             "assertz/1" | "asserta/1" => { self.execute_assert_builtin(op) }
             "retractall/1" => { self.execute_retractall_builtin() }
             _ => false,

--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -6,7 +6,7 @@
         self.term_input_pos = 0;
     }
 
-    fn execute_read_term_builtin(&mut self) -> bool {
+    fn execute_read_term_builtin(&mut self, options: Option<&Value>) -> bool {
         use std::io::Read;
         if self.term_input_pos >= self.term_input.len() {
             let mut input = String::new();
@@ -24,11 +24,22 @@
                 self.term_input_pos = self.term_input.len();
                 let eof = Value::Atom("end_of_file".to_string());
                 let target = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
-                return if self.unify(&target, &eof) { self.pc += 1; true } else { false };
+                if !self.unify(&target, &eof) {
+                    return false;
+                }
+                if let Some(options) = options {
+                    if !self.bind_empty_read_term_options(options) {
+                        return false;
+                    }
+                }
+                self.pc += 1;
+                return true;
             }
         };
         self.term_input_pos = next_pos;
-        if self.bind_compiled_parse_atom(&text, "A1") { self.pc += 1; true }
+        if self.bind_compiled_parse_atom_with_options(&text, "A1", options) {
+            self.pc += 1; true
+        }
         else { false }
     }
 
@@ -98,6 +109,18 @@
             }
         }
         None
+    }
+
+    fn bind_empty_read_term_options(&mut self, options: &Value) -> bool {
+        let empty = Value::List(Vec::new());
+        for name in ["variable_names", "variables", "singletons"] {
+            if let Some(target) = self.read_term_option_arg(options, name) {
+                if !self.unify(&target, &empty) {
+                    return false;
+                }
+            }
+        }
+        true
     }
 
     fn copy_named_variables_from_env(

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -213,6 +213,37 @@ fn conjunction_rule_backtracks_left_subgoal_for_more_body_solutions() {
 }
 
 #[test]
+fn generated_read_term_two_applies_variable_names() {
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code, labels);
+    vm.set_term_input("p(A, A, B).");
+    vm.set_reg_str("A1", ub("Term"));
+    vm.set_reg_str("A2", ub("Names"));
+    vm.pc = *vm.labels
+        .get("rust_read_term_options_demo/2")
+        .expect("generated read_term/2 label");
+
+    assert!(vm.run());
+    let parsed = vm.bindings.get("Term").cloned().expect("Term bound");
+    let args = match parsed {
+        Value::Str(ref functor, ref args) if functor == "p" => args.clone(),
+        other => panic!("unexpected parsed term: {:?}", other),
+    };
+    assert_eq!(args[0], args[1]);
+    assert_ne!(args[0], args[2]);
+
+    let names_raw = vm.bindings.get("Names").cloned().expect("Names bound");
+    let names = vm.deref_heap(&vm.deref_var(&names_raw));
+    assert_eq!(
+        names,
+        Value::List(vec![
+            fact("=", vec![at("A"), args[0].clone()]),
+            fact("=", vec![at("B"), args[2].clone()]),
+        ]),
+    );
+}
+
+#[test]
 fn read_eof_binds_end_of_file() {
     let mut vm = WamState::new(vec![], HashMap::new());
     vm.set_reg_str("A1", ub("T"));

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -12,6 +12,10 @@ rust_dyn_dummy.
 :- dynamic rust_assert_alias_demo/0.
 rust_assert_alias_demo :- assert(dyn(alias)).
 
+:- dynamic rust_read_term_options_demo/2.
+rust_read_term_options_demo(Term, Names) :-
+    read_term(Term, [variable_names(Names)]).
+
 cargo_ok :-
     catch(( process_create(path(cargo), ['--version'],
                            [stdout(null), stderr(null), process(P)]),
@@ -27,7 +31,9 @@ test(assert_retract_dynamic_db,
     Dir = 'output/test_wam_rust_dynamic_builtins',
     safe_rmdir(Dir),
     once(write_wam_rust_project(
-        [user:rust_dyn_dummy/0, user:rust_assert_alias_demo/0],
+        [user:rust_dyn_dummy/0,
+         user:rust_assert_alias_demo/0,
+         user:rust_read_term_options_demo/2],
         [module_name(dynrt), no_kernels(true), runtime_parser(compiled)],
         Dir)),
     atom_concat(Dir, '/tests', TestsDir),


### PR DESCRIPTION
## Summary

- support current-input `read_term/2` in Rust WAM
- reuse `variable_names/1`, `variables/1`, and `singletons/1` handling
- return empty metadata lists at end of input
- locally intercept ordinary `Call` and `Execute` instructions
- avoid shared builtin registry or cross-target changes
- verify behavior through a generated Rust predicate

## Testing

- focused generated Rust dynamic-builtin crate
- complete Rust WAM target suite
- Rust WAM target syntax load