### PR TITLE
WAM/LLVM plawk: `rows of TABLE as r` positional row reader (phase 8.5 core)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -32,11 +32,13 @@ pass's record source (named fields — key bound to `VAR`, value via
 `TABLE[VAR]`) instead of re-scanning the input; and row-oriented / record-valued tables
 (phase 8, §3.6): a table whose value is a named-field **row** — captured with
 `TABLE[$k] = $0` and read back by column name with `records of TABLE as r`
-(`r["col"]`, resolved through the `declare TABLE(col type, …)` schema), in-run.
+(`r["col"]`, resolved through the `declare TABLE(col type, …)` schema), or by
+position with `rows of TABLE as r` (`r[N]`, no schema), in-run.
 **Not yet:** durable rows across runs (byte-valued cache storage, phase 8.4);
-the positional `rows of` reader (phase 8.5); the `over prev` reader (phase 4
-follow-on); the query reader (phase 6); namespaces / `eager` / secondary
-indexes; string-literal print fields. See the per-phase status tags in §5.
+`rows of`'s `unsafe` / inline check-or-rename spec; the `over prev` reader
+(phase 4 follow-on); the query reader (phase 6); namespaces / `eager` /
+secondary indexes; string-literal print fields. See the per-phase status tags
+in §5.
 
 ## Implemented surface (quick reference)
 
