### PR TITLE
Add Rust WAM atom_to_term/3 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_runtime_parser_capability.pl
+++ b/src/unifyweaver/targets/wam_runtime_parser_capability.pl
@@ -37,6 +37,7 @@ parser_dependent_builtin(read/2).
 parser_dependent_builtin(read_term/1).
 parser_dependent_builtin(read_term_from_atom/2).
 parser_dependent_builtin(read_term_from_atom/3).
+parser_dependent_builtin(atom_to_term/3).
 parser_dependent_builtin(term_to_atom/2).
 
 %% parser_dependent_goal(+Goal, -Builtin)

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1602,6 +1602,7 @@ compile_execute_term_builtin_to_rust(Code) :-
             "reverse/2" => { self.execute_reverse_builtin() }
             "atom_codes/2" => { self.execute_atom_codes_builtin() }
             "number_codes/2" => { self.execute_number_codes_builtin() }
+            "atom_to_term/3" => { self.execute_atom_to_term_builtin() }
             "term_to_atom/2" => { self.execute_term_to_atom_builtin() }
             "read_term_from_atom/2" => { self.execute_read_term_from_atom_builtin(2) }
             "read_term_from_atom/3" => { self.execute_read_term_from_atom_builtin(3) }
@@ -1720,6 +1721,27 @@ compile_execute_term_builtin_to_rust(Code) :-
                         }
                     }
                     None => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn execute_atom_to_term_builtin(&mut self) -> bool {
+        let atom = self.get_reg_raw("A1")
+            .map(|value| self.deref_heap(&self.deref_var(&value)));
+        let bindings = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+        let options = Value::List(vec![Value::Str(
+            "variable_names".to_string(),
+            vec![bindings],
+        )]);
+        match atom {
+            Some(Value::Atom(text)) => {
+                if self.bind_compiled_parse_atom_with_options(&text, "A2", Some(&options)) {
+                    self.pc += 1;
+                    true
+                } else {
+                    false
                 }
             }
             _ => false,

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -244,6 +244,37 @@ fn generated_read_term_two_applies_variable_names() {
 }
 
 #[test]
+fn generated_atom_to_term_preserves_variables_and_bindings() {
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code, labels);
+    vm.set_reg_str("A1", ub("Term"));
+    vm.set_reg_str("A2", ub("Bindings"));
+    vm.pc = *vm
+        .labels
+        .get("rust_atom_to_term_demo/2")
+        .expect("generated atom_to_term/3 label");
+
+    assert!(vm.run());
+    let parsed = vm.bindings.get("Term").cloned().expect("Term bound");
+    let args = match parsed {
+        Value::Str(ref functor, ref args) if functor == "p" => args.clone(),
+        other => panic!("unexpected parsed term: {:?}", other),
+    };
+    assert_eq!(args[0], args[1]);
+    assert_ne!(args[0], args[2]);
+
+    let bindings_raw = vm.bindings.get("Bindings").cloned().expect("Bindings bound");
+    let bindings = vm.deref_heap(&vm.deref_var(&bindings_raw));
+    assert_eq!(
+        bindings,
+        Value::List(vec![
+            fact("=", vec![at("A"), args[0].clone()]),
+            fact("=", vec![at("B"), args[2].clone()]),
+        ]),
+    );
+}
+
+#[test]
 fn read_eof_binds_end_of_file() {
     let mut vm = WamState::new(vec![], HashMap::new());
     vm.set_reg_str("A1", ub("T"));

--- a/tests/test_wam_runtime_parser_capability.pl
+++ b/tests/test_wam_runtime_parser_capability.pl
@@ -81,6 +81,7 @@ test(parser_dependent_builtin_catalogue) :-
                       read_term/1,
                       read_term_from_atom/2,
                       read_term_from_atom/3,
+                      atom_to_term/3,
                       term_to_atom/2]).
 
 test(parser_dependent_goal_read_default_stream) :-
@@ -92,6 +93,9 @@ test(parser_dependent_goal_read) :-
 test(parser_dependent_goal_module_qualified) :-
     once(parser_dependent_goal(user:read_term_from_atom('f(a)', _),
                                read_term_from_atom/2)).
+
+test(parser_dependent_goal_atom_to_term) :-
+    once(parser_dependent_goal(atom_to_term('f(A)', _, _), atom_to_term/3)).
 
 test(parser_dependent_goal_term_to_atom_forward_fails, [fail]) :-
     parser_dependent_goal(term_to_atom(f(a), _), _).

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -16,6 +16,10 @@ rust_assert_alias_demo :- assert(dyn(alias)).
 rust_read_term_options_demo(Term, Names) :-
     read_term(Term, [variable_names(Names)]).
 
+:- dynamic rust_atom_to_term_demo/2.
+rust_atom_to_term_demo(Term, Bindings) :-
+    atom_to_term('p(A, A, B)', Term, Bindings).
+
 :- dynamic rust_syntax_error_demo/1.
 rust_syntax_error_demo(Result) :-
     catch(
@@ -41,6 +45,7 @@ test(assert_retract_dynamic_db,
         [user:rust_dyn_dummy/0,
          user:rust_assert_alias_demo/0,
          user:rust_read_term_options_demo/2,
+         user:rust_atom_to_term_demo/2,
          user:rust_syntax_error_demo/1],
         [module_name(dynrt), no_kernels(true), runtime_parser(compiled)],
         Dir)),


### PR DESCRIPTION
## Summary

- Implement `atom_to_term/3` in the Rust WAM runtime.
- Reuse the compiled parser and existing `variable_names` metadata path.
- Preserve repeated-variable identity and return `Name=Variable` bindings.
- Register `atom_to_term/3` as parser-dependent so parser-disabled projects fail during generation instead of silently failing at runtime.
- Add generated WAM and capability catalogue regressions.

The shared change is one declarative parser-capability entry and does not affect runtime performance.

## Testing

- 52 runtime-parser capability tests
- Focused generated Rust dynamic-builtin crate
- Full Rust WAM target suite
- Prolog syntax check
- `git diff --check`