### PR TITLE
fix(kotlin-wam): KT-ARITH-SLASH-FUNCTOR — parse // without split-on-/

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -31,7 +31,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | CONF-LUA | Conformance adapter | Lua | M | — |
 | CONF-KOTLIN ✅ | Conformance adapter | Kotlin | M | done — opt-in (`cursor/conf-kotlin-f421`); append green, 5 xfails |
 | KT-LIST-BACKTRACK | Conformance gap fix | Kotlin | M | CONF-KOTLIN |
-| KT-ARITH-SLASH-FUNCTOR | Conformance gap fix | Kotlin | S | CONF-KOTLIN |
+| KT-ARITH-SLASH-FUNCTOR ✅ | Conformance gap fix | Kotlin | S | done — `///2` last-slash parse (`cursor/kt-arith-slash-functor-f421`) |
 | KT-Y-ENV-RECURSION | Conformance gap fix | Kotlin | M | CONF-KOTLIN |
 | PARSE-C | Runtime-parser entry | C | S | — |
 | PARSE-GO | Runtime-parser entry | Go | S | — |
@@ -168,6 +168,7 @@ external toolchain.
 
 ### KT-ARITH-SLASH-FUNCTOR: Parse `//` functor without split-on-`/` (Kotlin)
 - **Lever:** Conformance gap fix  **Target:** Kotlin  **Size:** S  **Depends on:** CONF-KOTLIN
+- **Status:** ✅ **Landed** on `cursor/kt-arith-slash-functor-f421` (2026-07-12). `evalArith` now uses `functorName` (strip trailing `/<digits>` via `substringBeforeLast`) so `"///2"` → `"//"`. Removed `ct_xfail` for builtins; append+builtins green under kotlin and kotlin_functions.
 - **Goal:** Retire builtins xfail for `cbi_arith`. `evalArith` does `functor.split("/")` so `///2` yields empty name. Strip only a trailing `/<digits>` (WAT/Haskell `bareArithOp` / last-component fix).
 
 ### KT-Y-ENV-RECURSION: Y-register bind-through across recursive call (Kotlin)

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -43,15 +43,16 @@ module in the fleet.
 - **Lowered emitter scope** — deterministic single-clause only. No T4/T5
   multi-clause, ITE, or `call`/`execute` in lowered bodies (separate cards).
 - **Conformance (opt-in)** — `conformance_target(kotlin)` /
-  `kotlin_functions` registered. **append/3 green**; member/reverse/builtins/fib/ack
-  are `ct_xfail` on measured interpreter gaps (list placeholder clobber under
-  backtrack; `///2` arith functor parse; Y-register bind-through across recursion).
+  `kotlin_functions` registered. **append + builtins green**; member/reverse/fib/ack
+  remain `ct_xfail` (list placeholder clobber under backtrack; Y-register
+  bind-through across recursion). `///2` arith functor parse fixed
+  (KT-ARITH-SLASH-FUNCTOR).
 - **No foreign kernels, no LMDB / fact source, no ISO contract.**
 - **No runtime-parser capability entry.**
 
 ## Path forward
 
-1. Retire kotlin `ct_xfail`s (list structure-sharing, `//` functor strip, Y-env).
+1. Retire remaining kotlin `ct_xfail`s (list structure-sharing, Y-env).
 2. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
 3. Add ISO / kernels if Kotlin graduates beyond scaffold.
 
