### PR TITLE
WAM/LLVM eval: record binds/views inside a foreach loop body (F2 step 2)

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -264,9 +264,20 @@ different plawk containers — this is the through-line for the rest of item 4:
   lowered `dynrec_bind` in any position; the gap was branch-body
   VALIDATION (`plawk_scalar_rule_body_plain_action` did not list the bind
   among a branch's allowed actions), now closed. Test:
-  `tests/test_plawk_dyncall_rec_if.pl`. A view nested in a for-in / foreach
-  loop body is the next step (the loop-body drivers, unlike the scalar-if
-  path, do not yet route through the record-bind emitter).
+  `tests/test_plawk_dyncall_rec_if.pl`.
+  **Binds/views inside a `foreach` loop body LANDED:** a `foreach { ... }`
+  over a record's repetition elements can call a grammar per element and
+  destructure or view the returned record. The foreach body already lowers
+  through the scalar action-sequence walker, so the branch-body validation
+  fix carried it, and the record-view desugar now recurses into `foreach`
+  (and `for_in`) bodies so a view there desugars in place — its block `$k`
+  become the view's hidden temps while the view's Call args (e.g. `$1`
+  passing the current element) ride the later foreach-element rebind. Test:
+  `tests/test_plawk_dyncall_rec_loop.pl` (destructure, view, and
+  view-in-if-in-foreach). The `for (k in arr)` assoc for-in stays
+  print-only by construction (its body is a per-key print plan, not a
+  scalar action sequence), so record binds there remain a separate driver
+  concern.
 - **Associative array** (`arr = dyncall@name(...) as assoc`) — *mechanism +
   surface LANDED (named entry, integer keys).* A grammar returning a list of
   pairs (`[K1-V1, K2-V2, ...]`) materializes into an i64 assoc table via

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -7738,6 +7738,19 @@ plawk_resolve_dynrec_view_action(if(Pattern, Then0, Else0), K0, K,
     !,
     plawk_resolve_dynrec_view_actions(Then0, K0, K1, Then),
     plawk_resolve_dynrec_view_actions(Else0, K1, K, Else).
+% A view nested in a loop body: recurse so its `$k` rewrite happens
+% wherever the view sits. `foreach` runs before its own foreach-resolve
+% pass (which rebinds a naked `$k` to the current element), so a view's
+% block `$k` become the view's hidden temps here and only unrewritten
+% `$k` reach the element rebind -- and the view's Call args (e.g. `$1`
+% passing the current element into the grammar) are left for that pass.
+plawk_resolve_dynrec_view_action(foreach(Body0), K0, K, [foreach(Body)]) :-
+    !,
+    plawk_resolve_dynrec_view_actions(Body0, K0, K, Body).
+plawk_resolve_dynrec_view_action(for_in(V, A, Body0), K0, K,
+        [for_in(V, A, Body)]) :-
+    !,
+    plawk_resolve_dynrec_view_actions(Body0, K0, K, Body).
 plawk_resolve_dynrec_view_action(Action, K, K, [Action]).
 
 %% plawk_dynrec_view_specs(+K, +I, +Types, -Bindings, -FieldTargets)

--- a/tests/test_plawk_dyncall_rec_loop.pl
+++ b/tests/test_plawk_dyncall_rec_loop.pl
@@ -1,0 +1,143 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Structured-return record binds/views inside a LOOP body -- the second
+% step of routing record binds through every block body (if-branches
+% were the first). A `foreach { ... }` over a record's repetition
+% elements can call a grammar per element and destructure or view the
+% returned record: the foreach body already lowers through the scalar
+% action-sequence walker (which handles dynrec_bind), so once branch/loop
+% body VALIDATION accepts the bind and the record-view desugar recurses
+% into the loop body, both surfaces compile.
+%
+% (`for (k in arr)` -- the assoc for-in -- stays print-only by
+% construction: its body is a per-key print plan, not a scalar action
+% sequence, so record binds there remain a separate driver concern.)
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammar object: rec(X) -> pair(X, X+1)
+recp(X, pair(X, Y)) :- Y is X + 1.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_rec_loop).
+
+% The record-view desugar now recurses into foreach bodies: a view there
+% becomes a hidden destructure + rewritten block, both inside the loop.
+test(view_in_foreach_desugars) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64 rep4(i64)\" ; DYNLOAD = \"l.wamo\" }\n\c
+         { foreach { dyncall@recp($1) as (i64 i64) { total += $1 } } }\n\c
+         END { print total }\n",
+        program(_, Rules0, _)),
+    plawk_native_codegen:plawk_resolve_dynrec_view_rules(Rules0, Rules),
+    Rules = [rule(_, [foreach(Body)])],
+    assertion(memberchk(dynrec_bind(_, dyncall_named(recp, [field(1)]), _),
+        Body)),
+    assertion(\+ ( member(A, Body), A = dynrec_view(_, _, _) )),
+    !.
+
+% Destructure inside foreach, end to end. rep elements 10, 20, 30;
+% recp(X) = pair(X, X+1); total += n(=X) -> 60.
+test(destructure_in_foreach_runs, [condition(clang_available)]) :-
+    rl_dir(Dir),
+    directory_file_path(Dir, 'recp.wamo', Wamo),
+    write_wam_object([user:recp/2], [wamo_entries([recp/2])], Wamo),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 rep4(i64)\" ; DYNLOAD = \"~w\" }\n\c
+         { foreach { (n, m) = dyncall@recp($1) as (i64 i64) ; total += n } }\n\c
+         END { print total }\n", [Wamo]),
+    build_run_rep(Dir, 'rld', Src, [1, 3, 10, 20, 30], "60\n"),
+    !.
+
+% Record VIEW inside foreach: total sums $1 (=X), s sums $2 (=X+1).
+% elements 10, 20, 30 -> total 60, s 11+21+31 = 63.
+test(view_in_foreach_runs, [condition(clang_available)]) :-
+    rl_dir(Dir),
+    directory_file_path(Dir, 'recp.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:recp/2], [wamo_entries([recp/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 rep4(i64)\" ; DYNLOAD = \"~w\" }\n\c
+         { foreach { dyncall@recp($1) as (i64 i64) { total += $1 ; s += $2 } } }\n\c
+         END { print total, s }\n", [Wamo]),
+    build_run_rep(Dir, 'rlv', Src, [1, 3, 10, 20, 30], "60 63\n"),
+    !.
+
+% Combined: a view inside an if inside foreach -- the desugar recurses
+% through both, and the per-element guard selects which elements view.
+% elements 10, 20, 30; guard $1 > 15 keeps 20, 30; total = 20 + 30 = 50.
+test(view_in_if_in_foreach_runs, [condition(clang_available)]) :-
+    rl_dir(Dir),
+    directory_file_path(Dir, 'recp.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:recp/2], [wamo_entries([recp/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 rep4(i64)\" ; DYNLOAD = \"~w\" }\n\c
+         { foreach { if ($1 > 15) { dyncall@recp($1) as (i64 i64) { total += $1 } } } }\n\c
+         END { print total }\n", [Wamo]),
+    build_run_rep(Dir, 'rliv', Src, [1, 3, 10, 20, 30], "50\n"),
+    !.
+
+:- end_tests(plawk_dyncall_rec_loop).
+
+% --- helpers ---------------------------------------------------------------
+
+rl_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_rec_loop', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Text) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text), close(Out)).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% one record: a flat i64 sequence [id, count, elem1, ...] for
+% BINFMT "i64 rep4(i64)".
+write_rep_record(Path, Words) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(V, Words), write_i64_le(Out, V)),
+        close(Out)).
+
+build_run_rep(Dir, Name, Src, Words, Expected) :-
+    write_prog(Dir, Name, Src),
+    directory_file_path(Dir, Name, Prog),
+    atom_concat(Prog, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog, '_in.bin', Input),
+    write_rep_record(Input, Words),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == Expected).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
Second step of routing record binds through every block body (full lift, option A). Stacked on #3658 (if-branches), which is stacked on #3657 (F1).

