### PR TITLE
mu_cosine: post-#3648 validation and GPU square-root/QR conditioning

### DIFF
--- a/prototypes/mu_cosine/DESIGN_cheap_judge_joint_posterior.md
+++ b/prototypes/mu_cosine/DESIGN_cheap_judge_joint_posterior.md
@@ -77,6 +77,18 @@ The common source vector is:
 [prior_D, prior_S, graph_D, graph_S, luna_D, luna_S]
 ```
 
+### Graph supervision has two roles
+
+The graph judge is not only a last-mile measurement for the final posterior. Its nearly free structural labels
+can also familiarize or adapt a model to a particular dataset: its entities, vocabulary, topology, and recurring
+relation patterns. That representation-learning role may improve later priors or features even when graph_S has
+little incremental value after Luna in a fixed downstream fusion ladder.
+
+The held-row graph ablations in this work estimate only the first role: the immediate value of graph channels as
+posterior inputs. They do not estimate the value of graph-generated supervision for dataset adaptation. A small
+post-Luna increment must therefore not be interpreted as a reason to remove graph supervision from the broader
+dataset-learning pipeline; that second role needs its own frozen-initialisation, matched-training ablation.
+
 The methods are:
 
 - **JointPosterior:** multinomial LR over the full source vector. This is the train-standardized learned

--- a/prototypes/mu_cosine/DESIGN_cheap_judge_joint_posterior.md
+++ b/prototypes/mu_cosine/DESIGN_cheap_judge_joint_posterior.md
@@ -56,11 +56,12 @@ ablation remains follow-up work if a preregistered, paired diagnostic materially
 
 ## Same-split comparison
 
-For each corpus, a seeded random partition assigns nodes—not rows—to combiner/calibration train or held sets.
-Pairs crossing the node partition are dropped. Thus no held endpoint enters this follow-up's calibration or
-combiner fit. The partition uses only sorted node identifiers and the seed, never labels. This does not prove
-the upstream `model_prod_namecond.pt` checkpoint never saw those node identities; its campaign independence is
-audited, but endpoint independence from all earlier training is not.
+For each corpus, the shared `node_disjoint_pair_split` considers 64 seeded node—not row—assignments and chooses
+one using retained-pair coverage plus macro-class strata. Pairs crossing the node partition are dropped. Thus
+no held endpoint enters this follow-up's calibration or combiner fit. Candidate selection never inspects model
+outcomes. This endpoint split is not edge-disjoint or k-hop-isolated from the ambient parent graph used for graph
+features. It also does not prove the upstream `model_prod_namecond.pt` checkpoint never saw those node identities;
+its campaign independence is audited, but endpoint independence from all earlier training is not.
 
 Every calibration is fit on the same training rows:
 
@@ -120,6 +121,10 @@ AURC intervals resample endpoint-connected components. Every row sharing either 
 block, avoiding the false independence assumption of a row bootstrap. The report includes the number of
 blocks and largest block size; a corpus dominated by one component cannot support a useful block-bootstrap
 interval and must be reported as such.
+
+AURC is retained as the registered selective-risk metric, but it can over-weight early high-confidence errors
+and has finite-sample estimator bias. Report conclusions require the paired interval and effective block counts;
+an AUGRC calculation is a separately named robustness check rather than a post-hoc replacement.
 
 Source separability and the full Pearson correlation matrix are printed from training rows only. A source earns
 its keep through a same-held-set rung/ablation improvement, not through a training correlation alone.

--- a/prototypes/mu_cosine/DESIGN_cheap_judge_joint_posterior.md
+++ b/prototypes/mu_cosine/DESIGN_cheap_judge_joint_posterior.md
@@ -1,0 +1,131 @@
+# Cheap-judge JointPosterior comparison: an explicit decision-space bridge
+
+Status: implementation and declared primary protocol for the post-#3648 validation work.
+
+## Why the obvious comparison is invalid
+
+`campaign_scored.tsv` does not contain honest relation-class targets in `cur_rel`. All 1,770 rows have
+`cur_rel=subcategory`; that field records the relation used by the structural sampler, while the campaign
+deliberately includes siblings, cousins, and random pairs. Training or evaluating `JointPosterior` against
+`cur_rel` would therefore measure the ability to predict a constant.
+
+The operating judge does provide eight relation probabilities and eight relation-specific μ values. The dense
+Gaussian conditioner in #3648 does **not** retain those eight values. It reduces them to two continuous states:
+
+- `D = max(μ_element_of, μ_subcategory, μ_subtopic, μ_super_category)`
+- `S = max(μ_see_also, μ_assoc)`
+
+No honest decoder can recover which directional or symmetric subtype attained the maximum. Consequently this
+work does not claim an eight-way relation comparison.
+
+## Declared common decision space
+
+The comparison aggregates the GPT-5.5 operating judge's probabilities before taking an argmax:
+
+| macro decision | summed operating-judge probabilities |
+|---|---|
+| directional | element_of, subcategory, subtopic, super_category |
+| symmetric | see_also, assoc |
+| other | unknown, none |
+
+This target is **GPT-5.5 macro-decision fidelity**, not independent truth. The full aggregated probability
+vector, top-two margin, tie flag, and fixed-order tie resolution are persisted per comparison row; the hard
+decision is used because the repository's `JointPosterior` is a hard-class discriminative head.
+
+### Do not confuse within-judge pooling with across-expert fusion
+
+The #3648 D/S target uses a hard maximum over relation-specific μ values emitted in **one GPT-5.5 response**.
+It is a within-judge reduction, not “select the most confident expert.” JointPosterior versus correlated
+Gaussian is a separate, downstream question about combining prior, graph, and Luna experts.
+
+Hard max is inherited from #3648, not assumed optimal. The runner audits two bounded alternatives without
+changing the primary estimator:
+
+- probability-weighted pooling, normalizing the judge's relation probabilities within the directional or
+  symmetric group;
+- temperature-softmax pooling of relation μ values (default `T=0.10`), which approaches max as `T→0` but is
+  smoother and remains between the group's minimum and maximum.
+
+For each alternative it prints the full-matched-corpus D/S shift and correlation versus hard max, then refits
+the train-only `D,S → macro decision` bridge and reports a finite-sample linear-reference metric. This is only
+a same-response target-construction diagnostic; it has no paired selection interval.
+A fair production ablation must rebuild *all* targets and sources—GPT-5.5, Luna, and model readouts—with the
+same pooling rule, then refit covariance blocks on the same node split. Mixing a soft-pooled target with
+hard-max prior or measurement channels would change the estimand and is prohibited. That end-to-end pooling
+ablation remains follow-up work if a preregistered, paired diagnostic materially improves held log-loss/AURC.
+
+## Same-split comparison
+
+For each corpus, a seeded random partition assigns nodes—not rows—to combiner/calibration train or held sets.
+Pairs crossing the node partition are dropped. Thus no held endpoint enters this follow-up's calibration or
+combiner fit. The partition uses only sorted node identifiers and the seed, never labels. This does not prove
+the upstream `model_prod_namecond.pt` checkpoint never saw those node identities; its campaign independence is
+audited, but endpoint independence from all earlier training is not.
+
+Every calibration is fit on the same training rows:
+
+1. campaign-independent model prior `(prior_D, prior_S)`;
+2. affine graph-D calibration;
+3. linear graph-S calibration from the four #3648 structural features;
+4. global per-channel affine Luna calibration;
+5. the dense joint error covariance `(P, C, R)`;
+6. every discriminative or factored decision head.
+
+The common source vector is:
+
+```text
+[prior_D, prior_S, graph_D, graph_S, luna_D, luna_S]
+```
+
+The methods are:
+
+- **JointPosterior:** multinomial LR over the full source vector. This is the train-standardized learned
+  combiner; its raw probability calibration is audited rather than assumed.
+- **Dense correlated Gaussian:** fuse graph and Luna measurements into `N(D,S)`, preserving the fitted
+  prior–measurement cross-covariance. A train-only multinomial bridge estimates `p(decision | D,S)`.
+  Two-dimensional Gauss-Hermite quadrature reports `E[p(decision | Z)]` for `Z ~ N(μ_post,P_post)`, so
+  posterior covariance affects confidence.
+- **D/S linear reference:** apply the same train-only LR bridge to the held row's operating-judge D/S. It is
+  not deployable and not a Bayes ceiling: its error also includes finite training data, LR misspecification,
+  optimisation, and possible incoherence between relation probabilities and relation-specific μ values.
+- **Factored controls:** equal-weight and separability-weighted products of one-dimensional histograms.
+  They are included to expose the cost of pretending correlated sources are independent.
+
+The prior-only, prior+graph, prior+Luna, and all-source rungs are fit for both learned families. This separates
+the graph and cheap-judge contributions without changing held rows.
+
+## Metrics and uncertainty
+
+Report on the same held rows:
+
+- accuracy;
+- multiclass log-loss;
+- ECE with 10 equal-width confidence bins;
+- AURC gated by the top-1 minus top-2 posterior margin;
+- a paired AURC difference, `JointPosterior(all) - Gaussian(all)`.
+
+AURC intervals resample endpoint-connected components. Every row sharing either node is in the same bootstrap
+block, avoiding the false independence assumption of a row bootstrap. The report includes the number of
+blocks and largest block size; a corpus dominated by one component cannot support a useful block-bootstrap
+interval and must be reported as such.
+
+Source separability and the full Pearson correlation matrix are printed from training rows only. A source earns
+its keep through a same-held-set rung/ablation improvement, not through a training correlation alone.
+
+## Scope and non-claims
+
+- This comparison cannot identify whether the Gaussian or joint method recovers the correct eight-way relation.
+- Its labels and D/S bridge share the GPT-5.5 operating judge; it measures fidelity to that judge.
+- The D/S linear reference diagnoses the bridge/representation combination; it does not isolate max-pooling
+  information loss or upper-bound a learned source combiner.
+- Alternative within-judge pooling rows are same-response linear-reference diagnostics, not an across-expert
+  fusion result or a continuous-target selection experiment.
+- Seed 0 is the declared primary node split; additional seeds are refitted sensitivity analyses and must not
+  be pooled as independent rows. One split-specific bootstrap is not evidence of partition robustness.
+- No held labels are used for post-hoc temperature calibration. ECE and log-loss therefore audit the raw
+  cross-entropy-trained probabilities; a future calibrator needs a nested train/calibration partition.
+- A future soft-target head could train against the aggregated three-way probability vector. It should be a
+  separately named estimator, not silently substituted for the existing `JointPosterior`.
+
+Implementation: `run_cheap_judge_joint_posterior.py`. Focused tests:
+`test_cheap_judge_joint_posterior.py`.

--- a/prototypes/mu_cosine/DESIGN_joint_square_root_qr_conditioner.md
+++ b/prototypes/mu_cosine/DESIGN_joint_square_root_qr_conditioner.md
@@ -1,0 +1,162 @@
+# Joint square-root / QR conditioner — inverse-root updates by Householder triangularisation
+
+Strictly, the factors below are covariance/information (precision) factors. A square root of the inverse
+correlation matrix is the standardized, unit-variance special case; the same QR update applies after the state
+and measurements are scaled to correlation coordinates.
+
+## Scope
+
+This is a numerically robust implementation of the **same dense correlated Gaussian conditioner** used by
+`gaussian_condition_update`. It does not change the fusion model, make sources independent, or supply a new
+confidence heuristic. Its purpose is to maintain a triangular square root of the **precision** matrix and to
+accept new conditionally independent measurement blocks without explicitly inverting the posterior covariance.
+
+The name is deliberately descriptive. Potter and Carlson are historical antecedents, but classical Carlson is
+a triangular covariance-root recursion for scalar measurements. The vector, nonzero-cross-covariance algorithm
+here is more accurately called a **joint square-root information / QR conditioner**.
+
+Householder transformations are reflections; Givens transformations are plane rotations. Either can perform
+the orthogonal triangularisation. Householder QR is attractive for dense blocks; Givens is attractive when rows
+arrive one at a time.
+
+For a fixed corpus/rung, `H`, `P`, `C`, and `R` are constant across rows. The coefficient pre-array and its
+Householder reflectors can therefore be compiled once and reused; only the right-hand side changes per row.
+That optimization is exact. By contrast, when a later measurement block is assimilated for the same state,
+the new block must start from the previous `U_post`, because the first block changed `P`. Streaming independent
+blocks this way is algebraically equivalent to one batch QR.
+
+## 1. Correlated static measurement model
+
+Use the PR #3648 residual convention:
+
+```
+e = truth - prior
+v = measurement - H truth
+Cov([e, v]) = [[P, C], [C^T, R]]
+r = measurement - H prior = H e + v
+```
+
+Maintain a factor `U` such that
+
+```
+P^-1 = U^T U.
+```
+
+Conditioning `v` on `e` removes the prior/measurement cross-covariance:
+
+```
+Rc = R - C^T P^-1 C
+J  = H + C^T P^-1
+r | e ~ Normal(J e, Rc).
+```
+
+Using the maintained factor avoids forming `P^-1`:
+
+```
+UC = U C
+Rc = R - (UC)^T (UC)
+J  = H + (UC)^T U.
+```
+
+`Rc` is the Schur complement of `P`. A materially non-positive `Rc` means the proposed joint covariance is
+invalid. Small round-off defects may be regularised; a false statistical covariance must not be hidden.
+
+## 2. Householder pre-array
+
+Let `L L^T = Rc`, and whiten the measurement block:
+
+```
+A = L^-1 J
+b = L^-1 r.
+```
+
+For a zero-mean prior error, `z_prior = 0`. More generally `z_prior = U m_prior`. Form
+
+```
+[ U_prior   z_prior ]
+[ A         b       ].
+```
+
+Apply Householder reflectors to the coefficient columns and the RHS together, without forming `Q`:
+
+```
+Q^T [ U_prior   z_prior ] = [ U_post   z_post ]
+    [ A         b       ]   [ 0        residual ].
+```
+
+Then
+
+```
+Lambda_post = U_post^T U_post
+e_post      = solve(U_post, z_post)
+x_post      = x_prior + e_post.
+```
+
+The implementation normalises the diagonal of `U_post` to be non-negative, making the root deterministic
+under row permutations up to floating-point error.
+
+## 3. Block updates
+
+If several likelihood blocks are conditionally independent, stack all whitened rows at once or feed them
+sequentially by reusing `(U_post, z_post)` as the next prior. Batch and streamed QR are algebraically identical.
+
+The independence condition is **block diagonality of `Rc`**, not raw `R`:
+
+```
+Rc_ij = R_ij - C_i^T P^-1 C_j.
+```
+
+Therefore raw measurement families can be uncorrelated while their conditional residuals remain coupled through
+the shared prior. Estimate and test the off-block entries of `Rc` on held-out, node-disjoint calibration data
+before enabling streamed bundle updates. The state prior is inserted exactly once; never repeat a complete
+`[[P,C_i],[C_i^T,R_i]]` block for every bundle.
+
+The streamed `(U_post,z_post)` state remains in one fixed state coordinate. If every `b_i` is formed relative
+to the original prior origin, carry both `U_post` and `z_post`. If instead the state is recentered at the first
+posterior solution `e_hat`, reset the information RHS to zero and shift a later whitened RHS to
+`b_i - A_i e_hat`; carrying `z_post` and recentering would double-count the earlier block. With nonzero `C`,
+that shift uses the conditional design `J` (through `A=L^-1 J`), not merely the physical observation matrix
+`H`.
+
+## 4. Relationship to other alternatives
+
+- **Compiled dense-gain conditioner:** same posterior and the correct fixed-design throughput baseline; cache
+  `K` and the posterior covariance, then apply only the affine innovation update per row.
+- **JointPosterior:** different statistical model; can learn nonlinear interactions and must be compared on a
+  common held-out decision metric.
+- **Factored PoE / hand weights:** control only; unsafe when shared e5 or judge lineage correlates errors.
+- **Softmax/MoE gating across experts:** learned nonlinear alternative, not a numerical square-root method.
+- **Pooling within a judge:** the current hard `max` over directional or symmetric relation scores is separate
+  from across-expert fusion. Hard max versus weighted or temperature/log-sum-exp pooling deserves its own
+  ablation; the square-root conditioner accepts whichever calibrated channel definition wins.
+
+## 5. Batched CPU/GPU implementation
+
+`joint_square_root_conditioner_torch.py` implements two paths:
+
+- a generic batched design path for different `(U,H,R,C)` matrices;
+- a throughput path that compiles one fixed design with `torch.geqrf`, stores the compact Householder vectors,
+  applies `Q^T` to many innovation right-hand sides with `torch.ormqr`, and never materialises `Q`.
+
+The second path is a valid GPU formulation, but the matched static baseline changes the decision. If
+`P,H,C,R` are fixed, the dense Gaussian gain and posterior covariance can be compiled once; each row then needs
+only the affine innovation update. On the local GTX 1660 SUPER, that compiled dense path beats QR on both CPU
+and CUDA in every tested fixed-design cell. The present two-state/four-measurement case is fastest on CPU dense;
+large batches and states do benefit from CUDA, but CUDA dense remains substantially faster than CUDA QR.
+
+QR's distinct value is carrying a numerically stable information root through changing/sequential blocks. A
+later measurement block must start from `(U_post,z_post)`, so the original static gain is no longer reusable.
+See `REPORT_joint_square_root_qr_benchmark.md` for the matched static table. A separate sequential benchmark is
+required before choosing the root-threading implementation for production.
+
+## 6. Acceptance tests
+
+1. Match `gaussian_condition_update` for random valid dense joint covariances with nonzero `C`.
+2. Match batch and sequential processing when `Rc` is block diagonal.
+3. Be invariant to measurement-row permutations after root-sign normalisation.
+4. Preserve a positive precision root on ill-conditioned but valid problems.
+5. Reject a materially invalid Schur complement.
+6. Measure numerical error versus the dense implementation in float64 and float32 before replacing production
+   code; statistical metrics should be identical within numerical tolerance.
+7. Sweep covariance scales and condition numbers logarithmically; an absolute float32 regularisation floor
+   alone is not evidence of scale-independent stability.

--- a/prototypes/mu_cosine/REPORT_cheap_judge_joint_posterior.md
+++ b/prototypes/mu_cosine/REPORT_cheap_judge_joint_posterior.md
@@ -6,47 +6,53 @@ Run 2026-07-10 from the post-#3648 validation branch. Protocol and non-claims:
 ## Bottom line
 
 The learned `JointPosterior` does **not** establish a win over the dense correlated-Gaussian conditioner plus
-its D/S LR bridge on this declared three-way task. Seed 0 is near-tied; fresh seed 1 significantly favours the
-Gaussian+bridge pipeline. The #3648 dense method therefore remains a strong interpretable baseline rather than
-a control that has already been superseded.
+its D/S LR bridge on this declared three-way task. After both experiments use the same audited, stratum-aware
+node splitter, seeds 0 and 1 are near-tied on both corpora and every paired AURC interval includes zero. The
+#3648 dense method therefore remains a strong interpretable baseline rather than a control that has already
+been superseded.
 
 This is fidelity to GPT-5.5's macro decision (directional / symmetric / other), not independent ground truth.
-The campaign's `cur_rel` cannot be used: it is `subcategory` on all 1,770 rows.
+The raw campaign's `cur_rel` cannot be used: it is `subcategory` on all 1,770 rows; 1,700 rows remain after
+matching the exploratory and fresh campaign views to Luna outputs.
 The reported ECE/log-loss audit raw cross-entropy outputs; no held labels were used for post-hoc calibration.
 
 ## Primary split and headline comparison
 
-Seed 0 partitions nodes before retaining within-side pairs. No held endpoint appears in this follow-up's
-combiner/calibration training. The campaign-independent upstream checkpoint is not audited as node-independent
-from every earlier training source, so this is not an end-to-end unseen-node claim.
+Seed 0 selects the best of 64 outcome-blind node assignments using retained coverage and macro-class strata,
+then retains within-side pairs. No held endpoint appears in this follow-up's combiner/calibration training.
+This endpoint split is not edge-disjoint or k-hop-isolated from the ambient parent graph used to construct graph
+features. The campaign-independent upstream checkpoint is not audited as node-independent from every earlier
+training source, so this is not an end-to-end unseen-node claim.
 
 | corpus | train / held / crossing rows dropped | method | accuracy | log-loss | ECE-10 | margin AURC [component-bootstrap 95% CI] |
 |---|---:|---|---:|---:|---:|---:|
-| exploratory | 329 / 173 / 498 | D/S hard-max linear reference | 0.931 | 0.161 | 0.020 | 0.006 [0.002, 0.013] |
-| | | dense Gaussian + D/S LR bridge, all | **0.879** | **0.331** | 0.071 | **0.025 [0.012, 0.042]** |
-| | | JointPosterior LR, all sources | 0.873 | 0.333 | **0.043** | 0.026 [0.013, 0.045] |
-| | | factored PoE, equal | 0.844 | 0.508 | 0.100 | 0.032 [0.017, 0.050] |
-| | | factored PoE, separability | 0.809 | 0.543 | 0.118 | 0.065 [0.038, 0.097] |
-| fresh | 263 / 108 / 329 | D/S hard-max linear reference | **0.935** | **0.217** | **0.028** | **0.012 [0.003, 0.025]** |
-| | | dense Gaussian + D/S LR bridge, all | **0.787** | **0.573** | **0.062** | **0.084 [0.046, 0.137]** |
-| | | JointPosterior LR, all sources | 0.778 | 0.591 | 0.092 | 0.092 [0.049, 0.146] |
-| | | factored PoE, equal | 0.722 | 0.753 | 0.166 | 0.084 [0.046, 0.128] |
-| | | factored PoE, separability | 0.796 | 0.853 | 0.341 | 0.077 [0.044, 0.119] |
+| exploratory | 365 / 161 / 474 | D/S hard-max linear reference | **0.925** | **0.170** | **0.018** | **0.008 [0.003, 0.016]** |
+| | | dense Gaussian + D/S LR bridge, all | 0.851 | 0.378 | **0.037** | **0.033 [0.018, 0.054]** |
+| | | JointPosterior LR, all sources | **0.870** | **0.377** | 0.071 | 0.035 [0.020, 0.059] |
+| | | factored PoE, equal | 0.795 | 0.596 | 0.143 | 0.043 [0.024, 0.070] |
+| | | factored PoE, separability | 0.770 | 0.584 | 0.109 | 0.077 [0.043, 0.118] |
+| fresh | 262 / 117 / 321 | D/S hard-max linear reference | **0.923** | **0.212** | **0.058** | **0.009 [0.002, 0.021]** |
+| | | dense Gaussian + D/S LR bridge, all | **0.718** | **0.598** | 0.121 | **0.108 [0.069, 0.165]** |
+| | | JointPosterior LR, all sources | 0.701 | 0.660 | **0.113** | 0.113 [0.072, 0.175] |
+| | | factored PoE, equal | 0.726 | 0.808 | 0.135 | 0.118 [0.073, 0.175] |
+| | | factored PoE, separability | 0.650 | 0.817 | 0.156 | 0.146 [0.093, 0.217] |
 
 Paired `AURC(Joint/all) - AURC(Gaussian/all)` (negative favours JointPosterior):
 
-- exploratory: **+0.0008 [-0.0053, +0.0065]**;
-- fresh: **+0.0074 [-0.0123, +0.0280]**.
+- exploratory: **+0.0013 [-0.0061, +0.0081]** (122 blocks; largest 5 rows);
+- fresh: **+0.0058 [-0.0075, +0.0193]** (72 blocks; largest 7 rows).
 
 Partition sensitivity matters. On seed 1, exploratory Gaussian+bridge versus Joint is
-`.897/.326/.070/.033` versus `.903/.272/.019/.021` (accuracy/log-loss/ECE/AURC), paired delta
-`-0.0127 [-0.0403,+0.0030]`; fresh is `.728/.618/.131/.111` versus `.737/.670/.088/.150`, paired delta
-**`+0.0384 [+0.0056,+0.0781]`**, favouring Gaussian+bridge. Seed 0 remains the declared primary split, but
-its near-tie is not a partition-robust equivalence result.
+`.854/.339/.050/.033` versus `.884/.322/.046/.025` (accuracy/log-loss/ECE/AURC), paired delta
+`-0.0085 [-0.0288,+0.0033]` (122 blocks; largest 4); fresh is `.750/.593/.071/.102` versus
+`.759/.618/.080/.104`, paired delta `+0.0022 [-0.0228,+0.0293]` (69 blocks; largest 6). These audited
+splits do not support a method-level AURC difference, but two seeds are not an equivalence study.
 
-The endpoint-component bootstrap had 126 blocks (largest 8 rows) for exploratory and 73 blocks (largest 4)
-for fresh. These blocks are sufficiently dispersed for the interval to be more informative than a row
-bootstrap, though it remains a one-split operating-judge result.
+The endpoint-component bootstrap respects shared endpoints, but AURC can over-emphasize the earliest
+high-confidence errors ([AUGRC, NeurIPS 2024](https://proceedings.neurips.cc/paper_files/paper/2024/file/047c84ec50bd8ea29349b996fc64af4b-Paper-Conference.pdf))
+and its empirical estimator is biased at small held-set sizes
+([population AURC](https://arxiv.org/html/2410.15361v4)). An AUGRC robustness check and more node partitions
+remain follow-up work; the present intervals are one-split operating-judge results.
 
 The D/S linear-reference gap is diagnostic, not a ceiling. It can reflect max-pooling information loss, but
 also finite training data, LR misspecification/optimisation, and incoherence between the judge's relation
@@ -57,39 +63,35 @@ representation ceiling.
 
 | corpus | method family | prior only | +graph | +Luna | all |
 |---|---|---:|---:|---:|---:|
-| exploratory | dense Gaussian + bridge AURC | 0.181 | 0.072 | 0.032 | **0.025** |
-| | JointPosterior AURC | 0.181 | 0.066 | 0.044 | **0.026** |
-| fresh | dense Gaussian + bridge AURC | 0.348 | 0.149 | 0.101 | **0.084** |
-| | JointPosterior AURC | 0.299 | 0.166 | 0.115 | **0.092** |
+| exploratory | dense Gaussian + bridge AURC | 0.202 | 0.071 | 0.040 | **0.033** |
+| | JointPosterior AURC | 0.208 | 0.058 | 0.042 | **0.035** |
+| fresh | dense Gaussian + bridge AURC | 0.388 | 0.197 | 0.143 | **0.108** |
+| | JointPosterior AURC | 0.347 | 0.232 | 0.120 | **0.113** |
 
 The seed-0 all-source point estimate is best for each family, but its paired ablation is conditional on that
 one fitted partition. Deltas are `AURC(all) - AURC(without source)`; negative favours adding the source:
 
 | corpus | family | add graph [95% CI] | add debiased Luna [95% CI] |
 |---|---|---:|---:|
-| exploratory | dense Gaussian + bridge | -0.0073 [-0.0183, +0.0003] | **-0.0469 [-0.0791, -0.0183]** |
-| | JointPosterior | **-0.0177 [-0.0423, -0.0025]** | **-0.0402 [-0.0768, -0.0099]** |
-| fresh | dense Gaussian + bridge | -0.0163 [-0.0471, +0.0076] | **-0.0644 [-0.1337, -0.0133]** |
-| | JointPosterior | -0.0237 [-0.0815, +0.0325] | **-0.0746 [-0.1380, -0.0307]** |
+| exploratory | dense Gaussian + bridge | -0.0068 [-0.0166, +0.0010] | **-0.0373 [-0.0659, -0.0114]** |
+| | JointPosterior | -0.0074 [-0.0215, +0.0040] | **-0.0231 [-0.0452, -0.0059]** |
+| fresh | dense Gaussian + bridge | **-0.0357 [-0.0778, -0.0055]** | **-0.0888 [-0.1592, -0.0324]** |
+| | JointPosterior | -0.0067 [-0.0336, +0.0215] | **-0.1188 [-0.1864, -0.0514]** |
 
-Conditional on the seed-0 fitted split, debiased Luna's interval favours inclusion in all four cells. This is
-not robustness across node partitions: a seed-1 sensitivity makes fresh Joint add-Luna inconclusive and fresh
-Joint add-graph harmful (`+0.0441 [+0.0104,+0.0806]`); fresh Joint add-Luna becomes
-`-0.0739 [-0.1573,+0.0007]`. Graph's seed-0 point estimate is beneficial in all four, but its interval excludes
-zero only for exploratory JointPosterior. The result is not evidence of source independence. On exploratory
-training
-rows, `corr(graph_S,luna_S)=+0.68`,
-`corr(graph_D,luna_D)=+0.60`, and `corr(prior_D,graph_D)=+0.58`. On fresh, the corresponding graph-D/Luna-D
-correlation is +0.56. The learned joint head and fitted cross-covariance can price this redundancy; a factored
+Debiased Luna's interval favours inclusion in all four seed-0 cells and all four audited seed-1 cells. Graph's
+seed-0 point estimate is beneficial in all four, but its interval excludes zero only for fresh Gaussian; the
+same pattern holds at seed 1. This two-seed stability remains descriptive and is not evidence of source
+independence. On exploratory training rows, `corr(graph_S,luna_S)=+0.60`,
+`corr(graph_D,luna_D)=+0.63`, and `corr(prior_D,graph_D)=+0.40`. On fresh, the corresponding graph-D/Luna-D
+correlation is +0.65. The learned joint head and fitted cross-covariance can price this redundancy; a factored
 control cannot.
 
-The separability-weighted factored control illustrates why one metric is insufficient: on fresh it has high
-accuracy and low AURC, but its log-loss 0.853 and ECE 0.341 reveal severe miscalibration. It is not a preferred
-combiner.
+The factored controls illustrate why one metric is insufficient: fresh equal-weight PoE has slightly higher
+accuracy than both joint methods, but worse log-loss and ECE than either. It is not a preferred combiner.
 
 The hard macro target resolves exact ties in fixed class order (directional, symmetric, other). Across the
-1,770-row campaign there are 7 exact top ties and 41 normalized top-two margins below 0.02. The result JSON now
-persists each comparison row's macro vector, margin, tie flag, and train/held/cross-dropped membership.
+1,700-row matched campaign there are 7 exact top ties and 41 normalized top-two margins below 0.02. The result
+JSON persists each comparison row's macro vector, margin, tie flag, and train/held/cross-dropped membership.
 
 ## Within-judge pooling diagnostic
 
@@ -98,12 +100,12 @@ scores inside **one** GPT-5.5 response. They are not ways of choosing among prio
 
 | corpus | linear-reference pooling | full-corpus mean D/S shift | full-corpus D/S corr | accuracy | log-loss | AURC |
 |---|---|---:|---:|---:|---:|---:|
-| exploratory | hard max | 0 / 0 | 1 / 1 | **0.931** | **0.161** | **0.006** |
-| | probability weighted | -0.052 / -0.028 | 0.983 / 0.998 | 0.919 | **0.161** | **0.006** |
-| | softmax `T=0.10` | -0.018 / -0.014 | 0.998 / 0.998 | 0.925 | 0.164 | 0.007 |
-| fresh | hard max | 0 / 0 | 1 / 1 | **0.935** | **0.217** | 0.012 |
-| | probability weighted | -0.073 / -0.052 | 0.982 / 0.997 | 0.889 | 0.251 | 0.016 |
-| | softmax `T=0.10` | -0.030 / -0.019 | 0.998 / 0.999 | **0.935** | 0.223 | **0.011** |
+| exploratory | hard max | 0 / 0 | 1 / 1 | **0.925** | **0.170** | **0.008** |
+| | probability weighted | -0.052 / -0.028 | 0.983 / 0.998 | 0.919 | 0.186 | 0.010 |
+| | softmax `T=0.10` | -0.018 / -0.014 | 0.998 / 0.998 | 0.919 | 0.177 | 0.009 |
+| fresh | hard max | 0 / 0 | 1 / 1 | **0.923** | **0.212** | **0.009** |
+| | probability weighted | -0.073 / -0.052 | 0.982 / 0.997 | 0.906 | 0.255 | 0.016 |
+| | softmax `T=0.10` | -0.030 / -0.019 | 0.998 / 0.999 | **0.923** | 0.214 | 0.010 |
 
 In this same-response macro-decision diagnostic at `T=0.10`, no alternative has a clear point improvement over
 hard max. The shifts/correlations use the full matched corpus, probability-weighted pooling reuses probabilities
@@ -118,7 +120,7 @@ cd prototypes/mu_cosine
 python3 test_cheap_judge_joint_posterior.py
 python3 run_cheap_judge_joint_posterior.py \
   --ckpt model_prod_namecond.pt \
-  --seed 0 --held-frac 0.40 --epochs 400 --boot 500 \
+  --seed 0 --held-frac 0.40 --split-candidates 64 --epochs 400 --boot 500 \
   --pool-temperature 0.10 \
   --out /tmp/cheap_judge_joint_posterior_seed0.json
 ```

--- a/prototypes/mu_cosine/REPORT_cheap_judge_joint_posterior.md
+++ b/prototypes/mu_cosine/REPORT_cheap_judge_joint_posterior.md
@@ -1,0 +1,131 @@
+# Cheap-judge JointPosterior comparison — node-disjoint combiner/calibration result
+
+Run 2026-07-10 from the post-#3648 validation branch. Protocol and non-claims:
+`DESIGN_cheap_judge_joint_posterior.md`.
+
+## Bottom line
+
+The learned `JointPosterior` does **not** establish a win over the dense correlated-Gaussian conditioner plus
+its D/S LR bridge on this declared three-way task. Seed 0 is near-tied; fresh seed 1 significantly favours the
+Gaussian+bridge pipeline. The #3648 dense method therefore remains a strong interpretable baseline rather than
+a control that has already been superseded.
+
+This is fidelity to GPT-5.5's macro decision (directional / symmetric / other), not independent ground truth.
+The campaign's `cur_rel` cannot be used: it is `subcategory` on all 1,770 rows.
+The reported ECE/log-loss audit raw cross-entropy outputs; no held labels were used for post-hoc calibration.
+
+## Primary split and headline comparison
+
+Seed 0 partitions nodes before retaining within-side pairs. No held endpoint appears in this follow-up's
+combiner/calibration training. The campaign-independent upstream checkpoint is not audited as node-independent
+from every earlier training source, so this is not an end-to-end unseen-node claim.
+
+| corpus | train / held / crossing rows dropped | method | accuracy | log-loss | ECE-10 | margin AURC [component-bootstrap 95% CI] |
+|---|---:|---|---:|---:|---:|---:|
+| exploratory | 329 / 173 / 498 | D/S hard-max linear reference | 0.931 | 0.161 | 0.020 | 0.006 [0.002, 0.013] |
+| | | dense Gaussian + D/S LR bridge, all | **0.879** | **0.331** | 0.071 | **0.025 [0.012, 0.042]** |
+| | | JointPosterior LR, all sources | 0.873 | 0.333 | **0.043** | 0.026 [0.013, 0.045] |
+| | | factored PoE, equal | 0.844 | 0.508 | 0.100 | 0.032 [0.017, 0.050] |
+| | | factored PoE, separability | 0.809 | 0.543 | 0.118 | 0.065 [0.038, 0.097] |
+| fresh | 263 / 108 / 329 | D/S hard-max linear reference | **0.935** | **0.217** | **0.028** | **0.012 [0.003, 0.025]** |
+| | | dense Gaussian + D/S LR bridge, all | **0.787** | **0.573** | **0.062** | **0.084 [0.046, 0.137]** |
+| | | JointPosterior LR, all sources | 0.778 | 0.591 | 0.092 | 0.092 [0.049, 0.146] |
+| | | factored PoE, equal | 0.722 | 0.753 | 0.166 | 0.084 [0.046, 0.128] |
+| | | factored PoE, separability | 0.796 | 0.853 | 0.341 | 0.077 [0.044, 0.119] |
+
+Paired `AURC(Joint/all) - AURC(Gaussian/all)` (negative favours JointPosterior):
+
+- exploratory: **+0.0008 [-0.0053, +0.0065]**;
+- fresh: **+0.0074 [-0.0123, +0.0280]**.
+
+Partition sensitivity matters. On seed 1, exploratory Gaussian+bridge versus Joint is
+`.897/.326/.070/.033` versus `.903/.272/.019/.021` (accuracy/log-loss/ECE/AURC), paired delta
+`-0.0127 [-0.0403,+0.0030]`; fresh is `.728/.618/.131/.111` versus `.737/.670/.088/.150`, paired delta
+**`+0.0384 [+0.0056,+0.0781]`**, favouring Gaussian+bridge. Seed 0 remains the declared primary split, but
+its near-tie is not a partition-robust equivalence result.
+
+The endpoint-component bootstrap had 126 blocks (largest 8 rows) for exploratory and 73 blocks (largest 4)
+for fresh. These blocks are sufficiently dispersed for the interval to be more informative than a row
+bootstrap, though it remains a one-split operating-judge result.
+
+The D/S linear-reference gap is diagnostic, not a ceiling. It can reflect max-pooling information loss, but
+also finite training data, LR misspecification/optimisation, and incoherence between the judge's relation
+probabilities and relation-specific μ values. A flexible cross-fitted decoder would be needed to estimate a
+representation ceiling.
+
+## Source rungs and dependence
+
+| corpus | method family | prior only | +graph | +Luna | all |
+|---|---|---:|---:|---:|---:|
+| exploratory | dense Gaussian + bridge AURC | 0.181 | 0.072 | 0.032 | **0.025** |
+| | JointPosterior AURC | 0.181 | 0.066 | 0.044 | **0.026** |
+| fresh | dense Gaussian + bridge AURC | 0.348 | 0.149 | 0.101 | **0.084** |
+| | JointPosterior AURC | 0.299 | 0.166 | 0.115 | **0.092** |
+
+The seed-0 all-source point estimate is best for each family, but its paired ablation is conditional on that
+one fitted partition. Deltas are `AURC(all) - AURC(without source)`; negative favours adding the source:
+
+| corpus | family | add graph [95% CI] | add debiased Luna [95% CI] |
+|---|---|---:|---:|
+| exploratory | dense Gaussian + bridge | -0.0073 [-0.0183, +0.0003] | **-0.0469 [-0.0791, -0.0183]** |
+| | JointPosterior | **-0.0177 [-0.0423, -0.0025]** | **-0.0402 [-0.0768, -0.0099]** |
+| fresh | dense Gaussian + bridge | -0.0163 [-0.0471, +0.0076] | **-0.0644 [-0.1337, -0.0133]** |
+| | JointPosterior | -0.0237 [-0.0815, +0.0325] | **-0.0746 [-0.1380, -0.0307]** |
+
+Conditional on the seed-0 fitted split, debiased Luna's interval favours inclusion in all four cells. This is
+not robustness across node partitions: a seed-1 sensitivity makes fresh Joint add-Luna inconclusive and fresh
+Joint add-graph harmful (`+0.0441 [+0.0104,+0.0806]`); fresh Joint add-Luna becomes
+`-0.0739 [-0.1573,+0.0007]`. Graph's seed-0 point estimate is beneficial in all four, but its interval excludes
+zero only for exploratory JointPosterior. The result is not evidence of source independence. On exploratory
+training
+rows, `corr(graph_S,luna_S)=+0.68`,
+`corr(graph_D,luna_D)=+0.60`, and `corr(prior_D,graph_D)=+0.58`. On fresh, the corresponding graph-D/Luna-D
+correlation is +0.56. The learned joint head and fitted cross-covariance can price this redundancy; a factored
+control cannot.
+
+The separability-weighted factored control illustrates why one metric is insufficient: on fresh it has high
+accuracy and low AURC, but its log-loss 0.853 and ECE 0.341 reveal severe miscalibration. It is not a preferred
+combiner.
+
+The hard macro target resolves exact ties in fixed class order (directional, symmetric, other). Across the
+1,770-row campaign there are 7 exact top ties and 41 normalized top-two margins below 0.02. The result JSON now
+persists each comparison row's macro vector, margin, tie flag, and train/held/cross-dropped membership.
+
+## Within-judge pooling diagnostic
+
+Hard max, probability-weighted pooling, and temperature-softmax pooling (`T=0.10`) are reductions of relation
+scores inside **one** GPT-5.5 response. They are not ways of choosing among prior/graph/Luna experts.
+
+| corpus | linear-reference pooling | full-corpus mean D/S shift | full-corpus D/S corr | accuracy | log-loss | AURC |
+|---|---|---:|---:|---:|---:|---:|
+| exploratory | hard max | 0 / 0 | 1 / 1 | **0.931** | **0.161** | **0.006** |
+| | probability weighted | -0.052 / -0.028 | 0.983 / 0.998 | 0.919 | **0.161** | **0.006** |
+| | softmax `T=0.10` | -0.018 / -0.014 | 0.998 / 0.998 | 0.925 | 0.164 | 0.007 |
+| fresh | hard max | 0 / 0 | 1 / 1 | **0.935** | **0.217** | 0.012 |
+| | probability weighted | -0.073 / -0.052 | 0.982 / 0.997 | 0.889 | 0.251 | 0.016 |
+| | softmax `T=0.10` | -0.030 / -0.019 | 0.998 / 0.999 | **0.935** | 0.223 | **0.011** |
+
+In this same-response macro-decision diagnostic at `T=0.10`, no alternative has a clear point improvement over
+hard max. The shifts/correlations use the full matched corpus, probability-weighted pooling reuses probabilities
+that define the macro target, and no paired pooling-difference intervals were computed. This does not establish
+hard max as the best continuous target. A production comparison must regenerate the prior and every judge
+measurement under one pooling rule; mixing reductions changes the estimand.
+
+## Reproduction
+
+```bash
+cd prototypes/mu_cosine
+python3 test_cheap_judge_joint_posterior.py
+python3 run_cheap_judge_joint_posterior.py \
+  --ckpt model_prod_namecond.pt \
+  --seed 0 --held-frac 0.40 --epochs 400 --boot 500 \
+  --pool-temperature 0.10 \
+  --out /tmp/cheap_judge_joint_posterior_seed0.json
+```
+
+Inputs are the existing local campaign artifacts:
+`/tmp/mu_data/campaign_scored.tsv`, `/tmp/mu_data/campaign_scored_luna.tsv`, and the graph/e5 artifacts used by
+`load_campaign_datasets`. No new judge calls are made.
+
+Eight focused tests pass. They cover macro aggregation/ties, combiner endpoint disjointness, endpoint-component
+construction, component bootstrap, Gaussian bridge quadrature, and alternative within-judge pooling.

