### PR TITLE
mu_cosine: gate structured residual covariance before QR/CUDA optimization

### DIFF
--- a/prototypes/mu_cosine/DESIGN_structured_residual_covariance.md
+++ b/prototypes/mu_cosine/DESIGN_structured_residual_covariance.md
@@ -1,0 +1,222 @@
+# Semantic/graph residual covariance — evidence-gate protocol
+
+## Status and question
+
+This protocol is the statistical follow-up to the batched square-root/QR conditioner.  The conditioner can
+already whiten a dense conditional measurement covariance and triangularise the resulting information rows.
+The open question is whether campaign rows that are close in frozen semantic or graph-feature space actually
+have enough *held predictive residual dependence* to justify a cross-item covariance model.
+
+This is an evidence gate, not a production integration.  It deliberately keeps CUDA and an optimized
+Kronecker inverse-root operator out of scope until a structured covariance improves held data.
+
+The operating target is the existing GPT-5.5 campaign response.  Results therefore measure fidelity to that
+judge, not truth or judge-independent quality.  No new judge calls are required.  An independent or
+human-verified target remains necessary for a general-quality claim.
+
+## Statistical object: condition first, then model cross-item residuals
+
+For one campaign row, retain the sign convention used by the correlated Gaussian conditioner:
+
+```text
+e = truth - prior
+v = measurement - H truth
+Cov(e)   = P0
+Cov(e,v) = C0
+Cov(v)   = R0.
+```
+
+The within-item calibration split estimates `P0`, `C0`, and `R0`.  Conditioning measurement error on prior
+error gives
+
+```text
+J0 = H + C0.T P0^-1
+q  = v - C0.T P0^-1 e
+Rc = Cov(q) = R0 - C0.T P0^-1 C0.
+```
+
+`q` is the object whose dependence across campaign rows is tested.  This ordering matters: fitting a
+cross-item model to raw `R0` and then passing it to the conditional whitener would subtract the prior/shared
+term twice.
+
+For a held batch of `N` items, the information update uses
+
+```text
+prior error state:  e_batch ~ N(0, I_N kron P0)
+conditional design: J_batch = I_N kron J0
+conditional noise:  q_batch ~ N(mean_q, Rc_batch).
+```
+
+The measurement RHS is `measurement - H prior - mean_q`.  Dense `Rc_batch` is whitened once and passed to the
+existing Householder information update.  Item-major flattening is fixed throughout: all measurement channels
+for item 0, then all channels for item 1, and so on.
+
+This first protocol leaves cross-item prior-error covariance at `I_N kron P0`.  A persistent regional error in
+the *prior* belongs in `P`, or in an augmented regional-bias state, and is not silently relabelled as
+measurement noise here.
+
+## Split and leakage contract
+
+For each corpus and split seed:
+
+1. Use `node_disjoint_pair_split` with 40% held nodes and 64 candidate assignments.
+2. Candidate balancing may use the campaign's sampling/neighbourhood stratum and pair incidence.  It must not
+   use held D/S values, held residuals, or the operating judge's hard decision.
+3. Drop every pair crossing the node partition.
+4. Fit graph-D affine calibration, graph-S regression, Luna affine calibration, `P0/C0/R0`, feature
+   standardisation, RBF bandwidths, regional-mean hyperparameters, and covariance parameters on train rows
+   only.
+5. Do not use held outcomes to choose numerical loading, optimization duration, kernel weights, or a model.
+
+The primary run uses predeclared seeds 0 through 9.  Mean and SD across those node partitions are descriptive
+partition stability, not an SE or population confidence interval.  A dense held covariance couples rows, so a
+row or endpoint bootstrap is not attached to the joint Gaussian likelihood.
+
+The run manifest must content-hash the scored campaign, Luna scores, model checkpoint, both E5 caches, the
+exploratory graph TSV, and the fresh LMDB `data.mdb`.  LMDB `lock.mdb` is excluded because it is mutable
+process state rather than graph content.  A CLI campaign override must be passed to both target and dataset
+loaders; recording a path that was not actually consumed is a provenance failure.
+
+## Outcome-blind row geometry
+
+Two PSD RBF kernels are available on both corpora:
+
+- **semantic:** the row feature is the normalized concatenation of frozen e5 `passage(node)` and
+  `query(root)` embeddings;
+- **graph-feature:** train-standardized `[hit_prob, inverse common-ancestor distance, shared-parent,
+  shared-grandparent, ancestor-related]` features.
+
+The second is called a graph-*feature* kernel, not a shortest-path or diffusion kernel.  Applying an RBF to an
+arbitrary shortest-path distance matrix is not guaranteed PSD.  A true graph diffusion kernel or an RBF over
+a provenance-tracked structural embedding is later work; the existing structural embedding does not cover
+the fresh corpus.
+
+Each RBF bandwidth is the median nonzero pair distance on train rows.  Held rows do not influence it.
+
+## Separate regional mean from covariance
+
+One response per judge/item cannot identify a persistent regional bias field and correlated random noise by
+interpretation alone.  The protocol therefore compares them predictively.
+
+A train-only kernel-ridge regional mean is selected by exact leave-one-out MSE across semantic,
+graph-feature, and equal-mixture kernels and a fixed ridge grid.  The covariance models are fit to the
+corresponding leave-one-out train residuals; held residuals are centered using the train-fitted prediction.
+The global-mean block model remains an explicit baseline.
+
+## Covariance models
+
+All component matrices are PSD by construction (`B = L L.T`).  The statistical independent term is distinct
+from the numerical diagonal loading applied, if necessary, by the existing whitener.
+
+1. **`block_global`**
+
+   ```text
+   Rc = I_N kron B0
+   ```
+
+   with only the train global residual mean removed.
+
+2. **`block_regional`**
+
+   The same block form, fit after the cross-fitted regional mean.  The difference from `block_global` tests
+   predictable local bias without claiming residual covariance.
+
+3. **`separable_regional`**
+
+   ```text
+   Rc = I_N kron B0
+        + (w_sem K_sem + w_graph K_graph) kron Bshared,
+   w_sem,w_graph >= 0,  w_sem + w_graph = 1.
+   ```
+
+   This is the restricted model that could later support a compact diagonalization/operator path.
+
+4. **`dense_lmc_regional`**
+
+   ```text
+   Rc = I_N kron B0
+        + K_sem   kron B_sem
+        + K_graph kron B_graph.
+   ```
+
+   This additive latent-kernel model is the flexible structured reference.  It is dense when materialized but
+   is not an arbitrary unstructured covariance, which cannot be estimated or transferred to unseen held items
+   from one residual field.
+
+The structured component matrices are fit by deterministic pairwise composite Gaussian likelihood on train
+rows.  The primary held score is nevertheless the full joint Gaussian likelihood of the held residual field.
+The block model's analytic train objective is in original channel units, whereas the structured optimizer's
+composite objective uses train-RMS-standardized channels; those train diagnostics are not comparable across
+families.  Every held NLL below is evaluated in the same original units and is the valid model comparison.
+
+Each structured fit retains the exact independent-block submodel as a candidate.  Dense LMC also retains the
+fitted separable model as a candidate.  When an inherited structured factor is zero, Adam starts from a
+material PSD seed rather than an effectively zero Cholesky factor, whose `B=L L.T` gradient would vanish.
+Tests require escape from a zero block start and require dense LMC to beat the restricted family on a planted
+nonseparable field.  These checks reduce optimizer false negatives; they do not turn a finite-step fit into a
+global-optimality proof.
+
+## Metrics and required diagnostics
+
+Primary covariance score:
+
+- held joint conditional-residual Gaussian NLL per scalar.
+
+Secondary posterior scores after one joint QR update:
+
+- mean bivariate marginal posterior NLL;
+- state MSE;
+- Mahalanobis squared error per state dimension;
+- empirical 95% bivariate ellipse coverage.
+
+Operating-judge decision diagnostics use the existing train-only D/S logistic bridge:
+
+- accuracy;
+- categorical log-loss;
+- ECE with 10 equal-width confidence bins;
+- AURC using top-1 minus top-2 probability margin.
+
+Every covariance result must also report:
+
+- relative off-item Frobenius mass;
+- largest whitened off-item block spectral norm;
+- minimum/maximum eigenvalue and condition number;
+- absolute and relative diagonal loading actually applied;
+- covariance dimension and conditioner wall time;
+- train residual mean removed, selected regional kernel/ridge, RBF bandwidths, and optimization provenance.
+
+## Predeclared engineering gate
+
+This gate decides whether a later inverse-root/CUDA PR is warranted; it is not a significance test.
+
+1. `dense_lmc_regional` must beat `block_regional` in held joint residual NLL on both corpora and on at least
+   8 of 10 split seeds per corpus.
+2. `separable_regional` must beat `block_regional` on both corpora and at least 8 of 10 seeds, and recover at
+   least 80% of the dense-LMC NLL gain after macro-averaging the per-scalar gain equally across the 20
+   predeclared corpus/split records (not weighting by held batch size):
+
+   ```text
+   (NLL_block - NLL_separable) / (NLL_block - NLL_dense) >= 0.80.
+   ```
+
+3. Separable posterior NLL may not be worse than the regional block model on either corpus.
+4. Decision log-loss and margin AURC may not worsen by more than 0.01 absolute.
+5. No model may require silently increasing the conditioner's declared relative-loading budget.
+
+If dense LMC helps but the separable model fails, revise the kernel/statistical model rather than optimizing a
+Kronecker operator.  If neither helps, retain the block conditioner.  If the separable model passes, the next
+PR may implement item-kernel diagonalization, small per-eigenmode judge factors, exact correlated online-block
+conditioning, and a matched end-to-end CUDA benchmark that includes whitening.
+
+## Explicit non-claims and separate follow-ups
+
+- This protocol does not establish human or judge-independent quality.
+- It does not show that graph supervision familiarizes the model with a dataset.  That needs the separate
+  training-time graph-supervision × final-fusion factorial ablation.
+- It does not promote `JointPosterior` over the correlated Gaussian model.  `JointPosterior` remains the
+  learned nonlinear decision comparator and should be revisited only with soft macro targets and nested
+  calibration.
+- It does not interpret a fitted kernel component as causal judge noise.  Held predictive performance is the
+  evidence; the component name is a modeling label.
+- It does not claim a CUDA crossover from the earlier compute-only benchmark.  The proposed covariance can
+  make whitening the dominant cost, which must be included in any future timing claim.

