### PR TITLE
WAM/LLVM: persistent cache runtime primitive (@wam_cache_*), phase 1a

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4916,6 +4916,108 @@ vat.miss:
   ret i64 0
 }
 
+; ---- persistent cache: a file-backed assoc table -------------------------
+; The cache handle IS a %WamAssocI64Table*. @wam_cache_open builds a table
+; and loads (key,value) i64 pairs from a flat little-endian file laid out as
+; [count:i64][key:i64 value:i64]...; @wam_cache_commit writes the table back;
+; @wam_cache_close frees it. The i64 fast path (inc/get/set/iterate) reuses
+; the assoc helpers directly on the handle. internal linkage so an unused
+; cache is dead-code eliminated -- zero cost when no store is opened.
+define internal %WamAssocI64Table* @wam_cache_open(i8* %path) {
+entry:
+  %cbuf = alloca i64
+  %pbuf = alloca [2 x i64]
+  %table = call %WamAssocI64Table* @wam_assoc_i64_new(i64 64)
+  %fd = call i32 @open(i8* %path, i32 0, i32 0)
+  %fd_ok = icmp sge i32 %fd, 0
+  br i1 %fd_ok, label %co.readcount, label %co.done
+
+co.readcount:
+  %cbuf_i8 = bitcast i64* %cbuf to i8*
+  %cn = call i64 @read(i32 %fd, i8* %cbuf_i8, i64 8)
+  %cn_ok = icmp eq i64 %cn, 8
+  br i1 %cn_ok, label %co.loop, label %co.close
+
+co.loop:
+  %i = phi i64 [ 0, %co.readcount ], [ %i.next, %co.store ]
+  %count = load i64, i64* %cbuf
+  %i.done = icmp uge i64 %i, %count
+  br i1 %i.done, label %co.close, label %co.readpair
+
+co.readpair:
+  %pbuf_i8 = bitcast [2 x i64]* %pbuf to i8*
+  %pn = call i64 @read(i32 %fd, i8* %pbuf_i8, i64 16)
+  %pn_ok = icmp eq i64 %pn, 16
+  br i1 %pn_ok, label %co.store, label %co.close
+
+co.store:
+  %kp = getelementptr [2 x i64], [2 x i64]* %pbuf, i64 0, i64 0
+  %k = load i64, i64* %kp
+  %vp = getelementptr [2 x i64], [2 x i64]* %pbuf, i64 0, i64 1
+  %v = load i64, i64* %vp
+  %setrc = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %k, i64 %v)
+  %i.next = add i64 %i, 1
+  br label %co.loop
+
+co.close:
+  %crc = call i32 @close(i32 %fd)
+  br label %co.done
+
+co.done:
+  ret %WamAssocI64Table* %table
+}
+
+define internal void @wam_cache_commit(%WamAssocI64Table* %table, i8* %path) {
+entry:
+  %cbuf = alloca i64
+  %pbuf = alloca [2 x i64]
+  %fd = call i32 @open(i8* %path, i32 577, i32 420)
+  %fd_ok = icmp sge i32 %fd, 0
+  br i1 %fd_ok, label %cc.writecount, label %cc.done
+
+cc.writecount:
+  %count_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 0
+  %count = load i64, i64* %count_slot
+  store i64 %count, i64* %cbuf
+  %cbuf_i8 = bitcast i64* %cbuf to i8*
+  %cw = call i64 @write(i32 %fd, i8* %cbuf_i8, i64 8)
+  br label %cc.loop
+
+cc.loop:
+  %cur = phi i64 [ 0, %cc.writecount ], [ %cur.next, %cc.wrote ]
+  %slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %table, i64 %cur)
+  %slot.done = icmp slt i64 %slot, 0
+  br i1 %slot.done, label %cc.close, label %cc.emit
+
+cc.emit:
+  %k = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %table, i64 %slot)
+  %v = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %table, i64 %slot)
+  %kp = getelementptr [2 x i64], [2 x i64]* %pbuf, i64 0, i64 0
+  store i64 %k, i64* %kp
+  %vp = getelementptr [2 x i64], [2 x i64]* %pbuf, i64 0, i64 1
+  store i64 %v, i64* %vp
+  %pbuf_i8 = bitcast [2 x i64]* %pbuf to i8*
+  %pw = call i64 @write(i32 %fd, i8* %pbuf_i8, i64 16)
+  br label %cc.wrote
+
+cc.wrote:
+  %cur.next = add i64 %slot, 1
+  br label %cc.loop
+
+cc.close:
+  %crc = call i32 @close(i32 %fd)
+  br label %cc.done
+
+cc.done:
+  ret void
+}
+
+define internal void @wam_cache_close(%WamAssocI64Table* %table) {
+entry:
+  call void @wam_assoc_i64_free(%WamAssocI64Table* %table)
+  ret void
+}
+
 ; POSIX ERE matching over atom-backed text records. Patterns are
 ; compile-time constants; each match site owns a cache slot holding a
 ; lazily regcomp()ed regex_t. The regex_t is malloc''d at 512 bytes,

