### PR TITLE
WAM/LLVM eval: positional-array target (`as array`) — item 4's last target container

### DIFF
--- a/docs/design/PLAWK_EVAL_ARCHITECTURE.md
+++ b/docs/design/PLAWK_EVAL_ARCHITECTURE.md
@@ -196,6 +196,14 @@ Deliberately deferred, in rough value order:
   LANDED: `for (k in arr) print ...` runs per record inside the rule's
   action chain, over the table as accumulated so far (str-valued
   tables print text there too).
+- ~~**Positional-array target (`as array`)**~~ — LANDED (named +
+  default entry, i64 values): the last of item 4's target containers.
+  `arr = dyncall[@name](args) as array` lands a flat returned list
+  `[V1..Vn]` into one array by position (element i → key i, 1-indexed),
+  reusing the whole assoc pipeline via a `posarray(...)` spec wrapper
+  and a new `@wam_object_call_posarray` walk. Its integer position keys
+  read unambiguously in text mode (unlike a regular integer-keyed
+  assoc). String values deferred, like the assoc `(str)` kind was.
 - ~~**`dyncall_at@name(...)`**~~ — LANDED (all three return kinds:
   i64, `float(...)`, `blob(...)`): named entries on runtime sources
   and `compile(...)` handles, resolved per call against the VM's

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -214,7 +214,7 @@ Purely additive; no dependency on the other items.
 **Effort:** A landed. B is moderate (declaration table + a resolution pass +
 the reserved-name check). **Depends on:** nothing.
 
-### 4. Binary-data returns — structured records (deserialization) — **LANDED (all string surfaces; string values deferred)**
+### 4. Binary-data returns — structured records (deserialization) — **LANDED (all target containers; posarray/assoc string values deferred)**
 
 **What:** let a grammar return a **compound term** (e.g. `rec(42, 3.14,
 "name")`) that plawk **deserializes** into typed fields against a declared
@@ -299,9 +299,25 @@ different plawk containers — this is the through-line for the rest of item 4:
   (for-in value prints, END `arr["literal"]` lookups) resolve the id
   back to text through `@wam_atom_to_string`, exactly as key prints
   already did. Same table layout; only the declared value kind differs.
-  **Still deferred:** for-in iteration over a grammar-populated table
-  inside rule bodies.
-- **Positional array** — fields by numeric index into one array value.
+  **Rule-body for-in LANDED:** `for (k in arr)` iterates a
+  grammar-populated table inside the rule''s action chain (a per-record
+  running snapshot), not only in END.
+- **Positional array — LANDED (named + default entry, i64 values):**
+  `arr = dyncall[@name](args) as array` binds a FLAT returned list
+  `[V1, ..., Vn]` into one array value by POSITION — element i at key i
+  (1-indexed, the awk `split` convention). `@wam_object_call_posarray`
+  walks the list into the shared i64 table via `@wam_assoc_i64_set`
+  (REPLACE semantics, so the array reflects the most recent record), and
+  the `posarray(...)` spec wrapper rides the whole assoc pipeline
+  (planning, table, for-in, lookups) — only the shim name and the
+  runtime walk differ. A positional table''s keys are integer positions,
+  never interned atom ids, so int-key reads (`arr[1]`, and a for-in loop
+  key) are unambiguous and permitted in TEXT mode too, unlike a regular
+  integer-keyed assoc (which stays binary-only to avoid the atom-id
+  collision). Value binding uses whatever the entry returns; string
+  values (`[Atom, ...]` elements) are a natural follow-on, deferred like
+  the assoc `(str)` kind was. Tests:
+  `tests/test_plawk_dyncall_posarray.pl`.
 
 Each target reuses one marshaller over the same walked compound; they differ
 only in where fields are written (scalar slots, the line record, an assoc

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -132,6 +132,8 @@ build(File, Out0, KeepLL) :-
         ; plawk_program_dyncall_assoc_arities(Program, DynAssocArities), DynAssocArities \== []
         ; plawk_program_dyncall_named_assoc_str_entries(Program, DynNamedAssocS), DynNamedAssocS \== []
         ; plawk_program_dyncall_assoc_str_arities(Program, DynAssocSArities), DynAssocSArities \== []
+        ; plawk_program_dyncall_named_posarray_entries(Program, DynNamedPosarr), DynNamedPosarr \== []
+        ; plawk_program_dyncall_posarray_arities(Program, DynPosarrArities), DynPosarrArities \== []
         )
     ->  ProjectOptions = [module_name(OutBase), emit_wamo_loader(true)]
     ;   ProjectOptions = [module_name(OutBase)]

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -16,6 +16,8 @@
     plawk_program_dyncall_assoc_arities/2,
     plawk_program_dyncall_named_assoc_str_entries/2,
     plawk_program_dyncall_assoc_str_arities/2,
+    plawk_program_dyncall_named_posarray_entries/2,
+    plawk_program_dyncall_posarray_arities/2,
     plawk_program_dyncall_at_arities/2,
     plawk_program_dyncall_at_named_entries/2,
     plawk_program_dyncall_at_named_float_entries/2,
@@ -647,6 +649,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_dyncall_assoc_arities(Program, DynAssocArities),
     plawk_program_dyncall_named_assoc_str_entries(Program, DynNamedAssocS),
     plawk_program_dyncall_assoc_str_arities(Program, DynAssocSArities),
