### PR TITLE
WAM/LLVM plawk: f64 decoded fields in the for-in decode body

### DIFF
--- a/docs/design/PLAWK_ASSOC_FORIN.md
+++ b/docs/design/PLAWK_ASSOC_FORIN.md
@@ -141,10 +141,12 @@ Each stage is a shippable PR with tests.
   boxes it, calls the shim into a fresh slot array, loads the typed fields,
   and prints the loop key and/or the decoded fields.
 
-  Scope is i64 fields with an END for-in (the demonstrable slice). f64 /
-  string decoded fields ride the same shim (they already work in `foreach`
-  bodies) and a rule-body decode for-in would reuse the same emitter over
-  the assoc rule chain; both deferred until a use needs them.
+  **i64 and f64 decoded fields LANDED** (`(a, b) = dyncall@decf(arr[k]) as
+  (f64 f64)`, and mixed `as (i64 f64)`): each is one scalar slot loaded
+  directly, and the per-entry print emits `%g` for a decoded f64 and the
+  integer printf for an i64. **String decoded fields** (a `(ptr,len)` pair
+  of slots) and a **rule-body (non-END) decode for-in** are deferred — both
+  reuse the same shim/emitter and can follow when a use needs them.
 
 ## Parity reached
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4077,12 +4077,13 @@ plawk_forin_accum_separator_lines(Index, OutputSeparator) -->
 %  Emit the END decode for-in (stage 3): walk the iterated table's occupied
 %  slots, load each value, box it as the grammar argument (`forin_val`),
 %  destructure the returned record into typed fields via the shared record
-%  shim, then print the loop key and the decoded fields. Fields are i64
-%  (the demonstrable slice; f64/string decode into a for-in body would ride
-%  the same shim -- deferred). GlobalIR carries the field-typecode constant.
+%  shim, then print the loop key and the decoded fields. Fields are i64 or
+%  f64 -- one scalar slot each, loaded directly (string fields take a
+%  (ptr,len) pair and are a separate round). GlobalIR carries the
+%  field-typecode constant.
 plawk_forin_end_decode_ir(LoopVar, ArrayName, Vars, Call, Types, PrintFields,
         AssocPlan, Descriptor, OutputSeparator, GlobalIR, IR) :-
-    forall(member(T, Types), T == i64),
+    forall(member(T, Types), memberchk(T, [i64, f64])),
     length(Types, NFields),
     length(Vars, NFields),
     plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
