### PR TITLE
plawk: string values via a second assoc table kind — `as assoc(str)` (WAM/LLVM) [stack 3/4]

### DIFF
--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -127,6 +127,8 @@ build(File, Out0, KeepLL) :-
         ; plawk_program_dyncall_at_blob_arities(Program, DynAtBArities), DynAtBArities \== []
         ; plawk_program_dyncall_named_assoc_entries(Program, DynNamedAssoc), DynNamedAssoc \== []
         ; plawk_program_dyncall_assoc_arities(Program, DynAssocArities), DynAssocArities \== []
+        ; plawk_program_dyncall_named_assoc_str_entries(Program, DynNamedAssocS), DynNamedAssocS \== []
+        ; plawk_program_dyncall_assoc_str_arities(Program, DynAssocSArities), DynAssocSArities \== []
         )
     ->  ProjectOptions = [module_name(OutBase), emit_wamo_loader(true)]
     ;   ProjectOptions = [module_name(OutBase)]

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -14,6 +14,8 @@
     plawk_program_dyncall_named_rec_entries/2,
     plawk_program_dyncall_named_assoc_entries/2,
     plawk_program_dyncall_assoc_arities/2,
+    plawk_program_dyncall_named_assoc_str_entries/2,
+    plawk_program_dyncall_assoc_str_arities/2,
     plawk_program_dyncall_at_arities/2,
     plawk_program_dyncall_float_arities/2,
     plawk_program_dyncall_at_float_arities/2,
@@ -640,6 +642,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_dyncall_named_rec_entries(Program, DynNamedRec),
     plawk_program_dyncall_named_assoc_entries(Program, DynNamedAssoc),
     plawk_program_dyncall_assoc_arities(Program, DynAssocArities),
+    plawk_program_dyncall_named_assoc_str_entries(Program, DynNamedAssocS),
+    plawk_program_dyncall_assoc_str_arities(Program, DynAssocSArities),
     plawk_program_dyncall_at_arities(Program, DynAtArities),
     plawk_program_dyncall_float_arities(Program, DynFArities),
     plawk_program_dyncall_at_float_arities(Program, DynAtFArities),
@@ -656,6 +660,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         DynNamedRec == [],
         DynNamedAssoc == [],
         DynAssocArities == [],
+        DynNamedAssocS == [],
+        DynAssocSArities == [],
         DynAtArities == [],
         DynFArities == [],
         DynAtFArities == [],
@@ -676,7 +682,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         (   DynArities == [], DynFArities == [], DynBArities == [],
             DynNamed == [], DynNamedF == [], DynNamedB == [],
             DynRecArities == [], DynNamedRec == [], DynNamedAssoc == [],
-            DynAssocArities == []
+            DynAssocArities == [], DynNamedAssocS == [],
+            DynAssocSArities == []
         ->  DyncallSupportIR = ''
         ;   ( plawk_program_dynload_path(Program, DynPath)
             ->  true
@@ -687,7 +694,7 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
             plawk_dyncall_support_ir(DynPath, DynArities, DynFArities,
                 DynBArities, DynNamed, DynNamedF, DynNamedB,
                 DynRecArities, DynNamedRec, DynNamedAssoc, DynAssocArities,
-                DyncallSupportIR)
+                DynNamedAssocS, DynAssocSArities, DyncallSupportIR)
         ),
         % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...)) /
         % blob(dyncall_at(...)) sites + the shared path cache.
@@ -929,11 +936,49 @@ plawk_program_dyncall_assoc_arities(program(_Begin, Rules, EndClauses),
         A0),
     sort(A0, Arities).
 
+%% plawk_program_dyncall_named_assoc_str_entries(+Program, -Entries)
+%% plawk_program_dyncall_assoc_str_arities(+Program, -Arities)
+%  The str-valued table kind: `arr = dyncall@name(args) as assoc(str)`
+%  sites get @plawk_dyncall_assoc_str_<Name>_<N> shims, default-entry
+%  sites @plawk_dyncall_assoc_str_default_<N> -- both forwarding to
+%  @wam_object_call_assoc_str (atom values, replace semantics).
+plawk_program_dyncall_named_assoc_str_entries(
+        program(_Begin, Rules, EndClauses), Entries) :-
+    findall(Name-NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          member(Action, Actions),
+          plawk_subterm_dynassoc_str_call(Action, dyncall_named(Name, Args)),
+          length(Args, NArgs)
+        ),
+        Entries0),
+    sort(Entries0, Entries).
+
+plawk_program_dyncall_assoc_str_arities(program(_Begin, Rules, EndClauses),
+        Arities) :-
+    findall(NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          member(Action, Actions),
+          plawk_subterm_dynassoc_str_call(Action, dyncall(Args)),
+          length(Args, NArgs)
+        ),
+        A0),
+    sort(A0, Arities).
+
 plawk_subterm_dynassoc_call(dynassoc_bind(_Var, Call), Call).
 plawk_subterm_dynassoc_call(Term, Call) :-
     compound(Term),
     arg(_, Term, Sub),
     plawk_subterm_dynassoc_call(Sub, Call).