--- a/prototypes/mu_cosine/REPORT_structured_residual_covariance.md
+++ b/prototypes/mu_cosine/REPORT_structured_residual_covariance.md
@@ -1,0 +1,180 @@
+# Structured conditional-residual covariance — evidence-gate report
+
+**Run date:** 2026-07-11
+
+**Status:** primary 10-seed run complete; preregistered engineering gate **failed**
+
+**Decision:** retain independent item blocks in the joint square-root/QR conditioner.  Do not build the
+semantic/graph inverse-root or CUDA path from this evidence.
+
+## Bottom line
+
+Frozen semantic and graph-feature proximity did not predict enough transferable cross-item conditional
+residual covariance to justify a more complex conditioner.  Both structured models lost held joint residual
+likelihood on average in both corpora, and their downstream posteriors were worse.  This remained true after
+giving dense LMC an exact block fallback, an exact separable fallback, and a nonzero optimization start.
+
+There is a different, strong signal: a train-fitted regional residual **mean** improved conditional-residual
+NLL on every one of the 20 corpus/split records.  That is evidence for predictable local bias, not correlated
+random measurement noise.  It deserves a separate validation, because its operating-judge decision metrics
+did not improve consistently.
+
+This result does not remove dense correlated batches from the QR conditioner.  The conditioner remains the
+correct general mechanism when a defensible covariance is supplied.  It says that the particular
+semantic/graph covariance model tested here is not a reason to optimize a larger inverse-root/CUDA path.
+
+## Protocol
+
+The split, models, metrics, and gate were frozen in `DESIGN_structured_residual_covariance.md` before the
+first 10-seed result was inspected.
+
+- Target: GPT-5.5 operating-judge D/S and macro-decision fidelity, **not ground truth**.
+- Data: 1,000 matched exploratory rows and 700 matched fresh rows.
+- Splits: seeds 0–9, 40% held nodes, strict node-disjoint retained pairs; crossing pairs dropped.
+- Fitting: calibration, conditionalization, feature scaling, bandwidths, regional mean, covariance, and the
+  decision bridge all use train rows only.
+- Conditional residual: `q = v - C.T P^-1 e`, after removing within-item prior/measurement correlation.
+- Primary comparison: full held joint Gaussian NLL per scalar in original channel units.
+- Structured family: PSD separable kernel covariance and a more flexible additive LMC reference over frozen
+  semantic and graph-feature RBF kernels.
+- Optimizer safeguards: exact block candidate for both structured models, exact separable candidate for dense
+  LMC, a material seed for zero inherited factors, best-iterate retention, and planted nonseparable recovery
+  coverage.
+
+Mean ± SD below describes variation across node partitions; it is not an SE or population confidence
+interval.  A positive gain means the model named in the column is better.
+
+### Implementation-audit chronology
+
+After the first complete run, a read-only code audit found optimizer bookkeeping and zero-factor warm-start
+risks plus incomplete loading/objective metadata.  Those implementation issues were fixed without changing
+the data, split seeds, model families, metrics, or gate.  The hardened rerun added exact submodel fallbacks,
+a material dense start, prior-loading diagnostics, and regression tests.  Its verdict and aggregate values
+reproduced the first run to rounding.  All numbers below are from the hardened rerun.
+
+## Primary residual-likelihood result
+
+| Corpus | Regional mean gain over global block | Separable covariance gain over regional block | Dense LMC gain over regional block |
+|---|---:|---:|---:|
+| Exploratory | +0.181786 ± 0.042311 (10/10 positive) | -0.000575 ± 0.003075 (3/10) | -0.000469 ± 0.003044 (4/10) |
+| Fresh | +0.150996 ± 0.031034 (10/10 positive) | -0.002777 ± 0.003890 (2/10) | -0.002923 ± 0.004101 (2/10) |
+
+The regional block mean NLLs were -0.875663 ± 0.049187 (exploratory) and
+-0.759485 ± 0.042587 (fresh).  Dense LMC did improve its train composite objective over the inherited
+separable candidate on all 20 fits, but only by a very small amount, and that gain did not transfer to held
+joint likelihood.  The negative result is therefore not caused by returning a worse optimizer start.
+
+## Posterior and decision guardrails
+
+All values are the mean gain of `separable_regional` over `block_regional`; positive is better.
+
+| Corpus | Bivariate posterior NLL | Positive seeds | Decision log-loss | Margin AURC | Maximum prior/noise relative loading |
+|---|---:|---:|---:|---:|---:|
+| Exploratory | -0.073120 | 1/10 | -0.009036 | -0.000394 | 0 |
+| Fresh | -0.145861 | 0/10 | -0.041428 | -0.011650 | 0 |
+
+The structured models reduced empirical 95% ellipse coverage as well: regional block → separable was
+0.861 → 0.848 on exploratory and 0.848 → 0.815 on fresh.  This is consistent with harmful confidence from a
+cross-item covariance pattern that did not transfer.
+
+The gate failed independently in several places:
+
+1. Dense LMC did not have positive mean held gain or 8/10 positive seeds in either corpus.
+2. Separable covariance did not have positive mean held gain or 8/10 positive seeds.
+3. The 80% recovery ratio was undefined because the macro-average dense gain was nonpositive.
+4. Posterior NLL worsened in both corpora.
+5. Fresh decision log-loss and AURC exceeded the allowed 0.01 degradation.
+
+The numerical-loading guardrail passed: neither the calibrated prior covariance nor any conditional-noise
+covariance required diagonal loading.
+
+## What the regional-mean result does and does not show
+
+The selected train-only mean was graph-feature kernel ridge on 8/10 exploratory splits, an equal semantic /
+graph-feature mixture on 2/10 exploratory splits, and the equal mixture on all 10 fresh splits.  Its held
+residual-likelihood gain was large and directionally stable.
+
+That does not yet make it a production component.  Relative to the global block baseline, the regional block
+slightly improved mean posterior NLL (+0.00738 exploratory, +0.00604 fresh), but decision log-loss worsened by
+0.00805 and 0.00267 respectively; fresh margin AURC worsened by 0.01030.  The next statistical experiment
+should distinguish a transferable regional bias field from operating-judge-specific smoothing, preferably
+with soft or independent targets and nested calibration.
+
+It also does not test the broader purpose of the graph judge—helping a model learn a dataset.  That requires
+the separate training-time graph-supervision × final-fusion factorial ablation; a post-hoc residual covariance
+test cannot answer it.
+
+## Numerical diagnostics
+
+- Retained held batches ranged from 150–168 items exploratory and 99–116 fresh, corresponding to state
+  dimensions 300–336 / 198–232 and measurement dimensions 600–672 / 396–464.
+- Mean separable off-item Frobenius mass was 0.188 exploratory and 0.115 fresh.  Nonzero fitted mass alone was
+  not evidence: it failed held likelihood.
+- Maximum whitened off-item coupling averaged 0.0447 exploratory and 0.0380 fresh.
+- Materialized separable covariance condition numbers ranged 6.57–37.83 exploratory and 7.29–36.73 fresh.
+- The CPU conditioner call averaged about 0.052 s exploratory and 0.022 s fresh.  This is a diagnostic timing
+  of conditioning after covariance materialization, not an end-to-end or CUDA benchmark.
+
+## Limitations
+
+- The target is one operating judge, not human truth or an independent quality measure.
+- Ten node partitions measure partition stability on one campaign realization; they are not independent
+  experiments or confidence intervals.
+- The graph kernel is an RBF over explicit graph features, not a shortest-path or diffusion kernel.  The
+  existing structural embedding lacks fresh-corpus coverage.
+- Pairwise composite likelihood is a finite-step fitting device.  Exact submodel fallbacks and planted tests
+  reduce optimizer failure risk but do not prove a global optimum.
+- The regional mean is selected from the same train campaign and needs independent/nested validation before
+  deployment.
+
+## Recommendation and next work
+
+1. Keep `I_item kron Rc` as the default covariance for batched QR conditioning.
+2. Do not start the structured inverse-root/CUDA optimization PR now.
+3. Validate the regional mean as a separate bias model, including an augmented regional-bias-state comparator
+   and soft/independent decision targets.
+4. Run the separate graph-supervision × final-fusion factorial experiment to measure dataset familiarization.
+5. Reopen item-kernel diagonalization and matched CUDA timing only if a future preregistered covariance model
+   passes held residual, posterior, decision, and loading guardrails.
+
+`JointPosterior` remains a separate learned nonlinear decision comparator; this experiment neither promotes
+nor rejects it, and it should not be conflated with the square-root/QR numerical conditioner.
+
+## Reproduction and provenance
+
+```bash
+python3 -u prototypes/mu_cosine/run_structured_residual_covariance.py \
+  --artifact-repo /home/s243a/Projects/UnifyWeaver \
+  --ckpt /home/s243a/Projects/UnifyWeaver/prototypes/mu_cosine/model_prod_namecond.pt \
+  --seeds 10 --fit-steps 150 --max-pairs 4096 --bridge-epochs 300 \
+  --cpu-threads 1 \
+  --out /tmp/structured_residual_covariance_10seeds_provenance.json
+```
+
+Input SHA-256:
+
+- `campaign_scored.tsv`: `c2acf399aadd35c3797171d5b42d64e45b07055802092cc28becf308d460ef09`
+- `campaign_scored_luna.tsv`: `a8d951b4fd05f0ca111fbe9d9c23881bb47b790ccb335731113bfd4ae77ffe6e`
+- `model_prod_namecond.pt`: `c1cfc3a3827e42a1993f4286b6a881aee7ff10eb56a76367735b9ec8fdf11f7d`
+- `campaign_100k_e5.pt`: `037396a1d6552892d3d6aa04b3cc12bc6d5e6a532d3697e28da1f28e04810700`
+- `sigma_hop_behavior_slice_e5.pt`: `ab51eb5d07cdd3bed34112a1d92005fcd3f8c46245cf068a7ab0a225afc6cd6b`
+- `data/benchmark/100k_cats/category_parent.tsv`:
+  `4881beedfd876e3abb9f1783cbc3fb8a7350e108e3f531cc4de28ef9956dc8ec`
+- `data/benchmark/enwiki_cats_correct/lmdb_scoped/data.mdb`:
+  `3bcfe59a3f85870f377fad1ea77547f7c3566370f6172e27748f4f7ceba5d690`
+
+LMDB `lock.mdb` is intentionally excluded because it is mutable process state, not graph content.  The runner
+passes `--campaign` to both the target loader and the campaign-row loader and records the exact consumed path.
+
+Exact hardened-run output SHA-256 (the JSON contains wall-clock diagnostics, so an otherwise identical rerun
+need not have the same whole-file hash):
+`c1962b81fa8db981802c05bd9023c21c36e3fde0b852b9e55bce9a7dfa5beea4`
+
+The compact, tracked machine-readable gate and provenance record is
+`repro/structured_residual_covariance/primary_gate_summary.json`.
+
+Validation suite:
+
+```text
+101 passed, 9 skipped
+```

--- a/prototypes/mu_cosine/fine_tune_channel_heads.py
+++ b/prototypes/mu_cosine/fine_tune_channel_heads.py
@@ -90,12 +90,17 @@ CAMPAIGN_SCORED = "/tmp/mu_data/campaign_scored.tsv"
 CAMPAIGN_E5_100K = "/tmp/mu_data/campaign_100k_e5.pt"
 
 