--- a/prototypes/mu_cosine/REPORT_cheap_judge_post3648_validation.md
+++ b/prototypes/mu_cosine/REPORT_cheap_judge_post3648_validation.md
@@ -8,7 +8,8 @@ matched-cost proxy, Gaussian NLL, and macro-decision AURC answer different quest
 
 1. **Do not retain “k≥4 wins at new-corpus scale.”** After nesting pseudo-target generation outside the paid
    validation fold, no exact-budget cheap arm has a positive training-subsample interval excluding zero. At
-   `n=160,k=2`, S is nominally worse on both corpora.
+   `n=160,k=2`, all 10 S subsample deltas are negative on both corpora, but this fixed-partition precision
+   diagnostic is not an inferential harm claim.
 2. **Free graph_S is real, but mostly a pre-Luna channel.** Its free-only S-NLL gain is positive across all 40
    node partitions and the fixed held-node interval excludes zero on both corpora. Its increment after debiased
    Luna is small and both fixed intervals include zero. This tests graph_S as a final-posterior input, not the
@@ -16,10 +17,10 @@ matched-cost proxy, Gaussian NLL, and macro-decision AURC answer different quest
 3. **Debiased Luna is still valuable, but task- and partition-dependent.** It dominates the analytic D/S
    Gaussian ladder. Macro-decision AURC favours it on seed 0, but one fresh seed-1 Joint interval includes zero.
    The leakage-free matched-cost ridge proxy does not show a general spending advantage for cheap labels.
-4. **JointPosterior does not establish a win over Gaussian+bridge.** Seed 0 is near-tied; on fresh seed 1 the
-   paired AURC interval significantly favours Gaussian+bridge.
+4. **JointPosterior does not establish a win over Gaussian+bridge.** After both runners use the same audited,
+   stratum-aware node splitter, paired AURC intervals include zero on both corpora at seeds 0 and 1.
 5. **The joint square-root/QR conditioner is numerically equivalent and GPU-capable, but not the fixed-design
-   throughput winner.** A matched compiled dense correlated gain beat QR on CPU and CUDA in every static cell.
+   throughput winner.** A matched design-cached dense correlated gain beat QR on CPU and CUDA in every static cell.
    Reserve root-threading QR for changing/sequential blocks, pending their own matched benchmark.
 
 ## 1. Matched-cost proxy: strict node-disjoint primary result
@@ -44,21 +45,22 @@ Coverage at split seed 0:
 
 Only untruncated, exact-budget cells support a matched-cost claim. Deltas below are candidate minus `A: 5.5
 only`; intervals are percentile bootstraps over the 10 paired training-subsample replicates and condition on
-this one fixed held-node split. They are not population intervals over possible node partitions.
+this one fixed held-node split. The column therefore reports **subsample precision, not an inferential CI**;
+it is not a population interval over possible node partitions.
 
-| corpus | budget / ratio | D delta [95% CI] | S delta [95% CI] | interpretation |
+| corpus | budget / ratio | D delta [95% subsample precision] | S delta [95% subsample precision] | interpretation |
 |---|---|---:|---:|---|
 | exploratory | n=80, k=2 | -0.007 [-0.046,+0.021] | -0.011 [-0.052,+0.042] | no nominal improvement |
 | exploratory | n=80, k=4 | -0.037 [-0.102,+0.027] | -0.049 [-0.114,+0.030] | no nominal improvement |
 | fresh | n=80, k=2 | -0.003 [-0.028,+0.020] | -0.012 [-0.035,+0.011] | no nominal improvement |
 | fresh | n=80, k=4 | +0.023 [-0.026,+0.065] | -0.001 [-0.043,+0.043] | no nominal improvement |
-| exploratory | n=160, k=2 | -0.023 [-0.076,+0.040] | **-0.050 [-0.099,-0.010]** | nominal S harm |
-| fresh | n=160, k=2 | -0.029 [-0.073,+0.006] | **-0.062 [-0.103,-0.021]** | nominal S harm |
+| exploratory | n=160, k=2 | -0.023 [-0.076,+0.040] | -0.050 [-0.099,-0.010] | negative in these subsamples; no population harm claim |
+| fresh | n=160, k=2 | -0.029 [-0.073,+0.006] | -0.062 [-0.103,-0.021] | negative in these subsamples; no population harm claim |
 
 The free control is also a tradeoff, not a universal winner. At `n=80`, `A+free−A` is exploratory D
-**-0.039 [-0.082,-0.005]**, S -0.012 [-0.091,+0.067], and fresh D +0.046 [-0.007,+0.088], S
-**-0.071 [-0.119,-0.025]**. At fresh `n=160` it improves D **+0.019 [+0.004,+0.034]** while hurting S
-**-0.057 [-0.108,-0.014]**. Direct `k=4−A+free` at `n=80` is exploratory D +0.002 [-0.062,+0.070],
+-0.039 [-0.082,-0.005], S -0.012 [-0.091,+0.067], and fresh D +0.046 [-0.007,+0.088], S
+-0.071 [-0.119,-0.025]. At fresh `n=160` its D/S deltas are +0.019 [+0.004,+0.034] and
+-0.057 [-0.108,-0.014]. Direct `k=4−A+free` at `n=80` is exploratory D +0.002 [-0.062,+0.070],
 S -0.037 [-0.084,+0.005], and fresh D -0.023 [-0.078,+0.035], S +0.070 [-0.004,+0.145]. No paid
 allocation Pareto-dominates the other across endpoints and corpora.
 
@@ -118,21 +120,23 @@ run, within-stratum D correlation improves from Luna-head 0.373/0.398 to fused 0
 
 The campaign's `cur_rel` is constant `subcategory`, so an eight-way relation comparison would be false. The
 declared bridge instead predicts the operating judge's three-way macro decision (directional/symmetric/other)
-from the identical source vector `[prior_D,prior_S,graph_D,graph_S,luna_D,luna_S]` on one node-disjoint
-combiner/calibration split. The upstream checkpoint is campaign-independent but not audited as endpoint-
-independent from all earlier training.
+from the identical source vector `[prior_D,prior_S,graph_D,graph_S,luna_D,luna_S]` on one audited,
+stratum-aware node-disjoint combiner/calibration split. Endpoint labels are isolated, but graph features still
+use the ambient parent graph; this is not edge-disjoint or k-hop-isolated. The upstream checkpoint is
+campaign-independent but not audited as endpoint-independent from all earlier training.
 
-| seed / corpus | Gaussian + D/S LR bridge acc / log-loss / ECE / AURC | JointPosterior acc / log-loss / ECE / AURC | paired AURC Joint−Gaussian [95% CI] |
-|---|---:|---:|---:|
-| 0 / exploratory | .879 / .331 / .071 / .025 | .873 / .333 / .043 / .026 | +.0008 [-.0053,+.0065] |
-| 0 / fresh | .787 / .573 / .062 / .084 | .778 / .591 / .092 / .092 | +.0074 [-.0123,+.0280] |
-| 1 / exploratory | .897 / .326 / .070 / .033 | .903 / .272 / .019 / .021 | -.0127 [-.0403,+.0030] |
-| 1 / fresh | .728 / .618 / .131 / .111 | .737 / .670 / .088 / .150 | **+.0384 [+.0056,+.0781]** |
+| seed / corpus | Gaussian + D/S LR bridge acc / log-loss / ECE / AURC | JointPosterior acc / log-loss / ECE / AURC | paired AURC Joint−Gaussian [95% CI] | endpoint blocks / largest |
+|---|---:|---:|---:|---:|
+| 0 / exploratory | .851 / .378 / .037 / .033 | .870 / .377 / .071 / .035 | +.0013 [-.0061,+.0081] | 122 / 5 |
+| 0 / fresh | .718 / .598 / .121 / .108 | .701 / .660 / .113 / .113 | +.0058 [-.0075,+.0193] | 72 / 7 |
+| 1 / exploratory | .854 / .339 / .050 / .033 | .884 / .322 / .046 / .025 | -.0085 [-.0288,+.0033] | 122 / 4 |
+| 1 / fresh | .750 / .593 / .071 / .102 | .759 / .618 / .080 / .104 | +.0022 [-.0228,+.0293] | 69 / 6 |
 
-On seed 0, add-Luna intervals are below zero in all four family/corpus cells; fresh Joint add-Luna includes zero
-on seed 1. Hard max, probability-weighted pooling, and temperature-softmax pooling were audited **within one
-judge** as same-response point diagnostics at `T=.10`, without paired selection intervals; this does not prove
-hard max is the best continuous target. These are not expert-selection rules. See
+Add-Luna intervals are below zero in all four family/corpus cells at both audited seeds. AURC remains a
+small-sample, early-error-sensitive metric; AUGRC is an explicit robustness follow-up, not a post-hoc replacement
+for this table. Hard max, probability-weighted pooling, and temperature-softmax pooling were audited **within
+one judge** as same-response point diagnostics at `T=.10`, without paired selection intervals; this does not
+prove hard max is the best continuous target. These are not expert-selection rules. See
 `REPORT_cheap_judge_joint_posterior.md`.
 
 ## 5. Joint square-root/QR conditioner
@@ -144,11 +148,13 @@ invariant after sign normalisation, and gives identical batch/streamed results f
 blocks.
 
 The PyTorch backend adds generic batched designs, a fixed-design compact `geqrf`/`ormqr` path that never forms
-Q, and the matched compiled dense-gain baseline. Twenty-four combined tests pass, including CPU/CUDA
-float32/float64 parity and protection against caller-side mutation of a compiled `H`. On the local GTX 1660
+Q, and the matched design-cached dense-gain baseline. Twenty-nine combined tests pass, including CPU/CUDA
+float32/float64 parity, distinct-design CUDA batches, sequential CUDA root threading, and protection against
+caller-side mutation of compiled coefficient inputs. On the local GTX 1660
 SUPER, static `n=2,m=4` is fastest on CPU dense: 0.058 ms for one row and 0.113 ms for 4096 rows, versus CPU QR
 0.220/0.596 ms. Large batches do benefit from CUDA dense: 0.129 ms at `n=32,m=32,batch=4096` and 0.131 ms at
-`n=128,m=32`, but CUDA QR remains slower at 0.543/1.121 ms.
+`n=128,m=32`, but CUDA QR remains slower at 0.543/1.121 ms. These are single-run, on-device compute point
+measurements; they exclude transfer and do not benchmark the sequential regime where QR carries the updated root.
 See `DESIGN_joint_square_root_qr_conditioner.md` and
 `REPORT_joint_square_root_qr_benchmark.md`.
 

--- a/prototypes/mu_cosine/REPORT_cheap_judge_post3648_validation.md
+++ b/prototypes/mu_cosine/REPORT_cheap_judge_post3648_validation.md
@@ -1,0 +1,161 @@
+# Cheap-judge pipeline after PR #3648: corrected validation and handoff
+
+Run 2026-07-10 on `codex/post-3648-validation`. This report supersedes the merged PR's deployment headline;
+it does not rewrite the historical PR record. Each section names its target and uncertainty unit because the
+matched-cost proxy, Gaussian NLL, and macro-decision AURC answer different questions.
+
+## Bottom line
+
+1. **Do not retain “k≥4 wins at new-corpus scale.”** After nesting pseudo-target generation outside the paid
+   validation fold, no exact-budget cheap arm has a positive training-subsample interval excluding zero. At
+   `n=160,k=2`, S is nominally worse on both corpora.
+2. **Free graph_S is real, but mostly a pre-Luna channel.** Its free-only S-NLL gain is positive across all 40
+   node partitions and the fixed held-node interval excludes zero on both corpora. Its increment after debiased
+   Luna is small and both fixed intervals include zero.
+3. **Debiased Luna is still valuable, but task- and partition-dependent.** It dominates the analytic D/S
+   Gaussian ladder. Macro-decision AURC favours it on seed 0, but one fresh seed-1 Joint interval includes zero.
+   The leakage-free matched-cost ridge proxy does not show a general spending advantage for cheap labels.
+4. **JointPosterior does not establish a win over Gaussian+bridge.** Seed 0 is near-tied; on fresh seed 1 the
+   paired AURC interval significantly favours Gaussian+bridge.
+5. **The joint square-root/QR conditioner is numerically equivalent and GPU-capable, but not the fixed-design
+   throughput winner.** A matched compiled dense correlated gain beat QR on CPU and CUDA in every static cell.
+   Reserve root-threading QR for changing/sequential blocks, pending their own matched benchmark.
+
+## 1. Matched-cost proxy: strict node-disjoint primary result
+
+Protocol fixes:
+
+- campaign-independent prior;
+- strict node partition (`held-node-frac=0.40`), all crossing pairs discarded;
+- exact realised-spend assertions and integral price ratios;
+- one stable corpus/replicate permutation, invariant to `--n` order;
+- identity-keyed paid-label inner split; calibration/covariance/pseudo-target/ridge/scaler fit on paid
+  inner-train, lambda scored only on paid inner-valid true labels, then full-pipeline refit on all paid rows;
+- 10 paired training-subsample replicates;
+- an `A+free` control using the same `n` paid 5.5 labels and all remaining zero-cost prior+graph targets.
+
+Coverage at split seed 0:
+
+| corpus | train pairs | held pairs | crossing pairs dropped |
+|---|---:|---:|---:|
+| exploratory | 377 | 168 | 455 |
+| fresh | 242 | 99 | 359 |
+
+Only untruncated, exact-budget cells support a matched-cost claim. Deltas below are candidate minus `A: 5.5
+only`; intervals are percentile bootstraps over the 10 paired training-subsample replicates and condition on
+this one fixed held-node split. They are not population intervals over possible node partitions.
+
+| corpus | budget / ratio | D delta [95% CI] | S delta [95% CI] | interpretation |
+|---|---|---:|---:|---|
+| exploratory | n=80, k=2 | -0.007 [-0.046,+0.021] | -0.011 [-0.052,+0.042] | no nominal improvement |
+| exploratory | n=80, k=4 | -0.037 [-0.102,+0.027] | -0.049 [-0.114,+0.030] | no nominal improvement |
+| fresh | n=80, k=2 | -0.003 [-0.028,+0.020] | -0.012 [-0.035,+0.011] | no nominal improvement |
+| fresh | n=80, k=4 | +0.023 [-0.026,+0.065] | -0.001 [-0.043,+0.043] | no nominal improvement |
+| exploratory | n=160, k=2 | -0.023 [-0.076,+0.040] | **-0.050 [-0.099,-0.010]** | nominal S harm |
+| fresh | n=160, k=2 | -0.029 [-0.073,+0.006] | **-0.062 [-0.103,-0.021]** | nominal S harm |
+
+The free control is also a tradeoff, not a universal winner. At `n=80`, `A+free−A` is exploratory D
+**-0.039 [-0.082,-0.005]**, S -0.012 [-0.091,+0.067], and fresh D +0.046 [-0.007,+0.088], S
+**-0.071 [-0.119,-0.025]**. At fresh `n=160` it improves D **+0.019 [+0.004,+0.034]** while hurting S
+**-0.057 [-0.108,-0.014]**. Direct `k=4−A+free` at `n=80` is exploratory D +0.002 [-0.062,+0.070],
+S -0.037 [-0.084,+0.005], and fresh D -0.023 [-0.078,+0.035], S +0.070 [-0.004,+0.145]. No paid
+allocation Pareto-dominates the other across endpoints and corpora.
+
+The intervals above are **nominal training-subsample intervals**, not confirmation: they hold the node
+partition and held outcomes fixed and do not adjust for endpoint multiplicity or multiple cells/endpoints.
+The descendant-disjoint mode remains available to reproduce the historical split but has not been rerun under
+the final nested protocol. Next work should repeat the exact-budget cells across preregistered node partitions
+and use held-node resampling for correlation deltas.
+
+Exact reproduction:
+
+```bash
+python3 -u prototypes/mu_cosine/sim_matched_cost.py \
+  --ckpt prototypes/mu_cosine/model_prod_namecond.pt \
+  --split node-disjoint --split-seed 0 --held-node-frac 0.40 --split-candidates 64 \
+  --n 80 160 --k 2 4 --reps 10 --seed 0 --bootstrap-reps 5000 --confidence 0.95
+```
+
+SHA-256: prior checkpoint `c1cfc3a3827e42a1993f4286b6a881aee7ff10eb56a76367735b9ec8fdf11f7d`;
+GPT-5.5 campaign `c2acf399aadd35c3797171d5b42d64e45b07055802092cc28becf308d460ef09`;
+Luna campaign `a8d951b4fd05f0ca111fbe9d9c23881bb47b790ccb335731113bfd4ae77ffe6e`;
+exploratory e5 `037396a1d6552892d3d6aa04b3cc12bc6d5e6a532d3697e28da1f28e04810700`;
+fresh e5 `ab51eb5d07cdd3bed34112a1d92005fcd3f8c46245cf068a7ab0a225afc6cd6b`.
+
+## 2. graph_S: 40 node partitions plus held-node uncertainty
+
+Mean value is baseline S-NLL minus augmented S-NLL. Split SD is descriptive partition stability. The fixed
+seed-0 interval uses paired two-endpoint/pigeonhole node resampling on the held partition.
+
+| corpus / graph_S role | mean ± split SD | positive split seeds | fixed estimate [95% node CI] |
+|---|---:|---:|---:|
+| exploratory, free-only | +0.4034 ± 0.0605 | 40/40 | **+0.3586 [+0.1537,+0.5519]** |
+| fresh, free-only | +0.6477 ± 0.0807 | 40/40 | **+0.6565 [+0.2723,+1.0383]** |
+| exploratory, after Luna | +0.0968 ± 0.0353 | 40/40 | +0.0874 [-0.0608,+0.2668] |
+| fresh, after Luna | +0.0765 ± 0.0417 | 39/40 | +0.0219 [-0.1759,+0.2067] |
+
+This confirms graph_S as useful free supervision. It does not confirm a material increment once debiased Luna
+is present.
+
+## 3. Corrected Luna campaign
+
+`fine_tune_fused_head_luna.py` now separates the trainable channel-head initialisation/anchor from the
+campaign-independent Gaussian prior and performs global train-only affine Luna calibration before covariance
+fitting. It also has an analytic-only mode and an explicit historical reproduction mode.
+
+Corrected held NLL (`prior | +graph | +Luna`) is exploratory `-0.285 | -0.568 | -1.493` and fresh
+`+0.405 | -0.018 | -1.101`; Luna's incremental value is +0.925/+1.083. In the deterministic 800-step head
+run, within-stratum D correlation improves from Luna-head 0.373/0.398 to fused 0.402/0.467. S does not improve:
+0.369/0.296 to 0.361/0.261. Full historical comparison, provenance, and reproduction commands are in
+`REPORT_luna_campaign.md`.
+
+## 4. Same-split JointPosterior comparison
+
+The campaign's `cur_rel` is constant `subcategory`, so an eight-way relation comparison would be false. The
+declared bridge instead predicts the operating judge's three-way macro decision (directional/symmetric/other)
+from the identical source vector `[prior_D,prior_S,graph_D,graph_S,luna_D,luna_S]` on one node-disjoint
+combiner/calibration split. The upstream checkpoint is campaign-independent but not audited as endpoint-
+independent from all earlier training.
+
+| seed / corpus | Gaussian + D/S LR bridge acc / log-loss / ECE / AURC | JointPosterior acc / log-loss / ECE / AURC | paired AURC Joint−Gaussian [95% CI] |
+|---|---:|---:|---:|
+| 0 / exploratory | .879 / .331 / .071 / .025 | .873 / .333 / .043 / .026 | +.0008 [-.0053,+.0065] |
+| 0 / fresh | .787 / .573 / .062 / .084 | .778 / .591 / .092 / .092 | +.0074 [-.0123,+.0280] |
+| 1 / exploratory | .897 / .326 / .070 / .033 | .903 / .272 / .019 / .021 | -.0127 [-.0403,+.0030] |
+| 1 / fresh | .728 / .618 / .131 / .111 | .737 / .670 / .088 / .150 | **+.0384 [+.0056,+.0781]** |
+
+On seed 0, add-Luna intervals are below zero in all four family/corpus cells; fresh Joint add-Luna includes zero
+on seed 1. Hard max, probability-weighted pooling, and temperature-softmax pooling were audited **within one
+judge** as same-response point diagnostics at `T=.10`, without paired selection intervals; this does not prove
+hard max is the best continuous target. These are not expert-selection rules. See
+`REPORT_cheap_judge_joint_posterior.md`.
+
+## 5. Joint square-root/QR conditioner
+
+The NumPy reference maintains `P^-1 = U^T U`, decorrelates nonzero prior/measurement cross-covariance through
+the Schur complement, Cholesky-whitens each conditionally independent block, and Householder-triangularises the
+information pre-array. It matches the dense conditioner for random nonzero-C problems, is row-permutation
+invariant after sign normalisation, and gives identical batch/streamed results for conditionally independent
+blocks.
+
+The PyTorch backend adds generic batched designs, a fixed-design compact `geqrf`/`ormqr` path that never forms
+Q, and the matched compiled dense-gain baseline. Twenty-four combined tests pass, including CPU/CUDA
+float32/float64 parity and protection against caller-side mutation of a compiled `H`. On the local GTX 1660
+SUPER, static `n=2,m=4` is fastest on CPU dense: 0.058 ms for one row and 0.113 ms for 4096 rows, versus CPU QR
+0.220/0.596 ms. Large batches do benefit from CUDA dense: 0.129 ms at `n=32,m=32,batch=4096` and 0.131 ms at
+`n=128,m=32`, but CUDA QR remains slower at 0.543/1.121 ms.
+See `DESIGN_joint_square_root_qr_conditioner.md` and
+`REPORT_joint_square_root_qr_benchmark.md`.
+
+## Ordered next work
+
+1. Repeat strict matched-cost `n=80,k∈{2,4}` and `n=160,k=2` across preregistered node partitions;
+   calculate paired held-node intervals and declare a multi-endpoint decision rule before looking at results.
+2. Add a human-verified or independent-judge target. All current decision/head results measure GPT-5.5
+   operating-judge fidelity.
+3. Test per-stratum/per-D-bin Luna calibration only inside nested training data; keep global affine as baseline.
+4. If revisiting JointPosterior, use aggregated soft macro probabilities and a nested calibration split. Do not
+   add capacity merely because the linear head tied.
+5. Integrate the Torch QR conditioner only behind a parity/benchmark gate. Keep the dense Cholesky conditioner
+   for n=2 single-row work; compare compiled QR against a compiled dense gain for large same-design batches,
+   and prefer root-threading QR when sequential blocks change the posterior.

--- a/prototypes/mu_cosine/REPORT_cheap_judge_post3648_validation.md
+++ b/prototypes/mu_cosine/REPORT_cheap_judge_post3648_validation.md
@@ -11,7 +11,8 @@ matched-cost proxy, Gaussian NLL, and macro-decision AURC answer different quest
    `n=160,k=2`, S is nominally worse on both corpora.
 2. **Free graph_S is real, but mostly a pre-Luna channel.** Its free-only S-NLL gain is positive across all 40
    node partitions and the fixed held-node interval excludes zero on both corpora. Its increment after debiased
-   Luna is small and both fixed intervals include zero.
+   Luna is small and both fixed intervals include zero. This tests graph_S as a final-posterior input, not the
+   graph judge's separate role in familiarizing or adapting a model to the dataset.
 3. **Debiased Luna is still valuable, but task- and partition-dependent.** It dominates the analytic D/S
    Gaussian ladder. Macro-decision AURC favours it on seed 0, but one fresh seed-1 Joint interval includes zero.
    The leakage-free matched-cost ridge proxy does not show a general spending advantage for cheap labels.
@@ -95,7 +96,11 @@ seed-0 interval uses paired two-endpoint/pigeonhole node resampling on the held 
 | fresh, after Luna | +0.0765 ± 0.0417 | 39/40 | +0.0219 [-0.1759,+0.2067] |
 
 This confirms graph_S as useful free supervision. It does not confirm a material increment once debiased Luna
-is present.
+is present. That conclusion is deliberately narrow: the graph judge can also provide broad, nearly free
+structural supervision that teaches a model a dataset's entities, vocabulary, topology, and relation patterns.
+This evaluation holds the upstream representation fixed and therefore does not measure that dataset-
+familiarization benefit. Removing graph supervision based on the post-Luna fusion increment would be an invalid
+inference; a matched adaptation ablation is separate future work.
 
 ## 3. Corrected Luna campaign
 

--- a/prototypes/mu_cosine/REPORT_joint_square_root_qr_benchmark.md
+++ b/prototypes/mu_cosine/REPORT_joint_square_root_qr_benchmark.md
@@ -1,0 +1,92 @@
+# Fixed-design Gaussian conditioning: dense-gain versus square-root/QR
+
+Run 2026-07-10. This is a numerical throughput benchmark, not a statistical comparison: the PyTorch backend
+is tested against the NumPy Householder implementation and the dense correlated Gaussian conditioner before
+timing.
+
+## Implementation under test
+
+For one fixed `(U,H,R,C)` design, `CompiledCorrelatedConditionerTorch`:
+
+1. decorrelates the measurement block through `Rc = R - C^T P^-1 C` and `J = H + C^T P^-1`;
+2. Cholesky-whitens `(J,Rc)`;
+3. calls `torch.geqrf` once on `stack([U, L^-1 J])`, retaining compact Householder reflectors;
+4. treats a batch of innovations as RHS columns, applies `Q^T` with `torch.ormqr`, and performs one triangular
+   solve.
+
+`Q` is never formed. A generic distinct-design batch and a sequential state that threads `(U_post,z_post)`
+are also implemented, but only the fixed-design path can share the factorisation across rows.
+
+For the matched static baseline, `CompiledDenseGainConditionerTorch` derives the same conditional `(J,Rc)`
+model, computes the dense correlated gain and posterior covariance once, and batches only the per-row affine
+mean update. It cannot reuse that gain after a sequential block changes the posterior.
+
+## Hardware and protocol
+
+- CPU: Intel Core i7-10700KF, 8 WSL-visible logical CPUs; `torch.set_num_threads(8)`.
+- GPU: NVIDIA GeForce GTX 1660 SUPER, 6 GiB, driver 591.74.
+- PyTorch 2.4.1+cu121; CUDA runtime 12.1; float32.
+- Selected cells were run in isolation with 20 warmups, 500 conditioning repeats, and 50 factorisation
+  repeats; explicit CUDA synchronisation around timings.
+- `compile_ms` and `condition_ms` are deliberately separate. Rows/s measures only repeated conditioning after
+  compilation. Dense compile time includes checking/regularising the subtraction-form posterior covariance;
+  without that check a highly informative float32 update can round the dense covariance to singular zero.
+
+The matched baseline, `CompiledDenseGainConditionerTorch`, validates the same Schur-complement model and
+precomputes the correlated gain `K` and posterior covariance. Each row then needs only the affine innovation
+update. This is the appropriate static-design comparator; QR's distinct purpose is carrying an updated
+precision root through changing or sequential blocks.
+
+Selected synchronized results:
+
+| n | m | rows | CPU QR compile / condition ms | CPU dense compile / condition ms | CUDA QR compile / condition ms | CUDA dense compile / condition ms |
+|---:|---:|---:|---:|---:|---:|---:|
+| 2 | 4 | 1 | 0.506 / 0.220 | **0.459 / 0.058** | 1.939 / 0.453 | 1.818 / 0.116 |
+| 2 | 4 | 4096 | 0.434 / 0.596 | **0.422 / 0.113** | 1.523 / 0.520 | 1.945 / 0.132 |
+| 2 | 32 | 4096 | 0.474 / 0.992 | 0.465 / 0.256 | 2.722 / 0.534 | **2.679 / 0.129** |
+| 32 | 32 | 4096 | 0.724 / 2.106 | 1.037 / 0.363 | 2.386 / 0.543 | **3.667 / 0.129** |
+| 128 | 32 | 4096 | 0.800 / 5.694 | 1.532 / 0.734 | 3.273 / 1.121 | **5.402 / 0.131** |
+
+## Interpretation
+
+- The dense-gain baseline is faster than QR on both devices in every tested fixed-design cell. For the current
+  `n=2,m=4` problem it is 3.8x faster than QR on CPU at batch one and 5.3x faster at batch 4096. CPU dense is
+  also faster than CUDA dense there, so the current conditioner has no GPU throughput case.
+- Large same-design batches do benefit from GPU parallelism, but it is not a QR-specific win. At
+  `n=32,m=32,batch=4096`, CUDA dense takes 0.129 ms versus CPU dense 0.363 ms; at `n=128,m=32`, CUDA dense takes
+  0.131 ms versus CPU dense 0.734 ms.
+- QR remains useful when the deliverable is the updated precision root or later blocks change the posterior.
+  In that sequential regime `(U_post,z_post)` must feed the next factorization; a static cached gain cannot be
+  reused. All RHS blocks must stay in one coordinate system; recentering requires resetting `z` and shifting
+  the later likelihood RHS. That regime needs its own matched end-to-end benchmark.
+- Constant `H,P,C,R` is a performance opportunity, not a correctness shortcut: compile the dense gain for
+  static rows. Prefer root-threading QR when the design/posterior changes and its numerical behavior earns the
+  extra work.
+- These crossover points are hardware/runtime-specific. Rebenchmark on deployment hardware and include data
+  transfer if inputs do not already reside on the device.
+- The table reports one timed run per cell after warmup, not multi-trial dispersion. Treat the exact speedups
+  as local point measurements; the qualitative small-state/large-batch crossover reproduced, but CPU
+  contention can move the ratios materially.
+
+Reproduction:
+
+```bash
+python3 -m pytest -q -s \
+  prototypes/mu_cosine/test_joint_square_root_conditioner.py \
+  prototypes/mu_cosine/test_joint_square_root_conditioner_torch.py
+
+python3 -u prototypes/mu_cosine/benchmark_joint_square_root_qr.py \
+  --state-dims 2,32,128 --measurement-dims 4,32 --batch-sizes 1,4096 \
+  --devices cpu,cuda --dtype float32 --warmups 20 --repeats 500 \
+  --compile-repeats 50 --cpu-threads 8
+```
+
+The combined NumPy/PyTorch suite passes 24 tests, including dense-gain/QR float32/float64 parity, CUDA parity,
+full distinct-design batches, nonzero-`C` block-diagonal-`Rc` streaming, and both fixed-coordinate and recentered
+sequential blocks. Compiled conditioners also snapshot their fixed design so later caller-side mutation cannot
+silently mix stale factors with a changed `H`.
+
+Next benchmark: compare end-to-end latency, memory, and numerical drift under genuinely sequential block
+workloads where each update changes the carried posterior root. Add multi-trial median/MAD timings, host/device
+transfer, peak-memory accounting, and a log-spaced scale/condition-number sweep. The static-design decision is
+already clear: use the compiled dense gain.

--- a/prototypes/mu_cosine/REPORT_joint_square_root_qr_benchmark.md
+++ b/prototypes/mu_cosine/REPORT_joint_square_root_qr_benchmark.md
@@ -19,7 +19,8 @@ are also implemented, but only the fixed-design path can share the factorisation
 
 For the matched static baseline, `CompiledDenseGainConditionerTorch` derives the same conditional `(J,Rc)`
 model, computes the dense correlated gain and posterior covariance once, and batches only the per-row affine
-mean update. It cannot reuse that gain after a sequential block changes the posterior.
+mean update. Here “compiled” means **design-cached**, not `torch.compile` or kernel fusion. It cannot reuse that
+gain after a sequential block changes the posterior.
 
 ## Hardware and protocol
 
@@ -28,6 +29,8 @@ mean update. It cannot reuse that gain after a sequential block changes the post
 - PyTorch 2.4.1+cu121; CUDA runtime 12.1; float32.
 - Selected cells were run in isolation with 20 warmups, 500 conditioning repeats, and 50 factorisation
   repeats; explicit CUDA synchronisation around timings.
+- Timings are on-device compute point measurements from one process run. They exclude host/device transfer and
+  report a mean over repeats, not median/MAD across independent trials.
 - `compile_ms` and `condition_ms` are deliberately separate. Rows/s measures only repeated conditioning after
   compilation. Dense compile time includes checking/regularising the subtraction-form posterior covariance;
   without that check a highly informative float32 update can round the dense covariance to singular zero.
