### PR TITLE
WAM/LLVM plawk: cache-backed shared table in multi-pass (phase 3, durable inter-pass channel)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -19,10 +19,13 @@ no assoc table at all and passes coordinate only through scalar globals;
 and arithmetic in prints (`$2 / total`) evaluated in f64 (the surface `/`
 is integer, so a print expression is promoted to double and printed with
 `%g`). Together the last two complete **grand-total normalise**
-(`pass { total += $2 } pass { print $1, $2 / total }`). **Not yet:**
-configurable readers (phase 4); the query reader (phase 6);
-namespaces / `eager` / secondary indexes; string-literal print fields. See
-the per-phase status tags in §5.
+(`pass { total += $2 } pass { print $1, $2 / total }`); and the cache as the
+inter-pass channel (phase 3): a `BEGIN cache("path") { declare NAME }` table
+shared by the passes is loaded before pass 1 and committed after the last
+pass, so it is both the in-memory channel between passes and durable across
+runs (file and LMDB backends). **Not yet:** configurable readers (phase 4);
+the query reader (phase 6); namespaces / `eager` / secondary indexes;
+string-literal print fields. See the per-phase status tags in §5.
 
 ## Implemented surface (quick reference)
 
@@ -54,9 +57,11 @@ an assoc program is supported — a `print` in the record loop with a text
 field `$N` or a table lookup `arr[$N]` — which is what makes pass-2 emit one
 line per record from pass-1's table. It requires a **file** argument (each
 pass re-opens it; stdin is not re-openable), a single shared table, and
-always-rule pass bodies. Combining a cache-backed table with multi-pass,
-cross-pass *scalars*, string-literal print fields, multiple tables, and
-reader selection are follow-ons.
+always-rule pass bodies. A **cache-backed** shared table (`BEGIN
+cache("path") { declare NAME }`) now works with multi-pass too (phase 3):
+loaded before pass 1, committed after the last pass, durable across runs.
+String-literal print fields, multiple tables, and reader selection are
+follow-ons.
 
 ## TL;DR
 
@@ -483,15 +488,29 @@ single-pass test before any driver surgery).
   `@wam_atom_field_f64_value`, a scalar via `load`+`sitofp`, an int constant
   via `sitofp`) and prints with `%g`. Grand-total normalise
   (`pass { total += $2 } pass { print $1, $2 / total }`) now works with no
-  assoc table at all. **Deferred:** multiple tables, arithmetic operands
-  that are table lookups, and pairing multi-pass with a cache-backed /
-  `BEGIN`-declared table.
+  assoc table at all. **Deferred:** multiple tables, and arithmetic operands
+  that are table lookups.
 