+    plawk_program_dyncall_named_posarray_entries(Program, DynNamedPosarr),
+    plawk_program_dyncall_posarray_arities(Program, DynPosarrArities),
     plawk_program_dyncall_at_arities(Program, DynAtArities),
     plawk_program_dyncall_at_named_entries(Program, DynAtNamed),
     plawk_program_dyncall_at_named_float_entries(Program, DynAtNamedF),
@@ -669,6 +673,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         DynAssocArities == [],
         DynNamedAssocS == [],
         DynAssocSArities == [],
+        DynNamedPosarr == [],
+        DynPosarrArities == [],
         DynAtArities == [],
         DynAtNamed == [],
         DynAtNamedF == [],
@@ -694,7 +700,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
             DynNamed == [], DynNamedF == [], DynNamedB == [],
             DynRecArities == [], DynNamedRec == [], DynNamedAssoc == [],
             DynAssocArities == [], DynNamedAssocS == [],
-            DynAssocSArities == []
+            DynAssocSArities == [], DynNamedPosarr == [],
+            DynPosarrArities == []
         ->  DyncallSupportIR = ''
         ;   ( plawk_program_dynload_path(Program, DynPath)
             ->  true
@@ -705,7 +712,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
             plawk_dyncall_support_ir(DynPath, DynArities, DynFArities,
                 DynBArities, DynNamed, DynNamedF, DynNamedB,
                 DynRecArities, DynNamedRec, DynNamedAssoc, DynAssocArities,
-                DynNamedAssocS, DynAssocSArities, DyncallSupportIR)
+                DynNamedAssocS, DynAssocSArities, DynNamedPosarr,
+                DynPosarrArities, DyncallSupportIR)
         ),
         % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...)) /
         % blob(dyncall_at(...)) sites + the shared path cache. A compile
@@ -995,6 +1003,45 @@ plawk_subterm_dynassoc_str_call(Term, Call) :-
     compound(Term),
     arg(_, Term, Sub),
     plawk_subterm_dynassoc_str_call(Sub, Call).
+
+%% plawk_program_dyncall_named_posarray_entries(+Program, -Entries)
+%% plawk_program_dyncall_posarray_arities(+Program, -Arities)
+%  Positional-array target (`arr = dyncall[@name](args) as array`): named
+%  sites get @plawk_dyncall_posarray_<Name>_<N> shims, default-entry sites
+%  @plawk_dyncall_posarray_default_<N> -- both forwarding to
+%  @wam_object_call_posarray (flat [V1..Vn] list walked into keys 1..n,
+%  i64 values, replace semantics).
+plawk_program_dyncall_named_posarray_entries(
+        program(_Begin, Rules, EndClauses), Entries) :-
+    findall(Name-NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          member(Action, Actions),
+          plawk_subterm_dynposarray_call(Action, dyncall_named(Name, Args)),
+          length(Args, NArgs)
+        ),
+        Entries0),
+    sort(Entries0, Entries).
+
+plawk_program_dyncall_posarray_arities(program(_Begin, Rules, EndClauses),
+        Arities) :-
+    findall(NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          member(Action, Actions),
+          plawk_subterm_dynposarray_call(Action, dyncall(Args)),
+          length(Args, NArgs)
+        ),
+        A0),
+    sort(A0, Arities).
+
+plawk_subterm_dynposarray_call(dynposarray_bind(_Var, Call), Call).
+plawk_subterm_dynposarray_call(Term, Call) :-
+    compound(Term),
+    arg(_, Term, Sub),
+    plawk_subterm_dynposarray_call(Sub, Call).
 
 plawk_subterm_dynrec_call(dynrec_bind(_Vars, Call, _Types), Call).
 plawk_subterm_dynrec_call(dynrec_view(Call, _Types, _Body), Call).
@@ -1355,7 +1402,8 @@ plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
 %  handle + @plawk_dyncall_get.
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
         NamedI, NamedF, NamedB, RecArities, NamedRec, NamedAssoc,
-        AssocArities, NamedAssocStr, AssocStrArities, IR) :-
+        AssocArities, NamedAssocStr, AssocStrArities,
+        NamedPosarray, PosarrayArities, IR) :-
     llvm_emit_c_string_global('plawk_dyncall_path', Path, PathGlobal,
         _StrLen, BytesLen),
     format(atom(GetterIR),
@@ -1393,7 +1441,8 @@ load:
     % one shared resolver per named entry, over the union of the kinds
     % (record binds that name an entry feed the union too, so their
     % resolver exists even when the entry is used nowhere else)
-    append([NamedI, NamedF, NamedB, NamedRec, NamedAssoc, NamedAssocStr],
+    append([NamedI, NamedF, NamedB, NamedRec, NamedAssoc, NamedAssocStr,
+            NamedPosarray],
         NamedAll0),
     sort(NamedAll0, NamedAll),
     findall(ResIR,
@@ -1435,9 +1484,17 @@ load:
         ( member(DSN, AssocStrArities),
           plawk_dyncall_assoc_default_str_shim_ir(DSN, DSShim) ),
         DSShims),
+    findall(NPShim,
+        ( member(NPName-NPNArgs, NamedPosarray),
+          plawk_dyncall_named_posarray_shim_ir(NPName, NPNArgs, NPShim) ),
+        NPShims),
+    findall(DPShim,
+        ( member(DPN, PosarrayArities),
+          plawk_dyncall_posarray_default_shim_ir(DPN, DPShim) ),
+        DPShims),
     append([[PathGlobal, GetterIR], IShims, FShims, BShims,
             Resolvers, NIShims, NFShims, NBShims, RecShims, NRecShims,
-            NAShims, DAShims, NSShims, DSShims], Parts),
+            NAShims, DAShims, NSShims, DSShims, NPShims, DPShims], Parts),
     atomic_list_concat(Parts, '\n\n', IR).
 
 %% plawk_dyncall_named_assoc_shim_ir(+Name, +NArgs, -IR)
