### PR TITLE
WAM/LLVM eval polish: compile_file(path) — grammar source files, change-rebust by content

### DIFF
--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -30,8 +30,9 @@ BEGIN { DYNLOAD = "..." }
 
 Steps 3–5 already have their primitives: `@wam_object_call_bytes` returns a
 byte slice, and `@wam_object_load_bytes` + `@wam_object_call_i64` load and run
-a buffer. The `mtime` cache-invalidation path (#3465) is the natural home for
-"recompile when the source changes." **The hard part is step 1**: getting the
+a buffer. "Recompile when the source changes" landed as `compile_file(path)`
+with CONTENT dedup rather than the anticipated mtime path (#3465) -- see
+"The landed surface" below. **The hard part is step 1**: getting the
 compiler to run *as a loaded object*, which needs the loadable WAM subset
 expanded to cover what the compiler leans on.
 
@@ -75,10 +76,29 @@ How it works:
   converts with `atom_number/2` before arithmetic — the loaded runtime,
   like SWI, fails (rather than coerces) arithmetic on atoms.
 
+**`compile_file(path)`** — the grammar SOURCE lives in a file the binary
+reads at runtime (per call, via `@wamo_read_file`) and compiles through
+the same registry. Content dedup makes it change-rebust with **no mtime
+bookkeeping**: an edited file is new source text (fresh compile, fresh
+handle); unchanged bytes hit the registry. This is the query/userspace
+redefinition story by content rather than mtime — the same binary,
+rerun after editing the grammar file, behaves differently with no
+rebuild (and mid-run edits become visible on the next record).
+
+Descoped from the polish round, with rationale: **named entries on
+compile handles** (`dyncall_at@name(compile(...), ...)`) would need the
+bootstrap compiler to emit multi-entry tables and the loader to retain
+name→label maps per handle — the bootstrap emits single-entry objects
+by design, and a dispatch argument in the grammar covers the need.
+**Handle-in-scalar** (`g = compile($1)`) stays skipped: per-source
+dedup makes the nested form equivalent, and threading a handle kind
+through the SSA scalar plan buys no new capability.
+
 End-to-end tests: `tests/test_plawk_eval_compile.pl` — a grammar compiled
 from source text inside the binary sums `sq(x)` over input records; two
 distinct runtime-compiled grammars coexist with per-source dedup; the
-cache-off build error.
+cache-off build error; and the compile_file edit-without-rebuild round
+trip (squares 150 → edit the file → doubles 44, same binary).
 
 ## Why it is genuinely last
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1975,6 +1975,27 @@ record:
   ret i64 %h64m
 fail:
   ret i64 0
+}
+
+define i64 @plawk_compile_file(i8* %path) {
+entry:
+  ; compile_file(path): read the grammar SOURCE file and compile its
+  ; contents through @plawk_compile. Content dedup makes this
+  ; change-rebust with no mtime bookkeeping: an edited file is new
+  ; source text (fresh compile, fresh handle); unchanged bytes hit the
+  ; registry. The read is per call -- cheap next to a compile, and it
+  ; keeps mid-run edits visible on the next record.
+  %totp = alloca i64
+  %buf = call i8* @wamo_read_file(i8* %path, i64* %totp)
+  %buf_null = icmp eq i8* %buf, null
+  br i1 %buf_null, label %fail, label %compile
+compile:
+  %total = load i64, i64* %totp
+  %h = call i64 @plawk_compile(i8* %buf, i64 %total)
+  call void @free(i8* %buf)
+  ret i64 %h
+fail:
+  ret i64 0
 }',
         [PathGlobal, BytesLen, BytesLen]).
 
