### PR TITLE
plawk: `//` integer-division semantics in loaded arith (WAM/LLVM) [stack 1/4]

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -17775,11 +17775,32 @@ ev_pow_pos_finish:
 
 ev_div:
   ; M85: second-byte check disambiguates ``/'' (division) from
-  ; ``/\\'' (bitwise AND). ``/\\'' has fn_ptr[1] = ''\\'' (92).
+  ; ``/\\'' (bitwise AND, fn_ptr[1] = ''\\'' = 92) and ``//''
+  ; (truncating integer division, fn_ptr[1] = ''/'' = 47 -- it used to
+  ; silently alias float-capable /, so 7 // 2 evaluated to 3.5 where
+  ; SWI yields 3).
   %div.fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
   %div.fn1 = load i8, i8* %div.fn1_ptr
   %div.is_band = icmp eq i8 %div.fn1, 92
-  br i1 %div.is_band, label %ev_band, label %ev_div_normal
+  br i1 %div.is_band, label %ev_band, label %ev_div_chk_int
+ev_div_chk_int:
+  %div.is_intdiv = icmp eq i8 %div.fn1, 47
+  br i1 %div.is_intdiv, label %ev_intdiv, label %ev_div_normal
+ev_intdiv:
+  ; // -- truncating integer division (LLVM sdiv truncates toward
+  ; zero, matching SWI). Integer operands only: a float operand is an
+  ; evaluation error, like SWI''s type check. Division by zero fails
+  ; through the arith-error channel.
+  br i1 %either_float, label %ev_zero, label %ev_intdiv_chk0
+ev_intdiv_chk0:
+  %idv.a_i = extractvalue %Value %a, 1
+  %idv.b_i = extractvalue %Value %b, 1
+  %idv.b_zero = icmp eq i64 %idv.b_i, 0
+  br i1 %idv.b_zero, label %ev_zero, label %ev_intdiv_go
+ev_intdiv_go:
+  %idv.r = sdiv i64 %idv.a_i, %idv.b_i
+  %idv.v = call %Value @value_integer(i64 %idv.r)
+  ret %Value %idv.v
 ev_band:
   ; M85: /\\ -- integer bitwise AND.
   %band.a_i = extractvalue %Value %a, 1

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -1590,6 +1590,31 @@ test(selfhost_arith_error_fails_cleanly, [condition(clang_available)]) :-
     assertion(Out == "2\n"),
     !.
 
+% Loaded truncating integer division (deferred small item): // used to
+% alias float-capable / (7 // 2 evaluated to 3.5 where SWI yields 3).
+% It now truncates toward zero (sdiv, matching SWI's default
+% integer_rounding_function), and division by zero fails through the
+% arith-error channel into the else branch. 7//2=3, -7//2=-3,
+% (3*100+3)*10+4 = 3034.
+test(selfhost_intdiv_truncates, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgid_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- A is 7 // 2, B is 0 - 7, C is B // 2, (D is 5 // 0 -> E = D ; E = 4), R is (A * 100 + (0 - C)) * 10 + E)]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "3034\n"),
+    !.
+
 % Nested arithmetic in the loaded compiler: the is-expression is staged
 % with c_operand (build_struct + X-temp deferral), so arbitrarily nested
 % expressions compile. (X + Y) * (X - 1) + 100 with X=3, Y=4 -> 114.


### PR DESCRIPTION
**Stack 1 of 4** (deferred small items + consolidation). Merge order: this PR → default-assoc → string-values → eval-docs. Each later PR is based on this one's branch, so merging top to bottom keeps every diff minimal.

## What

Closes the last first-byte aliasing residue *inside* the loaded-arith whitelist: `//` (integer division) shares its first byte with `/`, so `X is 7 // 2` in a loaded object ran as float division. The `ev_div` branch of `eval_arith_value` now checks the second byte of the functor name:

- `fn[1] == '\'` → `/\` (band, as before)
- `fn[1] == '/'` → **new `ev_intdiv`**: truncating `sdiv` (SWI's default `//` semantics)
- otherwise → normal division

Float operands and division by zero route through the existing arith-error flag (`@wam_arith_err`), failing `is/2` rather than yielding a wrong number — the same fail-loud channel the capstone round introduced.

## Tests

`selfhost_intdiv_truncates` in `tests/test_wam_object.pl`: a loaded grammar exercises positive truncation (`7 // 2 = 3`), negative truncation toward zero (`-7 // 2 = -3`), and div-by-zero failing cleanly into an if-then-else fallback — combined into one checked result (`3034`).

Full `test_wam_object` suite: 63/63 pass (fresh cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_