### PR TITLE
WAM/LLVM loaded clause indexing: real switch_on_constant dispatch in .wamo objects

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -118,10 +118,38 @@ L_col_2_3: trust_me
 The switch is an *optimization*: its entries only point deeper into the same
 `try_me_else`/`retry`/`trust` chain that follows it inline. Dropping the
 switch and falling through runs every clause in order — correct, just
-unindexed. The loader already did this for `switch_on_term`; extending it to
-`switch_on_constant`/`_a2` (this PR) means grammars with atom-keyed clauses —
-pervasive in the compiler — now load. Cost: unindexed dispatch in loaded
-objects (an optimization gap, not a correctness one).
+unindexed. The loader did this for the whole family through the eval
+campaign — the "optimization gap, not a correctness one" that let
+atom-keyed grammars (pervasive in the compiler) load early.
+
+**The gap is now closed for `switch_on_constant` / `_a2`** (loaded clause
+indexing): the writer encodes them as REAL dispatch rows (tags 25/27 —
+the same step cases the AOT dispatcher uses) with their key→label tables
+in a trailing `.wamo` section (emitted only when non-empty, so
+switch-free objects — including everything the bootstrap compiler's own
+serializer emits — stay byte-identical to the pre-section format, and
+old objects load with the new loader unchanged). At load time each table
+materializes as the `%SwitchEntry` array `@wam_switch_on_constant`
+already consumes, with atom keys resolved through the object's relocated
+atom ids and label indices resolved against the loaded VM's own label
+table via `@wam_label_pc` — no new dispatch code at all. A strict switch
+miss backtracks (exactly the AOT semantics), an unbound argument skips
+into the chain. On a 200-clause atom-keyed fact table probed 20 000
+times at its last key, the indexed object runs **7.6× faster** than the
+same object with its tables stripped (25 ms vs 189 ms end to end),
+byte-identical results. `switch_on_term`/`_structure` and the
+`*_fallthrough` variants stay nops — matching the AOT dispatcher, which
+nops them too.
+
+The lift also fixed a latent AOT bug the loaded path inherited: the
+switch-entry parser split `key:label` at the FIRST colon and never
+unquoted writeq-style keys, so entries for atoms like `'=:='` or `'\=='`
+sheared in half or interned their quote characters — either way the
+table entry never matched at runtime and a strict switch silently
+FAILED the call. Both parsers now split at the last colon and unquote
+(`switch_entry_split/3`, `switch_entry_unquote/2`); regression
+`loaded_switch_on_constant_dispatch` pins quoted-key dispatch, the
+clean miss-into-else, and the unbound skip.
 
 ## Milestones (subset expansion → bootstrap)
 
@@ -338,10 +366,12 @@ independently useful (richer hand-written grammars load sooner).
 - **Pay-for-what-you-use holds:** the compiler object (large) loads only when
   an `eval`/`compile` surface is compiled into the program, riding
   `emit_wamo_loader(true)` like every other dynamic capability.
