### PR TITLE
Support callable Rust assert/1 alias

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1611,6 +1611,7 @@ compile_execute_term_builtin_to_rust(Code) :-
                 self.execute_read_term_builtin(options.as_ref())
             }
             "read/1" | "read_term/1" => { self.execute_read_term_builtin(None) }
+            "assert/1" => { self.execute_assert_builtin("assert/1") }
             "assertz/1" | "asserta/1" => { self.execute_assert_builtin(op) }
             "retractall/1" => { self.execute_retractall_builtin() }
             _ => false,

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -62,6 +62,30 @@ fn generated_assert_alias_appends_a_dynamic_fact() {
 }
 
 #[test]
+fn asserted_rule_body_can_call_assert_alias() {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    assert_clause(
+        &mut vm,
+        "assertz/1",
+        rule(
+            at("seed_alias"),
+            fact("assert", vec![fact("dyn", vec![at("meta_alias")])]),
+        ),
+    );
+
+    vm.reset_query();
+    vm.code = vec![
+        Instruction::Call("seed_alias/0".to_string(), 0),
+        Instruction::Proceed,
+    ];
+    vm.labels = HashMap::new();
+    vm.pc = 1;
+
+    assert!(vm.run());
+    assert_eq!(dyn_values(&mut vm), vec![at("meta_alias")]);
+}
+
+#[test]
 fn assertz_asserta_query_order_and_retractall() {
     let mut vm = WamState::new(vec![], HashMap::new());
     assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("red")]));


### PR DESCRIPTION
## Summary

- Add `assert/1` to Rust’s generic term-builtin dispatch.
- Preserve its existing append semantics.
- Allow asserted rule bodies and other callable-term paths to invoke `assert/1`.
- Add an end-to-end regression that asserts `dyn(meta_alias)` from an asserted rule body.

The runtime change is one Rust match arm. Shared registries and ordinary WAM step execution are unchanged.

## Testing

- Focused generated Rust dynamic-builtin crate
- Full Rust WAM target suite
- Prolog target syntax check
- `git diff --check`