### PR TITLE
plawk eval: `cgfullm` — multi-entry name tables for compiled handles (WAM/LLVM)

### DIFF
--- a/docs/design/PLAWK_EVAL_ARCHITECTURE.md
+++ b/docs/design/PLAWK_EVAL_ARCHITECTURE.md
@@ -196,9 +196,11 @@ Deliberately deferred, in rough value order:
   works today).
 - ~~**`dyncall_at@name(...)`**~~ — LANDED (i64): named entries on
   runtime sources and `compile(...)` handles, resolved per call
-  against the VM's materialized entry table. Follow-ups: `float`/`blob`
-  named-at variants, and multi-entry name tables from the bootstrap
-  serializer (today a compiled handle names its first predicate only).
+  against the VM's materialized entry table. Compiled handles expose
+  their whole predicate family: the CLI ships `cgfullm` (cgfull's core
+  + a multi-entry name table; byte-identical on single-predicate
+  sources, so `cgfull` stays the self-host oracle). Remaining
+  follow-up: `float`/`blob` named-at variants.
 - **Surface B (`DYNENTRY`)** — declaration-bound library names with
   static PC bake (see the roadmap's namespace-rule discussion).
 - **Handle-in-scalar** — storing a compile handle in a plawk variable

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -151,12 +151,20 @@ runtime-compiled grammar). Resolution is per call (a short in-memory
 scan; caching a PC by VM pointer would go stale across an mtime-mode
 reload at the same address). One `@plawk_dyncall_at_named_<Sym>` shim
 per Name-NArgs, in cached and off modes (the off variant frees the
-fresh VM on the resolve-miss path too). Note: the bootstrap compiler's
-serializer emits ONE named entry (the first predicate), so a compiled
-handle exposes exactly that name today — emitting all predicate
-entries is a follow-up whose blast radius is the self-host
-byte-identity goldens. `float`/`blob` named-at variants are the other
-follow-up, mirroring how surface A landed i64-first. Surface **B**
+fresh VM on the resolve-miss path too). **Multi-entry compiled handles
+LANDED via `cgfullm/2`:** rather than changing `cgfull`'s header (whose
+bytes every self-host golden compares against), the bootstrap module
+gained a second entry sharing the whole compilation core
+(`cgfull_core`) with a multi-entry serializer (`wzam_serialize`) — one
+"name/arity" → group-label row per predicate. The plawk CLI ships
+`cgfullm` as `<bin>.evalc.wamo`, so a `compile(...)` source holding a
+grammar FAMILY exposes every predicate to `dyncall_at@name` (verified:
+two grammars in one source, two named call sites, one content-deduped
+handle → 194). Single-predicate sources serialize byte-identically to
+`cgfull` (NE=1, first predicate named), so handles, dedup, and every
+existing compile are unchanged — and `cgfull` stays the untouched
+self-host fixpoint subject. `float`/`blob` named-at variants remain
+the follow-up, mirroring how surface A landed i64-first. Surface **B**
 below stays planned.
 
 **Surface B — declaration-bound library names (planned):** for a fixed

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -144,9 +144,13 @@ build(File, Out0, KeepLL) :-
         \+ plawk_program_evalc_path(Program, _)
     ->  absolute_file_name(Out, OutAbs),
         atom_concat(OutAbs, '.evalc.wamo', EvalcPath),
+        % cgfullm = cgfull + a multi-entry name table, so a runtime-
+        % compiled object exposes its whole predicate family to
+        % dyncall_at@name (single-predicate sources emit byte-identical
+        % objects, so handles and content-dedup are unchanged).
         catch(
-            write_wam_object([wam_bootstrap_compiler:cgfull/2],
-                [wamo_entry(cgfull/2)], EvalcPath),
+            write_wam_object([wam_bootstrap_compiler:cgfullm/2],
+                [wamo_entry(cgfullm/2)], EvalcPath),
             EvalcErr,
             ( report_error('compile error', File, EvalcErr), halt(3) )),
         EvalcOptions = [evalc_path(EvalcPath)]

