### PR TITLE
WAM/LLVM plawk: multi-table stores PR 2 — per-store grouping + class-A compile error

### DIFF
--- a/docs/design/PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
@@ -66,18 +66,26 @@ params to one `%plawk_assoc_table_<i>` per table — indexed by position in the
 sorted list, so setup / params / per-pass planning stay consistent — is the
 whole change. Every pass function now takes the full table set; a rule or reader
 references its table by index. `tests/test_plawk_multitable.pl`: two bare
-(schema-less) row tables with no cache; two schema'd `records of` tables in one
-store; a mixed i64-counter + row program; three row tables. The full plawk
-row/cache suite stays green (N=1 lowers exactly as before — the single-table
-clause is just the N=1 case of the general one). No storage, no new syntax.
+(schema-less) row tables with no cache; a schema'd `records of` table alongside
+a bare positional table; a mixed i64-counter + row program; three row tables.
+The full plawk row/cache suite stays green (N=1 lowers exactly as before — the
+single-table clause is just the N=1 case of the general one). No storage, no new
+syntax.
 
-### PR 2 — Per-store table grouping + class-A compile error
+### PR 2 — Per-store table grouping + class-A compile error — **LANDED**
 
-Compile-time bookkeeping the storage step needs: group cache tables by store
-path; when a store has ≥2 tables, mark it multi-table and assign each table its
-sub-DB name (the table name). On the **file** backend, a multi-table store is a
-clean compile error citing the class-A rule (replacing the generic driver
-rejection). Small, low-risk, and it fixes the confusing error today.
+`check_multitable_store/2` in `examples/plawk/bin/plawk` groups declared cache
+tables by store path; when a path carries ≥2 distinct table names it applies the
+backend rule (`PLAWK_CACHE_BACKENDS.md`): a **file** store (class A) is
+single-table — a permanent compile error pointing at `backend "lmdb"`; an
+**lmdb** store is a clear *"not yet"* error (its named-sub-DB routing is PR 3)
+rather than a silent overwrite of every table into the one unnamed DB. In-memory
+tables (no `cache_table` entry) are untouched, so multiple bare tables, or one
+backed table plus bare ones, still build. `tests/test_plawk_multitable_store.pl`
+covers all four cases. (Note: this replaced the PR-1 test that had put two
+schema'd tables in one file store — now correctly an error — with a
+named-plus-bare mix.) Small and low-risk; it also fixes the confusing generic
+rejection.
 
 ### PR 3 — LMDB named sub-DB storage routing
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -100,6 +100,7 @@ build(File, Out0, KeepLL) :-
     ),
     normalize_passes(File, Program0, Program1),
     resolve_cache_use(File, Program1, Program),
