### PR TITLE
plawk: float/blob named-at, rule-body for-in, and DYNENTRY (WAM/LLVM)

### DIFF
--- a/docs/design/PLAWK_EVAL_ARCHITECTURE.md
+++ b/docs/design/PLAWK_EVAL_ARCHITECTURE.md
@@ -192,17 +192,21 @@ plus a compile site is a **build error**, not a silent miscompile.
 
 Deliberately deferred, in rough value order:
 
-- **for-in over grammar-populated tables inside rule bodies** (END
-  works today).
-- ~~**`dyncall_at@name(...)`**~~ — LANDED (i64): named entries on
-  runtime sources and `compile(...)` handles, resolved per call
-  against the VM's materialized entry table. Compiled handles expose
-  their whole predicate family: the CLI ships `cgfullm` (cgfull's core
-  + a multi-entry name table; byte-identical on single-predicate
-  sources, so `cgfull` stays the self-host oracle). Remaining
-  follow-up: `float`/`blob` named-at variants.
-- **Surface B (`DYNENTRY`)** — declaration-bound library names with
-  static PC bake (see the roadmap's namespace-rule discussion).
+- ~~**for-in over grammar-populated tables inside rule bodies**~~ —
+  LANDED: `for (k in arr) print ...` runs per record inside the rule's
+  action chain, over the table as accumulated so far (str-valued
+  tables print text there too).
+- ~~**`dyncall_at@name(...)`**~~ — LANDED (all three return kinds:
+  i64, `float(...)`, `blob(...)`): named entries on runtime sources
+  and `compile(...)` handles, resolved per call against the VM's
+  materialized entry table. Compiled handles expose their whole
+  predicate family: the CLI ships `cgfullm` (cgfull's core + a
+  multi-entry name table; byte-identical on single-predicate sources,
+  so `cgfull` stays the self-host oracle).
+- ~~**Surface B (`DYNENTRY`)**~~ — LANDED as parse-time sugar:
+  `DYNENTRY parse, score` reserves the names and rewrites bare calls
+  to the named-entry nodes (startup-cached PC); shadowing a userspace
+  or builtin name is a parse error.
 - **Handle-in-scalar** — storing a compile handle in a plawk variable
   across records (today the dedup makes the nested form equivalent).
 - **Further compiler-subset growth** — the bootstrap compiler covers

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -163,22 +163,26 @@ two grammars in one source, two named call sites, one content-deduped
 handle → 194). Single-predicate sources serialize byte-identically to
 `cgfull` (NE=1, first predicate named), so handles, dedup, and every
 existing compile are unchanged — and `cgfull` stays the untouched
-self-host fixpoint subject. `float`/`blob` named-at variants remain
-the follow-up, mirroring how surface A landed i64-first. Surface **B**
-below stays planned.
+self-host fixpoint subject. The `float`/`blob` named-at variants have
+LANDED too (`float(dyncall_at@name(...))` / `blob(dyncall_at@name(...))`
+— the i64 shim shape with the f64/bytes call primitives, cached and
+off modes), so the named-at surface covers all three return kinds.
+Surface **B** below has landed as well (see next section).
 
-**Surface B — declaration-bound library names (planned):** for a fixed
+**Surface B — declaration-bound library names — LANDED:** for a fixed
 `DYNLOAD` shipping a known family, bind entries once at declaration and call
-them like ordinary functions: `DYNENTRY parse` → `parse($1)`. Cleaner call
-sites than A, and resolution stays static (baked PC) because the object is
-compile-time-fixed. **A is for the userspace/dynamic case (call site says
-`@name`, cost is visible); B is for the pre-compiled library case (bare
-call, cost read from the declaration).** The rule that makes B coherent:
-*entry resolution inherits the object's sourcing* — fixed `DYNLOAD` ⇒ static
-PC bake; a runtime source ⇒ per-load resolution. Build B when a real
-multi-entry library exists and A's `@name` call sites feel noisy.
+them like ordinary functions: `DYNENTRY parse, score` → `parse($1)`,
+`float(score($2))`. Implemented as PARSE-TIME sugar: a declared name's
+bare-call nodes rewrite to the named-entry nodes (`dyncall_named` /
+`float_dyncall_named`), so the whole surface-A machinery — the shared
+startup-resolved cached-PC resolver — carries B with zero new codegen.
+**A is for the userspace/dynamic case (call site says `@name`, cost is
+visible); B is for the pre-compiled library case (bare call, cost read
+from the declaration).** The rule that makes B coherent: *entry
+resolution inherits the object's sourcing* — fixed `DYNLOAD` ⇒ static
+PC bake; a runtime source ⇒ per-load resolution (`dyncall_at@name`).
 
-**Namespace rule for B (settled):** `DYNENTRY name` **reserves** `name` for
+**Namespace rule for B (implemented as settled):** `DYNENTRY name` **reserves** `name` for
 the compiled object — it removes that identifier from userspace, so the two
 name sets are disjoint *by construction*. A bare `name(...)` call resolves
 by set membership: in the `DYNENTRY` set → compiled entry; otherwise →

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -122,6 +122,8 @@ build(File, Out0, KeepLL) :-
         ; plawk_program_dyncall_named_rec_entries(Program, DynNamedRec), DynNamedRec \== []
         ; plawk_program_dyncall_at_arities(Program, DynAtArities), DynAtArities \== []
         ; plawk_program_dyncall_at_named_entries(Program, DynAtNamed), DynAtNamed \== []
+        ; plawk_program_dyncall_at_named_float_entries(Program, DynAtNamedF), DynAtNamedF \== []
+        ; plawk_program_dyncall_at_named_blob_entries(Program, DynAtNamedB), DynAtNamedB \== []
         ; plawk_program_dyncall_float_arities(Program, DynFArities), DynFArities \== []
         ; plawk_program_dyncall_at_float_arities(Program, DynAtFArities), DynAtFArities \== []
         ; plawk_program_dyncall_blob_arities(Program, DynBArities), DynBArities \== []

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -18,6 +18,8 @@
     plawk_program_dyncall_assoc_str_arities/2,
     plawk_program_dyncall_at_arities/2,
     plawk_program_dyncall_at_named_entries/2,
+    plawk_program_dyncall_at_named_float_entries/2,
+    plawk_program_dyncall_at_named_blob_entries/2,
     plawk_program_dyncall_float_arities/2,
     plawk_program_dyncall_at_float_arities/2,
     plawk_program_dyncall_blob_arities/2,
@@ -647,6 +649,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_dyncall_assoc_str_arities(Program, DynAssocSArities),
     plawk_program_dyncall_at_arities(Program, DynAtArities),
     plawk_program_dyncall_at_named_entries(Program, DynAtNamed),
+    plawk_program_dyncall_at_named_float_entries(Program, DynAtNamedF),
+    plawk_program_dyncall_at_named_blob_entries(Program, DynAtNamedB),
     plawk_program_dyncall_float_arities(Program, DynFArities),
     plawk_program_dyncall_at_float_arities(Program, DynAtFArities),
     plawk_program_dyncall_blob_arities(Program, DynBArities),
@@ -666,6 +670,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         DynAssocSArities == [],
         DynAtArities == [],
         DynAtNamed == [],
+        DynAtNamedF == [],
+        DynAtNamedB == [],
         DynFArities == [],
         DynAtFArities == [],
         DynBArities == [],
@@ -702,11 +708,12 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...)) /
         % blob(dyncall_at(...)) sites + the shared path cache.
         (   DynAtArities == [], DynAtFArities == [], DynAtBArities == [],
-            DynAtNamed == []
+            DynAtNamed == [], DynAtNamedF == [], DynAtNamedB == []
         ->  DyncallAtSupportIR = ''
         ;   plawk_program_dyncache_mode(Program, CacheMode),
             plawk_dyncall_at_support_ir(CacheMode, DynAtArities, DynAtFArities,
-                DynAtBArities, DynAtNamed, DyncallAtSupportIR)
+                DynAtBArities, DynAtNamed, DynAtNamedF, DynAtNamedB,
+                DyncallAtSupportIR)
         ),
         % The eval surface: compile(...) sites need @plawk_compile plus
         % the bootstrap-compiler object path (BEGIN { EVALC = "..." }
@@ -1850,49 +1857,65 @@ plawk_dyncall_store_lines(NArgs, Lines) :-
 %  Cache capacity is 64 distinct grammars; beyond that "on"/"mtime" load
 %  without caching (correct, just not reused).
 plawk_dyncall_at_support_ir(Mode, Arities, IR) :-
-    plawk_dyncall_at_support_ir(Mode, Arities, [], [], [], IR).
+    plawk_dyncall_at_support_ir(Mode, Arities, [], [], [], [], [], IR).
 plawk_dyncall_at_support_ir(Mode, IArities, FArities, IR) :-
-    plawk_dyncall_at_support_ir(Mode, IArities, FArities, [], [], IR).
+    plawk_dyncall_at_support_ir(Mode, IArities, FArities, [], [], [], [], IR).
 plawk_dyncall_at_support_ir(Mode, IArities, FArities, BArities, IR) :-
-    plawk_dyncall_at_support_ir(Mode, IArities, FArities, BArities, [], IR).
+    plawk_dyncall_at_support_ir(Mode, IArities, FArities, BArities,
+        [], [], [], IR).
+plawk_dyncall_at_support_ir(Mode, IArities, FArities, BArities,
+        NamedEntries, IR) :-
+    plawk_dyncall_at_support_ir(Mode, IArities, FArities, BArities,
+        NamedEntries, [], [], IR).
 
 %% plawk_dyncall_at_support_ir(+Mode, +IArities, +FArities, +BArities,
-%%                             +NamedEntries, -IR)
+%%                             +NamedI, +NamedF, +NamedB, -IR)
 %  IArities -> i64 @plawk_dyncall_at_N shims; FArities -> double
 %  @plawk_dyncall_at_f_N shims (float(dyncall_at(...))); BArities ->
 %  byte-slice @plawk_dyncall_at_b_N shims (blob(dyncall_at(...))).
