### PR TITLE
mu_cosine: fail closed on repeated-judge candidate capacity

### DIFF
--- a/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
+++ b/prototypes/mu_cosine/DECISIONS_repeated_judge_campaign.md
@@ -287,3 +287,40 @@ matrices, reuse fitted factors across folds/replicates, or round gains at the de
 blocks and reduces 120-dimensional factorizations to 12-dimensional collective/contrast systems.  Equal counts
 can hide different overlap schedules, while real prompt incidence need not commute with the item kernel; dense
 joint QR therefore remains the general correctness reference.
+
+## 2026-07-13 — stop candidate construction at the connected-component capacity gate
+
+**Decision:** interpret the existing 10% `source_component` cap literally as an undirected graph connected-
+component cap for this preflight.  Before enumerating triples or generating Nomic embeddings, compute the
+optimistic endpoint-disjoint upper bound
+`U_1(G)=sum_s min(|V_s|, max(1,floor(.10 G)))`, charging only one distinct endpoint to its declared source.
+Block the candidate builder whenever `U_1(G)<G` for a required corpus.  Both frozen corpora fail every
+registered `G`.  Also report the sharper four-endpoint same-source sensitivity, but do not require its
+interpretation for the blocking proof.
+
+**Rejected:** silently substitute top-level branches for connected components, relax the 10% cap after seeing
+capacity, or continue to Nomic/history/candidate work after the structural impossibility is known.
+
+**Reason:** endpoint disjointness requires at least one distinct endpoint from every candidate's declared
+source, and later filters cannot add endpoints when the audited source components remain frozen.  This loose
+bound avoids relying on whether a permitted disconnected distant comparator belongs to the same component.
+When all three descendant-to-root paths are finite in the same canonical graph, all four endpoints do share a
+weak component and the sharper `/4` bound applies.  The future builder must reject a finite-hop/disconnected
+combination that is impossible under its graph semantics.  The fresh `Behavior` closure is one connected
+component; the exploratory graph is 98.88% one giant component.  A branch-based dependency partition may be
+scientifically preferable, but it is a preregistration amendment and must be named and validated as such
+rather than hidden behind the old term.
+
+**Reconsider if:** an outcome-blind amendment freezes deterministic exclusive source groups (including
+multi-branch assignment, concentration caps, fold containment, and group-aware inference), or replaces the
+source-cap design with a powered dependence model.  Rerun this necessary gate before any Nomic cache or
+candidate pool is produced.
+
+## 2026-07-13 — bind the exact Nomic task-prefix bytes
+
+**Decision:** use `"clustering: "`, including the trailing U+0020 space, as the frozen Nomic input prefix.
+
+**Rejected:** compare or hash the display token `"clustering:"` while the cache builder encodes different text.
+
+**Reason:** a trailing space changes model input bytes and therefore belongs in reproducibility provenance.
+This correction was made before a new candidate-universe cache or any outcome was produced.

--- a/prototypes/mu_cosine/DESIGN_graph_geometry_confirmatory.md
+++ b/prototypes/mu_cosine/DESIGN_graph_geometry_confirmatory.md
@@ -140,7 +140,8 @@ semantic geometry.  Two locally available candidates are frozen:
 - `sentence-transformers/all-MiniLM-L6-v2`, revision
   `c9745ed1d9f207416be6d2e6f8de32d1f16199bf`, symmetric title encoding;
 - `nomic-ai/nomic-embed-text-v1.5`, revision
