### PR TITLE
WAM/LLVM plawk: multi-table stores PR 3 — LMDB named sub-DB storage routing

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -1098,11 +1098,13 @@ single-pass test before any driver surgery).
   (`tests/test_plawk_use_table.pl`); (8.9) multiple named tables per store
   (namespaces / LMDB named sub-DBs, §3.5, per `PLAWK_CACHE_BACKENDS.md`) so
   `use ns.table` selects among them — **in progress**, sequenced into five
-  PRs in `PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md`. PR 1 **LANDED**: the
-  multi-pass driver is generalised from one shared table to N, so a program
-  with several in-memory tables builds and runs (`tests/test_plawk_multitable.pl`);
-  durable storage routing (LMDB named sub-DBs) and the `as ns` / `use ns.table`
-  surface follow. (8.10) **reader guards** — a
+  PRs in `PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md`. PRs 1–3 **LANDED**: the
+  multi-pass driver takes N tables (`tests/test_plawk_multitable.pl`); a
+  multi-table *file* store is a class-A compile error while an *lmdb* store
+  routes each table to its own named sub-DB — durable and isolated, both i64 and
+  row values (`tests/test_plawk_multitable_store.pl`,
+  `tests/test_plawk_multitable_lmdb.pl`). Remaining: the `as ns` namespace and
+  `use ns.table` selection (PRs 4–5). (8.10) **reader guards** — a
   `WHERE`-style row filter on any of the three readers: `if (r["col"] CMP int)`
   (records), `if (r[N] CMP int)` (positional), `if ($N CMP int)` (anon), for
   the six operators `== != < <= > >=`. The guard lowers to an i64 field extract

--- a/docs/design/PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
@@ -26,10 +26,11 @@ driver rejects multi-table programs before storage is ever reached.
   two-`declare` program failed the driver match and the build reported
   *"uses multi-pass features outside the current multi-pass surface"*, before
   any cache/storage code ran.)
-- **One store path ≈ one table (storage).** Even once the driver accepts N
-  tables, the LMDB backend writes every table to the **unnamed** DB, so several
-  tables sharing a `cache("store.lmdb")` path overwrite each other on commit
-  (`PLAWK_MULTIPASS_CACHE.md` §3.7). Multi-table storage needs named sub-DBs.
+- **One store path ≈ one table (storage) — FIXED (PR 3).** A multi-table LMDB
+  store now routes each table to its own named sub-DB (`mdb_env_set_maxdbs` +
+  named `mdb_dbi_open`), so tables sharing a `cache("store.lmdb")` path are
+  isolated and durable. A multi-table *file* store stays a compile error (class
+  A, PR 2).
 
 Much of the plumbing was already list-shaped, which is why PR 1 was small: the
 setup/free helpers and `plawk_cache_entries/6` iterate the table list, and the
@@ -87,16 +88,26 @@ schema'd tables in one file store — now correctly an error — with a
 named-plus-bare mix.) Small and low-risk; it also fixes the confusing generic
 rejection.
 
-### PR 3 — LMDB named sub-DB storage routing
+### PR 3 — LMDB named sub-DB storage routing — **LANDED**
 
-The storage payoff. Add sub-DB-aware commit/load to `wam_cache_lmdb.c`
-(`…_lmdb_sub` / `…_lmdb_str_sub`, factored over a shared core taking a
-`const char *subname`, NULL = unnamed): `mdb_env_set_maxdbs` + a named
-`mdb_dbi_open` with `MDB_CREATE` on commit. Codegen routes a multi-table
-store's tables to their sub-DB helpers (single-table stores keep the unnamed
-path, so existing stores stay byte-compatible). Durable multi-table over LMDB,
-both i64 and row (`_str`) values. Test mirrors the durable-rows suites with two
-tables.
+The storage payoff. `wam_cache_lmdb.c` was refactored so each op has a core
+taking `const char *subname` (NULL = unnamed default DB); a shared
+`wam_cache_lmdb_open` sets `mdb_env_set_maxdbs` and opens the named
+`mdb_dbi_open` (`MDB_CREATE` on commit) when a subname is given. Public
+`…_lmdb_sub` / `…_lmdb_str_sub` entry points expose the named-sub-DB form; the
+existing `…_lmdb` / `…_lmdb_str` are the `subname = NULL` case, so single-table
+stores are byte-identical. The schema is stored under its distinguished key
+**inside each named sub-DB**, so every table is independently self-describing
+and validated. Codegen threads a `SubDb` field (`none` | `subdb(Ref)`) through
+the cache entries: `plawk_multitable_paths/2` marks paths with ≥2 tables, each
+such table gets a sub-DB-name global (the table name) and routes to the `_sub`
+helpers; `plawk_cache_fn/5`, `plawk_cache_call_ir/7`, and the decls gained the
+`SubDb` dimension. The bin/plawk gate now allows lmdb multi-table (only file
+stays an error). Tests: `tests/test_plawk_multitable_lmdb.pl` (two row tables
+durable across runs in separate sub-DBs; two i64 counter tables accumulating
+independently; per-sub-DB schema-mismatch → exit 3). The PR-2
+`lmdb_multitable_is_not_yet_error` test flips to `lmdb_multitable_builds_and_runs`.
+Durable multi-table over LMDB, both i64 and row values.
 
 ### PR 4 — `as ns` namespace + `ns.table` references (parser)
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -245,31 +245,21 @@ lmdb_c_runtime_file(CFile) :-
     file_directory_name(TargetPl, Dir),
     directory_file_path(Dir, 'wam_cache_lmdb.c', CFile).
 