+
+plawk_subterm_dynassoc_str_call(dynassoc_bind_str(_Var, Call), Call).
+plawk_subterm_dynassoc_str_call(Term, Call) :-
+    compound(Term),
+    arg(_, Term, Sub),
+    plawk_subterm_dynassoc_str_call(Sub, Call).
 
 plawk_subterm_dynrec_call(dynrec_bind(_Vars, Call, _Types), Call).
 plawk_subterm_dynrec_call(dynrec_view(Call, _Types, _Body), Call).
@@ -1257,15 +1302,23 @@ plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
         NamedI, NamedF, NamedB, RecArities, NamedRec, IR) :-
     plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
-        NamedI, NamedF, NamedB, RecArities, NamedRec, [], [], IR).
+        NamedI, NamedF, NamedB, RecArities, NamedRec, [], [], [], [], IR).
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
         NamedI, NamedF, NamedB, RecArities, NamedRec, NamedAssoc, IR) :-
     plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
-        NamedI, NamedF, NamedB, RecArities, NamedRec, NamedAssoc, [], IR).
+        NamedI, NamedF, NamedB, RecArities, NamedRec, NamedAssoc,
+        [], [], [], IR).
+plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
+        NamedI, NamedF, NamedB, RecArities, NamedRec, NamedAssoc,
+        AssocArities, IR) :-
+    plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
+        NamedI, NamedF, NamedB, RecArities, NamedRec, NamedAssoc,
+        AssocArities, [], [], IR).
 
 %% plawk_dyncall_support_ir(+Path, +IArities, +FArities, +BArities,
 %%                          +NamedI, +NamedF, +NamedB, +RecArities,
-%%                          +NamedRec, +NamedAssoc, +AssocArities, -IR)
+%%                          +NamedRec, +NamedAssoc, +AssocArities,
+%%                          +NamedAssocStr, +AssocStrArities, -IR)
 %  IArities -> i64 @plawk_dyncall_N shims; FArities -> double
 %  @plawk_dyncall_f_N shims (float(dyncall(...))); BArities -> byte-slice
 %  @plawk_dyncall_b_N shims (blob(dyncall(...))). NamedI/NamedF/NamedB are
@@ -1280,10 +1333,13 @@ plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
 %  destructure binds (they also feed the resolver union). NamedAssoc ->
 %  @plawk_dyncall_assoc_<Name>_<N> assoc-populating shims and AssocArities
 %  -> their default-entry @plawk_dyncall_assoc_default_<N> counterparts.
-%  All share the single lazily loaded object handle + @plawk_dyncall_get.
+%  NamedAssocStr / AssocStrArities are the str-valued table kind
+%  (@plawk_dyncall_assoc_str_* shims forwarding to
+%  @wam_object_call_assoc_str). All share the single lazily loaded object
+%  handle + @plawk_dyncall_get.
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
         NamedI, NamedF, NamedB, RecArities, NamedRec, NamedAssoc,
-        AssocArities, IR) :-
+        AssocArities, NamedAssocStr, AssocStrArities, IR) :-
     llvm_emit_c_string_global('plawk_dyncall_path', Path, PathGlobal,
         _StrLen, BytesLen),
     format(atom(GetterIR),
@@ -1321,7 +1377,8 @@ load:
     % one shared resolver per named entry, over the union of the kinds
     % (record binds that name an entry feed the union too, so their
     % resolver exists even when the entry is used nowhere else)
-    append([NamedI, NamedF, NamedB, NamedRec, NamedAssoc], NamedAll0),
+    append([NamedI, NamedF, NamedB, NamedRec, NamedAssoc, NamedAssocStr],
+        NamedAll0),
     sort(NamedAll0, NamedAll),
     findall(ResIR,
         ( member(REName-RENArgs, NamedAll),
@@ -1354,9 +1411,17 @@ load:
         ( member(DAN, AssocArities),
           plawk_dyncall_assoc_default_shim_ir(DAN, DAShim) ),
         DAShims),
+    findall(NSShim,
+        ( member(NSName-NSNArgs, NamedAssocStr),
+          plawk_dyncall_named_assoc_str_shim_ir(NSName, NSNArgs, NSShim) ),
+        NSShims),
+    findall(DSShim,
+        ( member(DSN, AssocStrArities),
+          plawk_dyncall_assoc_default_str_shim_ir(DSN, DSShim) ),
+        DSShims),
     append([[PathGlobal, GetterIR], IShims, FShims, BShims,
             Resolvers, NIShims, NFShims, NBShims, RecShims, NRecShims,
-            NAShims, DAShims], Parts),
+            NAShims, DAShims, NSShims, DSShims], Parts),
     atomic_list_concat(Parts, '\n\n', IR).
 
 %% plawk_dyncall_named_assoc_shim_ir(+Name, +NArgs, -IR)
