### PR TITLE
Add SimpleMind Product-Kalman campaign sampler

### DIFF
--- a/prototypes/mu_cosine/DESIGN_product_kalman_cross_corpus_campaign.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_cross_corpus_campaign.md
@@ -171,7 +171,9 @@ counts, root IDs, graph-view rules, correction-manifest hash, model/judge identi
    and title-audit manifests before scoring.
 3. Use `sample_product_kalman_pearltrees_campaign.py` for the path-local Pearltrees primary view; keep its
    cross-record conflict exclusions and title aliases in the manifest.
-4. Add the SimpleMind cleaned within-map adapter with the same campaign output schema.
+4. Use `sample_product_kalman_simplemind_campaign.py` for the cleaned within-map SimpleMind primary view. It
+   classifies structural labels case-insensitively, excludes secondary ancestry, preserves identity aliases, and
+   emits the same hop-balanced unscored campaign schema.
 5. Freeze any title-correction manifests.
 6. Score all raw-title views with the same judge and model, then run matched audited-title sensitivities.
 7. Evaluate each corpus separately, followed by explicit cross-corpus and domain-transfer summaries.

--- a/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
+++ b/prototypes/mu_cosine/DESIGN_product_kalman_poe.md
@@ -454,6 +454,11 @@ remaining D-channel shape defect as model-side relation-class structure rather t
   hop-balanced sampling within recorded principal paths, with cross-record conflicts excluded and source title
   aliases preserved.
 - `REPORT_product_kalman_pearltrees_sampling.md` - durable unscored Pearltrees sampling and source-audit summary.
+- `sample_product_kalman_simplemind_campaign.py` and `test_product_kalman_simplemind_campaign.py` - deterministic,
+  hop-balanced sampling from content-rooted within-map principal paths, with structural/secondary ancestry and
+  direction/hop conflicts excluded while raw title and cross-corpus identity metadata remain auditable.
+- `REPORT_product_kalman_simplemind_sampling.md` - durable unscored SimpleMind pilot sampling and source-audit
+  summary, including deep-hop map concentration and raw-title typo guardrails.
 - `DESIGN_uncertainty_estimation_playbook.md` — current rule: learned calibrated combiner, held-out node-disjoint,
   margin gate, and PoE as a control rather than an independence assumption.
 - `REPORT_mu_posterior.md` — empirical evidence that joint heads beat factored PoE under correlated readouts.

