### PR TITLE
docs: MapReduce as producer/scope/eliminator + parallelization corollary

### DIFF
--- a/docs/design/UNIFYWEAVER_LANGUAGE_PRINCIPLES.md
+++ b/docs/design/UNIFYWEAVER_LANGUAGE_PRINCIPLES.md
@@ -114,6 +114,50 @@ the hot loop stays choicepoint-free.
   first-class surface — the Prolog/comprehension face, with the collapse
   operator as the boundary.
 
+### Worked example: MapReduce is producer / scope / eliminator
+
+MapReduce is a fifth face of the same shape — worth writing out because it is
+the one whose vocabulary already *names* the three parts, and because it points
+at where parallelism belongs.
+
+| MapReduce stage | shape role | what it is |
+|---|---|---|
+| **map** | producer (+ per-item transform) | emit `(key, value)` pairs from each input record |
+| **shuffle / group-by-key** | scope | gather all values sharing a key — the bracket in which one key's multiplicity exists |
+| **reduce** | eliminator | fold each key's value-set to a deterministic result |
+
+So `map` is the generator, the shuffle is the `GROUP BY` / `where` scope, and
+`reduce` is `collect`/`sum`/`count` — a per-group fold. A MapReduce job *is* a
+distributed `GROUP BY`, which is why it lowers to the same producer / scope /
+eliminator decomposition as every other face above.
+
+### Parallelization corollary
+
+Naming the three parts also locates where a computation is safe to parallelize —
+the boundary is the seam:
+
+- **The producer is data-parallel.** `map` over independent input records has no
+  cross-record dependency, so it shards freely — one worker per partition.
+- **The eliminator parallelizes *when the fold is associative* (and ideally
+  commutative).** An associative reduce is a tree: fold shards independently,
+  then combine partial results. `count`, `sum`, `min`, `max`, set-union are
+  associative and shard cleanly; a fold that depends on order (or on the whole
+  set at once) does not, and must run after a barrier.
+- **The scope is the shard boundary.** The shuffle/group-by is exactly the
+  repartition step — the point where the framework moves data so each key's
+  values land together. It is the barrier between the parallel producer and the
+  parallel-if-associative eliminator.
+
+This is a design signpost, not a current feature: UnifyWeaver's surfaces are
+single-process today. But it says *where* parallelism would attach if added —
+map-side sharding before the scope, tree-reduction after it, gated on the
+eliminator's associativity — and it explains why the associativity of an
+aggregate (`sum` vs. a fold that reads the whole ordered set) is the property
+that decides whether a collapse can be distributed. The same reasoning applies
+to the contained-search sketch (§3.10): independent generator branches are the
+map-parallel part, and an associative collapse (`count`/`exists`/`collect`)
+is the tree-reducible part.
+
 ---
 
 *Add further principles below as they recur across surfaces.*


### PR DESCRIPTION
## Summary

Documentation-only. **Stacked on #3727** (which is stacked on #3725) — merge order: #3725 → #3727 → this. Its own diff is just the principles-doc addition.

Extends **Principle 1 (bounded multiplicity)** in `UNIFYWEAVER_LANGUAGE_PRINCIPLES.md` with the two things that came out of the discussion.

### MapReduce is a fifth face of producer / scope / eliminator

The one whose vocabulary already names the three parts:

| stage | role |
|---|---|
| **map** | producer (+ per-item transform) |
| **shuffle / group-by-key** | scope |
| **reduce** | eliminator (per-key fold) |

A MapReduce job *is* a distributed `GROUP BY`, so it lowers to the same decomposition as the SQL / Prolog / Haskell / Python faces already in the doc.

### Parallelization corollary

Naming the parts locates where parallelism attaches:

- **producer (map)** — data-parallel, shards freely;
- **eliminator (reduce)** — parallelizes as a tree *when the fold is associative* (`count`/`sum`/`min`/`max`/union); an order-dependent fold needs a barrier;
- **scope (shuffle)** — the shard boundary / repartition step between them.

A design signpost, not a feature (UnifyWeaver is single-process today): it says *where* parallelism would attach if added, and explains why an aggregate's **associativity** is the property that decides whether a collapse can be distributed. The same reasoning carries to the contained-search sketch (§3.10) — independent generator branches are the map-parallel part, an associative collapse the tree-reducible part.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_