### PR TITLE
WAM/LLVM plawk: assoc for-in filter (hash iteration with per-entry logic, stage 1) + design doc

### DIFF
--- a/docs/design/PLAWK_ASSOC_FORIN.md
+++ b/docs/design/PLAWK_ASSOC_FORIN.md
@@ -1,0 +1,135 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2026 John William Creighton (@s243a)
+-->
+
+# plawk assoc for-in with per-entry logic
+
+Design for iterating an associative array (a hash table built with
+`arr[key] = ...` / `arr[key]++`) and doing **real work per entry** —
+not only the print-shaped body that ships today.
+
+## What works today
+
+`for (k in arr)` iterates the table's keys. The body is restricted to a
+single `print` whose fields are drawn from a fixed plan:
+
+- `k` — the loop key (resolved to text, or numeric for a positional array);
+- `arr[k]` — the iterated table's value at the current key (`value_self`);
+- `other[k]` — another table's value at the current key (`value_lookup`);
+- a string literal.
+
+```awk
+{ arr[$1]++ }
+END { for (k in arr) print k, arr[k] }          # key + value, per entry
+```
+
+That covers "dump the histogram." It does **not** cover filtering,
+aggregating, or decoding a value into a structured record — the loop body
+is a print *plan*, not a general action sequence, and `k` / `arr[k]` exist
+only as print-field plan atoms, not as readable expression operands.
+
+## The gap, precisely
+
+Three independent things are missing; each stage below closes one.
+
+1. **`k` and `arr[k]` are not expression/pattern operands.** The pattern
+   grammar has no production for a bare loop variable or an `arr[k]`
+   read, so `if (arr[k] > 100)` and `total += arr[k]` do not parse. They
+   are meaningful *only inside* the lexical scope of a `for (k in arr)`
+   body, so the natural home is a for-in-scoped operand set, not the
+   global pattern/expression grammar (where `k` has no binding).
+
+2. **The for-in body is not an action sequence.** It is planned as
+   `[print(Fields)]` and emitted by a bespoke per-key print loop
+   (`assoc_forin_action`), separate from the scalar action-sequence
+   walker (`plawk_scalar_action_sequence_pairs`) that lowers `if`,
+   updates, and record binds/views everywhere else.
+
+3. **The assoc driver has no scalar-slot state.** Assoc programs
+   accumulate in *tables*, not scalar variables, so there is no
+   loop-carried scalar threading of the kind `foreach` uses (head phis
+   per slot). `total += arr[k]` needs a scalar `total` that persists
+   across the record loop *and* mutates inside the per-record for-in
+   loop.
+
+## Architecture — reuse the `foreach` harness
+
+`foreach` already solved the hard part: a **runtime loop with a scalar
+action-sequence body and loop-carried accumulator state**. It threads one
+head phi per scalar slot (`plawk_foreach_head_phi_lines`), runs the body
+through `plawk_scalar_action_sequence_pairs` with those phis as the
+incoming slot values, and exposes the current element's fields as `$k`
+reads resolved to a fixed **staging area** in the record buffer.
+
+The plan is to make `for (k in arr) { BODY }` a sibling of `foreach`:
+
+- **Iteration source:** the assoc table's occupied slots
+  (`wam_assoc_i64_iter_next` / `_key_at` / `_value_at`) instead of a
+  repetition field's elements.
+- **Per-iteration staging:** write the current `(key, value)` into a
+  two-field staging area at loop-body entry — exactly as `foreach`
+  memcpy's the current element into staging. Then rewrite the body's
+  `k` → staging field 1 and `arr[k]` → staging field 2 (a resolve pass,
+  mirroring `foreach`'s field-shift). The body becomes an ordinary scalar
+  action sequence reading two staging fields; **all** existing emitters
+  (updates, `if`, record binds/views) apply unchanged.
+- **Loop-carried state:** reuse `plawk_foreach_head_phi_lines` for the
+  accumulator slots.
+
+Reusing the staging trick means `k`/`arr[k]` never need to become global
+expression operands — they are for-in-local staging fields, resolved once
+at desugar time, and the scalar machinery does the rest. This is the same
+move that let record views nest in `foreach` bodies (they rode the
+element staging).
+
+The one genuinely new driver concern is #3 (scalar-slot state in the
+assoc driver): the assoc rule chain must carry a scalar `Slots` plan and
+thread the final slot values into END, so a `total` mutated inside a
+for-in survives to the END print.
+
+## Staged plan
+
+Each stage is a shippable PR with tests.
+
+- **Stage 1 — filter + print (per-iteration output, no loop-carried
+  state).** `for (k in arr) { if (arr[k] CMP int) print k, arr[k] }`.
+  Adds a for-in-scoped condition (`k`/`arr[k]` compared to an integer)
+  and an `if` wrapper around the existing per-key print. No scalar
+  accumulation, so no head-phi threading yet — the guard just gates the
+  print inside the current bespoke loop. Smallest useful slice: "print
+  the histogram entries above a threshold."
+
+- **Stage 2 — scalar accumulation.** `for (k in arr) total += arr[k]`.
+  Gives the assoc driver a scalar `Slots` plan and threads it through the
+  record loop and the for-in loop (head phis), so a scalar mutated per
+  entry survives to END. This is the canonical "sum/aggregate the hash"
+  idiom and the largest driver piece.
+
+- **Stage 3 — decode a value into a struct.** `for (k in arr) {
+  (n, m) = dyncall@decode(arr[k]) as (i64 i64) ; ... }`. Once the body is
+  a real scalar sequence (Stage 2), record binds/views already lower
+  inside it (as they do in `foreach` bodies today); the remaining piece
+  is a surface for passing `arr[k]` — the current value — as a grammar
+  argument (the staging field 2 read, marshalled like any i64 arg).
+
+## Parser notes
+
+The for-in body already parses through `action_block`, so `if` / updates
+/ record binds parse structurally. What does not parse is the **operands**
+`k` and `arr[k]` in expression/pattern position. Rather than widen the
+global grammar (where a bare `k` is ambiguous), the operands are accepted
+in a for-in-body context and validated against the loop's key variable and
+the tables in scope; the desugar-to-staging pass then rewrites them before
+the generic emitters run, so no emitter needs a special "for-in operand"
+case.
+
+## Relationship to `foreach`
+
+`foreach` covers the **list-shaped** collection (a repetition field whose
+elements are tuples), and already supports the full action body including
+record binds/views (see `tests/test_plawk_foreach_tuples.pl`). This design
+brings the same expressive body to the **hash-shaped** collection
+(`for (k in arr)`), reusing `foreach`'s loop harness. When both land, the
+two collection shapes have parity: iterate, read the item (tuple fields /
+key+value), and decode each into a struct.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3587,6 +3587,11 @@ plawk_assoc_spec_forin_array(ActionSpecs, ArrayName) :-
     ( ArrayName = FA
     ; member(assoc(var(ArrayName), var(_)), FFields)
     ).
