### PR TITLE
EMIT-KOTLIN-4: lower last-call execute (tail recursion)

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -56,7 +56,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | EMIT-KOTLIN ✅ | Lowered emitter | Kotlin | M | done — flat facts/unify (`cursor/emit-kotlin-lowered-f421`) |
 | EMIT-KOTLIN-2 ✅ | Lowered emitter (structures) | Kotlin | M | done — write-mode structures (`cursor/emit-kotlin-structures-f421`) |
 | EMIT-KOTLIN-3 ✅ | Multi-clause deterministic | Kotlin | M | done — T5/T4 no call (`cursor/emit-kotlin-multi-clause-f421`) |
-| EMIT-KOTLIN-4 | Last-call `execute` | Kotlin | M | tail-recursive member/append (no mid-body `call`) |
+| EMIT-KOTLIN-4 ✅ | Last-call `execute` | Kotlin | M | done — tail execute (`cursor/emit-kotlin-execute-f421`) |
 | EMIT-KOTLIN-5 | Mid-body `call` | Kotlin | M | fib/ack / non-tail continuation |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |
@@ -589,7 +589,7 @@ fallback) to the three Tier-D targets. Reference small emitters:
 
 ### EMIT-KOTLIN-4: Lower last-call `execute` (tail recursion / inter-predicate)
 - **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-3
-- **Status:** In progress on `cursor/emit-kotlin-execute-f421` (2026-07-13).
+- **Status:** ✅ **Landed** on `cursor/emit-kotlin-execute-f421` (2026-07-13). Dispatch seam `(state, dispatch)` + `return dispatch("P/N", state)`. member/append/acc-reverse LOWER; fib/ack with mid-body `call` still decline.
 - **Goal:** Allow a clause's final `execute P/N` in lowered bodies so tail-recursive predicates (`member/2`, `append/3`, accumulator `reverse`) LOWER under `emit_mode(functions)`. Mid-body `call` stays declined → **EMIT-KOTLIN-5**.
 - **Dispatch seam:** native fn signature is `(WamState, dispatch:(String,WamState)->Boolean) -> Boolean`; `tryRun` passes `this::tryRun` so `return dispatch("P/N", state)` is native-first then bytecode.
 - **Boundary:**

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -55,8 +55,9 @@ self-contained so a single coding agent can pick it up in isolation.
 | EMIT-JVM | Lowered emitter | JVM | L | — |
 | EMIT-KOTLIN ✅ | Lowered emitter | Kotlin | M | done — flat facts/unify (`cursor/emit-kotlin-lowered-f421`) |
 | EMIT-KOTLIN-2 ✅ | Lowered emitter (structures) | Kotlin | M | done — write-mode structures (`cursor/emit-kotlin-structures-f421`) |
-| EMIT-KOTLIN-3 ✅ | Multi-clause deterministic | Kotlin | M | done — T5/T4 no call/execute (`cursor/emit-kotlin-multi-clause-f421`) |
-| EMIT-KOTLIN-4 | Recursion in lowered bodies | Kotlin | M | call/execute → inter-predicate / recursion |
+| EMIT-KOTLIN-3 ✅ | Multi-clause deterministic | Kotlin | M | done — T5/T4 no call (`cursor/emit-kotlin-multi-clause-f421`) |
+| EMIT-KOTLIN-4 | Last-call `execute` | Kotlin | M | tail-recursive member/append (no mid-body `call`) |
+| EMIT-KOTLIN-5 | Mid-body `call` | Kotlin | M | fib/ack / non-tail continuation |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |
 | BENCH-C | Effective-distance bench row | C | M | — |
@@ -576,21 +577,32 @@ fallback) to the three Tier-D targets. Reference small emitters:
 
 ### EMIT-KOTLIN-3: Deterministic multi-clause clause selection (Kotlin)
 - **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-2
-- **Status:** In progress on `cursor/emit-kotlin-multi-clause-f421` (2026-07-12).
+- **Status:** ✅ **Landed** on `cursor/emit-kotlin-multi-clause-f421` (2026-07-12). T5 first-arg `clause_chain` + T4 `multi_clause_n` (snapshot/restore between clauses). Predicates with `call`/`execute` still declined at landing; **EMIT-KOTLIN-4** later added last-call `execute`.
 - **Goal:** Extend `wam_kotlin_lowered_emitter.pl` so **deterministic multi-clause** predicates whose bodies contain only unification/builtins (NO `call`/`execute`) lower to native clause selection instead of declining. Mirror Lua's T5 `clause_chain` (first-arg constant dispatch) and T4 `multi_clause_n` (all clauses inline with trail/register restore between attempts).
 - **Boundary (this card):**
   - **Lowers:** multi-clause facts (`p(a). p(b). p(c).`), first-arg-indexed constant chains (T5), and other multi-clause deterministic bodies without inter-predicate calls (T4).
