### PR TITLE
WAM/LLVM plawk: record binds in blocks + assoc for-in filter (stack recovery, lands #3658–#3664 + stage 1b on the base)

### DIFF
--- a/docs/design/PLAWK_ASSOC_FORIN.md
+++ b/docs/design/PLAWK_ASSOC_FORIN.md
@@ -98,13 +98,24 @@ Each stage is a shippable PR with tests.
   and an `if` wrapper around the existing per-key print. No scalar
   accumulation, so no head-phi threading yet — the guard just gates the
   print inside the current bespoke loop. Smallest useful slice: "print
-  the histogram entries above a threshold."
+  the histogram entries above a threshold." **LANDED** (rule-body and END
+  forms; `tests/test_plawk_forin_filter.pl`).
 
 - **Stage 2 — scalar accumulation.** `for (k in arr) total += arr[k]`.
-  Gives the assoc driver a scalar `Slots` plan and threads it through the
-  record loop and the for-in loop (head phis), so a scalar mutated per
-  entry survives to END. This is the canonical "sum/aggregate the hash"
-  idiom and the largest driver piece.
+  The canonical "sum/aggregate the hash" idiom and the largest driver
+  piece. Two concrete blockers scoped it out of the filter PR (both
+  confirmed empirically):
+  1. **The END for-in is a whole-END construct.** The driver matches
+     exactly `[end([for_in(...)])]`; `END { for (k in c) ... ; print sum }`
+     (a for-in *plus* a later action to read the accumulator) is a parse
+     error today. Reading an accumulator therefore needs the END grammar
+     + driver to allow a for-in among multiple END actions.
+  2. **Loop-carried scalar threading.** The assoc driver *does* carry
+     scalar slots (a record-loop `s += 1` alongside `c[$1]++` works and
+     survives to END), but the for-in loop does not thread a slot as a
+     head phi, so a scalar mutated per entry is not carried out. Stage 2
+     brings `foreach`'s head-phi threading to the for-in loop and lets the
+     mutated slot flow to the following END action.
 
 - **Stage 3 — decode a value into a struct.** `for (k in arr) {
   (n, m) = dyncall@decode(arr[k]) as (i64 i64) ; ... }`. Once the body is

