### PR TITLE
WAM/LLVM plawk: pure-scalar multi-pass + f64 arithmetic-in-print (normalise)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -12,11 +12,15 @@ cache (file backend + `BEGIN cache("path") { declare NAME }` surface, phase
 execution (`pass { }` blocks over a shared assoc table, phase 2); and
 per-record output in assoc programs (`print $N` / `print arr[$N]` in the
 record loop), which gives the "normalise" shape — pass 2 prints each record
-from pass 1's table; and cross-pass scalars (`acc += 1` / `acc += $N`
+from pass 1's table; cross-pass scalars (`acc += 1` / `acc += $N`
 folded in one pass and read in a later pass, backed by a zero-initialised
-module global). **Not yet:** pure-scalar (no-table) multi-pass and
-arithmetic in prints (`$2 / total`) — together these complete grand-total
-normalise; configurable readers (phase 4); the query reader (phase 6);
+module global); pure-scalar (no-table) multi-pass, where a program carries
+no assoc table at all and passes coordinate only through scalar globals;
+and arithmetic in prints (`$2 / total`) evaluated in f64 (the surface `/`
+is integer, so a print expression is promoted to double and printed with
+`%g`). Together the last two complete **grand-total normalise**
+(`pass { total += $2 } pass { print $1, $2 / total }`). **Not yet:**
+configurable readers (phase 4); the query reader (phase 6);
 namespaces / `eager` / secondary indexes; string-literal print fields. See
 the per-phase status tags in §5.
 
