### PR TITLE
mu_cosine: preregister batched repeated-judge covariance campaign

### DIFF
--- a/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
+++ b/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
@@ -5,7 +5,7 @@ the conditions under which they may be reconsidered.
 
 ## 2026-07-12 — freeze a no-spend campaign layer before fresh judgments
 
-**Decision:** implement and audit the sampler, scoring schema, repeat estimand, full-procedure simulation, and
+**Decision:** implement and audit the sampler, scoring schema, repeat estimand, synthetic primary-event simulation, and
 decision gates before making any judge call.  A scorer pilot needs a preregistered amendment and is excluded
 from confirmation.
 
@@ -137,8 +137,8 @@ analysis.
 ## 2026-07-12 — freeze the PSD safety adapter completely
 
 **Decision:** use shrinkage multipliers `s_safe in {0,.25,.50,.75,1}`, define missing spectral mass from
-inner-held whitened repeat-mean residual second moments including `W_call/R_eff`, and set the cross-batch
-omission tolerance to `epsilon_batch=.025`.
+inner-held whitened repeat-mean residual second moments including the full fitted call/prompt/wave sampling
+covariance, and set the cross-batch omission tolerance to `epsilon_batch=.025`.
 
 **Rejected:** an unspecified “lower covariance confidence bound,” entrywise lower bounds, or tuning the
 batch-independence tolerance after observing residuals.
@@ -185,3 +185,37 @@ covariance Loewner-safe.
 
 **Reason:** coherent missing covariance can accumulate with block size, so local entry/block accuracy does not
 imply a dimension-free spectral bound.
+
+## 2026-07-12 — distinguish synthetic primary sizing from deployment power
+
+**Decision:** let the synthetic harness report only the smallest joint-two-corpus `G` passing the simultaneous
+residual/posterior primary event.  Keep final campaign `G` and every deployment flag unset until decision-space,
+source-component, spectral-safety, and batching gates receive their own power/feasibility bridge.
+
+**Rejected:** call two Gaussian NLL endpoints a full deployment event or transfer its synthetic null threshold
+to unknown real-data nuisance scale.
+
+**Reason:** calibration, AURC/noninferiority, and spectral safety are meaningful real gates but are not made
+representative merely by inventing a synthetic class-label process.  Real selector nulls are recalibrated from
+outer-training prompt blocks with the complete refit.
+
+## 2026-07-12 — contain and stress-test graph source components
+
+**Decision:** keep each selected graph source component inside one outer/global-inner fold and require a
+two-way prompt-block/source-component multiplier sensitivity in addition to primary prompt-block inference.
+
+**Rejected:** assume endpoint disjointness alone removes every graph-component-level random effect.
+
+**Reason:** prompt blocks capture shared requests, while connected graph components can carry a different
+dependence path.  Fold containment prevents leakage; the two-way sensitivity exposes remaining held dependence.
+
+## 2026-07-12 — retain stable inner labels with the minimax integer balance
+
+**Decision:** freeze one global inner label per component/source group and accept a maximum inner-total spread
+of two in each leave-one-outer training set on the registered G grid.
+
+**Rejected:** independently rebalance inner labels for each outer fold or claim an impossible spread of one.
+
+**Reason:** stable labels keep shared prompts out of train/held crossings.  At `G=160`, five outer folds of 32
+force one leave-one-outer inner allocation to be 44/42/42; changing labels by outer split would break the stable
+prompt-block contract.

--- a/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
+++ b/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
@@ -110,3 +110,15 @@ and identifying JointPosterior with a matrix factorization.
 
 **Reason:** JointPosterior is the calibrated decision comparator.  The eigenmode/QR conditioner is a numerical
 implementation of an already validated covariance model.
+
+## 2026-07-12 — distinguish campaign quotas from fold apportionment
+
+**Decision:** interpret `G` as the count per required corpus.  Preserve exact equal quotas across each corpus's
+32 joint cells, then apportion those selected components across five outer folds and three nested inner folds
+as evenly as integer counts allow.  Materialize all assignments before outcomes.
+
+**Rejected:** require every cell to divide equally across every fold.
+
+**Reason:** all frozen `G` values divide by 32, so campaign-cell balance is exact.  At `G=512`, however, each
+cell has 16 components and cannot divide equally over five outer folds.  Requiring impossible fold equality or
+silently changing `G` would invalidate the power recommendation; near-balanced fold apportionment preserves it.

--- a/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
+++ b/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
@@ -162,3 +162,15 @@ individual components as if the request induced no dependence.
 **Reason:** single-row requests waste tokens; unmodelled shared prompts invalidate component-only uncertainty.
 Stable bounded blocks preserve token amortization, prevent requests crossing held-out boundaries, and make the
 remaining dependence explicit in the power calculation and inference.
+
+## 2026-07-12 — include prompt incidence in the conditioner
+
+**Decision:** construct the fitted prompt covariance from immutable request-incidence matrices and add it,
+along with row-call and retained wave terms, to the safe measurement covariance before dense QR.
+
+**Rejected:** use prompt blocks only for bootstrap clustering while omitting their shared random effect from
+the covariance supplied to the conditioner.
+
+**Reason:** repeated averaging reduces but does not erase a shared prompt effect.  Its schedule-dependent
+incidence term can couple multiple components and may not commute with the selected graph kernel.  Dense QR
+handles the general sum; the eigenmode shortcut requires a separately proved block/commutation condition.

--- a/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
+++ b/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
@@ -136,8 +136,9 @@ analysis.
 
 ## 2026-07-12 — freeze the PSD safety adapter completely
 
-**Decision:** use shrinkage multipliers `{0,.25,.50,.75,1}`, define missing spectral mass from inner-held
-whitened residual second moments, and set the cross-batch omission tolerance to `epsilon_batch=.025`.
+**Decision:** use shrinkage multipliers `s_safe in {0,.25,.50,.75,1}`, define missing spectral mass from
+inner-held whitened repeat-mean residual second moments including `W_call/R_eff`, and set the cross-batch
+omission tolerance to `epsilon_batch=.025`.
 
 **Rejected:** an unspecified “lower covariance confidence bound,” entrywise lower bounds, or tuning the
 batch-independence tolerance after observing residuals.
@@ -145,3 +146,19 @@ batch-independence tolerance after observing residuals.
 **Reason:** covariance safety is an eigenvalue/PSD-order question.  The `.025` tolerance equals the smallest
 nonzero coupling the registered selector attempts to resolve; anything larger must remain in the conditioning
 matrix.
+
+## 2026-07-12 — supersede single-row calls with explicit prompt blocks
+
+**Decision:** amortize the system prompt over at most ten same-role rows from distinct components.  Keep stable
+prompt-block membership across judges/repeats/roles, contain every block within one corpus/outer/inner split
+signature, fit request effects, and use whole prompt blocks as the conservative inference clusters.
+
+**Supersedes:** the earlier same-day single-row-request decision, before any campaign selection, simulation
+result, or fresh judge response existed.
+
+**Rejected:** either repay the full system prompt for every row or batch rows while continuing to bootstrap
+individual components as if the request induced no dependence.
+
+**Reason:** single-row requests waste tokens; unmodelled shared prompts invalidate component-only uncertainty.
+Stable bounded blocks preserve token amortization, prevent requests crossing held-out boundaries, and make the
+remaining dependence explicit in the power calculation and inference.

--- a/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
+++ b/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
@@ -1,0 +1,112 @@
+# Repeated-judge campaign decisions
+
+Append-only rationale for `PREREG_graph_geometry_repeated_judge.md`.  Entries record rejected alternatives and
+the conditions under which they may be reconsidered.
+
+## 2026-07-12 — freeze a no-spend campaign layer before fresh judgments
+
+**Decision:** implement and audit the sampler, scoring schema, repeat estimand, full-procedure simulation, and
+decision gates before making any judge call.  A scorer pilot needs a preregistered amendment and is excluded
+from confirmation.
+
+**Rejected:** collecting a convenient number of labels first and choosing the covariance analysis afterward.
+
+**Reason:** candidate capacity, sample size, and nuisance refitting all affect the familywise null.  Freezing
+them after outcomes would convert a confirmatory claim into post-hoc reuse.
+
+## 2026-07-12 — substitute cumulative walk without expanding the selector
+
+**Decision:** use one deployment-capable convex family
+`K_gamma=gamma K_cumulative+(1-gamma)K_Nomic`, with the complete `gamma x rho_max` grid calibrated as one
+familywise maximum.  Cumulative decay `(1,.5,.25,.125)` replaces same-hop walk.
+
+**Rejected:** separate deployment votes for closed, same-hop, heat, resolvent, cumulative, Nomic, MiniLM, e5,
+and their products.
+
+**Reason:** closed/cumulative/heat/resolvent were nearly equivalent on the inspected topology, same-hop failed
+its adjacency ordering, and Nomic/MiniLM/e5 were strongly redundant.  Extra branches add null multiplicity
+without identified geometry.
+
+**Reconsider if:** a new outcome-blind graph has pairwise kernel correlation below the frozen equivalence
+threshold before any residual is inspected.  Any expansion requires a new null calibration.
+
+## 2026-07-12 — match maximum coupling, not a common path coefficient
+
+**Decision:** search a common `rho_max` grid and derive `alpha(K,rho)` per kernel.
+
+**Rejected:** applying one `alpha` to kernels with different maximum/off-diagonal energy.
+
+**Reason:** the failed v1 mechanism audit showed that common alpha is not matched covariance strength.
+
+## 2026-07-12 — repeat waves identify noise components, not independent votes
+
+**Decision:** retain at least three fresh calls per row and judge, with wave/request/batch identity.  Estimate
+persistent, cross-wave, and repeat-specific covariance separately.
+
+**Rejected:** averaging repeats before covariance estimation or counting three outputs as three independent
+components.
+
+**Reason:** repeats estimate call noise; endpoint components determine cross-item power.  Unrecorded call
+pairing cannot identify stochastic cross-judge covariance.
+
+**Reconsider:** four waves are already frozen as a sensitivity design; increase them if missingness or
+repeat-split instability dominates, not as a substitute for more components.
+
+## 2026-07-12 — Luna is a measurement family, not truth
+
+**Decision:** repeat both the operating gpt-5.5-low judge and calibrated gpt-5.6-luna.  Restrict the primary
+claim to operating-judge fidelity unless a blinded third-family, human, structural, or downstream target is
+added under an amendment.
+
+**Rejected:** calling cross-model agreement ground truth or treating the two judges as independent fusion
+votes.
+
+## 2026-07-12 — size by full deployment-event power
+
+**Decision:** simulate `G={160,320,512,800}` independently per required corpus, using full nuisance refitting,
+1,999 null draws, and 200 alternatives.  Four repeats are a sensitivity at `G={320,800}`.
+
+**Rejected:** treating the favorable 320-component pointwise mechanism result or the phrase “more than 400” as
+a final sample size.
+
+**Reason:** simultaneous inference plus calibration, mean, marginal covariance, and selector fitting consumes
+more information.  If 800 fails, increase components rather than lower 95% confidence.
+
+## 2026-07-12 — use PSD-path shrinkage and a spectral envelope
+
+**Decision:** choose `alpha_safe` by multiplicity-adjusted held benefit on a PSD path and add a separately
+estimated Loewner-safe `delta_95` spectral envelope.
+
+**Rejected:** elementwise lower confidence bounds on covariance entries.
+
+**Reason:** decreasing individual off-diagonals is not ordered in the PSD cone and can decrease an eigenvalue.
+Statistical uncertainty and numerical Cholesky loading have different meanings and must remain separate.
+
+## 2026-07-12 — independence needs an upper bound
+
+**Decision:** omit a cross-batch block only if its simultaneous 95% upper whitened spectral-norm bound is below
+a preregistered `epsilon_batch`.
+
+**Rejected:** using a small fitted alpha, large distance, or extra diagonal loading as proof of independence.
+
+## 2026-07-12 — graph familiarization is cross-fitted mean learning
+
+**Decision:** reuse anchor/adjacent/distant triples as a contrastive curriculum only inside outer-training
+components.  Held components never train the graph judge/model.
+
+**Rejected:** training on the confirmation components and then crediting smoother residuals to covariance.
+
+**Reason:** the graph judge is also intended to learn a dataset's topology, but improved mean prediction and
+random residual covariance are different estimands.
+
+## 2026-07-12 — defer numerical specialization until statistical promotion
+
+**Decision:** dense correlated QR remains the reference.  A passing single kernel may later use
+`K=U Lambda U.T` and parallel factorizations of `B0+lambda_i Bg`, benchmarked end to end at
+`N_item=128,M_channel=32,P_state=2`.
+
+**Rejected for this PR:** CUDA performance claims, multiple noncommuting kernels, explicit covariance inverse,
+and identifying JointPosterior with a matrix factorization.
+
+**Reason:** JointPosterior is the calibrated decision comparator.  The eigenmode/QR conditioner is a numerical
+implementation of an already validated covariance model.

--- a/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
+++ b/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
@@ -174,3 +174,14 @@ the covariance supplied to the conditioner.
 **Reason:** repeated averaging reduces but does not erase a shared prompt effect.  Its schedule-dependent
 incidence term can couple multiple components and may not commute with the selected graph kernel.  Dense QR
 handles the general sum; the eigenmode shortcut requires a separately proved block/commutation condition.
+
+## 2026-07-12 — do not extrapolate a three-row spectral envelope to 128 items
+
+**Decision:** validate the numerical `N_item=128` conditioner against stipulated dense covariance only.  Require
+an N-aware simulation, direct validation, or concentration/row-sum envelope before calling its statistical
+covariance Loewner-safe.
+
+**Rejected:** reuse the three-row campaign's scalar `delta_95` unchanged at 128 items.
+
+**Reason:** coherent missing covariance can accumulate with block size, so local entry/block accuracy does not
+imply a dimension-free spectral bound.

--- a/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
+++ b/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
@@ -72,6 +72,15 @@ a final sample size.
 **Reason:** simultaneous inference plus calibration, mean, marginal covariance, and selector fitting consumes
 more information.  If 800 fails, increase components rather than lower 95% confidence.
 
+## 2026-07-13 — both zero-coupling controls must pass the false-promotion gate
+
+**Decision:** apply the same observed primary-event rate at most 10% and one-sided exact-binomial
+non-rejection gate to both the graph-local block null and the zero-coupling smooth-mean-only control.  Retain
+the held residual no-harm checks as separate requirements.
+
+**Rejected:** allowing smooth-mean-only to pass merely because its average residual gain is nonnegative.  That
+would permit an arbitrarily high structured false-promotion rate under a zero-coupling control.
+
 ## 2026-07-12 — use PSD-path shrinkage and a spectral envelope
 
 **Decision:** choose `alpha_safe` by multiplicity-adjusted held benefit on a PSD path and add a separately
@@ -221,3 +230,60 @@ realized global and leave-one-outer totals, and does not claim the synthetic bou
 **Reason:** stable labels keep shared prompts out of train/held crossings.  At `G=160`, five outer folds of 32
 force one leave-one-outer inner allocation to be 44/42/42; changing labels by outer split would break the stable
 prompt-block contract.
+
+## 2026-07-12 — distinguish reproducible declarations from verified campaign inputs
+
+**Decision:** let the no-spend selector validate and hash an externally materialized candidate pool and request
+contract, but label even a frozen-shaped output `protocol-shape-compatible-no-spend-inputs-unverified` until a
+repository-owned candidate builder and an approved exact model-revision/prompt/settings contract exist.
+
+**Rejected:** interpret a caller-supplied implementation or artifact hash as independent attestation, or let a
+dry-run manifest authorize live judge calls.
+
+**Reason:** content addressing makes the supplied bytes reproducible; it does not prove how those bytes were
+created or that a prompt was approved.  Conflating those properties would turn a useful dry-run tool into a
+false confirmatory readiness claim.
+
+## 2026-07-12 — counterbalance prompt position and bind exact request bytes
+
+**Decision:** keep prompt-block membership stable, give each role-by-judge measurement an independently hashed
+base order, and spread its repeat rotations across the available positions.  Hash the exact serialized
+request-input bytes into the logical request ID, and require provider request/nonempty response IDs to be
+unique across logical attempts.  Treat a position-effect pilot, train-only adjustment, and power sensitivity
+as prerequisites for live approval rather than claims of this synthetic harness.
+
+**Rejected:** keep each component at one list position, identify a request only by normalized endpoint IDs, or
+accept one provider call as evidence for multiple nominal repeats.
+
+**Reason:** a persistent list-position effect could otherwise follow a component and masquerade as cross-item
+or cross-role covariance.  Independent bases plus spread rotations reduce that alignment but cannot identify
+an arbitrary position nuisance with only three repeats.  Normalized identity deliberately ignores presentation
+changes that alter actual prompt bytes, while reused provider IDs destroy the fresh-call estimand.  Membership
+stability preserves the inference cluster; the remaining position question is explicitly fail-closed.
+
+## 2026-07-12 — treat smooth mean misspecification as a false-promotion null
+
+**Decision:** require the smooth-mean-only, zero-coupling control to pass the same at-most-10% joint primary
+promotion and exact-binomial no-excess gate as the simpler block null, in addition to its no-harm diagnostic.
+
+**Rejected:** let improved held likelihood alone validate a structured covariance under mean-only truth.
+
+**Reason:** a covariance kernel can absorb a misspecified mean and improve prediction while still being a
+false covariance discovery.  The scientific question is residual coupling after mean removal, so robustness
+to the frozen nonlinear mean control is part of false-promotion control, not merely a predictive diagnostic.
+
+## 2026-07-12 — use exact prompt-block eigenmodes with a dense fallback
+
+**Decision:** when every component in a prompt block has the identical observed request schedule, write its
+joint covariance as `I_m tensor A + J_m tensor B` and score one collective mode `A+mB` plus `m-1` contrast
+modes `A`.  Validate the exact boolean schedule, use the dense overlap-aware solve otherwise, and densely
+recompute candidates within `1e-12` of a strict-zero eligibility decision.  Permit factor caching only inside
+one fitted nuisance object.
+
+**Rejected:** infer exchangeability from repeat counts alone, apply the shortcut to arbitrary real incidence
+matrices, reuse fitted factors across folds/replicates, or round gains at the decision boundary.
+
+**Reason:** shared request-level missingness makes the reduction algebraically exact in the current synthetic
+blocks and reduces 120-dimensional factorizations to 12-dimensional collective/contrast systems.  Equal counts
+can hide different overlap schedules, while real prompt incidence need not commute with the item kernel; dense
+joint QR therefore remains the general correctness reference.

--- a/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
+++ b/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
@@ -211,8 +211,10 @@ dependence path.  Fold containment prevents leakage; the two-way sensitivity exp
 
 ## 2026-07-12 — retain stable inner labels with the minimax integer balance
 
-**Decision:** freeze one global inner label per component/source group and accept a maximum inner-total spread
-of two in each leave-one-outer training set on the registered G grid.
+**Decision:** freeze one global inner label per component/source group.  The synthetic sizing model, whose
+dependency atom is one component, accepts a maximum inner-total spread of two in each leave-one-outer training
+set on the registered G grid.  The real selector instead balances indivisible source groups, records the
+realized global and leave-one-outer totals, and does not claim the synthetic bound for those grouped data.
 
 **Rejected:** independently rebalance inner labels for each outer fold or claim an impossible spread of one.
 

--- a/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
+++ b/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
@@ -122,3 +122,26 @@ as evenly as integer counts allow.  Materialize all assignments before outcomes.
 **Reason:** all frozen `G` values divide by 32, so campaign-cell balance is exact.  At `G=512`, however, each
 cell has 16 components and cannot divide equally over five outer folds.  Requiring impossible fold equality or
 silently changing `G` would invalidate the power recommendation; near-balanced fold apportionment preserves it.
+
+## 2026-07-12 — isolate every confirmatory judge request
+
+**Decision:** send one campaign row per stateless judge request and retain request identity.  Numerical batches
+used later by the conditioner are formed only after measurement collection.
+
+**Rejected:** score ten campaign rows in one prompt while treating endpoint components as independent.
+
+**Reason:** a shared prompt can induce request-level covariance and connects otherwise endpoint-disjoint
+components.  The frozen simulator has no such cluster effect, so shared requests would invalidate its unit of
+analysis.
+
+## 2026-07-12 — freeze the PSD safety adapter completely
+
+**Decision:** use shrinkage multipliers `{0,.25,.50,.75,1}`, define missing spectral mass from inner-held
+whitened residual second moments, and set the cross-batch omission tolerance to `epsilon_batch=.025`.
+
+**Rejected:** an unspecified “lower covariance confidence bound,” entrywise lower bounds, or tuning the
+batch-independence tolerance after observing residuals.
+
+**Reason:** covariance safety is an eigenvalue/PSD-order question.  The `.025` tolerance equals the smallest
+nonzero coupling the registered selector attempts to resolve; anything larger must remain in the conditioning
+matrix.

--- a/prototypes/mu_cosine/DESIGN_graph_geometry_confirmatory.md
+++ b/prototypes/mu_cosine/DESIGN_graph_geometry_confirmatory.md
@@ -222,8 +222,8 @@ The mechanism audit does not identify real stochastic covariance.  The next data
 3. stratify outcome-blind graph-kernel similarity and independent-embedding similarity so their disagreement is
    observed, not extrapolated;
 4. obtain at least three independent calls per judge family and preserve call identity;
-5. use more than 400 independent endpoint components, with the final count chosen by a full-procedure power
-   simulation rather than computational convenience;
+5. use the per-corpus component count chosen by the later frozen full-procedure power grid in
+   `PREREG_graph_geometry_repeated_judge.md`; this supersedes the earlier heuristic “more than 400” floor;
 6. split whole endpoint components and refit mean, marginal covariance, kernel weights, amplitude, and any
    selector inside each outer fold;
 7. include a different judge family or non-LLM target for generality claims.

--- a/prototypes/mu_cosine/DESIGN_graph_geometry_confirmatory.md
+++ b/prototypes/mu_cosine/DESIGN_graph_geometry_confirmatory.md
@@ -269,5 +269,8 @@ K_cumulative(r,s) = <Phi_cumulative(r), Phi_cumulative(s)>
 ```
 
 It is an explicit Gram and therefore PSD.  Nonnegative weights keep its diffusion interpretation.  The frozen
-topology grids remain `local=(1,1)`, `two_hop=(1,1,1)`, and `decay=(1,1/2,1/4,1/8)`.  Adding it to a covariance
-selector requires a separately calibrated v3 mechanism audit; v1/v2 outputs are not rewritten.
+topology grids remain `local=(1,1)`, `two_hop=(1,1,1)`, and `decay=(1,1/2,1/4,1/8)`.  Campaign collection does
+not require a standalone cumulative-only v3.  Before any campaign residual is inspected, cumulative decay
+replaces same-hop walk inside the single deployment-capable convex cumulative/Nomic family frozen in
+`PREREG_graph_geometry_repeated_judge.md`; its complete mixture-by-coupling search receives one full-procedure
+familywise calibration.  V1/v2 outputs are not rewritten, and the near-equivalent kernel zoo remains diagnostic.

--- a/prototypes/mu_cosine/DESIGN_graph_geometry_confirmatory.md
+++ b/prototypes/mu_cosine/DESIGN_graph_geometry_confirmatory.md
@@ -222,8 +222,9 @@ The mechanism audit does not identify real stochastic covariance.  The next data
 3. stratify outcome-blind graph-kernel similarity and independent-embedding similarity so their disagreement is
    observed, not extrapolated;
 4. obtain at least three independent calls per judge family and preserve call identity;
-5. use the per-corpus component count chosen by the later frozen full-procedure power grid in
-   `PREREG_graph_geometry_repeated_judge.md`; this supersedes the earlier heuristic “more than 400” floor;
+5. use at least the per-corpus component count chosen by the later frozen synthetic primary-event power grid in
+   `PREREG_graph_geometry_repeated_judge.md`, then complete its unsimulated secondary sizing gates; this
+   supersedes the earlier heuristic “more than 400” floor;
 6. split whole endpoint components and refit mean, marginal covariance, kernel weights, amplitude, and any
    selector inside each outer fold;
 7. include a different judge family or non-LLM target for generality claims.
@@ -272,5 +273,6 @@ It is an explicit Gram and therefore PSD.  Nonnegative weights keep its diffusio
 topology grids remain `local=(1,1)`, `two_hop=(1,1,1)`, and `decay=(1,1/2,1/4,1/8)`.  Campaign collection does
 not require a standalone cumulative-only v3.  Before any campaign residual is inspected, cumulative decay
 replaces same-hop walk inside the single deployment-capable convex cumulative/Nomic family frozen in
-`PREREG_graph_geometry_repeated_judge.md`; its complete mixture-by-coupling search receives one full-procedure
-familywise calibration.  V1/v2 outputs are not rewritten, and the near-equivalent kernel zoo remains diagnostic.
+`PREREG_graph_geometry_repeated_judge.md`; its complete mixture-by-coupling search receives one synthetic
+primary-event familywise calibration and a separate training-only real-data null calibration.  V1/v2 outputs
+are not rewritten, and the near-equivalent kernel zoo remains diagnostic.

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -203,13 +203,15 @@ PoE is retained only as a control.
 
 ## PSD-safe deployment adapter and batching
 
-No elementwise covariance lower bound is called conservative.  Select `alpha_safe` inside outer training as
-the largest frozen-grid value whose multiplicity-adjusted held-benefit lower bound is positive; otherwise use
-zero.  In whitened coordinates,
+No elementwise covariance lower bound is called conservative.  Select `alpha_safe` inside outer training,
+using only its inner-held components, as the largest frozen-grid value whose multiplicity-adjusted benefit
+lower bound is positive; otherwise use zero.  In whitened coordinates,
 
 ```text
 C_alpha = (1-alpha_safe) I + alpha_safe C_hat,
-R_safe = (I tensor L_B) [C_alpha + delta_95 I] (I tensor L_B)^T.
+R_safe = (I_N tensor L_B)
+         [C_alpha tensor I_m + delta_95 I_(N*m)]
+         (I_N tensor L_B)^T.
 ```
 
 `delta_95` is the full-procedure 95th percentile of maximum missing spectral mass.  Statistical `delta_95` and

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -3,9 +3,11 @@
 ## Status and authorization boundary
 
 **Frozen before running the new power harness, selecting any new endpoint, or making any fresh judge call.**
-This PR is deliberately no-spend: it freezes the candidate capacity, outcome-blind sampler, repeat-aware data
-contract, simulation, estimands, and decision rules.  It creates no labels, authorizes no API/judge calls, and
-cannot unlock covariance deployment, independent batching, QR specialization, or CUDA claims.
+This PR is deliberately no-spend: it freezes the **planned** candidate-capacity grid, outcome-blind selector
+contract, repeat-aware data contract, simulation, estimands, and decision rules.  It creates no labels,
+authorizes no API/judge calls, and cannot unlock covariance deployment, independent batching, QR
+specialization, or CUDA claims.  The candidate builder and approved live request contract are not included;
+caller-supplied hashes make a dry-run reproducible but do not verify those missing artifacts.
 
 If a named judge or prompt is unavailable, this document must be amended before any fresh response exists.
 Operational dry runs may use synthetic responses only.  A 64-component live engineering pilot is permitted
@@ -57,12 +59,18 @@ stratum and are never pooled silently.
 
 To amortize the system prompt, one confirmatory request contains up to ten rows from distinct endpoint
 components and a single row role.  Prompt-block membership is stable across roles, judges, and repeats, so the
-request-connected dependence clusters remain bounded.  A block and all of its rows remain wholly inside one
+request-connected dependence clusters remain bounded.  Each role-by-judge measurement gets an independent
+deterministic base order and evenly spaced repeat rotations.  Exact serialized request-input bytes are hashed
+into request identity, and provider call identities may not be reused across logical attempts.  A block and all
+of its rows remain wholly inside one
 corpus, outer fold, and global inner-fold label; no request crosses an analysis boundary.  The prompt block,
 not an individual component, is the conservative inference/resampling cluster.  Request and block effects are
 integrated as held random effects using covariance fit inside training folds; their realized held values are
 not estimated from training data.  The later `N_item=128,M_channel=32` numerical batch is a different
 conditioning layout over already collected measurements.
+
+Every submitted score row includes a stable `row_id`; the eventual approved prompt/parser must return that key.
+Responses join on `(request_id,row_id)` and never infer identity from list position.
 
 Repeats are not averaged before variance decomposition.  The analysis reports:
 
@@ -177,6 +185,9 @@ epsilon_gir ~ Normal(0, I_item tensor W_call).
 ```
 
 `w`, `b`, and request-level missingness are generated and refit; uncertainty resamples stable prompt blocks.
+The synthetic sizing model does **not** generate arbitrary list-position effects.  Counterbalanced scheduling
+mitigates but does not identify that nuisance: live approval requires an engineering pilot, a frozen
+position-by-role-by-judge train-only adjustment, and a position-effect power sensitivity in a later amendment.
 The **block null** sets graph-local persistent item coupling to zero while retaining fitted prompt, wave, and
 row-call incidence covariance; it is not full independence of every row in `R`.  Candidate item covariances
 are explicit feature Grams.  Frozen scenarios are block null, smooth-mean only,
@@ -187,7 +198,9 @@ only graph-local persistent coupling.
 
 Every null and alternative replicate repeats component splitting, mean/ridge selection, repeat decomposition,
 `W_call`, `B`, kernel/mixture/coupling selection, loading, and endpoint scoring.  Cache only outcome-blind feature
-Grams, folds, eigensystems, and linear-system structure.  Seeds derive from `(G,R,scenario,replicate)`; scientific
+Grams, folds, eigensystems, and linear-system structure across replicates.  Ephemeral factor memoization is
+permitted only within one fitted nuisance object and may not cross a fit, fold, replicate, scenario, or corpus.
+Seeds derive from `(G,R,scenario,replicate)`; scientific
 JSON excludes wall time and output paths.
 
 The frozen implementation details are: prompt-block capacity 10; five outer and three inner folds; mean-ridge
@@ -215,8 +228,8 @@ draw, and apply the resulting threshold only to that fold's untouched held block
 The reported primary-event count is the smallest `G` for which the joint two-corpus simulation, at
 `rho_max=.10` and `.20`, satisfies:
 
-1. graph-local block-null false primary promotion does not reject `p<=.05` in a one-sided exact binomial test at 5%,
-   and its observed rate is at most 10%;
+1. for **both** the graph-local block null and zero-coupling smooth-mean-only control, false primary promotion
+   does not reject `p<=.05` in a one-sided exact binomial test at 5%, and the observed rate is at most 10%;
 2. simultaneous residual/posterior primary-event power is at least 80% for cumulative, Nomic, and mixture
    truths in both corpora;
 3. mean selected outer-held residual NLL gain is positive;

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -223,7 +223,7 @@ every primary lower bound must exceed zero.  Secondary requirements are:
 
 - posterior calibration/coverage and Mahalanobis diagnostics do not worsen;
 - decision log-loss and margin-gated AURC degradation are each at most `.01`;
-- ECE uses ten fixed equal-width bins and AURC uses component bootstrap intervals;
+- ECE uses ten fixed equal-width bins and AURC uses prompt-block bootstrap intervals;
 - graph/Nomic source correlations and same-split ablations are reported;
 - topology benefit exceeds derangement/hard negatives;
 - statistical and numerical loading remain below frozen report-only limits.
@@ -241,20 +241,31 @@ whitened coordinates,
 
 ```text
 C_safe = (1-s_safe) I + s_safe C_hat,
-R_safe = (I_N tensor L_B)
-         [C_safe tensor I_m + delta_95 I_(N*m)]
-         (I_N tensor L_B)^T
-         + I_N tensor W_call/R_eff.
+L = I_N tensor L_B,
+R_safe = L [C_safe tensor I_m
+            + T_call + T_prompt + T_wave
+            + delta_95 I_(N*m)] L^T.
 ```
 
 `C_hat` is the already rho-matched selected `C(K_gamma,rho_max)`, `B=L_B L_B^T` is the persistent channel
-covariance, and `R_eff` is the number of independent calls averaged for that deployed measurement.  Thus
-`s_safe` is distinguishable from the kernel path coefficient `alpha(K,rho)` and call noise is not silently
-absorbed into persistent covariance.
+covariance, and `R_eff` is the number of independent calls averaged for that deployed measurement.  In the
+same whitened coordinates,
+
+```text
+T_call   = L^-1 [I_N tensor (W_call/R_eff)] L^-T,
+R_prompt = sum_q Z_q V_prompt,f(q) Z_q^T,
+T_prompt = L^-1 R_prompt L^-T.
+```
+
+`Z_q` is the frozen request-incidence/channel matrix including the actual repeat-mean aggregation weights;
+it is zero for observations not in request `q`.  `T_wave` is defined analogously from retained wave effects
+and is zero only when their fitted removal plus uncertainty envelope is demonstrated.  Missing calls change
+the recorded `Z_q` weights rather than being replaced by a nominal common `R`.  Thus `s_safe` is
+distinguishable from the kernel path coefficient `alpha(K,rho)`, and neither row-specific call noise nor
+shared prompt/wave covariance is silently absorbed into persistent `B`.
 
 For each inner split, whiten with training-only `B`, form the inner-held repeat-mean residual second moment
-`S_held`, include the correspondingly whitened `W_call/R_eff` term in `T_model`, and record the positive
-missing-mass statistic
+`S_held`, include `T_call`, `T_prompt`, and `T_wave` in `T_model`, and record the positive missing-mass statistic
 
 ```text
 e_delta = max(0, lambda_max(S_held - T_model)).
@@ -267,6 +278,10 @@ loading are distinct and reported separately.  Distance-separated batching addit
 simultaneous 95% upper bound on every proposed cross-batch whitened block norm below
 `epsilon_batch=.025`, the smallest nonzero coupling resolved by the frozen selector grid; neither small
 `alpha`, large distance, nor added loading establishes independence.
+
+The schedule-dependent prompt term need not commute with `C_safe tensor B`.  Dense joint QR remains valid;
+the single-item-kernel eigenmode shortcut is eligible only when the extra terms are block separable or their
+commutation is proved for the deployed schedule.
 
 ## Decision outcomes
 

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -53,6 +53,10 @@ Four waves are a frozen sensitivity design.  Wave, request, batch, model revisio
 timestamp, raw response, retry, and failure identity are retained.  Model or prompt changes create a new
 stratum and are never pooled silently.
 
+One confirmatory request contains exactly one campaign row.  Grouping several rows into a scorer prompt would
+add an unmodelled request-level dependence and is prohibited.  The later `N_item=128,M_channel=32` numerical
+batch is a conditioning layout over already collected measurements, not a multi-row judge request.
+
 Repeats are not averaged before variance decomposition.  The analysis reports:
 
 1. within-call D/S covariance and judge-specific sampling variance from repeat deviations;
@@ -210,9 +214,11 @@ PoE is retained only as a control.
 
 ## PSD-safe deployment adapter and batching
 
-No elementwise covariance lower bound is called conservative.  Select `alpha_safe` inside outer training,
-using only its inner-held components, as the largest frozen-grid value whose multiplicity-adjusted benefit
-lower bound is positive; otherwise use zero.  In whitened coordinates,
+No elementwise covariance lower bound is called conservative.  Select the shrinkage multiplier
+`alpha_safe` from `{0,.25,.50,.75,1}` inside outer training, using only its inner-held components, as the
+largest value whose multiplicity-adjusted benefit lower bound is positive; otherwise use zero.  It multiplies
+the already selected, rho-matched correlation path and is not a second unconstrained covariance fit.  In
+whitened coordinates,
 
 ```text
 C_alpha = (1-alpha_safe) I + alpha_safe C_hat,
@@ -221,10 +227,20 @@ R_safe = (I_N tensor L_B)
          (I_N tensor L_B)^T.
 ```
 
-`delta_95` is the full-procedure 95th percentile of maximum missing spectral mass.  Statistical `delta_95` and
-numerical Cholesky loading are distinct and reported separately.  Distance-separated batching additionally
-requires a simultaneous 95% upper bound on every proposed cross-batch whitened block norm below a separately
-frozen `epsilon_batch`; neither small `alpha` nor added loading establishes independence.
+For each inner split, whiten with training-only `B`, form the inner-held residual second moment `S_held`, and
+record the positive missing-mass statistic
+
+```text
+e_delta = max(0, lambda_max(S_held - C_alpha)).
+```
+
+`delta_95` is the simultaneous one-sided 95% upper component-bootstrap bound on the maximum `e_delta` across
+inner splits and required corpora, with the whole mean/covariance/selector refit inside each resample.  If that
+bound is not finite and identified, deployment fails closed.  Statistical `delta_95` and numerical Cholesky
+loading are distinct and reported separately.  Distance-separated batching additionally requires a
+simultaneous 95% upper bound on every proposed cross-batch whitened block norm below
+`epsilon_batch=.025`, the smallest nonzero coupling resolved by the frozen selector grid; neither small
+`alpha`, large distance, nor added loading establishes independence.
 
 ## Decision outcomes
 

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -66,7 +66,8 @@ layout over already collected measurements.
 Repeats are not averaged before variance decomposition.  The analysis reports:
 
 1. within-call D/S covariance and judge-specific sampling variance from repeat deviations;
-2. persistent item/judge covariance from repeat means with the `W_call/R` diagonal correction;
+2. persistent item/judge covariance from repeat means after subtracting the full fitted repeat-mean sampling
+   covariance (`R_call + R_prompt + R_wave`), not only a diagonal `W_call/R` term;
 3. cross-repeat U-statistic covariance;
 4. same-wave covariance after fitted wave-effect removal; and
 5. the same-wave-minus-cross-wave contrast.
@@ -252,29 +253,40 @@ covariance, and `R_eff` is the number of independent calls averaged for that dep
 same whitened coordinates,
 
 ```text
-T_call   = L^-1 [I_N tensor (W_call/R_eff)] L^-T,
+R_call   = sum_t A_t W_call,f(t) A_t^T,
+T_call   = L^-1 R_call L^-T,
 R_prompt = sum_q Z_q V_prompt,f(q) Z_q^T,
 T_prompt = L^-1 R_prompt L^-T.
 ```
 
-`Z_q` is the frozen request-incidence/channel matrix including the actual repeat-mean aggregation weights;
-it is zero for observations not in request `q`.  `T_wave` is defined analogously from retained wave effects
-and is zero only when their fitted removal plus uncertainty envelope is demonstrated.  Missing calls change
-the recorded `Z_q` weights rather than being replaced by a nominal common `R`.  Thus `s_safe` is
+Here `t` indexes an observed row-specific call and `q` an actual family/role/wave prompt request.  `A_t` and
+`Z_q` have shape `(N*m, m_f)`, map the affected family channels into the full observation vector, and contain
+the actual repeat-mean aggregation weights; they are zero for unaffected observations.  `T_wave` is defined
+analogously from retained wave effects and is zero only when their fitted removal plus uncertainty envelope is
+demonstrated.  Missing calls change the recorded `A_t` and `Z_q` weights rather than being replaced by a nominal
+common `R`.  Thus `s_safe` is
 distinguishable from the kernel path coefficient `alpha(K,rho)`, and neither row-specific call noise nor
 shared prompt/wave covariance is silently absorbed into persistent `B`.
 
-For each inner split, whiten with training-only `B`, form the inner-held repeat-mean residual second moment
-`S_held`, include `T_call`, `T_prompt`, and `T_wave` in `T_model`, and record the positive missing-mass statistic
+For each inner split/corpus index `j`, whiten with training-only `B`, form the inner-held repeat-mean residual
+second moment `S_held,j`, include `T_call`, `T_prompt`, and `T_wave` in `T_model,j`, and record
 
 ```text
-e_delta = max(0, lambda_max(S_held - T_model)).
+theta_hat_j = lambda_max(S_held,j - T_model,j).
 ```
 
-`delta_95` is the simultaneous one-sided 95% upper prompt-block-bootstrap bound on the maximum `e_delta` across
-inner splits and required corpora, with the whole mean/covariance/selector refit inside each resample.  If that
-bound is not finite and identified, deployment fails closed.  Statistical `delta_95` and numerical Cholesky
-loading are distinct and reported separately.  Distance-separated batching additionally requires a
+Under exchangeable prompt blocks, refit the whole mean/covariance/selector in every block-bootstrap resample
+and compute
+
+```text
+c_95 = quantile_.95(max_j(theta_hat_j - theta_hat_star_j)),
+delta_95 = max(0, max_j(theta_hat_j + c_95)).
+```
+
+This is the centered simultaneous one-sided missing-mass bound; an uncentered percentile of `theta_hat` is not
+substituted.  If prompt blocks are not exchangeable or the bound is not finite and identified, deployment fails
+closed.  Statistical `delta_95` and numerical Cholesky loading are distinct and reported separately.
+Distance-separated batching additionally requires a
 simultaneous 95% upper bound on every proposed cross-batch whitened block norm below
 `epsilon_batch=.025`, the smallest nonzero coupling resolved by the frozen selector grid; neither small
 `alpha`, large distance, nor added loading establishes independence.
@@ -282,6 +294,12 @@ simultaneous 95% upper bound on every proposed cross-batch whitened block norm b
 The schedule-dependent prompt term need not commute with `C_safe tensor B`.  Dense joint QR remains valid;
 the single-item-kernel eigenmode shortcut is eligible only when the extra terms are block separable or their
 commutation is proved for the deployed schedule.
+
+This campaign's local covariance blocks contain three rows.  Its `delta_95` is not extrapolated to a coherent
+128-item block: omitted spectral mass can grow with block size.  An `N_item=128` conditioner may be tested for
+numerical equivalence against stipulated covariance, but statistical deployment at that scale additionally
+requires an `N=128` full-procedure simulation/validation or an explicit N-aware matrix-concentration/row-sum
+envelope.
 
 ## Decision outcomes
 

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -35,6 +35,10 @@ consuming selection.  Structural near/far defines the sampling contrast; cumulat
 are retained continuously.  The target count is determined by the power procedure below, separately for every
 corpus required to pass.
 
+`G` is the component count **per required corpus**.  Each corpus has 32 joint cells (four hop transitions by
+four degree quartiles by two agreement classes), so every frozen `G` supports exact equal cell counts.  The
+selector rejects a requested per-corpus total that cannot preserve those frozen quotas.
+
 ## Repeated-call estimand
 
 For component `g`, row `i`, judge family `f`, and independent call wave `r`, the conditional residual model is
@@ -110,8 +114,11 @@ zoo requires a new preregistration and recalibrated null before outcomes.
 
 ## Component-disjoint fitting contract
 
-Each corpus uses five deterministic outer folds and three inner component folds.  Every row, repeat, and judge
-from one endpoint component remains in one fold.  Endpoint IDs and normalized titles are disjoint across folds.
+Each corpus uses five deterministic outer folds and three inner component folds.  Fold totals differ by at most
+one, and each feasible stratum margin is distributed as evenly as integer counts allow; equal per-cell counts
+inside every fold are not required.  Every row, repeat, and judge from one endpoint component remains in one
+fold.  Endpoint IDs and normalized titles are disjoint across folds.  For every outer-held fold the selector
+also materializes the three inner-fold assignments of its outer-training components, before outcomes exist.
 All outcome-dependent objects are refit inside the appropriate training components:
 
 - judge calibration and conditionalization;

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -14,8 +14,8 @@ only under a separate amendment and must be permanently excluded from confirmati
 ## Question and experimental unit
 
 The question is whether an outcome-blind graph/semantic geometry predicts transferable cross-item conditional
-measurement error after calibration and mean removal.  The independent unit is an endpoint-disjoint component
-containing three rows with a shared descendant `x`:
+measurement error after calibration and mean removal.  The structural sampling unit is an endpoint-disjoint
+component containing three rows with a shared descendant `x`:
 
 ```text
 anchor:             (x, a)
@@ -41,21 +41,27 @@ selector rejects a requested per-corpus total that cannot preserve those frozen 
 
 ## Repeated-call estimand
 
-For component `g`, row `i`, judge family `f`, and independent call wave `r`, the conditional residual model is
+For component `g`, row `i`, judge family `f`, independent call wave `r`, and prompt block `p(g)`, the
+conditional residual model is
 
 ```text
-q_gifr = m(x_gi, f) + u_gif + w_fr + epsilon_gifr.
+q_gifr = m(x_gi, f) + u_gif + w_fr + b_f,r,role(i),p(g) + epsilon_gifr.
 ```
 
-`u` is persistent item-by-judge error, `w` is an optional recorded repeat-wave effect, and `epsilon` is fresh
-call noise.  Every selected row is crossed with at least three fresh, stateless requests per judge family.
+`u` is persistent item-by-judge error, `w` is an optional recorded repeat-wave effect, `b` is a fresh shared
+prompt-request effect, and `epsilon` is row-specific call noise.  Every selected row is crossed with at least
+three fresh, stateless request waves per judge family.
 Four waves are a frozen sensitivity design.  Wave, request, batch, model revision, prompt hash, settings/seed,
 timestamp, raw response, retry, and failure identity are retained.  Model or prompt changes create a new
 stratum and are never pooled silently.
 
-One confirmatory request contains exactly one campaign row.  Grouping several rows into a scorer prompt would
-add an unmodelled request-level dependence and is prohibited.  The later `N_item=128,M_channel=32` numerical
-batch is a conditioning layout over already collected measurements, not a multi-row judge request.
+To amortize the system prompt, one confirmatory request contains up to ten rows from distinct endpoint
+components and a single row role.  Prompt-block membership is stable across roles, judges, and repeats, so the
+request-connected dependence clusters remain bounded.  A block and all of its rows remain wholly inside one
+corpus, outer fold, and global inner-fold label; no request crosses an analysis boundary.  The prompt block,
+not an individual component, is the conservative inference/resampling cluster.  Request and block effects are
+refit inside training folds.  The later `N_item=128,M_channel=32` numerical batch is a different conditioning
+layout over already collected measurements.
 
 Repeats are not averaged before variance decomposition.  The analysis reports:
 
@@ -82,13 +88,14 @@ Each produces the frozen D/S response schema.  Luna is a second measurement fami
 An operating-judge fidelity claim needs repeated operating-judge targets.  A generality/truth claim additionally
 requires a preregistered blinded third-family, human, graph-structural, or downstream target subset.
 
-For `G` selected components, three rows, `F` judge families, and `R` repeats, the planned evaluation count is
+For `G` selected components, three rows, `F` judge families, and `R` repeats, the planned item-evaluation count is
 
 ```text
-calls = 3 * G * F * R.
+item_evaluations = 3 * G * F * R.
 ```
 
-The sampler emits this count but never performs a call.
+The sampler emits this count and the smaller prompt-request count implied by the split-contained blocks, but
+never performs a call.
 
 ## One deployment-capable geometry family
 
@@ -123,6 +130,8 @@ one, and each feasible stratum margin is distributed as evenly as integer counts
 inside every fold are not required.  Every row, repeat, and judge from one endpoint component remains in one
 fold.  Endpoint IDs and normalized titles are disjoint across folds.  For every outer-held fold the selector
 also materializes the three inner-fold assignments of its outer-training components, before outcomes exist.
+Prompt blocks are then formed only among components with the same corpus/outer/inner signature, and whole
+prompt blocks—not component rows—are the resampling units for uncertainty intervals.
 All outcome-dependent objects are refit inside the appropriate training components:
 
 - judge calibration and conditionalization;
@@ -151,11 +160,12 @@ smoke tests may use smaller explicit CLI values but cannot set the reported reco
 The repeat-aware generator uses two judge families by D/S channels (`m=4`) and three rows per component:
 
 ```text
-q_gir = X_gi beta + u_gi + epsilon_gir,
+q_gir = X_gi beta + u_gi + w_r + b_r,role(i),p(g) + epsilon_gir,
 u_g ~ Normal(0, C_theta,g tensor B_persistent),
 epsilon_gir ~ Normal(0, I_item tensor W_call).
 ```
 
+`w`, `b`, and request-level missingness are generated and refit; uncertainty resamples stable prompt blocks.
 Candidate item covariances are explicit feature Grams.  Frozen scenarios are block null, smooth-mean only,
 cumulative truth, Nomic truth, convex-mixture truth, and equal-energy derangement at `rho_max=.04,.10,.20`.
 An optional shared-wave scenario is labelled separately.  Nulls preserve component topology, regional mean,
@@ -166,6 +176,14 @@ Every null and alternative replicate repeats component splitting, mean/ridge sel
 `W_call`, `B`, kernel/mixture/coupling selection, loading, and endpoint scoring.  Cache only outcome-blind feature
 Grams, folds, eigensystems, and linear-system structure.  Seeds derive from `(G,R,scenario,replicate)`; scientific
 JSON excludes wall time and output paths.
+
+The frozen implementation details are: prompt-block capacity 10; five outer and three inner folds; mean-ridge
+grid `{0,.01,.1,1,10}`; 5% shrinkage toward channel-diagonal targets for `W_call` and `B`; and a relative
+numerical SPD floor of `1e-8`.  A non-block candidate is inner-eligible only when its macro held gain is positive
+and at least two of three inner folds are positive.  Ties prefer larger gain, then smaller `rho_max`, then
+`gamma` closest to `.5`, then smaller `gamma`.  The committed simulation module freezes the numeric generative
+`W_call`, `B`, mean, wave, request, heteroskedasticity, and missingness constants; its content hash is recorded
+before a reported run and changing it requires a new preregistered run.
 
 The finite familywise threshold is the upper-95% null order statistic at one-based rank
 
@@ -179,7 +197,8 @@ with strict `observed > threshold` promotion.  Calibration and evaluation null s
 
 The recommended count is the smallest `G` for which, at `rho_max=.10` and `.20`:
 
-1. independent block-null false deployment is consistent with the nominal 5% familywise rule and at most 10%;
+1. independent block-null false deployment does not reject `p<=.05` in a one-sided exact binomial test at 5%,
+   and its observed rate is at most 10%;
 2. full deployment-event power is at least 80% for cumulative, Nomic, and mixture truths;
 3. mean selected outer-held residual NLL gain is positive;
 4. mean harm is nonpositive under block-null and smooth-mean controls;
@@ -198,7 +217,7 @@ d_residual,g  = NLL_block,g - NLL_structured,g
 d_posterior,g = posterior_NLL_block,g - posterior_NLL_structured,g.
 ```
 
-Use a preregistered one-sided component multiplier/max-statistic construction for simultaneous 95% lower bounds
+Use a preregistered one-sided prompt-block multiplier/max-statistic construction for simultaneous 95% lower bounds
 across both primary endpoints and every corpus required to pass.  The familywise selector must reject block and
 every primary lower bound must exceed zero.  Secondary requirements are:
 
@@ -215,26 +234,33 @@ PoE is retained only as a control.
 ## PSD-safe deployment adapter and batching
 
 No elementwise covariance lower bound is called conservative.  Select the shrinkage multiplier
-`alpha_safe` from `{0,.25,.50,.75,1}` inside outer training, using only its inner-held components, as the
+`s_safe` from `{0,.25,.50,.75,1}` inside outer training, using only its inner-held components, as the
 largest value whose multiplicity-adjusted benefit lower bound is positive; otherwise use zero.  It multiplies
 the already selected, rho-matched correlation path and is not a second unconstrained covariance fit.  In
 whitened coordinates,
 
 ```text
-C_alpha = (1-alpha_safe) I + alpha_safe C_hat,
+C_safe = (1-s_safe) I + s_safe C_hat,
 R_safe = (I_N tensor L_B)
-         [C_alpha tensor I_m + delta_95 I_(N*m)]
-         (I_N tensor L_B)^T.
+         [C_safe tensor I_m + delta_95 I_(N*m)]
+         (I_N tensor L_B)^T
+         + I_N tensor W_call/R_eff.
 ```
 
-For each inner split, whiten with training-only `B`, form the inner-held residual second moment `S_held`, and
-record the positive missing-mass statistic
+`C_hat` is the already rho-matched selected `C(K_gamma,rho_max)`, `B=L_B L_B^T` is the persistent channel
+covariance, and `R_eff` is the number of independent calls averaged for that deployed measurement.  Thus
+`s_safe` is distinguishable from the kernel path coefficient `alpha(K,rho)` and call noise is not silently
+absorbed into persistent covariance.
+
+For each inner split, whiten with training-only `B`, form the inner-held repeat-mean residual second moment
+`S_held`, include the correspondingly whitened `W_call/R_eff` term in `T_model`, and record the positive
+missing-mass statistic
 
 ```text
-e_delta = max(0, lambda_max(S_held - C_alpha)).
+e_delta = max(0, lambda_max(S_held - T_model)).
 ```
 
-`delta_95` is the simultaneous one-sided 95% upper component-bootstrap bound on the maximum `e_delta` across
+`delta_95` is the simultaneous one-sided 95% upper prompt-block-bootstrap bound on the maximum `e_delta` across
 inner splits and required corpora, with the whole mean/covariance/selector refit inside each resample.  If that
 bound is not finite and identified, deployment fails closed.  Statistical `delta_95` and numerical Cholesky
 loading are distinct and reported separately.  Distance-separated batching additionally requires a

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -41,8 +41,8 @@ selector rejects a requested per-corpus total that cannot preserve those frozen 
 
 ## Repeated-call estimand
 
-For component `g`, row `i`, judge family `f`, independent call wave `r`, and prompt block `p(g)`, the
-conditional residual model is
+For component `g`, row `i`, judge family `f`, independent call wave `r`, and prompt block `p(g)`, the D/S
+conditional residual vector `q_gifr in R^2` follows
 
 ```text
 q_gifr = m(x_gi, f) + u_gif + w_fr + b_f,r,role(i),p(g) + epsilon_gifr.
@@ -60,8 +60,9 @@ components and a single row role.  Prompt-block membership is stable across role
 request-connected dependence clusters remain bounded.  A block and all of its rows remain wholly inside one
 corpus, outer fold, and global inner-fold label; no request crosses an analysis boundary.  The prompt block,
 not an individual component, is the conservative inference/resampling cluster.  Request and block effects are
-refit inside training folds.  The later `N_item=128,M_channel=32` numerical batch is a different conditioning
-layout over already collected measurements.
+integrated as held random effects using covariance fit inside training folds; their realized held values are
+not estimated from training data.  The later `N_item=128,M_channel=32` numerical batch is a different
+conditioning layout over already collected measurements.
 
 Repeats are not averaged before variance decomposition.  The analysis reports:
 
@@ -126,13 +127,19 @@ zoo requires a new preregistration and recalibrated null before outcomes.
 
 ## Component-disjoint fitting contract
 
-Each corpus uses five deterministic outer folds and three inner component folds.  Fold totals differ by at most
-one, and each feasible stratum margin is distributed as evenly as integer counts allow; equal per-cell counts
-inside every fold are not required.  Every row, repeat, and judge from one endpoint component remains in one
-fold.  Endpoint IDs and normalized titles are disjoint across folds.  For every outer-held fold the selector
-also materializes the three inner-fold assignments of its outer-training components, before outcomes exist.
+Each corpus uses five deterministic outer folds and three inner component folds.  **Outer** fold totals differ
+by at most one, and each feasible stratum margin is distributed as evenly as integer counts allow; equal
+per-cell counts inside every fold are not required.  A single stable global inner label keeps prompt requests
+from crossing any nested split.  On the frozen G grid, each leave-one-outer training set's inner totals differ
+by at most two; at `G=160` a 44/42/42 split is the unavoidable integer optimum, so a false at-most-one rule is
+not imposed.  Every row, repeat, and judge from one endpoint component remains in one fold.  Endpoint IDs and
+normalized titles are disjoint across folds.  For every outer-held fold the selector also materializes the
+three inner-fold assignments of its outer-training components, before outcomes exist.
 Prompt blocks are then formed only among components with the same corpus/outer/inner signature, and whole
 prompt blocks—not component rows—are the resampling units for uncertainty intervals.
+Every `(corpus, source_component)` group is also wholly contained in one outer and global inner fold.  Primary
+intervals use prompt blocks; a two-way prompt-block/source-component multiplier sensitivity must also pass,
+unless source-component dependence is proved absent from training-only residual diagnostics.
 All outcome-dependent objects are refit inside the appropriate training components:
 
 - judge calibration and conditionalization;
@@ -146,7 +153,7 @@ All outcome-dependent objects are refit inside the appropriate training componen
 If the graph judge/model is trained on the adjacent-positive/distant-negative curriculum, training is restricted
 to outer-training components and repeated inside each outer fold.  Held components never teach the mean model.
 
-## Frozen full-procedure simulation
+## Frozen synthetic primary-event simulation
 
 The primary sample-size grid per required corpus is
 
@@ -167,11 +174,13 @@ epsilon_gir ~ Normal(0, I_item tensor W_call).
 ```
 
 `w`, `b`, and request-level missingness are generated and refit; uncertainty resamples stable prompt blocks.
-Candidate item covariances are explicit feature Grams.  Frozen scenarios are block null, smooth-mean only,
+The **block null** sets graph-local persistent item coupling to zero while retaining fitted prompt, wave, and
+row-call incidence covariance; it is not full independence of every row in `R`.  Candidate item covariances
+are explicit feature Grams.  Frozen scenarios are block null, smooth-mean only,
 cumulative truth, Nomic truth, convex-mixture truth, and equal-energy derangement at `rho_max=.04,.10,.20`.
 An optional shared-wave scenario is labelled separately.  Nulls preserve component topology, regional mean,
-repeat heteroskedasticity, within-call D/S covariance, missingness, and any wave strata while removing cross-item
-coupling.
+repeat heteroskedasticity, within-call D/S covariance, missingness, and any wave/prompt strata while removing
+only graph-local persistent coupling.
 
 Every null and alternative replicate repeats component splitting, mean/ridge selection, repeat decomposition,
 `W_call`, `B`, kernel/mixture/coupling selection, loading, and endpoint scoring.  Cache only outcome-blind feature
@@ -186,28 +195,37 @@ and at least two of three inner folds are positive.  Ties prefer larger gain, th
 `W_call`, `B`, mean, wave, request, heteroskedasticity, and missingness constants; its content hash is recorded
 before a reported run and changing it requires a new preregistered run.
 
-The finite familywise threshold is the upper-95% null order statistic at one-based rank
+For synthetic sizing, the finite familywise threshold is the upper-95% null order statistic at one-based rank
 
 ```text
 ceil(.95 * (K_null + 1)).
 ```
 
-with strict `observed > threshold` promotion.  Calibration and evaluation null seeds are disjoint.
+with strict `observed > threshold` promotion.  Calibration and evaluation null seeds are disjoint.  This
+synthetic threshold is never transferred to real residuals.  Inside every real outer fold, recalibrate the same
+complete selector from outer-training prompt blocks under a graph-local block null that retains fitted
+mean/call/prompt/wave/missingness/source structure; rerun every nuisance fit and inner selection in each null
+draw, and apply the resulting threshold only to that fold's untouched held blocks.
 
-## Simulation sizing gate
+## Synthetic primary-event sizing gate
 
-The recommended count is the smallest `G` for which, at `rho_max=.10` and `.20`:
+The reported primary-event count is the smallest `G` for which the joint two-corpus simulation, at
+`rho_max=.10` and `.20`, satisfies:
 
-1. independent block-null false deployment does not reject `p<=.05` in a one-sided exact binomial test at 5%,
+1. graph-local block-null false primary promotion does not reject `p<=.05` in a one-sided exact binomial test at 5%,
    and its observed rate is at most 10%;
-2. full deployment-event power is at least 80% for cumulative, Nomic, and mixture truths;
+2. simultaneous residual/posterior primary-event power is at least 80% for cumulative, Nomic, and mixture
+   truths in both corpora;
 3. mean selected outer-held residual NLL gain is positive;
 4. mean harm is nonpositive under block-null and smooth-mean controls;
 5. topology truth beats the equal-energy derangement in at least 80% of replicates; and
 6. the procedure does not pass with an incomplete scenario grid.
 
-If no grid value passes, increase independent components.  Do not reduce confidence, drop a difficult truth,
-or use additional repeats as a substitute for components.
+This is not yet the final campaign `G`: decision calibration, margin-AURC/noninferiority, source-component
+sensitivity, `s_safe/delta_95`, and cross-batch safety are unsimulated secondary gates and therefore fail
+closed in this PR.  A final count requires their own power/feasibility bridge and is at least the primary-event
+count.  If no grid value passes, increase prompt-block/source-component information.  Do not reduce confidence,
+drop a difficult truth, or use additional repeats as a substitute for independent structure.
 
 ## Real-data endpoints and simultaneous inference
 
@@ -220,14 +238,17 @@ d_posterior,g = posterior_NLL_block,g - posterior_NLL_structured,g.
 
 Use a preregistered one-sided prompt-block multiplier/max-statistic construction for simultaneous 95% lower bounds
 across both primary endpoints and every corpus required to pass.  The familywise selector must reject block and
-every primary lower bound must exceed zero.  Secondary requirements are:
+every primary lower bound must exceed zero both before and after the complete `R_safe` adapter (including
+`delta_95` and numerical loading).  Secondary requirements are:
 
 - posterior calibration/coverage and Mahalanobis diagnostics do not worsen;
 - decision log-loss and margin-gated AURC degradation are each at most `.01`;
 - ECE uses ten fixed equal-width bins and AURC uses prompt-block bootstrap intervals;
 - graph/Nomic source correlations and same-split ablations are reported;
 - topology benefit exceeds derangement/hard negatives;
-- statistical and numerical loading remain below frozen report-only limits.
+- the two-way prompt-block/source-component sensitivity also passes;
+- statistical loading is reported, and relative numerical loading
+  `max(load_i / max_j R_jj)` is at most `1e-6`.
 
 JointPosterior is a learned decision comparator; it is not the covariance factorization.  Factored independent
 PoE is retained only as a control.
@@ -248,9 +269,8 @@ R_safe = L [C_safe tensor I_m
             + delta_95 I_(N*m)] L^T.
 ```
 
-`C_hat` is the already rho-matched selected `C(K_gamma,rho_max)`, `B=L_B L_B^T` is the persistent channel
-covariance, and `R_eff` is the number of independent calls averaged for that deployed measurement.  In the
-same whitened coordinates,
+`C_hat` is the already rho-matched selected `C(K_gamma,rho_max)` and `B=L_B L_B^T` is the persistent channel
+covariance.  In the same whitened coordinates,
 
 ```text
 R_call   = sum_t A_t W_call,f(t) A_t^T,
@@ -268,10 +288,13 @@ common `R`.  Thus `s_safe` is
 distinguishable from the kernel path coefficient `alpha(K,rho)`, and neither row-specific call noise nor
 shared prompt/wave covariance is silently absorbed into persistent `B`.
 
-For each inner split/corpus index `j`, whiten with training-only `B`, form the inner-held repeat-mean residual
-second moment `S_held,j`, include `T_call`, `T_prompt`, and `T_wave` in `T_model,j`, and record
+For each inner split/corpus index `j`, stack each held component's three row residuals into a `3m` vector and
+form the equal-component pooled `3m x 3m` second moment `S_held,j`; the block bootstrap resamples whole prompt
+blocks containing those vectors.  Whiten with training-only `B`, include the matching local restrictions of
+`T_call`, `T_prompt`, and `T_wave` in `T_model,j`, and record
 
 ```text
+T_model,j = C_safe,j tensor I_m + T_call,j + T_prompt,j + T_wave,j,
 theta_hat_j = lambda_max(S_held,j - T_model,j).
 ```
 

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -1,0 +1,232 @@
+# Repeated-judge graph-covariance campaign — preregistration
+
+## Status and authorization boundary
+
+**Frozen before running the new power harness, selecting any new endpoint, or making any fresh judge call.**
+This PR is deliberately no-spend: it freezes the candidate capacity, outcome-blind sampler, repeat-aware data
+contract, simulation, estimands, and decision rules.  It creates no labels, authorizes no API/judge calls, and
+cannot unlock covariance deployment, independent batching, QR specialization, or CUDA claims.
+
+If a named judge or prompt is unavailable, this document must be amended before any fresh response exists.
+Operational dry runs may use synthetic responses only.  A 64-component live engineering pilot is permitted
+only under a separate amendment and must be permanently excluded from confirmation.
+
+## Question and experimental unit
+
+The question is whether an outcome-blind graph/semantic geometry predicts transferable cross-item conditional
+measurement error after calibration and mean removal.  The independent unit is an endpoint-disjoint component
+containing three rows with a shared descendant `x`:
+
+```text
+anchor:             (x, a)
+adjacent positive:  (x, b), where a--b is a direct undirected graph edge
+matched negative:   (x, c), where distance(a,c) >= 3 or c is disconnected
+```
+
+The positive and negative roots must match on shortest descendant-to-root hop, campaign tag, and root-degree
+quartile.  The sampler balances anchor-to-comparator hop transition, anchor-degree quartile, corpus, and frozen
+graph/Nomic agreement class.  No graph endpoint ID or normalized endpoint title may occur in two selected
+components or in the historical scored campaigns.  Any graph connected component contributes at most 10% of
+a corpus sample where topology permits; otherwise the shortfall is reported and the campaign does not silently
+weaken this rule.
+
+Graph/Nomic thresholds are computed and recorded on the frozen structural candidate universe before endpoint-
+consuming selection.  Structural near/far defines the sampling contrast; cumulative-walk and Nomic similarities
+are retained continuously.  The target count is determined by the power procedure below, separately for every
+corpus required to pass.
+
+## Repeated-call estimand
+
+For component `g`, row `i`, judge family `f`, and independent call wave `r`, the conditional residual model is
+
+```text
+q_gifr = m(x_gi, f) + u_gif + w_fr + epsilon_gifr.
+```
+
+`u` is persistent item-by-judge error, `w` is an optional recorded repeat-wave effect, and `epsilon` is fresh
+call noise.  Every selected row is crossed with at least three fresh, stateless requests per judge family.
+Four waves are a frozen sensitivity design.  Wave, request, batch, model revision, prompt hash, settings/seed,
+timestamp, raw response, retry, and failure identity are retained.  Model or prompt changes create a new
+stratum and are never pooled silently.
+
+Repeats are not averaged before variance decomposition.  The analysis reports:
+
+1. within-call D/S covariance and judge-specific sampling variance from repeat deviations;
+2. persistent item/judge covariance from repeat means with the `W_call/R` diagonal correction;
+3. cross-repeat U-statistic covariance;
+4. same-wave covariance after fitted wave-effect removal; and
+5. the same-wave-minus-cross-wave contrast.
+
+Arbitrarily paired independent requests cannot identify stochastic cross-judge covariance.  It is zero by
+design unless a recorded shared wave/session supports that estimand.  Persistent cross-judge covariance is
+estimable.  A stochastic graph-local covariance claim additionally requires a positive simultaneous contrast
+in the repeat-specific component; a persistent-only result remains useful prediction error but is not relabelled
+fresh-call correlation.
+
+## Frozen judges and claim boundary
+
+The intended measurement families are:
+
+- operating judge `gpt-5.5-low` (model `gpt-5.5`, low reasoning), using the established campaign prompt;
+- cheap comparison judge `gpt-5.6-luna` (low reasoning), with train-only global affine calibration first.
+
+Each produces the frozen D/S response schema.  Luna is a second measurement family, not independent truth.
+An operating-judge fidelity claim needs repeated operating-judge targets.  A generality/truth claim additionally
+requires a preregistered blinded third-family, human, graph-structural, or downstream target subset.
+
+For `G` selected components, three rows, `F` judge families, and `R` repeats, the planned evaluation count is
+
+```text
+calls = 3 * G * F * R.
+```
+
+The sampler emits this count but never performs a call.
+
+## One deployment-capable geometry family
+
+The production baseline is block independence (`rho_max=0`).  The only nonzero family eligible to win is
+
+```text
+K_gamma = gamma K_cumulative + (1-gamma) K_Nomic,
+gamma in {0, .25, .50, .75, 1},
+rho_max in {.025, .05, .10, .20}.
+```
+
+`K_cumulative` uses walk weights `(1,.5,.25,.125)`.  Both endpoints and every convex mixture are PSD and unit
+diagonal.  For each non-block kernel, convert the common maximum off-item coupling to its path coefficient via
+
+```text
+alpha(K, rho) = rho / max_{i != j} abs(K_ij),
+C(K, rho) = (1-alpha) I + alpha K.
+```
+
+Ineligible cells with `alpha>=.95` are declared before outcomes.  This avoids the v1 error of comparing a common
+path coefficient across kernels with different off-diagonal energy.  The entire `gamma x rho_max` search is one
+familywise maximum, not five independent votes.
+
+Closed-neighborhood, same-hop walk, exact heat/resolvent, MiniLM, shared e5, Schur graph-by-Nomic, and equal-
+energy topology derangements are diagnostics or negative controls and cannot win deployment.  A broader kernel
+zoo requires a new preregistration and recalibrated null before outcomes.
+
+## Component-disjoint fitting contract
+
+Each corpus uses five deterministic outer folds and three inner component folds.  Every row, repeat, and judge
+from one endpoint component remains in one fold.  Endpoint IDs and normalized titles are disjoint across folds.
+All outcome-dependent objects are refit inside the appropriate training components:
+
+- judge calibration and conditionalization;
+- regional/role mean and its ridge choice;
+- repeat-wave effects and missing-call policy;
+- `W_call` and persistent marginal/channel covariance `B`;
+- Nomic bandwidth and any permitted kernel normalization;
+- `gamma`, `rho_max`, path coefficient, and statistical loading;
+- JointPosterior comparison/calibration and its margin gate.
+
+If the graph judge/model is trained on the adjacent-positive/distant-negative curriculum, training is restricted
+to outer-training components and repeated inside each outer fold.  Held components never teach the mean model.
+
+## Frozen full-procedure simulation
+
+The primary sample-size grid per required corpus is
+
+```text
+G in {160, 320, 512, 800}, R=3;
+R=4 sensitivity at G in {320, 800}.
+```
+
+Use 1,999 block-null calibration draws and 200 independent evaluation replicates per scenario/cell.  Synthetic
+smoke tests may use smaller explicit CLI values but cannot set the reported recommendation.
+
+The repeat-aware generator uses two judge families by D/S channels (`m=4`) and three rows per component:
+
+```text
+q_gir = X_gi beta + u_gi + epsilon_gir,
+u_g ~ Normal(0, C_theta,g tensor B_persistent),
+epsilon_gir ~ Normal(0, I_item tensor W_call).
+```
+
+Candidate item covariances are explicit feature Grams.  Frozen scenarios are block null, smooth-mean only,
+cumulative truth, Nomic truth, convex-mixture truth, and equal-energy derangement at `rho_max=.04,.10,.20`.
+An optional shared-wave scenario is labelled separately.  Nulls preserve component topology, regional mean,
+repeat heteroskedasticity, within-call D/S covariance, missingness, and any wave strata while removing cross-item
+coupling.
+
+Every null and alternative replicate repeats component splitting, mean/ridge selection, repeat decomposition,
+`W_call`, `B`, kernel/mixture/coupling selection, loading, and endpoint scoring.  Cache only outcome-blind feature
+Grams, folds, eigensystems, and linear-system structure.  Seeds derive from `(G,R,scenario,replicate)`; scientific
+JSON excludes wall time and output paths.
+
+The finite familywise threshold is the upper-95% null order statistic at one-based rank
+
+```text
+ceil(.95 * (K_null + 1)).
+```
+
+with strict `observed > threshold` promotion.  Calibration and evaluation null seeds are disjoint.
+
+## Simulation sizing gate
+
+The recommended count is the smallest `G` for which, at `rho_max=.10` and `.20`:
+
+1. independent block-null false deployment is consistent with the nominal 5% familywise rule and at most 10%;
+2. full deployment-event power is at least 80% for cumulative, Nomic, and mixture truths;
+3. mean selected outer-held residual NLL gain is positive;
+4. mean harm is nonpositive under block-null and smooth-mean controls;
+5. topology truth beats the equal-energy derangement in at least 80% of replicates; and
+6. the procedure does not pass with an incomplete scenario grid.
+
+If no grid value passes, increase independent components.  Do not reduce confidence, drop a difficult truth,
+or use additional repeats as a substitute for components.
+
+## Real-data endpoints and simultaneous inference
+
+Primary equal-component paired endpoints are:
+
+```text
+d_residual,g  = NLL_block,g - NLL_structured,g
+d_posterior,g = posterior_NLL_block,g - posterior_NLL_structured,g.
+```
+
+Use a preregistered one-sided component multiplier/max-statistic construction for simultaneous 95% lower bounds
+across both primary endpoints and every corpus required to pass.  The familywise selector must reject block and
+every primary lower bound must exceed zero.  Secondary requirements are:
+
+- posterior calibration/coverage and Mahalanobis diagnostics do not worsen;
+- decision log-loss and margin-gated AURC degradation are each at most `.01`;
+- ECE uses ten fixed equal-width bins and AURC uses component bootstrap intervals;
+- graph/Nomic source correlations and same-split ablations are reported;
+- topology benefit exceeds derangement/hard negatives;
+- statistical and numerical loading remain below frozen report-only limits.
+
+JointPosterior is a learned decision comparator; it is not the covariance factorization.  Factored independent
+PoE is retained only as a control.
+
+## PSD-safe deployment adapter and batching
+
+No elementwise covariance lower bound is called conservative.  Select `alpha_safe` inside outer training as
+the largest frozen-grid value whose multiplicity-adjusted held-benefit lower bound is positive; otherwise use
+zero.  In whitened coordinates,
+
+```text
+C_alpha = (1-alpha_safe) I + alpha_safe C_hat,
+R_safe = (I tensor L_B) [C_alpha + delta_95 I] (I tensor L_B)^T.
+```
+
+`delta_95` is the full-procedure 95th percentile of maximum missing spectral mass.  Statistical `delta_95` and
+numerical Cholesky loading are distinct and reported separately.  Distance-separated batching additionally
+requires a simultaneous 95% upper bound on every proposed cross-batch whitened block norm below a separately
+frozen `epsilon_batch`; neither small `alpha` nor added loading establishes independence.
+
+## Decision outcomes
+
+This no-spend PR can conclude only that the protocol and tooling are valid or that they require redesign.  The
+later campaign can conclude:
+
+- **promote one item kernel to dense-QR validation**, if every simultaneous/statistical/repeat gate passes;
+- **retain block covariance**, if the gates fail; or
+- **not identified**, if repeat, power, calibration, or data-quality requirements fail.
+
+Only the first outcome unlocks the single-kernel eigenmode/QR/CUDA comparison at
+`N_item=128, M_channel=32, P_state=2`.  Multiple noncommuting kernels, explicit covariance inversion,
+eigenvalue clipping as structural repair, randomized eigensolvers, and automatic block discovery remain
+deferred.

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -130,9 +130,12 @@ zoo requires a new preregistration and recalibrated null before outcomes.
 Each corpus uses five deterministic outer folds and three inner component folds.  **Outer** fold totals differ
 by at most one, and each feasible stratum margin is distributed as evenly as integer counts allow; equal
 per-cell counts inside every fold are not required.  A single stable global inner label keeps prompt requests
-from crossing any nested split.  On the frozen G grid, each leave-one-outer training set's inner totals differ
-by at most two; at `G=160` a 44/42/42 split is the unavoidable integer optimum, so a false at-most-one rule is
-not imposed.  Every row, repeat, and judge from one endpoint component remains in one fold.  Endpoint IDs and
+from crossing any nested split.  In the synthetic sizing model, where components are the dependency atoms,
+each leave-one-outer training set's inner totals differ by at most two; at `G=160` a 44/42/42 split is the
+unavoidable integer optimum, so a false at-most-one rule is not imposed.  In the real sampler,
+`(corpus, source_component)` groups are indivisible and their realized leave-one-outer imbalance is recorded;
+it is not silently described as the synthetic optimum.  Every row, repeat, and judge from one endpoint
+component remains in one fold.  Endpoint IDs and
 normalized titles are disjoint across folds.  For every outer-held fold the selector also materializes the
 three inner-fold assignments of its outer-training components, before outcomes exist.
 Prompt blocks are then formed only among components with the same corpus/outer/inner signature, and whole

--- a/prototypes/mu_cosine/REPORT_graph_geometry_confirmatory.md
+++ b/prototypes/mu_cosine/REPORT_graph_geometry_confirmatory.md
@@ -203,9 +203,12 @@ The append-only rationale and reconsideration conditions are in `DECISIONS_graph
 
 ## Next confirmatory campaign
 
-1. Sample more than 400 independent endpoint components; use a full-procedure simulation to set the final count.
+1. Use the repeated-judge full-procedure simulation to size the registered `G={160,320,512,800}` grid; do not
+   carry forward the earlier informal “more than 400” estimate as a fixed campaign count.
 2. Within components, balance anchor, direct/local positive, and matched distant/hard-negative triples.
-3. Obtain at least three independent calls per judge family and retain call identity.
+3. Obtain at least three independent call waves per judge family and retain call identity.  Amortize the system
+   prompt over stable split-contained blocks of at most ten same-role rows, retain request identity, and model
+   the resulting shared-prompt covariance; do not treat rows from one request as independent.
 4. Oversample graph/Nomic disagreement cells rather than relying on their 1.7--2.8% natural frequency.
 5. Primary covariance candidates: block, closed-neighborhood, cumulative-walk, Nomic, and one nonnegative
    graph-plus-Nomic mixture.  MiniLM and e5 are sensitivity/redundancy controls, not extra selector votes.

--- a/prototypes/mu_cosine/REPORT_repeated_judge_campaign_power.md
+++ b/prototypes/mu_cosine/REPORT_repeated_judge_campaign_power.md
@@ -1,0 +1,168 @@
+# Repeated-judge graph covariance — no-spend campaign and power-harness report
+
+## Bottom line
+
+This PR produces **protocol and tooling, not a covariance result**.  It made no judge/model calls, selected no
+new endpoint, and did not run the full preregistered simulation.  Consequently it reports no campaign size and
+authorizes neither live scoring nor covariance deployment.
+
+The main design change is token-efficient but statistically explicit batching.  One LLM request may contain up
+to ten same-role rows from distinct endpoint components, amortizing the system prompt.  Stable prompt-block
+membership defines the dependence/inference cluster; role-by-judge base order is independently deterministic
+and repeats use spread rotations.  Shared-request covariance is part of the fitted/scored covariance rather
+than being ignored after batching.
+
+The tooling is suitable for reproducible dry runs.  It is deliberately not live-campaign-ready because the
+repository-owned candidate builder, verified historical inventory, exact approved prompt/model/settings
+contract, and list-position pilot/sensitivity do not yet exist.
+
+## What is frozen
+
+- three-row endpoint-disjoint components: anchor, directly adjacent, and distance-at-least-three/disconnected
+  matched negative;
+- two required synthetic corpora and planned `G={160,320,512,800}` components per required corpus at `R=3`,
+  with `R=4` sensitivities at `G={320,800}`;
+- 32 equal campaign cells per corpus, a 10% graph-source-component cap, five outer folds, and three stable inner
+  folds;
+- judges `gpt-5.5-low` and `gpt-5.6-luna`, with at least three fresh stateless waves per judge and a four-wave
+  sensitivity;
+- one deployment-eligible PSD family
+  `K_gamma=gamma K_cumulative+(1-gamma)K_Nomic`, with the preregistered gamma/rho grid and one familywise
+  selector maximum;
+- residual Gaussian NLL and latent-state posterior NLL as distinct synthetic endpoints;
+- block-null and smooth-mean-only false-promotion controls, planted cumulative/Nomic/mixture truths, and
+  equal-energy topology derangements;
+- `1999` null calibrations, `200` power replicates, and `999` prompt-block multiplier draws for a reported full
+  run.
+
+Only an exact `--full-prereg` run over the entire frozen grid may set the synthetic sizing fields.  Customized
+or smoke runs hard-code those fields to false/null even if they happen to include every scenario.
+
+## Request and response integrity
+
+The materializer emits immutable split-contained prompt requests but never sends them.  Each request:
+
+- carries no more than one row from a component and no more than ten rows total;
+- includes a stable `row_id` that the eventual approved scorer/parser must echo;
+- hashes the exact serialized request TSV bytes, model revision, prompt hash, settings, wave, role, and derived
+  seed into `request_id`;
+- remains inside one corpus/outer/global-inner signature;
+- records its prompt block as the inference cluster; and
+- requires provider request IDs, and nonempty provider response IDs, to be unique across logical attempts.
+
+An otherwise frozen-shaped output is labeled
+`protocol-shape-compatible-no-spend-inputs-unverified`, never “confirmatory-ready.”  Caller-supplied builder
+hashes make supplied bytes reproducible but do not attest how the graph, embedding, or candidate pool was made.
+
+## Synthetic procedure and claim boundary
+
+Every replicate regenerates folds and prompt blocks, simulates repeat/call/request/wave/missingness effects,
+selects mean ridge and graph covariance only inside training components, recalibrates nuisance covariance, and
+scores untouched outer components.  The two synthetic corpus labels are independent copies of a generic DGP:
+they enforce two-corpus multiplicity but do **not** simulate empirical corpus heterogeneity, real source-group
+dependence, or the 32-cell sampling distribution.
+
+The synthetic selector threshold is never reusable on real residuals.  Real analysis must recalibrate the
+complete selector inside every outer-training prompt-block set.  JointPosterior remains the calibrated decision
+comparator; it is not identified with a matrix factorization.  Final campaign `G`, deployment, independent
+batching, QR specialization, and CUDA remain false/null until the real calibration, margin-AURC, source,
+position, spectral-safety, and cross-batch gates pass.
+
+## Exact prompt-block diagonalization
+
+For the synthetic request schedule, every component in one prompt block has the same observed repeat schedule.
+Its joint noise covariance is therefore exactly
+
+```text
+Sigma_m = I_m tensor A + J_m tensor B,
+```
+
+where `B` is the shared-request block.  An orthogonal component transform yields one collective mode with
+covariance `A+mB` and `m-1` contrast modes with covariance `A`.  Residual scoring needs two 12-by-12 Cholesky
+systems; posterior scoring adds two 6-by-6 systems.  This is an exact block diagonalization, not an independent-
+rows approximation.
+
+The fast path compares the complete boolean observation schedules, not counts alone.  Different schedules or
+counts use the dense overlap-aware reference.  Candidates within `1e-12` of a strict-zero eligibility boundary
+are recomputed densely without rounding or changing the `>0` rule.  Factors are cached only inside one fitted
+nuisance object.
+
+Dense equivalence tests at prompt-block sizes 1, 2, and 10 observed maximum residual/posterior differences of
+`2.22e-16` and `3.33e-16`.  A local single-thread microbenchmark over ten 10-component blocks measured:
+
+| endpoint | eigenmode path | dense path | local speedup |
+|---|---:|---:|---:|
+| residual NLL | 1.177 ms | 33.457 ms | 28.43x |
+| posterior NLL | 1.815 ms | 40.362 ms | 22.24x |
+
+This shortcut is specific to verified compound symmetry.  Arbitrary real prompt incidence may not commute with
+the item kernel, so dense joint square-root/QR remains the general numerical reference.
+
+## Compute audit and smoke runs
+
+Before the eigenmode reduction, the exact full workload comprised 11,994 joint null draws, 16,800 joint power
+replicates, 57,588 generated corpus worlds, about 1.03 million nuisance fits, and about 296.7 million
+prompt-block endpoint evaluations.  Local measurements projected roughly 230--300 single-thread CPU-hours
+(10--12 serial days).
+
+The exact reduced prototype projected roughly 40--45 CPU-hours, or about 11--15 wall-clock hours on four
+physical cores with one BLAS thread per worker.  This is a compute projection, not a completed run.  A
+five-null-draw pilot at every `G` is still required before launching the full job.
+
+Two diagnostic executions checked the operational path:
+
+- default smoke, two workers: 40.15 s; an exact checkpoint resume took 0.02 s and reproduced SHA-256
+  `17a9c7693a307fb15d0290f946d0475e3cafb956ffb377ca19398b8a21c3191d`;
+- `G=160,R=3`, five null draws and one replicate for all 14 scenarios, four workers: 30.55 s.
+
+Both were customized diagnostics.  Neither is a power estimate, and both retained false/null sizing and
+deployment fields.
+
+The runner uses atomic indexed shards, a hard null-threshold barrier before power jobs, canonical
+scenario/replicate reconstruction, one BLAS thread per worker, content fingerprints, and start/end provenance
+checks.  A changed preregistration, implementation, configuration, or checkpoint payload fails closed.
+
+## Verification
+
+- repeated-campaign/sampler/power/runner suites: 67 passed;
+- inherited graph geometry, synthetic-v2, structured covariance, JointPosterior, and square-root conditioner
+  suites: 97 passed, 9 optional CUDA skips;
+- Python compilation and `git diff --check`: clean.
+
+No ignored artifact, checkpoint, smoke JSON, or generated score input is committed.
+
+## Required next work
+
+1. Implement and review the repository-owned candidate builder, then freeze graph/Nomic/historical artifacts.
+2. Freeze the exact approved live prompt, model revisions, settings, and keyed response parser.
+3. Run a list-position engineering pilot; preregister a train-only position-by-role-by-judge adjustment and add
+   a position-effect power sensitivity.
+4. Run five null pilots at each registered `G`; review timing/equivalence, then run the immutable full simulation
+   with checkpoints.
+5. Only if the synthetic primary event passes, request a separate live-campaign authorization.  Real covariance
+   still must pass calibration, decision log-loss, margin-AURC, source-component, topology, loading,
+   `s_safe/delta_95`, and cross-batch safety gates before entering the joint QR conditioner.
+
+## Reproduction
+
+Diagnostic smoke:
+
+```bash
+python prototypes/mu_cosine/run_repeated_judge_power.py \
+  --workers 2 \
+  --checkpoint-dir /tmp/repeated-judge-smoke-checkpoint \
+  --out /tmp/repeated-judge-smoke.json
+```
+
+Eventual immutable full run, after the remaining preregistered prerequisites and timing pilots are accepted:
+
+```bash
+python prototypes/mu_cosine/run_repeated_judge_power.py \
+  --full-prereg \
+  --workers 4 \
+  --checkpoint-dir /path/to/immutable-checkpoints \
+  --out /path/to/repeated-judge-power.json
+```
+
+Changing scientific settings alongside `--full-prereg` is rejected.  Worker count, checkpoint location, and
+output path are operational only and do not enter the scientific JSON.

--- a/prototypes/mu_cosine/REPORT_repeated_judge_campaign_power.md
+++ b/prototypes/mu_cosine/REPORT_repeated_judge_campaign_power.md
@@ -124,7 +124,7 @@ checks.  A changed preregistration, implementation, configuration, or checkpoint
 
 ## Verification
 
-- repeated-campaign/sampler/power/runner suites: 67 passed;
+- repeated-campaign/sampler/power/runner suites: 68 passed;
 - inherited graph geometry, synthetic-v2, structured covariance, JointPosterior, and square-root conditioner
   suites: 97 passed, 9 optional CUDA skips;
 - Python compilation and `git diff --check`: clean.

--- a/prototypes/mu_cosine/repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/repeated_judge_campaign.py
@@ -1,0 +1,1426 @@
+#!/usr/bin/env python3
+"""Outcome-blind selection and scoring schedules for a repeated-judge campaign.
+
+The module deliberately stops at immutable score-input files.  It never loads a
+model, calls a judge, or consumes a response.  A separate candidate builder must
+freeze the graph/Nomic candidate pool before this selector is run.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass, replace
+import csv
+import hashlib
+import io
+import json
+import math
+from pathlib import Path
+import unicodedata
+
+
+SCHEMA_VERSION = 2
+ALGORITHM = "repeated-judge-campaign-selector-v2"
+ENDPOINT_ROLES = ("descendant", "anchor", "adjacent", "distant")
+ROW_ROLES = ("anchor", "adjacent", "distant")
+DEFAULT_CORPORA = ("exploratory", "fresh")
+DEFAULT_HOP_TRANSITIONS = ("h1-h2", "h2-h3", "h3-h4", "h4-h5")
+DEFAULT_DEGREE_QUARTILES = ("q1", "q2", "q3", "q4")
+DEFAULT_AGREEMENT_CLASSES = ("agreement", "disagreement")
+DEFAULT_JUDGES = ("gpt-5.5-low", "gpt-5.6-luna")
+DEFAULT_COMPONENTS_PER_CORPUS = 320
+FROZEN_COMPONENT_REPEAT_GRID = frozenset({
+    (160, 3), (320, 3), (512, 3), (800, 3), (320, 4), (800, 4),
+})
+FROZEN_NOMIC_MODEL = "nomic-ai/nomic-embed-text-v1.5"
+FROZEN_NOMIC_REVISION = "e9b6763023c676ca8431644204f50c2b100d9aab"
+FROZEN_NOMIC_PREFIX = "clustering:"
+FROZEN_WALK_WEIGHTS = (1.0, 0.5, 0.25, 0.125)
+
+CANDIDATE_REQUIRED_COLUMNS = (
+    "candidate_id",
+    "corpus",
+    "source_component",
+    "hop_transition",
+    "degree_quartile",
+    "agreement_class",
+    "anchor_hop",
+    "adjacent_hop",
+    "distant_hop",
+    "anchor_campaign_tag",
+    "adjacent_campaign_tag",
+    "distant_campaign_tag",
+    "anchor_degree_quartile",
+    "adjacent_degree_quartile",
+    "distant_degree_quartile",
+    "anchor_adjacent_direct_edge",
+    "anchor_distant_distance",
+    "anchor_distant_disconnected",
+    "cumulative_anchor_adjacent_similarity",
+    "cumulative_anchor_distant_similarity",
+    "nomic_anchor_adjacent_similarity",
+    "nomic_anchor_distant_similarity",
+    "descendant_id",
+    "descendant_title",
+    "anchor_id",
+    "anchor_title",
+    "adjacent_id",
+    "adjacent_title",
+    "distant_id",
+    "distant_title",
+)
+HISTORICAL_REQUIRED_COLUMNS = ("corpus", "endpoint_id", "endpoint_title")
+NESTED_FOLD_COLUMNS = (
+    "component_id", "corpus", "outer_fold", "partition", "inner_fold",
+)
+RESPONSE_REQUIRED_COLUMNS = (
+    "request_id", "row_id", "attempt", "provider_request_id", "provider_response_id",
+    "started_at_utc", "completed_at_utc", "status", "judge", "model_id",
+    "model_revision", "prompt_sha256", "settings_sha256", "raw_response_sha256",
+    "raw_response", "score_d", "score_s", "error_type", "parse_status",
+    "parse_error_type",
+)
+
+
+class CampaignInputError(ValueError):
+    """Raised when an outcome-blind campaign input violates its contract."""
+
+
+def normalize_title(value: str) -> str:
+    """Canonical identity used to catch title aliases across graph snapshots."""
+    value = unicodedata.normalize("NFKC", str(value)).replace("_", " ")
+    return " ".join(value.split()).casefold()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def content_record(value: bytes) -> dict:
+    return {"size_bytes": len(value), "sha256": sha256_bytes(value)}
+
+
+def file_record(path) -> dict:
+    return content_record(Path(path).read_bytes())
+
+
+def _stable_digest(*values) -> str:
+    payload = json.dumps(values, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return sha256_bytes(payload)
+
+
+def _read_tsv(path, required_columns, *, label):
+    raw = Path(path).read_bytes()
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CampaignInputError(f"{label} must be UTF-8") from exc
+    reader = csv.DictReader(io.StringIO(text), delimiter="\t")
+    if reader.fieldnames is None:
+        raise CampaignInputError(f"{label} has no header")
+    if len(reader.fieldnames) != len(set(reader.fieldnames)):
+        raise CampaignInputError(f"{label} has duplicate header columns")
+    missing = [name for name in required_columns if name not in reader.fieldnames]
+    if missing:
+        raise CampaignInputError(f"{label} misses required columns: {', '.join(missing)}")
+    rows = []
+    for line_number, row in enumerate(reader, 2):
+        if None in row:
+            raise CampaignInputError(f"{label} row {line_number} has too many fields")
+        if any(value is None for value in row.values()):
+            raise CampaignInputError(f"{label} row {line_number} has too few fields")
+        if not any(value != "" for value in row.values()):
+            raise CampaignInputError(f"{label} row {line_number} is blank")
+        rows.append({name: row[name] for name in reader.fieldnames})
+    if not rows:
+        raise CampaignInputError(f"{label} contains no records")
+    return tuple(reader.fieldnames), rows, content_record(raw)
+
+
+def _load_json_object(path, *, label):
+    raw = Path(path).read_bytes()
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CampaignInputError(f"{label} must be a UTF-8 JSON document") from exc
+    if not isinstance(value, dict):
+        raise CampaignInputError(f"{label} must contain a JSON object")
+    return value, content_record(raw)
+
+
+def _require_sha256(value, *, label):
+    if not isinstance(value, str) or len(value) != 64:
+        raise CampaignInputError(f"{label} must be a 64-character SHA-256 hex digest")
+    try:
+        int(value, 16)
+    except ValueError as exc:
+        raise CampaignInputError(f"{label} must be a SHA-256 hex digest") from exc
+    if value != value.lower():
+        raise CampaignInputError(f"{label} must use canonical lowercase hex")
+    return value
+
+
+def _canonical_token(value, *, label):
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise CampaignInputError(f"{label} must be a non-empty canonical token without edge whitespace")
+    return value
+
+
+def _canonical_int(value, *, label, minimum=None):
+    _canonical_token(value, label=label)
+    if not value.isascii() or not value.isdigit() or (len(value) > 1 and value.startswith("0")):
+        raise CampaignInputError(f"{label} must be a canonical non-negative integer")
+    result = int(value)
+    if minimum is not None and result < minimum:
+        raise CampaignInputError(f"{label} must be at least {minimum}")
+    return result
+
+
+def _canonical_float(value, *, label):
+    _canonical_token(value, label=label)
+    try:
+        result = float(value)
+    except ValueError as exc:
+        raise CampaignInputError(f"{label} must be numeric") from exc
+    if not math.isfinite(result):
+        raise CampaignInputError(f"{label} must be finite")
+    return result
+
+
+def _canonical_bool(value, *, label):
+    _canonical_token(value, label=label)
+    if value not in {"true", "false"}:
+        raise CampaignInputError(f"{label} must be canonical JSON-style true or false")
+    return value == "true"
+
+
+def load_candidate_builder_manifest(path, candidate_artifact):
+    """Validate content-addressed graph/Nomic candidate-builder provenance."""
+    value, artifact = _load_json_object(path, label="candidate-builder manifest")
+    try:
+        pool = value["candidate_pool"]
+        graph = value["graph"]
+        nomic = value["nomic"]
+        thresholds = value["agreement_thresholds"]
+    except KeyError as exc:
+        raise CampaignInputError(
+            f"candidate-builder manifest misses required field {exc.args[0]!r}"
+        ) from exc
+    if value.get("schema_version") != 1:
+        raise CampaignInputError("candidate-builder manifest schema_version must equal 1")
+    _canonical_token(value.get("algorithm"), label="candidate-builder algorithm")
+    _require_sha256(value.get("implementation_sha256"), label="candidate-builder implementation_sha256")
+    if pool != candidate_artifact:
+        raise CampaignInputError(
+            "candidate-builder manifest candidate_pool record does not match the supplied TSV bytes"
+        )
+    _require_sha256(graph.get("artifact_sha256"), label="graph artifact_sha256")
+    weights = graph.get("cumulative_walk_weights")
+    if not isinstance(weights, list) or tuple(float(item) for item in weights) != FROZEN_WALK_WEIGHTS:
+        raise CampaignInputError(
+            f"cumulative_walk_weights must equal {list(FROZEN_WALK_WEIGHTS)!r}"
+        )
+    if nomic.get("model_id") != FROZEN_NOMIC_MODEL:
+        raise CampaignInputError(f"Nomic model_id must equal {FROZEN_NOMIC_MODEL!r}")
+    if nomic.get("revision") != FROZEN_NOMIC_REVISION:
+        raise CampaignInputError("Nomic revision does not match the frozen commit")
+    if nomic.get("task_prefix") != FROZEN_NOMIC_PREFIX:
+        raise CampaignInputError(f"Nomic task_prefix must equal {FROZEN_NOMIC_PREFIX!r}")
+    _require_sha256(
+        nomic.get("embedding_manifest_sha256"), label="Nomic embedding_manifest_sha256"
+    )
+    parsed_thresholds = {}
+    for name in ("graph_delta_min", "nomic_delta_min"):
+        raw_threshold = thresholds.get(name)
+        if isinstance(raw_threshold, bool) or not isinstance(raw_threshold, (int, float)):
+            raise CampaignInputError(f"agreement_thresholds.{name} must be numeric")
+        threshold = float(raw_threshold)
+        if not math.isfinite(threshold) or threshold < 0:
+            raise CampaignInputError(f"agreement_thresholds.{name} must be finite and non-negative")
+        parsed_thresholds[name] = threshold
+    return value, artifact, parsed_thresholds
+
+
+def load_request_contract(path, judges):
+    """Load exact immutable model, prompt, and request settings for each judge alias."""
+    value, artifact = _load_json_object(path, label="request contract")
+    if value.get("schema_version") != 1:
+        raise CampaignInputError("request contract schema_version must equal 1")
+    specs = value.get("judges")
+    if not isinstance(specs, dict) or set(specs) != set(judges):
+        raise CampaignInputError("request contract judge aliases must exactly match --judges")
+    output = {}
+    for alias in judges:
+        spec = specs[alias]
+        if not isinstance(spec, dict):
+            raise CampaignInputError(f"request contract judge {alias!r} must be an object")
+        for field in ("model_id", "model_revision", "prompt_id", "reasoning_effort"):
+            _canonical_token(spec.get(field), label=f"request contract {alias}.{field}")
+        prompt_sha256 = _require_sha256(
+            spec.get("prompt_sha256"), label=f"request contract {alias}.prompt_sha256"
+        )
+        settings = spec.get("settings")
+        if not isinstance(settings, dict):
+            raise CampaignInputError(f"request contract {alias}.settings must be an object")
+        settings_json = json.dumps(
+            settings, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False
+        )
+        if spec.get("stateless") is not True:
+            raise CampaignInputError(f"request contract {alias}.stateless must be true")
+        call_seed = spec.get("call_seed")
+        if call_seed is not None and (isinstance(call_seed, bool) or not isinstance(call_seed, int)):
+            raise CampaignInputError(f"request contract {alias}.call_seed must be null or an integer")
+        output[alias] = {
+            "request_schema_version": 1,
+            "model_id": spec["model_id"],
+            "model_revision": spec["model_revision"],
+            "prompt_id": spec["prompt_id"],
+            "prompt_sha256": prompt_sha256,
+            "reasoning_effort": spec["reasoning_effort"],
+            "settings_json": settings_json,
+            "settings_sha256": sha256_bytes(settings_json.encode("utf-8")),
+            "call_seed_base": call_seed,
+            "shared_session_id": "",
+            "stateless": True,
+        }
+    return output, value, artifact
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    graph_id: str
+    title: str
+    normalized_title: str
+
+
+@dataclass(frozen=True)
+class Candidate:
+    candidate_id: str
+    corpus: str
+    source_component: str
+    hop_transition: str
+    degree_quartile: str
+    agreement_class: str
+    endpoints: tuple[Endpoint, Endpoint, Endpoint, Endpoint]
+    raw: dict
+    component_id: str | None = None
+    fold: int | None = None
+    inner_fold: int | None = None
+
+    @property
+    def cell(self):
+        return (
+            self.corpus,
+            self.hop_transition,
+            self.degree_quartile,
+            self.agreement_class,
+        )
+
+    @property
+    def scoped_ids(self):
+        return frozenset((self.corpus, endpoint.graph_id) for endpoint in self.endpoints)
+
+    @property
+    def normalized_titles(self):
+        return frozenset(endpoint.normalized_title for endpoint in self.endpoints)
+
+
+@dataclass(frozen=True)
+class HistoricalEndpoints:
+    scoped_ids: frozenset
+    normalized_titles: frozenset
+    records: tuple[dict, ...]
+
+
+def load_candidates(path) -> tuple[tuple[str, ...], tuple[Candidate, ...], dict]:
+    """Load and strictly validate the frozen rich candidate-pool TSV."""
+    columns, records, artifact = _read_tsv(
+        path, CANDIDATE_REQUIRED_COLUMNS, label="candidate pool"
+    )
+    candidates = []
+    candidate_ids = set()
+    id_to_title = {}
+    for row_number, record in enumerate(records, 2):
+        for name in CANDIDATE_REQUIRED_COLUMNS:
+            if not record[name].strip():
+                raise CampaignInputError(
+                    f"candidate pool row {row_number} has empty required value {name!r}"
+                )
+        for name in (
+            "candidate_id", "corpus", "source_component", "hop_transition",
+            "degree_quartile", "agreement_class", "anchor_campaign_tag",
+            "adjacent_campaign_tag", "distant_campaign_tag", "anchor_degree_quartile",
+            "adjacent_degree_quartile", "distant_degree_quartile",
+        ):
+            _canonical_token(
+                record[name], label=f"candidate pool row {row_number} field {name}"
+            )
+        candidate_id = record["candidate_id"]
+        if candidate_id in candidate_ids:
+            raise CampaignInputError(f"duplicate candidate_id {candidate_id!r}")
+        candidate_ids.add(candidate_id)
+
+        anchor_hop = _canonical_int(
+            record["anchor_hop"], label=f"candidate {candidate_id} anchor_hop", minimum=1
+        )
+        adjacent_hop = _canonical_int(
+            record["adjacent_hop"], label=f"candidate {candidate_id} adjacent_hop", minimum=1
+        )
+        distant_hop = _canonical_int(
+            record["distant_hop"], label=f"candidate {candidate_id} distant_hop", minimum=1
+        )
+        if adjacent_hop != distant_hop:
+            raise CampaignInputError(
+                f"candidate {candidate_id!r} does not match adjacent and distant hop strata"
+            )
+        expected_transition = f"h{min(anchor_hop, adjacent_hop)}-h{max(anchor_hop, adjacent_hop)}"
+        if record["hop_transition"] != expected_transition:
+            raise CampaignInputError(
+                f"candidate {candidate_id!r} hop_transition does not match its structural hops"
+            )
+        if record["adjacent_campaign_tag"] != record["distant_campaign_tag"]:
+            raise CampaignInputError(
+                f"candidate {candidate_id!r} does not match comparator campaign tags"
+            )
+        if record["adjacent_degree_quartile"] != record["distant_degree_quartile"]:
+            raise CampaignInputError(
+                f"candidate {candidate_id!r} does not match comparator degree quartiles"
+            )
+        if record["anchor_degree_quartile"] != record["degree_quartile"]:
+            raise CampaignInputError(
+                f"candidate {candidate_id!r} anchor degree quartile disagrees with its balance cell"
+            )
+        if not _canonical_bool(
+            record["anchor_adjacent_direct_edge"],
+            label=f"candidate {candidate_id} anchor_adjacent_direct_edge",
+        ):
+            raise CampaignInputError(
+                f"candidate {candidate_id!r} adjacent comparator is not a direct graph neighbor"
+            )
+        disconnected = _canonical_bool(
+            record["anchor_distant_disconnected"],
+            label=f"candidate {candidate_id} anchor_distant_disconnected",
+        )
+        distance = record["anchor_distant_distance"]
+        if disconnected:
+            if distance != "inf":
+                raise CampaignInputError(
+                    f"candidate {candidate_id!r} disconnected distant comparator must use distance 'inf'"
+                )
+        else:
+            _canonical_int(
+                distance, label=f"candidate {candidate_id} anchor_distant_distance", minimum=3
+            )
+        for name in (
+            "cumulative_anchor_adjacent_similarity", "cumulative_anchor_distant_similarity",
+            "nomic_anchor_adjacent_similarity", "nomic_anchor_distant_similarity",
+        ):
+            similarity = _canonical_float(
+                record[name], label=f"candidate {candidate_id} {name}"
+            )
+            if not 0.0 <= similarity <= 1.0:
+                raise CampaignInputError(
+                    f"candidate {candidate_id!r} {name} must lie in [0,1]"
+                )
+        endpoints = []
+        for role in ENDPOINT_ROLES:
+            graph_id = record[f"{role}_id"]
+            title = record[f"{role}_title"]
+            _canonical_token(graph_id, label=f"candidate {candidate_id} {role}_id")
+            normalized = normalize_title(title)
+            if not normalized:
+                raise CampaignInputError(
+                    f"candidate {candidate_id!r} has empty normalized {role} title"
+                )
+            scoped = (record["corpus"], graph_id)
+            previous = id_to_title.setdefault(scoped, normalized)
+            if previous != normalized:
+                raise CampaignInputError(
+                    f"endpoint id {scoped!r} maps to inconsistent normalized titles"
+                )
+            endpoints.append(Endpoint(graph_id, title, normalized))
+        if len({endpoint.graph_id for endpoint in endpoints}) != len(endpoints):
+            raise CampaignInputError(
+                f"candidate {candidate_id!r} repeats an endpoint id within the triple"
+            )
+        if len({endpoint.normalized_title for endpoint in endpoints}) != len(endpoints):
+            raise CampaignInputError(
+                f"candidate {candidate_id!r} repeats a normalized endpoint title within the triple"
+            )
+        candidates.append(Candidate(
+            candidate_id=candidate_id,
+            corpus=record["corpus"],
+            source_component=record["source_component"],
+            hop_transition=record["hop_transition"],
+            degree_quartile=record["degree_quartile"],
+            agreement_class=record["agreement_class"],
+            endpoints=tuple(endpoints),
+            raw=dict(record),
+        ))
+    return tuple(columns), tuple(candidates), artifact
+
+
+def validate_candidate_geometry(candidates, thresholds):
+    """Verify frozen agreement labels from the recorded continuous kernels."""
+    for candidate in candidates:
+        record = candidate.raw
+        graph_delta = (
+            float(record["cumulative_anchor_adjacent_similarity"])
+            - float(record["cumulative_anchor_distant_similarity"])
+        )
+        nomic_delta = (
+            float(record["nomic_anchor_adjacent_similarity"])
+            - float(record["nomic_anchor_distant_similarity"])
+        )
+        graph_prefers_adjacent = graph_delta >= thresholds["graph_delta_min"]
+        nomic_prefers_adjacent = nomic_delta >= thresholds["nomic_delta_min"]
+        expected = "agreement" if graph_prefers_adjacent == nomic_prefers_adjacent else "disagreement"
+        if candidate.agreement_class != expected:
+            raise CampaignInputError(
+                f"candidate {candidate.candidate_id!r} agreement_class={candidate.agreement_class!r} "
+                f"but frozen deltas imply {expected!r}"
+            )
+
+
+def load_historical_endpoints(paths) -> tuple[HistoricalEndpoints, tuple[dict, ...]]:
+    """Load one or more explicit historical endpoint inventories."""
+    scoped_ids = set()
+    normalized_titles = set()
+    records = []
+    artifacts = []
+    for path in paths:
+        _columns, rows, artifact = _read_tsv(
+            path, HISTORICAL_REQUIRED_COLUMNS, label="historical endpoint inventory"
+        )
+        artifacts.append(artifact)
+        for row_number, record in enumerate(rows, 2):
+            corpus = _canonical_token(
+                record["corpus"], label=f"historical endpoint row {row_number} corpus"
+            )
+            endpoint_id = _canonical_token(
+                record["endpoint_id"], label=f"historical endpoint row {row_number} endpoint_id"
+            )
+            title = record["endpoint_title"]
+            normalized = normalize_title(title)
+            if not corpus or not endpoint_id or not normalized:
+                raise CampaignInputError(
+                    f"historical endpoint row {row_number} has an empty required identity"
+                )
+            scoped_ids.add((corpus, endpoint_id))
+            normalized_titles.add(normalized)
+            records.append({
+                "corpus": corpus,
+                "endpoint_id": endpoint_id,
+                "normalized_title": normalized,
+            })
+    if not paths:
+        raise CampaignInputError("at least one historical endpoint inventory is required")
+    artifacts.sort(key=lambda value: (value["sha256"], value["size_bytes"]))
+    records.sort(key=lambda value: (
+        value["corpus"], value["endpoint_id"], value["normalized_title"]
+    ))
+    return HistoricalEndpoints(
+        frozenset(scoped_ids), frozenset(normalized_titles), tuple(records)
+    ), tuple(artifacts)
+
+
+def expected_quotas(
+    *,
+    per_cell=10,
+    corpora=DEFAULT_CORPORA,
+    hop_transitions=DEFAULT_HOP_TRANSITIONS,
+    degree_quartiles=DEFAULT_DEGREE_QUARTILES,
+    agreement_classes=DEFAULT_AGREEMENT_CLASSES,
+):
+    if int(per_cell) != per_cell or per_cell < 1:
+        raise CampaignInputError("per_cell must be a positive integer")
+    return {
+        (corpus, hop, degree, agreement): int(per_cell)
+        for corpus in corpora
+        for hop in hop_transitions
+        for degree in degree_quartiles
+        for agreement in agreement_classes
+    }
+
+
+def component_quotas(
+    components_per_corpus,
+    *,
+    corpora=DEFAULT_CORPORA,
+    hop_transitions=DEFAULT_HOP_TRANSITIONS,
+    degree_quartiles=DEFAULT_DEGREE_QUARTILES,
+    agreement_classes=DEFAULT_AGREEMENT_CLASSES,
+):
+    """Derive exact equal cell quotas from a frozen total G for each corpus."""
+    if isinstance(components_per_corpus, bool) or not isinstance(components_per_corpus, int):
+        raise CampaignInputError("components_per_corpus must be an integer")
+    cell_count = len(hop_transitions) * len(degree_quartiles) * len(agreement_classes)
+    if components_per_corpus < cell_count or components_per_corpus % cell_count:
+        raise CampaignInputError(
+            f"components_per_corpus must be a positive multiple of {cell_count} "
+            "so every required cell has an exact equal quota"
+        )
+    return expected_quotas(
+        per_cell=components_per_corpus // cell_count,
+        corpora=corpora,
+        hop_transitions=hop_transitions,
+        degree_quartiles=degree_quartiles,
+        agreement_classes=agreement_classes,
+    )
+
+
+def filter_candidate_pool(candidates, historical, quotas):
+    """Reject historical endpoints and candidates outside the frozen cells."""
+    kept = []
+    reasons = Counter()
+    for candidate in candidates:
+        if candidate.cell not in quotas:
+            reasons["unknown_cell"] += 1
+            continue
+        if candidate.scoped_ids & historical.scoped_ids:
+            reasons["historical_endpoint_id"] += 1
+            continue
+        if candidate.normalized_titles & historical.normalized_titles:
+            reasons["historical_normalized_title"] += 1
+            continue
+        kept.append(candidate)
+    unknown = sorted({candidate.cell for candidate in candidates if candidate.cell not in quotas})
+    if unknown:
+        raise CampaignInputError(f"candidate pool contains unknown frozen cells; first={unknown[0]!r}")
+    by_cell = Counter(candidate.cell for candidate in kept)
+    shortages = {
+        cell: {"available": by_cell[cell], "required": required}
+        for cell, required in quotas.items()
+        if by_cell[cell] < required
+    }
+    if shortages:
+        cell = sorted(shortages)[0]
+        value = shortages[cell]
+        raise CampaignInputError(
+            f"cell {cell!r} has {value['available']} eligible candidates; "
+            f"requires {value['required']}"
+        )
+    return tuple(kept), dict(sorted(reasons.items()))
+
+
+def _eligible(candidate, used_ids, used_titles, source_counts, source_cap):
+    return (
+        not (candidate.scoped_ids & used_ids)
+        and not (candidate.normalized_titles & used_titles)
+        and source_counts[(candidate.corpus, candidate.source_component)] < source_cap[candidate.corpus]
+    )
+
+
+def select_candidates(
+    candidates,
+    quotas,
+    *,
+    source_cap_fraction=0.10,
+    seed=0,
+    max_attempts=512,
+):
+    """Deterministic scarcity-first packing under endpoint and source caps."""
+    candidates = tuple(candidates)
+    if not 0.0 < source_cap_fraction <= 1.0:
+        raise CampaignInputError("source_cap_fraction must lie in (0,1]")
+    if max_attempts < 1:
+        raise CampaignInputError("max_attempts must be positive")
+    totals = Counter()
+    for cell, count in quotas.items():
+        totals[cell[0]] += count
+    source_cap = {
+        corpus: max(1, int(math.floor(total * source_cap_fraction + 1e-12)))
+        for corpus, total in totals.items()
+    }
+    by_cell = defaultdict(list)
+    for candidate in candidates:
+        if candidate.cell in quotas:
+            by_cell[candidate.cell].append(candidate)
+    last_failure = None
+    for attempt in range(max_attempts):
+        selected = []
+        selected_ids = set()
+        used_ids = set()
+        used_titles = set()
+        source_counts = Counter()
+        deficits = dict(quotas)
+        while any(deficits.values()):
+            choices = []
+            eligible_by_cell = {}
+            for cell in sorted(deficits):
+                deficit = deficits[cell]
+                if not deficit:
+                    continue
+                eligible = [
+                    candidate for candidate in by_cell[cell]
+                    if candidate.candidate_id not in selected_ids
+                    and _eligible(candidate, used_ids, used_titles, source_counts, source_cap)
+                ]
+                eligible.sort(key=lambda candidate: (
+                    _stable_digest(seed, attempt, candidate.candidate_id),
+                    candidate.candidate_id,
+                ))
+                eligible_by_cell[cell] = eligible
+                slack = len(eligible) - deficit
+                choices.append((slack, len(eligible), cell))
+            slack, available, cell = min(choices)
+            if slack < 0:
+                last_failure = (attempt, cell, available, deficits[cell])
+                break
+            candidate = eligible_by_cell[cell][0]
+            selected.append(candidate)
+            selected_ids.add(candidate.candidate_id)
+            used_ids.update(candidate.scoped_ids)
+            used_titles.update(candidate.normalized_titles)
+            source_counts[(candidate.corpus, candidate.source_component)] += 1
+            deficits[cell] -= 1
+        else:
+            by_id = Counter(endpoint for candidate in selected for endpoint in candidate.scoped_ids)
+            by_title = Counter(title for candidate in selected for title in candidate.normalized_titles)
+            if max(by_id.values(), default=0) != 1 or max(by_title.values(), default=0) != 1:
+                raise AssertionError("selected campaign is not endpoint-disjoint")
+            if Counter(candidate.cell for candidate in selected) != Counter(quotas):
+                raise AssertionError("selected campaign does not match frozen quotas")
+            return tuple(selected), {
+                "attempt": attempt,
+                "source_cap_fraction": float(source_cap_fraction),
+                "source_component_caps": dict(sorted(source_cap.items())),
+                "source_component_counts": {
+                    f"{corpus}|{component}": count
+                    for (corpus, component), count in sorted(source_counts.items())
+                },
+            }
+    raise CampaignInputError(
+        "could not pack endpoint-disjoint quotas under the source-component cap "
+        f"after {max_attempts} deterministic attempts; last_failure={last_failure!r}"
+    )
+
+
+def component_identity(candidate):
+    fields = {
+        "candidate_id": candidate.candidate_id,
+        "cell": candidate.cell,
+        "source_component": candidate.source_component,
+        "endpoints": [
+            [role, endpoint.graph_id, endpoint.normalized_title]
+            for role, endpoint in zip(ENDPOINT_ROLES, candidate.endpoints)
+        ],
+    }
+    return "component-" + _stable_digest(fields)[:24]
+
+
+def _atomic_balanced_assignment(
+    items,
+    *,
+    group_key,
+    dimensions,
+    bins,
+    seed,
+    label,
+    max_attempts=512,
+):
+    """Assign dependency groups atomically under floor/ceiling balance bounds."""
+    if bins < 2:
+        raise CampaignInputError(f"{label} bins must be at least two")
+    grouped = defaultdict(list)
+    dimension_totals = Counter()
+    item_dimensions = {}
+    for item in items:
+        key = group_key(item)
+        values = tuple(dimensions(item))
+        if not values or len(values) != len(set(values)):
+            raise AssertionError(f"{label} dimensions must be non-empty and unique per item")
+        grouped[key].append(item)
+        item_dimensions[item.component_id] = values
+        dimension_totals.update(values)
+    lower = {dimension: total // bins for dimension, total in dimension_totals.items()}
+    upper = {
+        dimension: (total + bins - 1) // bins
+        for dimension, total in dimension_totals.items()
+    }
+    vectors = {}
+    for key, values in grouped.items():
+        vector = Counter(
+            dimension
+            for item in values
+            for dimension in item_dimensions[item.component_id]
+        )
+        impossible = [
+            dimension for dimension, count in vector.items()
+            if count > upper[dimension]
+        ]
+        if impossible:
+            dimension = sorted(impossible, key=repr)[0]
+            raise CampaignInputError(
+                f"atomic source group {key!r} contributes {vector[dimension]} rows to "
+                f"{label} stratum {dimension!r}, exceeding the per-bin ceiling "
+                f"{upper[dimension]}"
+            )
+        vectors[key] = vector
+
+    last_failure = None
+    for attempt in range(max_attempts):
+        counts = Counter()
+        assignment = {}
+        remaining = Counter(dimension_totals)
+        keys = sorted(grouped, key=lambda key: (
+            -sum(vectors[key].values()),
+            -len(vectors[key]),
+            _stable_digest(seed, label, "group-order", attempt, key),
+            repr(key),
+        ))
+        failed = False
+        for key in keys:
+            vector = vectors[key]
+            remaining.subtract(vector)
+            choices = []
+            for bin_index in range(bins):
+                if any(
+                    counts[(bin_index, dimension)] + value > upper[dimension]
+                    for dimension, value in vector.items()
+                ):
+                    continue
+                feasible = True
+                for dimension in dimension_totals:
+                    for other_bin in range(bins):
+                        proposed = counts[(other_bin, dimension)]
+                        if other_bin == bin_index:
+                            proposed += vector[dimension]
+                        if proposed + remaining[dimension] < lower[dimension]:
+                            feasible = False
+                            break
+                    if not feasible:
+                        break
+                if not feasible:
+                    continue
+                deficit_filled = sum(
+                    min(value, max(0, lower[dimension] - counts[(bin_index, dimension)]))
+                    for dimension, value in vector.items()
+                )
+                peak_fraction = max(
+                    (
+                        (counts[(bin_index, dimension)] + value) / upper[dimension]
+                        if upper[dimension] else 0.0
+                    )
+                    for dimension, value in vector.items()
+                )
+                choices.append((
+                    -deficit_filled,
+                    peak_fraction,
+                    sum(counts[(bin_index, dimension)] for dimension in vector),
+                    _stable_digest(seed, label, "bin-tie", attempt, key, bin_index),
+                    bin_index,
+                ))
+            if not choices:
+                last_failure = {"attempt": attempt, "source_group": repr(key)}
+                failed = True
+                break
+            bin_index = min(choices)[-1]
+            assignment[key] = bin_index
+            for dimension, value in vector.items():
+                counts[(bin_index, dimension)] += value
+        if failed:
+            continue
+        violations = []
+        for dimension in dimension_totals:
+            values = [counts[(bin_index, dimension)] for bin_index in range(bins)]
+            if min(values) < lower[dimension] or max(values) > upper[dimension]:
+                violations.append((dimension, values))
+        if violations:
+            last_failure = {"attempt": attempt, "violation": repr(violations[0])}
+            continue
+        return assignment, counts, {
+            "attempt": attempt,
+            "source_group_count": len(grouped),
+            "dimension_bounds": {
+                repr(dimension): {"floor": lower[dimension], "ceiling": upper[dimension]}
+                for dimension in sorted(dimension_totals, key=repr)
+            },
+        }
+    raise CampaignInputError(
+        f"could not assign atomic source groups to near-balanced {label} bins after "
+        f"{max_attempts} deterministic attempts; last_failure={last_failure!r}"
+    )
+
+
+def assign_component_folds(selected, quotas, *, folds=5, seed=0):
+    """Assign source-component dependency groups atomically to outer folds."""
+    if folds < 2:
+        raise CampaignInputError("folds must be at least two")
+    enriched = []
+    component_ids = set()
+    for candidate in selected:
+        component_id = component_identity(candidate)
+        if component_id in component_ids:
+            raise CampaignInputError(f"component hash collision: {component_id}")
+        component_ids.add(component_id)
+        enriched.append(replace(candidate, component_id=component_id))
+
+    assignment, _counts, atomic_diagnostics = _atomic_balanced_assignment(
+        enriched,
+        group_key=lambda candidate: (candidate.corpus, candidate.source_component),
+        dimensions=lambda candidate: (
+            ("cell", *candidate.cell),
+            ("corpus-total", candidate.corpus),
+            ("campaign-total",),
+        ),
+        bins=folds,
+        seed=seed,
+        label="outer-fold",
+    )
+    output = [
+        replace(
+            candidate,
+            fold=assignment[(candidate.corpus, candidate.source_component)],
+        )
+        for candidate in enriched
+    ]
+    output.sort(key=lambda candidate: candidate.component_id)
+    fold_totals = Counter(candidate.fold for candidate in output)
+    fold_source_counts = Counter(
+        (candidate.fold, candidate.corpus, candidate.source_component)
+        for candidate in output
+    )
+    diagnostics = {
+        "component_counts": {str(fold): fold_totals[fold] for fold in range(folds)},
+        "cell_counts": {
+            str(fold): {
+                "|".join(cell): sum(
+                    candidate.fold == fold and candidate.cell == cell for candidate in output
+                )
+                for cell in sorted(quotas)
+            }
+            for fold in range(folds)
+        },
+        "source_component_counts": {
+            str(fold): {
+                f"{corpus}|{source}": count
+                for (at, corpus, source), count in sorted(fold_source_counts.items())
+                if at == fold
+            }
+            for fold in range(folds)
+        },
+        "atomic_assignment": atomic_diagnostics,
+    }
+    if len({candidate.component_id for candidate in output}) != len(output):
+        raise AssertionError("component ids must remain unique after fold assignment")
+    for cell in quotas:
+        counts = [
+            sum(candidate.fold == fold and candidate.cell == cell for candidate in output)
+            for fold in range(folds)
+        ]
+        if max(counts) - min(counts) > 1:
+            raise AssertionError("outer per-cell fold counts must differ by at most one")
+    totals = [fold_totals[fold] for fold in range(folds)]
+    if max(totals) - min(totals) > 1:
+        raise AssertionError("outer fold totals must differ by at most one")
+    source_folds = defaultdict(set)
+    for candidate in output:
+        source_folds[(candidate.corpus, candidate.source_component)].add(candidate.fold)
+    if any(len(values) != 1 for values in source_folds.values()):
+        raise AssertionError("a source-component dependency group crossed outer folds")
+    return tuple(output), diagnostics
+
+
+def assign_nested_inner_folds(components, *, outer_folds=5, inner_folds=3, seed=0):
+    """Freeze one global inner label, then materialize every nested outer split."""
+    if outer_folds < 2 or inner_folds < 2:
+        raise CampaignInputError("outer_folds and inner_folds must both be at least two")
+    components = tuple(components)
+    if any(component.fold not in range(outer_folds) for component in components):
+        raise CampaignInputError("every component must have a valid outer fold")
+    source_outer_folds = defaultdict(set)
+    for component in components:
+        source_outer_folds[(component.corpus, component.source_component)].add(component.fold)
+    if any(len(values) != 1 for values in source_outer_folds.values()):
+        raise CampaignInputError(
+            "source-component dependency groups must be atomic before inner-fold assignment"
+        )
+    by_cell = defaultdict(list)
+    for component in components:
+        by_cell[component.cell].append(component)
+    assignment, _counts, atomic_diagnostics = _atomic_balanced_assignment(
+        components,
+        group_key=lambda component: (component.corpus, component.source_component),
+        dimensions=lambda component: (
+            ("cell", *component.cell),
+            ("corpus-total", component.corpus),
+            ("campaign-total",),
+        ),
+        bins=inner_folds,
+        seed=seed,
+        label="global-inner-fold",
+    )
+
+    enriched = tuple(sorted(
+        (
+            replace(
+                component,
+                inner_fold=assignment[(component.corpus, component.source_component)],
+            )
+            for component in components
+        ),
+        key=lambda component: component.component_id,
+    ))
+    global_inner_totals = Counter(component.inner_fold for component in enriched)
+    global_cell_counts = Counter(
+        (component.cell, component.inner_fold) for component in enriched
+    )
+    records = []
+    diagnostics = {
+        "global_inner_component_counts": {
+            str(fold): global_inner_totals[fold] for fold in range(inner_folds)
+        },
+        "global_cell_inner_counts": {
+            "|".join((*cell, str(fold))): global_cell_counts[(cell, fold)]
+            for cell in sorted(by_cell)
+            for fold in range(inner_folds)
+        },
+        "atomic_assignment": atomic_diagnostics,
+        "outer_splits": {},
+    }
+    for outer_fold in range(outer_folds):
+        held = [component for component in enriched if component.fold == outer_fold]
+        training = [component for component in enriched if component.fold != outer_fold]
+        for component in enriched:
+            is_held = component.fold == outer_fold
+            records.append({
+                "component_id": component.component_id,
+                "corpus": component.corpus,
+                "outer_fold": outer_fold,
+                "partition": "held" if is_held else "train",
+                "inner_fold": "" if is_held else component.inner_fold,
+            })
+        diagnostics["outer_splits"][str(outer_fold)] = {
+            "held_components": len(held),
+            "training_components": len(training),
+            "training_inner_component_counts": {
+                str(fold): sum(component.inner_fold == fold for component in training)
+                for fold in range(inner_folds)
+            },
+        }
+    records.sort(key=lambda row: (
+        row["outer_fold"], row["partition"] != "held", row["component_id"]
+    ))
+    expected = len(components) * outer_folds
+    if len(records) != expected:
+        raise AssertionError("nested fold table must contain every component in every outer split")
+    source_inner_folds = defaultdict(set)
+    for component in enriched:
+        source_inner_folds[(component.corpus, component.source_component)].add(
+            component.inner_fold
+        )
+    if any(len(values) != 1 for values in source_inner_folds.values()):
+        raise AssertionError("a source-component dependency group crossed global inner folds")
+    return enriched, tuple(records), diagnostics
+
+
+def campaign_rows(components):
+    """Expand each selected component into anchor/adjacent/distant score rows."""
+    rows = []
+    role_endpoint = {"anchor": 1, "adjacent": 2, "distant": 3}
+    for component in components:
+        descendant = component.endpoints[0]
+        for role in ROW_ROLES:
+            root = component.endpoints[role_endpoint[role]]
+            rows.append({
+                "row_id": f"{component.component_id}:{role}",
+                "component_id": component.component_id,
+                "fold": component.fold,
+                "inner_fold": component.inner_fold,
+                "candidate_id": component.candidate_id,
+                "corpus": component.corpus,
+                "source_component": component.source_component,
+                "hop_transition": component.hop_transition,
+                "degree_quartile": component.degree_quartile,
+                "agreement_class": component.agreement_class,
+                "role": role,
+                "node_id": descendant.graph_id,
+                "node_title": descendant.title,
+                "node_normalized_title": descendant.normalized_title,
+                "root_id": root.graph_id,
+                "root_title": root.title,
+                "root_normalized_title": root.normalized_title,
+                "cur_relation": "subcategory",
+                "conf": "1.0",
+                "neighborhood": (
+                    f"repeatcov_{component.corpus}_{component.hop_transition}_"
+                    f"{component.degree_quartile}_{component.agreement_class}_{role}"
+                ),
+                "node_type": "category",
+                "root_type": "category",
+                "raw": "",
+            })
+    rows.sort(key=lambda row: (row["component_id"], ROW_ROLES.index(row["role"])))
+    return tuple(rows)
+
+
+def build_scoring_schedule(
+    rows,
+    *,
+    judges=DEFAULT_JUDGES,
+    repeats=3,
+    batch_size=10,
+    seed=0,
+    judge_specs=None,
+):
+    """Build stable prompt blocks contained within one nested split signature."""
+    rows = tuple(rows)
+    if repeats < 3:
+        raise CampaignInputError("repeats must be at least three for repeated-judge covariance")
+    if batch_size < 1:
+        raise CampaignInputError("batch_size must be positive")
+    if len(set(judges)) != len(tuple(judges)) or not judges:
+        raise CampaignInputError("judges must be non-empty and unique")
+    if not isinstance(judge_specs, dict) or set(judge_specs) != set(judges):
+        raise CampaignInputError("judge_specs must exactly cover the scheduled judges")
+    by_component = defaultdict(dict)
+    for row in rows:
+        role = row["role"]
+        component = row["component_id"]
+        if role in by_component[component]:
+            raise CampaignInputError(f"component {component!r} repeats role {role!r}")
+        by_component[component][role] = row
+    if any(set(values) != set(ROW_ROLES) for values in by_component.values()):
+        raise CampaignInputError("every component must have exactly the three frozen row roles")
+
+    signatures = {}
+    for component, values in by_component.items():
+        signature_values = {
+            (row["corpus"], int(row["fold"]), int(row["inner_fold"]))
+            for row in values.values()
+        }
+        if len(signature_values) != 1:
+            raise CampaignInputError(
+                f"component {component!r} has inconsistent nested split metadata"
+            )
+        signatures[component] = next(iter(signature_values))
+
+    components_by_signature = defaultdict(list)
+    for component, signature in signatures.items():
+        components_by_signature[signature].append(component)
+    prompt_blocks = []
+    for signature in sorted(components_by_signature):
+        components = sorted(components_by_signature[signature], key=lambda component: (
+            _stable_digest(seed, "prompt-block-order", signature, component), component,
+        ))
+        for start in range(0, len(components), batch_size):
+            members = tuple(components[start:start + batch_size])
+            prompt_block_id = "prompt-block-" + _stable_digest(signature, members)[:24]
+            prompt_blocks.append((prompt_block_id, signature, members))
+    prompt_blocks.sort(key=lambda item: item[0])
+
+    records = []
+    wave_orders = {}
+    for judge in judges:
+        spec = judge_specs[judge]
+        for repeat in range(repeats):
+            wave_id = f"{judge}:repeat-{repeat}"
+            requests = []
+            for prompt_block_id, signature, members in prompt_blocks:
+                for role in ROW_ROLES:
+                    batch = [by_component[component][role] for component in members]
+                    requests.append((prompt_block_id, signature, role, batch))
+            requests.sort(key=lambda item: (
+                _stable_digest(seed, wave_id, "request-order", item[0], item[2]),
+                item[0], item[2],
+            ))
+            ordered_rows = []
+            for batch_index, (prompt_block_id, signature, role, batch) in enumerate(requests):
+                batch = sorted(batch, key=lambda row: (
+                    _stable_digest(seed, prompt_block_id, "within", row["component_id"]),
+                    row["component_id"],
+                ))
+                if len({row["component_id"] for row in batch}) != len(batch):
+                    raise AssertionError("a request repeats a component")
+                if {
+                    (row["corpus"], int(row["fold"]), int(row["inner_fold"]))
+                    for row in batch
+                } != {signature}:
+                    raise AssertionError("a request crosses its nested split signature")
+                immutable_contract = {
+                    "request_schema_version": spec["request_schema_version"],
+                    "model_id": spec["model_id"],
+                    "model_revision": spec["model_revision"],
+                    "prompt_id": spec["prompt_id"],
+                    "prompt_sha256": spec["prompt_sha256"],
+                    "reasoning_effort": spec["reasoning_effort"],
+                    "settings_sha256": spec["settings_sha256"],
+                    "call_seed_base": spec["call_seed_base"],
+                    "shared_session_id": spec["shared_session_id"],
+                }
+                request_preimage = (
+                    wave_id,
+                    role,
+                    prompt_block_id,
+                    [row["row_id"] for row in batch],
+                    immutable_contract,
+                )
+                call_seed = ""
+                if spec["call_seed_base"] is not None:
+                    call_seed = int(
+                        _stable_digest(spec["call_seed_base"], request_preimage)[:8], 16
+                    ) % (2 ** 31)
+                request_id = "request-" + _stable_digest(
+                    request_preimage, {"call_seed": call_seed}
+                )[:24]
+                for batch_row, row in enumerate(batch):
+                    position = len(ordered_rows)
+                    ordered_rows.append(row)
+                    records.append({
+                        "request_schema_version": spec["request_schema_version"],
+                        "model_id": spec["model_id"],
+                        "model_revision": spec["model_revision"],
+                        "prompt_id": spec["prompt_id"],
+                        "prompt_sha256": spec["prompt_sha256"],
+                        "reasoning_effort": spec["reasoning_effort"],
+                        "settings_json": spec["settings_json"],
+                        "settings_sha256": spec["settings_sha256"],
+                        "call_seed": call_seed,
+                        "shared_session_id": spec["shared_session_id"],
+                        "wave_id": wave_id,
+                        "judge": judge,
+                        "repeat": repeat,
+                        "batch_size": len(batch),
+                        "batch_index": batch_index,
+                        "batch_row": batch_row,
+                        "global_position": position,
+                        "request_id": request_id,
+                        "prompt_block_id": prompt_block_id,
+                        "inference_cluster_id": prompt_block_id,
+                        "corpus": signature[0],
+                        "outer_fold": signature[1],
+                        "global_inner_fold": signature[2],
+                        "row_id": row["row_id"],
+                        "component_id": row["component_id"],
+                        "role": role,
+                    })
+            if {row["row_id"] for row in ordered_rows} != {row["row_id"] for row in rows}:
+                raise AssertionError("a scoring wave must contain every campaign row exactly once")
+            wave_orders[wave_id] = tuple(ordered_rows)
+    return tuple(records), wave_orders
+
+
+def response_ingestion_schema():
+    """Machine-readable contract for keyed, retry-preserving response ingestion."""
+    return {
+        "schema_version": 1,
+        "join_key": ["request_id", "row_id"],
+        "retry_key": ["request_id", "row_id", "attempt"],
+        "required_columns": list(RESPONSE_REQUIRED_COLUMNS),
+        "statuses": ["success", "retryable_failure", "terminal_failure"],
+        "parse_statuses": ["parsed", "parse_failure", ""],
+        "rules": [
+            "responses join by request_id + row_id, never by row position",
+            "every attempt is retained and attempts are unique non-negative integers",
+            "every scheduled row has exactly one terminal outcome: success or terminal_failure",
+            "attempts are contiguous from zero and every batched row records every call attempt",
+            "provider-call identity, status, timestamps, and raw response are common within an attempt",
+            "immutable model, prompt, and settings identities must match the schedule",
+            "successful raw response bytes are SHA-256 authenticated",
+        ],
+    }
+
+
+def validate_response_records(schedule, responses):
+    """Validate fully ingested responses without relying on file order."""
+    schedule = tuple(schedule)
+    responses = tuple(responses)
+    scheduled = {}
+    scheduled_by_request = defaultdict(set)
+    for row in schedule:
+        key = (row["request_id"], row["row_id"])
+        if key in scheduled:
+            raise CampaignInputError(f"duplicate schedule join key {key!r}")
+        scheduled[key] = row
+        scheduled_by_request[row["request_id"]].add(row["row_id"])
+    attempts = set()
+    attempts_by_key = defaultdict(list)
+    successes = Counter()
+    terminal_failures = Counter()
+    terminal_attempt = {}
+    retry_attempt_count = 0
+    parsed_row_count = 0
+    parse_failure_count = 0
+    response_batches = defaultdict(list)
+    for index, response in enumerate(responses, 1):
+        missing = [column for column in RESPONSE_REQUIRED_COLUMNS if column not in response]
+        if missing:
+            raise CampaignInputError(
+                f"response record {index} misses required columns: {', '.join(missing)}"
+            )
+        request_id = _canonical_token(
+            response["request_id"], label=f"response record {index} request_id"
+        )
+        row_id = _canonical_token(response["row_id"], label=f"response record {index} row_id")
+        key = (request_id, row_id)
+        if key not in scheduled:
+            raise CampaignInputError(f"response record {index} has unknown join key {key!r}")
+        attempt = _canonical_int(
+            str(response["attempt"]), label=f"response record {index} attempt", minimum=0
+        )
+        retry_key = (*key, attempt)
+        if retry_key in attempts:
+            raise CampaignInputError(f"duplicate response retry key {retry_key!r}")
+        attempts.add(retry_key)
+        attempts_by_key[key].append(attempt)
+        response_batches[(request_id, attempt)].append(response)
+        expected = scheduled[key]
+        for field in (
+            "judge", "model_id", "model_revision", "prompt_sha256", "settings_sha256",
+        ):
+            if str(response[field]) != str(expected[field]):
+                raise CampaignInputError(
+                    f"response record {index} immutable {field} does not match its schedule"
+                )
+        status = response["status"]
+        if status not in {"success", "retryable_failure", "terminal_failure"}:
+            raise CampaignInputError(f"response record {index} has invalid status {status!r}")
+        _canonical_token(
+            response["provider_request_id"],
+            label=f"response record {index} provider_request_id",
+        )
+        _canonical_token(
+            response["started_at_utc"], label=f"response record {index} started_at_utc"
+        )
+        _canonical_token(
+            response["completed_at_utc"], label=f"response record {index} completed_at_utc"
+        )
+        if status == "success":
+            successes[key] += 1
+            terminal_attempt[key] = attempt
+            _canonical_token(
+                response["provider_response_id"],
+                label=f"response record {index} provider_response_id",
+            )
+            raw = response["raw_response"]
+            if not isinstance(raw, str):
+                raise CampaignInputError(f"response record {index} raw_response must be text")
+            digest = _require_sha256(
+                response["raw_response_sha256"],
+                label=f"response record {index} raw_response_sha256",
+            )
+            if digest != sha256_bytes(raw.encode("utf-8")):
+                raise CampaignInputError(f"response record {index} raw response hash mismatch")
+            if response["error_type"] not in {"", None}:
+                raise CampaignInputError(
+                    f"successful response record {index} must not declare error_type"
+                )
+            parse_status = response["parse_status"]
+            if parse_status == "parsed":
+                parsed_row_count += 1
+                for field in ("score_d", "score_s"):
+                    _canonical_float(
+                        str(response[field]), label=f"response record {index} {field}"
+                    )
+                if response["parse_error_type"] not in {"", None}:
+                    raise CampaignInputError(
+                        f"parsed response record {index} must not declare parse_error_type"
+                    )
+            elif parse_status == "parse_failure":
+                parse_failure_count += 1
+                if not str(response["parse_error_type"]).strip():
+                    raise CampaignInputError(
+                        f"response record {index} parse_failure requires parse_error_type"
+                    )
+                if response["score_d"] not in {"", None} or response["score_s"] not in {"", None}:
+                    raise CampaignInputError(
+                        f"response record {index} parse_failure must not contain parsed scores"
+                    )
+            else:
+                raise CampaignInputError(
+                    f"successful response record {index} parse_status must be parsed or parse_failure"
+                )
+        else:
+            if not str(response["error_type"]).strip():
+                raise CampaignInputError(f"failed response record {index} requires error_type")
+            if status == "terminal_failure":
+                terminal_failures[key] += 1
+                terminal_attempt[key] = attempt
+            else:
+                retry_attempt_count += 1
+            if response["parse_status"] not in {"", None} or response["parse_error_type"] not in {"", None}:
+                raise CampaignInputError(
+                    f"provider-failure response record {index} must not declare row parse state"
+                )
+
+    common_attempt_fields = (
+        "provider_request_id", "provider_response_id", "started_at_utc", "completed_at_utc",
+        "status", "raw_response_sha256", "raw_response", "error_type",
+    )
+    for request_id, expected_rows in sorted(scheduled_by_request.items()):
+        request_attempts = sorted(
+            attempt for at_request, attempt in response_batches if at_request == request_id
+        )
+        if request_attempts != list(range(len(request_attempts))):
+            raise CampaignInputError(
+                f"request {request_id!r} attempts must be contiguous from zero"
+            )
+        for attempt in request_attempts:
+            batch = response_batches[(request_id, attempt)]
+            actual_rows = {record["row_id"] for record in batch}
+            if actual_rows != expected_rows:
+                raise CampaignInputError(
+                    f"request {request_id!r} attempt {attempt} does not cover every scheduled row"
+                )
+            for field in common_attempt_fields:
+                if len({str(record[field]) for record in batch}) != 1:
+                    raise CampaignInputError(
+                        f"request {request_id!r} attempt {attempt} has inconsistent provider {field}"
+                    )
+    duplicate_success = [key for key, count in successes.items() if count > 1]
+    if duplicate_success:
+        raise CampaignInputError(f"join key {sorted(duplicate_success)[0]!r} has multiple successes")
+    duplicate_failure = [key for key, count in terminal_failures.items() if count > 1]
+    if duplicate_failure:
+        raise CampaignInputError(
+            f"join key {sorted(duplicate_failure)[0]!r} has multiple terminal failures"
+        )
+    for key in sorted(scheduled):
+        terminal_count = successes[key] + terminal_failures[key]
+        if terminal_count != 1:
+            raise CampaignInputError(
+                f"scheduled join key {key!r} must have exactly one terminal outcome"
+            )
+        if terminal_attempt[key] != max(attempts_by_key[key]):
+            raise CampaignInputError(f"join key {key!r} has attempts after its terminal outcome")
+    return {
+        "scheduled_rows": len(scheduled),
+        "response_attempts": len(responses),
+        "successful_rows": sum(successes.values()),
+        "terminal_failure_rows": sum(terminal_failures.values()),
+        "retry_attempts": retry_attempt_count,
+        "provider_call_attempts": len(response_batches),
+        "retry_call_attempts": sum(
+            next(iter(records))["status"] == "retryable_failure"
+            for records in response_batches.values()
+        ),
+        "parsed_rows": parsed_row_count,
+        "parse_failure_rows": parse_failure_count,
+    }
+
+
+def tsv_bytes(columns, rows):
+    stream = io.StringIO(newline="")
+    writer = csv.DictWriter(
+        stream, fieldnames=list(columns), delimiter="\t", lineterminator="\n", extrasaction="ignore"
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+    return stream.getvalue().encode("utf-8")
+
+
+def score_input_bytes(rows):
+    columns = (
+        "node_title", "root_title", "cur_relation", "conf", "neighborhood",
+        "node_type", "root_type", "raw",
+    )
+    body = tsv_bytes(columns, rows).decode("utf-8")
+    header, remainder = body.split("\n", 1)
+    return ("# " + header + "\n" + remainder).encode("utf-8")
+
+
+def json_bytes(value):
+    return (
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode("utf-8")

--- a/prototypes/mu_cosine/repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/repeated_judge_campaign.py
@@ -1075,8 +1075,8 @@ def build_scoring_schedule(
     rows = tuple(rows)
     if repeats < 3:
         raise CampaignInputError("repeats must be at least three for repeated-judge covariance")
-    if batch_size < 1:
-        raise CampaignInputError("batch_size must be positive")
+    if not 1 <= batch_size <= 10:
+        raise CampaignInputError("batch_size must be between one and ten rows")
     if len(set(judges)) != len(tuple(judges)) or not judges:
         raise CampaignInputError("judges must be non-empty and unique")
     if not isinstance(judge_specs, dict) or set(judge_specs) != set(judges):

--- a/prototypes/mu_cosine/repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/repeated_judge_campaign.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Outcome-blind selection and scoring schedules for a repeated-judge campaign.
 
-The module deliberately stops at immutable score-input files.  It never loads a
-model, calls a judge, or consumes a response.  A separate candidate builder must
-freeze the graph/Nomic candidate pool before this selector is run.
+The selection/scheduling path deliberately stops at immutable score-input
+files.  It never loads a model or calls a judge.  The response helper validates
+only transport/schema integrity; it does not analyze scores.  A separate
+candidate builder must freeze the graph/Nomic candidate pool before this
+selector is run.
 """
 
 from __future__ import annotations
@@ -195,7 +197,12 @@ def _canonical_bool(value, *, label):
 
 
 def load_candidate_builder_manifest(path, candidate_artifact):
-    """Validate content-addressed graph/Nomic candidate-builder provenance."""
+    """Validate a caller-supplied, content-addressed provenance declaration.
+
+    This checks internal consistency and frozen geometry identifiers.  It does
+    not attest that the declared builder, graph, or embedding artifacts were
+    produced by repository code; that builder remains a future prerequisite.
+    """
     value, artifact = _load_json_object(path, label="candidate-builder manifest")
     try:
         pool = value["candidate_pool"]
@@ -1127,10 +1134,18 @@ def build_scoring_schedule(
             ))
             ordered_rows = []
             for batch_index, (prompt_block_id, signature, role, batch) in enumerate(requests):
+                # Membership is stable, while each role x judge gets an
+                # independent deterministic base order.  Evenly spaced repeat
+                # rotations spread each measurement across list positions.
                 batch = sorted(batch, key=lambda row: (
-                    _stable_digest(seed, prompt_block_id, "within", row["component_id"]),
+                    _stable_digest(
+                        seed, prompt_block_id, "position-base", judge, role,
+                        row["component_id"],
+                    ),
                     row["component_id"],
                 ))
+                rotation = (repeat * len(batch)) // repeats
+                batch = batch[rotation:] + batch[:rotation]
                 if len({row["component_id"] for row in batch}) != len(batch):
                     raise AssertionError("a request repeats a component")
                 if {
@@ -1149,11 +1164,13 @@ def build_scoring_schedule(
                     "call_seed_base": spec["call_seed_base"],
                     "shared_session_id": spec["shared_session_id"],
                 }
+                request_input_sha256 = sha256_bytes(score_input_bytes(batch))
                 request_preimage = (
                     wave_id,
                     role,
                     prompt_block_id,
                     [row["row_id"] for row in batch],
+                    request_input_sha256,
                     immutable_contract,
                 )
                 call_seed = ""
@@ -1186,6 +1203,7 @@ def build_scoring_schedule(
                         "batch_row": batch_row,
                         "global_position": position,
                         "request_id": request_id,
+                        "request_input_sha256": request_input_sha256,
                         "prompt_block_id": prompt_block_id,
                         "inference_cluster_id": prompt_block_id,
                         "corpus": signature[0],
@@ -1212,10 +1230,12 @@ def response_ingestion_schema():
         "parse_statuses": ["parsed", "parse_failure", ""],
         "rules": [
             "responses join by request_id + row_id, never by row position",
+            "the scorer must echo the row_id supplied in each score-input row",
             "every attempt is retained and attempts are unique non-negative integers",
             "every scheduled row has exactly one terminal outcome: success or terminal_failure",
             "attempts are contiguous from zero and every batched row records every call attempt",
             "provider-call identity, status, timestamps, and raw response are common within an attempt",
+            "provider request and nonempty response identities are unique across logical call attempts",
             "immutable model, prompt, and settings identities must match the schedule",
             "successful raw response bytes are SHA-256 authenticated",
         ],
@@ -1348,6 +1368,8 @@ def validate_response_records(schedule, responses):
         "provider_request_id", "provider_response_id", "started_at_utc", "completed_at_utc",
         "status", "raw_response_sha256", "raw_response", "error_type",
     )
+    provider_request_owners = {}
+    provider_response_owners = {}
     for request_id, expected_rows in sorted(scheduled_by_request.items()):
         request_attempts = sorted(
             attempt for at_request, attempt in response_batches if at_request == request_id
@@ -1367,6 +1389,22 @@ def validate_response_records(schedule, responses):
                 if len({str(record[field]) for record in batch}) != 1:
                     raise CampaignInputError(
                         f"request {request_id!r} attempt {attempt} has inconsistent provider {field}"
+                    )
+            owner = (request_id, attempt)
+            provider_request_id = str(batch[0]["provider_request_id"])
+            previous = provider_request_owners.setdefault(provider_request_id, owner)
+            if previous != owner:
+                raise CampaignInputError(
+                    f"provider_request_id {provider_request_id!r} is reused across "
+                    f"logical call attempts {previous!r} and {owner!r}"
+                )
+            provider_response_id = str(batch[0]["provider_response_id"])
+            if provider_response_id:
+                previous = provider_response_owners.setdefault(provider_response_id, owner)
+                if previous != owner:
+                    raise CampaignInputError(
+                        f"provider_response_id {provider_response_id!r} is reused across "
+                        f"logical call attempts {previous!r} and {owner!r}"
                     )
     duplicate_success = [key for key, count in successes.items() if count > 1]
     if duplicate_success:
@@ -1412,7 +1450,7 @@ def tsv_bytes(columns, rows):
 
 def score_input_bytes(rows):
     columns = (
-        "node_title", "root_title", "cur_relation", "conf", "neighborhood",
+        "row_id", "node_title", "root_title", "cur_relation", "conf", "neighborhood",
         "node_type", "root_type", "raw",
     )
     body = tsv_bytes(columns, rows).decode("utf-8")

--- a/prototypes/mu_cosine/repeated_judge_power.py
+++ b/prototypes/mu_cosine/repeated_judge_power.py
@@ -29,6 +29,9 @@ DEFAULT_MEAN_RIDGES = (0.0, 0.01, 0.10, 1.0, 10.0)
 PRIMARY_ENDPOINTS = ("residual_nll", "posterior_state_nll")
 MAX_PROMPT_ROWS = 10
 SYNTHETIC_CORPORA = ("synthetic_corpus_1", "synthetic_corpus_2")
+# This is only a trigger for canonical dense recomputation near a strict-zero
+# selector decision.  Dense-recomputed gains are still compared to exactly 0.
+DENSE_DECISION_RECHECK_ATOL = 1e-12
 
 
 def derive_seed(base: int, *parts) -> int:
@@ -662,7 +665,14 @@ def fit_repeat_nuisance(
     )
 
 
-def candidate_covariance(nuisance, item_kernel, rho, repeat_counts=None):
+def _candidate_covariance(
+    nuisance,
+    item_kernel,
+    rho,
+    repeat_counts=None,
+    *,
+    validate=True,
+):
     item = rho_matched_correlation(item_kernel, rho)
     counts = nuisance.evaluate_repeat_counts if repeat_counts is None else np.asarray(repeat_counts, dtype=float)
     if counts.ndim == 2 and counts.shape == (ROWS_PER_COMPONENT, 2):
@@ -683,8 +693,15 @@ def candidate_covariance(nuisance, item_kernel, rho, repeat_counts=None):
     output = 0.5 * (output + np.swapaxes(output, -1, -2))
     # The batched Cholesky is both a fail-closed PSD check and substantially
     # cheaper than a Python loop at the preregistered G=800 ceiling.
-    np.linalg.cholesky(output)
+    if validate:
+        np.linalg.cholesky(output)
     return output
+
+
+def candidate_covariance(nuisance, item_kernel, rho, repeat_counts=None):
+    return _candidate_covariance(
+        nuisance, item_kernel, rho, repeat_counts, validate=True
+    )
 
 
 def component_gaussian_nll(residuals, covariance):
@@ -709,11 +726,13 @@ def component_gaussian_nll(residuals, covariance):
     ) / flat.shape[1]
 
 
-def prompt_block_candidate_covariance(
+def _prompt_block_candidate_covariance(
     nuisance,
     item_kernel,
     rho,
     positions,
+    *,
+    validate=True,
 ):
     """Joint repeat-mean covariance for one stable prompt block.
 
@@ -726,11 +745,12 @@ def prompt_block_candidate_covariance(
     positions = np.asarray(positions, dtype=int)
     if positions.ndim != 1 or not len(positions):
         raise ValueError("positions must identify at least one component")
-    marginal = candidate_covariance(
+    marginal = _candidate_covariance(
         nuisance,
         item_kernel,
         rho,
         nuisance.evaluate_repeat_counts[positions],
+        validate=False,
     )
     component_dimension = ROWS_PER_COMPONENT * CHANNELS
     output = np.zeros((
@@ -762,8 +782,21 @@ def prompt_block_candidate_covariance(
                     output[left_sl, right_sl] = cross
                     output[right_sl, left_sl] = cross.T
     output = _symmetric(output)
-    np.linalg.cholesky(output)
+    if validate:
+        np.linalg.cholesky(output)
     return output
+
+
+def prompt_block_candidate_covariance(
+    nuisance,
+    item_kernel,
+    rho,
+    positions,
+):
+    """Joint repeat-mean covariance for one stable prompt block."""
+    return _prompt_block_candidate_covariance(
+        nuisance, item_kernel, rho, positions, validate=True
+    )
 
 
 def _prompt_block_positions(prompt_block_ids):
@@ -771,6 +804,168 @@ def _prompt_block_positions(prompt_block_ids):
     if prompt_block_ids.ndim != 1:
         raise ValueError("prompt block IDs must be a vector")
     return tuple(np.flatnonzero(prompt_block_ids == block) for block in np.unique(prompt_block_ids))
+
+
+def _cholesky_solve(factor, value):
+    return np.linalg.solve(factor.T, np.linalg.solve(factor, value))
+
+
+def _cholesky_logdet(factor):
+    return 2.0 * float(np.sum(np.log(np.diag(factor))))
+
+
+def _exchangeable_prompt_schedule(nuisance, positions):
+    """Return a shared schedule and exact cache signature, else ``None``."""
+    positions = np.asarray(positions, dtype=int)
+    observed = nuisance.evaluate_observed_calls[positions]
+    counts = nuisance.evaluate_repeat_counts[positions]
+    if not (
+        np.all(observed == observed[0])
+        and np.all(counts == counts[0])
+    ):
+        return None
+    shared_observed = observed[0]
+    shared_counts = np.asarray(counts[0], dtype=float)
+    signature = (
+        len(positions),
+        shared_counts.tobytes(),
+        shared_observed.shape,
+        np.packbits(shared_observed).tobytes(),
+    )
+    return shared_counts, shared_observed, signature
+
+
+def _compound_symmetric_prompt_covariances(
+    nuisance,
+    item_kernel,
+    rho,
+    positions,
+    schedule=None,
+):
+    """Return contrast/collective covariance blocks, or ``None`` if unsafe.
+
+    Request-level missingness gives every component in one stable prompt block
+    the same recorded repeat schedule.  Conditional on that exact invariant,
+    the joint covariance is ``I_m kron A + J_m kron B`` and has one collective
+    mode ``A + m B`` plus ``m - 1`` contrast modes ``A``.  Public callers may
+    also provide arbitrary fields, so nonexchangeable schedules deliberately
+    fall back to the dense overlap-aware covariance.
+    """
+    positions = np.asarray(positions, dtype=int)
+    schedule = (
+        _exchangeable_prompt_schedule(nuisance, positions)
+        if schedule is None else schedule
+    )
+    if schedule is None:
+        return None
+    counts, observed, _signature = schedule
+
+    marginal = _candidate_covariance(
+        nuisance,
+        item_kernel,
+        rho,
+        counts,
+        validate=False,
+    )[0]
+    shared_request = np.zeros_like(marginal)
+    for row in range(ROWS_PER_COMPONENT):
+        for family, channel_start in enumerate((0, 2)):
+            start = row * CHANNELS + channel_start
+            sl = slice(start, start + 2)
+            family_sl = slice(channel_start, channel_start + 2)
+            overlap = float(np.sum(observed[row, :, family]))
+            coefficient = overlap / float(counts[row, family] ** 2)
+            shared_request[sl, sl] = (
+                nuisance.request_covariance[family_sl, family_sl] * coefficient
+            )
+
+    # The marginal already contains the diagonal request variance.  Removing
+    # one shared-request block gives the contrast covariance; adding the other
+    # m - 1 copies gives the normalized collective-mode covariance.
+    contrast = _symmetric(marginal - shared_request)
+    collective = _symmetric(
+        marginal + (len(positions) - 1.0) * shared_request
+    )
+    return contrast, collective
+
+
+def _dense_prompt_block_gaussian_score(
+    residuals,
+    nuisance,
+    item_kernel,
+    rho,
+    positions,
+):
+    covariance = _prompt_block_candidate_covariance(
+        nuisance, item_kernel, rho, positions, validate=False
+    )
+    vector = residuals[positions].reshape(-1)
+    factor = np.linalg.cholesky(covariance)
+    whitened = np.linalg.solve(factor, vector)
+    return 0.5 * (
+        whitened @ whitened
+        + _cholesky_logdet(factor)
+        + len(vector) * math.log(2.0 * math.pi)
+    ) / len(vector)
+
+
+def _dense_prompt_block_gaussian_nll(
+    residuals,
+    nuisance,
+    item_kernel,
+    rho,
+    prompt_block_ids,
+):
+    """Force the canonical dense block score without eigenmode shortcuts."""
+    residuals = np.asarray(residuals, dtype=float)
+    output = np.empty(len(residuals), dtype=float)
+    for positions in _prompt_block_positions(prompt_block_ids):
+        output[positions] = _dense_prompt_block_gaussian_score(
+            residuals, nuisance, item_kernel, rho, positions
+        )
+    return output
+
+
+def _factor_compound_symmetric_gaussian_modes(
+    contrast_covariance,
+    collective_covariance,
+    component_count,
+):
+    collective_factor = np.linalg.cholesky(collective_covariance)
+    contrast_factor = (
+        np.linalg.cholesky(contrast_covariance)
+        if component_count > 1 else None
+    )
+    logdet = _cholesky_logdet(collective_factor)
+    if contrast_factor is not None:
+        logdet += (component_count - 1) * _cholesky_logdet(contrast_factor)
+    return contrast_factor, collective_factor, logdet
+
+
+def _compound_symmetric_prompt_block_gaussian_score(
+    residuals,
+    positions,
+    factored_modes,
+):
+    values = residuals[positions].reshape(len(positions), -1)
+    component_count, component_dimension = values.shape
+    mean = np.mean(values, axis=0)
+    contrast_factor, collective_factor, logdet = factored_modes
+
+    collective_whitened = np.linalg.solve(
+        collective_factor, math.sqrt(component_count) * mean
+    )
+    quadratic = float(collective_whitened @ collective_whitened)
+
+    if component_count > 1:
+        centered = values - mean
+        contrast_whitened = np.linalg.solve(contrast_factor, centered.T)
+        quadratic += float(np.sum(contrast_whitened * contrast_whitened))
+
+    dimension = component_count * component_dimension
+    return 0.5 * (
+        quadratic + logdet + dimension * math.log(2.0 * math.pi)
+    ) / dimension
 
 
 def prompt_block_gaussian_nll(
@@ -783,19 +978,28 @@ def prompt_block_gaussian_nll(
     """Joint composite residual NLL, returned on an equal-component scale."""
     residuals = np.asarray(residuals, dtype=float)
     output = np.empty(len(residuals), dtype=float)
+    candidate = rho_matched_correlation(item_kernel, rho)
+    mode_cache = {}
     for positions in _prompt_block_positions(prompt_block_ids):
-        covariance = prompt_block_candidate_covariance(
-            nuisance, item_kernel, rho, positions
-        )
-        vector = residuals[positions].reshape(-1)
-        factor = np.linalg.cholesky(covariance)
-        whitened = np.linalg.solve(factor, vector)
-        logdet = 2.0 * float(np.sum(np.log(np.diag(factor))))
-        score = 0.5 * (
-            whitened @ whitened
-            + logdet
-            + len(vector) * math.log(2.0 * math.pi)
-        ) / len(vector)
+        schedule = _exchangeable_prompt_schedule(nuisance, positions)
+        if schedule is None:
+            score = _dense_prompt_block_gaussian_score(
+                residuals, nuisance, item_kernel, rho, positions
+            )
+        else:
+            cache_key = (candidate.shape, candidate.tobytes(), schedule[2])
+            factored_modes = mode_cache.get(cache_key)
+            if factored_modes is None:
+                modes = _compound_symmetric_prompt_covariances(
+                    nuisance, item_kernel, rho, positions, schedule
+                )
+                factored_modes = _factor_compound_symmetric_gaussian_modes(
+                    *modes, len(positions)
+                )
+                mode_cache[cache_key] = factored_modes
+            score = _compound_symmetric_prompt_block_gaussian_score(
+                residuals, positions, factored_modes
+            )
         output[positions] = score
     return output
 
@@ -839,6 +1043,126 @@ def posterior_state_nll(residuals, covariance, states):
     return np.asarray(output)
 
 
+def _dense_prompt_block_posterior_state_score(
+    residuals,
+    nuisance,
+    item_kernel,
+    rho,
+    states,
+    positions,
+    component_design,
+    component_prior_precision,
+):
+    noise_covariance = _prompt_block_candidate_covariance(
+        nuisance, item_kernel, rho, positions, validate=False
+    )
+    component_count = len(positions)
+    design = np.kron(np.eye(component_count), component_design)
+    prior_precision = np.kron(
+        np.eye(component_count), component_prior_precision
+    )
+    truth = states[positions].reshape(-1)
+    observed = design @ truth + residuals[positions].reshape(-1)
+
+    noise_factor = np.linalg.cholesky(noise_covariance)
+    solved_design = _cholesky_solve(noise_factor, design)
+    precision = _symmetric(prior_precision + design.T @ solved_design)
+    precision_factor = np.linalg.cholesky(precision)
+    posterior_mean = _cholesky_solve(
+        precision_factor, solved_design.T @ observed
+    )
+    delta = truth - posterior_mean
+    quadratic = float(np.sum((delta @ precision_factor) ** 2))
+    posterior_logdet = -_cholesky_logdet(precision_factor)
+    return 0.5 * (
+        quadratic
+        + posterior_logdet
+        + len(delta) * math.log(2.0 * math.pi)
+    ) / len(delta)
+
+
+def _factor_posterior_mode(noise_covariance, design, prior_precision):
+    noise_factor = np.linalg.cholesky(noise_covariance)
+    solved_design = _cholesky_solve(noise_factor, design)
+    precision = _symmetric(prior_precision + design.T @ solved_design)
+    precision_factor = np.linalg.cholesky(precision)
+    return solved_design, precision_factor
+
+
+def _factor_compound_symmetric_posterior_modes(
+    contrast_covariance,
+    collective_covariance,
+    component_count,
+    design,
+    prior_precision,
+):
+    collective = _factor_posterior_mode(
+        collective_covariance, design, prior_precision
+    )
+    contrast = (
+        _factor_posterior_mode(contrast_covariance, design, prior_precision)
+        if component_count > 1 else None
+    )
+    posterior_logdet = -_cholesky_logdet(collective[1])
+    if contrast is not None:
+        posterior_logdet -= (
+            (component_count - 1) * _cholesky_logdet(contrast[1])
+        )
+    return contrast, collective, posterior_logdet
+
+
+def _compound_symmetric_prompt_block_posterior_state_score(
+    residuals,
+    states,
+    positions,
+    design,
+    factored_modes,
+):
+    component_count = len(positions)
+    truth = states[positions].reshape(component_count, -1)
+    errors = residuals[positions].reshape(component_count, -1)
+    observed = truth @ design.T + errors
+    truth_mean = np.mean(truth, axis=0)
+    observed_mean = np.mean(observed, axis=0)
+    contrast, collective, posterior_logdet = factored_modes
+
+    collective_design, collective_precision_factor = collective
+    collective_information = (
+        collective_design.T
+        @ (math.sqrt(component_count) * observed_mean)
+    )
+    collective_posterior_mean = _cholesky_solve(
+        collective_precision_factor, collective_information
+    )
+    collective_delta = (
+        math.sqrt(component_count) * truth_mean
+        - collective_posterior_mean
+    )
+    quadratic = float(np.sum(
+        (collective_delta @ collective_precision_factor) ** 2
+    ))
+
+    if contrast is not None:
+        contrast_design, contrast_precision_factor = contrast
+        centered_observed = observed - observed_mean
+        centered_truth = truth - truth_mean
+        contrast_information = contrast_design.T @ centered_observed.T
+        contrast_posterior_mean = _cholesky_solve(
+            contrast_precision_factor, contrast_information
+        ).T
+        contrast_delta = centered_truth - contrast_posterior_mean
+        quadratic += float(np.sum(
+            (contrast_delta @ contrast_precision_factor) ** 2
+        ))
+
+    dimension = component_count * truth.shape[1]
+    return 0.5 * (
+        quadratic
+        + posterior_logdet
+        + dimension * math.log(2.0 * math.pi)
+    ) / dimension
+
+
 def prompt_block_posterior_state_nll(
     residuals,
     nuisance,
@@ -854,31 +1178,46 @@ def prompt_block_posterior_state_nll(
         raise ValueError("states must have shape [G,3,2]")
     component_design = np.kron(np.eye(ROWS_PER_COMPONENT), MEASUREMENT_DESIGN)
     component_prior = np.kron(np.eye(ROWS_PER_COMPONENT), PRIOR_STATE_COVARIANCE)
+    component_prior_precision = np.linalg.solve(
+        component_prior, np.eye(len(component_prior))
+    )
     output = np.empty(len(residuals), dtype=float)
+    candidate = rho_matched_correlation(item_kernel, rho)
+    mode_cache = {}
     for positions in _prompt_block_positions(prompt_block_ids):
-        noise_covariance = prompt_block_candidate_covariance(
-            nuisance, item_kernel, rho, positions
-        )
-        design = np.kron(np.eye(len(positions)), component_design)
-        prior = np.kron(np.eye(len(positions)), component_prior)
-        prior_precision = np.linalg.solve(prior, np.eye(len(prior)))
-        truth = states[positions].reshape(-1)
-        observed = design @ truth + residuals[positions].reshape(-1)
-        solved_design = np.linalg.solve(noise_covariance, design)
-        precision = prior_precision + design.T @ solved_design
-        posterior_covariance = np.linalg.solve(precision, np.eye(len(precision)))
-        posterior_mean = posterior_covariance @ (
-            design.T @ np.linalg.solve(noise_covariance, observed)
-        )
-        delta = truth - posterior_mean
-        sign, logdet = np.linalg.slogdet(posterior_covariance)
-        if sign <= 0:
-            raise np.linalg.LinAlgError("posterior covariance is not positive definite")
-        score = 0.5 * (
-            delta @ precision @ delta
-            + logdet
-            + len(delta) * math.log(2.0 * math.pi)
-        ) / len(delta)
+        schedule = _exchangeable_prompt_schedule(nuisance, positions)
+        if schedule is None:
+            score = _dense_prompt_block_posterior_state_score(
+                residuals,
+                nuisance,
+                item_kernel,
+                rho,
+                states,
+                positions,
+                component_design,
+                component_prior_precision,
+            )
+        else:
+            cache_key = (candidate.shape, candidate.tobytes(), schedule[2])
+            factored_modes = mode_cache.get(cache_key)
+            if factored_modes is None:
+                modes = _compound_symmetric_prompt_covariances(
+                    nuisance, item_kernel, rho, positions, schedule
+                )
+                factored_modes = _factor_compound_symmetric_posterior_modes(
+                    *modes,
+                    len(positions),
+                    component_design,
+                    component_prior_precision,
+                )
+                mode_cache[cache_key] = factored_modes
+            score = _compound_symmetric_prompt_block_posterior_state_score(
+                residuals,
+                states,
+                positions,
+                component_design,
+                factored_modes,
+            )
         output[positions] = score
     return output
 
@@ -928,6 +1267,18 @@ def candidate_grid(gammas=DEFAULT_GAMMAS, rhos=DEFAULT_RHOS):
     return tuple(output)
 
 
+def _candidate_gain_needs_dense_recheck(
+    fold_gains,
+    tolerance=DENSE_DECISION_RECHECK_ATOL,
+):
+    """Flag only numerical proximity to a strict fold/macro zero boundary."""
+    values = np.asarray(fold_gains, dtype=float)
+    return bool(
+        np.any(np.abs(values) <= tolerance)
+        or abs(float(np.mean(values))) <= tolerance
+    )
+
+
 def inner_candidate_search(
     field,
     geometry,
@@ -940,15 +1291,18 @@ def inner_candidate_search(
 ):
     candidates = candidate_grid(gammas, rhos)
     gains: Dict[Candidate, list] = {candidate: [] for candidate in candidates}
+    fold_contexts = []
+    block_kernel = gamma_item_kernel(0.5, geometry.kernels)
     for fit, held in outer_fold.inner:
         nuisance = fit_repeat_nuisance(
             field, geometry, fit, held, mean_ridges=mean_ridges, shrinkage=shrinkage
         )
         held_prompt_blocks = geometry.prompt_block_index[held]
+        fold_contexts.append((nuisance, held_prompt_blocks))
         block_nll = prompt_block_gaussian_nll(
             nuisance.evaluate_centered_means,
             nuisance,
-            gamma_item_kernel(0.5, geometry.kernels),
+            block_kernel,
             0.0,
             held_prompt_blocks,
         )
@@ -964,6 +1318,42 @@ def inner_candidate_search(
                     held_prompt_blocks,
                 )
             gains[candidate].append(float(np.mean(block_nll - candidate_nll)))
+
+    # Eigenmode and dense factorizations are algebraically equivalent, but a
+    # last-bit difference must not decide the preregistered strict `> 0`
+    # eligibility rule.  Near either a fold zero or the macro zero, recompute
+    # all three gains with the canonical dense scorer.  The tolerance triggers
+    # recomputation only: dense values remain unrounded and face the same exact
+    # zero comparison below.
+    dense_block_nll = [None] * len(fold_contexts)
+    for candidate in candidates:
+        if candidate.is_block or not _candidate_gain_needs_dense_recheck(
+            gains[candidate]
+        ):
+            continue
+        candidate_kernel = gamma_item_kernel(candidate.gamma, geometry.kernels)
+        dense_values = []
+        for fold_index, (nuisance, held_prompt_blocks) in enumerate(fold_contexts):
+            if dense_block_nll[fold_index] is None:
+                dense_block_nll[fold_index] = _dense_prompt_block_gaussian_nll(
+                    nuisance.evaluate_centered_means,
+                    nuisance,
+                    block_kernel,
+                    0.0,
+                    held_prompt_blocks,
+                )
+            candidate_nll = _dense_prompt_block_gaussian_nll(
+                nuisance.evaluate_centered_means,
+                nuisance,
+                candidate_kernel,
+                candidate.rho,
+                held_prompt_blocks,
+            )
+            dense_values.append(float(np.mean(
+                dense_block_nll[fold_index] - candidate_nll
+            )))
+        gains[candidate] = dense_values
+
     summaries = tuple(CandidateSummary(
         candidate,
         float(np.mean(values)),

--- a/prototypes/mu_cosine/repeated_judge_power.py
+++ b/prototypes/mu_cosine/repeated_judge_power.py
@@ -1,0 +1,1479 @@
+"""Repeat-aware synthetic power primitives for graph-local judge covariance.
+
+This is a sizing mechanism, not a real-data analysis.  Every synthetic
+replicate regenerates its component partition, cross-fits five outer folds,
+selects mean regularization and covariance capacity inside outer training, and
+scores two distinct held endpoints: residual Gaussian NLL and the NLL of a
+small linear-Gaussian posterior over latent D/S states.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import itertools
+import json
+import math
+from typing import Dict, Iterable, Mapping, Sequence, Tuple
+
+import numpy as np
+
+
+ROWS_PER_COMPONENT = 3
+CHANNELS = 4  # operating D/S, Luna D/S
+STATE_CHANNELS = 2
+OUTER_FOLDS = 5
+INNER_FOLDS = 3
+DEFAULT_GAMMAS = (0.0, 0.25, 0.50, 0.75, 1.0)
+DEFAULT_RHOS = (0.0, 0.025, 0.05, 0.10, 0.20)
+DEFAULT_MEAN_RIDGES = (0.0, 0.01, 0.10, 1.0, 10.0)
+PRIMARY_ENDPOINTS = ("residual_nll", "posterior_state_nll")
+MAX_PROMPT_ROWS = 10
+SYNTHETIC_CORPORA = ("synthetic_corpus_1", "synthetic_corpus_2")
+
+
+def derive_seed(base: int, *parts) -> int:
+    payload = json.dumps((int(base), *parts), separators=(",", ":")).encode("utf-8")
+    return int.from_bytes(hashlib.sha256(payload).digest()[:8], "little") % (2**32 - 1)
+
+
+def _symmetric(value):
+    value = np.asarray(value, dtype=float)
+    return 0.5 * (value + value.T)
+
+
+def _spd_floor(value, relative_floor=1e-8):
+    value = _symmetric(value)
+    eigenvalues = np.linalg.eigvalsh(value)
+    scale = max(float(np.max(np.abs(eigenvalues))), np.finfo(float).tiny)
+    loading = max(relative_floor * scale - float(eigenvalues[0]), 0.0)
+    return value + loading * np.eye(len(value)), float(loading)
+
+
+def _normalize_rows(features):
+    features = np.asarray(features, dtype=float)
+    norms = np.linalg.norm(features, axis=1)
+    if np.any(norms <= np.finfo(float).eps):
+        raise ValueError("feature rows must be nonzero")
+    return features / norms[:, None]
+
+
+def explicit_item_kernels():
+    """Frozen explicit PSD cumulative-walk and Nomic proxy Gram blocks."""
+    cumulative_features = _normalize_rows(np.array([
+        [1.00, 0.00, 0.00],
+        [0.85, math.sqrt(1.0 - 0.85**2), 0.00],
+        [0.10, 0.00, math.sqrt(1.0 - 0.10**2)],
+    ]))
+    nomic_features = _normalize_rows(np.array([
+        [1.00, 0.00, 0.00],
+        [0.45, math.sqrt(1.0 - 0.45**2), 0.00],
+        [0.65, -0.15, math.sqrt(1.0 - 0.65**2 - 0.15**2)],
+    ]))
+    kernels = {
+        "cumulative": _symmetric(cumulative_features @ cumulative_features.T),
+        "nomic": _symmetric(nomic_features @ nomic_features.T),
+    }
+    kernels["graph"] = kernels["cumulative"]  # compatibility alias; never a separate vote
+    kernels["deranged_cumulative"] = deranged_item_kernel(kernels["cumulative"])
+    for name, kernel in kernels.items():
+        if not np.allclose(np.diag(kernel), 1.0, atol=1e-12):
+            raise AssertionError(f"{name} kernel is not unit diagonal")
+        if np.linalg.eigvalsh(kernel)[0] < -1e-12:
+            raise AssertionError(f"{name} kernel is not PSD")
+    return kernels
+
+
+def deranged_item_kernel(kernel):
+    """Equal-energy/spectrum control that exchanges adjacent and distant roles."""
+    kernel = np.asarray(kernel, dtype=float)
+    if kernel.shape != (ROWS_PER_COMPONENT, ROWS_PER_COMPONENT):
+        raise ValueError("item kernel must be 3x3")
+    permutation = np.array([0, 2, 1])
+    return _symmetric(kernel[np.ix_(permutation, permutation)])
+
+
+def gamma_item_kernel(gamma, kernels=None):
+    gamma = float(gamma)
+    if not 0.0 <= gamma <= 1.0:
+        raise ValueError("gamma must lie in [0,1]")
+    kernels = explicit_item_kernels() if kernels is None else kernels
+    return _symmetric(
+        gamma * np.asarray(kernels["cumulative"])
+        + (1.0 - gamma) * np.asarray(kernels["nomic"])
+    )
+
+
+def maximum_off_diagonal(kernel):
+    kernel = np.asarray(kernel, dtype=float)
+    if kernel.shape != (ROWS_PER_COMPONENT, ROWS_PER_COMPONENT):
+        raise ValueError("item kernel must be 3x3")
+    return float(np.max(np.abs(kernel[~np.eye(len(kernel), dtype=bool)])))
+
+
+def rho_matched_correlation(kernel, rho):
+    kernel = _symmetric(np.asarray(kernel, dtype=float))
+    rho = float(rho)
+    if not 0.0 <= rho < 1.0:
+        raise ValueError("rho must lie in [0,1)")
+    scale = maximum_off_diagonal(kernel)
+    if scale <= 0.0:
+        if rho == 0.0:
+            return np.eye(len(kernel))
+        raise ValueError("a zero off-diagonal kernel cannot carry nonzero rho")
+    alpha = rho / scale
+    if alpha >= 0.95:
+        raise ValueError("rho requires path amplitude at or above the frozen 0.95 limit")
+    correlation = _symmetric((1.0 - alpha) * np.eye(len(kernel)) + alpha * kernel)
+    if np.linalg.eigvalsh(correlation)[0] <= 0.0:
+        raise np.linalg.LinAlgError("rho-matched item correlation is not SPD")
+    return correlation
+
+
+PERSISTENT_CHANNEL_COVARIANCE = np.array([
+    [0.70, 0.15, 0.18, 0.05],
+    [0.15, 0.62, -0.06, 0.14],
+    [0.18, -0.06, 0.58, 0.11],
+    [0.05, 0.14, 0.11, 0.66],
+])
+CALL_CHANNEL_COVARIANCE = np.array([
+    [0.30, 0.08, 0.00, 0.00],
+    [0.08, 0.25, 0.00, 0.00],
+    [0.00, 0.00, 0.20, -0.04],
+    [0.00, 0.00, -0.04, 0.28],
+])
+REQUEST_CHANNEL_COVARIANCE = np.array([
+    [0.075, 0.018, 0.000, 0.000],
+    [0.018, 0.060, 0.000, 0.000],
+    [0.000, 0.000, 0.055, -0.010],
+    [0.000, 0.000, -0.010, 0.070],
+])
+WAVE_CHANNEL_COVARIANCE = 0.025 * np.array([
+    [1.0, 0.2, 0.0, 0.0],
+    [0.2, 0.8, 0.0, 0.0],
+    [0.0, 0.0, 0.7, -0.1],
+    [0.0, 0.0, -0.1, 0.9],
+])
+PRIOR_STATE_COVARIANCE = np.array([[0.85, 0.12], [0.12, 0.70]])
+MEASUREMENT_DESIGN = np.array([
+    [1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]
+])
+
+
+@dataclass(frozen=True)
+class RepeatedScenario:
+    name: str
+    truth_gamma: float
+    truth_rho: float
+    mean_strength: float = 0.65
+    deranged_truth: bool = False
+
+
+def _rho_name(value):
+    return f"{float(value):.2f}"
+
+
+SCENARIOS = tuple([
+    RepeatedScenario("block_null", 1.0, 0.0),
+    RepeatedScenario("mean_only", 1.0, 0.0, mean_strength=1.0),
+] + [
+    RepeatedScenario(f"{family}_rho_{_rho_name(rho)}", gamma, rho, deranged_truth=deranged)
+    for family, gamma, deranged in (
+        ("cumulative", 1.0, False),
+        ("nomic", 0.0, False),
+        ("mixture", 0.5, False),
+        ("deranged", 1.0, True),
+    )
+    for rho in (0.04, 0.10, 0.20)
+])
+SCENARIO_BY_NAME = {scenario.name: scenario for scenario in SCENARIOS}
+
+
+@dataclass(frozen=True)
+class CampaignGeometry:
+    component_count: int
+    mean_design: np.ndarray
+    true_mean: np.ndarray
+    kernels: Mapping[str, np.ndarray]
+    prompt_blocks: Tuple[np.ndarray, ...]
+    prompt_block_index: np.ndarray
+
+
+def _validate_prompt_blocks(component_count, prompt_blocks, max_prompt_rows=MAX_PROMPT_ROWS):
+    blocks = tuple(np.sort(np.asarray(block, dtype=int)) for block in prompt_blocks)
+    if not blocks or any(not len(block) or len(block) > max_prompt_rows for block in blocks):
+        raise ValueError("prompt blocks must contain one to ten components")
+    flattened = np.concatenate(blocks)
+    if sorted(flattened.tolist()) != list(range(component_count)):
+        raise ValueError("prompt blocks must partition every component exactly once")
+    index = np.empty(component_count, dtype=int)
+    for block_index, block in enumerate(blocks):
+        index[block] = block_index
+    return blocks, index
+
+
+def _simple_prompt_blocks(component_count, seed, max_prompt_rows=MAX_PROMPT_ROWS):
+    block_count = max(OUTER_FOLDS, int(math.ceil(component_count / max_prompt_rows)))
+    order = np.random.default_rng(seed).permutation(component_count)
+    return tuple(np.sort(chunk) for chunk in np.array_split(order, block_count))
+
+
+def build_campaign_geometry(
+    component_count,
+    seed=24051,
+    *,
+    prompt_blocks=None,
+    max_prompt_rows=MAX_PROMPT_ROWS,
+):
+    if component_count < 12:
+        raise ValueError("at least 12 endpoint components are required")
+    rng = np.random.default_rng(seed)
+    latent = rng.standard_normal((component_count, 2))
+    design = np.zeros((component_count, ROWS_PER_COMPONENT, 6), dtype=float)
+    for role in range(ROWS_PER_COMPONENT):
+        design[:, role, 0] = 1.0
+        design[:, role, 1:3] = latent
+        design[:, role, 3] = float(role == 1)
+        design[:, role, 4] = float(role == 2)
+        design[:, role, 5] = latent[:, 0] * float(role == 1) - latent[:, 1] * float(role == 2)
+    coefficients = np.array([
+        [0.12, -0.08, 0.06, -0.04],
+        [0.18, -0.13, 0.09, -0.07],
+        [-0.11, 0.16, -0.05, 0.12],
+        [0.20, -0.06, 0.13, -0.10],
+        [-0.14, 0.09, -0.12, 0.08],
+        [0.08, 0.05, -0.07, 0.04],
+    ])
+    true_mean = design @ coefficients
+    nonlinear = 0.10 * np.sin(1.25 * latent[:, 0])[:, None, None]
+    true_mean += nonlinear * np.array([1.0, 0.65, -0.35])[None, :, None] * np.array(
+        [0.70, -0.45, 0.35, -0.25]
+    )[None, None, :]
+    if prompt_blocks is None:
+        prompt_blocks = _simple_prompt_blocks(
+            component_count, derive_seed(seed, "prompt-blocks"), max_prompt_rows
+        )
+    prompt_blocks, prompt_block_index = _validate_prompt_blocks(
+        component_count, prompt_blocks, max_prompt_rows
+    )
+    return CampaignGeometry(
+        int(component_count),
+        design,
+        true_mean,
+        explicit_item_kernels(),
+        prompt_blocks,
+        prompt_block_index,
+    )
+
+
+def scenario_item_kernel(geometry, scenario):
+    kernel = gamma_item_kernel(scenario.truth_gamma, geometry.kernels)
+    return deranged_item_kernel(kernel) if scenario.deranged_truth else kernel
+
+
+def draw_repeated_field(
+    geometry,
+    scenario,
+    repeats,
+    seed,
+    *,
+    missing_rate=0.02,
+    include_wave_effect=True,
+):
+    """Draw ``[component,row,repeat,channel]``; missing calls are whole-response NaNs."""
+    if repeats < 3:
+        raise ValueError("the repeated-judge design requires at least three calls")
+    if not 0.0 <= missing_rate < 0.25:
+        raise ValueError("missing_rate must lie in [0,.25)")
+    rng = np.random.default_rng(seed)
+    item = rho_matched_correlation(scenario_item_kernel(geometry, scenario), scenario.truth_rho)
+    persistent_factor = np.linalg.cholesky(np.kron(item, PERSISTENT_CHANNEL_COVARIANCE))
+    persistent = (
+        rng.standard_normal((geometry.component_count, ROWS_PER_COMPONENT * CHANNELS))
+        @ persistent_factor.T
+    ).reshape(geometry.component_count, ROWS_PER_COMPONENT, CHANNELS)
+    call_factor = np.linalg.cholesky(CALL_CHANNEL_COVARIANCE)
+    call = rng.standard_normal(
+        (geometry.component_count, ROWS_PER_COMPONENT, repeats, CHANNELS)
+    ) @ call_factor.T
+    # A request contains one role from each component in one stable prompt
+    # block.  Separate judge-family requests make this covariance block
+    # diagonal across the two D/S families, as frozen above.
+    request = rng.standard_normal((
+        len(geometry.prompt_blocks), ROWS_PER_COMPONENT, repeats, CHANNELS
+    )) @ np.linalg.cholesky(REQUEST_CHANNEL_COVARIANCE).T
+    wave = np.zeros((repeats, CHANNELS))
+    if include_wave_effect:
+        wave = rng.standard_normal((repeats, CHANNELS)) @ np.linalg.cholesky(
+            WAVE_CHANNEL_COVARIANCE
+        ).T
+        wave -= wave.mean(axis=0, keepdims=True)
+    field = (
+        scenario.mean_strength * geometry.true_mean[:, :, None, :]
+        + persistent[:, :, None, :]
+        + call
+        + request[geometry.prompt_block_index]
+        + wave[None, None, :, :]
+    )
+    if missing_rate:
+        # Failures occur at the request level: all rows in a prompt block lose
+        # the same judge-family response.  Each request contains no repeated
+        # component and every block/role/family retains at least two waves.
+        observed_request = rng.random((
+            len(geometry.prompt_blocks), ROWS_PER_COMPONENT, repeats, 2
+        )) >= missing_rate
+        for block in range(len(geometry.prompt_blocks)):
+            for row in range(ROWS_PER_COMPONENT):
+                for family in range(2):
+                    if np.sum(observed_request[block, row, :, family]) < 2:
+                        observed_request[block, row, :2, family] = True
+        field = field.copy()
+        observed = observed_request[geometry.prompt_block_index]
+        for family, start in enumerate((0, 2)):
+            field[..., start:start + 2] = np.where(
+                observed[..., family, None], field[..., start:start + 2], np.nan
+            )
+    return field
+
+
+@dataclass(frozen=True)
+class OuterFold:
+    train: np.ndarray
+    held: np.ndarray
+    inner: Tuple[Tuple[np.ndarray, np.ndarray], ...]
+
+
+@dataclass(frozen=True)
+class ComponentSplits:
+    outer: Tuple[OuterFold, ...]
+    seed: int
+    outer_label: np.ndarray
+    inner_label: np.ndarray
+    prompt_blocks: Tuple[np.ndarray, ...]
+    prompt_block_index: np.ndarray
+
+    @property
+    def outer_train(self):  # compatibility: first fold only
+        return self.outer[0].train
+
+    @property
+    def outer_held(self):
+        return self.outer[0].held
+
+    @property
+    def inner(self):
+        return self.outer[0].inner
+
+
+def _balanced_inner_rotations(outer_sizes):
+    """Choose deterministic cell rotations that balance every leave-one-row margin."""
+    best = None
+    for rotations in itertools.product(range(INNER_FOLDS), repeat=OUTER_FOLDS):
+        table = np.zeros((OUTER_FOLDS, INNER_FOLDS), dtype=int)
+        for outer, (size, rotation) in enumerate(zip(outer_sizes, rotations)):
+            quotient, remainder = divmod(int(size), INNER_FOLDS)
+            table[outer] = quotient
+            for offset in range(remainder):
+                table[outer, (rotation + offset) % INNER_FOLDS] += 1
+        leave_one_imbalances = [
+            int(np.ptp(np.sum(np.delete(table, outer, axis=0), axis=0)))
+            for outer in range(OUTER_FOLDS)
+        ]
+        score = (max(leave_one_imbalances), int(np.ptp(table.sum(axis=0))), rotations)
+        if best is None or score < best[0]:
+            best = (score, table)
+    return best[1]
+
+
+def component_splits(
+    component_count,
+    *,
+    seed=51001,
+    outer_folds=OUTER_FOLDS,
+    inner_folds=INNER_FOLDS,
+    max_prompt_rows=MAX_PROMPT_ROWS,
+):
+    if outer_folds != OUTER_FOLDS:
+        raise ValueError("the frozen procedure requires exactly five outer folds")
+    if inner_folds != INNER_FOLDS:
+        raise ValueError("the frozen procedure requires exactly three inner folds")
+    if component_count < outer_folds * 2:
+        raise ValueError("too few components for five outer folds")
+    if not 1 <= max_prompt_rows <= MAX_PROMPT_ROWS:
+        raise ValueError("prompt capacity must lie in [1,10]")
+    rng = np.random.default_rng(seed)
+    order = rng.permutation(component_count)
+    held_chunks = np.array_split(order, outer_folds)
+    outer_label = np.empty(component_count, dtype=int)
+    inner_label = np.empty(component_count, dtype=int)
+    for outer_index, chunk in enumerate(held_chunks):
+        outer_label[chunk] = outer_index
+    inner_counts = _balanced_inner_rotations([len(chunk) for chunk in held_chunks])
+    for outer_index, chunk in enumerate(held_chunks):
+        shuffled = np.random.default_rng(
+            derive_seed(seed, "global-inner", outer_index)
+        ).permutation(chunk)
+        start = 0
+        for inner_index, count in enumerate(inner_counts[outer_index]):
+            inner_label[shuffled[start:start + count]] = inner_index
+            start += count
+
+    prompt_blocks = []
+    for outer_index in range(outer_folds):
+        for inner_index in range(inner_folds):
+            cell = np.flatnonzero(
+                (outer_label == outer_index) & (inner_label == inner_index)
+            )
+            cell = np.random.default_rng(
+                derive_seed(seed, "prompt-cell", outer_index, inner_index)
+            ).permutation(cell)
+            if not len(cell):
+                continue
+            block_count = max(1, int(math.ceil(len(cell) / max_prompt_rows)))
+            prompt_blocks.extend(np.sort(part) for part in np.array_split(cell, block_count))
+    prompt_blocks, prompt_block_index = _validate_prompt_blocks(
+        component_count, prompt_blocks, max_prompt_rows
+    )
+
+    all_components = set(range(component_count))
+    outer = []
+    for outer_index in range(outer_folds):
+        held = np.flatnonzero(outer_label == outer_index)
+        train = np.asarray(sorted(all_components - set(map(int, held))), dtype=int)
+        inner = []
+        train_set = set(map(int, train))
+        for inner_index in range(inner_folds):
+            inner_held = np.flatnonzero(
+                (outer_label != outer_index) & (inner_label == inner_index)
+            )
+            inner_fit = np.asarray(sorted(train_set - set(map(int, inner_held))), dtype=int)
+            inner.append((inner_fit, inner_held))
+        outer.append(OuterFold(train, held, tuple(inner)))
+    if sorted(np.concatenate([fold.held for fold in outer]).tolist()) != list(range(component_count)):
+        raise AssertionError("five held folds must cover every component exactly once")
+    # A stable prompt request can never cross an outer or global-inner label.
+    for block in prompt_blocks:
+        if len(set(outer_label[block])) != 1 or len(set(inner_label[block])) != 1:
+            raise AssertionError("a prompt block crossed an analysis split signature")
+    return ComponentSplits(
+        tuple(outer),
+        int(seed),
+        outer_label,
+        inner_label,
+        prompt_blocks,
+        prompt_block_index,
+    )
+
+
+def _fit_linear_mean(geometry, repeat_means, fit, evaluate, ridge):
+    fit = np.asarray(fit, dtype=int)
+    evaluate = np.asarray(evaluate, dtype=int)
+    X = geometry.mean_design[fit].reshape(-1, geometry.mean_design.shape[-1])
+    y = repeat_means[fit].reshape(-1, CHANNELS)
+    penalty = np.eye(X.shape[1]) * float(ridge)
+    penalty[0, 0] = 0.0
+    coefficients = np.linalg.solve(X.T @ X + penalty, X.T @ y)
+    return (
+        coefficients,
+        geometry.mean_design[fit] @ coefficients,
+        geometry.mean_design[evaluate] @ coefficients,
+    )
+
+
+def _select_mean_ridge(geometry, means, fit, ridges):
+    ridges = tuple(sorted(set(map(float, ridges))))
+    if not ridges or any(value < 0.0 for value in ridges):
+        raise ValueError("mean ridge grid must be nonempty and nonnegative")
+    fit = np.asarray(fit, dtype=int)
+    fit_blocks = np.unique(geometry.prompt_block_index[fit])
+    chunks = np.array_split(fit_blocks, min(3, len(fit_blocks)))
+    scores = []
+    fit_set = set(map(int, fit))
+    for ridge in ridges:
+        fold_scores = []
+        for held_blocks in chunks:
+            held = fit[np.isin(geometry.prompt_block_index[fit], held_blocks)]
+            train = np.asarray(sorted(fit_set - set(map(int, held))), dtype=int)
+            if not len(train) or not len(held):
+                continue
+            _coef, _train_pred, held_pred = _fit_linear_mean(
+                geometry, means, train, held, ridge
+            )
+            fold_scores.append(float(np.mean((means[held] - held_pred) ** 2)))
+        scores.append((float(np.mean(fold_scores)), ridge))
+    return min(scores)[1]
+
+
+def _estimate_wave_effects(field, fit):
+    fit_values = field[np.asarray(fit, dtype=int)]
+    wave_means = np.nanmean(fit_values, axis=(0, 1))
+    grand = np.nanmean(wave_means, axis=0, keepdims=True)
+    return wave_means - grand
+
+
+def _fit_total_repeat_covariance(field):
+    row_means = np.nanmean(field, axis=2, keepdims=True)
+    centered = field - row_means
+    structured = np.zeros((CHANNELS, CHANNELS), dtype=float)
+    for start in (0, 2):
+        estimates = []
+        for component in range(field.shape[0]):
+            for row in range(field.shape[1]):
+                observed = np.isfinite(centered[component, row, :, start])
+                values = centered[component, row, observed, start:start + 2]
+                if len(values) >= 2:
+                    estimates.append(values.T @ values / (len(values) - 1.0))
+        if not estimates:
+            raise ValueError("no row retains two calls for repeat-covariance estimation")
+        block = _symmetric(np.mean(estimates, axis=0))
+        structured[start:start + 2, start:start + 2] = 0.95 * block + 0.05 * np.diag(
+            np.diag(block)
+        )
+    return _spd_floor(structured)[0]
+
+
+def _fit_request_covariance(field, geometry, fit):
+    """Method-of-moments covariance for the shared prompt-request effect.
+
+    The cross-component product within one stable request eliminates the
+    row-specific call noise.  Complete-wave component pairs are used so the
+    usual ``1 - 1/R`` centering correction is exact.  The estimator is refit
+    from training prompt blocks only and receives the frozen 5% diagonal
+    shrinkage plus the reported numerical SPD floor.
+    """
+    fit = np.asarray(fit, dtype=int)
+    structured = np.zeros((CHANNELS, CHANNELS), dtype=float)
+    for family, start in enumerate((0, 2)):
+        estimates = []
+        for block_id in np.unique(geometry.prompt_block_index[fit]):
+            components = fit[geometry.prompt_block_index[fit] == block_id]
+            if len(components) < 2:
+                continue
+            for row in range(ROWS_PER_COMPONENT):
+                values = field[components, row, :, start:start + 2]
+                complete = np.all(np.isfinite(values), axis=(1, 2))
+                values = values[complete]
+                if len(values) < 2:
+                    continue
+                values = values - values.mean(axis=1, keepdims=True)
+                repeats = values.shape[1]
+                centering = 1.0 - 1.0 / repeats
+                for repeat in range(repeats):
+                    wave_values = values[:, repeat, :]
+                    total = np.sum(wave_values, axis=0)
+                    cross_sum = (
+                        np.outer(total, total)
+                        - np.einsum("ni,nj->ij", wave_values, wave_values)
+                    ) / (len(wave_values) * (len(wave_values) - 1.0))
+                    estimates.append(cross_sum / centering)
+        if not estimates:
+            raise ValueError(
+                "request covariance is not identified from two complete components "
+                f"in any training prompt block for family {family}"
+            )
+        block = _symmetric(np.mean(estimates, axis=0))
+        block = 0.95 * block + 0.05 * np.diag(np.diag(block))
+        structured[start:start + 2, start:start + 2] = block
+    return _spd_floor(structured)
+
+
+@dataclass(frozen=True)
+class NuisanceFit:
+    coefficients: np.ndarray
+    selected_mean_ridge: float
+    wave_effects: np.ndarray
+    call_covariance: np.ndarray
+    request_covariance: np.ndarray
+    repeat_covariance: np.ndarray
+    persistent_covariance: np.ndarray
+    call_loading: float
+    request_loading: float
+    persistent_loading: float
+    evaluate_prediction: np.ndarray
+    evaluate_centered_means: np.ndarray
+    evaluate_repeat_counts: np.ndarray
+    evaluate_observed_calls: np.ndarray
+
+
+def fit_repeat_nuisance(
+    field,
+    geometry,
+    fit_components,
+    evaluate_components,
+    *,
+    mean_ridges=DEFAULT_MEAN_RIDGES,
+    shrinkage=0.05,
+):
+    field = np.asarray(field, dtype=float)
+    if field.ndim != 4 or field.shape[:2] != (geometry.component_count, ROWS_PER_COMPONENT) or field.shape[3] != CHANNELS:
+        raise ValueError("field must have shape [G,3,R,4]")
+    if field.shape[2] < 3:
+        raise ValueError("at least three repeats are required")
+    fit = np.asarray(fit_components, dtype=int)
+    evaluate = np.asarray(evaluate_components, dtype=int)
+    wave_effects = _estimate_wave_effects(field, fit)
+    adjusted = field - wave_effects[None, None, :, :]
+    observed_calls = np.stack([
+        np.isfinite(adjusted[..., start]) for start in (0, 2)
+    ], axis=-1)
+    counts = np.sum(observed_calls, axis=2)
+    if np.any(counts < 2):
+        raise ValueError("every row must retain at least two calls")
+    means = np.nanmean(adjusted, axis=2)
+    selected_ridge = _select_mean_ridge(geometry, means, fit, mean_ridges)
+    coefficients, train_prediction, evaluate_prediction = _fit_linear_mean(
+        geometry, means, fit, evaluate, selected_ridge
+    )
+    train_residual = means[fit] - train_prediction
+    total_repeat_covariance = _fit_total_repeat_covariance(adjusted[fit])
+    request_covariance, request_loading = _fit_request_covariance(
+        adjusted, geometry, fit
+    )
+    call_raw = _symmetric(total_repeat_covariance - request_covariance)
+    call_raw = (1.0 - shrinkage) * call_raw + shrinkage * np.diag(np.diag(call_raw))
+    call_covariance, call_loading = _spd_floor(call_raw)
+    repeat_covariance = call_covariance + request_covariance
+    flat = train_residual.reshape(-1, CHANNELS)
+    mean_covariance = flat.T @ flat / len(flat)
+    sampling_covariance = np.zeros((CHANNELS, CHANNELS), dtype=float)
+    for family, start in enumerate((0, 2)):
+        sl = slice(start, start + 2)
+        average_inverse_repeats = float(np.mean(1.0 / counts[fit, :, family]))
+        sampling_covariance[sl, sl] = (
+            repeat_covariance[sl, sl] * average_inverse_repeats
+        )
+    persistent = _symmetric(mean_covariance - sampling_covariance)
+    persistent = (1.0 - shrinkage) * persistent + shrinkage * np.diag(np.diag(persistent))
+    persistent_covariance, persistent_loading = _spd_floor(persistent)
+    return NuisanceFit(
+        coefficients,
+        float(selected_ridge),
+        wave_effects,
+        call_covariance,
+        request_covariance,
+        repeat_covariance,
+        persistent_covariance,
+        call_loading,
+        request_loading,
+        persistent_loading,
+        evaluate_prediction,
+        means[evaluate] - evaluate_prediction,
+        counts[evaluate],
+        observed_calls[evaluate],
+    )
+
+
+def candidate_covariance(nuisance, item_kernel, rho, repeat_counts=None):
+    item = rho_matched_correlation(item_kernel, rho)
+    counts = nuisance.evaluate_repeat_counts if repeat_counts is None else np.asarray(repeat_counts, dtype=float)
+    if counts.ndim == 2 and counts.shape == (ROWS_PER_COMPONENT, 2):
+        counts = counts[None, :, :]
+    if counts.ndim != 3 or counts.shape[1:] != (ROWS_PER_COMPONENT, 2) or np.any(counts < 1):
+        raise ValueError("repeat counts must have shape [N,3,2] and be positive")
+    base = np.kron(item, nuisance.persistent_covariance)
+    output = np.repeat(base[None, :, :], len(counts), axis=0)
+    for row in range(ROWS_PER_COMPONENT):
+        for family, channel_start in enumerate((0, 2)):
+            start = row * CHANNELS + channel_start
+            sl = slice(start, start + 2)
+            family_sl = slice(channel_start, channel_start + 2)
+            output[:, sl, sl] += (
+                nuisance.repeat_covariance[None, family_sl, family_sl]
+                / counts[:, row, family, None, None]
+            )
+    output = 0.5 * (output + np.swapaxes(output, -1, -2))
+    # The batched Cholesky is both a fail-closed PSD check and substantially
+    # cheaper than a Python loop at the preregistered G=800 ceiling.
+    np.linalg.cholesky(output)
+    return output
+
+
+def component_gaussian_nll(residuals, covariance):
+    residuals = np.asarray(residuals, dtype=float)
+    if residuals.ndim != 3 or residuals.shape[1:] != (ROWS_PER_COMPONENT, CHANNELS):
+        raise ValueError("residuals must have shape [G,3,4]")
+    flat = residuals.reshape(len(residuals), -1)
+    covariance = np.asarray(covariance, dtype=float)
+    if covariance.ndim == 2:
+        covariance = np.repeat(covariance[None, :, :], len(flat), axis=0)
+    if covariance.shape != (len(flat), flat.shape[1], flat.shape[1]):
+        raise ValueError("covariance must be [12,12] or [G,12,12]")
+    factor = np.linalg.cholesky(covariance)
+    whitened = np.linalg.solve(factor, flat[..., None])[..., 0]
+    logdet = 2.0 * np.sum(
+        np.log(np.diagonal(factor, axis1=-2, axis2=-1)), axis=1
+    )
+    return 0.5 * (
+        np.sum(whitened * whitened, axis=1)
+        + logdet
+        + flat.shape[1] * math.log(2.0 * math.pi)
+    ) / flat.shape[1]
+
+
+def prompt_block_candidate_covariance(
+    nuisance,
+    item_kernel,
+    rho,
+    positions,
+):
+    """Joint repeat-mean covariance for one stable prompt block.
+
+    The diagonal component blocks contain persistent item covariance plus the
+    marginal row-call and shared-request sampling variance.  Off-component
+    blocks contain the fitted request covariance multiplied by the overlap of
+    the recorded repeat schedules.  Thus a shared prompt request changes the
+    Gaussian score itself; clustering is not its only acknowledgement.
+    """
+    positions = np.asarray(positions, dtype=int)
+    if positions.ndim != 1 or not len(positions):
+        raise ValueError("positions must identify at least one component")
+    marginal = candidate_covariance(
+        nuisance,
+        item_kernel,
+        rho,
+        nuisance.evaluate_repeat_counts[positions],
+    )
+    component_dimension = ROWS_PER_COMPONENT * CHANNELS
+    output = np.zeros((
+        len(positions) * component_dimension,
+        len(positions) * component_dimension,
+    ))
+    for local, covariance in enumerate(marginal):
+        sl = slice(local * component_dimension, (local + 1) * component_dimension)
+        output[sl, sl] = covariance
+    observed = nuisance.evaluate_observed_calls[positions]
+    counts = nuisance.evaluate_repeat_counts[positions]
+    for left in range(len(positions)):
+        for right in range(left + 1, len(positions)):
+            for row in range(ROWS_PER_COMPONENT):
+                for family, channel_start in enumerate((0, 2)):
+                    overlap = float(np.sum(
+                        observed[left, row, :, family]
+                        & observed[right, row, :, family]
+                    ))
+                    coefficient = overlap / (
+                        counts[left, row, family] * counts[right, row, family]
+                    )
+                    left_start = left * component_dimension + row * CHANNELS + channel_start
+                    right_start = right * component_dimension + row * CHANNELS + channel_start
+                    left_sl = slice(left_start, left_start + 2)
+                    right_sl = slice(right_start, right_start + 2)
+                    family_sl = slice(channel_start, channel_start + 2)
+                    cross = nuisance.request_covariance[family_sl, family_sl] * coefficient
+                    output[left_sl, right_sl] = cross
+                    output[right_sl, left_sl] = cross.T
+    output = _symmetric(output)
+    np.linalg.cholesky(output)
+    return output
+
+
+def _prompt_block_positions(prompt_block_ids):
+    prompt_block_ids = np.asarray(prompt_block_ids, dtype=int)
+    if prompt_block_ids.ndim != 1:
+        raise ValueError("prompt block IDs must be a vector")
+    return tuple(np.flatnonzero(prompt_block_ids == block) for block in np.unique(prompt_block_ids))
+
+
+def prompt_block_gaussian_nll(
+    residuals,
+    nuisance,
+    item_kernel,
+    rho,
+    prompt_block_ids,
+):
+    """Joint composite residual NLL, returned on an equal-component scale."""
+    residuals = np.asarray(residuals, dtype=float)
+    output = np.empty(len(residuals), dtype=float)
+    for positions in _prompt_block_positions(prompt_block_ids):
+        covariance = prompt_block_candidate_covariance(
+            nuisance, item_kernel, rho, positions
+        )
+        vector = residuals[positions].reshape(-1)
+        factor = np.linalg.cholesky(covariance)
+        whitened = np.linalg.solve(factor, vector)
+        logdet = 2.0 * float(np.sum(np.log(np.diag(factor))))
+        score = 0.5 * (
+            whitened @ whitened
+            + logdet
+            + len(vector) * math.log(2.0 * math.pi)
+        ) / len(vector)
+        output[positions] = score
+    return output
+
+
+def draw_latent_states(component_count, seed):
+    factor = np.linalg.cholesky(PRIOR_STATE_COVARIANCE)
+    return np.random.default_rng(seed).standard_normal(
+        (component_count, ROWS_PER_COMPONENT, STATE_CHANNELS)
+    ) @ factor.T
+
+
+def posterior_state_nll(residuals, covariance, states):
+    """Score true latent states under a candidate linear-Gaussian posterior."""
+    residuals = np.asarray(residuals, dtype=float)
+    states = np.asarray(states, dtype=float)
+    if states.shape != (len(residuals), ROWS_PER_COMPONENT, STATE_CHANNELS):
+        raise ValueError("states must have shape [G,3,2]")
+    covariance = np.asarray(covariance, dtype=float)
+    if covariance.ndim == 2:
+        covariance = np.repeat(covariance[None], len(residuals), axis=0)
+    design = np.kron(np.eye(ROWS_PER_COMPONENT), MEASUREMENT_DESIGN)
+    prior = np.kron(np.eye(ROWS_PER_COMPONENT), PRIOR_STATE_COVARIANCE)
+    prior_precision = np.linalg.solve(prior, np.eye(len(prior)))
+    output = []
+    for error, truth, noise_covariance in zip(residuals, states, covariance):
+        truth = truth.reshape(-1)
+        observed = design @ truth + error.reshape(-1)
+        solved_design = np.linalg.solve(noise_covariance, design)
+        precision = prior_precision + design.T @ solved_design
+        posterior_covariance = np.linalg.solve(precision, np.eye(len(precision)))
+        posterior_mean = posterior_covariance @ (
+            design.T @ np.linalg.solve(noise_covariance, observed)
+        )
+        delta = truth - posterior_mean
+        sign, logdet = np.linalg.slogdet(posterior_covariance)
+        if sign <= 0:
+            raise np.linalg.LinAlgError("posterior covariance is not positive definite")
+        output.append(0.5 * (
+            delta @ precision @ delta + logdet + len(delta) * math.log(2.0 * math.pi)
+        ) / len(delta))
+    return np.asarray(output)
+
+
+def prompt_block_posterior_state_nll(
+    residuals,
+    nuisance,
+    item_kernel,
+    rho,
+    states,
+    prompt_block_ids,
+):
+    """Joint latent-state posterior NLL under the prompt schedule covariance."""
+    residuals = np.asarray(residuals, dtype=float)
+    states = np.asarray(states, dtype=float)
+    if states.shape != (len(residuals), ROWS_PER_COMPONENT, STATE_CHANNELS):
+        raise ValueError("states must have shape [G,3,2]")
+    component_design = np.kron(np.eye(ROWS_PER_COMPONENT), MEASUREMENT_DESIGN)
+    component_prior = np.kron(np.eye(ROWS_PER_COMPONENT), PRIOR_STATE_COVARIANCE)
+    output = np.empty(len(residuals), dtype=float)
+    for positions in _prompt_block_positions(prompt_block_ids):
+        noise_covariance = prompt_block_candidate_covariance(
+            nuisance, item_kernel, rho, positions
+        )
+        design = np.kron(np.eye(len(positions)), component_design)
+        prior = np.kron(np.eye(len(positions)), component_prior)
+        prior_precision = np.linalg.solve(prior, np.eye(len(prior)))
+        truth = states[positions].reshape(-1)
+        observed = design @ truth + residuals[positions].reshape(-1)
+        solved_design = np.linalg.solve(noise_covariance, design)
+        precision = prior_precision + design.T @ solved_design
+        posterior_covariance = np.linalg.solve(precision, np.eye(len(precision)))
+        posterior_mean = posterior_covariance @ (
+            design.T @ np.linalg.solve(noise_covariance, observed)
+        )
+        delta = truth - posterior_mean
+        sign, logdet = np.linalg.slogdet(posterior_covariance)
+        if sign <= 0:
+            raise np.linalg.LinAlgError("posterior covariance is not positive definite")
+        score = 0.5 * (
+            delta @ precision @ delta
+            + logdet
+            + len(delta) * math.log(2.0 * math.pi)
+        ) / len(delta)
+        output[positions] = score
+    return output
+
+
+@dataclass(frozen=True)
+class Candidate:
+    gamma: float
+    rho: float
+
+    @property
+    def is_block(self):
+        return self.rho == 0.0
+
+
+BLOCK_CANDIDATE = Candidate(0.5, 0.0)
+
+
+@dataclass(frozen=True)
+class CandidateSummary:
+    candidate: Candidate
+    macro_gain: float
+    positive_folds: int
+    fold_gains: Tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class InnerSearch:
+    selected: Candidate
+    summaries: Tuple[CandidateSummary, ...]
+    maximum_eligible_gain: float
+
+
+def candidate_grid(gammas=DEFAULT_GAMMAS, rhos=DEFAULT_RHOS):
+    gammas = tuple(sorted(set(map(float, gammas))))
+    rhos = tuple(sorted(set(map(float, rhos))))
+    if 0.0 not in rhos:
+        raise ValueError("rho grid must contain block rho=0")
+    output = [BLOCK_CANDIDATE]
+    for gamma in gammas:
+        if not 0.0 <= gamma <= 1.0:
+            raise ValueError("gamma values must lie in [0,1]")
+        for rho in rhos:
+            if rho > 0.0:
+                # Declare path eligibility before any outcome is scored.
+                rho_matched_correlation(gamma_item_kernel(gamma), rho)
+                output.append(Candidate(gamma, rho))
+    return tuple(output)
+
+
+def inner_candidate_search(
+    field,
+    geometry,
+    outer_fold,
+    *,
+    gammas=DEFAULT_GAMMAS,
+    rhos=DEFAULT_RHOS,
+    mean_ridges=DEFAULT_MEAN_RIDGES,
+    shrinkage=0.05,
+):
+    candidates = candidate_grid(gammas, rhos)
+    gains: Dict[Candidate, list] = {candidate: [] for candidate in candidates}
+    for fit, held in outer_fold.inner:
+        nuisance = fit_repeat_nuisance(
+            field, geometry, fit, held, mean_ridges=mean_ridges, shrinkage=shrinkage
+        )
+        held_prompt_blocks = geometry.prompt_block_index[held]
+        block_nll = prompt_block_gaussian_nll(
+            nuisance.evaluate_centered_means,
+            nuisance,
+            gamma_item_kernel(0.5, geometry.kernels),
+            0.0,
+            held_prompt_blocks,
+        )
+        for candidate in candidates:
+            if candidate.is_block:
+                candidate_nll = block_nll
+            else:
+                candidate_nll = prompt_block_gaussian_nll(
+                    nuisance.evaluate_centered_means,
+                    nuisance,
+                    gamma_item_kernel(candidate.gamma, geometry.kernels),
+                    candidate.rho,
+                    held_prompt_blocks,
+                )
+            gains[candidate].append(float(np.mean(block_nll - candidate_nll)))
+    summaries = tuple(CandidateSummary(
+        candidate,
+        float(np.mean(values)),
+        int(np.sum(np.asarray(values) > 0.0)),
+        tuple(values),
+    ) for candidate, values in gains.items())
+    eligible = [
+        row for row in summaries
+        if not row.candidate.is_block and row.macro_gain > 0.0 and row.positive_folds >= 2
+    ]
+    if not eligible:
+        return InnerSearch(BLOCK_CANDIDATE, summaries, 0.0)
+    best = min(eligible, key=lambda row: (
+        -row.macro_gain, row.candidate.rho, abs(row.candidate.gamma - 0.5), row.candidate.gamma
+    ))
+    return InnerSearch(best.candidate, summaries, float(max(row.macro_gain for row in eligible)))
+
+
+def finite_null_maximum_threshold(maxima, confidence=0.95):
+    values = np.asarray(maxima, dtype=float)
+    if values.ndim != 1 or not len(values) or not np.isfinite(values).all():
+        raise ValueError("null maxima must be a nonempty finite vector")
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must lie in (0,1)")
+    rank = min(int(math.ceil(confidence * (len(values) + 1))), len(values))
+    return float(np.sort(values)[rank - 1]), rank
+
+
+def select_strictly_calibrated(search, threshold):
+    if not np.isfinite(threshold) or threshold < 0.0:
+        raise ValueError("threshold must be finite and nonnegative")
+    rejected = bool(not search.selected.is_block and search.maximum_eligible_gain > threshold)
+    return (search.selected if rejected else BLOCK_CANDIDATE), rejected
+
+
+def _replicate_geometry_and_splits(component_count, seed, max_prompt_rows=MAX_PROMPT_ROWS):
+    splits = component_splits(
+        component_count,
+        seed=derive_seed(seed, "splits"),
+        max_prompt_rows=max_prompt_rows,
+    )
+    geometry = build_campaign_geometry(
+        component_count,
+        derive_seed(seed, "geometry"),
+        prompt_blocks=splits.prompt_blocks,
+        max_prompt_rows=max_prompt_rows,
+    )
+    return geometry, splits
+
+
+def calibrate_synthetic_selector_null(
+    component_count,
+    *,
+    repeats,
+    draws,
+    seed,
+    gammas=DEFAULT_GAMMAS,
+    rhos=DEFAULT_RHOS,
+    mean_ridges=DEFAULT_MEAN_RIDGES,
+    shrinkage=0.05,
+    confidence=0.95,
+    missing_rate=0.02,
+    max_prompt_rows=MAX_PROMPT_ROWS,
+):
+    if draws < 1:
+        raise ValueError("draws must be positive")
+    maxima = []
+    for draw in range(draws):
+        replicate_seed = derive_seed(seed, "null", draw)
+        joint_search_maxima = []
+        for corpus in SYNTHETIC_CORPORA:
+            corpus_seed = derive_seed(replicate_seed, corpus)
+            geometry, splits = _replicate_geometry_and_splits(
+                component_count, corpus_seed, max_prompt_rows
+            )
+            field = draw_repeated_field(
+                geometry,
+                SCENARIO_BY_NAME["block_null"],
+                repeats,
+                derive_seed(corpus_seed, "field"),
+                missing_rate=missing_rate,
+            )
+            searches = [inner_candidate_search(
+                field,
+                geometry,
+                fold,
+                gammas=gammas,
+                rhos=rhos,
+                mean_ridges=mean_ridges,
+                shrinkage=shrinkage,
+            ) for fold in splits.outer]
+            joint_search_maxima.extend(
+                search.maximum_eligible_gain for search in searches
+            )
+        maxima.append(max(joint_search_maxima))
+    values = np.asarray(maxima)
+    threshold, rank = finite_null_maximum_threshold(values, confidence)
+    return values, threshold, rank
+
+
+def prompt_block_multiplier_simultaneous_lower_bounds(
+    values,
+    prompt_block_ids,
+    *,
+    confidence=0.95,
+    draws=999,
+    seed=0,
+):
+    """One-sided max-t bounds with stable prompt blocks as inference clusters.
+
+    The point estimate remains the preregistered equal-component mean.  Wild
+    multiplier perturbations sum centered component influences inside each
+    request-connected prompt block before signs are drawn, so batching cannot
+    masquerade as independent component information.
+    """
+    lower, critical, cluster_counts = multicorpus_prompt_block_lower_bounds(
+        (values,),
+        (prompt_block_ids,),
+        confidence=confidence,
+        draws=draws,
+        seed=seed,
+    )
+    return lower[0], critical, cluster_counts[0]
+
+
+def multicorpus_prompt_block_lower_bounds(
+    corpus_values,
+    corpus_prompt_block_ids,
+    *,
+    confidence=0.95,
+    draws=999,
+    seed=0,
+):
+    """Simultaneous lower bounds across endpoints and required corpora."""
+    corpus_values = tuple(np.asarray(value, dtype=float) for value in corpus_values)
+    corpus_prompt_block_ids = tuple(
+        np.asarray(value, dtype=int) for value in corpus_prompt_block_ids
+    )
+    if not corpus_values or len(corpus_values) != len(corpus_prompt_block_ids):
+        raise ValueError("corpus values and block-ID collections must align")
+    endpoint_count = corpus_values[0].shape[1] if corpus_values[0].ndim == 2 else 0
+    for values, prompt_block_ids in zip(corpus_values, corpus_prompt_block_ids):
+        if (
+            values.ndim != 2
+            or values.shape[0] < 2
+            or values.shape[1] != endpoint_count
+            or endpoint_count < 2
+            or not np.isfinite(values).all()
+        ):
+            raise ValueError("values must be finite [components,endpoints] matrices")
+        if prompt_block_ids.shape != (len(values),):
+            raise ValueError("prompt block IDs must have one entry per component")
+    if draws < 1 or not 0.0 < confidence < 1.0:
+        raise ValueError("invalid multiplier configuration")
+    point = np.concatenate([values.mean(axis=0) for values in corpus_values])
+    cluster_rows = []
+    cluster_counts = []
+    total_endpoints = len(corpus_values) * endpoint_count
+    for corpus_index, (values, prompt_block_ids) in enumerate(zip(
+        corpus_values, corpus_prompt_block_ids
+    )):
+        blocks = np.unique(prompt_block_ids)
+        if len(blocks) < 2:
+            raise ValueError("at least two independent prompt blocks are required")
+        cluster_counts.append(int(len(blocks)))
+        centered = values - values.mean(axis=0)
+        correction = math.sqrt(len(blocks) / (len(blocks) - 1.0))
+        target = slice(corpus_index * endpoint_count, (corpus_index + 1) * endpoint_count)
+        for block in blocks:
+            row = np.zeros(total_endpoints, dtype=float)
+            row[target] = (
+                np.sum(centered[prompt_block_ids == block], axis=0)
+                / len(values)
+                * correction
+            )
+            cluster_rows.append(row)
+    cluster_influence = np.asarray(cluster_rows)
+    standard_error = np.sqrt(np.sum(cluster_influence * cluster_influence, axis=0))
+    safe = np.where(standard_error > np.finfo(float).eps, standard_error, 1.0)
+    signs = np.random.default_rng(seed).choice(
+        (-1.0, 1.0), size=(draws, len(cluster_influence))
+    )
+    deviations = signs @ cluster_influence
+    max_stat = np.max(-deviations / safe[None, :], axis=1)
+    critical = float(np.quantile(max_stat, confidence))
+    lower = point - critical * standard_error
+    lower = np.where(standard_error > np.finfo(float).eps, lower, point)
+    return lower.reshape(len(corpus_values), endpoint_count), critical, tuple(cluster_counts)
+
+
+@dataclass(frozen=True)
+class PowerReplicate:
+    scenario: str
+    selected: Tuple[Tuple[Candidate, ...], ...]
+    corpus_selector_rejected: Tuple[bool, ...]
+    familywise_rejected: bool
+    maximum_inner_gain: float
+    endpoint_component_gains: np.ndarray
+    endpoint_mean_gains: np.ndarray
+    endpoint_lower_bounds: np.ndarray
+    multiplier_critical_value: float
+    inference_prompt_blocks: Tuple[int, ...]
+    topology_component_advantage: np.ndarray | None
+    topology_truth_beats_derangement: bool | None
+    promoted: bool
+    call_loading: float
+    persistent_loading: float
+    request_loading: float
+
+
+@dataclass(frozen=True)
+class _CorpusPowerReplicate:
+    selected: Tuple[Candidate, ...]
+    selector_rejected: bool
+    maximum_inner_gain: float
+    endpoint_component_gains: np.ndarray
+    prompt_block_ids: np.ndarray
+    topology_component_advantage: np.ndarray | None
+    call_loading: float
+    persistent_loading: float
+    request_loading: float
+
+
+def _run_corpus_power_replicate(
+    component_count,
+    scenario,
+    *,
+    repeats,
+    seed,
+    null_threshold,
+    gammas=DEFAULT_GAMMAS,
+    rhos=DEFAULT_RHOS,
+    mean_ridges=DEFAULT_MEAN_RIDGES,
+    shrinkage=0.05,
+    missing_rate=0.02,
+    max_prompt_rows=MAX_PROMPT_ROWS,
+):
+    geometry, splits = _replicate_geometry_and_splits(
+        component_count, seed, max_prompt_rows
+    )
+    field = draw_repeated_field(
+        geometry, scenario, repeats, derive_seed(seed, "field"), missing_rate=missing_rate
+    )
+    states = draw_latent_states(component_count, derive_seed(seed, "states"))
+    endpoint_gains = np.empty((component_count, len(PRIMARY_ENDPOINTS)), dtype=float)
+    topology_advantage = np.empty(component_count, dtype=float) if (
+        scenario.truth_rho > 0.0 and not scenario.deranged_truth
+    ) else None
+    selected_by_fold = []
+    rejected_by_fold = []
+    maxima = []
+    call_loadings = []
+    persistent_loadings = []
+    request_loadings = []
+    for fold in splits.outer:
+        search = inner_candidate_search(
+            field,
+            geometry,
+            fold,
+            gammas=gammas,
+            rhos=rhos,
+            mean_ridges=mean_ridges,
+            shrinkage=shrinkage,
+        )
+        selected, rejected = select_strictly_calibrated(search, null_threshold)
+        selected_by_fold.append(selected)
+        rejected_by_fold.append(rejected)
+        maxima.append(search.maximum_eligible_gain)
+        nuisance = fit_repeat_nuisance(
+            field,
+            geometry,
+            fold.train,
+            fold.held,
+            mean_ridges=mean_ridges,
+            shrinkage=shrinkage,
+        )
+        call_loadings.append(nuisance.call_loading)
+        persistent_loadings.append(nuisance.persistent_loading)
+        request_loadings.append(nuisance.request_loading)
+        held_prompt_blocks = geometry.prompt_block_index[fold.held]
+        block_kernel = gamma_item_kernel(0.5, geometry.kernels)
+        selected_kernel = (
+            block_kernel if selected.is_block
+            else gamma_item_kernel(selected.gamma, geometry.kernels)
+        )
+        block_residual = prompt_block_gaussian_nll(
+            nuisance.evaluate_centered_means,
+            nuisance,
+            block_kernel,
+            0.0,
+            held_prompt_blocks,
+        )
+        selected_residual = prompt_block_gaussian_nll(
+            nuisance.evaluate_centered_means,
+            nuisance,
+            selected_kernel,
+            selected.rho,
+            held_prompt_blocks,
+        )
+        block_posterior = prompt_block_posterior_state_nll(
+            nuisance.evaluate_centered_means,
+            nuisance,
+            block_kernel,
+            0.0,
+            states[fold.held],
+            held_prompt_blocks,
+        )
+        selected_posterior = prompt_block_posterior_state_nll(
+            nuisance.evaluate_centered_means,
+            nuisance,
+            selected_kernel,
+            selected.rho,
+            states[fold.held],
+            held_prompt_blocks,
+        )
+        endpoint_gains[fold.held, 0] = block_residual - selected_residual
+        endpoint_gains[fold.held, 1] = block_posterior - selected_posterior
+        if topology_advantage is not None:
+            truth_kernel = scenario_item_kernel(geometry, scenario)
+            topology_advantage[fold.held] = (
+                prompt_block_gaussian_nll(
+                    nuisance.evaluate_centered_means,
+                    nuisance,
+                    deranged_item_kernel(truth_kernel),
+                    scenario.truth_rho,
+                    held_prompt_blocks,
+                )
+                - prompt_block_gaussian_nll(
+                    nuisance.evaluate_centered_means,
+                    nuisance,
+                    truth_kernel,
+                    scenario.truth_rho,
+                    held_prompt_blocks,
+                )
+            )
+    return _CorpusPowerReplicate(
+        tuple(selected_by_fold),
+        bool(any(rejected_by_fold)),
+        float(max(maxima)),
+        endpoint_gains,
+        geometry.prompt_block_index,
+        topology_advantage,
+        float(max(call_loadings)),
+        float(max(persistent_loadings)),
+        float(max(request_loadings)),
+    )
+
+
+def run_power_replicate(
+    component_count,
+    scenario,
+    *,
+    repeats,
+    seed,
+    null_threshold,
+    gammas=DEFAULT_GAMMAS,
+    rhos=DEFAULT_RHOS,
+    mean_ridges=DEFAULT_MEAN_RIDGES,
+    shrinkage=0.05,
+    confidence=0.95,
+    multiplier_draws=999,
+    missing_rate=0.02,
+    max_prompt_rows=MAX_PROMPT_ROWS,
+):
+    """Run one joint event spanning both required synthetic corpora."""
+    corpus_records = tuple(
+        _run_corpus_power_replicate(
+            component_count,
+            scenario,
+            repeats=repeats,
+            seed=derive_seed(seed, corpus),
+            null_threshold=null_threshold,
+            gammas=gammas,
+            rhos=rhos,
+            mean_ridges=mean_ridges,
+            shrinkage=shrinkage,
+            missing_rate=missing_rate,
+            max_prompt_rows=max_prompt_rows,
+        )
+        for corpus in SYNTHETIC_CORPORA
+    )
+    endpoint_gains = np.stack([
+        record.endpoint_component_gains for record in corpus_records
+    ])
+    lower, critical, inference_prompt_blocks = multicorpus_prompt_block_lower_bounds(
+        tuple(record.endpoint_component_gains for record in corpus_records),
+        tuple(record.prompt_block_ids for record in corpus_records),
+        confidence=confidence,
+        draws=multiplier_draws,
+        seed=derive_seed(seed, "joint-multiplier"),
+    )
+    corpus_selector_rejected = tuple(
+        record.selector_rejected for record in corpus_records
+    )
+    familywise_rejected = bool(all(corpus_selector_rejected))
+    if scenario.truth_rho > 0.0 and not scenario.deranged_truth:
+        topology_advantage = np.stack([
+            record.topology_component_advantage for record in corpus_records
+        ])
+        topology_beats = bool(np.all(np.mean(topology_advantage, axis=1) > 0.0))
+    else:
+        topology_advantage = None
+        topology_beats = None
+    promoted = bool(familywise_rejected and np.all(lower > 0.0))
+    return PowerReplicate(
+        scenario.name,
+        tuple(record.selected for record in corpus_records),
+        corpus_selector_rejected,
+        familywise_rejected,
+        float(max(record.maximum_inner_gain for record in corpus_records)),
+        endpoint_gains,
+        endpoint_gains.mean(axis=1),
+        lower,
+        critical,
+        inference_prompt_blocks,
+        topology_advantage,
+        topology_beats,
+        promoted,
+        float(max(record.call_loading for record in corpus_records)),
+        float(max(record.persistent_loading for record in corpus_records)),
+        float(max(record.request_loading for record in corpus_records)),
+    )
+
+
+def summary(values: Iterable[float]):
+    values = np.asarray(tuple(values), dtype=float)
+    if values.ndim != 1 or not len(values) or not np.isfinite(values).all():
+        raise ValueError("summary needs a nonempty finite vector")
+    return {
+        "mean": float(np.mean(values)),
+        "sd": float(np.std(values, ddof=1)) if len(values) > 1 else 0.0,
+        "minimum": float(np.min(values)),
+        "maximum": float(np.max(values)),
+    }
+
+
+def aggregate_power_records(records):
+    if not records:
+        raise ValueError("at least one power record is required")
+    if len({row.scenario for row in records}) != 1:
+        raise ValueError("power records must share one scenario")
+    selected = [
+        candidate
+        for row in records
+        for corpus_selected in row.selected
+        for candidate in corpus_selected
+    ]
+    topology = [
+        row.topology_truth_beats_derangement for row in records
+        if row.topology_truth_beats_derangement is not None
+    ]
+    return {
+        "scenario": records[0].scenario,
+        "replicates": len(records),
+        "both_corpus_selector_rejections": int(sum(row.familywise_rejected for row in records)),
+        "both_corpus_selector_rejection_rate": float(np.mean([row.familywise_rejected for row in records])),
+        "per_corpus_selector_rejection_rate": {
+            corpus: float(np.mean([
+                row.corpus_selector_rejected[index] for row in records
+            ]))
+            for index, corpus in enumerate(SYNTHETIC_CORPORA)
+        },
+        "joint_synthetic_primary_events": int(sum(row.promoted for row in records)),
+        "joint_synthetic_primary_event_rate": float(np.mean([row.promoted for row in records])),
+        "endpoint_mean_gain_per_scalar": {
+            corpus: {
+                endpoint: summary(
+                    row.endpoint_mean_gains[corpus_index, endpoint_index]
+                    for row in records
+                )
+                for endpoint_index, endpoint in enumerate(PRIMARY_ENDPOINTS)
+            }
+            for corpus_index, corpus in enumerate(SYNTHETIC_CORPORA)
+        },
+        "endpoint_simultaneous_lower_bound": {
+            corpus: {
+                endpoint: summary(
+                    row.endpoint_lower_bounds[corpus_index, endpoint_index]
+                    for row in records
+                )
+                for endpoint_index, endpoint in enumerate(PRIMARY_ENDPOINTS)
+            }
+            for corpus_index, corpus in enumerate(SYNTHETIC_CORPORA)
+        },
+        "multiplier_max_t_critical_value": summary(
+            row.multiplier_critical_value for row in records
+        ),
+        "inference_prompt_blocks": {
+            corpus: {
+                "minimum": int(min(
+                    row.inference_prompt_blocks[index] for row in records
+                )),
+                "maximum": int(max(
+                    row.inference_prompt_blocks[index] for row in records
+                )),
+            }
+            for index, corpus in enumerate(SYNTHETIC_CORPORA)
+        },
+        "topology_truth_beats_derangement_rate": (
+            float(np.mean(topology)) if topology else None
+        ),
+        "selected_gamma_counts_across_outer_folds": {
+            str(value): int(sum(candidate.gamma == value for candidate in selected))
+            for value in sorted({candidate.gamma for candidate in selected})
+        },
+        "selected_rho_counts_across_outer_folds": {
+            str(value): int(sum(candidate.rho == value for candidate in selected))
+            for value in sorted({candidate.rho for candidate in selected})
+        },
+        "maximum_call_loading": float(max(row.call_loading for row in records)),
+        "maximum_persistent_loading": float(max(row.persistent_loading for row in records)),
+        "maximum_request_loading": float(max(row.request_loading for row in records)),
+    }

--- a/prototypes/mu_cosine/run_repeated_judge_power.py
+++ b/prototypes/mu_cosine/run_repeated_judge_power.py
@@ -697,19 +697,24 @@ def _file_digest(path):
     return {"bytes": size, "sha256": digest.hexdigest()}
 
 
+def _portable_blas_runtime(records):
+    """Keep numerical BLAS identity while excluding host-specific paths."""
+    fields = (
+        "user_api", "internal_api", "prefix", "version",
+        "threading_layer", "architecture",
+    )
+    return sorted(
+        ({field: record.get(field) for field in fields} for record in records),
+        key=lambda record: tuple(str(record[field]) for field in fields),
+    )
+
+
 def _blas_runtime_identity():
     try:
         from threadpoolctl import threadpool_info
     except ImportError:
         return []
-    fields = (
-        "user_api", "internal_api", "prefix", "filepath", "version",
-        "threading_layer", "architecture",
-    )
-    return sorted(
-        ({field: record.get(field) for field in fields} for record in threadpool_info()),
-        key=lambda record: tuple(str(record[field]) for field in fields),
-    )
+    return _portable_blas_runtime(threadpool_info())
 
 
 def _provenance():
@@ -723,7 +728,10 @@ def _provenance():
         "python_version": sys.version,
         "numpy_version": np.__version__,
         "blas_runtime": _blas_runtime_identity(),
-        "worker_blas_threads": 1,
+        "blas_thread_limit_policy": (
+            "child workers request one thread via environment; serial execution "
+            "uses threadpoolctl when available"
+        ),
         "seed_derivation": "sha256(base,G,R,scenario,replicate); null namespace is disjoint",
     }
 

--- a/prototypes/mu_cosine/run_repeated_judge_power.py
+++ b/prototypes/mu_cosine/run_repeated_judge_power.py
@@ -10,9 +10,12 @@ not part of the unit-test suite.
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from contextlib import contextmanager
 import hashlib
 import json
 import math
+import multiprocessing
 import os
 import sys
 import tempfile
@@ -24,17 +27,23 @@ import numpy as np
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
 from repeated_judge_power import (  # noqa: E402
+    Candidate,
     DEFAULT_GAMMAS,
     DEFAULT_MEAN_RIDGES,
     DEFAULT_RHOS,
     MAX_PROMPT_ROWS,
     PRIMARY_ENDPOINTS,
+    PowerReplicate,
     SCENARIOS,
     SCENARIO_BY_NAME,
     SYNTHETIC_CORPORA,
+    _replicate_geometry_and_splits,
     aggregate_power_records,
     calibrate_synthetic_selector_null,
     derive_seed,
+    draw_repeated_field,
+    finite_null_maximum_threshold,
+    inner_candidate_search,
     run_power_replicate,
     summary,
 )
@@ -66,6 +75,17 @@ FULL_INNER_FOLDS = 3
 FULL_SHRINKAGE = 0.05
 FULL_MISSING_RATE = 0.02
 FULL_SEED = 1207000
+
+CHECKPOINT_SCHEMA_VERSION = 1
+_BLAS_ENVIRONMENT_VARIABLES = (
+    "OPENBLAS_NUM_THREADS",
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "BLIS_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
+_WORKER_THREADPOOL_LIMIT = None
 
 SCIENCE_ARGUMENTS = (
     "config",
@@ -127,6 +147,17 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--missing-rate", type=float, default=None)
     parser.add_argument("--prompt-batch-rows", type=int, default=None)
     parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="operational worker-process count; does not change the scientific design",
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
+        default=None,
+        help="operational atomic checkpoint directory; an exact matching run resumes",
+    )
     parser.add_argument("--out", default="/tmp/repeated_judge_power_smoke.json")
     return parser
 
@@ -259,22 +290,25 @@ def _configuration_decision(
             "reason": "the complete frozen scenario grid is required",
         }
 
-    null = by_name["block_null"]
-    null_trials = int(null["replicates"])
-    null_promotions = int(null.get(
-        "joint_synthetic_primary_events",
-        round(float(null["joint_synthetic_primary_event_rate"]) * null_trials),
-    ))
-    null_pvalue = _one_sided_exact_binomial_pvalue(null_promotions, null_trials)
-    null_gate = bool(
-        float(null["joint_synthetic_primary_event_rate"]) <= 0.10
-        and null_pvalue >= 0.05
-    )
-
     control_gates = {}
     for name in ("block_null", "mean_only"):
-        gains = _mean_endpoint_gains(by_name[name], "residual_nll")
+        row = by_name[name]
+        trials = int(row["replicates"])
+        event_rate = float(row["joint_synthetic_primary_event_rate"])
+        promotions = int(row.get(
+            "joint_synthetic_primary_events", round(event_rate * trials)
+        ))
+        pvalue = _one_sided_exact_binomial_pvalue(promotions, trials)
+        false_promotion_gate = bool(event_rate <= 0.10 and pvalue >= 0.05)
+        gains = _mean_endpoint_gains(row, "residual_nll")
         control_gates[name] = {
+            "promotions": promotions,
+            "replicates": trials,
+            "joint_synthetic_primary_event_rate": event_rate,
+            "one_sided_exact_binomial_excess_pvalue_at_p_0_05": pvalue,
+            "does_not_reject_p_at_most_0_05_and_observed_at_most_0_10": (
+                false_promotion_gate
+            ),
             "mean_selected_residual_nll_gain_by_synthetic_corpus": gains,
             "mean_harm_nonpositive_in_both_synthetic_corpora": bool(
                 all(gain >= 0.0 for gain in gains.values())
@@ -319,9 +353,9 @@ def _configuration_decision(
             }
 
     passed = bool(
-        null_gate
-        and all(
-            row["mean_harm_nonpositive_in_both_synthetic_corpora"]
+        all(
+            row["does_not_reject_p_at_most_0_05_and_observed_at_most_0_10"]
+            and row["mean_harm_nonpositive_in_both_synthetic_corpora"]
             for row in control_gates.values()
         )
         and all(
@@ -335,13 +369,14 @@ def _configuration_decision(
         "evaluable": True,
         "repeat_design": int(repeats),
         "block_null": {
-            "promotions": null_promotions,
-            "replicates": null_trials,
-            "joint_synthetic_primary_event_rate": float(
-                null["joint_synthetic_primary_event_rate"]
-            ),
-            "one_sided_exact_binomial_excess_pvalue_at_p_0_05": null_pvalue,
-            "does_not_reject_p_at_most_0_05_and_observed_at_most_0_10": null_gate,
+            key: control_gates["block_null"][key]
+            for key in (
+                "promotions",
+                "replicates",
+                "joint_synthetic_primary_event_rate",
+                "one_sided_exact_binomial_excess_pvalue_at_p_0_05",
+                "does_not_reject_p_at_most_0_05_and_observed_at_most_0_10",
+            )
         },
         "controls": control_gates,
         "required_truths": truth_gates,
@@ -349,48 +384,284 @@ def _configuration_decision(
     }
 
 
-def run_configuration(configuration: Tuple[int, int], resolved: dict) -> dict:
-    components, repeats = map(int, configuration)
-    null_seed = derive_seed(
-        resolved["seed"], components, repeats, "block_null_calibration"
+def _compute_null_draw(components, repeats, draw, null_seed, resolved):
+    """Compute one indexed draw exactly as the monolithic calibrator does."""
+    replicate_seed = derive_seed(null_seed, "null", int(draw))
+    joint_search_maxima = []
+    for corpus in SYNTHETIC_CORPORA:
+        corpus_seed = derive_seed(replicate_seed, corpus)
+        geometry, splits = _replicate_geometry_and_splits(
+            components, corpus_seed, resolved["prompt_batch_rows"]
+        )
+        field = draw_repeated_field(
+            geometry,
+            SCENARIO_BY_NAME["block_null"],
+            repeats,
+            derive_seed(corpus_seed, "field"),
+            missing_rate=resolved["missing_rate"],
+        )
+        searches = [
+            inner_candidate_search(
+                field,
+                geometry,
+                fold,
+                gammas=resolved["gammas"],
+                rhos=resolved["rhos"],
+                mean_ridges=resolved["mean_ridges"],
+                shrinkage=resolved["shrinkage"],
+            )
+            for fold in splits.outer
+        ]
+        joint_search_maxima.extend(
+            search.maximum_eligible_gain for search in searches
+        )
+    return float(max(joint_search_maxima))
+
+
+def _null_worker(task):
+    components, repeats, draw, null_seed, resolved = task
+    return int(draw), _compute_null_draw(
+        components, repeats, draw, null_seed, resolved
     )
-    null_maxima, threshold, rank = calibrate_synthetic_selector_null(
+
+
+def _power_worker(task):
+    components, repeats, scenario_index, replicate, threshold, resolved = task
+    scenario_name = resolved["scenarios"][scenario_index]
+    replicate_seed = derive_seed(
+        resolved["seed"], components, repeats, scenario_name, replicate
+    )
+    record = run_power_replicate(
         components,
+        SCENARIO_BY_NAME[scenario_name],
         repeats=repeats,
-        draws=resolved["null_draws"],
-        seed=null_seed,
+        seed=replicate_seed,
+        null_threshold=threshold,
         gammas=resolved["gammas"],
         rhos=resolved["rhos"],
         mean_ridges=resolved["mean_ridges"],
         shrinkage=resolved["shrinkage"],
         confidence=resolved["confidence"],
+        multiplier_draws=resolved["multiplier_draws"],
         missing_rate=resolved["missing_rate"],
         max_prompt_rows=resolved["prompt_batch_rows"],
     )
-    scenario_results = []
-    for scenario_name in resolved["scenarios"]:
-        scenario = SCENARIO_BY_NAME[scenario_name]
-        records = []
-        for replicate in range(resolved["power_replicates"]):
-            replicate_seed = derive_seed(
-                resolved["seed"], components, repeats, scenario_name, replicate
-            )
-            records.append(run_power_replicate(
+    return int(replicate), record
+
+
+def _initialize_worker_blas(expected_provenance=None):
+    global _WORKER_THREADPOOL_LIMIT
+    for name in _BLAS_ENVIRONMENT_VARIABLES:
+        os.environ[name] = "1"
+    if expected_provenance is not None:
+        _assert_provenance_unchanged(expected_provenance)
+    try:
+        from threadpoolctl import threadpool_limits
+    except ImportError:
+        return
+    _WORKER_THREADPOOL_LIMIT = threadpool_limits(limits=1, user_api="blas")
+    _WORKER_THREADPOOL_LIMIT.__enter__()
+
+
+@contextmanager
+def _single_thread_current_blas():
+    try:
+        from threadpoolctl import threadpool_limits
+    except ImportError:
+        yield
+        return
+    with threadpool_limits(limits=1, user_api="blas"):
+        yield
+
+
+@contextmanager
+def _single_thread_child_environment():
+    previous = {name: os.environ.get(name) for name in _BLAS_ENVIRONMENT_VARIABLES}
+    try:
+        for name in _BLAS_ENVIRONMENT_VARIABLES:
+            os.environ[name] = "1"
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+@contextmanager
+def _process_pool(workers, provenance_snapshot=None):
+    if workers == 1:
+        yield None
+        return
+    with _single_thread_child_environment():
+        with ProcessPoolExecutor(
+            max_workers=workers,
+            mp_context=multiprocessing.get_context("spawn"),
+            initializer=_initialize_worker_blas,
+            initargs=(provenance_snapshot,),
+        ) as executor:
+            yield executor
+
+
+def _execute_tasks(tasks, worker, executor):
+    if executor is None:
+        with _single_thread_current_blas():
+            for task in tasks:
+                yield worker(task)
+        return
+    futures = [executor.submit(worker, task) for task in tasks]
+    for future in as_completed(futures):
+        yield future.result()
+
+
+def run_configuration(
+    configuration: Tuple[int, int],
+    resolved: dict,
+    *,
+    configuration_index=0,
+    workers=1,
+    checkpoint_store=None,
+    provenance_snapshot=None,
+) -> dict:
+    components, repeats = map(int, configuration)
+    null_seed = derive_seed(
+        resolved["seed"], components, repeats, "block_null_calibration"
+    )
+
+    barrier = (
+        checkpoint_store.load_null_barrier(
+            configuration_index,
+            components,
+            repeats,
+            null_seed,
+            resolved["confidence"],
+            resolved["null_draws"],
+        )
+        if checkpoint_store is not None
+        else None
+    )
+    if barrier is None:
+        maxima_by_draw = {}
+        if checkpoint_store is not None:
+            for draw in range(resolved["null_draws"]):
+                value = checkpoint_store.load_null_draw(
+                    configuration_index, components, repeats, draw, null_seed
+                )
+                if value is not None:
+                    maxima_by_draw[draw] = value
+        missing_draws = [
+            draw for draw in range(resolved["null_draws"])
+            if draw not in maxima_by_draw
+        ]
+        null_tasks = [
+            (components, repeats, draw, null_seed, resolved)
+            for draw in missing_draws
+        ]
+        if provenance_snapshot is not None:
+            _assert_provenance_unchanged(provenance_snapshot)
+        with _process_pool(workers, provenance_snapshot) as executor:
+            for draw, value in _execute_tasks(null_tasks, _null_worker, executor):
+                maxima_by_draw[draw] = value
+                if checkpoint_store is not None:
+                    checkpoint_store.save_null_draw(
+                        configuration_index,
+                        components,
+                        repeats,
+                        draw,
+                        null_seed,
+                        value,
+                    )
+        null_maxima = np.asarray([
+            maxima_by_draw[draw] for draw in range(resolved["null_draws"])
+        ])
+        threshold, rank = finite_null_maximum_threshold(
+            null_maxima, resolved["confidence"]
+        )
+        if checkpoint_store is not None:
+            checkpoint_store.save_null_barrier(
+                configuration_index,
                 components,
-                scenario,
-                repeats=repeats,
-                seed=replicate_seed,
-                null_threshold=threshold,
-                gammas=resolved["gammas"],
-                rhos=resolved["rhos"],
-                mean_ridges=resolved["mean_ridges"],
-                shrinkage=resolved["shrinkage"],
-                confidence=resolved["confidence"],
-                multiplier_draws=resolved["multiplier_draws"],
-                missing_rate=resolved["missing_rate"],
-                max_prompt_rows=resolved["prompt_batch_rows"],
-            ))
-        scenario_results.append(aggregate_power_records(records))
+                repeats,
+                null_seed,
+                null_maxima,
+                threshold,
+                rank,
+                resolved["confidence"],
+            )
+    else:
+        null_maxima, threshold, rank = barrier
+
+    scenario_results = []
+    if provenance_snapshot is not None:
+        _assert_provenance_unchanged(provenance_snapshot)
+    with _process_pool(workers, provenance_snapshot) as executor:
+        for scenario_index, scenario_name in enumerate(resolved["scenarios"]):
+            records_by_replicate = {}
+            if checkpoint_store is not None:
+                for replicate in range(resolved["power_replicates"]):
+                    replicate_seed = derive_seed(
+                        resolved["seed"],
+                        components,
+                        repeats,
+                        scenario_name,
+                        replicate,
+                    )
+                    record = checkpoint_store.load_power_record(
+                        configuration_index,
+                        components,
+                        repeats,
+                        scenario_index,
+                        scenario_name,
+                        replicate,
+                        threshold,
+                        replicate_seed,
+                    )
+                    if record is not None:
+                        records_by_replicate[replicate] = record
+            missing_replicates = [
+                replicate for replicate in range(resolved["power_replicates"])
+                if replicate not in records_by_replicate
+            ]
+            tasks = [
+                (
+                    components,
+                    repeats,
+                    scenario_index,
+                    replicate,
+                    threshold,
+                    resolved,
+                )
+                for replicate in missing_replicates
+            ]
+            for replicate, record in _execute_tasks(tasks, _power_worker, executor):
+                records_by_replicate[replicate] = record
+                if checkpoint_store is not None:
+                    replicate_seed = derive_seed(
+                        resolved["seed"],
+                        components,
+                        repeats,
+                        scenario_name,
+                        replicate,
+                    )
+                    checkpoint_store.save_power_record(
+                        configuration_index,
+                        components,
+                        repeats,
+                        scenario_index,
+                        scenario_name,
+                        replicate,
+                        threshold,
+                        replicate_seed,
+                        record,
+                    )
+            records = [
+                records_by_replicate[replicate]
+                for replicate in range(resolved["power_replicates"])
+            ]
+            scenario_results.append(aggregate_power_records(records))
+    if provenance_snapshot is not None:
+        _assert_provenance_unchanged(provenance_snapshot)
     return {
         "components_per_required_corpus": components,
         "repeats": repeats,
@@ -426,6 +697,21 @@ def _file_digest(path):
     return {"bytes": size, "sha256": digest.hexdigest()}
 
 
+def _blas_runtime_identity():
+    try:
+        from threadpoolctl import threadpool_info
+    except ImportError:
+        return []
+    fields = (
+        "user_api", "internal_api", "prefix", "filepath", "version",
+        "threading_layer", "architecture",
+    )
+    return sorted(
+        ({field: record.get(field) for field in fields} for record in threadpool_info()),
+        key=lambda record: tuple(str(record[field]) for field in fields),
+    )
+
+
 def _provenance():
     files = {
         "preregistration": os.path.join(HERE, "PREREG_graph_geometry_repeated_judge.md"),
@@ -434,38 +720,361 @@ def _provenance():
     }
     return {
         "files": {name: _file_digest(path) for name, path in files.items()},
+        "python_version": sys.version,
         "numpy_version": np.__version__,
+        "blas_runtime": _blas_runtime_identity(),
+        "worker_blas_threads": 1,
         "seed_derivation": "sha256(base,G,R,scenario,replicate); null namespace is disjoint",
     }
 
 
-def build_scientific_payload(resolved: dict) -> dict:
-    configurations = [
-        run_configuration(configuration, resolved)
-        for configuration in resolved["configurations"]
-    ]
-    primary_r3 = [row for row in configurations if row["repeats"] == 3]
-    repeat4 = [row for row in configurations if row["repeats"] == 4]
-    passing_r3 = sorted(
-        (
-            row["components_per_required_corpus"]
-            for row in primary_r3
-            if row["decision"]["evaluable"] and row["decision"]["pass"]
-        )
-    )
-    synthetic_smallest_passing_G = passing_r3[0] if passing_r3 else None
-    sizing_evaluable = bool(primary_r3) and all(
-        row["decision"]["evaluable"] for row in primary_r3
-    )
-
-    configuration_record = {
-        key: value for key, value in resolved.items() if key != "configurations"
-    }
-    configuration_record["configurations"] = [
+def _configuration_record(resolved):
+    record = {key: value for key, value in resolved.items() if key != "configurations"}
+    record["configurations"] = [
         {"components_per_required_corpus": int(value[0]), "repeats": int(value[1])}
         for value in resolved["configurations"]
     ]
+    return json.loads(json.dumps(record, allow_nan=False))
+
+
+def _canonical_digest(value):
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _run_fingerprint(resolved, provenance):
+    return _canonical_digest({
+        "checkpoint_schema_version": CHECKPOINT_SCHEMA_VERSION,
+        "configuration": _configuration_record(resolved),
+        "provenance": provenance,
+    })
+
+
+def _assert_provenance_unchanged(expected):
+    observed = _provenance()
+    if observed != expected:
+        raise RuntimeError(
+            "preregistration or implementation changed during the run; refusing output"
+        )
+
+
+def _checkpoint_envelope(payload):
+    return {"payload": payload, "payload_sha256": _canonical_digest(payload)}
+
+
+def _read_checkpoint(path):
+    try:
+        with open(path, "r", encoding="utf-8") as stream:
+            envelope = json.load(stream)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"invalid checkpoint file: {path}") from error
+    if not isinstance(envelope, dict) or set(envelope) != {
+        "payload", "payload_sha256"
+    }:
+        raise ValueError(f"invalid checkpoint envelope: {path}")
+    if _canonical_digest(envelope["payload"]) != envelope["payload_sha256"]:
+        raise ValueError(f"checkpoint integrity hash mismatch: {path}")
+    return envelope["payload"]
+
+
+def _candidate_to_json(candidate):
+    return {"gamma": float(candidate.gamma), "rho": float(candidate.rho)}
+
+
+def _power_record_to_json(record):
+    # Persist only fields consumed by aggregate_power_records.  The full
+    # component arrays would make the preregistered checkpoint set enormous.
     return {
+        "record_schema": "aggregate_inputs_v1",
+        "scenario": record.scenario,
+        "selected": [
+            [_candidate_to_json(candidate) for candidate in corpus]
+            for corpus in record.selected
+        ],
+        "corpus_selector_rejected": list(record.corpus_selector_rejected),
+        "familywise_rejected": bool(record.familywise_rejected),
+        "maximum_inner_gain": float(record.maximum_inner_gain),
+        "endpoint_mean_gains": record.endpoint_mean_gains.tolist(),
+        "endpoint_lower_bounds": record.endpoint_lower_bounds.tolist(),
+        "multiplier_critical_value": float(record.multiplier_critical_value),
+        "inference_prompt_blocks": list(record.inference_prompt_blocks),
+        "topology_truth_beats_derangement": record.topology_truth_beats_derangement,
+        "promoted": bool(record.promoted),
+        "call_loading": float(record.call_loading),
+        "persistent_loading": float(record.persistent_loading),
+        "request_loading": float(record.request_loading),
+    }
+
+
+def _power_record_from_json(value):
+    if value.get("record_schema") != "aggregate_inputs_v1":
+        raise ValueError("unsupported power checkpoint record schema")
+    return PowerReplicate(
+        str(value["scenario"]),
+        tuple(tuple(
+            Candidate(float(candidate["gamma"]), float(candidate["rho"]))
+            for candidate in corpus
+        ) for corpus in value["selected"]),
+        tuple(map(bool, value["corpus_selector_rejected"])),
+        bool(value["familywise_rejected"]),
+        float(value["maximum_inner_gain"]),
+        np.empty((0, 0, 0), dtype=float),
+        np.asarray(value["endpoint_mean_gains"], dtype=float),
+        np.asarray(value["endpoint_lower_bounds"], dtype=float),
+        float(value["multiplier_critical_value"]),
+        tuple(map(int, value["inference_prompt_blocks"])),
+        None,
+        value["topology_truth_beats_derangement"],
+        bool(value["promoted"]),
+        float(value["call_loading"]),
+        float(value["persistent_loading"]),
+        float(value["request_loading"]),
+    )
+
+
+class CheckpointStore:
+    def __init__(self, root, resolved, provenance, fingerprint):
+        self.root = os.path.abspath(root)
+        self.fingerprint = fingerprint
+        manifest = {
+            "schema_version": CHECKPOINT_SCHEMA_VERSION,
+            "fingerprint": fingerprint,
+            "configuration": _configuration_record(resolved),
+            "provenance": provenance,
+        }
+        manifest_path = os.path.join(self.root, "manifest.json")
+        if os.path.exists(manifest_path):
+            if _read_checkpoint(manifest_path) != manifest:
+                raise ValueError(
+                    "checkpoint fingerprint/configuration mismatch; use a new directory"
+                )
+        else:
+            if os.path.isdir(self.root) and os.listdir(self.root):
+                raise ValueError("nonempty checkpoint directory has no valid manifest")
+            write_payload(manifest_path, _checkpoint_envelope(manifest))
+
+    def _configuration_dir(self, index, components, repeats):
+        return os.path.join(
+            self.root, f"configuration_{index:03d}_G{components}_R{repeats}"
+        )
+
+    def _metadata(self, kind, index, components, repeats):
+        return {
+            "schema_version": CHECKPOINT_SCHEMA_VERSION,
+            "fingerprint": self.fingerprint,
+            "kind": kind,
+            "configuration_index": int(index),
+            "components": int(components),
+            "repeats": int(repeats),
+        }
+
+    def _load_optional(self, path, expected):
+        if not os.path.exists(path):
+            return None
+        payload = _read_checkpoint(path)
+        for key, value in expected.items():
+            if payload.get(key) != value:
+                raise ValueError(f"checkpoint hash/config mismatch: {path}")
+        return payload
+
+    def load_null_draw(self, index, components, repeats, draw, null_seed):
+        path = os.path.join(
+            self._configuration_dir(index, components, repeats),
+            "null",
+            f"draw_{draw:06d}.json",
+        )
+        expected = self._metadata("null_draw", index, components, repeats)
+        expected.update({"draw": int(draw), "null_seed": int(null_seed)})
+        payload = self._load_optional(path, expected)
+        return None if payload is None else float(payload["maximum"])
+
+    def save_null_draw(
+        self, index, components, repeats, draw, null_seed, maximum
+    ):
+        path = os.path.join(
+            self._configuration_dir(index, components, repeats),
+            "null",
+            f"draw_{draw:06d}.json",
+        )
+        payload = self._metadata("null_draw", index, components, repeats)
+        payload.update({
+            "draw": int(draw),
+            "null_seed": int(null_seed),
+            "maximum": float(maximum),
+        })
+        write_payload(path, _checkpoint_envelope(payload))
+
+    def load_null_barrier(
+        self, index, components, repeats, null_seed, confidence, draws
+    ):
+        path = os.path.join(
+            self._configuration_dir(index, components, repeats),
+            "null_barrier.json",
+        )
+        expected = self._metadata("null_barrier", index, components, repeats)
+        expected.update({
+            "null_seed": int(null_seed),
+            "confidence": float(confidence),
+            "draws": int(draws),
+        })
+        payload = self._load_optional(path, expected)
+        if payload is None:
+            return None
+        maxima = np.asarray(payload["maxima"], dtype=float)
+        if maxima.shape != (int(draws),):
+            raise ValueError(f"checkpoint null barrier has wrong draw count: {path}")
+        threshold, rank = finite_null_maximum_threshold(
+            maxima, float(confidence)
+        )
+        if threshold != float(payload["threshold"]) or rank != int(payload["rank"]):
+            raise ValueError(f"checkpoint null barrier is inconsistent: {path}")
+        return maxima, threshold, rank
+
+    def save_null_barrier(
+        self, index, components, repeats, null_seed, maxima, threshold, rank,
+        confidence
+    ):
+        path = os.path.join(
+            self._configuration_dir(index, components, repeats),
+            "null_barrier.json",
+        )
+        payload = self._metadata("null_barrier", index, components, repeats)
+        payload.update({
+            "null_seed": int(null_seed),
+            "confidence": float(confidence),
+            "draws": int(len(maxima)),
+            "maxima": np.asarray(maxima, dtype=float).tolist(),
+            "threshold": float(threshold),
+            "rank": int(rank),
+        })
+        write_payload(path, _checkpoint_envelope(payload))
+
+    def _power_path(self, index, components, repeats, scenario_index, replicate):
+        return os.path.join(
+            self._configuration_dir(index, components, repeats),
+            "power",
+            f"scenario_{scenario_index:03d}",
+            f"replicate_{replicate:06d}.json",
+        )
+
+    def load_power_record(
+        self, index, components, repeats, scenario_index, scenario_name,
+        replicate, threshold, replicate_seed
+    ):
+        path = self._power_path(
+            index, components, repeats, scenario_index, replicate
+        )
+        expected = self._metadata("power_replicate", index, components, repeats)
+        expected.update({
+            "scenario_index": int(scenario_index),
+            "scenario": scenario_name,
+            "replicate": int(replicate),
+            "threshold": float(threshold),
+            "replicate_seed": int(replicate_seed),
+        })
+        payload = self._load_optional(path, expected)
+        return None if payload is None else _power_record_from_json(payload["record"])
+
+    def save_power_record(
+        self, index, components, repeats, scenario_index, scenario_name,
+        replicate, threshold, replicate_seed, record
+    ):
+        path = self._power_path(
+            index, components, repeats, scenario_index, replicate
+        )
+        payload = self._metadata("power_replicate", index, components, repeats)
+        payload.update({
+            "scenario_index": int(scenario_index),
+            "scenario": scenario_name,
+            "replicate": int(replicate),
+            "threshold": float(threshold),
+            "replicate_seed": int(replicate_seed),
+            "record": _power_record_to_json(record),
+        })
+        write_payload(path, _checkpoint_envelope(payload))
+
+
+def _is_exact_full_preregistration(resolved):
+    return bool(
+        resolved.get("full_preregistration") is True
+        and tuple(resolved["configurations"]) == FULL_CONFIGURATIONS
+        and tuple(resolved["scenarios"]) == FULL_SCENARIOS
+        and tuple(resolved["gammas"]) == DEFAULT_GAMMAS
+        and tuple(resolved["rhos"]) == DEFAULT_RHOS
+        and tuple(resolved["mean_ridges"]) == DEFAULT_MEAN_RIDGES
+        and resolved["null_draws"] == FULL_NULL_DRAWS
+        and resolved["power_replicates"] == FULL_POWER_REPLICATES
+        and resolved["multiplier_draws"] == FULL_MULTIPLIER_DRAWS
+        and resolved["confidence"] == FULL_CONFIDENCE
+        and resolved["outer_folds"] == FULL_OUTER_FOLDS
+        and resolved["inner_folds"] == FULL_INNER_FOLDS
+        and resolved["shrinkage"] == FULL_SHRINKAGE
+        and resolved["missing_rate"] == FULL_MISSING_RATE
+        and resolved["prompt_batch_rows"] == MAX_PROMPT_ROWS
+        and resolved["seed"] == FULL_SEED
+    )
+
+
+def build_scientific_payload(
+    resolved: dict,
+    *,
+    workers=1,
+    checkpoint_dir=None,
+    provenance_snapshot=None,
+    run_fingerprint=None,
+) -> dict:
+    if int(workers) < 1:
+        raise ValueError("workers must be positive")
+    provenance_snapshot = _provenance() if provenance_snapshot is None else provenance_snapshot
+    expected_fingerprint = _run_fingerprint(resolved, provenance_snapshot)
+    if run_fingerprint is not None and run_fingerprint != expected_fingerprint:
+        raise ValueError("run fingerprint does not match configuration/provenance")
+    run_fingerprint = expected_fingerprint
+    checkpoint_store = (
+        None if checkpoint_dir is None
+        else CheckpointStore(
+            checkpoint_dir, resolved, provenance_snapshot, run_fingerprint
+        )
+    )
+    configurations = []
+    for index, configuration in enumerate(resolved["configurations"]):
+        _assert_provenance_unchanged(provenance_snapshot)
+        if workers == 1 and checkpoint_store is None:
+            row = run_configuration(configuration, resolved)
+        else:
+            row = run_configuration(
+                configuration,
+                resolved,
+                configuration_index=index,
+                workers=int(workers),
+                checkpoint_store=checkpoint_store,
+                provenance_snapshot=provenance_snapshot,
+            )
+        configurations.append(row)
+    primary_r3 = [row for row in configurations if row["repeats"] == 3]
+    repeat4 = [row for row in configurations if row["repeats"] == 4]
+    exact_full_preregistration = _is_exact_full_preregistration(resolved)
+    passing_r3 = sorted((
+        row["components_per_required_corpus"]
+        for row in primary_r3
+        if row["decision"]["evaluable"] and row["decision"]["pass"]
+    )) if exact_full_preregistration else []
+    synthetic_smallest_passing_G = passing_r3[0] if passing_r3 else None
+    sizing_evaluable = exact_full_preregistration and bool(primary_r3) and all(
+        row["decision"]["evaluable"] for row in primary_r3
+    )
+    gate_reason = (
+        "R=3 can identify only a smallest passing two-corpus synthetic-primary-event "
+        "grid point; R=4 is reported separately. No final campaign G or deployment "
+        "recommendation is emitted until the unsimulated real-data gates pass."
+        if exact_full_preregistration
+        else "Smoke or customized runs are diagnostic only. Synthetic sizing is evaluable "
+        "only for --full-prereg with the exact frozen grid, counts, and seed."
+    )
+
+    payload = {
         "schema_version": 2,
         "status": "SYNTHETIC SIZING ONLY; NO REAL COVARIANCE DEPLOYMENT",
         "scope": (
@@ -474,8 +1083,8 @@ def build_scientific_payload(resolved: dict) -> dict:
             "request effects, repeated four-channel measurements, five-fold outer "
             "cross-fitting, and distinct residual and latent-state posterior NLL endpoints"
         ),
-        "configuration": configuration_record,
-        "provenance": _provenance(),
+        "configuration": _configuration_record(resolved),
+        "provenance": provenance_snapshot,
         "primary_r3_results": primary_r3,
         "repeat4_sensitivity_results": repeat4,
         "gate": {
@@ -489,11 +1098,7 @@ def build_scientific_payload(resolved: dict) -> dict:
             "final_campaign_G_recommendation": None,
             "deployment_pass": False,
             "real_covariance_deployment": False,
-            "reason": (
-                "R=3 can identify only a smallest passing two-corpus synthetic-primary-event "
-                "grid point; R=4 is reported separately. No final campaign G or deployment "
-                "recommendation is emitted until the unsimulated real-data gates pass."
-            ),
+            "reason": gate_reason,
         },
         "real_campaign_selector_requirement": (
             "Each outer-training prompt-block set must recalibrate its own block-null "
@@ -507,10 +1112,15 @@ def build_scientific_payload(resolved: dict) -> dict:
             "ten-bin ECE and prompt-block-bootstrap AURC intervals",
             "real graph/Nomic source-correlation and same-split ablations",
             "real topology benefit over derangement and hard negatives",
+            "list-position engineering pilot",
+            "frozen train-only position×role×judge adjustment",
+            "position-effect power sensitivity",
             "s_safe spectral adapter, full call/prompt/wave incidence covariance, and delta_95",
             "statistical/numerical loading limits and cross-batch independence bound",
         ],
     }
+    _assert_provenance_unchanged(provenance_snapshot)
+    return payload
 
 
 def serialize_payload(payload: dict) -> str:
@@ -543,9 +1153,21 @@ def write_payload(path: str, payload: dict) -> None:
 def main(argv: Iterable[str] | None = None) -> dict:
     args = build_arg_parser().parse_args(argv)
     resolved = resolve_configuration(args)
+    if args.workers < 1:
+        raise ValueError("--workers must be positive")
+    provenance_snapshot = _provenance()
+    run_fingerprint = _run_fingerprint(resolved, provenance_snapshot)
     started = time.perf_counter()
-    payload = build_scientific_payload(resolved)
+    payload = build_scientific_payload(
+        resolved,
+        workers=args.workers,
+        checkpoint_dir=args.checkpoint_dir,
+        provenance_snapshot=provenance_snapshot,
+        run_fingerprint=run_fingerprint,
+    )
+    _assert_provenance_unchanged(provenance_snapshot)
     serialized = serialize_payload(payload).encode("utf-8")
+    _assert_provenance_unchanged(provenance_snapshot)
     write_payload(args.out, payload)
     print(json.dumps({
         "content_sha256": hashlib.sha256(serialized).hexdigest(),

--- a/prototypes/mu_cosine/run_repeated_judge_power.py
+++ b/prototypes/mu_cosine/run_repeated_judge_power.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+"""Run the frozen repeated-judge synthetic sizing mechanism.
+
+The ordinary CLI defaults are deliberately small smoke settings.  Passing
+``--full-prereg`` selects, without scientific overrides, the exact component,
+repeat, scenario, candidate-grid, resampling, and confidence settings frozen in
+``PREREG_graph_geometry_repeated_judge.md``.  Full runs are expensive and are
+not part of the unit-test suite.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import sys
+import tempfile
+import time
+from typing import Iterable, Sequence, Tuple
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+from repeated_judge_power import (  # noqa: E402
+    DEFAULT_GAMMAS,
+    DEFAULT_MEAN_RIDGES,
+    DEFAULT_RHOS,
+    MAX_PROMPT_ROWS,
+    PRIMARY_ENDPOINTS,
+    SCENARIOS,
+    SCENARIO_BY_NAME,
+    SYNTHETIC_CORPORA,
+    aggregate_power_records,
+    calibrate_synthetic_selector_null,
+    derive_seed,
+    run_power_replicate,
+    summary,
+)
+
+
+SMOKE_CONFIGURATIONS = ((32, 3),)
+FULL_CONFIGURATIONS = (
+    (160, 3),
+    (320, 3),
+    (512, 3),
+    (800, 3),
+    (320, 4),
+    (800, 4),
+)
+SMOKE_SCENARIOS = (
+    "block_null",
+    "mean_only",
+    "cumulative_rho_0.10",
+    "cumulative_rho_0.20",
+)
+FULL_SCENARIOS = tuple(scenario.name for scenario in SCENARIOS)
+
+FULL_NULL_DRAWS = 1999
+FULL_POWER_REPLICATES = 200
+FULL_MULTIPLIER_DRAWS = 999
+FULL_CONFIDENCE = 0.95
+FULL_OUTER_FOLDS = 5
+FULL_INNER_FOLDS = 3
+FULL_SHRINKAGE = 0.05
+FULL_MISSING_RATE = 0.02
+FULL_SEED = 1207000
+
+SCIENCE_ARGUMENTS = (
+    "config",
+    "null_draws",
+    "power_replicates",
+    "multiplier_draws",
+    "confidence",
+    "outer_folds",
+    "inner_folds",
+    "mean_ridges",
+    "shrinkage",
+    "gammas",
+    "rhos",
+    "scenarios",
+    "missing_rate",
+    "prompt_batch_rows",
+    "seed",
+)
+
+
+def parse_configuration(value: str) -> Tuple[int, int]:
+    try:
+        component_text, repeat_text = value.split(":", 1)
+        components, repeats = int(component_text), int(repeat_text)
+    except (ValueError, AttributeError) as error:
+        raise argparse.ArgumentTypeError(
+            "configuration must have form COMPONENTS:REPEATS"
+        ) from error
+    if components < 12 or repeats < 3:
+        raise argparse.ArgumentTypeError(
+            "configuration needs at least 12 components and 3 repeats"
+        )
+    return components, repeats
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--full-prereg", action="store_true")
+    parser.add_argument(
+        "--config",
+        action="append",
+        type=parse_configuration,
+        default=None,
+        help="COMPONENTS:REPEATS; may be supplied more than once",
+    )
+    parser.add_argument("--null-draws", type=int, default=None)
+    parser.add_argument("--power-replicates", type=int, default=None)
+    parser.add_argument("--multiplier-draws", type=int, default=None)
+    parser.add_argument("--confidence", type=float, default=None)
+    parser.add_argument("--outer-folds", type=int, default=None)
+    parser.add_argument("--inner-folds", type=int, default=None)
+    parser.add_argument("--mean-ridges", nargs="+", type=float, default=None)
+    parser.add_argument("--shrinkage", type=float, default=None)
+    parser.add_argument("--gammas", nargs="+", type=float, default=None)
+    parser.add_argument("--rhos", nargs="+", type=float, default=None)
+    parser.add_argument(
+        "--scenarios", nargs="+", choices=FULL_SCENARIOS, default=None
+    )
+    parser.add_argument("--missing-rate", type=float, default=None)
+    parser.add_argument("--prompt-batch-rows", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--out", default="/tmp/repeated_judge_power_smoke.json")
+    return parser
+
+
+def resolve_configuration(args: argparse.Namespace) -> dict:
+    if args.full_prereg:
+        overridden = [name for name in SCIENCE_ARGUMENTS if getattr(args, name) is not None]
+        if overridden:
+            rendered = ", ".join("--" + name.replace("_", "-") for name in overridden)
+            raise ValueError(f"--full-prereg rejects scientific overrides: {rendered}")
+        return {
+            "full_preregistration": True,
+            "configurations": FULL_CONFIGURATIONS,
+            "scenarios": FULL_SCENARIOS,
+            "gammas": DEFAULT_GAMMAS,
+            "rhos": DEFAULT_RHOS,
+            "mean_ridges": DEFAULT_MEAN_RIDGES,
+            "null_draws": FULL_NULL_DRAWS,
+            "power_replicates": FULL_POWER_REPLICATES,
+            "multiplier_draws": FULL_MULTIPLIER_DRAWS,
+            "confidence": FULL_CONFIDENCE,
+            "outer_folds": FULL_OUTER_FOLDS,
+            "inner_folds": FULL_INNER_FOLDS,
+            "shrinkage": FULL_SHRINKAGE,
+            "missing_rate": FULL_MISSING_RATE,
+            "prompt_batch_rows": MAX_PROMPT_ROWS,
+            "seed": FULL_SEED,
+        }
+
+    configurations = tuple(args.config or SMOKE_CONFIGURATIONS)
+    values = {
+        "null_draws": 19 if args.null_draws is None else args.null_draws,
+        "power_replicates": 12 if args.power_replicates is None else args.power_replicates,
+        "multiplier_draws": 199 if args.multiplier_draws is None else args.multiplier_draws,
+    }
+    if any(int(value) < 1 for value in values.values()):
+        raise ValueError("draw and replicate counts must be positive")
+    confidence = FULL_CONFIDENCE if args.confidence is None else float(args.confidence)
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must lie in (0,1)")
+    outer_folds = FULL_OUTER_FOLDS if args.outer_folds is None else int(args.outer_folds)
+    inner_folds = FULL_INNER_FOLDS if args.inner_folds is None else int(args.inner_folds)
+    if outer_folds != FULL_OUTER_FOLDS or inner_folds != FULL_INNER_FOLDS:
+        raise ValueError("the implemented procedure requires exactly five outer and three inner folds")
+    shrinkage = FULL_SHRINKAGE if args.shrinkage is None else float(args.shrinkage)
+    missing_rate = FULL_MISSING_RATE if args.missing_rate is None else float(args.missing_rate)
+    if not 0.0 <= shrinkage < 1.0:
+        raise ValueError("shrinkage must lie in [0,1)")
+    if not 0.0 <= missing_rate < 0.25:
+        raise ValueError("missing rate must lie in [0,.25)")
+    prompt_batch_rows = (
+        MAX_PROMPT_ROWS if args.prompt_batch_rows is None else int(args.prompt_batch_rows)
+    )
+    if not 1 <= prompt_batch_rows <= MAX_PROMPT_ROWS:
+        raise ValueError("prompt batch rows must lie in [1,10]")
+    gammas = tuple(DEFAULT_GAMMAS if args.gammas is None else map(float, args.gammas))
+    rhos = tuple(DEFAULT_RHOS if args.rhos is None else map(float, args.rhos))
+    if not gammas or len(set(gammas)) != len(gammas) or any(
+        not 0.0 <= value <= 1.0 for value in gammas
+    ):
+        raise ValueError("gammas must be unique and lie in [0,1]")
+    if not rhos or len(set(rhos)) != len(rhos) or 0.0 not in rhos or any(
+        not 0.0 <= value < 1.0 for value in rhos
+    ):
+        raise ValueError("rhos must be unique, lie in [0,1), and include zero")
+    mean_ridges = tuple(
+        DEFAULT_MEAN_RIDGES if args.mean_ridges is None else map(float, args.mean_ridges)
+    )
+    if not mean_ridges or len(set(mean_ridges)) != len(mean_ridges) or any(
+        value < 0.0 for value in mean_ridges
+    ):
+        raise ValueError("mean ridges must be unique and nonnegative")
+    scenarios = tuple(args.scenarios or SMOKE_SCENARIOS)
+    return {
+        "full_preregistration": False,
+        "configurations": configurations,
+        "scenarios": scenarios,
+        "gammas": gammas,
+        "rhos": rhos,
+        "mean_ridges": mean_ridges,
+        "null_draws": int(values["null_draws"]),
+        "power_replicates": int(values["power_replicates"]),
+        "multiplier_draws": int(values["multiplier_draws"]),
+        "confidence": confidence,
+        "outer_folds": outer_folds,
+        "inner_folds": inner_folds,
+        "shrinkage": shrinkage,
+        "missing_rate": missing_rate,
+        "prompt_batch_rows": prompt_batch_rows,
+        "seed": FULL_SEED if args.seed is None else int(args.seed),
+    }
+
+
+def _one_sided_exact_binomial_pvalue(successes, trials, null_probability=0.05):
+    if trials < 1 or not 0 <= successes <= trials:
+        raise ValueError("invalid binomial counts")
+    if not 0.0 < null_probability < 1.0:
+        raise ValueError("null probability must lie in (0,1)")
+    if successes == 0:
+        return 1.0
+    tail = math.fsum(
+        math.comb(trials, count)
+        * null_probability**count
+        * (1.0 - null_probability) ** (trials - count)
+        for count in range(successes, trials + 1)
+    )
+    return float(min(1.0, max(0.0, tail)))
+
+
+def _mean_endpoint_gains(row, endpoint):
+    return {
+        corpus: float(
+            row["endpoint_mean_gain_per_scalar"][corpus][endpoint]["mean"]
+        )
+        for corpus in SYNTHETIC_CORPORA
+    }
+
+
+def _configuration_decision(
+    results: Sequence[dict], selected_scenarios: Sequence[str], *, repeats=3
+) -> dict:
+    by_name = {row["scenario"]: row for row in results}
+    complete = set(FULL_SCENARIOS).issubset(selected_scenarios) and set(
+        FULL_SCENARIOS
+    ).issubset(by_name)
+    if not complete:
+        return {
+            "evaluable": False,
+            "pass": False,
+            "reason": "the complete frozen scenario grid is required",
+        }
+
+    null = by_name["block_null"]
+    null_trials = int(null["replicates"])
+    null_promotions = int(null.get(
+        "joint_synthetic_primary_events",
+        round(float(null["joint_synthetic_primary_event_rate"]) * null_trials),
+    ))
+    null_pvalue = _one_sided_exact_binomial_pvalue(null_promotions, null_trials)
+    null_gate = bool(
+        float(null["joint_synthetic_primary_event_rate"]) <= 0.10
+        and null_pvalue >= 0.05
+    )
+
+    control_gates = {}
+    for name in ("block_null", "mean_only"):
+        gains = _mean_endpoint_gains(by_name[name], "residual_nll")
+        control_gates[name] = {
+            "mean_selected_residual_nll_gain_by_synthetic_corpus": gains,
+            "mean_harm_nonpositive_in_both_synthetic_corpora": bool(
+                all(gain >= 0.0 for gain in gains.values())
+            ),
+        }
+
+    truth_gates = {}
+    for family in ("cumulative", "nomic", "mixture"):
+        for rho in (0.10, 0.20):
+            name = f"{family}_rho_{rho:.2f}"
+            row = by_name[name]
+            endpoint_gains = {
+                corpus: {
+                    endpoint: float(
+                        row["endpoint_mean_gain_per_scalar"][corpus][endpoint]["mean"]
+                    )
+                    for endpoint in PRIMARY_ENDPOINTS
+                }
+                for corpus in SYNTHETIC_CORPORA
+            }
+            all_endpoint_gains = [
+                endpoint_gains[corpus][endpoint]
+                for corpus in SYNTHETIC_CORPORA
+                for endpoint in PRIMARY_ENDPOINTS
+            ]
+            topology_rate = row["topology_truth_beats_derangement_rate"]
+            truth_gates[name] = {
+                "joint_two_corpus_synthetic_primary_event_power": float(
+                    row["joint_synthetic_primary_event_rate"]
+                ),
+                "power_at_least_80pct": bool(
+                    float(row["joint_synthetic_primary_event_rate"]) >= 0.80
+                ),
+                "mean_endpoint_gains_by_synthetic_corpus": endpoint_gains,
+                "all_four_corpus_by_endpoint_mean_gains_positive": bool(
+                    all(value > 0.0 for value in all_endpoint_gains)
+                ),
+                "topology_truth_beats_derangement_rate": topology_rate,
+                "topology_rate_at_least_80pct": bool(
+                    topology_rate is not None and float(topology_rate) >= 0.80
+                ),
+            }
+
+    passed = bool(
+        null_gate
+        and all(
+            row["mean_harm_nonpositive_in_both_synthetic_corpora"]
+            for row in control_gates.values()
+        )
+        and all(
+            row["power_at_least_80pct"]
+            and row["all_four_corpus_by_endpoint_mean_gains_positive"]
+            and row["topology_rate_at_least_80pct"]
+            for row in truth_gates.values()
+        )
+    )
+    return {
+        "evaluable": True,
+        "repeat_design": int(repeats),
+        "block_null": {
+            "promotions": null_promotions,
+            "replicates": null_trials,
+            "joint_synthetic_primary_event_rate": float(
+                null["joint_synthetic_primary_event_rate"]
+            ),
+            "one_sided_exact_binomial_excess_pvalue_at_p_0_05": null_pvalue,
+            "does_not_reject_p_at_most_0_05_and_observed_at_most_0_10": null_gate,
+        },
+        "controls": control_gates,
+        "required_truths": truth_gates,
+        "pass": passed,
+    }
+
+
+def run_configuration(configuration: Tuple[int, int], resolved: dict) -> dict:
+    components, repeats = map(int, configuration)
+    null_seed = derive_seed(
+        resolved["seed"], components, repeats, "block_null_calibration"
+    )
+    null_maxima, threshold, rank = calibrate_synthetic_selector_null(
+        components,
+        repeats=repeats,
+        draws=resolved["null_draws"],
+        seed=null_seed,
+        gammas=resolved["gammas"],
+        rhos=resolved["rhos"],
+        mean_ridges=resolved["mean_ridges"],
+        shrinkage=resolved["shrinkage"],
+        confidence=resolved["confidence"],
+        missing_rate=resolved["missing_rate"],
+        max_prompt_rows=resolved["prompt_batch_rows"],
+    )
+    scenario_results = []
+    for scenario_name in resolved["scenarios"]:
+        scenario = SCENARIO_BY_NAME[scenario_name]
+        records = []
+        for replicate in range(resolved["power_replicates"]):
+            replicate_seed = derive_seed(
+                resolved["seed"], components, repeats, scenario_name, replicate
+            )
+            records.append(run_power_replicate(
+                components,
+                scenario,
+                repeats=repeats,
+                seed=replicate_seed,
+                null_threshold=threshold,
+                gammas=resolved["gammas"],
+                rhos=resolved["rhos"],
+                mean_ridges=resolved["mean_ridges"],
+                shrinkage=resolved["shrinkage"],
+                confidence=resolved["confidence"],
+                multiplier_draws=resolved["multiplier_draws"],
+                missing_rate=resolved["missing_rate"],
+                max_prompt_rows=resolved["prompt_batch_rows"],
+            ))
+        scenario_results.append(aggregate_power_records(records))
+    return {
+        "components_per_required_corpus": components,
+        "repeats": repeats,
+        "outer_component_folds": resolved["outer_folds"],
+        "inner_component_folds": resolved["inner_folds"],
+        "maximum_rows_per_prompt_request": resolved["prompt_batch_rows"],
+        "synthetic_joint_selector_null": {
+            "draws": resolved["null_draws"],
+            "seed": int(null_seed),
+            "maximum_eligible_inner_gain": summary(null_maxima),
+            "upper_order_statistic_threshold": float(threshold),
+            "order_statistic_rank_one_based": int(rank),
+            "strict_rejection": "synthetic observed joint maximum must be strictly greater than threshold",
+            "real_campaign_reuse_prohibited": True,
+        },
+        "scenarios": scenario_results,
+        "decision": _configuration_decision(
+            scenario_results, resolved["scenarios"], repeats=repeats
+        ),
+    }
+
+
+def _file_digest(path):
+    digest = hashlib.sha256()
+    size = 0
+    with open(path, "rb") as stream:
+        while True:
+            chunk = stream.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+            size += len(chunk)
+    return {"bytes": size, "sha256": digest.hexdigest()}
+
+
+def _provenance():
+    files = {
+        "preregistration": os.path.join(HERE, "PREREG_graph_geometry_repeated_judge.md"),
+        "power_primitives": os.path.join(HERE, "repeated_judge_power.py"),
+        "power_runner": os.path.abspath(__file__),
+    }
+    return {
+        "files": {name: _file_digest(path) for name, path in files.items()},
+        "numpy_version": np.__version__,
+        "seed_derivation": "sha256(base,G,R,scenario,replicate); null namespace is disjoint",
+    }
+
+
+def build_scientific_payload(resolved: dict) -> dict:
+    configurations = [
+        run_configuration(configuration, resolved)
+        for configuration in resolved["configurations"]
+    ]
+    primary_r3 = [row for row in configurations if row["repeats"] == 3]
+    repeat4 = [row for row in configurations if row["repeats"] == 4]
+    passing_r3 = sorted(
+        (
+            row["components_per_required_corpus"]
+            for row in primary_r3
+            if row["decision"]["evaluable"] and row["decision"]["pass"]
+        )
+    )
+    synthetic_smallest_passing_G = passing_r3[0] if passing_r3 else None
+    sizing_evaluable = bool(primary_r3) and all(
+        row["decision"]["evaluable"] for row in primary_r3
+    )
+
+    configuration_record = {
+        key: value for key, value in resolved.items() if key != "configurations"
+    }
+    configuration_record["configurations"] = [
+        {"components_per_required_corpus": int(value[0]), "repeats": int(value[1])}
+        for value in resolved["configurations"]
+    ]
+    return {
+        "schema_version": 2,
+        "status": "SYNTHETIC SIZING ONLY; NO REAL COVARIANCE DEPLOYMENT",
+        "scope": (
+            "generic per-corpus synthetic sizing mechanism with three-row endpoint-disjoint "
+            "components, stable split-contained prompt blocks of at most ten rows, shared "
+            "request effects, repeated four-channel measurements, five-fold outer "
+            "cross-fitting, and distinct residual and latent-state posterior NLL endpoints"
+        ),
+        "configuration": configuration_record,
+        "provenance": _provenance(),
+        "primary_r3_results": primary_r3,
+        "repeat4_sensitivity_results": repeat4,
+        "gate": {
+            "synthetic_primary_event_sizing_evaluable": sizing_evaluable,
+            "synthetic_primary_event_pass": bool(
+                sizing_evaluable and synthetic_smallest_passing_G is not None
+            ),
+            "smallest_passing_synthetic_primary_event_G_per_corpus": (
+                synthetic_smallest_passing_G
+            ),
+            "final_campaign_G_recommendation": None,
+            "deployment_pass": False,
+            "real_covariance_deployment": False,
+            "reason": (
+                "R=3 can identify only a smallest passing two-corpus synthetic-primary-event "
+                "grid point; R=4 is reported separately. No final campaign G or deployment "
+                "recommendation is emitted until the unsimulated real-data gates pass."
+            ),
+        },
+        "real_campaign_selector_requirement": (
+            "Each outer-training prompt-block set must recalibrate its own block-null "
+            "familywise selector. The synthetic sizing threshold is never reusable."
+        ),
+        "unsimulated_required_gates": [
+            "blinded third-family, human, graph-structural, or downstream truth/generalization",
+            "real repeated-judge repeat-specific stochastic-correlation identification",
+            "real posterior calibration, coverage, and Mahalanobis non-worsening",
+            "real decision log-loss and margin-gated AURC degradation at most .01",
+            "ten-bin ECE and prompt-block-bootstrap AURC intervals",
+            "real graph/Nomic source-correlation and same-split ablations",
+            "real topology benefit over derangement and hard negatives",
+            "s_safe spectral adapter, full call/prompt/wave incidence covariance, and delta_95",
+            "statistical/numerical loading limits and cross-batch independence bound",
+        ],
+    }
+
+
+def serialize_payload(payload: dict) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+
+
+def write_payload(path: str, payload: dict) -> None:
+    path = os.path.abspath(path)
+    parent = os.path.dirname(path)
+    os.makedirs(parent, exist_ok=True)
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", newline="\n", dir=parent, delete=False
+        ) as stream:
+            temporary = stream.name
+            stream.write(serialize_payload(payload))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        temporary = None
+    finally:
+        if temporary is not None:
+            try:
+                os.unlink(temporary)
+            except FileNotFoundError:
+                pass
+
+
+def main(argv: Iterable[str] | None = None) -> dict:
+    args = build_arg_parser().parse_args(argv)
+    resolved = resolve_configuration(args)
+    started = time.perf_counter()
+    payload = build_scientific_payload(resolved)
+    serialized = serialize_payload(payload).encode("utf-8")
+    write_payload(args.out, payload)
+    print(json.dumps({
+        "content_sha256": hashlib.sha256(serialized).hexdigest(),
+        "output": os.path.abspath(args.out),
+        "wall_seconds": time.perf_counter() - started,
+        "full_preregistration": resolved["full_preregistration"],
+        "configurations": len(resolved["configurations"]),
+    }, indent=2, sort_keys=True))
+    return payload
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/sample_repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/sample_repeated_judge_campaign.py
@@ -185,6 +185,8 @@ def build_campaign(args):
     historical, historical_artifacts = load_historical_endpoints(args.historical_endpoints)
     if args.repeats < 3:
         raise CampaignInputError("repeats must be at least three")
+    if not 1 <= args.batch_size <= 10:
+        raise CampaignInputError("batch_size must be between one and ten rows")
     safe_judges = [_safe_judge(judge) for judge in args.judges]
     if len(safe_judges) != len(set(safe_judges)):
         raise CampaignInputError("judge names collide after safe artifact-name normalization")

--- a/prototypes/mu_cosine/sample_repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/sample_repeated_judge_campaign.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Select and schedule the frozen repeated-judge campaign without scoring it."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import os
+from pathlib import Path
+import shutil
+import tempfile
+
+from repeated_judge_campaign import (
+    ALGORITHM,
+    DEFAULT_COMPONENTS_PER_CORPUS,
+    DEFAULT_JUDGES,
+    FROZEN_COMPONENT_REPEAT_GRID,
+    NESTED_FOLD_COLUMNS,
+    ROW_ROLES,
+    SCHEMA_VERSION,
+    CampaignInputError,
+    assign_component_folds,
+    assign_nested_inner_folds,
+    build_scoring_schedule,
+    campaign_rows,
+    component_quotas,
+    content_record,
+    expected_quotas,
+    filter_candidate_pool,
+    json_bytes,
+    load_candidates,
+    load_candidate_builder_manifest,
+    load_historical_endpoints,
+    load_request_contract,
+    response_ingestion_schema,
+    score_input_bytes,
+    select_candidates,
+    tsv_bytes,
+    validate_candidate_geometry,
+)
+
+
+ROW_COLUMNS = (
+    "row_id",
+    "component_id",
+    "fold",
+    "inner_fold",
+    "candidate_id",
+    "corpus",
+    "source_component",
+    "hop_transition",
+    "degree_quartile",
+    "agreement_class",
+    "role",
+    "node_id",
+    "node_title",
+    "node_normalized_title",
+    "root_id",
+    "root_title",
+    "root_normalized_title",
+    "cur_relation",
+    "conf",
+    "neighborhood",
+    "node_type",
+    "root_type",
+    "raw",
+)
+SCHEDULE_COLUMNS = (
+    "request_schema_version",
+    "model_id",
+    "model_revision",
+    "prompt_id",
+    "prompt_sha256",
+    "reasoning_effort",
+    "settings_json",
+    "settings_sha256",
+    "call_seed",
+    "shared_session_id",
+    "wave_id",
+    "judge",
+    "repeat",
+    "batch_size",
+    "batch_index",
+    "batch_row",
+    "global_position",
+    "request_id",
+    "prompt_block_id",
+    "inference_cluster_id",
+    "corpus",
+    "outer_fold",
+    "global_inner_fold",
+    "row_id",
+    "component_id",
+    "role",
+)
+
+
+def _safe_judge(value):
+    output = "".join(character if character.isalnum() or character in ".-_" else "_" for character in value)
+    if not output or output in {".", ".."}:
+        raise CampaignInputError(f"judge name cannot form a safe artifact name: {value!r}")
+    return output
+
+
+def _artifact(root, relative, payload):
+    relative = Path(relative)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise CampaignInputError(f"artifact name must be relative and contained: {relative}")
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    return {"name": relative.as_posix(), **content_record(payload)}
+
+
+def _component_rows(components, input_columns):
+    if any(name in input_columns for name in ("component_id", "fold", "inner_fold")):
+        raise CampaignInputError(
+            "candidate pool may not predeclare component_id, fold, or inner_fold; "
+            "they are selector outputs"
+        )
+    rows = []
+    for component in components:
+        row = {
+            "component_id": component.component_id,
+            "fold": component.fold,
+            "inner_fold": component.inner_fold,
+        }
+        row.update(component.raw)
+        rows.append(row)
+    return ("component_id", "fold", "inner_fold", *input_columns), rows
+
+
+def _cell_counts(components):
+    values = Counter("|".join(component.cell) for component in components)
+    return dict(sorted(values.items()))
+
+
+def _configuration_classification(args, request_specs):
+    deviations = []
+    if args.seed != 0:
+        deviations.append("selector seed differs from the frozen value 0")
+    if args.per_cell is not None:
+        deviations.append("--per-cell is an exploratory-only quota override")
+    if (args.components_per_corpus, args.repeats) not in FROZEN_COMPONENT_REPEAT_GRID:
+        deviations.append("(components_per_corpus, repeats) is outside the frozen G/R grid")
+    if args.source_component_cap_fraction != 0.10:
+        deviations.append("source-component cap differs from the frozen 0.10")
+    if args.folds != 5 or args.inner_folds != 3:
+        deviations.append("outer/inner folds differ from frozen 5/3")
+    if tuple(args.judges) != DEFAULT_JUDGES:
+        deviations.append("judge aliases differ from the frozen pair")
+    frozen_models = {
+        "gpt-5.5-low": "gpt-5.5",
+        "gpt-5.6-luna": "gpt-5.6-luna",
+    }
+    for alias, expected_model in frozen_models.items():
+        if alias in request_specs and (
+            request_specs[alias]["model_id"] != expected_model
+            or request_specs[alias]["reasoning_effort"] != "low"
+        ):
+            deviations.append(f"{alias} model identity or reasoning effort is not frozen")
+    if args.batch_size > 10:
+        deviations.append("prompt blocks exceed the frozen maximum of 10 rows")
+    if any(not spec["stateless"] for spec in request_specs.values()):
+        deviations.append("request contract is not stateless")
+    classification = (
+        "confirmatory-compatible-no-spend" if not deviations else "exploratory-smoke-only"
+    )
+    return classification, deviations
+
+
+def build_campaign(args):
+    candidate_columns, candidates, candidate_artifact = load_candidates(args.candidate_pool)
+    builder_manifest, builder_artifact, thresholds = load_candidate_builder_manifest(
+        args.candidate_builder_manifest, candidate_artifact
+    )
+    validate_candidate_geometry(candidates, thresholds)
+    historical, historical_artifacts = load_historical_endpoints(args.historical_endpoints)
+    if args.repeats < 3:
+        raise CampaignInputError("repeats must be at least three")
+    safe_judges = [_safe_judge(judge) for judge in args.judges]
+    if len(safe_judges) != len(set(safe_judges)):
+        raise CampaignInputError("judge names collide after safe artifact-name normalization")
+    request_specs, request_contract, request_contract_artifact = load_request_contract(
+        args.request_contract, tuple(args.judges)
+    )
+    if args.per_cell is None:
+        quotas = component_quotas(args.components_per_corpus)
+    else:
+        quotas = expected_quotas(per_cell=args.per_cell)
+    eligible, exclusions = filter_candidate_pool(candidates, historical, quotas)
+    selected, selection = select_candidates(
+        eligible,
+        quotas,
+        source_cap_fraction=args.source_component_cap_fraction,
+        seed=args.seed,
+        max_attempts=args.max_selection_attempts,
+    )
+    components, fold_diagnostics = assign_component_folds(
+        selected, quotas, folds=args.folds, seed=args.seed
+    )
+    components, nested_fold_records, nested_fold_diagnostics = assign_nested_inner_folds(
+        components,
+        outer_folds=args.folds,
+        inner_folds=args.inner_folds,
+        seed=args.seed,
+    )
+    rows = campaign_rows(components)
+    schedule, wave_orders = build_scoring_schedule(
+        rows,
+        judges=tuple(args.judges),
+        repeats=args.repeats,
+        batch_size=args.batch_size,
+        seed=args.seed,
+        judge_specs=request_specs,
+    )
+    classification, deviations = _configuration_classification(args, request_specs)
+
+    out = Path(args.out_dir)
+    if out.exists():
+        raise CampaignInputError(f"output directory already exists: {out}")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{out.name}.", dir=str(out.parent)))
+    try:
+        artifacts = []
+        component_columns, component_records = _component_rows(components, candidate_columns)
+        artifacts.append(_artifact(
+            temporary, "selected_components.tsv",
+            tsv_bytes(component_columns, component_records),
+        ))
+        artifacts.append(_artifact(
+            temporary, "campaign_rows.tsv", tsv_bytes(ROW_COLUMNS, rows)
+        ))
+        artifacts.append(_artifact(
+            temporary,
+            "nested_component_folds.tsv",
+            tsv_bytes(NESTED_FOLD_COLUMNS, nested_fold_records),
+        ))
+        artifacts.append(_artifact(
+            temporary, "scoring_schedule.tsv", tsv_bytes(SCHEDULE_COLUMNS, schedule)
+        ))
+        artifacts.append(_artifact(
+            temporary,
+            "response_ingestion_schema.json",
+            json_bytes(response_ingestion_schema()),
+        ))
+
+        wave_files = []
+        row_by_id = {row["row_id"]: row for row in rows}
+        for judge in args.judges:
+            safe = _safe_judge(judge)
+            for repeat in range(args.repeats):
+                wave_id = f"{judge}:repeat-{repeat}"
+                relative = Path("score_inputs") / f"{safe}.repeat-{repeat}.tsv"
+                artifact = _artifact(
+                    temporary, relative, score_input_bytes(wave_orders[wave_id])
+                )
+                request_artifacts = []
+                wave_schedule = [row for row in schedule if row["wave_id"] == wave_id]
+                request_ids = sorted({row["request_id"] for row in wave_schedule})
+                for request_id in request_ids:
+                    request_schedule = sorted(
+                        (row for row in wave_schedule if row["request_id"] == request_id),
+                        key=lambda row: row["batch_row"],
+                    )
+                    request_rows = [row_by_id[row["row_id"]] for row in request_schedule]
+                    request_relative = (
+                        Path("request_inputs") / safe / f"repeat-{repeat}" / f"{request_id}.tsv"
+                    )
+                    request_artifact = _artifact(
+                        temporary, request_relative, score_input_bytes(request_rows)
+                    )
+                    request_artifacts.append({
+                        "request_id": request_id,
+                        "prompt_block_id": request_schedule[0]["prompt_block_id"],
+                        "inference_cluster_id": request_schedule[0]["inference_cluster_id"],
+                        "row_count": len(request_rows),
+                        "artifact": request_artifact,
+                    })
+                    artifacts.append(request_artifact)
+                wave_files.append({
+                    "wave_id": wave_id,
+                    "judge": judge,
+                    "repeat": repeat,
+                    "batch_size": args.batch_size,
+                    "request_count": len(request_ids),
+                    "artifact": artifact,
+                    "request_artifacts": request_artifacts,
+                })
+                artifacts.append(artifact)
+
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "status": "OUTCOME-BLIND CAMPAIGN MATERIALIZATION; NO JUDGE OR MODEL CALLS",
+            "classification": classification,
+            "call_authorized": False,
+            "configuration_deviations": deviations,
+            "algorithm": ALGORITHM,
+            "configuration": {
+                "seed": args.seed,
+                "components_per_corpus": args.components_per_corpus,
+                "per_cell": args.per_cell,
+                "source_component_cap_fraction": args.source_component_cap_fraction,
+                "folds": args.folds,
+                "inner_folds": args.inner_folds,
+                "judges": list(args.judges),
+                "repeats": args.repeats,
+                "batch_size": args.batch_size,
+                "max_selection_attempts": args.max_selection_attempts,
+            },
+            "inputs": {
+                "candidate_pool": candidate_artifact,
+                "candidate_builder_manifest": builder_artifact,
+                "candidate_builder_contract": builder_manifest,
+                "request_contract": request_contract_artifact,
+                "request_contract_contents": request_contract,
+                "historical_endpoint_inventories": list(historical_artifacts),
+                "historical_unique_scoped_ids": len(historical.scoped_ids),
+                "historical_unique_normalized_titles": len(historical.normalized_titles),
+            },
+            "selection": {
+                **selection,
+                "candidate_pool_rows": len(candidates),
+                "eligible_candidate_rows": len(eligible),
+                "exclusions": exclusions,
+                "component_count": len(components),
+                "row_count": len(rows),
+                "cell_counts": _cell_counts(components),
+                "quota_counts": {
+                    "|".join(cell): count for cell, count in sorted(quotas.items())
+                },
+            },
+            "folds": fold_diagnostics,
+            "nested_folds": nested_fold_diagnostics,
+            "schedule": {
+                "wave_count": len(wave_orders),
+                "records": len(schedule),
+                "roles": list(ROW_ROLES),
+                "same_component_per_request_max": 1,
+                "maximum_rows_per_request": args.batch_size,
+                "request_split_signature": ["corpus", "outer_fold", "global_inner_fold"],
+                "prompt_block_is_inference_cluster": True,
+                "prompt_block_membership_stable_across_roles_judges_repeats": True,
+                "wave_files": wave_files,
+            },
+            "outputs": sorted(artifacts, key=lambda value: value["name"]),
+            "non_claims": [
+                "materialization does not establish covariance",
+                "component folds do not consume outcomes",
+                "score inputs have not been submitted to any judge",
+                "materialization never authorizes fresh calls, including confirmatory-compatible output",
+            ],
+        }
+        manifest_payload = json_bytes(manifest)
+        (temporary / "manifest.json").write_bytes(manifest_payload)
+        os.replace(temporary, out)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return manifest, content_record(manifest_payload)
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-pool", required=True)
+    parser.add_argument(
+        "--candidate-builder-manifest",
+        required=True,
+        help="content-addressed graph/Nomic builder contract for the candidate pool",
+    )
+    parser.add_argument(
+        "--request-contract",
+        required=True,
+        help="immutable model revision, prompt hash, settings, and stateless-call contract",
+    )
+    parser.add_argument(
+        "--historical-endpoints",
+        action="append",
+        required=True,
+        help="repeatable TSV with corpus, endpoint_id, endpoint_title",
+    )
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument(
+        "--components-per-corpus", type=int, default=DEFAULT_COMPONENTS_PER_CORPUS
+    )
+    parser.add_argument(
+        "--per-cell", type=int, default=None,
+        help="exploratory-only direct cell quota override",
+    )
+    parser.add_argument("--source-component-cap-fraction", type=float, default=0.10)
+    parser.add_argument("--folds", type=int, default=5)
+    parser.add_argument("--inner-folds", type=int, default=3)
+    parser.add_argument("--judges", nargs="+", default=list(DEFAULT_JUDGES))
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--batch-size", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--max-selection-attempts", type=int, default=512)
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    try:
+        manifest, record = build_campaign(args)
+    except CampaignInputError as exc:
+        raise SystemExit(str(exc)) from exc
+    print(json_bytes({
+        "component_count": manifest["selection"]["component_count"],
+        "row_count": manifest["selection"]["row_count"],
+        "wave_count": manifest["schedule"]["wave_count"],
+        "manifest_sha256": record["sha256"],
+        "out_dir": os.path.abspath(args.out_dir),
+    }).decode("utf-8"), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/sample_repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/sample_repeated_judge_campaign.py
@@ -84,6 +84,7 @@ SCHEDULE_COLUMNS = (
     "batch_row",
     "global_position",
     "request_id",
+    "request_input_sha256",
     "prompt_block_id",
     "inference_cluster_id",
     "corpus",
@@ -163,8 +164,14 @@ def _configuration_classification(args, request_specs):
         deviations.append("prompt blocks exceed the frozen maximum of 10 rows")
     if any(not spec["stateless"] for spec in request_specs.values()):
         deviations.append("request contract is not stateless")
+    # This repository does not yet contain the candidate builder or the exact
+    # approved prompt/settings artifacts.  A caller-supplied content hash is
+    # useful for reproducibility but is not independent verification, so even
+    # an otherwise frozen-shaped materialization must not be labeled
+    # confirmatory-ready.
     classification = (
-        "confirmatory-compatible-no-spend" if not deviations else "exploratory-smoke-only"
+        "protocol-shape-compatible-no-spend-inputs-unverified"
+        if not deviations else "exploratory-smoke-only"
     )
     return classification, deviations
 
@@ -270,6 +277,10 @@ def build_campaign(args):
                     request_artifact = _artifact(
                         temporary, request_relative, score_input_bytes(request_rows)
                     )
+                    if request_artifact["sha256"] != request_schedule[0]["request_input_sha256"]:
+                        raise AssertionError(
+                            "request ID input hash differs from materialized request bytes"
+                        )
                     request_artifacts.append({
                         "request_id": request_id,
                         "prompt_block_id": request_schedule[0]["prompt_block_id"],
@@ -294,6 +305,8 @@ def build_campaign(args):
             "status": "OUTCOME-BLIND CAMPAIGN MATERIALIZATION; NO JUDGE OR MODEL CALLS",
             "classification": classification,
             "call_authorized": False,
+            "candidate_builder_verified_by_repository": False,
+            "request_contract_approved_for_live_use": False,
             "configuration_deviations": deviations,
             "algorithm": ALGORITHM,
             "configuration": {
@@ -341,6 +354,11 @@ def build_campaign(args):
                 "request_split_signature": ["corpus", "outer_fold", "global_inner_fold"],
                 "prompt_block_is_inference_cluster": True,
                 "prompt_block_membership_stable_across_roles_judges_repeats": True,
+                "row_position_schedule": (
+                    "independent deterministic base per role-by-judge; "
+                    "evenly spaced rotations across repeats"
+                ),
+                "list_position_effect_power_sensitivity_implemented": False,
                 "wave_files": wave_files,
             },
             "outputs": sorted(artifacts, key=lambda value: value["name"]),
@@ -348,7 +366,10 @@ def build_campaign(args):
                 "materialization does not establish covariance",
                 "component folds do not consume outcomes",
                 "score inputs have not been submitted to any judge",
-                "materialization never authorizes fresh calls, including confirmatory-compatible output",
+                "candidate-builder hashes are caller-supplied provenance, not repository verification",
+                "model revision, prompt hash, and settings have not been approved for live use",
+                "list-position effects require a pilot and later frozen sensitivity before live use",
+                "materialization never authorizes fresh calls, including protocol-shaped output",
             ],
         }
         manifest_payload = json_bytes(manifest)

--- a/prototypes/mu_cosine/test_repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/test_repeated_judge_campaign.py
@@ -294,6 +294,14 @@ def test_source_cap_and_repeats_below_three_fail_loudly(tmp_path):
             batch_size=3,
             judge_specs=judge_specs(),
         )
+    with pytest.raises(CampaignInputError, match="between one and ten"):
+        build_scoring_schedule(
+            campaign_rows(folded),
+            judges=("judge-a",),
+            repeats=3,
+            batch_size=11,
+            judge_specs=judge_specs(),
+        )
 
 
 def test_unknown_cells_are_rejected_not_silently_dropped(tmp_path):

--- a/prototypes/mu_cosine/test_repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/test_repeated_judge_campaign.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Focused tests for outcome-blind repeated-campaign primitives."""
+
+from collections import Counter, defaultdict
+import csv
+
+import pytest
+
+from repeated_judge_campaign import (
+    CANDIDATE_REQUIRED_COLUMNS,
+    CampaignInputError,
+    HistoricalEndpoints,
+    assign_component_folds,
+    assign_nested_inner_folds,
+    build_scoring_schedule,
+    campaign_rows,
+    component_quotas,
+    filter_candidate_pool,
+    load_candidates,
+    normalize_title,
+    sha256_bytes,
+    select_candidates,
+    tsv_bytes,
+    validate_candidate_geometry,
+    validate_response_records,
+)
+
+
+def candidate_record(candidate_id, cell, base, *, source="source-a", shared_id=None):
+    corpus, hop, degree, agreement = cell
+    first_hop, second_hop = (part[1:] if part.startswith("h") else part for part in hop.split("-"))
+    descendant_id = shared_id or f"id-{base}-x"
+    record = {
+        "candidate_id": candidate_id,
+        "corpus": corpus,
+        "source_component": source,
+        "hop_transition": hop,
+        "degree_quartile": degree,
+        "agreement_class": agreement,
+        "anchor_hop": first_hop,
+        "adjacent_hop": second_hop,
+        "distant_hop": second_hop,
+        "anchor_campaign_tag": "anchor-campaign",
+        "adjacent_campaign_tag": "comparator-campaign",
+        "distant_campaign_tag": "comparator-campaign",
+        "anchor_degree_quartile": degree,
+        "adjacent_degree_quartile": "q2",
+        "distant_degree_quartile": "q2",
+        "anchor_adjacent_direct_edge": "true",
+        "anchor_distant_distance": "3",
+        "anchor_distant_disconnected": "false",
+        "cumulative_anchor_adjacent_similarity": "0.9",
+        "cumulative_anchor_distant_similarity": "0.1",
+        "nomic_anchor_adjacent_similarity": "0.8" if agreement == "agreement" else "0.2",
+        "nomic_anchor_distant_similarity": "0.2" if agreement == "agreement" else "0.8",
+        "descendant_id": descendant_id,
+        "descendant_title": f"Title_{descendant_id}",
+        "anchor_id": f"id-{base}-a",
+        "anchor_title": f"Title_{base}_a",
+        "adjacent_id": f"id-{base}-b",
+        "adjacent_title": f"Title_{base}_b",
+        "distant_id": f"id-{base}-c",
+        "distant_title": f"Title_{base}_c",
+    }
+    return record
+
+
+def judge_specs(judges=("judge-a",)):
+    return {
+        judge: {
+            "request_schema_version": 1,
+            "model_id": f"model-{judge}",
+            "model_revision": "revision-1",
+            "prompt_id": "prompt-1",
+            "prompt_sha256": "a" * 64,
+            "reasoning_effort": "low",
+            "settings_json": "{}",
+            "settings_sha256": sha256_bytes(b"{}"),
+            "call_seed_base": None,
+            "shared_session_id": "",
+            "stateless": True,
+        }
+        for judge in judges
+    }
+
+
+def write_tsv(path, columns, rows):
+    path.write_bytes(tsv_bytes(columns, rows))
+
+
+def test_normalization_matches_campaign_identity_contract():
+    assert normalize_title("  Foo__BAR  ") == "foo bar"
+    assert normalize_title("ＡＢＣ") == "abc"
+
+
+def test_loader_rejects_duplicate_candidate_and_inconsistent_endpoint_identity(tmp_path):
+    cell = ("exploratory", "h1-h2", "q1", "agreement")
+    row = candidate_record("c0", cell, 0)
+    path = tmp_path / "pool.tsv"
+    write_tsv(path, CANDIDATE_REQUIRED_COLUMNS, [row, row])
+    with pytest.raises(CampaignInputError, match="duplicate candidate_id"):
+        load_candidates(path)
+
+    first = candidate_record("c0", cell, 0, shared_id="same")
+    second = candidate_record("c1", cell, 1, shared_id="same")
+    second["descendant_title"] = "A genuinely different title"
+    write_tsv(path, CANDIDATE_REQUIRED_COLUMNS, [first, second])
+    with pytest.raises(CampaignInputError, match="inconsistent normalized titles"):
+        load_candidates(path)
+
+
+def test_historical_filter_selection_folds_and_schedule_are_deterministic(tmp_path):
+    cells = (
+        ("exploratory", "h1-h2", "q1", "agreement"),
+        ("exploratory", "h1-h2", "q1", "disagreement"),
+    )
+    records = []
+    for cell_index, cell in enumerate(cells):
+        for value in range(6):
+            base = 100 * cell_index + value
+            records.append(candidate_record(
+                f"candidate-{cell_index}-{value}", cell, base,
+                source=f"source-{cell_index}-{value}",
+            ))
+    # This otherwise eligible row is removed by normalized historical title.
+    records.append(candidate_record("historical-candidate", cells[0], 999))
+    pool = tmp_path / "pool.tsv"
+    write_tsv(pool, CANDIDATE_REQUIRED_COLUMNS, records)
+    _columns, candidates, _artifact = load_candidates(pool)
+    historical = HistoricalEndpoints(
+        frozenset(), frozenset({normalize_title("Title_999_a")}), tuple()
+    )
+    quotas = {cell: 2 for cell in cells}
+    eligible, exclusions = filter_candidate_pool(candidates, historical, quotas)
+    assert exclusions == {"historical_normalized_title": 1}
+
+    selected_a, audit_a = select_candidates(
+        eligible, quotas, source_cap_fraction=0.50, seed=17
+    )
+    selected_b, audit_b = select_candidates(
+        eligible, quotas, source_cap_fraction=0.50, seed=17
+    )
+    assert [value.candidate_id for value in selected_a] == [value.candidate_id for value in selected_b]
+    assert audit_a == audit_b
+    assert Counter(value.cell for value in selected_a) == Counter(quotas)
+    ids = [endpoint for value in selected_a for endpoint in value.scoped_ids]
+    titles = [title for value in selected_a for title in value.normalized_titles]
+    assert len(ids) == len(set(ids))
+    assert len(titles) == len(set(titles))
+    assert max(audit_a["source_component_counts"].values()) <= 2
+
+    folded_a, diagnostics_a = assign_component_folds(selected_a, quotas, folds=2, seed=19)
+    folded_b, diagnostics_b = assign_component_folds(selected_a, quotas, folds=2, seed=19)
+    assert [(value.component_id, value.fold) for value in folded_a] == [
+        (value.component_id, value.fold) for value in folded_b
+    ]
+    assert diagnostics_a == diagnostics_b
+    for fold in range(2):
+        assert sum(value.fold == fold for value in folded_a) == 2
+        for cell in cells:
+            assert sum(value.fold == fold and value.cell == cell for value in folded_a) == 1
+
+    folded_a, nested_a, inner_diagnostics_a = assign_nested_inner_folds(
+        folded_a, outer_folds=2, inner_folds=2, seed=21
+    )
+    folded_b, nested_b, inner_diagnostics_b = assign_nested_inner_folds(
+        folded_b, outer_folds=2, inner_folds=2, seed=21
+    )
+    assert nested_a == nested_b
+    assert inner_diagnostics_a == inner_diagnostics_b
+    assert len(nested_a) == len(folded_a) * 2
+    rows = campaign_rows(folded_a)
+    schedule, waves = build_scoring_schedule(
+        rows,
+        judges=("judge-a",),
+        repeats=3,
+        batch_size=2,
+        seed=23,
+        judge_specs=judge_specs(),
+    )
+    assert len(rows) == 12
+    assert len(schedule) == 36
+    assert len(waves) == 3
+    for wave_id, order in waves.items():
+        assert len(order) == len(rows)
+        assert {row["row_id"] for row in order} == {row["row_id"] for row in rows}, wave_id
+    by_request = Counter()
+    for record in schedule:
+        by_request[(record["wave_id"], record["request_id"], record["component_id"])] += 1
+    assert max(by_request.values()) == 1
+    request_signatures = defaultdict(set)
+    request_blocks = defaultdict(set)
+    for record in schedule:
+        request_signatures[record["request_id"]].add(
+            (record["corpus"], record["outer_fold"], record["global_inner_fold"])
+        )
+        request_blocks[(record["prompt_block_id"], record["role"])].add(record["component_id"])
+    assert all(len(values) == 1 for values in request_signatures.values())
+    assert all(record["prompt_block_id"] == record["inference_cluster_id"] for record in schedule)
+
+    changed_specs = judge_specs()
+    changed_specs["judge-a"]["model_revision"] = "revision-2"
+    changed_schedule, _ = build_scoring_schedule(
+        rows,
+        judges=("judge-a",),
+        repeats=3,
+        batch_size=2,
+        seed=23,
+        judge_specs=changed_specs,
+    )
+    assert {record["request_id"] for record in schedule}.isdisjoint(
+        {record["request_id"] for record in changed_schedule}
+    )
+    seeded_specs = judge_specs()
+    seeded_specs["judge-a"]["call_seed_base"] = 7
+    seeded_schedule, _ = build_scoring_schedule(
+        rows,
+        judges=("judge-a",),
+        repeats=3,
+        batch_size=2,
+        seed=23,
+        judge_specs=seeded_specs,
+    )
+    seeds_by_request = defaultdict(set)
+    for record in seeded_schedule:
+        seeds_by_request[record["request_id"]].add(record["call_seed"])
+    assert all(len(values) == 1 for values in seeds_by_request.values())
+    assert len({next(iter(values)) for values in seeds_by_request.values()}) == len(
+        seeds_by_request
+    )
+
+
+def test_source_cap_and_repeats_below_three_fail_loudly(tmp_path):
+    cell = ("exploratory", "h1-h2", "q1", "agreement")
+    records = [
+        candidate_record(f"c-{value}", cell, value, source="only-source")
+        for value in range(4)
+    ]
+    pool = tmp_path / "pool.tsv"
+    write_tsv(pool, CANDIDATE_REQUIRED_COLUMNS, records)
+    _columns, candidates, _artifact = load_candidates(pool)
+    with pytest.raises(CampaignInputError, match="could not pack"):
+        select_candidates(
+            candidates, {cell: 4}, source_cap_fraction=0.25, max_attempts=3
+        )
+
+    unique_records = [
+        candidate_record(f"unique-{value}", cell, 100 + value, source=f"source-{value}")
+        for value in range(4)
+    ]
+    write_tsv(pool, CANDIDATE_REQUIRED_COLUMNS, unique_records)
+    _columns, unique_candidates, _artifact = load_candidates(pool)
+    selected, _ = select_candidates(
+        unique_candidates, {cell: 4}, source_cap_fraction=1.0
+    )
+    folded, _ = assign_component_folds(selected, {cell: 4}, folds=2)
+    folded, _nested, _diagnostics = assign_nested_inner_folds(
+        folded, outer_folds=2, inner_folds=2
+    )
+    with pytest.raises(CampaignInputError, match="at least three"):
+        build_scoring_schedule(
+            campaign_rows(folded),
+            judges=("judge-a",),
+            repeats=2,
+            batch_size=3,
+            judge_specs=judge_specs(),
+        )
+
+
+def test_unknown_cells_are_rejected_not_silently_dropped(tmp_path):
+    good = ("exploratory", "h1-h2", "q1", "agreement")
+    bad = ("exploratory", "h9-h10", "q1", "agreement")
+    pool = tmp_path / "pool.tsv"
+    write_tsv(
+        pool,
+        CANDIDATE_REQUIRED_COLUMNS,
+        [candidate_record("good", good, 1), candidate_record("bad", bad, 2)],
+    )
+    _columns, candidates, _artifact = load_candidates(pool)
+    empty_history = HistoricalEndpoints(frozenset(), frozenset(), tuple())
+    with pytest.raises(CampaignInputError, match="unknown frozen cells"):
+        filter_candidate_pool(candidates, empty_history, {good: 1})
+
+
+def test_candidate_structural_contract_and_canonical_identity(tmp_path):
+    cell = ("exploratory", "h1-h2", "q1", "agreement")
+    path = tmp_path / "pool.tsv"
+    row = candidate_record(" c0", cell, 0)
+    write_tsv(path, CANDIDATE_REQUIRED_COLUMNS, [row])
+    with pytest.raises(CampaignInputError, match="canonical token"):
+        load_candidates(path)
+
+    row = candidate_record("c0", cell, 0)
+    row["anchor_adjacent_direct_edge"] = "false"
+    write_tsv(path, CANDIDATE_REQUIRED_COLUMNS, [row])
+    with pytest.raises(CampaignInputError, match="not a direct graph neighbor"):
+        load_candidates(path)
+
+    row = candidate_record("c0", cell, 0)
+    row["anchor_distant_distance"] = "2"
+    write_tsv(path, CANDIDATE_REQUIRED_COLUMNS, [row])
+    with pytest.raises(CampaignInputError, match="at least 3"):
+        load_candidates(path)
+
+    row = candidate_record("c0", cell, 0)
+    row["agreement_class"] = "disagreement"
+    write_tsv(path, CANDIDATE_REQUIRED_COLUMNS, [row])
+    _columns, candidates, _artifact = load_candidates(path)
+    with pytest.raises(CampaignInputError, match="deltas imply"):
+        validate_candidate_geometry(
+            candidates, {"graph_delta_min": 0.0, "nomic_delta_min": 0.0}
+        )
+
+
+@pytest.mark.parametrize("components_per_corpus", [160, 320, 512, 800])
+def test_frozen_g_grid_has_exact_cells_and_near_balanced_outer_folds(
+    tmp_path, components_per_corpus
+):
+    quotas = component_quotas(components_per_corpus)
+    by_corpus = Counter()
+    for cell, count in quotas.items():
+        by_corpus[cell[0]] += count
+    assert set(by_corpus.values()) == {components_per_corpus}
+    assert len(set(quotas.values())) == 1
+
+    # One synthetic cell is sufficient to pin the G=512 regression: 16 cannot
+    # divide five folds exactly but must still materialize 4/3/3/3/3.
+    cell = ("exploratory", "h1-h2", "q1", "agreement")
+    per_cell = components_per_corpus // 32
+    rows = [
+        candidate_record(f"c-{value}", cell, value, source=f"source-{value}")
+        for value in range(per_cell)
+    ]
+    path = tmp_path / "pool.tsv"
+    write_tsv(path, CANDIDATE_REQUIRED_COLUMNS, rows)
+    _columns, candidates, _artifact = load_candidates(path)
+    selected, _ = select_candidates(
+        candidates, {cell: per_cell}, source_cap_fraction=1.0
+    )
+    components, _ = assign_component_folds(selected, {cell: per_cell}, folds=5)
+    counts = [sum(component.fold == fold for component in components) for fold in range(5)]
+    assert max(counts) - min(counts) <= 1
+    components, nested, _ = assign_nested_inner_folds(
+        components, outer_folds=5, inner_folds=3
+    )
+    assert len(nested) == len(components) * 5
+    for outer_fold in range(5):
+        records = [row for row in nested if row["outer_fold"] == outer_fold]
+        assert {row["component_id"] for row in records} == {
+            component.component_id for component in components
+        }
+        assert all(
+            (row["partition"] == "held") == (
+                next(
+                    component.fold for component in components
+                    if component.component_id == row["component_id"]
+                ) == outer_fold
+            )
+            for row in records
+        )
+
+
+def test_response_ingestion_joins_by_keys_and_preserves_retries():
+    common = {
+        "judge": "judge-a",
+        "model_id": "model-a",
+        "model_revision": "revision-1",
+        "prompt_sha256": "a" * 64,
+        "settings_sha256": "b" * 64,
+    }
+    schedule = [
+        {"request_id": "request-a", "row_id": "row-a", **common},
+        {"request_id": "request-b", "row_id": "row-b", **common},
+    ]
+
+    def success(request_id, row_id, score, attempt=0):
+        raw = f'{{"D": {score}, "S": {score}}}'
+        return {
+            "request_id": request_id,
+            "row_id": row_id,
+            "attempt": str(attempt),
+            "provider_request_id": f"provider-{request_id}-{attempt}",
+            "provider_response_id": f"response-{request_id}-{attempt}",
+            "started_at_utc": "2026-01-01T00:00:00Z",
+            "completed_at_utc": "2026-01-01T00:00:01Z",
+            "status": "success",
+            **common,
+            "raw_response_sha256": sha256_bytes(raw.encode()),
+            "raw_response": raw,
+            "score_d": str(score),
+            "score_s": str(score),
+            "error_type": "",
+            "parse_status": "parsed",
+            "parse_error_type": "",
+        }
+
+    retry = {
+        "request_id": "request-a",
+        "row_id": "row-a",
+        "attempt": "0",
+        "provider_request_id": "provider-request-a-0",
+        "provider_response_id": "",
+        "started_at_utc": "2026-01-01T00:00:00Z",
+        "completed_at_utc": "2026-01-01T00:00:30Z",
+        "status": "retryable_failure",
+        **common,
+        "raw_response_sha256": "",
+        "raw_response": "",
+        "score_d": "",
+        "score_s": "",
+        "error_type": "timeout",
+        "parse_status": "",
+        "parse_error_type": "",
+    }
+    responses = [
+        success("request-b", "row-b", 0.4),
+        retry,
+        success("request-a", "row-a", 0.5, attempt=1),
+    ]
+    assert validate_response_records(schedule, responses) == {
+        "scheduled_rows": 2,
+        "response_attempts": 3,
+        "successful_rows": 2,
+        "terminal_failure_rows": 0,
+        "retry_attempts": 1,
+        "provider_call_attempts": 3,
+        "retry_call_attempts": 1,
+        "parsed_rows": 2,
+        "parse_failure_rows": 0,
+    }
+    bad = [dict(record) for record in responses]
+    bad[0]["model_revision"] = "wrong"
+    with pytest.raises(CampaignInputError, match="immutable model_revision"):
+        validate_response_records(schedule, bad)
+
+    terminal = {
+        "request_id": "request-b",
+        "row_id": "row-b",
+        "attempt": "0",
+        "provider_request_id": "provider-request-b-0",
+        "provider_response_id": "",
+        "started_at_utc": "2026-01-01T00:00:00Z",
+        "completed_at_utc": "2026-01-01T00:00:30Z",
+        "status": "terminal_failure",
+        **common,
+        "raw_response_sha256": "",
+        "raw_response": "",
+        "score_d": "",
+        "score_s": "",
+        "error_type": "provider_rejected",
+        "parse_status": "",
+        "parse_error_type": "",
+    }
+    terminal_summary = validate_response_records(
+        schedule, [retry, success("request-a", "row-a", 0.5, attempt=1), terminal]
+    )
+    assert terminal_summary["successful_rows"] == 1
+    assert terminal_summary["terminal_failure_rows"] == 1
+
+
+def test_source_dependency_groups_are_atomic_across_outer_and_inner_folds(tmp_path):
+    cells = (
+        ("exploratory", "h1-h2", "q1", "agreement"),
+        ("exploratory", "h1-h2", "q1", "disagreement"),
+    )
+    records = []
+    base = 0
+    for cell_index, cell in enumerate(cells):
+        for source in ("shared-a", "shared-b", f"unique-{cell_index}-a", f"unique-{cell_index}-b"):
+            records.append(candidate_record(f"c-{base}", cell, base, source=source))
+            base += 1
+    path = tmp_path / "atomic.tsv"
+    write_tsv(path, CANDIDATE_REQUIRED_COLUMNS, records)
+    _columns, candidates, _artifact = load_candidates(path)
+    quotas = {cell: 4 for cell in cells}
+    selected, _ = select_candidates(candidates, quotas, source_cap_fraction=1.0)
+    outer, _ = assign_component_folds(selected, quotas, folds=2, seed=51)
+    outer_by_source = defaultdict(set)
+    for component in outer:
+        outer_by_source[(component.corpus, component.source_component)].add(component.fold)
+    assert all(len(folds) == 1 for folds in outer_by_source.values())
+
+    nested_components, _nested, _ = assign_nested_inner_folds(
+        outer, outer_folds=2, inner_folds=2, seed=52
+    )
+    inner_by_source = defaultdict(set)
+    for component in nested_components:
+        inner_by_source[(component.corpus, component.source_component)].add(
+            component.inner_fold
+        )
+    assert all(len(folds) == 1 for folds in inner_by_source.values())
+
+    infeasible = [
+        candidate_record(f"bad-{value}", cells[0], 100 + value, source=(
+            "oversized" if value < 3 else "singleton"
+        ))
+        for value in range(4)
+    ]
+    write_tsv(path, CANDIDATE_REQUIRED_COLUMNS, infeasible)
+    _columns, bad_candidates, _artifact = load_candidates(path)
+    bad_selected, _ = select_candidates(
+        bad_candidates, {cells[0]: 4}, source_cap_fraction=1.0
+    )
+    with pytest.raises(CampaignInputError, match="atomic source group"):
+        assign_component_folds(bad_selected, {cells[0]: 4}, folds=2)
+
+
+def test_batched_response_attempts_have_common_provider_identity_and_contiguous_retries():
+    immutable = {
+        "judge": "judge-a",
+        "model_id": "model-a",
+        "model_revision": "revision-1",
+        "prompt_sha256": "a" * 64,
+        "settings_sha256": "b" * 64,
+    }
+    schedule = [
+        {"request_id": "request-batch", "row_id": row_id, **immutable}
+        for row_id in ("row-a", "row-b")
+    ]
+    raw = '{"rows":[{"D":0.1,"S":0.2},{"D":0.3,"S":0.4}]}'
+    responses = []
+    for row_id, score in (("row-a", "0.1"), ("row-b", "0.3")):
+        responses.append({
+            "request_id": "request-batch",
+            "row_id": row_id,
+            "attempt": "0",
+            "provider_request_id": "provider-call-0",
+            "provider_response_id": "provider-response-0",
+            "started_at_utc": "2026-01-01T00:00:00Z",
+            "completed_at_utc": "2026-01-01T00:00:01Z",
+            "status": "success",
+            **immutable,
+            "raw_response_sha256": sha256_bytes(raw.encode()),
+            "raw_response": raw,
+            "score_d": score,
+            "score_s": score,
+            "error_type": "",
+            "parse_status": "parsed",
+            "parse_error_type": "",
+        })
+    assert validate_response_records(schedule, responses)["provider_call_attempts"] == 1
+
+    inconsistent = [dict(record) for record in responses]
+    inconsistent[1]["completed_at_utc"] = "2026-01-01T00:00:02Z"
+    with pytest.raises(CampaignInputError, match="inconsistent provider completed_at_utc"):
+        validate_response_records(schedule, inconsistent)
+
+    skipped_zero = [dict(record, attempt="1") for record in responses]
+    with pytest.raises(CampaignInputError, match="contiguous from zero"):
+        validate_response_records(schedule, skipped_zero)

--- a/prototypes/mu_cosine/test_repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/test_repeated_judge_campaign.py
@@ -197,6 +197,20 @@ def test_historical_filter_selection_folds_and_schedule_are_deterministic(tmp_pa
         request_blocks[(record["prompt_block_id"], record["role"])].add(record["component_id"])
     assert all(len(values) == 1 for values in request_signatures.values())
     assert all(record["prompt_block_id"] == record["inference_cluster_id"] for record in schedule)
+    assert all(len(record["request_input_sha256"]) == 64 for record in schedule)
+
+    positions = defaultdict(Counter)
+    batch_sizes = {}
+    for record in schedule:
+        key = (
+            record["prompt_block_id"], record["component_id"],
+            record["role"], record["judge"],
+        )
+        positions[key][record["batch_row"]] += 1
+        batch_sizes[key] = record["batch_size"]
+    for key, counts in positions.items():
+        values = [counts[position] for position in range(batch_sizes[key])]
+        assert max(values) - min(values) <= 1
 
     changed_specs = judge_specs()
     changed_specs["judge-a"]["model_revision"] = "revision-2"
@@ -210,6 +224,21 @@ def test_historical_filter_selection_folds_and_schedule_are_deterministic(tmp_pa
     )
     assert {record["request_id"] for record in schedule}.isdisjoint(
         {record["request_id"] for record in changed_schedule}
+    )
+    presentation_changed = [dict(row) for row in rows]
+    for row in presentation_changed:
+        row["node_title"] = row["node_title"].upper()
+        row["root_title"] = row["root_title"].upper()
+    presentation_schedule, _ = build_scoring_schedule(
+        presentation_changed,
+        judges=("judge-a",),
+        repeats=3,
+        batch_size=2,
+        seed=23,
+        judge_specs=judge_specs(),
+    )
+    assert {record["request_id"] for record in schedule}.isdisjoint(
+        {record["request_id"] for record in presentation_schedule}
     )
     seeded_specs = judge_specs()
     seeded_specs["judge-a"]["call_seed_base"] = 7
@@ -432,6 +461,20 @@ def test_response_ingestion_joins_by_keys_and_preserves_retries():
     bad[0]["model_revision"] = "wrong"
     with pytest.raises(CampaignInputError, match="immutable model_revision"):
         validate_response_records(schedule, bad)
+
+    reused_provider_request = [dict(record) for record in responses]
+    reused_provider_request[2]["provider_request_id"] = reused_provider_request[0][
+        "provider_request_id"
+    ]
+    with pytest.raises(CampaignInputError, match="provider_request_id.*reused"):
+        validate_response_records(schedule, reused_provider_request)
+
+    reused_provider_response = [dict(record) for record in responses]
+    reused_provider_response[2]["provider_response_id"] = reused_provider_response[0][
+        "provider_response_id"
+    ]
+    with pytest.raises(CampaignInputError, match="provider_response_id.*reused"):
+        validate_response_records(schedule, reused_provider_response)
 
     terminal = {
         "request_id": "request-b",

--- a/prototypes/mu_cosine/test_repeated_judge_power.py
+++ b/prototypes/mu_cosine/test_repeated_judge_power.py
@@ -1,0 +1,382 @@
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from repeated_judge_power import (
+    BLOCK_CANDIDATE,
+    CALL_CHANNEL_COVARIANCE,
+    DEFAULT_GAMMAS,
+    DEFAULT_MEAN_RIDGES,
+    DEFAULT_RHOS,
+    MAX_PROMPT_ROWS,
+    REQUEST_CHANNEL_COVARIANCE,
+    Candidate,
+    CandidateSummary,
+    InnerSearch,
+    SCENARIOS,
+    SCENARIO_BY_NAME,
+    build_campaign_geometry,
+    calibrate_synthetic_selector_null,
+    candidate_covariance,
+    candidate_grid,
+    component_gaussian_nll,
+    component_splits,
+    deranged_item_kernel,
+    draw_latent_states,
+    draw_repeated_field,
+    explicit_item_kernels,
+    finite_null_maximum_threshold,
+    fit_repeat_nuisance,
+    gamma_item_kernel,
+    inner_candidate_search,
+    maximum_off_diagonal,
+    posterior_state_nll,
+    prompt_block_candidate_covariance,
+    prompt_block_gaussian_nll,
+    prompt_block_multiplier_simultaneous_lower_bounds,
+    prompt_block_posterior_state_nll,
+    rho_matched_correlation,
+    run_power_replicate,
+    select_strictly_calibrated,
+)
+
+
+def geometry_and_splits(component_count=48, seed=1):
+    splits = component_splits(component_count, seed=seed)
+    geometry = build_campaign_geometry(
+        component_count, seed=seed + 1, prompt_blocks=splits.prompt_blocks
+    )
+    return geometry, splits
+
+
+def test_frozen_grids_scenarios_and_psd_geometry_are_exact():
+    assert DEFAULT_GAMMAS == (0.0, 0.25, 0.50, 0.75, 1.0)
+    assert DEFAULT_RHOS == (0.0, 0.025, 0.05, 0.10, 0.20)
+    assert DEFAULT_MEAN_RIDGES == (0.0, 0.01, 0.10, 1.0, 10.0)
+    expected_scenarios = ["block_null", "mean_only"] + [
+        f"{family}_rho_{rho}"
+        for family in ("cumulative", "nomic", "mixture", "deranged")
+        for rho in ("0.04", "0.10", "0.20")
+    ]
+    assert [scenario.name for scenario in SCENARIOS] == expected_scenarios
+    grid = candidate_grid()
+    assert len(grid) == 1 + len(DEFAULT_GAMMAS) * (len(DEFAULT_RHOS) - 1)
+    assert grid[0] == BLOCK_CANDIDATE
+
+    kernels = explicit_item_kernels()
+    for name in ("cumulative", "nomic", "deranged_cumulative"):
+        kernel = kernels[name]
+        assert np.allclose(kernel, kernel.T)
+        assert np.allclose(np.diag(kernel), 1.0)
+        assert np.linalg.eigvalsh(kernel)[0] >= -1e-12
+    assert not np.allclose(kernels["cumulative"], kernels["nomic"])
+    assert np.allclose(
+        np.linalg.eigvalsh(kernels["cumulative"]),
+        np.linalg.eigvalsh(kernels["deranged_cumulative"]),
+    )
+
+
+def test_rho_matched_path_has_requested_maximum_and_is_spd():
+    for gamma in DEFAULT_GAMMAS:
+        kernel = gamma_item_kernel(gamma)
+        for rho in DEFAULT_RHOS:
+            correlation = rho_matched_correlation(kernel, rho)
+            assert np.allclose(np.diag(correlation), 1.0)
+            assert np.linalg.eigvalsh(correlation)[0] > 0.0
+            assert np.isclose(maximum_off_diagonal(correlation), rho)
+    with pytest.raises(ValueError, match="0.95"):
+        rho_matched_correlation(np.full((3, 3), 1.0), 0.96)
+
+
+def test_prompt_blocks_are_bounded_stable_and_never_cross_split_signatures():
+    _geometry, splits = geometry_and_splits(160, seed=123)
+    assert len(splits.outer) == 5
+    assert np.ptp([len(fold.held) for fold in splits.outer]) <= 1
+    assert sorted(np.concatenate([fold.held for fold in splits.outer]).tolist()) == list(range(160))
+    assert max(map(len, splits.prompt_blocks)) <= MAX_PROMPT_ROWS
+    for block in splits.prompt_blocks:
+        assert len(set(splits.outer_label[block])) == 1
+        assert len(set(splits.inner_label[block])) == 1
+    for fold in splits.outer:
+        assert not set(fold.train) & set(fold.held)
+        train_blocks = set(splits.prompt_block_index[fold.train])
+        held_blocks = set(splits.prompt_block_index[fold.held])
+        assert not train_blocks & held_blocks
+        # With five equal G=160 outer folds and one stable global three-way
+        # inner label, a <=1 leave-one-outer margin is combinatorially
+        # impossible for every outer fold; the deterministic optimum is 2.
+        assert np.ptp([len(held) for _fit, held in fold.inner]) <= 2
+        for fit, held in fold.inner:
+            assert not set(fit) & set(held)
+            assert set(fit) | set(held) == set(fold.train)
+            assert not (
+                set(splits.prompt_block_index[fit])
+                & set(splits.prompt_block_index[held])
+            )
+    changed = component_splits(160, seed=124)
+    assert not np.array_equal(splits.prompt_block_index, changed.prompt_block_index)
+
+
+def test_repeat_generator_has_request_level_missingness_and_is_deterministic():
+    geometry, _splits = geometry_and_splits(64, seed=14)
+    scenario = SCENARIO_BY_NAME["cumulative_rho_0.20"]
+    first = draw_repeated_field(geometry, scenario, repeats=4, seed=702)
+    second = draw_repeated_field(geometry, scenario, repeats=4, seed=702)
+    np.testing.assert_allclose(first, second, equal_nan=True)
+    for block in geometry.prompt_blocks:
+        for row in range(3):
+            for repeat in range(4):
+                for start in (0, 2):
+                    observed = np.isfinite(first[block, row, repeat, start])
+                    assert np.all(observed == observed[0])
+        counts = np.stack([
+            np.sum(np.isfinite(first[block, ..., start]), axis=2)
+            for start in (0, 2)
+        ], axis=-1)
+        assert np.min(counts) >= 2
+
+
+def test_request_and_row_call_moments_are_separately_refit():
+    component_count = 600
+    geometry = build_campaign_geometry(component_count, seed=91)
+    field = draw_repeated_field(
+        geometry,
+        SCENARIO_BY_NAME["block_null"],
+        repeats=4,
+        seed=92,
+        missing_rate=0.0,
+        include_wave_effect=False,
+    )
+    nuisance = fit_repeat_nuisance(
+        field, geometry, np.arange(component_count), np.arange(20)
+    )
+    assert np.allclose(
+        nuisance.request_covariance,
+        REQUEST_CHANNEL_COVARIANCE,
+        atol=0.035,
+    )
+    assert np.allclose(nuisance.call_covariance, CALL_CHANNEL_COVARIANCE, atol=0.055)
+    assert np.linalg.eigvalsh(nuisance.request_covariance)[0] > 0.0
+    assert np.linalg.eigvalsh(nuisance.call_covariance)[0] > 0.0
+
+
+def test_nuisance_refit_uses_only_training_prompt_blocks():
+    geometry, splits = geometry_and_splits(80, seed=20)
+    field = draw_repeated_field(
+        geometry, SCENARIO_BY_NAME["cumulative_rho_0.10"], repeats=4, seed=22
+    )
+    fold = splits.outer[0]
+    fitted = fit_repeat_nuisance(field, geometry, fold.train, fold.held)
+    changed = field.copy()
+    changed[fold.held] += 100.0
+    refitted = fit_repeat_nuisance(changed, geometry, fold.train, fold.held)
+    for name in (
+        "coefficients",
+        "wave_effects",
+        "call_covariance",
+        "request_covariance",
+        "persistent_covariance",
+    ):
+        assert np.array_equal(getattr(fitted, name), getattr(refitted, name))
+    assert fitted.selected_mean_ridge in DEFAULT_MEAN_RIDGES
+    assert not np.array_equal(
+        fitted.evaluate_centered_means, refitted.evaluate_centered_means
+    )
+
+
+def test_candidate_marginal_and_prompt_schedule_covariances_are_both_present():
+    geometry, splits = geometry_and_splits(80, seed=30)
+    field = draw_repeated_field(
+        geometry, SCENARIO_BY_NAME["block_null"], repeats=3, seed=31
+    )
+    fold = splits.outer[0]
+    nuisance = fit_repeat_nuisance(field, geometry, fold.train, fold.held)
+    covariance = candidate_covariance(
+        nuisance, gamma_item_kernel(0.5, geometry.kernels), 0.10
+    )
+    assert covariance.shape == (len(fold.held), 12, 12)
+    row, family = 0, 0
+    start = row * 4 + family * 2
+    count = nuisance.evaluate_repeat_counts[0, row, family]
+    expected = (
+        nuisance.persistent_covariance[:2, :2]
+        + nuisance.repeat_covariance[:2, :2] / count
+    )
+    assert np.allclose(covariance[0, start:start + 2, start:start + 2], expected)
+
+    held_blocks = geometry.prompt_block_index[fold.held]
+    positions = np.flatnonzero(held_blocks == held_blocks[0])
+    assert len(positions) >= 2
+    joint = prompt_block_candidate_covariance(
+        nuisance, gamma_item_kernel(0.5, geometry.kernels), 0.0, positions
+    )
+    overlap = np.sum(
+        nuisance.evaluate_observed_calls[positions[0], row, :, family]
+        & nuisance.evaluate_observed_calls[positions[1], row, :, family]
+    )
+    coefficient = overlap / (
+        nuisance.evaluate_repeat_counts[positions[0], row, family]
+        * nuisance.evaluate_repeat_counts[positions[1], row, family]
+    )
+    cross = joint[start:start + 2, 12 + start:12 + start + 2]
+    assert np.allclose(cross, nuisance.request_covariance[:2, :2] * coefficient)
+    assert np.max(np.abs(cross)) > 0.0
+
+
+def test_component_nll_matches_direct_dense_formula():
+    rng = np.random.default_rng(33)
+    residuals = rng.standard_normal((4, 3, 4))
+    base = rng.standard_normal((12, 12))
+    covariance = base @ base.T + np.eye(12)
+    observed = component_gaussian_nll(residuals, covariance)
+    vector = residuals[0].reshape(-1)
+    sign, logdet = np.linalg.slogdet(covariance)
+    expected = 0.5 * (
+        vector @ np.linalg.solve(covariance, vector)
+        + logdet
+        + len(vector) * np.log(2.0 * np.pi)
+    ) / len(vector)
+    assert sign > 0
+    assert np.isclose(observed[0], expected)
+
+
+def test_primary_posterior_endpoint_is_not_a_duplicate_residual_score():
+    geometry, splits = geometry_and_splits(64, seed=40)
+    field = draw_repeated_field(
+        geometry, SCENARIO_BY_NAME["cumulative_rho_0.10"], repeats=3, seed=41
+    )
+    fold = splits.outer[0]
+    nuisance = fit_repeat_nuisance(field, geometry, fold.train, fold.held)
+    blocks = geometry.prompt_block_index[fold.held]
+    kernel = gamma_item_kernel(1.0, geometry.kernels)
+    residual_nll = prompt_block_gaussian_nll(
+        nuisance.evaluate_centered_means, nuisance, kernel, 0.10, blocks
+    )
+    states = draw_latent_states(len(fold.held), seed=42)
+    posterior_nll = prompt_block_posterior_state_nll(
+        nuisance.evaluate_centered_means, nuisance, kernel, 0.10, states, blocks
+    )
+    changed_states = states + 0.5
+    changed_posterior = prompt_block_posterior_state_nll(
+        nuisance.evaluate_centered_means,
+        nuisance,
+        kernel,
+        0.10,
+        changed_states,
+        blocks,
+    )
+    assert np.isfinite(residual_nll).all()
+    assert np.isfinite(posterior_nll).all()
+    assert not np.allclose(residual_nll, posterior_nll)
+    assert not np.allclose(posterior_nll, changed_posterior)
+
+
+def test_inner_search_uses_complete_grid_three_folds_and_frozen_tie_break():
+    geometry, splits = geometry_and_splits(48, seed=50)
+    field = draw_repeated_field(
+        geometry, SCENARIO_BY_NAME["cumulative_rho_0.10"], repeats=3, seed=51
+    )
+    search = inner_candidate_search(field, geometry, splits.outer[0])
+    assert len(search.summaries) == 21
+    assert all(len(row.fold_gains) == 3 for row in search.summaries)
+    # Exact tie order: lower rho, then gamma nearer .5, then lower gamma.
+    summaries = [
+        CandidateSummary(Candidate(0.0, 0.10), 1.0, 2, (1.0, 1.0, -1.0)),
+        CandidateSummary(Candidate(0.5, 0.10), 1.0, 2, (1.0, 1.0, -1.0)),
+        CandidateSummary(Candidate(0.5, 0.05), 1.0, 2, (1.0, 1.0, -1.0)),
+    ]
+    chosen = min(summaries, key=lambda row: (
+        -row.macro_gain,
+        row.candidate.rho,
+        abs(row.candidate.gamma - 0.5),
+        row.candidate.gamma,
+    ))
+    assert chosen.candidate == Candidate(0.5, 0.05)
+
+
+def test_prompt_block_multiplier_uses_clusters_and_constant_bounds_are_exact():
+    values = np.tile([0.1, 0.2], (20, 1))
+    block_ids = np.repeat(np.arange(4), 5)
+    lower, critical, clusters = prompt_block_multiplier_simultaneous_lower_bounds(
+        values, block_ids, draws=99, seed=60
+    )
+    assert clusters == 4
+    assert np.allclose(lower, [0.1, 0.2])
+    assert np.isfinite(critical)
+    with pytest.raises(ValueError, match="two independent prompt blocks"):
+        prompt_block_multiplier_simultaneous_lower_bounds(
+            values, np.zeros(20, dtype=int), draws=9
+        )
+
+
+def test_finite_null_threshold_and_strict_rejection_boundary():
+    threshold, rank = finite_null_maximum_threshold(np.arange(20.0), confidence=0.95)
+    assert rank == 20
+    assert threshold == 19.0
+    candidate = Candidate(1.0, 0.1)
+    row = CandidateSummary(candidate, 19.0, 3, (19.0, 19.0, 19.0))
+    search = InnerSearch(candidate, (row,), 19.0)
+    selected, rejected = select_strictly_calibrated(search, threshold)
+    assert selected == BLOCK_CANDIDATE
+    assert not rejected
+    stronger = InnerSearch(candidate, (row,), np.nextafter(19.0, np.inf))
+    selected, rejected = select_strictly_calibrated(stronger, threshold)
+    assert selected == candidate
+    assert rejected
+
+
+def test_tiny_null_and_power_runs_are_deterministic_and_regenerate_designs():
+    null_first = calibrate_synthetic_selector_null(
+        32,
+        repeats=3,
+        draws=2,
+        seed=70,
+        gammas=(0.0, 1.0),
+        rhos=(0.0, 0.10),
+        mean_ridges=(0.0, 0.1),
+        missing_rate=0.0,
+    )
+    null_second = calibrate_synthetic_selector_null(
+        32,
+        repeats=3,
+        draws=2,
+        seed=70,
+        gammas=(0.0, 1.0),
+        rhos=(0.0, 0.10),
+        mean_ridges=(0.0, 0.1),
+        missing_rate=0.0,
+    )
+    np.testing.assert_array_equal(null_first[0], null_second[0])
+    assert null_first[1:] == null_second[1:]
+    record = run_power_replicate(
+        32,
+        SCENARIO_BY_NAME["cumulative_rho_0.10"],
+        repeats=3,
+        seed=71,
+        null_threshold=null_first[1],
+        gammas=(0.0, 1.0),
+        rhos=(0.0, 0.10),
+        mean_ridges=(0.0, 0.1),
+        multiplier_draws=19,
+        missing_rate=0.0,
+    )
+    repeated = run_power_replicate(
+        32,
+        SCENARIO_BY_NAME["cumulative_rho_0.10"],
+        repeats=3,
+        seed=71,
+        null_threshold=null_first[1],
+        gammas=(0.0, 1.0),
+        rhos=(0.0, 0.10),
+        mean_ridges=(0.0, 0.1),
+        multiplier_draws=19,
+        missing_rate=0.0,
+    )
+    np.testing.assert_array_equal(record.endpoint_component_gains, repeated.endpoint_component_gains)
+    assert record.selected == repeated.selected
+    assert record.endpoint_component_gains.shape == (2, 32, 2)
+    assert len(record.inference_prompt_blocks) == 2
+    assert max(record.inference_prompt_blocks) < 32

--- a/prototypes/mu_cosine/test_repeated_judge_power.py
+++ b/prototypes/mu_cosine/test_repeated_judge_power.py
@@ -1,10 +1,12 @@
 import os
 import sys
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import repeated_judge_power as power
 from repeated_judge_power import (
     BLOCK_CANDIDATE,
     CALL_CHANNEL_COVARIANCE,
@@ -50,6 +52,66 @@ def geometry_and_splits(component_count=48, seed=1):
         component_count, seed=seed + 1, prompt_blocks=splits.prompt_blocks
     )
     return geometry, splits
+
+
+def shared_varying_schedule(component_count):
+    shared = np.zeros((3, 5, 2), dtype=bool)
+    shared[0, :, 0] = True
+    shared[0, :4, 1] = True
+    shared[1, (0, 2, 4), 0] = True
+    shared[1, :, 1] = True
+    shared[2, :4, 0] = True
+    shared[2, :2, 1] = True
+    return np.repeat(shared[None], component_count, axis=0)
+
+
+def score_only_nuisance(observed):
+    counts = np.sum(observed, axis=2)
+    return SimpleNamespace(
+        persistent_covariance=power.PERSISTENT_CHANNEL_COVARIANCE.copy(),
+        call_covariance=CALL_CHANNEL_COVARIANCE.copy(),
+        request_covariance=REQUEST_CHANNEL_COVARIANCE.copy(),
+        repeat_covariance=(
+            CALL_CHANNEL_COVARIANCE + REQUEST_CHANNEL_COVARIANCE
+        ),
+        evaluate_repeat_counts=counts,
+        evaluate_observed_calls=observed,
+    )
+
+
+def dense_prompt_score_reference(residuals, nuisance, kernel, rho, states):
+    positions = np.arange(len(residuals))
+    covariance = prompt_block_candidate_covariance(
+        nuisance, kernel, rho, positions
+    )
+    residual_vector = residuals.reshape(-1)
+    residual_score = 0.5 * (
+        residual_vector @ np.linalg.solve(covariance, residual_vector)
+        + np.linalg.slogdet(covariance)[1]
+        + len(residual_vector) * np.log(2.0 * np.pi)
+    ) / len(residual_vector)
+
+    component_design = np.kron(np.eye(3), power.MEASUREMENT_DESIGN)
+    component_prior = np.kron(
+        np.eye(3), power.PRIOR_STATE_COVARIANCE
+    )
+    design = np.kron(np.eye(len(residuals)), component_design)
+    prior = np.kron(np.eye(len(residuals)), component_prior)
+    truth = states.reshape(-1)
+    observed = design @ truth + residual_vector
+    solved_design = np.linalg.solve(covariance, design)
+    precision = np.linalg.solve(prior, np.eye(len(prior))) + design.T @ solved_design
+    posterior_covariance = np.linalg.solve(precision, np.eye(len(precision)))
+    posterior_mean = posterior_covariance @ (
+        design.T @ np.linalg.solve(covariance, observed)
+    )
+    delta = truth - posterior_mean
+    posterior_score = 0.5 * (
+        delta @ precision @ delta
+        + np.linalg.slogdet(posterior_covariance)[1]
+        + len(delta) * np.log(2.0 * np.pi)
+    ) / len(delta)
+    return residual_score, posterior_score
 
 
 def test_frozen_grids_scenarios_and_psd_geometry_are_exact():
@@ -226,6 +288,143 @@ def test_candidate_marginal_and_prompt_schedule_covariances_are_both_present():
     assert np.max(np.abs(cross)) > 0.0
 
 
+@pytest.mark.parametrize("component_count", [1, 2, 10])
+def test_compound_symmetric_fast_scores_match_dense_for_shared_varying_counts(
+    component_count,
+    monkeypatch,
+):
+    observed = shared_varying_schedule(component_count)
+    nuisance = score_only_nuisance(observed)
+    rng = np.random.default_rng(3100 + component_count)
+    residuals = rng.standard_normal((component_count, 3, 4))
+    states = rng.standard_normal((component_count, 3, 2))
+    blocks = np.zeros(component_count, dtype=int)
+    kernel = gamma_item_kernel(0.75)
+    rho = 0.10
+    dense_residual, dense_posterior = dense_prompt_score_reference(
+        residuals, nuisance, kernel, rho, states
+    )
+
+    def forbidden_dense_fallback(*_args, **_kwargs):
+        raise AssertionError("exchangeable schedule used the dense fallback")
+
+    monkeypatch.setattr(
+        power, "_dense_prompt_block_gaussian_score", forbidden_dense_fallback
+    )
+    monkeypatch.setattr(
+        power,
+        "_dense_prompt_block_posterior_state_score",
+        forbidden_dense_fallback,
+    )
+    fast_residual = prompt_block_gaussian_nll(
+        residuals, nuisance, kernel, rho, blocks
+    )
+    fast_posterior = prompt_block_posterior_state_nll(
+        residuals, nuisance, kernel, rho, states, blocks
+    )
+    np.testing.assert_allclose(
+        fast_residual,
+        np.full(component_count, dense_residual),
+        rtol=2e-12,
+        atol=2e-12,
+    )
+    np.testing.assert_allclose(
+        fast_posterior,
+        np.full(component_count, dense_posterior),
+        rtol=2e-12,
+        atol=2e-12,
+    )
+
+
+@pytest.mark.parametrize("schedule_case", ["unequal_counts", "different_schedule"])
+def test_nonexchangeable_schedules_use_dense_fallback_and_remain_exact(
+    schedule_case,
+    monkeypatch,
+):
+    observed = shared_varying_schedule(3)
+    if schedule_case == "unequal_counts":
+        observed[1, 0, 4, 0] = False
+    else:
+        # Preserve the count while changing which repeat was recorded.  With
+        # three components this creates nonconstant pairwise overlaps.
+        observed[1, 0, 0, 1] = False
+        observed[1, 0, 4, 1] = True
+    nuisance = score_only_nuisance(observed)
+    rng = np.random.default_rng(3200 + int(schedule_case == "different_schedule"))
+    residuals = rng.standard_normal((3, 3, 4))
+    states = rng.standard_normal((3, 3, 2))
+    blocks = np.zeros(3, dtype=int)
+    kernel = gamma_item_kernel(0.25)
+    rho = 0.05
+    dense_residual, dense_posterior = dense_prompt_score_reference(
+        residuals, nuisance, kernel, rho, states
+    )
+    assert power._exchangeable_prompt_schedule(nuisance, np.arange(3)) is None
+
+    fallback_calls = {"residual": 0, "posterior": 0}
+    original_residual = power._dense_prompt_block_gaussian_score
+    original_posterior = power._dense_prompt_block_posterior_state_score
+
+    def residual_spy(*args, **kwargs):
+        fallback_calls["residual"] += 1
+        return original_residual(*args, **kwargs)
+
+    def posterior_spy(*args, **kwargs):
+        fallback_calls["posterior"] += 1
+        return original_posterior(*args, **kwargs)
+
+    monkeypatch.setattr(power, "_dense_prompt_block_gaussian_score", residual_spy)
+    monkeypatch.setattr(
+        power, "_dense_prompt_block_posterior_state_score", posterior_spy
+    )
+    actual_residual = prompt_block_gaussian_nll(
+        residuals, nuisance, kernel, rho, blocks
+    )
+    actual_posterior = prompt_block_posterior_state_nll(
+        residuals, nuisance, kernel, rho, states, blocks
+    )
+    assert fallback_calls == {"residual": 1, "posterior": 1}
+    np.testing.assert_allclose(
+        actual_residual, np.full(3, dense_residual), rtol=2e-12, atol=2e-12
+    )
+    np.testing.assert_allclose(
+        actual_posterior, np.full(3, dense_posterior), rtol=2e-12, atol=2e-12
+    )
+
+
+def test_exchangeable_mode_factorizations_are_cached_by_exact_signature(monkeypatch):
+    observed = shared_varying_schedule(4)
+    nuisance = score_only_nuisance(observed)
+    rng = np.random.default_rng(3300)
+    residuals = rng.standard_normal((4, 3, 4))
+    states = rng.standard_normal((4, 3, 2))
+    blocks = np.repeat(np.arange(2), 2)
+    kernel = gamma_item_kernel(0.5)
+    calls = {"residual": 0, "posterior": 0}
+    original_residual = power._factor_compound_symmetric_gaussian_modes
+    original_posterior = power._factor_compound_symmetric_posterior_modes
+
+    def residual_spy(*args, **kwargs):
+        calls["residual"] += 1
+        return original_residual(*args, **kwargs)
+
+    def posterior_spy(*args, **kwargs):
+        calls["posterior"] += 1
+        return original_posterior(*args, **kwargs)
+
+    monkeypatch.setattr(
+        power, "_factor_compound_symmetric_gaussian_modes", residual_spy
+    )
+    monkeypatch.setattr(
+        power, "_factor_compound_symmetric_posterior_modes", posterior_spy
+    )
+    prompt_block_gaussian_nll(residuals, nuisance, kernel, 0.10, blocks)
+    prompt_block_posterior_state_nll(
+        residuals, nuisance, kernel, 0.10, states, blocks
+    )
+    assert calls == {"residual": 1, "posterior": 1}
+
+
 def test_component_nll_matches_direct_dense_formula():
     rng = np.random.default_rng(33)
     residuals = rng.standard_normal((4, 3, 4))
@@ -295,6 +494,120 @@ def test_inner_search_uses_complete_grid_three_folds_and_frozen_tie_break():
         row.candidate.gamma,
     ))
     assert chosen.candidate == Candidate(0.5, 0.05)
+
+
+def test_inner_search_recomputes_dense_before_a_last_bit_zero_decision(monkeypatch):
+    geometry, splits = geometry_and_splits(36, seed=61)
+    field = draw_repeated_field(
+        geometry, SCENARIO_BY_NAME["block_null"], repeats=3, seed=62
+    )
+    tolerance = power.DENSE_DECISION_RECHECK_ATOL
+    dense_calls = 0
+
+    def fast_score(residuals, _nuisance, _kernel, rho, _blocks):
+        value = -0.5 * tolerance if rho > 0.0 else 0.0
+        return np.full(len(residuals), value)
+
+    def dense_score(residuals, _nuisance, _kernel, rho, _blocks):
+        nonlocal dense_calls
+        dense_calls += 1
+        value = 0.5 * tolerance if rho > 0.0 else 0.0
+        return np.full(len(residuals), value)
+
+    monkeypatch.setattr(power, "prompt_block_gaussian_nll", fast_score)
+    monkeypatch.setattr(power, "_dense_prompt_block_gaussian_nll", dense_score)
+    search = inner_candidate_search(
+        field,
+        geometry,
+        splits.outer[0],
+        gammas=(0.5,),
+        rhos=(0.0, 0.10),
+    )
+    candidate_summary = next(
+        row for row in search.summaries if not row.candidate.is_block
+    )
+    assert dense_calls == 6  # block and candidate in each of three folds
+    assert candidate_summary.fold_gains == pytest.approx(
+        (-0.5 * tolerance,) * 3
+    )
+    assert candidate_summary.positive_folds == 0
+    assert search.selected == BLOCK_CANDIDATE
+
+
+def test_dense_zero_guard_is_a_trigger_not_a_changed_threshold(monkeypatch):
+    geometry, splits = geometry_and_splits(36, seed=63)
+    field = draw_repeated_field(
+        geometry, SCENARIO_BY_NAME["block_null"], repeats=3, seed=64
+    )
+    gain = 2.0 * power.DENSE_DECISION_RECHECK_ATOL
+
+    def fast_score(residuals, _nuisance, _kernel, rho, _blocks):
+        return np.full(len(residuals), -gain if rho > 0.0 else 0.0)
+
+    def forbidden_dense_score(*_args, **_kwargs):
+        raise AssertionError("a gain outside the numerical guard was recomputed")
+
+    monkeypatch.setattr(power, "prompt_block_gaussian_nll", fast_score)
+    monkeypatch.setattr(
+        power, "_dense_prompt_block_gaussian_nll", forbidden_dense_score
+    )
+    search = inner_candidate_search(
+        field,
+        geometry,
+        splits.outer[0],
+        gammas=(0.5,),
+        rhos=(0.0, 0.10),
+    )
+    assert search.selected == Candidate(0.5, 0.10)
+    assert search.maximum_eligible_gain == pytest.approx(gain)
+
+
+@pytest.mark.parametrize(
+    ("seed", "scenario_name"),
+    [
+        (71, "block_null"),
+        (72, "cumulative_rho_0.10"),
+        (73, "mixture_rho_0.20"),
+    ],
+)
+def test_inner_search_selection_matches_forced_dense_scoring(
+    seed,
+    scenario_name,
+    monkeypatch,
+):
+    geometry, splits = geometry_and_splits(36, seed=seed)
+    field = draw_repeated_field(
+        geometry,
+        SCENARIO_BY_NAME[scenario_name],
+        repeats=4,
+        seed=seed + 200,
+        missing_rate=0.15,
+    )
+    fast = inner_candidate_search(field, geometry, splits.outer[0])
+    with monkeypatch.context() as context:
+        context.setattr(
+            power,
+            "_exchangeable_prompt_schedule",
+            lambda _nuisance, _positions: None,
+        )
+        dense = inner_candidate_search(field, geometry, splits.outer[0])
+
+    assert fast.selected == dense.selected
+    assert fast.maximum_eligible_gain == pytest.approx(
+        dense.maximum_eligible_gain, abs=1e-12
+    )
+    for fast_summary, dense_summary in zip(fast.summaries, dense.summaries):
+        assert fast_summary.candidate == dense_summary.candidate
+        assert fast_summary.positive_folds == dense_summary.positive_folds
+        assert fast_summary.macro_gain == pytest.approx(
+            dense_summary.macro_gain, abs=1e-12
+        )
+        np.testing.assert_allclose(
+            fast_summary.fold_gains,
+            dense_summary.fold_gains,
+            rtol=0.0,
+            atol=1e-12,
+        )
 
 
 def test_prompt_block_multiplier_uses_clusters_and_constant_bounds_are_exact():

--- a/prototypes/mu_cosine/test_run_repeated_judge_power.py
+++ b/prototypes/mu_cosine/test_run_repeated_judge_power.py
@@ -373,3 +373,27 @@ def test_start_of_run_provenance_is_rechecked(monkeypatch):
     monkeypatch.setattr(runner, "_provenance", lambda: changed)
     with pytest.raises(RuntimeError, match="changed during the run"):
         runner._assert_provenance_unchanged(snapshot)
+
+
+def test_blas_provenance_is_portable_and_thread_policy_is_honest():
+    common = {
+        "user_api": "blas",
+        "internal_api": "openblas",
+        "prefix": "libopenblas",
+        "version": "0.3.26",
+        "threading_layer": "pthreads",
+        "architecture": "Haswell",
+    }
+    first = runner._portable_blas_runtime([{
+        **common, "filepath": "/machine-a/lib/libopenblas.so",
+    }])
+    second = runner._portable_blas_runtime([{
+        **common, "filepath": "/different-prefix/lib/libopenblas.so",
+    }])
+    assert first == second
+    assert "filepath" not in first[0]
+    provenance = runner._provenance()
+    assert "worker_blas_threads" not in provenance
+    assert provenance["blas_thread_limit_policy"].startswith(
+        "child workers request one thread"
+    )

--- a/prototypes/mu_cosine/test_run_repeated_judge_power.py
+++ b/prototypes/mu_cosine/test_run_repeated_judge_power.py
@@ -1,0 +1,217 @@
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_repeated_judge_power as runner
+from run_repeated_judge_power import (
+    FULL_CONFIGURATIONS,
+    FULL_SCENARIOS,
+    _configuration_decision,
+    _one_sided_exact_binomial_pvalue,
+    build_arg_parser,
+    build_scientific_payload,
+    main,
+    parse_configuration,
+    resolve_configuration,
+    serialize_payload,
+)
+
+
+def test_configuration_parser_and_full_preregistration_contract_are_exact():
+    assert parse_configuration("160:3") == (160, 3)
+    with pytest.raises(Exception):
+        parse_configuration("160")
+    resolved = resolve_configuration(build_arg_parser().parse_args(["--full-prereg"]))
+    assert resolved["configurations"] == FULL_CONFIGURATIONS
+    assert resolved["null_draws"] == 1999
+    assert resolved["power_replicates"] == 200
+    assert resolved["multiplier_draws"] == 999
+    assert resolved["confidence"] == 0.95
+    assert resolved["outer_folds"] == 5
+    assert resolved["inner_folds"] == 3
+    assert resolved["mean_ridges"] == (0.0, 0.01, 0.1, 1.0, 10.0)
+    assert resolved["gammas"] == (0.0, 0.25, 0.5, 0.75, 1.0)
+    assert resolved["rhos"] == (0.0, 0.025, 0.05, 0.1, 0.2)
+    assert resolved["scenarios"] == FULL_SCENARIOS
+    assert resolved["prompt_batch_rows"] == 10
+    assert (320, 4) in FULL_CONFIGURATIONS
+    assert (800, 4) in FULL_CONFIGURATIONS
+    assert (160, 4) not in FULL_CONFIGURATIONS
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        ["--config", "32:3"],
+        ["--null-draws", "1999"],
+        ["--power-replicates", "200"],
+        ["--confidence", ".95"],
+        ["--outer-folds", "5"],
+        ["--mean-ridges", "0", ".01", ".1", "1", "10"],
+        ["--gammas", "0", ".25", ".5", ".75", "1"],
+        ["--rhos", "0", ".025", ".05", ".1", ".2"],
+        ["--scenarios", "block_null"],
+        ["--prompt-batch-rows", "10"],
+        ["--seed", "1207000"],
+    ],
+)
+def test_full_prereg_rejects_every_scientific_override_even_if_value_matches(override):
+    args = build_arg_parser().parse_args(["--full-prereg", *override])
+    with pytest.raises(ValueError, match="rejects scientific overrides"):
+        resolve_configuration(args)
+
+
+def test_nonfull_mode_fails_closed_on_unsupported_folds_or_prompt_capacity():
+    parser = build_arg_parser()
+    with pytest.raises(ValueError, match="exactly five outer"):
+        resolve_configuration(parser.parse_args(["--outer-folds", "4"]))
+    with pytest.raises(ValueError, match=r"\[1,10\]"):
+        resolve_configuration(parser.parse_args(["--prompt-batch-rows", "11"]))
+
+
+def fake_scenario_row(name, *, promotions=180, gain=0.02, topology=0.90):
+    replicates = 200
+    if name == "block_null":
+        promotions = 6
+        gain = 0.0
+        topology = None
+    elif name == "mean_only":
+        promotions = 0
+        gain = 0.0
+        topology = None
+    elif name.startswith("deranged"):
+        topology = None
+    return {
+        "scenario": name,
+        "replicates": replicates,
+        "joint_synthetic_primary_events": promotions,
+        "joint_synthetic_primary_event_rate": promotions / replicates,
+        "endpoint_mean_gain_per_scalar": {
+            corpus: {
+                "residual_nll": {"mean": gain},
+                "posterior_state_nll": {"mean": gain},
+            }
+            for corpus in ("synthetic_corpus_1", "synthetic_corpus_2")
+        },
+        "topology_truth_beats_derangement_rate": topology,
+    }
+
+
+def passing_rows():
+    return [fake_scenario_row(name) for name in FULL_SCENARIOS]
+
+
+def test_exact_binomial_and_complete_sizing_decision():
+    assert _one_sided_exact_binomial_pvalue(0, 200) == 1.0
+    assert _one_sided_exact_binomial_pvalue(6, 200) > 0.05
+    assert _one_sided_exact_binomial_pvalue(20, 200) < 0.05
+    decision = _configuration_decision(passing_rows(), FULL_SCENARIOS)
+    assert decision["evaluable"] is True
+    assert decision["pass"] is True
+    assert decision["block_null"][
+        "does_not_reject_p_at_most_0_05_and_observed_at_most_0_10"
+    ] is True
+
+
+def test_decision_fails_on_incomplete_grid_or_either_primary_endpoint():
+    incomplete = _configuration_decision(
+        [fake_scenario_row("block_null")], ["block_null"]
+    )
+    assert incomplete == {
+        "evaluable": False,
+        "pass": False,
+        "reason": "the complete frozen scenario grid is required",
+    }
+    rows = passing_rows()
+    target = next(row for row in rows if row["scenario"] == "nomic_rho_0.10")
+    target["endpoint_mean_gain_per_scalar"]["synthetic_corpus_2"][
+        "posterior_state_nll"
+    ]["mean"] = -0.001
+    assert _configuration_decision(rows, FULL_SCENARIOS)["pass"] is False
+
+
+def test_smallest_r3_passing_G_is_recommendation_and_r4_stays_sensitivity(monkeypatch):
+    resolved = resolve_configuration(build_arg_parser().parse_args([]))
+    resolved["configurations"] = ((160, 3), (320, 3), (320, 4), (800, 4))
+    resolved["scenarios"] = FULL_SCENARIOS
+
+    def fake_configuration(configuration, _resolved):
+        components, repeats = configuration
+        passed = components >= 320 and repeats == 3
+        return {
+            "components_per_required_corpus": components,
+            "repeats": repeats,
+            "decision": {"evaluable": True, "pass": passed},
+        }
+
+    monkeypatch.setattr(runner, "run_configuration", fake_configuration)
+    payload = build_scientific_payload(resolved)
+    assert payload["gate"]["smallest_passing_synthetic_primary_event_G_per_corpus"] == 320
+    assert payload["gate"]["synthetic_primary_event_pass"] is True
+    assert payload["gate"]["final_campaign_G_recommendation"] is None
+    assert payload["gate"]["deployment_pass"] is False
+    assert [row["repeats"] for row in payload["primary_r3_results"]] == [3, 3]
+    assert [row["repeats"] for row in payload["repeat4_sensitivity_results"]] == [4, 4]
+    assert payload["gate"]["real_covariance_deployment"] is False
+
+
+def tiny_resolved():
+    return resolve_configuration(build_arg_parser().parse_args([
+        "--config", "32:3",
+        "--null-draws", "1",
+        "--power-replicates", "1",
+        "--multiplier-draws", "7",
+        "--mean-ridges", "0", ".1",
+        "--gammas", "0",
+        "--rhos", "0",
+        "--scenarios", "block_null",
+        "--missing-rate", "0",
+        "--seed", "81000",
+    ]))
+
+
+def test_small_scientific_payload_is_deterministic_and_provenanced():
+    resolved = tiny_resolved()
+    first = build_scientific_payload(resolved)
+    second = build_scientific_payload(resolved)
+    assert serialize_payload(first) == serialize_payload(second)
+    assert first["gate"]["real_covariance_deployment"] is False
+    assert first["gate"]["synthetic_primary_event_sizing_evaluable"] is False
+    assert first["primary_r3_results"][0]["synthetic_joint_selector_null"]["draws"] == 1
+    assert "wall_seconds" not in serialize_payload(first)
+    assert "/tmp/" not in serialize_payload(first)
+    assert "path" not in first["provenance"]["files"]["power_runner"]
+    for record in first["provenance"]["files"].values():
+        assert record["bytes"] > 0
+        assert len(record["sha256"]) == 64
+    scenario = first["primary_r3_results"][0]["scenarios"][0]
+    assert scenario["inference_prompt_blocks"]["synthetic_corpus_1"]["maximum"] < 32
+    assert set(scenario["endpoint_mean_gain_per_scalar"]) == {
+        "synthetic_corpus_1", "synthetic_corpus_2"
+    }
+
+
+def test_cli_atomically_creates_parent_and_output_is_path_independent(tmp_path):
+    common = [
+        "--config", "32:3",
+        "--null-draws", "1",
+        "--power-replicates", "1",
+        "--multiplier-draws", "7",
+        "--mean-ridges", "0", ".1",
+        "--gammas", "0",
+        "--rhos", "0",
+        "--scenarios", "block_null",
+        "--missing-rate", "0",
+        "--seed", "91000",
+    ]
+    first_path = tmp_path / "new" / "first.json"
+    second_path = tmp_path / "other" / "second.json"
+    main(common + ["--out", str(first_path)])
+    main(common + ["--out", str(second_path)])
+    assert first_path.read_bytes() == second_path.read_bytes()
+    assert not list(tmp_path.rglob("*.tmp"))
+    payload = json.loads(first_path.read_text())
+    assert payload["gate"]["synthetic_primary_event_sizing_evaluable"] is False

--- a/prototypes/mu_cosine/test_run_repeated_judge_power.py
+++ b/prototypes/mu_cosine/test_run_repeated_judge_power.py
@@ -40,6 +40,12 @@ def test_configuration_parser_and_full_preregistration_contract_are_exact():
     assert (320, 4) in FULL_CONFIGURATIONS
     assert (800, 4) in FULL_CONFIGURATIONS
     assert (160, 4) not in FULL_CONFIGURATIONS
+    operational = build_arg_parser().parse_args([
+        "--full-prereg",
+        "--workers", "2",
+        "--checkpoint-dir", "/tmp/operational-only",
+    ])
+    assert resolve_configuration(operational) == resolved
 
 
 @pytest.mark.parametrize(
@@ -133,7 +139,19 @@ def test_decision_fails_on_incomplete_grid_or_either_primary_endpoint():
     assert _configuration_decision(rows, FULL_SCENARIOS)["pass"] is False
 
 
-def test_smallest_r3_passing_G_is_recommendation_and_r4_stays_sensitivity(monkeypatch):
+def test_mean_only_false_promotions_fail_the_same_null_gate():
+    rows = passing_rows()
+    mean_only = next(row for row in rows if row["scenario"] == "mean_only")
+    mean_only["joint_synthetic_primary_events"] = 200
+    mean_only["joint_synthetic_primary_event_rate"] = 1.0
+    decision = _configuration_decision(rows, FULL_SCENARIOS)
+    assert decision["pass"] is False
+    assert decision["controls"]["mean_only"][
+        "does_not_reject_p_at_most_0_05_and_observed_at_most_0_10"
+    ] is False
+
+
+def test_custom_complete_grid_cannot_emit_a_sizing_recommendation(monkeypatch):
     resolved = resolve_configuration(build_arg_parser().parse_args([]))
     resolved["configurations"] = ((160, 3), (320, 3), (320, 4), (800, 4))
     resolved["scenarios"] = FULL_SCENARIOS
@@ -149,13 +167,37 @@ def test_smallest_r3_passing_G_is_recommendation_and_r4_stays_sensitivity(monkey
 
     monkeypatch.setattr(runner, "run_configuration", fake_configuration)
     payload = build_scientific_payload(resolved)
-    assert payload["gate"]["smallest_passing_synthetic_primary_event_G_per_corpus"] == 320
-    assert payload["gate"]["synthetic_primary_event_pass"] is True
+    assert payload["gate"]["smallest_passing_synthetic_primary_event_G_per_corpus"] is None
+    assert payload["gate"]["synthetic_primary_event_sizing_evaluable"] is False
+    assert payload["gate"]["synthetic_primary_event_pass"] is False
     assert payload["gate"]["final_campaign_G_recommendation"] is None
     assert payload["gate"]["deployment_pass"] is False
     assert [row["repeats"] for row in payload["primary_r3_results"]] == [3, 3]
     assert [row["repeats"] for row in payload["repeat4_sensitivity_results"]] == [4, 4]
     assert payload["gate"]["real_covariance_deployment"] is False
+    assert "diagnostic only" in payload["gate"]["reason"]
+
+
+def test_exact_full_prereg_can_emit_smallest_passing_synthetic_G(monkeypatch):
+    resolved = resolve_configuration(
+        build_arg_parser().parse_args(["--full-prereg"])
+    )
+
+    def fake_configuration(configuration, _resolved):
+        components, repeats = configuration
+        return {
+            "components_per_required_corpus": components,
+            "repeats": repeats,
+            "decision": {
+                "evaluable": True,
+                "pass": components >= 320 and repeats == 3,
+            },
+        }
+
+    monkeypatch.setattr(runner, "run_configuration", fake_configuration)
+    payload = build_scientific_payload(resolved)
+    assert payload["gate"]["synthetic_primary_event_sizing_evaluable"] is True
+    assert payload["gate"]["smallest_passing_synthetic_primary_event_G_per_corpus"] == 320
 
 
 def tiny_resolved():
@@ -171,6 +213,34 @@ def tiny_resolved():
         "--missing-rate", "0",
         "--seed", "81000",
     ]))
+
+
+def test_indexed_null_units_match_the_original_monolithic_calibrator():
+    resolved = tiny_resolved()
+    components, repeats = resolved["configurations"][0]
+    null_seed = runner.derive_seed(
+        resolved["seed"], components, repeats, "block_null_calibration"
+    )
+    expected, _threshold, _rank = runner.calibrate_synthetic_selector_null(
+        components,
+        repeats=repeats,
+        draws=2,
+        seed=null_seed,
+        gammas=resolved["gammas"],
+        rhos=resolved["rhos"],
+        mean_ridges=resolved["mean_ridges"],
+        shrinkage=resolved["shrinkage"],
+        confidence=resolved["confidence"],
+        missing_rate=resolved["missing_rate"],
+        max_prompt_rows=resolved["prompt_batch_rows"],
+    )
+    observed = [
+        runner._compute_null_draw(
+            components, repeats, draw, null_seed, resolved
+        )
+        for draw in range(2)
+    ]
+    assert observed == expected.tolist()
 
 
 def test_small_scientific_payload_is_deterministic_and_provenanced():
@@ -192,6 +262,11 @@ def test_small_scientific_payload_is_deterministic_and_provenanced():
     assert set(scenario["endpoint_mean_gain_per_scalar"]) == {
         "synthetic_corpus_1", "synthetic_corpus_2"
     }
+    assert {
+        "list-position engineering pilot",
+        "frozen train-only position×role×judge adjustment",
+        "position-effect power sensitivity",
+    }.issubset(first["unsimulated_required_gates"])
 
 
 def test_cli_atomically_creates_parent_and_output_is_path_independent(tmp_path):
@@ -215,3 +290,86 @@ def test_cli_atomically_creates_parent_and_output_is_path_independent(tmp_path):
     assert not list(tmp_path.rglob("*.tmp"))
     payload = json.loads(first_path.read_text())
     assert payload["gate"]["synthetic_primary_event_sizing_evaluable"] is False
+
+
+def test_serial_parallel_and_checkpoint_resume_are_canonical(tmp_path, monkeypatch):
+    resolved = tiny_resolved()
+    serial = build_scientific_payload(resolved, workers=1)
+    parallel = build_scientific_payload(resolved, workers=2)
+    assert serialize_payload(parallel) == serialize_payload(serial)
+
+    checkpoint_dir = tmp_path / "checkpoint"
+    first = build_scientific_payload(
+        resolved, workers=1, checkpoint_dir=str(checkpoint_dir)
+    )
+    original_null_worker = runner._null_worker
+    original_power_worker = runner._power_worker
+
+    def unexpected_task(_task):
+        raise AssertionError("a complete checkpoint should not recompute work")
+
+    monkeypatch.setattr(runner, "_null_worker", unexpected_task)
+    monkeypatch.setattr(runner, "_power_worker", unexpected_task)
+    resumed = build_scientific_payload(
+        resolved, workers=1, checkpoint_dir=str(checkpoint_dir)
+    )
+    assert serialize_payload(resumed) == serialize_payload(first) == serialize_payload(serial)
+    assert not list(checkpoint_dir.rglob("*.tmp"))
+
+    next(checkpoint_dir.rglob("null_barrier.json")).unlink()
+    next(checkpoint_dir.rglob("draw_*.json")).unlink()
+    next(checkpoint_dir.rglob("replicate_*.json")).unlink()
+    recomputed = {"null": 0, "power": 0}
+
+    def count_null(task):
+        recomputed["null"] += 1
+        return original_null_worker(task)
+
+    def count_power(task):
+        recomputed["power"] += 1
+        return original_power_worker(task)
+
+    monkeypatch.setattr(runner, "_null_worker", count_null)
+    monkeypatch.setattr(runner, "_power_worker", count_power)
+    partial = build_scientific_payload(
+        resolved, workers=1, checkpoint_dir=str(checkpoint_dir)
+    )
+    assert recomputed == {"null": 1, "power": 1}
+    assert serialize_payload(partial) == serialize_payload(serial)
+
+
+def test_checkpoint_integrity_and_configuration_mismatches_fail_closed(tmp_path):
+    resolved = tiny_resolved()
+    checkpoint_dir = tmp_path / "checkpoint"
+    build_scientific_payload(
+        resolved, workers=1, checkpoint_dir=str(checkpoint_dir)
+    )
+
+    power_path = next(checkpoint_dir.rglob("replicate_*.json"))
+    envelope = json.loads(power_path.read_text())
+    envelope["payload"]["record"]["promoted"] = not envelope["payload"][
+        "record"
+    ]["promoted"]
+    power_path.write_text(json.dumps(envelope))
+    with pytest.raises(ValueError, match="integrity hash mismatch"):
+        build_scientific_payload(
+            resolved, workers=1, checkpoint_dir=str(checkpoint_dir)
+        )
+
+    other_dir = tmp_path / "other-checkpoint"
+    build_scientific_payload(resolved, workers=1, checkpoint_dir=str(other_dir))
+    changed = dict(resolved)
+    changed["seed"] = int(resolved["seed"]) + 1
+    with pytest.raises(ValueError, match="fingerprint/configuration mismatch"):
+        build_scientific_payload(
+            changed, workers=1, checkpoint_dir=str(other_dir)
+        )
+
+
+def test_start_of_run_provenance_is_rechecked(monkeypatch):
+    snapshot = runner._provenance()
+    changed = json.loads(json.dumps(snapshot))
+    changed["files"]["power_runner"]["sha256"] = "0" * 64
+    monkeypatch.setattr(runner, "_provenance", lambda: changed)
+    with pytest.raises(RuntimeError, match="changed during the run"):
+        runner._assert_provenance_unchanged(snapshot)

--- a/prototypes/mu_cosine/test_sample_repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/test_sample_repeated_judge_campaign.py
@@ -181,7 +181,11 @@ def test_cli_materializes_reproducible_content_addressed_campaign(tmp_path, caps
     assert manifest["schedule"]["records"] == 11520
     assert manifest["schedule"]["same_component_per_request_max"] == 1
     assert manifest["schedule"]["prompt_block_is_inference_cluster"] is True
-    assert manifest["classification"] == "confirmatory-compatible-no-spend"
+    assert manifest["classification"] == (
+        "protocol-shape-compatible-no-spend-inputs-unverified"
+    )
+    assert manifest["candidate_builder_verified_by_repository"] is False
+    assert manifest["request_contract_approved_for_live_use"] is False
     assert manifest["call_authorized"] is False
     assert str(tmp_path) not in json.dumps(manifest)
     assert "elapsed" not in json.dumps(manifest).lower()
@@ -214,6 +218,7 @@ def test_cli_materializes_reproducible_content_addressed_campaign(tmp_path, caps
     score_inputs = sorted((first / "score_inputs").glob("*.tsv"))
     assert len(score_inputs) == 6
     assert all(len(data_rows(path)) == 1920 for path in score_inputs)
+    assert all(path.read_text(encoding="utf-8").startswith("# row_id\t") for path in score_inputs)
     assert (first / "nested_component_folds.tsv").exists()
     assert (first / "response_ingestion_schema.json").exists()
     request_inputs = sorted((first / "request_inputs").rglob("*.tsv"))
@@ -326,7 +331,7 @@ def test_nonfrozen_selector_seed_is_exploratory_only():
         },
     }
     assert sampler._configuration_classification(args, specs)[0] == (
-        "confirmatory-compatible-no-spend"
+        "protocol-shape-compatible-no-spend-inputs-unverified"
     )
     args.seed = 1
     classification, deviations = sampler._configuration_classification(args, specs)

--- a/prototypes/mu_cosine/test_sample_repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/test_sample_repeated_judge_campaign.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""CLI/materialization tests for the repeated-judge campaign sampler."""
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+import sample_repeated_judge_campaign as sampler
+
+from repeated_judge_campaign import (
+    CANDIDATE_REQUIRED_COLUMNS,
+    DEFAULT_AGREEMENT_CLASSES,
+    DEFAULT_CORPORA,
+    DEFAULT_DEGREE_QUARTILES,
+    DEFAULT_HOP_TRANSITIONS,
+    FROZEN_NOMIC_MODEL,
+    FROZEN_NOMIC_PREFIX,
+    FROZEN_NOMIC_REVISION,
+    FROZEN_WALK_WEIGHTS,
+    content_record,
+    tsv_bytes,
+)
+from sample_repeated_judge_campaign import main
+
+
+EXTRA_COLUMN = "nomic_similarity"
+
+
+def candidate_record(candidate_id, cell, base):
+    corpus, hop, degree, agreement = cell
+    first_hop, second_hop = (part[1:] if part.startswith("h") else part for part in hop.split("-"))
+    return {
+        "candidate_id": candidate_id,
+        "corpus": corpus,
+        "source_component": f"source-{corpus}-{base}",
+        "hop_transition": hop,
+        "degree_quartile": degree,
+        "agreement_class": agreement,
+        "anchor_hop": first_hop,
+        "adjacent_hop": second_hop,
+        "distant_hop": second_hop,
+        "anchor_campaign_tag": "anchor-campaign",
+        "adjacent_campaign_tag": "comparator-campaign",
+        "distant_campaign_tag": "comparator-campaign",
+        "anchor_degree_quartile": degree,
+        "adjacent_degree_quartile": "q2",
+        "distant_degree_quartile": "q2",
+        "anchor_adjacent_direct_edge": "true",
+        "anchor_distant_distance": "3",
+        "anchor_distant_disconnected": "false",
+        "cumulative_anchor_adjacent_similarity": "0.9",
+        "cumulative_anchor_distant_similarity": "0.1",
+        "nomic_anchor_adjacent_similarity": "0.8" if agreement == "agreement" else "0.2",
+        "nomic_anchor_distant_similarity": "0.2" if agreement == "agreement" else "0.8",
+        "descendant_id": f"{corpus}-id-{base}-x",
+        "descendant_title": f"{corpus}_Title_{base}_x",
+        "anchor_id": f"{corpus}-id-{base}-a",
+        "anchor_title": f"{corpus}_Title_{base}_a",
+        "adjacent_id": f"{corpus}-id-{base}-b",
+        "adjacent_title": f"{corpus}_Title_{base}_b",
+        "distant_id": f"{corpus}-id-{base}-c",
+        "distant_title": f"{corpus}_Title_{base}_c",
+        EXTRA_COLUMN: f"0.{base % 10}",
+    }
+
+
+def write_inputs(tmp_path):
+    rows = []
+    value = 0
+    for cell in (
+        (corpus, hop, degree, agreement)
+        for corpus in DEFAULT_CORPORA
+        for hop in DEFAULT_HOP_TRANSITIONS
+        for degree in DEFAULT_DEGREE_QUARTILES
+        for agreement in DEFAULT_AGREEMENT_CLASSES
+    ):
+        for _ in range(10):
+            rows.append(candidate_record(f"candidate-{value:04d}", cell, value))
+            value += 1
+    historical_candidate = candidate_record(
+        "candidate-historical-extra",
+        (
+            DEFAULT_CORPORA[0], DEFAULT_HOP_TRANSITIONS[0],
+            DEFAULT_DEGREE_QUARTILES[0], DEFAULT_AGREEMENT_CLASSES[0],
+        ),
+        999999,
+    )
+    rows.append(historical_candidate)
+    pool = tmp_path / "candidate_pool.tsv"
+    pool.write_bytes(tsv_bytes((*CANDIDATE_REQUIRED_COLUMNS, EXTRA_COLUMN), rows))
+    history = tmp_path / "historical.tsv"
+    history.write_bytes(tsv_bytes(
+        ("corpus", "endpoint_id", "endpoint_title"),
+        [{
+            "corpus": historical_candidate["corpus"],
+            "endpoint_id": historical_candidate["anchor_id"],
+            "endpoint_title": historical_candidate["anchor_title"],
+        }],
+    ))
+    builder = tmp_path / "candidate_builder.json"
+    builder.write_text(json.dumps({
+        "schema_version": 1,
+        "algorithm": "test-candidate-builder-v1",
+        "implementation_sha256": "d" * 64,
+        "candidate_pool": content_record(pool.read_bytes()),
+        "graph": {
+            "artifact_sha256": "e" * 64,
+            "cumulative_walk_weights": list(FROZEN_WALK_WEIGHTS),
+        },
+        "nomic": {
+            "model_id": FROZEN_NOMIC_MODEL,
+            "revision": FROZEN_NOMIC_REVISION,
+            "task_prefix": FROZEN_NOMIC_PREFIX,
+            "embedding_manifest_sha256": "f" * 64,
+        },
+        "agreement_thresholds": {"graph_delta_min": 0.0, "nomic_delta_min": 0.0},
+    }), encoding="utf-8")
+    request = tmp_path / "request_contract.json"
+    request.write_text(json.dumps({
+        "schema_version": 1,
+        "judges": {
+            "gpt-5.5-low": {
+                "model_id": "gpt-5.5",
+                "model_revision": "test-revision-55",
+                "prompt_id": "frozen-relation-prompt",
+                "prompt_sha256": "a" * 64,
+                "reasoning_effort": "low",
+                "settings": {"temperature": 0},
+                "call_seed": None,
+                "stateless": True,
+            },
+            "gpt-5.6-luna": {
+                "model_id": "gpt-5.6-luna",
+                "model_revision": "test-revision-luna",
+                "prompt_id": "frozen-relation-prompt",
+                "prompt_sha256": "a" * 64,
+                "reasoning_effort": "low",
+                "settings": {"temperature": 0},
+                "call_seed": None,
+                "stateless": True,
+            },
+        },
+    }), encoding="utf-8")
+    return pool, history, builder, request
+
+
+def tree_payloads(root):
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*")) if path.is_file()
+    }
+
+
+def data_rows(path):
+    return [line for line in path.read_text(encoding="utf-8").splitlines() if not line.startswith("#")]
+
+
+def test_cli_materializes_reproducible_content_addressed_campaign(tmp_path, capsys):
+    pool, history, builder, request = write_inputs(tmp_path)
+    first = tmp_path / "campaign-a"
+    second = tmp_path / "campaign-b"
+    common = [
+        "--candidate-pool", str(pool),
+        "--candidate-builder-manifest", str(builder),
+        "--request-contract", str(request),
+        "--historical-endpoints", str(history),
+    ]
+    assert main([*common, "--out-dir", str(first)]) == 0
+    capsys.readouterr()
+    assert main([*common, "--out-dir", str(second)]) == 0
+    capsys.readouterr()
+
+    assert tree_payloads(first) == tree_payloads(second)
+    manifest = json.loads((first / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["selection"]["component_count"] == 640
+    assert manifest["selection"]["row_count"] == 1920
+    assert manifest["selection"]["exclusions"] == {"historical_endpoint_id": 1}
+    assert manifest["schedule"]["wave_count"] == 6
+    assert manifest["schedule"]["records"] == 11520
+    assert manifest["schedule"]["same_component_per_request_max"] == 1
+    assert manifest["schedule"]["prompt_block_is_inference_cluster"] is True
+    assert manifest["classification"] == "confirmatory-compatible-no-spend"
+    assert manifest["call_authorized"] is False
+    assert str(tmp_path) not in json.dumps(manifest)
+    assert "elapsed" not in json.dumps(manifest).lower()
+    assert EXTRA_COLUMN in (first / "selected_components.tsv").read_text(encoding="utf-8").splitlines()[0]
+
+    with open(first / "scoring_schedule.tsv", encoding="utf-8", newline="") as stream:
+        records = list(csv.DictReader(stream, delimiter="\t"))
+    by_request = {}
+    for record in records:
+        key = (record["wave_id"], record["request_id"])
+        by_request.setdefault(key, []).append(record)
+    assert by_request
+    for request in by_request.values():
+        assert 1 <= len(request) <= 10
+        assert len({record["component_id"] for record in request}) == len(request)
+        assert len({(
+            record["corpus"], record["outer_fold"], record["global_inner_fold"]
+        ) for record in request}) == 1
+        assert len({record["prompt_block_id"] for record in request}) == 1
+        assert all(record["prompt_block_id"] == record["inference_cluster_id"] for record in request)
+
+    block_members = {}
+    for record in records:
+        key = (record["prompt_block_id"], record["role"])
+        block_members.setdefault(key, set()).add(record["component_id"])
+    for block_id in {record["prompt_block_id"] for record in records}:
+        memberships = [block_members[(block_id, role)] for role in ("anchor", "adjacent", "distant")]
+        assert memberships[0] == memberships[1] == memberships[2]
+
+    score_inputs = sorted((first / "score_inputs").glob("*.tsv"))
+    assert len(score_inputs) == 6
+    assert all(len(data_rows(path)) == 1920 for path in score_inputs)
+    assert (first / "nested_component_folds.tsv").exists()
+    assert (first / "response_ingestion_schema.json").exists()
+    request_inputs = sorted((first / "request_inputs").rglob("*.tsv"))
+    assert len(request_inputs) == len(by_request)
+    assert all(1 <= len(data_rows(path)) <= 10 for path in request_inputs)
+    output_names = {record["name"] for record in manifest["outputs"]}
+    assert output_names == {
+        path.relative_to(first).as_posix()
+        for path in first.rglob("*") if path.is_file() and path.name != "manifest.json"
+    }
+
+
+def test_cli_marks_direct_per_cell_override_exploratory(tmp_path, capsys):
+    pool, history, builder, request = write_inputs(tmp_path)
+    out = tmp_path / "invalid-campaign"
+    assert main([
+        "--candidate-pool", str(pool),
+        "--candidate-builder-manifest", str(builder),
+        "--request-contract", str(request),
+        "--historical-endpoints", str(history),
+        "--out-dir", str(out),
+        "--per-cell", "9",
+    ]) == 0
+    capsys.readouterr()
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["classification"] == "exploratory-smoke-only"
+    assert manifest["call_authorized"] is False
+    assert max(manifest["folds"]["component_counts"].values()) - min(
+        manifest["folds"]["component_counts"].values()
+    ) <= 1
+
+
+def test_cli_refuses_to_overwrite_an_existing_directory(tmp_path):
+    pool, history, builder, request = write_inputs(tmp_path)
+    out = tmp_path / "existing"
+    out.mkdir()
+    with pytest.raises(SystemExit, match="already exists"):
+        main([
+            "--candidate-pool", str(pool),
+            "--candidate-builder-manifest", str(builder),
+            "--request-contract", str(request),
+            "--historical-endpoints", str(history),
+            "--out-dir", str(out),
+        ])
+
+
+def test_cli_rejects_builder_hash_drift_repeats_and_safe_name_collisions(tmp_path):
+    pool, history, builder, request = write_inputs(tmp_path)
+    common = [
+        "--candidate-pool", str(pool),
+        "--candidate-builder-manifest", str(builder),
+        "--request-contract", str(request),
+        "--historical-endpoints", str(history),
+    ]
+    with pytest.raises(SystemExit, match="at least three"):
+        main([*common, "--out-dir", str(tmp_path / "too-few"), "--repeats", "2"])
+    with pytest.raises(SystemExit, match="collide"):
+        main([
+            *common,
+            "--out-dir", str(tmp_path / "collision"),
+            "--judges", "judge/a", "judge_a",
+        ])
+
+    pool.write_bytes(pool.read_bytes() + b"\n")
+    with pytest.raises(SystemExit, match="does not match"):
+        main([*common, "--out-dir", str(tmp_path / "drift")])
+
+
+def test_materialization_cleans_temporary_directory_after_write_failure(
+    tmp_path, monkeypatch
+):
+    pool, history, builder, request = write_inputs(tmp_path)
+    out = tmp_path / "atomic"
+    original = sampler._artifact
+    count = {"value": 0}
+
+    def fail_on_second(root, relative, payload):
+        count["value"] += 1
+        if count["value"] == 2:
+            raise RuntimeError("injected artifact failure")
+        return original(root, relative, payload)
+
+    monkeypatch.setattr(sampler, "_artifact", fail_on_second)
+    with pytest.raises(RuntimeError, match="injected"):
+        sampler.main([
+            "--candidate-pool", str(pool),
+            "--candidate-builder-manifest", str(builder),
+            "--request-contract", str(request),
+            "--historical-endpoints", str(history),
+            "--out-dir", str(out),
+        ])
+    assert not out.exists()
+    assert not list(tmp_path.glob(".atomic.*"))
+
+
+def test_nonfrozen_selector_seed_is_exploratory_only():
+    args = sampler.build_arg_parser().parse_args([
+        "--candidate-pool", "pool.tsv",
+        "--candidate-builder-manifest", "builder.json",
+        "--request-contract", "request.json",
+        "--historical-endpoints", "history.tsv",
+        "--out-dir", "campaign",
+    ])
+    specs = {
+        "gpt-5.5-low": {
+            "model_id": "gpt-5.5", "reasoning_effort": "low", "stateless": True,
+        },
+        "gpt-5.6-luna": {
+            "model_id": "gpt-5.6-luna", "reasoning_effort": "low", "stateless": True,
+        },
+    }
+    assert sampler._configuration_classification(args, specs)[0] == (
+        "confirmatory-compatible-no-spend"
+    )
+    args.seed = 1
+    classification, deviations = sampler._configuration_classification(args, specs)
+    assert classification == "exploratory-smoke-only"
+    assert any("selector seed" in deviation for deviation in deviations)


### PR DESCRIPTION
## Summary

This is a **no-spend preregistration and tooling PR**, not a covariance result or live-campaign authorization.

- Freezes the planned repeated-judge campaign: endpoint-disjoint anchor/adjacent/distant components, 32 balanced cells per corpus, source-safe nested folds, repeated judge waves, estimands, nulls, alternatives, and fail-closed decision gates.
- Amortizes the LLM system prompt over stable blocks of up to 10 same-role rows while explicitly modeling shared-request covariance and using prompt blocks as inference clusters.
- Adds outcome-blind sampling/scheduling plus keyed response validation: exact request bytes are hashed, stable row IDs are submitted, retries are preserved, and provider call IDs cannot be reused as nominally fresh repeats.
- Adds a repeat-aware synthetic sizing harness with block-null and smooth-mean false-promotion controls, residual and latent-state posterior NLL endpoints, topology derangements, and full nested refitting.
- Adds an exact compound-symmetry eigenmode path for exchangeable prompt schedules, with dense overlap-aware fallback and dense decision-boundary rechecks.
- Adds deterministic process workers, one BLAS thread per worker, atomic checkpoint/resume, a hard null-calibration barrier, canonical result reconstruction, and immutable provenance checks.

## Why

Scoring one item per LLM request repays the system prompt for every item. Batching is materially cheaper, but rows in one prompt can share request and list-position effects. This design keeps batching economical while making the induced dependence explicit instead of treating batched rows as independent.

The repeated calls are needed to separate row-call noise from persistent item/judge covariance before any graph/Nomic geometry can be considered for the joint square-root/QR conditioner.

## Important boundaries

- No endpoint was selected and no judge/model/API call was made.
- The full preregistered simulation was **not** run, so there is no sample-size recommendation.
- Smoke/custom runs are diagnostic-only and cannot set sizing fields.
- Final campaign G, deployment, independent batching, QR specialization, and CUDA remain false/null.
- The repository-owned candidate builder, verified historical inventory, and approved exact prompt/model/settings contract are still prerequisites.
- List-position effects are mitigated by independent role-by-judge orderings and spread repeat rotations, but remain a required pilot/train-only-adjustment/power-sensitivity gate before live scoring.
- The two synthetic corpus labels are independent copies of a generic DGP; they enforce multiplicity, not empirical corpus heterogeneity.

See `prototypes/mu_cosine/REPORT_repeated_judge_campaign_power.md` for the full claim boundary, math, compute audit, and next steps.

## Performance notes

The original dense implementation projected roughly 230–300 serial CPU-hours. Exact prompt-block diagonalization reduced local 10×10-block scoring by 28.43× (residual) and 22.24× (posterior), projecting roughly 40–45 CPU-hours / 11–15 hours on four physical cores before a full run.

A diagnostic two-worker smoke completed in 40.15 s; checkpoint resume reproduced byte-identical scientific JSON in 0.02 s. A G=160 diagnostic with five null draws and one replicate across all 14 scenarios completed in 30.55 s. These are compute checks, not scientific results.

## Validation

- Repeated campaign/sampler/power/runner: **68 passed**
- Relevant inherited graph geometry, synthetic-v2, structured covariance, JointPosterior, and square-root conditioner suites: **97 passed, 9 optional CUDA skips**
- Dense/eigenmode maximum observed differences: residual **2.22e-16**, posterior **3.33e-16**
- Python compilation and `git diff --check`: clean

## Review focus

1. Prompt-block membership, position scheduling, and request-covariance assumptions.
2. The two zero-coupling false-promotion gates and synthetic-primary-event boundary.
3. Collective/contrast eigenmode algebra and dense fallback conditions.
4. Checkpoint fingerprinting, null barrier, and deterministic reconstruction.
5. Whether the remaining live-campaign prerequisites are sufficiently fail-closed.