### PR TITLE
docs: multipass cache — phases 1 & 5 landed; liblmdb setup script

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -42,6 +42,31 @@ pass { print $1, $2 / total[$1] }     # pass 2: normalise each record by the
 END   { }
 ```
 
+## Status (implemented so far)
+
+- **Phase 1 — cache primitive + single-pass surface: LANDED.** A backed
+  block `BEGIN cache("path") { declare NAME }` makes an assoc table durable:
+  the codegen creates the table as usual, loads the store into it at setup,
+  and commits it at the top of the END phase. A histogram accumulates across
+  separate runs / rebuilds against the same store. Tables only for now
+  (scalars unimplemented); single pass; the generic END-for-in driver.
+- **Phase 5 — LMDB backend: LANDED.** `BEGIN cache("x.lmdb" backend "lmdb")`
+  stores in a real single-file LMDB database instead of the flat file. A
+  small C runtime (`src/unifyweaver/targets/wam_cache_lmdb.c`) is linked with
+  `-llmdb` only when a program selects it; the file backend links nothing
+  new. Install liblmdb with `scripts/setup/setup_lmdb.sh`.
+
+The runtime as built differs from the aspirational ABI in §4: rather than a
+full byte-span get/put/iterate ABI, the cache handle **is** the in-memory
+`%WamAssocI64Table`, and each backend supplies just `load` (store → table)
+and `commit` (table → store); the assoc helpers drive the in-loop i64 ops.
+This is eager materialisation — correct and simple, RAM-bound. The lazy,
+per-access, larger-than-RAM path (and the multi-table / namespace / secondary
+-index designs below) will grow the ABI toward §4 as those phases land.
+
+**Not yet:** multiple `pass { }` blocks (Phase 2), configurable readers
+(Phase 4), the query reader (Phase 6), namespaces/`eager`/secondary indexes.
+
 ## 1. The determinism model (the reminder, and why it constrains this)
 
 `PLAWK_PHILOSOPHY.md §2` states the stance precisely; the operative facts:
@@ -405,8 +430,8 @@ Each phase is a shippable PR with tests. Phases 1–2 are independent enough
 to land in either order, but 1 first is lower-risk (a primitive with a
 single-pass test before any driver surgery).
 
-- **Phase 1 — the cache runtime primitive + single-pass surface.** Add the
-  `@wam_cache_*` ABI and the fallback (file-backed) backend; wire a
+- **Phase 1 — the cache runtime primitive + single-pass surface. LANDED.**
+  Add the `@wam_cache_*` ABI and the fallback (file-backed) backend; wire a
   `BEGIN cache("...") { declare NAME }` block so `arr[k]++` / `arr[k]=v` /
   `arr[k]` / `for (k in arr)` route through the store **within a single
   pass** (lazy materialisation; `eager` deferred to a later phase). Proves
@@ -442,7 +467,7 @@ single-pass test before any driver surgery).
   gain the spool sink. Test: pass 1 emits a filtered/derived stream, pass 2
   `over prev` consumes it.
 
-- **Phase 5 — LMDB backend + materialisation modes.** Swap the fallback for
+- **Phase 5 — LMDB backend + materialisation modes. LANDED (eager).** Swap the fallback for
   `liblmdb` behind the build flag; add a test that exceeds a small RAM cap
   to demonstrate the lazy memory-mapped path, and wire the per-variable
   `eager` marker (load fully at open). Test: an `eager` scalar/table reads

--- a/scripts/setup/setup_lmdb.sh
+++ b/scripts/setup/setup_lmdb.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# scripts/setup/setup_lmdb.sh
+# Install liblmdb for the plawk multi-pass cache LMDB backend.
+#
+# The plawk LLVM/WAM target has two persistent-cache backends
+# (PLAWK_MULTIPASS_CACHE.md): a portable file backend (the default, pure
+# LLVM IR, no dependency) and an LMDB backend (`BEGIN cache("x.lmdb")
+# backend "lmdb")`). Only the LMDB backend needs liblmdb, and only at build
+# and run time for programs that select it. This script installs the dev
+# package (header + shared lib) so `clang ... -llmdb` links.
+
+set -e
+
+echo "=========================================="
+echo "liblmdb setup for UnifyWeaver (plawk LMDB cache backend)"
+echo "=========================================="
+echo ""
+
+# Already present?
+if [ -f /usr/include/lmdb.h ] || [ -f /usr/local/include/lmdb.h ]; then
+    if ldconfig -p 2>/dev/null | grep -qi 'liblmdb'; then
+        echo "✅ liblmdb already installed (header + shared library present)."
+        exit 0
+    fi
+fi
+
+install_apt()    { sudo apt-get update -qq && sudo apt-get install -y liblmdb-dev; }
+install_dnf()    { sudo dnf install -y lmdb-devel; }
+install_yum()    { sudo yum install -y lmdb-devel; }
+install_pacman() { sudo pacman -S --noconfirm lmdb; }
+install_apk()    { sudo apk add lmdb-dev; }
+install_brew()   { brew install lmdb; }
+
+if   command -v apt-get >/dev/null 2>&1; then echo "Using apt-get...";  install_apt
+elif command -v dnf     >/dev/null 2>&1; then echo "Using dnf...";      install_dnf
+elif command -v yum     >/dev/null 2>&1; then echo "Using yum...";      install_yum
+elif command -v pacman  >/dev/null 2>&1; then echo "Using pacman...";   install_pacman
+elif command -v apk     >/dev/null 2>&1; then echo "Using apk...";      install_apk
+elif command -v brew    >/dev/null 2>&1; then echo "Using brew...";     install_brew
+else
+    echo "❌ No supported package manager found."
+    echo "   Install liblmdb (dev package) manually: it must provide lmdb.h"
+    echo "   and a linkable liblmdb so 'clang ... -llmdb' works."
+    exit 1
+fi
+
+echo ""
+if [ -f /usr/include/lmdb.h ] || [ -f /usr/local/include/lmdb.h ]; then
+    echo "✅ liblmdb installed. plawk programs using backend \"lmdb\" can now build."
+else
+    echo "⚠️  Install completed but lmdb.h was not found in a standard include path."
+    echo "   You may need to point clang at its location."
+fi


### PR DESCRIPTION
## Docs + reproducibility — stacked PR 2 of 2 (on top of #3678)

> **Base**: this targets the LMDB-backend branch (#3678), not the main feature branch. GitHub auto-retargets it to the feature branch once #3678 merges. Merge #3678 first.

- **`PLAWK_MULTIPASS_CACHE.md`** — a **Status** section recording what actually shipped: Phase 1 (file backend + single-pass surface) and Phase 5 (LMDB backend, eager). It also notes, honestly, that the built runtime reuses the in-memory assoc table with per-backend `load`/`commit` rather than the fuller byte-span ABI sketched in §4 — that ABI grows as the lazy / namespace / secondary-index phases land. Tagged the Phase 1 and Phase 5 list entries **LANDED**.
- **`scripts/setup/setup_lmdb.sh`** — installs `liblmdb` (dev package) across apt/dnf/yum/pacman/apk/brew, mirroring the existing `scripts/setup/setup_litedb.sh` convention. Only the LMDB backend needs it; the default file backend has no dependency. Idempotent (no-ops if already installed).

No code changes — docs and a setup script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_