### PR TITLE
EMIT-KOTLIN-3: lower deterministic multi-clause (T5/T4, no call/execute)

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -55,6 +55,8 @@ self-contained so a single coding agent can pick it up in isolation.
 | EMIT-JVM | Lowered emitter | JVM | L | — |
 | EMIT-KOTLIN ✅ | Lowered emitter | Kotlin | M | done — flat facts/unify (`cursor/emit-kotlin-lowered-f421`) |
 | EMIT-KOTLIN-2 ✅ | Lowered emitter (structures) | Kotlin | M | done — write-mode structures (`cursor/emit-kotlin-structures-f421`) |
+| EMIT-KOTLIN-3 | Multi-clause deterministic | Kotlin | M | T5 chain + T4 all-clauses-inline (no call/execute) |
+| EMIT-KOTLIN-4 | Recursion in lowered bodies | Kotlin | M | call/execute → inter-predicate / recursion |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |
 | BENCH-C | Effective-distance bench row | C | M | — |
@@ -571,6 +573,24 @@ fallback) to the three Tier-D targets. Reference small emitters:
   3. Re-add the declined `parts_supported/1` facts; keep the read-mode path (which already worked) intact.
   4. Add gradle e2e tests asserting lowered output == interpreter output for a structure builder AND a list builder (the regression tests added in EMIT-KOTLIN already assert the *decline* path; convert/extend them to assert the *lowered* path once fixed).
 - **Acceptance:** `swipl -q -g run_tests -t halt tests/test_wam_kotlin_target.pl` passes with structure/list predicates lowering (not declining) and producing bindings identical to `emit_mode(interpreter)`.
+
+### EMIT-KOTLIN-3: Deterministic multi-clause clause selection (Kotlin)
+- **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-2
+- **Status:** In progress on `cursor/emit-kotlin-multi-clause-f421` (2026-07-12).
+- **Goal:** Extend `wam_kotlin_lowered_emitter.pl` so **deterministic multi-clause** predicates whose bodies contain only unification/builtins (NO `call`/`execute`) lower to native clause selection instead of declining. Mirror Lua's T5 `clause_chain` (first-arg constant dispatch) and T4 `multi_clause_n` (all clauses inline with trail/register restore between attempts).
+- **Boundary (this card):**
+  - **Lowers:** multi-clause facts (`p(a). p(b). p(c).`), first-arg-indexed constant chains (T5), and other multi-clause deterministic bodies without inter-predicate calls (T4).
+  - **Still declines:** any clause with `call`/`execute` (member/append/reverse/fib/ack stay on the interpreter) — see **EMIT-KOTLIN-4**. ITE/soft-cut, cut, aggregates also out of scope.
+- **Native mechanics:** per clause: `snapshotForNative`, try head + body, on failure `restoreFromSnapshot` and try next; return true on first success, false if all fail (T5 unbound A1 returns false so `tryRun` falls back to the interpreter).
+- **Files to touch:** `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl`, `tests/test_wam_kotlin_target.pl`, `docs/WAM_KOTLIN_STATUS.md`, this card.
+- **Reference:** `wam_lua_lowered_emitter.pl` `build_emission_plan`/`classify_clause_shape`; shared `wam_clause_chain`.
+- **Acceptance:** multi-clause facts + T4/T5 preds LOWER under `emit_mode(functions)` and match `emit_mode(interpreter)` true/false (incl. non-matching); call/execute preds still decline; unit suite + `CONFORMANCE_TARGETS=kotlin,kotlin_functions` stay green.
+
+### EMIT-KOTLIN-4: Lower `call`/`execute` in bodies (recursion / inter-predicate)
+- **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-3
+- **Goal:** Allow lowered bodies to invoke other predicates (native or interpreter) so recursive/multi-clause programs like member/append/reverse/fib/ack can lower instead of declining.
+- **Out of scope here:** ITE/soft-cut, cut, aggregates (separate cards if needed).
+- **Acceptance:** member/append (or equivalent) LOWER under `emit_mode(functions)` and match interpreter; conformance `kotlin_functions` remains green.
 
 ---
 

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -55,7 +55,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | EMIT-JVM | Lowered emitter | JVM | L | — |
 | EMIT-KOTLIN ✅ | Lowered emitter | Kotlin | M | done — flat facts/unify (`cursor/emit-kotlin-lowered-f421`) |
 | EMIT-KOTLIN-2 ✅ | Lowered emitter (structures) | Kotlin | M | done — write-mode structures (`cursor/emit-kotlin-structures-f421`) |
-| EMIT-KOTLIN-3 | Multi-clause deterministic | Kotlin | M | T5 chain + T4 all-clauses-inline (no call/execute) |
+| EMIT-KOTLIN-3 ✅ | Multi-clause deterministic | Kotlin | M | done — T5/T4 no call/execute (`cursor/emit-kotlin-multi-clause-f421`) |
 | EMIT-KOTLIN-4 | Recursion in lowered bodies | Kotlin | M | call/execute → inter-predicate / recursion |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -30,7 +30,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | CONF-CLOJURE | Conformance adapter | Clojure | L | — |
 | CONF-LUA | Conformance adapter | Lua | M | — |
 | CONF-KOTLIN ✅ | Conformance adapter | Kotlin | M | done — opt-in (`cursor/conf-kotlin-f421`); append green, 5 xfails |
-| KT-LIST-BACKTRACK | Conformance gap fix | Kotlin | M | CONF-KOTLIN |
+| KT-LIST-BACKTRACK ✅ | Conformance gap fix | Kotlin | M | done — X heap-identity vars (`cursor/kt-list-backtrack-f421`) |
 | KT-ARITH-SLASH-FUNCTOR ✅ | Conformance gap fix | Kotlin | S | done — `///2` last-slash parse (`cursor/kt-arith-slash-functor-f421`) |
 | KT-Y-ENV-RECURSION | Conformance gap fix | Kotlin | M | CONF-KOTLIN |
 | PARSE-C | Runtime-parser entry | C | S | — |