--- a/prototypes/mu_cosine/REPORT_product_kalman_simplemind_sampling.md
+++ b/prototypes/mu_cosine/REPORT_product_kalman_simplemind_sampling.md
@@ -1,0 +1,109 @@
+# SimpleMind Product-Kalman Campaign Sampling
+
+Status: pre-scoring exploratory artifact. No judge labels or Product-Kalman result were produced in this run.
+
+## Primary View
+
+The primary SimpleMind view is the plain parent hierarchy within each map. Blank containers are bypassed, but
+`See Also`, `Via Link`, `Related`, super-category, navigation, wiki-anchor, explicit-relation, and cross-map edges
+do not enter the primary lineage. Structural labels are classified case-insensitively because the source maps use
+variants such as `super Categories` and `via link`.
+
+Only chains ending at the map's content root are retained. A private topic removes its entire raw subtree before
+endpoint metadata is assembled. Maps with private, sentinel, or conflicted-copy roots are excluded. Repeated
+consecutive title identities collapse; nonconsecutive repeats and endpoint pairs with conflicting direction or hop
+across path observations are excluded rather than resolved post hoc.
+
+## Source
+
+The pilot uses the six systems-theory maps available in `prototypes/mu_cosine/context/`.
+
+| map | bytes | SHA-256 |
+| --- | ---: | --- |
+| `Chaos theory.smmx` | 3,341 | `95f64197b7923c0ce7da41c78732b3f073cacc49731f34cd76d794219c2135f6` |
+| `Complex systems theory.smmx` | 4,536 | `7ff88d4f27add6853affaf81b620545dad0ecd7b2d00b00f07ed0d5b4e0c46aa` |
+| `Cybernetics.smmx` | 2,983 | `612f7612cffb6487fbe124ba914d4ce0d38d02e40f37f15a14bd2be068be16a8` |
+| `Dynamical systems.smmx` | 5,108 | `12eb0282b5b47f0e4d57fc59091f1684034a71c8fda412d028abbc3ea891588c` |
+| `Engineering.smmx` | 23,846 | `49d9c6963c9d4d46e48d54892dc9dd6f82db8ce59c8539cc17b0bef44f1e32c1` |
+| `LTI System Theory.smmx` | 65,167 | `9addc45279a0f50e12616123f6da5a4712d92ee719177cc26ac76905d1a7b5dc` |
+
+Command:
+
+```bash
+python3 prototypes/mu_cosine/sample_product_kalman_simplemind_campaign.py \
+  --maps \
+    prototypes/mu_cosine/context/Chaos\ theory.smmx \
+    prototypes/mu_cosine/context/Complex\ systems\ theory.smmx \
+    prototypes/mu_cosine/context/Cybernetics.smmx \
+    prototypes/mu_cosine/context/Dynamical\ systems.smmx \
+    prototypes/mu_cosine/context/Engineering.smmx \
+    prototypes/mu_cosine/context/LTI\ System\ Theory.smmx \
+  --pairs 250 --hmax 5 --seed 0 \
+  --pairs-tsv /tmp/mu_data/simplemind_campaign_pairs_unscored.tsv \
+  --score-in /tmp/mu_data/simplemind_campaign_score_in_unscored.tsv \
+  --manifest /tmp/mu_data/simplemind_campaign_manifest_unscored.json
+```
+
+## Source Audit
+
+| measurement | value |
+| --- | ---: |
+| maps retained | 6 of 6 |
+| raw topics | 685 |
+| primary-view real topics | 521 |
+| structural containers | 161 |
+| content-rooted path records | 370 |
+| cross-map link annotations retained as provenance, not edges | 150 |
+| explicit relations excluded from the primary view | 7 |
+| wiki anchors excluded as nodes, retained as endpoint aliases | 3 |
+| see-also ancestry rejections | 62 |
+| super-category ancestry rejections | 33 |
+| endpoint pairs rejected for direction conflict | 1 |
+| endpoint pairs rejected for hop conflict | 11 |
+
+The eligible pools after conflict removal contain 334, 296, 244, 171, and 106 pairs at hops 1 through 5.
+No structural endpoint (`via link`, `see also`, `related`, or super-category label) remains in the selected table.
+
+## Sample
+
+The emitted table contains 250 unique unordered endpoint pairs, with 50 pairs at each hop from 1 through 5.
+Sampling is deterministic and round-robins across maps while a map has eligible candidates.
+
+| hop | eligible pool | maps represented | largest map contribution |
+| ---: | ---: | ---: | ---: |
+| 1 | 334 | 6 | 10 |
+| 2 | 296 | 6 | 11 |
+| 3 | 244 | 6 | 22 |
+| 4 | 171 | 5 | 34 |
+| 5 | 106 | 5 | 38 |
+
+Engineering contributes 38 of the 50 hop-5 rows. This concentration is a property of the available clean deep
+paths, not a confidence signal. Later evaluation must report per-map sensitivity and must not interpret a pooled
+deep-hop effect as map-invariant.
+
+The selected rows contain 174 unique endpoint identities, 174 unique normalized titles, and 174 unique raw titles.
+Their identity overlay contains 145 Pearltrees slugs, three raw-title aliases, and one selected enwiki alias.
+The deterministic formatting audit found no duplicate normalized-title groups or encoding defects. That audit is
+not a spelling checker: raw typos such as `Differentail Equation` remain deliberately unchanged. Pearltrees slugs,
+enwiki aliases, raw topic IDs, source-map IDs, and title aliases are preserved for later identity closure and
+audited-title sensitivity analysis. No semantic corrections were applied.
+
+## Ephemeral Artifacts
+
+| artifact | SHA-256 |
+| --- | --- |
+| `/tmp/mu_data/simplemind_campaign_pairs_unscored.tsv` | `2a81438a51360d48fe8b3a4a74e17850fc61e4e61a2e1be0d06b6b2a530eb43e` |
+| `/tmp/mu_data/simplemind_campaign_score_in_unscored.tsv` | `1768dbc2ebbba6a38b5036daf704e30594bbf86ce6e84120ecf89c377c750b7f` |
+| `/tmp/mu_data/simplemind_campaign_manifest_unscored.json` | `cea70e1b89865da27fc5e62a6217fde90fb7f4c8bf407943684e994a62bbc3af` |
+
+These files are local and ephemeral. The committed sampler, source fingerprints, seed, and command are the durable
+regeneration anchors.
+
+## Interpretation Guardrails
+
+- The sample is judge-ready, not scored evidence.
+- Within-map principal paths do not establish that SimpleMind is more tree-like or calibrates better than enwiki.
+- Raw typos are a title-channel property, not evidence of lateral semantic drift.
+- Structural and cross-map relations remain secondary sensitivity views; they are not silently mixed into hop.
+- Product-Kalman still requires identity-disjoint calibration/evaluation and comparison with the registered
+  `JointPosterior` baseline on held-out NLL, calibration, and selective risk.

--- a/prototypes/mu_cosine/SKILL_understand_smmx.md
+++ b/prototypes/mu_cosine/SKILL_understand_smmx.md
@@ -117,6 +117,15 @@ Read `map_edges.tsv` instead of eyeballing the XML. (Run with no `--out-prefix` 
 edges on stdout.) The tool applies exactly the rules above; use it to avoid mistakes on large maps, and use
 the by-hand rules to sanity-check or when only XML is pasted to you.
 
+### Product-Kalman campaign primary view
+
+For the cross-corpus campaign, use `sample_product_kalman_simplemind_campaign.py`, not the parser's full typed-edge
+union. Its primary graph is only the plain, content-rooted within-map parent hierarchy, with blank containers
+bypassed. It excludes `See Also`/`Via Link`/`Related`, super-category, navigation, wiki-anchor, explicit-relation,
+and cross-map edges from hop calculations. Structural labels are matched case-insensitively because real maps use
+mixed-case variants. Raw titles, topic IDs, Pearltrees slugs, enwiki aliases, and title aliases remain in the output for
+identity closure and audited-title sensitivity; title typos are not silently corrected.
+
 ---
 
 ## For vision-capable models: render the map to an image

