### PR TITLE
WAM/LLVM plawk: assoc for-in decode-into-struct (stage 3)

### DIFF
--- a/docs/design/PLAWK_ASSOC_FORIN.md
+++ b/docs/design/PLAWK_ASSOC_FORIN.md
@@ -126,11 +126,33 @@ Each stage is a shippable PR with tests.
   `foreach`'s full head-phi harness; deferred until a use needs it.
 
 - **Stage 3 — decode a value into a struct.** `for (k in arr) {
-  (n, m) = dyncall@decode(arr[k]) as (i64 i64) ; ... }`. Once the body is
-  a real scalar sequence (Stage 2), record binds/views already lower
-  inside it (as they do in `foreach` bodies today); the remaining piece
-  is a surface for passing `arr[k]` — the current value — as a grammar
-  argument (the staging field 2 read, marshalled like any i64 arg).
+  (n, m) = dyncall@decode(arr[k]) as (i64 i64) ; print k, n, m }`.
+  **LANDED** (END form, i64 fields; `tests/test_plawk_forin_decode.pl`).
+  The genuinely new surface was passing `arr[k]` — the current value — as
+  a grammar argument: a for-in-scoped `forin_val` operand that boxes the
+  already-loaded slot value (`%forin_slot_value`) as an integer `%Value`,
+  marshalled like any other dyncall arg. Everything downstream is reused:
+  the record shim, typecodes, slot alloca, and field loads are the same
+  `dyncall@name(...) as (...)` destructure machinery that runs in rule and
+  `foreach` bodies, and the shim + object handle are emitted by the
+  program-wide dyncall support IR the outer driver already assembles — the
+  collectors recurse into the for-in body and find the destructure, so no
+  new support-IR wiring was needed. The per-entry loop loads the value,
+  boxes it, calls the shim into a fresh slot array, loads the typed fields,
+  and prints the loop key and/or the decoded fields.
+
+  Scope is i64 fields with an END for-in (the demonstrable slice). f64 /
+  string decoded fields ride the same shim (they already work in `foreach`
+  bodies) and a rule-body decode for-in would reuse the same emitter over
+  the assoc rule chain; both deferred until a use needs them.
+
+## Parity reached
+
+With stages 1/1b (filter), 2 (accumulate), and 3 (decode) landed, the
+hash-shaped collection (`for (k in arr)`) has the per-entry expressiveness
+the list-shaped collection (`foreach`) already had: iterate, read the entry
+(key + value), filter it, fold it into a scalar, and decode it into a
+struct — all in native WAM/LLVM.
 
 ## Parser notes
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -598,6 +598,48 @@ plawk_program_native_driver_ir(
             AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% decode-into-struct END for-in (assoc for-in, stage 3): destructure each
+% iterated value `arr[k]` through a grammar into typed fields, then print
+% them -- `END { for (k in arr) { (n,m) = dyncall@decode(arr[k]) as (T..) ;
+% print k, n, m } }`. The per-entry value is boxed and passed as the
+% grammar argument (the `forin_val` operand); the record shim + object
+% handle come from the program-wide dyncall support IR the outer driver
+% assembles (the collectors recurse into the for-in body and find the
+% destructure). Distinct four-part body shape, so ordering is unambiguous.
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules,
+        [end([for_in(var(LoopVar), var(ArrayName),
+            [dynrec_bind(Vars, Call, Types), print(PrintFields)])])]),
+    InputPath,
+    DriverIR
+) :-
+    Call = dyncall_named(_Name, [forin_val(ArrayName)]),
+    plawk_forin_end_decode_plan(Rules, ArrayName, AssocPlan),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_assoc_record_program_ok(FieldSeparator, Rules, PrintFields),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
+    plawk_forin_end_decode_ir(LoopVar, ArrayName, Vars, Call, Types,
+        PrintFields, AssocPlan, FieldSeparator, OutputSeparator,
+        DecodeGlobalIR, EndPrintIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, AssocRuleGlobalIR, DecodeGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w',
+        [EndPrintIR]),
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
+            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
 % accumulate-then-print END for-in (assoc for-in, stage 2): fold the FINAL
 % hash into a loop-carried scalar, then print it --
 % `END { for (k in arr) acc += OPERAND ; print acc }`. The for-in loop
@@ -3662,6 +3704,14 @@ plawk_forin_accum_operand_ok(forin_val(ArrayName), ArrayName).
 plawk_forin_accum_operand_ok(forin_key, _ArrayName).
 plawk_forin_accum_operand_ok(int(_Value), _ArrayName).
 
+%% plawk_forin_end_decode_plan(+Rules, +ArrayName, -AssocPlan)
+%  Plan the END decode for-in (stage 3): the record rules populate the hash,
+%  the loop destructures each value. The decoded fields are for-in-scoped
+%  (loaded fresh each iteration), so the only tables are the iterated array
+%  and whatever the rules touch -- like the accumulate plan.
+plawk_forin_end_decode_plan(Rules, ArrayName, AssocPlan) :-
+    plawk_forin_assoc_plan(Rules, ArrayName, [], AssocPlan).
+
 plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays,
         assoc_plan(Tables, PlannedRules)) :-
     maplist(plawk_assoc_rule_action_specs, Rules, RuleSpecs),
@@ -4019,6 +4069,164 @@ plawk_forin_accum_separator_lines(Index, OutputSeparator) -->
           [Index, OutputSeparator])
     },
     [SpaceCall].
+
+%% plawk_forin_end_decode_ir(+LoopVar, +ArrayName, +Vars, +Call, +Types,
+%%     +PrintFields, +AssocPlan, +Descriptor, +OutputSeparator,
+%%     -GlobalIR, -IR)
+%
+%  Emit the END decode for-in (stage 3): walk the iterated table's occupied
+%  slots, load each value, box it as the grammar argument (`forin_val`),
+%  destructure the returned record into typed fields via the shared record
+%  shim, then print the loop key and the decoded fields. Fields are i64
+%  (the demonstrable slice; f64/string decode into a for-in body would ride
+%  the same shim -- deferred). GlobalIR carries the field-typecode constant.
+plawk_forin_end_decode_ir(LoopVar, ArrayName, Vars, Call, Types, PrintFields,
+        AssocPlan, Descriptor, OutputSeparator, GlobalIR, IR) :-
+    forall(member(T, Types), T == i64),
+    length(Types, NFields),
+    length(Vars, NFields),
+    plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
+    % The record shim call, arg-boxing and field loads, base `forin_dec`.
+    maplist(plawk_dynrec_type_code, Types, Codes),
+    plawk_dynrec_typecodes_escaped(Codes, Escaped),
+    format(atom(GlobalIR),
+        '@.forin_dec_tc = private constant [~w x i8] c"~w"',
+        [NFields, Escaped]),
+    plawk_dynrec_call_ir(Call, Descriptor, forin_dec, CallArgsIR,
+        _ArgGlobals, ArgSetup, ShimName),
+    NLast is NFields - 1,
+    numlist(0, NLast, Fields),
+    findall(ZLine,
+        ( member(FZ, Fields),
+          format(atom(ZLine),
+              '  %forin_dec_z~wp = getelementptr i64, i64* %forin_dec_slots, i64 ~w\n  store i64 0, i64* %forin_dec_z~wp\n  %forin_dec_zl~wp = getelementptr i64, i64* %forin_dec_lens, i64 ~w\n  store i64 0, i64* %forin_dec_zl~wp',
+              [FZ, FZ, FZ, FZ, FZ, FZ]) ),
+        ZeroLines),
+    plawk_dynrec_field_load_lines(Fields, Types, forin_dec, LoadLines),
+    atomic_list_concat(ArgSetup, '\n', ArgSetupIR),
+    atomic_list_concat(ZeroLines, '\n', ZeroIR),
+    atomic_list_concat(LoadLines, '\n', LoadIR),
+    format(atom(CallIR),
+        '  %forin_dec_ok = call i1 @~w(~w, i32 ~w, i8* %forin_dec_tcp, i64* %forin_dec_slots, i64* %forin_dec_lens)',
+        [ShimName, CallArgsIR, NFields]),
+    % Map each decoded variable to its loaded-field SSA for the print.
+    findall(V-SSA,
+        ( nth0(I, Vars, V), format(atom(SSA), '%forin_dec_f~w', [I]) ),
+        VarSSAs),
+    phrase(plawk_forin_decode_print_lines(PrintFields, LoopVar, VarSSAs,
+        Descriptor, OutputSeparator, 0), PrintLineList),
+    atomic_list_concat(PrintLineList, '\n', PrintIR),
+    phrase(plawk_assoc_free_lines(AssocPlan), FreeLines),
+    atomic_list_concat(FreeLines, '\n', FreeIR),
+    format(atom(IR),
+'  br label %forin_head
+
+forin_head:
+  %forin_idx = phi i64 [0, %end_print], [%forin_next_idx, %forin_body_done]
+  %forin_slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_idx)
+  %forin_done = icmp slt i64 %forin_slot, 0
+  br i1 %forin_done, label %forin_after, label %forin_body
+
+forin_body:
+  %forin_key_id = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)
+  %forin_slot_value = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)
+~w
+  %forin_dec_slots = alloca i64, i32 ~w
+  %forin_dec_lens = alloca i64, i32 ~w
+~w
+  %forin_dec_tcp = getelementptr [~w x i8], [~w x i8]* @.forin_dec_tc, i32 0, i32 0
+~w
+~w
+~w
+  %forin_dec_newline = call i32 @putchar(i32 10)
+  br label %forin_body_done
+
+forin_body_done:
+  %forin_next_idx = add i64 %forin_slot, 1
+  br label %forin_head
+
+forin_after:
+~w
+  ret i32 0',
+        [TableIndex, TableIndex, TableIndex, ArgSetupIR, NFields, NFields,
+         ZeroIR, NFields, NFields, CallIR, LoadIR, PrintIR, FreeIR]).
+
+%% plawk_forin_decode_print_lines(+PrintFields, +LoopVar, +VarSSAs,
+%%     +Descriptor, +OutputSeparator, +Index)//
+%  The per-entry print in an END decode body: the loop key (text, or
+%  numeric for a binary descriptor), a decoded field (its loaded i64 SSA),
+%  or a string literal. Distinct label prefix (forin_dprint_*).
+plawk_forin_decode_print_lines([], _LoopVar, _VarSSAs, _Descriptor,
+        _OutputSeparator, _Index) -->
+    [].
+plawk_forin_decode_print_lines([var(LoopVar) | Rest], LoopVar, VarSSAs,
+        Descriptor, OutputSeparator, Index) -->
+    { \+ memberchk(LoopVar-_, VarSSAs) },
+    % The loop key.
+    plawk_forin_decode_separator_lines(Index, OutputSeparator),
+    { plawk_descriptor_is_binary(Descriptor)
+    ->  format(atom(FmtVar), 'forin_dprint_key_fmt_~w', [Index]),
+        format(atom(PrintVar), 'forin_dprint_key_~w', [Index]),
+        llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+            '%forin_key_id', Lines)
+    ;   format(atom(KeyStr),
+            '  %forin_dprint_key_s_~w = call i8* @wam_atom_to_string(i64 %forin_key_id)',
+            [Index]),
+        format(atom(FmtVar), 'forin_dprint_key_fmt_~w', [Index]),
+        format(atom(PrintVar), 'forin_dprint_key_~w', [Index]),
+        format(atom(PtrIR), '%forin_dprint_key_s_~w', [Index]),
+        llvm_emit_printf_string(plawk_surface_print_string, FmtVar, PrintVar,
+            PtrIR, [FmtPtr, PrintCall]),
+        Lines = [KeyStr, FmtPtr, PrintCall]
+    },
+    plawk_emit_lines(Lines),
+    { NextIndex is Index + 1 },
+    plawk_forin_decode_print_lines(Rest, LoopVar, VarSSAs, Descriptor,
+        OutputSeparator, NextIndex).
+plawk_forin_decode_print_lines([var(Var) | Rest], LoopVar, VarSSAs, Descriptor,
+        OutputSeparator, Index) -->
+    { memberchk(Var-SSA, VarSSAs) },
+    % A decoded field.
+    plawk_forin_decode_separator_lines(Index, OutputSeparator),
+    { format(atom(FmtVar), 'forin_dprint_fld_fmt_~w', [Index]),
+      format(atom(PrintVar), 'forin_dprint_fld_~w', [Index]),
+      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, SSA,
+          [FmtPtr, PrintCall]),
+      NextIndex is Index + 1
+    },
+    [FmtPtr, PrintCall],
+    plawk_forin_decode_print_lines(Rest, LoopVar, VarSSAs, Descriptor,
+        OutputSeparator, NextIndex).
+plawk_forin_decode_print_lines([string(Value) | Rest], LoopVar, VarSSAs,
+        Descriptor, OutputSeparator, Index) -->
+    plawk_forin_decode_separator_lines(Index, OutputSeparator),
+    plawk_end_string_print_lines(Value, Index),
+    { NextIndex is Index + 1 },
+    plawk_forin_decode_print_lines(Rest, LoopVar, VarSSAs, Descriptor,
+        OutputSeparator, NextIndex).
+
+plawk_forin_decode_separator_lines(0, _OutputSeparator) -->
+    !,
+    [].
+plawk_forin_decode_separator_lines(Index, OutputSeparator) -->
+    { format(atom(SpaceCall),
+          '  %forin_dprint_separator_~w = call i32 @putchar(i32 ~w)',
+          [Index, OutputSeparator])
+    },
+    [SpaceCall].
+
+%% plawk_foreign_arg_ir(forin_val(_), ...) -- a for-in-scoped grammar arg:
+%  the current iterated value, already loaded into %forin_slot_value by the
+%  decode loop, boxed as an integer %Value. (Clause lives beside the other
+%  plawk_foreign_arg_ir clauses via discontiguous; kept here next to the
+%  for-in decode emitter that relies on the fixed %forin_slot_value name.)
+:- discontiguous plawk_foreign_arg_ir/6.
+plawk_foreign_arg_ir(forin_val(_Array), _FieldSeparator, ArgBase, ArgValueIR,
+        [], [IntIR]) :-
+    format(atom(IntIR),
+        '  %~w_v = call %Value @value_integer(i64 %forin_slot_value)',
+        [ArgBase]),
+    format(atom(ArgValueIR), '%~w_v', [ArgBase]).
 
 plawk_forin_body_print_lines([], _LoopVar, _ArrayName, _TableIndex, _AssocPlan,
         _Descriptor, _OutputSeparator, _) -->

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -897,6 +897,33 @@ begin_assignment_name('FS') -->
 begin_assignment_name('OFS') -->
     "OFS".
 
+% END decode-into-struct (assoc for-in, stage 3): a for-in whose body
+% destructures the iterated value `arr[k]` through a grammar into typed
+% fields, then prints them. `END { for (k in arr) { (n, m) =
+% dyncall@decode(arr[k]) as (i64 i64) ; print k, n, m } }`. The decode
+% argument is the for-in value `arr[k]` (array/key must match the loop);
+% the destructured variables are for-in-scoped and read back in the print.
+% Tried before the accumulate and single-action END clauses -- the
+% `for (...) { ( vars ) = dyncall@... }` shape is unambiguous. See
+% PLAWK_ASSOC_FORIN.md.
+end_clauses([end([for_in(var(LoopVar), var(ArrayName),
+                  [dynrec_bind(Vars, dyncall_named(Name, [forin_val(ArrayName)]),
+                       Types),
+                   print(PrintFields)])])]) -->
+    "END", ws, "{", ws,
+    "for", ws, "(", ws,
+    identifier(LoopVar), ws, "in", identifier_boundary, ws,
+    identifier(ArrayName), ws, ")", ws,
+    "{", ws,
+    "(", ws, dynrec_var_list(Vars), ws, ")", ws, "=", ws,
+    "dyncall@", identifier(Name), ws, "(", ws,
+    identifier(ArrayName), ws, "[", ws, identifier(LoopVar), ws, "]", ws, ")", ws,
+    "as", identifier_boundary, ws, "(", ws, dynrec_type_list(Types), ws, ")", ws,
+    action_sep, ws,
+    print_action(print(PrintFields)), ws,
+    "}", ws,
+    "}", ws,
+    !.
 % END accumulate-then-print (assoc for-in, stage 2): a for-in that folds
 % the hash into a scalar, followed by a print that reads the accumulator.
 % `END { for (k in arr) acc += arr[k] ; print acc }`. The for-in body is a

--- a/tests/test_plawk_forin_decode.pl
+++ b/tests/test_plawk_forin_decode.pl
@@ -1,0 +1,130 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Assoc for-in with per-entry logic, stage 3: DECODE A VALUE INTO A STRUCT.
+% An END `for (k in arr) { (n, m) = dyncall@decode(arr[k]) as (i64 i64) ;
+% print k, n, m }` destructures each iterated value through a grammar into
+% typed fields and prints them. The per-entry value `arr[k]` is boxed and
+% passed as the grammar argument (a for-in-scoped `forin_val` operand); the
+% record shim and object handle come from the program-wide dyncall support
+% IR (the collectors recurse into the for-in body and find the destructure).
+% This is the hash-shaped counterpart to record destructure inside a
+% `foreach` body -- iterate, read the entry, decode it into a struct.
+% i64 fields are the demonstrable slice; see PLAWK_ASSOC_FORIN.md.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+% grammar object: decode(N) -> r(N, N+100)
+decode(N, r(N, M)) :- M is N + 100.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_forin_decode).
+
+% The decode body parses to a for-in whose body is a destructure over the
+% for-in value `forin_val(c)` plus a print of the loop key and slots.
+test(decode_parses) :-
+    plawk_parse_string(
+        "BEGIN { DYNLOAD = \"d.wamo\" }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) { (n, m) = dyncall@decode(c[k]) as (i64 i64) ; print k, n, m } }\n",
+        program(_, _, [end([for_in(var(k), var(c),
+            [dynrec_bind([n, m], dyncall_named(decode, [forin_val(c)]),
+                 [i64, i64]),
+             print([var(k), var(n), var(m)])])])])),
+    !.
+
+% End to end: counts a=3, b=2, c=1; decode(N) = r(N, N+100). Each entry
+% prints "key count count+100" (order-independent).
+test(decode_runs, [condition(clang_available)]) :-
+    fd_dir(Dir),
+    decode_wamo(Dir, Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) { (n, m) = dyncall@decode(c[k]) as (i64 i64) ; print k, n, m } }\n",
+        [Wamo]),
+    build_run_text(Dir, 'dec', Src, "a\na\na\nb\nb\nc\n", Out),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, S),
+    assertion(S == ["a 3 103", "b 2 102", "c 1 101"]),
+    !.
+
+% Print only the decoded fields (no key): the destructured struct stands
+% on its own. Same counts -> "count count+100" per entry.
+test(decode_fields_only_runs, [condition(clang_available)]) :-
+    fd_dir(Dir),
+    decode_wamo(Dir, Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) { (n, m) = dyncall@decode(c[k]) as (i64 i64) ; print n, m } }\n",
+        [Wamo]),
+    build_run_text(Dir, 'decf', Src, "a\na\na\nb\nb\nc\n", Out),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, S),
+    assertion(S == ["1 101", "2 102", "3 103"]),
+    !.
+
+% A string literal alongside the decoded fields.
+test(decode_labeled_runs, [condition(clang_available)]) :-
+    fd_dir(Dir),
+    decode_wamo(Dir, Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) { (n, m) = dyncall@decode(c[k]) as (i64 i64) ; print \"e\", n, m } }\n",
+        [Wamo]),
+    build_run_text(Dir, 'decl', Src, "a\na\nb\n", Out),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, S),
+    assertion(S == ["e 1 101", "e 2 102"]),
+    !.
+
+:- end_tests(plawk_forin_decode).
+
+% --- helpers ---------------------------------------------------------------
+
+fd_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_forin_decode', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+decode_wamo(Dir, Wamo) :-
+    directory_file_path(Dir, 'decode.wamo', Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:decode/2], [wamo_entries([decode/2])], Wamo) ).
+
+build_run_text(Dir, Name, Src, InputText, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], _, 0),
+    atom_concat(Prog0, '_in.txt', Input),
+    setup_call_cleanup(open(Input, write, SI, [encoding(utf8)]),
+        write(SI, InputText), close(SI)),
+    run_bin(Bin, [Input], Out, 0).
+
+cli(Args, Out, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out, ExpectedStatus) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out),
+    close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Assoc for-in stage 3 — decode a value into a struct

Destructure each iterated value of an associative hash through a grammar into typed fields, inside an END `for (k in arr)`, and print them:

```awk
BEGIN { DYNLOAD = "decode.wamo" }
{ c[$1]++ }
END { for (k in c) { (n, m) = dyncall@decode(c[k]) as (i64 i64) ; print k, n, m } }
```

This is stage 3 of `docs/design/PLAWK_ASSOC_FORIN.md` and the hash-shaped counterpart to record destructure inside a `foreach` body: iterate, read the entry, decode it into a struct. With stages 1/1b (filter), 2 (accumulate), and 3 (decode) landed, `for (k in arr)` now has the per-entry expressiveness `foreach` already had.

### What changed

The one genuinely new surface is passing `arr[k]` — the current value — as a **grammar argument**: a for-in-scoped `forin_val` operand that boxes the already-loaded slot value (`%forin_slot_value`) as an integer `%Value`, marshalled like any other dyncall arg.

Everything downstream is **reused, not rebuilt**:
- The record shim, typecodes, slot `alloca`, and field loads are the same `dyncall@name(...) as (...)` destructure machinery that runs in rule and `foreach` bodies.
- The shim + object handle come from the program-wide dyncall support IR the outer driver already assembles — its collectors recurse into the for-in body and find the destructure, so **no new support-IR wiring** was needed.

The per-entry loop loads the value, boxes it, calls the shim into a fresh slot array, loads the typed fields, and prints the loop key and/or the decoded fields.

### Scope

i64 fields with an END for-in (the demonstrable slice). f64 / string decoded fields ride the same shim (they already work in `foreach` bodies) and a rule-body decode for-in would reuse the same emitter over the assoc rule chain — both deferred until a use needs them. Prior for-in stages (filter 1/1b, accumulate 2) and the `foreach` record-destructure tests are unaffected — verified below.

### Tests

`tests/test_plawk_forin_decode.pl` (4/4 pass): key+fields (`a 3 103`), fields-only (`3 103`), labeled (`e 3 103`), plus parse coverage. Regression: `test_plawk_forin_filter` (7/7), `test_plawk_forin_accum` (7/7), `test_plawk_dyncall_rec_loop` (4/4) all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_