### PR TITLE
WAM/LLVM plawk: multi-table stores PR 1 — generalise the multi-pass driver to N tables

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -1097,10 +1097,12 @@ single-pass test before any driver surgery).
   `select` surface, no re-`declare` — **LANDED (file backend)**
   (`tests/test_plawk_use_table.pl`); (8.9) multiple named tables per store
   (namespaces / LMDB named sub-DBs, §3.5, per `PLAWK_CACHE_BACKENDS.md`) so
-  `use ns.table` selects among them — **planned**, sequenced into five
-  PRs in `PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md` (the first is generalising
-  the single-table multi-pass driver to N tables; storage routing and the
-  `as ns` / `use ns.table` surface follow). (8.10) **reader guards** — a
+  `use ns.table` selects among them — **in progress**, sequenced into five
+  PRs in `PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md`. PR 1 **LANDED**: the
+  multi-pass driver is generalised from one shared table to N, so a program
+  with several in-memory tables builds and runs (`tests/test_plawk_multitable.pl`);
+  durable storage routing (LMDB named sub-DBs) and the `as ns` / `use ns.table`
+  surface follow. (8.10) **reader guards** — a
   `WHERE`-style row filter on any of the three readers: `if (r["col"] CMP int)`
   (records), `if (r[N] CMP int)` (positional), `if ($N CMP int)` (anon), for
   the six operators `== != < <= > >=`. The guard lowers to an i64 field extract

--- a/docs/design/PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
@@ -17,25 +17,26 @@ Two independent single-table assumptions must fall, and they are *not* in the
 order the surface suggests. Storage routing is **not** the first obstacle — the
 driver rejects multi-table programs before storage is ever reached.
 
-- **The multi-pass driver is hardwired to one shared table.** In
-  `examples/plawk/codegen/plawk_native_codegen.pl`, every
-  `plawk_program_multipass_driver_ir/2` clause discovers a single table and
-  threads it as one parameter: the END-for-in driver asserts
-  `AssocPlan = assoc_plan([ArrayName], _)` and calls
-  `plawk_cache_entries([ArrayName], …)` / `plawk_multipass_table_params([ArrayName], …)`;
-  the no-END and reader drivers make the same one-table assumption. A program
-  with two `declare`s therefore fails the driver match and the build reports
-  *"uses multi-pass features outside the current multi-pass surface"* — before
-  any cache/storage code runs. **This is the first thing to fix.**
+- **The multi-pass driver was hardwired to one shared table — FIXED (PR 1).**
+  The no-END reader driver in
+  `examples/plawk/codegen/plawk_native_codegen.pl` now threads N tables (see PR
+  1 below); a program with several `declare`s / row tables builds and runs
+  in-memory. The END-for-in driver still assumes its single END-loop table,
+  which is fine — a multi-table program takes the reader driver. (Before PR 1 a
+  two-`declare` program failed the driver match and the build reported
+  *"uses multi-pass features outside the current multi-pass surface"*, before
+  any cache/storage code ran.)
 - **One store path ≈ one table (storage).** Even once the driver accepts N
   tables, the LMDB backend writes every table to the **unnamed** DB, so several
   tables sharing a `cache("store.lmdb")` path overwrite each other on commit
   (`PLAWK_MULTIPASS_CACHE.md` §3.7). Multi-table storage needs named sub-DBs.
 
-Encouragingly, some plumbing is already list-shaped: `plawk_multipass_table_params/3`
-takes a *list* of tables, and the row readers (`records of` / `rows of`)
-already resolve their table by name via `nth0(TableIndex, Tables, Table)`. The
-work is to stop hardcoding `[ArrayName]` and thread the full table set.
+Much of the plumbing was already list-shaped, which is why PR 1 was small: the
+setup/free helpers and `plawk_cache_entries/6` iterate the table list, and the
+row readers (`records of` / `rows of`) resolve their table by name via
+`nth0(TableIndex, Tables, Table)`. PR 1 only had to drop the artificial
+single-table cap and generalise `plawk_multipass_table_params/3` (which had had
+clauses only for `[]` and `[_Table]`) to N tables.
 
 ## 2. The backend rule (fixed, from PLAWK_CACHE_BACKENDS.md)
 