-- **Correctness-first, speed-later:** loaded objects run unindexed (milestone
-  1). If the eval loop becomes hot, a real switch-table in the loader is a
-  later optimization — the format already carries the switch operands we
-  currently drop.
+- **Correctness-first, speed-later — the "later" arrived:** loaded objects
+  ran unindexed through the whole campaign (milestone 1's nop lift); with
+  the fixpoint closed, `switch_on_constant`/`_a2` are now REAL dispatch in
+  loaded objects (see "Why indexing dispatch is a safe nop" above for the
+  landed design: a trailing table section, loader-built `%SwitchEntry`
+  arrays, shared step cases, 7.6× on a wide-fact-table probe).
 - **Milestones 1–5 have landed, and the dynamic store is complete through rule
   bodies (3b-db PR 3);** milestone 6 is self-host. The reader (3b), byte-buffer
   output (4), dynamic store incl. rule bodies + catch/throw (3b-db/3c), and the

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -311,14 +311,23 @@ six milestones live in the same doc; item 5 was a **subset-expansion
 campaign** with the bootstrap as its payoff, and each milestone was its
 own PR(s).
 
-- **Milestone 1 — clause indexing — LANDED.** Every `switch_on_*` dispatch
-  variant (matched by prefix, so the `_fallthrough` and `_a2` forms are
-  covered) is now in the loadable `.wamo` subset as a nop-fallthrough. Safe
-  because the tier-2 compiler emits every indexing instruction *inline at the
-  head of the predicate*, immediately before the `try_me_else` chain it
-  dispatches into; dropping the switch and falling through runs every clause
-  in order — correct, just unindexed. Lets atom-keyed multi-clause predicates
-  (pervasive in the compiler) load.
+- **Milestone 1 — clause indexing — LANDED, now REAL dispatch.** Every
+  `switch_on_*` dispatch variant first entered the loadable `.wamo` subset
+  as a nop-fallthrough — safe because the tier-2 compiler emits every
+  indexing instruction *inline at the head of the predicate*, immediately
+  before the `try_me_else` chain it dispatches into, so falling through
+  runs every clause in order (correct, just unindexed). That let
+  atom-keyed multi-clause predicates (pervasive in the compiler) load
+  early. Post-fixpoint, `switch_on_constant`/`_a2` are REAL indexed
+  dispatch in loaded objects: the writer carries their key→label tables
+  in a trailing section (emitted only when non-empty — switch-free and
+  bootstrap-emitted objects stay byte-identical), and the loader builds
+  the same `%SwitchEntry` arrays the AOT dispatcher feeds
+  `@wam_switch_on_constant`, so the shared step cases run them with no
+  new dispatch code (7.6× on a 200-clause fact-table probe; the lift
+  also fixed a latent quoted-key parsing bug shared with the AOT switch
+  tables — see PLAWK_EVAL_BOOTSTRAP.md). `switch_on_term`/`_structure`
+  and `*_fallthrough` remain nops, matching the AOT dispatcher.
 - **Milestone 2 — `call/N` meta-call in objects — LANDED.** A meta-call
   encodes `op1 = -1`; dispatch resolves the runtime goal through a new
   **per-object meta-call table** (format version 2) hung off two new

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -21530,11 +21530,13 @@ wam_line_to_llvm_literal_resolved(Parts, _LabelMap, Lit) :-
 parse_switch_entries([], _, []).
 parse_switch_entries([Part | Rest], LabelMap, [Entry | RestEntries]) :-
     clean_comma(Part, Clean),
-    ( sub_string(Clean, Before, 1, After, ":")
-    -> sub_string(Clean, 0, Before, _, KeyStr),
-       sub_string(Clean, _, After, 0, LabelStr)
-    ;  KeyStr = Clean, LabelStr = ""
-    ),
+    % Split at the LAST colon and unquote writeq-style keys (see
+    % switch_entry_split/3 -- a first-colon split sheared quoted keys
+    % like '=:=' in half, and un-unquoted keys interned their quote
+    % characters into the atom name; either way the table entry never
+    % matched the runtime atom and dispatch silently failed).
+    switch_entry_split(Clean, KeyStr0, LabelStr),
+    switch_entry_unquote(KeyStr0, KeyStr),
     % Pack the key: integer keys use tag=1, atom keys use tag=0 with interned id.
     ( number_string(N, KeyStr)
     -> KeyTag = 1, KeyPayload = N
@@ -22014,9 +22016,10 @@ wam_object_encode(Predicates, Options0, Codes) :-
     wamo_entries_list(Predicates, Options, LabelMap, Entries),
     wamo_all_instr_parts(Records, AllParts),
     foldl(wamo_encode_step(LabelMap), AllParts,
-          ws([], tab([], 0), tab([], 0)),
-          ws(RevEnc, ATab0, FTab)),
+          ws([], 0, tab([], 0), tab([], 0), []),
+          ws(RevEnc, _, ATab0, FTab, RevSw)),
     reverse(RevEnc, EncInstrs),
+    reverse(RevSw, SwTabs),
     % A meta-call table is only needed if the object actually contains a
     % call/N meta-call (op1 = -1); interning predicate names for objects that
     % never meta-call would bloat them for no benefit (pay-for-what-you-use).
@@ -22028,7 +22031,7 @@ wam_object_encode(Predicates, Options0, Codes) :-
     wamo_table_list(FTab, Functors),
     findall(PC, member(_-PC, NamePCPairs), PCs),
     wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs,
-                   MetaRows, Codes).
+                   MetaRows, SwTabs, Codes).
 
 %% wamo_has_meta_call(+EncInstrs) is semidet.
 %  True if any encoded call/execute dispatches a goal through the object's
