### PR TITLE
 Handle inline comments in Rust WAM term input

### DIFF
--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -61,6 +61,45 @@
         }
     }
 
+    fn strip_term_line_comments(text: &str) -> String {
+        if !text.as_bytes().contains(&b'%') {
+            return text.trim().to_string();
+        }
+        let mut out = String::with_capacity(text.len());
+        let mut in_quote = false;
+        let mut escaped = false;
+        let mut in_comment = false;
+        for ch in text.chars() {
+            if in_comment {
+                if ch == '\n' {
+                    in_comment = false;
+                    out.push(' ');
+                }
+                continue;
+            }
+            if in_quote {
+                out.push(ch);
+                if escaped {
+                    escaped = false;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else if ch == '\'' {
+                    in_quote = false;
+                }
+                continue;
+            }
+            if ch == '\'' {
+                in_quote = true;
+                out.push(ch);
+            } else if ch == '%' {
+                in_comment = true;
+            } else {
+                out.push(ch);
+            }
+        }
+        out.trim().to_string()
+    }
+
     fn next_dotted_term_text(input: &str, start: usize) -> Option<(String, usize)> {
         let term_start = Self::skip_term_layout(input, start);
         let trimmed = input.get(term_start..)?;
@@ -68,6 +107,7 @@
         let bytes = trimmed.as_bytes();
         let mut in_quote = false;
         let mut escaped = false;
+        let mut in_line_comment = false;
         for (idx, &b) in bytes.iter().enumerate() {
             if in_quote {
                 if escaped { escaped = false; continue; }
@@ -75,19 +115,27 @@
                 if b == 39 { in_quote = false; }
                 continue;
             }
+            if in_line_comment {
+                if b == 10 { in_line_comment = false; }
+                continue;
+            }
+            if b == 37 { in_line_comment = true; continue; }
             if b == 39 { in_quote = true; continue; }
             if b == 46 {
                 let next_is_term_end = bytes.get(idx + 1)
                     .map(|c| c.is_ascii_whitespace() || *c == b'%')
                     .unwrap_or(true);
                 if next_is_term_end {
-                    return Some((trimmed[..idx].trim().to_string(), term_start + idx + 1));
+                    return Some((
+                        Self::strip_term_line_comments(&trimmed[..idx]),
+                        term_start + idx + 1,
+                    ));
                 }
             }
         }
         let body = trimmed.trim_end();
         let body = body.strip_suffix(".").unwrap_or(body);
-        Some((body.trim().to_string(), input.len()))
+        Some((Self::strip_term_line_comments(body), input.len()))
     }
 
     fn term_atom_text(atom: &str) -> String {

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -409,7 +409,8 @@ fn read_eof_binds_end_of_file() {
 fn read_consumes_buffered_terms_before_end_of_file() {
     let (code, labels) = shared_wam_program();
     let mut vm = WamState::new(code, labels);
-    vm.set_term_input("% header\nfirst.% between terms\npair(second, 2).");
+    vm.set_term_input(
+        "% header\nfirst.% between terms\npair(second, % ignored . full stop\n 2).");
 
     vm.set_reg_str("A1", ub("T1"));
     assert!(vm.execute_builtin("read/1", 1));


### PR DESCRIPTION
## Summary

- Ignore `%` line comments while locating a term’s terminating full stop.
- Remove inline comment text before invoking the portable parser.
- Preserve percent signs and escapes inside quoted atoms.
- Prevent full stops inside comments from prematurely ending a term.
- Keep the existing allocation behavior for comment-free reads.

The change is confined to Rust read-term input processing and does not affect ordinary WAM execution.

## Testing

- Focused generated Rust dynamic-builtin crate
- Full Rust WAM target suite
- Prolog target syntax check
- `git diff --check`