@@ -2188,6 +2209,22 @@ plawk_dyncall_source_ir(compile_src(Arg), FieldSeparator, Base, GlobalBase,
     PathPtrIR = null,
     format(atom(PathLenIR), '%~w_h', [Base]),
     append(SrcSetup, [CallIR], SetupParts).
+% compile_file(path): marshal the path like any dyncall_at source, read
+% the named grammar SOURCE file at runtime, and compile its contents
+% through the same handle registry -- @plawk_compile_file delegates to
+% @plawk_compile, so content dedup gives change-rebust for free (an
+% edited file is new source text; unchanged bytes hit the registry).
+plawk_dyncall_source_ir(compile_file_src(Arg), FieldSeparator, Base, GlobalBase,
+        PathPtrIR, PathLenIR, GlobalParts, SetupParts) :-
+    format(atom(FBase), '~w_cfile', [Base]),
+    plawk_dyncall_source_ir(Arg, FieldSeparator, FBase, GlobalBase,
+        PPtrIR, _PLenIR, GlobalParts, PSetup),
+    format(atom(CallIR),
+        '  %~w_h = call i64 @plawk_compile_file(i8* ~w)',
+        [Base, PPtrIR]),
+    PathPtrIR = null,
+    format(atom(PathLenIR), '%~w_h', [Base]),
+    append(PSetup, [CallIR], SetupParts).
 
 %% plawk_blob_expr_ir(+Expr, +FieldSeparator, +Base, -LenIR, -PtrIR,
 %%     -GlobalParts, -SetupParts)
@@ -2302,15 +2339,22 @@ plawk_program_compile_sites(Program, Sites) :-
         ( ( member(rule(_Pattern, Actions), Rules)
           ; member(end(Actions), EndClauses)
           ),
-          ( plawk_actions_dyncall_at(Actions, compile_src(Arg), _)
-          ; plawk_actions_float_dyncall_at(Actions, compile_src(Arg), _)
-          )
+          ( plawk_actions_dyncall_at(Actions, CSrc, _)
+          ; plawk_actions_float_dyncall_at(Actions, CSrc, _)
+          ),
+          plawk_compile_source_node(CSrc, Arg)
         ;   % blob positions via the generic walk (print fields, writebin
             % slots, assoc keys, blob_eq patterns)
-            plawk_program_blob_node(Program, blob_dyncall_at(compile_src(Arg), _))
+            plawk_program_blob_node(Program, blob_dyncall_at(CSrc, _)),
+            plawk_compile_source_node(CSrc, Arg)
         ),
         Sites0),
     sort(Sites0, Sites).
+
+% both eval-source forms count as compile sites (they need the shipped
+% compiler object and the @plawk_compile support IR)
+plawk_compile_source_node(compile_src(Arg), Arg).
+plawk_compile_source_node(compile_file_src(Arg), Arg).
 
 plawk_actions_dyncall_at(Actions, Source, Args) :-
     member(Action, Actions),
@@ -6121,6 +6165,13 @@ plawk_dyncall_at_expr(dyncall_at(Source, Args)) :-
     maplist(plawk_foreign_arg, Args).
 
 plawk_dyncall_at_source_ok(compile_src(Arg)) :-
+    !,
+    plawk_foreign_arg(Arg).
+% compile_file(path): the path names a grammar SOURCE file read at
+% runtime; its contents compile through the same registry as
+% compile(...), so an edited file is a new source text and recompiles
+% (change-rebust by content dedup, no mtime bookkeeping).
+plawk_dyncall_at_source_ok(compile_file_src(Arg)) :-
     !,
     plawk_foreign_arg(Arg).
 plawk_dyncall_at_source_ok(Source) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -468,6 +468,20 @@ foreign_args_rest([]) -->
 %  of the same source reuse one loaded grammar). "compile" is reserved
 %  in this position only; elsewhere it still parses as an ordinary
 %  identifier.
+% compile_file(field-or-string): the path names a grammar SOURCE file
+% read at runtime; its contents compile through the same handle
+% registry as compile(...), so editing the file changes behaviour with
+% no rebuild (content dedup recompiles exactly when the bytes differ).
+% Parsed before compile: they share a prefix.
+dyncall_at_source(compile_file_src(Arg)) -->
+    "compile_file",
+    ws,
+    "(",
+    ws,
+    foreign_arg(Arg),
+    ws,
+    ")",
+    !.
 dyncall_at_source(compile_src(Arg)) -->
     "compile",
     ws,

--- a/tests/test_plawk_eval_compile.pl
+++ b/tests/test_plawk_eval_compile.pl
@@ -89,6 +89,49 @@ test(two_runtime_grammars_coexist, [condition(clang_available)]) :-
     assertion(Out == "194\n"),
     !.
 