@@ -467,10 +471,21 @@ single-pass test before any driver surgery).
   the END for-in. Verified: reading the input twice into a shared counter
   doubles the counts (`tests/test_plawk_multipass.pl`). v1 scope: text mode,
   a single shared table, always-rule pass bodies, `END { for (k in arr)
-  print ... }`, a file argument. **Deferred:** cross-pass *scalars* (need
-  loop-phi threading between pass functions, or scalar globals), per-record
-  *output* passes (per-record `arr[k]` reads), multiple tables, and pairing
-  multi-pass with a cache-backed / `BEGIN`-declared table.
+  print ... }`, a file argument. **Landed since:** per-record *output*
+  passes (per-record `$N` / `arr[$N]` reads, `tests/test_plawk_assoc_print.pl`);
+  cross-pass *scalars* via zero-initialised module globals — no loop-phi
+  threading needed (`tests/test_plawk_crosspass_scalar.pl`); pure-scalar
+  (no-table) multi-pass, where the shared-table parameter is dropped
+  entirely and passes coordinate only through scalar globals; and
+  arithmetic in a per-record print evaluated in f64 (`$2 / total`,
+  `tests/test_plawk_normalise.pl`) — the surface `/` is integer, so print
+  arithmetic promotes operands to double (fields via
+  `@wam_atom_field_f64_value`, a scalar via `load`+`sitofp`, an int constant
+  via `sitofp`) and prints with `%g`. Grand-total normalise
+  (`pass { total += $2 } pass { print $1, $2 / total }`) now works with no
+  assoc table at all. **Deferred:** multiple tables, arithmetic operands
+  that are table lookups, and pairing multi-pass with a cache-backed /
+  `BEGIN`-declared table.
 
 - **Phase 3 — cache as the inter-pass channel (durable payoff).** Combine
   1+2: a table declared in a `BEGIN cache("db")` block written in pass 1 and

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3708,18 +3708,19 @@ plawk_program_multipass_driver_ir(
         ),
         PassPairs),
     pairs_keys_values(PassPairs, ChainGlobals, Chains),
-    % One function per pass; index them.
+    % One function per pass; index them. The END for-in always has one
+    % shared table, threaded to each pass.
+    plawk_multipass_table_params([ArrayName], TableParamsIR, TableArgsIR),
     findall(FnIR,
         ( nth0(I, Chains, Chain),
-          plawk_multipass_pass_fn_ir(I, Chain, FnIR) ),
+          plawk_multipass_pass_fn_ir(I, TableParamsIR, Chain, FnIR) ),
         FnIRs),
     atomic_list_concat(FnIRs, '\n', PassFnsIR),
     % main's pass-call sequence.
     findall(CallLine,
         ( nth0(I, Chains, _),
           format(atom(CallLine),
-              '  call void @plawk_pass_~w(%Value %mp_path, %WamAssocI64Table* %plawk_assoc_table_0)',
-              [I]) ),
+              '  call void @plawk_pass_~w(%Value %mp_path~w)', [I, TableArgsIR]) ),
         CallLines),
     atomic_list_concat(CallLines, '\n', CallsIR),
     % Setup (create the shared table), BEGIN, and the END for-in print.
@@ -3774,13 +3775,13 @@ plawk_program_multipass_driver_ir(
     Passes = [_, _ | _],
     plawk_record_descriptor(BeginClauses, FieldSeparator),
     integer(FieldSeparator),
-    plawk_passes_shared_table(Passes, ArrayName),
+    plawk_passes_tables(Passes, Tables),        % 0 or 1 table (v1)
     findall(R, ( member(pass(PassRules), Passes), member(R, PassRules) ), AllRules),
-    plawk_forin_assoc_plan(AllRules, ArrayName, [], AssocPlan),
-    AssocPlan = assoc_plan([ArrayName], _),
+    plawk_multipass_pass_plan(AllRules, Tables, AssocPlan),  % validates surface
+    plawk_multipass_table_params(Tables, TableParamsIR, TableArgsIR),
     findall(GlobalIR-ChainIR,
         ( member(pass(PassRules), Passes),
-          plawk_forin_assoc_plan(PassRules, ArrayName, [], PassPlan),
+          plawk_multipass_pass_plan(PassRules, Tables, PassPlan),
           plawk_assoc_rule_controls(PassPlan, PassControls),
           plawk_assoc_break_close_ir(PassControls, ''),
           plawk_assoc_rule_chain_ir(PassPlan, FieldSeparator, GlobalIR, ChainIR)
@@ -3788,14 +3789,14 @@ plawk_program_multipass_driver_ir(
         PassPairs),
     pairs_keys_values(PassPairs, ChainGlobals, Chains),
     findall(FnIR,
-        ( nth0(I, Chains, Chain), plawk_multipass_pass_fn_ir(I, Chain, FnIR) ),
+        ( nth0(I, Chains, Chain),
+          plawk_multipass_pass_fn_ir(I, TableParamsIR, Chain, FnIR) ),
         FnIRs),
     atomic_list_concat(FnIRs, '\n', PassFnsIR),
     findall(CallLine,
         ( nth0(I, Chains, _),
           format(atom(CallLine),
-              '  call void @plawk_pass_~w(%Value %mp_path, %WamAssocI64Table* %plawk_assoc_table_0)',
-              [I]) ),
+              '  call void @plawk_pass_~w(%Value %mp_path~w)', [I, TableArgsIR]) ),
         CallLines),
     atomic_list_concat(CallLines, '\n', CallsIR),
     plawk_output_separator(BeginClauses, OutputSeparator),
@@ -3835,29 +3836,50 @@ get_path:
 ',
         [RuntimeGlobals, PassFnsIR, CombinedEntrySetupIR, CallsIR, FreeIR]).
 
-%% plawk_passes_shared_table(+Passes, -TableName)
-%  The single assoc table a multi-pass program shares (v1). Discovered from
-%  the passes' actions: a counted key `arr[$k]++` or a print lookup
-%  `arr[$k]`. Exactly one distinct table across all passes.
-plawk_passes_shared_table(Passes, TableName) :-
+%% plawk_passes_tables(+Passes, -Tables)
+%  The assoc tables a multi-pass program shares (v1: zero or one). Discovered
+%  from the passes' actions: a counted key `arr[$k]++` or a print lookup
+%  `arr[$k]`. A pure-scalar program (e.g. `pass { total += $2 }`) has none.
+plawk_passes_tables(Passes, Tables) :-
     findall(Name,
         ( member(pass(Rules), Passes), member(rule(_, Actions), Rules),
           member(Action, Actions), plawk_action_table_name(Action, Name) ),
         Names0),
-    sort(Names0, [TableName]).
+    sort(Names0, Tables),
+    length(Tables, N),
+    N =< 1.
 
 plawk_action_table_name(inc_assoc(var(Name), _Key), Name).
 plawk_action_table_name(print(Fields), Name) :-
     member(assoc(var(Name), _Key), Fields).
+
+%% plawk_multipass_table_params(+Tables, -ParamsIR, -ArgsIR)
+%  The LLVM parameter/argument suffix threading the shared table(s) into a
+%  pass function. Zero tables (pure scalar) -> empty; one table -> the
+%  %plawk_assoc_table_0 parameter the rule chain references.
+plawk_multipass_table_params([], '', '').
+plawk_multipass_table_params([_Table],
+    ', %WamAssocI64Table* %plawk_assoc_table_0',
+    ', %WamAssocI64Table* %plawk_assoc_table_0').
+
+%% plawk_multipass_pass_plan(+Rules, +Tables, -AssocPlan)
+%  Plan a pass's rules against the (already discovered) shared table set, so
+%  table indices are consistent across passes. Works with zero tables.
+plawk_multipass_pass_plan(Rules, Tables, assoc_plan(Tables, PlannedRules)) :-
+    maplist(plawk_assoc_rule_action_specs, Rules, RuleSpecs),
+    plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays),
+    plawk_assoc_specs_posarray_arrays(RuleSpecs, PosArrays),
+    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, StrArrays, PosArrays, 0),
+        PlannedRules).
 
 %% plawk_multipass_pass_fn_ir(+Index, +RecordIR, -IR)
 %  One pass as a self-contained function: open the shared input path, loop
 %  reading transient line records, run RecordIR per record (it branches to
 %  %continue_loop and references the %plawk_assoc_table_0 parameter), and
 %  return. Function-local labels/SSA, so passes never collide.
-plawk_multipass_pass_fn_ir(Index, RecordIR, IR) :-
+plawk_multipass_pass_fn_ir(Index, TableParamsIR, RecordIR, IR) :-
     format(atom(IR),
-'define void @plawk_pass_~w(%Value %mp_path, %WamAssocI64Table* %plawk_assoc_table_0) {
+'define void @plawk_pass_~w(%Value %mp_path~w) {
 entry:
   %handle = call %Value @wam_stream_open_value(%Value %mp_path)
   %handle_tag = extractvalue %Value %handle, 0
@@ -3902,7 +3924,7 @@ close_stream:
 ret_void:
   ret void
 }
-', [Index, RecordIR]).
+', [Index, TableParamsIR, RecordIR]).
 
 %% plawk_forin_end_plan(+Rules, +LoopVar, +ArrayName, +BodyActions, -AssocPlan, -PrintFields)
 %
@@ -5301,12 +5323,36 @@ plawk_assoc_print_field_spec(assoc(var(Arr), field(N)), lookup(Arr, N)) :-
 % A scalar accumulator read in a per-record print.
 plawk_assoc_print_field_spec(var(Name), svar(Name)) :-
     atom(Name).
+% Arithmetic in a per-record print, e.g. `$2 / total` (normalise). The
+% surface `/` is integer (div_i64), which truncates fractions to 0, so a
+% print arithmetic expression is evaluated in f64 and printed with %g:
+% fields via @wam_atom_field_f64_value, a scalar via load+sitofp, an int
+% constant as a double literal. Operands are field/scalar/int (a table
+% lookup in arithmetic is a follow-on).
+plawk_assoc_print_field_spec(Expr, farith(F64Op, LOperand, ROperand)) :-
+    Expr =.. [Op, L, R],
+    plawk_i64_op_f64(Op, F64Op),
+    plawk_assoc_arith_operand(L, LOperand),
+    plawk_assoc_arith_operand(R, ROperand).
+
+% Surface i64 arithmetic operator -> the f64 LLVM opcode for print arithmetic.
+plawk_i64_op_f64(add_i64, fadd).
+plawk_i64_op_f64(sub_i64, fsub).
+plawk_i64_op_f64(mul_i64, fmul).
+plawk_i64_op_f64(div_i64, fdiv).
+plawk_i64_op_f64(mod_i64, frem).
+
+% An arithmetic operand in a print expression.
+plawk_assoc_arith_operand(field(N), afield(N)) :- integer(N), N > 0.
+plawk_assoc_arith_operand(var(Name), asvar(Name)) :- atom(Name).
+plawk_assoc_arith_operand(int(V), aint(V)) :- integer(V).
 
 % Resolve a print field's lookup array to its table index in the plan.
 plawk_assoc_print_plan_field(_Tables, fld(N), fld(N)).
 plawk_assoc_print_plan_field(Tables, lookup(Arr, N), lookup(TableIndex, N)) :-
     nth0(TableIndex, Tables, Arr).
 plawk_assoc_print_plan_field(_Tables, svar(Name), svar(Name)).
+plawk_assoc_print_plan_field(_Tables, farith(Op, L, R), farith(Op, L, R)).
 
 % The per-record source value added to a scalar accumulator: a constant, or
 % field N converted to i64.
@@ -5377,6 +5423,37 @@ plawk_assoc_print_one_field(svar(Name), Base, Index, _FieldSep, Lines) :-
     format(atom(PrL),
         '  %~w_pr = call i32 (i8*, ...) @printf(i8* %~w_fmt, i64 %~w_sv)', [P, P, P]),
     Lines = [LoadL, FmtL, PrL].
+% Print arithmetic in f64: evaluate both operands as doubles, apply the op,
+% print with %g.
+plawk_assoc_print_one_field(farith(F64Op, LOperand, ROperand), Base, Index, FieldSep, Lines) :-
+    format(atom(P), '~w_f~w', [Base, Index]),
+    plawk_assoc_arith_operand_lines(LOperand, P, l, FieldSep, LVar, LLines),
+    plawk_assoc_arith_operand_lines(ROperand, P, r, FieldSep, RVar, RLines),
+    format(atom(OpL), '  %~w_res = ~w double ~w, ~w', [P, F64Op, LVar, RVar]),
+    format(atom(FmtL),
+        '  %~w_fmt = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_f64, i32 0, i32 0',
+        [P]),
+    format(atom(PrL),
+        '  %~w_pr = call i32 (i8*, ...) @printf(i8* %~w_fmt, double %~w_res)', [P, P, P]),
+    append([LLines, RLines, [OpL, FmtL, PrL]], Lines).
+
+%% plawk_assoc_arith_operand_lines(+Operand, +P, +Slot, +FieldSep, -ValVar, -Lines)
+%  Emit IR computing a print-arithmetic operand as a double. `afield(N)`
+%  reads field N as f64; `asvar(Name)` loads the scalar global and promotes
+%  it (sitofp); `aint(V)` promotes the integer constant.
+plawk_assoc_arith_operand_lines(afield(N), P, Slot, FieldSep, ValVar, [Line]) :-
+    format(atom(ValVar), '%~w_~w', [P, Slot]),
+    format(atom(Line),
+        '  ~w = call double @wam_atom_field_f64_value(%Value %line, i64 ~w, i8 ~w)',
+        [ValVar, N, FieldSep]).
+plawk_assoc_arith_operand_lines(asvar(Name), P, Slot, _FieldSep, ValVar, [LoadL, PromL]) :-
+    format(atom(IVar), '%~w_~w_i', [P, Slot]),
+    format(atom(ValVar), '%~w_~w', [P, Slot]),
+    format(atom(LoadL), '  ~w = load i64, i64* @plawk_scalar_~w', [IVar, Name]),
+    format(atom(PromL), '  ~w = sitofp i64 ~w to double', [ValVar, IVar]).
+plawk_assoc_arith_operand_lines(aint(V), P, Slot, _FieldSep, ValVar, [Line]) :-
+    format(atom(ValVar), '%~w_~w', [P, Slot]),
+    format(atom(Line), '  ~w = sitofp i64 ~w to double', [ValVar, V]).
 
 plawk_assoc_body_action_spec(for_in(var(LoopVar), var(ArrayName), Body),
         forin(LoopVar, ArrayName, Fields)) :-

--- a/tests/test_plawk_normalise.pl
+++ b/tests/test_plawk_normalise.pl
@@ -1,0 +1,82 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Grand-total normalise: the canonical two-pass shape that motivated the
+% whole multi-pass arc. Pass 1 folds a grand total into a cross-pass scalar
+% (`total += $N`); pass 2 prints each record divided by that total
+% (`print $1, $N / total`). Two things had to land for this to be faithful:
+%   * a pure-scalar (no assoc table) multi-pass program, and
+%   * arithmetic in a per-record print evaluated in f64 -- the surface `/`
+%     is integer (div_i64), which would truncate every ratio to 0, so a
+%     print arithmetic expression is computed as double and printed with %g.
+% See PLAWK_MULTIPASS_CACHE.md.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_normalise).
+
+% Fractional normalise, no assoc table: sum field 2 in pass 1, print each
+% record's share in pass 2. Over 10/20/5 (total 35): 0.285714, 0.571429,
+% 0.142857.
+test(normalise_fraction, [condition(clang_available)]) :-
+    ndir(Dir),
+    Src = "pass { total += $2 }\npass { print $1, $2 / total }\n",
+    run_sorted(Dir, 'norm', Src, "a 10\na 20\nb 5\n", S),
+    assertion(S == ["a 0.285714", "a 0.571429", "b 0.142857"]),
+    !.
+
+% Pure-scalar grand total (no table, no arithmetic): pass 1 sums, pass 2
+% annotates each record with the total. Over 10/20/5: 35 on every line.
+test(grand_total_scalar, [condition(clang_available)]) :-
+    ndir(Dir),
+    Src = "pass { total += $2 }\npass { print $1, total }\n",
+    run_sorted(Dir, 'gt', Src, "a 10\na 20\nb 5\n", S),
+    assertion(S == ["a 35", "a 35", "b 35"]),
+    !.
+
+% Arithmetic against a constant in a print (promotes the int to double):
+% `$2 / 2` halves each value with a fractional result.
+test(print_arith_const, [condition(clang_available)]) :-
+    ndir(Dir),
+    Src = "pass { total += $2 }\npass { print $1, $2 / 2 }\n",
+    run_sorted(Dir, 'half', Src, "a 3\nb 5\n", S),
+    assertion(S == ["a 1.5", "b 2.5"]),
+    !.
+
+:- end_tests(plawk_normalise).
+
+% --- helpers ---------------------------------------------------------------
+
+ndir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_normalise', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
Completes the grand-total **normalise** shape end to end:

```awk
pass { total += $2 }
pass { print $1, $2 / total }
```

Over `a 10 / a 20 / b 5` (total 35) this now emits `a 0.285714`, `a 0.571429`, `b 0.142857`.

Two capabilities land together — they're paired because neither finishes normalise alone.

## Pure-scalar (no-table) multi-pass
The multi-pass driver previously required exactly one shared assoc table. It now discovers **zero or one** table (`plawk_passes_tables`) and threads the shared-table parameter into each pass function only when a table exists (`plawk_multipass_table_params`). A program that carries no table — where passes coordinate purely through scalar globals — drops the `%WamAssocI64Table*` parameter entirely. Per-pass planning is unified through `plawk_multipass_pass_plan` so table indices stay consistent across passes and the program is validated against the current surface.

## Arithmetic in a per-record print, evaluated in f64
The surface `/` is integer (`div_i64`) and would truncate every ratio to 0. So a print arithmetic expression is promoted to `double` and printed with `%g`:
- fields via `@wam_atom_field_f64_value`,
- a scalar accumulator via `load` + `sitofp`,
- an int constant via `sitofp`.

Operands are field / scalar / int. Supported ops map `add_i64/sub_i64/mul_i64/div_i64/mod_i64` → `fadd/fsub/fmul/fdiv/frem`. (An arithmetic operand that is itself a table lookup is a follow-on.)

## Tests
- New `tests/test_plawk_normalise.pl`: fractional normalise (10/20/5 → 0.285714 / 0.571429 / 0.142857), the pure-scalar grand total (35 on every line), and arithmetic against an int constant (`$2 / 2`).
- Regression green: multipass, passes, assoc-print, crosspass-scalar, forin-filter, binary-records.
- Design doc status updated (`docs/design/PLAWK_MULTIPASS_CACHE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_