### PR TITLE
Parse comments in Rust WAM source atoms

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1798,6 +1798,7 @@ compile_execute_term_builtin_to_rust(Code) :-
         target_reg: &str,
         options: Option<&Value>,
     ) -> bool {
+        let atom_text = Self::strip_term_comments(atom_text);
         let variable_names = options
             .and_then(|value| self.read_term_option_arg(value, "variable_names"));
         let variables = options
@@ -1834,7 +1835,7 @@ compile_execute_term_builtin_to_rust(Code) :-
 
         parser.reset_query();
         let parsed_var = Value::Unbound("_RP_term".to_string());
-        parser.set_reg_str("A1", Value::Atom(atom_text.to_string()));
+        parser.set_reg_str("A1", Value::Atom(atom_text));
         parser.set_reg_str("A2", ops);
         parser.set_reg_str("A3", parsed_var.clone());
         let var_env = Value::Unbound("_RP_env".to_string());

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -502,7 +502,10 @@ fn term_to_atom_quotes_and_roundtrips_non_bare_atoms() {
 fn read_term_from_atom_returns_variable_metadata_with_shared_variables() {
     let (code, labels) = shared_wam_program();
     let mut vm = WamState::new(code, labels);
-    vm.set_reg_str("A1", at("p(A, B, A, _, _C, _C, D)"));
+    vm.set_reg_str(
+        "A1",
+        at("p(A, /* ignored . block */ B, A, _, _C, _C, D)"),
+    );
     vm.set_reg_str("A2", ub("Term"));
     vm.set_reg_str(
         "A3",


### PR DESCRIPTION
## Summary

- Sanitize `%` and `/* ... */` comments in the shared Rust atom-parser bridge.
- Apply comment handling consistently to:
  - `read_term_from_atom/2,3`
  - `atom_to_term/3`
  - reverse `term_to_atom/2`
- Preserve variable sharing and read-term metadata.
- Move the sanitized source string directly into the parser VM.

The bridge still performs one owned source-string allocation; sanitization replaces the previous copy rather than adding another allocation.

## Testing

- Focused generated Rust dynamic-builtin crate
- Full Rust WAM target suite
- Prolog target syntax check
- `git diff --check`