### PR TITLE
WAM/LLVM plawk: cross-pass scalars in multi-pass programs

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -12,9 +12,13 @@ cache (file backend + `BEGIN cache("path") { declare NAME }` surface, phase
 execution (`pass { }` blocks over a shared assoc table, phase 2); and
 per-record output in assoc programs (`print $N` / `print arr[$N]` in the
 record loop), which gives the "normalise" shape — pass 2 prints each record
-from pass 1's table. **Not yet:** cross-pass scalars, configurable readers
-(phase 4), the query reader (phase 6), namespaces / `eager` / secondary
-indexes, string-literal print fields. See the per-phase status tags in §5.
+from pass 1's table; and cross-pass scalars (`acc += 1` / `acc += $N`
+folded in one pass and read in a later pass, backed by a zero-initialised
+module global). **Not yet:** pure-scalar (no-table) multi-pass and
+arithmetic in prints (`$2 / total`) — together these complete grand-total
+normalise; configurable readers (phase 4); the query reader (phase 6);
+namespaces / `eager` / secondary indexes; string-literal print fields. See
+the per-phase status tags in §5.
 
 ## Implemented surface (quick reference)
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5285,15 +5285,37 @@ plawk_assoc_body_action_spec(print(Fields), assoc_print(FieldSpecs)) :-
     Fields = [_ | _],
     maplist(plawk_assoc_print_field_spec, Fields, FieldSpecs).
 
+% Scalar accumulator in an assoc program: `acc += 1` (count) or `acc += $N`
+% (sum a field). Backed by a module global (zero-initialised), so in a
+% multi-pass program the accumulator persists across passes -- pass 1 folds,
+% a later pass reads it (`print $1, acc`). One line per record semantics.
+plawk_assoc_body_action_spec(add(var(Name), int(V)), scalar_add(Name, int(V))) :-
+    integer(V).
+plawk_assoc_body_action_spec(add(var(Name), field(K)), scalar_add(Name, field(K))) :-
+    integer(K), K > 0.
+
 plawk_assoc_print_field_spec(field(N), fld(N)) :-
     integer(N), N > 0.
 plawk_assoc_print_field_spec(assoc(var(Arr), field(N)), lookup(Arr, N)) :-
     integer(N), N > 0.
+% A scalar accumulator read in a per-record print.
+plawk_assoc_print_field_spec(var(Name), svar(Name)) :-
+    atom(Name).
 
 % Resolve a print field's lookup array to its table index in the plan.
 plawk_assoc_print_plan_field(_Tables, fld(N), fld(N)).
 plawk_assoc_print_plan_field(Tables, lookup(Arr, N), lookup(TableIndex, N)) :-
     nth0(TableIndex, Tables, Arr).
+plawk_assoc_print_plan_field(_Tables, svar(Name), svar(Name)).
+
+% The per-record source value added to a scalar accumulator: a constant, or
+% field N converted to i64.
+plawk_assoc_scalar_src_lines(int(V), _Base, _FieldSep, V, []).
+plawk_assoc_scalar_src_lines(field(K), Base, FieldSep, SrcVar, [Line]) :-
+    format(atom(Line),
+        '  %~w_fv = call i64 @wam_atom_field_i64_value(%Value %line, i64 ~w, i8 ~w)',
+        [Base, K, FieldSep]),
+    format(atom(SrcVar), '%~w_fv', [Base]).
 
 %% plawk_assoc_print_field_lines(+PlannedFields, +Base, +FieldSep, +Index, -Lines)
 %  Emit the per-record print: each field preceded by a space separator
@@ -5346,6 +5368,15 @@ plawk_assoc_print_one_field(lookup(TableIndex, N), Base, Index, FieldSep, Lines)
     format(atom(PrL),
         '  %~w_pr = call i32 (i8*, ...) @printf(i8* %~w_fmt, i64 %~w_val)', [P, P, P]),
     Lines = [SliceL, PtrL, LenL, KidL, ValL, FmtL, PrL].
