### PR TITLE
Add Rust WAM dynamic clause/2 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -673,6 +673,8 @@ wam_instruction_arm('Instruction::Call(p, _arity)', Body) :-
                     true
                 } else if p == "retract/1" {
                     self.dynamic_retract_call(self.pc + 1)
+                } else if p == "clause/2" {
+                    self.dynamic_clause_call(self.pc + 1)
                 } else if p == "assert/1" {
                     self.execute_assert_builtin("assert/1")
                 } else if p == "read_term/2" {
@@ -749,6 +751,8 @@ wam_instruction_arm('Instruction::Execute(p)', Body) :-
                     true
                 } else if p == "retract/1" {
                     self.dynamic_retract_call(self.cp)
+                } else if p == "clause/2" {
+                    self.dynamic_clause_call(self.cp)
                 } else if p == "assert/1" {
                     if self.execute_assert_builtin("assert/1") {
                         self.pc = self.cp;
@@ -3677,6 +3681,29 @@ compile_resume_builtin_to_rust(Code) :-
                 };
                 self.dynamic_retract_attempt(key, start_idx, pattern, cont_pc)
             }
+            "dynamic_clause" => {
+                let key = match state.args.get(0) {
+                    Some(Value::Atom(key)) => key.clone(),
+                    _ => return false,
+                };
+                let head = match state.args.get(1) {
+                    Some(head) => head.clone(),
+                    _ => return false,
+                };
+                let body = match state.args.get(2) {
+                    Some(body) => body.clone(),
+                    _ => return false,
+                };
+                let start_idx = match state.data.get(0) {
+                    Some(Value::Integer(n)) => *n as usize,
+                    _ => return false,
+                };
+                let cont_pc = match state.data.get(1) {
+                    Some(Value::Integer(n)) => *n as usize,
+                    _ => return false,
+                };
+                self.dynamic_clause_attempt(key, start_idx, head, body, cont_pc)
+            }
             "dynamic_rule_body" => {
                 let clause = match state.args.get(0) {
                     Some(clause) => clause.clone(),
@@ -4860,6 +4887,9 @@ compile_execute_meta_builtin_to_rust(Code) :-
         let saved_pc = self.pc;
         if key == "retract/1" {
             return self.dynamic_retract_call(saved_pc);
+        }
+        if key == "clause/2" {
+            return self.dynamic_clause_call(saved_pc);
         }
         if self.execute_builtin(key, arity) {
             self.pc = saved_pc;

--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -656,6 +656,84 @@
         self.dynamic_retract_attempt(key, 0, pattern, cont_pc)
     }
 
+    fn dynamic_clause_call(&mut self, cont_pc: usize) -> bool {
+        let head_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let head = self.deref_heap(&self.deref_var(&head_raw));
+        if matches!(head, Value::Unbound(_) | Value::Uninit) { return false; }
+        let key = match self.dynamic_head_key(&head) {
+            Some(key) => key,
+            None => return false,
+        };
+        let body_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+        let body = self.deref_heap(&self.deref_var(&body_raw));
+        self.dynamic_clause_attempt(key, 0, head, body, cont_pc)
+    }
+
+    fn dynamic_clause_attempt(
+        &mut self,
+        key: String,
+        start_idx: usize,
+        head_pattern: Value,
+        body_pattern: Value,
+        cont_pc: usize,
+    ) -> bool {
+        let clauses = match self.dynamic_db.get(&key) {
+            Some(clauses) => clauses.clone(),
+            None => return false,
+        };
+        for idx in start_idx..clauses.len() {
+            let cp_trail = self.trail.len();
+            let cp_heap = self.heap.len();
+            let cp_regs = self.save_regs();
+            let cp_stack = self.stack.clone();
+            let mut clause_vars = std::collections::HashMap::new();
+            let clause = Self::copy_term_walk(
+                &mut self.var_counter,
+                &mut clause_vars,
+                &clauses[idx],
+            );
+            let (head, body) = match self.dynamic_clause_head_body(&clause) {
+                Some((head, body)) => (
+                    head,
+                    body.unwrap_or_else(|| Value::Atom("true".to_string())),
+                ),
+                None => continue,
+            };
+            if self.unify(&head_pattern, &head) && self.unify(&body_pattern, &body) {
+                if idx + 1 < clauses.len() {
+                    self.choice_points.push(ChoicePoint {
+                        next_pc: cont_pc,
+                        saved_args: cp_regs,
+                        stack: cp_stack,
+                        cp: self.cp,
+                        trail_len: cp_trail,
+                        heap_len: cp_heap,
+                        builtin_state: Some(BuiltinState {
+                            name: "dynamic_clause".to_string(),
+                            args: vec![
+                                Value::Atom(key.clone()),
+                                head_pattern.clone(),
+                                body_pattern.clone(),
+                            ],
+                            data: vec![
+                                Value::Integer((idx + 1) as i64),
+                                Value::Integer(cont_pc as i64),
+                            ],
+                        }),
+                        cut_barrier: self.cut_barrier,
+                    });
+                }
+                self.pc = cont_pc;
+                return true;
+            }
+            self.unwind_trail_to(cp_trail);
+            self.heap.truncate(cp_heap);
+            self.restore_regs(&cp_regs);
+            self.stack = cp_stack;
+        }
+        false
+    }
+
     fn dynamic_retract_candidate(&self, pattern: &Value, clause: &Value) -> Option<Value> {
         let pattern_functor = match pattern {
             Value::Str(f, args) if (f == ":-" || f == ":-/2") && args.len() == 2 => Some(f),

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -207,6 +207,70 @@ fn retract_backtracks_through_each_matching_fact() {
 }
 
 #[test]
+fn clause_backtracks_over_facts_and_rules_without_removing_them() {
+    let mut vm = WamState::new(
+        vec![Instruction::Call("clause/2".to_string(), 2), Instruction::Proceed],
+        HashMap::new(),
+    );
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("red")]));
+    assert_clause(&mut vm, "assertz/1", fact("marker", vec![at("blue")]));
+    assert_clause(
+        &mut vm,
+        "assertz/1",
+        rule(
+            fact("dyn", vec![at("blue")]),
+            fact("marker", vec![at("blue")]),
+        ),
+    );
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("dyn", vec![ub("X")]));
+    vm.set_reg_str("A2", ub("Body"));
+    vm.pc = 1;
+
+    let mut clauses = Vec::new();
+    assert!(vm.run());
+    loop {
+        let x = vm.bindings.get("X").cloned().expect("X bound");
+        let body = vm.bindings.get("Body").cloned().expect("Body bound");
+        clauses.push((
+            vm.deref_heap(&vm.deref_var(&x)),
+            vm.deref_heap(&vm.deref_var(&body)),
+        ));
+        if !vm.backtrack() { break; }
+    }
+
+    assert_eq!(
+        clauses,
+        vec![
+            (at("red"), at("true")),
+            (at("blue"), fact("marker", vec![at("blue")]))
+        ],
+    );
+    assert_eq!(dyn_values(&mut vm), vec![at("red"), at("blue")]);
+}
+
+#[test]
+fn generated_tail_clause_call_reads_dynamic_facts() {
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code, labels);
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("tail")]));
+
+    vm.reset_query();
+    vm.set_reg_str("A1", ub("X"));
+    vm.set_reg_str("A2", ub("Body"));
+    vm.pc = *vm.labels
+        .get("rust_clause_demo/2")
+        .expect("generated clause demo label");
+
+    assert!(vm.run());
+    let x = vm.bindings.get("X").cloned().expect("X bound");
+    let body = vm.bindings.get("Body").cloned().expect("Body bound");
+    assert_eq!(vm.deref_heap(&vm.deref_var(&x)), at("tail"));
+    assert_eq!(vm.deref_heap(&vm.deref_var(&body)), at("true"));
+}
+
+#[test]
 fn retract_distinguishes_fact_patterns_from_rule_patterns() {
     let mut vm = WamState::new(vec![Instruction::Call("retract/1".to_string(), 1), Instruction::Proceed], HashMap::new());
     assert_clause(&mut vm, "assertz/1", fact("marker", vec![at("rule")]));

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -12,6 +12,10 @@ rust_dyn_dummy.
 :- dynamic rust_assert_alias_demo/0.
 rust_assert_alias_demo :- assert(dyn(alias)).
 
+:- dynamic rust_clause_demo/2.
+rust_clause_demo(X, Body) :-
+    clause(dyn(X), Body).
+
 :- dynamic rust_read_term_options_demo/2.
 rust_read_term_options_demo(Term, Names) :-
     read_term(Term, [variable_names(Names)]).
@@ -44,6 +48,7 @@ test(assert_retract_dynamic_db,
     once(write_wam_rust_project(
         [user:rust_dyn_dummy/0,
          user:rust_assert_alias_demo/0,
+         user:rust_clause_demo/2,
          user:rust_read_term_options_demo/2,
          user:rust_atom_to_term_demo/2,
          user:rust_syntax_error_demo/1],


### PR DESCRIPTION
## Summary

- add nondeterministic `clause/2` enumeration for Rust's dynamic database
- return `true` as the body of asserted facts
- preserve variable sharing when copying asserted rules
- support direct calls, tail-position execution, and callable dynamic rule bodies
- leave the dynamic database unchanged during enumeration
- avoid changes to the shared builtin registry

## Testing

- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `swipl -q -s tests/test_wam_rust_dynamic_builtins.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_rust_target.pl`