### PR TITLE
WAM/LLVM plawk: durable rows across runs via byte-valued cache (phase 8.4)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -33,11 +33,14 @@ pass's record source (named fields — key bound to `VAR`, value via
 (phase 8, §3.6): a table whose value is a named-field **row** — captured with
 `TABLE[$k] = $0` and read back by column name with `records of TABLE as r`
 (`r["col"]`, resolved through the `declare TABLE(col type, …)` schema), or by
-position with `rows of TABLE as r` (`r[N]`, no schema), in-run.
-**Not yet:** durable rows across runs (byte-valued cache storage, phase 8.4);
-`rows of`'s `unsafe` / inline check-or-rename spec; the `over prev` reader
-(phase 4 follow-on); the query reader (phase 6); namespaces / `eager` /
-secondary indexes; string-literal print fields. See the per-phase status tags
+position with `rows of TABLE as r` (`r[N]`, no schema); a column may be an
+arithmetic expression (`r["amt"] / 2`, f64); the row is written with
+`TABLE[$k] = $0` or `TABLE[$k] = row($a, $b)`; and rows are **durable across
+runs** on the file backend (the row bytes are persisted, phase 8.4).
+**Not yet:** durable rows over the LMDB backend; `rows of`'s `unsafe` /
+inline check-or-rename spec; the `over prev` reader (phase 4 follow-on); the
+query reader (phase 6); namespaces / `eager` / secondary indexes;
+string-literal print fields. See the per-phase status tags
 in §5.
 
 ## Implemented surface (quick reference)
@@ -502,13 +505,16 @@ replace semantics, keyed by field k. A later pass reads the row back (`over
 TABLE as k`, or `records of` / `rows of`). Field-wise writes
 (`orders[$1]["amount"] = $2`) remain a follow-on.
 