-% Phase 8.9 (PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md PR 2): when several
-% declared tables share ONE cache store path, apply the per-backend rule
+% Phase 8.9 (PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md): when several declared
+% tables share ONE cache store path, apply the per-backend rule
 % (PLAWK_CACHE_BACKENDS.md). A `file` store (class A) is single-table -- a
-% permanent compile error. An `lmdb` store (class B) will hold each table in
-% its own named sub-DB, but that routing is not wired yet (PR 3), so a
-% multi-table lmdb store is a clear "not yet" error rather than a silent
-% overwrite of every table into the one unnamed DB. In-memory tables (no cache
-% backing) are unaffected -- they are not cache_table entries, so a store with
-% one backed table plus bare in-memory tables is fine.
+% permanent compile error. An `lmdb` store (class B, PR 3) holds each table in
+% its own named sub-DB, so multi-table is allowed there. In-memory tables (no
+% cache backing) are unaffected -- they are not cache_table entries, so a store
+% with one backed table plus bare in-memory tables is fine.
 check_multitable_store(File, Program) :-
-    (   multitable_store(Program, Path, Backend, Names)
-    ->  ( Backend == file
-        ->  format(user_error,
-                'plawk: ~w declares multiple tables ~w in one file store "~w". \c
-                 The file backend is single-table (class A); use a `backend \c
-                 "lmdb"` store for multiple named tables.~n',
-                [File, Names, Path]),
-            halt(2)
-        ;   format(user_error,
-                'plawk: ~w declares multiple tables ~w in one ~w store "~w". \c
-                 Multiple named tables per store are not yet implemented for \c
-                 this backend (phase 8.9).~n',
-                [File, Names, Backend, Path]),
-            halt(2)
-        )
+    (   multitable_store(Program, Path, file, Names)
+    ->  format(user_error,
+            'plawk: ~w declares multiple tables ~w in one file store "~w". \c
+             The file backend is single-table (class A); use a `backend \c
+             "lmdb"` store for multiple named tables.~n',
+            [File, Names, Path]),
+        halt(2)
     ;   true
     ).
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -6054,9 +6054,9 @@ plawk_assoc_entry_setup_lines([_ArrayName | Rest], Index, CacheEntries) -->
     { format(atom(NewLine),
           '  %plawk_assoc_table_~w = call %WamAssocI64Table* @wam_assoc_i64_new(i64 4096)',
           [Index]),
-      ( memberchk(cache(Index, BytesLen, Backend, ValueKind, SchemaRef), CacheEntries)
-      ->  plawk_cache_fn(Backend, load, ValueKind, LoadFn),
-          plawk_cache_call_ir(LoadFn, Index, BytesLen, ValueKind, SchemaRef, LoadLine),
+      ( memberchk(cache(Index, BytesLen, Backend, ValueKind, SchemaRef, SubDb), CacheEntries)
+      ->  plawk_cache_fn(Backend, load, ValueKind, SubDb, LoadFn),
+          plawk_cache_call_ir(LoadFn, Index, BytesLen, ValueKind, SchemaRef, SubDb, LoadLine),
           Lines = [NewLine, LoadLine]
       ;   Lines = [NewLine]
       ),
@@ -6075,22 +6075,29 @@ plawk_program_cache_tables(BeginClauses, Triples) :-
         ),
         Triples).
 
-%% plawk_cache_fn(+Backend, +Op, +ValueKind, -FnName)
-%  The runtime function for a cache Op (load|commit) under a backend and value
-%  kind. A str-valued (row) table on the `file` backend uses the byte-valued
-%  helpers so the row bytes survive across runs (an i64 store would persist a
-%  process-local atom id). i64 tables use the plain file helpers. `lmdb` has
-%  both: a str-valued (row) table uses the byte-valued external C helpers
-%  (`_lmdb_str`, which store the row bytes + a validated schema entry), while
-%  an i64 table uses the plain `_lmdb` helpers.
-plawk_cache_fn(file, load, str, wam_cache_load_str) :- !.
-plawk_cache_fn(file, commit, str, wam_cache_commit_str) :- !.
-plawk_cache_fn(lmdb, load, str, wam_cache_load_lmdb_str) :- !.
-plawk_cache_fn(lmdb, commit, str, wam_cache_commit_lmdb_str) :- !.
-plawk_cache_fn(lmdb, load, _Kind, wam_cache_load_lmdb) :- !.
-plawk_cache_fn(lmdb, commit, _Kind, wam_cache_commit_lmdb) :- !.
-plawk_cache_fn(_File, load, _Kind, wam_cache_load).
-plawk_cache_fn(_File, commit, _Kind, wam_cache_commit).
+%% plawk_cache_fn(+Backend, +Op, +ValueKind, +SubDb, -FnName)
+%  The runtime function for a cache Op (load|commit) under a backend, value
+%  kind, and store mode (SubDb = `none` for a single-table store's default DB,
+%  or `subdb(_)` for a multi-table store, phase 8.9). A str-valued (row) table
+%  on the `file` backend uses the byte-valued helpers so the row bytes survive
+%  across runs (an i64 store would persist a process-local atom id). i64 tables
+%  use the plain file helpers. `lmdb` has both value kinds, and each in a
+%  single-table (`_lmdb` / `_lmdb_str`, unnamed default DB) or multi-table
+%  (`_lmdb_sub` / `_lmdb_str_sub`, a named sub-DB) form. The file backend is
+%  never multi-table (a compile error, checked earlier), so file never sees
+%  subdb(_).
+plawk_cache_fn(lmdb, load, str, subdb(_), wam_cache_load_lmdb_str_sub) :- !.
+plawk_cache_fn(lmdb, commit, str, subdb(_), wam_cache_commit_lmdb_str_sub) :- !.
+plawk_cache_fn(lmdb, load, _Kind, subdb(_), wam_cache_load_lmdb_sub) :- !.
+plawk_cache_fn(lmdb, commit, _Kind, subdb(_), wam_cache_commit_lmdb_sub) :- !.
+plawk_cache_fn(file, load, str, _Sub, wam_cache_load_str) :- !.
+plawk_cache_fn(file, commit, str, _Sub, wam_cache_commit_str) :- !.
+plawk_cache_fn(lmdb, load, str, _Sub, wam_cache_load_lmdb_str) :- !.
+plawk_cache_fn(lmdb, commit, str, _Sub, wam_cache_commit_lmdb_str) :- !.
+plawk_cache_fn(lmdb, load, _Kind, _Sub, wam_cache_load_lmdb) :- !.
+plawk_cache_fn(lmdb, commit, _Kind, _Sub, wam_cache_commit_lmdb) :- !.
+plawk_cache_fn(_File, load, _Kind, _Sub, wam_cache_load).
+plawk_cache_fn(_File, commit, _Kind, _Sub, wam_cache_commit).
 
 %% plawk_cache_entries(+Tables, +StrArrays, +Schemas, +Triples, -CacheEntries,
 %%     -PathGlobalsIR)
@@ -6104,7 +6111,8 @@ plawk_cache_fn(_File, commit, _Kind, wam_cache_commit).
 %  declared name absent from the plan (never used) is skipped. PathGlobalsIR
 %  carries the path/schema globals plus any lmdb backend declares in use.
 plawk_cache_entries(Tables, StrArrays, Schemas, Triples, CacheEntries, PathGlobalsIR) :-
-    findall(cache(Index, BytesLen, Backend, ValueKind, SchemaRef)-GroupIR,
+    plawk_multitable_paths(Triples, MultiPaths),
+    findall(cache(Index, BytesLen, Backend, ValueKind, SchemaRef, SubDb)-GroupIR,
         ( member(ct(Name, Path, Backend), Triples),
           nth0(Index, Tables, Name),
           ( memberchk(Name, StrArrays) -> ValueKind = str ; ValueKind = i64 ),
@@ -6117,26 +6125,73 @@ plawk_cache_entries(Tables, StrArrays, Schemas, Triples, CacheEntries, PathGloba
               format(atom(SchemaRef),
                   'getelementptr inbounds ([~w x i8], [~w x i8]* @.~w, i64 0, i64 0)',
                   [SBytes, SBytes, SGName]),
-              atomic_list_concat([PathGlobal, SchemaGlobal], '\n', GroupIR)
+              SchemaGlobals = [SchemaGlobal]
           ;   SchemaRef = 'null',
-              GroupIR = PathGlobal
-          )
+              SchemaGlobals = []
+          ),
+          % A multi-table LMDB store routes each table to its own named sub-DB
+          % (phase 8.9); the sub-DB name is the plawk table name. Single-table
+          % stores (and the file backend, which is never multi-table) use the
+          % unnamed default DB.
+          ( Backend == lmdb, memberchk(Path, MultiPaths)
+          ->  format(atom(SubGName), 'plawk_cache_subdb_~w', [Index]),
+              atom_string(Name, NameStr),
+              llvm_emit_c_string_global(SubGName, NameStr, SubGlobal, _SubLen, SubBytes),
+              format(atom(SubRef),
+                  'getelementptr inbounds ([~w x i8], [~w x i8]* @.~w, i64 0, i64 0)',
+                  [SubBytes, SubBytes, SubGName]),
+              SubDb = subdb(SubRef),
+              SubGlobals = [SubGlobal]
+          ;   SubDb = none,
+              SubGlobals = []
+          ),
+          append([[PathGlobal], SchemaGlobals, SubGlobals], GroupParts),
+          atomic_list_concat(GroupParts, '\n', GroupIR)
         ),
         Pairs),
     pairs_keys_values(Pairs, CacheEntries, Globals),
-    ( memberchk(cache(_, _, lmdb, _, _), CacheEntries)
-    ->  BaseLmdbDecls = ['declare void @wam_cache_load_lmdb(%WamAssocI64Table*, i8*)',
-                         'declare void @wam_cache_commit_lmdb(%WamAssocI64Table*, i8*)'],
-        ( memberchk(cache(_, _, lmdb, str, _), CacheEntries)
-        ->  StrLmdbDecls = ['declare void @wam_cache_load_lmdb_str(%WamAssocI64Table*, i8*, i8*)',
-                            'declare void @wam_cache_commit_lmdb_str(%WamAssocI64Table*, i8*, i8*)']
-        ;   StrLmdbDecls = []
-        ),
-        append(BaseLmdbDecls, StrLmdbDecls, LmdbDecls)
-    ;   LmdbDecls = []
-    ),
+    plawk_lmdb_decls(CacheEntries, LmdbDecls),
     append(Globals, LmdbDecls, AllGlobals),
     atomic_list_concat(AllGlobals, '\n', PathGlobalsIR).
+
+%% plawk_multitable_paths(+Triples, -MultiPaths)
+%  Store paths that carry two or more distinct table names -- i.e. multi-table
+%  stores, whose tables route to named sub-DBs. (A multi-table *file* store is
+%  rejected earlier as a compile error, so in practice these are lmdb.)
+plawk_multitable_paths(Triples, MultiPaths) :-
+    findall(Path,
+        ( member(ct(_, Path, _), Triples),
+          findall(N, member(ct(N, Path, _), Triples), Ns0),
+          sort(Ns0, Ns), Ns = [_, _ | _] ),
+        MultiPaths0),
+    sort(MultiPaths0, MultiPaths).
+
+%% plawk_lmdb_decls(+CacheEntries, -Decls)
+%  `declare`s for the external LMDB helpers actually referenced: the plain
+%  (unnamed-DB) i64/str helpers when any lmdb table is present, plus the
+%  named-sub-DB (`_sub`) helpers when a multi-table lmdb store is in use.
+plawk_lmdb_decls(CacheEntries, Decls) :-
+    ( memberchk(cache(_, _, lmdb, _, _, _), CacheEntries)
+    ->  Base = ['declare void @wam_cache_load_lmdb(%WamAssocI64Table*, i8*)',
+                'declare void @wam_cache_commit_lmdb(%WamAssocI64Table*, i8*)'],
+        ( memberchk(cache(_, _, lmdb, str, _, _), CacheEntries)
+        ->  Str = ['declare void @wam_cache_load_lmdb_str(%WamAssocI64Table*, i8*, i8*)',
+                   'declare void @wam_cache_commit_lmdb_str(%WamAssocI64Table*, i8*, i8*)']
+        ;   Str = []
+        ),
+        ( memberchk(cache(_, _, lmdb, i64, _, subdb(_)), CacheEntries)
+        ->  SubI = ['declare void @wam_cache_load_lmdb_sub(%WamAssocI64Table*, i8*, i8*)',
+                    'declare void @wam_cache_commit_lmdb_sub(%WamAssocI64Table*, i8*, i8*)']
+        ;   SubI = []
+        ),
+        ( memberchk(cache(_, _, lmdb, str, _, subdb(_)), CacheEntries)
+        ->  SubS = ['declare void @wam_cache_load_lmdb_str_sub(%WamAssocI64Table*, i8*, i8*, i8*)',
+                    'declare void @wam_cache_commit_lmdb_str_sub(%WamAssocI64Table*, i8*, i8*, i8*)']
+        ;   SubS = []
+        ),
+        append([Base, Str, SubI, SubS], Decls)
+    ;   Decls = []
+    ).
 
 %% plawk_schema_string(+Columns, -Str)
 %  Canonical schema string for a row table: `name:type,name:type,...`. Written
@@ -6146,18 +6201,32 @@ plawk_schema_string(Columns, Str) :-
                   format(atom(CS), '~w:~w', [Name, Type]) ), Parts),
     atomic_list_concat(Parts, ',', Str).
 
