### PR TITLE
Add Rust WAM intersection/3 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -4098,6 +4098,17 @@ compile_execute_ext_builtin_to_rust(Code) :-
         }
     }
 
+    /// Test list membership by unification. Failed candidates are
+    /// unwound; the first successful candidate keeps its bindings.
+    fn builtin_unify_member(&mut self, item: &Value, candidates: &[Value]) -> bool {
+        for candidate in candidates {
+            let mark = self.trail.len();
+            if self.unify(item, candidate) { return true; }
+            self.unwind_trail_to(mark);
+        }
+        false
+    }
+
     /// One alternative of between/3 enumeration: bind X to N, leaving a
     /// choice point for N+1..High. Called from the first builtin
     /// dispatch and from resume_builtin on backtrack.
@@ -4372,6 +4383,32 @@ compile_execute_ext_builtin_to_rust(Code) :-
                     .collect();
                 let a3 = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
                 if self.unify(&a3, &Value::List(kept)) { self.pc += 1; true } else { false }
+            }
+            "intersection/3" => {
+                let left = match self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let right = match self.get_reg_raw("A2")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let mark = self.trail.len();
+                let mut common = Vec::with_capacity(left.len());
+                for item in &left {
+                    if self.builtin_unify_member(item, &right) {
+                        common.push(item.clone());
+                    }
+                }
+                let output = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+                if self.unify(&output, &Value::List(common)) {
+                    self.pc += 1; true
+                } else {
+                    self.unwind_trail_to(mark);
+                    false
+                }
             }
             "select/3" => {
                 let x_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -817,6 +817,71 @@ fn test_variant_equivalence_direct() {
 }
 
 #[test]
+fn test_intersection_direct() {
+    let (ok, vm) = call3(
+        "intersection/3",
+        Value::List(vec![a("a"), a("b"), a("c"), a("b")]),
+        Value::List(vec![a("b"), a("d")]),
+        ub("Common"),
+    );
+    assert!(ok);
+    assert_eq!(read_var(&vm, "Common"), Value::List(vec![a("b"), a("b")]));
+
+    let (empty_ok, empty_vm) = call3(
+        "intersection/3",
+        Value::List(vec![]),
+        Value::List(vec![a("a")]),
+        ub("Common"),
+    );
+    assert!(empty_ok);
+    assert_eq!(read_var(&empty_vm, "Common"), Value::List(vec![]));
+    assert!(!call3("intersection/3", a("bad"), Value::List(vec![]), ub("R")).0);
+    assert!(!call3("intersection/3", Value::List(vec![]), a("bad"), ub("R")).0);
+
+    let (vars_ok, vars_vm) = call3(
+        "intersection/3",
+        Value::List(vec![ub("X"), ub("Y")]),
+        Value::List(vec![a("a")]),
+        ub("Common"),
+    );
+    assert!(vars_ok);
+    assert_eq!(read_var(&vars_vm, "X"), a("a"));
+    assert_eq!(read_var(&vars_vm, "Y"), a("a"));
+    assert_eq!(read_var(&vars_vm, "Common"), Value::List(vec![a("a"), a("a")]));
+
+    let (retry_ok, retry_vm) = call3(
+        "intersection/3",
+        Value::List(vec![Value::Str("f/1".to_string(), vec![ub("X")])]),
+        Value::List(vec![
+            Value::Str("g/1".to_string(), vec![a("wrong")]),
+            Value::Str("f/1".to_string(), vec![a("right")]),
+        ]),
+        ub("Common"),
+    );
+    assert!(retry_ok);
+    assert_eq!(read_var(&retry_vm, "X"), a("right"));
+
+    let (miss_ok, miss_vm) = call3(
+        "intersection/3",
+        Value::List(vec![Value::Str("f/2".to_string(), vec![ub("X"), a("a")])]),
+        Value::List(vec![Value::Str("f/2".to_string(), vec![a("bound"), a("b")])]),
+        ub("Common"),
+    );
+    assert!(miss_ok);
+    assert_eq!(read_var(&miss_vm, "X"), ub("X"));
+    assert_eq!(read_var(&miss_vm, "Common"), Value::List(vec![]));
+
+    let (mismatch_ok, mismatch_vm) = call3(
+        "intersection/3",
+        Value::List(vec![ub("X")]),
+        Value::List(vec![a("a")]),
+        Value::List(vec![]),
+    );
+    assert!(!mismatch_ok);
+    assert_eq!(read_var(&mismatch_vm, "X"), ub("X"));
+}
+
+#[test]
 fn test_ground() {
     assert!(call1("ground/1", a("x")).0);
     assert!(call1("ground/1", Value::List(vec![i(1), a("b")])).0);

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -467,6 +467,8 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, 'variant_terms'),
         sub_string(S, _, _, _, '"unifiable/3"'),
         sub_string(S, _, _, _, '"subtract/3"'),
+        sub_string(S, _, _, _, '"intersection/3"'),
+        sub_string(S, _, _, _, 'builtin_unify_member'),
         %% copy_term_walk helper (sharing-preserving recursive copy).
         sub_string(S, _, _, _, 'copy_term_walk'),
         %% Runtime-parser bridge support and the parser-required text/list builtins.


### PR DESCRIPTION
## Summary

- implement relational `intersection/3` for the Rust WAM runtime
- preserve input order and duplicate elements
- retain bindings from the first successful unification match
- unwind failed candidates and failed output-list unification
- reject improper/non-list inputs
- add focused generator and generated-Rust coverage

## Testing

- `swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl`
- `swipl -q -s tests/test_wam_rust_target.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `git diff --check`