@@ -22155,8 +22158,94 @@ wamo_table_list(tab(Pairs, _), List) :-
 
 % --- per-instruction encoding ---------------------------------------------
 
-wamo_encode_step(LabelMap, Parts, ws(E0, A0, F0), ws([Enc|E0], A1, F1)) :-
-    wamo_enc(Parts, LabelMap, A0, A1, F0, F1, Enc).
+% The fold threads the instruction PC (one WAM line = one row = one PC
+% slot, the invariant the label map depends on) and a switch-table
+% accumulator. switch_on_constant / _a2 encode as REAL dispatch rows
+% (tags 25 / 27 -- the same step cases the AOT dispatcher uses) with
+% op1/op2 left 0; their key->label tables ride a TRAILING SECTION (like
+% the meta-call table) keyed by this PC, so the code/PC/label layout is
+% untouched and the loader patches op1 = table pointer, op2 = count.
+% The *_fallthrough variants and switch_on_term / _structure stay nops,
+% exactly matching the AOT dispatcher.
+wamo_encode_step(LabelMap, Parts, ws(E0, PC, A0, F0, S0),
+                 ws([Enc|E0], PC1, A1, F1, S1)) :-
+    PC1 is PC + 1,
+    (   Parts = [Op | EntryParts],
+        wamo_switch_tag(Op, Tag)
+    ->  wamo_switch_entries(EntryParts, LabelMap, A0, A1, SwEntries),
+        F1 = F0,
+        Enc = enc(Tag, 0, 0, none),
+        S1 = [sw(PC, SwEntries) | S0]
+    ;   wamo_enc(Parts, LabelMap, A0, A1, F0, F1, Enc),
+        S1 = S0
+    ).
+
+wamo_switch_tag("switch_on_constant", 25).
+wamo_switch_tag("switch_on_constant_a2", 27).
+
+%% wamo_switch_entries(+Parts, +LabelMap, +A0, -A1, -Entries)
+%  Parse "key:label" switch entries into se(Kind, Key, LabelIdx) rows.
+%  Kind 1 = integer key (Key is the value); Kind 0 = atom key (Key is an
+%  ATOM-TABLE index -- the loader resolves it through the same relocated
+%  atomIds array as any reloc-1 operand, so the runtime payload compares
+%  equal to a relocated get_constant/A-register atom id). "default" and
+%  unresolvable labels encode as -1, the fall-through sentinel
+%  @wam_switch_on_constant already maps to "advance PC".
+wamo_switch_entries([], _, A, A, []).
+wamo_switch_entries([Part | Rest], LabelMap, A0, A,
+                    [se(Kind, Key, LabelIdx) | Es]) :-
+    clean_comma(Part, Clean),
+    switch_entry_split(Clean, KeyStr0, LabelStr),
+    switch_entry_unquote(KeyStr0, KeyStr),
+    (   number_string(N, KeyStr), integer(N)
+    ->  Kind = 1, Key = N, A1 = A0
+    ;   Kind = 0, tab_intern(KeyStr, A0, Key, A1)
+    ),
+    (   LabelStr == "default"
+    ->  LabelIdx = -1
+    ;   lookup_label_index(LabelStr, LabelMap, LabelIdx)
+    ->  true
+    ;   LabelIdx = -1
+    ),
+    wamo_switch_entries(Rest, LabelMap, A1, A, Es).
+
+%% switch_entry_split(+Part, -KeyStr, -LabelStr)
+%  Split "key:label" at the LAST colon: labels never contain colons, but
+%  quoted atom keys can ('=:=' -- a first-colon split would shear the
+%  key in half and treat its remainder as the label).
+switch_entry_split(Clean, KeyStr, LabelStr) :-
+    string_length(Clean, Len),
+    (   between(1, Len, Back),
+        Pos is Len - Back,
+        sub_string(Clean, Pos, 1, _, ":")
+    ->  sub_string(Clean, 0, Pos, _, KeyStr),
+        P1 is Pos + 1,
+        sub_string(Clean, P1, _, 0, LabelStr)
+    ;   KeyStr = Clean, LabelStr = ""
+    ).
+
+%% switch_entry_unquote(+KeyStr0, -KeyStr)
+%  The tier-2 compiler writes atom keys writeq-style: atoms needing
+%  quotes arrive as '...' with backslash escapes doubled ('=\\=').
+%  Strip the quotes and undo the escapes so the interned key matches
+%  the runtime atom exactly -- a still-quoted key would intern the
+%  quote characters into the name and the switch entry would NEVER
+%  match at dispatch time (a silent no-match means the call FAILS,
+%  since a strict switch backtracks on miss).
+switch_entry_unquote(KeyStr0, KeyStr) :-
+    (   string_concat("'", R1, KeyStr0),
+        string_concat(Body, "'", R1)
+    ->  string_codes(Body, Cs),
+        switch_unescape_codes(Cs, OutCs),
+        string_codes(KeyStr, OutCs)
+    ;   KeyStr = KeyStr0
+    ).
+
+switch_unescape_codes([], []).
+switch_unescape_codes([0'\\, C | R], [C | T]) :- !,
+    switch_unescape_codes(R, T).
+switch_unescape_codes([C | R], [C | T]) :-
+    switch_unescape_codes(R, T).
 
 %% wamo_enc(+Parts, +LabelMap, +A0, -A1, +F0, -F1, -enc(Tag,Op1,Op2,Reloc))
 %  Encode one parsed WAM instruction into the object's triple form,
@@ -22281,10 +22370,12 @@ wamo_enc(["end_aggregate", ValRegStr], _, A, A, F, F, enc(29, ValIdx, 0, none)) 
 % switch_on_term. Lifting these is the first subset-expansion step toward
 % the eval bootstrap (item 5) -- the WAM compiler's own predicates lean
 % heavily on atom-keyed clause indexing.
-% Every switch_on_* variant is an indexing optimization sitting inline before
-% the clause chain -- including the *_fallthrough forms (no-match falls through
-% to the next clause) and the first/second-argument (_a2) variants. A prefix
-% match covers the whole family; the loader runs them all as nops.
+% The remaining switch_on_* variants stay nops -- switch_on_constant and
+% switch_on_constant_a2 are intercepted upstream (wamo_encode_step) and
+% encode as REAL indexed dispatch with a trailing-section table. What
+% reaches here: the *_fallthrough forms and switch_on_term / _structure,
+% which the AOT dispatcher also runs as nop fallthroughs, so loaded
+% semantics stay exactly host semantics.
 wamo_enc([Op | _], _, A, A, F, F, enc(26, 0, 0, none)) :-
     string_concat("switch_on_", _, Op), !.
 wamo_enc(["try" | _],   _, A, A, F, F, enc(26, 0, 0, none)) :- !.
@@ -22364,9 +22455,11 @@ wamo_reloc_id(atom, 1).
 wamo_reloc_id(functor, 2).
 wamo_reloc_id(float, 3).
 
-wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs, MetaRows, Codes) :-
+wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs, MetaRows,
+               SwTabs, Codes) :-
     length(Entries, NE), length(Atoms, NA), length(Functors, NF),
     length(PCs, NL), length(EncInstrs, NC), length(MetaRows, NM),
