### PR TITLE
WAM/LLVM plawk: durable rows over the LMDB backend

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -29,8 +29,8 @@ surface, the runtime ABI, and a phased rollout.
   `TABLE[$k] = $0` and `TABLE[$k] = row($a, $b)`; readers `records of TABLE
   as r` (`r["col"]`, by schema name), `rows of TABLE as r` (`r[N]`, by
   position), and `rows of TABLE` (no `as` → awk-native `$N`); column
-  arithmetic in f64 (`r["amt"] / 2`); durable rows on the file backend (row
-  bytes persisted, phase 8.4); self-describing store — schema persisted and
+  arithmetic in f64 (`r["amt"] / 2`); durable rows on the file **and LMDB**
+  backends (row bytes persisted, phase 8.4); self-describing store — schema persisted and
   validated on open (phase 8.7); and `use NAME` to attach to an existing
   store without re-`declare` (phase 8.8).
 - **Reader guards** (a `WHERE`-style row filter): any of the three row readers
@@ -39,9 +39,10 @@ surface, the runtime ABI, and a phased rollout.
   or `$N CMP int` (anon). The six operators are `== != < <= > >=`; filtered
   rows never reach the print block (`tests/test_plawk_reader_guards.pl`).
 
-**Not yet:** durable rows over the
-LMDB backend; `rows of`'s `unsafe` / inline check-or-rename spec; multiple
-named tables per store (phase 8.9); the `over prev` reader (phase 4
+**Not yet:** `use NAME` over an LMDB store (the build-time schema resolver
+reads the file-backend header, not the LMDB schema key — a follow-on; `declare`
+works over LMDB today); `rows of`'s `unsafe` / inline check-or-rename spec;
+multiple named tables per store (phase 8.9); the `over prev` reader (phase 4
 follow-on); the query reader (phase 6); `eager` / secondary indexes;
 string-literal print fields. Future sketches: nested pass blocks (§3.8),
 `while`/loop statements (§3.8), views (§3.9), contained non-determinism / a
@@ -524,14 +525,19 @@ TABLE as k`, or `records of` / `rows of`). Field-wise writes
 
 **In-run and durable.** A row value is an atom **id** (process-local), so the
 plain i64 cache — which persists the id — cannot restore a row in a fresh
-process. On the **file** backend a str-valued (row) table therefore commits
-the value **bytes** (`@wam_cache_commit_str`) and re-interns them on load
-(`@wam_cache_load_str`), so rows are **durable across runs** (phase 8.4,
-`tests/test_plawk_row_durable.pl`): a reader pass in a later run sees rows a
-prior run committed. Keys stay i64 ids (content-stable interning reproduces
-them; readers only iterate, and a re-writing pass re-interns the same key).
-Durable str values over the **LMDB** backend remain a follow-on (an lmdb row
-table currently rides the i64 lmdb path, i.e. in-run only).
+process. A str-valued (row) table therefore commits the value **bytes** and
+re-interns them on load, so rows are **durable across runs** (phase 8.4). This
+holds on **both** backends: the file backend uses `@wam_cache_commit_str` /
+`@wam_cache_load_str` (`tests/test_plawk_row_durable.pl`), and the **LMDB**
+backend uses `wam_cache_commit_lmdb_str` / `wam_cache_load_lmdb_str`
+(`tests/test_plawk_row_durable_lmdb.pl`), which `mdb_put` the row bytes under
+the i64 key and store the declared schema under a distinguished non-8-byte key
+(validated on open; data rows are skipped-by-size). A reader pass in a later
+run sees rows a prior run committed. Keys stay i64 ids (content-stable
+interning reproduces them; readers only iterate, and a re-writing pass
+re-interns the same key). One gap remains on LMDB: `use NAME` (attach without
+re-`declare`) needs a build-time resolver that reads the LMDB schema key —
+`declare` works over LMDB today.
 
 **Phasing** (each its own PR):
 1. **Schema surface** — `declare NAME(col type, …)` parses and carries a row
@@ -545,10 +551,12 @@ table currently rides the i64 lmdb path, i.e. in-run only).
    that field of the stored row; an unknown column is unsupported (clean
    compile-time failure). In-run (rides the row-capture writer's storage).
 4. **Byte-valued cache storage** — durable rows across runs (store row bytes,
-   not the id). **LANDED (file backend)** (`tests/test_plawk_row_durable.pl`):
-   a str-valued (row) table on the file backend commits the value BYTES
-   (`@wam_cache_commit_str`) and re-interns them on load
-   (`@wam_cache_load_str`), so a row committed by one run is read by a later
+   not the id). **LANDED (file + LMDB backends)**
+   (`tests/test_plawk_row_durable.pl`, `tests/test_plawk_row_durable_lmdb.pl`):
+   a str-valued (row) table commits the value BYTES and re-interns them on load
+   — the file backend via `@wam_cache_commit_str` / `@wam_cache_load_str`, LMDB
+   via `wam_cache_commit_lmdb_str` / `wam_cache_load_lmdb_str` — so a row
+   committed by one run is read by a later
    run — proven with a reader-pass-then-writer program run twice. Keys stay
    i64 ids (content-stable interning reproduces them). Durable str values over
    the **LMDB** backend remain a follow-on (an lmdb row table currently rides
@@ -1071,9 +1079,12 @@ single-pass test before any driver surgery).
   TABLE` — **LANDED** (`tests/test_plawk_row_capture.pl`); (8.3) the safe
   `records of TABLE as r` reader with name-only `r["col"]` decode by schema —
   **LANDED** (`tests/test_plawk_records_reader.pl`); (8.4) byte-valued cache
-  storage for durable rows across runs — **LANDED (file backend)**
-  (`tests/test_plawk_row_durable.pl`; LMDB durable rows are a follow-on);
-  (8.5) the positional `rows of`
+  storage for durable rows across runs — **LANDED (file + LMDB backends)**
+  (`tests/test_plawk_row_durable.pl` for the file backend,
+  `tests/test_plawk_row_durable_lmdb.pl` for LMDB via
+  `wam_cache_{commit,load}_lmdb_str` — schema stored under a distinguished key
+  and validated on open; `use NAME` over an LMDB store still awaits a
+  build-time LMDB schema resolver); (8.5) the positional `rows of`
   reader (`r[N]`, no schema) — **LANDED**
   (`tests/test_plawk_rows_reader.pl`; its `unsafe` / inline check-or-rename
   spec remain a follow-on); (8.6) richer row producers (`row(...)` /

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -6068,11 +6068,14 @@ plawk_program_cache_tables(BeginClauses, Triples) :-
 %  The runtime function for a cache Op (load|commit) under a backend and value
 %  kind. A str-valued (row) table on the `file` backend uses the byte-valued
 %  helpers so the row bytes survive across runs (an i64 store would persist a
-%  process-local atom id). i64 tables use the plain file helpers. `lmdb` uses
-%  the external C functions (durable str values over lmdb are a follow-on, so
-%  an lmdb str table currently rides the i64 lmdb path).
+%  process-local atom id). i64 tables use the plain file helpers. `lmdb` has
+%  both: a str-valued (row) table uses the byte-valued external C helpers
+%  (`_lmdb_str`, which store the row bytes + a validated schema entry), while
+%  an i64 table uses the plain `_lmdb` helpers.
 plawk_cache_fn(file, load, str, wam_cache_load_str) :- !.
 plawk_cache_fn(file, commit, str, wam_cache_commit_str) :- !.
+plawk_cache_fn(lmdb, load, str, wam_cache_load_lmdb_str) :- !.
+plawk_cache_fn(lmdb, commit, str, wam_cache_commit_lmdb_str) :- !.
 plawk_cache_fn(lmdb, load, _Kind, wam_cache_load_lmdb) :- !.
 plawk_cache_fn(lmdb, commit, _Kind, wam_cache_commit_lmdb) :- !.
 plawk_cache_fn(_File, load, _Kind, wam_cache_load).
@@ -6111,8 +6114,14 @@ plawk_cache_entries(Tables, StrArrays, Schemas, Triples, CacheEntries, PathGloba
         Pairs),
     pairs_keys_values(Pairs, CacheEntries, Globals),
     ( memberchk(cache(_, _, lmdb, _, _), CacheEntries)
-    ->  LmdbDecls = ['declare void @wam_cache_load_lmdb(%WamAssocI64Table*, i8*)',
-                     'declare void @wam_cache_commit_lmdb(%WamAssocI64Table*, i8*)']
+    ->  BaseLmdbDecls = ['declare void @wam_cache_load_lmdb(%WamAssocI64Table*, i8*)',
+                         'declare void @wam_cache_commit_lmdb(%WamAssocI64Table*, i8*)'],
+        ( memberchk(cache(_, _, lmdb, str, _), CacheEntries)
+        ->  StrLmdbDecls = ['declare void @wam_cache_load_lmdb_str(%WamAssocI64Table*, i8*, i8*)',
+                            'declare void @wam_cache_commit_lmdb_str(%WamAssocI64Table*, i8*, i8*)']
+        ;   StrLmdbDecls = []
+        ),
+        append(BaseLmdbDecls, StrLmdbDecls, LmdbDecls)
     ;   LmdbDecls = []
     ),
     append(Globals, LmdbDecls, AllGlobals),
@@ -6127,10 +6136,12 @@ plawk_schema_string(Columns, Str) :-
     atomic_list_concat(Parts, ',', Str).
 
 %% plawk_cache_call_ir(+Fn, +Index, +BytesLen, +ValueKind, +SchemaRef, -Line)
-%  A load/commit call. The byte-valued (str) file helpers take an extra i8*
-%  schema argument (a getelementptr or null); the i64 / lmdb helpers do not.
+%  A load/commit call. The byte-valued (str) helpers -- both the file
+%  (`_str`) and lmdb (`_lmdb_str`) variants -- take an extra i8* schema
+%  argument (a getelementptr or null); the plain i64 / i64-lmdb helpers do not.
 plawk_cache_call_ir(Fn, Index, BytesLen, str, SchemaRef, Line) :-
-    ( Fn == wam_cache_load_str ; Fn == wam_cache_commit_str ),
+    ( Fn == wam_cache_load_str ; Fn == wam_cache_commit_str
+    ; Fn == wam_cache_load_lmdb_str ; Fn == wam_cache_commit_lmdb_str ),
     !,
     format(atom(Line),
         '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0), i8* ~w)',

--- a/src/unifyweaver/targets/wam_cache_lmdb.c
+++ b/src/unifyweaver/targets/wam_cache_lmdb.c
@@ -22,6 +22,9 @@
 #include <lmdb.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 /* The runtime's assoc-table helpers (defined as LLVM IR in the same
  * binary). The table pointer is opaque here; we only thread it through. */
@@ -29,6 +32,14 @@ extern int64_t wam_assoc_i64_set(void *table, int64_t key, int64_t value);
 extern int64_t wam_assoc_i64_iter_next(void *table, int64_t start);
 extern int64_t wam_assoc_i64_key_at(void *table, int64_t idx);
 extern int64_t wam_assoc_i64_value_at(void *table, int64_t idx);
+
+/* Atom-registry helpers (also LLVM IR in the same binary), for byte-valued
+ * (row) tables: resolve a process-local value id to its bytes and back. Used
+ * only by the _str variants below -- the durable form stores the row bytes,
+ * not the id, so rows survive across runs (mirrors the file backend's
+ * @wam_cache_commit_str / _load_str). */
+extern const char *wam_atom_to_string(int64_t id);
+extern int64_t wam_intern_atom(const char *bytes, int64_t len);
 
 /* 1 GiB map ceiling -- generous for a scratch/aggregation store; the file
  * grows only as needed. A later knob can make this configurable. */
@@ -93,5 +104,85 @@ void wam_cache_commit_lmdb(void *table, const char *path) {
         cursor = slot + 1;
     }
     mdb_txn_commit(txn);
+    mdb_env_close(env);
+}
+
+/* ---- byte-valued (row) LMDB store ---------------------------------------
+ * A str-valued (row) table stores an atom id as its i64 value, and that id is
+ * process-local -- so the plain i64 path above (which persists the id) does
+ * not survive across runs. These variants store the VALUE BYTES instead:
+ * commit resolves each value id to its bytes; load re-interns the bytes to a
+ * fresh id. Keys stay i64. The schema (when the program declares one) is
+ * stored under a distinguished non-8-byte key and validated on open, matching
+ * the file backend's self-describing store; data rows are the 8-byte keys, so
+ * the schema entry is skipped by size on load. */
+static const char WAM_LMDB_SCHEMA_KEY[] = "__wam_schema__";
+#define WAM_LMDB_SCHEMA_KEYLEN 14  /* strlen(WAM_LMDB_SCHEMA_KEY), != 8 */
+
+void wam_cache_commit_lmdb_str(void *table, const char *path,
+                               const char *schema) {
+    MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
+    int64_t cursor = 0, slot;
+    if (wam_cache_lmdb_env(path, 0, &env)) return;
+    if (mdb_txn_begin(env, NULL, 0, &txn)) { mdb_env_close(env); return; }
+    if (mdb_dbi_open(txn, NULL, 0, &dbi)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
+    if (schema) {
+        MDB_val sk = { WAM_LMDB_SCHEMA_KEYLEN, (void *)WAM_LMDB_SCHEMA_KEY };
+        MDB_val sv = { strlen(schema), (void *)schema };
+        mdb_put(txn, dbi, &sk, &sv, 0);
+    }
+    while ((slot = wam_assoc_i64_iter_next(table, cursor)) >= 0) {
+        int64_t key = wam_assoc_i64_key_at(table, slot);
+        int64_t vid = wam_assoc_i64_value_at(table, slot);
+        const char *vptr = wam_atom_to_string(vid);
+        MDB_val k = { sizeof(int64_t), &key };
+        MDB_val v = { strlen(vptr), (void *)vptr };
+        mdb_put(txn, dbi, &k, &v, 0);
+        cursor = slot + 1;
+    }
+    mdb_txn_commit(txn);
+    mdb_env_close(env);
+}
+
+void wam_cache_load_lmdb_str(void *table, const char *path,
+                             const char *schema) {
+    MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
+    MDB_cursor *cur;
+    MDB_val k, v;
+    if (wam_cache_lmdb_env(path, MDB_RDONLY, &env)) return;
+    if (mdb_txn_begin(env, NULL, MDB_RDONLY, &txn)) { mdb_env_close(env); return; }
+    if (mdb_dbi_open(txn, NULL, 0, &dbi)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
+    /* Validate the stored schema against the program's (when both present),
+     * exactly like the file backend: mismatch is a loud, non-zero exit rather
+     * than a silent mis-read of field offsets. */
+    if (schema) {
+        MDB_val sk = { WAM_LMDB_SCHEMA_KEYLEN, (void *)WAM_LMDB_SCHEMA_KEY };
+        MDB_val sv;
+        if (mdb_get(txn, dbi, &sk, &sv) == 0) {
+            size_t explen = strlen(schema);
+            if (sv.mv_size != explen ||
+                memcmp(sv.mv_data, schema, explen) != 0) {
+                printf("plawk: cache schema mismatch");
+                mdb_txn_abort(txn);
+                mdb_env_close(env);
+                exit(3);
+            }
+        }
+    }
+    if (mdb_cursor_open(txn, dbi, &cur)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
+    while (mdb_cursor_get(cur, &k, &v, MDB_NEXT) == 0) {
+        int64_t key;
+        int64_t vid;
+        if (k.mv_size != sizeof(int64_t)) continue;  /* skip the schema entry */
+        __builtin_memcpy(&key, k.mv_data, sizeof(int64_t));
+        vid = wam_intern_atom((const char *)v.mv_data, (int64_t)v.mv_size);
+        wam_assoc_i64_set(table, key, vid);
+    }
+    mdb_cursor_close(cur);
+    mdb_txn_abort(txn);
     mdb_env_close(env);
 }

--- a/tests/test_plawk_row_durable_lmdb.pl
+++ b/tests/test_plawk_row_durable_lmdb.pl
@@ -1,0 +1,130 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk row-oriented records (PLAWK_MULTIPASS_CACHE.md §3.6, phase 8.4): DURABLE
+% ROWS over the LMDB BACKEND. The file-backend counterpart is
+% test_plawk_row_durable.pl; this is the same durability contract for a store
+% declared `backend "lmdb"`. A row value is a process-local atom id, so the
+% plain i64 lmdb path (which persists the id) cannot restore a row in a fresh
+% process. The byte-valued lmdb helpers (wam_cache_{commit,load}_lmdb_str)
+% persist the row BYTES instead -- commit resolves each id to its bytes and
+% mdb_puts them under the i64 key; load re-interns the bytes to a valid
+% this-process id. The declared schema is stored under a distinguished key and
+% validated on open, so a mismatched reopen fails cleanly (exit 3).
+%
+% Requires liblmdb at build+run time (apt-get install liblmdb-dev); skipped
+% when clang cannot link -llmdb.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_lmdb_available :-
+    catch(( tmp_c(C, Bin),
+            setup_call_cleanup(open(C, write, S),
+                write(S, "#include <lmdb.h>\nint main(void){MDB_env*e;return mdb_env_create(&e);}\n"),
+                close(S)),
+            format(atom(Cmd), 'clang -w ~w -o ~w -llmdb 2>/dev/null', [C, Bin]),
+            process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+tmp_c(C, Bin) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_lmdb_rows_probe.c', C),
+    directory_file_path(Tmp, 'uw_lmdb_rows_probe', Bin).
+
+:- begin_tests(plawk_row_durable_lmdb).
+
+% Reader pass first (reads the committed store), writer pass second. Run 1:
+% empty lmdb store -> reader silent; writer writes x/y and commits the row
+% BYTES. Run 2: reader sees the durable rows from run 1 -- which only works if
+% bytes, not the stale process-local id, were persisted to LMDB.
+test(rows_persist_across_runs, [condition(clang_lmdb_available)]) :-
+    ldir(Dir),
+    store(Dir, 'dur.lmdb', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare t(a str, b str) }\n\c
+         pass records of t as r { print r[\"a\"], r[\"b\"] }\n\c
+         pass { t[$1] = row($1, $2) }\n", [Store]),
+    build(Dir, 'ldur', Src, Bin, In, "x 10\ny 20\n"),
+    run_sorted(Bin, In, S1),
+    assertion(S1 == []),                        % run 1: store was empty
+    run_sorted(Bin, In, S2),
+    assertion(S2 == ["x 10", "y 20"]),          % run 2: durable rows restored
+    !.
+
+% Positional durability over LMDB: bytes survive, read back with `rows of`.
+test(rows_persist_positional, [condition(clang_lmdb_available)]) :-
+    ldir(Dir),
+    store(Dir, 'durp.lmdb', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare t(a str, b str) }\n\c
+         pass rows of t as r { print r[1], r[2] }\n\c
+         pass { t[$1] = $0 }\n", [Store]),
+    build(Dir, 'ldurp', Src, Bin, In, "p 1\nq 2\n"),
+    run_sorted(Bin, In, S1), assertion(S1 == []),
+    run_sorted(Bin, In, S2), assertion(S2 == ["p 1", "q 2"]),
+    !.
+
+% Self-describing lmdb store: the schema is persisted under its own key, so a
+% reopen with a DIFFERENT declared schema fails cleanly (exit 3) rather than
+% mis-reading field offsets. Run 1 writes schema (a,b); the second program
+% opens it with schema (a,c).
+test(schema_mismatch_errors, [condition(clang_lmdb_available)]) :-
+    ldir(Dir),
+    store(Dir, 'scm.lmdb', Store),
+    format(atom(SrcA),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare t(a str, b str) }\n\c
+         pass records of t as r { print r[\"a\"], r[\"b\"] }\n\c
+         pass { t[$1] = row($1, $2) }\n", [Store]),
+    build(Dir, 'lscma', SrcA, BinA, InA, "x 10\n"),
+    run_sorted(BinA, InA, _),                   % run 1: populate + commit schema
+    format(atom(SrcB),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare t(a str, c str) }\n\c
+         pass records of t as r { print r[\"a\"], r[\"c\"] }\n\c
+         pass { t[$1] = row($1, $2) }\n", [Store]),
+    build(Dir, 'lscmb', SrcB, BinB, InB, "x 10\n"),
+    process_create(BinB, [InB], [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Code)),
+    assertion(Code == 3),                       % schema mismatch -> clean fail
+    !.
+
+:- end_tests(plawk_row_durable_lmdb).
+
+% --- helpers ---------------------------------------------------------------
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_row_durable_lmdb', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+% Fresh single-file lmdb store: remove the data file and its -lock sidecar.
+store(Dir, Name, Store) :-
+    directory_file_path(Dir, Name, Store),
+    atom_concat(Store, '-lock', Lock),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    ( exists_file(Lock) -> delete_file(Lock) ; true ).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+run_sorted(Bin, In, Sorted) :-
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Summary

Row-oriented tables were durable only on the **file** backend. An LMDB-backed row table rode the plain i64 lmdb path, so it persisted the process-local atom **id** — which can't restore a row in a fresh process (in-run only). This extends byte-valued durability to LMDB, so row **bytes** survive across runs, closing the first "Not yet" item in the design doc's Status list.

```awk
BEGIN cache("orders.lmdb" backend "lmdb") { declare orders(cust str, amt str) }
pass records of orders as r { print r["cust"], r["amt"] }   # run 2 sees run 1's rows
pass { orders[$1] = row($1, $2) }
```

## What changed

**Runtime** (`src/unifyweaver/targets/wam_cache_lmdb.c`):
- `wam_cache_commit_lmdb_str` — resolves each value id to its bytes (`wam_atom_to_string`) and `mdb_put`s them under the i64 key.
- `wam_cache_load_lmdb_str` — re-interns the stored bytes (`wam_intern_atom`) to a valid this-process id.
- The declared schema is stored under a distinguished **non-8-byte key** and validated against the program's on open — a mismatch is a clean `exit(3)`, mirroring the file backend. Data rows (8-byte keys) are skipped-by-size during the load scan, so the schema entry never leaks into the table.

**Codegen** (`plawk_native_codegen.pl`):
- `plawk_cache_fn` routes `lmdb + str` to the new `_lmdb_str` helpers; i64 lmdb tables keep the plain path.
- `plawk_cache_call_ir` threads the `i8*` schema arg to them (as it already does for the file `_str` helpers).
- The lmdb `declare`s gain the 3-arg str signatures when a str-valued lmdb store is in use.

**Tests** (`tests/test_plawk_row_durable_lmdb.pl`, guarded on clang + liblmdb): the file-durable suite's contract over `backend "lmdb"` — rows persist across runs by name and by position, and a mismatched-schema reopen exits 3. All 3 pass; file-durable, cache-lmdb, and use-table regressions stay green.

**Docs**: `PLAWK_MULTIPASS_CACHE.md` Status + §3.6 + phase 8.4 now read "file + LMDB".

## Follow-on (called out in the doc)

`use NAME` over an LMDB store needs a build-time resolver that reads the LMDB schema key; `declare` works over LMDB today. Scoped out to keep this PR to the durable commit/load path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_