### PR TITLE
feat(kotlin-wam): CONF-KOTLIN — register cross-target conformance adapter

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -29,6 +29,10 @@ self-contained so a single coding agent can pick it up in isolation.
 | CONF-R | Conformance adapter | R | M | — |
 | CONF-CLOJURE | Conformance adapter | Clojure | L | — |
 | CONF-LUA | Conformance adapter | Lua | M | — |
+| CONF-KOTLIN ✅ | Conformance adapter | Kotlin | M | done — opt-in (`cursor/conf-kotlin-f421`); append green, 5 xfails |
+| KT-LIST-BACKTRACK | Conformance gap fix | Kotlin | M | CONF-KOTLIN |
+| KT-ARITH-SLASH-FUNCTOR | Conformance gap fix | Kotlin | S | CONF-KOTLIN |
+| KT-Y-ENV-RECURSION | Conformance gap fix | Kotlin | M | CONF-KOTLIN |
 | PARSE-C | Runtime-parser entry | C | S | — |
 | PARSE-GO | Runtime-parser entry | Go | S | — |
 | PARSE-SCALA | Runtime-parser entry | Scala | S | — |
@@ -149,6 +153,26 @@ external toolchain.
   6. `ct_teardown(lua, lua_ctx(Dir, Map)) :- cleanup_dir(Dir), abolish_wrappers(Map).`
   7. Add `test(lua, [condition(ct_available(lua))]) :- run_target_conformance(lua).`
 - **Acceptance:** `CONFORMANCE_TARGETS=lua swipl -g run_tests tests/test_wam_cross_target_conformance.pl` passes (skips if `lua` absent).
+
+### CONF-KOTLIN: Register Kotlin in the cross-target conformance harness
+- **Lever:** Conformance adapters  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-2
+- **Status:** ✅ **Landed** on `cursor/conf-kotlin-f421` (2026-07-12). Opt-in `conformance_target(kotlin)` + `kotlin_functions` (interpreter vs `emit_mode(functions)`). Added `WamRuntime.tryRun` + `conformance_main(true)` so Main prints `true`/`false` without changing the human-facing register dump. Gradle `compileKotlin` build gate. **Measured:** `append/3` green; `ct_xfail` for member/reverse (list CDR `Var(Xn)` clobber under backtrack), builtins (`///2` functor split in `evalArith`), fib/ack (scoped Y-regs unbound after recursive call). Follow-ups: KT-LIST-BACKTRACK, KT-ARITH-SLASH-FUNCTOR, KT-Y-ENV-RECURSION.
+- **Goal:** Add a Kotlin adapter so the shared WAM classic-program spec runs against the Kotlin hybrid backend (interpreter and functions modes).
+- **Files to touch:** `tests/test_wam_cross_target_conformance.pl`, `templates/targets/kotlin_wam/WamRuntime.kt.mustache`, `templates/targets/kotlin_wam/Main.kt.mustache`, `src/unifyweaver/targets/wam_kotlin_target.pl`.
+- **Acceptance:** `CONFORMANCE_TARGETS=kotlin,kotlin_functions LANG=C.UTF-8 swipl -q -g run_tests -t halt tests/test_wam_cross_target_conformance.pl` runs both adapters (skips if `gradle` absent); xfails documented; append passes.
+
+### KT-LIST-BACKTRACK: Fix list placeholder clobber under backtracking (Kotlin)
+- **Lever:** Conformance gap fix  **Target:** Kotlin  **Size:** M  **Depends on:** CONF-KOTLIN
+- **Goal:** Retire `ct_xfail(kotlin, member)` / `reverse`. Heap-built lists store CDR as `Var(Xn)`; recursive clauses reuse `Xn` via `unify_variable` and overwrite the binding that shared Structs still reference.
+- **Hint:** deep-copy structs at choice points, or heap refs instead of register-named vars for structure args (same class Haskell fixed with cons-cell finalize).
+
+### KT-ARITH-SLASH-FUNCTOR: Parse `//` functor without split-on-`/` (Kotlin)
+- **Lever:** Conformance gap fix  **Target:** Kotlin  **Size:** S  **Depends on:** CONF-KOTLIN
+- **Goal:** Retire builtins xfail for `cbi_arith`. `evalArith` does `functor.split("/")` so `///2` yields empty name. Strip only a trailing `/<digits>` (WAT/Haskell `bareArithOp` / last-component fix).
+
+### KT-Y-ENV-RECURSION: Y-register bind-through across recursive call (Kotlin)
+- **Lever:** Conformance gap fix  **Target:** Kotlin  **Size:** M  **Depends on:** CONF-KOTLIN
+- **Goal:** Retire fib/ack xfails. After recursive `call`/`execute`, `is/2` sees unbound scoped temps (`Y5@E9`) inside `+/2` trees — permanent-variable / environment bank gap.
 
 ---
 

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -42,17 +42,21 @@ module in the fleet.
 
 - **Lowered emitter scope** — deterministic single-clause only. No T4/T5
   multi-clause, ITE, or `call`/`execute` in lowered bodies (separate cards).
