### PR TITLE
WAM/LLVM plawk: awk-native `$N` field addressing in `rows of` (no `as`)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -465,6 +465,12 @@ contracts so neither is a grab-bag of modifiers:
   (`tests/test_plawk_rows_reader.pl`). Reuses the same row-decode function as
   `records of`, sourcing field indices from the literal positions. The
   `unsafe` modifier and inline check-or-rename spec below are a **follow-on**.
+  - **`rows of TABLE` — no `as`, awk-native `$N`. LANDED.** Omitting the
+    `as VAR` binding switches to awk field addressing: `pass rows of t {
+    print $1, $2 }` — a stored row is a field-separated record, so `$N`
+    addresses its Nth column (and arithmetic over `$N` works, in f64). The
+    two spellings do not mix: no `as` ⇒ `$N`; `as VAR` ⇒ `VAR[N]`. This makes
+    the schemaless positional reader read like plain awk over the stored rows.
   A schema spec may appear at the read site, and its role depends on whether
   an authoritative (`declare`d) schema already exists:
   - **schema present →** the spec is a **check**: the store's row shape

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3813,6 +3813,7 @@ plawk_program_multipass_driver_ir(
     findall(RT,
         ( member(pass_records(_RV, var(RT), _RB), Passes)
         ; member(pass_rows(_PV, var(RT), _PB), Passes)
+        ; member(pass_rows_anon(var(RT), _AB), Passes)
         ; member(cache_schema(RT, _), Schemas)
         ),
         ReaderStr),
@@ -3897,6 +3898,7 @@ plawk_passes_tables(Passes, Tables) :-
         ; member(pass_over(_Var, var(Name), _Body), Passes)
         ; member(pass_records(_RVar, var(Name), _RBody), Passes)
         ; member(pass_rows(_PVar, var(Name), _PBody), Passes)
+        ; member(pass_rows_anon(var(Name), _ABody), Passes)
         ),
         Names0),
     sort(Names0, Tables),
@@ -4009,6 +4011,27 @@ plawk_rows_field_plan(Var, Expr, arith(F64Op, LPlan, RPlan)) :-
     plawk_rows_operand(Var, R, RPlan).
 plawk_rows_operand(Var, assoc(var(Var), int(N)), col(N)) :- integer(N), N > 0.
 plawk_rows_operand(_Var, int(V), aint(V)) :- integer(V).
+
+% The no-`as` positional reader (`pass rows of T { print $1, $2 }`): awk-native
+% `$N` field addressing over the stored row. Mirrors plawk_rows_field_plan but
+% sources positions from `field(N)` ($N) rather than `VAR[N]`.
+plawk_multipass_pass_fn(Index, pass_rows_anon(var(Table), Body), Tables,
+        _StrArrays, _Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
+    Body = [print(PrintFields)],
+    PrintFields = [_ | _],
+    maplist(plawk_rows_anon_field_plan, PrintFields, FieldPlans),
+    nth0(TableIndex, Tables, Table),
+    plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, FieldPlans,
+        FieldSep, OutputSep, FnIR).
+
+plawk_rows_anon_field_plan(field(N), col(N)) :- integer(N), N > 0.
+plawk_rows_anon_field_plan(Expr, arith(F64Op, LPlan, RPlan)) :-
+    Expr =.. [Op, L, R],
+    plawk_i64_op_f64(Op, F64Op),
+    plawk_rows_anon_operand(L, LPlan),
+    plawk_rows_anon_operand(R, RPlan).
+plawk_rows_anon_operand(field(N), col(N)) :- integer(N), N > 0.
+plawk_rows_anon_operand(int(V), aint(V)) :- integer(V).
 
 % Over-reader print fields (v1): the loop key, or a lookup of the iterated
 % table keyed by it. String literals / other tables are follow-ons.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -228,6 +228,19 @@ pass_clauses([pass_rows(var(Var), var(Table), Body) | Rest]) -->
     for_in_body(Body),
     ws,
     pass_clauses(Rest).
