### PR TITLE
mu_cosine: audit PSD graph geometries with independent embedding controls

### DIFF
--- a/prototypes/mu_cosine/DECISIONS_graph_geometry.md
+++ b/prototypes/mu_cosine/DECISIONS_graph_geometry.md
@@ -1,0 +1,193 @@
+# Graph-geometry covariance decision log
+
+This is the append-only companion to `DESIGN_graph_geometry_confirmatory.md`.  Record a decision when it is
+made, the evidence available at that time, alternatives rejected or deferred, and what result would reverse it.
+Do not silently rewrite rationale after outcomes are known.
+
+## 2026-07-12 — separate distance, kernel, and covariance
+
+**Decision:** use scalar graph distance for sampling/interpretation, but admit a covariance geometry only with
+an explicit PSD certificate.
+
+**Reason:** an arbitrary graph shortest-path RBF need not be PSD.  The conditioner needs a valid covariance,
+not merely a plausible similarity score.
+
+**Accepted:** feature Grams, symmetric-Laplacian spectral kernels, nonnegative sums, and Schur products.
+
+**Rejected:** clipping negative eigenvalues of an otherwise indefinite candidate as the primary construction.
+Clipping hides a model error and changes the intended geometry.
+
+**Reconsider if:** a proposed graph metric is proved negative type on the exact graph family and its kernel
+passes the same held gates.
+
+## 2026-07-12 — scalable graph family
+
+**Decision:** make finite-hop walk-feature diffusion the primary scalable family; retain exact heat and
+regularized-Laplacian kernels as small-graph references.
+
+**Reason:** `Phi Phi.T` is PSD by construction, nonnegative hop weights are easy to constrain, and local sparse
+walk features avoid whole-graph eigendecomposition.  Heat/resolvent references test whether the finite feature
+family loses important spectral behavior.
+
+**Rejected for now:** immediate CUDA work on exact full-graph diagonalization.
+
+**Reconsider if:** a statistically validated component routinely exceeds CPU/sparse-feature budgets and matched
+timing shows the exact spectral form improves held predictions enough to justify it.
+
+## 2026-07-12 — independent semantic geometry
+
+**Decision:** preregister Nomic `nomic-embed-text-v1.5` with the `clustering:` prefix as the primary frozen
+external semantic candidate and MiniLM `all-MiniLM-L6-v2` as the lower-capacity comparator.  Pin exact model
+revisions and cache content.
+
+**Reason:** current mu readouts consume e5, so using e5 again would make redundancy likely and attribution weak.
+Nomic and MiniLM provide a representation channel not used by the operating pipeline.  Nomic's clustering
+prefix matches symmetric topic geometry; query/document prefixes would inject an unnecessary retrieval role.
+
+**Not claimed:** either embedder is statistically independent of all language-model priors or superior on this
+corpus.  Independence is an empirical correlation/ablation question.
+
+**Rejected as primary:** e5 semantic geometry.  Keep it as a shared-input control because it is scientifically
+useful to measure how much apparent benefit comes from reusing the model's own representation.
+
+**Reconsider if:** an independent embedder has inadequate title coverage or fails held likelihood while e5 adds
+incremental benefit under an honest redundancy ablation.
+
+## 2026-07-12 — judge-derived distance
+
+**Decision:** exclude distances computed from the same observed judge calls.  Allow cross-fitted `mu_hat`
+distance only as a future leave-one-judge-out diagnostic.
+
+**Reason:** same-call noise otherwise enters both the geometry and the residual, exaggerating correlation.  A
+cross-fitted prediction can be a valid conditional covariate, but it is not independent evidence.
+
+**Reconsider if:** a complete generative model jointly specifies the observation-dependent covariance and wins
+outer-held likelihood/calibration without leakage.
+
+## 2026-07-12 — graph plus embedding combination
+
+**Decision:** nonnegative convex sums are primary; Schur products are secondary.
+
+**Reason:** a sum lets either geometry explain an independent covariance mode.  A product is conservative but
+can erase real graph-local structure whenever a general-purpose embedder misses domain-specific similarity.
+
+**Rejected:** unconstrained signed kernel weights and post-hoc choice of a large mixture grid.
+
+**Reconsider if:** a preregistered multiple-kernel learner with nonnegative weights passes full-procedure null
+calibration and outer-held gates.
+
+## 2026-07-12 — evidence order
+
+**Decision:** mechanism audit, then outcome-blind campaign construction, then repeated-judge confirmation, then
+QR integration/optimization.
+
+**Reason:** the merged pilot showed that stable covariance-looking structure can coexist with inadequate power
+and identification.  Numerical sophistication cannot repair weak covariance evidence.
+
+**Rejected:** lowering the 95% deployment bound to use more apparent correlation.
+
+**Reconsider if:** additional independent components and repeated calls tighten the simultaneous bound while
+held posterior/calibration metrics remain favorable.
+
+## 2026-07-12 — v1 mechanism audit failed: common alpha was not matched effect
+
+**Observed:** the preregistered v1 family-wise selector controlled the block-null nonzero rate, but selected held
+gain was usually negative.  Common `alpha` planted 4.25 times more off-diagonal RMS energy in the closed kernel
+than the walk kernel.  Heat and resolvent were 0.999 correlated on the fixed graph, so exact family recovery was
+also unidentifiable.
+
+**Decision:** preserve v1 as failed.  Freeze v2 around matched maximum off-item coupling `rho`, which is the
+operational batching quantity, and score predictive equivalence classes rather than requiring arbitrary labels
+for nearly identical kernels.
+
+**Rejected:** deleting weak families, shrinking the candidate grid after seeing v1, or calling larger training
+field counts a successful primary result.
+
+**Reconsider if:** a different outcome-blind graph makes the spectral kernels distinguishable; equivalence
+classes must then be recomputed before outcomes on that graph.
+
+## 2026-07-12 — same-hop walk concatenation rejected by outcome-blind topology inventory
+
+**Observed without residual outcomes:** the separate-hop feature Gram was almost identity and did not make
+directly adjacent campaign roots closer than nonadjacent roots.  It only compares equal-hop landing
+distributions and misses the important `p_0(a)` versus `p_1(b)` overlap.
+
+**Decision:** retain it as a negative/control geometry and add a cumulative-walk Gram that sums hop
+distributions in one feature space.  This preserves PSD and sparse execution while admitting cross-hop overlap.
+
+**Rejected:** tuning hop weights against residuals to rescue the original construction.
+
+**Reconsider if:** a different estimand specifically requires equal diffusion time rather than local adjacency;
+the same-hop version can then be preregistered for that estimand.
+
+## 2026-07-12 — independent embeddings are distinct models but not independent geometry
+
+**Observed without residual outcomes:** Nomic versus shared-e5 distance Spearman correlation was 0.776
+exploratory and 0.838 fresh; MiniLM versus e5 was 0.810 and 0.868.  Nomic and MiniLM were themselves 0.894 and
+0.907 correlated.  All three semantic models made adjacent roots closer on average.
+
+**Decision:** keep Nomic as the primary external semantic candidate because it is modestly less redundant with
+e5; keep MiniLM as a lower-cost sensitivity comparator, not a separate high-capacity selector branch.  Sample
+the graph/semantic disagreement cells deliberately (about 4% exploratory and 10% fresh in the first inventory).
+
+**Rejected:** describing either external embedding as independent ground truth, or treating Nomic plus MiniLM
+as two independent votes.
+
+**Reconsider if:** residual-held ablation demonstrates incremental benefit from both after full search/null
+calibration.
+
+## 2026-07-12 — cumulative walk accepted as the scalable local representative
+
+**Observed without residual outcomes:** cumulative walk restores the intended adjacency ordering: mean distance
+adjacent/nonadjacent was `0.857/0.996` exploratory and `0.770/0.982` fresh.  Its distance correlation with the
+closed-neighborhood baseline was 0.730 / 0.885 Spearman.  On the fixed synthetic graph it was 0.962--0.972
+correlated with closed, heat, and resolvent kernels, placing it in the same local/spectral predictive class.
+
+**Decision:** use closed neighborhood as the cheapest fixed baseline and cumulative walk as the scalable
+learnable representative.  Keep exact heat/resolvent as mathematical references, not three extra selector
+branches unless a future outcome-blind graph makes them distinguishable.  Do not create a v3 selector merely
+to add a nearly equivalent kernel; that would increase null multiplicity without adding identified geometry.
+
+**Independent-embedding update:** relative to cumulative walk, graph/semantic disagreement cells are only
+`13/764` exploratory and `22/777` fresh for Nomic (1.7% / 2.8%).  Existing data are thin for interaction
+estimation, so the new campaign must oversample disagreement rather than rely on natural frequency.
+
+**Rejected:** interpreting a larger candidate count as broader evidence, and treating heat/resolvent/cumulative
+as independent votes on this topology.
+
+**Reconsider if:** outcome-blind kernel correlation falls below the preregistered equivalence threshold on a new
+corpus or graph representation.
+
+## 2026-07-12 — prefer one selected item kernel before numerical diagonalization
+
+**Decision:** the first structured covariance promoted to the conditioner should have one selected item kernel,
+
+```text
+R = I_n tensor B0 + K_theta tensor Bg.
+```
+
+If `K_theta=U Lambda U.T`, the item transform `U tensor I_m` reduces `R` to `n` independent channel blocks
+`B0 + lambda_i Bg`.  For the proposed `n=128,m=32` regime, this exposes one 128-dimensional eigendecomposition
+plus 128 parallel 32-dimensional factorizations, which is a plausible CPU/GPU path after statistical validation.
+
+**Rejected for the first optimized path:** several independently weighted, noncommuting item kernels
+`sum_g K_g tensor Bg`.  They generally cannot be simultaneously diagonalized.  Select a nonnegative convex
+item-kernel mixture first; retain dense LMC as a statistical reference.
+
+**Not yet authorized:** CUDA performance claims or a specialized inverse-root implementation.  The existing
+dense QR conditioner remains the correctness baseline until real repeated-judge covariance passes its gates.
+
+**Reconsider if:** multiple item kernels show separately identified held benefit large enough to justify a
+joint/block diagonalization or iterative solver.
+
+## 2026-07-12 — distinguish rank deficiency from positive-spectrum conditioning
+
+**Decision:** report both exact numerical rank and `positive_spectrum_condition_number`.  The latter describes
+the ratio among nonzero eigenvalues only; it is not the ordinary condition number of a singular matrix.
+Closed-neighborhood Gram kernels can be rank deficient by construction, so a finite value must never imply
+that the full kernel is invertible.
+
+**Rejected:** silently dropping zero eigenvalues while labelling the remaining ratio `condition_number`.
+
+**Operational consequence:** downstream covariance construction still adds the separately selected nugget or
+block-noise term before whitening.  Kernel diagnostics do not authorize directly inverting a singular kernel.

