### PR TITLE
Fix callable Rust retract/1 backtracking

### DIFF
--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -484,12 +484,32 @@
         }
     }
 
+    fn dynamic_clause_body_is_direct_retract(&self, clause: &Value) -> bool {
+        let body = match self.dynamic_clause_head_body(clause) {
+            Some((_, Some(body))) => self.deref_heap(&self.deref_var(&body)),
+            _ => return false,
+        };
+        matches!(
+            body,
+            Value::Str(ref functor, ref args)
+                if args.len() == 1 &&
+                   Self::display_functor_name(functor, 1) == "retract"
+        )
+    }
+
     fn dynamic_rule_body_attempt(&mut self, clause: Value, solution_idx: usize, cont_pc: usize) -> bool {
         let cp_trail = self.trail.len();
         let cp_heap = self.heap.len();
         let cp_regs = self.save_regs();
         let cp_stack = self.stack.clone();
-        if self.dynamic_apply_clause_solution(&clause, solution_idx) {
+        // retract/1 mutates its candidate set, so retry from the first
+        // remaining match instead of skipping by the historical index.
+        let effective_idx = if self.dynamic_clause_body_is_direct_retract(&clause) {
+            0
+        } else {
+            solution_idx
+        };
+        if self.dynamic_apply_clause_solution(&clause, effective_idx) {
             self.choice_points.push(ChoicePoint {
                 next_pc: cont_pc,
                 saved_args: cp_regs,

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -121,6 +121,47 @@ fn asserted_rule_body_can_call_retract() {
 }
 
 #[test]
+fn asserted_rule_body_retract_backtracks_without_skipping() {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    for value in ["red", "blue", "green"] {
+        assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at(value)]));
+    }
+    assert_clause(
+        &mut vm,
+        "assertz/1",
+        rule(
+            fact("take", vec![ub("X")]),
+            fact("retract", vec![fact("dyn", vec![ub("X")])]),
+        ),
+    );
+
+    vm.reset_query();
+    vm.code = vec![
+        Instruction::Call("take/1".to_string(), 1),
+        Instruction::Proceed,
+    ];
+    vm.labels = HashMap::new();
+    vm.set_reg_str("A1", ub("X"));
+    vm.pc = 1;
+
+    let mut removed = Vec::new();
+    assert!(vm.run());
+    loop {
+        let result_raw = vm.bindings.get("X").cloned().expect("X bound");
+        removed.push(vm.deref_heap(&vm.deref_var(&result_raw)));
+        if !vm.backtrack() {
+            break;
+        }
+    }
+
+    assert_eq!(
+        removed,
+        vec![at("red"), at("blue"), at("green")],
+    );
+    assert!(dyn_values(&mut vm).is_empty());
+}
+
+#[test]
 fn retract_backtracks_through_each_matching_fact() {
     let mut vm = WamState::new(vec![Instruction::Call("retract/1".to_string(), 1), Instruction::Proceed], HashMap::new());
     assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("red")]));


### PR DESCRIPTION
## Summary

- Fix asserted `retract/1` rule bodies skipping matches during backtracking.
- Retry direct retract bodies from the first remaining database match instead of applying a stale solution index.
- Preserve existing indexed retries for pure and non-retract dynamic bodies.
- Add a three-fact regression verifying `red`, `blue`, and `green` are all yielded and removed.

Before this change, `blue` was removed but never returned, producing only `red` and `green`.

The additional body-shape check runs only while retrying asserted rule bodies. Compiled predicates and first-solution calls are unaffected.

## Testing

- Focused generated Rust dynamic-builtin crate
- Full Rust WAM target suite
- Prolog target syntax check
- `git diff --check`