### PR TITLE
WAM/LLVM plawk: cache surface — BEGIN cache(...) declared tables (phase 1b)

### DIFF
--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -721,26 +721,31 @@ plawk_program_native_driver_ir(
     DriverIR
 ) :-
     plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions, AssocPlan, PrintFields),
+    AssocPlan = assoc_plan(Tables, _),
+    plawk_program_cache_tables(BeginClauses, CacheNamePaths),
+    plawk_cache_entries(Tables, CacheNamePaths, CacheEntries, CachePathGlobals),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_record_descriptor(BeginClauses, FieldSeparator),
     plawk_assoc_record_program_ok(FieldSeparator, Rules, PrintFields),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
-    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, CacheEntries, EntrySetupIR),
     plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
     plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
     plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
     plawk_forin_end_print_ir(LoopVar, ArrayName, PrintFields, AssocPlan,
         FieldSeparator, OutputSeparator, EndPrintIR),
-    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
-        [BeginGlobalIR, StringGlobalIR, AssocRuleGlobalIR]),
+    plawk_cache_commit_lines(CacheEntries, CommitIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, AssocRuleGlobalIR, CachePathGlobals]),
     plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
+~w
 ~w',
-        [EndPrintIR]),
+        [CommitIR, EndPrintIR]),
     plawk_emit_record_driver_ir(FieldSeparator, InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
             AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
@@ -5143,8 +5148,75 @@ plawk_forin_rule_field_plan(LoopVar, _ArrayName, _TableIndex, Tables,
 plawk_forin_rule_field_plan(_LoopVar, _ArrayName, _TableIndex, _Tables,
         _StrArrays, _PosArrays, string(Value), lit(Value)).
 
-plawk_assoc_entry_setup_ir(assoc_plan(Tables, _Actions), IR) :-
-    phrase(plawk_assoc_entry_setup_lines(Tables, 0), Lines),
+plawk_assoc_entry_setup_ir(Plan, IR) :-
+    plawk_assoc_entry_setup_ir(Plan, [], IR).
+
+%% plawk_assoc_entry_setup_ir(+Plan, +CacheEntries, -IR)
+%  CacheEntries is a list of cache(TableIndex, PathGlobalBytesLen) for tables
+%  backed by a persistent store (multi-pass cache, phase 1b). A cache-backed
+%  table is created like any assoc table, then loaded from its store file so
+%  a pre-populated or prior-run store is read in. [] => no cache (the /2
+%  form), so non-cache programs emit exactly the old IR.
+plawk_assoc_entry_setup_ir(assoc_plan(Tables, _Actions), CacheEntries, IR) :-
+    phrase(plawk_assoc_entry_setup_lines(Tables, 0, CacheEntries), Lines),
+    atomic_list_concat(Lines, '\n', IR).
+
+plawk_assoc_entry_setup_lines([], _, _CacheEntries) -->
+    [].
+plawk_assoc_entry_setup_lines([_ArrayName | Rest], Index, CacheEntries) -->
+    { format(atom(NewLine),
+          '  %plawk_assoc_table_~w = call %WamAssocI64Table* @wam_assoc_i64_new(i64 4096)',
+          [Index]),
+      ( memberchk(cache(Index, BytesLen), CacheEntries)
+      ->  format(atom(LoadLine),
+              '  call void @wam_cache_load(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
+              [Index, BytesLen, BytesLen, Index]),
+          Lines = [NewLine, LoadLine]
+      ;   Lines = [NewLine]
+      ),
+      NextIndex is Index + 1
+    },
+    plawk_emit_lines(Lines),
+    plawk_assoc_entry_setup_lines(Rest, NextIndex, CacheEntries).
+
+%% plawk_program_cache_tables(+BeginClauses, -NamePaths)
+%  Name-Path pairs for every table declared in a `BEGIN cache("path") {
+%  declare NAME ... }` block.
+plawk_program_cache_tables(BeginClauses, NamePaths) :-
+    findall(Name-Path,
+        ( member(begin(Actions), BeginClauses),
+          member(cache_table(Name, Path), Actions)
+        ),
+        NamePaths).
+
+%% plawk_cache_entries(+Tables, +NamePaths, -CacheEntries, -PathGlobalsIR)
+%  Resolve each cache-backed table name to its index in the plan's table
+%  list, emit a private string global @.plawk_cache_path_<idx> for its path,
+%  and record cache(Index, BytesLen) so setup/commit can reference the
+%  global. A declared name absent from the plan (never used) is skipped.
+plawk_cache_entries(Tables, NamePaths, CacheEntries, PathGlobalsIR) :-
+    findall(cache(Index, BytesLen)-Global,
+        ( member(Name-Path, NamePaths),
+          nth0(Index, Tables, Name),
+          format(atom(GName), 'plawk_cache_path_~w', [Index]),
+          llvm_emit_c_string_global(GName, Path, Global, _Len, BytesLen)
+        ),
+        Pairs),
+    pairs_keys_values(Pairs, CacheEntries, Globals),
+    atomic_list_concat(Globals, '\n', PathGlobalsIR).
+
+%% plawk_cache_commit_lines(+CacheEntries, -IR)
+%  A @wam_cache_commit call per cache-backed table, writing the final table
+%  back to its store. Emitted at the top of the END phase (after the record
+%  loop, table still live), so the committed state is the completed pass.
+plawk_cache_commit_lines(CacheEntries, IR) :-
+    findall(Line,
+        ( member(cache(Index, BytesLen), CacheEntries),
+          format(atom(Line),
+              '  call void @wam_cache_commit(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
+              [Index, BytesLen, BytesLen, Index])
+        ),
+        Lines),
     atomic_list_concat(Lines, '\n', IR).
 
 plawk_assoc_entry_setup_lines([], _) -->

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -842,6 +842,19 @@ quoted_string_escape_codes([0'\\, Code]) -->
     [Code],
     { Code =\= 0'\n, Code =\= 0'\r }.
 
+% Backed BEGIN block (multi-pass persistent cache, phase 1b): `BEGIN
+% cache("path") { declare NAME ... }` declares one or more tables backed by
+% the store at "path". Each `declare NAME` becomes a cache_table(NAME,
+% "path") begin action; the codegen opens the store into NAME at setup and
+% commits it at END. Tried before the plain BEGIN clause. See
+% PLAWK_MULTIPASS_CACHE.md.
+begin_clauses([begin(Actions)]) -->
+    "BEGIN", ws, "cache", ws, "(", ws, quoted_string(PathCodes), ws, ")", ws,
+    "{", ws,
+    { string_codes(Path, PathCodes) },
+    cache_decl_list(Path, Actions),
+    ws, "}", ws,
+    !.
 begin_clauses([begin(Actions)]) -->
     "BEGIN",
     ws,
@@ -854,6 +867,18 @@ begin_clauses([begin(Actions)]) -->
     !.
 begin_clauses([]) -->
     [].
+
+cache_decl_list(Path, [cache_table(Name, Path) | Rest]) -->
+    "declare", required_ws, identifier(Name),
+    cache_decl_list_rest(Path, Rest).
+cache_decl_list_rest(Path, [cache_table(Name, Path) | Rest]) -->
+    ws, cache_decl_sep, ws, "declare", required_ws, identifier(Name),
+    !,
+    cache_decl_list_rest(Path, Rest).
+cache_decl_list_rest(_Path, []) -->
+    [].
+cache_decl_sep --> ";", !.
+cache_decl_sep --> [].
 
 begin_actions([Action | Actions]) -->
     begin_action(Action),

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4923,47 +4923,56 @@ vat.miss:
 ; @wam_cache_close frees it. The i64 fast path (inc/get/set/iterate) reuses
 ; the assoc helpers directly on the handle. internal linkage so an unused
 ; cache is dead-code eliminated -- zero cost when no store is opened.
-define internal %WamAssocI64Table* @wam_cache_open(i8* %path) {
+; Load (key,value) i64 pairs from the file at %path INTO an existing table
+; (merging over whatever it already holds). A missing/short file is a no-op,
+; so an unseeded store starts empty and a pre-populated one is read in.
+define internal void @wam_cache_load(%WamAssocI64Table* %table, i8* %path) {
 entry:
   %cbuf = alloca i64
   %pbuf = alloca [2 x i64]
-  %table = call %WamAssocI64Table* @wam_assoc_i64_new(i64 64)
   %fd = call i32 @open(i8* %path, i32 0, i32 0)
   %fd_ok = icmp sge i32 %fd, 0
-  br i1 %fd_ok, label %co.readcount, label %co.done
+  br i1 %fd_ok, label %cl.readcount, label %cl.done
 
-co.readcount:
+cl.readcount:
   %cbuf_i8 = bitcast i64* %cbuf to i8*
   %cn = call i64 @read(i32 %fd, i8* %cbuf_i8, i64 8)
   %cn_ok = icmp eq i64 %cn, 8
-  br i1 %cn_ok, label %co.loop, label %co.close
+  br i1 %cn_ok, label %cl.loop, label %cl.close
 
-co.loop:
-  %i = phi i64 [ 0, %co.readcount ], [ %i.next, %co.store ]
+cl.loop:
+  %i = phi i64 [ 0, %cl.readcount ], [ %i.next, %cl.store ]
   %count = load i64, i64* %cbuf
   %i.done = icmp uge i64 %i, %count
-  br i1 %i.done, label %co.close, label %co.readpair
+  br i1 %i.done, label %cl.close, label %cl.readpair
 
-co.readpair:
+cl.readpair:
   %pbuf_i8 = bitcast [2 x i64]* %pbuf to i8*
   %pn = call i64 @read(i32 %fd, i8* %pbuf_i8, i64 16)
   %pn_ok = icmp eq i64 %pn, 16
-  br i1 %pn_ok, label %co.store, label %co.close
+  br i1 %pn_ok, label %cl.store, label %cl.close
 
-co.store:
+cl.store:
   %kp = getelementptr [2 x i64], [2 x i64]* %pbuf, i64 0, i64 0
   %k = load i64, i64* %kp
   %vp = getelementptr [2 x i64], [2 x i64]* %pbuf, i64 0, i64 1
   %v = load i64, i64* %vp
   %setrc = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %k, i64 %v)
   %i.next = add i64 %i, 1
-  br label %co.loop
+  br label %cl.loop
 
-co.close:
+cl.close:
   %crc = call i32 @close(i32 %fd)
-  br label %co.done
+  br label %cl.done
 
-co.done:
+cl.done:
+  ret void
+}
+
+define internal %WamAssocI64Table* @wam_cache_open(i8* %path) {
+entry:
+  %table = call %WamAssocI64Table* @wam_assoc_i64_new(i64 64)
+  call void @wam_cache_load(%WamAssocI64Table* %table, i8* %path)
   ret %WamAssocI64Table* %table
 }
 

--- a/tests/test_plawk_cache_surface.pl
+++ b/tests/test_plawk_cache_surface.pl
@@ -1,0 +1,120 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk multi-pass persistent cache, phase 1b: the SURFACE over the phase-1a
+% runtime engine. `BEGIN cache("path") { declare NAME }` declares a table
+% backed by a store file; the codegen creates the assoc table as usual, then
+% loads the store into it at setup (@wam_cache_load) and commits it at END
+% (@wam_cache_commit). So a histogram accumulates across separate runs of the
+% same binary against the same store -- and a pre-populated store (from a
+% prior run or seeded externally in the same flat format) is read in on open.
+% File-backed backend; the LMDB backend rides the same surface later.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_cache_surface).
+
+% A BEGIN cache block declares a table as a cache_table begin action.
+test(cache_block_parses) :-
+    plawk_parse_string(
+        "BEGIN cache(\"h.db\") { declare c }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) print k, c[k] }\n",
+        program([begin([cache_table(c, "h.db")])],
+            [rule(always, [inc_assoc(var(c), field(1))])],
+            [end([for_in(var(k), var(c),
+                [print([var(k), assoc(var(c), var(k))])])])])),
+    !.
+
+% Two declares in one block share the store path.
+test(multi_declare_parses) :-
+    plawk_parse_string(
+        "BEGIN cache(\"s.db\") { declare a ; declare b }\n{ a[$1]++ }\n",
+        program([begin([cache_table(a, "s.db"), cache_table(b, "s.db")])],
+            _, _)),
+    !.
+
+% Cross-run persistence: the histogram counts accumulate across separate
+% invocations of the binary against the same store file. Run 1 over an empty
+% store yields a=2,b=1; run 2 loads that (pre-population from the prior run)
+% and adds again -> a=4,b=2; run 3 -> a=6,b=3.
+test(histogram_persists_across_runs, [condition(clang_available)]) :-
+    cs_dir(Dir),
+    directory_file_path(Dir, 'hist.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(string(Src),
+        "BEGIN cache(\"~w\") { declare c }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) print k, c[k] }\n", [Store]),
+    build_bin(Dir, 'hist', Src, Bin),
+    directory_file_path(Dir, 'in.txt', Input),
+    setup_call_cleanup(open(Input, write, SI, [encoding(utf8)]),
+        write(SI, "a\na\nb\n"), close(SI)),
+    run_sorted(Bin, [Input], S1), assertion(S1 == ["a 2", "b 1"]),
+    run_sorted(Bin, [Input], S2), assertion(S2 == ["a 4", "b 2"]),
+    run_sorted(Bin, [Input], S3), assertion(S3 == ["a 6", "b 3"]),
+    !.
+
+% A fresh binary (recompiled) reading a store a DIFFERENT binary populated:
+% pre-population survives across program rebuilds, not just reruns.
+test(store_survives_rebuild, [condition(clang_available)]) :-
+    cs_dir(Dir),
+    directory_file_path(Dir, 'shared.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(string(Src),
+        "BEGIN cache(\"~w\") { declare c }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) print k, c[k] }\n", [Store]),
+    directory_file_path(Dir, 'seed.txt', SeedIn),
+    setup_call_cleanup(open(SeedIn, write, S0, [encoding(utf8)]),
+        write(S0, "x\nx\nx\n"), close(S0)),
+    build_bin(Dir, 'writer', Src, WriterBin),
+    run_sorted(WriterBin, [SeedIn], _),               % store now has x=3
+    build_bin(Dir, 'reader', Src, ReaderBin),          % separate compile
+    directory_file_path(Dir, 'more.txt', MoreIn),
+    setup_call_cleanup(open(MoreIn, write, S1, [encoding(utf8)]),
+        write(S1, "x\n"), close(S1)),
+    run_sorted(ReaderBin, [MoreIn], S), assertion(S == ["x 4"]),
+    !.
+
+:- end_tests(plawk_cache_surface).
+
+% --- helpers ---------------------------------------------------------------
+
+cs_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_cache_surface', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_bin(Dir, Name, Src, Bin) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0).
+
+run_sorted(Bin, Args, Sorted) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## The plawk surface over the phase-1a cache engine

Builds on #3676. A backed `BEGIN` block now makes a table durable:

```awk
BEGIN cache("hist.db") { declare c }
{ c[$1]++ }
END { for (k in c) print k, c[k] }
```

`c` is backed by the store at `hist.db`: the codegen creates the assoc table as before, **loads** the store into it at setup (`@wam_cache_load`) and **commits** it at the top of the END phase (`@wam_cache_commit`, table still live, before the free). So the histogram accumulates across separate runs of the binary against the same store — `2/1 → 4/2 → 6/3` — and a **pre-populated** store (from a prior run, or a separately-compiled binary writing the same flat format) is read in on open.

### Pieces

- **Parser**: `BEGIN cache("path") { declare NAME [; declare NAME]… }` → a `cache_table(NAME, "path")` begin action per declaration; tried before the plain `BEGIN` clause.
- **Runtime**: factored `@wam_cache_load` (load pairs into an existing table) out of `@wam_cache_open`, so a cache-backed table is just `assoc_new` + `cache_load`.
- **Codegen**: `plawk_assoc_entry_setup_ir/3` emits the load after `new` for cache-backed tables; `plawk_cache_entries` resolves declared names → table indices and emits a private path-string global per store; `plawk_cache_commit_lines` emits the END commit. Wired into the generic plain END-for-in driver clause. The `/2` setup entry point delegates with an empty cache map, so **non-cache programs emit byte-identical IR** and link nothing new (the cache runtime is `internal` and dead-code-eliminated).

### Pre-population

Explicitly covered: `store_survives_rebuild` seeds a store with one compiled binary, then a **separately compiled** binary opens the same store, reads the seeded counts, and adds to them (`x=3` seeded → reader sees `x 4`).

### Tests & regression

`tests/test_plawk_cache_surface.pl` (4/4): parse coverage, cross-run accumulation, and persistence across a separate recompile. Regression: `test_plawk_forin_filter` (7/7), `test_plawk_forin_accum` (7/7), `test_plawk_forin_decode` (6/6) all still pass — the shared END-for-in driver is unchanged for non-cache programs.

### Scope / next

File-backed backend, i64 tables, single pass, the generic END-for-in driver. Next: multiple `pass { }` blocks (Phase 2), then the LMDB backend (Phase 5 — now unblocked, `liblmdb` installs and links here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_