-  - **Still declines:** any clause with `call`/`execute` (member/append/reverse/fib/ack stay on the interpreter) — see **EMIT-KOTLIN-4**. ITE/soft-cut, cut, aggregates also out of scope.
+  - **Still declines (at EMIT-KOTLIN-3 landing):** any clause with `call`/`execute` — superseded in part by **EMIT-KOTLIN-4** (`execute`) / **EMIT-KOTLIN-5** (`call`). ITE/soft-cut, cut, aggregates also out of scope.
 - **Native mechanics:** per clause: `snapshotForNative`, try head + body, on failure `restoreFromSnapshot` and try next; return true on first success, false if all fail (T5 unbound A1 returns false so `tryRun` falls back to the interpreter).
 - **Files to touch:** `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl`, `tests/test_wam_kotlin_target.pl`, `docs/WAM_KOTLIN_STATUS.md`, this card.
 - **Reference:** `wam_lua_lowered_emitter.pl` `build_emission_plan`/`classify_clause_shape`; shared `wam_clause_chain`.
 - **Acceptance:** multi-clause facts + T4/T5 preds LOWER under `emit_mode(functions)` and match `emit_mode(interpreter)` true/false (incl. non-matching); call/execute preds still decline; unit suite + `CONFORMANCE_TARGETS=kotlin,kotlin_functions` stay green.
 
-### EMIT-KOTLIN-4: Lower `call`/`execute` in bodies (recursion / inter-predicate)
+### EMIT-KOTLIN-4: Lower last-call `execute` (tail recursion / inter-predicate)
 - **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-3
-- **Goal:** Allow lowered bodies to invoke other predicates (native or interpreter) so recursive/multi-clause programs like member/append/reverse/fib/ack can lower instead of declining.
-- **Out of scope here:** ITE/soft-cut, cut, aggregates (separate cards if needed).
-- **Acceptance:** member/append (or equivalent) LOWER under `emit_mode(functions)` and match interpreter; conformance `kotlin_functions` remains green.
+- **Status:** In progress on `cursor/emit-kotlin-execute-f421` (2026-07-13).
+- **Goal:** Allow a clause's final `execute P/N` in lowered bodies so tail-recursive predicates (`member/2`, `append/3`, accumulator `reverse`) LOWER under `emit_mode(functions)`. Mid-body `call` stays declined → **EMIT-KOTLIN-5**.
+- **Dispatch seam:** native fn signature is `(WamState, dispatch:(String,WamState)->Boolean) -> Boolean`; `tryRun` passes `this::tryRun` so `return dispatch("P/N", state)` is native-first then bytecode.
+- **Boundary:**
+  - **Lowers:** last-call `execute` only (member, append, `crev_acc` / `clist_reverse`).
+  - **Still declines:** mid-body `call` (fib, ack clause with call), `builtin_call` (except as already unsupported), cut/ITE/aggregates.
+- **Depth caveat:** native `execute` recursion uses the JVM call stack. Measured ~1000 peano-depth OK, ~2000 → `StackOverflowError` on default stack. Conformance list lengths (3) are safe. Prefer decline over wrong answers if a workload overflows.
+- **Acceptance:** member/append/(acc)reverse LOWER and match interpreter via gradle differential; fib still declines; unit + `kotlin`/`kotlin_functions` conformance green with no xfails; emitted project registers `lowered_cmem_2` / etc. under kotlin_functions.
+
+### EMIT-KOTLIN-5: Lower mid-body `call P/N` (non-tail / continuation)
+- **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-4
+- **Goal:** Emit non-tail `call` with saved continuation / environment so fib/ack and non-tail reverse lower.
+- **Out of scope here:** cut, ITE/soft-cut, aggregates, multi-solution enumeration.
+- **Acceptance:** fib (or equivalent) LOWERS under `emit_mode(functions)` and matches interpreter; conformance remains green.
 
 ---
 

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -22,7 +22,7 @@ module in the fleet.
 | Module | Approx. lines |
 |---|---:|
 | `src/unifyweaver/targets/wam_kotlin_target.pl` | ~0.5k |
-| `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl` | ~0.4k (T1 + T4 + T5) |
+| `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl` | ~0.5k (T1 + T4 + T5 + execute) |
 | Dedicated tests | ~1 file (plunit + Gradle e2e when available) |
 
 ## What's shipped
@@ -32,24 +32,29 @@ module in the fleet.
   path when the toolchain is available.
 - **WAM-lowered native dispatch:** `wam_kotlin_lowered_emitter.pl` lowers:
   - **T1** deterministic single-clause — flat facts, register unification,
-    write/read-mode structure/list construction.
+    write/read-mode structure/list construction, last-call `execute`.
   - **T5** `clause_chain` — multi-clause with distinct first-arg
     `get_constant` discriminators (bound A1 if-cascade; unbound A1
     returns `false` so `tryRun` falls back to the interpreter).
   - **T4** `multi_clause_n` — all supported deterministic clauses
     inlined, tried in order with `snapshotForNative` /
-    `restoreFromSnapshot` between attempts.
-  Registered via `WamProgram.registerNative`. `WamRuntime.run` /
-  `tryRun` tries native first and falls back to the bytecode
-  interpreter on `false`. `functions` / `mixed` modes route lowerable
-  preds through this path.
+    `restoreFromSnapshot` between attempts (incl. clauses ending in
+    `execute`).
+  - **Last-call `execute` (EMIT-KOTLIN-4):** native fns take
+    `(state, dispatch)` where `dispatch` is `WamRuntime.tryRun`; emit
+    `return dispatch("P/N", state)`. Tail-recursive member/append and
+    accumulator reverse lower.
+  Registered via `WamProgram.registerNative`. `functions` / `mixed`
+  modes route lowerable preds through this path.
 
 ## Gaps
 
