### PR TITLE
WAM/LLVM eval: positional-array string values (`as array(str)`)

### DIFF
--- a/docs/design/PLAWK_EVAL_ARCHITECTURE.md
+++ b/docs/design/PLAWK_EVAL_ARCHITECTURE.md
@@ -203,7 +203,9 @@ Deliberately deferred, in rough value order:
   reusing the whole assoc pipeline via a `posarray(...)` spec wrapper
   and a new `@wam_object_call_posarray` walk. Its integer position keys
   read unambiguously in text mode (unlike a regular integer-keyed
-  assoc). String values deferred, like the assoc `(str)` kind was.
+  assoc). String values LANDED too (`as array(str)`, a flat `[Atom,...]`
+  list stored by position and resolved back to text on read), so the
+  container × value-kind matrix is complete.
 - ~~**`dyncall_at@name(...)`**~~ — LANDED (all three return kinds:
   i64, `float(...)`, `blob(...)`): named entries on runtime sources
   and `compile(...)` handles, resolved per call against the VM's

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -302,7 +302,7 @@ different plawk containers — this is the through-line for the rest of item 4:
   **Rule-body for-in LANDED:** `for (k in arr)` iterates a
   grammar-populated table inside the rule''s action chain (a per-record
   running snapshot), not only in END.
-- **Positional array — LANDED (named + default entry, i64 values):**
+- **Positional array — LANDED (named + default entry, i64 AND str values):**
   `arr = dyncall[@name](args) as array` binds a FLAT returned list
   `[V1, ..., Vn]` into one array value by POSITION — element i at key i
   (1-indexed, the awk `split` convention). `@wam_object_call_posarray`
@@ -314,9 +314,14 @@ different plawk containers — this is the through-line for the rest of item 4:
   never interned atom ids, so int-key reads (`arr[1]`, and a for-in loop
   key) are unambiguous and permitted in TEXT mode too, unlike a regular
   integer-keyed assoc (which stays binary-only to avoid the atom-id
-  collision). Value binding uses whatever the entry returns; string
-  values (`[Atom, ...]` elements) are a natural follow-on, deferred like
-  the assoc `(str)` kind was. Tests:
+  collision). **String values (`as array(str)`):** a grammar returning a
+  flat `[Atom, ...]` list gives a str-valued positional table — the
+  element atoms' registry ids are stored by position
+  (`@wam_object_call_posarray_str`), and reads (END `arr[1]`, for-in
+  values) resolve them back to text through `@wam_atom_to_string`. Such a
+  table is BOTH positional-keyed (int positions, int reads work in text
+  mode) and str-valued (its name joins both the posarray set and the
+  str-array set), completing the container × value-kind matrix. Tests:
   `tests/test_plawk_dyncall_posarray.pl`.
 
 Each target reuses one marshaller over the same walked compound; they differ

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -134,6 +134,8 @@ build(File, Out0, KeepLL) :-
         ; plawk_program_dyncall_assoc_str_arities(Program, DynAssocSArities), DynAssocSArities \== []
         ; plawk_program_dyncall_named_posarray_entries(Program, DynNamedPosarr), DynNamedPosarr \== []
         ; plawk_program_dyncall_posarray_arities(Program, DynPosarrArities), DynPosarrArities \== []
+        ; plawk_program_dyncall_named_posarray_str_entries(Program, DynNamedPosarrS), DynNamedPosarrS \== []
+        ; plawk_program_dyncall_posarray_str_arities(Program, DynPosarrSArities), DynPosarrSArities \== []
         )
     ->  ProjectOptions = [module_name(OutBase), emit_wamo_loader(true)]
     ;   ProjectOptions = [module_name(OutBase)]

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -18,6 +18,8 @@
     plawk_program_dyncall_assoc_str_arities/2,
     plawk_program_dyncall_named_posarray_entries/2,
     plawk_program_dyncall_posarray_arities/2,
+    plawk_program_dyncall_named_posarray_str_entries/2,
+    plawk_program_dyncall_posarray_str_arities/2,
     plawk_program_dyncall_at_arities/2,
     plawk_program_dyncall_at_named_entries/2,
     plawk_program_dyncall_at_named_float_entries/2,
