### PR TITLE
WAM/LLVM eval: findall + call/N emission, assert family, and runtime finding no. 14

### DIFF
--- a/docs/design/PLAWK_EVAL_ARCHITECTURE.md
+++ b/docs/design/PLAWK_EVAL_ARCHITECTURE.md
@@ -224,8 +224,17 @@ Deliberately deferred, in rough value order:
   the reader gained its one prefix operator), and the text-family
   builtin whitelist (`sub_atom`, case mapping, `string_concat`,
   `atom_string`, `split_string`, `term_to_atom`, `char_type`,
-  `code_type`). Known next demands, deliberately deferred: `findall`
-  emission (aggregate opcodes are loadable; the bootstrap does not
-  emit them yet) and `call/N` meta-call emission — which also gates
-  the assert-family whitelist, since a grammar cannot read the
-  dynamic store back without it.
+  `code_type`). The second round landed the recorded next demands:
+  **`call/N`** (goal staged into A1 with the meta sentinel; the
+  serializer emits the meta-call table — pay-for-what-you-use, so
+  call-free programs stay byte-identical), **`findall/3`** with a
+  variable template (the host's `begin_aggregate(collect)` bracket),
+  and the **assert family** (`assertz`/`asserta`/`retractall`) —
+  readable back through `call/1`'s dynamic-store fallback, so a
+  runtime-compiled grammar can keep CROSS-RECORD STATE. Landing the
+  empty-findall case surfaced campaign finding **no. 14**: the
+  aggregate frame never saved/restored `stack_size` (an allocating
+  inner goal that failed left an orphaned environment frame), and
+  finalize restored only 512 of the 2048 saved register bytes.
+  Remaining recorded demands: nondet `retract/1` emission (call
+  sentinel −3) and compound `findall` templates.

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -545,7 +545,7 @@ own PR(s).
   milliseconds, once per distinct source (the compile() surface dedups),
   so the remaining mildly-superlinear tail is not worth further
   restatement.
-  The campaign keeps surfacing and fixing latent runtime bugs — **thirteen found
+  The campaign keeps surfacing and fixing latent runtime bugs — **fourteen found
   so far**: a 64-register-file ceiling corrupting memory for large clauses;
   `get_structure` not comparing the functor; the choice-point saved-register
   block not widened with the register file (failed clause bodies leaked Y17+
@@ -578,7 +578,14 @@ own PR(s).
   shares its first byte with `/` and ran as float division — the `/`
   branch now checks the second byte and routes `//` to a truncating
   `sdiv` (SWI's default), with float operands and division by zero
-  failing through the same error flag. See
+  failing through the same error flag. Finding **no. 14** came from the
+  subset-growth campaign's empty-findall case: the AGGREGATE frame
+  never saved/restored `stack_size` — an inner goal that allocated an
+  environment and then failed left its frame orphaned, so the caller's
+  later `deallocate` popped the orphan (masked whenever every inner
+  clause was allocate-free) — and `wam_finalize_aggregate` restored
+  only 512 of the 2048 register bytes `begin_aggregate` saves (the
+  finding-no.-3 narrow-block class again). See
   [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md).
 
 ## The binary-return question, specifically

--- a/src/unifyweaver/targets/wam_bootstrap_compiler.pl
+++ b/src/unifyweaver/targets/wam_bootstrap_compiler.pl
@@ -416,11 +416,43 @@ cgfull(Src, Wamo) :-
 % output stays BYTE-IDENTICAL (the single-entry header, first predicate
 % named) -- it is the oracle every self-host golden compares against.
 cgfull_term(Clauses, Wamo) :-
-    cgfull_core(Clauses, _Groups, Atoms, Functors, PCs, AllIs),
+    cgfull_core(Clauses, Groups, Atoms0, Functors, PCs, AllIs),
+    cg_meta_rows(AllIs, Groups, Atoms0, Functors, Atoms, MetaRows),
     Clauses = [First|_], clause_hb(First, H0, _), functor(H0, P0, A0),
     pred_name_codes(P0, A0, EntryName),
-    wza_serialize(0, EntryName, 0, Atoms, Functors, PCs, AllIs, Codes),
+    wza_serialize_m(0, EntryName, 0, Atoms, Functors, PCs, AllIs,
+        MetaRows, Codes),
     atom_codes(Wamo, Codes).
+
+% The meta-call table (pay-for-what-you-use, mirroring the host writer):
+% emitted only when the instruction stream contains a meta-call
+% (op1 = -1 on a call), so call-free programs serialize byte-identically
+% to before -- every self-host golden is call-free. One row per
+% predicate group: <atomIdx> <funIdx> <arity> <labelIdx>. The predicate
+% name joins the ATOM table (appended, so existing reloc indices are
+% unchanged); funIdx points at the name's functor-table row when the
+% object builds such a compound (call(k(V)) collected k into the table
+% already), else -1.
+cg_meta_rows(AllIs, Groups, Atoms0, Functors, Atoms, Rows) :-
+    ( memberchk(enc(18, -1, _, _), AllIs)
+    -> cg_meta_names(Groups, 0, Names),
+       cg_meta_atoms(Names, Atoms0, Atoms),
+       cg_meta_rows_list(Names, Atoms, Functors, Rows)
+    ;  Atoms = Atoms0, Rows = []
+    ).
+cg_meta_names([], _, []).
+cg_meta_names([pred(P, A, _)|Gs], I, [mp(P, A, I)|R]) :-
+    I1 is I + 1, cg_meta_names(Gs, I1, R).
+cg_meta_atoms([], At, At).
+cg_meta_atoms([mp(P, _, _)|Ms], At0, At) :-
+    add_unique(P, At0, At1), cg_meta_atoms(Ms, At1, At).
+cg_meta_rows_list([], _, _, []).
+cg_meta_rows_list([mp(P, A, I)|Ms], At, FT, [mr(AI, FI, A, I)|R]) :-
+    cg_idx_of(P, At, AI),
+    ( cg_idx_of(P, FT, FI0) -> FI = FI0 ; FI = -1 ),
+    cg_meta_rows_list(Ms, At, FT, R).
+cg_idx_of(X, [Y|Ys], I) :-
+    ( X == Y -> I = 0 ; cg_idx_of(X, Ys, I1), I is I1 + 1 ).
 
 % the shared front+middle: grouping, labels, tables, per-group codegen,
 % and the closed PC table -- everything up to the header choice.
@@ -445,9 +477,11 @@ cgfullm(Src, Wamo) :-
     read_term_from_atom(Src, Clauses),
     cgfullm_term(Clauses, Wamo).
 cgfullm_term(Clauses, Wamo) :-
-    cgfull_core(Clauses, Groups, Atoms, Functors, PCs, AllIs),
+    cgfull_core(Clauses, Groups, Atoms0, Functors, PCs, AllIs),
+    cg_meta_rows(AllIs, Groups, Atoms0, Functors, Atoms, MetaRows),
     group_entries(Groups, 0, Entries),
-    wzam_serialize(0, Entries, Atoms, Functors, PCs, AllIs, Codes),
+    wzam_serialize_m(0, Entries, Atoms, Functors, PCs, AllIs, MetaRows,
+        Codes),
     atom_codes(Wamo, Codes).
 
 group_entries([], _, []).
@@ -674,6 +708,45 @@ f_goal(( A ; B ), PL, At, FT, PC0, PC, L0, L, Prs0, Prs, In0, In, Is) :- !,
 f_goal((\+ G), PL, At, FT, PC0, PC, L0, L, Prs0, Prs, In0, In, Is) :- !,
     f_goal(( G -> fail ; true ), PL, At, FT, PC0, PC, L0, L, Prs0, Prs,
         In0, In, Is).
+% call/N meta-call (demand-driven subset growth): stage the goal term
+% into A1 and the extra args into A2.., then call with the meta
+% sentinel (op1 = -1, op2 = total arity). Dispatch resolves the runtime
+% goal through the object's meta-call table (emitted by the serializer
+% when any meta-call is present -- see cg_meta_rows) with the dynamic
+% clause store as fallback, so call/1 also reaches assertz'd facts.
+f_goal(Goal, _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-
+    functor(Goal, call, A), A >= 1, !,
+    call_args(Goal, 1, A, At, FT, In0, In, SetupIs),
+    append(SetupIs, [enc(18, -1, A, 0)], Is),
+    length(Is, N), PC is PC0 + N.
+% findall(Template, Goal, List) with a VARIABLE template and result
+% (the dominant shape; compound templates stay outside the subset and
+% throw). Emits the host's aggregate bracket: initialize the template
+% and result registers if fresh, begin_aggregate(collect,
+% valreg<<16|resreg), the goal inline, end_aggregate(valreg) -- the
+% runtime collects one frozen copy per solution and binds the list on
+% finalize (begin scans forward for its matching end, so no label is
+% needed). Register inits made INSIDE the goal are discarded from the
+% out-set: backtracking rewinds them per solution.
+f_goal(findall('$VAR'(TN), G, '$VAR'(LN)), PL, At, FT, PC0, PC, L0, L,
+        Prs0, Prs, In0, In, Is) :-
+    integer(TN), integer(LN), !,
+    TY is 48 + TN,
+    LY is 48 + LN,
+    ( memberchk(TN, In0) -> TInit = [], In1 = In0
+    ; TInit = [enc(9, TY, TY, 0)], In1 = [TN | In0] ),
+    ( memberchk(LN, In1) -> LInit = [], In2 = In1
+    ; LInit = [enc(9, LY, LY, 0)], In2 = [LN | In1] ),
+    append(TInit, LInit, Inits),
+    length(Inits, NI),
+    GoalPC is PC0 + NI + 1,
+    conj_list(G, Gs),
+    f_goals(Gs, PL, At, FT, GoalPC, PCg, L0, L, Prs0, Prs, In2, _InG, GIs),
+    PC is PCg + 1,
+    Op2 is (TY << 16) \/ LY,
+    append(Inits, [enc(28, 4, Op2, 0) | GIs], Front),
+    append(Front, [enc(29, TY, 0, 0)], Is),
+    In = In2.
 f_goal((L is E), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In2, Is) :- !,
     % NESTED arithmetic: the expression is just a term -- stage it with
     % c_operand (build_struct + X-temp deferral handles arbitrary nesting,
@@ -770,6 +843,12 @@ bi_id(numbervars, 3, 124).
 bi_id(!, 0, 10).
 bi_id(true, 0, 8).
 bi_id(fail, 0, 9).
+% assert family -- readable now that call/N emission lands (call/1
+% reaches assertz'd facts through the dynamic-store fallback of the
+% meta-call dispatch). Nondet retract/1 (call sentinel -3) stays out.
+bi_id(assertz, 1, 175).
+bi_id(asserta, 1, 176).
+bi_id(retractall, 1, 177).
 bi_id(sub_atom, 5, 41).
 bi_id(upcase_atom, 2, 45).
 bi_id(downcase_atom, 2, 46).
@@ -860,22 +939,40 @@ defer_builds([d(C,Reg)|Ds], At, FT, Xt0, Xt, In0, In, Is) :-
 % serializer with an atom table: NA + NA length-prefixed atom name strings
 % between the label index and the functor table
 wza_serialize(EI, NC, LI, Atoms, Fs, PCs, Is, Out) :-
+    wza_serialize_m(EI, NC, LI, Atoms, Fs, PCs, Is, [], Out).
+
+% +MetaRows variant: the trailing section carries the meta-call rows
+% (count, then <atomIdx> <funIdx> <arity> <labelIdx> per row). An empty
+% list emits the count 0 -- exactly the old trailing byte, so call-free
+% programs are byte-identical.
+wza_serialize_m(EI, NC, LI, Atoms, Fs, PCs, Is, MetaRows, Out) :-
     wz_a('WAMO', Out, A1), wz_i(2, A1, A2), wz_i(EI, A2, A3), wz_i(1, A3, A4),
     wz_n(NC, A4, A5), wz_i(LI, A5, A6),
     length(Atoms, NA), wz_i(NA, A6, A7), wz_funcs(Atoms, A7, A8),
     length(Fs, NF), wz_i(NF, A8, A9), wz_funcs(Fs, A9, A10),
-    wz_pcs_sec(PCs, A10, A11), wz_instr_sec(Is, A11, A12), wz_i(0, A12, []).
+    wz_pcs_sec(PCs, A10, A11), wz_instr_sec(Is, A11, A12),
+    wz_meta_sec(MetaRows, A12, []).
 
 % multi-entry variant: NE from the Entries list (NameCodes-LabelIdx
 % pairs), one name/label row per entry. With a single entry the emitted
 % bytes equal wza_serialize's -- the header shape is the same, only the
 % count and rows generalize.
 wzam_serialize(EI, Entries, Atoms, Fs, PCs, Is, Out) :-
+    wzam_serialize_m(EI, Entries, Atoms, Fs, PCs, Is, [], Out).
+wzam_serialize_m(EI, Entries, Atoms, Fs, PCs, Is, MetaRows, Out) :-
     wz_a('WAMO', Out, A1), wz_i(2, A1, A2), wz_i(EI, A2, A3),
     length(Entries, NE), wz_i(NE, A3, A4), wz_entry_rows(Entries, A4, A5),
     length(Atoms, NA), wz_i(NA, A5, A6), wz_funcs(Atoms, A6, A7),
     length(Fs, NF), wz_i(NF, A7, A8), wz_funcs(Fs, A8, A9),
-    wz_pcs_sec(PCs, A9, A10), wz_instr_sec(Is, A10, A11), wz_i(0, A11, []).
+    wz_pcs_sec(PCs, A9, A10), wz_instr_sec(Is, A10, A11),
+    wz_meta_sec(MetaRows, A11, []).
 wz_entry_rows([], A, A).
 wz_entry_rows([NC-LI|Es], A0, A3) :-
     wz_n(NC, A0, A1), wz_i(LI, A1, A2), wz_entry_rows(Es, A2, A3).
+
+wz_meta_sec(Rows, A0, A2) :-
+    length(Rows, NM), wz_i(NM, A0, A1), wz_meta_rows(Rows, A1, A2).
+wz_meta_rows([], A, A).
+wz_meta_rows([mr(AI, FI, Ar, LI)|Rs], A0, A5) :-
+    wz_i(AI, A0, A1), wz_i(FI, A1, A2), wz_i(Ar, A2, A3), wz_i(LI, A3, A4),
+    wz_meta_rows(Rs, A4, A5).

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4060,6 +4060,18 @@ ba.setup:
   %ba.sht_ptr = getelementptr %ChoicePoint, %ChoicePoint* %ba.cp_slot, i32 0, i32 11
   store i32 %ba.hs, i32* %ba.sht_ptr
 
+  ; Save stack_size (campaign finding no. 14): an inner goal that
+  ; ALLOCATES an environment and then fails leaves its frame orphaned --
+  ; ordinary CPs save/restore stack_size (try_me_else / backtrack), but
+  ; the aggregate frame did not, so the caller''s later deallocate popped
+  ; the orphan instead of its own frame. Masked when every inner clause
+  ; is allocate-free (simple fact bodies); fatal for any rule-bodied
+  ; inner goal that fails -- the empty-findall case.
+  %ba.sss_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 3
+  %ba.sss = load i32, i32* %ba.sss_ptr
+  %ba.csss_ptr = getelementptr %ChoicePoint, %ChoicePoint* %ba.cp_slot, i32 0, i32 13
+  store i32 %ba.sss, i32* %ba.csss_ptr
+
   ; Increment choice point count
   %ba.new_cpn = add i32 %ba.cpn, 1
   store i32 %ba.new_cpn, i32* %ba.cpn_ptr

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -4641,12 +4641,24 @@ do_finalize:
   %tm = load i32, i32* %tm_ptr
   call void @unwind_trail(%WamState* %vm, i32 %tm)
 
-  ; Restore registers from CP
+  ; Restore registers from CP -- the FULL register file (campaign
+  ; finding no. 14, second half): begin_aggregate saves 2048 bytes (128
+  ; registers) but this restore copied only 512, leaving X17..X32 and
+  ; every Y register holding whatever the failed goal wrote -- the same
+  ; narrow-saved-block class as campaign finding no. 3.
   %dst_regs = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
   %src_regs = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 1, i32 0
   %dst_raw = bitcast %Value* %dst_regs to i8*
   %src_raw = bitcast %Value* %src_regs to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dst_raw, i8* %src_raw, i64 512, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dst_raw, i8* %src_raw, i64 2048, i1 false)
+
+  ; Restore stack_size (finding no. 14): pop any environment frames the
+  ; failed inner goal left allocated, exactly as ordinary backtrack does
+  ; from try_me_else CPs.
+  %fin_sss_ptr = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 13
+  %fin_sss = load i32, i32* %fin_sss_ptr
+  %vm_sss_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 3
+  store i32 %fin_sss, i32* %vm_sss_ptr
 
   ; M9: bind via wam_bind_reg so the result propagates through Refs
   ; — when the caller's L is an unbound var (Ref to a heap cell), the

--- a/tests/test_plawk_eval_compile.pl
+++ b/tests/test_plawk_eval_compile.pl
@@ -153,6 +153,25 @@ test(compile_runs_grammar_with_cut_and_disjunction,
     assertion(Out == "208\n"),
     !.
 
+% CROSS-RECORD STATE in a runtime-compiled grammar: each record asserts
+% its value into the process-global clause store, then findall over
+% call/1 (the store consult) reads the whole history back -- a running
+% sum computed inside the grammar. 3, 4, 5 -> 3 + 7 + 12 = 22.
+test(compile_runs_stateful_grammar, [condition(clang_available)]) :-
+    ev_dir(Dir),
+    format(string(Src),
+        "{ total += dyncall_at(compile(\"[(cnt(X2, R2) :- atom_number(X2, N2), assertz(v(N2)), G = v(Q), findall(Q, call(G), L), sum_list(L, R2))]\"), $1) }\n\c
+         END { print total }\n", []),
+    write_prog(Dir, 'stateful.plawk', Src),
+    directory_file_path(Dir, 'stateful.plawk', Prog),
+    directory_file_path(Dir, 'stateful_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'nums3.txt', Input),
+    write_num_lines(Input, [3, 4, 5]),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "22\n"),
+    !.
+
 % compile(...) with the cache disabled is a build error (exit 3), not a
 % silent miscompile: the grammar handle lives in the cache registry.
 test(compile_with_cache_off_fails_build, [condition(clang_available)]) :-

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -1702,6 +1702,99 @@ test(selfhost_sub_atom_slices, [condition(clang_available)]) :-
     assertion(Out == "13\n"),
     !.
 
+% call/N meta-call emission: the goal stages into A1 (extras A2..) with
+% the meta sentinel (op1 = -1), and the serializer emits the meta-call
+% table so dispatch resolves the object's OWN predicates -- a compound
+% goal built at runtime (add1(5) -> 6) and an atom goal with an extra
+% arg (seven -> 7). R = 67.
+test(selfhost_call_n_meta, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgcall_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- G = add1(5), call(G, V), call(seven, W), R is V * 10 + W), (add1(X, Y) :- Y is X + 1), seven(7)]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "67\n"),
+    !.
+
+% The assert family reads back through call/1's dynamic-store fallback:
+% k/1 is not in the object's meta table, so dispatch consults the
+% process-global clause store. The COMPLETE-goal form is the supported
+% idiom (the store iterator reads the goal from reg0; a call/N closure
+% with extra args fails cleanly there by design -- see the dispatcher's
+% atom_consult note). assertz(k(41)), G = k(V), call(G) -> 42.
+test(selfhost_assertz_call_readback, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgaz_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- assertz(k(41)), G = k(V), call(G), R is V + 1)]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "42\n"),
+    !.
+
+% findall emission: begin_aggregate(collect) / goal / end_aggregate
+% compile from source and collect over a fact table. Sum 6, length 3
+% -> 63.
+test(selfhost_findall_collects, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgfa_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- findall(X, m(X), L), sum_list(L, S), length(L, N2), R is S * 10 + N2), m(1), m(2), m(3)]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "63\n"),
+    !.
+
+% Zero solutions is begin_aggregate's edge case (the continuation PC is
+% computed by the forward scan at begin time, since end_aggregate never
+% runs): an empty findall binds [] and execution continues. -> 100.
+test(selfhost_findall_empty, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgfe_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- findall(X, m(X), L), length(L, N2), (L == [] -> R is N2 + 100 ; R = 0)), (m(1) :- fail)]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "100\n"),
+    !.
+
 % cgfullm: cgfull + a MULTI-ENTRY name table (the eval compiler the
 % plawk CLI ships). Byte-compat guard: a single-predicate source
 % serializes IDENTICALLY through both (NE=1, first predicate named,


### PR DESCRIPTION
One PR, two commits: a runtime bug fix the work surfaced, then the emission round. (Both demands from the first subset round land together — they were interlocked, since the assert family is only *readable* through `call/N`.)

## Commit 1 — runtime: aggregate frames save/restore `stack_size` (campaign finding no. 14)

Surfaced by the **empty-findall** case. Two halves:
- `begin_aggregate` never saved `stack_size` and `wam_finalize_aggregate` never restored it — ordinary CPs do both. An inner goal that **allocates an environment and then fails** leaves its frame orphaned, and the caller's later `deallocate` pops the orphan. Masked whenever every inner clause is allocate-free (simple fact bodies — all prior aggregate tests); fatal for any rule-bodied inner goal that fails, i.e. zero solutions. This bites **AOT and loaded alike**.
- Finalize restored only **512 of the 2048** register bytes begin saves — the finding-no.-3 narrow-block class again (X17..X32 and all Y registers kept the failed goal's values).

## Commit 2 — emission

**`call/N`**: the goal stages into A1 (extras A2..) with the meta sentinel (`op1 = -1`); the serializer emits the **meta-call table pay-for-what-you-use**, mirroring the host writer — only when the stream contains a meta-call, one row per predicate group, names *appended* to the atom table so existing reloc indices don't move. Call-free programs serialize **byte-identically**, so every self-host golden stays green untouched.

**`findall/3`** (variable template + result — the dominant shape): the host's aggregate bracket — self-init fresh registers, `begin_aggregate(collect, valreg<<16|resreg)`, goal inline, `end_aggregate(valreg)`. A template that already holds a register is not re-initialized (the shared-cell rule from #1647); inner-goal register inits are discarded from the out-set. Compound templates throw (recorded demand).

**Assert family whitelisted** (`assertz`/`asserta`/`retractall`) — readable through `call/1`'s dynamic-store fallback using the complete-goal idiom (`G = k(V), call(G)`; a call/N closure over a store predicate fails cleanly by the store iterator's documented design). Nondet `retract/1` is the other recorded next demand.

## Tests

Four loaded-run shapes through the eval host: `call/N` over compound + atom goals (67), assertz + `call/1` read-back (42), findall over facts (63), **empty findall** (100 — fails without commit 1). And the payoff: a runtime-compiled grammar keeping **cross-record state** — `assertz` per record + `findall` over the store computes a running sum inside the grammar (3, 4, 5 → 22).

`test_wam_object` **73/73** (all self-host goldens byte-identical — the meta table is pay-for-what-you-use), `test_plawk_eval_compile` 9/9, handle-scalar 5/5, at-named 9/9.

Docs: the architecture summary's subset-growth entry records the landed demands, finding no. 14, and the remaining demands; the roadmap's campaign-findings count is now fourteen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_