--- a/docs/design/PLAWK_ASSOC_FORIN.md
+++ b/docs/design/PLAWK_ASSOC_FORIN.md
@@ -1,0 +1,135 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2026 John William Creighton (@s243a)
+-->
+
+# plawk assoc for-in with per-entry logic
+
+Design for iterating an associative array (a hash table built with
+`arr[key] = ...` / `arr[key]++`) and doing **real work per entry** —
+not only the print-shaped body that ships today.
+
+## What works today
+
+`for (k in arr)` iterates the table's keys. The body is restricted to a
+single `print` whose fields are drawn from a fixed plan:
+
+- `k` — the loop key (resolved to text, or numeric for a positional array);
+- `arr[k]` — the iterated table's value at the current key (`value_self`);
+- `other[k]` — another table's value at the current key (`value_lookup`);
+- a string literal.
+
+```awk
+{ arr[$1]++ }
+END { for (k in arr) print k, arr[k] }          # key + value, per entry
+```
+
+That covers "dump the histogram." It does **not** cover filtering,
+aggregating, or decoding a value into a structured record — the loop body
+is a print *plan*, not a general action sequence, and `k` / `arr[k]` exist
+only as print-field plan atoms, not as readable expression operands.
+
+## The gap, precisely
+
+Three independent things are missing; each stage below closes one.
+
+1. **`k` and `arr[k]` are not expression/pattern operands.** The pattern
+   grammar has no production for a bare loop variable or an `arr[k]`
+   read, so `if (arr[k] > 100)` and `total += arr[k]` do not parse. They
+   are meaningful *only inside* the lexical scope of a `for (k in arr)`
+   body, so the natural home is a for-in-scoped operand set, not the
+   global pattern/expression grammar (where `k` has no binding).
+
+2. **The for-in body is not an action sequence.** It is planned as
+   `[print(Fields)]` and emitted by a bespoke per-key print loop
+   (`assoc_forin_action`), separate from the scalar action-sequence
+   walker (`plawk_scalar_action_sequence_pairs`) that lowers `if`,
+   updates, and record binds/views everywhere else.
+
+3. **The assoc driver has no scalar-slot state.** Assoc programs
+   accumulate in *tables*, not scalar variables, so there is no
+   loop-carried scalar threading of the kind `foreach` uses (head phis
+   per slot). `total += arr[k]` needs a scalar `total` that persists
+   across the record loop *and* mutates inside the per-record for-in
+   loop.
+
+## Architecture — reuse the `foreach` harness
+
+`foreach` already solved the hard part: a **runtime loop with a scalar
+action-sequence body and loop-carried accumulator state**. It threads one
+head phi per scalar slot (`plawk_foreach_head_phi_lines`), runs the body
+through `plawk_scalar_action_sequence_pairs` with those phis as the
+incoming slot values, and exposes the current element's fields as `$k`
+reads resolved to a fixed **staging area** in the record buffer.
+
+The plan is to make `for (k in arr) { BODY }` a sibling of `foreach`:
+
+- **Iteration source:** the assoc table's occupied slots
+  (`wam_assoc_i64_iter_next` / `_key_at` / `_value_at`) instead of a
+  repetition field's elements.
+- **Per-iteration staging:** write the current `(key, value)` into a
+  two-field staging area at loop-body entry — exactly as `foreach`
+  memcpy's the current element into staging. Then rewrite the body's
+  `k` → staging field 1 and `arr[k]` → staging field 2 (a resolve pass,
+  mirroring `foreach`'s field-shift). The body becomes an ordinary scalar
+  action sequence reading two staging fields; **all** existing emitters
+  (updates, `if`, record binds/views) apply unchanged.
+- **Loop-carried state:** reuse `plawk_foreach_head_phi_lines` for the
+  accumulator slots.
+
+Reusing the staging trick means `k`/`arr[k]` never need to become global
+expression operands — they are for-in-local staging fields, resolved once
+at desugar time, and the scalar machinery does the rest. This is the same
+move that let record views nest in `foreach` bodies (they rode the
+element staging).
+
+The one genuinely new driver concern is #3 (scalar-slot state in the
+assoc driver): the assoc rule chain must carry a scalar `Slots` plan and
+thread the final slot values into END, so a `total` mutated inside a
+for-in survives to the END print.
+
+## Staged plan
+
+Each stage is a shippable PR with tests.
+
+- **Stage 1 — filter + print (per-iteration output, no loop-carried
+  state).** `for (k in arr) { if (arr[k] CMP int) print k, arr[k] }`.
+  Adds a for-in-scoped condition (`k`/`arr[k]` compared to an integer)
+  and an `if` wrapper around the existing per-key print. No scalar
+  accumulation, so no head-phi threading yet — the guard just gates the
+  print inside the current bespoke loop. Smallest useful slice: "print
+  the histogram entries above a threshold."
+
+- **Stage 2 — scalar accumulation.** `for (k in arr) total += arr[k]`.
+  Gives the assoc driver a scalar `Slots` plan and threads it through the
+  record loop and the for-in loop (head phis), so a scalar mutated per
+  entry survives to END. This is the canonical "sum/aggregate the hash"
+  idiom and the largest driver piece.
+
+- **Stage 3 — decode a value into a struct.** `for (k in arr) {
+  (n, m) = dyncall@decode(arr[k]) as (i64 i64) ; ... }`. Once the body is
+  a real scalar sequence (Stage 2), record binds/views already lower
+  inside it (as they do in `foreach` bodies today); the remaining piece
+  is a surface for passing `arr[k]` — the current value — as a grammar
+  argument (the staging field 2 read, marshalled like any i64 arg).
+
+## Parser notes
+
+The for-in body already parses through `action_block`, so `if` / updates
+/ record binds parse structurally. What does not parse is the **operands**
+`k` and `arr[k]` in expression/pattern position. Rather than widen the
+global grammar (where a bare `k` is ambiguous), the operands are accepted
+in a for-in-body context and validated against the loop's key variable and
+the tables in scope; the desugar-to-staging pass then rewrites them before
+the generic emitters run, so no emitter needs a special "for-in operand"
+case.
+
+## Relationship to `foreach`
+
+`foreach` covers the **list-shaped** collection (a repetition field whose
+elements are tuples), and already supports the full action body including
+record binds/views (see `tests/test_plawk_foreach_tuples.pl`). This design
+brings the same expressive body to the **hash-shaped** collection
+(`for (k in arr)`), reusing `foreach`'s loop harness. When both land, the
+two collection shapes have parity: iterate, read the item (tuple fields /
+key+value), and decode each into a struct.

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -274,10 +274,24 @@ different plawk containers — this is the through-line for the rest of item 4:
   become the view's hidden temps while the view's Call args (e.g. `$1`
   passing the current element) ride the later foreach-element rebind. Test:
   `tests/test_plawk_dyncall_rec_loop.pl` (destructure, view, and
-  view-in-if-in-foreach). The `for (k in arr)` assoc for-in stays
-  print-only by construction (its body is a per-key print plan, not a
-  scalar action sequence), so record binds there remain a separate driver
-  concern.
+  view-in-if-in-foreach).
+  **Recommended "iterate a collection, object per item" pattern:** a
+  `foreach` over a repetition field whose elements have MORE THAN ONE
+  field iterates TUPLES — element `$1, $2, …` are the tuple's fields (a
+  (key, value) pair for `rep(i64 i64)`) — and the body can decode any
+  field into a structured record via a grammar. So "loop and process each
+  item as an object" is served today for list-shaped (repeating-field)
+  data. Test: `tests/test_plawk_foreach_tuples.pl` (tuple fields;
+  tuple→struct destructure; tuple→struct view).
+  **The `for (k in arr)` assoc for-in stays print-only** by construction
+  (its body is a per-key print plan, not a scalar action sequence), so
+  record binds there remain a separate, larger surface. Iterating a HASH
+  table with real per-entry work needs two read forms plumbed through the
+  expression model — the loop key `k` as a readable value and the `arr[k]`
+  value-lookup — plus loop-carried state for accumulation, and a surface
+  answer for referencing the current value as a grammar argument. Deferred
+  as a distinct feature; `foreach`-over-tuples covers the list-shaped case
+  without it.
 - **Associative array** (`arr = dyncall@name(...) as assoc`) — *mechanism +
   surface LANDED (named entry, integer keys).* A grammar returning a list of
   pairs (`[K1-V1, K2-V2, ...]`) materializes into an i64 assoc table via

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -257,9 +257,16 @@ different plawk containers — this is the through-line for the rest of item 4:
   every `$k` (1≤k≤nfields) rewritten to the k-th temporary — so it rides the
   destructure machinery with no field-pointer repoint. A body field outside
   1..nfields (including `$0`) leaves the view uncompilable (the record has no
-  such field). Recurses into if-branches; a view nested in a for-in body is a
-  follow-on. Verified: `dyncall@rec($1) as (i64 f64) { total += $1 }` sums
+  such field). Verified: `dyncall@rec($1) as (i64 f64) { total += $1 }` sums
   the i64 field to 30; `{ sum += $2 }` sums the f64 field to 31.