-%% plawk_cache_call_ir(+Fn, +Index, +BytesLen, +ValueKind, +SchemaRef, -Line)
-%  A load/commit call. The byte-valued (str) helpers -- both the file
-%  (`_str`) and lmdb (`_lmdb_str`) variants -- take an extra i8* schema
-%  argument (a getelementptr or null); the plain i64 / i64-lmdb helpers do not.
-plawk_cache_call_ir(Fn, Index, BytesLen, str, SchemaRef, Line) :-
+%% plawk_cache_call_ir(+Fn, +Index, +BytesLen, +ValueKind, +SchemaRef, +SubDb, -Line)
+%  A load/commit call. Four shapes by (value kind x store mode):
+%   - str, named sub-DB: (table, path, subname, schema)  -- lmdb multi-table
+%   - i64, named sub-DB: (table, path, subname)          -- lmdb multi-table
+%   - str, default DB:   (table, path, schema)           -- file / lmdb single
+%   - i64, default DB:   (table, path)                    -- file / lmdb single
+%  The byte-valued (str) helpers carry the i8* schema (a getelementptr or
+%  null); the named-sub-DB helpers carry the i8* sub-DB name before it.
+plawk_cache_call_ir(Fn, Index, BytesLen, str, SchemaRef, subdb(SubRef), Line) :-
+    !,
+    format(atom(Line),
+        '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0), i8* ~w, i8* ~w)',
+        [Fn, Index, BytesLen, BytesLen, Index, SubRef, SchemaRef]).
+plawk_cache_call_ir(Fn, Index, BytesLen, _ValueKind, _SchemaRef, subdb(SubRef), Line) :-
+    !,
+    format(atom(Line),
+        '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0), i8* ~w)',
+        [Fn, Index, BytesLen, BytesLen, Index, SubRef]).
+plawk_cache_call_ir(Fn, Index, BytesLen, str, SchemaRef, none, Line) :-
     ( Fn == wam_cache_load_str ; Fn == wam_cache_commit_str
     ; Fn == wam_cache_load_lmdb_str ; Fn == wam_cache_commit_lmdb_str ),
     !,
     format(atom(Line),
         '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0), i8* ~w)',
         [Fn, Index, BytesLen, BytesLen, Index, SchemaRef]).
