### PR TITLE
WAM/LLVM eval: lock in the foreach-over-tuples (object-per-item) pattern

### DIFF
--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -274,10 +274,24 @@ different plawk containers — this is the through-line for the rest of item 4:
   become the view's hidden temps while the view's Call args (e.g. `$1`
   passing the current element) ride the later foreach-element rebind. Test:
   `tests/test_plawk_dyncall_rec_loop.pl` (destructure, view, and
-  view-in-if-in-foreach). The `for (k in arr)` assoc for-in stays
-  print-only by construction (its body is a per-key print plan, not a
-  scalar action sequence), so record binds there remain a separate driver
-  concern.
+  view-in-if-in-foreach).
+  **Recommended "iterate a collection, object per item" pattern:** a
+  `foreach` over a repetition field whose elements have MORE THAN ONE
+  field iterates TUPLES — element `$1, $2, …` are the tuple's fields (a
+  (key, value) pair for `rep(i64 i64)`) — and the body can decode any
+  field into a structured record via a grammar. So "loop and process each
+  item as an object" is served today for list-shaped (repeating-field)
+  data. Test: `tests/test_plawk_foreach_tuples.pl` (tuple fields;
+  tuple→struct destructure; tuple→struct view).
+  **The `for (k in arr)` assoc for-in stays print-only** by construction
+  (its body is a per-key print plan, not a scalar action sequence), so
+  record binds there remain a separate, larger surface. Iterating a HASH
+  table with real per-entry work needs two read forms plumbed through the
+  expression model — the loop key `k` as a readable value and the `arr[k]`
+  value-lookup — plus loop-carried state for accumulation, and a surface
+  answer for referencing the current value as a grammar argument. Deferred
+  as a distinct feature; `foreach`-over-tuples covers the list-shaped case
+  without it.
 - **Associative array** (`arr = dyncall@name(...) as assoc`) — *mechanism +
   surface LANDED (named entry, integer keys).* A grammar returning a list of
   pairs (`[K1-V1, K2-V2, ...]`) materializes into an i64 assoc table via