+    length(SwTabs, NS),
     % header: magic, version, default-entry index, then the named-entry
     % table (early, so @wam_object_load can skip it without a full parse).
     % Version 2 adds a trailing meta-call table section (milestone 2 of the
@@ -22384,9 +22477,31 @@ wamo_serialize(EntryIndex, Entries, Atoms, Functors, PCs, EncInstrs, MetaRows, C
     % meta-call table: <count>\n then <atomIdx> <funIdx> <arity> <labelIdx>\n
     format(codes(MHdr), "~w\n", [NM]),
     maplist(wamo_meta_row_codes, MetaRows, MetaChunks),
+    % switch-table section (loaded clause indexing): <count>\n then per
+    % table "<pc> <n>\n" and n entry rows "<kind> <key> <labelIdx>\n".
+    % Trails the meta table, and is emitted ONLY when non-empty: the
+    % loader's wamo_next_int reads 0 at EOF, so switch-free objects stay
+    % byte-identical to the pre-section format -- which the bootstrap
+    % compiler's serializer (and its byte-exact goldens) still emit.
+    (   NS =:= 0
+    ->  SwSection = []
+    ;   format(codes(SHdr), "~w\n", [NS]),
+        maplist(wamo_switch_codes, SwTabs, SwChunks),
+        SwSection = [SHdr | SwChunks]
+    ),
     append([[Head], EntryChunks, [AHdr], AtomChunks, [FHdr], FunChunks,
-            [LHdr], PCChunks, [CHdr], InstrChunks, [MHdr], MetaChunks], Lists),
+            [LHdr], PCChunks, [CHdr], InstrChunks, [MHdr], MetaChunks,
+            SwSection], Lists),
     append(Lists, Codes).
