### PR TITLE
WAM/LLVM plawk: `over TABLE` reader for multi-pass (phase 4, named fields)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -26,9 +26,13 @@ arithmetic operand (`$2 / total[$1]`), which completes **per-key normalise**
 inter-pass channel (phase 3): a `BEGIN cache("path") { declare NAME }` table
 shared by the passes is loaded before pass 1 and committed after the last
 pass, so it is both the in-memory channel between passes and durable across
-runs (file and LMDB backends). **Not yet:** configurable readers (phase 4);
-the query reader (phase 6); namespaces / `eager` / secondary indexes;
-string-literal print fields. See the per-phase status tags in §5.
+runs (file and LMDB backends); and the `over TABLE` reader (phase 4):
+`pass over TABLE as VAR { print ... }` iterates a table's entries as the
+pass's record source (named fields — key bound to `VAR`, value via
+`TABLE[VAR]`) instead of re-scanning the input. **Not yet:** the `over prev`
+reader (phase 4 follow-on); the query reader (phase 6); namespaces / `eager`
+/ secondary indexes; string-literal print fields. See the per-phase status
+tags in §5.
 
 ## Implemented surface (quick reference)
 
@@ -314,17 +318,19 @@ the next item"). Multi-pass makes that role **selectable per pass**, so a
 pass is not forced to re-scan the original input:
 
 ```awk
-pass { ... }                    # default: re-scan the original input
-pass over total { ... }         # iterate a table (cache-backed or in-memory)
-pass over prev { ... }          # consume the previous pass's emitted records
-pass over query(Goal) { ... }   # each solution of a query is a record
+pass { ... }                          # default: re-scan the original input
+pass over total as k { print k, total[k] }  # iterate a table (LANDED)
+pass over prev { ... }                # consume the previous pass's records
+pass over query(Goal) { ... }         # each solution of a query is a record
 ```
 
 - **`over input`** (the default) — re-open and re-scan the program's input.