@@ -1408,6 +1473,60 @@ do_call:
   %args = alloca %Value, i32 ~w
 ~w
   %r = call i1 @wam_object_call_assoc(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, %WamAssocI64Table* %table)
+  ret i1 %r
+
+fail:
+  ret i1 false
+}',
+        [NArgs, ParamsIR, NArgs, StoreIR, NArgs, NArgs]).
+
+%% plawk_dyncall_named_assoc_str_shim_ir(+Name, +NArgs, -IR)
+%  Str-valued table kind, named entry: same shape as the i64 assoc shim
+%  but forwarding to @wam_object_call_assoc_str, which requires ATOM
+%  values and stores their registry ids with replace semantics.
+plawk_dyncall_named_assoc_str_shim_ir(Name, NArgs, IR) :-
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define i1 @plawk_dyncall_assoc_str_~w(~w, %WamAssocI64Table* %table) {
+entry:
+  %pc = call i32 @plawk_dyncall_resolve_~w()
+  %bad = icmp slt i32 %pc, 0
+  br i1 %bad, label %fail, label %do_call
+
+do_call:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call i1 @wam_object_call_assoc_str(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, %WamAssocI64Table* %table)
+  ret i1 %r
+
+fail:
+  ret i1 false
+}',
+        [Sym, ParamsIR, Sym, NArgs, StoreIR, NArgs, NArgs]).
+
+%% plawk_dyncall_assoc_default_str_shim_ir(+NArgs, -IR)
+%  Str-valued table kind, default entry: entry PC recorded at object-load
+%  time, values forwarded to @wam_object_call_assoc_str.
+plawk_dyncall_assoc_default_str_shim_ir(NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define i1 @plawk_dyncall_assoc_str_default_~w(~w, %WamAssocI64Table* %table) {
+entry:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %pc = load i32, i32* @plawk_dyncall_pc
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call i1 @wam_object_call_assoc_str(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, %WamAssocI64Table* %table)
   ret i1 %r
 
 fail:
@@ -2764,14 +2883,28 @@ plawk_forin_body_print_lines([assoc(var(LookupArrayName), var(LoopVar)) | Rest],
               '  %forin_value_~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_key_id)',
               [PrintIndex, LookupTableIndex])
       ),
-      format(atom(FmtVar), 'forin_i64_fmt_~w', [PrintIndex]),
-      format(atom(PrintVar), 'forin_printed_i64_~w', [PrintIndex]),
       format(atom(ValueIR), '%forin_value_~w', [PrintIndex]),
-      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
-          [FmtPtr, PrintCall]),
+      (   plawk_assoc_plan_str_array(AssocPlan, LookupArrayName)
+      ->  % str-valued table: the stored i64 is an atom-registry id --
+          % resolve it to text, like the key print does.
+          format(atom(ValueString),
+              '  %forin_value_s_~w = call i8* @wam_atom_to_string(i64 ~w)',
+              [PrintIndex, ValueIR]),
+          format(atom(FmtVar), 'forin_str_fmt_~w', [PrintIndex]),
+          format(atom(PrintVar), 'forin_printed_str_~w', [PrintIndex]),
+          format(atom(PtrIR), '%forin_value_s_~w', [PrintIndex]),
+          llvm_emit_printf_string(plawk_surface_print_string, FmtVar, PrintVar,
+              PtrIR, [FmtPtr, PrintCall]),
+          ValueLines = [Value, ValueString, FmtPtr, PrintCall]
+      ;   format(atom(FmtVar), 'forin_i64_fmt_~w', [PrintIndex]),
+          format(atom(PrintVar), 'forin_printed_i64_~w', [PrintIndex]),
+          llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+              ValueIR, [FmtPtr, PrintCall]),
+          ValueLines = [Value, FmtPtr, PrintCall]
+      ),
       NextPrintIndex is PrintIndex + 1
     },
-    [Value, FmtPtr, PrintCall],
+    plawk_emit_lines(ValueLines),
     plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
         Descriptor, OutputSeparator, NextPrintIndex).
 plawk_forin_body_print_lines([string(Value) | Rest], LoopVar, ArrayName,
@@ -3463,6 +3596,13 @@ plawk_assoc_body_action_spec(inc_assoc(var(ArrayName), Blob),
     plawk_assoc_blob_key_ok(Blob).
 plawk_assoc_body_action_spec(dynassoc_bind(var(ArrayName), Call),
         dynassoc(ArrayName, Call)) :-
+    plawk_dynrec_call_ok(Call).
+% str-valued table kind: the call rides the same dynassoc spec wrapped in
+% str(...), so planning and the apply emitter reuse the same action --
+% only the shim name (via plawk_dynassoc_call_parts) and the table's
+% declared value kind differ.
+plawk_assoc_body_action_spec(dynassoc_bind_str(var(ArrayName), Call),
+        dynassoc(ArrayName, str(Call))) :-
     plawk_dynrec_call_ok(Call).
 
 plawk_assoc_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), ArrayName-KeyIndex) :-