-- **`call`/`execute` in lowered bodies** — still declined (member,
-  append, reverse, fib, ack stay on the interpreter). Follow-up
-  **EMIT-KOTLIN-4**.
+- **Mid-body `call`** — still declined (fib, ack with non-tail call).
+  Follow-up **EMIT-KOTLIN-5**.
 - **ITE/soft-cut, cut, aggregates** — not lowered.
+- **Native recursion depth:** `execute` uses the JVM call stack.
+  Measured ~1000 peano-depth OK, ~2000 → `StackOverflowError` on the
+  default stack. Conformance depths (list length 3) are fine.
 - **Conformance (opt-in)** — `conformance_target(kotlin)` /
   `kotlin_functions` registered. **All classic programs green** (append,
   member, reverse, builtins, fib, ack) — no remaining `ct_xfail`s after
@@ -59,8 +64,7 @@ module in the fleet.
 
 ## Path forward
 
-1. EMIT-KOTLIN-4: emit `call`/`execute` in lowered bodies (recursion /
-   inter-predicate).
+1. EMIT-KOTLIN-5: mid-body `call` with continuation (fib/ack).
 2. Optional: ITE/soft-cut lowering; ISO / kernels if Kotlin graduates
    beyond scaffold.
 
@@ -68,6 +72,5 @@ module in the fleet.
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
-(2026-07-12). EMIT-KOTLIN-2 + CONF-KOTLIN + KT-ARITH-SLASH-FUNCTOR +
-KT-LIST-BACKTRACK + KT-Y-ENV-RECURSION + EMIT-KOTLIN-3 landed
-(T4/T5 multi-clause without call/execute; EMIT-KOTLIN-4 next).
+(2026-07-13). Through EMIT-KOTLIN-4 (last-call execute); EMIT-KOTLIN-5
+next for mid-body call.

--- a/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
@@ -45,7 +45,8 @@ classify_clause_shape([FirstLine|Rest],
     clause_chain(Terms, chain(Guards)),
     forall(member(guard(_, Rem), Guards), kotlin_chain_rem_supported(Rem)),
     !.
-% T4: multi-clause with only supported deterministic bodies (no call/execute).
+% T4: multi-clause with only supported deterministic bodies (no mid-body call).
+% Last-call `execute` is allowed (EMIT-KOTLIN-4); mid-body `call` is EMIT-KOTLIN-5.
 classify_clause_shape([FirstLine|Rest], plan(multi_clause_n, none, Clauses)) :-
     wam_kotlin_target:tokenize_wam_line(FirstLine, ["try_me_else", _AltStr]),
     kotlin_split_clause_lines([FirstLine|Rest], Clauses),
@@ -94,7 +95,10 @@ kotlin_chain_rem_supported([T|Rest]) :-
     (   T = get_constant(_, _)
     ->  true
     ;   T = line(Parts)
-    ->  parts_supported(Parts)
+    ->  (   Parts = ["call"|_]
+        ->  fail
+        ;   parts_supported(Parts)
+        )
     ),
     kotlin_chain_rem_supported(Rest).
 
@@ -120,22 +124,26 @@ kotlin_split_at_terminal([L|Ls], [Clause|Rest]) :-
 
 kotlin_take_to_terminal([Line|Rest], [Line], Rest) :-
     wam_kotlin_target:tokenize_wam_line(Line, Parts),
-    ( Parts == ["proceed"] ; Parts == ["fail"] ), !.
+    kotlin_is_terminal_parts(Parts), !.
 kotlin_take_to_terminal([Line|Rest], [Line|More], After) :-
     kotlin_take_to_terminal(Rest, More, After).
 kotlin_take_to_terminal([], [], []).
+
+kotlin_is_terminal_parts(["proceed"]).
+kotlin_is_terminal_parts(["fail"]).
+kotlin_is_terminal_parts(["execute"|_]).
 
 kotlin_t4_clause_line_supported(Line) :-
     wam_kotlin_target:tokenize_wam_line(Line, Parts),
     ( Parts == [] -> true ; parts_supported(Parts) ),
     Parts \= ["cut_ite"|_],
     Parts \= ["jump"|_],
-    \+ (Parts = ["call"|_]),
-    \+ (Parts = ["execute"|_]).
+    % Mid-body call needs a continuation — EMIT-KOTLIN-5.
+    \+ (Parts = ["call"|_]).
 
 kotlin_t4_terminal_line(Line) :-
     wam_kotlin_target:tokenize_wam_line(Line, Parts),
-    ( Parts == ["proceed"] ; Parts == ["fail"] ).
+    kotlin_is_terminal_parts(Parts).
 
 wam_kotlin_lowerable(_PI, WamCode, Reason) :-
     catch(build_emission_plan(WamCode, plan(Reason, _, Payload)), _, fail),
@@ -144,9 +152,15 @@ wam_kotlin_lowerable(_PI, WamCode, Reason) :-
         forall(member(guard(_, Rem), Guards), kotlin_chain_rem_supported(Rem))
     ;   Reason == multi_clause_n
     ->  forall(member(Cl, Payload),
-               forall(member(Line, Cl), line_supported(Line)))
-    ;   forall(member(Line, Payload), line_supported(Line))
+               ( forall(member(Line, Cl), line_supported(Line)),
+                 \+ kotlin_clause_has_call(Cl) ))
+    ;   forall(member(Line, Payload), line_supported(Line)),
+        \+ kotlin_clause_has_call(Payload)
     ).
