### PR TITLE
WAM/LLVM eval: demand-driven subset growth — cut, disjunction, negation, text builtins

### DIFF
--- a/docs/design/PLAWK_EVAL_ARCHITECTURE.md
+++ b/docs/design/PLAWK_EVAL_ARCHITECTURE.md
@@ -209,6 +209,17 @@ Deliberately deferred, in rough value order:
   or builtin name is a parse error.
 - **Handle-in-scalar** — storing a compile handle in a plawk variable
   across records (today the dedup makes the nested form equivalent).
-- **Further compiler-subset growth** — the bootstrap compiler covers
-  the grammar shapes the eval surface targets; widening it is
-  demand-driven.
+- **Further compiler-subset growth** — demand-driven. The first
+  demand round probed common grammar shapes and landed the ones real
+  eval grammars hit: **cut** (`!` — committed choice; the loaded
+  reader also learned the solo `!` token), **bare disjunction**
+  (`(A ; B)` with live backtracking into the second branch),
+  **negation as failure** (`\+ G`, desugared to the ITE machinery;
+  the reader gained its one prefix operator), and the text-family
+  builtin whitelist (`sub_atom`, case mapping, `string_concat`,
+  `atom_string`, `split_string`, `term_to_atom`, `char_type`,
+  `code_type`). Known next demands, deliberately deferred: `findall`
+  emission (aggregate opcodes are loadable; the bootstrap does not
+  emit them yet) and `call/N` meta-call emission — which also gates
+  the assert-family whitelist, since a grammar cannot read the
+  dynamic store back without it.

--- a/src/unifyweaver/targets/wam_bootstrap_compiler.pl
+++ b/src/unifyweaver/targets/wam_bootstrap_compiler.pl
@@ -492,7 +492,7 @@ walk_term(T, S0, S) :- compound(T), !, T =.. [F|Args],
 % control / goal functors never appear as data terms in instructions
 skip_fn(':-'). skip_fn(','). skip_fn(';'). skip_fn('->'). skip_fn(is).
 skip_fn(=). skip_fn(>). skip_fn(<). skip_fn(>=). skip_fn(=<).
-skip_fn(=:=). skip_fn(=\=). skip_fn(==). skip_fn(\==).
+skip_fn(=:=). skip_fn(=\=). skip_fn(==). skip_fn(\==). skip_fn(\+).
 walk_term(T, S0, S) :- atom(T), !,          % data atom -> atom table
     S0 = s(At0, Fn0), add_unique(T, At0, At1), S = s(At1, Fn0).
 walk_term(_, S, S).
@@ -650,6 +650,30 @@ f_goal(( C -> T ; E ), PL, At, FT, PC0, PC, L0, L, Prs0, Prs, In0, In, Is) :- !,
     inter(InT, InE, In),
     append([enc(22,ElseL,0,0)|CondIs], [enc(31,0,0,0)|ThenIs], Front),
     append(Front, [enc(32,JoinL,0,0), enc(24,0,0,0)|ElseIs], Is).