--- a/tests/test_wam_cache_runtime.pl
+++ b/tests/test_wam_cache_runtime.pl
@@ -1,0 +1,128 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Runtime primitive for the plawk multi-pass persistent cache
+% (PLAWK_MULTIPASS_CACHE.md, phase 1): @wam_cache_open / _commit / _close in
+% the LLVM/WAM target. The cache handle IS a %WamAssocI64Table*; open builds
+% a table and loads (key,value) i64 pairs from a flat little-endian file,
+% commit writes the table back, close frees it. The i64 fast path reuses the
+% assoc helpers on the handle.
+%
+% There is no plawk surface for the cache yet (that is phase 1b), so this
+% test exercises the primitive directly: it builds a real plawk binary with
+% `--keep-ll` to obtain a module carrying the full runtime (types, libc
+% declares, assoc helpers, and the new cache functions), then swaps the
+% generated `main` for a synthesized one that drives the cache and prints
+% what it reads back. Running the binary twice against the same file proves
+% the file round-trip and cross-run persistence. This is a file-backed
+% backend; the LMDB backend (larger-than-RAM) rides the same ABI later.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+% The synthesized entry point: open a store at argv[1], accumulate key 1 by
+% 5 and key 2 by 3, commit, close; reopen and read the committed values back,
+% printing "v1 v2". Run 1 over an empty file -> "5 3"; run 2 loads that and
+% accumulates again -> "10 6".
+cache_test_main("
+@.cachetest_fmt = private constant [9 x i8] c\"%ld %ld\\0A\\00\"
+
+define i32 @main(i32 %argc, i8** %argv) {
+entry:
+  %argv1_ptr = getelementptr i8*, i8** %argv, i64 1
+  %path = load i8*, i8** %argv1_ptr
+  %t = call %WamAssocI64Table* @wam_cache_open(i8* %path)
+  %a = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %t, i64 1, i64 5)
+  %b = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %t, i64 2, i64 3)
+  call void @wam_cache_commit(%WamAssocI64Table* %t, i8* %path)
+  call void @wam_cache_close(%WamAssocI64Table* %t)
+  %t2 = call %WamAssocI64Table* @wam_cache_open(i8* %path)
+  %v1 = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %t2, i64 1)
+  %v2 = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %t2, i64 2)
+  %fmt = getelementptr [9 x i8], [9 x i8]* @.cachetest_fmt, i32 0, i32 0
+  %r = call i32 (i8*, ...) @printf(i8* %fmt, i64 %v1, i64 %v2)
+  call void @wam_cache_close(%WamAssocI64Table* %t2)
+  ret i32 0
+}
+").
+
+:- begin_tests(wam_cache_runtime).
+
+% Round-trip within one run, then cross-run persistence across two runs.
+test(cache_roundtrip_and_persistence, [condition(clang_available)]) :-
+    cr_dir(Dir),
+    % A trivial plawk program just to obtain a module with the full runtime.
+    directory_file_path(Dir, 'seed.plawk', Seed),
+    setup_call_cleanup(open(Seed, write, S, [encoding(utf8)]),
+        write(S, "{ c[$1]++ }\nEND { for (k in c) print k, c[k] }\n"), close(S)),
+    directory_file_path(Dir, 'seed_bin', SeedBin),
+    cli([build, Seed, '-o', SeedBin, '--keep-ll'], 0),
+    atom_concat(SeedBin, '.ll', SeedLL),
+    read_file_to_string(SeedLL, LL0, []),
+    % Swap the generated entry point for our cache driver.
+    ( sub_string(LL0, _, _, _, "define i32 @main(")
+    -> true ; throw(no_generated_main) ),
+    string_replace(LL0, "define i32 @main(",
+        "define i32 @plawk_unused_main(", LL1),
+    cache_test_main(TestMain),
+    string_concat(LL1, TestMain, LLFinal),
+    directory_file_path(Dir, 'cachetest.ll', TestLL),
+    setup_call_cleanup(open(TestLL, write, S2, [encoding(utf8)]),
+        write(S2, LLFinal), close(S2)),
+    directory_file_path(Dir, 'cachetest_bin', TestBin),
+    format(atom(ClangCmd), 'clang -w -O2 ~w -o ~w -lm 2>&1', [TestLL, TestBin]),
+    process_create(path(sh), ['-c', ClangCmd],
+        [stdout(pipe(CS)), process(CPid)]),
+    read_string(CS, _, ClangOut), close(CS),
+    process_wait(CPid, CStatus),
+    ( CStatus == exit(0) -> true
+    ; throw(clang_failed(CStatus, ClangOut)) ),
+    directory_file_path(Dir, 'store.cache', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    % Run 1 over an empty store: 5 3.
+    run_bin(TestBin, [Store], Out1),
+    assertion(Out1 == "5 3\n"),
+    % Run 2 loads the committed store and accumulates again: 10 6.
+    run_bin(TestBin, [Store], Out2),
+    assertion(Out2 == "10 6\n"),
+    !.
+
+:- end_tests(wam_cache_runtime).
+
+% --- helpers ---------------------------------------------------------------
+
+cr_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_wam_cache_runtime', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+string_replace(In, From, To, Out) :-
+    sub_string(In, Before, _, After, From),
+    sub_string(In, 0, Before, _, Pre),
+    string_length(In, Len), string_length(From, FLen),
+    Start is Before + FLen, Rest is Len - Start,
+    sub_string(In, Start, Rest, 0, Post),
+    ( After >= 0 -> true ; true ),
+    string_concat(Pre, To, Tmp0),
+    string_concat(Tmp0, Post, Out).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).
+
+run_bin(Bin, Args, Out) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0).