-%  NamedEntries (Name-NArgs) -> @plawk_dyncall_at_named_<Sym> shims for
-%  dyncall_at@name sites, resolving the entry per call against the loaded
-%  VM's entry table. All share the cache + @plawk_dyncall_at_get emitted
-%  per Mode.
+%  NamedI/NamedF/NamedB (Name-NArgs) -> @plawk_dyncall_at_named[_f/_b]
+%  shims for dyncall_at@name sites in each return kind, resolving the
+%  entry per call against the loaded VM's entry table. All share the
+%  cache + @plawk_dyncall_at_get emitted per Mode.
 plawk_dyncall_at_support_ir(Mode, IArities, FArities, BArities,
-        NamedEntries, IR) :-
+        NamedI, NamedF, NamedB, IR) :-
     (   Mode == "off"
     ->  Globals = '', GetIR = '',
         ICShim = plawk_dyncall_at_shim_off_ir,
         FCShim = plawk_dyncall_at_shim_off_f_ir,
         BCShim = plawk_dyncall_at_shim_off_b_ir,
-        NShim = plawk_dyncall_at_named_shim_off_ir
+        NShim = plawk_dyncall_at_named_shim_off_ir,
+        NFShim = plawk_dyncall_at_named_shim_off_f_ir,
+        NBShim = plawk_dyncall_at_named_shim_off_b_ir
     ;   Mode == "mtime"
     ->  plawk_dyncache_globals_ir(mtime, Globals),
         plawk_dyncall_at_get_mtime_ir(GetIR),
         ICShim = plawk_dyncall_at_shim_cached_ir,
         FCShim = plawk_dyncall_at_shim_cached_f_ir,
         BCShim = plawk_dyncall_at_shim_cached_b_ir,
-        NShim = plawk_dyncall_at_named_shim_cached_ir
+        NShim = plawk_dyncall_at_named_shim_cached_ir,
+        NFShim = plawk_dyncall_at_named_shim_cached_f_ir,
+        NBShim = plawk_dyncall_at_named_shim_cached_b_ir
     ;   plawk_dyncache_globals_ir(plain, Globals),
         plawk_dyncall_at_get_on_ir(GetIR),
         ICShim = plawk_dyncall_at_shim_cached_ir,
         FCShim = plawk_dyncall_at_shim_cached_f_ir,
         BCShim = plawk_dyncall_at_shim_cached_b_ir,
-        NShim = plawk_dyncall_at_named_shim_cached_ir
+        NShim = plawk_dyncall_at_named_shim_cached_ir,
+        NFShim = plawk_dyncall_at_named_shim_cached_f_ir,
+        NBShim = plawk_dyncall_at_named_shim_cached_b_ir
     ),
     findall(S,  ( member(N, IArities),  call(ICShim, N, S) ), IShims),
     findall(FS, ( member(FN, FArities), call(FCShim, FN, FS) ), FShims),
     findall(BS, ( member(BN, BArities), call(BCShim, BN, BS) ), BShims),
