### PR TITLE
feat(kotlin-wam): deterministic single-clause lowered emitter (EMIT-KOTLIN)

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -49,7 +49,8 @@ self-contained so a single coding agent can pick it up in isolation.
 | KERN-FSHARP | Finish F# kernel templates | F# | L | — |
 | EMIT-ILASM | Lowered emitter | ILAsm | L | — |
 | EMIT-JVM | Lowered emitter | JVM | L | — |
-| EMIT-KOTLIN ⭐ | Lowered emitter | Kotlin | M | — | **done** (`cursor/emit-kotlin-lowered-f421`) |
+| EMIT-KOTLIN ✅ | Lowered emitter | Kotlin | M | done — flat facts/unify (`cursor/emit-kotlin-lowered-f421`) |
+| EMIT-KOTLIN-2 | Lowered emitter (structures) | Kotlin | M | EMIT-KOTLIN |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |
 | BENCH-C | Effective-distance bench row | C | M | — |
@@ -490,7 +491,7 @@ fallback) to the three Tier-D targets. Reference small emitters:
 
 ### EMIT-KOTLIN: Add Kotlin WAM-lowered emitter (deterministic clause-1 native dispatch)
 - **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** —
-- **Status:** ✅ **Done** on branch `cursor/emit-kotlin-lowered-f421` (2026-07-12) — deterministic single-clause lowered emitter + `registerNative` runtime seam landed; T4/T5/ITE deferred as follow-up cards. Historical context below retained for future implementers.
+- **Status:** ✅ **Landed (narrowed)** on `cursor/emit-kotlin-lowered-f421` (2026-07-12). The `registerNative` runtime seam + native-first dispatch with interpreter fallback shipped and work. **Correctness caveat found in review:** write-mode structure/list construction lowered to unbound vars (silent wrong answer, returned `true` so fallback never fired). Fix narrows the lowerable set to **flat facts + register unification only** (`get/put_constant|integer|nil`, `get_variable`, `get_value`, `put_variable`, `put_value`); any predicate that constructs or unifies a structure/list declines and stays on the correct bytecode interpreter. See follow-up **EMIT-KOTLIN-2**. Historical context below retained.
 
 **Context — read this first (verified against source 2026-07-11).** The Kotlin target is NOT missing its partition. `wam_kotlin_target.pl` already ships:
 - `wam_kotlin_resolve_emit_mode/2` (`interpreter` | `functions` | `mixed(List)`) — lines 57–69; default `interpreter`.
@@ -529,6 +530,19 @@ fallback) to the three Tier-D targets. Reference small emitters:
   5. Extend `tests/test_wam_kotlin_target.pl`: a unit test asserting a `functions`-mode project for a single-clause predicate emits a real `fun …(state: WamState)` + `registerNative` (NOT `/* Native Kotlin lowering selected`), and — under `[condition(gradle_available)]` — a gradle `run` of that predicate producing the same result as the interpreter path (compare against an `emit_mode(interpreter)` run of the same predicate).
 - **Acceptance:** `swipl -q -g run_tests -t halt tests/test_wam_kotlin_target.pl` passes including the new native-dispatch cases; the existing interpreter gradle test still passes; a `functions`-mode single-clause predicate is now actually runnable (native), and a non-lowerable predicate still round-trips through the WAM interpreter.
 - **Out of scope / follow-ups (leave as new cards):** T4/T5/ITE/multi-clause Kotlin lowering; deciding whether to also surface `kotlin_target.pl`'s non-WAM native output through this seam.