--- a/src/unifyweaver/targets/wam_bootstrap_compiler.pl
+++ b/src/unifyweaver/targets/wam_bootstrap_compiler.pl
@@ -44,7 +44,10 @@
     cgarith/2,         % +Src, -Wamo  (Stage C: arithmetic + functor table)
     cgfull/2,          % +Src, -Wamo  (Stage D: the unified compiler)
     cgfull_term/2,     % +Clauses, -Wamo (cgfull minus the reader; SWI oracle)
-    wza_serialize/8    % low-level serializer (golden-byte construction)
+    cgfullm/2,         % +Src, -Wamo  (cgfull + MULTI-ENTRY name table)
+    cgfullm_term/2,    % +Clauses, -Wamo (cgfullm minus the reader)
+    wza_serialize/8,   % low-level serializer (golden-byte construction)
+    wzam_serialize/7   % multi-entry serializer (cgfullm back end)
 ]).
 
 :- discontiguous walk_term/3.
@@ -409,18 +412,49 @@ cgfull(Src, Wamo) :-
 % Split off the reader call so the middle+back end can run in SWI too
 % (read_term_from_atom/2 exists only in the loaded runtime): tests
 % compute expected golden bytes by feeding cgfull_term/2 clause TERMS.
+% The compilation core is shared with cgfullm_term below; cgfull_term's
+% output stays BYTE-IDENTICAL (the single-entry header, first predicate
+% named) -- it is the oracle every self-host golden compares against.
 cgfull_term(Clauses, Wamo) :-
+    cgfull_core(Clauses, _Groups, Atoms, Functors, PCs, AllIs),
+    Clauses = [First|_], clause_hb(First, H0, _), functor(H0, P0, A0),
+    pred_name_codes(P0, A0, EntryName),
+    wza_serialize(0, EntryName, 0, Atoms, Functors, PCs, AllIs, Codes),
+    atom_codes(Wamo, Codes).
+
+% the shared front+middle: grouping, labels, tables, per-group codegen,
+% and the closed PC table -- everything up to the header choice.
+cgfull_core(Clauses, Groups, Atoms, Functors, PCs, AllIs) :-
     group_clauses(Clauses, Groups),
     group_labels(Groups, 0, PL),
     length(Groups, NP),
     collect_tables(Clauses, s([],[]), s(Atoms, Functors)),
     g_groups(Groups, PL, Atoms, Functors, 0, NP, AllIs, EntryPCs, Pairs),
     keysort(Pairs, SortedPairs), pairs_values(SortedPairs, ExtraPCs),
-    append(EntryPCs, ExtraPCs, PCs),
-    Clauses = [First|_], clause_hb(First, H0, _), functor(H0, P0, A0),
-    pred_name_codes(P0, A0, EntryName),
-    wza_serialize(0, EntryName, 0, Atoms, Functors, PCs, AllIs, Codes),
+    append(EntryPCs, ExtraPCs, PCs).
+
+% cgfullm: cgfull with a MULTI-ENTRY name table -- every predicate group
+% gets an entry row ("name/arity" -> its group label), so a runtime-
+% compiled object exposes its whole predicate family to dyncall_at@name.
+% For a single-predicate source the header is byte-identical to cgfull's
+% (NE=1, first predicate named, label 0), so content-dedup handles and
+% every existing single-grammar compile are unchanged. This is the entry
+% the plawk CLI ships as <bin>.evalc.wamo; cgfull stays the self-host
+% fixpoint subject (the goldens compare against ITS bytes).
+cgfullm(Src, Wamo) :-
+    read_term_from_atom(Src, Clauses),
+    cgfullm_term(Clauses, Wamo).
+cgfullm_term(Clauses, Wamo) :-
+    cgfull_core(Clauses, Groups, Atoms, Functors, PCs, AllIs),
+    group_entries(Groups, 0, Entries),
+    wzam_serialize(0, Entries, Atoms, Functors, PCs, AllIs, Codes),
     atom_codes(Wamo, Codes).
