### PR TITLE
Add Rust read term syntax errors

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1777,6 +1777,9 @@ compile_execute_term_builtin_to_rust(Code) :-
             .and_then(|value| self.read_term_option_arg(value, "variables"));
         let singletons = options
             .and_then(|value| self.read_term_option_arg(value, "singletons"));
+        let syntax_errors_error = options
+            .and_then(|value| self.read_term_option_atom(value, "syntax_errors"))
+            .as_deref() == Some("error");
         let wants_env = variable_names.is_some() || variables.is_some() || singletons.is_some();
         let parser_entry = if wants_env {
             "parse_term_from_atom/4"
@@ -1785,6 +1788,9 @@ compile_execute_term_builtin_to_rust(Code) :-
         };
         if !self.labels.contains_key("canonical_op_table/1") ||
            !self.labels.contains_key(parser_entry) {
+            if syntax_errors_error {
+                return self.raise_read_syntax_error();
+            }
             return false;
         }
         let mut parser = WamState::new(self.code.clone(), self.labels.clone());
@@ -1792,6 +1798,9 @@ compile_execute_term_builtin_to_rust(Code) :-
         let ops_var = Value::Unbound("_RP_ops".to_string());
         parser.set_reg_str("A1", ops_var.clone());
         if !parser.run_named_label("canonical_op_table/1") {
+            if syntax_errors_error {
+                return self.raise_read_syntax_error();
+            }
             return false;
         }
         let ops = parser.deref_heap(&parser.deref_var(&ops_var));
@@ -1806,6 +1815,9 @@ compile_execute_term_builtin_to_rust(Code) :-
             parser.set_reg_str("A4", var_env.clone());
         }
         if !parser.run_named_label(parser_entry) {
+            if syntax_errors_error {
+                return self.raise_read_syntax_error();
+            }
             return false;
         }
 

--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -111,6 +111,30 @@
         None
     }
 
+    fn read_term_option_atom(&self, options: &Value, name: &str) -> Option<String> {
+        let value = self.read_term_option_arg(options, name)?;
+        match self.deref_heap(&self.deref_var(&value)) {
+            Value::Atom(atom) => Some(atom),
+            _ => None,
+        }
+    }
+
+    fn raise_read_syntax_error(&mut self) -> bool {
+        self.var_counter += 1;
+        let context = Value::Unbound(format!("_SE{}", self.var_counter));
+        self.thrown_ball = Some(Value::Str(
+            "error/2".to_string(),
+            vec![
+                Value::Str(
+                    "syntax_error/1".to_string(),
+                    vec![Value::Atom("end_of_clause".to_string())],
+                ),
+                context,
+            ],
+        ));
+        false
+    }
+
     fn bind_empty_read_term_options(&mut self, options: &Value) -> bool {
         let empty = Value::List(Vec::new());
         for name in ["variable_names", "variables", "singletons"] {

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -377,3 +377,27 @@ fn read_term_from_atom_returns_variable_metadata_with_shared_variables() {
         ]),
     );
 }
+
+#[test]
+fn read_term_syntax_errors_error_throws_and_quiet_fails() {
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code.clone(), labels.clone());
+    vm.set_reg_str("A1", ub("Result"));
+    vm.pc = *vm
+        .labels
+        .get("rust_syntax_error_demo/1")
+        .expect("missing syntax error demo");
+    assert!(vm.run());
+    assert_eq!(vm.bindings.get("Result"), Some(&at("caught")));
+    assert!(vm.thrown_ball.is_none());
+
+    let mut quiet = WamState::new(code, labels);
+    quiet.set_reg_str("A1", at("p("));
+    quiet.set_reg_str("A2", ub("Term"));
+    quiet.set_reg_str(
+        "A3",
+        Value::List(vec![fact("syntax_errors", vec![at("quiet")])]),
+    );
+    assert!(!quiet.execute_builtin("read_term_from_atom/3", 3));
+    assert!(quiet.thrown_ball.is_none());
+}

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -16,6 +16,13 @@ rust_assert_alias_demo :- assert(dyn(alias)).
 rust_read_term_options_demo(Term, Names) :-
     read_term(Term, [variable_names(Names)]).
 
+:- dynamic rust_syntax_error_demo/1.
+rust_syntax_error_demo(Result) :-
+    catch(
+        read_term_from_atom('p(', _, [syntax_errors(error)]),
+        error(syntax_error(_), _),
+        Result = caught).
+
 cargo_ok :-
     catch(( process_create(path(cargo), ['--version'],
                            [stdout(null), stderr(null), process(P)]),
@@ -33,7 +40,8 @@ test(assert_retract_dynamic_db,
     once(write_wam_rust_project(
         [user:rust_dyn_dummy/0,
          user:rust_assert_alias_demo/0,
-         user:rust_read_term_options_demo/2],
+         user:rust_read_term_options_demo/2,
+         user:rust_syntax_error_demo/1],
         [module_name(dynrt), no_kernels(true), runtime_parser(compiled)],
         Dir)),
     atom_concat(Dir, '/tests', TestsDir),


### PR DESCRIPTION
## Summary

- Support `syntax_errors(error)` in the Rust WAM read-term parser bridge.
- Throw `error(syntax_error(end_of_clause), _)` on malformed input.
- Preserve ordinary failure for `syntax_errors(quiet)`, `fail`, and the default mode.
- Avoid allocations on the ordinary no-options path.
- Add generated Prolog `catch/3` and quiet-mode regressions.

The implementation is confined to the Rust target and its template; shared builtin registries and other targets are unchanged.

## Testing

- Focused generated Rust dynamic-builtin tests
- Full Rust WAM target suite
- Prolog target syntax check
- `git diff --check`