### PR TITLE
WAM/LLVM self-host: nondet retract/1, compound findall templates, catch/throw (+ runtime finding no. 15)

### DIFF
--- a/docs/design/PLAWK_EVAL_ARCHITECTURE.md
+++ b/docs/design/PLAWK_EVAL_ARCHITECTURE.md
@@ -236,5 +236,23 @@ Deliberately deferred, in rough value order:
   aggregate frame never saved/restored `stack_size` (an allocating
   inner goal that failed left an orphaned environment frame), and
   finalize restored only 512 of the 2048 saved register bytes.
-  Remaining recorded demands: nondet `retract/1` emission (call
-  sentinel −3) and compound `findall` templates.
+  The third round landed the recorded next demands: nondet
+  **`retract/1`** (pattern staged into A1, call sentinel −3 — the
+  runtime's consult+remove+backtrack iterator, so re-satisfaction
+  yields the next match and exhaustion fails cleanly), **compound
+  `findall` templates** (`findall(p(X, Y), G, L)` — fresh template
+  variables self-init before `begin_aggregate`, and the template
+  structure is BUILT into the value register after each solution),
+  and **`catch/3`/`throw/1`** (sentinels −5/−6; Goal and Recovery
+  resolve through the meta-call table, whose emission now also
+  triggers on −5/−6). Catcher and Recovery must be PLAIN operands:
+  a control construct (conjunction, `=/2`, …) as Recovery is
+  rejected at compile time with `cg_unsupported_operand` — wrap it
+  in a helper predicate. Landing the catch tests surfaced campaign
+  finding **no. 15**: `wam_catch_setup` stored the fully-deref'd
+  catcher, collapsing an unbound catcher — the common
+  `catch(G, E, Rec)` shape — to the addressless Unbound sentinel
+  that the throw-side unify cannot bind through, so every ball
+  sailed past a variable catcher to the uncaught halt (all prior
+  runtime tests used compound catchers). The frame now keeps the
+  chain-end Ref.

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -545,7 +545,7 @@ own PR(s).
   milliseconds, once per distinct source (the compile() surface dedups),
   so the remaining mildly-superlinear tail is not worth further
   restatement.
-  The campaign keeps surfacing and fixing latent runtime bugs — **fourteen found
+  The campaign keeps surfacing and fixing latent runtime bugs — **fifteen found
   so far**: a 64-register-file ceiling corrupting memory for large clauses;
   `get_structure` not comparing the functor; the choice-point saved-register
   block not widened with the register file (failed clause bodies leaked Y17+
@@ -585,7 +585,16 @@ own PR(s).
   later `deallocate` popped the orphan (masked whenever every inner
   clause was allocate-free) — and `wam_finalize_aggregate` restored
   only 512 of the 2048 register bytes `begin_aggregate` saves (the
-  finding-no.-3 narrow-block class again). See
+  finding-no.-3 narrow-block class again). Finding **no. 15** came from
+  the catch/throw emission round: `wam_catch_setup` stored the
+  fully-deref'd catcher in the catch frame, so an UNBOUND catcher — the
+  common `catch(G, E, Rec)` shape — collapsed to the addressless Unbound
+  sentinel, which the throw-side `wam_unify_value` cannot bind through
+  (its bind arm requires a Ref); every ball sailed past a variable
+  catcher to the uncaught halt. Masked because every prior catch test
+  used a compound catcher (`myerr(V)` keeps its struct identity). The
+  frame now stores the chain-end Ref (`@wam_deref_keep_var`, the same
+  helper that closed the earlier variable-identity collapses). See
   [PLAWK_SELFHOST.md](./PLAWK_SELFHOST.md).
 
 ## The binary-return question, specifically

--- a/src/unifyweaver/targets/wam_bootstrap_compiler.pl
+++ b/src/unifyweaver/targets/wam_bootstrap_compiler.pl
@@ -425,21 +425,27 @@ cgfull_term(Clauses, Wamo) :-
     atom_codes(Wamo, Codes).
 
 % The meta-call table (pay-for-what-you-use, mirroring the host writer):
