### PR TITLE
fix(kotlin-wam): KT-LIST-BACKTRACK — heap identity for X-register vars

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -30,7 +30,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | CONF-CLOJURE | Conformance adapter | Clojure | L | — |
 | CONF-LUA | Conformance adapter | Lua | M | — |
 | CONF-KOTLIN ✅ | Conformance adapter | Kotlin | M | done — opt-in (`cursor/conf-kotlin-f421`); append green, 5 xfails |
-| KT-LIST-BACKTRACK | Conformance gap fix | Kotlin | M | CONF-KOTLIN |
+| KT-LIST-BACKTRACK ✅ | Conformance gap fix | Kotlin | M | done — X heap-identity vars (`cursor/kt-list-backtrack-f421`) |
 | KT-ARITH-SLASH-FUNCTOR ✅ | Conformance gap fix | Kotlin | S | done — `///2` last-slash parse (`cursor/kt-arith-slash-functor-f421`) |
 | KT-Y-ENV-RECURSION | Conformance gap fix | Kotlin | M | CONF-KOTLIN |
 | PARSE-C | Runtime-parser entry | C | S | — |
@@ -163,6 +163,7 @@ external toolchain.
 
 ### KT-LIST-BACKTRACK: Fix list placeholder clobber under backtracking (Kotlin)
 - **Lever:** Conformance gap fix  **Target:** Kotlin  **Size:** M  **Depends on:** CONF-KOTLIN
+- **Status:** ✅ **Landed** on `cursor/kt-list-backtrack-f421` (2026-07-12; stacks on KT-ARITH-SLASH-FUNCTOR). `newVariable` for X-registers now allocates a heap identity `H<n>` (Struct/list cells hold `Var(H<n>)`); rebinding `Xn` via `unify_variable` no longer mutates already-built terms. Y-registers still use scoped names (KT-Y-ENV-RECURSION). Removed member/reverse `ct_xfail`s.
 - **Goal:** Retire `ct_xfail(kotlin, member)` / `reverse`. Heap-built lists store CDR as `Var(Xn)`; recursive clauses reuse `Xn` via `unify_variable` and overwrite the binding that shared Structs still reference.
 - **Hint:** deep-copy structs at choice points, or heap refs instead of register-named vars for structure args (same class Haskell fixed with cons-cell finalize).
 

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -43,16 +43,15 @@ module in the fleet.
 - **Lowered emitter scope** — deterministic single-clause only. No T4/T5
   multi-clause, ITE, or `call`/`execute` in lowered bodies (separate cards).
 - **Conformance (opt-in)** — `conformance_target(kotlin)` /
-  `kotlin_functions` registered. **append + builtins green**; member/reverse/fib/ack
-  remain `ct_xfail` (list placeholder clobber under backtrack; Y-register
-  bind-through across recursion). `///2` arith functor parse fixed
-  (KT-ARITH-SLASH-FUNCTOR).
+  `kotlin_functions` registered. **append + builtins + member + reverse green**;
+  fib/ack remain `ct_xfail` (Y-register scoped-name bind-through across
+  recursion — KT-Y-ENV-RECURSION). List CDR clobber and `///2` arith parse fixed.
 - **No foreign kernels, no LMDB / fact source, no ISO contract.**
 - **No runtime-parser capability entry.**
 
 ## Path forward
 
-1. Retire remaining kotlin `ct_xfail`s (list structure-sharing, Y-env).
+1. Retire fib/ack `ct_xfail`s (Y-env / scoped permanent vars).
 2. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
 3. Add ISO / kernels if Kotlin graduates beyond scaffold.
 