-def load_campaign_datasets():
+def load_campaign_datasets(campaign_scored=None):
     """The stratified campaign, split by corpus membership. Same ds-dict shape as load_dataset; strata tags
-    kept so eval can slice by pair type (the S channel should now have VARIANCE on sib/cous rows)."""
+    kept so eval can slice by pair type (the S channel should now have VARIANCE on sib/cous rows).
+
+    ``campaign_scored`` is explicit for provenance-sensitive runners; existing callers retain the canonical
+    campaign default.
+    """
+    campaign_scored = CAMPAIGN_SCORED if campaign_scored is None else os.path.abspath(campaign_scored)
     DIRR = ["subcategory", "subtopic", "element_of", "super_category"]; SYMM = ["see_also", "assoc"]
     rows = []
-    with open(CAMPAIGN_SCORED, encoding="utf-8") as f:
+    with open(campaign_scored, encoding="utf-8") as f:
         header = f.readline().lstrip("#").strip().split("\t")
         col = {c: i for i, c in enumerate(header)}
         for ln in f:

--- a/prototypes/mu_cosine/repro/structured_residual_covariance/primary_gate_summary.json
+++ b/prototypes/mu_cosine/repro/structured_residual_covariance/primary_gate_summary.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 1,
+  "run_date": "2026-07-11",
+  "protocol": "structured conditional residual covariance evidence gate; strict node-disjoint; train-only fitting",
+  "target_scope": "GPT-5.5 operating-judge fidelity; not independent ground truth",
+  "full_output": {
+    "filename": "structured_residual_covariance_10seeds_provenance.json",
+    "size_bytes": 532137,
+    "sha256": "c1962b81fa8db981802c05bd9023c21c36e3fde0b852b9e55bce9a7dfa5beea4",
+    "note": "The full JSON contains wall-clock diagnostics, so an otherwise identical rerun need not have the same whole-file hash."
+  },
+  "inputs": {
+    "campaign_scored.tsv": {
+      "sha256": "c2acf399aadd35c3797171d5b42d64e45b07055802092cc28becf308d460ef09"
+    },
+    "campaign_scored_luna.tsv": {
+      "sha256": "a8d951b4fd05f0ca111fbe9d9c23881bb47b790ccb335731113bfd4ae77ffe6e"
+    },
+    "model_prod_namecond.pt": {
+      "sha256": "c1cfc3a3827e42a1993f4286b6a881aee7ff10eb56a76367735b9ec8fdf11f7d"
+    },
+    "campaign_100k_e5.pt": {
+      "size_bytes": 28284878,
+      "sha256": "037396a1d6552892d3d6aa04b3cc12bc6d5e6a532d3697e28da1f28e04810700"
+    },
+    "sigma_hop_behavior_slice_e5.pt": {
+      "size_bytes": 239602704,
+      "sha256": "ab51eb5d07cdd3bed34112a1d92005fcd3f8c46245cf068a7ab0a225afc6cd6b"
+    },
+    "data/benchmark/100k_cats/category_parent.tsv": {
+      "size_bytes": 10126922,
+      "sha256": "4881beedfd876e3abb9f1783cbc3fb8a7350e108e3f531cc4de28ef9956dc8ec"
+    },
+    "data/benchmark/enwiki_cats_correct/lmdb_scoped/data.mdb": {
+      "size_bytes": 1319403520,
+      "sha256": "3bcfe59a3f85870f377fad1ea77547f7c3566370f6172e27748f4f7ceba5d690"
+    }
+  },
+  "configuration": {
+    "seeds": 10,
+    "held_node_fraction": 0.4,
+    "split_candidates": 64,
+    "shrinkage": 0.05,
+    "ridge_grid": [0.001, 0.01, 0.1, 1.0, 10.0],
+    "fit_steps": 150,
+    "learning_rate": 0.03,
+    "max_pairs": 4096,
+    "bridge_epochs": 300,
+    "quad_order": 5,
+    "maximum_relative_loading": 0.001,
+    "cpu_threads": 1
+  },
+  "engineering_gate": {
+    "by_corpus": {
+      "exploratory": {
+        "block_nll_mean_sd": [-0.8756625013119601, 0.04918711805420144],
+        "dense_gain_mean_sd": [-0.00046912077253226104, 0.003044221534856325],
+        "dense_positive_seeds": 4,
+        "maximum_relative_diagonal_loading": 0.0,
+        "regional_mean_gain_vs_global_block_mean_sd": [0.18178562669192305, 0.042310776817244454],
+        "regional_mean_positive_seeds": 10,
+        "separable_decision_aurc_gain_mean": -0.00039432326869700933,
+        "separable_decision_log_loss_gain_mean": -0.009035549625988449,
+        "separable_gain_mean_sd": [-0.0005749954258351009, 0.0030753449825658887],
+        "separable_positive_seeds": 3,
+        "separable_posterior_nll_gain_mean": -0.07312029215932134,
+        "separable_posterior_nll_positive_seeds": 1,
+        "split_seeds": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+      },
+      "fresh": {
+        "block_nll_mean_sd": [-0.7594847356743704, 0.042587496928159774],
+        "dense_gain_mean_sd": [-0.0029234812458911463, 0.004101461857255718],
+        "dense_positive_seeds": 2,
+        "maximum_relative_diagonal_loading": 0.0,
+        "regional_mean_gain_vs_global_block_mean_sd": [0.15099569650412423, 0.03103409136582324],
+        "regional_mean_positive_seeds": 10,
+        "separable_decision_aurc_gain_mean": -0.01164978315489992,
+        "separable_decision_log_loss_gain_mean": -0.04142822279739848,
+        "separable_gain_mean_sd": [-0.002777475248013528, 0.0038899331760688313],
+        "separable_positive_seeds": 2,
+        "separable_posterior_nll_gain_mean": -0.1458614669515629,
+        "separable_posterior_nll_positive_seeds": 0,
+        "split_seeds": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+      }
+    },
+    "dense_lmc_passes_direction_and_stability": false,
+    "gate_evaluable": true,
+    "loading_budget_guardrail_passes": true,
+    "macro_split_separable_fraction_of_dense_gain": null,
+    "note": "10-seed direction, stability, posterior, decision, and loading guardrails evaluated",
+    "passes_80_percent_recovery": false,
+    "separable_decision_guardrail_passes": false,
+    "separable_passes_direction_and_stability": false,
+    "separable_posterior_nll_guardrail_passes": false,
+    "structured_covariance_gate_passes": false,
+    "recommendation": "retain block covariance; do not optimize structured inverse-root/CUDA from this evidence"
+  }
+}

--- a/prototypes/mu_cosine/run_structured_residual_covariance.py
+++ b/prototypes/mu_cosine/run_structured_residual_covariance.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+"""Held node-disjoint evidence gate for cross-item conditional residual covariance.
+
+This runner reuses the post-#3648 campaign calibration and residual convention.  It first removes the
+within-item prior/measurement cross term, then asks whether the remaining conditional residual ``q`` is
+predictable/correlated across campaign rows in frozen semantic or graph-feature geometry.
+
+The target is GPT-5.5 operating-judge fidelity, not ground truth.  No new judge calls are made.  See
+``DESIGN_structured_residual_covariance.md`` for the preregistered models, metrics, and go/no-go rule.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+from collections import Counter
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from eval_luna_transfer import load_luna as load_scored_mu_tsv
+from emit_transitive_hops import hit_prob
+from fine_tune_channel_heads import CAMPAIGN_E5_100K, load_campaign_datasets, load_expanded
+from fine_tune_fused_head import agnostic_readouts
+from mu_posterior import JointPosterior, _eval, aurc, margin_conf
+from node_disjoint_eval import format_split_diagnostics, node_disjoint_pair_split
+from run_cheap_judge_joint_posterior import (
+    CLASSES,
+    calibrate_sources,
+    gaussian_bridge_proba,
+    load_decision_targets,
+)
+from run_product_kalman_logit import dequant
+from run_product_kalman_realdata import DATASETS
+from run_sym_channel_fusion import H4, sym_graph_features
+from sigma_hop_confirmatory import FeatureGraphConfig, load_feature_graph
+from structured_residual_covariance import (
+    condition_item_batch,
+    conditional_residuals,
+    fit_block_model,
+    fit_lmc_model,
+    gaussian_joint_nll,
+    median_rbf_bandwidth,
+    off_block_diagnostics,
+    rbf_kernel,
+    select_kernel_ridge_mean,
+)
+
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_CAMPAIGN = "/tmp/mu_data/campaign_scored.tsv"
+DEFAULT_LUNA = "/tmp/mu_data/campaign_scored_luna.tsv"
+MODEL_NAMES = (
+    "block_global",
+    "block_regional",
+    "separable_regional",
+    "dense_lmc_regional",
+)
+CHI2_2_95 = 5.991464547107979
+
+
+def sha256_file(path):
+    """Hash one immutable input without loading it all into memory."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        while True:
+            chunk = stream.read(1 << 20)
+            if not chunk:
+                return digest.hexdigest()
+            digest.update(chunk)
+
+
+def file_provenance(path):
+    """Absolute path, byte size, and content hash for an outcome-determining regular file."""
+    path = os.path.abspath(path)
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"missing provenance file: {path}")
+    return {
+        "path": path,
+        "size_bytes": os.path.getsize(path),
+        "sha256": sha256_file(path),
+    }
+
+
+def configure_artifact_repo(repo):
+    """Point ignored graph artifacts at a checkout that owns them.
+
+    Git worktrees intentionally do not duplicate ignored checkpoints/LMDB stores.  Mutating the shared
+    ``DATASETS`` dictionary before calling the canonical loader keeps the loader itself unchanged and makes
+    the external-artifact dependency explicit in result provenance.
+    """
+    repo = os.path.abspath(repo)
+    exploratory = os.path.join(repo, "data", "benchmark", "100k_cats", "category_parent.tsv")
+    fresh = os.path.join(repo, "data", "benchmark", "enwiki_cats_correct", "lmdb_scoped")
+    if not os.path.isfile(exploratory):
+        raise FileNotFoundError(f"missing exploratory graph: {exploratory}")
+    if not os.path.isdir(fresh):
+        raise FileNotFoundError(f"missing fresh LMDB graph: {fresh}")
+    DATASETS["exploratory"]["graph"]["graph"] = exploratory
+    DATASETS["fresh"]["graph"]["candidate_lmdb"] = fresh
+    DATASETS["fresh"]["graph"]["exploratory_graph"] = exploratory
+    fresh_data = os.path.join(fresh, "data.mdb")
+    return {
+        "repository": repo,
+        "exploratory_graph": file_provenance(exploratory),
+        "fresh_lmdb_directory": fresh,
+        "fresh_lmdb_data": file_provenance(fresh_data),
+        "fresh_lmdb_lock_excluded": "lock.mdb is process state, not graph content",
+    }
+
+
+def semantic_pair_features(ds, pairs):
+    """Normalized outcome-blind row features: ``[passage(node), query(root)]``."""
+    rows = []
+    for node, root in pairs:
+        try:
+            left = ds["tok"].p[ds["tok"].idx[node]].detach().cpu().numpy()
+            right = ds["tok"].q[ds["tok"].idx[root]].detach().cpu().numpy()
+        except KeyError as exc:
+            raise ValueError(f"pair endpoint is absent from the frozen e5 cache: {exc.args[0]!r}") from exc
+        rows.append(np.concatenate([left, right]))
+    features = np.asarray(rows, dtype=float)
+    norm = np.linalg.norm(features, axis=1, keepdims=True)
+    if np.any(norm == 0) or not np.isfinite(features).all():
+        raise ValueError("semantic pair features must be finite and nonzero")
+    return features / norm
+
+
+def train_standardize(features, train):
+    """Fit a feature standardizer on train rows and apply it to every row."""
+    features = np.asarray(features, dtype=float)
+    train = np.asarray(train, dtype=int)
+    if features.ndim != 2 or len(train) == 0 or not np.isfinite(features).all():
+        raise ValueError("features must be a finite matrix with non-empty train indices")
+    mean = features[train].mean(axis=0)
+    scale = features[train].std(axis=0)
+    scale = np.where(scale > 1e-12, scale, 1.0)
+    return (features - mean) / scale, mean, scale
+
+
+def decision_metrics(proba, labels):
+    """Operating-judge decision metrics; AURC uses margin confidence and no row bootstrap."""
+    labels = np.asarray(labels)
+    relation_index = {name: i for i, name in enumerate(CLASSES)}
+    accuracy, log_loss, ece = _eval(proba, labels, relation_index, bins=10)
+    target = np.asarray([relation_index[value] for value in labels], dtype=int)
+    correct = proba.argmax(axis=1) == target
+    return {
+        "accuracy": accuracy,
+        "log_loss": log_loss,
+        "ece_10_equal_width": ece,
+        "aurc_margin": aurc(margin_conf(proba), correct),
+    }
+
+
+def state_metrics(observed, mean, marginal_covariances):
+    """Per-item bivariate posterior diagnostics from marginal 2x2 covariance blocks."""
+    observed = np.asarray(observed, dtype=float)
+    mean = np.asarray(mean, dtype=float)
+    covariance = np.asarray(marginal_covariances, dtype=float)
+    if observed.shape != mean.shape or observed.ndim != 2 or observed.shape[1] != 2:
+        raise ValueError("observed and mean must both be [N,2]")
+    if covariance.shape != (len(mean), 2, 2):
+        raise ValueError("marginal_covariances must be [N,2,2]")
+    error = observed - mean
+    nll, mahal = [], []
+    for value, cov in zip(error, covariance):
+        sign, logdet = np.linalg.slogdet(cov)
+        if sign <= 0:
+            raise np.linalg.LinAlgError("posterior marginal covariance is not positive definite")
+        m = float(value @ np.linalg.solve(cov, value))
+        mahal.append(m)
+        nll.append(0.5 * (m + logdet + 2.0 * np.log(2.0 * np.pi)))
+    mahal = np.asarray(mahal)
+    return {
+        "mean_bivariate_nll": float(np.mean(nll)),
+        "mse_per_scalar": float(np.mean(error * error)),
+        "mahalanobis_per_dimension": float(np.mean(mahal) / 2.0),
+        "coverage_95_bivariate_ellipse": float(np.mean(mahal <= CHI2_2_95)),
+    }
+
+
+def _kernel_geometry(semantic, graph, train, held):
+    semantic_length = median_rbf_bandwidth(semantic[train])
+    graph_length = median_rbf_bandwidth(graph[train])
+    kernels_train = {
+        "semantic": rbf_kernel(semantic[train], length_scale=semantic_length),
+        "graph_feature": rbf_kernel(graph[train], length_scale=graph_length),
+    }
+    kernels_train["equal_mixture"] = 0.5 * (
+        kernels_train["semantic"] + kernels_train["graph_feature"]
+    )
+    kernels_cross = {
+        "semantic": rbf_kernel(semantic[held], semantic[train], length_scale=semantic_length),
+        "graph_feature": rbf_kernel(graph[held], graph[train], length_scale=graph_length),
+    }
+    kernels_cross["equal_mixture"] = 0.5 * (
+        kernels_cross["semantic"] + kernels_cross["graph_feature"]
+    )
+    held_semantic = rbf_kernel(semantic[held], length_scale=semantic_length)
+    held_graph = rbf_kernel(graph[held], length_scale=graph_length)
+    return kernels_train, kernels_cross, held_semantic, held_graph, semantic_length, graph_length
+
+
+def _model_record(model, held_semantic, held_graph, centered_held, block_size):
+    covariance = model.materialize(held_semantic, held_graph)
+    nll = gaussian_joint_nll(centered_held, covariance)
+    diagnostics = off_block_diagnostics(covariance, block_size)
+    return covariance, {
+        "held_joint_residual_nll": float(nll.total),
+        "held_joint_residual_nll_per_scalar": float(nll.per_scalar),
+        "fit": model.to_dict(),
+        "diagnostics": diagnostics.to_dict(),
+    }
+
+
+def _posterior_record(split, held, conditional_design, residual_mean, covariance, bridge, hard_target, args):
+    prior = split.prior[held]
+    measurement = split.meas[held]
+    innovation = measurement - prior @ H4.T - residual_mean
+    started = time.perf_counter()
+    conditioned = condition_item_batch(
+        split.P0,
+        conditional_design,
+        innovation,
+        covariance,
+        maximum_relative_loading=args.maximum_relative_loading,
+    )
+    elapsed = time.perf_counter() - started
+    posterior_mean = prior + conditioned.state_mean
+    state = state_metrics(split.y_ds[held], posterior_mean, conditioned.marginal_covariances)
+    probability = gaussian_bridge_proba(
+        bridge, posterior_mean, conditioned.marginal_covariances, order=args.quad_order
+    )
+    return {
+        "state": state,
+        "decision": decision_metrics(probability, hard_target[held]),
+        "conditioner": {
+            "wall_seconds": elapsed,
+            "state_dimension": int(2 * len(held)),
+            "measurement_dimension": int(H4.shape[0] * len(held)),
+            "loading": conditioned.loading_diagnostics,
+            "prior_loading": conditioned.prior_loading_diagnostics,
+        },
+    }
+
+
+def materialize_corpus(name, ds, target_by_pair, luna_by_pair, checkpoint):
+    """Compute seed-independent campaign sources and geometry once per corpus."""
+    corpus = name.replace("-campaign", "")
+    parents, _, _, _ = load_feature_graph(FeatureGraphConfig(**DATASETS[corpus]["graph"]))
+    parents = {node: tuple(sorted(values)) for node, values in parents.items()}
+    ds["tok"].parents = parents
+    model, _ = checkpoint
+    readout = agnostic_readouts(model, ds, "cpu")
+    keep = [
+        i for i, pair in enumerate(ds["pairs"])
+        if pair in target_by_pair and pair in luna_by_pair
+    ]
+    pairs = [ds["pairs"][i] for i in keep]
+    if len(pairs) != len(set(pairs)):
+        raise ValueError("structured residual comparison requires unique pairs")
+    tags = np.asarray([ds["tags"][i] for i in keep])
+    y_ds = dequant(np.column_stack([ds["D"][keep], ds["S"][keep]]))
+    prior = np.column_stack([readout["prior_D"][keep], readout["prior_S"][keep]])
+    graph_d_raw = np.asarray([hit_prob(parents, node, root) for node, root in pairs])
+    graph_s_features = sym_graph_features(parents, pairs)
+    graph_item_raw = np.column_stack([graph_d_raw, graph_s_features])
+    luna = np.asarray([luna_by_pair[pair] for pair in pairs], dtype=float)
+    hard_target = np.asarray([target_by_pair[pair][1] for pair in pairs])
+    semantic = semantic_pair_features(ds, pairs)
+    return {
+        "pairs": pairs,
+        "tags": tags,
+        "y_ds": y_ds,
+        "prior": prior,
+        "graph_d_raw": graph_d_raw,
+        "graph_s_features": graph_s_features,
+        "graph_item_raw": graph_item_raw,
+        "luna": luna,
+        "hard_target": hard_target,
+        "semantic": semantic,
+    }
+
+
+def run_corpus(name, ds, target_by_pair, luna_by_pair, checkpoint, seed, args):
+    corpus = name.replace("-campaign", "")
+    cache_key = "_structured_residual_covariance_cache"
+    if cache_key not in ds:
+        ds[cache_key] = materialize_corpus(name, ds, target_by_pair, luna_by_pair, checkpoint)
+    materialized = ds[cache_key]
+    pairs = materialized["pairs"]
+    tags = materialized["tags"]
+    y_ds = materialized["y_ds"]
+    prior = materialized["prior"]
+    graph_d_raw = materialized["graph_d_raw"]
+    graph_s_features = materialized["graph_s_features"]
+    graph_item_raw = materialized["graph_item_raw"]
+    luna = materialized["luna"]
+    hard_target = materialized["hard_target"]
+    semantic = materialized["semantic"]
+
+    split_spec = node_disjoint_pair_split(
+        pairs,
+        seed,
+        held_node_fraction=args.held_node_fraction,
+        strata=tags,
+        candidates=args.split_candidates,
+        minimum_per_stratum=args.minimum_per_stratum,
+    )
+    train, held = split_spec.train, split_spec.held
+    if not len(train) or not len(held):
+        raise ValueError(f"{name} seed {seed} produced an empty retained partition")
+    calibrated = calibrate_sources(prior, graph_d_raw, graph_s_features, luna, y_ds, train)
+    observed_measurement_state = y_ds[:, [0, 1, 0, 1]]
+    prior_error = y_ds - calibrated.prior
+    measurement_error = calibrated.meas - observed_measurement_state
+    conditional_design, q = conditional_residuals(
+        prior_error, measurement_error, calibrated.P0, calibrated.C_pm, H4
+    )
+
+    graph_item, graph_mean, graph_scale = train_standardize(graph_item_raw, train)
+    geometry = _kernel_geometry(semantic, graph_item, train, held)
+    kernels_train, kernels_cross, held_semantic, held_graph, sem_length, graph_length = geometry
+    regional = select_kernel_ridge_mean(
+        q[train], kernels_train, ridge_grid=args.ridge_grid
+    )
+    held_regional_mean = regional.predict(kernels_cross[regional.kernel_name])
+    global_mean = np.mean(q[train], axis=0)
+
+    block_global = fit_block_model(q[train] - global_mean, shrinkage=args.shrinkage)
+    block_regional = fit_block_model(regional.loo_residuals, shrinkage=args.shrinkage)
+    separable = fit_lmc_model(
+        regional.loo_residuals,
+        kernels_train["semantic"],
+        kernels_train["graph_feature"],
+        kind="separable",
+        steps=args.fit_steps,
+        learning_rate=args.learning_rate,
+        max_pairs=args.max_pairs,
+        seed=4000 + seed,
+    )
+    dense_lmc = fit_lmc_model(
+        regional.loo_residuals,
+        kernels_train["semantic"],
+        kernels_train["graph_feature"],
+        kind="dense_lmc",
+        steps=args.fit_steps,
+        learning_rate=args.learning_rate,
+        max_pairs=args.max_pairs,
+        seed=4000 + seed,
+        initial_model=separable,
+    )
+    fits = {
+        "block_global": block_global,
+        "block_regional": block_regional,
+        "separable_regional": separable,
+        "dense_lmc_regional": dense_lmc,
+    }
+    held_means = {
+        "block_global": np.broadcast_to(global_mean, (len(held), len(global_mean))),
+        "block_regional": held_regional_mean,
+        "separable_regional": held_regional_mean,
+        "dense_lmc_regional": held_regional_mean,
+    }
+    bridge = JointPosterior(CLASSES, n_features=2, hidden=0, seed=3000 + seed).fit(
+        y_ds[train], hard_target[train], epochs=args.bridge_epochs
+    )
+
+    records = {}
+    for model_name in MODEL_NAMES:
+        centered = q[held] - held_means[model_name]
+        covariance, record = _model_record(
+            fits[model_name], held_semantic, held_graph, centered, H4.shape[0]
+        )
+        record["posterior"] = _posterior_record(
+            calibrated,
+            held,
+            conditional_design,
+            held_means[model_name],
+            covariance,
+            bridge,
+            hard_target,
+            args,
+        )
+        records[model_name] = record
+
+    return {
+        "corpus": corpus,
+        "seed": seed,
+        "target_frame": "GPT-5.5 operating-judge D/S and macro-decision fidelity; not ground truth",
+        "split": {
+            "diagnostics": format_split_diagnostics(split_spec),
+            "train_rows": len(train),
+            "held_rows": len(held),
+            "cross_rows_dropped": len(split_spec.cross),
+            "train_nodes": len(split_spec.train_nodes),
+            "held_nodes": len(split_spec.held_nodes),
+            "selected_candidate": split_spec.selected_candidate,
+            "candidates": split_spec.candidates,
+            "stratification": "campaign neighborhood tag; outcome-blind",
+            "train_tags": dict(Counter(map(str, tags[train]))),
+            "held_tags": dict(Counter(map(str, tags[held]))),
+        },
+        "geometry": {
+            "semantic_feature": "normalized concat(passage(node), query(root))",
+            "graph_feature": "train-standardized [hit_prob, *sym_graph_features]; not shortest-path",
+            "semantic_rbf_bandwidth": sem_length,
+            "graph_feature_rbf_bandwidth": graph_length,
+            "graph_standardizer_mean": graph_mean.tolist(),
+            "graph_standardizer_scale": graph_scale.tolist(),
+            "regional_mean": regional.to_dict(),
+        },
+        "conditional_model": {
+            "signs": "e=truth-prior; v=measurement-H truth; q=v-C.T P^-1 e",
+            "prior_covariance": calibrated.P0.tolist(),
+            "prior_measurement_cross_covariance": calibrated.C_pm.tolist(),
+            "conditional_design": conditional_design.tolist(),
+            "train_global_q_mean": global_mean.tolist(),
+        },
+        "models": records,
+    }
+
+
+def aggregate_gate(results):
+    """Apply the predeclared engineering gate to completed split records."""
+    summary = {}
+    for corpus in sorted({row["corpus"] for row in results}):
+        rows = [row for row in results if row["corpus"] == corpus]
+        block = np.asarray([
+            row["models"]["block_regional"]["held_joint_residual_nll_per_scalar"]
+            for row in rows
+        ])
+        separable = np.asarray([
+            row["models"]["separable_regional"]["held_joint_residual_nll_per_scalar"]
+            for row in rows
+        ])
+        dense = np.asarray([
+            row["models"]["dense_lmc_regional"]["held_joint_residual_nll_per_scalar"]
+            for row in rows
+        ])
+        dense_gain, separable_gain = block - dense, block - separable
+        global_block = np.asarray([
+            row["models"]["block_global"]["held_joint_residual_nll_per_scalar"]
+            for row in rows
+        ])
+        regional_gain = global_block - block
+
+        def secondary_gain(model, path):
+            values = []
+            for row in rows:
+                baseline = row["models"]["block_regional"]
+                candidate = row["models"][model]
+                for key in path:
+                    baseline, candidate = baseline[key], candidate[key]
+                values.append(float(baseline) - float(candidate))
+            return np.asarray(values)
+
+        separable_posterior = secondary_gain(
+            "separable_regional", ("posterior", "state", "mean_bivariate_nll")
+        )
+        separable_log_loss = secondary_gain(
+            "separable_regional", ("posterior", "decision", "log_loss")
+        )
+        separable_aurc = secondary_gain(
+            "separable_regional", ("posterior", "decision", "aurc_margin")
+        )
+        loading = np.asarray([
+            value
+            for row in rows
+            for model_name in MODEL_NAMES
+            for value in (
+                row["models"][model_name]["posterior"]["conditioner"]["loading"]
+                ["relative_diagonal_loading"],
+                row["models"][model_name]["posterior"]["conditioner"].get(
+                    "prior_loading", {"relative_diagonal_loading": 0.0}
+                )["relative_diagonal_loading"],
+            )
+        ])
+        summary[corpus] = {
+            "split_seeds": [row["seed"] for row in rows],
+            "block_nll_mean_sd": [float(block.mean()), float(block.std(ddof=1)) if len(block) > 1 else 0.0],
+            "dense_gain_mean_sd": [
+                float(dense_gain.mean()), float(dense_gain.std(ddof=1)) if len(rows) > 1 else 0.0,
+            ],
+            "dense_positive_seeds": int(np.sum(dense_gain > 0)),
+            "separable_gain_mean_sd": [
+                float(separable_gain.mean()),
+                float(separable_gain.std(ddof=1)) if len(rows) > 1 else 0.0,
+            ],
+            "separable_positive_seeds": int(np.sum(separable_gain > 0)),
+            "regional_mean_gain_vs_global_block_mean_sd": [
+                float(regional_gain.mean()),
+                float(regional_gain.std(ddof=1)) if len(rows) > 1 else 0.0,
+            ],
+            "regional_mean_positive_seeds": int(np.sum(regional_gain > 0)),
+            "separable_posterior_nll_gain_mean": float(separable_posterior.mean()),
+            "separable_posterior_nll_positive_seeds": int(np.sum(separable_posterior > 0)),
+            "separable_decision_log_loss_gain_mean": float(separable_log_loss.mean()),
+            "separable_decision_aurc_gain_mean": float(separable_aurc.mean()),
+            "maximum_relative_diagonal_loading": float(np.max(loading)),
+        }
+    expected_corpora = {"exploratory", "fresh"}
+    expected_seeds = set(range(10))
+    complete_primary_run = set(summary) == expected_corpora and all(
+        len(value["split_seeds"]) == 10
+        and set(value["split_seeds"]) == expected_seeds
+        for value in summary.values()
+    )
+    required = 8 if complete_primary_run else None
+    dense_ok = required is not None and all(
+        value["dense_gain_mean_sd"][0] > 0 and value["dense_positive_seeds"] >= required
+        for value in summary.values()
+    )
+    separable_ok = required is not None and all(
+        value["separable_gain_mean_sd"][0] > 0 and value["separable_positive_seeds"] >= required
+        for value in summary.values()
+    )
+    dense_gain = sum(value["dense_gain_mean_sd"][0] for value in summary.values())
+    separable_gain = sum(value["separable_gain_mean_sd"][0] for value in summary.values())
+    macro_split_recovery = separable_gain / dense_gain if dense_gain > 0 else None
+    posterior_guardrail = all(
+        value["separable_posterior_nll_gain_mean"] >= 0.0 for value in summary.values()
+    )
+    decision_guardrail = all(
+        value["separable_decision_log_loss_gain_mean"] >= -0.01
+        and value["separable_decision_aurc_gain_mean"] >= -0.01
+        for value in summary.values()
+    )
+    loading_guardrail = all(
+        value["maximum_relative_diagonal_loading"] <= 1e-3 for value in summary.values()
+    )
+    statistical_gate = (
+        dense_ok
+        and separable_ok
+        and macro_split_recovery is not None
+        and macro_split_recovery >= 0.80
+        and posterior_guardrail
+        and decision_guardrail
+        and loading_guardrail
+    )
+    return {
+        "by_corpus": summary,
+        "gate_evaluable": required is not None,
+        "dense_lmc_passes_direction_and_stability": dense_ok,
+        "separable_passes_direction_and_stability": separable_ok,
+        "macro_split_separable_fraction_of_dense_gain": macro_split_recovery,
+        "passes_80_percent_recovery": (
+            macro_split_recovery is not None and macro_split_recovery >= 0.80
+        ),
+        "separable_posterior_nll_guardrail_passes": posterior_guardrail,
+        "separable_decision_guardrail_passes": decision_guardrail,
+        "loading_budget_guardrail_passes": loading_guardrail,
+        "structured_covariance_gate_passes": statistical_gate,
+        "recommendation": (
+            "proceed to optimized inverse-root/CUDA work"
+            if statistical_gate else
+            "retain block covariance; do not optimize structured inverse-root/CUDA from this evidence"
+        ),
+        "note": (
+            "10-seed direction, stability, posterior, decision, and loading guardrails evaluated"
+            if required is not None else
+            "fewer than 10 seeds: smoke/descriptive result only; predeclared 8/10 gate not evaluated"
+        ),
+    }
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-repo", default=os.path.abspath(os.path.join(ROOT, "..", "..")))
+    parser.add_argument("--ckpt", default=os.path.join(ROOT, "model_prod_namecond.pt"))
+    parser.add_argument("--campaign", default=DEFAULT_CAMPAIGN)
+    parser.add_argument("--luna", default=DEFAULT_LUNA)
+    parser.add_argument("--seeds", type=int, default=10)
+    parser.add_argument("--held-node-fraction", type=float, default=0.40)
+    parser.add_argument("--split-candidates", type=int, default=64)
+    parser.add_argument("--minimum-per-stratum", type=int, default=1)
+    parser.add_argument("--shrinkage", type=float, default=0.05)
+    parser.add_argument("--ridge-grid", type=float, nargs="+", default=[1e-3, 1e-2, 1e-1, 1.0, 10.0])
+    parser.add_argument("--fit-steps", type=int, default=150)
+    parser.add_argument("--learning-rate", type=float, default=0.03)
+    parser.add_argument("--max-pairs", type=int, default=4096)
+    parser.add_argument("--bridge-epochs", type=int, default=300)
+    parser.add_argument("--quad-order", type=int, default=5)
+    parser.add_argument("--maximum-relative-loading", type=float, default=1e-3)
+    parser.add_argument("--cpu-threads", type=int, default=1)
+    parser.add_argument("--out", default="/tmp/structured_residual_covariance.json")
+    return parser
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    if args.seeds < 1:
+        raise ValueError("--seeds must be positive")
+    torch.set_num_threads(args.cpu_threads)
+    np.random.seed(0)
+    artifacts = configure_artifact_repo(args.artifact_repo)
+    target_by_pair, cur_rel = load_decision_targets(args.campaign)
+    luna_pairs, luna_d, luna_s = load_scored_mu_tsv(args.luna)
+    luna_by_pair = {pair: (luna_d[i], luna_s[i]) for i, pair in enumerate(luna_pairs)}
+    checkpoint = load_expanded(args.ckpt, dev="cpu")
+    checkpoint[0].eval()
+    datasets = load_campaign_datasets(campaign_scored=args.campaign)
+    results = []
+    for seed in range(args.seeds):
+        for name, dataset in datasets.items():
+            print(f"\n=== structured residual covariance: {name}, split seed {seed} ===", flush=True)
+            row = run_corpus(name, dataset, target_by_pair, luna_by_pair, checkpoint, seed, args)
+            results.append(row)
+            for model_name in MODEL_NAMES:
+                model = row["models"][model_name]
+                print(
+                    f"  {model_name:22s} q-NLL/scalar "
+                    f"{model['held_joint_residual_nll_per_scalar']:+.6f}; "
+                    f"posterior NLL {model['posterior']['state']['mean_bivariate_nll']:+.6f}; "
+                    f"decision logloss {model['posterior']['decision']['log_loss']:.6f}",
+                    flush=True,
+                )
+    payload = {
+        "protocol": "structured conditional residual covariance evidence gate; strict node-disjoint; train-only fitting",
+        "target_scope": "GPT-5.5 operating-judge fidelity; not independent ground truth",
+        "inputs": {
+            "checkpoint": os.path.abspath(args.ckpt),
+            "checkpoint_sha256": sha256_file(args.ckpt),
+            "campaign": os.path.abspath(args.campaign),
+            "campaign_sha256": sha256_file(args.campaign),
+            "luna": os.path.abspath(args.luna),
+            "luna_sha256": sha256_file(args.luna),
+            "artifact_paths": artifacts,
+            "e5_caches": {
+                "exploratory": file_provenance(CAMPAIGN_E5_100K),
+                "fresh": file_provenance(DATASETS["fresh"]["e5_cache"]),
+            },
+            "campaign_cur_rel_counts": dict(cur_rel),
+        },
+        "configuration": vars(args),
+        "results": results,
+        "engineering_gate": aggregate_gate(results),
+    }
+    with open(args.out, "w", encoding="utf-8") as stream:
+        json.dump(payload, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+    print(f"\nwrote {args.out}")
+    print(json.dumps(payload["engineering_gate"], indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/structured_residual_covariance.py
+++ b/prototypes/mu_cosine/structured_residual_covariance.py
@@ -1,0 +1,719 @@
+#!/usr/bin/env python3
+"""PSD structured cross-item covariance for conditional judge residuals.
+
+The fitted family is an additive linear model of coregionalisation (LMC),
+
+    Rc = I_item kron B0 + K_sem kron B_sem + K_graph kron B_graph,
+
+with every channel component parameterized as ``B = L L.T``.  The module keeps statistical nugget covariance
+inside ``B0`` separate from the existing conditioner's observable numerical loading.
+
+All arrays use item-major order: the channels for item 0 are contiguous, followed by the channels for item 1.
+Fitting is deterministic CPU float64 pairwise composite likelihood.  Held evaluation uses the full materialized
+covariance; pair terms are an optimization device, not independent evidence.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+import numpy as np
+import torch
+
+from joint_square_root_conditioner_torch import (
+    SquareRootInformationStateTorch,
+    precision_root_from_covariance_torch,
+    prepare_noise_whitener_torch,
+)
+
+
+LOG2PI = math.log(2.0 * math.pi)
+
+
+def _matrix(name, value, *, rows=None, cols=None):
+    array = np.asarray(value, dtype=float)
+    if array.ndim != 2:
+        raise ValueError(f"{name} must be a matrix")
+    if rows is not None and array.shape[0] != rows:
+        raise ValueError(f"{name} has {array.shape[0]} rows, expected {rows}")
+    if cols is not None and array.shape[1] != cols:
+        raise ValueError(f"{name} has {array.shape[1]} columns, expected {cols}")
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must be finite")
+    return array
+
+
+def _symmetric(name, value, *, dimension=None):
+    array = _matrix(name, value)
+    if array.shape[0] != array.shape[1]:
+        raise ValueError(f"{name} must be square")
+    if dimension is not None and array.shape != (dimension, dimension):
+        raise ValueError(f"{name} must have shape {(dimension, dimension)}")
+    scale = max(float(np.max(np.abs(array), initial=0.0)), 1.0)
+    if not np.allclose(array, array.T, rtol=0.0, atol=128 * np.finfo(float).eps * scale):
+        raise ValueError(f"{name} must be symmetric")
+    return 0.5 * (array + array.T)
+
+
+def _positive_finite(name, value):
+    value = float(value)
+    if not np.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be positive and finite")
+    return value
+
+
+def _psd_floor(covariance, relative_floor=1e-10):
+    """Return a symmetric SPD covariance and the explicit absolute loading used."""
+    covariance = _symmetric("covariance", covariance)
+    relative_floor = _positive_finite("relative_floor", relative_floor)
+    eigenvalues = np.linalg.eigvalsh(covariance)
+    scale = max(float(np.max(np.abs(eigenvalues), initial=0.0)), np.finfo(float).tiny)
+    target = relative_floor * scale
+    loading = max(target - float(eigenvalues[0]), 0.0)
+    return covariance + np.eye(len(covariance)) * loading, loading
+
+
+def conditional_residuals(
+    prior_errors,
+    measurement_errors,
+    prior_covariance,
+    cross_covariance,
+    observation_matrix,
+):
+    """Return conditional design ``J`` and residuals ``q`` under the project sign convention.
+
+    ``e = truth-prior``, ``v = measurement-H truth`` and ``C=Cov(e,v)`` imply
+    ``J=H+C.T P^-1`` and ``q=v-C.T P^-1 e``.  Rows of ``prior_errors`` and
+    ``measurement_errors`` are aligned campaign items.
+    """
+    e = _matrix("prior_errors", prior_errors)
+    v = _matrix("measurement_errors", measurement_errors, rows=len(e))
+    P = _symmetric("prior_covariance", prior_covariance, dimension=e.shape[1])
+    C = _matrix("cross_covariance", cross_covariance, rows=e.shape[1], cols=v.shape[1])
+    H = _matrix("observation_matrix", observation_matrix, rows=v.shape[1], cols=e.shape[1])
+    solved = np.linalg.solve(P, C)
+    return H + C.T @ np.linalg.solve(P, np.eye(P.shape[0])), v - e @ solved
+
+
+def median_rbf_bandwidth(features):
+    """Train-only median nonzero Euclidean distance for an RBF kernel."""
+    features = _matrix("features", features)
+    if len(features) < 2:
+        raise ValueError("at least two feature rows are required")
+    norm = np.sum(features * features, axis=1)
+    squared = np.maximum(norm[:, None] + norm[None, :] - 2.0 * features @ features.T, 0.0)
+    upper = squared[np.triu_indices(len(features), 1)]
+    positive = upper[upper > np.finfo(float).eps]
+    if not len(positive):
+        raise ValueError("RBF bandwidth is undefined when all feature rows are identical")
+    return float(np.sqrt(np.median(positive)))
+
+
+def rbf_kernel(features_a, features_b=None, *, length_scale):
+    """PSD Euclidean RBF Gram/cross-kernel; bandwidth must be fit without held outcomes."""
+    left = _matrix("features_a", features_a)
+    right = left if features_b is None else _matrix(
+        "features_b", features_b, cols=left.shape[1]
+    )
+    length_scale = _positive_finite("length_scale", length_scale)
+    left_norm = np.sum(left * left, axis=1)[:, None]
+    right_norm = np.sum(right * right, axis=1)[None, :]
+    squared = np.maximum(left_norm + right_norm - 2.0 * left @ right.T, 0.0)
+    kernel = np.exp(-0.5 * squared / (length_scale * length_scale))
+    if features_b is None:
+        kernel = 0.5 * (kernel + kernel.T)
+        np.fill_diagonal(kernel, 1.0)
+    return kernel
+
+
+@dataclass(frozen=True)
+class RegionalMeanModel:
+    """Train-only kernel-ridge mean with exact intercept-aware LOO residuals."""
+
+    kernel_name: str
+    ridge: float
+    intercept: np.ndarray
+    alpha: np.ndarray
+    loo_residuals: np.ndarray
+    loo_mse: float
+
+    @property
+    def global_mean(self):
+        """Compatibility name: the unpenalized fitted intercept vector."""
+        return self.intercept
+
+    def predict(self, cross_kernel):
+        cross = _matrix("cross_kernel", cross_kernel, cols=len(self.alpha))
+        return self.intercept + cross @ self.alpha
+
+    def to_dict(self):
+        return {
+            "kernel_name": self.kernel_name,
+            "ridge": self.ridge,
+            "intercept": self.intercept.tolist(),
+            "loo_mse": self.loo_mse,
+        }
+
+
+def _kernel_ridge_loo(residuals, kernel, ridge):
+    residuals = _matrix("residuals", residuals)
+    kernel = _symmetric("kernel", kernel, dimension=len(residuals))
+    ridge = _positive_finite("ridge", ridge)
+    A = kernel + np.eye(len(kernel)) * ridge
+    inverse = np.linalg.solve(A, np.eye(len(A)))
+    ones = np.ones(len(A))
+    inverse_ones = inverse @ ones
+    denominator = float(ones @ inverse_ones)
+    if denominator <= 0.0:
+        raise np.linalg.LinAlgError("kernel-ridge intercept system is not positive definite")
+    intercept = (ones @ inverse @ residuals) / denominator
+    centered = residuals - intercept
+    projection = inverse - np.outer(inverse_ones, inverse_ones) / denominator
+    alpha = projection @ residuals
+    diagonal = np.diag(projection)
+    if np.any(diagonal <= 0.0):
+        raise np.linalg.LinAlgError("kernel-ridge LOO leverage is invalid")
+    # K alpha + intercept = y - ridge*alpha; exact linear-smoother LOO residual is alpha/diag(P).
+    loo_residuals = alpha / diagonal[:, None]
+    loo_prediction = residuals - loo_residuals
+    mse = float(np.mean((residuals - loo_prediction) ** 2))
+    return RegionalMeanModel("", ridge, intercept, alpha, loo_residuals, mse)
+
+
+def select_kernel_ridge_mean(residuals, kernels, *, ridge_grid):
+    """Select a regional mean only by exact train LOO MSE."""
+    residuals = _matrix("residuals", residuals)
+    if not kernels:
+        raise ValueError("kernels must not be empty")
+    candidates = []
+    for kernel_name in sorted(kernels):
+        kernel = _symmetric(kernel_name, kernels[kernel_name], dimension=len(residuals))
+        for ridge in ridge_grid:
+            fitted = _kernel_ridge_loo(residuals, kernel, ridge)
+            candidates.append(RegionalMeanModel(
+                kernel_name, fitted.ridge, fitted.intercept, fitted.alpha,
+                fitted.loo_residuals, fitted.loo_mse,
+            ))
+    if not candidates:
+        raise ValueError("ridge_grid must contain at least one positive value")
+    return min(candidates, key=lambda value: (value.loo_mse, value.kernel_name, value.ridge))
+
+
+@dataclass(frozen=True)
+class StructuredResidualCovarianceModel:
+    """Train-fitted additive LMC component matrices in original channel units."""
+
+    kind: str
+    independent_covariance: np.ndarray
+    semantic_covariance: np.ndarray
+    graph_covariance: np.ndarray
+    train_objective: float
+    initial_objective: float
+    steps: int
+    pair_count: int
+    statistical_floor: float
+    semantic_weight: float | None = None
+    graph_weight: float | None = None
+    channel_rms_scale: np.ndarray | None = None
+    block_reference_objective: float | None = None
+    initial_model_reference_objective: float | None = None
+
+    @property
+    def channel_count(self):
+        return self.independent_covariance.shape[0]
+
+    def materialize(self, semantic_kernel, graph_kernel):
+        semantic = _symmetric("semantic_kernel", semantic_kernel)
+        graph = _symmetric("graph_kernel", graph_kernel, dimension=len(semantic))
+        return (
+            np.kron(np.eye(len(semantic)), self.independent_covariance)
+            + np.kron(semantic, self.semantic_covariance)
+            + np.kron(graph, self.graph_covariance)
+        )
+
+    def to_dict(self):
+        if self.kind == "block":
+            objective_type = "full_joint_gaussian_nll"
+            objective_units = "original_channel_units"
+            floor_units = "original_channel_variance"
+            restored_floor = np.full(self.channel_count, self.statistical_floor)
+        else:
+            objective_type = "pairwise_composite_gaussian_nll"
+            objective_units = "train_rms_standardized_channels"
+            floor_units = "train_rms_standardized_variance"
+            if self.channel_rms_scale is None:
+                raise ValueError("structured model is missing its channel RMS scale")
+            restored_floor = self.statistical_floor * self.channel_rms_scale ** 2
+        return {
+            "kind": self.kind,
+            "independent_covariance": self.independent_covariance.tolist(),
+            "semantic_covariance": self.semantic_covariance.tolist(),
+            "graph_covariance": self.graph_covariance.tolist(),
+            "train_objective_per_scalar": self.train_objective,
+            "initial_objective_per_scalar": self.initial_objective,
+            "block_reference_objective_per_scalar": self.block_reference_objective,
+            "initial_model_reference_objective_per_scalar": self.initial_model_reference_objective,
+            "train_objective_type": objective_type,
+            "train_objective_units": objective_units,
+            "steps": self.steps,
+            "pair_count": self.pair_count,
+            "statistical_floor": self.statistical_floor,
+            "statistical_floor_units": floor_units,
+            "statistical_floor_original_channel_diagonal": restored_floor.tolist(),
+            "channel_rms_scale": self.channel_rms_scale.tolist()
+            if self.channel_rms_scale is not None else None,
+            "semantic_weight": self.semantic_weight,
+            "graph_weight": self.graph_weight,
+        }
+
+
+def fit_block_model(residuals, *, shrinkage=0.05, relative_floor=1e-8):
+    """Analytic Gaussian MLE for independent item blocks."""
+    residuals = _matrix("residuals", residuals)
+    if len(residuals) < 2:
+        raise ValueError("at least two residual rows are required")
+    shrinkage = float(shrinkage)
+    if not 0.0 <= shrinkage <= 1.0:
+        raise ValueError("shrinkage must be in [0,1]")
+    covariance = residuals.T @ residuals / len(residuals)
+    covariance = (1.0 - shrinkage) * covariance + shrinkage * np.diag(np.diag(covariance))
+    covariance, loading = _psd_floor(covariance, relative_floor)
+    zeros = np.zeros_like(covariance)
+    model = StructuredResidualCovarianceModel(
+        "block", covariance, zeros, zeros, float("nan"), float("nan"), 0, 0, loading,
+    )
+    covariance_train = model.materialize(np.eye(len(residuals)), np.eye(len(residuals)))
+    objective = gaussian_joint_nll(residuals, covariance_train).per_scalar
+    return StructuredResidualCovarianceModel(
+        "block", covariance, zeros, zeros, objective, objective, 0, 0, loading,
+    )
+
+
+def _factor_initial(covariance, fraction, floor):
+    target = covariance * fraction + np.eye(len(covariance)) * floor
+    return np.linalg.cholesky(target)
+
+
+def _pair_indices(count, maximum, seed):
+    left, right = np.triu_indices(count, 1)
+    if not len(left):
+        raise ValueError("pairwise fitting requires at least two residual rows")
+    if maximum is not None and maximum < len(left):
+        if maximum < 1:
+            raise ValueError("max_pairs must be positive")
+        rng = np.random.default_rng(seed)
+        selected = np.sort(rng.choice(len(left), size=maximum, replace=False))
+        left, right = left[selected], right[selected]
+    return left, right
+
+
+def _component_from_factor(factor, floor=0.0):
+    value = torch.tril(factor)
+    covariance = value @ value.mT
+    if floor:
+        covariance = covariance + torch.eye(
+            covariance.shape[0], dtype=covariance.dtype, device=covariance.device
+        ) * floor
+    return covariance
+
+
+def _pairwise_objective(residuals, left, right, K_sem, K_graph, components):
+    B0, B_sem, B_graph = components
+    diagonal = B0 + B_sem + B_graph
+    cross = (
+        K_sem[left, right, None, None] * B_sem
+        + K_graph[left, right, None, None] * B_graph
+    )
+    plus_covariance = diagonal + cross
+    minus_covariance = diagonal - cross
+    plus_factor, plus_info = torch.linalg.cholesky_ex(plus_covariance)
+    minus_factor, minus_info = torch.linalg.cholesky_ex(minus_covariance)
+    if torch.any(plus_info) or torch.any(minus_info):
+        raise torch.linalg.LinAlgError("pairwise LMC covariance is not positive definite")
+    scale = math.sqrt(0.5)
+    plus = (residuals[left] + residuals[right]) * scale
+    minus = (residuals[left] - residuals[right]) * scale
+
+    def term(value, factor):
+        solved = torch.cholesky_solve(value.unsqueeze(-1), factor).squeeze(-1)
+        quadratic = torch.sum(value * solved, dim=-1)
+        logdet = 2.0 * torch.sum(torch.log(torch.diagonal(factor, dim1=-2, dim2=-1)), dim=-1)
+        return quadratic + logdet
+
+    judge_count = residuals.shape[1]
+    nll = 0.5 * (term(plus, plus_factor) + term(minus, minus_factor) + 2 * judge_count * LOG2PI)
+    return torch.mean(nll) / (2.0 * judge_count)
+
+
+def fit_lmc_model(
+    residuals,
+    semantic_kernel,
+    graph_kernel,
+    *,
+    kind,
+    steps=150,
+    learning_rate=0.03,
+    max_pairs=4096,
+    seed=0,
+    relative_floor=1e-6,
+    initial_model=None,
+):
+    """Fit separable or additive-LMC components by deterministic pairwise likelihood."""
+    residuals = _matrix("residuals", residuals)
+    semantic = _symmetric("semantic_kernel", semantic_kernel, dimension=len(residuals))
+    graph = _symmetric("graph_kernel", graph_kernel, dimension=len(residuals))
+    if kind not in {"separable", "dense_lmc"}:
+        raise ValueError("kind must be 'separable' or 'dense_lmc'")
+    if steps < 1:
+        raise ValueError("steps must be positive")
+    learning_rate = _positive_finite("learning_rate", learning_rate)
+    diagonal_tolerance = 1e-8
+    if not np.allclose(np.diag(semantic), 1.0, atol=diagonal_tolerance) or not np.allclose(
+        np.diag(graph), 1.0, atol=diagonal_tolerance
+    ):
+        raise ValueError("LMC item kernels must have unit diagonal")
+
+    rms = np.sqrt(np.mean(residuals * residuals, axis=0))
+    rms = np.where(rms > 1e-8, rms, 1.0)
+    standardized = residuals / rms
+    marginal = standardized.T @ standardized / len(standardized)
+    marginal, _ = _psd_floor(marginal, 1e-8)
+    judge_count = residuals.shape[1]
+    statistical_floor = relative_floor * float(np.trace(marginal) / judge_count)
+    left_np, right_np = _pair_indices(len(residuals), max_pairs, seed)
+
+    dtype = torch.float64
+    z = torch.tensor(standardized, dtype=dtype)
+    K_sem = torch.tensor(semantic, dtype=dtype)
+    K_graph = torch.tensor(graph, dtype=dtype)
+    left = torch.tensor(left_np, dtype=torch.long)
+    right = torch.tensor(right_np, dtype=torch.long)
+    initial_reference_components = None
+    if kind == "separable":
+        parameters = [
+            torch.nn.Parameter(torch.tensor(_factor_initial(marginal, 0.8, 0.0), dtype=dtype)),
+            torch.nn.Parameter(torch.tensor(_factor_initial(marginal, 0.2, 0.0), dtype=dtype)),
+            torch.nn.Parameter(torch.zeros(2, dtype=dtype)),
+        ]
+    elif initial_model is None:
+        parameters = [
+            torch.nn.Parameter(torch.tensor(_factor_initial(marginal, 0.8, 0.0), dtype=dtype)),
+            torch.nn.Parameter(torch.tensor(_factor_initial(marginal, 0.1, 0.0), dtype=dtype)),
+            torch.nn.Parameter(torch.tensor(_factor_initial(marginal, 0.1, 0.0), dtype=dtype)),
+        ]
+    else:
+        if not isinstance(initial_model, StructuredResidualCovarianceModel):
+            raise TypeError("initial_model must be a StructuredResidualCovarianceModel")
+        inverse_unit = np.diag(1.0 / rms)
+
+        initial_reference_components = tuple(
+            torch.tensor(inverse_unit @ value @ inverse_unit, dtype=dtype)
+            for value in (
+                initial_model.independent_covariance,
+                initial_model.semantic_covariance,
+                initial_model.graph_covariance,
+            )
+        )
+
+        def standardized_factor(value, *, subtract_floor=False, seed_if_near_zero=False):
+            scaled = inverse_unit @ value @ inverse_unit
+            if subtract_floor:
+                scaled = scaled - np.eye(judge_count) * statistical_floor
+            if seed_if_near_zero:
+                marginal_scale = max(float(np.max(np.abs(marginal))), np.finfo(float).tiny)
+                if float(np.max(np.abs(scaled))) <= 1e-8 * marginal_scale:
+                    # A zero LMC factor has zero gradient under B=L L.T.  Preserve the inherited
+                    # model as an exact saved candidate below, but start Adam from material mass.
+                    scaled = scaled + 0.05 * marginal
+            scaled, _ = _psd_floor(scaled, 1e-10)
+            return np.linalg.cholesky(scaled)
+
+        parameters = [
+            torch.nn.Parameter(torch.tensor(
+                standardized_factor(initial_model.independent_covariance, subtract_floor=True), dtype=dtype
+            )),
+            torch.nn.Parameter(torch.tensor(
+                standardized_factor(initial_model.semantic_covariance, seed_if_near_zero=True),
+                dtype=dtype,
+            )),
+            torch.nn.Parameter(torch.tensor(
+                standardized_factor(initial_model.graph_covariance, seed_if_near_zero=True),
+                dtype=dtype,
+            )),
+        ]
+    optimizer = torch.optim.Adam(parameters, lr=learning_rate)
+
+    def components():
+        B0 = _component_from_factor(parameters[0], statistical_floor)
+        if kind == "separable":
+            shared = _component_from_factor(parameters[1])
+            weights = torch.softmax(parameters[2], dim=0)
+            return B0, weights[0] * shared, weights[1] * shared
+        return B0, _component_from_factor(parameters[1]), _component_from_factor(parameters[2])
+
+    def current_weights():
+        if kind != "separable":
+            return None
+        return torch.softmax(parameters[2], dim=0).detach().clone()
+
+    def clone_components(values):
+        return tuple(value.detach().clone() for value in values)
+
+    # The structured families contain the independent-item model.  Keep that exact submodel as a
+    # deterministic fallback so a weak Adam iterate cannot manufacture evidence against structure.
+    block_components = (
+        torch.tensor(marginal, dtype=dtype) + torch.eye(judge_count, dtype=dtype) * statistical_floor,
+        torch.zeros((judge_count, judge_count), dtype=dtype),
+        torch.zeros((judge_count, judge_count), dtype=dtype),
+    )
+    with torch.no_grad():
+        initial_components = components()
+        initial = float(_pairwise_objective(
+            z, left, right, K_sem, K_graph, initial_components
+        ))
+        block_reference = float(_pairwise_objective(
+            z, left, right, K_sem, K_graph, block_components
+        ))
+        initial_model_reference = (
+            float(_pairwise_objective(
+                z, left, right, K_sem, K_graph, initial_reference_components
+            ))
+            if initial_reference_components is not None else None
+        )
+    if initial < block_reference:
+        best_loss = initial
+        best_components = clone_components(initial_components)
+        best_weights = current_weights()
+    else:
+        best_loss = block_reference
+        best_components = clone_components(block_components)
+        best_weights = torch.tensor([0.5, 0.5], dtype=dtype) if kind == "separable" else None
+    if initial_model_reference is not None and initial_model_reference < best_loss:
+        best_loss = initial_model_reference
+        best_components = clone_components(initial_reference_components)
+        best_weights = None
+    for _ in range(steps):
+        optimizer.zero_grad()
+        candidate_components = components()
+        loss = _pairwise_objective(z, left, right, K_sem, K_graph, candidate_components)
+        if not torch.isfinite(loss):
+            raise FloatingPointError("non-finite pairwise LMC objective")
+        value = float(loss.detach())
+        if value < best_loss:
+            best_loss = value
+            best_components = clone_components(candidate_components)
+            best_weights = current_weights()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(parameters, 100.0)
+        optimizer.step()
+    with torch.no_grad():
+        last_components = components()
+        last_loss = float(_pairwise_objective(
+            z, left, right, K_sem, K_graph, last_components
+        ))
+    if last_loss < best_loss:
+        best_loss = last_loss
+        best_components = clone_components(last_components)
+        best_weights = current_weights()
+    B0_t, B_sem_t, B_graph_t = best_components
+    final = best_loss
+    weights = best_weights.cpu().numpy() if best_weights is not None else None
+    unit = np.diag(rms)
+
+    def restore(value):
+        array = value.detach().cpu().numpy()
+        return unit @ array @ unit
+
+    return StructuredResidualCovarianceModel(
+        kind,
+        restore(B0_t),
+        restore(B_sem_t),
+        restore(B_graph_t),
+        final,
+        initial,
+        int(steps),
+        int(len(left)),
+        float(statistical_floor),
+        float(weights[0]) if weights is not None else None,
+        float(weights[1]) if weights is not None else None,
+        rms.copy(),
+        block_reference,
+        initial_model_reference,
+    )
+
+
+@dataclass(frozen=True)
+class GaussianJointNLL:
+    total: float
+    per_scalar: float
+
+
+def gaussian_joint_nll(residuals, covariance):
+    """Full joint Gaussian NLL for one held residual field."""
+    residuals = _matrix("residuals", residuals)
+    covariance = _symmetric(
+        "covariance", covariance, dimension=residuals.shape[0] * residuals.shape[1]
+    )
+    factor = np.linalg.cholesky(covariance)
+    flat = residuals.reshape(-1)
+    whitened = np.linalg.solve(factor, flat)
+    logdet = 2.0 * np.sum(np.log(np.diag(factor)))
+    total = 0.5 * (float(whitened @ whitened) + float(logdet) + len(flat) * LOG2PI)
+    return GaussianJointNLL(total, total / len(flat))
+
+
+@dataclass(frozen=True)
+class OffBlockDiagnostics:
+    relative_off_item_frobenius_mass: float
+    maximum_whitened_off_block_spectral_norm: float
+    maximum_coupling_item_pair: tuple[int, int] | None
+    minimum_eigenvalue: float
+    maximum_eigenvalue: float
+    condition_number: float
+
+    def to_dict(self):
+        return {
+            "relative_off_item_frobenius_mass": self.relative_off_item_frobenius_mass,
+            "maximum_whitened_off_block_spectral_norm": self.maximum_whitened_off_block_spectral_norm,
+            "maximum_coupling_item_pair": list(self.maximum_coupling_item_pair)
+            if self.maximum_coupling_item_pair is not None else None,
+            "minimum_eigenvalue": self.minimum_eigenvalue,
+            "maximum_eigenvalue": self.maximum_eigenvalue,
+            "condition_number": self.condition_number,
+        }
+
+
+def off_block_diagnostics(covariance, block_size):
+    """Materialized covariance diagnostics required by the streaming independence contract."""
+    covariance = _symmetric("covariance", covariance)
+    if not isinstance(block_size, (int, np.integer)) or block_size < 1:
+        raise ValueError("block_size must be a positive integer")
+    if len(covariance) % block_size:
+        raise ValueError("covariance dimension must be divisible by block_size")
+    count = len(covariance) // block_size
+    block_diagonal = np.zeros_like(covariance)
+    factors = []
+    for i in range(count):
+        section = slice(i * block_size, (i + 1) * block_size)
+        block = covariance[section, section]
+        block_diagonal[section, section] = block
+        factors.append(np.linalg.cholesky(block))
+    off = covariance - block_diagonal
+    total_norm = np.linalg.norm(covariance, ord="fro")
+    relative = float(np.linalg.norm(off, ord="fro") / total_norm) if total_norm else 0.0
+    maximum, pair = 0.0, None
+    for i in range(count):
+        rows = slice(i * block_size, (i + 1) * block_size)
+        for j in range(i + 1, count):
+            cols = slice(j * block_size, (j + 1) * block_size)
+            left_whitened = np.linalg.solve(factors[i], covariance[rows, cols])
+            whitened = np.linalg.solve(factors[j], left_whitened.T).T
+            value = float(np.linalg.norm(whitened, ord=2))
+            if value > maximum:
+                maximum, pair = value, (i, j)
+    eigenvalues = np.linalg.eigvalsh(covariance)
+    return OffBlockDiagnostics(
+        relative,
+        maximum,
+        pair,
+        float(eigenvalues[0]),
+        float(eigenvalues[-1]),
+        float(eigenvalues[-1] / eigenvalues[0]),
+    )
+
+
+def _loading_to_dict(diagnostics):
+    fields = (
+        "matrix_scale",
+        "minimum_eigenvalue",
+        "target_minimum_eigenvalue",
+        "diagonal_loading",
+        "relative_diagonal_loading",
+        "was_loaded",
+        "relative_eigenvalue_floor",
+        "negative_eigenvalue_tolerance",
+        "maximum_relative_loading",
+        "source",
+    )
+    out = {}
+    for field in fields:
+        value = getattr(diagnostics, field)
+        if torch.is_tensor(value):
+            value = value.detach().cpu()
+            value = value.item() if value.ndim == 0 else value.tolist()
+        out[field] = value
+    return out
+
+
+@dataclass(frozen=True)
+class ConditionedItemBatch:
+    state_mean: np.ndarray
+    marginal_covariances: np.ndarray
+    full_covariance: np.ndarray
+    loading_diagnostics: dict
+    prior_loading_diagnostics: dict
+
+
+def condition_item_batch(
+    prior_covariance,
+    conditional_design,
+    innovation,
+    conditional_covariance,
+    *,
+    maximum_relative_loading=1e-3,
+):
+    """Joint prior-centered information-QR update for a coupled held item batch."""
+    prior = _symmetric("prior_covariance", prior_covariance)
+    design = _matrix("conditional_design", conditional_design, cols=len(prior))
+    innovation = _matrix("innovation", innovation, cols=design.shape[0])
+    item_count = len(innovation)
+    covariance = _symmetric(
+        "conditional_covariance",
+        conditional_covariance,
+        dimension=item_count * design.shape[0],
+    )
+    dtype = torch.float64
+    P0 = torch.tensor(prior, dtype=dtype)
+    J0 = torch.tensor(design, dtype=dtype)
+    residual = torch.tensor(innovation.reshape(-1), dtype=dtype)
+    Rc = torch.tensor(covariance, dtype=dtype)
+    prior_whitener = prepare_noise_whitener_torch(
+        P0,
+        maximum_relative_loading=maximum_relative_loading,
+        name="prior covariance",
+    )
+    root0 = precision_root_from_covariance_torch(
+        prior_whitener.covariance,
+        maximum_relative_loading=maximum_relative_loading,
+    )
+    identity_items = torch.eye(item_count, dtype=dtype)
+    root = torch.kron(identity_items, root0)
+    J = torch.kron(identity_items, J0)
+    whitener = prepare_noise_whitener_torch(
+        Rc,
+        maximum_relative_loading=maximum_relative_loading,
+        name="structured conditional residual covariance",
+    )
+    state = SquareRootInformationStateTorch(
+        root, torch.zeros(item_count * len(prior), dtype=dtype)
+    )
+    _, update = state.update_noise_block(J, residual, whitener)
+    posterior_root = update.precision_root
+    identity_state = torch.eye(posterior_root.shape[-1], dtype=dtype)
+    inverse_root = torch.linalg.solve_triangular(posterior_root, identity_state, upper=True)
+    posterior_covariance = inverse_root @ inverse_root.mT
+    state_mean = update.solution.reshape(item_count, len(prior))
+    marginals = torch.stack([
+        posterior_covariance[
+            i * len(prior):(i + 1) * len(prior),
+            i * len(prior):(i + 1) * len(prior),
+        ]
+        for i in range(item_count)
+    ])
+    return ConditionedItemBatch(
+        state_mean.detach().cpu().numpy(),
+        marginals.detach().cpu().numpy(),
+        posterior_covariance.detach().cpu().numpy(),
+        _loading_to_dict(whitener.diagnostics),
+        _loading_to_dict(prior_whitener.diagnostics),
+    )