@@ -81,10 +84,10 @@ python3 -u prototypes/mu_cosine/benchmark_joint_square_root_qr.py \
   --compile-repeats 50 --cpu-threads 8
 ```
 
-The combined NumPy/PyTorch suite passes 24 tests, including dense-gain/QR float32/float64 parity, CUDA parity,
-full distinct-design batches, nonzero-`C` block-diagonal-`Rc` streaming, and both fixed-coordinate and recentered
-sequential blocks. Compiled conditioners also snapshot their fixed design so later caller-side mutation cannot
-silently mix stale factors with a changed `H`.
+The combined NumPy/PyTorch suite passes 29 tests, including dense-gain/QR float32/float64 parity, CUDA parity,
+CPU/CUDA distinct-design batches, nonzero-`C` block-diagonal-`Rc` streaming, and CPU/CUDA fixed-coordinate root
+threading plus recentered sequential blocks. Compiled conditioners also snapshot their fixed design so later
+caller-side mutation cannot silently mix stale factors with changed `H`, `R`, or `C` inputs.
 
 Next benchmark: compare end-to-end latency, memory, and numerical drift under genuinely sequential block
 workloads where each update changes the carried posterior root. Add multi-trial median/MAD timings, host/device

--- a/prototypes/mu_cosine/REPORT_luna_campaign.md
+++ b/prototypes/mu_cosine/REPORT_luna_campaign.md
@@ -1,4 +1,12 @@
-# Luna campaign: the §7 verdict revised, stratified fusion value, and the fused head's first win
+# Luna campaign: corrected prior/calibration rerun and historical comparison
+
+Post-#3648 correction (2026-07-10): the original campaign report used the campaign-trained `r0` checkpoint
+both to initialise the channel head and to define the Gaussian prior, and it left Luna's affine tilt inside
+the residual covariance. The corrected run separates those roles: `model_channel_heads_namecond_r0.pt` remains
+the training initialisation/anchor, while campaign-independent `model_prod_namecond.pt` supplies the prior;
+Luna is globally affine-calibrated on the train split before covariance fitting. Graph traversal, PyTorch
+threading, row sampling, and augmentation are deterministic. The old numbers remain below only as an exactly
+reproducible historical configuration.
 
 Stratified luna scoring (same 2,000 campaign pairs as the 5.5 run; 200/200 batches, 1,930 ingested, 0
 failures, 111 min, ~0.30 pairs/s at gpt-5.6-luna low) → 1,700 pair-matched dual-judge rows. Three results.
@@ -20,43 +28,62 @@ luna's S where S doesn't vary. Where it varies (sib/cous), luna agrees at 0.48�
 0.766 ceiling. **Luna ≈ 90% of 5.5's self-agreement at a fraction of the price.** Tilt refined: −S bias is
 universal; the +D bias is transitive-specific (luna reads more hierarchy only in true hierarchy pairs).
 
-## 2. Stratified luna channel value + empirical R (fine_tune_fused_head_luna.py, analytic part)
+## 2. Corrected stratified Luna value + empirical R (`fine_tune_fused_head_luna.py`)
 
-5×5 joint blocks fit per corpus on the train split from the dual-judge data (no imported R):
-fitted R_luna D 0.030/0.040, S 0.015/0.032 (≈7–10× 5.5's self-R, as the multi-judge report estimated).
-Ladder vs the 5.5 target (held rows): luna channel worth **+0.766/+0.721 NLL** over prior+graph
-(expl/fresh) — larger than the transitive-only +0.451. Fusion non-degeneracy pull 0.080/0.095.
+Five-by-five joint blocks are fit per corpus on the dual-judge train rows; no R is imported. Held-row NLL:
 
-## 3. The fused head beats a channel head for the first time — in the predicted regime
+| configuration / corpus | fitted R Luna D / S | prior | +graph | +debiased Luna | Luna value | mean \|post_D − Luna_D\| |
+|---|---:|---:|---:|---:|---:|---:|
+| corrected exploratory | 0.0208 / 0.0149 | -0.285 | -0.568 | **-1.493** | **+0.925** | 0.030 |
+| corrected fresh | 0.0273 / 0.0234 | +0.405 | -0.018 | **-1.101** | **+1.083** | 0.035 |
+| historical exploratory | 0.0302 / 0.0153 | -0.212 | -0.472 | -1.238 | +0.766 | 0.080 |
+| historical fresh | 0.0395 / 0.0321 | +0.569 | +0.187 | -0.533 | +0.721 | 0.095 |
+
+The correction makes the scientific interpretation clearer: debiased Luna is the S workhorse and dominates
+the analytic gain. The posterior legitimately moves less far from Luna after systematic bias is removed; a
+small pull is no longer evidence that fusion is degenerate. These are one-split descriptive results (row SD,
+not an independence-based SE); strict node-disjoint uncertainty is reported separately by
+`run_sym_channel_fusion.py`.
+
+## 3. Corrected deterministic fused-head run
 
 kalman-fused retrained on the LUNA-fused posteriors (prior ⊕ graph ⊕ luna), alongside 5.5/graph/luna
 channel supervision; held rows, WITHIN-stratum, vs the 5.5 labels:
 
 | head (within-stratum vs 5.5) | expl D | fresh D | expl S | fresh S |
 |---|---|---|---|---|
-| luna channel head (raw cheap labels) | +0.351 | +0.407 | +0.373 | +0.312 |
-| **luna-FUSED head** | **+0.396** | **+0.451** | +0.363 | +0.305 |
-| 5.5 head (expensive labels — reference) | +0.411 | +0.503 | +0.369 | +0.323 |
+| luna channel head (raw cheap labels) | +0.373 | +0.398 | **+0.369** | **+0.296** |
+| **luna-FUSED head** | **+0.402** | **+0.467** | +0.361 | +0.261 |
+| 5.5 head (expensive labels — reference) | +0.419 | +0.481 | +0.354 | +0.287 |
 
-- **D**: fusion recovers roughly HALF the gap between cheap-label and expensive-label heads
-  (+0.045/+0.044 within-stratum), at zero additional scoring cost. This is REPORT_fused_head.md's null
-  boundary confirmed constructively: with a noisy judge the posterior differs from the label (pull 0.08–0.10)
-  and the fused head learns the difference (fidelity to its own target: within +0.381–0.588).
-- **S**: a wash, as expected — the graph doesn't observe S, so the S fusion has only the weak prior to add.
-- The luna channel head itself now has stratified S signal (within vs luna's own labels +0.25–0.28) —
-  fixing the B2-step-3 residual's S starvation.
+- **D:** fusion improves over the Luna channel by +0.029/+0.069 and closes about 63%/83% of the gap to the
+  expensive-label head in this single deterministic run. Fidelity to the analytic posterior is +0.350/+0.479
+  within-stratum.
+- **S:** fusion does not improve over the Luna channel (−0.008/−0.035). This agrees with the node-disjoint
+  result that graph_S's small incremental value after debiased Luna is not confirmed. Posterior fidelity
+  (+0.453/+0.461) shows this is not simply a failure to learn the target.
+- The Luna channel retains stratified S signal (within vs its own labels +0.312/+0.224), fixing the earlier
+  transitive-only S starvation.
 
-**Economics statement.** For future corpora labeled with the cheap judge, fuse-then-distill recovers ~half
-of the D-channel quality gap to expensive labels for free. Combined with §1 (luna ≈ 90% of ceiling pooled),
-the cheap-judge pipeline is live: luna labels + Kalman fusion + conflict-routed 5.5 calls (Lever A) is the
-deployment recipe to beat.
+**Economics statement.** The corrected evidence supports debiased Luna as the paid S workhorse and
+fuse-then-distill as a promising D improvement. It does not yet justify a universal “half the gap for free”
+claim: the recovery is corpus-dependent, S does not improve, and this head result is one
+descendant-disjoint—not strict node-disjoint—split. Matched-cost and routing decisions should use the separate
+paired-budget and node-disjoint validations rather than extrapolating this table.
 
 ## Caveats
 
-Single seed, single split per corpus for the trained heads (the analytic ladder is held-out but one split);
-target = the 5.5 operating judge, not ground truth (same-family privilege — a human-verified subset remains
-the gold-standard upgrade); 14 non-dict response objects skipped at ingest (the §3 format-discipline guard);
-luna's fitted R absorbs its tilt as variance (bias-augmented state would price it properly).
+Single deterministic seed and one descendant-disjoint split per corpus; target = the 5.5 operating judge,
+not ground truth (same-family privilege — a human-verified subset remains the gold-standard upgrade); 14
+non-dict response objects skipped at ingest (the §3 format-discipline guard). The implemented bias correction
+is a global per-channel affine fit. Per-stratum/per-D-bin bias models and strict node-disjoint repeated head
+training remain follow-up work.
+
+Run provenance (SHA-256): channel init `797e0b79ceba8af6e98c2fafb21b963de238a68a427deb71a75029f2c97cf1de`;
+campaign-independent prior `c1cfc3a3827e42a1993f4286b6a881aee7ff10eb56a76367735b9ec8fdf11f7d`;
+GPT-5.5 campaign `c2acf399aadd35c3797171d5b42d64e45b07055802092cc28becf308d460ef09`;
+Luna campaign `a8d951b4fd05f0ca111fbe9d9c23881bb47b790ccb335731113bfd4ae77ffe6e`;
+corrected `/tmp` output `fa6a5778452a2a92968cbae14a2150d056d0069d4f20aaa36fbf9aac1a919338`.
 
 Repro:
 ```
@@ -64,5 +91,15 @@ python3 score_with_codex.py --pairs /tmp/mu_data/campaign_pairs.tsv --batch 10 \
     --model gpt-5.6-luna --judge gpt-5.6-luna --out /tmp/mu_data/campaign_scored_luna.tsv \
     --responses /tmp/mu_data/campaign_luna_responses.txt
 python3 compare_judges_campaign.py