--- a/prototypes/mu_cosine/sample_product_kalman_simplemind_campaign.py
+++ b/prototypes/mu_cosine/sample_product_kalman_simplemind_campaign.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""Sample a hop-balanced SimpleMind campaign from within-map principal paths.
+
+Only plain hierarchy edges, with blank structural containers bypassed, enter the
+primary view. See-also, super-category, navigation, explicit-relation, and
+cross-map edges remain available to later sensitivity analyses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import unicodedata
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from parse_smmx import (
+    NAV_LABEL,
+    SEE_ALSO,
+    SUPER,
+    WIKI_LABEL,
+    cloud_of,
+    label,
+    load_xml,
+    slug_of,
+    wiki_of,
+)
+from privacy import is_private_title, propagate
+from sample_product_kalman_enwiki_campaign import (
+    load_excluded_titles,
+    normalize_title,
+    title_audit,
+    title_quality_flags,
+    write_json_atomic,
+)
+from sample_sigma_hop_fresh_corpus import FreshCorpusError, hop_targets
+
+
+SCHEMA_VERSION = 1
+CORPUS = "simplemind"
+GRAPH_VIEW = "within_map_principal_path"
+CONFLICTED_COPY = re.compile(r"\b(?:conflicted|conflicting) copy\b", re.IGNORECASE)
+SENTINEL_ROOTS = {"root node", "root_node"}
+
+
+def sha256_path(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def canonical_title(title):
+    text = unicodedata.normalize("NFKC", str(title)).replace("_", " ").replace("-", " ")
+    return " ".join(text.split()).casefold()
+
+
+SEE_ALSO_IDENTITIES = {canonical_title(title) for title in SEE_ALSO}
+SUPER_IDENTITIES = {canonical_title(title) for title in SUPER}
+
+
+def structural_kind(title):
+    identity = canonical_title(title)
+    if not identity:
+        return "blank"
+    if identity in SEE_ALSO_IDENTITIES:
+        return "see_also"
+    if identity in SUPER_IDENTITIES:
+        return "super_category"
+    return None
+
+
+def map_id(path, digest):
+    return f"{Path(path).stem}:{digest[:12]}"
+
+
+def _merge_endpoint_metadata(endpoint, others):
+    titles = {endpoint["title"], *endpoint["title_aliases"]}
+    topic_ids = set(endpoint["topic_ids"])
+    slugs = set(endpoint["pearltrees_slugs"])
+    enwiki_aliases = set(endpoint["enwiki_aliases"])
+    flags = set(endpoint["quality_flags"])
+    for other in others:
+        titles.add(other["title"])
+        titles.update(other["title_aliases"])
+        topic_ids.update(other["topic_ids"])
+        slugs.update(other["pearltrees_slugs"])
+        enwiki_aliases.update(other["enwiki_aliases"])
+        flags.update(other["quality_flags"])
+    out = dict(endpoint)
+    out["title_aliases"] = tuple(sorted(titles - {endpoint["title"]}, key=lambda value: (value.casefold(), value)))
+    out["topic_ids"] = tuple(sorted(topic_ids))
+    out["pearltrees_slugs"] = tuple(sorted(slugs))
+    out["enwiki_aliases"] = tuple(sorted(enwiki_aliases))
+    out["quality_flags"] = tuple(sorted(flags))
+    return out
+
+
+def _topic_endpoint(topic_id, topic, metadata):
+    title = label(topic)
+    identity = canonical_title(title)
+    if not identity:
+        return None
+    group = metadata[identity]
+    all_titles = set(group["titles"])
+    return {
+        "id": f"title:{identity}",
+        "identity": identity,
+        "title": title,
+        "title_aliases": tuple(sorted(all_titles - {title}, key=lambda value: (value.casefold(), value))),
+        "normalized_title": normalize_title(title),
+        "topic_ids": tuple(sorted(group["topic_ids"])),
+        "pearltrees_slugs": tuple(sorted(group["pearltrees_slugs"])),
+        "enwiki_aliases": tuple(sorted(group["enwiki_aliases"])),
+        "quality_flags": tuple(sorted({
+            flag
+            for raw_title in all_titles
+            for flag in title_quality_flags(raw_title)
+        })),
+    }
+
+
+def parse_primary_map(path):
+    path = Path(path)
+    digest = sha256_path(path)
+    source = {
+        "path": str(path),
+        "size": path.stat().st_size,
+        "mtime_ns": path.stat().st_mtime_ns,
+        "sha256": digest,
+        "map_id": map_id(path, digest),
+    }
+    root = load_xml(str(path))
+    topic_list = root.findall(".//topic")
+    topics = {}
+    for topic in topic_list:
+        topic_id = topic.get("id")
+        if not topic_id:
+            continue
+        if topic_id in topics:
+            raise FreshCorpusError(f"{path}: duplicate topic id {topic_id}")
+        topics[topic_id] = topic
+    parent = {topic_id: topic.get("parent") for topic_id, topic in topics.items()}
+    root_ids = sorted(topic_id for topic_id in topics if parent.get(topic_id) in (None, "-1"))
+    if len(root_ids) != 1:
+        raise FreshCorpusError(f"{path}: expected one map root, found {len(root_ids)}")
+    root_id = root_ids[0]
+    root_title = label(topics[root_id])
+    source["root_topic_id"] = root_id
+    source["root_title"] = root_title
+
+    children = defaultdict(list)
+    for topic_id, parent_id in parent.items():
+        children[parent_id].append(topic_id)
+    private_seed = {topic_id for topic_id, topic in topics.items() if is_private_title(label(topic))}
+    private_ids = propagate(private_seed, children)
+    if root_id in private_ids:
+        source["status"] = "excluded_private_root"
+        return [], source, {"map_excluded_private_root": 1}
+    if CONFLICTED_COPY.search(path.name) or CONFLICTED_COPY.search(root_title):
+        source["status"] = "excluded_conflicted_copy"
+        return [], source, {"map_excluded_conflicted_copy": 1}
+    if root_title.strip().casefold() in SENTINEL_ROOTS:
+        source["status"] = "excluded_sentinel_root"
+        return [], source, {"map_excluded_sentinel_root": 1}
+
+    anchor_ids = {
+        topic_id
+        for topic_id, topic in topics.items()
+        if WIKI_LABEL.match(label(topic)) and wiki_of(topic) and parent.get(topic_id) in topics
+    }
+    container_ids = {
+        topic_id for topic_id, topic in topics.items()
+        if structural_kind(label(topic)) is not None
+    }
+    navigation_ids = {topic_id for topic_id, topic in topics.items() if NAV_LABEL.match(label(topic))}
+    real_ids = set(topics) - private_ids - anchor_ids - container_ids - navigation_ids
+    if root_id not in real_ids:
+        source["status"] = "excluded_noncontent_root"
+        return [], source, {"map_excluded_noncontent_root": 1}
+
+    enwiki_by_topic = defaultdict(set)
+    for topic_id, topic in topics.items():
+        enwiki_title = wiki_of(topic)
+        if not enwiki_title:
+            continue
+        endpoint_id = parent.get(topic_id) if topic_id in anchor_ids else topic_id
+        if endpoint_id in real_ids:
+            enwiki_by_topic[endpoint_id].add(enwiki_title)
+
+    metadata = defaultdict(lambda: {
+        "titles": set(),
+        "topic_ids": set(),
+        "pearltrees_slugs": set(),
+        "enwiki_aliases": set(),
+    })
+    for topic_id in real_ids:
+        title = label(topics[topic_id])
+        identity = canonical_title(title)
+        if not identity:
+            continue
+        slug, _pearltrees_id = slug_of(topics[topic_id])
+        metadata[identity]["titles"].add(title)
+        metadata[identity]["topic_ids"].add(topic_id)
+        if slug:
+            metadata[identity]["pearltrees_slugs"].add(slug)
+        metadata[identity]["enwiki_aliases"].update(enwiki_by_topic[topic_id])
+
+    primary_parent = {}
+    edge_rejections = Counter()
+    for topic_id in sorted(real_ids):
+        if topic_id == root_id:
+            continue
+        parent_id = parent.get(topic_id)
+        reason = None
+        seen = set()
+        while parent_id in topics and parent_id not in real_ids:
+            if parent_id in seen:
+                reason = "container_cycle"
+                break
+            seen.add(parent_id)
+            if parent_id in private_ids:
+                reason = "private_ancestry"
+                break
+            if parent_id in navigation_ids:
+                reason = "navigation_ancestry"
+            elif parent_id in anchor_ids:
+                reason = "wiki_anchor_ancestry"
+            elif parent_id in container_ids:
+                kind = structural_kind(label(topics[parent_id]))
+                if kind == "see_also":
+                    reason = "see_also_ancestry"
+                elif kind == "super_category":
+                    reason = "super_category_ancestry"
+            parent_id = parent.get(parent_id)
+        if reason:
+            edge_rejections[reason] += 1
+            continue
+        if parent_id in real_ids and parent_id != topic_id:
+            primary_parent[topic_id] = parent_id
+        else:
+            edge_rejections["missing_real_parent"] += 1
+
+    records = []
+    path_rejections = Counter()
+    for topic_id in sorted(real_ids):
+        chain = [topic_id]
+        seen = {topic_id}
+        cur = topic_id
+        while cur in primary_parent:
+            cur = primary_parent[cur]
+            if cur in seen:
+                path_rejections["raw_parent_cycle"] += 1
+                chain = []
+                break
+            seen.add(cur)
+            chain.append(cur)
+        if not chain or chain[-1] != root_id:
+            path_rejections["non_content_rooted"] += 1
+            continue
+        chain.reverse()
+        endpoints = []
+        endpoint_identities = set()
+        repeated = False
+        for raw_topic_id in chain:
+            endpoint = _topic_endpoint(raw_topic_id, topics[raw_topic_id], metadata)
+            if endpoint is None:
+                repeated = True
+                break
+            if endpoints and endpoint["id"] == endpoints[-1]["id"]:
+                endpoints[-1] = _merge_endpoint_metadata(endpoints[-1], [endpoint])
+                continue
+            if endpoint["id"] in endpoint_identities:
+                repeated = True
+                break
+            endpoint_identities.add(endpoint["id"])
+            endpoints.append(endpoint)
+        if repeated:
+            path_rejections["repeated_nonconsecutive_identity"] += 1
+            continue
+        if len(endpoints) < 2:
+            path_rejections["short_after_identity_collapse"] += 1
+            continue
+        records.append({
+            "map_id": source["map_id"],
+            "map_title": root_title,
+            "source_topic_id": topic_id,
+            "endpoints": tuple(endpoints),
+        })
+
+    source["status"] = "retained"
+    source["stats"] = {
+        "topics": len(topics),
+        "real_topics": len(real_ids),
+        "private_topics": len(private_ids),
+        "structural_containers": len(container_ids),
+        "wiki_anchor_topics": len(anchor_ids),
+        "navigation_topics": len(navigation_ids),
+        "cross_map_link_topics": sum(bool(cloud_of(topic)[0]) for topic in topics.values()),
+        "explicit_relations": len(root.findall(".//relation")),
+        "primary_parent_edges": len(primary_parent),
+        "path_records": len(records),
+        "edge_rejections": dict(sorted(edge_rejections.items())),
+        "path_rejections": dict(sorted(path_rejections.items())),
+    }
+    return records, source, {}
+
+
+def load_primary_maps(paths):
+    records = []
+    sources = []
+    stats = Counter()
+    for path in sorted({Path(path) for path in paths}, key=lambda value: str(value)):
+        map_records, source, excluded = parse_primary_map(path)
+        records.extend(map_records)
+        sources.append(source)
+        stats.update(excluded)
+    stats["maps_total"] = len(sources)
+    stats["maps_retained"] = sum(source.get("status") == "retained" for source in sources)
+    stats["path_records"] = len(records)
+    return {"records": records, "sources": sources, "stats": dict(sorted(stats.items()))}
+
+
+def candidate_rank(seed, hop, map_identifier, descendant_id, ancestor_id):
+    payload = f"{seed}:{hop}:{map_identifier}:{descendant_id}:{ancestor_id}".encode("utf-8")
+    return hashlib.blake2b(payload, digest_size=16).digest()
+
+
+def candidate_pools(dataset, hmax, seed, excluded_titles=()):
+    observations = defaultdict(list)
+    rejected = Counter()
+    excluded_titles = {normalize_title(title) for title in excluded_titles}
+    for record in dataset["records"]:
+        endpoints = record["endpoints"]
+        for index in range(1, len(endpoints)):
+            descendant = endpoints[index]
+            if descendant["normalized_title"] in excluded_titles:
+                rejected["excluded_descendant_title"] += 1
+                continue
+            for hop in range(1, min(hmax, index) + 1):
+                ancestor = endpoints[index - hop]
+                if ancestor["normalized_title"] in excluded_titles:
+                    rejected["excluded_ancestor_title"] += 1
+                    continue
+                unordered = tuple(sorted((descendant["id"], ancestor["id"])))
+                observations[unordered].append({
+                    "map_id": record["map_id"],
+                    "map_title": record["map_title"],
+                    "source_topic_id": record["source_topic_id"],
+                    "descendant": descendant,
+                    "ancestor": ancestor,
+                    "hop": hop,
+                })
+
+    pools = {hop: defaultdict(list) for hop in range(1, hmax + 1)}
+    conflict_examples = []
+    for unordered in sorted(observations):
+        seen = observations[unordered]
+        orientations = {(row["descendant"]["id"], row["ancestor"]["id"]) for row in seen}
+        hops = {row["hop"] for row in seen}
+        if len(orientations) > 1:
+            rejected["direction_conflict_pairs"] += 1
+            rejected["direction_conflict_observations"] += len(seen)
+            if len(conflict_examples) < 20:
+                conflict_examples.append({
+                    "kind": "direction",
+                    "endpoint_ids": list(unordered),
+                    "orientations": [
+                        {
+                            "descendant_id": direction[0],
+                            "ancestor_id": direction[1],
+                            "observation_count": sum(
+                                (item["descendant"]["id"], item["ancestor"]["id"]) == direction
+                                for item in seen
+                            ),
+                        }
+                        for direction in sorted(orientations)
+                    ],
+                })
+            continue
+        if len(hops) > 1:
+            rejected["hop_conflict_pairs"] += 1
+            rejected["hop_conflict_observations"] += len(seen)
+            if len(conflict_examples) < 20:
+                conflict_examples.append({
+                    "kind": "hop",
+                    "endpoint_ids": list(unordered),
+                    "observed_hops": sorted(hops),
+                    "observation_count": len(seen),
+                })
+            continue
+        provenance = sorted(
+            seen,
+            key=lambda row: (row["map_id"], row["source_topic_id"], row["descendant"]["id"]),
+        )
+        row = dict(provenance[0])
+        row["source_map_ids"] = tuple(sorted({item["map_id"] for item in provenance}))
+        row["source_topic_ids"] = tuple(sorted({item["source_topic_id"] for item in provenance}))
+        row["source_record_count"] = len(provenance)
+        row["descendant"] = _merge_endpoint_metadata(
+            row["descendant"], [item["descendant"] for item in provenance[1:]]
+        )
+        row["ancestor"] = _merge_endpoint_metadata(
+            row["ancestor"], [item["ancestor"] for item in provenance[1:]]
+        )
+        rejected["duplicate_consistent_observations"] += len(provenance) - 1
+        pools[row["hop"]][row["map_id"]].append(row)
+
+    for hop, by_map in pools.items():
+        for map_identifier, rows in by_map.items():
+            rows.sort(key=lambda row: (
+                candidate_rank(seed, hop, map_identifier, row["descendant"]["id"], row["ancestor"]["id"]),
+                row["descendant"]["id"],
+                row["ancestor"]["id"],
+            ))
+    return pools, dict(sorted(rejected.items())), conflict_examples
+
+
+def sample_campaign_pairs(dataset, pairs=250, hmax=5, seed=0, excluded_titles=()):
+    if pairs <= 0 or hmax <= 0:
+        raise FreshCorpusError("pairs and hmax must be positive")
+    targets = hop_targets(pairs, hmax)
+    pools, rejected, conflict_examples = candidate_pools(dataset, hmax, seed, excluded_titles)
+    rows = []
+    accepted_by_hop_map = defaultdict(Counter)
+    pool_counts = {}
+    for hop in range(1, hmax + 1):
+        maps = sorted(
+            pools[hop],
+            key=lambda identifier: (pools[hop][identifier][0]["map_title"].casefold(), identifier),
+        )
+        queues = {identifier: list(pools[hop][identifier]) for identifier in maps}
+        pool_counts[str(hop)] = sum(len(queue) for queue in queues.values())
+        accepted = 0
+        while accepted < targets[hop]:
+            progressed = False
+            for identifier in maps:
+                if accepted >= targets[hop]:
+                    break
+                if not queues[identifier]:
+                    continue
+                row = queues[identifier].pop(0)
+                row.update({
+                    "pair_id": f"simplemind-h{hop}-{accepted:04d}",
+                    "corpus": CORPUS,
+                    "graph_view": GRAPH_VIEW,
+                    "branch_id": identifier,
+                    "branch_title": row["map_title"],
+                })
+                rows.append(row)
+                accepted_by_hop_map[hop][identifier] += 1
+                accepted += 1
+                progressed = True
+            if not progressed:
+                break
+        if accepted < targets[hop]:
+            raise FreshCorpusError(
+                f"hop {hop} has {pool_counts[str(hop)]} eligible within-map pairs; need {targets[hop]}"
+            )
+    return rows, {
+        "target_hop_counts": {str(hop): targets[hop] for hop in sorted(targets)},
+        "hop_counts": {str(hop): sum(row["hop"] == hop for row in rows) for hop in sorted(targets)},
+        "candidate_pool_counts": pool_counts,
+        "candidate_rejections": rejected,
+        "candidate_conflict_examples": conflict_examples,
+        "accepted_by_hop_map": {
+            str(hop): dict(sorted(accepted_by_hop_map[hop].items()))
+            for hop in sorted(targets)
+        },
+    }
+
+
+def _json_list(values):
+    return json.dumps(tuple(values), ensure_ascii=False)
+
+
+def write_pairs_tsv(path, rows):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "pair_id", "corpus", "graph_view", "branch_id", "branch_title",
+        "source_map_ids", "source_topic_ids", "source_record_count",
+        "descendant_id", "descendant_title", "descendant_title_aliases",
+        "descendant_topic_ids", "descendant_pearltrees_slugs", "descendant_enwiki_aliases",
+        "descendant_normalized_title",
+        "ancestor_id", "ancestor_title", "ancestor_title_aliases",
+        "ancestor_topic_ids", "ancestor_pearltrees_slugs", "ancestor_enwiki_aliases",
+        "ancestor_normalized_title", "hop",
+    ]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields, delimiter="\t")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({
+                "pair_id": row["pair_id"],
+                "corpus": row["corpus"],
+                "graph_view": row["graph_view"],
+                "branch_id": row["branch_id"],
+                "branch_title": row["branch_title"],
+                "source_map_ids": _json_list(row["source_map_ids"]),
+                "source_topic_ids": _json_list(row["source_topic_ids"]),
+                "source_record_count": row["source_record_count"],
+                "descendant_id": row["descendant"]["id"],
+                "descendant_title": row["descendant"]["title"],
+                "descendant_title_aliases": _json_list(row["descendant"]["title_aliases"]),
+                "descendant_topic_ids": _json_list(row["descendant"]["topic_ids"]),
+                "descendant_pearltrees_slugs": _json_list(row["descendant"]["pearltrees_slugs"]),
+                "descendant_enwiki_aliases": _json_list(row["descendant"]["enwiki_aliases"]),
+                "descendant_normalized_title": row["descendant"]["normalized_title"],
+                "ancestor_id": row["ancestor"]["id"],
+                "ancestor_title": row["ancestor"]["title"],
+                "ancestor_title_aliases": _json_list(row["ancestor"]["title_aliases"]),
+                "ancestor_topic_ids": _json_list(row["ancestor"]["topic_ids"]),
+                "ancestor_pearltrees_slugs": _json_list(row["ancestor"]["pearltrees_slugs"]),
+                "ancestor_enwiki_aliases": _json_list(row["ancestor"]["enwiki_aliases"]),
+                "ancestor_normalized_title": row["ancestor"]["normalized_title"],
+                "hop": row["hop"],
+            })
+
+
+def write_score_in(path, rows):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("# node_title\troot_title\tcur_relation\tconf\tneighborhood\tnode_type\troot_type\traw\n")
+        for row in rows:
+            f.write(
+                f"{row['descendant']['title']}\t{row['ancestor']['title']}\tsubtopic\t1.0\t"
+                f"principal_h{row['hop']}\tmindmap_node\tmindmap_node\t\n"
+            )
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--maps", nargs="+", required=True, type=Path)
+    ap.add_argument("--pairs", type=int, default=250)
+    ap.add_argument("--hmax", type=int, default=5)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--exclude-graph")
+    ap.add_argument("--pairs-tsv", required=True, type=Path)
+    ap.add_argument("--score-in", required=True, type=Path)
+    ap.add_argument("--manifest", required=True, type=Path)
+    ap.add_argument("--allow-small-sample", action="store_true")
+    args = ap.parse_args(argv)
+    if not args.allow_small_sample and args.pairs < 250:
+        ap.error("campaign sampling requires at least 250 pairs; use --allow-small-sample for tests")
+
+    dataset = load_primary_maps(args.maps)
+    excluded_titles = load_excluded_titles(args.exclude_graph)
+    rows, summary = sample_campaign_pairs(
+        dataset,
+        pairs=args.pairs,
+        hmax=args.hmax,
+        seed=args.seed,
+        excluded_titles=excluded_titles,
+    )
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "corpus": CORPUS,
+        "graph_view": GRAPH_VIEW,
+        "primary_edge_rule": "plain within-map parent hierarchy; blank containers bypassed",
+        "secondary_edge_policy": "see-also, super-category, navigation, explicit relation, and cross-map edges excluded",
+        "identity_rule": "NFKC; underscore/hyphen-to-space; whitespace-collapse; casefold",
+        "conflict_policy": "exclude identity pairs whose direction or collapsed hop differs across path records",
+        "privacy_rule": "private title removes its raw topic subtree before endpoint metadata is built",
+        "title_policy": "raw title primary; duplicate-title variants preserved as aliases; no semantic correction",
+        "sampling_method": "canonical map for duplicate observations; deterministic hash order; map round-robin",
+        "maps": dataset["sources"],
+        "dataset_stats": dataset["stats"],
+        "pairs": len(rows),
+        "hmax": args.hmax,
+        "seed": args.seed,
+        "exclude_graph": args.exclude_graph,
+        "excluded_title_count": len(excluded_titles),
+        "pairs_tsv": str(args.pairs_tsv),
+        "score_in": str(args.score_in),
+        "title_audit": title_audit(rows),
+        "identity_alias_counts": {
+            "raw_title_aliases": len({
+                value
+                for row in rows
+                for side in ("descendant", "ancestor")
+                for value in row[side]["title_aliases"]
+            }),
+            "pearltrees_slugs": len({
+                value
+                for row in rows
+                for side in ("descendant", "ancestor")
+                for value in row[side]["pearltrees_slugs"]
+            }),
+            "enwiki_aliases": len({
+                value
+                for row in rows
+                for side in ("descendant", "ancestor")
+                for value in row[side]["enwiki_aliases"]
+            }),
+        },
+    }
+    manifest.update(summary)
+    write_pairs_tsv(args.pairs_tsv, rows)
+    write_score_in(args.score_in, rows)
+    write_json_atomic(args.manifest, manifest)
+    print(f"sampled {len(rows)} SimpleMind within-map pairs")
+    print(f"pairs -> {args.pairs_tsv}")
+    print(f"score input -> {args.score_in}")
+    print(f"manifest -> {args.manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_product_kalman_simplemind_campaign.py
+++ b/prototypes/mu_cosine/test_product_kalman_simplemind_campaign.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Tests for the SimpleMind within-map campaign sampler."""
+
+import csv
+import json
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from sample_product_kalman_simplemind_campaign import (
+    candidate_pools,
+    load_primary_maps,
+    main,
+    parse_primary_map,
+)
+
+
+def add_topic(root, topic_id, parent, text, link=None, cloud=None):
+    attrs = {"id": str(topic_id), "parent": str(parent), "text": text}
+    topic = ET.SubElement(root, "topic", attrs)
+    if link:
+        ET.SubElement(topic, "link", {"urllink": link})
+    if cloud:
+        ET.SubElement(topic, "link", {"cloudmapref": cloud})
+    return topic
+
+
+def write_campaign_map(path, prefix):
+    root = ET.Element("mindmap")
+    add_topic(root, 1, -1, f"Map {prefix}")
+    add_topic(root, 2, 1, f"{prefix} node 2", link=f"https://www.pearltrees.com/s243a/{prefix.lower()}-node-2/id2")
+    add_topic(root, 50, 2, "")
+    add_topic(root, 3, 50, f"{prefix} node 3")
+    add_topic(root, 4, 3, f"{prefix} node 4")
+    add_topic(root, 5, 4, f"{prefix} node 5")
+    add_topic(root, 6, 5, f"{prefix}-node 6", cloud="../Other.smmx")
+    add_topic(root, 60, 6, f"{prefix}_node 6")
+
+    add_topic(root, 100, 1, "see also")
+    add_topic(root, 101, 100, f"{prefix} associative")
+    add_topic(root, 110, 1, "via link")
+    add_topic(root, 111, 110, f"{prefix} via-link child")
+    add_topic(root, 200, 1, "super Categories")
+    add_topic(root, 201, 200, f"{prefix} broader")
+    add_topic(root, 300, 1, "Private material")
+    add_topic(root, 301, 300, f"{prefix} hidden")
+    add_topic(root, 400, 1, "pg1")
+    add_topic(root, 401, 400, f"{prefix} navigation child")
+    add_topic(root, 500, 1, "wiki", link="https://en.wikipedia.org/wiki/Example")
+    ET.SubElement(root, "relation", {"source": "2", "target": "5"})
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def write_two_node_map(path, root_title, child_title):
+    root = ET.Element("mindmap")
+    add_topic(root, 1, -1, root_title)
+    add_topic(root, 2, 1, child_title)
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def test_primary_parser_keeps_content_paths_and_excludes_secondary_structure():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "Map A.xml"
+        write_campaign_map(path, "A")
+        records, source, excluded = parse_primary_map(path)
+        assert excluded == {}
+        assert source["status"] == "retained"
+        assert source["stats"]["private_topics"] == 2
+        assert source["stats"]["structural_containers"] == 4
+        assert source["stats"]["navigation_topics"] == 1
+        assert source["stats"]["cross_map_link_topics"] == 1
+        assert source["stats"]["explicit_relations"] == 1
+        assert source["stats"]["edge_rejections"]["see_also_ancestry"] == 2
+        assert source["stats"]["edge_rejections"]["super_category_ancestry"] == 1
+        assert source["stats"]["edge_rejections"]["navigation_ancestry"] == 1
+
+        identities = {
+            endpoint["identity"]
+            for record in records
+            for endpoint in record["endpoints"]
+        }
+        assert "a associative" not in identities
+        assert "a via link child" not in identities
+        assert "a broader" not in identities
+        assert "a hidden" not in identities
+        assert "a navigation child" not in identities
+        assert "a node 3" in identities
+        leaf = next(
+            endpoint
+            for record in records
+            for endpoint in record["endpoints"]
+            if endpoint["identity"] == "a node 6"
+        )
+        assert leaf["title_aliases"] == ("A_node 6",)
+        assert leaf["pearltrees_slugs"] == ()
+        linked = next(
+            endpoint
+            for record in records
+            for endpoint in record["endpoints"]
+            if endpoint["identity"] == "a node 2"
+        )
+        assert linked["pearltrees_slugs"] == ("a-node-2",)
+        map_root = next(
+            endpoint
+            for record in records
+            for endpoint in record["endpoints"]
+            if endpoint["identity"] == "map a"
+        )
+        assert map_root["enwiki_aliases"] == ("Example",)
+
+
+def test_cross_map_direction_conflicts_are_excluded():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        first = root / "Alpha.xml"
+        second = root / "Beta.xml"
+        write_two_node_map(first, "Alpha", "Beta")
+        write_two_node_map(second, "Beta", "Alpha")
+        dataset = load_primary_maps([first, second])
+        _pools, rejected, conflicts = candidate_pools(dataset, hmax=1, seed=0)
+        assert rejected["direction_conflict_pairs"] == 1
+        assert rejected["direction_conflict_observations"] == 2
+        assert conflicts[0]["kind"] == "direction"
+
+
+def test_cli_balances_maps_and_writes_stable_outputs():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        first = root / "Map A.xml"
+        second = root / "Map B.xml"
+        write_campaign_map(first, "A")
+        write_campaign_map(second, "B")
+        pairs = root / "pairs.tsv"
+        score = root / "score.tsv"
+        manifest = root / "manifest.json"
+        args = [
+            "--maps", str(first), str(second),
+            "--pairs", "10",
+            "--hmax", "5",
+            "--seed", "9",
+            "--pairs-tsv", str(pairs),
+            "--score-in", str(score),
+            "--manifest", str(manifest),
+            "--allow-small-sample",
+        ]
+        assert main(args) == 0
+        with open(pairs, newline="", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f, delimiter="\t"))
+        assert len(rows) == 10
+        assert {row["corpus"] for row in rows} == {"simplemind"}
+        assert {row["graph_view"] for row in rows} == {"within_map_principal_path"}
+        for hop in range(1, 6):
+            hop_rows = [row for row in rows if int(row["hop"]) == hop]
+            assert len(hop_rows) == 2
+            assert {row["branch_title"] for row in hop_rows} == {"Map A", "Map B"}
+        assert len({tuple(sorted((row["descendant_id"], row["ancestor_id"]))) for row in rows}) == 10
+        assert any(
+            "a-node-2" in row["descendant_pearltrees_slugs"]
+            or "a-node-2" in row["ancestor_pearltrees_slugs"]
+            for row in rows
+        )
+        assert any(
+            "Example" in row["descendant_enwiki_aliases"]
+            or "Example" in row["ancestor_enwiki_aliases"]
+            for row in rows
+        )
+
+        score_rows = [
+            line.rstrip("\n").split("\t")
+            for line in score.read_text(encoding="utf-8").splitlines()
+            if not line.startswith("#")
+        ]
+        assert len(score_rows) == 10
+        assert all(row[2] == "subtopic" for row in score_rows)
+        assert all(row[5:7] == ["mindmap_node", "mindmap_node"] for row in score_rows)
+
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        assert data["hop_counts"] == {str(hop): 2 for hop in range(1, 6)}
+        assert data["dataset_stats"]["maps_retained"] == 2
+        assert data["secondary_edge_policy"].startswith("see-also")
+        assert data["title_audit"]["semantic_corrections_applied"] is False
+        assert data["identity_alias_counts"]["enwiki_aliases"] == 1
+
+        first_bytes = (pairs.read_bytes(), score.read_bytes(), manifest.read_bytes())
+        assert main(args) == 0
+        assert (pairs.read_bytes(), score.read_bytes(), manifest.read_bytes()) == first_bytes
+
+
+if __name__ == "__main__":
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} SimpleMind campaign sampler tests passed")


### PR DESCRIPTION
## Summary

- Add deterministic sampling from content-rooted SimpleMind principal paths.
- Produce 250 unscored pairs balanced across hops 1 through 5.
- Exclude see-also, super-category, navigation, wiki-anchor, explicit-relation,
  private, and cross-map edges from the primary graph view.
- Preserve raw titles, aliases, topic IDs, Pearltrees slugs, and enwiki aliases
  for identity-disjoint splitting and later title-quality sensitivity analysis.
- Document the six-map source audit, conflict exclusions, and deep-hop map
  concentration.

## Results

The pilot sample contains 50 pairs at each hop. Engineering contributes 38 of
the 50 hop-5 pairs, which is recorded as a required per-map sensitivity rather
than interpreted as confidence or a corpus-wide effect.

This is a pre-scoring artifact. It contains no judge labels or Product-Kalman
performance claim.

## Validation

- `test_product_kalman_simplemind_campaign.py`: 3 passed
- `test_product_kalman_pearltrees_campaign.py`: 3 passed
- `test_product_kalman_enwiki_campaign.py`: 4 passed
- Regenerated real artifacts match the hashes in the committed report.