### PR TITLE
Add Rust WAM term_variables/2 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1624,6 +1624,13 @@ compile_execute_term_builtin_to_rust(Code) :-
             "assertz/1" | "asserta/1" => { self.execute_assert_builtin(op) }
             "retractall/1" => { self.execute_retractall_builtin() }
             "predicate_property/2" => { self.execute_predicate_property_builtin() }
+            "term_variables/2" => {
+                let term = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+                let variables = self.variables_from_term(&term);
+                let output = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+                if self.unify(&output, &variables) { self.pc += 1; true }
+                else { false }
+            }
             _ => false,
         }
     }

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -623,6 +623,32 @@ fn test_atom_text_ops() {
 }
 
 #[test]
+fn test_term_variables_direct() {
+    let term = Value::Str(
+        "outer/3".to_string(),
+        vec![
+            ub("X"),
+            Value::Str("inner/3".to_string(), vec![ub("Y"), ub("X"), ub("Z")]),
+            Value::List(vec![ub("Z"), ub("Y")]),
+        ],
+    );
+    let (ok, vm) = call2("term_variables/2", term, ub("Vars"));
+    assert!(ok);
+    assert_eq!(
+        read_var(&vm, "Vars"),
+        Value::List(vec![ub("X"), ub("Y"), ub("Z")]),
+    );
+    let (ground_ok, ground_vm) = call2(
+        "term_variables/2",
+        Value::Str("ground/2".to_string(), vec![a("x"), i(1)]),
+        ub("Vars"),
+    );
+    assert!(ground_ok);
+    assert_eq!(read_var(&ground_vm, "Vars"), Value::List(vec![]));
+    assert!(!call2("term_variables/2", ub("X"), Value::List(vec![])).0);
+}
+
+#[test]
 fn test_ground() {
     assert!(call1("ground/1", a("x")).0);
     assert!(call1("ground/1", Value::List(vec![i(1), a("b")])).0);

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -461,6 +461,7 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"arg/3"'),
         sub_string(S, _, _, _, '"=../2"'),
         sub_string(S, _, _, _, '"copy_term/2"'),
+        sub_string(S, _, _, _, '"term_variables/2"'),
         sub_string(S, _, _, _, '"subtract/3"'),
         %% copy_term_walk helper (sharing-preserving recursive copy).
         sub_string(S, _, _, _, 'copy_term_walk'),


### PR DESCRIPTION
## Summary

- implement `term_variables/2` for Rust WAM
- reuse the existing parser-metadata variable walker
- preserve left-to-right first-occurrence order
- return shared variables only once
- support compound terms and lists
- add no new traversal code, VM state, or choicepoints

## Testing

- shared-variable deduplication
- left-to-right variable ordering
- compound and list traversal
- ground-term empty result
- incompatible output failure
- dedicated Rust builtin parity execution suite
- full Rust WAM target suite
- Rust target syntax/load check
- patch whitespace validation