### PR TITLE
WAM/LLVM plawk: column arithmetic in the row readers (records of / rows of)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -483,6 +483,14 @@ contracts so neither is a grab-bag of modifiers:
 `arr[N]` key surface already exists; what is new is that `r` resolves against
 the row schema / positional slots rather than being a separate table.
 
+**Column arithmetic (LANDED).** A print field in either reader may be an
+arithmetic expression over columns and integer constants, e.g.
+`r["amount"] * 2`, `r["amount"] / 4`, `r[2] / r[3]`. It is evaluated in **f64**
+and printed with `%g` (the surface `/` is integer, so a bare column ratio
+would truncate) — the same print-arithmetic path grand-total normalise uses,
+with a column operand read via `@wam_atom_field_f64_value` on the row.
+Tests: `tests/test_plawk_records_reader.pl`, `tests/test_plawk_rows_reader.pl`.
+
 **Write side.** How a pass *builds* a row touches multi-column value
 assembly and the commit path. The **first, minimal writer has LANDED**:
 `TABLE[$k] = $0` captures the whole current record as a row value (its bytes,

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3943,14 +3943,26 @@ plawk_multipass_pass_fn(Index, pass_records(var(Var), var(Table), Body), Tables,
     Body = [print(PrintFields)],
     PrintFields = [_ | _],
     memberchk(cache_schema(Table, Columns), Schemas),
-    maplist(plawk_records_field_index(Var, Columns), PrintFields, ColIndexes),
+    maplist(plawk_records_field_plan(Var, Columns), PrintFields, FieldPlans),
     nth0(TableIndex, Tables, Table),
-    plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, ColIndexes,
+    plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, FieldPlans,
         FieldSep, OutputSep, FnIR).
 
-% Resolve a `records of` print field VAR["col"] to the column's 1-based
-% position in the schema. Name-only: a non-string / non-VAR field fails.
-plawk_records_field_index(Var, Columns, assoc(var(Var), string(Col)), Index) :-
+% Resolve a `records of` print field to a plan: a plain column VAR["col"] ->
+% col(Index) (its 1-based schema position, printed as text), or an arithmetic
+% expression over columns/constants -> arith(F64Op, L, R) (evaluated in f64,
+% printed with %g -- the surface `/` is integer). Name-only operands.
+plawk_records_field_plan(Var, Columns, assoc(var(Var), string(Col)), col(Index)) :-
+    plawk_records_col_index(Columns, Col, Index).
+plawk_records_field_plan(Var, Columns, Expr, arith(F64Op, LPlan, RPlan)) :-
+    Expr =.. [Op, L, R],
+    plawk_i64_op_f64(Op, F64Op),
+    plawk_records_operand(Var, Columns, L, LPlan),
+    plawk_records_operand(Var, Columns, R, RPlan).
+plawk_records_operand(Var, Columns, assoc(var(Var), string(Col)), col(Index)) :-
+    plawk_records_col_index(Columns, Col, Index).
+plawk_records_operand(_Var, _Columns, int(V), aint(V)) :- integer(V).
+plawk_records_col_index(Columns, Col, Index) :-
     atom_string(ColAtom, Col),
     nth1(Index, Columns, col(ColAtom, _Type)).
 % The positional row reader: iterate TABLE's rows, print columns addressed
@@ -3961,15 +3973,22 @@ plawk_multipass_pass_fn(Index, pass_rows(var(Var), var(Table), Body), Tables,
         _StrArrays, _Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
     Body = [print(PrintFields)],
     PrintFields = [_ | _],
-    maplist(plawk_rows_field_index(Var), PrintFields, ColIndexes),
+    maplist(plawk_rows_field_plan(Var), PrintFields, FieldPlans),
     nth0(TableIndex, Tables, Table),
-    plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, ColIndexes,
+    plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, FieldPlans,
         FieldSep, OutputSep, FnIR).
 
-% A `rows of` print field VAR[N] is the row's Nth field (1-indexed).
-% Positional only: a string / non-VAR field fails (that is `records of`).
-plawk_rows_field_index(Var, assoc(var(Var), int(N)), N) :-
+% A `rows of` print field: a plain position VAR[N] -> col(N), or arithmetic
+% over positions/constants -> arith(...), evaluated in f64. Positional only.
+plawk_rows_field_plan(Var, assoc(var(Var), int(N)), col(N)) :-
     integer(N), N > 0.
+plawk_rows_field_plan(Var, Expr, arith(F64Op, LPlan, RPlan)) :-
+    Expr =.. [Op, L, R],
+    plawk_i64_op_f64(Op, F64Op),
+    plawk_rows_operand(Var, L, LPlan),
+    plawk_rows_operand(Var, R, RPlan).
+plawk_rows_operand(Var, assoc(var(Var), int(N)), col(N)) :- integer(N), N > 0.
+plawk_rows_operand(_Var, int(V), aint(V)) :- integer(V).
 
 % Over-reader print fields (v1): the loop key, or a lookup of the iterated
 % table keyed by it. String literals / other tables are follow-ons.
@@ -4057,38 +4076,68 @@ rec_after:
 }
 ', [Index, TableParamsIR, TableIndex, TableIndex, ColIR]).
 
