### PR TITLE
WAM/LLVM plawk: associative add-assign (arr[k] += v) for per-key aggregation

### DIFF
--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3850,6 +3850,7 @@ plawk_passes_tables(Passes, Tables) :-
     N =< 1.
 
 plawk_action_table_name(inc_assoc(var(Name), _Key), Name).
+plawk_action_table_name(add_assoc(var(Name), _Key, _Delta), Name).
 plawk_action_table_name(print(Fields), Name) :-
     member(assoc(var(Name), _Key), Fields).
 
@@ -5267,6 +5268,17 @@ plawk_assoc_body_action_spec(inc_assoc(var(ArrayName), field(KeyIndex)),
 plawk_assoc_body_action_spec(inc_assoc(var(ArrayName), Blob),
         ArrayName-blob_key(Blob)) :-
     plawk_assoc_blob_key_ok(Blob).
+% Associative add-assign `arr[$k] += DELTA`: fold DELTA (a field value or an
+% integer constant) into the table at the key interned from field k. The
+% general form of `arr[$k]++` and the pass-1 half of per-key normalise. v1
+% keys on a field (`arr[$k]`); other key shapes are a follow-on.
+plawk_assoc_body_action_spec(add_assoc(var(ArrayName), field(KeyIndex), Delta),
+        assoc_add(ArrayName, KeyIndex, Delta)) :-
+    integer(KeyIndex), KeyIndex > 0,
+    plawk_assoc_add_delta_ok(Delta).
+
+plawk_assoc_add_delta_ok(field(V)) :- integer(V), V > 0.
+plawk_assoc_add_delta_ok(int(V)) :- integer(V).
 plawk_assoc_body_action_spec(dynassoc_bind(var(ArrayName), Call),
         dynassoc(ArrayName, Call)) :-
     plawk_dynrec_call_ok(Call).
@@ -5509,6 +5521,13 @@ plawk_assoc_planned_actions([ArrayName-KeyIndex | Rest], Tables, StrArrays,
       NextIndex is Index + 1
     },
     [assoc_action(Index, ArrayName, TableIndex, KeyIndex)],
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
+plawk_assoc_planned_actions([assoc_add(ArrayName, KeyIndex, Delta) | Rest],
+        Tables, StrArrays, PosArrays, Index) -->
+    { nth0(TableIndex, Tables, ArrayName),
+      NextIndex is Index + 1
+    },
+    [assoc_add_action(Index, ArrayName, TableIndex, KeyIndex, Delta)],
     plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
 plawk_assoc_planned_actions([dynassoc(ArrayName, Call) | Rest], Tables,
         StrArrays, PosArrays, Index) -->
@@ -6161,6 +6180,45 @@ plawk_assoc_rule_action_blocks(RuleIndex, [assoc_action(Index, _ArrayName, Table
       format(atom(Next), '  br label %~w', [ActionNextLabel])
     },
     [Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, KeyId, Inc, Next, ''],
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+% Associative add-assign `arr[$k] += DELTA`: same key-intern + missing-key
+% skip as the counted inc, but the inc delta is the record's DELTA (a field
+% value via @wam_atom_field_i64_value, or an integer constant) rather than 1.
+plawk_assoc_rule_action_blocks(RuleIndex,
+        [assoc_add_action(Index, _ArrayName, TableIndex, KeyIndex, Delta) | Rest],
+        NextLabel, FieldSeparator) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(HaveLabelName), 'assoc_rule_~w_action_~w_have_key',
+          [RuleIndex, Index]),
+      format(atom(HaveLabel), 'assoc_rule_~w_action_~w_have_key:',
+          [RuleIndex, Index]),
+      format(atom(B), 'assoc_rule_~w_action_~w', [RuleIndex, Index]),
+      format(atom(Slice),
+          '  %~w_key_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 ~w)',
+          [B, KeyIndex, FieldSeparator]),
+      format(atom(Ptr), '  %~w_key_ptr = extractvalue %WamSlice %~w_key_slice, 0', [B, B]),
+      format(atom(Len), '  %~w_key_len = extractvalue %WamSlice %~w_key_slice, 1', [B, B]),
+      format(atom(Missing), '  %~w_key_missing = icmp eq i8* %~w_key_ptr, null', [B, B]),
+      format(atom(Branch), '  br i1 %~w_key_missing, label %~w, label %~w',
+          [B, ActionNextLabel, HaveLabelName]),
+      format(atom(KeyId),
+          '  %~w_key_id = call i64 @wam_intern_atom(i8* %~w_key_ptr, i64 %~w_key_len)',
+          [B, B, B]),
+      plawk_assoc_scalar_src_lines(Delta, B, FieldSeparator, DeltaVar, DeltaLines),
+      format(atom(Inc),
+          '  %~w_sum = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_key_id, i64 ~w)',
+          [B, TableIndex, B, DeltaVar]),
+      format(atom(Next), '  br label %~w', [ActionNextLabel]),
+      append([[Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, KeyId],
+              DeltaLines, [Inc, Next, '']], Lines)
+    },
+    plawk_emit_lines(Lines),
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
 
 %% plawk_record_program_ok(+Descriptor, +Rules, +EndPrintFields) is semidet.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1407,12 +1407,45 @@ dynrec_type(i64) --> "i64".
 dynrec_type(f64) --> "f64".
 dynrec_type(string) --> "string".
 
