### PR TITLE
Add Rust clause/2 ISO errors

### DIFF
--- a/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
+++ b/templates/targets/rust_wam/dynamic_db_methods.rs.mustache
@@ -872,10 +872,22 @@
     fn dynamic_clause_call(&mut self, cont_pc: usize) -> bool {
         let head_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
         let head = self.deref_heap(&self.deref_var(&head_raw));
-        if matches!(head, Value::Unbound(_) | Value::Uninit) { return false; }
+        if matches!(&head, Value::Unbound(_) | Value::Uninit) {
+            return self.raise_iso_error(Value::Atom(
+                "instantiation_error".to_string(),
+            ));
+        }
         let key = match self.dynamic_head_key(&head) {
             Some(key) => key,
-            None => return false,
+            None => {
+                return self.raise_iso_error(Value::Str(
+                    "type_error/2".to_string(),
+                    vec![
+                        Value::Atom("callable".to_string()),
+                        head,
+                    ],
+                ));
+            }
         };
         let body_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
         let body = self.deref_heap(&self.deref_var(&body_raw));

--- a/tests/fixtures/wam_rust_dynamic_builtins.rs
+++ b/tests/fixtures/wam_rust_dynamic_builtins.rs
@@ -271,6 +271,23 @@ fn generated_tail_clause_call_reads_dynamic_facts() {
 }
 
 #[test]
+fn generated_clause_errors_are_catchable() {
+    let (code, labels) = shared_wam_program();
+    for pred in [
+        "rust_clause_instantiation_demo/1",
+        "rust_clause_type_demo/1",
+    ] {
+        let mut vm = WamState::new(code.clone(), labels.clone());
+        vm.set_reg_str("A1", ub("Result"));
+        vm.pc = *vm.labels.get(pred).expect("generated clause error label");
+
+        assert!(vm.run(), "{} should catch its error", pred);
+        assert_eq!(vm.bindings.get("Result"), Some(&at("caught")));
+        assert!(vm.thrown_ball.is_none(), "{} should consume the error", pred);
+    }
+}
+
+#[test]
 fn current_predicate_backtracks_over_matching_dynamic_arities() {
     let mut vm = WamState::new(
         vec![

--- a/tests/test_wam_rust_dynamic_builtins.pl
+++ b/tests/test_wam_rust_dynamic_builtins.pl
@@ -16,6 +16,20 @@ rust_assert_alias_demo :- assert(dyn(alias)).
 rust_clause_demo(X, Body) :-
     clause(dyn(X), Body).
 
+:- dynamic rust_clause_instantiation_demo/1.
+rust_clause_instantiation_demo(Result) :-
+    catch(
+        clause(_, _),
+        error(instantiation_error, _),
+        Result = caught).
+
+:- dynamic rust_clause_type_demo/1.
+rust_clause_type_demo(Result) :-
+    catch(
+        clause(7, _),
+        error(type_error(callable, _), _),
+        Result = caught).
+
 :- dynamic rust_current_predicate_demo/2.
 rust_current_predicate_demo(Name, Arity) :-
     current_predicate(Name/Arity).
@@ -113,6 +127,8 @@ test(assert_retract_dynamic_db,
         [user:rust_dyn_dummy/0,
          user:rust_assert_alias_demo/0,
          user:rust_clause_demo/2,
+         user:rust_clause_instantiation_demo/1,
+         user:rust_clause_type_demo/1,
          user:rust_current_predicate_demo/2,
          user:rust_current_predicate_instantiation_demo/1,
          user:rust_current_predicate_type_demo/1,


### PR DESCRIPTION
## Summary

- raise `instantiation_error` when the clause head is unbound
- raise `type_error(callable, Head)` when the head is not callable
- reuse the existing catchable Rust `error/2` mechanism
- leave clause enumeration, choicepoints, and dynamic database access unchanged
- preserve existing retract behavior, matching the C++ runtime

## Testing

- generated `catch/3` tests for both error forms
- focused Rust dynamic builtin suite
- full Rust WAM target suite
- Rust target syntax/load check
- patch whitespace validation