### PR DESCRIPTION
## First implementation step of the multi-pass persistent cache

Begins `PLAWK_MULTIPASS_CACHE.md`. This is the runtime **engine** — the plawk `cache(...)` surface is the next PR (phase 1b).

### Why file-backed, not LMDB (for now)

I checked: **liblmdb is not present in this environment** (no lib, no header, no tools), and the LLVM target links **no external libraries** — plawk emits a single `.ll` compiled with `clang -w -O2 <ll> -o <out> -lm`. So an LMDB-linked binary can't be built or tested here. Per the merged design, the first backend is therefore a **portable file-backed store emitted as LLVM IR**, sharing the exact ABI a later LMDB backend fills in (design Phase 5, in an environment with the library). This *is* cache support in the LLVM target — with a backend we can compile and verify now.

### What it adds

Three `internal` runtime functions beside the assoc helpers:

- `@wam_cache_open(path)` — build a `%WamAssocI64Table` and load `(key,value)` i64 pairs from a flat little-endian file `[count][key value]…`; a missing file yields an empty store.
- `@wam_cache_commit(t, path)` — write the table back (count, then each occupied slot's key/value), truncating.
- `@wam_cache_close(t)` — free the table.

The **cache handle *is* an assoc table**, so the i64 fast path (`inc`/`get`/`set`/iterate) reuses the existing `@wam_assoc_i64_*` helpers on the handle with no new code. The functions are `internal`, so an unused cache is dead-code-eliminated — **zero cost when no store is opened**, honoring the design's pay-only-for-what-you-use invariant.

### Verification

`clang`'s IR verifier runs over the cache functions on every build (confirmed: normal plawk programs still build and run). Behavior is tested directly in `tests/test_wam_cache_runtime.pl`: since there's no plawk surface yet, it builds a real plawk binary with `--keep-ll`, swaps the generated `main` for a synthesized one driving `open → inc → commit → close → reopen → get`, then runs it **twice against one file** — proving the file round-trip (`5 3`) and **cross-run persistence** (`10 6`). Test passes.

### Next (phase 1b)

The plawk surface: `BEGIN cache("path") { declare NAME }` + routing a declared table's setup to `@wam_cache_open` and adding `@wam_cache_commit` at END. Small delta, since the handle is already an assoc table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_