@@ -651,6 +653,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
     plawk_program_dyncall_assoc_str_arities(Program, DynAssocSArities),
     plawk_program_dyncall_named_posarray_entries(Program, DynNamedPosarr),
     plawk_program_dyncall_posarray_arities(Program, DynPosarrArities),
+    plawk_program_dyncall_named_posarray_str_entries(Program, DynNamedPosarrS),
+    plawk_program_dyncall_posarray_str_arities(Program, DynPosarrSArities),
     plawk_program_dyncall_at_arities(Program, DynAtArities),
     plawk_program_dyncall_at_named_entries(Program, DynAtNamed),
     plawk_program_dyncall_at_named_float_entries(Program, DynAtNamedF),
@@ -675,6 +679,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
         DynAssocSArities == [],
         DynNamedPosarr == [],
         DynPosarrArities == [],
+        DynNamedPosarrS == [],
+        DynPosarrSArities == [],
         DynAtArities == [],
         DynAtNamed == [],
         DynAtNamedF == [],
@@ -701,7 +707,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
             DynRecArities == [], DynNamedRec == [], DynNamedAssoc == [],
             DynAssocArities == [], DynNamedAssocS == [],
             DynAssocSArities == [], DynNamedPosarr == [],
-            DynPosarrArities == []
+            DynPosarrArities == [], DynNamedPosarrS == [],
+            DynPosarrSArities == []
         ->  DyncallSupportIR = ''
         ;   ( plawk_program_dynload_path(Program, DynPath)
             ->  true
@@ -713,7 +720,8 @@ plawk_program_native_driver_ir(Program, InputPath, Options, DriverIR) :-
                 DynBArities, DynNamed, DynNamedF, DynNamedB,
                 DynRecArities, DynNamedRec, DynNamedAssoc, DynAssocArities,
                 DynNamedAssocS, DynAssocSArities, DynNamedPosarr,
-                DynPosarrArities, DyncallSupportIR)
+                DynPosarrArities, DynNamedPosarrS, DynPosarrSArities,
+                DyncallSupportIR)
         ),
         % Dynamic-source shims for dyncall_at(...) / float(dyncall_at(...)) /
         % blob(dyncall_at(...)) sites + the shared path cache. A compile
@@ -1042,6 +1050,45 @@ plawk_subterm_dynposarray_call(Term, Call) :-
     compound(Term),
     arg(_, Term, Sub),
     plawk_subterm_dynposarray_call(Sub, Call).
+
+%% plawk_program_dyncall_named_posarray_str_entries(+Program, -Entries)
+%% plawk_program_dyncall_posarray_str_arities(+Program, -Arities)
+%  Str-valued positional array (`arr = dyncall[@name](args) as array(str)`):
+%  named sites get @plawk_dyncall_posarray_str_<Name>_<N> shims,
+%  default-entry sites @plawk_dyncall_posarray_str_default_<N> -- both
+%  forwarding to @wam_object_call_posarray_str (flat [Atom..] list, atom
+%  ids stored by position, resolved to text on read).
+plawk_program_dyncall_named_posarray_str_entries(
+        program(_Begin, Rules, EndClauses), Entries) :-
+    findall(Name-NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          member(Action, Actions),
+          plawk_subterm_dynposarray_str_call(Action, dyncall_named(Name, Args)),
+          length(Args, NArgs)
+        ),
+        Entries0),
+    sort(Entries0, Entries).
+
+plawk_program_dyncall_posarray_str_arities(program(_Begin, Rules, EndClauses),
+        Arities) :-
+    findall(NArgs,
+        ( ( member(rule(_Pattern, Actions), Rules)
+          ; member(end(Actions), EndClauses)
+          ),
+          member(Action, Actions),
+          plawk_subterm_dynposarray_str_call(Action, dyncall(Args)),
+          length(Args, NArgs)
+        ),
+        A0),
+    sort(A0, Arities).
+
+plawk_subterm_dynposarray_str_call(dynposarray_bind_str(_Var, Call), Call).
+plawk_subterm_dynposarray_str_call(Term, Call) :-
+    compound(Term),
+    arg(_, Term, Sub),
+    plawk_subterm_dynposarray_str_call(Sub, Call).
 
 plawk_subterm_dynrec_call(dynrec_bind(_Vars, Call, _Types), Call).
 plawk_subterm_dynrec_call(dynrec_view(Call, _Types, _Body), Call).