-plawk_cache_call_ir(Fn, Index, BytesLen, _ValueKind, _SchemaRef, Line) :-
+plawk_cache_call_ir(Fn, Index, BytesLen, _ValueKind, _SchemaRef, none, Line) :-
     format(atom(Line),
         '  call void @~w(%WamAssocI64Table* %plawk_assoc_table_~w, i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.plawk_cache_path_~w, i64 0, i64 0))',
         [Fn, Index, BytesLen, BytesLen, Index]).
@@ -6168,9 +6237,9 @@ plawk_cache_call_ir(Fn, Index, BytesLen, _ValueKind, _SchemaRef, Line) :-
 %  still live), so the committed state is the completed pass.
 plawk_cache_commit_lines(CacheEntries, IR) :-
     findall(Line,
-        ( member(cache(Index, BytesLen, Backend, ValueKind, SchemaRef), CacheEntries),
-          plawk_cache_fn(Backend, commit, ValueKind, CommitFn),
-          plawk_cache_call_ir(CommitFn, Index, BytesLen, ValueKind, SchemaRef, Line)
+        ( member(cache(Index, BytesLen, Backend, ValueKind, SchemaRef, SubDb), CacheEntries),
+          plawk_cache_fn(Backend, commit, ValueKind, SubDb, CommitFn),
+          plawk_cache_call_ir(CommitFn, Index, BytesLen, ValueKind, SchemaRef, SubDb, Line)
         ),
         Lines),
     atomic_list_concat(Lines, '\n', IR).

--- a/src/unifyweaver/targets/wam_cache_lmdb.c
+++ b/src/unifyweaver/targets/wam_cache_lmdb.c
@@ -45,31 +45,58 @@ extern int64_t wam_intern_atom(const char *bytes, int64_t len);
  * grows only as needed. A later knob can make this configurable. */
 #define WAM_CACHE_LMDB_MAPSIZE ((size_t)1 << 30)
 
-static int wam_cache_lmdb_env(const char *path, unsigned int flags,
-                              MDB_env **env_out) {
+/* Max named sub-DBs openable per env (phase 8.9 multi-table). Each cache op
+ * opens at most ONE named sub-DB, so this is a generous ceiling on how many
+ * *distinct* named tables a store may hold; a later knob can raise it. An
+ * unnamed / single-table store passes subname == NULL and needs no maxdbs. */
+#define WAM_CACHE_LMDB_MAXDBS 128
+
+/* Open the store (single NOSUBDIR file), begin a txn, and open the target DB:
+ * the unnamed default DB when `subname` is NULL (single-table store), or the
+ * named sub-DB `subname` otherwise (multi-table store, phase 8.9). Named DBs
+ * require maxdbs set before open; `dbi_flags` carries MDB_CREATE on the write
+ * path. Returns 0 with *env/*txn/*dbi set, else non-zero (nothing to clean up
+ * -- a missing store or absent sub-DB is a no-op for the caller). */
+static int wam_cache_lmdb_open(const char *path, unsigned int env_flags,
+                               const char *subname, unsigned int dbi_flags,
+                               MDB_env **env_out, MDB_txn **txn_out,
+                               MDB_dbi *dbi_out) {
     MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
     if (mdb_env_create(&env)) return -1;
     mdb_env_set_mapsize(env, WAM_CACHE_LMDB_MAPSIZE);
-    if (mdb_env_open(env, path, MDB_NOSUBDIR | flags, 0644)) {
+    if (subname) mdb_env_set_maxdbs(env, WAM_CACHE_LMDB_MAXDBS);
+    if (mdb_env_open(env, path, MDB_NOSUBDIR | env_flags, 0644)) {
+        mdb_env_close(env);
+        return -1;
+    }
+    if (mdb_txn_begin(env, NULL, (env_flags & MDB_RDONLY), &txn)) {
+        mdb_env_close(env);
+        return -1;
+    }
+    if (mdb_dbi_open(txn, subname, dbi_flags, &dbi)) {
+        mdb_txn_abort(txn);
         mdb_env_close(env);
         return -1;
     }
     *env_out = env;
+    *txn_out = txn;
+    *dbi_out = dbi;
     return 0;
 }
 
-/* Load every i64->i64 pair from the store at `path` into `table`. A missing
- * store is a no-op, so an unseeded cache starts empty and a pre-populated
- * one (a prior run, or a peer that wrote the same store) is read in. */
-void wam_cache_load_lmdb(void *table, const char *path) {
+/* Load every i64->i64 pair from the `subname` DB (NULL = unnamed) into `table`.
+ * A missing store or absent sub-DB is a no-op, so an unseeded cache starts
+ * empty and a pre-populated one (a prior run, or a peer) is read in. */
+static void wam_cache_load_lmdb_core(void *table, const char *path,
+                                     const char *subname) {
     MDB_env *env;
     MDB_txn *txn;
     MDB_dbi dbi;
     MDB_cursor *cur;
     MDB_val k, v;
-    if (wam_cache_lmdb_env(path, MDB_RDONLY, &env)) return;
-    if (mdb_txn_begin(env, NULL, MDB_RDONLY, &txn)) { mdb_env_close(env); return; }
-    if (mdb_dbi_open(txn, NULL, 0, &dbi)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
+    if (wam_cache_lmdb_open(path, MDB_RDONLY, subname, 0, &env, &txn, &dbi)) return;
     if (mdb_cursor_open(txn, dbi, &cur)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
     while (mdb_cursor_get(cur, &k, &v, MDB_NEXT) == 0) {
         if (k.mv_size == sizeof(int64_t) && v.mv_size == sizeof(int64_t)) {
@@ -85,16 +112,16 @@ void wam_cache_load_lmdb(void *table, const char *path) {
     mdb_env_close(env);
 }
 
-/* Write every occupied entry of `table` back to the store at `path` in one
- * write transaction (insert-or-replace per key). */
-void wam_cache_commit_lmdb(void *table, const char *path) {
+/* Write every occupied i64 entry of `table` back to the `subname` DB
+ * (NULL = unnamed) in one write transaction (insert-or-replace per key). */
+static void wam_cache_commit_lmdb_core(void *table, const char *path,
+                                       const char *subname) {
     MDB_env *env;
     MDB_txn *txn;
     MDB_dbi dbi;
     int64_t cursor = 0, slot;
-    if (wam_cache_lmdb_env(path, 0, &env)) return;
-    if (mdb_txn_begin(env, NULL, 0, &txn)) { mdb_env_close(env); return; }
-    if (mdb_dbi_open(txn, NULL, 0, &dbi)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
+    unsigned int dbi_flags = subname ? MDB_CREATE : 0;
+    if (wam_cache_lmdb_open(path, 0, subname, dbi_flags, &env, &txn, &dbi)) return;
     while ((slot = wam_assoc_i64_iter_next(table, cursor)) >= 0) {
         int64_t key = wam_assoc_i64_key_at(table, slot);
         int64_t val = wam_assoc_i64_value_at(table, slot);
@@ -105,6 +132,21 @@ void wam_cache_commit_lmdb(void *table, const char *path) {
     }
     mdb_txn_commit(txn);
     mdb_env_close(env);
+}
+
+/* Public i64 entry points: the plain names target the unnamed default DB
+ * (single-table store), the _sub names a named sub-DB (multi-table store). */
+void wam_cache_load_lmdb(void *table, const char *path) {
+    wam_cache_load_lmdb_core(table, path, NULL);
+}
+void wam_cache_commit_lmdb(void *table, const char *path) {
+    wam_cache_commit_lmdb_core(table, path, NULL);
+}
+void wam_cache_load_lmdb_sub(void *table, const char *path, const char *subname) {
+    wam_cache_load_lmdb_core(table, path, subname);
+}
+void wam_cache_commit_lmdb_sub(void *table, const char *path, const char *subname) {
+    wam_cache_commit_lmdb_core(table, path, subname);
 }
 
 /* ---- byte-valued (row) LMDB store ---------------------------------------
@@ -119,15 +161,18 @@ void wam_cache_commit_lmdb(void *table, const char *path) {
 static const char WAM_LMDB_SCHEMA_KEY[] = "__wam_schema__";
 #define WAM_LMDB_SCHEMA_KEYLEN 14  /* strlen(WAM_LMDB_SCHEMA_KEY), != 8 */
 
-void wam_cache_commit_lmdb_str(void *table, const char *path,
-                               const char *schema) {
+/* Commit row bytes for `table` into the `subname` DB (NULL = unnamed). The
+ * declared schema (when present) goes under the distinguished key inside that
+ * same DB, so each named sub-DB is independently self-describing. */
+static void wam_cache_commit_lmdb_str_core(void *table, const char *path,
+                                           const char *subname,
+                                           const char *schema) {
     MDB_env *env;
     MDB_txn *txn;
     MDB_dbi dbi;
     int64_t cursor = 0, slot;
-    if (wam_cache_lmdb_env(path, 0, &env)) return;
-    if (mdb_txn_begin(env, NULL, 0, &txn)) { mdb_env_close(env); return; }
-    if (mdb_dbi_open(txn, NULL, 0, &dbi)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
+    unsigned int dbi_flags = subname ? MDB_CREATE : 0;
+    if (wam_cache_lmdb_open(path, 0, subname, dbi_flags, &env, &txn, &dbi)) return;
     if (schema) {
         MDB_val sk = { WAM_LMDB_SCHEMA_KEYLEN, (void *)WAM_LMDB_SCHEMA_KEY };
         MDB_val sv = { strlen(schema), (void *)schema };
@@ -146,19 +191,19 @@ void wam_cache_commit_lmdb_str(void *table, const char *path,
     mdb_env_close(env);
 }
 
-void wam_cache_load_lmdb_str(void *table, const char *path,
-                             const char *schema) {
+/* Load row bytes from the `subname` DB (NULL = unnamed) into `table`,
+ * re-interning each value; the schema (if present in both store and program)
+ * is validated first -- a mismatch is a loud non-zero exit, exactly like the
+ * file backend -- and the 8-byte data rows skip the schema key by size. */
+static void wam_cache_load_lmdb_str_core(void *table, const char *path,
+                                         const char *subname,
+                                         const char *schema) {
     MDB_env *env;
     MDB_txn *txn;
     MDB_dbi dbi;
     MDB_cursor *cur;
     MDB_val k, v;
-    if (wam_cache_lmdb_env(path, MDB_RDONLY, &env)) return;
-    if (mdb_txn_begin(env, NULL, MDB_RDONLY, &txn)) { mdb_env_close(env); return; }
-    if (mdb_dbi_open(txn, NULL, 0, &dbi)) { mdb_txn_abort(txn); mdb_env_close(env); return; }
-    /* Validate the stored schema against the program's (when both present),
-     * exactly like the file backend: mismatch is a loud, non-zero exit rather
-     * than a silent mis-read of field offsets. */
+    if (wam_cache_lmdb_open(path, MDB_RDONLY, subname, 0, &env, &txn, &dbi)) return;
     if (schema) {
         MDB_val sk = { WAM_LMDB_SCHEMA_KEYLEN, (void *)WAM_LMDB_SCHEMA_KEY };
         MDB_val sv;
@@ -185,4 +230,23 @@ void wam_cache_load_lmdb_str(void *table, const char *path,
     mdb_cursor_close(cur);
     mdb_txn_abort(txn);
     mdb_env_close(env);
+}
+
+/* Public row (str) entry points: plain names target the unnamed default DB
+ * (single-table store); _sub names a named sub-DB (multi-table store). */
+void wam_cache_commit_lmdb_str(void *table, const char *path,
+                               const char *schema) {
+    wam_cache_commit_lmdb_str_core(table, path, NULL, schema);
+}
+void wam_cache_load_lmdb_str(void *table, const char *path,
+                             const char *schema) {
+    wam_cache_load_lmdb_str_core(table, path, NULL, schema);
+}
+void wam_cache_commit_lmdb_str_sub(void *table, const char *path,
+                                   const char *subname, const char *schema) {
+    wam_cache_commit_lmdb_str_core(table, path, subname, schema);
+}
+void wam_cache_load_lmdb_str_sub(void *table, const char *path,
+                                 const char *subname, const char *schema) {
+    wam_cache_load_lmdb_str_core(table, path, subname, schema);
 }

--- a/tests/test_plawk_multitable_lmdb.pl
+++ b/tests/test_plawk_multitable_lmdb.pl
@@ -1,0 +1,131 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk multi-table stores (PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md, phase 8.9
+% PR 3): durable multiple tables in one LMDB store via NAMED SUB-DBs. A store
+% with two or more declared tables routes each to its own sub-DB (named by the
+% plawk table name) -- mdb_env_set_maxdbs + a named mdb_dbi_open -- so the
+% tables are isolated and durable, and each named sub-DB carries its own schema
+% entry (validated independently on open). The unnamed default DB is the
+% catalog and holds no plawk data. Single-table stores keep the unnamed-DB path
+% (byte-compatible with existing stores).
+%
+% Requires liblmdb at build+run time; skipped when clang cannot link -llmdb.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_lmdb_available :-
+    catch(( tmp_c(C, Bin),
+            setup_call_cleanup(open(C, write, S),
+                write(S, "#include <lmdb.h>\nint main(void){MDB_env*e;return mdb_env_create(&e);}\n"),
+                close(S)),
+            format(atom(Cmd), 'clang -w ~w -o ~w -llmdb 2>/dev/null', [C, Bin]),
+            process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+tmp_c(C, Bin) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_mt_lmdb_probe.c', C),
+    directory_file_path(Tmp, 'uw_mt_lmdb_probe', Bin).
+
+:- begin_tests(plawk_multitable_lmdb).
+
+% Two ROW tables in one lmdb store persist across runs, each in its own sub-DB.
+% Readers first, writer last: run 1 both readers silent (empty sub-DBs), writer
+% commits; run 2 each reader sees its own durable rows -- and orders/customers
+% stay distinct, which only holds if they are in separate sub-DBs.
+test(two_row_tables_persist, [condition(clang_lmdb_available)]) :-
+    mdir(Dir),
+    store(Dir, 'rows.lmdb', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare orders(k str, v str); declare customers(k str, v str) }\n\c
+         pass records of orders as r { print r[\"k\"], r[\"v\"] }\n\c
+         pass records of customers as r { print r[\"k\"], r[\"v\"] }\n\c
+         pass { orders[$1] = row($1, $2); customers[$1] = row($2, $1) }\n", [Store]),
+    build(Dir, 'mtr', Src, Bin, In, "a 1\nb 2\n"),
+    run_sorted(Bin, In, S1),
+    assertion(S1 == []),
+    run_sorted(Bin, In, S2),
+    assertion(S2 == ["1 a", "2 b", "a 1", "b 2"]),
+    !.
+
+% Two i64 counter tables in one lmdb store accumulate independently across runs.
+test(two_i64_tables_accumulate, [condition(clang_lmdb_available)]) :-
+    mdir(Dir),
+    store(Dir, 'ctrs.lmdb', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare ca; declare cb }\n\c
+         pass { ca[$1]++ ; cb[$2]++ }\n\c
+         pass over ca as k { print k, ca[k] }\n\c
+         pass over cb as k { print k, cb[k] }\n", [Store]),
+    build(Dir, 'mti', Src, Bin, In, "a x\na y\nb x\n"),
+    run_sorted(Bin, In, S1),
+    assertion(S1 == ["a 2", "b 1", "x 2", "y 1"]),
+    run_sorted(Bin, In, S2),
+    assertion(S2 == ["a 4", "b 2", "x 4", "y 2"]),
+    !.
+
+% Per-sub-DB schema validation: reopening the store with a DIFFERENT schema for
+% one of the named tables fails cleanly (exit 3) -- the schema lives inside each
+% sub-DB, so it is checked per table.
+test(per_subdb_schema_mismatch, [condition(clang_lmdb_available)]) :-
+    mdir(Dir),
+    store(Dir, 'scm.lmdb', Store),
+    format(atom(SrcA),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare orders(k str, v str); declare customers(k str, v str) }\n\c
+         pass records of orders as r { print r[\"k\"] }\n\c
+         pass records of customers as r { print r[\"k\"] }\n\c
+         pass { orders[$1] = row($1, $2); customers[$1] = row($2, $1) }\n", [Store]),
+    build(Dir, 'mtsa', SrcA, BinA, InA, "a 1\n"),
+    run_sorted(BinA, InA, _),
+    format(atom(SrcB),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare orders(k str, w str); declare customers(k str, v str) }\n\c
+         pass records of orders as r { print r[\"k\"] }\n\c
+         pass records of customers as r { print r[\"k\"] }\n\c
+         pass { orders[$1] = row($1, $2); customers[$1] = row($2, $1) }\n", [Store]),
+    build(Dir, 'mtsb', SrcB, BinB, InB, "a 1\n"),
+    process_create(BinB, [InB], [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Code)),
+    assertion(Code == 3),
+    !.
+
+:- end_tests(plawk_multitable_lmdb).
+
+% --- helpers ---------------------------------------------------------------
+
+mdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_multitable_lmdb', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+store(Dir, Name, Store) :-
+    directory_file_path(Dir, Name, Store),
+    atom_concat(Store, '-lock', Lock),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    ( exists_file(Lock) -> delete_file(Lock) ; true ).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+run_sorted(Bin, In, Sorted) :-
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_plawk_multitable_store.pl
+++ b/tests/test_plawk_multitable_store.pl
@@ -21,6 +21,17 @@ clang_available :-
                            [stdout(null), stderr(null), process(Pid)]),
             process_wait(Pid, exit(0)) ), _, fail).
 
+clang_lmdb_available :-
+    catch(( current_prolog_flag(tmp_dir, Tmp),
+            directory_file_path(Tmp, 'uw_mts_lmdb_probe.c', C),
+            directory_file_path(Tmp, 'uw_mts_lmdb_probe', Bin),
+            setup_call_cleanup(open(C, write, S),
+                write(S, "#include <lmdb.h>\nint main(void){MDB_env*e;return mdb_env_create(&e);}\n"),
+                close(S)),
+            format(atom(Cmd), 'clang -w ~w -o ~w -llmdb 2>/dev/null', [C, Bin]),
+            process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
 :- begin_tests(plawk_multitable_store).
 
 % Two tables in one FILE store -> class-A compile error (exit 2). The check
@@ -36,17 +47,23 @@ test(file_multitable_is_compile_error) :-
     assertion(St == 2),
     !.
 
-% Two tables in one LMDB store -> "not yet" compile error (exit 2) until the
-% sub-DB routing (PR 3) lands.
-test(lmdb_multitable_is_not_yet_error) :-
+% Two tables in one LMDB store now build and run (PR 3): each table routes to
+% its own named sub-DB, so they stay isolated. (Durability across runs is
+% covered by test_plawk_multitable_lmdb.pl; here we assert one-run correctness
+% and that it is no longer a compile error.)
+test(lmdb_multitable_builds_and_runs, [condition(clang_lmdb_available)]) :-
     sdir(Dir),
     directory_file_path(Dir, 'ml.lmdb', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    atom_concat(Store, '-lock', Lock),
+    ( exists_file(Lock) -> delete_file(Lock) ; true ),
     format(atom(Src),
         "BEGIN cache(\"~w\" backend \"lmdb\") { declare orders(k str, v str); declare customers(k str, v str) }\n\c
-         pass records of orders as r { print r[\"k\"] }\n\c
-         pass records of customers as r { print r[\"k\"] }\n", [Store]),
-    build_status(Dir, 'ml', Src, St),
-    assertion(St == 2),
+         pass { orders[$1] = row($1, $2); customers[$1] = row($2, $1) }\n\c
+         pass records of orders as r { print r[\"k\"], r[\"v\"] }\n\c
+         pass records of customers as r { print r[\"k\"], r[\"v\"] }\n", [Store]),
+    run_sorted(Dir, 'ml', Src, "a 1\nb 2\n", S),
+    assertion(S == ["1 a", "2 b", "a 1", "b 2"]),
     !.
 
 % Multiple IN-MEMORY tables (no cache) are not a store at all -> still builds


### PR DESCRIPTION
## Summary

**PR 3 of the phase-8.9 arc** — the storage payoff. PR 2 made a multi-table LMDB store a "not yet" error; this wires the routing so each table gets its own **named sub-DB** — durable and isolated.

```awk
BEGIN cache("shop.lmdb" backend "lmdb") { declare orders(k str, v str); declare customers(k str, v str) }
pass { orders[$1] = row($1, $2); customers[$1] = row($2, $1) }
pass records of orders    as r { print r["k"], r["v"] }   # separate sub-DBs,
pass records of customers as r { print r["k"], r["v"] }   # durable across runs
```

## What changed

**Runtime** (`wam_cache_lmdb.c`): refactored so each op has a core taking `const char *subname` (NULL = unnamed default DB). A shared `wam_cache_lmdb_open` sets `mdb_env_set_maxdbs` and opens the named `mdb_dbi_open` (`MDB_CREATE` on commit) when a subname is given. New public `…_lmdb_sub` / `…_lmdb_str_sub`; the existing `…_lmdb` / `…_lmdb_str` are the `subname = NULL` case, so **single-table stores are byte-identical**. The row schema is stored under its key **inside each named sub-DB**, so every table is independently self-describing and validated.

**Codegen** (`plawk_native_codegen.pl`): thread a `SubDb` field (`none` | `subdb(Ref)`) through the cache entries. `plawk_multitable_paths/2` marks store paths with ≥2 tables; each such lmdb table gets a sub-DB-name global (the table name) and routes to the `_sub` helpers. `plawk_cache_fn/5`, `plawk_cache_call_ir/7` (four shapes: value-kind × default/named), and the decls gained the `SubDb` dimension. Single-table and file programs keep the old 2/3-arg calls.

**`bin/plawk`**: the multi-table gate now errors only on `file` (class A); `lmdb` multi-table is allowed and routed.

## Tests

`tests/test_plawk_multitable_lmdb.pl`: two row tables durable across runs in separate sub-DBs (run 1 empty → run 2 sees each table's rows, isolated); two i64 counter tables accumulating independently; per-sub-DB schema mismatch → exit 3.

The PR-2 `lmdb_multitable_is_not_yet_error` test flips to `lmdb_multitable_builds_and_runs` (lmdb multi-table now works). Regressions green: `multitable`, `multitable_store`, `cache_lmdb`, `row_durable_lmdb` (single-table LMDB byte-compatible), `multipass`, `multipass_cache`, `use_table`, `row_cons`, `records_reader`, `row_durable`.

## Next

**PR 4** — `as ns` namespace + `ns.table` references (parser), then **PR 5** — `use ns.table` selection (extends the resolver + gives the LMDB schema probe a sub-DB arg; builds on the still-open #3727).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_