-%% plawk_records_col_lines(+ColIndexes, +FieldSep, +OutputSep, +PrintIndex)//
-%  Per-column print for the named row reader: a separator before each column
-%  after the first, then extract field <ColIndex> of the row (%rec_row_v) and
-%  print its text (%.*s).
+%% plawk_records_col_lines(+FieldPlans, +FieldSep, +OutputSep, +PrintIndex)//
+%  Per-field print for the row readers: a separator before each field after
+%  the first, then either a plain column col(Index) -- extract field Index of
+%  the row (%rec_row_v) and print its text (%.*s) -- or an arithmetic
+%  expression arith(F64Op, L, R) over columns/constants, evaluated in f64 (a
+%  column via @wam_atom_field_f64_value, a constant via sitofp) and printed
+%  with %g.
 plawk_records_col_lines([], _FieldSep, _OutputSep, _PrintIndex) --> [].
-plawk_records_col_lines([ColIndex | Rest], FieldSep, OutputSep, PrintIndex) -->
+plawk_records_col_lines([Plan | Rest], FieldSep, OutputSep, PrintIndex) -->
     { ( PrintIndex =:= 0
       ->  SepLines = []
       ;   format(atom(SepLine),
               '  %rec_sep~w = call i32 @putchar(i32 ~w)', [PrintIndex, OutputSep]),
           SepLines = [SepLine]
       ),
-      format(atom(Slice),
-          '  %rec_f~w_slice = call %WamSlice @wam_atom_field_slice_value(%Value %rec_row_v, i64 ~w, i8 ~w)',
-          [PrintIndex, ColIndex, FieldSep]),
-      format(atom(Ptr), '  %rec_f~w_ptr = extractvalue %WamSlice %rec_f~w_slice, 0',
-          [PrintIndex, PrintIndex]),
-      format(atom(Len), '  %rec_f~w_len = extractvalue %WamSlice %rec_f~w_slice, 1',
-          [PrintIndex, PrintIndex]),
-      format(atom(Lenw), '  %rec_f~w_lenw = trunc i64 %rec_f~w_len to i32',
-          [PrintIndex, PrintIndex]),
-      format(atom(Fmt),
-          '  %rec_f~w_fmt = getelementptr [5 x i8], [5 x i8]* @.plawk_surface_print_slice, i32 0, i32 0',
-          [PrintIndex]),
-      format(atom(Pr),
-          '  %rec_f~w_pr = call i32 (i8*, ...) @printf(i8* %rec_f~w_fmt, i32 %rec_f~w_lenw, i8* %rec_f~w_ptr)',
-          [PrintIndex, PrintIndex, PrintIndex, PrintIndex]),
-      append([SepLines, [Slice, Ptr, Len, Lenw, Fmt, Pr]], Lines),
+      plawk_records_field_lines(Plan, PrintIndex, FieldSep, FieldLines),
+      append([SepLines, FieldLines], Lines),
       NextPrintIndex is PrintIndex + 1
     },
     plawk_emit_lines(Lines),
     plawk_records_col_lines(Rest, FieldSep, OutputSep, NextPrintIndex).
