### PR TITLE
WAM/LLVM plawk: reader guards (WHERE-style row filter)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -33,8 +33,13 @@ surface, the runtime ABI, and a phased rollout.
   bytes persisted, phase 8.4); self-describing store — schema persisted and
   validated on open (phase 8.7); and `use NAME` to attach to an existing
   store without re-`declare` (phase 8.8).
+- **Reader guards** (a `WHERE`-style row filter): any of the three row readers
+  may wrap its `print` in `if (COND) …`, where `COND` compares a column to an
+  integer literal — `r["col"] CMP int` (records), `r[N] CMP int` (positional),
+  or `$N CMP int` (anon). The six operators are `== != < <= > >=`; filtered
+  rows never reach the print block (`tests/test_plawk_reader_guards.pl`).
 
-**Not yet:** reader guards (a `WHERE`-style row filter); durable rows over the
+**Not yet:** durable rows over the
 LMDB backend; `rows of`'s `unsafe` / inline check-or-rename spec; multiple
 named tables per store (phase 8.9); the `over prev` reader (phase 4
 follow-on); the query reader (phase 6); `eager` / secondary indexes;
@@ -659,7 +664,8 @@ either is taken up.
 constructs line up with pieces we already have: a `do { … }` block is almost
 exactly a `pass { … }` block — a block of actions run (repeatedly) over a
 record stream — and a `while (cond)` clause is essentially a **filter**, a
-narrower cousin of the `WHERE`-style reader guard (§3.9-adjacent): the guard
+narrower cousin of the `WHERE`-style reader guard (now landed — see the Status
+list): the guard
 selects which rows a reader emits, while the `while` selects how long a loop
 continues. That symmetry suggests the eventual `do`/`while` should share the
 guard/condition machinery (a boolean predicate over the current record's
@@ -668,8 +674,8 @@ fields) rather than grow a parallel one.
 ### 3.9 Views (future TODO — brief spec, not planned)
 
 A **view** is a named, derived query over one or more tables — conceptually a
-stored `records of … WHERE … ` (once reader guards, §status, land) with a
-projection. Recorded as a sketch, **not** scheduled.
+stored `records of … WHERE … ` (reader guards have landed; a view would pair
+one with a projection). Recorded as a sketch, **not** scheduled.
 
 Backend-adaptive, mirroring `PLAWK_CACHE_BACKENDS.md`:
 
@@ -879,7 +885,13 @@ single-pass test before any driver surgery).
   `select` surface, no re-`declare` — **LANDED (file backend)**
   (`tests/test_plawk_use_table.pl`); (8.9) multiple named tables per store
   (namespaces / LMDB named sub-DBs, §3.5, per `PLAWK_CACHE_BACKENDS.md`) so
-  `use ns.table` selects among them.
+  `use ns.table` selects among them. (8.10) **reader guards** — a
+  `WHERE`-style row filter on any of the three readers: `if (r["col"] CMP int)`
+  (records), `if (r[N] CMP int)` (positional), `if ($N CMP int)` (anon), for
+  the six operators `== != < <= > >=`. The guard lowers to an i64 field extract
+  + `icmp` + conditional branch, so filtered rows never reach the print block —
+  **LANDED** (`tests/test_plawk_reader_guards.pl`; a guard against a
+  non-integer literal / a boolean combination of guards remain a follow-on).
 
 ## 6. Open questions
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3962,13 +3962,27 @@ plawk_multipass_pass_fn(Index, pass_over(var(Var), var(Table), Body), Tables,
 % -- numeric/other fields fail the clause, so the driver reports unsupported).
 plawk_multipass_pass_fn(Index, pass_records(var(Var), var(Table), Body), Tables,
         _StrArrays, Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
-    Body = [print(PrintFields)],
+    plawk_reader_body(Body, PrintFields, GuardTerm),
     PrintFields = [_ | _],
     memberchk(cache_schema(Table, Columns), Schemas),
     maplist(plawk_records_field_plan(Var, Columns), PrintFields, FieldPlans),
+    plawk_records_guard(GuardTerm, Var, Columns, GuardPlan),
     nth0(TableIndex, Tables, Table),
     plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, FieldPlans,
-        FieldSep, OutputSep, FnIR).
+        GuardPlan, FieldSep, OutputSep, FnIR).
+
+% A row-reader body is either a bare `{ print ... }` or a guarded
+% `{ if (GUARD) print ... }` (a WHERE-style filter). Extract the print fields
+% and the guard term (none when unguarded).
+plawk_reader_body([print(Fields)], Fields, none).
+plawk_reader_body([if(Guard, [print(Fields)], [])], Fields, Guard).
+
+% Resolve a `records of` guard (name column) to guard(ColIndex, Op, Value),
+% the schema position compared to an integer; `none` passes through.
+plawk_records_guard(none, _Var, _Columns, none).
+plawk_records_guard(rcol_cmp(Var, Col, Op, Value), Var, Columns,
+        guard(Index, Op, Value)) :-
+    plawk_records_col_index(Columns, Col, Index).
 
 % Resolve a `records of` print field to a plan: a plain column VAR["col"] ->
 % col(Index) (its 1-based schema position, printed as text), or an arithmetic