--- a/prototypes/mu_cosine/DESIGN_graph_geometry_confirmatory.md
+++ b/prototypes/mu_cosine/DESIGN_graph_geometry_confirmatory.md
@@ -1,0 +1,273 @@
+# Confirmatory graph geometry for cross-item residual covariance
+
+## Status and scope
+
+**Frozen before running the graph-geometry synthetic benchmark or any new geometry comparison on real
+residuals.**  This design follows the merged adjacent-residual pilot.  That pilot found a stable descriptive
+adjacency-plus-hop signal but could not identify stochastic covariance separately from persistent item effects
+and failed its synthetic power gate.
+
+This workstream asks which outcome-blind item geometry, if any, can predict transferable cross-item conditional
+residual covariance.  It does not change the square-root/QR conditioner: that implementation already accepts a
+dense covariance.  It does not promote `JointPosterior`, which remains a learned decision comparator rather
+than a covariance factorization.
+
+The first PR is infrastructure and mechanism evidence only:
+
+1. specify PSD-safe graph and independent-embedding kernel families;
+2. implement their deterministic feature maps and small-graph references;
+3. audit planted-geometry recovery, misspecification, and covariance sensitivity synthetically;
+4. preregister the repeated-judge campaign that would be required for a deployment claim.
+
+No kernel may enter production QR, certify independent batching, or relax the 95% simultaneous safety rule in
+this PR.
+
+## Statistical object
+
+For measurement item `i`, after train-only calibration, prior/measurement conditionalization, and mean removal,
+let the conditional residual be
+
+```text
+q_i = m(x_i) + epsilon_i,
+E[epsilon_i | x_i] = 0,
+Cov(epsilon_i, epsilon_j | z_i, z_j) = alpha K_theta(i,j) B_cross.
+```
+
+`B_cross` is a PSD judge/channel covariance contribution.  The exact within-item marginal `B` is preserved by
+the correlation path used by the conditioner.  In the first mechanism study, `B_cross=B` to isolate item
+geometry; the confirmatory study must estimate judge-axis structure from independent repeated calls.
+
+The crucial ordering is:
+
+1. fit the mean on outer-training endpoint components;
+2. compute residuals on disjoint components;
+3. learn kernel scales/weights and covariance amplitudes inside training components only;
+4. score the entire frozen procedure on outer-held components.
+
+A geometry that only absorbs a missed regional mean is not residual covariance evidence.
+
+## Distance is not automatically a covariance kernel
+
+A scalar distance `d(i,j)` is useful for sampling and interpretation, but `exp(-d^2/(2 ell^2))` is PSD for
+Euclidean/negative-type distances, not for every graph shortest-path metric.  The implementation therefore
+constructs kernels from one of three PSD certificates:
+
+- an explicit feature Gram `Phi Phi.T`;
+- a nonnegative spectral function of a symmetric graph Laplacian;
+- a nonnegative sum or Schur product of already-PSD kernels.
+
+Every materialized item kernel must be symmetric, unit-diagonal, finite, and have minimum eigenvalue at least
+`-1e-10` in float64.  Numerical clipping may remove roundoff below that tolerance; it may not repair a
+structurally indefinite candidate.
+
+## Frozen graph candidate family
+
+All graph topology is outcome-blind.  Candidate hyperparameters are selected within outer-training components.
+
+### G0 — independent block
+
+`K=I`.  This is the production baseline and is always an eligible fallback.
+
+### G1 — closed-neighborhood Gram
+
+The merged pilot's same-descendant cosine between binary closed one-hop root neighborhoods.  It is the fixed,
+low-capacity baseline and must reproduce the existing implementation.
+
+### G2 — finite-hop walk-feature diffusion (primary scalable family)
+
+For root `r`, let `p_h(r)` be its outcome-blind `h`-step random-walk landing distribution on the undirected
+graph, with `p_0(r)` a point mass.  For nonnegative hop weights `w_h`, define
+
+```text
+Phi(r) = concat_h sqrt(w_h) p_h(r),
+K_walk(r,s) = <Phi(r),Phi(s)> / (||Phi(r)|| ||Phi(s)||).
+```
+
+This is PSD by construction for any nonnegative weights.  It is local and sparse for small maximum hop, avoids
+whole-graph diagonalization, and generalizes the one-hop overlap idea.  The frozen mechanism grids are:
+
+```text
+local      w = (1, 1)
+two_hop    w = (1, 1, 1)
+decay      w = (1, 1/2, 1/4, 1/8)
+```
+
+Future learning may use a softmax over hop logits, preserving nonnegativity.  Unconstrained signed hop weights
+are not allowed.
+
+### G3 — heat/diffusion kernel (small-graph mathematical reference)
+
+For symmetric normalized Laplacian `L`,
+
+```text
+K_heat(t) = exp(-t L),       t in {0.25, 0.5, 1, 2, 4}.
+```
+
+The diagonal-normalized form is PSD.  Exact eigendecomposition is a reference for small components and
+synthetic checks, not the large-graph execution plan.  This follows the diffusion-kernel construction of
+[Kondor and Lafferty (2002)](https://people.cs.uchicago.edu/~risi/papers/diffusion-kernels.pdf).
+
+### G4 — regularized-Laplacian/resolvent kernel (small-graph reference)
+
+```text
+K_resolvent(tau) = (I + tau L)^-1,  tau in {0.25, 0.5, 1, 2, 4}.
+```
+
+The diagonal-normalized inverse is PSD for `tau>0`.  It decays spectrally more slowly than heat and is a useful
+longer-range comparator; see [Smola and Kondor (2003)](https://people.cs.uchicago.edu/~risi/papers/SmolaKondor.pdf).
+
+### Role gating
+
+The first confirmatory estimand retains the pilot's same-descendant restriction:
+
+```text
+K_item((left_i,root_i),(left_j,root_j))
+  = 1[left_i=left_j] K_root(root_i,root_j).
+```
+
+The indicator is itself a one-hot Gram, so the Schur product remains PSD.  Cross-descendant covariance is a
+later extension requiring its own repeated-call evidence.
+
+## Independent embedding geometry
+
+An embedding candidate is acceptable only when it is frozen before the judge campaign, available at inference,
+not trained on the campaign labels, revision-pinned, and stored with content-addressed provenance.  “Not called
+a judge” is insufficient if it shares the same outcome labels or representation stack.
+
+The current mu readouts consume e5, so e5 geometry is a **shared-input control**, not the preferred independent
+semantic geometry.  Two locally available candidates are frozen:
+
+- `sentence-transformers/all-MiniLM-L6-v2`, revision
+  `c9745ed1d9f207416be6d2e6f8de32d1f16199bf`, symmetric title encoding;
+- `nomic-ai/nomic-embed-text-v1.5`, revision
+  `e9b6763023c676ca8431644204f50c2b100d9aab`, using the model-card `clustering:` prefix because the task is
+  symmetric semantic grouping, not query/document retrieval.  Nomic's open embedding design is described in
+  [Nussbaum et al. (2024)](https://arxiv.org/abs/2402.01613).
+
+Nomic is the primary independent candidate; MiniLM is the lower-capacity comparator.  This is a preregistered
+ordering, not a claim that Nomic will win.
+
+For normalized node vectors `u(node)`, form the role-aware item feature
+
+```text
+f_i = normalize(concat(u(left_i), u(root_i))).
+```
+
+Use a Euclidean RBF with median bandwidth fit on outer-training components, then apply the same-descendant Gram
+gate.  Raw cosine is retained only as a diagnostic.  The cache builder must never download in tests and must
+record model id, exact revision, task prefix, normalization, node ordering, and a SHA-256 over the emitted
+arrays/metadata.
+
+## Combining graph and embedding geometry
+
+The primary combination is a nonnegative convex sum,
+
+```text
+K_mix = gamma K_graph + (1-gamma) K_embed,
+gamma in {0.25, 0.5, 0.75}.
+```
+
+This asks whether either geometry explains an independent residual mode.  The Schur product
+`K_graph * K_embed` is PSD and is retained as a secondary “both must agree” comparator, but it can erase a real
+graph correlation when the external embedder misses domain-specific proximity.  No candidate count may be
+expanded after held results are inspected; any expansion requires an amended preregistration and repeated null
+calibration.
+
+## Judge-derived mu distance
+
+Distance from the same observed judge measurements is excluded: measurement noise would enter both the
+covariance predictor and the residual being explained.  A distance from a cross-fitted `mu_hat` is a valid
+future conditional-covariance covariate only when it is produced on disjoint endpoint components and preferably
+leave-one-judge-family-out.  Even then its interpretation is “covariance conditional on `mu_hat`,” not
+independent structural evidence.  It is preregistered as a diagnostic ablation after repeated calls exist, not
+as a primary geometry.
+
+## Synthetic mechanism audit
+
+Before any new real-residual comparison, generate independent graph components and repeated residual fields
+under block, walk-feature, heat, resolvent, and deranged-kernel truths.  Use known zero mean and known channel
+covariance first; label this mechanism-only.
+
+For each candidate, select covariance amplitude from
+
+```text
+alpha in {0, .025, .05, .10, .20, .35, .50}
+```
+
+on training fields, then score untouched held fields by Gaussian NLL per scalar.  Report:
+
+- block-null nonzero-selection rate and held harm;
+- correct-geometry selection and NLL recovery;
+- wrong-geometry/derangement rejection;
+- sensitivity when the assumed alpha is below/equal/above truth;
+- kernel eigenvalue, condition-number, and diagonal-loading diagnostics.
+
+Frozen mechanism gates:
+
+1. every kernel construction is PSD and unit-diagonal without structural repair;
+2. block-null nonzero selection is at most 10%;
+3. at planted `alpha>=0.10`, the correct family has positive mean held gain and beats the deranged candidate in
+   at least 80% of replicates;
+4. an over-coupled candidate may not improve mean held NLL merely by numerical loading;
+5. all deployment flags remain false regardless of these outcomes.
+
+Failure narrows or redesigns the candidate family; it does not prove accurate covariance would be useless.
+
+## Confirmatory repeated-judge campaign
+
+The mechanism audit does not identify real stochastic covariance.  The next data campaign must:
+
+1. sample balanced `(anchor, adjacent/local positive, matched distant or hard negative)` triples;
+2. balance hop, campaign tag, degree bin, and graph component by construction;
+3. stratify outcome-blind graph-kernel similarity and independent-embedding similarity so their disagreement is
+   observed, not extrapolated;
+4. obtain at least three independent calls per judge family and preserve call identity;
+5. use more than 400 independent endpoint components, with the final count chosen by a full-procedure power
+   simulation rather than computational convenience;
+6. split whole endpoint components and refit mean, marginal covariance, kernel weights, amplitude, and any
+   selector inside each outer fold;
+7. include a different judge family or non-LLM target for generality claims.
+
+Primary gates are outer-held joint residual NLL, posterior NLL/risk, calibration, and numerical loading.  A
+geometry earns deployment consideration only if the 95% simultaneous lower bound on held benefit is positive.
+Distance-separated batching additionally requires a 95% simultaneous **upper** bound on whitened cross-block
+coupling below a preregistered `epsilon_batch`.
+
+## Rejected or deferred alternatives
+
+The rationale and reconsideration conditions are maintained in `DECISIONS_graph_geometry.md`.  At freeze time:
+
+- shortest-path Gaussian covariance: rejected as a direct kernel because PSD is not guaranteed on an arbitrary
+  graph; retain shortest path for sampling strata;
+- naive random-walk/PPR matrix: rejected because it is generally asymmetric on irregular graphs; use a feature
+  Gram or symmetric Laplacian construction;
+- unconstrained learned dense covariance/kernel: rejected for low-sample overfit, weak identifiability, and PSD
+  risk;
+- e5 as the primary semantic distance: rejected because it is a shared input to the current mu readouts;
+- same-judge observed-mu distance: rejected for endogeneity;
+- effective-resistance geometry: deferred because disconnected components, hub/global-edge sensitivity, and
+  pseudoinverse cost complicate the first confirmatory cut;
+- whole-graph exact heat/resolvent diagonalization and CUDA optimization: deferred until a geometry passes the
+  statistical gates;
+- lowering the 95% deployment confidence level: rejected because it changes error tolerance rather than adding
+  information.
+
+## Outcome-blind topology amendment — cumulative walk features
+
+This amendment was frozen after the first campaign **geometry-only** inventory and before any comparison with
+judge residuals.  The original G2 concatenation places each `p_h` in a separate feature block.  On the campaign
+roots its kernel was nearly identity: mean distance was `0.9991` adjacent versus `0.9982` nonadjacent
+exploratory, and `0.9973` versus `0.9919` fresh.  Separate blocks omit cross-hop overlap, so `p_0(a)` cannot
+match `p_1(b)` even when `a` and `b` are directly connected.
+
+Retain that same-hop construction as a negative/control geometry.  Add the primary scalable variant
+
+```text
+Phi_cumulative(r) = sum_h sqrt(w_h) p_h(r),
+K_cumulative(r,s) = <Phi_cumulative(r), Phi_cumulative(s)>
+                      / (||Phi_cumulative(r)|| ||Phi_cumulative(s)||).
+```
+
+It is an explicit Gram and therefore PSD.  Nonnegative weights keep its diffusion interpretation.  The frozen
+topology grids remain `local=(1,1)`, `two_hop=(1,1,1)`, and `decay=(1,1/2,1/4,1/8)`.  Adding it to a covariance
+selector requires a separately calibrated v3 mechanism audit; v1/v2 outputs are not rewritten.

--- a/prototypes/mu_cosine/DESIGN_graph_geometry_synthetic_v2.md
+++ b/prototypes/mu_cosine/DESIGN_graph_geometry_synthetic_v2.md
@@ -1,0 +1,99 @@
+# Graph-geometry synthetic v2 — matched coupling and predictive equivalence
+
+## Status
+
+**Frozen after the v1 mechanism audit failed and before running v2.**  The v1 protocol and failed conclusion
+are retained as an instructive invalid-comparison diagnostic; they are not relabelled or discarded.  The
+portable v1 artifact reported later was recomputed after the shared kernel core changed, so it is a labelled
+reproduction rather than a claim that the original temporary artifact remained byte-for-byte unchanged.
+
+## Why v1 could not answer the intended question
+
+V1 planted the same correlation-path amplitude `alpha` for every unit-diagonal kernel.  On the fixed graph,
+that did not plant the same covariance effect:
+
+| kernel | off-diagonal RMS | maximum off-diagonal |
+|---|---:|---:|
+| closed neighborhood | 0.3063 | 0.8165 |
+| walk-feature decay | 0.0720 | 0.2453 |
+| heat | 0.1848 | 0.6027 |
+| resolvent | 0.1120 | 0.3618 |
+| deranged walk | 0.0720 | 0.2453 |
+
+At common `alpha`, the closed-neighborhood truth therefore carried 4.25 times the RMS coupling energy of the
+walk truth.  Detection and held gain were not comparable across families.
+
+V1 also found kernel correlations `corr(heat,resolvent)=0.999`, `corr(closed,heat)=0.922`, and
+`corr(closed,resolvent)=0.927` on this graph.  Exact family recovery among those three is not identified and is
+not a scientifically useful gate.  Their predictive covariance can be nearly interchangeable.
+
+Finally, v1's family-wise threshold controlled block-null selection (3.5--6% across the sizing runs), but at 12
+training fields selected held gain was negative for all planted cases except closed `alpha=0.2`.  Increasing to
+96 fields helped the stronger local/spectral truths but did not repair the unmatched weak walk signal.  This
+motivates matched effect size; it does not authorize post-hoc removal of difficult scenarios.
+
+## V2 effect parameterization
+
+For unit-diagonal kernel `K`, define
+
+```text
+s_max(K) = max_{i != j} |K_ij|,
+alpha(K, rho) = rho / s_max(K),
+C(K, rho) = (1-alpha) I + alpha K.
+```
+
+The frozen target grid is maximum whitened off-item coupling
+
+```text
+rho in {0, .025, .05, .10, .20}.
+```
+
+All resulting amplitudes must be `<0.95`; otherwise that family/effect cell is declared ineligible before
+simulation.  Report off-diagonal RMS as a secondary effect diagnostic.  Maximum coupling is primary because it
+is also the quantity that governs the proposed independent-batching upper bound.
+
+The selector searches the same family set and this family-specific `rho` grid.  Its full maximum train gain is
+calibrated under block-null fields exactly as in v1.  Selection uses training fields only; scoring uses
+independent held fields.
+
+## Predictive equivalence classes
+
+Before generating v2 residual fields, group candidate kernels using only outcome-blind upper-triangle kernel
+correlation:
+
+```text
+local_spectral = {closed, heat, resolvent}  # every pair correlation >= .90 here
+walk           = {walk_decay}
+deranged       = {deranged_walk}
+```
+
+Exact family selection remains descriptive.  The primary recovery event is selection from the truth's
+equivalence class.  Geometry specificity is assessed by comparing the best train-selected truth-family
+covariance with an equal-energy derangement on held fields.
+
+## Frozen v2 runs and gates
+
+Primary run:
+
+```text
+replicates=200, calibration_draws=1000,
+train_fields=48, held_fields=64, confidence=.95.
+```
+
+The 48-field count is frozen from the v1 field-count sizing grid `{12,24,48,96}` as the first count at which a
+planted local/spectral case at the smaller v1 effect stopped having negative mean held gain.  It is a mechanism
+setting, not a claim that 48 judge calls are required; the real campaign's independent components and repeated
+calls need an end-to-end power model.
+
+For `rho in {.10,.20}`:
+
+1. block-null nonzero selection is at most 10%;
+2. every planted **non-deranged** truth at `rho=.20` has positive mean selected held NLL gain;
+3. the truth's predictive equivalence class is selected in at least 60% of replicates at `rho=.20`;
+4. the train-selected truth family beats its equal-energy derangement on held fields in at least 80% of
+   replicates at `rho=.20`;
+5. lower `rho=.10` results are reported as measured power, not forced to pass;
+6. all real-covariance, batching, and QR-deployment gates remain false.
+
+The deranged truth is a negative-control recovery check and does not need positive deployment value.  Failure
+of gates 2--4 means the candidate search is still too broad or underpowered for the confirmatory campaign.

--- a/prototypes/mu_cosine/REPORT_graph_geometry_confirmatory.md
+++ b/prototypes/mu_cosine/REPORT_graph_geometry_confirmatory.md
@@ -241,11 +241,17 @@ python3 prototypes/mu_cosine/run_graph_geometry_inventory.py \
   --out /tmp/graph_geometry_inventory_cumulative_final.json
 ```
 
-Portable output SHA-256:
+Same-environment output-integrity SHA-256:
 
 - v1 mechanism: `9cd6c0b6f6e7b4efdbf6e8afcff88607b871348fc3a8c212c421a8c8e5d2ee51`;
 - v2 mechanism: `24333d08941ac2c356bb33fdd602a0009317de0daa6d0f7788e176c6bcc33969`;
 - outcome-blind inventory: `81c35eaa8f9fa82afbbcf6a9040f4905f97140b4b91d7134ecfb69957b9fb9a1`.
+
+These hashes exclude wall-clock timing and absolute paths, but they are not a promise of byte-identical output
+across NumPy/BLAS stacks.  Floating-point drift can change the weakest `walk_decay` selection count by about one
+replicate in 200 while leaving every frozen gate unchanged.  Cross-environment reproduction should therefore
+compare the reported scientific fields and gate booleans within their stated precision; use the hashes only to
+check artifact integrity within a matched numerical environment.
 
 The graph-geometry focused suite has 34 passing tests.  Including the inherited adjacent-residual,
 structured-covariance, covariance-sensitivity, and NumPy/Torch square-root-conditioner suites gives

--- a/prototypes/mu_cosine/REPORT_graph_geometry_confirmatory.md
+++ b/prototypes/mu_cosine/REPORT_graph_geometry_confirmatory.md
@@ -1,0 +1,252 @@
+# Graph geometry for residual covariance — theory, mechanism audit, and outcome-blind inventory
+
+## Bottom line
+
+The graph-geometry infrastructure is ready, but no real covariance or QR deployment is unlocked.
+
+- PSD graph geometry is now structural: closed-neighborhood, sparse walk-feature, cumulative-walk, exact heat,
+  and exact regularized-Laplacian references all produce unit-diagonal Gram matrices without eigenvalue repair.
+- The original synthetic comparison failed honestly because common path amplitude `alpha` did not mean common
+  covariance strength across kernels.  Its family-wise null control passed, but selected held likelihood was
+  usually worse.
+- A preregistered v2 matched maximum off-item coupling.  At `rho_max=0.20`, every non-deranged truth had positive
+  held gain, 86.0--97.5% predictive-class recovery, and 97.0--98.5% wins over equal-energy topology controls.
+  Block-null nonzero selection was 5.5%.  At `rho_max=0.10`, power was mixed and the heat case had essentially
+  zero selected gain.
+- The first outcome-blind campaign inventory rejected the original same-hop walk concatenation: it was nearly
+  identity and did not make adjacent roots closer.  Cumulative walk fixes that while remaining a sparse PSD
+  feature Gram.
+- Nomic and MiniLM are different models from the e5-based operating pipeline, but their geometry is not
+  statistically independent of e5.  Nomic is modestly less redundant and remains the primary external
+  semantic candidate; MiniLM is a lower-cost sensitivity comparator.
+
+The next scientific step is the repeated-judge campaign described below.  The current independent/block item
+covariance stays in production.
+
+## Theory implemented
+
+### PSD comes before interpretability
+
+An arbitrary graph distance is useful for sampling but is not automatically a covariance kernel.  In
+particular, a Gaussian RBF over general graph shortest-path distances is not guaranteed PSD.  The accepted
+constructions are:
+
+```text
+explicit Gram:       K = Phi Phi.T
+heat reference:      K = exp(-t L)
+resolvent reference: K = (I + tau L)^-1
+convex mixture:      K = sum_g theta_g K_g, theta_g >= 0
+interaction:         K = K_graph * K_embed       # Schur product
+```
+
+Every kernel is diagonal-normalized to correlation form.  Same-descendant gating is a one-hot Gram multiplied
+elementwise by the root kernel, so it also preserves PSD.  The heat and regularized-Laplacian references follow
+the graph spectral constructions of [Kondor and Lafferty](https://people.cs.uchicago.edu/~risi/papers/diffusion-kernels.pdf)
+and [Smola and Kondor](https://people.cs.uchicago.edu/~risi/papers/SmolaKondor.pdf).
+
+### The scalable graph candidate
+
+The original same-hop feature map was
+
+```text
+concat_h sqrt(w_h) p_h(root).
+```
+
+It compares landing distributions at equal diffusion time.  That is valid and PSD, but it misses the
+cross-hop overlap `p_0(a)` versus `p_1(b)` that represents a direct edge.  The accepted scalable candidate is
+
+```text
+Phi_cumulative(root) = sum_h sqrt(w_h) p_h(root),
+K_cumulative = normalize(Phi_cumulative Phi_cumulative.T).
+```
+
+Sparse CSR propagation and direct sparse Gram accumulation avoid whole-graph diagonalization.  The original
+same-hop kernel remains a negative/control geometry.
+
+### Why one selected item kernel matters numerically
+
+For one item kernel,
+
+```text
+R = I_n tensor B0 + K_theta tensor Bg,
+K_theta = U Lambda U.T,
+```
+
+the transform `U tensor I_m` reduces `R` to independent channel blocks
+
+```text
+B0 + lambda_i Bg,  i=1,...,n.
+```
+
+At the proposed `n=128,m=32`, this suggests one 128-dimensional item eigendecomposition and 128 parallel
+32-dimensional factorizations instead of a single unstructured 4096-dimensional factorization.  Multiple
+noncommuting `K_g tensor B_g` terms generally lose this reduction, which is another reason not to promote a
+large kernel zoo.  This is future optimization theory, not a CUDA performance claim; dense QR remains the
+correctness reference.
+
+## Embedding contract
+
+The cache builder pins model revision, task prefix, title transformation, normalization, node order, array
+shape/dtype, package versions, and content hashes.  Evaluation never downloads a model.
+
+| candidate | exact revision | role |
+|---|---|---|
+| Nomic `nomic-embed-text-v1.5` | `e9b6763023c676ca8431644204f50c2b100d9aab` | primary external semantic geometry; `clustering:` title prefix |
+| MiniLM `all-MiniLM-L6-v2` | `c9745ed1d9f207416be6d2e6f8de32d1f16199bf` | lower-cost sensitivity comparator |
+| e5 | existing frozen caches | shared-input redundancy control, not an independent candidate |
+
+Nomic's clustering prefix is deliberate: this experiment groups semantically similar items and is not a
+query/document retrieval task.  Query/document prefixes are deferred because they inject directional
+membership semantics closer to the quantities being judged.  Nomic's model family and open training design are
+described in [Nussbaum et al.](https://arxiv.org/abs/2402.01613); MiniLM's distilled base architecture is
+described in [Wang et al.](https://arxiv.org/abs/2002.10957).
+
+Both pinned models loaded from local cache and produced deterministic, normalized campaign caches covering
+2,681 unique endpoint titles.  Manifest SHA-256:
+
+- MiniLM: `35fc09608d16dc2b5111686f587a57d5f60895611465b109de6898e864758569`;
+- Nomic: `702f5f4af33c8994d25ad259c6a46ac7f7c762f4d6ef2a47f4335f9bc912e3d2`.
+
+## Synthetic audit chronology
+
+### V1 failed: common alpha was not matched cost
+
+V1 calibrated its full candidate/alpha search with 1,000 block-null simulations, selected on 12 train fields,
+and scored 64 independent held fields.  The block-null nonzero rate was 6.0%, but the frozen planted gates
+failed.  For example:
+
+| truth | alpha | selected held NLL gain/scalar | topology-control win rate |
+|---|---:|---:|---:|
+| closed | 0.10 | -0.001128 | 76.5% |
+| closed | 0.20 | +0.001091 | 87.5% |
+| walk same-hop | 0.10 | -0.001072 | 59.0% |
+| walk same-hop | 0.20 | -0.001216 | 67.5% |
+| heat | 0.20 | -0.000953 | 84.0% |
+| resolvent | 0.20 | -0.001680 | 70.0% |
+
+The reason was visible in outcome-blind kernel diagnostics: off-diagonal RMS ranged from 0.0720 walk to 0.3063
+closed, while heat and resolvent were 0.999 correlated.  Common `alpha` neither matched covariance energy nor
+identified exact family labels.  Field-count diagnostics through 96 reduced the threshold but did not repair
+that comparison.  V1 is retained as failed evidence.
+
+### V2 passed its matched-coupling strong-effect gates
+
+V2 froze `rho_max=max_{i!=j}|C_ij|` as the common effect and grouped the outcome-blind
+`{closed,heat,resolvent}` predictive class.  It used 48 train fields and the same 200 replicates / 1,000 null
+calibrations / 64 held fields.
+
+| truth | rho_max | nonzero selection | equivalence-class selection | truth beats derangement/base | selected held NLL gain/scalar |
+|---|---:|---:|---:|---:|---:|
+| closed | 0.10 | 60.5% | 52.0% | 83.5% | +0.000906 |
+| closed | 0.20 | 98.5% | 97.5% | 98.5% | +0.014632 |
+| walk same-hop | 0.10 | 40.0% | 33.5% | 81.0% | +0.000290 |
+| walk same-hop | 0.20 | 90.5% | 86.0% | 97.0% | +0.008174 |
+| heat | 0.10 | 48.0% | 42.0% | 82.0% | -0.000036 |
+| heat | 0.20 | 94.5% | 93.5% | 97.5% | +0.008939 |
+| resolvent | 0.10 | 45.5% | 43.0% | 78.0% | +0.000143 |
+| resolvent | 0.20 | 93.0% | 92.0% | 98.5% | +0.009957 |
+
+The v2 block-null nonzero rate was 5.5%.  All frozen `rho_max=0.20` gates passed.  The mixed 0.10 rows are the
+most relevant warning for real data: accurate weak covariance can help in oracle sensitivity curves while a
+finite-sample selector still fails to exploit it reliably.
+
+Neither synthetic result is end-to-end power.  Both assume known zero mean, known scalar channel covariance,
+one fixed 12-node topology, and many independent residual fields.
+
+## Outcome-blind campaign geometry inventory
+
+No judge score or residual entered this inventory.  Campaign rows supplied endpoint identities only.
+
+| corpus | rows | within-descendant row pairs | direct-adjacent pairs |
+|---|---:|---:|---:|
+| exploratory | 1,000 | 764 | 84 |
+| fresh | 770 | 777 | 206 |
+
+### Distance rank correlations
+
+| pair | exploratory | fresh |
+|---|---:|---:|
+| Nomic vs shared e5 | 0.776 | 0.838 |
+| MiniLM vs shared e5 | 0.810 | 0.868 |
+| MiniLM vs Nomic | 0.894 | 0.907 |
+| closed graph vs Nomic | 0.481 | 0.396 |
+| cumulative walk vs Nomic | 0.590 | 0.493 |
+| closed graph vs cumulative walk | 0.730 | 0.885 |
+
+Thus Nomic is more independent of e5 than MiniLM, but neither is an independent vote.  Graph geometry remains
+the more distinct channel.  Cumulative walk makes adjacent roots closer (`0.857` vs `0.996` exploratory;
+`0.770` vs `0.982` fresh), while the rejected same-hop walk did not.
+
+The strongest disagreement quartiles between cumulative walk and Nomic contain only 13 exploratory and 22
+fresh row-pairs (1.7% / 2.8%).  Existing data are too thin for a graph-by-embedding interaction claim.  A new
+campaign must deliberately oversample those cells.
+
+## Alternatives rejected or deferred
+
+| alternative | disposition | reason / reconsideration condition |
+|---|---|---|
+| shortest-path Gaussian covariance | reject as direct kernel | not PSD on an arbitrary graph; retain distance for sampling unless negative type is proved |
+| ordinary PPR/random-walk matrix | reject | asymmetric on irregular graphs; use a feature Gram or symmetric resolvent |
+| concatenated same-hop walk as adjacency model | reject as primary | topology inventory showed near-identity and wrong adjacency ordering; retain as negative control |
+| e5 as primary semantic geometry | reject | shared input to current mu readouts; retain as redundancy control |
+| observed same-judge mu distance | reject | endogenous: the same noise enters geometry and residual |
+| cross-fitted mu-hat distance | defer diagnostic | valid conditional covariate only with component-disjoint, preferably leave-one-judge-out construction |
+| Nomic and MiniLM as independent votes | reject | their distance ranks correlate 0.89--0.91 |
+| separate closed/heat/resolvent/cumulative selector votes | reject on current topology | nearly equivalent kernels inflate search multiplicity; reopen only if outcome-blind correlation drops on another graph |
+| effective-resistance RBF | defer | mathematically promising but needs disconnected-component and global-solve infrastructure |
+| unconstrained dense learned kernel | reject | low-sample overfit and PSD/identification risk |
+| graph x embedding Schur product | defer secondary | PSD but can erase graph-local signal when the embedder misses domain-specific proximity |
+| full-graph eigendecomposition/CUDA now | defer | statistical covariance is not validated yet |
+| lower deployment confidence | reject | changes accepted error rate rather than adding information |
+
+The append-only rationale and reconsideration conditions are in `DECISIONS_graph_geometry.md`.
+
+## Next confirmatory campaign
+
+1. Sample more than 400 independent endpoint components; use a full-procedure simulation to set the final count.
+2. Within components, balance anchor, direct/local positive, and matched distant/hard-negative triples.
+3. Obtain at least three independent calls per judge family and retain call identity.
+4. Oversample graph/Nomic disagreement cells rather than relying on their 1.7--2.8% natural frequency.
+5. Primary covariance candidates: block, closed-neighborhood, cumulative-walk, Nomic, and one nonnegative
+   graph-plus-Nomic mixture.  MiniLM and e5 are sensitivity/redundancy controls, not extra selector votes.
+6. Refit calibration, regional mean, marginal/channel covariance, geometry, and amplitude inside whole-component
+   outer folds.
+7. Gate on held joint residual NLL, posterior NLL/calibration/coverage, decision log-loss, margin AURC, topology
+   derangement, loading, and the 95% simultaneous spectral envelope.
+8. Only after those gates pass, compare dense QR with the single-kernel eigenmode conditioner and matched CUDA
+   timing at `n=128,m=32`.
+
+## Reproduction
+
+```bash
+python3 prototypes/mu_cosine/run_graph_geometry_synthetic.py \
+  --out /tmp/graph_geometry_synthetic_final_v1_portable.json
+
+python3 prototypes/mu_cosine/run_graph_geometry_synthetic_v2.py \
+  --out /tmp/graph_geometry_synthetic_final_v2_portable.json
+
+python3 prototypes/mu_cosine/independent_embedding_cache.py \
+  --pairs-tsv /tmp/mu_data/campaign_scored.tsv --preset minilm \
+  --out-prefix /tmp/campaign_minilm_geometry --device cpu
+
+python3 prototypes/mu_cosine/independent_embedding_cache.py \
+  --pairs-tsv /tmp/mu_data/campaign_scored.tsv --preset nomic \
+  --out-prefix /tmp/campaign_nomic_geometry --device cpu
+
+python3 prototypes/mu_cosine/run_graph_geometry_inventory.py \
+  --artifact-repo /home/s243a/Projects/UnifyWeaver \
+  --campaign /tmp/mu_data/campaign_scored.tsv \
+  --minilm-prefix /tmp/campaign_minilm_geometry \
+  --nomic-prefix /tmp/campaign_nomic_geometry --lmdb-no-lock \
+  --out /tmp/graph_geometry_inventory_cumulative_final.json
+```
+
+Portable output SHA-256:
+
+- v1 mechanism: `9cd6c0b6f6e7b4efdbf6e8afcff88607b871348fc3a8c212c421a8c8e5d2ee51`;
+- v2 mechanism: `24333d08941ac2c356bb33fdd602a0009317de0daa6d0f7788e176c6bcc33969`;
+- outcome-blind inventory: `81c35eaa8f9fa82afbbcf6a9040f4905f97140b4b91d7134ecfb69957b9fb9a1`.
+
+The graph-geometry focused suite has 34 passing tests.  Including the inherited adjacent-residual,
+structured-covariance, covariance-sensitivity, and NumPy/Torch square-root-conditioner suites gives
+`157 passed, 9 skipped`.

--- a/prototypes/mu_cosine/graph_geometry.py
+++ b/prototypes/mu_cosine/graph_geometry.py
@@ -1,0 +1,375 @@
+"""PSD-safe item geometries for conditional residual covariance experiments.
+
+The public constructors return float64, symmetric, unit-diagonal Gram matrices.
+Exact spectral kernels are small-graph references.  ``walk_feature_kernel`` is
+the scalable family: its explicit feature map makes positive semidefiniteness
+structural rather than a post-hoc eigenvalue repair.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import math
+
+import numpy as np
+from scipy import sparse
+
+
+PSD_TOLERANCE = 1e-10
+
+
+def _stable_key(value):
+    return type(value).__name__, repr(value)
+
+
+def _positive_finite(name, value):
+    value = float(value)
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be positive and finite")
+    return value
+
+
+def _kernel(name, value, *, unit_diagonal=True):
+    value = np.asarray(value, dtype=float)
+    if value.ndim != 2 or value.shape[0] != value.shape[1] or not np.isfinite(value).all():
+        raise ValueError(f"{name} must be a finite square matrix")
+    if not np.allclose(value, value.T, atol=PSD_TOLERANCE, rtol=0.0):
+        raise ValueError(f"{name} must be symmetric")
+    value = 0.5 * (value + value.T)
+    if unit_diagonal and not np.allclose(
+        np.diag(value), 1.0, atol=PSD_TOLERANCE, rtol=0.0
+    ):
+        raise ValueError(f"{name} must have unit diagonal")
+    minimum = float(np.min(np.linalg.eigvalsh(value))) if len(value) else 0.0
+    if minimum < -PSD_TOLERANCE:
+        raise ValueError(f"{name} is not positive semidefinite: min eigenvalue {minimum:.3e}")
+    return value
+
+
+def normalize_psd_kernel(value):
+    """Normalize a PSD matrix to unit diagonal without repairing indefiniteness."""
+    value = _kernel("value", value, unit_diagonal=False)
+    diagonal = np.diag(value)
+    if np.any(diagonal <= 0.0):
+        raise ValueError("a normalizable kernel must have a strictly positive diagonal")
+    scale = np.sqrt(diagonal)
+    normalized = value / scale[:, None] / scale[None, :]
+    normalized = 0.5 * (normalized + normalized.T)
+    np.fill_diagonal(normalized, 1.0)
+    return _kernel("normalized kernel", normalized)
+
+
+def _fixed_node_graph(nodes, neighbors):
+    nodes = tuple(nodes)
+    if len(set(nodes)) != len(nodes):
+        raise ValueError("nodes must be unique")
+    index = {node: row for row, node in enumerate(nodes)}
+    adjacency = np.zeros((len(nodes), len(nodes)), dtype=float)
+    for left in nodes:
+        i = index[left]
+        for right in neighbors.get(left, ()):
+            j = index.get(right)
+            if j is not None and i != j:
+                adjacency[i, j] = 1.0
+                adjacency[j, i] = 1.0
+    return nodes, adjacency
+
+
+def symmetric_normalized_laplacian(nodes, neighbors):
+    """Return the normalized Laplacian on one fixed outcome-blind node universe."""
+    nodes, adjacency = _fixed_node_graph(nodes, neighbors)
+    degree = adjacency.sum(axis=1)
+    inverse_root = np.zeros_like(degree)
+    active = degree > 0.0
+    inverse_root[active] = 1.0 / np.sqrt(degree[active])
+    normalized_adjacency = inverse_root[:, None] * adjacency * inverse_root[None, :]
+    laplacian = -normalized_adjacency
+    laplacian[np.diag_indices_from(laplacian)] = active.astype(float)
+    laplacian = 0.5 * (laplacian + laplacian.T)
+    eigenvalues = np.linalg.eigvalsh(laplacian)
+    if np.min(eigenvalues) < -PSD_TOLERANCE or np.max(eigenvalues) > 2.0 + PSD_TOLERANCE:
+        raise ValueError("normalized Laplacian spectrum must lie in [0,2]")
+    return nodes, laplacian
+
+
+def heat_kernel_reference(nodes, neighbors, *, diffusion_time):
+    """Exact ``exp(-t L)`` reference on a fixed, small graph domain.
+
+    Do not rebuild the node domain per measurement batch: that would make the
+    geometry depend on batching.  Large graphs should use walk features.
+    """
+    diffusion_time = _positive_finite("diffusion_time", diffusion_time)
+    nodes, laplacian = symmetric_normalized_laplacian(nodes, neighbors)
+    eigenvalues, eigenvectors = np.linalg.eigh(laplacian)
+    value = (eigenvectors * np.exp(-diffusion_time * eigenvalues)) @ eigenvectors.T
+    return nodes, normalize_psd_kernel(value)
+
+
+def resolvent_kernel_reference(nodes, neighbors, *, scale):
+    """Exact ``(I + scale L)^-1`` reference on a fixed, small graph domain."""
+    scale = _positive_finite("scale", scale)
+    nodes, laplacian = symmetric_normalized_laplacian(nodes, neighbors)
+    value = np.linalg.solve(np.eye(len(nodes)) + scale * laplacian, np.eye(len(nodes)))
+    return nodes, normalize_psd_kernel(value)
+
+
+def _walk_basis(query_nodes, neighbors, maximum_hop):
+    query_nodes = tuple(query_nodes)
+    if len(set(query_nodes)) != len(query_nodes):
+        raise ValueError("query_nodes must be unique")
+    if not query_nodes:
+        raise ValueError("query_nodes must be non-empty")
+    reached = set(query_nodes)
+    frontier = set(query_nodes)
+    for _ in range(maximum_hop):
+        frontier = {
+            neighbor
+            for node in frontier
+            for neighbor in neighbors.get(node, ())
+            if neighbor not in reached
+        }
+        reached.update(frontier)
+    return tuple(sorted(reached, key=_stable_key))
+
+
+def _walk_distributions(query_nodes, neighbors, hop_weights):
+    weights = np.asarray(hop_weights, dtype=float)
+    if weights.ndim != 1 or not len(weights) or not np.isfinite(weights).all():
+        raise ValueError("hop_weights must be a non-empty finite vector")
+    if np.any(weights < 0.0) or not np.any(weights > 0.0):
+        raise ValueError("hop_weights must be nonnegative with at least one positive entry")
+    query_nodes = tuple(query_nodes)
+    basis = _walk_basis(query_nodes, neighbors, len(weights) - 1)
+    index = {node: row for row, node in enumerate(basis)}
+    row_indices, column_indices, values = [], [], []
+    for node in basis:
+        i = index[node]
+        adjacent = tuple(neighbors.get(node, ()))
+        if not adjacent:
+            row_indices.append(i)
+            column_indices.append(i)
+            values.append(1.0)
+            continue
+        retained = [index[value] for value in adjacent if value in index]
+        row_indices.extend([i] * len(retained))
+        column_indices.extend(retained)
+        values.extend([1.0 / len(adjacent)] * len(retained))
+    transition = sparse.csr_matrix(
+        (values, (row_indices, column_indices)),
+        shape=(len(basis), len(basis)),
+        dtype=float,
+    )
+    distribution = sparse.csr_matrix(
+        (
+            np.ones(len(query_nodes), dtype=float),
+            (np.arange(len(query_nodes)), [index[node] for node in query_nodes]),
+        ),
+        shape=(len(query_nodes), len(basis)),
+    )
+    distributions = []
+    for hop in range(len(weights)):
+        distributions.append(distribution)
+        if hop + 1 < len(weights):
+            distribution = distribution @ transition
+    return query_nodes, basis, weights, distributions
+
+
+def walk_feature_map(query_nodes, neighbors, hop_weights):
+    """Explicit finite-hop random-walk features with nonnegative hop weights.
+
+    This materializes the feature matrix and is intended for inspection/tests.
+    ``walk_feature_kernel`` accumulates sparse feature Grams directly at scale.
+    """
+    query_nodes, basis, weights, distributions = _walk_distributions(
+        query_nodes, neighbors, hop_weights
+    )
+    blocks = [
+        np.sqrt(weight) * distribution.toarray()
+        for weight, distribution in zip(weights, distributions)
+        if weight > 0.0
+    ]
+    features = np.concatenate(blocks, axis=1)
+    if not np.isfinite(features).all() or np.any(np.linalg.norm(features, axis=1) == 0.0):
+        raise ValueError("walk features must be finite and nonzero")
+    return features, basis
+
+
+def walk_feature_kernel(query_nodes, neighbors, hop_weights):
+    query_nodes, basis, weights, distributions = _walk_distributions(
+        query_nodes, neighbors, hop_weights
+    )
+    gram = np.zeros((len(query_nodes), len(query_nodes)), dtype=float)
+    for weight, distribution in zip(weights, distributions):
+        if weight > 0.0:
+            gram += weight * (distribution @ distribution.T).toarray()
+    return query_nodes, normalize_psd_kernel(gram), basis
+
+
+def cumulative_walk_feature_map(query_nodes, neighbors, hop_weights):
+    """Cross-hop diffusion features ``sum_h sqrt(w_h) p_h``."""
+    query_nodes, basis, weights, distributions = _walk_distributions(
+        query_nodes, neighbors, hop_weights
+    )
+    features = sparse.csr_matrix(distributions[0].shape, dtype=float)
+    for weight, distribution in zip(weights, distributions):
+        if weight > 0.0:
+            features = features + np.sqrt(weight) * distribution
+    return features, basis
+
+
+def cumulative_walk_feature_kernel(query_nodes, neighbors, hop_weights):
+    """PSD cumulative-walk Gram; unlike separate hop blocks, includes cross-hop overlap."""
+    features, basis = cumulative_walk_feature_map(query_nodes, neighbors, hop_weights)
+    gram = (features @ features.T).toarray()
+    return tuple(query_nodes), normalize_psd_kernel(gram), basis
+
+
+def closed_neighborhood_kernel(query_nodes, neighbors):
+    """Binary closed-neighborhood cosine Gram used by the merged pilot."""
+    query_nodes = tuple(query_nodes)
+    if len(set(query_nodes)) != len(query_nodes) or not query_nodes:
+        raise ValueError("query_nodes must be non-empty and unique")
+    basis = tuple(sorted(
+        set(query_nodes).union(*(
+            set(neighbors.get(node, ())) for node in query_nodes
+        )),
+        key=_stable_key,
+    ))
+    index = {node: column for column, node in enumerate(basis)}
+    features = np.zeros((len(query_nodes), len(basis)), dtype=float)
+    for row, node in enumerate(query_nodes):
+        for member in (node, *neighbors.get(node, ())):
+            features[row, index[member]] = 1.0
+    return query_nodes, normalize_psd_kernel(features @ features.T), basis
+
+
+def descendant_gated_item_kernel(pairs, root_nodes, root_kernel):
+    """Lift a root kernel to pair items and gate it by equal descendant/left role."""
+    pairs = tuple(pairs)
+    root_nodes = tuple(root_nodes)
+    root_kernel = _kernel("root_kernel", root_kernel)
+    if root_kernel.shape != (len(root_nodes), len(root_nodes)):
+        raise ValueError("root_kernel must align with root_nodes")
+    index = {node: row for row, node in enumerate(root_nodes)}
+    try:
+        roots = np.asarray([index[root] for _left, root in pairs], dtype=int)
+    except KeyError as exc:
+        raise ValueError(f"pair root absent from root_nodes: {exc.args[0]!r}") from exc
+    lifted = root_kernel[np.ix_(roots, roots)]
+    left = [pair[0] for pair in pairs]
+    gate = np.equal.outer(left, left).astype(float)
+    return _kernel("descendant-gated item kernel", lifted * gate)
+
+
+def role_aware_pair_features(pairs, node_embeddings):
+    """Normalized ``concat(left_embedding, root_embedding)`` item features."""
+    pairs = tuple(pairs)
+    if not pairs:
+        raise ValueError("pairs must be non-empty")
+    rows = []
+    dimension = None
+    for left, root in pairs:
+        try:
+            left_vector = np.asarray(node_embeddings[left], dtype=float)
+            root_vector = np.asarray(node_embeddings[root], dtype=float)
+        except KeyError as exc:
+            raise ValueError(f"pair node absent from embeddings: {exc.args[0]!r}") from exc
+        if left_vector.ndim != 1 or root_vector.shape != left_vector.shape:
+            raise ValueError("every node embedding must be a same-width vector")
+        dimension = len(left_vector) if dimension is None else dimension
+        if len(left_vector) != dimension:
+            raise ValueError("every node embedding must have the same width")
+        rows.append(np.concatenate((left_vector, root_vector)))
+    features = np.asarray(rows, dtype=float)
+    norms = np.linalg.norm(features, axis=1, keepdims=True)
+    if not np.isfinite(features).all() or np.any(norms <= 0.0):
+        raise ValueError("pair features must be finite and nonzero")
+    return features / norms
+
+
+def median_pairwise_distance(features):
+    features = np.asarray(features, dtype=float)
+    if features.ndim != 2 or len(features) < 2 or not np.isfinite(features).all():
+        raise ValueError("features must be a finite matrix with at least two rows")
+    squared = np.maximum(
+        np.sum(features * features, axis=1)[:, None]
+        + np.sum(features * features, axis=1)[None, :]
+        - 2.0 * features @ features.T,
+        0.0,
+    )
+    values = np.sqrt(squared[np.triu_indices(len(features), 1)])
+    positive = values[values > np.finfo(float).eps]
+    if not len(positive):
+        raise ValueError("median distance is undefined for identical features")
+    return float(np.median(positive))
+
+
+def embedding_item_kernel(pairs, node_embeddings, *, length_scale, gate_descendant=True):
+    """Role-aware Euclidean RBF, optionally Schur-gated by equal descendants."""
+    length_scale = _positive_finite("length_scale", length_scale)
+    pairs = tuple(pairs)
+    features = role_aware_pair_features(pairs, node_embeddings)
+    norm = np.sum(features * features, axis=1)
+    squared = np.maximum(norm[:, None] + norm[None, :] - 2.0 * features @ features.T, 0.0)
+    value = np.exp(-0.5 * squared / (length_scale * length_scale))
+    if gate_descendant:
+        left = [pair[0] for pair in pairs]
+        value *= np.equal.outer(left, left)
+    np.fill_diagonal(value, 1.0)
+    return _kernel("embedding item kernel", value)
+
+
+def convex_kernel_mixture(kernels, weights):
+    """Nonnegative normalized sum of unit-diagonal PSD kernels."""
+    kernels = tuple(_kernel(f"kernels[{i}]", value) for i, value in enumerate(kernels))
+    weights = np.asarray(weights, dtype=float)
+    if not kernels or weights.shape != (len(kernels),) or not np.isfinite(weights).all():
+        raise ValueError("weights must be a finite vector aligned with non-empty kernels")
+    if np.any(weights < 0.0) or np.sum(weights) <= 0.0:
+        raise ValueError("mixture weights must be nonnegative with positive sum")
+    if any(value.shape != kernels[0].shape for value in kernels):
+        raise ValueError("all kernels must have the same shape")
+    weights = weights / np.sum(weights)
+    value = sum(weight * kernel for weight, kernel in zip(weights, kernels))
+    return _kernel("convex kernel mixture", value)
+
+
+def schur_kernel_product(kernels):
+    """Unit-diagonal Schur product of aligned PSD kernels."""
+    kernels = tuple(_kernel(f"kernels[{i}]", value) for i, value in enumerate(kernels))
+    if not kernels or any(value.shape != kernels[0].shape for value in kernels):
+        raise ValueError("aligned non-empty kernels are required")
+    value = np.ones_like(kernels[0])
+    for kernel in kernels:
+        value *= kernel
+    return _kernel("Schur kernel product", value)
+
+
+@dataclass(frozen=True)
+class KernelDiagnostics:
+    minimum_eigenvalue: float
+    maximum_eigenvalue: float
+    rank: int
+    positive_spectrum_condition_number: float
+    effective_rank: float
+    off_diagonal_rms: float
+    sha256: str
+
+
+def kernel_diagnostics(value):
+    value = _kernel("value", value)
+    eigenvalues = np.linalg.eigvalsh(value)
+    positive = eigenvalues[eigenvalues > np.finfo(float).eps]
+    condition = float(np.max(positive) / np.min(positive)) if len(positive) else math.inf
+    total = float(np.sum(eigenvalues))
+    effective_rank = float(total * total / np.sum(eigenvalues * eigenvalues)) if total else 0.0
+    off = value - np.eye(len(value))
+    return KernelDiagnostics(
+        float(np.min(eigenvalues)),
+        float(np.max(eigenvalues)),
+        int(len(positive)),
+        condition,
+        effective_rank,
+        float(np.sqrt(np.mean(off * off))),
+        hashlib.sha256(np.ascontiguousarray(value).tobytes()).hexdigest(),
+    )

--- a/prototypes/mu_cosine/independent_embedding_cache.py
+++ b/prototypes/mu_cosine/independent_embedding_cache.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Build and validate frozen, revision-pinned node embedding caches.
+
+Evaluation code only consumes the three deterministic files written under an
+output prefix.  Model loading is confined to the CLI and defaults to
+``local_files_only=True`` so tests and covariance evaluation never download.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class EmbeddingModelSpec:
+    model_id: str
+    revision: str
+    task_prefix: str
+    dimension: int
+    trust_remote_code: bool
+    text_transform: str = "underscores_to_spaces"
+    normalization: str = "l2"
+
+
+MODEL_SPECS = {
+    "minilm": EmbeddingModelSpec(
+        "sentence-transformers/all-MiniLM-L6-v2",
+        "c9745ed1d9f207416be6d2e6f8de32d1f16199bf",
+        "",
+        384,
+        False,
+    ),
+    "nomic": EmbeddingModelSpec(
+        "nomic-ai/nomic-embed-text-v1.5",
+        "e9b6763023c676ca8431644204f50c2b100d9aab",
+        "clustering: ",
+        768,
+        True,
+    ),
+}
+
+
+def _sha256_bytes(value):
+    return hashlib.sha256(value).hexdigest()
+
+
+def _content_record(value):
+    return {"size_bytes": len(value), "sha256": _sha256_bytes(value)}
+
+
+def canonical_names(names):
+    """Stable unique title order; empty titles and normalization collisions fail."""
+    names = [str(value) for value in names]
+    if any(not value.strip() for value in names):
+        raise ValueError("node names must be non-empty")
+    if len(set(names)) != len(names):
+        raise ValueError("node names must be unique")
+    return tuple(sorted(names))
+
+
+def embedding_texts(names, spec):
+    names = canonical_names(names)
+    if spec.text_transform != "underscores_to_spaces":
+        raise ValueError(f"unsupported text transform: {spec.text_transform}")
+    return tuple(spec.task_prefix + value.replace("_", " ") for value in names)
+
+
+def validate_embeddings(names, embeddings, spec):
+    names = tuple(names)
+    embeddings = np.asarray(embeddings, dtype=np.float32)
+    if embeddings.shape != (len(names), spec.dimension):
+        raise ValueError(
+            f"embedding shape {embeddings.shape} does not match "
+            f"({len(names)}, {spec.dimension})"
+        )
+    if not np.isfinite(embeddings).all():
+        raise ValueError("embeddings must be finite")
+    norms = np.linalg.norm(embeddings.astype(np.float64), axis=1)
+    if np.any(norms <= 0.0):
+        raise ValueError("embeddings must be nonzero")
+    normalized = embeddings / norms[:, None].astype(np.float32)
+    if not np.allclose(norms, 1.0, atol=2e-5, rtol=2e-5):
+        raise ValueError("cache contract requires L2-normalized embeddings")
+    return np.ascontiguousarray(normalized, dtype=np.float32)
+
+
+def encode_with_model(names, spec, model, *, batch_size=256):
+    """Encode canonical node titles using an injected SentenceTransformer-like model."""
+    names = canonical_names(names)
+    texts = embedding_texts(names, spec)
+    embeddings = model.encode(
+        list(texts),
+        batch_size=int(batch_size),
+        convert_to_numpy=True,
+        normalize_embeddings=True,
+        show_progress_bar=False,
+    )
+    return names, texts, validate_embeddings(names, embeddings, spec)
+
+
+def _npy_bytes(value):
+    stream = io.BytesIO()
+    np.save(stream, value, allow_pickle=False)
+    return stream.getvalue()
+
+
+def _atomic_write(path, value):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    with open(temporary, "wb") as stream:
+        stream.write(value)
+    os.replace(temporary, path)
+
+
+def cache_paths(prefix):
+    prefix = Path(prefix)
+    return {
+        "nodes": Path(str(prefix) + ".nodes.json"),
+        "embeddings": Path(str(prefix) + ".embeddings.npy"),
+        "manifest": Path(str(prefix) + ".manifest.json"),
+    }
+
+
+def write_embedding_cache(prefix, names, embeddings, spec, *, package_versions=None):
+    """Write a deterministic three-file cache and return its portable manifest."""
+    names = tuple(names)
+    if canonical_names(names) != names:
+        raise ValueError("names must already be canonical and sorted before writing")
+    embeddings = validate_embeddings(names, embeddings, spec)
+    texts = embedding_texts(names, spec)
+    nodes_bytes = (
+        json.dumps(list(names), ensure_ascii=False, indent=2, separators=(",", ": ")) + "\n"
+    ).encode("utf-8")
+    embeddings_bytes = _npy_bytes(embeddings)
+    text_bytes = (json.dumps(list(texts), ensure_ascii=False, separators=(",", ":")) + "\n").encode(
+        "utf-8"
+    )
+    manifest = {
+        "schema_version": 1,
+        "model": asdict(spec),
+        "node_count": len(names),
+        "array": {"shape": list(embeddings.shape), "dtype": str(embeddings.dtype)},
+        "input_text_sha256": _sha256_bytes(text_bytes),
+        "artifacts": {
+            "nodes": _content_record(nodes_bytes),
+            "embeddings": _content_record(embeddings_bytes),
+        },
+        "package_versions": dict(sorted((package_versions or {}).items())),
+    }
+    manifest_bytes = (
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode("utf-8")
+    paths = cache_paths(prefix)
+    _atomic_write(paths["nodes"], nodes_bytes)
+    _atomic_write(paths["embeddings"], embeddings_bytes)
+    _atomic_write(paths["manifest"], manifest_bytes)
+    return manifest, _content_record(manifest_bytes)
+
+
+@dataclass(frozen=True)
+class EmbeddingCache:
+    names: tuple
+    embeddings: np.ndarray
+    metadata: dict
+    manifest_sha256: str
+
+    def by_name(self):
+        return {name: self.embeddings[row] for row, name in enumerate(self.names)}
+
+
+def load_embedding_cache(prefix, *, expected_spec=None, required_names=()):
+    paths = cache_paths(prefix)
+    raw = {name: path.read_bytes() for name, path in paths.items()}
+    manifest = json.loads(raw["manifest"].decode("utf-8"))
+    if manifest.get("schema_version") != 1:
+        raise ValueError("unsupported embedding-cache schema")
+    for role in ("nodes", "embeddings"):
+        if manifest["artifacts"][role] != _content_record(raw[role]):
+            raise ValueError(f"{role} content hash/size does not match the manifest")
+    names = tuple(json.loads(raw["nodes"].decode("utf-8")))
+    if canonical_names(names) != names:
+        raise ValueError("cached names must be canonical, unique, and sorted")
+    spec = EmbeddingModelSpec(**manifest["model"])
+    if expected_spec is not None and spec != expected_spec:
+        raise ValueError("embedding model specification does not match the required frozen spec")
+    text_bytes = (
+        json.dumps(
+            list(embedding_texts(names, spec)),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ) + "\n"
+    ).encode("utf-8")
+    if manifest.get("input_text_sha256") != _sha256_bytes(text_bytes):
+        raise ValueError("input text hash does not match names and the frozen text contract")
+    embeddings = np.load(io.BytesIO(raw["embeddings"]), allow_pickle=False)
+    embeddings = validate_embeddings(names, embeddings, spec)
+    if manifest["array"] != {"shape": list(embeddings.shape), "dtype": str(embeddings.dtype)}:
+        raise ValueError("embedding array metadata does not match its content")
+    missing = sorted(set(required_names) - set(names))
+    if missing:
+        raise ValueError(f"embedding cache misses {len(missing)} required nodes; first={missing[0]!r}")
+    return EmbeddingCache(
+        names,
+        embeddings,
+        manifest,
+        _sha256_bytes(raw["manifest"]),
+    )
+
+
+def _read_nodes(path):
+    with open(path, encoding="utf-8") as stream:
+        return canonical_names(line.rstrip("\n") for line in stream if line.strip())
+
+
+def read_pair_nodes(path):
+    """Canonical endpoint titles from the first two columns of a TSV campaign."""
+    nodes = set()
+    with open(path, encoding="utf-8") as stream:
+        for line_number, line in enumerate(stream, 1):
+            if not line.strip() or line.startswith("#"):
+                continue
+            columns = line.rstrip("\n").split("\t")
+            if len(columns) < 2 or not columns[0] or not columns[1]:
+                raise ValueError(f"malformed pair row at line {line_number}")
+            nodes.update(columns[:2])
+    if not nodes:
+        raise ValueError("pair TSV contains no data rows")
+    return canonical_names(nodes)
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--nodes", help="one exact node title per line")
+    source.add_argument("--pairs-tsv", help="campaign TSV; first two columns are endpoint titles")
+    parser.add_argument("--preset", choices=sorted(MODEL_SPECS), required=True)
+    parser.add_argument("--out-prefix", required=True)
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--device", default=None)
+    parser.add_argument(
+        "--allow-download",
+        action="store_true",
+        help="allow model retrieval; default evaluation contract is local cache only",
+    )
+    return parser
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    if args.batch_size < 1:
+        raise ValueError("batch-size must be positive")
+    from sentence_transformers import SentenceTransformer, __version__ as sentence_transformers_version
+    import transformers
+
+    spec = MODEL_SPECS[args.preset]
+    model = SentenceTransformer(
+        spec.model_id,
+        revision=spec.revision,
+        trust_remote_code=spec.trust_remote_code,
+        local_files_only=not args.allow_download,
+        device=args.device,
+    )
+    input_names = _read_nodes(args.nodes) if args.nodes else read_pair_nodes(args.pairs_tsv)
+    names, _texts, embeddings = encode_with_model(
+        input_names, spec, model, batch_size=args.batch_size
+    )
+    manifest, manifest_record = write_embedding_cache(
+        args.out_prefix,
+        names,
+        embeddings,
+        spec,
+        package_versions={
+            "sentence_transformers": sentence_transformers_version,
+            "transformers": transformers.__version__,
+            "numpy": np.__version__,
+        },
+    )
+    print(json.dumps({
+        "model": manifest["model"],
+        "node_count": manifest["node_count"],
+        "manifest_sha256": manifest_record["sha256"],
+        "out_prefix": os.path.abspath(args.out_prefix),
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/repro/graph_geometry/summary.json
+++ b/prototypes/mu_cosine/repro/graph_geometry/summary.json
@@ -1,0 +1,76 @@
+{
+  "status": "PSD geometry infrastructure complete; matched synthetic strong-effect gates pass; no real covariance or QR deployment",
+  "design": "DESIGN_graph_geometry_confirmatory.md",
+  "synthetic_v2_design": "DESIGN_graph_geometry_synthetic_v2.md",
+  "decision_log": "DECISIONS_graph_geometry.md",
+  "deployment": {
+    "real_covariance_gate_unlocked": false,
+    "batching_gate_unlocked": false,
+    "qr_deployment_unlocked": false,
+    "deployment_confidence_level": 0.95
+  },
+  "kernel_decisions": {
+    "fixed_baseline": "closed_neighborhood",
+    "primary_scalable": "cumulative_walk_feature_gram",
+    "same_hop_walk": "negative_control",
+    "small_graph_references": ["heat", "regularized_laplacian"],
+    "primary_external_embedding": "nomic",
+    "embedding_sensitivity_control": "minilm",
+    "shared_input_control": "e5"
+  },
+  "synthetic_v1": {
+    "formal_result": "failed",
+    "failure": "common path amplitude did not match off-diagonal covariance strength across kernels",
+    "block_null_nonzero_selection_rate": 0.06,
+    "all_frozen_gates_pass": false
+  },
+  "synthetic_v2": {
+    "formal_result": "matched-coupling rho=0.20 mechanism gates pass",
+    "train_fields": 48,
+    "held_fields": 64,
+    "replicates": 200,
+    "calibration_draws": 1000,
+    "block_null_nonzero_selection_rate": 0.055,
+    "rho_0_20": {
+      "closed": {"equivalence_selection_rate": 0.975, "topology_win_rate": 0.985, "held_nll_gain": 0.014632400460997204},
+      "walk_same_hop": {"equivalence_selection_rate": 0.86, "topology_win_rate": 0.97, "held_nll_gain": 0.008174402254935698},
+      "heat": {"equivalence_selection_rate": 0.935, "topology_win_rate": 0.975, "held_nll_gain": 0.00893864885277062},
+      "resolvent": {"equivalence_selection_rate": 0.92, "topology_win_rate": 0.985, "held_nll_gain": 0.009956571832873436}
+    },
+    "all_frozen_gates_pass": true,
+    "rho_0_10_power_warning": "mixed selection power; heat selected held gain approximately zero"
+  },
+  "outcome_blind_inventory": {
+    "exploratory": {
+      "campaign_rows": 1000,
+      "within_descendant_pairs": 764,
+      "adjacent_pairs": 84,
+      "nomic_e5_distance_spearman": 0.7763558201992552,
+      "minilm_e5_distance_spearman": 0.8102888131572337,
+      "cumulative_walk_nomic_distance_spearman": 0.589502679406453,
+      "closed_cumulative_distance_spearman": 0.7298022116068588,
+      "cumulative_nomic_disagreement_pairs": 13
+    },
+    "fresh": {
+      "campaign_rows": 770,
+      "within_descendant_pairs": 777,
+      "adjacent_pairs": 206,
+      "nomic_e5_distance_spearman": 0.8376352100877055,
+      "minilm_e5_distance_spearman": 0.8676558120678654,
+      "cumulative_walk_nomic_distance_spearman": 0.4930419031166443,
+      "closed_cumulative_distance_spearman": 0.8845233288541023,
+      "cumulative_nomic_disagreement_pairs": 22
+    }
+  },
+  "embedding_manifests": {
+    "minilm_sha256": "35fc09608d16dc2b5111686f587a57d5f60895611465b109de6898e864758569",
+    "nomic_sha256": "702f5f4af33c8994d25ad259c6a46ac7f7c762f4d6ef2a47f4335f9bc912e3d2",
+    "unique_endpoint_titles": 2681
+  },
+  "full_output_sha256": {
+    "synthetic_v1": "9cd6c0b6f6e7b4efdbf6e8afcff88607b871348fc3a8c212c421a8c8e5d2ee51",
+    "synthetic_v2": "24333d08941ac2c356bb33fdd602a0009317de0daa6d0f7788e176c6bcc33969",
+    "outcome_blind_inventory": "81c35eaa8f9fa82afbbcf6a9040f4905f97140b4b91d7134ecfb69957b9fb9a1"
+  },
+  "recommended_next": "purpose-built repeated-judge campaign with more than 400 independent components, at least three calls per judge family, and deliberate graph/Nomic disagreement oversampling"
+}

--- a/prototypes/mu_cosine/run_graph_geometry_inventory.py
+++ b/prototypes/mu_cosine/run_graph_geometry_inventory.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Outcome-blind geometry redundancy/disagreement inventory on campaign rows.
+
+No residual, judge score, or covariance outcome is consumed.  The campaign TSV
+only supplies endpoint pairs and strata.  Results describe where graph,
+shared-e5, MiniLM, and Nomic geometries agree or disagree so a later repeated-
+judge campaign can sample informative cells.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import time
+
+import numpy as np
+from scipy.stats import rankdata
+
+from fine_tune_channel_heads import CAMPAIGN_E5_100K, load_campaign_datasets
+from graph_geometry import (
+    closed_neighborhood_kernel,
+    cumulative_walk_feature_kernel,
+    descendant_gated_item_kernel,
+    embedding_item_kernel,
+    median_pairwise_distance,
+    role_aware_pair_features,
+    walk_feature_kernel,
+)
+from independent_embedding_cache import MODEL_SPECS, load_embedding_cache
+from run_product_kalman_realdata import DATASETS
+from run_structured_residual_covariance import (
+    configure_artifact_repo,
+    semantic_pair_features,
+)
+
+
+def _content_record(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(chunk)
+    return {"size_bytes": os.path.getsize(path), "sha256": digest.hexdigest()}
+
+
+def _undirected_neighbors(parents):
+    output = {}
+    for child, values in parents.items():
+        output.setdefault(child, set()).update(values)
+        for parent in values:
+            output.setdefault(parent, set()).add(child)
+    return {node: frozenset(values) for node, values in output.items()}
+
+
+def _rbf_item_kernel(pairs, features):
+    bandwidth = median_pairwise_distance(features)
+    norm = np.sum(features * features, axis=1)
+    squared = np.maximum(norm[:, None] + norm[None, :] - 2.0 * features @ features.T, 0.0)
+    value = np.exp(-0.5 * squared / (bandwidth * bandwidth))
+    left = [pair[0] for pair in pairs]
+    value *= np.equal.outer(left, left)
+    np.fill_diagonal(value, 1.0)
+    return value, bandwidth
+
+
+def _pearson(left, right):
+    left, right = np.asarray(left, dtype=float), np.asarray(right, dtype=float)
+    if np.std(left) <= 1e-15 or np.std(right) <= 1e-15:
+        return None
+    return float(np.corrcoef(left, right)[0, 1])
+
+
+def _spearman(left, right):
+    return _pearson(rankdata(left, method="average"), rankdata(right, method="average"))
+
+
+def summarize_geometry_inventory(pairs, kernels, neighbors):
+    """Summarize within-descendant off-diagonal geometry without outcomes."""
+    pairs = tuple(pairs)
+    size = len(pairs)
+    if any(np.asarray(value).shape != (size, size) for value in kernels.values()):
+        raise ValueError("every kernel must align with pairs")
+    rows, columns = np.triu_indices(size, 1)
+    same_descendant = np.asarray([
+        pairs[left][0] == pairs[right][0] for left, right in zip(rows, columns)
+    ])
+    rows, columns = rows[same_descendant], columns[same_descendant]
+    if not len(rows):
+        raise ValueError("inventory requires within-descendant row pairs")
+    vectors = {
+        name: 1.0 - np.asarray(kernel, dtype=float)[rows, columns]
+        for name, kernel in kernels.items()
+    }
+    pearson = {
+        left: {right: _pearson(vectors[left], vectors[right]) for right in vectors}
+        for left in vectors
+    }
+    spearman = {
+        left: {right: _spearman(vectors[left], vectors[right]) for right in vectors}
+        for left in vectors
+    }
+    adjacent = np.asarray([
+        pairs[right][1] in neighbors.get(pairs[left][1], ())
+        or pairs[left][1] in neighbors.get(pairs[right][1], ())
+        for left, right in zip(rows, columns)
+    ])
+    by_adjacency = {}
+    for name, values in vectors.items():
+        by_adjacency[name] = {
+            "adjacent_mean_distance": float(np.mean(values[adjacent])) if np.any(adjacent) else None,
+            "nonadjacent_mean_distance": (
+                float(np.mean(values[~adjacent])) if np.any(~adjacent) else None
+            ),
+        }
+    disagreement = {}
+    graph_similarity = 1.0 - vectors["graph_walk_cumulative"]
+    for name in ("minilm", "nomic", "shared_e5"):
+        semantic_similarity = 1.0 - vectors[name]
+        graph_high = graph_similarity >= np.quantile(graph_similarity, 0.75)
+        graph_low = graph_similarity <= np.quantile(graph_similarity, 0.25)
+        semantic_high = semantic_similarity >= np.quantile(semantic_similarity, 0.75)
+        semantic_low = semantic_similarity <= np.quantile(semantic_similarity, 0.25)
+        disagreement[name] = {
+            "graph_high_semantic_low": int(np.sum(graph_high & semantic_low)),
+            "graph_low_semantic_high": int(np.sum(graph_low & semantic_high)),
+            "fraction": float(np.mean((graph_high & semantic_low) | (graph_low & semantic_high))),
+        }
+    return {
+        "within_descendant_row_pairs": int(len(rows)),
+        "directly_adjacent_root_pairs": int(np.sum(adjacent)),
+        "distance_pearson": pearson,
+        "distance_spearman": spearman,
+        "mean_distance_by_graph_adjacency": by_adjacency,
+        "graph_walk_quartile_disagreement": disagreement,
+    }
+
+
+def run_corpus(name, dataset, minilm, nomic):
+    corpus = name.replace("-campaign", "")
+    pairs = tuple(dataset["pairs"])
+    if len(pairs) != len(set(pairs)):
+        raise ValueError("geometry inventory requires unique campaign pairs")
+    required = {node for pair in pairs for node in pair}
+    minilm_missing = required - set(minilm.names)
+    nomic_missing = required - set(nomic.names)
+    if minilm_missing or nomic_missing:
+        raise ValueError("independent embedding caches do not cover every campaign endpoint")
+    neighbors = _undirected_neighbors(dataset["tok"].parents)
+    roots = tuple(sorted({root for _left, root in pairs}))
+    _, root_closed, _ = closed_neighborhood_kernel(roots, neighbors)
+    _, root_walk_same_hop, _ = walk_feature_kernel(
+        roots, neighbors, (1.0, 0.5, 0.25, 0.125)
+    )
+    _, root_walk_cumulative, _ = cumulative_walk_feature_kernel(
+        roots, neighbors, (1.0, 0.5, 0.25, 0.125)
+    )
+    graph_closed = descendant_gated_item_kernel(pairs, roots, root_closed)
+    graph_walk_same_hop = descendant_gated_item_kernel(
+        pairs, roots, root_walk_same_hop
+    )
+    graph_walk_cumulative = descendant_gated_item_kernel(
+        pairs, roots, root_walk_cumulative
+    )
+
+    minilm_map, nomic_map = minilm.by_name(), nomic.by_name()
+    minilm_features = role_aware_pair_features(pairs, minilm_map)
+    nomic_features = role_aware_pair_features(pairs, nomic_map)
+    e5_features = semantic_pair_features(dataset, pairs)
+    minilm_kernel = embedding_item_kernel(
+        pairs,
+        minilm_map,
+        length_scale=median_pairwise_distance(minilm_features),
+    )
+    nomic_kernel = embedding_item_kernel(
+        pairs,
+        nomic_map,
+        length_scale=median_pairwise_distance(nomic_features),
+    )
+    e5_kernel, e5_bandwidth = _rbf_item_kernel(pairs, e5_features)
+    inventory = summarize_geometry_inventory(
+        pairs,
+        {
+            "graph_closed": graph_closed,
+            "graph_walk_same_hop": graph_walk_same_hop,
+            "graph_walk_cumulative": graph_walk_cumulative,
+            "minilm": minilm_kernel,
+            "nomic": nomic_kernel,
+            "shared_e5": e5_kernel,
+        },
+        neighbors,
+    )
+    inventory.update({
+        "corpus": corpus,
+        "campaign_rows": len(pairs),
+        "unique_endpoints": len(required),
+        "unique_roots": len(roots),
+        "rbf_bandwidths": {
+            "minilm": median_pairwise_distance(minilm_features),
+            "nomic": median_pairwise_distance(nomic_features),
+            "shared_e5": e5_bandwidth,
+        },
+    })
+    return inventory
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-repo", required=True)
+    parser.add_argument("--campaign", default="/tmp/mu_data/campaign_scored.tsv")
+    parser.add_argument("--minilm-prefix", required=True)
+    parser.add_argument("--nomic-prefix", required=True)
+    parser.add_argument("--lmdb-no-lock", action="store_true")
+    parser.add_argument("--out", default="/tmp/graph_geometry_inventory.json")
+    return parser
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    started = time.perf_counter()
+    artifacts = configure_artifact_repo(args.artifact_repo)
+    if args.lmdb_no_lock:
+        DATASETS["fresh"]["graph"]["lmdb_no_lock"] = True
+    minilm = load_embedding_cache(args.minilm_prefix, expected_spec=MODEL_SPECS["minilm"])
+    nomic = load_embedding_cache(args.nomic_prefix, expected_spec=MODEL_SPECS["nomic"])
+    datasets = load_campaign_datasets(campaign_scored=args.campaign)
+    results = [
+        run_corpus(name, datasets[name], minilm, nomic)
+        for name in ("exploratory-campaign", "fresh-campaign")
+    ]
+    root = os.path.dirname(os.path.abspath(__file__))
+    payload = {
+        "schema_version": 1,
+        "status": "OUTCOME-BLIND GEOMETRY INVENTORY; NO RESIDUAL OR DEPLOYMENT CLAIM",
+        "design": "DESIGN_graph_geometry_confirmatory.md",
+        "implementation": {
+            "design": _content_record(os.path.join(root, "DESIGN_graph_geometry_confirmatory.md")),
+            "geometry": _content_record(os.path.join(root, "graph_geometry.py")),
+            "cache": _content_record(os.path.join(root, "independent_embedding_cache.py")),
+            "runner": _content_record(os.path.abspath(__file__)),
+            "campaign_loader": _content_record(os.path.join(root, "fine_tune_channel_heads.py")),
+            "graph_loader": _content_record(os.path.join(root, "run_product_kalman_realdata.py")),
+            "pair_features": _content_record(
+                os.path.join(root, "run_structured_residual_covariance.py")
+            ),
+        },
+        "inputs": {
+            "campaign": _content_record(args.campaign),
+            "minilm_manifest_sha256": minilm.manifest_sha256,
+            "nomic_manifest_sha256": nomic.manifest_sha256,
+            "exploratory_e5": _content_record(CAMPAIGN_E5_100K),
+            "fresh_e5": _content_record(DATASETS["fresh"]["e5_cache"]),
+            "graph_artifacts": {
+                "exploratory_graph": {
+                    key: artifacts["exploratory_graph"][key] for key in ("size_bytes", "sha256")
+                },
+                "fresh_lmdb_data": {
+                    key: artifacts["fresh_lmdb_data"][key] for key in ("size_bytes", "sha256")
+                },
+                "fresh_lmdb_lock_excluded": artifacts["fresh_lmdb_lock_excluded"],
+            },
+        },
+        "configuration": {"lmdb_no_lock": bool(args.lmdb_no_lock)},
+        "results": results,
+        "deployment_gate_unlocked": False,
+        "reason": "geometry redundancy and disagreement use no repeated residual fields",
+    }
+    serialized = json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    path = os.path.abspath(args.out)
+    temporary = path + ".tmp"
+    with open(temporary, "w", encoding="utf-8", newline="\n") as stream:
+        stream.write(serialized)
+    os.replace(temporary, path)
+    print(json.dumps({
+        "output": path,
+        "corpora": [
+            {
+                "corpus": row["corpus"],
+                "within_descendant_row_pairs": row["within_descendant_row_pairs"],
+                "graph_nomic_spearman": row["distance_spearman"][
+                    "graph_walk_cumulative"
+                ]["nomic"],
+                "nomic_e5_spearman": row["distance_spearman"]["nomic"]["shared_e5"],
+            }
+            for row in results
+        ],
+        "wall_seconds": time.perf_counter() - started,
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/run_graph_geometry_synthetic.py
+++ b/prototypes/mu_cosine/run_graph_geometry_synthetic.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Mechanism audit for PSD graph geometries with repeated residual fields.
+
+This is a known-zero-mean, known-unit-channel-covariance audit.  It calibrates
+the complete candidate/alpha search under a block-null field, selects on train
+fields, and scores independent held fields.  It cannot unlock real covariance
+or QR deployment.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+import os
+import time
+
+import numpy as np
+
+from graph_geometry import (
+    closed_neighborhood_kernel,
+    heat_kernel_reference,
+    kernel_diagnostics,
+    resolvent_kernel_reference,
+    walk_feature_kernel,
+)
+
+
+ALPHAS = (0.0, 0.025, 0.05, 0.10, 0.20, 0.35, 0.50)
+TRUTH_ALPHAS = (0.10, 0.20)
+
+
+def _content_record(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(chunk)
+    return {"size_bytes": os.path.getsize(path), "sha256": digest.hexdigest()}
+
+
+def benchmark_graph():
+    """Fixed asymmetric-branch topology with local and longer-range ambiguity."""
+    nodes = tuple(f"n{index}" for index in range(12))
+    edges = (
+        (0, 1), (1, 2), (2, 3), (3, 4), (4, 5),
+        (2, 6), (6, 7), (4, 8), (8, 9),
+        (1, 10), (10, 3), (5, 11),
+    )
+    neighbors = {node: set() for node in nodes}
+    for left, right in edges:
+        a, b = nodes[left], nodes[right]
+        neighbors[a].add(b)
+        neighbors[b].add(a)
+    return nodes, {node: frozenset(values) for node, values in neighbors.items()}
+
+
+def candidate_kernels():
+    nodes, neighbors = benchmark_graph()
+    _, closed, _ = closed_neighborhood_kernel(nodes, neighbors)
+    _, walk, _ = walk_feature_kernel(nodes, neighbors, (1.0, 0.5, 0.25, 0.125))
+    _, heat = heat_kernel_reference(nodes, neighbors, diffusion_time=1.0)
+    _, resolvent = resolvent_kernel_reference(nodes, neighbors, scale=1.0)
+    permutation = np.roll(np.arange(len(nodes)), 5)
+    deranged_walk = walk[np.ix_(permutation, permutation)]
+    return nodes, {
+        "closed": closed,
+        "walk_decay": walk,
+        "heat": heat,
+        "resolvent": resolvent,
+        "deranged_walk": deranged_walk,
+    }
+
+
+def correlation_path(kernel, alpha):
+    alpha = float(alpha)
+    if not 0.0 <= alpha < 1.0:
+        raise ValueError("alpha must be in [0,1)")
+    kernel = np.asarray(kernel, dtype=float)
+    return (1.0 - alpha) * np.eye(len(kernel)) + alpha * kernel
+
+
+@dataclass(frozen=True)
+class PreparedGaussian:
+    precision: np.ndarray
+    log_determinant: float
+    dimension: int
+
+
+def prepare_gaussian(covariance):
+    covariance = np.asarray(covariance, dtype=float)
+    sign, logdet = np.linalg.slogdet(covariance)
+    if covariance.ndim != 2 or covariance.shape[0] != covariance.shape[1] or sign <= 0:
+        raise ValueError("covariance must be positive definite")
+    return PreparedGaussian(np.linalg.inv(covariance), float(logdet), len(covariance))
+
+
+def mean_nll_per_scalar(fields, prepared):
+    fields = np.asarray(fields, dtype=float)
+    if fields.ndim != 2 or fields.shape[1] != prepared.dimension:
+        raise ValueError("fields must be [draw, dimension]")
+    quadratic = np.einsum("bi,ij,bj->b", fields, prepared.precision, fields)
+    return float(np.mean(
+        0.5 * (quadratic + prepared.log_determinant + prepared.dimension * np.log(2.0 * np.pi))
+        / prepared.dimension
+    ))
+
+
+def draw_fields(covariance, count, rng):
+    covariance = np.asarray(covariance, dtype=float)
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    if np.min(eigenvalues) <= 0.0 or count < 1:
+        raise ValueError("covariance must be positive definite and count positive")
+    root = eigenvectors @ np.diag(np.sqrt(eigenvalues))
+    return rng.standard_normal((count, len(covariance))) @ root.T
+
+
+def prepare_candidates(kernels, alphas=ALPHAS):
+    output = {("block", 0.0): prepare_gaussian(np.eye(len(next(iter(kernels.values())))))}
+    for name, kernel in kernels.items():
+        for alpha in alphas:
+            if alpha > 0.0:
+                output[(name, float(alpha))] = prepare_gaussian(correlation_path(kernel, alpha))
+    return output
+
+
+def best_candidate(fields, prepared):
+    scores = {key: mean_nll_per_scalar(fields, value) for key, value in prepared.items()}
+    selected = min(scores, key=lambda key: (scores[key], key[0], key[1]))
+    block = scores[("block", 0.0)]
+    return selected, float(block - scores[selected]), scores
+
+
+def calibrate_familywise_threshold(prepared, *, train_fields, draws, seed, confidence=0.95):
+    if draws < 10 or not 0.5 < confidence < 1.0:
+        raise ValueError("draws must be at least 10 and confidence in (0.5,1)")
+    rng = np.random.default_rng(seed)
+    maxima = []
+    identity = np.eye(next(iter(prepared.values())).dimension)
+    for _ in range(draws):
+        fields = draw_fields(identity, train_fields, rng)
+        _selected, gain, _scores = best_candidate(fields, prepared)
+        maxima.append(gain)
+    return float(np.quantile(maxima, confidence)), np.asarray(maxima)
+
+
+def select_with_threshold(fields, prepared, threshold):
+    selected, gain, scores = best_candidate(fields, prepared)
+    if gain <= threshold:
+        selected = ("block", 0.0)
+    return selected, scores
+
+
+def _best_family_key(scores, family):
+    eligible = [key for key in scores if key[0] == family]
+    if not eligible:
+        raise ValueError(f"unknown candidate family: {family}")
+    return min(eligible, key=lambda key: (scores[key], key[1]))
+
+
+def _summary(values):
+    values = np.asarray(values, dtype=float)
+    return {
+        "mean": float(np.mean(values)),
+        "sd": float(np.std(values, ddof=1)) if len(values) > 1 else 0.0,
+        "q05": float(np.quantile(values, 0.05)),
+        "median": float(np.median(values)),
+        "q95": float(np.quantile(values, 0.95)),
+    }
+
+
+def run_scenario(name, truth_kernel, truth_alpha, kernels, prepared, threshold, args, seed):
+    truth_covariance = (
+        np.eye(len(truth_kernel))
+        if name == "block"
+        else correlation_path(truth_kernel, truth_alpha)
+    )
+    rng = np.random.default_rng(seed)
+    records = []
+    sensitivity = {str(alpha): [] for alpha in ALPHAS}
+    comparison_family = "walk_decay" if name == "deranged_walk" else "deranged_walk"
+    for _ in range(args.replicates):
+        train = draw_fields(truth_covariance, args.train_fields, rng)
+        held = draw_fields(truth_covariance, args.held_fields, rng)
+        selected, train_scores = select_with_threshold(train, prepared, threshold)
+        held_scores = {
+            key: mean_nll_per_scalar(held, candidate) for key, candidate in prepared.items()
+        }
+        block_nll = held_scores[("block", 0.0)]
+        selected_gain = block_nll - held_scores[selected]
+        if name == "block":
+            correct_beats_comparison = selected == ("block", 0.0)
+        else:
+            correct_key = _best_family_key(train_scores, name)
+            comparison_key = _best_family_key(train_scores, comparison_family)
+            correct_beats_comparison = held_scores[correct_key] < held_scores[comparison_key]
+            for alpha in ALPHAS:
+                candidate = (
+                    prepared[("block", 0.0)]
+                    if alpha == 0.0
+                    else prepare_gaussian(correlation_path(truth_kernel, alpha))
+                )
+                sensitivity[str(alpha)].append(
+                    block_nll - mean_nll_per_scalar(held, candidate)
+                )
+        records.append({
+            "selected": selected,
+            "selected_gain": selected_gain,
+            "correct_family_selected": selected[0] == name,
+            "correct_beats_comparison": correct_beats_comparison,
+        })
+    return {
+        "truth_family": name,
+        "truth_alpha": float(truth_alpha),
+        "replicates": int(args.replicates),
+        "nonzero_selection_rate": float(np.mean([row["selected"][0] != "block" for row in records])),
+        "correct_family_selection_rate": float(np.mean([
+            row["correct_family_selected"] for row in records
+        ])),
+        "correct_beats_deranged_or_base_rate": float(np.mean([
+            row["correct_beats_comparison"] for row in records
+        ])),
+        "selected_held_nll_gain_per_scalar": _summary([
+            row["selected_gain"] for row in records
+        ]),
+        "selected_counts": {
+            f"{family}@{alpha:g}": int(sum(row["selected"] == (family, alpha) for row in records))
+            for family, alpha in sorted(set(row["selected"] for row in records))
+        },
+        "correct_geometry_alpha_sensitivity": {
+            alpha: _summary(values) for alpha, values in sensitivity.items() if values
+        },
+    }
+
+
+def run_benchmark(args):
+    nodes, kernels = candidate_kernels()
+    prepared = prepare_candidates(kernels)
+    threshold, null_maxima = calibrate_familywise_threshold(
+        prepared,
+        train_fields=args.train_fields,
+        draws=args.calibration_draws,
+        seed=args.seed + 1,
+        confidence=args.confidence,
+    )
+    scenarios = [
+        run_scenario(
+            "block",
+            np.eye(len(nodes)),
+            0.0,
+            kernels,
+            prepared,
+            threshold,
+            args,
+            args.seed + 100,
+        )
+    ]
+    for family, kernel in kernels.items():
+        for offset, alpha in enumerate(TRUTH_ALPHAS):
+            scenarios.append(run_scenario(
+                family,
+                kernel,
+                alpha,
+                kernels,
+                prepared,
+                threshold,
+                args,
+                args.seed + 1000 * (list(kernels).index(family) + 1) + offset,
+            ))
+    block = scenarios[0]
+    planted = [row for row in scenarios if row["truth_alpha"] >= 0.10]
+    mechanism_gates = {
+        "block_null_nonzero_selection_at_most_10pct": block["nonzero_selection_rate"] <= 0.10,
+        "every_planted_selected_gain_positive": all(
+            row["selected_held_nll_gain_per_scalar"]["mean"] > 0.0 for row in planted
+        ),
+        "every_planted_correct_beats_control_at_least_80pct": all(
+            row["correct_beats_deranged_or_base_rate"] >= 0.80 for row in planted
+        ),
+    }
+    upper = np.triu_indices(len(nodes), 1)
+    overlap = {
+        left: {
+            right: float(np.corrcoef(kernels[left][upper], kernels[right][upper])[0, 1])
+            for right in kernels
+        }
+        for left in kernels
+    }
+    root = os.path.dirname(os.path.abspath(__file__))
+    configuration = vars(args).copy()
+    configuration.pop("out", None)
+    return {
+        "schema_version": 1,
+        "status": "KNOWN-MEAN/KNOWN-B GRAPH-GEOMETRY MECHANISM AUDIT; NO REAL DEPLOYMENT",
+        "design": "DESIGN_graph_geometry_confirmatory.md",
+        "implementation": {
+            "design": _content_record(os.path.join(root, "DESIGN_graph_geometry_confirmatory.md")),
+            "core": _content_record(os.path.join(root, "graph_geometry.py")),
+            "runner": _content_record(os.path.abspath(__file__)),
+        },
+        "configuration": configuration,
+        "graph": {"nodes": list(nodes), "candidate_overlap": overlap},
+        "kernel_diagnostics": {
+            name: asdict(kernel_diagnostics(kernel)) for name, kernel in kernels.items()
+        },
+        "familywise_null": {
+            "threshold_nll_gain_per_scalar": threshold,
+            "calibration_maximum_gain": _summary(null_maxima),
+        },
+        "scenarios": scenarios,
+        "mechanism_gates": mechanism_gates,
+        "all_mechanism_gates_pass": all(mechanism_gates.values()),
+        "real_covariance_gate_unlocked": False,
+        "qr_deployment_unlocked": False,
+        "reason": (
+            "known mean/B and synthetic repeated fields do not identify real judge covariance; "
+            "the preregistered repeated-judge campaign is absent"
+        ),
+    }
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--replicates", type=int, default=200)
+    parser.add_argument("--calibration-draws", type=int, default=1000)
+    parser.add_argument("--train-fields", type=int, default=12)
+    parser.add_argument("--held-fields", type=int, default=64)
+    parser.add_argument("--confidence", type=float, default=0.95)
+    parser.add_argument("--seed", type=int, default=884200)
+    parser.add_argument("--out", default="/tmp/graph_geometry_synthetic.json")
+    return parser
+
+
+def _validate_args(args):
+    if min(args.replicates, args.calibration_draws, args.train_fields, args.held_fields) < 1:
+        raise ValueError("replicate, calibration, and field counts must be positive")
+    if args.calibration_draws < 10 or not 0.5 < args.confidence < 1.0:
+        raise ValueError("calibration-draws must be at least 10 and confidence in (0.5,1)")
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    _validate_args(args)
+    started = time.perf_counter()
+    payload = run_benchmark(args)
+    serialized = json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    path = os.path.abspath(args.out)
+    temporary = path + ".tmp"
+    with open(temporary, "w", encoding="utf-8", newline="\n") as stream:
+        stream.write(serialized)
+    os.replace(temporary, path)
+    print(json.dumps({
+        "all_mechanism_gates_pass": payload["all_mechanism_gates_pass"],
+        "mechanism_gates": payload["mechanism_gates"],
+        "output": path,
+        "wall_seconds": time.perf_counter() - started,
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/run_graph_geometry_synthetic_v2.py
+++ b/prototypes/mu_cosine/run_graph_geometry_synthetic_v2.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Matched-coupling v2 mechanism audit for graph residual geometries."""
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+import os
+import time
+
+import numpy as np
+
+from graph_geometry import kernel_diagnostics
+from run_graph_geometry_synthetic import (
+    _content_record,
+    _summary,
+    calibrate_familywise_threshold,
+    candidate_kernels,
+    draw_fields,
+    mean_nll_per_scalar,
+    prepare_gaussian,
+    select_with_threshold,
+)
+
+
+RHO_GRID = (0.0, 0.025, 0.05, 0.10, 0.20)
+TRUTH_RHOS = (0.10, 0.20)
+EQUIVALENCE_CLASS = {
+    "closed": "local_spectral",
+    "heat": "local_spectral",
+    "resolvent": "local_spectral",
+    "walk_decay": "walk",
+    "deranged_walk": "deranged",
+}
+
+
+def maximum_off_diagonal(kernel):
+    kernel = np.asarray(kernel, dtype=float)
+    if kernel.ndim != 2 or kernel.shape[0] != kernel.shape[1] or len(kernel) < 2:
+        raise ValueError("kernel must be square with at least two rows")
+    off = kernel - np.diag(np.diag(kernel))
+    maximum = float(np.max(np.abs(off)))
+    if maximum <= 0.0:
+        raise ValueError("kernel must contain nonzero off-diagonal geometry")
+    return maximum
+
+
+def matched_correlation(kernel, rho):
+    rho = float(rho)
+    if not 0.0 <= rho < 1.0:
+        raise ValueError("rho must be in [0,1)")
+    amplitude = rho / maximum_off_diagonal(kernel) if rho else 0.0
+    if amplitude >= 0.95:
+        raise ValueError(f"matched amplitude {amplitude:.3f} is outside the frozen <0.95 domain")
+    covariance = (1.0 - amplitude) * np.eye(len(kernel)) + amplitude * kernel
+    return covariance, amplitude
+
+
+def prepare_matched_candidates(kernels, rho_grid=RHO_GRID):
+    dimension = len(next(iter(kernels.values())))
+    prepared = {("block", 0.0): prepare_gaussian(np.eye(dimension))}
+    amplitudes = {}
+    for family, kernel in kernels.items():
+        for rho in rho_grid:
+            if rho == 0.0:
+                continue
+            covariance, amplitude = matched_correlation(kernel, rho)
+            prepared[(family, float(rho))] = prepare_gaussian(covariance)
+            amplitudes[f"{family}@{rho:g}"] = amplitude
+    return prepared, amplitudes
+
+
+def _best_family_key(scores, family):
+    eligible = [key for key in scores if key[0] == family]
+    return min(eligible, key=lambda key: (scores[key], key[1]))
+
+
+def _deranged(kernel):
+    permutation = np.roll(np.arange(len(kernel)), 5)
+    return kernel[np.ix_(permutation, permutation)]
+
+
+def _diagnostic_family_prepared(kernel, label):
+    return {
+        (label, rho): prepare_gaussian(matched_correlation(kernel, rho)[0])
+        for rho in RHO_GRID
+        if rho > 0.0
+    }
+
+
+def run_scenario(family, truth_kernel, truth_rho, prepared, threshold, args, seed):
+    truth_covariance = (
+        np.eye(len(truth_kernel))
+        if family == "block"
+        else matched_correlation(truth_kernel, truth_rho)[0]
+    )
+    if family == "block":
+        comparison_family = None
+        comparison_prepared = {}
+    elif family == "deranged_walk":
+        comparison_family = "walk_decay"
+        comparison_prepared = {}
+    else:
+        comparison_family = "equal_energy_derangement"
+        comparison_prepared = _diagnostic_family_prepared(
+            _deranged(truth_kernel), comparison_family
+        )
+    rng = np.random.default_rng(seed)
+    records = []
+    sensitivity = {str(rho): [] for rho in RHO_GRID}
+    for _ in range(args.replicates):
+        train = draw_fields(truth_covariance, args.train_fields, rng)
+        held = draw_fields(truth_covariance, args.held_fields, rng)
+        selected, train_scores = select_with_threshold(train, prepared, threshold)
+        held_scores = {
+            key: mean_nll_per_scalar(held, candidate) for key, candidate in prepared.items()
+        }
+        block_nll = held_scores[("block", 0.0)]
+        if family == "block":
+            comparison_win = selected == ("block", 0.0)
+        else:
+            truth_key = _best_family_key(train_scores, family)
+            if family == "deranged_walk":
+                comparison_key = _best_family_key(train_scores, comparison_family)
+                comparison_nll = held_scores[comparison_key]
+            else:
+                comparison_train_scores = {
+                    key: mean_nll_per_scalar(train, candidate)
+                    for key, candidate in comparison_prepared.items()
+                }
+                comparison_key = min(
+                    comparison_train_scores,
+                    key=lambda key: (comparison_train_scores[key], key[1]),
+                )
+                comparison_nll = mean_nll_per_scalar(
+                    held, comparison_prepared[comparison_key]
+                )
+            comparison_win = held_scores[truth_key] < comparison_nll
+            for rho in RHO_GRID:
+                candidate = (
+                    prepared[("block", 0.0)]
+                    if rho == 0.0
+                    else prepare_gaussian(matched_correlation(truth_kernel, rho)[0])
+                )
+                sensitivity[str(rho)].append(
+                    block_nll - mean_nll_per_scalar(held, candidate)
+                )
+        records.append({
+            "selected": selected,
+            "selected_gain": block_nll - held_scores[selected],
+            "exact_family_selected": selected[0] == family,
+            "equivalence_class_selected": (
+                family == "block" and selected[0] == "block"
+            ) or (
+                family != "block"
+                and EQUIVALENCE_CLASS.get(selected[0]) == EQUIVALENCE_CLASS[family]
+            ),
+            "truth_beats_deranged_or_base": comparison_win,
+        })
+    return {
+        "truth_family": family,
+        "truth_equivalence_class": "block" if family == "block" else EQUIVALENCE_CLASS[family],
+        "truth_maximum_coupling": float(truth_rho),
+        "truth_path_amplitude": (
+            0.0 if family == "block" else matched_correlation(truth_kernel, truth_rho)[1]
+        ),
+        "replicates": int(args.replicates),
+        "nonzero_selection_rate": float(np.mean([row["selected"][0] != "block" for row in records])),
+        "exact_family_selection_rate": float(np.mean([
+            row["exact_family_selected"] for row in records
+        ])),
+        "equivalence_class_selection_rate": float(np.mean([
+            row["equivalence_class_selected"] for row in records
+        ])),
+        "truth_beats_deranged_or_base_rate": float(np.mean([
+            row["truth_beats_deranged_or_base"] for row in records
+        ])),
+        "selected_held_nll_gain_per_scalar": _summary([
+            row["selected_gain"] for row in records
+        ]),
+        "selected_counts": {
+            f"{selected_family}@rho={rho:g}": int(sum(
+                row["selected"] == (selected_family, rho) for row in records
+            ))
+            for selected_family, rho in sorted(set(row["selected"] for row in records))
+        },
+        "truth_geometry_rho_sensitivity": {
+            rho: _summary(values) for rho, values in sensitivity.items() if values
+        },
+    }
+
+
+def run_benchmark(args):
+    nodes, kernels = candidate_kernels()
+    prepared, amplitudes = prepare_matched_candidates(kernels)
+    threshold, null_maxima = calibrate_familywise_threshold(
+        prepared,
+        train_fields=args.train_fields,
+        draws=args.calibration_draws,
+        seed=args.seed + 1,
+        confidence=args.confidence,
+    )
+    scenarios = [run_scenario(
+        "block", np.eye(len(nodes)), 0.0, prepared, threshold, args, args.seed + 100
+    )]
+    for family, kernel in kernels.items():
+        for offset, rho in enumerate(TRUTH_RHOS):
+            scenarios.append(run_scenario(
+                family,
+                kernel,
+                rho,
+                prepared,
+                threshold,
+                args,
+                args.seed + 1000 * (list(kernels).index(family) + 1) + offset,
+            ))
+    block = scenarios[0]
+    strong = [
+        row for row in scenarios
+        if row["truth_maximum_coupling"] == 0.20 and row["truth_family"] != "deranged_walk"
+    ]
+    gates = {
+        "block_null_nonzero_selection_at_most_10pct": block["nonzero_selection_rate"] <= 0.10,
+        "rho_0_20_nonderanged_selected_gain_positive": all(
+            row["selected_held_nll_gain_per_scalar"]["mean"] > 0.0 for row in strong
+        ),
+        "rho_0_20_nonderanged_equivalence_selection_at_least_60pct": all(
+            row["equivalence_class_selection_rate"] >= 0.60 for row in strong
+        ),
+        "rho_0_20_nonderanged_beats_derangement_at_least_80pct": all(
+            row["truth_beats_deranged_or_base_rate"] >= 0.80 for row in strong
+        ),
+    }
+    upper = np.triu_indices(len(nodes), 1)
+    overlap = {
+        left: {
+            right: float(np.corrcoef(kernels[left][upper], kernels[right][upper])[0, 1])
+            for right in kernels
+        }
+        for left in kernels
+    }
+    root = os.path.dirname(os.path.abspath(__file__))
+    configuration = vars(args).copy()
+    configuration.pop("out", None)
+    return {
+        "schema_version": 1,
+        "status": "MATCHED-COUPLING GRAPH-GEOMETRY V2 MECHANISM AUDIT; NO REAL DEPLOYMENT",
+        "design": "DESIGN_graph_geometry_synthetic_v2.md",
+        "implementation": {
+            "design": _content_record(os.path.join(root, "DESIGN_graph_geometry_synthetic_v2.md")),
+            "core": _content_record(os.path.join(root, "graph_geometry.py")),
+            "v1_dependency": _content_record(os.path.join(root, "run_graph_geometry_synthetic.py")),
+            "runner": _content_record(os.path.abspath(__file__)),
+        },
+        "configuration": configuration,
+        "maximum_coupling_grid": list(RHO_GRID),
+        "family_specific_path_amplitudes": amplitudes,
+        "equivalence_classes": EQUIVALENCE_CLASS,
+        "graph": {"nodes": list(nodes), "candidate_overlap": overlap},
+        "kernel_diagnostics": {
+            name: asdict(kernel_diagnostics(kernel)) for name, kernel in kernels.items()
+        },
+        "familywise_null": {
+            "threshold_nll_gain_per_scalar": threshold,
+            "calibration_maximum_gain": _summary(null_maxima),
+        },
+        "scenarios": scenarios,
+        "mechanism_gates": gates,
+        "all_mechanism_gates_pass": all(gates.values()),
+        "real_covariance_gate_unlocked": False,
+        "batching_gate_unlocked": False,
+        "qr_deployment_unlocked": False,
+        "reason": (
+            "matched synthetic coupling with known mean/B cannot identify real repeated-judge covariance"
+        ),
+    }
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--replicates", type=int, default=200)
+    parser.add_argument("--calibration-draws", type=int, default=1000)
+    parser.add_argument("--train-fields", type=int, default=48)
+    parser.add_argument("--held-fields", type=int, default=64)
+    parser.add_argument("--confidence", type=float, default=0.95)
+    parser.add_argument("--seed", type=int, default=885200)
+    parser.add_argument("--out", default="/tmp/graph_geometry_synthetic_v2.json")
+    return parser
+
+
+def _validate_args(args):
+    if min(args.replicates, args.calibration_draws, args.train_fields, args.held_fields) < 1:
+        raise ValueError("replicate, calibration, and field counts must be positive")
+    if args.calibration_draws < 10 or not 0.5 < args.confidence < 1.0:
+        raise ValueError("calibration-draws must be at least 10 and confidence in (0.5,1)")
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    _validate_args(args)
+    started = time.perf_counter()
+    payload = run_benchmark(args)
+    serialized = json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    path = os.path.abspath(args.out)
+    temporary = path + ".tmp"
+    with open(temporary, "w", encoding="utf-8", newline="\n") as stream:
+        stream.write(serialized)
+    os.replace(temporary, path)
+    print(json.dumps({
+        "all_mechanism_gates_pass": payload["all_mechanism_gates_pass"],
+        "mechanism_gates": payload["mechanism_gates"],
+        "output": path,
+        "wall_seconds": time.perf_counter() - started,
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/test_graph_geometry.py
+++ b/prototypes/mu_cosine/test_graph_geometry.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Regression tests for PSD-safe graph and embedding item geometries."""
+import numpy as np
+import pytest
+
+from graph_geometry import (
+    closed_neighborhood_kernel,
+    convex_kernel_mixture,
+    cumulative_walk_feature_kernel,
+    cumulative_walk_feature_map,
+    descendant_gated_item_kernel,
+    embedding_item_kernel,
+    heat_kernel_reference,
+    kernel_diagnostics,
+    median_pairwise_distance,
+    normalize_psd_kernel,
+    resolvent_kernel_reference,
+    role_aware_pair_features,
+    schur_kernel_product,
+    symmetric_normalized_laplacian,
+    walk_feature_kernel,
+    walk_feature_map,
+)
+
+
+def _neighbors(edges, extra=()):
+    output = {node: set() for node in extra}
+    for left, right in edges:
+        output.setdefault(left, set()).add(right)
+        output.setdefault(right, set()).add(left)
+    return {node: frozenset(values) for node, values in output.items()}
+
+
+def _assert_correlation_kernel(value):
+    assert np.all(np.isfinite(value))
+    assert np.allclose(value, value.T, atol=1e-12)
+    assert np.allclose(np.diag(value), 1.0, atol=1e-12)
+    assert np.min(np.linalg.eigvalsh(value)) >= -1e-10
+
+
+@pytest.mark.parametrize(
+    "neighbors,nodes",
+    [
+        (_neighbors((("a", "b"), ("b", "c"))), ("a", "b", "c")),
+        (_neighbors((("o", "a"), ("o", "b"), ("o", "c"))), ("o", "a", "b", "c")),
+        (_neighbors((("a", "b"),), extra=("z",)), ("a", "b", "z")),
+        (_neighbors((), extra=("z",)), ("z",)),
+    ],
+)
+def test_reference_graph_kernels_are_psd_on_basic_topologies(neighbors, nodes):
+    for constructor, argument in (
+        (heat_kernel_reference, {"diffusion_time": 0.7}),
+        (resolvent_kernel_reference, {"scale": 0.7}),
+    ):
+        returned, kernel = constructor(nodes, neighbors, **argument)
+        assert returned == nodes
+        _assert_correlation_kernel(kernel)
+
+
+def test_two_node_heat_and_resolvent_match_analytic_spectrum():
+    nodes = ("a", "b")
+    neighbors = _neighbors((("a", "b"),))
+    _, laplacian = symmetric_normalized_laplacian(nodes, neighbors)
+    assert np.allclose(laplacian, [[1.0, -1.0], [-1.0, 1.0]])
+
+    time = 0.6
+    _, heat = heat_kernel_reference(nodes, neighbors, diffusion_time=time)
+    raw_heat = 0.5 * np.array([
+        [1.0 + np.exp(-2.0 * time), 1.0 - np.exp(-2.0 * time)],
+        [1.0 - np.exp(-2.0 * time), 1.0 + np.exp(-2.0 * time)],
+    ])
+    assert np.allclose(heat, normalize_psd_kernel(raw_heat))
+
+    scale = 0.4
+    _, resolvent = resolvent_kernel_reference(nodes, neighbors, scale=scale)
+    raw_resolvent = np.linalg.inv(np.eye(2) + scale * laplacian)
+    assert np.allclose(resolvent, normalize_psd_kernel(raw_resolvent))
+
+
+def test_reference_scales_approach_identity_and_disconnected_blocks_stay_zero():
+    nodes = ("a", "b", "x", "y")
+    neighbors = _neighbors((("a", "b"), ("x", "y")))
+    _, heat = heat_kernel_reference(nodes, neighbors, diffusion_time=1e-8)
+    _, resolvent = resolvent_kernel_reference(nodes, neighbors, scale=1e-8)
+    assert np.allclose(heat, np.eye(4), atol=3e-8)
+    assert np.allclose(resolvent, np.eye(4), atol=3e-8)
+    assert np.allclose(heat[:2, 2:], 0.0, atol=1e-12)
+    assert np.allclose(resolvent[:2, 2:], 0.0, atol=1e-12)
+
+
+def test_walk_feature_kernel_is_explicit_psd_and_order_equivariant():
+    neighbors = _neighbors((("a", "b"), ("b", "c"), ("c", "d")))
+    nodes = ("a", "b", "c", "d")
+    features, basis = walk_feature_map(nodes, neighbors, (1.0, 0.5, 0.25))
+    returned, kernel, returned_basis = walk_feature_kernel(
+        nodes, neighbors, (1.0, 0.5, 0.25)
+    )
+    assert returned == nodes and returned_basis == basis
+    assert np.allclose(kernel, normalize_psd_kernel(features @ features.T))
+    _assert_correlation_kernel(kernel)
+
+    reverse = tuple(reversed(nodes))
+    _, reversed_kernel, _ = walk_feature_kernel(reverse, neighbors, (1.0, 0.5, 0.25))
+    assert np.allclose(reversed_kernel, kernel[::-1, ::-1])
+
+
+def test_closed_neighborhood_kernel_is_the_binary_feature_gram():
+    neighbors = _neighbors((("a", "b"), ("b", "c")))
+    nodes, kernel, basis = closed_neighborhood_kernel(("a", "b", "c"), neighbors)
+    assert nodes == ("a", "b", "c")
+    assert set(basis) == {"a", "b", "c"}
+    _assert_correlation_kernel(kernel)
+    assert kernel[0, 2] == pytest.approx(0.5)
+    assert kernel[0, 1] == pytest.approx(2.0 / np.sqrt(6.0))
+
+
+def test_cumulative_walk_features_include_cross_hop_adjacent_overlap():
+    neighbors = _neighbors((("a", "b"), ("b", "c")))
+    nodes = ("a", "b", "c")
+    features, basis = cumulative_walk_feature_map(nodes, neighbors, (1.0, 1.0))
+    returned, kernel, returned_basis = cumulative_walk_feature_kernel(
+        nodes, neighbors, (1.0, 1.0)
+    )
+    assert returned == nodes and returned_basis == basis
+    assert np.allclose(kernel, normalize_psd_kernel((features @ features.T).toarray()))
+    _assert_correlation_kernel(kernel)
+    assert kernel[0, 1] > 0.0
+    assert kernel[0, 1] > kernel[0, 2]
+
+
+def test_zero_hop_walk_features_are_identity_and_invalid_weights_fail():
+    neighbors = _neighbors((("a", "b"),))
+    _, kernel, _ = walk_feature_kernel(("a", "b"), neighbors, (1.0,))
+    assert np.array_equal(kernel, np.eye(2))
+    with pytest.raises(ValueError, match="nonnegative"):
+        walk_feature_map(("a",), neighbors, (1.0, -0.1))
+    with pytest.raises(ValueError, match="at least one positive"):
+        walk_feature_map(("a",), neighbors, (0.0, 0.0))
+
+
+def test_descendant_gate_lifts_root_kernel_and_preserves_psd():
+    root_nodes = ("r1", "r2", "r3")
+    neighbors = _neighbors((("r1", "r2"), ("r2", "r3")))
+    _, root_kernel, _ = walk_feature_kernel(root_nodes, neighbors, (1.0, 1.0))
+    pairs = (("x", "r1"), ("x", "r2"), ("y", "r2"), ("y", "r3"))
+    item = descendant_gated_item_kernel(pairs, root_nodes, root_kernel)
+    _assert_correlation_kernel(item)
+    assert np.all(item[:2, 2:] == 0.0)
+    assert item[0, 1] == pytest.approx(root_kernel[0, 1])
+
+
+def test_role_aware_embedding_rbf_and_bandwidth_are_psd():
+    embeddings = {
+        "x": np.array([1.0, 0.0, 0.0]),
+        "y": np.array([0.0, 1.0, 0.0]),
+        "r1": np.array([0.8, 0.2, 0.0]),
+        "r2": np.array([0.7, 0.3, 0.0]),
+        "r3": np.array([0.0, 0.2, 0.8]),
+    }
+    pairs = (("x", "r1"), ("x", "r2"), ("y", "r2"), ("y", "r3"))
+    features = role_aware_pair_features(pairs, embeddings)
+    bandwidth = median_pairwise_distance(features)
+    kernel = embedding_item_kernel(pairs, embeddings, length_scale=bandwidth)
+    _assert_correlation_kernel(kernel)
+    assert np.all(kernel[:2, 2:] == 0.0)
+
+
+def test_convex_and_schur_combinations_preserve_psd_and_reject_bad_weights():
+    first = np.eye(3)
+    second = np.full((3, 3), 0.25)
+    np.fill_diagonal(second, 1.0)
+    mixed = convex_kernel_mixture((first, second), (0.25, 0.75))
+    product = schur_kernel_product((mixed, second))
+    _assert_correlation_kernel(mixed)
+    _assert_correlation_kernel(product)
+    with pytest.raises(ValueError, match="nonnegative"):
+        convex_kernel_mixture((first, second), (1.0, -0.1))
+
+
+def test_indefinite_input_is_rejected_not_repaired():
+    indefinite = np.array([[1.0, 2.0], [2.0, 1.0]])
+    with pytest.raises(ValueError, match="not positive semidefinite"):
+        normalize_psd_kernel(indefinite)
+
+
+def test_kernel_diagnostics_are_stable_and_content_addressed():
+    value = np.array([[1.0, 0.2], [0.2, 1.0]])
+    first = kernel_diagnostics(value)
+    second = kernel_diagnostics(value.copy())
+    assert first == second
+    assert first.minimum_eigenvalue == pytest.approx(0.8)
+    assert first.maximum_eigenvalue == pytest.approx(1.2)
+    assert first.rank == 2
+    assert first.positive_spectrum_condition_number == pytest.approx(1.5)
+    assert len(first.sha256) == 64
+
+    singular = kernel_diagnostics(np.ones((2, 2)))
+    assert singular.rank == 1
+    assert singular.positive_spectrum_condition_number == pytest.approx(1.0)

--- a/prototypes/mu_cosine/test_independent_embedding_cache.py
+++ b/prototypes/mu_cosine/test_independent_embedding_cache.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for network-free, content-addressed independent embedding caches."""
+from dataclasses import replace
+import json
+
+import numpy as np
+import pytest
+
+from independent_embedding_cache import (
+    EmbeddingModelSpec,
+    cache_paths,
+    canonical_names,
+    embedding_texts,
+    encode_with_model,
+    load_embedding_cache,
+    read_pair_nodes,
+    validate_embeddings,
+    write_embedding_cache,
+)
+
+
+SPEC = EmbeddingModelSpec(
+    "example/frozen-embedder",
+    "0123456789abcdef",
+    "clustering: ",
+    3,
+    False,
+)
+
+
+class FakeModel:
+    def encode(self, texts, **kwargs):
+        assert kwargs["normalize_embeddings"]
+        rows = []
+        for index, _text in enumerate(texts):
+            value = np.array([index + 1.0, 1.0, 0.5], dtype=np.float32)
+            rows.append(value / np.linalg.norm(value))
+        return np.asarray(rows)
+
+
+def test_canonical_names_and_task_texts_are_stable():
+    assert canonical_names(("Zeta_node", "Alpha_node")) == ("Alpha_node", "Zeta_node")
+    assert embedding_texts(("Alpha_node", "Zeta_node"), SPEC) == (
+        "clustering: Alpha node",
+        "clustering: Zeta node",
+    )
+    with pytest.raises(ValueError, match="unique"):
+        canonical_names(("x", "x"))
+    with pytest.raises(ValueError, match="non-empty"):
+        canonical_names(("x", " "))
+
+
+def test_fake_encoder_receives_frozen_contract_without_model_download():
+    names, texts, embeddings = encode_with_model(
+        ("Zeta_node", "Alpha_node"), SPEC, FakeModel(), batch_size=2
+    )
+    assert names == ("Alpha_node", "Zeta_node")
+    assert texts[0] == "clustering: Alpha node"
+    assert embeddings.shape == (2, 3)
+    assert np.allclose(np.linalg.norm(embeddings, axis=1), 1.0)
+
+
+def test_cache_is_byte_deterministic_and_portable_across_prefixes(tmp_path):
+    names, _texts, embeddings = encode_with_model(
+        ("Alpha_node", "Zeta_node"), SPEC, FakeModel()
+    )
+    first_manifest, first_record = write_embedding_cache(
+        tmp_path / "first" / "cache",
+        names,
+        embeddings,
+        SPEC,
+        package_versions={"numpy": "test"},
+    )
+    second_manifest, second_record = write_embedding_cache(
+        tmp_path / "second" / "renamed",
+        names,
+        embeddings,
+        SPEC,
+        package_versions={"numpy": "test"},
+    )
+    assert first_manifest == second_manifest
+    assert first_record == second_record
+    for role in ("nodes", "embeddings", "manifest"):
+        assert cache_paths(tmp_path / "first" / "cache")[role].read_bytes() == cache_paths(
+            tmp_path / "second" / "renamed"
+        )[role].read_bytes()
+    assert "/tmp" not in repr(first_manifest)
+
+
+def test_cache_loader_validates_spec_coverage_and_hashes(tmp_path):
+    names, _texts, embeddings = encode_with_model(
+        ("Alpha_node", "Zeta_node"), SPEC, FakeModel()
+    )
+    prefix = tmp_path / "cache"
+    write_embedding_cache(prefix, names, embeddings, SPEC)
+    loaded = load_embedding_cache(
+        prefix, expected_spec=SPEC, required_names=("Alpha_node",)
+    )
+    assert loaded.names == names
+    assert set(loaded.by_name()) == set(names)
+    assert np.array_equal(loaded.embeddings, embeddings)
+
+    with pytest.raises(ValueError, match="frozen spec"):
+        load_embedding_cache(prefix, expected_spec=replace(SPEC, revision="different"))
+    with pytest.raises(ValueError, match="misses 1"):
+        load_embedding_cache(prefix, required_names=("missing",))
+
+    paths = cache_paths(prefix)
+    paths["nodes"].write_bytes(paths["nodes"].read_bytes() + b" ")
+    with pytest.raises(ValueError, match="content hash"):
+        load_embedding_cache(prefix)
+
+
+def test_write_rejects_unsorted_names_to_prevent_embedding_misalignment(tmp_path):
+    embeddings = np.eye(3, dtype=np.float32)[:2]
+    embeddings /= np.linalg.norm(embeddings, axis=1, keepdims=True)
+    with pytest.raises(ValueError, match="canonical and sorted"):
+        write_embedding_cache(tmp_path / "cache", ("z", "a"), embeddings, SPEC)
+
+
+def test_embedding_validation_rejects_shape_nonfinite_zero_and_unnormalized():
+    names = ("a", "b")
+    with pytest.raises(ValueError, match="shape"):
+        validate_embeddings(names, np.ones((2, 2)), SPEC)
+    bad = np.ones((2, 3), dtype=np.float32)
+    bad[0, 0] = np.nan
+    with pytest.raises(ValueError, match="finite"):
+        validate_embeddings(names, bad, SPEC)
+    with pytest.raises(ValueError, match="nonzero"):
+        validate_embeddings(names, np.zeros((2, 3)), SPEC)
+    with pytest.raises(ValueError, match="L2-normalized"):
+        validate_embeddings(names, np.ones((2, 3)), SPEC)
+
+
+def test_pair_tsv_endpoint_inventory_is_comment_aware_and_canonical(tmp_path):
+    path = tmp_path / "pairs.tsv"
+    path.write_text(
+        "# left\tright\textra\n"
+        "Zeta\tAlpha\tone\n"
+        "Beta\tZeta\ttwo\n",
+        encoding="utf-8",
+    )
+    assert read_pair_nodes(path) == ("Alpha", "Beta", "Zeta")
+    path.write_text("broken\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="malformed"):
+        read_pair_nodes(path)
+
+
+def test_loader_rejects_manifest_text_contract_tampering(tmp_path):
+    names, _texts, embeddings = encode_with_model(("Alpha", "Zeta"), SPEC, FakeModel())
+    prefix = tmp_path / "cache"
+    write_embedding_cache(prefix, names, embeddings, SPEC)
+    paths = cache_paths(prefix)
+    manifest = json.loads(paths["manifest"].read_text(encoding="utf-8"))
+    manifest["input_text_sha256"] = "0" * 64
+    paths["manifest"].write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="input text hash"):
+        load_embedding_cache(prefix)

--- a/prototypes/mu_cosine/test_run_graph_geometry_inventory.py
+++ b/prototypes/mu_cosine/test_run_graph_geometry_inventory.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Tests for outcome-blind geometry inventory summaries."""
+import numpy as np
+import pytest
+
+from run_graph_geometry_inventory import summarize_geometry_inventory
+
+
+def test_inventory_uses_only_within_descendant_off_diagonal_pairs():
+    pairs = (("x", "a"), ("x", "b"), ("x", "c"), ("y", "a"), ("y", "c"))
+    base = np.eye(len(pairs))
+    graph = base.copy()
+    graph[0, 1] = graph[1, 0] = 0.8
+    graph[0, 2] = graph[2, 0] = 0.2
+    graph[1, 2] = graph[2, 1] = 0.4
+    graph[3, 4] = graph[4, 3] = 0.2
+    semantic = base.copy()
+    semantic[0, 1] = semantic[1, 0] = 0.1
+    semantic[0, 2] = semantic[2, 0] = 0.9
+    semantic[1, 2] = semantic[2, 1] = 0.5
+    semantic[3, 4] = semantic[4, 3] = 0.9
+    kernels = {
+        "graph_closed": graph,
+        "graph_walk_same_hop": graph,
+        "graph_walk_cumulative": graph,
+        "minilm": semantic,
+        "nomic": semantic,
+        "shared_e5": semantic,
+    }
+    neighbors = {"a": {"b"}, "b": {"a"}, "c": set()}
+    summary = summarize_geometry_inventory(pairs, kernels, neighbors)
+    assert summary["within_descendant_row_pairs"] == 4
+    assert summary["directly_adjacent_root_pairs"] == 1
+    assert summary["distance_pearson"]["graph_walk_cumulative"]["graph_closed"] == pytest.approx(1.0)
+    assert summary["distance_spearman"]["minilm"]["nomic"] == pytest.approx(1.0)
+    assert summary["mean_distance_by_graph_adjacency"]["graph_walk_cumulative"][
+        "adjacent_mean_distance"
+    ] == pytest.approx(0.2)
+
+
+def test_inventory_rejects_misaligned_or_no_within_descendant_kernels():
+    with pytest.raises(ValueError, match="align"):
+        summarize_geometry_inventory(
+            (("x", "a"), ("x", "b")),
+            {name: np.eye(3) for name in (
+                "graph_closed", "graph_walk_same_hop", "graph_walk_cumulative",
+                "minilm", "nomic", "shared_e5"
+            )},
+            {},
+        )
+    with pytest.raises(ValueError, match="within-descendant"):
+        summarize_geometry_inventory(
+            (("x", "a"), ("y", "b")),
+            {name: np.eye(2) for name in (
+                "graph_closed", "graph_walk_same_hop", "graph_walk_cumulative",
+                "minilm", "nomic", "shared_e5"
+            )},
+            {},
+        )

--- a/prototypes/mu_cosine/test_run_graph_geometry_synthetic.py
+++ b/prototypes/mu_cosine/test_run_graph_geometry_synthetic.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Focused tests for the graph-geometry mechanism runner."""
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from run_graph_geometry_synthetic import (
+    _validate_args,
+    benchmark_graph,
+    calibrate_familywise_threshold,
+    candidate_kernels,
+    correlation_path,
+    draw_fields,
+    mean_nll_per_scalar,
+    prepare_candidates,
+    prepare_gaussian,
+    run_benchmark,
+    select_with_threshold,
+)
+
+
+def _args(**overrides):
+    values = dict(
+        replicates=8,
+        calibration_draws=30,
+        train_fields=6,
+        held_fields=8,
+        confidence=0.90,
+        seed=1234,
+        out="/tmp/not-scientific.json",
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_benchmark_graph_and_candidate_set_are_deterministic_psd():
+    nodes, neighbors = benchmark_graph()
+    second_nodes, second = benchmark_graph()
+    assert nodes == second_nodes and neighbors == second
+    returned, kernels = candidate_kernels()
+    assert returned == nodes
+    assert set(kernels) == {"closed", "walk_decay", "heat", "resolvent", "deranged_walk"}
+    for kernel in kernels.values():
+        assert np.allclose(kernel, kernel.T)
+        assert np.allclose(np.diag(kernel), 1.0)
+        assert np.min(np.linalg.eigvalsh(kernel)) >= -1e-10
+
+
+def test_draws_and_nll_prefer_the_generating_covariance():
+    _nodes, kernels = candidate_kernels()
+    truth = correlation_path(kernels["walk_decay"], 0.35)
+    fields = draw_fields(truth, 4000, np.random.default_rng(7))
+    assert np.allclose(np.cov(fields, rowvar=False), truth, atol=0.08)
+    true_nll = mean_nll_per_scalar(fields, prepare_gaussian(truth))
+    block_nll = mean_nll_per_scalar(fields, prepare_gaussian(np.eye(len(truth))))
+    assert true_nll < block_nll
+
+
+def test_familywise_threshold_is_deterministic_and_can_force_block_fallback():
+    _nodes, kernels = candidate_kernels()
+    prepared = prepare_candidates(kernels)
+    first, maxima = calibrate_familywise_threshold(
+        prepared, train_fields=5, draws=30, seed=99, confidence=0.9
+    )
+    second, _ = calibrate_familywise_threshold(
+        prepared, train_fields=5, draws=30, seed=99, confidence=0.9
+    )
+    assert first == second == pytest.approx(np.quantile(maxima, 0.9))
+    fields = np.zeros((5, len(next(iter(kernels.values())))))
+    selected, _scores = select_with_threshold(fields, prepared, threshold=float("inf"))
+    assert selected == ("block", 0.0)
+
+
+def test_small_benchmark_is_deterministic_and_never_unlocks_real_or_qr():
+    first = run_benchmark(_args())
+    second = run_benchmark(_args(out="/different/runtime/path.json"))
+    assert first == second
+    assert first["status"].startswith("KNOWN-MEAN/KNOWN-B")
+    assert not first["real_covariance_gate_unlocked"]
+    assert not first["qr_deployment_unlocked"]
+    assert len(first["scenarios"]) == 11
+
+
+def test_argument_validation():
+    _validate_args(_args())
+    with pytest.raises(ValueError, match="positive"):
+        _validate_args(_args(replicates=0))
+    with pytest.raises(ValueError, match="at least 10"):
+        _validate_args(_args(calibration_draws=9))

--- a/prototypes/mu_cosine/test_run_graph_geometry_synthetic_v2.py
+++ b/prototypes/mu_cosine/test_run_graph_geometry_synthetic_v2.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Focused tests for matched-coupling graph-geometry v2."""
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from run_graph_geometry_synthetic import candidate_kernels
+from run_graph_geometry_synthetic_v2 import (
+    _validate_args,
+    matched_correlation,
+    maximum_off_diagonal,
+    prepare_matched_candidates,
+    run_benchmark,
+)
+
+
+def _args(**overrides):
+    values = dict(
+        replicates=6,
+        calibration_draws=20,
+        train_fields=8,
+        held_fields=8,
+        confidence=0.9,
+        seed=22,
+        out="/tmp/runtime-only.json",
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_matched_correlation_equalizes_maximum_off_diagonal_coupling():
+    _nodes, kernels = candidate_kernels()
+    amplitudes = []
+    for kernel in kernels.values():
+        covariance, amplitude = matched_correlation(kernel, 0.1)
+        amplitudes.append(amplitude)
+        assert maximum_off_diagonal(covariance) == pytest.approx(0.1)
+        assert np.min(np.linalg.eigvalsh(covariance)) > 0.0
+    assert max(amplitudes) / min(amplitudes) > 3.0
+
+
+def test_matched_candidate_keys_use_rho_not_common_alpha():
+    _nodes, kernels = candidate_kernels()
+    prepared, amplitudes = prepare_matched_candidates(kernels)
+    assert ("block", 0.0) in prepared
+    assert ("walk_decay", 0.2) in prepared
+    assert amplitudes["walk_decay@0.2"] > amplitudes["closed@0.2"]
+
+
+def test_small_v2_benchmark_is_deterministic_and_hard_gated():
+    first = run_benchmark(_args())
+    second = run_benchmark(_args(out="/different/path.json"))
+    assert first == second
+    assert not first["real_covariance_gate_unlocked"]
+    assert not first["batching_gate_unlocked"]
+    assert not first["qr_deployment_unlocked"]
+    assert len(first["scenarios"]) == 11
+
+
+def test_v2_argument_validation():
+    _validate_args(_args())
+    with pytest.raises(ValueError, match="positive"):
+        _validate_args(_args(held_fields=0))


### PR DESCRIPTION
## Summary

This PR establishes the statistical and numerical groundwork for learning item-correlation geometry before feeding it to the existing joint square-root/QR conditioner.

- Freezes the theory, candidate geometries, confidence gates, leakage rules, and an append-only record of alternatives rejected or deferred.
- Adds PSD-by-construction graph kernels: closed-neighborhood Gram, finite cumulative-walk Gram, exact heat and regularized-Laplacian references, descendant gating, role-aware pair features, convex mixtures, and Schur products.
- Adds deterministic, revision-pinned Nomic and MiniLM embedding caches, with e5 retained as the shared-input redundancy control.
- Adds two synthetic mechanism audits and an outcome-blind campaign geometry inventory.
- Documents the one-kernel structure `R = I_n ⊗ B0 + K_theta ⊗ Bg`, whose item eigenbasis reduces conditioning to `n` channel blocks. CUDA/QR timing remains gated on real covariance evidence.

## What the audits found

The original v1 comparison **failed**: using a common path amplitude did not match covariance strength across kernels. That failure is retained rather than hidden.

The frozen v2 comparison matches maximum off-item coupling. At `rho_max=0.20`, every non-deranged planted geometry passes the preregistered strong-effect gates:

- 90.5–98.5% nonzero selection;
- 86.0–97.5% predictive-equivalence selection;
- 97.0–98.5% truth-over-derangement win rate;
- positive selected held NLL gain for every non-deranged truth.

Power at `rho_max=0.10` remains mixed, so this is a mechanism result, not a real-data deployment claim. Block-null nonzero selection is 5.5%.

The outcome-blind campaign inventory found:

- the initial same-hop walk feature is nearly identity-like and does not encode adjacency well, so it is retained only as a negative control;
- cumulative walk restores the intended adjacency ordering and is the scalable graph candidate;
- Nomic/e5 distance Spearman correlation is 0.776 exploratory and 0.838 fresh;
- MiniLM/e5 is still more redundant (0.810 / 0.868);
- cumulative-walk/Nomic correlation is moderate (0.590 / 0.493), but natural disagreement cells are sparse.

Accordingly, Nomic is the primary external semantic covariate, MiniLM is a sensitivity comparator, and neither is treated as independent ground truth or as an extra independent vote.

## Safety boundary and next experiment

No judge residual or score is used by the real-data inventory. This PR does **not** unlock real structured covariance, adjacency batching, QR deployment, or CUDA performance claims.

The next gate is a purpose-built repeated-judge campaign with more than 400 independent components, at least three calls per judge family, component-disjoint calibration/evaluation, and deliberate oversampling of graph/Nomic disagreement cells. Only after simultaneous lower confidence bounds and held predictive gates pass should the selected covariance enter dense QR and the single-kernel eigenmode/CUDA comparison.

## Review hardening

- Result provenance now fingerprints every direct loader/feature dependency.
- Singular kernels report numerical rank and a clearly named positive-spectrum condition number; zero eigenvalues are not silently presented as full-matrix conditioning.
- Independent embedding manifests validate model revision, text order/content, normalization, and array hashes.

## Validation

- Focused graph-geometry suite: 34 passed.
- Full relevant inherited + new suites: **157 passed, 9 skipped**.
- Both synthetic audits and the outcome-blind inventory were rerun after the final provenance/diagnostic fixes.
- Recorded SHA-256 values are same-environment integrity checks, not cross-stack byte-reproducibility promises. NumPy/BLAS drift can move the weakest `walk_decay` result by roughly 1/200 without changing any frozen gate; cross-environment reruns should compare scientific fields and gate booleans within the report's stated precision.