### PR TITLE
WAM/LLVM plawk: table lookup in print arithmetic → per-key normalise

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -16,11 +16,14 @@ from pass 1's table; cross-pass scalars (`acc += 1` / `acc += $N`
 folded in one pass and read in a later pass, backed by a zero-initialised
 module global); pure-scalar (no-table) multi-pass, where a program carries
 no assoc table at all and passes coordinate only through scalar globals;
-and arithmetic in prints (`$2 / total`) evaluated in f64 (the surface `/`
+arithmetic in prints (`$2 / total`) evaluated in f64 (the surface `/`
 is integer, so a print expression is promoted to double and printed with
-`%g`). Together the last two complete **grand-total normalise**
-(`pass { total += $2 } pass { print $1, $2 / total }`). **Not yet:**
-configurable readers (phase 4); the query reader (phase 6);
+`%g`), which completes **grand-total normalise**
+(`pass { total += $2 } pass { print $1, $2 / total }`); and per-key
+aggregation via associative add-assign (`total[$1] += $2`) plus a table
+lookup as an arithmetic operand (`$2 / total[$1]`), which completes
+**per-key normalise** — each record divided by its own key's total. **Not
+yet:** configurable readers (phase 4); the query reader (phase 6);
 namespaces / `eager` / secondary indexes; string-literal print fields. See
 the per-phase status tags in §5.
 
@@ -483,9 +486,15 @@ single-pass test before any driver surgery).
   `@wam_atom_field_f64_value`, a scalar via `load`+`sitofp`, an int constant
   via `sitofp`) and prints with `%g`. Grand-total normalise
   (`pass { total += $2 } pass { print $1, $2 / total }`) now works with no
-  assoc table at all. **Deferred:** multiple tables, arithmetic operands
-  that are table lookups, and pairing multi-pass with a cache-backed /
-  `BEGIN`-declared table.
+  assoc table at all. **Landed since:** per-key aggregation — associative
+  add-assign `arr[$k] += DELTA` (`tests/test_plawk_perkey.pl`, the general
+  form of `arr[$k]++`, mapping to `@wam_assoc_i64_inc` with the record's
+  delta) folds a per-key sum in pass 1, and a table lookup as an arithmetic
+  operand (`$2 / total[$1]`, interned key → `@wam_assoc_i64_get` → `sitofp`)
+  lets pass 2 divide each record by its own key's total. Grand-total and
+  per-key normalise both work end to end. **Deferred:** multiple tables,
+  non-field keys / deltas in add-assign, and pairing multi-pass with a
+  cache-backed / `BEGIN`-declared table.
 
 - **Phase 3 — cache as the inter-pass channel (durable payoff).** Combine
   1+2: a table declared in a `BEGIN cache("db")` block written in pass 1 and

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5358,13 +5358,27 @@ plawk_i64_op_f64(mod_i64, frem).
 plawk_assoc_arith_operand(field(N), afield(N)) :- integer(N), N > 0.
 plawk_assoc_arith_operand(var(Name), asvar(Name)) :- atom(Name).
 plawk_assoc_arith_operand(int(V), aint(V)) :- integer(V).
+% A table lookup `arr[$N]` as an operand, e.g. `$2 / total[$1]` (per-key
+% normalise). The array is resolved to a table index at planning time.
+plawk_assoc_arith_operand(assoc(var(Arr), field(N)), alookup(Arr, N)) :-
+    atom(Arr), integer(N), N > 0.
 
 % Resolve a print field's lookup array to its table index in the plan.
 plawk_assoc_print_plan_field(_Tables, fld(N), fld(N)).
 plawk_assoc_print_plan_field(Tables, lookup(Arr, N), lookup(TableIndex, N)) :-
     nth0(TableIndex, Tables, Arr).
 plawk_assoc_print_plan_field(_Tables, svar(Name), svar(Name)).
-plawk_assoc_print_plan_field(_Tables, farith(Op, L, R), farith(Op, L, R)).
+plawk_assoc_print_plan_field(Tables, farith(Op, L, R), farith(Op, L2, R2)) :-
+    plawk_assoc_arith_operand_plan(Tables, L, L2),
+    plawk_assoc_arith_operand_plan(Tables, R, R2).
+
+% Resolve an arithmetic operand against the table set: a lookup operand
+% binds its array to a table index; field/scalar/int operands pass through.
+plawk_assoc_arith_operand_plan(Tables, alookup(Arr, N), alookup_at(TableIndex, N)) :-
+    nth0(TableIndex, Tables, Arr).
+plawk_assoc_arith_operand_plan(_Tables, afield(N), afield(N)).
+plawk_assoc_arith_operand_plan(_Tables, asvar(Name), asvar(Name)).
+plawk_assoc_arith_operand_plan(_Tables, aint(V), aint(V)).
 
 % The per-record source value added to a scalar accumulator: a constant, or
 % field N converted to i64.
