### PR TITLE
docs: bounded-multiplicity principle (new principles doc) + call-mode refinement

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -139,7 +139,11 @@ END   { }
 
 **So the invariant we must not break:** *within the iteration brackets, work
 is deterministic.* Backtracking is "contained and annotated" (the Haskell
-`IO`-monad analogy), never the default in the hot loop.
+`IO`-monad analogy), never the default in the hot loop. This is the general
+**bounded-multiplicity** principle — contain non-determinism by collapsing it
+at a boundary, the same shape as SQL `GROUP BY`, Prolog `findall`, and list
+comprehensions; stated once in `UNIFYWEAVER_LANGUAGE_PRINCIPLES.md` (Principle
+1) and applied throughout this doc.
 
 ### 1.1 Cross-iteration information under that invariant
 
@@ -390,7 +394,10 @@ multi-valued, and therefore exactly the nondeterminism §1 insists be
 aggregation** that collapses the set to a deterministic value or a
 deterministically-ordered array; using it raw (as a scalar) is a
 compile-time error. This is not just ergonomics — it is what keeps the
-multi-valued lookup from leaking a choicepoint into the hot loop.
+multi-valued lookup from leaking a choicepoint into the hot loop. It is the
+**bounded-multiplicity** principle in its SQL `GROUP BY` form — a set collapsed
+by an aggregate at a boundary (`UNIFYWEAVER_LANGUAGE_PRINCIPLES.md`, Principle
+1).
 
 ```awk
 # unique index: one record
@@ -693,7 +700,9 @@ values. So a loop does not hand back *non-determinism*; it hands back the
 enumerate-until — but under explicit, deterministic, step-by-step control. A
 Prolog solver explores a solution space implicitly; a `while` lets you do the
 same thing by hand. This is the same containment as Phase 6's aggregation
-rule, seen from the other side: a multi-solution goal is tamed either by
+rule (the bounded-multiplicity principle,
+`UNIFYWEAVER_LANGUAGE_PRINCIPLES.md`), seen from the other side: a
+multi-solution goal is tamed either by
 **folding it** (`collect`/`count` → one value, enumeration implicit) or by
 **looping over it** (enumeration explicit, one deterministic step at a time).
 The cost the loop pays is exactly the boundedness it drops: the
@@ -823,6 +832,25 @@ boundary**. Concretely:
    solved search flows into ordinary plawk values. In type terms, "unbound
    logic var" is a distinct kind that the collapse operators are the only way
    to eliminate.
+
+**What actually triggers the non-determinism (and where it must live).** The
+`where` is a **list comprehension**: `collect (A, B) where { A in nodes(g); B in
+nodes(g); adjacent(A, B) }` is exactly Haskell's `[ (a,b) | a <- nodes, b <-
+nodes, adjacent a b ]`. So it is worth being precise about which piece carries
+the non-determinism. It is **not** the collapse keyword — `collect` is the
+*eliminator* (one of `find`/`the`/`count`/`forall`), chosen for *how* to fold
+the solution set. The **producers** are the generators (`A in …`) and any
+multi-solution goal. Crucially, a goal's multiplicity is a property of its
+**mode**, not the predicate: `adjacent(A, B)` with both unbound *generates*
+pairs, `adjacent(a, B)` *extends* one, `adjacent(a, b)` is a yes/no *test*. So
+the rule is enforced by mode analysis (`demand_analysis` /
+`binding_state_analysis`, §1): a call carrying an **unbound logic variable** —
+the only calls that can backtrack — must sit inside the `where`. The same
+predicate called all-ground is an ordinary deterministic test, callable
+anywhere. That relation-run-backwards (a test used as a generator) is the extra
+power the search has over a plain comprehension guard. This is Principle 1 of
+`UNIFYWEAVER_LANGUAGE_PRINCIPLES.md` (bounded multiplicity) in its
+Prolog/comprehension form.
 
 **Termination.** A general `while` (§3.8) is deterministic but may not
 terminate. This search is the mirror image: non-deterministic but **bounded

--- a/docs/design/UNIFYWEAVER_LANGUAGE_PRINCIPLES.md
+++ b/docs/design/UNIFYWEAVER_LANGUAGE_PRINCIPLES.md
@@ -1,0 +1,119 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2026 John William Creighton (@s243a)
+-->
+
+# UnifyWeaver language principles
+
+**Status**: living document. A catalog of the *language-design* principles that
+recur across UnifyWeaver's surfaces (plawk, the query/cache layer, the WAM
+targets) and how each maps onto established programming traditions — SQL,
+Prolog, functional (Haskell), and imperative (Python). The point is not novelty
+but *coherence*: when the same principle shows up in four idioms, adopting its
+well-understood form keeps our surfaces predictable and lets us borrow the laws
+those idioms already proved.
+
+Each principle is stated once here and *referenced* from the design docs where
+it is applied, so the rationale lives in one place.
+
+---
+
+## Principle 1 — Bounded multiplicity: contain non-determinism by collapsing it at a boundary
+
+**Statement.** Wherever a construct can yield *many* answers — a set of matching
+rows, a goal with several proofs, a generator over a domain — that multiplicity
+must be **collapsed to a deterministic value at a syntactic boundary** before it
+flows into ordinary (imperative, single-valued) code. Multiplicity is allowed to
+*exist* only inside a bounded scope, and a **collapse operator** both opens that
+scope and closes it. Raw use of a multi-valued result as if it were a scalar is
+an error, not a convenience.
+
+This is the single idea behind UnifyWeaver's determinism stance: *"backtracking
+is contained and annotated, never the default in the hot loop"*
+(`PLAWK_PHILOSOPHY.md §2`, `PLAWK_MULTIPASS_CACHE.md §1`). "Bounded multiplicity"
+is that stance named as a reusable rule.
+
+### The same principle, four idioms
+
+| tradition | the multiplicity | the collapse (the boundary) | raw use |
+|---|---|---|---|
+| **SQL** | rows in a group | `GROUP BY` + an aggregate (`COUNT`, `SUM`, `array_agg`) | selecting a non-grouped, non-aggregated column is an error |
+| **Prolog** | a goal's solution set | `findall/3`, `aggregate_all/3`, `forall/2` (encapsulated search) | a nondet goal left in a det context leaks a choicepoint |
+| **functional (Haskell)** | the list monad | a list comprehension `[ e \| x <- xs, p x ]` / `concatMap` | — (the type *is* the list; the comprehension is the boundary) |
+| **imperative (Python)** | a generator / iterable | `[e for x in xs if p]`, `sum(...)`, `any(...)` | consuming a generator where a scalar is expected |
+
+They are not analogies — they are the same construct. A SQL `GROUP BY … COUNT`,
+a Prolog `aggregate_all(count, Goal, N)`, a Haskell `length [ () | x <- xs, p x
+]`, and a Python `sum(1 for x in xs if p(x))` compute the identical thing by the
+identical shape: **generate a multiplicity, prune it, fold it to one value.**
+
+### The unifying shape: producer / scope / eliminator
+
+Every instance decomposes into three parts, and naming them avoids the common
+confusion that the *eliminator keyword* is what "creates" the non-determinism:
+
+- **Producers** — what introduces multiplicity: a generator drawing from a
+  domain (`x <- xs`, `FROM table`, `X in domain`), or a relation/goal with more
+  than one solution.
+- **Scope** — the brackets in which multiplicity may exist: the comprehension
+  body, the `WHERE`/`GROUP BY`, the encapsulated-search goal, plawk's `where`.
+- **Eliminator (collapse operator)** — what consumes the scope and yields a
+  deterministic result: `collect`/`findall` (all → array), `find` (first),
+  `the` (require exactly one), `count`/`sum`/`min`/`max` (fold → scalar),
+  `forall` (universal test → boolean).
+
+The eliminator is chosen for *how* to collapse; the producers are where the
+non-determinism actually lives. "`collect` triggers the non-determinism" is
+backwards — `collect` is the *eliminator*; the generators are the trigger.
+
+### Refinement: multiplicity is a property of the *call*, not the *function*
+
+A predicate is not statically "deterministic" or "non-deterministic." Its
+multiplicity depends on its **mode** — which arguments are bound at the call.
+`adjacent(A, B)` with both unbound *generates* pairs; `adjacent(a, B)` *extends*
+one; `adjacent(a, b)` is a yes/no *test*. So the rule "multiplicity must be
+collapsed at a boundary" is enforced not by coloring functions but by **mode
+analysis** (`demand_analysis` / `binding_state_analysis`): a call carrying an
+unbound logic variable — the only calls that can backtrack — is precisely the
+one that must sit inside a collapse scope. A relation used "backwards" (a test
+run as a generator) is the extra power Prolog has over a comprehension guard,
+and it is exactly the power the mode determines.
+
+Equivalently, the three faces of the plawk containment rule are one statement:
+
+> "multiplicity must be collapsed at a boundary"
+> = "unbound logic variables must live inside a `where`"
+> = "no choicepoint escapes an iteration bracket."
+
+### Why it matters (not just tidiness)
+
+The boundary is a *performance* invariant, not a style rule. UnifyWeaver streams
+in constant memory because per-record state lives in native SSA slots, not a
+managed heap. A multiplicity that escaped its scope would force the engine to
+retain choicepoints (and the trail/heap they pin) *across* records — turning the
+constant-memory loop into one that grows with the input
+(`PLAWK_MULTIPASS_CACHE.md §1`). Collapsing at the boundary is what guarantees
+the hot loop stays choicepoint-free.
+
+### Where this principle is applied in UnifyWeaver
+
+- **The determinism model** — `PLAWK_MULTIPASS_CACHE.md §1`, `PLAWK_PHILOSOPHY.md
+  §2`: the per-record body is deterministic by default; backtracking is
+  contained and annotated.
+- **Non-unique secondary indexes** — `PLAWK_MULTIPASS_CACHE.md §3.5` (Phase 7):
+  a non-unique lookup matches a *set*, so it **must** be consumed by an
+  aggregation (`collect` → array, `count`, `sum`/`min`/`max`); raw scalar use is
+  a compile-time error. This is the SQL `GROUP BY` face.
+- **Reader guards** — `PLAWK_MULTIPASS_CACHE.md` (landed): the `WHERE`-style row
+  filter is the *prune* step of the shape, applied to a row reader.
+- **Loops vs determinism** — `PLAWK_MULTIPASS_CACHE.md §3.8`: a `while` re-adds
+  *unboundedness*, not multiplicity; it lets you enumerate a solution set by
+  hand (explicit collapse) instead of folding it (implicit collapse).
+- **The contained-search sketch** — `PLAWK_MULTIPASS_CACHE.md §3.10`: the
+  future `collect (…) where { … }` construct is this principle made into a
+  first-class surface — the Prolog/comprehension face, with the collapse
+  operator as the boundary.
+
+---
+
+*Add further principles below as they recur across surfaces.*


### PR DESCRIPTION
## Summary

Documentation-only. Promotes the cross-language theory from the recent design discussion into a standalone, referenceable principles document, and cross-links it from every place the principle is applied.

## New: `UNIFYWEAVER_LANGUAGE_PRINCIPLES.md`

A living catalog of the *language-design* principles that recur across UnifyWeaver's surfaces (plawk, the query/cache layer, the WAM targets) and how each maps onto SQL, Prolog, functional (Haskell), and imperative (Python) traditions. First entry:

**Principle 1 — Bounded multiplicity: contain non-determinism by collapsing it at a boundary.** Wherever a construct can yield *many* answers, that multiplicity must be collapsed to a deterministic value at a syntactic boundary before it flows into ordinary single-valued code. The doc shows this is one construct in four idioms:

| tradition | multiplicity | collapse |
|---|---|---|
| SQL | rows in a group | `GROUP BY` + aggregate |
| Prolog | a goal's solution set | `findall` / `aggregate_all` / `forall` |
| Haskell | the list monad | list comprehension |
| Python | a generator | comprehension / `sum` / `any` |

It names the unifying shape — **producer / scope / eliminator** — so the eliminator keyword (`collect`) isn't mistaken for the trigger, and adds the key refinement: **a call's multiplicity is a property of its mode** (which args are bound), enforced by mode analysis, not a static coloring of the predicate. It records where the principle is already applied and why the boundary is a performance invariant (choicepoints must not leak into the constant-memory hot loop), not tidiness.

## Cross-references added to `PLAWK_MULTIPASS_CACHE.md`

- **§1** determinism invariant → the general principle.
- **§3.5** non-unique secondary-index aggregation → its SQL `GROUP BY` face.
- **§3.8** loops-vs-determinism note → the principle by name.
- **§3.10** search sketch → a new paragraph pinning down the exact list-comprehension equivalence (`collect (A,B) where {…}` = `[ (a,b) | a <- …, b <- …, adjacent a b ]`) and the call-mode rule: `collect` is the *eliminator*; generators and unbound logic vars are the trigger; **mode** decides whether a goal generates or tests.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_