### PR TITLE
WAM/LLVM plawk: parser + AST for `pass { }` blocks (phase 2, PR-A)

### DIFF
--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -92,12 +92,13 @@ build(File, Out0, KeepLL) :-
     ;   Out = Out0
     ),
     read_file_to_string(File, Src, []),
-    (   catch(plawk_parse_source(Src, Program, Clauses), ParseErr,
+    (   catch(plawk_parse_source(Src, Program0, Clauses), ParseErr,
             ( report_error('parse error', File, ParseErr), halt(2) ))
     ->  true
     ;   format(user_error, 'plawk: parse error in ~w~n', [File]),
         halt(2)
     ),
+    normalize_passes(File, Program0, Program),
     (   Clauses == []
     ->  Preds = [user:plawk_cli_marker/0]
     ;   (   plawk_prolog_block_preds(Clauses, Preds)
@@ -223,6 +224,23 @@ lmdb_c_runtime_file(CFile) :-
     module_property(wam_llvm_target, file(TargetPl)),
     file_directory_name(TargetPl, Dir),
     directory_file_path(Dir, 'wam_cache_lmdb.c', CFile).
+
+% Multi-pass normalisation (PLAWK_MULTIPASS_CACHE.md phase 2). A single
+% `pass { ... }` block is exactly today's main loop, so it lowers to the
+% ordinary single-pass program and the whole existing pipeline applies. Two
+% or more passes need the multi-pass driver (a focused follow-on); until it
+% lands they are reported as unsupported rather than mis-compiled.
+normalize_passes(_File, program_passes(Begin, [pass(Rules)], End),
+        program(Begin, Rules, End)) :-
+    !.
+normalize_passes(File, program_passes(_Begin, Passes, _End), _) :-
+    is_list(Passes), length(Passes, N), N >= 2,
+    !,
+    format(user_error,
+        'plawk: ~w uses ~w pass blocks; multi-pass execution is not yet \c
+         implemented (single `pass { }` works today)~n', [File, N]),
+    halt(3).
+normalize_passes(_File, Program, Program).
 
 ll_path(Out, true, LLPath) :-
     !,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -162,6 +162,25 @@ plawk_program(Program) -->
 plawk_program(Program, FunctionClauses) -->
     plawk_program(Program, FunctionClauses, _DynEntries).
 
+% Multi-pass form (PLAWK_MULTIPASS_CACHE.md, phase 2): one or more explicit
+% `pass { ... }` blocks between BEGIN and END, each a full record loop with
+% its own actions. Produces program_passes(Begin, [pass(Rules), ...], End).
+% Tried before the single implicit-main form; the `pass` keyword is
+% unambiguous, and a program with no `pass` block falls through (the guard
+% requires at least one) to the ordinary program(...) clause.
+plawk_program(program_passes(BeginClauses, Passes, EndClauses),
+        FunctionClauses, DynEntries) -->
+    ws,
+    begin_clauses(BeginClauses),
+    function_defs(FunctionClauses),
+    dynentry_decls(DynEntries),
+    pass_clauses(Passes0),
+    { Passes0 = [_ | _] },
+    end_clauses(EndClauses0),
+    eos,
+    { maplist(plawk_pass_dynentry_rewrite(DynEntries), Passes0, Passes),
+      plawk_dynentry_rewrite_all(EndClauses0, DynEntries, EndClauses)
+    }.
 plawk_program(program(BeginClauses, Rules, EndClauses), FunctionClauses,
         DynEntries) -->
     ws,
@@ -174,6 +193,17 @@ plawk_program(program(BeginClauses, Rules, EndClauses), FunctionClauses,
     { plawk_dynentry_rewrite_all(Rules0, DynEntries, Rules),
       plawk_dynentry_rewrite_all(EndClauses0, DynEntries, EndClauses)
     }.
+
+% A `pass { ACTIONS }` block is one pass carrying a single always-rule with
+% those actions (per-pattern rules within a pass are a later extension).
+pass_clauses([pass([rule(always, Actions)]) | Rest]) -->
+    "pass", identifier_boundary, ws, action_block(Actions), ws,
+    pass_clauses(Rest).
+pass_clauses([]) -->
+    [].
+
+plawk_pass_dynentry_rewrite(DynEntries, pass(Rules0), pass(Rules)) :-
+    plawk_dynentry_rewrite_all(Rules0, DynEntries, Rules).
 
 %% dynentry_decls(-Names)//
 %

--- a/tests/test_plawk_passes.pl
+++ b/tests/test_plawk_passes.pl
@@ -1,0 +1,108 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk multi-pass, phase 2 PR-A: parser + AST for `pass { }` blocks. A
+% program with one or more `pass { }` blocks parses to
+% program_passes(Begin, [pass(Rules), ...], End); a bare-main program is
+% unchanged (program(...)). A SINGLE pass is exactly today's main loop, so
+% the plawk CLI normalises it to the ordinary single-pass program and the
+% whole existing pipeline compiles+runs it. Two-or-more passes need the
+% multi-pass driver (PR-B); until then the CLI reports them as unsupported
+% rather than mis-compiling. See PLAWK_MULTIPASS_CACHE.md.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_passes).
+
+% One `pass { }` block -> program_passes with a single pass.
+test(single_pass_parses) :-
+    plawk_parse_string(
+        "pass { c[$1]++ }\nEND { for (k in c) print k, c[k] }\n",
+        program_passes([], [pass([rule(always, [inc_assoc(var(c), field(1))])])],
+            [end([for_in(var(k), var(c),
+                [print([var(k), assoc(var(c), var(k))])])])])),
+    !.
+
+% Two `pass { }` blocks -> program_passes with two passes, in order.
+test(two_passes_parse) :-
+    plawk_parse_string(
+        "pass { a[$1]++ }\npass { print $1 }\n",
+        program_passes([],
+            [pass([rule(always, [inc_assoc(var(a), field(1))])]),
+             pass([rule(always, [print([field(1)])])])],
+            [])),
+    !.
+
+% A bare-main program is untouched -- still program(...), not program_passes.
+test(bare_main_unchanged) :-
+    plawk_parse_string(
+        "{ c[$1]++ }\nEND { for (k in c) print k, c[k] }\n",
+        program(_, _, _)),
+    \+ plawk_parse_string(
+        "{ c[$1]++ }\nEND { for (k in c) print k, c[k] }\n",
+        program_passes(_, _, _)),
+    !.
+
+% A single pass compiles and runs exactly like the equivalent bare main.
+test(single_pass_runs_like_main, [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "pass { c[$1]++ }\nEND { for (k in c) print k, c[k] }\n",
+    build_bin(Dir, 'one', Src, Bin, 0),
+    directory_file_path(Dir, 'in.txt', Input),
+    setup_call_cleanup(open(Input, write, S, [encoding(utf8)]),
+        write(S, "a\na\nb\n"), close(S)),
+    run_sorted(Bin, [Input], Out),
+    assertion(Out == ["a 2", "b 1"]),
+    !.
+
+% Two passes are diagnosed as not-yet-implemented (exit 3), not mis-built.
+test(two_passes_reported_unsupported) :-
+    pdir(Dir),
+    Src = "pass { c[$1]++ }\npass { print $1 }\nEND { for (k in c) print k, c[k] }\n",
+    directory_file_path(Dir, 'two.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    directory_file_path(Dir, 'two_bin', Bin),
+    cli([build, Prog, '-o', Bin], 3),
+    !.
+
+:- end_tests(plawk_passes).
+
+% --- helpers ---------------------------------------------------------------
+
+pdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_passes', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_bin(Dir, Name, Src, Bin, ExpectedStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], ExpectedStatus).
+
+run_sorted(Bin, Args, Sorted) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Multi-pass foundation — parser + AST (phase 2, PR-A of the stack)

First step of Phase 2 (multiple passes) from `PLAWK_MULTIPASS_CACHE.md`. **Additive** — lands the surface/AST and the single-pass path without touching the driver, so it's low-risk and fully tested. The multi-pass **driver** is PR-B (the focused follow-on).

### What changed

- **Parser**: a program with one or more `pass { … }` blocks parses to `program_passes(Begin, [pass(Rules), …], End)`; each pass carries an always-rule with its actions. A bare-main program is unchanged (still `program(…)`). The multi-pass clause is tried first but **guarded** to require ≥1 `pass` block, so a `pass`-free program backtracks to the ordinary clause — no churn to the many `program(…)` driver clauses.
- **CLI** (`normalize_passes` in `bin/plawk`): a **single** `pass { }` is exactly today's main loop, so it lowers to the ordinary single-pass program and the whole existing pipeline compiles + runs it identically. **Two or more** passes need the per-pass-function driver (PR-B); until then they're reported as unsupported (exit 3) rather than mis-compiled.

### Why this shape

Running N passes in one `main` would collide the driver's fixed labels (`%loop`, `continue_loop`, …) and couldn't share the `main`-local tables. PR-B will emit **each pass as its own function** (function-local labels, no collision) with **BEGIN-scoped state globalized** to persist across passes, and `main` orchestrating BEGIN → pass_1 → … → END. This PR lays the AST that PR-B consumes.

### Tests

`tests/test_plawk_passes.pl` (5/5): single/two-pass parse, bare-main unchanged (not `program_passes`), single-pass runs identically to a bare main, two-pass diagnosed with exit 3. Regression: cache surface (4/4), for-in filter (7/7), binary records (14/14).

Next: **PR-B** — the multi-pass driver (per-pass functions + globalized cross-pass state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_