### PR TITLE
Add Rust WAM current_predicate/1 enumeration

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -675,6 +675,8 @@ wam_instruction_arm('Instruction::Call(p, _arity)', Body) :-
                     self.dynamic_retract_call(self.pc + 1)
                 } else if p == "clause/2" {
                     self.dynamic_clause_call(self.pc + 1)
+                } else if p == "current_predicate/1" {
+                    self.current_predicate_call(self.pc + 1)
                 } else if p == "assert/1" {
                     self.execute_assert_builtin("assert/1")
                 } else if p == "read_term/2" {
@@ -753,6 +755,8 @@ wam_instruction_arm('Instruction::Execute(p)', Body) :-
                     self.dynamic_retract_call(self.cp)
                 } else if p == "clause/2" {
                     self.dynamic_clause_call(self.cp)
+                } else if p == "current_predicate/1" {
+                    self.current_predicate_call(self.cp)
                 } else if p == "assert/1" {
                     if self.execute_assert_builtin("assert/1") {
                         self.pc = self.cp;
@@ -3704,6 +3708,29 @@ compile_resume_builtin_to_rust(Code) :-
                 };
                 self.dynamic_clause_attempt(key, start_idx, head, body, cont_pc)
             }
+            "current_predicate" => {
+                let keys = match state.args.get(0) {
+                    Some(Value::List(keys)) => keys.clone(),
+                    _ => return false,
+                };
+                let name = match state.args.get(1) {
+                    Some(name) => name.clone(),
+                    _ => return false,
+                };
+                let arity = match state.args.get(2) {
+                    Some(arity) => arity.clone(),
+                    _ => return false,
+                };
+                let start_idx = match state.data.get(0) {
+                    Some(Value::Integer(n)) => *n as usize,
+                    _ => return false,
+                };
+                let cont_pc = match state.data.get(1) {
+                    Some(Value::Integer(n)) => *n as usize,
+                    _ => return false,
+                };
+                self.current_predicate_attempt(keys, start_idx, name, arity, cont_pc)
+            }
             "dynamic_rule_body" => {
                 let clause = match state.args.get(0) {
                     Some(clause) => clause.clone(),
@@ -4890,6 +4917,9 @@ compile_execute_meta_builtin_to_rust(Code) :-
         }
         if key == "clause/2" {
             return self.dynamic_clause_call(saved_pc);
+        }
+        if key == "current_predicate/1" {
+            return self.current_predicate_call(saved_pc);
         }
         if self.execute_builtin(key, arity) {
             self.pc = saved_pc;

--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -656,6 +656,120 @@
         self.dynamic_retract_attempt(key, 0, pattern, cont_pc)
     }
 
+    fn current_predicate_call(&mut self, cont_pc: usize) -> bool {
+        let spec_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let spec = self.deref_heap(&self.deref_var(&spec_raw));
+        let (name, arity) = match spec {
+            Value::Str(functor, args)
+                if args.len() == 2 && Self::display_functor_name(&functor, 2) == "/" =>
+            {
+                (
+                    self.deref_heap(&self.deref_var(&args[0])),
+                    self.deref_heap(&self.deref_var(&args[1])),
+                )
+            }
+            _ => return false,
+        };
+        if !matches!(&name, Value::Atom(_) | Value::Unbound(_)) {
+            return false;
+        }
+        if !matches!(&arity, Value::Integer(n) if *n >= 0) &&
+            !matches!(&arity, Value::Unbound(_))
+        {
+            return false;
+        }
+
+        let mut all_keys = std::collections::BTreeSet::new();
+        all_keys.extend(self.labels.keys().cloned());
+        all_keys.extend(self.dynamic_db.keys().cloned());
+        let keys: Vec<Value> = all_keys
+            .into_iter()
+            .filter(|key| {
+                let (candidate_name, candidate_arity) = match key.rsplit_once('/') {
+                    Some((candidate_name, candidate_arity)) => {
+                        match candidate_arity.parse::<i64>() {
+                            Ok(candidate_arity) => (candidate_name, candidate_arity),
+                            Err(_) => return false,
+                        }
+                    }
+                    None => return false,
+                };
+                let name_matches = match &name {
+                    Value::Atom(expected) => expected == candidate_name,
+                    _ => true,
+                };
+                let arity_matches = match &arity {
+                    Value::Integer(expected) => *expected == candidate_arity,
+                    _ => true,
+                };
+                name_matches && arity_matches
+            })
+            .map(Value::Atom)
+            .collect();
+        self.current_predicate_attempt(keys, 0, name, arity, cont_pc)
+    }
+
+    fn current_predicate_attempt(
+        &mut self,
+        keys: Vec<Value>,
+        start_idx: usize,
+        name_pattern: Value,
+        arity_pattern: Value,
+        cont_pc: usize,
+    ) -> bool {
+        for idx in start_idx..keys.len() {
+            let key = match &keys[idx] {
+                Value::Atom(key) => key,
+                _ => continue,
+            };
+            let (name, arity) = match key.rsplit_once('/') {
+                Some((name, arity)) => match arity.parse::<i64>() {
+                    Ok(arity) => (name, arity),
+                    Err(_) => continue,
+                },
+                None => continue,
+            };
+            let cp_trail = self.trail.len();
+            let cp_heap = self.heap.len();
+            let cp_regs = self.save_regs();
+            let cp_stack = self.stack.clone();
+            if self.unify(&name_pattern, &Value::Atom(name.to_string())) &&
+                self.unify(&arity_pattern, &Value::Integer(arity))
+            {
+                if idx + 1 < keys.len() {
+                    self.choice_points.push(ChoicePoint {
+                        next_pc: cont_pc,
+                        saved_args: cp_regs,
+                        stack: cp_stack,
+                        cp: self.cp,
+                        trail_len: cp_trail,
+                        heap_len: cp_heap,
+                        builtin_state: Some(BuiltinState {
+                            name: "current_predicate".to_string(),
+                            args: vec![
+                                Value::List(keys.clone()),
+                                name_pattern.clone(),
+                                arity_pattern.clone(),
+                            ],
+                            data: vec![
+                                Value::Integer((idx + 1) as i64),
+                                Value::Integer(cont_pc as i64),
+                            ],
+                        }),
+                        cut_barrier: self.cut_barrier,
+                    });
+                }
+                self.pc = cont_pc;
+                return true;
+            }
+            self.unwind_trail_to(cp_trail);
+            self.heap.truncate(cp_heap);
+            self.restore_regs(&cp_regs);
+            self.stack = cp_stack;
+        }
+        false
+    }
+
     fn dynamic_clause_call(&mut self, cont_pc: usize) -> bool {
         let head_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
         let head = self.deref_heap(&self.deref_var(&head_raw));

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -271,6 +271,51 @@ fn generated_tail_clause_call_reads_dynamic_facts() {
 }
 
 #[test]
+fn current_predicate_backtracks_over_matching_dynamic_arities() {
+    let mut vm = WamState::new(
+        vec![
+            Instruction::Call("current_predicate/1".to_string(), 1),
+            Instruction::Proceed,
+        ],
+        HashMap::new(),
+    );
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("one")]));
+    assert_clause(
+        &mut vm,
+        "assertz/1",
+        fact("dyn", vec![at("one"), at("two")]),
+    );
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("/", vec![at("dyn"), ub("Arity")]));
+    vm.pc = 1;
+
+    let mut arities = Vec::new();
+    assert!(vm.run());
+    loop {
+        let arity = vm.bindings.get("Arity").cloned().expect("Arity bound");
+        arities.push(vm.deref_heap(&vm.deref_var(&arity)));
+        if !vm.backtrack() { break; }
+    }
+    assert_eq!(arities, vec![Value::Integer(1), Value::Integer(2)]);
+}
+
+#[test]
+fn generated_tail_current_predicate_call_reads_static_labels() {
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code, labels);
+    vm.set_reg_str("A1", at("rust_clause_demo"));
+    vm.set_reg_str("A2", ub("Arity"));
+    vm.pc = *vm.labels
+        .get("rust_current_predicate_demo/2")
+        .expect("generated current_predicate demo label");
+
+    assert!(vm.run());
+    let arity = vm.bindings.get("Arity").cloned().expect("Arity bound");
+    assert_eq!(vm.deref_heap(&vm.deref_var(&arity)), Value::Integer(2));
+}
+
+#[test]
 fn retract_distinguishes_fact_patterns_from_rule_patterns() {
     let mut vm = WamState::new(vec![Instruction::Call("retract/1".to_string(), 1), Instruction::Proceed], HashMap::new());
     assert_clause(&mut vm, "assertz/1", fact("marker", vec![at("rule")]));

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -16,6 +16,10 @@ rust_assert_alias_demo :- assert(dyn(alias)).
 rust_clause_demo(X, Body) :-
     clause(dyn(X), Body).
 
+:- dynamic rust_current_predicate_demo/2.
+rust_current_predicate_demo(Name, Arity) :-
+    current_predicate(Name/Arity).
+
 :- dynamic rust_read_term_options_demo/2.
 rust_read_term_options_demo(Term, Names) :-
     read_term(Term, [variable_names(Names)]).
@@ -49,6 +53,7 @@ test(assert_retract_dynamic_db,
         [user:rust_dyn_dummy/0,
          user:rust_assert_alias_demo/0,
          user:rust_clause_demo/2,
+         user:rust_current_predicate_demo/2,
          user:rust_read_term_options_demo/2,
          user:rust_atom_to_term_demo/2,
          user:rust_syntax_error_demo/1],


### PR DESCRIPTION
## Summary

- route `current_predicate/1` through Rust runtime call and execute paths
- enumerate static labels and dynamic database predicates
- support bound and partial `Name/Arity` indicators
- deduplicate and sort candidates for deterministic backtracking
- support callable runtime dispatch
- keep candidate scanning limited to actual `current_predicate/1` calls

Malformed-indicator ISO exception parity is intentionally left for a separate change.

## Testing

- focused Rust dynamic builtin suite
- full Rust WAM target suite
- Rust WAM target syntax/load check
- patch whitespace validation