-% emitted only when the instruction stream contains a meta-call
-% (op1 = -1 on a call), so call-free programs serialize byte-identically
-% to before -- every self-host golden is call-free. One row per
-% predicate group: <atomIdx> <funIdx> <arity> <labelIdx>. The predicate
-% name joins the ATOM table (appended, so existing reloc indices are
-% unchanged); funIdx points at the name's functor-table row when the
-% object builds such a compound (call(k(V)) collected k into the table
-% already), else -1.
+% emitted only when the instruction stream contains a meta-dispatching
+% call -- a plain meta-call (op1 = -1), or catch/3 (-5) / throw/1 (-6)
+% whose Goal and Recovery resolve through the same path, exactly the
+% host's wamo_has_meta_call set (retract's -3 consults the store
+% directly and needs no table). Call-free programs serialize
+% byte-identically to before -- every self-host golden is call-free.
+% One row per predicate group: <atomIdx> <funIdx> <arity> <labelIdx>.
+% The predicate name joins the ATOM table (appended, so existing reloc
+% indices are unchanged); funIdx points at the name's functor-table row
+% when the object builds such a compound (call(k(V)) collected k into
+% the table already), else -1.
 cg_meta_rows(AllIs, Groups, Atoms0, Functors, Atoms, Rows) :-