+
+### EMIT-KOTLIN-2: Lower write-mode structure/list construction (Kotlin)
+- **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN
+- **Goal:** Extend the Kotlin lowered emitter to correctly build structures/lists in the head (write mode), then re-enable those ops in `parts_supported` so predicates like `p(X, wrap(X))` / `p(X,Y,[X,Y])` lower instead of declining to the interpreter.
+- **Why deferred:** EMIT-KOTLIN's first cut lowered `put_structure`/`put_list`/`set_*`/`unify_*` incorrectly — write-mode arg pushes read the register *before* the head variable was bound, so the built term contained unbound vars (e.g. `kt_make_list(X,Y,[X,Y])` with `alpha beta` produced `[X1,X2]` not `[alpha,beta]`), and the lowered fn returned `true` so the interpreter fallback never fired. The fix narrowed the lowerable set; this card does it properly.
+- **Files to touch:** `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl` (re-add the `parts_supported/1` facts for `get/put_structure`, `get/put_list`, `set_*`, `unify_*`; fix `emit_line_parts/2` for the write-mode ops), `templates/targets/kotlin_wam/WamRuntime.kt.mustache` (the `kotlinLoUnify*` helpers + `pushWriteArg`/`beginStructure*` already exist — audit their read-vs-write-mode contract), `tests/test_wam_kotlin_target.pl`.
+- **Reference to copy from:** the WAM-register interpreter already in `WamRuntime.kt.mustache` (`beginStructure`/`beginStructurePut`/`pushWriteArg`/`nextReadArg`, and the main `run` loop's handling of `get_structure`/`unify_*`) — the lowered emit must reproduce exactly that read/write-mode sequencing. Lua's `wam_lua_lowered_emitter.pl` structure handling is the cross-target analog.
+- **Steps:**
+  1. Reproduce the bug: generate `kt_make_list/3` under `emit_mode(functions)`, gradle-run `kt_make_list/3 alpha beta`, confirm `A3` has unbound vars.
+  2. Fix the emitted write-mode sequence so head-variable bindings are visible before the arg push (mirror the interpreter's ordering; likely the `set_value`/`unify_value` register read must deref through the just-bound register, and `get_variable` must bind before any subsequent `put_structure`).
+  3. Re-add the declined `parts_supported/1` facts; keep the read-mode path (which already worked) intact.
+  4. Add gradle e2e tests asserting lowered output == interpreter output for a structure builder AND a list builder (the regression tests added in EMIT-KOTLIN already assert the *decline* path; convert/extend them to assert the *lowered* path once fixed).
+- **Acceptance:** `swipl -q -g run_tests -t halt tests/test_wam_kotlin_target.pl` passes with structure/list predicates lowering (not declining) and producing bindings identical to `emit_mode(interpreter)`.
 
 ---
 

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -490,7 +490,7 @@ fallback) to the three Tier-D targets. Reference small emitters:
 
 ### EMIT-KOTLIN: Add Kotlin WAM-lowered emitter (deterministic clause-1 native dispatch)
 - **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** —
-- **Status:** ⭐ **In progress** on branch `cursor/emit-kotlin-lowered-f421` — deterministic single-clause lowered emitter + `registerNative` runtime seam landed; T4/T5/ITE deferred.
+- **Status:** ✅ **Done** on branch `cursor/emit-kotlin-lowered-f421` (2026-07-12) — deterministic single-clause lowered emitter + `registerNative` runtime seam landed; T4/T5/ITE deferred as follow-up cards. Historical context below retained for future implementers.
 
 **Context — read this first (verified against source 2026-07-11).** The Kotlin target is NOT missing its partition. `wam_kotlin_target.pl` already ships:
 - `wam_kotlin_resolve_emit_mode/2` (`interpreter` | `functions` | `mixed(List)`) — lines 57–69; default `interpreter`.

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -49,7 +49,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | KERN-FSHARP | Finish F# kernel templates | F# | L | — |
 | EMIT-ILASM | Lowered emitter | ILAsm | L | — |
 | EMIT-JVM | Lowered emitter | JVM | L | — |
-| EMIT-KOTLIN ⭐ | Lowered emitter | Kotlin | M | — (recommended first task) — **in progress** (`cursor/emit-kotlin-lowered-f421`) |
+| EMIT-KOTLIN ⭐ | Lowered emitter | Kotlin | M | — | **done** (`cursor/emit-kotlin-lowered-f421`) |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |
 | BENCH-C | Effective-distance bench row | C | M | — |

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -49,7 +49,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | KERN-FSHARP | Finish F# kernel templates | F# | L | — |
 | EMIT-ILASM | Lowered emitter | ILAsm | L | — |
 | EMIT-JVM | Lowered emitter | JVM | L | — |
-| EMIT-KOTLIN ⭐ | Lowered emitter | Kotlin | M | — (recommended first task) |
+| EMIT-KOTLIN ⭐ | Lowered emitter | Kotlin | M | — (recommended first task) — **in progress** (`cursor/emit-kotlin-lowered-f421`) |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |
 | BENCH-C | Effective-distance bench row | C | M | — |
@@ -490,7 +490,7 @@ fallback) to the three Tier-D targets. Reference small emitters:
 
 ### EMIT-KOTLIN: Add Kotlin WAM-lowered emitter (deterministic clause-1 native dispatch)
 - **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** —
-- **Status:** ⭐ **First hand-off — fully scoped below.** Lowest-risk target: least mature, and the plumbing already exists.
+- **Status:** ⭐ **In progress** on branch `cursor/emit-kotlin-lowered-f421` — deterministic single-clause lowered emitter + `registerNative` runtime seam landed; T4/T5/ITE deferred.
 
 **Context — read this first (verified against source 2026-07-11).** The Kotlin target is NOT missing its partition. `wam_kotlin_target.pl` already ships:
 - `wam_kotlin_resolve_emit_mode/2` (`interpreter` | `functions` | `mixed(List)`) — lines 57–69; default `interpreter`.

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -31,16 +31,20 @@ module in the fleet.
 - **Gradle e2e** hook — the test suite includes a Gradle end-to-end
   path when the toolchain is available.
 - **WAM-lowered native dispatch (first cut):** `wam_kotlin_lowered_emitter.pl`
-  lowers deterministic single-clause predicates to `fun (state: WamState): Boolean`,
-  registered via `WamProgram.registerNative`. `WamRuntime.run` tries native
-  first and falls back to the bytecode interpreter on `false` (WAT-style snapshot
-  restore). `functions` / `mixed` modes route lowerable preds through this path;
-  everything else stays on the interpreter registrars.
+  lowers **flat single-clause facts + register unification** (no structure/list
+  construction — see below) to `fun (state: WamState): Boolean`, registered via
+  `WamProgram.registerNative`. `WamRuntime.run` tries native first and falls back
+  to the bytecode interpreter on `false` (WAT-style snapshot restore). `functions`
+  / `mixed` modes route lowerable preds through this path; everything else
+  (including any structure/list builder) stays on the interpreter registrars.
 
 ## Gaps
 
-- **Lowered emitter scope** — only deterministic single-clause facts/simple
-  rules; no T4/T5 multi-clause, ITE, or `call`/`execute` in lowered bodies.
+- **Lowered emitter scope** — only flat single-clause facts + register
+  unification. Structure/list **construction** was silently wrong in the first
+  cut (unbound vars in the result) and now declines to the interpreter; fixing it
+  is follow-up **EMIT-KOTLIN-2**. No T4/T5 multi-clause, ITE, or `call`/`execute`
+  in lowered bodies.
 - **No foreign kernels, no LMDB / fact source, no ISO contract.**
 - **No conformance registration** — no `conformance_target(kotlin)`.
 - **No runtime-parser capability entry.**

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -22,31 +22,36 @@ module in the fleet.
 | Module | Approx. lines |
 |---|---:|
 | `src/unifyweaver/targets/wam_kotlin_target.pl` | ~0.5k |
-| Lowered emitter | none |
-| Dedicated tests | ~1 file (~9 plunit cases, incl. Gradle e2e when available) |
+| `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl` | ~0.3k (deterministic single-clause) |
+| Dedicated tests | ~1 file (~12 plunit cases, incl. Gradle e2e when available) |
 
 ## What's shipped
 
 - **Hybrid partition** emit with a WAM fallback.
 - **Gradle e2e** hook — the test suite includes a Gradle end-to-end
   path when the toolchain is available.