@@ -1403,7 +1450,8 @@ plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
 plawk_dyncall_support_ir(Path, IArities, FArities, BArities,
         NamedI, NamedF, NamedB, RecArities, NamedRec, NamedAssoc,
         AssocArities, NamedAssocStr, AssocStrArities,
-        NamedPosarray, PosarrayArities, IR) :-
+        NamedPosarray, PosarrayArities,
+        NamedPosarrayStr, PosarrayStrArities, IR) :-
     llvm_emit_c_string_global('plawk_dyncall_path', Path, PathGlobal,
         _StrLen, BytesLen),
     format(atom(GetterIR),
@@ -1442,7 +1490,7 @@ load:
     % (record binds that name an entry feed the union too, so their
     % resolver exists even when the entry is used nowhere else)
     append([NamedI, NamedF, NamedB, NamedRec, NamedAssoc, NamedAssocStr,
-            NamedPosarray],
+            NamedPosarray, NamedPosarrayStr],
         NamedAll0),
     sort(NamedAll0, NamedAll),
     findall(ResIR,
@@ -1492,9 +1540,18 @@ load:
         ( member(DPN, PosarrayArities),
           plawk_dyncall_posarray_default_shim_ir(DPN, DPShim) ),
         DPShims),
+    findall(NPSShim,
+        ( member(NPSName-NPSNArgs, NamedPosarrayStr),
+          plawk_dyncall_named_posarray_str_shim_ir(NPSName, NPSNArgs, NPSShim) ),
+        NPSShims),
+    findall(DPSShim,
+        ( member(DPSN, PosarrayStrArities),
+          plawk_dyncall_posarray_str_default_shim_ir(DPSN, DPSShim) ),
+        DPSShims),
     append([[PathGlobal, GetterIR], IShims, FShims, BShims,
             Resolvers, NIShims, NFShims, NBShims, RecShims, NRecShims,
-            NAShims, DAShims, NSShims, DSShims, NPShims, DPShims], Parts),
+            NAShims, DAShims, NSShims, DSShims, NPShims, DPShims,
+            NPSShims, DPSShims], Parts),
     atomic_list_concat(Parts, '\n\n', IR).
 
 %% plawk_dyncall_named_assoc_shim_ir(+Name, +NArgs, -IR)
@@ -1654,6 +1711,58 @@ do_call:
   %args = alloca %Value, i32 ~w
 ~w
   %r = call i1 @wam_object_call_posarray(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, %WamAssocI64Table* %table)
+  ret i1 %r
+
+fail:
+  ret i1 false
+}',
+        [NArgs, ParamsIR, NArgs, StoreIR, NArgs, NArgs]).
+
+%% plawk_dyncall_named_posarray_str_shim_ir(+Name, +NArgs, -IR)
+%  Str-valued positional array, named entry: same shape as the posarray
+%  shim but forwarding to @wam_object_call_posarray_str (atom elements).
+plawk_dyncall_named_posarray_str_shim_ir(Name, NArgs, IR) :-
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define i1 @plawk_dyncall_posarray_str_~w(~w, %WamAssocI64Table* %table) {
+entry:
+  %pc = call i32 @plawk_dyncall_resolve_~w()
+  %bad = icmp slt i32 %pc, 0
+  br i1 %bad, label %fail, label %do_call
+
+do_call:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call i1 @wam_object_call_posarray_str(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, %WamAssocI64Table* %table)
+  ret i1 %r
+
+fail:
+  ret i1 false
+}',
+        [Sym, ParamsIR, Sym, NArgs, StoreIR, NArgs, NArgs]).
+
+%% plawk_dyncall_posarray_str_default_shim_ir(+NArgs, -IR)
+%  Str-valued positional array, default entry.
+plawk_dyncall_posarray_str_default_shim_ir(NArgs, IR) :-
+    plawk_foreign_wrapper_params(NArgs, ParamsIR),
+    plawk_dyncall_store_lines(NArgs, StoreLines),
+    atomic_list_concat(StoreLines, '\n', StoreIR),
+    format(atom(IR),
+'define i1 @plawk_dyncall_posarray_str_default_~w(~w, %WamAssocI64Table* %table) {
+entry:
+  %vm = call %WamState* @plawk_dyncall_get()
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+
+do_call:
+  %pc = load i32, i32* @plawk_dyncall_pc
+  %args = alloca %Value, i32 ~w
+~w
+  %r = call i1 @wam_object_call_posarray_str(%WamState* %vm, i32 %pc, i32 ~w, %Value* %args, i32 ~w, %WamAssocI64Table* %table)
   ret i1 %r
 
 fail:
@@ -3278,7 +3387,9 @@ plawk_assoc_spec_forin_array(ActionSpecs, ArrayName) :-
 plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays) :-
     findall(A,
         ( member(rule(_P, ActionSpecs, _C), RuleSpecs),
-          member(dynassoc(A, str(_Call)), ActionSpecs)
+          ( member(dynassoc(A, str(_Call)), ActionSpecs)
+          ; member(dynassoc(A, posarray_str(_Call)), ActionSpecs)
+          )
         ),
         As0),
     sort(As0, StrArrays).
