### PR TITLE
fix(kotlin-wam): EMIT-KOTLIN-2 — lower write-mode structure/list construction

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -50,7 +50,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | EMIT-ILASM | Lowered emitter | ILAsm | L | — |
 | EMIT-JVM | Lowered emitter | JVM | L | — |
 | EMIT-KOTLIN ✅ | Lowered emitter | Kotlin | M | done — flat facts/unify (`cursor/emit-kotlin-lowered-f421`) |
-| EMIT-KOTLIN-2 | Lowered emitter (structures) | Kotlin | M | EMIT-KOTLIN |
+| EMIT-KOTLIN-2 ✅ | Lowered emitter (structures) | Kotlin | M | done — write-mode structures (`cursor/emit-kotlin-structures-f421`) |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |
 | BENCH-C | Effective-distance bench row | C | M | — |
@@ -533,6 +533,7 @@ fallback) to the three Tier-D targets. Reference small emitters:
 
 ### EMIT-KOTLIN-2: Lower write-mode structure/list construction (Kotlin)
 - **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN
+- **Status:** ✅ **Landed** on `cursor/emit-kotlin-structures-f421` (2026-07-12). Root cause was not a write-mode register-ordering bug in the helpers: the emitter wrapped `get_variable`/`put_variable` in a bare Kotlin `{ ... }` block, which is a **discarded lambda** (never invoked). Head vars stayed unbound; `kotlinLoUnifyValue` then fabricated fresh `Var(Xn)` via `?: newVariable`, producing silent wrong answers (`[X1,X2]` instead of `[alpha,beta]`). Fix: emit `run { ... }` so the block executes; re-enable `parts_supported` for structure/list/`set_*`/`unify_*`. Runtime helpers were already correct. Tests assert structure/list/nested builders LOWER and match `emit_mode(interpreter)` via gradle.
 - **Goal:** Extend the Kotlin lowered emitter to correctly build structures/lists in the head (write mode), then re-enable those ops in `parts_supported` so predicates like `p(X, wrap(X))` / `p(X,Y,[X,Y])` lower instead of declining to the interpreter.
 - **Why deferred:** EMIT-KOTLIN's first cut lowered `put_structure`/`put_list`/`set_*`/`unify_*` incorrectly — write-mode arg pushes read the register *before* the head variable was bound, so the built term contained unbound vars (e.g. `kt_make_list(X,Y,[X,Y])` with `alpha beta` produced `[X1,X2]` not `[alpha,beta]`), and the lowered fn returned `true` so the interpreter fallback never fired. The fix narrowed the lowerable set; this card does it properly.
 - **Files to touch:** `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl` (re-add the `parts_supported/1` facts for `get/put_structure`, `get/put_list`, `set_*`, `unify_*`; fix `emit_line_parts/2` for the write-mode ops), `templates/targets/kotlin_wam/WamRuntime.kt.mustache` (the `kotlinLoUnify*` helpers + `pushWriteArg`/`beginStructure*` already exist — audit their read-vs-write-mode contract), `tests/test_wam_kotlin_target.pl`.

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -30,21 +30,18 @@ module in the fleet.
 - **Hybrid partition** emit with a WAM fallback.
 - **Gradle e2e** hook — the test suite includes a Gradle end-to-end
   path when the toolchain is available.
-- **WAM-lowered native dispatch (first cut):** `wam_kotlin_lowered_emitter.pl`
-  lowers **flat single-clause facts + register unification** (no structure/list
-  construction — see below) to `fun (state: WamState): Boolean`, registered via
-  `WamProgram.registerNative`. `WamRuntime.run` tries native first and falls back
-  to the bytecode interpreter on `false` (WAT-style snapshot restore). `functions`
-  / `mixed` modes route lowerable preds through this path; everything else
-  (including any structure/list builder) stays on the interpreter registrars.
+- **WAM-lowered native dispatch:** `wam_kotlin_lowered_emitter.pl` lowers
+  **deterministic single-clause** predicates — flat facts, register unification,
+  and write/read-mode structure/list construction (`get/put_structure`,
+  `get/put_list`, `set_*`, `unify_*`) — to `fun (state: WamState): Boolean`,
+  registered via `WamProgram.registerNative`. `WamRuntime.run` tries native first
+  and falls back to the bytecode interpreter on `false` (WAT-style snapshot
+  restore). `functions` / `mixed` modes route lowerable preds through this path.
 
 ## Gaps
 
