### PR TITLE
docs: eval-arc architecture summary + roadmap consolidation (WAM/LLVM) [stack 4/4]

### DIFF
--- a/docs/design/PLAWK_EVAL_ARCHITECTURE.md
+++ b/docs/design/PLAWK_EVAL_ARCHITECTURE.md
@@ -1,0 +1,206 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2026 John William Creighton (@s243a)
+-->
+
+# The plawk eval arc — a top-level architecture summary
+
+Everything in one place: how a plawk binary compiles Prolog **source
+text** at runtime, loads the result, and calls it — and how the pieces
+that make that possible stack on each other. This is the map; the
+detailed design docs are linked from each layer.
+
+The one-line demo the whole arc exists for:
+
+```awk
+{ total += dyncall_at(compile("[(sq(X, R) :- atom_number(X, N), R is N * N)]"), $1) }
+END { print total }
+```
+
+A compiled, stand-alone native binary reads that grammar as **text**,
+compiles it to bytecode **inside the running process** (through a
+self-hosted compiler that ships alongside the binary), loads it, and
+calls it once per record — compiling exactly once thanks to
+content-based deduplication. Editing a `compile_file(...)` source
+changes the next run's behaviour with **no rebuild**.
+
+## The layer stack
+
+Each layer is useful on its own and each was shipped (and is tested)
+independently. Later layers only *compose* earlier ones.
+
+```
+ 6  eval surface        compile(src) / compile_file(path) → handle → dyncall_at
+ 5  self-hosted compiler  cgfull in the loadable subset, shipped as <bin>.evalc.wamo
+ 4  return marshalling  i64 / double / blob / record / assoc — one call primitive each
+ 3  plawk call surfaces dyncall, dyncall@name, dyncall_at + typed wrappers
+ 2  loader + object VM  .wamo text format, @wam_object_load, shared step/run_loop
+ 1  AOT target          WAM→LLVM compiler, the %Instruction stream, the runtime IR
+```
+
+### Layer 1 — the AOT target (the ground everything stands on)
+
+`src/unifyweaver/targets/wam_llvm_target.pl` compiles Prolog predicates
+through a WAM instruction stream into LLVM IR, which clang links into a
+native binary. Two properties of this layer carry the whole arc:
+
+- **One instruction representation.** Every WAM instruction is a
+  `%Instruction {tag, op1, op2}` row; execution is a `step` dispatch
+  inside `run_loop`. Anything that can *produce* that array — the AOT
+  compiler or a runtime loader — executes on the same engine with the
+  same semantics.
+- **The runtime IR is a library.** Atom registry, assoc tables, line
+  readers, arithmetic, the dynamic clause store: all are plain LLVM
+  functions the compiled code calls. New capabilities (a loader, new
+  call primitives) are additions to this library, not changes to
+  compiled programs.
+
+See [PLAWK_EXECUTION_ARCHITECTURE.md](./PLAWK_EXECUTION_ARCHITECTURE.md)
+for the tier picture (plawk rules are fully native; transpiled Prolog is
+bytecode on the AOT-compiled interpreter).
+
+### Layer 2 — the `.wamo` object format and loader
+
+`write_wam_object/3` serializes compiled predicates into `.wamo` — a
+**text** format (version 2): instruction rows plus trailing sections for
+relocations (atoms, floats, functors), the meta-call table, and — when
+non-empty — the `switch_on_constant` dispatch tables.
+`@wam_object_load` (and `@wam_object_load_bytes` for in-memory buffers)
+parses that into a fresh `%WamState` whose instruction array feeds the
+**same** `step`/`run_loop` as AOT code. Loaded objects get real indexed
+dispatch: the loader rebuilds the `%SwitchEntry` arrays the AOT
+dispatcher uses, so a 200-clause fact table probes ~7.6× faster than the
+try-chain fallback.
+
+Text format matters twice: it made the loader small, and it made
+**emitting** an object mere string assembly — which is what lets a
+compiler written in the loadable subset exist at all (layer 5).
+
+### Layer 3 — the plawk call surfaces
+
+plawk programs reach loaded objects through three call forms, all
+riding pay-for-what-you-use IR (a program with no dynamic calls emits
+none of this):
+
+- `dyncall(args)` — the fixed `BEGIN { DYNLOAD = "lib.wamo" }` object's
+  default entry, loaded lazily once per run.
+- `dyncall@name(args)` — a named entry of a multi-entry object; the
+  entry's PC resolves once through a shared per-entry resolver and is
+  cached.
+- `dyncall_at(source, args)` — a **runtime-chosen** source, with a
+  cache registry (`DYNCACHE = "on" | "mtime" | "off"`) mapping sources
+  to loaded VMs.
+
+### Layer 4 — return marshalling (choosing the target type)
+
+A grammar's output cell can materialize into any plawk container; each
+shape is one `@wam_object_call_*` primitive that walks the result
+**before** the arena rewind and one thin shim per call site kind:
+
+| Return shape | Surface | Primitive |
+|---|---|---|
+| integer | `dyncall...` | `@wam_object_call_i64` |
+| double | `float(dyncall...)` | `@wam_object_call_f64` |
+| opaque bytes | `blob(dyncall...)` | `@wam_object_call_bytes` |
+| typed record | `(a,b) = ... as (i64 f64)` / record view `as (...) { ... }` | `@wam_object_call_record` |
+| assoc, i64 values | `arr = ... as assoc` | `@wam_object_call_assoc` |
+| assoc, string values | `arr = ... as assoc(str)` | `@wam_object_call_assoc_str` |
+
+Strings thread through everything by **registry id**: record string
+fields and blob returns are `(ptr,len)` slices into the persistent atom
+table; assoc atom keys and `(str)`-kind atom values are stored as their
+global-registry ids — the same keyspace text-mode field slices intern
+into — so for-in reports, literal lookups, and value prints all resolve
+ids to text with the one `@wam_atom_to_string` helper.
+
+### Layer 5 — the self-hosted compiler
+
+The payoff needs a Prolog→`.wamo` compiler that *itself* runs as a
+loaded object. `src/unifyweaver/targets/wam_bootstrap_compiler.pl` is
+that compiler: a minimal (not the 22k-line host) tier-2 compiler written
+inside the loadable subset — reader, register allocation, clause
+grouping, try-chains, if-then-else, structure patterns, a builtin
+whitelist, and the `.wamo` serializer.
+
+The campaign that made the subset rich enough (clause indexing,
+meta-call, the dynamic clause store, `catch/throw`, the term
+reader/writer) is chronicled in
+[PLAWK_EVAL_BOOTSTRAP.md](./PLAWK_EVAL_BOOTSTRAP.md); the staged
+self-compile — culminating in the fixpoint `gen2 == gen3`
+byte-identical, i.e. the compiler compiled by its own output is its own
+output — in [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md). The campaign
+surfaced and fixed **thirteen latent runtime bugs** (register-file
+ceiling, choice-point width, `copy_term` aliasing, variable-identity
+collapse, the monotonic-heap re-entry pair, the arith error channel,
+...) — the self-compile was the most demanding client the runtime ever
+had, which is much of its value.
+
+### Layer 6 — the eval surface
+
+`compile(src)` / `compile_file(path)` in the `dyncall_at` source
+position tie it together:
+
+- At **build** time, the CLI (`examples/plawk/bin/plawk`) detects
+  compile sites and ships the bootstrap compiler as `<bin>.evalc.wamo`
+  next to the binary (`BEGIN { EVALC = "..." }` points at an existing
+  object instead). No compile sites → nothing ships.
+- At **run** time, `@plawk_compile` interns the source text, dedups by
+  content (same text → same handle, compiled once), and otherwise runs
+  `@wam_object_eval`: load the compiler object (cached), call it on the
+  source, load the `.wamo` bytes it emits, register the fresh VM in the
+  `dyncall_at` cache, and return the registry **handle**.
+  `@plawk_compile_file` reads the file and delegates — content dedup
+  makes edit-and-rerun work with no mtime tracking.
+- The handle flows into the existing `dyncall_at` shims as
+  `(null path, handle)`; every downstream marshalling shape (layer 4)
+  works on runtime-compiled grammars unchanged.
+
+Because the cache registry carries the handle, `DYNCACHE = "off"`
+plus a compile site is a **build error**, not a silent miscompile.
+
+## Invariants the arc keeps
+
+- **One engine.** Loaded code runs through the same `step`/`run_loop`
+  as AOT code — semantics can't drift between the two.
+- **Pay for what you use.** Loader, shims, resolvers, the compile
+  support, the shipped compiler object: each is emitted only when the
+  program has a site that needs it.
+- **Constant memory per call.** Every call primitive saves the heap
+  mark, marshals results out before the arena rewind, and rewinds —
+  a per-record dyncall does not grow the process.
+- **Strings are registry ids.** One intern keyspace across text-mode
+  fields, blob keys, assoc atom keys, and `(str)` values; one resolver
+  (`@wam_atom_to_string`) back to text.
+- **Content over mtime.** The eval cache keys on source text, so
+  "did it change" has one answer everywhere.
+- **Fail loud.** Unsupported constructs throw at compile
+  (`throw/1` diagnostics in the walkers); arith errors fail `is/2`
+  rather than yielding 0; cache-off + compile is a build error.
+
+## Where each design doc fits
+
+| Doc | Layer(s) | What it holds |
+|---|---|---|
+| [PLAWK_EXECUTION_ARCHITECTURE.md](./PLAWK_EXECUTION_ARCHITECTURE.md) | 1 | the compiled/interpreted tier picture |
+| [PLAWK_JIT_ROADMAP.md](./PLAWK_JIT_ROADMAP.md) | 2–4 | the capability-by-capability history + what's next |
+| [PLAWK_DCG_BINARY_READERS.md](./PLAWK_DCG_BINARY_READERS.md) | 4 | grammar-driven readers meeting BINFMT |
+| [PLAWK_EVAL_BOOTSTRAP.md](./PLAWK_EVAL_BOOTSTRAP.md) | 5–6 | the subset-expansion milestones + the landed surface |
+| [PLAWK_DYNAMIC_DB.md](./PLAWK_DYNAMIC_DB.md) | 5 | the dynamic clause store (`assertz`/`retract`) |
+| [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md) | 5 | the staged self-compile to the fixpoint |
+
+## What remains open
+
+Deliberately deferred, in rough value order:
+
+- **for-in over grammar-populated tables inside rule bodies** (END
+  works today).
+- **`dyncall_at@name(...)`** — named entries on runtime sources (PC
+  cached per (object, name) pair); with it, named entries on
+  `compile(...)` handles.
+- **Surface B (`DYNENTRY`)** — declaration-bound library names with
+  static PC bake (see the roadmap's namespace-rule discussion).
+- **Handle-in-scalar** — storing a compile handle in a plawk variable
+  across records (today the dedup makes the nested form equivalent).
+- **Further compiler-subset growth** — the bootstrap compiler covers
+  the grammar shapes the eval surface targets; widening it is
+  demand-driven.

--- a/docs/design/PLAWK_EVAL_BOOTSTRAP.md
+++ b/docs/design/PLAWK_EVAL_BOOTSTRAP.md
@@ -9,6 +9,9 @@ Compiling a grammar from **source text at runtime** — the endgame of the
 dynamic-grammar arc. This was the plan and the milestone sequence; **the
 payoff has landed** (see "The landed surface" below).
 
+> **Top-level map:** how this layer fits the whole eval arc is
+> summarized in [PLAWK_EVAL_ARCHITECTURE.md](./PLAWK_EVAL_ARCHITECTURE.md).
+
 ## The goal
 
 ```awk

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -7,6 +7,10 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 Where the runtime-loadable-grammar (JIT) arc stands, and what comes next.
 
+> **Top-level map:** for a one-stop architecture summary of the whole
+> eval arc — the layers, how they compose, and where each design doc
+> fits — see [PLAWK_EVAL_ARCHITECTURE.md](./PLAWK_EVAL_ARCHITECTURE.md).
+
 ## What has landed
 
 The dynamic-grammar surface is feature-complete for numeric work:
@@ -255,10 +259,20 @@ different plawk containers — this is the through-line for the rest of item 4:
   emitter DISCARDED its arg-marshal globals (text-mode field args emit
   a fallback constant each), leaving the IR referencing undefined
   values; they now ride the apply path's global channel (added in the
-  blob-consumers round). **Deferred:** the default-entry
-  `dyncall(...) as assoc` (named only for now), for-in iteration over a
-  grammar-populated table inside rule bodies, and string VALUES (the
-  table is an i64 accumulator).
+  blob-consumers round). **Default-entry LANDED:**
+  `arr = dyncall(args) as assoc` runs the DYNLOAD object's `wamo_entry`
+  through `@plawk_dyncall_assoc_default_<N>` (entry PC recorded at
+  object-load time, no resolver). **String VALUES LANDED — the second
+  table kind:** `arr = dyncall[@name](args) as assoc(str)` declares a
+  str-valued table; the grammar returns `[K-Atom, ...]` pairs,
+  `@wam_object_call_assoc_str` stores each value's registry id via
+  `@wam_assoc_i64_set` (insert-or-REPLACE — accumulating ids is
+  meaningless, a repeated key keeps the latest label), and reads
+  (for-in value prints, END `arr["literal"]` lookups) resolve the id
+  back to text through `@wam_atom_to_string`, exactly as key prints
+  already did. Same table layout; only the declared value kind differs.
+  **Still deferred:** for-in iteration over a grammar-populated table
+  inside rule bodies.
 - **Positional array** — fields by numeric index into one array value.
 
 Each target reuses one marshaller over the same walked compound; they differ
@@ -287,9 +301,8 @@ scalar. Verified: `info(X) -> tag(X, big/small)` over 5,200,7 prints
 
 The **destructure** target still rejects string fields by design (no
 scalar to bind them to — the record view is the string surface); the
-**assoc** target now takes interned atom keys (see above), leaving
-string VALUES as the one string shape without a container (an i64
-table cannot hold them).
+**assoc** target takes interned atom keys AND, with the `(str)` value
+kind, atom values (see above) — every string shape now has a container.
 
 **Why:** this is the *other half* of your binary-return idea — the case
 that **does** need deserialization. It is also the endgame that closes the
@@ -532,7 +545,12 @@ own PR(s).
   functors evaluated to a benign 0, and the first-byte dispatch let
   unknown names *alias* real ops (`f(2)` ran as `floor(2)`) — fixed
   with an arith-error flag failing `is/2` and the comparisons, plus a
-  full-name whitelist gate before dispatch. See
+  full-name whitelist gate before dispatch. A follow-up closed the last
+  aliasing residue *inside* the whitelist: `//` (integer division)
+  shares its first byte with `/` and ran as float division — the `/`
+  branch now checks the second byte and routes `//` to a truncating
+  `sdiv` (SWI's default), with float operands and division by zero
+  failing through the same error flag. See
   [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md).
 
 ## The binary-return question, specifically

--- a/docs/design/PLAWK_SELFHOST.md
+++ b/docs/design/PLAWK_SELFHOST.md
@@ -11,6 +11,9 @@ grammar entirely inside the running binary. This is the design pass —
 scoping *what* to build and *in what testable stages* — not an
 implementation PR.
 
+> **Top-level map:** how this layer fits the whole eval arc is
+> summarized in [PLAWK_EVAL_ARCHITECTURE.md](./PLAWK_EVAL_ARCHITECTURE.md).
+
 ## What "self-host" means here (and what it does not)
 
 Milestone 5 landed the eval loop at the runtime layer: `@wam_object_eval`


### PR DESCRIPTION
**Stack 4 of 4** — based on #3632. Docs only.

## What

The consolidation round for the eval arc:

- **NEW `docs/design/PLAWK_EVAL_ARCHITECTURE.md`** — the top-level map of the whole arc as a six-layer stack (AOT target → `.wamo` loader → call surfaces → return marshalling → self-hosted compiler → eval surface), the invariants it keeps (one engine, pay-for-what-you-use, constant memory per call, strings as registry ids, content over mtime, fail loud), a doc-to-layer index, and the deliberately-deferred list.
- **`PLAWK_JIT_ROADMAP.md`** — records the three deferred small items landing in this stack (default-entry `as assoc`, string values via `as assoc(str)`, `//` semantics in loaded arith) and links the new architecture doc.
- **`PLAWK_EVAL_BOOTSTRAP.md` / `PLAWK_SELFHOST.md`** — cross-link the architecture summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_