@@ -1543,6 +1600,60 @@ do_call:
   %args = alloca %Value, i32 ~w
 ~w
   %r = call i1 @wam_object_call_assoc_str(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, %WamAssocI64Table* %table)
+  ret i1 %r
+
+fail:
+  ret i1 false
+}',
+        [NArgs, ParamsIR, NArgs, StoreIR, NArgs, NArgs]).
+
+%% plawk_dyncall_named_posarray_shim_ir(+Name, +NArgs, -IR)
+%  Positional-array target, named entry: same shape as the i64 assoc
+%  shim but forwarding to @wam_object_call_posarray, which walks a flat
+%  returned [V1..Vn] list into keys 1..n (i64 values, replace semantics).
+plawk_dyncall_named_posarray_shim_ir(Name, NArgs, IR) :-
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define i1 @plawk_dyncall_posarray_~w(~w, %WamAssocI64Table* %table) {
+entry:
+  %pc = call i32 @plawk_dyncall_resolve_~w()
+  %bad = icmp slt i32 %pc, 0
+  br i1 %bad, label %fail, label %do_call
+
+do_call:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call i1 @wam_object_call_posarray(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, %WamAssocI64Table* %table)
+  ret i1 %r
+
+fail:
+  ret i1 false
+}',
+        [Sym, ParamsIR, Sym, NArgs, StoreIR, NArgs, NArgs]).
+
+%% plawk_dyncall_posarray_default_shim_ir(+NArgs, -IR)
+%  Positional-array target, default entry: entry PC recorded at
+%  object-load time, values forwarded to @wam_object_call_posarray.
+plawk_dyncall_posarray_default_shim_ir(NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define i1 @plawk_dyncall_posarray_default_~w(~w, %WamAssocI64Table* %table) {
+entry:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %pc = load i32, i32* @plawk_dyncall_pc
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call i1 @wam_object_call_posarray(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, %WamAssocI64Table* %table)
   ret i1 %r
 
 fail:
@@ -3148,8 +3259,9 @@ plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays,
     append([ActionArrays, [ArrayName], LookupArrays], ArrayNames0),
     sort(ArrayNames0, Tables),
     plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays),
-    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, StrArrays, 0),
-        PlannedRules).
+    plawk_assoc_specs_posarray_arrays(RuleSpecs, PosArrays),
+    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, StrArrays, PosArrays,
+        0), PlannedRules).
 
 %% plawk_assoc_spec_forin_array(+ActionSpecs, -ArrayName)
 %  Arrays a rule-body for-in touches: the iterated table and every
@@ -3170,6 +3282,18 @@ plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays) :-
         ),
         As0),
     sort(As0, StrArrays).
+
+%% plawk_assoc_specs_posarray_arrays(+RuleSpecs, -PosArrays)
+%  Names of tables populated through `as array` (positional) binds --
+%  their keys are integer positions, so for-in loop-key reads print
+%  numerically rather than resolving an atom-registry id to text.
+plawk_assoc_specs_posarray_arrays(RuleSpecs, PosArrays) :-
+    findall(A,
+        ( member(rule(_P, ActionSpecs, _C), RuleSpecs),
+          member(dynassoc(A, posarray(_Call)), ActionSpecs)
+        ),
+        As0),
+    sort(As0, PosArrays).
 
 plawk_forin_print_field(LoopVar, var(LoopVar)).
 plawk_forin_print_field(LoopVar, assoc(var(_ArrayName), var(LoopVar))).
@@ -3809,9 +3933,9 @@ plawk_mixed_planned_rules([rule(Pattern, Actions) | Rest], assoc_plan(Tables, Ac
          NextIndex = Index,
          PlannedAssocActions = []
       ;  HasActions = true,
-         % the mixed route plans increment specs only (no dynassoc-str
-         % binds reach it), so the str-array set is empty here
-         phrase(plawk_assoc_planned_actions(AssocSpecs, Tables, [], 0),
+         % the mixed route plans increment specs only (no dynassoc-str or
+         % posarray binds reach it), so both kind-sets are empty here
+         phrase(plawk_assoc_planned_actions(AssocSpecs, Tables, [], [], 0),
              PlannedAssocActions),
          NextIndex is Index + 1
       )
@@ -4052,8 +4176,9 @@ plawk_assoc_runtime_count_plan(
     append(ActionArrays, PrintArrays, ArrayNames0),
     sort(ArrayNames0, Tables),
     plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays),
-    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, StrArrays, 0),
-        PlannedRules).
+    plawk_assoc_specs_posarray_arrays(RuleSpecs, PosArrays),
+    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, StrArrays, PosArrays,
+        0), PlannedRules).
 
 plawk_assoc_rule_controls(assoc_plan(_Tables, Rules), Controls) :-
     findall(Control, member(assoc_rule(_Index, _Pattern, _Actions, Control), Rules), Controls).
