### PR TITLE
plawk eval: handle-in-scalar — name a compiled grammar once (WAM/LLVM)

### DIFF
--- a/docs/design/PLAWK_EVAL_ARCHITECTURE.md
+++ b/docs/design/PLAWK_EVAL_ARCHITECTURE.md
@@ -207,8 +207,14 @@ Deliberately deferred, in rough value order:
   `DYNENTRY parse, score` reserves the names and rewrites bare calls
   to the named-entry nodes (startup-cached PC); shadowing a userspace
   or builtin name is a parse error.
-- **Handle-in-scalar** — storing a compile handle in a plawk variable
-  across records (today the dedup makes the nested form equivalent).
+- ~~**Handle-in-scalar**~~ — LANDED: `compile(src)` / `compile_file(path)`
+  as i64 expressions (the value IS the registry handle), stored in an
+  ordinary scalar and used as a `dyncall_at[@name]` source
+  (`h = compile("[...]") ; total += dyncall_at@sq(h, $1)`). Names a
+  compiled family once instead of repeating the source per call site;
+  per-record re-assignment is a registry hit (content dedup). No
+  runtime changes — the handle travels as the (null, handle) pair the
+  cache getter already spoke.
 - **Further compiler-subset growth** — demand-driven. The first
   demand round probed common grammar shapes and landed the ones real
   eval grammars hit: **cut** (`!` — committed choice; the loaded

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -655,6 +655,7 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_dyncall_at_float_arities(Program, DynAtFArities),
     plawk_program_dyncall_blob_arities(Program, DynBArities),
     plawk_program_dyncall_at_blob_arities(Program, DynAtBArities),
+    plawk_program_compile_sites(Program, CompileSites),
     (   GuardSpecs == [],
         CallSpecs == [],
         FCallSpecs == [],
@@ -675,7 +676,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         DynFArities == [],
         DynAtFArities == [],
         DynBArities == [],
-        DynAtBArities == []
+        DynAtBArities == [],
+        CompileSites == []
     ->  plawk_program_native_driver_ir(Program, InputPath, DriverIR)
     ;   % Compiled-foreign support (shared VM + per-predicate wrappers)
         % only when the program actually calls a compiled predicate; it
@@ -706,9 +708,13 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
                 DynNamedAssocS, DynAssocSArities, DyncallSupportIR)
         ),
         % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...)) /
