### PR TITLE
Add Rust WAM subtract/3 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -4225,6 +4225,21 @@ compile_execute_ext_builtin_to_rust(Code) :-
                 let a3 = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
                 if self.unify(&a3, &Value::List(kept)) { self.pc += 1; true } else { false }
             }
+            "subtract/3" => {
+                let list = match self.get_reg_raw("A1").map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let excluded = match self.get_reg_raw("A2").map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let kept: Vec<Value> = list.into_iter()
+                    .filter(|item| !excluded.contains(item))
+                    .collect();
+                let a3 = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+                if self.unify(&a3, &Value::List(kept)) { self.pc += 1; true } else { false }
+            }
             "select/3" => {
                 let x_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
                 let list = match self.get_reg_raw("A2").map(|v| self.deref_heap(&self.deref_var(&v))) {

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -493,6 +493,25 @@ fn test_list_utilities() {
         Value::List(vec![a("a"), a("b"), a("a"), a("c")]), a("a"), ub("R"));
     assert!(ok5);
     assert_eq!(read_var(&vm5, "R"), Value::List(vec![a("b"), a("c")]));
+    let (ok6, vm6) = call3(
+        "subtract/3",
+        Value::List(vec![a("a"), a("b"), a("a"), a("c"), a("d")]),
+        Value::List(vec![a("a"), a("d")]),
+        ub("R"),
+    );
+    assert!(ok6);
+    assert_eq!(read_var(&vm6, "R"), Value::List(vec![a("b"), a("c")]));
+    let pair = Value::Str("pair/2".to_string(), vec![a("x"), i(1)]);
+    let (ok7, vm7) = call3(
+        "subtract/3",
+        Value::List(vec![pair.clone(), a("keep")]),
+        Value::List(vec![pair]),
+        ub("R"),
+    );
+    assert!(ok7);
+    assert_eq!(read_var(&vm7, "R"), Value::List(vec![a("keep")]));
+    assert!(!call3("subtract/3", a("not_a_list"), Value::List(vec![]), ub("R")).0);
+    assert!(!call3("subtract/3", Value::List(vec![]), a("not_a_list"), ub("R")).0);
 }
 
 #[test]

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -461,6 +461,7 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"arg/3"'),
         sub_string(S, _, _, _, '"=../2"'),
         sub_string(S, _, _, _, '"copy_term/2"'),
+        sub_string(S, _, _, _, '"subtract/3"'),
         %% copy_term_walk helper (sharing-preserving recursive copy).
         sub_string(S, _, _, _, 'copy_term_walk'),
         %% Runtime-parser bridge support and the parser-required text/list builtins.


### PR DESCRIPTION
## Summary

- implement deterministic `subtract/3` for Rust WAM
- remove every first-list element structurally present in the exclusion list
- preserve order and duplicates that are not excluded
- support structural compound-term comparisons
- fail cleanly when either input is not a list
- add no VM state, helpers, or choicepoints

## Testing

- duplicate and order preservation
- multiple excluded values
- compound-term subtraction
- invalid-list failures
- dedicated Rust builtin parity execution suite
- full Rust WAM target suite
- Rust target syntax/load check
- patch whitespace validation