### PR TITLE
Add Pearltrees principal-path campaign sampler

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_cross_corpus_campaign.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_cross_corpus_campaign.md
@@ -16,13 +16,18 @@ typos, duplicate variants, or organizational labels. Either advantage can domina
 | corpus | primary graph view | title source | primary risk |
 | --- | --- | --- | --- |
 | enwiki | category DAG below Main_topic_classifications | MediaWiki page titles | multi-parent and generic-apex ambiguity |
-| Pearltrees | principal Collection containment (subtopic) | harvested collection titles | typos, incomplete harvests, and secondary annotations |
+| Pearltrees | recorded principal path lineages (subtopic) | harvested collection titles | cross-record cycles, typos, incomplete harvests, and secondary annotations |
 | SimpleMind | within-map principal parent, content-rooted only | raw node text after duplicate-title cleanup | typos, conflicted copies, and organizational super-layers |
 
 Primary results use these views separately. Pearltrees section relations, shortcuts, and bridges are secondary
 edges, not replacements for principal containment. SimpleMind cross-map and organizational ancestors are secondary
 views. They may be evaluated as within-corpus sensitivity analyses, but must not be silently mixed into the primary
 tree view.
+
+Pearltrees paths are tree-like individually, but the current path-record union is not globally a tree: some records
+reverse the direction of shared endpoint pairs. The primary campaign therefore samples within each recorded
+principal lineage and excludes cross-record direction/hop conflicts. It does not merge the paths and break cycles
+post hoc. The assembled multi-parent DAG remains an explicit sensitivity view.
 
 ## Verified Enwiki Starting Point
 
@@ -71,7 +76,7 @@ campaign source.
    as pair endpoints.
 4. For enwiki, allocate each hop in deterministic round-robin order across eligible direct children of
    Main_topic_classifications; do not let the already-studied Behavior branch dominate the campaign.
-5. For Pearltrees, stratify over harvested principal trees and record account/tree provenance. For SimpleMind,
+5. For Pearltrees, stratify over recorded principal-path components and retain account/tree provenance. For SimpleMind,
    stratify over maps and retain only content-rooted chains after duplicate-title and organizational-layer cleanup.
 6. Preserve raw IDs, raw titles, corpus, graph view, source branch/tree/map, hop, and every endpoint alias in the
    pair manifest.
@@ -164,7 +169,9 @@ counts, root IDs, graph-view rules, correction-manifest hash, model/judge identi
    scoped LMDB. It traverses numeric IDs, verifies exact shortest upward hop, and joins titles at the output boundary.
 2. Run `audit_product_kalman_lmdb_topology.py` on the same LMDB snapshot, then materialize the sampler's pair/source
    and title-audit manifests before scoring.
-3. Add Pearltrees principal-containment and SimpleMind cleaned within-map adapters with the same output schema.
-4. Freeze any title-correction manifests.
-5. Score all raw-title views with the same judge and model, then run matched audited-title sensitivities.
-6. Evaluate each corpus separately, followed by explicit cross-corpus and domain-transfer summaries.
+3. Use `sample_product_kalman_pearltrees_campaign.py` for the path-local Pearltrees primary view; keep its
+   cross-record conflict exclusions and title aliases in the manifest.
+4. Add the SimpleMind cleaned within-map adapter with the same campaign output schema.
+5. Freeze any title-correction manifests.
+6. Score all raw-title views with the same judge and model, then run matched audited-title sensitivities.
+7. Evaluate each corpus separately, followed by explicit cross-corpus and domain-transfer summaries.

--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -450,6 +450,10 @@ remaining D-channel shape defect as model-side relation-class structure rather t
 - `audit_product_kalman_lmdb_topology.py` and `test_product_kalman_lmdb_topology.py` - streaming numeric LMDB
   degree audit with exact all-node denominators; topology is descriptive and is never used as a confidence input.
 - `REPORT_product_kalman_enwiki_topology.md` - durable pre-scoring enwiki topology summary and source fingerprint.
+- `sample_product_kalman_pearltrees_campaign.py` and `test_product_kalman_pearltrees_campaign.py` - privacy-safe,
+  hop-balanced sampling within recorded principal paths, with cross-record conflicts excluded and source title
+  aliases preserved.
+- `REPORT_product_kalman_pearltrees_sampling.md` - durable unscored Pearltrees sampling and source-audit summary.
 - `DESIGN_uncertainty_estimation_playbook.md` — current rule: learned calibrated combiner, held-out node-disjoint,
   margin gate, and PoE as a control rather than an independence assumption.
 - `REPORT_mu_posterior.md` — empirical evidence that joint heads beat factored PoE under correlated readouts.