@@ -3290,7 +3401,9 @@ plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays) :-
 plawk_assoc_specs_posarray_arrays(RuleSpecs, PosArrays) :-
     findall(A,
         ( member(rule(_P, ActionSpecs, _C), RuleSpecs),
-          member(dynassoc(A, posarray(_Call)), ActionSpecs)
+          ( member(dynassoc(A, posarray(_Call)), ActionSpecs)
+          ; member(dynassoc(A, posarray_str(_Call)), ActionSpecs)
+          )
         ),
         As0),
     sort(As0, PosArrays).
@@ -4220,6 +4333,13 @@ plawk_assoc_body_action_spec(dynassoc_bind_str(var(ArrayName), Call),
 plawk_assoc_body_action_spec(dynposarray_bind(var(ArrayName), Call),
         dynassoc(ArrayName, posarray(Call))) :-
     plawk_dynrec_call_ok(Call).
+% str-valued positional array: the call rides the dynassoc spec wrapped
+% in posarray_str(...) -- integer position KEYS (like posarray) and atom
+% VALUES resolved to text (like str), so the array name joins BOTH the
+% posarray set and the str-array set.
+plawk_assoc_body_action_spec(dynposarray_bind_str(var(ArrayName), Call),
+        dynassoc(ArrayName, posarray_str(Call))) :-
+    plawk_dynrec_call_ok(Call).
 % rule-body for-in: per-record iteration over an assoc table with a
 % print body -- the END for-in's field shapes (loop key / lookups keyed
 % by it / string literals), emitted as a loop inside the rule's action
@@ -4744,6 +4864,7 @@ plawk_program_posarray_arrays(Rules, Names) :-
     sort(Names0, Names).
 
 plawk_posarray_bind_name(dynposarray_bind(var(Name), _Call), Name).
+plawk_posarray_bind_name(dynposarray_bind_str(var(Name), _Call), Name).
 plawk_posarray_bind_name(Term, Name) :-
     compound(Term),
     arg(_, Term, Sub),
@@ -4761,6 +4882,10 @@ plawk_binfmt_assoc_action_ok(Descriptor, dynassoc_bind(var(_Name), Call)) :-
 plawk_binfmt_assoc_action_ok(Descriptor, dynposarray_bind(var(_Name), Call)) :-
     !,
     plawk_dynassoc_call_parts(posarray(Call), Args, _Shim),
+    plawk_binfmt_foreign_args_ok(Descriptor, Args).
+plawk_binfmt_assoc_action_ok(Descriptor, dynposarray_bind_str(var(_Name), Call)) :-
+    !,
+    plawk_dynassoc_call_parts(posarray_str(Call), Args, _Shim),
     plawk_binfmt_foreign_args_ok(Descriptor, Args).
 
 plawk_record_program_ok(binfmt(Types), Rules, _EndPrintFields) :-
