### PR TITLE
WAM/LLVM plawk: `records of TABLE as r` named row reader (phase 8.3)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -29,12 +29,14 @@ pass, so it is both the in-memory channel between passes and durable across
 runs (file and LMDB backends); and the `over TABLE` reader (phase 4):
 `pass over TABLE as VAR { print ... }` iterates a table's entries as the
 pass's record source (named fields — key bound to `VAR`, value via
-`TABLE[VAR]`) instead of re-scanning the input. **Not yet:** row-oriented /
-record-valued tables (phase 8 — a table whose value is a named-field row,
-`records of TABLE as r` / `r["col"]`; designed in §3.6); the `over prev`
-reader (phase 4 follow-on); the query reader (phase 6); namespaces / `eager`
-/ secondary indexes; string-literal print fields. See the per-phase status
-tags in §5.
+`TABLE[VAR]`) instead of re-scanning the input; and row-oriented / record-valued tables
+(phase 8, §3.6): a table whose value is a named-field **row** — captured with
+`TABLE[$k] = $0` and read back by column name with `records of TABLE as r`
+(`r["col"]`, resolved through the `declare TABLE(col type, …)` schema), in-run.
+**Not yet:** durable rows across runs (byte-valued cache storage, phase 8.4);
+the positional `rows of` reader (phase 8.5); the `over prev` reader (phase 4
+follow-on); the query reader (phase 6); namespaces / `eager` / secondary
+indexes; string-literal print fields. See the per-phase status tags in §5.
 
 ## Implemented surface (quick reference)
 
@@ -445,10 +447,12 @@ list) stays exactly today's `i64`-valued table.
 Reader role (§3.4) but for row values, and they have deliberately distinct
 contracts so neither is a grab-bag of modifiers:
 