@@ -4087,6 +4212,14 @@ plawk_assoc_body_action_spec(dynassoc_bind(var(ArrayName), Call),
 plawk_assoc_body_action_spec(dynassoc_bind_str(var(ArrayName), Call),
         dynassoc(ArrayName, str(Call))) :-
     plawk_dynrec_call_ok(Call).
+% positional-array target: rides the same dynassoc spec wrapped in
+% posarray(...), so planning, the i64 table, for-in, and lookups reuse
+% the assoc machinery unchanged -- only the shim name (via
+% plawk_dynassoc_call_parts) and the runtime walk (a flat list into keys
+% 1..n) differ. Values are i64, so the table is NOT str-marked.
+plawk_assoc_body_action_spec(dynposarray_bind(var(ArrayName), Call),
+        dynassoc(ArrayName, posarray(Call))) :-
+    plawk_dynrec_call_ok(Call).
 % rule-body for-in: per-record iteration over an assoc table with a
 % print body -- the END for-in's field shapes (loop key / lookups keyed
 % by it / string literals), emitted as a loop inside the rule's action
@@ -4113,62 +4246,64 @@ plawk_assoc_blob_key_ok(Blob) :-
 plawk_assoc_print_array(assoc(var(ArrayName), string(_Key)), ArrayName).
 plawk_assoc_print_array(assoc(var(ArrayName), int(_Key)), ArrayName).
 
-plawk_assoc_planned_rules([], _Tables, _StrArrays, _Index) -->
+plawk_assoc_planned_rules([], _Tables, _StrArrays, _PosArrays, _Index) -->
     [].
 plawk_assoc_planned_rules([rule(Pattern, ActionSpecs, Control) | Rest], Tables,
-        StrArrays, Index) -->
-    { phrase(plawk_assoc_planned_actions(ActionSpecs, Tables, StrArrays, 0),
-          PlannedActions),
+        StrArrays, PosArrays, Index) -->
+    { phrase(plawk_assoc_planned_actions(ActionSpecs, Tables, StrArrays,
+          PosArrays, 0), PlannedActions),
       NextIndex is Index + 1
     },
     [assoc_rule(Index, Pattern, PlannedActions, Control)],
-    plawk_assoc_planned_rules(Rest, Tables, StrArrays, NextIndex).
+    plawk_assoc_planned_rules(Rest, Tables, StrArrays, PosArrays, NextIndex).
 
-plawk_assoc_planned_actions([], _Tables, _StrArrays, _Index) -->
+plawk_assoc_planned_actions([], _Tables, _StrArrays, _PosArrays, _Index) -->
     [].
 plawk_assoc_planned_actions([ArrayName-KeyIndex | Rest], Tables, StrArrays,
-        Index) -->
+        PosArrays, Index) -->
     { nth0(TableIndex, Tables, ArrayName),
       NextIndex is Index + 1
     },
     [assoc_action(Index, ArrayName, TableIndex, KeyIndex)],
-    plawk_assoc_planned_actions(Rest, Tables, StrArrays, NextIndex).
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
 plawk_assoc_planned_actions([dynassoc(ArrayName, Call) | Rest], Tables,
-        StrArrays, Index) -->
+        StrArrays, PosArrays, Index) -->
     { nth0(TableIndex, Tables, ArrayName),
       NextIndex is Index + 1
     },
     [assoc_dyn_action(Index, ArrayName, TableIndex, Call)],
-    plawk_assoc_planned_actions(Rest, Tables, StrArrays, NextIndex).
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
 % rule-body for-in: resolve each print field to a plan (loop key /
 % iterated-table value / lookup by key / literal), with the value kind
 % (i64 vs str) baked in from the str-array set, so the emitter needs no
-% program context.
+% program context. A positional-array iterated table gives a numeric loop
+% key (key_int) instead of the atom-resolved default.
 plawk_assoc_planned_actions([forin(LoopVar, ArrayName, Fields) | Rest],
-        Tables, StrArrays, Index) -->
+        Tables, StrArrays, PosArrays, Index) -->
     { nth0(TableIndex, Tables, ArrayName),
       maplist(plawk_forin_rule_field_plan(LoopVar, ArrayName, TableIndex,
-          Tables, StrArrays), Fields, FieldPlans),
+          Tables, StrArrays, PosArrays), Fields, FieldPlans),
       NextIndex is Index + 1
     },
     [assoc_forin_action(Index, TableIndex, FieldPlans)],
-    plawk_assoc_planned_actions(Rest, Tables, StrArrays, NextIndex).
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
 
-plawk_forin_rule_field_plan(LoopVar, _ArrayName, _TableIndex, _Tables,
-        _StrArrays, var(LoopVar), key) :- !.
+plawk_forin_rule_field_plan(LoopVar, ArrayName, _TableIndex, _Tables,
+        _StrArrays, PosArrays, var(LoopVar), KeyPlan) :- !,
+    ( memberchk(ArrayName, PosArrays) -> KeyPlan = key_int ; KeyPlan = key ).
 plawk_forin_rule_field_plan(LoopVar, ArrayName, TableIndex, _Tables,
-        StrArrays, assoc(var(ArrayName), var(LoopVar)),
+        StrArrays, _PosArrays, assoc(var(ArrayName), var(LoopVar)),
         value_self(TableIndex, Kind)) :-
     !,
     ( memberchk(ArrayName, StrArrays) -> Kind = str ; Kind = i64 ).
 plawk_forin_rule_field_plan(LoopVar, _ArrayName, _TableIndex, Tables,
-        StrArrays, assoc(var(LookupName), var(LoopVar)),
+        StrArrays, _PosArrays, assoc(var(LookupName), var(LoopVar)),
         value_lookup(LookupIndex, Kind)) :-
     !,
     nth0(LookupIndex, Tables, LookupName),
     ( memberchk(LookupName, StrArrays) -> Kind = str ; Kind = i64 ).
 plawk_forin_rule_field_plan(_LoopVar, _ArrayName, _TableIndex, _Tables,
-        _StrArrays, string(Value), lit(Value)).
+        _StrArrays, _PosArrays, string(Value), lit(Value)).
 
 plawk_assoc_entry_setup_ir(assoc_plan(Tables, _Actions), IR) :-
     phrase(plawk_assoc_entry_setup_lines(Tables, 0), Lines),