@@ -5801,14 +5941,27 @@ plawk_assoc_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], AssocPl
       format(atom(Value),
           '  %assoc_end_value_~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %assoc_end_key_~w_id)',
           [PrintIndex, TableIndex, PrintIndex]),
-      format(atom(FmtVar), 'assoc_end_i64_fmt_~w', [PrintIndex]),
-      format(atom(PrintVar), 'printed_assoc_end_i64_~w', [PrintIndex]),
       format(atom(ValueIR), '%assoc_end_value_~w', [PrintIndex]),
-      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
-          [FmtPtr, PrintCall]),
+      (   plawk_assoc_plan_str_array(AssocPlan, ArrayName)
+      ->  % str-valued table: resolve the stored atom-registry id to text.
+          format(atom(ValueString),
+              '  %assoc_end_value_s_~w = call i8* @wam_atom_to_string(i64 ~w)',
+              [PrintIndex, ValueIR]),
+          format(atom(FmtVar), 'assoc_end_str_fmt_~w', [PrintIndex]),
+          format(atom(PrintVar), 'printed_assoc_end_str_~w', [PrintIndex]),
+          format(atom(PtrIR), '%assoc_end_value_s_~w', [PrintIndex]),
+          llvm_emit_printf_string(plawk_surface_print_string, FmtVar, PrintVar,
+              PtrIR, [FmtPtr, PrintCall]),
+          ValueLines = [KeyPtr, KeyId, Value, ValueString, FmtPtr, PrintCall]
+      ;   format(atom(FmtVar), 'assoc_end_i64_fmt_~w', [PrintIndex]),
+          format(atom(PrintVar), 'printed_assoc_end_i64_~w', [PrintIndex]),
+          llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+              ValueIR, [FmtPtr, PrintCall]),
+          ValueLines = [KeyPtr, KeyId, Value, FmtPtr, PrintCall]
+      ),
       NextPrintIndex is PrintIndex + 1
     },
-    [KeyPtr, KeyId, Value, FmtPtr, PrintCall],
+    plawk_emit_lines(ValueLines),
     plawk_assoc_end_print_lines(Rest, AssocPlan, Descriptor, OutputSeparator, NextPrintIndex).
 plawk_assoc_end_print_lines([string(Value) | Rest], AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
@@ -5818,6 +5971,17 @@ plawk_assoc_end_print_lines([string(Value) | Rest], AssocPlan, Descriptor, Outpu
 
 plawk_assoc_table_index(assoc_plan(Tables, _Actions), ArrayName, TableIndex) :-
     nth0(TableIndex, Tables, ArrayName).
+
+%% plawk_assoc_plan_str_array(+AssocPlan, +ArrayName) is semidet.
+%  ArrayName's table holds STRING values: some rule populates it through
+%  an `as assoc(str)` bind (the planned action carries the str(...)
+%  wrapper), so reads resolve the stored i64 back to atom text instead
+%  of printing it numerically.
+plawk_assoc_plan_str_array(assoc_plan(_Tables, Rules), ArrayName) :-
+    member(assoc_rule(_RuleIndex, _Pattern, Actions, _Control), Rules),
+    member(assoc_dyn_action(_Index, ArrayName, _TableIndex, str(_Call)),
+        Actions),
+    !.
 
 % Binary record modes: assoc keys are raw i64 field values (no
 % interning), so END key handling prints them numerically.
@@ -5875,14 +6039,27 @@ plawk_mixed_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], ScalarP
       format(atom(Value),
           '  %assoc_end_value_~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %assoc_end_key_~w_id)',
           [PrintIndex, TableIndex, PrintIndex]),
-      format(atom(FmtVar), 'assoc_end_i64_fmt_~w', [PrintIndex]),
-      format(atom(PrintVar), 'printed_assoc_end_i64_~w', [PrintIndex]),
       format(atom(ValueIR), '%assoc_end_value_~w', [PrintIndex]),
-      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
-          [FmtPtr, PrintCall]),
+      (   plawk_assoc_plan_str_array(AssocPlan, ArrayName)
+      ->  % str-valued table: resolve the stored atom-registry id to text.
+          format(atom(ValueString),
+              '  %assoc_end_value_s_~w = call i8* @wam_atom_to_string(i64 ~w)',
+              [PrintIndex, ValueIR]),
+          format(atom(FmtVar), 'assoc_end_str_fmt_~w', [PrintIndex]),
+          format(atom(PrintVar), 'printed_assoc_end_str_~w', [PrintIndex]),
+          format(atom(PtrIR), '%assoc_end_value_s_~w', [PrintIndex]),
+          llvm_emit_printf_string(plawk_surface_print_string, FmtVar, PrintVar,
+              PtrIR, [FmtPtr, PrintCall]),
+          ValueLines = [KeyPtr, KeyId, Value, ValueString, FmtPtr, PrintCall]
+      ;   format(atom(FmtVar), 'assoc_end_i64_fmt_~w', [PrintIndex]),
+          format(atom(PrintVar), 'printed_assoc_end_i64_~w', [PrintIndex]),
+          llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+              ValueIR, [FmtPtr, PrintCall]),
+          ValueLines = [KeyPtr, KeyId, Value, FmtPtr, PrintCall]
+      ),
       NextPrintIndex is PrintIndex + 1
     },