@@ -454,10 +456,14 @@ contracts so neither is a grab-bag of modifiers:
   row). This is the recommended, everyday form. Numeric addressing is not
   accepted here (that is the positional `rows of` reader's job, below).
 
-- **`rows of TABLE as r` — positional.** Columns are addressed **by position**
-  (`r[1]`, `r[2]`, 1-indexed), for raw or ad-hoc stores. A schema spec may
-  appear at the read site, and its role depends on whether an authoritative
-  (`declare`d) schema already exists:
+- **`rows of TABLE as r` — positional. Core LANDED.** Columns are addressed
+  **by position** (`r[1]`, `r[2]`, 1-indexed = field N of the stored row),
+  for raw or ad-hoc stores; **no schema required**
+  (`tests/test_plawk_rows_reader.pl`). Reuses the same row-decode function as
+  `records of`, sourcing field indices from the literal positions. The
+  `unsafe` modifier and inline check-or-rename spec below are a **follow-on**.
+  A schema spec may appear at the read site, and its role depends on whether
+  an authoritative (`declare`d) schema already exists:
   - **schema present →** the spec is a **check**: the store's row shape
     (arity / types / names) must match, diagnosed at open, not as silent
     garbage later.
@@ -509,8 +515,9 @@ non-i64 cache values" open question — deferred to its own runtime round.
    compile-time failure). In-run (rides the row-capture writer's storage).
 4. **Byte-valued cache storage** — durable rows across runs (store row bytes,
    not the id).
-5. **`rows of` + `unsafe` + inline spec** — the positional reader and the
-   check/rename semantics above.
+5. **`rows of` positional reader** — `r[N]` by position, no schema. **LANDED**
+   (`tests/test_plawk_rows_reader.pl`). Its `unsafe` modifier + inline
+   check-or-rename spec remain a follow-on.
 6. **Richer row producers** — `row(...)` constructor / field-wise writes.
 
 ## 4. Runtime: the cache ABI (the first build step)
@@ -689,10 +696,12 @@ single-pass test before any driver surgery).
   TABLE` — **LANDED** (`tests/test_plawk_row_capture.pl`); (8.3) the safe
   `records of TABLE as r` reader with name-only `r["col"]` decode by schema —
   **LANDED** (`tests/test_plawk_records_reader.pl`); (8.4) byte-valued cache
-  storage for durable rows across runs; (8.5) the
-  positional `rows of` reader with `unsafe` / inline check-or-rename spec;
-  (8.6) richer row producers (`row(...)` / field-wise). Foundational for
-  Phase 7 (secondary indexes need addressable named fields).
+  storage for durable rows across runs; (8.5) the positional `rows of`
+  reader (`r[N]`, no schema) — **LANDED**
+  (`tests/test_plawk_rows_reader.pl`; its `unsafe` / inline check-or-rename
+  spec remain a follow-on); (8.6) richer row producers (`row(...)` /
+  field-wise). Foundational for Phase 7 (secondary indexes need addressable
+  named fields).
 
 ## 6. Open questions
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3877,6 +3877,7 @@ plawk_passes_tables(Passes, Tables) :-
           member(Action, Actions), plawk_action_table_name(Action, Name)
         ; member(pass_over(_Var, var(Name), _Body), Passes)
         ; member(pass_records(_RVar, var(Name), _RBody), Passes)
+        ; member(pass_rows(_PVar, var(Name), _PBody), Passes)
         ),
         Names0),
     sort(Names0, Tables),
@@ -3952,6 +3953,23 @@ plawk_multipass_pass_fn(Index, pass_records(var(Var), var(Table), Body), Tables,
 plawk_records_field_index(Var, Columns, assoc(var(Var), string(Col)), Index) :-
     atom_string(ColAtom, Col),
     nth1(Index, Columns, col(ColAtom, _Type)).
+% The positional row reader: iterate TABLE's rows, print columns addressed
+% BY POSITION (`VAR[N]`, 1-indexed = field N of the stored row). No schema
+% needed -- for raw stores. Reuses the same row-decode function emitter as
+% `records of`, just sourcing the field indices from the literal positions.
+plawk_multipass_pass_fn(Index, pass_rows(var(Var), var(Table), Body), Tables,
+        _StrArrays, _Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
+    Body = [print(PrintFields)],
+    PrintFields = [_ | _],
+    maplist(plawk_rows_field_index(Var), PrintFields, ColIndexes),
+    nth0(TableIndex, Tables, Table),
+    plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, ColIndexes,
+        FieldSep, OutputSep, FnIR).
+
+% A `rows of` print field VAR[N] is the row's Nth field (1-indexed).
+% Positional only: a string / non-VAR field fails (that is `records of`).
+plawk_rows_field_index(Var, assoc(var(Var), int(N)), N) :-
+    integer(N), N > 0.
 
 % Over-reader print fields (v1): the loop key, or a lookup of the iterated
 % table keyed by it. String literals / other tables are follow-ons.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -212,6 +212,22 @@ pass_clauses([pass_records(var(Var), var(Table), Body) | Rest]) -->
     for_in_body(Body),
     ws,
     pass_clauses(Rest).
+% A `pass rows of TABLE as VAR { print VAR[N], ... }` block: the POSITIONAL
+% row reader (PLAWK_MULTIPASS_CACHE.md §3.6, phase 8.5). Like `records of`,
+% but columns are addressed BY POSITION (`VAR[1]`, 1-indexed) instead of by
+% schema name -- for raw / schema-less stores. Tried before `over` / plain
+% `pass`; the `rows of` keyword pair is unambiguous. (The `unsafe` modifier
+% and an inline check-or-rename spec are a follow-on; core is positional.)
+pass_clauses([pass_rows(var(Var), var(Table), Body) | Rest]) -->
+    "pass", identifier_boundary, ws,
+    "rows", identifier_boundary, ws,
+    "of", identifier_boundary, ws,
+    identifier(Table), ws,
+    "as", identifier_boundary, ws,
+    identifier(Var), ws,
+    for_in_body(Body),
+    ws,
+    pass_clauses(Rest).
 % A `pass over TABLE as VAR { print ... }` block: a configurable reader
 % (PLAWK_MULTIPASS_CACHE.md phase 4). Instead of re-scanning the input, the
 % pass iterates TABLE's entries as records, binding each key to VAR -- the
@@ -242,6 +258,8 @@ plawk_pass_dynentry_rewrite(DynEntries, pass(Rules0), pass(Rules)) :-
 plawk_pass_dynentry_rewrite(_DynEntries, pass_over(V, T, Body), pass_over(V, T, Body)).
 % A `records of TABLE` reader likewise has no rule actions -- pass it through.
 plawk_pass_dynentry_rewrite(_DynEntries, pass_records(V, T, Body), pass_records(V, T, Body)).
+% A `rows of TABLE` reader likewise has no rule actions -- pass it through.
+plawk_pass_dynentry_rewrite(_DynEntries, pass_rows(V, T, Body), pass_rows(V, T, Body)).
 
 %% dynentry_decls(-Names)//
 %

--- a/tests/test_plawk_rows_reader.pl
+++ b/tests/test_plawk_rows_reader.pl
@@ -1,0 +1,83 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk row-oriented records (PLAWK_MULTIPASS_CACHE.md §3.6, phase 8.5): the
+% POSITIONAL row reader. `pass rows of TABLE as r { print r[N], ... }`
+% iterates TABLE's stored rows, addressing columns BY POSITION (`r[1]`,
+% 1-indexed = field N of the stored row) rather than by schema name -- the
+% raw / schema-less counterpart to `records of ... r["col"]`. No `declare`
+% schema is required. (The `unsafe` modifier and an inline check-or-rename
+% spec are a follow-on; this is the positional core.)
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_rows_reader).
+
+% `pass rows of T as r { print ... }` parses to pass_rows/3; positional
+% fields are assoc(var(r), int(N)).
+test(rows_parses) :-
+    plawk_parse_string(
+        "pass { t[$1] = $0 }\npass rows of t as r { print r[1], r[2] }\n",
+        program_passes([],
+            [pass([rule(always, [set_row(var(t), field(1))])]),
+             pass_rows(var(r), var(t),
+                 [print([assoc(var(r), int(1)), assoc(var(r), int(2))])])],
+            [])),
+    !.
+
+% Positional read, no schema: r[1] = field 1, r[2] = field 2. Reordering
+% (`r[2], r[1]`) proves positional resolution. Over a=10, b=5, a=20
+% (replace): a -> "20 a", b -> "5 b".
+test(rows_positional_read, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t as r { print r[2], r[1] }\n",
+    run_sorted(Dir, 'rows', Src, "a 10\nb 5\na 20\n", S),
+    assertion(S == ["20 a", "5 b"]),
+    !.
+
+% A single positional column.
+test(rows_single_col, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t as r { print r[1] }\n",
+    run_sorted(Dir, 'rows1', Src, "k1 a b\nk2 c d\n", S),
+    assertion(S == ["k1", "k2"]),
+    !.
+
+:- end_tests(plawk_rows_reader).
+
+% --- helpers ---------------------------------------------------------------
+
+wdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_rows_reader', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
The positional counterpart to `records of` (§3.6), completing the reader duo you designed. `rows of TABLE as r` addresses columns **by position** for raw / schema-less stores:

```awk
pass { t[$1] = $0 }
pass rows of t as r { print r[2], r[1] }   # field 2, then field 1 — no schema needed
```

## Changes
- **Parser**: `pass rows of IDENT as IDENT { print ... }` → `pass_rows/3` (tried before `over`/plain `pass`; the `rows of` keyword pair is unambiguous).
- **Codegen**: a `pass_rows` dispatch reuses the **same** row-decode function emitter as `records of`, sourcing the field indices straight from the literal positions (`plawk_rows_field_index`). Positional-only — a string key (`r["col"]`) in `rows of` is `records of`'s job and falls outside the surface (clean unsupported).

## Scope
Positional core only. The `unsafe` modifier and inline check-or-rename spec (the safe/positional bridge from the design) remain a follow-on. In-run, like `records of`.

## Verified
Parse, positional read with reordering (`r[2], r[1]`), single column. Regression green across multipass, passes, over-table, row-capture, records-reader, row-schema, multipass-cache, perkey.

## Row arc status
8.1 schema ✅ · 8.2 capture ✅ · 8.3 `records of` (named) ✅ · **8.5 `rows of` (positional) ✅**. Remaining: 8.4 durable rows across runs (byte-valued cache storage — a deliberate runtime arc, since durable read-only also needs single-pass reader support), `rows of` `unsafe`/rename, 8.6 richer producers (`row(...)`), and typed-column arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_