--- a/tests/test_plawk_foreach_tuples.pl
+++ b/tests/test_plawk_foreach_tuples.pl
@@ -1,0 +1,121 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% "Iterate tuples, get a struct per item" -- the loop-over-a-collection
+% shape, served by `foreach` over a repetition field whose elements have
+% MORE THAN ONE field. Each element is a tuple ($1, $2, ...), and the
+% body (a full scalar action sequence, since #recbind-loop) can decode
+% any field into a structured record via a grammar. This is the
+% recommended pattern for "loop and process each item as an object";
+% iterating a hash table built with `arr[key]=val` (assoc for-in) with
+% real per-entry work is a separate, larger surface (it needs the loop
+% key and `arr[k]` value plumbed through the expression model).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammar: sq(X) -> pair(X, X*X) -- decode an element field into a struct
+sq(X, pair(X, Y)) :- Y is X * X.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_foreach_tuples).
+
+% A tuple element: foreach over rep(i64 i64) exposes $1 and $2 (the two
+% fields of the current element) -- the (key, value) pair. 2 elements
+% (10,100), (20,200): ta = 30, tb = 300.
+test(foreach_tuple_fields, [condition(clang_available)]) :-
+    ft_dir(Dir),
+    Src = "BEGIN { BINFMT = \"i64 rep4(i64 i64)\" }\n\c
+           { foreach { ta += $1 ; tb += $2 } }\n\c
+           END { print ta, tb }\n",
+    build_run(Dir, 'ftt', Src, [1, 2, 10, 100, 20, 200], "30 300\n"),
+    !.
+
+% Struct per tuple: decode the first field of each element into a record
+% via a grammar, alongside the raw tuple fields. sq(a) = pair(a, a*a);
+% tsq sums a*a. (10,100),(20,200): ta=30, tb=300, tsq=100+400=500.
+test(foreach_tuple_to_struct, [condition(clang_available)]) :-
+    ft_dir(Dir),
+    directory_file_path(Dir, 'sq.wamo', Wamo),
+    write_wam_object([user:sq/2], [wamo_entries([sq/2])], Wamo),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 rep4(i64 i64)\" ; DYNLOAD = \"~w\" }\n\c
+         { foreach { (n, sqr) = dyncall@sq($1) as (i64 i64) ; ta += $1 ; tb += $2 ; tsq += sqr } }\n\c
+         END { print ta, tb, tsq }\n", [Wamo]),
+    build_run(Dir, 'fts', Src, [1, 2, 10, 100, 20, 200], "30 300 500\n"),
+    !.
+
+% Struct-view per tuple: the record view reads the decoded struct as the
+% current record inside its block ($1 = a, $2 = a*a from sq), while the
+% element's own fields are captured first. sum of a*a = 500.
+test(foreach_tuple_struct_view, [condition(clang_available)]) :-
+    ft_dir(Dir),
+    directory_file_path(Dir, 'sq.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:sq/2], [wamo_entries([sq/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 rep4(i64 i64)\" ; DYNLOAD = \"~w\" }\n\c
+         { foreach { dyncall@sq($1) as (i64 i64) { tsq += $2 } } }\n\c
+         END { print tsq }\n", [Wamo]),
+    build_run(Dir, 'ftv', Src, [1, 2, 10, 100, 20, 200], "500\n"),
+    !.
+
+:- end_tests(plawk_foreach_tuples).
+
+% --- helpers ---------------------------------------------------------------
+
+ft_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_foreach_tuples', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Text) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text), close(Out)).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_rep_record(Path, Words) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(V, Words), write_i64_le(Out, V)),
+        close(Out)).
+
+build_run(Dir, Name, Src, Words, Expected) :-
+    write_prog(Dir, Name, Src),
+    directory_file_path(Dir, Name, Prog),
+    atom_concat(Prog, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog, '_in.bin', Input),
+    write_rep_record(Input, Words),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == Expected).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
Captures — as a tested, documented capability — the "iterate a collection, get a struct per item" shape that the foreach loop-body work (#3659) now provides for list-shaped data. This is the concrete answer to *"when people loop they want tuples (key and value), and objects/structs not just strings."*

A `foreach` over a repetition field whose elements have **more than one field** iterates **tuples**: element `$1, $2, …` are the tuple's fields (a `(key, value)` pair for `rep(i64 i64)`), and the body — a full scalar action sequence since #3659 — can decode any field into a **structured record** via a grammar.

```awk
BEGIN { BINFMT = "i64 rep4(i64 i64)" ; DYNLOAD = "sq.wamo" }
{ foreach { (n, sqr) = dyncall@sq($1) as (i64 i64) ; ta += $1 ; tb += $2 ; tsq += sqr } }
```

**No code changes** — this is a standing test + roadmap note built on the merged foreach-body binds/views.

## Tests — `tests/test_plawk_foreach_tuples.pl`

- tuple field access (`$1`,`$2` per element → `30 300`);
- tuple→struct **destructure** (decode `$1` via a grammar, sum `a*a` → `500`);
- tuple→struct **view** (read the decoded record as `$1`,`$2` in a block → `500`).

## The assoc-hash `for (k in arr)` case — scoped, deferred

Iterating a **hash table** (`arr["key"]=val` built across records) with real per-entry work stays a distinct, larger surface, and the roadmap now records exactly why: unlike `foreach` (fixed `$1`,`$2` offsets), it needs two new read forms plumbed through the whole expression model — the loop key `k` as a readable value and the `arr[k]` value-lookup — plus loop-carried state for accumulation, and a surface answer for referencing the current value as a grammar argument. `foreach`-over-tuples covers the list-shaped case without it.

I couldn't get the interactive picker to confirm scope (the tool errored twice), so I took the low-risk path: lock in the pattern that already serves the stated need and document the hash-iteration lift as an explicit, greenlightable next round rather than build it speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_