+% Associative add-assign: `arr[k] += DELTA` folds DELTA into the table at
+% the key. The natural pass-1 half of per-key normalise (`total[$1] += $2`),
+% and the general form of `arr[k]++` (which is `+= 1`). DELTA is a field or
+% an integer literal (i64 table values); other deltas are a follow-on. Tried
+% before the scalar clause -- the `[` distinguishes them.
+add_assign_action(add_assoc(var(Name), KeyExpr, Delta)) -->
+    identifier(Name),
+    ws,
+    "[",
+    ws,
+    assoc_key_expr(KeyExpr),
+    ws,
+    "]",
+    !,
+    ws,
+    "+=",
+    ws,
+    assoc_add_delta(Delta).
 add_assign_action(add(var(Name), Delta)) -->
     identifier(Name),
     ws,
     "+=",
     ws,
     scalar_delta_expr(Delta).
+
+% Delta for an assoc add-assign: a numeric field or an integer literal.
+assoc_add_delta(field(Index)) -->
+    "$",
+    integer_codes(IndexCodes),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    },
+    !.
+assoc_add_delta(int(Value)) -->
+    integer_codes(ValueCodes),
+    { ValueCodes \== [],
+      number_codes(Value, ValueCodes)
+    }.
 
 assignment_action(set(var(Name), Value)) -->
     identifier(Name),

--- a/tests/test_plawk_perkey.pl
+++ b/tests/test_plawk_perkey.pl
@@ -1,0 +1,79 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Per-key aggregation across passes: associative add-assign `arr[$k] += $v`
+% folds a per-key sum into a table in pass 1; pass 2 reads it back per record
+% (`print $1, total[$1]`). This is the per-key counterpart to grand-total
+% normalise -- each record is annotated with the total for ITS key, not the
+% grand total. `arr[$k] += 1` is the general form of the counted `arr[$k]++`.
+% (Fractional per-key normalise -- `$2 / total[$1]` -- rides on top of this
+% once arithmetic operands can be table lookups.) See PLAWK_MULTIPASS_CACHE.md.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_perkey).
+
+% Per-key sum: pass 1 folds `total[$1] += $2`, pass 2 annotates each record
+% with its key's total. Over a=10, a=20, b=5: a->30, b->5.
+test(perkey_sum, [condition(clang_available)]) :-
+    kdir(Dir),
+    Src = "pass { total[$1] += $2 }\npass { print $1, total[$1] }\n",
+    run_sorted(Dir, 'pks', Src, "a 10\na 20\nb 5\n", S),
+    assertion(S == ["a 30", "a 30", "b 5"]),
+    !.
+
+% `arr[$k] += 1` is the general form of `arr[$k]++`: a per-key count folded
+% in pass 1, annotated per record in pass 2. Over a a b: a->2, b->1.
+test(perkey_count_via_add, [condition(clang_available)]) :-
+    kdir(Dir),
+    Src = "pass { c[$1] += 1 }\npass { print $1, c[$1] }\n",
+    run_sorted(Dir, 'pkc', Src, "a\na\nb\n", S),
+    assertion(S == ["a 2", "a 2", "b 1"]),
+    !.
+
+% Single-pass add-assign folds a per-key sum, dumped in END -- the add-assign
+% chain must not break the pure-assoc route.
+test(single_pass_add_assign, [condition(clang_available)]) :-
+    kdir(Dir),
+    Src = "{ total[$1] += $2 }\nEND { for (k in total) print k, total[k] }\n",
+    run_sorted(Dir, 'spa', Src, "a 10\na 20\nb 5\n", S),
+    assertion(S == ["a 30", "b 5"]),
+    !.
+
+:- end_tests(plawk_perkey).
+
+% --- helpers ---------------------------------------------------------------
+
+kdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_perkey', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
**PR 1 of 2** in a stack completing per-key normalise. This one adds the pass-1 half.

Adds `arr[$k] += DELTA` to the surface — fold a field value or an integer constant into an assoc table at the key interned from field `k`. This is the general form of the counted `arr[$k]++`, and the pass-1 half of **per-key normalise**:

```awk
pass { total[$1] += $2 }        # build per-key sum
pass { print $1, total[$1] }    # annotate each record with ITS key's total
```

Over `a 10 / a 20 / b 5` → `a 30`, `a 30`, `b 5`.

## Changes
- **Parser**: `add_assign_action` gains an assoc clause (`identifier[key] += delta`), tried before the scalar clause — the `[` distinguishes them. Delta is a numeric field or an integer literal.
- **Codegen**: a new `assoc_add` spec / `assoc_add_action` planned action / emitter, mirroring the counted-inc path (same key-intern + missing-key skip) but passing the record's delta to `@wam_assoc_i64_inc` instead of a literal `1`. Table discovery (`plawk_action_table_name` / `plawk_passes_tables`) recognises `add_assoc` so the multi-pass driver threads the shared table.

## Tests
`tests/test_plawk_perkey.pl`: per-key sum, per-key count via `+= 1`, single-pass add-assign dumped in END. Regression green across multipass, passes, assoc-print, crosspass-scalar, normalise, forin-filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_