+plawk_assoc_print_one_field(svar(Name), Base, Index, _FieldSep, Lines) :-
+    format(atom(P), '~w_f~w', [Base, Index]),
+    format(atom(LoadL), '  %~w_sv = load i64, i64* @plawk_scalar_~w', [P, Name]),
+    format(atom(FmtL),
+        '  %~w_fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0',
+        [P]),
+    format(atom(PrL),
+        '  %~w_pr = call i32 (i8*, ...) @printf(i8* %~w_fmt, i64 %~w_sv)', [P, P, P]),
+    Lines = [LoadL, FmtL, PrL].
 
 plawk_assoc_body_action_spec(for_in(var(LoopVar), var(ArrayName), Body),
         forin(LoopVar, ArrayName, Fields)) :-
@@ -5420,6 +5451,11 @@ plawk_assoc_planned_actions([assoc_print(FieldSpecs) | Rest],
       NextIndex is Index + 1
     },
     [assoc_print_action(Index, PlannedFields)],
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
+plawk_assoc_planned_actions([scalar_add(Name, Src) | Rest],
+        Tables, StrArrays, PosArrays, Index) -->
+    { NextIndex is Index + 1 },
+    [assoc_scalar_add_action(Index, Name, Src)],
     plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
 plawk_assoc_planned_actions([forin(LoopVar, ArrayName, Fields) | Rest],
         Tables, StrArrays, PosArrays, Index) -->
@@ -5640,7 +5676,8 @@ plawk_assoc_rule_apply_ir(RuleIndex, Actions, NextLabel, FieldSeparator,
     atomic_list_concat(Lines, '\n', IR),
     (   Globals == []
     ->  GlobalIR = ''
-    ;   atomic_list_concat(Globals, '\n', Gs),
+    ;   sort(Globals, GlobalsDedup),   % identical scalar-global decls collapse
+        atomic_list_concat(GlobalsDedup, '\n', Gs),
         atom_concat('\n', Gs, GlobalIR)
     ).
 
@@ -5688,6 +5725,32 @@ plawk_assoc_rule_action_blocks(RuleIndex,
           [Base, ShimName, CallArgsIR, TableIndex]),
       format(atom(Next), '  br label %~w', [ActionNextLabel]),
       append([GlobalMarkers, [Label], Setup, [CallLine, Next, '']], Lines)
+    },
+    plawk_emit_lines(Lines),
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+% Scalar accumulator: `acc += 1` / `acc += $N`, folded into a module global
+% (@plawk_scalar_<acc>, zero-init), so the value persists across multi-pass
+% passes. Emits the global declaration on the global channel (deduped by the
+% rule/driver), then load/add/store per record.
+plawk_assoc_rule_action_blocks(RuleIndex,
+        [assoc_scalar_add_action(Index, Name, Src) | Rest], NextLabel, FieldSeparator) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(Base), 'assoc_rule_~w_action_~w_sadd', [RuleIndex, Index]),
+      format(atom(GlobalDecl),
+          '@plawk_scalar_~w = internal global i64 0', [Name]),
+      plawk_assoc_scalar_src_lines(Src, Base, FieldSeparator, SrcVar, SrcLines),
+      format(atom(LoadL), '  %~w_cur = load i64, i64* @plawk_scalar_~w', [Base, Name]),
+      format(atom(AddL), '  %~w_new = add i64 %~w_cur, ~w', [Base, Base, SrcVar]),
+      format(atom(StoreL), '  store i64 %~w_new, i64* @plawk_scalar_~w', [Base, Name]),
+      format(atom(Next), '  br label %~w', [ActionNextLabel]),
+      append([[global(GlobalDecl), Label], SrcLines,
+              [LoadL, AddL, StoreL, Next, '']], Lines)
     },
     plawk_emit_lines(Lines),
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).