--- a/prototypes/mu_cosine/REPORT_product_kalman_pearltrees_sampling.md
+++ b/prototypes/mu_cosine/REPORT_product_kalman_pearltrees_sampling.md
@@ -1,0 +1,88 @@
+# Pearltrees Product-Kalman Campaign Sampling
+
+Status: pre-scoring exploratory artifact. No judge labels or Product-Kalman result were produced in this run.
+
+## Primary View
+
+The primary Pearltrees view is path-local lineage, not the unioned multi-parent DAG. Each
+`api_tree_paths_v8.jsonl` record supplies one account-tagged materialized `path_ids` lineage. Candidate pairs are
+formed only within a recorded lineage. The account token is provenance and is not a graph node.
+
+This distinction matters in the current snapshot. Individual paths are tree-like, but their union can cycle. For
+example, some records place `ethics` beneath `philosophy`, while others place `philosophy` beneath `ethics`. The
+sampler excludes an endpoint pair whenever records disagree about its direction or hop; it does not break the cycle
+or select one context post hoc. Alias and secondary-reference edges in `assembled_dag.tsv` remain a separate
+sensitivity view.
+
+## Source
+
+| artifact | bytes | mtime_ns | SHA-256 |
+| --- | ---: | ---: | --- |
+| `.local/data/api_tree_paths_v8.jsonl` | 347,589 | 1769651833578690785 | `89c1ceff7ef95293a9771eb343c21f5a01fe88a1b1e0efab41840f19b998ebc5` |
+| `.local/data/pearltrees_api/assembled_titles.tsv` | 472,564 | 1782970573157666345 | `65bd587b680f2092bd4e3cac586bf80d54ed2804515be221946159b8c5316ded` |
+
+Command:
+
+```bash
+python3 prototypes/mu_cosine/sample_product_kalman_pearltrees_campaign.py \
+  --paths-jsonl .local/data/api_tree_paths_v8.jsonl \
+  --titles-tsv .local/data/pearltrees_api/assembled_titles.tsv \
+  --pairs 250 --hmax 5 --seed 0 \
+  --pairs-tsv /tmp/mu_data/pearltrees_campaign_pairs_unscored.tsv \
+  --score-in /tmp/mu_data/pearltrees_campaign_score_in_unscored.tsv \
+  --manifest /tmp/mu_data/pearltrees_campaign_manifest_unscored.json
+```
+
+## Source Audit
+
+| measurement | value |
+| --- | ---: |
+| path records | 881 |
+| private paths removed before title aliasing | 129 |
+| retained path records | 752 |
+| unique path nodes | 1,294 |
+| unique consecutive path edges | 1,188 |
+| consecutive edge observations | 2,920 |
+| title-covered path nodes | 1,224 |
+| missing-title path nodes | 70 |
+| retained path/table title disagreements preserved as aliases | 152 |
+| endpoint pairs rejected for cross-record direction conflict | 20 |
+
+One direction-conflict example is tree IDs `10311488` and `10391040`: 29 observations point one way and 41 point
+the other, all at hop 1. Such pairs are absent from the campaign table and retained as manifest diagnostics.
+
+## Sample
+
+The emitted table contains 250 unique unordered endpoint pairs, 50 at each hop from 1 through 5.
+
+| hop | eligible pool | represented top-level components | maximum selected from one component |
+| ---: | ---: | ---: | ---: |
+| 1 | 1,077 | 50 | 1 |
+| 2 | 965 | 41 | 2 |
+| 3 | 738 | 30 | 2 |
+| 4 | 492 | 25 | 3 |
+| 5 | 352 | 16 | 4 |
+
+The 250 rows contain 284 unique endpoint IDs, 282 unique raw titles, and 281 unique normalized titles. Three pairs
+of endpoint IDs collapse into duplicate normalized-title groups. No semantic corrections were applied. The pair
+table preserves assembled raw titles plus path-record aliases; only normalized copies are used for matching.
+
+## Ephemeral Artifacts
+
+| artifact | SHA-256 |
+| --- | --- |
+| `/tmp/mu_data/pearltrees_campaign_pairs_unscored.tsv` | `586c81c9065ef4f003f8039c78054f0f96bf35a0c311d1a8c3399533733f230f` |
+| `/tmp/mu_data/pearltrees_campaign_score_in_unscored.tsv` | `f05b404632b8649b0e89a37a0d1b192a64bd18d8601a5cbdf9ebee910db2098a` |
+| `/tmp/mu_data/pearltrees_campaign_manifest_unscored.json` | `51d0c970abce1d382c5f7b3d93653f7a30e42eacebf0632534aed2306593c4d5` |
+
+These files are local and ephemeral. The committed sampler, source fingerprints, seed, and command are the durable
+regeneration anchors.
+
+## Interpretation Guardrails
+
+- The sample is judge-ready, not scored evidence.
+- Path-local tree-likeness does not establish that Pearltrees calibrates better than enwiki.
+- Title aliases are provenance, not automatic corrections.
+- Direction-conflicted pairs are excluded rather than resolved from model residuals or judge labels.
+- Product-Kalman still requires node-disjoint calibration/evaluation and comparison with the registered
+  `JointPosterior` baseline on NLL, calibration, and selective risk.