-    [KeyPtr, KeyId, Value, FmtPtr, PrintCall],
+    plawk_emit_lines(ValueLines),
     plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
 plawk_mixed_end_print_lines([special('NR') | Rest], ScalarPlan, AssocPlan, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
@@ -6450,6 +6627,15 @@ plawk_dynassoc_call_parts(dyncall_named(Name, Args), Args, ShimName) :-
 plawk_dynassoc_call_parts(dyncall(Args), Args, ShimName) :-
     length(Args, NArgs),
     format(atom(ShimName), 'plawk_dyncall_assoc_default_~w', [NArgs]).
+% str-valued table kind (`as assoc(str)`): the spec wraps the call in
+% str(...); route to the @wam_object_call_assoc_str shims.
+plawk_dynassoc_call_parts(str(dyncall_named(Name, Args)), Args, ShimName) :-
+    length(Args, NArgs),
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    format(atom(ShimName), 'plawk_dyncall_assoc_str_~w', [Sym]).
+plawk_dynassoc_call_parts(str(dyncall(Args)), Args, ShimName) :-
+    length(Args, NArgs),
+    format(atom(ShimName), 'plawk_dyncall_assoc_str_default_~w', [NArgs]).
 
 plawk_dynrec_field_load_lines([], [], _Base, []).
 plawk_dynrec_field_load_lines([F | Fs], [Type | Ts], Base, [Line | Lines]) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -984,12 +984,17 @@ break_action(break) -->
 %
 %      arr = dyncall@tally($1) as assoc
 %      arr = dyncall($1) as assoc          % DYNLOAD object's default entry
+%      arr = dyncall@label($1) as assoc(str)   % string VALUES
 %
 %  desugars to dynassoc_bind(var(arr), dyncall_named(tally, [field(1)]))
 %  (or dynassoc_bind(var(arr), dyncall([field(1)])) for the default-entry
 %  form); per record the returned [K-V, ...] pairs are inserted into arr's
 %  i64 table, so END `arr[key]` lookups see the accumulated result.
-dynassoc_bind_action(dynassoc_bind(var(Name), Call)) -->
+%
+%  The `(str)` value kind yields dynassoc_bind_str(var(arr), Call): the
+%  grammar returns ATOM values, stored by registry id with replace (not
+%  accumulate) semantics, and reads print the text.
+dynassoc_bind_action(Action) -->
     identifier(Name),
     ws,
     "=",
@@ -999,7 +1004,18 @@ dynassoc_bind_action(dynassoc_bind(var(Name), Call)) -->
     "as",
     identifier_boundary,
     ws,
-    "assoc".
+    "assoc",
+    dynassoc_value_kind(Kind),
+    { Kind == str
+    ->  Action = dynassoc_bind_str(var(Name), Call)
+    ;   Action = dynassoc_bind(var(Name), Call)
+    }.
+
+dynassoc_value_kind(str) -->
+    ws, "(", ws, "str", ws, ")",
+    !.
+dynassoc_value_kind(i64) -->
+    [].
 
 dynrec_view_action(dynrec_view(Call, Types, Body)) -->
     dynrec_call_expr(Call),

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4710,6 +4710,86 @@ inc.fail:
   ret i64 0
 }
 