-        % blob(dyncall_at(...)) sites + the shared path cache.
+        % blob(dyncall_at(...)) sites + the shared path cache. A compile
+        % site with NO dyncall_at site (a handle expression --
+        % h = compile(...)) still needs the cache GLOBALS: @plawk_compile
+        % records the loaded grammar in the registry.
         (   DynAtArities == [], DynAtFArities == [], DynAtBArities == [],
-            DynAtNamed == [], DynAtNamedF == [], DynAtNamedB == []
+            DynAtNamed == [], DynAtNamedF == [], DynAtNamedB == [],
+            CompileSites == []
         ->  DyncallAtSupportIR = ''
         ;   plawk_program_dyncache_mode(Program, CacheMode),
             plawk_dyncall_at_support_ir(CacheMode, DynAtArities, DynAtFArities,
@@ -719,8 +725,7 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         % the bootstrap-compiler object path (BEGIN { EVALC = "..." }
         % or the CLI-provided evalc_path option). The handle lives in
         % the dyncall_at cache registry, so mode "off" cannot carry it.
-        (   plawk_program_compile_sites(Program, CompileSites),
-            CompileSites \== []
+        (   CompileSites \== []
         ->  plawk_program_dyncache_mode(Program, CMode),
             (   CMode == "off"
             ->  throw(error(plawk_compile_requires_cache,
@@ -2707,6 +2712,12 @@ plawk_dyncall_source_ir(compile_file_src(Arg), FieldSeparator, Base, GlobalBase,
     PathPtrIR = null,
     format(atom(PathLenIR), '%~w_h', [Base]),
     append(PSetup, [CallIR], SetupParts).
+% a handle read from a scalar (substituted to its slot SSA value by the
+% apply pass): (null path, handle id), no marshaling -- the handle IS
+% the i64. An unset or failed-compile handle is 0, which the registry
+% range check rejects, so the call contributes its failure value.
+plawk_dyncall_source_ir(handle_src(ssa(Value)), _FieldSeparator, _Base,
+        _GlobalBase, null, Value, [], []).
 
 %% plawk_blob_expr_ir(+Expr, +FieldSeparator, +Base, -LenIR, -PtrIR,
 %%     -GlobalParts, -SetupParts)
@@ -2859,12 +2870,16 @@ plawk_program_compile_sites(Program, Sites) :-
         ( ( member(rule(_Pattern, Actions), Rules)
           ; member(end(Actions), EndClauses)
           ),
-          ( plawk_actions_dyncall_at(Actions, CSrc, _)
-          ; plawk_actions_dyncall_at_named(Actions, _NName, CSrc, _)
-          ; plawk_actions_float_dyncall_at(Actions, CSrc, _)
-          ; plawk_actions_float_dyncall_at_named(Actions, _FName, CSrc, _)
-          ),
-          plawk_compile_source_node(CSrc, Arg)
+          ( ( plawk_actions_dyncall_at(Actions, CSrc, _)
+            ; plawk_actions_dyncall_at_named(Actions, _NName, CSrc, _)
+            ; plawk_actions_float_dyncall_at(Actions, CSrc, _)
+            ; plawk_actions_float_dyncall_at_named(Actions, _FName, CSrc, _)
+            ),
+            plawk_compile_source_node(CSrc, Arg)
+          ; % handle expressions (h = compile(...)) -- compile sites
+            % OUTSIDE any dyncall_at source position
+            plawk_actions_compile_handle(Actions, Arg)
+          )
         ;   % blob positions via the generic walk (print fields, writebin
             % slots, assoc keys, blob_eq patterns)
             ( plawk_program_blob_node(Program, blob_dyncall_at(CSrc, _))
@@ -2880,6 +2895,18 @@ plawk_program_compile_sites(Program, Sites) :-
 % compiler object and the @plawk_compile support IR)
 plawk_compile_source_node(compile_src(Arg), Arg).
 plawk_compile_source_node(compile_file_src(Arg), Arg).
+
+% handle-expression walker: h = compile(src) / compile_file(path) in
+% set positions (incl. if-branches) are compile sites too.
+plawk_actions_compile_handle(Actions, Arg) :-
+    member(Action, Actions),
+    plawk_action_compile_handle(Action, Arg).
+plawk_action_compile_handle(set(_Var, compile_handle(Arg)), Arg).
+plawk_action_compile_handle(set(_Var, compile_file_handle(Arg)), Arg).
+plawk_action_compile_handle(if(_Pattern, ThenActions, ElseActions), Arg) :-
+    ( plawk_actions_compile_handle(ThenActions, Arg)
+    ; plawk_actions_compile_handle(ElseActions, Arg)
+    ).
 
 plawk_actions_dyncall_at(Actions, Source, Args) :-
     member(Action, Actions),
@@ -7049,6 +7076,11 @@ plawk_dyncall_at_source_ok(compile_src(Arg)) :-
 plawk_dyncall_at_source_ok(compile_file_src(Arg)) :-
     !,
     plawk_foreign_arg(Arg).
+% a grammar handle read from a scalar (h = compile("..."); the handle
+% is an i64 registry index and travels as (null path, handle id))
+plawk_dyncall_at_source_ok(handle_src(var(Name))) :-
+    !,
+    atom(Name).
 plawk_dyncall_at_source_ok(Source) :-
     plawk_foreign_arg(Source).
 
@@ -7412,6 +7444,39 @@ plawk_substitute_scalar_reads(blob_slice_vars(A0, B0), Slots, Values,
     !,
     plawk_substitute_scalar_reads(A0, Slots, Values, A),
     plawk_substitute_scalar_reads(B0, Slots, Values, B).
+% dyncall_at sources may hold a scalar HANDLE read (handle_src(var(h)))
+% -- substitute it to the slot's SSA value so the source marshal sees a
+% concrete i64, like any other scalar read.
+plawk_substitute_scalar_reads(dyncall_at(Source0, Args), Slots, Values,
+        dyncall_at(Source, Args)) :-
+    !,
+    plawk_substitute_handle_source(Source0, Slots, Values, Source).
+plawk_substitute_scalar_reads(dyncall_at_named(Name, Source0, Args), Slots,
+        Values, dyncall_at_named(Name, Source, Args)) :-
+    !,
+    plawk_substitute_handle_source(Source0, Slots, Values, Source).
+plawk_substitute_scalar_reads(float_dyncall_at(Source0, Args), Slots, Values,
+        float_dyncall_at(Source, Args)) :-
+    !,
+    plawk_substitute_handle_source(Source0, Slots, Values, Source).
+plawk_substitute_scalar_reads(float_dyncall_at_named(Name, Source0, Args),
+        Slots, Values, float_dyncall_at_named(Name, Source, Args)) :-
+    !,
+    plawk_substitute_handle_source(Source0, Slots, Values, Source).
+plawk_substitute_scalar_reads(blob_dyncall_at(Source0, Args), Slots, Values,
+        blob_dyncall_at(Source, Args)) :-
+    !,
+    plawk_substitute_handle_source(Source0, Slots, Values, Source).
+plawk_substitute_scalar_reads(blob_dyncall_at_named(Name, Source0, Args),
+        Slots, Values, blob_dyncall_at_named(Name, Source, Args)) :-
+    !,
+    plawk_substitute_handle_source(Source0, Slots, Values, Source).
+
+plawk_substitute_handle_source(handle_src(var(Name)), Slots, Values,
+        handle_src(Substituted)) :-
+    !,
+    plawk_substitute_scalar_reads(var(Name), Slots, Values, Substituted).
+plawk_substitute_handle_source(Source, _Slots, _Values, Source).
 plawk_substitute_scalar_reads(Expr0, Slots, Values, Expr) :-
     plawk_i64_binary_expr(Expr0, _LLVMOp, _NamePart, Left0, Right0),
     !,
@@ -7565,6 +7630,14 @@ plawk_scalar_action_update(set(var(Name), dyncall_at(Source, Args)), Name,
 plawk_scalar_action_update(set(var(Name), dyncall_at_named(E, Source, Args)),
         Name, set(dyncall_at_named(E, Source, Args))) :-
     plawk_dyncall_at_expr(dyncall_at_named(E, Source, Args)).
+% h = compile(src) / compile_file(path): store the grammar handle in a
+% scalar (only set makes sense -- a handle is an opaque registry index).
+plawk_scalar_action_update(set(var(Name), compile_handle(Arg)), Name,
+        set(compile_handle(Arg))) :-
+    plawk_foreign_arg(Arg).
+plawk_scalar_action_update(set(var(Name), compile_file_handle(Arg)), Name,
+        set(compile_file_handle(Arg))) :-
+    plawk_foreign_arg(Arg).
 % Double-typed update expressions: float literals, float($N), and
 % binary trees mixing them with i64 operands or scalar reads. The
 % written slot becomes a double via plawk_scalar_typed_slots/3.
@@ -7932,6 +8005,18 @@ plawk_scalar_numeric_expr_ir(dyncall_at_named(Name, Source, Args),
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(dyncall_at_named(Name, Source, Args),
         FieldSeparator, DynAtBase, DynAtBase, ValueIR, GlobalIR, IR).
+plawk_scalar_numeric_expr_ir(compile_handle(Arg), FieldSeparator, Prefix,
+        SlotIndex, OpIndex, ValueIR, GlobalIR, IR) :-
+    format(atom(CHBase), '~w_slot_~w_op_~w_compile_h',
+        [Prefix, SlotIndex, OpIndex]),
+    plawk_i64_expr_ir_parts(compile_handle(Arg), FieldSeparator, CHBase,
+        CHBase, ValueIR, GlobalIR, IR).
+plawk_scalar_numeric_expr_ir(compile_file_handle(Arg), FieldSeparator, Prefix,
+        SlotIndex, OpIndex, ValueIR, GlobalIR, IR) :-
+    format(atom(CFBase), '~w_slot_~w_op_~w_compile_fh',
+        [Prefix, SlotIndex, OpIndex]),
+    plawk_i64_expr_ir_parts(compile_file_handle(Arg), FieldSeparator, CFBase,
+        CFBase, ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(const(Value), _FieldSeparator, _Prefix, _SlotIndex,
         _OpIndex, ValueIR, GlobalIR, IR) :-
     plawk_i64_expr_ir_parts(const(Value), 0, scalar_const, scalar_const_global,
@@ -8059,6 +8144,17 @@ plawk_i64_expr_ir(dyncall_at(Source, Args), FieldSeparator, Base, GlobalBase,
     append(SrcGlobals, ArgGlobals, GlobalParts),
     append(SrcSetup, ArgSetup, PreSetup),
     append(PreSetup, [ResIR, ValIR, OkIR, SelIR], SetupParts).
+% compile(src) / compile_file(path) as i64 expressions: the value IS
+% the handle -- reuse the source marshal, whose (null, handle) pair's
+% second half is exactly the handle SSA value.
+plawk_i64_expr_ir(compile_handle(Arg), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    plawk_dyncall_source_ir(compile_src(Arg), FieldSeparator, Base,
+        GlobalBase, _NullPtr, ValueIR, GlobalParts, SetupParts).
+plawk_i64_expr_ir(compile_file_handle(Arg), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    plawk_dyncall_source_ir(compile_file_src(Arg), FieldSeparator, Base,
+        GlobalBase, _NullPtr, ValueIR, GlobalParts, SetupParts).
 plawk_i64_expr_ir(dyncall_at_named(Name, Source, Args), FieldSeparator, Base,
         GlobalBase, ValueIR, GlobalParts, SetupParts) :-
     length(Args, NArgs),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -617,6 +617,17 @@ dyncall_at_source(compile_src(Arg)) -->
     ws,
     ")",
     !.
+% a bare identifier: a grammar HANDLE stored in a scalar --
+%
+%     { h = compile("[(sq(...)...)]") ; total += dyncall_at@sq(h, $1) }
+%
+% names the compiled source once instead of repeating it per call
+% site. The handle IS an i64 (a registry index), so it rides the
+% scalar machinery; the source marshals as (null path, handle id), the
+% registry discriminator @plawk_dyncall_at_get already speaks.
+dyncall_at_source(handle_src(var(Name))) -->
+    identifier(Name),
+    !.
 dyncall_at_source(Source) -->
     foreign_arg(Source).
 
@@ -1611,6 +1622,30 @@ i64_factor_expr(var(Name)) -->
 % materialized entry table (@wam_object_vm_entry_pc) rather than a
 % startup-cached PC. Parsed before the bare dyncall_at so the @ form
 % wins.
+% compile(src) / compile_file(path) as EXPRESSIONS: yield the grammar
+% HANDLE (an i64 registry index; 0 on failure) for storing in a scalar.
+% Content dedup makes a per-record re-assignment a registry hit, so
+% `h = compile("...")` in a rule body costs one compile per distinct
+% source. Reserved like dyncall; `compilex(...)` still parses as an
+% ordinary identifier call.
+prolog_call_expr(compile_file_handle(Arg)) -->
+    "compile_file",
+    ws,
+    "(",
+    ws,
+    foreign_arg(Arg),
+    ws,
+    ")",
+    !.
+prolog_call_expr(compile_handle(Arg)) -->
+    "compile",
+    ws,
+    "(",
+    ws,
+    foreign_arg(Arg),
+    ws,
+    ")",
+    !.
 prolog_call_expr(dyncall_at_named(Name, Source, Args)) -->
     "dyncall_at@",
     identifier(Name),

--- a/tests/test_plawk_handle_scalar.pl
+++ b/tests/test_plawk_handle_scalar.pl
@@ -1,0 +1,140 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Handle-in-scalar: compile(src) / compile_file(path) as EXPRESSIONS
+% whose value is the grammar HANDLE (an i64 registry index), stored in
+% an ordinary scalar and used as a dyncall_at source:
+%
+%     { h = compile("[...]") ; total += dyncall_at@sq(h, $1) }
+%
+% Names the compiled source once instead of repeating it per call site.
+% Content dedup makes the per-record re-assignment a registry hit, and
+% the handle travels as (null path, handle id) -- the discriminator the
+% cache getter already speaks. No runtime changes; parser + codegen only.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_handle_scalar).
+
+% compile(...) in a set position parses to the handle expression;
+% a bare identifier in dyncall_at source position parses as a handle
+% read. compile_file takes the same expression form.
+test(handle_expressions_parse) :-
+    plawk_parse_string(
+        "{ h = compile(\"[(sq(X, R) :- R is X)]\") ; g = compile_file($2) ; t += dyncall_at@sq(h, $1) + dyncall_at(g, $1) }\nEND { print t }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(set(var(h), compile_handle(string(_))), Actions),
+    memberchk(set(var(g), compile_file_handle(field(2))), Actions),
+    memberchk(add(var(t), add_i64(
+        dyncall_at_named(sq, handle_src(var(h)), [field(1)]),
+        dyncall_at(handle_src(var(g)), [field(1)]))), Actions),
+    !.
+
+% THE POINT: one compile() of a two-grammar source, named ONCE, called
+% by name at two sites through the scalar. Squares 150 + doubles 44
+% over 3,4,5,10 -> 194 -- the family payoff without repeating the
+% source text.
+test(handle_names_family_once, [condition(clang_available)]) :-
+    hs_dir(Dir),
+    format(string(Src),
+        "{ h = compile(\"[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2), (dbl(X3, R3) :- atom_number(X3, N3), R3 is N3 * 2)]\") ; total += dyncall_at@sq(h, $1) + dyncall_at@dbl(h, $1) }\n\c
+         END { print total }\n", []),
+    build_run(Dir, 'fam', Src, "3\n4\n5\n10\n", Out),
+    assertion(Out == "194\n"),
+    !.
+
+% The bare (default-entry) form works through a handle too: squares
+% over 3,4,5,10 -> 150.
+test(handle_default_entry, [condition(clang_available)]) :-
+    hs_dir(Dir),
+    format(string(Src),
+        "{ h = compile(\"[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2)]\") ; total += dyncall_at(h, $1) }\n\c
+         END { print total }\n", []),
+    build_run(Dir, 'def', Src, "3\n4\n5\n10\n", Out),
+    assertion(Out == "150\n"),
+    !.
+
+% compile_file through a scalar keeps the edit-no-rebuild property: the
+% per-record re-assignment re-reads the file, and content dedup makes
+% an edited file a fresh compile (150 squares -> 44 doubles, same
+% binary).
+test(handle_compile_file_edit_no_rebuild, [condition(clang_available)]) :-
+    hs_dir(Dir),
+    directory_file_path(Dir, 'gram.pl', GramPath),
+    write_text(GramPath,
+        '[(sq(X2, R2) :- atom_number(X2, N2), R2 is N2 * N2)]'),
+    format(string(Src),
+        "{ h = compile_file(\"~w\") ; total += dyncall_at(h, $1) }\n\c
+         END { print total }\n", [GramPath]),
+    directory_file_path(Dir, 'cf.plawk', Prog),
+    write_text(Prog, Src),
+    directory_file_path(Dir, 'cf_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'nums.txt', Input),
+    write_text(Input, "3\n4\n5\n10\n"),
+    run_bin(Bin, [Input], Out1, 0),
+    assertion(Out1 == "150\n"),
+    write_text(GramPath,
+        '[(dbl(X3, R3) :- atom_number(X3, N3), R3 is N3 * 2)]'),
+    run_bin(Bin, [Input], Out2, 0),
+    assertion(Out2 == "44\n"),
+    !.
+
+% A handle expression with the cache off is a build error (exit 3) --
+% the handle lives in the cache registry.
+test(handle_with_cache_off_fails_build, [condition(clang_available)]) :-
+    hs_dir(Dir),
+    directory_file_path(Dir, 'off.plawk', Prog),
+    write_text(Prog,
+        "BEGIN { DYNCACHE = \"off\" }\n{ h = compile(\"[(sq(X, R) :- R is X)]\") ; t += dyncall_at(h, $1) }\nEND { print t }\n"),
+    cli([build, Prog, '-o', '/dev/null'], _, 3),
+    !.
+
+:- end_tests(plawk_handle_scalar).
+
+% --- helpers ---------------------------------------------------------------
+
+hs_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_handle_scalar', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_text(Path, Text) :-
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]),
+        write(S, Text), close(S)).
+
+build_run(Dir, Name, Src, InputText, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    write_text(Prog, Src),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog0, '_in.txt', Input),
+    write_text(Input, InputText),
+    run_bin(Bin, [Input], Out, 0).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## What

The last open item from the architecture doc's backlog. `compile(src)` / `compile_file(path)` become i64 **expressions** whose value is the grammar handle (a registry index; 0 on failure), storable in an ordinary scalar and usable as a `dyncall_at[@name]` source:

```awk
{ h = compile("[(sq(...)...), (dbl(...)...)]")
; total += dyncall_at@sq(h, $1) + dyncall_at@dbl(h, $1) }
```

A compiled family is named **once** instead of repeating the source text at every call site — the ergonomic gap the multi-entry work exposed. Content dedup makes the per-record re-assignment a registry hit, and `compile_file` through a scalar keeps the edit-no-rebuild property.

## How — no runtime changes

- **Parser**: `compile`/`compile_file` as reserved call expressions, and a bare identifier in `dyncall_at` source position as `handle_src(var(h))`. Both were parse errors before, so both are non-breaking.
- **Emission reuses the source marshal**: the existing `compile_src` marshal's `(null, handle)` output pair's second half *is* the handle SSA value — the expression emitter just takes it. `handle_src` marshals as `(null, slot-value)`, the registry discriminator `@plawk_dyncall_at_get` already speaks, uniformly across all at-shim kinds (i64/float/blob, bare and `@named`).
- **Scalar-read substitution** learns to reach into `dyncall_at` sources (all six node kinds), turning `handle_src(var(h))` into the slot's SSA value.
- **One real invariant fix**: a handle expression is the first legal compile site *outside* a `dyncall_at` source — previously every compile site lived inside one, which guaranteed the dyncache globals co-emitted. The driver now emits them whenever compile sites exist.

## Tests

`tests/test_plawk_handle_scalar.pl` (5/5): both expression parses + the handle-source node; the family named once → **194**; the default-entry form → 150; `compile_file` edit-no-rebuild through a scalar (150 → 44, same binary); cache-off build error (exit 3).

Regressions green: eval-compile 8, dyncall_at 5 + named 9, dyncall 5 + named 6, scalar-expr suites 16+22, assoc 12, dynentry 5, rule-body for-in 3, CLI 5.

With this merged, the architecture doc's "what remains open" list is empty except demand-driven compiler-subset growth, whose next recorded demands are `findall` and `call/N` emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_