### PR TITLE
fix(kotlin-wam): KT-Y-ENV-RECURSION — heap identity for Y-register vars

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -32,7 +32,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | CONF-KOTLIN ✅ | Conformance adapter | Kotlin | M | done — opt-in (`cursor/conf-kotlin-f421`); append green, 5 xfails |
 | KT-LIST-BACKTRACK ✅ | Conformance gap fix | Kotlin | M | done — X heap-identity vars (`cursor/kt-list-backtrack-f421`) |
 | KT-ARITH-SLASH-FUNCTOR ✅ | Conformance gap fix | Kotlin | S | done — `///2` last-slash parse (`cursor/kt-arith-slash-functor-f421`) |
-| KT-Y-ENV-RECURSION | Conformance gap fix | Kotlin | M | CONF-KOTLIN |
+| KT-Y-ENV-RECURSION ✅ | Conformance gap fix | Kotlin | M | done — Y heap-identity vars (`cursor/kt-y-env-recursion-f421`) |
 | PARSE-C | Runtime-parser entry | C | S | — |
 | PARSE-GO | Runtime-parser entry | Go | S | — |
 | PARSE-SCALA | Runtime-parser entry | Scala | S | — |
@@ -174,6 +174,7 @@ external toolchain.
 
 ### KT-Y-ENV-RECURSION: Y-register bind-through across recursive call (Kotlin)
 - **Lever:** Conformance gap fix  **Target:** Kotlin  **Size:** M  **Depends on:** CONF-KOTLIN
+- **Status:** ✅ **Landed** on `cursor/kt-y-env-recursion-f421` (2026-07-12; stacks on KT-LIST-BACKTRACK). Extends heap-identity `newVariable` to Y-registers (drops scoped `Y@E` Var names that recursive `allocate`/`call` could miss on deref). Removed fib/ack `ct_xfail`s; **all classic programs green**, no remaining Kotlin xfails.
 - **Goal:** Retire fib/ack xfails. After recursive `call`/`execute`, `is/2` sees unbound scoped temps (`Y5@E9`) inside `+/2` trees — permanent-variable / environment bank gap.
 
 ---

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -43,21 +43,20 @@ module in the fleet.
 - **Lowered emitter scope** — deterministic single-clause only. No T4/T5
   multi-clause, ITE, or `call`/`execute` in lowered bodies (separate cards).
 - **Conformance (opt-in)** — `conformance_target(kotlin)` /
-  `kotlin_functions` registered. **append + builtins + member + reverse green**;
-  fib/ack remain `ct_xfail` (Y-register scoped-name bind-through across
-  recursion — KT-Y-ENV-RECURSION). List CDR clobber and `///2` arith parse fixed.
+  `kotlin_functions` registered. **All classic programs green** (append,
+  member, reverse, builtins, fib, ack) — no remaining `ct_xfail`s after
+  KT-ARITH-SLASH-FUNCTOR + KT-LIST-BACKTRACK + KT-Y-ENV-RECURSION.
 - **No foreign kernels, no LMDB / fact source, no ISO contract.**
 - **No runtime-parser capability entry.**
 
 ## Path forward
 