@@ -4385,6 +4520,16 @@ plawk_forin_rule_field_value(key, B, N) -->
           PtrIR, [FmtPtr, PrintCall])
     },
     [KeyS, FmtPtr, PrintCall].
+% positional-array loop key: the key is an integer position -- print it
+% numerically, not as an atom-registry id.
+plawk_forin_rule_field_value(key_int, B, N) -->
+    { format(atom(FmtVar), '~w_key_fmt_~w', [B, N]),
+      format(atom(PrintVar), '~w_key_p_~w', [B, N]),
+      format(atom(KeyIR), '%~w_key', [B]),
+      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+          KeyIR, [FmtPtr, PrintCall])
+    },
+    [FmtPtr, PrintCall].
 plawk_forin_rule_field_value(value_self(TableIndex, Kind), B, N) -->
     { format(atom(Value),
           '  %~w_v_~w = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_slot)',
@@ -4573,13 +4718,36 @@ plawk_assoc_record_program_ok(binfmt_union(_Arms), Rules, EndPrintFields) :-
              Field = assoc(_Array, Key)
            ),
         ( Key = int(_) ; Key = var(_) )).
-plawk_assoc_record_program_ok(_FieldSeparator, _Rules, EndPrintFields) :-
-    % Text mode: integer assoc keys would collide with atom ids, so
-    % they stay binary-only.
+plawk_assoc_record_program_ok(_FieldSeparator, Rules, EndPrintFields) :-
+    % Text mode: integer assoc keys would collide with atom ids, so they
+    % stay binary-only -- EXCEPT positional-array tables, whose keys are
+    % integer positions (never interned atom ids), so int lookups on them
+    % are unambiguous.
+    plawk_program_posarray_arrays(Rules, PosArrays),
     forall(( member(Field, EndPrintFields),
-             Field = assoc(_Array, Key)
+             Field = assoc(Array, Key)
            ),
-        Key \= int(_)).
+        ( Key \= int(_)
+        ; Array = var(Name), memberchk(Name, PosArrays)
+        )).
+
+%% plawk_program_posarray_arrays(+Rules, -Names) is det.
+%  The array names bound by an `as array` (positional) target, walked
+%  through nested actions.
+plawk_program_posarray_arrays(Rules, Names) :-
+    findall(Name,
+        ( member(rule(_P, Actions), Rules),
+          member(Action, Actions),
+          plawk_posarray_bind_name(Action, Name)
+        ),
+        Names0),
+    sort(Names0, Names).
+
+plawk_posarray_bind_name(dynposarray_bind(var(Name), _Call), Name).
+plawk_posarray_bind_name(Term, Name) :-
+    compound(Term),
+    arg(_, Term, Sub),
+    plawk_posarray_bind_name(Sub, Name).
 
 plawk_binfmt_assoc_action_ok(_Descriptor, next) :- !.
 plawk_binfmt_assoc_action_ok(_Descriptor, break) :- !.
@@ -4589,6 +4757,10 @@ plawk_binfmt_assoc_action_ok(Descriptor, inc_assoc(var(_Name), field(Index))) :-
 plawk_binfmt_assoc_action_ok(Descriptor, dynassoc_bind(var(_Name), Call)) :-
     !,
     plawk_dynassoc_call_parts(Call, Args, _Shim),
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
+plawk_binfmt_assoc_action_ok(Descriptor, dynposarray_bind(var(_Name), Call)) :-
+    !,
+    plawk_dynassoc_call_parts(posarray(Call), Args, _Shim),
     plawk_binfmt_foreign_args_ok(Descriptor, Args).
 
 plawk_record_program_ok(binfmt(Types), Rules, _EndPrintFields) :-
