### PR TITLE
WAM/LLVM record strings: atom keys in the as-assoc container

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -182,7 +182,7 @@ Purely additive; no dependency on the other items.
 **Effort:** A landed. B is moderate (declaration table + a resolution pass +
 the reserved-name check). **Depends on:** nothing.
 
-### 4. Binary-data returns — structured records (deserialization) — *mechanism + destructure surface LANDED (numeric fields)*
+### 4. Binary-data returns — structured records (deserialization) — **LANDED (all string surfaces; string values deferred)**
 
 **What:** let a grammar return a **compound term** (e.g. `rec(42, 3.14,
 "name")`) that plawk **deserializes** into typed fields against a declared
@@ -243,9 +243,22 @@ different plawk containers — this is the through-line for the rest of item 4:
   fills `arr`'s table each record, keyed into the same assoc plan as
   `arr[k]++`, so END `arr[k]` lookups see the accumulated result. Verified:
   `tally($1) -> [1-$1, 2-100]` over inputs 5,7 gives `arr[1]=12`,
-  `arr[2]=200`. **Deferred:** the default-entry `dyncall(...) as assoc` (named
-  only for now), for-in iteration over a grammar-populated table, and
-  atom/string keys (interned — an extension of the integer-key mechanism).
+  `arr[2]=200`. **Atom/string keys LANDED:** a grammar returning
+  `[Atom-V, ...]` pairs populates the table under the atom's
+  global-registry id — the same keyspace text-mode field slices and blob
+  keys intern into — so END `for (k in arr)` reports resolve the key
+  names and `arr["literal"]` lookups intern to the same ids (verified:
+  a bucketing grammar over text records reports `big 4 / small 2 /
+  seen 4` and answers literal lookups). One key kind per table (integer
+  keys collide with atom ids — the documented text-mode ambiguity).
+  Landing this also fixed a latent text-mode bug: the dynassoc action
+  emitter DISCARDED its arg-marshal globals (text-mode field args emit
+  a fallback constant each), leaving the IR referencing undefined
+  values; they now ride the apply path's global channel (added in the
+  blob-consumers round). **Deferred:** the default-entry
+  `dyncall(...) as assoc` (named only for now), for-in iteration over a
+  grammar-populated table inside rule bodies, and string VALUES (the
+  table is an i64 accumulator).
 - **Positional array** — fields by numeric index into one array value.
 
 Each target reuses one marshaller over the same walked compound; they differ