+  **Binds/views inside if-branches LANDED:** a record destructure or view
+  can sit inside `if { ... } else { ... }`. The sequence walker already
+  lowered `dynrec_bind` in any position; the gap was branch-body
+  VALIDATION (`plawk_scalar_rule_body_plain_action` did not list the bind
+  among a branch's allowed actions), now closed. Test:
+  `tests/test_plawk_dyncall_rec_if.pl`. A view nested in a for-in / foreach
+  loop body is the next step (the loop-body drivers, unlike the scalar-if
+  path, do not yet route through the record-bind emitter).
 - **Associative array** (`arr = dyncall@name(...) as assoc`) — *mechanism +
   surface LANDED (named entry, integer keys).* A grammar returning a list of
   pairs (`[K1-V1, K2-V2, ...]`) materializes into an i64 assoc table via

--- a/docs/design/PLAWK_JIT_ROADMAP.md
+++ b/docs/design/PLAWK_JIT_ROADMAP.md
@@ -264,9 +264,20 @@ different plawk containers — this is the through-line for the rest of item 4:
   lowered `dynrec_bind` in any position; the gap was branch-body
   VALIDATION (`plawk_scalar_rule_body_plain_action` did not list the bind
   among a branch's allowed actions), now closed. Test:
-  `tests/test_plawk_dyncall_rec_if.pl`. A view nested in a for-in / foreach
-  loop body is the next step (the loop-body drivers, unlike the scalar-if
-  path, do not yet route through the record-bind emitter).
+  `tests/test_plawk_dyncall_rec_if.pl`.
+  **Binds/views inside a `foreach` loop body LANDED:** a `foreach { ... }`
+  over a record's repetition elements can call a grammar per element and
+  destructure or view the returned record. The foreach body already lowers
+  through the scalar action-sequence walker, so the branch-body validation
+  fix carried it, and the record-view desugar now recurses into `foreach`
+  (and `for_in`) bodies so a view there desugars in place — its block `$k`
+  become the view's hidden temps while the view's Call args (e.g. `$1`
+  passing the current element) ride the later foreach-element rebind. Test:
+  `tests/test_plawk_dyncall_rec_loop.pl` (destructure, view, and
+  view-in-if-in-foreach). The `for (k in arr)` assoc for-in stays
+  print-only by construction (its body is a per-key print plan, not a
+  scalar action sequence), so record binds there remain a separate driver
+  concern.
 - **Associative array** (`arr = dyncall@name(...) as assoc`) — *mechanism +
   surface LANDED (named entry, integer keys).* A grammar returning a list of
   pairs (`[K1-V1, K2-V2, ...]`) materializes into an i64 assoc table via

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3587,6 +3587,11 @@ plawk_assoc_spec_forin_array(ActionSpecs, ArrayName) :-
     ( ArrayName = FA
     ; member(assoc(var(ArrayName), var(_)), FFields)
     ).
+plawk_assoc_spec_forin_array(ActionSpecs, ArrayName) :-
+    member(forin_guarded(_LoopVar, FA, _Guard, FFields), ActionSpecs),
+    ( ArrayName = FA
+    ; member(assoc(var(ArrayName), var(_)), FFields)
+    ).
 
 %% plawk_assoc_specs_str_arrays(+RuleSpecs, -StrArrays)
 %  Names of tables populated through `as assoc(str)` binds -- their
@@ -4557,6 +4562,20 @@ plawk_assoc_body_action_spec(for_in(var(LoopVar), var(ArrayName), Body),
     Body = [print(Fields)],
     Fields = [_ | _],
     maplist(plawk_forin_print_field(LoopVar), Fields).
+% for-in FILTER (assoc for-in stage 1): a per-key print gated by a guard
+% on the loop key or the iterated value. `k` / `arr[k]` are for-in-scoped
+% operands (see PLAWK_ASSOC_FORIN.md).
+plawk_assoc_body_action_spec(
+        for_in(var(LoopVar), var(ArrayName), [if(Guard, [print(Fields)], [])]),
+        forin_guarded(LoopVar, ArrayName, Guard, Fields)) :-
+    plawk_forin_guard_ok(Guard, LoopVar, ArrayName),
+    Fields = [_ | _],
+    maplist(plawk_forin_print_field(LoopVar), Fields).
+
+% Stage 1 guards: `arr[k] CMP int` where arr is the iterated table
+% (value_self), or `k CMP int` (the raw loop key).
+plawk_forin_guard_ok(forin_val_cmp(Array, LoopVar, _Op, _V), LoopVar, Array).
+plawk_forin_guard_ok(forin_key_cmp(LoopVar, _Op, _V), LoopVar, _Array).
 
 plawk_assoc_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), ArrayName-KeyIndex) :-
     KeyIndex > 0.
@@ -4614,6 +4633,22 @@ plawk_assoc_planned_actions([forin(LoopVar, ArrayName, Fields) | Rest],
     },
     [assoc_forin_action(Index, TableIndex, FieldPlans)],
     plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
+plawk_assoc_planned_actions(
+        [forin_guarded(LoopVar, ArrayName, Guard, Fields) | Rest],
+        Tables, StrArrays, PosArrays, Index) -->
+    { nth0(TableIndex, Tables, ArrayName),
+      plawk_forin_guard_plan(Guard, GuardPlan),
+      maplist(plawk_forin_rule_field_plan(LoopVar, ArrayName, TableIndex,
+          Tables, StrArrays, PosArrays), Fields, FieldPlans),
+      NextIndex is Index + 1
+    },
+    [assoc_forin_guarded_action(Index, TableIndex, GuardPlan, FieldPlans)],
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
+
+% guard operand: the iterated table's value at the current slot, or the
+% raw loop key; both compared to an integer literal.
+plawk_forin_guard_plan(forin_val_cmp(_A, _K, Op, V), guard_value(Op, V)).
+plawk_forin_guard_plan(forin_key_cmp(_K, Op, V), guard_key(Op, V)).
 
 plawk_forin_rule_field_plan(LoopVar, ArrayName, _TableIndex, _Tables,
         _StrArrays, PosArrays, var(LoopVar), KeyPlan) :- !,
@@ -4821,6 +4856,87 @@ plawk_assoc_rule_action_blocks(RuleIndex,
     },
     plawk_emit_lines(Lines),
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+% Guarded for-in (stage 1 filter): same slot-iteration loop, but a guard
+% on the key or the iterated value gates the per-key print. Passing
+% entries print; the rest fall straight through to the loop-continue.
+plawk_assoc_rule_action_blocks(RuleIndex,
+        [assoc_forin_guarded_action(Index, TableIndex, GuardPlan, FieldPlans)
+         | Rest],
+        NextLabel, FieldSeparator) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(B), 'arfg_~w_~w', [RuleIndex, Index]),
+      format(atom(HeadBr), '  br label %~w_head', [B]),
+      format(atom(HeadLbl), '~w_head:', [B]),
+      format(atom(Phi),
+          '  %~w_idx = phi i64 [0, %assoc_rule_~w_action_~w], [%~w_next, %~w_done]',
+          [B, RuleIndex, Index, B, B]),
+      format(atom(Slot),
+          '  %~w_slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_idx)',
+          [B, TableIndex, B]),
+      format(atom(DoneC), '  %~w_done_c = icmp slt i64 %~w_slot, 0', [B, B]),
+      format(atom(BrBody),
+          '  br i1 %~w_done_c, label %~w_after, label %~w_body', [B, B, B]),
+      format(atom(BodyLbl), '~w_body:', [B]),
+      format(atom(Key),
+          '  %~w_key = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_slot)',
+          [B, TableIndex, B]),
+      plawk_forin_guard_lines(GuardPlan, B, TableIndex, GuardLines, CondVar),
+      format(atom(BrGuard),
+          '  br i1 ~w, label %~w_print, label %~w_skip', [CondVar, B, B]),
+      format(atom(PrintLbl), '~w_print:', [B]),
+      phrase(plawk_forin_rule_field_lines(FieldPlans, B, 0), FieldLines),
+      format(atom(NL), '  %~w_nl = call i32 @putchar(i32 10)', [B]),
+      format(atom(BrDoneP), '  br label %~w_done', [B]),
+      format(atom(SkipLbl), '~w_skip:', [B]),
+      format(atom(BrDoneS), '  br label %~w_done', [B]),
+      format(atom(DoneLbl), '~w_done:', [B]),
+      format(atom(Next), '  %~w_next = add i64 %~w_slot, 1', [B, B]),
+      format(atom(BrHead), '  br label %~w_head', [B]),
+      format(atom(AfterLbl), '~w_after:', [B]),
+      format(atom(BrNext), '  br label %~w', [ActionNextLabel]),
+      append([[Label, HeadBr, '', HeadLbl, Phi, Slot, DoneC, BrBody, '',
+               BodyLbl, Key],
+              GuardLines,
+              [BrGuard, '', PrintLbl],
+              FieldLines,
+              [NL, BrDoneP, '', SkipLbl, BrDoneS, '', DoneLbl, Next, BrHead,
+               '', AfterLbl, BrNext, '']],
+          Lines)
+    },
+    plawk_emit_lines(Lines),
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+
+% Guard operand load + comparison. guard_value reads the iterated table's
+% value at the current slot; guard_key uses the raw key. Both icmp against
+% the integer literal.
+plawk_forin_guard_lines(guard_value(Op, V), B, TableIndex, Lines, CondVar) :-
+    plawk_forin_cmp_pred(Op, Pred),
+    format(atom(ValLine),
+        '  %~w_gval = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_slot)',
+        [B, TableIndex, B]),
+    format(atom(CmpLine),
+        '  %~w_gcmp = icmp ~w i64 %~w_gval, ~w', [B, Pred, B, V]),
+    format(atom(CondVar), '%~w_gcmp', [B]),
+    Lines = [ValLine, CmpLine].
+plawk_forin_guard_lines(guard_key(Op, V), B, _TableIndex, Lines, CondVar) :-
+    plawk_forin_cmp_pred(Op, Pred),
+    format(atom(CmpLine),
+        '  %~w_gcmp = icmp ~w i64 %~w_key, ~w', [B, Pred, B, V]),
+    format(atom(CondVar), '%~w_gcmp', [B]),
+    Lines = [CmpLine].
+
+plawk_forin_cmp_pred(eq, eq).
+plawk_forin_cmp_pred(ne, ne).
+plawk_forin_cmp_pred(lt, slt).
+plawk_forin_cmp_pred(le, sle).
+plawk_forin_cmp_pred(gt, sgt).
+plawk_forin_cmp_pred(ge, sge).
 
 plawk_forin_rule_field_lines([], _B, _N) -->
     [].

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -598,6 +598,43 @@ plawk_program_native_driver_ir(
             AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% guarded END for-in (stage 1b): iterate the FINAL hash and filter --
+% `END { for (k in arr) { if (GUARD) print ... } }`. Matched before the
+% generic END for-in clause so the guarded body routes to the guarded
+% emitter; otherwise identical driver wiring.
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules,
+        [end([for_in(var(LoopVar), var(ArrayName),
+            [if(Guard, [print(PrintFields)], [])])])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_forin_end_plan(Rules, LoopVar, ArrayName,
+        [if(Guard, [print(PrintFields)], [])], AssocPlan, PrintFields),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_assoc_record_program_ok(FieldSeparator, Rules, PrintFields),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_forin_end_guarded_print_ir(LoopVar, ArrayName, Guard, PrintFields,
+        AssocPlan, FieldSeparator, OutputSeparator, EndPrintIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, AssocRuleGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w',
+        [EndPrintIR]),
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
+            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
 plawk_program_native_driver_ir(
     program(BeginClauses, Rules, [end([for_in(var(LoopVar), var(ArrayName), BodyActions)])]),
     InputPath,
@@ -3559,6 +3596,17 @@ plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions,
         member(assoc(var(LookupArrayName), var(LoopVar)), PrintFields),
         LookupArrays),
     plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays, AssocPlan).
+% guarded END for-in (assoc for-in stage 1b): the body is a guarded
+% print, so the plan is the same table set but the guard gates output.
+plawk_forin_end_plan(Rules, LoopVar, ArrayName,
+        [if(Guard, [print(PrintFields)], [])], AssocPlan, PrintFields) :-
+    plawk_forin_guard_ok(Guard, LoopVar, ArrayName),
+    PrintFields = [_ | _],
+    maplist(plawk_forin_print_field(LoopVar), PrintFields),
+    findall(LookupArrayName,
+        member(assoc(var(LookupArrayName), var(LoopVar)), PrintFields),
+        LookupArrays),
+    plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays, AssocPlan).
 
 plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays,
         assoc_plan(Tables, PlannedRules)) :-