+% BARE disjunction ( A ; B ) -- the ITE shape WITHOUT the soft cut, so
+% the alternatives stay backtrackable: a failure after the first branch
+% succeeds re-enters at the second (try_me_else's CP is still live).
+% Demand-driven subset growth: common in real grammars fed to
+% compile(...). Placed after the ITE clause, so ( C -> T ; E ) keeps
+% its committed-choice compilation.
+f_goal(( A ; B ), PL, At, FT, PC0, PC, L0, L, Prs0, Prs, In0, In, Is) :- !,
+    ElseL = L0, JoinL is L0 + 1, L1 is L0 + 2,
+    conj_list(A, AGs), conj_list(B, BGs),
+    PC1 is PC0 + 1,                                    % try_me_else(ElseL)
+    f_goals(AGs, PL, At, FT, PC1, PC2, L1, L2, Prs0, Prs1, In0, InA, AIs),
+    ElsePC is PC2 + 1,                                 % after jump(JoinL)
+    PC5 is ElsePC + 1,                                 % after trust_me
+    f_goals(BGs, PL, At, FT, PC5, JoinPC, L2, L, Prs1, Prs2, In0, InB, BIs),
+    PC = JoinPC,
+    append(Prs2, [ElseL-ElsePC, JoinL-JoinPC], Prs),
+    inter(InA, InB, In),
+    append([enc(22,ElseL,0,0)|AIs],
+        [enc(32,JoinL,0,0), enc(24,0,0,0)|BIs], Is).
+% Negation as failure: \+ G desugars to ( G -> fail ; true ) and rides
+% the ITE machinery unchanged (fail/0 and true/0 are runtime builtins).
+f_goal((\+ G), PL, At, FT, PC0, PC, L0, L, Prs0, Prs, In0, In, Is) :- !,
+    f_goal(( G -> fail ; true ), PL, At, FT, PC0, PC, L0, L, Prs0, Prs,
+        In0, In, Is).
 f_goal((L is E), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In2, Is) :- !,
     % NESTED arithmetic: the expression is just a term -- stage it with
     % c_operand (build_struct + X-temp deferral handles arbitrary nesting,
@@ -737,6 +761,24 @@ bi_id(succ, 2, 22).
 bi_id(\=, 2, 25).
 bi_id(sum_list, 2, 59).
 bi_id(numbervars, 3, 124).
+% demand-driven subset growth: control atoms and the text/string family
+% (all existing runtime builtins -- these rows only let source-level
+% grammars reach them). Plain `!` is the runtime's clause-level cut
+% builtin; true/fail anchor the \+ desugar above. assertz-family ids
+% exist in the runtime but stay unlisted until call/N emission lands (a
+% grammar cannot read the store back without it).
+bi_id(!, 0, 10).
+bi_id(true, 0, 8).
+bi_id(fail, 0, 9).
+bi_id(sub_atom, 5, 41).
+bi_id(upcase_atom, 2, 45).
+bi_id(downcase_atom, 2, 46).
+bi_id(string_concat, 3, 47).
+bi_id(atom_string, 2, 49).
+bi_id(split_string, 4, 85).
+bi_id(term_to_atom, 2, 173).
+bi_id(char_type, 2, 75).
+bi_id(code_type, 2, 172).
 bi_id(term_to_atom, 2, 173).
 bi_id(read_term_from_atom, 2, 174).
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -6853,6 +6853,33 @@ entry:
   ret %Value %v
 }
 
+; Unary compound builder (the prefix-operator counterpart of
+; @wam_build_binop): functor from the token bytes, arity 1, one arg.
+define %Value @wam_build_unop(i8* %s, i64 %opstart, i64 %oplen, %Value %a) {
+entry:
+  %nameptr = getelementptr i8, i8* %s, i64 %opstart
+  %fid = call i64 @wam_intern_atom(i8* %nameptr, i64 %oplen)
+  %fnstr = call i8* @wam_atom_to_string(i64 %fid)
+  call void @wam_arena_ensure()
+  %cpsz = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %cpmem = call i8* @wam_arena_alloc(i64 %cpsz)
+  %cp = bitcast i8* %cpmem to %Compound*
+  %fnsl = getelementptr %Compound, %Compound* %cp, i32 0, i32 0
+  store i8* %fnstr, i8** %fnsl
+  %arsl = getelementptr %Compound, %Compound* %cp, i32 0, i32 1
+  store i32 1, i32* %arsl
+  %argsmem = call i8* @wam_arena_alloc(i64 16)
+  %args = bitcast i8* %argsmem to %Value*
+  %argssl = getelementptr %Compound, %Compound* %cp, i32 0, i32 2
+  store %Value* %args, %Value** %argssl
+  %a0 = getelementptr %Value, %Value* %args, i64 0
+  store %Value %a, %Value* %a0
+  %cpi = ptrtoint %Compound* %cp to i64
+  %v0 = insertvalue %Value undef, i32 3, 0
+  %v = insertvalue %Value %v0, i64 %cpi, 1
+  ret %Value %v
+}
+
 ; Parse a term of priority <= maxprec: a primary, then a left-associative
 ; infix-operator loop (precedence climbing). yfx/xfx parse the right operand at
 ; prio-1, xfy at prio, giving correct associativity.
@@ -7137,7 +7164,53 @@ chk_paren:
   br i1 %is_lp0, label %do_paren, label %chk_quote
 chk_quote:
   %is_q = icmp eq i8 %c, 39
-  br i1 %is_q, label %do_quoted, label %chk_digit
+  br i1 %is_q, label %do_quoted, label %chk_bang
+chk_bang:
+  ; `!` is a SOLO token (neither a symbol-run nor an alnum char), read
+  ; as the atom ! -- the cut goal. Demand-driven subset growth: grammars
+  ; fed to compile(...) use cut freely; before this case the reader
+  ; simply failed on it.
+  %is_bang = icmp eq i8 %c, 33
+  br i1 %is_bang, label %do_bang, label %chk_backslash
+chk_backslash:
+  %is_bsl = icmp eq i8 %c, 92
+  br i1 %is_bsl, label %chk_nplus, label %chk_digit
+do_bang:
+  %bangp = getelementptr i8, i8* %s, i64 %p0
+  %bang_id = call i64 @wam_intern_atom(i8* %bangp, i64 1)
+  %bang1 = add i64 %p0, 1
+  store i64 %bang1, i64* %pos
+  %bv0 = insertvalue %Value undef, i32 0, 0
+  %bv = insertvalue %Value %bv0, i64 %bang_id, 1
+  ret %Value %bv
+chk_nplus:
+  ; prefix negation-as-failure (backslash-plus, fy 900): the only
+  ; prefix operator the reader knows -- parse the operand at 900 and
+  ; build the arity-1 compound. Guarded on exactly the two bytes 92,43
+  ; with no third symbol char, so a longer symbol run still reads as an
+  ; ordinary name token.
+  %np1 = add i64 %p0, 1
+  %np_has2 = icmp ult i64 %np1, %len
+  br i1 %np_has2, label %chk_nplus2, label %read_ident
+chk_nplus2:
+  %np1p = getelementptr i8, i8* %s, i64 %np1
+  %np1c = load i8, i8* %np1p
+  %np_is_plus = icmp eq i8 %np1c, 43
+  br i1 %np_is_plus, label %chk_nplus3, label %read_ident
+chk_nplus3:
+  %np2 = add i64 %p0, 2
+  %np_has3 = icmp ult i64 %np2, %len
+  br i1 %np_has3, label %chk_nplus4, label %do_nplus
+chk_nplus4:
+  %np2p = getelementptr i8, i8* %s, i64 %np2
+  %np2c = load i8, i8* %np2p
+  %np2_sym = call i1 @wam_is_symbol_char(i8 %np2c)
+  br i1 %np2_sym, label %read_ident, label %do_nplus
+do_nplus:
+  store i64 %np2, i64* %pos
+  %np_arg = call %Value @wam_parse_expr(%WamState* %vm, i8* %s, i64 %len, i64* %pos, i32 900)
+  %np_v = call %Value @wam_build_unop(i8* %s, i64 %p0, i64 2, %Value %np_arg)
+  ret %Value %np_v
 chk_digit:
   %c_ge0 = icmp uge i8 %c, 48
   %c_le9 = icmp ule i8 %c, 57

--- a/tests/test_plawk_eval_compile.pl
+++ b/tests/test_plawk_eval_compile.pl
@@ -132,6 +132,27 @@ test(compile_file_edit_changes_behavior_no_rebuild,
     assertion(Out2 == "44\n"),                    % doubles: 6+8+10+20
     !.
 
+% Demand-driven subset growth: real Prolog idioms -- committed choice
+% (cut), bare backtrackable disjunction -- now compile AT RUNTIME.
+% cls2(3): guard fails, second clause, first branch (7); cls2(4):
+% first branch fails, BACKTRACKS to the second (1); cls2(5)/cls2(10):
+% guard passes, cut commits (100 each). 7+1+100+100 = 208.
+test(compile_runs_grammar_with_cut_and_disjunction,
+     [condition(clang_available)]) :-
+    ev_dir(Dir),
+    format(string(Src),
+        "{ total += dyncall_at(compile(\"[(cls(X2, R2) :- atom_number(X2, N2), cls2(N2, R2)), (cls2(N3, R3) :- N3 > 4, !, R3 = 100), (cls2(N4, R4) :- (N4 == 3, R4 = 7 ; R4 = 1))]\"), $1) }\n\c
+         END { print total }\n", []),
+    write_prog(Dir, 'cutdisj.plawk', Src),
+    directory_file_path(Dir, 'cutdisj.plawk', Prog),
+    directory_file_path(Dir, 'cutdisj_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'nums.txt', Input),
+    write_num_lines(Input, [3, 4, 5, 10]),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "208\n"),
+    !.
+
 % compile(...) with the cache disabled is a build error (exit 3), not a
 % silent miscompile: the grammar handle lives in the cache registry.
 test(compile_with_cache_off_fails_build, [condition(clang_available)]) :-

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -1615,6 +1615,93 @@ test(selfhost_intdiv_truncates, [condition(clang_available)]) :-
     assertion(Out == "3034\n"),
     !.
 
+% Demand-driven subset growth: plain CUT compiles from source and runs
+% loaded with committed-choice semantics. pick(7) commits to the first
+% clause (guard passed, cut fired -> 1); pick(3) fails the guard BEFORE
+% the cut and falls to the second clause (-> 2). R = 12.
+test(selfhost_cut_commits, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgcut_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- pick(7, A), pick(3, B), R is A * 10 + B), (pick(X, R2) :- X > 5, !, R2 = 1), pick(_, 2)]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "12\n"),
+    !.
+
+% BARE disjunction stays backtrackable: d(a) takes the first branch;
+% d(b) enters it, fails the ==, and BACKTRACKS into the second (the
+% try_me_else CP is live -- no soft cut). R = 12.
+test(selfhost_bare_disjunction_backtracks, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgdisj_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- d(a, A), d(b, B), R is A * 10 + B), (d(X, R2) :- (X == a, R2 = 1 ; R2 = 2))]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "12\n"),
+    !.
+
+% Negation as failure: \+ G desugars to ( G -> fail ; true ). good is
+% not bad (1); bad is (2). R = 12.
+test(selfhost_negation_as_failure, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgneg_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- n(good, A), n(bad, B), R is A * 10 + B), (n(X, R2) :- (\\+ X == bad -> R2 = 1 ; R2 = 2))]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "12\n"),
+    !.
+
+% Text-family whitelist: sub_atom slices, the slice compares, and its
+% length feeds arithmetic. sub_atom(hello, 1, 3, _, ell) -> 3 + 10.
+test(selfhost_sub_atom_slices, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgsub_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- sub_atom(hello, 1, 3, _, S), atom_length(S, L), (S == ell -> R is L + 10 ; R = 0))]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "13\n"),
+    !.
+
 % cgfullm: cgfull + a MULTI-ENTRY name table (the eval compiler the
 % plawk CLI ships). Byte-compat guard: a single-predicate source
 % serializes IDENTICALLY through both (NE=1, first predicate named,


### PR DESCRIPTION
## Method

Rather than guessing what the bootstrap compiler should learn next, this round **probed** it with the grammar shapes real `compile(...)` users write and landed exactly the failures. The probe found: cut, bare disjunction, negation, `sub_atom` + string-family builtins, `assertz`, and `findall` all threw `cg_unsupported_goal`; `between`, `atom_number`, pairs, arithmetic, and list builtins already worked.

## What landed

**Loaded reader (runtime IR)** — two gaps the probe exposed only when running loaded (SWI-side `cgfull_term` bypasses the reader):
- solo `!` token — byte 33 is neither a symbol-run nor an alnum char, so *any* grammar containing cut failed to parse;
- prefix `\+` (its one prefix operator, fy 900), with `@wam_build_unop` as the arity-1 counterpart of the binop builder.

**Bootstrap compiler** — all additive, so existing programs' bytes are unchanged and **every self-host golden stays byte-identical**:
- bare disjunction `( A ; B )`: the ITE shape *without* the soft cut — a failure after the first branch backtracks into the second (the `try_me_else` CP stays live);
- `\+ G` desugars to `( G -> fail ; true )` and rides the ITE machinery;
- whitelist grows by the control atoms (`!/0` — the runtime's clause-level cut builtin, `true/0`, `fail/0`) and the text family (`sub_atom/5`, `upcase/downcase_atom/2`, `string_concat/3`, `atom_string/2`, `split_string/4`, `term_to_atom/2`, `char_type/2`, `code_type/2`).

**Deliberately deferred, recorded in the architecture doc**: `findall` emission (aggregate opcodes are loadable; the bootstrap doesn't emit them) and `call/N` meta-call emission — which also gates the assert-family whitelist, since a grammar can't read the dynamic store back without it.

## Tests

Four loaded-run shapes through the eval host: cut commits/falls through (12), bare disjunction **backtracks** (12), negation (12), `sub_atom` slice (13). Plus the plawk payoff: a runtime-compiled grammar mixing cut and backtrackable disjunction over 3,4,5,10 → **208**.

`test_wam_object` **69/69** (all self-host goldens green with the reader changes), `test_plawk_eval_compile` 8/8.

## Handle-in-scalar assessment (the other asked-for item)

**Recommendation: worth doing, one small round.** The multi-entry family work created its real use case — today two named calls into one compiled source must *repeat the whole source text* at both sites. With it:

```awk
{ h = compile("[(sq(...)...), (dbl(...)...)]") ; total += dyncall_at@sq(h, $1) + dyncall_at@dbl(h, $1) }
```

The pieces (checked against the code): `compile(...)`/`compile_file(...)` as an i64 *expression* (a handle IS an i64; `@plawk_compile` already exists and dedups, so per-record re-assignment is a registry hit); a `handle_src(var(h))` source shape for `dyncall_at[@name]` marshaling as `(null, scalar)` — the `(null, handle)` convention the cache getter already speaks; and threading the scalar-read substitution into the source position. No runtime changes at all. Say the word and it's the next round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_