A `foreach { ... }` over a record's repetition elements can now call a grammar per element and destructure or view the returned record:

```awk
{ foreach { (n, m) = dyncall@recp($1) as (i64 i64) ; total += n } }
{ foreach { dyncall@recp($1) as (i64 i64) { total += $1 ; s += $2 } } }
```

## How it fell out

The foreach body already lowers through the scalar action-sequence walker (which handles `dynrec_bind`), so the branch-body validation fix from #3658 carried the **destructure** case for free. The **view** case needed one more thing: the record-view desugar recursed only into if-branches, so a view inside `foreach` stayed an undesugared `dynrec_view` that the body validator rejected. Extended the desugar to recurse into `foreach` (and `for_in`) bodies.

The ordering works out: the view desugar runs *before* the foreach-element resolve pass, so a view's block `$k` become its hidden temps here, while the view's Call args (e.g. `$1` passing the current element into the grammar) are left untouched for the element rebind — exactly the behavior the destructure-in-foreach case already demonstrated.

## Tests — `tests/test_plawk_dyncall_rec_loop.pl`

- desugar: a view in a foreach body desugars in place to a `dynrec_bind` + rewritten block;
- destructure in foreach, end to end (elements 10,20,30 → `60`);
- view in foreach (`$1`+`$2` → `60 63`);
- a view nested in an `if` inside `foreach` (per-element guard `$1>15` → `50`).

Regressions green: `test_plawk_bounded_rep` (8), `test_plawk_dyncall_record_view` (7), `test_plawk_dyncall_rec_if` (4), `test_plawk_rep_strings` (7).

## Scope boundary

The `for (k in arr)` **assoc for-in** stays print-only by construction — its body is a per-key print plan, not a scalar action sequence — so record binds there would need a separate assoc-driver generalization, documented as a distinct concern rather than folded in here. This PR covers the loop body that *is* a scalar action sequence (`foreach`), which is the substantive "record bind/view in a loop body" capability. Docs: `PLAWK_JIT_ROADMAP.md` item 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_