@@ -3763,6 +3811,70 @@ forin_after:
 ~w
   ret i32 0',
         [TableIndex, TableIndex, BodyIR, FreeIR]).
+
+%% plawk_forin_end_guarded_print_ir(+LoopVar, +ArrayName, +Guard,
+%%     +PrintFields, +AssocPlan, +Descriptor, +OutputSeparator, -IR)
+%  Guarded END for-in (stage 1b filter): same slot-walk, but a guard on
+%  the key or the iterated value gates the per-key print. Passing entries
+%  print; the rest branch straight to the loop-continue.
+plawk_forin_end_guarded_print_ir(LoopVar, ArrayName, Guard, PrintFields,
+        AssocPlan, Descriptor, OutputSeparator, IR) :-
+    plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
+    phrase(plawk_forin_body_print_lines(PrintFields, LoopVar, ArrayName,
+        TableIndex, AssocPlan, Descriptor, OutputSeparator, 0), BodyLines),
+    atomic_list_concat(BodyLines, '\n', BodyIR),
+    phrase(plawk_assoc_free_lines(AssocPlan), FreeLines),
+    atomic_list_concat(FreeLines, '\n', FreeIR),
+    plawk_forin_guard_plan(Guard, GuardPlan),
+    plawk_forin_end_guard_lines(GuardPlan, TableIndex, GuardLines, CondVar),
+    atomic_list_concat(GuardLines, '\n', GuardIR),
+    format(atom(IR),
+'  br label %forin_head
+
+forin_head:
+  %forin_idx = phi i64 [0, %end_print], [%forin_next_idx, %forin_body_done]
+  %forin_slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_idx)
+  %forin_done = icmp slt i64 %forin_slot, 0
+  br i1 %forin_done, label %forin_after, label %forin_body
+
+forin_body:
+  %forin_key_id = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)
+~w
+  br i1 ~w, label %forin_print, label %forin_skip
+
+forin_print:
+~w
+  %forin_printed_newline = call i32 @putchar(i32 10)
+  br label %forin_body_done
+
+forin_skip:
+  br label %forin_body_done
+
+forin_body_done:
+  %forin_next_idx = add i64 %forin_slot, 1
+  br label %forin_head
+
+forin_after:
+~w
+  ret i32 0',
+        [TableIndex, TableIndex, GuardIR, CondVar, BodyIR, FreeIR]).
+
+% END-loop guard operand load + comparison (fixed `forin` prefix).
+plawk_forin_end_guard_lines(guard_value(Op, V), TableIndex, Lines, CondVar) :-
+    plawk_forin_cmp_pred(Op, Pred),
+    format(atom(ValLine),
+        '  %forin_gval = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)',
+        [TableIndex]),
+    format(atom(CmpLine),
+        '  %forin_gcmp = icmp ~w i64 %forin_gval, ~w', [Pred, V]),
+    CondVar = '%forin_gcmp',
+    Lines = [ValLine, CmpLine].
+plawk_forin_end_guard_lines(guard_key(Op, V), _TableIndex, Lines, CondVar) :-
+    plawk_forin_cmp_pred(Op, Pred),
+    format(atom(CmpLine),
+        '  %forin_gcmp = icmp ~w i64 %forin_key_id, ~w', [Pred, V]),
+    CondVar = '%forin_gcmp',
+    Lines = [CmpLine].
 
 plawk_forin_body_print_lines([], _LoopVar, _ArrayName, _TableIndex, _AssocPlan,
         _Descriptor, _OutputSeparator, _) -->

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -7483,6 +7483,12 @@ plawk_scalar_branch_body_actions(Actions) :-
 
 plawk_scalar_rule_body_plain_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
