### PR TITLE
WAM/LLVM plawk: `use NAME` reader attaches to an existing store (phase 8.8)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -581,11 +581,14 @@ a short sequence rather than a lone keyword:
   stored schema and the program's `declare(cols)` are present and differ, the
   open **fails cleanly** (`plawk: cache schema mismatch`, exit 3) instead of
   silently mis-reading field offsets. `tests/test_plawk_row_durable.pl`.
-- **(b) `use TABLE as r` (the `select`).** A reader that **attaches to an
-  existing store and takes its schema from (a)** — no re-`declare`. This is
-  the "query an existing database" surface the `declare`-everywhere model
-  lacks; today `declare NAME` already *opens* the existing table, so `use`
-  only adds value once the schema no longer has to be restated.
+- **(b) `use NAME` (the `select`). LANDED (file backend).** A backed-BEGIN
+  `use NAME` **attaches to an existing store and takes its schema from (a)** —
+  no re-`declare(cols)`. The plawk build reads the store's persisted schema
+  header at **compile time** and expands `use NAME` into the same
+  `cache_table` + `cache_schema` a matching `declare NAME(cols)` would produce,
+  so `records of` / `rows of` and the runtime schema check work unchanged. A
+  missing / schema-less store is a compile error.
+  `tests/test_plawk_use_table.pl`.
 - **(c) Multiple named tables per store.** With the namespace design (§3.5,
   LMDB named sub-DBs), a store holds several tables and `use ns.orders`
   selects among them. This is the point at which `select` becomes load-bearing
@@ -791,10 +794,12 @@ single-pass test before any driver surgery).
   named fields). Table lifecycle / selecting an existing table (§3.7):
   (8.7) persist the schema in the store + validate it on open (self-describing
   store, closes the schema-mismatch hole) — **LANDED (file backend)**
-  (`tests/test_plawk_row_durable.pl`); (8.8) `use TABLE as r` reader that
-  attaches to an existing store and takes its schema from 8.7 — the `select`
-  surface, no re-`declare`; (8.9) multiple named tables per store (namespaces
-  / LMDB named sub-DBs, §3.5) so `use ns.table` selects among them.
+  (`tests/test_plawk_row_durable.pl`); (8.8) `use NAME` that attaches to an
+  existing store and takes its schema from 8.7 (read at build time) — the
+  `select` surface, no re-`declare` — **LANDED (file backend)**
+  (`tests/test_plawk_use_table.pl`); (8.9) multiple named tables per store
+  (namespaces / LMDB named sub-DBs, §3.5, per `PLAWK_CACHE_BACKENDS.md`) so
+  `use ns.table` selects among them.
 
 ## 6. Open questions
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -98,7 +98,8 @@ build(File, Out0, KeepLL) :-
     ;   format(user_error, 'plawk: parse error in ~w~n', [File]),
         halt(2)
     ),