@@ -6748,14 +6873,27 @@ plawk_assoc_end_print_lines([assoc(var(ArrayName), int(Key)) | Rest], AssocPlan,
       format(atom(Value),
           '  %assoc_end_value_~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 ~w)',
           [PrintIndex, TableIndex, Key]),
-      format(atom(FmtVar), 'assoc_end_i64_fmt_~w', [PrintIndex]),
-      format(atom(PrintVar), 'printed_assoc_end_i64_~w', [PrintIndex]),
       format(atom(ValueIR), '%assoc_end_value_~w', [PrintIndex]),
-      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
-          [FmtPtr, PrintCall]),
+      (   plawk_assoc_plan_str_array(AssocPlan, ArrayName)
+      ->  % str-valued positional table: resolve the stored id to text.
+          format(atom(ValueString),
+              '  %assoc_end_value_s_~w = call i8* @wam_atom_to_string(i64 ~w)',
+              [PrintIndex, ValueIR]),
+          format(atom(FmtVar), 'assoc_end_str_fmt_~w', [PrintIndex]),
+          format(atom(PrintVar), 'printed_assoc_end_str_~w', [PrintIndex]),
+          format(atom(PtrIR), '%assoc_end_value_s_~w', [PrintIndex]),
+          llvm_emit_printf_string(plawk_surface_print_string, FmtVar, PrintVar,
+              PtrIR, [FmtPtr, PrintCall]),
+          ValueLines = [Value, ValueString, FmtPtr, PrintCall]
+      ;   format(atom(FmtVar), 'assoc_end_i64_fmt_~w', [PrintIndex]),
+          format(atom(PrintVar), 'printed_assoc_end_i64_~w', [PrintIndex]),
+          llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+              ValueIR, [FmtPtr, PrintCall]),
+          ValueLines = [Value, FmtPtr, PrintCall]
+      ),
       NextPrintIndex is PrintIndex + 1
     },
-    [Value, FmtPtr, PrintCall],
+    plawk_emit_lines(ValueLines),
     plawk_assoc_end_print_lines(Rest, AssocPlan, Descriptor, OutputSeparator, NextPrintIndex).
 plawk_assoc_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
@@ -6810,8 +6948,11 @@ plawk_assoc_table_index(assoc_plan(Tables, _Actions), ArrayName, TableIndex) :-
 %  of printing it numerically.
 plawk_assoc_plan_str_array(assoc_plan(_Tables, Rules), ArrayName) :-
     member(assoc_rule(_RuleIndex, _Pattern, Actions, _Control), Rules),
-    member(assoc_dyn_action(_Index, ArrayName, _TableIndex, str(_Call)),
-        Actions),
+    ( member(assoc_dyn_action(_Index, ArrayName, _TableIndex, str(_Call)),
+        Actions)
+    ; member(assoc_dyn_action(_Index2, ArrayName, _TableIndex2,
+        posarray_str(_Call2)), Actions)
+    ),
     !.
 
 %% plawk_assoc_plan_posarray_array(+AssocPlan, +ArrayName) is semidet.
@@ -6821,8 +6962,11 @@ plawk_assoc_plan_str_array(assoc_plan(_Tables, Rules), ArrayName) :-
 %  even in text mode.
 plawk_assoc_plan_posarray_array(assoc_plan(_Tables, Rules), ArrayName) :-
     member(assoc_rule(_RuleIndex, _Pattern, Actions, _Control), Rules),