-1. Retire fib/ack `ct_xfail`s (Y-env / scoped permanent vars).
-2. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
-3. Add ISO / kernels if Kotlin graduates beyond scaffold.
+1. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
+2. Add ISO / kernels if Kotlin graduates beyond scaffold.
 
 ## Document status
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
 (2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN + KT-ARITH-SLASH-FUNCTOR +
-KT-LIST-BACKTRACK landed.
+KT-LIST-BACKTRACK + KT-Y-ENV-RECURSION landed.

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -94,15 +94,13 @@ class WamState(
     }
 
     fun newVariable(register: String): Value.Var {
-        // X registers: heap identity (KT-LIST-BACKTRACK). Y registers: keep
-        // scoped names for now (KT-Y-ENV-RECURSION handles those separately).
-        if (isEnvironmentRegister(register)) {
-            val scopedName = scopedRegisterName(register)
-            val value = Value.Var(scopedName)
-            writeRegister(register, value)
-            if (scopedName != register) writeRegister(scopedName, value)
-            return value
-        }
+        // Heap identity independent of the register name (Xn or Yn).
+        // Structure/list cells and arithmetic trees store this Var; later
+        // unify_variable/writeRegister on the register must not clobber
+        // already-built terms, and bindings must survive recursive
+        // call/execute across allocate frames (KT-LIST-BACKTRACK +
+        // KT-Y-ENV-RECURSION). Scoped Y@E names lived in environment
+        // slots that recursive allocate/call could miss on deref.
         val heapName = "H${nextHeapVarId++}"
         val value = Value.Var(heapName)
         registers[heapName] = value

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -278,17 +278,9 @@ ct_default_target(elixir).
 %  is now recursive and cons-aware ($unify_addrs). Both are conformant;
 %  the skips are removed.
 
-%  Kotlin (CONF-KOTLIN, 2026-07-12). Adapter registered (opt-in). append/3
-%  + builtins green. Remaining xfails:
-%   - member/reverse: FIXED in KT-LIST-BACKTRACK — X-register structure
-%     placeholders now use heap identities (H<n>), not Var("Xn").
-%   - fib/ack: permanent Y-registers still use scoped names (Y5@E9); after
-%     recursive call, is/2 sees unbound scoped vars in the +/2 tree
-%     (KT-Y-ENV-RECURSION).
-ct_xfail(kotlin, fib).
-ct_xfail(kotlin, ack).
-ct_xfail(kotlin_functions, fib).
-ct_xfail(kotlin_functions, ack).
+%  Kotlin (CONF-KOTLIN, 2026-07-12). Adapter registered (opt-in). All classic
+%  programs green after KT-ARITH-SLASH-FUNCTOR + KT-LIST-BACKTRACK +
+%  KT-Y-ENV-RECURSION (no remaining kotlin ct_xfail entries).
 
 % ============================================================
 % Toolchain probes

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -24,6 +24,9 @@
 :- dynamic kt_mem_b/0.
 :- dynamic kt_mem_c/0.
 :- dynamic kt_mem_z/0.
+:- dynamic kt_fib/2.
+:- dynamic kt_fib_ok/0.
+:- dynamic kt_fib_bad/0.
 
 :- begin_tests(wam_kotlin_target).
 
@@ -486,6 +489,41 @@ test(list_backtrack_member, [condition(gradle_available), nondet]) :-
             retractall(user:kt_mem_b),
             retractall(user:kt_mem_c),
             retractall(user:kt_mem_z)
+        )
+    ).
+
+% KT-Y-ENV-RECURSION: recursive arithmetic must see Y-register bindings
+% after call returns (heap-identity vars, not scoped Y@E names).
+test(y_env_recursion_fib, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_y_env_fib',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt_fib(_, _)),
+            retractall(user:kt_fib_ok),
+            retractall(user:kt_fib_bad),
+            assertz(user:kt_fib(0, 0)),
+            assertz(user:kt_fib(1, 1)),
+            assertz(user:(kt_fib(N, R) :- N > 1, N1 is N - 1, N2 is N - 2,
+                kt_fib(N1, R1), kt_fib(N2, R2), R is R1 + R2)),
+            assertz(user:(kt_fib_ok :- kt_fib(10, 55))),
+            assertz(user:(kt_fib_bad :- kt_fib(10, 54)))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt_fib_ok/0, user:kt_fib_bad/0, user:kt_fib/2],
+                [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_fib_ok/0'], OkOut, _OkErr, OkStatus),
+            assertion(OkStatus == exit(0)),
+            normalize_space(string(OkTrim), OkOut),
+            assertion(OkTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_fib_bad/0'], BadOut, _BadErr, BadStatus),
+            assertion(BadStatus == exit(0)),
+            normalize_space(string(BadTrim), BadOut),
+            assertion(BadTrim == "false")
+        ),
+        (   retractall(user:kt_fib(_, _)),
+            retractall(user:kt_fib_ok),
+            retractall(user:kt_fib_bad)
         )
     ).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**KT-Y-ENV-RECURSION** — third of three stacked Kotlin interpreter gap fixes. Stacks on #3690 (KT-LIST-BACKTRACK).

## Fix

Permanent Y-registers used scoped `Var(Y5@E9)` names inside arithmetic trees; after recursive `call`/`allocate`, `is/2` saw those vars unbound (fib/ack). Extends heap-identity `newVariable` to **Y-registers** so bindings live in the global `H<n>` bank (same approach as X-registers in KT-LIST-BACKTRACK).

## Acceptance

- Removed `ct_xfail` for fib + ack (kotlin and kotlin_functions)
- **All classic programs green** under both modes — no remaining Kotlin xfails
- Regression: recursive `kt_fib(10,55)` / `kt_fib(10,54)` via gradle
- append/member/reverse/builtins remain green

## Stack

1. #3689 KT-ARITH-SLASH-FUNCTOR ← main
2. #3690 KT-LIST-BACKTRACK ← #3689
3. **This PR** ← #3690

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