+
+kotlin_clause_has_call(Lines) :-
+    member(Line, Lines),
+    wam_kotlin_target:tokenize_wam_line(Line, ["call"|_]).
 
 line_supported(Line) :-
     wam_kotlin_target:tokenize_wam_line(Line, Parts),
@@ -154,15 +168,19 @@ line_supported(Line) :-
     ->  true
     ;   Parts = [F|_], sub_string(F, _, 1, 0, ":")
     ->  true
+    ;   Parts = ["call"|_]
+    ->  fail
     ;   parts_supported(Parts)
     ).
 
-% Structure/list + unify/set ops are lowerable. NO call/execute (EMIT-KOTLIN-4).
+% Structure/list + unify/set + last-call execute. Mid-body call → EMIT-KOTLIN-5.
 % get_variable/put_variable must emit `run { ... }` — see emit_line_parts/2.
 parts_supported(["allocate"]).
 parts_supported(["deallocate"]).
 parts_supported(["proceed"]).
 parts_supported(["fail"]).
+parts_supported(["execute", _]).
+parts_supported(["execute", _, _]).
 parts_supported(["get_constant", _, _]).
 parts_supported(["get_variable", _, _]).
 parts_supported(["get_value", _, _]).
@@ -212,12 +230,11 @@ lower_predicate_to_kotlin(PI, WamCode, _Options, lowered(PredName, FuncName, Cod
     ).
 
 emit_deterministic_function(PredName, FuncName, Lines, Code) :-
-    with_output_to(string(Body), emit_lines(Lines, "    ", comment)),
+    with_output_to(string(Body), emit_lines(Lines, "    ", return_true)),
     format(string(Code),
 '// Lowered: ~w (deterministic single-clause)
-fun ~w(state: WamState): Boolean {
-~w    return true
-}
+fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {
+~w}
 ', [PredName, FuncName, Body]).
 
 % T4: try each clause as a local fun; restore snapshot between attempts.
@@ -225,7 +242,7 @@ emit_multi_clause_n_function(PredName, FuncName, Clauses, Code) :-
     with_output_to(string(Body), emit_kotlin_t4_clauses(Clauses, 0)),
     format(string(Code),
 '// Lowered: ~w (T4 all-clauses inline)
-fun ~w(state: WamState): Boolean {
+fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {
     val _t4 = state.snapshotForNative()
 ~w    return false
 }
@@ -236,7 +253,7 @@ emit_kotlin_t4_clauses([Clause|Rest], N) :-
     N1 is N + 1,
     format(atom(CName), 'clause_~w', [N1]),
     format("    fun ~w(): Boolean {~n", [CName]),
-    % proceed → return true; fail → return false (via emit_line_parts).
+    % proceed → return true; execute → return dispatch(...); fail → return false.
     emit_lines(Clause, "        ", return_true),
     format("    }~n", []),
     format("    if (~w()) return true~n", [CName]),
@@ -248,7 +265,7 @@ emit_clause_chain_function(PredName, FuncName, Guards, Code) :-
     with_output_to(string(Dispatch), emit_kotlin_t5_guards(Guards)),
     format(string(Code),
 '// Lowered: ~w (T5 first-argument dispatch)
-fun ~w(state: WamState): Boolean {
+fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {
     val t5a1 = state.deref(state.readRegister("A1"))
     if (t5a1 is Value.Var) return false
 ~w    return false
@@ -259,21 +276,27 @@ emit_kotlin_t5_guards([]).
 emit_kotlin_t5_guards([guard(V, Rem)|Rest]) :-
     kotlin_constant_expr(V, Expr),
     format("    if (t5a1 == ~w) {~n", [Expr]),
-    emit_kotlin_t5_rem(Rem, "        "),
-    format("        return true~n", []),
+    emit_kotlin_t5_rem(Rem, "        ", Ended),
+    (   Ended == true
+    ->  true
+    ;   format("        return true~n", [])
+    ),
     format("    }~n", []),
     emit_kotlin_t5_guards(Rest).
 
-emit_kotlin_t5_rem([], _).
-emit_kotlin_t5_rem([get_constant(C, R)|Rest], Ind) :- !,
+emit_kotlin_t5_rem([], _, false).
+emit_kotlin_t5_rem([get_constant(C, R)|Rest], Ind, Ended) :- !,
     emit_line_parts(["get_constant", C, R], Ind),
-    emit_kotlin_t5_rem(Rest, Ind).
-emit_kotlin_t5_rem([line(Parts)|Rest], Ind) :- !,
+    emit_kotlin_t5_rem(Rest, Ind, Ended).
+emit_kotlin_t5_rem([line(Parts)|Rest], Ind, Ended) :- !,
     (   Parts == ["proceed"]
-    ->  true
-    ;   emit_line_parts(Parts, Ind)
-    ),
-    emit_kotlin_t5_rem(Rest, Ind).
+    ->  emit_kotlin_t5_rem(Rest, Ind, Ended)
+    ;   Parts = ["execute"|_]
+    ->  emit_line_parts(Parts, Ind),
+        Ended = true
+    ;   emit_line_parts(Parts, Ind),
+        emit_kotlin_t5_rem(Rest, Ind, Ended)
+    ).
 
 % ProceedMode = comment | return_true
 emit_lines([], _, _).
@@ -289,6 +312,15 @@ emit_lines([Line|Rest], Ind, ProceedMode) :-
 
 emit_line_parts(["proceed"], I) :- !, format("~w// proceed~n", [I]).
 emit_line_parts(["fail"], I) :- !, format("~wreturn false~n", [I]).
+emit_line_parts(["execute", PredArity], I) :- !,
+    kotlin_execute_pred_key(PredArity, Key),
+    escape_kotlin_string(Key, Esc),
+    format("~wreturn dispatch(\"~w\", state)~n", [I, Esc]).
+emit_line_parts(["execute", Pred, ArityStr], I) :- !,
+    strip_arity_token(Pred, Name),
+    format(string(PA), '~w/~w', [Name, ArityStr]),
+    escape_kotlin_string(PA, Esc),
+    format("~wreturn dispatch(\"~w\", state)~n", [I, Esc]).
 emit_line_parts(["allocate"], I) :- !,
     format("~wstate.allocateEnvironment()~n", [I]).
 emit_line_parts(["deallocate"], I) :- !,
@@ -379,6 +411,22 @@ emit_line_parts(["unify_constant", C], I) :- !,
     format("~wif (!kotlinLoUnifyConstant(state, ~w)) return false~n", [I, Expr]).
 emit_line_parts(["unify_nil"], I) :- !,
     format("~wif (!kotlinLoUnifyConstant(state, Value.Atom(\"[]\"))) return false~n", [I]).
+
+% execute target key: "foo/2" or already-slashed token.
+kotlin_execute_pred_key(Tok, Key) :-
+    atom_string_like(Tok, S),
+    (   sub_string(S, _, 1, _, "/")
+    ->  Key = S
+    ;   Key = S
+    ).
+
+strip_arity_token(Tok, Name) :-
+    atom_string_like(Tok, S),
+    (   sub_string(S, B, 1, _, "/"),
+        sub_string(S, 0, B, _, Name)
+    ->  true
+    ;   Name = S
+    ).
 
 kotlin_register_lit(Reg, Lit) :-
     atom_string_like(Reg, S),

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -310,9 +310,13 @@ data class WamNativeSnapshot(
     val pc: Int,
 )
 
+// Native lowered predicates. The dispatch callback is WamRuntime.tryRun —
+// used for last-call `execute P/N` (EMIT-KOTLIN-4). Non-execute bodies ignore it.
+typealias WamNativeFn = (WamState, (String, WamState) -> Boolean) -> Boolean
+
 class WamProgram {
     private val predicates: MutableMap<String, PredicateCode> = linkedMapOf()
-    private val natives: MutableMap<String, (WamState) -> Boolean> = linkedMapOf()
+    private val natives: MutableMap<String, WamNativeFn> = linkedMapOf()
 
     fun register(name: String, instructions: List<Instruction>) {
         val labels = linkedMapOf<String, Int>()
@@ -324,11 +328,11 @@ class WamProgram {
         predicates[name] = PredicateCode(instructions, labels)
     }
 
-    fun registerNative(key: String, fn: (WamState) -> Boolean) {
+    fun registerNative(key: String, fn: WamNativeFn) {
         natives[key] = fn
     }
 
-    fun findNative(key: String): ((WamState) -> Boolean)? = natives[key]
+    fun findNative(key: String): WamNativeFn? = natives[key]
 
     fun findCode(name: String): PredicateCode? = predicates[name]
 
@@ -356,7 +360,9 @@ class WamRuntime(private val program: WamProgram) {
     fun tryRun(predicate: String, initialState: WamState = WamState()): Boolean {
         program.findNative(predicate)?.let { nativeFn ->
             val snapshot = initialState.snapshotForNative()
-            if (nativeFn(initialState)) {
+            // Thread tryRun as dispatch so lowered `execute P` can tail-call
+            // (native-first, then bytecode) without a separate runtime handle.
+            if (nativeFn(initialState, this::tryRun)) {
                 return true
             }
             if (program.findCode(predicate) == null) {

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -984,9 +984,9 @@ ct_teardown(cpp, cpp_ctx(Dir, Map)) :-
 % Two opt-in targets share this adapter:
 %   kotlin            — emit_mode(interpreter)
 %   kotlin_functions  — emit_mode(functions) (native-first + WAM fallback)
-% Classic multi-clause programs (member/append/fib/…) decline lowering and
-% stay on the interpreter under kotlin_functions; that is expected until
-% EMIT-KOTLIN-3 (multi-clause / call in lowered bodies).
+% Classic multi-clause programs with last-call execute (member/append/acc-reverse)
+% lower under kotlin_functions (EMIT-KOTLIN-4). Mid-body call (fib/ack) still
+% declines to the interpreter until EMIT-KOTLIN-5.
 % ============================================================
 
 ct_build(kotlin, Preds, Queries, kotlin_ctx(Dir, Map)) :-

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -31,6 +31,17 @@
 :- dynamic kt3_pair/2.
 :- dynamic kt3_t4/2.
 :- dynamic kt3_mem/2.
+:- dynamic kt4_mem/2.
+:- dynamic kt4_mem_ok/0.
+:- dynamic kt4_mem_bad/0.
+:- dynamic kt4_app/3.
+:- dynamic kt4_app_ok/0.
+:- dynamic kt4_app_bad/0.
+:- dynamic kt4_rev_acc/3.
+:- dynamic kt4_rev/2.
+:- dynamic kt4_rev_ok/0.
+:- dynamic kt4_rev_bad/0.
+:- dynamic kt4_fib/2.
 
 :- begin_tests(wam_kotlin_target).
 
@@ -97,9 +108,11 @@ test(runtime_template_exposes_executable_wam_abi) :-
     assertion(has_substring(Code, '"get_structure"')),
     assertion(has_substring(Code, '"unify_variable"')),
     assertion(has_substring(Code, '"put_value", "put_unsafe_value"')),
-    assertion(has_substring(Code, 'fun registerNative(key: String, fn: (WamState) -> Boolean)')),
+    assertion(has_substring(Code, 'typealias WamNativeFn')),
+    assertion(has_substring(Code, 'fun registerNative(key: String, fn: WamNativeFn)')),
     assertion(has_substring(Code, 'fun snapshotForNative(): WamNativeSnapshot')),
     assertion(has_substring(Code, 'fun tryRun(predicate: String, initialState: WamState')),
+    assertion(has_substring(Code, 'this::tryRun')),
     assertion(has_substring(Code, 'fun functorName(functor: String): String')),
     assertion(has_substring(Code, 'fun kotlinLoGetConstant(state: WamState')),
     assertion(has_substring(Code, 'fun stateFromCliArgs(values: List<String>): WamState')).
@@ -531,8 +544,8 @@ test(y_env_recursion_fib, [condition(gradle_available), nondet]) :-
         )
     ).
 
-% EMIT-KOTLIN-3: deterministic multi-clause (no call/execute) lowers;
-% recursion still declines.
+% EMIT-KOTLIN-3: deterministic multi-clause (no mid-body call) lowers;
+% EMIT-KOTLIN-4: last-call execute (member) also lowers; fib stays declined.
 test(functions_mode_multi_clause_partition, [nondet]) :-
     setup_call_cleanup(
         (   retractall(user:kt3_color(_)),
@@ -556,7 +569,7 @@ test(functions_mode_multi_clause_partition, [nondet]) :-
             assertion(memberchk(native(kt3_color/1, _), Native)),
             assertion(memberchk(native(kt3_pair/2, _), Native)),
             assertion(memberchk(native(kt3_t4/2, _), Native)),
-            assertion(\+ memberchk(native(kt3_mem/2, _), Native)),
+            assertion(memberchk(native(kt3_mem/2, _), Native)),
             assertion(memberchk(wam(kt3_mem/2, _), Wam)),
             memberchk(native(kt3_color/1, lowered(_, _, ColorCode)), Native),
             assertion(has_substring(ColorCode, 'T5 first-argument dispatch')),
@@ -564,7 +577,10 @@ test(functions_mode_multi_clause_partition, [nondet]) :-
             memberchk(native(kt3_t4/2, lowered(_, _, T4Code)), Native),
             assertion(has_substring(T4Code, 'T4 all-clauses inline')),
             assertion(has_substring(T4Code, 'snapshotForNative')),
-            assertion(has_substring(T4Code, 'restoreFromSnapshot'))
+            assertion(has_substring(T4Code, 'restoreFromSnapshot')),
+            memberchk(native(kt3_mem/2, lowered(_, _, MemCode)), Native),
+            assertion(has_substring(MemCode, 'return dispatch("kt3_mem/2"')),
+            assertion(has_substring(MemCode, 'dispatch: (String, WamState) -> Boolean'))
         ),
         (   retractall(user:kt3_color(_)),
             retractall(user:kt3_pair(_, _)),
@@ -672,6 +688,180 @@ test(functions_mode_gradle_multi_clause_t4, [condition(gradle_available), nondet
             assertion(FZTrim == IZTrim)
         ),
         retractall(user:kt3_t4(_, _))
+    ).
+
+% EMIT-KOTLIN-4: last-call execute — member/append/acc-reverse LOWER;
+% mid-body call (fib) still declines.
+test(functions_mode_execute_partition, [nondet]) :-
+    setup_call_cleanup(
+        (   retractall(user:kt4_mem(_, _)),
+            retractall(user:kt4_app(_, _, _)),
+            retractall(user:kt4_rev_acc(_, _, _)),
+            retractall(user:kt4_rev(_, _)),
+            retractall(user:kt4_fib(_, _)),
+            assertz(user:kt4_mem(X, [X|_])),
+            assertz(user:(kt4_mem(X, [_|T]) :- kt4_mem(X, T))),
+            assertz(user:kt4_app([], L, L)),
+            assertz(user:(kt4_app([H|T], L, [H|R]) :- kt4_app(T, L, R))),
+            assertz(user:kt4_rev_acc([], A, A)),
+            assertz(user:(kt4_rev_acc([H|T], A, R) :- kt4_rev_acc(T, [H|A], R))),
+            assertz(user:(kt4_rev(L, R) :- kt4_rev_acc(L, [], R))),
+            assertz(user:kt4_fib(0, 0)),
+            assertz(user:kt4_fib(1, 1)),
+            assertz(user:(kt4_fib(N, R) :- N > 1, N1 is N - 1, N2 is N - 2,
+                kt4_fib(N1, R1), kt4_fib(N2, R2), R is R1 + R2))
+        ),
+        (   wam_kotlin_partition_predicates(functions,
+                [user:kt4_mem/2, user:kt4_app/3, user:kt4_rev_acc/3,
+                 user:kt4_rev/2, user:kt4_fib/2],
+                Native, _Wam, Failed),
+            assertion(Failed == []),
+            assertion(memberchk(native(kt4_mem/2, _), Native)),
+            assertion(memberchk(native(kt4_app/3, _), Native)),
+            assertion(memberchk(native(kt4_rev_acc/3, _), Native)),
+            assertion(memberchk(native(kt4_rev/2, _), Native)),
+            assertion(\+ memberchk(native(kt4_fib/2, _), Native)),
+            memberchk(native(kt4_mem/2, lowered(_, _, MemCode)), Native),
+            assertion(has_substring(MemCode, 'return dispatch("kt4_mem/2"')),
+            memberchk(native(kt4_app/3, lowered(_, _, AppCode)), Native),
+            assertion(has_substring(AppCode, 'return dispatch("kt4_app/3"'))
+        ),
+        (   retractall(user:kt4_mem(_, _)),
+            retractall(user:kt4_app(_, _, _)),
+            retractall(user:kt4_rev_acc(_, _, _)),
+            retractall(user:kt4_rev(_, _)),
+            retractall(user:kt4_fib(_, _))
+        )
+    ).
+
+test(functions_mode_gradle_execute_member_append, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_execute_mem_app',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    Preds = [user:kt4_mem_ok/0, user:kt4_mem_bad/0, user:kt4_mem/2,
+             user:kt4_app_ok/0, user:kt4_app_bad/0, user:kt4_app/3],
+    setup_call_cleanup(
+        (   retractall(user:kt4_mem(_, _)),
+            retractall(user:kt4_mem_ok),
+            retractall(user:kt4_mem_bad),
+            retractall(user:kt4_app(_, _, _)),
+            retractall(user:kt4_app_ok),
+            retractall(user:kt4_app_bad),
+            assertz(user:kt4_mem(X, [X|_])),
+            assertz(user:(kt4_mem(X, [_|T]) :- kt4_mem(X, T))),
+            assertz(user:(kt4_mem_ok :- kt4_mem(b, [a,b,c]))),
+            assertz(user:(kt4_mem_bad :- kt4_mem(z, [a,b,c]))),
+            assertz(user:kt4_app([], L, L)),
+            assertz(user:(kt4_app([H|T], L, [H|R]) :- kt4_app(T, L, R))),
+            assertz(user:(kt4_app_ok :- kt4_app([a,b], [c], [a,b,c]))),
+            assertz(user:(kt4_app_bad :- kt4_app([a], [b], [a,c])))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                Preds, [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_mem_ok/0'], IMO, _, SM1),
+            assertion(SM1 == exit(0)),
+            normalize_space(string(IMOTrim), IMO),
+            assertion(IMOTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_mem_bad/0'], IMB, _, SM2),
+            assertion(SM2 == exit(0)),
+            normalize_space(string(IMBTrim), IMB),
+            assertion(IMBTrim == "false"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_app_ok/0'], IAO, _, SA1),
+            assertion(SA1 == exit(0)),
+            normalize_space(string(IAOTrim), IAO),
+            assertion(IAOTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_app_bad/0'], IAB, _, SA2),
+            assertion(SA2 == exit(0)),
+            normalize_space(string(IABTrim), IAB),
+            assertion(IABTrim == "false"),
+            wam_kotlin_target:write_wam_kotlin_project(
+                Preds, [emit_mode(functions), conformance_main(true)], TmpDir),
+            read_file_to_string(
+                'output/test_wam_kotlin_execute_mem_app/src/main/kotlin/generated/wam/Main.kt',
+                Main, []),
+            assertion(has_substring(Main, 'fun lowered_kt4_mem_2')),
+            assertion(has_substring(Main, 'registerNative("kt4_mem/2"')),
+            assertion(has_substring(Main, 'fun lowered_kt4_app_3')),
+            assertion(has_substring(Main, 'return dispatch("kt4_mem/2"')),
+            assertion(has_substring(Main, 'return dispatch("kt4_app/3"')),
+            run_gradle(TmpDir, ['-q', 'compileKotlin'], _, _, CS),
+            assertion(CS == exit(0)),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_mem_ok/0'], FMO, _, SM3),
+            assertion(SM3 == exit(0)),
+            normalize_space(string(FMOTrim), FMO),
+            assertion(FMOTrim == IMOTrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_mem_bad/0'], FMB, _, SM4),
+            assertion(SM4 == exit(0)),
+            normalize_space(string(FMBTrim), FMB),
+            assertion(FMBTrim == IMBTrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_app_ok/0'], FAO, _, SA3),
+            assertion(SA3 == exit(0)),
+            normalize_space(string(FAOTrim), FAO),
+            assertion(FAOTrim == IAOTrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_app_bad/0'], FAB, _, SA4),
+            assertion(SA4 == exit(0)),
+            normalize_space(string(FABTrim), FAB),
+            assertion(FABTrim == IABTrim)
+        ),
+        (   retractall(user:kt4_mem(_, _)),
+            retractall(user:kt4_mem_ok),
+            retractall(user:kt4_mem_bad),
+            retractall(user:kt4_app(_, _, _)),
+            retractall(user:kt4_app_ok),
+            retractall(user:kt4_app_bad)
+        )
+    ).
+
+test(functions_mode_gradle_execute_acc_reverse, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_execute_rev',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    Preds = [user:kt4_rev_ok/0, user:kt4_rev_bad/0, user:kt4_rev/2, user:kt4_rev_acc/3],
+    setup_call_cleanup(
+        (   retractall(user:kt4_rev_acc(_, _, _)),
+            retractall(user:kt4_rev(_, _)),
+            retractall(user:kt4_rev_ok),
+            retractall(user:kt4_rev_bad),
+            assertz(user:kt4_rev_acc([], A, A)),
+            assertz(user:(kt4_rev_acc([H|T], A, R) :- kt4_rev_acc(T, [H|A], R))),
+            assertz(user:(kt4_rev(L, R) :- kt4_rev_acc(L, [], R))),
+            assertz(user:(kt4_rev_ok :- kt4_rev([a,b,c], [c,b,a]))),
+            assertz(user:(kt4_rev_bad :- kt4_rev([a,b,c], [a,b,c])))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                Preds, [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_rev_ok/0'], IO, _, S1),
+            assertion(S1 == exit(0)),
+            normalize_space(string(IOTrim), IO),
+            assertion(IOTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_rev_bad/0'], IB, _, S2),
+            assertion(S2 == exit(0)),
+            normalize_space(string(IBTrim), IB),
+            assertion(IBTrim == "false"),
+            wam_kotlin_target:write_wam_kotlin_project(
+                Preds, [emit_mode(functions), conformance_main(true)], TmpDir),
+            read_file_to_string(
+                'output/test_wam_kotlin_execute_rev/src/main/kotlin/generated/wam/Main.kt',
+                Main, []),
+            assertion(has_substring(Main, 'registerNative("kt4_rev_acc/3"')),
+            assertion(has_substring(Main, 'registerNative("kt4_rev/2"')),
+            assertion(has_substring(Main, 'return dispatch("kt4_rev_acc/3"')),
+            run_gradle(TmpDir, ['-q', 'compileKotlin'], _, _, CS),
+            assertion(CS == exit(0)),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_rev_ok/0'], FO, _, S3),
+            assertion(S3 == exit(0)),
+            normalize_space(string(FOTrim), FO),
+            assertion(FOTrim == IOTrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt4_rev_bad/0'], FB, _, S4),
+            assertion(S4 == exit(0)),
+            normalize_space(string(FBTrim), FB),
+            assertion(FBTrim == IBTrim)
+        ),
+        (   retractall(user:kt4_rev_acc(_, _, _)),
+            retractall(user:kt4_rev(_, _)),
+            retractall(user:kt4_rev_ok),
+            retractall(user:kt4_rev_bad)
+        )
     ).
 
 :- end_tests(wam_kotlin_target).

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -262,7 +262,7 @@ test(functions_mode_emits_lowered_fun_and_register_native, [nondet]) :-
         ),
         (   wam_kotlin_target:write_wam_kotlin_project([user:kt_fact/2], [emit_mode(functions)], TmpDir),
             read_file_to_string('output/test_wam_kotlin_functions_fact/src/main/kotlin/generated/wam/Main.kt', Main, []),
-            assertion(has_substring(Main, 'fun lowered_kt_fact_2(state: WamState): Boolean')),
+            assertion(has_substring(Main, 'fun lowered_kt_fact_2(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean')),
             assertion(has_substring(Main, 'program.registerNative("kt_fact/2", ::lowered_kt_fact_2)')),
             assertion(has_substring(Main, 'register_kt_fact(program)')),
             assertion(\+ has_substring(Main, 'Native Kotlin lowering selected'))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lowers last-call `execute P/N` in Kotlin hybrid WAM bodies so tail-recursive predicates (member, append, accumulator reverse) register as native instead of declining. Mid-body `call` stays declined → **EMIT-KOTLIN-5**.

### Dispatch seam
- Native fn type: `(WamState, dispatch: (String, WamState) -> Boolean) -> Boolean`
- `tryRun` passes `this::tryRun` as dispatch
- Emit: `return dispatch("P/N", state)`

### Boundary
- **Lowers:** `execute` only (`cmem`, `capp`, `crev_acc`, `clist_reverse`)
- **Declines:** mid-body `call` (fib/ack), cut/ITE/aggregates
- **Depth:** JVM stack; ~1000 peano OK, ~2000 → StackOverflowError; conformance list lengths safe

### Verification (green)
```bash
LANG=C.UTF-8 swipl -q -g run_tests -t halt tests/test_wam_kotlin_target.pl
# 25 passed

LANG=C.UTF-8 CONFORMANCE_TARGETS=kotlin,kotlin_functions swipl -q -g run_tests -t halt tests/test_wam_cross_target_conformance.pl
# kotlin + kotlin_functions passed

# kotlin_functions registers lowered_cmem_2 / lowered_capp_3 / etc.; cfib/cack decline
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