+- **WAM-lowered native dispatch (first cut):** `wam_kotlin_lowered_emitter.pl`
+  lowers deterministic single-clause predicates to `fun (state: WamState): Boolean`,
+  registered via `WamProgram.registerNative`. `WamRuntime.run` tries native
+  first and falls back to the bytecode interpreter on `false` (WAT-style snapshot
+  restore). `functions` / `mixed` modes route lowerable preds through this path;
+  everything else stays on the interpreter registrars.
 
 ## Gaps
 
-- **No lowered emitter** (partition logic lives in the target).
+- **Lowered emitter scope** — only deterministic single-clause facts/simple
+  rules; no T4/T5 multi-clause, ITE, or `call`/`execute` in lowered bodies.
 - **No foreign kernels, no LMDB / fact source, no ISO contract.**
 - **No conformance registration** — no `conformance_target(kotlin)`.
 - **No runtime-parser capability entry.**
 
 ## Path forward
 
-1. Decide whether Kotlin earns investment given Scala/Clojure already
-   cover the JVM maturely.
-2. Add a lowered emitter and conformance adapter if it graduates.
+1. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
+2. Add conformance adapter if Kotlin graduates beyond scaffold.
 
 ## Document status
 
-Fleet-aligned snapshot; source-verified line count, the
-hybrid-partition + Gradle-e2e shape, ~9-case density, and absence of
-conformance registration against `wam_kotlin_target.pl` and the
-conformance harness (2026-07-11).
+Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
+`wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
+(2026-07-12).

--- a/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
@@ -59,6 +59,10 @@ line_supported(Line) :-
     ;   parts_supported(Parts)
     ).
 
+% NOTE: structure/list construction (get_structure/get_list/put_structure/
+% put_list/set_*/unify_*) is intentionally NOT lowerable in this first cut:
+% write-mode term building was silently wrong (unbound vars in the result).
+% Such predicates decline and stay on the correct bytecode interpreter.
 parts_supported(["allocate"]).
 parts_supported(["deallocate"]).
 parts_supported(["proceed"]).
@@ -66,26 +70,13 @@ parts_supported(["fail"]).
 parts_supported(["get_constant", _, _]).
 parts_supported(["get_variable", _, _]).
 parts_supported(["get_value", _, _]).
-parts_supported(["get_structure", _, _]).
-parts_supported(["get_list", _]).
 parts_supported(["get_nil", _]).
 parts_supported(["get_integer", _, _]).
 parts_supported(["put_constant", _, _]).
 parts_supported(["put_variable", _, _]).
 parts_supported(["put_value", _, _]).
-parts_supported(["put_structure", _, _]).
-parts_supported(["put_list", _]).
 parts_supported(["put_nil", _]).
 parts_supported(["put_integer", _, _]).
-parts_supported(["unify_variable", _]).
-parts_supported(["unify_value", _]).
-parts_supported(["unify_constant", _]).
-parts_supported(["unify_nil"]).
-parts_supported(["set_variable", _]).
-parts_supported(["set_value", _]).
-parts_supported(["set_constant", _]).
-parts_supported(["set_nil"]).
-parts_supported(["set_integer", _]).
 
 kotlin_lowered_func_name(Functor/Arity, Name) :-
     atom_string(Functor, S),

--- a/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
@@ -1,0 +1,256 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+
+:- module(wam_kotlin_lowered_emitter, [
+    wam_kotlin_lowerable/3,
+    lower_predicate_to_kotlin/4,
+    kotlin_lowered_func_name/2
+]).
+
+:- use_module(library(lists)).
+:- use_module(wam_text_parser, [wam_classify_constant_token/2]).
+
+build_emission_plan(WamCode, plan(deterministic, none, ClauseLines)) :-
+    atom_string(WamCode, S),
+    split_string(S, "\n", "", Lines),
+    skip_to_first_real_instr(Lines, Filtered),
+    deterministic_single_clause(Filtered, ClauseLines).
+
+skip_to_first_real_instr([], []).
+skip_to_first_real_instr([Line|Rest], Out) :-
+    wam_kotlin_target:tokenize_wam_line(Line, Parts),
+    (   skippable_prefix_line(Parts)
+    ->  skip_to_first_real_instr(Rest, Out)
+    ;   Out = [Line|Rest]
+    ).
+
+skippable_prefix_line([]).
+skippable_prefix_line([First|_]) :- sub_string(First, _, 1, 0, ":").
+skippable_prefix_line(["switch_on_constant"|_]).
+skippable_prefix_line(["switch_on_constant_a2"|_]).
+skippable_prefix_line(["switch_on_structure"|_]).
+skippable_prefix_line(["switch_on_term"|_]).
+
+deterministic_single_clause(Lines, Lines) :-
+    \+ has_unsupported_shape(Lines),
+    forall(member(Line, Lines), line_supported(Line)).
+
+has_unsupported_shape(Lines) :-
+    member(Line, Lines),
+    wam_kotlin_target:tokenize_wam_line(Line, Parts),
+    unsupported_shape_parts(Parts).
+
+unsupported_shape_parts(["try_me_else"|_]).
+unsupported_shape_parts(["retry_me_else"|_]).
+unsupported_shape_parts(["trust_me"]).
+unsupported_shape_parts(["cut_ite"]).
+unsupported_shape_parts(["jump"|_]).
+
+wam_kotlin_lowerable(_PI, WamCode, deterministic) :-
+    catch(build_emission_plan(WamCode, plan(deterministic, _, Payload)), _, fail),
+    forall(member(Line, Payload), line_supported(Line)).
+
+line_supported(Line) :-
+    wam_kotlin_target:tokenize_wam_line(Line, Parts),
+    (   Parts == []
+    ->  true
+    ;   Parts = [F|_], sub_string(F, _, 1, 0, ":")
+    ->  true
+    ;   parts_supported(Parts)
+    ).
+
+parts_supported(["allocate"]).
+parts_supported(["deallocate"]).
+parts_supported(["proceed"]).
+parts_supported(["fail"]).
+parts_supported(["get_constant", _, _]).
+parts_supported(["get_variable", _, _]).
+parts_supported(["get_value", _, _]).
+parts_supported(["get_structure", _, _]).
+parts_supported(["get_list", _]).
+parts_supported(["get_nil", _]).
+parts_supported(["get_integer", _, _]).
+parts_supported(["put_constant", _, _]).
+parts_supported(["put_variable", _, _]).
+parts_supported(["put_value", _, _]).
+parts_supported(["put_structure", _, _]).
+parts_supported(["put_list", _]).
+parts_supported(["put_nil", _]).
+parts_supported(["put_integer", _, _]).
+parts_supported(["unify_variable", _]).
+parts_supported(["unify_value", _]).
+parts_supported(["unify_constant", _]).
+parts_supported(["unify_nil"]).
+parts_supported(["set_variable", _]).
+parts_supported(["set_value", _]).
+parts_supported(["set_constant", _]).
+parts_supported(["set_nil"]).
+parts_supported(["set_integer", _]).
+
+kotlin_lowered_func_name(Functor/Arity, Name) :-
+    atom_string(Functor, S),
+    string_codes(S, Codes),
+    maplist(kotlin_safe_code, Codes, Safe),
+    string_codes(SafeS, Safe),
+    format(atom(Name), 'lowered_~w_~w', [SafeS, Arity]).
+
+kotlin_safe_code(C, C) :-
+    (C >= 0'a, C =< 0'z ; C >= 0'A, C =< 0'Z ; C >= 0'0, C =< 0'9 ; C =:= 0'_), !.
+kotlin_safe_code(_, 0'_).
+
+lower_predicate_to_kotlin(PI, WamCode, _Options, lowered(PredName, FuncName, Code)) :-
+    (PI = _M:Pred/Arity -> true ; PI = Pred/Arity),
+    format(atom(PredName), '~w/~w', [Pred, Arity]),
+    kotlin_lowered_func_name(Pred/Arity, FuncName),
+    build_emission_plan(WamCode, plan(deterministic, _, Payload)),
+    emit_deterministic_function(PredName, FuncName, Payload, Code).
+
+emit_deterministic_function(PredName, FuncName, Lines, Code) :-
+    with_output_to(string(Body), emit_lines(Lines, "    ")),
+    format(string(Code),
+'// Lowered: ~w (deterministic single-clause)
+fun ~w(state: WamState): Boolean {
+~w    return true
+}
+', [PredName, FuncName, Body]).
+
+emit_lines([], _).
+emit_lines([Line|Rest], Ind) :-
+    wam_kotlin_target:tokenize_wam_line(Line, Parts),
+    (   Parts == [] -> true
+    ;   Parts = [F|_], sub_string(F, _, 1, 0, ":") -> true
+    ;   emit_line_parts(Parts, Ind)
+    ),
+    emit_lines(Rest, Ind).
+
+emit_line_parts(["proceed"], I) :- !, format("~w// proceed~n", [I]).
+emit_line_parts(["fail"], I) :- !, format("~wreturn false~n", [I]).
+emit_line_parts(["allocate"], I) :- !,
+    format("~wstate.allocateEnvironment()~n", [I]).
+emit_line_parts(["deallocate"], I) :- !,
+    format("~wstate.deallocateEnvironment()~n", [I]).
+emit_line_parts(["get_constant", C, R], I) :- !,
+    kotlin_constant_expr(C, Expr),
+    kotlin_register_lit(R, RL),
+    format("~wif (!kotlinLoGetConstant(state, ~w, ~w)) return false~n", [I, Expr, RL]).
+emit_line_parts(["get_integer", C, R], I) :- !,
+    kotlin_constant_expr(C, Expr),
+    kotlin_register_lit(R, RL),
+    format("~wif (!kotlinLoGetConstant(state, ~w, ~w)) return false~n", [I, Expr, RL]).
+emit_line_parts(["get_nil", R], I) :- !,
+    kotlin_register_lit(R, RL),
+    format("~wif (!kotlinLoGetConstant(state, Value.Atom(\"[]\"), ~w)) return false~n", [I, RL]).
+emit_line_parts(["get_variable", X, A], I) :- !,
+    kotlin_register_lit(X, XL), kotlin_register_lit(A, AL),
+    format("~w{~n", [I]),
+    format("~w    val v = state.deref(state.readRegister(~w)) ?: state.newVariable(~w)~n", [I, AL, XL]),
+    format("~w    state.writeRegister(~w, v)~n", [I, XL]),
+    format("~w    state.writeRegister(~w, v)~n", [I, AL]),
+    format("~w}~n", [I]).
+emit_line_parts(["get_value", X, A], I) :- !,
+    kotlin_register_lit(X, XL), kotlin_register_lit(A, AL),
+    format("~wif (!kotlinLoGetValue(state, ~w, ~w)) return false~n", [I, XL, AL]).
+emit_line_parts(["get_structure", F, R], I) :- !,
+    kotlin_register_lit(R, RL),
+    kotlin_string_lit(F, FL),
+    format("~wif (!state.beginStructure(~w, ~w)) return false~n", [I, FL, RL]).
+emit_line_parts(["get_list", R], I) :- !,
+    kotlin_register_lit(R, RL),
+    format("~wif (!state.beginStructure(\"[|]/2\", ~w)) return false~n", [I, RL]).
+emit_line_parts(["put_constant", C, R], I) :- !,
+    kotlin_constant_expr(C, Expr),
+    kotlin_register_lit(R, RL),
+    format("~wstate.writeRegister(~w, ~w)~n", [I, RL, Expr]).
+emit_line_parts(["put_integer", C, R], I) :- !,
+    kotlin_constant_expr(C, Expr),
+    kotlin_register_lit(R, RL),
+    format("~wstate.writeRegister(~w, ~w)~n", [I, RL, Expr]).
+emit_line_parts(["put_nil", R], I) :- !,
+    kotlin_register_lit(R, RL),
+    format("~wstate.writeRegister(~w, Value.Atom(\"[]\"))~n", [I, RL]).
+emit_line_parts(["put_variable", X, A], I) :- !,
+    kotlin_register_lit(X, XL), kotlin_register_lit(A, AL),
+    format("~w{~n", [I]),
+    format("~w    val v = state.newVariable(~w)~n", [I, XL]),
+    format("~w    state.writeRegister(~w, v)~n", [I, XL]),
+    format("~w    state.writeRegister(~w, v)~n", [I, AL]),
+    format("~w}~n", [I]).
+emit_line_parts(["put_value", X, A], I) :- !,
+    kotlin_register_lit(X, XL), kotlin_register_lit(A, AL),
+    format("~wstate.writeRegister(~w, state.deref(state.readRegister(~w)))~n", [I, AL, XL]).
+emit_line_parts(["put_structure", F, R], I) :- !,
+    kotlin_register_lit(R, RL),
+    kotlin_string_lit(F, FL),
+    format("~wif (!state.beginStructurePut(~w, ~w)) return false~n", [I, FL, RL]).
+emit_line_parts(["put_list", R], I) :- !,
+    kotlin_register_lit(R, RL),
+    format("~wif (!state.beginStructurePut(\"[|]/2\", ~w)) return false~n", [I, RL]).
+emit_line_parts(["set_variable", X], I) :- !,
+    kotlin_register_lit(X, XL),
+    format("~wif (!state.pushWriteArg(state.newVariable(~w))) return false~n", [I, XL]).
+emit_line_parts(["set_value", X], I) :- !,
+    kotlin_register_lit(X, XL),
+    format("~wif (!state.pushWriteArg(state.deref(state.readRegister(~w)))) return false~n", [I, XL]).
+emit_line_parts(["set_constant", C], I) :- !,
+    kotlin_constant_expr(C, Expr),
+    format("~wif (!state.pushWriteArg(~w)) return false~n", [I, Expr]).
+emit_line_parts(["set_nil"], I) :- !,
+    format("~wif (!state.pushWriteArg(Value.Atom(\"[]\"))) return false~n", [I]).
+emit_line_parts(["set_integer", C], I) :- !,
+    kotlin_constant_expr(C, Expr),
+    format("~wif (!state.pushWriteArg(~w)) return false~n", [I, Expr]).
+emit_line_parts(["unify_variable", X], I) :- !,
+    kotlin_register_lit(X, XL),
+    format("~wif (!kotlinLoUnifyVariable(state, ~w)) return false~n", [I, XL]).
+emit_line_parts(["unify_value", X], I) :- !,
+    kotlin_register_lit(X, XL),
+    format("~wif (!kotlinLoUnifyValue(state, ~w)) return false~n", [I, XL]).
+emit_line_parts(["unify_constant", C], I) :- !,
+    kotlin_constant_expr(C, Expr),
+    format("~wif (!kotlinLoUnifyConstant(state, ~w)) return false~n", [I, Expr]).
+emit_line_parts(["unify_nil"], I) :- !,
+    format("~wif (!kotlinLoUnifyConstant(state, Value.Atom(\"[]\"))) return false~n", [I]).
+
+kotlin_register_lit(Reg, Lit) :-
+    atom_string_like(Reg, S),
+    escape_kotlin_string(S, Esc),
+    format(string(Lit), '"~w"', [Esc]).
+
+kotlin_string_lit(Atom, Lit) :-
+    atom_string_like(Atom, S),
+    escape_kotlin_string(S, Esc),
+    format(string(Lit), '"~w"', [Esc]).
+
+kotlin_constant_expr(Token, Expr) :-
+    wam_classify_constant_token(Token, Class),
+    (   Class = integer(N)
+    ->  format(string(Expr), 'Value.IntVal(~wL)', [N])
+    ;   Class = float(F)
+    ->  format(string(Expr), 'Value.FloatVal(~w)', [F])
+    ;   Class = atom(Name)
+    ->  escape_kotlin_string(Name, Esc),
+        format(string(Expr), 'Value.Atom("~w")', [Esc])
+    ).
+
+atom_string_like(Value, String) :-
+    string(Value), !, String = Value.
+atom_string_like(Value, String) :-
+    atom(Value), !, atom_string(Value, String).
+atom_string_like(Value, String) :-
+    number(Value), !, number_string(Value, String).
+atom_string_like(Value, String) :-
+    term_string(Value, String).
+
+escape_kotlin_string(Input, Escaped) :-
+    atom_string_like(Input, S),
+    string_chars(S, Chars),
+    phrase(escaped_chars(Chars), OutChars),
+    string_chars(Escaped, OutChars).
+
+escaped_chars([]) --> [].
+escaped_chars(['\\'|Cs]) --> ['\\','\\'], escaped_chars(Cs).
+escaped_chars(['"'|Cs]) --> ['\\','"'], escaped_chars(Cs).
+escaped_chars(['\n'|Cs]) --> ['\\','n'], escaped_chars(Cs).
+escaped_chars(['\r'|Cs]) --> ['\\','r'], escaped_chars(Cs).
+escaped_chars(['\t'|Cs]) --> ['\\','t'], escaped_chars(Cs).
+escaped_chars([C|Cs]) --> [C], escaped_chars(Cs).

--- a/src/unifyweaver/targets/wam_kotlin_target.pl
+++ b/src/unifyweaver/targets/wam_kotlin_target.pl
@@ -35,6 +35,15 @@
     wam_classify_constant_token/2
 ]).
 :- use_module('../core/template_system', [render_template/3]).
+:- use_module('../targets/wam_kotlin_lowered_emitter', [
+    wam_kotlin_lowerable/3,
+    lower_predicate_to_kotlin/4,
+    kotlin_lowered_func_name/2
+]).
+
+% Compatibility wrapper for the lowered emitter (rules live in wam_text_parser).
+tokenize_wam_line(Line, Tokens) :-
+    wam_tokenize_line(Line, Tokens).
 
 % ============================================================================
 % Public hybrid entry points
@@ -81,17 +90,17 @@ partition_predicates_([], _Mode, Native, Native, Wam, Wam, Failed, Failed).
 partition_predicates_([Spec|Rest], Mode, Native0, Native, Wam0, Wam, Failed0, Failed) :-
     pi_parts(Spec, Module, Pred, Arity),
     PI = Pred/Arity,
-    (   should_attempt_native(Mode, PI),
-        catch(kotlin_target:compile_predicate_to_kotlin(Module:PI,
-                [include_main(false)], NativeCode), _, fail),
-        \+ native_code_is_stub(NativeCode)
-    ->  Native1 = [native(PI, NativeCode)|Native0],
-        Wam1 = Wam0,
-        Failed1 = Failed0
-    ;   catch(compile_predicate_to_wam(Module:PI, [], WamText), _, fail)
-    ->  Native1 = Native0,
-        Wam1 = [wam(PI, WamText)|Wam0],
-        Failed1 = Failed0
+  ( catch(compile_predicate_to_wam(Module:PI, [], WamText), _, fail)
+    ->  (   should_attempt_native(Mode, PI),
+            catch(wam_kotlin_lowerable(Module:PI, WamText, _), _, fail),
+            catch(lower_predicate_to_kotlin(Module:PI, WamText, [], Lowered), _, fail)
+        ->  Native1 = [native(PI, Lowered)|Native0],
+            Wam1 = [wam(PI, WamText)|Wam0],
+            Failed1 = Failed0
+        ;   Native1 = Native0,
+            Wam1 = [wam(PI, WamText)|Wam0],
+            Failed1 = Failed0
+        )
     ;   Native1 = Native0,
         Wam1 = Wam0,
         Failed1 = [failed(PI)|Failed0]
@@ -101,11 +110,6 @@ partition_predicates_([Spec|Rest], Mode, Native0, Native, Wam0, Wam, Failed0, Fa
 should_attempt_native(functions, _PI) :- !.
 should_attempt_native(mixed(List), PI) :- !, member(PI, List).
 should_attempt_native(_, _) :- fail.
-
-native_code_is_stub(Code) :-
-    sub_string(Code, _, _, _, 'TODO: Implement').
-native_code_is_stub(Code) :-
-    sub_string(Code, _, _, _, 'return null').
 
 % ============================================================================
 % WAM text -> Kotlin program registration
@@ -294,7 +298,7 @@ write_wam_kotlin_project(Predicates, Options, ProjectDir) :-
     compile_native_parts(NativeParts, NativeCode),
     compile_wam_parts(WamParts, Options, WamCode),
     compile_failed_parts(FailedParts, FailedCode),
-    registrar_names(WamParts, Registrars),
+    registrar_calls(NativeParts, WamParts, Registrars),
     render_kotlin_wam_template('Main.kt.mustache', [
         package=Package,
         native_predicates=NativeCode,
@@ -312,12 +316,8 @@ write_wam_kotlin_project(Predicates, Options, ProjectDir) :-
 compile_native_parts([], '// No native Kotlin predicates selected.').
 compile_native_parts(NativeParts, Code) :-
     NativeParts \= [],
-    findall(Comment,
-        (   member(native(Pred/Arity, Part), NativeParts),
-            sanitize_block_comment(Part, SafePart),
-            format(string(Comment),
-                '/* Native Kotlin lowering selected for ~w/~w.\n   Direct native dispatch wiring is a follow-up; source captured for audit:\n~w\n*/',
-                [Pred, Arity, SafePart])
+    findall(Part,
+        (   member(native(_PI, lowered(_PredName, _FuncName, Part)), NativeParts)
         ),
         Parts),
     atomic_list_concat(Parts, '\n\n', Code).
@@ -342,16 +342,22 @@ compile_failed_parts(FailedParts, Code) :-
         Lines),
     atomic_list_concat(Lines, '\n', Code).
 
-registrar_names([], '// No WAM registrars.').
-registrar_names(WamParts, Calls) :-
-    WamParts \= [],
-    findall(Call,
-        (   member(wam(Pred/_Arity, _), WamParts),
-            kotlin_safe_identifier(Pred, Safe),
-            format(string(Call), '    register_~w(program)', [Safe])
-        ),
-        CallLines),
+registrar_calls([], [], '// No predicate registrars.').
+registrar_calls(NativeParts, WamParts, Calls) :-
+    (NativeParts \= [] ; WamParts \= []),
+    findall(Call, registrar_native_call(NativeParts, Call), NativeCalls),
+    findall(Call, registrar_wam_call(WamParts, Call), WamCalls),
+    append(NativeCalls, WamCalls, CallLines),
     atomic_list_concat(CallLines, '\n', Calls).
+
+registrar_native_call(NativeParts, Call) :-
+    member(native(_PI, lowered(PredName, FuncName, _)), NativeParts),
+    format(string(Call), '    program.registerNative("~w", ::~w)', [PredName, FuncName]).
+
+registrar_wam_call(WamParts, Call) :-
+    member(wam(Pred/_Arity, _), WamParts),
+    kotlin_safe_identifier(Pred, Safe),
+    format(string(Call), '    register_~w(program)', [Safe]).
 
 gradle_check_project(ProjectDir, Result) :-
     setup_call_cleanup(

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -248,10 +248,63 @@ class WamState(
     }
 
     fun restoreChoicePoint(): Boolean = restoreChoicePointFrame() != null
+
+    fun snapshotForNative(): WamNativeSnapshot =
+        WamNativeSnapshot(
+            registers = LinkedHashMap(registers),
+            trail = trail.toList(),
+            choicePoints = choicePoints.map { cp ->
+                ChoicePoint(
+                    cp.code,
+                    cp.pc,
+                    LinkedHashMap(cp.registers),
+                    cp.trailSize,
+                    cp.context,
+                    cp.callStack.toList(),
+                    cp.environmentStack.map { EnvironmentFrame(it.id, LinkedHashMap(it.slots)) },
+                )
+            },
+            callStack = callStack.map { frame ->
+                CallFrame(
+                    frame.code,
+                    frame.returnPc,
+                    frame.context,
+                    frame.environmentStack.map { EnvironmentFrame(it.id, LinkedHashMap(it.slots)) },
+                )
+            },
+            environmentStack = snapshotEnvironmentStack(),
+            context = context,
+            pc = pc,
+        )
+
+    fun restoreFromSnapshot(snapshot: WamNativeSnapshot) {
+        registers.clear()
+        registers.putAll(snapshot.registers)
+        trail.clear()
+        trail.addAll(snapshot.trail)
+        choicePoints.clear()
+        choicePoints.addAll(snapshot.choicePoints)
+        callStack.clear()
+        callStack.addAll(snapshot.callStack)
+        restoreEnvironmentStack(snapshot.environmentStack)
+        context = snapshot.context
+        pc = snapshot.pc
+    }
 }
+
+data class WamNativeSnapshot(
+    val registers: Map<String, Value?>,
+    val trail: List<String>,
+    val choicePoints: List<ChoicePoint>,
+    val callStack: List<CallFrame>,
+    val environmentStack: List<EnvironmentFrame>,
+    val context: WamContext?,
+    val pc: Int,
+)
 
 class WamProgram {
     private val predicates: MutableMap<String, PredicateCode> = linkedMapOf()
+    private val natives: MutableMap<String, (WamState) -> Boolean> = linkedMapOf()
 
     fun register(name: String, instructions: List<Instruction>) {
         val labels = linkedMapOf<String, Int>()
@@ -262,6 +315,12 @@ class WamProgram {
         }
         predicates[name] = PredicateCode(instructions, labels)
     }
+
+    fun registerNative(key: String, fn: (WamState) -> Boolean) {
+        natives[key] = fn
+    }
+
+    fun findNative(key: String): ((WamState) -> Boolean)? = natives[key]
 
     fun findCode(name: String): PredicateCode? = predicates[name]
 
@@ -277,6 +336,17 @@ class WamRuntime(private val program: WamProgram) {
     private lateinit var currentCode: PredicateCode
 
     fun run(predicate: String, initialState: WamState = WamState()): WamState {
+        program.findNative(predicate)?.let { nativeFn ->
+            val snapshot = initialState.snapshotForNative()
+            if (nativeFn(initialState)) {
+                return initialState
+            }
+            if (program.findCode(predicate) == null) {
+                initialState.restoreFromSnapshot(snapshot)
+                return initialState
+            }
+            initialState.restoreFromSnapshot(snapshot)
+        }
         currentCode = program.codeFor(predicate)
         initialState.pc = 0
         while (initialState.pc in currentCode.instructions.indices) {
@@ -764,4 +834,57 @@ fun stateFromCliArgs(values: List<String>): WamState {
         state.writeRegister("A${index + 1}", parseWamCliValue(raw))
     }
     return state
+}
+
+// Lowered-predicate helpers (single-clause WAM fast path).
+fun kotlinLoGetConstant(state: WamState, expected: Value, register: String): Boolean {
+    val current = state.deref(state.readRegister(register))
+    return when {
+        current == null -> {
+            state.bind(register, expected)
+            true
+        }
+        current is Value.Var -> {
+            state.bind(current.name, expected)
+            true
+        }
+        current == expected -> true
+        else -> false
+    }
+}
+
+fun kotlinLoGetValue(state: WamState, variable: String, argument: String): Boolean {
+    val left = state.readRegister(variable) ?: state.newVariable(variable)
+    val right = state.readRegister(argument) ?: state.newVariable(argument)
+    return state.unify(left, right)
+}
+
+fun kotlinLoUnifyVariable(state: WamState, variable: String): Boolean {
+  return when (val ctx = state.context) {
+        is WamContext.Write -> state.pushWriteArg(state.newVariable(variable))
+        else -> {
+            val value = state.nextReadArg() ?: return false
+            state.writeRegister(variable, state.deref(value))
+            true
+        }
+    }
+}
+
+fun kotlinLoUnifyValue(state: WamState, register: String): Boolean {
+    return when (val ctx = state.context) {
+        is WamContext.Write ->
+            state.pushWriteArg(state.deref(state.readRegister(register)) ?: state.newVariable(register))
+        else -> {
+            val value = state.nextReadArg() ?: return false
+            val regValue = state.readRegister(register) ?: state.newVariable(register)
+            state.unify(regValue, value)
+        }
+    }
+}
+
+fun kotlinLoUnifyConstant(state: WamState, value: Value): Boolean {
+    return when (state.context) {
+        is WamContext.Write -> state.pushWriteArg(value)
+        else -> state.unify(state.nextReadArg(), value)
+    }
 }

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -263,6 +263,44 @@ test(functions_mode_gradle_runs_lowered_fact, [condition(gradle_available), nond
         retractall(user:kt_fact(_, _))
     ).
 
+% Regression guard for the silent-wrong-answer bug: write-mode structure/list
+% construction was lowered incorrectly (unbound vars in the result). Such
+% predicates must DECLINE lowering and stay on the correct bytecode interpreter.
+test(functions_mode_declines_structure_lowering) :-
+    setup_call_cleanup(
+        (   retractall(user:kt_wrap(_, _)),
+            assertz(user:(kt_wrap(X, wrap(X))))
+        ),
+        (   wam_kotlin_target:wam_kotlin_partition_predicates(functions, [user:kt_wrap/2], Native, Wam, Failed),
+            assertion(Native == []),
+            assertion(Wam = [wam(kt_wrap/2, _)]),
+            assertion(Failed == [])
+        ),
+        retractall(user:kt_wrap(_, _))
+    ).
+
+% End-to-end: a list-building single-clause predicate under functions mode must
+% produce the SAME bindings as the interpreter (it declines lowering and runs
+% via the WAM fallback). Before the narrowing fix this returned [X1,X2] with
+% unbound vars instead of [alpha,beta].
+test(functions_mode_gradle_list_matches_interpreter, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_functions_list',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt_make_list(_, _, _)),
+            assertz(user:(kt_make_list(A, B, [A, B])))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project([user:kt_make_list/3], [emit_mode(functions)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'compileKotlin'], _CompileOut, _CompileErr, CompileStatus),
+            assertion(CompileStatus == exit(0)),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_make_list/3 alpha beta'], ListOut, _ListErr, ListStatus),
+            assertion(ListStatus == exit(0)),
+            assertion(has_substring(ListOut, 'A3=Struct(functor=[|]/2, args=[Atom(name=alpha), Struct(functor=[|]/2, args=[Atom(name=beta), Atom(name=[])])])'))
+        ),
+        retractall(user:kt_make_list(_, _, _))
+    ).
+
 test(registry_exposes_wam_kotlin_target, [nondet]) :-
     target_registry:target_exists(wam_kotlin),
     target_registry:target_family(wam_kotlin, jvm),

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -84,6 +84,9 @@ test(runtime_template_exposes_executable_wam_abi) :-
     assertion(has_substring(Code, '"get_structure"')),
     assertion(has_substring(Code, '"unify_variable"')),
     assertion(has_substring(Code, '"put_value", "put_unsafe_value"')),
+    assertion(has_substring(Code, 'fun registerNative(key: String, fn: (WamState) -> Boolean)')),
+    assertion(has_substring(Code, 'fun snapshotForNative(): WamNativeSnapshot')),
+    assertion(has_substring(Code, 'fun kotlinLoGetConstant(state: WamState')),
     assertion(has_substring(Code, 'fun stateFromCliArgs(values: List<String>): WamState')).
 
 test(interpreter_project_writes_gradle_and_sources, [nondet]) :-
@@ -210,15 +213,54 @@ test(generated_project_compiles_and_runs_fact_variable_and_terms, [condition(gra
 
 test(functions_mode_partitions_native_when_available) :-
     setup_call_cleanup(
-        (   retractall(user:kt_guard(_, _)),
-            assertz(user:(kt_guard(X, yes) :- X > 0))
+        (   retractall(user:kt_fact(_, _)),
+            assertz(user:kt_fact(alpha, beta))
         ),
-        (   wam_kotlin_target:wam_kotlin_partition_predicates(functions, [user:kt_guard/2], Native, Wam, Failed),
-            assertion(Native = [native(kt_guard/2, _)]),
-            assertion(Wam == []),
+        (   wam_kotlin_target:wam_kotlin_partition_predicates(functions, [user:kt_fact/2], Native, Wam, Failed),
+            assertion(Native = [native(kt_fact/2, lowered(_PredKey, lowered_kt_fact_2, _))]),
+            assertion(Wam = [wam(kt_fact/2, _)]),
             assertion(Failed == [])
         ),
-        retractall(user:kt_guard(_, _))
+        retractall(user:kt_fact(_, _))
+    ).
+
+test(functions_mode_emits_lowered_fun_and_register_native, [nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_functions_fact',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt_fact(_, _)),
+            assertz(user:kt_fact(alpha, beta))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project([user:kt_fact/2], [emit_mode(functions)], TmpDir),
+            read_file_to_string('output/test_wam_kotlin_functions_fact/src/main/kotlin/generated/wam/Main.kt', Main, []),
+            assertion(has_substring(Main, 'fun lowered_kt_fact_2(state: WamState): Boolean')),
+            assertion(has_substring(Main, 'program.registerNative("kt_fact/2", ::lowered_kt_fact_2)')),
+            assertion(has_substring(Main, 'register_kt_fact(program)')),
+            assertion(\+ has_substring(Main, 'Native Kotlin lowering selected'))
+        ),
+        retractall(user:kt_fact(_, _))
+    ).
+
+test(functions_mode_gradle_runs_lowered_fact, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_functions_gradle_fact',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt_fact(_, _)),
+            assertz(user:kt_fact(alpha, beta))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project([user:kt_fact/2], [emit_mode(functions)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'compileKotlin'], _CompileOut, CompileErr, CompileStatus),
+            assertion(CompileStatus == exit(0)),
+            assertion(CompileErr == ""),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_fact/2 alpha beta'], FactOut, _FactErr, FactStatus),
+            assertion(FactStatus == exit(0)),
+            assertion(has_substring(FactOut, 'Ran kt_fact/2')),
+            assertion(has_substring(FactOut, 'A1=Atom(name=alpha)')),
+            assertion(has_substring(FactOut, 'A2=Atom(name=beta)'))
+        ),
+        retractall(user:kt_fact(_, _))
     ).
 
 test(registry_exposes_wam_kotlin_target, [nondet]) :-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements fleet gap card **EMIT-KOTLIN** from [`docs/WAM_FLEET_GAP_TASKS.md`](docs/WAM_FLEET_GAP_TASKS.md): close the dead-end native bucket on the Kotlin hybrid WAM target by emitting a real lowered Kotlin function and dispatching it via `registerNative`, with WAT-style interpreter fallback.

## Problem

`functions` / `mixed` mode previously routed “native” predicates through non-WAM `kotlin_target:compile_predicate_to_kotlin/3`, then emitted only an audit block comment. Those predicates were **not runnable**.

## Solution

- New `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl` — deterministic **single-clause** only (declines `try_me_else`, ITE, `call`/`execute`)
- `WamProgram.registerNative` + snapshot/restore fallthrough in `WamRuntime.run`
- Partition wires lowerable preds to both native fun + WAM bytecode fallback
- Tests assert emission of `fun lowered_*` + `registerNative` (not the old comment)

## Tests

```
swipl -q -g run_tests -t halt tests/test_wam_kotlin_target.pl
```

**All plunit cases pass**, including Gradle e2e after installing Gradle 8.10.2:

- `generated_project_compiles_and_runs_fact_variable_and_terms` (interpreter)
- `functions_mode_gradle_runs_lowered_fact` (lowered native dispatch)

Environment: OpenJDK 21 (already present) + Gradle 8.10.2 at `/usr/local/bin/gradle`.

## Out of scope (follow-up cards)

T4/T5 multi-clause, ITE, `call`/`execute` in lowered bodies, conformance adapter.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

