### PR TITLE
mu_cosine: multi-judge fusion — fused-head null's boundary confirmed, luna fusion non-degenerate

### DIFF
--- a/prototypes/mu_cosine/REPORT_multi_judge_fusion.md
+++ b/prototypes/mu_cosine/REPORT_multi_judge_fusion.md
@@ -1,0 +1,49 @@
+# Multi-judge fusion: the fused-head null's boundary confirmed — luna's fusion is non-degenerate
+
+`run_multi_judge_fusion.py` — boundary case #1 from REPORT_fused_head.md, tested on existing data (the
+fresh 250 carries prior, graph, gpt-5.5 run 2, and gpt-5.6-luna against the gpt-5.5 run 1 target; zero new
+scoring). Setup mirrors run_judge_channel.py: 7×7 joint residual covariance fit per split, so luna's
+cross-correlations with 5.5 and the prior are PRICED; 40 descendant-disjoint splits, constant blocks.
+
+## Ladder (target = judge1 = the operating campaign judge; NLL ↓)
+
+| rung | NLL | Mahal/dim | channel value over prior+graph |
+|---|---|---|---|
+| prior | +0.408 | 1.42 | — |
+| prior+graph | −0.012 | 1.40 | — |
+| prior+graph+**luna** | −0.462 | 1.55 | **+0.451** (row-SE 0.026) |
+| prior+graph+**j2** | −1.946 | 1.09 | **+1.935** (0.034) — Lever A's +1.94 replicates |
+| all | −1.981 | 1.14 | luna's marginal after j2: **+0.034** (0.009) |
+
+## The two findings
+
+1. **The fused-head null's boundary is real.** Fusion non-degeneracy (mean |posterior_D − judge_D|):
+   **0.133 with luna** vs 0.020 with j2. With the reliable judge the posterior collapses onto the
+   measurement (why the fused head learned nothing beyond the LLM head); with the noisy judge the filter
+   genuinely mixes prior, graph, and judge. A luna-fused posterior is a target that DIFFERS from any single
+   channel — the setting where an amortized `mu_PoE` head has something to learn.
+
+2. **Judge economics, extended.** Luna lost as a solo campaign judge (§7: not interchangeable, S at half
+   the ceiling) but carries ~23% of the full-price judge's channel value through fusion, and a small
+   positive consensus increment after 5.5. This prices the Lever-A escalation ladder's bottom rung: if
+   luna is ≥~4× cheaper per call, luna-on-every-row + 5.5-on-conflict-routed-rows dominates 5.5-only at
+   matched spend (subject to the caveats below).
+
+## Caveats
+
+- **Same-family target privilege**: y = gpt-5.5 run 1, so j2's fitted R absorbs shared 5.5 bias (looks
+  better than against ground truth) and luna's fitted R absorbs its true +D/−S tilt (looks worse). This is
+  the operationally-correct frame — 5.5 IS the campaign judge — but it lower-bounds luna against an
+  independent truth; a human-verified subset remains the gold-standard upgrade (the §12(3) lesson).
+- Luna-rung error bars mildly overconfident (Mahal/dim 1.55 vs ≈1.4 base) — the tilt is a bias term, and
+  constant blocks fold it into R as variance; a bias-augmented state (DESIGN metastable §) would price it
+  properly.
+- All-transitive 250 (S channel starved as usual); constant blocks, no Σ(hop).
+
+## Follow-up unlocked
+
+Re-run the fused-head distillation with LUNA-fused targets — now non-degenerate (pull 0.133). Blocked on
+data breadth: 250 all-transitive pairs are too thin/narrow to train a head; wants the stratified luna
+scoring run (~2,000 pairs at luna prices ≈ well under the usual spend guideline).
+
+Repro: `python3 run_multi_judge_fusion.py`