-- **Lowered emitter scope** — only flat single-clause facts + register
-  unification. Structure/list **construction** was silently wrong in the first
-  cut (unbound vars in the result) and now declines to the interpreter; fixing it
-  is follow-up **EMIT-KOTLIN-2**. No T4/T5 multi-clause, ITE, or `call`/`execute`
-  in lowered bodies.
+- **Lowered emitter scope** — deterministic single-clause only. No T4/T5
+  multi-clause, ITE, or `call`/`execute` in lowered bodies (separate cards).
 - **No foreign kernels, no LMDB / fact source, no ISO contract.**
 - **No conformance registration** — no `conformance_target(kotlin)`.
 - **No runtime-parser capability entry.**
@@ -58,4 +55,4 @@ module in the fleet.
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
-(2026-07-12).
+(2026-07-12). EMIT-KOTLIN-2 write-mode structure/list lowering landed.

--- a/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
@@ -59,10 +59,8 @@ line_supported(Line) :-
     ;   parts_supported(Parts)
     ).
 
-% NOTE: structure/list construction (get_structure/get_list/put_structure/
-% put_list/set_*/unify_*) is intentionally NOT lowerable in this first cut:
-% write-mode term building was silently wrong (unbound vars in the result).
-% Such predicates decline and stay on the correct bytecode interpreter.
+% Structure/list + unify/set ops are lowerable. get_variable/put_variable must
+% emit `run { ... }` (not a bare block) — see emit_line_parts/2 note.
 parts_supported(["allocate"]).
 parts_supported(["deallocate"]).
 parts_supported(["proceed"]).
@@ -70,13 +68,26 @@ parts_supported(["fail"]).
 parts_supported(["get_constant", _, _]).
 parts_supported(["get_variable", _, _]).
 parts_supported(["get_value", _, _]).
+parts_supported(["get_structure", _, _]).
+parts_supported(["get_list", _]).
 parts_supported(["get_nil", _]).
 parts_supported(["get_integer", _, _]).
 parts_supported(["put_constant", _, _]).
 parts_supported(["put_variable", _, _]).
 parts_supported(["put_value", _, _]).
+parts_supported(["put_structure", _, _]).
+parts_supported(["put_list", _]).
 parts_supported(["put_nil", _]).
 parts_supported(["put_integer", _, _]).
+parts_supported(["unify_variable", _]).
+parts_supported(["unify_value", _]).
+parts_supported(["unify_constant", _]).
+parts_supported(["unify_nil"]).
+parts_supported(["set_variable", _]).
+parts_supported(["set_value", _]).
+parts_supported(["set_constant", _]).
+parts_supported(["set_nil"]).
+parts_supported(["set_integer", _]).
 
 kotlin_lowered_func_name(Functor/Arity, Name) :-
     atom_string(Functor, S),
@@ -131,9 +142,13 @@ emit_line_parts(["get_integer", C, R], I) :- !,
 emit_line_parts(["get_nil", R], I) :- !,
     kotlin_register_lit(R, RL),
     format("~wif (!kotlinLoGetConstant(state, Value.Atom(\"[]\"), ~w)) return false~n", [I, RL]).
+% NOTE: must use `run { ... }`, not a bare `{ ... }` block. In Kotlin a
+% standalone lambda literal is NOT invoked, so get_variable/put_variable
+% would silently no-op — write-mode unify_value then saw null registers and
+% fabricated unbound vars (kt_make_list → [X1,X2] instead of [alpha,beta]).
 emit_line_parts(["get_variable", X, A], I) :- !,
     kotlin_register_lit(X, XL), kotlin_register_lit(A, AL),
-    format("~w{~n", [I]),
+    format("~wrun {~n", [I]),
     format("~w    val v = state.deref(state.readRegister(~w)) ?: state.newVariable(~w)~n", [I, AL, XL]),
     format("~w    state.writeRegister(~w, v)~n", [I, XL]),
     format("~w    state.writeRegister(~w, v)~n", [I, AL]),
