### PR TITLE
WAM/LLVM plawk: LMDB cache backend (phase 5)

### DIFF
--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -189,7 +189,12 @@ build(File, Out0, KeepLL) :-
         open(LLPath, append, S, [encoding(utf8)]),
         ( nl(S), write(S, DriverIR) ),
         close(S)),
-    format(atom(Cmd), 'clang -w -O2 ~w -o ~w -lm 2>&1', [LLPath, Out]),
+    (   plawk_program_uses_lmdb_cache(Program)
+    ->  lmdb_c_runtime_file(CFile),
+        format(atom(Cmd),
+            'clang -w -O2 ~w ~w -o ~w -lm -llmdb 2>&1', [LLPath, CFile, Out])
+    ;   format(atom(Cmd), 'clang -w -O2 ~w -o ~w -lm 2>&1', [LLPath, Out])
+    ),
     process_create(path(sh), ['-c', Cmd],
         [stdout(pipe(CS)), stderr(std), process(Pid)]),
     read_string(CS, _, ClangOut),
@@ -204,6 +209,20 @@ build(File, Out0, KeepLL) :-
     ;   format(user_error, 'plawk: clang failed:~n~w~n', [ClangOut]),
         halt(4)
     ).
+
+% A program uses the LMDB cache backend if any declared cache table names
+% it. Such a build links the C LMDB runtime (wam_cache_lmdb.c) and -llmdb;
+% the default file backend links neither.
+plawk_program_uses_lmdb_cache(program(BeginClauses, _, _)) :-
+    member(begin(Actions), BeginClauses),
+    member(cache_table(_Name, _Path, lmdb), Actions),
+    !.
+
+% The C LMDB runtime ships beside wam_llvm_target.pl.
+lmdb_c_runtime_file(CFile) :-
+    module_property(wam_llvm_target, file(TargetPl)),
+    file_directory_name(TargetPl, Dir),
+    directory_file_path(Dir, 'wam_cache_lmdb.c', CFile).
 
 ll_path(Out, true, LLPath) :-
     !,

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5167,10 +5167,11 @@ plawk_assoc_entry_setup_lines([_ArrayName | Rest], Index, CacheEntries) -->
     { format(atom(NewLine),
           '  %plawk_assoc_table_~w = call %WamAssocI64Table* @wam_assoc_i64_new(i64 4096)',
           [Index]),
-      ( memberchk(cache(Index, BytesLen), CacheEntries)
-      ->  format(atom(LoadLine),
-              '  call void @wam_cache_load(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
-              [Index, BytesLen, BytesLen, Index]),
+      ( memberchk(cache(Index, BytesLen, Backend), CacheEntries)
+      ->  plawk_cache_fn(Backend, load, LoadFn),
+          format(atom(LoadLine),
+              '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
+              [LoadFn, Index, BytesLen, BytesLen, Index]),
           Lines = [NewLine, LoadLine]
       ;   Lines = [NewLine]
       ),
@@ -5182,39 +5183,58 @@ plawk_assoc_entry_setup_lines([_ArrayName | Rest], Index, CacheEntries) -->
 %% plawk_program_cache_tables(+BeginClauses, -NamePaths)
 %  Name-Path pairs for every table declared in a `BEGIN cache("path") {
 %  declare NAME ... }` block.
-plawk_program_cache_tables(BeginClauses, NamePaths) :-
-    findall(Name-Path,
+plawk_program_cache_tables(BeginClauses, Triples) :-
+    findall(ct(Name, Path, Backend),
         ( member(begin(Actions), BeginClauses),
-          member(cache_table(Name, Path), Actions)
+          member(cache_table(Name, Path, Backend), Actions)
         ),
-        NamePaths).
+        Triples).
 
-%% plawk_cache_entries(+Tables, +NamePaths, -CacheEntries, -PathGlobalsIR)
+%% plawk_cache_fn(+Backend, +Op, -FnName)
+%  The runtime function for a cache Op (load|commit) under a backend. The
+%  `file` backend uses the always-present LLVM-IR helpers; `lmdb` uses the
+%  external C functions linked from wam_cache_lmdb.c (+ -llmdb) when the
+%  build detects an lmdb-backed store.
+plawk_cache_fn(lmdb, load, wam_cache_load_lmdb) :- !.
+plawk_cache_fn(lmdb, commit, wam_cache_commit_lmdb) :- !.
+plawk_cache_fn(_File, load, wam_cache_load).
+plawk_cache_fn(_File, commit, wam_cache_commit).
+
+%% plawk_cache_entries(+Tables, +Triples, -CacheEntries, -PathGlobalsIR)
 %  Resolve each cache-backed table name to its index in the plan's table
 %  list, emit a private string global @.plawk_cache_path_<idx> for its path,
-%  and record cache(Index, BytesLen) so setup/commit can reference the
-%  global. A declared name absent from the plan (never used) is skipped.
-plawk_cache_entries(Tables, NamePaths, CacheEntries, PathGlobalsIR) :-
-    findall(cache(Index, BytesLen)-Global,
-        ( member(Name-Path, NamePaths),
+%  and record cache(Index, BytesLen, Backend) so setup/commit can reference
+%  the global and pick the backend function. A declared name absent from the
+%  plan (never used) is skipped. PathGlobalsIR also carries external declares
+%  for any lmdb backend functions in use.
+plawk_cache_entries(Tables, Triples, CacheEntries, PathGlobalsIR) :-
+    findall(cache(Index, BytesLen, Backend)-Global,
+        ( member(ct(Name, Path, Backend), Triples),
           nth0(Index, Tables, Name),
           format(atom(GName), 'plawk_cache_path_~w', [Index]),
           llvm_emit_c_string_global(GName, Path, Global, _Len, BytesLen)
         ),
         Pairs),
     pairs_keys_values(Pairs, CacheEntries, Globals),
-    atomic_list_concat(Globals, '\n', PathGlobalsIR).
+    ( memberchk(cache(_, _, lmdb), CacheEntries)
+    ->  LmdbDecls = ['declare void @wam_cache_load_lmdb(%WamAssocI64Table*, i8*)',
+                     'declare void @wam_cache_commit_lmdb(%WamAssocI64Table*, i8*)']
+    ;   LmdbDecls = []
+    ),
+    append(Globals, LmdbDecls, AllGlobals),
+    atomic_list_concat(AllGlobals, '\n', PathGlobalsIR).
 
 %% plawk_cache_commit_lines(+CacheEntries, -IR)
-%  A @wam_cache_commit call per cache-backed table, writing the final table
-%  back to its store. Emitted at the top of the END phase (after the record
-%  loop, table still live), so the committed state is the completed pass.
+%  A commit call per cache-backed table, writing the final table back to its
+%  store. Emitted at the top of the END phase (after the record loop, table
+%  still live), so the committed state is the completed pass.
 plawk_cache_commit_lines(CacheEntries, IR) :-
     findall(Line,
-        ( member(cache(Index, BytesLen), CacheEntries),
+        ( member(cache(Index, BytesLen, Backend), CacheEntries),
+          plawk_cache_fn(Backend, commit, CommitFn),
           format(atom(Line),
-              '  call void @wam_cache_commit(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
-              [Index, BytesLen, BytesLen, Index])
+              '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
+              [CommitFn, Index, BytesLen, BytesLen, Index])
         ),
         Lines),
     atomic_list_concat(Lines, '\n', IR).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -849,10 +849,11 @@ quoted_string_escape_codes([0'\\, Code]) -->
 % commits it at END. Tried before the plain BEGIN clause. See
 % PLAWK_MULTIPASS_CACHE.md.
 begin_clauses([begin(Actions)]) -->
-    "BEGIN", ws, "cache", ws, "(", ws, quoted_string(PathCodes), ws, ")", ws,
+    "BEGIN", ws, "cache", ws, "(", ws, quoted_string(PathCodes), ws,
+    cache_backend(Backend), ws, ")", ws,
     "{", ws,
     { string_codes(Path, PathCodes) },
-    cache_decl_list(Path, Actions),
+    cache_decl_list(Path, Backend, Actions),
     ws, "}", ws,
     !.
 begin_clauses([begin(Actions)]) -->
@@ -868,14 +869,23 @@ begin_clauses([begin(Actions)]) -->
 begin_clauses([]) -->
     [].
 
-cache_decl_list(Path, [cache_table(Name, Path) | Rest]) -->
+% Optional backend selector inside cache(...): `backend "lmdb"` (durable
+% LMDB store) or `backend "file"` (the default portable file backend).
+cache_backend(Backend) -->
+    ws, "backend", required_ws, quoted_string(BCodes),
+    { atom_codes(Backend, BCodes) },
+    !.
+cache_backend(file) -->
+    [].
+
+cache_decl_list(Path, Backend, [cache_table(Name, Path, Backend) | Rest]) -->
     "declare", required_ws, identifier(Name),
-    cache_decl_list_rest(Path, Rest).
-cache_decl_list_rest(Path, [cache_table(Name, Path) | Rest]) -->
+    cache_decl_list_rest(Path, Backend, Rest).
+cache_decl_list_rest(Path, Backend, [cache_table(Name, Path, Backend) | Rest]) -->
     ws, cache_decl_sep, ws, "declare", required_ws, identifier(Name),
     !,
-    cache_decl_list_rest(Path, Rest).
-cache_decl_list_rest(_Path, []) -->
+    cache_decl_list_rest(Path, Backend, Rest).
+cache_decl_list_rest(_Path, _Backend, []) -->
     [].
 cache_decl_sep --> ";", !.
 cache_decl_sep --> [].

--- a/src/unifyweaver/targets/wam_cache_lmdb.c
+++ b/src/unifyweaver/targets/wam_cache_lmdb.c
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0
+ * Copyright (c) 2026 John William Creighton (@s243a)
+ *
+ * LMDB backend for the plawk multi-pass persistent cache
+ * (PLAWK_MULTIPASS_CACHE.md, phase 5). Compiled and linked into a plawk
+ * binary ONLY when a program declares a `backend "lmdb"` cache store
+ * (the plawk build appends this file and -llmdb in that case); otherwise
+ * the pure-LLVM file-backed backend (@wam_cache_load / _commit, emitted as
+ * IR) is used and nothing here is linked.
+ *
+ * Like the file backend, the cache handle is the runtime's in-memory
+ * %WamAssocI64Table*: load reads every (key,value) i64 pair from the LMDB
+ * store into the table, commit writes the table back. This is eager
+ * materialisation -- the LMDB file is the durable format and the working
+ * set is the assoc table. (Lazy per-access LMDB -- the larger-than-RAM
+ * story -- is a later refinement over the same surface.)
+ *
+ * The store is a single file (MDB_NOSUBDIR), so `cache("run.lmdb")` names
+ * one file (plus an LMDB "run.lmdb-lock" sidecar), matching the file
+ * backend's one-path-one-store shape. */
+
+#include <lmdb.h>
+#include <stdint.h>
+#include <stddef.h>
+
+/* The runtime's assoc-table helpers (defined as LLVM IR in the same
+ * binary). The table pointer is opaque here; we only thread it through. */
+extern int64_t wam_assoc_i64_set(void *table, int64_t key, int64_t value);
+extern int64_t wam_assoc_i64_iter_next(void *table, int64_t start);
+extern int64_t wam_assoc_i64_key_at(void *table, int64_t idx);
+extern int64_t wam_assoc_i64_value_at(void *table, int64_t idx);
+
+/* 1 GiB map ceiling -- generous for a scratch/aggregation store; the file
+ * grows only as needed. A later knob can make this configurable. */
+#define WAM_CACHE_LMDB_MAPSIZE ((size_t)1 << 30)
+
+static int wam_cache_lmdb_env(const char *path, unsigned int flags,
+                              MDB_env **env_out) {
+    MDB_env *env;
+    if (mdb_env_create(&env)) return -1;
+    mdb_env_set_mapsize(env, WAM_CACHE_LMDB_MAPSIZE);
+    if (mdb_env_open(env, path, MDB_NOSUBDIR | flags, 0644)) {
+        mdb_env_close(env);
+        return -1;
+    }
+    *env_out = env;
+    return 0;
+}
+
+/* Load every i64->i64 pair from the store at `path` into `table`. A missing
+ * store is a no-op, so an unseeded cache starts empty and a pre-populated
+ * one (a prior run, or a peer that wrote the same store) is read in. */
+void wam_cache_load_lmdb(void *table, const char *path) {
+    MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
+    MDB_cursor *cur;
+    MDB_val k, v;
+    if (wam_cache_lmdb_env(path, MDB_RDONLY, &env)) return;
+    if (mdb_txn_begin(env, NULL, MDB_RDONLY, &txn)) { mdb_env_close(env); return; }
+    if (mdb_dbi_open(txn, NULL, 0, &dbi)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
+    if (mdb_cursor_open(txn, dbi, &cur)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
+    while (mdb_cursor_get(cur, &k, &v, MDB_NEXT) == 0) {
+        if (k.mv_size == sizeof(int64_t) && v.mv_size == sizeof(int64_t)) {
+            int64_t key, val;
+            /* mv_data may be unaligned; copy out. */
+            __builtin_memcpy(&key, k.mv_data, sizeof(int64_t));
+            __builtin_memcpy(&val, v.mv_data, sizeof(int64_t));
+            wam_assoc_i64_set(table, key, val);
+        }
+    }
+    mdb_cursor_close(cur);
+    mdb_txn_abort(txn);
+    mdb_env_close(env);
+}
+
+/* Write every occupied entry of `table` back to the store at `path` in one
+ * write transaction (insert-or-replace per key). */
+void wam_cache_commit_lmdb(void *table, const char *path) {
+    MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
+    int64_t cursor = 0, slot;
+    if (wam_cache_lmdb_env(path, 0, &env)) return;
+    if (mdb_txn_begin(env, NULL, 0, &txn)) { mdb_env_close(env); return; }
+    if (mdb_dbi_open(txn, NULL, 0, &dbi)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
+    while ((slot = wam_assoc_i64_iter_next(table, cursor)) >= 0) {
+        int64_t key = wam_assoc_i64_key_at(table, slot);
+        int64_t val = wam_assoc_i64_value_at(table, slot);
+        MDB_val k = { sizeof(int64_t), &key };
+        MDB_val v = { sizeof(int64_t), &val };
+        mdb_put(txn, dbi, &k, &v, 0);
+        cursor = slot + 1;
+    }
+    mdb_txn_commit(txn);
+    mdb_env_close(env);
+}

--- a/tests/test_plawk_cache_lmdb.pl
+++ b/tests/test_plawk_cache_lmdb.pl
@@ -1,0 +1,127 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk multi-pass persistent cache, phase 5: the LMDB BACKEND. A cache
+% store declared `backend "lmdb"` is durable in a real LMDB file rather than
+% the portable flat file. The plawk build links the C LMDB runtime
+% (src/unifyweaver/targets/wam_cache_lmdb.c) and -llmdb when (and only when)
+% a program uses an lmdb-backed store; the file backend links neither. The
+% cache handle is still the in-memory assoc table (eager materialisation):
+% load reads all pairs from LMDB into the table, commit writes them back.
+%
+% Requires liblmdb at build+run time (apt-get install liblmdb-dev); the test
+% is skipped when clang cannot link -llmdb.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_lmdb_available :-
+    catch(( tmp_c(C, Bin),
+            setup_call_cleanup(open(C, write, S),
+                write(S, "#include <lmdb.h>\nint main(void){MDB_env*e;return mdb_env_create(&e);}\n"),
+                close(S)),
+            format(atom(Cmd), 'clang -w ~w -o ~w -llmdb 2>/dev/null', [C, Bin]),
+            process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+tmp_c(C, Bin) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_lmdb_probe.c', C),
+    directory_file_path(Tmp, 'uw_lmdb_probe', Bin).
+
+:- begin_tests(plawk_cache_lmdb).
+
+% `backend "lmdb"` parses to a cache_table with the lmdb backend; the
+% default (no backend clause) is `file`.
+test(lmdb_backend_parses) :-
+    plawk_parse_string(
+        "BEGIN cache(\"h.lmdb\" backend \"lmdb\") { declare c }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) print k, c[k] }\n",
+        program([begin([cache_table(c, "h.lmdb", lmdb)])], _, _)),
+    plawk_parse_string(
+        "BEGIN cache(\"h.db\") { declare c }\n{ c[$1]++ }\n",
+        program([begin([cache_table(c, "h.db", file)])], _, _)),
+    !.
+
+% End to end: an lmdb-backed histogram persists and accumulates across runs,
+% and writes a real LMDB file (data + -lock sidecar).
+test(lmdb_histogram_persists, [condition(clang_lmdb_available)]) :-
+    cl_dir(Dir),
+    directory_file_path(Dir, 'h.lmdb', Store),
+    directory_file_path(Dir, 'h.lmdb-lock', Lock),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    ( exists_file(Lock) -> delete_file(Lock) ; true ),
+    format(string(Src),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare c }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) print k, c[k] }\n", [Store]),
+    build_bin(Dir, 'hist', Src, Bin),
+    directory_file_path(Dir, 'in.txt', Input),
+    setup_call_cleanup(open(Input, write, SI, [encoding(utf8)]),
+        write(SI, "a\na\nb\n"), close(SI)),
+    run_sorted(Bin, [Input], S1), assertion(S1 == ["a 2", "b 1"]),
+    run_sorted(Bin, [Input], S2), assertion(S2 == ["a 4", "b 2"]),
+    % A genuine LMDB store was created (single-file: data + lock sidecar).
+    assertion(exists_file(Store)),
+    assertion(exists_file(Lock)),
+    !.
+
+% The store written by one compiled binary is read by a SEPARATELY compiled
+% binary: LMDB durability across rebuilds (pre-population).
+test(lmdb_store_survives_rebuild, [condition(clang_lmdb_available)]) :-
+    cl_dir(Dir),
+    directory_file_path(Dir, 'shared.lmdb', Store),
+    directory_file_path(Dir, 'shared.lmdb-lock', Lock),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    ( exists_file(Lock) -> delete_file(Lock) ; true ),
+    format(string(Src),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare c }\n\c
+         { c[$1]++ }\n\c
+         END { for (k in c) print k, c[k] }\n", [Store]),
+    directory_file_path(Dir, 'seed.txt', SeedIn),
+    setup_call_cleanup(open(SeedIn, write, S0, [encoding(utf8)]),
+        write(S0, "x\nx\nx\n"), close(S0)),
+    build_bin(Dir, 'writer', Src, WriterBin),
+    run_sorted(WriterBin, [SeedIn], _),
+    build_bin(Dir, 'reader', Src, ReaderBin),
+    directory_file_path(Dir, 'more.txt', MoreIn),
+    setup_call_cleanup(open(MoreIn, write, S1, [encoding(utf8)]),
+        write(S1, "x\n"), close(S1)),
+    run_sorted(ReaderBin, [MoreIn], S), assertion(S == ["x 4"]),
+    !.
+
+:- end_tests(plawk_cache_lmdb).
+
+% --- helpers ---------------------------------------------------------------
+
+cl_dir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_cache_lmdb', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_bin(Dir, Name, Src, Bin) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0).
+
+run_sorted(Bin, Args, Sorted) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_plawk_cache_surface.pl
+++ b/tests/test_plawk_cache_surface.pl
@@ -30,7 +30,7 @@ test(cache_block_parses) :-
         "BEGIN cache(\"h.db\") { declare c }\n\c
          { c[$1]++ }\n\c
          END { for (k in c) print k, c[k] }\n",
-        program([begin([cache_table(c, "h.db")])],
+        program([begin([cache_table(c, "h.db", file)])],
             [rule(always, [inc_assoc(var(c), field(1))])],
             [end([for_in(var(k), var(c),
                 [print([var(k), assoc(var(c), var(k))])])])])),
@@ -40,7 +40,7 @@ test(cache_block_parses) :-
 test(multi_declare_parses) :-
     plawk_parse_string(
         "BEGIN cache(\"s.db\") { declare a ; declare b }\n{ a[$1]++ }\n",
-        program([begin([cache_table(a, "s.db"), cache_table(b, "s.db")])],
+        program([begin([cache_table(a, "s.db", file), cache_table(b, "s.db", file)])],
             _, _)),
     !.
 


### PR DESCRIPTION
## LMDB cache backend — stacked PR 1 of 2

Builds on the merged file backend (#3676/#3677). A cache store can now be durable in a **real LMDB database**, selected per store:

```awk
BEGIN cache("run.lmdb" backend "lmdb") { declare c }
{ c[$1]++ }
END { for (k in c) print k, c[k] }
```

The default (no `backend`, or `backend "file"`) stays the portable pure-LLVM-IR file backend; `backend "lmdb"` links a small C runtime + `liblmdb`.

### Pieces

- **Runtime** — `src/unifyweaver/targets/wam_cache_lmdb.c`: `wam_cache_load_lmdb` / `wam_cache_commit_lmdb` over a single-file (`MDB_NOSUBDIR`) store, bridging to the runtime's assoc-table helpers. The handle stays the in-memory assoc table (**eager materialisation**): load reads every i64→i64 pair from LMDB into the table, commit writes them back in one txn. Writing the backend in **C** lets `lmdb.h` supply the `MDB_val` layout and `MDB_cursor_op` values — no hand-guessed struct/enum constants in IR.
- **Parser** — optional `backend "lmdb"|"file"` inside `cache(...)`; `cache_table/2` → `cache_table/3` carrying the backend.
- **Codegen** — `plawk_cache_fn/3` picks the load/commit function per backend; an lmdb store emits external declares and the setup/END emitters call the `_lmdb` variants.
- **Build** — `bin/plawk` detects an lmdb-backed store and appends the C file + `-llmdb` to the clang invocation (one `.ll` + one `.c`). Non-lmdb programs link neither, so the pure-IR path is byte-for-byte unchanged.

### Verification

`liblmdb` verified present here (0.9.31). `tests/test_plawk_cache_lmdb.pl` (3/3): parse coverage, cross-run accumulation writing a genuine LMDB file (data + `-lock` sidecar), and persistence across a **separate recompile**; skipped when clang can't link `-llmdb`. The file-backend surface test is updated for `cache_table/3` and still passes 4/4.

### Scope

Eager materialisation (LMDB as the durable format; working set is the assoc table), i64 tables, single pass. The lazy per-access / larger-than-RAM mode is a later refinement over the same surface.

**Merge order:** this first, then the stacked docs/setup PR (auto-retargets to base after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_