-- **Phase 3 — cache as the inter-pass channel (durable payoff).** Combine
-  1+2: a table declared in a `BEGIN cache("db")` block written in pass 1 and
-  read in pass 2, with the commit barrier between passes; plus the
-  one-store-per-block and load-on-open rules. Also introduce the name
-  resolution surface: `as ns` namespaces a store (tables `ns.table`,
+- **Phase 3 — cache as the inter-pass channel (durable payoff). LANDED
+  (v1).** A table declared in a `BEGIN cache("path") { declare NAME }` block
+  and shared by the passes is loaded from its store before pass 1 and
+  committed after the last pass — so the same table is both the in-memory
+  channel between passes and durable between separate runs of the binary;
+  re-running loads the prior committed state and accumulates onto it. Wired
+  into both multi-pass driver shapes (no-END normalise and END for-in) by
+  reusing the single-pass cache machinery (`plawk_program_cache_tables` /
+  `plawk_cache_entries` / the cache-aware `plawk_assoc_entry_setup_ir/3` /
+  `plawk_cache_commit_lines`); the passes themselves are unchanged (they
+  already reference the shared table). Works for the file backend and, when
+  liblmdb is present, `backend "lmdb"` (`bin/plawk` links the C runtime and
+  `-llmdb` for a multi-pass program too). Verified: a cache-backed per-key
+  sum / histogram persists and accumulates across runs
+  (`tests/test_plawk_multipass_cache.pl`). **Deferred:** the commit *barrier*
+  between passes (v1 commits once, after the last pass — the in-memory table
+  IS the live channel between passes, so an intermediate commit is only
+  needed for cross-process coordination); the name resolution surface below;
+  and one-store-per-block with multiple stores. Follow-on: `as ns`
+  namespaces a store (tables `ns.table`,
   mapping to LMDB named sub-databases), no-alias blocks stay global, and
   `global` lifts a namespaced table to bare. Test: `total[$1] += $2` in
   pass 1; `print $1, $2 / total[$1]` in pass 2, verifying pass 2 sees

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -232,6 +232,10 @@ plawk_program_uses_lmdb_cache(program(BeginClauses, _, _)) :-
     member(begin(Actions), BeginClauses),
     member(cache_table(_Name, _Path, lmdb), Actions),
     !.
+plawk_program_uses_lmdb_cache(program_passes(BeginClauses, _, _)) :-
+    member(begin(Actions), BeginClauses),
+    member(cache_table(_Name, _Path, lmdb), Actions),
+    !.
 
 % The C LMDB runtime ships beside wam_llvm_target.pl.
 lmdb_c_runtime_file(CFile) :-

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3698,6 +3698,11 @@ plawk_program_multipass_driver_ir(
     plawk_forin_end_plan(AllRules, LoopVar, ArrayName, [print(PrintFields)],
         AssocPlan, PrintFields),
     AssocPlan = assoc_plan([ArrayName], _),  % v1: one shared table
+    % A `BEGIN cache("path") { declare NAME }` table shared by the passes:
+    % load the store into the shared table before pass 1, commit it after the
+    % last pass. Non-cache programs get [] and behave exactly as before.
+    plawk_program_cache_tables(BeginClauses, CacheTriples),
+    plawk_cache_entries([ArrayName], CacheTriples, CacheEntries, CachePathGlobals),
     % Per-pass RecordIR (rule chain) against the single shared table.
     findall(GlobalIR-ChainIR,
         ( member(pass(PassRules), Passes),
@@ -3723,15 +3728,18 @@ plawk_program_multipass_driver_ir(
               '  call void @plawk_pass_~w(%Value %mp_path~w)', [I, TableArgsIR]) ),
         CallLines),
     atomic_list_concat(CallLines, '\n', CallsIR),
-    % Setup (create the shared table), BEGIN, and the END for-in print.
-    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    % Setup (create + load the shared table), BEGIN, and the END for-in print.
+    plawk_assoc_entry_setup_ir(AssocPlan, CacheEntries, EntrySetupIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
+    plawk_cache_commit_lines(CacheEntries, CommitIR),
     plawk_forin_end_print_ir(LoopVar, ArrayName, PrintFields, AssocPlan,
-        FieldSeparator, OutputSeparator, EndPrintIR),
-    % Module globals: the chains' string/format globals, deduplicated.
+        FieldSeparator, OutputSeparator, EndPrintIR0),
+    atomic_list_concat([CommitIR, EndPrintIR0], '\n', EndPrintIR),
+    % Module globals: the chains' string/format globals + cache path globals.
     sort(ChainGlobals, ChainGlobalsSorted),
-    atomic_list_concat(ChainGlobalsSorted, '\n', ChainGlobalsIR),
+    atomic_list_concat(ChainGlobalsSorted, '\n', ChainGlobalsIR0),
+    atomic_list_concat([ChainGlobalsIR0, CachePathGlobals], '\n', ChainGlobalsIR),
     plawk_i64_end_print_globals(ChainGlobalsIR, RuntimeGlobals),
     format(atom(DriverIR),
 '@.wam_stream_eof = private constant [12 x i8] c"end_of_file\\00"
@@ -3779,6 +3787,10 @@ plawk_program_multipass_driver_ir(
     findall(R, ( member(pass(PassRules), Passes), member(R, PassRules) ), AllRules),
     plawk_multipass_pass_plan(AllRules, Tables, AssocPlan),  % validates surface
     plawk_multipass_table_params(Tables, TableParamsIR, TableArgsIR),
+    % A `BEGIN cache(...)`-declared shared table: load before pass 1, commit
+    % after the last pass. Empty for pure-scalar / non-cache programs.
+    plawk_program_cache_tables(BeginClauses, CacheTriples),
+    plawk_cache_entries(Tables, CacheTriples, CacheEntries, CachePathGlobals),
     findall(GlobalIR-ChainIR,
         ( member(pass(PassRules), Passes),
           plawk_multipass_pass_plan(PassRules, Tables, PassPlan),
@@ -3800,14 +3812,16 @@ plawk_program_multipass_driver_ir(
         CallLines),
     atomic_list_concat(CallLines, '\n', CallsIR),
     plawk_output_separator(BeginClauses, OutputSeparator),
-    plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
+    plawk_assoc_entry_setup_ir(AssocPlan, CacheEntries, EntrySetupIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
     sort(ChainGlobals, ChainGlobalsSorted),
-    atomic_list_concat(ChainGlobalsSorted, '\n', ChainGlobalsIR),
+    atomic_list_concat(ChainGlobalsSorted, '\n', ChainGlobalsIR0),
+    atomic_list_concat([ChainGlobalsIR0, CachePathGlobals], '\n', ChainGlobalsIR),
     plawk_i64_end_print_globals(ChainGlobalsIR, RuntimeGlobals),
+    plawk_cache_commit_lines(CacheEntries, CommitIR),
     phrase(plawk_assoc_free_lines(AssocPlan), FreeLines),
-    atomic_list_concat(FreeLines, '\n', FreeIR),
+    atomic_list_concat([CommitIR | FreeLines], '\n', FreeIR),
     format(atom(DriverIR),
 '@.wam_stream_eof = private constant [12 x i8] c"end_of_file\\00"
 ~w

--- a/tests/test_plawk_multipass_cache.pl
+++ b/tests/test_plawk_multipass_cache.pl
@@ -1,0 +1,127 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk multi-pass persistent cache, phase 3: the cache as the INTER-PASS
+% CHANNEL, and durable across runs. A table declared in `BEGIN cache("path")
+% { declare NAME }` and shared by the passes is loaded from its store before
+% pass 1 and committed after the last pass -- so the same table is both the
+% in-memory channel between passes (already the multi-pass model) AND durable
+% between separate runs of the binary. Re-running the binary loads the prior
+% committed state and accumulates onto it. Works for the file backend
+% (default) and, when liblmdb is present, `backend "lmdb"`; and for both the
+% no-END normalise shape and the END for-in report. See
+% PLAWK_MULTIPASS_CACHE.md.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+clang_lmdb_available :-
+    catch(( cdir(Dir), directory_file_path(Dir, 'probe.c', C),
+            directory_file_path(Dir, 'probe_bin', Bin),
+            setup_call_cleanup(open(C, write, S),
+                write(S, "#include <lmdb.h>\nint main(void){MDB_env*e;return mdb_env_create(&e);}\n"),
+                close(S)),
+            format(atom(Cmd), 'clang -w ~w -o ~w -llmdb 2>/dev/null', [C, Bin]),
+            process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_multipass_cache).
+
+% File backend, no-END normalise shape: `total[$1] += $2` folded in pass 1
+% into a cache-backed table, read back per record in pass 2. The store
+% persists, so each run adds another copy of the input to the totals.
+% Over a=10, b=5: run 1 -> a 10 / b 5; run 2 -> a 20 / b 10.
+test(file_backend_persists, [condition(clang_available)]) :-
+    cdir(Dir),
+    fresh(Dir, 'mpc.db'),
+    directory_file_path(Dir, 'mpc.db', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare total }\n\c
+         pass { total[$1] += $2 }\n\c
+         pass { print $1, total[$1] }\n", [Store]),
+    build(Dir, 'mpc', Src, Bin, In, "a 10\nb 5\n"),
+    run_sorted(Bin, In, S1), assertion(S1 == ["a 10", "b 5"]),
+    run_sorted(Bin, In, S2), assertion(S2 == ["a 20", "b 10"]),
+    run_sorted(Bin, In, S3), assertion(S3 == ["a 30", "b 15"]),
+    !.
+
+% File backend, END for-in report: two passes each count every record, so a
+% single run doubles the counts; the store persists across runs. Over a a b:
+% run 1 -> a 4 / b 2; run 2 -> a 8 / b 4.
+test(file_backend_end_forin, [condition(clang_available)]) :-
+    cdir(Dir),
+    fresh(Dir, 'mpe.db'),
+    directory_file_path(Dir, 'mpe.db', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare c }\n\c
+         pass { c[$1]++ }\n\c
+         pass { c[$1]++ }\n\c
+         END { for (k in c) print k, c[k] }\n", [Store]),
+    build(Dir, 'mpe', Src, Bin, In, "a\na\nb\n"),
+    run_sorted(Bin, In, S1), assertion(S1 == ["a 4", "b 2"]),
+    run_sorted(Bin, In, S2), assertion(S2 == ["a 8", "b 4"]),
+    !.
+
+% LMDB backend, same durability across runs (skipped without liblmdb).
+test(lmdb_backend_persists,
+        [condition((clang_available, clang_lmdb_available))]) :-
+    cdir(Dir),
+    fresh_lmdb(Dir, 'mpl.lmdb'),
+    directory_file_path(Dir, 'mpl.lmdb', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare c }\n\c
+         pass { c[$1]++ }\n\c
+         pass { print $1, c[$1] }\n", [Store]),
+    build(Dir, 'mpl', Src, Bin, In, "a\na\nb\n"),
+    run_sorted(Bin, In, S1), assertion(S1 == ["a 2", "a 2", "b 1"]),
+    run_sorted(Bin, In, S2), assertion(S2 == ["a 4", "a 4", "b 2"]),
+    !.
+
+:- end_tests(plawk_multipass_cache).
+
+% --- helpers ---------------------------------------------------------------
+
+cdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_multipass_cache', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+fresh(Dir, Name) :-
+    directory_file_path(Dir, Name, F),
+    ( exists_file(F) -> delete_file(F) ; true ).
+
+% LMDB with MDB_NOSUBDIR leaves a "<name>-lock" sibling too.
+fresh_lmdb(Dir, Name) :-
+    fresh(Dir, Name),
+    atom_concat(Name, '-lock', Lock),
+    fresh(Dir, Lock).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+run_sorted(Bin, In, Sorted) :-
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
**Phase 3** of the multi-pass cache design — the "durable payoff." Pairs multi-pass with a `BEGIN cache(...)`-declared table.

The table shared by the passes is loaded from its store before pass 1 and committed after the last pass, so it's both the in-memory channel between passes *and* durable between separate runs of the binary — re-running loads the prior committed state and accumulates onto it:

```awk
BEGIN cache("run.db") { declare total }
pass { total[$1] += $2 }
pass { print $1, total[$1] }
```

Over `a 10 / b 5`: run 1 → `a 10`, `b 5`; run 2 → `a 20`, `b 10`; run 3 → `a 30`, `b 15`.

## Changes
- **Codegen**: wired the cache into both multi-pass driver shapes (no-END normalise and END for-in) by reusing the single-pass cache machinery — `plawk_program_cache_tables` / `plawk_cache_entries` discover the declared store and emit its path global; the cache-aware `plawk_assoc_entry_setup_ir/3` loads it into the shared table at setup; `plawk_cache_commit_lines` writes it back after the passes (in the END phase for the for-in shape, before the table free otherwise). The pass functions are unchanged — they already reference the shared table.
- **bin/plawk**: `plawk_program_uses_lmdb_cache` now also matches `program_passes`, so a multi-pass program declaring `backend "lmdb"` links the C runtime and `-llmdb` like the single-pass case.

## Tests
`tests/test_plawk_multipass_cache.pl` — file-backend persistence across runs (both no-END normalise and END for-in shapes) and the LMDB backend (skipped without liblmdb). Regression green across multipass, passes, assoc-print, crosspass-scalar, normalise, perkey, cache-surface, cache-lmdb, cache-runtime. Design doc: phase 3 marked landed.

> Independent of the still-open per-key-normalise PR #3694 (arithmetic table-lookup operand) — different code paths, no conflict; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_