-    findall(NS, ( member(NName-NN, NamedEntries), call(NShim, NName, NN, NS) ),
+    findall(NS, ( member(NName-NN, NamedI), call(NShim, NName, NN, NS) ),
         NShims),
-    append([[Globals, GetIR], IShims, FShims, BShims, NShims], Parts0),
+    findall(NFS, ( member(NFName-NFN, NamedF), call(NFShim, NFName, NFN, NFS) ),
+        NFShims),
+    findall(NBS, ( member(NBName-NBN, NamedB), call(NBShim, NBName, NBN, NBS) ),
+        NBShims),
+    append([[Globals, GetIR], IShims, FShims, BShims, NShims, NFShims,
+        NBShims], Parts0),
     exclude(==(''), Parts0, Parts),
     atomic_list_concat(Parts, '\n\n', IR).
 
@@ -2444,6 +2467,175 @@ fail:
 }',
         [NArgs, ParamsIR, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
 
+% double / byte-slice named-at shims (float(dyncall_at@name(...)) /
+% blob(dyncall_at@name(...))): the i64 named-at shape with the other
+% call primitives -- fetch the VM per the mode, resolve the entry name
+% against its materialized entry table per call, then read the output
+% as a double or byte slice.
+plawk_dyncall_at_named_shim_cached_f_ir(Name, NArgs, IR) :-
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    EntryArity is NArgs + 1,
+    format(atom(EntryName), '~w/~w', [Name, EntryArity]),
+    format(atom(ENameGlobal), 'plawk_at_ename_f_~w', [Sym]),
+    llvm_emit_c_string_global(ENameGlobal, EntryName, ENameGlobalIR,
+        ENameLen, ENameBytesLen),
+    plawk_dyncall_at_params(NArgs, ParamsIR),
+    plawk_dyncall_at_argsetup(NArgs, ArgsPtrIR, ArgsSetupIR),
+    format(atom(IR),
+'~w
+
+define { double, i1 } @plawk_dyncall_at_named_f_~w(~w) {
+entry:
+  %obj = call { %WamState*, i32 } @plawk_dyncall_at_get(i8* %path, i64 %len)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %resolve
+
+resolve:
+  %namep = getelementptr [~w x i8], [~w x i8]* @.plawk_at_ename_f_~w, i32 0, i32 0
+  %pc = call i32 @wam_object_vm_entry_pc(%WamState* %vm, i8* %namep, i64 ~w)
+  %bad = icmp slt i32 %pc, 0
+  br i1 %bad, label %fail, label %do_call
+
+do_call:
+~w
+  %r = call { double, i1 } @wam_object_call_f64(%WamState* %vm, i32 %pc, i32 ~w, %Value* ~w, i32 ~w)
+  ret { double, i1 } %r
+
+fail:
+  %f0 = insertvalue { double, i1 } undef, double 0.0, 0
+  %f1 = insertvalue { double, i1 } %f0, i1 false, 1
+  ret { double, i1 } %f1
+}',
+        [ENameGlobalIR, Sym, ParamsIR, ENameBytesLen, ENameBytesLen, Sym,
+         ENameLen, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
+
+plawk_dyncall_at_named_shim_off_f_ir(Name, NArgs, IR) :-
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    EntryArity is NArgs + 1,
+    format(atom(EntryName), '~w/~w', [Name, EntryArity]),
+    format(atom(ENameGlobal), 'plawk_at_ename_f_~w', [Sym]),
+    llvm_emit_c_string_global(ENameGlobal, EntryName, ENameGlobalIR,
+        ENameLen, ENameBytesLen),
+    plawk_dyncall_at_params(NArgs, ParamsIR),
+    plawk_dyncall_at_argsetup(NArgs, ArgsPtrIR, ArgsSetupIR),
+    format(atom(IR),
+'~w
+
+define { double, i1 } @plawk_dyncall_at_named_f_~w(~w) {
+entry:
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %resolve
+
+resolve:
+  %namep = getelementptr [~w x i8], [~w x i8]* @.plawk_at_ename_f_~w, i32 0, i32 0
+  %pc = call i32 @wam_object_vm_entry_pc(%WamState* %vm, i8* %namep, i64 ~w)
+  %bad = icmp slt i32 %pc, 0
+  br i1 %bad, label %free_fail, label %do_call
+
+do_call:
+~w
+  %r = call { double, i1 } @wam_object_call_f64(%WamState* %vm, i32 %pc, i32 ~w, %Value* ~w, i32 ~w)
+  call void @wam_state_free(%WamState* %vm)
+  ret { double, i1 } %r
+
+free_fail:
+  call void @wam_state_free(%WamState* %vm)
+  br label %fail
+
+fail:
+  %f0 = insertvalue { double, i1 } undef, double 0.0, 0
+  %f1 = insertvalue { double, i1 } %f0, i1 false, 1
+  ret { double, i1 } %f1
+}',
+        [ENameGlobalIR, Sym, ParamsIR, ENameBytesLen, ENameBytesLen, Sym,
+         ENameLen, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
+
+plawk_dyncall_at_named_shim_cached_b_ir(Name, NArgs, IR) :-
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    EntryArity is NArgs + 1,
+    format(atom(EntryName), '~w/~w', [Name, EntryArity]),
+    format(atom(ENameGlobal), 'plawk_at_ename_b_~w', [Sym]),
+    llvm_emit_c_string_global(ENameGlobal, EntryName, ENameGlobalIR,
+        ENameLen, ENameBytesLen),
+    plawk_dyncall_at_params(NArgs, ParamsIR),
+    plawk_dyncall_at_argsetup(NArgs, ArgsPtrIR, ArgsSetupIR),
+    format(atom(IR),
+'~w
+
+define { i8*, i64, i1 } @plawk_dyncall_at_named_b_~w(~w) {
+entry:
+  %obj = call { %WamState*, i32 } @plawk_dyncall_at_get(i8* %path, i64 %len)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %resolve
+
+resolve:
+  %namep = getelementptr [~w x i8], [~w x i8]* @.plawk_at_ename_b_~w, i32 0, i32 0
+  %pc = call i32 @wam_object_vm_entry_pc(%WamState* %vm, i8* %namep, i64 ~w)
+  %bad = icmp slt i32 %pc, 0
+  br i1 %bad, label %fail, label %do_call
+
+do_call:
+~w
+  %r = call { i8*, i64, i1 } @wam_object_call_bytes(%WamState* %vm, i32 %pc, i32 ~w, %Value* ~w, i32 ~w)
+  ret { i8*, i64, i1 } %r
+
+fail:
+  %f0 = insertvalue { i8*, i64, i1 } undef, i8* null, 0
+  %f1 = insertvalue { i8*, i64, i1 } %f0, i64 0, 1
+  %f2 = insertvalue { i8*, i64, i1 } %f1, i1 false, 2
+  ret { i8*, i64, i1 } %f2
+}',
+        [ENameGlobalIR, Sym, ParamsIR, ENameBytesLen, ENameBytesLen, Sym,
+         ENameLen, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
+
+plawk_dyncall_at_named_shim_off_b_ir(Name, NArgs, IR) :-
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    EntryArity is NArgs + 1,
+    format(atom(EntryName), '~w/~w', [Name, EntryArity]),
+    format(atom(ENameGlobal), 'plawk_at_ename_b_~w', [Sym]),
+    llvm_emit_c_string_global(ENameGlobal, EntryName, ENameGlobalIR,
+        ENameLen, ENameBytesLen),
+    plawk_dyncall_at_params(NArgs, ParamsIR),
+    plawk_dyncall_at_argsetup(NArgs, ArgsPtrIR, ArgsSetupIR),
+    format(atom(IR),
+'~w
+
+define { i8*, i64, i1 } @plawk_dyncall_at_named_b_~w(~w) {
+entry:
+  %obj = call { %WamState*, i32 } @wam_object_load(i8* %path)
+  %vm = extractvalue { %WamState*, i32 } %obj, 0
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %resolve
+
+resolve:
+  %namep = getelementptr [~w x i8], [~w x i8]* @.plawk_at_ename_b_~w, i32 0, i32 0
+  %pc = call i32 @wam_object_vm_entry_pc(%WamState* %vm, i8* %namep, i64 ~w)
+  %bad = icmp slt i32 %pc, 0
+  br i1 %bad, label %free_fail, label %do_call
+
+do_call:
+~w
+  %r = call { i8*, i64, i1 } @wam_object_call_bytes(%WamState* %vm, i32 %pc, i32 ~w, %Value* ~w, i32 ~w)
+  call void @wam_state_free(%WamState* %vm)
+  ret { i8*, i64, i1 } %r
+
+free_fail:
+  call void @wam_state_free(%WamState* %vm)
+  br label %fail
+
+fail:
+  %f0 = insertvalue { i8*, i64, i1 } undef, i8* null, 0
+  %f1 = insertvalue { i8*, i64, i1 } %f0, i64 0, 1
+  %f2 = insertvalue { i8*, i64, i1 } %f1, i1 false, 2
+  ret { i8*, i64, i1 } %f2
+}',
+        [ENameGlobalIR, Sym, ParamsIR, ENameBytesLen, ENameBytesLen, Sym,
+         ENameLen, ArgsSetupIR, NArgs, ArgsPtrIR, NArgs]).
+
 plawk_dyncall_at_params(0, 'i8* %path, i64 %len') :- !.
 plawk_dyncall_at_params(NArgs, ParamsIR) :-
     plawk_foreign_wrapper_params(NArgs, ValParams),
@@ -2561,6 +2753,25 @@ plawk_blob_expr_ir(blob_dyncall_at(Source, Args), FieldSeparator, Base,
     append(SrcGlobals, ArgGlobals, GlobalParts),
     append(SrcSetup, ArgSetup, PreSetup),
     plawk_blob_tail_ir(Base, ResIR, PreSetup, LenIR, PtrIR, SetupParts).
+plawk_blob_expr_ir(blob_dyncall_at_named(Name, Source, Args), FieldSeparator,
+        Base, LenIR, PtrIR, GlobalParts, SetupParts) :-
+    length(Args, NArgs),
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    plawk_dyncall_source_ir(Source, FieldSeparator, Base, Base,
+        PathPtrIR, PathLenIR, SrcGlobals, SrcSetup),
+    plawk_foreign_args_ir(Args, FieldSeparator, Base, ArgValueIRs,
+        ArgGlobals, ArgSetup),
+    ( ArgValueIRs == []
+    -> CallArgsSuffix = ''
+    ;  plawk_foreign_call_args_ir(ArgValueIRs, AV),
+       format(atom(CallArgsSuffix), ', ~w', [AV])
+    ),
+    format(atom(ResIR),
+        '  %~w_res = call { i8*, i64, i1 } @plawk_dyncall_at_named_b_~w(i8* ~w, i64 ~w~w)',
+        [Base, Sym, PathPtrIR, PathLenIR, CallArgsSuffix]),
+    append(SrcGlobals, ArgGlobals, GlobalParts),
+    append(SrcSetup, ArgSetup, PreSetup),
+    plawk_blob_tail_ir(Base, ResIR, PreSetup, LenIR, PtrIR, SetupParts).
 
 plawk_blob_tail_ir(Base, ResIR, PreSetup, LenIR, PtrIR, SetupParts) :-
     format(atom(OkIR),
@@ -2651,11 +2862,15 @@ plawk_program_compile_sites(Program, Sites) :-
           ( plawk_actions_dyncall_at(Actions, CSrc, _)
           ; plawk_actions_dyncall_at_named(Actions, _NName, CSrc, _)
           ; plawk_actions_float_dyncall_at(Actions, CSrc, _)
+          ; plawk_actions_float_dyncall_at_named(Actions, _FName, CSrc, _)
           ),
           plawk_compile_source_node(CSrc, Arg)
         ;   % blob positions via the generic walk (print fields, writebin
             % slots, assoc keys, blob_eq patterns)
-            plawk_program_blob_node(Program, blob_dyncall_at(CSrc, _)),
+            ( plawk_program_blob_node(Program, blob_dyncall_at(CSrc, _))
+            ; plawk_program_blob_node(Program,
+                  blob_dyncall_at_named(_BName, CSrc, _))
+            ),
             plawk_compile_source_node(CSrc, Arg)
         ),
         Sites0),
@@ -2779,6 +2994,47 @@ plawk_expr_float_dyncall_at(Expr, S, A) :-
     ; plawk_expr_float_dyncall_at(Right, S, A)
     ).
 
+%% plawk_program_dyncall_at_named_float_entries(+Program, -Entries)
+%  Name-NArgs pairs across float(dyncall_at@name(...)) sites -- the
+%  double-returning named-at shims.
+plawk_program_dyncall_at_named_float_entries(
+        program(_Begin, Rules, EndClauses), Entries) :-
+    findall(Name-NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          plawk_actions_float_dyncall_at_named(Actions, Name, _Source, Args),
+          length(Args, NArgs)
+        ),
+        Entries0),
+    sort(Entries0, Entries).
+
+plawk_actions_float_dyncall_at_named(Actions, Name, Source, Args) :-
+    member(Action, Actions),
+    plawk_action_float_dyncall_at_named(Action, Name, Source, Args).
+plawk_action_float_dyncall_at_named(add(_Var, Expr), N, S, A) :-
+    plawk_expr_float_dyncall_at_named(Expr, N, S, A).
+plawk_action_float_dyncall_at_named(set(_Var, Expr), N, S, A) :-
+    plawk_expr_float_dyncall_at_named(Expr, N, S, A).
+plawk_action_float_dyncall_at_named(print(Fields), N, S, A) :-
+    member(Field, Fields),
+    plawk_expr_float_dyncall_at_named(Field, N, S, A).
+plawk_action_float_dyncall_at_named(printf(_Format, PrintfArgs), N, S, A) :-
+    member(Field, PrintfArgs),
+    plawk_expr_float_dyncall_at_named(Field, N, S, A).
+plawk_action_float_dyncall_at_named(if(_Pattern, ThenActions, ElseActions),
+        N, S, A) :-
+    ( plawk_actions_float_dyncall_at_named(ThenActions, N, S, A)
+    ; plawk_actions_float_dyncall_at_named(ElseActions, N, S, A)
+    ).
+plawk_expr_float_dyncall_at_named(float_dyncall_at_named(Name, Source, Args),
+    Name, Source, Args).
+plawk_expr_float_dyncall_at_named(Expr, N, S, A) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    ( plawk_expr_float_dyncall_at_named(Left, N, S, A)
+    ; plawk_expr_float_dyncall_at_named(Right, N, S, A)
+    ).
+
 %% blob(dyncall(...)) / blob(dyncall_at(...)) arity collectors -- one
 %  byte-slice shim per distinct call-arg count. blob only appears as a
 %  print/writebin field (not inside arithmetic), so the walkers scan
@@ -2794,7 +3050,8 @@ plawk_program_blob_node(program(_Begin, Rules, EndClauses), Blob) :-
 plawk_subterm_blob(Term, Term) :-
     compound(Term),
     functor(Term, F, _),
-    memberchk(F, [blob_dyncall, blob_dyncall_named, blob_dyncall_at]).
+    memberchk(F, [blob_dyncall, blob_dyncall_named, blob_dyncall_at,
+        blob_dyncall_at_named]).
 plawk_subterm_blob(Term, Blob) :-
     compound(Term),
     arg(_, Term, Sub),
@@ -2815,6 +3072,18 @@ plawk_program_dyncall_at_blob_arities(Program, Arities) :-
         ),
         A0),
     sort(A0, Arities).
+
+%% plawk_program_dyncall_at_named_blob_entries(+Program, -Entries)
+%  Name-NArgs pairs across blob(dyncall_at@name(...)) sites, found by
+%  the same generic blob-node walk as the other blob kinds.
+plawk_program_dyncall_at_named_blob_entries(Program, Entries) :-
+    findall(Name-NArgs,
+        ( plawk_program_blob_node(Program,
+              blob_dyncall_at_named(Name, _Source, Args)),
+          length(Args, NArgs)
+        ),
+        E0),
+    sort(E0, Entries).
 
 plawk_action_blob_field(print(Fields), Blob) :- member(Blob, Fields).
 plawk_action_blob_field(printf(_Format, PrintfArgs), Blob) :- member(Blob, PrintfArgs).
@@ -4791,6 +5060,7 @@ plawk_writebin_str_arg(Blob, _Width) :-
 plawk_blob_node_shape(blob_dyncall(_)).
 plawk_blob_node_shape(blob_dyncall_named(_, _)).
 plawk_blob_node_shape(blob_dyncall_at(_, _)).
+plawk_blob_node_shape(blob_dyncall_at_named(_, _, _)).
 
 %% plawk_blob_call_arg_ok(+Expr) is semidet.
 %  Shape plus argument validation (same checks as the float variants;
@@ -4801,6 +5071,8 @@ plawk_blob_call_arg_ok(blob_dyncall_named(Name, Args)) :-
     plawk_float_dyncall_named_expr(float_dyncall_named(Name, Args)).
 plawk_blob_call_arg_ok(blob_dyncall_at(Source, Args)) :-
     plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)).
+plawk_blob_call_arg_ok(blob_dyncall_at_named(Name, Source, Args)) :-
+    plawk_float_dyncall_at_expr(float_dyncall_at_named(Name, Source, Args)).
 
 plawk_writebin_i64_arg(special('NR')).
 plawk_writebin_i64_arg(special('NF')).
@@ -6487,6 +6759,8 @@ plawk_rule_body_print_field(blob_dyncall_named(Name, Args)) :-
     plawk_float_dyncall_named_expr(float_dyncall_named(Name, Args)).
 plawk_rule_body_print_field(blob_dyncall_at(Source, Args)) :-
     plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)).
