### PR TITLE
Skip block comments between Rust WAM terms

### DIFF
--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -51,12 +51,18 @@
             };
             let trimmed = suffix.trim_start();
             pos += suffix.len() - trimmed.len();
-            if !trimmed.starts_with('%') {
+            if trimmed.starts_with('%') {
+                match trimmed.find('\n') {
+                    Some(end) => pos += end + 1,
+                    None => return input.len(),
+                }
+            } else if let Some(block) = trimmed.strip_prefix("/*") {
+                match block.find("*/") {
+                    Some(end) => pos += end + 4,
+                    None => return input.len(),
+                }
+            } else {
                 return pos;
-            }
-            match trimmed.find('\n') {
-                Some(end) => pos += end + 1,
-                None => return input.len(),
             }
         }
     }
@@ -122,9 +128,12 @@
             if b == 37 { in_line_comment = true; continue; }
             if b == 39 { in_quote = true; continue; }
             if b == 46 {
-                let next_is_term_end = bytes.get(idx + 1)
-                    .map(|c| c.is_ascii_whitespace() || *c == b'%')
-                    .unwrap_or(true);
+                let next_is_term_end = match bytes.get(idx + 1) {
+                    None => true,
+                    Some(c) if c.is_ascii_whitespace() || *c == b'%' => true,
+                    Some(b'/') => bytes.get(idx + 2) == Some(&b'*'),
+                    _ => false,
+                };
                 if next_is_term_end {
                     return Some((
                         Self::strip_term_line_comments(&trimmed[..idx]),

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -410,7 +410,8 @@ fn read_consumes_buffered_terms_before_end_of_file() {
     let (code, labels) = shared_wam_program();
     let mut vm = WamState::new(code, labels);
     vm.set_term_input(
-        "% header\nfirst.% between terms\npair(second, % ignored . full stop\n 2).");
+        "/* block header . */% header\nfirst./* block between . */% between terms\n\
+         pair(second, % ignored . full stop\n 2).");
 
     vm.set_reg_str("A1", ub("T1"));
     assert!(vm.execute_builtin("read/1", 1));


### PR DESCRIPTION
## Summary

- Skip leading `/* ... */` comments before buffered terms.
- Recognize a block-comment opener after a terminating full stop.
- Support adjacent block and `%` comments as source layout.
- Ignore misleading full stops inside inter-term block comments.
- Add focused coverage alongside the existing line-comment cases.

This is confined to Rust read-term layout handling. Inline block comments remain outside this PR.

## Testing

- Focused generated Rust dynamic-builtin crate
- Full Rust WAM target suite
- Prolog target syntax check
- `git diff --check`