@@ -3993,12 +4007,18 @@ plawk_records_col_index(Columns, Col, Index) :-
 % `records of`, just sourcing the field indices from the literal positions.
 plawk_multipass_pass_fn(Index, pass_rows(var(Var), var(Table), Body), Tables,
         _StrArrays, _Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
-    Body = [print(PrintFields)],
+    plawk_reader_body(Body, PrintFields, GuardTerm),
     PrintFields = [_ | _],
     maplist(plawk_rows_field_plan(Var), PrintFields, FieldPlans),
+    plawk_rows_guard(GuardTerm, Var, GuardPlan),
     nth0(TableIndex, Tables, Table),
     plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, FieldPlans,
-        FieldSep, OutputSep, FnIR).
+        GuardPlan, FieldSep, OutputSep, FnIR).
+
+% Resolve a `rows of` guard (positional) -> guard(N, Op, Value); none passes.
+plawk_rows_guard(none, _Var, none).
+plawk_rows_guard(rpos_cmp(Var, N, Op, Value), Var, guard(N, Op, Value)) :-
+    integer(N), N > 0.
 
 % A `rows of` print field: a plain position VAR[N] -> col(N), or arithmetic
 % over positions/constants -> arith(...), evaluated in f64. Positional only.
@@ -4017,12 +4037,18 @@ plawk_rows_operand(_Var, int(V), aint(V)) :- integer(V).
 % sources positions from `field(N)` ($N) rather than `VAR[N]`.
 plawk_multipass_pass_fn(Index, pass_rows_anon(var(Table), Body), Tables,
         _StrArrays, _Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
-    Body = [print(PrintFields)],
+    plawk_reader_body(Body, PrintFields, GuardTerm),
     PrintFields = [_ | _],
     maplist(plawk_rows_anon_field_plan, PrintFields, FieldPlans),
+    plawk_rows_anon_guard(GuardTerm, GuardPlan),
     nth0(TableIndex, Tables, Table),
     plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, FieldPlans,
-        FieldSep, OutputSep, FnIR).
+        GuardPlan, FieldSep, OutputSep, FnIR).
+
+% Resolve a no-`as` guard (`$N CMP int`) -> guard(N, Op, Value); none passes.
+plawk_rows_anon_guard(none, none).
+plawk_rows_anon_guard(rfield_cmp(N, Op, Value), guard(N, Op, Value)) :-
+    integer(N), N > 0.
 
 plawk_rows_anon_field_plan(field(N), col(N)) :- integer(N), N > 0.
 plawk_rows_anon_field_plan(Expr, arith(F64Op, LPlan, RPlan)) :-