+plawk_rule_body_print_field(blob_dyncall_at_named(Name, Source, Args)) :-
+    plawk_float_dyncall_at_expr(float_dyncall_at_named(Name, Source, Args)).
 plawk_rule_body_print_field(Expr) :-
     plawk_f64_print_expr(Expr).
 plawk_rule_body_print_field(length(field(_))).
@@ -6590,6 +6864,10 @@ plawk_float_dyncall_named_expr(float_dyncall_named(Name, Args)) :-
     Args = [_ | _],
     maplist(plawk_foreign_arg, Args).
 plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)) :-
+    plawk_dyncall_at_source_ok(Source),
+    maplist(plawk_foreign_arg, Args).
+plawk_float_dyncall_at_expr(float_dyncall_at_named(Name, Source, Args)) :-
+    atom(Name),
     plawk_dyncall_at_source_ok(Source),
     maplist(plawk_foreign_arg, Args).
 
@@ -7118,6 +7396,8 @@ plawk_f64_scalar_read_operand_expr(float_dyncall_named(Name, Args)) :-
     plawk_float_dyncall_named_expr(float_dyncall_named(Name, Args)).
 plawk_f64_scalar_read_operand_expr(float_dyncall_at(Source, Args)) :-
     plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)).
+plawk_f64_scalar_read_operand_expr(float_dyncall_at_named(Name, Source, Args)) :-
+    plawk_float_dyncall_at_expr(float_dyncall_at_named(Name, Source, Args)).
 plawk_f64_scalar_read_operand_expr(Expr) :-
     plawk_i64_operand_expr(Expr).
 plawk_f64_scalar_read_operand_expr(Expr) :-
@@ -7700,6 +7980,7 @@ plawk_expr_is_double(float_call(_Name, _Args)).
 plawk_expr_is_double(float_dyncall(_Args)).
 plawk_expr_is_double(float_dyncall_named(_Name, _Args)).
 plawk_expr_is_double(float_dyncall_at(_Source, _Args)).
+plawk_expr_is_double(float_dyncall_at_named(_Name, _Source, _Args)).
 % A substituted read of a double scalar slot (see
 % plawk_substitute_scalar_reads/4).
 plawk_expr_is_double(ssa_f64(_Value)).
@@ -7731,6 +8012,8 @@ plawk_f64_operand_expr(float_dyncall_named(Name, Args)) :-
     plawk_float_dyncall_named_expr(float_dyncall_named(Name, Args)).
 plawk_f64_operand_expr(float_dyncall_at(Source, Args)) :-
     plawk_float_dyncall_at_expr(float_dyncall_at(Source, Args)).
+plawk_f64_operand_expr(float_dyncall_at_named(Name, Source, Args)) :-
+    plawk_float_dyncall_at_expr(float_dyncall_at_named(Name, Source, Args)).
 plawk_f64_operand_expr(Expr) :-
     plawk_i64_operand_expr(Expr).
 plawk_f64_operand_expr(Expr) :-
@@ -7806,6 +8089,26 @@ plawk_f64_expr_ir(float_dyncall_at(Source, Args), FieldSeparator, Base, GlobalBa
     format(atom(ResIR),
         '  %~w_res = call { double, i1 } @plawk_dyncall_at_f_~w(i8* ~w, i64 ~w~w)',
         [Base, NArgs, PathPtrIR, PathLenIR, CallArgsSuffix]),
+    append(SrcGlobals, ArgGlobals, GlobalParts),
+    append(SrcSetup, ArgSetup, PreSetup),
+    plawk_f64_call_tail_ir(Base, ResIR, PreSetup, ValueIR, SetupParts).
+plawk_f64_expr_ir(float_dyncall_at_named(Name, Source, Args), FieldSeparator,
+        Base, GlobalBase, ValueIR, GlobalParts, SetupParts) :-
+    !,
+    length(Args, NArgs),
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    plawk_dyncall_source_ir(Source, FieldSeparator, Base, GlobalBase,
+        PathPtrIR, PathLenIR, SrcGlobals, SrcSetup),
+    plawk_foreign_args_ir(Args, FieldSeparator, GlobalBase, ArgValueIRs,
+        ArgGlobals, ArgSetup),
+    ( ArgValueIRs == []
+    -> CallArgsSuffix = ''
+    ;  plawk_foreign_call_args_ir(ArgValueIRs, AV),
+       format(atom(CallArgsSuffix), ', ~w', [AV])
+    ),
+    format(atom(ResIR),
+        '  %~w_res = call { double, i1 } @plawk_dyncall_at_named_f_~w(i8* ~w, i64 ~w~w)',
+        [Base, Sym, PathPtrIR, PathLenIR, CallArgsSuffix]),
     append(SrcGlobals, ArgGlobals, GlobalParts),
     append(SrcSetup, ArgSetup, PreSetup),
     plawk_f64_call_tail_ir(Base, ResIR, PreSetup, ValueIR, SetupParts).
@@ -8965,6 +9268,13 @@ plawk_emit_print_expr_for_context(blob_dyncall_at(Source, Args), FieldSeparator,
     plawk_print_expr_output_names(Context, blob, FmtPrefix, PrintPrefix),
     plawk_blob_expr_ir(blob_dyncall_at(Source, Args), FieldSeparator, Base,
         LenIR, PtrIR, GlobalParts, SetupParts).
+plawk_emit_print_expr_for_context(blob_dyncall_at_named(Name, Source, Args),
+        FieldSeparator, Context,
+        slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, blob, Base),
+    plawk_print_expr_output_names(Context, blob, FmtPrefix, PrintPrefix),
+    plawk_blob_expr_ir(blob_dyncall_at_named(Name, Source, Args),
+        FieldSeparator, Base, LenIR, PtrIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(length(field(FieldIndex)), FieldSeparator, Context,
         i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3112,12 +3112,37 @@ plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays,
     RuleSpecs \== [],
     findall(RuleArrayName,
         ( member(rule(_Pattern, ActionSpecs, _Control), RuleSpecs),
-          member(RuleArrayName-_KeyIndex, ActionSpecs)
+          ( member(RuleArrayName-_KeyIndex, ActionSpecs)
+          ; member(dynassoc(RuleArrayName, _Call), ActionSpecs)
+          ; plawk_assoc_spec_forin_array(ActionSpecs, RuleArrayName)
+          )
         ),
         ActionArrays),
     append([ActionArrays, [ArrayName], LookupArrays], ArrayNames0),
     sort(ArrayNames0, Tables),
-    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, 0), PlannedRules).
+    plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays),
+    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, StrArrays, 0),
+        PlannedRules).
+
+%% plawk_assoc_spec_forin_array(+ActionSpecs, -ArrayName)
+%  Arrays a rule-body for-in touches: the iterated table and every
+%  lookup array in its print fields -- all need table slots.
+plawk_assoc_spec_forin_array(ActionSpecs, ArrayName) :-
+    member(forin(_LoopVar, FA, FFields), ActionSpecs),
+    ( ArrayName = FA
+    ; member(assoc(var(ArrayName), var(_)), FFields)
+    ).
+
+%% plawk_assoc_specs_str_arrays(+RuleSpecs, -StrArrays)
+%  Names of tables populated through `as assoc(str)` binds -- their
+%  values are atom-registry ids, so for-in value reads resolve to text.
+plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays) :-
+    findall(A,
+        ( member(rule(_P, ActionSpecs, _C), RuleSpecs),
+          member(dynassoc(A, str(_Call)), ActionSpecs)
+        ),
+        As0),
+    sort(As0, StrArrays).
 
 plawk_forin_print_field(LoopVar, var(LoopVar)).
 plawk_forin_print_field(LoopVar, assoc(var(_ArrayName), var(LoopVar))).