+% a structured-return destructure inside a branch body: the sequence
+% walker lowers dynrec_bind wherever it appears (its slots/call IR is
+% branch-position-independent), so branch-body validation accepts it
+% exactly as the top-level body does.
+plawk_scalar_rule_body_plain_action(Action) :-
+    plawk_dynrec_bind_ok(Action).
 plawk_scalar_rule_body_plain_action(Action) :-
     plawk_rule_body_print_action(Action).
 plawk_scalar_rule_body_plain_action(writebin_out(Types, Fields)) :-

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -7738,6 +7738,19 @@ plawk_resolve_dynrec_view_action(if(Pattern, Then0, Else0), K0, K,
     !,
     plawk_resolve_dynrec_view_actions(Then0, K0, K1, Then),
     plawk_resolve_dynrec_view_actions(Else0, K1, K, Else).
+% A view nested in a loop body: recurse so its `$k` rewrite happens
+% wherever the view sits. `foreach` runs before its own foreach-resolve
+% pass (which rebinds a naked `$k` to the current element), so a view's
+% block `$k` become the view's hidden temps here and only unrewritten
+% `$k` reach the element rebind -- and the view's Call args (e.g. `$1`
+% passing the current element into the grammar) are left for that pass.
+plawk_resolve_dynrec_view_action(foreach(Body0), K0, K, [foreach(Body)]) :-
+    !,
+    plawk_resolve_dynrec_view_actions(Body0, K0, K, Body).
+plawk_resolve_dynrec_view_action(for_in(V, A, Body0), K0, K,
+        [for_in(V, A, Body)]) :-
+    !,
+    plawk_resolve_dynrec_view_actions(Body0, K0, K, Body).
 plawk_resolve_dynrec_view_action(Action, K, K, [Action]).
 
 %% plawk_dynrec_view_specs(+K, +I, +Types, -Bindings, -FieldTargets)

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -935,11 +935,31 @@ for_in_action(for_in(var(LoopVar), var(ArrayName), Body)) -->
 for_in_body(Actions) -->
     action_block(Actions),
     !.
+% for-in filter (assoc for-in, stage 1): `{ if (GUARD) print ... }` where
+% GUARD compares the loop key `k` or the value `arr[k]` to an integer.
+% A for-in-scoped condition -- k / arr[k] are only meaningful inside the
+% loop, so the operands live here rather than in the global pattern
+% grammar. Gates the per-key print; no cross-iteration state.
+for_in_body([if(Guard, [PrintAction], [])]) -->
+    "{", ws, "if", ws, "(", ws, forin_guard(Guard), ws, ")", ws,
+    print_action(PrintAction), ws, "}",
+    !.
 for_in_body([WritebinAction]) -->
     writebin_action(WritebinAction),
     !.
 for_in_body([PrintAction]) -->
     print_action(PrintAction).
+
+% arr[k] CMP int -- value comparison (tried before the bare-key form,
+% since `arr[` also starts with an identifier).
+forin_guard(forin_val_cmp(Array, LoopVar, Op, Value)) -->
+    identifier(Array), ws, "[", ws, identifier(LoopVar), ws, "]", ws,
+    numeric_cmp_op(Op), ws, signed_integer_value(Value),
+    !.
+% k CMP int -- loop-key comparison.
+forin_guard(forin_key_cmp(LoopVar, Op, Value)) -->
+    identifier(LoopVar), ws, numeric_cmp_op(Op), ws,
+    signed_integer_value(Value).
 
 actions([Action | Actions]) -->
     action(Action),