@@ -60,4 +59,5 @@ module in the fleet.
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
-(2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN + KT-ARITH-SLASH-FUNCTOR landed.
+(2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN + KT-ARITH-SLASH-FUNCTOR +
+KT-LIST-BACKTRACK landed.

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -67,6 +67,7 @@ class WamState(
     val environmentStack: MutableList<EnvironmentFrame> = mutableListOf(),
     var context: WamContext? = null,
     private var nextEnvironmentId: Int = 0,
+    private var nextHeapVarId: Int = 0,
 ) {
     fun isEnvironmentRegister(register: String): Boolean =
         register.startsWith("Y")
@@ -93,10 +94,19 @@ class WamState(
     }
 
     fun newVariable(register: String): Value.Var {
-        val scopedName = scopedRegisterName(register)
-        val value = Value.Var(scopedName)
+        // X registers: heap identity (KT-LIST-BACKTRACK). Y registers: keep
+        // scoped names for now (KT-Y-ENV-RECURSION handles those separately).
+        if (isEnvironmentRegister(register)) {
+            val scopedName = scopedRegisterName(register)
+            val value = Value.Var(scopedName)
+            writeRegister(register, value)
+            if (scopedName != register) writeRegister(scopedName, value)
+            return value
+        }
+        val heapName = "H${nextHeapVarId++}"
+        val value = Value.Var(heapName)
+        registers[heapName] = value
         writeRegister(register, value)
-        if (scopedName != register) writeRegister(scopedName, value)
         return value
     }
 

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -279,22 +279,14 @@ ct_default_target(elixir).
 %  the skips are removed.
 
 %  Kotlin (CONF-KOTLIN, 2026-07-12). Adapter registered (opt-in). append/3
-%  is GREEN. Remaining classic programs xfail on measured interpreter gaps
-%  (not adapter bugs) — follow-ups tracked in WAM_FLEET_GAP_TASKS.md:
-%   - member/reverse: heap-built list CDRs are Var(Xn) placeholders; later
-%     unify_variable Xn in a recursive clause overwrites that register and
-%     corrupts the shared Struct under backtracking (b/c in [a,b,c] → false).
-%   - builtins: FIXED in KT-ARITH-SLASH-FUNCTOR — evalArith now strips only
-%     the trailing /<digits> so '///2' → name "//".
-%   - fib/ack: permanent Y-registers use scoped names (Y5@E9); after recursive
-%     call, is/2 sees unbound scoped vars in the +/2 tree (environment /
-%     bind-through gap across call/execute).
-ct_xfail(kotlin, member).
-ct_xfail(kotlin, reverse).
+%  + builtins green. Remaining xfails:
+%   - member/reverse: FIXED in KT-LIST-BACKTRACK — X-register structure
+%     placeholders now use heap identities (H<n>), not Var("Xn").
+%   - fib/ack: permanent Y-registers still use scoped names (Y5@E9); after
+%     recursive call, is/2 sees unbound scoped vars in the +/2 tree
+%     (KT-Y-ENV-RECURSION).
 ct_xfail(kotlin, fib).
 ct_xfail(kotlin, ack).
-ct_xfail(kotlin_functions, member).
-ct_xfail(kotlin_functions, reverse).
 ct_xfail(kotlin_functions, fib).
 ct_xfail(kotlin_functions, ack).
 

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -20,6 +20,10 @@
 :- dynamic kt_two_step/2.
 :- dynamic kt_chain/2.
 :- dynamic kt_arith/1.
+:- dynamic kt_member/2.
+:- dynamic kt_mem_b/0.
+:- dynamic kt_mem_c/0.
+:- dynamic kt_mem_z/0.
 
 :- begin_tests(wam_kotlin_target).
 
@@ -442,6 +446,47 @@ test(arith_slash_functor_integer_div, [condition(gradle_available), nondet]) :-
             assertion(BadTrim == "false")
         ),
         retractall(user:kt_arith(_, _))
+    ).
+
+% KT-LIST-BACKTRACK: recursive member must survive backtracking over a
+% heap-built list (CDR placeholders must not share the unify_variable Xn
+% register name).
+test(list_backtrack_member, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_list_backtrack',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt_member(_, _)),
+            retractall(user:kt_mem_b),
+            retractall(user:kt_mem_c),
+            retractall(user:kt_mem_z),
+            assertz(user:kt_member(X, [X|_])),
+            assertz(user:(kt_member(X, [_|T]) :- kt_member(X, T))),
+            assertz(user:(kt_mem_b :- kt_member(b, [a,b,c]))),
+            assertz(user:(kt_mem_c :- kt_member(c, [a,b,c]))),
+            assertz(user:(kt_mem_z :- kt_member(z, [a,b,c])))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt_mem_b/0, user:kt_mem_c/0, user:kt_mem_z/0, user:kt_member/2],
+                [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_mem_b/0'], BOut, _BErr, BStatus),
+            assertion(BStatus == exit(0)),
+            normalize_space(string(BTrim), BOut),
+            assertion(BTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_mem_c/0'], COut, _CErr, CStatus),
+            assertion(CStatus == exit(0)),
+            normalize_space(string(CTrim), COut),
+            assertion(CTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_mem_z/0'], ZOut, _ZErr, ZStatus),
+            assertion(ZStatus == exit(0)),
+            normalize_space(string(ZTrim), ZOut),
+            assertion(ZTrim == "false")
+        ),
+        (   retractall(user:kt_member(_, _)),
+            retractall(user:kt_mem_b),
+            retractall(user:kt_mem_c),
+            retractall(user:kt_mem_z)
+        )
     ).
 
 :- end_tests(wam_kotlin_target).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**KT-LIST-BACKTRACK** — second of three stacked Kotlin interpreter gap fixes. Stacks on #3689 (KT-ARITH-SLASH-FUNCTOR).

## Fix

Heap-built list CDRs were `Value.Var("Xn")` keyed by the **register name**. A later `unify_variable Xn` in a recursive clause overwrote that binding and corrupted the shared `Struct` under backtracking (`member(b,[a,b,c])` → false).

`newVariable` for **X-registers** now allocates a heap identity `H<n>`; cells hold `Var(H<n>)`, so rebinding `Xn` cannot mutate already-built terms. **Y-registers** still use scoped names (`Y5@E9`) — left for KT-Y-ENV-RECURSION.

## Acceptance

- Removed `ct_xfail` for member + reverse (kotlin and kotlin_functions)
- member/reverse green (positive + negative) under both modes
- Regression: recursive `kt_member` via gradle `conformance_main`
- append + builtins remain green; fib/ack still xfail (intentional — PR-3)

## Stack

- Base: #3689 KT-ARITH-SLASH-FUNCTOR
- This PR → base for **KT-Y-ENV-RECURSION**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