+plawk_assoc_spec_forin_array(ActionSpecs, ArrayName) :-
+    member(forin_guarded(_LoopVar, FA, _Guard, FFields), ActionSpecs),
+    ( ArrayName = FA
+    ; member(assoc(var(ArrayName), var(_)), FFields)
+    ).
 
 %% plawk_assoc_specs_str_arrays(+RuleSpecs, -StrArrays)
 %  Names of tables populated through `as assoc(str)` binds -- their
@@ -4557,6 +4562,20 @@ plawk_assoc_body_action_spec(for_in(var(LoopVar), var(ArrayName), Body),
     Body = [print(Fields)],
     Fields = [_ | _],
     maplist(plawk_forin_print_field(LoopVar), Fields).
+% for-in FILTER (assoc for-in stage 1): a per-key print gated by a guard
+% on the loop key or the iterated value. `k` / `arr[k]` are for-in-scoped
+% operands (see PLAWK_ASSOC_FORIN.md).
+plawk_assoc_body_action_spec(
+        for_in(var(LoopVar), var(ArrayName), [if(Guard, [print(Fields)], [])]),
+        forin_guarded(LoopVar, ArrayName, Guard, Fields)) :-
+    plawk_forin_guard_ok(Guard, LoopVar, ArrayName),
+    Fields = [_ | _],
+    maplist(plawk_forin_print_field(LoopVar), Fields).
+
+% Stage 1 guards: `arr[k] CMP int` where arr is the iterated table
+% (value_self), or `k CMP int` (the raw loop key).
+plawk_forin_guard_ok(forin_val_cmp(Array, LoopVar, _Op, _V), LoopVar, Array).
+plawk_forin_guard_ok(forin_key_cmp(LoopVar, _Op, _V), LoopVar, _Array).
 
 plawk_assoc_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), ArrayName-KeyIndex) :-
     KeyIndex > 0.
@@ -4614,6 +4633,22 @@ plawk_assoc_planned_actions([forin(LoopVar, ArrayName, Fields) | Rest],
     },
     [assoc_forin_action(Index, TableIndex, FieldPlans)],
     plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