@@ -161,7 +176,7 @@ emit_line_parts(["put_nil", R], I) :- !,
     format("~wstate.writeRegister(~w, Value.Atom(\"[]\"))~n", [I, RL]).
 emit_line_parts(["put_variable", X, A], I) :- !,
     kotlin_register_lit(X, XL), kotlin_register_lit(A, AL),
-    format("~w{~n", [I]),
+    format("~wrun {~n", [I]),
     format("~w    val v = state.newVariable(~w)~n", [I, XL]),
     format("~w    state.writeRegister(~w, v)~n", [I, XL]),
     format("~w    state.writeRegister(~w, v)~n", [I, AL]),
@@ -181,7 +196,8 @@ emit_line_parts(["set_variable", X], I) :- !,
     format("~wif (!state.pushWriteArg(state.newVariable(~w))) return false~n", [I, XL]).
 emit_line_parts(["set_value", X], I) :- !,
     kotlin_register_lit(X, XL),
-    format("~wif (!state.pushWriteArg(state.deref(state.readRegister(~w)))) return false~n", [I, XL]).
+    % Mirror interpreter set_value: missing register → fail (not push null).
+    format("~wif (!state.pushWriteArg(state.deref(state.readRegister(~w)) ?: return false)) return false~n", [I, XL]).
 emit_line_parts(["set_constant", C], I) :- !,
     kotlin_constant_expr(C, Expr),
     format("~wif (!state.pushWriteArg(~w)) return false~n", [I, Expr]).

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -11,6 +11,7 @@
 :- dynamic kt_eq/2.
 :- dynamic kt_wrap/2.
 :- dynamic kt_make_list/3.
+:- dynamic kt_nested/3.
 :- dynamic kt_match_pair/3.
 :- dynamic kt_color/1.
 :- dynamic kt_parent/2.
