### PR TITLE
WAM/LLVM plawk: row-oriented records design + schema surface (phase 8.1)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -29,7 +29,9 @@ pass, so it is both the in-memory channel between passes and durable across
 runs (file and LMDB backends); and the `over TABLE` reader (phase 4):
 `pass over TABLE as VAR { print ... }` iterates a table's entries as the
 pass's record source (named fields — key bound to `VAR`, value via
-`TABLE[VAR]`) instead of re-scanning the input. **Not yet:** the `over prev`
+`TABLE[VAR]`) instead of re-scanning the input. **Not yet:** row-oriented /
+record-valued tables (phase 8 — a table whose value is a named-field row,
+`records of TABLE as r` / `r["col"]`; designed in §3.6); the `over prev`
 reader (phase 4 follow-on); the query reader (phase 6); namespaces / `eager`
 / secondary indexes; string-literal print fields. See the per-phase status
 tags in §5.
@@ -402,6 +404,91 @@ updates the table's index sub-DBs (a write-amplification cost to keep in
 mind). Deferred to a phase past v1; captured here so the surface is coherent
 when it lands.
 
+### 3.6 Row-oriented records (record-valued tables)
+
+Everything above keys a table to a single `i64` value. The next step is a
+table whose value is a **row** — a record with several named columns — so a
+lookup returns the row and a program addresses a field by **column name**,
+exactly as if the row were an associative array:
+
+```awk
+BEGIN cache("orders.db") { declare orders(cust str, amount i64) }   # schema
+
+pass records of orders as r {          # iterate rows; r is a named-field row
+    print r["cust"], r["amount"]       # field = row/column intersection
+}
+```
+
+This is the "retrieve by key, get the row back as an assoc array keyed by
+column name" shape the surface has been building toward — it is the
+concrete meaning of the "record-valued tables" that §3.5 (secondary indexes)
+and Phase 7 already depend on.
+
+**Storage model (decided): a row-blob per key.** Each primary key maps to
+one serialized record; a field read decodes that column from the blob using
+the declared schema. One store entry per row keeps it aligned with the
+durable / LMDB / larger-than-RAM direction (a row is one key→value pair, not
+N fanned-out tables) and reuses the existing record (de)serialization
+(`@wam_object_call_record` typecodes, the decode-into-struct machinery from
+the for-in stage-3 work) rather than adding a parallel encoding. The rejected
+alternative — one assoc table per column sharing a row-id key space — is
+less new runtime but costs N store round-trips and N commits per row and
+fights the single-entry-per-row durable model.
+
+**The schema lives with the table.** `declare NAME(col type, …)` extends the
+backed-`BEGIN` declaration with a column list (names + types; `str` / `i64`
+to start). The schema is the single source of truth used to (de)serialize
+and to resolve a column name to its slot. A bare `declare NAME` (no column
+list) stays exactly today's `i64`-valued table.
+
+**Two readers — a safe named one and a positional one.** These mirror the
+Reader role (§3.4) but for row values, and they have deliberately distinct
+contracts so neither is a grab-bag of modifiers:
+
+- **`records of TABLE as r` — safe, named, schema-required.** Columns are
+  addressed **by name only**: `r["cust"]`. **Numeric addressing is a parse
+  error** here. Requires a declared schema (that is what supplies the names
+  and the decode layout). This is the recommended, everyday form.
+
+- **`rows of TABLE as r` — positional.** Columns are addressed **by position**
+  (`r[1]`, `r[2]`, 1-indexed), for raw or ad-hoc stores. A schema spec may
+  appear at the read site, and its role depends on whether an authoritative
+  (`declare`d) schema already exists:
+  - **schema present →** the spec is a **check**: the store's row shape
+    (arity / types / names) must match, diagnosed at open, not as silent
+    garbage later.
+  - **no schema →** the reader must be marked **`unsafe`**, and the spec then
+    **defines/renames** the positional columns into names (so `r["a"]`
+    becomes usable even though the store carried no declared schema). The
+    same spec syntax thus *checks* in the safe case and *names* in the
+    unsafe case. `rows of` with named access but neither a declared schema
+    nor `unsafe` is an error (you are naming columns you never defined).
+
+  `unsafe` means precisely "I have no trusted schema — trust mine / skip the
+  check"; it is confined to `rows of`. `records of` never takes `unsafe` and
+  never addresses columns positionally.
+
+**Field access.** `r["col"]` (string-literal column key) for named access;
+`r[N]` (integer) for positional access under `rows of`. The `arr["str"]` /
+`arr[N]` key surface already exists; what is new is that `r` resolves against
+the row schema / positional slots rather than being a separate table.
+
+**Write side — separate design round.** Reading rows is the tractable half.
+How a pass *builds* a row (`orders[$1] = row($1, $2)`, field-wise
+`orders[$1]["amount"] = $2`, or an insert form) touches multi-column value
+assembly and the commit path, and is deferred to its own design step. The
+first implementation targets the **read path** over rows a prior pass or a
+pre-populated store produced.
+
+**Phasing** (each its own PR):
+1. **Schema surface** — `declare NAME(col type, …)` parses and carries a row
+   schema; bare `declare NAME` unchanged. No behavior change yet.
+2. **`records of TABLE as r`** — decode row blobs by schema, `r["col"]` read
+   path (the safe, named reader; model A).
+3. **Row write surface** — how a pass populates rows (own design round).
+4. **`rows of` + `unsafe` + inline spec** — the positional reader and the
+   check/rename semantics above.
+
 ## 4. Runtime: the cache ABI (the first build step)
 
 The LLVM target has no persistence layer. We add a small **backend-agnostic