--- a/tests/test_plawk_crosspass_scalar.pl
+++ b/tests/test_plawk_crosspass_scalar.pl
@@ -1,0 +1,81 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Cross-pass scalars: a scalar accumulator (`acc += 1` count, `acc += $N`
+% sum) folded in one pass and read in a later pass. Because passes are
+% separate functions, the accumulator is a module global (@plawk_scalar_<acc>,
+% zero-initialised), so its value persists across passes -- pass 1 folds the
+% grand total, pass 2 annotates each record with it. See
+% PLAWK_MULTIPASS_CACHE.md. v1: the program also carries a shared table (the
+% multi-pass driver is table-based); a pure-scalar (no-table) program and
+% arithmetic in prints (`$2 / total`) are follow-ons.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_crosspass_scalar).
+
+% Count records in pass 1 (total += 1), annotate each record in pass 2 with
+% its per-key count and the grand total. Over a a b: total = 3.
+test(crosspass_count, [condition(clang_available)]) :-
+    cd(Dir),
+    Src = "pass { c[$1]++ ; total += 1 }\npass { print $1, c[$1], total }\n",
+    run_sorted(Dir, 'cnt', Src, "a\na\nb\n", S),
+    assertion(S == ["a 2 3", "a 2 3", "b 1 3"]),
+    !.
+
+% Sum field 2 in pass 1 (total += $2), print each record with the grand
+% total in pass 2. Over a=10, a=20, b=5: total = 35.
+test(crosspass_field_sum, [condition(clang_available)]) :-
+    cd(Dir),
+    Src = "pass { c[$1]++ ; total += $2 }\npass { print $1, total }\n",
+    run_sorted(Dir, 'sum', Src, "a 10\na 20\nb 5\n", S),
+    assertion(S == ["a 35", "a 35", "b 35"]),
+    !.
+
+% A scalar accumulator in a single-pass assoc program (END for-in) compiles
+% and runs -- the accumulator is dead here (END dumps the table) but the
+% scalar action must not break the pure-assoc chain.
+test(single_pass_scalar_ok, [condition(clang_available)]) :-
+    cd(Dir),
+    Src = "{ c[$1]++ ; total += 1 }\nEND { for (k in c) print k, c[k] }\n",
+    run_sorted(Dir, 'sp', Src, "a\na\nb\n", S),
+    assertion(S == ["a 2", "b 1"]),
+    !.
+
+:- end_tests(plawk_crosspass_scalar).
+
+% --- helpers ---------------------------------------------------------------
+
+cd(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_crosspass_scalar', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Cross-pass scalars

A scalar accumulator folded in one pass can be read in a later pass:

```awk
pass { c[$1]++ ; total += 1 }         # count records
pass { print $1, c[$1], total }       # over `a a b`: a 2 3 / a 2 3 / b 1 3

pass { c[$1]++ ; total += $2 }        # sum field 2
pass { print $1, total }              # over a=10,a=20,b=5: a 35 / a 35 / b 35
```

### How

Passes are separate functions, so a cross-pass scalar can't be a shared SSA value — it's lowered to a **zero-initialised module global** (`@plawk_scalar_<name>`), loaded/added/stored per record, so it persists across passes.

- The assoc rule chain gains a **scalar-accumulator action** (`acc += 1`, or `acc += $N` via `@wam_atom_field_i64_value`) and a **scalar read** as a per-record print field (`print …, acc`).
- The global declaration rides the chain's global channel and is **deduped** (within a rule and across passes), so multiple passes touching the same scalar emit one definition.

### Scope (v1)

The program also carries a shared table (the multi-pass driver is table-based). The two remaining pieces for full grand-total **normalise** — pure-scalar (no-table) multi-pass and **arithmetic in prints** (`$2 / total`) — are follow-ons. Single-pass assoc programs may now also carry a scalar accumulator through the pure-assoc chain (verified it doesn't break the END for-in path).

### Tests

`tests/test_plawk_crosspass_scalar.pl` (3/3): cross-pass count, cross-pass field-sum, single-pass scalar in an assoc program. Regression: assoc-print (3/3), multipass (4/4), passes (5/5), for-in filter (7/7), binary records (14/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_