### PR TITLE
WAM/LLVM eval: grammar-driven binary reader capstone (bytes-in + record-out)

### DIFF
--- a/docs/design/PLAWK_DCG_BINARY_READERS.md
+++ b/docs/design/PLAWK_DCG_BINARY_READERS.md
@@ -206,6 +206,22 @@ length `L` (validated `0 ≤ L ≤ 16` unsigned), then `L` payload bytes.
    the ordinary slot-type fixpoint. Constraints: one blob argument per
    call (one shared buffer), NUL-free payloads (the transient atom is
    a C string), blob output is a later slice.
+5. **Grammar-driven reader through a LOADED object (landed):** the same
+   `blobN` payload can flow into a grammar shipped as a `.wamo` rather
+   than a compiled-in predicate, and that grammar can return a
+   **structured record**: `(s, c) = dyncall@parse($2) as (i64 i64)`
+   frames the payload natively, marshals it as the transient atom (same
+   `@wam_transient_atom_from_bytes` path, one blob per call), and
+   `@wam_object_call_record` deserializes the returned compound into the
+   typed scalars. This is the JIT-roadmap item-4 endgame — bytes-in +
+   record-out — with the reader grammar as a swappable artifact (the
+   object can be a shipped `DYNLOAD` library or a runtime `compile(...)`
+   handle). It composes from the item-2 blob bridge and item-4 record
+   destructure with no new codegen; standing test
+   `tests/test_plawk_grammar_reader.pl`. Tier-3 (a full DCG engine in
+   the loop) remains the only unbuilt rung, and stays deliberately out
+   of scope — the loaded-grammar reader covers the irregular-format
+   cases without one.
 
 ## Embedded Prolog blocks (landed)
 

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -357,6 +357,23 @@ out into the same fixed access layout `BINFMT` describes. Bytes-in +
 record-out = a grammar-driven reader for formats too irregular for the
 native Tier-1 reader, without leaving the compiled loop.
 
+**Grammar-driven reader capstone — LANDED (proven, no new code):** the
+endgame above composes today, and now has a standing end-to-end test
+(`tests/test_plawk_grammar_reader.pl`). A `BINFMT` `blobN` field frames
+a binary payload natively; the payload flows — as a transient atom,
+constant-memory, no interning — into a grammar shipped as a `.wamo`
+(`(s, c) = dyncall@parse($2) as (i64 i64)`), which parses the bytes with
+a real WAM DCG (choice points and all) and returns a `pair(Sum, Count)`
+compound; `@wam_object_call_record` deserializes that into the typed
+plawk scalars. The novelty is routing bytes-in + record-out **through a
+loaded object** rather than a compiled-in foreign predicate, so the
+reader grammar is a shippable, swappable artifact. It fell out of the
+existing pieces — item 2's blob→transient-atom arg marshalling
+(`plawk_foreign_args_ir`, `≤1` blob per call) meeting this item's record
+destructure (`dynrec_bind`, legal as a binary-mode action) — with no
+connecting code needed; a scalar id field can still guard the record
+while the grammar reads the payload.
+
 **Effort:** large — a return-shape surface, a term-walking marshaller in
 the call primitive, and typed materialization. **Depends on:** item 2 (the
 byte-return primitive and the "output is a term, not a scalar" plumbing),