+; Insert-or-REPLACE variant: a repeated key takes the latest value instead
+; of accumulating. This is the write primitive for str-valued tables, whose
+; i64 payloads are atom-registry ids -- adding two ids is meaningless, so
+; last-write-wins is the accumulate analogue for labels.
+define i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %key, i64 %value) {
+entry:
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %set.fail, label %set.load
+
+set.load:
+  %cap_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 1
+  %cap = load i64, i64* %cap_slot
+  %cap_zero = icmp eq i64 %cap, 0
+  br i1 %cap_zero, label %set.fail, label %set.start
+
+set.start:
+  %entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  %entries = load %WamAssocI64Entry*, %WamAssocI64Entry** %entries_slot
+  %entries_null = icmp eq %WamAssocI64Entry* %entries, null
+  br i1 %entries_null, label %set.fail, label %set.hash
+
+set.hash:
+  %start = urem i64 %key, %cap
+  br label %set.loop
+
+set.loop:
+  %idx = phi i64 [ %start, %set.hash ], [ %next_idx, %set.next ]
+  %probes = phi i64 [ 0, %set.hash ], [ %next_probes, %set.next ]
+  %assoc_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %idx
+  %occupied_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 2
+  %occupied = load i1, i1* %occupied_slot
+  br i1 %occupied, label %set.check_key, label %set.insert
+
+set.check_key:
+  %key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 0
+  %found_key = load i64, i64* %key_slot
+  %key_match = icmp eq i64 %found_key, %key
+  br i1 %key_match, label %set.update, label %set.next_check
+
+set.update:
+  %value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 1
+  store i64 %value, i64* %value_slot
+  ret i64 %value
+
+set.insert:
+  %count_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 0
+  %old_count = load i64, i64* %count_slot
+  %new_count = add i64 %old_count, 1
+  %half_cap = lshr i64 %cap, 1
+  %needs_grow = icmp ugt i64 %new_count, %half_cap
+  br i1 %needs_grow, label %set.grow, label %set.insert_store
+
+set.grow:
+  %grew = call i1 @wam_assoc_i64_resize(%WamAssocI64Table* %table)
+  br i1 %grew, label %set.load, label %set.insert_store
+
+set.insert_store:
+  %insert_key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 0
+  store i64 %key, i64* %insert_key_slot
+  %insert_value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 1
+  store i64 %value, i64* %insert_value_slot
+  store i1 true, i1* %occupied_slot
+  store i64 %new_count, i64* %count_slot
+  ret i64 %value
+
+set.next_check:
+  %next_probes = add i64 %probes, 1
+  %full = icmp uge i64 %next_probes, %cap
+  br i1 %full, label %set.fail, label %set.next
+
+set.next:
+  %idx_plus = add i64 %idx, 1
+  %wrap = icmp uge i64 %idx_plus, %cap
+  %next_idx = select i1 %wrap, i64 0, i64 %idx_plus
+  br label %set.loop
+
+set.fail:
+  ret i64 0
+}
+
 define void @wam_assoc_i64_free(%WamAssocI64Table* %table) {
 entry:
   %table_null = icmp eq %WamAssocI64Table* %table, null
@@ -23489,6 +23569,119 @@ insert:
   %kval = call i64 @value_payload(%Value %kv)
   %vval = call i64 @value_payload(%Value %vv)
   %ignored = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 %kval, i64 %vval)