+
+%% wamo_switch_codes(+sw(PC, Entries), -Codes)
+wamo_switch_codes(sw(PC, Entries), Codes) :-
+    length(Entries, N),
+    format(codes(Hdr), "~w ~w\n", [PC, N]),
+    maplist([se(Kind, Key, LabelIdx), Cs]>>
+                format(codes(Cs), "~w ~w ~w\n", [Kind, Key, LabelIdx]),
+            Entries, EntryChunks),
+    append([Hdr | EntryChunks], Codes).
 
 %% wamo_meta_row_codes(+row(AtomIdx,FunIdx,Arity,LabelIdx), -Codes)
 wamo_meta_row_codes(row(AtomIdx, FunIdx, Arity, LabelIdx), Cs) :-
@@ -22797,7 +22912,7 @@ mloop:
   %mi = phi i64 [ 0, %meta_init ], [ %mi1, %mstore ]
   %mcur = phi i64 [ %cur_m0, %meta_init ], [ %mcur4, %mstore ]
   %mdone = icmp uge i64 %mi, %nmeta
-  br i1 %mdone, label %build_vm, label %mstep
+  br i1 %mdone, label %sw_init, label %mstep
 mstep:
   %matom_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %mcur)
   %matomIdx = extractvalue { i64, i64 } %matom_r, 0
@@ -22836,6 +22951,86 @@ mstore:
   store i32 %mlabel32, i32* %mrow_lbl
   %mi1 = add i64 %mi, 1
   br label %mloop