@@ -52,16 +53,23 @@ work is to stop hardcoding `[ArrayName]` and thread the full table set.
 
 Each step is its own PR, green regressions required before the next.
 
-### PR 1 — Generalise the multi-pass driver to N in-memory tables
+### PR 1 — Generalise the multi-pass driver to N in-memory tables — **LANDED**
 
-The foundational refactor; no durability yet. Stop hardcoding a single table:
-collect every table referenced by the passes/readers/END into a `Tables` list;
-create, thread (as N params), and free each; route each pass's writes/reads and
-each reader to its table by index. The END-for-in still iterates the one table
-its loop names; the others simply live alongside. Deliverable: a **purely
-in-memory** program with two `declare`d row tables, each written and read back
-in one run. Highest regression risk (touches the core driver) — run the full
-plawk row/cache suite each iteration. No storage, no new syntax.
+The foundational refactor; no durability yet. Much of the no-END reader driver
+was already list-shaped (`plawk_passes_tables/2` collected and `sort/2`-ed every
+referenced table; the setup/free helpers and `plawk_cache_entries/6` iterate the
+list; the row-reader pass-fns resolve their table by `nth0`). Only two spots
+hardcoded a single table: an artificial `N =< 1` cap in `plawk_passes_tables/2`,
+and `plawk_multipass_table_params/3` (clauses only for `[]` and `[_Table]`,
+emitting one `%plawk_assoc_table_0`). Dropping the cap and generalising the
+params to one `%plawk_assoc_table_<i>` per table — indexed by position in the
+sorted list, so setup / params / per-pass planning stay consistent — is the
+whole change. Every pass function now takes the full table set; a rule or reader
+references its table by index. `tests/test_plawk_multitable.pl`: two bare
+(schema-less) row tables with no cache; two schema'd `records of` tables in one
+store; a mixed i64-counter + row program; three row tables. The full plawk
+row/cache suite stays green (N=1 lowers exactly as before — the single-table
+clause is just the N=1 case of the general one). No storage, no new syntax.
 
 ### PR 2 — Per-store table grouping + class-A compile error
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3887,10 +3887,14 @@ get_path:
         [RuntimeGlobals, PassFnsIR, CombinedEntrySetupIR, CallsIR, FreeIR]).
 
 %% plawk_passes_tables(+Passes, -Tables)
-%  The assoc tables a multi-pass program shares (v1: zero or one). Discovered
-%  from the passes' actions: a counted key `arr[$k]++` or a print lookup
-%  `arr[$k]`; and from an `over TABLE` reader (phase 4), which names the table
-%  it iterates. A pure-scalar program (e.g. `pass { total += $2 }`) has none.
+%  The assoc tables a multi-pass program shares. Discovered from the passes'
+%  actions: a counted key `arr[$k]++` or a print lookup `arr[$k]`; and from an
+%  `over TABLE` / `records of` / `rows of` reader, which names the table it
+%  iterates. A pure-scalar program (e.g. `pass { total += $2 }`) has none.
+%  `sort/2` dedups and fixes a stable order, so each table's position is its
+%  `%plawk_assoc_table_<i>` index consistently across setup, params, and every
+%  pass's rule/reader planning. Multiple tables (phase 8.9, PR 1) share this
+%  one in-memory set; durable multi-table storage (named sub-DBs) is a later PR.
 plawk_passes_tables(Passes, Tables) :-
     findall(Name,
         ( member(pass(Rules), Passes), member(rule(_, Actions), Rules),
@@ -3901,9 +3905,7 @@ plawk_passes_tables(Passes, Tables) :-
         ; member(pass_rows_anon(var(Name), _ABody), Passes)
         ),
         Names0),