@@ -569,7 +656,15 @@ single-pass test before any driver surgery).
   `max`/`avg` over a field). Backed by plain / `MDB_DUPSORT` index sub-DBs,
   maintained on write. The aggregation requirement is the determinism
   containment for a multi-valued lookup. Rides Phase 5 (needs the LMDB
-  sub-DB backend) and record-valued cache entries.
+  sub-DB backend) and record-valued cache entries (Phase 8).
+
+- **Phase 8 — row-oriented records (record-valued tables) (§3.6).** A table
+  whose value is a named-field **row**, stored as one serialized record per
+  key (model A). Sub-phases: (8.1) the `declare NAME(col type, …)` schema
+  surface; (8.2) the safe `records of TABLE as r` reader with name-only
+  `r["col"]` access; (8.3) the row write surface (own design); (8.4) the
+  positional `rows of` reader with `unsafe` / inline check-or-rename spec.
+  Foundational for Phase 7 (secondary indexes need addressable named fields).
 
 ## 6. Open questions
 
@@ -591,10 +686,11 @@ single-pass test before any driver surgery).
   its `print` feeds the spool instead of stdout. Does it *also* echo to
   stdout (tee), or only feed the next pass? Proposal: only feed the next
   pass (a true pipeline stage); the final, unconsumed pass prints to stdout.
-- **Value encoding for non-i64 cache values.** Records/blobs need a
-  serialization. v1: i64 and blob-bytes only; structured records reuse the
-  existing record (de)serialization (`@wam_object_call_record` typecodes)
-  keyed by the same layout — deferred to when a use needs it.
+- **Value encoding for non-i64 cache values — direction set (§3.6).**
+  Records/blobs need a serialization. v1: i64 and blob-bytes only.
+  Structured **row** values (Phase 8) reuse the existing record
+  (de)serialization (`@wam_object_call_record` typecodes) as one blob per
+  key, decoded by the table's declared `declare NAME(col type, …)` schema.
 - **Cache lifetime / cleanup.** A backed `BEGIN cache("path")` block names
   an explicit path, so the store is durable by construction (survives exit).
   Open: do we also want an *unnamed* backed block (`BEGIN cache { … }`) that

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -926,17 +926,48 @@ cache_backend(Backend) -->
 cache_backend(file) -->
     [].
 