--- a/prototypes/mu_cosine/test_run_structured_residual_covariance.py
+++ b/prototypes/mu_cosine/test_run_structured_residual_covariance.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Pure-function tests for the structured residual covariance campaign runner."""
+import copy
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+import fine_tune_channel_heads as channel_heads
+
+from run_structured_residual_covariance import (
+    aggregate_gate,
+    decision_metrics,
+    file_provenance,
+    semantic_pair_features,
+    state_metrics,
+    train_standardize,
+)
+
+
+def test_file_provenance_hashes_exact_regular_file(tmp_path):
+    artifact = tmp_path / "artifact.bin"
+    artifact.write_bytes(b"structured-covariance\n")
+    got = file_provenance(artifact)
+    assert got["path"] == str(artifact)
+    assert got["size_bytes"] == 22
+    assert got["sha256"] == "f8eac5833bfc8255254a47f92350e9ebce1f5ec59ed27741f13a6a9af27f2a5d"
+
+
+def test_campaign_loader_honors_explicit_scored_path(tmp_path, monkeypatch):
+    scored = tmp_path / "custom_campaign.tsv"
+    scored.write_text(
+        "#node\troot\tneighborhood\tmu[subcategory]\tmu[subtopic]\tmu[element_of]"
+        "\tmu[super_category]\tmu[see_also]\tmu[assoc]\n"
+        "custom-node\tcustom-root\tcustom-tag\t0.1\t0.2\t0.3\t0.4\t0.5\t0.6\n",
+        encoding="utf-8",
+    )
+    parents = {"custom-node": ("custom-root",), "custom-root": ()}
+    children = {"custom-root": ("custom-node",)}
+    monkeypatch.setattr(
+        channel_heads,
+        "load_feature_graph",
+        lambda config: (parents, children, {"custom-node": 1, "custom-root": 1}, None),
+    )
+    monkeypatch.setattr(
+        channel_heads,
+        "load_e5_cache_and_filter",
+        lambda pairs, hop, D, S, cache: (
+            {"query": {}, "passage": {}}, {}, pairs, hop, D, S
+        ),
+    )
+    monkeypatch.setattr(channel_heads, "Tokenizer", lambda *args: "tokenizer")
+    monkeypatch.setattr(channel_heads, "hit_prob", lambda *args: 1.0)
+    monkeypatch.setattr(
+        channel_heads,
+        "descendant_disjoint_split",
+        lambda pairs, seed, held_frac: (np.array([0]), np.array([], dtype=int)),
+    )
+    loaded = channel_heads.load_campaign_datasets(campaign_scored=scored)
+    assert loaded["exploratory-campaign"]["pairs"] == [("custom-node", "custom-root")]
+    assert loaded["fresh-campaign"]["tags"] == ["custom-tag"]
+
+
+def test_semantic_pair_features_are_item_aligned_normalized_and_role_aware():
+    tok = SimpleNamespace(
+        idx={"a": 0, "b": 1, "r": 2},
+        p=torch.tensor([[1.0, 0.0], [0.0, 2.0], [1.0, 1.0]]),
+        q=torch.tensor([[0.5, 0.5], [1.0, 0.0], [0.0, 3.0]]),
+    )
+    got = semantic_pair_features({"tok": tok}, [("a", "r"), ("b", "r")])
+    assert got.shape == (2, 4)
+    np.testing.assert_allclose(np.linalg.norm(got, axis=1), 1.0)
+    assert not np.allclose(got[0], got[1])
+    # Candidate uses passage coordinates; root uses query coordinates.
+    np.testing.assert_allclose(got[0] / got[0, 0], [1.0, 0.0, 0.0, 3.0])
+
+
+def test_train_standardizer_does_not_fit_on_held_rows():
+    features = np.array([[0.0, 1.0], [2.0, 3.0], [10.0, -20.0], [30.0, 40.0]])
+    train = np.array([0, 1])
+    first, mean1, scale1 = train_standardize(features, train)
+    changed = features.copy()
+    changed[2:] *= 1e6
+    second, mean2, scale2 = train_standardize(changed, train)
+    np.testing.assert_array_equal(mean1, mean2)
+    np.testing.assert_array_equal(scale1, scale2)
+    np.testing.assert_array_equal(first[train], second[train])
+    np.testing.assert_allclose(first[train].mean(axis=0), 0.0, atol=1e-15)
+
+
+def test_state_metrics_match_known_standard_normal_geometry():
+    observed = np.array([[1.0, 0.0], [0.0, 2.0]])
+    mean = np.zeros_like(observed)
+    covariance = np.repeat(np.eye(2)[None], 2, axis=0)
+    got = state_metrics(observed, mean, covariance)
+    assert np.isclose(got["mse_per_scalar"], 1.25)
+    assert np.isclose(got["mahalanobis_per_dimension"], 1.25)
+    assert got["coverage_95_bivariate_ellipse"] == 1.0
+    expected = np.mean([0.5 * (1.0 + 2 * np.log(2 * np.pi)),
+                        0.5 * (4.0 + 2 * np.log(2 * np.pi))])
+    assert np.isclose(got["mean_bivariate_nll"], expected)
+
+
+def test_decision_metrics_use_margin_gate_and_equal_width_ece():
+    proba = np.array([
+        [0.90, 0.05, 0.05],
+        [0.10, 0.80, 0.10],
+        [0.33, 0.33, 0.34],
+        [0.15, 0.15, 0.70],
+    ])
+    got = decision_metrics(proba, ["directional", "symmetric", "other", "other"])
+    assert got["accuracy"] == 1.0
+    assert got["log_loss"] > 0.0
+    assert 0.0 <= got["ece_10_equal_width"] <= 1.0
+    assert got["aurc_margin"] == 0.0
+
+
+def _gate_row(corpus, seed, block, separable, dense):
+    def metric(value, *, loading=0.0):
+        return {
+            "held_joint_residual_nll_per_scalar": value,
+            "posterior": {
+                "state": {"mean_bivariate_nll": value},
+                "decision": {"log_loss": value, "aurc_margin": value},
+                "conditioner": {
+                    "loading": {"relative_diagonal_loading": loading},
+                    "prior_loading": {"relative_diagonal_loading": 0.0},
+                },
+            },
+        }
+
+    return {
+        "corpus": corpus,
+        "seed": seed,
+        "models": {
+            "block_global": metric(block + 0.05),
+            "block_regional": metric(block),
+            "separable_regional": metric(separable),
+            "dense_lmc_regional": metric(dense),
+        },
+    }
+
+
+def test_engineering_gate_requires_all_ten_predeclared_seeds():
+    smoke = [_gate_row(corpus, seed, 1.0, 0.9, 0.8)
+             for corpus in ("exploratory", "fresh") for seed in range(2)]
+    assert not aggregate_gate(smoke)["gate_evaluable"]
+
+    primary = [_gate_row(corpus, seed, 1.0, 0.85, 0.8)
+               for corpus in ("exploratory", "fresh") for seed in range(10)]
+    gate = aggregate_gate(primary)
+    assert gate["gate_evaluable"]
+    assert gate["dense_lmc_passes_direction_and_stability"]
+    assert gate["separable_passes_direction_and_stability"]
+    assert np.isclose(gate["macro_split_separable_fraction_of_dense_gain"], 0.75)
+    assert not gate["passes_80_percent_recovery"]
+
+    duplicated = [_gate_row(corpus, 0, 1.0, 0.85, 0.8)
+                  for corpus in ("exploratory", "fresh") for _ in range(10)]
+    assert not aggregate_gate(duplicated)["gate_evaluable"]
+
+    one_corpus = [_gate_row("fresh", seed, 1.0, 0.85, 0.8) for seed in range(10)]
+    assert not aggregate_gate(one_corpus)["gate_evaluable"]
+
+
+def test_engineering_gate_pins_direction_mean_and_every_guardrail():
+    passing = [_gate_row(corpus, seed, 1.0, 0.8, 0.8)
+               for corpus in ("exploratory", "fresh") for seed in range(10)]
+    assert aggregate_gate(passing)["structured_covariance_gate_passes"]
+
+    exactly_eight = [
+        _gate_row(corpus, seed, 1.0, 0.9 if seed < 8 else 1.01,
+                  0.9 if seed < 8 else 1.01)
+        for corpus in ("exploratory", "fresh") for seed in range(10)
+    ]
+    gate = aggregate_gate(exactly_eight)
+    assert gate["dense_lmc_passes_direction_and_stability"]
+    assert gate["separable_passes_direction_and_stability"]
+
+    negative_mean = [
+        _gate_row(corpus, seed, 1.0, 0.99 if seed < 8 else 1.10,
+                  0.99 if seed < 8 else 1.10)
+        for corpus in ("exploratory", "fresh") for seed in range(10)
+    ]
+    gate = aggregate_gate(negative_mean)
+    assert all(value["separable_positive_seeds"] == 8 for value in gate["by_corpus"].values())
+    assert not gate["separable_passes_direction_and_stability"]
+
+    bad_posterior = copy.deepcopy(passing)
+    for row in bad_posterior:
+        if row["corpus"] == "fresh":
+            baseline = row["models"]["block_regional"]["posterior"]["state"]
+            row["models"]["separable_regional"]["posterior"]["state"][
+                "mean_bivariate_nll"
+            ] = baseline["mean_bivariate_nll"] + 1e-4
+    assert not aggregate_gate(bad_posterior)["separable_posterior_nll_guardrail_passes"]
+
+    decision_boundary = copy.deepcopy(passing)
+    for row in decision_boundary:
+        baseline = row["models"]["block_regional"]["posterior"]["decision"]
+        candidate = row["models"]["separable_regional"]["posterior"]["decision"]
+        candidate["log_loss"] = baseline["log_loss"] + 0.009999
+        candidate["aurc_margin"] = baseline["aurc_margin"] + 0.009999
+    assert aggregate_gate(decision_boundary)["separable_decision_guardrail_passes"]
+    for row in decision_boundary:
+        if row["corpus"] == "fresh":
+            baseline = row["models"]["block_regional"]["posterior"]["decision"]
+            row["models"]["separable_regional"]["posterior"]["decision"][
+                "log_loss"
+            ] = baseline["log_loss"] + 0.010001
+    assert not aggregate_gate(decision_boundary)["separable_decision_guardrail_passes"]
+
+    bad_loading = copy.deepcopy(passing)
+    bad_loading[0]["models"]["dense_lmc_regional"]["posterior"]["conditioner"][
+        "prior_loading"
+    ]["relative_diagonal_loading"] = 0.0011
+    assert not aggregate_gate(bad_loading)["loading_budget_guardrail_passes"]

--- a/prototypes/mu_cosine/test_structured_residual_covariance.py
+++ b/prototypes/mu_cosine/test_structured_residual_covariance.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Correctness tests for structured cross-item conditional residual covariance."""
+import numpy as np
+import pytest
+import torch
+
+from product_kalman import gaussian_condition_update
+from structured_residual_covariance import (
+    condition_item_batch,
+    conditional_residuals,
+    fit_block_model,
+    fit_lmc_model,
+    gaussian_joint_nll,
+    median_rbf_bandwidth,
+    off_block_diagnostics,
+    rbf_kernel,
+    select_kernel_ridge_mean,
+)
+
+
+def test_conditional_residual_sign_and_design_match_schur_reduction():
+    P = np.array([[2.0, 0.3], [0.3, 1.0]])
+    C = np.array([[0.2, -0.1], [0.05, 0.3]])
+    H = np.array([[1.0, 0.0], [0.0, 1.0]])
+    e = np.array([[0.4, -0.2], [-0.1, 0.8]])
+    q_true = np.array([[0.3, -0.4], [0.1, 0.2]])
+    solved = np.linalg.solve(P, C)
+    v = e @ solved + q_true
+    J, q = conditional_residuals(e, v, P, C, H)
+    np.testing.assert_allclose(J, H + C.T @ np.linalg.inv(P))
+    np.testing.assert_allclose(q, q_true)
+
+
+def test_rbf_kernel_is_psd_unit_diagonal_and_cross_aligned():
+    features = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 2.0], [1.0, 2.0]])
+    length = median_rbf_bandwidth(features)
+    kernel = rbf_kernel(features, length_scale=length)
+    np.testing.assert_allclose(kernel, kernel.T)
+    np.testing.assert_allclose(np.diag(kernel), 1.0)
+    assert np.linalg.eigvalsh(kernel).min() > -1e-12
+    cross = rbf_kernel(features[:2], features[2:], length_scale=length)
+    np.testing.assert_allclose(cross, kernel[:2, 2:])
+    with pytest.raises(ValueError, match="identical"):
+        median_rbf_bandwidth(np.ones((3, 2)))
+
+
+def test_kernel_ridge_regional_mean_uses_exact_train_loo_and_predicts():
+    x = np.linspace(0.0, 3.0, 30)[:, None]
+    target = np.column_stack([np.sin(x[:, 0]), np.cos(x[:, 0])])
+    kernel = rbf_kernel(x, length_scale=0.5)
+    model = select_kernel_ridge_mean(
+        target,
+        {"semantic": kernel, "identity": np.eye(len(x))},
+        ridge_grid=[0.01, 0.1, 1.0],
+    )
+    assert model.kernel_name == "semantic"
+    assert model.loo_mse < np.mean((target - target.mean(axis=0)) ** 2)
+    assert model.loo_residuals.shape == target.shape
+    prediction = model.predict(rbf_kernel(x[:4], x, length_scale=0.5))
+    assert prediction.shape == (4, 2)
+    assert np.isfinite(prediction).all()
+
+
+def test_block_model_materialization_is_item_major_and_exact():
+    residuals = np.array([[1.0, 0.2], [-0.5, 0.7], [0.3, -0.4]])
+    model = fit_block_model(residuals, shrinkage=0.0)
+    got = model.materialize(np.eye(3), np.eye(3))
+    expected_block = residuals.T @ residuals / len(residuals)
+    # The only difference is the declared tiny SPD floor.
+    np.testing.assert_allclose(got[:2, :2], expected_block, rtol=1e-7, atol=1e-9)
+    np.testing.assert_allclose(got[:2, 2:], 0.0)
+    np.testing.assert_allclose(got[2:4, 2:4], got[:2, :2])
+    metadata = model.to_dict()
+    assert metadata["train_objective_type"] == "full_joint_gaussian_nll"
+    assert metadata["train_objective_units"] == "original_channel_units"
+    assert metadata["statistical_floor_units"] == "original_channel_variance"
+    np.testing.assert_allclose(
+        metadata["statistical_floor_original_channel_diagonal"],
+        np.repeat(model.statistical_floor, 2),
+    )
+
+
+def _synthetic_lmc(seed=8, n=28):
+    rng = np.random.default_rng(seed)
+    x = np.linspace(-2.0, 2.0, n)[:, None]
+    g = np.column_stack([np.sin(x[:, 0]), np.cos(x[:, 0])])
+    Ks = rbf_kernel(x, length_scale=0.7)
+    Kg = rbf_kernel(g, length_scale=1.0)
+    B0 = np.array([[0.12, 0.01], [0.01, 0.10]])
+    Bs = np.array([[0.20, 0.08], [0.08, 0.08]])
+    Bg = np.array([[0.04, -0.02], [-0.02, 0.12]])
+    covariance = np.kron(np.eye(n), B0) + np.kron(Ks, Bs) + np.kron(Kg, Bg)
+    residuals = rng.multivariate_normal(np.zeros(2 * n), covariance).reshape(n, 2)
+    return residuals, Ks, Kg
+
+
+@pytest.mark.parametrize("kind", ["separable", "dense_lmc"])
+def test_lmc_fit_is_deterministic_psd_and_does_not_lose_its_train_objective(kind):
+    residuals, Ks, Kg = _synthetic_lmc()
+    kwargs = dict(kind=kind, steps=50, learning_rate=0.03, max_pairs=256, seed=4)
+    first = fit_lmc_model(residuals, Ks, Kg, **kwargs)
+    second = fit_lmc_model(residuals, Ks, Kg, **kwargs)
+    assert first.train_objective <= first.initial_objective + 1e-10
+    assert first.train_objective <= first.block_reference_objective + 1e-10
+    np.testing.assert_array_equal(first.independent_covariance, second.independent_covariance)
+    np.testing.assert_array_equal(first.semantic_covariance, second.semantic_covariance)
+    np.testing.assert_array_equal(first.graph_covariance, second.graph_covariance)
+    covariance = first.materialize(Ks, Kg)
+    assert np.linalg.eigvalsh(covariance).min() > 0.0
+    if kind == "separable":
+        assert np.isclose(first.semantic_weight + first.graph_weight, 1.0)
+    metadata = first.to_dict()
+    assert metadata["train_objective_type"] == "pairwise_composite_gaussian_nll"
+    assert metadata["train_objective_units"] == "train_rms_standardized_channels"
+    assert metadata["statistical_floor_units"] == "train_rms_standardized_variance"
+    np.testing.assert_allclose(
+        metadata["statistical_floor_original_channel_diagonal"],
+        first.statistical_floor * first.channel_rms_scale ** 2,
+    )
+
+
+def test_dense_lmc_can_start_from_and_not_lose_separable_fit():
+    residuals, Ks, Kg = _synthetic_lmc()
+    separable = fit_lmc_model(
+        residuals, Ks, Kg, kind="separable", steps=20, max_pairs=256, seed=4
+    )
+    dense = fit_lmc_model(
+        residuals,
+        Ks,
+        Kg,
+        kind="dense_lmc",
+        steps=20,
+        learning_rate=0.5,
+        max_pairs=256,
+        seed=4,
+        initial_model=separable,
+    )
+    assert dense.train_objective <= dense.initial_objective + 1e-12
+    assert dense.train_objective <= dense.block_reference_objective + 1e-12
+    assert dense.train_objective <= dense.initial_model_reference_objective + 1e-12
+    np.testing.assert_allclose(
+        dense.initial_model_reference_objective,
+        separable.train_objective,
+        rtol=0.0,
+        atol=1e-10,
+    )
+
+
+def test_dense_lmc_escapes_zero_structured_block_warm_start():
+    residuals, Ks, Kg = _synthetic_lmc(n=40)
+    block = fit_block_model(residuals, shrinkage=0.0)
+    dense = fit_lmc_model(
+        residuals,
+        Ks,
+        Kg,
+        kind="dense_lmc",
+        steps=100,
+        learning_rate=0.03,
+        max_pairs=512,
+        seed=9,
+        initial_model=block,
+    )
+    structured_mass = (
+        np.linalg.norm(dense.semantic_covariance, ord="fro")
+        + np.linalg.norm(dense.graph_covariance, ord="fro")
+    )
+    assert structured_mass > 1e-4
+    assert dense.train_objective < dense.block_reference_objective - 1e-4
+
+
+def test_dense_lmc_beats_restricted_separable_model_on_planted_nonseparable_field():
+    residuals, Ks, Kg = _synthetic_lmc(n=60)
+    separable = fit_lmc_model(
+        residuals, Ks, Kg, kind="separable", steps=120, max_pairs=1024, seed=9
+    )
+    dense = fit_lmc_model(
+        residuals,
+        Ks,
+        Kg,
+        kind="dense_lmc",
+        steps=120,
+        max_pairs=1024,
+        seed=9,
+        initial_model=separable,
+    )
+    assert dense.train_objective < separable.train_objective - 1e-3
+
+
+def test_gaussian_joint_nll_matches_torch_distribution():
+    residuals = np.array([[0.2, -0.3], [0.1, 0.7]])
+    covariance = np.array([
+        [1.2, 0.1, 0.2, 0.0],
+        [0.1, 0.8, 0.0, 0.1],
+        [0.2, 0.0, 1.0, -0.1],
+        [0.0, 0.1, -0.1, 0.9],
+    ])
+    got = gaussian_joint_nll(residuals, covariance)
+    distribution = torch.distributions.MultivariateNormal(
+        torch.zeros(4, dtype=torch.float64),
+        covariance_matrix=torch.tensor(covariance, dtype=torch.float64),
+    )
+    expected = -float(distribution.log_prob(torch.tensor(residuals.reshape(-1), dtype=torch.float64)))
+    assert np.isclose(got.total, expected)
+    assert np.isclose(got.per_scalar, expected / 4.0)
+
+
+def test_off_block_diagnostics_pin_mass_coupling_and_independence():
+    B0 = np.array([[1.0, 0.2], [0.2, 0.8]])
+    cross = np.array([[0.3, 0.1], [0.1, 0.2]])
+    covariance = np.block([[B0, cross], [cross, B0]])
+    got = off_block_diagnostics(covariance, 2)
+    assert got.relative_off_item_frobenius_mass > 0.0
+    assert got.maximum_whitened_off_block_spectral_norm > 0.0
+    assert got.maximum_coupling_item_pair == (0, 1)
+    independent = off_block_diagnostics(np.kron(np.eye(3), B0), 2)
+    assert independent.relative_off_item_frobenius_mass == 0.0
+    assert independent.maximum_whitened_off_block_spectral_norm == 0.0
+    assert independent.maximum_coupling_item_pair is None
+
+
+def test_joint_information_qr_batch_matches_dense_gaussian_conditioner():
+    n_items = 3
+    P0 = np.array([[1.2, 0.15], [0.15, 0.9]])
+    # Match the campaign's overdetermined four-judge/two-state geometry.
+    J0 = np.array([[1.0, 0.2], [-0.1, 0.8], [0.9, -0.2], [0.15, 1.1]])
+    innovation = np.array([
+        [0.2, -0.4, 0.1, 0.3],
+        [0.7, 0.1, -0.2, 0.5],
+        [-0.3, 0.5, 0.4, -0.1],
+    ])
+    K = np.array([[1.0, 0.3, 0.1], [0.3, 1.0, 0.25], [0.1, 0.25, 1.0]])
+    factor = np.array([
+        [0.6, 0.0, 0.0, 0.0],
+        [0.1, 0.7, 0.0, 0.0],
+        [-0.05, 0.08, 0.5, 0.0],
+        [0.02, -0.03, 0.07, 0.55],
+    ])
+    B0 = factor @ factor.T
+    Rc = np.kron(np.eye(n_items), np.eye(4) * 0.1) + np.kron(K, B0)
+    actual = condition_item_batch(P0, J0, innovation, Rc)
+    P = np.kron(np.eye(n_items), P0)
+    H = np.kron(np.eye(n_items), J0)
+    dense = gaussian_condition_update(
+        np.zeros(2 * n_items), P, innovation.reshape(-1), Rc, H=H,
+        cross_covariance=np.zeros((2 * n_items, 4 * n_items)), jitter=0.0,
+    )
+    np.testing.assert_allclose(actual.state_mean.reshape(-1), dense.mean, rtol=1e-10, atol=1e-11)
+    np.testing.assert_allclose(actual.full_covariance, dense.covariance, rtol=1e-9, atol=1e-10)
+    assert not actual.loading_diagnostics["was_loaded"]
+    assert not actual.prior_loading_diagnostics["was_loaded"]
+
+
+def test_item_permutation_equivariance_of_materialization_nll_and_posterior():
+    residuals, Ks, Kg = _synthetic_lmc(n=8)
+    model = fit_lmc_model(
+        residuals, Ks, Kg, kind="separable", steps=20, learning_rate=0.03, max_pairs=28, seed=2
+    )
+    covariance = model.materialize(Ks, Kg)
+    permutation = np.array([5, 0, 7, 2, 1, 6, 3, 4])
+    permuted_covariance = model.materialize(Ks[np.ix_(permutation, permutation)], Kg[np.ix_(permutation, permutation)])
+    assert np.isclose(
+        gaussian_joint_nll(residuals, covariance).total,
+        gaussian_joint_nll(residuals[permutation], permuted_covariance).total,
+    )
+    P0 = np.array([[1.1, 0.2], [0.2, 0.8]])
+    J0 = np.array([[1.0, 0.1], [-0.2, 0.9]])
+    original = condition_item_batch(P0, J0, residuals, covariance)
+    permuted = condition_item_batch(P0, J0, residuals[permutation], permuted_covariance)
+    state_indices = np.concatenate([
+        np.arange(2 * item, 2 * item + 2) for item in permutation
+    ])
+    np.testing.assert_allclose(permuted.state_mean, original.state_mean[permutation])
+    np.testing.assert_allclose(
+        permuted.full_covariance,
+        original.full_covariance[np.ix_(state_indices, state_indices)],
+    )


