### PR TITLE
WAM/LLVM plawk: `use NAME` over an LMDB store (build-time schema probe)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -39,9 +39,7 @@ surface, the runtime ABI, and a phased rollout.
   or `$N CMP int` (anon). The six operators are `== != < <= > >=`; filtered
   rows never reach the print block (`tests/test_plawk_reader_guards.pl`).
 
-**Not yet:** `use NAME` over an LMDB store (the build-time schema resolver
-reads the file-backend header, not the LMDB schema key — a follow-on; `declare`
-works over LMDB today); `rows of`'s `unsafe` / inline check-or-rename spec;
+**Not yet:** `rows of`'s `unsafe` / inline check-or-rename spec;
 multiple named tables per store (phase 8.9); the `over prev` reader (phase 4
 follow-on); the query reader (phase 6); `eager` / secondary indexes;
 string-literal print fields. Future sketches: nested pass blocks (§3.8),
@@ -535,9 +533,11 @@ the i64 key and store the declared schema under a distinguished non-8-byte key
 (validated on open; data rows are skipped-by-size). A reader pass in a later
 run sees rows a prior run committed. Keys stay i64 ids (content-stable
 interning reproduces them; readers only iterate, and a re-writing pass
-re-interns the same key). One gap remains on LMDB: `use NAME` (attach without
-re-`declare`) needs a build-time resolver that reads the LMDB schema key —
-`declare` works over LMDB today.
+re-interns the same key). `use NAME` (attach without re-`declare`) works over
+both backends: on the file backend the build reads the schema header directly;
+on LMDB the schema lives under a key inside the B-tree, so the build compiles
+and runs a small liblmdb probe (`wam_cache_lmdb_schema.c`) to extract it
+(phase 8.8, `tests/test_plawk_use_table_lmdb.pl`).
 
 **Phasing** (each its own PR):
 1. **Schema surface** — `declare NAME(col type, …)` parses and carries a row
@@ -606,14 +606,18 @@ a short sequence rather than a lone keyword:
   stored schema and the program's `declare(cols)` are present and differ, the
   open **fails cleanly** (`plawk: cache schema mismatch`, exit 3) instead of
   silently mis-reading field offsets. `tests/test_plawk_row_durable.pl`.
-- **(b) `use NAME` (the `select`). LANDED (file backend).** A backed-BEGIN
+- **(b) `use NAME` (the `select`). LANDED (file + LMDB backends).** A
+  backed-BEGIN
   `use NAME` **attaches to an existing store and takes its schema from (a)** —
-  no re-`declare(cols)`. The plawk build reads the store's persisted schema
-  header at **compile time** and expands `use NAME` into the same
+  no re-`declare(cols)`. At **compile time** the plawk build reads the store's
+  persisted schema and expands `use NAME` into the same
   `cache_table` + `cache_schema` a matching `declare NAME(cols)` would produce,
-  so `records of` / `rows of` and the runtime schema check work unchanged. A
-  missing / schema-less store is a compile error.
-  `tests/test_plawk_use_table.pl`.
+  so `records of` / `rows of` and the runtime schema check work unchanged. On
+  the file backend the build reads the schema header directly; on LMDB the
+  schema is under a B-tree key, so the build compiles and runs a small liblmdb
+  probe (`wam_cache_lmdb_schema.c`) to extract it. A missing / schema-less
+  store is a compile error.
+  `tests/test_plawk_use_table.pl`, `tests/test_plawk_use_table_lmdb.pl`.
 - **(c) Multiple named tables per store.** With the namespace design (§3.5,
   LMDB named sub-DBs), a store holds several tables and `use ns.orders`
   selects among them. This is the point at which `select` becomes load-bearing
@@ -1083,8 +1087,7 @@ single-pass test before any driver surgery).
   (`tests/test_plawk_row_durable.pl` for the file backend,
   `tests/test_plawk_row_durable_lmdb.pl` for LMDB via
   `wam_cache_{commit,load}_lmdb_str` — schema stored under a distinguished key
-  and validated on open; `use NAME` over an LMDB store still awaits a
-  build-time LMDB schema resolver); (8.5) the positional `rows of`
+  and validated on open); (8.5) the positional `rows of`
   reader (`r[N]`, no schema) — **LANDED**
   (`tests/test_plawk_rows_reader.pl`; its `unsafe` / inline check-or-rename
   spec remain a follow-on); (8.6) richer row producers (`row(...)` /
@@ -1094,8 +1097,10 @@ single-pass test before any driver surgery).
   store, closes the schema-mismatch hole) — **LANDED (file backend)**
   (`tests/test_plawk_row_durable.pl`); (8.8) `use NAME` that attaches to an
   existing store and takes its schema from 8.7 (read at build time) — the