@@ -4109,9 +4110,11 @@ plawk_forin_end_decode_ir(LoopVar, ArrayName, Vars, Call, Types, PrintFields,
     format(atom(CallIR),
         '  %forin_dec_ok = call i1 @~w(~w, i32 ~w, i8* %forin_dec_tcp, i64* %forin_dec_slots, i64* %forin_dec_lens)',
         [ShimName, CallArgsIR, NFields]),
-    % Map each decoded variable to its loaded-field SSA for the print.
-    findall(V-SSA,
-        ( nth0(I, Vars, V), format(atom(SSA), '%forin_dec_f~w', [I]) ),
+    % Map each decoded variable to its loaded-field SSA and type for the
+    % print (i64 -> integer printf, f64 -> %g).
+    findall(V-(SSA-Type),
+        ( nth0(I, Vars, V), nth0(I, Types, Type),
+          format(atom(SSA), '%forin_dec_f~w', [I]) ),
         VarSSAs),
     phrase(plawk_forin_decode_print_lines(PrintFields, LoopVar, VarSSAs,
         Descriptor, OutputSeparator, 0), PrintLineList),
@@ -4154,15 +4157,17 @@ forin_after:
 %% plawk_forin_decode_print_lines(+PrintFields, +LoopVar, +VarSSAs,
 %%     +Descriptor, +OutputSeparator, +Index)//
 %  The per-entry print in an END decode body: the loop key (text, or
-%  numeric for a binary descriptor), a decoded field (its loaded i64 SSA),
-%  or a string literal. Distinct label prefix (forin_dprint_*).
+%  numeric for a binary descriptor), a decoded field (its loaded SSA, as
+%  i64 or f64 per its type), or a string literal. Distinct label prefix
+%  (forin_dprint_*).
 plawk_forin_decode_print_lines([], _LoopVar, _VarSSAs, _Descriptor,
         _OutputSeparator, _Index) -->
     [].
 plawk_forin_decode_print_lines([var(LoopVar) | Rest], LoopVar, VarSSAs,
         Descriptor, OutputSeparator, Index) -->
     { \+ memberchk(LoopVar-_, VarSSAs) },
-    % The loop key.
+    % The loop key (a decoded var never shadows the loop key -- distinct
+    % identifiers by construction).
     plawk_forin_decode_separator_lines(Index, OutputSeparator),
     { plawk_descriptor_is_binary(Descriptor)
     ->  format(atom(FmtVar), 'forin_dprint_key_fmt_~w', [Index]),
@@ -4185,15 +4190,22 @@ plawk_forin_decode_print_lines([var(LoopVar) | Rest], LoopVar, VarSSAs,
         OutputSeparator, NextIndex).
 plawk_forin_decode_print_lines([var(Var) | Rest], LoopVar, VarSSAs, Descriptor,
         OutputSeparator, Index) -->
-    { memberchk(Var-SSA, VarSSAs) },
-    % A decoded field.
+    { memberchk(Var-(SSA-Type), VarSSAs) },
+    % A decoded field: i64 via the integer printf, f64 via %g.
     plawk_forin_decode_separator_lines(Index, OutputSeparator),
-    { format(atom(FmtVar), 'forin_dprint_fld_fmt_~w', [Index]),
-      format(atom(PrintVar), 'forin_dprint_fld_~w', [Index]),
-      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, SSA,
-          [FmtPtr, PrintCall]),
-      NextIndex is Index + 1
+    { Type == f64
+    ->  format(atom(FmtPtr),
+            '  %forin_dprint_fld_fmt_~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_f64, i32 0, i32 0',
+            [Index]),
+        format(atom(PrintCall),
+            '  %forin_dprint_fld_~w = call i32 (i8*, ...) @printf(i8* %forin_dprint_fld_fmt_~w, double ~w)',
+            [Index, Index, SSA])
+    ;   format(atom(FmtVar), 'forin_dprint_fld_fmt_~w', [Index]),
+        format(atom(PrintVar), 'forin_dprint_fld_~w', [Index]),
+        llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, SSA,
+            [FmtPtr, PrintCall])
     },
+    { NextIndex is Index + 1 },
     [FmtPtr, PrintCall],
     plawk_forin_decode_print_lines(Rest, LoopVar, VarSSAs, Descriptor,
         OutputSeparator, NextIndex).

--- a/tests/test_plawk_forin_decode.pl
+++ b/tests/test_plawk_forin_decode.pl
@@ -11,7 +11,8 @@
 % IR (the collectors recurse into the for-in body and find the destructure).
 % This is the hash-shaped counterpart to record destructure inside a
 % `foreach` body -- iterate, read the entry, decode it into a struct.
-% i64 fields are the demonstrable slice; see PLAWK_ASSOC_FORIN.md.
+% i64 and f64 fields decode into one scalar slot each; string fields (a
+% (ptr,len) pair) are a separate round. See PLAWK_ASSOC_FORIN.md.
 
 :- use_module(library(plunit)).
 :- use_module(library(process)).
@@ -22,6 +23,9 @@
 
 % grammar object: decode(N) -> r(N, N+100)
 decode(N, r(N, M)) :- M is N + 100.
+% f64 fields: decf(N) -> r(N*1.5, N+0.25); mixed: decm(N) -> r(N, N*1.5)
+decf(N, r(F1, F2)) :- F1 is N * 1.5, F2 is N + 0.25.
+decm(N, r(N, F)) :- F is N * 1.5.
 
 clang_available :-
     catch(( process_create(path(clang), ['--version'],
@@ -87,6 +91,35 @@ test(decode_labeled_runs, [condition(clang_available)]) :-
     assertion(S == ["e 1 101", "e 2 102"]),
     !.
 
+% f64 decoded fields: decf(N) = r(N*1.5, N+0.25). Counts a=3,b=2,c=1 ->
+% a:(4.5,3.25) b:(3,2.25) c:(1.5,1.25) (%g drops the trailing .0).
+test(decode_f64_runs, [condition(clang_available)]) :-
+    fd_dir(Dir),
+    named_wamo(Dir, decf, Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) { (a, b) = dyncall@decf(c[k]) as (f64 f64) ; print k, a, b } }\n",
+        [Wamo]),
+    build_run_text(Dir, 'decff', Src, "a\na\na\nb\nb\nc\n", Out),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, S),
+    assertion(S == ["a 4.5 3.25", "b 3 2.25", "c 1.5 1.25"]),
+    !.
+
+% Mixed i64 + f64 fields in one destructure: decm(N) = r(N, N*1.5).
+test(decode_mixed_runs, [condition(clang_available)]) :-
+    fd_dir(Dir),
+    named_wamo(Dir, decm, Wamo),
+    format(string(Src),
+        "BEGIN { DYNLOAD = \"~w\" }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) { (n, f) = dyncall@decm(c[k]) as (i64 f64) ; print k, n, f } }\n",
+        [Wamo]),
+    build_run_text(Dir, 'decmm', Src, "a\na\na\nb\nb\nc\n", Out),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, S),
+    assertion(S == ["a 3 4.5", "b 2 3", "c 1 1.5"]),
+    !.
+
 :- end_tests(plawk_forin_decode).
 
 % --- helpers ---------------------------------------------------------------