+% `pass rows of TABLE { print $1, $2 }` -- the positional reader WITHOUT an
+% `as VAR` binding uses awk-native field addressing: a stored row is a
+% field-separated record, so `$N` addresses its Nth column directly. Tried
+% after the `as` form (which owns `VAR[N]`); the two spellings do not mix --
+% no `as` => `$N`, `as VAR` => `VAR[N]`. Represented as pass_rows_anon/2.
+pass_clauses([pass_rows_anon(var(Table), Body) | Rest]) -->
+    "pass", identifier_boundary, ws,
+    "rows", identifier_boundary, ws,
+    "of", identifier_boundary, ws,
+    identifier(Table), ws,
+    for_in_body(Body),
+    ws,
+    pass_clauses(Rest).
 % A `pass over TABLE as VAR { print ... }` block: a configurable reader
 % (PLAWK_MULTIPASS_CACHE.md phase 4). Instead of re-scanning the input, the
 % pass iterates TABLE's entries as records, binding each key to VAR -- the
@@ -260,6 +273,8 @@ plawk_pass_dynentry_rewrite(_DynEntries, pass_over(V, T, Body), pass_over(V, T, 
 plawk_pass_dynentry_rewrite(_DynEntries, pass_records(V, T, Body), pass_records(V, T, Body)).
 % A `rows of TABLE` reader likewise has no rule actions -- pass it through.
 plawk_pass_dynentry_rewrite(_DynEntries, pass_rows(V, T, Body), pass_rows(V, T, Body)).
+% The no-`as` (`$N`) positional reader likewise has no rule actions.
+plawk_pass_dynentry_rewrite(_DynEntries, pass_rows_anon(T, Body), pass_rows_anon(T, Body)).
 
 %% dynentry_decls(-Names)//
 %

--- a/tests/test_plawk_rows_reader.pl
+++ b/tests/test_plawk_rows_reader.pl
@@ -61,6 +61,34 @@ test(rows_column_arith, [condition(clang_available)]) :-
     assertion(S == ["a 2.5", "b 4.5"]),
     !.
 
+% Awk-native `$N` field addressing WITHOUT an `as VAR` binding: `pass rows of
+% t { print $1, $2 }`. A stored row is a field-separated record, so $N maps to
+% its Nth column directly.
+test(rows_anon_field_addressing, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t { print $1, $2 }\n",
+    run_sorted(Dir, 'anon', Src, "a 10\nb 5\n", S),
+    assertion(S == ["a 10", "b 5"]),
+    !.
+
+% `$N` parses to pass_rows_anon (no `as`), distinct from the `as VAR` form.
+test(rows_anon_parses) :-
+    plawk_parse_string(
+        "pass { t[$1] = $0 }\npass rows of t { print $1, $2 }\n",
+        program_passes([],
+            [pass([rule(always, [set_row(var(t), field(1))])]),
+             pass_rows_anon(var(t), [print([field(1), field(2)])])],
+            [])),
+    !.
+
+% Awk-native arithmetic over `$N` (f64): `$2 / 2`.
+test(rows_anon_arith, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t { print $1, $2 / 2 }\n",
+    run_sorted(Dir, 'anar', Src, "a 10\nb 6\n", S),
+    assertion(S == ["a 5", "b 3"]),
+    !.
+
 :- end_tests(plawk_rows_reader).
 
 % --- helpers ---------------------------------------------------------------


### PR DESCRIPTION
Per your suggestion: the positional row reader **without** an `as VAR` binding now uses awk-native `$N` field addressing. A stored row is a field-separated record, so `$N` addresses its Nth column — the schemaless positional reader reads like plain awk over the stored rows:

```awk
pass { t[$1] = $0 }
pass rows of t { print $1, $2 / 2 }        # awk-style; arithmetic in f64
```

The two spellings are kept **disjoint**, exactly as you proposed: no `as` ⇒ `$N`; `as VAR` ⇒ `VAR[N]`. Each reader has one addressing style, no ambiguity.

## Changes
- **Parser**: a `pass rows of IDENT { BODY }` clause (no `as`) → `pass_rows_anon/2`, tried after the `as` form.
- **Codegen**: a `pass_rows_anon` dispatch maps `$N` (`field(N)`) print fields — plain or arithmetic — to the same `col()`/`arith()` field plans the `rows of … as r` reader uses, reusing the row-decode emitter. Table discovery and the str-valued (row) table set recognise it.

## Tests
`tests/test_plawk_rows_reader.pl` gains `rows_anon_field_addressing`, `rows_anon_parses`, `rows_anon_arith`. Regression green across rows/records readers, row-capture, row-cons, use-table, row-durable, multipass-cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_