-    ( memberchk(enc(18, -1, _, _), AllIs)
+    ( cg_has_meta(AllIs)
     -> cg_meta_names(Groups, 0, Names),
        cg_meta_atoms(Names, Atoms0, Atoms),
        cg_meta_rows_list(Names, Atoms, Functors, Rows)
     ;  Atoms = Atoms0, Rows = []
     ).
+cg_has_meta(AllIs) :- memberchk(enc(18, -1, _, _), AllIs).
+cg_has_meta(AllIs) :- memberchk(enc(18, -5, _, _), AllIs).
+cg_has_meta(AllIs) :- memberchk(enc(18, -6, _, _), AllIs).
 cg_meta_names([], _, []).
 cg_meta_names([pred(P, A, _)|Gs], I, [mp(P, A, I)|R]) :-
     I1 is I + 1, cg_meta_names(Gs, I1, R).
@@ -719,9 +725,33 @@ f_goal(Goal, _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-
     call_args(Goal, 1, A, At, FT, In0, In, SetupIs),
     append(SetupIs, [enc(18, -1, A, 0)], Is),
     length(Is, N), PC is PC0 + N.
+% retract/1 (nondeterministic): the clause pattern stages into A1 and
+% the call carries sentinel -3 -- the runtime's consult+remove+
+% backtrack iterator over the dynamic store (agg -4 frames), so
+% re-satisfaction removes and yields the next match and exhaustion
+% fails cleanly.
+f_goal(retract(Cl), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :- !,
+    c_operand(Cl, 0, At, FT, In0, In, IC),
+    append(IC, [enc(18, -3, 1, 0)], Is),
+    length(Is, N), PC is PC0 + N.
+% catch/3: A1=Goal, A2=Catcher, A3=Recovery, sentinel -5; throw/1: the
+% ball in A1, sentinel -6. Goal and Recovery dispatch through the
+% object's meta-call table, so -5/-6 trigger its emission exactly as
+% the host writer does (see cg_meta_rows).
+f_goal(catch(G, C, Rc), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :- !,
+    c_operand(G, 0, At, FT, In0, In1, IG),
+    c_operand(C, 1, At, FT, In1, In2, ICt),
+    c_operand(Rc, 2, At, FT, In2, In, IR),
+    append(IG, ICt, GC), append(GC, IR, Setup),
+    append(Setup, [enc(18, -5, 3, 0)], Is),
+    length(Is, N), PC is PC0 + N.
+f_goal(throw(B), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :- !,
+    c_operand(B, 0, At, FT, In0, In, IB),
+    append(IB, [enc(18, -6, 1, 0)], Is),
+    length(Is, N), PC is PC0 + N.
 % findall(Template, Goal, List) with a VARIABLE template and result
-% (the dominant shape; compound templates stay outside the subset and
-% throw). Emits the host's aggregate bracket: initialize the template
+% (the dominant shape; a COMPOUND template has its own clause below).
+% Emits the host's aggregate bracket: initialize the template
 % and result registers if fresh, begin_aggregate(collect,
 % valreg<<16|resreg), the goal inline, end_aggregate(valreg) -- the
 % runtime collects one frozen copy per solution and binds the list on
@@ -747,6 +777,35 @@ f_goal(findall('$VAR'(TN), G, '$VAR'(LN)), PL, At, FT, PC0, PC, L0, L,
     append(Inits, [enc(28, 4, Op2, 0) | GIs], Front),
     append(Front, [enc(29, TY, 0, 0)], Is),
     In = In2.
+% COMPOUND template: findall(p(X, Y), Goal, List) -- the host's shape.
+% Fresh template variables self-init BEFORE begin (the frame saves the
+% registers; each solution's backtrack restores them and the trail
+% unwind resets their cells, so every iteration starts fresh). AFTER
+% the goal succeeds, the template structure is BUILT into A1 with the
+% goal's in-set (the just-bound solution values), and
+% end_aggregate(A1) freezes it -- value register 0.
+f_goal(findall(T, G, '$VAR'(LN)), PL, At, FT, PC0, PC, L0, L,
+        Prs0, Prs, In0, In, Is) :-
+    compound(T), T \= '$VAR'(_), integer(LN), !,
+    LY is 48 + LN,
+    cg_template_vars(T, TVars),
+    cg_template_inits(TVars, In0, In1, TInits),
+    ( memberchk(LN, In1) -> LInit = [], In2 = In1
+    ; LInit = [enc(9, LY, LY, 0)], In2 = [LN | In1] ),
+    append(TInits, LInit, Inits),
+    length(Inits, NI),
+    GoalPC is PC0 + NI + 1,
+    conj_list(G, Gs),
+    f_goals(Gs, PL, At, FT, GoalPC, PCg, L0, L, Prs0, Prs, In2, InG, GIs),
+    c_operand(T, 0, At, FT, InG, _InB, BIs),
+    length(BIs, NB),
+    PC is PCg + NB + 1,
+    Op2 is LY,
+    append(GIs, BIs, Body),
+    append(Inits, [enc(28, 4, Op2, 0) | Body], Front),
+    append(Front, [enc(29, 0, 0, 0)], Is),
+    In = In2.
+
 f_goal((L is E), _, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In2, Is) :- !,
     % NESTED arithmetic: the expression is just a term -- stage it with
     % c_operand (build_struct + X-temp deferral handles arbitrary nesting,
@@ -791,6 +850,23 @@ f_goal(Goal, PL, At, FT, PC0, PC, Lb, Lb, Prs, Prs, In0, In, Is) :-  % predicate
 % loadable (call sentinel), so the loaded compiler aborts immediately.
 f_goal(Goal, _, _, _, _, _, _, _, _, _, _, _, _) :-
     functor(Goal, P, A), throw(cg_unsupported_goal(P, A)).
+
+% distinct '$VAR' indices of a findall template term, first-occurrence
+% order -- the compound-template clause self-inits each fresh one.
+cg_template_vars(T, Vs) :- cg_tv(T, [], Vs).
+cg_tv('$VAR'(N), Acc, Out) :- integer(N), !,
+    ( memberchk(N, Acc) -> Out = Acc ; append(Acc, [N], Out) ).
+cg_tv(T, Acc, Out) :- compound(T), !, T =.. [_|As], cg_tvl(As, Acc, Out).
+cg_tv(_, Acc, Acc).
+cg_tvl([], A, A).
+cg_tvl([X|Xs], A0, A) :- cg_tv(X, A0, A1), cg_tvl(Xs, A1, A).
+
+cg_template_inits([], In, In, []).
+cg_template_inits([N|Ns], In0, In, Is) :-
+    ( memberchk(N, In0) -> In1 = In0, Head = []
+    ; Y is 48 + N, Head = [enc(9, Y, Y, 0)], In1 = [N | In0] ),
+    cg_template_inits(Ns, In1, In, Rest),
+    append(Head, Rest, Is).
 
 % builtin goals the grammar can emit directly: name/arity -> builtin id (the
 % host runtime's builtin_op_to_id table). Staged like a call (c_operand per

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -6226,6 +6226,26 @@ done:
 }
 
 ; Push a catch frame snapshotting the current VM marks.
+; Read a catch/3 argument register for frame storage: deref to the
+; bound value, EXCEPT when the cell is still unbound and the register
+; holds a Ref -- then keep the chain-end Ref so the frame retains the
+; variable's ADDRESS (the throw-side unify binds through it).
+define %Value @wam_catch_arg(%WamState* %vm, i32 %idx) {
+entry:
+  %raw = call %Value @wam_get_reg(%WamState* %vm, i32 %idx)
+  %d = call %Value @wam_deref_value(%WamState* %vm, %Value %raw)
+  %unb = call i1 @value_is_unbound(%Value %d)
+  %rtag = extractvalue %Value %raw, 0
+  %isref = icmp eq i32 %rtag, 5
+  %keep = and i1 %unb, %isref
+  br i1 %keep, label %kv, label %use_d
+kv:
+  %chain_end = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %raw)
+  ret %Value %chain_end
+use_d:
+  ret %Value %d
+}
+
 define void @wam_catch_push(%WamState* %vm, %Value %catcher, %Value %recovery, i32 %return_pc) {
 entry:
   %count = load i32, i32* @wam_catch_count
@@ -6283,10 +6303,16 @@ have:
 ; catch(Goal, Catcher, Recovery): A1=Goal, A2=Catcher, A3=Recovery. Push a
 ; frame, then meta-call Goal (reg 0 already holds it) with continuation
 ; return_pc. If Goal cannot be dispatched, pop the frame and fail.
+; Finding no. 15: an UNBOUND catcher (the common ``catch(G, E, Rec)``
+; shape) must be stored as its chain-end Ref, not the full deref --
+; @wam_get_reg_deref collapses it to the addressless Unbound sentinel,
+; which @wam_unify_value cannot bind through (its bind_a arm requires a
+; Ref), so the throw-side catcher match failed and EVERY ball sailed
+; past a variable catcher to the uncaught halt.
 define i1 @wam_catch_setup(%WamState* %vm, i32 %return_pc) {
 entry:
-  %catcher = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
-  %recovery = call %Value @wam_get_reg_deref(%WamState* %vm, i32 2)
+  %catcher = call %Value @wam_catch_arg(%WamState* %vm, i32 1)
+  %recovery = call %Value @wam_catch_arg(%WamState* %vm, i32 2)
   call void @wam_catch_push(%WamState* %vm, %Value %catcher, %Value %recovery, i32 %return_pc)
   %ok = call i1 @wam_dispatch_meta_call(%WamState* %vm, i32 1, i32 %return_pc)
   br i1 %ok, label %done, label %goalfail

--- a/tests/test_wam_object.pl
+++ b/tests/test_wam_object.pl
@@ -228,6 +228,14 @@ ctcompute(R) :- X is 6*7, throw(result(X)), R = X.
 ctgrab(V, V).
 ct_ball(R)    :- catch(ctcompute(R), result(V), ctgrab(V, R)).               % 42 (recovery uses ball)
 ct_uncaught(R) :- throw(oops), R = 1.                                        % uncaught -> fails
+% Finding no. 15: a VARIABLE catcher. wam_catch_setup stored the fully
+% deref'd catcher, so an unbound one collapsed to the addressless Unbound
+% sentinel; the throw-side unify cannot bind through that (its bind arm
+% needs a Ref) and every ball sailed past to the uncaught halt. The frame
+% now keeps the chain-end Ref: E binds to the whole ball, the recovery
+% destructures it.
+ctunwrap(myerr(V), V).
+ct_varcatch(R) :- catch(ctrisky(R), E, ctunwrap(E, R)).                       % 42 (var catcher)
 
 % Milestone 5 (eval/compile pipeline): a loaded compiler object runs on source
 % text and emits .wamo bytes, which @wam_object_eval loads into a fresh VM in
@@ -907,6 +915,7 @@ test(catch_and_throw_in_object, [condition(clang_available)]) :-
               ct_nothrow-[ctok/1, ctnorec/1]-"5\n"-0,
               ct_nested-[ctmid/1, ctthrower/1, cthia/1, cthb/2]-"9\n"-0,
               ct_ball-[ctcompute/1, ctgrab/2]-"42\n"-0,
+              ct_varcatch-[ctrisky/1, ctunwrap/2]-"42\n"-0,
               ct_uncaught-[]-""-21 ],
     forall(member(Name-Deps-Expected-ExpStatus, Cases),
            ( findall(user:P, member(P, Deps), DepPIs),
@@ -1793,6 +1802,101 @@ test(selfhost_findall_empty, [condition(clang_available)]) :-
     process_wait(Pid, exit(Status)),
     assertion(Status == 0),
     assertion(Out == "100\n"),
+    !.
+
+% retract/1 emission (call sentinel -3): nondeterministic consult +
+% REMOVE over the dynamic store. Two asserts, two retracts pull 1 then
+% 2 (assert order), and a third attempt finds the store EMPTY -- the
+% ITE else branch proves exhaustion fails cleanly. (1*10+2)*10+7 = 127.
+test(selfhost_retract_nondet, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgrt_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- assertz(k(1)), assertz(k(2)), retract(k(V)), retract(k(W)), (retract(k(Z)) -> E = Z ; E = 7), R is (V * 10 + W) * 10 + E)]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "127\n"),
+    !.
+
+% COMPOUND findall template: p(X, Y) self-inits its fresh variables
+% before begin_aggregate, the goal binds them per solution, and the
+% template structure is BUILT into A1 after each success (value
+% register 0) -- one frozen p/2 per row. The q/2 clause head then
+% decodes the pair list back to digits: 1234.
+test(selfhost_findall_compound_template, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgct_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- findall(p(X, Y), m(X, Y), L), q(L, R)), m(1, 2), m(3, 4), (q([p(A, B), p(C, D)], R2) :- R2 is ((A * 10 + B) * 10 + C) * 10 + D)]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "1234\n"),
+    !.
+
+% catch/throw emission (call sentinels -5/-6): boom/1 throws oops(1),
+% the catcher unifies, and the SIMPLE-CALL recovery goal rec/2 computes
+% 42. Recovery must be a plain callable (atom or compound) -- a control
+% construct like a conjunction is rejected at compile time with
+% cg_unsupported_operand (documented subset restriction).
+test(selfhost_catch_throw_recovers, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgcth_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- catch(boom(1), E, rec(E, R))), (boom(N) :- X = oops(N), throw(X)), (rec(oops(V), R) :- R is V + 41)]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "42\n"),
+    !.
+
+% catch with NO throw: the goal succeeds, the catch frame is discarded,
+% and the recovery never runs. ok(3) -> R = 3. (The recovery is a
+% helper predicate, not V = 0: recovery must be a PLAIN CALLABLE --
+% =/2 is a control functor outside the operand builder, same
+% restriction as conjunction recoveries.)
+test(selfhost_catch_no_throw, [condition(clang_available)]) :-
+    obj_dir(Dir),
+    directory_file_path(Dir, 'cgfull.wamo', CompWamo),
+    write_wam_object([wam_bootstrap_compiler:cgfull/2], [wamo_entry(cgfull/2)], CompWamo),
+    directory_file_path(Dir, 'eval_host_bin', Host),
+    ( exists_file(Host) -> true ; build_eval_host(Dir, Host) ),
+    directory_file_path(Dir, 'cgcnt_src.txt', SrcPath),
+    setup_call_cleanup(open(SrcPath, write, S0),
+        write(S0, '[(main0(R) :- catch(ok(V), _, zrec(V)), R = V), ok(3), zrec(0)]'),
+        close(S0)),
+    process_create(Host, [CompWamo, SrcPath],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    assertion(Out == "3\n"),
     !.
 
 % cgfullm: cgfull + a MULTI-ENTRY name table (the eval compiler the


### PR DESCRIPTION
Third demand-driven growth round for the bootstrap compiler, landing the recorded next demands — nondet `retract/1` emission (call sentinel −3) and compound `findall` templates — plus `catch/3`/`throw/1` emission (same staging shape, sentinels −5/−6).

## Bootstrap-compiler emission (`wam_bootstrap_compiler.pl`)

- **`retract/1`**: the clause pattern stages into A1 and the call carries sentinel −3 — the runtime's consult+remove+backtrack iterator over the dynamic store, so re-satisfaction removes and yields the next match and exhaustion fails cleanly.
- **Compound `findall` templates**: `findall(p(X, Y), G, L)` — distinct template variables (first-occurrence order) self-init BEFORE `begin_aggregate` (each solution's backtrack restores the registers and the trail unwind resets their cells, so every iteration starts fresh); after the goal succeeds the template structure is BUILT into A1 with the goal's in-set, and `end_aggregate(A1)` freezes one copy per solution.
- **`catch/3` / `throw/1`**: Goal/Catcher/Recovery stage into A1..A3 with sentinel −5 (ball in A1, sentinel −6 for throw). The pay-for-what-you-use meta-call table now also triggers on −5/−6, mirroring the host writer's `wamo_has_meta_call` set. Catcher and Recovery must be **plain operands**: a control construct (conjunction, `=/2`, …) as Recovery fails fast at compile time with `cg_unsupported_operand` — wrap it in a helper predicate.
- Byte-compat guard intact: meta-free sources serialize identically through `cgfull` and `cgfullm` (goldens safe).

## Runtime finding no. 15 (`state.ll.mustache`)

Landing the catch tests surfaced the fifteenth latent runtime bug of the campaign: `wam_catch_setup` stored the catcher via `wam_get_reg_deref`, which collapses an UNBOUND catcher — the common `catch(G, E, Rec)` shape — to the addressless Unbound sentinel. The throw-side `wam_unify_value` can only bind through a Ref (its `bind_a` arm requires tag 5), so every ball sailed past a variable catcher to the uncaught halt. Masked because every prior catch test used a compound catcher (`myerr(V)` keeps its struct identity). Bisected host-side across ten catch shapes: all compound-catcher variants passed, all variable-catcher variants failed.

Fix: new `@wam_catch_arg` reads the register raw and, when the cell is still unbound, keeps the chain-end Ref (`@wam_deref_keep_var`) so the frame retains the variable's address; bound values still store fully deref'd as before. All ten bisection shapes pass after the fix.

## Tests

- `selfhost_retract_nondet` (loaded): two asserts, two retracts pull 1 then 2, a third attempt proves exhaustion fails cleanly → 127.
- `selfhost_findall_compound_template` (loaded): `findall(p(X, Y), m(X, Y), L)` over a fact table, decoded back to digits by a destructuring clause head → 1234.
- `selfhost_catch_throw_recovers` (loaded): throw through a variable catcher, recovery destructures the ball → 42.
- `selfhost_catch_no_throw` (loaded): goal succeeds, frame discarded, recovery never runs → 3.
- `ct_varcatch` added to the milestone-3c host-compile matrix — the variable-catcher case that pins finding no. 15.
- Full regressions fresh-cache: `test_wam_object` **77/77**, `test_plawk_eval_compile` **9/9**, `test_wam_llvm_meta_call_runtime` green.

## Docs

- `PLAWK_EVAL_ARCHITECTURE.md`: third growth round recorded (retract, compound templates, catch/throw + the plain-operand restriction), finding no. 15 noted.
- `PLAWK_JIT_ROADMAP.md`: findings count fourteen → fifteen, finding no. 15 write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_