@@ -4079,18 +4105,21 @@ forin_after:
 ', [Index, TableParamsIR, TableIndex, TableIndex, BodyIR]).
 
 %% plawk_multipass_records_fn_ir(+Index, +TableParamsIR, +TableIndex,
-%%     +ColIndexes, +FieldSep, +OutputSep, -IR)
+%%     +ColIndexes, +GuardPlan, +FieldSep, +OutputSep, -IR)
 %  The named row reader as a void function: walk the shared table's occupied
 %  slots; for each, the value is the stored row's atom id. Build a row %Value
 %  from it and print the requested columns -- each `r["col"]` resolved to the
 %  column's schema position, extracted as field N of the row via
 %  @wam_atom_field_slice_value (the same field projection the input record
-%  uses), printed as text. Does not open the input; the table is freed by
-%  main.
+%  uses), printed as text. An optional GuardPlan (guard(ColIndex, Op, Value))
+%  gates the print: a WHERE-style filter comparing a column's i64 value to a
+%  constant, only emitting the row when it passes. Does not open the input;
+%  the table is freed by main.
 plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, ColIndexes,
-        FieldSep, OutputSep, IR) :-
+        GuardPlan, FieldSep, OutputSep, IR) :-
     phrase(plawk_records_col_lines(ColIndexes, FieldSep, OutputSep, 0), ColLines),
     atomic_list_concat(ColLines, '\n', ColIR),
+    plawk_records_guard_ir(GuardPlan, FieldSep, GuardIR),
     format(atom(IR),
 'define void @plawk_pass_~w(%Value %mp_path~w) {
 entry:
@@ -4107,6 +4136,9 @@ rec_body:
   %rec_row_v0 = insertvalue %Value undef, i32 0, 0
   %rec_row_v = insertvalue %Value %rec_row_v0, i64 %rec_row_id, 1
 ~w
+
+rec_print:
+~w
   %rec_printed_newline = call i32 @putchar(i32 10)
   br label %rec_body_done
 
@@ -4117,7 +4149,29 @@ rec_body_done:
 rec_after:
   ret void
 }
-', [Index, TableParamsIR, TableIndex, TableIndex, ColIR]).
+', [Index, TableParamsIR, TableIndex, TableIndex, GuardIR, ColIR]).
+
+%% plawk_records_guard_ir(+GuardPlan, +FieldSep, -IR)
+%  The transition out of rec_body: unguarded readers fall straight into
+%  rec_print; a guard extracts its column as i64 (@wam_atom_field_i64_value on
+%  the row %Value), compares to the constant, and branches to rec_print or
+%  skips the row (rec_body_done).
+plawk_records_guard_ir(none, _FieldSep, '  br label %rec_print').
+plawk_records_guard_ir(guard(ColIndex, Op, Value), FieldSep, IR) :-
+    plawk_icmp_pred(Op, Pred),
+    format(atom(IR),
+'  %rec_gv = call i64 @wam_atom_field_i64_value(%Value %rec_row_v, i64 ~w, i8 ~w)
+  %rec_gcmp = icmp ~w i64 %rec_gv, ~w
+  br i1 %rec_gcmp, label %rec_print, label %rec_body_done',
+        [ColIndex, FieldSep, Pred, Value]).
+
+% Surface comparison op -> signed LLVM icmp predicate.
+plawk_icmp_pred(eq, eq).
+plawk_icmp_pred(ne, ne).
+plawk_icmp_pred(lt, slt).
+plawk_icmp_pred(le, sle).
+plawk_icmp_pred(gt, sgt).
+plawk_icmp_pred(ge, sge).
 
 %% plawk_records_col_lines(+FieldPlans, +FieldSep, +OutputSep, +PrintIndex)//
 %  Per-field print for the row readers: a separator before each field after

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1198,6 +1198,25 @@ forin_guard(forin_val_cmp(Array, LoopVar, Op, Value)) -->
 forin_guard(forin_key_cmp(LoopVar, Op, Value)) -->
     identifier(LoopVar), ws, numeric_cmp_op(Op), ws,
     signed_integer_value(Value).