+sw_init:
+  ; --- switch-table section (loaded clause indexing) ----------------------
+  ; One count NS, then per table a "pc n" pair and n entry rows of
+  ; "kind key labelIdx" (all newline-separated ints).
+  ; kind 0 = atom key (key is an atom-table index, resolved through the same
+  ; relocated atomIds array as any reloc-1 operand, so it compares equal to
+  ; relocated register payloads); kind 1 = integer key. Each table
+  ; materializes as a malloc-ed [n x %SwitchEntry] whose pointer patches
+  ; op1 (and op2 = n) of the tag-25/27 instruction at <pc> -- the exact
+  ; shape the AOT dispatcher feeds @wam_switch_on_constant(_a2), so the
+  ; SHARED step cases run loaded switches with no new dispatch code, and
+  ; label indices resolve through the loaded VM own label table via
+  ; @wam_label_pc. Objects without the section (the bootstrap compiler
+  ; emits none; pre-section v2 objects end here) read NS = 0 at EOF.
+  ; Tables follow the code array lifetime (not freed by wam_state_free,
+  ; same policy as the code/labels/meta allocations).
+  %ps = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %mcur)
+  %nsw = extractvalue { i64, i64 } %ps, 0
+  %cur_s0 = extractvalue { i64, i64 } %ps, 1
+  br label %swloop
+swloop:
+  %si = phi i64 [ 0, %sw_init ], [ %si1, %swpatch ]
+  %scur = phi i64 [ %cur_s0, %sw_init ], [ %secur, %swpatch ]
+  %sdone = icmp uge i64 %si, %nsw
+  br i1 %sdone, label %build_vm, label %swtab
+swtab:
+  %spc_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %scur)
+  %spc = extractvalue { i64, i64 } %spc_r, 0
+  %scur1 = extractvalue { i64, i64 } %spc_r, 1
+  %sn_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %scur1)
+  %sn = extractvalue { i64, i64 } %sn_r, 0
+  %scur2 = extractvalue { i64, i64 } %sn_r, 1
+  %se_sz = ptrtoint %SwitchEntry* getelementptr (%SwitchEntry, %SwitchEntry* null, i32 1) to i64
+  %stab_bytes = mul i64 %sn, %se_sz
+  %stab_mem = call i8* @malloc(i64 %stab_bytes)
+  %stab = bitcast i8* %stab_mem to %SwitchEntry*
+  br label %seloop
+seloop:
+  %sei = phi i64 [ 0, %swtab ], [ %sei1, %sestore ]
+  %secur = phi i64 [ %scur2, %swtab ], [ %secur3, %sestore ]
+  %sedone = icmp uge i64 %sei, %sn
+  br i1 %sedone, label %swpatch, label %sestep
+sestep:
+  %sk_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %secur)
+  %skind = extractvalue { i64, i64 } %sk_r, 0
+  %secur1 = extractvalue { i64, i64 } %sk_r, 1
+  %skey_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %secur1)
+  %skey = extractvalue { i64, i64 } %skey_r, 0
+  %secur2 = extractvalue { i64, i64 } %skey_r, 1
+  %slbl_r = call { i64, i64 } @wamo_next_int(i8* %bufc, i64 %total, i64 %secur2)
+  %slbl = extractvalue { i64, i64 } %slbl_r, 0
+  %secur3 = extractvalue { i64, i64 } %slbl_r, 1
+  %sk_is_atom = icmp eq i64 %skind, 0
+  br i1 %sk_is_atom, label %se_atom, label %sestore
+se_atom:
+  %sa_slot = getelementptr i64, i64* %atomIds, i64 %skey
+  %sa_id = load i64, i64* %sa_slot
+  br label %sestore
+sestore:
+  %skey_final = phi i64 [ %sa_id, %se_atom ], [ %skey, %sestep ]
+  %stag_final = phi i32 [ 0, %se_atom ], [ 1, %sestep ]
+  %sep = getelementptr %SwitchEntry, %SwitchEntry* %stab, i64 %sei
+  %sep_tag = getelementptr %SwitchEntry, %SwitchEntry* %sep, i32 0, i32 0
+  store i32 %stag_final, i32* %sep_tag
+  %sep_pay = getelementptr %SwitchEntry, %SwitchEntry* %sep, i32 0, i32 1
+  store i64 %skey_final, i64* %sep_pay
+  %sep_lbl = getelementptr %SwitchEntry, %SwitchEntry* %sep, i32 0, i32 2
+  %slbl32 = trunc i64 %slbl to i32
+  store i32 %slbl32, i32* %sep_lbl
+  %sei1 = add i64 %sei, 1
+  br label %seloop
+swpatch:
+  %swip = getelementptr %Instruction, %Instruction* %code, i64 %spc
+  %swip_op1 = getelementptr %Instruction, %Instruction* %swip, i32 0, i32 1
+  %stab_i = ptrtoint %SwitchEntry* %stab to i64
+  store i64 %stab_i, i64* %swip_op1
+  %swip_op2 = getelementptr %Instruction, %Instruction* %swip, i32 0, i32 2
+  store i64 %sn, i64* %swip_op2
+  %si1 = add i64 %si, 1
+  br label %swloop
 build_vm:
   ; entry pc = labels[entry_idx]
   %eslot = getelementptr i32, i32* %labels, i64 %entry_idx64

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -370,6 +370,31 @@ dlknot(R) :-
 knot9(A, A).
 em9(V, A0, A1) :- append([V], A1, A0).
 