+- **Conformance (opt-in)** — `conformance_target(kotlin)` /
+  `kotlin_functions` registered. **append/3 green**; member/reverse/builtins/fib/ack
+  are `ct_xfail` on measured interpreter gaps (list placeholder clobber under
+  backtrack; `///2` arith functor parse; Y-register bind-through across recursion).
 - **No foreign kernels, no LMDB / fact source, no ISO contract.**
-- **No conformance registration** — no `conformance_target(kotlin)`.
 - **No runtime-parser capability entry.**
 
 ## Path forward
 
-1. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
-2. Add conformance adapter if Kotlin graduates beyond scaffold.
+1. Retire kotlin `ct_xfail`s (list structure-sharing, `//` functor strip, Y-env).
+2. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
+3. Add ISO / kernels if Kotlin graduates beyond scaffold.
 
 ## Document status
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
-(2026-07-12). EMIT-KOTLIN-2 write-mode structure/list lowering landed.
+(2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN landed.

--- a/src/unifyweaver/targets/wam_kotlin_target.pl
+++ b/src/unifyweaver/targets/wam_kotlin_target.pl
@@ -299,12 +299,14 @@ write_wam_kotlin_project(Predicates, Options, ProjectDir) :-
     compile_wam_parts(WamParts, Options, WamCode),
     compile_failed_parts(FailedParts, FailedCode),
     registrar_calls(NativeParts, WamParts, Registrars),
+    option(conformance_main(ConfMain), Options, false),
     render_kotlin_wam_template('Main.kt.mustache', [
         package=Package,
         native_predicates=NativeCode,
         wam_predicates=WamCode,
         failed_predicates=FailedCode,
-        registrar_calls=Registrars
+        registrar_calls=Registrars,
+        conformance_main=ConfMain
     ], MainCode),
     directory_file_path(SrcDir, 'Main.kt', MainPath),
     write_file(MainPath, MainCode),

--- a/templates/targets/kotlin_wam/Main.kt.mustache
+++ b/templates/targets/kotlin_wam/Main.kt.mustache
@@ -16,13 +16,24 @@ fun main(args: Array<String>) {
     val program = buildProgram()
     val predicate = args.firstOrNull() ?: program.predicateNames().firstOrNull()
     if (predicate == null) {
+{{#conformance_main}}
+        println("false")
+{{/conformance_main}}
+{{^conformance_main}}
         println("No WAM predicates registered")
+{{/conformance_main}}
         return
     }
     val runtime = WamRuntime(program)
+{{#conformance_main}}
+    val ok = runtime.tryRun(predicate, stateFromCliArgs(args.drop(1)))
+    println(if (ok) "true" else "false")
+{{/conformance_main}}
+{{^conformance_main}}
     val state = runtime.run(predicate, stateFromCliArgs(args.drop(1)))
     println("Ran $predicate")
     state.snapshotRegisters().forEach { (name, value) ->
         println("$name=$value")
     }
+{{/conformance_main}}
 }

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -336,26 +336,37 @@ class WamRuntime(private val program: WamProgram) {
     private lateinit var currentCode: PredicateCode
 
     fun run(predicate: String, initialState: WamState = WamState()): WamState {
+        if (!tryRun(predicate, initialState)) {
+            error("WAM predicate failed: $predicate")
+        }
+        return initialState
+    }
+
+    // Conformance / boolean entry: native-first, then bytecode; false on
+    // exhaustion (no throw). Used by conformance_main projects so ct_run
+    // can map stdout true/false without relying on exceptions.
+    fun tryRun(predicate: String, initialState: WamState = WamState()): Boolean {
         program.findNative(predicate)?.let { nativeFn ->
             val snapshot = initialState.snapshotForNative()
             if (nativeFn(initialState)) {
-                return initialState
+                return true
             }
             if (program.findCode(predicate) == null) {
                 initialState.restoreFromSnapshot(snapshot)
-                return initialState
+                return false
             }
             initialState.restoreFromSnapshot(snapshot)
         }
-        currentCode = program.codeFor(predicate)
+        val code = program.findCode(predicate) ?: return false
+        currentCode = code
         initialState.pc = 0
         while (initialState.pc in currentCode.instructions.indices) {
             val instruction = currentCode.instructions[initialState.pc]
             if (!step(initialState, instruction) && !restoreChoicePoint(initialState)) {
-                error("WAM instruction failed at pc=${initialState.pc}: $instruction")
+                return false
             }
         }
-        return initialState
+        return true
     }
 
     fun restoreChoicePoint(state: WamState): Boolean {

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -278,6 +278,29 @@ ct_default_target(elixir).
 %  is now recursive and cons-aware ($unify_addrs). Both are conformant;
 %  the skips are removed.
 
+%  Kotlin (CONF-KOTLIN, 2026-07-12). Adapter registered (opt-in). append/3
+%  is GREEN. Remaining classic programs xfail on measured interpreter gaps
+%  (not adapter bugs) — follow-ups tracked in WAM_FLEET_GAP_TASKS.md:
+%   - member/reverse: heap-built list CDRs are Var(Xn) placeholders; later
+%     unify_variable Xn in a recursive clause overwrites that register and
+%     corrupts the shared Struct under backtracking (b/c in [a,b,c] → false).
+%   - builtins: evalArith splits functor on '/' so '///2' (// arity 2) yields
+%     name="" and 17//5 fails closed (same class WAT/Haskell already fixed);
+%     cbi_cmp/cbi_eq already pass.
+%   - fib/ack: permanent Y-registers use scoped names (Y5@E9); after recursive
+%     call, is/2 sees unbound scoped vars in the +/2 tree (environment /
+%     bind-through gap across call/execute).
+ct_xfail(kotlin, member).
+ct_xfail(kotlin, reverse).
+ct_xfail(kotlin, builtins).
+ct_xfail(kotlin, fib).
+ct_xfail(kotlin, ack).
+ct_xfail(kotlin_functions, member).
+ct_xfail(kotlin_functions, reverse).
+ct_xfail(kotlin_functions, builtins).
+ct_xfail(kotlin_functions, fib).
+ct_xfail(kotlin_functions, ack).
+
 % ============================================================
 % Toolchain probes
 % ============================================================

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -69,6 +69,8 @@
 :- use_module(library(pairs)).
 :- use_module('../src/unifyweaver/targets/wam_cpp_target',
               [write_wam_cpp_project/3]).
+:- use_module('../src/unifyweaver/targets/wam_kotlin_target',
+              [write_wam_kotlin_project/3]).
 
 % ============================================================
 % Target registry + known-divergence (xfail) registry
@@ -83,15 +85,15 @@ conformance_target(go).
 conformance_target(rust).
 conformance_target(c).
 conformance_target(cpp).
+conformance_target(kotlin).
+conformance_target(kotlin_functions).
 
 %% ct_default_target(Target): runs unless CONFORMANCE_TARGETS overrides.
 %  Only scala and elixir run by default. Every other registered backend
-%  (wat, haskell, python, go, rust, c, cpp) is conformant — each passes the
-%  whole spec with no ct_xfail/ct_skip entries — but stays opt-in via
-%  CONFORMANCE_TARGETS because it builds a per-program project with an
-%  external toolchain (wat2wasm+node / cabal / python3 / go / cargo / gcc /
-%  g++) that a default run should not require or pay for. Haskell is the
-%  slowest (a cabal compile per program); audited green 2026-06.
+%  (wat, haskell, python, go, rust, c, cpp, kotlin, kotlin_functions) is
+%  opt-in via CONFORMANCE_TARGETS because it builds a per-program project
+%  with an external toolchain. Kotlin is especially slow (gradle compile
+%  per program) and stays opt-in like Haskell.
 ct_default_target(scala).
 ct_default_target(elixir).
 
@@ -289,6 +291,8 @@ ct_toolchain(go,     [go]).
 ct_toolchain(rust,   [cargo]).
 ct_toolchain(c,      [gcc]).
 ct_toolchain(cpp,    ['g++']).
+ct_toolchain(kotlin, [gradle]).
+ct_toolchain(kotlin_functions, [gradle]).
 
 ct_available(scala) :-
     ct_enabled(scala),
@@ -330,6 +334,9 @@ test(go,     [condition(ct_available(go))])     :- run_target_conformance(go).
 test(rust,   [condition(ct_available(rust))])   :- run_target_conformance(rust).
 test(c,      [condition(ct_available(c))])      :- run_target_conformance(c).
 test(cpp,    [condition(ct_available(cpp))])    :- run_target_conformance(cpp).
+test(kotlin, [condition(ct_available(kotlin))]) :- run_target_conformance(kotlin).
+test(kotlin_functions, [condition(ct_available(kotlin_functions))]) :-
+    run_target_conformance(kotlin_functions).
 
 :- end_tests(wam_cross_target_conformance).
 
@@ -960,6 +967,59 @@ ct_run(cpp, cpp_ctx(Dir, Map), K, A, Bool) :-
     ; throw(cpp_run_failed(KeyAtom, Status)) ).
 
 ct_teardown(cpp, cpp_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+
+% ============================================================
+% Adapter: Kotlin  (0-arity wrapper -> gradle run --args=<key> -> true/false)
+%
+% write_wam_kotlin_project/3 emits a Gradle Kotlin project. The human-facing
+% Main prints "Ran <pred>" + registers; for conformance we pass
+% conformance_main(true) so Main uses WamRuntime.tryRun and prints true/false
+% (additive — default Main output for existing e2e tests is unchanged).
+%
+% Two opt-in targets share this adapter:
+%   kotlin            — emit_mode(interpreter)
+%   kotlin_functions  — emit_mode(functions) (native-first + WAM fallback)
+% Classic multi-clause programs (member/append/fib/…) decline lowering and
+% stay on the interpreter under kotlin_functions; that is expected until
+% EMIT-KOTLIN-3 (multi-clause / call in lowered bodies).
+% ============================================================
+
+ct_build(kotlin, Preds, Queries, kotlin_ctx(Dir, Map)) :-
+    kotlin_ct_build(interpreter, Preds, Queries, Dir, Map).
+
+ct_build(kotlin_functions, Preds, Queries, kotlin_ctx(Dir, Map)) :-
+    kotlin_ct_build(functions, Preds, Queries, Dir, Map).
+
+kotlin_ct_build(EmitMode, Preds, Queries, Dir, Map) :-
+    ct_tmp_dir('tmp_ct_kotlin', Dir),
+    synth_wrappers(Queries, WPreds, Map),
+    maplist(strip_pred, Preds, BarePreds),
+    append(WPreds, BarePreds, AllPreds0),
+    maplist(qualify_user, AllPreds0, AllPreds),
+    write_wam_kotlin_project(AllPreds,
+        [module_name(wam_ct),
+         emit_mode(EmitMode),
+         conformance_main(true)], Dir),
+    run_proc(gradle, ['-q', 'compileKotlin'], Dir, BExit, BErr),
+    ( BExit =:= 0 -> true ; throw(kotlin_build_failed(BExit, BErr)) ).
+
+ct_run(kotlin, Ctx, K, A, Bool) :-
+    kotlin_ct_run(Ctx, K, A, Bool).
+ct_run(kotlin_functions, Ctx, K, A, Bool) :-
+    kotlin_ct_run(Ctx, K, A, Bool).
+
+kotlin_ct_run(kotlin_ctx(Dir, Map), K, A, Bool) :-
+    memberchk((K-A)-WName, Map),
+    format(atom(KeyAtom), '~w/0', [WName]), atom_string(KeyAtom, KeyStr),
+    format(atom(ArgsOpt), '--args=~w', [KeyStr]),
+    run_proc_out(gradle, ['-q', 'run', ArgsOpt], Dir, _Exit, OutStr),
+    normalize_space(string(Out), OutStr),
+    bool_of_string(Out, Bool).
+
+ct_teardown(kotlin, kotlin_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+ct_teardown(kotlin_functions, kotlin_ctx(Dir, Map)) :-
     cleanup_dir(Dir), abolish_wrappers(Map).
 
 %% c_copy_runtime_header(+Dir) — copy the static wam_runtime.h into Dir.

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -87,6 +87,7 @@ test(runtime_template_exposes_executable_wam_abi) :-
     assertion(has_substring(Code, '"put_value", "put_unsafe_value"')),
     assertion(has_substring(Code, 'fun registerNative(key: String, fn: (WamState) -> Boolean)')),
     assertion(has_substring(Code, 'fun snapshotForNative(): WamNativeSnapshot')),
+    assertion(has_substring(Code, 'fun tryRun(predicate: String, initialState: WamState')),
     assertion(has_substring(Code, 'fun kotlinLoGetConstant(state: WamState')),
     assertion(has_substring(Code, 'fun stateFromCliArgs(values: List<String>): WamState')).
 
@@ -384,5 +385,36 @@ test(registry_exposes_wam_kotlin_target, [nondet]) :-
     target_registry:target_family(wam_kotlin, jvm),
     target_registry:target_has_capability(wam_kotlin, wam),
     target_registry:target_module(wam_kotlin, wam_kotlin_target).
+
+test(conformance_main_prints_true_false, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_conformance_main',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt_fact(_, _)),
+            assertz(user:kt_fact(alpha, beta))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt_fact/2],
+                [emit_mode(functions), conformance_main(true)], TmpDir),
+            read_file_to_string(
+                'output/test_wam_kotlin_conformance_main/src/main/kotlin/generated/wam/Main.kt',
+                Main, []),
+            assertion(has_substring(Main, 'tryRun')),
+            assertion(has_substring(Main, 'println(if (ok) "true" else "false")')),
+            assertion(\+ has_substring(Main, 'Ran $predicate')),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_fact/2 alpha beta'],
+                       OkOut, _OkErr, OkStatus),
+            assertion(OkStatus == exit(0)),
+            normalize_space(string(OkTrim), OkOut),
+            assertion(OkTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_fact/2 alpha gamma'],
+                       BadOut, _BadErr, BadStatus),
+            assertion(BadStatus == exit(0)),
+            normalize_space(string(BadTrim), BadOut),
+            assertion(BadTrim == "false")
+        ),
+        retractall(user:kt_fact(_, _))
+    ).
 
 :- end_tests(wam_kotlin_target).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Registers the Kotlin hybrid WAM target in the cross-target conformance harness (**CONF-KOTLIN**). Opt-in only — does not slow the default scala/elixir run.

## Success signal

`WamRuntime.run` previously threw on failure. Added `tryRun(...): Boolean` and a `conformance_main(true)` project option so generated `Main` prints `true` / `false` for the harness. Default human-facing `"Ran <pred>"` + register dump is unchanged.

## Adapter

- `conformance_target(kotlin)` — `emit_mode(interpreter)`
- `conformance_target(kotlin_functions)` — `emit_mode(functions)` (native-first + WAM fallback; classic multi-clause programs still decline to the interpreter)
- `ct_toolchain(..., [gradle])`, gradle `compileKotlin` build gate, `gradle -q run --args=<ctw_N/0>`
- Not in `ct_default_target`

## Measured maturity

| Program | Result |
|---|---|
| **append** | **green** |
| member | `ct_xfail` — list CDR `Var(Xn)` clobber under backtrack |
| reverse | `ct_xfail` — same list-sharing class |
| builtins | `ct_xfail` — `///2` functor split in `evalArith` (`//`); cmp/eq pass |
| fib / ack | `ct_xfail` — scoped Y-regs unbound after recursive call |

Follow-up cards: `KT-LIST-BACKTRACK`, `KT-ARITH-SLASH-FUNCTOR`, `KT-Y-ENV-RECURSION`.

## Verification

```bash
LANG=C.UTF-8 swipl -q -g run_tests -t halt tests/test_wam_kotlin_target.pl   # green
LANG=C.UTF-8 CONFORMANCE_TARGETS=kotlin,kotlin_functions \
  swipl -q -g run_tests -t halt tests/test_wam_cross_target_conformance.pl   # green (xfails logged)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