-    member(assoc_dyn_action(_Index, ArrayName, _TableIndex, posarray(_Call)),
-        Actions),
+    ( member(assoc_dyn_action(_Index, ArrayName, _TableIndex, posarray(_Call)),
+        Actions)
+    ; member(assoc_dyn_action(_Index2, ArrayName, _TableIndex2,
+        posarray_str(_Call2)), Actions)
+    ),
     !.
 
 % Binary record modes: assoc keys are raw i64 field values (no
@@ -7506,6 +7650,14 @@ plawk_dynassoc_call_parts(posarray(dyncall_named(Name, Args)), Args, ShimName) :
 plawk_dynassoc_call_parts(posarray(dyncall(Args)), Args, ShimName) :-
     length(Args, NArgs),
     format(atom(ShimName), 'plawk_dyncall_posarray_default_~w', [NArgs]).
+% str-valued positional array (`as array(str)`): posarray_str(...) wrapper.
+plawk_dynassoc_call_parts(posarray_str(dyncall_named(Name, Args)), Args, ShimName) :-
+    length(Args, NArgs),
+    plawk_dyncall_named_symbol(Name, NArgs, Sym),
+    format(atom(ShimName), 'plawk_dyncall_posarray_str_~w', [Sym]).
+plawk_dynassoc_call_parts(posarray_str(dyncall(Args)), Args, ShimName) :-
+    length(Args, NArgs),
+    format(atom(ShimName), 'plawk_dyncall_posarray_str_default_~w', [NArgs]).
 
 plawk_dynrec_field_load_lines([], [], _Base, []).
 plawk_dynrec_field_load_lines([F | Fs], [Type | Ts], Base, [Line | Lines]) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1181,7 +1181,7 @@ dynassoc_value_kind(i64) -->
 %  table as `as assoc`, but filled from a flat [V1, ..., Vn] list instead
 %  of key-value pairs, so END `arr[1]`, `arr[2]`, ... and for-in read the
 %  positional values.
-dynposarray_bind_action(dynposarray_bind(var(Name), Call)) -->
+dynposarray_bind_action(Action) -->
     identifier(Name),
     ws,
     "=",
@@ -1191,7 +1191,12 @@ dynposarray_bind_action(dynposarray_bind(var(Name), Call)) -->
     "as",
     identifier_boundary,
     ws,
-    "array".
+    "array",
+    dynassoc_value_kind(Kind),
+    { Kind == str
+    ->  Action = dynposarray_bind_str(var(Name), Call)
+    ;   Action = dynposarray_bind(var(Name), Call)
+    }.
 
 dynrec_view_action(dynrec_view(Call, Types, Body)) -->
     dynrec_call_expr(Call),

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -22761,6 +22761,9 @@ wamo_utf8_bytes([C|Cs], Bytes) :-
 %    @wam_object_call_posarray - call the entry and materialize a returned
 %                           FLAT list [V1..Vn] into an i64 table by POSITION
 %                           (element i -> key i, 1-indexed, @wam_assoc_i64_set)
+%    @wam_object_call_posarray_str - like call_posarray but the elements are
+%                           ATOMS; their registry ids are stored per position
+%                           (reads resolve back to text)
 %    @wam_object_entry_index / @wam_object_entry_index_bytes
 %                        - resolve a named entry to its label index (or -1)
 %                          for multi-entry objects; @wam_label_pc turns that
@@ -23885,6 +23888,93 @@ have_cell:
 insert:
   %eval = call i64 @value_payload(%Value %elem)
   %ignored = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %pos, i64 %eval)
