### PR TITLE
WAM/LLVM plawk: row capture writer (arr[$k] = $0) for record-valued tables (phase 8.2)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -473,21 +473,37 @@ contracts so neither is a grab-bag of modifiers:
 `arr[N]` key surface already exists; what is new is that `r` resolves against
 the row schema / positional slots rather than being a separate table.
 
-**Write side — separate design round.** Reading rows is the tractable half.
-How a pass *builds* a row (`orders[$1] = row($1, $2)`, field-wise
-`orders[$1]["amount"] = $2`, or an insert form) touches multi-column value
-assembly and the commit path, and is deferred to its own design step. The
-first implementation targets the **read path** over rows a prior pass or a
-pre-populated store produced.
+**Write side.** How a pass *builds* a row touches multi-column value
+assembly and the commit path. The **first, minimal writer has LANDED**:
+`TABLE[$k] = $0` captures the whole current record as a row value (its bytes,
+interned to a stable id; replace semantics), keyed by field k. This is the
+natural "capture / index / dedup records by a key" producer and needs no new
+storage runtime — the row rides the existing str-value assoc mechanism (the
+i64 value is the row's atom id). A later pass reads it back (`over TABLE as
+k` today; `records of TABLE as r` once the named reader lands). A richer
+producer (`orders[$1] = row($1, $2)`, field-wise `orders[$1]["amount"] =
+$2`) remains a follow-on.
+
+**In-run vs durable — a limitation to note.** Because the stored value is an
+atom **id** (process-local), captured rows are correct **in-run** (multi-pass
+within one process, the primary use). They do **not** survive across separate
+runs of the binary: the current cache format persists `[key:i64 value:i64]`,
+so a committed row id is stale on reload. **Durable rows need a byte-valued
+cache format** (store the row's bytes, not the id) — the "value encoding for
+non-i64 cache values" open question — deferred to its own runtime round.
 
 **Phasing** (each its own PR):
 1. **Schema surface** — `declare NAME(col type, …)` parses and carries a row
-   schema; bare `declare NAME` unchanged. No behavior change yet.
-2. **`records of TABLE as r`** — decode row blobs by schema, `r["col"]` read
-   path (the safe, named reader; model A).
-3. **Row write surface** — how a pass populates rows (own design round).
-4. **`rows of` + `unsafe` + inline spec** — the positional reader and the
+   schema; bare `declare NAME` unchanged. No behavior change yet. **LANDED.**
+2. **Row capture writer** — `TABLE[$k] = $0` stores the record as a row
+   value; read back via `over TABLE`. In-run. **LANDED.**
+3. **`records of TABLE as r`** — decode a stored row by the schema, name-only
+   `r["col"]` read path (the safe, named reader).
+4. **Byte-valued cache storage** — durable rows across runs (store row bytes,
+   not the id).
+5. **`rows of` + `unsafe` + inline spec** — the positional reader and the
    check/rename semantics above.
+6. **Richer row producers** — `row(...)` constructor / field-wise writes.
 
 ## 4. Runtime: the cache ABI (the first build step)
 
@@ -659,12 +675,15 @@ single-pass test before any driver surgery).
   sub-DB backend) and record-valued cache entries (Phase 8).
 
 - **Phase 8 — row-oriented records (record-valued tables) (§3.6).** A table
-  whose value is a named-field **row**, stored as one serialized record per
-  key (model A). Sub-phases: (8.1) the `declare NAME(col type, …)` schema
-  surface; (8.2) the safe `records of TABLE as r` reader with name-only
-  `r["col"]` access; (8.3) the row write surface (own design); (8.4) the
-  positional `rows of` reader with `unsafe` / inline check-or-rename spec.
-  Foundational for Phase 7 (secondary indexes need addressable named fields).
+  whose value is a named-field **row** (model A). Sub-phases: (8.1) the
+  `declare NAME(col type, …)` schema surface — **LANDED**; (8.2) the row
+  capture writer `TABLE[$k] = $0` (str-value; in-run), read back via `over
+  TABLE` — **LANDED** (`tests/test_plawk_row_capture.pl`); (8.3) the safe
+  `records of TABLE as r` reader with name-only `r["col"]` decode by schema;
+  (8.4) byte-valued cache storage for durable rows across runs; (8.5) the
+  positional `rows of` reader with `unsafe` / inline check-or-rename spec;
+  (8.6) richer row producers (`row(...)` / field-wise). Foundational for
+  Phase 7 (secondary indexes need addressable named fields).
 
 ## 6. Open questions
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3788,6 +3788,11 @@ plawk_program_multipass_driver_ir(
     findall(R, ( member(pass(PassRules), Passes), member(R, PassRules) ), AllRules),
     plawk_multipass_pass_plan(AllRules, Tables, AssocPlan),  % validates surface
     plawk_multipass_table_params(Tables, TableParamsIR, TableArgsIR),
+    % Program-wide str-valued (row) tables: a table a writer pass populates
+    % via `arr[$k] = $0` holds string values, so an `over`/`records` reader
+    % must resolve the stored id to the row's bytes. Threaded to each reader.
+    maplist(plawk_assoc_rule_action_specs, AllRules, AllRuleSpecs),
+    plawk_assoc_specs_str_arrays(AllRuleSpecs, StrArrays),
     % A `BEGIN cache(...)`-declared shared table: load before pass 1, commit
     % after the last pass. Empty for pure-scalar / non-cache programs.
     plawk_program_cache_tables(BeginClauses, CacheTriples),
@@ -3799,7 +3804,7 @@ plawk_program_multipass_driver_ir(
     % sequence by index.
     findall(FnIR-GlobalIR,
         ( nth0(I, Passes, Pass),
-          plawk_multipass_pass_fn(I, Pass, Tables, TableParamsIR,
+          plawk_multipass_pass_fn(I, Pass, Tables, StrArrays, TableParamsIR,
               FieldSeparator, OutputSeparator, FnIR, GlobalIR)
         ),
         FnPairs),
@@ -3867,6 +3872,7 @@ plawk_passes_tables(Passes, Tables) :-
 
 plawk_action_table_name(inc_assoc(var(Name), _Key), Name).
 plawk_action_table_name(add_assoc(var(Name), _Key, _Delta), Name).
+plawk_action_table_name(set_row(var(Name), _Key), Name).
 plawk_action_table_name(print(Fields), Name) :-
     member(assoc(var(Name), _Key), Fields).
 
@@ -3897,7 +3903,7 @@ plawk_multipass_pass_plan(Rules, Tables, assoc_plan(Tables, PlannedRules)) :-
 %  of the input. GlobalIR carries any module globals the pass's body needs
 %  (rule chains emit format/string globals; the over reader emits none in
 %  v1 -- key + lookup print fields use the shared runtime constants).
-plawk_multipass_pass_fn(Index, pass(PassRules), Tables, TableParamsIR,
+plawk_multipass_pass_fn(Index, pass(PassRules), Tables, _StrArrays, TableParamsIR,
         FieldSep, _OutputSep, FnIR, GlobalIR) :-
     plawk_multipass_pass_plan(PassRules, Tables, PassPlan),
     plawk_assoc_rule_controls(PassPlan, PassControls),
@@ -3905,11 +3911,13 @@ plawk_multipass_pass_fn(Index, pass(PassRules), Tables, TableParamsIR,
     plawk_assoc_rule_chain_ir(PassPlan, FieldSep, GlobalIR, ChainIR),
     plawk_multipass_pass_fn_ir(Index, TableParamsIR, ChainIR, FnIR).
 plawk_multipass_pass_fn(Index, pass_over(var(Var), var(Table), Body), Tables,
-        TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
+        StrArrays, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
     Body = [print(PrintFields)],
     PrintFields = [_ | _],
     maplist(plawk_over_print_field_ok(Var), PrintFields),
-    AssocPlan = assoc_plan(Tables, []),
+    % Carry the program's str-valued tables so a lookup of a row-valued table
+    % (`TABLE[k]` = a stored row) resolves the id to the row's bytes.
+    AssocPlan = assoc_plan(Tables, [str_arrays(StrArrays)]),
     plawk_multipass_over_fn_ir(Index, TableParamsIR, Var, Table, PrintFields,
         AssocPlan, FieldSep, OutputSep, FnIR).
 
@@ -4103,6 +4111,7 @@ plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays) :-
         ( member(rule(_P, ActionSpecs, _C), RuleSpecs),
           ( member(dynassoc(A, str(_Call)), ActionSpecs)
           ; member(dynassoc(A, posarray_str(_Call)), ActionSpecs)
+          ; member(assoc_set_row(A, _Key), ActionSpecs)   % row-valued (str)
           )
         ),
         As0),
@@ -5364,6 +5373,14 @@ plawk_assoc_body_action_spec(add_assoc(var(ArrayName), field(KeyIndex), Delta),
 
 plawk_assoc_add_delta_ok(field(V)) :- integer(V), V > 0.
 plawk_assoc_add_delta_ok(int(V)) :- integer(V).
+% Row capture `arr[$k] = $0` (§3.6): store the whole current record ($0) as a
+% str-value (the record's bytes, interned) in the table at the key interned
+% from field k. The first producer of row-valued tables; a later pass reads
+% the row back (`over TABLE`, or `records of` with a schema). The table is
+% marked str-valued so value reads resolve to text.
+plawk_assoc_body_action_spec(set_row(var(ArrayName), field(KeyIndex)),
+        assoc_set_row(ArrayName, KeyIndex)) :-
+    integer(KeyIndex), KeyIndex > 0.
 plawk_assoc_body_action_spec(dynassoc_bind(var(ArrayName), Call),
         dynassoc(ArrayName, Call)) :-
     plawk_dynrec_call_ok(Call).
@@ -5644,6 +5661,13 @@ plawk_assoc_planned_actions([assoc_add(ArrayName, KeyIndex, Delta) | Rest],
       NextIndex is Index + 1
     },
     [assoc_add_action(Index, ArrayName, TableIndex, KeyIndex, Delta)],
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
+plawk_assoc_planned_actions([assoc_set_row(ArrayName, KeyIndex) | Rest],
+        Tables, StrArrays, PosArrays, Index) -->
+    { nth0(TableIndex, Tables, ArrayName),
+      NextIndex is Index + 1
+    },
+    [assoc_set_row_action(Index, ArrayName, TableIndex, KeyIndex)],
     plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
 plawk_assoc_planned_actions([dynassoc(ArrayName, Call) | Rest], Tables,
         StrArrays, PosArrays, Index) -->
@@ -6333,6 +6357,55 @@ plawk_assoc_rule_action_blocks(RuleIndex,
       format(atom(Next), '  br label %~w', [ActionNextLabel]),
       append([[Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, KeyId],
               DeltaLines, [Inc, Next, '']], Lines)
+    },
+    plawk_emit_lines(Lines),
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+% Row capture `arr[$k] = $0`: same key-intern + missing-key skip, then intern
+% the whole current record (field 0, a stable copy of the transient line) and
+% store that atom id as the table's value (str-value / replace semantics via
+% @wam_assoc_i64_set). A later pass resolves the id back to the row's bytes.
+plawk_assoc_rule_action_blocks(RuleIndex,
+        [assoc_set_row_action(Index, _ArrayName, TableIndex, KeyIndex) | Rest],
+        NextLabel, FieldSeparator) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(HaveLabelName), 'assoc_rule_~w_action_~w_have_key',
+          [RuleIndex, Index]),
+      format(atom(HaveLabel), 'assoc_rule_~w_action_~w_have_key:',
+          [RuleIndex, Index]),
+      format(atom(B), 'assoc_rule_~w_action_~w', [RuleIndex, Index]),
+      format(atom(Slice),
+          '  %~w_key_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 ~w)',
+          [B, KeyIndex, FieldSeparator]),
+      format(atom(Ptr), '  %~w_key_ptr = extractvalue %WamSlice %~w_key_slice, 0', [B, B]),
+      format(atom(Len), '  %~w_key_len = extractvalue %WamSlice %~w_key_slice, 1', [B, B]),
+      format(atom(Missing), '  %~w_key_missing = icmp eq i8* %~w_key_ptr, null', [B, B]),
+      format(atom(Branch), '  br i1 %~w_key_missing, label %~w, label %~w',
+          [B, ActionNextLabel, HaveLabelName]),
+      format(atom(KeyId),
+          '  %~w_key_id = call i64 @wam_intern_atom(i8* %~w_key_ptr, i64 %~w_key_len)',
+          [B, B, B]),
+      % the row value: the whole record ($0 is %line, the record atom). The
+      % transient line buffer is reused, so intern a stable copy of its bytes
+      % (atom -> string -> re-intern) and store that id as the table's value.
+      format(atom(RowLineId), '  %~w_row_lineid = extractvalue %Value %line, 1', [B]),
+      format(atom(RowPtr),
+          '  %~w_row_ptr = call i8* @wam_atom_to_string(i64 %~w_row_lineid)', [B, B]),
+      format(atom(RowLen), '  %~w_row_len = call i64 @strlen(i8* %~w_row_ptr)', [B, B]),
+      format(atom(RowId),
+          '  %~w_row_id = call i64 @wam_intern_atom(i8* %~w_row_ptr, i64 %~w_row_len)',
+          [B, B, B]),
+      format(atom(Set),
+          '  %~w_setrc = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_key_id, i64 %~w_row_id)',
+          [B, TableIndex, B, B]),
+      format(atom(Next), '  br label %~w', [ActionNextLabel]),
+      Lines = [Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, KeyId,
+               RowLineId, RowPtr, RowLen, RowId, Set, Next, '']
     },
     plawk_emit_lines(Lines),
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
@@ -8494,6 +8567,13 @@ plawk_assoc_plan_str_array(assoc_plan(_Tables, Rules), ArrayName) :-
     ; member(assoc_dyn_action(_Index2, ArrayName, _TableIndex2,
         posarray_str(_Call2)), Actions)
     ),
+    !.
+% A reader plan (e.g. the multi-pass `over`/`records` reader) carries the
+% program's str-valued table names directly, since the populating writer is
+% in a different pass function than this reader.
+plawk_assoc_plan_str_array(assoc_plan(_Tables, Rules), ArrayName) :-
+    member(str_arrays(StrArrays), Rules),
+    memberchk(ArrayName, StrArrays),
     !.
 
 %% plawk_assoc_plan_posarray_array(+AssocPlan, +ArrayName) is semidet.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1496,6 +1496,26 @@ assoc_add_delta(int(Value)) -->
       number_codes(Value, ValueCodes)
     }.
 
+% Row capture (PLAWK_MULTIPASS_CACHE.md §3.6): `TABLE[$k] = $0` stores the
+% whole current record ($0) as a row value in TABLE, keyed by field k -- the
+% first, minimal producer of row-valued tables. The row is a str-value (the
+% record's bytes); a later pass reads it back (`over TABLE`, and, with a
+% schema, `records of TABLE as r`). v1 stores $0 only (a `row(...)`
+% constructor is a follow-on). Tried before the scalar `set` -- the `[`
+% distinguishes them.
+assignment_action(set_row(var(Name), KeyExpr)) -->
+    identifier(Name),
+    ws,
+    "[",
+    ws,
+    assoc_key_expr(KeyExpr),
+    ws,
+    "]",
+    !,
+    ws,
+    "=",
+    ws,
+    "$0".
 assignment_action(set(var(Name), Value)) -->
     identifier(Name),
     ws,

--- a/tests/test_plawk_row_capture.pl
+++ b/tests/test_plawk_row_capture.pl
@@ -1,0 +1,86 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk row-oriented records (PLAWK_MULTIPASS_CACHE.md §3.6): the first ROW
+% WRITER. `TABLE[$k] = $0` captures the whole current record ($0) as a row
+% value in TABLE, keyed by field k -- the first producer of row-valued tables
+% (a str-value: the record's bytes, interned to a stable id, replace
+% semantics). A later pass reads the row back: `over TABLE as k` prints the
+% key and `TABLE[k]` resolves the stored id to the row's text. This is the
+% storage the named-column `records of TABLE as r` reader (next sub-phase)
+% builds on. In-run (one process); cross-run durable rows need byte-valued
+% cache storage, a follow-on.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_row_capture).
+
+% `TABLE[$k] = $0` parses to set_row/2; the scalar `NAME = expr` is unchanged.
+test(set_row_parses) :-
+    plawk_parse_string(
+        "pass { orders[$1] = $0 }\npass over orders as k { print k, orders[k] }\n",
+        program_passes([],
+            [pass([rule(always, [set_row(var(orders), field(1))])]),
+             pass_over(var(k), var(orders),
+                 [print([var(k), assoc(var(orders), var(k))])])],
+            [])),
+    plawk_parse_string("{ x = 5 }\nEND { print x }\n",
+        program(_, [rule(always, [set(var(x), int(5))])], _)),
+    !.
+
+% Capture each record keyed by $1, read the stored rows back. Replace
+% semantics: a repeated key keeps the LAST record. Over the three lines,
+% key a -> "a 20 z" (last a), key b -> "b 5 y".
+test(row_capture_readback, [condition(clang_available)]) :-
+    rdir(Dir),
+    Src = "pass { orders[$1] = $0 }\npass over orders as k { print k, orders[k] }\n",
+    run_sorted(Dir, 'row', Src, "a 10 x\nb 5 y\na 20 z\n", S),
+    assertion(S == ["a a 20 z", "b b 5 y"]),
+    !.
+
+% The stored row is the full record text (all fields), not just the key.
+test(row_is_full_record, [condition(clang_available)]) :-
+    rdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass over t as k { print t[k] }\n",
+    run_sorted(Dir, 'full', Src, "k1 alpha beta\nk2 gamma\n", S),
+    assertion(S == ["k1 alpha beta", "k2 gamma"]),
+    !.
+
+:- end_tests(plawk_row_capture).
+
+% --- helpers ---------------------------------------------------------------
+
+rdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_row_capture', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
The first producer of **row-valued tables** (§3.6, phase 8.2). `TABLE[$k] = $0` captures the whole current record as a row value, keyed by field k; a later pass reads it back:

```awk
pass { orders[$1] = $0 }
pass over orders as k { print k, orders[k] }
```

Over `a 10 x / b 5 y / a 20 z` → `a a 20 z` / `b b 5 y` (replace semantics — a repeated key keeps the last record).

### Why the writer first
`records of ... as r` (the named-column reader you asked for) can't be exercised without rows *in* the store, and today there's no way to write a multi-field row — so this is the storage prerequisite. It also surfaced the real constraint below.

## Changes
- **Parser**: `assignment_action` gains `IDENT[key] = $0` → `set_row/2` (tried before the scalar `set`; the `[` distinguishes; RHS is `$0` for now). Scalar `NAME = expr` unchanged.
- **Codegen**: `set_row` spec / `assoc_set_row_action` planned action / emitter (intern key + capture `$0` as a stable interned copy of the record's bytes + `@wam_assoc_i64_set`), table discovery, and str-array marking. The row rides the existing **str-value** assoc mechanism (value = the row's atom id) — **no new storage runtime**. The table is marked str-valued program-wide so a reader's `TABLE[k]` resolves the id back to the row text; that set is threaded to the multi-pass over-reader (whose writer lives in a different pass function) via a `str_arrays(...)` marker on its plan.

## Known limitation (documented)
**In-run only.** The value is a process-local atom **id**, so captured rows are correct within one process (multi-pass — the primary use) but do **not** survive across separate runs: the cache persists `[key:i64 value:i64]`, so a committed row id is stale on reload. **Durable rows need a byte-valued cache format** (store the row's bytes) — the "value encoding" open question, now phase 8.4.

## Tests
`tests/test_plawk_row_capture.pl` — `set_row` parse (scalar `set` unchanged), capture + readback with replace semantics, full-record storage. Regression green across multipass, passes, over-table, assoc-print, crosspass-scalar, perkey, multipass-cache, row-schema, forin-filter.

Next (phase 8.3): the `records of TABLE as r` named-column reader decoding a stored row by the declared schema (`r["cust"]` → the schema's column position → that field of the row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_