### PR TITLE
WAM/LLVM plawk: persist + validate row schema in the store (phase 8.7)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -575,11 +575,12 @@ a "select an existing table" surface would mean:
 meaningful once one of the two properties above changes, so it is planned as
 a short sequence rather than a lone keyword:
 
-- **(a) Persist the schema in the store.** Write the column names/types into
-  the store header on commit and read them on load, making a store
-  *self-describing*. Immediately useful on its own: an open can then
-  **validate** that the program's `declare(cols)` matches the stored schema
-  and fail cleanly on mismatch (closing the silent-mis-read hole above).
+- **(a) Persist the schema in the store. LANDED (file backend).** The
+  byte-valued store header now carries the row schema
+  (`name:type,name:type,…`); commit writes it, load reads it. When both the
+  stored schema and the program's `declare(cols)` are present and differ, the
+  open **fails cleanly** (`plawk: cache schema mismatch`, exit 3) instead of
+  silently mis-reading field offsets. `tests/test_plawk_row_durable.pl`.
 - **(b) `use TABLE as r` (the `select`).** A reader that **attaches to an
   existing store and takes its schema from (a)** — no re-`declare`. This is
   the "query an existing database" surface the `declare`-everywhere model
@@ -779,7 +780,8 @@ single-pass test before any driver surgery).
   field-wise). Foundational for Phase 7 (secondary indexes need addressable
   named fields). Table lifecycle / selecting an existing table (§3.7):
   (8.7) persist the schema in the store + validate it on open (self-describing
-  store, closes the schema-mismatch hole); (8.8) `use TABLE as r` reader that
+  store, closes the schema-mismatch hole) — **LANDED (file backend)**
+  (`tests/test_plawk_row_durable.pl`); (8.8) `use TABLE as r` reader that
   attaches to an existing store and takes its schema from 8.7 — the `select`
   surface, no re-`declare`; (8.9) multiple named tables per store (namespaces
   / LMDB named sub-DBs, §3.5) so `use ns.table` selects among them.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -724,7 +724,7 @@ plawk_program_native_driver_ir(
     plawk_forin_end_plan(Rules, LoopVar, ArrayName, BodyActions, AssocPlan, PrintFields),
     AssocPlan = assoc_plan(Tables, _),
     plawk_program_cache_tables(BeginClauses, CacheNamePaths),
-    plawk_cache_entries(Tables, [], CacheNamePaths, CacheEntries, CachePathGlobals),
+    plawk_cache_entries(Tables, [], [], CacheNamePaths, CacheEntries, CachePathGlobals),
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
@@ -3705,7 +3705,11 @@ plawk_program_multipass_driver_ir(
     plawk_program_cache_tables(BeginClauses, CacheTriples),
     maplist(plawk_assoc_rule_action_specs, AllRules, AllRuleSpecs),
     plawk_assoc_specs_str_arrays(AllRuleSpecs, StrArrays),
-    plawk_cache_entries([ArrayName], StrArrays, CacheTriples, CacheEntries,
+    findall(cache_schema(ST, SC),
+        ( member(begin(BActions), BeginClauses),
+          member(cache_schema(ST, SC), BActions) ),
+        Schemas),
+    plawk_cache_entries([ArrayName], StrArrays, Schemas, CacheTriples, CacheEntries,
         CachePathGlobals),
     % Per-pass RecordIR (rule chain) against the single shared table.
     findall(GlobalIR-ChainIR,
@@ -3806,7 +3810,7 @@ plawk_program_multipass_driver_ir(
     % A `BEGIN cache(...)`-declared shared table: load before pass 1, commit
     % after the last pass. Empty for pure-scalar / non-cache programs.
     plawk_program_cache_tables(BeginClauses, CacheTriples),
-    plawk_cache_entries(Tables, StrArrays, CacheTriples, CacheEntries,
+    plawk_cache_entries(Tables, StrArrays, Schemas, CacheTriples, CacheEntries,
         CachePathGlobals),
     plawk_output_separator(BeginClauses, OutputSeparator),
     % One function per pass, in order -- dispatching on the pass shape:
@@ -5951,11 +5955,9 @@ plawk_assoc_entry_setup_lines([_ArrayName | Rest], Index, CacheEntries) -->
     { format(atom(NewLine),
           '  %plawk_assoc_table_~w = call %WamAssocI64Table* @wam_assoc_i64_new(i64 4096)',
           [Index]),
-      ( memberchk(cache(Index, BytesLen, Backend, ValueKind), CacheEntries)
+      ( memberchk(cache(Index, BytesLen, Backend, ValueKind, SchemaRef), CacheEntries)
       ->  plawk_cache_fn(Backend, load, ValueKind, LoadFn),
-          format(atom(LoadLine),
-              '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
-              [LoadFn, Index, BytesLen, BytesLen, Index]),
+          plawk_cache_call_ir(LoadFn, Index, BytesLen, ValueKind, SchemaRef, LoadLine),
           Lines = [NewLine, LoadLine]
       ;   Lines = [NewLine]
       ),
@@ -5988,24 +5990,39 @@ plawk_cache_fn(lmdb, commit, _Kind, wam_cache_commit_lmdb) :- !.
 plawk_cache_fn(_File, load, _Kind, wam_cache_load).
 plawk_cache_fn(_File, commit, _Kind, wam_cache_commit).
 
-%% plawk_cache_entries(+Tables, +Triples, -CacheEntries, -PathGlobalsIR)
+%% plawk_cache_entries(+Tables, +StrArrays, +Schemas, +Triples, -CacheEntries,
+%%     -PathGlobalsIR)
 %  Resolve each cache-backed table name to its index in the plan's table
 %  list, emit a private string global @.plawk_cache_path_<idx> for its path,
-%  and record cache(Index, BytesLen, Backend) so setup/commit can reference
-%  the global and pick the backend function. A declared name absent from the
-%  plan (never used) is skipped. PathGlobalsIR also carries external declares
-%  for any lmdb backend functions in use.
-plawk_cache_entries(Tables, StrArrays, Triples, CacheEntries, PathGlobalsIR) :-
-    findall(cache(Index, BytesLen, Backend, ValueKind)-Global,
+%  and record cache(Index, BytesLen, Backend, ValueKind, SchemaRef) so
+%  setup/commit can reference the global, pick the backend function, and (for
+%  a str/row table with a declared schema) pass the schema so the store is
+%  self-describing and validated on open. SchemaRef is an `i8*` operand: a
+%  getelementptr to the schema-string global, or `null` when no schema. A
+%  declared name absent from the plan (never used) is skipped. PathGlobalsIR
+%  carries the path/schema globals plus any lmdb backend declares in use.
+plawk_cache_entries(Tables, StrArrays, Schemas, Triples, CacheEntries, PathGlobalsIR) :-
+    findall(cache(Index, BytesLen, Backend, ValueKind, SchemaRef)-GroupIR,
         ( member(ct(Name, Path, Backend), Triples),
           nth0(Index, Tables, Name),
           ( memberchk(Name, StrArrays) -> ValueKind = str ; ValueKind = i64 ),
           format(atom(GName), 'plawk_cache_path_~w', [Index]),
-          llvm_emit_c_string_global(GName, Path, Global, _Len, BytesLen)
+          llvm_emit_c_string_global(GName, Path, PathGlobal, _Len, BytesLen),
+          ( ValueKind == str, memberchk(cache_schema(Name, Cols), Schemas)
+          ->  plawk_schema_string(Cols, SchemaStr),
+              format(atom(SGName), 'plawk_cache_schema_~w', [Index]),
+              llvm_emit_c_string_global(SGName, SchemaStr, SchemaGlobal, _SLen, SBytes),
+              format(atom(SchemaRef),
+                  'getelementptr inbounds ([~w x i8], [~w x i8]* @.~w, i64 0, i64 0)',
+                  [SBytes, SBytes, SGName]),
+              atomic_list_concat([PathGlobal, SchemaGlobal], '\n', GroupIR)
+          ;   SchemaRef = 'null',
+              GroupIR = PathGlobal
+          )
         ),
         Pairs),
     pairs_keys_values(Pairs, CacheEntries, Globals),
-    ( memberchk(cache(_, _, lmdb, _), CacheEntries)
+    ( memberchk(cache(_, _, lmdb, _, _), CacheEntries)
     ->  LmdbDecls = ['declare void @wam_cache_load_lmdb(%WamAssocI64Table*, i8*)',
                      'declare void @wam_cache_commit_lmdb(%WamAssocI64Table*, i8*)']
     ;   LmdbDecls = []
@@ -6013,17 +6030,37 @@ plawk_cache_entries(Tables, StrArrays, Triples, CacheEntries, PathGlobalsIR) :-
     append(Globals, LmdbDecls, AllGlobals),
     atomic_list_concat(AllGlobals, '\n', PathGlobalsIR).
 
+%% plawk_schema_string(+Columns, -Str)
+%  Canonical schema string for a row table: `name:type,name:type,...`. Written
+%  into the store header and compared on open (must match byte-for-byte).
+plawk_schema_string(Columns, Str) :-
+    findall(CS, ( member(col(Name, Type), Columns),
+                  format(atom(CS), '~w:~w', [Name, Type]) ), Parts),
+    atomic_list_concat(Parts, ',', Str).
+
+%% plawk_cache_call_ir(+Fn, +Index, +BytesLen, +ValueKind, +SchemaRef, -Line)
+%  A load/commit call. The byte-valued (str) file helpers take an extra i8*
+%  schema argument (a getelementptr or null); the i64 / lmdb helpers do not.
+plawk_cache_call_ir(Fn, Index, BytesLen, str, SchemaRef, Line) :-
+    ( Fn == wam_cache_load_str ; Fn == wam_cache_commit_str ),
+    !,
+    format(atom(Line),
+        '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0), i8* ~w)',
+        [Fn, Index, BytesLen, BytesLen, Index, SchemaRef]).
+plawk_cache_call_ir(Fn, Index, BytesLen, _ValueKind, _SchemaRef, Line) :-
+    format(atom(Line),
+        '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
+        [Fn, Index, BytesLen, BytesLen, Index]).
+
 %% plawk_cache_commit_lines(+CacheEntries, -IR)
 %  A commit call per cache-backed table, writing the final table back to its
 %  store. Emitted at the top of the END phase (after the record loop, table
 %  still live), so the committed state is the completed pass.
 plawk_cache_commit_lines(CacheEntries, IR) :-
     findall(Line,
-        ( member(cache(Index, BytesLen, Backend, ValueKind), CacheEntries),
+        ( member(cache(Index, BytesLen, Backend, ValueKind, SchemaRef), CacheEntries),
           plawk_cache_fn(Backend, commit, ValueKind, CommitFn),
-          format(atom(Line),
-              '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
-              [CommitFn, Index, BytesLen, BytesLen, Index])
+          plawk_cache_call_ir(CommitFn, Index, BytesLen, ValueKind, SchemaRef, Line)
         ),
         Lines),
     atomic_list_concat(Lines, '\n', IR).

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -5037,13 +5037,34 @@ entry:
 ; them; row readers only iterate, and a re-writing pass re-interns the same
 ; key). internal linkage, so this is dead-code eliminated unless a str-valued
 ; store is used.
-define internal void @wam_cache_commit_str(%WamAssocI64Table* %table, i8* %path) {
+@.wam_cache_schema_err = private constant [29 x i8] c"plawk: cache schema mismatch\00"
+
+define internal void @wam_cache_commit_str(%WamAssocI64Table* %table, i8* %path, i8* %schema) {
 entry:
   %cbuf = alloca i64
   %hbuf = alloca [2 x i64]
   %fd = call i32 @open(i8* %path, i32 577, i32 420)
   %fd_ok = icmp sge i32 %fd, 0
-  br i1 %fd_ok, label %ccs.writecount, label %ccs.done
+  br i1 %fd_ok, label %ccs.schema, label %ccs.done
+
+; header: [schemalen:i64][schemabytes...] -- 0 length when no schema is given.
+ccs.schema:
+  %schema_null = icmp eq i8* %schema, null
+  br i1 %schema_null, label %ccs.noschema, label %ccs.haveschema
+
+ccs.haveschema:
+  %slen = call i64 @strlen(i8* %schema)
+  store i64 %slen, i64* %cbuf
+  %cbuf_i8a = bitcast i64* %cbuf to i8*
+  %sw1 = call i64 @write(i32 %fd, i8* %cbuf_i8a, i64 8)
+  %sw2 = call i64 @write(i32 %fd, i8* %schema, i64 %slen)
+  br label %ccs.writecount
+
+ccs.noschema:
+  store i64 0, i64* %cbuf
+  %cbuf_i8b = bitcast i64* %cbuf to i8*
+  %sw0 = call i64 @write(i32 %fd, i8* %cbuf_i8b, i64 8)
+  br label %ccs.writecount
 
 ccs.writecount:
   %count_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 0
@@ -5085,13 +5106,63 @@ ccs.done:
   ret void
 }
 
-define internal void @wam_cache_load_str(%WamAssocI64Table* %table, i8* %path) {
+define internal void @wam_cache_load_str(%WamAssocI64Table* %table, i8* %path, i8* %schema) {
 entry:
   %cbuf = alloca i64
   %hbuf = alloca [2 x i64]
+  %slbuf = alloca i64
   %fd = call i32 @open(i8* %path, i32 0, i32 0)
   %fd_ok = icmp sge i32 %fd, 0
-  br i1 %fd_ok, label %cls.readcount, label %cls.done
+  br i1 %fd_ok, label %cls.readschemalen, label %cls.done
+
+; header: read [schemalen][schemabytes]. When both the stored schema and the
+; program schema are present, they must match, else the store was written for
+; a different row shape -- fail loudly rather than mis-read field offsets.
+cls.readschemalen:
+  %slbuf_i8 = bitcast i64* %slbuf to i8*
+  %sln = call i64 @read(i32 %fd, i8* %slbuf_i8, i64 8)
+  %sln_ok = icmp eq i64 %sln, 8
+  br i1 %sln_ok, label %cls.checkschemalen, label %cls.close
+
+cls.checkschemalen:
+  %schemalen = load i64, i64* %slbuf
+  %has_schema = icmp sgt i64 %schemalen, 0
+  br i1 %has_schema, label %cls.readschema, label %cls.readcount
+
+cls.readschema:
+  %sbuf = call i8* @malloc(i64 %schemalen)
+  %srn = call i64 @read(i32 %fd, i8* %sbuf, i64 %schemalen)
+  %srn_ok = icmp eq i64 %srn, %schemalen
+  br i1 %srn_ok, label %cls.validate, label %cls.sfreeclose
+
+cls.validate:
+  %expect_null = icmp eq i8* %schema, null
+  br i1 %expect_null, label %cls.sfree_ok, label %cls.cmplen
+
+cls.cmplen:
+  %explen = call i64 @strlen(i8* %schema)
+  %len_eq = icmp eq i64 %explen, %schemalen
+  br i1 %len_eq, label %cls.cmpbytes, label %cls.mismatch
+
+cls.cmpbytes:
+  %cmp = call i32 @memcmp(i8* %sbuf, i8* %schema, i64 %schemalen)
+  %cmp_eq = icmp eq i32 %cmp, 0
+  br i1 %cmp_eq, label %cls.sfree_ok, label %cls.mismatch
+
+cls.mismatch:
+  call void @free(i8* %sbuf)
+  %errp = getelementptr [29 x i8], [29 x i8]* @.wam_cache_schema_err, i64 0, i64 0
+  %eprc = call i32 (i8*, ...) @printf(i8* %errp)
+  call void @exit(i32 3)
+  unreachable
+
+cls.sfree_ok:
+  call void @free(i8* %sbuf)
+  br label %cls.readcount
+
+cls.sfreeclose:
+  call void @free(i8* %sbuf)
+  br label %cls.close
 
 cls.readcount:
   %cbuf_i8 = bitcast i64* %cbuf to i8*

--- a/tests/test_plawk_row_durable.pl
+++ b/tests/test_plawk_row_durable.pl
@@ -58,6 +58,30 @@ test(rows_persist_positional, [condition(clang_available)]) :-
     run_sorted(Bin, In, S2), assertion(S2 == ["p 1", "q 2"]),
     !.
 
+% Self-describing store: the schema is persisted, so reopening the same store
+% with a DIFFERENT declared schema fails cleanly (exit 3) rather than silently
+% mis-reading field offsets. Run 1 writes with schema (a,b); a second program
+% opening it with schema (a,c) mismatches.
+test(schema_mismatch_errors, [condition(clang_available)]) :-
+    ddir(Dir),
+    directory_file_path(Dir, 'scm.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(SrcA),
+        "BEGIN cache(\"~w\") { declare t(a str, b str) }\n\c
+         pass records of t as r { print r[\"a\"], r[\"b\"] }\n\c
+         pass { t[$1] = row($1, $2) }\n", [Store]),
+    build(Dir, 'scma', SrcA, BinA, InA, "x 10\n"),
+    run_sorted(BinA, InA, _),                   % run 1: populate + commit schema
+    format(atom(SrcB),
+        "BEGIN cache(\"~w\") { declare t(a str, c str) }\n\c
+         pass records of t as r { print r[\"a\"], r[\"c\"] }\n\c
+         pass { t[$1] = row($1, $2) }\n", [Store]),
+    build(Dir, 'scmb', SrcB, BinB, InB, "x 10\n"),
+    process_create(BinB, [InB], [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Code)),
+    assertion(Code == 3),                       % schema mismatch -> clean fail
+    !.
+
 :- end_tests(plawk_row_durable).
 
 % --- helpers ---------------------------------------------------------------


### PR DESCRIPTION
Makes a row store **self-describing** and catches schema mismatches — directly answering your "what if the db already has a (differently-shaped) table?" question: it's now diagnosed at open, not silently mis-read.

The byte-valued (str) file store writes the row schema into its header (`name:type,name:type,…`) on commit and reads it on load. When both the stored schema and the program's `declare(cols)` are present and differ, the open **fails cleanly**:

```
$ ./reader in.txt
plawk: cache schema mismatch      # exit 3
```

instead of reading a store written for a different row shape against the wrong field offsets.

## Changes
- **Runtime** (`wam_llvm_target.pl`): `@wam_cache_commit_str` / `@wam_cache_load_str` gain an `i8*` schema arg and a `[schemalen:i64][schemabytes]` header ahead of `[count][key vallen valbytes]…`. Commit writes the schema (length 0 when none); load reads it and, if the program passed a differing schema (length or bytes, via `@memcmp`), prints the error and `@exit(3)`s. A null program schema (e.g. a positional `rows of` reader) skips validation; a length-0 stored schema likewise.
- **Codegen**: cache entries carry a value kind + schema ref; a str/row table with a declared schema emits a `@.plawk_cache_schema_<idx>` global and passes it to the byte-valued calls (`plawk_cache_call_ir` adds the extra `i8*` only for the str helpers). i64 / lmdb calls unchanged. Threaded through all three cache call sites (single-pass passes `[]`).

## Tests
`tests/test_plawk_row_durable.pl` gains `schema_mismatch_errors` (reopen with a different schema → exit 3); durable read-back still passes. Regression green across cache-surface, cache-lmdb, multipass-cache, cache-runtime, records-reader, rows-reader, row-cons.

## Toward `select`/`use`
This is phase 8.7 — the enabler. With the store now self-describing, the next step is **8.8 `use TABLE as r`**: a reader that attaches to an existing store and takes its columns *from the persisted schema*, no re-`declare`. That's the `select` you asked about. (8.9 multi-table stores — LMDB named sub-DBs — follows.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_