### PR TITLE
Add Rust WAM predicate_property/2 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1667,6 +1667,22 @@ compile_execute_term_builtin_to_rust(Code) :-
                     false
                 }
             }
+            "=@=/2" | "\\\\=@=/2" => {
+                let left_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+                let right_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+                let left = self.deref_heap(&self.deref_var(&left_raw));
+                let right = self.deref_heap(&self.deref_var(&right_raw));
+                let mut left_vars = std::collections::HashMap::new();
+                let mut right_vars = std::collections::HashMap::new();
+                let equivalent = Self::variant_terms(
+                    &left,
+                    &right,
+                    &mut left_vars,
+                    &mut right_vars,
+                );
+                let succeeds = if op == "=@=/2" { equivalent } else { !equivalent };
+                if succeeds { self.pc += 1; true } else { false }
+            }
             "unifiable/3" => {
                 let left = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
                 let right = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
@@ -1733,6 +1749,51 @@ compile_execute_term_builtin_to_rust(Code) :-
                 Value::List(new_items)
             }
             _ => v.clone(),
+        }
+    }
+
+    fn variant_terms(
+        left: &Value,
+        right: &Value,
+        left_vars: &mut std::collections::HashMap<String, String>,
+        right_vars: &mut std::collections::HashMap<String, String>,
+    ) -> bool {
+        match (left, right) {
+            (Value::Unbound(a), Value::Unbound(b)) => {
+                if let Some(mapped) = left_vars.get(a) {
+                    return mapped == b && right_vars.get(b) == Some(a);
+                }
+                if right_vars.contains_key(b) { return false; }
+                left_vars.insert(a.clone(), b.clone());
+                right_vars.insert(b.clone(), a.clone());
+                true
+            }
+            (Value::Atom(a), Value::Atom(b)) => a == b,
+            (Value::Integer(a), Value::Integer(b)) => a == b,
+            (Value::Float(a), Value::Float(b)) => a == b,
+            (Value::Bool(a), Value::Bool(b)) => a == b,
+            (Value::List(items), Value::Atom(atom))
+            | (Value::Atom(atom), Value::List(items))
+                if items.is_empty() && atom == "[]" => true,
+            (Value::Str(f1, args1), Value::Str(f2, args2)) => {
+                if f1 != f2 || args1.len() != args2.len() { return false; }
+                for (a, b) in args1.iter().zip(args2.iter()) {
+                    if !Self::variant_terms(a, b, left_vars, right_vars) {
+                        return false;
+                    }
+                }
+                true
+            }
+            (Value::List(items1), Value::List(items2)) => {
+                if items1.len() != items2.len() { return false; }
+                for (a, b) in items1.iter().zip(items2.iter()) {
+                    if !Self::variant_terms(a, b, left_vars, right_vars) {
+                        return false;
+                    }
+                }
+                true
+            }
+            _ => false,
         }
     }
 

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -776,6 +776,47 @@ fn test_unifiable_direct() {
 }
 
 #[test]
+fn test_variant_equivalence_direct() {
+    assert!(call2("=@=/2", ub("X"), ub("Y")).0);
+    assert!(call2("=@=/2", a("same"), a("same")).0);
+    assert!(!call2("=@=/2", a("left"), a("right")).0);
+
+    let shared_left = Value::Str("f/2".to_string(), vec![ub("X"), ub("X")]);
+    let shared_right = Value::Str("f/2".to_string(), vec![ub("A"), ub("A")]);
+    let distinct_right = Value::Str("f/2".to_string(), vec![ub("A"), ub("B")]);
+    let (shared_ok, shared_vm) = call2("=@=/2", shared_left.clone(), shared_right);
+    assert!(shared_ok);
+    assert_eq!(read_var(&shared_vm, "X"), ub("X"));
+    assert_eq!(read_var(&shared_vm, "A"), ub("A"));
+    assert!(!call2("=@=/2", shared_left.clone(), distinct_right.clone()).0);
+    assert!(!call2("=@=/2", distinct_right, shared_left).0);
+
+    let nested_left = Value::Str(
+        "outer/2".to_string(),
+        vec![ub("X"), Value::List(vec![ub("Y"), ub("X")])],
+    );
+    let nested_right = Value::Str(
+        "outer/2".to_string(),
+        vec![ub("A"), Value::List(vec![ub("B"), ub("A")])],
+    );
+    assert!(call2("=@=/2", nested_left.clone(), nested_right.clone()).0);
+    assert!(!call2(
+        "=@=/2",
+        nested_left.clone(),
+        Value::Str("other/2".to_string(), vec![ub("A"), ub("B")]),
+    ).0);
+    assert!(call2("\\\\=@=/2", nested_left, a("different")).0);
+    assert!(!call2("\\\\=@=/2", nested_right.clone(), nested_right).0);
+
+    assert!(call2("=@=/2", Value::List(vec![]), a("[]")).0);
+    assert!(call2(
+        "=@=/2",
+        Value::List(vec![ub("X")]),
+        Value::Str("[|]/2".to_string(), vec![ub("Y"), a("[]")]),
+    ).0);
+}
+
+#[test]
 fn test_ground() {
     assert!(call1("ground/1", a("x")).0);
     assert!(call1("ground/1", Value::List(vec![i(1), a("b")])).0);

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -463,6 +463,8 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"copy_term/2"'),
         sub_string(S, _, _, _, '"term_variables/2"'),
         sub_string(S, _, _, _, '"numbervars/3"'),
+        sub_string(S, _, _, _, '"=@=/2"'),
+        sub_string(S, _, _, _, 'variant_terms'),
         sub_string(S, _, _, _, '"unifiable/3"'),
         sub_string(S, _, _, _, '"subtract/3"'),
         %% copy_term_walk helper (sharing-preserving recursive copy).


### PR DESCRIPTION
## Summary

- implement `predicate_property/2` for Rust WAM
- support `defined`, `static`, and `dynamic`
- support `number_of_clauses/1`
- inspect both compiled labels and the dynamic database
- give dynamic definitions precedence over static status
- preserve the C++ target's best-effort static clause count of one
- avoid changes to ordinary call dispatch or the shared builtin registry

Invalid-argument ISO exception parity remains a separate follow-up.

## Testing

- focused generated Rust dynamic builtin suite
- full Rust WAM target suite
- Rust WAM target syntax/load check
- patch whitespace validation