+% compile_file(path) parses to its own node and counts as a compile
+% site (needs the shipped compiler object like compile(...)).
+test(compile_file_parses_and_collects) :-
+    plawk_parse_source(
+        "{ t += dyncall_at(compile_file($2), $1) }\nEND { print t }\n",
+        Program, _),
+    Program = program(_, Rules, _),
+    memberchk(rule(_, Actions), Rules),
+    memberchk(add(var(t), dyncall_at(compile_file_src(field(2)), [field(1)])),
+              Actions),
+    plawk_program_compile_sites(Program, Sites),
+    assertion(Sites == [field(2)]),
+    !.
+
+% compile_file(path): the grammar SOURCE lives in a file the binary
+% reads at runtime. Editing the file changes behaviour on the NEXT RUN
+% of the SAME binary -- no rebuild -- because content dedup treats the
+% edited text as a fresh source (the query/userspace redefinition
+% story, by content rather than mtime).
+test(compile_file_edit_changes_behavior_no_rebuild,
+     [condition(clang_available)]) :-
+    ev_dir(Dir),
+    directory_file_path(Dir, 'gram.pl', GramPath),
+    write_prog(Dir, 'gram.pl',
+        '[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2)]'),
+    format(string(Src),
+        "{ total += dyncall_at(compile_file(\"~w\"), $1) }\n\c
+         END { print total }\n", [GramPath]),
+    write_prog(Dir, 'evfile.plawk', Src),
+    directory_file_path(Dir, 'evfile.plawk', Prog),
+    directory_file_path(Dir, 'evfile_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'nums.txt', Input),
+    write_num_lines(Input, [3, 4, 5, 10]),
+    run_bin(Bin, [Input], Out1, 0),
+    assertion(Out1 == "150\n"),                   % squares: 9+16+25+100
+    % swap the grammar source; same binary, no rebuild
+    write_prog(Dir, 'gram.pl',
+        '[(dbl(X3, R3) :- atom_number(X3, N3), R3 is N3 * 2)]'),
+    run_bin(Bin, [Input], Out2, 0),
+    assertion(Out2 == "44\n"),                    % doubles: 6+8+10+20
+    !.
+
 % compile(...) with the cache disabled is a build error (exit 3), not a
 % silent miscompile: the grammar handle lives in the cache registry.
 test(compile_with_cache_off_fails_build, [condition(clang_available)]) :-


### PR DESCRIPTION
## Round 4 of 4: eval-surface polish

The grammar **source** can now live in a file the binary reads at runtime:

```awk
{ total += dyncall_at(compile_file("gram.pl"), $1) }
END { print total }
```

`@plawk_compile_file` reads the named file per call (`@wamo_read_file`) and compiles its contents through the same handle registry as `compile(...)`. **Content dedup makes this change-rebust with no mtime bookkeeping**: an edited file is new source text (fresh compile, fresh handle); unchanged bytes hit the registry. This lands the "recompile when the source changes" story — the design doc anticipated an mtime path (#3465); content turned out to be both simpler and stronger: the same binary, rerun after editing the grammar file, behaves differently with **no rebuild**, and even mid-run edits become visible on the next record. The path can also come from a field (`compile_file($2)`), so an input stream can name grammar source files per record.

`compile_file` sites count as compile sites — the CLI ships the bootstrap-compiler object and the `@plawk_compile` support IR exactly as for `compile(...)`.

### Descoped, with rationale (recorded in PLAWK_EVAL_BOOTSTRAP.md)

- **Named entries on compile handles** (`dyncall_at@name(compile(...), ...)`): the bootstrap compiler emits single-entry objects by design, and resolving `@name` per handle would need multi-entry tables emitted by the bootstrap plus VM-side name→label retention — a dispatch argument in the grammar covers the need.
- **Handle-in-scalar** (`g = compile($1)`) — skipped per the flag raised at the start of the sequence: per-source dedup makes the nested form equivalent, and threading a handle kind through the SSA scalar plan buys no new capability.

### Tests

`tests/test_plawk_eval_compile.pl` gains the parse/compile-site test and the crown: **the edit-without-rebuild round trip** — the binary sums squares to 150, the test rewrites `gram.pl` into a doubling grammar, and the *same binary* then prints 44. Full plawk battery green with true exit propagation (codegen/parser-only change; the WAM runtime is untouched).

### Sequence complete

This closes the four agreed rounds: loader clause indexing (#3611, hardened in #3615), blob consumers (#3619), record strings / assoc atom keys (#3622), and this eval polish. Roadmap items 1–5 are all marked LANDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_