@@ -6565,7 +6737,13 @@ plawk_assoc_end_print_lines([], AssocPlan, _Descriptor, _OutputSeparator, _) -->
     plawk_assoc_free_lines(AssocPlan).
 plawk_assoc_end_print_lines([assoc(var(ArrayName), int(Key)) | Rest], AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
-    { plawk_descriptor_is_binary(Descriptor),
+    % Integer-key lookups are binary-mode only (a text-mode literal key
+    % would collide with an atom id) -- EXCEPT a positional-array table,
+    % whose keys are genuine integer POSITIONS, never interned atom ids,
+    % so an int lookup on it is unambiguous in text mode too.
+    { ( plawk_descriptor_is_binary(Descriptor)
+      ; plawk_assoc_plan_posarray_array(AssocPlan, ArrayName)
+      ),
       plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
       format(atom(Value),
           '  %assoc_end_value_~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 ~w)',
@@ -6633,6 +6811,17 @@ plawk_assoc_table_index(assoc_plan(Tables, _Actions), ArrayName, TableIndex) :-
 plawk_assoc_plan_str_array(assoc_plan(_Tables, Rules), ArrayName) :-
     member(assoc_rule(_RuleIndex, _Pattern, Actions, _Control), Rules),
     member(assoc_dyn_action(_Index, ArrayName, _TableIndex, str(_Call)),
+        Actions),
+    !.
+
+%% plawk_assoc_plan_posarray_array(+AssocPlan, +ArrayName) is semidet.
+%  ArrayName''s table is a POSITIONAL array: some rule fills it through an
+%  `as array` bind (the planned action carries the posarray(...) wrapper).
+%  Its keys are integer positions 1..n, so int-key reads are permitted
+%  even in text mode.
+plawk_assoc_plan_posarray_array(assoc_plan(_Tables, Rules), ArrayName) :-
+    member(assoc_rule(_RuleIndex, _Pattern, Actions, _Control), Rules),
+    member(assoc_dyn_action(_Index, ArrayName, _TableIndex, posarray(_Call)),
         Actions),
     !.
 
@@ -7308,6 +7497,15 @@ plawk_dynassoc_call_parts(str(dyncall_named(Name, Args)), Args, ShimName) :-
 plawk_dynassoc_call_parts(str(dyncall(Args)), Args, ShimName) :-
     length(Args, NArgs),
     format(atom(ShimName), 'plawk_dyncall_assoc_str_default_~w', [NArgs]).
+% positional-array kind (`as array`): the spec wraps the call in
+% posarray(...); route to the @wam_object_call_posarray shims.
+plawk_dynassoc_call_parts(posarray(dyncall_named(Name, Args)), Args, ShimName) :-
+    length(Args, NArgs),
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    format(atom(ShimName), 'plawk_dyncall_posarray_~w', [Sym]).
+plawk_dynassoc_call_parts(posarray(dyncall(Args)), Args, ShimName) :-
+    length(Args, NArgs),
+    format(atom(ShimName), 'plawk_dyncall_posarray_default_~w', [NArgs]).
 
 plawk_dynrec_field_load_lines([], [], _Base, []).
 plawk_dynrec_field_load_lines([F | Fs], [Type | Ts], Base, [Line | Lines]) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1021,6 +1021,9 @@ action(Action) -->
     dynassoc_bind_action(Action),
     !.
 action(Action) -->
+    dynposarray_bind_action(Action),
+    !.
+action(Action) -->
     dynrec_bind_action(Action),
     !.
 % for (k in arr) { ... } as a RULE-BODY action: per-record iteration
@@ -1161,6 +1164,34 @@ dynassoc_value_kind(str) -->
     !.
 dynassoc_value_kind(i64) -->
     [].
+
+%% dynposarray_bind_action(-Action)//
+%
+%  Positional-array return: a grammar returning a FLAT list of integers
+%  populates a plawk array by POSITION -- element i lands at key i
+%  (1-indexed, the awk `split` convention), replace semantics (the array
+%  reflects the most recent record's list).
+%
+%      arr = dyncall@fields($1) as array
+%      arr = dyncall($1) as array          % DYNLOAD object's default entry
+%
+%  desugars to dynposarray_bind(var(arr), dyncall_named(fields, [field(1)]))
+%  (or dynposarray_bind(var(arr), dyncall([field(1)])) for the default
+%  entry). The last target container of JIT roadmap item 4: same i64
+%  table as `as assoc`, but filled from a flat [V1, ..., Vn] list instead
+%  of key-value pairs, so END `arr[1]`, `arr[2]`, ... and for-in read the
+%  positional values.
+dynposarray_bind_action(dynposarray_bind(var(Name), Call)) -->
+    identifier(Name),
+    ws,
+    "=",
+    ws,
+    dynrec_call_expr(Call),
+    ws,
+    "as",
+    identifier_boundary,
+    ws,
+    "array".
 
 dynrec_view_action(dynrec_view(Call, Types, Body)) -->
     dynrec_call_expr(Call),

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -22758,6 +22758,9 @@ wamo_utf8_bytes([C|Cs], Bytes) :-
 %    @wam_object_call_assoc - call the entry and materialize a returned list
 %                           of [Key-Value] integer pairs into an i64 assoc
 %                           table (@wam_assoc_i64_inc per pair)
+%    @wam_object_call_posarray - call the entry and materialize a returned
+%                           FLAT list [V1..Vn] into an i64 table by POSITION
+%                           (element i -> key i, 1-indexed, @wam_assoc_i64_set)
 %    @wam_object_entry_index / @wam_object_entry_index_bytes
 %                        - resolve a named entry to its label index (or -1)
 %                          for multi-entry objects; @wam_label_pc turns that
@@ -23797,6 +23800,94 @@ insert:
   %ignored = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %kval, i64 %vval)
   br label %next
 next:
+  %tail_d = call %Value @wam_deref_value(%WamState* %vm, %Value %t_raw)
+  br label %walk
+walk_done:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  ret i1 true
+rewind_fail:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  br label %fail
+fail:
+  ret i1 false
+}
+
+; The THIRD table kind: a POSITIONAL array. The entry returns a FLAT
+; list [V1, V2, ..., Vn] (not key-value pairs); element i is stored at
+; key i (1-indexed, the awk `split` convention) via @wam_assoc_i64_set --
+; REPLACE semantics, so a per-record bind reflects the most recent
+; record''s list. Values must be Integer; the shared i64 table holds them
+; (JIT roadmap item 4''s last target container). Returns i1 ok; false on
+; call failure, a non-list output, or a non-Integer element.
+define i1 @wam_object_call_posarray(%WamState* %vm, i32 %entry_pc, i32 %nargs, %Value* %args, i32 %out_reg, %WamAssocI64Table* %table) {
+entry:
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+do_call:
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs_saved = load i32, i32* %hs_ptr
+  %unb = call %Value @value_unbound(i8* null)
+  %out_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %out_ref = call %Value @value_ref(i32 %out_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %entry_pc)
+  br label %argloop
+argloop:
+  %ai = phi i32 [ 0, %do_call ], [ %ai1, %argstep ]
+  %adone = icmp sge i32 %ai, %nargs
+  br i1 %adone, label %args_done, label %argstep
+argstep:
+  %aidx64 = sext i32 %ai to i64
+  %ap = getelementptr %Value, %Value* %args, i64 %aidx64
+  %av = load %Value, %Value* %ap
+  call void @wam_set_reg(%WamState* %vm, i32 %ai, %Value %av)
+  %ai1 = add i32 %ai, 1
+  br label %argloop
+args_done:
+  call void @wam_set_reg(%WamState* %vm, i32 %out_reg, %Value %out_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %walk_init, label %rewind_fail
+walk_init:
+  %consfn = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  %head0 = call %Value @wam_deref_value(%WamState* %vm, %Value %out_ref)
+  br label %walk
+walk:
+  %cur = phi %Value [ %head0, %walk_init ], [ %tail_d, %next ]
+  %pos = phi i64 [ 1, %walk_init ], [ %pos1, %next ]
+  %ctag = call i32 @value_tag(%Value %cur)
+  %is_comp = icmp eq i32 %ctag, 3
+  br i1 %is_comp, label %check_cons, label %walk_done
+check_cons:
+  %cbits = call i64 @value_payload(%Value %cur)
+  %ccp = inttoptr i64 %cbits to %Compound*
+  %cfn_slot = getelementptr %Compound, %Compound* %ccp, i32 0, i32 0
+  %cfn = load i8*, i8** %cfn_slot
+  %car_slot = getelementptr %Compound, %Compound* %ccp, i32 0, i32 1
+  %car = load i32, i32* %car_slot
+  %car_ok = icmp eq i32 %car, 2
+  br i1 %car_ok, label %cmp_cons, label %walk_done
+cmp_cons:
+  %fncmp = call i32 @strcmp(i8* %cfn, i8* %consfn)
+  %is_cons = icmp eq i32 %fncmp, 0
+  br i1 %is_cons, label %have_cell, label %walk_done
+have_cell:
+  %cargs_slot = getelementptr %Compound, %Compound* %ccp, i32 0, i32 2
+  %cargs = load %Value*, %Value** %cargs_slot
+  %h_ptr = getelementptr %Value, %Value* %cargs, i64 0
+  %h_raw = load %Value, %Value* %h_ptr
+  %t_ptr = getelementptr %Value, %Value* %cargs, i64 1
+  %t_raw = load %Value, %Value* %t_ptr
+  %elem = call %Value @wam_deref_value(%WamState* %vm, %Value %h_raw)
+  %etag = call i32 @value_tag(%Value %elem)
+  %e_is_int = icmp eq i32 %etag, 1
+  br i1 %e_is_int, label %insert, label %rewind_fail
+insert:
+  %eval = call i64 @value_payload(%Value %elem)
+  %ignored = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %pos, i64 %eval)
+  br label %next
+next:
+  %pos1 = add i64 %pos, 1
   %tail_d = call %Value @wam_deref_value(%WamState* %vm, %Value %t_raw)
   br label %walk
 walk_done:

--- a/tests/test_plawk_dyncall_posarray.pl
+++ b/tests/test_plawk_dyncall_posarray.pl
@@ -1,0 +1,152 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Positional-array target (JIT roadmap item 4's LAST target container):
+% a grammar returns a FLAT list [V1, ..., Vn] and plawk lands each Vi at
+% key i (1-indexed, the awk `split` convention) into one i64 array value.
+%
+%     arr = dyncall@fields($1) as array         % named entry
+%     arr = dyncall($1) as array                % DYNLOAD default entry
+%
+% Same i64 table as `as assoc`, but filled from a flat list instead of
+% key-value pairs (@wam_object_call_posarray walks the list into keys
+% 1..n via @wam_assoc_i64_set -- REPLACE semantics, so the array reflects
+% the most recent record's list). END `arr[1]`, `arr[2]`, ... and for-in
+% read the positional values.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% split a number N into a 3-element positional list [N, N*10, N*100]
+splitc(X, R) :-
+    atom_number(X, N),
+    R1 is N * 10,
+    R2 is N * 100,
+    R = [N, R1, R2].
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_posarray).
+
+% `... as array` parses to a dynposarray_bind action (named + default).
+test(posarray_named_parses) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         { arr = dyncall@splitc($1) as array }\n\c
+         END { print arr[1], arr[2], arr[3] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(dynposarray_bind(var(arr),
+        dyncall_named(splitc, [field(1)])), Actions),
+    !.
+
+test(posarray_default_parses) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         { arr = dyncall($1) as array }\n\c
+         END { print arr[1] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(dynposarray_bind(var(arr), dyncall([field(1)])), Actions),
+    !.
+
+% `... as assoc` still parses unchanged (regression: the two targets are
+% disjoint keywords after `as`).
+test(assoc_still_parses) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         { arr = dyncall@splitc($1) as assoc }\n\c
+         END { print arr[\"k\"] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(dynassoc_bind(var(arr),
+        dyncall_named(splitc, [field(1)])), Actions),
+    !.
+
+% NAMED entry, end to end: each record repopulates arr[1..3] positionally;
+% END reads them back. Last record is 7 -> arr = [7, 70, 700].
+test(posarray_named_running, [condition(clang_available)]) :-
+    pa_dir(Dir),
+    directory_file_path(Dir, 'splitc.wamo', Wamo),
+    write_wam_object([user:splitc/2], [wamo_entries([splitc/2])], Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@splitc($1) as array }\n\c
+         END { print arr[1], arr[2], arr[3] }\n", [Wamo]),
+    build_run(Dir, 'pan', Src, "3\n7\n", Out),
+    assertion(Out == "7 70 700\n"),
+    !.
+
+% DEFAULT entry (the DYNLOAD object's wamo_entry), end to end. One record
+% 5 -> arr = [5, 50, 500].
+test(posarray_default_running, [condition(clang_available)]) :-
+    pa_dir(Dir),
+    directory_file_path(Dir, 'splitd.wamo', Wamo),
+    write_wam_object([user:splitc/2], [wamo_entry(splitc/2)], Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall($1) as array }\n\c
+         END { print arr[1], arr[2], arr[3] }\n", [Wamo]),
+    build_run(Dir, 'pad', Src, "5\n", Out),
+    assertion(Out == "5 50 500\n"),
+    !.
+
+% for-in over a positional array inside the rule body: iterate the slots
+% the grammar just filled. One record 2 -> arr = [2, 20, 200]; the loop
+% prints "pos value" per slot (slot order), END reads arr[2].
+test(posarray_forin_rule_body, [condition(clang_available)]) :-
+    pa_dir(Dir),
+    directory_file_path(Dir, 'splitf.wamo', Wamo),
+    write_wam_object([user:splitc/2], [wamo_entries([splitc/2])], Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@splitc($1) as array ; for (k in arr) print k, arr[k] }\n\c
+         END { print arr[2] }\n", [Wamo]),
+    build_run(Dir, 'paf', Src, "2\n", Out),
+    split_string(Out, "\n", "", Lines0),
+    exclude(==(""), Lines0, Lines),
+    msort(Lines, Sorted),
+    assertion(Sorted == ["1 2", "2 20", "20", "3 200"]),
+    !.
+
+:- end_tests(plawk_dyncall_posarray).
+
+% --- helpers ---------------------------------------------------------------
+
+pa_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_posarray', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, InputText, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog0, '_in.txt', Input),
+    setup_call_cleanup(open(Input, write, SI, [encoding(utf8)]),
+        write(SI, InputText), close(SI)),
+    run_bin(Bin, [Input], Out, 0).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
Lands the **positional-array** target — the only structured-return target container from JIT roadmap item 4 that hadn't shipped (typed scalars, record view, and assoc were already done). A grammar returning a **flat list** `[V1, …, Vn]` now materializes into one plawk array value by **position**: element i at key i, 1-indexed (the awk `split` convention).

```awk
arr = dyncall@fields($1) as array     # named entry
arr = dyncall($1) as array            # DYNLOAD default entry
```

## Parser
`arr = dyncall[@name](args) as array` → `dynposarray_bind(var(arr), Call)`. Disjoint keyword from `as assoc`, so both parse cleanly.

## Codegen
Rides the **entire assoc pipeline** via a `posarray(...)` spec wrapper — planning, the shared i64 table, rule-body for-in, and `arr[k]` lookups are all unchanged; only the shim name (`plawk_dyncall_posarray_*`) and the runtime walk differ. Named + default-entry shims, both forwarding to the new primitive.

A positional table's keys are integer **positions**, never interned atom ids, so integer-key reads (`arr[1]`, and a for-in loop key) are unambiguous and permitted in **text mode** too — unlike a regular integer-keyed assoc, which stays binary-only to avoid the documented atom-id collision. The text-mode surface check and the END / rule-body for-in key emitters learned the positional-table set (threaded parallel to the existing str-array set) so the loop key prints numerically instead of resolving as an atom.

The `emit_wamo_loader` gate in `bin/plawk` gained the posarray collectors, so a default-entry-only posarray program pulls in the loader runtime (the named case had been triggering it incidentally via the generic subterm walker).

## Runtime
`@wam_object_call_posarray` walks the returned cons list into the i64 table via `@wam_assoc_i64_set` at keys 1..n — **REPLACE** semantics, so a per-record bind reflects the most recent record's list. Same heap-save/rewind discipline as the sibling `call_assoc` primitives (constant-memory per record). Emitted with the loader (`emit_wamo_loader(true)`), pay-for-what-you-use.

## Scope
i64 values are the first slice; **string values** (`[Atom, …]` elements) are deferred as a follow-on, matching how the assoc `(str)` kind shipped.

## Tests
`tests/test_plawk_dyncall_posarray.pl` — parse (named + default), and end-to-end named / default / rule-body for-in runs. Regressions green: `test_plawk_dyncall_assoc` (12), `test_plawk_forin_rule_body` (3), `test_plawk_binary_assoc` (11), `test_plawk_union_assoc` (5), `test_plawk_surface_forin_end_print` (14), `test_plawk_forin_writebin` (7), `test_plawk_dyncall_record_view` (7), `test_plawk_dyncall_struct` (5), `test_plawk_blob_consumers` (5), `test_plawk_eval_compile` (9), plus the dyncall base/named/at/float suites.

## Docs
`PLAWK_JIT_ROADMAP.md` item 4 (positional array LANDED; header updated to "all target containers") and `PLAWK_EVAL_ARCHITECTURE.md` deferred list. Also corrected a stale "for-in over grammar-populated tables inside rule bodies — still deferred" note (that landed in an earlier round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_