### PR TITLE
mu_cosine: batched square-root/QR conditioning with correlation whitening

### DIFF
--- a/prototypes/mu_cosine/DESIGN_joint_square_root_qr_conditioner.md
+++ b/prototypes/mu_cosine/DESIGN_joint_square_root_qr_conditioner.md
@@ -117,6 +117,13 @@ measurement space while `U` lives in state space) and, even when the dimensions 
 product of precisions rather than the Bayesian sum.  `W @ J` is the valid multiplication; QR of the vertical
 stack performs the required addition without forming normal equations.
 
+This vertical-stack construction is the classical square-root-information pattern.  A
+[CERFACS sequential-least-squares presentation](https://cerfacs.fr/wp-content/uploads/2017/05/Alina_presentation_kf.pdf)
+explicitly triangularises a prior information root/RHS together with new measurement rows, and
+[Tracy (2022)](https://arxiv.org/abs/2208.06452) gives a QR-only square-root Kalman construction.  These
+references support the orthogonal stacking pattern; they do not by themselves establish this conditioner's
+nonzero-`C` Schur-complement reduction, which is the model-specific preprocessing derived above.
+
 ### Diagonal loading
 
 Near-singular empirical correlations can require a small diagonal load before Cholesky.  Loading must be in
@@ -135,6 +142,20 @@ round-off may be lifted; a materially indefinite `Rc` is evidence that the fitte
 complement is invalid and must be rejected.  Reports and benchmark output should include `scale`, the raw
 minimum eigenvalue, `target`, and `delta`, since increasing `delta` weakens the measurement statistically as
 well as stabilising the factorisation.
+
+There are deliberately two rejection gates.  The negative-eigenvalue tolerance is a **hard validity gate**
+applied before loading; `maximum_relative_loading` is a separate **repair budget**.  Their defaults are coupled:
+the negative tolerance is capped at half of the budget remaining after the relative floor, so a
+round-off-negative matrix accepted by the default validity gate remains repairable within the default budget.
+An explicitly supplied negative tolerance may override that coupling and can still pass the first gate but fail
+the repair-budget gate.  This is preferable to silently weakening a measurement; a caller that changes either
+gate must justify the statistical and numerical budget together.
+
+The Torch square-root and conditional-conditioning APIs now default `jitter` to `0.0`, rather than applying the
+historical absolute `1e-9` floor.  The scale-relative floor remains active and observable, while an absolute
+floor is opt-in and expressed in covariance units.  Consequently, a near-singular covariance that the old
+absolute jitter happened to repair can now be rejected by the hard-validity or loading-budget gate.  The
+compatibility helper `regularize_covariance_torch` retains its explicitly absolute policy.
 
 For a zero-mean prior error, `z_prior = 0`. More generally `z_prior = U m_prior`. Form
 
@@ -170,6 +191,45 @@ x_post      = x_prior + e_post.
 
 The implementation normalises the diagonal of `U_post` to be non-negative, making the root deterministic
 under row permutations up to floating-point error.
+
+### Rank and input-validation contract
+
+For an `M x N` information pre-array `G`, the NumPy and Torch implementations first compute `a = max(abs(G))` for
+finite/zero/subnormal validation, then evaluates the rank comparison without materialising a possibly
+unrepresentable Frobenius scale:
+
+```
+rho = ||G / a||_F
+min(abs(diag(U_post))) / a <= eps(dtype) * max(M, N) * rho
+```
+
+This is algebraically the test with `s_F = a * rho` and
+`tau = eps(dtype) * max(M, N) * s_F`, but avoids overflow in `s_F`.  The Frobenius scale is a conservative,
+cheap upper bound on `sigma_max(G)`, not an exact singular-value or rank-revealing-QR test.  It preserves the
+previous normal-scale sensitivity without the old unit-scale clamp, and the predicate is homogeneous when the
+**entire** pre-array is multiplied by one nonzero finite scalar.  It does not promise invariance to independent
+per-column/per-direction rescaling; mixed-unit state coordinates should be explicitly standardized or
+equilibrated and still require condition-number tests.
+
+Both implementations reject non-finite coefficients, zero scale, and subnormal global scale.  In the Torch
+backend these design-time checks intentionally synchronize a CUDA stream.  Repeated Torch hot-RHS application
+does not perform a per-call finiteness reduction, so a non-finite innovation/RHS can propagate as a non-finite
+result.  Production callers that require fail-fast behavior should validate observations once at batch ingress
+(or enable a debug boundary check), rather than inserting device synchronizations into every compiled update.
+
+### Dense covariance companion
+
+When the compiled dense-gain baseline must return a covariance, it uses the effective conditional model and
+the Joseph form
+
+```
+P_post = (I - K J) P (I - K J)^T + K Rc K^T
+```
+
+rather than the cancellation-prone subtraction `P - K S K^T`.  Each summand is positive semidefinite in exact
+arithmetic.  [Tracy (2022)](https://arxiv.org/abs/2208.06452) likewise starts from Joseph-form covariance
+algebra in deriving a QR square-root update; here that citation motivates the numerical form, while the tests
+establish equivalence for this implementation's correlated conditional model.
 
 ## 3. Block updates
 

--- a/prototypes/mu_cosine/DESIGN_joint_square_root_qr_conditioner.md
+++ b/prototypes/mu_cosine/DESIGN_joint_square_root_qr_conditioner.md
@@ -70,12 +70,88 @@ A = L^-1 J
 b = L^-1 r.
 ```
 
+This is the precise correlation-to-inverse-root step.  If the **conditional** measurement-error model is
+supplied as a correlation matrix `Kc` and marginal conditional standard deviations `s`, construct
+
+```
+Rc = diag(s) Kc diag(s).
+```
+
+If instead calibration supplies the raw joint correlation of prior error `e` and measurement noise `v`, first
+restore covariance units blockwise,
+
+```
+P = diag(s_e) K_ee diag(s_e)
+C = diag(s_e) K_ev diag(s_v)
+R = diag(s_v) K_vv diag(s_v),
+```
+
+and only then form the Schur complement `Rc = R - C^T P^-1 C`.  With nonzero `C`, raw measurement correlation
+`K_vv` is not generally the conditional correlation `Kc` that must be whitened.
+
+The operator `W = L^-1` is a left square root of the measurement precision because
+
+```
+W^T W = Rc^-1
+W Rc W^T = I.
+```
+
+The implementation should normally **apply** `W` with triangular solves (`solve(L, J)` and `solve(L, r)`) rather
+than materialise either `W` or `Rc^-1`.  An explicit inverse square root is useful for inspection or interchange,
+but is unnecessary work in the update itself.
+
+There is one related multiplication that *is* valid: converting an existing state-covariance root into
+standardized correlation coordinates.  If `P = D K D` and `U_P^T U_P = P^-1`, then
+`U_K = U_P D` satisfies `U_K^T U_K = K^-1`.  This is a coordinate change within the same state space; it is not
+how a new likelihood is assimilated.
+
+The prior and measurement roots are stacked, not multiplied:
+
+```
+[ U ]^T [ U ] = U^T U + J^T Rc^-1 J.
+[ WJ]   [ WJ]
+```
+
+Multiplying a Cholesky factor of `Rc^-1` by the previous root is generally dimensionally invalid (`Rc` lives in
+measurement space while `U` lives in state space) and, even when the dimensions happen to match, represents a
+product of precisions rather than the Bayesian sum.  `W @ J` is the valid multiplication; QR of the vertical
+stack performs the required addition without forming normal equations.
+
+### Diagonal loading
+
+Near-singular empirical correlations can require a small diagonal load before Cholesky.  Loading must be in
+covariance units and visible in diagnostics.  A scale-aware policy uses
+
+```
+scale = max(abs(eig(Rc)))
+target = max(absolute_floor, relative_floor * scale)
+delta = max(0, target - min(eig(Rc)))
+Rc_stable = Rc + delta I
+```
+
+Here `target` is the desired minimum eigenvalue and `delta` is the amount actually added; they must not be
+conflated.  Machine epsilon alone is not a scale-independent policy.  A tiny negative eigenvalue consistent with
+round-off may be lifted; a materially indefinite `Rc` is evidence that the fitted joint covariance or the Schur
+complement is invalid and must be rejected.  Reports and benchmark output should include `scale`, the raw
+minimum eigenvalue, `target`, and `delta`, since increasing `delta` weakens the measurement statistically as
+well as stabilising the factorisation.
+
 For a zero-mean prior error, `z_prior = 0`. More generally `z_prior = U m_prior`. Form
 
 ```
 [ U_prior   z_prior ]
 [ A         b       ].
 ```
+
+`z` is the **square-root information RHS**, not the canonical information vector.  The identities are
+
+```
+eta = U^T z
+z   = U m
+m   = solve(U, z).
+```
+
+Passing `eta` where this API expects `z` gives the wrong posterior mean.
 
 Apply Householder reflectors to the coefficient columns and the RHS together, without forming `Q`:
 
@@ -110,6 +186,12 @@ Therefore raw measurement families can be uncorrelated while their conditional r
 the shared prior. Estimate and test the off-block entries of `Rc` on held-out, node-disjoint calibration data
 before enabling streamed bundle updates. The state prior is inserted exactly once; never repeat a complete
 `[[P,C_i],[C_i^T,R_i]]` block for every bundle.
+
+For an empirical approximate partition, report at least the conditional correlation matrix, relative off-block
+Frobenius mass, and the largest whitened off-block spectral norm
+`||Rc_ii^-1/2 Rc_ij Rc_jj^-1/2||_2`.  Select any approximation threshold before the confirmatory evaluation and
+validate its posterior/NLL sensitivity against full-`Rc` whitening.  The present streamed API assumes the caller
+has already accepted that contract; automatic partition selection is future work.
 
 The streamed `(U_post,z_post)` state remains in one fixed state coordinate. If every `b_i` is formed relative
 to the original prior origin, carry both `U_post` and `z_post`. If instead the state is recentered at the first

--- a/prototypes/mu_cosine/REPORT_joint_square_root_qr_benchmark.md
+++ b/prototypes/mu_cosine/REPORT_joint_square_root_qr_benchmark.md
@@ -32,8 +32,9 @@ gain after a sequential block changes the posterior.
 - Timings are on-device compute point measurements from one process run. They exclude host/device transfer and
   report a mean over repeats, not median/MAD across independent trials.
 - `compile_ms` and `condition_ms` are deliberately separate. Rows/s measures only repeated conditioning after
-  compilation. Dense compile time includes checking/regularising the subtraction-form posterior covariance;
-  without that check a highly informative float32 update can round the dense covariance to singular zero.
+  compilation. At the time of this run, dense compilation checked/regularised a subtraction-form posterior
+  covariance. The implementation now uses the algebraically equivalent Joseph form to avoid that catastrophic
+  subtraction; the conditioning timings are unaffected, but the historical setup timings were not rerun.
 
 The matched baseline, `CompiledDenseGainConditionerTorch`, validates the same Schur-complement model and
 precomputes the correlated gain `K` and posterior covariance. Each row then needs only the affine innovation

--- a/prototypes/mu_cosine/REPORT_streamed_block_qr_benchmark.md
+++ b/prototypes/mu_cosine/REPORT_streamed_block_qr_benchmark.md
@@ -1,0 +1,301 @@
+# Batched measurement blocks with the joint square-root / QR conditioner
+
+Run 2026-07-11. This report benchmarks the sequential regime left open by
+`REPORT_joint_square_root_qr_benchmark.md`.
+
+## Result in one paragraph
+
+Batching several available measurement blocks into **one stacked Householder QR** is substantially faster than
+launching one QR per block. CUDA becomes worthwhile for QR when a fixed design has thousands of independent
+right-hand sides: at `n=128`, 32 measurements per block, 16 blocks, and `B=4096`, full stacked QR fell from
+`10.392 ± 0.197 ms` on CPU to `3.939 ± 0.034 ms` on CUDA. It did **not** cross over at `B=128`, and batched QR
+of 128 distinct designs was slower on the local GTX 1660 SUPER than CPU QR. Dense normal-equation updates were
+usually faster, but in the conditioning stress test their float32 Cholesky failed in one regime and incurred
+`1.50e-4` relative solution error in another, while Householder QR stayed near `1e-6`. The resulting policy is:
+stack blocks that are already available, stream only genuinely online/adaptive blocks, retain QR for its
+stability, and use CUDA after measuring the actual shared-versus-distinct design shape.
+
+This square-root conditioner is not `JointPosterior`. `JointPosterior` is a learned nonlinear decision model;
+the conditioner is a numerical backend for a correlated linear-Gaussian posterior. They can be used together.
+
+## Four dimensions, not two
+
+The benchmark uses separate symbols for quantities that are easy to conflate:
+
+| symbol | meaning | values exercised |
+|---|---|---|
+| `n` | latent-state dimension | `2, 32, 128` |
+| `m_block` | measurements/judges in one block | `32` |
+| `T` | blocks assimilated into one posterior | selected `1,4,16`; CLI also exposes `2,8` |
+| `B` | independent posterior systems processed together | `128`, plus the `4096` crossover cell |
+| `M_total` | total likelihood rows, `T * m_block` | `32,128,512` |
+
+Thus the proposed `n=128,m=32` case becomes a `(n + Tm_block) × n` information pre-array when all blocks are
+stacked. `B` is a separate CUDA batch/RHS axis.
+
+Two design regimes matter:
+
+- **shared:** all `B` systems use the same block coefficients and differ only in their right-hand sides. One
+  factorization can serve all systems.
+- **distinct:** every system has its own block coefficients, as can happen when covariance or observation
+  geometry depends on the item. CUDA must perform `B` distinct factorizations.
+
+## Statistical construction and algorithms
+
+Each synthetic block starts with a dense within-block conditional covariance `Rc_t`. It is Cholesky-whitened to
+
+```text
+A_t = chol(Rc_t)^-1 J_t
+b_t = chol(Rc_t)^-1 r_t
+```
+
+and conditional cross-block covariance is exactly zero. Whitening and covariance estimation are outside the
+timed region. That isolates the conditioner; it also means this benchmark does **not** yet test semantic- or
+graph-distance cross-block correlation.
+
+All algorithms start with `P^-1 = U.T @ U` and zero information RHS:
+
+1. **`full_stacked_qr`:** one Householder QR of `stack([U,A_1,...,A_T])`.
+2. **`streamed_qr`:** `T` Householder QR calls, carrying `(U_t,z_t)` into the next block.
+3. **`dense_recompute`:** accumulate `Lambda += A_t.T @ A_t` and `eta += A_t.T @ b_t`, Cholesky-refactoring
+   the normal equations after every block. This is a speed baseline, not a square-root-stability method.
+4. **`cached_dense_full`:** for a shared, completely known design only, factor the final normal equations once
+   and apply new RHS batches. It does not produce the intermediate online roots.
+
+The stacked and streamed QR paths produce the same posterior in exact arithmetic. Stacking wins when all blocks
+are already present because it replaces `T` factorizations and launches with one larger operation. Streaming is
+still necessary when a block arrives later, depends on an earlier posterior, or an intermediate root is itself
+the required output.
+
+## Hardware and timing protocol
+
+- CPU: Intel Core i7-10700KF, eight PyTorch threads.
+- GPU: NVIDIA GeForce GTX 1660 SUPER, 6 GiB.
+- PyTorch 2.4.1+cu121; CUDA runtime 12.1; WSL2.
+- Nominal workload: float32, target prior/within-block covariance condition number 10, conditional-noise scale
+  1, seed `20260711`.
+- CUDA timing synchronizes around every trial. Tables report median ± median absolute deviation (MAD).
+- Input H2D and result D2H copies are timed separately and excluded from trajectory latency. The current harness
+  pre-casts on the host so H2D measures transfer rather than transfer plus a CUDA-only dtype conversion.
+- Peak CUDA memory is incremental temporary allocation, not the allocator's reserved pool; it excludes any
+  compiled object already resident at the start of a conditioning trial.
+- The final `n=128,B=128` CUDA cells use 11 trials and CPU cells use 7; the smaller-state table uses 11. The
+  `B=4096` crossover uses 11 trials. All have warmups. Exact commands appear below.
+
+### Authoritative-run policy
+
+The compute tables use the **final recorded runs**: compute receives the configured warmups and CUDA's caching
+allocator is not emptied between timed trials. Peak allocation is measured with `reset_peak_memory_stats`
+without changing that steady-state timing protocol.
+
+These runs supersede exploratory figures produced while the harness still called `empty_cache()` before each
+trial and before transfer timing had a warmup. In particular, do not mix the superseded
+`2.934 / 196.941 ms` `B=128` CUDA values or the `10.666 / 3.967 ms`, `H2D=4.375 ms` `B=4096` values with the
+tables below. The authoritative corresponding compute values are `3.424 / 193.247 ms` and
+`10.392 / 3.939 ms`.
+
+The recorded `H2D=4.855 ms` value also included float64-to-float32 conversion. A post-review harness correction
+now pre-casts identically for CPU and CUDA, so that value is retained below only as a conservative historical
+upper bound; the current command must be rerun on a CUDA host for a transfer-only number. Compute timings are
+unaffected by this correction.
+
+## `n=128`, `m_block=32`, `B=128`
+
+### Shared design
+
+Trajectory median ± MAD, milliseconds. Cached dense is shown as `setup + condition`.
+
+| `T` | CPU stacked QR | CUDA stacked QR | CPU streamed QR | CUDA streamed QR | CPU dense recompute | CUDA dense recompute | CPU cached dense | CUDA cached dense |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 0.719 ± .005 | 3.147 ± .088 | 0.749 ± .017 | 2.980 ± .090 | 0.409 ± .010 | 0.767 ± .007 | .136 + .165 | .415 + .311 |
+| 4 | 0.873 ± .006 | 2.743 ± .179 | 3.075 ± .110 | 10.474 ± .342 | 1.484 ± .036 | 2.382 ± .087 | .173 + .205 | .410 + .329 |
+| 16 | **1.273 ± .024** | 3.424 ± .095 | 11.033 ± .495 | 39.879 ± 1.281 | 5.731 ± .244 | 9.574 ± .637 | .177 + .218 | .406 + .335 |
+
+At this batch size the CPU wins every shared-design QR cell. At `T=16`, stacking is 8.7× faster than streaming
+on CPU and 11.6× on CUDA. The cached-dense row is a static lower bound, not a matched cache comparison: this
+sequential harness does not yet time cached full/streamed QR chains. Compare `setup + condition` for a one-shot
+call; use `REPORT_joint_square_root_qr_benchmark.md` for the matched repeated fixed-design comparison.
+
+### Distinct design per system
+
+| `T` | CPU stacked QR | CUDA stacked QR | CPU streamed QR | CUDA streamed QR | CPU dense recompute | CUDA dense recompute |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 24.356 ± 1.412 | 113.350 ± .362 | 24.472 ± .513 | 113.111 ± .261 | 22.207 ± 4.185 | **1.625 ± .038** |
+| 4 | 34.799 ± .750 | 119.602 ± .466 | 109.855 ± 11.635 | 454.403 ± 2.043 | 45.038 ± 1.640 | **6.152 ± .103** |
+| 16 | **66.145 ± .878** | 193.247 ± .788 | 422.071 ± 11.815 | 1804.537 ± 4.470 | 177.832 ± 4.051 | **23.828 ± .187** |
+
+The local GPU's batched `geqrf` path is a poor fit for 128 distinct tall-skinny factorizations: CPU
+Householder wins decisively. CUDA does accelerate the dense batched Cholesky baseline. This is a backend and
+hardware result, not evidence against QR's numerical role.
+
+For the distinct `T=16` CUDA cell, the historical cast-plus-H2D upper bound is `15.097 ± .239 ms`; D2H is about
+`1.6 ms`. Peak incremental
+allocation is 160.94 MiB for stacked QR, 46.61 MiB for streamed QR, and 32.19 MiB for dense recomputation.
+Streaming trades substantially more time for bounded memory as `T` grows.
+
+## The shared-design CUDA crossover: `B=4096`
+
+At `n=128,m_block=32,T=16`, increasing the shared RHS batch from 128 to 4096 produces the expected GPU
+crossover:
+
+| algorithm | CPU trajectory ms | CUDA trajectory ms | CUDA peak MiB |
+|---|---:|---:|---:|
+| full stacked QR | 10.392 ± .197 | **3.939 ± .034** | 34.95 |
+| streamed QR | 54.951 ± 2.336 | **39.146 ± .407** | 17.31 |
+| dense recompute | 54.164 ± 3.870 | **20.464 ± .066** | 10.19 |
+| cached dense full | .183 setup + 2.812 condition | **.492 setup + 1.220 condition** | 6.25 |
+
+The historical cast-plus-input-transfer upper bound is `4.855 ± .171 ms`; output transfer is `.74–.93 ms`.
+Even with that conservative surcharge, stacked QR barely wins end-to-end if every batch begins and ends on the
+host; device residency materially strengthens the CUDA case. The current pre-cast harness needs a CUDA rerun
+before quoting a transfer-only crossover. Cached dense loses its end-to-end CUDA advantage under the historical
+cast-plus-transfer protocol.
+
+## Smaller states
+
+The selected distinct-design grid shows the same qualitative result at `B=128,T=16`:
+
+| `n` | CPU stacked QR ms | CUDA stacked QR ms | CPU streamed QR ms | CUDA streamed QR ms | CPU / CUDA dense recompute ms |
+|---:|---:|---:|---:|---:|---:|
+| 2 | **.808** | 5.958 | **10.387** | 54.136 | **2.388** / 7.739 |
+| 32 | **14.749** | 46.922 | **64.750** | 420.016 | **9.604** / 10.287 |
+| 128 | **66.145** | 193.247 | **422.071** | 1804.537 | 177.832 / **23.828** |
+
+There is no general rule that a larger pre-array automatically makes CUDA QR faster. Shared reflector reuse,
+the number of independent RHSs, distinct versus common designs, GPU generation, and transfer all matter.
+
+## Numerical behavior
+
+Every output is compared with a float64 dense full-trajectory reference. The CSV reports:
+
+- relative final-solution error;
+- relative root error against the positive-diagonal float64 Cholesky root;
+- relative Gram error `||U.T U - Lambda_ref|| / ||Lambda_ref||`; and
+- solution and Gram changes after reversing block order.
+
+In the nominal `n=128,B=128,T=16` float32 runs, QR solution errors were below `7.3e-7`, Gram errors below
+`3.0e-7`, and reverse-order solution changes below `1.1e-6`. At `B=4096`, streamed QR's solution error was
+`1.06e-6` and its reverse-order change was `1.50e-6`.
+
+A focused `condition=1e6` CUDA stress run demonstrates why the root method remains useful:
+
+| noise scale | dtype | stacked QR solution / Gram error | streamed QR solution / Gram error | dense solution / Gram error |
+|---:|---|---:|---:|---:|
+| .001 | float32 | `5.73e-7 / 1.41e-7` | `1.44e-6 / 4.11e-7` | **Cholesky failed** |
+| 1000 | float32 | `8.18e-7 / 1.96e-7` | `2.07e-6 / 8.13e-7` | `1.50e-4 / 1.83e-7` |
+| .001 | float64 | `1.20e-14 / 3.90e-16` | `1.23e-14 / 8.07e-16` | `1.47e-14 / 3.15e-16` |
+| 1000 | float64 | `2.35e-13 / 5.23e-16` | `2.35e-13 / 1.44e-15` | `2.88e-13 / 2.79e-16` |
+
+The dense baseline forms normal equations. Its tiny Gram error does not guarantee an accurate solution when
+conditioning is poor, and its mathematically positive precision can become non-positive in float32. The
+benchmark records per-algorithm execution failures as CSV rows rather than aborting that cell.
+
+## What “blocks on the diagonal” permits
+
+Exact independent streaming requires block diagonality of the **conditional** covariance
+
+```text
+Rc = R - C.T @ P^-1 @ C,
+```
+
+not merely raw `R`. Dense interactions among the 32 judges inside one block are already permitted and are
+absorbed by that block's whitening factor. Off-block semantic or graph-distance correlation makes `Rc` dense
+and cannot be ignored without changing the statistical model.
+
+A good next statistical extension is a positive-semidefinite structured residual model, fit on held-out
+calibration residuals, for example
+
+```text
+Rc = D + K_item(graph_distance, semantic_distance) ⊗ Sigma_judge.
+```
+
+Use a PSD graph diffusion kernel or embedding RBF rather than an arbitrary distance-to-correlation rule. A
+low-rank shared judge/corpus-drift term is especially attractive: augmenting the latent state with those
+factors can restore conditional block independence and preserve streamed QR. Compare full dense whitening,
+the structured model, and a block-diagonal approximation on posterior KL/calibration—not just runtime.
+
+This covariance experiment is distinct from measuring whether graph-judge supervision helps a model learn a
+dataset's entities and topology. That requires a matched training/adaptation ablation.
+
+## Reproduction
+
+Lightweight default (`n=128`, `T=1,4`, `B=1,128`, distinct float32 design; CPU and CUDA when available):
+
+```bash
+python3 -u prototypes/mu_cosine/benchmark_streamed_block_qr.py
+```
+
+The full shape grid is exposed but intentionally not the default:
+
+```bash
+python3 -u prototypes/mu_cosine/benchmark_streamed_block_qr.py \
+  --full-grid --measurements-per-block 32 --devices cpu,cuda \
+  --warmups 5 --trials 21 --transfer-trials 11 --cpu-threads 8
+```
+
+The `n=128,B=128` reported cells were produced by the following CPU and CUDA runs:
+
+```bash
+python3 -u prototypes/mu_cosine/benchmark_streamed_block_qr.py \
+  --state-dims 128 --measurements-per-block 32 --block-counts 1,4,16 \
+  --batch-sizes 128 --design-modes shared,distinct --dtypes float32 \
+  --condition-numbers 10 --noise-scales 1 \
+  --algorithms full_stacked_qr,streamed_qr,dense_recompute,cached_dense_full \
+  --devices cpu --warmups 2 --trials 7 --transfer-trials 1 \
+  --inner-repeats 1 --cpu-threads 8
+
+python3 -u prototypes/mu_cosine/benchmark_streamed_block_qr.py \
+  --state-dims 128 --measurements-per-block 32 --block-counts 1,4,16 \
+  --batch-sizes 128 --design-modes shared,distinct --dtypes float32 \
+  --condition-numbers 10 --noise-scales 1 \
+  --algorithms full_stacked_qr,streamed_qr,dense_recompute,cached_dense_full \
+  --devices cuda --warmups 5 --trials 11 --transfer-trials 7 \
+  --inner-repeats 1 --cpu-threads 8
+
+python3 -u prototypes/mu_cosine/benchmark_streamed_block_qr.py \
+  --state-dims 2,32 --measurements-per-block 32 --block-counts 16 \
+  --batch-sizes 128 --design-modes distinct --dtypes float32 \
+  --condition-numbers 10 --noise-scales 1 \
+  --algorithms full_stacked_qr,streamed_qr,dense_recompute \
+  --devices cpu,cuda --warmups 5 --trials 11 --transfer-trials 7 \
+  --inner-repeats 1 --cpu-threads 8
+```
+
+The `B=4096` crossover and numerical stress commands were:
+
+```bash
+python3 -u prototypes/mu_cosine/benchmark_streamed_block_qr.py \
+  --state-dims 128 --measurements-per-block 32 --block-counts 16 \
+  --batch-sizes 4096 --design-modes shared --dtypes float32 \
+  --condition-numbers 10 --noise-scales 1 \
+  --algorithms full_stacked_qr,streamed_qr,dense_recompute,cached_dense_full \
+  --devices cpu,cuda --warmups 5 --trials 11 --transfer-trials 7 \
+  --inner-repeats 1 --cpu-threads 8
+
+python3 -u prototypes/mu_cosine/benchmark_streamed_block_qr.py \
+  --state-dims 128 --measurements-per-block 32 --block-counts 16 \
+  --batch-sizes 128 --design-modes shared --dtypes float32,float64 \
+  --condition-numbers 1000000 --noise-scales 0.001,1000 \
+  --algorithms full_stacked_qr,streamed_qr,dense_recompute \
+  --devices cuda --warmups 1 --trials 2 --transfer-trials 2 \
+  --inner-repeats 1 --cpu-threads 8
+```
+
+Validation performed:
+
+```bash
+python3 -m py_compile prototypes/mu_cosine/benchmark_streamed_block_qr.py
+
+python3 prototypes/mu_cosine/benchmark_streamed_block_qr.py \
+  --state-dims 3 --measurements-per-block 4 --block-counts 2 \
+  --batch-sizes 2 --design-modes shared,distinct --dtypes float32 \
+  --condition-numbers 10 --noise-scales 1 --devices cpu \
+  --warmups 1 --trials 1 --transfer-trials 1 --inner-repeats 1 \
+  --cpu-threads 1
+```
+
+All smoke cells completed with `status=ok`; the expected dense float32 algorithm failure was captured as
+`failed_LinAlgError`. Per-algorithm execution failures are emitted as CSV status rows after a problem and its
+reference have been constructed. Problem generation, reference construction, or device-transfer/OOM failures
+can still abort the sweep and should be handled by the outer job runner. The complete condition/scale grid is
+deliberately opt-in because it multiplies an already large shape grid.

--- a/prototypes/mu_cosine/REPORT_streamed_block_qr_benchmark.md
+++ b/prototypes/mu_cosine/REPORT_streamed_block_qr_benchmark.md
@@ -15,6 +15,10 @@ usually faster, but in the conditioning stress test their float32 Cholesky faile
 stack blocks that are already available, stream only genuinely online/adaptive blocks, retain QR for its
 stability, and use CUDA after measuring the actual shared-versus-distinct design shape.
 
+The CUDA crossover is a **local, compute-only, hardware-specific** result: trajectory timing excludes transfers,
+and the corrected pre-cast transfer benchmark has not been rerun, so no transfer-inclusive crossover is
+established. It is not a general `B=4096` recommendation for other GPUs or deployment pipelines.
+
 This square-root conditioner is not `JointPosterior`. `JointPosterior` is a learned nonlinear decision model;
 the conditioner is a numerical backend for a correlated linear-Gaussian posterior. They can be used together.
 
@@ -71,22 +75,45 @@ the required output.
 
 - CPU: Intel Core i7-10700KF, eight PyTorch threads.
 - GPU: NVIDIA GeForce GTX 1660 SUPER, 6 GiB.
+- NVIDIA lists no Tensor Cores for this consumer Turing card. That specification alone does not predict QR
+  throughput, so its crossover and float64 results remain device- and backend-specific measurements. See NVIDIA's
+  [GeForce comparison table](https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs).
 - PyTorch 2.4.1+cu121; CUDA runtime 12.1; WSL2.
 - Nominal workload: float32, target prior/within-block covariance condition number 10, conditional-noise scale
   1, seed `20260711`.
 - CUDA timing synchronizes around every trial. Tables report median ± median absolute deviation (MAD).
+- QR trajectory timing also includes finite/scale/rank validation and its device synchronizations for every
+  factorization. Streamed QR repeats that cost once per block, whereas stacked QR pays it once. A fixed,
+  prevalidated design can hoist these guards and reuse a compiled factor, so the streamed/stacked ratios measure
+  this harness's complete conditioner-core path, not pure `geqrf`/kernel-launch arithmetic.
 - Input H2D and result D2H copies are timed separately and excluded from trajectory latency. The current harness
   pre-casts on the host so H2D measures transfer rather than transfer plus a CUDA-only dtype conversion.
 - Peak CUDA memory is incremental temporary allocation, not the allocator's reserved pool; it excludes any
   compiled object already resident at the start of a conditioning trial.
+- CPU peak memory was not measured; the reported memory/latency trade-off is characterized only on CUDA.
 - The final `n=128,B=128` CUDA cells use 11 trials and CPU cells use 7; the smaller-state table uses 11. The
   `B=4096` crossover uses 11 trials. All have warmups. Exact commands appear below.
+
+The named CUDA paths executed locally to produce the timing tables, but the CUDA-gated correctness tests were
+skipped in the available non-CUDA validation environment and are not presently verified by CI. The GTX 1660
+SUPER results should therefore be treated as local prototype evidence, not cross-device validation.
 
 ### Authoritative-run policy
 
 The compute tables use the **final recorded runs**: compute receives the configured warmups and CUDA's caching
 allocator is not emptied between timed trials. Peak allocation is measured with `reset_peak_memory_stats`
 without changing that steady-state timing protocol.
+
+The recorded timing tables predate the post-review rank-guard cleanup, which removed a duplicate scale check
+and restored a stable Frobenius rank scale. They have not been rebaselined against that code change, so their
+absolute values describe the pre-review conditioner path; the per-factorization guard/synchronization caveat
+above still applies to the current path.
+
+The reported error rows also predate the switch from a float64 normal-equations reference solve to the current
+direct stacked least-squares reference. On the two seeded problems with target prior/within-block covariance
+condition number `1e6`, the old and new float64 solutions differ by only `1.21e-14` and `2.51e-13` relatively,
+respectively; this independently confirms that the historical error magnitudes remain representative, but the
+CUDA rows themselves were not rerun.
 
 These runs supersede exploratory figures produced while the harness still called `empty_cache()` before each
 trial and before transfer timing had a warmup. In particular, do not mix the superseded
@@ -96,8 +123,8 @@ tables below. The authoritative corresponding compute values are `3.424 / 193.24
 
 The recorded `H2D=4.855 ms` value also included float64-to-float32 conversion. A post-review harness correction
 now pre-casts identically for CPU and CUDA, so that value is retained below only as a conservative historical
-upper bound; the current command must be rerun on a CUDA host for a transfer-only number. Compute timings are
-unaffected by this correction.
+upper bound; the current command must be rerun on a CUDA host before establishing a transfer-inclusive
+crossover. Compute timings are unaffected by this correction.
 
 ## `n=128`, `m_block=32`, `B=128`
 
@@ -135,7 +162,7 @@ Streaming trades substantially more time for bounded memory as `T` grows.
 
 ## The shared-design CUDA crossover: `B=4096`
 
-At `n=128,m_block=32,T=16`, increasing the shared RHS batch from 128 to 4096 produces the expected GPU
+At `n=128,m_block=32,T=16`, increasing the shared RHS batch from 128 to 4096 produces a local compute-only GPU
 crossover:
 
 | algorithm | CPU trajectory ms | CUDA trajectory ms | CUDA peak MiB |
@@ -148,7 +175,7 @@ crossover:
 The historical cast-plus-input-transfer upper bound is `4.855 ± .171 ms`; output transfer is `.74–.93 ms`.
 Even with that conservative surcharge, stacked QR barely wins end-to-end if every batch begins and ends on the
 host; device residency materially strengthens the CUDA case. The current pre-cast harness needs a CUDA rerun
-before quoting a transfer-only crossover. Cached dense loses its end-to-end CUDA advantage under the historical
+before quoting a transfer-inclusive crossover. Cached dense loses its end-to-end CUDA advantage under the historical
 cast-plus-transfer protocol.
 
 ## Smaller states
@@ -166,10 +193,12 @@ the number of independent RHSs, distinct versus common designs, GPU generation, 
 
 ## Numerical behavior
 
-Every output is compared with a float64 dense full-trajectory reference. The CSV reports:
+Current benchmark runs compare every output with a float64 full-trajectory reference. The reference solves the original stacked
+least-squares system directly and obtains its root by a separate reduced QR; it does not solve normal equations.
+The CSV reports:
 
 - relative final-solution error;
-- relative root error against the positive-diagonal float64 Cholesky root;
+- relative root error against the positive-diagonal float64 QR reference root;
 - relative Gram error `||U.T U - Lambda_ref|| / ||Lambda_ref||`; and
 - solution and Gram changes after reversing block order.
 
@@ -177,7 +206,8 @@ In the nominal `n=128,B=128,T=16` float32 runs, QR solution errors were below `7
 `3.0e-7`, and reverse-order solution changes below `1.1e-6`. At `B=4096`, streamed QR's solution error was
 `1.06e-6` and its reverse-order change was `1.50e-6`.
 
-A focused `condition=1e6` CUDA stress run demonstrates why the root method remains useful:
+A focused CUDA stress run with target prior/within-block covariance condition number `1e6` illustrates why the
+root method remains useful:
 
 | noise scale | dtype | stacked QR solution / Gram error | streamed QR solution / Gram error | dense solution / Gram error |
 |---:|---|---:|---:|---:|
@@ -189,6 +219,10 @@ A focused `condition=1e6` CUDA stress run demonstrates why the root method remai
 The dense baseline forms normal equations. Its tiny Gram error does not guarantee an accurate solution when
 conditioning is poor, and its mathematically positive precision can become non-positive in float32. The
 benchmark records per-algorithm execution failures as CSV rows rather than aborting that cell.
+
+These stability figures are one seeded synthetic instance (`20260711`) per reported setting. They demonstrate
+a concrete failure mode but do not estimate its frequency or error distribution; a multi-seed, independently
+generated condition/scale sweep remains required before making a probabilistic reliability claim.
 
 ## What “blocks on the diagonal” permits
 
@@ -294,8 +328,8 @@ python3 prototypes/mu_cosine/benchmark_streamed_block_qr.py \
   --cpu-threads 1
 ```
 
-All smoke cells completed with `status=ok`; the expected dense float32 algorithm failure was captured as
-`failed_LinAlgError`. Per-algorithm execution failures are emitted as CSV status rows after a problem and its
-reference have been constructed. Problem generation, reference construction, or device-transfer/OOM failures
-can still abort the sweep and should be handled by the outer job runner. The complete condition/scale grid is
-deliberately opt-in because it multiplies an already large shape grid.
+All nominal smoke cells completed with `status=ok`. In the separately reported ill-conditioned stress run, the
+dense failure was emitted as `failed_LinAlgError`. Per-algorithm execution failures are emitted as CSV status
+rows after a problem and its reference have been constructed. Problem generation, reference construction, or
+device-transfer/OOM failures can still abort the sweep and should be handled by the outer job runner. The
+complete condition/scale grid is deliberately opt-in because it multiplies an already large shape grid.

--- a/prototypes/mu_cosine/benchmark_streamed_block_qr.py
+++ b/prototypes/mu_cosine/benchmark_streamed_block_qr.py
@@ -1,0 +1,745 @@
+#!/usr/bin/env python3
+"""Benchmark batched sequential information updates with 32-judge blocks.
+
+The four workload axes are deliberately separate:
+
+``n``
+    latent state dimension;
+``m_block``
+    measurements (for example judges/channels) in one likelihood block;
+``T``
+    blocks assimilated into one posterior trajectory; and
+``B``
+    independent posterior systems processed in parallel.
+
+The synthetic likelihood has a dense covariance *within* each block and zero
+conditional covariance *between* blocks.  Each block is Cholesky-whitened
+before timing.  The benchmark therefore measures the information-conditioner
+core, not covariance estimation or whitening.
+
+Algorithms:
+
+* ``full_stacked_qr``: one Householder QR of all ``T * m_block`` rows;
+* ``streamed_qr``: one Householder QR per block, carrying ``(U, z)``;
+* ``dense_recompute``: accumulate normal equations and refactor them after
+  every block (a less stable but useful sequential baseline);
+* ``cached_dense_full``: compile the final normal equations once and apply
+  only new right-hand sides.  This is valid only for a shared, fixed design
+  and does not provide intermediate sequential roots.  No matched cached-QR
+  chain is timed here, so static repeated-throughput claims must use the
+  earlier fixed-design benchmark instead.
+
+Timings are warmup followed by independent trials and are reported as
+median/MAD.  CUDA compute uses explicit synchronization.  Host/device input
+and output transfers are measured separately and excluded from trajectory
+latency.  Peak CUDA memory is the maximum incremental allocation observed in
+the timed trials; persistent compiled storage that predates a conditioning
+trial is not included. Algorithm execution failures are emitted as CSV rows
+after problem/reference construction, while generation, transfer, or OOM
+failures remain the responsibility of the outer job runner.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import math
+import platform
+import statistics
+import time
+from typing import Callable, Iterable
+
+import torch
+
+from joint_square_root_conditioner_torch import (
+    compile_information_update_torch,
+    householder_information_update_torch,
+    precision_root_from_covariance_torch,
+)
+
+
+ALGORITHMS = (
+    "full_stacked_qr",
+    "streamed_qr",
+    "dense_recompute",
+    "cached_dense_full",
+)
+
+
+@dataclass(frozen=True)
+class Problem:
+    root: torch.Tensor
+    blocks: torch.Tensor
+    rhs: torch.Tensor
+    shared_design: bool
+
+    def tensors(self) -> tuple[torch.Tensor, ...]:
+        return self.root, self.blocks, self.rhs
+
+
+@dataclass(frozen=True)
+class Result:
+    root: torch.Tensor
+    information_rhs: torch.Tensor
+    solution: torch.Tensor
+
+
+@dataclass(frozen=True)
+class Timing:
+    median_ms: float
+    mad_ms: float
+    peak_cuda_mib: float
+
+
+@dataclass(frozen=True)
+class CachedDenseFull:
+    root: torch.Tensor
+    cholesky: torch.Tensor
+    blocks: torch.Tensor
+
+    def condition(self, rhs: torch.Tensor) -> Result:
+        batch, block_count, block_size = rhs.shape
+        stacked_rhs = rhs.reshape(batch, block_count * block_size)
+        stacked_blocks = self.blocks.reshape(
+            block_count * block_size, self.blocks.shape[-1]
+        )
+        eta = torch.einsum("mn,bm->bn", stacked_blocks, stacked_rhs)
+        solution = torch.cholesky_solve(
+            eta.transpose(0, 1).contiguous(), self.cholesky
+        ).transpose(0, 1)
+        information_rhs = torch.linalg.solve_triangular(
+            self.cholesky,
+            eta.transpose(0, 1).contiguous(),
+            upper=False,
+        ).transpose(0, 1)
+        return Result(self.root, information_rhs, solution)
+
+
+def _csv_positive_ints(value: str) -> list[int]:
+    try:
+        values = [int(part.strip()) for part in value.split(",") if part.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected comma-separated integers") from exc
+    if not values or any(item <= 0 for item in values):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return values
+
+
+def _csv_positive_floats(value: str) -> list[float]:
+    try:
+        values = [float(part.strip()) for part in value.split(",") if part.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected comma-separated numbers") from exc
+    if not values or any(not math.isfinite(item) or item <= 0 for item in values):
+        raise argparse.ArgumentTypeError("expected comma-separated positive finite numbers")
+    return values
+
+
+def _csv_choices(value: str, choices: Iterable[str]) -> list[str]:
+    allowed = set(choices)
+    values = [part.strip() for part in value.split(",") if part.strip()]
+    invalid = [item for item in values if item not in allowed]
+    if not values or invalid:
+        raise argparse.ArgumentTypeError(
+            f"expected comma-separated values from {sorted(allowed)}; invalid={invalid}"
+        )
+    return values
+
+
+def _dtypes(value: str) -> list[str]:
+    return _csv_choices(value, ("float32", "float64"))
+
+
+def _design_modes(value: str) -> list[str]:
+    return _csv_choices(value, ("shared", "distinct"))
+
+
+def _algorithms(value: str) -> list[str]:
+    return _csv_choices(value, ALGORITHMS)
+
+
+def _dtype(name: str) -> torch.dtype:
+    return {"float32": torch.float32, "float64": torch.float64}[name]
+
+
+def _devices(specification: str) -> list[torch.device]:
+    names = [part.strip() for part in specification.split(",") if part.strip()]
+    if names == ["auto"]:
+        names = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+    invalid = [name for name in names if name not in ("cpu", "cuda")]
+    if not names or invalid:
+        raise argparse.ArgumentTypeError(
+            f"devices must be auto or comma-separated cpu,cuda; invalid={invalid}"
+        )
+    devices: list[torch.device] = []
+    for name in names:
+        if name == "cuda" and not torch.cuda.is_available():
+            print("# skipping cuda: torch.cuda.is_available() is false")
+            continue
+        devices.append(torch.device(name))
+    if not devices:
+        raise SystemExit("no requested benchmark device is available")
+    return devices
+
+
+def _synchronise(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _median_mad(values: list[float]) -> tuple[float, float]:
+    median = statistics.median(values)
+    return median, statistics.median(abs(value - median) for value in values)
+
+
+def _time_callable(
+    function: Callable[[], object],
+    *,
+    device: torch.device,
+    warmups: int,
+    trials: int,
+    inner_repeats: int,
+) -> Timing:
+    for _ in range(warmups):
+        output = function()
+        del output
+    _synchronise(device)
+
+    elapsed_ms: list[float] = []
+    peak_bytes: list[int] = []
+    for _ in range(trials):
+        if device.type == "cuda":
+            _synchronise(device)
+            baseline = torch.cuda.memory_allocated(device)
+            torch.cuda.reset_peak_memory_stats(device)
+        else:
+            baseline = 0
+        start = time.perf_counter()
+        for _ in range(inner_repeats):
+            output = function()
+            # Avoid retaining a previous result while the next repeat
+            # allocates; that would inflate peak memory for inner_repeats > 1.
+            del output
+        _synchronise(device)
+        elapsed_ms.append(
+            1000.0 * (time.perf_counter() - start) / inner_repeats
+        )
+        if device.type == "cuda":
+            peak_bytes.append(
+                max(0, torch.cuda.max_memory_allocated(device) - baseline)
+            )
+    median, mad = _median_mad(elapsed_ms)
+    return Timing(median, mad, max(peak_bytes, default=0) / (1024.0**2))
+
+
+def _time_transfer(
+    function: Callable[[], object],
+    *,
+    device: torch.device,
+    trials: int,
+) -> tuple[float, float, object]:
+    if device.type != "cuda":
+        return 0.0, 0.0, function()
+    # Exclude one-time CUDA context/allocation initialization from transfer
+    # latency just as compute timing excludes warmups.
+    output = function()
+    _synchronise(device)
+    del output
+    values: list[float] = []
+    output: object | None = None
+    for _ in range(trials):
+        start = time.perf_counter()
+        output = function()
+        _synchronise(device)
+        values.append(1000.0 * (time.perf_counter() - start))
+        del output
+    median, mad = _median_mad(values)
+    output = function()
+    _synchronise(device)
+    return median, mad, output
+
+
+def _make_problem(
+    *,
+    n: int,
+    m_block: int,
+    block_count: int,
+    batch: int,
+    shared_design: bool,
+    condition_number: float,
+    noise_scale: float,
+    seed: int,
+) -> Problem:
+    """Generate a float64 CPU problem with block-diagonal conditional noise."""
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(
+        seed
+        + 1009 * n
+        + 917 * m_block
+        + 101 * block_count
+        + 17 * batch
+        + int(not shared_design)
+    )
+    def spd(shape: tuple[int, ...], dimension: int, scale: float) -> torch.Tensor:
+        factor = torch.randn(
+            *shape, dimension, dimension, generator=generator, dtype=torch.float64
+        )
+        orthogonal, _ = torch.linalg.qr(factor)
+        half_log_condition = 0.5 * math.log10(condition_number)
+        eigenvalues = torch.logspace(
+            -half_log_condition,
+            half_log_condition,
+            dimension,
+            dtype=torch.float64,
+        )
+        return (
+            orthogonal
+            @ torch.diag(eigenvalues * scale)
+            @ orthogonal.mT
+        )
+
+    covariance = spd((), n, 1.0)
+    root = precision_root_from_covariance_torch(covariance, jitter=0.0)
+
+    design_shape = (
+        (block_count, m_block, n)
+        if shared_design
+        else (batch, block_count, m_block, n)
+    )
+    design = torch.randn(*design_shape, generator=generator, dtype=torch.float64)
+    design = design / math.sqrt(n)
+    covariance_batch_shape = (
+        (block_count,) if shared_design else (batch, block_count)
+    )
+    conditional_covariance = spd(
+        covariance_batch_shape, m_block, noise_scale
+    )
+    cholesky = torch.linalg.cholesky(conditional_covariance)
+    blocks = torch.linalg.solve_triangular(cholesky, design, upper=False)
+
+    latent = torch.randn(batch, n, generator=generator, dtype=torch.float64)
+    noise = torch.randn(
+        batch, block_count, m_block, generator=generator, dtype=torch.float64
+    )
+    if shared_design:
+        rhs = torch.einsum("tmn,bn->btm", blocks, latent) + noise
+    else:
+        rhs = torch.einsum("btmn,bn->btm", blocks, latent) + noise
+    return Problem(root=root, blocks=blocks, rhs=rhs, shared_design=shared_design)
+
+
+def _to_device(problem: Problem, device: torch.device, dtype: torch.dtype) -> Problem:
+    return Problem(
+        *(value.to(device=device, dtype=dtype) for value in problem.tensors()),
+        shared_design=problem.shared_design,
+    )
+
+
+def _full_stacked_qr(problem: Problem) -> Result:
+    batch, block_count, block_size = problem.rhs.shape
+    n = problem.root.shape[-1]
+    if problem.shared_design:
+        blocks = problem.blocks.reshape(block_count * block_size, n)
+    else:
+        blocks = problem.blocks.reshape(batch, block_count * block_size, n)
+    rhs = problem.rhs.reshape(batch, block_count * block_size)
+    result = householder_information_update_torch(
+        problem.root,
+        torch.zeros(batch, n, dtype=problem.root.dtype, device=problem.root.device),
+        blocks,
+        rhs,
+    )
+    root = result.precision_root[0] if problem.shared_design else result.precision_root
+    return Result(root, result.information_rhs, result.solution)
+
+
+def _streamed_qr(problem: Problem) -> Result:
+    batch, block_count, _ = problem.rhs.shape
+    n = problem.root.shape[-1]
+    information_rhs = torch.zeros(
+        batch, n, dtype=problem.root.dtype, device=problem.root.device
+    )
+    if problem.shared_design:
+        root = problem.root
+        solution = torch.zeros_like(information_rhs)
+        for block_index in range(block_count):
+            compiled = compile_information_update_torch(
+                root, problem.blocks[block_index]
+            )
+            update = compiled.apply_vectors(
+                information_rhs, problem.rhs[:, block_index]
+            )
+            root = compiled.precision_root
+            information_rhs = update.information_rhs
+            solution = update.solution
+        return Result(root, information_rhs, solution)
+
+    root = problem.root.expand(batch, n, n).contiguous()
+    solution = torch.zeros_like(information_rhs)
+    for block_index in range(block_count):
+        update = householder_information_update_torch(
+            root,
+            information_rhs,
+            problem.blocks[:, block_index],
+            problem.rhs[:, block_index],
+        )
+        root = update.precision_root
+        information_rhs = update.information_rhs
+        solution = update.solution
+    return Result(root, information_rhs, solution)
+
+
+def _dense_recompute(problem: Problem) -> Result:
+    batch, block_count, _ = problem.rhs.shape
+    n = problem.root.shape[-1]
+    precision = problem.root.mT @ problem.root
+    if not problem.shared_design:
+        precision = precision.expand(batch, n, n).clone()
+    eta = torch.zeros(batch, n, dtype=problem.root.dtype, device=problem.root.device)
+    solution = torch.zeros_like(eta)
+    root = problem.root
+    information_rhs = eta
+    for block_index in range(block_count):
+        block = (
+            problem.blocks[block_index]
+            if problem.shared_design
+            else problem.blocks[:, block_index]
+        )
+        precision = precision + block.mT @ block
+        eta = eta + torch.einsum(
+            "...mn,...m->...n", block, problem.rhs[:, block_index]
+        )
+        cholesky = torch.linalg.cholesky(precision)
+        root = cholesky.mT
+        if problem.shared_design:
+            information_rhs = torch.linalg.solve_triangular(
+                cholesky,
+                eta.transpose(0, 1).contiguous(),
+                upper=False,
+            ).transpose(0, 1)
+            solution = torch.cholesky_solve(
+                eta.transpose(0, 1).contiguous(), cholesky
+            ).transpose(0, 1)
+        else:
+            information_rhs = torch.linalg.solve_triangular(
+                cholesky, eta.unsqueeze(-1), upper=False
+            ).squeeze(-1)
+            solution = torch.cholesky_solve(
+                eta.unsqueeze(-1), cholesky
+            ).squeeze(-1)
+    return Result(root, information_rhs, solution)
+
+
+def _compile_cached_dense_full(problem: Problem) -> CachedDenseFull:
+    if not problem.shared_design:
+        raise ValueError("cached_dense_full requires a shared fixed design")
+    block_count, block_size, n = problem.blocks.shape
+    stacked = problem.blocks.reshape(block_count * block_size, n)
+    precision = problem.root.mT @ problem.root + stacked.mT @ stacked
+    cholesky = torch.linalg.cholesky(precision)
+    return CachedDenseFull(cholesky.mT, cholesky, problem.blocks)
+
+
+def _reference(problem: Problem) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Float64 dense full-trajectory reference on CPU."""
+    batch, block_count, block_size = problem.rhs.shape
+    n = problem.root.shape[-1]
+    if problem.shared_design:
+        blocks = problem.blocks.reshape(block_count * block_size, n)
+        precision = problem.root.mT @ problem.root + blocks.mT @ blocks
+        eta = torch.einsum(
+            "mn,bm->bn", blocks, problem.rhs.reshape(batch, block_count * block_size)
+        )
+        solution = torch.linalg.solve(
+            precision, eta.transpose(0, 1)
+        ).transpose(0, 1)
+    else:
+        blocks = problem.blocks.reshape(batch, block_count * block_size, n)
+        precision = (
+            problem.root.mT @ problem.root
+        ).expand(batch, n, n) + blocks.mT @ blocks
+        eta = torch.einsum(
+            "bmn,bm->bn", blocks, problem.rhs.reshape(batch, block_count * block_size)
+        )
+        solution = torch.linalg.solve(precision, eta.unsqueeze(-1)).squeeze(-1)
+    root = torch.linalg.cholesky(precision).mT
+    return precision, root, solution
+
+
+def _relative_error(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    actual = actual.detach().cpu().to(torch.float64)
+    expected = expected.detach().cpu().to(torch.float64)
+    numerator = torch.linalg.vector_norm(actual - expected)
+    denominator = torch.clamp(torch.linalg.vector_norm(expected), min=1e-30)
+    return float(numerator / denominator)
+
+
+def _errors(
+    result: Result,
+    reference: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+) -> tuple[float, float, float]:
+    expected_precision, expected_root, expected_solution = reference
+    root = result.root.detach().cpu().to(torch.float64)
+    actual_precision = root.mT @ root
+    return (
+        _relative_error(result.solution, expected_solution),
+        _relative_error(root, expected_root),
+        _relative_error(actual_precision, expected_precision),
+    )
+
+
+def _reverse_blocks(problem: Problem) -> Problem:
+    block_axis = 0 if problem.shared_design else 1
+    return Problem(
+        root=problem.root,
+        blocks=torch.flip(problem.blocks, dims=(block_axis,)),
+        rhs=torch.flip(problem.rhs, dims=(1,)),
+        shared_design=problem.shared_design,
+    )
+
+
+def _order_errors(result: Result, reversed_result: Result) -> tuple[float, float]:
+    root = result.root.detach().cpu().to(torch.float64)
+    reversed_root = reversed_result.root.detach().cpu().to(torch.float64)
+    return (
+        _relative_error(reversed_result.solution, result.solution),
+        _relative_error(reversed_root.mT @ reversed_root, root.mT @ root),
+    )
+
+
+def _output_transfer(result: Result) -> tuple[torch.Tensor, ...]:
+    return tuple(
+        value.detach().to(device="cpu", copy=True)
+        for value in (result.root, result.information_rhs, result.solution)
+    )
+
+
+def _print_header() -> None:
+    print(
+        "algorithm,design_mode,device,dtype,n,m_block,T,B,M_total,"
+        "target_condition,noise_scale,"
+        "setup_median_ms,setup_mad_ms,trajectory_median_ms,trajectory_mad_ms,"
+        "setup_plus_one_ms,h2d_median_ms,h2d_mad_ms,d2h_median_ms,d2h_mad_ms,"
+        "peak_cuda_mib,one_shot_systems_per_second,relative_solution_error,"
+        "relative_root_error,relative_precision_gram_error,"
+        "reverse_order_solution_delta,reverse_order_precision_delta,status"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--state-dims", type=_csv_positive_ints)
+    parser.add_argument("--measurements-per-block", type=int, default=32)
+    parser.add_argument("--block-counts", type=_csv_positive_ints)
+    parser.add_argument("--batch-sizes", type=_csv_positive_ints)
+    parser.add_argument("--design-modes", type=_design_modes)
+    parser.add_argument("--dtypes", type=_dtypes)
+    parser.add_argument("--condition-numbers", type=_csv_positive_floats)
+    parser.add_argument("--noise-scales", type=_csv_positive_floats)
+    parser.add_argument("--algorithms", type=_algorithms, default=list(ALGORITHMS))
+    parser.add_argument("--devices", default="auto", help="auto or cpu,cuda")
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--trials", type=int, default=7)
+    parser.add_argument("--inner-repeats", type=int, default=1)
+    parser.add_argument("--transfer-trials", type=int, default=5)
+    parser.add_argument("--cpu-threads", type=int)
+    parser.add_argument("--seed", type=int, default=20260711)
+    parser.add_argument(
+        "--full-grid",
+        action="store_true",
+        help=(
+            "fill unspecified axes with n=2,32,128; T=1,2,4,8,16; "
+            "B=1,8,32,128; shared,distinct; float32,float64"
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.measurements_per_block <= 0:
+        parser.error("--measurements-per-block must be positive")
+    if min(args.warmups, args.trials, args.inner_repeats, args.transfer_trials) <= 0:
+        parser.error("warmups, trials, repeats, and transfer trials must be positive")
+    if args.cpu_threads is not None:
+        if args.cpu_threads <= 0:
+            parser.error("--cpu-threads must be positive")
+        torch.set_num_threads(args.cpu_threads)
+
+    if args.full_grid:
+        state_dims = args.state_dims or [2, 32, 128]
+        block_counts = args.block_counts or [1, 2, 4, 8, 16]
+        batch_sizes = args.batch_sizes or [1, 8, 32, 128]
+        design_modes = args.design_modes or ["shared", "distinct"]
+        dtype_names = args.dtypes or ["float32", "float64"]
+        condition_numbers = args.condition_numbers or [10.0]
+        noise_scales = args.noise_scales or [1.0]
+    else:
+        state_dims = args.state_dims or [128]
+        block_counts = args.block_counts or [1, 4]
+        batch_sizes = args.batch_sizes or [1, 128]
+        design_modes = args.design_modes or ["distinct"]
+        dtype_names = args.dtypes or ["float32"]
+        condition_numbers = args.condition_numbers or [10.0]
+        noise_scales = args.noise_scales or [1.0]
+
+    if any(value < 1.0 for value in condition_numbers):
+        parser.error("--condition-numbers values must be at least 1")
+
+    devices = _devices(args.devices)
+    print("# Streamed block square-root/information benchmark")
+    print(f"# host={platform.platform()}")
+    print(f"# torch={torch.__version__}; cuda_runtime={torch.version.cuda}")
+    if torch.cuda.is_available():
+        print(f"# cuda_device={torch.cuda.get_device_name(0)}")
+    print(
+        "# Rc is dense within each block and conditionally block diagonal across T; "
+        "whitening is excluded"
+    )
+    print(
+        f"# warmups={args.warmups}; trials={args.trials}; "
+        f"inner_repeats={args.inner_repeats}; seed={args.seed}"
+    )
+    _print_header()
+
+    with torch.inference_mode():
+        for n in state_dims:
+            for block_count in block_counts:
+                for batch in batch_sizes:
+                    for condition_number in condition_numbers:
+                        for noise_scale in noise_scales:
+                            for design_mode in design_modes:
+                                shared_design = design_mode == "shared"
+                                cpu_problem = _make_problem(
+                                    n=n,
+                                    m_block=args.measurements_per_block,
+                                    block_count=block_count,
+                                    batch=batch,
+                                    shared_design=shared_design,
+                                    condition_number=condition_number,
+                                    noise_scale=noise_scale,
+                                    seed=args.seed,
+                                )
+                                reference = _reference(cpu_problem)
+                                for dtype_name in dtype_names:
+                                    dtype = _dtype(dtype_name)
+                                    # Cast on the host for both CPU and CUDA.
+                                    # H2D then measures transfer only, not a
+                                    # CUDA-only dtype-conversion surcharge.
+                                    host_problem = _to_device(
+                                        cpu_problem, torch.device("cpu"), dtype
+                                    )
+                                    for device in devices:
+                                        h2d_median, h2d_mad, transferred = _time_transfer(
+                                            lambda: _to_device(host_problem, device, dtype),
+                                            device=device,
+                                            trials=args.transfer_trials,
+                                        )
+                                        problem = transferred
+                                        assert isinstance(problem, Problem)
+                                        for algorithm in args.algorithms:
+                                            if algorithm == "cached_dense_full" and not shared_design:
+                                                continue
+
+                                            total_measurements = block_count * args.measurements_per_block
+                                            prefix = (
+                                                f"{algorithm},{design_mode},{device.type},{dtype_name},"
+                                                f"{n},{args.measurements_per_block},{block_count},{batch},"
+                                                f"{total_measurements},{condition_number:.6g},"
+                                                f"{noise_scale:.6g}"
+                                            )
+                                            try:
+                                                setup = Timing(0.0, 0.0, 0.0)
+                                                if algorithm == "full_stacked_qr":
+                                                    function = lambda: _full_stacked_qr(problem)
+                                                elif algorithm == "streamed_qr":
+                                                    function = lambda: _streamed_qr(problem)
+                                                elif algorithm == "dense_recompute":
+                                                    function = lambda: _dense_recompute(problem)
+                                                elif algorithm == "cached_dense_full":
+                                                    setup = _time_callable(
+                                                        lambda: _compile_cached_dense_full(problem),
+                                                        device=device,
+                                                        warmups=args.warmups,
+                                                        trials=args.trials,
+                                                        inner_repeats=args.inner_repeats,
+                                                    )
+                                                    compiled = _compile_cached_dense_full(problem)
+                                                    function = lambda: compiled.condition(problem.rhs)
+                                                else:  # pragma: no cover - argparse validates choices
+                                                    raise AssertionError(algorithm)
+
+                                                timing = _time_callable(
+                                                    function,
+                                                    device=device,
+                                                    warmups=args.warmups,
+                                                    trials=args.trials,
+                                                    inner_repeats=args.inner_repeats,
+                                                )
+                                                result = function()
+                                                _synchronise(device)
+                                                assert isinstance(result, Result)
+                                                solution_error, root_error, precision_error = _errors(
+                                                    result, reference
+                                                )
+                                                reversed_problem = _reverse_blocks(problem)
+                                                if algorithm == "full_stacked_qr":
+                                                    reversed_result = _full_stacked_qr(reversed_problem)
+                                                elif algorithm == "streamed_qr":
+                                                    reversed_result = _streamed_qr(reversed_problem)
+                                                elif algorithm == "dense_recompute":
+                                                    reversed_result = _dense_recompute(reversed_problem)
+                                                else:
+                                                    reversed_compiled = _compile_cached_dense_full(
+                                                        reversed_problem
+                                                    )
+                                                    reversed_result = reversed_compiled.condition(
+                                                        reversed_problem.rhs
+                                                    )
+                                                order_solution, order_precision = _order_errors(
+                                                    result, reversed_result
+                                                )
+                                                d2h_median, d2h_mad, copied = _time_transfer(
+                                                    lambda: _output_transfer(result),
+                                                    device=device,
+                                                    trials=args.transfer_trials,
+                                                )
+                                                del copied
+                                                setup_plus_one = (
+                                                    setup.median_ms + timing.median_ms
+                                                )
+                                                one_shot_systems_per_second = (
+                                                    1000.0 * batch / setup_plus_one
+                                                )
+                                                print(
+                                                    f"{prefix},{setup.median_ms:.6f},"
+                                                    f"{setup.mad_ms:.6f},{timing.median_ms:.6f},"
+                                                    f"{timing.mad_ms:.6f},"
+                                                    f"{setup_plus_one:.6f},"
+                                                    f"{h2d_median:.6f},{h2d_mad:.6f},"
+                                                    f"{d2h_median:.6f},{d2h_mad:.6f},"
+                                                    f"{max(setup.peak_cuda_mib, timing.peak_cuda_mib):.6f},"
+                                                    f"{one_shot_systems_per_second:.3f},"
+                                                    f"{solution_error:.9e},"
+                                                    f"{root_error:.9e},{precision_error:.9e},"
+                                                    f"{order_solution:.9e},{order_precision:.9e},ok"
+                                                )
+                                                del result, reversed_result
+                                            except Exception as exc:
+                                                try:
+                                                    _synchronise(device)
+                                                except Exception:
+                                                    pass
+                                                message = str(exc).replace("\n", " ").replace(",", ";")
+                                                failure_name = type(exc).__name__.lstrip("_")
+                                                print(
+                                                    f"# failed {algorithm}/{design_mode}/{device.type}/"
+                                                    f"{dtype_name}: {failure_name}: {message}"
+                                                )
+                                                print(
+                                                    f"{prefix},nan,nan,nan,nan,nan,"
+                                                    f"{h2d_median:.6f},{h2d_mad:.6f},"
+                                                    "nan,nan,nan,nan,nan,nan,nan,nan,nan,"
+                                                    f"failed_{failure_name}"
+                                                )
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/benchmark_streamed_block_qr.py
+++ b/prototypes/mu_cosine/benchmark_streamed_block_qr.py
@@ -441,28 +441,58 @@ def _compile_cached_dense_full(problem: Problem) -> CachedDenseFull:
 
 
 def _reference(problem: Problem) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Float64 dense full-trajectory reference on CPU."""
+    """Float64 stacked least-squares/QR reference on CPU.
+
+    Solve the original augmented system directly instead of solving its Gram
+    system.  Keeping the reference off the normal-equations path makes the
+    reported stability comparison independent of the failure mode being
+    measured.  A separate reduced QR supplies the unique upper precision root
+    after normalising its diagonal positive.
+    """
     batch, block_count, block_size = problem.rhs.shape
     n = problem.root.shape[-1]
+    stacked_rhs = problem.rhs.reshape(batch, block_count * block_size)
     if problem.shared_design:
         blocks = problem.blocks.reshape(block_count * block_size, n)
-        precision = problem.root.mT @ problem.root + blocks.mT @ blocks
-        eta = torch.einsum(
-            "mn,bm->bn", blocks, problem.rhs.reshape(batch, block_count * block_size)
+        stacked = torch.cat((problem.root, blocks), dim=0)
+        augmented_rhs = torch.cat(
+            (
+                torch.zeros(
+                    n,
+                    batch,
+                    dtype=problem.root.dtype,
+                    device=problem.root.device,
+                ),
+                stacked_rhs.mT,
+            ),
+            dim=0,
         )
-        solution = torch.linalg.solve(
-            precision, eta.transpose(0, 1)
-        ).transpose(0, 1)
+        solution = torch.linalg.lstsq(stacked, augmented_rhs).solution.mT
     else:
         blocks = problem.blocks.reshape(batch, block_count * block_size, n)
-        precision = (
-            problem.root.mT @ problem.root
-        ).expand(batch, n, n) + blocks.mT @ blocks
-        eta = torch.einsum(
-            "bmn,bm->bn", blocks, problem.rhs.reshape(batch, block_count * block_size)
+        stacked = torch.cat(
+            (problem.root.expand(batch, n, n), blocks), dim=1
         )
-        solution = torch.linalg.solve(precision, eta.unsqueeze(-1)).squeeze(-1)
-    root = torch.linalg.cholesky(precision).mT
+        augmented_rhs = torch.cat(
+            (
+                torch.zeros(
+                    batch,
+                    n,
+                    1,
+                    dtype=problem.root.dtype,
+                    device=problem.root.device,
+                ),
+                stacked_rhs.unsqueeze(-1),
+            ),
+            dim=1,
+        )
+        solution = torch.linalg.lstsq(stacked, augmented_rhs).solution.squeeze(-1)
+
+    _, root = torch.linalg.qr(stacked, mode="r")
+    diagonal = torch.diagonal(root, dim1=-2, dim2=-1)
+    signs = torch.where(diagonal < 0, -torch.ones_like(diagonal), torch.ones_like(diagonal))
+    root = root * signs.unsqueeze(-1)
+    precision = root.mT @ root
     return precision, root, solution
 
 

--- a/prototypes/mu_cosine/joint_square_root_conditioner.py
+++ b/prototypes/mu_cosine/joint_square_root_conditioner.py
@@ -171,23 +171,31 @@ def householder_information_update(prior_precision_root, prior_information_rhs,
         np.column_stack([U, z]),
         np.column_stack([A, b]),
     ]).astype(float, copy=False)
-    scale = float(np.max(np.abs(work[:, :n]), initial=0.0))
-    if scale == 0.0:
+    pre_array = work[:, :n]
+    entry_scale = float(np.max(np.abs(pre_array), initial=0.0))
+    if entry_scale == 0.0:
         raise np.linalg.LinAlgError("information pre-array is rank deficient")
-    tol = np.finfo(float).eps * max(work.shape) * scale
+    if entry_scale < np.finfo(float).tiny:
+        raise np.linalg.LinAlgError(
+            "information pre-array scale is subnormal; rescale before QR"
+        )
+    relative_frobenius = float(np.linalg.norm(pre_array / entry_scale))
+    relative_tol = (
+        np.finfo(float).eps * max(pre_array.shape) * relative_frobenius
+    )
 
     # Apply each reflector directly to the remaining coefficient/RHS array;
     # Q is never formed.  This is the standard numerically stable QR update.
     for col in range(n):
         x = work[col:, col].copy()
         norm_x = _scaled_norm(x)
-        if norm_x <= tol:
+        if not np.isfinite(norm_x) or norm_x / entry_scale <= relative_tol:
             raise np.linalg.LinAlgError("information pre-array is rank deficient")
         first_sign = 1.0 if x[0] >= 0.0 else -1.0
         alpha = -first_sign * norm_x
         x[0] -= alpha
         norm_v = _scaled_norm(x)
-        if norm_v <= tol:
+        if not np.isfinite(norm_v) or norm_v / entry_scale <= relative_tol:
             raise np.linalg.LinAlgError("cannot construct a stable Householder reflector")
         v = x / norm_v
         tail = work[col:, col:]
@@ -198,7 +206,10 @@ def householder_information_update(prior_precision_root, prior_information_rhs,
     root = np.triu(work[:n, :n])
     rhs = work[:n, n]
     root, rhs = _normalise_root_signs(root, rhs)
-    if np.any(np.abs(np.diag(root)) <= tol):
+    diagonal = np.abs(np.diag(root))
+    if np.any(~np.isfinite(diagonal)) or np.any(
+        diagonal / entry_scale <= relative_tol
+    ):
         raise np.linalg.LinAlgError("posterior information root is singular")
     solution = np.linalg.solve(root, rhs)
     residual = work[n:, n]

--- a/prototypes/mu_cosine/joint_square_root_conditioner.py
+++ b/prototypes/mu_cosine/joint_square_root_conditioner.py
@@ -84,7 +84,11 @@ def _matrix(name, value, rows=None, cols=None):
 
 @dataclass(frozen=True)
 class InformationRootUpdate:
-    """Result of one Householder information-root update."""
+    """Result of one Householder information-root update.
+
+    ``information_rhs`` is the square-root RHS ``z``.  The canonical
+    information vector is ``eta = precision_root.T @ z``.
+    """
 
     precision_root: np.ndarray
     information_rhs: np.ndarray
@@ -137,6 +141,15 @@ def _normalise_root_signs(root, rhs):
     return root, rhs
 
 
+def _scaled_norm(value):
+    """Euclidean norm without overflow/underflow from squaring raw entries."""
+    value = np.asarray(value, dtype=float)
+    scale = float(np.max(np.abs(value), initial=0.0))
+    if scale == 0.0:
+        return 0.0
+    return scale * float(np.linalg.norm(value / scale))
+
+
 def householder_information_update(prior_precision_root, prior_information_rhs,
                                    measurement_matrix, measurement_rhs):
     """Triangularise a prior information root plus whitened measurement rows.
@@ -158,20 +171,22 @@ def householder_information_update(prior_precision_root, prior_information_rhs,
         np.column_stack([U, z]),
         np.column_stack([A, b]),
     ]).astype(float, copy=False)
-    scale = max(float(np.linalg.norm(work[:, :n])), 1.0)
+    scale = float(np.max(np.abs(work[:, :n]), initial=0.0))
+    if scale == 0.0:
+        raise np.linalg.LinAlgError("information pre-array is rank deficient")
     tol = np.finfo(float).eps * max(work.shape) * scale
 
     # Apply each reflector directly to the remaining coefficient/RHS array;
     # Q is never formed.  This is the standard numerically stable QR update.
     for col in range(n):
         x = work[col:, col].copy()
-        norm_x = float(np.linalg.norm(x))
+        norm_x = _scaled_norm(x)
         if norm_x <= tol:
             raise np.linalg.LinAlgError("information pre-array is rank deficient")
         first_sign = 1.0 if x[0] >= 0.0 else -1.0
         alpha = -first_sign * norm_x
         x[0] -= alpha
-        norm_v = float(np.linalg.norm(x))
+        norm_v = _scaled_norm(x)
         if norm_v <= tol:
             raise np.linalg.LinAlgError("cannot construct a stable Householder reflector")
         v = x / norm_v

--- a/prototypes/mu_cosine/joint_square_root_conditioner_torch.py
+++ b/prototypes/mu_cosine/joint_square_root_conditioner_torch.py
@@ -22,7 +22,10 @@ when a later block changes the posterior, which is the root-threading QR case.
 All functions require real floating PyTorch tensors and preserve their dtype
 and device.  The implementation is inference-oriented.  In particular,
 ``geqrf``/``ormqr`` backend and autograd coverage is narrower than
-``torch.linalg.qr`` on some PyTorch/device combinations.
+``torch.linalg.qr`` on some PyTorch/device combinations.  One-time covariance
+and coefficient preparation validates finiteness; repeated RHS hot paths avoid
+device-synchronising finiteness checks, so NaN/Inf observations propagate and
+must be gated by the caller when that is not acceptable.
 """
 
 from __future__ import annotations
@@ -118,37 +121,53 @@ def _normalised_root_from_packed(
     return raw_root * signs.unsqueeze(-1), signs
 
 
-def _pre_array_scale(pre_array: torch.Tensor) -> torch.Tensor:
-    # Use a homogeneous scale: clamping it to one falsely labels a perfectly
-    # conditioned factor such as 1e-20 * I as rank deficient.  Max-entry scale
-    # also avoids squaring underflow in a Frobenius norm.
-    scale = torch.amax(torch.abs(pre_array), dim=(-2, -1))
-    nonfinite = ~torch.isfinite(scale)
+def _pre_array_scale(
+    pre_array: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # Preserve the prior Frobenius-scale rank sensitivity without its unit
+    # clamp. Return ``(a, ||G/a||_F)`` instead of materialising
+    # ``a * ||G/a||_F``: the latter can overflow even when every entry and QR
+    # diagonal is representable. The pair remains homogeneous under a
+    # *global* scalar rescaling when used by ``_check_root_rank``.
+    entry_scale = torch.amax(torch.abs(pre_array), dim=(-2, -1))
+    nonfinite = ~torch.isfinite(entry_scale)
     if bool(torch.any(nonfinite).item()):
         raise ValueError(
             "information pre-array must be finite"
             + _batch_failure_detail(nonfinite)
         )
-    zero = scale == 0
+    zero = entry_scale == 0
     if bool(torch.any(zero).item()):
         raise torch.linalg.LinAlgError(
             "information pre-array is rank deficient (zero scale)"
             + _batch_failure_detail(zero)
         )
-    subnormal = scale < torch.finfo(pre_array.dtype).tiny
+    subnormal = entry_scale < torch.finfo(pre_array.dtype).tiny
     if bool(torch.any(subnormal).item()):
         raise torch.linalg.LinAlgError(
             "information pre-array scale is subnormal; rescale before QR"
             + _batch_failure_detail(subnormal)
         )
-    return scale
+    normalised = pre_array / entry_scale[..., None, None]
+    relative_frobenius = torch.linalg.vector_norm(normalised, dim=(-2, -1))
+    return entry_scale, relative_frobenius
 
 
-def _check_root_rank(pre_array: torch.Tensor, root: torch.Tensor) -> None:
-    scale = _pre_array_scale(pre_array)
-    tolerance = torch.finfo(pre_array.dtype).eps * max(pre_array.shape[-2:]) * scale
+def _check_root_rank(
+    pre_array: torch.Tensor,
+    root: torch.Tensor,
+    scale: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    entry_scale, relative_frobenius = scale
+    relative_tolerance = (
+        torch.finfo(pre_array.dtype).eps
+        * max(pre_array.shape[-2:])
+        * relative_frobenius
+    )
     smallest = torch.amin(torch.abs(torch.diagonal(root, dim1=-2, dim2=-1)), dim=-1)
-    failed = smallest <= tolerance
+    failed = (~torch.isfinite(smallest)) | (
+        smallest / entry_scale <= relative_tolerance
+    )
     if bool(torch.any(failed).item()):
         if failed.ndim:
             indices = torch.nonzero(failed, as_tuple=False).detach().cpu().tolist()
@@ -255,7 +274,7 @@ class NoiseWhitenerTorch:
         batch_shape = torch.broadcast_shapes(self.batch_shape, value.shape[:-2])
         factor = self.cholesky_factor.expand(
             batch_shape + self.cholesky_factor.shape[-2:]
-        )
+        ).contiguous()
         value = value.expand(batch_shape + value.shape[-2:])
         return torch.linalg.solve_triangular(
             factor, value.contiguous(), upper=False
@@ -277,7 +296,7 @@ class NoiseWhitenerTorch:
         value = value.expand(batch_shape + (self.dimension,))
         return self.apply_columns(value.unsqueeze(-1)).squeeze(-1)
 
-    def materialize_precision_root(self) -> torch.Tensor:
+    def materialize_row_root(self) -> torch.Tensor:
         """Materialise ``L^-1`` with a solve for inspection or interop.
 
         The result ``U = L^-1`` is a lower-triangular *row root* satisfying
@@ -426,10 +445,10 @@ def compile_information_update_torch(
     _same_backend(root, measurement_matrix=matrix)
     root, matrix = _broadcast_matrices(root, matrix)
     pre_array = torch.cat([root, matrix], dim=-2).contiguous()
-    _pre_array_scale(pre_array)
+    scale = _pre_array_scale(pre_array)
     packed, tau = torch.geqrf(pre_array)
     posterior_root, signs = _normalised_root_from_packed(packed, n)
-    _check_root_rank(pre_array, posterior_root)
+    _check_root_rank(pre_array, posterior_root, scale)
     return CompiledInformationQRTorch(
         packed=packed,
         tau=tau,
@@ -505,7 +524,12 @@ def prepare_noise_whitener_torch(
     number near ``1/sqrt(eps)`` (about ``2.9e3`` in float32 and ``6.7e7`` in
     float64).  The float32 load can be statistically material; it is exposed
     in diagnostics and may be lowered explicitly when a caller has validated
-    a tighter numerical error budget.
+    a tighter numerical error budget.  The default negative-eigenvalue
+    tolerance is capped at half of the remaining loading budget, so any
+    round-off-negative input accepted by the hard indefiniteness gate remains
+    repairable within ``maximum_relative_loading``.  An explicitly supplied
+    tolerance may intentionally override that coupling and still be rejected
+    by the separate loading-budget gate.
     """
     covariance_mode = covariance is not None
     correlation_mode = correlation is not None or stddev is not None
@@ -599,16 +623,16 @@ def prepare_noise_whitener_torch(
     absolute_floor = _nonnegative_finite(
         "absolute_eigenvalue_floor", absolute_eigenvalue_floor
     )
-    negative_tolerance = (
-        64.0 * n * eps
-        if negative_eigenvalue_tolerance is None
-        else _nonnegative_finite(
-            "negative_eigenvalue_tolerance", negative_eigenvalue_tolerance
-        )
-    )
     maximum_loading = _nonnegative_finite(
         "maximum_relative_loading", maximum_relative_loading
     )
+    if negative_eigenvalue_tolerance is None:
+        repair_budget = max(maximum_loading - relative_floor, 0.0)
+        negative_tolerance = min(64.0 * n * eps, 0.5 * repair_budget)
+    else:
+        negative_tolerance = _nonnegative_finite(
+            "negative_eigenvalue_tolerance", negative_eigenvalue_tolerance
+        )
     symmetry_limit = (
         64.0 * n * eps
         if symmetry_tolerance is None
@@ -762,12 +786,12 @@ def precision_root_from_covariance_torch(
         maximum_relative_loading=maximum_relative_loading,
         name="prior covariance",
     )
-    inverse_factor = whitener.materialize_precision_root()
+    inverse_factor = whitener.materialize_row_root()
     n = inverse_factor.shape[-1]
-    _pre_array_scale(inverse_factor)
+    scale = _pre_array_scale(inverse_factor)
     packed, _ = torch.geqrf(inverse_factor.contiguous())
     root, _ = _normalised_root_from_packed(packed, n)
-    _check_root_rank(inverse_factor, root)
+    _check_root_rank(inverse_factor, root, scale)
     return root
 
 
@@ -918,7 +942,6 @@ def condition_correlated_gaussian_qr_torch(
     H_design = H.expand(design_batch + (m, n))
     effective_H = effective_H.expand(design_batch + (m, n))
     conditional_R = conditional_R.expand(design_batch + (m, m))
-    chol = conditional_whitener.cholesky_factor
     whitened_H = conditional_whitener.apply_columns(effective_H)
     compiled = compile_information_update_torch(root, whitened_H)
 
@@ -926,10 +949,7 @@ def condition_correlated_gaussian_qr_torch(
     observation = observation.expand(result_batch + (m,))
     H_result = H_design.expand(result_batch + (m, n))
     innovation = observation - (H_result @ mean.unsqueeze(-1)).squeeze(-1)
-    chol_result = chol.expand(result_batch + (m, m))
-    whitened_innovation = torch.linalg.solve_triangular(
-        chol_result, innovation.unsqueeze(-1), upper=False
-    ).squeeze(-1)
+    whitened_innovation = conditional_whitener.apply_vectors(innovation)
     information = compiled.apply_vectors(
         torch.zeros_like(mean), whitened_innovation
     )
@@ -1236,7 +1256,9 @@ class SquareRootInformationStateTorch:
         ``measurement_rhs`` is its matching innovation ``r``.  Both are acted
         on from the left by the same implicit ``L^-1``.  This convenience
         avoids materialising an inverse root or accidentally applying the
-        whitening factor with the wrong orientation.
+        whitening factor with the wrong orientation.  This hot path does not
+        recheck ``measurement_matrix`` or ``measurement_rhs`` for finiteness;
+        callers that cannot tolerate NaN/Inf propagation must gate them first.
         """
         if not isinstance(whitener, NoiseWhitenerTorch):
             raise TypeError("whitener must be a NoiseWhitenerTorch")

--- a/prototypes/mu_cosine/joint_square_root_conditioner_torch.py
+++ b/prototypes/mu_cosine/joint_square_root_conditioner_torch.py
@@ -37,15 +37,19 @@ __all__ = [
     "CompiledCorrelatedConditionerTorch",
     "CompiledDenseGainConditionerTorch",
     "CompiledInformationQRTorch",
+    "CovarianceLoadingDiagnosticsTorch",
     "DenseGaussianUpdateTorch",
     "InformationRootUpdateTorch",
     "JointSquareRootUpdateTorch",
+    "NoiseWhitenerTorch",
     "SquareRootInformationStateTorch",
     "compile_information_update_torch",
     "condition_correlated_gaussian_qr_torch",
     "conditional_measurement_model_torch",
+    "conditional_measurement_whitener_torch",
     "householder_information_update_torch",
     "precision_root_from_covariance_torch",
+    "prepare_noise_whitener_torch",
     "regularize_covariance_torch",
 ]
 
@@ -114,9 +118,34 @@ def _normalised_root_from_packed(
     return raw_root * signs.unsqueeze(-1), signs
 
 
+def _pre_array_scale(pre_array: torch.Tensor) -> torch.Tensor:
+    # Use a homogeneous scale: clamping it to one falsely labels a perfectly
+    # conditioned factor such as 1e-20 * I as rank deficient.  Max-entry scale
+    # also avoids squaring underflow in a Frobenius norm.
+    scale = torch.amax(torch.abs(pre_array), dim=(-2, -1))
+    nonfinite = ~torch.isfinite(scale)
+    if bool(torch.any(nonfinite).item()):
+        raise ValueError(
+            "information pre-array must be finite"
+            + _batch_failure_detail(nonfinite)
+        )
+    zero = scale == 0
+    if bool(torch.any(zero).item()):
+        raise torch.linalg.LinAlgError(
+            "information pre-array is rank deficient (zero scale)"
+            + _batch_failure_detail(zero)
+        )
+    subnormal = scale < torch.finfo(pre_array.dtype).tiny
+    if bool(torch.any(subnormal).item()):
+        raise torch.linalg.LinAlgError(
+            "information pre-array scale is subnormal; rescale before QR"
+            + _batch_failure_detail(subnormal)
+        )
+    return scale
+
+
 def _check_root_rank(pre_array: torch.Tensor, root: torch.Tensor) -> None:
-    scale = torch.linalg.matrix_norm(pre_array, ord="fro", dim=(-2, -1))
-    scale = torch.maximum(scale, torch.ones_like(scale))
+    scale = _pre_array_scale(pre_array)
     tolerance = torch.finfo(pre_array.dtype).eps * max(pre_array.shape[-2:]) * scale
     smallest = torch.amin(torch.abs(torch.diagonal(root, dim1=-2, dim2=-1)), dim=-1)
     failed = smallest <= tolerance
@@ -131,7 +160,11 @@ def _check_root_rank(pre_array: torch.Tensor, root: torch.Tensor) -> None:
 
 @dataclass(frozen=True)
 class InformationRootUpdateTorch:
-    """One information-root update, possibly batched or with multiple RHSs."""
+    """One information-root update, possibly batched or with multiple RHSs.
+
+    ``information_rhs`` is the square-root RHS ``z``.  The canonical
+    information vector is ``eta = precision_root.mT @ z``.
+    """
 
     precision_root: torch.Tensor
     information_rhs: torch.Tensor
@@ -151,6 +184,7 @@ class JointSquareRootUpdateTorch:
     innovation: torch.Tensor
     effective_observation_matrix: torch.Tensor
     conditional_observation_covariance: torch.Tensor
+    conditional_loading_diagnostics: CovarianceLoadingDiagnosticsTorch
     whitened_observation_matrix: torch.Tensor
     whitened_innovation: torch.Tensor
     residual_sum_squares: torch.Tensor
@@ -165,6 +199,103 @@ class DenseGaussianUpdateTorch:
     gain: torch.Tensor
     innovation: torch.Tensor
     innovation_covariance: torch.Tensor
+    conditional_loading_diagnostics: CovarianceLoadingDiagnosticsTorch
+
+
+@dataclass(frozen=True)
+class CovarianceLoadingDiagnosticsTorch:
+    """Observable contract for scale-relative covariance diagonal loading.
+
+    Tensor fields have the covariance batch shape.  ``minimum_eigenvalue`` is
+    measured before loading; ``target_minimum_eigenvalue`` and
+    ``diagonal_loading`` state exactly what was added.  A materially indefinite
+    input is rejected instead of appearing here as a large silent repair.
+    """
+
+    matrix_scale: torch.Tensor
+    minimum_eigenvalue: torch.Tensor
+    target_minimum_eigenvalue: torch.Tensor
+    diagonal_loading: torch.Tensor
+    relative_diagonal_loading: torch.Tensor
+    relative_symmetry_error: torch.Tensor
+    was_loaded: torch.Tensor
+    relative_eigenvalue_floor: float
+    negative_eigenvalue_tolerance: float
+    maximum_relative_loading: float
+    source: str
+
+
+@dataclass(frozen=True)
+class NoiseWhitenerTorch:
+    """Implicit Cholesky inverse factor for one or a batch of noise models.
+
+    If ``covariance = L L.T``, this object stores ``L`` and applies the
+    whitening factor ``L^-1`` exclusively with triangular solves.  It never
+    materialises an explicit matrix inverse.  Use :meth:`apply_vectors` for
+    ``(..., dimension)`` samples and :meth:`apply_columns` for
+    ``(..., dimension, nrhs)`` right-hand-side matrices.
+    """
+
+    covariance: torch.Tensor
+    cholesky_factor: torch.Tensor
+    diagnostics: CovarianceLoadingDiagnosticsTorch
+
+    @property
+    def dimension(self) -> int:
+        return self.cholesky_factor.shape[-1]
+
+    @property
+    def batch_shape(self) -> torch.Size:
+        return self.cholesky_factor.shape[:-2]
+
+    def apply_columns(self, value: torch.Tensor) -> torch.Tensor:
+        """Apply ``L^-1`` to ``(..., dimension, nrhs)`` with a solve."""
+        value = _matrix("value", value, rows=self.dimension)
+        _same_backend(self.cholesky_factor, value=value)
+        batch_shape = torch.broadcast_shapes(self.batch_shape, value.shape[:-2])
+        factor = self.cholesky_factor.expand(
+            batch_shape + self.cholesky_factor.shape[-2:]
+        )
+        value = value.expand(batch_shape + value.shape[-2:])
+        return torch.linalg.solve_triangular(
+            factor, value.contiguous(), upper=False
+        )
+
+    def apply_vectors(self, value: torch.Tensor) -> torch.Tensor:
+        """Apply ``L^-1`` to a vector or an arbitrary vector batch."""
+        value = _vector("value", value, length=self.dimension)
+        _same_backend(self.cholesky_factor, value=value)
+        vector_batch = value.shape[:-1]
+        if len(self.batch_shape) == 0:
+            count = math.prod(vector_batch) if vector_batch else 1
+            columns = value.reshape(count, self.dimension).transpose(0, 1)
+            whitened = self.apply_columns(columns)
+            return whitened.transpose(0, 1).reshape(
+                vector_batch + (self.dimension,)
+            )
+        batch_shape = torch.broadcast_shapes(self.batch_shape, vector_batch)
+        value = value.expand(batch_shape + (self.dimension,))
+        return self.apply_columns(value.unsqueeze(-1)).squeeze(-1)
+
+    def materialize_precision_root(self) -> torch.Tensor:
+        """Materialise ``L^-1`` with a solve for inspection or interop.
+
+        The result ``U = L^-1`` is a lower-triangular *row root* satisfying
+        ``covariance^-1 = U.T @ U``; it is not the canonical upper Cholesky
+        factor of the precision.  QR-triangularise it if an upper root is
+        required.  Hot paths should use :meth:`apply_vectors` or
+        :meth:`apply_columns`; both avoid allocating this dense factor.  This
+        method still uses a triangular solve and never calls a matrix-inverse
+        routine.
+        """
+        identity = torch.eye(
+            self.dimension,
+            dtype=self.cholesky_factor.dtype,
+            device=self.cholesky_factor.device,
+        ).expand(self.batch_shape + (self.dimension, self.dimension))
+        return torch.linalg.solve_triangular(
+            self.cholesky_factor, identity, upper=False
+        )
 
 
 @dataclass(frozen=True)
@@ -295,6 +426,7 @@ def compile_information_update_torch(
     _same_backend(root, measurement_matrix=matrix)
     root, matrix = _broadcast_matrices(root, matrix)
     pre_array = torch.cat([root, matrix], dim=-2).contiguous()
+    _pre_array_scale(pre_array)
     packed, tau = torch.geqrf(pre_array)
     posterior_root, signs = _normalised_root_from_packed(packed, n)
     _check_root_rank(pre_array, posterior_root)
@@ -321,17 +453,274 @@ def householder_information_update_torch(
     return compiled.apply_vectors(prior_information_rhs, measurement_rhs)
 
 
+def _batch_failure_detail(failed: torch.Tensor) -> str:
+    if failed.ndim == 0:
+        return " for the unbatched input"
+    indices = torch.nonzero(failed, as_tuple=False).detach().cpu().tolist()
+    return f" at batch indices {indices}"
+
+
+def _nonnegative_finite(name: str, value: float) -> float:
+    value = float(value)
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return value
+
+
+def prepare_noise_whitener_torch(
+    covariance: torch.Tensor | None = None,
+    *,
+    correlation: torch.Tensor | None = None,
+    stddev: torch.Tensor | None = None,
+    relative_eigenvalue_floor: float | None = None,
+    absolute_eigenvalue_floor: float = 0.0,
+    negative_eigenvalue_tolerance: float | None = None,
+    maximum_relative_loading: float = 1e-3,
+    symmetry_tolerance: float | None = None,
+    correlation_tolerance: float | None = None,
+    name: str = "noise covariance",
+) -> NoiseWhitenerTorch:
+    """Validate, minimally load, and Cholesky-factor a noise model.
+
+    Supply exactly one of:
+
+    - ``covariance``; or
+    - ``correlation`` plus strictly positive ``stddev``, which constructs
+      ``diag(stddev) @ correlation @ diag(stddev)``.
+
+    Loading is relative to the covariance spectral scale.  A nearly singular
+    positive-semidefinite matrix is lifted to a documented eigenvalue floor;
+    a materially indefinite matrix or a repair exceeding
+    ``maximum_relative_loading`` is rejected.  All loading is returned in
+    :class:`CovarianceLoadingDiagnosticsTorch`, including one value per batch
+    element.  This preparation step intentionally synchronises to make invalid
+    input observable; repeated hot-path whitening does not.
+
+    The returned object represents ``L^-1`` implicitly and applies it only via
+    :func:`torch.linalg.solve_triangular`.
+
+    By default the relative eigenvalue floor is
+    ``max(sqrt(machine_epsilon), 8 * dimension * machine_epsilon)``.  The
+    ``sqrt(eps)`` term intentionally caps the loaded covariance condition
+    number near ``1/sqrt(eps)`` (about ``2.9e3`` in float32 and ``6.7e7`` in
+    float64).  The float32 load can be statistically material; it is exposed
+    in diagnostics and may be lowered explicitly when a caller has validated
+    a tighter numerical error budget.
+    """
+    covariance_mode = covariance is not None
+    correlation_mode = correlation is not None or stddev is not None
+    if covariance_mode == correlation_mode:
+        raise ValueError(
+            "supply either covariance or correlation plus stddev, but not both"
+        )
+
+    source: str
+    if covariance_mode:
+        if correlation is not None or stddev is not None:
+            raise ValueError("stddev/correlation cannot accompany covariance")
+        raw = _matrix(name, covariance)
+        if raw.shape[-2] != raw.shape[-1] or raw.shape[-1] == 0:
+            raise ValueError(f"{name} must be nonempty and square")
+        raw = raw.clone()
+        source = "covariance"
+    else:
+        if correlation is None or stddev is None:
+            raise ValueError("correlation and stddev must be supplied together")
+        corr = _matrix("correlation", correlation)
+        if corr.shape[-2] != corr.shape[-1] or corr.shape[-1] == 0:
+            raise ValueError("correlation must be nonempty and square")
+        standard_deviation = _vector(
+            "stddev", stddev, length=corr.shape[-1]
+        )
+        _same_backend(corr, stddev=standard_deviation)
+        batch_shape = torch.broadcast_shapes(
+            corr.shape[:-2], standard_deviation.shape[:-1]
+        )
+        corr = corr.expand(batch_shape + corr.shape[-2:]).clone()
+        standard_deviation = standard_deviation.expand(
+            batch_shape + standard_deviation.shape[-1:]
+        ).clone()
+        if not bool(torch.isfinite(corr).all().item()):
+            raise ValueError("correlation must be finite")
+        if not bool(torch.isfinite(standard_deviation).all().item()):
+            raise ValueError("stddev must be finite")
+        nonpositive = torch.any(standard_deviation <= 0, dim=-1)
+        if bool(torch.any(nonpositive).item()):
+            raise ValueError(
+                "stddev must be strictly positive"
+                + _batch_failure_detail(nonpositive)
+            )
+        n = corr.shape[-1]
+        eps = torch.finfo(corr.dtype).eps
+        corr_tol = (
+            64.0 * n * eps
+            if correlation_tolerance is None
+            else _nonnegative_finite("correlation_tolerance", correlation_tolerance)
+        )
+        diagonal_error = torch.amax(
+            torch.abs(torch.diagonal(corr, dim1=-2, dim2=-1) - 1.0), dim=-1
+        )
+        bad_diagonal = diagonal_error > corr_tol
+        if bool(torch.any(bad_diagonal).item()):
+            worst = float(torch.amax(diagonal_error).detach().cpu())
+            raise ValueError(
+                f"correlation diagonal must be one within tolerance {corr_tol:g}; "
+                f"maximum error={worst:g}"
+                + _batch_failure_detail(bad_diagonal)
+            )
+        maximum_entry = torch.amax(torch.abs(corr), dim=(-2, -1))
+        bad_entry = maximum_entry > 1.0 + corr_tol
+        if bool(torch.any(bad_entry).item()):
+            worst = float(torch.amax(maximum_entry).detach().cpu())
+            raise ValueError(
+                f"correlation entries must satisfy |rho| <= 1 within tolerance "
+                f"{corr_tol:g}; maximum |rho|={worst:g}"
+                + _batch_failure_detail(bad_entry)
+            )
+        raw = (
+            standard_deviation.unsqueeze(-1)
+            * corr
+            * standard_deviation.unsqueeze(-2)
+        )
+        name = "noise covariance from correlation"
+        source = "correlation+stddev"
+
+    if not bool(torch.isfinite(raw).all().item()):
+        raise ValueError(f"{name} must be finite")
+    n = raw.shape[-1]
+    eps = torch.finfo(raw.dtype).eps
+    relative_floor = (
+        max(math.sqrt(eps), 8.0 * n * eps)
+        if relative_eigenvalue_floor is None
+        else _nonnegative_finite(
+            "relative_eigenvalue_floor", relative_eigenvalue_floor
+        )
+    )
+    absolute_floor = _nonnegative_finite(
+        "absolute_eigenvalue_floor", absolute_eigenvalue_floor
+    )
+    negative_tolerance = (
+        64.0 * n * eps
+        if negative_eigenvalue_tolerance is None
+        else _nonnegative_finite(
+            "negative_eigenvalue_tolerance", negative_eigenvalue_tolerance
+        )
+    )
+    maximum_loading = _nonnegative_finite(
+        "maximum_relative_loading", maximum_relative_loading
+    )
+    symmetry_limit = (
+        64.0 * n * eps
+        if symmetry_tolerance is None
+        else _nonnegative_finite("symmetry_tolerance", symmetry_tolerance)
+    )
+
+    entry_scale = torch.amax(torch.abs(raw), dim=(-2, -1))
+    symmetry_error = torch.amax(
+        torch.abs(raw - raw.transpose(-2, -1)), dim=(-2, -1)
+    )
+    relative_symmetry_error = symmetry_error / torch.clamp(
+        entry_scale, min=torch.finfo(raw.dtype).tiny
+    )
+    nonsymmetric = relative_symmetry_error > symmetry_limit
+    if bool(torch.any(nonsymmetric).item()):
+        worst = float(torch.amax(relative_symmetry_error).detach().cpu())
+        raise ValueError(
+            f"{name} is not symmetric within relative tolerance "
+            f"{symmetry_limit:g}; maximum relative error={worst:g}"
+            + _batch_failure_detail(nonsymmetric)
+        )
+
+    symmetric = 0.5 * (raw + raw.transpose(-2, -1))
+    eigenvalues = torch.linalg.eigvalsh(symmetric)
+    minimum = eigenvalues[..., 0]
+    matrix_scale = torch.amax(torch.abs(eigenvalues), dim=-1)
+    zero_scale = matrix_scale == 0
+    if absolute_floor == 0.0 and bool(torch.any(zero_scale).item()):
+        raise ValueError(
+            f"{name} has zero spectral scale; supply positive variances, or "
+            "provide absolute_eigenvalue_floor > 0 together with "
+            "maximum_relative_loading >= 1 to authorize a full-scale repair"
+            + _batch_failure_detail(zero_scale)
+        )
+
+    materially_indefinite = minimum < -negative_tolerance * matrix_scale
+    if bool(torch.any(materially_indefinite).item()):
+        relative_negative = -minimum / torch.clamp(
+            matrix_scale, min=torch.finfo(raw.dtype).tiny
+        )
+        worst = float(torch.amax(relative_negative).detach().cpu())
+        raise ValueError(
+            f"{name} is genuinely indefinite: worst relative negative "
+            f"eigenvalue={worst:g} exceeds tolerance {negative_tolerance:g}"
+            + _batch_failure_detail(materially_indefinite)
+        )
+
+    absolute_floor_tensor = torch.as_tensor(
+        absolute_floor, dtype=raw.dtype, device=raw.device
+    )
+    target_minimum = torch.maximum(
+        relative_floor * matrix_scale, absolute_floor_tensor
+    )
+    loading = torch.clamp(target_minimum - minimum, min=0.0)
+    loading_reference = torch.where(
+        matrix_scale > 0, matrix_scale, target_minimum
+    )
+    relative_loading = loading / torch.clamp(
+        loading_reference, min=torch.finfo(raw.dtype).tiny
+    )
+    excessive_loading = relative_loading > maximum_loading
+    if bool(torch.any(excessive_loading).item()):
+        worst = float(torch.amax(relative_loading).detach().cpu())
+        raise ValueError(
+            f"{name} requires relative diagonal loading {worst:g}, exceeding "
+            f"maximum_relative_loading={maximum_loading:g}"
+            + _batch_failure_detail(excessive_loading)
+        )
+
+    identity = torch.eye(n, dtype=raw.dtype, device=raw.device)
+    loaded_covariance = symmetric + loading[..., None, None] * identity
+    cholesky, info = torch.linalg.cholesky_ex(loaded_covariance, check_errors=False)
+    failed_cholesky = info != 0
+    if bool(torch.any(failed_cholesky).item()):
+        raise torch.linalg.LinAlgError(
+            f"{name} remained non-positive-definite after declared loading; "
+            "increase relative_eigenvalue_floor"
+            + _batch_failure_detail(failed_cholesky)
+        )
+
+    diagnostics = CovarianceLoadingDiagnosticsTorch(
+        matrix_scale=matrix_scale,
+        minimum_eigenvalue=minimum,
+        target_minimum_eigenvalue=target_minimum,
+        diagonal_loading=loading,
+        relative_diagonal_loading=relative_loading,
+        relative_symmetry_error=relative_symmetry_error,
+        was_loaded=loading > 0,
+        relative_eigenvalue_floor=relative_floor,
+        negative_eigenvalue_tolerance=negative_tolerance,
+        maximum_relative_loading=maximum_loading,
+        source=source,
+    )
+    return NoiseWhitenerTorch(
+        covariance=loaded_covariance,
+        cholesky_factor=cholesky,
+        diagnostics=diagnostics,
+    )
+
+
 def regularize_covariance_torch(
     covariance: torch.Tensor,
     *,
     jitter: float = 1e-9,
     name: str = "covariance",
 ) -> torch.Tensor:
-    """Symmetrise and minimally lift a PSD covariance, in batch.
+    """Compatibility helper using an absolute covariance floor.
 
-    The effective floor is at least machine epsilon.  Thus float64 matches the
-    NumPy prototype's default ``1e-9`` floor, while float32 automatically uses
-    a representable stability floor.
+    New square-root and noise-conditioning paths use
+    :func:`prepare_noise_whitener_torch`, whose loading is scale-relative and
+    observable.  Keep this helper only for callers that explicitly depend on
+    the historical absolute-unit policy.
     """
     if jitter < 0:
         raise ValueError("jitter must be nonnegative")
@@ -353,18 +742,29 @@ def regularize_covariance_torch(
 
 
 def precision_root_from_covariance_torch(
-    covariance: torch.Tensor, *, jitter: float = 1e-9
+    covariance: torch.Tensor,
+    *,
+    jitter: float = 0.0,
+    relative_eigenvalue_floor: float | None = None,
+    negative_eigenvalue_tolerance: float | None = None,
+    maximum_relative_loading: float = 1e-3,
 ) -> torch.Tensor:
-    """Return upper ``U`` with ``P^-1 = U.T @ U`` without forming ``P^-1``."""
-    covariance = regularize_covariance_torch(
-        covariance, jitter=jitter, name="prior covariance"
+    """Return upper ``U`` with ``P^-1 = U.T @ U`` without forming ``P^-1``.
+
+    ``jitter`` is an optional absolute floor in covariance units; it defaults
+    to zero so the scale-relative policy remains valid under unit changes.
+    """
+    whitener = prepare_noise_whitener_torch(
+        covariance,
+        relative_eigenvalue_floor=relative_eigenvalue_floor,
+        absolute_eigenvalue_floor=jitter,
+        negative_eigenvalue_tolerance=negative_eigenvalue_tolerance,
+        maximum_relative_loading=maximum_relative_loading,
+        name="prior covariance",
     )
-    n = covariance.shape[-1]
-    chol = torch.linalg.cholesky(covariance)
-    identity = torch.eye(n, dtype=chol.dtype, device=chol.device).expand(
-        chol.shape[:-2] + (n, n)
-    )
-    inverse_factor = torch.linalg.solve_triangular(chol, identity, upper=False)
+    inverse_factor = whitener.materialize_precision_root()
+    n = inverse_factor.shape[-1]
+    _pre_array_scale(inverse_factor)
     packed, _ = torch.geqrf(inverse_factor.contiguous())
     root, _ = _normalised_root_from_packed(packed, n)
     _check_root_rank(inverse_factor, root)
@@ -377,9 +777,43 @@ def conditional_measurement_model_torch(
     observation_covariance: torch.Tensor,
     cross_covariance: torch.Tensor,
     *,
-    jitter: float = 1e-9,
+    jitter: float = 0.0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Return the decorrelated ``(J, Rc)`` likelihood in information form."""
+    """Return the loaded decorrelated ``(J, Rc)`` likelihood.
+
+    For loading diagnostics and the reusable implicit inverse factor, call
+    :func:`conditional_measurement_whitener_torch` directly.
+    """
+    effective_H, whitener = conditional_measurement_whitener_torch(
+        prior_precision_root,
+        H,
+        observation_covariance,
+        cross_covariance,
+        jitter=jitter,
+    )
+    return effective_H, whitener.covariance
+
+
+def conditional_measurement_whitener_torch(
+    prior_precision_root: torch.Tensor,
+    H: torch.Tensor,
+    observation_covariance: torch.Tensor,
+    cross_covariance: torch.Tensor,
+    *,
+    jitter: float = 0.0,
+    relative_eigenvalue_floor: float | None = None,
+    negative_eigenvalue_tolerance: float | None = None,
+    maximum_relative_loading: float = 1e-3,
+) -> tuple[torch.Tensor, NoiseWhitenerTorch]:
+    """Decorrelate a measurement block and prepare its implicit whitener.
+
+    ``jitter`` is an absolute eigenvalue floor in the measurement's units;
+    the scale-relative floor and repair diagnostics come from
+    :func:`prepare_noise_whitener_torch`.  A bad Schur complement is rejected,
+    not silently converted into a plausible covariance.
+    """
+    if jitter < 0:
+        raise ValueError("jitter must be nonnegative")
     root = _matrix("prior_precision_root", prior_precision_root)
     if root.shape[-2] != root.shape[-1] or root.shape[-1] == 0:
         raise ValueError("prior_precision_root must be nonempty and square")
@@ -403,16 +837,19 @@ def conditional_measurement_model_torch(
     )
     root_cross = root @ cross_covariance
     effective_H = H + root_cross.transpose(-2, -1) @ root
-    conditional_R = (
+    raw_conditional_R = (
         observation_covariance
         - root_cross.transpose(-2, -1) @ root_cross
     )
-    conditional_R = regularize_covariance_torch(
-        conditional_R,
-        jitter=jitter,
+    whitener = prepare_noise_whitener_torch(
+        raw_conditional_R,
+        relative_eigenvalue_floor=relative_eigenvalue_floor,
+        absolute_eigenvalue_floor=jitter,
+        negative_eigenvalue_tolerance=negative_eigenvalue_tolerance,
+        maximum_relative_loading=maximum_relative_loading,
         name="conditional observation covariance R - C.T P^-1 C",
     )
-    return effective_H, conditional_R
+    return effective_H, whitener
 
 
 def _posterior_covariance(root: torch.Tensor) -> torch.Tensor:
@@ -444,7 +881,7 @@ def condition_correlated_gaussian_qr_torch(
     H: torch.Tensor,
     cross_covariance: torch.Tensor,
     *,
-    jitter: float = 1e-9,
+    jitter: float = 0.0,
 ) -> JointSquareRootUpdateTorch:
     """Condition a Gaussian with batched tensors and compact Householder QR.
 
@@ -463,13 +900,14 @@ def condition_correlated_gaussian_qr_torch(
     observation = _vector("observation", observation, length=m)
     _same_backend(root, mean=mean, H=H, observation=observation)
 
-    effective_H, conditional_R = conditional_measurement_model_torch(
+    effective_H, conditional_whitener = conditional_measurement_whitener_torch(
         root,
         H,
         observation_covariance,
         cross_covariance,
         jitter=jitter,
     )
+    conditional_R = conditional_whitener.covariance
     design_batch = torch.broadcast_shapes(
         root.shape[:-2], H.shape[:-2], effective_H.shape[:-2]
     )
@@ -480,10 +918,8 @@ def condition_correlated_gaussian_qr_torch(
     H_design = H.expand(design_batch + (m, n))
     effective_H = effective_H.expand(design_batch + (m, n))
     conditional_R = conditional_R.expand(design_batch + (m, m))
-    chol = torch.linalg.cholesky(conditional_R)
-    whitened_H = torch.linalg.solve_triangular(
-        chol, effective_H, upper=False
-    )
+    chol = conditional_whitener.cholesky_factor
+    whitened_H = conditional_whitener.apply_columns(effective_H)
     compiled = compile_information_update_torch(root, whitened_H)
 
     mean = mean.expand(result_batch + (n,))
@@ -507,6 +943,7 @@ def condition_correlated_gaussian_qr_torch(
         conditional_observation_covariance=conditional_R.expand(
             result_batch + (m, m)
         ),
+        conditional_loading_diagnostics=conditional_whitener.diagnostics,
         whitened_observation_matrix=whitened_H.expand(result_batch + (m, n)),
         whitened_innovation=whitened_innovation,
         residual_sum_squares=information.residual_sum_squares,
@@ -521,6 +958,7 @@ class CompiledCorrelatedConditionerTorch:
     H: torch.Tensor
     effective_observation_matrix: torch.Tensor
     conditional_observation_covariance: torch.Tensor
+    conditional_loading_diagnostics: CovarianceLoadingDiagnosticsTorch
     conditional_cholesky: torch.Tensor
     whitened_observation_matrix: torch.Tensor
     information_qr: CompiledInformationQRTorch
@@ -534,7 +972,7 @@ class CompiledCorrelatedConditionerTorch:
         observation_covariance: torch.Tensor,
         cross_covariance: torch.Tensor,
         *,
-        jitter: float = 1e-9,
+        jitter: float = 0.0,
     ) -> "CompiledCorrelatedConditionerTorch":
         """Compile an unbatched fixed design.
 
@@ -550,22 +988,23 @@ class CompiledCorrelatedConditionerTorch:
         ):
             if not isinstance(value, torch.Tensor) or value.ndim != 2:
                 raise ValueError(f"{name} must be one unbatched matrix")
-        # Compiled objects own a snapshot of coefficient inputs. Otherwise an
-        # in-place caller mutation of H would combine a new innovation with
-        # stale QR reflectors.
+        # Compiled objects own a snapshot of every design input. Otherwise an
+        # in-place caller mutation could combine a new innovation with stale
+        # QR reflectors (or race an asynchronous device operation).
         prior_precision_root = prior_precision_root.clone()
         H = H.clone()
-        effective_H, conditional_R = conditional_measurement_model_torch(
+        observation_covariance = observation_covariance.clone()
+        cross_covariance = cross_covariance.clone()
+        effective_H, conditional_whitener = conditional_measurement_whitener_torch(
             prior_precision_root,
             H,
             observation_covariance,
             cross_covariance,
             jitter=jitter,
         )
-        chol = torch.linalg.cholesky(conditional_R)
-        whitened_H = torch.linalg.solve_triangular(
-            chol, effective_H, upper=False
-        )
+        conditional_R = conditional_whitener.covariance
+        chol = conditional_whitener.cholesky_factor
+        whitened_H = conditional_whitener.apply_columns(effective_H)
         information_qr = compile_information_update_torch(
             prior_precision_root, whitened_H
         )
@@ -574,6 +1013,7 @@ class CompiledCorrelatedConditionerTorch:
             H=H,
             effective_observation_matrix=effective_H,
             conditional_observation_covariance=conditional_R,
+            conditional_loading_diagnostics=conditional_whitener.diagnostics,
             conditional_cholesky=chol,
             whitened_observation_matrix=whitened_H,
             information_qr=information_qr,
@@ -621,6 +1061,7 @@ class CompiledCorrelatedConditionerTorch:
                     batch_shape + (m, m)
                 )
             ),
+            conditional_loading_diagnostics=self.conditional_loading_diagnostics,
             whitened_observation_matrix=self.whitened_observation_matrix.expand(
                 batch_shape + (m, n)
             ),
@@ -648,6 +1089,7 @@ class CompiledDenseGainConditionerTorch:
     gain: torch.Tensor
     posterior_covariance: torch.Tensor
     innovation_covariance: torch.Tensor
+    conditional_loading_diagnostics: CovarianceLoadingDiagnosticsTorch
 
     @classmethod
     def compile(
@@ -657,7 +1099,7 @@ class CompiledDenseGainConditionerTorch:
         observation_covariance: torch.Tensor,
         cross_covariance: torch.Tensor,
         *,
-        jitter: float = 1e-9,
+        jitter: float = 0.0,
     ) -> "CompiledDenseGainConditionerTorch":
         """Compile an unbatched fixed design into a dense correlated gain."""
         for name, value in (
@@ -673,18 +1115,21 @@ class CompiledDenseGainConditionerTorch:
             raise ValueError("prior_precision_root must be nonempty and square")
         n = root.shape[-1]
         H = _matrix("H", H, cols=n).clone()
+        observation_covariance = observation_covariance.clone()
+        cross_covariance = cross_covariance.clone()
         _same_backend(root, H=H)
 
         # Use the same Schur-complement model as QR.  This both validates the
         # proposed joint covariance and makes jitter behavior directly
         # comparable between the two static implementations.
-        effective_H, conditional_R = conditional_measurement_model_torch(
+        effective_H, conditional_whitener = conditional_measurement_whitener_torch(
             root,
             H,
             observation_covariance,
             cross_covariance,
             jitter=jitter,
         )
+        conditional_R = conditional_whitener.covariance
         # The first precision factor need not already be triangular: left
         # orthogonal rotations preserve U.T U.  Use a general solve here;
         # posterior QR roots use the cheaper triangular helper above.
@@ -700,26 +1145,24 @@ class CompiledDenseGainConditionerTorch:
         gain = torch.cholesky_solve(
             state_innovation_cross.mT, innovation_chol
         ).mT
+        # Joseph form avoids the catastrophic subtraction in
+        # ``P - K S K.T`` when an observation is much more precise than the
+        # prior.  Both summands are PSD and preserve the covariance's units.
+        identity = torch.eye(n, dtype=root.dtype, device=root.device)
+        residual_map = identity - gain @ effective_H
         posterior_covariance = (
-            prior_covariance - gain @ state_innovation_cross.mT
+            residual_map @ prior_covariance @ residual_map.mT
+            + gain @ conditional_R @ gain.mT
         )
         posterior_covariance = 0.5 * (
             posterior_covariance + posterior_covariance.mT
-        )
-        # The dense subtraction can lose the last positive bits when a very
-        # informative observation makes P_post tiny.  Keep this baseline a
-        # valid Gaussian rather than returning a singular/negative covariance;
-        # the square-root path is positive definite by construction.
-        posterior_covariance = regularize_covariance_torch(
-            posterior_covariance,
-            jitter=jitter,
-            name="dense posterior covariance",
         )
         return cls(
             H=H,
             gain=gain,
             posterior_covariance=posterior_covariance,
             innovation_covariance=innovation_covariance,
+            conditional_loading_diagnostics=conditional_whitener.diagnostics,
         )
 
     def condition(
@@ -746,6 +1189,7 @@ class CompiledDenseGainConditionerTorch:
             innovation_covariance=self.innovation_covariance.expand(
                 batch_shape + (m, m)
             ),
+            conditional_loading_diagnostics=self.conditional_loading_diagnostics,
         )
 
 
@@ -753,7 +1197,9 @@ class CompiledDenseGainConditionerTorch:
 class SquareRootInformationStateTorch:
     """Sequential information state in one fixed coordinate system.
 
-    Each block threads ``U_post`` and ``z``, so every measurement RHS must use
+    ``information_rhs`` is the square-root RHS ``z``, not the canonical
+    information vector ``eta``; ``eta = U.T @ z``. Each block threads
+    ``U_post`` and ``z``, so every measurement RHS must use
     the same state origin.  To recenter at the current posterior mean, instead
     reset ``z`` to zero and shift each later RHS by ``-A @ current_solution``;
     do not both carry ``z`` and recenter the likelihood.
@@ -777,3 +1223,23 @@ class SquareRootInformationStateTorch:
             information_rhs=result.information_rhs,
         )
         return state, result
+
+    def update_noise_block(
+        self,
+        measurement_matrix: torch.Tensor,
+        measurement_rhs: torch.Tensor,
+        whitener: NoiseWhitenerTorch,
+    ) -> tuple["SquareRootInformationStateTorch", InformationRootUpdateTorch]:
+        """Whiten one noise block consistently, then absorb it with QR.
+
+        ``measurement_matrix`` is the unwhitened conditional design ``J`` and
+        ``measurement_rhs`` is its matching innovation ``r``.  Both are acted
+        on from the left by the same implicit ``L^-1``.  This convenience
+        avoids materialising an inverse root or accidentally applying the
+        whitening factor with the wrong orientation.
+        """
+        if not isinstance(whitener, NoiseWhitenerTorch):
+            raise TypeError("whitener must be a NoiseWhitenerTorch")
+        whitened_matrix = whitener.apply_columns(measurement_matrix)
+        whitened_rhs = whitener.apply_vectors(measurement_rhs)
+        return self.update(whitened_matrix, whitened_rhs)

--- a/prototypes/mu_cosine/test_joint_square_root_conditioner.py
+++ b/prototypes/mu_cosine/test_joint_square_root_conditioner.py
@@ -105,6 +105,53 @@ def test_information_qr_rank_check_is_invariant_to_uniform_small_scale():
     )
 
 
+def test_information_qr_rank_boundary_preserves_frobenius_sensitivity():
+    n, m = 128, 32
+    boundary = np.finfo(float).eps * (n + m) * np.sqrt(m * n)
+    measurement = np.ones((m, n))
+
+    with np.testing.assert_raises(np.linalg.LinAlgError):
+        householder_information_update(
+            np.eye(n) * (0.5 * boundary),
+            np.zeros(n),
+            measurement,
+            np.zeros(m),
+        )
+
+    accepted = householder_information_update(
+        np.eye(n) * (2.0 * boundary),
+        np.zeros(n),
+        measurement,
+        np.zeros(m),
+    )
+    assert np.isfinite(accepted.precision_root).all()
+
+
+def test_information_qr_rank_scale_does_not_overflow_near_dtype_max():
+    n = 16
+    scale = np.finfo(float).max / 2.0
+    update = householder_information_update(
+        np.eye(n) * scale,
+        np.zeros(n),
+        np.zeros((0, n)),
+        np.zeros(0),
+    )
+    np.testing.assert_allclose(update.precision_root / scale, np.eye(n))
+
+
+def test_information_qr_rejects_subnormal_scale_with_rescale_message():
+    scale = np.finfo(float).tiny / 2.0
+    with np.testing.assert_raises_regex(
+        np.linalg.LinAlgError, "subnormal; rescale"
+    ):
+        householder_information_update(
+            np.eye(2) * scale,
+            np.zeros(2),
+            np.zeros((0, 2)),
+            np.zeros(0),
+        )
+
+
 def test_householder_update_is_row_permutation_invariant():
     rng = np.random.default_rng(23)
     n, m = 4, 9

--- a/prototypes/mu_cosine/test_joint_square_root_conditioner.py
+++ b/prototypes/mu_cosine/test_joint_square_root_conditioner.py
@@ -83,6 +83,28 @@ def test_independent_blocks_batch_equals_streaming_update():
     assert np.allclose(batch.solution, streamed.solution, atol=1e-10)
 
 
+def test_information_qr_rank_check_is_invariant_to_uniform_small_scale():
+    rng = np.random.default_rng(21)
+    n = 3
+    A = rng.standard_normal((5, n))
+    z = rng.standard_normal(n)
+    b = rng.standard_normal(5)
+    reference = householder_information_update(np.eye(n), z, A, b)
+
+    scale = 1e-20
+    scaled = householder_information_update(
+        scale * np.eye(n), scale * z, scale * A, scale * b
+    )
+
+    np.testing.assert_allclose(scaled.solution, reference.solution, atol=2e-12)
+    np.testing.assert_allclose(
+        scaled.precision_root.T @ scaled.precision_root,
+        scale**2 * (reference.precision_root.T @ reference.precision_root),
+        rtol=2e-12,
+        atol=0.0,
+    )
+
+
 def test_householder_update_is_row_permutation_invariant():
     rng = np.random.default_rng(23)
     n, m = 4, 9

--- a/prototypes/mu_cosine/test_joint_square_root_conditioner_torch.py
+++ b/prototypes/mu_cosine/test_joint_square_root_conditioner_torch.py
@@ -20,6 +20,7 @@ from joint_square_root_conditioner_torch import (  # noqa: E402
     conditional_measurement_model_torch,
     householder_information_update_torch,
     precision_root_from_covariance_torch,
+    prepare_noise_whitener_torch,
 )
 
 
@@ -40,6 +41,300 @@ def _problem(seed=7, n=4, m=5):
 
 def _as_torch(*arrays, device="cpu", dtype=torch.float64):
     return tuple(torch.as_tensor(a, dtype=dtype, device=device) for a in arrays)
+
+
+@pytest.mark.parametrize("dtype,rtol,atol", [
+    (torch.float32, 2e-5, 2e-6),
+    (torch.float64, 2e-12, 2e-13),
+])
+def test_noise_whitener_correlation_and_covariance_are_equivalent(dtype, rtol, atol):
+    correlation = torch.tensor(
+        [[1.0, 0.25, -0.1], [0.25, 1.0, 0.2], [-0.1, 0.2, 1.0]],
+        dtype=dtype,
+    )
+    stddev = torch.tensor([2.0, 0.5, 1.5], dtype=dtype)
+    covariance = stddev[:, None] * correlation * stddev[None, :]
+    from_correlation = prepare_noise_whitener_torch(
+        correlation=correlation, stddev=stddev
+    )
+    from_covariance = prepare_noise_whitener_torch(covariance)
+    torch.testing.assert_close(
+        from_correlation.covariance, from_covariance.covariance, rtol=rtol, atol=atol
+    )
+
+    rhs = torch.arange(12, dtype=dtype).reshape(4, 3) / 7.0
+    torch.testing.assert_close(
+        from_correlation.apply_vectors(rhs),
+        from_covariance.apply_vectors(rhs),
+        rtol=rtol,
+        atol=atol,
+    )
+    precision_root = from_correlation.materialize_precision_root()
+    identity = torch.eye(3, dtype=dtype)
+    torch.testing.assert_close(
+        precision_root.mT @ precision_root @ from_correlation.covariance,
+        identity,
+        rtol=10 * rtol,
+        atol=10 * atol,
+    )
+    assert from_correlation.diagnostics.source == "correlation+stddev"
+    assert from_covariance.diagnostics.source == "covariance"
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_noise_whitener_nearly_singular_psd_loading_is_scale_relative(dtype):
+    scales = torch.tensor([1e-6, 1.0, 1e6], dtype=dtype)
+    singular = torch.tensor([[1.0, 1.0], [1.0, 1.0]], dtype=dtype)
+    covariance = scales[:, None, None] * singular
+    whitener = prepare_noise_whitener_torch(covariance)
+    diagnostics = whitener.diagnostics
+    assert diagnostics.was_loaded.shape == (3,)
+    assert bool(torch.all(diagnostics.was_loaded))
+    assert bool(torch.all(diagnostics.diagonal_loading > 0))
+    expected = torch.full_like(
+        diagnostics.relative_diagonal_loading,
+        diagnostics.relative_eigenvalue_floor,
+    )
+    assert diagnostics.relative_eigenvalue_floor == pytest.approx(
+        max(
+            np.sqrt(torch.finfo(dtype).eps),
+            8.0 * 2 * torch.finfo(dtype).eps,
+        )
+    )
+    torch.testing.assert_close(
+        diagnostics.relative_diagonal_loading,
+        expected,
+        rtol=0.08,
+        atol=8 * torch.finfo(dtype).eps,
+    )
+    root = whitener.materialize_precision_root()
+    identity = torch.eye(2, dtype=dtype).expand(3, 2, 2)
+    torch.testing.assert_close(
+        root.transpose(-2, -1) @ root @ whitener.covariance,
+        identity,
+        rtol=3e-3 if dtype == torch.float32 else 2e-9,
+        atol=3e-3 if dtype == torch.float32 else 2e-9,
+    )
+
+
+def test_noise_whitener_rejects_indefinite_and_excessive_loading():
+    indefinite = torch.tensor([[1.0, 0.0], [0.0, -0.05]], dtype=torch.float64)
+    with pytest.raises(ValueError, match="genuinely indefinite"):
+        prepare_noise_whitener_torch(indefinite)
+
+    singular = torch.tensor([[1.0, 1.0], [1.0, 1.0]], dtype=torch.float64)
+    with pytest.raises(ValueError, match="exceeding maximum_relative_loading"):
+        prepare_noise_whitener_torch(
+            singular,
+            relative_eigenvalue_floor=1e-3,
+            maximum_relative_loading=1e-4,
+        )
+
+
+@pytest.mark.parametrize("device", [
+    "cpu",
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable"),
+    ),
+])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_noise_whitener_batched_dtype_device_and_solve(device, dtype):
+    correlation = torch.tensor(
+        [
+            [[1.0, 0.2, 0.0], [0.2, 1.0, 0.1], [0.0, 0.1, 1.0]],
+            [[1.0, -0.3, 0.05], [-0.3, 1.0, 0.15], [0.05, 0.15, 1.0]],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    stddev = torch.tensor(
+        [[1.0, 0.5, 2.0], [0.7, 1.4, 0.9]], dtype=dtype, device=device
+    )
+    whitener = prepare_noise_whitener_torch(
+        correlation=correlation, stddev=stddev
+    )
+    values = torch.arange(24, dtype=dtype, device=device).reshape(4, 2, 3) / 11.0
+    actual = whitener.apply_vectors(values)
+    expected = torch.stack([
+        torch.stack([
+            torch.linalg.solve_triangular(
+                whitener.cholesky_factor[batch],
+                values[sample, batch, :, None],
+                upper=False,
+            ).squeeze(-1)
+            for batch in range(2)
+        ])
+        for sample in range(4)
+    ])
+    torch.testing.assert_close(actual, expected)
+    assert actual.dtype == dtype
+    assert actual.device.type == device
+    assert whitener.diagnostics.diagonal_loading.shape == (2,)
+
+
+def test_noise_whitener_validates_correlation_and_positive_stddev():
+    correlation = torch.eye(2, dtype=torch.float64)
+    with pytest.raises(ValueError, match="strictly positive"):
+        prepare_noise_whitener_torch(
+            correlation=correlation,
+            stddev=torch.tensor([1.0, 0.0], dtype=torch.float64),
+        )
+    with pytest.raises(ValueError, match="diagonal must be one"):
+        prepare_noise_whitener_torch(
+            correlation=torch.tensor([[0.9, 0.0], [0.0, 1.0]]),
+            stddev=torch.ones(2),
+        )
+    with pytest.raises(ValueError, match=r"\|rho\| <= 1"):
+        prepare_noise_whitener_torch(
+            correlation=torch.tensor([[1.0, 1.01], [1.01, 1.0]]),
+            stddev=torch.ones(2),
+        )
+
+
+def test_noise_whitener_never_calls_explicit_inverse(monkeypatch):
+    def forbidden(*args, **kwargs):
+        raise AssertionError("explicit inverse called")
+
+    monkeypatch.setattr(torch.linalg, "inv", forbidden)
+    monkeypatch.setattr(torch, "inverse", forbidden)
+    covariance = torch.tensor([[1.2, 0.2], [0.2, 0.8]], dtype=torch.float64)
+    whitener = prepare_noise_whitener_torch(covariance)
+    whitener.apply_vectors(torch.tensor([0.3, -0.4], dtype=torch.float64))
+    whitener.apply_columns(torch.eye(2, dtype=torch.float64))
+    whitener.materialize_precision_root()
+
+
+@pytest.mark.parametrize("device", [
+    "cpu",
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable"),
+    ),
+])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_information_state_update_noise_block_matches_normal_equations(device, dtype):
+    correlation = torch.tensor(
+        [
+            [[1.0, 0.2, -0.1], [0.2, 1.0, 0.15], [-0.1, 0.15, 1.0]],
+            [[1.0, -0.25, 0.0], [-0.25, 1.0, 0.1], [0.0, 0.1, 1.0]],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    stddev = torch.tensor(
+        [[0.8, 1.2, 0.6], [1.1, 0.7, 1.4]], dtype=dtype, device=device
+    )
+    whitener = prepare_noise_whitener_torch(
+        correlation=correlation, stddev=stddev
+    )
+    matrix = torch.tensor(
+        [
+            [[1.0, 0.2], [0.1, -0.7], [0.4, 0.9]],
+            [[0.5, -0.1], [0.3, 0.8], [-0.6, 0.2]],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    rhs = torch.tensor(
+        [[0.4, -0.2, 0.9], [-0.1, 0.7, 0.3]], dtype=dtype, device=device
+    )
+    root = torch.eye(2, dtype=dtype, device=device)
+    state = SquareRootInformationStateTorch(
+        root, torch.zeros(2, dtype=dtype, device=device)
+    )
+    _, actual = state.update_noise_block(matrix, rhs, whitener)
+
+    whitened_matrix = whitener.apply_columns(matrix)
+    whitened_rhs = whitener.apply_vectors(rhs)
+    precision = (
+        torch.eye(2, dtype=dtype, device=device).expand(2, 2, 2)
+        + whitened_matrix.transpose(-2, -1) @ whitened_matrix
+    )
+    information = (
+        whitened_matrix.transpose(-2, -1) @ whitened_rhs.unsqueeze(-1)
+    )
+    expected = torch.linalg.solve(precision, information).squeeze(-1)
+    torch.testing.assert_close(actual.solution, expected, rtol=2e-4, atol=2e-5)
+
+
+@pytest.mark.parametrize("dtype,scales", [
+    (torch.float32, (1e-20, 1.0, 1e20)),
+    (torch.float64, (1e-150, 1.0, 1e150)),
+])
+def test_information_qr_rank_check_is_scale_homogeneous(dtype, scales):
+    for scale in scales:
+        root = torch.eye(3, dtype=dtype) * scale
+        compiled = compile_information_update_torch(
+            root, torch.zeros(0, 3, dtype=dtype)
+        )
+        torch.testing.assert_close(
+            compiled.precision_root / scale,
+            torch.eye(3, dtype=dtype),
+            rtol=20 * torch.finfo(dtype).eps,
+            atol=20 * torch.finfo(dtype).eps,
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_information_qr_rejects_subnormal_scale_with_rescale_message(dtype):
+    scale = torch.finfo(dtype).tiny / 2.0
+    with pytest.raises(torch.linalg.LinAlgError, match="subnormal; rescale"):
+        compile_information_update_torch(
+            torch.eye(2, dtype=dtype) * scale,
+            torch.zeros(0, 2, dtype=dtype),
+        )
+
+
+def test_conditioner_exposes_loading_without_absolute_float32_eps_inflation():
+    dtype = torch.float32
+    root = torch.eye(2, dtype=dtype)
+    H = torch.zeros(2, 2, dtype=dtype)
+    R = torch.eye(2, dtype=dtype) * 1e-9
+    C = torch.zeros(2, 2, dtype=dtype)
+    mean = torch.zeros(2, dtype=dtype)
+    observation = torch.ones(2, dtype=dtype) * 1e-4
+    update = condition_correlated_gaussian_qr_torch(
+        mean, root, observation, R, H, C
+    )
+    compiled = CompiledCorrelatedConditionerTorch.compile(root, H, R, C)
+    torch.testing.assert_close(
+        update.conditional_observation_covariance,
+        R,
+        rtol=2e-6,
+        atol=1e-15,
+    )
+    assert not bool(update.conditional_loading_diagnostics.was_loaded)
+    assert not bool(compiled.conditional_loading_diagnostics.was_loaded)
+
+
+@pytest.mark.parametrize("dtype,scales", [
+    (torch.float32, (1e-20, 1e-12, 1.0, 1e20)),
+    (torch.float64, (1e-150, 1e-30, 1.0, 1e150)),
+])
+def test_default_covariance_roots_and_conditioner_are_scale_relative(dtype, scales):
+    for scale in scales:
+        covariance = torch.eye(2, dtype=dtype) * scale
+        root = precision_root_from_covariance_torch(covariance)
+        torch.testing.assert_close(
+            root.mT @ root @ covariance,
+            torch.eye(2, dtype=dtype),
+            rtol=5e-5 if dtype == torch.float32 else 2e-12,
+            atol=5e-6 if dtype == torch.float32 else 2e-13,
+        )
+
+        update = condition_correlated_gaussian_qr_torch(
+            torch.zeros(2, dtype=dtype),
+            torch.eye(2, dtype=dtype),
+            torch.zeros(2, dtype=dtype),
+            covariance,
+            torch.zeros(2, 2, dtype=dtype),
+            torch.zeros(2, 2, dtype=dtype),
+        )
+        torch.testing.assert_close(
+            update.conditional_observation_covariance, covariance
+        )
+        assert not bool(update.conditional_loading_diagnostics.was_loaded)
 
 
 @pytest.mark.parametrize("n,m", [(1, 1), (2, 4), (4, 5)])
@@ -161,6 +456,7 @@ def test_compiled_conditioners_snapshot_coefficients_against_caller_mutation():
     dense = CompiledDenseGainConditionerTorch.compile(root, Ht, Rt, Ct)
     qr_before = qr.condition(mt, yt).mean.clone()
     dense_before = dense.condition(mt, yt).mean.clone()
+    root.add_(100.0)
     Ht.add_(100.0)
     Rt.add_(100.0)
     Ct.add_(100.0)
@@ -168,11 +464,12 @@ def test_compiled_conditioners_snapshot_coefficients_against_caller_mutation():
     torch.testing.assert_close(dense.condition(mt, yt).mean, dense_before)
 
 
-def test_dense_gain_keeps_positive_covariance_under_float32_cancellation():
+@pytest.mark.parametrize("noise_scale", [1e-12, 1e-9])
+def test_dense_gain_joseph_covariance_matches_qr_below_float32_epsilon(noise_scale):
     dtype = torch.float32
     P = torch.eye(2, dtype=dtype)
     H = torch.eye(2, dtype=dtype)
-    R = torch.eye(2, dtype=dtype) * 1e-9
+    R = torch.eye(2, dtype=dtype) * noise_scale
     C = torch.zeros(2, 2, dtype=dtype)
     root = precision_root_from_covariance_torch(P, jitter=0.0)
     dense = CompiledDenseGainConditionerTorch.compile(
@@ -185,8 +482,8 @@ def test_dense_gain_keeps_positive_covariance_under_float32_cancellation():
     torch.testing.assert_close(
         dense.posterior_covariance,
         qr.posterior_covariance,
-        rtol=2e-6,
-        atol=torch.finfo(dtype).eps,
+        rtol=5e-4,
+        atol=noise_scale * 5e-5,
     )
 
 

--- a/prototypes/mu_cosine/test_joint_square_root_conditioner_torch.py
+++ b/prototypes/mu_cosine/test_joint_square_root_conditioner_torch.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Correctness tests for the batched CPU/CUDA Householder-QR backend."""
 
+import math
+
 import numpy as np
 import pytest
 
@@ -69,7 +71,7 @@ def test_noise_whitener_correlation_and_covariance_are_equivalent(dtype, rtol, a
         rtol=rtol,
         atol=atol,
     )
-    precision_root = from_correlation.materialize_precision_root()
+    precision_root = from_correlation.materialize_row_root()
     identity = torch.eye(3, dtype=dtype)
     torch.testing.assert_close(
         precision_root.mT @ precision_root @ from_correlation.covariance,
@@ -107,7 +109,7 @@ def test_noise_whitener_nearly_singular_psd_loading_is_scale_relative(dtype):
         rtol=0.08,
         atol=8 * torch.finfo(dtype).eps,
     )
-    root = whitener.materialize_precision_root()
+    root = whitener.materialize_row_root()
     identity = torch.eye(2, dtype=dtype).expand(3, 2, 2)
     torch.testing.assert_close(
         root.transpose(-2, -1) @ root @ whitener.covariance,
@@ -202,7 +204,7 @@ def test_noise_whitener_never_calls_explicit_inverse(monkeypatch):
     whitener = prepare_noise_whitener_torch(covariance)
     whitener.apply_vectors(torch.tensor([0.3, -0.4], dtype=torch.float64))
     whitener.apply_columns(torch.eye(2, dtype=torch.float64))
-    whitener.materialize_precision_root()
+    whitener.materialize_row_root()
 
 
 @pytest.mark.parametrize("device", [
@@ -277,6 +279,41 @@ def test_information_qr_rank_check_is_scale_homogeneous(dtype, scales):
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_information_qr_rank_boundary_preserves_frobenius_sensitivity(dtype):
+    n, m = 128, 32
+    eps = torch.finfo(dtype).eps
+    expected_frobenius_scale = math.sqrt(m * n)
+    boundary = eps * (n + m) * expected_frobenius_scale
+    measurement = torch.ones(m, n, dtype=dtype)
+
+    with pytest.raises(torch.linalg.LinAlgError, match="rank deficient"):
+        compile_information_update_torch(
+            torch.eye(n, dtype=dtype) * (0.5 * boundary), measurement
+        )
+
+    accepted = compile_information_update_torch(
+        torch.eye(n, dtype=dtype) * (2.0 * boundary), measurement
+    )
+    assert torch.isfinite(accepted.precision_root).all()
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_information_qr_rank_scale_does_not_overflow_near_dtype_max(dtype):
+    n = 16
+    scale = torch.finfo(dtype).max / 2.0
+    compiled = compile_information_update_torch(
+        torch.eye(n, dtype=dtype) * scale,
+        torch.zeros(0, n, dtype=dtype),
+    )
+    torch.testing.assert_close(
+        compiled.precision_root / scale,
+        torch.eye(n, dtype=dtype),
+        rtol=20 * torch.finfo(dtype).eps,
+        atol=20 * torch.finfo(dtype).eps,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_information_qr_rejects_subnormal_scale_with_rescale_message(dtype):
     scale = torch.finfo(dtype).tiny / 2.0
     with pytest.raises(torch.linalg.LinAlgError, match="subnormal; rescale"):
@@ -335,6 +372,54 @@ def test_default_covariance_roots_and_conditioner_are_scale_relative(dtype, scal
             update.conditional_observation_covariance, covariance
         )
         assert not bool(update.conditional_loading_diagnostics.was_loaded)
+
+
+def test_float32_large_n_negative_tolerance_fits_loading_budget():
+    n = 128
+    dtype = torch.float32
+    maximum_loading = 1e-3
+    eps = torch.finfo(dtype).eps
+    relative_floor = max(math.sqrt(eps), 8.0 * n * eps)
+    expected_negative_tolerance = min(
+        64.0 * n * eps,
+        0.5 * (maximum_loading - relative_floor),
+    )
+    covariance = torch.eye(n, dtype=dtype)
+    covariance[-1, -1] = -0.9 * expected_negative_tolerance
+
+    whitener = prepare_noise_whitener_torch(
+        covariance, maximum_relative_loading=maximum_loading
+    )
+    assert whitener.diagnostics.negative_eigenvalue_tolerance == pytest.approx(
+        expected_negative_tolerance
+    )
+    assert float(whitener.diagnostics.relative_diagonal_loading) < maximum_loading
+
+    too_negative = covariance.clone()
+    too_negative[-1, -1] = -1.1 * expected_negative_tolerance
+    with pytest.raises(ValueError, match="genuinely indefinite"):
+        prepare_noise_whitener_torch(
+            too_negative, maximum_relative_loading=maximum_loading
+        )
+
+
+def test_zero_covariance_full_scale_repair_requires_explicit_budget():
+    whitener = prepare_noise_whitener_torch(
+        torch.zeros(2, 2, dtype=torch.float64),
+        relative_eigenvalue_floor=0.0,
+        absolute_eigenvalue_floor=1e-4,
+        maximum_relative_loading=1.0,
+    )
+    torch.testing.assert_close(
+        whitener.covariance, torch.eye(2, dtype=torch.float64) * 1e-4
+    )
+    assert float(whitener.diagnostics.relative_diagonal_loading) == pytest.approx(1.0)
+
+
+def test_information_state_update_noise_block_rejects_wrong_whitener_type():
+    state = SquareRootInformationStateTorch(torch.eye(2), torch.zeros(2))
+    with pytest.raises(TypeError, match="NoiseWhitenerTorch"):
+        state.update_noise_block(torch.eye(2), torch.zeros(2), object())
 
 
 @pytest.mark.parametrize("n,m", [(1, 1), (2, 4), (4, 5)])


### PR DESCRIPTION
## Summary

- add a batched CPU/CUDA noise whitener that accepts covariance or correlation plus marginal standard deviations
- convert measurement correlation to an implicit precision row root with Cholesky triangular solves; no explicit inverse is formed
- expose correlated measurement blocks through `SquareRootInformationStateTorch.update_noise_block()`
- support stacked and streamed Householder-QR information updates over explicit `n`, `m_block`, `T`, and `B` axes
- add scale-relative covariance loading with observable diagnostics and hard rejection of materially indefinite models
- use a Joseph-form dense posterior covariance and an independent direct least-squares/QR benchmark reference
- document the correlation-to-precision-root algebra, conditional-`Rc` block-independence requirement, and semantic/graph covariance follow-up

## Why

For `Rc = L L.T`, apply the measurement precision row root implicitly:

```
A = solve(L, J)
b = solve(L, r)
```

The posterior precision is a sum,

```
U_post.T U_post = U.T U + J.T Rc^-1 J,
```

so the correct operation is QR triangularization of `stack([U, A])`. Multiplying a Cholesky factor of `Rc^-1` by the previous state root is generally dimensionally and statistically wrong: the factors live in different spaces, and Bayesian assimilation adds information rather than multiplying precisions.

This is the classical square-root-information vertical-stack pattern described by [Tracy (2022)](https://arxiv.org/abs/2208.06452) and the [CERFACS SRIF presentation](https://cerfacs.fr/wp-content/uploads/2017/05/Alina_presentation_kf.pdf). The nonzero-cross-covariance Schur reduction in this PR is documented separately.

## Review follow-up

This revision addresses the Perplexity council review:

- removes the duplicate pre-array scale reduction/device synchronization
- restores conservative Frobenius-scale rank sensitivity without a unit clamp, while comparing normalized quantities so the threshold cannot overflow near the dtype maximum
- adds `n=128,m=32` rank-boundary tests plus global-scale, near-maximum, and subnormal-scale regressions
- replaces the float64 normal-equations “gold” solve with direct stacked `torch.linalg.lstsq`; a separate reduced QR supplies the positive-diagonal reference root
- couples the default negative-eigenvalue validity tolerance to the remaining loading budget, while preserving explicit overrides and separate rejection gates
- renames the explicit lower row-root helper to `materialize_row_root()`
- hardens expanded batched triangular solves and documents the hot-path NaN/Inf policy
- adds compute/transfer, CUDA-validation, CPU-memory, single-seed, and hardware-specific caveats to the report
- cites the square-root-information literature in the design document

## Benchmark result — local prototype evidence

The recorded timing tables are local, compute-only measurements on a GTX 1660 SUPER and predate the post-review rank-guard cleanup. Transfers are excluded, and the corrected pre-cast transfer benchmark has not been rerun, so no transfer-inclusive crossover is established.

At `n=128`, `m_block=32`, `T=16`, and shared-design `B=4096`, stacked QR measured **3.939 ms CUDA versus 10.392 ms CPU**. It did not cross over at `B=128`, and distinct-design batched QR was slower on this local GPU. This is not a general `B=4096` recommendation.

In one seeded synthetic stress instance with target prior/within-block covariance condition number `1e6`, the historical run showed a float32 dense Cholesky failure in one scale regime and `1.50e-4` solution error in another, while QR remained near `1e-6`. Those CUDA error rows predate the current independent float64 stacked least-squares/QR reference and were not rerun. Old and new float64 references agree to `2.51e-13` or better on the tested solutions, so the historical magnitudes remain representative, but they show one concrete failure mode—not its frequency.

## API behavior worth noting

- The Torch square-root and conditional-conditioning helpers now default `jitter` to `0.0` instead of the historical absolute `1e-9` floor. Scale-relative loading remains active and observable; a near-singular covariance previously rescued by absolute jitter can now be rejected by the validity or loading-budget gate.
- Preparation validates covariance/design finiteness. Repeated compiled RHS paths avoid device-synchronizing finiteness checks, so NaN/Inf observations propagate unless callers gate them at batch ingress.

## Validation

- `70 passed, 9 skipped` across Product-Kalman and NumPy/Torch square-root suites
- all 9 skips are CUDA-only correctness cases and are not currently verified by CI
- CPU shared/distinct benchmark smoke runs pass against the direct least-squares/QR reference
- Python compilation and `git diff --check` pass
- final independent audit found no remaining actionable correctness issue

## Follow-up

- rerun the corrected transfer benchmark on CUDA before making an end-to-end crossover claim
- add CUDA CI or cross-device correctness coverage and a multi-seed conditioning sweep
- fit PSD semantic/graph residual kernels on held-out node-disjoint calibration data, then compare full-`Rc`, structured, and block-diagonal approximations
- separately test the graph judge as dataset-adaptation supervision—helping the model learn a dataset's entities and topology—not only as an input to the final judgment