### PR DESCRIPTION
## Summary

This is the evidence-gate follow-up to #3666. It asks whether semantic or graph proximity predicts enough **held cross-item conditional-residual covariance** to justify a larger structured inverse-root/CUDA implementation.

- conditions the four judge channels on prior error first, using `q = v - CᵀP⁻¹e`
- compares global block, regional-mean block, separable semantic/graph covariance, and dense additive LMC
- uses seeds 0–9 with strict node-disjoint retained pairs and train-only fitting
- runs every covariance through the existing joint square-root/QR conditioner
- exposes both prior and conditional-noise loading
- records hashes for the campaign, Luna scores, checkpoint, both E5 caches, graph TSV, and LMDB data
- includes a compact tracked gate/provenance record plus the full human report

## Result

Positive gain means better held joint conditional-residual NLL per scalar.

| Corpus | Regional mean vs global block | Separable covariance vs regional block | Dense LMC vs regional block |
|---|---:|---:|---:|
| Exploratory | +0.181786 ± 0.042311 (10/10) | -0.000575 ± 0.003075 (3/10) | -0.000469 ± 0.003044 (4/10) |
| Fresh | +0.150996 ± 0.031034 (10/10) | -0.002777 ± 0.003890 (2/10) | -0.002923 ± 0.004101 (2/10) |

