### PR TITLE
WAM/LLVM plawk: `row(...)` constructor for shaping stored rows (phase 8.6)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -492,15 +492,15 @@ with a column operand read via `@wam_atom_field_f64_value` on the row.
 Tests: `tests/test_plawk_records_reader.pl`, `tests/test_plawk_rows_reader.pl`.
 
 **Write side.** How a pass *builds* a row touches multi-column value
-assembly and the commit path. The **first, minimal writer has LANDED**:
-`TABLE[$k] = $0` captures the whole current record as a row value (its bytes,
-interned to a stable id; replace semantics), keyed by field k. This is the
-natural "capture / index / dedup records by a key" producer and needs no new
-storage runtime — the row rides the existing str-value assoc mechanism (the
-i64 value is the row's atom id). A later pass reads it back (`over TABLE as
-k` today; `records of TABLE as r` once the named reader lands). A richer
-producer (`orders[$1] = row($1, $2)`, field-wise `orders[$1]["amount"] =
-$2`) remains a follow-on.
+assembly and the commit path. Two producers have **LANDED**, both riding the
+existing str-value assoc mechanism (the i64 value is the row's atom id), no
+new storage runtime: `TABLE[$k] = $0` captures the whole current record
+(the "capture / index / dedup by a key" case), and `TABLE[$k] = row($a, $b,
+…)` builds a row from chosen input fields, in that order (project / reorder),
+joined by the field separator so a reader recovers the columns. Both are
+replace semantics, keyed by field k. A later pass reads the row back (`over
+TABLE as k`, or `records of` / `rows of`). Field-wise writes
+(`orders[$1]["amount"] = $2`) remain a follow-on.
 
 **In-run vs durable — a limitation to note.** Because the stored value is an
 atom **id** (process-local), captured rows are correct **in-run** (multi-pass
@@ -527,6 +527,11 @@ non-i64 cache values" open question — deferred to its own runtime round.
    (`tests/test_plawk_rows_reader.pl`). Its `unsafe` modifier + inline
    check-or-rename spec remain a follow-on.
 6. **Richer row producers** — `row(...)` constructor / field-wise writes.
+   The `row($a, $b, …)` constructor is **LANDED**
+   (`tests/test_plawk_row_cons.pl`): `TABLE[$k] = row($a, $b, …)` stores a row
+   built from the chosen input fields, in that order (projected / reordered),
+   joined by the field separator so both readers recover the columns.
+   Field-wise writes (`r["col"] = …`) remain a follow-on.
 
 ## 4. Runtime: the cache ABI (the first build step)
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3887,6 +3887,7 @@ plawk_passes_tables(Passes, Tables) :-
 plawk_action_table_name(inc_assoc(var(Name), _Key), Name).
 plawk_action_table_name(add_assoc(var(Name), _Key, _Delta), Name).
 plawk_action_table_name(set_row(var(Name), _Key), Name).
+plawk_action_table_name(set_row_cons(var(Name), _Key, _Fields), Name).
 plawk_action_table_name(print(Fields), Name) :-
     member(assoc(var(Name), _Key), Fields).
 
@@ -4285,6 +4286,7 @@ plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays) :-
           ( member(dynassoc(A, str(_Call)), ActionSpecs)
           ; member(dynassoc(A, posarray_str(_Call)), ActionSpecs)
           ; member(assoc_set_row(A, _Key), ActionSpecs)   % row-valued (str)
+          ; member(assoc_set_row_cons(A, _Key2, _Fs), ActionSpecs)  % row (str)
           )
         ),
         As0),
@@ -5554,6 +5556,16 @@ plawk_assoc_add_delta_ok(int(V)) :- integer(V).
 plawk_assoc_body_action_spec(set_row(var(ArrayName), field(KeyIndex)),
         assoc_set_row(ArrayName, KeyIndex)) :-
     integer(KeyIndex), KeyIndex > 0.
+% Row constructor `arr[$k] = row($a, $b, ...)`: store a row built from the
+% chosen fields (in that order), joined by the field separator so a reader's
+% field projection recovers the columns. Like set_row, a str-value.
+plawk_assoc_body_action_spec(set_row_cons(var(ArrayName), field(KeyIndex), Fields),
+        assoc_set_row_cons(ArrayName, KeyIndex, Indexes)) :-
+    integer(KeyIndex), KeyIndex > 0,
+    Fields = [_ | _],
+    maplist(plawk_row_cons_field, Fields, Indexes).
+
+plawk_row_cons_field(field(N), N) :- integer(N), N > 0.
 plawk_assoc_body_action_spec(dynassoc_bind(var(ArrayName), Call),
         dynassoc(ArrayName, Call)) :-
     plawk_dynrec_call_ok(Call).
@@ -5841,6 +5853,13 @@ plawk_assoc_planned_actions([assoc_set_row(ArrayName, KeyIndex) | Rest],
       NextIndex is Index + 1
     },
     [assoc_set_row_action(Index, ArrayName, TableIndex, KeyIndex)],
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
+plawk_assoc_planned_actions([assoc_set_row_cons(ArrayName, KeyIndex, Fields) | Rest],
+        Tables, StrArrays, PosArrays, Index) -->
+    { nth0(TableIndex, Tables, ArrayName),
+      NextIndex is Index + 1
+    },
+    [assoc_set_row_cons_action(Index, ArrayName, TableIndex, KeyIndex, Fields)],
     plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
 plawk_assoc_planned_actions([dynassoc(ArrayName, Call) | Rest], Tables,
         StrArrays, PosArrays, Index) -->
@@ -6582,6 +6601,111 @@ plawk_assoc_rule_action_blocks(RuleIndex,
     },
     plawk_emit_lines(Lines),
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+% Row constructor `arr[$k] = row($a, $b, ...)`: same key-intern + missing-key
+% skip, then build the row as the chosen fields joined by the field separator
+% (so a reader's field projection recovers them), intern it, and store the id.
+% The join is a single snprintf with a compile-time format ("%.*s<sep>..."),
+% each field made null-safe (empty on a missing field), into a fixed buffer.
+plawk_assoc_rule_action_blocks(RuleIndex,
+        [assoc_set_row_cons_action(Index, _ArrayName, TableIndex, KeyIndex, Fields) | Rest],
+        NextLabel, FieldSeparator) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(HaveLabelName), 'assoc_rule_~w_action_~w_have_key', [RuleIndex, Index]),
+      format(atom(HaveLabel), 'assoc_rule_~w_action_~w_have_key:', [RuleIndex, Index]),
+      format(atom(B), 'assoc_rule_~w_action_~w', [RuleIndex, Index]),
+      format(atom(Slice),
+          '  %~w_key_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 ~w)',
+          [B, KeyIndex, FieldSeparator]),
+      format(atom(Ptr), '  %~w_key_ptr = extractvalue %WamSlice %~w_key_slice, 0', [B, B]),
+      format(atom(Len), '  %~w_key_len = extractvalue %WamSlice %~w_key_slice, 1', [B, B]),
+      format(atom(Missing), '  %~w_key_missing = icmp eq i8* %~w_key_ptr, null', [B, B]),
+      format(atom(Branch), '  br i1 %~w_key_missing, label %~w, label %~w',
+          [B, ActionNextLabel, HaveLabelName]),
+      format(atom(KeyId),
+          '  %~w_key_id = call i64 @wam_intern_atom(i8* %~w_key_ptr, i64 %~w_key_len)',
+          [B, B, B]),
+      % empty-atom fallback for a missing field, and the join format string.
+      format(atom(EmptyName), '~w_empty', [B]),
+      format(atom(EmptyGlobal),
+          '@.~w = private constant [1 x i8] zeroinitializer', [EmptyName]),
+      plawk_row_cons_format_atom(Fields, FieldSeparator, FmtAtom),
+      format(atom(FmtName), '~w_fmt', [B]),
+      llvm_emit_c_string_global(FmtName, FmtAtom, FmtGlobal, _FmtLen, _FmtBytes),
+      plawk_row_cons_field_lines(Fields, B, EmptyName, FieldSeparator, 0,
+          FieldLines, ArgFrags),
+      atomic_list_concat(ArgFrags, ', ', ArgsIR),
+      format(atom(BufA), '  %~w_buf = alloca [4096 x i8]', [B]),
+      format(atom(BufP),
+          '  %~w_bufp = getelementptr [4096 x i8], [4096 x i8]* %~w_buf, i64 0, i64 0',
+          [B, B]),
+      format(atom(FmtP),
+          '  %~w_fmtp = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0',
+          [B, _FmtBytes, _FmtBytes, FmtName]),
+      format(atom(Snp),
+          '  %~w_wrote = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %~w_bufp, i64 4096, i8* %~w_fmtp, ~w)',
+          [B, B, B, ArgsIR]),
+      format(atom(RowLen), '  %~w_row_len = call i64 @strlen(i8* %~w_bufp)', [B, B]),
+      format(atom(RowId),
+          '  %~w_row_id = call i64 @wam_intern_atom(i8* %~w_bufp, i64 %~w_row_len)',
+          [B, B, B]),
+      format(atom(Set),
+          '  %~w_setrc = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %~w_key_id, i64 %~w_row_id)',
+          [B, TableIndex, B, B]),
+      format(atom(Next), '  br label %~w', [ActionNextLabel]),
+      append([[global(EmptyGlobal), global(FmtGlobal), Label, Slice, Ptr, Len,
+               Missing, Branch, '', HaveLabel, KeyId],
+              FieldLines,
+              [BufA, BufP, FmtP, Snp, RowLen, RowId, Set, Next, '']], Lines)
+    },
+    plawk_emit_lines(Lines),
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+
+%% plawk_row_cons_format_atom(+Indexes, +FieldSep, -FmtAtom)
+%  The snprintf format joining N fields: "%.*s" per field, the field
+%  separator byte between, so a reader splitting on that separator recovers
+%  the columns.
+plawk_row_cons_format_atom(Indexes, FieldSep, FmtAtom) :-
+    length(Indexes, N),
+    length(Slots, N),
+    maplist(=('%.*s'), Slots),
+    atom_codes(SepAtom, [FieldSep]),
+    atomic_list_concat(Slots, SepAtom, FmtAtom).
+
+%% plawk_row_cons_field_lines(+Indexes, +Base, +EmptyName, +FieldSep, +Pos,
+%%     -Lines, -ArgFrags)
+%  Per constructor field: project field N of the current record, null-safe
+%  (empty on a missing field), yielding an `i32 <len>, i8* <ptr>` snprintf
+%  argument pair for the `%.*s` slot.
+plawk_row_cons_field_lines([], _B, _Empty, _FieldSep, _Pos, [], []).
+plawk_row_cons_field_lines([N | Rest], B, EmptyName, FieldSep, Pos,
+        Lines, [Frag | Frags]) :-
+    format(atom(Slice),
+        '  %~w_c~w_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 ~w)',
+        [B, Pos, N, FieldSep]),
+    format(atom(Ptr), '  %~w_c~w_ptr = extractvalue %WamSlice %~w_c~w_slice, 0',
+        [B, Pos, B, Pos]),
+    format(atom(Len), '  %~w_c~w_len = extractvalue %WamSlice %~w_c~w_slice, 1',
+        [B, Pos, B, Pos]),
+    format(atom(Null), '  %~w_c~w_null = icmp eq i8* %~w_c~w_ptr, null',
+        [B, Pos, B, Pos]),
+    format(atom(SafePtr),
+        '  %~w_c~w_sptr = select i1 %~w_c~w_null, i8* getelementptr ([1 x i8], [1 x i8]* @.~w, i64 0, i64 0), i8* %~w_c~w_ptr',
+        [B, Pos, B, Pos, EmptyName, B, Pos]),
+    format(atom(SafeLen), '  %~w_c~w_slen = select i1 %~w_c~w_null, i64 0, i64 %~w_c~w_len',
+        [B, Pos, B, Pos, B, Pos]),
+    format(atom(Lenw), '  %~w_c~w_lenw = trunc i64 %~w_c~w_slen to i32',
+        [B, Pos, B, Pos]),
+    format(atom(Frag), 'i32 %~w_c~w_lenw, i8* %~w_c~w_sptr', [B, Pos, B, Pos]),
+    ThisLines = [Slice, Ptr, Len, Null, SafePtr, SafeLen, Lenw],
+    Pos1 is Pos + 1,
+    plawk_row_cons_field_lines(Rest, B, EmptyName, FieldSep, Pos1, RestLines, Frags),
+    append(ThisLines, RestLines, Lines).
 
 %% plawk_record_program_ok(+Descriptor, +Rules, +EndPrintFields) is semidet.
 %

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1534,26 +1534,39 @@ assoc_add_delta(int(Value)) -->
       number_codes(Value, ValueCodes)
     }.
 
-% Row capture (PLAWK_MULTIPASS_CACHE.md §3.6): `TABLE[$k] = $0` stores the
-% whole current record ($0) as a row value in TABLE, keyed by field k -- the
-% first, minimal producer of row-valued tables. The row is a str-value (the
-% record's bytes); a later pass reads it back (`over TABLE`, and, with a
-% schema, `records of TABLE as r`). v1 stores $0 only (a `row(...)`
-% constructor is a follow-on). Tried before the scalar `set` -- the `[`
-% distinguishes them.
-assignment_action(set_row(var(Name), KeyExpr)) -->
+% Row store (PLAWK_MULTIPASS_CACHE.md §3.6): `TABLE[$k] = RHS` stores a row
+% value in TABLE, keyed by field k. RHS is either `$0` (capture the whole
+% current record -- set_row/2) or `row($a, $b, ...)` (construct a row from
+% chosen fields, in that order -- set_row_cons/3), the producer of row-valued
+% tables. A later pass reads it back (`over TABLE`, and, with a schema,
+% `records of TABLE as r`). Tried before the scalar `set` -- the `[`
+% distinguishes them; the `!` commits once `TABLE[key] =` is seen.
+assignment_action(Action) -->
     identifier(Name),
-    ws,
-    "[",
-    ws,
-    assoc_key_expr(KeyExpr),
-    ws,
-    "]",
+    ws, "[", ws, assoc_key_expr(KeyExpr), ws, "]", ws, "=", ws,
     !,
-    ws,
-    "=",
-    ws,
-    "$0".
+    assoc_row_rhs(var(Name), KeyExpr, Action).
+
+assoc_row_rhs(VarName, KeyExpr, set_row(VarName, KeyExpr)) -->
+    "$0",
+    !.
+assoc_row_rhs(VarName, KeyExpr, set_row_cons(VarName, KeyExpr, Fields)) -->
+    "row", ws, "(", ws, row_field_list(Fields), ws, ")".
+
+% Row constructor fields: one or more `$N` field references.
+row_field_list([F | Fs]) -->
+    row_field(F),
+    row_field_list_rest(Fs).
+row_field_list_rest([F | Fs]) -->
+    ws, ",", ws, row_field(F),
+    !,
+    row_field_list_rest(Fs).
+row_field_list_rest([]) --> [].
+row_field(field(Index)) -->
+    "$",
+    integer_codes(Codes),
+    { Codes \== [], number_codes(Index, Codes), Index >= 0 }.
+
 assignment_action(set(var(Name), Value)) -->
     identifier(Name),
     ws,

--- a/tests/test_plawk_row_cons.pl
+++ b/tests/test_plawk_row_cons.pl
@@ -1,0 +1,105 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk row-oriented records (PLAWK_MULTIPASS_CACHE.md §3.6, phase 8.6): the
+% ROW CONSTRUCTOR. `TABLE[$k] = row($a, $b, ...)` stores a row built from the
+% CHOSEN fields, in that order -- so a writer can project / reorder the input
+% columns into a stored row rather than only capturing the whole record
+% (`= $0`). The row is the fields joined by the field separator, so a reader's
+% field projection recovers them: `records of` by schema name, `rows of` by
+% position. Str-value storage, in-run (like `= $0`).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_row_cons).
+
+% `TABLE[$k] = row($a, $b)` parses to set_row_cons/3 with the chosen fields;
+% `= $0` still parses to set_row/2.
+test(row_cons_parses) :-
+    plawk_parse_string(
+        "pass { t[$1] = row($3, $2) }\npass rows of t as r { print r[1], r[2] }\n",
+        program_passes([],
+            [pass([rule(always,
+                 [set_row_cons(var(t), field(1), [field(3), field(2)])])]),
+             pass_rows(var(r), var(t),
+                 [print([assoc(var(r), int(1)), assoc(var(r), int(2))])])],
+            [])),
+    plawk_parse_string("pass { t[$1] = $0 }\npass rows of t as r { print r[1] }\n",
+        program_passes([],
+            [pass([rule(always, [set_row(var(t), field(1))])]) | _], [])),
+    !.
+
+% row($3, $2) reorders: field 3 then field 2 become the stored row's columns
+% 1 and 2. Read positionally with `rows of`. Over "k1 100 alice" ->
+% row is "alice 100" -> r[1]=alice, r[2]=100.
+test(row_cons_reorder_positional, [condition(clang_available)]) :-
+    cdir(Dir),
+    Src = "pass { t[$1] = row($3, $2) }\npass rows of t as r { print r[1], r[2] }\n",
+    run_sorted(Dir, 'rcp', Src, "k1 100 alice\nk2 250 bob\n", S),
+    assertion(S == ["alice 100", "bob 250"]),
+    !.
+
+% The same constructed row read by NAME through a schema (cust=col1, amt=col2).
+test(row_cons_named_read, [condition(clang_available)]) :-
+    cdir(Dir),
+    Src = "BEGIN cache(\"$STORE\") { declare rev(name str, amt str) }\n\c
+           pass { rev[$1] = row($3, $2) }\n\c
+           pass records of rev as r { print r[\"name\"], r[\"amt\"] }\n",
+    run_sorted(Dir, 'rcn', Src, "k1 100 alice\nk2 250 bob\n", S),
+    assertion(S == ["alice 100", "bob 250"]),
+    !.
+
+% A subset / single field: row($2) keeps just field 2.
+test(row_cons_subset, [condition(clang_available)]) :-
+    cdir(Dir),
+    Src = "pass { t[$1] = row($2) }\npass rows of t as r { print r[1] }\n",
+    run_sorted(Dir, 'rcs', Src, "a x y\nb p q\n", S),
+    assertion(S == ["p", "x"]),
+    !.
+
+:- end_tests(plawk_row_cons).
+
+% --- helpers ---------------------------------------------------------------
+
+cdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_row_cons', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+replace_store(Src, Store, Out) :-
+    split_string(Src, "", "", [S0]),
+    atomic_list_concat(Parts, "$STORE", S0),
+    atomic_list_concat(Parts, Store, Out).
+
+run_sorted(Dir, Name, Src0, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    replace_store(Src0, Store, Src),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
A second row producer alongside `TABLE[$k] = $0`. `TABLE[$k] = row($a, $b, …)` stores a row built from the **chosen** input fields, in that order — so a writer can project / reorder columns into a stored row instead of only capturing the whole record:

```awk
pass { rev[$1] = row($3, $2) }                          # field 3, then field 2
pass records of rev as r { print r["name"], r["amt"] }
```

Over `k1 100 alice` the stored row is `alice 100`, read back `name=alice, amt=100` (or positionally via `rows of`).

## Approach
The row is the chosen fields joined by the field separator (so a reader's field projection recovers them), assembled with a single `snprintf` over a **compile-time** format (`"%.*s<sep>…"`, arity + separator known), each field null-safe (empty on a missing field), interned, and stored via `@wam_assoc_i64_set` — the same str-value storage as `= $0`, **no new runtime**.

## Changes
- **Parser**: the assoc-assign RHS now accepts `$0` (`set_row/2`, unchanged) or `row($a, …)` (`set_row_cons/3`); the `!` commits once `TABLE[key] =` is seen, then the RHS alternates. Scalar `NAME = expr` unchanged.
- **Codegen**: `set_row_cons` spec / planned action / emitter, table discovery, and str-array marking, mirroring `set_row`.

## Tests
`tests/test_plawk_row_cons.pl` — parse (both RHS forms), reorder read positionally and by schema name, single-field subset. Regression green across row-capture, records-reader, rows-reader, over-table, multipass, multipass-cache, passes, perkey, normalise, row-schema.

## Scope
In-run (str-value storage), like the other row producers. Field-wise writes (`r["col"] = …`) remain a follow-on; the snprintf join uses a fixed 4096-byte buffer (documented; a size-aware join is a follow-on for very wide rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_