-**In-run vs durable — a limitation to note.** Because the stored value is an
-atom **id** (process-local), captured rows are correct **in-run** (multi-pass
-within one process, the primary use). They do **not** survive across separate
-runs of the binary: the current cache format persists `[key:i64 value:i64]`,
-so a committed row id is stale on reload. **Durable rows need a byte-valued
-cache format** (store the row's bytes, not the id) — the "value encoding for
-non-i64 cache values" open question — deferred to its own runtime round.
+**In-run and durable.** A row value is an atom **id** (process-local), so the
+plain i64 cache — which persists the id — cannot restore a row in a fresh
+process. On the **file** backend a str-valued (row) table therefore commits
+the value **bytes** (`@wam_cache_commit_str`) and re-interns them on load
+(`@wam_cache_load_str`), so rows are **durable across runs** (phase 8.4,
+`tests/test_plawk_row_durable.pl`): a reader pass in a later run sees rows a
+prior run committed. Keys stay i64 ids (content-stable interning reproduces
+them; readers only iterate, and a re-writing pass re-interns the same key).
+Durable str values over the **LMDB** backend remain a follow-on (an lmdb row
+table currently rides the i64 lmdb path, i.e. in-run only).
 
 **Phasing** (each its own PR):
 1. **Schema surface** — `declare NAME(col type, …)` parses and carries a row
@@ -522,7 +528,14 @@ non-i64 cache values" open question — deferred to its own runtime round.
    that field of the stored row; an unknown column is unsupported (clean
    compile-time failure). In-run (rides the row-capture writer's storage).
 4. **Byte-valued cache storage** — durable rows across runs (store row bytes,
-   not the id).
+   not the id). **LANDED (file backend)** (`tests/test_plawk_row_durable.pl`):
+   a str-valued (row) table on the file backend commits the value BYTES
+   (`@wam_cache_commit_str`) and re-interns them on load
+   (`@wam_cache_load_str`), so a row committed by one run is read by a later
+   run — proven with a reader-pass-then-writer program run twice. Keys stay
+   i64 ids (content-stable interning reproduces them). Durable str values over
+   the **LMDB** backend remain a follow-on (an lmdb row table currently rides
+   the i64 lmdb path).
 5. **`rows of` positional reader** — `r[N]` by position, no schema. **LANDED**
    (`tests/test_plawk_rows_reader.pl`). Its `unsafe` modifier + inline
    check-or-rename spec remain a follow-on.
@@ -709,7 +722,9 @@ single-pass test before any driver surgery).
   TABLE` — **LANDED** (`tests/test_plawk_row_capture.pl`); (8.3) the safe
   `records of TABLE as r` reader with name-only `r["col"]` decode by schema —
   **LANDED** (`tests/test_plawk_records_reader.pl`); (8.4) byte-valued cache
-  storage for durable rows across runs; (8.5) the positional `rows of`
+  storage for durable rows across runs — **LANDED (file backend)**
+  (`tests/test_plawk_row_durable.pl`; LMDB durable rows are a follow-on);
+  (8.5) the positional `rows of`
   reader (`r[N]`, no schema) — **LANDED**
   (`tests/test_plawk_rows_reader.pl`; its `unsafe` / inline check-or-rename
   spec remain a follow-on); (8.6) richer row producers (`row(...)` /

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -724,7 +724,7 @@ plawk_program_native_driver_ir(
     plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions, AssocPlan, PrintFields),
     AssocPlan = assoc_plan(Tables, _),
     plawk_program_cache_tables(BeginClauses, CacheNamePaths),
-    plawk_cache_entries(Tables, CacheNamePaths, CacheEntries, CachePathGlobals),
+    plawk_cache_entries(Tables, [], CacheNamePaths, CacheEntries, CachePathGlobals),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
@@ -3703,7 +3703,10 @@ plawk_program_multipass_driver_ir(
     % load the store into the shared table before pass 1, commit it after the
     % last pass. Non-cache programs get [] and behave exactly as before.
     plawk_program_cache_tables(BeginClauses, CacheTriples),
-    plawk_cache_entries([ArrayName], CacheTriples, CacheEntries, CachePathGlobals),
+    maplist(plawk_assoc_rule_action_specs, AllRules, AllRuleSpecs),
+    plawk_assoc_specs_str_arrays(AllRuleSpecs, StrArrays),
+    plawk_cache_entries([ArrayName], StrArrays, CacheTriples, CacheEntries,
+        CachePathGlobals),
     % Per-pass RecordIR (rule chain) against the single shared table.
     findall(GlobalIR-ChainIR,
         ( member(pass(PassRules), Passes),
@@ -3803,7 +3806,8 @@ plawk_program_multipass_driver_ir(
     % A `BEGIN cache(...)`-declared shared table: load before pass 1, commit
     % after the last pass. Empty for pure-scalar / non-cache programs.
     plawk_program_cache_tables(BeginClauses, CacheTriples),
-    plawk_cache_entries(Tables, CacheTriples, CacheEntries, CachePathGlobals),
+    plawk_cache_entries(Tables, StrArrays, CacheTriples, CacheEntries,
+        CachePathGlobals),
     plawk_output_separator(BeginClauses, OutputSeparator),
     % One function per pass, in order -- dispatching on the pass shape:
     % an input-scanning `pass { }` or a table-iterating `pass over T as V`.
@@ -5947,8 +5951,8 @@ plawk_assoc_entry_setup_lines([_ArrayName | Rest], Index, CacheEntries) -->
     { format(atom(NewLine),
           '  %plawk_assoc_table_~w = call %WamAssocI64Table* @wam_assoc_i64_new(i64 4096)',
           [Index]),
-      ( memberchk(cache(Index, BytesLen, Backend), CacheEntries)
-      ->  plawk_cache_fn(Backend, load, LoadFn),
+      ( memberchk(cache(Index, BytesLen, Backend, ValueKind), CacheEntries)
+      ->  plawk_cache_fn(Backend, load, ValueKind, LoadFn),
           format(atom(LoadLine),
               '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
               [LoadFn, Index, BytesLen, BytesLen, Index]),
@@ -5970,15 +5974,19 @@ plawk_program_cache_tables(BeginClauses, Triples) :-
         ),
         Triples).
 
-%% plawk_cache_fn(+Backend, +Op, -FnName)
-%  The runtime function for a cache Op (load|commit) under a backend. The
-%  `file` backend uses the always-present LLVM-IR helpers; `lmdb` uses the
-%  external C functions linked from wam_cache_lmdb.c (+ -llmdb) when the
-%  build detects an lmdb-backed store.
-plawk_cache_fn(lmdb, load, wam_cache_load_lmdb) :- !.
-plawk_cache_fn(lmdb, commit, wam_cache_commit_lmdb) :- !.
-plawk_cache_fn(_File, load, wam_cache_load).
-plawk_cache_fn(_File, commit, wam_cache_commit).
+%% plawk_cache_fn(+Backend, +Op, +ValueKind, -FnName)
+%  The runtime function for a cache Op (load|commit) under a backend and value
+%  kind. A str-valued (row) table on the `file` backend uses the byte-valued
+%  helpers so the row bytes survive across runs (an i64 store would persist a
+%  process-local atom id). i64 tables use the plain file helpers. `lmdb` uses
+%  the external C functions (durable str values over lmdb are a follow-on, so
+%  an lmdb str table currently rides the i64 lmdb path).
+plawk_cache_fn(file, load, str, wam_cache_load_str) :- !.
+plawk_cache_fn(file, commit, str, wam_cache_commit_str) :- !.
+plawk_cache_fn(lmdb, load, _Kind, wam_cache_load_lmdb) :- !.
+plawk_cache_fn(lmdb, commit, _Kind, wam_cache_commit_lmdb) :- !.
+plawk_cache_fn(_File, load, _Kind, wam_cache_load).
+plawk_cache_fn(_File, commit, _Kind, wam_cache_commit).
 
 %% plawk_cache_entries(+Tables, +Triples, -CacheEntries, -PathGlobalsIR)
 %  Resolve each cache-backed table name to its index in the plan's table
@@ -5987,16 +5995,17 @@ plawk_cache_fn(_File, commit, wam_cache_commit).
 %  the global and pick the backend function. A declared name absent from the
 %  plan (never used) is skipped. PathGlobalsIR also carries external declares
 %  for any lmdb backend functions in use.
-plawk_cache_entries(Tables, Triples, CacheEntries, PathGlobalsIR) :-
-    findall(cache(Index, BytesLen, Backend)-Global,
+plawk_cache_entries(Tables, StrArrays, Triples, CacheEntries, PathGlobalsIR) :-
+    findall(cache(Index, BytesLen, Backend, ValueKind)-Global,
         ( member(ct(Name, Path, Backend), Triples),
           nth0(Index, Tables, Name),
+          ( memberchk(Name, StrArrays) -> ValueKind = str ; ValueKind = i64 ),
           format(atom(GName), 'plawk_cache_path_~w', [Index]),
           llvm_emit_c_string_global(GName, Path, Global, _Len, BytesLen)
         ),
         Pairs),
     pairs_keys_values(Pairs, CacheEntries, Globals),
-    ( memberchk(cache(_, _, lmdb), CacheEntries)
+    ( memberchk(cache(_, _, lmdb, _), CacheEntries)
     ->  LmdbDecls = ['declare void @wam_cache_load_lmdb(%WamAssocI64Table*, i8*)',
                      'declare void @wam_cache_commit_lmdb(%WamAssocI64Table*, i8*)']
     ;   LmdbDecls = []
@@ -6010,8 +6019,8 @@ plawk_cache_entries(Tables, Triples, CacheEntries, PathGlobalsIR) :-
 %  still live), so the committed state is the completed pass.
 plawk_cache_commit_lines(CacheEntries, IR) :-
     findall(Line,
-        ( member(cache(Index, BytesLen, Backend), CacheEntries),
-          plawk_cache_fn(Backend, commit, CommitFn),
+        ( member(cache(Index, BytesLen, Backend, ValueKind), CacheEntries),
+          plawk_cache_fn(Backend, commit, ValueKind, CommitFn),
           format(atom(Line),
               '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
               [CommitFn, Index, BytesLen, BytesLen, Index])

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -5027,6 +5027,119 @@ entry:
   ret void
 }
 
+; ---- byte-valued cache for STRING (row) values ---------------------------
+; A str-valued table stores an atom-registry id as its i64 value -- that id is
+; process-local, so the plain i64 cache (which stores the id) does not survive
+; across runs. The str variant stores the VALUE BYTES instead: commit resolves
+; each value id to its bytes and writes [count][key:i64 vallen:i64
+; valbytes...]; load reads the bytes and re-interns them to a fresh (valid
+; this-process) id. Keys stay i64 ids (content-stable interning reproduces
+; them; row readers only iterate, and a re-writing pass re-interns the same
+; key). internal linkage, so this is dead-code eliminated unless a str-valued
+; store is used.
+define internal void @wam_cache_commit_str(%WamAssocI64Table* %table, i8* %path) {
+entry:
+  %cbuf = alloca i64
+  %hbuf = alloca [2 x i64]
+  %fd = call i32 @open(i8* %path, i32 577, i32 420)
+  %fd_ok = icmp sge i32 %fd, 0
+  br i1 %fd_ok, label %ccs.writecount, label %ccs.done
+
+ccs.writecount:
+  %count_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 0
+  %count = load i64, i64* %count_slot
+  store i64 %count, i64* %cbuf
+  %cbuf_i8 = bitcast i64* %cbuf to i8*
+  %cw = call i64 @write(i32 %fd, i8* %cbuf_i8, i64 8)
+  br label %ccs.loop
+
+ccs.loop:
+  %cur = phi i64 [ 0, %ccs.writecount ], [ %cur.next, %ccs.wrote ]
+  %slot = call i64 @wam_assoc_i64_iter_next(%WamAssocI64Table* %table, i64 %cur)
+  %slot.done = icmp slt i64 %slot, 0
+  br i1 %slot.done, label %ccs.close, label %ccs.emit
+
+ccs.emit:
+  %k = call i64 @wam_assoc_i64_key_at(%WamAssocI64Table* %table, i64 %slot)
+  %v = call i64 @wam_assoc_i64_value_at(%WamAssocI64Table* %table, i64 %slot)
+  %vptr = call i8* @wam_atom_to_string(i64 %v)
+  %vlen = call i64 @strlen(i8* %vptr)
+  %kp = getelementptr [2 x i64], [2 x i64]* %hbuf, i64 0, i64 0
+  store i64 %k, i64* %kp
+  %lp = getelementptr [2 x i64], [2 x i64]* %hbuf, i64 0, i64 1
+  store i64 %vlen, i64* %lp
+  %hbuf_i8 = bitcast [2 x i64]* %hbuf to i8*
+  %hw = call i64 @write(i32 %fd, i8* %hbuf_i8, i64 16)
+  %bw = call i64 @write(i32 %fd, i8* %vptr, i64 %vlen)
+  br label %ccs.wrote
+
+ccs.wrote:
+  %cur.next = add i64 %slot, 1
+  br label %ccs.loop
+
+ccs.close:
+  %crc = call i32 @close(i32 %fd)
+  br label %ccs.done
+
+ccs.done:
+  ret void
+}
+
+define internal void @wam_cache_load_str(%WamAssocI64Table* %table, i8* %path) {
+entry:
+  %cbuf = alloca i64
+  %hbuf = alloca [2 x i64]
+  %fd = call i32 @open(i8* %path, i32 0, i32 0)
+  %fd_ok = icmp sge i32 %fd, 0
+  br i1 %fd_ok, label %cls.readcount, label %cls.done
+
+cls.readcount:
+  %cbuf_i8 = bitcast i64* %cbuf to i8*
+  %cn = call i64 @read(i32 %fd, i8* %cbuf_i8, i64 8)
+  %cn_ok = icmp eq i64 %cn, 8
+  br i1 %cn_ok, label %cls.loop, label %cls.close
+
+cls.loop:
+  %i = phi i64 [ 0, %cls.readcount ], [ %i.next, %cls.store ]
+  %count = load i64, i64* %cbuf
+  %i.done = icmp uge i64 %i, %count
+  br i1 %i.done, label %cls.close, label %cls.readhdr
+
+cls.readhdr:
+  %hbuf_i8 = bitcast [2 x i64]* %hbuf to i8*
+  %hn = call i64 @read(i32 %fd, i8* %hbuf_i8, i64 16)
+  %hn_ok = icmp eq i64 %hn, 16
+  br i1 %hn_ok, label %cls.readbytes, label %cls.close
+
+cls.readbytes:
+  %kp = getelementptr [2 x i64], [2 x i64]* %hbuf, i64 0, i64 0
+  %k = load i64, i64* %kp
+  %lp = getelementptr [2 x i64], [2 x i64]* %hbuf, i64 0, i64 1
+  %vlen = load i64, i64* %lp
+  %vbuf = call i8* @malloc(i64 %vlen)
+  %rn = call i64 @read(i32 %fd, i8* %vbuf, i64 %vlen)
+  %rn_ok = icmp eq i64 %rn, %vlen
+  br i1 %rn_ok, label %cls.store, label %cls.freeclose
+
+cls.store:
+  %vid = call i64 @wam_intern_atom(i8* %vbuf, i64 %vlen)
+  call void @free(i8* %vbuf)
+  %setrc = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %k, i64 %vid)
+  %i.next = add i64 %i, 1
+  br label %cls.loop
+
+cls.freeclose:
+  call void @free(i8* %vbuf)
+  br label %cls.close
+
+cls.close:
+  %crc = call i32 @close(i32 %fd)
+  br label %cls.done
+
+cls.done:
+  ret void
+}
+
 ; POSIX ERE matching over atom-backed text records. Patterns are
 ; compile-time constants; each match site owns a cache slot holding a
 ; lazily regcomp()ed regex_t. The regex_t is malloc''d at 512 bytes,

--- a/tests/test_plawk_row_durable.pl
+++ b/tests/test_plawk_row_durable.pl
@@ -1,0 +1,91 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk row-oriented records (PLAWK_MULTIPASS_CACHE.md §3.6, phase 8.4):
+% DURABLE ROWS across runs. A row value is an atom-registry id, which is
+% process-local -- the plain i64 cache (which persists the id) cannot restore
+% a row in a fresh process. The byte-valued cache variant persists the row
+% BYTES for a str-valued (row) table: commit resolves each value id to its
+% bytes; load re-interns them to a valid this-process id. So a row committed
+% by one run is readable by a later run.
+%
+% Tested with a reader-pass-then-writer-pass program run twice: run 1's store
+% is empty (reader prints nothing), the writer populates + commits; run 2's
+% reader sees the rows run 1 committed -- which only works if the row bytes,
+% not the (stale) id, were persisted.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_row_durable).
+
+% Reader pass first (reads the committed store), writer pass second
+% (repopulates from input). Run 1: empty store -> reader silent; writer
+% writes x/y. Run 2: reader sees the durable rows from run 1.
+test(rows_persist_across_runs, [condition(clang_available)]) :-
+    ddir(Dir),
+    directory_file_path(Dir, 'dur.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare t(a str, b str) }\n\c
+         pass records of t as r { print r[\"a\"], r[\"b\"] }\n\c
+         pass { t[$1] = row($1, $2) }\n", [Store]),
+    build(Dir, 'dur', Src, Bin, In, "x 10\ny 20\n"),
+    run_sorted(Bin, In, S1),
+    assertion(S1 == []),                        % run 1: store was empty
+    run_sorted(Bin, In, S2),
+    assertion(S2 == ["x 10", "y 20"]),          % run 2: durable rows restored
+    !.
+
+% Positional durability: the row bytes survive, read back with `rows of`.
+test(rows_persist_positional, [condition(clang_available)]) :-
+    ddir(Dir),
+    directory_file_path(Dir, 'durp.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare t(a str, b str) }\n\c
+         pass rows of t as r { print r[1], r[2] }\n\c
+         pass { t[$1] = $0 }\n", [Store]),
+    build(Dir, 'durp', Src, Bin, In, "p 1\nq 2\n"),
+    run_sorted(Bin, In, S1), assertion(S1 == []),
+    run_sorted(Bin, In, S2), assertion(S2 == ["p 1", "q 2"]),
+    !.
+
+:- end_tests(plawk_row_durable).
+
+% --- helpers ---------------------------------------------------------------
+
+ddir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_row_durable', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+run_sorted(Bin, In, Sorted) :-
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
Makes row-valued tables **persist across separate runs** — the cross-run/persistent database the row work has been building toward.

A row value is an atom-registry id (process-local), so the plain i64 cache — which persists the id — restores garbage in a fresh process. On the **file** backend a str-valued (row) table now commits the value **bytes** and re-interns them on load:

```awk
BEGIN cache("t.db") { declare t(a str, b str) }
pass records of t as r { print r["a"], r["b"] }   # reads the committed store
pass { t[$1] = row($1, $2) }                        # (re)populates + commits
```

Run 1's store is empty (reader silent), the writer commits; **run 2's reader prints the rows run 1 committed** — durable.

## Changes
- **Runtime** (`wam_llvm_target.pl`): new internal `@wam_cache_commit_str` / `@wam_cache_load_str`. Commit writes `[count][key:i64 vallen:i64 valbytes…]`, resolving each value id to its bytes (`@wam_atom_to_string`); load reads the bytes and re-interns them (`@wam_intern_atom`) to a valid this-process id. Keys stay i64 ids (content-stable interning reproduces them; readers only iterate, and a re-writing pass re-interns the same key). `internal` linkage → DCE'd unless a str store is used.
- **Codegen**: cache entries now carry a value kind (`str` for tables in the program's `StrArrays` set, else `i64`); `plawk_cache_fn` picks the byte-valued file helpers for str tables and the plain helpers otherwise. Threaded through both multi-pass driver clauses; the single-pass histogram path passes `[]` → `i64`, unchanged.

## Tests
`tests/test_plawk_row_durable.pl` — rows persist across runs, read back named (`records of`) and positionally (`rows of`). Regression green across multipass-cache, cache-surface, cache-lmdb, cache-runtime, records-reader, rows-reader, row-capture, row-cons, multipass.

## Scope
File backend only. Durable str values over the **LMDB** backend remain a follow-on (an lmdb row table currently rides the i64 lmdb path, i.e. in-run only).

## Row arc
8.1 schema ✅ · 8.2 `= $0` ✅ · 8.3 `records of` ✅ · 8.5 `rows of` ✅ · col arithmetic ✅ · 8.6 `row(...)` ✅ · **8.4 durable rows (file) ✅**. The in-run row model is now durable — a persistent, named-column, cross-run key/row store. Remaining: LMDB-durable rows, `rows of` `unsafe`/rename, field-wise writes, reader guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_