@@ -263,42 +264,119 @@ test(functions_mode_gradle_runs_lowered_fact, [condition(gradle_available), nond
         retractall(user:kt_fact(_, _))
     ).
 
-% Regression guard for the silent-wrong-answer bug: write-mode structure/list
-% construction was lowered incorrectly (unbound vars in the result). Such
-% predicates must DECLINE lowering and stay on the correct bytecode interpreter.
-test(functions_mode_declines_structure_lowering) :-
+% Structure/list builders must LOWER under functions mode (Native partition),
+% not decline. Regression guard for the silent-wrong-answer bug where a bare
+% Kotlin `{ ... }` block around get_variable was a no-op lambda.
+test(functions_mode_lowers_structure_builders) :-
     setup_call_cleanup(
         (   retractall(user:kt_wrap(_, _)),
-            assertz(user:(kt_wrap(X, wrap(X))))
+            retractall(user:kt_make_list(_, _, _)),
+            assertz(user:(kt_wrap(X, wrap(X)))),
+            assertz(user:(kt_make_list(A, B, [A, B])))
         ),
-        (   wam_kotlin_target:wam_kotlin_partition_predicates(functions, [user:kt_wrap/2], Native, Wam, Failed),
-            assertion(Native == []),
-            assertion(Wam = [wam(kt_wrap/2, _)]),
-            assertion(Failed == [])
+        (   wam_kotlin_target:wam_kotlin_partition_predicates(
+                functions, [user:kt_wrap/2, user:kt_make_list/3], Native, Wam, Failed),
+            assertion(Failed == []),
+            assertion(memberchk(native(kt_wrap/2, _), Native)),
+            assertion(memberchk(native(kt_make_list/3, _), Native)),
+            assertion(memberchk(wam(kt_wrap/2, _), Wam)),
+            assertion(memberchk(wam(kt_make_list/3, _), Wam)),
+            memberchk(native(kt_wrap/2, lowered(_, _, WrapCode)), Native),
+            assertion(has_substring(WrapCode, 'fun lowered_kt_wrap_2')),
+            assertion(has_substring(WrapCode, 'beginStructure')),
+            memberchk(native(kt_make_list/3, lowered(_, _, ListCode)), Native),
+            assertion(has_substring(ListCode, 'fun lowered_kt_make_list_3')),
+            assertion(has_substring(ListCode, 'run {'))
         ),
-        retractall(user:kt_wrap(_, _))
+        (   retractall(user:kt_wrap(_, _)),
+            retractall(user:kt_make_list(_, _, _))
+        )
     ).
 
-% End-to-end: a list-building single-clause predicate under functions mode must
-% produce the SAME bindings as the interpreter (it declines lowering and runs
-% via the WAM fallback). Before the narrowing fix this returned [X1,X2] with
-% unbound vars instead of [alpha,beta].
+% End-to-end: list builder under functions mode must LOWER and produce the
+% SAME bindings as emit_mode(interpreter). Before the run{} fix this returned
+% [X1,X2] unbound vars while still returning true (no interpreter fallback).
 test(functions_mode_gradle_list_matches_interpreter, [condition(gradle_available), nondet]) :-
     TmpDir = 'output/test_wam_kotlin_functions_list',
     make_directory_path('output'),
     clean_dir(TmpDir),
+    Expected = 'A3=Struct(functor=[|]/2, args=[Atom(name=alpha), Struct(functor=[|]/2, args=[Atom(name=beta), Atom(name=[])])])',
     setup_call_cleanup(
         (   retractall(user:kt_make_list(_, _, _)),
             assertz(user:(kt_make_list(A, B, [A, B])))
         ),
-        (   wam_kotlin_target:write_wam_kotlin_project([user:kt_make_list/3], [emit_mode(functions)], TmpDir),
+        (   wam_kotlin_target:write_wam_kotlin_project([user:kt_make_list/3], [emit_mode(interpreter)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_make_list/3 alpha beta'], InterpOut, _InterpErr, InterpStatus),
+            assertion(InterpStatus == exit(0)),
+            assertion(has_substring(InterpOut, Expected)),
+            clean_dir(TmpDir),
+            wam_kotlin_target:write_wam_kotlin_project([user:kt_make_list/3], [emit_mode(functions)], TmpDir),
+            assertion(exists_file('output/test_wam_kotlin_functions_list/src/main/kotlin/generated/wam/Main.kt')),
+            read_file_to_string('output/test_wam_kotlin_functions_list/src/main/kotlin/generated/wam/Main.kt', Main, []),
+            assertion(has_substring(Main, 'fun lowered_kt_make_list_3')),
+            assertion(has_substring(Main, 'registerNative("kt_make_list/3"')),
             run_gradle(TmpDir, ['-q', 'compileKotlin'], _CompileOut, _CompileErr, CompileStatus),
             assertion(CompileStatus == exit(0)),
             run_gradle(TmpDir, ['-q', 'run', '--args=kt_make_list/3 alpha beta'], ListOut, _ListErr, ListStatus),
             assertion(ListStatus == exit(0)),
-            assertion(has_substring(ListOut, 'A3=Struct(functor=[|]/2, args=[Atom(name=alpha), Struct(functor=[|]/2, args=[Atom(name=beta), Atom(name=[])])])'))
+            assertion(has_substring(ListOut, Expected))
         ),
         retractall(user:kt_make_list(_, _, _))
+    ).
+
+% Structure builder: p(X, wrap(X)) lowers and matches interpreter bindings.
+test(functions_mode_gradle_wrap_matches_interpreter, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_functions_wrap',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    Expected = 'A2=Struct(functor=wrap/1, args=[Atom(name=alpha)])',
+    setup_call_cleanup(
+        (   retractall(user:kt_wrap(_, _)),
+            assertz(user:(kt_wrap(X, wrap(X))))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project([user:kt_wrap/2], [emit_mode(interpreter)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_wrap/2 alpha'], InterpOut, _InterpErr, InterpStatus),
+            assertion(InterpStatus == exit(0)),
+            assertion(has_substring(InterpOut, Expected)),
+            clean_dir(TmpDir),
+            wam_kotlin_target:write_wam_kotlin_project([user:kt_wrap/2], [emit_mode(functions)], TmpDir),
+            read_file_to_string('output/test_wam_kotlin_functions_wrap/src/main/kotlin/generated/wam/Main.kt', Main, []),
+            assertion(has_substring(Main, 'fun lowered_kt_wrap_2')),
+            assertion(has_substring(Main, 'registerNative("kt_wrap/2"')),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_wrap/2 alpha'], WrapOut, _WrapErr, WrapStatus),
+            assertion(WrapStatus == exit(0)),
+            assertion(has_substring(WrapOut, Expected))
+        ),
+        retractall(user:kt_wrap(_, _))
+    ).
+
+% Nested/mixed structure+list: p(X, Y, foo(X, [Y])) lowers == interpreter.
+test(functions_mode_gradle_nested_matches_interpreter, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_functions_nested',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    Expected = 'A3=Struct(functor=foo/2, args=[Atom(name=alpha), Struct(functor=[|]/2, args=[Atom(name=beta), Atom(name=[])])])',
+    setup_call_cleanup(
+        (   retractall(user:kt_nested(_, _, _)),
+            assertz(user:(kt_nested(X, Y, foo(X, [Y]))))
+        ),
+        (   wam_kotlin_target:wam_kotlin_partition_predicates(functions, [user:kt_nested/3], Native, _Wam, Failed),
+            assertion(Failed == []),
+            assertion(memberchk(native(kt_nested/3, _), Native)),
+            wam_kotlin_target:write_wam_kotlin_project([user:kt_nested/3], [emit_mode(interpreter)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_nested/3 alpha beta'], InterpOut, _InterpErr, InterpStatus),
+            assertion(InterpStatus == exit(0)),
+            assertion(has_substring(InterpOut, Expected)),
+            clean_dir(TmpDir),
+            wam_kotlin_target:write_wam_kotlin_project([user:kt_nested/3], [emit_mode(functions)], TmpDir),
+            read_file_to_string('output/test_wam_kotlin_functions_nested/src/main/kotlin/generated/wam/Main.kt', Main, []),
+            assertion(has_substring(Main, 'fun lowered_kt_nested_3')),
+            assertion(has_substring(Main, 'registerNative("kt_nested/3"')),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_nested/3 alpha beta'], NestedOut, _NestedErr, NestedStatus),
+            assertion(NestedStatus == exit(0)),
+            assertion(has_substring(NestedOut, Expected))
+        ),
+        retractall(user:kt_nested(_, _, _))
     ).
 
 test(registry_exposes_wam_kotlin_target, [nondet]) :-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes **EMIT-KOTLIN-2**: re-enable write-mode structure/list lowering in the Kotlin hybrid WAM target so builders like `wrap(X)` / `[X,Y]` / `foo(X,[Y])` lower correctly instead of declining (or silently returning unbound vars).

## Root cause

The first-cut emitter wrapped `get_variable` / `put_variable` in a bare Kotlin `{ ... }` block. That is a **discarded lambda** and never runs, so head registers stayed unbound. `kotlinLoUnifyValue` then hit `?: newVariable(reg)` and pushed fresh unbound vars — e.g. `kt_make_list/3 alpha beta` produced `A3=[X1,X2]` while returning `true` (no interpreter fallback).

Runtime helpers (`beginStructure`, `pushWriteArg`, `kotlinLoUnify*`) were already correct.

## Fix

- Emit `run { ... }` for `get_variable` / `put_variable`
- Re-add `parts_supported` for `get/put_structure`, `get/put_list`, `set_*`, `unify_*`
- Align `set_value` with the interpreter (`?: return false` on missing register)

## Tests

`LANG=C.UTF-8 swipl -q -g run_tests -t halt tests/test_wam_kotlin_target.pl` — **15/15 green** (incl. gradle e2e).

- Convert decline-path regressions to assert **Native** partition + lowered fun emit
- Gradle e2e: list builder, structure builder, and nested `foo(X,[Y])` under `emit_mode(functions)` match `emit_mode(interpreter)` bindings

## Out of scope

T4/T5 multi-clause, ITE, `call`/`execute` in lowered bodies (separate cards).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