-    sort(Names0, Tables),
-    length(Tables, N),
-    N =< 1.
+    sort(Names0, Tables).
 
 plawk_action_table_name(inc_assoc(var(Name), _Key), Name).
 plawk_action_table_name(add_assoc(var(Name), _Key, _Delta), Name).
@@ -3914,12 +3916,21 @@ plawk_action_table_name(print(Fields), Name) :-
 
 %% plawk_multipass_table_params(+Tables, -ParamsIR, -ArgsIR)
 %  The LLVM parameter/argument suffix threading the shared table(s) into a
-%  pass function. Zero tables (pure scalar) -> empty; one table -> the
-%  %plawk_assoc_table_0 parameter the rule chain references.
-plawk_multipass_table_params([], '', '').
-plawk_multipass_table_params([_Table],
-    ', %WamAssocI64Table* %plawk_assoc_table_0',
-    ', %WamAssocI64Table* %plawk_assoc_table_0').
+%  pass function. Zero tables (pure scalar) -> empty; N tables -> one
+%  `%plawk_assoc_table_<i>` per table, indexed by position in the (sorted)
+%  Tables list, so every pass function receives the whole table set and a
+%  rule/reader references its table by that index. Param and arg strings are
+%  identical (same SSA names in main and in the callee signature).
+plawk_multipass_table_params(Tables, ParamsIR, ParamsIR) :-
+    plawk_multipass_table_params_parts(Tables, 0, Parts),
+    atomic_list_concat(Parts, '', ParamsIR).
+
+plawk_multipass_table_params_parts([], _, []).
+plawk_multipass_table_params_parts([_Table | Rest], Index, [Part | Parts]) :-
+    format(atom(Part),
+        ', %WamAssocI64Table* %plawk_assoc_table_~w', [Index]),
+    NextIndex is Index + 1,
+    plawk_multipass_table_params_parts(Rest, NextIndex, Parts).
 
 %% plawk_multipass_pass_plan(+Rules, +Tables, -AssocPlan)
 %  Plan a pass's rules against the (already discovered) shared table set, so

