### PR TITLE
Add Rust WAM predicate_property/2 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1622,6 +1622,7 @@ compile_execute_term_builtin_to_rust(Code) :-
             "assert/1" => { self.execute_assert_builtin("assert/1") }
             "assertz/1" | "asserta/1" => { self.execute_assert_builtin(op) }
             "retractall/1" => { self.execute_retractall_builtin() }
+            "predicate_property/2" => { self.execute_predicate_property_builtin() }
             _ => false,
         }
     }

--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -414,6 +414,45 @@
         true
     }
 
+    fn execute_predicate_property_builtin(&mut self) -> bool {
+        let head_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let head = self.deref_heap(&self.deref_var(&head_raw));
+        let key = match self.dynamic_head_key(&head) {
+            Some(key) => key,
+            None => return false,
+        };
+        let in_labels = self.labels.contains_key(&key);
+        let dynamic_count = self.dynamic_db.get(&key).map(Vec::len);
+        let property_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+        let property = self.deref_heap(&self.deref_var(&property_raw));
+        let succeeds = match property {
+            Value::Atom(name) => match name.as_str() {
+                "defined" => in_labels || dynamic_count.is_some(),
+                "dynamic" => dynamic_count.is_some(),
+                "static" => in_labels && dynamic_count.is_none(),
+                _ => false,
+            },
+            Value::Str(functor, args)
+                if args.len() == 1 &&
+                    Self::display_functor_name(&functor, 1) == "number_of_clauses" =>
+            {
+                let count = match dynamic_count {
+                    Some(count) => count,
+                    None if in_labels => 1,
+                    None => return false,
+                };
+                self.unify(&args[0], &Value::Integer(count as i64))
+            }
+            _ => false,
+        };
+        if succeeds {
+            self.pc += 1;
+            true
+        } else {
+            false
+        }
+    }
+
     fn dynamic_clause_key(&self, clause: &Value) -> Option<String> {
         let head = self.dynamic_clause_head(clause)?;
         self.dynamic_head_key(&head)

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -316,6 +316,71 @@ fn generated_tail_current_predicate_call_reads_static_labels() {
 }
 
 #[test]
+fn generated_predicate_property_reads_static_labels() {
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code, labels);
+    vm.set_reg_str("A1", fact("rust_clause_demo", vec![ub("_"), ub("_")]));
+    vm.set_reg_str("A2", at("static"));
+    assert!(vm.execute_builtin("predicate_property/2", 2));
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("rust_clause_demo", vec![ub("_"), ub("_")]));
+    vm.set_reg_str("A2", at("static"));
+    vm.pc = *vm.labels
+        .get("rust_predicate_property_demo/2")
+        .expect("generated predicate_property demo label");
+
+    assert!(vm.run());
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("rust_clause_demo", vec![ub("_"), ub("_")]));
+    vm.set_reg_str("A2", at("defined"));
+    assert!(vm.execute_builtin("predicate_property/2", 2));
+
+    vm.reset_query();
+    vm.set_reg_str(
+        "A1",
+        fact("rust_clause_demo", vec![ub("_"), ub("_")]),
+    );
+    vm.set_reg_str("A2", fact("number_of_clauses", vec![ub("Count")]));
+    assert!(vm.execute_builtin("predicate_property/2", 2));
+    let count = vm.bindings.get("Count").cloned().expect("Count bound");
+    assert_eq!(vm.deref_heap(&vm.deref_var(&count)), Value::Integer(1));
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("missing", vec![ub("_")]));
+    vm.set_reg_str("A2", at("defined"));
+    assert!(!vm.execute_builtin("predicate_property/2", 2));
+}
+
+#[test]
+fn predicate_property_reports_dynamic_status_and_clause_count() {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("red")]));
+    assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("blue")]));
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("dyn", vec![ub("_")]));
+    vm.set_reg_str("A2", at("dynamic"));
+    assert!(vm.execute_builtin("predicate_property/2", 2));
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("dyn", vec![ub("_")]));
+    vm.set_reg_str(
+        "A2",
+        fact("number_of_clauses", vec![ub("Count")]),
+    );
+    assert!(vm.execute_builtin("predicate_property/2", 2));
+    let count = vm.bindings.get("Count").cloned().expect("Count bound");
+    assert_eq!(vm.deref_heap(&vm.deref_var(&count)), Value::Integer(2));
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("dyn", vec![ub("_")]));
+    vm.set_reg_str("A2", at("static"));
+    assert!(!vm.execute_builtin("predicate_property/2", 2));
+}
+
+#[test]
 fn retract_distinguishes_fact_patterns_from_rule_patterns() {
     let mut vm = WamState::new(vec![Instruction::Call("retract/1".to_string(), 1), Instruction::Proceed], HashMap::new());
     assert_clause(&mut vm, "assertz/1", fact("marker", vec![at("rule")]));

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -20,6 +20,10 @@ rust_clause_demo(X, Body) :-
 rust_current_predicate_demo(Name, Arity) :-
     current_predicate(Name/Arity).
 
+:- dynamic rust_predicate_property_demo/2.
+rust_predicate_property_demo(Head, Property) :-
+    predicate_property(Head, Property).
+
 :- dynamic rust_read_term_options_demo/2.
 rust_read_term_options_demo(Term, Names) :-
     read_term(Term, [variable_names(Names)]).
@@ -54,6 +58,7 @@ test(assert_retract_dynamic_db,
          user:rust_assert_alias_demo/0,
          user:rust_clause_demo/2,
          user:rust_current_predicate_demo/2,
+         user:rust_predicate_property_demo/2,
          user:rust_read_term_options_demo/2,
          user:rust_atom_to_term_demo/2,
          user:rust_syntax_error_demo/1],


### PR DESCRIPTION
## Summary

- implement `predicate_property/2` for Rust WAM
- support `defined`, `static`, and `dynamic`
- support `number_of_clauses/1`
- inspect both compiled labels and the dynamic database
- give dynamic definitions precedence over static status
- preserve the C++ target's best-effort static clause count of one
- avoid changes to ordinary call dispatch or the shared builtin registry

Invalid-argument ISO exception parity remains a separate follow-up.

## Testing

- focused generated Rust dynamic builtin suite
- full Rust WAM target suite
- Rust WAM target syntax/load check
- patch whitespace validation