### PR TITLE
mu_cosine: calibrate adjacency-residual confidence with component-safe folds

### DIFF
--- a/prototypes/mu_cosine/DESIGN_adjacent_residual_pilot.md
+++ b/prototypes/mu_cosine/DESIGN_adjacent_residual_pilot.md
@@ -1,0 +1,184 @@
+# Adjacent-row residual pilot — component cross-fitting and stability bands
+
+## Status
+
+This executable amendment was frozen after inspecting graph incidence, campaign tags, and pair counts, but
+before computing any adjacency-stratified residual statistic.  It implements the existing-data pilot proposed
+in `DESIGN_adjacent_row_residual_correlation.md`.  No new judge calls are used.
+
+The pilot is **descriptive and conditional on the existing campaign**.  It cannot license structured
+cross-item covariance or distance-separated QR batching.  A confirmatory deployment claim requires a
+purpose-built adjacency-enriched sample with independent repeated judge draws.
+
+## Outcome-blind limitations found before residual analysis
+
+After the operating-judge, Luna, graph, and e5 intersection, the two corpora contain:
+
+| corpus | rows | same-descendant, adjacent-root pairs | nonadjacent pool | endpoint components with positives |
+|---|---:|---:|---:|---:|
+| exploratory | 1,000 | 84 | 680 | 29 |
+| fresh | 700 | 206 | 571 | 40 |
+
+The exploratory corpus is below even a rough 30-cluster threshold, components are unequal (largest 69 and 31
+rows), and every corpus has only one residual field.  Component resampling therefore produces **stability
+bands**, not population confidence or coverage intervals.
+
+Adjacency is also aligned with campaign construction.  Positive pairs are overwhelmingly tag pairs
+`h1-h2`, `h2-h3`, `h3-h4`, and `h4-h5`.  Within a fixed descendant there are no exact tag-pair-matched
+nonadjacent controls.  The identified existing-data estimand is consequently **predictive adjacency plus hop
+proximity**, not a pure causal adjacency effect.
+
+## Component-cross-fitted residual field
+
+Rows are partitioned by connected components of the exact endpoint-incidence graph.  Whole components, never
+individual rows, are assigned to five outcome-blind folds.  The assignment balances row count, campaign tags,
+and the number of outcome-blind adjacent-root pairs.  Assignment seeds are 20 through 29, disjoint from the
+#3671 seed range.  Repeated assignments are stability probes on the same labels, not independent samples.
+
+For each held component fold, refit on the other four folds:
+
+1. graph-D, graph-S, and debiased-Luna calibration;
+2. the joint `P/C/R` residual model and conditional design;
+3. semantic/graph scaling and the regional kernel-ridge mean;
+4. the within-item conditional residual covariance `B`.
+
+For held row `i`, form
+
+```text
+q_i = v_i - C.T P^-1 e_i
+z_i = B^-1/2 (q_i - m_hat_i).
+```
+
+All rows receive exactly one out-of-fold residual per assignment.  Any two primary rows share their descendant,
+so component assignment guarantees that their residuals were produced by the same train-only fit.
+
+The regional mean's ridge/kernel choice still uses exact row LOO within the training components.  The outer
+component holdout prevents direct held leakage, but shared-endpoint dependence can affect hyperparameter choice.
+The smooth-mean synthetic control and assignment stability must be reported; this pilot does not call that
+selection population-calibrated.
+
+## Pair records and estimands
+
+For each two different rows sharing descendant `x`, let their roots be `a` and `b`.  The record is positive when
+`a` and `b` share a direct graph edge in either direction.  Its matrix observation is
+
+```text
+G_ij = 0.5 * (z_i z_j.T + z_j z_i.T).
+```
+
+For every positive `p=(i,j)`, select up to three nonadjacent controls that share `x` and one anchor row:
+`(i,k)` or `(j,k)`.  Rank candidates without outcomes by partner-tag distance, root-degree-bin difference,
+frozen semantic distance, and finally stable row identity.  Average the selected control matrices with equal
+weight and define
+
+```text
+A_p = G_ij - mean_control(G_anchor,k).
+```
+
+Report eligibility/exclusions and the achieved tag, degree-bin, and semantic imbalance.  Average `A_p` within
+each exact-endpoint component, then give every positive component equal weight.  The primary scalar is frozen
+before inspecting matrix entries:
+
+```text
+delta = mean_component(trace(A_component) / 4).
+```
+
+Report:
+
+- the 4x4 positive and control cross-product means;
+- their anchor-matched adjacency-minus-control contrast;
+- every diagonal/channel entry and all ten unique symmetric entries;
+- spectral norms of the two means and their contrast;
+- counts by corpus, stratum, descendant, and endpoint component.
+
+The component-macro point estimate describes the observed positive-component population.  Use 9,999
+Rademacher component-multiplier draws on the centered component estimates.  Report pointwise and max-|t|
+simultaneous stability bands over the primary trace and ten unique matrix entries, plus the spectral error
+radius
+
+```text
+delta_stability = Q_0.95(||Delta_star - Delta_hat||_2).
+```
+
+These are explicitly labelled conditional component-resampling stability summaries, not population CIs.
+Disable every CI-like gate when there are fewer than 30 effective components or one component has more than
+10% weight.  Leave-one-positive-
+component-out estimates expose domination by a single component.
+
+## Low-capacity PSD comparator
+
+For root `r`, let `psi(r)` be the unit-normalized binary incidence vector of `r` and its one-hop parents and
+children.  For campaign row `i`, use the role-aware sparse feature
+
+```text
+Phi_i = one_hot(descendant_i) tensor psi(root_i)
+K_adj = Phi Phi.T.
+```
+
+This Gram matrix is PSD, has unit diagonal, and only couples rows with the same descendant.  With the fold-fit
+within-item block `B=L_B L_B.T`, test only the frozen trust path
+
+```text
+C_alpha = ((1-alpha) I + alpha K_adj) tensor I_4
+R_alpha = (I tensor L_B) C_alpha (I tensor L_B).T
+alpha in {0, .025, .05, .10, .20, .35, .50}.
+```
+
+`alpha=1` is diagnostic only because repeated or identical features can make the endpoint singular.  A fixed
+outcome-blind within-descendant derangement `P K_adj P.T` is the equal-capacity topology-specificity
+comparator; it is a common-mode diagnostic, not a null distribution.  Any alpha selection used for a claim
+must be nested and its block-null calibration must repeat calibration, `P/C/q`, mean selection, `B`, and alpha
+selection on the same component topology.
+
+## Synthetic controls
+
+Before interpreting real residuals, exercise the statistic on independent synthetic components with:
+
+- block-null residuals;
+- smooth mean only, removed by the same cross-fitting contract;
+- planted positive-pair coupling at 0.04, 0.10, and 0.20;
+- equal-energy label/geometry permutation;
+- unequal component sizes matching the two real inventories.
+
+Mechanism power with known mean and `B` must be separate from end-to-end nuisance estimation.  Failure of a
+nominal detection target blocks interpretation but does not prove that good covariance information is useless.
+
+## PSD-safe covariance consequence
+
+An elementwise lower confidence band is not matrix-conservative: for a two-row correlation matrix, changing
+`rho` moves the common and contrast eigenvalues in opposite directions, and entrywise bounds need not be PSD.
+The eventual deployment adapter therefore has two separate safeguards:
+
+1. shrink uncertain correlation geometry toward the block model on a PSD path;
+2. inflate the resulting conditional noise covariance by a high-probability spectral error envelope.
+
+For a validated estimate, the intended form is
+
+```text
+R_hat(alpha) = L_B [(1-alpha) I + alpha C_hat] L_B.T
+R_safe       = R_hat(alpha_safe) + delta_95 I.
+```
+
+`alpha_safe` is selected by a lower bound on held-out benefit or by worst-case validation, not by lowering
+individual covariance entries.  `delta_95` must come from a confirmatory procedure that refits all
+outcome-dependent objects.  This pilot's `delta_stability` is diagnostic and must not be relabelled `delta_95`.
+
+Likewise, a proposed block separation is safe only when an **upper** bound on
+
+```text
+||B_i^-1/2 R_ij B_j^-1/2||_2
+```
+
+is below a preregistered `epsilon_batch`.  The present pilot cannot establish that bound.
+
+## Decision rule
+
+This PR can conclude only one of:
+
+- **promising descriptive structure:** both corpora have the same contrast direction, assignment signs are
+  stable, leave-one-component-out behavior is not dominated, and synthetic mechanism power is adequate;
+- **not resolved by existing data:** any of those conditions fails.
+
+In both cases the deployment gate remains false.  The next confirmatory campaign should deliberately sample
+`(anchor, adjacent positive, matched distant/hard negative)` triples, balance hop/tag strata by construction,
+and obtain at least two independent calls from each judge family.