--- a/tests/test_plawk_multitable.pl
+++ b/tests/test_plawk_multitable.pl
@@ -1,0 +1,110 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk multi-table stores (PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md, phase 8.9
+% PR 1): the multi-pass driver generalised from ONE shared table to N. Until
+% now a program that referenced two tables was rejected ("uses multi-pass
+% features outside the current multi-pass surface") because the driver
+% hardcoded a single `%plawk_assoc_table_0`. This exercises several in-memory
+% tables in one program -- each table is its own `%plawk_assoc_table_<i>`,
+% created once and threaded to every pass, so a writer populates them and later
+% passes read each back independently. In-memory only; durable multi-table
+% storage (LMDB named sub-DBs) is a later PR in the plan.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_multitable).
+
+% Two bare (schema-less) row tables in one program, no cache: a writer keys
+% `a` by field 1 and `b` by field 2 (both storing $0), then two positional
+% readers read each back. Distinct tables -> distinct contents; proves the
+% driver threads more than one in-memory table.
+test(two_bare_row_tables, [condition(clang_available)]) :-
+    mdir(Dir),
+    Src = "pass { a[$1] = $0 ; b[$2] = $0 }\n\c
+           pass rows of a as r { print r[1], r[2] }\n\c
+           pass rows of b as r { print r[2], r[1] }\n",
+    run_sorted(Dir, 'bare', Src, "x 10\ny 20\n", S),
+    assertion(S == ["10 x", "20 y", "x 10", "y 20"]),
+    !.
+
+% Two schema'd row tables in one cache store, populated in one pass and read
+% back by name in separate passes. (One file store holds both in-memory tables
+% for the run; durable per-table storage is a later PR, so this asserts the
+% single-run in-memory behaviour.)
+test(two_named_row_tables, [condition(clang_available)]) :-
+    mdir(Dir),
+    directory_file_path(Dir, 'mt.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare orders(k str, v str); declare customers(k str, v str) }\n\c
+         pass { orders[$1] = row($1, $2); customers[$1] = row($2, $1) }\n\c
+         pass records of orders as r { print r[\"k\"], r[\"v\"] }\n\c
+         pass records of customers as r { print r[\"k\"], r[\"v\"] }\n", [Store]),
+    run_sorted(Dir, 'named', Src, "a 1\nb 2\n", S),
+    % orders: key=$1 val=$2 ; customers: key=$1 col1=$2 col2=$1
+    assertion(S == ["1 a", "2 b", "a 1", "b 2"]),
+    !.
+
+% Mixed table kinds in one program: an i64 counter table `c` and a row table
+% `t`, both written in pass 1, then `rows of t` and `over c` in later passes.
+% The i64 and str (row) tables coexist as separate `%plawk_assoc_table_<i>`.
+test(mixed_i64_and_row_tables, [condition(clang_available)]) :-
+    mdir(Dir),
+    Src = "pass { c[$1]++ ; t[$1] = $0 }\n\c
+           pass rows of t as r { print r[1], r[2] }\n\c
+           pass over c as k { print k, c[k] }\n",
+    run_sorted(Dir, 'mixed', Src, "a 10\na 20\nb 5\n", S),
+    % t: last write per key wins -> a "a 20", b "b 5"; c: counts a=2 b=1
+    assertion(S == ["a 2", "a 20", "b 1", "b 5"]),
+    !.
+
+% Three row tables in one program, each read by a distinct positional reader.
+test(three_row_tables, [condition(clang_available)]) :-
+    mdir(Dir),
+    Src = "pass { a[$1] = $0 ; b[$1] = $0 ; c[$1] = $0 }\n\c
+           pass rows of a as r { print r[1] }\n\c
+           pass rows of b as r { print r[2] }\n\c
+           pass rows of c as r { print r[3] }\n",
+    run_sorted(Dir, 'three', Src, "k p q\n", S),
+    assertion(S == ["k", "p", "q"]),
+    !.
+
+:- end_tests(plawk_multitable).
+
+% --- helpers ---------------------------------------------------------------
+
+mdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_multitable', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Summary

**PR 1 of the phase-8.9 arc** (`PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md`). The no-END multi-pass driver was capped at a single shared table, so a program referencing two tables was rejected — *"uses multi-pass features outside the current multi-pass surface"* — before any storage code ran. This generalises it to **N in-memory tables**.

```awk
pass { orders[$1] = row($1, $2); customers[$1] = row($2, $1) }   # two tables, one pass
pass records of orders    as r { print r["k"], r["v"] }
pass records of customers as r { print r["k"], r["v"] }          # each read back independently
```

## Why it's small

Most of the driver was already list-shaped: `plawk_passes_tables/2` collects and `sort/2`s every referenced table; the setup/free helpers and `plawk_cache_entries/6` iterate the list; the row-reader pass-fns resolve their table by `nth0`. Only **two** spots hardcoded one table:

- an artificial `N =< 1` cap in `plawk_passes_tables/2` → dropped;
- `plawk_multipass_table_params/3` had clauses only for `[]` and `[_Table]` (one `%plawk_assoc_table_0`) → generalised to one `%plawk_assoc_table_<i>` per table, indexed by position in the sorted list, so setup / params / per-pass planning stay consistent.

Every pass function now receives the whole table set and a rule/reader references its table by index. **`N=1` lowers exactly as before** — the old single-table clause is just the N=1 case.

## Tests

`tests/test_plawk_multitable.pl` (4): two bare schema-less row tables with no cache; two schema'd `records of` tables in one store; a mixed i64-counter + row program (`over c` + `rows of t`); three row tables each read by its own positional reader.

Regressions green: `multipass`, `multipass_cache`, `records_reader`, `rows_reader`, `row_cons`, `row_durable`, `row_schema`, `row_capture`, `normalise`, `perkey`, `reader_guards`.

## Scope

In-memory only. Durable multi-table storage (LMDB named sub-DBs) and the class-A file-backend compile error are **PRs 2–3**; the `as ns` / `use ns.table` surface is **PRs 4–5**. Plan doc updated (PR 1 → LANDED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_