### PR TITLE
mu_cosine: luna campaign — §7 verdict revised, fused head's first win, cheap-judge pipeline live

### DIFF
--- a/prototypes/mu_cosine/REPORT_luna_campaign.md
+++ b/prototypes/mu_cosine/REPORT_luna_campaign.md
@@ -1,0 +1,68 @@
+# Luna campaign: the §7 verdict revised, stratified fusion value, and the fused head's first win
+
+Stratified luna scoring (same 2,000 campaign pairs as the 5.5 run; 200/200 batches, 1,930 ingested, 0
+failures, 111 min, ~0.30 pairs/s at gpt-5.6-luna low) → 1,700 pair-matched dual-judge rows. Three results.
+
+## 1. The §7 "weak on S" verdict was a stratum artifact (compare_judges_campaign.py)
+
+| stratum | n | D corr | D bias | S corr | S bias |
+|---|---|---|---|---|---|
+| trans | 660 | +0.795 | **+0.090** | +0.375 | −0.150 |
+| sib | 332 | +0.606 | −0.063 | **+0.476** | −0.094 |
+| cous | 331 | +0.665 | −0.047 | **+0.608** | −0.060 |
+| rand | 377 | +0.807 | −0.001 | +0.550 | −0.007 |
+| ALL | 1700 | **+0.877** | +0.013 | **+0.703** | −0.090 |
+
+(ceilings: 5.5 same-judge repeat D 0.954, S 0.766)
+
+The fresh-250 S number (0.35–0.44) reproduces exactly on the transitive stratum (+0.375) — §7 measured
+luna's S where S doesn't vary. Where it varies (sib/cous), luna agrees at 0.48–0.61; pooled S +0.703 vs the
+0.766 ceiling. **Luna ≈ 90% of 5.5's self-agreement at a fraction of the price.** Tilt refined: −S bias is
+universal; the +D bias is transitive-specific (luna reads more hierarchy only in true hierarchy pairs).
+
+## 2. Stratified luna channel value + empirical R (fine_tune_fused_head_luna.py, analytic part)
+
+5×5 joint blocks fit per corpus on the train split from the dual-judge data (no imported R):
+fitted R_luna D 0.030/0.040, S 0.015/0.032 (≈7–10× 5.5's self-R, as the multi-judge report estimated).
+Ladder vs the 5.5 target (held rows): luna channel worth **+0.766/+0.721 NLL** over prior+graph
+(expl/fresh) — larger than the transitive-only +0.451. Fusion non-degeneracy pull 0.080/0.095.
+
+## 3. The fused head beats a channel head for the first time — in the predicted regime
+
+kalman-fused retrained on the LUNA-fused posteriors (prior ⊕ graph ⊕ luna), alongside 5.5/graph/luna
+channel supervision; held rows, WITHIN-stratum, vs the 5.5 labels:
+
+| head (within-stratum vs 5.5) | expl D | fresh D | expl S | fresh S |
+|---|---|---|---|---|
+| luna channel head (raw cheap labels) | +0.351 | +0.407 | +0.373 | +0.312 |
+| **luna-FUSED head** | **+0.396** | **+0.451** | +0.363 | +0.305 |
+| 5.5 head (expensive labels — reference) | +0.411 | +0.503 | +0.369 | +0.323 |
+
+- **D**: fusion recovers roughly HALF the gap between cheap-label and expensive-label heads
+  (+0.045/+0.044 within-stratum), at zero additional scoring cost. This is REPORT_fused_head.md's null
+  boundary confirmed constructively: with a noisy judge the posterior differs from the label (pull 0.08–0.10)
+  and the fused head learns the difference (fidelity to its own target: within +0.381–0.588).
+- **S**: a wash, as expected — the graph doesn't observe S, so the S fusion has only the weak prior to add.
+- The luna channel head itself now has stratified S signal (within vs luna's own labels +0.25–0.28) —
+  fixing the B2-step-3 residual's S starvation.
+
+**Economics statement.** For future corpora labeled with the cheap judge, fuse-then-distill recovers ~half
+of the D-channel quality gap to expensive labels for free. Combined with §1 (luna ≈ 90% of ceiling pooled),
+the cheap-judge pipeline is live: luna labels + Kalman fusion + conflict-routed 5.5 calls (Lever A) is the
+deployment recipe to beat.
+
+## Caveats
+
+Single seed, single split per corpus for the trained heads (the analytic ladder is held-out but one split);
+target = the 5.5 operating judge, not ground truth (same-family privilege — a human-verified subset remains
+the gold-standard upgrade); 14 non-dict response objects skipped at ingest (the §3 format-discipline guard);
+luna's fitted R absorbs its tilt as variance (bias-augmented state would price it properly).
+
+Repro:
+```
+python3 score_with_codex.py --pairs /tmp/mu_data/campaign_pairs.tsv --batch 10 \
+    --model gpt-5.6-luna --judge gpt-5.6-luna --out /tmp/mu_data/campaign_scored_luna.tsv \
+    --responses /tmp/mu_data/campaign_luna_responses.txt
+python3 compare_judges_campaign.py
+python3 fine_tune_fused_head_luna.py --ckpt model_channel_heads_namecond_r0.pt
+```

--- a/prototypes/mu_cosine/compare_judges_campaign.py
+++ b/prototypes/mu_cosine/compare_judges_campaign.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Pair-matched judge comparison on the stratified campaign — the §7 luna verdict, re-measured where it
+matters. §7 rejected luna on the fresh 250, but those are ALL-TRANSITIVE pairs: S barely varies there, so
+luna's S weakness (0.35-0.44 vs the 0.766 ceiling) was measured on the S-starved stratum. The campaign's
+sib/cous rows are where S varies (the whole point of the stratified sample) — this is the fair test.
+
+Per stratum × channel: corr(luna, 5.5), MAE, bias (luna − 5.5), and both sds. Bias should reproduce the
+measured tilt (+D/−S); the decision-relevant number is S corr on sib/cous.
+
+  python3 compare_judges_campaign.py --a /tmp/mu_data/campaign_scored.tsv --b /tmp/mu_data/campaign_scored_luna.tsv
+"""
+import argparse
+from collections import defaultdict
+
+import numpy as np
+
+DIRR = ["subcategory", "subtopic", "element_of", "super_category"]
+SYMM = ["see_also", "assoc"]
+
+
+def load(path):
+    out = {}
+    with open(path, encoding="utf-8") as f:
+        header = f.readline().lstrip("#").strip().split("\t")
+        col = {c: i for i, c in enumerate(header)}
+        for ln in f:
+            c = ln.rstrip("\n").split("\t")
+            if len(c) < len(header):
+                continue
+            D = max(float(c[col[f"mu[{r}]"]]) for r in DIRR)
+            S = max(float(c[col[f"mu[{r}]"]]) for r in SYMM)
+            tag = c[col["neighborhood"]]
+            out[(c[col["node"]], c[col["root"]])] = (tag, D, S)
+    return out
+
+
+def group(tag):
+    return "trans" if tag.startswith("campaign_h") else tag.replace("campaign_", "")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--a", default="/tmp/mu_data/campaign_scored.tsv", help="reference judge (gpt-5.5-low)")
+    ap.add_argument("--b", default="/tmp/mu_data/campaign_scored_luna.tsv", help="candidate judge (luna)")
+    a = ap.parse_args()
+    A, B = load(a.a), load(a.b)
+    common = sorted(set(A) & set(B))
+    print(f"pair-matched: {len(common)} (A {len(A)}, B {len(B)})")
+
+    by = defaultdict(list)
+    for p in common:
+        tag, Da, Sa = A[p]
+        _, Db, Sb = B[p]
+        by[group(tag)].append((Da, Sa, Db, Sb))
+        by["ALL"].append((Da, Sa, Db, Sb))
+
+    r = lambda x, y: float(np.corrcoef(x, y)[0, 1]) if np.std(x) > 1e-9 and np.std(y) > 1e-9 else float("nan")
+    print(f"\n{'stratum':8s} {'n':>5s} | {'D corr':>7s} {'D MAE':>6s} {'D bias':>7s} {'sd A/B':>11s} | "
+          f"{'S corr':>7s} {'S MAE':>6s} {'S bias':>7s} {'sd A/B':>11s}")
+    for g in ["trans", "sib", "cous", "rand", "ALL"]:
+        if g not in by:
+            continue
+        v = np.array(by[g])
+        Da, Sa, Db, Sb = v[:, 0], v[:, 1], v[:, 2], v[:, 3]
+        print(f"{g:8s} {len(v):>5d} | {r(Da, Db):+7.3f} {np.abs(Db - Da).mean():6.3f} "
+              f"{(Db - Da).mean():+7.3f} {Da.std():5.3f}/{Db.std():5.3f} | "
+              f"{r(Sa, Sb):+7.3f} {np.abs(Sb - Sa).mean():6.3f} "
+              f"{(Sb - Sa).mean():+7.3f} {Sa.std():5.3f}/{Sb.std():5.3f}")
+    print("\n(reference ceilings from the fresh-250 self-consistency: D 0.954, S 0.766 — same-judge repeat)")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/fine_tune_fused_head_luna.py
+++ b/prototypes/mu_cosine/fine_tune_fused_head_luna.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Luna-fused distillation — the fused head retrained in the regime where it has something to learn.
+
+REPORT_fused_head.md's null: with the reliable judge (R≈0.004) the posterior collapses onto the label.
+REPORT_multi_judge_fusion.md's boundary: with LUNA the posterior genuinely mixes channels (pull 0.133).
+The stratified luna campaign closes the loop: build Kalman posteriors from [prior, graph, LUNA] against
+the 5.5 operating target — luna's error blocks (including its tilt and cross-correlations) FIT EMPIRICALLY
+on the train split from the pair-matched dual-judge data, no imported R — and distill them into the
+kalman-fused name head.
+
+Deployment question this answers: a CHEAP pipeline (luna labels fused with graph+prior, amortized into one
+head) — how close does it get to the expensive judge's labels, vs the raw luna channel head?
+
+Also trains the luna CHANNEL head on stratified data (fixing step 3's S starvation) and prints the
+analytic fusion ladder (prior | +graph | +graph+luna vs 5.5) before any training.
+
+  python3 fine_tune_fused_head_luna.py --ckpt model_channel_heads_namecond_r0.pt
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from eval_luna_transfer import load_luna as load_scored_mu_tsv
+from eval_within_stratum import decompose, group
+from fine_tune_channel_heads import load_campaign_datasets, load_expanded, mu_batch
+from fine_tune_fused_head import agnostic_readouts
+from mu_attention import CORPORA, JUDGES, OPS
+from product_kalman import fit_residual_covariance
+from run_judge_channel import H_ALL, correlated_update_H, nll_mahal
+from run_product_kalman_logit import dequant
+from run_product_kalman_realdata import affine_calibrate
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+LUNA_CAMPAIGN = "/tmp/mu_data/campaign_scored_luna.tsv"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", default=os.path.join(ROOT, "model_channel_heads_namecond_r0.pt"))
+    ap.add_argument("--out", default=os.path.join(ROOT, "model_fused_head_luna.pt"))
+    ap.add_argument("--steps", type=int, default=800)
+    ap.add_argument("--bs", type=int, default=64)
+    ap.add_argument("--lr", type=float, default=5e-4)
+    ap.add_argument("--anchor-weight", type=float, default=1.0)
+    ap.add_argument("--shrink", type=float, default=0.05)
+    a = ap.parse_args()
+    dev = "cpu"
+    torch.manual_seed(0)
+    rng = np.random.default_rng(0)
+
+    model, cfg = load_expanded(a.ckpt, dev=dev)
+    assert model.judge_name is not None
+    ref, _ = load_expanded(a.ckpt, dev=dev)
+    ref.eval()
+    for p in ref.parameters():
+        p.requires_grad = False
+    for p in model.parameters():
+        p.requires_grad = False
+    model.judge_name.W.weight.requires_grad = True
+    model.judge_name.resid.weight.requires_grad = True
+    last = model.encoder.layers[-1]
+    for p in last.parameters():
+        p.requires_grad = True
+    model.readout_w.requires_grad = True
+    model.readout_b.requires_grad = True
+    trainable = [model.judge_name.W.weight, model.judge_name.resid.weight,
+                 model.readout_w, model.readout_b] + list(last.parameters())
+    opt = torch.optim.Adam(trainable, lr=a.lr)
+
+    lp, lD, lS = load_scored_mu_tsv(LUNA_CAMPAIGN)
+    luna_by = {p: (lD[i], lS[i]) for i, p in enumerate(lp)}
+    dss = load_campaign_datasets()
+    posts, train_rows, matched = {}, {}, {}
+    for n, ds in dss.items():
+        mi = [i for i, p in enumerate(ds["pairs"]) if p in luna_by]
+        matched[n] = set(mi)
+        luna = np.array([luna_by[ds["pairs"][i]] if i in matched[n] else (np.nan, np.nan)
+                         for i in range(len(ds["pairs"]))])
+        tr_l = [i for i in ds["tr"] if i in matched[n]]
+        he_l = [i for i in ds["he"] if i in matched[n]]
+        ds["he_l"], ds["luna"] = he_l, luna
+        ro = agnostic_readouts(ref, ds, dev)
+        y = dequant(np.column_stack([ds["D"], ds["S"]]))
+        prior = np.column_stack([ro["prior_D"], ro["prior_S"]])
+        m = affine_calibrate(ds["d"][tr_l], y[tr_l, 0], ds["d"])
+        meas = np.column_stack([m, luna[:, 0], luna[:, 1]])
+        E5 = np.column_stack([y - prior, meas - y[:, [0, 0, 1]]])[tr_l]
+        C5 = fit_residual_covariance(E5, shrinkage=a.shrink)
+        P0, C_pm, R0 = C5[:2, :2], C5[:2, 2:], C5[2:, 2:]
+        print(f"\n{n}: {len(mi)} luna-matched ({len(tr_l)} train / {len(he_l)} held); "
+              f"fitted R_luna: D {R0[1, 1]:.4f}  S {R0[2, 2]:.4f}  (5.5 self-consistency R ≈ 0.004)")
+
+        # analytic ladder on held rows (vs the 5.5 target) — the stratified value of the luna channel
+        acc = {r: [] for r in ("prior", "prior+graph", "prior+graph+luna")}
+        post = np.full((len(y), 2), np.nan)
+        pull = []
+        for i in range(len(y)):
+            if i not in matched[n]:
+                continue
+            x = prior[i]
+            xp_g, Pp_g = correlated_update_H(x, P0, meas[i][[0]], R0[:1, :1], C_pm[:, [0]], H_ALL[:1])
+            xp_a, Pp_a = correlated_update_H(x, P0, meas[i], R0, C_pm, H_ALL)
+            post[i] = np.clip(xp_a, 0.0, 1.0)
+            pull.append(abs(xp_a[0] - meas[i][1]))
+            if i in ds["he_l"]:
+                acc["prior"].append(nll_mahal(y[i] - x, P0)[0])
+                acc["prior+graph"].append(nll_mahal(y[i] - xp_g, Pp_g)[0])
+                acc["prior+graph+luna"].append(nll_mahal(y[i] - xp_a, Pp_a)[0])
+        posts[n] = post
+        g = np.array(acc["prior+graph"]) - np.array(acc["prior+graph+luna"])
+        print(f"  ladder (held NLL): prior {np.mean(acc['prior']):+.3f} | +graph "
+              f"{np.mean(acc['prior+graph']):+.3f} | +luna {np.mean(acc['prior+graph+luna']):+.3f}  "
+              f"(luna channel value {g.mean():+.3f}, row-SE {g.std()/np.sqrt(len(g)):.3f})")
+        print(f"  fusion non-degeneracy: mean |post_D − luna_D| = {np.mean(pull):.3f}")
+
+        rows = []
+        for i in tr_l:
+            x_, y_ = ds["pairs"][i]
+            rows.append(((x_, y_, OPS["HIER"], CORPORA["enwiki"], JUDGES["gpt-5.5-low"]), ds["D"][i]))
+            rows.append(((x_, y_, OPS["SYM"], CORPORA["enwiki"], JUDGES["gpt-5.5-low"]), ds["S"][i]))
+            rows.append(((x_, y_, OPS["HIER"], CORPORA["enwiki"], JUDGES["graph"]), ds["d"][i]))
+            rows.append(((x_, y_, OPS["HIER"], CORPORA["enwiki"], JUDGES["gpt-5.6-luna"]), luna[i, 0]))
+            rows.append(((x_, y_, OPS["SYM"], CORPORA["enwiki"], JUDGES["gpt-5.6-luna"]), luna[i, 1]))
+            rows.append(((x_, y_, OPS["HIER"], CORPORA["enwiki"], JUDGES["kalman-fused"]), post[i, 0]))
+            rows.append(((x_, y_, OPS["SYM"], CORPORA["enwiki"], JUDGES["kalman-fused"]), post[i, 1]))
+        train_rows[n] = rows
+        print(f"  {len(rows)} train rows (5.5 + graph + luna + fused channels)")
+
+    names = list(train_rows)
+    model.train()
+    for step in range(1, a.steps + 1):
+        n = names[step % len(names)]
+        rows = train_rows[n]
+        sel = rng.choice(len(rows), size=min(a.bs, len(rows)), replace=False)
+        items = [rows[j][0] for j in sel]
+        tgt = torch.tensor([rows[j][1] for j in sel], dtype=torch.float32, device=dev)
+        mu = mu_batch(model, dss[n]["tok"], items, dev, train=True, rng=np.random)
+        loss = torch.mean((mu - tgt) ** 2)
+        ag_items = [(it[0], it[1], it[2]) for it in items]
+        mu_ag = mu_batch(model, dss[n]["tok"], ag_items, dev)
+        with torch.no_grad():
+            mu_ref = mu_batch(ref, dss[n]["tok"], ag_items, dev)
+        loss = loss + a.anchor_weight * torch.mean((mu_ag - mu_ref) ** 2)
+        opt.zero_grad(); loss.backward()
+        torch.nn.utils.clip_grad_norm_(trainable, 1.0)
+        opt.step()
+        if step % 200 == 0 or step == 1:
+            print(f"step {step:4d} loss {loss.item():.4f}")
+
+    model.eval()
+    for n, ds in dss.items():
+        he = ds["he_l"]
+        groups = [group(ds["tags"][i]) for i in he]
+        mus = {}
+        with torch.no_grad():
+            for key, judge, op in [("fused_D", "kalman-fused", "HIER"), ("fused_S", "kalman-fused", "SYM"),
+                                   ("luna_D", "gpt-5.6-luna", "HIER"), ("luna_S", "gpt-5.6-luna", "SYM"),
+                                   ("llm_D", "gpt-5.5-low", "HIER"), ("llm_S", "gpt-5.5-low", "SYM")]:
+                items = [(ds["pairs"][i][0], ds["pairs"][i][1], OPS[op], CORPORA["enwiki"], JUDGES[judge])
+                         for i in he]
+                mus[key] = np.array(mu_batch(model, ds["tok"], items, dev).cpu())
+        print(f"\n=== {n} (held {len(he)}) — pooled / between / WITHIN vs the 5.5 labels ===")
+        for label, mu, tgt in [
+            ("fused vs 5.5 D", mus["fused_D"], ds["D"][he]),
+            ("luna  vs 5.5 D", mus["luna_D"], ds["D"][he]),
+            ("5.5h  vs 5.5 D", mus["llm_D"], ds["D"][he]),
+            ("fused vs 5.5 S", mus["fused_S"], ds["S"][he]),
+            ("luna  vs 5.5 S", mus["luna_S"], ds["S"][he]),
+            ("5.5h  vs 5.5 S", mus["llm_S"], ds["S"][he]),
+            ("fused vs POST D", mus["fused_D"], posts[n][he, 0]),
+            ("fused vs POST S", mus["fused_S"], posts[n][he, 1]),
+            ("luna-head vs luna labels D", mus["luna_D"], ds["luna"][he, 0]),
+            ("luna-head vs luna labels S", mus["luna_S"], ds["luna"][he, 1]),
+        ]:
+            pooled, between, within, per = decompose(mu, tgt, groups)
+            print(f"  {label:28s}: {pooled:+.3f} / {between:+.3f} / {within:+.3f}")
+
+    torch.save({"state": model.state_dict(), "cfg": {**cfg, "judge_name": True}}, a.out)
+    print(f"\nsaved → {a.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/score_with_codex.py
+++ b/prototypes/mu_cosine/score_with_codex.py
@@ -61,6 +61,7 @@ def main():
     ap.add_argument("--sandbox", default="read-only", help="codex -s sandbox mode (review #10)")
     ap.add_argument("--out", required=True)
     ap.add_argument("--responses", default="/tmp/mu_data/codex_responses.txt")
+    ap.add_argument("--judge", default=JUDGE, help="provenance tag for ingest (must be a JUDGES key, e.g. gpt-5.6-luna)")
     a = ap.parse_args()
     os.makedirs(os.path.dirname(a.responses) or ".", exist_ok=True)
 
@@ -97,9 +98,9 @@ def main():
             f.write("\n".join(header + data) + "\n")
     else:
         ing_path = a.pairs
-    ingest(ing_path, a.responses, a.out, judge=JUDGE)
+    ingest(ing_path, a.responses, a.out, judge=a.judge)
     print("DONE: %d/%d batches scored, %d failed (%.0f%%), %.0fs total → %s  (judge=%s)"
-          % (ok, len(prompts), fail, 100.0 * fail / max(1, len(prompts)), time.time() - t0, a.out, JUDGE),
+          % (ok, len(prompts), fail, 100.0 * fail / max(1, len(prompts)), time.time() - t0, a.out, a.judge),
           flush=True)
 
 


### PR DESCRIPTION
Stratified luna scoring of the same 2,000 campaign pairs (1,930 ingested, 0 batch failures, 111 min)
→ 1,700 pair-matched dual-judge rows. Full trail in `REPORT_luna_campaign.md`.

1. **§7 verdict revised**: luna's "weak S" (0.35–0.44) reproduces on the transitive stratum (+0.375)
   but is +0.48/+0.61 on sib/cous where S varies; pooled D +0.877 / S +0.703 vs ceilings 0.954/0.766.
   Luna ≈ 90% of 5.5's self-agreement. Tilt refined: −S universal, +D transitive-specific.
2. **Empirical pricing**: fitted R_luna D 0.030/0.040, S 0.015/0.032 (7–10× 5.5's self-R);
   stratified luna channel value +0.766/+0.721 NLL over prior+graph; fusion pull 0.08–0.10.
3. **Fused head's first win**: retrained on luna-fused posteriors, kalman-fused beats the raw luna
   channel head on D within-stratum (+0.396/+0.451 vs +0.351/+0.407) — half the gap to the
   expensive-label 5.5 head, free. S a wash (graph doesn't observe S). Constructive confirmation
   of REPORT_fused_head.md's null boundary.

Also: `score_with_codex.py --judge` flag; `compare_judges_campaign.py` (pair-matched per-stratum
judge comparison); `fine_tune_fused_head_luna.py` (empirical 5×5 blocks, ladder, distillation).

Caveats: single seed; target = the 5.5 operating judge, not ground truth; luna's tilt folded into R
as variance (bias-augmented state is the proper fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)