-cache_decl_list(Path, Backend, [cache_table(Name, Path, Backend) | Rest]) -->
-    "declare", required_ws, identifier(Name),
-    cache_decl_list_rest(Path, Backend, Rest).
-cache_decl_list_rest(Path, Backend, [cache_table(Name, Path, Backend) | Rest]) -->
-    ws, cache_decl_sep, ws, "declare", required_ws, identifier(Name),
+cache_decl_list(Path, Backend, Actions) -->
+    cache_decl(Path, Backend, First),
+    cache_decl_list_rest(Path, Backend, Rest),
+    { append(First, Rest, Actions) }.
+cache_decl_list_rest(Path, Backend, Actions) -->
+    ws, cache_decl_sep, ws, cache_decl(Path, Backend, First),
     !,
-    cache_decl_list_rest(Path, Backend, Rest).
+    cache_decl_list_rest(Path, Backend, Rest),
+    { append(First, Rest, Actions) }.
 cache_decl_list_rest(_Path, _Backend, []) -->
     [].
 cache_decl_sep --> ";", !.
 cache_decl_sep --> [].
+
+% One `declare` in a backed BEGIN block. A bare `declare NAME` is today's
+% i64-valued table (one begin action, cache_table/3). `declare NAME(col type,
+% ...)` (PLAWK_MULTIPASS_CACHE.md §3.6, row-oriented records) additionally
+% carries a ROW SCHEMA -- named columns with types -- emitted as a separate
+% cache_schema(NAME, Columns) action, so the existing cache_table/3 consumers
+% are untouched and the schema is available to the record readers. Columns are
+% col(Name, Type) with Type in {str, i64}. The column-list clause is tried
+% first; a bare declare falls through.
+cache_decl(Path, Backend,
+        [cache_table(Name, Path, Backend), cache_schema(Name, Columns)]) -->
+    "declare", required_ws, identifier(Name), ws,
+    cache_col_list(Columns),
+    !.
+cache_decl(Path, Backend, [cache_table(Name, Path, Backend)]) -->
+    "declare", required_ws, identifier(Name).
+
+cache_col_list(Columns) -->
+    "(", ws, cache_cols(Columns), ws, ")".
+cache_cols([col(Name, Type) | Rest]) -->
+    identifier(Name), required_ws, cache_col_type(Type),
+    cache_cols_rest(Rest).
+cache_cols_rest([col(Name, Type) | Rest]) -->
+    ws, ",", ws, identifier(Name), required_ws, cache_col_type(Type),
+    !,
+    cache_cols_rest(Rest).
+cache_cols_rest([]) --> [].
+cache_col_type(str) --> "str".
+cache_col_type(i64) --> "i64".
 
 begin_actions([Action | Actions]) -->
     begin_action(Action),