@@ -3757,7 +3782,10 @@ plawk_mixed_planned_rules([rule(Pattern, Actions) | Rest], assoc_plan(Tables, Ac
          NextIndex = Index,
          PlannedAssocActions = []
       ;  HasActions = true,
-         phrase(plawk_assoc_planned_actions(AssocSpecs, Tables, 0), PlannedAssocActions),
+         % the mixed route plans increment specs only (no dynassoc-str
+         % binds reach it), so the str-array set is empty here
+         phrase(plawk_assoc_planned_actions(AssocSpecs, Tables, [], 0),
+             PlannedAssocActions),
          NextIndex is Index + 1
       )
     },
@@ -3990,12 +4018,15 @@ plawk_assoc_runtime_count_plan(
         ( member(rule(_Pattern, ActionSpecs, _Control), RuleSpecs),
           ( member(ArrayName-_KeyIndex, ActionSpecs)
           ; member(dynassoc(ArrayName, _Call), ActionSpecs)
+          ; plawk_assoc_spec_forin_array(ActionSpecs, ArrayName)
           )
         ),
         ActionArrays),
     append(ActionArrays, PrintArrays, ArrayNames0),
     sort(ArrayNames0, Tables),
-    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, 0), PlannedRules).
+    plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays),
+    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, StrArrays, 0),
+        PlannedRules).
 
 plawk_assoc_rule_controls(assoc_plan(_Tables, Rules), Controls) :-
     findall(Control, member(assoc_rule(_Index, _Pattern, _Actions, Control), Rules), Controls).
@@ -4029,6 +4060,16 @@ plawk_assoc_body_action_spec(dynassoc_bind(var(ArrayName), Call),
 plawk_assoc_body_action_spec(dynassoc_bind_str(var(ArrayName), Call),
         dynassoc(ArrayName, str(Call))) :-
     plawk_dynrec_call_ok(Call).
+% rule-body for-in: per-record iteration over an assoc table with a
+% print body -- the END for-in's field shapes (loop key / lookups keyed
+% by it / string literals), emitted as a loop inside the rule's action
+% chain. Field plans (table indexes, i64-vs-str value kinds) resolve at
+% planning time.
+plawk_assoc_body_action_spec(for_in(var(LoopVar), var(ArrayName), Body),
+        forin(LoopVar, ArrayName, Fields)) :-
+    Body = [print(Fields)],
+    Fields = [_ | _],
+    maplist(plawk_forin_print_field(LoopVar), Fields).
 
 plawk_assoc_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), ArrayName-KeyIndex) :-
     KeyIndex > 0.
@@ -4045,29 +4086,62 @@ plawk_assoc_blob_key_ok(Blob) :-
 plawk_assoc_print_array(assoc(var(ArrayName), string(_Key)), ArrayName).
 plawk_assoc_print_array(assoc(var(ArrayName), int(_Key)), ArrayName).
 
-plawk_assoc_planned_rules([], _Tables, _Index) -->
+plawk_assoc_planned_rules([], _Tables, _StrArrays, _Index) -->
     [].
-plawk_assoc_planned_rules([rule(Pattern, ActionSpecs, Control) | Rest], Tables, Index) -->
-    { phrase(plawk_assoc_planned_actions(ActionSpecs, Tables, 0), PlannedActions),
+plawk_assoc_planned_rules([rule(Pattern, ActionSpecs, Control) | Rest], Tables,
+        StrArrays, Index) -->
+    { phrase(plawk_assoc_planned_actions(ActionSpecs, Tables, StrArrays, 0),
+          PlannedActions),
       NextIndex is Index + 1
     },
     [assoc_rule(Index, Pattern, PlannedActions, Control)],
-    plawk_assoc_planned_rules(Rest, Tables, NextIndex).
+    plawk_assoc_planned_rules(Rest, Tables, StrArrays, NextIndex).
 
-plawk_assoc_planned_actions([], _Tables, _Index) -->
+plawk_assoc_planned_actions([], _Tables, _StrArrays, _Index) -->
     [].
-plawk_assoc_planned_actions([ArrayName-KeyIndex | Rest], Tables, Index) -->
+plawk_assoc_planned_actions([ArrayName-KeyIndex | Rest], Tables, StrArrays,
+        Index) -->
     { nth0(TableIndex, Tables, ArrayName),
       NextIndex is Index + 1
     },
     [assoc_action(Index, ArrayName, TableIndex, KeyIndex)],
-    plawk_assoc_planned_actions(Rest, Tables, NextIndex).
-plawk_assoc_planned_actions([dynassoc(ArrayName, Call) | Rest], Tables, Index) -->
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, NextIndex).
+plawk_assoc_planned_actions([dynassoc(ArrayName, Call) | Rest], Tables,
+        StrArrays, Index) -->
     { nth0(TableIndex, Tables, ArrayName),
       NextIndex is Index + 1
     },
     [assoc_dyn_action(Index, ArrayName, TableIndex, Call)],
-    plawk_assoc_planned_actions(Rest, Tables, NextIndex).
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, NextIndex).
+% rule-body for-in: resolve each print field to a plan (loop key /
+% iterated-table value / lookup by key / literal), with the value kind
+% (i64 vs str) baked in from the str-array set, so the emitter needs no
+% program context.
+plawk_assoc_planned_actions([forin(LoopVar, ArrayName, Fields) | Rest],
+        Tables, StrArrays, Index) -->
+    { nth0(TableIndex, Tables, ArrayName),
+      maplist(plawk_forin_rule_field_plan(LoopVar, ArrayName, TableIndex,
+          Tables, StrArrays), Fields, FieldPlans),
+      NextIndex is Index + 1
+    },
+    [assoc_forin_action(Index, TableIndex, FieldPlans)],
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, NextIndex).
+
+plawk_forin_rule_field_plan(LoopVar, _ArrayName, _TableIndex, _Tables,
+        _StrArrays, var(LoopVar), key) :- !.
+plawk_forin_rule_field_plan(LoopVar, ArrayName, TableIndex, _Tables,
+        StrArrays, assoc(var(ArrayName), var(LoopVar)),
+        value_self(TableIndex, Kind)) :-
+    !,
+    ( memberchk(ArrayName, StrArrays) -> Kind = str ; Kind = i64 ).
+plawk_forin_rule_field_plan(LoopVar, _ArrayName, _TableIndex, Tables,
+        StrArrays, assoc(var(LookupName), var(LoopVar)),
+        value_lookup(LookupIndex, Kind)) :-
+    !,
+    nth0(LookupIndex, Tables, LookupName),
+    ( memberchk(LookupName, StrArrays) -> Kind = str ; Kind = i64 ).
+plawk_forin_rule_field_plan(_LoopVar, _ArrayName, _TableIndex, _Tables,
+        _StrArrays, string(Value), lit(Value)).
 
 plawk_assoc_entry_setup_ir(assoc_plan(Tables, _Actions), IR) :-
     phrase(plawk_assoc_entry_setup_lines(Tables, 0), Lines),
