### PR TITLE
Add Rust WAM numbervars/3 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1631,6 +1631,42 @@ compile_execute_term_builtin_to_rust(Code) :-
                 if self.unify(&output, &variables) { self.pc += 1; true }
                 else { false }
             }
+            "numbervars/3" => {
+                let start = match self.get_reg_raw("A2")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::Integer(n)) => n,
+                    _ => return false,
+                };
+                let term = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+                let variables = match self.variables_from_term(&term) {
+                    Value::List(items) => items,
+                    _ => return false,
+                };
+                let mark = self.trail.len();
+                let mut next_number = start;
+                for variable in variables {
+                    let following = match next_number.checked_add(1) {
+                        Some(n) => n,
+                        None => { self.unwind_trail_to(mark); return false; }
+                    };
+                    let numbered = Value::Str(
+                        "$VAR/1".to_string(),
+                        vec![Value::Integer(next_number)],
+                    );
+                    if !self.unify(&variable, &numbered) {
+                        self.unwind_trail_to(mark);
+                        return false;
+                    }
+                    next_number = following;
+                }
+                let output = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+                if self.unify(&output, &Value::Integer(next_number)) {
+                    self.pc += 1; true
+                } else {
+                    self.unwind_trail_to(mark);
+                    false
+                }
+            }
             _ => false,
         }
     }

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -649,6 +649,49 @@ fn test_term_variables_direct() {
 }
 
 #[test]
+fn test_numbervars_direct() {
+    let term = Value::Str(
+        "outer/3".to_string(),
+        vec![
+            ub("X"),
+            Value::Str("inner/2".to_string(), vec![ub("Y"), ub("X")]),
+            ub("Z"),
+        ],
+    );
+    let (ok, vm) = call3("numbervars/3", term, i(3), ub("End"));
+    assert!(ok);
+    assert_eq!(read_var(&vm, "X"), Value::Str("$VAR".to_string(), vec![i(3)]));
+    assert_eq!(read_var(&vm, "Y"), Value::Str("$VAR".to_string(), vec![i(4)]));
+    assert_eq!(read_var(&vm, "Z"), Value::Str("$VAR".to_string(), vec![i(5)]));
+    assert_eq!(read_var(&vm, "End"), i(6));
+
+    let (ground_ok, ground_vm) = call3(
+        "numbervars/3",
+        Value::Str("ground/2".to_string(), vec![a("x"), i(1)]),
+        i(7),
+        ub("End"),
+    );
+    assert!(ground_ok);
+    assert_eq!(read_var(&ground_vm, "End"), i(7));
+    assert!(!call3("numbervars/3", ub("X"), ub("Start"), ub("End")).0);
+
+    let (mismatch_ok, mismatch_vm) = call3(
+        "numbervars/3",
+        Value::Str("pair/2".to_string(), vec![ub("X"), ub("Y")]),
+        i(0),
+        i(9),
+    );
+    assert!(!mismatch_ok);
+    assert_eq!(read_var(&mismatch_vm, "X"), ub("X"));
+    assert_eq!(read_var(&mismatch_vm, "Y"), ub("Y"));
+
+    let (overflow_ok, overflow_vm) =
+        call3("numbervars/3", ub("X"), i(i64::MAX), ub("End"));
+    assert!(!overflow_ok);
+    assert_eq!(read_var(&overflow_vm, "X"), ub("X"));
+}
+
+#[test]
 fn test_ground() {
     assert!(call1("ground/1", a("x")).0);
     assert!(call1("ground/1", Value::List(vec![i(1), a("b")])).0);

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -462,6 +462,7 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"=../2"'),
         sub_string(S, _, _, _, '"copy_term/2"'),
         sub_string(S, _, _, _, '"term_variables/2"'),
+        sub_string(S, _, _, _, '"numbervars/3"'),
         sub_string(S, _, _, _, '"subtract/3"'),
         %% copy_term_walk helper (sharing-preserving recursive copy).
         sub_string(S, _, _, _, 'copy_term_walk'),


### PR DESCRIPTION
## Summary

- implement `numbervars/3` for the Rust hybrid WAM target
- preserve left-to-right variable order and shared-variable identity
- trail bindings and roll them back on End mismatch or integer overflow
- add focused runtime and generator coverage

## Testing

- `swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl`
- `swipl -q -s tests/test_wam_rust_target.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `git diff --check`