+% Reader guards (row readers, a WHERE-style filter): a column compared to an
+% integer. Named `r["col"] CMP int`, positional `r[N] CMP int`, or awk-field
+% `$N CMP int`. Distinct functors so the reader dispatch resolves the column;
+% the for-in planner does not generate them. Tried after the for-in forms
+% (which fail cleanly on a non-identifier key / `$`, then backtrack here).
+forin_guard(rcol_cmp(Var, Col, Op, Value)) -->
+    identifier(Var), ws, "[", ws, quoted_string(CCodes), ws, "]", ws,
+    numeric_cmp_op(Op), ws, signed_integer_value(Value),
+    { string_codes(Col, CCodes) },
+    !.
+forin_guard(rpos_cmp(Var, N, Op, Value)) -->
+    identifier(Var), ws, "[", ws, integer_codes(NCodes), ws, "]", ws,
+    numeric_cmp_op(Op), ws, signed_integer_value(Value),
+    { NCodes \== [], number_codes(N, NCodes), N > 0 },
+    !.
+forin_guard(rfield_cmp(N, Op, Value)) -->
+    "$", integer_codes(NCodes), ws,
+    numeric_cmp_op(Op), ws, signed_integer_value(Value),
+    { NCodes \== [], number_codes(N, NCodes), N > 0 }.
 
 actions([Action | Actions]) -->
     action(Action),

