### PR TITLE
Add Rust WAM union/3 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -4410,6 +4410,33 @@ compile_execute_ext_builtin_to_rust(Code) :-
                     false
                 }
             }
+            "union/3" => {
+                let left = match self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let right = match self.get_reg_raw("A2")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let mark = self.trail.len();
+                let mut union = Vec::with_capacity(left.len() + right.len());
+                union.extend(left.iter().cloned());
+                for item in &right {
+                    if !self.builtin_unify_member(item, &left) {
+                        union.push(item.clone());
+                    }
+                }
+                let output = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+                if self.unify(&output, &Value::List(union)) {
+                    self.pc += 1; true
+                } else {
+                    self.unwind_trail_to(mark);
+                    false
+                }
+            }
             "select/3" => {
                 let x_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
                 let list = match self.get_reg_raw("A2").map(|v| self.deref_heap(&self.deref_var(&v))) {

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -882,6 +882,83 @@ fn test_intersection_direct() {
 }
 
 #[test]
+fn test_union_direct() {
+    let (ok, vm) = call3(
+        "union/3",
+        Value::List(vec![a("a"), a("b"), a("c")]),
+        Value::List(vec![a("b"), a("d"), a("e")]),
+        ub("Union"),
+    );
+    assert!(ok);
+    assert_eq!(
+        read_var(&vm, "Union"),
+        Value::List(vec![a("a"), a("b"), a("c"), a("d"), a("e")]),
+    );
+
+    let (dupes_ok, dupes_vm) = call3(
+        "union/3",
+        Value::List(vec![a("a"), a("a"), a("b")]),
+        Value::List(vec![a("a"), a("c")]),
+        ub("Union"),
+    );
+    assert!(dupes_ok);
+    assert_eq!(
+        read_var(&dupes_vm, "Union"),
+        Value::List(vec![a("a"), a("a"), a("b"), a("c")]),
+    );
+
+    let (empty_ok, empty_vm) = call3(
+        "union/3",
+        Value::List(vec![]),
+        Value::List(vec![a("x"), a("y")]),
+        ub("Union"),
+    );
+    assert!(empty_ok);
+    assert_eq!(read_var(&empty_vm, "Union"), Value::List(vec![a("x"), a("y")]));
+    assert!(!call3("union/3", a("bad"), Value::List(vec![]), ub("R")).0);
+    assert!(!call3("union/3", Value::List(vec![]), a("bad"), ub("R")).0);
+
+    let (vars_ok, vars_vm) = call3(
+        "union/3",
+        Value::List(vec![ub("X")]),
+        Value::List(vec![a("a"), a("b")]),
+        ub("Union"),
+    );
+    assert!(vars_ok);
+    assert_eq!(read_var(&vars_vm, "X"), a("a"));
+    assert_eq!(read_var(&vars_vm, "Union"), Value::List(vec![a("a"), a("b")]));
+
+    let (miss_ok, miss_vm) = call3(
+        "union/3",
+        Value::List(vec![Value::Str("f/2".to_string(), vec![ub("X"), a("a")])]),
+        Value::List(vec![
+            Value::Str("f/2".to_string(), vec![a("bound"), a("b")]),
+            a("keep"),
+        ]),
+        ub("Union"),
+    );
+    assert!(miss_ok);
+    assert_eq!(read_var(&miss_vm, "X"), ub("X"));
+    assert_eq!(
+        read_var(&miss_vm, "Union"),
+        Value::List(vec![
+            Value::Str("f".to_string(), vec![ub("X"), a("a")]),
+            Value::Str("f".to_string(), vec![a("bound"), a("b")]),
+            a("keep"),
+        ]),
+    );
+
+    let (mismatch_ok, mismatch_vm) = call3(
+        "union/3",
+        Value::List(vec![ub("X")]),
+        Value::List(vec![a("a")]),
+        Value::List(vec![]),
+    );
+    assert!(!mismatch_ok);
+    assert_eq!(read_var(&mismatch_vm, "X"), ub("X"));
+}
+
+#[test]
 fn test_ground() {
     assert!(call1("ground/1", a("x")).0);
     assert!(call1("ground/1", Value::List(vec![i(1), a("b")])).0);

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -468,6 +468,7 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"unifiable/3"'),
         sub_string(S, _, _, _, '"subtract/3"'),
         sub_string(S, _, _, _, '"intersection/3"'),
+        sub_string(S, _, _, _, '"union/3"'),
         sub_string(S, _, _, _, 'builtin_unify_member'),
         %% copy_term_walk helper (sharing-preserving recursive copy).
         sub_string(S, _, _, _, 'copy_term_walk'),


### PR DESCRIPTION
## Summary

- implement `union/3` using the established cross-target contract
- preserve every left-list element, including duplicates
- append right-list elements that do not unify with the left list
- retain successful membership bindings
- unwind failed membership attempts and rejected output unification
- reject improper/non-list inputs
- add focused generator and generated-Rust coverage

## Testing

- `swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl`
- `swipl -q -s tests/test_wam_rust_target.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `git diff --check`