### PR TITLE
WAM/LLVM plawk: multi-pass execution driver (phase 2, PR-B)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -5,10 +5,38 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk multi-pass processing over a persistent cache
 
-**Status**: design. No implementation yet. Captures the determinism
-rationale, the surface, the runtime ABI, and a phased rollout so the
-context survives across sessions. The LLVM target has **no cache/LMDB
-layer today** — that runtime primitive is the first build step.
+**Status**: partially implemented. Captures the determinism rationale, the
+surface, the runtime ABI, and a phased rollout. **Landed:** the persistent
+cache (file backend + `BEGIN cache("path") { declare NAME }` surface, phase
+1); the LMDB backend (`backend "lmdb"`, phase 5, eager); and multi-pass
+execution (`pass { }` blocks over a shared assoc table, phase 2). **Not yet:**
+cross-pass scalars, configurable readers (phase 4), the query reader
+(phase 6), namespaces / `eager` / secondary indexes. See the per-phase
+status tags in §5.
+
+## Implemented surface (quick reference)
+
+```awk
+# persistent cache (phase 1/5): counts survive across runs of the binary
+BEGIN cache("hist.db") { declare c }                 # file backend (default)
+BEGIN cache("hist.lmdb" backend "lmdb") { declare c } # LMDB backend
+{ c[$1]++ }
+END { for (k in c) print k, c[k] }
+
+# multi-pass (phase 2): read the input once per pass into a shared table
+pass { c[$1]++ }
+pass { c[$1]++ }        # input re-read; counts accumulate across passes
+END { for (k in c) print k, c[k] }
+```
+
+Multi-pass v1 lowers each `pass` to its own function (fixed per-record SSA
+`%line` / loop labels are then function-local and cannot collide), creates
+the shared assoc table once in `main`, threads it to each pass as a
+parameter, and reads it back in the END for-in. It requires a **file**
+argument (each pass re-opens it; stdin is not re-openable), a single shared
+table, and always-rule pass bodies. Combining a cache-backed table with
+multi-pass, cross-pass scalars, per-record output passes, and reader
+selection are follow-ons.
 
 ## TL;DR
 
@@ -414,16 +442,19 @@ single-pass test before any driver surgery).
   run) with no multi-pass machinery yet. Test: a histogram whose counts
   survive across two separate binary invocations against the same store.
 
-- **Phase 2 — variable scoping + multiple `pass { }` blocks.** Parser:
-  `program(Begin, Passes, End)` where `Passes` is a list of rule-sets.
-  Scoping (§3.2): pass-local by default (reset per pass); `BEGIN`-introduced
-  variables persist in memory across passes. Driver: run the record loop
-  once per pass, re-scanning input between passes, threading loaded objects
-  / foreign wrappers / resolved entries across passes (they already live in
-  process-global state, so this is mostly *not resetting* them). Test: the
-  normalise-by-total example with an **in-memory, `BEGIN`-declared** total —
-  impossible single-pass; here pass 1 fills it, pass 2 divides. (No cache
-  needed for this phase — it exercises in-memory cross-pass persistence.)
+- **Phase 2 — multiple `pass { }` blocks. LANDED (v1).** Parser:
+  `program_passes(Begin, [pass(Rules), ...], End)` (PR-A). Driver (PR-B):
+  each pass is emitted as its own function so the fixed per-record SSA
+  (`%line`) and loop labels are function-local and cannot collide; `main`
+  creates the shared assoc table once, threads it to each pass as a
+  parameter, re-opens the input file per pass, and reads the table back in
+  the END for-in. Verified: reading the input twice into a shared counter
+  doubles the counts (`tests/test_plawk_multipass.pl`). v1 scope: text mode,
+  a single shared table, always-rule pass bodies, `END { for (k in arr)
+  print ... }`, a file argument. **Deferred:** cross-pass *scalars* (need
+  loop-phi threading between pass functions, or scalar globals), per-record
+  *output* passes (per-record `arr[k]` reads), multiple tables, and pairing
+  multi-pass with a cache-backed / `BEGIN`-declared table.
 
 - **Phase 3 — cache as the inter-pass channel (durable payoff).** Combine
   1+2: a table declared in a `BEGIN cache("db")` block written in pass 1 and

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -109,7 +109,13 @@ build(File, Out0, KeepLL) :-
             halt(2)
         )
     ),