-python3 fine_tune_fused_head_luna.py --ckpt model_channel_heads_namecond_r0.pt
+python3 fine_tune_fused_head_luna.py --analytic-only \
+    --ckpt model_channel_heads_namecond_r0.pt \
+    --prior-ckpt model_prod_namecond.pt --luna-calibration global
+python3 fine_tune_fused_head_luna.py --steps 800 --out /tmp/model_fused_head_luna_corrected.pt \
+    --ckpt model_channel_heads_namecond_r0.pt \
+    --prior-ckpt model_prod_namecond.pt --luna-calibration global
+
+# Exact historical analytic configuration (no training):
+python3 fine_tune_fused_head_luna.py --analytic-only \
+    --ckpt model_channel_heads_namecond_r0.pt \
+    --prior-ckpt model_channel_heads_namecond_r0.pt --luna-calibration none
 ```

--- a/prototypes/mu_cosine/benchmark_joint_square_root_qr.py
+++ b/prototypes/mu_cosine/benchmark_joint_square_root_qr.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Benchmark compiled dense-gain and square-root/QR conditioners.
+
+This separates design compilation (covariance decorrelation, whitening, and
+``geqrf``) from conditioning an observation batch (one compact-reflector
+``ormqr`` plus triangular solve).  CUDA timings include warmups and explicit
+synchronisation.
+
+The current mu-cosine D/S state has ``n=2``.  At batch size one that problem is
+expected to be launch/latency-bound.  For any fixed design the cached dense
+gain is the primary throughput baseline; QR is intended for workloads that
+must retain and update the precision root across later blocks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import time
+
+import torch
+
+from joint_square_root_conditioner_torch import (
+    CompiledCorrelatedConditionerTorch,
+    CompiledDenseGainConditionerTorch,
+    precision_root_from_covariance_torch,
+)
+
+
+def _csv_ints(value: str) -> list[int]:
+    values = [int(part.strip()) for part in value.split(",") if part.strip()]
+    if not values or any(item <= 0 for item in values):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return values
+
+
+def _dtype(name: str) -> torch.dtype:
+    return {"float32": torch.float32, "float64": torch.float64}[name]
+
+
+def _devices(specification: str) -> list[torch.device]:
+    names = [part.strip() for part in specification.split(",") if part.strip()]
+    if names == ["auto"]:
+        names = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+    devices = []
+    for name in names:
+        if name == "cuda" and not torch.cuda.is_available():
+            print("# skipping cuda: torch.cuda.is_available() is false")
+            continue
+        devices.append(torch.device(name))
+    if not devices:
+        raise SystemExit("no requested benchmark device is available")
+    return devices
+
+
+def _synchronise(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _time_ms(function, repeats: int, warmups: int, device: torch.device) -> float:
+    for _ in range(warmups):
+        function()
+    _synchronise(device)
+    start = time.perf_counter()
+    for _ in range(repeats):
+        function()
+    _synchronise(device)
+    return 1000.0 * (time.perf_counter() - start) / repeats
+
+
+def _problem(n: int, m: int, batch: int, device: torch.device, dtype: torch.dtype):
+    generator = torch.Generator(device=device)
+    generator.manual_seed(1729 + 1009 * n + 917 * m + batch)
+    eye_n = torch.eye(n, dtype=dtype, device=device)
+    eye_m = torch.eye(m, dtype=dtype, device=device)
+    p_factor = torch.randn(n, n, generator=generator, dtype=dtype, device=device)
+    r_factor = torch.randn(m, m, generator=generator, dtype=dtype, device=device)
+    P = p_factor @ p_factor.mT / max(n, 1) + 0.75 * eye_n
+    R = r_factor @ r_factor.mT / max(m, 1) + 0.75 * eye_m
+
+    # Construct nonzero C while guaranteeing the joint covariance is SPD:
+    # C = Lp B Lr.T and ||B||_2 < 1 implies R - C.T P^-1 C > 0.
+    Lp = torch.linalg.cholesky(P)
+    Lr = torch.linalg.cholesky(R)
+    bridge = torch.randn(n, m, generator=generator, dtype=dtype, device=device)
+    bridge = 0.25 * bridge / torch.clamp(
+        torch.linalg.matrix_norm(bridge, ord=2), min=torch.finfo(dtype).eps
+    )
+    C = Lp @ bridge @ Lr.mT
+    H = torch.randn(m, n, generator=generator, dtype=dtype, device=device) / math.sqrt(n)
+    mean = torch.randn(batch, n, generator=generator, dtype=dtype, device=device)
+    observation = torch.randn(batch, m, generator=generator, dtype=dtype, device=device)
+    root = precision_root_from_covariance_torch(P)
+    return root, H, R, C, mean, observation
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--state-dims", type=_csv_ints, default=_csv_ints("2,16,64"))
+    parser.add_argument("--measurement-dims", type=_csv_ints, default=_csv_ints("2,16"))
+    parser.add_argument("--batch-sizes", type=_csv_ints, default=_csv_ints("1,256,4096"))
+    parser.add_argument("--devices", default="auto", help="auto or comma-separated cpu,cuda")
+    parser.add_argument("--dtype", choices=("float32", "float64"), default="float32")
+    parser.add_argument("--warmups", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument(
+        "--compile-repeats",
+        type=int,
+        default=5,
+        help="repetitions for the more expensive design-compilation timing",
+    )
+    parser.add_argument("--cpu-threads", type=int, default=None)
+    args = parser.parse_args()
+    if min(args.warmups, args.repeats, args.compile_repeats) < 1:
+        parser.error("warmups and repeat counts must be positive")
+    if args.cpu_threads is not None:
+        if args.cpu_threads < 1:
+            parser.error("--cpu-threads must be positive")
+        torch.set_num_threads(args.cpu_threads)
+
+    dtype = _dtype(args.dtype)
+    print("# Fixed-design correlated conditioning: compiled QR versus compiled dense gain")
+    print("# n=2 (current D/S state) and batch=1 is expected to be latency-bound on CUDA")
+    print("algorithm,device,dtype,n,m,batch,compile_ms,condition_ms,rows_per_second")
+    with torch.inference_mode():
+        for device in _devices(args.devices):
+            for n in args.state_dims:
+                for m in args.measurement_dims:
+                    for batch in args.batch_sizes:
+                        root, H, R, C, mean, observation = _problem(
+                            n, m, batch, device, dtype
+                        )
+
+                        algorithms = (
+                            ("qr", CompiledCorrelatedConditionerTorch),
+                            ("dense_gain", CompiledDenseGainConditionerTorch),
+                        )
+                        for algorithm, conditioner_type in algorithms:
+                            def compile_design():
+                                return conditioner_type.compile(root, H, R, C)
+
+                            compile_ms = _time_ms(
+                                compile_design,
+                                args.compile_repeats,
+                                min(args.warmups, args.compile_repeats),
+                                device,
+                            )
+                            compiled = compile_design()
+
+                            def condition_batch():
+                                return compiled.condition(mean, observation)
+
+                            condition_ms = _time_ms(
+                                condition_batch, args.repeats, args.warmups, device
+                            )
+                            rows_per_second = 1000.0 * batch / condition_ms
+                            print(
+                                f"{algorithm},{device.type},{args.dtype},{n},{m},{batch},"
+                                f"{compile_ms:.6f},{condition_ms:.6f},"
+                                f"{rows_per_second:.3f}"
+                            )
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/emit_transitive_hops.py
+++ b/prototypes/mu_cosine/emit_transitive_hops.py
@@ -50,7 +50,9 @@ def hit_prob(parents, desc, anc):
             return 1.0
         if x in memo:
             return memo[x]
-        ps = parents.get(x) or []
+        # Parent maps are commonly sets. Canonical order makes both floating-point summation and the
+        # cycle-guard fallback reproducible across PYTHONHASHSEED values/processes.
+        ps = sorted(parents.get(x) or [])
         if not ps:
             return 0.0                                   # reached a root without hitting anc
         memo[x] = 0.0                                    # cycle guard: node currently being computed → 0

--- a/prototypes/mu_cosine/fine_tune_fused_head_luna.py
+++ b/prototypes/mu_cosine/fine_tune_fused_head_luna.py
@@ -4,9 +4,10 @@
 REPORT_fused_head.md's null: with the reliable judge (R≈0.004) the posterior collapses onto the label.
 REPORT_multi_judge_fusion.md's boundary: with LUNA the posterior genuinely mixes channels (pull 0.133).
 The stratified luna campaign closes the loop: build Kalman posteriors from [prior, graph, LUNA] against
-the 5.5 operating target — luna's error blocks (including its tilt and cross-correlations) FIT EMPIRICALLY
-on the train split from the pair-matched dual-judge data, no imported R — and distill them into the
-kalman-fused name head.
+the 5.5 operating target — luna's error blocks and cross-correlations FIT EMPIRICALLY on the train split
+from the pair-matched dual-judge data, no imported R — and distill them into the kalman-fused name head.
+Luna is globally affine-calibrated on that train split before the covariance fit, so systematic tilt is
+removed as bias rather than charged to measurement variance.
 
 Deployment question this answers: a CHEAP pipeline (luna labels fused with graph+prior, amortized into one
 head) — how close does it get to the expensive judge's labels, vs the raw luna channel head?
@@ -14,7 +15,12 @@ head) — how close does it get to the expensive judge's labels, vs the raw luna
 Also trains the luna CHANNEL head on stratified data (fixing step 3's S starvation) and prints the
 analytic fusion ladder (prior | +graph | +graph+luna vs 5.5) before any training.
 
-  python3 fine_tune_fused_head_luna.py --ckpt model_channel_heads_namecond_r0.pt
+The channel checkpoint initializes/anchors the trainable model. A separate, campaign-independent checkpoint
+supplies the Gaussian prior and P0 residuals; keeping those roles separate avoids an optimistic prior fit.
+
+  python3 fine_tune_fused_head_luna.py \
+      --ckpt model_channel_heads_namecond_r0.pt \
+      --prior-ckpt model_prod_namecond.pt
 """
 import argparse
 import os
@@ -33,25 +39,40 @@ from product_kalman import fit_residual_covariance
 from run_judge_channel import H_ALL, correlated_update_H, nll_mahal
 from run_product_kalman_logit import dequant
 from run_product_kalman_realdata import affine_calibrate
-from run_sym_channel_fusion import calibrate_luna
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 LUNA_CAMPAIGN = "/tmp/mu_data/campaign_scored_luna.tsv"
 
 
+def calibrate_luna_global(luna, y, fit_idx):
+    """Train-only global affine calibration, applied to every row before fitting residual covariance."""
+    cal_D = affine_calibrate(luna[fit_idx, 0], y[fit_idx, 0], luna[:, 0])
+    cal_S = affine_calibrate(luna[fit_idx, 1], y[fit_idx, 1], luna[:, 1])
+    return np.column_stack([cal_D, cal_S])
+
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--ckpt", default=os.path.join(ROOT, "model_channel_heads_namecond_r0.pt"))
+    ap.add_argument("--ckpt", default=os.path.join(ROOT, "model_channel_heads_namecond_r0.pt"),
+                    help="channel-head checkpoint used only for model initialization and the training anchor")
+    ap.add_argument("--prior-ckpt", default=os.path.join(ROOT, "model_prod_namecond.pt"),
+                    help="campaign-independent checkpoint used for prior means and P0")
     ap.add_argument("--out", default=os.path.join(ROOT, "model_fused_head_luna.pt"))
     ap.add_argument("--steps", type=int, default=800)
     ap.add_argument("--bs", type=int, default=64)
     ap.add_argument("--lr", type=float, default=5e-4)
     ap.add_argument("--anchor-weight", type=float, default=1.0)
     ap.add_argument("--shrink", type=float, default=0.05)
+    ap.add_argument("--luna-calibration", choices=("global", "none"), default="global",
+                    help="global=train-only affine correction; none only reproduces the historical report")
+    ap.add_argument("--analytic-only", action="store_true",
+                    help="print the corrected analytic ladder and exit without training or writing a checkpoint")
     a = ap.parse_args()
     dev = "cpu"
+    torch.set_num_threads(1)  # tiny deterministic campaign batches do not benefit from a large BLAS pool
     torch.manual_seed(0)
     rng = np.random.default_rng(0)
+    augment_rng = np.random.default_rng(1)
 
     model, cfg = load_expanded(a.ckpt, dev=dev)
     assert model.judge_name is not None
@@ -59,6 +80,13 @@ def main():
     ref.eval()
     for p in ref.parameters():
         p.requires_grad = False
+    prior_ref, _ = load_expanded(a.prior_ckpt, dev=dev)
+    prior_ref.eval()
+    for p in prior_ref.parameters():
+        p.requires_grad = False
+    print(f"training init/anchor: {os.path.basename(a.ckpt)}")
+    print(f"Gaussian prior:      {os.path.basename(a.prior_ckpt)}")
+    print(f"Luna calibration:    {a.luna_calibration}")
     for p in model.parameters():
         p.requires_grad = False
     model.judge_name.W.weight.requires_grad = True
@@ -84,11 +112,12 @@ def main():
         tr_l = [i for i in ds["tr"] if i in matched[n]]
         he_l = [i for i in ds["he"] if i in matched[n]]
         ds["he_l"], ds["luna"] = he_l, luna
-        ro = agnostic_readouts(ref, ds, dev)
+        ro = agnostic_readouts(prior_ref, ds, dev)
         y = dequant(np.column_stack([ds["D"], ds["S"]]))
         prior = np.column_stack([ro["prior_D"], ro["prior_S"]])
         m = affine_calibrate(ds["d"][tr_l], y[tr_l, 0], ds["d"])
-        luna_c = calibrate_luna(luna, y, tr_l)          # bias first (blocker 3 / DESIGN §2)
+        luna_c = (calibrate_luna_global(luna, y, tr_l)
+                  if a.luna_calibration == "global" else luna.copy())  # bias first (DESIGN §2)
         meas = np.column_stack([m, luna_c[:, 0], luna_c[:, 1]])
         E5 = np.column_stack([y - prior, meas - y[:, [0, 0, 1]]])[tr_l]
         C5 = fit_residual_covariance(E5, shrinkage=a.shrink)
@@ -116,7 +145,7 @@ def main():
         g = np.array(acc["prior+graph"]) - np.array(acc["prior+graph+luna"])
         print(f"  ladder (held NLL): prior {np.mean(acc['prior']):+.3f} | +graph "
               f"{np.mean(acc['prior+graph']):+.3f} | +luna {np.mean(acc['prior+graph+luna']):+.3f}  "
-              f"(luna channel value {g.mean():+.3f}, row-SE {g.std()/np.sqrt(len(g)):.3f})")
+              f"(luna channel value {g.mean():+.3f}, descriptive row-SD {g.std(ddof=1):.3f})")
         print(f"  fusion non-degeneracy: mean |post_D − luna_D| = {np.mean(pull):.3f}")
 
         rows = []
@@ -132,6 +161,10 @@ def main():
         train_rows[n] = rows
         print(f"  {len(rows)} train rows (5.5 + graph + luna + fused channels)")
 
+    if a.analytic_only:
+        print("\nanalytic-only: skipped training and did not write a checkpoint")
+        return
+
     names = list(train_rows)
     model.train()
     for step in range(1, a.steps + 1):
@@ -140,7 +173,7 @@ def main():
         sel = rng.choice(len(rows), size=min(a.bs, len(rows)), replace=False)
         items = [rows[j][0] for j in sel]
         tgt = torch.tensor([rows[j][1] for j in sel], dtype=torch.float32, device=dev)
-        mu = mu_batch(model, dss[n]["tok"], items, dev, train=True, rng=np.random)
+        mu = mu_batch(model, dss[n]["tok"], items, dev, train=True, rng=augment_rng)
         loss = torch.mean((mu - tgt) ** 2)
         ag_items = [(it[0], it[1], it[2]) for it in items]
         mu_ag = mu_batch(model, dss[n]["tok"], ag_items, dev)

--- a/prototypes/mu_cosine/joint_square_root_conditioner.py
+++ b/prototypes/mu_cosine/joint_square_root_conditioner.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Joint square-root / Householder-QR Gaussian conditioner.
+
+This module is the square-root-information implementation of the same static
+correlated Gaussian update used by ``product_kalman.gaussian_condition_update``.
+It maintains a factor ``U`` of the precision matrix,
+
+    P^-1 = U.T @ U,
+
+and incorporates a measurement block by triangularising the augmented least-
+squares array with Householder reflections.  It is an implementation change,
+not a new statistical fusion rule.
+
+For prior error ``e = truth - prior`` and measurement noise
+``v = observation - H @ truth`` with ``Cov(e, v) = C``, first condition the
+measurement noise on ``e``:
+
+    Rc = R - C.T @ P^-1 @ C
+    J  = H + C.T @ P^-1
+    innovation | e ~ N(J @ e, Rc)
+
+Whitening ``Rc`` produces rows ``A`` and ``b``.  Stacking those below the
+previous information root and applying Householder QR gives the posterior
+information root and right-hand side:
+
+    [ U_prior   z_prior ]       [ U_post   z_post ]
+    [ A         b       ]  ->   [ 0        residual ]
+
+Householder transformations are reflections.  Givens transformations are the
+closely related plane rotations often used for streaming one row at a time.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from product_kalman import regularize_covariance
+
+
+__all__ = [
+    "InformationRootUpdate",
+    "JointSquareRootUpdate",
+    "condition_correlated_gaussian_qr",
+    "conditional_measurement_model",
+    "householder_information_update",
+    "precision_root_from_covariance",
+    "whiten_measurement_block",
+]
+
+
+def _readonly(value):
+    arr = np.array(value, dtype=float, copy=True)
+    arr.setflags(write=False)
+    return arr
+
+
+def _vector(name, value, length=None):
+    arr = np.asarray(value, dtype=float)
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+    elif arr.ndim == 2 and 1 in arr.shape:
+        arr = arr.reshape(-1)
+    if arr.ndim != 1:
+        raise ValueError(f"{name} must be a vector")
+    if length is not None and len(arr) != length:
+        raise ValueError(f"{name} has length {len(arr)}, expected {length}")
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} must be finite")
+    return arr
+
+
+def _matrix(name, value, rows=None, cols=None):
+    arr = np.asarray(value, dtype=float)
+    if arr.ndim != 2:
+        raise ValueError(f"{name} must be a matrix")
+    if rows is not None and arr.shape[0] != rows:
+        raise ValueError(f"{name} has {arr.shape[0]} rows, expected {rows}")
+    if cols is not None and arr.shape[1] != cols:
+        raise ValueError(f"{name} has {arr.shape[1]} columns, expected {cols}")
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} must be finite")
+    return arr
+
+
+@dataclass(frozen=True)
+class InformationRootUpdate:
+    """Result of one Householder information-root update."""
+
+    precision_root: np.ndarray
+    information_rhs: np.ndarray
+    solution: np.ndarray
+    trailing_residual: np.ndarray
+    residual_sum_squares: float
+
+    def __post_init__(self):
+        for name in ("precision_root", "information_rhs", "solution", "trailing_residual"):
+            object.__setattr__(self, name, _readonly(getattr(self, name)))
+
+
+@dataclass(frozen=True)
+class JointSquareRootUpdate:
+    """Correlated Gaussian conditioning result in square-root-information form."""
+
+    mean: np.ndarray
+    covariance: np.ndarray
+    precision_root: np.ndarray
+    information_rhs: np.ndarray
+    innovation: np.ndarray
+    effective_observation_matrix: np.ndarray
+    conditional_observation_covariance: np.ndarray
+    whitened_observation_matrix: np.ndarray
+    whitened_innovation: np.ndarray
+    residual_sum_squares: float
+
+    def __post_init__(self):
+        for name in (
+            "mean",
+            "covariance",
+            "precision_root",
+            "information_rhs",
+            "innovation",
+            "effective_observation_matrix",
+            "conditional_observation_covariance",
+            "whitened_observation_matrix",
+            "whitened_innovation",
+        ):
+            object.__setattr__(self, name, _readonly(getattr(self, name)))
+
+
+def _normalise_root_signs(root, rhs):
+    """Choose the conventional non-negative diagonal without changing R.T R."""
+    root = np.array(root, dtype=float, copy=True)
+    rhs = np.array(rhs, dtype=float, copy=True)
+    signs = np.where(np.diag(root) < 0.0, -1.0, 1.0)
+    root *= signs[:, None]
+    rhs *= signs
+    return root, rhs
+
+
+def householder_information_update(prior_precision_root, prior_information_rhs,
+                                   measurement_matrix, measurement_rhs):
+    """Triangularise a prior information root plus whitened measurement rows.
+
+    ``prior_precision_root`` need only satisfy ``Lambda = U.T @ U``; the
+    first call may pass a non-triangular inverse covariance factor.  The
+    returned root is upper triangular.  Reusing that returned root and RHS in
+    a later call is the streaming block update.
+    """
+    U = _matrix("prior_precision_root", prior_precision_root)
+    if U.shape[0] != U.shape[1] or U.shape[0] == 0:
+        raise ValueError("prior_precision_root must be nonempty and square")
+    n = U.shape[0]
+    z = _vector("prior_information_rhs", prior_information_rhs, n)
+    A = _matrix("measurement_matrix", measurement_matrix, cols=n)
+    b = _vector("measurement_rhs", measurement_rhs, A.shape[0])
+
+    work = np.vstack([
+        np.column_stack([U, z]),
+        np.column_stack([A, b]),
+    ]).astype(float, copy=False)
+    scale = max(float(np.linalg.norm(work[:, :n])), 1.0)
+    tol = np.finfo(float).eps * max(work.shape) * scale
+
+    # Apply each reflector directly to the remaining coefficient/RHS array;
+    # Q is never formed.  This is the standard numerically stable QR update.
+    for col in range(n):
+        x = work[col:, col].copy()
+        norm_x = float(np.linalg.norm(x))
+        if norm_x <= tol:
+            raise np.linalg.LinAlgError("information pre-array is rank deficient")
+        first_sign = 1.0 if x[0] >= 0.0 else -1.0
+        alpha = -first_sign * norm_x
+        x[0] -= alpha
+        norm_v = float(np.linalg.norm(x))
+        if norm_v <= tol:
+            raise np.linalg.LinAlgError("cannot construct a stable Householder reflector")
+        v = x / norm_v
+        tail = work[col:, col:]
+        tail -= 2.0 * np.outer(v, v @ tail)
+        work[col:, col:] = tail
+        work[col + 1:, col] = 0.0
+
+    root = np.triu(work[:n, :n])
+    rhs = work[:n, n]
+    root, rhs = _normalise_root_signs(root, rhs)
+    if np.any(np.abs(np.diag(root)) <= tol):
+        raise np.linalg.LinAlgError("posterior information root is singular")
+    solution = np.linalg.solve(root, rhs)
+    residual = work[n:, n]
+    return InformationRootUpdate(
+        precision_root=root,
+        information_rhs=rhs,
+        solution=solution,
+        trailing_residual=residual,
+        residual_sum_squares=float(residual @ residual),
+    )
+
+
+def precision_root_from_covariance(covariance, jitter=1e-9):
+    """Return U with ``covariance^-1 = U.T @ U`` without forming the inverse."""
+    cov = regularize_covariance(covariance, jitter=jitter, name="prior covariance")
+    chol = np.linalg.cholesky(cov)
+    inverse_factor = np.linalg.solve(chol, np.eye(chol.shape[0]))
+    empty = np.zeros((0, chol.shape[0]))
+    return np.array(householder_information_update(
+        inverse_factor,
+        np.zeros(chol.shape[0]),
+        empty,
+        np.zeros(0),
+    ).precision_root)
+
+
+def conditional_measurement_model(prior_precision_root, H, observation_covariance,
+                                  cross_covariance, jitter=1e-9):
+    """Decorrelate measurement noise from the prior error in information form.
+
+    Returns ``(J, Rc)`` such that innovation ``r | e ~ N(J e, Rc)``.
+    Block-sequential updates are exact only when ``Rc`` (not raw ``R``) is
+    block diagonal for the proposed measurement partition.
+    """
+    U = _matrix("prior_precision_root", prior_precision_root)
+    if U.shape[0] != U.shape[1] or U.shape[0] == 0:
+        raise ValueError("prior_precision_root must be nonempty and square")
+    n = U.shape[0]
+    Hm = _matrix("H", H, cols=n)
+    m = Hm.shape[0]
+    R = _matrix("observation_covariance", observation_covariance, m, m)
+    C = _matrix("cross_covariance", cross_covariance, n, m)
+
+    UC = U @ C
+    effective_H = Hm + UC.T @ U
+    conditional_R = R - UC.T @ UC
+    conditional_R = regularize_covariance(
+        conditional_R,
+        jitter=jitter,
+        name="conditional observation covariance R - C.T P^-1 C",
+    )
+    return effective_H, conditional_R
+
+
+def whiten_measurement_block(measurement_matrix, measurement_covariance, measurement_rhs,
+                             jitter=1e-9):
+    """Whiten one independent likelihood block with a Cholesky solve."""
+    J = _matrix("measurement_matrix", measurement_matrix)
+    m, _ = J.shape
+    Rc = regularize_covariance(
+        _matrix("measurement_covariance", measurement_covariance, m, m),
+        jitter=jitter,
+        name="measurement covariance",
+    )
+    r = _vector("measurement_rhs", measurement_rhs, m)
+    chol = np.linalg.cholesky(Rc)
+    return np.linalg.solve(chol, J), np.linalg.solve(chol, r), Rc
+
+
+def condition_correlated_gaussian_qr(mean, prior_precision_root, observation,
+                                     observation_covariance, H, cross_covariance,
+                                     jitter=1e-9):
+    """Condition a static Gaussian using the joint square-root/QR algorithm.
+
+    ``cross_covariance`` uses the same sign convention as
+    ``product_kalman.gaussian_condition_update``: ``Cov(truth-mean, v)`` for
+    ``observation = H @ truth + v``.
+    """
+    x = _vector("mean", mean)
+    U = _matrix("prior_precision_root", prior_precision_root, len(x), len(x))
+    y = _vector("observation", observation)
+    Hm = _matrix("H", H, len(y), len(x))
+    innovation = y - Hm @ x
+
+    effective_H, conditional_R = conditional_measurement_model(
+        U,
+        Hm,
+        observation_covariance,
+        cross_covariance,
+        jitter=jitter,
+    )
+    A, b, conditional_R = whiten_measurement_block(
+        effective_H,
+        conditional_R,
+        innovation,
+        jitter=jitter,
+    )
+    info = householder_information_update(U, np.zeros(len(x)), A, b)
+    posterior_mean = x + np.asarray(info.solution)
+    root_inv = np.linalg.solve(np.asarray(info.precision_root), np.eye(len(x)))
+    posterior_cov = root_inv @ root_inv.T
+    posterior_cov = 0.5 * (posterior_cov + posterior_cov.T)
+
+    return JointSquareRootUpdate(
+        mean=posterior_mean,
+        covariance=posterior_cov,
+        precision_root=info.precision_root,
+        information_rhs=info.information_rhs,
+        innovation=innovation,
+        effective_observation_matrix=effective_H,
+        conditional_observation_covariance=conditional_R,
+        whitened_observation_matrix=A,
+        whitened_innovation=b,
+        residual_sum_squares=info.residual_sum_squares,
+    )

--- a/prototypes/mu_cosine/joint_square_root_conditioner.py
+++ b/prototypes/mu_cosine/joint_square_root_conditioner.py
@@ -239,15 +239,22 @@ def conditional_measurement_model(prior_precision_root, H, observation_covarianc
 
 
 def whiten_measurement_block(measurement_matrix, measurement_covariance, measurement_rhs,
-                             jitter=1e-9):
-    """Whiten one independent likelihood block with a Cholesky solve."""
+                             jitter=1e-9, *, covariance_is_regularized=False):
+    """Whiten one independent likelihood block with a Cholesky solve.
+
+    Set ``covariance_is_regularized`` only when the covariance came directly
+    from :func:`conditional_measurement_model`; this avoids applying the
+    jitter/PSD policy twice in the composed conditioner.
+    """
     J = _matrix("measurement_matrix", measurement_matrix)
     m, _ = J.shape
-    Rc = regularize_covariance(
-        _matrix("measurement_covariance", measurement_covariance, m, m),
-        jitter=jitter,
-        name="measurement covariance",
-    )
+    Rc = _matrix("measurement_covariance", measurement_covariance, m, m)
+    if not covariance_is_regularized:
+        Rc = regularize_covariance(
+            Rc,
+            jitter=jitter,
+            name="measurement covariance",
+        )
     r = _vector("measurement_rhs", measurement_rhs, m)
     chol = np.linalg.cholesky(Rc)
     return np.linalg.solve(chol, J), np.linalg.solve(chol, r), Rc
@@ -280,6 +287,7 @@ def condition_correlated_gaussian_qr(mean, prior_precision_root, observation,
         conditional_R,
         innovation,
         jitter=jitter,
+        covariance_is_regularized=True,
     )
     info = householder_information_update(U, np.zeros(len(x)), A, b)
     posterior_mean = x + np.asarray(info.solution)

--- a/prototypes/mu_cosine/joint_square_root_conditioner_torch.py
+++ b/prototypes/mu_cosine/joint_square_root_conditioner_torch.py
@@ -1,0 +1,767 @@
+#!/usr/bin/env python3
+"""Batched PyTorch backend for the joint square-root/QR conditioner.
+
+The statistical model is identical to ``joint_square_root_conditioner.py``.
+This module changes the linear algebra implementation: it stores the compact
+Householder representation returned by :func:`torch.geqrf` and applies
+``Q.T`` to one or many right-hand sides with :func:`torch.ormqr`.  It never
+forms ``Q`` merely to obtain ``R`` or transform an observation.
+
+For a fixed ``(U, H, R, C)`` design, use
+:class:`CompiledCorrelatedConditionerTorch`.  One factorization can then
+condition a whole observation batch as columns of one RHS matrix.  For truly
+sequential, conditionally independent measurement blocks, use
+:class:`SquareRootInformationStateTorch`; each update threads ``U_post`` (and
+the information RHS) into the next QR factorization.
+
+For a fixed design that only needs posterior means/covariance, the matched
+throughput baseline is :class:`CompiledDenseGainConditionerTorch`: it caches
+the correlated gain and is expected to be faster.  Its gain cannot be reused
+when a later block changes the posterior, which is the root-threading QR case.
+
+All functions require real floating PyTorch tensors and preserve their dtype
+and device.  The implementation is inference-oriented.  In particular,
+``geqrf``/``ormqr`` backend and autograd coverage is narrower than
+``torch.linalg.qr`` on some PyTorch/device combinations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+import torch
+
+
+__all__ = [
+    "CompiledCorrelatedConditionerTorch",
+    "CompiledDenseGainConditionerTorch",
+    "CompiledInformationQRTorch",
+    "DenseGaussianUpdateTorch",
+    "InformationRootUpdateTorch",
+    "JointSquareRootUpdateTorch",
+    "SquareRootInformationStateTorch",
+    "compile_information_update_torch",
+    "condition_correlated_gaussian_qr_torch",
+    "conditional_measurement_model_torch",
+    "householder_information_update_torch",
+    "precision_root_from_covariance_torch",
+    "regularize_covariance_torch",
+]
+
+
+_SUPPORTED_DTYPES = (torch.float32, torch.float64)
+
+
+def _tensor(name: str, value: torch.Tensor) -> torch.Tensor:
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor")
+    if value.dtype not in _SUPPORTED_DTYPES:
+        raise TypeError(f"{name} must have dtype float32 or float64")
+    # Deliberately avoid a per-call ``isfinite(...).item()``: that would force
+    # a device-to-host synchronisation in the hot batched-conditioning path.
+    # LAPACK/cuSOLVER will propagate non-finite inputs to the result.
+    return value
+
+
+def _same_backend(reference: torch.Tensor, **values: torch.Tensor) -> None:
+    for name, value in values.items():
+        if value.device != reference.device:
+            raise ValueError(
+                f"{name} is on {value.device}, expected {reference.device}"
+            )
+        if value.dtype != reference.dtype:
+            raise ValueError(
+                f"{name} has dtype {value.dtype}, expected {reference.dtype}"
+            )
+
+
+def _matrix(
+    name: str,
+    value: torch.Tensor,
+    *,
+    rows: int | None = None,
+    cols: int | None = None,
+) -> torch.Tensor:
+    value = _tensor(name, value)
+    if value.ndim < 2:
+        raise ValueError(f"{name} must be a matrix or a batch of matrices")
+    if rows is not None and value.shape[-2] != rows:
+        raise ValueError(f"{name} has {value.shape[-2]} rows, expected {rows}")
+    if cols is not None and value.shape[-1] != cols:
+        raise ValueError(f"{name} has {value.shape[-1]} columns, expected {cols}")
+    return value
+
+
+def _vector(name: str, value: torch.Tensor, *, length: int) -> torch.Tensor:
+    value = _tensor(name, value)
+    if value.ndim < 1 or value.shape[-1] != length:
+        raise ValueError(f"{name} must end in a vector of length {length}")
+    return value
+
+
+def _broadcast_matrices(*values: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    batch_shape = torch.broadcast_shapes(*(v.shape[:-2] for v in values))
+    return tuple(v.expand(batch_shape + v.shape[-2:]) for v in values)
+
+
+def _normalised_root_from_packed(
+    packed: torch.Tensor, n: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    raw_root = torch.triu(packed[..., :n, :n])
+    diagonal = torch.diagonal(raw_root, dim1=-2, dim2=-1)
+    signs = torch.where(diagonal < 0, -torch.ones_like(diagonal), torch.ones_like(diagonal))
+    return raw_root * signs.unsqueeze(-1), signs
+
+
+def _check_root_rank(pre_array: torch.Tensor, root: torch.Tensor) -> None:
+    scale = torch.linalg.matrix_norm(pre_array, ord="fro", dim=(-2, -1))
+    scale = torch.maximum(scale, torch.ones_like(scale))
+    tolerance = torch.finfo(pre_array.dtype).eps * max(pre_array.shape[-2:]) * scale
+    smallest = torch.amin(torch.abs(torch.diagonal(root, dim1=-2, dim2=-1)), dim=-1)
+    if bool(torch.any(smallest <= tolerance).item()):
+        raise torch.linalg.LinAlgError("information pre-array is rank deficient")
+
+
+@dataclass(frozen=True)
+class InformationRootUpdateTorch:
+    """One information-root update, possibly batched or with multiple RHSs."""
+
+    precision_root: torch.Tensor
+    information_rhs: torch.Tensor
+    solution: torch.Tensor
+    trailing_residual: torch.Tensor
+    residual_sum_squares: torch.Tensor
+
+
+@dataclass(frozen=True)
+class JointSquareRootUpdateTorch:
+    """Result of correlated Gaussian conditioning in square-root form."""
+
+    mean: torch.Tensor
+    covariance: torch.Tensor
+    precision_root: torch.Tensor
+    information_rhs: torch.Tensor
+    innovation: torch.Tensor
+    effective_observation_matrix: torch.Tensor
+    conditional_observation_covariance: torch.Tensor
+    whitened_observation_matrix: torch.Tensor
+    whitened_innovation: torch.Tensor
+    residual_sum_squares: torch.Tensor
+
+
+@dataclass(frozen=True)
+class DenseGaussianUpdateTorch:
+    """Fixed-design dense correlated-gain update, possibly batched over rows."""
+
+    mean: torch.Tensor
+    covariance: torch.Tensor
+    gain: torch.Tensor
+    innovation: torch.Tensor
+    innovation_covariance: torch.Tensor
+
+
+@dataclass(frozen=True)
+class CompiledInformationQRTorch:
+    """Compact Householder factorization of ``stack([U_prior, A])``.
+
+    ``packed`` and ``tau`` are the LAPACK/cuSOLVER-style reflector storage from
+    ``geqrf``.  ``apply_columns`` is the most general API: its final dimension
+    is the number of right-hand sides.  ``apply_vectors`` treats leading
+    dimensions as independent observations; for an unbatched design it folds
+    all of them into RHS columns so one ``ormqr`` call handles the batch.
+    """
+
+    packed: torch.Tensor
+    tau: torch.Tensor
+    precision_root: torch.Tensor
+    row_signs: torch.Tensor
+    state_dim: int
+    measurement_dim: int
+
+    @property
+    def batch_shape(self) -> torch.Size:
+        return self.packed.shape[:-2]
+
+    def apply_columns(
+        self,
+        prior_information_rhs: torch.Tensor,
+        measurement_rhs: torch.Tensor,
+    ) -> InformationRootUpdateTorch:
+        """Apply the compiled reflectors to ``(..., rows, nrhs)`` tensors."""
+        n, m = self.state_dim, self.measurement_dim
+        z = _matrix("prior_information_rhs", prior_information_rhs, rows=n)
+        b = _matrix("measurement_rhs", measurement_rhs, rows=m)
+        _same_backend(self.packed, prior_information_rhs=z, measurement_rhs=b)
+        if z.shape[-1] != b.shape[-1]:
+            raise ValueError("prior and measurement RHS counts must match")
+
+        batch_shape = torch.broadcast_shapes(
+            self.batch_shape, z.shape[:-2], b.shape[:-2]
+        )
+        packed = self.packed.expand(batch_shape + self.packed.shape[-2:]).contiguous()
+        tau = self.tau.expand(batch_shape + self.tau.shape[-1:]).contiguous()
+        z = z.expand(batch_shape + z.shape[-2:])
+        b = b.expand(batch_shape + b.shape[-2:])
+        rhs = torch.cat([z, b], dim=-2).contiguous()
+
+        # ormqr applies the compact reflectors directly; Q is never materialised.
+        transformed = torch.ormqr(packed, tau, rhs, left=True, transpose=True)
+        signs = self.row_signs.expand(batch_shape + self.row_signs.shape[-1:])
+        root = self.precision_root.expand(
+            batch_shape + self.precision_root.shape[-2:]
+        )
+        information_rhs = transformed[..., :n, :] * signs.unsqueeze(-1)
+        solution = torch.linalg.solve_triangular(
+            root, information_rhs, upper=True
+        )
+        trailing = transformed[..., n:, :]
+        return InformationRootUpdateTorch(
+            precision_root=root,
+            information_rhs=information_rhs,
+            solution=solution,
+            trailing_residual=trailing,
+            residual_sum_squares=torch.sum(trailing.square(), dim=-2),
+        )
+
+    def apply_vectors(
+        self,
+        prior_information_rhs: torch.Tensor,
+        measurement_rhs: torch.Tensor,
+    ) -> InformationRootUpdateTorch:
+        """Apply to vector batches ``(..., n)`` and ``(..., m)``.
+
+        For a single fixed design, arbitrary observation batch dimensions are
+        flattened into RHS columns.  That is the throughput-oriented GPU path.
+        A batched design instead applies one factorization per broadcast batch
+        element.
+        """
+        n, m = self.state_dim, self.measurement_dim
+        z = _vector("prior_information_rhs", prior_information_rhs, length=n)
+        b = _vector("measurement_rhs", measurement_rhs, length=m)
+        _same_backend(self.packed, prior_information_rhs=z, measurement_rhs=b)
+        vector_batch = torch.broadcast_shapes(z.shape[:-1], b.shape[:-1])
+
+        if len(self.batch_shape) == 0:
+            z = z.expand(vector_batch + (n,))
+            b = b.expand(vector_batch + (m,))
+            count = math.prod(vector_batch) if vector_batch else 1
+            columns = self.apply_columns(
+                z.reshape(count, n).transpose(0, 1),
+                b.reshape(count, m).transpose(0, 1),
+            )
+            root = self.precision_root.expand(vector_batch + (n, n))
+            return InformationRootUpdateTorch(
+                precision_root=root,
+                information_rhs=columns.information_rhs.transpose(0, 1).reshape(
+                    vector_batch + (n,)
+                ),
+                solution=columns.solution.transpose(0, 1).reshape(vector_batch + (n,)),
+                trailing_residual=columns.trailing_residual.transpose(0, 1).reshape(
+                    vector_batch + (m,)
+                ),
+                residual_sum_squares=columns.residual_sum_squares.reshape(vector_batch),
+            )
+
+        batch_shape = torch.broadcast_shapes(self.batch_shape, vector_batch)
+        z = z.expand(batch_shape + (n,))
+        b = b.expand(batch_shape + (m,))
+        columns = self.apply_columns(z.unsqueeze(-1), b.unsqueeze(-1))
+        return InformationRootUpdateTorch(
+            precision_root=columns.precision_root,
+            information_rhs=columns.information_rhs.squeeze(-1),
+            solution=columns.solution.squeeze(-1),
+            trailing_residual=columns.trailing_residual.squeeze(-1),
+            residual_sum_squares=columns.residual_sum_squares.squeeze(-1),
+        )
+
+
+def compile_information_update_torch(
+    prior_precision_root: torch.Tensor,
+    measurement_matrix: torch.Tensor,
+) -> CompiledInformationQRTorch:
+    """Factor ``stack([U_prior, A])`` into compact Householder storage once."""
+    root = _matrix("prior_precision_root", prior_precision_root)
+    if root.shape[-2] != root.shape[-1] or root.shape[-1] == 0:
+        raise ValueError("prior_precision_root must be nonempty and square")
+    n = root.shape[-1]
+    matrix = _matrix("measurement_matrix", measurement_matrix, cols=n)
+    _same_backend(root, measurement_matrix=matrix)
+    root, matrix = _broadcast_matrices(root, matrix)
+    pre_array = torch.cat([root, matrix], dim=-2).contiguous()
+    packed, tau = torch.geqrf(pre_array)
+    posterior_root, signs = _normalised_root_from_packed(packed, n)
+    _check_root_rank(pre_array, posterior_root)
+    return CompiledInformationQRTorch(
+        packed=packed,
+        tau=tau,
+        precision_root=posterior_root,
+        row_signs=signs,
+        state_dim=n,
+        measurement_dim=matrix.shape[-2],
+    )
+
+
+def householder_information_update_torch(
+    prior_precision_root: torch.Tensor,
+    prior_information_rhs: torch.Tensor,
+    measurement_matrix: torch.Tensor,
+    measurement_rhs: torch.Tensor,
+) -> InformationRootUpdateTorch:
+    """Factor and apply one possibly batched whitened information update."""
+    compiled = compile_information_update_torch(
+        prior_precision_root, measurement_matrix
+    )
+    return compiled.apply_vectors(prior_information_rhs, measurement_rhs)
+
+
+def regularize_covariance_torch(
+    covariance: torch.Tensor,
+    *,
+    jitter: float = 1e-9,
+    name: str = "covariance",
+) -> torch.Tensor:
+    """Symmetrise and minimally lift a PSD covariance, in batch.
+
+    The effective floor is at least machine epsilon.  Thus float64 matches the
+    NumPy prototype's default ``1e-9`` floor, while float32 automatically uses
+    a representable stability floor.
+    """
+    if jitter < 0:
+        raise ValueError("jitter must be nonnegative")
+    covariance = _matrix(name, covariance)
+    if covariance.shape[-2] != covariance.shape[-1]:
+        raise ValueError(f"{name} must be square")
+    covariance = 0.5 * (covariance + covariance.transpose(-2, -1))
+    eigenvalues = torch.linalg.eigvalsh(covariance)
+    minimum = eigenvalues[..., 0]
+    floor = max(float(jitter), torch.finfo(covariance.dtype).eps)
+    if bool(torch.any(minimum < -100.0 * floor).item()):
+        worst = float(torch.amin(minimum).detach().cpu())
+        raise ValueError(f"{name} is not positive semidefinite; min eigenvalue={worst:g}")
+    lift = torch.clamp(floor - minimum, min=0.0)
+    identity = torch.eye(
+        covariance.shape[-1], dtype=covariance.dtype, device=covariance.device
+    )
+    return covariance + lift[..., None, None] * identity
+
+
+def precision_root_from_covariance_torch(
+    covariance: torch.Tensor, *, jitter: float = 1e-9
+) -> torch.Tensor:
+    """Return upper ``U`` with ``P^-1 = U.T @ U`` without forming ``P^-1``."""
+    covariance = regularize_covariance_torch(
+        covariance, jitter=jitter, name="prior covariance"
+    )
+    n = covariance.shape[-1]
+    chol = torch.linalg.cholesky(covariance)
+    identity = torch.eye(n, dtype=chol.dtype, device=chol.device).expand(
+        chol.shape[:-2] + (n, n)
+    )
+    inverse_factor = torch.linalg.solve_triangular(chol, identity, upper=False)
+    packed, _ = torch.geqrf(inverse_factor.contiguous())
+    root, _ = _normalised_root_from_packed(packed, n)
+    _check_root_rank(inverse_factor, root)
+    return root
+
+
+def conditional_measurement_model_torch(
+    prior_precision_root: torch.Tensor,
+    H: torch.Tensor,
+    observation_covariance: torch.Tensor,
+    cross_covariance: torch.Tensor,
+    *,
+    jitter: float = 1e-9,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return the decorrelated ``(J, Rc)`` likelihood in information form."""
+    root = _matrix("prior_precision_root", prior_precision_root)
+    if root.shape[-2] != root.shape[-1] or root.shape[-1] == 0:
+        raise ValueError("prior_precision_root must be nonempty and square")
+    n = root.shape[-1]
+    H = _matrix("H", H, cols=n)
+    m = H.shape[-2]
+    observation_covariance = _matrix(
+        "observation_covariance", observation_covariance, rows=m, cols=m
+    )
+    cross_covariance = _matrix(
+        "cross_covariance", cross_covariance, rows=n, cols=m
+    )
+    _same_backend(
+        root,
+        H=H,
+        observation_covariance=observation_covariance,
+        cross_covariance=cross_covariance,
+    )
+    root, H, observation_covariance, cross_covariance = _broadcast_matrices(
+        root, H, observation_covariance, cross_covariance
+    )
+    root_cross = root @ cross_covariance
+    effective_H = H + root_cross.transpose(-2, -1) @ root
+    conditional_R = (
+        observation_covariance
+        - root_cross.transpose(-2, -1) @ root_cross
+    )
+    conditional_R = regularize_covariance_torch(
+        conditional_R,
+        jitter=jitter,
+        name="conditional observation covariance R - C.T P^-1 C",
+    )
+    return effective_H, conditional_R
+
+
+def _posterior_covariance(root: torch.Tensor) -> torch.Tensor:
+    n = root.shape[-1]
+    identity = torch.eye(n, dtype=root.dtype, device=root.device).expand(
+        root.shape[:-2] + (n, n)
+    )
+    inverse_root = torch.linalg.solve_triangular(root, identity, upper=True)
+    covariance = inverse_root @ inverse_root.transpose(-2, -1)
+    return 0.5 * (covariance + covariance.transpose(-2, -1))
+
+
+def _covariance_from_precision_factor(factor: torch.Tensor) -> torch.Tensor:
+    """Recover covariance from any square ``U`` satisfying ``Lambda=U.T U``."""
+    n = factor.shape[-1]
+    identity = torch.eye(n, dtype=factor.dtype, device=factor.device).expand(
+        factor.shape[:-2] + (n, n)
+    )
+    inverse_factor = torch.linalg.solve(factor, identity)
+    covariance = inverse_factor @ inverse_factor.transpose(-2, -1)
+    return 0.5 * (covariance + covariance.transpose(-2, -1))
+
+
+def condition_correlated_gaussian_qr_torch(
+    mean: torch.Tensor,
+    prior_precision_root: torch.Tensor,
+    observation: torch.Tensor,
+    observation_covariance: torch.Tensor,
+    H: torch.Tensor,
+    cross_covariance: torch.Tensor,
+    *,
+    jitter: float = 1e-9,
+) -> JointSquareRootUpdateTorch:
+    """Condition a Gaussian with batched tensors and compact Householder QR."""
+    root = _matrix("prior_precision_root", prior_precision_root)
+    if root.shape[-2] != root.shape[-1] or root.shape[-1] == 0:
+        raise ValueError("prior_precision_root must be nonempty and square")
+    n = root.shape[-1]
+    mean = _vector("mean", mean, length=n)
+    H = _matrix("H", H, cols=n)
+    m = H.shape[-2]
+    observation = _vector("observation", observation, length=m)
+    _same_backend(root, mean=mean, H=H, observation=observation)
+
+    effective_H, conditional_R = conditional_measurement_model_torch(
+        root,
+        H,
+        observation_covariance,
+        cross_covariance,
+        jitter=jitter,
+    )
+    design_batch = torch.broadcast_shapes(
+        root.shape[:-2], H.shape[:-2], effective_H.shape[:-2]
+    )
+    result_batch = torch.broadcast_shapes(
+        design_batch, mean.shape[:-1], observation.shape[:-1]
+    )
+    root = root.expand(design_batch + (n, n))
+    H_design = H.expand(design_batch + (m, n))
+    effective_H = effective_H.expand(design_batch + (m, n))
+    conditional_R = conditional_R.expand(design_batch + (m, m))
+    chol = torch.linalg.cholesky(conditional_R)
+    whitened_H = torch.linalg.solve_triangular(
+        chol, effective_H, upper=False
+    )
+    compiled = compile_information_update_torch(root, whitened_H)
+
+    mean = mean.expand(result_batch + (n,))
+    observation = observation.expand(result_batch + (m,))
+    H_result = H_design.expand(result_batch + (m, n))
+    innovation = observation - (H_result @ mean.unsqueeze(-1)).squeeze(-1)
+    chol_result = chol.expand(result_batch + (m, m))
+    whitened_innovation = torch.linalg.solve_triangular(
+        chol_result, innovation.unsqueeze(-1), upper=False
+    ).squeeze(-1)
+    information = compiled.apply_vectors(
+        torch.zeros_like(mean), whitened_innovation
+    )
+    return JointSquareRootUpdateTorch(
+        mean=mean + information.solution,
+        covariance=_posterior_covariance(information.precision_root),
+        precision_root=information.precision_root,
+        information_rhs=information.information_rhs,
+        innovation=innovation,
+        effective_observation_matrix=effective_H.expand(result_batch + (m, n)),
+        conditional_observation_covariance=conditional_R.expand(
+            result_batch + (m, m)
+        ),
+        whitened_observation_matrix=whitened_H.expand(result_batch + (m, n)),
+        whitened_innovation=whitened_innovation,
+        residual_sum_squares=information.residual_sum_squares,
+    )
+
+
+@dataclass(frozen=True)
+class CompiledCorrelatedConditionerTorch:
+    """Compile one fixed correlated measurement design and reuse it per row."""
+
+    prior_precision_root: torch.Tensor
+    H: torch.Tensor
+    effective_observation_matrix: torch.Tensor
+    conditional_observation_covariance: torch.Tensor
+    conditional_cholesky: torch.Tensor
+    whitened_observation_matrix: torch.Tensor
+    information_qr: CompiledInformationQRTorch
+    posterior_covariance: torch.Tensor
+
+    @classmethod
+    def compile(
+        cls,
+        prior_precision_root: torch.Tensor,
+        H: torch.Tensor,
+        observation_covariance: torch.Tensor,
+        cross_covariance: torch.Tensor,
+        *,
+        jitter: float = 1e-9,
+    ) -> "CompiledCorrelatedConditionerTorch":
+        """Compile an unbatched fixed design.
+
+        Unbatched design is intentional: it lets all sample dimensions become
+        RHS columns of one ``ormqr`` call.  Use the functional API for a batch
+        of distinct designs.
+        """
+        for name, value in (
+            ("prior_precision_root", prior_precision_root),
+            ("H", H),
+            ("observation_covariance", observation_covariance),
+            ("cross_covariance", cross_covariance),
+        ):
+            if not isinstance(value, torch.Tensor) or value.ndim != 2:
+                raise ValueError(f"{name} must be one unbatched matrix")
+        # Compiled objects own a snapshot of coefficient inputs. Otherwise an
+        # in-place caller mutation of H would combine a new innovation with
+        # stale QR reflectors.
+        prior_precision_root = prior_precision_root.clone()
+        H = H.clone()
+        effective_H, conditional_R = conditional_measurement_model_torch(
+            prior_precision_root,
+            H,
+            observation_covariance,
+            cross_covariance,
+            jitter=jitter,
+        )
+        chol = torch.linalg.cholesky(conditional_R)
+        whitened_H = torch.linalg.solve_triangular(
+            chol, effective_H, upper=False
+        )
+        information_qr = compile_information_update_torch(
+            prior_precision_root, whitened_H
+        )
+        return cls(
+            prior_precision_root=prior_precision_root,
+            H=H,
+            effective_observation_matrix=effective_H,
+            conditional_observation_covariance=conditional_R,
+            conditional_cholesky=chol,
+            whitened_observation_matrix=whitened_H,
+            information_qr=information_qr,
+            posterior_covariance=_posterior_covariance(
+                information_qr.precision_root
+            ),
+        )
+
+    def condition(
+        self, mean: torch.Tensor, observation: torch.Tensor
+    ) -> JointSquareRootUpdateTorch:
+        """Condition one row or an arbitrary batch using the compiled design."""
+        n = self.prior_precision_root.shape[-1]
+        m = self.H.shape[-2]
+        mean = _vector("mean", mean, length=n)
+        observation = _vector("observation", observation, length=m)
+        _same_backend(
+            self.prior_precision_root, mean=mean, observation=observation
+        )
+        batch_shape = torch.broadcast_shapes(mean.shape[:-1], observation.shape[:-1])
+        mean = mean.expand(batch_shape + (n,))
+        observation = observation.expand(batch_shape + (m,))
+        innovation = observation - torch.einsum("mn,...n->...m", self.H, mean)
+        count = math.prod(batch_shape) if batch_shape else 1
+        innovation_columns = innovation.reshape(count, m).transpose(0, 1)
+        whitened_innovation = torch.linalg.solve_triangular(
+            self.conditional_cholesky,
+            innovation_columns.contiguous(),
+            upper=False,
+        ).transpose(0, 1).reshape(batch_shape + (m,))
+        information = self.information_qr.apply_vectors(
+            torch.zeros_like(mean), whitened_innovation
+        )
+        return JointSquareRootUpdateTorch(
+            mean=mean + information.solution,
+            covariance=self.posterior_covariance.expand(batch_shape + (n, n)),
+            precision_root=information.precision_root,
+            information_rhs=information.information_rhs,
+            innovation=innovation,
+            effective_observation_matrix=self.effective_observation_matrix.expand(
+                batch_shape + (m, n)
+            ),
+            conditional_observation_covariance=(
+                self.conditional_observation_covariance.expand(
+                    batch_shape + (m, m)
+                )
+            ),
+            whitened_observation_matrix=self.whitened_observation_matrix.expand(
+                batch_shape + (m, n)
+            ),
+            whitened_innovation=whitened_innovation,
+            residual_sum_squares=information.residual_sum_squares,
+        )
+
+
+@dataclass(frozen=True)
+class CompiledDenseGainConditionerTorch:
+    """Compile the dense correlated Gaussian gain for one fixed design.
+
+    This is the matched static-throughput baseline for the compiled QR path.
+    It uses the same conditional ``(J, Rc)`` model (and therefore the same
+    cross-covariance validation/regularisation), then caches
+
+    ``K = Cov(e, r) @ Cov(r)^-1``.
+
+    Per row, conditioning is only ``r = y - H mean`` and ``mean + K r``.
+    Unlike square-root QR, this class does not carry an updated precision root
+    into a later measurement block; recompile it whenever the design changes.
+    """
+
+    H: torch.Tensor
+    gain: torch.Tensor
+    posterior_covariance: torch.Tensor
+    innovation_covariance: torch.Tensor
+
+    @classmethod
+    def compile(
+        cls,
+        prior_precision_root: torch.Tensor,
+        H: torch.Tensor,
+        observation_covariance: torch.Tensor,
+        cross_covariance: torch.Tensor,
+        *,
+        jitter: float = 1e-9,
+    ) -> "CompiledDenseGainConditionerTorch":
+        """Compile an unbatched fixed design into a dense correlated gain."""
+        for name, value in (
+            ("prior_precision_root", prior_precision_root),
+            ("H", H),
+            ("observation_covariance", observation_covariance),
+            ("cross_covariance", cross_covariance),
+        ):
+            if not isinstance(value, torch.Tensor) or value.ndim != 2:
+                raise ValueError(f"{name} must be one unbatched matrix")
+        root = _matrix("prior_precision_root", prior_precision_root).clone()
+        if root.shape[-2] != root.shape[-1] or root.shape[-1] == 0:
+            raise ValueError("prior_precision_root must be nonempty and square")
+        n = root.shape[-1]
+        H = _matrix("H", H, cols=n).clone()
+        _same_backend(root, H=H)
+
+        # Use the same Schur-complement model as QR.  This both validates the
+        # proposed joint covariance and makes jitter behavior directly
+        # comparable between the two static implementations.
+        effective_H, conditional_R = conditional_measurement_model_torch(
+            root,
+            H,
+            observation_covariance,
+            cross_covariance,
+            jitter=jitter,
+        )
+        # The first precision factor need not already be triangular: left
+        # orthogonal rotations preserve U.T U.  Use a general solve here;
+        # posterior QR roots use the cheaper triangular helper above.
+        prior_covariance = _covariance_from_precision_factor(root)
+        state_innovation_cross = prior_covariance @ effective_H.mT
+        innovation_covariance = (
+            effective_H @ state_innovation_cross + conditional_R
+        )
+        innovation_covariance = 0.5 * (
+            innovation_covariance + innovation_covariance.mT
+        )
+        innovation_chol = torch.linalg.cholesky(innovation_covariance)
+        gain = torch.cholesky_solve(
+            state_innovation_cross.mT, innovation_chol
+        ).mT
+        posterior_covariance = (
+            prior_covariance - gain @ state_innovation_cross.mT
+        )
+        posterior_covariance = 0.5 * (
+            posterior_covariance + posterior_covariance.mT
+        )
+        # The dense subtraction can lose the last positive bits when a very
+        # informative observation makes P_post tiny.  Keep this baseline a
+        # valid Gaussian rather than returning a singular/negative covariance;
+        # the square-root path is positive definite by construction.
+        posterior_covariance = regularize_covariance_torch(
+            posterior_covariance,
+            jitter=jitter,
+            name="dense posterior covariance",
+        )
+        return cls(
+            H=H,
+            gain=gain,
+            posterior_covariance=posterior_covariance,
+            innovation_covariance=innovation_covariance,
+        )
+
+    def condition(
+        self, mean: torch.Tensor, observation: torch.Tensor
+    ) -> DenseGaussianUpdateTorch:
+        """Condition one row or an arbitrary row batch with the cached gain."""
+        n = self.H.shape[-1]
+        m = self.H.shape[-2]
+        mean = _vector("mean", mean, length=n)
+        observation = _vector("observation", observation, length=m)
+        _same_backend(self.H, mean=mean, observation=observation)
+        batch_shape = torch.broadcast_shapes(mean.shape[:-1], observation.shape[:-1])
+        mean = mean.expand(batch_shape + (n,))
+        observation = observation.expand(batch_shape + (m,))
+        innovation = observation - torch.einsum("mn,...n->...m", self.H, mean)
+        posterior_mean = mean + torch.einsum(
+            "nm,...m->...n", self.gain, innovation
+        )
+        return DenseGaussianUpdateTorch(
+            mean=posterior_mean,
+            covariance=self.posterior_covariance.expand(batch_shape + (n, n)),
+            gain=self.gain.expand(batch_shape + (n, m)),
+            innovation=innovation,
+            innovation_covariance=self.innovation_covariance.expand(
+                batch_shape + (m, m)
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class SquareRootInformationStateTorch:
+    """Sequential information state in one fixed coordinate system.
+
+    Each block threads ``U_post`` and ``z``, so every measurement RHS must use
+    the same state origin.  To recenter at the current posterior mean, instead
+    reset ``z`` to zero and shift each later RHS by ``-A @ current_solution``;
+    do not both carry ``z`` and recenter the likelihood.
+    """
+
+    precision_root: torch.Tensor
+    information_rhs: torch.Tensor
+
+    def update(
+        self, measurement_matrix: torch.Tensor, measurement_rhs: torch.Tensor
+    ) -> tuple["SquareRootInformationStateTorch", InformationRootUpdateTorch]:
+        """Absorb one independent whitened block in the state's coordinates."""
+        result = householder_information_update_torch(
+            self.precision_root,
+            self.information_rhs,
+            measurement_matrix,
+            measurement_rhs,
+        )
+        state = SquareRootInformationStateTorch(
+            precision_root=result.precision_root,
+            information_rhs=result.information_rhs,
+        )
+        return state, result

--- a/prototypes/mu_cosine/joint_square_root_conditioner_torch.py
+++ b/prototypes/mu_cosine/joint_square_root_conditioner_torch.py
@@ -119,8 +119,14 @@ def _check_root_rank(pre_array: torch.Tensor, root: torch.Tensor) -> None:
     scale = torch.maximum(scale, torch.ones_like(scale))
     tolerance = torch.finfo(pre_array.dtype).eps * max(pre_array.shape[-2:]) * scale
     smallest = torch.amin(torch.abs(torch.diagonal(root, dim1=-2, dim2=-1)), dim=-1)
-    if bool(torch.any(smallest <= tolerance).item()):
-        raise torch.linalg.LinAlgError("information pre-array is rank deficient")
+    failed = smallest <= tolerance
+    if bool(torch.any(failed).item()):
+        if failed.ndim:
+            indices = torch.nonzero(failed, as_tuple=False).detach().cpu().tolist()
+            detail = f" at batch indices {indices}"
+        else:
+            detail = " for the unbatched design"
+        raise torch.linalg.LinAlgError(f"information pre-array is rank deficient{detail}")
 
 
 @dataclass(frozen=True)
@@ -440,7 +446,13 @@ def condition_correlated_gaussian_qr_torch(
     *,
     jitter: float = 1e-9,
 ) -> JointSquareRootUpdateTorch:
-    """Condition a Gaussian with batched tensors and compact Householder QR."""
+    """Condition a Gaussian with batched tensors and compact Householder QR.
+
+    This functional entry point validates and factorizes the design on every
+    call, including an eigendecomposition and device synchronization in the
+    covariance guard. Repeated fixed-design throughput should use
+    :class:`CompiledCorrelatedConditionerTorch`.
+    """
     root = _matrix("prior_precision_root", prior_precision_root)
     if root.shape[-2] != root.shape[-1] or root.shape[-1] == 0:
         raise ValueError("prior_precision_root must be nonempty and square")

--- a/prototypes/mu_cosine/node_disjoint_eval.py
+++ b/prototypes/mu_cosine/node_disjoint_eval.py
@@ -1,0 +1,304 @@
+"""Reusable node-disjoint splitting and paired node-block bootstrap utilities.
+
+The pair rows used by the mu-cosine experiments are not independent: a node can
+occur in many rows.  This module keeps two different uncertainty questions
+separate:
+
+* :func:`node_disjoint_pair_split` makes an outcome-blind train/held partition
+  by assigning *nodes*, then discarding pairs that cross the node partition.
+* :func:`paired_node_bootstrap_ci` estimates uncertainty of a paired row metric
+  on one fixed held partition by resampling held nodes.  A non-self pair gets
+  the product of its two endpoint multiplicities, so dependence through either
+  endpoint is retained (the two-endpoint/pigeonhole node bootstrap).
+
+Variation across several split seeds is useful as a Monte Carlo stability
+diagnostic.  It is not a sampling standard error and is deliberately not
+computed here.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Hashable, Sequence
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class PartitionCounts:
+    """Pair counts for one stratum after assigning nodes."""
+
+    total: int
+    train: int
+    held: int
+    cross: int
+
+
+@dataclass
+class NodeDisjointSplit:
+    """Indices and coverage diagnostics for an outcome-blind node split."""
+
+    train: np.ndarray
+    held: np.ndarray
+    cross: np.ndarray
+    train_nodes: frozenset[Hashable]
+    held_nodes: frozenset[Hashable]
+    strata: dict[Hashable, PartitionCounts]
+    seed: int
+    held_node_fraction: float
+    candidates: int
+    selected_candidate: int
+
+    @property
+    def retained_fraction(self) -> float:
+        total = len(self.train) + len(self.held) + len(self.cross)
+        return (len(self.train) + len(self.held)) / total if total else float("nan")
+
+    def missing_strata(self, minimum: int = 1) -> tuple[tuple[Hashable, ...], tuple[Hashable, ...]]:
+        """Return strata below ``minimum`` in train and held, respectively."""
+        train = tuple(k for k, v in self.strata.items() if v.train < minimum)
+        held = tuple(k for k, v in self.strata.items() if v.held < minimum)
+        return train, held
+
+
+@dataclass(frozen=True)
+class NodeBootstrapInterval:
+    """Percentile interval for a mean paired gain on one fixed held split."""
+
+    estimate: float
+    low: float
+    high: float
+    bootstrap_mean: float
+    confidence: float
+    n_resamples: int
+    n_attempts: int
+
+
+def _stable_node_key(node: Hashable) -> tuple[str, str]:
+    """Sort heterogeneous hashable node IDs without relying on set order."""
+    return type(node).__qualname__, repr(node)
+
+
+def _partition_indices(pairs, held_nodes):
+    train, held, cross = [], [], []
+    for i, (left, right) in enumerate(pairs):
+        left_held = left in held_nodes
+        right_held = right in held_nodes
+        if left_held and right_held:
+            held.append(i)
+        elif not left_held and not right_held:
+            train.append(i)
+        else:
+            cross.append(i)
+    return (
+        np.asarray(train, dtype=int),
+        np.asarray(held, dtype=int),
+        np.asarray(cross, dtype=int),
+    )
+
+
+def _stratum_counts(labels, train, held, cross):
+    total = Counter(labels)
+    tr = Counter(labels[i] for i in train)
+    he = Counter(labels[i] for i in held)
+    cr = Counter(labels[i] for i in cross)
+    return {
+        label: PartitionCounts(total[label], tr[label], he[label], cr[label])
+        for label in sorted(total, key=lambda x: (type(x).__qualname__, repr(x)))
+    }
+
+
+def _candidate_score(counts, train, held, cross, held_node_fraction, minimum):
+    """Outcome-blind balance score; smaller is better.
+
+    The expected held share among retained pairs is p²/(p²+(1-p)²) when a
+    fraction p of nodes is held.  Candidate search uses that target plus
+    per-stratum coverage.  Labels and graph incidence are allowed inputs;
+    D/S outcomes are not.
+    """
+    empty_partitions = int(len(train) == 0) + int(len(held) == 0)
+    coverage_deficit = sum(
+        max(0, minimum - value.train) + max(0, minimum - value.held)
+        for value in counts.values()
+    )
+    p = held_node_fraction
+    target = p * p / (p * p + (1.0 - p) * (1.0 - p))
+    retained = len(train) + len(held)
+    observed = len(held) / retained if retained else 0.0
+    pair_balance = abs(observed - target)
+
+    total_pairs = sum(value.total for value in counts.values())
+    stratum_balance = 0.0
+    for value in counts.values():
+        n = value.train + value.held
+        share = value.held / n if n else 0.0
+        stratum_balance += value.total / total_pairs * abs(share - target)
+
+    return (
+        empty_partitions,
+        coverage_deficit,
+        stratum_balance,
+        pair_balance,
+        -retained,
+        len(cross),
+    )
+
+
+def node_disjoint_pair_split(
+    pairs: Sequence[tuple[Hashable, Hashable]],
+    seed: int,
+    *,
+    held_node_fraction: float = 0.40,
+    strata: Sequence[Hashable] | None = None,
+    candidates: int = 64,
+    minimum_per_stratum: int = 1,
+) -> NodeDisjointSplit:
+    """Choose a deterministic, coverage-aware node-disjoint pair split.
+
+    Exactly ``round(held_node_fraction * n_nodes)`` nodes are assigned to held
+    (bounded to leave at least one node on each side).  The 0.40 default yields
+    an expected held share of about 30.8% among retained pairs, because random
+    node assignment gives p²/(p²+(1-p)²), rather than p, as the retained-pair
+    share.  Pairs with one endpoint on each side are returned in ``cross`` and
+    must not be used for fitting or evaluation.  If ``candidates > 1``, several
+    seeded node assignments are scored using only pair incidence and optional
+    stratum labels; outcomes are never inspected.
+    """
+    pairs = list(pairs)
+    if not pairs:
+        raise ValueError("pairs must be non-empty")
+    if not 0.0 < held_node_fraction < 1.0:
+        raise ValueError("held_node_fraction must be strictly between 0 and 1")
+    if candidates < 1:
+        raise ValueError("candidates must be positive")
+    if minimum_per_stratum < 0:
+        raise ValueError("minimum_per_stratum must be non-negative")
+    if any(len(pair) != 2 for pair in pairs):
+        raise ValueError("every pair must contain exactly two endpoints")
+
+    labels = list(strata) if strata is not None else ["all"] * len(pairs)
+    if len(labels) != len(pairs):
+        raise ValueError("strata must align one-for-one with pairs")
+    nodes = sorted({node for pair in pairs for node in pair}, key=_stable_node_key)
+    if len(nodes) < 2:
+        raise ValueError("a node-disjoint split requires at least two distinct nodes")
+
+    n_held = int(np.floor(held_node_fraction * len(nodes) + 0.5))
+    n_held = min(len(nodes) - 1, max(1, n_held))
+    rng = np.random.default_rng(seed)
+    best = None
+    best_score = None
+    for candidate in range(candidates):
+        order = rng.permutation(len(nodes))
+        held_nodes = frozenset(nodes[i] for i in order[:n_held])
+        train, held, cross = _partition_indices(pairs, held_nodes)
+        counts = _stratum_counts(labels, train, held, cross)
+        score = _candidate_score(
+            counts,
+            train,
+            held,
+            cross,
+            held_node_fraction,
+            minimum_per_stratum,
+        ) + (candidate,)
+        if best_score is None or score < best_score:
+            best_score = score
+            best = (candidate, held_nodes, train, held, cross, counts)
+
+    candidate, held_nodes, train, held, cross, counts = best
+    return NodeDisjointSplit(
+        train=train,
+        held=held,
+        cross=cross,
+        train_nodes=frozenset(nodes) - held_nodes,
+        held_nodes=held_nodes,
+        strata=counts,
+        seed=int(seed),
+        held_node_fraction=float(held_node_fraction),
+        candidates=int(candidates),
+        selected_candidate=int(candidate),
+    )
+
+
+def format_split_diagnostics(split: NodeDisjointSplit) -> str:
+    """Return compact train/held/cross and per-stratum coverage diagnostics."""
+    pair_total = len(split.train) + len(split.held) + len(split.cross)
+    lines = [
+        f"nodes train/held={len(split.train_nodes)}/{len(split.held_nodes)} "
+        f"(held {len(split.held_nodes) / (len(split.train_nodes) + len(split.held_nodes)):.1%}); "
+        f"pairs train/held/cross={len(split.train)}/{len(split.held)}/{len(split.cross)} "
+        f"(retained {split.retained_fraction:.1%} of {pair_total})",
+        "stratum                 total  train  held  cross",
+    ]
+    for label, value in split.strata.items():
+        lines.append(
+            f"{str(label):24.24s} {value.total:6d} {value.train:6d} {value.held:5d} {value.cross:6d}"
+        )
+    return "\n".join(lines)
+
+
+def paired_node_bootstrap_ci(
+    pairs: Sequence[tuple[Hashable, Hashable]],
+    paired_values: Sequence[float],
+    *,
+    n_resamples: int = 2000,
+    seed: int = 0,
+    confidence: float = 0.95,
+) -> NodeBootstrapInterval:
+    """Paired percentile CI for a mean using nodes as dependence blocks.
+
+    ``paired_values`` should already be row-wise differences (for example,
+    baseline NLL minus candidate NLL) on one fixed held split.  Each bootstrap
+    draw samples the held nodes with replacement.  A pair's weight is the
+    product of its endpoint multiplicities; self-pairs use the single endpoint
+    multiplicity.  Draws containing none of the observed pairs are retried.
+    """
+    pairs = list(pairs)
+    values = np.asarray(paired_values, dtype=float)
+    if len(pairs) == 0:
+        raise ValueError("pairs must be non-empty")
+    if values.ndim != 1 or len(values) != len(pairs):
+        raise ValueError("paired_values must be a one-dimensional array aligned with pairs")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("paired_values must all be finite")
+    if n_resamples < 1:
+        raise ValueError("n_resamples must be positive")
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be strictly between 0 and 1")
+
+    nodes = sorted({node for pair in pairs for node in pair}, key=_stable_node_key)
+    node_index = {node: i for i, node in enumerate(nodes)}
+    left = np.asarray([node_index[pair[0]] for pair in pairs], dtype=int)
+    right = np.asarray([node_index[pair[1]] for pair in pairs], dtype=int)
+    self_pair = left == right
+    rng = np.random.default_rng(seed)
+    probabilities = np.full(len(nodes), 1.0 / len(nodes))
+    replicates = []
+    attempts = 0
+    max_attempts = max(n_resamples * 20, n_resamples + 100)
+    while len(replicates) < n_resamples and attempts < max_attempts:
+        attempts += 1
+        multiplicity = rng.multinomial(len(nodes), probabilities)
+        weights = multiplicity[left] * multiplicity[right]
+        weights[self_pair] = multiplicity[left[self_pair]]
+        total_weight = int(weights.sum())
+        if total_weight:
+            replicates.append(float(np.dot(weights, values) / total_weight))
+    if len(replicates) < n_resamples:
+        raise RuntimeError(
+            f"only {len(replicates)}/{n_resamples} non-empty node-bootstrap draws "
+            f"after {attempts} attempts"
+        )
+
+    boot = np.asarray(replicates)
+    alpha = (1.0 - confidence) / 2.0
+    low, high = np.quantile(boot, [alpha, 1.0 - alpha])
+    return NodeBootstrapInterval(
+        estimate=float(values.mean()),
+        low=float(low),
+        high=float(high),
+        bootstrap_mean=float(boot.mean()),
+        confidence=float(confidence),
+        n_resamples=int(n_resamples),
+        n_attempts=int(attempts),
+    )

--- a/prototypes/mu_cosine/node_disjoint_eval.py
+++ b/prototypes/mu_cosine/node_disjoint_eval.py
@@ -63,7 +63,13 @@ class NodeDisjointSplit:
 
 @dataclass(frozen=True)
 class NodeBootstrapInterval:
-    """Percentile interval for a mean paired gain on one fixed held split."""
+    """Percentile interval for a mean paired gain on one fixed held split.
+
+    ``estimate`` is the empirical plug-in row mean (equivalently, the
+    pigeonhole ratio statistic when every observed node has multiplicity one).
+    Bootstrap replicates use sampled endpoint multiplicities; their finite-
+    sample mean can differ, so ``bootstrap_mean`` is retained for auditing.
+    """
 
     estimate: float
     low: float
@@ -252,6 +258,9 @@ def paired_node_bootstrap_ci(
     draw samples the held nodes with replacement.  A pair's weight is the
     product of its endpoint multiplicities; self-pairs use the single endpoint
     multiplicity.  Draws containing none of the observed pairs are retried.
+    The reported point is the empirical plug-in row mean; resampled intervals
+    use multiplicity-weighted ratio means and agree with that estimand only in
+    expectation under the bootstrap law.
     """
     pairs = list(pairs)
     values = np.asarray(paired_values, dtype=float)

--- a/prototypes/mu_cosine/run_cheap_judge_joint_posterior.py
+++ b/prototypes/mu_cosine/run_cheap_judge_joint_posterior.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Same-split JointPosterior comparison for the cheap-judge pipeline.
+
+The campaign cannot support an honest eight-way relation-class comparison: ``cur_rel`` is the
+sampler's structural provenance and is ``subcategory`` for every scored row.  Instead, this script
+declares a *decision-space bridge* from the operating judge's eight probabilities to three macro
+decisions that the continuous D/S state can plausibly represent:
+
+    directional = element_of + subcategory + subtopic + super_category
+    symmetric   = see_also + assoc
+    other       = unknown + none
+
+The target is the argmax macro decision.  It is GPT-5.5 decision fidelity, not ground truth and not
+eight-way relation recovery.  A train-only logistic ``p(decision | D,S)`` bridge maps the correlated
+Gaussian posterior into that same decision space.  Its expectation under ``N(mu_post, P_post)`` is
+computed with two-dimensional Gauss-Hermite quadrature, so the Gaussian covariance affects confidence.
+The bridge applied to the held row's operating-judge D/S is reported as a finite-sample linear reference.
+Its gap mixes representation loss with bridge misspecification and estimation error; it is not a Bayes ceiling.
+
+Both learned methods use the identical train-calibrated source vector on a node-disjoint
+combiner/calibration split (upstream checkpoint endpoint exposure is not claimed):
+
+    [prior_D, prior_S, graph_D, graph_S, luna_D, luna_S]
+
+JointPosterior learns ``p(decision | all sources)`` directly.  The dense Gaussian baseline first fuses
+the sources into ``N(D,S)`` and then applies the declared decision bridge.  Equal and separability-
+weighted factored products are controls, not recommended estimators.  Metrics are accuracy, log-loss,
+ECE (10 equal-width confidence bins), and margin-gated AURC with an endpoint-connected-component
+bootstrap.  The component bootstrap keeps every row sharing a node in the same resampled block.
+
+Typical run (local scored artifacts and campaign-independent checkpoint required):
+
+    python3 run_cheap_judge_joint_posterior.py --seed 0 --boot 500
+
+The script intentionally does not modify the PR #3648 experiment or report files.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+from dataclasses import dataclass
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from eval_luna_transfer import load_luna as load_scored_mu_tsv
+from emit_transitive_hops import hit_prob
+from fine_tune_channel_heads import load_campaign_datasets, load_expanded
+from fine_tune_fused_head import agnostic_readouts
+from mu_posterior import JointPosterior, MuPosterior, _eval, aurc, margin_conf, pearson
+from product_kalman import fit_residual_covariance
+from run_judge_channel import correlated_update_H
+from run_product_kalman_logit import dequant
+from run_product_kalman_realdata import DATASETS, affine_calibrate
+from sample_channel_campaign import ancestors
+from sigma_hop_confirmatory import FeatureGraphConfig, load_feature_graph
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+CAMPAIGN = "/tmp/mu_data/campaign_scored.tsv"
+LUNA_CAMPAIGN = "/tmp/mu_data/campaign_scored_luna.tsv"
+CLASSES = ("directional", "symmetric", "other")
+GROUPS = {
+    "directional": ("element_of", "subcategory", "subtopic", "super_category"),
+    "symmetric": ("see_also", "assoc"),
+    "other": ("unknown", "none"),
+}
+SOURCES = ("prior_D", "prior_S", "graph_D", "graph_S", "luna_D", "luna_S")
+H4 = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]])
+GAUSSIAN_RUNGS = {
+    "gaussian/prior": (),
+    "gaussian/+graph": (0, 1),
+    "gaussian/+luna": (2, 3),
+    "gaussian/all": (0, 1, 2, 3),
+}
+JOINT_RUNGS = {
+    "joint/prior": (0, 1),
+    "joint/+graph": (0, 1, 2, 3),
+    "joint/+luna": (0, 1, 4, 5),
+    "joint/all": (0, 1, 2, 3, 4, 5),
+}
+
+
+@dataclass
+class SplitData:
+    """Train-calibrated sources and dense Gaussian blocks for one split."""
+
+    X: np.ndarray
+    y_ds: np.ndarray
+    prior: np.ndarray
+    meas: np.ndarray
+    P0: np.ndarray
+    C_pm: np.ndarray
+    R0: np.ndarray
+
+
+def sym_graph_features(parents, pairs, hmax=6, cap=13):
+    """#3648 graph-S features, kept local so this follow-up is independently runnable."""
+    feats = np.zeros((len(pairs), 4))
+    cache = {}
+
+    def anc(node):
+        if node not in cache:
+            values = ancestors(parents, node, hmax)
+            values[node] = 0
+            cache[node] = values
+        return cache[node]
+
+    for i, (x, y) in enumerate(pairs):
+        ax, ay = anc(x), anc(y)
+        common = set(ax) & set(ay)
+        distance = min((ax[c] + ay[c] for c in common), default=cap)
+        px, py = set(parents.get(x, ())), set(parents.get(y, ()))
+        gx = {g for p in px for g in parents.get(p, ())}
+        gy = {g for p in py for g in parents.get(p, ())}
+        feats[i] = (1.0 / (1.0 + distance), float(bool(px & py)), float(bool(gx & gy)),
+                    float(y in ax or x in ay))
+    return feats
+
+
+def calibrate_luna(luna, y_ds, train):
+    """Global train-only affine correction for each Luna channel."""
+    return np.column_stack([
+        affine_calibrate(luna[train, 0], y_ds[train, 0], luna[:, 0]),
+        affine_calibrate(luna[train, 1], y_ds[train, 1], luna[:, 1]),
+    ])
+
+
+def aggregate_decision_probabilities(row, col):
+    """Aggregate one campaign TSV row into the declared three-way decision simplex."""
+    p = np.array([sum(float(row[col[f"P[{rel}]"]]) for rel in GROUPS[group]) for group in CLASSES])
+    z = float(p.sum())
+    if not np.isfinite(z) or z <= 0:
+        raise ValueError("judge relation probabilities do not have positive finite mass")
+    return p / z
+
+
+def macro_decision(probability, *, tie_atol=0.0):
+    """Return fixed-order hard decision, top-two margin, and an explicit top-tie flag."""
+    probability = np.asarray(probability, dtype=float)
+    if probability.shape != (len(CLASSES),) or not np.isfinite(probability).all():
+        raise ValueError(f"expected {len(CLASSES)} finite macro probabilities")
+    order = np.argsort(-probability, kind="stable")
+    top = probability[order[0]]
+    tied = np.flatnonzero(np.isclose(probability, top, rtol=0.0, atol=tie_atol))
+    # Stable CLASSES order resolves exact/near-exact ties; persist the tie flag so this is auditable.
+    decision_index = int(tied[0]) if len(tied) else int(order[0])
+    margin = float(top - probability[order[1]])
+    return CLASSES[decision_index], margin, bool(len(tied) > 1)
+
+
+def load_decision_targets(path=CAMPAIGN):
+    """Return pair -> (normalised macro probabilities, hard macro decision).
+
+    The hard decision is used because the repository JointPosterior trains on class labels. The runner
+    persists row-level aggregated vectors, margins, tie flags, and split membership for auditing.
+    Duplicate pairs must agree rather than being silently overwritten.
+    """
+    out = {}
+    cur_rel = Counter()
+    with open(path, encoding="utf-8") as f:
+        header = f.readline().lstrip("#").strip().split("\t")
+        col = {name: i for i, name in enumerate(header)}
+        required = {"node", "root", "cur_rel"} | {
+            f"P[{rel}]" for rels in GROUPS.values() for rel in rels
+        }
+        missing = required - set(col)
+        if missing:
+            raise ValueError(f"campaign file lacks columns: {sorted(missing)}")
+        for line in f:
+            row = line.rstrip("\n").split("\t")
+            if len(row) < len(header):
+                continue
+            pair = (row[col["node"]], row[col["root"]])
+            prob = aggregate_decision_probabilities(row, col)
+            decision, _margin, _tied = macro_decision(prob)
+            value = (prob, decision)
+            if pair in out and (out[pair][1] != value[1] or not np.allclose(out[pair][0], prob)):
+                raise ValueError(f"conflicting duplicate decision target for {pair!r}")
+            out[pair] = value
+            cur_rel[row[col["cur_rel"]]] += 1
+    return out, cur_rel
+
+
+def pool_relation_values(mu, probability, temperature=0.10):
+    """Return hard-max, conditional-probability, and temperature-softmax pooled values."""
+    mu, probability = np.asarray(mu, float), np.asarray(probability, float)
+    if mu.ndim != 1 or probability.shape != mu.shape or len(mu) == 0:
+        raise ValueError("mu and probability must be same-length non-empty vectors")
+    if temperature <= 0:
+        raise ValueError("pooling temperature must be positive")
+    p_total = probability.sum()
+    soft_weight = np.exp((mu - mu.max()) / temperature)
+    return (float(mu.max()),
+            float(probability @ mu / p_total) if p_total > 0 else float(mu.mean()),
+            float(soft_weight @ mu / soft_weight.sum()))
+
+
+def load_within_judge_pooling_states(path=CAMPAIGN, temperature=0.10):
+    """Alternative reductions of one judge's relation-specific mu values to D/S.
+
+    These are within-judge relation pooling diagnostics. They are not expert selection: all terms come
+    from one GPT-5.5 response. ``softmax`` is a temperature-softmax weighted mean (bounded by the input
+    mu values), while ``prob_weighted`` uses the judge's conditional relation probabilities within each
+    D/S group. The #3648 estimator remains on its preregistered hard maximum; alternatives are linear-reference
+    diagnostics until all prior/measurement channels are retrained with the same pooling rule.
+    """
+    if temperature <= 0:
+        raise ValueError("pooling temperature must be positive")
+    out = {}
+    pooled_groups = (GROUPS["directional"], GROUPS["symmetric"])
+    with open(path, encoding="utf-8") as f:
+        header = f.readline().lstrip("#").strip().split("\t")
+        col = {name: i for i, name in enumerate(header)}
+        required = {"node", "root"} | {
+            prefix + rel + "]" for rels in pooled_groups for rel in rels for prefix in ("P[", "mu[")
+        }
+        missing = required - set(col)
+        if missing:
+            raise ValueError(f"campaign file lacks pooling columns: {sorted(missing)}")
+        for line in f:
+            row = line.rstrip("\n").split("\t")
+            if len(row) < len(header):
+                continue
+            pair = (row[col["node"]], row[col["root"]])
+            hard, prob_weighted, softmax = [], [], []
+            for relations in pooled_groups:
+                mu = np.array([float(row[col[f"mu[{rel}]"]]) for rel in relations])
+                probability = np.array([float(row[col[f"P[{rel}]"]]) for rel in relations])
+                hp, pp, sp = pool_relation_values(mu, probability, temperature)
+                hard.append(hp); prob_weighted.append(pp); softmax.append(sp)
+            value = {
+                "hard_max": np.asarray(hard),
+                "prob_weighted": np.asarray(prob_weighted),
+                f"softmax_t{temperature:g}": np.asarray(softmax),
+            }
+            if pair in out and any(not np.allclose(out[pair][key], val) for key, val in value.items()):
+                raise ValueError(f"conflicting duplicate pooling state for {pair!r}")
+            out[pair] = value
+    return out
+
+
+def strict_node_disjoint_split(pairs, seed=0, held_frac=0.40):
+    """Random node partition; retain only within-side pairs and drop every crossing pair.
+
+    This is stricter than ``descendant_disjoint_split``: no endpoint in the held rows can occur in a
+    training row.  The split is based only on sorted node identities and ``seed``, never targets.
+    """
+    if not 0.0 < held_frac < 1.0:
+        raise ValueError("held_frac must be strictly between 0 and 1")
+    nodes = sorted({n for pair in pairs for n in pair})
+    rng = np.random.default_rng(seed)
+    rng.shuffle(nodes)
+    n_held = min(max(1, int(round(held_frac * len(nodes)))), len(nodes) - 1)
+    held_nodes = set(nodes[:n_held])
+    train = np.array([i for i, (a, b) in enumerate(pairs) if a not in held_nodes and b not in held_nodes], int)
+    held = np.array([i for i, (a, b) in enumerate(pairs) if a in held_nodes and b in held_nodes], int)
+    train_nodes = {n for i in train for n in pairs[i]}
+    eval_nodes = {n for i in held for n in pairs[i]}
+    if train_nodes & eval_nodes:
+        raise AssertionError("strict node-disjoint split leaked an endpoint")
+    return train, held
+
+
+def endpoint_components(pairs):
+    """Row-index blocks induced by connected components of the pair endpoint graph."""
+    parent = {}
+
+    def find(x):
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for a, b in pairs:
+        union(a, b)
+    by = {}
+    for i, (a, _b) in enumerate(pairs):
+        by.setdefault(find(a), []).append(i)
+    return [np.asarray(ix, int) for ix in by.values()]
+
+
+def component_bootstrap_aurc(proba, labels, pairs, B=500, seed=0):
+    """Margin AURC and 95% CI from endpoint-connected-component resampling."""
+    proba = np.asarray(proba, float)
+    labels = np.asarray(labels, int)
+    correct = (proba.argmax(1) == labels).astype(float)
+    conf = margin_conf(proba)
+    blocks = endpoint_components(pairs)
+    point = aurc(conf, correct)
+    if B <= 0:
+        return point, float("nan"), float("nan"), len(blocks), max(map(len, blocks), default=0)
+    rng = np.random.default_rng(seed)
+    vals = []
+    for _ in range(B):
+        chosen = rng.integers(0, len(blocks), len(blocks))
+        ix = np.concatenate([blocks[j] for j in chosen])
+        vals.append(aurc(conf[ix], correct[ix]))
+    lo, hi = np.percentile(vals, [2.5, 97.5])
+    return point, float(lo), float(hi), len(blocks), max(map(len, blocks), default=0)
+
+
+def component_bootstrap_aurc_delta(proba_a, proba_b, labels, pairs, B=500, seed=0):
+    """Paired component-bootstrap CI for AURC(A)-AURC(B); negative favours A."""
+    labels = np.asarray(labels, int)
+    ca = (np.asarray(proba_a).argmax(1) == labels).astype(float)
+    cb = (np.asarray(proba_b).argmax(1) == labels).astype(float)
+    ma, mb = margin_conf(proba_a), margin_conf(proba_b)
+    blocks = endpoint_components(pairs)
+    point = aurc(ma, ca) - aurc(mb, cb)
+    if B <= 0:
+        return point, float("nan"), float("nan")
+    rng = np.random.default_rng(seed)
+    vals = []
+    for _ in range(B):
+        chosen = rng.integers(0, len(blocks), len(blocks))
+        ix = np.concatenate([blocks[j] for j in chosen])
+        vals.append(aurc(ma[ix], ca[ix]) - aurc(mb[ix], cb[ix]))
+    lo, hi = np.percentile(vals, [2.5, 97.5])
+    return point, float(lo), float(hi)
+
+
+def gaussian_bridge_proba(bridge, means, covariances, order=5):
+    """E[p(class | Z)] for Z~N(mean,cov), by product Gauss-Hermite quadrature."""
+    means = np.asarray(means, float)
+    covariances = np.asarray(covariances, float)
+    if means.ndim != 2 or means.shape[1] != 2 or covariances.shape != (len(means), 2, 2):
+        raise ValueError("expected means [N,2] and covariances [N,2,2]")
+    nodes, weights = np.polynomial.hermite.hermgauss(order)
+    z = np.array([(a, b) for a in nodes for b in nodes], float) * np.sqrt(2.0)
+    w = np.array([wa * wb for wa in weights for wb in weights], float) / np.pi
+    out = []
+    for mu, cov in zip(means, covariances):
+        eigval, eigvec = np.linalg.eigh(0.5 * (cov + cov.T))
+        root = eigvec @ np.diag(np.sqrt(np.clip(eigval, 0.0, None)))
+        points = mu + z @ root.T
+        out.append(w @ bridge.proba(points))
+    out = np.asarray(out)
+    return out / out.sum(axis=1, keepdims=True)
+
+
+def fit_factored(Xtr, labels_tr, Xhe, weights="equal", nbins=12):
+    """Factored histogram product control fit strictly on training rows."""
+    post = MuPosterior(nbins=nbins, lo=-0.10, hi=1.10, smoothing=1.0)
+    for j, source in enumerate(SOURCES):
+        post.fit_source(source, zip(labels_tr, Xtr[:, j]))
+    if weights == "separability":
+        for source in SOURCES:
+            post.weights[source] = post.separability(source)[0]
+    elif weights != "equal":
+        raise ValueError("weights must be 'equal' or 'separability'")
+    return np.array([
+        [post.posterior(dict(zip(SOURCES, row))).get(cls, 1e-12) for cls in CLASSES]
+        for row in Xhe
+    ])
+
+
+def calibrate_sources(prior, graph_raw, graph_features, luna, y_ds, train):
+    """Fit every affine/graph calibration and residual block on ``train`` only."""
+    graph_d = affine_calibrate(graph_raw[train], y_ds[train, 0], graph_raw)
+    design = np.column_stack([graph_features, np.ones(len(graph_features))])
+    beta, *_ = np.linalg.lstsq(design[train], y_ds[train, 1], rcond=None)
+    graph_s = design @ beta
+    luna_c = calibrate_luna(luna, y_ds, train)
+    meas = np.column_stack([graph_d, graph_s, luna_c[:, 0], luna_c[:, 1]])
+    X = np.column_stack([prior, meas])
+    observed_state = y_ds[:, [0, 1, 0, 1]]
+    errors = np.column_stack([y_ds - prior, meas - observed_state])[train]
+    cov = fit_residual_covariance(errors, shrinkage=0.05)
+    return SplitData(X=X, y_ds=y_ds, prior=prior, meas=meas,
+                     P0=cov[:2, :2], C_pm=cov[:2, 2:], R0=cov[2:, 2:])
+
+
+def gaussian_posterior(split, indices, selected):
+    """Dense Gaussian posterior for a measurement subset (prior enters exactly once)."""
+    means, covs = [], []
+    selected = list(selected)
+    for i in indices:
+        if selected:
+            xp, Pp = correlated_update_H(
+                split.prior[i], split.P0, split.meas[i, selected],
+                split.R0[np.ix_(selected, selected)], split.C_pm[:, selected], H4[selected],
+            )
+        else:
+            xp, Pp = split.prior[i].copy(), split.P0.copy()
+        means.append(xp)
+        covs.append(Pp)
+    return np.asarray(means), np.asarray(covs)
+
+
+def metric_record(proba, label_names, pairs, boot, seed):
+    ri = {name: i for i, name in enumerate(CLASSES)}
+    labels = np.array([ri[x] for x in label_names], int)
+    acc, logloss, ece = _eval(proba, label_names, ri, bins=10)
+    a, lo, hi, blocks, largest = component_bootstrap_aurc(proba, labels, pairs, B=boot, seed=seed)
+    return {
+        "accuracy": acc,
+        "log_loss": logloss,
+        "ece_10_equal_width": ece,
+        "aurc_margin": a,
+        "aurc_ci95_component_boot": [lo, hi],
+        "bootstrap_blocks": blocks,
+        "largest_block_rows": largest,
+    }
+
+
+def print_source_diagnostics(Xtr, label_names):
+    print("  source separability on TRAIN (SD of per-class means):")
+    for j, source in enumerate(SOURCES):
+        means = [np.mean(Xtr[np.array(label_names) == cls, j]) for cls in CLASSES]
+        print(f"    {source:9s} {np.std(means):.4f}  means=" + "/".join(f"{v:.3f}" for v in means))
+    print("  source correlation on TRAIN (Pearson; large |r| means redundancy):")
+    print("               " + " ".join(f"{s[:8]:>8s}" for s in SOURCES))
+    for i, source in enumerate(SOURCES):
+        vals = " ".join(f"{pearson(Xtr[:, i], Xtr[:, j]):+8.2f}" for j in range(len(SOURCES)))
+        print(f"    {source:9s} {vals}")
+
+
+def run_corpus(name, ds, target_by_pair, pooling_by_pair, luna_by_pair, checkpoint, args):
+    corpus = name.replace("-campaign", "")
+    parents, _, _, _ = load_feature_graph(FeatureGraphConfig(**DATASETS[corpus]["graph"]))
+    # Graph loaders expose parent sets. Both the walk DP's cycle guard and tokenizer ancestor order can
+    # otherwise depend on Python's per-process hash seed. Canonicalise locally before either feature path.
+    parents = {node: tuple(sorted(values)) for node, values in parents.items()}
+    ds["tok"].parents = parents
+    model, _ = checkpoint
+    ro = agnostic_readouts(model, ds, "cpu")
+    keep = [i for i, pair in enumerate(ds["pairs"])
+            if pair in target_by_pair and pair in pooling_by_pair and pair in luna_by_pair]
+    pairs = [ds["pairs"][i] for i in keep]
+    if len(pairs) != len(set(pairs)):
+        raise ValueError("comparison requires unique campaign pairs")
+    y_ds = dequant(np.column_stack([ds["D"][keep], ds["S"][keep]]))
+    prior = np.column_stack([ro["prior_D"][keep], ro["prior_S"][keep]])
+    graph_raw = np.array([hit_prob(parents, x, y) for x, y in pairs])
+    graph_features = sym_graph_features(parents, pairs)
+    luna = np.asarray([luna_by_pair[pair] for pair in pairs])
+    soft_target = np.asarray([target_by_pair[pair][0] for pair in pairs])
+    hard_target = np.asarray([target_by_pair[pair][1] for pair in pairs])
+    pooling_states = {
+        key: dequant(np.asarray([pooling_by_pair[pair][key] for pair in pairs]))
+        for key in next(iter(pooling_by_pair.values()))
+    }
+    if not np.allclose(y_ds, pooling_states["hard_max"]):
+        raise AssertionError("campaign loader's D/S differs from audited hard-max relation pooling")
+
+    train, held = strict_node_disjoint_split(pairs, seed=args.seed, held_frac=args.held_frac)
+    train_counts, held_counts = Counter(hard_target[train]), Counter(hard_target[held])
+    if min((train_counts[c] for c in CLASSES), default=0) < args.min_class:
+        raise ValueError(f"{name}: seed {args.seed} has too few training rows per class: {train_counts}")
+    if min((held_counts[c] for c in CLASSES), default=0) < args.min_class:
+        raise ValueError(f"{name}: seed {args.seed} has too few held rows per class: {held_counts}")
+    print(f"\n=== {name}: combiner/calibration node-disjoint seed={args.seed}; train={len(train)} held={len(held)} "
+          f"cross-dropped={len(pairs)-len(train)-len(held)} ===")
+    print(f"  train classes {dict(train_counts)}; held classes {dict(held_counts)}")
+
+    split = calibrate_sources(prior, graph_raw, graph_features, luna, y_ds, train)
+    print_source_diagnostics(split.X[train], hard_target[train])
+    bridge = JointPosterior(CLASSES, n_features=2, hidden=0, seed=1000 + args.seed).fit(
+        y_ds[train], hard_target[train], epochs=args.epochs,
+    )
+    methods = {"bridge/D-S-hard-max-reference": bridge.proba(y_ds[held])}
+    pooling_diagnostics = {}
+    print("  within-judge pooling diagnostics (full matched corpus; one response; NOT expert selection):")
+    for j, (pool_name, state) in enumerate(pooling_states.items()):
+        delta = state - y_ds
+        pooling_diagnostics[pool_name] = {
+            "mean_delta_from_hard_max_D_S": delta.mean(axis=0).tolist(),
+            "correlation_with_hard_max_D_S": [pearson(state[:, k], y_ds[:, k]) for k in range(2)],
+        }
+        print(f"    {pool_name:14s} mean delta D/S {delta[:, 0].mean():+.3f}/{delta[:, 1].mean():+.3f}; "
+              f"corr {pearson(state[:, 0], y_ds[:, 0]):+.3f}/{pearson(state[:, 1], y_ds[:, 1]):+.3f}")
+        if pool_name != "hard_max":
+            # Linear-reference target-construction diagnostic. A production comparison must retrain every
+            # prior and measurement channel under this same within-judge pooling definition.
+            alt_bridge = JointPosterior(CLASSES, n_features=2, hidden=0,
+                                        seed=1100 + args.seed + j).fit(
+                state[train], hard_target[train], epochs=args.epochs,
+            )
+            methods[f"bridge/D-S-{pool_name}-reference"] = alt_bridge.proba(state[held])
+
+    for method, selected in GAUSSIAN_RUNGS.items():
+        means, covs = gaussian_posterior(split, held, selected)
+        methods[method] = gaussian_bridge_proba(bridge, means, covs, order=args.quad_order)
+    for method, selected in JOINT_RUNGS.items():
+        cols = list(selected)
+        joint = JointPosterior(CLASSES, n_features=len(cols), hidden=args.hidden,
+                               seed=2000 + args.seed).fit(
+            split.X[train][:, cols], hard_target[train], epochs=args.epochs,
+        )
+        methods[method] = joint.proba(split.X[held][:, cols])
+    methods["factored/equal"] = fit_factored(
+        split.X[train], hard_target[train], split.X[held], weights="equal", nbins=args.nbins,
+    )
+    methods["factored/separability"] = fit_factored(
+        split.X[train], hard_target[train], split.X[held], weights="separability", nbins=args.nbins,
+    )
+
+    held_pairs = [pairs[i] for i in held]
+    records = {}
+    print("  metrics (ECE=10 equal-width confidence bins; AURC=margin gate, component bootstrap):")
+    print(f"    {'method':26s} {'acc':>6s} {'logloss':>8s} {'ECE':>7s} {'AURC [95% CI]':>25s}")
+    for j, (method, proba) in enumerate(methods.items()):
+        rec = metric_record(proba, hard_target[held], held_pairs, args.boot, args.seed * 100 + j)
+        records[method] = rec
+        lo, hi = rec["aurc_ci95_component_boot"]
+        print(f"    {method:26s} {rec['accuracy']:6.3f} {rec['log_loss']:8.3f} {rec['ece_10_equal_width']:7.3f} "
+              f"{rec['aurc_margin']:7.3f} [{lo:.3f}, {hi:.3f}]")
+    ri = {name: i for i, name in enumerate(CLASSES)}
+    y_int = np.array([ri[x] for x in hard_target[held]])
+    delta, dlo, dhi = component_bootstrap_aurc_delta(
+        methods["joint/all"], methods["gaussian/all"], y_int, held_pairs,
+        B=args.boot, seed=9000 + args.seed,
+    )
+    print(f"  paired AURC delta joint/all - gaussian/all: {delta:+.4f} [{dlo:+.4f}, {dhi:+.4f}] "
+          "(negative favours JointPosterior)")
+    source_deltas = {}
+    for j, (family, source, with_method, without_method) in enumerate([
+        ("gaussian", "graph", "gaussian/all", "gaussian/+luna"),
+        ("gaussian", "luna", "gaussian/all", "gaussian/+graph"),
+        ("joint", "graph", "joint/all", "joint/+luna"),
+        ("joint", "luna", "joint/all", "joint/+graph"),
+    ]):
+        point, lo, hi = component_bootstrap_aurc_delta(
+            methods[with_method], methods[without_method], y_int, held_pairs,
+            B=args.boot, seed=10000 + args.seed * 10 + j,
+        )
+        source_deltas[f"{family}_add_{source}"] = [point, lo, hi]
+        print(f"  paired AURC delta {family}/all - {without_method} (add {source}): "
+              f"{point:+.4f} [{lo:+.4f}, {hi:+.4f}]")
+    train_set, held_set = set(map(int, train)), set(map(int, held))
+    decision_rows = []
+    for i, pair in enumerate(pairs):
+        decision, margin, tied = macro_decision(soft_target[i])
+        decision_rows.append({
+            "pair": list(pair),
+            "split": "train" if i in train_set else "held" if i in held_set else "cross-dropped",
+            "probability": dict(zip(CLASSES, soft_target[i].tolist())),
+            "hard_decision": decision,
+            "top_two_margin": margin,
+            "top_tie_fixed_class_order": tied,
+        })
+    return {
+        "corpus": name,
+        "seed": args.seed,
+        "split": {
+            "kind": "combiner-calibration-node-disjoint",
+            "held_fraction_nodes": args.held_frac,
+            "train_rows": len(train),
+            "held_rows": len(held),
+            "cross_rows_dropped": len(pairs) - len(train) - len(held),
+            "train_classes": dict(train_counts),
+            "held_classes": dict(held_counts),
+        },
+        "target": {
+            "frame": "gpt-5.5-low macro-decision fidelity; not ground truth",
+            "classes": {key: list(value) for key, value in GROUPS.items()},
+            "mean_soft_probability_held": dict(zip(CLASSES, soft_target[held].mean(axis=0).tolist())),
+            "decision_rows": decision_rows,
+            "audit_counts": {
+                "top_ties": int(sum(row["top_tie_fixed_class_order"] for row in decision_rows)),
+                "margin_below_0.02": int(sum(row["top_two_margin"] < 0.02 for row in decision_rows)),
+            },
+            "within_judge_pooling": {
+                "role": "same-response linear-reference diagnostic only; hard max remains the #3648 estimator",
+                "not_expert_selection": True,
+                "shift_correlation_scope": "full matched corpus, including train/held/cross-dropped rows",
+                "diagnostics": pooling_diagnostics,
+            },
+        },
+        "metrics": records,
+        "paired_aurc_delta_joint_minus_gaussian": [delta, dlo, dhi],
+        "paired_source_aurc_deltas": source_deltas,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", default=os.path.join(ROOT, "model_prod_namecond.pt"),
+                    help="campaign-independent prior checkpoint")
+    ap.add_argument("--campaign", default=CAMPAIGN)
+    ap.add_argument("--luna", default=LUNA_CAMPAIGN)
+    ap.add_argument("--seed", type=int, default=0, help="node partition and model-init seed")
+    ap.add_argument("--held-frac", type=float, default=0.40, help="fraction of nodes assigned held")
+    ap.add_argument("--min-class", type=int, default=5)
+    ap.add_argument("--epochs", type=int, default=400)
+    ap.add_argument("--hidden", type=int, default=0,
+                    help="JointPosterior hidden units; 0 is the preregistered multinomial LR")
+    ap.add_argument("--nbins", type=int, default=12, help="factored-control histogram bins")
+    ap.add_argument("--boot", type=int, default=500)
+    ap.add_argument("--quad-order", type=int, default=5)
+    ap.add_argument("--pool-temperature", type=float, default=0.10,
+                    help="temperature for the within-judge softmax-pooling linear-reference diagnostic")
+    ap.add_argument("--out", default=None, help="optional JSON result path")
+    args = ap.parse_args()
+
+    import torch
+    torch.set_num_threads(1)  # tiny heads are much faster and deterministic without a large BLAS pool
+    target_by_pair, cur_rel = load_decision_targets(args.campaign)
+    pooling_by_pair = load_within_judge_pooling_states(args.campaign, args.pool_temperature)
+    if len(cur_rel) == 1:
+        only, count = next(iter(cur_rel.items()))
+        print(f"campaign cur_rel is degenerate: {only}={count}; using declared macro decision bridge")
+    luna_pairs, luna_d, luna_s = load_scored_mu_tsv(args.luna)
+    luna_by_pair = {pair: (luna_d[i], luna_s[i]) for i, pair in enumerate(luna_pairs)}
+    model, cfg = load_expanded(args.ckpt, dev="cpu")
+    model.eval()
+    dss = load_campaign_datasets()
+    results = [run_corpus(name, ds, target_by_pair, pooling_by_pair, luna_by_pair, (model, cfg), args)
+               for name, ds in dss.items()]
+    payload = {
+        "protocol": "same split; combiner/calibration node-disjoint; train-only calibration; macro decision bridge",
+        "checkpoint": os.path.abspath(args.ckpt),
+        "results": results,
+    }
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, sort_keys=True)
+            f.write("\n")
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/run_cheap_judge_joint_posterior.py
+++ b/prototypes/mu_cosine/run_cheap_judge_joint_posterior.py
@@ -51,11 +51,12 @@ from emit_transitive_hops import hit_prob
 from fine_tune_channel_heads import load_campaign_datasets, load_expanded
 from fine_tune_fused_head import agnostic_readouts
 from mu_posterior import JointPosterior, MuPosterior, _eval, aurc, margin_conf, pearson
+from node_disjoint_eval import node_disjoint_pair_split
 from product_kalman import fit_residual_covariance
 from run_judge_channel import correlated_update_H
 from run_product_kalman_logit import dequant
 from run_product_kalman_realdata import DATASETS, affine_calibrate
-from sample_channel_campaign import ancestors
+from run_sym_channel_fusion import H4, calibrate_luna, sym_graph_features
 from sigma_hop_confirmatory import FeatureGraphConfig, load_feature_graph
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
@@ -68,7 +69,6 @@ GROUPS = {
     "other": ("unknown", "none"),
 }
 SOURCES = ("prior_D", "prior_S", "graph_D", "graph_S", "luna_D", "luna_S")
-H4 = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]])
 GAUSSIAN_RUNGS = {
     "gaussian/prior": (),
     "gaussian/+graph": (0, 1),
@@ -94,38 +94,6 @@ class SplitData:
     P0: np.ndarray
     C_pm: np.ndarray
     R0: np.ndarray
-
-
-def sym_graph_features(parents, pairs, hmax=6, cap=13):
-    """#3648 graph-S features, kept local so this follow-up is independently runnable."""
-    feats = np.zeros((len(pairs), 4))
-    cache = {}
-
-    def anc(node):
-        if node not in cache:
-            values = ancestors(parents, node, hmax)
-            values[node] = 0
-            cache[node] = values
-        return cache[node]
-
-    for i, (x, y) in enumerate(pairs):
-        ax, ay = anc(x), anc(y)
-        common = set(ax) & set(ay)
-        distance = min((ax[c] + ay[c] for c in common), default=cap)
-        px, py = set(parents.get(x, ())), set(parents.get(y, ()))
-        gx = {g for p in px for g in parents.get(p, ())}
-        gy = {g for p in py for g in parents.get(p, ())}
-        feats[i] = (1.0 / (1.0 + distance), float(bool(px & py)), float(bool(gx & gy)),
-                    float(y in ax or x in ay))
-    return feats
-
-
-def calibrate_luna(luna, y_ds, train):
-    """Global train-only affine correction for each Luna channel."""
-    return np.column_stack([
-        affine_calibrate(luna[train, 0], y_ds[train, 0], luna[:, 0]),
-        affine_calibrate(luna[train, 1], y_ds[train, 1], luna[:, 1]),
-    ])
 
 
 def aggregate_decision_probabilities(row, col):
@@ -240,28 +208,6 @@ def load_within_judge_pooling_states(path=CAMPAIGN, temperature=0.10):
                 raise ValueError(f"conflicting duplicate pooling state for {pair!r}")
             out[pair] = value
     return out
-
-
-def strict_node_disjoint_split(pairs, seed=0, held_frac=0.40):
-    """Random node partition; retain only within-side pairs and drop every crossing pair.
-
-    This is stricter than ``descendant_disjoint_split``: no endpoint in the held rows can occur in a
-    training row.  The split is based only on sorted node identities and ``seed``, never targets.
-    """
-    if not 0.0 < held_frac < 1.0:
-        raise ValueError("held_frac must be strictly between 0 and 1")
-    nodes = sorted({n for pair in pairs for n in pair})
-    rng = np.random.default_rng(seed)
-    rng.shuffle(nodes)
-    n_held = min(max(1, int(round(held_frac * len(nodes)))), len(nodes) - 1)
-    held_nodes = set(nodes[:n_held])
-    train = np.array([i for i, (a, b) in enumerate(pairs) if a not in held_nodes and b not in held_nodes], int)
-    held = np.array([i for i, (a, b) in enumerate(pairs) if a in held_nodes and b in held_nodes], int)
-    train_nodes = {n for i in train for n in pairs[i]}
-    eval_nodes = {n for i in held for n in pairs[i]}
-    if train_nodes & eval_nodes:
-        raise AssertionError("strict node-disjoint split leaked an endpoint")
-    return train, held
 
 
 def endpoint_components(pairs):
@@ -452,14 +398,27 @@ def run_corpus(name, ds, target_by_pair, pooling_by_pair, luna_by_pair, checkpoi
     if not np.allclose(y_ds, pooling_states["hard_max"]):
         raise AssertionError("campaign loader's D/S differs from audited hard-max relation pooling")
 
-    train, held = strict_node_disjoint_split(pairs, seed=args.seed, held_frac=args.held_frac)
+    split_spec = node_disjoint_pair_split(
+        pairs,
+        args.seed,
+        held_node_fraction=args.held_frac,
+        strata=hard_target,
+        candidates=args.split_candidates,
+        minimum_per_stratum=args.min_class,
+    )
+    train, held = split_spec.train, split_spec.held
+    train_nodes = {node for i in train for node in pairs[i]}
+    held_nodes = {node for i in held for node in pairs[i]}
+    if train_nodes & held_nodes:
+        raise AssertionError("audited node-disjoint split leaked an endpoint")
     train_counts, held_counts = Counter(hard_target[train]), Counter(hard_target[held])
     if min((train_counts[c] for c in CLASSES), default=0) < args.min_class:
         raise ValueError(f"{name}: seed {args.seed} has too few training rows per class: {train_counts}")
     if min((held_counts[c] for c in CLASSES), default=0) < args.min_class:
         raise ValueError(f"{name}: seed {args.seed} has too few held rows per class: {held_counts}")
-    print(f"\n=== {name}: combiner/calibration node-disjoint seed={args.seed}; train={len(train)} held={len(held)} "
-          f"cross-dropped={len(pairs)-len(train)-len(held)} ===")
+    print(f"\n=== {name}: combiner/calibration node-disjoint seed={args.seed}; "
+          f"candidate={split_spec.selected_candidate}/{split_spec.candidates}; "
+          f"train={len(train)} held={len(held)} cross-dropped={len(split_spec.cross)} ===")
     print(f"  train classes {dict(train_counts)}; held classes {dict(held_counts)}")
 
     split = calibrate_sources(prior, graph_raw, graph_features, luna, y_ds, train)
@@ -556,7 +515,10 @@ def run_corpus(name, ds, target_by_pair, pooling_by_pair, luna_by_pair, checkpoi
             "held_fraction_nodes": args.held_frac,
             "train_rows": len(train),
             "held_rows": len(held),
-            "cross_rows_dropped": len(pairs) - len(train) - len(held),
+            "cross_rows_dropped": len(split_spec.cross),
+            "candidates": split_spec.candidates,
+            "selected_candidate": split_spec.selected_candidate,
+            "retained_fraction": split_spec.retained_fraction,
             "train_classes": dict(train_counts),
             "held_classes": dict(held_counts),
         },
@@ -590,6 +552,8 @@ def main():
     ap.add_argument("--luna", default=LUNA_CAMPAIGN)
     ap.add_argument("--seed", type=int, default=0, help="node partition and model-init seed")
     ap.add_argument("--held-frac", type=float, default=0.40, help="fraction of nodes assigned held")
+    ap.add_argument("--split-candidates", type=int, default=64,
+                    help="deterministic coverage-aware node partitions considered per seed")
     ap.add_argument("--min-class", type=int, default=5)
     ap.add_argument("--epochs", type=int, default=400)
     ap.add_argument("--hidden", type=int, default=0,

--- a/prototypes/mu_cosine/run_sym_channel_fusion.py
+++ b/prototypes/mu_cosine/run_sym_channel_fusion.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-"""The symmetric-graph S channel (user, DESIGN_cheap_judge_pipeline §5.1) — does S fusion become
-non-trivial the way D's did?
+"""Confirm the symmetric-graph S channel with strict node-disjoint evaluation.
 
-Every fusion so far had NO graph measurement of S ("the graph doesn't observe S"), so the S posterior was
-prior⊕judge only. But the graph DOES carry symmetric structure: common-ancestor lateral distance,
-shared-parent/grandparent, ancestor flags. This builds a graph_S measurement — a small linear model on
-those features, calibrated to S on the train split (the multivariate analog of affine_calibrate for d→D) —
-and adds it as an S measurement row (H=[0,1]).
+Every fusion before PR #3648 had no graph measurement of S ("the graph doesn't observe S"), so the S
+posterior was prior⊕judge only.  The graph does carry symmetric structure: common-ancestor lateral distance,
+shared-parent/grandparent, and ancestor flags.  This script builds a graph_S measurement — a small linear model
+on those features, calibrated to S on the train split — and adds it as an S measurement row (H=[0,1]).
 
-Ladder (40 descendant-disjoint splits, joint 6×6 fit per split, correlated updates):
+Ladder (40 node-disjoint splits, joint 6×6 fit per split, correlated updates):
   prior | +graph_D | +graph_D+graph_S (FREE-ONLY fusion) | +graph_D+luna | ALL
-Reported: joint NLL and the S-MARGINAL NLL (the channel under test). Two questions:
-  (a) free-only: does graph_S improve S with no judge at all (the deployment cheap path)?
-  (b) marginal: does graph_S still add after luna?
+
+Two uncertainty summaries are intentionally separate:
+  * SD across seeded node partitions is descriptive Monte Carlo split stability, not an SE or CI.
+  * A paired two-endpoint node-block bootstrap on one fixed held partition gives a 95% population interval
+    conditional on that fitted split.
 
   python3 run_sym_channel_fusion.py
 """
@@ -26,24 +26,37 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from eval_luna_transfer import load_luna as load_scored_mu_tsv
 from fine_tune_channel_heads import load_campaign_datasets, load_expanded
 from fine_tune_fused_head import agnostic_readouts
+from node_disjoint_eval import (
+    format_split_diagnostics,
+    node_disjoint_pair_split,
+    paired_node_bootstrap_ci,
+)
 from product_kalman import fit_residual_covariance
 from run_judge_channel import correlated_update_H, nll_mahal
 from run_product_kalman_logit import dequant
 from run_product_kalman_realdata import DATASETS, affine_calibrate
 from sample_channel_campaign import ancestors
-from sigma_hop_confirmatory import FeatureGraphConfig, descendant_disjoint_split, load_feature_graph
+from sigma_hop_confirmatory import FeatureGraphConfig, load_feature_graph
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 LUNA_CAMPAIGN = "/tmp/mu_data/campaign_scored_luna.tsv"
 LOG2PI = float(np.log(2 * np.pi))
-H4 = np.array([[1, 0], [0, 1], [1, 0], [0, 1]], dtype=float)   # gD→D, gS→S, lunaD→D, lunaS→S
-RUNGS = {"prior": [], "+graph_D": [0], "+graph_D+graph_S": [0, 1],
-         "+graph_D+luna": [0, 2, 3], "ALL": [0, 1, 2, 3]}
+H4 = np.array([[1, 0], [0, 1], [1, 0], [0, 1]], dtype=float)  # gD→D, gS→S, lunaD→D, lunaS→S
+RUNGS = {
+    "prior": [],
+    "+graph_D": [0],
+    "+graph_D+graph_S": [0, 1],
+    "+graph_D+luna": [0, 2, 3],
+    "ALL": [0, 1, 2, 3],
+}
+EFFECTS = [
+    ("graph_S free-only (S)", "+graph_D", "+graph_D+graph_S"),
+    ("graph_S after luna (S)", "+graph_D+luna", "ALL"),
+]
 
 
 def sym_graph_features(parents, pairs, hmax=6, cap=13):
-    """[N, 4]: 1/(1+d_sym) with d_sym = min common-ancestor hop sum (self counts at 0);
-    shared-parent, shared-grandparent, is-ancestor indicators."""
+    """[N, 4]: inverse common-ancestor distance plus three symmetric graph indicators."""
     feats = np.zeros((len(pairs), 4))
     anc_cache = {}
 
@@ -61,16 +74,17 @@ def sym_graph_features(parents, pairs, hmax=6, cap=13):
         px, py = set(parents.get(x, ())), set(parents.get(y, ()))
         gx = {g for p in px for g in parents.get(p, ())}
         gy = {g for p in py for g in parents.get(p, ())}
-        feats[i] = (1.0 / (1.0 + d_sym), float(bool(px & py)), float(bool(gx & gy)),
-                    float(y in ax or x in ay))
+        feats[i] = (
+            1.0 / (1.0 + d_sym),
+            float(bool(px & py)),
+            float(bool(gx & gy)),
+            float(y in ax or x in ay),
+        )
     return feats
 
 
 def calibrate_luna(luna, y, fit_idx):
-    """Global per-channel affine (luna' = a·luna + b), fit on the train/overlap rows only, applied to ALL
-    rows BEFORE the residual-covariance fit (blocker 3 / DESIGN §2 'bias first'). Removes luna's tilt
-    (−S universal, +D on transitives) as a mean shift rather than leaving it folded into R as variance
-    (the Mahal-1.55 overconfidence). fit_idx are train indices into the full row array."""
+    """Fit global per-channel affine Luna calibration on train/overlap rows, then apply to all rows."""
     cal_D = affine_calibrate(luna[fit_idx, 0], y[fit_idx, 0], luna[:, 0])
     cal_S = affine_calibrate(luna[fit_idx, 1], y[fit_idx, 1], luna[:, 1])
     return np.column_stack([cal_D, cal_S])
@@ -80,14 +94,77 @@ def s_marginal_nll(r, v):
     return 0.5 * (r * r / v + np.log(v) + LOG2PI)
 
 
-def main():
+def build_arg_parser():
     ap = argparse.ArgumentParser()
-    # Campaign-INDEPENDENT prior (blocker 1): model_prod_namecond.pt was NOT fine-tuned on the campaign
-    # train split, so P0 is not optimistic on the fit rows. The r0 checkpoint memorized the fit split.
+    # Campaign-independent prior: model_prod_namecond.pt was not fine-tuned on the evaluated campaign.
     ap.add_argument("--ckpt", default=os.path.join(ROOT, "model_prod_namecond.pt"))
-    ap.add_argument("--seeds", type=int, default=40)
+    ap.add_argument(
+        "--seeds",
+        type=int,
+        default=40,
+        help="node-partition seeds used for descriptive Monte Carlo split stability",
+    )
     ap.add_argument("--shrink", type=float, default=0.05)
-    a = ap.parse_args()
+    ap.add_argument(
+        "--held-node-frac",
+        type=float,
+        default=0.40,
+        help=("fraction of unique nodes assigned held; 0.40 gives about 30% held among retained pairs; "
+              "cross-partition pairs are discarded"),
+    )
+    ap.add_argument(
+        "--split-candidates",
+        type=int,
+        default=64,
+        help="outcome-blind node assignments tried per seed to balance pair-stratum coverage",
+    )
+    ap.add_argument(
+        "--minimum-per-stratum",
+        type=int,
+        default=1,
+        help="minimum train and held pairs required in every campaign stratum",
+    )
+    ap.add_argument("--min-train", type=int, default=30)
+    ap.add_argument("--min-held", type=int, default=12)
+    ap.add_argument(
+        "--bootstrap-resamples",
+        type=int,
+        default=2000,
+        help="paired two-endpoint node-block draws on the fixed held split; 0 disables",
+    )
+    ap.add_argument("--bootstrap-seed", type=int, default=1729)
+    ap.add_argument(
+        "--bootstrap-split-seed",
+        type=int,
+        default=0,
+        help="node-partition seed held fixed for the population-uncertainty interval",
+    )
+    ap.add_argument("--bootstrap-confidence", type=float, default=0.95)
+    return ap
+
+
+def _mean_sd(values):
+    values = np.asarray(values, dtype=float)
+    sd = values.std(ddof=1) if len(values) > 1 else float("nan")
+    return float(values.mean()), float(sd)
+
+
+def _validate_args(a):
+    if a.seeds < 1:
+        raise ValueError("--seeds must be positive")
+    if a.bootstrap_resamples < 0:
+        raise ValueError("--bootstrap-resamples must be non-negative")
+    if a.bootstrap_seed < 0 or a.bootstrap_split_seed < 0:
+        raise ValueError("bootstrap seeds must be non-negative")
+    if not 0.0 < a.bootstrap_confidence < 1.0:
+        raise ValueError("--bootstrap-confidence must be strictly between 0 and 1")
+    if a.min_train < 1 or a.min_held < 1:
+        raise ValueError("--min-train and --min-held must be positive")
+
+
+def main(argv=None):
+    a = build_arg_parser().parse_args(argv)
+    _validate_args(a)
 
     ref, _ = load_expanded(a.ckpt, dev="cpu")
     ref.eval()
@@ -95,67 +172,180 @@ def main():
     luna_by = {p: (lD[i], lS[i]) for i, p in enumerate(lp)}
     dss = load_campaign_datasets()
 
-    for n, ds in dss.items():
-        corpus = n.replace("-campaign", "")
+    for corpus_index, (name, ds) in enumerate(dss.items()):
+        corpus = name.replace("-campaign", "")
         parents, _, _, _ = load_feature_graph(FeatureGraphConfig(**DATASETS[corpus]["graph"]))
-        keep = [i for i, p in enumerate(ds["pairs"]) if p in luna_by]
+        keep = [i for i, pair in enumerate(ds["pairs"]) if pair in luna_by]
         pairs = [ds["pairs"][i] for i in keep]
+        all_tags = ds.get("tags", ["all"] * len(ds["pairs"]))
+        tags = [all_tags[i] for i in keep]
         y = dequant(np.column_stack([ds["D"][keep], ds["S"][keep]]))
         ro = agnostic_readouts(ref, ds, "cpu")
         prior = np.column_stack([ro["prior_D"][keep], ro["prior_S"][keep]])
         d = ds["d"][keep]
-        luna = np.array([luna_by[p] for p in pairs])
+        luna = np.array([luna_by[pair] for pair in pairs])
         F = sym_graph_features(parents, pairs)
-        r = lambda x_, y_: float(np.corrcoef(x_, y_)[0, 1])
-        print(f"\n=== {n}: {len(pairs)} rows; raw corr(1/(1+d_sym), S) = {r(F[:, 0], y[:, 1]):+.3f}, "
-              f"corr(shared_parent, S) = {r(F[:, 1], y[:, 1]):+.3f} ===")
 
-        acc = {rn: {"j": [], "s": []} for rn in RUNGS}
-        split_s = {rn: [] for rn in RUNGS}   # per-split mean S-marginal NLL (blocker 4: paired per-split)
-        used = 0
-        for seed in range(a.seeds):
-            tr, he = descendant_disjoint_split(pairs, seed, held_frac=0.30)
-            if len(tr) < 30 or len(he) < 12:
+        def corr(x, target):
+            return float(np.corrcoef(x, target)[0, 1])
+
+        print(
+            f"\n=== {name}: {len(pairs)} rows; raw corr(1/(1+d_sym), S) = {corr(F[:, 0], y[:, 1]):+.3f}, "
+            f"corr(shared_parent, S) = {corr(F[:, 1], y[:, 1]):+.3f} ==="
+        )
+
+        # Split-seed values answer only whether the result is stable to the node partition. They are not
+        # independent replications, so their SD is descriptive and is never divided by sqrt(n).
+        split_scores = {rung: {"j": [], "s": []} for rung in RUNGS}
+        valid_splits = []
+        skipped = []
+        fixed = None
+        mc_seeds = list(range(a.seeds))
+        eval_seeds = list(mc_seeds)
+        if a.bootstrap_resamples and a.bootstrap_split_seed not in eval_seeds:
+            eval_seeds.append(a.bootstrap_split_seed)
+
+        for seed in eval_seeds:
+            split = node_disjoint_pair_split(
+                pairs,
+                seed,
+                held_node_fraction=a.held_node_frac,
+                strata=tags,
+                candidates=a.split_candidates,
+                minimum_per_stratum=a.minimum_per_stratum,
+            )
+            tr, he = split.train, split.held
+            missing_train, missing_held = split.missing_strata(a.minimum_per_stratum)
+            reasons = []
+            if len(tr) < a.min_train:
+                reasons.append(f"train {len(tr)} < {a.min_train}")
+            if len(he) < a.min_held:
+                reasons.append(f"held {len(he)} < {a.min_held}")
+            if missing_train:
+                reasons.append(f"train strata below minimum: {','.join(map(str, missing_train))}")
+            if missing_held:
+                reasons.append(f"held strata below minimum: {','.join(map(str, missing_held))}")
+            if reasons:
+                if seed in mc_seeds:
+                    skipped.append((seed, "; ".join(reasons)))
+                if a.bootstrap_resamples and seed == a.bootstrap_split_seed:
+                    raise RuntimeError(
+                        f"fixed bootstrap split seed {seed} is invalid: {'; '.join(reasons)}; "
+                        "choose another --bootstrap-split-seed or increase --split-candidates"
+                    )
                 continue
-            used += 1
-            cur_s = {rn: [] for rn in RUNGS}
-            m = affine_calibrate(d[tr], y[tr, 0], d)
+
+            graph_D = affine_calibrate(d[tr], y[tr, 0], d)
             X = np.column_stack([F, np.ones(len(F))])
-            beta, *_ = np.linalg.lstsq(X[tr], y[tr, 1], rcond=None)   # graph_S: linear fit to S on train
-            gs = X @ beta
-            luna_c = calibrate_luna(luna, y, tr)                      # bias first (blocker 3 / DESIGN §2)
-            meas = np.column_stack([m, gs, luna_c[:, 0], luna_c[:, 1]])
-            E = np.column_stack([y - prior, meas - y[:, [0, 1, 0, 1]]])[tr]
-            C6 = fit_residual_covariance(E, shrinkage=a.shrink)
-            P0, C_pm, R0 = C6[:2, :2], C6[:2, 2:], C6[2:, 2:]
+            beta, *_ = np.linalg.lstsq(X[tr], y[tr, 1], rcond=None)
+            graph_S = X @ beta
+            luna_calibrated = calibrate_luna(luna, y, tr)
+            meas = np.column_stack([graph_D, graph_S, luna_calibrated[:, 0], luna_calibrated[:, 1]])
+            errors = np.column_stack([y - prior, meas - y[:, [0, 1, 0, 1]]])[tr]
+            covariance = fit_residual_covariance(errors, shrinkage=a.shrink)
+            P0, C_pm, R0 = covariance[:2, :2], covariance[:2, 2:], covariance[2:, 2:]
+            row_scores = {rung: {"j": [], "s": []} for rung in RUNGS}
             for i in he:
                 x = prior[i]
-                for rn, sel in RUNGS.items():
-                    if not sel:
+                for rung, selected in RUNGS.items():
+                    if not selected:
                         xp, Pp = x, P0
                     else:
-                        xp, Pp = correlated_update_H(x, P0, meas[i][sel], R0[np.ix_(sel, sel)],
-                                                     C_pm[:, sel], H4[sel])
-                    sv = s_marginal_nll(y[i, 1] - xp[1], Pp[1, 1])
-                    acc[rn]["j"].append(nll_mahal(y[i] - xp, Pp)[0])
-                    acc[rn]["s"].append(sv)
-                    cur_s[rn].append(sv)
-            for rn in RUNGS:
-                split_s[rn].append(float(np.mean(cur_s[rn])))
+                        xp, Pp = correlated_update_H(
+                            x,
+                            P0,
+                            meas[i][selected],
+                            R0[np.ix_(selected, selected)],
+                            C_pm[:, selected],
+                            H4[selected],
+                        )
+                    s_nll = s_marginal_nll(y[i, 1] - xp[1], Pp[1, 1])
+                    row_scores[rung]["j"].append(nll_mahal(y[i] - xp, Pp)[0])
+                    row_scores[rung]["s"].append(s_nll)
 
-        print(f"ladder ({used} splits; NLL ↓):")
-        print(f"    {'rung':22s} {'joint':>8s} {'S-marginal':>11s}")
-        for rn in RUNGS:
-            print(f"    {rn:22s} {np.mean(acc[rn]['j']):+8.4f} {np.mean(acc[rn]['s']):+11.4f}")
-        # Blocker 4: held rows repeat across the 40 splits, so a pooled row-SE is NOT an independent-sample
-        # SE. Report the PAIRED per-split value (mean of per-split differences) ± across-split SE instead.
-        # descendant_disjoint_split is descendant-disjoint, not node-disjoint → treat as EXPLORATORY.
-        for nm, base, plus in [("graph_S free-only (S)", "+graph_D", "+graph_D+graph_S"),
-                               ("graph_S after luna (S)", "+graph_D+luna", "ALL")]:
-            g = np.array(split_s[base]) - np.array(split_s[plus])          # paired per-split differences
-            se = g.std(ddof=1) / np.sqrt(len(g)) if len(g) > 1 else float("nan")
-            print(f"    value of {nm:24s}: {g.mean():+.4f} (per-split SE {se:.4f}, "
-                  f"{int((g > 0).sum())}/{len(g)} splits +; EXPLORATORY — descendant-disjoint)")
+            if seed in mc_seeds:
+                valid_splits.append(split)
+                for rung in RUNGS:
+                    split_scores[rung]["j"].append(float(np.mean(row_scores[rung]["j"])))
+                    split_scores[rung]["s"].append(float(np.mean(row_scores[rung]["s"])))
+            if a.bootstrap_resamples and seed == a.bootstrap_split_seed:
+                fixed = {
+                    "split": split,
+                    "pairs": [pairs[i] for i in he],
+                    "gains": {
+                        effect: np.asarray(row_scores[base]["s"]) - np.asarray(row_scores[plus]["s"])
+                        for effect, base, plus in EFFECTS
+                    },
+                }
+
+        if not valid_splits:
+            raise RuntimeError("no valid node-disjoint Monte Carlo splits; inspect coverage settings")
+
+        print(
+            f"node-disjoint coverage: {len(valid_splits)}/{a.seeds} valid split seeds; "
+            f"{len(skipped)} skipped (cross-partition pairs always discarded)"
+        )
+        train_sizes = np.array([len(split.train) for split in valid_splits])
+        held_sizes = np.array([len(split.held) for split in valid_splits])
+        cross_sizes = np.array([len(split.cross) for split in valid_splits])
+        print(
+            "    pair counts across valid seeds (mean [min,max]): "
+            f"train {train_sizes.mean():.1f} [{train_sizes.min()},{train_sizes.max()}], "
+            f"held {held_sizes.mean():.1f} [{held_sizes.min()},{held_sizes.max()}], "
+            f"cross {cross_sizes.mean():.1f} [{cross_sizes.min()},{cross_sizes.max()}]"
+        )
+        for tag in sorted(valid_splits[0].strata, key=str):
+            train_cov = np.array([split.strata[tag].train for split in valid_splits])
+            held_cov = np.array([split.strata[tag].held for split in valid_splits])
+            print(
+                f"    stratum {str(tag):18.18s}: train min/median {train_cov.min()}/{np.median(train_cov):.0f}; "
+                f"held min/median {held_cov.min()}/{np.median(held_cov):.0f}"
+            )
+        if skipped:
+            sample = "; ".join(f"{seed} ({why})" for seed, why in skipped[:5])
+            print(f"    skipped seeds: {sample}" + ("; ..." if len(skipped) > 5 else ""))
+
+        print(f"ladder (mean across {len(valid_splits)} node-disjoint split means; NLL ↓):")
+        print("    split SD is descriptive Monte Carlo partition stability, not an SE or confidence interval")
+        print(f"    {'rung':22s} {'joint mean ± SD':>20s} {'S-marginal mean ± SD':>23s}")
+        for rung in RUNGS:
+            joint_mean, joint_sd = _mean_sd(split_scores[rung]["j"])
+            s_mean, s_sd = _mean_sd(split_scores[rung]["s"])
+            print(f"    {rung:22s} {joint_mean:+8.4f} ± {joint_sd:7.4f} {s_mean:+11.4f} ± {s_sd:7.4f}")
+        for effect, base, plus in EFFECTS:
+            gains = np.asarray(split_scores[base]["s"]) - np.asarray(split_scores[plus]["s"])
+            mean, sd = _mean_sd(gains)
+            print(
+                f"    value of {effect:24s}: {mean:+.4f} ± {sd:.4f} split SD; "
+                f"{int((gains > 0).sum())}/{len(gains)} split seeds +"
+            )
+
+        if a.bootstrap_resamples:
+            if fixed is None:
+                raise RuntimeError(f"fixed bootstrap split seed {a.bootstrap_split_seed} was not evaluated")
+            print(
+                f"fixed node-disjoint held evaluation (seed {a.bootstrap_split_seed}, "
+                f"selected candidate {fixed['split'].selected_candidate + 1}/{a.split_candidates}):"
+            )
+            for line in format_split_diagnostics(fixed["split"]).splitlines():
+                print(f"    {line}")
+            print(
+                f"    paired two-endpoint node-block bootstrap ({a.bootstrap_confidence:.0%} percentile CI; "
+                "conditional on this fitted split, not split-seed variability):"
+            )
+            for effect_index, (effect, _, _) in enumerate(EFFECTS):
+                interval = paired_node_bootstrap_ci(
+                    fixed["pairs"],
+                    fixed["gains"][effect],
+                    n_resamples=a.bootstrap_resamples,
+                    seed=a.bootstrap_seed + 1009 * corpus_index + effect_index,
+                    confidence=a.bootstrap_confidence,
+                )
+                print(
+                    f"      {effect:27s}: {interval.estimate:+.4f} "
+                    f"[{interval.low:+.4f}, {interval.high:+.4f}] "
+                    f"(B={interval.n_resamples}, held-node resampling uncertainty)"
+                )
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/sim_matched_cost.py
+++ b/prototypes/mu_cosine/sim_matched_cost.py
@@ -12,13 +12,21 @@ Fusion blocks (prior ⊕ graph_D ⊕ graph_S ⊕ luna, correlated) fit on the ov
 posteriors; the overlap trains on its 5.5 labels.
 
 Downstream estimator: ridge regression from frozen e5 pair-features (p_x⊙q_y ++ |p_x−q_y|) — a fast proxy
-for the head fine-tune; both arms use the SAME estimator so the comparison is about label quality×quantity,
-not the estimator (caveat: absolute numbers are proxy-level; the transformer head sees more). Eval: held
-corr vs 5.5 labels (D and S), 10 resamples per grid point.
+for the head fine-tune; all arms use the SAME estimator so the comparison is about label quality×quantity,
+not the estimator (caveat: absolute numbers are proxy-level; the transformer head sees more). Lambda is
+selected on an order-invariant PAID-label split: calibration, covariance, pseudo-targets, ridge, and scaler use
+paid inner-train only, candidates score only paid inner-valid true labels, then the selected pipeline is refit on
+the full arm. The default evaluation partition is strict node-disjoint; crossing pairs are dropped. Eval: held
+corr vs 5.5 labels (D and S), paired resamples per grid point.
+
+The A+free control spends the same n paid calls as arm A, fits the prior⊕graph conditioner on those rows,
+then fills the rest of the available training pool with zero-scoring-cost fused targets. It deliberately uses
+the whole free pool (and is labelled accordingly), rather than pretending that free rows consume budget.
 
   python3 sim_matched_cost.py --k 2 4 8
 """
 import argparse
+import hashlib
 import os
 import sys
 
@@ -28,6 +36,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from eval_luna_transfer import load_luna as load_scored_mu_tsv
 from fine_tune_channel_heads import load_campaign_datasets, load_expanded
 from fine_tune_fused_head import agnostic_readouts
+from node_disjoint_eval import format_split_diagnostics, node_disjoint_pair_split
 from product_kalman import fit_residual_covariance
 from run_judge_channel import correlated_update_H
 from run_product_kalman_logit import dequant
@@ -37,6 +46,37 @@ from sigma_hop_confirmatory import FeatureGraphConfig, descendant_disjoint_split
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 LUNA_CAMPAIGN = "/tmp/mu_data/campaign_scored_luna.tsv"
+H_FREE = np.array([[1.0, 0.0], [0.0, 1.0]])
+
+
+def positive_integer(value):
+    """Argparse/type helper for price ratios, which this row-count simulation requires to be integral."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}") from exc
+    if not np.isfinite(number) or number <= 0 or not number.is_integer():
+        raise argparse.ArgumentTypeError(
+            f"k must be a positive integer price ratio; got {value!r} (fractional rows cannot spend exactly)"
+        )
+    return int(number)
+
+
+def stable_seed(seed, *parts):
+    """Stable 64-bit seed, independent of Python hash randomization and grid traversal order."""
+    h = hashlib.blake2b(digest_size=8, person=b"mu-cost")
+    for value in (int(seed),) + parts:
+        payload = repr(value).encode("utf-8")
+        h.update(len(payload).to_bytes(8, "little"))
+        h.update(payload)
+    return int.from_bytes(h.digest(), "little")
+
+
+def replicate_permutation(pool, seed, corpus, rep):
+    """One reusable permutation per corpus/replicate, so n cells are nested and order-independent."""
+    pool = np.asarray(pool)
+    rng = np.random.default_rng(stable_seed(seed, corpus, int(rep), "sample"))
+    return pool[rng.permutation(len(pool))]
 
 
 def budget_plan(n, k, n_ov, avail):
@@ -45,41 +85,243 @@ def budget_plan(n, k, n_ov, avail):
         spend(overlap) = n_ov*(1+1/k);  n_bulk = k*(n - n_ov*(1+1/k)) = k*n - n_ov*(k+1).
     Realized spend equals n exactly when the cell is feasible and untruncated, and is < n otherwise.
     Returns (n_bulk_want, n_bulk_used, truncated, spend, feasible)."""
+    try:
+        k = positive_integer(k)
+    except argparse.ArgumentTypeError as exc:
+        raise ValueError(str(exc)) from exc
     spend_ov = n_ov * (1.0 + 1.0 / k)
     feasible = spend_ov <= n + 1e-6                 # can we even afford the dual-scored overlap?
-    n_bulk = int(k * n - n_ov * (k + 1))
+    n_bulk = k * n - n_ov * (k + 1)
     trunc = feasible and n_bulk > avail
     n_bulk_used = max(0, min(n_bulk, avail)) if feasible else 0
     spend = spend_ov + n_bulk_used / k
     return n_bulk, n_bulk_used, trunc, spend, feasible
 
 
-def ridge_fit_predict(X, y, Xq, lams=(3.0, 30.0, 300.0, 3000.0)):
-    """Ridge with λ selected on an inner 80/20 holdout — a fixed λ sits near the interpolation
-    threshold (n ≈ 768 features) at the large-n grid points and double-descent wrecks the curve."""
-    mu, sd = X.mean(0), X.std(0) + 1e-9
+def _canonical_ids(X, y, sample_ids):
+    """Return stable row identities; callers should pass dataset indices when available."""
+    if sample_ids is not None:
+        ids = np.asarray(sample_ids)
+        if len(ids) != len(X):
+            raise ValueError("sample_ids must have one value per training row")
+        labels = [repr(value.item() if hasattr(value, "item") else value) for value in ids]
+        if len(set(labels)) != len(labels):
+            raise ValueError("sample_ids must be unique")
+        return ids
+    # Content-derived fallback keeps the public helper permutation-invariant. Exact duplicate rows may
+    # share an identity, but their contribution is identical because the target is included in the digest.
+    ids = []
+    for row, target in zip(np.asarray(X), np.asarray(y)):
+        h = hashlib.blake2b(digest_size=16, person=b"mu-ridge-row")
+        h.update(np.ascontiguousarray(row).tobytes())
+        h.update(np.ascontiguousarray(np.asarray(target)).tobytes())
+        ids.append(h.hexdigest())
+    return np.asarray(ids)
+
+
+def _inner_partition(X, y, sample_ids=None, split_seed=0, valid_frac=0.20):
+    """Order-invariant inner split, canonically ordered to remove input-order floating-point drift."""
+    n = len(X)
+    if n < 3:
+        raise ValueError("ridge lambda selection needs at least three training rows")
+    if not 0.0 < valid_frac < 1.0:
+        raise ValueError("valid_frac must lie strictly between zero and one")
+    ids = _canonical_ids(X, y, sample_ids)
+    keyed = []
+    for i, value in enumerate(ids):
+        value = value.item() if hasattr(value, "item") else value
+        keyed.append((stable_seed(split_seed, "inner", value), repr(value), i))
+    order = np.array([item[2] for item in sorted(keyed)], dtype=int)
+    n_valid = min(n - 2, max(1, int(round(valid_frac * n))))
+    return order[n_valid:], order[:n_valid], order
+
+
+def _stable_order(sample_ids, seed, purpose):
+    """Canonical row order keyed only by stable identity, never by a target value or input position."""
+    keyed = []
+    for i, value in enumerate(np.asarray(sample_ids)):
+        value = value.item() if hasattr(value, "item") else value
+        keyed.append((stable_seed(seed, purpose, value), repr(value), i))
+    return np.array([item[2] for item in sorted(keyed)], dtype=int)
+
+
+def _ridge_weights(X, y, lam):
+    """Fit standardized ridge plus an unpenalized intercept, returning its complete transform."""
+    mu = X.mean(axis=0)
+    sd = X.std(axis=0) + 1e-9
+    y_mu = float(y.mean())
     Z = (X - mu) / sd
-    n = len(Z); n_in = max(20, int(0.8 * n))
-    G = Z.T @ Z; b = Z.T @ (y - y.mean())
-    Gi = Z[:n_in].T @ Z[:n_in]; bi = Z[:n_in].T @ (y[:n_in] - y[:n_in].mean())
-    best, w_best = -2.0, None
+    eye = np.eye(Z.shape[1])
+    w = np.linalg.solve(Z.T @ Z + float(lam) * eye, Z.T @ (y - y_mu))
+    return mu, sd, y_mu, w
+
+
+def _select_ridge_lambda(X, y, Xv, yv, lams, train_ids, valid_ids, split_seed):
+    """Fit/scaler on candidate-train only and score every lambda on paid true-label validation only."""
+    train_order = _stable_order(train_ids, split_seed, "ridge-candidate-train")
+    valid_order = _stable_order(valid_ids, split_seed, "ridge-candidate-valid")
+    X = np.asarray(X, dtype=float)[train_order]
+    y = np.asarray(y, dtype=float)[train_order]
+    Xv = np.asarray(Xv, dtype=float)[valid_order]
+    yv = np.asarray(yv, dtype=float)[valid_order]
+    mu = X.mean(axis=0)
+    sd = X.std(axis=0) + 1e-9
+    y_mu = float(y.mean())
+    Z = (X - mu) / sd
+    Zv = (Xv - mu) / sd
+    G = Z.T @ Z
+    b = Z.T @ (y - y_mu)
+    eye = np.eye(X.shape[1])
+    best_score = -np.inf
+    best_lam = None
     for lam in lams:
-        wi = np.linalg.solve(Gi + lam * np.eye(Z.shape[1]), bi)
-        pv = Z[n_in:] @ wi
-        c = np.corrcoef(pv, y[n_in:])[0, 1] if pv.std() > 1e-9 else -1.0
-        if c > best:
-            best, w_best = c, np.linalg.solve(G + lam * np.eye(Z.shape[1]), b)
-    return ((Xq - mu) / sd) @ w_best + y.mean()
+        w = np.linalg.solve(G + float(lam) * eye, b)
+        pv = y_mu + Zv @ w
+        score = np.corrcoef(pv, yv)[0, 1] if pv.std() > 1e-9 and yv.std() > 1e-9 else -np.inf
+        # Fixed lambda order is the deterministic tie-breaker.
+        if score > best_score:
+            best_score, best_lam = float(score), float(lam)
+    if best_lam is None:  # All validation correlations were undefined: choose the strongest regularizer.
+        best_lam = float(max(lams))
+    return best_lam, mu, sd
 
 
-def fused_targets(prior, meas, y, fit_idx, shrink=0.05):
+def nested_ridge_fit_predict(
+    X, y, Xq, paid_idx, bulk_idx=(), *, pseudo_target_builder=None,
+    lams=(3.0, 30.0, 300.0, 3000.0), sample_ids=None, split_seed=0, return_info=False,
+):
+    """Nested paid-label lambda selection followed by a full-budget refit.
+
+    ``pseudo_target_builder(fit_paid_idx)`` must return one pseudo-target per row in ``X``. During lambda
+    selection it is called with paid inner-train rows only; paid inner-valid labels are used exclusively to
+    score candidate lambdas. After selection, the builder and ridge are refit using all paid rows. This keeps
+    supervised calibration/covariance fitting out of the validation fold while retaining the whole paid
+    budget in the final arm.
+    """
+    X = np.asarray(X, dtype=float)
+    y = np.asarray(y, dtype=float)
+    Xq = np.asarray(Xq, dtype=float)
+    paid_idx = np.asarray(paid_idx, dtype=int)
+    bulk_idx = np.asarray(bulk_idx, dtype=int)
+    lams = tuple(float(lam) for lam in lams)
+    if X.ndim != 2 or y.shape != (len(X),):
+        raise ValueError("X must be 2-D with one true target per row")
+    if len(paid_idx) < 3:
+        raise ValueError("nested ridge selection needs at least three paid rows")
+    if paid_idx.ndim != 1 or bulk_idx.ndim != 1:
+        raise ValueError("paid_idx and bulk_idx must be 1-D")
+    all_idx = np.concatenate([paid_idx, bulk_idx])
+    if len(np.unique(all_idx)) != len(all_idx):
+        raise ValueError("paid and bulk rows must be unique and disjoint")
+    if len(all_idx) and (all_idx.min() < 0 or all_idx.max() >= len(X)):
+        raise ValueError("paid_idx and bulk_idx must index rows of X")
+    if not lams or any(lam <= 0 for lam in lams):
+        raise ValueError("lams must contain positive values")
+    if len(bulk_idx) and pseudo_target_builder is None:
+        raise ValueError("bulk rows require a pseudo_target_builder")
+
+    ids = _canonical_ids(X, y, sample_ids)
+    paid_inner, paid_valid, _ = _inner_partition(
+        X[paid_idx], y[paid_idx], sample_ids=ids[paid_idx], split_seed=split_seed,
+    )
+    fit_paid_idx = paid_idx[paid_inner]
+    valid_paid_idx = paid_idx[paid_valid]
+    bulk_order = _stable_order(ids[bulk_idx], split_seed, "bulk") if len(bulk_idx) else np.array([], dtype=int)
+    ordered_bulk_idx = bulk_idx[bulk_order]
+
+    if len(ordered_bulk_idx):
+        pseudo_inner = np.asarray(pseudo_target_builder(fit_paid_idx), dtype=float)
+        if pseudo_inner.shape != (len(X),) or not np.isfinite(pseudo_inner).all():
+            raise ValueError("pseudo_target_builder must return one finite target per row in X")
+        candidate_idx = np.concatenate([fit_paid_idx, ordered_bulk_idx])
+        candidate_y = np.concatenate([y[fit_paid_idx], pseudo_inner[ordered_bulk_idx]])
+    else:
+        candidate_idx = fit_paid_idx
+        candidate_y = y[fit_paid_idx]
+
+    best_lam, inner_mu, inner_sd = _select_ridge_lambda(
+        X[candidate_idx], candidate_y, X[valid_paid_idx], y[valid_paid_idx], lams,
+        ids[candidate_idx], ids[valid_paid_idx], split_seed,
+    )
+
+    paid_full_order = _stable_order(ids[paid_idx], split_seed, "paid-full")
+    ordered_paid_idx = paid_idx[paid_full_order]
+    if len(ordered_bulk_idx):
+        pseudo_full = np.asarray(pseudo_target_builder(ordered_paid_idx), dtype=float)
+        if pseudo_full.shape != (len(X),) or not np.isfinite(pseudo_full).all():
+            raise ValueError("pseudo_target_builder must return one finite target per row in X")
+        final_idx = np.concatenate([ordered_paid_idx, ordered_bulk_idx])
+        final_y = np.concatenate([y[ordered_paid_idx], pseudo_full[ordered_bulk_idx]])
+    else:
+        final_idx = ordered_paid_idx
+        final_y = y[ordered_paid_idx]
+    final_order = _stable_order(ids[final_idx], split_seed, "ridge-final")
+    mu, sd, y_mu, w = _ridge_weights(X[final_idx][final_order], final_y[final_order], best_lam)
+    pred = y_mu + ((Xq - mu) / sd) @ w
+    if return_info:
+        return pred, {
+            "lambda": best_lam,
+            "inner_train": fit_paid_idx.copy(),
+            "inner_valid": valid_paid_idx.copy(),
+            "inner_mu": inner_mu.copy(),
+            "inner_sd": inner_sd.copy(),
+            "selection_target_fit_ids": np.asarray(ids[fit_paid_idx]).copy(),
+            "paid_valid_ids": np.asarray(ids[valid_paid_idx]).copy(),
+            "final_target_fit_ids": np.asarray(ids[ordered_paid_idx]).copy(),
+        }
+    return pred
+
+
+def ridge_fit_predict(
+    X, y, Xq, lams=(3.0, 30.0, 300.0, 3000.0), *, sample_ids=None, split_seed=0,
+    return_info=False,
+):
+    """Paid-label-only convenience wrapper around :func:`nested_ridge_fit_predict`."""
+    X = np.asarray(X, dtype=float)
+    y = np.asarray(y, dtype=float)
+    return nested_ridge_fit_predict(
+        X, y, Xq, np.arange(len(X)), lams=lams, sample_ids=sample_ids,
+        split_seed=split_seed, return_info=return_info,
+    )
+
+
+def paired_delta_summary(baseline, candidate, *, n_boot=5000, confidence=0.95, seed=0):
+    """Paired candidate-minus-baseline replicate delta with a percentile bootstrap CI for its mean."""
+    baseline = np.asarray(baseline, dtype=float)
+    candidate = np.asarray(candidate, dtype=float)
+    if baseline.shape != candidate.shape or baseline.ndim != 1 or len(baseline) == 0:
+        raise ValueError("baseline and candidate must be nonempty paired 1-D arrays of equal length")
+    if not (np.isfinite(baseline).all() and np.isfinite(candidate).all()):
+        raise ValueError("paired observations must be finite")
+    if int(n_boot) != n_boot or n_boot < 1:
+        raise ValueError("n_boot must be a positive integer")
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must lie strictly between zero and one")
+    delta = candidate - baseline
+    rng = np.random.default_rng(seed)
+    boot = delta[rng.integers(0, len(delta), size=(int(n_boot), len(delta)))].mean(axis=1)
+    alpha = (1.0 - confidence) / 2.0
+    lo, hi = np.quantile(boot, [alpha, 1.0 - alpha])
+    return {
+        "mean": float(delta.mean()),
+        "ci_low": float(lo),
+        "ci_high": float(hi),
+        "confidence": float(confidence),
+        "n_pairs": int(len(delta)),
+    }
+
+
+def fused_targets(prior, meas, y, fit_idx, shrink=0.05, H=H4):
     """Blocks fit on fit_idx (the overlap); posteriors for ALL rows."""
-    E = np.column_stack([y - prior, meas - y[:, [0, 1, 0, 1]]])[fit_idx]
-    C6 = fit_residual_covariance(E, shrinkage=shrink)
-    P0, C_pm, R0 = C6[:2, :2], C6[:2, 2:], C6[2:, 2:]
+    H = np.asarray(H, dtype=float)
+    if H.shape != (meas.shape[1], prior.shape[1]):
+        raise ValueError("H must map the latent target dimensions to the measurement dimensions")
+    E = np.column_stack([y - prior, meas - y @ H.T])[fit_idx]
+    cov = fit_residual_covariance(E, shrinkage=shrink)
+    P0, C_pm, R0 = cov[:2, :2], cov[:2, 2:], cov[2:, 2:]
     post = np.zeros_like(prior)
     for i in range(len(prior)):
-        xp, _ = correlated_update_H(prior[i], P0, meas[i], R0, C_pm, H4)
+        xp, _ = correlated_update_H(prior[i], P0, meas[i], R0, C_pm, H)
         post[i] = np.clip(xp, 0.0, 1.0)
     return post
 
@@ -88,10 +330,26 @@ def main():
     ap = argparse.ArgumentParser()
     # Campaign-INDEPENDENT prior (blocker 1) — see run_sym_channel_fusion.py.
     ap.add_argument("--ckpt", default=os.path.join(ROOT, "model_prod_namecond.pt"))
-    ap.add_argument("--k", type=float, nargs="+", default=[2.0, 4.0, 8.0])
+    ap.add_argument("--k", type=positive_integer, nargs="+", default=[2, 4, 8])
     ap.add_argument("--n", type=int, nargs="+", default=[80, 160, 320, 640])
     ap.add_argument("--reps", type=int, default=10)
+    ap.add_argument("--seed", type=int, default=0,
+                    help="base seed; each corpus/replicate permutation is stable across --n list/order")
+    ap.add_argument("--split", choices=("node-disjoint", "descendant-disjoint"), default="node-disjoint",
+                    help="node-disjoint is the leakage-resistant primary split; descendant-disjoint reproduces PR #3648")
+    ap.add_argument("--split-seed", type=int, default=0)
+    ap.add_argument("--held-node-frac", type=float, default=0.40)
+    ap.add_argument("--split-candidates", type=int, default=64)
+    ap.add_argument("--bootstrap-reps", type=int, default=5000,
+                    help="paired-replicate bootstrap draws for candidate-minus-A confidence intervals")
+    ap.add_argument("--confidence", type=float, default=0.95)
     a = ap.parse_args()
+    if a.reps < 1:
+        ap.error("--reps must be positive")
+    if a.bootstrap_reps < 1:
+        ap.error("--bootstrap-reps must be positive")
+    if not 0.0 < a.confidence < 1.0:
+        ap.error("--confidence must lie strictly between zero and one")
 
     ref, _ = load_expanded(a.ckpt, dev="cpu")
     ref.eval()
@@ -104,6 +362,7 @@ def main():
         parents, _, _, _ = load_feature_graph(FeatureGraphConfig(**DATASETS[corpus]["graph"]))
         keep = [i for i, p in enumerate(ds["pairs"]) if p in luna_by]
         pairs = [ds["pairs"][i] for i in keep]
+        tags = [ds["tags"][i] for i in keep]
         y = dequant(np.column_stack([ds["D"][keep], ds["S"][keep]]))
         ro = agnostic_readouts(ref, ds, "cpu")
         prior = np.column_stack([ro["prior_D"][keep], ro["prior_S"][keep]])
@@ -114,12 +373,28 @@ def main():
         ii = [tok.idx[x] for x, _ in pairs]; jj = [tok.idx[yy] for _, yy in pairs]
         px = tok.p[ii].numpy(); qy = tok.q[jj].numpy()
         feat = np.column_stack([px * qy, np.abs(px - qy)])
+        graph_design = np.column_stack([F, np.ones(len(F))])
+        row_ids = np.arange(len(feat))
 
-        tr, he = descendant_disjoint_split(pairs, 0, held_frac=0.30)
-        tr, he = np.array(tr), np.array(he)
-        print(f"\n=== {n_name}: {len(pairs)} rows (pool {len(tr)}, held {len(he)}) ===")
-        print(f"{'n':>5s} {'arm':>14s}" + "".join(f" {c:>8s}" for c in ("D corr", "S corr")))
-        rngs = np.random.default_rng(0)
+        if a.split == "node-disjoint":
+            split = node_disjoint_pair_split(
+                pairs, a.split_seed, held_node_fraction=a.held_node_frac,
+                strata=tags, candidates=a.split_candidates, minimum_per_stratum=1,
+            )
+            tr, he = split.train, split.held
+            split_note = "STRICT node-disjoint; crossing pairs dropped"
+        else:
+            tr, he = descendant_disjoint_split(pairs, a.split_seed, held_frac=0.30)
+            tr, he = np.array(tr), np.array(he)
+            split = None
+            split_note = "EXPLORATORY descendant-disjoint; roots may overlap"
+        print(f"\n=== {n_name}: {len(pairs)} rows (pool {len(tr)}, held {len(he)}; {split_note}) ===")
+        if split is not None:
+            for line in format_split_diagnostics(split).splitlines():
+                print(f"  {line}")
+        print("paired training-subsample replicates; bootstrap intervals condition on this fixed held split")
+        print(f"{'n':>5s} {'arm':>20s}" + "".join(f" {c:>8s}" for c in ("D corr", "S corr")))
+        rep_orders = [replicate_permutation(tr, a.seed, corpus, rep) for rep in range(a.reps)]
         for n in a.n:
             if n > len(tr):
                 continue
@@ -135,46 +410,118 @@ def main():
                 acct[k] = budget_plan(n, k, n_ov, avail)
                 if acct[k][4]:
                     assert acct[k][3] <= n + 1e-6, f"arm B overspends: n={n} k={k} spend={acct[k][3]:.2f} > {n}"
+                    if not acct[k][2]:
+                        assert abs(acct[k][3] - n) <= 1e-6, (
+                            f"untruncated arm B must match budget exactly: n={n} k={k} "
+                            f"spend={acct[k][3]:.6f}"
+                        )
             print(f"  n={n}: overlap n_ov={n_ov}; " + "  ".join(
                 (f"k={k:g}:INFEASIBLE" if not acct[k][4] else
                  f"k={k:g}:n_bulk={acct[k][0]}" + (f"*TRUNC->{acct[k][1]}" if acct[k][2] else "")
                  + f"(spend {acct[k][3]:.1f})") for k in a.k))
             res = {}
             for rep in range(a.reps):
-                sel = rngs.permutation(tr)
+                sel = rep_orders[rep]
                 # arm A: n pure 5.5 labels
                 A_idx = sel[:n]
                 for ch, col in (("D", 0), ("S", 1)):
-                    pred = ridge_fit_predict(feat[A_idx], y[A_idx, col], feat[he])
+                    inner_seed = stable_seed(a.seed, corpus, n, rep, ch, "ridge-inner")
+                    pred = nested_ridge_fit_predict(
+                        feat, y[:, col], feat[he], A_idx, sample_ids=row_ids, split_seed=inner_seed,
+                    )
                     res.setdefault(("A: 5.5 only", ch), []).append(np.corrcoef(pred, y[he, col])[0, 1])
+
+                # Same paid spend as A, plus all remaining pool rows labelled by prior⊕free graph channels.
+                free_bulk = sel[n:]
+                free_post_cache = {}
+
+                def build_free_post(fit_paid_idx):
+                    key = tuple(sorted(np.asarray(fit_paid_idx, dtype=int).tolist()))
+                    if key not in free_post_cache:
+                        fit = np.asarray(key, dtype=int)
+                        free_d = affine_calibrate(d[fit], y[fit, 0], d)
+                        free_beta, *_ = np.linalg.lstsq(graph_design[fit], y[fit, 1], rcond=None)
+                        free_meas = np.column_stack([free_d, graph_design @ free_beta])
+                        free_post_cache[key] = fused_targets(prior, free_meas, y, fit, H=H_FREE)
+                    return free_post_cache[key]
+
+                for ch, col in (("D", 0), ("S", 1)):
+                    inner_seed = stable_seed(a.seed, corpus, n, rep, ch, "ridge-inner")
+                    pred = nested_ridge_fit_predict(
+                        feat, y[:, col], feat[he], A_idx, free_bulk,
+                        pseudo_target_builder=lambda fit, col=col: build_free_post(fit)[:, col],
+                        sample_ids=row_ids, split_seed=inner_seed,
+                    )
+                    res.setdefault(("A+free: full pool", ch), []).append(
+                        np.corrcoef(pred, y[he, col])[0, 1]
+                    )
+
                 # arm B per k: overlap n_ov (5.5 labels) + luna bulk with fused targets
                 ov = sel[:n_ov]
-                m_cal = affine_calibrate(d[ov], y[ov, 0], d)
-                X = np.column_stack([F, np.ones(len(F))])
-                beta, *_ = np.linalg.lstsq(X[ov], y[ov, 1], rcond=None)
-                luna_c = calibrate_luna(luna, y, ov)                  # bias first (blocker 3 / DESIGN §2)
-                meas = np.column_stack([m_cal, X @ beta, luna_c[:, 0], luna_c[:, 1]])
-                post = fused_targets(prior, meas, y, ov)
+                luna_post_cache = {}
+
+                def build_luna_post(fit_paid_idx):
+                    key = tuple(sorted(np.asarray(fit_paid_idx, dtype=int).tolist()))
+                    if key not in luna_post_cache:
+                        fit = np.asarray(key, dtype=int)
+                        m_cal = affine_calibrate(d[fit], y[fit, 0], d)
+                        beta, *_ = np.linalg.lstsq(graph_design[fit], y[fit, 1], rcond=None)
+                        luna_c = calibrate_luna(luna, y, fit)         # bias first (blocker 3 / DESIGN §2)
+                        meas = np.column_stack([
+                            m_cal, graph_design @ beta, luna_c[:, 0], luna_c[:, 1],
+                        ])
+                        luna_post_cache[key] = fused_targets(prior, meas, y, fit)
+                    return luna_post_cache[key]
+
                 for k in a.k:
                     if not acct[k][4]:
                         continue
                     B_bulk = sel[n_ov:n_ov + acct[k][1]]
-                    idx = np.concatenate([ov, B_bulk])
                     for ch, col in (("D", 0), ("S", 1)):
-                        tgt = np.concatenate([y[ov, col], post[B_bulk, col]])
-                        pred = ridge_fit_predict(feat[idx], tgt, feat[he])
+                        inner_seed = stable_seed(a.seed, corpus, n, rep, ch, "ridge-inner")
+                        pred = nested_ridge_fit_predict(
+                            feat, y[:, col], feat[he], ov, B_bulk,
+                            pseudo_target_builder=lambda fit, col=col: build_luna_post(fit)[:, col],
+                            sample_ids=row_ids, split_seed=inner_seed,
+                        )
                         res.setdefault((f"B: scheme k={k:g}", ch), []).append(
                             np.corrcoef(pred, y[he, col])[0, 1])
-            arms = sorted({arm for arm, _ in res})
+            arms = ["A: 5.5 only", "A+free: full pool"] + [
+                f"B: scheme k={k:g}" for k in a.k if (f"B: scheme k={k:g}", "D") in res
+            ]
+            baselines = {
+                "A": {ch: np.asarray(res[("A: 5.5 only", ch)]) for ch in ("D", "S")},
+                "A+free": {ch: np.asarray(res[("A+free: full pool", ch)]) for ch in ("D", "S")},
+            }
             for arm in arms:
                 cd = np.array(res[(arm, "D")]); cs = np.array(res[(arm, "S")])
                 flag = ""
                 if arm.startswith("B: scheme"):
-                    kv = float(arm.split("k=")[1])
+                    kv = int(arm.split("k=")[1])
                     if acct[kv][2]:
                         flag = "  [TRUNC: pool-limited, excluded from matched-cost claim]"
-                print(f"{n:>5d} {arm:>14s} {cd.mean():+8.3f} {cs.mean():+8.3f}"
-                      f"   (±{cd.std():.3f}/±{cs.std():.3f}){flag}")
+                elif arm.startswith("A+free"):
+                    flag = "  [same paid spend; zero-cost targets fill pool]"
+                print(f"{n:>5d} {arm:>20s} {cd.mean():+8.3f} {cs.mean():+8.3f}"
+                      f"   (replicate SD {cd.std():.3f}/{cs.std():.3f}){flag}")
+                if arm != "A: 5.5 only":
+                    comparisons = ["A"] + (["A+free"] if arm.startswith("B: scheme") else [])
+                    for comparison in comparisons:
+                        summaries = {}
+                        for ch, vals in (("D", cd), ("S", cs)):
+                            summaries[ch] = paired_delta_summary(
+                                baselines[comparison][ch], vals,
+                                n_boot=a.bootstrap_reps, confidence=a.confidence,
+                                seed=stable_seed(
+                                    a.seed, corpus, n, arm, comparison, ch, "paired-bootstrap"
+                                ),
+                            )
+                        pct = 100.0 * a.confidence
+                        print(" " * 28 + f"paired Δ vs {comparison}: " + "  ".join(
+                            f"{ch} {summary['mean']:+.3f} "
+                            f"({pct:g}% CI {summary['ci_low']:+.3f},{summary['ci_high']:+.3f})"
+                            for ch, summary in summaries.items()
+                        ))
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/test_cheap_judge_joint_posterior.py
+++ b/prototypes/mu_cosine/test_cheap_judge_joint_posterior.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Focused tests for the post-#3648 JointPosterior decision-space comparison."""
+import numpy as np
+
+from run_cheap_judge_joint_posterior import (
+    CLASSES,
+    aggregate_decision_probabilities,
+    component_bootstrap_aurc,
+    endpoint_components,
+    gaussian_bridge_proba,
+    macro_decision,
+    pool_relation_values,
+    strict_node_disjoint_split,
+)
+
+
+def test_macro_decision_aggregation_is_normalised_and_ordered():
+    names = [
+        "P[element_of]", "P[subcategory]", "P[subtopic]", "P[super_category]",
+        "P[see_also]", "P[assoc]", "P[unknown]", "P[none]",
+    ]
+    col = {name: i for i, name in enumerate(names)}
+    row = ["0.10", "0.20", "0.05", "0.05", "0.20", "0.10", "0.20", "0.10"]
+    p = aggregate_decision_probabilities(row, col)
+    assert CLASSES == ("directional", "symmetric", "other")
+    assert np.allclose(p, [0.40, 0.30, 0.30])
+    assert np.isclose(p.sum(), 1.0)
+
+
+def test_macro_decision_persists_margin_and_resolves_ties_in_class_order():
+    decision, margin, tied = macro_decision([0.4, 0.4, 0.2])
+    assert decision == "directional"
+    assert margin == 0.0
+    assert tied
+    decision, margin, tied = macro_decision([0.1, 0.7, 0.2])
+    assert decision == "symmetric"
+    assert np.isclose(margin, 0.5)
+    assert not tied
+
+
+def test_within_judge_pooling_is_bounded_and_not_expert_selection():
+    mu = np.array([0.1, 0.5, 0.9])
+    probability = np.array([0.7, 0.2, 0.1])
+    hard, prob_weighted, soft = pool_relation_values(mu, probability, temperature=0.1)
+    assert hard == 0.9
+    assert np.isclose(prob_weighted, 0.26)
+    assert mu.min() <= soft <= mu.max()
+    assert soft > prob_weighted  # different within-judge reductions of the same three relation values
+
+
+def test_strict_node_split_has_no_endpoint_leakage_and_is_deterministic():
+    pairs = [(f"n{i}", f"n{(i + 1) % 20}") for i in range(20)] + [
+        (f"n{i}", f"n{(i + 7) % 20}") for i in range(20)
+    ]
+    tr1, he1 = strict_node_disjoint_split(pairs, seed=7, held_frac=0.40)
+    tr2, he2 = strict_node_disjoint_split(pairs, seed=7, held_frac=0.40)
+    assert np.array_equal(tr1, tr2) and np.array_equal(he1, he2)
+    train_nodes = {n for i in tr1 for n in pairs[i]}
+    held_nodes = {n for i in he1 for n in pairs[i]}
+    assert train_nodes.isdisjoint(held_nodes)
+    assert len(tr1) + len(he1) < len(pairs)  # crossing rows are deliberately dropped
+
+
+def test_endpoint_components_keep_shared_node_rows_together():
+    pairs = [("a", "b"), ("b", "c"), ("x", "y"), ("q", "r"), ("r", "s")]
+    components = sorted((sorted(x.tolist()) for x in endpoint_components(pairs)), key=lambda x: x[0])
+    assert components == [[0, 1], [2], [3, 4]]
+
+
+class _Bridge:
+    def proba(self, X):
+        X = np.asarray(X, float)
+        logits = np.column_stack([X[:, 0], X[:, 1], np.zeros(len(X))])
+        logits -= logits.max(axis=1, keepdims=True)
+        p = np.exp(logits)
+        return p / p.sum(axis=1, keepdims=True)
+
+
+def test_gaussian_bridge_zero_covariance_equals_point_bridge():
+    means = np.array([[0.2, 0.8], [0.7, 0.1]])
+    cov = np.zeros((2, 2, 2))
+    got = gaussian_bridge_proba(_Bridge(), means, cov, order=5)
+    assert np.allclose(got, _Bridge().proba(means), atol=1e-12)
+
+
+def test_gaussian_bridge_nonzero_covariance_is_finite_and_normalised():
+    means = np.array([[0.2, 0.8], [0.7, 0.1]])
+    cov = np.array([[[0.2, 0.05], [0.05, 0.1]], [[0.1, -0.02], [-0.02, 0.3]]])
+    got = gaussian_bridge_proba(_Bridge(), means, cov, order=7)
+    assert np.isfinite(got).all()
+    assert np.all(got >= 0)
+    assert np.allclose(got.sum(axis=1), 1.0)
+
+
+def test_component_bootstrap_reports_blocks_not_rows():
+    pairs = [("a", "b"), ("b", "c"), ("x", "y"), ("q", "r")]
+    proba = np.array([[0.8, 0.1, 0.1], [0.7, 0.2, 0.1],
+                      [0.2, 0.7, 0.1], [0.1, 0.2, 0.7]])
+    labels = np.array([0, 0, 1, 2])
+    point, lo, hi, n_blocks, largest = component_bootstrap_aurc(
+        proba, labels, pairs, B=50, seed=4,
+    )
+    assert n_blocks == 3 and largest == 2
+    assert 0.0 <= lo <= point <= hi <= 1.0
+
+
+def _run_all():
+    tests = [fn for name, fn in sorted(globals().items()) if name.startswith("test_") and callable(fn)]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"all {len(tests)} cheap-judge JointPosterior tests passed")
+
+
+if __name__ == "__main__":
+    _run_all()

--- a/prototypes/mu_cosine/test_cheap_judge_joint_posterior.py
+++ b/prototypes/mu_cosine/test_cheap_judge_joint_posterior.py
@@ -10,8 +10,8 @@ from run_cheap_judge_joint_posterior import (
     gaussian_bridge_proba,
     macro_decision,
     pool_relation_values,
-    strict_node_disjoint_split,
 )
+from node_disjoint_eval import node_disjoint_pair_split
 
 
 def test_macro_decision_aggregation_is_normalised_and_ordered():
@@ -48,17 +48,24 @@ def test_within_judge_pooling_is_bounded_and_not_expert_selection():
     assert soft > prob_weighted  # different within-judge reductions of the same three relation values
 
 
-def test_strict_node_split_has_no_endpoint_leakage_and_is_deterministic():
+def test_audited_node_split_has_no_endpoint_leakage_and_is_deterministic():
     pairs = [(f"n{i}", f"n{(i + 1) % 20}") for i in range(20)] + [
         (f"n{i}", f"n{(i + 7) % 20}") for i in range(20)
     ]
-    tr1, he1 = strict_node_disjoint_split(pairs, seed=7, held_frac=0.40)
-    tr2, he2 = strict_node_disjoint_split(pairs, seed=7, held_frac=0.40)
-    assert np.array_equal(tr1, tr2) and np.array_equal(he1, he2)
-    train_nodes = {n for i in tr1 for n in pairs[i]}
-    held_nodes = {n for i in he1 for n in pairs[i]}
+    strata = ["even" if i % 2 == 0 else "odd" for i in range(len(pairs))]
+    split1 = node_disjoint_pair_split(
+        pairs, 7, held_node_fraction=0.40, strata=strata, candidates=16,
+    )
+    split2 = node_disjoint_pair_split(
+        pairs, 7, held_node_fraction=0.40, strata=strata, candidates=16,
+    )
+    assert np.array_equal(split1.train, split2.train)
+    assert np.array_equal(split1.held, split2.held)
+    assert split1.selected_candidate == split2.selected_candidate
+    train_nodes = {n for i in split1.train for n in pairs[i]}
+    held_nodes = {n for i in split1.held for n in pairs[i]}
     assert train_nodes.isdisjoint(held_nodes)
-    assert len(tr1) + len(he1) < len(pairs)  # crossing rows are deliberately dropped
+    assert len(split1.cross) > 0
 
 
 def test_endpoint_components_keep_shared_node_rows_together():

--- a/prototypes/mu_cosine/test_emit_transitive_hops.py
+++ b/prototypes/mu_cosine/test_emit_transitive_hops.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Determinism checks for graph-native hit probability."""
+
+import pytest
+
+from emit_transitive_hops import hit_prob
+
+
+def test_hit_prob_is_invariant_to_parent_container_order_with_cycle_guard():
+    # The a<->b cycle exercises the documented in-progress memo guard. Without canonical parent
+    # traversal, merely reversing x's parent list changes which branch encounters the guard first.
+    forward = {"x": ["a", "b"], "a": ["b", "target"], "b": ["a"], "target": []}
+    reversed_lists = {node: list(reversed(parents)) for node, parents in forward.items()}
+    set_backed = {node: set(parents) for node, parents in forward.items()}
+
+    expected = hit_prob(forward, "x", "target")
+    assert expected == pytest.approx(0.25)
+    assert hit_prob(reversed_lists, "x", "target") == pytest.approx(expected)
+    assert hit_prob(set_backed, "x", "target") == pytest.approx(expected)

--- a/prototypes/mu_cosine/test_joint_square_root_conditioner.py
+++ b/prototypes/mu_cosine/test_joint_square_root_conditioner.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Property tests for the joint square-root / Householder-QR conditioner."""
+
+import numpy as np
+
+from joint_square_root_conditioner import (
+    condition_correlated_gaussian_qr,
+    conditional_measurement_model,
+    householder_information_update,
+    precision_root_from_covariance,
+    whiten_measurement_block,
+)
+from product_kalman import gaussian_condition_update
+
+
+def _joint_spd(rng, n, m, floor=0.5):
+    a = rng.standard_normal((n + m, n + m))
+    sigma = a @ a.T + floor * np.eye(n + m)
+    return sigma[:n, :n], sigma[:n, n:], sigma[n:, n:]
+
+
+def test_scalar_correlated_matches_dense_conditioner():
+    mean = np.array([0.2])
+    P = np.array([[2.0]])
+    R = np.array([[1.0]])
+    C = np.array([[0.5]])
+    H = np.array([[1.0]])
+    y = np.array([1.2])
+    root = precision_root_from_covariance(P, jitter=0.0)
+    qr = condition_correlated_gaussian_qr(mean, root, y, R, H, C, jitter=0.0)
+    dense = gaussian_condition_update(mean, P, y, R, H=H, cross_covariance=C, jitter=0.0)
+    assert np.allclose(qr.mean, dense.mean, atol=1e-10)
+    assert np.allclose(qr.covariance, dense.covariance, atol=1e-10)
+    assert np.allclose(qr.precision_root.T @ qr.precision_root,
+                       np.linalg.inv(qr.covariance), atol=1e-9)
+
+
+def test_random_dense_nonzero_C_matches_gaussian_conditioning():
+    rng = np.random.default_rng(7)
+    for n, m in ((2, 4), (3, 2), (4, 5)):
+        for _ in range(12):
+            P, C, R = _joint_spd(rng, n, m)
+            H = rng.standard_normal((m, n))
+            mean = rng.standard_normal(n)
+            y = rng.standard_normal(m)
+            root = precision_root_from_covariance(P, jitter=0.0)
+            qr = condition_correlated_gaussian_qr(mean, root, y, R, H, C, jitter=0.0)
+            dense = gaussian_condition_update(mean, P, y, R, H=H, cross_covariance=C, jitter=0.0)
+            assert np.allclose(qr.mean, dense.mean, rtol=2e-8, atol=2e-9)
+            assert np.allclose(qr.covariance, dense.covariance, rtol=2e-8, atol=2e-9)
+
+
+def test_conditional_model_recovers_joint_innovation_covariance():
+    rng = np.random.default_rng(11)
+    P, C, R = _joint_spd(rng, 3, 4)
+    H = rng.standard_normal((4, 3))
+    root = precision_root_from_covariance(P, jitter=0.0)
+    J, Rc = conditional_measurement_model(root, H, R, C, jitter=0.0)
+    recovered = J @ P @ J.T + Rc
+    direct = H @ P @ H.T + R + H @ C + (H @ C).T
+    assert np.allclose(recovered, direct, atol=1e-9)
+
+
+def test_independent_blocks_batch_equals_streaming_update():
+    rng = np.random.default_rng(19)
+    n = 3
+    P = np.diag([1.5, 0.8, 2.0])
+    root = precision_root_from_covariance(P, jitter=0.0)
+    J1 = rng.standard_normal((2, n)); R1 = np.array([[0.8, 0.1], [0.1, 1.1]])
+    J2 = rng.standard_normal((3, n)); R2 = np.array([[1.2, 0.1, 0.0], [0.1, 0.9, 0.2], [0.0, 0.2, 1.4]])
+    r1 = rng.standard_normal(2); r2 = rng.standard_normal(3)
+    A1, b1, _ = whiten_measurement_block(J1, R1, r1, jitter=0.0)
+    A2, b2, _ = whiten_measurement_block(J2, R2, r2, jitter=0.0)
+
+    batch = householder_information_update(
+        root, np.zeros(n), np.vstack([A1, A2]), np.concatenate([b1, b2]))
+    first = householder_information_update(root, np.zeros(n), A1, b1)
+    streamed = householder_information_update(
+        first.precision_root, first.information_rhs, A2, b2)
+    assert np.allclose(batch.precision_root, streamed.precision_root, atol=1e-10)
+    assert np.allclose(batch.information_rhs, streamed.information_rhs, atol=1e-10)
+    assert np.allclose(batch.solution, streamed.solution, atol=1e-10)
+
+
+def test_householder_update_is_row_permutation_invariant():
+    rng = np.random.default_rng(23)
+    n, m = 4, 9
+    root = precision_root_from_covariance(np.diag([0.5, 1.0, 2.0, 4.0]), jitter=0.0)
+    A = rng.standard_normal((m, n)); b = rng.standard_normal(m)
+    ref = householder_information_update(root, np.zeros(n), A, b)
+    order = rng.permutation(m)
+    got = householder_information_update(root, np.zeros(n), A[order], b[order])
+    assert np.allclose(ref.precision_root, got.precision_root, atol=1e-10)
+    assert np.allclose(ref.information_rhs, got.information_rhs, atol=1e-10)
+
+
+def test_materially_invalid_conditional_covariance_raises():
+    root = precision_root_from_covariance(np.eye(1), jitter=0.0)
+    # R - C.T P^-1 C = 0.1 - 4 < 0: the proposed joint covariance is invalid.
+    try:
+        conditional_measurement_model(root, np.ones((1, 1)), np.array([[0.1]]), np.array([[2.0]]), jitter=0.0)
+    except ValueError as exc:
+        assert "conditional observation covariance" in str(exc)
+    else:
+        raise AssertionError("invalid joint covariance should fail")

--- a/prototypes/mu_cosine/test_joint_square_root_conditioner.py
+++ b/prototypes/mu_cosine/test_joint_square_root_conditioner.py
@@ -2,6 +2,7 @@
 """Property tests for the joint square-root / Householder-QR conditioner."""
 
 import numpy as np
+import joint_square_root_conditioner as square_root_module
 
 from joint_square_root_conditioner import (
     condition_correlated_gaussian_qr,
@@ -103,3 +104,23 @@ def test_materially_invalid_conditional_covariance_raises():
         assert "conditional observation covariance" in str(exc)
     else:
         raise AssertionError("invalid joint covariance should fail")
+
+
+def test_composed_conditioner_regularizes_conditional_covariance_once(monkeypatch):
+    mean = np.array([0.2])
+    P = np.array([[2.0]])
+    R = np.array([[1.0]])
+    C = np.array([[0.5]])
+    H = np.array([[1.0]])
+    y = np.array([1.2])
+    root = precision_root_from_covariance(P, jitter=0.0)
+    original = square_root_module.regularize_covariance
+    calls = []
+
+    def tracked(*args, **kwargs):
+        calls.append(kwargs.get("name"))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(square_root_module, "regularize_covariance", tracked)
+    condition_correlated_gaussian_qr(mean, root, y, R, H, C, jitter=0.0)
+    assert calls == ["conditional observation covariance R - C.T P^-1 C"]

--- a/prototypes/mu_cosine/test_joint_square_root_conditioner_torch.py
+++ b/prototypes/mu_cosine/test_joint_square_root_conditioner_torch.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Correctness tests for the batched CPU/CUDA Householder-QR backend."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from joint_square_root_conditioner import (  # noqa: E402
+    condition_correlated_gaussian_qr,
+    householder_information_update,
+    precision_root_from_covariance,
+)
+from joint_square_root_conditioner_torch import (  # noqa: E402
+    CompiledCorrelatedConditionerTorch,
+    CompiledDenseGainConditionerTorch,
+    SquareRootInformationStateTorch,
+    compile_information_update_torch,
+    condition_correlated_gaussian_qr_torch,
+    conditional_measurement_model_torch,
+    householder_information_update_torch,
+    precision_root_from_covariance_torch,
+)
+
+
+def _joint_spd(rng, n, m, floor=0.75):
+    factor = rng.standard_normal((n + m, n + m))
+    joint = factor @ factor.T + floor * np.eye(n + m)
+    return joint[:n, :n], joint[:n, n:], joint[n:, n:]
+
+
+def _problem(seed=7, n=4, m=5):
+    rng = np.random.default_rng(seed)
+    P, C, R = _joint_spd(rng, n, m)
+    H = rng.standard_normal((m, n))
+    mean = rng.standard_normal(n)
+    observation = rng.standard_normal(m)
+    return P, C, R, H, mean, observation
+
+
+def _as_torch(*arrays, device="cpu", dtype=torch.float64):
+    return tuple(torch.as_tensor(a, dtype=dtype, device=device) for a in arrays)
+
+
+@pytest.mark.parametrize("n,m", [(1, 1), (2, 4), (4, 5)])
+def test_cpu_float64_matches_numpy_correlated_conditioner(n, m):
+    P, C, R, H, mean, observation = _problem(10 + n + m, n, m)
+    root_np = precision_root_from_covariance(P, jitter=0.0)
+    expected = condition_correlated_gaussian_qr(
+        mean, root_np, observation, R, H, C, jitter=0.0
+    )
+    root, Ht, Rt, Ct, mt, yt = _as_torch(root_np, H, R, C, mean, observation)
+    actual = condition_correlated_gaussian_qr_torch(
+        mt, root, yt, Rt, Ht, Ct, jitter=0.0
+    )
+
+    np.testing.assert_allclose(actual.mean.numpy(), expected.mean, rtol=2e-9, atol=2e-10)
+    np.testing.assert_allclose(
+        actual.covariance.numpy(), expected.covariance, rtol=3e-9, atol=3e-10
+    )
+    np.testing.assert_allclose(
+        (actual.precision_root.mT @ actual.precision_root).numpy(),
+        np.linalg.inv(expected.covariance),
+        rtol=2e-8,
+        atol=2e-9,
+    )
+    assert actual.mean.device.type == "cpu"
+    assert actual.mean.dtype == torch.float64
+
+
+def test_compiled_batch_rhs_matches_individual_numpy_updates():
+    rng = np.random.default_rng(31)
+    n, m, rhs_count = 4, 7, 9
+    P = np.diag([0.5, 0.9, 1.7, 3.0])
+    root = precision_root_from_covariance(P, jitter=0.0)
+    A = rng.standard_normal((m, n))
+    z = rng.standard_normal((n, rhs_count))
+    b = rng.standard_normal((m, rhs_count))
+
+    compiled = compile_information_update_torch(*_as_torch(root, A))
+    actual = compiled.apply_columns(*_as_torch(z, b))
+    for column in range(rhs_count):
+        expected = householder_information_update(
+            root, z[:, column], A, b[:, column]
+        )
+        np.testing.assert_allclose(
+            actual.solution[:, column].numpy(), expected.solution, atol=2e-10
+        )
+        np.testing.assert_allclose(
+            actual.information_rhs[:, column].numpy(),
+            expected.information_rhs,
+            atol=2e-10,
+        )
+        np.testing.assert_allclose(
+            actual.residual_sum_squares[column].numpy(),
+            expected.residual_sum_squares,
+            atol=2e-10,
+        )
+
+
+def test_fixed_design_compiles_once_and_conditions_arbitrary_batch_shape():
+    P, C, R, H, mean, observation = _problem(41, 3, 5)
+    root_np = precision_root_from_covariance(P, jitter=0.0)
+    root, Ht, Rt, Ct = _as_torch(root_np, H, R, C)
+    compiled = CompiledCorrelatedConditionerTorch.compile(
+        root, Ht, Rt, Ct, jitter=0.0
+    )
+
+    rng = np.random.default_rng(42)
+    means = rng.standard_normal((2, 4, 3))
+    observations = rng.standard_normal((2, 4, 5))
+    actual = compiled.condition(*_as_torch(means, observations))
+    assert actual.mean.shape == (2, 4, 3)
+    assert actual.covariance.shape == (2, 4, 3, 3)
+    for index in np.ndindex(2, 4):
+        expected = condition_correlated_gaussian_qr(
+            means[index],
+            root_np,
+            observations[index],
+            R,
+            H,
+            C,
+            jitter=0.0,
+        )
+        np.testing.assert_allclose(actual.mean[index].numpy(), expected.mean, atol=3e-10)
+        np.testing.assert_allclose(
+            actual.covariance[index].numpy(), expected.covariance, atol=3e-10
+        )
+
+
+@pytest.mark.parametrize("dtype,rtol,atol", [
+    (torch.float32, 2e-4, 2e-5),
+    (torch.float64, 3e-9, 3e-10),
+])
+def test_compiled_dense_gain_matches_compiled_qr(dtype, rtol, atol):
+    P, C, R, H, _, _ = _problem(47, 5, 7)
+    rng = np.random.default_rng(48)
+    means = rng.standard_normal((3, 11, 5))
+    observations = rng.standard_normal((3, 11, 7))
+    Pt, Ct, Rt, Ht, mt, yt = _as_torch(
+        P, C, R, H, means, observations, dtype=dtype
+    )
+    root = precision_root_from_covariance_torch(Pt)
+    qr = CompiledCorrelatedConditionerTorch.compile(
+        root, Ht, Rt, Ct
+    ).condition(mt, yt)
+    dense = CompiledDenseGainConditionerTorch.compile(
+        root, Ht, Rt, Ct
+    ).condition(mt, yt)
+    torch.testing.assert_close(dense.mean, qr.mean, rtol=rtol, atol=atol)
+    torch.testing.assert_close(
+        dense.covariance, qr.covariance, rtol=rtol, atol=atol
+    )
+
+
+def test_compiled_conditioners_snapshot_H_against_caller_mutation():
+    P, C, R, H, mean, observation = _problem(48, 3, 5)
+    Pt, Ct, Rt, Ht, mt, yt = _as_torch(P, C, R, H, mean, observation)
+    root = precision_root_from_covariance_torch(Pt)
+    qr = CompiledCorrelatedConditionerTorch.compile(root, Ht, Rt, Ct)
+    dense = CompiledDenseGainConditionerTorch.compile(root, Ht, Rt, Ct)
+    qr_before = qr.condition(mt, yt).mean.clone()
+    dense_before = dense.condition(mt, yt).mean.clone()
+    Ht.add_(100.0)
+    torch.testing.assert_close(qr.condition(mt, yt).mean, qr_before)
+    torch.testing.assert_close(dense.condition(mt, yt).mean, dense_before)
+
+
+def test_dense_gain_keeps_positive_covariance_under_float32_cancellation():
+    dtype = torch.float32
+    P = torch.eye(2, dtype=dtype)
+    H = torch.eye(2, dtype=dtype)
+    R = torch.eye(2, dtype=dtype) * 1e-9
+    C = torch.zeros(2, 2, dtype=dtype)
+    root = precision_root_from_covariance_torch(P, jitter=0.0)
+    dense = CompiledDenseGainConditionerTorch.compile(
+        root, H, R, C, jitter=0.0
+    )
+    qr = CompiledCorrelatedConditionerTorch.compile(
+        root, H, R, C, jitter=0.0
+    )
+    assert torch.all(torch.linalg.eigvalsh(dense.posterior_covariance) > 0)
+    torch.testing.assert_close(
+        dense.posterior_covariance,
+        qr.posterior_covariance,
+        rtol=2e-6,
+        atol=torch.finfo(dtype).eps,
+    )
+
+
+def test_dense_gain_accepts_equivalent_nontriangular_precision_factor():
+    P, C, R, H, mean, observation = _problem(49, 4, 6)
+    root_np = precision_root_from_covariance(P, jitter=0.0)
+    rng = np.random.default_rng(50)
+    rotation, _ = np.linalg.qr(rng.standard_normal((4, 4)))
+    rotated_root = rotation @ root_np
+    root, rotated, Ht, Rt, Ct, mt, yt = _as_torch(
+        root_np, rotated_root, H, R, C, mean, observation
+    )
+    reference = CompiledDenseGainConditionerTorch.compile(
+        root, Ht, Rt, Ct, jitter=0.0
+    ).condition(mt, yt)
+    actual = CompiledDenseGainConditionerTorch.compile(
+        rotated, Ht, Rt, Ct, jitter=0.0
+    ).condition(mt, yt)
+    torch.testing.assert_close(actual.mean, reference.mean)
+    torch.testing.assert_close(actual.covariance, reference.covariance)
+
+
+def test_batched_distinct_designs_match_unbatched_calls():
+    rng = np.random.default_rng(53)
+    batch, n, m = 4, 3, 5
+    roots, matrices, prior_rhs, measurement_rhs = [], [], [], []
+    for _ in range(batch):
+        diagonal = np.exp(rng.standard_normal(n)) + 0.2
+        roots.append(precision_root_from_covariance(np.diag(diagonal), jitter=0.0))
+        matrices.append(rng.standard_normal((m, n)))
+        prior_rhs.append(rng.standard_normal(n))
+        measurement_rhs.append(rng.standard_normal(m))
+    roots, matrices, prior_rhs, measurement_rhs = _as_torch(
+        np.stack(roots),
+        np.stack(matrices),
+        np.stack(prior_rhs),
+        np.stack(measurement_rhs),
+    )
+    actual = householder_information_update_torch(
+        roots, prior_rhs, matrices, measurement_rhs
+    )
+    for index in range(batch):
+        expected = householder_information_update_torch(
+            roots[index], prior_rhs[index], matrices[index], measurement_rhs[index]
+        )
+        torch.testing.assert_close(actual.precision_root[index], expected.precision_root)
+        torch.testing.assert_close(actual.information_rhs[index], expected.information_rhs)
+        torch.testing.assert_close(actual.solution[index], expected.solution)
+
+
+def test_full_correlated_conditioner_batches_distinct_designs():
+    batch, n, m = 4, 3, 5
+    problems = [_problem(55 + index, n, m) for index in range(batch)]
+    roots = [precision_root_from_covariance(item[0], jitter=0.0) for item in problems]
+    root, H, R, C, mean, observation = _as_torch(
+        np.stack(roots),
+        np.stack([item[3] for item in problems]),
+        np.stack([item[2] for item in problems]),
+        np.stack([item[1] for item in problems]),
+        np.stack([item[4] for item in problems]),
+        np.stack([item[5] for item in problems]),
+    )
+    actual = condition_correlated_gaussian_qr_torch(
+        mean, root, observation, R, H, C, jitter=0.0
+    )
+    for index in range(batch):
+        expected = condition_correlated_gaussian_qr_torch(
+            mean[index],
+            root[index],
+            observation[index],
+            R[index],
+            H[index],
+            C[index],
+            jitter=0.0,
+        )
+        torch.testing.assert_close(actual.mean[index], expected.mean)
+        torch.testing.assert_close(actual.covariance[index], expected.covariance)
+
+
+def test_sequential_state_threads_updated_root_and_matches_batch_update():
+    rng = np.random.default_rng(61)
+    n = 4
+    root_np = precision_root_from_covariance(
+        np.diag([0.6, 1.1, 1.9, 2.7]), jitter=0.0
+    )
+    A1, b1 = rng.standard_normal((3, n)), rng.standard_normal(3)
+    A2, b2 = rng.standard_normal((6, n)), rng.standard_normal(6)
+    root, A1t, b1t, A2t, b2t = _as_torch(root_np, A1, b1, A2, b2)
+    initial = SquareRootInformationStateTorch(root, torch.zeros(n, dtype=root.dtype))
+    after_first, _ = initial.update(A1t, b1t)
+    after_second, streamed = after_first.update(A2t, b2t)
+    batch = householder_information_update_torch(
+        root,
+        torch.zeros(n, dtype=root.dtype),
+        torch.cat([A1t, A2t]),
+        torch.cat([b1t, b2t]),
+    )
+    torch.testing.assert_close(after_second.precision_root, batch.precision_root)
+    torch.testing.assert_close(after_second.information_rhs, batch.information_rhs)
+    torch.testing.assert_close(streamed.solution, batch.solution)
+
+
+def test_sequential_recentring_resets_rhs_and_shifts_likelihood():
+    rng = np.random.default_rng(63)
+    n = 3
+    root_np = precision_root_from_covariance(
+        np.diag([0.7, 1.4, 2.2]), jitter=0.0
+    )
+    A1, b1 = rng.standard_normal((4, n)), rng.standard_normal(4)
+    A2, b2 = rng.standard_normal((5, n)), rng.standard_normal(5)
+    root, A1t, b1t, A2t, b2t = _as_torch(root_np, A1, b1, A2, b2)
+
+    initial = SquareRootInformationStateTorch(root, torch.zeros(n, dtype=root.dtype))
+    after_first, first = initial.update(A1t, b1t)
+    _, global_coordinates = after_first.update(A2t, b2t)
+
+    # In coordinates delta = e - e_hat_1, the posterior prior has zero RHS
+    # and the second likelihood RHS is b2 - A2 e_hat_1.  Carrying z1 while
+    # also making this shift would double-count the first update.
+    recentered = SquareRootInformationStateTorch(
+        after_first.precision_root,
+        torch.zeros_like(after_first.information_rhs),
+    )
+    _, local_coordinates = recentered.update(
+        A2t, b2t - A2t @ first.solution
+    )
+    torch.testing.assert_close(
+        first.solution + local_coordinates.solution,
+        global_coordinates.solution,
+    )
+
+
+def test_nonzero_cross_covariance_block_diagonal_rc_streams_exactly():
+    rng = np.random.default_rng(65)
+    n, split, m = 3, 2, 5
+    P = np.diag([0.8, 1.3, 2.1])
+    C = 0.08 * rng.standard_normal((n, m))
+    Rc1 = np.array([[0.9, 0.12], [0.12, 1.2]])
+    Rc2 = np.array([[1.1, 0.08, 0.0], [0.08, 0.8, 0.1], [0.0, 0.1, 1.4]])
+    Rc = np.zeros((m, m))
+    Rc[:split, :split] = Rc1
+    Rc[split:, split:] = Rc2
+    R = Rc + C.T @ np.linalg.solve(P, C)
+    H = rng.standard_normal((m, n))
+    mean = rng.standard_normal(n)
+    observation = rng.standard_normal(m)
+    root_np = precision_root_from_covariance(P, jitter=0.0)
+    root, Ht, Rt, Ct, mt, yt = _as_torch(
+        root_np, H, R, C, mean, observation
+    )
+
+    full = condition_correlated_gaussian_qr_torch(
+        mt, root, yt, Rt, Ht, Ct, jitter=0.0
+    )
+    J, conditional_R = conditional_measurement_model_torch(
+        root, Ht, Rt, Ct, jitter=0.0
+    )
+    innovation = yt - Ht @ mt
+    blocks = []
+    for block in (slice(0, split), slice(split, m)):
+        chol = torch.linalg.cholesky(conditional_R[block, block])
+        blocks.append((
+            torch.linalg.solve_triangular(chol, J[block], upper=False),
+            torch.linalg.solve_triangular(
+                chol, innovation[block, None], upper=False
+            ).squeeze(-1),
+        ))
+    state = SquareRootInformationStateTorch(root, torch.zeros(n, dtype=root.dtype))
+    for A, b in blocks:
+        state, streamed = state.update(A, b)
+    torch.testing.assert_close(mt + streamed.solution, full.mean)
+    torch.testing.assert_close(state.precision_root, full.precision_root)
+
+
+def test_float32_device_and_dtype_are_preserved():
+    P, C, R, H, mean, observation = _problem(71, 2, 4)
+    Pt, Ct, Rt, Ht, mt, yt = _as_torch(
+        P, C, R, H, mean, observation, dtype=torch.float32
+    )
+    root = precision_root_from_covariance_torch(Pt)
+    compiled = CompiledCorrelatedConditionerTorch.compile(root, Ht, Rt, Ct)
+    actual = compiled.condition(mt, yt)
+    for value in (
+        actual.mean,
+        actual.covariance,
+        actual.precision_root,
+        actual.information_rhs,
+    ):
+        assert value.dtype == torch.float32
+        assert value.device == Pt.device
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+@pytest.mark.parametrize("dtype,rtol,atol", [
+    (torch.float32, 3e-4, 3e-5),
+    (torch.float64, 3e-9, 3e-10),
+])
+def test_cuda_geqrf_ormqr_matches_cpu(dtype, rtol, atol):
+    P, C, R, H, _, _ = _problem(83, 5, 8)
+    rng = np.random.default_rng(84)
+    means = rng.standard_normal((17, 5))
+    observations = rng.standard_normal((17, 8))
+    cpu_values = _as_torch(P, C, R, H, means, observations, dtype=dtype)
+    Pt, Ct, Rt, Ht, mt, yt = cpu_values
+    cpu_root = precision_root_from_covariance_torch(Pt)
+    cpu = CompiledCorrelatedConditionerTorch.compile(
+        cpu_root, Ht, Rt, Ct
+    ).condition(mt, yt)
+    cpu_dense = CompiledDenseGainConditionerTorch.compile(
+        cpu_root, Ht, Rt, Ct
+    ).condition(mt, yt)
+
+    gpu_values = tuple(value.cuda() for value in cpu_values)
+    Pg, Cg, Rg, Hg, mg, yg = gpu_values
+    gpu_root = precision_root_from_covariance_torch(Pg)
+    gpu = CompiledCorrelatedConditionerTorch.compile(
+        gpu_root, Hg, Rg, Cg
+    ).condition(mg, yg)
+    gpu_dense = CompiledDenseGainConditionerTorch.compile(
+        gpu_root, Hg, Rg, Cg
+    ).condition(mg, yg)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(gpu.mean.cpu(), cpu.mean, rtol=rtol, atol=atol)
+    torch.testing.assert_close(
+        gpu.covariance.cpu(), cpu.covariance, rtol=rtol, atol=atol
+    )
+    torch.testing.assert_close(
+        gpu_dense.mean.cpu(), cpu_dense.mean, rtol=rtol, atol=atol
+    )
+    torch.testing.assert_close(
+        gpu_dense.covariance.cpu(), cpu_dense.covariance, rtol=rtol, atol=atol
+    )
+    assert gpu.mean.device.type == "cuda"
+    assert gpu.mean.dtype == dtype

--- a/prototypes/mu_cosine/test_joint_square_root_conditioner_torch.py
+++ b/prototypes/mu_cosine/test_joint_square_root_conditioner_torch.py
@@ -153,7 +153,7 @@ def test_compiled_dense_gain_matches_compiled_qr(dtype, rtol, atol):
     )
 
 
-def test_compiled_conditioners_snapshot_H_against_caller_mutation():
+def test_compiled_conditioners_snapshot_coefficients_against_caller_mutation():
     P, C, R, H, mean, observation = _problem(48, 3, 5)
     Pt, Ct, Rt, Ht, mt, yt = _as_torch(P, C, R, H, mean, observation)
     root = precision_root_from_covariance_torch(Pt)
@@ -162,6 +162,8 @@ def test_compiled_conditioners_snapshot_H_against_caller_mutation():
     qr_before = qr.condition(mt, yt).mean.clone()
     dense_before = dense.condition(mt, yt).mean.clone()
     Ht.add_(100.0)
+    Rt.add_(100.0)
+    Ct.add_(100.0)
     torch.testing.assert_close(qr.condition(mt, yt).mean, qr_before)
     torch.testing.assert_close(dense.condition(mt, yt).mean, dense_before)
 
@@ -207,7 +209,14 @@ def test_dense_gain_accepts_equivalent_nontriangular_precision_factor():
     torch.testing.assert_close(actual.covariance, reference.covariance)
 
 
-def test_batched_distinct_designs_match_unbatched_calls():
+@pytest.mark.parametrize("device", [
+    "cpu",
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable"),
+    ),
+])
+def test_batched_distinct_designs_match_unbatched_calls(device):
     rng = np.random.default_rng(53)
     batch, n, m = 4, 3, 5
     roots, matrices, prior_rhs, measurement_rhs = [], [], [], []
@@ -222,6 +231,7 @@ def test_batched_distinct_designs_match_unbatched_calls():
         np.stack(matrices),
         np.stack(prior_rhs),
         np.stack(measurement_rhs),
+        device=device,
     )
     actual = householder_information_update_torch(
         roots, prior_rhs, matrices, measurement_rhs
@@ -235,7 +245,14 @@ def test_batched_distinct_designs_match_unbatched_calls():
         torch.testing.assert_close(actual.solution[index], expected.solution)
 
 
-def test_full_correlated_conditioner_batches_distinct_designs():
+@pytest.mark.parametrize("device", [
+    "cpu",
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable"),
+    ),
+])
+def test_full_correlated_conditioner_batches_distinct_designs(device):
     batch, n, m = 4, 3, 5
     problems = [_problem(55 + index, n, m) for index in range(batch)]
     roots = [precision_root_from_covariance(item[0], jitter=0.0) for item in problems]
@@ -246,6 +263,7 @@ def test_full_correlated_conditioner_batches_distinct_designs():
         np.stack([item[1] for item in problems]),
         np.stack([item[4] for item in problems]),
         np.stack([item[5] for item in problems]),
+        device=device,
     )
     actual = condition_correlated_gaussian_qr_torch(
         mean, root, observation, R, H, C, jitter=0.0
@@ -264,7 +282,26 @@ def test_full_correlated_conditioner_batches_distinct_designs():
         torch.testing.assert_close(actual.covariance[index], expected.covariance)
 
 
-def test_sequential_state_threads_updated_root_and_matches_batch_update():
+def test_batched_rank_failure_identifies_offending_design():
+    roots = torch.stack([torch.eye(2), torch.zeros(2, 2)])
+    matrices = torch.zeros(2, 1, 2)
+    with pytest.raises(torch.linalg.LinAlgError, match=r"batch indices \[\[1\]\]"):
+        householder_information_update_torch(
+            roots,
+            torch.zeros(2, 2),
+            matrices,
+            torch.zeros(2, 1),
+        )
+
+
+@pytest.mark.parametrize("device", [
+    "cpu",
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable"),
+    ),
+])
+def test_sequential_state_threads_updated_root_and_matches_batch_update(device):
     rng = np.random.default_rng(61)
     n = 4
     root_np = precision_root_from_covariance(
@@ -272,13 +309,15 @@ def test_sequential_state_threads_updated_root_and_matches_batch_update():
     )
     A1, b1 = rng.standard_normal((3, n)), rng.standard_normal(3)
     A2, b2 = rng.standard_normal((6, n)), rng.standard_normal(6)
-    root, A1t, b1t, A2t, b2t = _as_torch(root_np, A1, b1, A2, b2)
-    initial = SquareRootInformationStateTorch(root, torch.zeros(n, dtype=root.dtype))
+    root, A1t, b1t, A2t, b2t = _as_torch(root_np, A1, b1, A2, b2, device=device)
+    initial = SquareRootInformationStateTorch(
+        root, torch.zeros(n, dtype=root.dtype, device=root.device)
+    )
     after_first, _ = initial.update(A1t, b1t)
     after_second, streamed = after_first.update(A2t, b2t)
     batch = householder_information_update_torch(
         root,
-        torch.zeros(n, dtype=root.dtype),
+        torch.zeros(n, dtype=root.dtype, device=root.device),
         torch.cat([A1t, A2t]),
         torch.cat([b1t, b2t]),
     )

--- a/prototypes/mu_cosine/test_node_disjoint_eval.py
+++ b/prototypes/mu_cosine/test_node_disjoint_eval.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Focused synthetic tests for node-disjoint validation and node-block CIs."""
+
+import numpy as np
+
+from node_disjoint_eval import (
+    format_split_diagnostics,
+    node_disjoint_pair_split,
+    paired_node_bootstrap_ci,
+)
+
+
+def _dense_pairs(n=10):
+    pairs, strata = [], []
+    for i in range(n):
+        for j in range(i + 1, n):
+            pairs.append((f"n{i}", f"n{j}"))
+            strata.append("even" if (i + j) % 2 == 0 else "odd")
+    return pairs, strata
+
+
+def test_node_split_is_strictly_disjoint_and_drops_cross_pairs():
+    pairs, strata = _dense_pairs()
+    split = node_disjoint_pair_split(
+        pairs,
+        7,
+        held_node_fraction=0.30,
+        strata=strata,
+        candidates=32,
+    )
+    assert split.train_nodes.isdisjoint(split.held_nodes)
+    assert len(split.train) + len(split.held) + len(split.cross) == len(pairs)
+    for i in split.train:
+        assert set(pairs[i]) <= split.train_nodes
+    for i in split.held:
+        assert set(pairs[i]) <= split.held_nodes
+    for i in split.cross:
+        assert len(set(pairs[i]) & split.held_nodes) == 1
+
+
+def test_node_split_is_seeded_and_input_order_invariant():
+    pairs, strata = _dense_pairs()
+    a = node_disjoint_pair_split(pairs, 19, strata=strata, candidates=24)
+    b = node_disjoint_pair_split(pairs, 19, strata=strata, candidates=24)
+    assert a.held_nodes == b.held_nodes
+    assert np.array_equal(a.train, b.train)
+    assert np.array_equal(a.held, b.held)
+    assert np.array_equal(a.cross, b.cross)
+
+    order = np.random.default_rng(3).permutation(len(pairs))
+    shuffled_pairs = [pairs[i] for i in order]
+    shuffled_strata = [strata[i] for i in order]
+    c = node_disjoint_pair_split(shuffled_pairs, 19, strata=shuffled_strata, candidates=24)
+    assert a.held_nodes == c.held_nodes
+
+
+def test_default_fraction_targets_thirty_percent_of_retained_pairs():
+    pairs, strata = _dense_pairs(50)
+    split = node_disjoint_pair_split(pairs, 0, strata=strata, candidates=1)
+    retained_held_share = len(split.held) / (len(split.train) + len(split.held))
+    assert np.isclose(len(split.held_nodes) / 50, 0.40)
+    assert 0.29 < retained_held_share < 0.32, retained_held_share
+
+
+def test_runner_and_helper_defaults_are_aligned():
+    from run_sym_channel_fusion import build_arg_parser
+
+    args = build_arg_parser().parse_args([])
+    assert np.isclose(args.held_node_frac, 0.40)
+    pairs, strata = _dense_pairs(10)
+    split = node_disjoint_pair_split(pairs, 0, strata=strata, candidates=1)
+    assert np.isclose(len(split.held_nodes) / 10, args.held_node_frac)
+
+
+def test_candidate_search_never_worsens_stratum_coverage_deficit():
+    pairs, strata = _dense_pairs(12)
+    first = node_disjoint_pair_split(pairs, 4, strata=strata, candidates=1, minimum_per_stratum=3)
+    searched = node_disjoint_pair_split(pairs, 4, strata=strata, candidates=100, minimum_per_stratum=3)
+
+    def deficit(split):
+        return sum(max(0, 3 - c.train) + max(0, 3 - c.held) for c in split.strata.values())
+
+    assert deficit(searched) <= deficit(first)
+    for counts in searched.strata.values():
+        assert counts.train + counts.held + counts.cross == counts.total
+
+
+def test_split_diagnostics_expose_partition_and_stratum_coverage():
+    pairs, strata = _dense_pairs()
+    split = node_disjoint_pair_split(pairs, 2, strata=strata, candidates=8)
+    rendered = format_split_diagnostics(split)
+    assert "pairs train/held/cross=" in rendered
+    assert "retained" in rendered
+    assert "even" in rendered and "odd" in rendered
+
+
+def test_node_bootstrap_constant_gain_has_degenerate_interval():
+    pairs = [("hub", f"leaf{i}") for i in range(8)]
+    result = paired_node_bootstrap_ci(pairs, np.full(len(pairs), 0.25), n_resamples=300, seed=5)
+    assert np.isclose(result.estimate, 0.25)
+    assert np.isclose(result.low, 0.25)
+    assert np.isclose(result.high, 0.25)
+    assert result.n_resamples == 300
+    assert result.n_attempts >= result.n_resamples
+
+
+def test_node_bootstrap_is_deterministic_and_row_order_invariant():
+    pairs = [("hub", f"leaf{i}") for i in range(8)] + [("leaf0", "leaf1"), ("leaf2", "leaf3")]
+    gains = np.linspace(-0.2, 0.5, len(pairs))
+    a = paired_node_bootstrap_ci(pairs, gains, n_resamples=400, seed=23, confidence=0.90)
+    b = paired_node_bootstrap_ci(pairs, gains, n_resamples=400, seed=23, confidence=0.90)
+    assert a == b
+
+    order = np.random.default_rng(11).permutation(len(pairs))
+    c = paired_node_bootstrap_ci(
+        [pairs[i] for i in order],
+        gains[order],
+        n_resamples=400,
+        seed=23,
+        confidence=0.90,
+    )
+    assert np.isclose(a.estimate, c.estimate)
+    assert np.isclose(a.low, c.low)
+    assert np.isclose(a.high, c.high)
+
+
+def test_invalid_split_and_bootstrap_inputs_fail_loudly():
+    for fn in (
+        lambda: node_disjoint_pair_split([], 0),
+        lambda: node_disjoint_pair_split([("a", "b")], 0, held_node_fraction=1.0),
+        lambda: node_disjoint_pair_split([("a", "b")], 0, strata=[]),
+        lambda: paired_node_bootstrap_ci([("a", "b")], [], n_resamples=10),
+        lambda: paired_node_bootstrap_ci([("a", "b")], [0.1], confidence=0.0),
+    ):
+        try:
+            fn()
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("expected invalid input to raise ValueError")
+
+
+def _run_all():
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_") and callable(value)]
+    for test in tests:
+        test()
+        print(f"  ok  {test.__name__}")
+    print(f"{len(tests)} tests passed")
+
+
+if __name__ == "__main__":
+    _run_all()

--- a/prototypes/mu_cosine/test_sim_matched_cost.py
+++ b/prototypes/mu_cosine/test_sim_matched_cost.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Focused invariants for the post-#3648 matched-cost simulation hardening."""
+import argparse
+
+import numpy as np
+import pytest
+
+from sim_matched_cost import (
+    H_FREE,
+    budget_plan,
+    fused_targets,
+    nested_ridge_fit_predict,
+    paired_delta_summary,
+    positive_integer,
+    replicate_permutation,
+    ridge_fit_predict,
+    stable_seed,
+)
+
+
+def test_ridge_selection_is_row_permutation_invariant():
+    rng = np.random.default_rng(7)
+    X = rng.normal(size=(60, 8))
+    y = X @ rng.normal(size=8) + rng.normal(scale=0.4, size=60)
+    Xq = rng.normal(size=(11, 8))
+    ids = np.arange(1000, 1060)
+    pred, info = ridge_fit_predict(
+        X, y, Xq, sample_ids=ids, split_seed=91, return_info=True,
+    )
+    perm = rng.permutation(len(X))
+    pred_perm, info_perm = ridge_fit_predict(
+        X[perm], y[perm], Xq, sample_ids=ids[perm], split_seed=91, return_info=True,
+    )
+    assert info["lambda"] == info_perm["lambda"]
+    assert np.allclose(pred, pred_perm, rtol=0.0, atol=1e-12)
+    # The inner scaler must be fit on inner-train, not all rows (the means differ for this fixture).
+    assert not np.allclose(info["inner_mu"], X.mean(axis=0))
+
+
+def test_nested_target_fit_excludes_paid_validation_then_refits_all_paid():
+    rng = np.random.default_rng(17)
+    X = rng.normal(size=(90, 7))
+    y = X @ rng.normal(size=7) + rng.normal(scale=0.2, size=90)
+    Xq = rng.normal(size=(9, 7))
+    ids = np.arange(5000, 5090)
+    paid = np.arange(30)
+    bulk = np.arange(30, 80)
+    fit_calls = []
+
+    def pseudo_builder(fit_paid_idx):
+        fit_calls.append(np.asarray(fit_paid_idx).copy())
+        # A supervised target generator: its output changes with the paid labels it was allowed to fit.
+        return 0.25 * X[:, 0] + y[fit_paid_idx].mean()
+
+    _, info = nested_ridge_fit_predict(
+        X, y, Xq, paid, bulk, pseudo_target_builder=pseudo_builder,
+        sample_ids=ids, split_seed=41, return_info=True,
+    )
+    selection_fit_ids = set(info["selection_target_fit_ids"].tolist())
+    validation_ids = set(info["paid_valid_ids"].tolist())
+    assert selection_fit_ids.isdisjoint(validation_ids)
+    assert set(ids[fit_calls[0]].tolist()) == selection_fit_ids
+    assert set(ids[fit_calls[0]].tolist()).isdisjoint(validation_ids)
+    # The second builder call is the post-selection full-budget refit and must recover every paid row.
+    assert set(ids[fit_calls[1]].tolist()) == set(ids[paid].tolist())
+    assert set(info["final_target_fit_ids"].tolist()) == set(ids[paid].tolist())
+
+
+def test_nested_pseudo_pipeline_is_row_permutation_invariant():
+    rng = np.random.default_rng(23)
+    X = rng.normal(size=(75, 6))
+    y = X @ rng.normal(size=6) + rng.normal(scale=0.3, size=75)
+    Xq = rng.normal(size=(10, 6))
+    ids = np.arange(8000, 8075)
+    paid_ids = set(ids[:24].tolist())
+    bulk_ids = set(ids[24:65].tolist())
+
+    def run(X_, y_, ids_):
+        paid = np.array([i for i, value in enumerate(ids_) if value in paid_ids])
+        bulk = np.array([i for i, value in enumerate(ids_) if value in bulk_ids])
+
+        def pseudo_builder(fit_paid_idx):
+            return 0.4 * X_[:, 0] - 0.2 * X_[:, 1] + y_[fit_paid_idx].mean()
+
+        return nested_ridge_fit_predict(
+            X_, y_, Xq, paid, bulk, pseudo_target_builder=pseudo_builder,
+            sample_ids=ids_, split_seed=67, return_info=True,
+        )
+
+    pred, info = run(X, y, ids)
+    perm = rng.permutation(len(X))
+    pred_perm, info_perm = run(X[perm], y[perm], ids[perm])
+    assert info["lambda"] == info_perm["lambda"]
+    assert set(info["paid_valid_ids"].tolist()) == set(info_perm["paid_valid_ids"].tolist())
+    assert np.allclose(pred, pred_perm, rtol=0.0, atol=1e-12)
+
+
+def test_replicate_sampling_is_independent_of_n_grid_order():
+    pool = np.arange(900)
+    # A single rep order is reused: every n cell is a prefix, regardless of requested traversal order.
+    order = replicate_permutation(pool, seed=123, corpus="fresh", rep=4)
+    ascending = {n: order[:n].copy() for n in (80, 160, 320)}
+    descending = {n: replicate_permutation(pool, 123, "fresh", 4)[:n] for n in (320, 80, 160)}
+    assert all(np.array_equal(ascending[n], descending[n]) for n in ascending)
+    assert np.array_equal(ascending[80], ascending[320][:80])
+    assert not np.array_equal(order, replicate_permutation(pool, 123, "fresh", 5))
+
+
+def test_stable_seed_uses_cell_identity_not_call_order():
+    expected = stable_seed(9, "fresh", 160, 2, "D")
+    _ = [stable_seed(9, "expl", n, rep) for n in (640, 80) for rep in range(3)]
+    assert stable_seed(9, "fresh", 160, 2, "D") == expected
+
+
+def test_budget_and_sample_integration_for_reusable_order():
+    order = replicate_permutation(np.arange(1000), seed=3, corpus="expl", rep=0)
+    n, n_ov, k = 80, 30, 8
+    want, used, truncated, spend, feasible = budget_plan(n, k, n_ov, avail=len(order) - n_ov)
+    overlap = order[:n_ov]
+    bulk = order[n_ov:n_ov + used]
+    assert feasible and not truncated and want == used == 370
+    assert len(np.intersect1d(overlap, bulk)) == 0
+    assert len(overlap) * (1 + 1 / k) + len(bulk) / k == pytest.approx(spend)
+    assert spend == pytest.approx(n)
+
+
+def test_noninteger_k_is_rejected_in_cli_and_budget_api():
+    with pytest.raises(argparse.ArgumentTypeError, match="positive integer"):
+        positive_integer("2.5")
+    with pytest.raises(ValueError, match="positive integer"):
+        budget_plan(80, 2.5, 30, 1000)
+
+
+def test_free_tier_conditioner_accepts_two_measurement_channels():
+    rng = np.random.default_rng(11)
+    y = rng.uniform(0.1, 0.9, size=(48, 2))
+    prior = np.clip(y + rng.normal(scale=0.16, size=y.shape), 0.0, 1.0)
+    free_meas = np.clip(y + rng.normal(scale=0.10, size=y.shape), 0.0, 1.0)
+    post = fused_targets(prior, free_meas, y, np.arange(32), H=H_FREE)
+    assert post.shape == y.shape
+    assert np.isfinite(post).all()
+    assert ((0.0 <= post) & (post <= 1.0)).all()
+
+
+def test_paired_delta_summary_uses_within_replicate_differences():
+    # Large shared replicate effects cancel: every paired candidate gain is exactly +0.02.
+    baseline = np.array([-0.7, 0.8, -0.2, 0.5, 0.1])
+    candidate = baseline + 0.02
+    out = paired_delta_summary(baseline, candidate, n_boot=1000, confidence=0.95, seed=4)
+    assert out["n_pairs"] == 5
+    assert out["mean"] == pytest.approx(0.02)
+    assert out["ci_low"] == pytest.approx(0.02)
+    assert out["ci_high"] == pytest.approx(0.02)
+
+
+def test_paired_delta_summary_validates_pairing():
+    with pytest.raises(ValueError, match="paired"):
+        paired_delta_summary([0.1, 0.2], [0.3], n_boot=10)


### PR DESCRIPTION
## Summary

This follow-up validates and extends the cheap-judge pipeline merged in #3648.

- Fixes matched-cost model-selection leakage by nesting calibration, covariance fitting, pseudo-target generation, ridge fitting, and scaling inside the paid-label training fold.
- Reruns the exact-budget comparison on strict node-disjoint evaluation.
- Confirms graph_S across 40 node partitions and distinguishes the graph judge’s two roles:
  1. an immediate final-posterior measurement; and
  2. nearly free structural supervision that helps a model learn a dataset’s entities, vocabulary, topology, and recurring relations.
- Separates Luna head initialization from the campaign-independent prior and applies train-only global affine calibration.
- Adds a same-split JointPosterior comparison, calibrated uncertainty metrics, factored controls, and a within-judge hard-max/weighted/softmax pooling audit.
- Adds NumPy and PyTorch joint square-root information conditioners with nonzero prior/measurement cross-covariance, conditionally independent block streaming, compact Householder `geqrf/ormqr`, CUDA batching, and a matched design-cached dense-gain baseline.

## Corrected findings

- **The merged spending headline does not survive leakage-free evaluation.** No exact-budget cheap-label arm has a positive training-subsample interval excluding zero. At `n=160,k=2`, all ten S subsample deltas are negative on both corpora, but this fixed-partition diagnostic is not a population-level harm claim.
- **graph_S remains useful free supervision.** Its free-only S-NLL gain is positive across all 40 node partitions. Its incremental final-posterior value after debiased Luna is small and unconfirmed.
- **The graph result does not measure dataset familiarization.** The graph judge can still be valuable as broad structural supervision that teaches the model the entities, terminology, topology, and relation patterns of a dataset.
- **Debiased Luna remains valuable in the analytic Gaussian ladder**, although the leakage-free matched-cost proxy does not establish a general spending advantage.
- **JointPosterior and Gaussian+bridge are currently tied on AURC.** After both experiments use the same audited, stratum-aware node splitter, every paired interval includes zero across both corpora and both audited seeds:

| seed / corpus | JointPosterior − Gaussian AURC [95% CI] |
|---|---:|
| 0 / exploratory | +0.0013 [-0.0061,+0.0081] |
| 0 / fresh | +0.0058 [-0.0075,+0.0193] |
| 1 / exploratory | -0.0085 [-0.0288,+0.0033] |
| 1 / fresh | +0.0022 [-0.0228,+0.0293] |

This does not establish equivalence, and it is not a reason to retire JointPosterior. The learned joint combiner remains relevant when Gaussian assumptions or the linear D/S decision bridge are misspecified.

## Council-review follow-up

The post-implementation council review recommended approval and identified non-blocking improvements. The follow-up commit:

- replaces the duplicated plain node splitter with the shared, coverage-aware, stratum-aware `node_disjoint_pair_split`;
- reruns the JointPosterior comparison on that audited split;
- states explicitly that endpoint node-disjointness is not edge-disjointness or k-hop isolation from the ambient graph;
- relabels matched-cost intervals as subsample precision rather than inferential confidence intervals;
- adds endpoint-bootstrap block counts beside AURC comparisons;
- documents AURC’s early-error sensitivity and finite-sample limitations;
- adds distinct-design CUDA parity tests;
- adds sequential CUDA root-threading parity tests;
- tests compiled-conditioner safety against caller mutation of `H`, `R`, and `C`;
- removes duplicate conditional-covariance regularization;
- improves batched rank-failure diagnostics;
- corrects the 1,770 raw rows versus 1,700 Luna-matched rows distinction.

## Joint square-root/QR conditioner

The conditioner maintains an information root

`P^-1 = U.T @ U`

and converts the correlated residual model into a conditional likelihood:

`Rc = R - C.T @ P^-1 @ C`

`J = H + C.T @ P^-1`

After factoring `Rc = L @ L.T`, it triangularizes the information pre-array

`stack([U, solve(L, J)])`

while applying the same Householder transformations to the information right-hand side.

This avoids explicit posterior covariance inversion or subtraction-form downdates. It also allows independent measurement blocks to be streamed by carrying `(U_post, z_post)` into the next update.

The independence requirement is block diagonality of **conditional** covariance `Rc`, not raw `R`:

`Rc_ij = R_ij - C_i.T @ P^-1 @ C_j`

Raw measurement families can therefore be uncorrelated while remaining conditionally coupled through their shared prior. The state prior is inserted exactly once; repeating a complete `[[P,C_i],[C_i.T,R_i]]` block for each bundle would double-count prior information.

Potter and Carlson are historical antecedents. The implemented vector, nonzero-cross-covariance algorithm is more precisely a **joint square-root information/QR conditioner**, not a direct implementation of classical Potter or Carlson recursions.

## CPU/GPU result

GPU QR works and substantially accelerates larger factorizations, but a cached dense gain remains faster in every tested fixed-`P,H,C,R` cell.

Selected 4,096-row timings:

| state / measurements | CPU QR | CUDA QR | CPU dense | CUDA dense |
|---|---:|---:|---:|---:|
| `n=2,m=4` | 0.596 ms | 0.520 ms | **0.113 ms** | 0.132 ms |
| `n=32,m=32` | 2.106 ms | 0.543 ms | 0.363 ms | **0.129 ms** |
| `n=128,m=32` | 5.694 ms | 1.121 ms | 0.734 ms | **0.131 ms** |

These are single-run, on-device compute measurements. They exclude host/device transfer and do not benchmark the sequential regime where QR carries the updated root.

The resulting deployment rule is:

- use a design-cached dense gain for fixed, well-conditioned `P,H,C,R`;
- retain square-root/QR for changing, sequential, or ill-conditioned correlated measurement blocks;
- rebenchmark CUDA as the measurement dimension, state dimension, batch size, or augmented block size grows.

## Pooling and expert-selection scope

The inherited hard maximum pools relation-specific μ values **within one judge response**. It does not select the best expert.

Prior, graph, and Luna remain simultaneous measurements in the covariance-aware update. Probability-weighted and temperature-softmax pooling were audited as alternatives, but the present diagnostic does not establish a replacement. A fair production comparison must rebuild every target and source under the same pooling rule.

## Validation

- GitHub Actions passed on the current head.
- Independent focused run: `61 passed, 5 environment-gated skips`.
- The NumPy/PyTorch square-root suite contains 29 tests covering:
  - dense/QR posterior parity;
  - float32 and float64;
  - CPU and CUDA;
  - distinct batched designs;
  - nonzero prior/measurement cross-covariance;
  - block-diagonal conditional-covariance streaming;
  - fixed-coordinate and recentered sequential updates;
  - row-permutation invariance;
  - invalid Schur complements;
  - rank-deficient batches;
  - compiled-input mutation safety.
- Python compilation and diff checks passed.

## Selected references

- Dan Simon, [*Optimal State Estimation*](https://onlinelibrary.wiley.com/doi/book/10.1002/0470045345) — correlated-noise Kalman filtering.
- Toshio Michael Chin, [“Square-Root Formulas for Kalman Filter, Information Filter, and RTS Smoother”](https://ipnpr.jpl.nasa.gov/progress_report/42-233/42-233A.html) — modern square-root and SRIF background.
- Gerald J. Bierman, [*Sequential Least-Squares Using Orthogonal Transformations*](https://ntrs.nasa.gov/citations/19750023773) — Householder information arrays and sequential least squares.
- Neal A. Carlson, [“Fast Triangular Formulation of the Square Root Filter”](https://doi.org/10.2514/3.6907) — classical triangular covariance-root recursion.
- Catherine L. Thornton and Gerald J. Bierman, [*A Numerical Comparison of Discrete Kalman Filtering Algorithms*](https://ntrs.nasa.gov/api/citations/19760019842/downloads/19760019842.pdf) — numerical-stability and computational-cost comparisons.
- Gavin C. Cawley and Nicola L. C. Talbot, [“On Over-fitting in Model Selection and Subsequent Selection Bias in Performance Evaluation”](https://jmlr.org/papers/v11/cawley10a.html) — nested model selection and evaluation leakage.
- Traub et al., [“Overcoming Common Flaws in the Evaluation of Selective Classification Systems”](https://proceedings.neurips.cc/paper_files/paper/2024/file/047c84ec50bd8ea29349b996fc64af4b-Paper-Conference.pdf) — AURC limitations and AUGRC.
- Zhou et al., [“A Novel Characterization of Population AURC and Rates of Finite-Sample Estimators”](https://arxiv.org/html/2410.15361v4) — finite-sample AURC estimation.

## Follow-up

1. Repeat exact-budget matched-cost cells across preregistered node partitions.
2. Measure graph-supervision dataset adaptation with frozen initialization and matched training spend.
3. Add independent or human-verified targets.
4. Add AUGRC as a separately named robustness metric.
5. Benchmark genuinely sequential root-threading workloads with median/MAD timing, transfer, memory, and log-spaced scale/condition sweeps.
6. Sweep measurement count, state dimension, batch size, block-diagonal versus dense conditional correlation, and skinny-information versus full augmented QR to locate the CPU/CUDA crossover.