+  br label %next
+next:
+  %pos1 = add i64 %pos, 1
+  %tail_d = call %Value @wam_deref_value(%WamState* %vm, %Value %t_raw)
+  br label %walk
+walk_done:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  ret i1 true
+rewind_fail:
+  store i32 %hs_saved, i32* %hs_ptr
+  call void @wam_cleanup()
+  br label %fail
+fail:
+  ret i1 false
+}
+
+; Positional array, STRING values: same flat-list walk as
+; @wam_object_call_posarray, but each element must be an ATOM and its
+; registry id is stored at its position via @wam_assoc_i64_set -- the
+; str-valued positional table (reads resolve the id back to text through
+; @wam_atom_to_string, exactly as the assoc(str) kind does). Returns i1
+; ok; false on call failure, a non-list output, or a non-Atom element.
+define i1 @wam_object_call_posarray_str(%WamState* %vm, i32 %entry_pc, i32 %nargs, %Value* %args, i32 %out_reg, %WamAssocI64Table* %table) {
+entry:
+  %vm_null = icmp eq %WamState* %vm, null
+  br i1 %vm_null, label %fail, label %do_call
+do_call:
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %hs_saved = load i32, i32* %hs_ptr
+  %unb = call %Value @value_unbound(i8* null)
+  %out_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %out_ref = call %Value @value_ref(i32 %out_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %entry_pc)
+  br label %argloop
+argloop:
+  %ai = phi i32 [ 0, %do_call ], [ %ai1, %argstep ]
+  %adone = icmp sge i32 %ai, %nargs
+  br i1 %adone, label %args_done, label %argstep
+argstep:
+  %aidx64 = sext i32 %ai to i64
+  %ap = getelementptr %Value, %Value* %args, i64 %aidx64
+  %av = load %Value, %Value* %ap
+  call void @wam_set_reg(%WamState* %vm, i32 %ai, %Value %av)
+  %ai1 = add i32 %ai, 1
+  br label %argloop
+args_done:
+  call void @wam_set_reg(%WamState* %vm, i32 %out_reg, %Value %out_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %walk_init, label %rewind_fail
+walk_init:
+  %consfn = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  %head0 = call %Value @wam_deref_value(%WamState* %vm, %Value %out_ref)
+  br label %walk
+walk:
+  %cur = phi %Value [ %head0, %walk_init ], [ %tail_d, %next ]
+  %pos = phi i64 [ 1, %walk_init ], [ %pos1, %next ]
+  %ctag = call i32 @value_tag(%Value %cur)
+  %is_comp = icmp eq i32 %ctag, 3
+  br i1 %is_comp, label %check_cons, label %walk_done
+check_cons:
+  %cbits = call i64 @value_payload(%Value %cur)
+  %ccp = inttoptr i64 %cbits to %Compound*
+  %cfn_slot = getelementptr %Compound, %Compound* %ccp, i32 0, i32 0
+  %cfn = load i8*, i8** %cfn_slot
+  %car_slot = getelementptr %Compound, %Compound* %ccp, i32 0, i32 1
+  %car = load i32, i32* %car_slot
+  %car_ok = icmp eq i32 %car, 2
+  br i1 %car_ok, label %cmp_cons, label %walk_done
+cmp_cons:
+  %fncmp = call i32 @strcmp(i8* %cfn, i8* %consfn)
+  %is_cons = icmp eq i32 %fncmp, 0
+  br i1 %is_cons, label %have_cell, label %walk_done
+have_cell:
+  %cargs_slot = getelementptr %Compound, %Compound* %ccp, i32 0, i32 2
+  %cargs = load %Value*, %Value** %cargs_slot
+  %h_ptr = getelementptr %Value, %Value* %cargs, i64 0
+  %h_raw = load %Value, %Value* %h_ptr
+  %t_ptr = getelementptr %Value, %Value* %cargs, i64 1
+  %t_raw = load %Value, %Value* %t_ptr
+  %elem = call %Value @wam_deref_value(%WamState* %vm, %Value %h_raw)
+  %etag = call i32 @value_tag(%Value %elem)
+  %e_is_atom = icmp eq i32 %etag, 0
+  br i1 %e_is_atom, label %insert, label %rewind_fail
+insert:
+  %eid = call i64 @value_payload(%Value %elem)
+  %ignored = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %pos, i64 %eid)
   br label %next
 next:
   %pos1 = add i64 %pos, 1

--- a/tests/test_plawk_dyncall_posarray.pl
+++ b/tests/test_plawk_dyncall_posarray.pl
@@ -29,6 +29,14 @@ splitc(X, R) :-
     R2 is N * 100,
     R = [N, R1, R2].
 
+% label a number as a 2-element positional list of ATOMS (str values):
+% a size bucket and a parity tag.
+labelc(X, R) :-
+    atom_number(X, N),
+    ( N > 5 -> Size = big ; Size = small ),
+    ( 0 is N mod 2 -> Parity = even ; Parity = odd ),
+    R = [Size, Parity].
+
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
                            [stdout(null), stderr(null), process(Pid)]),
@@ -112,6 +120,51 @@ test(posarray_forin_rule_body, [condition(clang_available)]) :-
     exclude(==(""), Lines0, Lines),
     msort(Lines, Sorted),
     assertion(Sorted == ["1 2", "2 20", "20", "3 200"]),
