### PR TITLE
Skip line comments in Rust WAM term input

### DIFF
--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -43,11 +43,28 @@
         else { false }
     }
 
+    fn skip_term_layout(input: &str, mut pos: usize) -> usize {
+        loop {
+            let suffix = match input.get(pos..) {
+                Some(suffix) => suffix,
+                None => return input.len(),
+            };
+            let trimmed = suffix.trim_start();
+            pos += suffix.len() - trimmed.len();
+            if !trimmed.starts_with('%') {
+                return pos;
+            }
+            match trimmed.find('\n') {
+                Some(end) => pos += end + 1,
+                None => return input.len(),
+            }
+        }
+    }
+
     fn next_dotted_term_text(input: &str, start: usize) -> Option<(String, usize)> {
-        let suffix = input.get(start..)?;
-        let trimmed = suffix.trim_start();
+        let term_start = Self::skip_term_layout(input, start);
+        let trimmed = input.get(term_start..)?;
         if trimmed.is_empty() { return None; }
-        let term_start = start + suffix.len() - trimmed.len();
         let bytes = trimmed.as_bytes();
         let mut in_quote = false;
         let mut escaped = false;
@@ -61,7 +78,7 @@
             if b == 39 { in_quote = true; continue; }
             if b == 46 {
                 let next_is_term_end = bytes.get(idx + 1)
-                    .map(|c| c.is_ascii_whitespace())
+                    .map(|c| c.is_ascii_whitespace() || *c == b'%')
                     .unwrap_or(true);
                 if next_is_term_end {
                     return Some((trimmed[..idx].trim().to_string(), term_start + idx + 1));

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -409,7 +409,7 @@ fn read_eof_binds_end_of_file() {
 fn read_consumes_buffered_terms_before_end_of_file() {
     let (code, labels) = shared_wam_program();
     let mut vm = WamState::new(code, labels);
-    vm.set_term_input("first. pair(second, 2).");
+    vm.set_term_input("% header\nfirst.% between terms\npair(second, 2).");
 
     vm.set_reg_str("A1", ub("T1"));
     assert!(vm.execute_builtin("read/1", 1));


### PR DESCRIPTION
## Summary

- Skip leading and inter-term `%` line comments in buffered Rust term input.
- Accept `%` immediately after a terminating full stop as source layout.
- Preserve quoted atoms and existing dotted-term handling.
- Add coverage using a leading comment and a comment between two terms.

The layout scan performs no allocations and runs once per read operation.

## Testing

- Focused generated Rust dynamic-builtin crate
- Full Rust WAM target suite
- Prolog target syntax check
- `git diff --check`