+% Loaded clause indexing: swkey/2 is an atom-keyed multi-clause predicate
+% large enough for the tier-2 compiler to emit switch_on_constant --
+% including writeq-QUOTED keys ('=:=', '\==') whose table entries only
+% match if the writer unquotes them (switch_entry_unquote/2; a quoted key
+% interns its quote characters into the atom name and NEVER matches).
+% swmain probes: two quoted keys, a bare key, a MISSING key inside an
+% if-then-else (a strict switch miss backtracks -- the call must fail
+% cleanly into the else branch), and an UNBOUND first argument (the
+% switch skips and the try_me_else chain runs -- first clause binds).
+swkey(functor, 26).
+swkey(arg, 27).
+swkey('=:=', 5).
+swkey('\\==', 21).
+swkey(append, 55).
+swkey(length, 31).
+swkey(sort, 81).
+swkey(between, 23).
+swmain(R) :-
+    swkey('=:=', A),
+    swkey('\\==', B),
+    swkey(append, C),
+    ( swkey(nosuchkey, _) -> D = 1 ; D = 2 ),
+    ( swkey(K0, 26), K0 == functor -> E = 3 ; E = 4 ),
+    R is (((A * 100 + B) * 100 + C) * 10 + D) * 10 + E.  % 5215523
+
 % Milestone 3b-db PR 3: rule bodies. assertz((H :- B)) stores a rule; calling
 % its head runs the body (deterministic first solution). Bodies handle ,/2,
 % builtins (is/2, comparisons, =/2), and predicate calls; head<->body variable
@@ -1651,6 +1676,27 @@ test(register_file_many_permanents, [condition(clang_available)]) :-
     write_wam_object([user:manyperm/1], [wamo_entry(manyperm/1)], W),
     run_host(Host, W, Out, 0),
     assertion(Out == "210\n"),
+    !.
+
+% Loaded clause indexing: switch_on_constant is REAL dispatch in loaded
+% objects now (tag 25 + a trailing key->label table the loader turns
+% into the same %SwitchEntry shape the AOT dispatcher uses). swmain/1
+% exercises quoted-key entries ('=:=', '\==' -- only match if the writer
+% unquoted them), a strict switch MISS failing cleanly into an ITE else
+% branch, and an unbound first argument skipping the switch into the
+% try_me_else chain. The structural assertions pin the encoding: a real
+% tag-25 row (not the old nop 26) and the trailing section present.
+test(loaded_switch_on_constant_dispatch, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'host_bin', Host),
+    ( exists_file(Host) -> true ; build_host(Dir, Host) ),
+    directory_file_path(Dir, 'swkey.wamo', W),
+    write_wam_object([user:swmain/1, user:swkey/2],
+                     [wamo_entry(swmain/1)], W),
+    read_file_to_string(W, WS, [encoding(octet)]),
+    assertion(sub_string(WS, _, _, _, "\n25 0 0 0\n")),
+    run_host(Host, W, Out, 0),
+    assertion(Out == "5215523\n"),
     !.
 
 % Finding no. 9: get_value var-var linking + append bare-var tail seed