+
+% A plain column: extract its slice from the row and print as text.
+plawk_records_field_lines(col(ColIndex), PrintIndex, FieldSep, Lines) :-
+    format(atom(Slice),
+        '  %rec_f~w_slice = call %WamSlice @wam_atom_field_slice_value(%Value %rec_row_v, i64 ~w, i8 ~w)',
+        [PrintIndex, ColIndex, FieldSep]),
+    format(atom(Ptr), '  %rec_f~w_ptr = extractvalue %WamSlice %rec_f~w_slice, 0',
+        [PrintIndex, PrintIndex]),
+    format(atom(Len), '  %rec_f~w_len = extractvalue %WamSlice %rec_f~w_slice, 1',
+        [PrintIndex, PrintIndex]),
+    format(atom(Lenw), '  %rec_f~w_lenw = trunc i64 %rec_f~w_len to i32',
+        [PrintIndex, PrintIndex]),
+    format(atom(Fmt),
+        '  %rec_f~w_fmt = getelementptr [5 x i8], [5 x i8]* @.plawk_surface_print_slice, i32 0, i32 0',
+        [PrintIndex]),
+    format(atom(Pr),
+        '  %rec_f~w_pr = call i32 (i8*, ...) @printf(i8* %rec_f~w_fmt, i32 %rec_f~w_lenw, i8* %rec_f~w_ptr)',
+        [PrintIndex, PrintIndex, PrintIndex, PrintIndex]),
+    Lines = [Slice, Ptr, Len, Lenw, Fmt, Pr].
+% Arithmetic over columns, in f64, printed with %g.
+plawk_records_field_lines(arith(F64Op, LPlan, RPlan), PrintIndex, FieldSep, Lines) :-
+    format(atom(B), 'rec_f~w', [PrintIndex]),
+    plawk_records_operand_lines(LPlan, B, l, FieldSep, LVar, LLines),
+    plawk_records_operand_lines(RPlan, B, r, FieldSep, RVar, RLines),
+    format(atom(OpL), '  %~w_res = ~w double ~w, ~w', [B, F64Op, LVar, RVar]),
+    format(atom(FmtL),
+        '  %~w_fmt = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_f64, i32 0, i32 0',
+        [B]),
+    format(atom(PrL),
+        '  %~w_pr = call i32 (i8*, ...) @printf(i8* %~w_fmt, double %~w_res)', [B, B, B]),
+    append([LLines, RLines, [OpL, FmtL, PrL]], Lines).
+
+% A row-arithmetic operand as a double: a column read as f64, or a constant.
+plawk_records_operand_lines(col(ColIndex), B, Slot, FieldSep, ValVar, [Line]) :-
+    format(atom(ValVar), '%~w_~w', [B, Slot]),
+    format(atom(Line),
+        '  ~w = call double @wam_atom_field_f64_value(%Value %rec_row_v, i64 ~w, i8 ~w)',
+        [ValVar, ColIndex, FieldSep]).
+plawk_records_operand_lines(aint(V), B, Slot, _FieldSep, ValVar, [Line]) :-
+    format(atom(ValVar), '%~w_~w', [B, Slot]),
+    format(atom(Line), '  ~w = sitofp i64 ~w to double', [ValVar, V]).
 
 %% plawk_multipass_pass_fn_ir(+Index, +RecordIR, -IR)
 %  One pass as a self-contained function: open the shared input path, loop

--- a/tests/test_plawk_records_reader.pl
+++ b/tests/test_plawk_records_reader.pl
@@ -79,6 +79,29 @@ test(records_unknown_column_unsupported, [condition(clang_available)]) :-
     cli([build, Prog, '-o', Bin], 3),
     !.
 
