### PR TITLE
Support callable Rust retract/1

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -4856,6 +4856,9 @@ compile_execute_meta_builtin_to_rust(Code) :-
             self.set_reg(&format!("A{}", i + 1), arg.clone());
         }
         let saved_pc = self.pc;
+        if key == "retract/1" {
+            return self.dynamic_retract_call(saved_pc);
+        }
         if self.execute_builtin(key, arity) {
             self.pc = saved_pc;
             return true;

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -90,6 +90,37 @@ fn retract_removes_one_match_and_binds_pattern() {
 }
 
 #[test]
+fn asserted_rule_body_can_call_retract() {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("taken")]));
+    assert_clause(
+        &mut vm,
+        "assertz/1",
+        rule(
+            fact("take", vec![ub("X")]),
+            fact("retract", vec![fact("dyn", vec![ub("X")])]),
+        ),
+    );
+
+    vm.reset_query();
+    vm.code = vec![
+        Instruction::Call("take/1".to_string(), 1),
+        Instruction::Proceed,
+    ];
+    vm.labels = HashMap::new();
+    vm.set_reg_str("A1", ub("X"));
+    vm.pc = 1;
+
+    assert!(vm.run());
+    let result_raw = vm.bindings.get("X").cloned().expect("X bound");
+    assert_eq!(
+        vm.deref_heap(&vm.deref_var(&result_raw)),
+        at("taken"),
+    );
+    assert!(dyn_values(&mut vm).is_empty());
+}
+
+#[test]
 fn retract_backtracks_through_each_matching_fact() {
     let mut vm = WamState::new(vec![Instruction::Call("retract/1".to_string(), 1), Instruction::Proceed], HashMap::new());
     assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("red")]));


### PR DESCRIPTION
## Summary

- Route callable `retract/1` terms through the existing nondeterministic retract iterator.
- Allow asserted rule bodies and similar meta-call paths to retract clauses.
- Preserve outer variable bindings from the matched clause.
- Add an asserted `take/1 :- retract(dyn(X))` regression that verifies binding and removal.

The runtime change is three Rust lines inside callable-term dispatch. Ordinary WAM instruction execution is unaffected.

## Testing

- Focused generated Rust dynamic-builtin crate
- Full Rust WAM target suite
- Prolog target syntax check
- `git diff --check`