+    !.
+
+% `... as array(str)` parses to a dynposarray_bind_str action.
+test(posarray_str_parses) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"lib.wamo\" }\n\c
+         { arr = dyncall@labelc($1) as array(str) }\n\c
+         END { print arr[1], arr[2] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(dynposarray_bind_str(var(arr),
+        dyncall_named(labelc, [field(1)])), Actions),
+    !.
+
+% NAMED entry, str values end to end: a grammar returns a flat list of
+% ATOMS [Size, Parity]; each lands at its position and reads resolve back
+% to text. Last record 8 -> [big, even]; END prints arr[1], arr[2].
+test(posarray_str_named_running, [condition(clang_available)]) :-
+    pa_dir(Dir),
+    directory_file_path(Dir, 'labelc.wamo', Wamo),
+    write_wam_object([user:labelc/2], [wamo_entries([labelc/2])], Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@labelc($1) as array(str) }\n\c
+         END { print arr[1], arr[2] }\n", [Wamo]),
+    build_run(Dir, 'pans', Src, "3\n8\n", Out),
+    assertion(Out == "big even\n"),
+    !.
+
+% for-in over a str-valued positional array: the loop key is the integer
+% position (numeric), the value resolves to text. One record 3 ->
+% [small, odd]; slot order.
+test(posarray_str_forin, [condition(clang_available)]) :-
+    pa_dir(Dir),
+    directory_file_path(Dir, 'labelc.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:labelc/2], [wamo_entries([labelc/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { arr = dyncall@labelc($1) as array(str) ; for (k in arr) print k, arr[k] }\n\c
+         END { print arr[1] }\n", [Wamo]),
+    build_run(Dir, 'pafs', Src, "3\n", Out),
+    split_string(Out, "\n", "", Lines0),
+    exclude(==(""), Lines0, Lines),
+    msort(Lines, Sorted),
+    assertion(Sorted == ["1 small", "2 odd", "small"]),
     !.
 
 :- end_tests(plawk_dyncall_posarray).


### PR DESCRIPTION
Completes the structured-return **container × value-kind matrix**: the positional array now takes string values, the direct parallel to the already-shipped `assoc(str)`.

```awk
arr = dyncall@labelc($1) as array(str)   # grammar returns [Size, Parity] → arr[1], arr[2]
```

A grammar returning a flat `[Atom, …]` list populates a str-valued positional table — `@wam_object_call_posarray_str` stores each element atom's registry id at its position (1-indexed) via `@wam_assoc_i64_set`, and reads (END `arr[1]`, for-in values) resolve the ids back to text through `@wam_atom_to_string`.

## What made this its own dimension

A str-valued positional table is **both** positional-keyed and str-valued, so its array name joins **both** sets:
- the **posarray set** (integer position keys → int-key reads work in text mode, unlike a regular integer-keyed assoc);
- the **str-array set** (values resolve to text on read).

The `posarray_str(...)` spec wrapper rides the shared assoc pipeline exactly as `posarray(...)` does — only the shim name and the runtime walk (Atom elements, tag 0) differ. Two small read-path extensions were needed: the END int-key print gained a str-value branch (mirroring the string-key clause), and the surface check's posarray-name walk now recognizes `dynposarray_bind_str` so its int-key reads are permitted in text mode.

## Changes

- **Parser**: `as array(str)` reuses `dynassoc_value_kind` → `dynposarray_bind_str`.
- **Codegen**: `posarray_str` collectors, action-spec, call-parts, named + default shims, threaded through `plawk_dyncall_support_ir` and the `emit_wamo_loader` gate — parallel to the i64 posarray path. Both plan-level helpers (`plawk_assoc_plan_str_array` / `_posarray_array`) and both spec-level sets (`_str_arrays` / `_posarray_arrays`) now include `posarray_str`.
- **Runtime**: `@wam_object_call_posarray_str` — `call_posarray` with an Atom element check.

## Tests

`tests/test_plawk_dyncall_posarray.pl` gains: str parse, named end-to-end (`["big","even"]`), and for-in over a str positional array (numeric key, text value). **All 9 pass.** Regressions green: `test_plawk_dyncall_assoc` (12), `test_plawk_forin_rule_body` (3), `test_plawk_surface_forin_end_print` (14), `test_plawk_binary_assoc` (11), `test_plawk_union_assoc` (5), `test_plawk_dyncall_struct` (5), `test_plawk_grammar_reader` (4), plus the dyncall base/named suites.

## Docs

`PLAWK_JIT_ROADMAP.md` item 4 and `PLAWK_EVAL_ARCHITECTURE.md` note the completed matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_