+% Arithmetic over a named column, evaluated in f64 and printed with %g:
+% `r["amount"] * 2` doubles the (last) amount per key. a=10,20 -> a's row
+% amount 20 -> 40; b=5 -> 10.
+test(records_column_arith, [condition(clang_available)]) :-
+    rdir(Dir),
+    Src = "BEGIN cache(\"$STORE\") { declare orders(cust str, amount i64) }\n\c
+           pass { orders[$1] = $0 }\n\c
+           pass records of orders as r { print r[\"cust\"], r[\"amount\"] * 2 }\n",
+    run_sorted(Dir, 'rar', Src, "a 10\nb 5\na 20\n", S),
+    assertion(S == ["a 40", "b 10"]),
+    !.
+
+% Fractional column arithmetic (the surface `/` is integer, so the print
+% expression is evaluated in f64): `r["amount"] / 4`.
+test(records_column_fraction, [condition(clang_available)]) :-
+    rdir(Dir),
+    Src = "BEGIN cache(\"$STORE\") { declare orders(cust str, amount i64) }\n\c
+           pass { orders[$1] = $0 }\n\c
+           pass records of orders as r { print r[\"cust\"], r[\"amount\"] / 4 }\n",
+    run_sorted(Dir, 'rfr', Src, "a 10\nb 6\n", S),
+    assertion(S == ["a 2.5", "b 1.5"]),
+    !.
+
 :- end_tests(plawk_records_reader).
 
 % --- helpers ---------------------------------------------------------------

--- a/tests/test_plawk_rows_reader.pl
+++ b/tests/test_plawk_rows_reader.pl
@@ -52,6 +52,15 @@ test(rows_single_col, [condition(clang_available)]) :-
     assertion(S == ["k1", "k2"]),
     !.
 
+% Arithmetic over positional columns, in f64: field2 / field3 per row.
+% Over "a 10 4" / "b 9 2": 10/4 = 2.5, 9/2 = 4.5.
+test(rows_column_arith, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t as r { print r[1], r[2] / r[3] }\n",
+    run_sorted(Dir, 'rca', Src, "a 10 4\nb 9 2\n", S),
+    assertion(S == ["a 2.5", "b 4.5"]),
+    !.
+
 :- end_tests(plawk_rows_reader).
 
 % --- helpers ---------------------------------------------------------------


### PR DESCRIPTION
Makes rows do real math, not just projection. A print field in either row reader can now be an arithmetic expression over columns and integer constants:

```awk
pass records of orders as r { print r["cust"], r["amount"] * 2 }
pass rows of t as r        { print r[1], r[2] / r[3] }
```

Over the amounts, `r["amount"] * 2` → doubles; `r[2] / r[3]` → `10/4 = 2.5`, `9/2 = 4.5`.

## Approach
Evaluated in **f64**, printed with `%g` — the surface `/` is integer, so a bare column ratio would truncate to 0. This reuses the same print-arithmetic path grand-total normalise uses: a column operand read via `@wam_atom_field_f64_value` on the decoded row `%Value`, an integer constant via `sitofp`, op ∈ add/sub/mul/div/mod.

## Changes
The row readers' per-field resolution generalises from a bare column index to a **field plan** — `col(Index)` (printed as text, unchanged) or `arith(F64Op, L, R)` over col/constant operands — for both the named (`records of`, schema-resolved) and positional (`rows of`) readers, sharing one emitter. A column operand in `records of` resolves through the schema; in `rows of` it's the literal position.

## Tests
`records_column_arith` / `records_column_fraction` (named, ×2 and /4), `rows_column_arith` (positional, col/col division). Regression green across records-reader, rows-reader, row-capture, over-table, multipass, normalise, perkey, multipass-cache.

## Row arc status
8.1 schema ✅ · 8.2 capture ✅ · 8.3 `records of` ✅ · 8.5 `rows of` ✅ · **column arithmetic ✅**. Remaining: 8.4 durable rows across runs (byte-valued cache storage), 8.6 richer producers (`row(...)`), `rows of` `unsafe`/rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_