@@ -59,4 +60,4 @@ module in the fleet.
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
-(2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN landed.
+(2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN + KT-ARITH-SLASH-FUNCTOR landed.

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -439,8 +439,10 @@ class WamRuntime(private val program: WamProgram) {
             is Value.IntVal -> d
             is Value.FloatVal -> d
             is Value.Struct -> {
-                val parts = d.functor.split("/")
-                val name = parts.getOrNull(0) ?: return null
+                // Functor keys are "name/arity". Strip only the trailing
+                // "/<digits>" — a naive split("/") breaks slash-bearing ops
+                // like "//" (key "///2") and "/" (key "//2").
+                val name = functorName(d.functor)
                 if (d.args.size == 2) {
                     val a = evalArith(state, d.args[0]) ?: return null
                     val b = evalArith(state, d.args[1]) ?: return null
@@ -823,6 +825,11 @@ class WamRuntime(private val program: WamProgram) {
 
 fun functorArity(functor: String): Int? =
     functor.substringAfterLast('/', missingDelimiterValue = "").toIntOrNull()
+
+// Companion to functorArity: name is everything before the LAST '/', so
+// "///2" → "//", "//2" → "/", "+/2" → "+".
+fun functorName(functor: String): String =
+    functor.substringBeforeLast('/', missingDelimiterValue = functor)
 
 fun parseWamCliValue(token: String): Value =
     parseStructToken(token)

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -284,20 +284,17 @@ ct_default_target(elixir).
 %   - member/reverse: heap-built list CDRs are Var(Xn) placeholders; later
 %     unify_variable Xn in a recursive clause overwrites that register and
 %     corrupts the shared Struct under backtracking (b/c in [a,b,c] → false).
-%   - builtins: evalArith splits functor on '/' so '///2' (// arity 2) yields
-%     name="" and 17//5 fails closed (same class WAT/Haskell already fixed);
-%     cbi_cmp/cbi_eq already pass.
+%   - builtins: FIXED in KT-ARITH-SLASH-FUNCTOR — evalArith now strips only
+%     the trailing /<digits> so '///2' → name "//".
 %   - fib/ack: permanent Y-registers use scoped names (Y5@E9); after recursive
 %     call, is/2 sees unbound scoped vars in the +/2 tree (environment /
 %     bind-through gap across call/execute).
 ct_xfail(kotlin, member).
 ct_xfail(kotlin, reverse).
-ct_xfail(kotlin, builtins).
 ct_xfail(kotlin, fib).
 ct_xfail(kotlin, ack).
 ct_xfail(kotlin_functions, member).
 ct_xfail(kotlin_functions, reverse).
-ct_xfail(kotlin_functions, builtins).
 ct_xfail(kotlin_functions, fib).
 ct_xfail(kotlin_functions, ack).
 

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -19,6 +19,7 @@
 :- dynamic kt_edge/2.
 :- dynamic kt_two_step/2.
 :- dynamic kt_chain/2.
+:- dynamic kt_arith/1.
 
 :- begin_tests(wam_kotlin_target).
 
@@ -88,6 +89,7 @@ test(runtime_template_exposes_executable_wam_abi) :-
     assertion(has_substring(Code, 'fun registerNative(key: String, fn: (WamState) -> Boolean)')),
     assertion(has_substring(Code, 'fun snapshotForNative(): WamNativeSnapshot')),
     assertion(has_substring(Code, 'fun tryRun(predicate: String, initialState: WamState')),
+    assertion(has_substring(Code, 'fun functorName(functor: String): String')),
     assertion(has_substring(Code, 'fun kotlinLoGetConstant(state: WamState')),
     assertion(has_substring(Code, 'fun stateFromCliArgs(values: List<String>): WamState')).
 
@@ -415,6 +417,31 @@ test(conformance_main_prints_true_false, [condition(gradle_available), nondet]) 
             assertion(BadTrim == "false")
         ),
         retractall(user:kt_fact(_, _))
+    ).
+
+% KT-ARITH-SLASH-FUNCTOR: integer division // (functor key "///2") must
+% evaluate — a naive functor.split("/") yielded name="" and failed closed.
+test(arith_slash_functor_integer_div, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_arith_slash',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt_arith(_, _)),
+            assertz(user:(kt_arith(R) :- A is 17 // 5, B is 17 mod 5, R is A + B))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt_arith/1],
+                [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_arith/1 5'], OkOut, _OkErr, OkStatus),
+            assertion(OkStatus == exit(0)),
+            normalize_space(string(OkTrim), OkOut),
+            assertion(OkTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_arith/1 4'], BadOut, _BadErr, BadStatus),
+            assertion(BadStatus == exit(0)),
+            normalize_space(string(BadTrim), BadOut),
+            assertion(BadTrim == "false")
+        ),
+        retractall(user:kt_arith(_, _))
     ).
 
 :- end_tests(wam_kotlin_target).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**KT-ARITH-SLASH-FUNCTOR** — first of three stacked Kotlin interpreter gap fixes from CONF-KOTLIN.

## Fix

`evalArith` parsed functor keys with `split("/")`, so integer division `"///2"` became name `""` and `17 // 5` failed closed. Now uses `functorName` = everything before the **last** `/` (same class as Haskell `bareArithOp` / WAT last-component).

## Acceptance

- Removed `ct_xfail(kotlin, builtins)` and `ct_xfail(kotlin_functions, builtins)`
- `builtins` green under both targets (positive + negative)
- Regression: `kt_arith` with `17//5` + `mod` via gradle `conformance_main`
- `append` still green; other xfails deferred to later PRs in the stack

## Stack

1. **This PR** ← `main`
2. #3690 KT-LIST-BACKTRACK
3. #3691 KT-Y-ENV-RECURSION

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