+plawk_assoc_planned_actions(
+        [forin_guarded(LoopVar, ArrayName, Guard, Fields) | Rest],
+        Tables, StrArrays, PosArrays, Index) -->
+    { nth0(TableIndex, Tables, ArrayName),
+      plawk_forin_guard_plan(Guard, GuardPlan),
+      maplist(plawk_forin_rule_field_plan(LoopVar, ArrayName, TableIndex,
+          Tables, StrArrays, PosArrays), Fields, FieldPlans),
+      NextIndex is Index + 1
+    },
+    [assoc_forin_guarded_action(Index, TableIndex, GuardPlan, FieldPlans)],
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
+
+% guard operand: the iterated table's value at the current slot, or the
+% raw loop key; both compared to an integer literal.
+plawk_forin_guard_plan(forin_val_cmp(_A, _K, Op, V), guard_value(Op, V)).
+plawk_forin_guard_plan(forin_key_cmp(_K, Op, V), guard_key(Op, V)).
 
 plawk_forin_rule_field_plan(LoopVar, ArrayName, _TableIndex, _Tables,
         _StrArrays, PosArrays, var(LoopVar), KeyPlan) :- !,
@@ -4821,6 +4856,87 @@ plawk_assoc_rule_action_blocks(RuleIndex,
     },
     plawk_emit_lines(Lines),
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+% Guarded for-in (stage 1 filter): same slot-iteration loop, but a guard
+% on the key or the iterated value gates the per-key print. Passing
+% entries print; the rest fall straight through to the loop-continue.
+plawk_assoc_rule_action_blocks(RuleIndex,
+        [assoc_forin_guarded_action(Index, TableIndex, GuardPlan, FieldPlans)
+         | Rest],
+        NextLabel, FieldSeparator) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(B), 'arfg_~w_~w', [RuleIndex, Index]),
+      format(atom(HeadBr), '  br label %~w_head', [B]),
+      format(atom(HeadLbl), '~w_head:', [B]),
+      format(atom(Phi),
+          '  %~w_idx = phi i64 [0, %assoc_rule_~w_action_~w], [%~w_next, %~w_done]',
+          [B, RuleIndex, Index, B, B]),
+      format(atom(Slot),
+          '  %~w_slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_idx)',
+          [B, TableIndex, B]),
+      format(atom(DoneC), '  %~w_done_c = icmp slt i64 %~w_slot, 0', [B, B]),
+      format(atom(BrBody),
+          '  br i1 %~w_done_c, label %~w_after, label %~w_body', [B, B, B]),
+      format(atom(BodyLbl), '~w_body:', [B]),
+      format(atom(Key),
+          '  %~w_key = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_slot)',
+          [B, TableIndex, B]),
+      plawk_forin_guard_lines(GuardPlan, B, TableIndex, GuardLines, CondVar),
+      format(atom(BrGuard),
+          '  br i1 ~w, label %~w_print, label %~w_skip', [CondVar, B, B]),
+      format(atom(PrintLbl), '~w_print:', [B]),
+      phrase(plawk_forin_rule_field_lines(FieldPlans, B, 0), FieldLines),
+      format(atom(NL), '  %~w_nl = call i32 @putchar(i32 10)', [B]),
+      format(atom(BrDoneP), '  br label %~w_done', [B]),
+      format(atom(SkipLbl), '~w_skip:', [B]),
+      format(atom(BrDoneS), '  br label %~w_done', [B]),
+      format(atom(DoneLbl), '~w_done:', [B]),
+      format(atom(Next), '  %~w_next = add i64 %~w_slot, 1', [B, B]),
+      format(atom(BrHead), '  br label %~w_head', [B]),
+      format(atom(AfterLbl), '~w_after:', [B]),
+      format(atom(BrNext), '  br label %~w', [ActionNextLabel]),
+      append([[Label, HeadBr, '', HeadLbl, Phi, Slot, DoneC, BrBody, '',
+               BodyLbl, Key],
+              GuardLines,
+              [BrGuard, '', PrintLbl],
+              FieldLines,
+              [NL, BrDoneP, '', SkipLbl, BrDoneS, '', DoneLbl, Next, BrHead,
+               '', AfterLbl, BrNext, '']],
+          Lines)
+    },
+    plawk_emit_lines(Lines),
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+
+% Guard operand load + comparison. guard_value reads the iterated table's
+% value at the current slot; guard_key uses the raw key. Both icmp against
+% the integer literal.
+plawk_forin_guard_lines(guard_value(Op, V), B, TableIndex, Lines, CondVar) :-
+    plawk_forin_cmp_pred(Op, Pred),
+    format(atom(ValLine),
+        '  %~w_gval = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_slot)',
+        [B, TableIndex, B]),
+    format(atom(CmpLine),
+        '  %~w_gcmp = icmp ~w i64 %~w_gval, ~w', [B, Pred, B, V]),
+    format(atom(CondVar), '%~w_gcmp', [B]),
+    Lines = [ValLine, CmpLine].
+plawk_forin_guard_lines(guard_key(Op, V), B, _TableIndex, Lines, CondVar) :-
+    plawk_forin_cmp_pred(Op, Pred),
+    format(atom(CmpLine),
+        '  %~w_gcmp = icmp ~w i64 %~w_key, ~w', [B, Pred, B, V]),
+    format(atom(CondVar), '%~w_gcmp', [B]),
+    Lines = [CmpLine].
+
+plawk_forin_cmp_pred(eq, eq).
+plawk_forin_cmp_pred(ne, ne).
+plawk_forin_cmp_pred(lt, slt).
+plawk_forin_cmp_pred(le, sle).
+plawk_forin_cmp_pred(gt, sgt).
+plawk_forin_cmp_pred(ge, sge).
 
 plawk_forin_rule_field_lines([], _B, _N) -->
     [].

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -935,11 +935,31 @@ for_in_action(for_in(var(LoopVar), var(ArrayName), Body)) -->
 for_in_body(Actions) -->
     action_block(Actions),
     !.