-  `e9b6763023c676ca8431644204f50c2b100d9aab`, using the model-card `clustering:` prefix because the task is
+  `e9b6763023c676ca8431644204f50c2b100d9aab`, using the exact `"clustering: "` prefix (including its trailing
+  U+0020 space) because the task is
   symmetric semantic grouping, not query/document retrieval.  Nomic's open embedding design is described in
   [Nussbaum et al. (2024)](https://arxiv.org/abs/2402.01613).
 

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -13,6 +13,15 @@ If a named judge or prompt is unavailable, this document must be amended before 
 Operational dry runs may use synthetic responses only.  A 64-component live engineering pilot is permitted
 only under a separate amendment and must be permanently excluded from confirmation.
 
+**2026-07-13 structural preflight:** the literal 10% undirected-connected-component source cap makes every
+registered `G` infeasible on both frozen corpora.  The primary optimistic proof charges only one endpoint to
+each declared source before cells, history, or Nomic; the sharper four-endpoint sensitivity also fails every
+registered `G`, so the conclusion does not depend on how the permitted disconnected negative is interpreted.
+Candidate enumeration is therefore blocked.  Source-component identities remain frozen through later endpoint
+exclusions; they are not recomputed to create more cap slots.  A separate outcome-blind amendment must
+define and power a feasible dependency/source partition; graph branches are not silently relabelled connected
+components.  See `REPORT_repeated_judge_candidate_capacity.md`.
+
 ## Question and experimental unit
 
 The question is whether an outcome-blind graph/semantic geometry predicts transferable cross-item conditional
@@ -30,7 +39,8 @@ quartile.  The sampler balances anchor-to-comparator hop transition, anchor-degr
 graph/Nomic agreement class.  No graph endpoint ID or normalized endpoint title may occur in two selected
 components or in the historical scored campaigns.  Any graph connected component contributes at most 10% of
 a corpus sample where topology permits; otherwise the shortfall is reported and the campaign does not silently
-weaken this rule.
+weaken this rule.  The structural preflight found that the current frozen graphs do not permit any registered
+campaign size, so this is now a blocking amendment point rather than an executable selection rule.
 
 Graph/Nomic thresholds are computed and recorded on the frozen structural candidate universe before endpoint-
 consuming selection.  Structural near/far defines the sampling contrast; cumulative-walk and Nomic similarities

--- a/prototypes/mu_cosine/REPORT_graph_geometry_confirmatory.md
+++ b/prototypes/mu_cosine/REPORT_graph_geometry_confirmatory.md
@@ -91,7 +91,7 @@ shape/dtype, package versions, and content hashes.  Evaluation never downloads a
 
 | candidate | exact revision | role |
 |---|---|---|
-| Nomic `nomic-embed-text-v1.5` | `e9b6763023c676ca8431644204f50c2b100d9aab` | primary external semantic geometry; `clustering:` title prefix |
+| Nomic `nomic-embed-text-v1.5` | `e9b6763023c676ca8431644204f50c2b100d9aab` | primary external semantic geometry; exact `"clustering: "` prefix, including trailing U+0020 |
 | MiniLM `all-MiniLM-L6-v2` | `c9745ed1d9f207416be6d2e6f8de32d1f16199bf` | lower-cost sensitivity comparator |
 | e5 | existing frozen caches | shared-input redundancy control, not an independent candidate |
 

--- a/prototypes/mu_cosine/REPORT_repeated_judge_campaign_power.md
+++ b/prototypes/mu_cosine/REPORT_repeated_judge_campaign_power.md
@@ -133,6 +133,11 @@ No ignored artifact, checkpoint, smoke JSON, or generated score input is committ
 
 ## Required next work
 
+The first item was attempted by the repository-owned structural capacity preflight and failed before candidate
+enumeration: every registered `G` violates the literal 10% connected-component cap.  See
+`REPORT_repeated_judge_candidate_capacity.md`.  Work now stops at an outcome-blind source-partition amendment;
+the remaining ordering is unchanged after that gate passes.
+
 1. Implement and review the repository-owned candidate builder, then freeze graph/Nomic/historical artifacts.
 2. Freeze the exact approved live prompt, model revisions, settings, and keyed response parser.
 3. Run a list-position engineering pilot; preregister a train-only position-by-role-by-judge adjustment and add

--- a/prototypes/mu_cosine/REPORT_repeated_judge_candidate_capacity.md
+++ b/prototypes/mu_cosine/REPORT_repeated_judge_candidate_capacity.md
@@ -111,13 +111,15 @@ freeze agreement/degree/tag rules, and run exact packability checks for every re
 ```bash
 python prototypes/mu_cosine/run_repeated_judge_candidate_capacity.py \
   --artifact-repo /path/to/UnifyWeaver-with-ignored-graph-artifacts \
-  --out /tmp/repeated_judge_candidate_capacity.json \
-  --require-feasible
+  --out /tmp/repeated_judge_candidate_capacity.json
 ```
 
-For the frozen inputs, `--require-feasible` writes the complete audit and exits with status 2.  Omitting that
-flag exits zero to mean only “audit completed”; downstream automation must then inspect
-`decision.candidate_builder_must_stop`.  The tracked reproduction artifact is
+For the frozen inputs, the default command writes the complete audit and exits with status 2.  This makes a
+shell caller fail closed without needing to remember an extra flag.  Explicit reporting workflows may pass
+`--audit-only` to return zero after writing the same blocked JSON; they must then inspect
+`decision.candidate_builder_must_stop`.  Pipeline automation should not use `--audit-only`.  Exit 2 is also
+used by `argparse` for command-line errors, so the presence of a completed artifact and its decision field
+distinguish a capacity block from invalid invocation.  The tracked reproduction artifact is
 `repro/repeated_judge_candidate_capacity/summary.json`: 14,322 bytes, SHA-256
-`0524769b708ec0270fa288ac914b93509cca1a5d8648fa8d5e4390b7ec092406`.  The focused capacity suite passes
-20 tests; the broader repeated-judge regression set passes 88 tests.
+`403b1a59b6e53c87f881dad65ab6af2f401e046c0c7009a1efd220eb3899cdd8`.  The focused capacity suite passes
+24 tests; the broader repeated-judge regression set passes 92 tests.

--- a/prototypes/mu_cosine/REPORT_repeated_judge_candidate_capacity.md
+++ b/prototypes/mu_cosine/REPORT_repeated_judge_candidate_capacity.md
@@ -1,0 +1,123 @@
+# Repeated-judge candidate capacity — structural no-spend preflight
+
+## Bottom line
+
+The repository-owned structural preflight **blocks the candidate builder at every registered campaign size**.
+It consumed the two frozen graphs but no scores, residuals, historical labels, Nomic embeddings, or judge calls.
+
+The preregistration defines `source_component` as an undirected graph connected component and caps every such
+source at 10% of a corpus campaign.  Selected campaign components are endpoint-disjoint.  Charging only one
+distinct endpoint to each candidate's declared source gives the deliberately loose necessary bound
+
+```text
+U_1(G) = sum_s min(n_s, max(1, floor(0.10 G))).
+```
+
+This bound is valid even under the preregistration's permissive reading in which the distant negative may be
+disconnected from the anchor in the canonical graph.  If the shortest descendant-to-root hops for all three
+rows are instead finite in that same graph, their paths through the shared descendant put all four distinct
+endpoints in one weak component and give the sharper sensitivity
+
+```text
+U_4(G) = sum_s min(floor(n_s / 4), max(1, floor(0.10 G))).
+```
+
+The candidate schema currently permits both a finite distant hop and `anchor_distant_disconnected=true`; a
+future builder must resolve that ambiguity and reject combinations impossible in the graph it actually uses.
+The blocking conclusion here does not rely on that resolution.  Both bounds ignore the 32 balance cells, hop
+constraints, degree matching, graph/Nomic agreement, historical exclusions, normalized-title aliases, and
+actual packing conflicts.  With source-component identities frozen before endpoint exclusions, those later
+filters can only lower capacity.  Thus `U_1(G) < G` is a conclusive fail-closed result, not a power estimate.
+
+## Frozen graph inputs
+
+The command uses the same canonical loaders as the covariance work.  Paths are operational and are absent
+from the scientific JSON; content is bound by byte count and SHA-256.
+
+| corpus | retained graph | bytes | SHA-256 |
+|---|---|---:|---|
+| exploratory | SimpleWiki `100k_cats/category_parent.tsv` | 10,126,922 | `4881beedfd876e3abb9f1783cbc3fb8a7350e108e3f531cc4de28ef9956dc8ec` |
+| exploratory identity | `100k_cats/metadata.json` | 308 | `15a632799adebd8b4f736c8420add8969bb5e5e4f20aa21ecaae9e2d95a61577` |
+| fresh | enwiki scoped LMDB `data.mdb`, retained under `Behavior` | 1,319,403,520 | `3bcfe59a3f85870f377fad1ea77547f7c3566370f6172e27748f4f7ceba5d690` |
+
+The fresh loader also binds the exploratory graph because it removes SimpleWiki-title overlap.  LMDB
+`lock.mdb` is runtime state and is deliberately excluded.
+
+## Capacity result
+
+The canonical undirected graph removes self-loops and collapses reciprocal/duplicate direction while retaining
+all loader nodes.  Edge counts below are unique undirected non-self edges.
+
+| corpus | nodes | edges | connected components | largest component | largest fraction |
+|---|---:|---:|---:|---:|---:|
+| exploratory | 84,136 | 196,876 | 34 | 83,194 | 98.88% |
+| fresh | 75,901 | 99,971 | 1 | 75,901 | 100% |
+
+| `G` per corpus | per-source cap | exploratory `U_1(G)` | fresh `U_1(G)` | joint gate |
+|---:|---:|---:|---:|---|
+| 160 | 16 | 143 | 16 | fail |
+| 320 | 32 | 194 | 32 | fail |
+| 512 | 51 | 251 | 51 | fail |
+| 800 | 80 | 335 | 80 | fail |
+
+The sharper same-source four-endpoint sensitivity is 58/93/131/189 for exploratory and 16/32/51/80 for
+fresh at `G=160/320/512/800`.  It is not needed for the decision.
+
+Even the smallest `G=160` is impossible.  The fresh result follows immediately from its one connected
+component: the source cap permits at most 10% of the requested campaign.  The exploratory graph has a giant
+component plus only small alternatives, so increasing `G` does not repair the deficit.
+
+## Why the pipeline stops here
+
+Generating a larger Nomic cache, enumerating triples, or building the historical inventory cannot rescue this
+gate; each would only filter endpoints within the source components frozen by this audit.  Historical removal
+must not recompute and split those source components, because that would silently redefine the concentration
+unit.  The preflight therefore stops
+before those operations.  In particular:
+
+- no candidate pool or endpoint was selected;
+- no model was loaded and no embedding was generated;
+- no attempted or successful historical score file was consumed;
+- no prompt, judge, or provider was contacted; and
+- all campaign, covariance, QR, and CUDA authorization fields remain false.
+
+The audit also found an exact-byte contract mismatch before any cache regeneration: the Nomic cache builder
+uses the prefix `"clustering: "` including its trailing U+0020 space, while the selector had frozen the display
+token without that space.  The selector now binds the actual cache-input bytes.  This correction changes no
+embedding or outcome in this PR because Nomic was not run.
+
+## Alternatives and disposition
+
+| alternative | disposition | reason |
+|---|---|---|
+| silently call top-level branches “connected components” | reject | changes the preregistered dependency unit while hiding the change |
+| relax or drop the 10% cap after seeing capacity | reject | converts a frozen dependence safeguard into a convenience choice |
+| build the Nomic cache and candidate pool anyway | reject | spends compute after a mathematically conclusive upstream failure |
+| switch corpora to graphs with many connected components | defer | changes the scientific population and needs its own amendment |
+| define deterministic exclusive branch/source groups | candidate amendment | potentially feasible, but must name them as source groups, handle multi-branch nodes outcome-blindly, and retain true connected-component diagnostics |
+| retain one giant source and model/resample its dependence explicitly | defer | requires a new power model, fold contract, and effective-sample-size justification |
+
+The most promising next design is an explicit, deterministic **source-group** partition based on frozen graph
+branches, not a relabeling of connected components.  A later amendment must specify exclusive assignment for
+multi-branch nodes, concentration caps, fold containment, and source-group-aware inference before rerunning
+this preflight.
+
+Only after that necessary gate passes should work resume in this order: construct the attempted-input historical
+inventory, enumerate the structural universe, generate a revision-pinned Nomic cache over that universe,
+freeze agreement/degree/tag rules, and run exact packability checks for every registered `G`.
+
+## Reproduction
+
+```bash
+python prototypes/mu_cosine/run_repeated_judge_candidate_capacity.py \
+  --artifact-repo /path/to/UnifyWeaver-with-ignored-graph-artifacts \
+  --out /tmp/repeated_judge_candidate_capacity.json \
+  --require-feasible
+```
+
+For the frozen inputs, `--require-feasible` writes the complete audit and exits with status 2.  Omitting that
+flag exits zero to mean only “audit completed”; downstream automation must then inspect
+`decision.candidate_builder_must_stop`.  The tracked reproduction artifact is
+`repro/repeated_judge_candidate_capacity/summary.json`: 14,322 bytes, SHA-256
+`0524769b708ec0270fa288ac914b93509cca1a5d8648fa8d5e4390b7ec092406`.  The focused capacity suite passes
+20 tests; the broader repeated-judge regression set passes 88 tests.

--- a/prototypes/mu_cosine/repeated_judge_campaign.py
+++ b/prototypes/mu_cosine/repeated_judge_campaign.py
@@ -36,7 +36,9 @@ FROZEN_COMPONENT_REPEAT_GRID = frozenset({
 })
 FROZEN_NOMIC_MODEL = "nomic-ai/nomic-embed-text-v1.5"
 FROZEN_NOMIC_REVISION = "e9b6763023c676ca8431644204f50c2b100d9aab"
-FROZEN_NOMIC_PREFIX = "clustering:"
+# Exact bytes prepended by the revision-pinned Nomic cache builder.  The
+# trailing space is semantic input, not presentation whitespace.
+FROZEN_NOMIC_PREFIX = "clustering: "
 FROZEN_WALK_WEIGHTS = (1.0, 0.5, 0.25, 0.125)
 
 CANDIDATE_REQUIRED_COLUMNS = (

--- a/prototypes/mu_cosine/repeated_judge_candidate_capacity.py
+++ b/prototypes/mu_cosine/repeated_judge_candidate_capacity.py
@@ -1,0 +1,206 @@
+"""Outcome-blind structural capacity bounds for the repeated-judge campaign.
+
+This module deliberately stops before candidate enumeration, embedding, or
+scoring.  Endpoint-disjoint selection and a per-connected-component source cap
+imply the deliberately loose necessary bound
+
+    U_1(G) = sum_s min(|V_s|, max(1, floor(f_source * G))).
+
+It charges only one distinct endpoint to the declared source component.  This
+remains valid even if the preregistered ``disconnected`` negative comparator is
+interpreted as living outside that component.  If all four distinct endpoints
+(``descendant``, ``anchor``, ``adjacent``, and ``distant``) have finite paths in
+the same canonical graph, the sharper diagnostic is
+
+    U_4(G) = sum_s min(floor(|V_s| / 4), max(1, floor(f_source * G))).
+
+Every later requirement (hop cells, degree quartiles, graph/Nomic agreement,
+historical exclusions, and actual packability) can only reduce capacity.  Thus
+``U_1(G) < G`` is a conclusive, outcome-free reason to stop before expensive
+candidate or Nomic work.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+import math
+
+
+ENDPOINTS_PER_COMPONENT = 4
+GUARANTEED_SOURCE_ENDPOINTS_PER_COMPONENT = 1
+SOURCE_COMPONENT_CAP_FRACTION = 0.10
+
+
+class CandidateCapacityError(ValueError):
+    """Raised when a structural capacity input violates its contract."""
+
+
+def _canonical_graph(parents, children):
+    """Return a finite undirected adjacency map from directed graph maps."""
+    if not isinstance(parents, dict) or not isinstance(children, dict):
+        raise CandidateCapacityError("parents and children must be dictionaries")
+    adjacency = {}
+    canonical = {"parents": {}, "children": {}}
+
+    def add_node(node):
+        try:
+            hash(node)
+        except TypeError as exc:
+            raise CandidateCapacityError("graph nodes must be hashable") from exc
+        if isinstance(node, str) and not node:
+            raise CandidateCapacityError("graph node names must be non-empty")
+        adjacency.setdefault(node, set())
+
+    for mapping_name, mapping in (("parents", parents), ("children", children)):
+        for node, neighbors in mapping.items():
+            add_node(node)
+            if isinstance(neighbors, (str, bytes)):
+                raise CandidateCapacityError(
+                    f"{mapping_name}[{node!r}] must be an iterable of nodes, not text"
+                )
+            try:
+                values = tuple(neighbors)
+            except TypeError as exc:
+                raise CandidateCapacityError(
+                    f"{mapping_name}[{node!r}] must be an iterable of nodes"
+                ) from exc
+            canonical_values = set()
+            for neighbor in values:
+                add_node(neighbor)
+                if neighbor == node:
+                    continue
+                canonical_values.add(neighbor)
+                adjacency[node].add(neighbor)
+                adjacency[neighbor].add(node)
+            canonical[mapping_name][node] = canonical_values
+    if not adjacency:
+        raise CandidateCapacityError("graph must contain at least one node")
+    for node in adjacency:
+        canonical["parents"].setdefault(node, set())
+        canonical["children"].setdefault(node, set())
+    for child, values in canonical["parents"].items():
+        for parent in values:
+            if child not in canonical["children"][parent]:
+                raise CandidateCapacityError(
+                    f"parents/children maps disagree on edge {child!r}->{parent!r}"
+                )
+    for parent, values in canonical["children"].items():
+        for child in values:
+            if parent not in canonical["parents"][child]:
+                raise CandidateCapacityError(
+                    f"children/parents maps disagree on edge {child!r}->{parent!r}"
+                )
+    return adjacency
+
+
+def connected_component_sizes(parents, children):
+    """Return descending weak-component sizes, independent of input ordering."""
+    adjacency = _canonical_graph(parents, children)
+    unseen = set(adjacency)
+    sizes = []
+    while unseen:
+        start = min(unseen, key=lambda value: (type(value).__name__, repr(value)))
+        unseen.remove(start)
+        queue = deque((start,))
+        size = 0
+        while queue:
+            node = queue.popleft()
+            size += 1
+            discovered = adjacency[node] & unseen
+            unseen.difference_update(discovered)
+            queue.extend(discovered)
+        sizes.append(size)
+    return tuple(sorted(sizes, reverse=True))
+
+
+def edge_count(parents, children):
+    """Count unique non-self undirected edges in the canonical graph."""
+    adjacency = _canonical_graph(parents, children)
+    return sum(len(values) for values in adjacency.values()) // 2
+
+
+def source_component_cap(components_per_corpus, cap_fraction=SOURCE_COMPONENT_CAP_FRACTION):
+    if isinstance(components_per_corpus, bool) or not isinstance(components_per_corpus, int):
+        raise CandidateCapacityError("components_per_corpus must be an integer")
+    if components_per_corpus < 1:
+        raise CandidateCapacityError("components_per_corpus must be positive")
+    cap_fraction = float(cap_fraction)
+    if not math.isfinite(cap_fraction) or not 0.0 < cap_fraction <= 1.0:
+        raise CandidateCapacityError("cap_fraction must lie in (0,1]")
+    return max(1, int(math.floor(components_per_corpus * cap_fraction + 1e-12)))
+
+
+def optimistic_capacity_bound(
+    component_sizes,
+    components_per_corpus,
+    *,
+    cap_fraction=SOURCE_COMPONENT_CAP_FRACTION,
+    endpoints_per_component=GUARANTEED_SOURCE_ENDPOINTS_PER_COMPONENT,
+):
+    """Necessary pre-history capacity gate under endpoint and source caps."""
+    if isinstance(endpoints_per_component, bool) or not isinstance(endpoints_per_component, int):
+        raise CandidateCapacityError("endpoints_per_component must be an integer")
+    if endpoints_per_component < 1:
+        raise CandidateCapacityError("endpoints_per_component must be positive")
+    sizes = tuple(component_sizes)
+    if not sizes:
+        raise CandidateCapacityError("component_sizes must not be empty")
+    if any(isinstance(value, bool) or not isinstance(value, int) or value < 1 for value in sizes):
+        raise CandidateCapacityError("component_sizes must contain positive integers")
+    cap = source_component_cap(components_per_corpus, cap_fraction)
+    contributions = tuple(
+        min(size // endpoints_per_component, cap)
+        for size in sorted(sizes, reverse=True)
+    )
+    upper = sum(contributions)
+    return {
+        "components_per_corpus": components_per_corpus,
+        "source_component_cap": cap,
+        "endpoints_per_component": endpoints_per_component,
+        "optimistic_capacity_upper_bound": upper,
+        "necessary_capacity_gate_passes": upper >= components_per_corpus,
+        "nonzero_source_components": sum(value > 0 for value in contributions),
+        "largest_source_contributions": list(sorted(contributions, reverse=True)[:10]),
+    }
+
+
+def audit_graph_capacity(
+    parents,
+    children,
+    registered_sizes,
+    *,
+    cap_fraction=SOURCE_COMPONENT_CAP_FRACTION,
+):
+    """Summarize one frozen graph without using outcomes or embeddings."""
+    sizes = connected_component_sizes(parents, children)
+    conservative_grid = {
+        str(value): optimistic_capacity_bound(
+            sizes,
+            value,
+            cap_fraction=cap_fraction,
+            endpoints_per_component=GUARANTEED_SOURCE_ENDPOINTS_PER_COMPONENT,
+        )
+        for value in registered_sizes
+    }
+    same_source_four_endpoint_grid = {
+        str(value): optimistic_capacity_bound(
+            sizes,
+            value,
+            cap_fraction=cap_fraction,
+            endpoints_per_component=ENDPOINTS_PER_COMPONENT,
+        )
+        for value in registered_sizes
+    }
+    return {
+        "node_count": sum(sizes),
+        "edge_count": edge_count(parents, children),
+        "connected_component_count": len(sizes),
+        "connected_component_sizes_descending": list(sizes),
+        "largest_connected_component_fraction": sizes[0] / sum(sizes),
+        "registered_grid": conservative_grid,
+        "same_source_four_endpoint_sensitivity_grid": same_source_four_endpoint_grid,
+        "all_registered_sizes_pass_necessary_gate": all(
+            value["necessary_capacity_gate_passes"]
+            for value in conservative_grid.values()
+        ),
+    }

--- a/prototypes/mu_cosine/repro/repeated_judge_candidate_capacity/summary.json
+++ b/prototypes/mu_cosine/repro/repeated_judge_candidate_capacity/summary.json
@@ -52,8 +52,8 @@
       "size_bytes": 7653
     },
     "run_repeated_judge_candidate_capacity.py": {
-      "sha256": "03be42981d55296c0b9652288b3f41d13471de0314144a6ea92c38037094377f",
-      "size_bytes": 11937
+      "sha256": "18709c92f3a9e5afe460d408f88e31975c5d241061a1939bdfde25701b4948e3",
+      "size_bytes": 12142
     },
     "run_structured_residual_covariance.py": {
       "sha256": "2c7aabc0c73679ba34b88c44361235e859a06474aafc7b5054ee2b9fad4e3f2d",

--- a/prototypes/mu_cosine/repro/repeated_judge_candidate_capacity/summary.json
+++ b/prototypes/mu_cosine/repro/repeated_judge_candidate_capacity/summary.json
@@ -1,0 +1,486 @@
+{
+  "algorithm": "repeated-judge-candidate-capacity-preflight-v1",
+  "authorization": {
+    "candidate_builder_unlocked": false,
+    "candidate_enumeration_unlocked": false,
+    "covariance_deployment_unlocked": false,
+    "cuda_claim_unlocked": false,
+    "judge_calls_authorized": false,
+    "live_campaign_authorized": false,
+    "nomic_embedding_unlocked": false,
+    "qr_specialization_unlocked": false
+  },
+  "configuration": {
+    "distinct_graph_endpoints_per_campaign_component": 4,
+    "guaranteed_endpoints_charged_to_declared_source": 1,
+    "registered_components_per_corpus": [
+      160,
+      320,
+      512,
+      800
+    ],
+    "source_component_cap_fraction": 0.1,
+    "source_components_frozen_before_endpoint_exclusions": true,
+    "source_definition": "weak connected component of the canonical retained graph"
+  },
+  "decision": {
+    "all_registered_sizes_feasible": false,
+    "candidate_builder_must_stop": true,
+    "capacity_gate_passed": false,
+    "reason": "the conservative one-endpoint/source-cap upper bound is below G for at least one registered size in at least one required corpus; hop cells, degree matching, graph/Nomic agreement, history exclusions, and actual packing can only reduce capacity when source components remain frozen",
+    "required_next_action": "amend the preregistered dependency/source partition outcome-blindly; do not silently relabel branches as connected components or relax the cap"
+  },
+  "implementation": {
+    "lmdb_id.py": {
+      "sha256": "2ea3fa8e105e905b1c52147c1f7bd0cb61e524aae507e8091a85f2d50fba9eb0",
+      "size_bytes": 580
+    },
+    "mu_attention.py": {
+      "sha256": "60d187c7ed539097889ab05cfcc6e26d7717e37f6f08afb126bc9636f527a363",
+      "size_bytes": 39873
+    },
+    "repeated_judge_campaign.py": {
+      "sha256": "22d0469bee4bd49aaff484dd6f939246888c61319be6db27c6209c37c142ea74",
+      "size_bytes": 63443
+    },
+    "repeated_judge_candidate_capacity.py": {
+      "sha256": "2a0c15ae06d3c6145ae5c89977b3e33db26ce660486bd046fb68940e26055617",
+      "size_bytes": 8436
+    },
+    "run_product_kalman_realdata.py": {
+      "sha256": "7ce2396132e4568f73f24de846cb8de2407c8f3790bbc8960812647fce230ed2",
+      "size_bytes": 7653
+    },
+    "run_repeated_judge_candidate_capacity.py": {
+      "sha256": "03be42981d55296c0b9652288b3f41d13471de0314144a6ea92c38037094377f",
+      "size_bytes": 11937
+    },
+    "run_structured_residual_covariance.py": {
+      "sha256": "2c7aabc0c73679ba34b88c44361235e859a06474aafc7b5054ee2b9fad4e3f2d",
+      "size_bytes": 28232
+    },
+    "sample_sigma_hop_fresh_corpus.py": {
+      "sha256": "41c9b4b04bc02330b70e01b09d2b15d5d3f300a103fdfe6f071605264173caec",
+      "size_bytes": 30300
+    },
+    "sigma_hop_confirmatory.py": {
+      "sha256": "b31e34362ab1f2aa9250e505f21d36c1c4b9f40e2279ecc44501e7c54f4ab4d9",
+      "size_bytes": 21589
+    }
+  },
+  "inputs": {
+    "graph_bundle": {
+      "sha256": "e451d4b090dba2013b115aae2f80f40211776b240974777f6663f861d1a373bd",
+      "size_bytes": 823
+    },
+    "graphs": {
+      "exploratory": {
+        "artifacts": {
+          "category_parent": {
+            "sha256": "4881beedfd876e3abb9f1783cbc3fb8a7350e108e3f531cc4de28ef9956dc8ec",
+            "size_bytes": 10126922
+          },
+          "dataset_metadata": {
+            "sha256": "15a632799adebd8b4f736c8420add8969bb5e5e4f20aa21ecaae9e2d95a61577",
+            "size_bytes": 308
+          }
+        },
+        "corpus_identity": "SimpleWiki 100k category graph",
+        "format": "UTF-8 child-parent TSV"
+      },
+      "fresh": {
+        "artifacts": {
+          "category_lmdb_data": {
+            "sha256": "3bcfe59a3f85870f377fad1ea77547f7c3566370f6172e27748f4f7ceba5d690",
+            "size_bytes": 1319403520
+          },
+          "exploratory_title_exclusion_graph": {
+            "sha256": "4881beedfd876e3abb9f1783cbc3fb8a7350e108e3f531cc4de28ef9956dc8ec",
+            "size_bytes": 10126922
+          }
+        },
+        "corpus_identity": "enwiki category LMDB retained under Behavior",
+        "excluded_runtime_artifact": "lock.mdb is process state, not graph content",
+        "format": "LMDB uint32 graph with UTF-8 title layer"
+      }
+    },
+    "historical_inventory_consumed": false,
+    "nomic_cache_consumed": false,
+    "outcomes_consumed": false
+  },
+  "joint_grid": {
+    "160": {
+      "joint_necessary_capacity_gate_passes": false,
+      "passing_corpora": [],
+      "required_corpora": [
+        "exploratory",
+        "fresh"
+      ]
+    },
+    "320": {
+      "joint_necessary_capacity_gate_passes": false,
+      "passing_corpora": [],
+      "required_corpora": [
+        "exploratory",
+        "fresh"
+      ]
+    },
+    "512": {
+      "joint_necessary_capacity_gate_passes": false,
+      "passing_corpora": [],
+      "required_corpora": [
+        "exploratory",
+        "fresh"
+      ]
+    },
+    "800": {
+      "joint_necessary_capacity_gate_passes": false,
+      "passing_corpora": [],
+      "required_corpora": [
+        "exploratory",
+        "fresh"
+      ]
+    }
+  },
+  "loader_metadata": {
+    "exploratory": {
+      "feature_graph_source": "child-parent TSV"
+    },
+    "fresh": {
+      "feature_graph_lmdb_stats": {
+        "admin_node": 4022,
+        "child_edges_examined": 105825,
+        "missing_title_nodes": 60,
+        "overlap_node": 1757,
+        "parent_edges_examined": 274545,
+        "retained_edges": 99986,
+        "title_lookups": 509416
+      },
+      "feature_graph_root": "Behavior",
+      "feature_graph_slice_nodes": 75901,
+      "feature_graph_source": "lmdb"
+    }
+  },
+  "non_claims": [
+    "this preflight did not enumerate or select candidate triples",
+    "this preflight did not create or consume a Nomic embedding cache",
+    "this preflight did not build a historical endpoint inventory",
+    "this preflight did not consume judge scores or residuals",
+    "an optimistic upper bound is not evidence that a passing graph is actually packable",
+    "no branch/source partition has been substituted for connected components",
+    "the sharper four-endpoint sensitivity is not used as the blocking proof because the preregistration permits a disconnected distant comparator"
+  ],
+  "results": {
+    "exploratory": {
+      "all_registered_sizes_pass_necessary_gate": false,
+      "connected_component_count": 34,
+      "connected_component_sizes_descending": [
+        83194,
+        767,
+        77,
+        19,
+        5,
+        4,
+        4,
+        4,
+        4,
+        4,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        1
+      ],
+      "edge_count": 196876,
+      "largest_connected_component_fraction": 0.9888038413996387,
+      "node_count": 84136,
+      "registered_grid": {
+        "160": {
+          "components_per_corpus": 160,
+          "endpoints_per_component": 1,
+          "largest_source_contributions": [
+            16,
+            16,
+            16,
+            16,
+            5,
+            4,
+            4,
+            4,
+            4,
+            4
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 34,
+          "optimistic_capacity_upper_bound": 143,
+          "source_component_cap": 16
+        },
+        "320": {
+          "components_per_corpus": 320,
+          "endpoints_per_component": 1,
+          "largest_source_contributions": [
+            32,
+            32,
+            32,
+            19,
+            5,
+            4,
+            4,
+            4,
+            4,
+            4
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 34,
+          "optimistic_capacity_upper_bound": 194,
+          "source_component_cap": 32
+        },
+        "512": {
+          "components_per_corpus": 512,
+          "endpoints_per_component": 1,
+          "largest_source_contributions": [
+            51,
+            51,
+            51,
+            19,
+            5,
+            4,
+            4,
+            4,
+            4,
+            4
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 34,
+          "optimistic_capacity_upper_bound": 251,
+          "source_component_cap": 51
+        },
+        "800": {
+          "components_per_corpus": 800,
+          "endpoints_per_component": 1,
+          "largest_source_contributions": [
+            80,
+            80,
+            77,
+            19,
+            5,
+            4,
+            4,
+            4,
+            4,
+            4
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 34,
+          "optimistic_capacity_upper_bound": 335,
+          "source_component_cap": 80
+        }
+      },
+      "same_source_four_endpoint_sensitivity_grid": {
+        "160": {
+          "components_per_corpus": 160,
+          "endpoints_per_component": 4,
+          "largest_source_contributions": [
+            16,
+            16,
+            16,
+            4,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 10,
+          "optimistic_capacity_upper_bound": 58,
+          "source_component_cap": 16
+        },
+        "320": {
+          "components_per_corpus": 320,
+          "endpoints_per_component": 4,
+          "largest_source_contributions": [
+            32,
+            32,
+            19,
+            4,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 10,
+          "optimistic_capacity_upper_bound": 93,
+          "source_component_cap": 32
+        },
+        "512": {
+          "components_per_corpus": 512,
+          "endpoints_per_component": 4,
+          "largest_source_contributions": [
+            51,
+            51,
+            19,
+            4,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 10,
+          "optimistic_capacity_upper_bound": 131,
+          "source_component_cap": 51
+        },
+        "800": {
+          "components_per_corpus": 800,
+          "endpoints_per_component": 4,
+          "largest_source_contributions": [
+            80,
+            80,
+            19,
+            4,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 10,
+          "optimistic_capacity_upper_bound": 189,
+          "source_component_cap": 80
+        }
+      }
+    },
+    "fresh": {
+      "all_registered_sizes_pass_necessary_gate": false,
+      "connected_component_count": 1,
+      "connected_component_sizes_descending": [
+        75901
+      ],
+      "edge_count": 99971,
+      "largest_connected_component_fraction": 1.0,
+      "node_count": 75901,
+      "registered_grid": {
+        "160": {
+          "components_per_corpus": 160,
+          "endpoints_per_component": 1,
+          "largest_source_contributions": [
+            16
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 1,
+          "optimistic_capacity_upper_bound": 16,
+          "source_component_cap": 16
+        },
+        "320": {
+          "components_per_corpus": 320,
+          "endpoints_per_component": 1,
+          "largest_source_contributions": [
+            32
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 1,
+          "optimistic_capacity_upper_bound": 32,
+          "source_component_cap": 32
+        },
+        "512": {
+          "components_per_corpus": 512,
+          "endpoints_per_component": 1,
+          "largest_source_contributions": [
+            51
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 1,
+          "optimistic_capacity_upper_bound": 51,
+          "source_component_cap": 51
+        },
+        "800": {
+          "components_per_corpus": 800,
+          "endpoints_per_component": 1,
+          "largest_source_contributions": [
+            80
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 1,
+          "optimistic_capacity_upper_bound": 80,
+          "source_component_cap": 80
+        }
+      },
+      "same_source_four_endpoint_sensitivity_grid": {
+        "160": {
+          "components_per_corpus": 160,
+          "endpoints_per_component": 4,
+          "largest_source_contributions": [
+            16
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 1,
+          "optimistic_capacity_upper_bound": 16,
+          "source_component_cap": 16
+        },
+        "320": {
+          "components_per_corpus": 320,
+          "endpoints_per_component": 4,
+          "largest_source_contributions": [
+            32
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 1,
+          "optimistic_capacity_upper_bound": 32,
+          "source_component_cap": 32
+        },
+        "512": {
+          "components_per_corpus": 512,
+          "endpoints_per_component": 4,
+          "largest_source_contributions": [
+            51
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 1,
+          "optimistic_capacity_upper_bound": 51,
+          "source_component_cap": 51
+        },
+        "800": {
+          "components_per_corpus": 800,
+          "endpoints_per_component": 4,
+          "largest_source_contributions": [
+            80
+          ],
+          "necessary_capacity_gate_passes": false,
+          "nonzero_source_components": 1,
+          "optimistic_capacity_upper_bound": 80,
+          "source_component_cap": 80
+        }
+      }
+    }
+  },
+  "schema_version": 1,
+  "status": "NO-SPEND STRUCTURAL CAPACITY PREFLIGHT; CANDIDATE BUILDER BLOCKED"
+}

--- a/prototypes/mu_cosine/run_repeated_judge_candidate_capacity.py
+++ b/prototypes/mu_cosine/run_repeated_judge_candidate_capacity.py
@@ -4,6 +4,9 @@
 The command uses the repository's canonical graph loaders and emits a portable,
 content-addressed JSON result.  It consumes no scores, residuals, embeddings, or
 judge responses and cannot authorize a live call.
+
+An infeasible gate exits with status 2 after writing the audit.  ``--audit-only``
+is the explicit reporting-mode escape hatch when a zero exit is required.
 """
 
 from __future__ import annotations
@@ -293,9 +296,12 @@ def build_arg_parser():
     parser.add_argument("--out", required=True)
     parser.add_argument("--lmdb-no-lock", action="store_true")
     parser.add_argument(
-        "--require-feasible",
+        "--audit-only",
         action="store_true",
-        help="return status 2 when the necessary structural capacity gate fails",
+        help=(
+            "return zero after a completed audit even when infeasible; "
+            "does not unlock anything"
+        ),
     )
     return parser
 
@@ -312,7 +318,7 @@ def main(argv=None):
         "artifact": artifact,
         "candidate_builder_must_stop": payload["decision"]["candidate_builder_must_stop"],
     }, indent=2, sort_keys=True))