@@ -163,6 +163,7 @@ external toolchain.
 
 ### KT-LIST-BACKTRACK: Fix list placeholder clobber under backtracking (Kotlin)
 - **Lever:** Conformance gap fix  **Target:** Kotlin  **Size:** M  **Depends on:** CONF-KOTLIN
+- **Status:** ✅ **Landed** on `cursor/kt-list-backtrack-f421` (2026-07-12; stacks on KT-ARITH-SLASH-FUNCTOR). `newVariable` for X-registers now allocates a heap identity `H<n>` (Struct/list cells hold `Var(H<n>)`); rebinding `Xn` via `unify_variable` no longer mutates already-built terms. Y-registers still use scoped names (KT-Y-ENV-RECURSION). Removed member/reverse `ct_xfail`s.
 - **Goal:** Retire `ct_xfail(kotlin, member)` / `reverse`. Heap-built lists store CDR as `Var(Xn)`; recursive clauses reuse `Xn` via `unify_variable` and overwrite the binding that shared Structs still reference.
 - **Hint:** deep-copy structs at choice points, or heap refs instead of register-named vars for structure args (same class Haskell fixed with cons-cell finalize).
 

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -32,7 +32,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | CONF-KOTLIN ✅ | Conformance adapter | Kotlin | M | done — opt-in (`cursor/conf-kotlin-f421`); append green, 5 xfails |
 | KT-LIST-BACKTRACK ✅ | Conformance gap fix | Kotlin | M | done — X heap-identity vars (`cursor/kt-list-backtrack-f421`) |
 | KT-ARITH-SLASH-FUNCTOR ✅ | Conformance gap fix | Kotlin | S | done — `///2` last-slash parse (`cursor/kt-arith-slash-functor-f421`) |
-| KT-Y-ENV-RECURSION | Conformance gap fix | Kotlin | M | CONF-KOTLIN |
+| KT-Y-ENV-RECURSION ✅ | Conformance gap fix | Kotlin | M | done — Y heap-identity vars (`cursor/kt-y-env-recursion-f421`) |
 | PARSE-C | Runtime-parser entry | C | S | — |
 | PARSE-GO | Runtime-parser entry | Go | S | — |
 | PARSE-SCALA | Runtime-parser entry | Scala | S | — |
@@ -174,6 +174,7 @@ external toolchain.
 
 ### KT-Y-ENV-RECURSION: Y-register bind-through across recursive call (Kotlin)
 - **Lever:** Conformance gap fix  **Target:** Kotlin  **Size:** M  **Depends on:** CONF-KOTLIN
+- **Status:** ✅ **Landed** on `cursor/kt-y-env-recursion-f421` (2026-07-12; stacks on KT-LIST-BACKTRACK). Extends heap-identity `newVariable` to Y-registers (drops scoped `Y@E` Var names that recursive `allocate`/`call` could miss on deref). Removed fib/ack `ct_xfail`s; **all classic programs green**, no remaining Kotlin xfails.
 - **Goal:** Retire fib/ack xfails. After recursive `call`/`execute`, `is/2` sees unbound scoped temps (`Y5@E9`) inside `+/2` trees — permanent-variable / environment bank gap.
 
 ---

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -43,16 +43,15 @@ module in the fleet.
 - **Lowered emitter scope** — deterministic single-clause only. No T4/T5
   multi-clause, ITE, or `call`/`execute` in lowered bodies (separate cards).
 - **Conformance (opt-in)** — `conformance_target(kotlin)` /
-  `kotlin_functions` registered. **append + builtins green**; member/reverse/fib/ack
-  remain `ct_xfail` (list placeholder clobber under backtrack; Y-register
-  bind-through across recursion). `///2` arith functor parse fixed
-  (KT-ARITH-SLASH-FUNCTOR).
+  `kotlin_functions` registered. **append + builtins + member + reverse green**;
+  fib/ack remain `ct_xfail` (Y-register scoped-name bind-through across
+  recursion — KT-Y-ENV-RECURSION). List CDR clobber and `///2` arith parse fixed.
 - **No foreign kernels, no LMDB / fact source, no ISO contract.**
 - **No runtime-parser capability entry.**
 
 ## Path forward
 
-1. Retire remaining kotlin `ct_xfail`s (list structure-sharing, Y-env).
+1. Retire fib/ack `ct_xfail`s (Y-env / scoped permanent vars).
 2. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
 3. Add ISO / kernels if Kotlin graduates beyond scaffold.
 