+% for-in filter (assoc for-in, stage 1): `{ if (GUARD) print ... }` where
+% GUARD compares the loop key `k` or the value `arr[k]` to an integer.
+% A for-in-scoped condition -- k / arr[k] are only meaningful inside the
+% loop, so the operands live here rather than in the global pattern
+% grammar. Gates the per-key print; no cross-iteration state.
+for_in_body([if(Guard, [PrintAction], [])]) -->
+    "{", ws, "if", ws, "(", ws, forin_guard(Guard), ws, ")", ws,
+    print_action(PrintAction), ws, "}",
+    !.
 for_in_body([WritebinAction]) -->
     writebin_action(WritebinAction),
     !.
 for_in_body([PrintAction]) -->
     print_action(PrintAction).
+
+% arr[k] CMP int -- value comparison (tried before the bare-key form,
+% since `arr[` also starts with an identifier).
+forin_guard(forin_val_cmp(Array, LoopVar, Op, Value)) -->
+    identifier(Array), ws, "[", ws, identifier(LoopVar), ws, "]", ws,
+    numeric_cmp_op(Op), ws, signed_integer_value(Value),
+    !.
+% k CMP int -- loop-key comparison.
+forin_guard(forin_key_cmp(LoopVar, Op, Value)) -->
+    identifier(LoopVar), ws, numeric_cmp_op(Op), ws,
+    signed_integer_value(Value).
 
 actions([Action | Actions]) -->
     action(Action),