-    if args.require_feasible and payload["decision"]["candidate_builder_must_stop"]:
+    if not args.audit_only and payload["decision"]["candidate_builder_must_stop"]:
         return 2
     return 0
 

--- a/prototypes/mu_cosine/run_repeated_judge_candidate_capacity.py
+++ b/prototypes/mu_cosine/run_repeated_judge_candidate_capacity.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Audit repeated-judge structural capacity before candidates or Nomic.
+
+The command uses the repository's canonical graph loaders and emits a portable,
+content-addressed JSON result.  It consumes no scores, residuals, embeddings, or
+judge responses and cannot authorize a live call.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from repeated_judge_campaign import content_record
+from repeated_judge_candidate_capacity import (
+    ENDPOINTS_PER_COMPONENT,
+    GUARANTEED_SOURCE_ENDPOINTS_PER_COMPONENT,
+    SOURCE_COMPONENT_CAP_FRACTION,
+    audit_graph_capacity,
+)
+
+
+SCHEMA_VERSION = 1
+ALGORITHM = "repeated-judge-candidate-capacity-preflight-v1"
+REGISTERED_COMPONENT_SIZES = (160, 320, 512, 800)
+IMPLEMENTATION_FILES = (
+    "repeated_judge_candidate_capacity.py",
+    "run_repeated_judge_candidate_capacity.py",
+    "repeated_judge_campaign.py",
+    "sample_sigma_hop_fresh_corpus.py",
+    "sigma_hop_confirmatory.py",
+    "run_product_kalman_realdata.py",
+    "run_structured_residual_covariance.py",
+    "mu_attention.py",
+    "lmdb_id.py",
+)
+
+
+def _json_bytes(value):
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _implementation_records(root=HERE):
+    root = Path(root)
+    return {
+        name: content_record((root / name).read_bytes())
+        for name in IMPLEMENTATION_FILES
+    }
+
+
+def _graph_bundle_record(graph_inputs):
+    canonical = json.dumps(
+        graph_inputs,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return content_record(canonical)
+
+
+def build_capacity_payload(
+    graphs,
+    graph_inputs,
+    *,
+    registered_sizes=REGISTERED_COMPONENT_SIZES,
+    implementation=None,
+    loader_metadata=None,
+):
+    """Build path-free scientific JSON from already-loaded graph maps."""
+    if set(graphs) != {"exploratory", "fresh"}:
+        raise ValueError("graphs must contain exactly exploratory and fresh")
+    if set(graph_inputs) != set(graphs):
+        raise ValueError("graph_inputs must align exactly with graphs")
+    registered_sizes = tuple(registered_sizes)
+    if not registered_sizes:
+        raise ValueError("registered_sizes must be non-empty")
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value < 1
+        for value in registered_sizes
+    ):
+        raise ValueError("registered_sizes must contain positive non-bool integers")
+    if len(set(registered_sizes)) != len(registered_sizes):
+        raise ValueError("registered_sizes must be unique")
+    results = {
+        corpus: audit_graph_capacity(
+            graphs[corpus]["parents"],
+            graphs[corpus]["children"],
+            registered_sizes,
+            cap_fraction=SOURCE_COMPONENT_CAP_FRACTION,
+        )
+        for corpus in ("exploratory", "fresh")
+    }
+    joint_grid = {}
+    for size in registered_sizes:
+        key = str(size)
+        passing = [
+            corpus
+            for corpus in ("exploratory", "fresh")
+            if results[corpus]["registered_grid"][key][
+                "necessary_capacity_gate_passes"
+            ]
+        ]
+        joint_grid[key] = {
+            "passing_corpora": passing,
+            "required_corpora": ["exploratory", "fresh"],
+            "joint_necessary_capacity_gate_passes": len(passing) == 2,
+        }
+    all_feasible = all(
+        value["joint_necessary_capacity_gate_passes"]
+        for value in joint_grid.values()
+    )
+    metadata = loader_metadata or {}
+    portable_metadata = {
+        corpus: dict(metadata.get(corpus, {}))
+        for corpus in ("exploratory", "fresh")
+    }
+    if all_feasible:
+        status = "NO-SPEND STRUCTURAL CAPACITY PREFLIGHT PASSED; ENUMERATION ELIGIBLE"
+        reason = (
+            "the conservative one-endpoint/source-cap upper bound reaches G for every "
+            "registered size; this necessary gate does not establish actual packability"
+        )
+        required_next_action = (
+            "proceed only to the no-spend historical inventory and structural enumeration; "
+            "judge calls and scientific deployment remain unauthorized"
+        )
+    else:
+        status = "NO-SPEND STRUCTURAL CAPACITY PREFLIGHT; CANDIDATE BUILDER BLOCKED"
+        reason = (
+            "the conservative one-endpoint/source-cap upper bound is below G for at least "
+            "one registered size in at least one required corpus; hop cells, degree matching, "
+            "graph/Nomic agreement, history exclusions, and actual packing can only "
+            "reduce capacity when source components remain frozen"
+        )
+        required_next_action = (
+            "amend the preregistered dependency/source partition outcome-blindly; "
+            "do not silently relabel branches as connected components or relax the cap"
+        )
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "algorithm": ALGORITHM,
+        "authorization": {
+            "candidate_enumeration_unlocked": all_feasible,
+            "nomic_embedding_unlocked": False,
+            "candidate_builder_unlocked": False,
+            "judge_calls_authorized": False,
+            "live_campaign_authorized": False,
+            "covariance_deployment_unlocked": False,
+            "qr_specialization_unlocked": False,
+            "cuda_claim_unlocked": False,
+        },
+        "configuration": {
+            "registered_components_per_corpus": list(registered_sizes),
+            "source_definition": "weak connected component of the canonical retained graph",
+            "source_component_cap_fraction": SOURCE_COMPONENT_CAP_FRACTION,
+            "distinct_graph_endpoints_per_campaign_component": ENDPOINTS_PER_COMPONENT,
+            "guaranteed_endpoints_charged_to_declared_source": (
+                GUARANTEED_SOURCE_ENDPOINTS_PER_COMPONENT
+            ),
+            "source_components_frozen_before_endpoint_exclusions": True,
+        },
+        "implementation": (
+            _implementation_records() if implementation is None else implementation
+        ),
+        "inputs": {
+            "graph_bundle": _graph_bundle_record(graph_inputs),
+            "graphs": graph_inputs,
+            "outcomes_consumed": False,
+            "historical_inventory_consumed": False,
+            "nomic_cache_consumed": False,
+        },
+        "loader_metadata": portable_metadata,
+        "results": results,
+        "joint_grid": joint_grid,
+        "decision": {
+            "all_registered_sizes_feasible": all_feasible,
+            "capacity_gate_passed": all_feasible,
+            "candidate_builder_must_stop": not all_feasible,
+            "reason": reason,
+            "required_next_action": required_next_action,
+        },
+        "non_claims": [
+            "this preflight did not enumerate or select candidate triples",
+            "this preflight did not create or consume a Nomic embedding cache",
+            "this preflight did not build a historical endpoint inventory",
+            "this preflight did not consume judge scores or residuals",
+            "an optimistic upper bound is not evidence that a passing graph is actually packable",
+            "no branch/source partition has been substituted for connected components",
+            "the sharper four-endpoint sensitivity is not used as the blocking proof because the preregistration permits a disconnected distant comparator",
+        ],
+    }
+    return payload
+
+
+def load_frozen_graphs(artifact_repo, *, lmdb_no_lock=False):
+    """Load both frozen corpora and return portable content provenance."""
+    from run_product_kalman_realdata import DATASETS
+    from run_structured_residual_covariance import configure_artifact_repo
+    from sigma_hop_confirmatory import FeatureGraphConfig, load_feature_graph
+
+    artifacts = configure_artifact_repo(artifact_repo)
+    DATASETS["fresh"]["graph"]["lmdb_no_lock"] = bool(lmdb_no_lock)
+    graphs = {}
+    metadata = {}
+    for corpus in ("exploratory", "fresh"):
+        parents, children, _degree, raw_metadata = load_feature_graph(
+            FeatureGraphConfig(**DATASETS[corpus]["graph"])
+        )
+        graphs[corpus] = {"parents": parents, "children": children}
+        if corpus == "fresh":
+            metadata[corpus] = {
+                "feature_graph_source": raw_metadata.get("feature_graph_source"),
+                "feature_graph_root": raw_metadata.get("feature_graph_root"),
+                "feature_graph_slice_nodes": raw_metadata.get("feature_graph_slice_nodes"),
+                "feature_graph_lmdb_stats": raw_metadata.get("feature_graph_lmdb_stats", {}),
+            }
+        else:
+            metadata[corpus] = {
+                "feature_graph_source": "child-parent TSV",
+            }
+    exploratory_record = {
+        key: artifacts["exploratory_graph"][key]
+        for key in ("size_bytes", "sha256")
+    }
+    fresh_record = {
+        key: artifacts["fresh_lmdb_data"][key]
+        for key in ("size_bytes", "sha256")
+    }
+    exploratory_metadata = (
+        Path(artifact_repo) / "data" / "benchmark" / "100k_cats" / "metadata.json"
+    )
+    if not exploratory_metadata.is_file():
+        raise FileNotFoundError(
+            f"missing exploratory dataset metadata: {exploratory_metadata}"
+        )
+    graph_inputs = {
+        "exploratory": {
+            "corpus_identity": "SimpleWiki 100k category graph",
+            "format": "UTF-8 child-parent TSV",
+            "artifacts": {
+                "category_parent": exploratory_record,
+                "dataset_metadata": content_record(exploratory_metadata.read_bytes()),
+            },
+        },
+        "fresh": {
+            "corpus_identity": "enwiki category LMDB retained under Behavior",
+            "format": "LMDB uint32 graph with UTF-8 title layer",
+            "artifacts": {
+                "category_lmdb_data": fresh_record,
+                "exploratory_title_exclusion_graph": exploratory_record,
+            },
+            "excluded_runtime_artifact": artifacts["fresh_lmdb_lock_excluded"],
+        },
+    }
+    return graphs, graph_inputs, metadata
+
+
+def _atomic_write(path, payload):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    data = _json_bytes(payload)
+    try:
+        temporary.write_bytes(data)
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return content_record(data)
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-repo", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--lmdb-no-lock", action="store_true")
+    parser.add_argument(
+        "--require-feasible",
+        action="store_true",
+        help="return status 2 when the necessary structural capacity gate fails",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    graphs, graph_inputs, metadata = load_frozen_graphs(
+        args.artifact_repo, lmdb_no_lock=args.lmdb_no_lock
+    )
+    payload = build_capacity_payload(graphs, graph_inputs, loader_metadata=metadata)
+    artifact = _atomic_write(args.out, payload)
+    print(json.dumps({
+        "output": os.path.abspath(args.out),
+        "artifact": artifact,
+        "candidate_builder_must_stop": payload["decision"]["candidate_builder_must_stop"],
+    }, indent=2, sort_keys=True))
+    if args.require_feasible and payload["decision"]["candidate_builder_must_stop"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_repeated_judge_candidate_capacity.py
+++ b/prototypes/mu_cosine/test_repeated_judge_candidate_capacity.py
@@ -230,7 +230,7 @@ def test_mixed_grid_reports_at_least_one_failure_without_overclaiming():
     assert "every registered size" not in payload["decision"]["reason"]
 
 
-def test_require_feasible_returns_two_for_blocked_audit(monkeypatch, tmp_path):
+def test_blocked_audit_returns_two_by_default(monkeypatch, tmp_path):
     graph = graph_from_component_sizes((16,))
     graphs = {
         corpus: {"parents": graph[0], "children": graph[1]}
@@ -246,11 +246,109 @@ def test_require_feasible_returns_two_for_blocked_audit(monkeypatch, tmp_path):
         [
             "--artifact-repo", "unused",
             "--out", str(output),
-            "--require-feasible",
         ]
     )
     assert status == 2
     assert json.loads(output.read_text())["decision"]["candidate_builder_must_stop"] is True
+
+
+def test_audit_only_explicitly_returns_zero_for_blocked_audit(monkeypatch, tmp_path):
+    graph = graph_from_component_sizes((16,))
+    graphs = {
+        corpus: {"parents": graph[0], "children": graph[1]}
+        for corpus in ("exploratory", "fresh")
+    }
+    monkeypatch.setattr(
+        runner,
+        "load_frozen_graphs",
+        lambda *_args, **_kwargs: (graphs, fake_inputs(), {}),
+    )
+    blocked_output = tmp_path / "blocked.json"
+    blocked_status = runner.main(
+        [
+            "--artifact-repo", "unused",
+            "--out", str(blocked_output),
+        ]
+    )
+    output = tmp_path / "audit-only.json"
+    status = runner.main(
+        [
+            "--artifact-repo", "unused",
+            "--out", str(output),
+            "--audit-only",
+        ]
+    )
+    assert blocked_status == 2
+    assert status == 0
+    assert output.read_bytes() == blocked_output.read_bytes()
+    payload = json.loads(output.read_text())
+    assert payload["decision"]["candidate_builder_must_stop"] is True
+    assert all(value is False for value in payload["authorization"].values())
+
+
+def test_passing_audit_returns_zero_by_default(monkeypatch, tmp_path):
+    graph = graph_from_component_sizes((1,) * 800)
+    graphs = {
+        corpus: {"parents": graph[0], "children": graph[1]}
+        for corpus in ("exploratory", "fresh")
+    }
+    monkeypatch.setattr(
+        runner,
+        "load_frozen_graphs",
+        lambda *_args, **_kwargs: (graphs, fake_inputs(), {}),
+    )
+    output = tmp_path / "capacity.json"
+    status = runner.main(
+        [
+            "--artifact-repo", "unused",
+            "--out", str(output),
+        ]
+    )
+    assert status == 0
+    assert json.loads(output.read_text())["decision"]["capacity_gate_passed"] is True
+
+
+def test_audit_only_does_not_swallow_load_errors(monkeypatch, tmp_path):
+    def fail_load(*_args, **_kwargs):
+        raise RuntimeError("fixture load failure")
+
+    monkeypatch.setattr(runner, "load_frozen_graphs", fail_load)
+    output = tmp_path / "capacity.json"
+    with pytest.raises(RuntimeError, match="fixture load failure"):
+        runner.main(
+            [
+                "--artifact-repo", "unused",
+                "--out", str(output),
+                "--audit-only",
+            ]
+        )
+    assert not output.exists()
+
+
+def test_audit_only_does_not_swallow_write_errors(monkeypatch, tmp_path):
+    graph = graph_from_component_sizes((16,))
+    graphs = {
+        corpus: {"parents": graph[0], "children": graph[1]}
+        for corpus in ("exploratory", "fresh")
+    }
+    monkeypatch.setattr(
+        runner,
+        "load_frozen_graphs",
+        lambda *_args, **_kwargs: (graphs, fake_inputs(), {}),
+    )
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("fixture write failure")
+
+    monkeypatch.setattr(runner, "_atomic_write", fail_write)
+    with pytest.raises(OSError, match="fixture write failure"):
+        runner.main(
+            [
+                "--artifact-repo", "unused",
+                "--out", str(tmp_path / "capacity.json"),
+                "--audit-only",
+            ]
+        )
 
 
 def test_graph_input_sets_must_match_exactly():

--- a/prototypes/mu_cosine/test_repeated_judge_candidate_capacity.py
+++ b/prototypes/mu_cosine/test_repeated_judge_candidate_capacity.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Tests for the no-spend repeated-judge structural capacity preflight."""
+
+import json
+
+import pytest
+
+from independent_embedding_cache import MODEL_SPECS
+from repeated_judge_campaign import FROZEN_NOMIC_PREFIX
+from repeated_judge_candidate_capacity import (
+    CandidateCapacityError,
+    ENDPOINTS_PER_COMPONENT,
+    audit_graph_capacity,
+    connected_component_sizes,
+    optimistic_capacity_bound,
+    source_component_cap,
+)
+import run_repeated_judge_candidate_capacity as runner
+
+
+def graph_from_component_sizes(sizes, *, reverse=False):
+    parents = {}
+    children = {}
+    for component, size in enumerate(sizes):
+        nodes = [f"c{component}-n{value}" for value in range(size)]
+        for node in nodes:
+            parents[node] = set()
+            children[node] = set()
+        for child, parent in zip(nodes[1:], nodes[:-1]):
+            parents[child].add(parent)
+            children[parent].add(child)
+    if reverse:
+        parents = dict(reversed(list(parents.items())))
+        children = dict(reversed(list(children.items())))
+    return parents, children
+
+
+def fake_record(token):
+    return {"size_bytes": len(token), "sha256": token * 64}
+
+
+def fake_inputs():
+    return {
+        "exploratory": {
+            "corpus_identity": "fixture-a",
+            "format": "fixture",
+            "artifacts": {"graph": fake_record("a")},
+        },
+        "fresh": {
+            "corpus_identity": "fixture-b",
+            "format": "fixture",
+            "artifacts": {"graph": fake_record("b")},
+        },
+    }
+
+
+def test_one_connected_component_cannot_satisfy_a_ten_percent_cap():
+    bound = optimistic_capacity_bound((75_901,), 160)
+    assert bound["source_component_cap"] == 16
+    assert bound["optimistic_capacity_upper_bound"] == 16
+    assert bound["necessary_capacity_gate_passes"] is False
+
+
+def test_exact_exploratory_upper_bounds_and_g512_floor():
+    sizes = (
+        83_194, 767, 77, 19, 5, 4, 4, 4, 4, 4,
+        3, 3, 3, 3, 3, 3, 3,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        1,
+    )
+    assert sum(sizes) == 84_136
+    conservative = {
+        value: optimistic_capacity_bound(
+            sizes, value, endpoints_per_component=1
+        )["optimistic_capacity_upper_bound"]
+        for value in (160, 320, 512, 800)
+    }
+    sharper = {
+        value: optimistic_capacity_bound(
+            sizes, value, endpoints_per_component=ENDPOINTS_PER_COMPONENT
+        )[
+            "optimistic_capacity_upper_bound"
+        ]
+        for value in (160, 320, 512, 800)
+    }
+    assert conservative == {160: 143, 320: 194, 512: 251, 800: 335}
+    assert sharper == {160: 58, 320: 93, 512: 131, 800: 189}
+    assert source_component_cap(512) == 51
+    assert ENDPOINTS_PER_COMPONENT == 4
+
+
+def test_component_sizes_and_audit_are_input_order_invariant():
+    first = graph_from_component_sizes((9, 5, 1))
+    second = graph_from_component_sizes((9, 5, 1), reverse=True)
+    assert connected_component_sizes(*first) == (9, 5, 1)
+    assert connected_component_sizes(*second) == (9, 5, 1)
+    assert audit_graph_capacity(*first, (16,)) == audit_graph_capacity(
+        *second, (16,)
+    )
+
+
+def test_removing_nodes_from_frozen_source_components_cannot_increase_bound():
+    before = optimistic_capacity_bound((40, 20, 8), 32)
+    after = optimistic_capacity_bound((36, 16, 4), 32)
+    assert after["optimistic_capacity_upper_bound"] <= before[
+        "optimistic_capacity_upper_bound"
+    ]
+
+
+@pytest.mark.parametrize(
+    "parents,children,message",
+    [
+        ({}, {}, "at least one node"),
+        ({"a": "b"}, {}, "not text"),
+        ({"": set()}, {}, "non-empty"),
+        ({"a": [["unhashable"]]}, {}, "hashable"),
+    ],
+)
+def test_malformed_graphs_fail_closed(parents, children, message):
+    with pytest.raises(CandidateCapacityError, match=message):
+        connected_component_sizes(parents, children)
+
+
+def test_inconsistent_parent_child_maps_fail_closed():
+    with pytest.raises(CandidateCapacityError, match="maps disagree"):
+        connected_component_sizes({"child": {"parent"}}, {"parent": set()})
+
+
+def test_invalid_capacity_arguments_fail_closed():
+    with pytest.raises(CandidateCapacityError, match="integer"):
+        optimistic_capacity_bound((4,), True)
+    with pytest.raises(CandidateCapacityError, match="positive integers"):
+        optimistic_capacity_bound((4, 0), 10)
+    with pytest.raises(CandidateCapacityError, match=r"\(0,1\]"):
+        optimistic_capacity_bound((4,), 10, cap_fraction=0.0)
+
+
+@pytest.mark.parametrize("registered_sizes", [(0,), (True,), (1.5,), ("16",)])
+def test_invalid_registered_sizes_fail_closed(registered_sizes):
+    graph = graph_from_component_sizes((8,))
+    graphs = {
+        corpus: {"parents": graph[0], "children": graph[1]}
+        for corpus in ("exploratory", "fresh")
+    }
+    with pytest.raises(ValueError, match="positive non-bool integers"):
+        runner.build_capacity_payload(
+            graphs,
+            fake_inputs(),
+            registered_sizes=registered_sizes,
+            implementation={"runner.py": fake_record("c")},
+        )
+
+
+def test_payload_is_deterministic_path_free_and_fail_closed(tmp_path):
+    exploratory = graph_from_component_sizes((12, 4))
+    fresh = graph_from_component_sizes((16,))
+    graphs = {
+        "exploratory": {"parents": exploratory[0], "children": exploratory[1]},
+        "fresh": {"parents": fresh[0], "children": fresh[1]},
+    }
+    implementation = {"runner.py": fake_record("c")}
+    first = runner.build_capacity_payload(
+        graphs,
+        fake_inputs(),
+        registered_sizes=(16,),
+        implementation=implementation,
+    )
+    second = runner.build_capacity_payload(
+        graphs,
+        fake_inputs(),
+        registered_sizes=(16,),
+        implementation=implementation,
+    )
+    assert first == second
+    assert first["decision"]["candidate_builder_must_stop"] is True
+    assert all(value is False for value in first["authorization"].values())
+    assert first["inputs"]["outcomes_consumed"] is False
+    assert first["inputs"]["historical_inventory_consumed"] is False
+    assert first["inputs"]["nomic_cache_consumed"] is False
+    serialized = runner._json_bytes(first)
+    assert str(tmp_path).encode() not in serialized
+    output = tmp_path / "nested" / "capacity.json"
+    record_a = runner._atomic_write(output, first)
+    record_b = runner._atomic_write(output, second)
+    assert record_a == record_b
+    assert output.read_bytes() == serialized
+    assert not (output.parent / "capacity.json.tmp").exists()
+    assert json.loads(serialized)["schema_version"] == 1
+
+
+def test_passing_payload_unlocks_only_no_spend_enumeration():
+    graph = graph_from_component_sizes((1,) * 16)
+    graphs = {
+        corpus: {"parents": graph[0], "children": graph[1]}
+        for corpus in ("exploratory", "fresh")
+    }
+    payload = runner.build_capacity_payload(
+        graphs,
+        fake_inputs(),
+        registered_sizes=(16,),
+        implementation={"runner.py": fake_record("c")},
+    )
+    assert payload["decision"]["capacity_gate_passed"] is True
+    assert payload["decision"]["candidate_builder_must_stop"] is False
+    assert payload["authorization"]["candidate_enumeration_unlocked"] is True
+    assert all(
+        value is False
+        for name, value in payload["authorization"].items()
+        if name != "candidate_enumeration_unlocked"
+    )
+    assert "PASSED" in payload["status"]
+    assert "does not establish actual packability" in payload["decision"]["reason"]
+
+
+def test_mixed_grid_reports_at_least_one_failure_without_overclaiming():
+    graph = graph_from_component_sizes((1,))
+    graphs = {
+        corpus: {"parents": graph[0], "children": graph[1]}
+        for corpus in ("exploratory", "fresh")
+    }
+    payload = runner.build_capacity_payload(
+        graphs,
+        fake_inputs(),
+        registered_sizes=(1, 16),
+        implementation={"runner.py": fake_record("c")},
+    )
+    assert payload["joint_grid"]["1"]["joint_necessary_capacity_gate_passes"] is True
+    assert payload["joint_grid"]["16"]["joint_necessary_capacity_gate_passes"] is False
+    assert "at least one registered size" in payload["decision"]["reason"]
+    assert "every registered size" not in payload["decision"]["reason"]
+
+
+def test_require_feasible_returns_two_for_blocked_audit(monkeypatch, tmp_path):
+    graph = graph_from_component_sizes((16,))
+    graphs = {
+        corpus: {"parents": graph[0], "children": graph[1]}
+        for corpus in ("exploratory", "fresh")
+    }
+    monkeypatch.setattr(
+        runner,
+        "load_frozen_graphs",
+        lambda *_args, **_kwargs: (graphs, fake_inputs(), {}),
+    )
+    output = tmp_path / "capacity.json"
+    status = runner.main(
+        [
+            "--artifact-repo", "unused",
+            "--out", str(output),
+            "--require-feasible",
+        ]
+    )
+    assert status == 2
+    assert json.loads(output.read_text())["decision"]["candidate_builder_must_stop"] is True
+
+
+def test_graph_input_sets_must_match_exactly():
+    graph = graph_from_component_sizes((8,))
+    graphs = {"exploratory": {"parents": graph[0], "children": graph[1]}}
+    with pytest.raises(ValueError, match="exactly exploratory and fresh"):
+        runner.build_capacity_payload(graphs, {"exploratory": {}})
+
+
+def test_frozen_nomic_prefix_matches_exact_cache_input_bytes():
+    assert FROZEN_NOMIC_PREFIX == MODEL_SPECS["nomic"].task_prefix
+    assert FROZEN_NOMIC_PREFIX == "clustering: "


### PR DESCRIPTION
## Summary

This is a no-spend structural preflight for the repeated-judge graph-covariance campaign.

The preregistered 10% connected-component concentration cap makes the repository's frozen candidate design infeasible at every registered per-corpus size before candidate enumeration, historical filtering, Nomic embedding, or judge calls.

The primary necessary bound deliberately charges only one endpoint to each declared source component:

```text
U_1(G) = sum_s min(|V_s|, max(1, floor(0.10 G)))
```

That conservative proof avoids depending on how the preregistration's disconnected distant comparator is interpreted. The sharper same-source four-endpoint bound is retained only as a sensitivity.

## Frozen-graph result

| G per corpus | cap/source | exploratory U1 | fresh U1 | joint gate |
|---:|---:|---:|---:|---|
| 160 | 16 | 143 | 16 | fail |
| 320 | 32 | 194 | 32 | fail |
| 512 | 51 | 251 | 51 | fail |
| 800 | 80 | 335 | 80 | fail |

- exploratory: 84,136 nodes, 196,876 unique undirected edges, 34 components
- fresh: 75,901 nodes, 99,971 unique undirected edges, one component
- U4 sensitivity, exploratory: 58/93/131/189
- U4 sensitivity, fresh: 16/32/51/80

Because both corpora are required, no registered campaign can proceed under the current source definition. Later hop/cell/agreement/history/packing constraints can only remove capacity while the audited source components remain frozen.

## What changed

- adds a deterministic, path-portable capacity preflight
- makes an infeasible gate write its audit and exit 2 by default, so shell callers fail closed without remembering an extra flag
- provides explicit `--audit-only` reporting mode; it changes only the exit status and never unlocks an authorization
- records content provenance for the frozen graphs, dataset identity, and all loader/config implementation dependencies
- commits the byte-identical 14,322-byte reproduction artifact (SHA-256 `403b1a59b6e53c87f881dad65ab6af2f401e046c0c7009a1efd220eb3899cdd8`)
- documents the blocker, rejected alternatives, and the outcome-blind source-group amendment boundary
- corrects the frozen Nomic task-prefix bytes from `"clustering:"` to `"clustering: "` (trailing U+0020), matching the cache builder
- leaves candidate, Nomic, judge, campaign, covariance, QR, and CUDA authorizations false

No endpoint was selected, no embedding/model was loaded, and no provider was contacted.

## Review follow-up

Claude's official review found no correctness or safety defect and noted one optional orchestration risk: exit 2 previously required `--require-feasible`. This is now inverted:

- blocked default: writes JSON, then exits 2
- blocked `--audit-only`: writes byte-identical JSON, then exits 0
- feasible default: exits 0
- load, validation, and write failures still propagate

Pipeline automation should not use `--audit-only`. Exit 2 is also argparse's usage-error status, so artifact presence plus `decision.candidate_builder_must_stop` distinguishes a completed capacity block from invalid invocation.

## Validation

- 24 focused capacity tests
- 92 repeated-judge regression tests
- 111 inherited geometry/posterior/square-root tests passed; 9 expected skips
- real default replay writes the tracked artifact and exits 2
- default, `--audit-only`, and `--lmdb-no-lock` outputs are byte-identical
- `py_compile` and `git diff --check` pass
- independent post-review audit found no remaining actionable issue

## Next decision

Amend the dependency unit outcome-blindly—most plausibly deterministic exclusive branch/source groups with multi-branch assignment, concentration caps, fold containment, and group-aware inference—then rerun this necessary gate. Do not silently relabel branches as connected components or relax the cap after seeing capacity.