-    check_foreign_calls(File, Program, Preds),
+    % Multi-pass programs (program_passes) do not go through the foreign /
+    % dyncall surfaces in v1; the program(...) predicates below only match
+    % single-pass programs, so skip the foreign-call check for passes.
+    (   Program = program_passes(_, _, _)
+    ->  true
+    ;   check_foreign_calls(File, Program, Preds)
+    ),
     ll_path(Out, KeepLL, LLPath),
     file_base_name(Out, OutBase),
     % A program that uses dyncall(...) or dyncall_at(...) needs the .wamo
@@ -171,7 +177,15 @@ build(File, Out0, KeepLL) :-
               with_output_to(string(_CompilerChatter),
                   write_wam_llvm_project(Preds, ProjectOptions, LLPath)),
               wam_llvm_last_compile_counts(InstrCount, LabelCount),
-              (   plawk_program_native_driver_ir(Program, stdin_or_argv,
+              (   Program = program_passes(_, _, _)
+              ->  (   plawk_program_multipass_driver_ir(Program, DriverIR)
+                  ->  true
+                  ;   format(user_error,
+                          'plawk: ~w uses multi-pass features outside the \c
+                           current multi-pass surface~n', [File]),
+                      halt(3)
+                  )
+              ;   plawk_program_native_driver_ir(Program, stdin_or_argv,
                       [wam_vm(InstrCount, LabelCount) | EvalcOptions], DriverIR)
               ->  true
               ;   format(user_error,
@@ -233,13 +247,8 @@ lmdb_c_runtime_file(CFile) :-
 normalize_passes(_File, program_passes(Begin, [pass(Rules)], End),
         program(Begin, Rules, End)) :-
     !.
-normalize_passes(File, program_passes(_Begin, Passes, _End), _) :-
-    is_list(Passes), length(Passes, N), N >= 2,
-    !,
-    format(user_error,
-        'plawk: ~w uses ~w pass blocks; multi-pass execution is not yet \c
-         implemented (single `pass { }` works today)~n', [File, N]),
-    halt(3).
+% Two or more passes stay as program_passes and are lowered by the
+% dedicated multi-pass driver (see the compile step below).
 normalize_passes(_File, Program, Program).
 
 ll_path(Out, true, LLPath) :-

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4,6 +4,7 @@
 :- module(plawk_native_codegen, [
     plawk_program_native_driver_ir/3,
     plawk_program_native_driver_ir/4,
+    plawk_program_multipass_driver_ir/2,
     plawk_program_foreign_specs/3,
     plawk_program_foreign_specs/4,
     plawk_program_dyncall_arities/2,
@@ -3666,6 +3667,154 @@ plawk_action_blob_field(printf(_Format, PrintfArgs), Blob) :- member(Blob, Print
 plawk_action_blob_field(if(_Pattern, ThenActions, ElseActions), Blob) :-
     ( member(A, ThenActions) ; member(A, ElseActions) ),
     plawk_action_blob_field(A, Blob).
+
+%% plawk_program_multipass_driver_ir(+Program, -DriverIR) is semidet.
+%
+%  The multi-pass execution driver (PLAWK_MULTIPASS_CACHE.md phase 2, PR-B).
+%  A program with 2+ `pass { }` blocks runs the record loop once per pass
+%  over the (re-opened) input, then END. Each pass is emitted as its OWN
+%  function -- the per-record SSA (%line) and loop labels are fixed names,
+%  so N loops in one function would redefine them; a function per pass makes
+%  them function-local. Shared assoc tables are created once in main and
+%  threaded to each pass as a parameter (named %plawk_assoc_table_0 so the
+%  reused rule-chain IR references it unchanged); the END for-in reads the
+%  same tables back in main. Cross-pass state therefore lives in the shared
+%  table object, mutated by every pass.
+%
+%  v1 scope: text mode; a single shared assoc table; passes are always-rule
+%  bodies (no break/next); an `END { for (k in arr) print ... }`. The input
+%  must be a file argument (re-opened per pass); stdin is not re-openable
+%  (the design requires an explicit spool, a later phase).
+plawk_program_multipass_driver_ir(
+    program_passes(BeginClauses, Passes,
+        [end([for_in(var(LoopVar), var(ArrayName), [print(PrintFields)])])]),
+    DriverIR
+) :-
+    Passes = [_, _ | _],
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    integer(FieldSeparator),                 % text mode only (v1)
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    findall(R, ( member(pass(PassRules), Passes), member(R, PassRules) ), AllRules),
+    plawk_forin_end_plan(AllRules, LoopVar, ArrayName, [print(PrintFields)],
+        AssocPlan, PrintFields),
+    AssocPlan = assoc_plan([ArrayName], _),  % v1: one shared table
+    % Per-pass RecordIR (rule chain) against the single shared table.
+    findall(GlobalIR-ChainIR,
+        ( member(pass(PassRules), Passes),
+          plawk_forin_assoc_plan(PassRules, ArrayName, [], PassPlan),
+          plawk_assoc_rule_controls(PassPlan, PassControls),
+          plawk_assoc_break_close_ir(PassControls, ''),  % no break/next in v1
+          plawk_assoc_rule_chain_ir(PassPlan, FieldSeparator, GlobalIR, ChainIR)
+        ),
+        PassPairs),
+    pairs_keys_values(PassPairs, ChainGlobals, Chains),
+    % One function per pass; index them.
+    findall(FnIR,
+        ( nth0(I, Chains, Chain),
+          plawk_multipass_pass_fn_ir(I, Chain, FnIR) ),
+        FnIRs),
+    atomic_list_concat(FnIRs, '\n', PassFnsIR),
+    % main's pass-call sequence.
+    findall(CallLine,
+        ( nth0(I, Chains, _),
+          format(atom(CallLine),
+              '  call void @plawk_pass_~w(%Value %mp_path, %WamAssocI64Table* %plawk_assoc_table_0)',
+              [I]) ),
+        CallLines),
+    atomic_list_concat(CallLines, '\n', CallsIR),
+    % Setup (create the shared table), BEGIN, and the END for-in print.
+    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
+    plawk_forin_end_print_ir(LoopVar, ArrayName, PrintFields, AssocPlan,
+        FieldSeparator, OutputSeparator, EndPrintIR),
+    % Module globals: the chains' string/format globals, deduplicated.
+    sort(ChainGlobals, ChainGlobalsSorted),
+    atomic_list_concat(ChainGlobalsSorted, '\n', ChainGlobalsIR),
+    plawk_i64_end_print_globals(ChainGlobalsIR, RuntimeGlobals),
+    format(atom(DriverIR),
+'@.wam_stream_eof = private constant [12 x i8] c"end_of_file\\00"
+~w
+~w
+
+define i32 @main(i32 %argc, i8** %argv) {
+entry:
+~w
+  %have_arg = icmp sgt i32 %argc, 1
+  br i1 %have_arg, label %get_path, label %no_arg
+
+no_arg:
+  ret i32 20
+
+get_path:
+  %argv1_ptr = getelementptr i8*, i8** %argv, i64 1
+  %argv1 = load i8*, i8** %argv1_ptr
+  %argv1_len = call i64 @strlen(i8* %argv1)
+  %mp_path_id = call i64 @wam_intern_atom(i8* %argv1, i64 %argv1_len)
+  %mp_path0 = insertvalue %Value undef, i32 0, 0
+  %mp_path = insertvalue %Value %mp_path0, i64 %mp_path_id, 1
+~w
+  br label %end_print
+
+end_print:
+~w
+}
+',
+        [RuntimeGlobals, PassFnsIR, CombinedEntrySetupIR, CallsIR, EndPrintIR]).
+
+%% plawk_multipass_pass_fn_ir(+Index, +RecordIR, -IR)
+%  One pass as a self-contained function: open the shared input path, loop
+%  reading transient line records, run RecordIR per record (it branches to
+%  %continue_loop and references the %plawk_assoc_table_0 parameter), and
+%  return. Function-local labels/SSA, so passes never collide.
+plawk_multipass_pass_fn_ir(Index, RecordIR, IR) :-
+    format(atom(IR),
+'define void @plawk_pass_~w(%Value %mp_path, %WamAssocI64Table* %plawk_assoc_table_0) {
+entry:
+  %handle = call %Value @wam_stream_open_value(%Value %mp_path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle, label %ret_void
+
+check_handle:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %ret_void
+
+loop:
+  %line = call %Value @wam_stream_read_line_transient_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_payload = extractvalue %Value %line, 1
+  %line_is_int = icmp eq i32 %line_tag, 1
+  %line_bad_payload = icmp slt i64 %line_payload, 0
+  %line_bad = and i1 %line_is_int, %line_bad_payload
+  br i1 %line_bad, label %close_stream, label %check_line_atom
+
+check_line_atom:
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_eof, label %close_stream
+
+check_eof:
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %eof_s = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof, i32 0, i32 0
+  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
+  %is_eof = icmp eq i32 %eof_cmp, 0
+  br i1 %is_eof, label %close_stream, label %lowered_assoc
+
+lowered_assoc:
+~w
+
+continue_loop:
+  br label %loop
+
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br label %ret_void
+
+ret_void:
+  ret void
+}
+', [Index, RecordIR]).
 
 %% plawk_forin_end_plan(+Rules, +LoopVar, +ArrayName, +BodyActions, -AssocPlan, -PrintFields)
 %

--- a/scripts/setup/setup_lmdb.sh
+++ b/scripts/setup/setup_lmdb.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# scripts/setup/setup_lmdb.sh
+# Install liblmdb for the plawk multi-pass cache LMDB backend.
+#
+# The plawk LLVM/WAM target has two persistent-cache backends
+# (PLAWK_MULTIPASS_CACHE.md): a portable file backend (the default, pure
+# LLVM IR, no dependency) and an LMDB backend (`BEGIN cache("x.lmdb")
+# backend "lmdb")`). Only the LMDB backend needs liblmdb, and only at build
+# and run time for programs that select it. This script installs the dev
+# package (header + shared lib) so `clang ... -llmdb` links.
+
+set -e
+
+echo "=========================================="
+echo "liblmdb setup for UnifyWeaver (plawk LMDB cache backend)"
+echo "=========================================="
+echo ""
+
+if [ -f /usr/include/lmdb.h ] || [ -f /usr/local/include/lmdb.h ]; then
+    if ldconfig -p 2>/dev/null | grep -qi 'liblmdb'; then
+        echo "✅ liblmdb already installed (header + shared library present)."
+        exit 0
+    fi
+fi
+
+install_apt()    { sudo apt-get update -qq && sudo apt-get install -y liblmdb-dev; }
+install_dnf()    { sudo dnf install -y lmdb-devel; }
+install_yum()    { sudo yum install -y lmdb-devel; }
+install_pacman() { sudo pacman -S --noconfirm lmdb; }
+install_apk()    { sudo apk add lmdb-dev; }
+install_brew()   { brew install lmdb; }
+
+if   command -v apt-get >/dev/null 2>&1; then echo "Using apt-get...";  install_apt
+elif command -v dnf     >/dev/null 2>&1; then echo "Using dnf...";      install_dnf
+elif command -v yum     >/dev/null 2>&1; then echo "Using yum...";      install_yum
+elif command -v pacman  >/dev/null 2>&1; then echo "Using pacman...";   install_pacman
+elif command -v apk     >/dev/null 2>&1; then echo "Using apk...";      install_apk
+elif command -v brew    >/dev/null 2>&1; then echo "Using brew...";     install_brew
+else
+    echo "❌ No supported package manager found."
+    echo "   Install liblmdb (dev package) manually: it must provide lmdb.h"
+    echo "   and a linkable liblmdb so 'clang ... -llmdb' works."
+    exit 1
+fi
+
+echo ""
+if [ -f /usr/include/lmdb.h ] || [ -f /usr/local/include/lmdb.h ]; then
+    echo "✅ liblmdb installed. plawk programs using backend \"lmdb\" can now build."
+else
+    echo "⚠️  Install completed but lmdb.h was not found in a standard include path."
+    echo "   You may need to point clang at its location."
+fi

--- a/tests/test_plawk_multipass.pl
+++ b/tests/test_plawk_multipass.pl
@@ -1,0 +1,112 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk multi-pass, phase 2 PR-B: the multi-pass EXECUTION driver. A program
+% with 2+ `pass { }` blocks runs the record loop once per pass over the
+% (re-opened) input, sharing an assoc table across passes, then END. Each
+% pass is emitted as its own function (so the fixed per-record SSA %line and
+% loop labels are function-local and never collide); main creates the shared
+% table once and threads it to each pass as a parameter, and the END for-in
+% reads it back. Reading the same input twice into a shared counter table
+% therefore doubles the counts -- the observable proof of two passes.
+%
+% v1 scope: text mode; one shared assoc table; always-rule pass bodies
+% (no break/next); an `END { for (k in arr) print ... }`; a file argument
+% (re-opened per pass -- stdin is not re-openable). See
+% PLAWK_MULTIPASS_CACHE.md.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_multipass).
+
+% Two passes over the same input into one shared counter table double the
+% single-pass counts.
+test(two_passes_double, [condition(clang_available)]) :-
+    md(Dir),
+    Src = "pass { c[$1]++ }\npass { c[$1]++ }\nEND { for (k in c) print k, c[k] }\n",
+    build_bin(Dir, 'dbl', Src, Bin, 0),
+    write_input(Dir, "a\na\nb\n", In),
+    run_sorted(Bin, [In], S),
+    assertion(S == ["a 4", "b 2"]),
+    !.
+
+% Three passes triple; confirms the driver scales past two and re-reads each
+% time.
+test(three_passes_triple, [condition(clang_available)]) :-
+    md(Dir),
+    Src = "pass { c[$1]++ }\npass { c[$1]++ }\npass { c[$1]++ }\n\c
+           END { for (k in c) print k, c[k] }\n",
+    build_bin(Dir, 'tri', Src, Bin, 0),
+    write_input(Dir, "a\na\nb\n", In),
+    run_sorted(Bin, [In], S),
+    assertion(S == ["a 6", "b 3"]),
+    !.
+
+% A single `pass { }` is still normalised to the ordinary single-pass driver
+% (not the multi-pass one) and behaves like a bare main.
+test(single_pass_unchanged, [condition(clang_available)]) :-
+    md(Dir),
+    Src = "pass { c[$1]++ }\nEND { for (k in c) print k, c[k] }\n",
+    build_bin(Dir, 'one', Src, Bin, 0),
+    write_input(Dir, "a\na\nb\n", In),
+    run_sorted(Bin, [In], S),
+    assertion(S == ["a 2", "b 1"]),
+    !.
+
+% v1 supports a single shared table; two distinct tables across passes are
+% reported as outside the current multi-pass surface (exit 3), not
+% mis-compiled.
+test(two_tables_rejected) :-
+    md(Dir),
+    Src = "pass { a[$1]++ }\npass { b[$1]++ }\nEND { for (k in a) print k, a[k] }\n",
+    directory_file_path(Dir, 'twotbl.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    directory_file_path(Dir, 'twotbl_bin', Bin),
+    cli([build, Prog, '-o', Bin], 3),
+    !.
+
+:- end_tests(plawk_multipass).
+
+% --- helpers ---------------------------------------------------------------
+
+md(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_multipass', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_input(Dir, Text, In) :-
+    directory_file_path(Dir, 'in.txt', In),
+    setup_call_cleanup(open(In, write, S, [encoding(utf8)]),
+        write(S, Text), close(S)).
+
+build_bin(Dir, Name, Src, Bin, ExpectedStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], ExpectedStatus).
+
+run_sorted(Bin, Args, Sorted) :-
+    process_create(Bin, Args,
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, Out), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == 0),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Multi-pass execution — PR-B (on top of the merged PR-A #3680)

A program with 2+ `pass { }` blocks now **runs multiple passes over the input**, sharing an assoc table across passes:

```awk
pass { c[$1]++ }
pass { c[$1]++ }        # input re-read; counts accumulate
END { for (k in c) print k, c[k] }
```

Over `a a b` this prints `a 4, b 2` — double the single-pass `a 2, b 1`, the observable proof of two passes.

### How

Running N loops in one `main` would redefine the driver's fixed per-record SSA (`%line`) and loop labels. So the driver emits **each pass as its own function** (labels/SSA function-local, no collision); `main` creates the shared assoc table once, threads it to each pass as a `%plawk_assoc_table_0` **parameter** (so the reused rule-chain IR references it unchanged), **re-opens the input file per pass**, and reads the table back in the END for-in. Cross-pass state lives in the shared table, mutated by every pass.

- **Codegen**: `plawk_program_multipass_driver_ir` + a per-pass function emitter.
- **CLI**: `bin/plawk` routes 2+ passes to the multi-pass driver (a single `pass` still normalizes to the ordinary driver); the foreign-call check is skipped for `program_passes` (v1 has no foreign/dyncall surface).
- Recovered `scripts/setup/setup_lmdb.sh` (lost when the stacked #3679 didn't land) and refreshed the design-doc status (phases 1/2/5 landed).

### v1 scope (conservative — rejects, never mis-compiles)

Text mode, one shared table, always-rule pass bodies, `END { for (k in arr) print … }`, a **file** argument (each pass re-opens it; stdin isn't re-openable). Distinct tables, **cross-pass scalars**, **per-record output passes** (`print $1, arr[$1]`), and **multi-pass + cache-backed tables** are deferred — all reported as outside the multi-pass surface (exit 3) rather than mis-compiled.

### Tests

`tests/test_plawk_multipass.pl` (4/4): two-pass doubling, three-pass tripling, single-pass unchanged, two-table rejection. Regression: passes AST (5/5), cache surface (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_