+  br label %next
+next:
+  %tail_d = call %Value @wam_deref_value(%WamState* %vm, %Value %t_raw)
+  br label %walk
+walk_done:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  ret i1 true
+rewind_fail:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  br label %fail
+fail:
+  ret i1 false
+}
+
+; The SECOND table kind: string values. Same [K1-V1, K2-V2, ...] walk as
+; @wam_object_call_assoc, but each value must be an ATOM and its id (a
+; global-registry id, the keyspace text-mode slices intern into) is stored
+; via @wam_assoc_i64_set -- REPLACE semantics, since accumulating ids is
+; meaningless; a repeated key keeps the latest label. Keys stay Integer or
+; Atom as in the i64 kind. The table layout is the shared i64 table; only
+; the declared value kind (surface: `as assoc(str)`) tells the reader to
+; resolve values back to text. Returns i1 ok; false on call failure, a
+; non-list output, a non-pair element, a bad key, or a non-Atom value.
+define i1 @wam_object_call_assoc_str(%WamState* %vm, i32 %entry_pc, i32 %nargs, %Value* %args, i32 %out_reg, %WamAssocI64Table* %table) {
+entry:
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+do_call:
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs_saved = load i32, i32* %hs_ptr
+  %unb = call %Value @value_unbound(i8* null)
+  %out_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %out_ref = call %Value @value_ref(i32 %out_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %entry_pc)
+  br label %argloop
+argloop:
+  %ai = phi i32 [ 0, %do_call ], [ %ai1, %argstep ]
+  %adone = icmp sge i32 %ai, %nargs
+  br i1 %adone, label %args_done, label %argstep
+argstep:
+  %aidx64 = sext i32 %ai to i64
+  %ap = getelementptr %Value, %Value* %args, i64 %aidx64
+  %av = load %Value, %Value* %ap
+  call void @wam_set_reg(%WamState* %vm, i32 %ai, %Value %av)
+  %ai1 = add i32 %ai, 1
+  br label %argloop
+args_done:
+  call void @wam_set_reg(%WamState* %vm, i32 %out_reg, %Value %out_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %walk_init, label %rewind_fail
+walk_init:
+  %consfn = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  %head0 = call %Value @wam_deref_value(%WamState* %vm, %Value %out_ref)
+  br label %walk
+walk:
+  %cur = phi %Value [ %head0, %walk_init ], [ %tail_d, %next ]
+  %ctag = call i32 @value_tag(%Value %cur)
+  %is_comp = icmp eq i32 %ctag, 3
+  br i1 %is_comp, label %check_cons, label %walk_done
+check_cons:
+  %cbits = call i64 @value_payload(%Value %cur)
+  %ccp = inttoptr i64 %cbits to %Compound*
+  %cfn_slot = getelementptr %Compound, %Compound* %ccp, i32 0, i32 0
+  %cfn = load i8*, i8** %cfn_slot
+  %car_slot = getelementptr %Compound, %Compound* %ccp, i32 0, i32 1
+  %car = load i32, i32* %car_slot
+  %car_ok = icmp eq i32 %car, 2
+  br i1 %car_ok, label %cmp_cons, label %walk_done
+cmp_cons:
+  %fncmp = call i32 @strcmp(i8* %cfn, i8* %consfn)
+  %is_cons = icmp eq i32 %fncmp, 0
+  br i1 %is_cons, label %have_cell, label %walk_done
+have_cell:
+  %cargs_slot = getelementptr %Compound, %Compound* %ccp, i32 0, i32 2
+  %cargs = load %Value*, %Value** %cargs_slot
+  %h_ptr = getelementptr %Value, %Value* %cargs, i64 0
+  %h_raw = load %Value, %Value* %h_ptr
+  %t_ptr = getelementptr %Value, %Value* %cargs, i64 1
+  %t_raw = load %Value, %Value* %t_ptr
+  %pair = call %Value @wam_deref_value(%WamState* %vm, %Value %h_raw)
+  %ptag = call i32 @value_tag(%Value %pair)
+  %p_is_comp = icmp eq i32 %ptag, 3
+  br i1 %p_is_comp, label %pair_arity, label %rewind_fail
+pair_arity:
+  %pbits = call i64 @value_payload(%Value %pair)
+  %pcp = inttoptr i64 %pbits to %Compound*
+  %par_slot = getelementptr %Compound, %Compound* %pcp, i32 0, i32 1
+  %par = load i32, i32* %par_slot
+  %par_ok = icmp eq i32 %par, 2
+  br i1 %par_ok, label %pair_args, label %rewind_fail
+pair_args:
+  %pargs_slot = getelementptr %Compound, %Compound* %pcp, i32 0, i32 2
+  %pargs = load %Value*, %Value** %pargs_slot
+  %k_ptr = getelementptr %Value, %Value* %pargs, i64 0
+  %k_raw = load %Value, %Value* %k_ptr
+  %v_ptr = getelementptr %Value, %Value* %pargs, i64 1
+  %v_raw = load %Value, %Value* %v_ptr
+  %kv = call %Value @wam_deref_value(%WamState* %vm, %Value %k_raw)
+  %vv = call %Value @wam_deref_value(%WamState* %vm, %Value %v_raw)
+  %ktag = call i32 @value_tag(%Value %kv)
+  %vtag = call i32 @value_tag(%Value %vv)
+  %k_is_int = icmp eq i32 %ktag, 1
+  %k_is_atom = icmp eq i32 %ktag, 0
+  %k_ok = or i1 %k_is_int, %k_is_atom
+  %v_is_atom = icmp eq i32 %vtag, 0
+  %kv_ok = and i1 %k_ok, %v_is_atom
+  br i1 %kv_ok, label %insert, label %rewind_fail
+insert:
+  %kval = call i64 @value_payload(%Value %kv)
+  %vval = call i64 @value_payload(%Value %vv)
+  %ignored = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %kval, i64 %vval)
   br label %next
 next:
   %tail_d = call %Value @wam_deref_value(%WamState* %vm, %Value %t_raw)

--- a/tests/test_plawk_dyncall_assoc.pl
+++ b/tests/test_plawk_dyncall_assoc.pl
@@ -28,6 +28,13 @@ tallyc(X, R) :-
     atom_number(X, N),
     ( N > 100 -> R = [big-2, seen-1] ; R = [small-1, seen-1] ).
 
+% labeler(X) returns ATOM values (the str table kind): a size label that
+% every record overwrites (replace semantics -- the LAST record wins) and
+% the record text itself under last.
+labeler(X, R) :-
+    atom_number(X, N),
+    ( N > 100 -> R = [size-big, last-X] ; R = [size-small, last-X] ).
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -149,6 +156,70 @@ test(assoc_default_entry_populates_and_reads, [condition(clang_available)]) :-
          END { print arr[1], arr[2] }\n", [Wamo]),
     build_run(Dir, 'dadef', Src, [5, 7], Out),
     assertion(Out == "12 200\n"),
+    !.
+
+% String VALUES (the second table kind, deferred small item):
+% `arr = dyncall@name(...) as assoc(str)` parses to its own node.
+test(assoc_str_bind_parses) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         { arr = dyncall@labeler($1) as assoc(str) }\nEND { print arr[\"size\"] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(dynassoc_bind_str(var(arr), dyncall_named(labeler, [field(1)])),
+        Actions),
+    !.
+
+% The str entry is collected separately from the i64 kind, and the emitted
+% IR routes through the str shim + primitive and resolves the value back
+% to text at the read site.
+test(assoc_str_ir_emitted) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         { arr = dyncall@labeler($1) as assoc(str) }\nEND { print arr[\"size\"] }\n",
+        Program),
+    plawk_program_dyncall_named_assoc_str_entries(Program, StrEntries),
+    assertion(StrEntries == [labeler-1]),
+    plawk_program_dyncall_named_assoc_entries(Program, I64Entries),
+    assertion(I64Entries == []),
+    plawk_program_native_driver_ir(Program, stdin_or_argv,
+        [wam_vm(10, 10)], IR),
+    sub_atom(IR, _, _, _, '@plawk_dyncall_assoc_str_labeler_1'),
+    sub_atom(IR, _, _, _, '@wam_object_call_assoc_str'),
+    sub_atom(IR, _, _, _, '@wam_atom_to_string'),
+    !.
+
+% Full round trip: atom values land by registry id, the for-in report
+% resolves them to text, and a repeated key REPLACES (size flips
+% small/big/big/small over the records -- the last record wins).
+test(assoc_str_values_populate_and_report, [condition(clang_available)]) :-
+    da_dir(Dir),
+    directory_file_path(Dir, 'libs.wamo', Wamo),
+    write_wam_object([user:labeler/2], [wamo_entries([labeler/2])], Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@labeler($1) as assoc(str) }\n\c
+         END { for (k in arr) print k, arr[k] }\n", [Wamo]),
+    build_run_text(Dir, 'das', Src, "50\n200\n300\n7\n", Out),
+    split_string(Out, "\n", "", Lines0),
+    exclude(==(""), Lines0, Lines),
+    msort(Lines, Sorted),
+    assertion(Sorted == ["last 7", "size small"]),
+    !.
+
+% A str-valued table answers END string-literal lookups with text too.
+test(assoc_str_values_literal_lookup, [condition(clang_available)]) :-
+    da_dir(Dir),
+    directory_file_path(Dir, 'libs.wamo', Wamo),
+    ( exists_file(Wamo)
+    -> true
+    ;  write_wam_object([user:labeler/2], [wamo_entries([labeler/2])], Wamo)
+    ),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@labeler($1) as assoc(str) }\n\c
+         END { print arr[\"size\"], arr[\"last\"] }\n", [Wamo]),
+    build_run_text(Dir, 'dasl', Src, "50\n200\n300\n7\n", Out),
+    assertion(Out == "small 7\n"),
     !.
 
 :- end_tests(plawk_dyncall_assoc).


### PR DESCRIPTION
**Stack 3 of 4** — based on #3631.

## What

The last string shape gets a container: a grammar can return **atom values**, declared at the surface as a str-valued table.

```awk
arr = dyncall@labeler($1) as assoc(str)
arr = dyncall($1) as assoc(str)          # default entry
```

### Runtime (WAM/LLVM target)

- `@wam_assoc_i64_set`: insert-or-**REPLACE** twin of `@wam_assoc_i64_inc`. Values in a str table are atom-registry ids; adding ids is meaningless, so a repeated key keeps the latest label instead of accumulating.
- `@wam_object_call_assoc_str`: same `[K-V,...]` walk as `@wam_object_call_assoc`, but each value must be an Atom and its id (a global-registry id — the keyspace text-mode slices intern into) is stored via the set primitive. Keys stay Integer-or-Atom.

### Codegen

- Parser: optional `(str)` after `as assoc` yields `dynassoc_bind_str`; the spec wraps the call as `dynassoc(A, str(Call))` so planning and the apply emitter are **reused unchanged** — only the shim name and the table's declared value kind differ.
- `@plawk_dyncall_assoc_str_<Sym>` / `@plawk_dyncall_assoc_str_default_<N>` shims forward to the str primitive; collectors, support-IR params, driver wiring, and the CLI loader gate follow the established per-kind pattern.
- Reads resolve text: for-in value prints and END string-literal lookups check `plawk_assoc_plan_str_array` and route the stored i64 through `@wam_atom_to_string` (as key prints already did) instead of printing it numerically.

## Tests

`tests/test_plawk_dyncall_assoc.pl` (12/12): parse node; IR emission (str shim + primitive + text resolution, i64 collector stays empty); a for-in report round trip whose `size` key flips small/big/big/small across records — proving replace semantics; an END literal lookup printing text (`"small 7"`). Regression: `test_wam_object` 63/63 fresh-cache, plus the for-in/assoc/binfmt print suites all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_