-    normalize_passes(File, Program0, Program),
+    normalize_passes(File, Program0, Program1),
+    resolve_cache_use(File, Program1, Program),
     (   Clauses == []
     ->  Preds = [user:plawk_cli_marker/0]
     ;   (   plawk_prolog_block_preds(Clauses, Preds)
@@ -254,6 +255,84 @@ normalize_passes(_File, program_passes(Begin, [pass(Rules)], End),
 % Two or more passes stay as program_passes and are lowered by the
 % dedicated multi-pass driver (see the compile step below).
 normalize_passes(_File, Program, Program).
+
+% `use NAME` expansion (PLAWK_MULTIPASS_CACHE.md §3.7, phase 8.8). A
+% cache_use(Name, Path, Backend) begin action means "attach to the existing
+% store, take its schema from the store". At BUILD time we read the store's
+% persisted schema header (§8.7) and rewrite the action into the same
+% cache_table + cache_schema a matching `declare NAME(cols)` would have
+% produced, so every downstream reader (records of / rows of) and the runtime
+% schema check work unchanged. The store must exist and carry a schema at
+% build time; otherwise it is a compile error.
+resolve_cache_use(File, program(B0, R, E), program(B, R, E)) :-
+    !, maplist(resolve_use_begin(File), B0, B).
+resolve_cache_use(File, program_passes(B0, P, E), program_passes(B, P, E)) :-
+    !, maplist(resolve_use_begin(File), B0, B).
+resolve_cache_use(_File, Program, Program).
+
+resolve_use_begin(File, begin(As0), begin(As)) :-
+    !,
+    findall(Xs, ( member(A, As0), expand_cache_use(File, A, Xs) ), Nested),
+    append(Nested, As).
+resolve_use_begin(_File, Clause, Clause).
+
+expand_cache_use(File, cache_use(Name, Path, Backend),
+        [cache_table(Name, Path, Backend), cache_schema(Name, Cols)]) :-
+    !,
+    (   store_schema_columns(Path, Cols)
+    ->  true
+    ;   format(user_error,
+            'plawk: cannot `use ~w` in ~w: store "~w" is missing or has no schema~n',
+            [Name, File, Path]),
+        halt(2)
+    ).
+expand_cache_use(_File, Action, [Action]).
+
+% Read a byte-valued row store's persisted schema header and parse it into
+% col(Name, Type) columns. Header layout (§8.7): [schemalen:i64 (LE)]
+% [schemabytes: "name:type,name:type,..."][count]... A missing file, a
+% non-positive/absurd length, or an unparseable schema fails (-> compile
+% error at the call site).
+store_schema_columns(Path, Cols) :-
+    atom_string(PathA, Path),
+    exists_file(PathA),
+    setup_call_cleanup(
+        open(PathA, read, S, [type(binary)]),
+        read_store_schema_string(S, SchemaStr),
+        close(S)),
+    parse_schema_string(SchemaStr, Cols),
+    Cols = [_ | _].
+
+read_store_schema_string(S, SchemaStr) :-
+    read_le_i64(S, SchemaLen),
+    SchemaLen > 0,
+    SchemaLen =< 1048576,               % sanity cap: not a schema-bearing store
+    read_n_bytes(S, SchemaLen, Bytes),
+    atom_codes(SchemaAtom, Bytes),
+    atom_string(SchemaAtom, SchemaStr).
+
+read_le_i64(S, V) :-
+    read_n_bytes(S, 8, [B0, B1, B2, B3, B4, B5, B6, B7]),
+    V is B0 \/ (B1 << 8) \/ (B2 << 16) \/ (B3 << 24)
+       \/ (B4 << 32) \/ (B5 << 40) \/ (B6 << 48) \/ (B7 << 56).
+
+read_n_bytes(_S, 0, []) :- !.
+read_n_bytes(S, N, [B | Bs]) :-
+    N > 0,
+    get_byte(S, B),
+    B \== -1,
+    N1 is N - 1,
+    read_n_bytes(S, N1, Bs).
+
+% "cust:str,amount:i64" -> [col(cust,str), col(amount,i64)].
+parse_schema_string(Str, Cols) :-
+    split_string(Str, ",", "", Parts),
+    maplist(parse_schema_col, Parts, Cols).
+parse_schema_col(Part, col(NameA, TypeA)) :-
+    split_string(Part, ":", "", [NameS, TypeS]),
+    atom_string(NameA, NameS),
+    atom_string(TypeA, TypeS),
+    memberchk(TypeA, [str, i64]).
 
 ll_path(Out, true, LLPath) :-
     !,

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3795,18 +3795,29 @@ plawk_program_multipass_driver_ir(
     findall(R, ( member(pass(PassRules), Passes), member(R, PassRules) ), AllRules),
     plawk_multipass_pass_plan(AllRules, Tables, AssocPlan),  % validates surface
     plawk_multipass_table_params(Tables, TableParamsIR, TableArgsIR),
-    % Program-wide str-valued (row) tables: a table a writer pass populates
-    % via `arr[$k] = $0` holds string values, so an `over`/`records` reader
-    % must resolve the stored id to the row's bytes. Threaded to each reader.
-    maplist(plawk_assoc_rule_action_specs, AllRules, AllRuleSpecs),
-    plawk_assoc_specs_str_arrays(AllRuleSpecs, StrArrays),
-    % Row schemas (from `declare NAME(col type, ...)`) for the named
-    % `records of` reader: column name -> position. Empty for schema-less
-    % programs (the reader requires a schema and fails without one).
+    % Row schemas (from `declare NAME(col type, ...)` or a `use NAME` whose
+    % store schema was read at build time): column name -> position for the
+    % named `records of` reader. Empty for schema-less programs.
     findall(cache_schema(ST, SC),
         ( member(begin(BActions), BeginClauses),
           member(cache_schema(ST, SC), BActions) ),
         Schemas),
+    % Program-wide str-valued (ROW) tables: a table holds string (row) values
+    % if a writer populates it (`arr[$k] = $0` / `= row(...)`), if a row
+    % reader consumes it (`records of` / `rows of`), or if it carries a row
+    % schema (so a pure `use` reader with no writer is still byte-valued).
+    % Str tables use the byte-valued cache load/commit, so this must be
+    % complete or a durable row store is (mis)read with the i64 loader.
+    maplist(plawk_assoc_rule_action_specs, AllRules, AllRuleSpecs),
+    plawk_assoc_specs_str_arrays(AllRuleSpecs, WriterStr),
+    findall(RT,
+        ( member(pass_records(_RV, var(RT), _RB), Passes)
+        ; member(pass_rows(_PV, var(RT), _PB), Passes)
+        ; member(cache_schema(RT, _), Schemas)
+        ),
+        ReaderStr),
+    append(WriterStr, ReaderStr, StrArrays0),
+    sort(StrArrays0, StrArrays),
     % A `BEGIN cache(...)`-declared shared table: load before pass 1, commit
     % after the last pass. Empty for pure-scalar / non-cache programs.
     plawk_program_cache_tables(BeginClauses, CacheTriples),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -993,6 +993,15 @@ cache_decl(Path, Backend,
     !.
 cache_decl(Path, Backend, [cache_table(Name, Path, Backend)]) -->
     "declare", required_ws, identifier(Name).
+% `use NAME` (PLAWK_MULTIPASS_CACHE.md §3.7, phase 8.8): attach to an EXISTING
+% store without re-stating its columns -- the schema is taken from the store's
+% persisted header (§8.7). Parses to cache_use(NAME, Path, Backend); the plawk
+% build reads the store's schema and expands it into the same
+% cache_table/cache_schema a matching `declare NAME(cols)` would produce, so
+% the readers need no new machinery. Tried after `declare`; `use` is
+% unambiguous.
+cache_decl(Path, Backend, [cache_use(Name, Path, Backend)]) -->
+    "use", required_ws, identifier(Name).
 
 cache_col_list(Columns) -->
     "(", ws, cache_cols(Columns), ws, ")".

--- a/tests/test_plawk_use_table.pl
+++ b/tests/test_plawk_use_table.pl
@@ -1,0 +1,105 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk row-oriented records (PLAWK_MULTIPASS_CACHE.md §3.7, phase 8.8): the
+% `use` reader -- the `select`. `BEGIN cache("path") { use NAME }` attaches to
+% an EXISTING store without re-stating its columns: the plawk build reads the
+% store's persisted schema header (§8.7) and expands `use NAME` into the same
+% cache_table + cache_schema a matching `declare NAME(cols)` would produce. So
+% a reader queries a durable store by column name (`records of`) without
+% duplicating the schema, and the runtime schema check still guards drift.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_use_table).
+
+% `use NAME` parses to a cache_use begin action.
+test(use_parses) :-
+    plawk_parse_string(
+        "BEGIN cache(\"s.db\") { use t }\n\c
+         pass records of t as r { print r[\"a\"] }\n\c
+         pass rows of t as r { print r[1] }\n",
+        program_passes([begin([cache_use(t, "s.db", file)])], _, _)),
+    !.
+
+% End to end: a writer program populates a store with schema (a,b); a
+% separate `use` reader (NO declare(cols)) reads it back by column name and by
+% position. The reader's schema comes from the store, resolved at build time.
+test(use_reads_existing_store, [condition(clang_available)]) :-
+    udir(Dir),
+    directory_file_path(Dir, 'u.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    % writer: declare schema, populate rows, commit
+    format(atom(WSrc),
+        "BEGIN cache(\"~w\") { declare t(a str, b str) }\n\c
+         pass records of t as r { print r[\"a\"] }\n\c
+         pass { t[$1] = row($1, $2) }\n", [Store]),
+    build(Dir, 'uw', WSrc, WBin, WIn, "x 10\ny 20\n"),
+    run_sorted(WBin, WIn, _),                    % populate + commit schema
+    % use reader: no declare(cols); schema read from the store at build time
+    format(atom(RSrc),
+        "BEGIN cache(\"~w\") { use t }\n\c
+         pass records of t as r { print r[\"a\"], r[\"b\"] }\n\c
+         pass rows of t as r { print r[1] }\n", [Store]),
+    build(Dir, 'ur', RSrc, RBin, RIn, "x 10\ny 20\n"),
+    run_sorted(RBin, RIn, S),
+    assertion(S == ["x", "x 10", "y", "y 20"]),
+    !.
+
+% `use` on a missing store is a compile error (exit 2): the schema cannot be
+% read.
+test(use_missing_store_errors, [condition(clang_available)]) :-
+    udir(Dir),
+    directory_file_path(Dir, 'nope.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(RSrc),
+        "BEGIN cache(\"~w\") { use t }\n\c
+         pass records of t as r { print r[\"a\"] }\n\c
+         pass rows of t as r { print r[1] }\n", [Store]),
+    directory_file_path(Dir, 'um.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, W, [encoding(utf8)]),
+        write(W, RSrc), close(W)),
+    directory_file_path(Dir, 'um_bin', Bin),
+    cli([build, Prog, '-o', Bin], 2),            % compile error: no store/schema
+    !.
+
+:- end_tests(plawk_use_table).
+
+% --- helpers ---------------------------------------------------------------
+
+udir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_use_table', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+run_sorted(Bin, In, Sorted) :-
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
The **`select`** you asked about. `use NAME` attaches to an existing store *without re-stating its columns* — the schema comes from the store's persisted header (8.7):

```awk
BEGIN cache("orders.db") { use orders }      # no declare(cols)!
pass records of orders as r { print r["cust"], r["amount"] }
pass rows of orders as r    { print r[1] }
```

A writer populates a store; a separate `use` reader queries it by column name (and position) with no schema duplication.

## Design
`use` reads the store's schema at **compile time** and expands into the same `cache_table` + `cache_schema` a matching `declare NAME(cols)` produces — so `records of` / `rows of` resolution and the 8.7 runtime check work **unchanged, no new codegen**. If the store's schema later drifts from the build, 8.7's runtime check still fails cleanly.

## Changes
- **Parser**: `cache_decl` gains `use NAME` → `cache_use(Name, Path, Backend)`.
- **bin/plawk**: `resolve_cache_use` (after `normalize_passes`) reads the byte-valued store header (`[schemalen:i64 LE][schemabytes "name:type,…"]`), parses the columns, and rewrites `cache_use` → `cache_table` + `cache_schema`. A missing / schema-less store is a compile error (exit 2).
- **Codegen fix**: the program-wide str-valued (row) table set now also includes tables read by `records of`/`rows of` and tables carrying a row schema — so a **pure `use` reader** (no writer action) loads/commits with the byte-valued helpers instead of mis-reading a durable row store with the i64 loader. (This bug ate the first reader's output until fixed.)

## Tests
`tests/test_plawk_use_table.pl` — parse; end-to-end (writer populates, separate `use` reader reads by name + position, no `declare(cols)`); missing store → compile error. Regression green across row-durable, records/rows-reader, row-capture, row-cons, over-table, multipass-cache, cache-surface.

## Scope
File backend (matches where durable rows + schema persistence live). `use ns.table` across multiple named tables is 8.9 (LMDB named sub-DBs, per `PLAWK_CACHE_BACKENDS.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_