### PR TITLE
Add Rust WAM number_chars/2 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1610,6 +1610,7 @@ compile_execute_term_builtin_to_rust(Code) :-
             "reverse/2" => { self.execute_reverse_builtin() }
             "atom_codes/2" => { self.execute_atom_codes_builtin() }
             "number_codes/2" => { self.execute_number_codes_builtin() }
+            "number_chars/2" => { self.execute_number_chars_builtin() }
             "atom_to_term/3" => { self.execute_atom_to_term_builtin() }
             "term_to_atom/2" => { self.execute_term_to_atom_builtin() }
             "read_term_from_atom/2" => { self.execute_read_term_from_atom_builtin(2) }
@@ -1733,6 +1734,61 @@ compile_execute_term_builtin_to_rust(Code) :-
                             }
                             None => false,
                         }
+                    }
+                    None => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn execute_number_chars_builtin(&mut self) -> bool {
+        let num_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let chars_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+        let num = self.deref_heap(&self.deref_var(&num_raw));
+        let chars = self.deref_heap(&self.deref_var(&chars_raw));
+        match (num, chars) {
+            (Value::Integer(n), _) => {
+                let list = Value::List(
+                    n.to_string()
+                        .chars()
+                        .map(|ch| Value::Atom(ch.to_string()))
+                        .collect(),
+                );
+                if self.unify(&chars_raw, &list) { self.pc += 1; true }
+                else { false }
+            }
+            (Value::Float(f), _) => {
+                let list = Value::List(
+                    f.to_string()
+                        .chars()
+                        .map(|ch| Value::Atom(ch.to_string()))
+                        .collect(),
+                );
+                if self.unify(&chars_raw, &list) { self.pc += 1; true }
+                else { false }
+            }
+            (Value::Unbound(_), Value::List(items)) => {
+                let mut text = String::new();
+                for item in &items {
+                    match self.deref_heap(&self.deref_var(item)) {
+                        Value::Atom(atom) if atom.chars().count() == 1 => {
+                            text.push(atom.chars().next().unwrap());
+                        }
+                        _ => return false,
+                    }
+                }
+                let parsed = if let Ok(n) = text.parse::<i64>() {
+                    Some(Value::Integer(n))
+                } else if let Ok(f) = text.parse::<f64>() {
+                    Some(Value::Float(f))
+                } else {
+                    None
+                };
+                match parsed {
+                    Some(value) => {
+                        if self.unify(&num_raw, &value) { self.pc += 1; true }
+                        else { false }
                     }
                     None => false,
                 }

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -579,6 +579,22 @@ fn test_atom_text_ops() {
     assert!(ok10);
     assert_eq!(read_var(&vm10, "A"), a("7"));
     assert!(!call2("atom_number/2", a("notanum"), ub("N")).0);
+    let (ok_chars, vm_chars) = call2("number_chars/2", i(-42), ub("Cs"));
+    assert!(ok_chars);
+    assert_eq!(
+        read_var(&vm_chars, "Cs"),
+        Value::List(vec![a("-"), a("4"), a("2")]),
+    );
+    let (ok_float, vm_float) = call2(
+        "number_chars/2",
+        ub("N"),
+        Value::List(vec![a("3"), a("."), a("5")]),
+    );
+    assert!(ok_float);
+    assert_eq!(read_var(&vm_float, "N"), Value::Float(3.5));
+    assert!(!call2("number_chars/2", ub("N"), Value::List(vec![])).0);
+    assert!(!call2("number_chars/2", ub("N"), Value::List(vec![a("12")])).0);
+    assert!(!call2("number_chars/2", ub("N"), Value::List(vec![a("x")])).0);
     let (ok11, vm11) = call2("atom_string/2", a("x"), ub("S"));
     assert!(ok11);
     assert_eq!(read_var(&vm11, "S"), a("x"));

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -466,6 +466,7 @@ test_builtin_dispatch :-
         %% Runtime-parser bridge support and the parser-required text/list builtins.
         sub_string(S, _, _, _, '"atom_codes/2"'),
         sub_string(S, _, _, _, '"number_codes/2"'),
+        sub_string(S, _, _, _, '"number_chars/2"'),
         sub_string(S, _, _, _, '"reverse/2"'),
         sub_string(S, _, _, _, '"term_to_atom/2"'),
         sub_string(S, _, _, _, 'bind_compiled_parse_atom')


### PR DESCRIPTION
## Summary

- implement bidirectional `number_chars/2` for Rust WAM
- convert integers and floats to lists of single-character atoms
- parse character lists as integers first, then floats
- reject empty, malformed, and multi-character list elements
- add no VM state, choicepoints, or ordinary call-path checks

## Testing

- forward negative-integer conversion
- reverse float parsing
- malformed and empty character-list failures
- dedicated Rust builtin parity execution suite
- full Rust WAM target suite
- Rust target syntax/load check
- patch whitespace validation