@@ -4209,6 +4283,130 @@ plawk_assoc_rule_action_blocks(RuleIndex,
     },
     plawk_emit_lines(Lines),
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+% Rule-body for-in: a per-record loop over an assoc table's occupied
+% slots, printing the planned fields (loop key resolved to text, table
+% values numeric or str-resolved per the plan, literals) one line per
+% key -- the END for-in loop shape with rule/action-scoped labels so it
+% nests in the action chain. Literal-field constants ride the global
+% channel like blob-key marshals.
+plawk_assoc_rule_action_blocks(RuleIndex,
+        [assoc_forin_action(Index, TableIndex, FieldPlans) | Rest],
+        NextLabel, FieldSeparator) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(B), 'arfi_~w_~w', [RuleIndex, Index]),
+      format(atom(HeadBr), '  br label %~w_head', [B]),
+      format(atom(HeadLbl), '~w_head:', [B]),
+      format(atom(Phi),
+          '  %~w_idx = phi i64 [0, %assoc_rule_~w_action_~w], [%~w_next, %~w_done]',
+          [B, RuleIndex, Index, B, B]),
+      format(atom(Slot),
+          '  %~w_slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_idx)',
+          [B, TableIndex, B]),
+      format(atom(DoneC), '  %~w_done_c = icmp slt i64 %~w_slot, 0', [B, B]),
+      format(atom(BrBody),
+          '  br i1 %~w_done_c, label %~w_after, label %~w_body', [B, B, B]),
+      format(atom(BodyLbl), '~w_body:', [B]),
+      format(atom(Key),
+          '  %~w_key = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_slot)',
+          [B, TableIndex, B]),
+      phrase(plawk_forin_rule_field_lines(FieldPlans, B, 0), FieldLines),
+      format(atom(NL), '  %~w_nl = call i32 @putchar(i32 10)', [B]),
+      format(atom(BrDone), '  br label %~w_done', [B]),
+      format(atom(DoneLbl), '~w_done:', [B]),
+      format(atom(Next), '  %~w_next = add i64 %~w_slot, 1', [B, B]),
+      format(atom(BrHead), '  br label %~w_head', [B]),
+      format(atom(AfterLbl), '~w_after:', [B]),
+      format(atom(BrNext), '  br label %~w', [ActionNextLabel]),
+      append([[Label, HeadBr, '', HeadLbl, Phi, Slot, DoneC, BrBody, '',
+               BodyLbl, Key],
+              FieldLines,
+              [NL, BrDone, '', DoneLbl, Next, BrHead, '', AfterLbl, BrNext,
+               '']],
+          Lines)
+    },
+    plawk_emit_lines(Lines),
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+
+plawk_forin_rule_field_lines([], _B, _N) -->
+    [].
+plawk_forin_rule_field_lines([Plan | Rest], B, N) -->
+    ( { N > 0 }
+    ->  { format(atom(Sep), '  %~w_sep_~w = call i32 @putchar(i32 32)',
+              [B, N]) },
+        [Sep]
+    ;   []
+    ),
+    plawk_forin_rule_field_value(Plan, B, N),
+    { N1 is N + 1 },
+    plawk_forin_rule_field_lines(Rest, B, N1).
+
+% loop key: a text-mode table key is a registry id -- resolve to text.
+plawk_forin_rule_field_value(key, B, N) -->
+    { format(atom(KeyS),
+          '  %~w_key_s_~w = call i8* @wam_atom_to_string(i64 %~w_key)',
+          [B, N, B]),
+      format(atom(FmtVar), '~w_key_fmt_~w', [B, N]),
+      format(atom(PrintVar), '~w_key_p_~w', [B, N]),
+      format(atom(PtrIR), '%~w_key_s_~w', [B, N]),
+      llvm_emit_printf_string(plawk_surface_print_string, FmtVar, PrintVar,
+          PtrIR, [FmtPtr, PrintCall])
+    },
+    [KeyS, FmtPtr, PrintCall].
+plawk_forin_rule_field_value(value_self(TableIndex, Kind), B, N) -->
+    { format(atom(Value),
+          '  %~w_v_~w = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_slot)',
+          [B, N, TableIndex, B])
+    },
+    [Value],
+    plawk_forin_rule_value_print(Kind, B, N).
+plawk_forin_rule_field_value(value_lookup(LookupIndex, Kind), B, N) -->
+    { format(atom(Value),
+          '  %~w_v_~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_key)',
+          [B, N, LookupIndex, B])
+    },
+    [Value],
+    plawk_forin_rule_value_print(Kind, B, N).
+plawk_forin_rule_field_value(lit(Value), B, N) -->
+    { format(atom(GName), 'plawk_~w_lit_~w', [B, N]),
+      llvm_emit_c_string_global(GName, Value, Global, _StrLen, BytesLen),
+      format(atom(Ptr),
+          '  %~w_lit_~w = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
+          [B, N, BytesLen, BytesLen, GName]),
+      format(atom(FmtVar), '~w_lit_fmt_~w', [B, N]),
+      format(atom(PrintVar), '~w_lit_p_~w', [B, N]),
+      format(atom(PtrIR), '%~w_lit_~w', [B, N]),
+      llvm_emit_printf_string(plawk_surface_print_string, FmtVar, PrintVar,
+          PtrIR, [FmtPtr, PrintCall])
+    },
+    [global(Global), Ptr, FmtPtr, PrintCall].
+
+plawk_forin_rule_value_print(i64, B, N) -->
+    { format(atom(FmtVar), '~w_v_fmt_~w', [B, N]),
+      format(atom(PrintVar), '~w_v_p_~w', [B, N]),
+      format(atom(ValueIR), '%~w_v_~w', [B, N]),
+      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+          ValueIR, [FmtPtr, PrintCall])
+    },
+    [FmtPtr, PrintCall].
+% str-valued table: the stored i64 is an atom-registry id.
+plawk_forin_rule_value_print(str, B, N) -->
+    { format(atom(ValueS),
+          '  %~w_vs_~w = call i8* @wam_atom_to_string(i64 %~w_v_~w)',
+          [B, N, B, N]),
+      format(atom(FmtVar), '~w_vs_fmt_~w', [B, N]),
+      format(atom(PrintVar), '~w_vs_p_~w', [B, N]),
+      format(atom(PtrIR), '%~w_vs_~w', [B, N]),
+      llvm_emit_printf_string(plawk_surface_print_string, FmtVar, PrintVar,
+          PtrIR, [FmtPtr, PrintCall])
+    },
+    [ValueS, FmtPtr, PrintCall].
+
 % blob keys: evaluate the runtime grammar's byte output and intern it,
 % exactly as the text-field path interns its slice; a failed call (null
 % pointer) skips the increment, like a missing field. Works in text and

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -65,8 +65,46 @@ plawk_parse_source(Source, Program, PrologClauses) :-
     maplist(plawk_read_block_clauses, BlockTexts, ClausesNested),
     append(ClausesNested, BlockClauses),
     string_codes(Stripped, Codes),
-    phrase(plawk_program(Program, FunctionClauses), Codes),
-    append(BlockClauses, FunctionClauses, PrologClauses).
+    phrase(plawk_program(Program, FunctionClauses, DynEntries), Codes),
+    append(BlockClauses, FunctionClauses, PrologClauses),
+    plawk_dynentry_reserved_check(DynEntries, PrologClauses).
+
+%% plawk_dynentry_reserved_check(+DynEntries, +PrologClauses)
+%
+%  DYNENTRY reserves a name for the compiled object -- declaring one
+%  that an @prolog block or `function` definition also defines, or a
+%  surface builtin/keyword name, throws (a parse error at the CLI):
+%  never silent shadowing in either direction.
+plawk_dynentry_reserved_check([], _) :- !.
+plawk_dynentry_reserved_check(DynEntries, PrologClauses) :-
+    findall(Defined,
+        ( member(Clause, PrologClauses),
+          plawk_clause_head_name(Clause, Defined)
+        ),
+        DefinedNames),
+    forall(member(Name, DynEntries),
+        (   memberchk(Name, DefinedNames)
+        ->  throw(error(plawk_dynentry_reserved(Name),
+                context(plawk_parse_source/3,
+                    'DYNENTRY name is also defined by an @prolog block or function -- reservation forbids shadowing')))
+        ;   plawk_surface_reserved_name(Name)
+        ->  throw(error(plawk_dynentry_reserved(Name),
+                context(plawk_parse_source/3,
+                    'DYNENTRY name collides with a surface builtin/keyword')))
+        ;   true
+        )).
+
+plawk_clause_head_name((Head :- _Body), Name) :-
+    !,
+    functor(Head, Name, _).
+plawk_clause_head_name(Head, Name) :-
+    compound(Head),
+    functor(Head, Name, _).
+
+plawk_surface_reserved_name(Name) :-
+    memberchk(Name, [length, index, substr, int, tolower, toupper,
+        float, blob, dyncall, dyncall_at, compile, compile_file,
+        print, printf, function, for, in, if, else, next, break]).
 
 plawk_split_prolog_blocks(Source, Stripped, BlockTexts) :-
     split_string(Source, "\n", "", Lines),
@@ -121,13 +159,101 @@ plawk_read_stream_clauses(Stream, Clauses) :-
 plawk_program(Program) -->
     plawk_program(Program, _FunctionClauses).
 
-plawk_program(program(BeginClauses, Rules, EndClauses), FunctionClauses) -->
+plawk_program(Program, FunctionClauses) -->
+    plawk_program(Program, FunctionClauses, _DynEntries).
+
+plawk_program(program(BeginClauses, Rules, EndClauses), FunctionClauses,
+        DynEntries) -->
     ws,
     begin_clauses(BeginClauses),
     function_defs(FunctionClauses),