--- a/tests/test_plawk_dyncall_rec_if.pl
+++ b/tests/test_plawk_dyncall_rec_if.pl
@@ -1,0 +1,139 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Structured-return record binds/views inside an if-branch. The scalar
+% action-sequence walker already lowers `dynrec_bind` wherever it appears
+% (its slot + object-call IR is branch-position-independent); the only
+% gap was branch-body VALIDATION, which did not list dynrec_bind among
+% the actions a branch may hold. With that closed, a destructure or a
+% record view can sit inside `if { ... }` / `else { ... }` -- the first
+% step of routing record binds through every block body (loop bodies
+% are the next).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammar object: rec(X) -> pair(X, X+1)
+recp(X, pair(X, Y)) :- Y is X + 1.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_rec_if).
+
+% A destructure inside an if-branch validates as a scalar rule body.
+test(destructure_in_if_is_compilable_surface) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"l.wamo\" }\n\c
+         { if ($1 > 0) { (n, m) = dyncall@recp($1) as (i64 i64) ; total += n } }\n\c
+         END { print total }\n",
+        program(_, Rules, _)),
+    Rules = [rule(_, [if(_, Then, _)])],
+    assertion(memberchk(dynrec_bind([n, m], _, [i64, i64]), Then)),
+    % the branch-body validator now accepts the bind
+    assertion(forall(member(A, Then),
+        plawk_native_codegen:plawk_scalar_rule_body_plain_action(A))),
+    !.
+
+% Destructure in an if-branch, end to end. Records 3, -1, 5: the guard
+% keeps 3 and 5; recp(X) = pair(X, X+1); total += n(=X) -> 3 + 5 = 8.
+test(destructure_in_if_runs, [condition(clang_available)]) :-
+    ri_dir(Dir),
+    directory_file_path(Dir, 'recp.wamo', Wamo),
+    write_wam_object([user:recp/2], [wamo_entries([recp/2])], Wamo),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { if ($1 > 0) { (n, m) = dyncall@recp($1) as (i64 i64) ; total += n } }\n\c
+         END { print total }\n", [Wamo]),
+    build_run_i64(Dir, 'rif', Src, [3, -1, 5], "8\n"),
+    !.
+
+% Record VIEW inside an if-branch (desugars to a hidden destructure +
+% $k rewrite): total sums $1 (=X) over kept records, s sums $2 (=X+1).
+% 3, -1, 5 -> total = 8, s = 4 + 6 = 10.
+test(view_in_if_runs, [condition(clang_available)]) :-
+    ri_dir(Dir),
+    directory_file_path(Dir, 'recp.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:recp/2], [wamo_entries([recp/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { if ($1 > 0) { dyncall@recp($1) as (i64 i64) { total += $1 ; s += $2 } } }\n\c
+         END { print total, s }\n", [Wamo]),
+    build_run_i64(Dir, 'rifv', Src, [3, -1, 5], "8 10\n"),
+    !.
+
+% The else branch also takes a bind: guard picks the branch, each side
+% binds and accumulates. 3 (>0 -> a), -1 (else -> b): a += 3, b += (-1)+1=0
+% ... use recp so else adds X+1 of the negative. 3 -> a=3; -1 -> b += 0.
+test(bind_in_else_runs, [condition(clang_available)]) :-
+    ri_dir(Dir),
+    directory_file_path(Dir, 'recp.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:recp/2], [wamo_entries([recp/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64\" ; DYNLOAD = \"~w\" }\n\c
+         { if ($1 > 0) { (n, m) = dyncall@recp($1) as (i64 i64) ; a += n } \c
+           else { (p, q) = dyncall@recp($1) as (i64 i64) ; b += q } }\n\c
+         END { print a, b }\n", [Wamo]),
+    % 3 -> a += 3 ; -1 -> q = (-1)+1 = 0, b += 0 ; 5 -> a += 5. a=8, b=0.
+    build_run_i64(Dir, 'rife', Src, [3, -1, 5], "8 0\n"),
+    !.
+
+:- end_tests(plawk_dyncall_rec_if).
+
+% --- helpers ---------------------------------------------------------------
+
+ri_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_rec_if', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Text) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text), close(Out)).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_i64_records(Path, Values) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(V, Values), write_i64_le(Out, V)),
+        close(Out)).
+
+build_run_i64(Dir, Name, Src, Values, Expected) :-
+    write_prog(Dir, Name, Src),
+    directory_file_path(Dir, Name, Prog),
+    atom_concat(Prog, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog, '_in.bin', Input),
+    write_i64_records(Input, Values),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == Expected).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_plawk_dyncall_rec_loop.pl
+++ b/tests/test_plawk_dyncall_rec_loop.pl
@@ -1,0 +1,143 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Structured-return record binds/views inside a LOOP body -- the second
+% step of routing record binds through every block body (if-branches
+% were the first). A `foreach { ... }` over a record's repetition
+% elements can call a grammar per element and destructure or view the
+% returned record: the foreach body already lowers through the scalar
+% action-sequence walker (which handles dynrec_bind), so once branch/loop
+% body VALIDATION accepts the bind and the record-view desugar recurses
+% into the loop body, both surfaces compile.
+%
+% (`for (k in arr)` -- the assoc for-in -- stays print-only by
+% construction: its body is a per-key print plan, not a scalar action
+% sequence, so record binds there remain a separate driver concern.)
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammar object: rec(X) -> pair(X, X+1)
+recp(X, pair(X, Y)) :- Y is X + 1.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_dyncall_rec_loop).
+
+% The record-view desugar now recurses into foreach bodies: a view there
+% becomes a hidden destructure + rewritten block, both inside the loop.
+test(view_in_foreach_desugars) :-
+    plawk_parse_string(
+        "BEGIN { BINFMT = \"i64 rep4(i64)\" ; DYNLOAD = \"l.wamo\" }\n\c
+         { foreach { dyncall@recp($1) as (i64 i64) { total += $1 } } }\n\c
+         END { print total }\n",
+        program(_, Rules0, _)),
+    plawk_native_codegen:plawk_resolve_dynrec_view_rules(Rules0, Rules),
+    Rules = [rule(_, [foreach(Body)])],
+    assertion(memberchk(dynrec_bind(_, dyncall_named(recp, [field(1)]), _),
+        Body)),
+    assertion(\+ ( member(A, Body), A = dynrec_view(_, _, _) )),
+    !.
+
+% Destructure inside foreach, end to end. rep elements 10, 20, 30;
+% recp(X) = pair(X, X+1); total += n(=X) -> 60.
+test(destructure_in_foreach_runs, [condition(clang_available)]) :-
+    rl_dir(Dir),
+    directory_file_path(Dir, 'recp.wamo', Wamo),
+    write_wam_object([user:recp/2], [wamo_entries([recp/2])], Wamo),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 rep4(i64)\" ; DYNLOAD = \"~w\" }\n\c
+         { foreach { (n, m) = dyncall@recp($1) as (i64 i64) ; total += n } }\n\c
+         END { print total }\n", [Wamo]),
+    build_run_rep(Dir, 'rld', Src, [1, 3, 10, 20, 30], "60\n"),
+    !.
+
+% Record VIEW inside foreach: total sums $1 (=X), s sums $2 (=X+1).
+% elements 10, 20, 30 -> total 60, s 11+21+31 = 63.
+test(view_in_foreach_runs, [condition(clang_available)]) :-
+    rl_dir(Dir),
+    directory_file_path(Dir, 'recp.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:recp/2], [wamo_entries([recp/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 rep4(i64)\" ; DYNLOAD = \"~w\" }\n\c
+         { foreach { dyncall@recp($1) as (i64 i64) { total += $1 ; s += $2 } } }\n\c
+         END { print total, s }\n", [Wamo]),
+    build_run_rep(Dir, 'rlv', Src, [1, 3, 10, 20, 30], "60 63\n"),
+    !.
+
+% Combined: a view inside an if inside foreach -- the desugar recurses
+% through both, and the per-element guard selects which elements view.
+% elements 10, 20, 30; guard $1 > 15 keeps 20, 30; total = 20 + 30 = 50.
+test(view_in_if_in_foreach_runs, [condition(clang_available)]) :-
+    rl_dir(Dir),
+    directory_file_path(Dir, 'recp.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:recp/2], [wamo_entries([recp/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 rep4(i64)\" ; DYNLOAD = \"~w\" }\n\c
+         { foreach { if ($1 > 15) { dyncall@recp($1) as (i64 i64) { total += $1 } } } }\n\c
+         END { print total }\n", [Wamo]),
+    build_run_rep(Dir, 'rliv', Src, [1, 3, 10, 20, 30], "50\n"),
+    !.
+
+:- end_tests(plawk_dyncall_rec_loop).
+
+% --- helpers ---------------------------------------------------------------
+
+rl_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_rec_loop', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Text) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text), close(Out)).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+% one record: a flat i64 sequence [id, count, elem1, ...] for
+% BINFMT "i64 rep4(i64)".
+write_rep_record(Path, Words) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(V, Words), write_i64_le(Out, V)),
+        close(Out)).
+
+build_run_rep(Dir, Name, Src, Words, Expected) :-
+    write_prog(Dir, Name, Src),
+    directory_file_path(Dir, Name, Prog),
+    atom_concat(Prog, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog, '_in.bin', Input),
+    write_rep_record(Input, Words),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == Expected).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_plawk_foreach_tuples.pl
+++ b/tests/test_plawk_foreach_tuples.pl
@@ -1,0 +1,121 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% "Iterate tuples, get a struct per item" -- the loop-over-a-collection
+% shape, served by `foreach` over a repetition field whose elements have
+% MORE THAN ONE field. Each element is a tuple ($1, $2, ...), and the
+% body (a full scalar action sequence, since #recbind-loop) can decode
+% any field into a structured record via a grammar. This is the
+% recommended pattern for "loop and process each item as an object";
+% iterating a hash table built with `arr[key]=val` (assoc for-in) with
+% real per-entry work is a separate, larger surface (it needs the loop
+% key and `arr[k]` value plumbed through the expression model).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammar: sq(X) -> pair(X, X*X) -- decode an element field into a struct
+sq(X, pair(X, Y)) :- Y is X * X.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_foreach_tuples).
+
+% A tuple element: foreach over rep(i64 i64) exposes $1 and $2 (the two
+% fields of the current element) -- the (key, value) pair. 2 elements
+% (10,100), (20,200): ta = 30, tb = 300.
+test(foreach_tuple_fields, [condition(clang_available)]) :-
+    ft_dir(Dir),
+    Src = "BEGIN { BINFMT = \"i64 rep4(i64 i64)\" }\n\c
+           { foreach { ta += $1 ; tb += $2 } }\n\c
+           END { print ta, tb }\n",
+    build_run(Dir, 'ftt', Src, [1, 2, 10, 100, 20, 200], "30 300\n"),
+    !.
+
+% Struct per tuple: decode the first field of each element into a record
+% via a grammar, alongside the raw tuple fields. sq(a) = pair(a, a*a);
+% tsq sums a*a. (10,100),(20,200): ta=30, tb=300, tsq=100+400=500.
+test(foreach_tuple_to_struct, [condition(clang_available)]) :-
+    ft_dir(Dir),
+    directory_file_path(Dir, 'sq.wamo', Wamo),
+    write_wam_object([user:sq/2], [wamo_entries([sq/2])], Wamo),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 rep4(i64 i64)\" ; DYNLOAD = \"~w\" }\n\c
+         { foreach { (n, sqr) = dyncall@sq($1) as (i64 i64) ; ta += $1 ; tb += $2 ; tsq += sqr } }\n\c
+         END { print ta, tb, tsq }\n", [Wamo]),
+    build_run(Dir, 'fts', Src, [1, 2, 10, 100, 20, 200], "30 300 500\n"),
+    !.
+
+% Struct-view per tuple: the record view reads the decoded struct as the
+% current record inside its block ($1 = a, $2 = a*a from sq), while the
+% element's own fields are captured first. sum of a*a = 500.
+test(foreach_tuple_struct_view, [condition(clang_available)]) :-
+    ft_dir(Dir),
+    directory_file_path(Dir, 'sq.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:sq/2], [wamo_entries([sq/2])], Wamo) ),
+    format(string(Src),
+        "BEGIN { BINFMT = \"i64 rep4(i64 i64)\" ; DYNLOAD = \"~w\" }\n\c
+         { foreach { dyncall@sq($1) as (i64 i64) { tsq += $2 } } }\n\c
+         END { print tsq }\n", [Wamo]),
+    build_run(Dir, 'ftv', Src, [1, 2, 10, 100, 20, 200], "500\n"),
+    !.
+
+:- end_tests(plawk_foreach_tuples).
+
+% --- helpers ---------------------------------------------------------------
+
+ft_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_foreach_tuples', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Text) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(open(Path, write, Out, [encoding(utf8)]),
+        write(Out, Text), close(Out)).
+
+write_i64_le(Out, V) :-
+    V64 is V /\ 0xFFFFFFFFFFFFFFFF,
+    forall(between(0, 7, I),
+        ( Byte is (V64 >> (8 * I)) /\ 0xFF, put_byte(Out, Byte) )).
+
+write_rep_record(Path, Words) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [type(binary)]),
+        forall(member(V, Words), write_i64_le(Out, V)),
+        close(Out)).
+
+build_run(Dir, Name, Src, Words, Expected) :-
+    write_prog(Dir, Name, Src),
+    directory_file_path(Dir, Name, Prog),
+    atom_concat(Prog, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog, '_in.bin', Input),
+    write_rep_record(Input, Words),
+    run_bin(Bin, [Input], Out, 0),
+    assertion(Out == Expected).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_plawk_forin_filter.pl
+++ b/tests/test_plawk_forin_filter.pl
@@ -1,0 +1,109 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Assoc for-in with per-entry logic, stage 1: a FILTER in the rule-body
+% for-in. `for (k in arr) { if (GUARD) print ... }` where GUARD compares
+% the loop key `k` or the iterated value `arr[k]` to an integer, gating
+% the per-key print. `k` / `arr[k]` are for-in-scoped operands (they exist
+% only inside the loop), parsed by a for-in-body-local guard grammar and
+% lowered by the assoc rule-chain loop emitter. See PLAWK_ASSOC_FORIN.md.
+% (Per-record running-snapshot semantics, like every rule-body for-in;
+% the END-side filter is stage 1b.)
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_forin_filter).
+
+% Value guard: `arr[k] CMP int` parses to a for-in body if wrapping a
+% print, with a forin_val_cmp guard node.
+test(value_guard_parses) :-
+    plawk_parse_string(
+        "{ c[$1]++ ; for (k in c) { if (c[k] >= 2) print k, c[k] } }\n\c
+         END { print c[\"a\"] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(for_in(var(k), var(c),
+        [if(forin_val_cmp(c, k, ge, 2), [print([var(k), assoc(var(c), var(k))])], [])]),
+        Actions),
+    !.
+
+% Key guard: `k CMP int` parses to a forin_key_cmp guard node.
+test(key_guard_parses) :-
+    plawk_parse_string(
+        "{ c[$1]++ ; for (k in c) { if (k > 0) print k } }\n\c
+         END { print c[\"a\"] }\n",
+        program(_, [rule(_, Actions)], _)),
+    memberchk(for_in(var(k), var(c),
+        [if(forin_key_cmp(k, gt, 0), [print([var(k)])], [])]), Actions),
+    !.
+
+% Value filter, end to end. Input a a b (per-record running snapshot):
+%   rec "a" -> c={a:1}: 1>=2 no.
+%   rec "a" -> c={a:2}: a passes -> "a 2".
+%   rec "b" -> c={a:2,b:1}: a passes -> "a 2"; b (1) no.
+% END prints c["a"] = 2. Lines (order-independent): 2, a 2, a 2.
+test(value_filter_runs, [condition(clang_available)]) :-
+    ff_dir(Dir),
+    Src = "{ c[$1]++ ; for (k in c) { if (c[k] >= 2) print k, c[k] } }\n\c
+           END { print c[\"a\"] }\n",
+    build_run_text(Dir, 'ffv', Src, "a\na\nb\n", Out),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, S),
+    assertion(S == ["2", "a 2", "a 2"]),
+    !.
+
+% A stricter threshold filters everything out except the END read.
+% Input a a b, guard arr[k] >= 3: nothing ever reaches 3, so no loop
+% output; END prints c["a"] = 2.
+test(value_filter_excludes_all, [condition(clang_available)]) :-
+    ff_dir(Dir),
+    Src = "{ c[$1]++ ; for (k in c) { if (c[k] >= 3) print k, c[k] } }\n\c
+           END { print c[\"a\"] }\n",
+    build_run_text(Dir, 'ffx', Src, "a\na\nb\n", Out),
+    assertion(Out == "2\n"),
+    !.
+
+:- end_tests(plawk_forin_filter).
+
+% --- helpers ---------------------------------------------------------------
+
+ff_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_forin_filter', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run_text(Dir, Name, Src, InputText, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog0, '_in.txt', Input),
+    setup_call_cleanup(open(Input, write, SI, [encoding(utf8)]),
+        write(SI, InputText), close(SI)),
+    run_bin(Bin, [Input], Out, 0).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_plawk_forin_filter.pl
+++ b/tests/test_plawk_forin_filter.pl
@@ -71,6 +71,38 @@ test(value_filter_excludes_all, [condition(clang_available)]) :-
     assertion(Out == "2\n"),
     !.
 
+% Stage 1b: the same filter on the END for-in -- iterate the FINAL hash
+% (the common use). Parses to a guarded END for-in body.
+test(end_value_guard_parses) :-
+    plawk_parse_string(
+        "{ c[$1]++ }\n\c
+         END { for (k in c) { if (c[k] >= 2) print k, c[k] } }\n",
+        program(_, _, [end([for_in(var(k), var(c),
+            [if(forin_val_cmp(c, k, ge, 2),
+                [print([var(k), assoc(var(c), var(k))])], [])])])])),
+    !.
+
+% END value filter, end to end. Final hash a=3, b=2, c=1; guard >= 2
+% keeps a and b (order-independent): "a 3", "b 2".
+test(end_value_filter_runs, [condition(clang_available)]) :-
+    ff_dir(Dir),
+    Src = "{ c[$1]++ }\n\c
+           END { for (k in c) { if (c[k] >= 2) print k, c[k] } }\n",
+    build_run_text(Dir, 'efv', Src, "a\na\nb\na\nc\nb\n", Out),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, S),
+    assertion(S == ["a 3", "b 2"]),
+    !.
+
+% END filter that keeps nothing (threshold above every count) prints
+% nothing at all.
+test(end_value_filter_empty, [condition(clang_available)]) :-
+    ff_dir(Dir),
+    Src = "{ c[$1]++ }\n\c
+           END { for (k in c) { if (c[k] >= 9) print k, c[k] } }\n",
+    build_run_text(Dir, 'efe', Src, "a\na\nb\n", Out),
+    assertion(Out == ""),
+    !.
+
 :- end_tests(plawk_forin_filter).
 
 % --- helpers ---------------------------------------------------------------


### PR DESCRIPTION
## Why this PR exists (stacked-merge recovery)

The recent stacked PRs (#3658 → #3659 → #3663 → #3664) each merged into their **parent branch**, not into the base `claude/plawk-llvm-wam-hybrid-p9ujut` — so the base is still at #3657 and **none of that work reached the main line**. (Same trap the campaign hit once before.) This PR replays the whole accumulated chain onto the base in one go, plus the new stage 1b, so everything lands where it belongs. Merge this one PR and the base is fully caught up.

## What's in it (6 commits)

1. **record binds/views inside `if`-branches** (#3658) — the branch-body validator now accepts `dynrec_bind`.
2. **record binds/views inside a `foreach` body** (#3659) — destructure/view per repetition element; view desugar recurses into `foreach`/`for_in`.
3. **foreach-over-tuples pattern** (#3663) — tested "iterate tuples, decode each into a struct."
4. **assoc for-in filter, stage 1** (#3664) — `for (k in arr) { if (arr[k] CMP n) print ... }` on the **rule-body** for-in + `PLAWK_ASSOC_FORIN.md` design doc scoping the whole hash-iteration lift.
5. **assoc for-in filter, stage 1b** (new) — the same filter on the **END** for-in (iterate the *final* hash): `END { for (k in c) { if (c[k] >= 2) print k, c[k] } }`. A guarded END driver clause + emitter parallel to the rule-body one.
6. **docs** — stage 1b landed; stage 2 blockers recorded.

## Verification

All feature suites green on the accumulated branch: `test_plawk_forin_filter` (7), `test_plawk_dyncall_rec_if` (4), `test_plawk_dyncall_rec_loop` (4), `test_plawk_foreach_tuples` (3), `test_plawk_jit_reader` (4); the earlier regressions (`surface_forin_end_print`, `forin_rule_body`, `forin_writebin`, `dyncall_assoc`, record-view/struct) also pass.

## Stages 2 & 3 — deliberately deferred, with blockers documented

Scalar accumulation (`for (k in arr) total += arr[k]`) and value→struct decode are the remaining stages. Two concrete blockers (confirmed empirically, recorded in the design doc) put stage 2 in its own round rather than rushed here:
- the **END for-in is a whole-END construct** — `END { for (k in c) ... ; print sum }` is a parse error today, so reading an accumulator needs the END grammar/driver to allow a for-in among multiple END actions;
- the for-in loop doesn't yet **thread a scalar slot as a head phi** (the assoc driver *does* carry scalar slots — a record-loop `s += 1` works — but the loop doesn't carry one out).

Stage 2 brings `foreach`'s head-phi threading to the for-in loop; stage 3 rides it. I'll do those as focused rounds against this (now-caught-up) base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_