@@ -100,6 +133,13 @@ decode_wamo(Dir, Wamo) :-
     directory_file_path(Dir, 'decode.wamo', Wamo),
     ( exists_file(Wamo) -> true
     ; write_wam_object([user:decode/2], [wamo_entries([decode/2])], Wamo) ).
+
+% A .wamo exporting Name/2 (e.g. decf, decm), built on first use.
+named_wamo(Dir, Name, Wamo) :-
+    atom_concat(Name, '.wamo', File),
+    directory_file_path(Dir, File, Wamo),
+    ( exists_file(Wamo) -> true
+    ; write_wam_object([user:Name/2], [wamo_entries([Name/2])], Wamo) ).
 
 build_run_text(Dir, Name, Src, InputText, Out) :-
     directory_file_path(Dir, Name, Prog0),


### PR DESCRIPTION
## f64 decoded fields in the assoc for-in decode body

The documented JIT/self-host roadmap is fully landed; this is a small, coherent follow-on to the stage 3 decode-into-struct that just shipped (#3669). It generalizes the END for-in decode — previously i64-only — to **i64 AND f64** destructured fields:

```awk
{ c[$1]++ }
END { for (k in c) { (a, b) = dyncall@decf(c[k]) as (f64 f64) ; print k, a, b } }
END { for (k in c) { (n, f) = dyncall@decm(c[k]) as (i64 f64) ; print k, n, f } }
```

### What changed

Each field is still one scalar slot loaded directly — the record shim and field-load machinery already deserialize an f64 as a bitcast-from-bits `double`. The only additions:
- relax the decode emitter's type gate to accept `f64` (was `== i64`);
- thread each decoded variable's type into the per-entry print, emitting `%g` for an f64 field and the integer printf for an i64.

No new runtime, shim, or support-IR wiring — the parser already accepted `f64` in the type list, and the arg-boxing (`forin_val`) is unchanged.

### Scope

String decoded fields (a `(ptr,len)` pair of slots) and a rule-body (non-END) decode for-in stay deferred — both reuse the same shim/emitter and can follow when a use needs them.

### Tests

`tests/test_plawk_forin_decode.pl` — added f64-fields (`a 4.5 3.25`) and mixed i64/f64 (`a 3 4.5`) cases; 6/6 pass. The i64 cases and prior for-in stages are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_