--- a/tests/test_plawk_reader_guards.pl
+++ b/tests/test_plawk_reader_guards.pl
@@ -1,0 +1,147 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk reader guards (PLAWK_MULTIPASS_CACHE.md): a WHERE-style row filter on
+% the three row readers. `pass records of T as r { if (r["col"] CMP int) print
+% ... }` emits only rows whose column satisfies the numeric comparison; the
+% positional (`rows of T as r`, `r[N]`) and awk-native anonymous (`rows of T`,
+% `$N`) readers get the same guard. The comparison value is an integer literal
+% and the six operators are ==, !=, <, <=, >, >=. The guard is compiled to an
+% i64 field extraction + icmp + conditional branch, so filtered rows never
+% reach the print block.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_reader_guards).
+
+% --- parse -----------------------------------------------------------------
+
+% A records guard parses to an if/rcol_cmp wrapping the print.
+test(records_guard_parses) :-
+    plawk_parse_string(
+        "pass records of orders as r { if (r[\"amt\"] > 100) print r[\"cust\"] }\n",
+        program_passes([],
+            [pass_records(var(r), var(orders),
+                [if(rcol_cmp(r, "amt", gt, 100),
+                    [print([assoc(var(r), string("cust"))])], [])])],
+            [])),
+    !.
+
+% A positional guard parses to rpos_cmp.
+test(rows_guard_parses) :-
+    plawk_parse_string(
+        "pass rows of t as r { if (r[2] > 5) print r[1] }\n",
+        program_passes([],
+            [pass_rows(var(r), var(t),
+                [if(rpos_cmp(r, 2, gt, 5),
+                    [print([assoc(var(r), int(1))])], [])])],
+            [])),
+    !.
+
+% An anonymous `$N` guard parses to rfield_cmp.
+test(anon_guard_parses) :-
+    plawk_parse_string(
+        "pass rows of t { if ($2 >= 10) print $1 }\n",
+        program_passes([],
+            [pass_rows_anon(var(t),
+                [if(rfield_cmp(2, ge, 10),
+                    [print([field(1)])], [])])],
+            [])),
+    !.
+
+% --- records-by-name guard -------------------------------------------------
+
+% `records of` with a column-name guard: over a schema'd store, print the cust
+% column only for rows whose amt > 100.
+test(records_guard_filters, [condition(clang_available)]) :-
+    gdir(Dir),
+    directory_file_path(Dir, 'g.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare orders(cust str, amt str) }\n\c
+         pass { orders[$1] = row($1, $2) }\n\c
+         pass records of orders as r { if (r[\"amt\"] > 100) print r[\"cust\"] }\n",
+        [Store]),
+    run_sorted(Dir, 'grec', Src, "alice 150\nbob 50\ncarol 200\n", S),
+    assertion(S == ["alice", "carol"]),
+    !.
+
+% --- positional guard ------------------------------------------------------
+
+% `rows of ... as r` with an r[N] guard: r[2] > 5.
+test(rows_guard_filters, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t as r { if (r[2] > 5) print r[1] }\n",
+    run_sorted(Dir, 'grows', Src, "a 10\nb 5\nc 20\n", S),
+    assertion(S == ["a", "c"]),
+    !.
+
+% --- anonymous `$N` guard --------------------------------------------------
+
+% `rows of` (no `as`) with a $N guard: $2 >= 10.
+test(anon_guard_filters, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t { if ($2 >= 10) print $1 }\n",
+    run_sorted(Dir, 'ganon', Src, "a 10\nb 5\nc 20\n", S),
+    assertion(S == ["a", "c"]),
+    !.
+
+% --- all six comparison operators (via the anon reader) --------------------
+
+test(op_lt, [condition(clang_available)]) :-
+    op_result("$2 < 10", S), assertion(S == ["b"]).
+test(op_le, [condition(clang_available)]) :-
+    op_result("$2 <= 5", S), assertion(S == ["b"]).
+test(op_gt, [condition(clang_available)]) :-
+    op_result("$2 > 10", S), assertion(S == ["c"]).
+test(op_ge, [condition(clang_available)]) :-
+    op_result("$2 >= 10", S), assertion(S == ["a", "c"]).
+test(op_eq, [condition(clang_available)]) :-
+    op_result("$2 == 20", S), assertion(S == ["c"]).
+test(op_ne, [condition(clang_available)]) :-
+    op_result("$2 != 10", S), assertion(S == ["b", "c"]).
+
+:- end_tests(plawk_reader_guards).
+
+% --- helpers ---------------------------------------------------------------
+
+op_result(Cond, Sorted) :-
+    gdir(Dir),
+    format(atom(Src),
+        "pass { t[$1] = $0 }\npass rows of t { if (~w) print $1 }\n", [Cond]),
+    run_sorted(Dir, 'gop', Src, "a 10\nb 5\nc 20\n", Sorted).
+
+gdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_reader_guards', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Summary

Adds a **WHERE-style row filter** to all three row readers: a stored row is emitted only when a column satisfies a numeric comparison against an integer literal. This is the query capability on top of the phase-8 row store.

```awk
pass records of orders as r { if (r["amt"] > 100) print r["cust"] }   # by name
pass rows    of t      as r { if (r[2]     > 5)   print r[1]      }   # positional
pass rows    of t             { if ($2      >= 10) print $1        }   # awk-native $N
```

Supported operators: `== != < <= > >=`.

## What changed

- **Parser** (`plawk_parser.pl`): three guard functors under `forin_guard` — `rcol_cmp` (named column `r["col"]`), `rpos_cmp` (positional `r[N]`), `rfield_cmp` (awk-native `$N`) — each comparing a column to a signed integer. They sit after the existing for-in guard forms and backtrack in cleanly (the for-in forms fail on a non-identifier key / `$` and fall through).
- **Codegen** (`plawk_native_codegen.pl`): `plawk_reader_body/3` splits a reader body into `(print-fields, guard)`; per-reader resolvers lower the guard to `guard(ColIndex, Op, Value)`. The row-reader function gains a guard block between `rec_body` and a new `rec_print` label — it extracts the column as i64 via `@wam_atom_field_i64_value`, compares with a signed `icmp`, and branches to `rec_print` or skips the row, so filtered rows never reach the print/newline. Unguarded readers fall straight through (`br label %rec_print`).
- **Tests** (`tests/test_plawk_reader_guards.pl`): parse tests for each guard shape; end-to-end filtering for records / positional / anon readers; all six operators exercised via the anon reader.
- **Docs** (`PLAWK_MULTIPASS_CACHE.md`): Status list + phase 8.10; the `do`/`while` and views notes updated now that the WHERE-style guard has landed.

## Testing

- `tests/test_plawk_reader_guards.pl` — 12/12 pass.
- Regressions green: `records_reader`, `rows_reader`, `row_cons`, `row_schema`, `row_durable`, `use_table`, `multipass_cache`.

## Follow-ons (noted in the doc)

Guards against a non-integer literal, and boolean combinations of guards (`&&`/`||`), remain future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_