--- a/prototypes/mu_cosine/run_multi_judge_fusion.py
+++ b/prototypes/mu_cosine/run_multi_judge_fusion.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Multi-judge fusion — the fused-head null's boundary case #1, tested on existing data (zero scoring cost).
+
+REPORT_fused_head.md: with a single reliable judge (R≈0.004) the Kalman posterior collapses onto the label
+and fusion machinery adds nothing. Boundary claim: a NOISY judge (luna: R ~5-10× 5.5's, opposite-signed
+biases) makes the fusion non-degenerate. The fresh 250 already carries everything: gpt-5.5 run 1 (target),
+gpt-5.5 run 2 + gpt-5.6-luna (measurement channels), the graph walk, the model prior.
+
+Setup mirrors run_judge_channel.py (constant blocks, correlated updates, descendant-disjoint splits): the
+7×7 joint residual covariance [prior_D, prior_S, graph, j2_D, j2_S, luna_D, luna_S] is fit on each train
+split — so luna's cross-correlations (with 5.5, with the prior) are PRICED, not assumed.
+
+Target honesty: y = judge1 (gpt-5.5 run 1) = the campaign judge's labels. This measures "predict the
+operating judge", not ground truth — j2 is same-family and thus privileged (its fitted R absorbs shared
+5.5 bias); luna's fitted R absorbs its true tilt. That is the operationally-correct frame (5.5 IS the
+campaign judge) but it lower-bounds luna's value against an independent truth.
+
+Economics ladder (cost ↑): prior | +graph | +luna (cheap judge) | +j2 (full-price judge) | +j2+luna.
+
+  python3 run_multi_judge_fusion.py
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from eval_luna_transfer import load_luna as load_scored_mu_tsv
+from product_kalman import fit_residual_covariance
+from run_judge_channel import correlated_update_H, nll_mahal
+from run_product_kalman_logit import dequant
+from run_product_kalman_realdata import DATASETS, affine_calibrate
+from sigma_hop_confirmatory import (
+    FeatureGraphConfig,
+    build_confirmatory_data_from_labels,
+    descendant_disjoint_split,
+    load_scored_pairs,
+)
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+J2_TSV = "/tmp/mu_data/sigma_hop_fresh_scored_j2.tsv"
+LUNA_TSV = "/tmp/mu_data/sigma_hop_fresh_scored_luna.tsv"
+# measurement rows: graph→D, j2D→D, j2S→S, lunaD→D, lunaS→S
+H5 = np.array([[1, 0], [1, 0], [0, 1], [1, 0], [0, 1]], dtype=float)
+RUNGS = {  # name → measurement row indices (cost order)
+    "prior": [],
+    "prior+graph": [0],
+    "prior+graph+luna": [0, 3, 4],
+    "prior+graph+j2": [0, 1, 2],
+    "prior+graph+j2+luna": [0, 1, 2, 3, 4],
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seeds", type=int, default=40)
+    ap.add_argument("--shrink", type=float, default=0.05)
+    a = ap.parse_args()
+
+    cfg = DATASETS["fresh"]
+    pairs, hop, D, S = load_scored_pairs(cfg["score_in"], cfg["responses"], prefix="transitive_h")
+    data = build_confirmatory_data_from_labels(
+        pairs, hop, D, S, cfg["e5_cache"], FeatureGraphConfig(**cfg["graph"]),
+        os.path.join(ROOT, "model_prod.pt"), "cpu",
+    )
+    by = {}
+    for path, key in [(J2_TSV, "j2"), (LUNA_TSV, "luna")]:
+        p, d_, s_ = load_scored_mu_tsv(path)
+        by[key] = {pp: (d_[i], s_[i]) for i, pp in enumerate(p)}
+    keep = [i for i, p in enumerate(data.pairs) if p in by["j2"] and p in by["luna"]]
+    print(f"fresh pairs with prior+graph+j2+luna: {len(keep)}")
+    prior = data.X[keep, :2]; d = data.X[keep, 2]
+    y = dequant(np.column_stack([data.D[keep], data.S[keep]]))          # judge1 = the operating target
+    j2 = np.array([by["j2"][data.pairs[i]] for i in keep])
+    luna = np.array([by["luna"][data.pairs[i]] for i in keep])
+    pk = [data.pairs[i] for i in keep]
+
+    acc = {r: {"nll": [], "m2": []} for r in RUNGS}
+    lg = {"+luna_after_j2": [], "+j2_after_luna": []}
+    used = 0
+    for seed in range(a.seeds):
+        tr, he = descendant_disjoint_split(pk, seed, held_frac=0.30)
+        if len(tr) < 30 or len(he) < 12:
+            continue
+        used += 1
+        m = affine_calibrate(d[tr], y[tr, 0], d)
+        meas = np.column_stack([m, j2[:, 0], j2[:, 1], luna[:, 0], luna[:, 1]])
+        E = np.column_stack([y - prior, meas - y[:, [0, 0, 1, 0, 1]]])[tr]   # 2 prior + 5 meas errors
+        C7 = fit_residual_covariance(E, shrinkage=a.shrink)
+        P0, C_pm, R0 = C7[:2, :2], C7[:2, 2:], C7[2:, 2:]
+        for i in he:
+            x = prior[i]
+            row = {}
+            for rung, sel in RUNGS.items():
+                if not sel:
+                    xp, Pp = x, P0
+                else:
+                    xp, Pp = correlated_update_H(x, P0, meas[i][sel], R0[np.ix_(sel, sel)],
+                                                 C_pm[:, sel], H5[sel])
+                nll, m2 = nll_mahal(y[i] - xp, Pp)
+                acc[rung]["nll"].append(nll); acc[rung]["m2"].append(m2)
+                row[rung] = nll
+            lg["+luna_after_j2"].append(row["prior+graph+j2"] - row["prior+graph+j2+luna"])
+            lg["+j2_after_luna"].append(row["prior+graph+luna"] - row["prior+graph+j2+luna"])
+
+    print(f"\nfusion ladder ({used} splits; NLL ↓, Mahal/dim ≈ 1):")
+    print(f"    {'rung':24s} {'NLL':>8s} {'Mahal/dim':>10s}")
+    base = None
+    for r in RUNGS:
+        nll = np.array(acc[r]["nll"]); m2 = np.array(acc[r]["m2"])
+        print(f"    {r:24s} {nll.mean():+8.4f} {m2.mean()/2:10.2f}")
+        if r == "prior+graph":
+            base = nll
+    for nm, ref in [("luna (cheap judge)", "prior+graph+luna"), ("j2 (full-price judge)", "prior+graph+j2")]:
+        g = base - np.array(acc[ref]["nll"])
+        print(f"    value of {nm:22s} over prior+graph: {g.mean():+.4f} (row-SE {g.std()/np.sqrt(len(g)):.4f})")
+    for nm, g in lg.items():
+        g = np.array(g)
+        print(f"    marginal {nm:18s}: {g.mean():+.4f} (row-SE {g.std()/np.sqrt(len(g)):.4f})")
+
+    # how non-degenerate is the luna fusion? posterior pull off the raw luna measurement
+    print("\nfusion non-degeneracy (mean |posterior − measurement|, D channel, last split):")
+    for rung, mcol in [("prior+graph+luna", 3), ("prior+graph+j2", 1)]:
+        sel = RUNGS[rung]
+        pull = []
+        for i in range(len(y)):
+            xp, _ = correlated_update_H(prior[i], P0, meas[i][sel], R0[np.ix_(sel, sel)], C_pm[:, sel], H5[sel])
+            pull.append(abs(xp[0] - meas[i][mcol]))
+        print(f"    {rung:24s} |post_D − judge_D| = {np.mean(pull):.3f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Boundary case #1 from REPORT_fused_head.md, tested on existing data (fresh 250: prior, graph,
gpt-5.5 run 2, gpt-5.6-luna vs the gpt-5.5 run 1 operating target; zero new scoring). 7×7 joint
residual covariance per split — luna's cross-correlations are priced, not assumed. 40 splits.

- Luna's channel: **+0.451 NLL** over prior+graph (23% of j2's **+1.935**, which replicates Lever A).
  Marginal consensus after j2: +0.034 (4× row-SE).
- **Non-degeneracy**: posterior pull off the judge measurement 0.133 with luna vs 0.020 with j2 —
  the noisy judge's fusion genuinely mixes channels; this is the regime where an amortized fused
  head has something to learn.
- Economics: prices the Lever-A escalation ladder's bottom rung — luna everywhere + 5.5 on
  conflict-routed rows dominates 5.5-only at matched spend if luna is ≥~4× cheaper.
- Caveats recorded: same-family target privileges j2 / absorbs luna's tilt into R; luna rung mildly
  overconfident (Mahal/dim 1.55 — bias folded into variance; bias-augmented state would fix).

Follow-up unlocked: fused-head distillation on luna-fused targets (pull 0.133 = a target that
actually differs from the label) — blocked on a stratified luna scoring run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175Lx4bNRVaAv3hTDURCF69