+
+group_entries([], _, []).
+group_entries([pred(P, A, _)|Gs], I, [NC-I|R]) :-
+    pred_name_codes(P, A, NC),
+    I1 is I + 1,
+    group_entries(Gs, I1, R).
 
 % comparison-guard builtin ids
 cmp_id(>, 1). cmp_id(<, 2). cmp_id(>=, 3). cmp_id(=<, 4).
@@ -789,3 +823,17 @@ wza_serialize(EI, NC, LI, Atoms, Fs, PCs, Is, Out) :-
     length(Atoms, NA), wz_i(NA, A6, A7), wz_funcs(Atoms, A7, A8),
     length(Fs, NF), wz_i(NF, A8, A9), wz_funcs(Fs, A9, A10),
     wz_pcs_sec(PCs, A10, A11), wz_instr_sec(Is, A11, A12), wz_i(0, A12, []).
+
+% multi-entry variant: NE from the Entries list (NameCodes-LabelIdx
+% pairs), one name/label row per entry. With a single entry the emitted
+% bytes equal wza_serialize's -- the header shape is the same, only the
+% count and rows generalize.
+wzam_serialize(EI, Entries, Atoms, Fs, PCs, Is, Out) :-
+    wz_a('WAMO', Out, A1), wz_i(2, A1, A2), wz_i(EI, A2, A3),
+    length(Entries, NE), wz_i(NE, A3, A4), wz_entry_rows(Entries, A4, A5),
+    length(Atoms, NA), wz_i(NA, A5, A6), wz_funcs(Atoms, A6, A7),
+    length(Fs, NF), wz_i(NF, A7, A8), wz_funcs(Fs, A8, A9),
+    wz_pcs_sec(PCs, A9, A10), wz_instr_sec(Is, A10, A11), wz_i(0, A11, []).
+wz_entry_rows([], A, A).
+wz_entry_rows([NC-LI|Es], A0, A3) :-
+    wz_n(NC, A0, A1), wz_i(LI, A1, A2), wz_entry_rows(Es, A2, A3).

--- a/tests/test_plawk_dyncall_at_named.pl
+++ b/tests/test_plawk_dyncall_at_named.pl
@@ -118,6 +118,21 @@ test(named_entry_on_compile_handle, [condition(clang_available)]) :-
     assertion(Out == "150\n"),
     !.
 