--- a/tests/test_plawk_row_schema.pl
+++ b/tests/test_plawk_row_schema.pl
@@ -1,0 +1,102 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk row-oriented records (PLAWK_MULTIPASS_CACHE.md §3.6, phase 8.1): the
+% SCHEMA SURFACE. A backed-BEGIN `declare NAME(col type, ...)` carries a row
+% schema -- named columns with types -- for the record readers (records of /
+% rows of, later sub-phases). The schema is emitted as a separate
+% cache_schema(NAME, Columns) begin action ALONGSIDE the existing
+% cache_table/3, so every current cache_table consumer is untouched and a
+% schema-declared table used as an ordinary i64 table behaves exactly as
+% before (the schema is inert until the readers land). A bare `declare NAME`
+% is unchanged.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_row_schema).
+
+% `declare NAME(col type, ...)` yields cache_table/3 (unchanged) PLUS a
+% cache_schema/2 carrying the ordered typed columns.
+test(schema_declare_parses) :-
+    plawk_parse_string(
+        "BEGIN cache(\"o.db\") { declare orders(cust str, amount i64) }\n\c
+         { orders[$1]++ }\nEND { for (k in orders) print k, orders[k] }\n",
+        program([begin([cache_table(orders, "o.db", file),
+                        cache_schema(orders, [col(cust, str), col(amount, i64)])])],
+                _, _)),
+    !.
+
+% A bare `declare NAME` is unchanged -- cache_table/3 only, no cache_schema.
+test(bare_declare_unchanged) :-
+    plawk_parse_string(
+        "BEGIN cache(\"h.db\") { declare c }\n{ c[$1]++ }\n\c
+         END { for (k in c) print k, c[k] }\n",
+        program([begin([cache_table(c, "h.db", file)])], _, _)),
+    \+ plawk_parse_string(
+        "BEGIN cache(\"h.db\") { declare c }\n{ c[$1]++ }\n\c
+         END { for (k in c) print k, c[k] }\n",
+        program([begin([cache_table(_, _, _), cache_schema(_, _) | _])], _, _)),
+    !.
+
+% Mixed: a bare table and a schema'd table in one block, in order.
+test(mixed_declares_parse) :-
+    plawk_parse_string(
+        "BEGIN cache(\"m.db\") { declare c ; declare orders(cust str, amount i64) }\n\c
+         { c[$1]++ }\nEND { for (k in c) print k, c[k] }\n",
+        program([begin([cache_table(c, "m.db", file),
+                        cache_table(orders, "m.db", file),
+                        cache_schema(orders, [col(cust, str), col(amount, i64)])])],
+                _, _)),
+    !.
+
+% The schema is INERT: a schema-declared table used as an ordinary i64 table
+% compiles and runs exactly as a bare-declared one would. Over a a b: a 2 / b 1.
+test(schema_inert_compiles, [condition(clang_available)]) :-
+    sdir(Dir),
+    directory_file_path(Dir, 'sch.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare orders(cust str, amount i64) }\n\c
+         { orders[$1]++ }\nEND { for (k in orders) print k, orders[k] }\n", [Store]),
+    run_sorted(Dir, 'sch', Src, "a\na\nb\n", S),
+    assertion(S == ["a 2", "b 1"]),
+    !.
+
+:- end_tests(plawk_row_schema).
+
+% --- helpers ---------------------------------------------------------------
+
+sdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_row_schema', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
Design + first foundational slice for **record-valued tables** — a table whose value is a named-field **row**, so a lookup returns the row as an associative array keyed by column name (`r["cust"]`).

## Design (docs/design/PLAWK_MULTIPASS_CACHE.md §3.6, Phase 8)
Written into the project per our discussion:
- **Storage model A** — one serialized record per key (reuses the existing record (de)serialization rather than fanning out per-column tables; aligned with the durable/LMDB direction).
- **Two readers, distinct contracts:**
  - `records of TABLE as r` — **safe, name-only** (`r["cust"]`), schema-required; **numeric addressing is a parse error**.
  - `rows of TABLE as r` — **positional** (`r[N]`), with `unsafe` + an inline spec that **checks** against a declared schema or, under `unsafe`, **defines/renames** the positional columns. (`unsafe` = "no trusted schema — trust mine / skip the check"; confined to `rows of`.)
- **Write side deferred** to its own design round; the read path lands first.
- Sub-phases 8.1–8.4 recorded in §5; the "record-valued cache entries" that §3.5 (secondary indexes / Phase 7) already referenced now point here.

## Phase 8.1 — the schema surface (this PR)
A backed-BEGIN `declare NAME(col type, …)` (types `str` / `i64`) now carries a row schema, emitted as a **separate `cache_schema(NAME, Columns)`** begin action **alongside** the existing `cache_table/3`. So every current `cache_table` consumer is untouched, and a schema-declared table used as an ordinary i64 table behaves exactly as before — the schema is **inert** until the readers land. A bare `declare NAME` is unchanged.

## Tests
`tests/test_plawk_row_schema.pl` — schema parse (`cache_table` + ordered typed `cache_schema`), bare-declare unchanged, mixed declares, and the inert schema compiling/running as a plain i64 table. Regression green across cache-surface, cache-lmdb, multipass-cache, over-table, passes.

Next up (phase 8.2): the `records of TABLE as r` reader decoding row blobs by this schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_