+    check_multitable_store(File, Program),
     (   Clauses == []
     ->  Preds = [user:plawk_cli_marker/0]
     ;   (   plawk_prolog_block_preds(Clauses, Preds)
@@ -243,6 +244,53 @@ lmdb_c_runtime_file(CFile) :-
     module_property(wam_llvm_target, file(TargetPl)),
     file_directory_name(TargetPl, Dir),
     directory_file_path(Dir, 'wam_cache_lmdb.c', CFile).
+
+% Phase 8.9 (PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md PR 2): when several
+% declared tables share ONE cache store path, apply the per-backend rule
+% (PLAWK_CACHE_BACKENDS.md). A `file` store (class A) is single-table -- a
+% permanent compile error. An `lmdb` store (class B) will hold each table in
+% its own named sub-DB, but that routing is not wired yet (PR 3), so a
+% multi-table lmdb store is a clear "not yet" error rather than a silent
+% overwrite of every table into the one unnamed DB. In-memory tables (no cache
+% backing) are unaffected -- they are not cache_table entries, so a store with
+% one backed table plus bare in-memory tables is fine.
+check_multitable_store(File, Program) :-
+    (   multitable_store(Program, Path, Backend, Names)
+    ->  ( Backend == file
+        ->  format(user_error,
+                'plawk: ~w declares multiple tables ~w in one file store "~w". \c
+                 The file backend is single-table (class A); use a `backend \c
+                 "lmdb"` store for multiple named tables.~n',
+                [File, Names, Path]),
+            halt(2)
+        ;   format(user_error,
+                'plawk: ~w declares multiple tables ~w in one ~w store "~w". \c
+                 Multiple named tables per store are not yet implemented for \c
+                 this backend (phase 8.9).~n',
+                [File, Names, Backend, Path]),
+            halt(2)
+        )
+    ;   true
+    ).
+
+% True when some cache store PATH is declared with two or more distinct table
+% NAMES; binds that path, its backend, and the sorted name list.
+multitable_store(Program, Path, Backend, Names) :-
+    program_begin_clauses(Program, BeginClauses),
+    findall(N-P-B,
+        ( member(begin(Actions), BeginClauses),
+          member(cache_table(N, P, B), Actions) ),
+        Triples),
+    setof(P0, N0^B0^member(N0-P0-B0, Triples), Paths),
+    member(Path, Paths),
+    findall(N1, member(N1-Path-_, Triples), Names0),
+    sort(Names0, Names),
+    Names = [_, _ | _],
+    once(member(_-Path-Backend, Triples)),
+    !.
+
+program_begin_clauses(program(BeginClauses, _, _), BeginClauses).
+program_begin_clauses(program_passes(BeginClauses, _, _), BeginClauses).
 
 % Multi-pass normalisation (PLAWK_MULTIPASS_CACHE.md phase 2). A single
 % `pass { ... }` block is exactly today's main loop, so it lowers to the

--- a/tests/test_plawk_multitable.pl
+++ b/tests/test_plawk_multitable.pl
@@ -37,21 +37,22 @@ test(two_bare_row_tables, [condition(clang_available)]) :-
     assertion(S == ["10 x", "20 y", "x 10", "y 20"]),
     !.
 
-% Two schema'd row tables in one cache store, populated in one pass and read
-% back by name in separate passes. (One file store holds both in-memory tables
-% for the run; durable per-table storage is a later PR, so this asserts the
-% single-run in-memory behaviour.)
-test(two_named_row_tables, [condition(clang_available)]) :-
+% A schema'd (backed) `records of` table alongside a bare positional table, in
+% one program, populated together and read by name and by position. Two schema'd
+% tables cannot share one store (a class-A file store is single-table; LMDB
+% named sub-DBs are a later PR), so a named + a bare table is the valid mix that
+% exercises the driver's N-table plumbing across reader kinds.
+test(named_plus_bare_tables, [condition(clang_available)]) :-
     mdir(Dir),
     directory_file_path(Dir, 'mt.db', Store),
     ( exists_file(Store) -> delete_file(Store) ; true ),
     format(atom(Src),
-        "BEGIN cache(\"~w\") { declare orders(k str, v str); declare customers(k str, v str) }\n\c
-         pass { orders[$1] = row($1, $2); customers[$1] = row($2, $1) }\n\c
+        "BEGIN cache(\"~w\") { declare orders(k str, v str) }\n\c
+         pass { orders[$1] = row($1, $2); b[$1] = $0 }\n\c
          pass records of orders as r { print r[\"k\"], r[\"v\"] }\n\c
-         pass records of customers as r { print r[\"k\"], r[\"v\"] }\n", [Store]),
+         pass rows of b as r { print r[2], r[1] }\n", [Store]),
     run_sorted(Dir, 'named', Src, "a 1\nb 2\n", S),
-    % orders: key=$1 val=$2 ; customers: key=$1 col1=$2 col2=$1
+    % orders (by name): key=$1 val=$2 ; b (positional): col2,col1 of $0
     assertion(S == ["1 a", "2 b", "a 1", "b 2"]),
     !.
 

--- a/tests/test_plawk_multitable_store.pl
+++ b/tests/test_plawk_multitable_store.pl
@@ -1,0 +1,117 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk multi-table stores (PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md, phase 8.9
+% PR 2): per-store table grouping + the backend rule (PLAWK_CACHE_BACKENDS.md).
+% When several declared tables share ONE cache store path, the backend decides:
+% a `file` store (class A) is single-table -> a permanent compile error; an
+% `lmdb` store (class B) will route each table to its own named sub-DB, but that
+% routing is a later PR, so for now a multi-table lmdb store is a clear "not
+% yet" compile error rather than a silent overwrite into the unnamed DB.
+% In-memory tables (no cache backing) are unaffected -- multiple of them, or one
+% backed table plus bare in-memory ones, remain fine (PR 1).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_multitable_store).
+
+% Two tables in one FILE store -> class-A compile error (exit 2). The check
+% runs before codegen/clang, so this needs no clang.
+test(file_multitable_is_compile_error) :-
+    sdir(Dir),
+    directory_file_path(Dir, 'mf.db', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare orders(k str, v str); declare customers(k str, v str) }\n\c
+         pass records of orders as r { print r[\"k\"] }\n\c
+         pass records of customers as r { print r[\"k\"] }\n", [Store]),
+    build_status(Dir, 'mf', Src, St),
+    assertion(St == 2),
+    !.
+
+% Two tables in one LMDB store -> "not yet" compile error (exit 2) until the
+% sub-DB routing (PR 3) lands.
+test(lmdb_multitable_is_not_yet_error) :-
+    sdir(Dir),
+    directory_file_path(Dir, 'ml.lmdb', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare orders(k str, v str); declare customers(k str, v str) }\n\c
+         pass records of orders as r { print r[\"k\"] }\n\c
+         pass records of customers as r { print r[\"k\"] }\n", [Store]),
+    build_status(Dir, 'ml', Src, St),
+    assertion(St == 2),
+    !.
+
+% Multiple IN-MEMORY tables (no cache) are not a store at all -> still builds
+% and runs (the PR-1 capability is unaffected by the PR-2 check).
+test(in_memory_multitable_still_builds, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "pass { a[$1] = $0 ; b[$1] = $0 }\n\c
+           pass rows of a as r { print r[1] }\n\c
+           pass rows of b as r { print r[2] }\n",
+    run_sorted(Dir, 'mm', Src, "k v\n", S),
+    assertion(S == ["k", "v"]),
+    !.
+
+% One backed table plus a bare in-memory table: the store has a single table,
+% so no error; the in-memory table lives alongside.
+test(one_backed_plus_inmem_builds, [condition(clang_available)]) :-
+    sdir(Dir),
+    directory_file_path(Dir, 'ms.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare orders(k str, v str) }\n\c
+         pass { orders[$1] = row($1, $2) ; b[$1] = $0 }\n\c
+         pass records of orders as r { print r[\"k\"] }\n\c
+         pass rows of b as r { print r[2] }\n", [Store]),
+    run_sorted(Dir, 'ms', Src, "x 10\ny 20\n", S),
+    assertion(S == ["10", "20", "x", "y"]),
+    !.
+
+:- end_tests(plawk_multitable_store).
+
+% --- helpers ---------------------------------------------------------------
+
+sdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_multitable_store', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+% Build and return the CLI exit status (no assertion on it).
+build_status(Dir, Name, Src, Status) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Summary

**PR 2 of the phase-8.9 arc** (`PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md`). PR 1 made the driver accept multiple *in-memory* tables. But multiple tables sharing one cache **store** still had no correct behavior — on commit they'd all overwrite each other in the one backing. This applies the per-backend rule (`PLAWK_CACHE_BACKENDS.md`) at compile time.

`check_multitable_store/2` in `examples/plawk/bin/plawk` groups declared cache tables by store path; when a path carries ≥2 distinct table names:

- **`file` store (class A)** → permanent compile error (single-table container), pointing at `backend "lmdb"`.
- **`lmdb` store (class B)** → clear *"not yet"* error — its named-sub-DB routing is **PR 3** — rather than a silent overwrite into the unnamed DB.

In-memory tables (no `cache_table` entry) are untouched: multiple bare tables, or one backed table plus bare ones, still build and run.

## Tests

`tests/test_plawk_multitable_store.pl` (4): file multi-table → exit 2 (class-A message); lmdb multi-table → exit 2 (not-yet message); in-memory multi-table still builds+runs; one backed + one in-memory builds+runs.

## Note — one PR-1 test updated

The PR-1 test `two_named_row_tables` had put two schema'd tables in one file store, relying on single-run in-memory behavior. PR 2 correctly makes that a class-A error, so I updated it to a **named-plus-bare** mix (a schema'd `records of` table + a bare positional table) — same N-table driver plumbing, across a named and a positional reader. (Two schema'd tables in one store returns with PR 3's LMDB sub-DBs; separate cache stores per table don't parse yet.)

Regressions green: `multitable`, `multitable_store`, `multipass`, `multipass_cache`, `use_table`, `row_durable`, `row_cons`.

## Next

**PR 3** — LMDB named sub-DB storage routing (`mdb_env_set_maxdbs` + named `mdb_dbi_open`, factored over a shared core), which removes the lmdb "not yet" error and makes durable multi-table real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_