### PR TITLE
mu_cosine: calibrate covariance sensitivity + adjacency-aware batching design

### DIFF
--- a/prototypes/mu_cosine/DESIGN_adjacent_row_residual_correlation.md
+++ b/prototypes/mu_cosine/DESIGN_adjacent_row_residual_correlation.md
@@ -1,0 +1,142 @@
+# Explicit adjacent-row residual correlation — follow-up design
+
+## Status and question
+
+This is a future, post-hoc design written after the covariance-sensitivity controls exposed mean/covariance
+identifiability, but before computing adjacency-stratified residual statistics.  The only inspected inputs were
+outcome-blind graph incidence/counts.
+
+The question is distinct from the confirmed `Sigma(hop)` result:
+
+- `Sigma(hop)` asks whether one row's within-item D/S error block depends on the hop between that row's node
+  and root.
+- This study asks whether two different rows scored by the same judge have correlated errors when their graph
+  locations are adjacent.
+
+The engineering endpoint is a validated distance-separated batching rule: keep the full within-item judge
+block everywhere, and omit cross-item covariance only when predicted whitened coupling is negligible.
+
+## Outcome-blind inventory
+
+On the exact matched rows used by #3671:
+
+| Cross-row relation | Exploratory (1,000 rows) | Fresh (700 rows) |
+|---|---:|---:|
+| Same root; descendant nodes one edge apart | 0 | 0 |
+| Same descendant; roots one edge apart | 84 pairs / 139 rows | 206 pairs / 285 rows |
+| Any endpoints one edge apart | 876 pairs / 519 rows | 688 pairs / 372 rows |
+| At least one exact shared endpoint | 824 pairs / 582 rows | 841 pairs / 569 rows |
+
+The primary existing-data contrast is therefore **same descendant, adjacent roots** versus **the same
+descendant, nonadjacent roots**.  This controls the shared-descendant effect while varying direct root
+adjacency.  The reverse direction (same root, adjacent descendants) requires a deliberately sampled corpus.
+
+### Adjacent positives and distant negatives
+
+Treat adjacency-enriched sampling as a contrastive design, analogous in role (not identical likelihood) to
+negative sampling in word2vec:
+
+```text
+(anchor row, adjacent positive row, matched distant negative row).
+```
+
+Adjacent positives teach local smoothing and dataset topology.  Distant negatives identify where smoothing
+must stop and supply candidate near-independent pairs for block batching.  Match negatives on shared
+descendant/root family, row hop, campaign tag, and judge where possible; include hard negatives that are
+semantically similar but graph-distant so the task cannot be solved from trivial domain differences.
+
+The representation/mean objective and covariance objective remain separate.  Contrastive adjacency can train
+the graph judge/model to know the dataset; cross-fitted residuals then determine whether same-judge error
+coupling persists after that learned mean has been removed.
+
+## Residual and split contract
+
+Use the existing conditional residual convention
+
+```text
+e = truth - prior
+v = measurement - H truth
+q = v - C.T P^-1 e.
+```
+
+Calibration, graph scaling, regional mean, and within-item block covariance are fit on training components
+only.  Outer partitions are connected-component-disjoint under exact shared endpoints; crossing rows are
+dropped.  The regional mean is cross-fit before any adjacency covariance statistic is computed so a smooth
+mean realization is not relabelled as random covariance.
+
+The target remains GPT-5.5 operating-judge fidelity, not independent truth.  Existing labels make this a
+post-hoc reuse study; a later purpose-built sample must be registered before new judge calls.
+
+## Primary adjacency statistic
+
+Whiten held residual rows by the train-fitted within-item block `B`:
+
+```text
+z_i = B^-1/2 (q_i - m_hat_i).
+```
+
+For each adjacent row-pair, use the symmetric cross-product
+
+```text
+G_ij = 0.5 * (z_i z_j.T + z_j z_i.T).
+```
+
+Compare its mean with matched same-descendant/nonadjacent-root controls.  Report the full channel matrix,
+spectral norm, signs, and per-channel diagonal—not only one pooled correlation.  Inference uses a
+component-preserving permutation within corpus/tag/hop strata (`K >= 1000`); rows are never bootstrapped as
+IID observations.
+
+## PSD predictive comparator
+
+An adjacency matrix is not automatically PSD.  Build a row feature map from endpoint and one-hop-neighborhood
+incidence (or a preregistered graph diffusion feature map), normalize rows, and use its Gram matrix
+
+```text
+K_adj = Phi Phi.T.
+```
+
+The deployable comparator selects only correlation trust
+
+```text
+alpha in {0, .025, .05, .10, .20, .35, .50, .75, 1}
+```
+
+at one frozen adjacency geometry.  Bandwidth/channel-shape variants remain oracle sensitivity diagnostics;
+they do not enter deployment selection.  Nested selection must use a family-wise block-null threshold that
+repeats mean fitting and preserves overlapping components.
+
+Compare regional block, adjacency covariance, and a matched parameter-count nonadjacency kernel on full held
+joint residual NLL.  Then pass the covariance to the joint square-root/QR conditioner and report posterior
+NLL, decision log-loss/AURC, and prior/noise loading.
+
+## Identification and repeated-judge extension
+
+One residual field can confound a smooth fixed bias with a smooth random effect.  The existing-data study can
+establish predictive adjacency structure but cannot cleanly separate those causes.  A confirmatory corpus
+should therefore score the same adjacency-enriched items with at least two independent judge draws.  That
+supports separate estimates of persistent item bias, within-run adjacent error coupling, and run-to-run judge
+variation.
+
+Synthetic controls must include:
+
+- block null with regional mean refitting;
+- smooth mean only;
+- equal-energy permuted adjacency geometry;
+- planted adjacency coupling at 0.04, 0.10, and 0.20;
+- oracle-mean/known-marginal mechanism power separately from end-to-end nuisance estimation.
+
+## Gate and batching consequence
+
+Call explicit adjacency covariance promising only if its nested-selected NLL gain is positive on both corpora
+and at least 8/10 component-disjoint partitions per corpus, its family-wise null is rejected, posterior NLL
+does not worsen, and decision log-loss/AURC degradation stays within 0.01.
+
+If the gate passes, estimate a conservative separation threshold from
+
+```text
+norm(B^-1/2 R_ij B^-1/2, 2) <= epsilon_batch
+```
+
+on fresh held components.  Items beyond that validated threshold may use independent/block updates; adjacent
+connected components remain joint QR blocks.  If the gate fails, retain block batching for this adjacency
+definition without claiming that all possible graph geometries are independent.