-- **`over TABLE`** — iterate a table's entries as records (the `for (k in
-  arr)` iteration, but as the pass's record source). This is the natural
-  "process what the previous pass stored" shape when the previous pass
-  accumulated into a table.
+- **`over TABLE`** (LANDED) — iterate a table's entries as records (the
+  `for (k in arr)` iteration, but as the pass's record source), written
+  `pass over TABLE as VAR { ... }`. Fields are **named** (name lookup): the
+  loop key binds to `VAR`, its value reads as `TABLE[VAR]` — no positional
+  `$1`/`$2`. The natural "process what the previous pass stored" shape,
+  emitting one line per distinct key.
 - **`over prev`** — the previous pass's **sink becomes this pass's source**.
   When pass N declares `over prev`, pass N−1's `print`/`writebin` no longer
   go to stdout; they **spool** (to a cache table or a temp stream) and pass
@@ -527,11 +533,23 @@ single-pass test before any driver surgery).
   complete, durably-committed totals; plus a namespaced `stats.work` table
   addressed from a pass and a `global` table used bare.
 
-- **Phase 4 — configurable readers.** `over TABLE` (iterate a table as the
-  record source) and `over prev` (the previous pass's sink spools into this
-  pass — the in-process `awk | awk`, sugar over `over <spool>`). Writers
-  gain the spool sink. Test: pass 1 emits a filtered/derived stream, pass 2
-  `over prev` consumes it.
+- **Phase 4 — configurable readers.** `over TABLE` **LANDED (v1)**;
+  `over prev` deferred. `pass over TABLE as VAR { print ... }` iterates the
+  table's occupied slots as the pass's record source instead of re-scanning
+  the input — the "process what a previous pass stored" shape, emitting one
+  line per distinct key rather than per input record. Fields are **named**
+  (name lookup): the loop key binds to `VAR` and its value reads as
+  `TABLE[VAR]` (no positional `$1`/`$2`). Implemented by dispatching the
+  multi-pass driver's per-pass emission on the pass shape — a plain
+  `pass { }` scans input, a `pass over` walks the shared table with the same
+  body emitter the END for-in uses (`@wam_assoc_i64_iter_next` /
+  `key_at` / `value_at`), as a `void` function `main` calls in sequence. It
+  pairs with a cache-backed table (durable across runs) like the
+  input-scanning passes. Test: `tests/test_plawk_over_table.pl`.
+  **Deferred:** `over prev` (the previous pass's sink spools into this pass —
+  the in-process `awk | awk`, sugar over `over <spool>`; needs a spool sink +
+  redirect of the prior pass's writer); guarded / writebin over-bodies;
+  string-literal print fields; multiple tables.
 
 - **Phase 5 — LMDB backend + materialisation modes.** Swap the fallback for
   `liblmdb` behind the build flag; add a test that exceeds a small RAM cap

--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -16,10 +16,13 @@ from pass 1's table; cross-pass scalars (`acc += 1` / `acc += $N`
 folded in one pass and read in a later pass, backed by a zero-initialised
 module global); pure-scalar (no-table) multi-pass, where a program carries
 no assoc table at all and passes coordinate only through scalar globals;
-and arithmetic in prints (`$2 / total`) evaluated in f64 (the surface `/`
+arithmetic in prints (`$2 / total`) evaluated in f64 (the surface `/`
 is integer, so a print expression is promoted to double and printed with
-`%g`). Together the last two complete **grand-total normalise**
-(`pass { total += $2 } pass { print $1, $2 / total }`); and the cache as the
+`%g`), which completes **grand-total normalise**
+(`pass { total += $2 } pass { print $1, $2 / total }`); per-key aggregation
+via associative add-assign (`total[$1] += $2`) plus a table lookup as an
+arithmetic operand (`$2 / total[$1]`), which completes **per-key normalise**
+— each record divided by its own key's total; and the cache as the
 inter-pass channel (phase 3): a `BEGIN cache("path") { declare NAME }` table
 shared by the passes is loaded before pass 1 and committed after the last
 pass, so it is both the in-memory channel between passes and durable across
@@ -488,8 +491,15 @@ single-pass test before any driver surgery).
   `@wam_atom_field_f64_value`, a scalar via `load`+`sitofp`, an int constant
   via `sitofp`) and prints with `%g`. Grand-total normalise
   (`pass { total += $2 } pass { print $1, $2 / total }`) now works with no
-  assoc table at all. **Deferred:** multiple tables, and arithmetic operands
-  that are table lookups.
+  assoc table at all. **Landed since:** per-key aggregation — associative
+  add-assign `arr[$k] += DELTA` (`tests/test_plawk_perkey.pl`, the general
+  form of `arr[$k]++`, mapping to `@wam_assoc_i64_inc` with the record's
+  delta) folds a per-key sum in pass 1, and a table lookup as an arithmetic
+  operand (`$2 / total[$1]`, interned key → `@wam_assoc_i64_get` → `sitofp`)
+  lets pass 2 divide each record by its own key's total. Grand-total and
+  per-key normalise both work end to end. **Deferred:** multiple tables, and
+  non-field keys / deltas in add-assign. (Pairing multi-pass with a
+  cache-backed table landed in phase 3, below.)
 
 - **Phase 3 — cache as the inter-pass channel (durable payoff). LANDED
   (v1).** A table declared in a `BEGIN cache("path") { declare NAME }` block

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5372,13 +5372,27 @@ plawk_i64_op_f64(mod_i64, frem).
 plawk_assoc_arith_operand(field(N), afield(N)) :- integer(N), N > 0.
 plawk_assoc_arith_operand(var(Name), asvar(Name)) :- atom(Name).
 plawk_assoc_arith_operand(int(V), aint(V)) :- integer(V).
+% A table lookup `arr[$N]` as an operand, e.g. `$2 / total[$1]` (per-key
+% normalise). The array is resolved to a table index at planning time.
+plawk_assoc_arith_operand(assoc(var(Arr), field(N)), alookup(Arr, N)) :-
+    atom(Arr), integer(N), N > 0.
 
 % Resolve a print field's lookup array to its table index in the plan.
 plawk_assoc_print_plan_field(_Tables, fld(N), fld(N)).
 plawk_assoc_print_plan_field(Tables, lookup(Arr, N), lookup(TableIndex, N)) :-
     nth0(TableIndex, Tables, Arr).
 plawk_assoc_print_plan_field(_Tables, svar(Name), svar(Name)).
-plawk_assoc_print_plan_field(_Tables, farith(Op, L, R), farith(Op, L, R)).
+plawk_assoc_print_plan_field(Tables, farith(Op, L, R), farith(Op, L2, R2)) :-
+    plawk_assoc_arith_operand_plan(Tables, L, L2),
+    plawk_assoc_arith_operand_plan(Tables, R, R2).
+
+% Resolve an arithmetic operand against the table set: a lookup operand
+% binds its array to a table index; field/scalar/int operands pass through.
+plawk_assoc_arith_operand_plan(Tables, alookup(Arr, N), alookup_at(TableIndex, N)) :-
+    nth0(TableIndex, Tables, Arr).
+plawk_assoc_arith_operand_plan(_Tables, afield(N), afield(N)).
+plawk_assoc_arith_operand_plan(_Tables, asvar(Name), asvar(Name)).
+plawk_assoc_arith_operand_plan(_Tables, aint(V), aint(V)).
 
 % The per-record source value added to a scalar accumulator: a constant, or
 % field N converted to i64.
@@ -5480,6 +5494,23 @@ plawk_assoc_arith_operand_lines(asvar(Name), P, Slot, _FieldSep, ValVar, [LoadL,
 plawk_assoc_arith_operand_lines(aint(V), P, Slot, _FieldSep, ValVar, [Line]) :-
     format(atom(ValVar), '%~w_~w', [P, Slot]),
     format(atom(Line), '  ~w = sitofp i64 ~w to double', [ValVar, V]).
+% Table lookup operand: intern field N, read the table's i64 value there
+% (0 if absent), promote to double.
+plawk_assoc_arith_operand_lines(alookup_at(TableIndex, N), P, Slot, FieldSep, ValVar,
+        [SliceL, PtrL, LenL, KidL, ValL, PromL]) :-
+    format(atom(B), '~w_~w', [P, Slot]),
+    format(atom(ValVar), '%~w_lu', [B]),
+    format(atom(SliceL),
+        '  %~w_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 ~w)',
+        [B, N, FieldSep]),
+    format(atom(PtrL), '  %~w_ptr = extractvalue %WamSlice %~w_slice, 0', [B, B]),
+    format(atom(LenL), '  %~w_len = extractvalue %WamSlice %~w_slice, 1', [B, B]),
+    format(atom(KidL),
+        '  %~w_kid = call i64 @wam_intern_atom(i8* %~w_ptr, i64 %~w_len)', [B, B, B]),
+    format(atom(ValL),
+        '  %~w_val = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_kid)',
+        [B, TableIndex, B]),
+    format(atom(PromL), '  ~w = sitofp i64 %~w_val to double', [ValVar, B]).
 
 plawk_assoc_body_action_spec(for_in(var(LoopVar), var(ArrayName), Body),
         forin(LoopVar, ArrayName, Fields)) :-

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3691,6 +3691,7 @@ plawk_program_multipass_driver_ir(
     DriverIR
 ) :-
     Passes = [_, _ | _],
+    \+ member(pass_over(_, _, _), Passes),   % over-readers use the no-END driver
     plawk_record_descriptor(BeginClauses, FieldSeparator),
     integer(FieldSeparator),                 % text mode only (v1)
     plawk_output_separator(BeginClauses, OutputSeparator),
@@ -3791,27 +3792,25 @@ plawk_program_multipass_driver_ir(
     % after the last pass. Empty for pure-scalar / non-cache programs.
     plawk_program_cache_tables(BeginClauses, CacheTriples),
     plawk_cache_entries(Tables, CacheTriples, CacheEntries, CachePathGlobals),
-    findall(GlobalIR-ChainIR,
-        ( member(pass(PassRules), Passes),
-          plawk_multipass_pass_plan(PassRules, Tables, PassPlan),
-          plawk_assoc_rule_controls(PassPlan, PassControls),
-          plawk_assoc_break_close_ir(PassControls, ''),
-          plawk_assoc_rule_chain_ir(PassPlan, FieldSeparator, GlobalIR, ChainIR)
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    % One function per pass, in order -- dispatching on the pass shape:
+    % an input-scanning `pass { }` or a table-iterating `pass over T as V`.
+    % nth0 enumerates in order, so FnIRs/GlobalIRs line up with the call
+    % sequence by index.
+    findall(FnIR-GlobalIR,
+        ( nth0(I, Passes, Pass),
+          plawk_multipass_pass_fn(I, Pass, Tables, TableParamsIR,
+              FieldSeparator, OutputSeparator, FnIR, GlobalIR)
         ),
-        PassPairs),
-    pairs_keys_values(PassPairs, ChainGlobals, Chains),
-    findall(FnIR,
-        ( nth0(I, Chains, Chain),
-          plawk_multipass_pass_fn_ir(I, TableParamsIR, Chain, FnIR) ),
-        FnIRs),
+        FnPairs),
+    pairs_keys_values(FnPairs, FnIRs, ChainGlobals),
     atomic_list_concat(FnIRs, '\n', PassFnsIR),
     findall(CallLine,
-        ( nth0(I, Chains, _),
+        ( nth0(I, Passes, _),
           format(atom(CallLine),
               '  call void @plawk_pass_~w(%Value %mp_path~w)', [I, TableArgsIR]) ),
         CallLines),
     atomic_list_concat(CallLines, '\n', CallsIR),
-    plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_assoc_entry_setup_ir(AssocPlan, CacheEntries, EntrySetupIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
@@ -3853,11 +3852,14 @@ get_path:
 %% plawk_passes_tables(+Passes, -Tables)
 %  The assoc tables a multi-pass program shares (v1: zero or one). Discovered
 %  from the passes' actions: a counted key `arr[$k]++` or a print lookup
-%  `arr[$k]`. A pure-scalar program (e.g. `pass { total += $2 }`) has none.
+%  `arr[$k]`; and from an `over TABLE` reader (phase 4), which names the table
+%  it iterates. A pure-scalar program (e.g. `pass { total += $2 }`) has none.
 plawk_passes_tables(Passes, Tables) :-
     findall(Name,
         ( member(pass(Rules), Passes), member(rule(_, Actions), Rules),
-          member(Action, Actions), plawk_action_table_name(Action, Name) ),
+          member(Action, Actions), plawk_action_table_name(Action, Name)
+        ; member(pass_over(_Var, var(Name), _Body), Passes)
+        ),
         Names0),
     sort(Names0, Tables),
     length(Tables, N),
@@ -3886,6 +3888,75 @@ plawk_multipass_pass_plan(Rules, Tables, assoc_plan(Tables, PlannedRules)) :-
     plawk_assoc_specs_posarray_arrays(RuleSpecs, PosArrays),
     phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, StrArrays, PosArrays, 0),
         PlannedRules).
+
+%% plawk_multipass_pass_fn(+Index, +Pass, +Tables, +TableParamsIR,
+%%     +FieldSep, +OutputSep, -FnIR, -GlobalIR)
+%  Emit one pass function, dispatching on the pass shape. An input-scanning
+%  `pass { }` compiles its rule chain and scans the input per record; an
+%  `over TABLE as VAR` reader (phase 4) iterates the table's entries instead
+%  of the input. GlobalIR carries any module globals the pass's body needs
+%  (rule chains emit format/string globals; the over reader emits none in
+%  v1 -- key + lookup print fields use the shared runtime constants).
+plawk_multipass_pass_fn(Index, pass(PassRules), Tables, TableParamsIR,
+        FieldSep, _OutputSep, FnIR, GlobalIR) :-
+    plawk_multipass_pass_plan(PassRules, Tables, PassPlan),
+    plawk_assoc_rule_controls(PassPlan, PassControls),
+    plawk_assoc_break_close_ir(PassControls, ''),   % no break/next in v1
+    plawk_assoc_rule_chain_ir(PassPlan, FieldSep, GlobalIR, ChainIR),
+    plawk_multipass_pass_fn_ir(Index, TableParamsIR, ChainIR, FnIR).
+plawk_multipass_pass_fn(Index, pass_over(var(Var), var(Table), Body), Tables,
+        TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
+    Body = [print(PrintFields)],
+    PrintFields = [_ | _],
+    maplist(plawk_over_print_field_ok(Var), PrintFields),
+    AssocPlan = assoc_plan(Tables, []),
+    plawk_multipass_over_fn_ir(Index, TableParamsIR, Var, Table, PrintFields,
+        AssocPlan, FieldSep, OutputSep, FnIR).
+
+% Over-reader print fields (v1): the loop key, or a lookup of the iterated
+% table keyed by it. String literals / other tables are follow-ons.
+plawk_over_print_field_ok(Var, var(Var)).
+plawk_over_print_field_ok(Var, assoc(var(_Table), var(Var))).
+
+%% plawk_multipass_over_fn_ir(+Index, +TableParamsIR, +Var, +Table,
+%%     +PrintFields, +AssocPlan, +FieldSep, +OutputSep, -IR)
+%  An `over TABLE as VAR` pass as a self-contained void function: it does
+%  NOT open the input -- it walks the shared table's occupied slots
+%  (@wam_assoc_i64_iter_next) and prints each entry's fields (the same body
+%  emitter the END for-in uses, so key text / TABLE[VAR] value / separators
+%  are identical), one line per entry, then returns. The table is freed /
+%  committed by main, not here.
+plawk_multipass_over_fn_ir(Index, TableParamsIR, Var, Table, PrintFields,
+        AssocPlan, FieldSep, OutputSep, IR) :-
+    plawk_assoc_table_index(AssocPlan, Table, TableIndex),
+    phrase(plawk_forin_body_print_lines(PrintFields, Var, Table, TableIndex,
+        AssocPlan, FieldSep, OutputSep, 0), BodyLines),
+    atomic_list_concat(BodyLines, '\n', BodyIR),
+    format(atom(IR),
+'define void @plawk_pass_~w(%Value %mp_path~w) {
+entry:
+  br label %forin_head
+
+forin_head:
+  %forin_idx = phi i64 [0, %entry], [%forin_next_idx, %forin_body_done]
+  %forin_slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_idx)
+  %forin_done = icmp slt i64 %forin_slot, 0
+  br i1 %forin_done, label %forin_after, label %forin_body
+
+forin_body:
+  %forin_key_id = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %forin_slot)
+~w
+  %forin_printed_newline = call i32 @putchar(i32 10)
+  br label %forin_body_done
+
+forin_body_done:
+  %forin_next_idx = add i64 %forin_slot, 1
+  br label %forin_head
+
+forin_after:
+  ret void
+}
+', [Index, TableParamsIR, TableIndex, TableIndex, BodyIR]).
 
 %% plawk_multipass_pass_fn_ir(+Index, +RecordIR, -IR)
 %  One pass as a self-contained function: open the shared input path, loop

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -194,6 +194,22 @@ plawk_program(program(BeginClauses, Rules, EndClauses), FunctionClauses,
       plawk_dynentry_rewrite_all(EndClauses0, DynEntries, EndClauses)
     }.
 
+% A `pass over TABLE as VAR { print ... }` block: a configurable reader
+% (PLAWK_MULTIPASS_CACHE.md phase 4). Instead of re-scanning the input, the
+% pass iterates TABLE's entries as records, binding each key to VAR -- the
+% "process what a previous pass stored" shape. The body reuses the for-in
+% print body (key / TABLE[VAR] / literal). Tried before the plain `pass`
+% (the `over` keyword is unambiguous). Represented as pass_over/3 so the
+% driver can emit a table-iterating pass function rather than an input scan.
+pass_clauses([pass_over(var(Var), var(Table), Body) | Rest]) -->
+    "pass", identifier_boundary, ws,
+    "over", identifier_boundary, ws,
+    identifier(Table), ws,
+    "as", identifier_boundary, ws,
+    identifier(Var), ws,
+    for_in_body(Body),
+    ws,
+    pass_clauses(Rest).
 % A `pass { ACTIONS }` block is one pass carrying a single always-rule with
 % those actions (per-pattern rules within a pass are a later extension).
 pass_clauses([pass([rule(always, Actions)]) | Rest]) -->
@@ -204,6 +220,8 @@ pass_clauses([]) -->
 
 plawk_pass_dynentry_rewrite(DynEntries, pass(Rules0), pass(Rules)) :-
     plawk_dynentry_rewrite_all(Rules0, DynEntries, Rules).
+% An `over TABLE` pass has no rule actions to rewrite -- pass it through.
+plawk_pass_dynentry_rewrite(_DynEntries, pass_over(V, T, Body), pass_over(V, T, Body)).
 
 %% dynentry_decls(-Names)//
 %

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1809,6 +1809,17 @@ i64_factor_expr(field(Index)) -->
 i64_factor_expr(Expr) -->
     prolog_call_expr(Expr),
     !.
+% An assoc lookup `arr[k]` as an arithmetic operand, e.g. `$2 / total[$1]`
+% (per-key normalise). Tried before the bare identifier -- the `[` commits.
+i64_factor_expr(assoc(var(Name), KeyExpr)) -->
+    identifier(Name),
+    ws,
+    "[",
+    ws,
+    assoc_key_expr(KeyExpr),
+    ws,
+    "]",
+    !.
 i64_factor_expr(var(Name)) -->
     identifier(Name).
 

--- a/tests/test_plawk_over_table.pl
+++ b/tests/test_plawk_over_table.pl
@@ -1,0 +1,106 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk multi-pass, phase 4: the `over TABLE` reader. Instead of re-scanning
+% the input, a pass iterates a table's entries as its record source --
+% `pass over TABLE as VAR { print ... }`. Fields are NAMED (name lookup): the
+% loop key is bound to VAR, and the value is read as TABLE[VAR] (no positional
+% $1/$2). So pass 1 accumulates a table and pass 2 emits ONE line per distinct
+% key (not per input record), the "process what the previous pass stored"
+% shape. Reuses the END for-in body emitter, so the printed key/value/
+% separator are identical. Pairs with a cache-backed table (durable across
+% runs) just like the input-scanning passes. See PLAWK_MULTIPASS_CACHE.md.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_over_table).
+
+% `pass over T as V { ... }` parses to a pass_over/3 node, distinct from a
+% plain input-scanning pass.
+test(over_parses) :-
+    plawk_parse_string(
+        "pass { total[$1] += $2 }\npass over total as k { print k, total[k] }\n",
+        program_passes([],
+            [pass([rule(always, [add_assoc(var(total), field(1), field(2))])]),
+             pass_over(var(k), var(total),
+                 [print([var(k), assoc(var(total), var(k))])])],
+            [])),
+    !.
+
+% Pass 1 sums per key; pass 2 iterates the table (one line per KEY, not per
+% record) printing key + value. Over a=10,20 / b=5: a 30 / b 5 (two lines,
+% not three).
+test(over_key_value, [condition(clang_available)]) :-
+    odir(Dir),
+    Src = "pass { total[$1] += $2 }\npass over total as k { print k, total[k] }\n",
+    run_sorted(Dir, 'ov', Src, "a 10\na 20\nb 5\n", S),
+    assertion(S == ["a 30", "b 5"]),
+    !.
+
+% The key alone (name lookup of just the loop variable).
+test(over_key_only, [condition(clang_available)]) :-
+    odir(Dir),
+    Src = "pass { c[$1]++ }\npass over c as k { print k }\n",
+    run_sorted(Dir, 'ovk', Src, "a\na\nb\n", S),
+    assertion(S == ["a", "b"]),
+    !.
+
+% An `over TABLE` reader over a cache-backed table persists across runs, like
+% the input-scanning passes: run 1 -> a 10 / b 5; run 2 -> a 20 / b 10.
+test(over_cache_persists, [condition(clang_available)]) :-
+    odir(Dir),
+    directory_file_path(Dir, 'ovc.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare total }\n\c
+         pass { total[$1] += $2 }\n\c
+         pass over total as k { print k, total[k] }\n", [Store]),
+    build(Dir, 'ovc', Src, Bin, In, "a 10\nb 5\n"),
+    run_sorted_bin(Bin, In, S1), assertion(S1 == ["a 10", "b 5"]),
+    run_sorted_bin(Bin, In, S2), assertion(S2 == ["a 20", "b 10"]),
+    !.
+
+:- end_tests(plawk_over_table).
+
+% --- helpers ---------------------------------------------------------------
+
+odir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_over_table', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    build(Dir, Name, Src, Bin, In, Input),
+    run_sorted_bin(Bin, In, Sorted).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+run_sorted_bin(Bin, In, Sorted) :-
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_plawk_perkey.pl
+++ b/tests/test_plawk_perkey.pl
@@ -48,6 +48,17 @@ test(single_pass_add_assign, [condition(clang_available)]) :-
     assertion(S == ["a 30", "b 5"]),
     !.
 
+% Fractional per-key normalise: a table lookup as an arithmetic operand in a
+% print (`$2 / total[$1]`), evaluated in f64. Each record is divided by its
+% OWN key's total. Over a=10,30 (total 40) and b=5 (total 5):
+% 0.25, 0.75, 1.
+test(perkey_normalise, [condition(clang_available)]) :-
+    kdir(Dir),
+    Src = "pass { total[$1] += $2 }\npass { print $1, $2 / total[$1] }\n",
+    run_sorted(Dir, 'pkn', Src, "a 10\na 30\nb 5\n", S),
+    assertion(S == ["a 0.25", "a 0.75", "b 1"]),
+    !.
+
 :- end_tests(plawk_perkey).
 
 % --- helpers ---------------------------------------------------------------


### PR DESCRIPTION
**Phase 4 — configurable readers, first slice: `over TABLE`.** (`over prev` deferred to a follow-on.)

A pass can now iterate a table's entries as its record source instead of re-scanning the input:

```awk
pass { total[$1] += $2 }
pass over total as k { print k, total[k] }
```

Over `a 10 / a 20 / b 5` → `a 30`, `b 5` — **one line per distinct key**, not per input record. This is the "process what a previous pass stored" shape.

Fields are **named (name lookup)**, per your guidance: the loop key binds to `VAR`, its value reads as `TABLE[VAR]`. No positional `$1`/`$2`.

## Changes
- **Parser**: `pass over IDENT as IDENT { <for-in body> }` → `pass_over(var(Var), var(Table), Body)`, tried before the plain `pass`; the body reuses the existing for-in print-body grammar.
- **Codegen**: the multi-pass driver's per-pass emission now dispatches on pass shape (`plawk_multipass_pass_fn/8`). A plain `pass { }` scans input as before; a `pass over` emits a `void` function that walks the shared table (`@wam_assoc_i64_iter_next` / `key_at` / `value_at`) using the **same** body emitter the END for-in uses, so key/value/separator output is identical. `main` calls each pass function in order regardless of shape. Table discovery recognises the `over` table, so it joins the shared table set and pairs with a cache-backed table (durable across runs) exactly like the input-scanning passes. The END-for-in driver clause is guarded against `over` passes so a mixed program takes the no-END path rather than silently dropping the over pass.

## Tests
`tests/test_plawk_over_table.pl` — parse, key+value, key-only, and an over-reader over a cache-backed table persisting across runs. Regression green across multipass, passes, assoc-print, crosspass-scalar, normalise, perkey, multipass-cache, forin-filter. Design doc: phase 4 `over TABLE` marked landed.

> Independent of the recovery PR #3698 (fractional per-key operand) — different code paths, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_