-    program_rules(Rules),
-    end_clauses(EndClauses),
-    eos.
+    dynentry_decls(DynEntries),
+    program_rules(Rules0),
+    end_clauses(EndClauses0),
+    eos,
+    { plawk_dynentry_rewrite_all(Rules0, DynEntries, Rules),
+      plawk_dynentry_rewrite_all(EndClauses0, DynEntries, EndClauses)
+    }.
+
+%% dynentry_decls(-Names)//
+%
+%  Surface B (declaration-bound library names): for a fixed DYNLOAD
+%  shipping a known entry family, bind names once at declaration and
+%  call them like ordinary functions:
+%
+%      DYNENTRY parse, score
+%      { total += parse($1) + score($2) }
+%
+%  A declared name is RESERVED for the compiled object: every bare
+%  `name(args)` call site (and `float(name(args))`) rewrites at parse
+%  time to the named-entry node (dyncall_named / float_dyncall_named),
+%  so resolution stays static -- the entry's PC resolves once at
+%  startup and is cached, exactly like an explicit dyncall@name site.
+%  Reservation makes the name sets disjoint by construction: declaring
+%  a name that an @prolog block or `function` definition also defines,
+%  or a surface builtin name, is a PARSE ERROR (never silent
+%  shadowing) -- checked in plawk_parse_source once the block clauses
+%  are known.
+dynentry_decls(Names) -->
+    dynentry_decl(First),
+    !,
+    dynentry_decls(Rest),
+    { append(First, Rest, Names) }.
+dynentry_decls([]) -->
+    [].
+
+dynentry_decl(Names) -->
+    "DYNENTRY",
+    identifier_boundary,
+    ws,
+    dynentry_names(Names),
+    ws.
+
+dynentry_names([Name | Names]) -->
+    identifier(Name),
+    dynentry_names_rest(Names).
+
+dynentry_names_rest([Name | Names]) -->
+    ws,
+    ",",
+    ws,
+    !,
+    identifier(Name),
+    dynentry_names_rest(Names).
+dynentry_names_rest([]) -->
+    [].
+
+%% plawk_dynentry_rewrite_all(+Terms0, +Names, -Terms)
+%
+%  Substitute bare-call nodes over declared names with their
+%  named-entry counterparts, everywhere in the parsed rules/END:
+%  prolog_call -> dyncall_named, float_call -> float_dyncall_named.
+%  A declared name in a position the named machinery does not compile
+%  (e.g. a guard pattern) yields the ordinary
+%  outside-the-compilable-surface build error rather than silently
+%  calling userspace.
+plawk_dynentry_rewrite_all(Terms, [], Terms) :- !.
+plawk_dynentry_rewrite_all(Terms0, Names, Terms) :-
+    plawk_dynentry_rewrite(Terms0, Names, Terms).
+
+plawk_dynentry_rewrite(Term0, Names, Term) :-
+    (   Term0 = prolog_call(Name, Args0),
+        memberchk(Name, Names)
+    ->  plawk_dynentry_rewrite(Args0, Names, Args),
+        Term = dyncall_named(Name, Args)
+    ;   Term0 = float_call(Name, Args0),
+        memberchk(Name, Names)
+    ->  plawk_dynentry_rewrite(Args0, Names, Args),
+        Term = float_dyncall_named(Name, Args)
+    ;   compound(Term0)
+    ->  Term0 =.. [F | Args0],
+        maplist(plawk_dynentry_rewrite_arg(Names), Args0, Args),
+        Term =.. [F | Args]
+    ;   Term = Term0
+    ).
+
+plawk_dynentry_rewrite_arg(Names, Arg0, Arg) :-
+    plawk_dynentry_rewrite(Arg0, Names, Arg).
 
 %% function_defs(-Clauses)//
 %

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -886,6 +886,14 @@ action(Action) -->
 action(Action) -->
     dynrec_bind_action(Action),
     !.
+% for (k in arr) { ... } as a RULE-BODY action: per-record iteration
+% over an assoc table (e.g. one a grammar just populated via
+% `arr = dyncall@t($1) as assoc`), not just the END report. The body
+% grammar is shared with the END form; what compiles is gated by the
+% assoc-route codegen (a print body over the loop key / lookups).
+action(Action) -->
+    for_in_action(Action),
+    !.
 action(Action) -->
     add_assign_action(Action),
     !.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1563,6 +1563,26 @@ float_literal_expr(float_const(Mantissa, Denominator)) -->
 %  variants: the loaded grammar's numeric output is read as a double.
 %  These must precede the generic clause, whose inner prolog_call_expr
 %  would otherwise parse `dyncall` as an ordinary identifier call.
+% float(dyncall_at@name(Source, args...)): a named entry on a runtime
+% source, read as a double -- parsed before the bare at form so the @
+% form wins.
+float_call_expr(float_dyncall_at_named(Name, Source, Args)) -->
+    "float",
+    ws,
+    "(",
+    ws,
+    "dyncall_at@",
+    identifier(Name),
+    ws,
+    "(",
+    ws,
+    dyncall_at_source(Source),
+    foreign_args_rest(Args),
+    ws,
+    ")",
+    ws,
+    ")",
+    !.
 float_call_expr(float_dyncall_at(Source, Args)) -->
     "float",
     ws,
@@ -1624,6 +1644,25 @@ float_call_expr(float_call(Name, Args)) -->
 %  blob(dyncall(...)) / blob(dyncall_at(...)): read the runtime grammar's
 %  Atom output as opaque bytes (a slice), for print / writebin positions.
 %  Reserved like the dyncall forms; the inner keyword disambiguates.
+% blob(dyncall_at@name(Source, args...)): a named entry on a runtime
+% source, read as opaque bytes -- parsed before the bare at form.
+blob_call_expr(blob_dyncall_at_named(Name, Source, Args)) -->
+    "blob",
+    ws,
+    "(",
+    ws,
+    "dyncall_at@",
+    identifier(Name),
+    ws,
+    "(",
+    ws,
+    dyncall_at_source(Source),
+    foreign_args_rest(Args),
+    ws,
+    ")",
+    ws,
+    ")",
+    !.
 blob_call_expr(blob_dyncall_at(Source, Args)) -->
     "blob",
     ws,

--- a/tests/test_plawk_dyncall_at_named.pl
+++ b/tests/test_plawk_dyncall_at_named.pl
@@ -20,6 +20,11 @@
 square(X, R) :- atom_number(X, N), R is N * N.
 cube(X, R)   :- atom_number(X, N), R is N * N * N.
 
+% float / blob named-at variants: a halving grammar (keeps fractions)
+% and a greeting grammar (returns an atom = a byte string)
+halve(X, R) :- atom_number(X, N), R is N / 2.
+greet(X, R) :- atom_concat('hi-', X, R).
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -116,6 +121,36 @@ test(named_entry_on_compile_handle, [condition(clang_available)]) :-
          END { print total }\n", []),
     build_run(Dir, 'anh', Src, "3\n4\n5\n10\n", Out),
     assertion(Out == "150\n"),