--- a/prototypes/mu_cosine/REPORT_adjacent_residual_pilot.md
+++ b/prototypes/mu_cosine/REPORT_adjacent_residual_pilot.md
@@ -1,0 +1,216 @@
+# Adjacent conditional-residual pilot — strong descriptive signal, no covariance deployment
+
+## Bottom line
+
+Adjacent roots under the same descendant have more similar out-of-fold, conditionally whitened judge residuals
+than anchor-matched nonadjacent roots.  The component-macro contrast was positive for every one of ten
+component-fold assignments in both corpora: `0.2799 +/- 0.0074` exploratory and `0.1697 +/- 0.0111` fresh.
+Every leave-one-positive-component-out estimate was also positive.
+
+This is promising evidence that graph-local measurements share predictable structure.  It is **not** yet a
+validated covariance estimate.  Existing campaign construction confounds direct adjacency with local hop/tag
+position, provides only one residual field per corpus, and supplies just 28 / 40 eligible positive endpoint
+components.  A low-capacity adjacency Gram improves held residual likelihood more than a topology-deranged
+Gram, but the comparison is diagnostic and its best tested coupling lies at the edge of the frozen grid.
+
+Under the frozen two-outcome decision rule, the formal result is **not resolved by existing data**: the
+observed direction and component stability are strong, but the synthetic mechanism does not meet the required
+80% power gate.  “Promising” below describes the observed signal only; it is not a passed advancement gate.
+
+The operational decision therefore remains unchanged:
+
+- keep independent item blocks in the square-root/QR conditioner;
+- do not certify distance-separated batching from this pilot;
+- run a purpose-built, component-balanced campaign with repeated judge calls before estimating cross-item
+  covariance;
+- retain a 95% simultaneous safety bound for deployment.  An 80--90% band may be used only as a labelled
+  discovery screen or shadow-mode trigger for collecting more data.
+
+## What was measured
+
+The protocol in `DESIGN_adjacent_residual_pilot.md` was frozen after an outcome-blind graph/campaign inventory
+and before any adjacency-stratified residual statistic was computed.  Five-fold cross-fitting holds out whole
+components of the exact endpoint-incidence graph.  For each held fold, calibration, prior/measurement
+conditionalization, the regional mean, and the within-item covariance `B` are refit on the other components.
+
+For held row `i`, the analyzed residual is
+
+```text
+q_i = v_i - C.T P^-1 e_i
+z_i = B^-1/2 (q_i - m_hat_i).
+```
+
+Each positive record is a pair whose roots share a direct edge and whose rows share a descendant.  Up to three
+nonadjacent controls share that descendant and one anchor row, and are ranked without outcomes.  The primary
+contrast is the equal-component average of
+
+```text
+trace[ G_adjacent - mean(G_anchor-control) ] / 4,
+G_ij = 0.5 (z_i z_j.T + z_j z_i.T).
+```
+
+Seeds 20--29 vary the whole-component fold assignment.  These are stability probes over the same two label
+fields, not ten independent experiments.  Rademacher component-multiplier bands are therefore conditional
+stability summaries, not population confidence intervals.
+
+## Inventory and matching
+
+| corpus | matched rows | adjacent pairs | eligible pairs | eligible positive components | positive folds |
+|---|---:|---:|---:|---:|---:|
+| exploratory | 1,000 | 84 | 83 | 28 | 41 / 50 |
+| fresh | 700 | 206 | 206 | 40 | 46 / 50 |
+
+One exploratory pair had no anchor-sharing nonadjacent control.  The existing campaign offers no exact
+tag-pair-matched nonadjacent controls: adjacency is concentrated among consecutive hop tags.  The identified
+contrast is therefore **adjacency plus local-hop predictiveness**, not a pure causal adjacency effect.
+
+## Primary stability result
+
+| corpus | mean primary contrast | assignment SD | assignment range | positive assignments | minimum positive LOCO fraction |
+|---|---:|---:|---:|---:|---:|
+| exploratory | +0.279877 | 0.007426 | +0.265592 to +0.291888 | 10 / 10 | 100% |
+| fresh | +0.169740 | 0.011065 | +0.154176 to +0.191264 | 10 / 10 | 100% |
+
+The diagnostic 95% pointwise lower band for the primary contrast was positive in 10/10 assignments in both
+corpora.  The max-|t| simultaneous lower band was positive in 0/10 exploratory assignments and 6/10 fresh
+assignments.  The exploratory CI-like gate is disabled because it has fewer than 30 eligible components.
+Even for fresh, the band describes conditional component stability only; repeated measurement fields are
+needed to separate persistent item/mean structure from stochastic judge covariance.
+
+## Low-capacity likelihood diagnostic
+
+The PSD comparator uses a same-descendant, closed-one-hop-neighborhood Gram and tests only
+
+```text
+C_alpha = ((1-alpha) I + alpha K_adj) tensor I_4,
+alpha in {0, .025, .05, .10, .20, .35, .50}.
+```
+
+The table reports held component-macro NLL gain per scalar over the independent block at the best tested
+`alpha=0.50`, averaged over assignments.  Alpha was inspected on held outcomes, so this is an oracle diagnostic,
+not a fitted or deployable selector.
+
+| corpus | adjacency Gram gain | deranged Gram gain | topology-specific excess |
+|---|---:|---:|---:|
+| exploratory | +0.014673 | +0.003216 | +0.011457 |
+| fresh | +0.021167 | +0.010030 | +0.011137 |
+
+Both adjacency curves increase through the largest tested alpha.  That supports continued study, but it also
+means the pilot does not locate an interior coupling.  The deranged Gram's positive gain shows that common-mode
+structure remains useful even after topology is permuted; the excess for the true Gram is the more relevant
+topology-specific diagnostic.
+
+## Synthetic mechanism audit and sizing
+
+The implemented synthetic control isolates the statistic: the mean and `B` are known, and each independent
+component contributes one equal-weight adjacent-minus-two-controls contrast.  It does **not** rerun the real
+calibration, KRR mean selection, unequal component sizes, or `B` estimation.  Consequently it is a mechanism
+and rough sizing audit, not end-to-end power.
+
+At the real eligible-component counts:
+
+| components | true coupling | pointwise 95% lower band positive | simultaneous 95% lower band positive |
+|---:|---:|---:|---:|
+| 28 | 0.00 | 3.5% | 1.0% |
+| 28 | 0.10 | 18.0% | 5.5% |
+| 28 | 0.20 | 45.0% | 23.5% |
+| 40 | 0.00 | 0.5% | 0.5% |
+| 40 | 0.10 | 19.5% | 6.5% |
+| 40 | 0.20 | 61.0% | 29.5% |
+
+The frozen 80% power target fails.  A diagnostic extension with 200 replicates per cell gives:
+
+| independent components | coupling 0.10 pointwise / simultaneous | coupling 0.20 pointwise / simultaneous |
+|---:|---:|---:|
+| 160 | 58.0% / 26.5% | 99.0% / 91.0% |
+| 240 | 75.5% / 42.5% | 100% / 97.5% |
+| 320 | 81.0% / 54.0% | 100% / 100% |
+| 400 | 91.5% / 65.0% | 100% / 100% |
+
+Thus roughly 320 independent components are needed to reach 80% **pointwise** mechanism detection for a 0.10
+coupling under these favorable assumptions.  That is not adequate for a covariance-wide 95% gate: more than
+400 would be needed for an 80% simultaneous target; the exact number was not estimated.  A full-procedure
+campaign should be sized more conservatively because it
+must also estimate calibration, mean, marginal covariance, and any coupling selector.
+
+## Why not lower the confidence level?
+
+The 95% quantity is a coverage/safety level, not a minimum covariance magnitude.  Lowering it does not reveal
+more information; it moves the decision boundary so that noisier apparent correlations are admitted.  That is
+reasonable for generating hypotheses, but unsafe for a production covariance because an overstated coupling
+can make the posterior overconfident and can place supposedly independent measurements in separate batches.
+
+For deployment, retain the 95% simultaneous rule and address low power with more independent components and
+repeated judge calls.  For an explicitly non-operational discovery dashboard, an 80--90% pointwise band can
+rank candidates for follow-up, provided it cannot modify `R`, QR block membership, or a production decision.
+
+Also, “err on the low side of covariance entries” is not generally matrix-conservative: reducing an
+off-diagonal correlation increases one eigenvalue and decreases another, and elementwise lower bounds need not
+be PSD.  The future safe adapter should shrink on a PSD path and add a simultaneous spectral envelope:
+
+```text
+R_hat(alpha) = L_B [(1-alpha) I + alpha C_hat] L_B.T
+R_safe       = R_hat(alpha_safe) + delta_95 I.
+```
+
+`alpha_safe` should be chosen by a lower bound on held-out benefit or worst-case validation.  `delta_95` must
+come from a confirmatory full-procedure resampling audit.  A batching separation requires a high-confidence
+**upper** bound on whitened cross-block coupling, not a lower bound.
+
+## Recommended confirmatory campaign
+
+1. Sample balanced `(anchor, adjacent positive, matched distant/hard negative)` triples and balance hop/tag
+   strata by construction.  Adjacent samples test local smoothing; distant/hard negatives identify where it
+   should stop and may become independent-batch candidates.
+2. Obtain at least three independent calls per judge family for each sampled row.  This separates repeatable
+   item effects from within-judge stochastic covariance and permits judge-specific and cross-judge estimates.
+3. Split and resample whole endpoint components.  Size for at least 320 independent positive components as a
+   favorable lower bound for 0.10 pointwise detection, then increase the target for simultaneous and
+   full-procedure uncertainty.
+4. Refit calibration, conditionalization, regional mean, `B`, covariance, and coupling selection inside each
+   confirmatory null/power replicate.  Gate on held residual NLL, posterior calibration/risk, decision metrics,
+   numerical loading, and a simultaneous PSD-safe error envelope.
+5. Only after those gates pass, feed the validated dense block covariance to the existing square-root/QR
+   conditioner.  Keep distant blocks independent only when the simultaneous upper coupling bound is below a
+   preregistered batching tolerance.
+
+This follows the calibrated joint-posterior and component-disjoint validation policy: covariance is admitted
+because it improves held probabilistic predictions under its full uncertainty, not because a hand-set
+correlation weight looks plausible.
+
+## Reproduction
+
+Real pilot:
+
+```bash
+python3 prototypes/mu_cosine/run_adjacent_residual_pilot.py \
+  --artifact-repo /home/s243a/Projects/UnifyWeaver \
+  --ckpt /home/s243a/Projects/UnifyWeaver/prototypes/mu_cosine/model_prod_namecond.pt \
+  --assignments 10 --multiplier-draws 9999 --lmdb-no-lock \
+  --out /tmp/adjacent_residual_pilot_final.json
+```
+
+Known-mean/known-`B` mechanism audit:
+
+```bash
+python3 prototypes/mu_cosine/run_adjacent_residual_synthetic.py \
+  --out /tmp/adjacent_residual_synthetic_final.json
+```
+
+Focused tests:
+
+```bash
+python3 -m pytest -q \
+  prototypes/mu_cosine/test_adjacent_residual_pilot.py \
+  prototypes/mu_cosine/test_run_adjacent_residual_pilot.py
+```
+
+The real run completed in 119.0 seconds; runtime is printed to stdout and excluded from the deterministic
+scientific JSON.  Ten focused tests pass; including the inherited structured-covariance, covariance-sensitivity,
+and NumPy/Torch square-root-conditioner suites gives `120 passed, 9 skipped`.  Full output SHA-256 values are:
+
+- real pilot: `61b4b3c15bf509e70df0c2e39ed5edfbb28dec54887d399e9b036ac8e001564e`;
+- synthetic mechanism: `c736e25bc210ff3cd2b9f4385e80afe4c568093d1f1a024d6411e8436ef98057`.
+
+The compact tracked record is `repro/adjacent_residual_pilot/summary.json`.  Across numerical stacks, compare
+scientific fields within tolerance rather than assuming byte-identical floating-point output.