-  `select` surface, no re-`declare` — **LANDED (file backend)**
-  (`tests/test_plawk_use_table.pl`); (8.9) multiple named tables per store
+  `select` surface, no re-`declare` — **LANDED (file + LMDB backends)**
+  (`tests/test_plawk_use_table.pl`; `tests/test_plawk_use_table_lmdb.pl` for
+  LMDB, where the build extracts the schema with a small liblmdb probe,
+  `wam_cache_lmdb_schema.c`); (8.9) multiple named tables per store
   (namespaces / LMDB named sub-DBs, §3.5, per `PLAWK_CACHE_BACKENDS.md`) so
   `use ns.table` selects among them. (8.10) **reader guards** — a
   `WHERE`-style row filter on any of the three readers: `if (r["col"] CMP int)`

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -279,7 +279,7 @@ resolve_use_begin(_File, Clause, Clause).
 expand_cache_use(File, cache_use(Name, Path, Backend),
         [cache_table(Name, Path, Backend), cache_schema(Name, Cols)]) :-
     !,
-    (   store_schema_columns(Path, Cols)
+    (   store_schema_columns_for(Backend, Path, Cols)
     ->  true
     ;   format(user_error,
             'plawk: cannot `use ~w` in ~w: store "~w" is missing or has no schema~n',
@@ -287,6 +287,52 @@ expand_cache_use(File, cache_use(Name, Path, Backend),
         halt(2)
     ).
 expand_cache_use(_File, Action, [Action]).
+
+% Read a store's persisted schema, dispatching on backend. The file backend's
+% schema is a plain header this process reads directly; the LMDB backend keeps
+% it under a key inside the B-tree, so a tiny liblmdb probe (compiled by the
+% build, which already needs clang + liblmdb for lmdb stores) extracts it.
+store_schema_columns_for(lmdb, Path, Cols) :-
+    !, store_schema_columns_lmdb(Path, Cols).
+store_schema_columns_for(_Backend, Path, Cols) :-
+    store_schema_columns(Path, Cols).
+
+% Build-time schema read for an LMDB row store: compile the schema probe
+% (wam_cache_lmdb_schema.c) once into the build tmp dir, run it against the
+% store, and parse the schema string it prints. A missing store, a probe that
+% cannot link/run, or an empty/unparseable schema fails (-> compile error).
+store_schema_columns_lmdb(Path, Cols) :-
+    atom_string(PathA, Path),
+    exists_file(PathA),
+    lmdb_schema_probe_bin(ProbeBin),
+    process_create(ProbeBin, [PathA],
+        [stdout(pipe(PS)), stderr(null), process(Pid)]),
+    read_string(PS, _, Out), close(PS),
+    process_wait(Pid, exit(0)),
+    parse_schema_string(Out, Cols),
+    Cols = [_ | _].
+
+% Compile the LMDB schema probe once per build invocation, memoised by path.
+:- dynamic lmdb_schema_probe_bin_cache/1.
+lmdb_schema_probe_bin(ProbeBin) :-
+    ( lmdb_schema_probe_bin_cache(ProbeBin)
+    ->  true
+    ;   lmdb_schema_probe_source(CFile),
+        tmp_build_dir(Dir),
+        directory_file_path(Dir, 'wam_cache_lmdb_schema_probe', ProbeBin),
+        format(atom(Cmd), 'clang -w -O2 ~w -o ~w -llmdb 2>&1', [CFile, ProbeBin]),
+        process_create(path(sh), ['-c', Cmd],
+            [stdout(pipe(CS)), stderr(std), process(Pid)]),
+        read_string(CS, _, _), close(CS),
+        process_wait(Pid, exit(0)),
+        assertz(lmdb_schema_probe_bin_cache(ProbeBin))
+    ).
+
+% The schema probe source ships beside the LMDB C runtime.
+lmdb_schema_probe_source(CFile) :-
+    module_property(wam_llvm_target, file(TargetPl)),
+    file_directory_name(TargetPl, Dir),
+    directory_file_path(Dir, 'wam_cache_lmdb_schema.c', CFile).
 
 % Read a byte-valued row store's persisted schema header and parse it into
 % col(Name, Type) columns. Header layout (§8.7): [schemalen:i64 (LE)]

--- a/src/unifyweaver/targets/wam_cache_lmdb_schema.c
+++ b/src/unifyweaver/targets/wam_cache_lmdb_schema.c
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0
+ * Copyright (c) 2026 John William Creighton (@s243a)
+ *
+ * Build-time schema probe for the plawk LMDB cache backend
+ * (PLAWK_MULTIPASS_CACHE.md phase 8.8). A str-valued (row) store on the LMDB
+ * backend keeps its declared schema under a distinguished key
+ * ("__wam_schema__"), written by wam_cache_commit_lmdb_str. `use NAME` needs
+ * that schema at BUILD time -- but the file backend's schema is a plain file
+ * header the plawk build reads directly, whereas LMDB's lives inside the
+ * B-tree and needs liblmdb to extract. This tiny helper is compiled and run by
+ * the plawk build (which already depends on clang + liblmdb for lmdb stores):
+ * given a store path, it prints the schema string ("name:type,...") to stdout
+ * and exits 0, or exits non-zero when the store is missing / has no schema.
+ * It is NOT linked into the plawk binary; it is a standalone build-time tool. */
+
+#include <lmdb.h>
+#include <stdio.h>
+#include <stddef.h>
+
+/* Must match WAM_LMDB_SCHEMA_KEY / _KEYLEN in wam_cache_lmdb.c. */
+static const char SCHEMA_KEY[] = "__wam_schema__";
+#define SCHEMA_KEYLEN 14
+
+int main(int argc, char **argv) {
+    MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
+    MDB_val k, v;
+    int rc;
+    if (argc < 2) return 2;
+    if (mdb_env_create(&env)) return 1;
+    if (mdb_env_open(env, argv[1], MDB_NOSUBDIR | MDB_RDONLY, 0644)) {
+        mdb_env_close(env);
+        return 1;
+    }
+    if (mdb_txn_begin(env, NULL, MDB_RDONLY, &txn)) {
+        mdb_env_close(env);
+        return 1;
+    }
+    if (mdb_dbi_open(txn, NULL, 0, &dbi)) {
+        mdb_txn_abort(txn);
+        mdb_env_close(env);
+        return 1;
+    }
+    k.mv_size = SCHEMA_KEYLEN;
+    k.mv_data = (void *)SCHEMA_KEY;
+    rc = mdb_get(txn, dbi, &k, &v);
+    if (rc == 0 && v.mv_size > 0) {
+        fwrite(v.mv_data, 1, v.mv_size, stdout);
+    }
+    mdb_txn_abort(txn);
+    mdb_env_close(env);
+    return (rc == 0 && v.mv_size > 0) ? 0 : 1;
+}

--- a/tests/test_plawk_use_table_lmdb.pl
+++ b/tests/test_plawk_use_table_lmdb.pl
@@ -1,0 +1,112 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk row-oriented records (PLAWK_MULTIPASS_CACHE.md §3.7, phase 8.8): the
+% `use` reader over the LMDB BACKEND. The file-backend counterpart is
+% test_plawk_use_table.pl. `use NAME` attaches to an existing store without
+% re-stating its columns -- the plawk build reads the store's persisted schema
+% and expands `use NAME` into the cache_table + cache_schema a matching
+% `declare` would produce. On the file backend the schema is a plain header the
+% build reads directly; on LMDB it lives under a key inside the B-tree, so the
+% build compiles and runs a small liblmdb probe (wam_cache_lmdb_schema.c) to
+% extract it. This test proves a durable LMDB row store written by a `declare`
+% writer is read back by a separate `use` reader (no re-declare).
+%
+% Requires liblmdb at build+run time (apt-get install liblmdb-dev); skipped
+% when clang cannot link -llmdb.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_lmdb_available :-
+    catch(( tmp_c(C, Bin),
+            setup_call_cleanup(open(C, write, S),
+                write(S, "#include <lmdb.h>\nint main(void){MDB_env*e;return mdb_env_create(&e);}\n"),
+                close(S)),
+            format(atom(Cmd), 'clang -w ~w -o ~w -llmdb 2>/dev/null', [C, Bin]),
+            process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+tmp_c(C, Bin) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_lmdb_use_probe.c', C),
+    directory_file_path(Tmp, 'uw_lmdb_use_probe', Bin).
+
+:- begin_tests(plawk_use_table_lmdb).
+
+% End to end: a `declare` writer populates a durable LMDB store; a separate
+% `use` reader (NO declare(cols)) reads it back by column name and by position.
+% The reader's schema is read from the LMDB store at build time via the probe.
+test(use_reads_existing_lmdb_store, [condition(clang_lmdb_available)]) :-
+    udir(Dir),
+    store(Dir, 'u.lmdb', Store),
+    format(atom(WSrc),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare t(a str, b str) }\n\c
+         pass records of t as r { print r[\"a\"] }\n\c
+         pass { t[$1] = row($1, $2) }\n", [Store]),
+    build(Dir, 'luw', WSrc, WBin, WIn, "x 10\ny 20\n"),
+    run_sorted(WBin, WIn, _),                    % populate + commit schema
+    format(atom(RSrc),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { use t }\n\c
+         pass records of t as r { print r[\"a\"], r[\"b\"] }\n\c
+         pass rows of t as r { print r[1] }\n", [Store]),
+    build(Dir, 'lur', RSrc, RBin, RIn, "x 10\ny 20\n"),
+    run_sorted(RBin, RIn, S),
+    assertion(S == ["x", "x 10", "y", "y 20"]),
+    !.
+
+% `use` on a missing LMDB store is a compile error (exit 2): no schema to read.
+test(use_missing_lmdb_store_errors, [condition(clang_lmdb_available)]) :-
+    udir(Dir),
+    store(Dir, 'nope.lmdb', Store),
+    format(atom(RSrc),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { use t }\n\c
+         pass records of t as r { print r[\"a\"] }\n\c
+         pass rows of t as r { print r[1] }\n", [Store]),
+    directory_file_path(Dir, 'lum.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, W, [encoding(utf8)]),
+        write(W, RSrc), close(W)),
+    directory_file_path(Dir, 'lum_bin', Bin),
+    cli([build, Prog, '-o', Bin], 2),            % compile error: no store/schema
+    !.
+
+:- end_tests(plawk_use_table_lmdb).
+
+% --- helpers ---------------------------------------------------------------
+
+udir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_use_table_lmdb', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+% Fresh single-file lmdb store: remove the data file and its -lock sidecar.
+store(Dir, Name, Store) :-
+    directory_file_path(Dir, Name, Store),
+    atom_concat(Store, '-lock', Lock),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    ( exists_file(Lock) -> delete_file(Lock) ; true ).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+run_sorted(Bin, In, Sorted) :-
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Summary

**Stacked on #3725** (durable LMDB rows) — it reads the schema key that #3725's commit writes, so merge #3725 first.

`use NAME` attaches to an existing row store and takes its schema at build time, but the resolver only knew the **file** backend's plain header. An LMDB store keeps its schema under a B-tree key (written by `wam_cache_commit_lmdb_str` in #3725), so `use` over LMDB failed. This adds a build-time extractor so `use` works over LMDB too — completing the durable LMDB row story (`declare` already worked).

```awk
BEGIN cache("orders.lmdb" backend "lmdb") { use orders }   # no re-declare
pass records of orders as r { print r["cust"], r["amt"] }
```

## What changed

- **Build tool** (`src/unifyweaver/targets/wam_cache_lmdb_schema.c`): a tiny standalone liblmdb program — opens a store read-only, gets the `__wam_schema__` key, prints the schema string to stdout (non-zero exit when missing/schema-less). **Not linked** into the plawk binary; it's a build-time probe, reusing the clang + liblmdb the build already needs for lmdb stores.
- **Resolver** (`examples/plawk/bin/plawk`): `expand_cache_use` now dispatches on backend. File reads the header directly as before; lmdb compiles the probe once per build (memoised) into the build tmp dir, runs it against the store, and parses the printed schema into `col(Name,Type)` — feeding the same `cache_table` + `cache_schema` expansion, so readers and the runtime schema check are unchanged. Missing/schema-less store stays a clean compile error (exit 2).
- **Tests** (`tests/test_plawk_use_table_lmdb.pl`, guarded on clang+liblmdb): a `declare` writer populates a durable LMDB store; a separate `use` reader (no re-declare) reads it back by name and position; a missing store is a compile error. Both pass.
- **Docs**: `PLAWK_MULTIPASS_CACHE.md` — `use NAME` / §3.7(b) / phase 8.8 now read "file + LMDB"; the LMDB `use` follow-on removed from Not-yet.

## Verification

Built a durable LMDB store with a `declare` writer, then a separate `use` reader read it back (`x 10` / `y 20` by name, `x` / `y` by position); missing store → exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_