--- a/prototypes/mu_cosine/DESIGN_covariance_sensitivity.md
+++ b/prototypes/mu_cosine/DESIGN_covariance_sensitivity.md
@@ -1,0 +1,311 @@
+# Covariance misspecification sensitivity — nested shrinkage protocol
+
+## Status and question
+
+This is a post-hoc follow-up to the merged structured-residual evidence gate (#3671).  That gate established
+that the fitted semantic/graph covariance models did not improve held estimates when their plug-in covariance
+was treated as exact.  It did **not** establish that accurate correlation information is useless.
+
+The question here is narrower:
+
+> Did #3671 fail because the tested correlation geometry had no useful held signal, or because a real but
+> uncertain covariance estimate was too aggressive when inverted?
+
+No new judge calls are used.  Results remain GPT-5.5 operating-judge fidelity rather than independent truth.
+Because this hypothesis was formulated after inspecting #3671, this study is explicitly post-hoc and uses new
+outer partition seeds rather than retroactively changing the earlier gate.
+
+### Synthetic-control erratum (recorded before the corrected v2 rerun)
+
+The first v1 synthetic output is retained only as an invalidated diagnostic.  It scored the residual after a
+train-fitted KRR mean, `c = e_H - W e_T`, but used the pre-KRR held covariance `R_HH` as its “known truth.”  Even
+for fixed `W`, the correct covariance is
+
+```text
+R_HH + W R_TT W.T - R_HT W.T - W R_TH,
+```
+
+and selecting the KRR kernel/ridge from the same outcome field makes `W` random.  Consequently the original
+known-truth NLL/posterior recovery fractions are invalid (the spuriously positive block-null denominator is a
+direct symptom).  Corrected v2 separates an end-to-end KRR selection/harm track, which makes no such recovery
+claim, from an oracle-zero-mean/known-block mechanism track where `R_HH` really is the scored covariance.
+
+The first wrong-geometry control was also underpowered by construction: its narrow unrelated RBF had roughly
+32 times less RMS off-item coupling.  Corrected v2 uses a fixed derangement congruence `P K P.T`, preserving
+PSD, spectrum, maximum coupling, and off-diagonal energy while assigning covariance to the wrong item pairs.
+Because this also preserves the dense uncentered RBF's positive/common mode, the deranged result is a
+common-mode diagnostic rather than an orthogonal block-selection negative control.
+
+## Why covariance error can matter
+
+For the prior-centered conditional update,
+
+```text
+A(R) = P^-1 + J.T R^-1 J
+b(R) = J.T R^-1 r
+x(R) = A(R)^-1 b(R).
+```
+
+For a symmetric perturbation `dR`, the first-order posterior-mean response is
+
+```text
+dx = -A^-1 J.T R^-1 dR R^-1 (r - J x).
+```
+
+Square-root QR stabilizes the computation for a supplied `R`; it cannot make a misspecified `R` statistically
+correct.  This protocol therefore measures both predictive performance and the response of the estimate to
+PSD-preserving covariance perturbations.
+
+## Gaussian distance uncertainty and the RBF kernel
+
+The covariance indices are kept distinct:
+
+```text
+Cov(error[item i, channel a], error[item j, channel b])
+    = K_item(i,j) * Sigma_channel(a,b).
+```
+
+The product is ordinary scalar multiplication.  If `Sigma_channel` is fixed, then
+`E[K_item * Sigma_channel] = E[K_item] * Sigma_channel`.
+
+If a signed scalar separation `D ~ Normal(mu, tau^2)` is inserted into an RBF,
+
+```text
+E exp(-D^2 / (2 ell^2))
+  = ell / sqrt(ell^2 + tau^2)
+    * exp(-mu^2 / (2 (ell^2 + tau^2))).
+```
+
+For isotropic Gaussian uncertainty on two feature vectors, the normalized expected kernel is an RBF with a
+broader effective length scale.  Thus homogeneous Gaussian distance uncertainty is already a length-scale
+misspecification problem.  Merely drawing arbitrary covariance entries from a Gaussian distribution would
+not guarantee a PSD matrix and is excluded.
+
+Because the source predictions live nominally in mu-space with neutral point `0.5`, also record the distinct
+signed linear geometry
+
+```text
+z_i = calibrated_source_vector_i - 0.5
+K_mu(i,j) = z_i.T z_j / (norm(z_i) norm(z_j)).
+```
+
+This is a normalized Gram matrix and therefore PSD; positive similarity means that the available sources put
+two items on broadly the same side of neutral.  It is **not** an RBF correction: subtracting the same `0.5`
+from both arguments leaves every RBF distance unchanged.  The six-vector is the train-fitted calibrated
+`[prior_D, prior_S, graph_D, graph_S, luna_D, luna_S]` representation, evaluated on held rows without held
+outcomes.  Affine calibration may extrapolate slightly outside `[0,1]`; values are not clipped after looking
+at held data.
+
+The centered-mu kernel replaces the graph-feature RBF in a separately labelled secondary geometry family.
+It uses semantic multipliers `{0.5, 1, 2}`, the same `alpha` and `beta` grids, and no graph bandwidth.  It gets
+its own nested selection and null-max calibration and cannot make the primary graph/semantic gate pass.
+Normalization makes this a direction/sign kernel and deliberately removes the literal product's amplitude
+with distance from `0.5`.  The unnormalized product is implemented and tested as a PSD Gram, but is excluded
+from this grid because its item-varying diagonal would change the within-item marginal; testing it fairly
+requires a later per-item marginal-whitening extension rather than pretending it is the normalized kernel.
+
+### Distance-separated batching implication
+
+For a defensible RBF geometry, sufficiently separated items have negligible off-item covariance.  The
+operational criterion is not raw distance alone but the whitened cross-block coupling
+
+```text
+norm(B_item^-1/2 R_ij B_item^-1/2, 2) <= epsilon_batch.
+```
+
+For `K(d)=exp(-d^2/(2 ell^2))`, the scalar kernel is about `0.011` at `d=3 ell` and `0.00034` at `d=4 ell`.
+This motivates a future distance-separated batching policy: retain the full within-item judge block, put
+items with negligible predicted coupling in the same independent/block update, and keep nearby connected
+components separate or condition them jointly.  Distance uncertainty broadens the effective kernel, so the
+separation threshold must use the uncertainty-inflated length scale.  This is a sufficient engineering rule
+when the geometry is validated; failure of the tested geometry does not prove nearby residuals independent.
+
+## Data and nested split contract
+
+Use the same immutable campaign, Luna, checkpoint, graph, and E5 artifacts recorded by #3671.
+
+For each corpus and each **outer seed 10 through 19**:
+
+1. Create the same strict node-disjoint 40% held-node split with 64 outcome-blind candidates.  The retained
+   outer-held rows are never used for calibration, covariance fitting, or hyperparameter selection.
+2. Create three inner node-disjoint partitions with seeds `10000 + 3*outer_seed + k`, `k=0,1,2`, 35% held
+   nodes, 64 candidates, and campaign-neighborhood stratification.  These are repeated inner partitions, not
+   independent population folds.
+3. On each inner-fit partition only, refit source calibration, `P/C/R`, graph feature scaling, regional-mean
+   selection, RBF base bandwidths, and covariance components.
+4. Select covariance trust/geometry by macro inner-held joint conditional-residual NLL per scalar, subject to
+   the conservative stability rule below.
+5. Refit every selected statistical object on all outer-train rows, relative to newly computed outer-train
+   median bandwidths, then evaluate once on outer-held.
+
+The outer seeds are new partitions but not new labels; mean and SD remain partition-stability descriptions,
+not population confidence intervals.
+
+## PSD-preserving sensitivity family
+
+The independent baseline is `R_block = I kron B_block`.  The structured endpoint is the separable model from
+#3671, refit at each semantic/graph kernel-scale pair:
+
+```text
+R_struct = I kron B0
+         + (w_sem K_sem + w_graph K_graph) kron B_shared.
+```
+
+Before varying correlation, match the structured endpoint to the block marginal.  If `A_struct` is the
+constant within-item diagonal block of `R_struct`, form the correlation-like matrix
+
+```text
+C_struct = (I kron A_struct^-1/2) R_struct (I kron A_struct^-1/2).T
+```
+
+using Cholesky solves, not an explicit inverse.  Then, with `B_block = L_block L_block.T`, define the primary
+path
+
+```text
+R(alpha) = (I kron L_block)
+           [(1-alpha) I + alpha C_struct]
+           (I kron L_block).T.
+```
+
+Every point is PSD and every within-item block remains exactly `B_block`; only cross-item correlation changes.
+The direct convex blend of the two raw covariances is retained as a secondary diagnostic and cannot be used
+to claim a correlation-only effect.
+
+Three uncertainty axes are varied:
+
+1. **Correlation strength / trust**
+
+   ```text
+   alpha in {0, 0.025, 0.05, 0.10, 0.20, 0.35, 0.50, 0.75, 1.0}.
+   ```
+
+   `alpha=0` means do not trust cross-item correlation; `alpha=1` uses the full fitted correlation pattern
+   while retaining block-model marginals.
+
+2. **Item-distance scale**
+
+   ```text
+   semantic multiplier in {0.5, 1.0, 2.0};
+   graph-feature multiplier in {0.5, 1.0, 2.0}.
+   ```
+
+   `1.0` is each fit partition's train-median RBF bandwidth.  Values below/above it test correlations that
+   decay faster/slower.  The broader side also covers homogeneous Gaussian input-distance uncertainty after
+   kernel normalization.  The component factors are refit for every one of the nine bandwidth pairs.
+
+3. **Channel-covariance shape**
+
+   ```text
+   B_shared(beta) = (1-beta) B_shared + beta diag(B_shared),
+   beta in {0, 0.5, 1.0}.
+   ```
+
+   This is also PSD.  It tests whether uncertain cross-channel interaction terms, rather than item correlation
+   itself, destabilize the estimate.
+
+Equivalent `alpha=0` copies count once.  A nonzero candidate must beat block on at least two of the three inner
+partitions.  Among eligible candidates, find the best macro inner NLL, then select the smallest `alpha` within
+`0.001` NLL/scalar of it; remaining ties prefer larger `beta`, then semantic/graph multipliers closest to 1.0.
+If no eligible candidate has positive macro gain, select block.  This conservative rule is fixed before outer
+results exist.
+
+## Outer-held records
+
+For every outer split report:
+
+- regional block (`alpha=0`);
+- the nested-selected covariance;
+- the full plug-in covariance at the nested-selected geometry (`alpha=1`);
+- the original canonical plug-in endpoint (`alpha=1`, multiplier 1, `beta=0`);
+- the best point on the **outer-held** perturbation grid, clearly labelled a non-deployable oracle diagnostic.
+
+The oracle is upward-biased by grid search and is not evidence for a usable estimator.  On each exact held
+geometry, draw 200 residual fields from the fitted block null, repeat the identical oracle grid search, and
+record the 95th percentile of the null maximum gain.  A real oracle gain is called `above_null_max95` only
+when it exceeds that split-specific threshold.  Even then it remains diagnostic.  It separates two possible
+failure modes:
+
+- null-calibrated oracle headroom but nested selection fails: possible covariance value with inadequate
+  estimation/selection;
+- even oracle does not help: magnitude/length/channel-shape errors within this family do not explain #3671.
+
+## Metrics and sensitivity diagnostics
+
+Primary:
+
+- outer-held full joint conditional-residual Gaussian NLL per scalar.
+
+Posterior/decision guardrails:
+
+- bivariate posterior NLL, MSE, Mahalanobis/dimension, and 95% ellipse coverage;
+- accuracy, log-loss, ECE-10, and margin AURC from an outer-train-only bridge;
+- prior/noise diagonal loading.
+
+Sensitivity:
+
+- normalized analytic directional derivative of the posterior mean along `R_struct - R_block`;
+- mean per-item norm of `dx/dalpha`;
+- posterior-mean and NLL ranges along the nested-selected correlation path, plus NLL across the full outer
+  perturbation grid (conditioning every oracle candidate would turn a diagnostic grid into an avoidable
+  cubic-time model-selection workload);
+- selected `alpha`, kernel multiplier, and `beta` stability across partitions.
+
+For covariance-estimation stability, use 100 deterministic 80%-node induced subsamples of each outer-train
+set at fixed selected **primary-family** hyperparameters.  Refit calibration, regional mean, scaling, and
+covariance on each subsample; this is a stability analysis, not a bootstrap confidence interval.  Report the
+whitened covariance error radius, posterior-sigma-normalized mean displacement, mean marginal symmetric
+Gaussian KL, log-standard-deviation change, and decision-flip rate.  Individual rows are never bootstrapped
+as though independent.  The later-added centered-mu geometry is an endogenous secondary diagnostic and does
+not double this 2,000-refit stability budget; it cannot make the primary gate pass.
+
+Before fitting an outer split, deterministically enumerate all requested induced-node subsets.  Every subset
+must retain at least 20 rows and non-degenerate semantic and graph-feature geometry; otherwise abort that
+split before its expensive fits rather than silently dropping, replacing, or redefining a replicate.  The
+composite-likelihood pair-sampling seed is held fixed across the 100 subsets so the stability distribution
+reflects changed nodes/data rather than an avoidable second source of optimizer randomness.
+
+## Synthetic truth control
+
+Run 100 **selection-procedure controls with known covariance endpoints** per frozen scenario on deterministic
+RBF item geometry with known block and Kronecker channel covariance.  Each replicate refits the regional mean
+and block marginal and runs the same three-fold conservative `alpha`/length/channel selector, but deliberately
+does not re-run the real-data LMC optimizer: these controls isolate selector power and covariance
+misspecification from component-estimation quality.  Scenarios are block-null, regional-mean-only, wrong item
+geometry, and in-family maximum whitened coupling 0.04, 0.10, and 0.20.  Compare residual risk using:
+
+- the true covariance;
+- the independent block covariance;
+- under- and over-correlated strength;
+- incorrect shorter/longer RBF scales;
+- incorrect channel interaction shrinkage.
+
+For null, mean-only, and wrong-geometry scenarios, require mean held harm no greater than 0.001 NLL/scalar and
+block/conservative selection in at least 80% of replicates.  At coupling 0.10 and 0.20, require nonzero-alpha
+selection in at least 80% and recovery of at least 50% of the true-covariance oracle NLL/posterior-risk gain.
+Coupling 0.04 is a measured-power scenario with no required success.  These are mechanism checks, not evidence
+that the campaign has that covariance.
+
+## Historical v1 interpretation gate — disabled after synthetic controls
+
+The text below records the originally frozen v1 gate.  It must **not** be applied: v1 failed family-wise
+synthetic calibration, and its conditional fixed-path null omits mean/marginal fitting uncertainty.  No v1
+real-data result can be called robustly useful or oracle-headroom evidence under this rule.  The versioned v2
+requirements are in `DESIGN_covariance_sensitivity_v2_null_calibration.md`; a real-data full-procedure v2
+selector is not implemented in this PR.
+
+The nested-selected covariance is considered robustly useful only if it has positive mean outer-held residual
+NLL gain over block on both corpora, is positive on at least 8/10 seeds per corpus, does not worsen posterior
+NLL, and keeps decision log-loss/AURC degradation within 0.01.
+
+If that gate fails but the real oracle gain exceeds its null-max95 threshold and is positive on at least 8/10
+splits in both corpora, report **oracle headroom consistent with an estimation limitation** and prioritize
+better covariance data (repeated judges/independent targets).  This is not a deployable estimator claim.
+If both nested and null-calibrated oracle diagnostics fail, retain the block model for these kernels; this
+still does not rule out correlation supplied by a different, better-measured geometry.
+
+The inherited graph-feature geometry includes `hit_prob`, which is also the graph-D measurement.  It is
+available at inference and is not target leakage, but it makes the covariance explicitly conditional on an
+observed measurement rather than an exogenous noise law.  Results must be described that way; a topology-only
+kernel excluding `hit_prob` remains a future confirmatory geometry.
+
+No inverse-root optimization or CUDA claim is in scope.

--- a/prototypes/mu_cosine/DESIGN_covariance_sensitivity_v2_null_calibration.md
+++ b/prototypes/mu_cosine/DESIGN_covariance_sensitivity_v2_null_calibration.md
@@ -1,0 +1,125 @@
+# Covariance sensitivity v2 — family-wise nested-selection calibration
+
+## Status
+
+This is a **post-v1 addendum**, frozen after the v1 synthetic controls failed and before running v2.  It does
+not replace or reinterpret `DESIGN_covariance_sensitivity.md`: v1 remains the originally preregistered
+analysis.  In 100 block-null controls, v1 selected a nonzero covariance 90 times.  The 2-of-3 sign rule did
+not protect a search over 216 nonzero candidates, and KRR mean estimation may itself induce correlated held
+prediction error.  Therefore a nonzero v1 selection cannot be treated as evidence without family-wise null
+calibration.
+
+### Blocking correction before interpreting v2
+
+An independent audit invalidated the first completed v2 output before it was interpreted.  The end-to-end
+residual after a fitted regional mean is `c=e_H-W e_T`, not `e_H`; using `R_HH` as its recovery denominator is
+wrong.  For fixed `W`, use
+
+```text
+Cov(c) = R_HH + W R_TT W.T - R_HT W.T - W R_TH.
+```
+
+Here kernel/ridge selection makes `W` outcome-dependent, so corrected v2 does not call the pre-KRR covariance
+the truth.  It has two separately reported tracks:
+
+1. **End-to-end KRR:** rerun KRR selection and block fitting; evaluate only selection rate, harm/gain versus the
+   fitted block comparator, and the held-grid oracle.  It has no known-truth recovery denominator.
+2. **Oracle-mean/known-B mechanism:** set the regional mean to known zero and supply the true block marginal.
+   Then the held residual is exactly `e_H`, `R_HH` is the correct covariance, and residual/posterior recovery is
+   a valid power gate.  This track uses its matching fixed-path/known-B null threshold.
+
+The corrected wrong-geometry control is a fixed seed-33517 **derangement** congruence `P K P.T` (the first
+cyclic shift of the seeded permutation with no fixed points).  It preserves the canonical kernel's complete
+spectrum, maximum coupling, and off-diagonal RMS energy.  The earlier narrow-RBF control and both earlier v1
+and pre-correction v2 recovery outputs are invalidated diagnostics, not results.
+
+The energy-matched derangement is retained without redesign after its targeted result, but its block-selection
+gate is relabelled diagnostic.  A dense uncentered RBF has a large positive/common correlation mode, and
+`P K P.T` deliberately preserves that mode; therefore the candidate and permuted truth can remain useful
+covariance approximations even though their strongest pair identities differ.  It is not an orthogonal
+wrong-geometry null.  This common-mode contamination is itself reported and is not grounds for constructing a
+friendlier control after seeing the result.
+
+## Frozen v2 rule
+
+Keep the v1 grid, three repeated partitions, eligibility rule, `0.001` near-best tolerance, and tie-breaking
+unchanged.  For candidate `c`, define its observed macro inner gain
+
+```text
+g(c) = mean_fold [NLL_block(fold) - NLL_c(fold)].
+```
+
+Candidate `c` is eligible only when `g(c) > 0` and its gain is positive on at least two of three partitions.
+The observed family-wise statistic is
+
+```text
+M_observed = max(0, max_eligible_c g(c)).
+```
+
+Generate 2,000 deterministic null fields and repeat the identical eligibility/grid search for each, yielding
+`M_null[draw]`.  The threshold is the finite-simulation upper-95% order statistic at one-based rank
+`ceil(0.95 * (draws + 1))`, capped at `draws`.  V2 may retain the candidate selected by the v1 conservative
+tie-break only when `M_observed` is **strictly greater** than this threshold; otherwise it selects block.
+
+Two null calibrations are recorded separately:
+
+1. **A — conditional fixed-path/shared-z null.**  Hold all candidate correlation eigensystems fixed.  Draw one
+   global field of iid standardized channel residuals per simulation, map the same item residual to every
+   repeated held partition in which that item occurs, and run the candidate grid.  This preserves partition
+   overlap but conditions away mean and marginal estimation.
+2. **B — full block-null procedure.**  Draw one global field from the known block covariance.  On each of the
+   same three partitions, rerun regional KRR mean selection, exact LOO residual construction, block-marginal
+   fitting, and the complete candidate grid.  This includes mean-estimation error and partition overlap.
+   Calibration seed is `991000`, disjoint from evaluation seeds.
+
+The real-data implementation must use an analogous full-procedure callback or precomputed null distribution
+on its exact item identities and partitions.  Unlike these synthetic controls, whose covariance endpoints are
+known and outcome-blind, real endpoints are estimated by `fit_lmc_model`.  Therefore every real null draw must
+refit calibration, conditional residuals, KRR mean, block marginal, bandwidths, and **all LMC endpoints** before
+repeating selection.  Holding fitted real paths fixed omits endpoint-estimation overfit and must be labelled a
+conditional/non-deployable diagnostic; it cannot silently stand in for B.
+
+Two explicitly exploratory deployment capacities are compared:
+
+- **v2A, full-grid calibrated:** retain all 216 nonzero length/channel/alpha candidates and gate the v1
+  tie-break with the full-procedure family-wise threshold from that same grid.
+- **v2B, canonical-alpha calibrated:** deployment selection contains only the eight nonzero alpha values at
+  semantic/graph multipliers `(1,1)` and `beta=0`.  Its threshold comes from the full-procedure null maximum
+  over those eight candidates.  The length/beta grid remains available only as an outer sensitivity/oracle
+  diagnostic and cannot determine the deployed v2B covariance.
+
+Thus “null A/B” below refers to conditional versus full-procedure calibration, while “selector v2A/v2B”
+refers to full-grid versus canonical-alpha deployment capacity.
+
+## Frozen attribution audit
+
+Use 1,000 additional block-null fields with common random numbers.  Cross three mean treatments:
+
+- full regional KRR selection/refit;
+- fitted intercept only, with exact leave-one-out intercept residuals;
+- oracle zero mean, with no mean estimation.
+
+with three search sizes:
+
+- all 216 nonzero candidates (`3 x 3 x 3 x 8`);
+- the eight nonzero alpha values at canonical length/channel geometry;
+- one canonical full-strength candidate.
+
+Report the v1 nonzero-selection rate and the 50th/95th percentiles of `M_null`.  This audit attributes the v1
+failure to grid multiplicity versus mean estimation; it is diagnostic and does not change threshold B.
+
+## Corrected evaluation and gates
+
+Rerun the same 100 evaluation replicates per v1 scenario for both v2A and v2B, using the same seeds and common `0.20` candidate
+endpoint (true coupling `0.04`, `0.10`, and `0.20` corresponds to canonical `alpha=0.20`, `0.50`, and `1.0`).
+Write a separate v2 JSON; do not overwrite the v1 JSON.
+
+On the end-to-end KRR track, block-null and mean-only require mean harm no greater than `0.001` NLL/scalar and
+block selection in at least 80%; deranged wrong-geometry is the common-mode diagnostic above.  In-family selection/gain is descriptive because no valid
+closed-form truth denominator is asserted after outcome-selected KRR.
+
+On the oracle-mean/known-B mechanism track, block-null uses the same harm/80%-block gate and deranged
+wrong-geometry remains diagnostic.  Coupling `0.10` and `0.20` require nonzero selection in at least 80% and recovery of at least 50% of the
+now-valid known-truth residual-NLL and posterior-risk gain.  Coupling `0.04` remains measured power only.
+Failure after family-wise calibration means the procedure lacks power at this sample size; it is not
+permission to lower the threshold after inspecting corrected v2.

--- a/prototypes/mu_cosine/REPORT_covariance_sensitivity_synthetic_v2.md
+++ b/prototypes/mu_cosine/REPORT_covariance_sensitivity_synthetic_v2.md
@@ -158,18 +158,21 @@ the real fitted paths fixed is only a conditional diagnostic and is one reason n
 ```bash
 python3 prototypes/mu_cosine/run_covariance_sensitivity_synthetic_v2.py \
   --replicates 100 --calibration-draws 2000 --audit-draws 1000 \
-  --summary-only --out /tmp/covariance_sensitivity_synthetic_v2_corrected_final.json
+  --summary-only --out /tmp/covariance_sensitivity_synthetic_v2_corrected_deterministic.json
 ```
 
-The corrected run took 170.1 seconds.  The four focused covariance-sensitivity test files have 34 passing
-tests (55 when the two inherited structured-covariance suites are included).  Real v1
+The observed runtime was 175.9 seconds; runtime is printed to stdout and deliberately excluded from the
+reproducible scientific JSON.  The four focused covariance-sensitivity test files have 35 passing tests
+(56 when the two inherited structured-covariance suites are included).  Real v1
 multi-seed inference is explicitly blocked unless requested as a descriptive legacy run; no real-data v2
 full-procedure selector has been implemented.
 
 Corrected summary-only output SHA-256:
-`6bbe4fdd35bc70fae71dcb4dfade8bbaed143d310dd26a75469350c2f670997f`.  The compact tracked record is
+`bb4b81c6bd182ebe89bee3360345491b8068aecd56e3ff59d49da9ceac56a9ca`.  The compact tracked record is
 `repro/covariance_sensitivity/synthetic_v2_summary.json`; the full `/tmp` JSON also contains the audit tables
-and exact configuration but is not a durable repository artifact.
+and exact configuration but is not a durable repository artifact.  The byte hash is a reference for the
+documented numerical stack; across Python/NumPy/BLAS platforms, compare the scientific fields within numerical
+tolerance rather than assuming identical floating-point bytes.
 
 ```bash
 python3 -m pytest -q \

--- a/prototypes/mu_cosine/REPORT_covariance_sensitivity_synthetic_v2.md
+++ b/prototypes/mu_cosine/REPORT_covariance_sensitivity_synthetic_v2.md
@@ -1,0 +1,180 @@
+# Synthetic covariance sensitivity v2 — corrected family-wise controls
+
+## Bottom line
+
+The original 2-of-3 nested selector is not calibrated for its search.  Under a block-null field it selected a
+nonzero covariance about 85% of the time when KRR mean and block fitting were rerun.  A full-procedure
+family-wise null threshold fixes the false-selection problem, but the corrected selector does not reach its
+80% power gate at this sample size.
+
+The oracle-mean/known-block mechanism control answers the scientific question more positively: at true maximum
+whitened coupling 0.10 and 0.20, the selected procedure recovers 67–84% of the available residual-NLL gain and
+74–96% of the posterior-risk gain, depending on selector capacity.  It detects the effect in only 31–46% of
+replicates.  Thus accurate correlation **can** improve the estimate; the current estimation/selection procedure
+is underpowered.
+
+## Blocking corrections
+
+The first v1 and first v2 outputs are invalidated diagnostics.  They scored the post-KRR residual
+`c=e_H-W e_T` against the pre-KRR covariance `R_HH`.  For fixed `W`, the correct covariance is
+
+```text
+R_HH + W R_TT W.T - R_HT W.T - W R_TH,
+```
+
+and here KRR kernel/ridge selection makes `W` outcome-dependent.  Corrected v2 therefore separates:
+
+- **end-to-end KRR**, which reports selection and gain/harm versus its fitted block comparator but no
+  “known-truth recovery”; and
+- **oracle-zero-mean/known-B**, where the scored held residual is exactly `e_H`, making `R_HH` and recovery
+  mathematically valid.
+
+The original wrong-geometry RBF also had roughly 32 times less RMS coupling than the in-family kernel.  It was
+replaced with a fixed seed-33517 derangement congruence `P K P.T`, preserving PSD, spectrum, maximum coupling,
+and off-diagonal energy.  This preserves the dense RBF's positive/common mode too, so its result is retained as
+a common-mode-contaminated diagnostic, not an orthogonal negative-control gate.
+
+The invalidated records are
+`/tmp/covariance_sensitivity_synthetic_v1_INVALID_pre_krr_denominator_and_weak_wrong_geometry.json` and
+`/tmp/covariance_sensitivity_synthetic_v2_INVALID_pre_krr_denominator.json`.  The shared v1 runner was amended
+to the corrected derangement and therefore does not reproduce the original weak-geometry diagnostic.
+
+## Null calibration and failure attribution
+
+The 2,000-draw upper-95% family-wise thresholds were:
+
+| candidate search | fixed-path/shared-z threshold | full KRR/block-procedure threshold | ratio | v1 nonzero rate, fixed / full |
+|---|---:|---:|---:|---:|
+| one canonical `alpha=1` | 0.003663 | 0.008390 | 2.29x | 10.6% / 18.9% |
+| canonical eight-alpha grid | 0.004656 | 0.009416 | 2.02x | 28.2% / 43.2% |
+| full 216-candidate grid | 0.008437 | 0.017601 | 2.09x | 60.7% / 84.7% |
+
+The full-procedure null is about twice the fixed-path threshold; the conditional fixed-path null would
+undercalibrate real selection after mean/marginal estimation.
+
+The separate 1,000-field audit gives v1 nonzero-selection rates:
+
+| mean treatment | one candidate | canonical alpha grid | full 216 grid |
+|---|---:|---:|---:|
+| oracle zero mean | 12.1% | 30.1% | 64.9% |
+| fitted intercept only | 21.4% | 43.3% | 81.5% |
+| selected regional KRR | 21.9% | 44.4% | 84.5% |
+
+The largest contribution is search multiplicity: under KRR, full versus canonical capacity adds 40.1
+percentage points, and canonical versus one candidate adds 22.5 points.  Mean estimation also matters:
+oracle-zero to fitted-intercept adds 16.6 points on the full grid; the extra flexible-KRR step adds another
+3.0 points.  The failure is therefore neither “just KRR” nor “just a bad covariance”: the grid is dominant,
+with shared fitted-mean error materially raising the null maximum.
+
+## Corrected end-to-end KRR controls
+
+V2A searches all 216 candidates behind its full-procedure threshold.  V2B deploys only canonical lengths,
+`beta=0`, and the alpha grid; the larger grid remains an outer oracle diagnostic.
+
+| scenario | v2A nonzero | v2A NLL gain | v2B nonzero | v2B NLL gain | status |
+|---|---:|---:|---:|---:|---|
+| block null | 5% | -0.000171 | 7% | -0.000493 | both pass null gate |
+| regional mean only | 19% | +0.001351 | 22% | +0.000524 | v2A passes (81% block); v2B misses by 2 points |
+| deranged wrong geometry | 4% | +0.000076 | 4% | -0.000005 | common-mode diagnostic |
+| coupling 0.04 | 2% | +0.000395 | 5% | +0.000537 | descriptive |
+| coupling 0.10 | 3% | +0.000158 | 6% | +0.000174 | descriptive |
+| coupling 0.20 | 6% | -0.000091 | 14% | +0.000169 | descriptive |
+
+The in-family end-to-end rows deliberately have no known-truth recovery fraction.  Selection remains close to
+the calibrated null rate even at coupling 0.20.  This is an end-to-end power limitation; it does not negate the
+separate known-covariance mechanism result below.
+
+## Oracle-mean/known-B mechanism and power
+
+| scenario | v2A detect | v2A NLL / posterior recovery | v2B detect | v2B NLL / posterior recovery | gate |
+|---|---:|---:|---:|---:|---|
+| block null | 3% | n/a | 6% | n/a | both pass |
+| coupling 0.04 | 16% | 46.9% / 12.8% | 18% | 65.8% / 45.9% | measured power only |
+| coupling 0.10 | 31% | 67.3% / 73.5% | 35% | 69.5% / 85.6% | recovery passes; detection fails |
+| coupling 0.20 | 46% | 71.1% / 89.2% | 46% | 83.5% / 95.9% | recovery passes; detection fails |
+| deranged wrong geometry | 41% | 57.9% / 66.7% | 43% | 57.2% / 66.6% | common-mode diagnostic |
+
+V2B's lower capacity gives the best in-family recovery, but neither capacity meets the frozen 80% detection
+requirement.  The deranged kernel remains useful because permutation preserves the large positive/common mode
+of this dense uncentered RBF; “wrong strongest pairs” does not imply covariance orthogonality.
+
+## Kernel, adjacency, and batching implications
+
+Homogeneous Gaussian uncertainty in item-feature distance does not define a new covariance family after
+normalization; it broadens the RBF length scale.  For scalar `D ~ Normal(mu, tau^2)`,
+
+```text
+E exp(-D^2/(2 ell^2))
+  = ell / sqrt(ell^2 + tau^2)
+    * exp(-mu^2 / (2 (ell^2 + tau^2))).
+```
+
+Centering bounded predictions at `0.5` is a different idea.  The raw product
+`(mu_i-0.5)(mu_j-0.5)` is a PSD linear Gram and preserves signed distance-from-neutral amplitude; subtracting
+the same `0.5` inside an RBF distance cancels exactly.  The implemented secondary normalized Gram keeps only
+centered direction/sign and is not presented as the literal raw product.
+
+An outcome-blind inventory found that adjacent measurement rows already occur in the #3671 campaign, but
+only incidentally: 876 exploratory and 688 fresh row-pairs have some endpoints one graph edge apart.  The
+clean same-descendant/adjacent-root subset has 84 and 206 pairs respectively; the reverse same-root/adjacent-
+descendant subset has none.  #3671 used per-row graph features, not an explicit cross-row adjacency kernel, so
+these counts do not constitute an adjacency-covariance test.
+
+The next sampling design treats adjacent rows as positive smoothing examples and matched distant rows as
+contrastive negatives.  Adjacent positives teach dataset topology; distant/hard negatives show where
+smoothing stops and provide candidate near-independent items.  Mean/representation learning remains separate
+from covariance estimation on cross-fitted residuals.
+
+For a validated geometry, distance-separated batching can use the operational condition
+
+```text
+norm(B^-1/2 R_ij B^-1/2, 2) <= epsilon_batch.
+```
+
+With an RBF, scalar coupling is about `0.011` at `3 ell` and `0.00034` at `4 ell`; distance uncertainty requires
+using the broader effective length.  Items beyond a fresh-validated threshold can use independent/block
+updates, while adjacent connected components remain joint QR blocks.  This is a sufficient batching rule,
+not evidence that untested nearby rows are independent.
+
+## Decision
+
+- Retain the block covariance for deployment under the tested sample size/procedure.
+- Do not interpret a v1 nonzero selection; a real family-wise null must repeat the exact partitions and refit
+  every outcome-dependent candidate endpoint.
+- Treat v2B as the more promising future capacity, not as validated: its mechanism recovery is stronger, but
+  it fails the end-to-end mean-only gate (78% block versus required 80%) and remains underpowered.
+- Better covariance data—repeated independent judge calls, more independent item fields, or a jointly modeled
+  mean/covariance procedure—is higher leverage than expanding the kernel grid.
+- Run the explicit adjacent-positive / matched-distant-negative study in
+  `DESIGN_adjacent_row_residual_correlation.md` before claiming graph distance licenses sparse batching.
+- These controls support the narrow claim that good correlation information can help.  They do not show that
+  the current semantic/graph distances estimate that information reliably.
+
+A real-data v2 null would also have to refit every outcome-dependent LMC endpoint on every null draw.  Holding
+the real fitted paths fixed is only a conditional diagnostic and is one reason no real v2 gate is claimed here.
+
+## Reproduction
+
+```bash
+python3 prototypes/mu_cosine/run_covariance_sensitivity_synthetic_v2.py \
+  --replicates 100 --calibration-draws 2000 --audit-draws 1000 \
+  --summary-only --out /tmp/covariance_sensitivity_synthetic_v2_corrected_final.json
+```
+
+The corrected run took 170.1 seconds.  The four focused covariance-sensitivity test files have 34 passing
+tests (55 when the two inherited structured-covariance suites are included).  Real v1
+multi-seed inference is explicitly blocked unless requested as a descriptive legacy run; no real-data v2
+full-procedure selector has been implemented.
+
+Corrected summary-only output SHA-256:
+`6bbe4fdd35bc70fae71dcb4dfade8bbaed143d310dd26a75469350c2f670997f`.  The compact tracked record is
+`repro/covariance_sensitivity/synthetic_v2_summary.json`; the full `/tmp` JSON also contains the audit tables
+and exact configuration but is not a durable repository artifact.
+
+```bash
+python3 -m pytest -q \
+  prototypes/mu_cosine/test_covariance_sensitivity.py \
+  prototypes/mu_cosine/test_run_covariance_sensitivity.py \
+  prototypes/mu_cosine/test_run_covariance_sensitivity_synthetic.py \
+  prototypes/mu_cosine/test_run_covariance_sensitivity_synthetic_v2.py
+```

--- a/prototypes/mu_cosine/covariance_sensitivity.py
+++ b/prototypes/mu_cosine/covariance_sensitivity.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""PSD covariance-misspecification and posterior-sensitivity primitives.
+
+The primary path preserves the independent block model's within-item covariance while varying only the
+cross-item correlation learned by a structured model.  Arrays use item-major order throughout.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+import numpy as np
+
+
+LOG2PI = math.log(2.0 * math.pi)
+
+
+def _matrix(name, value):
+    array = np.asarray(value, dtype=float)
+    if array.ndim != 2 or not np.isfinite(array).all():
+        raise ValueError(f"{name} must be a finite matrix")
+    return array
+
+
+def _symmetric(name, value, *, dimension=None):
+    array = _matrix(name, value)
+    if array.shape[0] != array.shape[1]:
+        raise ValueError(f"{name} must be square")
+    if dimension is not None and array.shape != (dimension, dimension):
+        raise ValueError(f"{name} must have shape {(dimension, dimension)}")
+    scale = max(float(np.max(np.abs(array), initial=0.0)), 1.0)
+    if not np.allclose(array, array.T, rtol=0.0, atol=128 * np.finfo(float).eps * scale):
+        raise ValueError(f"{name} must be symmetric")
+    return 0.5 * (array + array.T)
+
+
+def _unit_interval(name, value):
+    value = float(value)
+    if not np.isfinite(value) or value < 0.0 or value > 1.0:
+        raise ValueError(f"{name} must be in [0,1]")
+    return value
+
+
+def _positive(name, value):
+    value = float(value)
+    if not np.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be positive and finite")
+    return value
+
+
+def shrink_channel_covariance(covariance, beta):
+    """Convexly shrink channel interactions toward their diagonal while preserving PSD."""
+    covariance = _symmetric("covariance", covariance)
+    beta = _unit_interval("beta", beta)
+    value = (1.0 - beta) * covariance + beta * np.diag(np.diag(covariance))
+    return 0.5 * (value + value.T)
+
+
+def materialize_channel_shrunk(model, semantic_kernel, graph_kernel, beta):
+    """Materialize an LMC after PSD shrinkage of structured channel interactions."""
+    semantic = _symmetric("semantic_kernel", semantic_kernel)
+    graph = _symmetric("graph_kernel", graph_kernel, dimension=len(semantic))
+    beta = _unit_interval("beta", beta)
+    B_sem = shrink_channel_covariance(model.semantic_covariance, beta)
+    B_graph = shrink_channel_covariance(model.graph_covariance, beta)
+    return (
+        np.kron(np.eye(len(semantic)), model.independent_covariance)
+        + np.kron(semantic, B_sem)
+        + np.kron(graph, B_graph)
+    )
+
+
+def direct_covariance_blend(block_covariance, structured_covariance, alpha):
+    """Secondary raw-covariance convex blend; this does not preserve item marginals."""
+    block = _symmetric("block_covariance", block_covariance)
+    structured = _symmetric(
+        "structured_covariance", structured_covariance, dimension=len(block)
+    )
+    alpha = _unit_interval("alpha", alpha)
+    return (1.0 - alpha) * block + alpha * structured
+
+
+def expected_rbf_kernel_gaussian(features, *, length_scale, input_std=0.0, normalize=True):
+    """Expected RBF between isotropic-Gaussian uncertain feature vectors.
+
+    Row ``i`` represents ``X_i ~ Normal(features[i], input_std[i]^2 I)``.  The raw result is
+    ``E[k(X_i,X_j)]`` for independent draws.  Diagonal normalization converts it to a correlation kernel.
+    With a common standard deviation, that normalized kernel is exactly an RBF with
+    ``ell_effective^2 = ell^2 + 2*input_std^2``.
+    """
+    features = _matrix("features", features)
+    length_scale = _positive("length_scale", length_scale)
+    std = np.asarray(input_std, dtype=float)
+    if std.ndim == 0:
+        std = np.full(len(features), float(std))
+    if std.shape != (len(features),) or not np.isfinite(std).all() or np.any(std < 0.0):
+        raise ValueError("input_std must be nonnegative scalar or one value per feature row")
+    squared_norm = np.sum(features * features, axis=1)
+    squared_distance = np.maximum(
+        squared_norm[:, None] + squared_norm[None, :] - 2.0 * features @ features.T,
+        0.0,
+    )
+    variance = std[:, None] ** 2 + std[None, :] ** 2
+    denominator = length_scale * length_scale + variance
+    dimension = features.shape[1]
+    amplitude = (length_scale * length_scale / denominator) ** (0.5 * dimension)
+    kernel = amplitude * np.exp(-0.5 * squared_distance / denominator)
+    kernel = 0.5 * (kernel + kernel.T)
+    if normalize:
+        diagonal = np.sqrt(np.diag(kernel))
+        kernel = kernel / diagonal[:, None] / diagonal[None, :]
+        kernel = 0.5 * (kernel + kernel.T)
+        np.fill_diagonal(kernel, 1.0)
+    return kernel
+
+
+def centered_linear_kernel(features_a, features_b=None, *, center=0.5, normalize=False):
+    """PSD linear Gram after centering bounded features around a neutral value.
+
+    For scalar ``mu`` values this is ``K[i,j] = (mu[i]-center) * (mu[j]-center)``.
+    Unlike an RBF, this kernel distinguishes values on the same versus opposite sides of the midpoint;
+    subtracting a common center inside an RBF distance would instead cancel exactly.
+
+    Optional normalization produces a correlation-like Gram only when every centered row has nonzero norm.
+    The raw Gram is the useful form when distance from the neutral midpoint should affect amplitude.
+    """
+    left = np.asarray(features_a, dtype=float)
+    if left.ndim == 1:
+        left = left[:, None]
+    if left.ndim != 2 or not np.isfinite(left).all():
+        raise ValueError("features_a must be a finite vector or matrix")
+    right = left if features_b is None else np.asarray(features_b, dtype=float)
+    if right.ndim == 1:
+        right = right[:, None]
+    if right.ndim != 2 or not np.isfinite(right).all() or right.shape[1] != left.shape[1]:
+        raise ValueError("features_b must be a finite vector or matrix with matching columns")
+    center = np.asarray(center, dtype=float)
+    if not np.isfinite(center).all():
+        raise ValueError("center must be finite")
+    if center.ndim > 1 or (center.ndim == 1 and center.shape != (left.shape[1],)):
+        raise ValueError("center must be scalar or one value per feature column")
+    centered_left = left - center
+    centered_right = right - center
+    kernel = centered_left @ centered_right.T
+    if features_b is None:
+        kernel = 0.5 * (kernel + kernel.T)
+    if normalize:
+        left_norms = np.linalg.norm(centered_left, axis=1)
+        right_norms = np.linalg.norm(centered_right, axis=1)
+        if np.any(left_norms == 0.0) or np.any(right_norms == 0.0):
+            raise ValueError("cannot normalize a centered feature row with zero norm")
+        kernel = kernel / left_norms[:, None] / right_norms[None, :]
+        if features_b is None:
+            kernel = 0.5 * (kernel + kernel.T)
+            np.fill_diagonal(kernel, 1.0)
+    return kernel
+
+
+def gaussian_input_std_ratio_for_length_multiplier(multiplier):
+    """Map a broadened normalized-RBF multiplier to common Gaussian input std / base length."""
+    multiplier = _positive("multiplier", multiplier)
+    if multiplier < 1.0:
+        return None
+    return math.sqrt((multiplier * multiplier - 1.0) / 2.0)
+
+
+@dataclass(frozen=True)
+class CorrelationPath:
+    """Eigen representation of a marginal-matched block-to-structured correlation path."""
+
+    block_item_covariance: np.ndarray
+    structured_item_covariance: np.ndarray
+    correlation: np.ndarray
+    eigenvalues: np.ndarray
+    eigenvectors: np.ndarray
+    block_size: int
+
+    @property
+    def item_count(self):
+        return len(self.correlation) // self.block_size
+
+    def mixture_eigenvalues(self, alpha):
+        alpha = _unit_interval("alpha", alpha)
+        values = 1.0 + alpha * (self.eigenvalues - 1.0)
+        if np.min(values) <= 0.0:
+            raise np.linalg.LinAlgError("correlation path is not positive definite")
+        return values
+
+    def covariance(self, alpha):
+        values = self.mixture_eigenvalues(alpha)
+        normalized = (self.eigenvectors * values) @ self.eigenvectors.T
+        factor = np.kron(
+            np.eye(self.item_count), np.linalg.cholesky(self.block_item_covariance)
+        )
+        covariance = factor @ normalized @ factor.T
+        return 0.5 * (covariance + covariance.T)
+
+    def nll_per_scalar(self, residuals, alpha):
+        residuals = _matrix("residuals", residuals)
+        if residuals.shape != (self.item_count, self.block_size):
+            raise ValueError("residuals do not match correlation-path geometry")
+        factor = np.linalg.cholesky(self.block_item_covariance)
+        whitened = np.linalg.solve(factor, residuals.T).T.reshape(-1)
+        coordinates = self.eigenvectors.T @ whitened
+        values = self.mixture_eigenvalues(alpha)
+        logdet_block = 2.0 * np.sum(np.log(np.diag(factor)))
+        total = 0.5 * (
+            float(np.sum(coordinates * coordinates / values))
+            + self.item_count * float(logdet_block)
+            + float(np.sum(np.log(values)))
+            + len(coordinates) * LOG2PI
+        )
+        return total / len(coordinates)
+
+
+def build_correlation_path(block_item_covariance, structured_covariance, block_size):
+    """Match structured correlations to fixed block marginals and eigendecompose the path."""
+    if not isinstance(block_size, (int, np.integer)) or block_size < 1:
+        raise ValueError("block_size must be a positive integer")
+    block = _symmetric(
+        "block_item_covariance", block_item_covariance, dimension=block_size
+    )
+    np.linalg.cholesky(block)
+    structured = _symmetric("structured_covariance", structured_covariance)
+    if len(structured) % block_size:
+        raise ValueError("structured covariance dimension must be divisible by block_size")
+    item_count = len(structured) // block_size
+    diagonal_blocks = np.stack([
+        structured[
+            item * block_size:(item + 1) * block_size,
+            item * block_size:(item + 1) * block_size,
+        ]
+        for item in range(item_count)
+    ])
+    structured_item = diagonal_blocks.mean(axis=0)
+    scale = max(float(np.max(np.abs(structured_item))), 1.0)
+    if not np.allclose(diagonal_blocks, structured_item, rtol=0.0, atol=1e-9 * scale):
+        raise ValueError("structured covariance must have a constant within-item block")
+    factor = np.linalg.cholesky(structured_item)
+    inverse_factor = np.linalg.solve(factor, np.eye(block_size))
+    whitener = np.kron(np.eye(item_count), inverse_factor)
+    correlation = whitener @ structured @ whitener.T
+    correlation = 0.5 * (correlation + correlation.T)
+    for item in range(item_count):
+        section = slice(item * block_size, (item + 1) * block_size)
+        correlation[section, section] = np.eye(block_size)
+    eigenvalues, eigenvectors = np.linalg.eigh(correlation)
+    if eigenvalues[0] <= 0.0:
+        raise np.linalg.LinAlgError("normalized structured correlation is not positive definite")
+    return CorrelationPath(
+        block, structured_item, correlation, eigenvalues, eigenvectors, block_size
+    )
+
+
+@dataclass(frozen=True)
+class PosteriorSensitivity:
+    state_mean: np.ndarray
+    state_covariance: np.ndarray
+    directional_derivative: np.ndarray
+    mean_item_derivative_norm: float
+    covariance_direction_relative_norm: float
+    relative_state_sensitivity: float
+
+    def to_dict(self):
+        return {
+            "mean_item_derivative_norm": self.mean_item_derivative_norm,
+            "covariance_direction_relative_norm": self.covariance_direction_relative_norm,
+            "relative_state_sensitivity": self.relative_state_sensitivity,
+        }
+
+
+def _dense_posterior_system(prior_covariance, design, innovation, covariance):
+    prior = _symmetric("prior_covariance", prior_covariance)
+    design = _matrix("design", design)
+    innovation = _matrix("innovation", innovation)
+    if design.shape[1] != len(prior) or innovation.shape[1] != design.shape[0]:
+        raise ValueError("design/innovation dimensions do not match the prior")
+    item_count = len(innovation)
+    noise = _symmetric(
+        "covariance", covariance, dimension=item_count * design.shape[0]
+    )
+    prior_batch = np.kron(np.eye(item_count), prior)
+    design_batch = np.kron(np.eye(item_count), design)
+    residual = innovation.reshape(-1)
+    weighted_design = np.linalg.solve(noise, design_batch)
+    weighted_residual = np.linalg.solve(noise, residual)
+    precision = np.linalg.solve(prior_batch, np.eye(len(prior_batch)))
+    system = precision + design_batch.T @ weighted_design
+    rhs = design_batch.T @ weighted_residual
+    state = np.linalg.solve(system, rhs)
+    posterior_covariance = np.linalg.solve(system, np.eye(len(system)))
+    return state, posterior_covariance, system, design_batch, residual, noise
+
+
+def posterior_mean_dense(prior_covariance, design, innovation, covariance):
+    """Dense reference posterior for a prior-centered batch."""
+    state, posterior, *_ = _dense_posterior_system(
+        prior_covariance, design, innovation, covariance
+    )
+    return state.reshape(len(innovation), -1), posterior
+
+
+def directional_posterior_sensitivity(
+    prior_covariance,
+    design,
+    innovation,
+    covariance,
+    covariance_direction,
+):
+    """Analytic first derivative of posterior mean along a symmetric covariance direction."""
+    state, posterior, system, design_batch, residual, noise = _dense_posterior_system(
+        prior_covariance, design, innovation, covariance
+    )
+    direction = _symmetric(
+        "covariance_direction", covariance_direction, dimension=len(noise)
+    )
+    model_residual = residual - design_batch @ state
+    right = np.linalg.solve(noise, model_residual)
+    twice_weighted = np.linalg.solve(noise, direction @ right)
+    derivative = -np.linalg.solve(system, design_batch.T @ twice_weighted)
+    item_count = len(innovation)
+    state_size = len(prior_covariance)
+    derivative_rows = derivative.reshape(item_count, state_size)
+    covariance_relative = float(
+        np.linalg.norm(direction, ord="fro") / np.linalg.norm(noise, ord="fro")
+    )
+    state_scale = max(
+        float(np.linalg.norm(state)),
+        math.sqrt(max(float(np.trace(posterior)), np.finfo(float).tiny)),
+    )
+    relative = float(np.linalg.norm(derivative) / state_scale)
+    if covariance_relative > 0.0:
+        relative /= covariance_relative
+    return PosteriorSensitivity(
+        state.reshape(item_count, state_size),
+        posterior,
+        derivative_rows,
+        float(np.mean(np.linalg.norm(derivative_rows, axis=1))),
+        covariance_relative,
+        relative,
+    )
+
+
+def select_nested_candidate(records, *, tolerance=1e-3, minimum_positive_folds=2):
+    """Conservatively select a covariance candidate from repeated inner node partitions."""
+    if not records:
+        raise ValueError("records must not be empty")
+    tolerance = float(tolerance)
+    if not np.isfinite(tolerance) or tolerance < 0.0:
+        raise ValueError("tolerance must be nonnegative and finite")
+    if (
+        not isinstance(minimum_positive_folds, (int, np.integer))
+        or isinstance(minimum_positive_folds, (bool, np.bool_))
+        or minimum_positive_folds < 1
+    ):
+        raise ValueError("minimum_positive_folds must be a positive integer")
+    grouped = {}
+    block_by_fold = {}
+    for row in records:
+        fold = int(row["fold"])
+        alpha = _unit_interval("alpha", row["alpha"])
+        nll = float(row["nll_per_scalar"])
+        if not np.isfinite(nll):
+            raise ValueError("candidate NLL must be finite")
+        if alpha == 0.0:
+            if fold in block_by_fold and not math.isclose(
+                block_by_fold[fold], nll, rel_tol=0.0, abs_tol=64 * np.finfo(float).eps
+            ):
+                raise ValueError("equivalent alpha=0 records disagree within a fold")
+            block_by_fold[fold] = nll
+            continue
+        key = (
+            alpha,
+            _positive("semantic_multiplier", row["semantic_multiplier"]),
+            _positive("graph_multiplier", row["graph_multiplier"]),
+            _unit_interval("beta", row["beta"]),
+        )
+        if fold in grouped.setdefault(key, {}):
+            raise ValueError("candidate is duplicated within a fold")
+        grouped[key][fold] = nll
+    folds = sorted(block_by_fold)
+    if len(folds) < minimum_positive_folds:
+        raise ValueError("insufficient block folds for conservative selection")
+    summaries = []
+    for key, values in grouped.items():
+        if sorted(values) != folds:
+            raise ValueError("every nonzero candidate must be scored on every fold")
+        gains = np.asarray([block_by_fold[fold] - values[fold] for fold in folds])
+        summaries.append({
+            "alpha": key[0],
+            "semantic_multiplier": key[1],
+            "graph_multiplier": key[2],
+            "beta": key[3],
+            "macro_nll_per_scalar": float(np.mean([values[fold] for fold in folds])),
+            "macro_gain_vs_block": float(gains.mean()),
+            "positive_folds": int(np.sum(gains > 0.0)),
+            "fold_gains": gains.tolist(),
+        })
+    eligible = [
+        row for row in summaries
+        if row["macro_gain_vs_block"] > 0.0
+        and row["positive_folds"] >= minimum_positive_folds
+    ]
+    block = {
+        "alpha": 0.0,
+        "semantic_multiplier": 1.0,
+        "graph_multiplier": 1.0,
+        "beta": 1.0,
+        "macro_nll_per_scalar": float(np.mean(list(block_by_fold.values()))),
+        "macro_gain_vs_block": 0.0,
+        "positive_folds": 0,
+        "fold_gains": [0.0 for _ in folds],
+    }
+    if not eligible:
+        return block, [block] + summaries
+    best = min(row["macro_nll_per_scalar"] for row in eligible)
+    near = [row for row in eligible if row["macro_nll_per_scalar"] <= best + tolerance]
+    selected = min(
+        near,
+        key=lambda row: (
+            row["alpha"],
+            -row["beta"],
+            abs(math.log(row["semantic_multiplier"]))
+            + abs(math.log(row["graph_multiplier"])),
+            row["semantic_multiplier"],
+            row["graph_multiplier"],
+        ),
+    )
+    return selected, [block] + summaries
+
+
+def maximum_eligible_macro_gain(candidate_summaries, *, minimum_positive_folds=2):
+    """Family-wise statistic for the same eligibility rule used by nested selection."""
+    if not candidate_summaries:
+        raise ValueError("candidate_summaries must not be empty")
+    if (
+        not isinstance(minimum_positive_folds, (int, np.integer))
+        or isinstance(minimum_positive_folds, (bool, np.bool_))
+        or minimum_positive_folds < 1
+    ):
+        raise ValueError("minimum_positive_folds must be a positive integer")
+    eligible_gains = []
+    for row in candidate_summaries:
+        alpha = _unit_interval("alpha", row["alpha"])
+        gain = float(row["macro_gain_vs_block"])
+        positive_folds = int(row["positive_folds"])
+        if not np.isfinite(gain):
+            raise ValueError("candidate macro gain must be finite")
+        if alpha > 0.0 and gain > 0.0 and positive_folds >= minimum_positive_folds:
+            eligible_gains.append(gain)
+    return float(max(eligible_gains, default=0.0))
+
+
+def finite_null_maximum_threshold(null_maximum_gains, *, confidence=0.95):
+    """Conservative finite-simulation upper quantile for a family-wise null statistic."""
+    values = np.asarray(null_maximum_gains, dtype=float)
+    if values.ndim != 1 or not len(values) or not np.isfinite(values).all():
+        raise ValueError("null_maximum_gains must be a non-empty finite vector")
+    confidence = float(confidence)
+    if not np.isfinite(confidence) or not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be in (0,1)")
+    if np.any(values < 0.0):
+        raise ValueError("null family-wise maximum gains must be nonnegative")
+    rank = min(int(math.ceil(confidence * (len(values) + 1))), len(values))
+    threshold = float(np.sort(values)[rank - 1])
+    return threshold, rank
+
+
+def select_nested_candidate_null_calibrated(
+    records,
+    null_maximum_gains,
+    *,
+    confidence=0.95,
+    tolerance=1e-3,
+    minimum_positive_folds=2,
+):
+    """Versioned v2 selector: v1 tie-break gated by a family-wise null maximum.
+
+    ``null_maximum_gains`` must come from repeating the complete candidate search under the intended null.
+    This helper deliberately accepts precomputed maxima so callers can use a full-procedure simulator rather
+    than silently substituting a conditional fixed-path null.
+    """
+    v1_selected, summaries = select_nested_candidate(
+        records,
+        tolerance=tolerance,
+        minimum_positive_folds=minimum_positive_folds,
+    )
+    observed = maximum_eligible_macro_gain(
+        summaries, minimum_positive_folds=minimum_positive_folds
+    )
+    threshold, rank = finite_null_maximum_threshold(
+        null_maximum_gains, confidence=confidence
+    )
+    comparison_tolerance = 64.0 * np.finfo(float).eps * max(
+        1.0, abs(observed), abs(threshold)
+    )
+    reject = bool(observed > threshold + comparison_tolerance)
+    selected = dict(v1_selected if reject else summaries[0])
+    selected["selection_version"] = "v2_familywise_null_calibrated"
+    selected["v1_selected_alpha"] = float(v1_selected["alpha"])
+    selected["familywise_null_rejected"] = reject
+    calibration = {
+        "selection_version": "v2_familywise_null_calibrated",
+        "confidence": float(confidence),
+        "null_draws": int(len(null_maximum_gains)),
+        "order_statistic_rank_one_based": int(rank),
+        "familywise_macro_gain_threshold": threshold,
+        "observed_maximum_eligible_macro_gain": observed,
+        "strict_comparison_absolute_tolerance": comparison_tolerance,
+        "strictly_exceeds_threshold": reject,
+        "v1_selected_candidate": dict(v1_selected),
+    }
+    return selected, summaries, calibration
+
+
+def gaussian_kl(mean_p, covariance_p, mean_q, covariance_q):
+    """KL[N_p || N_q] for one finite-dimensional Gaussian pair."""
+    mean_p = np.asarray(mean_p, dtype=float)
+    mean_q = np.asarray(mean_q, dtype=float)
+    if mean_p.ndim != 1 or mean_q.shape != mean_p.shape:
+        raise ValueError("means must be aligned vectors")
+    P = _symmetric("covariance_p", covariance_p, dimension=len(mean_p))
+    Q = _symmetric("covariance_q", covariance_q, dimension=len(mean_p))
+    delta = mean_q - mean_p
+    factor_p = np.linalg.cholesky(P)
+    factor_q = np.linalg.cholesky(Q)
+    logdet_p = 2.0 * np.sum(np.log(np.diag(factor_p)))
+    logdet_q = 2.0 * np.sum(np.log(np.diag(factor_q)))
+    return 0.5 * (
+        float(np.trace(np.linalg.solve(Q, P)))
+        + float(delta @ np.linalg.solve(Q, delta))
+        - len(delta)
+        + float(logdet_q - logdet_p)
+    )
+
+
+def mean_marginal_symmetric_kl(mean_a, covariance_a, mean_b, covariance_b):
+    """Mean symmetric KL across aligned per-item marginal Gaussians."""
+    mean_a = _matrix("mean_a", mean_a)
+    mean_b = _matrix("mean_b", mean_b)
+    covariance_a = np.asarray(covariance_a, dtype=float)
+    covariance_b = np.asarray(covariance_b, dtype=float)
+    if mean_b.shape != mean_a.shape:
+        raise ValueError("means must be aligned")
+    expected = (len(mean_a), mean_a.shape[1], mean_a.shape[1])
+    if covariance_a.shape != expected or covariance_b.shape != expected:
+        raise ValueError("marginal covariance arrays have the wrong shape")
+    values = []
+    for ma, Pa, mb, Pb in zip(mean_a, covariance_a, mean_b, covariance_b):
+        values.append(0.5 * (
+            gaussian_kl(ma, Pa, mb, Pb) + gaussian_kl(mb, Pb, ma, Pa)
+        ))
+    return float(np.mean(values))
+
+
+def whitened_covariance_error(reference, candidate):
+    """Spectral norm of a covariance perturbation in reference-whitened coordinates."""
+    reference = _symmetric("reference", reference)
+    candidate = _symmetric("candidate", candidate, dimension=len(reference))
+    factor = np.linalg.cholesky(reference)
+    left = np.linalg.solve(factor, candidate - reference)
+    whitened = np.linalg.solve(factor, left.T).T
+    whitened = 0.5 * (whitened + whitened.T)
+    eigenvalues = np.linalg.eigvalsh(whitened)
+    return float(np.max(np.abs(eigenvalues), initial=0.0))

--- a/prototypes/mu_cosine/repro/covariance_sensitivity/synthetic_v2_summary.json
+++ b/prototypes/mu_cosine/repro/covariance_sensitivity/synthetic_v2_summary.json
@@ -104,5 +104,5 @@
     "limitation": "family-wise calibrated detection power after mean/covariance estimation",
     "real_v1_multiseed_run_intentionally_not_executed": true
   },
-  "corrected_full_output_sha256": "6bbe4fdd35bc70fae71dcb4dfade8bbaed143d310dd26a75469350c2f670997f"
+  "corrected_full_output_sha256": "bb4b81c6bd182ebe89bee3360345491b8068aecd56e3ff59d49da9ceac56a9ca"
 }

--- a/prototypes/mu_cosine/repro/covariance_sensitivity/synthetic_v2_summary.json
+++ b/prototypes/mu_cosine/repro/covariance_sensitivity/synthetic_v2_summary.json
@@ -1,0 +1,108 @@
+{
+  "status": "corrected synthetic v2 complete; mechanism recovery passes but frozen 80% detection gate fails",
+  "configuration": {
+    "evaluation_replicates_per_scenario": 100,
+    "calibration_draws": 2000,
+    "attribution_audit_draws": 1000,
+    "items": 96,
+    "outer_held_items": 32,
+    "inner_held_items": 22,
+    "evaluation_seed": 881000,
+    "calibration_seed": 991000,
+    "audit_seed": 994000,
+    "block_covariance_shrinkage": 0.05,
+    "alpha_grid": [0.0, 0.025, 0.05, 0.1, 0.2, 0.35, 0.5, 0.75, 1.0],
+    "length_multiplier_grid": [0.5, 1.0, 2.0],
+    "channel_shrinkage_beta_grid": [0.0, 0.5, 1.0],
+    "design": "DESIGN_covariance_sensitivity_v2_null_calibration.md",
+    "candidate_nonzero_count_v2a": 216,
+    "candidate_nonzero_count_v2b": 8,
+    "familywise_confidence": 0.95
+  },
+  "familywise_thresholds": {
+    "fixed_path_shared_z": {
+      "v2a_full_grid": 0.008436969049373152,
+      "v2b_canonical_alpha": 0.004655646517924976
+    },
+    "full_procedure_krr": {
+      "v2a_full_grid": 0.01760085089307406,
+      "v2b_canonical_alpha": 0.009416216207897751
+    }
+  },
+  "v1_nonzero_selection_rate": {
+    "oracle_zero_mean": {
+      "single_canonical_endpoint": 0.121,
+      "canonical_alpha_grid": 0.301,
+      "full_grid": 0.649
+    },
+    "intercept_only": {
+      "single_canonical_endpoint": 0.214,
+      "canonical_alpha_grid": 0.433,
+      "full_grid": 0.815
+    },
+    "regional_krr": {
+      "single_canonical_endpoint": 0.219,
+      "canonical_alpha_grid": 0.444,
+      "full_grid": 0.845
+    }
+  },
+  "end_to_end_krr": {
+    "v2a": {
+      "block_null_nonzero_rate": 0.05,
+      "regional_mean_only_nonzero_rate": 0.19,
+      "block_null_pass": true,
+      "regional_mean_only_pass": true
+    },
+    "v2b": {
+      "block_null_nonzero_rate": 0.07,
+      "regional_mean_only_nonzero_rate": 0.22,
+      "block_null_pass": true,
+      "regional_mean_only_pass": false
+    }
+  },
+  "oracle_mean_known_block_mechanism": {
+    "v2a": {
+      "block_null_nonzero_rate": 0.03,
+      "coupling_0_04": {
+        "detection_rate": 0.16,
+        "nll_recovery": 0.46860593601108713,
+        "posterior_risk_recovery": 0.12788451341246743
+      },
+      "coupling_0_10": {
+        "detection_rate": 0.31,
+        "nll_recovery": 0.6728872894048984,
+        "posterior_risk_recovery": 0.7350476213037347
+      },
+      "coupling_0_20": {
+        "detection_rate": 0.46,
+        "nll_recovery": 0.7114938900534903,
+        "posterior_risk_recovery": 0.8916303779047412
+      }
+    },
+    "v2b": {
+      "block_null_nonzero_rate": 0.06,
+      "coupling_0_04": {
+        "detection_rate": 0.18,
+        "nll_recovery": 0.6576268635235664,
+        "posterior_risk_recovery": 0.4586863639391446
+      },
+      "coupling_0_10": {
+        "detection_rate": 0.35,
+        "nll_recovery": 0.6952942620558186,
+        "posterior_risk_recovery": 0.8561309654287135
+      },
+      "coupling_0_20": {
+        "detection_rate": 0.46,
+        "nll_recovery": 0.8350851135441434,
+        "posterior_risk_recovery": 0.9594849648584444
+      }
+    }
+  },
+  "decision": {
+    "deploy_structured_covariance": false,
+    "good_known_correlation_improves_estimate": true,
+    "limitation": "family-wise calibrated detection power after mean/covariance estimation",
+    "real_v1_multiseed_run_intentionally_not_executed": true
+  },
+  "corrected_full_output_sha256": "6bbe4fdd35bc70fae71dcb4dfade8bbaed143d310dd26a75469350c2f670997f"
+}

--- a/prototypes/mu_cosine/run_covariance_sensitivity.py
+++ b/prototypes/mu_cosine/run_covariance_sensitivity.py
@@ -1,0 +1,1297 @@
+#!/usr/bin/env python3
+"""Descriptive legacy-v1 covariance-misspecification and posterior-sensitivity runner.
+
+This is the executable companion to ``DESIGN_covariance_sensitivity.md``.  It deliberately refits every
+outcome-dependent object inside each node-disjoint partition.  The primary graph/semantic family and the
+secondary neutral-centered mu family are selected and null-calibrated separately.
+
+The v1 selector failed family-wise synthetic controls.  Multi-seed execution requires an explicit descriptive
+override, every aggregate inferential gate is disabled, and real-data full-procedure v2 calibration is not
+implemented here.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import dataclass
+import json
+import math
+import os
+import sys
+import time
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from covariance_sensitivity import (
+    build_correlation_path,
+    centered_linear_kernel,
+    direct_covariance_blend,
+    directional_posterior_sensitivity,
+    materialize_channel_shrunk,
+    mean_marginal_symmetric_kl,
+    select_nested_candidate,
+    whitened_covariance_error,
+)
+from eval_luna_transfer import load_luna as load_scored_mu_tsv
+from fine_tune_channel_heads import CAMPAIGN_E5_100K, load_campaign_datasets, load_expanded
+from mu_posterior import JointPosterior
+from node_disjoint_eval import format_split_diagnostics, node_disjoint_pair_split
+from run_cheap_judge_joint_posterior import CLASSES, calibrate_sources, gaussian_bridge_proba, load_decision_targets
+from run_product_kalman_realdata import DATASETS
+from run_structured_residual_covariance import (
+    configure_artifact_repo,
+    decision_metrics,
+    file_provenance,
+    materialize_corpus,
+    state_metrics,
+    train_standardize,
+)
+from run_sym_channel_fusion import H4
+from structured_residual_covariance import (
+    condition_item_batch,
+    conditional_residuals,
+    fit_block_model,
+    fit_lmc_model,
+    gaussian_joint_nll,
+    median_rbf_bandwidth,
+    rbf_kernel,
+    select_kernel_ridge_mean,
+)
+
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_CAMPAIGN = "/tmp/mu_data/campaign_scored.tsv"
+DEFAULT_LUNA = "/tmp/mu_data/campaign_scored_luna.tsv"
+ALPHAS = (0.0, 0.025, 0.05, 0.10, 0.20, 0.35, 0.50, 0.75, 1.0)
+MULTIPLIERS = (0.5, 1.0, 2.0)
+BETAS = (0.0, 0.5, 1.0)
+PRIMARY = "semantic_graph_rbf"
+SECONDARY = "semantic_centered_mu_linear"
+
+
+@dataclass
+class FitContext:
+    fit: np.ndarray
+    evaluate: np.ndarray
+    calibrated: object
+    conditional_design: np.ndarray
+    q: np.ndarray
+    centered_evaluate: np.ndarray
+    evaluate_mean: np.ndarray
+    block_model: object
+    semantic: np.ndarray
+    graph: np.ndarray
+    mu_features: np.ndarray
+    semantic_length: float
+    graph_length: float
+    regional: object
+    graph_mean: np.ndarray
+    graph_scale: np.ndarray
+
+
+@dataclass
+class Endpoint:
+    family: str
+    semantic_multiplier: float
+    graph_multiplier: float
+    beta: float
+    model: object
+    path: object
+    structured_covariance: np.ndarray
+
+
+def _jsonable(value):
+    """Convert NumPy scalars/arrays recursively for stable JSON output."""
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _node_split(materialized, indices, seed, held_fraction, args):
+    """Node-disjoint split of an induced row subset, mapped back to global indices."""
+    indices = np.asarray(indices, dtype=int)
+    split = node_disjoint_pair_split(
+        [materialized["pairs"][i] for i in indices],
+        seed,
+        held_node_fraction=held_fraction,
+        strata=materialized["tags"][indices],
+        candidates=args.split_candidates,
+        minimum_per_stratum=args.minimum_per_stratum,
+    )
+    return split, indices[split.train], indices[split.held], indices[split.cross]
+
+
+def _canonical_mean_kernels(semantic, graph, fit, evaluate, sem_length, graph_length):
+    train = {
+        "semantic": rbf_kernel(semantic[fit], length_scale=sem_length),
+        "graph_feature": rbf_kernel(graph[fit], length_scale=graph_length),
+    }
+    train["equal_mixture"] = 0.5 * (train["semantic"] + train["graph_feature"])
+    cross = {
+        "semantic": rbf_kernel(semantic[evaluate], semantic[fit], length_scale=sem_length),
+        "graph_feature": rbf_kernel(graph[evaluate], graph[fit], length_scale=graph_length),
+    }
+    cross["equal_mixture"] = 0.5 * (cross["semantic"] + cross["graph_feature"])
+    return train, cross
+
+
+def fit_context(materialized, fit, evaluate, args, *, fixed_regional=None):
+    """Refit calibration, conditional residuals, mean, bandwidths, and block covariance."""
+    fit = np.asarray(fit, dtype=int)
+    evaluate = np.asarray(evaluate, dtype=int)
+    if len(fit) < 2 or not len(evaluate):
+        raise ValueError("fit/evaluate partitions must be non-empty and fit needs two rows")
+    calibrated = calibrate_sources(
+        materialized["prior"],
+        materialized["graph_d_raw"],
+        materialized["graph_s_features"],
+        materialized["luna"],
+        materialized["y_ds"],
+        fit,
+    )
+    observed_measurement_state = materialized["y_ds"][:, [0, 1, 0, 1]]
+    prior_error = materialized["y_ds"] - calibrated.prior
+    measurement_error = calibrated.meas - observed_measurement_state
+    conditional_design, q = conditional_residuals(
+        prior_error, measurement_error, calibrated.P0, calibrated.C_pm, H4
+    )
+    graph, graph_mean, graph_scale = train_standardize(materialized["graph_item_raw"], fit)
+    semantic = materialized["semantic"]
+    sem_length = median_rbf_bandwidth(semantic[fit])
+    graph_length = median_rbf_bandwidth(graph[fit])
+    mean_train, mean_cross = _canonical_mean_kernels(
+        semantic, graph, fit, evaluate, sem_length, graph_length
+    )
+    if fixed_regional is None:
+        regional = select_kernel_ridge_mean(q[fit], mean_train, ridge_grid=args.ridge_grid)
+    else:
+        kernel_name, ridge = fixed_regional
+        regional = select_kernel_ridge_mean(
+            q[fit], {kernel_name: mean_train[kernel_name]}, ridge_grid=[ridge]
+        )
+    evaluate_mean = regional.predict(mean_cross[regional.kernel_name])
+    block = fit_block_model(regional.loo_residuals, shrinkage=args.shrinkage)
+    mu_features = calibrated.X - 0.5
+    return FitContext(
+        fit,
+        evaluate,
+        calibrated,
+        conditional_design,
+        q,
+        q[evaluate] - evaluate_mean,
+        evaluate_mean,
+        block,
+        semantic,
+        graph,
+        mu_features,
+        sem_length,
+        graph_length,
+        regional,
+        graph_mean,
+        graph_scale,
+    )
+
+
+def _family_scale_grid(family):
+    if family == PRIMARY:
+        return [(semantic, graph) for semantic in MULTIPLIERS for graph in MULTIPLIERS]
+    if family == SECONDARY:
+        return [(semantic, 1.0) for semantic in MULTIPLIERS]
+    raise ValueError(f"unknown geometry family: {family}")
+
+
+def fit_endpoint(
+    context,
+    family,
+    semantic_multiplier,
+    graph_multiplier,
+    beta,
+    args,
+    seed,
+    *,
+    fitted_model=None,
+):
+    """Fit one structured endpoint on context.fit and materialize it on context.evaluate."""
+    sem_scale = context.semantic_length * float(semantic_multiplier)
+    sem_train = rbf_kernel(context.semantic[context.fit], length_scale=sem_scale)
+    sem_evaluate = rbf_kernel(context.semantic[context.evaluate], length_scale=sem_scale)
+    if family == PRIMARY:
+        graph_scale = context.graph_length * float(graph_multiplier)
+        second_train = rbf_kernel(context.graph[context.fit], length_scale=graph_scale)
+        second_evaluate = rbf_kernel(context.graph[context.evaluate], length_scale=graph_scale)
+    elif family == SECONDARY:
+        if float(graph_multiplier) != 1.0:
+            raise ValueError("centered-mu family has no graph bandwidth")
+        second_train = centered_linear_kernel(context.mu_features[context.fit], center=0.0, normalize=True)
+        second_evaluate = centered_linear_kernel(
+            context.mu_features[context.evaluate], center=0.0, normalize=True
+        )
+    else:
+        raise ValueError(f"unknown geometry family: {family}")
+    model = fitted_model
+    if model is None:
+        model = fit_lmc_model(
+            context.regional.loo_residuals,
+            sem_train,
+            second_train,
+            kind="separable",
+            steps=args.fit_steps,
+            learning_rate=args.learning_rate,
+            max_pairs=args.max_pairs,
+            seed=seed,
+        )
+    structured = materialize_channel_shrunk(model, sem_evaluate, second_evaluate, beta)
+    path = build_correlation_path(
+        context.block_model.independent_covariance, structured, H4.shape[0]
+    )
+    return Endpoint(
+        family,
+        float(semantic_multiplier),
+        float(graph_multiplier),
+        float(beta),
+        model,
+        path,
+        structured,
+    )
+
+
+def score_inner_fold(context, fold, args, seed):
+    """Fit every structured scale once and score all PSD trust/channel perturbations."""
+    block_nll = gaussian_joint_nll(
+        context.centered_evaluate,
+        np.kron(np.eye(len(context.evaluate)), context.block_model.independent_covariance),
+    ).per_scalar
+    by_family = {}
+    for family in (PRIMARY, SECONDARY):
+        records = [{
+            "fold": fold,
+            "geometry_family": family,
+            "alpha": 0.0,
+            "semantic_multiplier": 1.0,
+            "graph_multiplier": 1.0,
+            "beta": 1.0,
+            "nll_per_scalar": float(block_nll),
+        }]
+        for semantic_multiplier, graph_multiplier in _family_scale_grid(family):
+            fitted_model = None
+            for beta in BETAS:
+                endpoint = fit_endpoint(
+                    context,
+                    family,
+                    semantic_multiplier,
+                    graph_multiplier,
+                    beta,
+                    args,
+                    # Keep the composite-likelihood row-pair sample identical across geometries.
+                    seed=seed,
+                    fitted_model=fitted_model,
+                )
+                fitted_model = endpoint.model
+                for alpha in ALPHAS[1:]:
+                    records.append({
+                        "fold": fold,
+                        "geometry_family": family,
+                        "alpha": alpha,
+                        "semantic_multiplier": semantic_multiplier,
+                        "graph_multiplier": graph_multiplier,
+                        "beta": beta,
+                        "nll_per_scalar": endpoint.path.nll_per_scalar(
+                            context.centered_evaluate, alpha
+                        ),
+                    })
+        by_family[family] = records
+    return by_family
+
+
+def nested_select(materialized, outer_train, outer_seed, args):
+    """Three repeated inner node-disjoint partitions with complete nuisance refitting."""
+    records = {PRIMARY: [], SECONDARY: []}
+    diagnostics = []
+    for fold in range(3):
+        split, fit, held, cross = _node_split(
+            materialized,
+            outer_train,
+            10000 + 3 * outer_seed + fold,
+            args.inner_held_node_fraction,
+            args,
+        )
+        context = fit_context(materialized, fit, held, args)
+        scored = score_inner_fold(context, fold, args, seed=200000 + 1000 * outer_seed + 100 * fold)
+        for family in records:
+            records[family].extend(scored[family])
+        diagnostics.append({
+            "fold": fold,
+            "seed": split.seed,
+            "diagnostics": format_split_diagnostics(split),
+            "fit_rows": len(fit),
+            "held_rows": len(held),
+            "cross_rows_dropped": len(cross),
+            "regional_mean": context.regional.to_dict(),
+        })
+    selections, summaries = {}, {}
+    for family in records:
+        selections[family], summaries[family] = select_nested_candidate(records[family])
+        selections[family]["geometry_family"] = family
+        for row in summaries[family]:
+            row["geometry_family"] = family
+    return selections, summaries, diagnostics
+
+
+def _null_maximum_gains(paths, draws, seed):
+    """Block-null distribution of the exact same alpha/path oracle maximum."""
+    if not paths:
+        raise ValueError("paths must not be empty")
+    dimension = len(paths[0].correlation)
+    if any(len(path.correlation) != dimension for path in paths):
+        raise ValueError("all null-calibration paths must have the same geometry")
+    z = np.random.default_rng(seed).standard_normal((dimension, draws))
+    block_quadratic = np.sum(z * z, axis=0)
+    maximum = np.zeros(draws)
+    for path in paths:
+        coordinates = path.eigenvectors.T @ z
+        squared = coordinates * coordinates
+        for alpha in ALPHAS[1:]:
+            values = path.mixture_eigenvalues(alpha)
+            gain = 0.5 / dimension * (
+                block_quadratic
+                - np.sum(squared / values[:, None], axis=0)
+                - np.sum(np.log(values))
+            )
+            maximum = np.maximum(maximum, gain)
+    return maximum
+
+
+def outer_grid(context, args, seed):
+    """Fit/score the complete outer diagnostic grid and null-calibrate per family."""
+    block_nll = gaussian_joint_nll(
+        context.centered_evaluate,
+        np.kron(np.eye(len(context.evaluate)), context.block_model.independent_covariance),
+    ).per_scalar
+    records, endpoints, null = {}, {}, {}
+    for family_index, family in enumerate((PRIMARY, SECONDARY)):
+        family_records = [{
+            "geometry_family": family,
+            "alpha": 0.0,
+            "semantic_multiplier": 1.0,
+            "graph_multiplier": 1.0,
+            "beta": 1.0,
+            "nll_per_scalar": float(block_nll),
+            "gain_vs_block": 0.0,
+        }]
+        family_paths = []
+        for semantic_multiplier, graph_multiplier in _family_scale_grid(family):
+            fitted_model = None
+            for beta in BETAS:
+                endpoint = fit_endpoint(
+                    context,
+                    family,
+                    semantic_multiplier,
+                    graph_multiplier,
+                    beta,
+                    args,
+                    # Keep the composite-likelihood row-pair sample identical across geometries.
+                    seed=seed,
+                    fitted_model=fitted_model,
+                )
+                fitted_model = endpoint.model
+                key = (semantic_multiplier, graph_multiplier, beta)
+                endpoints[(family,) + key] = endpoint
+                family_paths.append(endpoint.path)
+                for alpha in ALPHAS[1:]:
+                    nll = endpoint.path.nll_per_scalar(context.centered_evaluate, alpha)
+                    family_records.append({
+                        "geometry_family": family,
+                        "alpha": alpha,
+                        "semantic_multiplier": semantic_multiplier,
+                        "graph_multiplier": graph_multiplier,
+                        "beta": beta,
+                        "nll_per_scalar": float(nll),
+                        "gain_vs_block": float(block_nll - nll),
+                    })
+        records[family] = family_records
+        maxima = _null_maximum_gains(
+            family_paths, args.null_draws, seed + 50000 + 1000 * family_index
+        )
+        null[family] = {
+            "scope": "conditional_fixed_path_shared_z; KRR, block covariance, and LMC endpoints held fixed",
+            "inferential": False,
+            "warning": "not full-procedure v2; endpoint-estimation uncertainty is omitted",
+            "draws": int(args.null_draws),
+            "mean_maximum_gain": float(np.mean(maxima)),
+            "maximum_gain_95th_percentile": float(np.quantile(maxima, 0.95)),
+            "maximum_observed_null_gain": float(np.max(maxima)),
+        }
+    return float(block_nll), records, endpoints, null
+
+
+def _endpoint_for_selection(endpoints, selection):
+    return endpoints[(
+        selection["geometry_family"],
+        float(selection["semantic_multiplier"]),
+        float(selection["graph_multiplier"]),
+        float(selection["beta"]),
+    )]
+
+
+def _posterior_distribution(context, covariance, materialized, bridge, hard_target, args):
+    prior = context.calibrated.prior[context.evaluate]
+    measurement = context.calibrated.meas[context.evaluate]
+    innovation = measurement - prior @ H4.T - context.evaluate_mean
+    started = time.perf_counter()
+    conditioned = condition_item_batch(
+        context.calibrated.P0,
+        context.conditional_design,
+        innovation,
+        covariance,
+        maximum_relative_loading=args.maximum_relative_loading,
+    )
+    elapsed = time.perf_counter() - started
+    mean = prior + conditioned.state_mean
+    probability = gaussian_bridge_proba(
+        bridge, mean, conditioned.marginal_covariances, order=args.quad_order
+    )
+    posterior = {
+        "state": state_metrics(
+            materialized["y_ds"][context.evaluate], mean, conditioned.marginal_covariances
+        ),
+        "decision": decision_metrics(probability, hard_target[context.evaluate]),
+        "conditioner": {
+            "wall_seconds": elapsed,
+            "state_dimension": int(2 * len(context.evaluate)),
+            "measurement_dimension": int(H4.shape[0] * len(context.evaluate)),
+            "loading": conditioned.loading_diagnostics,
+            "prior_loading": conditioned.prior_loading_diagnostics,
+        },
+    }
+    return posterior, mean, conditioned.marginal_covariances, probability
+
+
+def _covariance_record(
+    label,
+    context,
+    covariance,
+    materialized,
+    bridge,
+    hard_target,
+    args,
+    *,
+    candidate,
+):
+    nll = gaussian_joint_nll(context.centered_evaluate, covariance)
+    posterior, mean, marginals, probability = _posterior_distribution(
+        context, covariance, materialized, bridge, hard_target, args
+    )
+    return {
+        "label": label,
+        "candidate": _jsonable(candidate),
+        "held_joint_residual_nll": float(nll.total),
+        "held_joint_residual_nll_per_scalar": float(nll.per_scalar),
+        "posterior": posterior,
+    }, mean, marginals, probability
+
+
+def _selected_path_range(
+    context,
+    endpoint,
+    materialized,
+    bridge,
+    hard_target,
+    args,
+):
+    means, nlls, decisions = [], [], []
+    for alpha in ALPHAS:
+        covariance = endpoint.path.covariance(alpha)
+        nlls.append(endpoint.path.nll_per_scalar(context.centered_evaluate, alpha))
+        _, mean, _, probability = _posterior_distribution(
+            context, covariance, materialized, bridge, hard_target, args
+        )
+        means.append(mean)
+        decisions.append(np.argmax(probability, axis=1))
+    means = np.asarray(means)
+    coordinate_range = np.ptp(means, axis=0)
+    reference = means[0]
+    displacement = np.linalg.norm(means - reference[None, :, :], axis=2)
+    decision_reference = decisions[0]
+    return {
+        "alphas": list(ALPHAS),
+        "nll_per_scalar": [float(value) for value in nlls],
+        "nll_range": float(max(nlls) - min(nlls)),
+        "mean_coordinate_range_rms": float(np.sqrt(np.mean(coordinate_range ** 2))),
+        "mean_item_max_displacement_mean": float(np.mean(np.max(displacement, axis=0))),
+        "mean_item_max_displacement_max": float(np.max(displacement)),
+        "maximum_decision_flip_rate_vs_block": float(max(
+            np.mean(value != decision_reference) for value in decisions
+        )),
+    }
+
+
+def _direct_blend_diagnostic(context, endpoint):
+    block = np.kron(
+        np.eye(len(context.evaluate)), context.block_model.independent_covariance
+    )
+    nlls = []
+    for alpha in ALPHAS:
+        covariance = direct_covariance_blend(
+            block, endpoint.structured_covariance, alpha
+        )
+        nlls.append(
+            gaussian_joint_nll(context.centered_evaluate, covariance).per_scalar
+        )
+    return {
+        "warning": "raw covariance blend changes within-item marginals; not a correlation-only effect",
+        "alphas": list(ALPHAS),
+        "nll_per_scalar": [float(value) for value in nlls],
+        "best_gain_vs_block": float(nlls[0] - min(nlls)),
+    }
+
+
+def _summarize(values):
+    values = np.asarray(values, dtype=float)
+    if values.ndim != 1 or not len(values) or not np.isfinite(values).all():
+        raise ValueError("summary values must be a non-empty finite vector")
+    return {
+        "mean": float(np.mean(values)),
+        "sd": float(np.std(values, ddof=1)) if len(values) > 1 else 0.0,
+        "q05": float(np.quantile(values, 0.05)),
+        "median": float(np.median(values)),
+        "q95": float(np.quantile(values, 0.95)),
+        "maximum": float(np.max(values)),
+    }
+
+
+def _posterior_displacement(reference_mean, reference_covariance, candidate_mean):
+    values = []
+    for reference, covariance, candidate in zip(
+        reference_mean, reference_covariance, candidate_mean
+    ):
+        delta = candidate - reference
+        values.append(math.sqrt(max(float(delta @ np.linalg.solve(covariance, delta)), 0.0)))
+    return float(np.mean(values))
+
+
+def _mean_abs_log_sd_change(reference_covariance, candidate_covariance):
+    reference_sd = np.sqrt(np.diagonal(reference_covariance, axis1=1, axis2=2))
+    candidate_sd = np.sqrt(np.diagonal(candidate_covariance, axis1=1, axis2=2))
+    return float(np.mean(np.abs(np.log(candidate_sd / reference_sd))))
+
+
+def _induced_node_subsample(materialized, outer_train, fraction, seed):
+    outer_train = np.asarray(outer_train, dtype=int)
+    nodes = sorted(
+        {node for i in outer_train for node in materialized["pairs"][i]},
+        key=lambda value: (type(value).__qualname__, repr(value)),
+    )
+    count = min(len(nodes), max(2, int(math.floor(fraction * len(nodes) + 0.5))))
+    chosen_index = np.random.default_rng(seed).choice(len(nodes), size=count, replace=False)
+    chosen = {nodes[i] for i in chosen_index}
+    kept = [
+        i for i in outer_train
+        if materialized["pairs"][i][0] in chosen and materialized["pairs"][i][1] in chosen
+    ]
+    return np.asarray(kept, dtype=int), len(nodes), len(chosen)
+
+
+def _preflight_stability_subsamples(materialized, outer_train, args, seed):
+    """Reject deterministic induced-node schedules that cannot support the frozen refits."""
+    if args.stability_subsamples == 0:
+        return {"subsamples": 0, "status": "disabled by explicit CLI override"}
+    row_counts = []
+    for replicate in range(args.stability_subsamples):
+        fit, _, _ = _induced_node_subsample(
+            materialized,
+            outer_train,
+            args.stability_node_fraction,
+            seed + replicate,
+        )
+        if len(fit) < 20:
+            raise ValueError(
+                f"stability replicate {replicate} retains only {len(fit)} rows; minimum is 20"
+            )
+        semantic = materialized["semantic"][fit]
+        graph = materialized["graph_item_raw"][fit]
+        if not np.any(np.abs(semantic - semantic[0]) > 1e-12):
+            raise ValueError(f"stability replicate {replicate} has degenerate semantic geometry")
+        if not np.any(np.abs(graph - graph[0]) > 1e-12):
+            raise ValueError(f"stability replicate {replicate} has degenerate graph geometry")
+        row_counts.append(len(fit))
+    return {
+        "subsamples": int(args.stability_subsamples),
+        "minimum_fit_rows": int(min(row_counts)),
+        "maximum_fit_rows": int(max(row_counts)),
+        "minimum_required_rows": 20,
+        "geometry_non_degenerate": True,
+    }
+
+
+def covariance_for_fixed_selection(context, selection, args, seed):
+    alpha = float(selection["alpha"])
+    if alpha == 0.0:
+        covariance = np.kron(
+            np.eye(len(context.evaluate)), context.block_model.independent_covariance
+        )
+        return covariance, None
+    endpoint = fit_endpoint(
+        context,
+        selection["geometry_family"],
+        selection["semantic_multiplier"],
+        selection["graph_multiplier"],
+        selection["beta"],
+        args,
+        seed,
+    )
+    return endpoint.path.covariance(alpha), endpoint
+
+
+def stability_study(
+    materialized,
+    outer_train,
+    outer_held,
+    selection,
+    outer_context,
+    reference_covariance,
+    reference_mean,
+    reference_marginals,
+    reference_probability,
+    bridge,
+    hard_target,
+    args,
+    seed,
+):
+    """Deterministic 80%-node induced-subsample covariance/posterior stability."""
+    if args.stability_subsamples == 0:
+        return {"subsamples": 0, "status": "disabled by explicit CLI override"}
+    metrics = {
+        "whitened_covariance_error": [],
+        "posterior_sigma_mean_displacement": [],
+        "mean_marginal_symmetric_gaussian_kl": [],
+        "mean_abs_log_standard_deviation_change": [],
+        "decision_flip_rate": [],
+        "held_nll_change_vs_outer_full_selected": [],
+        "fit_rows": [],
+    }
+    samples = []
+    fixed_regional = (outer_context.regional.kernel_name, outer_context.regional.ridge)
+    reference_decision = np.argmax(reference_probability, axis=1)
+    reference_nll = gaussian_joint_nll(
+        outer_context.centered_evaluate, reference_covariance
+    ).per_scalar
+    for replicate in range(args.stability_subsamples):
+        replicate_seed = seed + replicate
+        fit, node_total, node_kept = _induced_node_subsample(
+            materialized, outer_train, args.stability_node_fraction, replicate_seed
+        )
+        context = fit_context(
+            materialized,
+            fit,
+            outer_held,
+            args,
+            fixed_regional=fixed_regional,
+        )
+        covariance, _ = covariance_for_fixed_selection(
+            # Fixed pair-sampling RNG isolates node/data sensitivity from optimizer sampling noise.
+            context, selection, args, seed=seed + 100000
+        )
+        _, mean, marginals, probability = _posterior_distribution(
+            context, covariance, materialized, bridge, hard_target, args
+        )
+        values = {
+            "whitened_covariance_error": whitened_covariance_error(
+                reference_covariance, covariance
+            ),
+            "posterior_sigma_mean_displacement": _posterior_displacement(
+                reference_mean, reference_marginals, mean
+            ),
+            "mean_marginal_symmetric_gaussian_kl": mean_marginal_symmetric_kl(
+                reference_mean, reference_marginals, mean, marginals
+            ),
+            "mean_abs_log_standard_deviation_change": _mean_abs_log_sd_change(
+                reference_marginals, marginals
+            ),
+            "decision_flip_rate": float(np.mean(
+                np.argmax(probability, axis=1) != reference_decision
+            )),
+            "held_nll_change_vs_outer_full_selected": float(
+                gaussian_joint_nll(context.centered_evaluate, covariance).per_scalar
+                - reference_nll
+            ),
+            "fit_rows": int(len(fit)),
+        }
+        for key in metrics:
+            metrics[key].append(values[key])
+        samples.append({
+            "replicate": replicate,
+            "seed": replicate_seed,
+            "outer_train_nodes": node_total,
+            "selected_nodes": node_kept,
+            **values,
+        })
+    return {
+        "subsamples": int(args.stability_subsamples),
+        "node_fraction": float(args.stability_node_fraction),
+        "interpretation": "induced-node fit stability; not a bootstrap confidence interval",
+        "summary": {key: _summarize(value) for key, value in metrics.items()},
+        "samples": samples if args.keep_stability_samples else None,
+    }
+
+
+def run_outer_split(corpus, materialized, outer_seed, args):
+    all_indices = np.arange(len(materialized["pairs"]), dtype=int)
+    split, outer_train, outer_held, outer_cross = _node_split(
+        materialized, all_indices, outer_seed, args.outer_held_node_fraction, args
+    )
+    preflight = _preflight_stability_subsamples(
+        materialized, outer_train, args, seed=700000 + 10000 * outer_seed
+    )
+    started = time.perf_counter()
+    selections, inner_summaries, inner_diagnostics = nested_select(
+        materialized, outer_train, outer_seed, args
+    )
+    context = fit_context(materialized, outer_train, outer_held, args)
+    block_nll, grid, endpoints, null = outer_grid(
+        context, args, seed=400000 + 10000 * outer_seed
+    )
+    bridge = JointPosterior(CLASSES, n_features=2, hidden=0, seed=3000 + outer_seed).fit(
+        materialized["y_ds"][outer_train],
+        materialized["hard_target"][outer_train],
+        epochs=args.bridge_epochs,
+    )
+    block_covariance = np.kron(
+        np.eye(len(outer_held)), context.block_model.independent_covariance
+    )
+    models = {}
+    block_record, _, _, _ = _covariance_record(
+        "regional block",
+        context,
+        block_covariance,
+        materialized,
+        bridge,
+        materialized["hard_target"],
+        args,
+        candidate={"alpha": 0.0},
+    )
+    models["block_regional"] = block_record
+    family_records = {}
+    for family in (PRIMARY, SECONDARY):
+        selection = selections[family]
+        endpoint = _endpoint_for_selection(endpoints, selection)
+        selected_covariance = endpoint.path.covariance(selection["alpha"])
+        selected_record, selected_mean, selected_marginals, selected_probability = _covariance_record(
+            f"nested-selected {family}",
+            context,
+            selected_covariance,
+            materialized,
+            bridge,
+            materialized["hard_target"],
+            args,
+            candidate=selection,
+        )
+        full_candidate = dict(selection, alpha=1.0)
+        full_record, _, _, _ = _covariance_record(
+            f"full-trust marginal-matched endpoint at nested-selected {family} geometry",
+            context,
+            endpoint.path.covariance(1.0),
+            materialized,
+            bridge,
+            materialized["hard_target"],
+            args,
+            candidate=full_candidate,
+        )
+        oracle = min(grid[family], key=lambda row: row["nll_per_scalar"])
+        oracle_endpoint = _endpoint_for_selection(endpoints, oracle) if oracle["alpha"] else None
+        oracle_covariance = (
+            block_covariance if oracle_endpoint is None
+            else oracle_endpoint.path.covariance(oracle["alpha"])
+        )
+        oracle_record, _, _, _ = _covariance_record(
+            f"non-deployable outer oracle {family}",
+            context,
+            oracle_covariance,
+            materialized,
+            bridge,
+            materialized["hard_target"],
+            args,
+            candidate=oracle,
+        )
+        oracle_gain = float(block_nll - oracle["nll_per_scalar"])
+        oracle_record["gain_vs_block"] = oracle_gain
+        oracle_record["null_maximum_gain_95th_percentile"] = null[family][
+            "maximum_gain_95th_percentile"
+        ]
+        oracle_record["above_null_max95"] = bool(
+            oracle_gain > null[family]["maximum_gain_95th_percentile"]
+        )
+        oracle_record["null_calibration_scope"] = null[family]["scope"]
+        oracle_record["inferential_oracle_headroom"] = False
+        innovation = (
+            context.calibrated.meas[outer_held]
+            - context.calibrated.prior[outer_held] @ H4.T
+            - context.evaluate_mean
+        )
+        sensitivity = directional_posterior_sensitivity(
+            context.calibrated.P0,
+            context.conditional_design,
+            innovation,
+            selected_covariance,
+            endpoint.path.covariance(1.0) - endpoint.path.covariance(0.0),
+        )
+        stability = (
+            stability_study(
+                materialized,
+                outer_train,
+                outer_held,
+                selection,
+                context,
+                selected_covariance,
+                selected_mean,
+                selected_marginals,
+                selected_probability,
+                bridge,
+                materialized["hard_target"],
+                args,
+                seed=700000 + 10000 * outer_seed,
+            )
+            if family == PRIMARY else
+            {
+                "status": "not run for the secondary endogenous geometry",
+                "reason": "the preregistered 100-subsample stability budget applies to the primary family",
+            }
+        )
+        family_records[family] = {
+            "selection": selection,
+            "selected_endpoint_component_fit": endpoint.model.to_dict(),
+            "outer_grid_component_fits": [
+                {
+                    "semantic_multiplier": semantic_multiplier,
+                    "graph_multiplier": graph_multiplier,
+                    "fit": endpoints[(
+                        family, semantic_multiplier, graph_multiplier, 0.0
+                    )].model.to_dict(),
+                }
+                for semantic_multiplier, graph_multiplier in _family_scale_grid(family)
+            ],
+            "inner_candidate_summaries": inner_summaries[family],
+            "nested_selected": selected_record,
+            "full_at_selected_geometry": full_record,
+            "outer_oracle": oracle_record,
+            "null_calibration": null[family],
+            "outer_held_nll_grid": grid[family],
+            "analytic_sensitivity": sensitivity.to_dict(),
+            "selected_path_range": _selected_path_range(
+                context,
+                endpoint,
+                materialized,
+                bridge,
+                materialized["hard_target"],
+                args,
+            ),
+            "direct_raw_covariance_blend": _direct_blend_diagnostic(context, endpoint),
+            "covariance_estimation_stability": stability,
+        }
+    canonical_endpoint = endpoints[(PRIMARY, 1.0, 1.0, 0.0)]
+    canonical_record, _, _, _ = _covariance_record(
+        "original canonical primary raw plug-in endpoint",
+        context,
+        canonical_endpoint.structured_covariance,
+        materialized,
+        bridge,
+        materialized["hard_target"],
+        args,
+        candidate={
+            "geometry_family": PRIMARY,
+            "alpha": 1.0,
+            "semantic_multiplier": 1.0,
+            "graph_multiplier": 1.0,
+            "beta": 0.0,
+        },
+    )
+    models["canonical_primary_raw_plugin"] = canonical_record
+    canonical_matched_record, _, _, _ = _covariance_record(
+        "canonical primary marginal-matched full-trust endpoint",
+        context,
+        canonical_endpoint.path.covariance(1.0),
+        materialized,
+        bridge,
+        materialized["hard_target"],
+        args,
+        candidate={
+            "geometry_family": PRIMARY,
+            "alpha": 1.0,
+            "semantic_multiplier": 1.0,
+            "graph_multiplier": 1.0,
+            "beta": 0.0,
+        },
+    )
+    models["canonical_primary_marginal_matched"] = canonical_matched_record
+    return {
+        "corpus": corpus,
+        "outer_seed": outer_seed,
+        "target_frame": "GPT-5.5 operating-judge fidelity; not independent truth",
+        "split": {
+            "diagnostics": format_split_diagnostics(split),
+            "train_rows": len(outer_train),
+            "held_rows": len(outer_held),
+            "cross_rows_dropped": len(outer_cross),
+            "train_nodes": len(split.train_nodes),
+            "held_nodes": len(split.held_nodes),
+            "selected_candidate": split.selected_candidate,
+            "train_tags": dict(Counter(map(str, materialized["tags"][outer_train]))),
+            "held_tags": dict(Counter(map(str, materialized["tags"][outer_held]))),
+        },
+        "inner_partitions": inner_diagnostics,
+        "stability_preflight": preflight,
+        "outer_fit": {
+            "semantic_rbf_bandwidth": context.semantic_length,
+            "graph_rbf_bandwidth": context.graph_length,
+            "graph_standardizer_mean": context.graph_mean.tolist(),
+            "graph_standardizer_scale": context.graph_scale.tolist(),
+            "regional_mean": context.regional.to_dict(),
+            "block_model": context.block_model.to_dict(),
+        },
+        "models": models,
+        "families": family_records,
+        "wall_seconds": time.perf_counter() - started,
+    }
+
+
+def aggregate_results(results):
+    """Apply the frozen direction/stability/guardrail gates without row-level pseudo-SEs."""
+    by_family = {}
+    for family in (PRIMARY, SECONDARY):
+        by_corpus = {}
+        for corpus in sorted({row["corpus"] for row in results}):
+            rows = sorted(
+                [row for row in results if row["corpus"] == corpus],
+                key=lambda row: row["outer_seed"],
+            )
+            block = np.asarray([
+                row["models"]["block_regional"]["held_joint_residual_nll_per_scalar"]
+                for row in rows
+            ])
+            selected = np.asarray([
+                row["families"][family]["nested_selected"]["held_joint_residual_nll_per_scalar"]
+                for row in rows
+            ])
+            posterior_block = np.asarray([
+                row["models"]["block_regional"]["posterior"]["state"]["mean_bivariate_nll"]
+                for row in rows
+            ])
+            posterior_selected = np.asarray([
+                row["families"][family]["nested_selected"]["posterior"]["state"]["mean_bivariate_nll"]
+                for row in rows
+            ])
+            logloss_block = np.asarray([
+                row["models"]["block_regional"]["posterior"]["decision"]["log_loss"]
+                for row in rows
+            ])
+            logloss_selected = np.asarray([
+                row["families"][family]["nested_selected"]["posterior"]["decision"]["log_loss"]
+                for row in rows
+            ])
+            aurc_block = np.asarray([
+                row["models"]["block_regional"]["posterior"]["decision"]["aurc_margin"]
+                for row in rows
+            ])
+            aurc_selected = np.asarray([
+                row["families"][family]["nested_selected"]["posterior"]["decision"]["aurc_margin"]
+                for row in rows
+            ])
+            gain = block - selected
+            posterior_gain = posterior_block - posterior_selected
+            logloss_gain = logloss_block - logloss_selected
+            aurc_gain = aurc_block - aurc_selected
+            oracle_gain = np.asarray([
+                row["families"][family]["outer_oracle"]["gain_vs_block"] for row in rows
+            ])
+            oracle_above = np.asarray([
+                row["families"][family]["outer_oracle"]["above_null_max95"] for row in rows
+            ], dtype=bool)
+            alphas = np.asarray([
+                row["families"][family]["selection"]["alpha"] for row in rows
+            ])
+            noise_loading = np.asarray([
+                row["families"][family]["nested_selected"]["posterior"]["conditioner"]["loading"]
+                ["relative_diagonal_loading"]
+                for row in rows
+            ])
+            prior_loading = np.asarray([
+                row["families"][family]["nested_selected"]["posterior"]["conditioner"]
+                ["prior_loading"]["relative_diagonal_loading"]
+                for row in rows
+            ])
+            by_corpus[corpus] = {
+                "outer_seeds": [row["outer_seed"] for row in rows],
+                "nested_gain_mean_sd": [
+                    float(np.mean(gain)),
+                    float(np.std(gain, ddof=1)) if len(gain) > 1 else 0.0,
+                ],
+                "nested_positive_seeds": int(np.sum(gain > 0.0)),
+                "nonzero_alpha_seeds": int(np.sum(alphas > 0.0)),
+                "posterior_nll_gain_mean": float(np.mean(posterior_gain)),
+                "decision_log_loss_gain_mean": float(np.mean(logloss_gain)),
+                "decision_aurc_gain_mean": float(np.mean(aurc_gain)),
+                "oracle_gain_mean_sd": [
+                    float(np.mean(oracle_gain)),
+                    float(np.std(oracle_gain, ddof=1)) if len(oracle_gain) > 1 else 0.0,
+                ],
+                "oracle_positive_seeds": int(np.sum(oracle_gain > 0.0)),
+                "oracle_above_null_max95_seeds": int(np.sum(oracle_above)),
+                "maximum_noise_relative_diagonal_loading": float(np.max(noise_loading)),
+                "maximum_prior_relative_diagonal_loading": float(np.max(prior_loading)),
+            }
+        by_family[family] = by_corpus
+
+    complete = (
+        {row["corpus"] for row in results} == {"exploratory", "fresh"}
+        and all(
+            len([row for row in results if row["corpus"] == corpus]) == 10
+            and {row["outer_seed"] for row in results if row["corpus"] == corpus}
+                == set(range(10, 20))
+            for corpus in ("exploratory", "fresh")
+        )
+    )
+
+    def gate(family):
+        summaries = by_family[family]
+        raw_nested_direction = complete and all(
+            value["nested_gain_mean_sd"][0] > 0.0 and value["nested_positive_seeds"] >= 8
+            for value in summaries.values()
+        )
+        posterior = all(
+            value["posterior_nll_gain_mean"] >= 0.0 for value in summaries.values()
+        )
+        decision = all(
+            value["decision_log_loss_gain_mean"] >= -0.01
+            and value["decision_aurc_gain_mean"] >= -0.01
+            for value in summaries.values()
+        )
+        loading = all(
+            value["maximum_noise_relative_diagonal_loading"] <= 1e-3
+            and value["maximum_prior_relative_diagonal_loading"] <= 1e-3
+            for value in summaries.values()
+        )
+        conditional_oracle = complete and all(
+            value["oracle_positive_seeds"] >= 8
+            and value["oracle_above_null_max95_seeds"] >= 8
+            for value in summaries.values()
+        )
+        return {
+            "gate_evaluable": False,
+            "selector_status": (
+                "INVALIDATED v1: family-wise synthetic controls failed; multi-seed execution is descriptive only"
+            ),
+            "uncalibrated_v1_raw_direction_and_stability_would_pass": raw_nested_direction,
+            "posterior_guardrail_passes": posterior,
+            "decision_guardrail_passes": decision,
+            "loading_guardrail_passes": loading,
+            "nested_covariance_gate_passes": False,
+            "conditional_fixed_path_oracle_headroom_diagnostic": conditional_oracle,
+            "full_procedure_null_calibrated_oracle_headroom_passes": False,
+            "interpretation": (
+                "incomplete smoke/descriptive run; no inferential gate"
+                if not complete else
+                "complete descriptive v1 grid only; selector and fixed-path null are undercalibrated"
+            ),
+        }
+
+    return {
+        "complete_preregistered_outer_run": complete,
+        "inferential_gate_evaluable": False,
+        "blocking_reason": (
+            "v1 selector failed family-wise synthetic controls and the real outer null is conditional fixed-path only"
+        ),
+        "by_family": by_family,
+        "primary_gate": gate(PRIMARY),
+        "secondary_endogenous_geometry_gate": gate(SECONDARY),
+        "variation_note": "mean/SD across node partitions is descriptive stability, not a population CI",
+    }
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-repo", default=os.path.abspath(os.path.join(ROOT, "..", "..")))
+    parser.add_argument("--ckpt", default=os.path.join(ROOT, "model_prod_namecond.pt"))
+    parser.add_argument("--campaign", default=DEFAULT_CAMPAIGN)
+    parser.add_argument("--luna", default=DEFAULT_LUNA)
+    parser.add_argument("--outer-seed-start", type=int, default=10)
+    parser.add_argument("--seeds", type=int, default=1)
+    parser.add_argument("--outer-held-node-fraction", type=float, default=0.40)
+    parser.add_argument("--inner-held-node-fraction", type=float, default=0.35)
+    parser.add_argument("--split-candidates", type=int, default=64)
+    parser.add_argument("--minimum-per-stratum", type=int, default=1)
+    parser.add_argument("--shrinkage", type=float, default=0.05)
+    parser.add_argument("--ridge-grid", type=float, nargs="+", default=[1e-3, 1e-2, 1e-1, 1.0, 10.0])
+    parser.add_argument("--fit-steps", type=int, default=150)
+    parser.add_argument("--learning-rate", type=float, default=0.03)
+    parser.add_argument("--max-pairs", type=int, default=4096)
+    parser.add_argument("--bridge-epochs", type=int, default=300)
+    parser.add_argument("--quad-order", type=int, default=5)
+    parser.add_argument("--maximum-relative-loading", type=float, default=1e-3)
+    parser.add_argument("--null-draws", type=int, default=200)
+    parser.add_argument("--stability-subsamples", type=int, default=100)
+    parser.add_argument("--stability-node-fraction", type=float, default=0.80)
+    parser.add_argument("--keep-stability-samples", action="store_true")
+    parser.add_argument(
+        "--cpu-threads",
+        type=int,
+        default=1,
+        help="Torch intra-op threads only; set BLAS thread environment variables externally if required",
+    )
+    parser.add_argument("--out", default="/tmp/covariance_sensitivity.json")
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="resume an exactly matching atomically checkpointed output",
+    )
+    parser.add_argument(
+        "--allow-failed-v1-selector",
+        action="store_true",
+        help=(
+            "explicitly allow a multi-seed v1 run even though its preregistered synthetic selector gate failed"
+        ),
+    )
+    return parser
+
+
+def _validate_args(args):
+    if args.seeds < 1:
+        raise ValueError("--seeds must be positive")
+    if args.seeds > 1 and not args.allow_failed_v1_selector:
+        raise ValueError(
+            "multi-seed v1 execution is blocked because its synthetic selector gate failed; "
+            "pass --allow-failed-v1-selector only for an explicitly descriptive run"
+        )
+    if args.null_draws < 1:
+        raise ValueError("--null-draws must be positive")
+    if args.stability_subsamples < 0:
+        raise ValueError("--stability-subsamples must be nonnegative")
+    if not 0.0 < args.stability_node_fraction <= 1.0:
+        raise ValueError("--stability-node-fraction must be in (0,1]")
+
+
+def _write_payload(path, payload):
+    path = os.path.abspath(path)
+    temporary = path + ".tmp"
+    with open(temporary, "w", encoding="utf-8") as stream:
+        json.dump(_jsonable(payload), stream, indent=2, sort_keys=True)
+        stream.write("\n")
+    os.replace(temporary, path)
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    _validate_args(args)
+    torch.set_num_threads(args.cpu_threads)
+    np.random.seed(0)
+    artifacts = configure_artifact_repo(args.artifact_repo)
+    target_by_pair, cur_rel = load_decision_targets(args.campaign)
+    luna_pairs, luna_d, luna_s = load_scored_mu_tsv(args.luna)
+    luna_by_pair = {pair: (luna_d[i], luna_s[i]) for i, pair in enumerate(luna_pairs)}
+    checkpoint = load_expanded(args.ckpt, dev="cpu")
+    checkpoint[0].eval()
+    datasets = load_campaign_datasets(campaign_scored=args.campaign)
+    materialized = {
+        name.replace("-campaign", ""): materialize_corpus(
+            name, dataset, target_by_pair, luna_by_pair, checkpoint
+        )
+        for name, dataset in datasets.items()
+    }
+    configuration = vars(args).copy()
+    configuration.pop("resume")
+    payload = {
+        "status": (
+            "DESCRIPTIVE LEGACY V1; selector failed family-wise synthetic calibration; no inferential gate"
+        ),
+        "real_data_v2_selector_implemented": False,
+        "protocol": (
+            "legacy-v1 nested covariance sensitivity; node-disjoint; train-only refitting; "
+            "multi-seed inference disabled"
+        ),
+        "target_scope": "GPT-5.5 operating-judge fidelity; not independent ground truth",
+        "inputs": {
+            "checkpoint": file_provenance(args.ckpt),
+            "campaign": file_provenance(args.campaign),
+            "luna": file_provenance(args.luna),
+            "artifact_paths": artifacts,
+            "e5_caches": {
+                "exploratory": file_provenance(CAMPAIGN_E5_100K),
+                "fresh": file_provenance(DATASETS["fresh"]["e5_cache"]),
+            },
+            "campaign_cur_rel_counts": dict(cur_rel),
+        },
+        "configuration": configuration,
+        "frozen_grid": {
+            "alphas": list(ALPHAS),
+            "multipliers": list(MULTIPLIERS),
+            "betas": list(BETAS),
+            "families": [PRIMARY, SECONDARY],
+        },
+        "compute_note": (
+            "CPU float64; --cpu-threads controls Torch only, while NumPy linear algebra follows the "
+            "process BLAS environment; no CUDA claim"
+        ),
+        "results": [],
+        "aggregate": None,
+        "resume_events": [],
+    }
+    if args.resume and os.path.isfile(args.out):
+        with open(args.out, "r", encoding="utf-8") as stream:
+            previous = json.load(stream)
+        checks = (
+            ("protocol", previous.get("protocol"), payload["protocol"]),
+            ("configuration", previous.get("configuration"), payload["configuration"]),
+            ("frozen_grid", previous.get("frozen_grid"), payload["frozen_grid"]),
+            ("inputs", previous.get("inputs"), payload["inputs"]),
+        )
+        mismatched = [name for name, old, new in checks if old != new]
+        if mismatched:
+            raise ValueError(
+                "refusing to resume output with mismatched " + ", ".join(mismatched)
+            )
+        payload = previous
+        payload.setdefault("resume_events", []).append({
+            "completed_records_at_resume": len(payload.get("results", [])),
+            "note": "exact configuration, grid, and input provenance matched",
+        })
+    completed = {
+        (row["corpus"], int(row["outer_seed"])) for row in payload["results"]
+    }
+    if len(completed) != len(payload["results"]):
+        raise ValueError("checkpoint contains duplicate corpus/outer-seed records")
+    for outer_seed in range(args.outer_seed_start, args.outer_seed_start + args.seeds):
+        for corpus in ("exploratory", "fresh"):
+            if (corpus, outer_seed) in completed:
+                print(f"skipping completed {corpus} outer seed {outer_seed}", flush=True)
+                continue
+            print(f"\n=== covariance sensitivity: {corpus}, outer seed {outer_seed} ===", flush=True)
+            row = run_outer_split(corpus, materialized[corpus], outer_seed, args)
+            payload["results"].append(row)
+            completed.add((corpus, outer_seed))
+            for family in (PRIMARY, SECONDARY):
+                nested = row["families"][family]["nested_selected"]
+                oracle = row["families"][family]["outer_oracle"]
+                print(
+                    f"  {family:34s} alpha={row['families'][family]['selection']['alpha']:.3f} "
+                    f"nested={nested['held_joint_residual_nll_per_scalar']:+.6f} "
+                    f"oracle_gain={oracle['gain_vs_block']:+.6f} "
+                    f"above_null95={oracle['above_null_max95']}",
+                    flush=True,
+                )
+            payload["aggregate"] = aggregate_results(payload["results"])
+            _write_payload(args.out, payload)
+            print(f"  checkpointed {args.out}; split wall={row['wall_seconds']:.1f}s", flush=True)
+    payload["aggregate"] = aggregate_results(payload["results"])
+    _write_payload(args.out, payload)
+    print(f"\nwrote {args.out}")
+    print(json.dumps(payload["aggregate"], indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/run_covariance_sensitivity_synthetic.py
+++ b/prototypes/mu_cosine/run_covariance_sensitivity_synthetic.py
@@ -1,0 +1,920 @@
+#!/usr/bin/env python3
+"""Legacy v1 synthetic controls for nested covariance-sensitivity selection.
+
+The controls use deterministic item geometry and known PSD correlation endpoints.  Outcome-blind kernel
+systems and correlation eigensystems are cached, while every replicate refits the regional KRR coefficients,
+selects its mean model, estimates the block marginal, and runs the frozen three-partition conservative
+selector.  No real-data LMC optimization is used here; that separation is deliberate.
+
+Important: the first v1 output's post-KRR "known truth" recovery denominator is invalid because the scored
+residual is ``e_H-W e_T``, not ``e_H``.  The corrected, versioned runner separates end-to-end harm from an
+oracle-mean/known-B power mechanism; see ``run_covariance_sensitivity_synthetic_v2.py``.  This file remains to
+reproduce the v1 selection failure, not as a source of recovery claims.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import dataclass
+import json
+import math
+import os
+import sys
+import time
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from covariance_sensitivity import select_nested_candidate
+from structured_residual_covariance import gaussian_joint_nll, median_rbf_bandwidth, rbf_kernel
+
+
+CHANNELS = 4
+STATE_DIMENSION = 2
+ALPHAS = (0.0, 0.025, 0.05, 0.10, 0.20, 0.35, 0.50, 0.75, 1.0)
+MULTIPLIERS = (0.5, 1.0, 2.0)
+BETAS = (0.0, 0.5, 1.0)
+RIDGES = (1e-3, 1e-2, 1e-1, 1.0, 10.0)
+SCENARIO_ORDER = (
+    "block_null",
+    "regional_mean_only",
+    "wrong_item_geometry",
+    "in_family_coupling_0.04",
+    "in_family_coupling_0.10",
+    "in_family_coupling_0.20",
+)
+
+
+def _jsonable(value):
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _summary(values):
+    values = np.asarray(values, dtype=float)
+    if values.ndim != 1 or not len(values) or not np.isfinite(values).all():
+        raise ValueError("summary input must be a non-empty finite vector")
+    return {
+        "mean": float(np.mean(values)),
+        "sd": float(np.std(values, ddof=1)) if len(values) > 1 else 0.0,
+        "q05": float(np.quantile(values, 0.05)),
+        "median": float(np.median(values)),
+        "q95": float(np.quantile(values, 0.95)),
+    }
+
+
+def _ratio(numerator, denominator):
+    denominator = float(denominator)
+    if denominator <= 0.0:
+        return None
+    return float(numerator) / denominator
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    candidate_coupling: float
+    true_coupling: float
+    regional_mean: bool = False
+    wrong_geometry: bool = False
+
+
+SCENARIOS = (
+    Scenario("block_null", 0.20, 0.0),
+    Scenario("regional_mean_only", 0.20, 0.0, regional_mean=True),
+    Scenario("wrong_item_geometry", 0.20, 0.20, wrong_geometry=True),
+    # The common 0.20 endpoint makes 0.04 and 0.10 exactly alpha=0.20 and alpha=0.50,
+    # respectively, so those scenarios contain both under- and over-correlated candidates.
+    Scenario("in_family_coupling_0.04", 0.20, 0.04),
+    Scenario("in_family_coupling_0.10", 0.20, 0.10),
+    Scenario("in_family_coupling_0.20", 0.20, 0.20),
+)
+
+
+@dataclass(frozen=True)
+class CachedCorrelation:
+    """Outcome-blind eigensystem for one fixed marginal-preserving endpoint."""
+
+    correlation: np.ndarray
+    eigenvalues: np.ndarray
+    eigenvectors: np.ndarray
+
+    def mixture_eigenvalues(self, alpha):
+        alpha = float(alpha)
+        values = 1.0 + alpha * (self.eigenvalues - 1.0)
+        if values[0] <= 0.0:
+            raise np.linalg.LinAlgError("synthetic correlation path is not positive definite")
+        return values
+
+    def mixture(self, alpha):
+        alpha = float(alpha)
+        return (1.0 - alpha) * np.eye(len(self.correlation)) + alpha * self.correlation
+
+
+class NLLScorer:
+    """One block whitening reused across the complete endpoint/alpha grid."""
+
+    def __init__(self, residuals, block_covariance):
+        self.residuals = np.asarray(residuals, dtype=float)
+        self.block_covariance = np.asarray(block_covariance, dtype=float)
+        factor = np.linalg.cholesky(self.block_covariance)
+        self.whitened = np.linalg.solve(factor, self.residuals.T).T.reshape(-1)
+        self.block_logdet = 2.0 * np.sum(np.log(np.diag(factor)))
+        self.constant = len(self.whitened) * math.log(2.0 * math.pi)
+
+    @property
+    def block_nll(self):
+        total = 0.5 * (
+            float(self.whitened @ self.whitened)
+            + len(self.residuals) * float(self.block_logdet)
+            + self.constant
+        )
+        return total / len(self.whitened)
+
+    def score_path(self, endpoint):
+        squared = (endpoint.eigenvectors.T @ self.whitened) ** 2
+        output = {}
+        for alpha in ALPHAS[1:]:
+            values = endpoint.mixture_eigenvalues(alpha)
+            total = 0.5 * (
+                float(np.sum(squared / values))
+                + len(self.residuals) * float(self.block_logdet)
+                + float(np.sum(np.log(values)))
+                + self.constant
+            )
+            output[alpha] = total / len(self.whitened)
+        return output
+
+
+@dataclass(frozen=True)
+class CachedKRRCandidate:
+    kernel_name: str
+    ridge: float
+    intercept_weights: np.ndarray
+    projection: np.ndarray
+    loo_diagonal: np.ndarray
+    cross_kernel: np.ndarray
+
+
+@dataclass(frozen=True)
+class RegionalFit:
+    kernel_name: str
+    ridge: float
+    intercept: np.ndarray
+    alpha: np.ndarray
+    loo_residuals: np.ndarray
+    loo_mse: float
+    prediction: np.ndarray
+
+
+class KRRCache:
+    """Exact intercept-aware KRR refits with only outcome-blind matrix systems cached."""
+
+    def __init__(self, train_kernels, cross_kernels, ridge_grid=RIDGES):
+        if set(train_kernels) != set(cross_kernels):
+            raise ValueError("train and cross KRR kernels must have identical names")
+        candidates = []
+        for name in sorted(train_kernels):
+            kernel = np.asarray(train_kernels[name], dtype=float)
+            cross = np.asarray(cross_kernels[name], dtype=float)
+            if kernel.ndim != 2 or kernel.shape[0] != kernel.shape[1]:
+                raise ValueError("KRR train kernels must be square")
+            if cross.ndim != 2 or cross.shape[1] != len(kernel):
+                raise ValueError("KRR cross kernels must align with train kernels")
+            for ridge in ridge_grid:
+                system = kernel + float(ridge) * np.eye(len(kernel))
+                inverse = np.linalg.solve(system, np.eye(len(system)))
+                ones = np.ones(len(kernel))
+                inverse_ones = inverse @ ones
+                denominator = float(ones @ inverse_ones)
+                projection = inverse - np.outer(inverse_ones, inverse_ones) / denominator
+                diagonal = np.diag(projection)
+                if denominator <= 0.0 or np.any(diagonal <= 0.0):
+                    raise np.linalg.LinAlgError("invalid cached KRR system")
+                candidates.append(CachedKRRCandidate(
+                    name,
+                    float(ridge),
+                    (ones @ inverse) / denominator,
+                    projection,
+                    diagonal,
+                    cross,
+                ))
+        if not candidates:
+            raise ValueError("at least one KRR candidate is required")
+        self.candidates = tuple(candidates)
+
+    def fit_predict(self, residuals):
+        residuals = np.asarray(residuals, dtype=float)
+        if residuals.ndim != 2 or len(residuals) != len(self.candidates[0].projection):
+            raise ValueError("KRR residuals do not match cached train geometry")
+        fitted = []
+        for candidate in self.candidates:
+            intercept = candidate.intercept_weights @ residuals
+            alpha = candidate.projection @ residuals
+            loo_residuals = alpha / candidate.loo_diagonal[:, None]
+            fitted.append(RegionalFit(
+                candidate.kernel_name,
+                candidate.ridge,
+                intercept,
+                alpha,
+                loo_residuals,
+                float(np.mean(loo_residuals * loo_residuals)),
+                intercept + candidate.cross_kernel @ alpha,
+            ))
+        return min(fitted, key=lambda value: (value.loo_mse, value.kernel_name, value.ridge))
+
+
+class SyntheticGeometry:
+    """Fixed features, partitions, KRR systems, and covariance endpoint eigensystems."""
+
+    def __init__(self, item_count, outer_held_count, inner_held_count):
+        if item_count < 24:
+            raise ValueError("at least 24 synthetic items are required")
+        if not 4 <= outer_held_count <= item_count - 12:
+            raise ValueError("outer held count leaves too few fit or held items")
+        outer_train_count = item_count - outer_held_count
+        if not 4 <= inner_held_count <= outer_train_count - 8:
+            raise ValueError("inner held count leaves too few fit or held items")
+        rng = np.random.default_rng(24051)
+        latent = rng.normal(size=(item_count, 3))
+        self.semantic_features = np.column_stack((
+            latent[:, 0],
+            0.55 * latent[:, 1] + 0.20 * np.sin(latent[:, 0]),
+        ))
+        self.graph_features = np.column_stack((
+            0.65 * latent[:, 0] - 0.35 * latent[:, 1] + 0.30 * latent[:, 2],
+            np.sin(latent[:, 1]) + 0.25 * latent[:, 2],
+        ))
+        self.semantic_length = median_rbf_bandwidth(self.semantic_features)
+        self.graph_length = median_rbf_bandwidth(self.graph_features)
+        permutation = np.random.default_rng(907).permutation(item_count)
+        self.outer_held = np.sort(permutation[:outer_held_count])
+        self.outer_train = np.sort(permutation[outer_held_count:])
+        self.inner_partitions = []
+        for fold in range(3):
+            inner_order = np.random.default_rng(10000 + fold).permutation(self.outer_train)
+            held = np.sort(inner_order[:inner_held_count])
+            fit = np.sort(inner_order[inner_held_count:])
+            self.inner_partitions.append((fit, held))
+        self.channel_shape = self._channel_shape()
+        self.block_covariance = np.array([
+            [1.00, 0.22, -0.08, 0.12],
+            [0.22, 0.82, 0.14, -0.05],
+            [-0.08, 0.14, 0.68, 0.09],
+            [0.12, -0.05, 0.09, 0.74],
+        ])
+        np.linalg.cholesky(self.block_covariance)
+        self.prior_covariance = np.array([[0.80, 0.18], [0.18, 0.65]])
+        self.design = np.array([
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.75, 0.20],
+            [-0.15, 0.85],
+        ])
+        self.mean = self._regional_mean()
+        self._item_kernels = {}
+        for semantic_multiplier in MULTIPLIERS:
+            for graph_multiplier in MULTIPLIERS:
+                self._item_kernels[(float(semantic_multiplier), float(graph_multiplier))] = (
+                    0.5 * rbf_kernel(
+                        self.semantic_features,
+                        length_scale=self.semantic_length * semantic_multiplier,
+                    )
+                    + 0.5 * rbf_kernel(
+                        self.graph_features,
+                        length_scale=self.graph_length * graph_multiplier,
+                    )
+                )
+        self.canonical_item_kernel = self._item_kernels[(1.0, 1.0)]
+        # Congruence by a fixed permutation preserves the complete spectrum and off-diagonal energy while
+        # assigning the same correlations to the wrong item pairs.  A separate narrow RBF would make the
+        # misspecified control artificially easier merely by weakening its covariance mass.
+        base_permutation = np.random.default_rng(33517).permutation(item_count)
+        for shift in range(item_count):
+            candidate_permutation = np.roll(base_permutation, shift)
+            if np.all(candidate_permutation != np.arange(item_count)):
+                self.wrong_permutation = candidate_permutation
+                break
+        else:  # pragma: no cover - a cyclic shift always supplies a derangement for item_count > 1.
+            raise RuntimeError("failed to construct the frozen wrong-geometry derangement")
+        self.wrong_item_kernel = self.canonical_item_kernel[
+            np.ix_(self.wrong_permutation, self.wrong_permutation)
+        ]
+        self.canonical_maximum = self._maximum_off_diagonal(self.canonical_item_kernel)
+        self._krr = {}
+        for name, (fit, evaluate) in self.partition_map.items():
+            self._krr[name] = self._make_krr_cache(fit, evaluate)
+        self._endpoint_cache = {}
+        self._true_cache = {}
+        self._true_factor_cache = {}
+        self._posterior_system_cache = {}
+
+    @property
+    def item_count(self):
+        return len(self.semantic_features)
+
+    @property
+    def partition_map(self):
+        partitions = {"outer": (self.outer_train, self.outer_held)}
+        partitions.update({f"inner_{fold}": value for fold, value in enumerate(self.inner_partitions)})
+        return partitions
+
+    @staticmethod
+    def _channel_shape():
+        vector = np.array([0.62, -0.47, 0.51, -0.36])
+        vector /= np.linalg.norm(vector)
+        return np.outer(vector, vector)
+
+    def _regional_mean(self):
+        scalar = (
+            np.sin(0.9 * self.semantic_features[:, 0])
+            + 0.45 * np.cos(1.1 * self.semantic_features[:, 1])
+        )
+        scalar = (scalar - scalar.mean()) / scalar.std()
+        return scalar[:, None] * np.array([[0.75, -0.50, 0.38, -0.28]])
+
+    @staticmethod
+    def _maximum_off_diagonal(kernel):
+        mask = ~np.eye(len(kernel), dtype=bool)
+        return float(np.max(np.abs(kernel[mask])))
+
+    def _make_krr_cache(self, fit, evaluate):
+        train = {
+            "semantic": rbf_kernel(
+                self.semantic_features[fit], length_scale=self.semantic_length
+            ),
+            "graph": rbf_kernel(
+                self.graph_features[fit], length_scale=self.graph_length
+            ),
+        }
+        train["equal_mixture"] = 0.5 * (train["semantic"] + train["graph"])
+        cross = {
+            "semantic": rbf_kernel(
+                self.semantic_features[evaluate],
+                self.semantic_features[fit],
+                length_scale=self.semantic_length,
+            ),
+            "graph": rbf_kernel(
+                self.graph_features[evaluate],
+                self.graph_features[fit],
+                length_scale=self.graph_length,
+            ),
+        }
+        cross["equal_mixture"] = 0.5 * (cross["semantic"] + cross["graph"])
+        return KRRCache(train, cross)
+
+    def candidate_endpoint(self, scenario, partition_name, semantic_multiplier, graph_multiplier, beta):
+        key = (
+            scenario.candidate_coupling,
+            partition_name,
+            float(semantic_multiplier),
+            float(graph_multiplier),
+            float(beta),
+        )
+        if key not in self._endpoint_cache:
+            _, evaluate = self.partition_map[partition_name]
+            item = self._item_kernels[(float(semantic_multiplier), float(graph_multiplier))][
+                np.ix_(evaluate, evaluate)
+            ]
+            channel = (1.0 - beta) * self.channel_shape + beta * np.diag(
+                np.diag(self.channel_shape)
+            )
+            gamma = scenario.candidate_coupling / self.canonical_maximum
+            correlation = np.eye(CHANNELS * len(evaluate)) + gamma * np.kron(
+                item - np.eye(len(item)), channel
+            )
+            correlation = 0.5 * (correlation + correlation.T)
+            eigenvalues, eigenvectors = np.linalg.eigh(correlation)
+            if eigenvalues[0] <= 0.0:
+                raise np.linalg.LinAlgError("candidate synthetic endpoint is not SPD")
+            self._endpoint_cache[key] = CachedCorrelation(
+                correlation, eigenvalues, eigenvectors
+            )
+        return self._endpoint_cache[key]
+
+    def true_correlation(self, scenario, indices):
+        key = (scenario.name, tuple(map(int, indices)))
+        if key not in self._true_cache:
+            if scenario.true_coupling == 0.0:
+                correlation = np.eye(CHANNELS * len(indices))
+            else:
+                item_full = (
+                    self.wrong_item_kernel if scenario.wrong_geometry
+                    else self.canonical_item_kernel
+                )
+                item = item_full[np.ix_(indices, indices)]
+                maximum = (
+                    self._maximum_off_diagonal(item_full)
+                    if scenario.wrong_geometry else self.canonical_maximum
+                )
+                gamma = scenario.true_coupling / maximum
+                correlation = np.eye(CHANNELS * len(indices)) + gamma * np.kron(
+                    item - np.eye(len(item)), self.channel_shape
+                )
+                correlation = 0.5 * (correlation + correlation.T)
+            np.linalg.cholesky(correlation)
+            self._true_cache[key] = correlation
+        return self._true_cache[key]
+
+    def covariance_from_correlation(self, correlation, block_covariance):
+        item_count = len(correlation) // CHANNELS
+        factor = np.kron(np.eye(item_count), np.linalg.cholesky(block_covariance))
+        covariance = factor @ correlation @ factor.T
+        return 0.5 * (covariance + covariance.T)
+
+    def true_covariance(self, scenario, indices):
+        return self.covariance_from_correlation(
+            self.true_correlation(scenario, indices), self.block_covariance
+        )
+
+    def draw(self, scenario, seed):
+        rng = np.random.default_rng(seed)
+        if scenario.name not in self._true_factor_cache:
+            correlation = self.true_correlation(scenario, np.arange(self.item_count))
+            covariance = self.covariance_from_correlation(correlation, self.block_covariance)
+            self._true_factor_cache[scenario.name] = np.linalg.cholesky(covariance)
+        factor = self._true_factor_cache[scenario.name]
+        noise = (factor @ rng.standard_normal(len(factor))).reshape(
+            self.item_count, CHANNELS
+        )
+        state = rng.multivariate_normal(
+            np.zeros(STATE_DIMENSION), self.prior_covariance, size=self.item_count
+        )
+        regional_mean = self.mean if scenario.regional_mean else np.zeros_like(self.mean)
+        conditional_residual = regional_mean + noise
+        innovation = state @ self.design.T + conditional_residual
+        return conditional_residual, innovation, state
+
+    def posterior_system(self, item_count):
+        if item_count not in self._posterior_system_cache:
+            design = np.kron(np.eye(item_count), self.design)
+            prior_precision = np.kron(
+                np.eye(item_count), np.linalg.solve(self.prior_covariance, np.eye(STATE_DIMENSION))
+            )
+            self._posterior_system_cache[item_count] = (design, prior_precision)
+        return self._posterior_system_cache[item_count]
+
+
+def _candidate_covariance(geometry, block_covariance, endpoint, alpha):
+    return geometry.covariance_from_correlation(endpoint.mixture(alpha), block_covariance)
+
+
+def _fit_block_covariance(residuals, shrinkage):
+    """Analytic block marginal, matching ``fit_block_model`` without its unused train NLL."""
+    residuals = np.asarray(residuals, dtype=float)
+    block = residuals.T @ residuals / len(residuals)
+    block = (1.0 - shrinkage) * block + shrinkage * np.diag(np.diag(block))
+    eigenvalues = np.linalg.eigvalsh(block)
+    scale = max(float(np.max(np.abs(eigenvalues))), np.finfo(float).tiny)
+    loading = max(1e-8 * scale - float(eigenvalues[0]), 0.0)
+    return block + loading * np.eye(residuals.shape[1])
+
+
+def _fit_partition(geometry, partition_name, conditional_residual, shrinkage):
+    fit, evaluate = geometry.partition_map[partition_name]
+    regional = geometry._krr[partition_name].fit_predict(conditional_residual[fit])
+    block = _fit_block_covariance(regional.loo_residuals, shrinkage)
+    centered = conditional_residual[evaluate] - regional.prediction
+    return fit, evaluate, regional, block, centered
+
+
+def _inner_selection(geometry, scenario, conditional_residual, shrinkage):
+    records = []
+    regional_records = []
+    for fold in range(3):
+        partition_name = f"inner_{fold}"
+        fit, evaluate, regional, block, centered = _fit_partition(
+            geometry, partition_name, conditional_residual, shrinkage
+        )
+        scorer = NLLScorer(centered, block)
+        block_nll = scorer.block_nll
+        records.append({
+            "fold": fold,
+            "alpha": 0.0,
+            "semantic_multiplier": 1.0,
+            "graph_multiplier": 1.0,
+            "beta": 1.0,
+            "nll_per_scalar": float(block_nll),
+        })
+        regional_records.append({
+            "fold": fold,
+            "fit_items": len(fit),
+            "held_items": len(evaluate),
+            "kernel_name": regional.kernel_name,
+            "ridge": regional.ridge,
+            "loo_mse": regional.loo_mse,
+        })
+        for semantic_multiplier in MULTIPLIERS:
+            for graph_multiplier in MULTIPLIERS:
+                for beta in BETAS:
+                    endpoint = geometry.candidate_endpoint(
+                        scenario,
+                        partition_name,
+                        semantic_multiplier,
+                        graph_multiplier,
+                        beta,
+                    )
+                    path_scores = scorer.score_path(endpoint)
+                    for alpha in ALPHAS[1:]:
+                        records.append({
+                            "fold": fold,
+                            "alpha": float(alpha),
+                            "semantic_multiplier": float(semantic_multiplier),
+                            "graph_multiplier": float(graph_multiplier),
+                            "beta": float(beta),
+                            "nll_per_scalar": path_scores[alpha],
+                        })
+    selected, summaries = select_nested_candidate(records)
+    return selected, summaries, regional_records
+
+
+def _posterior_mse(geometry, innovation, state, evaluate, regional_prediction, covariance):
+    centered_innovation = innovation[evaluate] - regional_prediction
+    design, prior_precision = geometry.posterior_system(len(evaluate))
+    residual = centered_innovation.reshape(-1)
+    weighted = np.linalg.solve(covariance, np.column_stack((design, residual)))
+    system = prior_precision + design.T @ weighted[:, :-1]
+    rhs = design.T @ weighted[:, -1]
+    posterior_mean = np.linalg.solve(system, rhs).reshape(len(evaluate), STATE_DIMENSION)
+    return float(np.mean((posterior_mean - state[evaluate]) ** 2))
+
+
+def run_replicate(geometry, scenario, replicate, seed, shrinkage):
+    conditional_residual, innovation, state = geometry.draw(scenario, seed + replicate)
+    selection, candidate_summaries, inner_regional = _inner_selection(
+        geometry, scenario, conditional_residual, shrinkage
+    )
+    _, evaluate, regional, block, centered = _fit_partition(
+        geometry, "outer", conditional_residual, shrinkage
+    )
+    dimension = CHANNELS * len(evaluate)
+    block_covariance = np.kron(np.eye(len(evaluate)), block)
+    scorer = NLLScorer(centered, block)
+    block_nll = scorer.block_nll
+    selected_endpoint = geometry.candidate_endpoint(
+        scenario,
+        "outer",
+        selection["semantic_multiplier"],
+        selection["graph_multiplier"],
+        selection["beta"],
+    )
+    selected_covariance = _candidate_covariance(
+        geometry, block, selected_endpoint, selection["alpha"]
+    )
+    selected_scores = scorer.score_path(selected_endpoint)
+    selected_nll = (
+        block_nll if selection["alpha"] == 0.0 else selected_scores[selection["alpha"]]
+    )
+
+    grid = [{
+        "alpha": 0.0,
+        "semantic_multiplier": 1.0,
+        "graph_multiplier": 1.0,
+        "beta": 1.0,
+        "nll_per_scalar": float(block_nll),
+    }]
+    for semantic_multiplier in MULTIPLIERS:
+        for graph_multiplier in MULTIPLIERS:
+            for beta in BETAS:
+                endpoint = geometry.candidate_endpoint(
+                    scenario, "outer", semantic_multiplier, graph_multiplier, beta
+                )
+                path_scores = scorer.score_path(endpoint)
+                for alpha in ALPHAS[1:]:
+                    grid.append({
+                        "alpha": float(alpha),
+                        "semantic_multiplier": float(semantic_multiplier),
+                        "graph_multiplier": float(graph_multiplier),
+                        "beta": float(beta),
+                        "nll_per_scalar": path_scores[alpha],
+                    })
+    oracle = min(grid, key=lambda row: row["nll_per_scalar"])
+    oracle_endpoint = geometry.candidate_endpoint(
+        scenario,
+        "outer",
+        oracle["semantic_multiplier"],
+        oracle["graph_multiplier"],
+        oracle["beta"],
+    )
+    oracle_covariance = _candidate_covariance(
+        geometry, block, oracle_endpoint, oracle["alpha"]
+    )
+    true_covariance = geometry.true_covariance(scenario, evaluate)
+    true_nll = gaussian_joint_nll(centered, true_covariance).per_scalar
+    matched_covariance = geometry.covariance_from_correlation(
+        geometry.true_correlation(scenario, evaluate), block
+    )
+    matched_nll = gaussian_joint_nll(centered, matched_covariance).per_scalar
+
+    posterior_mse = {
+        "block": _posterior_mse(
+            geometry, innovation, state, evaluate, regional.prediction, block_covariance
+        ),
+        "selected": _posterior_mse(
+            geometry, innovation, state, evaluate, regional.prediction, selected_covariance
+        ),
+        "outer_nll_oracle": _posterior_mse(
+            geometry, innovation, state, evaluate, regional.prediction, oracle_covariance
+        ),
+        "known_true_covariance": _posterior_mse(
+            geometry, innovation, state, evaluate, regional.prediction, true_covariance
+        ),
+        "matched_true_correlation_refit_marginal": _posterior_mse(
+            geometry, innovation, state, evaluate, regional.prediction, matched_covariance
+        ),
+    }
+    return {
+        "replicate": int(replicate),
+        "seed": int(seed + replicate),
+        "selection": selection,
+        "eligible_nonzero_candidates": int(sum(
+            row["alpha"] > 0.0 and row["macro_gain_vs_block"] > 0.0
+            and row["positive_folds"] >= 2
+            for row in candidate_summaries
+        )),
+        "inner_regional_means": inner_regional,
+        "outer_regional_mean": {
+            "kernel_name": regional.kernel_name,
+            "ridge": regional.ridge,
+            "loo_mse": regional.loo_mse,
+        },
+        "outer_items": int(len(evaluate)),
+        "measurement_dimension": int(dimension),
+        "residual_nll_per_scalar": {
+            "block": float(block_nll),
+            "selected": float(selected_nll),
+            "outer_grid_oracle": float(oracle["nll_per_scalar"]),
+            "known_true_covariance": float(true_nll),
+            "matched_true_correlation_refit_marginal": float(matched_nll),
+        },
+        "outer_grid_oracle": oracle,
+        "posterior_state_mse": posterior_mse,
+    }
+
+
+def aggregate_scenario(scenario, records):
+    selected_alpha = np.asarray([row["selection"]["alpha"] for row in records])
+    block_nll = np.asarray([
+        row["residual_nll_per_scalar"]["block"] for row in records
+    ])
+    selected_nll = np.asarray([
+        row["residual_nll_per_scalar"]["selected"] for row in records
+    ])
+    oracle_nll = np.asarray([
+        row["residual_nll_per_scalar"]["outer_grid_oracle"] for row in records
+    ])
+    true_nll = np.asarray([
+        row["residual_nll_per_scalar"]["known_true_covariance"] for row in records
+    ])
+    matched_nll = np.asarray([
+        row["residual_nll_per_scalar"]["matched_true_correlation_refit_marginal"]
+        for row in records
+    ])
+    block_mse = np.asarray([row["posterior_state_mse"]["block"] for row in records])
+    selected_mse = np.asarray([row["posterior_state_mse"]["selected"] for row in records])
+    oracle_mse = np.asarray([
+        row["posterior_state_mse"]["outer_nll_oracle"] for row in records
+    ])
+    true_mse = np.asarray([
+        row["posterior_state_mse"]["known_true_covariance"] for row in records
+    ])
+    matched_mse = np.asarray([
+        row["posterior_state_mse"]["matched_true_correlation_refit_marginal"]
+        for row in records
+    ])
+    selected_nll_gain = block_nll - selected_nll
+    true_nll_gain = block_nll - true_nll
+    matched_nll_gain = block_nll - matched_nll
+    selected_mse_gain = block_mse - selected_mse
+    true_mse_gain = block_mse - true_mse
+    matched_mse_gain = block_mse - matched_mse
+    block_rate = float(np.mean(selected_alpha == 0.0))
+    nonzero_rate = float(np.mean(selected_alpha > 0.0))
+    residual_recovery = _ratio(np.mean(selected_nll_gain), np.mean(true_nll_gain))
+    posterior_recovery = _ratio(np.mean(selected_mse_gain), np.mean(true_mse_gain))
+    criterion = {
+        "type": "measured_power_only",
+        "pass": None,
+        "requirements": [],
+    }
+    if scenario.name in {"block_null", "regional_mean_only", "wrong_item_geometry"}:
+        harm = float(np.mean(selected_nll - block_nll))
+        criterion = {
+            "type": "null_or_misspecified_geometry_control",
+            "requirements": [
+                "mean held harm <= 0.001 NLL/scalar",
+                "block selected in at least 80% of replicates",
+            ],
+            "mean_held_harm_nll_per_scalar": harm,
+            "block_selection_rate": block_rate,
+            "harm_requirement_pass": bool(harm <= 0.001),
+            "selection_requirement_pass": bool(block_rate >= 0.80),
+            "pass": bool(harm <= 0.001 and block_rate >= 0.80),
+        }
+    elif scenario.true_coupling >= 0.10:
+        criterion = {
+            "type": "in_family_power_control",
+            "requirements": [
+                "nonzero alpha selected in at least 80% of replicates",
+                "recover at least 50% of known-true-covariance residual NLL gain",
+                "recover at least 50% of known-true-covariance posterior-risk gain",
+            ],
+            "nonzero_alpha_selection_rate": nonzero_rate,
+            "residual_nll_recovery_fraction": residual_recovery,
+            "posterior_risk_recovery_fraction": posterior_recovery,
+            "selection_requirement_pass": bool(nonzero_rate >= 0.80),
+            "residual_recovery_requirement_pass": bool(
+                residual_recovery is not None and residual_recovery >= 0.50
+            ),
+            "posterior_recovery_requirement_pass": bool(
+                posterior_recovery is not None and posterior_recovery >= 0.50
+            ),
+        }
+        criterion["pass"] = bool(
+            criterion["selection_requirement_pass"]
+            and criterion["residual_recovery_requirement_pass"]
+            and criterion["posterior_recovery_requirement_pass"]
+        )
+    return {
+        "scenario": scenario.name,
+        "replicates": len(records),
+        "true_maximum_whitened_off_block_coupling": scenario.true_coupling,
+        "candidate_endpoint_maximum_whitened_off_block_coupling": scenario.candidate_coupling,
+        "selection": {
+            "block_rate": block_rate,
+            "nonzero_alpha_rate": nonzero_rate,
+            "alpha_counts": dict(Counter(map(str, selected_alpha.tolist()))),
+            "semantic_multiplier_counts": dict(Counter(
+                str(row["selection"]["semantic_multiplier"]) for row in records
+            )),
+            "graph_multiplier_counts": dict(Counter(
+                str(row["selection"]["graph_multiplier"]) for row in records
+            )),
+            "beta_counts": dict(Counter(
+                str(row["selection"]["beta"]) for row in records
+            )),
+        },
+        "residual_nll_per_scalar": {
+            "block": _summary(block_nll),
+            "selected": _summary(selected_nll),
+            "outer_grid_oracle": _summary(oracle_nll),
+            "known_true_covariance": _summary(true_nll),
+            "matched_true_correlation_refit_marginal": _summary(matched_nll),
+            "selected_gain_vs_block": _summary(selected_nll_gain),
+            "outer_grid_oracle_gain_vs_block": _summary(block_nll - oracle_nll),
+            "known_true_covariance_gain_vs_block": _summary(true_nll_gain),
+            "matched_true_correlation_gain_vs_block": _summary(matched_nll_gain),
+            "selected_recovery_fraction_of_known_truth_mean_gain": residual_recovery,
+        },
+        "posterior_state_mse": {
+            "block": _summary(block_mse),
+            "selected": _summary(selected_mse),
+            "outer_nll_grid_oracle": _summary(oracle_mse),
+            "known_true_covariance": _summary(true_mse),
+            "matched_true_correlation_refit_marginal": _summary(matched_mse),
+            "selected_gain_vs_block": _summary(selected_mse_gain),
+            "known_true_covariance_gain_vs_block": _summary(true_mse_gain),
+            "matched_true_correlation_gain_vs_block": _summary(matched_mse_gain),
+            "selected_recovery_fraction_of_known_truth_mean_gain": posterior_recovery,
+        },
+        "preregistered_criterion": criterion,
+    }
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--replicates", type=int, default=100)
+    parser.add_argument("--items", type=int, default=96)
+    parser.add_argument("--outer-held-items", type=int, default=32)
+    parser.add_argument("--inner-held-items", type=int, default=22)
+    parser.add_argument("--seed", type=int, default=881000)
+    parser.add_argument("--shrinkage", type=float, default=0.05)
+    parser.add_argument(
+        "--scenarios", nargs="+", choices=SCENARIO_ORDER, default=list(SCENARIO_ORDER)
+    )
+    parser.add_argument("--summary-only", action="store_true")
+    parser.add_argument("--out", default="/tmp/covariance_sensitivity_synthetic.json")
+    return parser
+
+
+def _validate_args(args):
+    if args.replicates < 1:
+        raise ValueError("--replicates must be positive")
+    if not 0.0 <= args.shrinkage <= 1.0:
+        raise ValueError("--shrinkage must be in [0,1]")
+
+
+def _write_payload(path, payload):
+    path = os.path.abspath(path)
+    temporary = path + ".tmp"
+    with open(temporary, "w", encoding="utf-8") as stream:
+        json.dump(_jsonable(payload), stream, indent=2, sort_keys=True)
+        stream.write("\n")
+    os.replace(temporary, path)
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    _validate_args(args)
+    started = time.perf_counter()
+    geometry = SyntheticGeometry(
+        args.items, args.outer_held_items, args.inner_held_items
+    )
+    scenario_by_name = {scenario.name: scenario for scenario in SCENARIOS}
+    aggregates = {}
+    replicate_records = {}
+    for name in args.scenarios:
+        scenario = scenario_by_name[name]
+        scenario_index = SCENARIO_ORDER.index(name)
+        records = [
+            run_replicate(
+                geometry,
+                scenario,
+                replicate,
+                args.seed + 100000 * scenario_index,
+                args.shrinkage,
+            )
+            for replicate in range(args.replicates)
+        ]
+        aggregates[name] = aggregate_scenario(scenario, records)
+        if not args.summary_only:
+            replicate_records[name] = records
+    required = [
+        aggregates[name]["preregistered_criterion"]["pass"]
+        for name in args.scenarios
+        if aggregates[name]["preregistered_criterion"]["pass"] is not None
+    ]
+    invalidated_gate_evaluable = set(args.scenarios) == set(SCENARIO_ORDER)
+    invalidated_gate_pass = bool(
+        invalidated_gate_evaluable and required and all(required)
+    )
+    payload = {
+        "status": (
+            "INVALIDATED/AMENDED v1 diagnostic; corrected derangement no longer reproduces the original "
+            "weak wrong-geometry run; do not interpret known-truth recovery fractions"
+        ),
+        "blocking_erratum": (
+            "after fitted/outcome-selected KRR, centered residual is e_H-W e_T and does not have R_HH; "
+            "use corrected v2 oracle-mean/known-B mechanism for recovery"
+        ),
+        "protocol": (
+            "100-replicate default synthetic selector controls with known PSD covariance endpoints; "
+            "regional mean and block marginal refit per partition; no LMC optimization"
+        ),
+        "configuration": {
+            "replicates": args.replicates,
+            "seed": args.seed,
+            "requested_scenarios": list(args.scenarios),
+            "items": args.items,
+            "outer_train_items": len(geometry.outer_train),
+            "outer_held_items": len(geometry.outer_held),
+            "inner_fit_items": len(geometry.inner_partitions[0][0]),
+            "inner_held_items": len(geometry.inner_partitions[0][1]),
+            "channels": CHANNELS,
+            "state_dimension": STATE_DIMENSION,
+            "alphas": list(ALPHAS),
+            "length_multipliers": list(MULTIPLIERS),
+            "channel_shrinkage_betas": list(BETAS),
+            "regional_mean_ridges": list(RIDGES),
+            "block_covariance_shrinkage": args.shrinkage,
+            "semantic_base_length": geometry.semantic_length,
+            "graph_base_length": geometry.graph_length,
+            "wrong_geometry": {
+                "construction": (
+                    "fixed derangement congruence P K_canonical P.T; first cyclic shift of seed "
+                    "permutation having no fixed points"
+                ),
+                "permutation_seed": 33517,
+                "spectrum_and_off_diagonal_energy_preserved": True,
+            },
+            "outcome_blind_cache": (
+                "fixed partitions, KRR linear systems, kernels, and correlation eigensystems only"
+            ),
+        },
+        "scenario_aggregates": aggregates,
+        "invalidated_original_criteria_gate_evaluable": invalidated_gate_evaluable,
+        "invalidated_original_criteria_all_pass": invalidated_gate_pass,
+        "replicate_records": None if args.summary_only else replicate_records,
+        "wall_seconds": time.perf_counter() - started,
+    }
+    _write_payload(args.out, payload)
+    print(json.dumps({
+        "status": payload["status"],
+        "blocking_erratum": payload["blocking_erratum"],
+        "output": os.path.abspath(args.out),
+        "scenario_aggregates": aggregates,
+        "invalidated_original_criteria_gate_evaluable": invalidated_gate_evaluable,
+        "invalidated_original_criteria_all_pass": invalidated_gate_pass,
+        "wall_seconds": payload["wall_seconds"],
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/run_covariance_sensitivity_synthetic_v2.py
+++ b/prototypes/mu_cosine/run_covariance_sensitivity_synthetic_v2.py
@@ -831,12 +831,17 @@ def _validate_args(args):
         raise ValueError("--shrinkage must be in [0,1]")
 
 
-def _write_payload(path, payload):
+def _write_scientific_payload(path, payload):
+    """Write only deterministic scientific results, never runtime metadata."""
+    if "wall_seconds" in payload:
+        raise ValueError("wall_seconds belongs in stdout, not the reproducible artifact")
+    serialized = json.dumps(
+        _jsonable(payload), indent=2, sort_keys=True, allow_nan=False
+    ) + "\n"
     path = os.path.abspath(path)
     temporary = path + ".tmp"
-    with open(temporary, "w", encoding="utf-8") as stream:
-        json.dump(_jsonable(payload), stream, indent=2, sort_keys=True)
-        stream.write("\n")
+    with open(temporary, "w", encoding="utf-8", newline="\n") as stream:
+        stream.write(serialized)
     os.replace(temporary, path)
 
 
@@ -1016,16 +1021,16 @@ def main():
             "end_to_end_krr": end_records,
             "oracle_mean_known_B_mechanism": mechanism_records,
         },
-        "wall_seconds": time.perf_counter() - started,
     }
-    _write_payload(args.out, payload)
+    wall_seconds = time.perf_counter() - started
+    _write_scientific_payload(args.out, payload)
     print(json.dumps({
         "output": os.path.abspath(args.out),
         "null_calibrations": null_report,
         "v1_failure_attribution_audit": audit,
         "end_to_end_krr": payload["end_to_end_krr"],
         "oracle_mean_known_B_mechanism": payload["oracle_mean_known_B_mechanism"],
-        "wall_seconds": payload["wall_seconds"],
+        "wall_seconds": wall_seconds,
     }, indent=2, sort_keys=True))
 
 

--- a/prototypes/mu_cosine/run_covariance_sensitivity_synthetic_v2.py
+++ b/prototypes/mu_cosine/run_covariance_sensitivity_synthetic_v2.py
@@ -1,0 +1,1033 @@
+#!/usr/bin/env python3
+"""Versioned v2 family-wise calibration for the synthetic covariance selector.
+
+This executable preserves the invalidated v1 output record, not an exact v1 runner: the shared synthetic
+runner was later amended to use the corrected deranged wrong geometry.  V2 compares a conditional fixed-path
+null against a full block-null procedure that reruns regional KRR and block fitting, audits mean/search
+multiplicity, and evaluates two exploratory capacities: v2A's complete grid and v2B's canonical-geometry
+alpha grid.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+import os
+import time
+
+import numpy as np
+
+from covariance_sensitivity import (
+    finite_null_maximum_threshold,
+    maximum_eligible_macro_gain,
+    select_nested_candidate,
+    select_nested_candidate_null_calibrated,
+)
+from run_covariance_sensitivity_synthetic import (
+    ALPHAS,
+    BETAS,
+    CHANNELS,
+    MULTIPLIERS,
+    NLLScorer,
+    RIDGES,
+    SCENARIOS,
+    SCENARIO_ORDER,
+    SyntheticGeometry,
+    _candidate_covariance,
+    _fit_block_covariance,
+    _fit_partition,
+    _jsonable,
+    _posterior_mse,
+    _summary,
+)
+from structured_residual_covariance import gaussian_joint_nll
+
+
+SEARCH_FULL = "full_216"
+SEARCH_CANONICAL = "canonical_alpha_8"
+SEARCH_SINGLE = "canonical_alpha1_single"
+SEARCHES = (SEARCH_FULL, SEARCH_CANONICAL, SEARCH_SINGLE)
+SELECTOR_V2A = "v2A_full_grid_familywise"
+SELECTOR_V2B = "v2B_canonical_alpha_familywise"
+SELECTOR_SEARCH = {
+    SELECTOR_V2A: SEARCH_FULL,
+    SELECTOR_V2B: SEARCH_CANONICAL,
+}
+
+
+def _block_scenario():
+    return next(value for value in SCENARIOS if value.name == "block_null")
+
+
+def _fixed_path_scorers(geometry, standardized_field):
+    scorers = []
+    for fold in range(3):
+        partition_name = f"inner_{fold}"
+        _, held = geometry.partition_map[partition_name]
+        scorers.append((
+            fold,
+            partition_name,
+            NLLScorer(standardized_field[held], np.eye(CHANNELS)),
+            {
+                "fold": fold,
+                "mean_mode": "fixed_identity_held",
+                "fit_items": None,
+                "held_items": len(held),
+            },
+        ))
+    return scorers
+
+
+def _intercept_fit(field, fit, held):
+    train = field[fit]
+    intercept = np.mean(train, axis=0)
+    # Exact residual from predicting each train row with the mean of the other rows.
+    loo_residuals = len(train) / (len(train) - 1.0) * (train - intercept)
+    prediction = np.repeat(intercept[None, :], len(held), axis=0)
+    return loo_residuals, field[held] - prediction, {
+        "kernel_name": "intercept_only",
+        "ridge": None,
+        "loo_mse": float(np.mean(loo_residuals * loo_residuals)),
+    }
+
+
+def _procedure_scorers(geometry, field, shrinkage, mean_mode):
+    scorers = []
+    for fold in range(3):
+        partition_name = f"inner_{fold}"
+        fit, held = geometry.partition_map[partition_name]
+        if mean_mode == "regional_krr":
+            _, _, regional, block, centered = _fit_partition(
+                geometry, partition_name, field, shrinkage
+            )
+            mean_record = {
+                "kernel_name": regional.kernel_name,
+                "ridge": regional.ridge,
+                "loo_mse": regional.loo_mse,
+            }
+        elif mean_mode == "intercept_only":
+            loo, centered, mean_record = _intercept_fit(field, fit, held)
+            block = _fit_block_covariance(loo, shrinkage)
+        elif mean_mode == "oracle_zero":
+            block = _fit_block_covariance(field[fit], shrinkage)
+            centered = field[held]
+            mean_record = {
+                "kernel_name": "oracle_zero",
+                "ridge": None,
+                "loo_mse": float(np.mean(field[fit] * field[fit])),
+            }
+        else:
+            raise ValueError(f"unknown mean mode: {mean_mode}")
+        scorers.append((
+            fold,
+            partition_name,
+            NLLScorer(centered, block),
+            {
+                "fold": fold,
+                "mean_mode": mean_mode,
+                "fit_items": len(fit),
+                "held_items": len(held),
+                **mean_record,
+            },
+        ))
+    return scorers
+
+
+def _full_records(geometry, scenario, scorers):
+    records = []
+    for fold, partition_name, scorer, _ in scorers:
+        records.append({
+            "fold": fold,
+            "alpha": 0.0,
+            "semantic_multiplier": 1.0,
+            "graph_multiplier": 1.0,
+            "beta": 1.0,
+            "nll_per_scalar": float(scorer.block_nll),
+        })
+        for semantic_multiplier in MULTIPLIERS:
+            for graph_multiplier in MULTIPLIERS:
+                for beta in BETAS:
+                    endpoint = geometry.candidate_endpoint(
+                        scenario,
+                        partition_name,
+                        semantic_multiplier,
+                        graph_multiplier,
+                        beta,
+                    )
+                    path_scores = scorer.score_path(endpoint)
+                    for alpha in ALPHAS[1:]:
+                        records.append({
+                            "fold": fold,
+                            "alpha": float(alpha),
+                            "semantic_multiplier": float(semantic_multiplier),
+                            "graph_multiplier": float(graph_multiplier),
+                            "beta": float(beta),
+                            "nll_per_scalar": path_scores[alpha],
+                        })
+    return records
+
+
+def _filter_search(records, search):
+    if search == SEARCH_FULL:
+        return records
+    output = []
+    for row in records:
+        if row["alpha"] == 0.0:
+            output.append(row)
+            continue
+        canonical = (
+            row["semantic_multiplier"] == 1.0
+            and row["graph_multiplier"] == 1.0
+            and row["beta"] == 0.0
+        )
+        if canonical and (search == SEARCH_CANONICAL or row["alpha"] == 1.0):
+            output.append(row)
+    if search not in {SEARCH_CANONICAL, SEARCH_SINGLE}:
+        raise ValueError(f"unknown search: {search}")
+    return output
+
+
+def _v1_statistics(records):
+    selected, summaries = select_nested_candidate(records)
+    maximum = maximum_eligible_macro_gain(summaries)
+    return selected, summaries, maximum
+
+
+def _threshold_ratio(numerator, denominator):
+    """Return a finite diagnostic ratio, or ``None`` for a zero baseline.
+
+    A very small smoke calibration can legitimately produce an all-zero
+    fixed-path null maximum.  The full/fixed threshold ratio is undefined in
+    that case; it should not abort the run or be emitted as non-standard JSON
+    infinity.
+    """
+    numerator = float(numerator)
+    denominator = float(denominator)
+    if not np.isfinite(numerator) or not np.isfinite(denominator):
+        raise ValueError("null thresholds must be finite")
+    if numerator < 0.0 or denominator < 0.0:
+        raise ValueError("null thresholds must be nonnegative")
+    return None if denominator == 0.0 else numerator / denominator
+
+
+def calibrate_nulls(geometry, *, draws, seed, shrinkage):
+    """Paired conditional and full-procedure null maxima on shared global fields."""
+    scenario = _block_scenario()
+    maximum = {
+        "fixed_path_shared_z": {search: [] for search in SEARCHES},
+        "full_procedure_krr": {search: [] for search in SEARCHES},
+    }
+    selected_nonzero = {
+        null: {search: 0 for search in SEARCHES} for null in maximum
+    }
+    block_factor = np.linalg.cholesky(geometry.block_covariance)
+    for draw in range(draws):
+        z = np.random.default_rng(seed + draw).standard_normal(
+            (geometry.item_count, CHANNELS)
+        )
+        scorer_sets = {
+            "fixed_path_shared_z": _fixed_path_scorers(geometry, z),
+            "full_procedure_krr": _procedure_scorers(
+                geometry, z @ block_factor.T, shrinkage, "regional_krr"
+            ),
+        }
+        for null_name, scorers in scorer_sets.items():
+            full = _full_records(geometry, scenario, scorers)
+            for search in SEARCHES:
+                selected, _, value = _v1_statistics(_filter_search(full, search))
+                maximum[null_name][search].append(value)
+                selected_nonzero[null_name][search] += int(selected["alpha"] > 0.0)
+    arrays = {
+        null: {search: np.asarray(values, dtype=float) for search, values in by_search.items()}
+        for null, by_search in maximum.items()
+    }
+    report = {}
+    for null_name, by_search in arrays.items():
+        report[null_name] = {}
+        for search, values in by_search.items():
+            threshold, rank = finite_null_maximum_threshold(values)
+            report[null_name][search] = {
+                "draws": draws,
+                "seed_start": seed,
+                "v1_nonzero_selection_rate": selected_nonzero[null_name][search] / draws,
+                "maximum_eligible_macro_gain": _summary(values),
+                "upper_95_order_statistic_threshold": threshold,
+                "order_statistic_rank_one_based": rank,
+            }
+    report["full_vs_fixed_threshold_ratio"] = {
+        search: _threshold_ratio(
+            report["full_procedure_krr"][search]["upper_95_order_statistic_threshold"],
+            report["fixed_path_shared_z"][search]["upper_95_order_statistic_threshold"],
+        )
+        for search in SEARCHES
+    }
+    return arrays, report
+
+
+def attribution_audit(geometry, *, draws, seed, shrinkage):
+    """Cross mean capacity with search size using common block-null fields."""
+    scenario = _block_scenario()
+    modes = ("regional_krr", "intercept_only", "oracle_zero")
+    maxima = {mode: {search: [] for search in SEARCHES} for mode in modes}
+    nonzero = {mode: {search: 0 for search in SEARCHES} for mode in modes}
+    block_factor = np.linalg.cholesky(geometry.block_covariance)
+    for draw in range(draws):
+        z = np.random.default_rng(seed + draw).standard_normal(
+            (geometry.item_count, CHANNELS)
+        )
+        field = z @ block_factor.T
+        for mode in modes:
+            full = _full_records(
+                geometry,
+                scenario,
+                _procedure_scorers(geometry, field, shrinkage, mode),
+            )
+            for search in SEARCHES:
+                selected, _, value = _v1_statistics(_filter_search(full, search))
+                maxima[mode][search].append(value)
+                nonzero[mode][search] += int(selected["alpha"] > 0.0)
+    report = {}
+    for mode in modes:
+        report[mode] = {}
+        for search in SEARCHES:
+            values = np.asarray(maxima[mode][search], dtype=float)
+            report[mode][search] = {
+                "draws": draws,
+                "seed_start": seed,
+                "v1_nonzero_selection_rate": nonzero[mode][search] / draws,
+                "maximum_eligible_macro_gain": _summary(values),
+            }
+    report["contrasts"] = {
+        "full_grid_krr_minus_oracle_zero_nonzero_rate": (
+            report["regional_krr"][SEARCH_FULL]["v1_nonzero_selection_rate"]
+            - report["oracle_zero"][SEARCH_FULL]["v1_nonzero_selection_rate"]
+        ),
+        "krr_full_grid_minus_canonical_grid_nonzero_rate": (
+            report["regional_krr"][SEARCH_FULL]["v1_nonzero_selection_rate"]
+            - report["regional_krr"][SEARCH_CANONICAL]["v1_nonzero_selection_rate"]
+        ),
+        "krr_canonical_grid_minus_single_nonzero_rate": (
+            report["regional_krr"][SEARCH_CANONICAL]["v1_nonzero_selection_rate"]
+            - report["regional_krr"][SEARCH_SINGLE]["v1_nonzero_selection_rate"]
+        ),
+    }
+    return report
+
+
+def _outer_common(geometry, scenario, conditional_residual, innovation, state, shrinkage):
+    _, evaluate, regional, block, centered = _fit_partition(
+        geometry, "outer", conditional_residual, shrinkage
+    )
+    scorer = NLLScorer(centered, block)
+    block_covariance = np.kron(np.eye(len(evaluate)), block)
+    grid = [{
+        "alpha": 0.0,
+        "semantic_multiplier": 1.0,
+        "graph_multiplier": 1.0,
+        "beta": 1.0,
+        "nll_per_scalar": float(scorer.block_nll),
+    }]
+    for semantic_multiplier in MULTIPLIERS:
+        for graph_multiplier in MULTIPLIERS:
+            for beta in BETAS:
+                endpoint = geometry.candidate_endpoint(
+                    scenario, "outer", semantic_multiplier, graph_multiplier, beta
+                )
+                path_scores = scorer.score_path(endpoint)
+                for alpha in ALPHAS[1:]:
+                    grid.append({
+                        "alpha": float(alpha),
+                        "semantic_multiplier": float(semantic_multiplier),
+                        "graph_multiplier": float(graph_multiplier),
+                        "beta": float(beta),
+                        "nll_per_scalar": path_scores[alpha],
+                    })
+    oracle = min(grid, key=lambda row: row["nll_per_scalar"])
+    oracle_endpoint = geometry.candidate_endpoint(
+        scenario,
+        "outer",
+        oracle["semantic_multiplier"],
+        oracle["graph_multiplier"],
+        oracle["beta"],
+    )
+    oracle_covariance = _candidate_covariance(
+        geometry, block, oracle_endpoint, oracle["alpha"]
+    )
+    common_posterior = {
+        "block": _posterior_mse(
+            geometry, innovation, state, evaluate, regional.prediction, block_covariance
+        ),
+        "outer_nll_oracle": _posterior_mse(
+            geometry, innovation, state, evaluate, regional.prediction, oracle_covariance
+        ),
+    }
+    return {
+        "evaluate": evaluate,
+        "regional": regional,
+        "block": block,
+        "centered": centered,
+        "scorer": scorer,
+        "block_covariance": block_covariance,
+        "block_nll": scorer.block_nll,
+        "oracle": oracle,
+        "common_posterior": common_posterior,
+    }
+
+
+def run_replicate_pair(
+    geometry,
+    scenario,
+    replicate,
+    seed,
+    shrinkage,
+    full_procedure_null_maxima,
+):
+    conditional_residual, innovation, state = geometry.draw(scenario, seed + replicate)
+    inner_scorers = _procedure_scorers(
+        geometry, conditional_residual, shrinkage, "regional_krr"
+    )
+    full_records = _full_records(geometry, scenario, inner_scorers)
+    selections = {}
+    summaries = {}
+    calibrations = {}
+    for selector, search in SELECTOR_SEARCH.items():
+        records = _filter_search(full_records, search)
+        selections[selector], summaries[selector], calibrations[selector] = (
+            select_nested_candidate_null_calibrated(
+                records, full_procedure_null_maxima[search]
+            )
+        )
+        selections[selector]["selector_capacity"] = selector
+        calibrations[selector]["null_type"] = "full_procedure_krr"
+        calibrations[selector]["candidate_search"] = search
+    outer = _outer_common(
+        geometry, scenario, conditional_residual, innovation, state, shrinkage
+    )
+    records_by_selector = {}
+    for selector, selection in selections.items():
+        endpoint = geometry.candidate_endpoint(
+            scenario,
+            "outer",
+            selection["semantic_multiplier"],
+            selection["graph_multiplier"],
+            selection["beta"],
+        )
+        covariance = _candidate_covariance(
+            geometry, outer["block"], endpoint, selection["alpha"]
+        )
+        selected_nll = (
+            outer["block_nll"]
+            if selection["alpha"] == 0.0
+            else outer["scorer"].score_path(endpoint)[selection["alpha"]]
+        )
+        posterior = dict(outer["common_posterior"])
+        posterior["selected"] = _posterior_mse(
+            geometry,
+            innovation,
+            state,
+            outer["evaluate"],
+            outer["regional"].prediction,
+            covariance,
+        )
+        records_by_selector[selector] = {
+            "replicate": int(replicate),
+            "seed": int(seed + replicate),
+            "selection": selection,
+            "selection_calibration": calibrations[selector],
+            "eligible_nonzero_candidates": int(sum(
+                row["alpha"] > 0.0
+                and row["macro_gain_vs_block"] > 0.0
+                and row["positive_folds"] >= 2
+                for row in summaries[selector]
+            )),
+            "inner_regional_means": [row[3] for row in inner_scorers],
+            "outer_regional_mean": {
+                "kernel_name": outer["regional"].kernel_name,
+                "ridge": outer["regional"].ridge,
+                "loo_mse": outer["regional"].loo_mse,
+            },
+            "outer_items": int(len(outer["evaluate"])),
+            "measurement_dimension": int(CHANNELS * len(outer["evaluate"])),
+            "residual_nll_per_scalar": {
+                "block": float(outer["block_nll"]),
+                "selected": float(selected_nll),
+                "outer_grid_oracle": float(outer["oracle"]["nll_per_scalar"]),
+            },
+            "outer_grid_oracle": {
+                **outer["oracle"],
+                "scope": "full length/channel/alpha sensitivity grid; never deploys v2B",
+            },
+            "posterior_state_mse": posterior,
+            "truth_scope": (
+                "end-to-end fitted KRR: no known-truth recovery denominator; centered residual is "
+                "e_H-W e_T and W is outcome-selected"
+            ),
+        }
+    return records_by_selector
+
+
+def _mean_gain_ratio(numerator, denominator):
+    denominator = float(np.mean(denominator))
+    return None if denominator <= 0.0 else float(np.mean(numerator)) / denominator
+
+
+def aggregate_end_to_end(scenario, records):
+    """Valid fitted-KRR comparisons; deliberately contains no pre-KRR truth denominator."""
+    alphas = np.asarray([row["selection"]["alpha"] for row in records])
+    block_nll = np.asarray([row["residual_nll_per_scalar"]["block"] for row in records])
+    selected_nll = np.asarray([
+        row["residual_nll_per_scalar"]["selected"] for row in records
+    ])
+    oracle_nll = np.asarray([
+        row["residual_nll_per_scalar"]["outer_grid_oracle"] for row in records
+    ])
+    block_mse = np.asarray([row["posterior_state_mse"]["block"] for row in records])
+    selected_mse = np.asarray([
+        row["posterior_state_mse"]["selected"] for row in records
+    ])
+    oracle_mse = np.asarray([
+        row["posterior_state_mse"]["outer_nll_oracle"] for row in records
+    ])
+    block_rate = float(np.mean(alphas == 0.0))
+    gain = block_nll - selected_nll
+    criterion = {
+        "type": "end_to_end_power_descriptive",
+        "pass": None,
+        "reason": (
+            "known-covariance recovery is evaluated only in the oracle-mean/known-B mechanism track"
+        ),
+    }
+    if scenario.name == "wrong_item_geometry":
+        criterion = {
+            "type": "common_mode_contaminated_wrong_geometry_diagnostic",
+            "pass": None,
+            "reason": (
+                "permutation preserves the dense positive RBF common mode, so this is not an orthogonal "
+                "block-selection negative control"
+            ),
+        }
+    elif scenario.name in {"block_null", "regional_mean_only"}:
+        harm = float(np.mean(selected_nll - block_nll))
+        criterion = {
+            "type": "end_to_end_null_or_misspecified_geometry_control",
+            "requirements": [
+                "mean held harm <= 0.001 NLL/scalar",
+                "block selected in at least 80% of replicates",
+            ],
+            "mean_held_harm_nll_per_scalar": harm,
+            "block_selection_rate": block_rate,
+            "harm_requirement_pass": bool(harm <= 0.001),
+            "selection_requirement_pass": bool(block_rate >= 0.80),
+            "pass": bool(harm <= 0.001 and block_rate >= 0.80),
+        }
+    return {
+        "scenario": scenario.name,
+        "replicates": len(records),
+        "selection": {
+            "block_rate": block_rate,
+            "nonzero_alpha_rate": float(np.mean(alphas > 0.0)),
+            "alpha_counts": dict(Counter(map(str, alphas.tolist()))),
+        },
+        "residual_nll_per_scalar": {
+            "block": _summary(block_nll),
+            "selected": _summary(selected_nll),
+            "outer_grid_oracle": _summary(oracle_nll),
+            "selected_gain_vs_block": _summary(gain),
+            "outer_grid_oracle_gain_vs_block": _summary(block_nll - oracle_nll),
+        },
+        "posterior_state_mse": {
+            "block": _summary(block_mse),
+            "selected": _summary(selected_mse),
+            "outer_nll_grid_oracle": _summary(oracle_mse),
+            "selected_gain_vs_block": _summary(block_mse - selected_mse),
+        },
+        "preregistered_criterion": criterion,
+        "truth_scope": records[0]["truth_scope"],
+    }
+
+
+def _known_block_scorers(geometry, field):
+    scorers = []
+    for fold in range(3):
+        partition_name = f"inner_{fold}"
+        _, held = geometry.partition_map[partition_name]
+        scorers.append((
+            fold,
+            partition_name,
+            NLLScorer(field[held], geometry.block_covariance),
+            {
+                "fold": fold,
+                "mean_mode": "oracle_zero",
+                "block_mode": "known_true_B",
+                "fit_items": None,
+                "held_items": len(held),
+            },
+        ))
+    return scorers
+
+
+def run_mechanism_replicate_pair(
+    geometry,
+    scenario,
+    replicate,
+    seed,
+    fixed_path_null_maxima,
+):
+    """Oracle-zero-mean, known-B power mechanism where R_HH is the scored truth."""
+    field, innovation, state = geometry.draw(scenario, seed + replicate)
+    if scenario.regional_mean:
+        raise ValueError("regional-mean-only is not an oracle-zero-mean mechanism scenario")
+    inner = _known_block_scorers(geometry, field)
+    full_records = _full_records(geometry, scenario, inner)
+    selections, summaries, calibrations = {}, {}, {}
+    for selector, search in SELECTOR_SEARCH.items():
+        selections[selector], summaries[selector], calibrations[selector] = (
+            select_nested_candidate_null_calibrated(
+                _filter_search(full_records, search), fixed_path_null_maxima[search]
+            )
+        )
+        selections[selector]["selector_capacity"] = selector
+        calibrations[selector]["null_type"] = "fixed_path_shared_z_known_B"
+        calibrations[selector]["candidate_search"] = search
+
+    evaluate = geometry.outer_held
+    held = field[evaluate]
+    scorer = NLLScorer(held, geometry.block_covariance)
+    block_covariance = np.kron(np.eye(len(evaluate)), geometry.block_covariance)
+    grid = [{
+        "alpha": 0.0,
+        "semantic_multiplier": 1.0,
+        "graph_multiplier": 1.0,
+        "beta": 1.0,
+        "nll_per_scalar": float(scorer.block_nll),
+    }]
+    for semantic_multiplier in MULTIPLIERS:
+        for graph_multiplier in MULTIPLIERS:
+            for beta in BETAS:
+                endpoint = geometry.candidate_endpoint(
+                    scenario, "outer", semantic_multiplier, graph_multiplier, beta
+                )
+                scores = scorer.score_path(endpoint)
+                for alpha in ALPHAS[1:]:
+                    grid.append({
+                        "alpha": float(alpha),
+                        "semantic_multiplier": float(semantic_multiplier),
+                        "graph_multiplier": float(graph_multiplier),
+                        "beta": float(beta),
+                        "nll_per_scalar": scores[alpha],
+                    })
+    oracle = min(grid, key=lambda row: row["nll_per_scalar"])
+    oracle_endpoint = geometry.candidate_endpoint(
+        scenario,
+        "outer",
+        oracle["semantic_multiplier"],
+        oracle["graph_multiplier"],
+        oracle["beta"],
+    )
+    oracle_covariance = _candidate_covariance(
+        geometry, geometry.block_covariance, oracle_endpoint, oracle["alpha"]
+    )
+    true_covariance = geometry.true_covariance(scenario, evaluate)
+    true_nll = gaussian_joint_nll(held, true_covariance).per_scalar
+    zeros = np.zeros_like(held)
+    common_posterior = {
+        "block": _posterior_mse(
+            geometry, innovation, state, evaluate, zeros, block_covariance
+        ),
+        "outer_nll_oracle": _posterior_mse(
+            geometry, innovation, state, evaluate, zeros, oracle_covariance
+        ),
+        "known_true_covariance": _posterior_mse(
+            geometry, innovation, state, evaluate, zeros, true_covariance
+        ),
+    }
+    output = {}
+    for selector, selection in selections.items():
+        endpoint = geometry.candidate_endpoint(
+            scenario,
+            "outer",
+            selection["semantic_multiplier"],
+            selection["graph_multiplier"],
+            selection["beta"],
+        )
+        covariance = _candidate_covariance(
+            geometry, geometry.block_covariance, endpoint, selection["alpha"]
+        )
+        selected_nll = (
+            scorer.block_nll
+            if selection["alpha"] == 0.0
+            else scorer.score_path(endpoint)[selection["alpha"]]
+        )
+        posterior = dict(common_posterior)
+        posterior["selected"] = _posterior_mse(
+            geometry, innovation, state, evaluate, zeros, covariance
+        )
+        output[selector] = {
+            "replicate": int(replicate),
+            "seed": int(seed + replicate),
+            "selection": selection,
+            "selection_calibration": calibrations[selector],
+            "eligible_nonzero_candidates": int(sum(
+                row["alpha"] > 0.0
+                and row["macro_gain_vs_block"] > 0.0
+                and row["positive_folds"] >= 2
+                for row in summaries[selector]
+            )),
+            "residual_nll_per_scalar": {
+                "block": float(scorer.block_nll),
+                "selected": float(selected_nll),
+                "outer_grid_oracle": float(oracle["nll_per_scalar"]),
+                "known_true_covariance": float(true_nll),
+            },
+            "outer_grid_oracle": oracle,
+            "posterior_state_mse": posterior,
+            "truth_scope": "oracle zero mean and known B; R_HH is the exact scored covariance",
+        }
+    return output
+
+
+def aggregate_mechanism(scenario, records):
+    alphas = np.asarray([row["selection"]["alpha"] for row in records])
+    block_nll = np.asarray([row["residual_nll_per_scalar"]["block"] for row in records])
+    selected_nll = np.asarray([
+        row["residual_nll_per_scalar"]["selected"] for row in records
+    ])
+    oracle_nll = np.asarray([
+        row["residual_nll_per_scalar"]["outer_grid_oracle"] for row in records
+    ])
+    true_nll = np.asarray([
+        row["residual_nll_per_scalar"]["known_true_covariance"] for row in records
+    ])
+    block_mse = np.asarray([row["posterior_state_mse"]["block"] for row in records])
+    selected_mse = np.asarray([
+        row["posterior_state_mse"]["selected"] for row in records
+    ])
+    true_mse = np.asarray([
+        row["posterior_state_mse"]["known_true_covariance"] for row in records
+    ])
+    selected_nll_gain = block_nll - selected_nll
+    true_nll_gain = block_nll - true_nll
+    selected_mse_gain = block_mse - selected_mse
+    true_mse_gain = block_mse - true_mse
+    nll_recovery = _mean_gain_ratio(selected_nll_gain, true_nll_gain)
+    mse_recovery = _mean_gain_ratio(selected_mse_gain, true_mse_gain)
+    block_rate = float(np.mean(alphas == 0.0))
+    criterion = {"type": "measured_power_only", "pass": None}
+    if scenario.name == "wrong_item_geometry":
+        criterion = {
+            "type": "common_mode_contaminated_wrong_geometry_diagnostic",
+            "pass": None,
+            "reason": (
+                "P K P.T preserves the dense positive RBF common mode; candidate and truth remain "
+                "covariance-aligned despite wrong pair identities"
+            ),
+        }
+    elif scenario.name == "block_null":
+        harm = float(np.mean(selected_nll - block_nll))
+        criterion = {
+            "type": "mechanism_null_or_wrong_geometry_control",
+            "mean_held_harm_nll_per_scalar": harm,
+            "block_selection_rate": block_rate,
+            "harm_requirement_pass": bool(harm <= 0.001),
+            "selection_requirement_pass": bool(block_rate >= 0.80),
+            "pass": bool(harm <= 0.001 and block_rate >= 0.80),
+        }
+    elif scenario.true_coupling >= 0.10:
+        criterion = {
+            "type": "oracle_mean_known_B_power_control",
+            "nonzero_alpha_selection_rate": float(np.mean(alphas > 0.0)),
+            "residual_nll_recovery_fraction": nll_recovery,
+            "posterior_risk_recovery_fraction": mse_recovery,
+            "selection_requirement_pass": bool(np.mean(alphas > 0.0) >= 0.80),
+            "residual_recovery_requirement_pass": bool(
+                nll_recovery is not None and nll_recovery >= 0.50
+            ),
+            "posterior_recovery_requirement_pass": bool(
+                mse_recovery is not None and mse_recovery >= 0.50
+            ),
+        }
+        criterion["pass"] = bool(
+            criterion["selection_requirement_pass"]
+            and criterion["residual_recovery_requirement_pass"]
+            and criterion["posterior_recovery_requirement_pass"]
+        )
+    return {
+        "scenario": scenario.name,
+        "replicates": len(records),
+        "selection": {
+            "block_rate": block_rate,
+            "nonzero_alpha_rate": float(np.mean(alphas > 0.0)),
+            "alpha_counts": dict(Counter(map(str, alphas.tolist()))),
+        },
+        "residual_nll_per_scalar": {
+            "block": _summary(block_nll),
+            "selected": _summary(selected_nll),
+            "outer_grid_oracle": _summary(oracle_nll),
+            "known_true_covariance": _summary(true_nll),
+            "selected_gain_vs_block": _summary(selected_nll_gain),
+            "known_true_covariance_gain_vs_block": _summary(true_nll_gain),
+            "selected_recovery_fraction_of_known_truth_mean_gain": nll_recovery,
+        },
+        "posterior_state_mse": {
+            "block": _summary(block_mse),
+            "selected": _summary(selected_mse),
+            "known_true_covariance": _summary(true_mse),
+            "selected_gain_vs_block": _summary(selected_mse_gain),
+            "known_true_covariance_gain_vs_block": _summary(true_mse_gain),
+            "selected_recovery_fraction_of_known_truth_mean_gain": mse_recovery,
+        },
+        "preregistered_criterion": criterion,
+        "truth_scope": records[0]["truth_scope"],
+    }
+
+
+def _calibration_rejection_summary(records):
+    observed = np.asarray([
+        row["selection_calibration"]["observed_maximum_eligible_macro_gain"]
+        for row in records
+    ])
+    rejected = np.asarray([
+        row["selection_calibration"]["strictly_exceeds_threshold"] for row in records
+    ], dtype=bool)
+    return {
+        "familywise_rejection_rate": float(np.mean(rejected)),
+        "observed_maximum_eligible_macro_gain": _summary(observed),
+        "threshold": records[0]["selection_calibration"][
+            "familywise_macro_gain_threshold"
+        ],
+    }
+
+
+def _complete_control_gate(required_scenarios, selected_scenarios, decisions):
+    """Never let an empty or partial scenario run pass by vacuous truth."""
+    evaluable = set(required_scenarios).issubset(set(selected_scenarios))
+    return evaluable, bool(evaluable and decisions and all(decisions))
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--replicates", type=int, default=100)
+    parser.add_argument("--calibration-draws", type=int, default=2000)
+    parser.add_argument("--audit-draws", type=int, default=1000)
+    parser.add_argument("--items", type=int, default=96)
+    parser.add_argument("--outer-held-items", type=int, default=32)
+    parser.add_argument("--inner-held-items", type=int, default=22)
+    parser.add_argument("--evaluation-seed", type=int, default=881000)
+    parser.add_argument("--calibration-seed", type=int, default=991000)
+    parser.add_argument("--audit-seed", type=int, default=994000)
+    parser.add_argument("--shrinkage", type=float, default=0.05)
+    parser.add_argument(
+        "--scenarios", nargs="+", choices=SCENARIO_ORDER, default=list(SCENARIO_ORDER)
+    )
+    parser.add_argument("--summary-only", action="store_true")
+    parser.add_argument("--out", default="/tmp/covariance_sensitivity_synthetic_v2.json")
+    return parser
+
+
+def _validate_args(args):
+    if args.replicates < 1 or args.calibration_draws < 1 or args.audit_draws < 1:
+        raise ValueError("replicate, calibration, and audit counts must be positive")
+    if not 0.0 <= args.shrinkage <= 1.0:
+        raise ValueError("--shrinkage must be in [0,1]")
+
+
+def _write_payload(path, payload):
+    path = os.path.abspath(path)
+    temporary = path + ".tmp"
+    with open(temporary, "w", encoding="utf-8") as stream:
+        json.dump(_jsonable(payload), stream, indent=2, sort_keys=True)
+        stream.write("\n")
+    os.replace(temporary, path)
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    _validate_args(args)
+    started = time.perf_counter()
+    geometry = SyntheticGeometry(
+        args.items, args.outer_held_items, args.inner_held_items
+    )
+    null_arrays, null_report = calibrate_nulls(
+        geometry,
+        draws=args.calibration_draws,
+        seed=args.calibration_seed,
+        shrinkage=args.shrinkage,
+    )
+    audit = attribution_audit(
+        geometry,
+        draws=args.audit_draws,
+        seed=args.audit_seed,
+        shrinkage=args.shrinkage,
+    )
+    scenario_by_name = {scenario.name: scenario for scenario in SCENARIOS}
+    end_records = {selector: {} for selector in SELECTOR_SEARCH}
+    end_aggregates = {selector: {} for selector in SELECTOR_SEARCH}
+    mechanism_records = {selector: {} for selector in SELECTOR_SEARCH}
+    mechanism_aggregates = {selector: {} for selector in SELECTOR_SEARCH}
+    full_null = null_arrays["full_procedure_krr"]
+    fixed_null = null_arrays["fixed_path_shared_z"]
+    for name in args.scenarios:
+        scenario = scenario_by_name[name]
+        scenario_index = SCENARIO_ORDER.index(name)
+        paired = [
+            run_replicate_pair(
+                geometry,
+                scenario,
+                replicate,
+                args.evaluation_seed + 100000 * scenario_index,
+                args.shrinkage,
+                full_null,
+            )
+            for replicate in range(args.replicates)
+        ]
+        for selector in SELECTOR_SEARCH:
+            selector_records = [row[selector] for row in paired]
+            end_records[selector][name] = selector_records
+            end_aggregates[selector][name] = aggregate_end_to_end(
+                scenario, selector_records
+            )
+            end_aggregates[selector][name]["familywise_calibration"] = (
+                _calibration_rejection_summary(selector_records)
+            )
+        if not scenario.regional_mean:
+            mechanism_paired = [
+                run_mechanism_replicate_pair(
+                    geometry,
+                    scenario,
+                    replicate,
+                    args.evaluation_seed + 100000 * scenario_index,
+                    fixed_null,
+                )
+                for replicate in range(args.replicates)
+            ]
+            for selector in SELECTOR_SEARCH:
+                selector_records = [row[selector] for row in mechanism_paired]
+                mechanism_records[selector][name] = selector_records
+                mechanism_aggregates[selector][name] = aggregate_mechanism(
+                    scenario, selector_records
+                )
+                mechanism_aggregates[selector][name]["familywise_calibration"] = (
+                    _calibration_rejection_summary(selector_records)
+                )
+    end_required, mechanism_required = {}, {}
+    end_gate_scenarios = {"block_null", "regional_mean_only"}
+    mechanism_gate_scenarios = {
+        "block_null", "in_family_coupling_0.10", "in_family_coupling_0.20",
+    }
+    selected_scenarios = set(args.scenarios)
+    end_gate_evaluable = end_gate_scenarios.issubset(selected_scenarios)
+    mechanism_gate_evaluable = mechanism_gate_scenarios.issubset(selected_scenarios)
+    for selector in SELECTOR_SEARCH:
+        end_decisions = [
+            row["preregistered_criterion"]["pass"]
+            for row in end_aggregates[selector].values()
+            if row["preregistered_criterion"]["pass"] is not None
+        ]
+        mechanism_decisions = [
+            row["preregistered_criterion"]["pass"]
+            for row in mechanism_aggregates[selector].values()
+            if row["preregistered_criterion"]["pass"] is not None
+        ]
+        _, end_required[selector] = _complete_control_gate(
+            end_gate_scenarios, selected_scenarios, end_decisions
+        )
+        _, mechanism_required[selector] = _complete_control_gate(
+            mechanism_gate_scenarios, selected_scenarios, mechanism_decisions
+        )
+    payload = {
+        "protocol": (
+            "post-v1 v2 family-wise null calibration; v2A full-grid and v2B canonical-alpha; "
+            "full block-null procedure is the deployment threshold"
+        ),
+        "design_addendum": "DESIGN_covariance_sensitivity_v2_null_calibration.md",
+        "configuration": {
+            "evaluation_replicates_per_scenario": args.replicates,
+            "calibration_draws": args.calibration_draws,
+            "attribution_audit_draws": args.audit_draws,
+            "evaluation_seed": args.evaluation_seed,
+            "calibration_seed": args.calibration_seed,
+            "audit_seed": args.audit_seed,
+            "requested_scenarios": list(args.scenarios),
+            "block_covariance_shrinkage": args.shrinkage,
+            "regional_mean_ridges": list(RIDGES),
+            "semantic_base_length": geometry.semantic_length,
+            "graph_base_length": geometry.graph_length,
+            "geometry_feature_seed": 24051,
+            "outer_partition_seed": 907,
+            "inner_partition_seeds": [10000, 10001, 10002],
+            "wrong_geometry": {
+                "construction": "fixed derangement congruence P K_canonical P.T",
+                "permutation_seed": 33517,
+            },
+            "items": args.items,
+            "outer_train_items": len(geometry.outer_train),
+            "outer_held_items": len(geometry.outer_held),
+            "inner_fit_items": len(geometry.inner_partitions[0][0]),
+            "inner_held_items": len(geometry.inner_partitions[0][1]),
+            "alphas": list(ALPHAS),
+            "length_multipliers": list(MULTIPLIERS),
+            "channel_shrinkage_betas": list(BETAS),
+            "familywise_confidence": 0.95,
+        },
+        "null_calibrations": null_report,
+        "v1_failure_attribution_audit": audit,
+        "end_to_end_krr": {
+            "scope": (
+                "selection and harm only; no pre-KRR true-covariance recovery denominator"
+            ),
+            "selector_aggregates": end_aggregates,
+            "required_gate_scenarios": sorted(end_gate_scenarios),
+            "gate_evaluable_by_selector": {
+                selector: end_gate_evaluable for selector in SELECTOR_SEARCH
+            },
+            "all_applicable_controls_pass_by_selector": end_required,
+        },
+        "oracle_mean_known_B_mechanism": {
+            "scope": (
+                "oracle zero mean and known block marginal; exact R_HH recovery/power gate"
+            ),
+            "selector_aggregates": mechanism_aggregates,
+            "required_gate_scenarios": sorted(mechanism_gate_scenarios),
+            "gate_evaluable_by_selector": {
+                selector: mechanism_gate_evaluable for selector in SELECTOR_SEARCH
+            },
+            "all_applicable_controls_pass_by_selector": mechanism_required,
+        },
+        "invalidated_outputs": [
+            {
+                "path": (
+                    "/tmp/covariance_sensitivity_synthetic_v1_"
+                    "INVALID_pre_krr_denominator_and_weak_wrong_geometry.json"
+                ),
+                "reason": (
+                    "pre-KRR truth denominator plus weak narrow-RBF wrong geometry; exact old geometry "
+                    "is not reproduced by the amended shared runner"
+                ),
+            },
+            {
+                "path": (
+                    "/tmp/covariance_sensitivity_synthetic_v2_"
+                    "INVALID_pre_krr_denominator.json"
+                ),
+                "reason": "pre-KRR R_HH was not the covariance of e_H-W e_T",
+            },
+        ],
+        "replicate_records": None if args.summary_only else {
+            "end_to_end_krr": end_records,
+            "oracle_mean_known_B_mechanism": mechanism_records,
+        },
+        "wall_seconds": time.perf_counter() - started,
+    }
+    _write_payload(args.out, payload)
+    print(json.dumps({
+        "output": os.path.abspath(args.out),
+        "null_calibrations": null_report,
+        "v1_failure_attribution_audit": audit,
+        "end_to_end_krr": payload["end_to_end_krr"],
+        "oracle_mean_known_B_mechanism": payload["oracle_mean_known_B_mechanism"],
+        "wall_seconds": payload["wall_seconds"],
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/test_covariance_sensitivity.py
+++ b/prototypes/mu_cosine/test_covariance_sensitivity.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Focused mathematical regressions for covariance-sensitivity primitives."""
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from covariance_sensitivity import (
+    build_correlation_path,
+    centered_linear_kernel,
+    directional_posterior_sensitivity,
+    expected_rbf_kernel_gaussian,
+    gaussian_input_std_ratio_for_length_multiplier,
+    gaussian_kl,
+    materialize_channel_shrunk,
+    mean_marginal_symmetric_kl,
+    posterior_mean_dense,
+    select_nested_candidate,
+    shrink_channel_covariance,
+    whitened_covariance_error,
+)
+from structured_residual_covariance import gaussian_joint_nll, rbf_kernel
+
+
+def _assert_psd(matrix, tolerance=2e-12):
+    assert np.linalg.eigvalsh(matrix)[0] >= -tolerance
+
+
+def test_expected_rbf_zero_uncertainty_matches_ordinary_rbf():
+    features = np.array([
+        [-1.0, 0.2],
+        [0.1, 0.7],
+        [1.4, -0.3],
+        [2.0, 1.1],
+    ])
+    expected = rbf_kernel(features, length_scale=0.8)
+    actual = expected_rbf_kernel_gaussian(
+        features, length_scale=0.8, input_std=0.0
+    )
+    np.testing.assert_allclose(actual, expected, atol=2e-15)
+
+
+def test_common_gaussian_uncertainty_broadens_normalized_rbf_exactly():
+    features = np.array([[-1.0], [-0.2], [0.4], [1.7]])
+    length_scale, input_std = 0.7, 0.3
+    effective = np.sqrt(length_scale**2 + 2.0 * input_std**2)
+    actual = expected_rbf_kernel_gaussian(
+        features,
+        length_scale=length_scale,
+        input_std=input_std,
+        normalize=True,
+    )
+    expected = rbf_kernel(features, length_scale=effective)
+    np.testing.assert_allclose(actual, expected, atol=2e-15)
+    assert gaussian_input_std_ratio_for_length_multiplier(
+        effective / length_scale
+    ) == pytest.approx(input_std / length_scale)
+    assert gaussian_input_std_ratio_for_length_multiplier(0.9) is None
+
+
+def test_heterogeneous_uncertain_rbf_is_psd_before_and_after_normalization():
+    rng = np.random.default_rng(15)
+    features = rng.normal(size=(12, 3))
+    input_std = np.linspace(0.0, 0.8, len(features))
+    raw = expected_rbf_kernel_gaussian(
+        features,
+        length_scale=1.1,
+        input_std=input_std,
+        normalize=False,
+    )
+    normalized = expected_rbf_kernel_gaussian(
+        features,
+        length_scale=1.1,
+        input_std=input_std,
+        normalize=True,
+    )
+    _assert_psd(raw)
+    _assert_psd(normalized)
+    np.testing.assert_allclose(np.diag(normalized), 1.0, atol=0.0)
+
+
+def test_centered_linear_kernel_encodes_midpoint_sign_and_raw_amplitude():
+    mu = np.array([0.1, 0.4, 0.6, 0.9])
+    centered = mu - 0.5
+    kernel = centered_linear_kernel(mu)
+    np.testing.assert_allclose(kernel, np.outer(centered, centered), atol=0.0)
+    assert kernel[0, 1] > 0.0
+    assert kernel[0, 2] < 0.0
+    assert kernel[0, 0] > kernel[1, 1]
+    _assert_psd(kernel)
+    judge_covariance = np.array([[1.0, 0.25], [0.25, 0.7]])
+    _assert_psd(np.kron(kernel, judge_covariance))
+
+
+def test_centered_linear_cross_kernel_and_normalization_are_consistent():
+    left = np.array([[0.2, 0.9], [0.8, 0.7], [0.9, 0.2]])
+    right = np.array([[0.1, 0.4], [0.7, 0.8]])
+    expected = (left - 0.5) @ (right - 0.5).T
+    np.testing.assert_allclose(centered_linear_kernel(left, right), expected, atol=0.0)
+
+    normalized = centered_linear_kernel(left, normalize=True)
+    _assert_psd(normalized)
+    np.testing.assert_allclose(np.diag(normalized), 1.0, atol=0.0)
+    expected_normalized_cross = (
+        expected
+        / np.linalg.norm(left - 0.5, axis=1)[:, None]
+        / np.linalg.norm(right - 0.5, axis=1)[None, :]
+    )
+    np.testing.assert_allclose(
+        centered_linear_kernel(left, right, normalize=True),
+        expected_normalized_cross,
+        atol=2e-15,
+    )
+    with pytest.raises(ValueError, match="zero norm"):
+        centered_linear_kernel([0.2, 0.5, 0.8], normalize=True)
+
+
+def test_centering_by_half_does_not_change_rbf_distances():
+    mu = np.array([[0.05], [0.3], [0.8], [0.95]])
+    original = rbf_kernel(mu, length_scale=0.25)
+    centered = rbf_kernel(mu - 0.5, length_scale=0.25)
+    np.testing.assert_allclose(centered, original, atol=2e-15)
+
+
+def _structured_example():
+    features = np.array([[-0.4], [0.3], [1.2]])
+    item_kernel = rbf_kernel(features, length_scale=0.9)
+    independent = np.array([[1.1, 0.12], [0.12, 0.8]])
+    shared = np.array([[0.35, -0.04], [-0.04, 0.22]])
+    structured = np.kron(np.eye(len(features)), independent) + np.kron(
+        item_kernel, shared
+    )
+    block = np.array([[0.9, 0.18], [0.18, 0.65]])
+    return block, structured, independent + shared
+
+
+def test_correlation_path_endpoints_and_all_item_marginals_are_exact():
+    block, structured, structured_item = _structured_example()
+    path = build_correlation_path(block, structured, block_size=2)
+    expected_block = np.kron(np.eye(3), block)
+    np.testing.assert_allclose(path.covariance(0.0), expected_block, atol=2e-15)
+
+    structured_factor = np.linalg.cholesky(structured_item)
+    inverse_factor = np.linalg.solve(structured_factor, np.eye(2))
+    whitener = np.kron(np.eye(3), inverse_factor)
+    normalized = whitener @ structured @ whitener.T
+    block_factor = np.kron(np.eye(3), np.linalg.cholesky(block))
+    expected_matched = block_factor @ normalized @ block_factor.T
+    np.testing.assert_allclose(path.covariance(1.0), expected_matched, atol=3e-15)
+
+    for alpha in (0.0, 0.07, 0.5, 1.0):
+        covariance = path.covariance(alpha)
+        _assert_psd(covariance)
+        for item in range(3):
+            section = slice(2 * item, 2 * item + 2)
+            np.testing.assert_allclose(covariance[section, section], block, atol=3e-15)
+
+
+def test_correlation_path_fast_nll_matches_independent_cholesky_nll():
+    block, structured, _ = _structured_example()
+    path = build_correlation_path(block, structured, block_size=2)
+    residuals = np.array([[0.5, -0.3], [-1.2, 0.7], [0.1, 0.2]])
+    for alpha in (0.0, 0.025, 0.35, 1.0):
+        expected = gaussian_joint_nll(residuals, path.covariance(alpha)).per_scalar
+        assert path.nll_per_scalar(residuals, alpha) == pytest.approx(
+            expected, abs=2e-15
+        )
+
+
+def test_channel_covariance_shrinkage_and_materialization_preserve_psd():
+    semantic_covariance = np.array([[0.5, 0.25], [0.25, 0.3]])
+    graph_covariance = np.array([[0.2, -0.08], [-0.08, 0.15]])
+    model = SimpleNamespace(
+        independent_covariance=np.array([[0.4, 0.03], [0.03, 0.35]]),
+        semantic_covariance=semantic_covariance,
+        graph_covariance=graph_covariance,
+    )
+    semantic = rbf_kernel(np.array([[0.0], [0.8], [1.5]]), length_scale=0.7)
+    graph = rbf_kernel(np.array([[0.1], [0.4], [1.8]]), length_scale=1.0)
+    np.testing.assert_allclose(
+        shrink_channel_covariance(semantic_covariance, 0.0), semantic_covariance
+    )
+    np.testing.assert_allclose(
+        shrink_channel_covariance(semantic_covariance, 1.0),
+        np.diag(np.diag(semantic_covariance)),
+    )
+    for beta in (0.0, 0.5, 1.0):
+        _assert_psd(materialize_channel_shrunk(model, semantic, graph, beta))
+
+
+def test_analytic_posterior_covariance_sensitivity_matches_finite_difference():
+    rng = np.random.default_rng(72)
+    prior = np.array([[1.4, 0.2], [0.2, 0.9]])
+    design = np.array([[1.0, 0.2], [0.1, 1.0], [0.7, -0.4]])
+    innovation = rng.normal(size=(2, 3))
+    factor = rng.normal(size=(6, 6))
+    covariance = factor @ factor.T + 2.0 * np.eye(6)
+    raw_direction = rng.normal(size=(6, 6))
+    direction = 0.5 * (raw_direction + raw_direction.T)
+    direction /= np.linalg.norm(direction, ord=2)
+
+    analytic = directional_posterior_sensitivity(
+        prior, design, innovation, covariance, direction
+    )
+    epsilon = 2e-6
+    plus, _ = posterior_mean_dense(
+        prior, design, innovation, covariance + epsilon * direction
+    )
+    minus, _ = posterior_mean_dense(
+        prior, design, innovation, covariance - epsilon * direction
+    )
+    finite_difference = (plus - minus) / (2.0 * epsilon)
+    np.testing.assert_allclose(
+        analytic.directional_derivative,
+        finite_difference,
+        rtol=2e-8,
+        atol=2e-10,
+    )
+
+
+def _candidate_records(candidate_rows):
+    records = [
+        {
+            "fold": fold,
+            "alpha": 0.0,
+            "semantic_multiplier": 1.0,
+            "graph_multiplier": 1.0,
+            "beta": 1.0,
+            "nll_per_scalar": 1.0,
+        }
+        for fold in range(3)
+    ]
+    for alpha, beta, values in candidate_rows:
+        records.extend({
+            "fold": fold,
+            "alpha": alpha,
+            "semantic_multiplier": 1.0,
+            "graph_multiplier": 1.0,
+            "beta": beta,
+            "nll_per_scalar": nll,
+        } for fold, nll in enumerate(values))
+    return records
+
+
+def test_nested_selector_prefers_smallest_stable_alpha_within_tolerance():
+    records = _candidate_records([
+        (0.05, 1.0, [0.80, 1.10, 1.10]),  # Only one positive fold: ineligible.
+        (0.10, 0.5, [0.9000, 0.9005, 0.9010]),
+        (0.20, 0.0, [0.9000, 0.9000, 0.9000]),
+    ])
+    selected, summaries = select_nested_candidate(records, tolerance=1e-3)
+    assert selected["alpha"] == pytest.approx(0.10)
+    assert selected["positive_folds"] == 3
+    assert len(summaries) == 4
+
+
+def test_nested_selector_falls_back_to_block_without_stable_gain():
+    records = _candidate_records([
+        (0.10, 0.5, [0.80, 1.10, 1.10]),
+        (0.30, 0.0, [1.01, 1.02, 0.99]),
+    ])
+    selected, _ = select_nested_candidate(records)
+    assert selected["alpha"] == 0.0
+    assert selected["macro_gain_vs_block"] == 0.0
+
+
+def test_gaussian_kl_and_marginal_symmetric_kl_have_expected_invariants():
+    mean = np.array([0.2, -0.3])
+    covariance = np.array([[1.3, 0.2], [0.2, 0.7]])
+    assert gaussian_kl(mean, covariance, mean, covariance) == pytest.approx(
+        0.0, abs=2e-16
+    )
+    shifted = mean + np.array([0.4, -0.1])
+    other = np.array([[0.8, -0.05], [-0.05, 1.1]])
+    forward = gaussian_kl(mean, covariance, shifted, other)
+    reverse = gaussian_kl(shifted, other, mean, covariance)
+    assert forward > 0.0
+    assert reverse > 0.0
+
+    means_a = np.stack([mean, mean + 0.1])
+    means_b = np.stack([shifted, shifted - 0.1])
+    covariances_a = np.stack([covariance, 1.2 * covariance])
+    covariances_b = np.stack([other, 0.9 * other])
+    expected = np.mean([
+        0.5 * (
+            gaussian_kl(ma, Pa, mb, Pb) + gaussian_kl(mb, Pb, ma, Pa)
+        )
+        for ma, Pa, mb, Pb in zip(
+            means_a, covariances_a, means_b, covariances_b
+        )
+    ])
+    assert mean_marginal_symmetric_kl(
+        means_a, covariances_a, means_b, covariances_b
+    ) == pytest.approx(expected)
+    with pytest.raises(np.linalg.LinAlgError):
+        gaussian_kl(mean, -np.eye(2), mean, covariance)
+
+
+def test_whitened_covariance_error_uses_reference_relative_spectral_radius():
+    reference = np.diag([4.0, 1.0])
+    candidate = np.diag([6.0, 1.5])
+    assert whitened_covariance_error(reference, candidate) == pytest.approx(0.5)
+    assert whitened_covariance_error(reference, reference) == 0.0

--- a/prototypes/mu_cosine/test_run_covariance_sensitivity.py
+++ b/prototypes/mu_cosine/test_run_covariance_sensitivity.py
@@ -1,0 +1,158 @@
+import numpy as np
+import pytest
+from types import SimpleNamespace
+
+from covariance_sensitivity import CorrelationPath, build_correlation_path
+from run_covariance_sensitivity import (
+    ALPHAS,
+    PRIMARY,
+    SECONDARY,
+    _family_scale_grid,
+    _induced_node_subsample,
+    _null_maximum_gains,
+    _preflight_stability_subsamples,
+    _validate_args,
+    aggregate_results,
+)
+from structured_residual_covariance import gaussian_joint_nll
+
+
+def test_null_maximum_is_exactly_zero_for_identity_paths():
+    dimension = 12
+    identity = np.eye(dimension)
+    path = CorrelationPath(
+        np.eye(3), np.eye(3), identity, np.ones(dimension), identity, block_size=3
+    )
+    gains = _null_maximum_gains([path], draws=50, seed=7)
+    np.testing.assert_allclose(gains, 0.0, atol=2e-15)
+
+
+def test_null_maximum_is_deterministic_and_includes_block_fallback():
+    eigenvalues = np.array([0.8, 0.9, 1.1, 1.2])
+    identity = np.eye(4)
+    path = CorrelationPath(
+        np.eye(2), np.eye(2), np.diag(eigenvalues), eigenvalues, identity, block_size=2
+    )
+    first = _null_maximum_gains([path], draws=25, seed=11)
+    second = _null_maximum_gains([path], draws=25, seed=11)
+    np.testing.assert_array_equal(first, second)
+    assert np.all(first >= 0.0)
+
+
+def test_null_maximum_matches_brute_force_full_gaussian_nll():
+    block = np.array([[0.7, 0.12], [0.12, 0.4]])
+    item_kernel = np.array([[1.0, 0.35], [0.35, 1.0]])
+    structured = np.kron(item_kernel, block)
+    path = build_correlation_path(block, structured, block_size=2)
+    draws, seed = 9, 23
+    fast = _null_maximum_gains([path], draws=draws, seed=seed)
+
+    z = np.random.default_rng(seed).standard_normal((4, draws))
+    factor = np.kron(np.eye(2), np.linalg.cholesky(block))
+    residual_fields = (factor @ z).T.reshape(draws, 2, 2)
+    block_covariance = np.kron(np.eye(2), block)
+    brute = []
+    for residuals in residual_fields:
+        baseline = gaussian_joint_nll(residuals, block_covariance).per_scalar
+        gains = [0.0] + [
+            baseline - gaussian_joint_nll(residuals, path.covariance(alpha)).per_scalar
+            for alpha in ALPHAS[1:]
+        ]
+        brute.append(max(gains))
+    np.testing.assert_allclose(fast, brute, atol=2e-15, rtol=0.0)
+
+
+def test_geometry_grids_keep_secondary_family_separate():
+    assert len(_family_scale_grid(PRIMARY)) == 9
+    assert len(_family_scale_grid(SECONDARY)) == 3
+    assert {graph for _, graph in _family_scale_grid(SECONDARY)} == {1.0}
+
+
+def test_node_subsample_is_deterministic_and_induced():
+    materialized = {
+        "pairs": [("a", "b"), ("a", "c"), ("b", "c"), ("c", "d"), ("a", "d")]
+    }
+    outer_train = np.arange(5)
+    first, node_total, node_kept = _induced_node_subsample(
+        materialized, outer_train, 0.75, seed=19
+    )
+    second, _, _ = _induced_node_subsample(materialized, outer_train, 0.75, seed=19)
+    np.testing.assert_array_equal(first, second)
+    assert node_total == 4
+    assert node_kept == 3
+    retained_nodes = {node for index in first for node in materialized["pairs"][index]}
+    assert len(retained_nodes) <= node_kept
+
+
+def test_stability_preflight_rejects_too_small_induced_schedule():
+    materialized = {
+        "pairs": [(f"n{i}", f"n{i + 1}") for i in range(12)],
+        "semantic": np.arange(24, dtype=float).reshape(12, 2),
+        "graph_item_raw": np.arange(36, dtype=float).reshape(12, 3),
+    }
+    args = SimpleNamespace(
+        stability_subsamples=2,
+        stability_node_fraction=0.8,
+    )
+    with pytest.raises(ValueError, match="minimum is 20"):
+        _preflight_stability_subsamples(
+            materialized, np.arange(12), args, seed=17
+        )
+
+
+def test_multi_seed_v1_run_requires_explicit_failed_gate_acknowledgement():
+    args = SimpleNamespace(
+        seeds=10,
+        allow_failed_v1_selector=False,
+        null_draws=200,
+        stability_subsamples=100,
+        stability_node_fraction=0.8,
+    )
+    with pytest.raises(ValueError, match="synthetic selector gate failed"):
+        _validate_args(args)
+    args.allow_failed_v1_selector = True
+    _validate_args(args)
+
+
+def test_invalidated_v1_aggregate_can_never_emit_a_passing_gate():
+    def posterior(nll, log_loss, aurc):
+        return {
+            "state": {"mean_bivariate_nll": nll},
+            "decision": {"log_loss": log_loss, "aurc_margin": aurc},
+            "conditioner": {
+                "loading": {"relative_diagonal_loading": 0.0},
+                "prior_loading": {"relative_diagonal_loading": 0.0},
+            },
+        }
+
+    rows = []
+    for corpus in ("exploratory", "fresh"):
+        for seed in range(10, 20):
+            family = {
+                "selection": {"alpha": 0.5},
+                "nested_selected": {
+                    "held_joint_residual_nll_per_scalar": 0.9,
+                    "posterior": posterior(0.9, 0.9, 0.9),
+                },
+                "outer_oracle": {"gain_vs_block": 0.2, "above_null_max95": True},
+            }
+            rows.append({
+                "corpus": corpus,
+                "outer_seed": seed,
+                "models": {
+                    "block_regional": {
+                        "held_joint_residual_nll_per_scalar": 1.0,
+                        "posterior": posterior(1.0, 1.0, 1.0),
+                    }
+                },
+                "families": {PRIMARY: family, SECONDARY: family},
+            })
+    aggregate = aggregate_results(rows)
+    assert aggregate["complete_preregistered_outer_run"]
+    assert not aggregate["inferential_gate_evaluable"]
+    for key in ("primary_gate", "secondary_endogenous_geometry_gate"):
+        gate = aggregate[key]
+        assert gate["uncalibrated_v1_raw_direction_and_stability_would_pass"]
+        assert gate["conditional_fixed_path_oracle_headroom_diagnostic"]
+        assert not gate["nested_covariance_gate_passes"]
+        assert not gate["full_procedure_null_calibrated_oracle_headroom_passes"]

--- a/prototypes/mu_cosine/test_run_covariance_sensitivity_synthetic.py
+++ b/prototypes/mu_cosine/test_run_covariance_sensitivity_synthetic.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Focused regressions for the cached synthetic covariance controls."""
+import numpy as np
+import pytest
+
+from run_covariance_sensitivity_synthetic import (
+    ALPHAS,
+    CHANNELS,
+    KRRCache,
+    NLLScorer,
+    SCENARIOS,
+    SyntheticGeometry,
+    _candidate_covariance,
+    _fit_block_covariance,
+    run_replicate,
+)
+from structured_residual_covariance import (
+    fit_block_model,
+    gaussian_joint_nll,
+    rbf_kernel,
+    select_kernel_ridge_mean,
+)
+
+
+def test_cached_krr_refit_exactly_matches_project_reference():
+    x = np.linspace(-1.2, 1.4, 9)[:, None]
+    train, held = np.arange(6), np.arange(6, 9)
+    semantic = rbf_kernel(x[train], length_scale=0.7)
+    graph = rbf_kernel(1.3 * x[train], length_scale=1.1)
+    train_kernels = {
+        "semantic": semantic,
+        "graph": graph,
+        "equal_mixture": 0.5 * (semantic + graph),
+    }
+    semantic_cross = rbf_kernel(x[held], x[train], length_scale=0.7)
+    graph_cross = rbf_kernel(1.3 * x[held], 1.3 * x[train], length_scale=1.1)
+    cross_kernels = {
+        "semantic": semantic_cross,
+        "graph": graph_cross,
+        "equal_mixture": 0.5 * (semantic_cross + graph_cross),
+    }
+    residuals = np.column_stack((np.sin(x[train, 0]), np.cos(0.8 * x[train, 0])))
+    ridges = (1e-2, 0.3, 2.0)
+    actual = KRRCache(train_kernels, cross_kernels, ridges).fit_predict(residuals)
+    expected = select_kernel_ridge_mean(residuals, train_kernels, ridge_grid=ridges)
+    assert actual.kernel_name == expected.kernel_name
+    assert actual.ridge == expected.ridge
+    assert actual.loo_mse == pytest.approx(expected.loo_mse, abs=2e-15)
+    np.testing.assert_allclose(actual.intercept, expected.intercept, atol=2e-15)
+    np.testing.assert_allclose(actual.alpha, expected.alpha, atol=2e-15)
+    np.testing.assert_allclose(actual.loo_residuals, expected.loo_residuals, atol=2e-15)
+    np.testing.assert_allclose(
+        actual.prediction,
+        expected.predict(cross_kernels[expected.kernel_name]),
+        atol=2e-15,
+    )
+
+
+def test_fast_block_refit_matches_project_reference_covariance():
+    rng = np.random.default_rng(81)
+    residuals = rng.normal(size=(17, CHANNELS))
+    expected = fit_block_model(residuals, shrinkage=0.07).independent_covariance
+    actual = _fit_block_covariance(residuals, 0.07)
+    np.testing.assert_allclose(actual, expected, atol=2e-15)
+
+
+def test_true_and_candidate_endpoints_are_psd_and_preserve_item_marginals():
+    geometry = SyntheticGeometry(32, outer_held_count=8, inner_held_count=8)
+    scenario = next(value for value in SCENARIOS if value.name == "in_family_coupling_0.20")
+    correlation = geometry.true_correlation(scenario, np.arange(geometry.item_count))
+    np.linalg.cholesky(correlation)
+    for item in range(geometry.item_count):
+        section = slice(CHANNELS * item, CHANNELS * (item + 1))
+        np.testing.assert_allclose(correlation[section, section], np.eye(CHANNELS), atol=0.0)
+    maximum = 0.0
+    for left in range(geometry.item_count):
+        rows = slice(CHANNELS * left, CHANNELS * (left + 1))
+        for right in range(left + 1, geometry.item_count):
+            cols = slice(CHANNELS * right, CHANNELS * (right + 1))
+            maximum = max(maximum, np.linalg.norm(correlation[rows, cols], ord=2))
+    assert maximum == pytest.approx(0.20, abs=2e-15)
+
+    endpoint = geometry.candidate_endpoint(scenario, "outer", 0.5, 2.0, 0.5)
+    for alpha in ALPHAS:
+        np.linalg.cholesky(endpoint.mixture(alpha))
+    covariance = _candidate_covariance(
+        geometry, geometry.block_covariance, endpoint, alpha=0.35
+    )
+    for item in range(len(geometry.outer_held)):
+        section = slice(CHANNELS * item, CHANNELS * (item + 1))
+        np.testing.assert_allclose(
+            covariance[section, section], geometry.block_covariance, atol=3e-15
+        )
+
+
+def test_wrong_geometry_is_permutation_congruence_with_identical_energy():
+    geometry = SyntheticGeometry(32, outer_held_count=8, inner_held_count=8)
+    canonical = geometry.canonical_item_kernel
+    wrong = geometry.wrong_item_kernel
+    assert np.all(geometry.wrong_permutation != np.arange(geometry.item_count))
+    np.testing.assert_allclose(
+        wrong,
+        canonical[np.ix_(geometry.wrong_permutation, geometry.wrong_permutation)],
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        np.linalg.eigvalsh(wrong), np.linalg.eigvalsh(canonical), atol=3e-15
+    )
+    mask = ~np.eye(len(canonical), dtype=bool)
+    assert np.sqrt(np.mean(wrong[mask] ** 2)) == pytest.approx(
+        np.sqrt(np.mean(canonical[mask] ** 2)), abs=2e-15
+    )
+
+
+def test_cached_grid_nll_matches_independent_cholesky_reference():
+    geometry = SyntheticGeometry(32, outer_held_count=8, inner_held_count=8)
+    scenario = next(value for value in SCENARIOS if value.name == "in_family_coupling_0.10")
+    rng = np.random.default_rng(92)
+    residuals = rng.normal(size=(len(geometry.outer_held), CHANNELS))
+    block = _fit_block_covariance(rng.normal(size=(25, CHANNELS)), 0.05)
+    endpoint = geometry.candidate_endpoint(scenario, "outer", 2.0, 0.5, 1.0)
+    scorer = NLLScorer(residuals, block)
+    expected_block = gaussian_joint_nll(
+        residuals, np.kron(np.eye(len(residuals)), block)
+    ).per_scalar
+    assert scorer.block_nll == pytest.approx(expected_block, abs=2e-15)
+    scores = scorer.score_path(endpoint)
+    for alpha in ALPHAS[1:]:
+        expected = gaussian_joint_nll(
+            residuals, _candidate_covariance(geometry, block, endpoint, alpha)
+        ).per_scalar
+        assert scores[alpha] == pytest.approx(expected, abs=3e-15)
+
+
+def test_one_replicate_runs_three_fold_selector_and_outer_oracle():
+    geometry = SyntheticGeometry(32, outer_held_count=8, inner_held_count=8)
+    scenario = next(value for value in SCENARIOS if value.name == "block_null")
+    record = run_replicate(geometry, scenario, replicate=0, seed=12300, shrinkage=0.05)
+    assert len(record["inner_regional_means"]) == 3
+    assert record["selection"]["alpha"] in ALPHAS
+    assert record["outer_grid_oracle"]["nll_per_scalar"] <= (
+        record["residual_nll_per_scalar"]["block"] + 1e-15
+    )
+    assert record["measurement_dimension"] == len(geometry.outer_held) * CHANNELS

--- a/prototypes/mu_cosine/test_run_covariance_sensitivity_synthetic_v2.py
+++ b/prototypes/mu_cosine/test_run_covariance_sensitivity_synthetic_v2.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Regressions for versioned family-wise synthetic selection."""
+import json
+
 import numpy as np
 import pytest
 
@@ -19,6 +21,7 @@ from run_covariance_sensitivity_synthetic_v2 import (
     _full_records,
     _procedure_scorers,
     _threshold_ratio,
+    _write_scientific_payload,
     calibrate_nulls,
     run_mechanism_replicate_pair,
     run_replicate_pair,
@@ -82,6 +85,21 @@ def test_zero_fixed_path_threshold_has_undefined_safe_ratio():
     assert _threshold_ratio(0.25, 0.10) == pytest.approx(2.5)
     with pytest.raises(ValueError, match="nonnegative"):
         _threshold_ratio(0.25, -0.10)
+
+
+def test_scientific_artifact_is_deterministic_and_excludes_runtime(tmp_path):
+    output = tmp_path / "artifact.json"
+    _write_scientific_payload(output, {"z": 1.0, "a": [2, 3]})
+    first = output.read_bytes()
+    _write_scientific_payload(output, {"a": [2, 3], "z": 1.0})
+
+    assert output.read_bytes() == first
+    assert json.loads(first) == {"a": [2, 3], "z": 1.0}
+    with pytest.raises(ValueError, match="stdout"):
+        _write_scientific_payload(output, {"wall_seconds": 1.23})
+    with pytest.raises(ValueError, match="Out of range float"):
+        _write_scientific_payload(output, {"not_finite": float("nan")})
+    assert output.read_bytes() == first
 
 
 def test_search_filters_have_frozen_candidate_capacities():

--- a/prototypes/mu_cosine/test_run_covariance_sensitivity_synthetic_v2.py
+++ b/prototypes/mu_cosine/test_run_covariance_sensitivity_synthetic_v2.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Regressions for versioned family-wise synthetic selection."""
+import numpy as np
+import pytest
+
+from covariance_sensitivity import (
+    finite_null_maximum_threshold,
+    maximum_eligible_macro_gain,
+    select_nested_candidate,
+    select_nested_candidate_null_calibrated,
+)
+from run_covariance_sensitivity_synthetic import SCENARIOS, SyntheticGeometry
+from run_covariance_sensitivity_synthetic_v2 import (
+    SEARCH_CANONICAL,
+    SEARCH_FULL,
+    SEARCH_SINGLE,
+    _complete_control_gate,
+    _filter_search,
+    _full_records,
+    _procedure_scorers,
+    _threshold_ratio,
+    calibrate_nulls,
+    run_mechanism_replicate_pair,
+    run_replicate_pair,
+)
+
+
+def _records(gain):
+    rows = []
+    for fold in range(3):
+        rows.append({
+            "fold": fold,
+            "alpha": 0.0,
+            "semantic_multiplier": 1.0,
+            "graph_multiplier": 1.0,
+            "beta": 1.0,
+            "nll_per_scalar": 1.0,
+        })
+        rows.append({
+            "fold": fold,
+            "alpha": 0.1,
+            "semantic_multiplier": 1.0,
+            "graph_multiplier": 1.0,
+            "beta": 0.0,
+            "nll_per_scalar": 1.0 - gain,
+        })
+    return rows
+
+
+def test_finite_order_statistic_and_strict_familywise_gate():
+    threshold, rank = finite_null_maximum_threshold([0.0, 0.1, 0.2, 0.3], confidence=0.5)
+    assert rank == 3
+    assert threshold == pytest.approx(0.2)
+
+    records = _records(0.15)
+    v1, summaries = select_nested_candidate(records)
+    assert v1["alpha"] == pytest.approx(0.1)
+    assert maximum_eligible_macro_gain(summaries) == pytest.approx(0.15)
+
+    selected, _, calibration = select_nested_candidate_null_calibrated(
+        records, [0.15] * 20
+    )
+    assert selected["alpha"] == 0.0  # equality does not reject
+    assert not calibration["strictly_exceeds_threshold"]
+    selected, _, calibration = select_nested_candidate_null_calibrated(
+        records, [0.10] * 20
+    )
+    assert selected["alpha"] == pytest.approx(0.1)
+    assert calibration["strictly_exceeds_threshold"]
+
+
+def test_partial_or_empty_control_sets_cannot_pass_vacuously():
+    required = {"block_null", "regional_mean_only"}
+    assert _complete_control_gate(required, {"block_null"}, [True]) == (False, False)
+    assert _complete_control_gate(required, required, []) == (True, False)
+    assert _complete_control_gate(required, required, [True, True]) == (True, True)
+
+
+def test_zero_fixed_path_threshold_has_undefined_safe_ratio():
+    assert _threshold_ratio(0.0, 0.0) is None
+    assert _threshold_ratio(0.25, 0.0) is None
+    assert _threshold_ratio(0.25, 0.10) == pytest.approx(2.5)
+    with pytest.raises(ValueError, match="nonnegative"):
+        _threshold_ratio(0.25, -0.10)
+
+
+def test_search_filters_have_frozen_candidate_capacities():
+    geometry = SyntheticGeometry(32, outer_held_count=8, inner_held_count=8)
+    scenario = next(value for value in SCENARIOS if value.name == "block_null")
+    field = np.random.default_rng(3).normal(size=(geometry.item_count, 4))
+    full = _full_records(
+        geometry,
+        scenario,
+        _procedure_scorers(geometry, field, 0.05, "regional_krr"),
+    )
+    # Three block rows plus candidate count times three folds.
+    assert len(_filter_search(full, SEARCH_FULL)) == 3 + 216 * 3
+    assert len(_filter_search(full, SEARCH_CANONICAL)) == 3 + 8 * 3
+    assert len(_filter_search(full, SEARCH_SINGLE)) == 3 + 1 * 3
+
+
+def test_paired_fixed_and_full_procedure_calibrations_are_deterministic():
+    geometry = SyntheticGeometry(32, outer_held_count=8, inner_held_count=8)
+    first_arrays, first_report = calibrate_nulls(
+        geometry, draws=4, seed=5100, shrinkage=0.05
+    )
+    second_arrays, second_report = calibrate_nulls(
+        geometry, draws=4, seed=5100, shrinkage=0.05
+    )
+    assert first_report == second_report
+    for null_name in ("fixed_path_shared_z", "full_procedure_krr"):
+        for search in (SEARCH_FULL, SEARCH_CANONICAL, SEARCH_SINGLE):
+            np.testing.assert_array_equal(
+                first_arrays[null_name][search], second_arrays[null_name][search]
+            )
+
+
+def test_end_to_end_omits_invalid_pre_krr_truth_but_mechanism_truth_is_exact():
+    geometry = SyntheticGeometry(32, outer_held_count=8, inner_held_count=8)
+    scenario = next(value for value in SCENARIOS if value.name == "block_null")
+    never_reject = {
+        SEARCH_FULL: np.ones(20),
+        SEARCH_CANONICAL: np.ones(20),
+        SEARCH_SINGLE: np.ones(20),
+    }
+    end = run_replicate_pair(
+        geometry, scenario, replicate=0, seed=6200, shrinkage=0.05,
+        full_procedure_null_maxima=never_reject,
+    )
+    for record in end.values():
+        assert "known_true_covariance" not in record["residual_nll_per_scalar"]
+        assert "known_true_covariance" not in record["posterior_state_mse"]
+        assert "e_H-W e_T" in record["truth_scope"]
+
+    mechanism = run_mechanism_replicate_pair(
+        geometry, scenario, replicate=0, seed=6200,
+        fixed_path_null_maxima=never_reject,
+    )
+    for record in mechanism.values():
+        assert record["selection"]["alpha"] == 0.0
+        assert record["residual_nll_per_scalar"]["known_true_covariance"] == pytest.approx(
+            record["residual_nll_per_scalar"]["block"], abs=2e-15
+        )
+        assert record["posterior_state_mse"]["known_true_covariance"] == pytest.approx(
+            record["posterior_state_mse"]["block"], abs=2e-15
+        )


### PR DESCRIPTION
## Summary

This PR adds a calibrated covariance-sensitivity study for `mu_cosine` and turns the next graph-correlation question into an explicit adjacent-positive / matched-distant-negative experiment.

It:

- adds marginal-matched PSD correlation paths, nested selection, family-wise null calibration, posterior sensitivity metrics, and Gaussian/centered-μ kernel helpers;
- adds corrected synthetic v2 controls separating mechanism recovery from end-to-end covariance discovery;
- labels the real-data v1 runner as a legacy diagnostic and blocks accidental multi-seed inference;
- records the reproducible corrected results;
- designs adjacency-aware sampling and distance-separated square-root/QR batching.

## Corrected result

The original 216-candidate selector selected nonzero covariance under the block null 64.9% of the time even with an oracle mean, increasing to 84.5% with fitted regional KRR.

The corrected controls show:

- Good correlation information really can improve the estimate.
- At coupling 0.10, it recovers 67–70% of the available NLL improvement and 74–86% of posterior-risk improvement.
- At coupling 0.20, recovery reaches 71–84% for NLL and 89–96% for posterior risk.
- Detection remains only 31–46%, below the frozen 80% power gate.

Therefore this PR retains block covariance for deployment. It does not claim that cross-item correlation is useless; it shows that the current one-field estimator and selector cannot discover it reliably enough.

## Adjacent-positive / distant-negative follow-up

The graph judge serves two related purposes:

1. Help the model learn the local structure of a dataset.
2. Supply candidate geometry for residual correlation and safe batching.

The follow-up treats adjacent rows as smoothing positives and matched distant—including semantically similar hard-negative—rows as negatives. Cross-fitted conditional residuals then test whether same-judge error coupling remains after the learned mean is removed.

If validated, a conservative threshold on whitened cross-block coupling determines which distant items may use independent updates. Adjacent connected components remain joint square-root/QR blocks.

## Validation

- 56 relevant tests pass.
- All four new Python modules compile.
- All three CLIs parse `--help`.
- Deterministic scientific artifact SHA-256: `bb4b81c6bd182ebe89bee3360345491b8068aecd56e3ff59d49da9ceac56a9ca`.
- Runtime remains available on stdout but is deliberately excluded from the hashed JSON.
- Claude's sole reproducibility finding is addressed; all scientific values are unchanged.