--- a/prototypes/mu_cosine/SKILL_understand_pearltrees.md
+++ b/prototypes/mu_cosine/SKILL_understand_pearltrees.md
@@ -38,6 +38,11 @@ A Pearltrees account is a forest of **trees** (collections). The harvest stores 
   `left_index`/`right_index` are these; the parser reads pearls in `left_index` order so each section
   header scopes the pearls after it.
 
+**Path-local caveat.** An API path record is a single principal lineage, but the union of records need not be a
+global tree. The current snapshot includes shared endpoint pairs in opposite directions (and therefore cycles when
+the records are merged). For the Product-Kalman primary campaign, sample within each recorded lineage and exclude
+direction/hop conflicts across records. Do not choose a cycle-breaking parent from judge labels or model residuals.
+
 ---
 
 ## Section headers retype what follows (like SimpleMind containers)

--- a/prototypes/mu_cosine/sample_product_kalman_pearltrees_campaign.py
+++ b/prototypes/mu_cosine/sample_product_kalman_pearltrees_campaign.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Sample a hop-balanced Pearltrees campaign from recorded principal paths.
+
+`api_tree_paths` records one user-selected path per tree. Consecutive numeric
+IDs define the primary principal-parent view. Alias and secondary-reference
+edges from the assembled DAG are intentionally reserved for sensitivity runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import html
+import json
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from privacy import is_private_title
+from sample_product_kalman_enwiki_campaign import (
+    load_excluded_titles,
+    normalize_title,
+    title_audit,
+    title_quality_flags,
+    write_json_atomic,
+)
+from sample_sigma_hop_fresh_corpus import FreshCorpusError, hop_targets
+
+
+SCHEMA_VERSION = 1
+CORPUS = "pearltrees"
+GRAPH_VIEW = "principal_path_lineage"
+HTML_ENTITY = re.compile(r"&(?:#\d+|#x[0-9a-f]+|[a-z][a-z0-9]+);", re.IGNORECASE)
+
+
+def sha256_path(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def load_title_table(path):
+    titles = {}
+    duplicates = Counter()
+    with open(path, encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            parts = line.rstrip("\n").split("\t", 1)
+            if len(parts) != 2 or not parts[0]:
+                raise FreshCorpusError(f"{path}:{line_no}: expected id<TAB>title")
+            node_id, title = parts
+            if node_id in titles and titles[node_id] != title:
+                duplicates["conflicting_duplicate_title"] += 1
+                continue
+            titles.setdefault(node_id, title)
+    return titles, dict(sorted(duplicates.items()))
+
+
+def clean_path_ids(raw_ids):
+    return tuple(str(item) for item in raw_ids if not str(item).startswith("account:"))
+
+
+def record_is_private(record, path_ids, titles):
+    target_text = str(record.get("target_text") or "")
+    if "*private*" in target_text.casefold():
+        return True
+    if is_private_title(str(record.get("title") or "")):
+        return True
+    return any(is_private_title(titles.get(node_id, "")) for node_id in path_ids)
+
+
+def load_principal_paths(paths_jsonl, titles_tsv):
+    titles, title_table_stats = load_title_table(titles_tsv)
+    records = []
+    stats = Counter()
+    account_records = Counter()
+    title_mismatches = 0
+    title_aliases = defaultdict(set)
+
+    with open(paths_jsonl, encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            if not line.strip():
+                continue
+            stats["path_records_total"] += 1
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise FreshCorpusError(f"{paths_jsonl}:{line_no}: invalid JSON: {exc}") from exc
+            account = str(record.get("account") or "").strip()
+            path_ids = clean_path_ids(record.get("path_ids") or ())
+            if not account or not path_ids:
+                stats["path_records_missing_account_or_path"] += 1
+                continue
+            tree_id = str(record.get("tree_id") or "")
+            record_title = str(record.get("title") or "")
+            if record_is_private(record, path_ids, titles):
+                stats["path_records_private"] += 1
+                continue
+            if tree_id and record_title:
+                if tree_id in titles and titles[tree_id] != record_title:
+                    title_mismatches += 1
+                    title_aliases[tree_id].add(record_title)
+                titles.setdefault(tree_id, record_title)
+            records.append({"account": account, "path_ids": path_ids, "tree_id": tree_id})
+            account_records[account] += 1
+            stats["path_records_retained"] += 1
+
+    parent_candidates = defaultdict(set)
+    nodes = set()
+    path_edges = set()
+    edge_observations = 0
+    for record in records:
+        account, path_ids = record["account"], record["path_ids"]
+        keyed = tuple((account, node_id) for node_id in path_ids)
+        nodes.update(keyed)
+        for parent, child in zip(keyed, keyed[1:]):
+            if parent != child:
+                parent_candidates[child].add(parent)
+                path_edges.add((parent, child))
+                edge_observations += 1
+
+    conflicts = sum(len(parents) > 1 for parents in parent_candidates.values())
+    covered = sum(node_id in titles for _account, node_id in nodes)
+    stats.update({
+        "principal_path_nodes": len(nodes),
+        "principal_path_unique_edges": len(path_edges),
+        "principal_path_edge_observations": edge_observations,
+        "merged_parent_conflict_nodes": conflicts,
+        "title_covered_nodes": covered,
+        "missing_title_nodes": len(nodes) - covered,
+        "record_vs_table_title_mismatches": title_mismatches,
+        "record_title_alias_nodes": len(title_aliases),
+        "record_title_aliases": sum(len(values) for values in title_aliases.values()),
+    })
+    return {
+        "titles": titles,
+        "title_aliases": {key: tuple(sorted(values)) for key, values in sorted(title_aliases.items())},
+        "records": records,
+        "nodes": nodes,
+        "stats": dict(sorted(stats.items())),
+        "account_records": dict(sorted(account_records.items())),
+        "title_table_stats": title_table_stats,
+    }
+
+
+
+def pearltrees_quality_flags(title):
+    flags = list(title_quality_flags(title))
+    if HTML_ENTITY.search(title):
+        flags.append("html_entity")
+    if html.unescape(title) != title:
+        flags.append("encoded_display_text")
+    return sorted(set(flags))
+
+
+def endpoint(node, titles, title_aliases=None):
+    account, node_id = node
+    title = titles.get(node_id)
+    if not title:
+        return None
+    return {
+        "id": node_id,
+        "account": account,
+        "title": title,
+        "normalized_title": normalize_title(title),
+        "quality_flags": pearltrees_quality_flags(title),
+        "title_aliases": tuple((title_aliases or {}).get(node_id, ())),
+    }
+
+
+def candidate_rank(seed, hop, component, descendant, ancestor):
+    payload = ":".join((
+        str(seed), str(hop), component[0], component[1],
+        descendant[0], descendant[1], ancestor[0], ancestor[1],
+    )).encode("utf-8")
+    return hashlib.blake2b(payload, digest_size=16).digest()
+
+
+def candidate_pools(forest, hmax, seed, excluded_titles=()):
+    titles = forest["titles"]
+    pools = {hop: defaultdict(list) for hop in range(1, hmax + 1)}
+    rejected = Counter()
+    excluded_titles = {normalize_title(title) for title in excluded_titles}
+    observations = defaultdict(list)
+    conflict_examples = []
+
+    for record in forest["records"]:
+        account = record["account"]
+        keyed_path = tuple((account, node_id) for node_id in record["path_ids"])
+        component = keyed_path[0]
+        component_endpoint = endpoint(component, titles, forest["title_aliases"])
+        if component_endpoint is None:
+            rejected["records_missing_component_title"] += 1
+            continue
+        for index in range(1, len(keyed_path)):
+            descendant_node = keyed_path[index]
+            descendant = endpoint(descendant_node, titles, forest["title_aliases"])
+            if descendant is None:
+                rejected["missing_descendant_title"] += 1
+                continue
+            if descendant["normalized_title"] in excluded_titles:
+                rejected["excluded_descendant_title"] += 1
+                continue
+            for hop in range(1, min(hmax, index) + 1):
+                ancestor_node = keyed_path[index - hop]
+                if ancestor_node == descendant_node:
+                    rejected["self_pair_observations"] += 1
+                    continue
+                ancestor = endpoint(ancestor_node, titles, forest["title_aliases"])
+                if ancestor is None:
+                    rejected["missing_ancestor_title"] += 1
+                    continue
+                if ancestor["normalized_title"] in excluded_titles:
+                    rejected["excluded_ancestor_title"] += 1
+                    continue
+                unordered = tuple(sorted((descendant_node, ancestor_node)))
+                observations[unordered].append({
+                    "component": component,
+                    "component_title": component_endpoint["title"],
+                    "source_tree_id": record["tree_id"] or keyed_path[-1][1],
+                    "descendant_node": descendant_node,
+                    "ancestor_node": ancestor_node,
+                    "descendant": descendant,
+                    "ancestor": ancestor,
+                    "hop": hop,
+                })
+
+    for unordered in sorted(observations):
+        seen = observations[unordered]
+        orientations = {(row["descendant_node"], row["ancestor_node"]) for row in seen}
+        hops = {row["hop"] for row in seen}
+        if len(orientations) > 1:
+            rejected["direction_conflict_pairs"] += 1
+            rejected["direction_conflict_observations"] += len(seen)
+            if len(conflict_examples) < 20:
+                conflict_examples.append({
+                    "kind": "direction",
+                    "endpoint_ids": [unordered[0][1], unordered[1][1]],
+                    "observation_count": len(seen),
+                    "orientations": [
+                        {
+                            "descendant_id": orientation[0][1],
+                            "ancestor_id": orientation[1][1],
+                            "observation_count": sum(
+                                (item["descendant_node"], item["ancestor_node"]) == orientation
+                                for item in seen
+                            ),
+                            "observed_hops": sorted({
+                                item["hop"]
+                                for item in seen
+                                if (item["descendant_node"], item["ancestor_node"]) == orientation
+                            }),
+                        }
+                        for orientation in sorted(orientations)
+                    ],
+                })
+            continue
+        if len(hops) > 1:
+            rejected["hop_conflict_pairs"] += 1
+            rejected["hop_conflict_observations"] += len(seen)
+            if len(conflict_examples) < 20:
+                conflict_examples.append({
+                    "kind": "hop",
+                    "endpoint_ids": [unordered[0][1], unordered[1][1]],
+                    "observed_hops": sorted(hops),
+                    "observation_count": len(seen),
+                })
+            continue
+        provenance = sorted(
+            seen,
+            key=lambda row: (row["component"], row["source_tree_id"], row["descendant_node"], row["ancestor_node"]),
+        )
+        row = dict(provenance[0])
+        row["source_tree_ids"] = tuple(sorted({item["source_tree_id"] for item in provenance}))
+        row["source_record_count"] = len(provenance)
+        rejected["duplicate_consistent_observations"] += len(provenance) - 1
+        pools[row["hop"]][row["component"]].append(row)
+
+    for hop, by_component in pools.items():
+        for component, rows in by_component.items():
+            rows.sort(key=lambda row: (
+                candidate_rank(
+                    seed,
+                    hop,
+                    component,
+                    row["descendant_node"],
+                    row["ancestor_node"],
+                ),
+                row["descendant"]["id"],
+                row["ancestor"]["id"],
+            ))
+    return pools, dict(sorted(rejected.items())), conflict_examples
+
+
+def sample_campaign_pairs(forest, pairs=250, hmax=5, seed=0, excluded_titles=()):
+    if pairs <= 0 or hmax <= 0:
+        raise FreshCorpusError("pairs and hmax must be positive")
+    targets = hop_targets(pairs, hmax)
+    pools, rejected, conflict_examples = candidate_pools(forest, hmax, seed, excluded_titles)
+    rows = []
+    accepted_by_hop_component = defaultdict(Counter)
+    pool_counts = {}
+
+    for hop in range(1, hmax + 1):
+        components = sorted(
+            pools[hop],
+            key=lambda item: (pools[hop][item][0]["component_title"].casefold(), item),
+        )
+        queues = {component: list(pools[hop][component]) for component in components}
+        pool_counts[str(hop)] = sum(len(queue) for queue in queues.values())
+        accepted = 0
+        while accepted < targets[hop]:
+            progressed = False
+            for component in components:
+                if accepted >= targets[hop]:
+                    break
+                queue = queues[component]
+                if not queue:
+                    continue
+                row = queue.pop(0)
+                row.update({
+                    "pair_id": f"pearltrees-h{hop}-{accepted:04d}",
+                    "corpus": CORPUS,
+                    "graph_view": GRAPH_VIEW,
+                    "branch_id": component[1],
+                    "branch_title": row["component_title"],
+                    "account": component[0],
+                })
+                rows.append(row)
+                accepted_by_hop_component[hop][f"{component[0]}:{component[1]}"] += 1
+                accepted += 1
+                progressed = True
+            if not progressed:
+                break
+        if accepted < targets[hop]:
+            raise FreshCorpusError(
+                f"hop {hop} has {pool_counts[str(hop)]} eligible principal-path pairs; need {targets[hop]}"
+            )
+
+    return rows, {
+        "target_hop_counts": {str(hop): targets[hop] for hop in sorted(targets)},
+        "hop_counts": {str(hop): sum(row["hop"] == hop for row in rows) for hop in sorted(targets)},
+        "candidate_pool_counts": pool_counts,
+        "candidate_rejections": rejected,
+        "candidate_conflict_examples": conflict_examples,
+        "accepted_by_hop_component": {
+            str(hop): dict(sorted(accepted_by_hop_component[hop].items()))
+            for hop in sorted(targets)
+        },
+    }
+
+
+def write_pairs_tsv(path, rows):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "pair_id", "corpus", "graph_view", "account", "branch_id", "branch_title",
+        "source_tree_ids", "source_record_count", "descendant_id", "descendant_title", "descendant_title_aliases", "descendant_normalized_title",
+        "ancestor_id", "ancestor_title", "ancestor_title_aliases", "ancestor_normalized_title", "hop",
+    ]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields, delimiter="\t")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({
+                "pair_id": row["pair_id"],
+                "corpus": row["corpus"],
+                "graph_view": row["graph_view"],
+                "account": row["account"],
+                "branch_id": row["branch_id"],
+                "branch_title": row["branch_title"],
+                "source_tree_ids": ",".join(row["source_tree_ids"]),
+                "source_record_count": row["source_record_count"],
+                "descendant_id": row["descendant"]["id"],
+                "descendant_title": row["descendant"]["title"],
+                "descendant_title_aliases": json.dumps(row["descendant"]["title_aliases"], ensure_ascii=False),
+                "descendant_normalized_title": row["descendant"]["normalized_title"],
+                "ancestor_id": row["ancestor"]["id"],
+                "ancestor_title": row["ancestor"]["title"],
+                "ancestor_title_aliases": json.dumps(row["ancestor"]["title_aliases"], ensure_ascii=False),
+                "ancestor_normalized_title": row["ancestor"]["normalized_title"],
+                "hop": row["hop"],
+            })
+
+
+def write_score_in(path, rows):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("# node_title\troot_title\tcur_relation\tconf\tneighborhood\tnode_type\troot_type\traw\n")
+        for row in rows:
+            f.write(
+                f"{row['descendant']['title']}\t{row['ancestor']['title']}\tsubtopic\t1.0\t"
+                f"principal_h{row['hop']}\tpearltrees_collection\tpearltrees_collection\t\n"
+            )
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--paths-jsonl", required=True, type=Path)
+    ap.add_argument("--titles-tsv", required=True, type=Path)
+    ap.add_argument("--pairs", type=int, default=250)
+    ap.add_argument("--hmax", type=int, default=5)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--exclude-graph")
+    ap.add_argument("--pairs-tsv", required=True, type=Path)
+    ap.add_argument("--score-in", required=True, type=Path)
+    ap.add_argument("--manifest", required=True, type=Path)
+    ap.add_argument("--allow-small-sample", action="store_true")
+    args = ap.parse_args(argv)
+    if not args.allow_small_sample and args.pairs < 250:
+        ap.error("campaign sampling requires at least 250 pairs; use --allow-small-sample for tests")
+
+    forest = load_principal_paths(args.paths_jsonl, args.titles_tsv)
+    excluded_titles = load_excluded_titles(args.exclude_graph)
+    rows, summary = sample_campaign_pairs(
+        forest,
+        pairs=args.pairs,
+        hmax=args.hmax,
+        seed=args.seed,
+        excluded_titles=excluded_titles,
+    )
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "corpus": CORPUS,
+        "graph_view": GRAPH_VIEW,
+        "paths_jsonl": str(args.paths_jsonl),
+        "paths_jsonl_size": args.paths_jsonl.stat().st_size,
+        "paths_jsonl_mtime_ns": args.paths_jsonl.stat().st_mtime_ns,
+        "paths_jsonl_sha256": sha256_path(args.paths_jsonl),
+        "titles_tsv": str(args.titles_tsv),
+        "titles_tsv_size": args.titles_tsv.stat().st_size,
+        "titles_tsv_mtime_ns": args.titles_tsv.stat().st_mtime_ns,
+        "titles_tsv_sha256": sha256_path(args.titles_tsv),
+        "principal_path_rule": "sample within each recorded non-account path_ids lineage",
+        "cross_record_conflict_policy": "exclude endpoint pairs whose direction or hop differs across path records",
+        "secondary_edge_policy": "assembled DAG aliases and secondary references excluded from primary view",
+        "privacy_rule": "drop an entire record when target_text masks private ancestry or any known title is private",
+        "title_policy": "assembled raw title; retained path-record differences preserved as aliases; no semantic correction",
+        "title_normalization": "NFKC; underscore-to-space; whitespace-collapse; casefold (matching only)",
+        "sampling_method": "canonical component for consistent duplicate observations; deterministic hash order; component round-robin",
+        "pairs": len(rows),
+        "hmax": args.hmax,
+        "seed": args.seed,
+        "exclude_graph": args.exclude_graph,
+        "excluded_title_count": len(excluded_titles),
+        "account_record_counts": forest["account_records"],
+        "forest_stats": forest["stats"],
+        "title_table_stats": forest["title_table_stats"],
+        "pairs_tsv": str(args.pairs_tsv),
+        "score_in": str(args.score_in),
+        "title_audit": title_audit(rows),
+    }
+    manifest.update(summary)
+    write_pairs_tsv(args.pairs_tsv, rows)
+    write_score_in(args.score_in, rows)
+    write_json_atomic(args.manifest, manifest)
+    print(f"sampled {len(rows)} Pearltrees principal-path pairs")
+    print(f"pairs -> {args.pairs_tsv}")
+    print(f"score input -> {args.score_in}")
+    print(f"manifest -> {args.manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_product_kalman_pearltrees_campaign.py
+++ b/prototypes/mu_cosine/test_product_kalman_pearltrees_campaign.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests for the Pearltrees principal-parent campaign sampler."""
+
+import csv
+import json
+import tempfile
+from pathlib import Path
+
+from sample_product_kalman_pearltrees_campaign import (
+    candidate_pools,
+    load_principal_paths,
+    main,
+    pearltrees_quality_flags,
+)
+
+
+def write_fixture(root, conflict=False):
+    titles = {
+        **{str(node): f"A title {node}" for node in range(1, 7)},
+        **{str(node): f"B title {node}" for node in range(10, 16)},
+        "20": "Private root",
+        "21": "Hidden leaf",
+    }
+    titles["1"] = "Component A"
+    titles["10"] = "Component B"
+    titles_path = root / "titles.tsv"
+    titles_path.write_text(
+        "".join(f"{node_id}\t{title}\n" for node_id, title in sorted(titles.items(), key=lambda item: int(item[0]))),
+        encoding="utf-8",
+    )
+
+    records = [
+        {
+            "tree_id": "6",
+            "title": "A title 6",
+            "account": "s243a",
+            "path_ids": ["account:s243a", "1", "2", "3", "4", "5", "6"],
+            "target_text": "- s243a\n  - Component A\n    - A title 6",
+        },
+        {
+            "tree_id": "15",
+            "title": "B renamed 15",
+            "account": "s243a",
+            "path_ids": ["account:s243a", "10", "11", "12", "13", "14", "15"],
+            "target_text": "- s243a\n  - Component B\n    - B title 15",
+        },
+        {
+            "tree_id": "21",
+            "title": "Private alias label",
+            "account": "s243a",
+            "path_ids": ["account:s243a", "20", "21"],
+            "target_text": "- s243a\n  - *private*\n    - *private*",
+        },
+    ]
+    if conflict:
+        records.append({
+            "tree_id": "1",
+            "title": "Component A",
+            "account": "s243a",
+            "path_ids": ["account:s243a", "2", "1"],
+            "target_text": "- s243a\n  - A title 2\n    - Component A",
+        })
+    paths_path = root / "paths.jsonl"
+    paths_path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+    return paths_path, titles_path
+
+
+def test_quality_flags_preserve_encoded_raw_title():
+    assert pearltrees_quality_flags("Art &amp; Science") == ["encoded_display_text", "html_entity"]
+
+
+def test_private_paths_are_removed_and_cross_record_cycles_are_excluded():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        paths, titles = write_fixture(root)
+        forest = load_principal_paths(paths, titles)
+        assert forest["stats"]["path_records_total"] == 3
+        assert forest["stats"]["path_records_private"] == 1
+        assert forest["stats"]["path_records_retained"] == 2
+        assert forest["stats"]["principal_path_nodes"] == 12
+        assert forest["stats"]["principal_path_unique_edges"] == 10
+        assert ("s243a", "20") not in forest["nodes"]
+        assert ("s243a", "21") not in forest["nodes"]
+        assert "21" not in forest["title_aliases"]
+
+        conflict_root = root / "conflict"
+        conflict_root.mkdir()
+        conflict_paths, conflict_titles = write_fixture(conflict_root, conflict=True)
+        conflict_forest = load_principal_paths(conflict_paths, conflict_titles)
+        _pools, rejected, conflicts = candidate_pools(conflict_forest, hmax=1, seed=0)
+        assert rejected["direction_conflict_pairs"] == 1
+        assert rejected["direction_conflict_observations"] >= 2
+        assert conflicts[0]["kind"] == "direction"
+
+
+def test_cli_samples_balanced_components_and_writes_stable_outputs():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        paths, titles = write_fixture(root)
+        pairs_path = root / "pairs.tsv"
+        score_path = root / "score.tsv"
+        manifest_path = root / "manifest.json"
+        args = [
+            "--paths-jsonl", str(paths),
+            "--titles-tsv", str(titles),
+            "--pairs", "10",
+            "--hmax", "5",
+            "--seed", "7",
+            "--pairs-tsv", str(pairs_path),
+            "--score-in", str(score_path),
+            "--manifest", str(manifest_path),
+            "--allow-small-sample",
+        ]
+        assert main(args) == 0
+
+        with open(pairs_path, newline="", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f, delimiter="\t"))
+        assert len(rows) == 10
+        assert {row["corpus"] for row in rows} == {"pearltrees"}
+        assert {row["graph_view"] for row in rows} == {"principal_path_lineage"}
+        assert {row["account"] for row in rows} == {"s243a"}
+        assert all(row["source_tree_ids"] for row in rows)
+        assert all(int(row["source_record_count"]) >= 1 for row in rows)
+        alias_rows = [row for row in rows if row["descendant_id"] == "15"]
+        assert alias_rows and "B renamed 15" in alias_rows[0]["descendant_title_aliases"]
+        for hop in range(1, 6):
+            hop_rows = [row for row in rows if int(row["hop"]) == hop]
+            assert len(hop_rows) == 2
+            assert {row["branch_title"] for row in hop_rows} == {"Component A", "Component B"}
+        assert len({tuple(sorted((row["descendant_id"], row["ancestor_id"]))) for row in rows}) == 10
+
+        score_rows = [
+            line.rstrip("\n").split("\t")
+            for line in score_path.read_text(encoding="utf-8").splitlines()
+            if not line.startswith("#")
+        ]
+        assert len(score_rows) == 10
+        assert all(row[2] == "subtopic" for row in score_rows)
+        assert all(row[5:7] == ["pearltrees_collection", "pearltrees_collection"] for row in score_rows)
+
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["hop_counts"] == {str(hop): 2 for hop in range(1, 6)}
+        assert manifest["forest_stats"]["path_records_private"] == 1
+        assert manifest["forest_stats"]["merged_parent_conflict_nodes"] == 0
+        assert manifest["forest_stats"]["record_title_alias_nodes"] == 1
+        assert manifest["secondary_edge_policy"].startswith("assembled DAG aliases")
+        assert manifest["title_audit"]["semantic_corrections_applied"] is False
+
+        first = (pairs_path.read_bytes(), score_path.read_bytes(), manifest_path.read_bytes())
+        assert main(args) == 0
+        assert (pairs_path.read_bytes(), score_path.read_bytes(), manifest_path.read_bytes()) == first
+
+
+if __name__ == "__main__":
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} Pearltrees campaign sampler tests passed")


### PR DESCRIPTION
## Summary

- add deterministic Pearltrees campaign sampling from recorded principal paths
- generate 250 unscored pairs balanced to 50 pairs at hops 1–5
- remove entire paths containing private ancestry
- preserve path-snapshot title disagreements as endpoint aliases
- exclude endpoint pairs whose direction or hop conflicts across path records
- retain account, component, and source-tree provenance
- document the real unscored sampling run

## Methodological finding

Individual Pearltrees principal paths are tree-like, but their global union is not necessarily a tree. The current snapshot contains shared endpoint pairs in opposite directions, including cycles such as `ethics` and `philosophy`.

The primary campaign therefore samples within recorded lineages and excludes cross-record direction or hop conflicts. It does not choose a cycle-breaking parent post hoc. The assembled multi-parent DAG remains a separate sensitivity view.

## Real unscored run

- 881 source path records
- 129 private paths removed
- 752 retained paths
- 1,294 unique path nodes
- 20 direction-conflicted endpoint pairs excluded
- 152 source-title differences preserved as aliases
- 250 pairs, exactly 50 per hop
- hop-5 pool: 352 eligible pairs across 16 selected components

No judge scores or Product-Kalman result are included.

## Verification

- Python compilation passed
- 3 Pearltrees sampler tests passed
- 4 adjacent enwiki sampler tests passed
- deterministic byte-identical fixture reruns
- real 250-pair campaign generation completed
- `git diff origin/main...HEAD --check`