### PR TITLE
Add Rust predicate_property/2 ISO errors

### DIFF
--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -429,24 +429,47 @@
     fn execute_predicate_property_builtin(&mut self) -> bool {
         let head_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
         let head = self.deref_heap(&self.deref_var(&head_raw));
+        if matches!(&head, Value::Unbound(_) | Value::Uninit) {
+            return self.raise_iso_error(Value::Atom(
+                "instantiation_error".to_string(),
+            ));
+        }
         let key = match self.dynamic_head_key(&head) {
             Some(key) => key,
-            None => return false,
+            None => {
+                return self.raise_iso_error(Value::Str(
+                    "type_error/2".to_string(),
+                    vec![Value::Atom("callable".to_string()), head],
+                ));
+            }
         };
         let in_labels = self.labels.contains_key(&key);
         let dynamic_count = self.dynamic_db.get(&key).map(Vec::len);
         let property_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
         let property = self.deref_heap(&self.deref_var(&property_raw));
-        let succeeds = match property {
+        if matches!(&property, Value::Unbound(_) | Value::Uninit) {
+            return self.raise_iso_error(Value::Atom(
+                "instantiation_error".to_string(),
+            ));
+        }
+        let succeeds = match &property {
             Value::Atom(name) => match name.as_str() {
                 "defined" => in_labels || dynamic_count.is_some(),
                 "dynamic" => dynamic_count.is_some(),
                 "static" => in_labels && dynamic_count.is_none(),
-                _ => false,
+                _ => {
+                    return self.raise_iso_error(Value::Str(
+                        "domain_error/2".to_string(),
+                        vec![
+                            Value::Atom("predicate_property".to_string()),
+                            property,
+                        ],
+                    ));
+                }
             },
             Value::Str(functor, args)
                 if args.len() == 1 &&
-                    Self::display_functor_name(&functor, 1) == "number_of_clauses" =>
+                    Self::display_functor_name(functor, 1) == "number_of_clauses" =>
             {
                 let count = match dynamic_count {
                     Some(count) => count,
@@ -455,7 +478,15 @@
                 };
                 self.unify(&args[0], &Value::Integer(count as i64))
             }
-            _ => false,
+            _ => {
+                return self.raise_iso_error(Value::Str(
+                    "domain_error/2".to_string(),
+                    vec![
+                        Value::Atom("predicate_property".to_string()),
+                        property,
+                    ],
+                ));
+            }
         };
         if succeeds {
             self.pc += 1;

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -384,6 +384,25 @@ fn generated_predicate_property_reads_static_labels() {
 }
 
 #[test]
+fn generated_predicate_property_errors_are_catchable() {
+    let (code, labels) = shared_wam_program();
+    for pred in [
+        "rust_predicate_property_head_instantiation_demo/1",
+        "rust_predicate_property_head_type_demo/1",
+        "rust_predicate_property_property_instantiation_demo/1",
+        "rust_predicate_property_domain_demo/1",
+    ] {
+        let mut vm = WamState::new(code.clone(), labels.clone());
+        vm.set_reg_str("A1", ub("Result"));
+        vm.pc = *vm.labels.get(pred).expect("generated error demo label");
+
+        assert!(vm.run(), "{} should catch its error", pred);
+        assert_eq!(vm.bindings.get("Result"), Some(&at("caught")));
+        assert!(vm.thrown_ball.is_none(), "{} should consume the error", pred);
+    }
+}
+
+#[test]
 fn predicate_property_reports_dynamic_status_and_clause_count() {
     let mut vm = WamState::new(vec![], HashMap::new());
     assert_clause(&mut vm, "assertz/1", fact("dyn", vec![at("red")]));

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -52,6 +52,34 @@ rust_current_predicate_arity_type_demo(Result) :-
 rust_predicate_property_demo(Head, Property) :-
     predicate_property(Head, Property).
 
+:- dynamic rust_predicate_property_head_instantiation_demo/1.
+rust_predicate_property_head_instantiation_demo(Result) :-
+    catch(
+        predicate_property(_, defined),
+        error(instantiation_error, _),
+        Result = caught).
+
+:- dynamic rust_predicate_property_head_type_demo/1.
+rust_predicate_property_head_type_demo(Result) :-
+    catch(
+        predicate_property(7, defined),
+        error(type_error(callable, _), _),
+        Result = caught).
+
+:- dynamic rust_predicate_property_property_instantiation_demo/1.
+rust_predicate_property_property_instantiation_demo(Result) :-
+    catch(
+        predicate_property(rust_clause_demo(_, _), _),
+        error(instantiation_error, _),
+        Result = caught).
+
+:- dynamic rust_predicate_property_domain_demo/1.
+rust_predicate_property_domain_demo(Result) :-
+    catch(
+        predicate_property(rust_clause_demo(_, _), unsupported),
+        error(domain_error(predicate_property, _), _),
+        Result = caught).
+
 :- dynamic rust_read_term_options_demo/2.
 rust_read_term_options_demo(Term, Names) :-
     read_term(Term, [variable_names(Names)]).
@@ -91,6 +119,10 @@ test(assert_retract_dynamic_db,
          user:rust_current_predicate_name_type_demo/1,
          user:rust_current_predicate_arity_type_demo/1,
          user:rust_predicate_property_demo/2,
+         user:rust_predicate_property_head_instantiation_demo/1,
+         user:rust_predicate_property_head_type_demo/1,
+         user:rust_predicate_property_property_instantiation_demo/1,
+         user:rust_predicate_property_domain_demo/1,
          user:rust_read_term_options_demo/2,
          user:rust_atom_to_term_demo/2,
          user:rust_syntax_error_demo/1],


### PR DESCRIPTION
## Summary

- raise `instantiation_error` for an unbound predicate head
- raise `type_error(callable, Head)` for a non-callable head
- raise `instantiation_error` for an unbound property
- raise `domain_error(predicate_property, Property)` for unsupported properties
- reuse the existing catchable Rust `error/2` helper
- leave successful lookups, missing predicates, dispatch, and choicepoints unchanged

## Testing

- generated `catch/3` tests for all four error forms
- focused Rust dynamic builtin suite
- full Rust WAM target suite
- Rust target syntax/load check
- patch whitespace validation