+% THE FAMILY PAYOFF: one compile() source holding TWO grammars, called
+% by name at two sites. The source text is identical at both sites, so
+% content dedup yields ONE handle (one compile, one loaded VM), and the
+% multi-entry name table the shipped cgfullm compiler emits resolves
+% both predicates against it. Squares 150 + doubles 44 over 3,4,5,10.
+test(compile_handle_exposes_family, [condition(clang_available)]) :-
+    an_dir(Dir),
+    GramSrc = "[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2), (dbl(X3, R3) :- atom_number(X3, N3), R3 is N3 * 2)]",
+    format(string(Src),
+        "{ total += dyncall_at@sq(compile(\"~w\"), $1) + dyncall_at@dbl(compile(\"~w\"), $1) }\n\c
+         END { print total }\n", [GramSrc, GramSrc]),
+    build_run(Dir, 'anfam', Src, "3\n4\n5\n10\n", Out),
+    assertion(Out == "194\n"),
+    !.
+
 :- end_tests(plawk_dyncall_at_named).
 
 % --- helpers ---------------------------------------------------------------

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -1615,6 +1615,34 @@ test(selfhost_intdiv_truncates, [condition(clang_available)]) :-
     assertion(Out == "3034\n"),
     !.
 
+% cgfullm: cgfull + a MULTI-ENTRY name table (the eval compiler the
+% plawk CLI ships). Byte-compat guard: a single-predicate source
+% serializes IDENTICALLY through both (NE=1, first predicate named,
+% label 0), so content-dedup handles and every existing single-grammar
+% compile are unchanged -- and cgfull stays the self-host oracle.
+test(cgfullm_single_pred_byte_identical) :-
+    Clauses = [(sq(X, R) :- R is X * X)],
+    cgfull_term(Clauses, W1),
+    cgfullm_term(Clauses, W2),
+    assertion(W1 == W2),
+    !.
+
+% A multi-predicate source gains one entry row per predicate group
+% ("name/arity" -> its group label), which is what lets dyncall_at@name
+% resolve ANY predicate of a runtime-compiled object, not just the
+% first.
+test(cgfullm_multi_pred_entry_table) :-
+    Clauses = [(sq(X, R) :- R is X * X), (dbl(X2, R2) :- R2 is X2 * 2)],
+    cgfullm_term(Clauses, Wamo),
+    atomic_list_concat(Lines, '\n', Wamo),
+    Lines = ['WAMO', '2', '0', NE, E1Name, E1Lbl, E2Name, E2Lbl | _],
+    assertion(NE == '2'),
+    assertion(E1Name == '4 sq/2'),
+    assertion(E1Lbl == '0'),
+    assertion(E2Name == '5 dbl/2'),
+    assertion(E2Lbl == '1'),
+    !.
+
 % Nested arithmetic in the loaded compiler: the is-expression is staged
 % with c_operand (build_struct + X-temp deferral), so arbitrarily nested
 % expressions compile. (X + Y) * (X - 1) + 100 with X=3, Y=4 -> 114.


### PR DESCRIPTION
## What

A `compile(...)` source holding a grammar **family** now exposes every predicate to `dyncall_at@name` — previously a compiled handle named only its first predicate.

```awk
{ total += dyncall_at@sq(compile("[(sq(...)...), (dbl(...)...)]"), $1)
         + dyncall_at@dbl(compile("[(sq(...)...), (dbl(...)...)]"), $1) }
# same source text at both sites → ONE content-deduped handle, two named entries
```

## Design — why `cgfullm` instead of changing `cgfull`

Every self-host golden (the front, walkers, and capstone fixtures embed their own serializer restatements) compares byte-identically against `cgfull_term`'s output on multi-predicate programs. Changing `cgfull`'s header would mean rewriting three giant fixture strings in lockstep — high risk, no user-visible gain. Instead:

- `cgfull_term` is refactored around a shared `cgfull_core/6` (grouping, labels, tables, per-group codegen, closed PC table) — output **byte-identical**, so `cgfull` remains the untouched self-host fixpoint subject.
- **`cgfullm/2`** = the same core + `group_entries` (one `"name/arity"` → group-label row per predicate) through **`wzam_serialize/7`**, the multi-entry twin of `wza_serialize` (NE from the entries list instead of a hardcoded 1). New predicates stay inside the loadable subset like the rest of the module.
- For a **single-predicate** source the two serialize identically (NE=1, first predicate named, label 0) — content-dedup handles and every existing compile are unchanged.
- The plawk CLI now ships `cgfullm` as `<bin>.evalc.wamo`.

This composes directly with #3638's per-call entry resolution: the eval-loaded VM's materialized entry table now has one row per predicate.

## Tests

- `cgfullm_single_pred_byte_identical` — the byte-compat guard.
- `cgfullm_multi_pred_entry_table` — header rows asserted line-by-line (`NE=2`, `sq/2`→0, `dbl/2`→1).
- `compile_handle_exposes_family` (E2E) — two grammars in one `compile()` source, two named call sites, one handle: squares 150 + doubles 44 → **194**.

Regressions: `test_wam_object` **65/65** (all self-host goldens untouched, capstone included), `test_plawk_eval_compile` 7/7, `test_plawk_dyncall_at` 5/5, `test_plawk_dyncall_at_named` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_