### PR DESCRIPTION
## Round 1 of 4: the "correctness-first, speed-later" debt comes due

Loaded objects ran **unindexed** through the whole eval campaign — milestone 1 lifted every `switch_on_*` variant into the loadable subset as a nop-fallthrough, so each call walked the full `try_me_else` chain. With the fixpoint closed and `compile()` making runtime-loaded grammars first-class, this round makes `switch_on_constant` / `_a2` **real indexed dispatch** in loaded objects.

### Design

- **Writer**: the two constant switches encode as real dispatch rows (tags 25/27 — the same step cases the AOT dispatcher uses) with `op1`/`op2` zeroed; their key→label tables ride a **trailing `.wamo` section** (the meta-call-table precedent), keyed by instruction PC — the one-line-one-PC layout the label map depends on is untouched. The section is emitted **only when non-empty**: switch-free objects — including everything the bootstrap compiler's own serializer emits — stay byte-identical to the pre-section format (every fixpoint golden and checksum holds), and old objects load with the new loader unchanged (`wamo_next_int` reads 0 at EOF).
- **Loader**: each section row materializes as a `[n x %SwitchEntry]` — atom keys resolved through the object's relocated atom ids, integer keys verbatim — patching `op1 = table pointer, op2 = count` at the recorded PC. Label indices resolve against the loaded VM's **own** label table via `@wam_label_pc`, so the shared `@wam_switch_on_constant(_a2)` helpers run loaded switches with **no new dispatch code**. Strict-miss backtracks and unbound-argument skip are exactly the AOT semantics. `switch_on_term`/`_structure` and the `*_fallthrough` variants stay nops — matching the AOT dispatcher, which nops them too.

### Latent AOT bug fixed on the way

The switch-entry parser split `key:label` at the **first** colon and never unquoted writeq-style keys, so table entries for quoted atoms (`'=:='`, `'\=='`) sheared in half or interned their quote characters into the atom name — either way the entry never matched at runtime and a strict switch **silently failed the call**. Both the `.wamo` writer and the AOT `parse_switch_entries` now share `switch_entry_split/3` (last colon) and `switch_entry_unquote/2` (strip quotes, undo doubled backslashes).

### Performance

- **7.6×** on the workload indexing is for: a 200-clause atom-keyed fact table probed 20 000 times at its *last* key — 25 ms vs 189 ms end to end (same binary, tables stripped for the control), identical output.
- The self-compile (dispatch-light, append-heavy) gains ~4% with **byte-identical** generations — the A/B compared the indexed compiler object against a table-stripped copy and the emitted objects matched byte-for-byte.

### Tests

- New `loaded_switch_on_constant_dispatch`: quoted-key dispatch (`'=:='`, `'\=='`), a strict switch miss failing cleanly into an if-then-else else branch, an unbound first argument skipping into the chain, plus structural assertions that the object carries a real tag-25 row and the trailing section.
- Full battery green fresh-cache: entire `wam_object` suite (including the self-host fixpoint chain — gen2 == gen3 still holds since bootstrap-emitted objects are section-free by construction), `test_llvm_target` (FAIL count 0), plawk `dyncall`/`dyncall_at`/`eval-compile`/`stream` suites, and the `switch`/`multi_result_dispatch`/A*/Dijkstra/countdown execution suites.

### Docs

`PLAWK_EVAL_BOOTSTRAP.md` — "Why indexing dispatch is a safe nop" now documents the landed design and the quoted-key finding; the "correctness-first, speed-later" cross-cutting note marks the "later" as arrived. Roadmap milestone 1 updated to "LANDED, now REAL dispatch".

Next in the agreed sequence: round 2 — blob slices beyond print position (`writebin`, equality guards, assoc keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_