-- **`records of TABLE as r` — safe, named, schema-required.** Columns are
-  addressed **by name only**: `r["cust"]`. **Numeric addressing is a parse
-  error** here. Requires a declared schema (that is what supplies the names
-  and the decode layout). This is the recommended, everyday form.
+- **`records of TABLE as r` — safe, named, schema-required. LANDED.**
+  Columns are addressed **by name only**: `r["cust"]`. Requires a declared
+  schema (that is what supplies the names and the decode layout — `r["col"]`
+  resolves to the column's position and extracts that field of the stored
+  row). This is the recommended, everyday form. Numeric addressing is not
+  accepted here (that is the positional `rows of` reader's job, below).
 
 - **`rows of TABLE as r` — positional.** Columns are addressed **by position**
   (`r[1]`, `r[2]`, 1-indexed), for raw or ad-hoc stores. A schema spec may
@@ -498,7 +502,11 @@ non-i64 cache values" open question — deferred to its own runtime round.
 2. **Row capture writer** — `TABLE[$k] = $0` stores the record as a row
    value; read back via `over TABLE`. In-run. **LANDED.**
 3. **`records of TABLE as r`** — decode a stored row by the schema, name-only
-   `r["col"]` read path (the safe, named reader).
+   `r["col"]` read path (the safe, named reader). **LANDED**
+   (`tests/test_plawk_records_reader.pl`): `r["col"]` resolves through the
+   `declare TABLE(col type, …)` schema to the column's position and extracts
+   that field of the stored row; an unknown column is unsupported (clean
+   compile-time failure). In-run (rides the row-capture writer's storage).
 4. **Byte-valued cache storage** — durable rows across runs (store row bytes,
    not the id).
 5. **`rows of` + `unsafe` + inline spec** — the positional reader and the
@@ -679,8 +687,9 @@ single-pass test before any driver surgery).
   `declare NAME(col type, …)` schema surface — **LANDED**; (8.2) the row
   capture writer `TABLE[$k] = $0` (str-value; in-run), read back via `over
   TABLE` — **LANDED** (`tests/test_plawk_row_capture.pl`); (8.3) the safe
-  `records of TABLE as r` reader with name-only `r["col"]` decode by schema;
-  (8.4) byte-valued cache storage for durable rows across runs; (8.5) the
+  `records of TABLE as r` reader with name-only `r["col"]` decode by schema —
+  **LANDED** (`tests/test_plawk_records_reader.pl`); (8.4) byte-valued cache
+  storage for durable rows across runs; (8.5) the
   positional `rows of` reader with `unsafe` / inline check-or-rename spec;
   (8.6) richer row producers (`row(...)` / field-wise). Foundational for
   Phase 7 (secondary indexes need addressable named fields).

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3793,6 +3793,13 @@ plawk_program_multipass_driver_ir(
     % must resolve the stored id to the row's bytes. Threaded to each reader.
     maplist(plawk_assoc_rule_action_specs, AllRules, AllRuleSpecs),
     plawk_assoc_specs_str_arrays(AllRuleSpecs, StrArrays),
+    % Row schemas (from `declare NAME(col type, ...)`) for the named
+    % `records of` reader: column name -> position. Empty for schema-less
+    % programs (the reader requires a schema and fails without one).
+    findall(cache_schema(ST, SC),
+        ( member(begin(BActions), BeginClauses),
+          member(cache_schema(ST, SC), BActions) ),
+        Schemas),
     % A `BEGIN cache(...)`-declared shared table: load before pass 1, commit
     % after the last pass. Empty for pure-scalar / non-cache programs.
     plawk_program_cache_tables(BeginClauses, CacheTriples),
@@ -3804,10 +3811,15 @@ plawk_program_multipass_driver_ir(
     % sequence by index.
     findall(FnIR-GlobalIR,
         ( nth0(I, Passes, Pass),
-          plawk_multipass_pass_fn(I, Pass, Tables, StrArrays, TableParamsIR,
-              FieldSeparator, OutputSeparator, FnIR, GlobalIR)
+          plawk_multipass_pass_fn(I, Pass, Tables, StrArrays, Schemas,
+              TableParamsIR, FieldSeparator, OutputSeparator, FnIR, GlobalIR)
         ),
         FnPairs),
+    % Every pass must yield exactly one function; if any pass shape is
+    % outside the supported surface, fail the whole driver (bin/plawk then
+    % reports it unsupported) rather than emit a call to a missing function.
+    length(Passes, NPasses),
+    length(FnPairs, NPasses),
     pairs_keys_values(FnPairs, FnIRs, ChainGlobals),
     atomic_list_concat(FnIRs, '\n', PassFnsIR),
     findall(CallLine,
@@ -3864,6 +3876,7 @@ plawk_passes_tables(Passes, Tables) :-
         ( member(pass(Rules), Passes), member(rule(_, Actions), Rules),
           member(Action, Actions), plawk_action_table_name(Action, Name)
         ; member(pass_over(_Var, var(Name), _Body), Passes)
+        ; member(pass_records(_RVar, var(Name), _RBody), Passes)
         ),
         Names0),
     sort(Names0, Tables),
@@ -3903,15 +3916,15 @@ plawk_multipass_pass_plan(Rules, Tables, assoc_plan(Tables, PlannedRules)) :-
 %  of the input. GlobalIR carries any module globals the pass's body needs
 %  (rule chains emit format/string globals; the over reader emits none in
 %  v1 -- key + lookup print fields use the shared runtime constants).
-plawk_multipass_pass_fn(Index, pass(PassRules), Tables, _StrArrays, TableParamsIR,
-        FieldSep, _OutputSep, FnIR, GlobalIR) :-
+plawk_multipass_pass_fn(Index, pass(PassRules), Tables, _StrArrays, _Schemas,
+        TableParamsIR, FieldSep, _OutputSep, FnIR, GlobalIR) :-
     plawk_multipass_pass_plan(PassRules, Tables, PassPlan),
     plawk_assoc_rule_controls(PassPlan, PassControls),
     plawk_assoc_break_close_ir(PassControls, ''),   % no break/next in v1
     plawk_assoc_rule_chain_ir(PassPlan, FieldSep, GlobalIR, ChainIR),
     plawk_multipass_pass_fn_ir(Index, TableParamsIR, ChainIR, FnIR).
 plawk_multipass_pass_fn(Index, pass_over(var(Var), var(Table), Body), Tables,
-        StrArrays, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
+        StrArrays, _Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
     Body = [print(PrintFields)],
     PrintFields = [_ | _],
     maplist(plawk_over_print_field_ok(Var), PrintFields),
@@ -3920,6 +3933,25 @@ plawk_multipass_pass_fn(Index, pass_over(var(Var), var(Table), Body), Tables,
     AssocPlan = assoc_plan(Tables, [str_arrays(StrArrays)]),
     plawk_multipass_over_fn_ir(Index, TableParamsIR, Var, Table, PrintFields,
         AssocPlan, FieldSep, OutputSep, FnIR).
+% The named row reader: iterate TABLE's row entries, decode each stored row by
+% the declared schema, print the named columns. Requires a cache_schema for
+% TABLE; each print field must be VAR["col"] with col in the schema (name-only
+% -- numeric/other fields fail the clause, so the driver reports unsupported).
+plawk_multipass_pass_fn(Index, pass_records(var(Var), var(Table), Body), Tables,
+        _StrArrays, Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
+    Body = [print(PrintFields)],
+    PrintFields = [_ | _],
+    memberchk(cache_schema(Table, Columns), Schemas),
+    maplist(plawk_records_field_index(Var, Columns), PrintFields, ColIndexes),
+    nth0(TableIndex, Tables, Table),
+    plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, ColIndexes,
+        FieldSep, OutputSep, FnIR).
+
+% Resolve a `records of` print field VAR["col"] to the column's 1-based
+% position in the schema. Name-only: a non-string / non-VAR field fails.
+plawk_records_field_index(Var, Columns, assoc(var(Var), string(Col)), Index) :-
+    atom_string(ColAtom, Col),
+    nth1(Index, Columns, col(ColAtom, _Type)).
 
 % Over-reader print fields (v1): the loop key, or a lookup of the iterated
 % table keyed by it. String literals / other tables are follow-ons.
@@ -3965,6 +3997,80 @@ forin_after:
   ret void
 }
 ', [Index, TableParamsIR, TableIndex, TableIndex, BodyIR]).
+
+%% plawk_multipass_records_fn_ir(+Index, +TableParamsIR, +TableIndex,
+%%     +ColIndexes, +FieldSep, +OutputSep, -IR)
+%  The named row reader as a void function: walk the shared table's occupied
+%  slots; for each, the value is the stored row's atom id. Build a row %Value
+%  from it and print the requested columns -- each `r["col"]` resolved to the
+%  column's schema position, extracted as field N of the row via
+%  @wam_atom_field_slice_value (the same field projection the input record
+%  uses), printed as text. Does not open the input; the table is freed by
+%  main.
+plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, ColIndexes,
+        FieldSep, OutputSep, IR) :-
+    phrase(plawk_records_col_lines(ColIndexes, FieldSep, OutputSep, 0), ColLines),
+    atomic_list_concat(ColLines, '\n', ColIR),
+    format(atom(IR),
+'define void @plawk_pass_~w(%Value %mp_path~w) {
+entry:
+  br label %rec_head
+
+rec_head:
+  %rec_idx = phi i64 [0, %entry], [%rec_next_idx, %rec_body_done]
+  %rec_slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %rec_idx)
+  %rec_done = icmp slt i64 %rec_slot, 0
+  br i1 %rec_done, label %rec_after, label %rec_body
+
+rec_body:
+  %rec_row_id = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %rec_slot)
+  %rec_row_v0 = insertvalue %Value undef, i32 0, 0
+  %rec_row_v = insertvalue %Value %rec_row_v0, i64 %rec_row_id, 1
+~w
+  %rec_printed_newline = call i32 @putchar(i32 10)
+  br label %rec_body_done
+
+rec_body_done:
+  %rec_next_idx = add i64 %rec_slot, 1
+  br label %rec_head
+
+rec_after:
+  ret void
+}
+', [Index, TableParamsIR, TableIndex, TableIndex, ColIR]).
+
+%% plawk_records_col_lines(+ColIndexes, +FieldSep, +OutputSep, +PrintIndex)//
+%  Per-column print for the named row reader: a separator before each column
+%  after the first, then extract field <ColIndex> of the row (%rec_row_v) and
+%  print its text (%.*s).
+plawk_records_col_lines([], _FieldSep, _OutputSep, _PrintIndex) --> [].
+plawk_records_col_lines([ColIndex | Rest], FieldSep, OutputSep, PrintIndex) -->
+    { ( PrintIndex =:= 0
+      ->  SepLines = []
+      ;   format(atom(SepLine),
+              '  %rec_sep~w = call i32 @putchar(i32 ~w)', [PrintIndex, OutputSep]),
+          SepLines = [SepLine]
+      ),
+      format(atom(Slice),
+          '  %rec_f~w_slice = call %WamSlice @wam_atom_field_slice_value(%Value %rec_row_v, i64 ~w, i8 ~w)',
+          [PrintIndex, ColIndex, FieldSep]),
+      format(atom(Ptr), '  %rec_f~w_ptr = extractvalue %WamSlice %rec_f~w_slice, 0',
+          [PrintIndex, PrintIndex]),
+      format(atom(Len), '  %rec_f~w_len = extractvalue %WamSlice %rec_f~w_slice, 1',
+          [PrintIndex, PrintIndex]),
+      format(atom(Lenw), '  %rec_f~w_lenw = trunc i64 %rec_f~w_len to i32',
+          [PrintIndex, PrintIndex]),
+      format(atom(Fmt),
+          '  %rec_f~w_fmt = getelementptr [5 x i8], [5 x i8]* @.plawk_surface_print_slice, i32 0, i32 0',
+          [PrintIndex]),
+      format(atom(Pr),
+          '  %rec_f~w_pr = call i32 (i8*, ...) @printf(i8* %rec_f~w_fmt, i32 %rec_f~w_lenw, i8* %rec_f~w_ptr)',
+          [PrintIndex, PrintIndex, PrintIndex, PrintIndex]),
+      append([SepLines, [Slice, Ptr, Len, Lenw, Fmt, Pr]], Lines),
+      NextPrintIndex is PrintIndex + 1
+    },
+    plawk_emit_lines(Lines),
+    plawk_records_col_lines(Rest, FieldSep, OutputSep, NextPrintIndex).
 
 %% plawk_multipass_pass_fn_ir(+Index, +RecordIR, -IR)
 %  One pass as a self-contained function: open the shared input path, loop

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -194,6 +194,24 @@ plawk_program(program(BeginClauses, Rules, EndClauses), FunctionClauses,
       plawk_dynentry_rewrite_all(EndClauses0, DynEntries, EndClauses)
     }.
 
+% A `pass records of TABLE as VAR { print VAR["col"], ... }` block: the safe,
+% named row reader (PLAWK_MULTIPASS_CACHE.md §3.6, phase 8.3). Iterates
+% TABLE's row entries, binding each row to VAR; columns are addressed BY NAME
+% only (`VAR["col"]`), resolved through TABLE's declared schema. Distinct from
+% `pass over ... as k` (which binds a scalar key). Tried before `over` and the
+% plain `pass`; the `records of` keyword pair is unambiguous. Body reuses the
+% for-in print body, so numeric column addressing (`VAR[1]`) never appears
+% here -- that is the positional `rows of` reader's job.
+pass_clauses([pass_records(var(Var), var(Table), Body) | Rest]) -->
+    "pass", identifier_boundary, ws,
+    "records", identifier_boundary, ws,
+    "of", identifier_boundary, ws,
+    identifier(Table), ws,
+    "as", identifier_boundary, ws,
+    identifier(Var), ws,
+    for_in_body(Body),
+    ws,
+    pass_clauses(Rest).
 % A `pass over TABLE as VAR { print ... }` block: a configurable reader
 % (PLAWK_MULTIPASS_CACHE.md phase 4). Instead of re-scanning the input, the
 % pass iterates TABLE's entries as records, binding each key to VAR -- the
@@ -222,6 +240,8 @@ plawk_pass_dynentry_rewrite(DynEntries, pass(Rules0), pass(Rules)) :-
     plawk_dynentry_rewrite_all(Rules0, DynEntries, Rules).
 % An `over TABLE` pass has no rule actions to rewrite -- pass it through.
 plawk_pass_dynentry_rewrite(_DynEntries, pass_over(V, T, Body), pass_over(V, T, Body)).
+% A `records of TABLE` reader likewise has no rule actions -- pass it through.
+plawk_pass_dynentry_rewrite(_DynEntries, pass_records(V, T, Body), pass_records(V, T, Body)).
 
 %% dynentry_decls(-Names)//
 %

--- a/tests/test_plawk_records_reader.pl
+++ b/tests/test_plawk_records_reader.pl
@@ -1,0 +1,119 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk row-oriented records (PLAWK_MULTIPASS_CACHE.md §3.6, phase 8.3): the
+% SAFE NAMED ROW READER. `pass records of TABLE as r { print r["col"], ... }`
+% iterates TABLE's stored rows, binding each to r; columns are addressed BY
+% NAME (`r["col"]`), resolved through TABLE's declared schema
+% (`declare TABLE(col type, ...)`) to the column's position and extracted as
+% that field of the stored row. Reordering the printed columns proves the
+% mapping is by schema position, not print order. A column not in the schema
+% is unsupported (the driver fails cleanly rather than emitting broken IR).
+% Together with the row-capture writer (`TABLE[$k] = $0`), this is the
+% "retrieve the row as an assoc array keyed by column name" shape.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_records_reader).
+
+% `pass records of T as r { print ... }` parses to pass_records/3, with the
+% body's named fields as assoc(var(r), string("col")).
+test(records_parses) :-
+    plawk_parse_string(
+        "BEGIN cache(\"o.db\") { declare orders(cust str, amount i64) }\n\c
+         pass { orders[$1] = $0 }\n\c
+         pass records of orders as r { print r[\"cust\"], r[\"amount\"] }\n",
+        program_passes(_,
+            [pass([rule(always, [set_row(var(orders), field(1))])]),
+             pass_records(var(r), var(orders),
+                 [print([assoc(var(r), string("cust")),
+                         assoc(var(r), string("amount"))])])],
+            [])),
+    !.
+
+% Capture rows, read them back by column NAME. Schema orders(cust, amount):
+% r["cust"] = field 1, r["amount"] = field 2. Over a=10, b=5, a=20 (replace):
+% a -> "a 20", b -> "b 5".
+test(records_named_read, [condition(clang_available)]) :-
+    rdir(Dir),
+    Src = "BEGIN cache(\"$STORE\") { declare orders(cust str, amount i64) }\n\c
+           pass { orders[$1] = $0 }\n\c
+           pass records of orders as r { print r[\"cust\"], r[\"amount\"] }\n",
+    run_sorted(Dir, 'rec', Src, "a 10\nb 5\na 20\n", S),
+    assertion(S == ["a 20", "b 5"]),
+    !.
+
+% Reordering the columns proves resolution is by SCHEMA position, not by
+% print order: `print r["amount"], r["cust"]` puts the amount first.
+test(records_reorder_by_schema, [condition(clang_available)]) :-
+    rdir(Dir),
+    Src = "BEGIN cache(\"$STORE\") { declare orders(cust str, amount i64) }\n\c
+           pass { orders[$1] = $0 }\n\c
+           pass records of orders as r { print r[\"amount\"], r[\"cust\"] }\n",
+    run_sorted(Dir, 'rord', Src, "a 10\nb 5\na 20\n", S),
+    assertion(S == ["20 a", "5 b"]),
+    !.
+
+% A column not in the schema is outside the supported surface: the CLI
+% reports it unsupported (exit 3), not a broken build.
+test(records_unknown_column_unsupported, [condition(clang_available)]) :-
+    rdir(Dir),
+    Src = "BEGIN cache(\"$STORE\") { declare orders(cust str, amount i64) }\n\c
+           pass { orders[$1] = $0 }\n\c
+           pass records of orders as r { print r[\"nope\"] }\n",
+    directory_file_path(Dir, 'rbad.db', Store),
+    replace_store(Src, Store, Src1),
+    directory_file_path(Dir, 'rbad.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src1), close(S)),
+    directory_file_path(Dir, 'rbad_bin', Bin),
+    cli([build, Prog, '-o', Bin], 3),
+    !.
+
+:- end_tests(plawk_records_reader).
+
+% --- helpers ---------------------------------------------------------------
+
+rdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_records_reader', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+% substitute $STORE with a fresh per-name store path
+replace_store(Src, Store, Out) :-
+    split_string(Src, "", "", [S0]),
+    atomic_list_concat(Parts, "$STORE", S0),
+    atomic_list_concat(Parts, Store, Out).
+
+run_sorted(Dir, Name, Src0, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    replace_store(Src0, Store, Src),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
The **records syntax** the row work has been building toward — the safe, named row reader (§3.6, phase 8.3). It retrieves a stored row as an associative array keyed by column name:

```awk
BEGIN cache("orders.db") { declare orders(cust str, amount i64) }
pass { orders[$1] = $0 }                              # capture rows (phase 8.2)
pass records of orders as r { print r["cust"], r["amount"] }
```

`r["col"]` resolves the column to its position in the declared schema and extracts that field of the stored row (the same field projection an input record uses), printed as text. Over `a 10 / b 5 / a 20` → `a 20` / `b 5` (replace semantics).

## Changes
- **Parser**: `pass records of IDENT as IDENT { print ... }` → `pass_records/3`, tried before `over`/plain `pass` (the `records of` keyword pair is unambiguous). Body reuses the for-in print body — so **numeric column addressing never appears here**; that's the positional `rows of` reader's job (phase 8.5), keeping `records of` name-only as you specified.
- **Codegen**: the multi-pass driver threads the program's row schemas to a new `pass_records` dispatch; the reader emits a `void` function that walks the table, builds a `%Value` row from each stored id, and prints the named columns via `@wam_atom_field_slice_value` at their schema positions.
- **Hardening**: the driver now requires every pass to yield exactly one function (length check), so an unsupported pass shape fails the whole clause cleanly (CLI reports unsupported, exit 3) instead of dangling a call to an un-emitted `@plawk_pass_N`.

## Verified
- Named read; **reorder-by-schema** (`r["amount"], r["cust"]` → "20 a") proves resolution is by schema position, not print order; unknown column → clean unsupported.
- Regression green across multipass, passes, over-table, row-capture, row-schema, assoc-print, crosspass-scalar, perkey, multipass-cache, forin-filter.

## Scope
In-run (rides the row-capture writer's str-value storage). Durable rows across runs still await byte-valued cache storage (phase 8.4). Typed-column arithmetic (e.g. numeric ops on an `i64` column) and the positional `rows of` reader are later sub-phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_