--- a/tests/test_plawk_grammar_reader.pl
+++ b/tests/test_plawk_grammar_reader.pl
@@ -1,0 +1,215 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Grammar-driven binary reader -- the endgame JIT roadmap item 4 pointed
+% at, and the DCG-binary-readers Tier-2/3 story (PLAWK_DCG_BINARY_READERS.md):
+% BYTES IN + RECORD OUT through a LOADED WAM grammar.
+%
+% The record loop frames a binary payload natively (BINFMT `blobN`: an
+% 8-byte length + payload bytes). The payload is handed -- as a transient
+% atom, constant-memory, no interning -- to a grammar shipped as a .wamo
+% object, which PARSES the bytes with a real WAM DCG (choice points and
+% all) and RETURNS A STRUCTURED RECORD (a Compound). @wam_object_call_record
+% deserializes that compound's args into typed plawk scalars, so a format
+% too irregular for the native Tier-1 reader is read by a grammar without
+% leaving the compiled loop.
+%
+% This composes two arcs the campaign built separately: the blob bridge
+% (bytes into a compiled predicate, item 2 / Tier-2) and structured-return
+% destructuring (a Compound out, deserialized to typed fields, item 4).
+% The novelty here is routing the two THROUGH A LOADED OBJECT
+% (dyncall@name), not a compiled-in foreign predicate -- so the reader
+% grammar is a shippable, swappable artifact.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% The reader grammar, shipped as a .wamo. It takes the payload atom,
+% parses comma-separated decimal numbers with a difference-list DCG (the
+% same shape the Tier-2 blob bridge exercises), and returns a two-field
+% record pair(Sum, Count) -- a STRUCTURED result, not a scalar.
+:- dynamic user:gr_parse/2.
+:- dynamic user:gr_nums/4.
+:- dynamic user:gr_nums_rest/6.
+:- dynamic user:gr_num/3.
+:- dynamic user:gr_digits/4.
+:- dynamic user:gr_digit/3.
+
+user:gr_parse(Blob, pair(Sum, Count)) :-
+    atom_codes(Blob, Codes),
+    user:gr_nums(Sum, Count, Codes, []).
+
+% Sum and Count threaded together: one number seen, then the rest.
+user:gr_nums(Sum, Count, S0, S) :-
+    user:gr_num(N, S0, S1),
+    user:gr_nums_rest(N, 1, Sum, Count, S1, S).
+
+user:gr_nums_rest(AccSum, AccCount, Sum, Count, [0', | S0], S) :-
+    user:gr_num(N, S0, S1),
+    AccSum2 is AccSum + N,
+    AccCount2 is AccCount + 1,
+    user:gr_nums_rest(AccSum2, AccCount2, Sum, Count, S1, S).
+user:gr_nums_rest(Sum, Count, Sum, Count, S, S).
+
+user:gr_num(N, S0, S) :-
+    user:gr_digit(D, S0, S1),
+    user:gr_digits(D, N, S1, S).
+
+user:gr_digits(Acc, N, S0, S) :-
+    user:gr_digit(D, S0, S1),
+    Acc2 is Acc * 10 + D,
+    user:gr_digits(Acc2, N, S1, S).
+user:gr_digits(N, N, S, S).
+
+user:gr_digit(D, [C | S], S) :-
+    C >= 48,
+    C =< 57,
+    D is C - 48.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_grammar_reader).
+
+% A blob field flowing into a record-returning dyncall parses and passes
+% the binary-mode surface check (a blob field is a legal dyncall arg; the
+% record bind is a legal binary-mode action).
+test(reader_parses_and_collects) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64 blob32\" ; DYNLOAD = \"lib.wamo\" }\n\c
+         { (s, c) = dyncall@gr_parse($2) as (i64 i64) ; total += s ; recs += c }\n\c
+         END { print total }\n",
+        Program),
+    Program = program(_, [rule(_, Actions)], _),
+    memberchk(dynrec_bind([s, c], dyncall_named(gr_parse, [field(2)]),
+        [i64, i64]), Actions),
+    plawk_program_dyncall_named_rec_entries(Program, Entries),
+    assertion(Entries == [gr_parse-1]),
+    !.
+
+% The record shim + the record primitive + the blob transient-atom
+% marshal all appear: bytes-in (transient atom) meets record-out
+% (@wam_object_call_record) in one emitted driver.
+test(reader_ir_composes_blob_and_record) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64 blob32\" ; DYNLOAD = \"lib.wamo\" }\n\c
+         { (s, c) = dyncall@gr_parse($2) as (i64 i64) ; total += s }\n\c
+         END { print total }\n",
+        Program),
+    plawk_program_native_driver_ir(Program, 'in.bin',
+        [wam_vm(10, 10)], IR),
+    assertion(once(sub_atom(IR, _, _, _, '@plawk_dyncall_named_rec_gr_parse_1'))),
+    assertion(once(sub_atom(IR, _, _, _, '@wam_object_call_record'))),
+    assertion(once(sub_atom(IR, _, _, _, '@wam_transient_atom_from_bytes('))),
+    !.
+
+% THE CAPSTONE, end to end: each record carries an i64 id and a
+% comma-separated-number payload. The shipped grammar parses the payload
+% and returns pair(Sum, Count); the destructure lands Sum in s and Count
+% in c. Over the payloads "12,7" (sum 19, count 2), "100" (100, 1),
+% "40,41,9" (90, 3): total sum = 209, total count = 6.
+test(reader_bytes_in_record_out, [condition(clang_available)]) :-
+    gr_dir(Dir),
+    directory_file_path(Dir, 'reader.wamo', Wamo),
+    reader_preds(Preds),
+    write_wam_object(Preds, [wamo_entries([gr_parse/2])], Wamo),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 blob32\" ; DYNLOAD = \"~w\" }\n\c
+         { (s, c) = dyncall@gr_parse($2) as (i64 i64) ; total += s ; recs += c }\n\c
+         END { print total, recs }\n", [Wamo]),
+    write_prog(Dir, 'reader.plawk', Src),
+    directory_file_path(Dir, 'reader.plawk', Prog),
+    directory_file_path(Dir, 'reader_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'in.bin', Input),
+    write_blob_records(Input, [rec(1, "12,7"), rec(2, "100"),
+                               rec(3, "40,41,9")]),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "209 6\n"),
+    !.
+
+% A guard can gate on the id field while the payload is read by the
+% grammar: only id > 1 records contribute. "100" (sum 100) + "40,41,9"
+% (sum 90) = 190; the "12,7" record (id 1) is skipped.
+test(reader_guarded_by_scalar_field, [condition(clang_available)]) :-
+    gr_dir(Dir),
+    directory_file_path(Dir, 'reader.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; reader_preds(Preds),
+      write_wam_object(Preds, [wamo_entries([gr_parse/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 blob32\" ; DYNLOAD = \"~w\" }\n\c
+         $1 > 1 { (s, c) = dyncall@gr_parse($2) as (i64 i64) ; total += s }\n\c
+         END { print total }\n", [Wamo]),
+    write_prog(Dir, 'readerg.plawk', Src),
+    directory_file_path(Dir, 'readerg.plawk', Prog),
+    directory_file_path(Dir, 'readerg_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    directory_file_path(Dir, 'in.bin', Input),
+    write_blob_records(Input, [rec(1, "12,7"), rec(2, "100"),
+                               rec(3, "40,41,9")]),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == "190\n"),
+    !.
+
+:- end_tests(plawk_grammar_reader).
+
+% --- helpers ---------------------------------------------------------------
+
+reader_preds([ user:gr_parse/2,
+               user:gr_nums/4,
+               user:gr_nums_rest/6,
+               user:gr_num/3,
+               user:gr_digits/4,
+               user:gr_digit/3
+             ]).
+
+gr_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_grammar_reader', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Text) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text), close(Out)).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% rec(Id, PayloadString): i64 id, i64 payload length, payload bytes
+write_blob_records(Path, Recs) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(rec(Id, Payload), Recs),
+            ( write_i64_le(Out, Id),
+              string_codes(Payload, Codes),
+              length(Codes, Len),
+              write_i64_le(Out, Len),
+              forall(member(C, Codes), put_byte(Out, C)) )),
+        close(Out)).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
Proves and locks in the endgame JIT roadmap item 4 explicitly pointed at, and the DCG-binary-readers Tier-2/3 story: **bytes-in + record-out through a loaded WAM grammar.**

A binary payload framed natively by a `BINFMT` `blobN` field flows — as a transient atom, constant-memory, no interning — into a grammar shipped as a `.wamo` object, which parses the bytes with a real WAM DCG (choice points and all) and returns a **structured record** (a Compound); `@wam_object_call_record` deserializes that into typed plawk scalars.

```awk
BEGIN { BINFMT = "i64 blob32" ; DYNLOAD = "reader.wamo" }
{ (s, c) = dyncall@gr_parse($2) as (i64 i64) ; total += s ; recs += c }
END { print total, recs }
```

## No new code — a latent composition, now proven

The capability falls out of two arcs the campaign built separately, with **zero connecting codegen**:

- **item 2 / Tier-2** — a `blobN` field marshals to a transient-atom `%Value` (`plawk_foreign_args_ir`, ≤1 blob per call);
- **item 4** — the record destructure `(v…) = dyncall@name(…) as (T…)` is a legal binary-mode action (`dynrec_bind`) and forwards its args through that same marshaller into `@wam_object_call_record`.

The novelty over the existing Tier-2 blob tests is routing bytes-in + record-out **through a loaded object** (`dyncall@name`) rather than a compiled-in foreign predicate — so the reader grammar is a shippable, swappable artifact (a `DYNLOAD` library today, a runtime `compile(...)` handle by the same mechanism). A scalar id field can still guard the record while the grammar reads the payload.

Because nothing in the compiler/runtime changed, existing suites are unaffected by construction; this PR is a standing regression test plus doc updates that turn "should compose" into "proven, with coverage."

## Test — `tests/test_plawk_grammar_reader.pl`

- **parse + surface check**: a blob field into a record-returning `dyncall` parses to `dynrec_bind` and passes binary-mode validation.
- **IR composition**: the emitted driver contains the record shim (`@plawk_dyncall_named_rec_gr_parse_1`), the record primitive (`@wam_object_call_record`), and the blob transient-atom marshal (`@wam_transient_atom_from_bytes`) together.
- **end to end**: comma-separated-number payloads parsed by the shipped DCG to `pair(Sum, Count)`, destructured and accumulated across records → `209 6`.
- **scalar-guarded variant**: an `$1 > 1` guard on the id field gates which records the grammar reads → `190`.

## Docs

`PLAWK_JIT_ROADMAP.md` item 4 and `PLAWK_DCG_BINARY_READERS.md` Tier-2 section record the landed capstone. Tier-3 (a full DCG engine *in* the loop) stays the one deliberately-unbuilt rung — the loaded-grammar reader covers the irregular-format cases without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_