--- a/tests/test_plawk_forin_filter.pl
+++ b/tests/test_plawk_forin_filter.pl
@@ -1,0 +1,109 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Assoc for-in with per-entry logic, stage 1: a FILTER in the rule-body
+% for-in. `for (k in arr) { if (GUARD) print ... }` where GUARD compares
+% the loop key `k` or the iterated value `arr[k]` to an integer, gating
+% the per-key print. `k` / `arr[k]` are for-in-scoped operands (they exist
+% only inside the loop), parsed by a for-in-body-local guard grammar and
+% lowered by the assoc rule-chain loop emitter. See PLAWK_ASSOC_FORIN.md.
+% (Per-record running-snapshot semantics, like every rule-body for-in;
+% the END-side filter is stage 1b.)
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_forin_filter).
+
+% Value guard: `arr[k] CMP int` parses to a for-in body if wrapping a
+% print, with a forin_val_cmp guard node.
+test(value_guard_parses) :-
+    plawk_parse_string(
+        "{ c[$1]++ ; for (k in c) { if (c[k] >= 2) print k, c[k] } }\n\c
+         END { print c[\"a\"] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(for_in(var(k), var(c),
+        [if(forin_val_cmp(c, k, ge, 2), [print([var(k), assoc(var(c), var(k))])], [])]),
+        Actions),
+    !.
+
+% Key guard: `k CMP int` parses to a forin_key_cmp guard node.
+test(key_guard_parses) :-
+    plawk_parse_string(
+        "{ c[$1]++ ; for (k in c) { if (k > 0) print k } }\n\c
+         END { print c[\"a\"] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(for_in(var(k), var(c),
+        [if(forin_key_cmp(k, gt, 0), [print([var(k)])], [])]), Actions),
+    !.
+
+% Value filter, end to end. Input a a b (per-record running snapshot):
+%   rec "a" -> c={a:1}: 1>=2 no.
+%   rec "a" -> c={a:2}: a passes -> "a 2".
+%   rec "b" -> c={a:2,b:1}: a passes -> "a 2"; b (1) no.
+% END prints c["a"] = 2. Lines (order-independent): 2, a 2, a 2.
+test(value_filter_runs, [condition(clang_available)]) :-
+    ff_dir(Dir),
+    Src = "{ c[$1]++ ; for (k in c) { if (c[k] >= 2) print k, c[k] } }\n\c
+           END { print c[\"a\"] }\n",
+    build_run_text(Dir, 'ffv', Src, "a\na\nb\n", Out),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, S),
+    assertion(S == ["2", "a 2", "a 2"]),
+    !.
+
+% A stricter threshold filters everything out except the END read.
+% Input a a b, guard arr[k] >= 3: nothing ever reaches 3, so no loop
+% output; END prints c["a"] = 2.
+test(value_filter_excludes_all, [condition(clang_available)]) :-
+    ff_dir(Dir),
+    Src = "{ c[$1]++ ; for (k in c) { if (c[k] >= 3) print k, c[k] } }\n\c
+           END { print c[\"a\"] }\n",
+    build_run_text(Dir, 'ffx', Src, "a\na\nb\n", Out),
+    assertion(Out == "2\n"),
+    !.
+
+:- end_tests(plawk_forin_filter).
+
+% --- helpers ---------------------------------------------------------------
+
+ff_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_forin_filter', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run_text(Dir, Name, Src, InputText, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog0, '_in.txt', Input),
+    setup_call_cleanup(open(Input, write, SI, [encoding(utf8)]),
+        write(SI, InputText), close(SI)),
+    run_bin(Bin, [Input], Out, 0).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
Starts the big lift you greenlit — iterating a **hash table** (`arr["key"]=val`) and doing real work per entry, not just the print-shaped body that shipped. Stacked on the foreach-tuples chain.

## Design doc: `docs/design/PLAWK_ASSOC_FORIN.md`

Scopes the whole feature so the staging is deliberate. It names the **three independent gaps**:
1. `k` and `arr[k]` are not expression/pattern operands (so `if (arr[k] > N)` and `total += arr[k]` don't parse) — and they're meaningful *only* inside the loop scope;
2. the for-in body is a print *plan*, not a general action sequence;
3. the assoc driver has no scalar-slot state (assoc programs accumulate in *tables*, not scalar variables — so no loop-carried scalar threading like `foreach` has).

And the **architecture**: reuse `foreach`'s proven loop-carried-phi + staging harness, rewriting `k`/`arr[k]` to for-in-local staging reads so the generic scalar emitters apply unchanged — the same move that let record views nest in `foreach` bodies. Three stages follow.

## Stage 1 (this PR): the filter

```awk
{ c[$1]++ ; for (k in c) { if (c[k] >= 2) print k, c[k] } }
```

A guard on the loop key `k` or the iterated value `arr[k]` (compared to an integer) gates the per-key print. This is per-iteration **output** with **no cross-iteration state**, so it rides the existing for-in loop emitter — a guard block (value-at / key load + `icmp` + branch) wraps the print. No `foreach`-style head phis needed yet.

- **Parser:** a for-in-body-local guard grammar (`forin_val_cmp` / `forin_key_cmp`), keeping `k`/`arr[k]` operands in the loop scope rather than widening the global pattern grammar (where a bare `k` has no binding).
- **Codegen:** `forin_guarded` action spec + plan (`guard_value` / `guard_key`) + a guarded loop emitter mirroring `assoc_forin_action`, with the guard `icmp` gating the print block; `plawk_assoc_spec_forin_array` also collects the guarded form's arrays.

## Tests — `tests/test_plawk_forin_filter.pl`

Value/key guard parse; value filter end to end (`arr[k] >= 2` over `a a b` → `a 2` / `a 2`, END `2`, running-snapshot semantics like every rule-body for-in); a threshold excluding everything. Regressions green: `test_plawk_forin_rule_body` (3), `test_plawk_surface_forin_end_print` (14), `test_plawk_dyncall_assoc` (12), `test_plawk_binary_assoc` (11).

## Remaining stages (per the design doc)

- **Stage 1b** — the same filter on the **END** for-in (iterate the *final* hash; the more common use), a parallel extension of the separate END for-in driver.
- **Stage 2** — scalar accumulation (`for (k in arr) total += arr[k]`): gives the assoc driver scalar-slot state + loop-carried head phis. The largest driver piece.
- **Stage 3** — decode a value into a struct (`(n,m) = dyncall@decode(arr[k]) as (...)`), riding Stage 2's action-sequence body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_