@@ -272,9 +285,11 @@ reads (it didn't before), which now lets any rule-body print reference a
 scalar. Verified: `info(X) -> tag(X, big/small)` over 5,200,7 prints
 `small/big/small` and sums `$1` to 212.
 
-The **destructure** target still rejects string fields (no scalar to bind
-them to); the **assoc** target (string values / interned keys) is the
-remaining container.
+The **destructure** target still rejects string fields by design (no
+scalar to bind them to — the record view is the string surface); the
+**assoc** target now takes interned atom keys (see above), leaving
+string VALUES as the one string shape without a container (an i64
+table cannot hold them).
 
 **Why:** this is the *other half* of your binary-return idea — the case
 that **does** need deserialization. It is also the endgame that closes the

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3521,14 +3521,20 @@ plawk_assoc_rule_action_blocks(RuleIndex,
       format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
       format(atom(Base), 'assoc_rule_~w_action_~w_dyn', [RuleIndex, Index]),
       plawk_dynassoc_call_parts(Call, Args, ShimName),
+      % arg-marshal globals (text-mode field args emit an _empty
+      % fallback constant each) ride the line stream as global(G)
+      % markers, partitioned into the rule's global channel by the
+      % apply emitter -- discarding them left the emitted IR
+      % referencing undefined constants in text mode.
       plawk_foreign_args_ir(Args, FieldSeparator, Base, ArgValueIRs,
-          _Globals, Setup),
+          Globals, Setup),
+      findall(global(G), member(G, Globals), GlobalMarkers),
       plawk_foreign_call_args_ir(ArgValueIRs, CallArgsIR),
       format(atom(CallLine),
           '  %~w_ok = call i1 @~w(~w, %WamAssocI64Table* %plawk_assoc_table_~w)',
           [Base, ShimName, CallArgsIR, TableIndex]),
       format(atom(Next), '  br label %~w', [ActionNextLabel]),
-      append([[Label], Setup, [CallLine, Next, '']], Lines)
+      append([GlobalMarkers, [Label], Setup, [CallLine, Next, '']], Lines)
     },
     plawk_emit_lines(Lines),
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -23361,13 +23361,17 @@ fail:
 
 ; Associative-array variant (JIT roadmap #4): the entry output cell must bind
 ; to a proper list of 2-arg pairs -- e.g. [K1-V1, K2-V2, ...] -- and each
-; pair''s (Integer key, Integer value) is inserted into the caller''s i64
-; assoc table via @wam_assoc_i64_inc (add semantics: a fresh key ends at its
-; value; a repeated key accumulates, matching a tally). The walk reads the
-; cons cells (functor "[|]", arity 2) and pairs (any arity-2 compound; arg0 =
-; key, arg1 = value) BEFORE the arena rewind, since they live in the arena.
-; Returns i1 ok; false on call failure, a non-list output, a non-pair
-; element, or a non-Integer key/value.
+; pair''s (Integer-or-Atom key, Integer value) is inserted into the caller''s
+; i64 assoc table via @wam_assoc_i64_inc (add semantics: a fresh key ends at
+; its value; a repeated key accumulates, matching a tally). An Atom key''s id
+; is a global-registry id -- the same keyspace text-mode field slices and
+; blob keys intern into -- so for-in reports and string-literal lookups
+; resolve it like any other key (one key kind per table; integer keys
+; collide with atom ids, the documented text-mode ambiguity). The walk reads
+; the cons cells (functor "[|]", arity 2) and pairs (any arity-2 compound;
+; arg0 = key, arg1 = value) BEFORE the arena rewind, since they live in the
+; arena. Returns i1 ok; false on call failure, a non-list output, a non-pair
+; element, a non-Integer/non-Atom key, or a non-Integer value.
 define i1 @wam_object_call_assoc(%WamState* %vm, i32 %entry_pc, i32 %nargs, %Value* %args, i32 %out_reg, %WamAssocI64Table* %table) {
 entry:
   %vm_null = icmp eq %WamState* %vm, null
@@ -23446,9 +23450,19 @@ pair_args:
   %vv = call %Value @wam_deref_value(%WamState* %vm, %Value %v_raw)
   %ktag = call i32 @value_tag(%Value %kv)
   %vtag = call i32 @value_tag(%Value %vv)
+  ; Keys: Integer (payload as-is) or Atom (JIT roadmap item 4 string
+  ; fields -- the atom id IS a global-registry id, the same keyspace the
+  ; text-mode assoc pipeline interns field slices and blob keys into, so
+  ; for-in reports and "literal" lookups resolve it like any other key).
+  ; Values stay Integer: the table is an i64 accumulator. Mixing integer
+  ; and atom keys in ONE table is the documented text-mode ambiguity
+  ; (integer keys collide with atom ids) -- a grammar should return one
+  ; key kind per table.
   %k_is_int = icmp eq i32 %ktag, 1
+  %k_is_atom = icmp eq i32 %ktag, 0
+  %k_ok = or i1 %k_is_int, %k_is_atom
   %v_is_int = icmp eq i32 %vtag, 1
-  %kv_ok = and i1 %k_is_int, %v_is_int
+  %kv_ok = and i1 %k_ok, %v_is_int
   br i1 %kv_ok, label %insert, label %rewind_fail
 insert:
   %kval = call i64 @value_payload(%Value %kv)

--- a/tests/test_plawk_dyncall_assoc.pl
+++ b/tests/test_plawk_dyncall_assoc.pl
@@ -7,7 +7,10 @@
 %   arr = dyncall@tally($1) as assoc
 % Per record the returned [K-V, ...] pairs are inserted (accumulated) into
 % arr's i64 table via @wam_object_call_assoc; END arr[key] lookups see the
-% result. Named entry, integer keys/values (the mechanism's shape).
+% result. Named entry; keys are integers OR atoms (an atom key's id is a
+% global-registry id, the same keyspace text-mode field slices intern
+% into, so for-in reports and "literal" lookups resolve it); values are
+% integers. One key kind per table.
 
 :- use_module(library(plunit)).
 :- use_module(library(process)).
@@ -18,6 +21,12 @@
 
 % tally(X) returns two pairs: bucket 1 gets X, bucket 2 gets a flat 100.
 tally(X, R) :- R = [1-X, 2-100].
+
+% tallyc(X) returns ATOM-keyed pairs: every record tallies under seen,
+% and the big/small bucket gets weight 2/1 (text fields arrive as atoms).
+tallyc(X, R) :-
+    atom_number(X, N),
+    ( N > 100 -> R = [big-2, seen-1] ; R = [small-1, seen-1] ).
 
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
@@ -64,6 +73,44 @@ test(assoc_populates_and_reads, [condition(clang_available)]) :-
     assertion(Out == "12 200\n"),
     !.
 
+% ATOM keys (JIT roadmap item 4, the string story's remaining container):
+% a grammar returning [Atom-V, ...] pairs populates the table under the
+% atom's global-registry id -- the same keyspace text-mode field slices
+% and blob keys intern into -- so the END for-in report resolves the key
+% names like any text-mode table. 50, 200, 300, 7 -> big 4, small 2,
+% seen 4 (line order is table slot order, so compare sorted).
+test(assoc_atom_keys_populate_and_report, [condition(clang_available)]) :-
+    da_dir(Dir),
+    directory_file_path(Dir, 'libc.wamo', Wamo),
+    write_wam_object([user:tallyc/2], [wamo_entries([tallyc/2])], Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@tallyc($1) as assoc }\n\c
+         END { for (k in arr) print k, arr[k] }\n", [Wamo]),
+    build_run_text(Dir, 'dac', Src, "50\n200\n300\n7\n", Out),
+    split_string(Out, "\n", "", Lines0),
+    exclude(==(""), Lines0, Lines),
+    msort(Lines, Sorted),
+    assertion(Sorted == ["big 4", "seen 4", "small 2"]),
+    !.
+
+% An atom-keyed table also answers END string-literal lookups: the
+% literal interns to the same registry id the grammar's atom carries.
+test(assoc_atom_keys_string_lookup, [condition(clang_available)]) :-
+    da_dir(Dir),
+    directory_file_path(Dir, 'libc.wamo', Wamo),
+    ( exists_file(Wamo)
+    -> true
+    ;  write_wam_object([user:tallyc/2], [wamo_entries([tallyc/2])], Wamo)
+    ),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@tallyc($1) as assoc }\n\c
+         END { print arr[\"big\"], arr[\"seen\"] }\n", [Wamo]),
+    build_run_text(Dir, 'dacl', Src, "50\n200\n300\n7\n", Out),
+    assertion(Out == "4 4\n"),
+    !.
+
 :- end_tests(plawk_dyncall_assoc).
 
 % --- helpers ---------------------------------------------------------------
@@ -82,6 +129,19 @@ build_run(Dir, Name, Src, Values, Out) :-
     cli([build, Prog, '-o', Bin], _, 0),
     directory_file_path(Dir, 'in.bin', Input),
     write_i64_records(Input, Values),
+    run_bin(Bin, [Input], Out, 0).
+
+% text-mode variant: the input is text lines rather than binary records
+build_run_text(Dir, Name, Src, InputText, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog0, '_in.txt', Input),
+    setup_call_cleanup(open(Input, write, SI, [encoding(utf8)]),
+        write(SI, InputText), close(SI)),
     run_bin(Bin, [Input], Out, 0).
 
 write_i64_le(Out, V) :-


### PR DESCRIPTION
## Round 3 of 4: string fields in structured-record returns

**Investigation first, and it changed the scope.** The round-3 headline turned out to be substantially landed already: `@wam_object_call_record` has typecode 2 (string) with the `out_lens` array, and the **record-view surface** already exposes string fields as `(ptr,len)` slice reads (`dyncall@info($1) as (i64 string) { total += $1 ; print $2 }` — documented and verified in the existing suite). The destructure target rejects string fields **by design**: plawk scalars are numeric, and the record view *is* the string surface.

The genuinely missing string shape was the **assoc container** — `@wam_object_call_assoc` hard-failed on any non-integer key. This round closes it:

### Atom keys in `as assoc`

```awk
BEGIN { DYNLOAD = "libc.wamo" }
{ arr = dyncall@tallyc($1) as assoc }
END { for (k in arr) print k, arr[k] }
```

A grammar returning `[Atom-V, ...]` pairs populates the table under the atom's **global-registry id** — the same keyspace text-mode field slices and blob keys intern into — so END `for (k in arr)` reports resolve the key names, and `arr["literal"]` lookups intern to the same ids. The runtime change is one gate: the pair walker accepts Integer *or* Atom keys (an atom id is already a valid i64 table key); values stay Integer — the table is an i64 accumulator, so string *values* remain deferred and documented. One key kind per table (integer keys collide with atom ids — the pre-existing, documented text-mode ambiguity).

### Latent text-mode bug fixed on the way

The dynassoc action emitter **discarded its arg-marshal globals** (`_Globals`), and text-mode field args emit a fallback constant each — so any text-mode `arr = dyncall@name($1) as assoc` produced IR referencing undefined constants and failed the clang build. The BINFMT-only tests never hit it (binfmt args marshal without globals). The globals now ride the apply path's `global(G)` marker channel added in the blob-consumers round (#3619) — the second consumer of that channel in as many rounds.

### Tests

`tests/test_plawk_dyncall_assoc.pl` gains two end-to-end tests: a bucketing grammar (`tallyc`) returning atom-keyed pairs over text records — the for-in report gives `big 4 / small 2 / seen 4` (sorted compare; line order is table slot order) — and string-literal lookups answering `arr["big"], arr["seen"]` → `4 4`. The integer-key BINFMT round trip stays green.

**Full battery green with true exit propagation**: every `tests/test_plawk_*.pl` suite, the complete `wam_object` suite fresh-cache (the runtime IR changed, so all hosts rebuilt — fixpoint intact), and `test_llvm_target`.

### Docs

Roadmap item 4 marked **LANDED (all string surfaces; string values deferred)**, with the atom-key semantics, the by-design destructure rejection note, and the dynassoc globals fix recorded.

Next: round 4 — eval-surface polish (compile with named entries, compile-from-file with mtime rebust; skipping handle-in-scalar per the earlier flag unless told otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_