@@ -5466,6 +5480,23 @@ plawk_assoc_arith_operand_lines(asvar(Name), P, Slot, _FieldSep, ValVar, [LoadL,
 plawk_assoc_arith_operand_lines(aint(V), P, Slot, _FieldSep, ValVar, [Line]) :-
     format(atom(ValVar), '%~w_~w', [P, Slot]),
     format(atom(Line), '  ~w = sitofp i64 ~w to double', [ValVar, V]).
+% Table lookup operand: intern field N, read the table's i64 value there
+% (0 if absent), promote to double.
+plawk_assoc_arith_operand_lines(alookup_at(TableIndex, N), P, Slot, FieldSep, ValVar,
+        [SliceL, PtrL, LenL, KidL, ValL, PromL]) :-
+    format(atom(B), '~w_~w', [P, Slot]),
+    format(atom(ValVar), '%~w_lu', [B]),
+    format(atom(SliceL),
+        '  %~w_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 ~w)',
+        [B, N, FieldSep]),
+    format(atom(PtrL), '  %~w_ptr = extractvalue %WamSlice %~w_slice, 0', [B, B]),
+    format(atom(LenL), '  %~w_len = extractvalue %WamSlice %~w_slice, 1', [B, B]),
+    format(atom(KidL),
+        '  %~w_kid = call i64 @wam_intern_atom(i8* %~w_ptr, i64 %~w_len)', [B, B, B]),
+    format(atom(ValL),
+        '  %~w_val = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_kid)',
+        [B, TableIndex, B]),
+    format(atom(PromL), '  ~w = sitofp i64 %~w_val to double', [ValVar, B]).
 
 plawk_assoc_body_action_spec(for_in(var(LoopVar), var(ArrayName), Body),
         forin(LoopVar, ArrayName, Fields)) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1809,6 +1809,17 @@ i64_factor_expr(field(Index)) -->
 i64_factor_expr(Expr) -->
     prolog_call_expr(Expr),
     !.
+% An assoc lookup `arr[k]` as an arithmetic operand, e.g. `$2 / total[$1]`
+% (per-key normalise). Tried before the bare identifier -- the `[` commits.
+i64_factor_expr(assoc(var(Name), KeyExpr)) -->
+    identifier(Name),
+    ws,
+    "[",
+    ws,
+    assoc_key_expr(KeyExpr),
+    ws,
+    "]",
+    !.
 i64_factor_expr(var(Name)) -->
     identifier(Name).
 

--- a/tests/test_plawk_perkey.pl
+++ b/tests/test_plawk_perkey.pl
@@ -48,6 +48,17 @@ test(single_pass_add_assign, [condition(clang_available)]) :-
     assertion(S == ["a 30", "b 5"]),
     !.
 
+% Fractional per-key normalise: a table lookup as an arithmetic operand in a
+% print (`$2 / total[$1]`), evaluated in f64. Each record is divided by its
+% OWN key's total. Over a=10,30 (total 40) and b=5 (total 5):
+% 0.25, 0.75, 1.
+test(perkey_normalise, [condition(clang_available)]) :-
+    kdir(Dir),
+    Src = "pass { total[$1] += $2 }\npass { print $1, $2 / total[$1] }\n",
+    run_sorted(Dir, 'pkn', Src, "a 10\na 30\nb 5\n", S),
+    assertion(S == ["a 0.25", "a 0.75", "b 1"]),
+    !.
+
 :- end_tests(plawk_perkey).
 
 % --- helpers ---------------------------------------------------------------


### PR DESCRIPTION
**PR 2 of 2** — stacked on #perkey (assoc add-assign). Base it after that one merges.

Allows an assoc lookup `arr[$k]` as an operand in a per-record print arithmetic expression, so `$2 / total[$1]` divides each record by its own key's total. Combined with the add-assign from the first PR, this completes **per-key normalise** end to end:

```awk
pass { total[$1] += $2 }
pass { print $1, $2 / total[$1] }
```

Over `a 10 / a 30` (key total 40) and `b 5` (key total 5) → `0.25`, `0.75`, `1`.

## Changes
- **Parser**: `i64_factor_expr` accepts `identifier[key]` (the `[` commits; tried before the bare identifier).
- **Codegen**: an `alookup` arithmetic operand resolves its array to a table index at planning time (`plawk_assoc_arith_operand_plan`); the f64 operand emitter then interns field N, reads the table with `@wam_assoc_i64_get` (0 if absent), and promotes with `sitofp` — reusing the f64 print-arithmetic path from grand-total normalise.

## Tests
`tests/test_plawk_perkey.pl` gains `perkey_normalise` (fractional per-key). Regression green across multipass, passes, assoc-print, crosspass-scalar, normalise, forin-filter. Design doc status updated.

> Note: the diff shown here includes PR 1's commit until it merges; review only the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_