--- a/prototypes/mu_cosine/REPORT_adjacent_residual_pilot.md
+++ b/prototypes/mu_cosine/REPORT_adjacent_residual_pilot.md
@@ -205,12 +205,19 @@ python3 -m pytest -q \
   prototypes/mu_cosine/test_run_adjacent_residual_pilot.py
 ```
 
-The real run completed in 119.0 seconds; runtime is printed to stdout and excluded from the deterministic
-scientific JSON.  Ten focused tests pass; including the inherited structured-covariance, covariance-sensitivity,
-and NumPy/Torch square-root-conditioner suites gives `120 passed, 9 skipped`.  Full output SHA-256 values are:
+The original real run completed in 119.0 seconds; the portable-provenance rerun completed in 113.1 seconds.
+Runtime and runtime paths are printed only to stdout and excluded from the deterministic scientific JSON.
+Payload schema v2 stores role-keyed byte sizes and content hashes, not checkout/input/output locators.  Two
+complete synthetic runs written to different output paths were byte-identical, and the schema-v2 real run
+reproduced every prior scientific field exactly.
 
-- real pilot: `61b4b3c15bf509e70df0c2e39ed5edfbb28dec54887d399e9b036ac8e001564e`;
-- synthetic mechanism: `c736e25bc210ff3cd2b9f4385e80afe4c568093d1f1a024d6411e8436ef98057`.
+Thirteen focused tests pass; including the inherited structured-covariance, covariance-sensitivity, and
+NumPy/Torch square-root-conditioner suites gives `123 passed, 9 skipped`.  Portable full-output SHA-256 values
+are:
 
-The compact tracked record is `repro/adjacent_residual_pilot/summary.json`.  Across numerical stacks, compare
-scientific fields within tolerance rather than assuming byte-identical floating-point output.
+- real pilot: `407d52d8fe64df3bf9220da95976bee5c046c5d806d676aa38aafa4a475e100a`;
+- synthetic mechanism: `62695568b1eae247ece2d3e37a18250c756b57536bdf6fe7e0ec7a91f8b8c18e`.
+
+The compact tracked record is `repro/adjacent_residual_pilot/summary.json`.  Relocated inputs with identical
+content now produce identical provenance.  Across different numerical stacks, still compare scientific fields
+within tolerance rather than assuming byte-identical floating-point output.

--- a/prototypes/mu_cosine/adjacent_residual_pilot.py
+++ b/prototypes/mu_cosine/adjacent_residual_pilot.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Component-safe primitives for the adjacent-row conditional-residual pilot.
+
+The functions in this module are outcome-agnostic except for whitening and the
+final cross-product statistic.  They deliberately return conditional stability
+summaries rather than population confidence intervals; see
+``DESIGN_adjacent_residual_pilot.md``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import re
+
+import numpy as np
+
+
+VECH = tuple((i, j) for i in range(4) for j in range(i, 4))
+TAG_ORDER = {
+    "campaign_sib": 6.0,
+    "campaign_cous": 7.0,
+    "campaign_rand": 8.0,
+}
+
+
+def _stable_key(value):
+    return type(value).__qualname__, repr(value)
+
+
+def _finite_matrix(name, value, *, rows=None, cols=None):
+    value = np.asarray(value, dtype=float)
+    if value.ndim != 2:
+        raise ValueError(f"{name} must be a matrix")
+    if rows is not None and value.shape[0] != rows:
+        raise ValueError(f"{name} has {value.shape[0]} rows, expected {rows}")
+    if cols is not None and value.shape[1] != cols:
+        raise ValueError(f"{name} has {value.shape[1]} columns, expected {cols}")
+    if not np.isfinite(value).all():
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def endpoint_component_ids(pairs):
+    """Return canonical row-component ids under exact endpoint sharing."""
+    pairs = list(pairs)
+    if not pairs:
+        raise ValueError("pairs must not be empty")
+    parent = {}
+
+    def find(node):
+        parent.setdefault(node, node)
+        while parent[node] != node:
+            parent[node] = parent[parent[node]]
+            node = parent[node]
+        return node
+
+    def union(left, right):
+        left, right = find(left), find(right)
+        if left != right:
+            if _stable_key(left) <= _stable_key(right):
+                parent[right] = left
+            else:
+                parent[left] = right
+
+    for pair in pairs:
+        if len(pair) != 2:
+            raise ValueError("every pair must have two endpoints")
+        union(pair[0], pair[1])
+    roots = [find(pair[0]) for pair in pairs]
+    canonical = {
+        root: i for i, root in enumerate(sorted(set(roots), key=_stable_key))
+    }
+    return np.asarray([canonical[root] for root in roots], dtype=int)
+
+
+def _tag_value(tag):
+    tag = str(tag)
+    match = re.fullmatch(r"campaign_h([1-9][0-9]*)", tag)
+    if match:
+        return float(match.group(1))
+    return TAG_ORDER.get(tag, 100.0)
+
+
+def _degree_bin(value):
+    value = max(0, int(value))
+    return int(math.floor(math.log2(value + 1)))
+
+
+def _direct_edge(neighbors, left, right):
+    return right in neighbors.get(left, ()) or left in neighbors.get(right, ())
+
+
+def positive_row_pairs(pairs, neighbors):
+    """Enumerate same-descendant row pairs whose roots share a direct edge."""
+    pairs = list(pairs)
+    by_left = {}
+    for row, (left, _right) in enumerate(pairs):
+        by_left.setdefault(left, []).append(row)
+    output = []
+    for rows in by_left.values():
+        for offset, first in enumerate(rows):
+            for second in rows[offset + 1:]:
+                if _direct_edge(neighbors, pairs[first][1], pairs[second][1]):
+                    output.append((first, second))
+    return tuple(output)
+
+
+@dataclass(frozen=True)
+class ComponentFoldAssignment:
+    folds: tuple[np.ndarray, ...]
+    component_ids: np.ndarray
+    component_count: int
+    largest_component: int
+    fold_diagnostics: tuple[dict, ...]
+    seed: int
+
+
+def component_balanced_folds(pairs, tags, positive_pairs, *, n_folds=5, seed=20):
+    """Assign whole endpoint components to deterministic outcome-blind folds."""
+    pairs = list(pairs)
+    tags = np.asarray(tags)
+    if len(tags) != len(pairs):
+        raise ValueError("tags must align with pairs")
+    if not 2 <= n_folds <= len(pairs):
+        raise ValueError("n_folds must be between two and the row count")
+    component = endpoint_component_ids(pairs)
+    components = sorted(set(component.tolist()))
+    if len(components) < n_folds:
+        raise ValueError("fewer endpoint components than folds")
+    tag_names = sorted({str(value) for value in tags})
+    tag_index = {name: i for i, name in enumerate(tag_names)}
+    positive_count = np.zeros(len(components), dtype=float)
+    for first, second in positive_pairs:
+        if component[first] != component[second]:
+            raise ValueError("a positive row pair crosses endpoint components")
+        positive_count[component[first]] += 1.0
+    features = np.zeros((len(components), 2 + len(tag_names)), dtype=float)
+    rows_by_component = []
+    for value in components:
+        rows = np.flatnonzero(component == value)
+        rows_by_component.append(rows)
+        features[value, 0] = len(rows)
+        features[value, 1] = positive_count[value]
+        for row in rows:
+            features[value, 2 + tag_index[str(tags[row])]] += 1.0
+    target = features.sum(axis=0) / n_folds
+    scale = np.where(target > 0.0, target, 1.0)
+    rng = np.random.default_rng(seed)
+    tie = rng.random(len(components))
+    order = sorted(
+        components,
+        key=lambda value: (
+            -features[value, 1],
+            -features[value, 0],
+            -float(np.max(features[value, 2:], initial=0.0)),
+            tie[value],
+            value,
+        ),
+    )
+    totals = np.zeros((n_folds, features.shape[1]), dtype=float)
+    assigned = [[] for _ in range(n_folds)]
+    fold_tie = rng.permutation(n_folds)
+    fold_rank = np.empty(n_folds, dtype=int)
+    fold_rank[fold_tie] = np.arange(n_folds)
+    for value in order:
+        candidates = []
+        for fold in range(n_folds):
+            prospective = totals.copy()
+            prospective[fold] += features[value]
+            score = float(np.sum(((prospective - target) / scale) ** 2))
+            candidates.append((score, len(assigned[fold]), fold_rank[fold], fold))
+        fold = min(candidates)[-1]
+        assigned[fold].append(value)
+        totals[fold] += features[value]
+    folds, diagnostics = [], []
+    for fold, values in enumerate(assigned):
+        rows = np.sort(np.concatenate([rows_by_component[value] for value in values]))
+        folds.append(rows)
+        diagnostics.append({
+            "fold": fold,
+            "rows": int(len(rows)),
+            "components": int(len(values)),
+            "positive_pairs": int(totals[fold, 1]),
+            "tag_counts": {
+                name: int(totals[fold, 2 + at]) for at, name in enumerate(tag_names)
+            },
+        })
+    if sorted(np.concatenate(folds).tolist()) != list(range(len(pairs))):
+        raise AssertionError("component folds must partition every row exactly once")
+    for left in range(n_folds):
+        left_nodes = {node for row in folds[left] for node in pairs[row]}
+        for right in range(left + 1, n_folds):
+            right_nodes = {node for row in folds[right] for node in pairs[row]}
+            if left_nodes & right_nodes:
+                raise AssertionError("endpoint components leaked across folds")
+    sizes = np.bincount(component)
+    return ComponentFoldAssignment(
+        tuple(folds),
+        component,
+        len(components),
+        int(np.max(sizes)),
+        tuple(diagnostics),
+        int(seed),
+    )
+
+
+@dataclass(frozen=True)
+class AnchorContrast:
+    positive: tuple[int, int]
+    controls: tuple[tuple[int, int], ...]
+    component: int
+    positive_tag_pair: tuple[str, str]
+    mean_tag_distance: float
+    mean_degree_bin_difference: float
+    mean_semantic_distance: float
+
+
+def anchor_matched_contrasts(
+    pairs,
+    tags,
+    neighbors,
+    degrees,
+    semantic,
+    *,
+    maximum_controls=3,
+):
+    """Match each adjacent-root pair to deterministic anchor-sharing controls."""
+    pairs = list(pairs)
+    tags = np.asarray(tags)
+    semantic = _finite_matrix("semantic", semantic, rows=len(pairs))
+    if len(tags) != len(pairs):
+        raise ValueError("tags must align with pairs")
+    if maximum_controls < 1:
+        raise ValueError("maximum_controls must be positive")
+    component = endpoint_component_ids(pairs)
+    by_left = {}
+    for row, (left, _right) in enumerate(pairs):
+        by_left.setdefault(left, []).append(row)
+    records, excluded = [], []
+    for first, second in positive_row_pairs(pairs, neighbors):
+        candidates = []
+        for anchor, partner in ((first, second), (second, first)):
+            partner_root = pairs[partner][1]
+            for candidate in by_left[pairs[first][0]]:
+                if candidate in (first, second):
+                    continue
+                candidate_root = pairs[candidate][1]
+                if _direct_edge(neighbors, pairs[anchor][1], candidate_root):
+                    continue
+                tag_distance = abs(_tag_value(tags[partner]) - _tag_value(tags[candidate]))
+                degree_distance = abs(
+                    _degree_bin(degrees.get(partner_root, 0))
+                    - _degree_bin(degrees.get(candidate_root, 0))
+                )
+                semantic_distance = float(
+                    1.0 - np.clip(semantic[partner] @ semantic[candidate], -1.0, 1.0)
+                )
+                candidates.append((
+                    tag_distance,
+                    degree_distance,
+                    semantic_distance,
+                    anchor,
+                    candidate,
+                ))
+        candidates.sort()
+        chosen = candidates[:maximum_controls]
+        if not chosen:
+            excluded.append((first, second))
+            continue
+        records.append(AnchorContrast(
+            (first, second),
+            tuple((value[3], value[4]) for value in chosen),
+            int(component[first]),
+            tuple(sorted((str(tags[first]), str(tags[second])))),
+            float(np.mean([value[0] for value in chosen])),
+            float(np.mean([value[1] for value in chosen])),
+            float(np.mean([value[2] for value in chosen])),
+        ))
+    return tuple(records), tuple(excluded)
+
+
+def principal_whiten_rows(residuals, covariance):
+    """Whiten row residuals with the unique symmetric inverse square root."""
+    residuals = _finite_matrix("residuals", residuals)
+    covariance = _finite_matrix(
+        "covariance", covariance, rows=residuals.shape[1], cols=residuals.shape[1]
+    )
+    covariance = 0.5 * (covariance + covariance.T)
+    values, vectors = np.linalg.eigh(covariance)
+    if np.any(values <= 0.0):
+        raise np.linalg.LinAlgError("covariance must be positive definite")
+    inverse_root = (vectors * (1.0 / np.sqrt(values))) @ vectors.T
+    return residuals @ inverse_root
+
+
+def _symmetric_cross_product(rows, pair):
+    first, second = pair
+    value = np.outer(rows[first], rows[second])
+    return 0.5 * (value + value.T)
+
+
+@dataclass(frozen=True)
+class ComponentContrastEstimate:
+    component_ids: np.ndarray
+    contrast_matrices: np.ndarray
+    positive_matrices: np.ndarray
+    control_matrices: np.ndarray
+    contrast: np.ndarray
+    positive: np.ndarray
+    control: np.ndarray
+    primary_trace: float
+    edge_weighted_contrast: np.ndarray
+    record_count: int
+
+
+def component_contrast_estimate(whitened_rows, records):
+    """Compute anchor-matched matrices, then average endpoint components equally."""
+    rows = _finite_matrix("whitened_rows", whitened_rows, cols=4)
+    records = tuple(records)
+    if not records:
+        raise ValueError("records must not be empty")
+    by_component = {}
+    edge_contrasts = []
+    for record in records:
+        positive = _symmetric_cross_product(rows, record.positive)
+        controls = np.mean([
+            _symmetric_cross_product(rows, pair) for pair in record.controls
+        ], axis=0)
+        contrast = positive - controls
+        edge_contrasts.append(contrast)
+        by_component.setdefault(record.component, []).append((contrast, positive, controls))
+    component_ids = np.asarray(sorted(by_component), dtype=int)
+    contrast, positive, control = [], [], []
+    for value in component_ids:
+        rows_for_component = by_component[int(value)]
+        contrast.append(np.mean([row[0] for row in rows_for_component], axis=0))
+        positive.append(np.mean([row[1] for row in rows_for_component], axis=0))
+        control.append(np.mean([row[2] for row in rows_for_component], axis=0))
+    contrast = np.asarray(contrast)
+    positive = np.asarray(positive)
+    control = np.asarray(control)
+    point = np.mean(contrast, axis=0)
+    return ComponentContrastEstimate(
+        component_ids,
+        contrast,
+        positive,
+        control,
+        point,
+        np.mean(positive, axis=0),
+        np.mean(control, axis=0),
+        float(np.trace(point) / 4.0),
+        np.mean(edge_contrasts, axis=0),
+        len(records),
+    )
+
+
+def _statistic_vector(matrices):
+    matrices = np.asarray(matrices, dtype=float)
+    trace = np.trace(matrices, axis1=-2, axis2=-1) / 4.0
+    cells = np.stack([matrices[..., i, j] for i, j in VECH], axis=-1)
+    return np.concatenate([trace[..., None], cells], axis=-1)
+
+
+@dataclass(frozen=True)
+class MultiplierStabilityBand:
+    names: tuple[str, ...]
+    estimate: np.ndarray
+    standard_error: np.ndarray
+    pointwise_low: np.ndarray
+    pointwise_high: np.ndarray
+    simultaneous_low: np.ndarray
+    simultaneous_high: np.ndarray
+    simultaneous_critical_value: float
+    spectral_error_radius: float
+    spectral_norm: float
+    spectral_norm_lower: float
+    spectral_norm_upper: float
+    leave_one_component_out_min: float
+    leave_one_component_out_max: float
+    leave_one_component_out_positive_fraction: float
+    components: int
+    effective_components: float
+    maximum_component_weight: float
+    gate_evaluable: bool
+    draws: int
+    confidence: float
+
+
+def component_multiplier_stability(component_matrices, *, draws=9999, seed=0, confidence=0.95):
+    """Conditional Rademacher multiplier bands for equal component estimates."""
+    matrices = np.asarray(component_matrices, dtype=float)
+    if matrices.ndim != 3 or matrices.shape[1:] != (4, 4):
+        raise ValueError("component_matrices must have shape [G,4,4]")
+    if len(matrices) < 2 or draws < 1:
+        raise ValueError("at least two components and one draw are required")
+    if not 0.0 < confidence < 1.0 or not np.isfinite(matrices).all():
+        raise ValueError("confidence must be in (0,1) and matrices must be finite")
+    matrices = 0.5 * (matrices + matrices.transpose(0, 2, 1))
+    values = _statistic_vector(matrices)
+    point = np.mean(values, axis=0)
+    centered = values - point
+    standard_error = np.std(values, axis=0, ddof=1) / math.sqrt(len(values))
+    rng = np.random.default_rng(seed)
+    multipliers = rng.choice((-1.0, 1.0), size=(draws, len(values)))
+    deviations = multipliers @ centered / len(values)
+    valid = standard_error > np.finfo(float).eps
+    if np.any(valid):
+        maximum_t = np.max(np.abs(deviations[:, valid] / standard_error[valid]), axis=1)
+        critical = float(np.quantile(maximum_t, confidence))
+    else:
+        critical = 0.0
+    alpha = (1.0 - confidence) / 2.0
+    low_deviation, high_deviation = np.quantile(deviations, [alpha, 1.0 - alpha], axis=0)
+    centered_matrices = matrices - np.mean(matrices, axis=0)
+    matrix_deviation = np.einsum("bg,gij->bij", multipliers, centered_matrices) / len(matrices)
+    spectral_deviation = np.linalg.eigvalsh(matrix_deviation)
+    spectral_error = np.max(np.abs(spectral_deviation), axis=1)
+    radius = float(np.quantile(spectral_error, confidence))
+    point_matrix = np.mean(matrices, axis=0)
+    point_spectral = float(np.max(np.abs(np.linalg.eigvalsh(point_matrix))))
+    leave_one_out = []
+    for held in range(len(matrices)):
+        reduced = np.mean(np.delete(matrices, held, axis=0), axis=0)
+        leave_one_out.append(float(np.trace(reduced) / 4.0))
+    component_weight = 1.0 / len(matrices)
+    names = ("trace_over_4",) + tuple(f"channel_{i}_{j}" for i, j in VECH)
+    return MultiplierStabilityBand(
+        names,
+        point,
+        standard_error,
+        point + low_deviation,
+        point + high_deviation,
+        point - critical * standard_error,
+        point + critical * standard_error,
+        critical,
+        radius,
+        point_spectral,
+        max(0.0, point_spectral - radius),
+        point_spectral + radius,
+        float(np.min(leave_one_out)),
+        float(np.max(leave_one_out)),
+        float(np.mean(np.asarray(leave_one_out) > 0.0)),
+        len(matrices),
+        float(len(matrices)),
+        component_weight,
+        bool(len(matrices) >= 30 and component_weight <= 0.10),
+        int(draws),
+        float(confidence),
+    )
+
+
+def adjacency_feature_kernel(pairs_a, pairs_b, neighbors):
+    """PSD-compatible same-descendant closed-root-neighborhood Gram block."""
+    pairs_a, pairs_b = list(pairs_a), list(pairs_b)
+    closed = {}
+    for _left, root in pairs_a + pairs_b:
+        closed.setdefault(root, frozenset((root, *neighbors.get(root, ()))))
+    output = np.zeros((len(pairs_a), len(pairs_b)), dtype=float)
+    for i, (left_a, root_a) in enumerate(pairs_a):
+        set_a = closed[root_a]
+        for j, (left_b, root_b) in enumerate(pairs_b):
+            if left_a != left_b:
+                continue
+            set_b = closed[root_b]
+            output[i, j] = len(set_a & set_b) / math.sqrt(len(set_a) * len(set_b))
+    return output
+
+
+def within_descendant_derangement(kernel, pairs, *, seed):
+    """Derange non-singleton descendant blocks; singleton rows remain fixed."""
+    kernel = _finite_matrix("kernel", kernel)
+    pairs = list(pairs)
+    if kernel.shape != (len(pairs), len(pairs)):
+        raise ValueError("kernel must align with pairs")
+    if not np.allclose(kernel, kernel.T, atol=1e-10):
+        raise ValueError("kernel must be symmetric")
+    by_left = {}
+    for row, (left, _right) in enumerate(pairs):
+        by_left.setdefault(left, []).append(row)
+    permutation = np.arange(len(pairs))
+    rng = np.random.default_rng(seed)
+    for left in sorted(by_left, key=_stable_key):
+        rows = np.asarray(by_left[left], dtype=int)
+        if len(rows) < 2:
+            continue
+        order = rows[rng.permutation(len(rows))]
+        shift = int(rng.integers(1, len(rows)))
+        permutation[order] = np.roll(order, shift)
+    return kernel[np.ix_(permutation, permutation)], permutation
+
+
+def marginal_preserving_adjacency_covariance(kernel, block_covariance, alpha):
+    """Return ``C_alpha kron B`` with exact within-row block ``B``."""
+    kernel = _finite_matrix("kernel", kernel)
+    if kernel.ndim != 2 or kernel.shape[0] != kernel.shape[1]:
+        raise ValueError("kernel must be square")
+    if not np.isfinite(kernel).all() or not np.allclose(kernel, kernel.T, atol=1e-10):
+        raise ValueError("kernel must be finite and symmetric")
+    if not 0.0 <= alpha <= 1.0:
+        raise ValueError("alpha must be in [0,1]")
+    if not np.allclose(np.diag(kernel), 1.0, atol=1e-10):
+        raise ValueError("kernel must have unit diagonal")
+    block = _finite_matrix("block_covariance", block_covariance)
+    if block.ndim != 2 or block.shape[0] != block.shape[1]:
+        raise ValueError("block_covariance must be square")
+    if not np.isfinite(block).all() or not np.allclose(block, block.T, atol=1e-10):
+        raise ValueError("block_covariance must be finite and symmetric")
+    correlation = (1.0 - alpha) * np.eye(len(kernel)) + alpha * kernel
+    if np.min(np.linalg.eigvalsh(correlation)) < -1e-10:
+        raise ValueError("kernel path is not positive semidefinite")
+    if np.min(np.linalg.eigvalsh(block)) <= 0.0:
+        raise ValueError("block_covariance must be positive definite")
+    return np.kron(correlation, block)

--- a/prototypes/mu_cosine/repro/adjacent_residual_pilot/summary.json
+++ b/prototypes/mu_cosine/repro/adjacent_residual_pilot/summary.json
@@ -1,0 +1,94 @@
+{
+  "status": "descriptively strong adjacency-plus-hop signal; synthetic power and repeated-judge gates fail; no QR deployment",
+  "design": "DESIGN_adjacent_residual_pilot.md",
+  "configuration": {
+    "assignment_seeds": [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+    "component_folds": 5,
+    "maximum_anchor_controls": 3,
+    "multiplier_draws": 9999,
+    "conditional_stability_level": 0.95,
+    "alpha_grid": [0.0, 0.025, 0.05, 0.1, 0.2, 0.35, 0.5]
+  },
+  "real_pilot": {
+    "exploratory": {
+      "matched_rows": 1000,
+      "positive_pairs_total": 84,
+      "positive_pairs_eligible": 83,
+      "eligible_positive_components": 28,
+      "primary_trace_over_4_mean": 0.27987733286977634,
+      "primary_trace_over_4_sd": 0.007426452035645393,
+      "primary_trace_over_4_min": 0.26559243382494074,
+      "primary_trace_over_4_max": 0.29188834757049376,
+      "positive_assignments": 10,
+      "positive_folds_out_of_50": 41,
+      "minimum_leave_one_component_out_positive_fraction": 1.0,
+      "diagnostic_pointwise_lower_positive_assignments": 10,
+      "diagnostic_simultaneous_lower_positive_assignments": 0,
+      "ci_like_gate_evaluable": false,
+      "held_oracle_alpha_nondeployable": 0.5,
+      "held_adjacency_gain_vs_block_at_0_5": 0.01467267984808314,
+      "held_deranged_gain_vs_block_at_0_5": 0.003215770521771962
+    },
+    "fresh": {
+      "matched_rows": 700,
+      "positive_pairs_total": 206,
+      "positive_pairs_eligible": 206,
+      "eligible_positive_components": 40,
+      "primary_trace_over_4_mean": 0.16973974007708037,
+      "primary_trace_over_4_sd": 0.01106544878737865,
+      "primary_trace_over_4_min": 0.15417615648879876,
+      "primary_trace_over_4_max": 0.19126403123463268,
+      "positive_assignments": 10,
+      "positive_folds_out_of_50": 46,
+      "minimum_leave_one_component_out_positive_fraction": 1.0,
+      "diagnostic_pointwise_lower_positive_assignments": 10,
+      "diagnostic_simultaneous_lower_positive_assignments": 6,
+      "ci_like_gate_evaluable": true,
+      "held_oracle_alpha_nondeployable": 0.5,
+      "held_adjacency_gain_vs_block_at_0_5": 0.021166766116193808,
+      "held_deranged_gain_vs_block_at_0_5": 0.01002999697234894
+    }
+  },
+  "known_mean_known_B_mechanism": {
+    "replicates": 200,
+    "components_28": {
+      "block_null_pointwise_false_positive_rate": 0.035,
+      "coupling_0_10_pointwise_detection_rate": 0.18,
+      "coupling_0_20_pointwise_detection_rate": 0.45,
+      "frozen_80pct_power_gate": false
+    },
+    "components_40": {
+      "block_null_pointwise_false_positive_rate": 0.005,
+      "coupling_0_10_pointwise_detection_rate": 0.195,
+      "coupling_0_20_pointwise_detection_rate": 0.61,
+      "frozen_80pct_power_gate": false
+    },
+    "diagnostic_component_sizing_for_coupling_0_10": {
+      "components_160_pointwise_detection_rate": 0.58,
+      "components_240_pointwise_detection_rate": 0.755,
+      "components_320_pointwise_detection_rate": 0.81,
+      "components_400_pointwise_detection_rate": 0.915,
+      "components_320_simultaneous_detection_rate": 0.54,
+      "components_400_simultaneous_detection_rate": 0.65,
+      "favorable_pointwise_80pct_lower_bound_components": 320,
+      "simultaneous_80pct_components": null
+    },
+    "end_to_end_nuisance_control_implemented": false
+  },
+  "decision": {
+    "formal_design_outcome": "not resolved by existing data",
+    "observed_descriptive_contrast_strong": true,
+    "synthetic_mechanism_power_gate_passed": false,
+    "pure_adjacency_identified_separately_from_hop": false,
+    "advance_gate_passed": false,
+    "qr_covariance_deployment": false,
+    "distance_separated_batching_certified": false,
+    "deployment_confidence_level": 0.95,
+    "lower_confidence_use": "80-90% pointwise bands may screen discovery candidates only; they cannot modify covariance, QR batching, or production decisions",
+    "recommended_next": "purpose-built balanced adjacency/distant triples with at least three independent judge draws and more than 320 independent components for a simultaneous/full-procedure target"
+  },
+  "full_output_sha256": {
+    "real_pilot": "61b4b3c15bf509e70df0c2e39ed5edfbb28dec54887d399e9b036ac8e001564e",
+    "synthetic_mechanism": "c736e25bc210ff3cd2b9f4385e80afe4c568093d1f1a024d6411e8436ef98057"
+  }
+}

--- a/prototypes/mu_cosine/repro/adjacent_residual_pilot/summary.json
+++ b/prototypes/mu_cosine/repro/adjacent_residual_pilot/summary.json
@@ -1,6 +1,8 @@
 {
   "status": "descriptively strong adjacency-plus-hop signal; synthetic power and repeated-judge gates fail; no QR deployment",
   "design": "DESIGN_adjacent_residual_pilot.md",
+  "artifact_schema_version": 2,
+  "portable_content_addressed_provenance": true,
   "configuration": {
     "assignment_seeds": [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
     "component_folds": 5,
@@ -88,7 +90,7 @@
     "recommended_next": "purpose-built balanced adjacency/distant triples with at least three independent judge draws and more than 320 independent components for a simultaneous/full-procedure target"
   },
   "full_output_sha256": {
-    "real_pilot": "61b4b3c15bf509e70df0c2e39ed5edfbb28dec54887d399e9b036ac8e001564e",
-    "synthetic_mechanism": "c736e25bc210ff3cd2b9f4385e80afe4c568093d1f1a024d6411e8436ef98057"
+    "real_pilot": "407d52d8fe64df3bf9220da95976bee5c046c5d806d676aa38aafa4a475e100a",
+    "synthetic_mechanism": "62695568b1eae247ece2d3e37a18250c756b57536bdf6fe7e0ec7a91f8b8c18e"
   }
 }

--- a/prototypes/mu_cosine/run_adjacent_residual_pilot.py
+++ b/prototypes/mu_cosine/run_adjacent_residual_pilot.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""Run the descriptive adjacent-row conditional-residual pilot.
+
+This executable uses whole-endpoint-component OOF fits and anchor-sharing
+nonadjacent controls.  Its multiplier bands are conditional stability
+summaries, not population confidence intervals or a QR deployment gate.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import asdict
+import json
+import os
+import sys
+import time
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from adjacent_residual_pilot import (
+    adjacency_feature_kernel,
+    anchor_matched_contrasts,
+    component_balanced_folds,
+    component_contrast_estimate,
+    component_multiplier_stability,
+    marginal_preserving_adjacency_covariance,
+    positive_row_pairs,
+    principal_whiten_rows,
+    within_descendant_derangement,
+)
+from eval_luna_transfer import load_luna as load_scored_mu_tsv
+from fine_tune_channel_heads import CAMPAIGN_E5_100K, load_campaign_datasets, load_expanded
+from run_cheap_judge_joint_posterior import load_decision_targets
+from run_covariance_sensitivity import fit_context
+from run_product_kalman_realdata import DATASETS
+from run_structured_residual_covariance import (
+    DEFAULT_CAMPAIGN,
+    DEFAULT_LUNA,
+    configure_artifact_repo,
+    file_provenance,
+    materialize_corpus,
+)
+from structured_residual_covariance import gaussian_joint_nll
+
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+ADJACENCY_ALPHAS = (0.0, 0.025, 0.05, 0.10, 0.20, 0.35, 0.50)
+
+
+def _jsonable(value):
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _write_payload(path, payload):
+    serialized = json.dumps(_jsonable(payload), indent=2, sort_keys=True, allow_nan=False) + "\n"
+    path = os.path.abspath(path)
+    temporary = path + ".tmp"
+    with open(temporary, "w", encoding="utf-8", newline="\n") as stream:
+        stream.write(serialized)
+    os.replace(temporary, path)
+
+
+def _undirected_neighbors(parents):
+    neighbors = {}
+    for child, values in parents.items():
+        neighbors.setdefault(child, set()).update(values)
+        for parent in values:
+            neighbors.setdefault(parent, set()).add(child)
+    return {node: frozenset(values) for node, values in neighbors.items()}
+
+
+def _matrix_record(matrix):
+    matrix = np.asarray(matrix, dtype=float)
+    eigenvalues = np.linalg.eigvalsh(0.5 * (matrix + matrix.T))
+    return {
+        "matrix": matrix,
+        "trace_over_4": float(np.trace(matrix) / 4.0),
+        "eigenvalues": eigenvalues,
+        "spectral_norm": float(np.max(np.abs(eigenvalues))),
+    }
+
+
+def _stability_record(band):
+    values = asdict(band)
+    names = values.pop("names")
+    vector_fields = (
+        "estimate",
+        "standard_error",
+        "pointwise_low",
+        "pointwise_high",
+        "simultaneous_low",
+        "simultaneous_high",
+    )
+    by_stat = {}
+    for index, name in enumerate(names):
+        by_stat[name] = {
+            field: float(values[field][index]) for field in vector_fields
+        }
+    for field in vector_fields:
+        values.pop(field)
+    values["by_stat"] = by_stat
+    values["interpretation"] = (
+        "conditional Rademacher component-multiplier stability band; not a population CI"
+    )
+    return values
+
+
+def _matching_record(records, excluded, positive_count, pairs):
+    component_sizes = sorted(Counter(row.component for row in records).values())
+    return {
+        "positive_pairs_total": int(positive_count),
+        "positive_pairs_eligible": int(len(records)),
+        "positive_pairs_excluded_no_anchor_control": int(len(excluded)),
+        "positive_endpoint_components": int(len({row.component for row in records})),
+        "positive_descendants": int(len({pairs[row.positive[0]][0] for row in records})),
+        "eligible_positive_pairs_per_component_sorted": component_sizes,
+        "controls_total_with_reuse": int(sum(len(row.controls) for row in records)),
+        "positive_tag_pair_counts": dict(Counter(
+            "/".join(row.positive_tag_pair) for row in records
+        )),
+        "mean_tag_distance": float(np.mean([row.mean_tag_distance for row in records])),
+        "mean_degree_bin_difference": float(np.mean([
+            row.mean_degree_bin_difference for row in records
+        ])),
+        "mean_semantic_distance": float(np.mean([
+            row.mean_semantic_distance for row in records
+        ])),
+        "matching_note": (
+            "controls share descendant and one anchor row; exact hop/tag matching has no support"
+        ),
+    }
+
+
+def _oof_whitened_rows(
+    materialized, assignment, neighbors, positive_components, assignment_seed, args
+):
+    row_count = len(materialized["pairs"])
+    whitened = np.full((row_count, 4), np.nan, dtype=float)
+    fold_records = []
+    nll_components = []
+    all_rows = np.arange(row_count, dtype=int)
+    for fold, held in enumerate(assignment.folds):
+        train = np.setdiff1d(all_rows, held, assume_unique=True)
+        context = fit_context(materialized, train, held, args)
+        whitened[held] = principal_whiten_rows(
+            context.centered_evaluate,
+            context.block_model.independent_covariance,
+        )
+        held_component_ids = assignment.component_ids[held]
+        for component in sorted(set(held_component_ids) & set(positive_components)):
+            local = np.flatnonzero(held_component_ids == component)
+            component_pairs = [materialized["pairs"][held[index]] for index in local]
+            component_residuals = context.centered_evaluate[local]
+            kernel = adjacency_feature_kernel(component_pairs, component_pairs, neighbors)
+            deranged, permutation = within_descendant_derangement(
+                kernel,
+                component_pairs,
+                seed=900000 + 1000 * assignment_seed + 100 * fold + int(component),
+            )
+            topology_difference = kernel - deranged
+            relative_topology_difference = float(
+                np.linalg.norm(topology_difference)
+                / max(np.linalg.norm(kernel), np.finfo(float).eps)
+            )
+            block_covariance = context.block_model.independent_covariance
+            block_nll = gaussian_joint_nll(
+                component_residuals,
+                marginal_preserving_adjacency_covariance(
+                    kernel, block_covariance, 0.0
+                ),
+            ).per_scalar
+            curves = []
+            for alpha in ADJACENCY_ALPHAS:
+                adjacent_nll = gaussian_joint_nll(
+                    component_residuals,
+                    marginal_preserving_adjacency_covariance(
+                        kernel, block_covariance, alpha
+                    ),
+                ).per_scalar
+                deranged_nll = gaussian_joint_nll(
+                    component_residuals,
+                    marginal_preserving_adjacency_covariance(
+                        deranged, block_covariance, alpha
+                    ),
+                ).per_scalar
+                curves.append({
+                    "alpha": alpha,
+                    "adjacency_nll_per_scalar": float(adjacent_nll),
+                    "deranged_nll_per_scalar": float(deranged_nll),
+                    "adjacency_gain_vs_block": float(block_nll - adjacent_nll),
+                    "deranged_gain_vs_block": float(block_nll - deranged_nll),
+                })
+            nll_components.append({
+                "component": int(component),
+                "fold": int(fold),
+                "rows": int(len(local)),
+                "derangement_fixed_points": int(np.sum(permutation == np.arange(len(permutation)))),
+                "derangement_relative_frobenius_difference": relative_topology_difference,
+                "derangement_changed_entry_fraction": float(np.mean(
+                    np.abs(topology_difference) > 1e-12
+                )),
+                "block_nll_per_scalar": float(block_nll),
+                "curve": curves,
+            })
+        fold_records.append({
+            **assignment.fold_diagnostics[fold],
+            "train_rows": int(len(train)),
+            "regional_mean": context.regional.to_dict(),
+            "block_covariance": context.block_model.independent_covariance,
+            "block_shrinkage": float(args.shrinkage),
+            "semantic_rbf_bandwidth": float(context.semantic_length),
+            "graph_rbf_bandwidth": float(context.graph_length),
+        })
+    if not np.isfinite(whitened).all():
+        raise AssertionError("every row must receive one finite OOF whitened residual")
+    curve = []
+    for alpha in ADJACENCY_ALPHAS:
+        rows = [
+            next(value for value in component["curve"] if value["alpha"] == alpha)
+            for component in nll_components
+        ]
+        curve.append({
+            "alpha": alpha,
+            "components": len(rows),
+            "adjacency_nll_per_scalar_component_macro": float(np.mean([
+                value["adjacency_nll_per_scalar"] for value in rows
+            ])),
+            "deranged_nll_per_scalar_component_macro": float(np.mean([
+                value["deranged_nll_per_scalar"] for value in rows
+            ])),
+            "adjacency_gain_vs_block_component_macro": float(np.mean([
+                value["adjacency_gain_vs_block"] for value in rows
+            ])),
+            "deranged_gain_vs_block_component_macro": float(np.mean([
+                value["deranged_gain_vs_block"] for value in rows
+            ])),
+        })
+    return whitened, fold_records, nll_components, curve
+
+
+def run_assignment(corpus, materialized, neighbors, degrees, assignment_seed, args):
+    positives = positive_row_pairs(materialized["pairs"], neighbors)
+    assignment = component_balanced_folds(
+        materialized["pairs"],
+        materialized["tags"],
+        positives,
+        n_folds=args.folds,
+        seed=assignment_seed,
+    )
+    records, excluded = anchor_matched_contrasts(
+        materialized["pairs"],
+        materialized["tags"],
+        neighbors,
+        degrees,
+        materialized["semantic"],
+        maximum_controls=args.maximum_controls,
+    )
+    if len({record.component for record in records}) < 2:
+        raise ValueError(f"{corpus} has fewer than two eligible positive components")
+    positive_components = {record.component for record in records}
+    whitened, folds, nll_components, nll_curve = _oof_whitened_rows(
+        materialized,
+        assignment,
+        neighbors,
+        positive_components,
+        assignment_seed,
+        args,
+    )
+    estimate = component_contrast_estimate(whitened, records)
+    stability = component_multiplier_stability(
+        estimate.contrast_matrices,
+        draws=args.multiplier_draws,
+        seed=700000 + assignment_seed,
+        confidence=args.stability_confidence,
+    )
+    fold_primary = []
+    for held in assignment.folds:
+        held_set = set(map(int, held))
+        selected = [row for row in records if row.positive[0] in held_set]
+        if selected:
+            fold_primary.append(float(
+                component_contrast_estimate(whitened, selected).primary_trace
+            ))
+        else:
+            fold_primary.append(None)
+    oracle = min(
+        nll_curve,
+        key=lambda value: (
+            value["adjacency_nll_per_scalar_component_macro"], value["alpha"]
+        ),
+    )
+    oracle_deranged = next(
+        value for value in nll_curve if value["alpha"] == oracle["alpha"]
+    )
+    return {
+        "corpus": corpus,
+        "assignment_seed": int(assignment_seed),
+        "scope": "descriptive existing-data adjacency-plus-local-hop predictive contrast",
+        "matching": _matching_record(
+            records, excluded, len(positives), materialized["pairs"]
+        ),
+        "component_assignment": {
+            "folds": int(args.folds),
+            "endpoint_components": int(assignment.component_count),
+            "largest_endpoint_component_rows": int(assignment.largest_component),
+            "fold_records": folds,
+        },
+        "primary_trace_over_4": float(estimate.primary_trace),
+        "fold_primary_trace_over_4": fold_primary,
+        "positive_cross_product": _matrix_record(estimate.positive),
+        "anchor_control_cross_product": _matrix_record(estimate.control),
+        "component_macro_contrast": _matrix_record(estimate.contrast),
+        "edge_weighted_contrast_secondary": _matrix_record(
+            estimate.edge_weighted_contrast
+        ),
+        "nondeployable_held_alpha_grid": {
+            "warning": (
+                "outer-held descriptive oracle; alpha was not nested-selected and cannot be deployed"
+            ),
+            "alphas": list(ADJACENCY_ALPHAS),
+            "component_records": nll_components,
+            "component_macro_curve": nll_curve,
+            "adjacency_oracle": oracle,
+            "deranged_at_adjacency_oracle_alpha": oracle_deranged,
+            "diagnostic_checks": {
+                "oracle_gain_positive": bool(
+                    oracle["adjacency_gain_vs_block_component_macro"] > 0.0
+                ),
+                "adjacency_beats_deranged_at_oracle_alpha": bool(
+                    oracle["adjacency_nll_per_scalar_component_macro"]
+                    < oracle_deranged["deranged_nll_per_scalar_component_macro"]
+                ),
+            },
+        },
+        "stability": _stability_record(stability),
+        "advance_only_checks": {
+            "primary_positive": bool(estimate.primary_trace > 0.0),
+            "at_least_4_of_5_fold_directions_positive": bool(
+                sum(value is not None and value > 0.0 for value in fold_primary) >= 4
+            ),
+            "at_least_80pct_leave_one_component_out_positive": bool(
+                stability.leave_one_component_out_positive_fraction >= 0.80
+            ),
+            "conditional_simultaneous_lower_trace_positive": (
+                bool(stability.simultaneous_low[0] > 0.0)
+                if stability.gate_evaluable else None
+            ),
+            "stability_gate_evaluable": bool(stability.gate_evaluable),
+        },
+    }
+
+
+def aggregate_results(results, expected_assignments):
+    by_corpus = {}
+    for corpus in ("exploratory", "fresh"):
+        rows = [row for row in results if row["corpus"] == corpus]
+        values = np.asarray([row["primary_trace_over_4"] for row in rows], dtype=float)
+        all_stability_evaluable = bool(
+            len(rows) == expected_assignments
+            and all(row["stability"]["gate_evaluable"] for row in rows)
+        )
+        diagnostic_pointwise_positive = int(sum(
+            row["stability"]["by_stat"]["trace_over_4"]["pointwise_low"] > 0.0
+            for row in rows
+        ))
+        diagnostic_simultaneous_positive = int(sum(
+            row["stability"]["by_stat"]["trace_over_4"]["simultaneous_low"] > 0.0
+            for row in rows
+        ))
+        alpha_curve = []
+        for alpha in ADJACENCY_ALPHAS:
+            selected = [
+                next(
+                    value for value in row["nondeployable_held_alpha_grid"][
+                        "component_macro_curve"
+                    ] if value["alpha"] == alpha
+                )
+                for row in rows
+            ]
+            alpha_curve.append({
+                "alpha": alpha,
+                "adjacency_gain_vs_block_mean": (
+                    float(np.mean([
+                        value["adjacency_gain_vs_block_component_macro"]
+                        for value in selected
+                    ])) if selected else None
+                ),
+                "deranged_gain_vs_block_mean": (
+                    float(np.mean([
+                        value["deranged_gain_vs_block_component_macro"]
+                        for value in selected
+                    ])) if selected else None
+                ),
+            })
+        by_corpus[corpus] = {
+            "assignments_completed": int(len(rows)),
+            "expected_assignments": int(expected_assignments),
+            "primary_trace_over_4_mean": float(np.mean(values)) if len(values) else None,
+            "primary_trace_over_4_sd": (
+                float(np.std(values, ddof=1)) if len(values) > 1 else 0.0 if len(values) else None
+            ),
+            "primary_trace_over_4_min": float(np.min(values)) if len(values) else None,
+            "primary_trace_over_4_max": float(np.max(values)) if len(values) else None,
+            "positive_assignments": int(np.sum(values > 0.0)),
+            "diagnostic_primary_pointwise_lower_positive_assignments": (
+                diagnostic_pointwise_positive
+            ),
+            "diagnostic_primary_simultaneous_lower_positive_assignments": (
+                diagnostic_simultaneous_positive
+            ),
+            "ci_like_positive_assignment_counts": (
+                {
+                    "pointwise": diagnostic_pointwise_positive,
+                    "simultaneous": diagnostic_simultaneous_positive,
+                } if all_stability_evaluable else None
+            ),
+            "nondeployable_held_alpha_curve": alpha_curve,
+            "all_stability_gates_evaluable": all_stability_evaluable,
+            "minimum_leave_one_component_out_positive_fraction": (
+                float(min(
+                    row["stability"]["leave_one_component_out_positive_fraction"]
+                    for row in rows
+                )) if rows else None
+            ),
+        }
+    complete = all(
+        by_corpus[corpus]["assignments_completed"] == expected_assignments
+        for corpus in by_corpus
+    )
+    return {
+        "by_corpus": by_corpus,
+        "complete": complete,
+        "advance_to_repeated_judge_confirmation": False,
+        "qr_covariance_deployment": False,
+        "reason": (
+            "real pilot cannot pass deployment; full-procedure synthetic power and repeated-judge "
+            "confirmation are not supplied by this runner"
+        ),
+    }
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-repo", default=os.path.abspath(os.path.join(ROOT, "..", "..")))
+    parser.add_argument("--ckpt", default=os.path.join(ROOT, "model_prod_namecond.pt"))
+    parser.add_argument("--campaign", default=DEFAULT_CAMPAIGN)
+    parser.add_argument("--luna", default=DEFAULT_LUNA)
+    parser.add_argument("--assignment-seed-start", type=int, default=20)
+    parser.add_argument("--assignments", type=int, default=10)
+    parser.add_argument("--folds", type=int, default=5)
+    parser.add_argument("--maximum-controls", type=int, default=3)
+    parser.add_argument("--multiplier-draws", type=int, default=9999)
+    parser.add_argument("--stability-confidence", type=float, default=0.95)
+    parser.add_argument("--shrinkage", type=float, default=0.05)
+    parser.add_argument(
+        "--ridge-grid", type=float, nargs="+", default=[1e-3, 1e-2, 1e-1, 1.0, 10.0]
+    )
+    parser.add_argument("--cpu-threads", type=int, default=1)
+    parser.add_argument(
+        "--lmdb-no-lock",
+        action="store_true",
+        help="read the immutable local fresh graph without LMDB locking",
+    )
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--out", default="/tmp/adjacent_residual_pilot.json")
+    return parser
+
+
+def _validate_args(args):
+    if args.assignments < 1 or args.folds != 5:
+        raise ValueError("assignments must be positive and this frozen pilot requires exactly five folds")
+    if args.maximum_controls < 1 or args.multiplier_draws < 1:
+        raise ValueError("maximum-controls and multiplier-draws must be positive")
+    if not 0.0 < args.stability_confidence < 1.0:
+        raise ValueError("stability-confidence must be in (0,1)")
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    _validate_args(args)
+    torch.set_num_threads(args.cpu_threads)
+    np.random.seed(0)
+    artifacts = configure_artifact_repo(args.artifact_repo)
+    if args.lmdb_no_lock:
+        DATASETS["fresh"]["graph"]["lmdb_no_lock"] = True
+    target_by_pair, cur_rel = load_decision_targets(args.campaign)
+    luna_pairs, luna_d, luna_s = load_scored_mu_tsv(args.luna)
+    luna_by_pair = {pair: (luna_d[i], luna_s[i]) for i, pair in enumerate(luna_pairs)}
+    checkpoint = load_expanded(args.ckpt, dev="cpu")
+    checkpoint[0].eval()
+    datasets = load_campaign_datasets(campaign_scored=args.campaign)
+    materialized, graph = {}, {}
+    for name, dataset in datasets.items():
+        corpus = name.replace("-campaign", "")
+        materialized[corpus] = materialize_corpus(
+            name, dataset, target_by_pair, luna_by_pair, checkpoint
+        )
+        parents = dataset["tok"].parents
+        graph[corpus] = {
+            "neighbors": _undirected_neighbors(parents),
+            "degrees": dataset["tok"].deg,
+        }
+    configuration = vars(args).copy()
+    configuration.pop("resume")
+    payload = {
+        "schema_version": 1,
+        "status": "DESCRIPTIVE EXISTING-DATA PILOT; NO POPULATION CI OR QR DEPLOYMENT GATE",
+        "design": "DESIGN_adjacent_residual_pilot.md",
+        "target_scope": "GPT-5.5 operating-judge fidelity; not independent ground truth",
+        "estimand": "same-descendant adjacency plus local-hop proximity predictive contrast",
+        "implementation": {
+            "design": file_provenance(os.path.join(ROOT, "DESIGN_adjacent_residual_pilot.md")),
+            "core": file_provenance(os.path.join(ROOT, "adjacent_residual_pilot.py")),
+            "runner": file_provenance(os.path.abspath(__file__)),
+            "dependencies": {
+                name: file_provenance(os.path.join(ROOT, name))
+                for name in (
+                    "fine_tune_channel_heads.py",
+                    "run_cheap_judge_joint_posterior.py",
+                    "run_covariance_sensitivity.py",
+                    "run_structured_residual_covariance.py",
+                    "structured_residual_covariance.py",
+                )
+            },
+        },
+        "inputs": {
+            "checkpoint": file_provenance(args.ckpt),
+            "campaign": file_provenance(args.campaign),
+            "luna": file_provenance(args.luna),
+            "artifact_paths": artifacts,
+            "e5_caches": {
+                "exploratory": file_provenance(CAMPAIGN_E5_100K),
+                "fresh": file_provenance(DATASETS["fresh"]["e5_cache"]),
+            },
+            "campaign_cur_rel_counts": dict(cur_rel),
+        },
+        "configuration": configuration,
+        "results": [],
+        "aggregate": None,
+    }
+    if args.resume and os.path.isfile(args.out):
+        with open(args.out, encoding="utf-8") as stream:
+            previous = json.load(stream)
+        for key in (
+            "schema_version", "design", "implementation", "inputs", "configuration", "estimand"
+        ):
+            if previous.get(key) != payload[key]:
+                raise ValueError(f"refusing to resume with mismatched {key}")
+        payload = previous
+    completed = {
+        (row["corpus"], int(row["assignment_seed"])) for row in payload["results"]
+    }
+    if len(completed) != len(payload["results"]):
+        raise ValueError("resume output contains duplicate corpus/assignment records")
+    started = time.perf_counter()
+    for seed in range(args.assignment_seed_start, args.assignment_seed_start + args.assignments):
+        for corpus in ("exploratory", "fresh"):
+            if (corpus, seed) in completed:
+                print(f"skipping completed {corpus} assignment {seed}", flush=True)
+                continue
+            print(f"\n=== adjacent residual pilot: {corpus}, assignment {seed} ===", flush=True)
+            row = run_assignment(
+                corpus,
+                materialized[corpus],
+                graph[corpus]["neighbors"],
+                graph[corpus]["degrees"],
+                seed,
+                args,
+            )
+            payload["results"].append(row)
+            completed.add((corpus, seed))
+            payload["aggregate"] = aggregate_results(payload["results"], args.assignments)
+            _write_payload(args.out, payload)
+            print(
+                f"  trace/4={row['primary_trace_over_4']:+.6f}; "
+                f"eligible={row['matching']['positive_pairs_eligible']}; "
+                f"components={row['stability']['components']}; "
+                f"LOCO+={row['stability']['leave_one_component_out_positive_fraction']:.1%}",
+                flush=True,
+            )
+    payload["aggregate"] = aggregate_results(payload["results"], args.assignments)
+    _write_payload(args.out, payload)
+    print(f"\nwrote {args.out}; wall_seconds={time.perf_counter() - started:.1f}")
+    print(json.dumps(payload["aggregate"], indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/run_adjacent_residual_pilot.py
+++ b/prototypes/mu_cosine/run_adjacent_residual_pilot.py
@@ -47,6 +47,7 @@ from structured_residual_covariance import gaussian_joint_nll
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 ADJACENCY_ALPHAS = (0.0, 0.025, 0.05, 0.10, 0.20, 0.35, 0.50)
+LOCATOR_ARGUMENTS = ("artifact_repo", "ckpt", "campaign", "luna", "out", "resume")
 
 
 def _jsonable(value):
@@ -68,6 +69,35 @@ def _write_payload(path, payload):
     with open(temporary, "w", encoding="utf-8", newline="\n") as stream:
         stream.write(serialized)
     os.replace(temporary, path)
+
+
+def _content_provenance(path):
+    """Byte identity for a file, deliberately excluding its machine-local locator."""
+    record = file_provenance(path)
+    return {"size_bytes": record["size_bytes"], "sha256": record["sha256"]}
+
+
+def _scientific_configuration(args):
+    """Return outcome-determining options without input/output locators."""
+    configuration = vars(args).copy()
+    for name in LOCATOR_ARGUMENTS:
+        configuration.pop(name, None)
+    return configuration
+
+
+def _portable_artifact_provenance(artifacts):
+    """Keep content identity and the LMDB exclusion contract, not checkout paths."""
+    return {
+        "exploratory_graph": {
+            "size_bytes": artifacts["exploratory_graph"]["size_bytes"],
+            "sha256": artifacts["exploratory_graph"]["sha256"],
+        },
+        "fresh_lmdb_data": {
+            "size_bytes": artifacts["fresh_lmdb_data"]["size_bytes"],
+            "sha256": artifacts["fresh_lmdb_data"]["sha256"],
+        },
+        "fresh_lmdb_lock_excluded": artifacts["fresh_lmdb_lock_excluded"],
+    }
 
 
 def _undirected_neighbors(parents):
@@ -510,20 +540,19 @@ def main():
             "neighbors": _undirected_neighbors(parents),
             "degrees": dataset["tok"].deg,
         }
-    configuration = vars(args).copy()
-    configuration.pop("resume")
+    configuration = _scientific_configuration(args)
     payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "status": "DESCRIPTIVE EXISTING-DATA PILOT; NO POPULATION CI OR QR DEPLOYMENT GATE",
         "design": "DESIGN_adjacent_residual_pilot.md",
         "target_scope": "GPT-5.5 operating-judge fidelity; not independent ground truth",
         "estimand": "same-descendant adjacency plus local-hop proximity predictive contrast",
         "implementation": {
-            "design": file_provenance(os.path.join(ROOT, "DESIGN_adjacent_residual_pilot.md")),
-            "core": file_provenance(os.path.join(ROOT, "adjacent_residual_pilot.py")),
-            "runner": file_provenance(os.path.abspath(__file__)),
+            "design": _content_provenance(os.path.join(ROOT, "DESIGN_adjacent_residual_pilot.md")),
+            "core": _content_provenance(os.path.join(ROOT, "adjacent_residual_pilot.py")),
+            "runner": _content_provenance(os.path.abspath(__file__)),
             "dependencies": {
-                name: file_provenance(os.path.join(ROOT, name))
+                name: _content_provenance(os.path.join(ROOT, name))
                 for name in (
                     "fine_tune_channel_heads.py",
                     "run_cheap_judge_joint_posterior.py",
@@ -534,13 +563,13 @@ def main():
             },
         },
         "inputs": {
-            "checkpoint": file_provenance(args.ckpt),
-            "campaign": file_provenance(args.campaign),
-            "luna": file_provenance(args.luna),
-            "artifact_paths": artifacts,
+            "checkpoint": _content_provenance(args.ckpt),
+            "campaign": _content_provenance(args.campaign),
+            "luna": _content_provenance(args.luna),
+            "graph_artifacts": _portable_artifact_provenance(artifacts),
             "e5_caches": {
-                "exploratory": file_provenance(CAMPAIGN_E5_100K),
-                "fresh": file_provenance(DATASETS["fresh"]["e5_cache"]),
+                "exploratory": _content_provenance(CAMPAIGN_E5_100K),
+                "fresh": _content_provenance(DATASETS["fresh"]["e5_cache"]),
             },
             "campaign_cur_rel_counts": dict(cur_rel),
         },

--- a/prototypes/mu_cosine/run_adjacent_residual_synthetic.py
+++ b/prototypes/mu_cosine/run_adjacent_residual_synthetic.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Mechanism power audit for the adjacent component-multiplier statistic.
+
+This runner uses known zero mean and identity within-row covariance.  It does
+not emulate the end-to-end calibration/KRR/B fitting pipeline and therefore
+cannot by itself unlock the real-data pilot.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import time
+
+import numpy as np
+
+from adjacent_residual_pilot import component_multiplier_stability
+
+
+COMPONENT_COUNTS = (28, 40)
+COUPLINGS = (0.0, 0.04, 0.10, 0.20)
+
+
+def _file_record(path):
+    path = os.path.abspath(path)
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(chunk)
+    return {"path": path, "size_bytes": os.path.getsize(path), "sha256": digest.hexdigest()}
+
+
+def simulate_component_contrasts(components, coupling, seed):
+    """Generate one anchor-matched 4x4 contrast per independent component."""
+    if components < 2:
+        raise ValueError("components must be at least two")
+    if not 0.0 <= coupling < 1.0:
+        raise ValueError("coupling must be in [0,1)")
+    rng = np.random.default_rng(seed)
+    output = []
+    for _ in range(components):
+        anchor = rng.standard_normal(4)
+        positive_partner = (
+            coupling * anchor
+            + np.sqrt(1.0 - coupling * coupling) * rng.standard_normal(4)
+        )
+        first_control = rng.standard_normal(4)
+        second_control = rng.standard_normal(4)
+        positive = 0.5 * (
+            np.outer(anchor, positive_partner)
+            + np.outer(positive_partner, anchor)
+        )
+        controls = 0.25 * (
+            np.outer(anchor, first_control)
+            + np.outer(first_control, anchor)
+            + np.outer(positive_partner, second_control)
+            + np.outer(second_control, positive_partner)
+        )
+        output.append(positive - controls)
+    return np.asarray(output)
+
+
+def _summary(values):
+    values = np.asarray(values, dtype=float)
+    return {
+        "mean": float(np.mean(values)),
+        "sd": float(np.std(values, ddof=1)) if len(values) > 1 else 0.0,
+        "q05": float(np.quantile(values, 0.05)),
+        "median": float(np.median(values)),
+        "q95": float(np.quantile(values, 0.95)),
+    }
+
+
+def run_scenario(components, coupling, args):
+    records = []
+    for replicate in range(args.replicates):
+        seed = args.seed + 100000 * components + 10000 * int(round(coupling * 100)) + replicate
+        matrices = simulate_component_contrasts(components, coupling, seed)
+        band = component_multiplier_stability(
+            matrices,
+            draws=args.multiplier_draws,
+            seed=seed + 500000,
+            confidence=args.confidence,
+        )
+        primary = float(band.estimate[0])
+        pointwise_low = float(band.pointwise_low[0])
+        simultaneous_low = float(band.simultaneous_low[0])
+        true_matrix = np.eye(4) * coupling
+        error = float(np.max(np.abs(np.linalg.eigvalsh(
+            np.mean(matrices, axis=0) - true_matrix
+        ))))
+        records.append({
+            "primary_trace_over_4": primary,
+            "pointwise_lower_positive": bool(pointwise_low > 0.0),
+            "simultaneous_lower_positive": bool(simultaneous_low > 0.0),
+            "pointwise_contains_truth": bool(
+                band.pointwise_low[0] <= coupling <= band.pointwise_high[0]
+            ),
+            "spectral_radius_contains_truth": bool(error <= band.spectral_error_radius),
+        })
+    return {
+        "components": int(components),
+        "coupling": float(coupling),
+        "replicates": int(args.replicates),
+        "primary_trace_over_4": _summary([
+            row["primary_trace_over_4"] for row in records
+        ]),
+        "pointwise_positive_rate": float(np.mean([
+            row["pointwise_lower_positive"] for row in records
+        ])),
+        "simultaneous_positive_rate": float(np.mean([
+            row["simultaneous_lower_positive"] for row in records
+        ])),
+        "pointwise_truth_inclusion_rate": float(np.mean([
+            row["pointwise_contains_truth"] for row in records
+        ])),
+        "spectral_truth_inclusion_rate": float(np.mean([
+            row["spectral_radius_contains_truth"] for row in records
+        ])),
+    }
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--replicates", type=int, default=200)
+    parser.add_argument("--multiplier-draws", type=int, default=999)
+    parser.add_argument("--confidence", type=float, default=0.95)
+    parser.add_argument("--seed", type=int, default=731000)
+    parser.add_argument("--component-counts", type=int, nargs="+", default=list(COMPONENT_COUNTS))
+    parser.add_argument("--couplings", type=float, nargs="+", default=list(COUPLINGS))
+    parser.add_argument("--out", default="/tmp/adjacent_residual_synthetic.json")
+    return parser
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    if args.replicates < 1 or args.multiplier_draws < 1:
+        raise ValueError("replicates and multiplier-draws must be positive")
+    if not 0.0 < args.confidence < 1.0:
+        raise ValueError("confidence must be in (0,1)")
+    if any(value < 2 for value in args.component_counts):
+        raise ValueError("every component count must be at least two")
+    if any(not 0.0 <= value < 1.0 for value in args.couplings) or 0.0 not in args.couplings:
+        raise ValueError("couplings must be in [0,1) and include the block null 0.0")
+    started = time.perf_counter()
+    scenarios = [
+        run_scenario(components, coupling, args)
+        for components in args.component_counts
+        for coupling in args.couplings
+    ]
+    by_count = {}
+    for components in args.component_counts:
+        rows = {row["coupling"]: row for row in scenarios if row["components"] == components}
+        powered_couplings = [value for value in args.couplings if value >= 0.10]
+        by_count[str(components)] = {
+            "block_null_pointwise_false_positive_at_most_10pct": bool(
+                rows[0.0]["pointwise_positive_rate"] <= 0.10
+            ),
+            "pointwise_detection_at_least_80pct_for_all_requested_couplings_ge_0_10": bool(
+                powered_couplings
+                and all(rows[value]["pointwise_positive_rate"] >= 0.80 for value in powered_couplings)
+            ),
+        }
+    payload = {
+        "schema_version": 1,
+        "status": "KNOWN-MEAN/KNOWN-B MECHANISM AUDIT; END-TO-END POWER NOT IMPLEMENTED",
+        "mechanism_scope": (
+            "one equal-weight contrast with two anchor controls per independent component; "
+            "no unequal component sizes or fitted calibration/KRR/B nuisance"
+        ),
+        "design": "DESIGN_adjacent_residual_pilot.md",
+        "implementation": {
+            "design": _file_record(os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "DESIGN_adjacent_residual_pilot.md"
+            )),
+            "core": _file_record(os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "adjacent_residual_pilot.py"
+            )),
+            "runner": _file_record(os.path.abspath(__file__)),
+        },
+        "configuration": vars(args),
+        "component_counts": list(args.component_counts),
+        "couplings": list(args.couplings),
+        "scenarios": scenarios,
+        "mechanism_gates": by_count,
+        "real_data_gate_unlocked": False,
+        "reason": (
+            "full-procedure smooth-mean/null calibration and repeated-judge identification are absent"
+        ),
+    }
+    path = os.path.abspath(args.out)
+    temporary = path + ".tmp"
+    serialized = json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    with open(temporary, "w", encoding="utf-8", newline="\n") as stream:
+        stream.write(serialized)
+    os.replace(temporary, path)
+    print(json.dumps({
+        "output": path,
+        "wall_seconds": time.perf_counter() - started,
+        "mechanism_gates": by_count,
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/run_adjacent_residual_synthetic.py
+++ b/prototypes/mu_cosine/run_adjacent_residual_synthetic.py
@@ -28,7 +28,14 @@ def _file_record(path):
     with open(path, "rb") as stream:
         for chunk in iter(lambda: stream.read(1 << 20), b""):
             digest.update(chunk)
-    return {"path": path, "size_bytes": os.path.getsize(path), "sha256": digest.hexdigest()}
+    return {"size_bytes": os.path.getsize(path), "sha256": digest.hexdigest()}
+
+
+def _scientific_configuration(args):
+    """Return outcome-determining options without the output locator."""
+    configuration = vars(args).copy()
+    configuration.pop("out", None)
+    return configuration
 
 
 def simulate_component_contrasts(components, coupling, seed):
@@ -163,7 +170,7 @@ def main():
             ),
         }
     payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "status": "KNOWN-MEAN/KNOWN-B MECHANISM AUDIT; END-TO-END POWER NOT IMPLEMENTED",
         "mechanism_scope": (
             "one equal-weight contrast with two anchor controls per independent component; "
@@ -179,7 +186,7 @@ def main():
             )),
             "runner": _file_record(os.path.abspath(__file__)),
         },
-        "configuration": vars(args),
+        "configuration": _scientific_configuration(args),
         "component_counts": list(args.component_counts),
         "couplings": list(args.couplings),
         "scenarios": scenarios,

--- a/prototypes/mu_cosine/test_adjacent_residual_pilot.py
+++ b/prototypes/mu_cosine/test_adjacent_residual_pilot.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for the component-safe adjacent residual pilot primitives."""
+import numpy as np
+import pytest
+
+from adjacent_residual_pilot import (
+    AnchorContrast,
+    adjacency_feature_kernel,
+    anchor_matched_contrasts,
+    component_balanced_folds,
+    component_contrast_estimate,
+    component_multiplier_stability,
+    endpoint_component_ids,
+    marginal_preserving_adjacency_covariance,
+    positive_row_pairs,
+    principal_whiten_rows,
+    within_descendant_derangement,
+)
+from run_adjacent_residual_synthetic import simulate_component_contrasts
+
+
+def test_endpoint_components_and_balanced_folds_are_disjoint_and_deterministic():
+    pairs, tags = [], []
+    neighbors = {}
+    for component in range(9):
+        left = f"left-{component}"
+        first, second = f"root-{component}-a", f"root-{component}-b"
+        pairs.extend([(left, first), (left, second)])
+        tags.extend(["campaign_h1", "campaign_h2"])
+        neighbors[first] = {second}
+        neighbors[second] = {first}
+    positives = positive_row_pairs(pairs, neighbors)
+    first = component_balanced_folds(pairs, tags, positives, n_folds=3, seed=20)
+    second = component_balanced_folds(pairs, tags, positives, n_folds=3, seed=20)
+
+    assert first.component_count == 9
+    assert first.largest_component == 2
+    assert [fold.tolist() for fold in first.folds] == [fold.tolist() for fold in second.folds]
+    assert sorted(np.concatenate(first.folds).tolist()) == list(range(18))
+    assert [row["positive_pairs"] for row in first.fold_diagnostics] == [3, 3, 3]
+    for left in range(3):
+        left_nodes = {node for row in first.folds[left] for node in pairs[row]}
+        for right in range(left + 1, 3):
+            right_nodes = {node for row in first.folds[right] for node in pairs[row]}
+            assert left_nodes.isdisjoint(right_nodes)
+
+
+def test_anchor_controls_share_descendant_and_one_positive_row():
+    pairs = [("x", "r1"), ("x", "r2"), ("x", "r3"), ("x", "r4")]
+    tags = ["campaign_h1", "campaign_h2", "campaign_h3", "campaign_h4"]
+    neighbors = {"r1": {"r2"}, "r2": {"r1"}, "r3": set(), "r4": set()}
+    degrees = {root: len(values) for root, values in neighbors.items()}
+    semantic = np.eye(4)
+    records, excluded = anchor_matched_contrasts(
+        pairs, tags, neighbors, degrees, semantic, maximum_controls=3
+    )
+
+    assert not excluded
+    assert len(records) == 1
+    record = records[0]
+    assert record.positive == (0, 1)
+    assert len(record.controls) == 3
+    assert all(set(pair) & {0, 1} for pair in record.controls)
+    assert all(pairs[a][0] == pairs[b][0] == "x" for a, b in record.controls)
+    assert all(not (pairs[b][1] in neighbors.get(pairs[a][1], set())) for a, b in record.controls)
+
+
+def test_principal_whitening_uses_symmetric_inverse_root():
+    covariance = np.array([
+        [2.0, 0.3, 0.0, 0.0],
+        [0.3, 1.0, 0.1, 0.0],
+        [0.0, 0.1, 1.5, 0.2],
+        [0.0, 0.0, 0.2, 0.8],
+    ])
+    values, vectors = np.linalg.eigh(covariance)
+    symmetric_root = (vectors * np.sqrt(values)) @ vectors.T
+    whitened = principal_whiten_rows(symmetric_root, covariance)
+    np.testing.assert_allclose(whitened, np.eye(4), atol=1e-12)
+
+
+def test_component_macro_contrast_and_multiplier_stability():
+    rows = np.array([
+        [1.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [2.0, 0.0, 0.0, 0.0],
+        [2.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0, 0.0],
+    ])
+    records = (
+        AnchorContrast((0, 1), ((0, 2), (1, 3)), 10, ("h1", "h2"), 1, 0, 0),
+        AnchorContrast((4, 5), ((4, 6), (5, 7)), 20, ("h1", "h2"), 1, 0, 0),
+    )
+    estimate = component_contrast_estimate(rows, records)
+
+    assert estimate.record_count == 2
+    assert estimate.component_ids.tolist() == [10, 20]
+    assert estimate.primary_trace > 0.0
+    band = component_multiplier_stability(
+        np.repeat(estimate.contrast_matrices, 20, axis=0), draws=999, seed=8
+    )
+    assert band.components == 40
+    assert band.gate_evaluable
+    assert band.estimate[0] == pytest.approx(estimate.primary_trace)
+    assert band.leave_one_component_out_positive_fraction == 1.0
+
+
+def test_adjacency_gram_and_covariance_path_are_psd_and_marginal_matched():
+    pairs = [("x", "a"), ("x", "b"), ("x", "c"), ("y", "a")]
+    neighbors = {"a": {"b"}, "b": {"a", "c"}, "c": {"b"}}
+    kernel = adjacency_feature_kernel(pairs, pairs, neighbors)
+
+    np.testing.assert_allclose(np.diag(kernel), 1.0)
+    assert np.min(np.linalg.eigvalsh(kernel)) >= -1e-12
+    assert kernel[0, 3] == 0.0  # descendant role keeps otherwise identical roots separate
+    deranged, permutation = within_descendant_derangement(kernel, pairs, seed=71)
+    np.testing.assert_allclose(np.linalg.eigvalsh(deranged), np.linalg.eigvalsh(kernel))
+    np.testing.assert_allclose(np.diag(deranged), 1.0)
+    assert permutation[0] != 0 and permutation[3] == 3
+    block = np.array([[2.0, 0.2], [0.2, 1.0]])
+    covariance = marginal_preserving_adjacency_covariance(kernel, block, 0.35)
+    assert np.min(np.linalg.eigvalsh(covariance)) > 0.0
+    for row in range(len(pairs)):
+        np.testing.assert_allclose(
+            covariance[row * 2:(row + 1) * 2, row * 2:(row + 1) * 2], block
+        )
+
+
+def test_component_and_covariance_input_guards():
+    assert endpoint_component_ids([("a", "b"), ("b", "c"), ("x", "y")]).tolist() == [0, 0, 1]
+    with pytest.raises(ValueError, match="unit diagonal"):
+        marginal_preserving_adjacency_covariance(np.eye(2) * 2.0, np.eye(2), 0.5)
+    with pytest.raises(np.linalg.LinAlgError, match="positive definite"):
+        principal_whiten_rows(np.zeros((2, 4)), np.zeros((4, 4)))
+
+
+def test_synthetic_anchor_contrast_recovers_planted_trace():
+    matrices = simulate_component_contrasts(2000, 0.20, seed=901)
+    assert np.trace(np.mean(matrices, axis=0)) / 4.0 == pytest.approx(0.20, abs=0.025)
+    with pytest.raises(ValueError, match="components"):
+        simulate_component_contrasts(1, 0.20, seed=1)

--- a/prototypes/mu_cosine/test_run_adjacent_residual_pilot.py
+++ b/prototypes/mu_cosine/test_run_adjacent_residual_pilot.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Runner-level regressions for the descriptive adjacent residual pilot."""
+from types import SimpleNamespace
+
+import pytest
+
+from run_adjacent_residual_pilot import (
+    ADJACENCY_ALPHAS,
+    _validate_args,
+    _write_payload,
+    aggregate_results,
+)
+
+
+def _row(corpus, value, evaluable):
+    curve = [{
+        "alpha": alpha,
+        "adjacency_gain_vs_block_component_macro": alpha / 100.0,
+        "deranged_gain_vs_block_component_macro": alpha / 200.0,
+    } for alpha in ADJACENCY_ALPHAS]
+    return {
+        "corpus": corpus,
+        "primary_trace_over_4": value,
+        "stability": {
+            "gate_evaluable": evaluable,
+            "leave_one_component_out_positive_fraction": 1.0,
+            "by_stat": {
+                "trace_over_4": {"pointwise_low": value - 0.01, "simultaneous_low": value - 0.02}
+            },
+        },
+        "nondeployable_held_alpha_grid": {"component_macro_curve": curve},
+    }
+
+
+def test_frozen_runner_requires_exactly_five_folds():
+    base = dict(
+        assignments=1,
+        maximum_controls=3,
+        multiplier_draws=99,
+        stability_confidence=0.95,
+    )
+    _validate_args(SimpleNamespace(folds=5, **base))
+    with pytest.raises(ValueError, match="exactly five"):
+        _validate_args(SimpleNamespace(folds=4, **base))
+
+
+def test_aggregate_keeps_held_alpha_curve_nondeployable():
+    payload = aggregate_results([
+        _row("exploratory", 0.20, False),
+        _row("fresh", 0.10, True),
+    ], expected_assignments=1)
+
+    assert payload["complete"]
+    assert not payload["advance_to_repeated_judge_confirmation"]
+    assert not payload["qr_covariance_deployment"]
+    assert not payload["by_corpus"]["exploratory"]["all_stability_gates_evaluable"]
+    assert payload["by_corpus"]["fresh"]["ci_like_positive_assignment_counts"]["pointwise"] == 1
+    assert payload["by_corpus"]["exploratory"]["ci_like_positive_assignment_counts"] is None
+    assert len(payload["by_corpus"]["fresh"]["nondeployable_held_alpha_curve"]) == len(
+        ADJACENCY_ALPHAS
+    )
+
+
+def test_payload_writer_is_byte_deterministic_and_rejects_nan(tmp_path):
+    output = tmp_path / "pilot.json"
+    _write_payload(output, {"z": 1, "a": [2]})
+    first = output.read_bytes()
+    _write_payload(output, {"a": [2], "z": 1})
+    assert output.read_bytes() == first
+    with pytest.raises(ValueError, match="Out of range float"):
+        _write_payload(output, {"bad": float("nan")})
+    assert output.read_bytes() == first

--- a/prototypes/mu_cosine/test_run_adjacent_residual_pilot.py
+++ b/prototypes/mu_cosine/test_run_adjacent_residual_pilot.py
@@ -6,9 +6,16 @@ import pytest
 
 from run_adjacent_residual_pilot import (
     ADJACENCY_ALPHAS,
+    _content_provenance,
+    _portable_artifact_provenance,
+    _scientific_configuration,
     _validate_args,
     _write_payload,
     aggregate_results,
+)
+from run_adjacent_residual_synthetic import (
+    _file_record as synthetic_file_record,
+    _scientific_configuration as synthetic_scientific_configuration,
 )
 
 
@@ -70,3 +77,83 @@ def test_payload_writer_is_byte_deterministic_and_rejects_nan(tmp_path):
     with pytest.raises(ValueError, match="Out of range float"):
         _write_payload(output, {"bad": float("nan")})
     assert output.read_bytes() == first
+
+
+def test_content_provenance_is_portable_across_identical_files(tmp_path):
+    first = tmp_path / "first" / "input.bin"
+    second = tmp_path / "second" / "renamed.bin"
+    first.parent.mkdir()
+    second.parent.mkdir()
+    first.write_bytes(b"portable-input")
+    second.write_bytes(b"portable-input")
+
+    expected = {"size_bytes": 14, "sha256": synthetic_file_record(first)["sha256"]}
+    assert synthetic_file_record(first) == expected
+    assert synthetic_file_record(second) == expected
+    assert _content_provenance(first) == expected
+    assert "path" not in expected
+
+
+def test_scientific_configuration_excludes_runtime_locators():
+    scientific = dict(
+        assignments=10,
+        folds=5,
+        ridge_grid=[0.1, 1.0],
+        stability_confidence=0.95,
+    )
+    first = SimpleNamespace(
+        **scientific,
+        artifact_repo="/checkout/a",
+        ckpt="/models/a.pt",
+        campaign="/data/a.tsv",
+        luna="/data/luna-a.tsv",
+        out="/tmp/a.json",
+        resume=False,
+    )
+    second = SimpleNamespace(
+        **scientific,
+        artifact_repo="/checkout/b",
+        ckpt="/models/b.pt",
+        campaign="/data/b.tsv",
+        luna="/data/luna-b.tsv",
+        out="/other/b.json",
+        resume=True,
+    )
+    assert (
+        _scientific_configuration(first)
+        == _scientific_configuration(second)
+        == scientific
+    )
+
+    synthetic_first = SimpleNamespace(replicates=2, seed=7, out="/tmp/a.json")
+    synthetic_second = SimpleNamespace(replicates=2, seed=7, out="/other/b.json")
+    assert (
+        synthetic_scientific_configuration(synthetic_first)
+        == synthetic_scientific_configuration(synthetic_second)
+        == {"replicates": 2, "seed": 7}
+    )
+
+
+def test_artifact_provenance_drops_repository_and_directory_locators():
+    record = {
+        "repository": "/checkout/private",
+        "exploratory_graph": {
+            "path": "/checkout/private/graph.tsv",
+            "size_bytes": 10,
+            "sha256": "a",
+        },
+        "fresh_lmdb_directory": "/checkout/private/lmdb",
+        "fresh_lmdb_data": {
+            "path": "/checkout/private/lmdb/data.mdb",
+            "size_bytes": 20,
+            "sha256": "b",
+        },
+        "fresh_lmdb_lock_excluded": "lock.mdb is process state",
+    }
+    portable = _portable_artifact_provenance(record)
+    assert portable == {
+        "exploratory_graph": {"size_bytes": 10, "sha256": "a"},
+        "fresh_lmdb_data": {"size_bytes": 20, "sha256": "b"},
+        "fresh_lmdb_lock_excluded": "lock.mdb is process state",
+    }
+    assert "/checkout/private" not in repr(portable)


### PR DESCRIPTION
## Summary

- freeze an outcome-blind adjacent-residual pilot over the existing exploratory and fresh campaigns
- cross-fit calibration, conditionalization, regional mean, and within-item covariance while holding out whole endpoint components
- compare same-descendant/direct-edge residual cross-products with anchor-sharing nonadjacent controls
- add a low-capacity PSD adjacency Gram and topology-deranged held-likelihood diagnostic
- add a deterministic known-mean/known-`B` mechanism/power audit, compact provenance, tests, and a full report

## Result

The observed adjacency-plus-local-hop contrast is strong and directionally stable:

| corpus | component-macro trace/4 | positive assignments | eligible positive components |
|---|---:|---:|---:|
| exploratory | +0.279877 ± 0.007426 | 10/10 | 28 |
| fresh | +0.169740 ± 0.011065 | 10/10 | 40 |

Every leave-one-positive-component-out estimate is positive. At the largest frozen diagnostic coupling (`alpha=0.50`), the true adjacency Gram improves held NLL per scalar over the independent block by +0.014673 exploratory and +0.021167 fresh; the deranged comparator improves by +0.003216 and +0.010030.

However, the formal frozen outcome is **not resolved by existing data**:

- adjacency is confounded with local hop/tag position in the existing campaign
- there is only one residual field per corpus, so persistent item structure cannot be separated from stochastic judge covariance
- the known-mean/known-`B` mechanism reaches only 18.0% / 19.5% pointwise detection at coupling 0.10 for 28 / 40 components
- the 80% synthetic power gate fails
- no end-to-end nuisance-estimation null or repeated-judge confirmation is present

The runner therefore hard-codes both advancement and QR-covariance deployment gates false.

## Confidence and deployment policy

Keep the 95% simultaneous bound for any production covariance or batching decision. An 80–90% pointwise band may be used only as a labelled discovery/shadow-mode screen; it cannot modify `R`, QR block membership, or a production decision.

A favorable diagnostic sizing extension first reaches 80% pointwise mechanism detection for coupling 0.10 at about 320 independent components (81%), but simultaneous detection is only 54% there and 65% at 400. The confirmatory campaign should therefore use more than 400 independent components for a covariance-wide target, balance adjacent and distant/hard-negative triples by hop/tag strata, and obtain at least three independent calls per judge family.

The eventual covariance adapter should shrink on a PSD path and add a simultaneous spectral envelope; elementwise “lower covariance” bounds are not generally PSD-safe.

## Review follow-up: portable provenance

Claude Opus 4.8 reproduced the scientific results but found that whole-file hashes embedded machine-local absolute paths. Commit `5cbe638f8` addresses the full class, including locators beyond the cited line:

- payload schema v2 stores role-keyed `{size_bytes, sha256}` records and no checkout/input paths
- output and input-locator arguments are excluded from scientific configuration
- graph provenance retains content identity and the LMDB lock-file exclusion contract without repository/directory locators
- two complete synthetic runs written to different output paths are byte-identical
- the schema-v2 real rerun reproduces every previous scientific field exactly

Portable artifact hashes:

- real: `407d52d8fe64df3bf9220da95976bee5c046c5d806d676aa38aafa4a475e100a`
- synthetic: `62695568b1eae247ece2d3e37a18250c756b57536bdf6fe7e0ec7a91f8b8c18e`

The optional resume-RNG concern was also inspected: `fit_context` consumes no process-global RNG, while component assignment, multiplier bands, and derangement use explicit seeded generators.

## Validation

- focused adjacent-pilot tests: 13 passed
- adjacent + inherited structured-covariance and NumPy/Torch QR suites: 88 passed, 9 skipped
- inherited covariance-sensitivity suites: 35 passed
- combined: **123 passed, 9 skipped**
- two full synthetic outputs at different locations: byte-identical
- real schema-v2 rerun: all prior scientific fields identical
- `git diff --check`: clean

Full deterministic output hashes and reproduction commands are recorded in `REPORT_adjacent_residual_pilot.md` and `repro/adjacent_residual_pilot/summary.json`.