+    !.
+
+% float(dyncall_at@name(...)): the named entry's numeric output read as
+% a double. halve over 3,4 -> 1.5 + 2 = 3.5.
+test(float_named_at_entry, [condition(clang_available)]) :-
+    an_dir(Dir),
+    directory_file_path(Dir, 'fb.wamo', Wamo),
+    write_wam_object([user:halve/2, user:greet/2],
+        [wamo_entries([halve/2, greet/2])], Wamo),
+    format(string(Src),
+        "{ total += float(dyncall_at@halve(\"~w\", $1)) }\n\c
+         END { print total }\n", [Wamo]),
+    build_run(Dir, 'anf', Src, "3\n4\n", Out),
+    assertion(Out == "3.5\n"),
+    !.
+
+% blob(dyncall_at@name(...)): the named entry's Atom output read as a
+% byte slice and printed per record.
+test(blob_named_at_entry, [condition(clang_available)]) :-
+    an_dir(Dir),
+    directory_file_path(Dir, 'fb.wamo', Wamo),
+    ( exists_file(Wamo)
+    -> true
+    ;  write_wam_object([user:halve/2, user:greet/2],
+           [wamo_entries([halve/2, greet/2])], Wamo)
+    ),
+    format(string(Src),
+        "{ print blob(dyncall_at@greet(\"~w\", $1)) }\n", [Wamo]),
+    build_run(Dir, 'anb', Src, "bob\neve\n", Out),
+    assertion(Out == "hi-bob\nhi-eve\n"),
     !.
 
 % THE FAMILY PAYOFF: one compile() source holding TWO grammars, called

--- a/tests/test_plawk_dynentry.pl
+++ b/tests/test_plawk_dynentry.pl
@@ -1,0 +1,124 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Surface B (DYNENTRY): declaration-bound library names. For a fixed
+% DYNLOAD shipping a known entry family, bind names once and call them
+% like ordinary functions -- `parse($1)` instead of `dyncall@parse($1)`.
+% A declared name is RESERVED for the compiled object (parse-time
+% rewrite to the named-entry machinery, so the PC still resolves once
+% at startup); declaring a name userspace also defines is a parse
+% error, never silent shadowing.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+square(X, R) :- atom_number(X, N), R is N * N.
+cube(X, R)   :- atom_number(X, N), R is N * N * N.
+halve(X, R)  :- atom_number(X, N), R is N / 2.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dynentry).
+
+% DYNENTRY declarations rewrite bare calls to the named-entry nodes at
+% parse time -- i64 and float positions alike.
+test(dynentry_rewrites_bare_calls) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         DYNENTRY square, halve\n\c
+         { t += square($1) ; f += float(halve($1)) }\nEND { print t }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(add(var(t), dyncall_named(square, [field(1)])), Actions),
+    memberchk(add(var(f), float_dyncall_named(halve, [field(1)])), Actions),
+    !.
+
+% An undeclared bare call stays an ordinary compiled-foreign call node.
+test(undeclared_calls_untouched) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         DYNENTRY square\n\c
+         { t += square($1) + other($1) }\nEND { print t }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(add(var(t), add_i64(dyncall_named(square, [field(1)]),
+        prolog_call(other, [field(1)]))), Actions),
+    !.
+
+% Reservation: a DYNENTRY name an @prolog block also defines throws --
+% never silent shadowing.
+test(dynentry_over_block_predicate_throws,
+     [throws(error(plawk_dynentry_reserved(score), _))]) :-
+    plawk_parse_source(
+        "@prolog\nscore(X, R) :- R is X + 1.\n@end\n\c
+         BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         DYNENTRY score\n\c
+         { t += score($1) }\nEND { print t }\n", _, _).
+
+% Reservation: surface builtin/keyword names are off limits.
+test(dynentry_over_builtin_throws,
+     [throws(error(plawk_dynentry_reserved(length), _))]) :-
+    plawk_parse_source(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         DYNENTRY length\n\c
+         { t += length($0) }\nEND { print t }\n", _, _).
+
+% Full round trip: two declared entries called like ordinary functions,
+% resolving against the DYNLOAD object's entry table (squares 4+9 +
+% cubes 8+27 = 48 over 2,3).
+test(dynentry_calls_resolve, [condition(clang_available)]) :-
+    de_dir(Dir),
+    directory_file_path(Dir, 'lib.wamo', Wamo),
+    write_wam_object([user:square/2, user:cube/2],
+        [wamo_entries([square/2, cube/2])], Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         DYNENTRY square, cube\n\c
+         { total += square($1) + cube($1) }\n\c
+         END { print total }\n", [Wamo]),
+    build_run(Dir, 'de', Src, "2\n3\n", Out),
+    assertion(Out == "48\n"),
+    !.
+
+:- end_tests(plawk_dynentry).
+
+% --- helpers ---------------------------------------------------------------
+
+de_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_dynentry', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, InputText, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog0, '_in.txt', Input),
+    setup_call_cleanup(open(Input, write, SI, [encoding(utf8)]),
+        write(SI, InputText), close(SI)),
+    run_bin(Bin, [Input], Out, 0).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_plawk_forin_rule_body.pl
+++ b/tests/test_plawk_forin_rule_body.pl
@@ -1,0 +1,120 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Rule-body for-in: per-record iteration over an assoc table -- e.g. one
+% a grammar just populated via `arr = dyncall@t($1) as assoc` -- printing
+% one line per key, inside the rule's action chain rather than only in
+% END. The loop sees the table AS ACCUMULATED SO FAR (a running
+% snapshot per record).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% atom-keyed tally: every record bumps seen, big/small bucket by size
+tallyc(X, R) :-
+    atom_number(X, N),
+    ( N > 100 -> R = [big-2, seen-1] ; R = [small-1, seen-1] ).
+
+% str-valued labeler (the assoc(str) table kind)
+labeler(X, R) :-
+    atom_number(X, N),
+    ( N > 100 -> R = [size-big, last-X] ; R = [size-small, last-X] ).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_forin_rule_body).
+
+% for (k in arr) parses as a rule-body ACTION (same node as the END
+% form, inside the rule's action list).
+test(rule_body_forin_parses) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         { arr = dyncall@tallyc($1) as assoc ; for (k in arr) print k, arr[k] }\n\c
+         END { print arr[\"seen\"] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(for_in(var(k), var(arr),
+        [print([var(k), assoc(var(arr), var(k))])]), Actions),
+    !.
+
+% Per-record snapshot: each record populates then iterates the RUNNING
+% table. 50 -> {small:1, seen:1} (2 lines); 200 -> {small:1, seen:2,
+% big:2} (3 lines); END reads seen=2. Line order is slot order, so
+% compare sorted.
+test(rule_body_forin_running_snapshot, [condition(clang_available)]) :-
+    fr_dir(Dir),
+    directory_file_path(Dir, 'tallyc.wamo', Wamo),
+    write_wam_object([user:tallyc/2], [wamo_entries([tallyc/2])], Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@tallyc($1) as assoc ; for (k in arr) print k, arr[k] }\n\c
+         END { print arr[\"seen\"] }\n", [Wamo]),
+    build_run(Dir, 'frb', Src, "50\n200\n", Out),
+    split_string(Out, "\n", "", Lines0),
+    exclude(==(""), Lines0, Lines),
+    msort(Lines, Sorted),
+    assertion(Sorted ==
+        ["2", "big 2", "seen 1", "seen 2", "small 1", "small 1"]),
+    !.
+
+% str-valued tables print their values as TEXT inside the rule loop too
+% (the planned field carries the table's value kind). One record, two
+% keys; last record 7 -> size small, last 7.
+test(rule_body_forin_str_values, [condition(clang_available)]) :-
+    fr_dir(Dir),
+    directory_file_path(Dir, 'labeler.wamo', Wamo),
+    write_wam_object([user:labeler/2], [wamo_entries([labeler/2])], Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@labeler($1) as assoc(str) ; for (k in arr) print k, arr[k], \"row\" }\n\c
+         END { print arr[\"size\"] }\n", [Wamo]),
+    build_run(Dir, 'frs', Src, "7\n", Out),
+    split_string(Out, "\n", "", Lines0),
+    exclude(==(""), Lines0, Lines),
+    msort(Lines, Sorted),
+    assertion(Sorted == ["last 7 row", "size small row", "small"]),
+    !.
+
+:- end_tests(plawk_forin_rule_body).
+
+% --- helpers ---------------------------------------------------------------
+
+fr_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_forin_rule', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, InputText, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog0, '_in.txt', Input),
+    setup_call_cleanup(open(Input, write, SI, [encoding(utf8)]),
+        write(SI, InputText), close(SI)),
+    run_bin(Bin, [Input], Out, 0).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
Three surface features, one commit each (single PR — nothing stacked to mis-merge). Together they close three of the five open items in the architecture doc's backlog.

## 1. `float`/`blob` `dyncall_at@name` variants

The named-at surface now covers all three return kinds, completing the surface-A pattern:

```awk
{ total += float(dyncall_at@halve("lib.wamo", $1)) }
{ print blob(dyncall_at@greet("lib.wamo", $1)) }
```

`@plawk_dyncall_at_named_f_<Sym>` / `_b_<Sym>` shims (cached + off modes; off frees the fresh VM on the resolve-miss path), collectors, compile-site collection, validators across the f64/blob whitelists, expr emission, and gates.

## 2. Rule-body for-in over assoc tables

```awk
{ arr = dyncall@tallyc($1) as assoc ; for (k in arr) print k, arr[k] }
```

Per record the loop walks the table **as accumulated so far** (a running snapshot). Field plans (loop key / self-value / lookup / literal) resolve table indexes and the value kind (i64 vs `str`) at planning time via a `StrArrays` context threaded through the planners — so str-valued tables print text inside the rule loop exactly as in END. The emit block is the END loop shape with rule/action-scoped labels nested in the assoc action chain; literal constants ride the global channel like blob-key marshals.

## 3. `DYNENTRY` — Surface B

```awk
BEGIN { DYNLOAD = "lib.wamo" }
DYNENTRY parse, score
{ total += parse($1) + float(score($2)) }
```

Declaration-bound library names, implemented as **parse-time sugar**: bare-call nodes over declared names rewrite to `dyncall_named` / `float_dyncall_named`, so surface A's startup-resolved cached-PC machinery (the "static PC bake") carries B with zero new codegen. The settled namespace rule is enforced: declaring a name an `@prolog` block or `function` also defines — or a surface builtin/keyword — **throws at parse** (never silent shadowing in either direction).

## Tests

- at-named suite grows to 9/9 (float sum 3.5, blob per-record slices).
- New `test_plawk_forin_rule_body.pl` (3): parse, running-snapshot E2E (per-record lines + END lookup), str-values + literal field.
- New `test_plawk_dynentry.pl` (5): i64+float rewrite, undeclared calls untouched, both reservation errors, E2E (two declared entries → 48).

Regressions: `test_wam_object` 65/65, all dyncall suites (at/named/float/blob/named_fb), eval-compile, assoc suites (12+11+5), for-in END + writebin, blob-consumers, functions, prolog-blocks, surface-prolog-calls, CLI — all green.

Docs: roadmap named-at + surface-B sections marked landed; the architecture summary's open list now has only handle-in-scalar and demand-driven compiler-subset growth remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_