@@ -60,4 +59,5 @@ module in the fleet.
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
-(2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN + KT-ARITH-SLASH-FUNCTOR landed.
+(2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN + KT-ARITH-SLASH-FUNCTOR +
+KT-LIST-BACKTRACK landed.

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -69,5 +69,5 @@ module in the fleet.
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
 (2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN + KT-ARITH-SLASH-FUNCTOR +
-KT-LIST-BACKTRACK + KT-Y-ENV-RECURSION landed; EMIT-KOTLIN-3 in flight
-(T4/T5 multi-clause without call/execute).
+KT-LIST-BACKTRACK + KT-Y-ENV-RECURSION + EMIT-KOTLIN-3 landed
+(T4/T5 multi-clause without call/execute; EMIT-KOTLIN-4 next).

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -43,21 +43,20 @@ module in the fleet.
 - **Lowered emitter scope** — deterministic single-clause only. No T4/T5
   multi-clause, ITE, or `call`/`execute` in lowered bodies (separate cards).
 - **Conformance (opt-in)** — `conformance_target(kotlin)` /
-  `kotlin_functions` registered. **append + builtins + member + reverse green**;
-  fib/ack remain `ct_xfail` (Y-register scoped-name bind-through across
-  recursion — KT-Y-ENV-RECURSION). List CDR clobber and `///2` arith parse fixed.
+  `kotlin_functions` registered. **All classic programs green** (append,
+  member, reverse, builtins, fib, ack) — no remaining `ct_xfail`s after
+  KT-ARITH-SLASH-FUNCTOR + KT-LIST-BACKTRACK + KT-Y-ENV-RECURSION.
 - **No foreign kernels, no LMDB / fact source, no ISO contract.**
 - **No runtime-parser capability entry.**
 
 ## Path forward
 
-1. Retire fib/ack `ct_xfail`s (Y-env / scoped permanent vars).
-2. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
-3. Add ISO / kernels if Kotlin graduates beyond scaffold.
+1. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
+2. Add ISO / kernels if Kotlin graduates beyond scaffold.
 
 ## Document status
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
 (2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN + KT-ARITH-SLASH-FUNCTOR +
-KT-LIST-BACKTRACK landed.
+KT-LIST-BACKTRACK + KT-Y-ENV-RECURSION landed.

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -22,26 +22,34 @@ module in the fleet.
 | Module | Approx. lines |
 |---|---:|
 | `src/unifyweaver/targets/wam_kotlin_target.pl` | ~0.5k |
-| `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl` | ~0.3k (deterministic single-clause) |
-| Dedicated tests | ~1 file (~12 plunit cases, incl. Gradle e2e when available) |
+| `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl` | ~0.4k (T1 + T4 + T5) |
+| Dedicated tests | ~1 file (plunit + Gradle e2e when available) |
 
 ## What's shipped
 
 - **Hybrid partition** emit with a WAM fallback.
 - **Gradle e2e** hook — the test suite includes a Gradle end-to-end
   path when the toolchain is available.
-- **WAM-lowered native dispatch:** `wam_kotlin_lowered_emitter.pl` lowers
-  **deterministic single-clause** predicates — flat facts, register unification,
-  and write/read-mode structure/list construction (`get/put_structure`,
-  `get/put_list`, `set_*`, `unify_*`) — to `fun (state: WamState): Boolean`,
-  registered via `WamProgram.registerNative`. `WamRuntime.run` tries native first
-  and falls back to the bytecode interpreter on `false` (WAT-style snapshot
-  restore). `functions` / `mixed` modes route lowerable preds through this path.
+- **WAM-lowered native dispatch:** `wam_kotlin_lowered_emitter.pl` lowers:
+  - **T1** deterministic single-clause — flat facts, register unification,
+    write/read-mode structure/list construction.
+  - **T5** `clause_chain` — multi-clause with distinct first-arg
+    `get_constant` discriminators (bound A1 if-cascade; unbound A1
+    returns `false` so `tryRun` falls back to the interpreter).
+  - **T4** `multi_clause_n` — all supported deterministic clauses
+    inlined, tried in order with `snapshotForNative` /
+    `restoreFromSnapshot` between attempts.
+  Registered via `WamProgram.registerNative`. `WamRuntime.run` /
+  `tryRun` tries native first and falls back to the bytecode
+  interpreter on `false`. `functions` / `mixed` modes route lowerable
+  preds through this path.
 
 ## Gaps
 
-- **Lowered emitter scope** — deterministic single-clause only. No T4/T5
-  multi-clause, ITE, or `call`/`execute` in lowered bodies (separate cards).
+- **`call`/`execute` in lowered bodies** — still declined (member,
+  append, reverse, fib, ack stay on the interpreter). Follow-up
+  **EMIT-KOTLIN-4**.
+- **ITE/soft-cut, cut, aggregates** — not lowered.
 - **Conformance (opt-in)** — `conformance_target(kotlin)` /
   `kotlin_functions` registered. **All classic programs green** (append,
   member, reverse, builtins, fib, ack) — no remaining `ct_xfail`s after
@@ -51,12 +59,15 @@ module in the fleet.
 
 ## Path forward
 
-1. Extend lowered emitter (T4/T5/ITE) following Lua/Scala models.
-2. Add ISO / kernels if Kotlin graduates beyond scaffold.
+1. EMIT-KOTLIN-4: emit `call`/`execute` in lowered bodies (recursion /
+   inter-predicate).
+2. Optional: ITE/soft-cut lowering; ISO / kernels if Kotlin graduates
+   beyond scaffold.
 
 ## Document status
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
 (2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN + KT-ARITH-SLASH-FUNCTOR +
-KT-LIST-BACKTRACK + KT-Y-ENV-RECURSION landed.
+KT-LIST-BACKTRACK + KT-Y-ENV-RECURSION landed; EMIT-KOTLIN-3 in flight
+(T4/T5 multi-clause without call/execute).

--- a/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
@@ -9,12 +9,17 @@
 
 :- use_module(library(lists)).
 :- use_module(wam_text_parser, [wam_classify_constant_token/2]).
+:- use_module(wam_clause_chain, [clause_chain/2]).
 
-build_emission_plan(WamCode, plan(deterministic, none, ClauseLines)) :-
+% ============================================================================
+% Emission plan (T5 clause_chain → T4 multi_clause_n → T1 deterministic)
+% ============================================================================
+
+build_emission_plan(WamCode, Plan) :-
     atom_string(WamCode, S),
     split_string(S, "\n", "", Lines),
     skip_to_first_real_instr(Lines, Filtered),
-    deterministic_single_clause(Filtered, ClauseLines).
+    classify_clause_shape(Filtered, Plan).
 
 skip_to_first_real_instr([], []).
 skip_to_first_real_instr([Line|Rest], Out) :-
@@ -30,8 +35,27 @@ skippable_prefix_line(["switch_on_constant"|_]).
 skippable_prefix_line(["switch_on_constant_a2"|_]).
 skippable_prefix_line(["switch_on_structure"|_]).
 skippable_prefix_line(["switch_on_term"|_]).
+skippable_prefix_line(["switch_on_term_a2"|_]).
 
-deterministic_single_clause(Lines, Lines) :-
+% T5: distinct first-arg get_constant discriminators.
+classify_clause_shape([FirstLine|Rest],
+                     plan(clause_chain, none, chain_payload(Guards))) :-
+    wam_kotlin_target:tokenize_wam_line(FirstLine, ["try_me_else", _AltStr]),
+    kotlin_chain_terms([FirstLine|Rest], Terms),
+    clause_chain(Terms, chain(Guards)),
+    forall(member(guard(_, Rem), Guards), kotlin_chain_rem_supported(Rem)),
+    !.
+% T4: multi-clause with only supported deterministic bodies (no call/execute).
+classify_clause_shape([FirstLine|Rest], plan(multi_clause_n, none, Clauses)) :-
+    wam_kotlin_target:tokenize_wam_line(FirstLine, ["try_me_else", _AltStr]),
+    kotlin_split_clause_lines([FirstLine|Rest], Clauses),
+    Clauses = [_, _ | _],
+    forall(member(Cl, Clauses),
+           ( forall(member(Line, Cl), kotlin_t4_clause_line_supported(Line)),
+             last(Cl, LastLine), kotlin_t4_terminal_line(LastLine) )),
+    !.
+% T1: deterministic single-clause (no try_me_else / cut_ite / jump).
+classify_clause_shape(Lines, plan(deterministic, none, Lines)) :-
     \+ has_unsupported_shape(Lines),
     forall(member(Line, Lines), line_supported(Line)).
 
@@ -46,9 +70,83 @@ unsupported_shape_parts(["trust_me"]).
 unsupported_shape_parts(["cut_ite"]).
 unsupported_shape_parts(["jump"|_]).
 
-wam_kotlin_lowerable(_PI, WamCode, deterministic) :-
-    catch(build_emission_plan(WamCode, plan(deterministic, _, Payload)), _, fail),
-    forall(member(Line, Payload), line_supported(Line)).
+% --- T5 chain term parse -------------------------------------------------
+kotlin_chain_terms([], []).
+kotlin_chain_terms([Line|Rest], Terms) :-
+    wam_kotlin_target:tokenize_wam_line(Line, Parts),
+    (   Parts == []
+    ->  kotlin_chain_terms(Rest, Terms)
+    ;   Parts = [First|_], sub_string(First, _, 1, 0, ":")
+    ->  kotlin_chain_terms(Rest, Terms)
+    ;   kotlin_chain_term(Parts, T),
+        Terms = [T|More],
+        kotlin_chain_terms(Rest, More)
+    ).
+
+kotlin_chain_term(["try_me_else", L], try_me_else(L)) :- !.
+kotlin_chain_term(["retry_me_else", L], retry_me_else(L)) :- !.
+kotlin_chain_term(["trust_me"], trust_me) :- !.
+kotlin_chain_term(["get_constant", V, A], get_constant(V, A)) :- !.
+kotlin_chain_term(Parts, line(Parts)).
+
+kotlin_chain_rem_supported([]).
+kotlin_chain_rem_supported([T|Rest]) :-
+    (   T = get_constant(_, _)
+    ->  true
+    ;   T = line(Parts)
+    ->  parts_supported(Parts)
+    ),
+    kotlin_chain_rem_supported(Rest).
+
+% --- T4 clause splitting -------------------------------------------------
+kotlin_split_clause_lines(AllLines, Clauses) :-
+    include(kotlin_t4_instr_line, AllLines, InstrLines),
+    kotlin_split_at_terminal(InstrLines, Clauses).
+
+kotlin_t4_instr_line(Line) :-
+    wam_kotlin_target:tokenize_wam_line(Line, Parts),
+    Parts \== [],
+    Parts = [F|_],
+    \+ sub_string(F, _, 1, 0, ":"),
+    \+ member(F, ["try_me_else", "retry_me_else", "trust_me",
+                  "switch_on_constant", "switch_on_constant_a2",
+                  "switch_on_structure", "switch_on_term",
+                  "switch_on_term_a2"]).
+
+kotlin_split_at_terminal([], []).
+kotlin_split_at_terminal([L|Ls], [Clause|Rest]) :-
+    kotlin_take_to_terminal([L|Ls], Clause, After),
+    ( After == [] -> Rest = [] ; kotlin_split_at_terminal(After, Rest) ).
+
+kotlin_take_to_terminal([Line|Rest], [Line], Rest) :-
+    wam_kotlin_target:tokenize_wam_line(Line, Parts),
+    ( Parts == ["proceed"] ; Parts == ["fail"] ), !.
+kotlin_take_to_terminal([Line|Rest], [Line|More], After) :-
+    kotlin_take_to_terminal(Rest, More, After).
+kotlin_take_to_terminal([], [], []).
+
+kotlin_t4_clause_line_supported(Line) :-
+    wam_kotlin_target:tokenize_wam_line(Line, Parts),
+    ( Parts == [] -> true ; parts_supported(Parts) ),
+    Parts \= ["cut_ite"|_],
+    Parts \= ["jump"|_],
+    \+ (Parts = ["call"|_]),
+    \+ (Parts = ["execute"|_]).
+
+kotlin_t4_terminal_line(Line) :-
+    wam_kotlin_target:tokenize_wam_line(Line, Parts),
+    ( Parts == ["proceed"] ; Parts == ["fail"] ).
+
+wam_kotlin_lowerable(_PI, WamCode, Reason) :-
+    catch(build_emission_plan(WamCode, plan(Reason, _, Payload)), _, fail),
+    (   Reason == clause_chain
+    ->  Payload = chain_payload(Guards),
+        forall(member(guard(_, Rem), Guards), kotlin_chain_rem_supported(Rem))
+    ;   Reason == multi_clause_n
+    ->  forall(member(Cl, Payload),
+               forall(member(Line, Cl), line_supported(Line)))
+    ;   forall(member(Line, Payload), line_supported(Line))
+    ).
 
 line_supported(Line) :-
     wam_kotlin_target:tokenize_wam_line(Line, Parts),
@@ -59,8 +157,8 @@ line_supported(Line) :-
     ;   parts_supported(Parts)
     ).
 
-% Structure/list + unify/set ops are lowerable. get_variable/put_variable must
-% emit `run { ... }` (not a bare block) — see emit_line_parts/2 note.
+% Structure/list + unify/set ops are lowerable. NO call/execute (EMIT-KOTLIN-4).
+% get_variable/put_variable must emit `run { ... }` — see emit_line_parts/2.
 parts_supported(["allocate"]).
 parts_supported(["deallocate"]).
 parts_supported(["proceed"]).
@@ -104,11 +202,17 @@ lower_predicate_to_kotlin(PI, WamCode, _Options, lowered(PredName, FuncName, Cod
     (PI = _M:Pred/Arity -> true ; PI = Pred/Arity),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
     kotlin_lowered_func_name(Pred/Arity, FuncName),
-    build_emission_plan(WamCode, plan(deterministic, _, Payload)),
-    emit_deterministic_function(PredName, FuncName, Payload, Code).
+    build_emission_plan(WamCode, plan(Mode, _, Payload)),
+    (   Mode == clause_chain
+    ->  Payload = chain_payload(Guards),
+        emit_clause_chain_function(PredName, FuncName, Guards, Code)
+    ;   Mode == multi_clause_n
+    ->  emit_multi_clause_n_function(PredName, FuncName, Payload, Code)
+    ;   emit_deterministic_function(PredName, FuncName, Payload, Code)
+    ).
 
 emit_deterministic_function(PredName, FuncName, Lines, Code) :-
-    with_output_to(string(Body), emit_lines(Lines, "    ")),
+    with_output_to(string(Body), emit_lines(Lines, "    ", comment)),
     format(string(Code),
 '// Lowered: ~w (deterministic single-clause)
 fun ~w(state: WamState): Boolean {
@@ -116,14 +220,72 @@ fun ~w(state: WamState): Boolean {
 }
 ', [PredName, FuncName, Body]).
 
-emit_lines([], _).
-emit_lines([Line|Rest], Ind) :-
+% T4: try each clause as a local fun; restore snapshot between attempts.
+emit_multi_clause_n_function(PredName, FuncName, Clauses, Code) :-
+    with_output_to(string(Body), emit_kotlin_t4_clauses(Clauses, 0)),
+    format(string(Code),
+'// Lowered: ~w (T4 all-clauses inline)
+fun ~w(state: WamState): Boolean {
+    val _t4 = state.snapshotForNative()
+~w    return false
+}
+', [PredName, FuncName, Body]).
+
+emit_kotlin_t4_clauses([], _).
+emit_kotlin_t4_clauses([Clause|Rest], N) :-
+    N1 is N + 1,
+    format(atom(CName), 'clause_~w', [N1]),
+    format("    fun ~w(): Boolean {~n", [CName]),
+    % proceed → return true; fail → return false (via emit_line_parts).
+    emit_lines(Clause, "        ", return_true),
+    format("    }~n", []),
+    format("    if (~w()) return true~n", [CName]),
+    format("    state.restoreFromSnapshot(_t4)~n", []),
+    emit_kotlin_t4_clauses(Rest, N1).
+
+% T5: bound first-arg if-cascade; unbound → false (tryRun → interpreter).
+emit_clause_chain_function(PredName, FuncName, Guards, Code) :-
+    with_output_to(string(Dispatch), emit_kotlin_t5_guards(Guards)),
+    format(string(Code),
+'// Lowered: ~w (T5 first-argument dispatch)
+fun ~w(state: WamState): Boolean {
+    val t5a1 = state.deref(state.readRegister("A1"))
+    if (t5a1 is Value.Var) return false
+~w    return false
+}
+', [PredName, FuncName, Dispatch]).
+
+emit_kotlin_t5_guards([]).
+emit_kotlin_t5_guards([guard(V, Rem)|Rest]) :-
+    kotlin_constant_expr(V, Expr),
+    format("    if (t5a1 == ~w) {~n", [Expr]),
+    emit_kotlin_t5_rem(Rem, "        "),
+    format("        return true~n", []),
+    format("    }~n", []),
+    emit_kotlin_t5_guards(Rest).
+
+emit_kotlin_t5_rem([], _).
+emit_kotlin_t5_rem([get_constant(C, R)|Rest], Ind) :- !,
+    emit_line_parts(["get_constant", C, R], Ind),
+    emit_kotlin_t5_rem(Rest, Ind).
+emit_kotlin_t5_rem([line(Parts)|Rest], Ind) :- !,
+    (   Parts == ["proceed"]
+    ->  true
+    ;   emit_line_parts(Parts, Ind)
+    ),
+    emit_kotlin_t5_rem(Rest, Ind).
+
+% ProceedMode = comment | return_true
+emit_lines([], _, _).
+emit_lines([Line|Rest], Ind, ProceedMode) :-
     wam_kotlin_target:tokenize_wam_line(Line, Parts),
     (   Parts == [] -> true
     ;   Parts = [F|_], sub_string(F, _, 1, 0, ":") -> true
+    ;   Parts == ["proceed"], ProceedMode == return_true
+    ->  format("~wreturn true~n", [Ind])
     ;   emit_line_parts(Parts, Ind)
     ),
-    emit_lines(Rest, Ind).
+    emit_lines(Rest, Ind, ProceedMode).
 
 emit_line_parts(["proceed"], I) :- !, format("~w// proceed~n", [I]).
 emit_line_parts(["fail"], I) :- !, format("~wreturn false~n", [I]).

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -94,15 +94,13 @@ class WamState(
     }
 
     fun newVariable(register: String): Value.Var {
-        // X registers: heap identity (KT-LIST-BACKTRACK). Y registers: keep
-        // scoped names for now (KT-Y-ENV-RECURSION handles those separately).
-        if (isEnvironmentRegister(register)) {
-            val scopedName = scopedRegisterName(register)
-            val value = Value.Var(scopedName)
-            writeRegister(register, value)
-            if (scopedName != register) writeRegister(scopedName, value)
-            return value
-        }
+        // Heap identity independent of the register name (Xn or Yn).
+        // Structure/list cells and arithmetic trees store this Var; later
+        // unify_variable/writeRegister on the register must not clobber
+        // already-built terms, and bindings must survive recursive
+        // call/execute across allocate frames (KT-LIST-BACKTRACK +
+        // KT-Y-ENV-RECURSION). Scoped Y@E names lived in environment
+        // slots that recursive allocate/call could miss on deref.
         val heapName = "H${nextHeapVarId++}"
         val value = Value.Var(heapName)
         registers[heapName] = value

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -67,6 +67,7 @@ class WamState(
     val environmentStack: MutableList<EnvironmentFrame> = mutableListOf(),
     var context: WamContext? = null,
     private var nextEnvironmentId: Int = 0,
+    private var nextHeapVarId: Int = 0,
 ) {
     fun isEnvironmentRegister(register: String): Boolean =
         register.startsWith("Y")
@@ -93,10 +94,19 @@ class WamState(
     }
 
     fun newVariable(register: String): Value.Var {
-        val scopedName = scopedRegisterName(register)
-        val value = Value.Var(scopedName)
+        // X registers: heap identity (KT-LIST-BACKTRACK). Y registers: keep
+        // scoped names for now (KT-Y-ENV-RECURSION handles those separately).
+        if (isEnvironmentRegister(register)) {
+            val scopedName = scopedRegisterName(register)
+            val value = Value.Var(scopedName)
+            writeRegister(register, value)
+            if (scopedName != register) writeRegister(scopedName, value)
+            return value
+        }
+        val heapName = "H${nextHeapVarId++}"
+        val value = Value.Var(heapName)
+        registers[heapName] = value
         writeRegister(register, value)
-        if (scopedName != register) writeRegister(scopedName, value)
         return value
     }
 

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -279,22 +279,14 @@ ct_default_target(elixir).
 %  the skips are removed.
 
 %  Kotlin (CONF-KOTLIN, 2026-07-12). Adapter registered (opt-in). append/3
-%  is GREEN. Remaining classic programs xfail on measured interpreter gaps
-%  (not adapter bugs) — follow-ups tracked in WAM_FLEET_GAP_TASKS.md:
-%   - member/reverse: heap-built list CDRs are Var(Xn) placeholders; later
-%     unify_variable Xn in a recursive clause overwrites that register and
-%     corrupts the shared Struct under backtracking (b/c in [a,b,c] → false).
-%   - builtins: FIXED in KT-ARITH-SLASH-FUNCTOR — evalArith now strips only
-%     the trailing /<digits> so '///2' → name "//".
-%   - fib/ack: permanent Y-registers use scoped names (Y5@E9); after recursive
-%     call, is/2 sees unbound scoped vars in the +/2 tree (environment /
-%     bind-through gap across call/execute).
-ct_xfail(kotlin, member).
-ct_xfail(kotlin, reverse).
+%  + builtins green. Remaining xfails:
+%   - member/reverse: FIXED in KT-LIST-BACKTRACK — X-register structure
+%     placeholders now use heap identities (H<n>), not Var("Xn").
+%   - fib/ack: permanent Y-registers still use scoped names (Y5@E9); after
+%     recursive call, is/2 sees unbound scoped vars in the +/2 tree
+%     (KT-Y-ENV-RECURSION).
 ct_xfail(kotlin, fib).
 ct_xfail(kotlin, ack).
-ct_xfail(kotlin_functions, member).
-ct_xfail(kotlin_functions, reverse).
 ct_xfail(kotlin_functions, fib).
 ct_xfail(kotlin_functions, ack).
 

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -278,17 +278,9 @@ ct_default_target(elixir).
 %  is now recursive and cons-aware ($unify_addrs). Both are conformant;
 %  the skips are removed.
 
-%  Kotlin (CONF-KOTLIN, 2026-07-12). Adapter registered (opt-in). append/3
-%  + builtins green. Remaining xfails:
-%   - member/reverse: FIXED in KT-LIST-BACKTRACK — X-register structure
-%     placeholders now use heap identities (H<n>), not Var("Xn").
-%   - fib/ack: permanent Y-registers still use scoped names (Y5@E9); after
-%     recursive call, is/2 sees unbound scoped vars in the +/2 tree
-%     (KT-Y-ENV-RECURSION).
-ct_xfail(kotlin, fib).
-ct_xfail(kotlin, ack).
-ct_xfail(kotlin_functions, fib).
-ct_xfail(kotlin_functions, ack).
+%  Kotlin (CONF-KOTLIN, 2026-07-12). Adapter registered (opt-in). All classic
+%  programs green after KT-ARITH-SLASH-FUNCTOR + KT-LIST-BACKTRACK +
+%  KT-Y-ENV-RECURSION (no remaining kotlin ct_xfail entries).
 
 % ============================================================
 % Toolchain probes

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -24,6 +24,9 @@
 :- dynamic kt_mem_b/0.
 :- dynamic kt_mem_c/0.
 :- dynamic kt_mem_z/0.
+:- dynamic kt_fib/2.
+:- dynamic kt_fib_ok/0.
+:- dynamic kt_fib_bad/0.
 
 :- begin_tests(wam_kotlin_target).
 
@@ -486,6 +489,41 @@ test(list_backtrack_member, [condition(gradle_available), nondet]) :-
             retractall(user:kt_mem_b),
             retractall(user:kt_mem_c),
             retractall(user:kt_mem_z)
+        )
+    ).
+
+% KT-Y-ENV-RECURSION: recursive arithmetic must see Y-register bindings
+% after call returns (heap-identity vars, not scoped Y@E names).
+test(y_env_recursion_fib, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_y_env_fib',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt_fib(_, _)),
+            retractall(user:kt_fib_ok),
+            retractall(user:kt_fib_bad),
+            assertz(user:kt_fib(0, 0)),
+            assertz(user:kt_fib(1, 1)),
+            assertz(user:(kt_fib(N, R) :- N > 1, N1 is N - 1, N2 is N - 2,
+                kt_fib(N1, R1), kt_fib(N2, R2), R is R1 + R2)),
+            assertz(user:(kt_fib_ok :- kt_fib(10, 55))),
+            assertz(user:(kt_fib_bad :- kt_fib(10, 54)))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt_fib_ok/0, user:kt_fib_bad/0, user:kt_fib/2],
+                [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_fib_ok/0'], OkOut, _OkErr, OkStatus),
+            assertion(OkStatus == exit(0)),
+            normalize_space(string(OkTrim), OkOut),
+            assertion(OkTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_fib_bad/0'], BadOut, _BadErr, BadStatus),
+            assertion(BadStatus == exit(0)),
+            normalize_space(string(BadTrim), BadOut),
+            assertion(BadTrim == "false")
+        ),
+        (   retractall(user:kt_fib(_, _)),
+            retractall(user:kt_fib_ok),
+            retractall(user:kt_fib_bad)
         )
     ).
 

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -27,6 +27,10 @@
 :- dynamic kt_fib/2.
 :- dynamic kt_fib_ok/0.
 :- dynamic kt_fib_bad/0.
+:- dynamic kt3_color/1.
+:- dynamic kt3_pair/2.
+:- dynamic kt3_t4/2.
+:- dynamic kt3_mem/2.
 
 :- begin_tests(wam_kotlin_target).
 
@@ -525,6 +529,149 @@ test(y_env_recursion_fib, [condition(gradle_available), nondet]) :-
             retractall(user:kt_fib_ok),
             retractall(user:kt_fib_bad)
         )
+    ).
+
+% EMIT-KOTLIN-3: deterministic multi-clause (no call/execute) lowers;
+% recursion still declines.
+test(functions_mode_multi_clause_partition, [nondet]) :-
+    setup_call_cleanup(
+        (   retractall(user:kt3_color(_)),
+            retractall(user:kt3_pair(_, _)),
+            retractall(user:kt3_t4(_, _)),
+            retractall(user:kt3_mem(_, _)),
+            assertz(user:kt3_color(a)),
+            assertz(user:kt3_color(b)),
+            assertz(user:kt3_color(c)),
+            assertz(user:kt3_pair(a, 1)),
+            assertz(user:kt3_pair(b, 2)),
+            assertz(user:kt3_t4(_, a)),
+            assertz(user:kt3_t4(_, b)),
+            assertz(user:(kt3_mem(X, [X|_]))),
+            assertz(user:(kt3_mem(X, [_|T]) :- kt3_mem(X, T)))
+        ),
+        (   wam_kotlin_partition_predicates(functions,
+                [user:kt3_color/1, user:kt3_pair/2, user:kt3_t4/2, user:kt3_mem/2],
+                Native, Wam, Failed),
+            assertion(Failed == []),
+            assertion(memberchk(native(kt3_color/1, _), Native)),
+            assertion(memberchk(native(kt3_pair/2, _), Native)),
+            assertion(memberchk(native(kt3_t4/2, _), Native)),
+            assertion(\+ memberchk(native(kt3_mem/2, _), Native)),
+            assertion(memberchk(wam(kt3_mem/2, _), Wam)),
+            memberchk(native(kt3_color/1, lowered(_, _, ColorCode)), Native),
+            assertion(has_substring(ColorCode, 'T5 first-argument dispatch')),
+            assertion(has_substring(ColorCode, 'Value.Atom("a")')),
+            memberchk(native(kt3_t4/2, lowered(_, _, T4Code)), Native),
+            assertion(has_substring(T4Code, 'T4 all-clauses inline')),
+            assertion(has_substring(T4Code, 'snapshotForNative')),
+            assertion(has_substring(T4Code, 'restoreFromSnapshot'))
+        ),
+        (   retractall(user:kt3_color(_)),
+            retractall(user:kt3_pair(_, _)),
+            retractall(user:kt3_t4(_, _)),
+            retractall(user:kt3_mem(_, _))
+        )
+    ).
+
+% EMIT-KOTLIN-3: multi-clause facts (T5) — functions == interpreter.
+test(functions_mode_gradle_multi_clause_facts, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_multi_clause_facts',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt3_color(_)),
+            assertz(user:kt3_color(a)),
+            assertz(user:kt3_color(b)),
+            assertz(user:kt3_color(c))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt3_color/1],
+                [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_color/1 a'], IA, _E1, S1),
+            assertion(S1 == exit(0)),
+            normalize_space(string(IATrim), IA),
+            assertion(IATrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_color/1 z'], IZ, _E2, S2),
+            assertion(S2 == exit(0)),
+            normalize_space(string(IZTrim), IZ),
+            assertion(IZTrim == "false"),
+            wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt3_color/1],
+                [emit_mode(functions), conformance_main(true)], TmpDir),
+            read_file_to_string(
+                'output/test_wam_kotlin_multi_clause_facts/src/main/kotlin/generated/wam/Main.kt',
+                Main, []),
+            assertion(has_substring(Main, 'fun lowered_kt3_color_1')),
+            assertion(has_substring(Main, 'registerNative("kt3_color/1"')),
+            assertion(has_substring(Main, 'T5 first-argument dispatch')),
+            run_gradle(TmpDir, ['-q', 'compileKotlin'], _CO, _CE, CS),
+            assertion(CS == exit(0)),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_color/1 a'], FA, _E3, S3),
+            assertion(S3 == exit(0)),
+            normalize_space(string(FATrim), FA),
+            assertion(FATrim == IATrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_color/1 z'], FZ, _E4, S4),
+            assertion(S4 == exit(0)),
+            normalize_space(string(FZTrim), FZ),
+            assertion(FZTrim == IZTrim),
+            % Unbound A1: T5 returns false → tryRun falls back to interpreter.
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_color/1'], FU, _E5, S5),
+            assertion(S5 == exit(0)),
+            normalize_space(string(FUTrim), FU),
+            assertion(FUTrim == "true")
+        ),
+        retractall(user:kt3_color(_))
+    ).
+
+% EMIT-KOTLIN-3: T4 all-clauses-inline (non-first-arg-constant chain).
+test(functions_mode_gradle_multi_clause_t4, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_multi_clause_t4',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt3_t4(_, _)),
+            assertz(user:kt3_t4(_, a)),
+            assertz(user:kt3_t4(_, b))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt3_t4/2],
+                [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_t4/2 x a'], IA, _E1, S1),
+            assertion(S1 == exit(0)),
+            normalize_space(string(IATrim), IA),
+            assertion(IATrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_t4/2 x b'], IB, _E2, S2),
+            assertion(S2 == exit(0)),
+            normalize_space(string(IBTrim), IB),
+            assertion(IBTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_t4/2 x z'], IZ, _E3, S3),
+            assertion(S3 == exit(0)),
+            normalize_space(string(IZTrim), IZ),
+            assertion(IZTrim == "false"),
+            wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt3_t4/2],
+                [emit_mode(functions), conformance_main(true)], TmpDir),
+            read_file_to_string(
+                'output/test_wam_kotlin_multi_clause_t4/src/main/kotlin/generated/wam/Main.kt',
+                Main, []),
+            assertion(has_substring(Main, 'T4 all-clauses inline')),
+            assertion(has_substring(Main, 'registerNative("kt3_t4/2"')),
+            run_gradle(TmpDir, ['-q', 'compileKotlin'], _CO, _CE, CS),
+            assertion(CS == exit(0)),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_t4/2 x a'], FA, _E4, S4),
+            assertion(S4 == exit(0)),
+            normalize_space(string(FATrim), FA),
+            assertion(FATrim == IATrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_t4/2 x b'], FB, _E5, S5),
+            assertion(S5 == exit(0)),
+            normalize_space(string(FBTrim), FB),
+            assertion(FBTrim == IBTrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt3_t4/2 x z'], FZ, _E6, S6),
+            assertion(S6 == exit(0)),
+            normalize_space(string(FZTrim), FZ),
+            assertion(FZTrim == IZTrim)
+        ),
+        retractall(user:kt3_t4(_, _))
     ).
 
 :- end_tests(wam_kotlin_target).

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -20,6 +20,10 @@
 :- dynamic kt_two_step/2.
 :- dynamic kt_chain/2.
 :- dynamic kt_arith/1.
+:- dynamic kt_member/2.
+:- dynamic kt_mem_b/0.
+:- dynamic kt_mem_c/0.
+:- dynamic kt_mem_z/0.
 
 :- begin_tests(wam_kotlin_target).
 
@@ -442,6 +446,47 @@ test(arith_slash_functor_integer_div, [condition(gradle_available), nondet]) :-
             assertion(BadTrim == "false")
         ),
         retractall(user:kt_arith(_, _))
+    ).
+
+% KT-LIST-BACKTRACK: recursive member must survive backtracking over a
+% heap-built list (CDR placeholders must not share the unify_variable Xn
+% register name).
+test(list_backtrack_member, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_list_backtrack',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt_member(_, _)),
+            retractall(user:kt_mem_b),
+            retractall(user:kt_mem_c),
+            retractall(user:kt_mem_z),
+            assertz(user:kt_member(X, [X|_])),
+            assertz(user:(kt_member(X, [_|T]) :- kt_member(X, T))),
+            assertz(user:(kt_mem_b :- kt_member(b, [a,b,c]))),
+            assertz(user:(kt_mem_c :- kt_member(c, [a,b,c]))),
+            assertz(user:(kt_mem_z :- kt_member(z, [a,b,c])))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt_mem_b/0, user:kt_mem_c/0, user:kt_mem_z/0, user:kt_member/2],
+                [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_mem_b/0'], BOut, _BErr, BStatus),
+            assertion(BStatus == exit(0)),
+            normalize_space(string(BTrim), BOut),
+            assertion(BTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_mem_c/0'], COut, _CErr, CStatus),
+            assertion(CStatus == exit(0)),
+            normalize_space(string(CTrim), COut),
+            assertion(CTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_mem_z/0'], ZOut, _ZErr, ZStatus),
+            assertion(ZStatus == exit(0)),
+            normalize_space(string(ZTrim), ZOut),
+            assertion(ZTrim == "false")
+        ),
+        (   retractall(user:kt_member(_, _)),
+            retractall(user:kt_mem_b),
+            retractall(user:kt_mem_c),
+            retractall(user:kt_mem_z)
+        )
     ).
 
 :- end_tests(wam_kotlin_target).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the Kotlin hybrid WAM lowered emitter to deterministic **multi-clause** predicates whose bodies contain only unification/builtins — no `call`/`execute` (recursion is **EMIT-KOTLIN-4**).

### What lowers now
- **T5 `clause_chain`:** distinct first-arg `get_constant` discriminators → bound A1 if-cascade; unbound A1 returns `false` so `tryRun` falls back to the interpreter.
- **T4 `multi_clause_n`:** all supported deterministic clauses inlined; `snapshotForNative` / `restoreFromSnapshot` between attempts.

### Still declines
- Any clause with `call`/`execute` (member/append/reverse/fib/ack stay on the interpreter).
- ITE/soft-cut, cut, aggregates.

### Tests / docs
- Partition + gradle differential regressions in `tests/test_wam_kotlin_target.pl`.
- Cards **EMIT-KOTLIN-3** / **EMIT-KOTLIN-4** in `docs/WAM_FLEET_GAP_TASKS.md`; boundary updated in `docs/WAM_KOTLIN_STATUS.md`.

### Verification (green)
```bash
LANG=C.UTF-8 swipl -q -g run_tests -t halt tests/test_wam_kotlin_target.pl
# 22 passed (incl. multi-clause partition + gradle T5/T4 differentials)

LANG=C.UTF-8 CONFORMANCE_TARGETS=kotlin,kotlin_functions swipl -q -g run_tests -t halt tests/test_wam_cross_target_conformance.pl
# kotlin + kotlin_functions passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

