### PR TITLE
Add Rust current_predicate/1 ISO errors

### DIFF
--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -219,6 +219,18 @@
         }
     }
 
+    fn raise_iso_error(&mut self, formal: Value) -> bool {
+        self.var_counter += 1;
+        self.thrown_ball = Some(Value::Str(
+            "error/2".to_string(),
+            vec![
+                formal,
+                Value::Unbound(format!("_EC{}", self.var_counter)),
+            ],
+        ));
+        false
+    }
+
     fn raise_read_syntax_error(&mut self) -> bool {
         self.var_counter += 1;
         let context = Value::Unbound(format!("_SE{}", self.var_counter));
@@ -698,24 +710,41 @@
     fn current_predicate_call(&mut self, cont_pc: usize) -> bool {
         let spec_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
         let spec = self.deref_heap(&self.deref_var(&spec_raw));
-        let (name, arity) = match spec {
+        let (name, arity) = match &spec {
+            Value::Unbound(_) | Value::Uninit => {
+                return self.raise_iso_error(Value::Atom(
+                    "instantiation_error".to_string(),
+                ));
+            }
             Value::Str(functor, args)
-                if args.len() == 2 && Self::display_functor_name(&functor, 2) == "/" =>
+                if args.len() == 2 && Self::display_functor_name(functor, 2) == "/" =>
             {
                 (
                     self.deref_heap(&self.deref_var(&args[0])),
                     self.deref_heap(&self.deref_var(&args[1])),
                 )
             }
-            _ => return false,
+            _ => {
+                return self.raise_iso_error(Value::Str(
+                    "type_error/2".to_string(),
+                    vec![
+                        Value::Atom("predicate_indicator".to_string()),
+                        spec,
+                    ],
+                ));
+            }
         };
         if !matches!(&name, Value::Atom(_) | Value::Unbound(_)) {
-            return false;
+            return self.raise_iso_error(Value::Str(
+                "type_error/2".to_string(),
+                vec![Value::Atom("atom".to_string()), name],
+            ));
         }
-        if !matches!(&arity, Value::Integer(n) if *n >= 0) &&
-            !matches!(&arity, Value::Unbound(_))
-        {
-            return false;
+        if !matches!(&arity, Value::Integer(_) | Value::Unbound(_)) {
+            return self.raise_iso_error(Value::Str(
+                "type_error/2".to_string(),
+                vec![Value::Atom("integer".to_string()), arity],
+            ));
         }
 
         let mut all_keys = std::collections::BTreeSet::new();

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -298,6 +298,12 @@ fn current_predicate_backtracks_over_matching_dynamic_arities() {
         if !vm.backtrack() { break; }
     }
     assert_eq!(arities, vec![Value::Integer(1), Value::Integer(2)]);
+
+    vm.reset_query();
+    vm.set_reg_str("A1", fact("/", vec![at("dyn"), Value::Integer(-1)]));
+    vm.pc = 1;
+    assert!(!vm.run());
+    assert!(vm.thrown_ball.is_none());
 }
 
 #[test]
@@ -313,6 +319,30 @@ fn generated_tail_current_predicate_call_reads_static_labels() {
     assert!(vm.run());
     let arity = vm.bindings.get("Arity").cloned().expect("Arity bound");
     assert_eq!(vm.deref_heap(&vm.deref_var(&arity)), Value::Integer(2));
+}
+
+#[test]
+fn generated_current_predicate_errors_are_catchable() {
+    let (code, labels) = shared_wam_program();
+    for pred in [
+        "rust_current_predicate_instantiation_demo/1",
+        "rust_current_predicate_type_demo/1",
+        "rust_current_predicate_name_type_demo/1",
+        "rust_current_predicate_arity_type_demo/1",
+    ] {
+        let mut vm = WamState::new(code.clone(), labels.clone());
+        vm.set_reg_str("A1", ub("Result"));
+        vm.pc = *vm.labels.get(pred).expect("generated error demo label");
+
+        assert!(vm.run(), "{} should catch its error", pred);
+        assert_eq!(
+            vm.bindings.get("Result"),
+            Some(&at("caught")),
+            "{} recovery should run",
+            pred,
+        );
+        assert!(vm.thrown_ball.is_none(), "{} should consume the error", pred);
+    }
 }
 
 #[test]

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -20,6 +20,34 @@ rust_clause_demo(X, Body) :-
 rust_current_predicate_demo(Name, Arity) :-
     current_predicate(Name/Arity).
 
+:- dynamic rust_current_predicate_instantiation_demo/1.
+rust_current_predicate_instantiation_demo(Result) :-
+    catch(
+        current_predicate(_),
+        error(instantiation_error, _),
+        Result = caught).
+
+:- dynamic rust_current_predicate_type_demo/1.
+rust_current_predicate_type_demo(Result) :-
+    catch(
+        current_predicate(not_an_indicator),
+        error(type_error(predicate_indicator, _), _),
+        Result = caught).
+
+:- dynamic rust_current_predicate_name_type_demo/1.
+rust_current_predicate_name_type_demo(Result) :-
+    catch(
+        current_predicate(7/1),
+        error(type_error(atom, _), _),
+        Result = caught).
+
+:- dynamic rust_current_predicate_arity_type_demo/1.
+rust_current_predicate_arity_type_demo(Result) :-
+    catch(
+        current_predicate(named/not_an_arity),
+        error(type_error(integer, _), _),
+        Result = caught).
+
 :- dynamic rust_predicate_property_demo/2.
 rust_predicate_property_demo(Head, Property) :-
     predicate_property(Head, Property).
@@ -58,6 +86,10 @@ test(assert_retract_dynamic_db,
          user:rust_assert_alias_demo/0,
          user:rust_clause_demo/2,
          user:rust_current_predicate_demo/2,
+         user:rust_current_predicate_instantiation_demo/1,
+         user:rust_current_predicate_type_demo/1,
+         user:rust_current_predicate_name_type_demo/1,
+         user:rust_current_predicate_arity_type_demo/1,
          user:rust_predicate_property_demo/2,
          user:rust_read_term_options_demo/2,
          user:rust_atom_to_term_demo/2,


### PR DESCRIPTION
## Summary

- add a reusable Rust runtime constructor for catchable `error/2` terms
- raise `instantiation_error` for an unbound predicate indicator
- raise `type_error(predicate_indicator, Term)` for malformed indicators
- raise `type_error(atom, Name)` for invalid predicate names
- raise `type_error(integer, Arity)` for invalid arities
- allow negative integer arities to fail normally without throwing
- keep all new work confined to `current_predicate/1` error paths

## Testing

- generated `catch/3` tests for all four error forms
- negative-arity non-error regression
- focused Rust dynamic builtin suite
- full Rust WAM target suite
- patch whitespace validation