The preregistered structured-covariance gate **fails**:

- neither structured model has positive mean held gain or 8/10 positive seeds
- separable posterior NLL worsens on both corpora
- fresh decision log-loss worsens by 0.0414 and margin AURC by 0.01165
- no prior or noise covariance required diagonal loading

**Recommendation:** retain independent item blocks in batched QR conditioning. Do not optimize the semantic/graph inverse-root or CUDA path from this evidence.

The useful finding is separate: a train-fitted regional residual mean improves residual likelihood on all 20 corpus/split records. Its decision metrics are not reliably better, so it should be validated as a regional-bias model rather than relabeled as correlated noise.

## Optimizer and audit safeguards

- PSD components are parameterized as `B = LLᵀ`
- both structured fits retain an exact independent-block candidate
- dense LMC retains the exact separable candidate
- zero inherited factors receive a material optimization seed, avoiding the zero-gradient `LLᵀ` trap
- best iterates keep parameters and objectives aligned
- tests require dense recovery on a planted nonseparable field and escape from a zero block start
- held NLL uses common original units; incomparable train-objective units are labeled explicitly
- a post-run read-only audit found and verified fixes for campaign-path provenance and missing graph/E5 hashes

## Scope and non-claims

- The target is GPT-5.5 operating-judge fidelity, not human or judge-independent truth.
- The graph kernel is an RBF over explicit graph features, not graph diffusion or shortest-path covariance.
- This does **not** test the broader purpose of graph supervision—helping a model learn a dataset. That needs the separate training-time graph-supervision × final-fusion factorial experiment.
- `JointPosterior` remains a separate nonlinear decision comparator and is not the QR conditioner.

## Validation

- `101 passed, 9 skipped`
- final 10-seed × 2-corpus provenance rerun
- compact gate JSON exactly matched the full run's engineering-gate object
- staged diff check clean
- final independent re-audit: pass

See:

- `prototypes/mu_cosine/DESIGN_structured_residual_covariance.md`
- `prototypes/mu_cosine/REPORT_structured_residual_covariance.md`
- `prototypes/mu_cosine/repro/structured_residual_covariance/primary_gate_summary.json`
