### PR TITLE
mu_cosine: define dependence-aware source-region topology bridge

### DIFF
--- a/prototypes/mu_cosine/DECISIONS_graph_geometry.md
+++ b/prototypes/mu_cosine/DECISIONS_graph_geometry.md
@@ -191,3 +191,29 @@ that the full kernel is invertible.
 
 **Operational consequence:** downstream covariance construction still adds the separately selected nugget or
 block-noise term before whitening.  Kernel diagnostics do not authorize directly inverting a singular kernel.
+
+## 2026-07-13 — replace hard source-region separation with an explicit exposure bridge
+
+**Decision:** keep the exclusive connected source regions, discard the failed three-hop-core requirement, and
+represent cross-region exposure by the normalized Gram of region-average cumulative-walk features.  Lift that
+PSD Gram through a cap-constrained greedy allocation minimizing each exact incremental exposure and report the
+exact stipulated-correlation design effect over the frozen `rho` grid.
+
+**Reason:** full regions have usable raw endpoint capacity, while hard cores discarded 67--98% of nodes.  A
+feature Gram preserves PSD and makes the dependence assumption inspectable.  The stipulated `rho` path
+separates topology exposure from unknown residual amplitude and includes within-region correlation explicitly.
+
+**Authorization boundary:** topology alone cannot identify an effect size, residual covariance, exact
+candidate exposure, or end-to-end power.  A narrow pass unlocks nothing; it supplies fixed matrices to the
+next full-procedure null/power extension.  Only a passing power gate may unlock attempted-input identities.
+This audit does not select `K` or authorize candidates, Nomic, judges, covariance promotion, independent
+batching, QR, or CUDA.
+
+**Rejected:** calling regions independent; treating effective rank, Kish ESS, or a mean-test proxy as the
+complete campaign power calculation; tuning thresholds from the resulting matrices; and using entrywise lower
+covariance bounds for inference.
+
+**Reconsider:** candidate selection becomes eligible only after Stage A source-atomic full-procedure power with
+two-way prompt/source inference, followed by history exclusions, exact structural enumeration, and realized-
+design revalidation.  The ordering is Stage A power on the registered diagnostic allocation, then identity-
+only history if it passes, then Stage B exact candidate enumeration and revalidation.

--- a/prototypes/mu_cosine/DESIGN_repeated_judge_source_dependence.md
+++ b/prototypes/mu_cosine/DESIGN_repeated_judge_source_dependence.md
@@ -1,0 +1,149 @@
+# Repeated-judge source dependence — topology bridge
+
+## Purpose and claim boundary
+
+The three-hop-core construction in `REPORT_repeated_judge_source_regions.md` is too wasteful to support the
+planned campaign.  This amendment replaces hard cross-region separation with an explicit, topology-only
+dependence model over the **full** exclusive source regions.  It is a no-spend structural bridge: it reads only
+the two frozen graphs, creates no candidates or embeddings, consumes no historical outcomes, and calls no
+judge.
+
+Topology can identify a reproducible exposure geometry and its consequences under stipulated correlation
+strengths.  It cannot identify residual covariance, candidate packability, an effect size, or end-to-end power.
+Accordingly, this audit authorizes no downstream operation.  Its passing matrices become fixed inputs to a
+separate source-dependent full-procedure null/power extension.  Only that later power gate may unlock the
+attempted-input **identity** inventory needed to test exact candidate feasibility.  Candidate selection, Nomic,
+live scoring, covariance promotion, independent batching, QR specialization, and CUDA remain further away.
+
+## Frozen full-region construction
+
+Retain the deterministic `K in {64,96,128}` induced-connected partitions from the prior audit, but use every
+node assigned to a region.  Regions remain concentration, fold, and dependence-sensitivity units; they are not
+renamed connected components and are not claimed independent.  True weak-component identity remains a
+separate immutable diagnostic.
+
+Every later three-row candidate component has four distinct graph endpoints and all four must share one
+`source_region`.  A region contributes at most `floor(0.10 G)` components at registered
+`G in {160,320,512,800}`.  The topology audit charges four arbitrary nodes per component.  This is only an
+optimistic necessary capacity bound: history exclusions, the 32 campaign cells, endpoint-disjoint packing,
+the adjacent edge, and the matched finite-distance negative can all reduce realized capacity.
+
+For each `(corpus,K,G)`, form a deterministic exposure-aware diagnostic allocation.  Starting from zero
+counts `n`, repeatedly add one component to the eligible region minimizing the exact increase in
+`n.T E n`, namely `2(E n)_r + E_rr`, with stable region ID as the only tie-break.  A region is eligible until
+the smaller of `floor(region_size/4)` and `floor(0.10 G)` is reached.  Failure to allocate all `G` fails closed.
+This prospective greedy quota spreads components away from already exposed regions; it is not claimed to be
+the global integer optimum.  It is a planned source-diversity target, not evidence that exact candidates
+exist.  The eventual builder must reproduce or improve its registered information diagnostics with real
+candidate counts.
+
+## PSD region exposure
+
+Let `P` be the row-stochastic random-walk transition on the complete frozen undirected graph, with an isolated
+node retaining unit self-mass.  Let `U` be the `K x N` matrix whose row `r` is uniform over the nodes assigned
+to source region `r`.  With frozen cumulative-walk weights
+
+```text
+w = (1, .5, .25, .125),
+Z = sum_h sqrt(w_h) U P^h.
+```
+
+Normalize each nonzero row of `Z` and define
+
+```text
+E = Z_normalized Z_normalized.T.
+```
+
+`E` is symmetric positive semidefinite with unit diagonal by construction.  Because its features are
+nonnegative, its entries are nonnegative.  An off-diagonal entry measures overlap between the average
+radius-three landing profiles of two full regions.  It is an exposure proxy, not an empirical residual
+correlation and not an upper bound for adversarially boundary-concentrated candidates.
+
+For a diagnostic component allocation, let `H` be its one-hot `G x K` region-membership matrix.  The frozen
+source-dependence sensitivity family is
+
+```text
+S = H E H.T,
+C_rho = (1-rho) I_G + rho S,
+rho in {0, .025, .05, .10, .20}.
+```
+
+This path is PSD and unit diagonal.  Distinct components in the same region have correlation `rho`; components
+in different regions have correlation `rho E_rs`.  It deliberately includes within-region dependence instead
+of pretending that a region label makes its components independent.
+
+## Information diagnostics
+
+For an equal-component scalar mean under `C_rho`, report the exact design effect and equivalent independent
+component count
+
+```text
+DE_rho = 1.T C_rho 1 / G,
+G_eff,rho = G^2 / (1.T C_rho 1) = G / DE_rho.
+```
+
+For a separable vector endpoint covariance `C_rho tensor Sigma`, the same value is the worst-linear-contrast
+effective count after whitening by the average marginal `Sigma`.  A future nonseparable source/prompt model
+must instead report
+
+```text
+G_eff,min = 1 / lambda_max(Sigma_bar^-1/2 V_bar Sigma_bar^-1/2),
+```
+
+where `V_bar` is the full covariance of the equal-component vector mean.  Source ESS is a necessary design
+diagnostic, not a power calculation or a replacement for two-way prompt/source inference.
+
+Also report the exposure spectrum, numerical rank, effective rank `(tr E)^2 / tr(E^2)`, off-diagonal
+quantiles, and average hop-specific mass landing outside each source region.  This is not first-exit mass: a
+walk may leave and return by hop `h`.  Report an allocation-free numerically guarded ESS floor too.  Bound
+`n.T E n` above by the tighter of (a) `lambda_max(E)` times the largest feasible
+`sum_r n_r^2`, obtained by filling the largest region capacities first, and (b)
+`G max_r(E c)_r`, where `c` is the capacity vector.  Substituting that upper bound in the mean-variance formula
+gives a lower ESS bound for any cap-feasible allocation.  The implementation upper-bounds `lambda_max(E)` by
+the largest nonnegative row sum and guards floating reductions outward; it does not call an eigensolver-plus-
+tolerance value a formal certificate.  These quantities describe the frozen geometry; no threshold is tuned
+after seeing them.
+
+## Gates and next stage
+
+The narrow topology bridge passes for a `(corpus,K,G)` only when:
+
+1. the four-endpoint optimistic capacity bound can supply `G` components;
+2. the deterministic exposure-aware allocation supplies exactly `G`, respects the 10% cap, and uses at least 20
+   source regions; and
+3. `E` and every `C_rho` are finite, symmetric, PSD, and unit diagonal.
+
+The audit does **not** choose a winning `K` or impose an uncalibrated ESS cutoff.  All `K` values that pass the
+narrow bridge continue to the next stage.  Joint structural passage in both required corpora unlocks nothing
+by itself.  The next work is explicitly two-stage:
+
+1. **Stage A, still without history:** extend the complete repeated-judge null/power procedure using these
+   registered diagnostic allocations and exposure matrices, source-atomic folds, synthetic split-contained
+   prompt incidence, and two-way prompt/source inference.  Require family-wise null control and at least 80%
+   power before the attempted-input identity inventory can be constructed.  That inventory is still not a
+   live-campaign authorization.
+2. **Stage B, after a Stage-A pass:** consume only immutable attempted-input identities, enumerate exact
+   structural candidates after those exclusions, verify the 32 cells, endpoint-disjoint packing,
+   finite-distance negative, cap, and region quotas, then replace the diagnostic lift with realized candidate
+   exposure and prompt incidence.  The realized design must remain inside the powered Stage-A envelope or its
+   full procedure must be recalibrated before candidate selection, Nomic, or spending.
+
+Inference and conditioning use different conservative directions.  Power and uncertainty must cover a
+simultaneous **upper** dependence/spectral envelope; understating dependence is anti-conservative.  If a
+validated covariance is later supplied to the conditioner, its cross-item benefit path is shrunk toward block
+using training-only held benefit and the existing `s_safe`/`delta_95` gates.  Entrywise lower confidence bounds
+are not assumed PSD and are not substituted for either procedure.
+
+## Alternatives rejected or deferred
+
+| Alternative | Disposition | Reason |
+|---|---|---|
+| three-hop cores | reject for campaign construction | certified separation retained too little graph mass in both corpora |
+| call full regions independent | reject | a partition is an engineering unit, not a stochastic independence proof |
+| shortest-path Gaussian region kernel | reject | general graph-distance RBFs are not guaranteed PSD |
+| average pairwise node-kernel matrix without an explicit feature map | reject | expensive and easier to implement with hidden normalization/PSD errors |
+| hard-coded confidence weights or inverse-variance source weights | reject | correlated evidence requires the later calibrated joint posterior; confidence remains a margin gate |
+| entrywise lower 95% covariance for inference | reject | can be non-PSD and understates sampling variance |
+| region count or Kish ESS called power | reject | neither includes the selector, effect size, prompt dependence, multiplicity, nor candidate constraints |
+| tune `K`, hop weights, or `rho` from this audit | reject | would use the diagnostic result to redefine its own prospective family |
+| full repeated-judge power extension in this PR | defer to the next focused PR | first freeze and audit the source matrices; the synthetic extension can use the registered diagnostic allocations, then exact candidate incidence must be rechecked later |

--- a/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
+++ b/prototypes/mu_cosine/PREREG_graph_geometry_repeated_judge.md
@@ -43,6 +43,20 @@ for the frozen radius-three graph feature.  It does **not** make source regions 
 prompt, weak-component, and residual dependence may cross their boundaries.  See
 `REPORT_repeated_judge_source_regions.md`.
 
+**2026-07-13 dependence-aware bridge amendment (frozen before computing its exposure matrices):** retire hard
+three-hop cores as the proposed campaign construction and retain the full exclusive source regions.  Define a
+PSD region exposure Gram from normalized region-average cumulative-walk features, lift it through a
+deterministic cap-constrained exposure-aware greedy component allocation, and audit
+`C_rho=(1-rho)I+rho H E H.T` at `rho in {0,.025,.05,.10,.20}`.  The audit reports full-region four-endpoint
+capacity, exposure spectrum/effective rank, per-hop outside-region landing mass, and exact equal-mean
+design-effect/ESS diagnostics.
+It does not choose `K`, estimate residual covariance, set an ESS cutoff, claim power, or unlock history.
+Passing matrices become frozen inputs to a separate source-dependent full-procedure simulation; only its
+family-wise null/power gate may unlock the attempted-input identity inventory.  Exact candidates, realized
+exposure, source-atomic folds, and two-way prompt/source inference remain mandatory before candidate selection
+or spending.  The frozen construction and rejected alternatives are specified in
+`DESIGN_repeated_judge_source_dependence.md`.
+
 ## Question and experimental unit
 
 The question is whether an outcome-blind graph/semantic geometry predicts transferable cross-item conditional

--- a/prototypes/mu_cosine/REPORT_repeated_judge_campaign_power.md
+++ b/prototypes/mu_cosine/REPORT_repeated_judge_campaign_power.md
@@ -141,6 +141,12 @@ exploratory also fails larger-`G` four-endpoint capacity.  See
 a prospectively powered dependence-aware source design; the remaining ordering is unchanged after that gate
 passes.
 
+`REPORT_repeated_judge_source_dependence.md` subsequently defined that design's topology-only PSD exposure
+matrices and showed full-region structural feasibility for every frozen `K`, while deliberately making no
+power claim and unlocking nothing.  The immediate next item is therefore to lift those registered matrices
+and allocations into this complete null/power procedure with source-atomic folds and two-way prompt/source
+inference.  History remains after that Stage-A power gate, not before it.
+
 1. Implement and review the repository-owned candidate builder, then freeze graph/Nomic/historical artifacts.
 2. Freeze the exact approved live prompt, model revisions, settings, and keyed response parser.
 3. Run a list-position engineering pilot; preregister a train-only position-by-role-by-judge adjustment and add

--- a/prototypes/mu_cosine/REPORT_repeated_judge_source_dependence.md
+++ b/prototypes/mu_cosine/REPORT_repeated_judge_source_dependence.md
@@ -1,0 +1,197 @@
+# Repeated-judge source dependence — topology bridge report
+
+## Bottom line
+
+The hard three-hop-core design failed because it discarded too much of both graphs.  The dependence-aware
+replacement is structurally feasible: using the complete exclusive source regions, every frozen
+`K in {64,96,128}` passes the optimistic four-endpoint capacity, cap-constrained allocation, minimum-region,
+and PSD checks in both corpora at every registered `G in {160,320,512,800}`.
+
+That is a **structural bridge, not a power result or covariance result**.  Region-average graph exposure is a
+stipulated sensitivity geometry, not measured judge-residual correlation and not a worst-case candidate-level
+bound.  No `K` is selected.  The audit reads no history, candidates, embeddings, labels, or judge responses,
+and every authorization remains false.  Its matrices are fixed inputs to the next source-dependent
+full-procedure null/power simulation.
+
+The information diagnostics show why this explicit step matters.  At nominal `G=800` and stipulated
+`rho=.20`, the prospective allocations have only 103--235 effective components in exploratory and 225--365 in
+fresh.  Allocation-free guarded floors are lower still, 19--25 and 33--37.  Treating all 800 components as
+independent would therefore be anti-conservative under this sensitivity model even though most cross-region
+exposures are small.
+
+## Frozen construction
+
+The audit reuses the deterministic induced-connected source regions from the failed core audit but sets the
+halo radius to zero: every graph node remains in exactly one region, and every region remains inside one true
+weak component.  Source region is a concentration, fold, and sensitivity unit; it is not renamed a connected
+component and does not assert independence.
+
+For each region `r`, start a random walk uniformly over its full node set.  With the already frozen weights
+`w=(1,.5,.25,.125)`, form
+
+```text
+Z_r = sum_h sqrt(w_h) U_r P^h,
+E = normalize_rows(Z) normalize_rows(Z).T.
+```
+
+This computes only sparse `K x V` landing distributions and a dense `K x K` Gram; it never creates a
+`V x V` node kernel.  `E` is PSD and unit diagonal by construction.  The audit stores the complete matrix,
+spectrum, off-diagonal quantiles, and hop-specific outside-region landing mass.  The latter is not first-exit
+mass because a walk can leave and return.
+
+For each `(corpus,K,G)`, a prospective greedy quota adds the next component to the eligible region minimizing
+the exact increment `2(E n)_r+E_rr`, with stable region ID as the only tie-break.  Region capacity is
+
+```text
+min(floor(region_nodes/4), floor(.10 G)).
+```
+
+The quota is an outcome-blind design target, not proof that the later four-endpoint, 32-cell, history-disjoint
+candidate packing exists.  With one-hot component-to-region incidence `H`, the stipulated source path is
+
+```text
+C_rho = (1-rho) I_G + rho H E H.T,
+rho in {0,.025,.05,.10,.20}.
+```
+
+Distinct components assigned to the same source region have correlation `rho`; a cross-region pair has
+correlation `rho E_rs`.  For the equal-component scalar mean,
+
+```text
+G_eff = G^2 / [(1-rho)G + rho n.T E n].
+```
+
+This is exact for the stipulated separable path.  It is an information diagnostic, not the power of the
+repeated-judge selector.  The audit also gives a numerically guarded allocation-free lower ESS by upper-
+bounding `n.T E n` with the tighter of a nonnegative-row-sum/capacity-squared bound and a nonnegative
+row-capacity bound.
+
+## Frozen inputs and reproducibility
+
+| corpus | graph | nodes | undirected edges | content identity |
+|---|---|---:|---:|---|
+| exploratory | SimpleWiki `100k_cats/category_parent.tsv` | 84,136 | 196,876 | `4881beed...5dc8ec` |
+| fresh | enwiki `Behavior` LMDB slice | 75,901 | 99,971 | `3bcfe59a...a5d690` |
+
+The fresh loader continues to bind the exploratory graph used for title exclusion.  LMDB `lock.mdb` remains
+excluded runtime state.  The runner hashes the design, preregistration, implementation, graph inputs, and
+loader dependencies at startup; it reloads and compares graph content records and loader metadata after the
+audit, then rechecks the scientific files before output.  The path-free Python/NumPy/BLAS identity is recorded,
+and the CLI requests one BLAS thread through `threadpoolctl` when available.  Paths and elapsed time are absent
+from the JSON.
+
+Two final computations produced the same complete 2,767,735-byte payload record, SHA-256
+`bf9a09c35e54bd36c2e7efea19c432ccf1e9105ff67c4154cfc1c6e744a843b2`.  The tracked review projection is
+308,090 bytes, SHA-256 `89fe1e33568badc39c4a68eb419bceac40cdb4f06714f488b556b32879e0ec20`;
+it retains all decisions and scalar diagnostics plus content records for omitted exact matrices and quotas.
+
+## Full-region capacity
+
+The table is the optimistic number of four-endpoint components available after only region size and the 10%
+cap.  Every entry exceeds its requested `G`; exact candidate packability remains untested.
+
+| corpus | `K` | `U4(160)` | `U4(320)` | `U4(512)` | `U4(800)` | regions used at `G=800` |
+|---|---:|---:|---:|---:|---:|---:|
+| exploratory | 64 | 538 | 1,053 | 1,645 | 2,534 | 40 |
+| exploratory | 96 | 1,050 | 2,077 | 3,283 | 5,037 | 72 |
+| exploratory | 128 | 1,546 | 3,050 | 4,789 | 7,219 | 104 |
+| fresh | 64 | 1,024 | 2,048 | 3,261 | 5,088 | 64 |
+| fresh | 96 | 1,536 | 3,069 | 4,850 | 7,517 | 96 |
+| fresh | 128 | 2,048 | 4,068 | 6,379 | 9,757 | 128 |
+
+The exploratory graph contains small weak components and some regions with fewer than four nodes, so not all
+nominal regions receive a component.  The used counts still exceed the frozen minimum of 20.  The fresh graph
+uses every region.
+
+## Exposure geometry
+
+| corpus | `K` | numerical rank | effective rank | largest eigenvalue | off-diagonal 95th percentile | maximum | mean outside landing hop 1 / 2 / 3 |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| exploratory | 64 | 64 | 62.38 | 1.661 | .0244 | .535 | 17.89% / 18.99% / 25.17% |
+| exploratory | 96 | 96 | 91.31 | 2.077 | .0230 | .774 | 25.31% / 27.38% / 36.12% |
+| exploratory | 128 | 128 | 123.10 | 1.934 | .0207 | .584 | 28.63% / 32.25% / 41.87% |
+| fresh | 64 | 64 | 63.79 | 1.251 | .0087 | .246 | 6.54% / 9.55% / 12.84% |
+| fresh | 96 | 96 | 95.55 | 1.366 | .0063 | .362 | 6.63% / 10.00% / 13.22% |
+| fresh | 128 | 128 | 127.48 | 1.370 | .0046 | .364 | 6.73% / 10.08% / 13.44% |
+
+The matrices are full rank and have effective rank near `K`, so the average region landing profiles are mostly
+distinct.  This does **not** mean cross-region dependence is absent.  The high maxima show a small number of
+strongly exposed neighboring region pairs, while the low 95th percentiles show that most region pairs barely
+overlap.  Exploratory loses much more random-walk mass across its cuts than fresh, consistent with the earlier
+core failure.
+
+Average-region exposure can understate a candidate set concentrated near cut boundaries.  The later builder
+must recompute the lifted exposure for the realized candidate incidence; it cannot inherit these averages as
+a certified upper bound.
+
+## Effective-information sensitivity
+
+The table gives the exact prospective-quota `G_eff` at the weakest nonzero and strongest frozen source
+couplings.  Parentheses contain the allocation-free numerically guarded floor at `rho=.20`.
+
+| corpus | `K` | `G=160`, `.025` / `.20` | `G=320`, `.025` / `.20` | `G=512`, `.025` / `.20` | `G=800`, `.025` / `.20` (floor) |
+|---|---:|---:|---:|---:|---:|
+| exploratory | 64 | 141.1 / 77.3 | 244.7 / 92.5 | 337.1 / 99.4 | 434.1 / 103.3 (24.7) |
+| exploratory | 96 | 150.3 / 105.4 | 276.0 / 140.7 | 401.6 / 160.1 | 552.1 / 174.2 (21.2) |
+| exploratory | 128 | 154.2 / 123.1 | 290.4 / 176.4 | 433.6 / 209.4 | 615.4 / 235.3 (19.0) |
+| fresh | 64 | 153.0 / 117.3 | 287.4 / 167.9 | 428.1 / 199.4 | 606.1 / 224.7 (36.5) |
+| fresh | 96 | 156.3 / 134.7 | 299.6 / 207.1 | 456.0 / 258.2 | 663.6 / 302.6 (33.8) |
+| fresh | 128 | 158.0 / 145.3 | 306.0 / 234.2 | 471.3 / 302.8 | 696.4 / 365.3 (33.3) |
+
+Finer partitions improve the exact greedy-quota information but are not declared winners: the audit has no
+effect size, selector, multiplicity calibration, prompt incidence, or exact candidate universe.  The guarded
+floor is intentionally allocation-agnostic and can be lower at larger `K` because it protects against any
+cap-feasible concentration, not the prospective quota.  Neither diagnostic is a confidence interval.
+
+## Decision and next work
+
+All three `K` values define a jointly feasible structural bridge, and all continue forward.  No region count
+is selected.  Every authorization field is false and the normal runner exits 2 after writing the completed
+artifact; `--audit-only` is the explicit report-mode zero exit and changes no decision.
+
+The next no-spend PR is Stage A: extend the complete repeated-judge simulation rather than jump to history or
+candidate construction:
+
+1. lift these fixed source matrices through the registered component allocations in the persistent-error DGP;
+2. make source regions indivisible in outer and inner folds while keeping prompt blocks split-contained;
+3. include prompt and source incidence jointly in the estimator and a two-way prompt/source or graph-aware
+   simultaneous inference path;
+4. use the upper `rho=.20` dependence envelope for error control, while keeping any later conditioner benefit
+   on the separate train-only `s_safe` shrinkage path;
+5. rerun the complete family-wise selector under block-null, mean-only, planted topology, and deranged controls
+   and require at least 80% primary-event power in both synthetic corpora; and
+6. only after that gate passes, begin Stage B by unlocking the attempted-input identity inventory and exact
+   structural candidate packing.  Realized candidate exposure and prompt incidence must remain inside the
+   powered envelope or trigger recalibration before Nomic or judge work.
+
+`JointPosterior` remains the calibrated learned decision comparator.  It is not this source kernel and is not
+the square-root/QR factorization.  Dense QR remains the numerical reference, and no QR/CUDA optimization is
+eligible until a real covariance model passes the later statistical gates.
+
+## Verification and reproduction
+
+The new focused module/runner tests cover PSD and unit diagonal, input-order invariance, direct equivalence to
+the canonical cumulative-walk feature map, boundary and isolated-node outside-landing mass, exact
+cap/allocation behavior, analytic ESS, exhaustive toy verification of the guarded bound, malformed inputs,
+two-corpus joint logic, all-false authorization, path-free numerical-runtime identity, portable atomic output,
+and start/end scientific and external-input provenance drift.  The 35 focused tests pass; together with the
+inherited source-region, capacity, and graph-geometry suites, 99 tests pass.  Python compilation and
+`git diff --check` are clean.  The broader repeated-judge set has 146 passing tests when its multiprocessing
+power-runner file is executed in the required fresh pytest process; loading graph/SciPy libraries first in the
+same parent intentionally changes the recorded BLAS identity and makes that provenance test fail closed.
+
+```bash
+python prototypes/mu_cosine/run_repeated_judge_source_dependence.py \
+  --artifact-repo /path/to/UnifyWeaver-with-ignored-graph-artifacts \
+  --out /tmp/repeated_judge_source_dependence.json \
+  --audit-only
+
+python prototypes/mu_cosine/run_repeated_judge_source_dependence.py \
+  --artifact-repo /path/to/UnifyWeaver-with-ignored-graph-artifacts \
+  --out prototypes/mu_cosine/repro/repeated_judge_source_dependence/summary.json \
+  --summary-only --audit-only
+```
+
+The tracked artifact is `repro/repeated_judge_source_dependence/summary.json`.  `--summary-only` changes only
+the review projection, not scientific computation or decisions.  Omitting `--audit-only` still writes the
+requested complete/summary artifact and exits 2 because this PR intentionally unlocks nothing.

--- a/prototypes/mu_cosine/REPORT_repeated_judge_source_regions.md
+++ b/prototypes/mu_cosine/REPORT_repeated_judge_source_regions.md
@@ -171,6 +171,13 @@ exact packability, prompt/position pilots, repeated judge collection, covariance
 square-root/QR/CUDA implementation.  `JointPosterior` remains the learned decision comparator; the QR
 conditioner remains the numerical implementation of a statistically promoted covariance model.
 
+**Subsequent result:** `REPORT_repeated_judge_source_dependence.md` retains these exclusive regions but replaces
+the failed cores with a PSD dependence bridge over full-region cumulative-walk landing profiles.  All
+`K={64,96,128}` pass its narrow two-corpus structural grid, without selecting a winner.  That later audit
+still unlocks nothing: its fixed matrices and registered allocations now feed a Stage-A source-dependent
+full-procedure null/power simulation.  Only a passing simulation may unlock attempted-input identities; exact
+post-exclusion candidate exposure and prompt incidence are then a separate Stage-B recheck.
+
 Verification passes 25 focused source-region/runner tests, 117 repeated-judge regressions, and 15 graph-
 geometry tests.  Python compilation and `git diff --check` are clean.  The multiprocessing repeated-judge and
 graph-geometry suites are run in separate pytest processes so their BLAS-runtime provenance is not affected by

--- a/prototypes/mu_cosine/repeated_judge_source_dependence.py
+++ b/prototypes/mu_cosine/repeated_judge_source_dependence.py
@@ -1,0 +1,585 @@
+"""Topology-only source-region exposure and ESS diagnostics.
+
+The module operates on full :class:`SourceRegionPartition` regions.  It never
+forms a node-by-node Gram matrix, reads outcomes, or claims that the exposure
+proxy is an empirical covariance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Mapping
+
+import numpy as np
+
+from repeated_judge_campaign import FROZEN_WALK_WEIGHTS
+from repeated_judge_candidate_capacity import (
+    ENDPOINTS_PER_COMPONENT,
+    SOURCE_COMPONENT_CAP_FRACTION,
+)
+from repeated_judge_source_regions import (
+    SourceRegionPartition,
+    _canonical_source_graph,
+    build_source_region_partition,
+)
+
+
+DEFAULT_RHO_GRID = (0.0, 0.025, 0.05, 0.10, 0.20)
+DEFAULT_MIN_EFFECTIVE_REGIONS = 20
+
+
+class SourceDependenceError(ValueError):
+    """Raised when a source-dependence input or invariant fails closed."""
+
+
+@dataclass(frozen=True)
+class RegionExposure:
+    """Canonical exposure and per-hop outside-region landing diagnostics."""
+
+    region_ids: tuple[str, ...]
+    matrix: np.ndarray
+    walk_weights: tuple[float, ...]
+    per_region_outside_landing_mass: tuple[tuple[float, ...], ...]
+    mean_outside_landing_mass_by_hop: tuple[float, ...]
+
+
+def _positive_integer(value, name):
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise SourceDependenceError(f"{name} must be a positive integer")
+    return value
+
+
+def _validated_weights(weights):
+    try:
+        values = tuple(float(value) for value in weights)
+    except (TypeError, ValueError) as exc:
+        raise SourceDependenceError("walk weights must be numeric") from exc
+    if (
+        not values
+        or any(not math.isfinite(value) or value < 0.0 for value in values)
+        or not any(value > 0.0 for value in values)
+    ):
+        raise SourceDependenceError(
+            "walk weights must be finite, nonnegative, and have positive support"
+        )
+    return values
+
+
+def _validated_partition(adjacency, partition):
+    if not isinstance(partition, SourceRegionPartition):
+        raise SourceDependenceError("partition must be a SourceRegionPartition")
+    region_ids = tuple(sorted(partition.region_nodes))
+    if (
+        len(region_ids) != partition.target_region_count
+        or not region_ids
+        or any(not isinstance(region, str) or not region for region in region_ids)
+    ):
+        raise SourceDependenceError("partition has invalid stable region IDs")
+    covered = set()
+    expected_assignment = {}
+    for region in region_ids:
+        nodes = partition.region_nodes[region]
+        if not nodes:
+            raise SourceDependenceError("full source regions must be nonempty")
+        if covered & set(nodes):
+            raise SourceDependenceError("source regions must be disjoint")
+        for node in nodes:
+            expected_assignment[node] = region
+        covered.update(nodes)
+    if covered != set(adjacency):
+        raise SourceDependenceError(
+            "full source regions must cover the canonical graph exactly"
+        )
+    if partition.assignment != expected_assignment:
+        raise SourceDependenceError("partition assignment disagrees with region nodes")
+    return region_ids
+
+
+def _advance_walk(distribution, adjacency):
+    output = {}
+    for node, mass in sorted(distribution.items()):
+        neighbors = adjacency[node]
+        if not neighbors:
+            output[node] = output.get(node, 0.0) + mass
+            continue
+        share = mass / len(neighbors)
+        for neighbor in sorted(neighbors):
+            output[neighbor] = output.get(neighbor, 0.0) + share
+    return output
+
+
+def build_region_exposure(
+    parents,
+    children,
+    partition,
+    *,
+    walk_weights=FROZEN_WALK_WEIGHTS,
+):
+    """Build ``E = Z_normalized Z_normalized.T`` without a node Gram."""
+    try:
+        adjacency = _canonical_source_graph(parents, children)
+    except Exception as exc:
+        if isinstance(exc, SourceDependenceError):
+            raise
+        raise SourceDependenceError(str(exc)) from exc
+    region_ids = _validated_partition(adjacency, partition)
+    weights = _validated_weights(walk_weights)
+    features = []
+    outside_landing = []
+    for region in region_ids:
+        nodes = partition.region_nodes[region]
+        current = {node: 1.0 / len(nodes) for node in sorted(nodes)}
+        accumulated = {}
+        region_outside_landing = []
+        for hop, weight in enumerate(weights):
+            retained = math.fsum(
+                mass for node, mass in current.items() if node in nodes
+            )
+            region_outside_landing.append(
+                float(min(1.0, max(0.0, 1.0 - retained)))
+            )
+            scale = math.sqrt(weight)
+            if scale:
+                for node, mass in sorted(current.items()):
+                    accumulated[node] = accumulated.get(node, 0.0) + scale * mass
+            if hop + 1 < len(weights):
+                current = _advance_walk(current, adjacency)
+        norm = math.sqrt(math.fsum(value * value for value in accumulated.values()))
+        if not math.isfinite(norm) or norm <= 0.0:
+            raise SourceDependenceError("every cumulative-walk feature must be nonzero")
+        features.append({node: value / norm for node, value in accumulated.items()})
+        outside_landing.append(tuple(region_outside_landing))
+
+    # Accumulate only the K x K Gram from sparse region features.  No V x V
+    # node Gram is constructed.
+    by_node = {}
+    for region_index, feature in enumerate(features):
+        for node, value in feature.items():
+            by_node.setdefault(node, []).append((region_index, value))
+    exposure = np.zeros((len(region_ids), len(region_ids)), dtype=float)
+    for node in sorted(by_node):
+        entries = by_node[node]
+        for left_offset, (left, left_value) in enumerate(entries):
+            for right, right_value in entries[left_offset:]:
+                product = left_value * right_value
+                exposure[left, right] += product
+                if left != right:
+                    exposure[right, left] += product
+    exposure = 0.5 * (exposure + exposure.T)
+    diagonal = np.diag(exposure)
+    if np.any(diagonal <= 0.0) or not np.isfinite(exposure).all():
+        raise SourceDependenceError("region exposure is not finite with positive diagonal")
+    exposure /= np.sqrt(diagonal[:, None] * diagonal[None, :])
+    exposure = 0.5 * (exposure + exposure.T)
+    np.fill_diagonal(exposure, 1.0)
+    if np.min(exposure) < -1e-12:
+        raise SourceDependenceError("nonnegative walk features produced negative exposure")
+    eigenvalues = np.linalg.eigvalsh(exposure)
+    tolerance = 64.0 * np.finfo(float).eps * max(1, len(region_ids))
+    if eigenvalues[0] < -tolerance:
+        raise SourceDependenceError("region exposure is not numerically PSD")
+    mean_outside_landing = tuple(
+        float(np.mean([row[hop] for row in outside_landing]))
+        for hop in range(len(weights))
+    )
+    exposure.setflags(write=False)
+    return RegionExposure(
+        region_ids,
+        exposure,
+        weights,
+        tuple(outside_landing),
+        mean_outside_landing,
+    )
+
+
+def compute_per_hop_outside_landing_mass(
+    parents,
+    children,
+    partition,
+    *,
+    walk_weights=FROZEN_WALK_WEIGHTS,
+):
+    """Return hop-h mass landing outside each start region.
+
+    This is not a first-exit probability: a walk may leave and return before
+    hop ``h``.
+    """
+    exposure = build_region_exposure(
+        parents, children, partition, walk_weights=walk_weights
+    )
+    return {
+        "region_ids": list(exposure.region_ids),
+        "per_region": {
+            region: list(exposure.per_region_outside_landing_mass[index])
+            for index, region in enumerate(exposure.region_ids)
+        },
+        "mean_by_hop": list(exposure.mean_outside_landing_mass_by_hop),
+    }
+
+
+def full_region_capacities(
+    partition,
+    components_per_corpus,
+    *,
+    endpoints_per_component=ENDPOINTS_PER_COMPONENT,
+    cap_fraction=SOURCE_COMPONENT_CAP_FRACTION,
+):
+    """Return exact optimistic full-region capacities in stable ID order."""
+    components_per_corpus = _positive_integer(
+        components_per_corpus, "components_per_corpus"
+    )
+    endpoints_per_component = _positive_integer(
+        endpoints_per_component, "endpoints_per_component"
+    )
+    if cap_fraction != SOURCE_COMPONENT_CAP_FRACTION:
+        raise SourceDependenceError("cap_fraction must equal the frozen 0.10")
+    if not isinstance(partition, SourceRegionPartition):
+        raise SourceDependenceError("partition must be a SourceRegionPartition")
+    cap = components_per_corpus // 10
+    return {
+        region: min(len(partition.region_nodes[region]) // endpoints_per_component, cap)
+        for region in sorted(partition.region_nodes)
+    }
+
+
+def _validated_exposure(exposure):
+    if not isinstance(exposure, RegionExposure):
+        raise SourceDependenceError("exposure must be a RegionExposure")
+    matrix = np.asarray(exposure.matrix, dtype=float)
+    size = len(exposure.region_ids)
+    if (
+        tuple(exposure.region_ids) != tuple(sorted(set(exposure.region_ids)))
+        or any(not isinstance(region, str) or not region for region in exposure.region_ids)
+        or matrix.shape != (size, size)
+        or not np.isfinite(matrix).all()
+        or not np.allclose(matrix, matrix.T, atol=1e-12, rtol=0.0)
+        or not np.allclose(np.diag(matrix), 1.0, atol=1e-12, rtol=0.0)
+        or np.min(matrix) < -1e-12
+        or np.linalg.eigvalsh(matrix)[0] < -1e-10
+    ):
+        raise SourceDependenceError(
+            "exposure must be finite, symmetric, nonnegative, PSD, and unit diagonal"
+        )
+    return matrix
+
+
+def _validated_counts(exposure, values, name):
+    if isinstance(values, Mapping) and "counts_by_region" in values:
+        values = values["counts_by_region"]
+    if not isinstance(values, Mapping) or set(values) != set(exposure.region_ids):
+        raise SourceDependenceError(f"{name} must contain every canonical region ID")
+    counts = []
+    for region in exposure.region_ids:
+        value = values[region]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise SourceDependenceError(f"{name} must contain nonnegative integers")
+        counts.append(value)
+    return np.asarray(counts, dtype=int)
+
+
+def exposure_aware_greedy_allocation(
+    exposure,
+    capacities,
+    components_per_corpus,
+):
+    """Allocate components by the exact greedy quadratic-objective increment."""
+    matrix = _validated_exposure(exposure)
+    components_per_corpus = _positive_integer(
+        components_per_corpus, "components_per_corpus"
+    )
+    capacity = _validated_counts(exposure, capacities, "capacities")
+    if int(np.sum(capacity)) < components_per_corpus:
+        raise SourceDependenceError("full-region capacities cannot allocate all components")
+    counts = np.zeros(len(exposure.region_ids), dtype=int)
+    matrix_counts = np.zeros(len(exposure.region_ids), dtype=float)
+    assignments = []
+    for _ in range(components_per_corpus):
+        eligible = np.flatnonzero(counts < capacity)
+        if not len(eligible):
+            raise SourceDependenceError("allocation exhausted eligible regions")
+        winner = min(
+            map(int, eligible),
+            key=lambda index: (
+                float(2.0 * matrix_counts[index] + matrix[index, index]),
+                exposure.region_ids[index],
+            ),
+        )
+        counts[winner] += 1
+        matrix_counts += matrix[:, winner]
+        assignments.append(exposure.region_ids[winner])
+    objective = float(counts @ matrix @ counts)
+    return {
+        "counts_by_region": {
+            region: int(counts[index])
+            for index, region in enumerate(exposure.region_ids)
+        },
+        "assignment_region_ids": assignments,
+        "used_region_count": int(np.count_nonzero(counts)),
+        "quadratic_exposure": objective,
+    }
+
+
+def _validated_rho(rho):
+    if isinstance(rho, bool):
+        raise SourceDependenceError("rho must be numeric, not boolean")
+    try:
+        rho = float(rho)
+    except (TypeError, ValueError) as exc:
+        raise SourceDependenceError("rho must be numeric") from exc
+    if not math.isfinite(rho) or not 0.0 <= rho <= 1.0:
+        raise SourceDependenceError("rho must lie in [0,1]")
+    return rho
+
+
+def exact_mean_ess(exposure, allocation, rho):
+    """Exact scalar-mean design effect and ESS for the stipulated path."""
+    matrix = _validated_exposure(exposure)
+    counts = _validated_counts(exposure, allocation, "allocation")
+    total = int(np.sum(counts))
+    if total < 1:
+        raise SourceDependenceError("allocation must contain at least one component")
+    rho = _validated_rho(rho)
+    quadratic = float(counts @ matrix @ counts)
+    variance_sum = float((1.0 - rho) * total + rho * quadratic)
+    design_effect = variance_sum / total
+    return {
+        "components": total,
+        "rho": rho,
+        "quadratic_exposure": quadratic,
+        "one_C_one": variance_sum,
+        "design_effect": design_effect,
+        "effective_components": total * total / variance_sum,
+    }
+
+
+def certified_ess_lower_bound(
+    exposure,
+    capacities,
+    components_per_corpus,
+    rho,
+):
+    """Allocation-free ESS floor for every cap-feasible count vector."""
+    matrix = _validated_exposure(exposure)
+    total = _positive_integer(components_per_corpus, "components_per_corpus")
+    capacity = _validated_counts(exposure, capacities, "capacities")
+    if int(np.sum(capacity)) < total:
+        raise SourceDependenceError("capacities cannot supply the requested total")
+    rho = _validated_rho(rho)
+    remaining = total
+    max_sum_squares = 0
+    for index in sorted(
+        range(len(capacity)),
+        key=lambda item: (-int(capacity[item]), exposure.region_ids[item]),
+    ):
+        taken = min(remaining, int(capacity[index]))
+        max_sum_squares += taken * taken
+        remaining -= taken
+        if not remaining:
+            break
+    # For a symmetric nonnegative matrix, the spectral radius is no greater
+    # than its largest row sum.  ``nextafter`` guards the floating reductions
+    # outward; unlike an eigensolver residual heuristic, this preserves the
+    # analytic Perron/Gershgorin inequality for the stored float matrix.
+    row_sums = [
+        float(np.nextafter(math.fsum(map(float, row)), math.inf))
+        for row in matrix
+    ]
+    lambda_upper = max(row_sums)
+    spectral_upper = float(
+        np.nextafter(lambda_upper * max_sum_squares, math.inf)
+    )
+    capacity_image_upper = []
+    for row in matrix:
+        products = [
+            float(np.nextafter(float(value) * int(limit), math.inf))
+            if value > 0.0 and limit > 0
+            else 0.0
+            for value, limit in zip(row, capacity)
+        ]
+        capacity_image_upper.append(
+            float(np.nextafter(math.fsum(products), math.inf))
+        )
+    capacity_upper = float(
+        np.nextafter(total * max(capacity_image_upper), math.inf)
+    )
+    quadratic_upper = max(float(total), min(spectral_upper, capacity_upper))
+    variance_upper = float((1.0 - rho) * total + rho * quadratic_upper)
+    return {
+        "components": total,
+        "rho": rho,
+        "lambda_max_upper": lambda_upper,
+        "lambda_max_upper_method": (
+            "maximum nonnegative row sum with outward float guard"
+        ),
+        "maximum_feasible_sum_squares": int(max_sum_squares),
+        "spectral_quadratic_upper_bound": float(spectral_upper),
+        "capacity_quadratic_upper_bound": float(capacity_upper),
+        "quadratic_exposure_upper_bound": quadratic_upper,
+        "design_effect_upper_bound": variance_upper / total,
+        "effective_components_lower_bound": total * total / variance_upper,
+    }
+
+
+def component_correlation_matrix(exposure, allocation, rho):
+    """Materialize the stipulated component correlation for small diagnostics."""
+    matrix = _validated_exposure(exposure)
+    counts = _validated_counts(exposure, allocation, "allocation")
+    rho = _validated_rho(rho)
+    indices = np.repeat(np.arange(len(counts)), counts)
+    if not len(indices):
+        raise SourceDependenceError("allocation must contain at least one component")
+    source = matrix[np.ix_(indices, indices)]
+    return (1.0 - rho) * np.eye(len(indices)) + rho * source
+
+
+def _exposure_diagnostics(exposure):
+    matrix = _validated_exposure(exposure)
+    eigenvalues = np.linalg.eigvalsh(matrix)
+    tolerance = max(matrix.shape) * np.finfo(float).eps * max(
+        1.0, float(eigenvalues[-1])
+    )
+    trace_square = float(np.sum(matrix * matrix))
+    off_diagonal = matrix[~np.eye(len(matrix), dtype=bool)]
+    quantile_levels = (0.0, 0.25, 0.50, 0.75, 0.90, 0.95, 1.0)
+    quantiles = (
+        {str(level): float(np.quantile(off_diagonal, level)) for level in quantile_levels}
+        if len(off_diagonal)
+        else {str(level): 0.0 for level in quantile_levels}
+    )
+    return {
+        "region_ids": list(exposure.region_ids),
+        "matrix": matrix.tolist(),
+        "eigenvalues_descending": list(map(float, eigenvalues[::-1])),
+        "numerical_rank": int(np.sum(eigenvalues > tolerance)),
+        "effective_rank": float(np.trace(matrix) ** 2 / trace_square),
+        "off_diagonal_quantiles": quantiles,
+        "per_region_outside_landing_mass_by_hop": {
+            region: list(exposure.per_region_outside_landing_mass[index])
+            for index, region in enumerate(exposure.region_ids)
+        },
+        "mean_outside_landing_mass_by_hop": list(
+            exposure.mean_outside_landing_mass_by_hop
+        ),
+    }
+
+
+def audit_source_dependence(
+    parents,
+    children,
+    target_region_count,
+    registered_sizes,
+    *,
+    rho_grid=DEFAULT_RHO_GRID,
+):
+    """Audit one deterministic full-region partition across registered G/rho."""
+    target_region_count = _positive_integer(
+        target_region_count, "target_region_count"
+    )
+    registered_sizes = tuple(registered_sizes)
+    if (
+        not registered_sizes
+        or any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 1
+            for value in registered_sizes
+        )
+        or len(set(registered_sizes)) != len(registered_sizes)
+    ):
+        raise SourceDependenceError(
+            "registered_sizes must contain unique positive integers"
+        )
+    rhos = tuple(_validated_rho(value) for value in rho_grid)
+    if not rhos or len(set(rhos)) != len(rhos):
+        raise SourceDependenceError("rho_grid must contain unique values")
+    partition = build_source_region_partition(
+        parents, children, target_region_count, halo_hops=0
+    )
+    exposure = build_region_exposure(parents, children, partition)
+    matrix = _validated_exposure(exposure)
+    size_results = {}
+    for total in registered_sizes:
+        capacities = full_region_capacities(partition, total)
+        capacity_pass = sum(capacities.values()) >= total
+        if capacity_pass:
+            allocation = exposure_aware_greedy_allocation(
+                exposure, capacities, total
+            )
+            exact = {
+                str(rho): exact_mean_ess(exposure, allocation, rho)
+                for rho in rhos
+            }
+            lower = {
+                str(rho): certified_ess_lower_bound(
+                    exposure, capacities, total, rho
+                )
+                for rho in rhos
+            }
+            used = allocation["used_region_count"]
+            cap_respected = all(
+                allocation["counts_by_region"][region] <= capacities[region]
+                for region in exposure.region_ids
+            )
+        else:
+            allocation = None
+            exact = None
+            lower = None
+            used = 0
+            cap_respected = False
+        correlation_path_valid = bool(
+            np.isfinite(matrix).all()
+            and np.allclose(matrix, matrix.T, atol=1e-12, rtol=0.0)
+            and np.allclose(np.diag(matrix), 1.0, atol=1e-12, rtol=0.0)
+            and np.linalg.eigvalsh(matrix)[0] >= -1e-10
+            and all(0.0 <= rho <= 1.0 for rho in rhos)
+        )
+        gates = {
+            "capacity_supplies_all_components": capacity_pass,
+            "allocation_supplies_exactly_G": bool(
+                allocation is not None
+                and sum(allocation["counts_by_region"].values()) == total
+            ),
+            "allocation_respects_cap": cap_respected,
+            "uses_at_least_20_source_regions": used >= DEFAULT_MIN_EFFECTIVE_REGIONS,
+            "exposure_and_correlation_path_valid": correlation_path_valid,
+        }
+        gates["all_topology_gates_pass"] = all(gates.values())
+        size_results[str(total)] = {
+            "components_per_corpus": total,
+            "capacities_by_region": capacities,
+            "optimistic_capacity_upper_bound": int(sum(capacities.values())),
+            "allocation": allocation,
+            "exact_mean_ess_by_rho": exact,
+            "certified_mean_ess_lower_bound_by_rho": lower,
+            "gates": gates,
+        }
+    return {
+        "target_region_count": target_region_count,
+        "actual_region_count": len(exposure.region_ids),
+        "walk_weights": list(exposure.walk_weights),
+        "rho_grid": list(rhos),
+        "partition_assignment_record": partition.assignment_record,
+        "exposure": _exposure_diagnostics(exposure),
+        "registered_size_results": size_results,
+        "gates": {
+            "all_registered_sizes_pass": all(
+                row["gates"]["all_topology_gates_pass"]
+                for row in size_results.values()
+            )
+        },
+        "authorization": {
+            "attempted_input_inventory_authorized": False,
+            "candidate_selection_authorized": False,
+            "nomic_authorized": False,
+            "live_scoring_authorized": False,
+            "covariance_promotion_authorized": False,
+            "independent_batching_authorized": False,
+            "qr_specialization_authorized": False,
+            "cuda_authorized": False,
+        },
+    }
+
+
+# Readable aliases for callers that phrase the operation around components.
+allocate_components_exposure_aware = exposure_aware_greedy_allocation
+audit_source_region_dependence = audit_source_dependence
+compute_per_hop_mean_escape = compute_per_hop_outside_landing_mass

--- a/prototypes/mu_cosine/repro/repeated_judge_source_dependence/summary.json
+++ b/prototypes/mu_cosine/repro/repeated_judge_source_dependence/summary.json
@@ -1,0 +1,8469 @@
+{
+  "algorithm": "repeated-judge-topology-source-dependence-bridge-v1",
+  "artifact_projection": "tracked-summary-v1",
+  "authorization": {
+    "candidate_builder_unlocked": false,
+    "candidate_enumeration_unlocked": false,
+    "covariance_deployment_unlocked": false,
+    "cuda_claim_unlocked": false,
+    "historical_inventory_unlocked": false,
+    "independent_batching_unlocked": false,
+    "judge_calls_authorized": false,
+    "live_campaign_authorized": false,
+    "nomic_embedding_unlocked": false,
+    "qr_specialization_unlocked": false
+  },
+  "configuration": {
+    "all_jointly_passing_region_counts_continue": true,
+    "cumulative_walk_weights": [
+      1.0,
+      0.5,
+      0.25,
+      0.125
+    ],
+    "endpoints_charged_per_campaign_component": 4,
+    "external_graph_records_recheck_required_before_write": true,
+    "full_source_regions_used_without_halo_exclusion": true,
+    "graph_inputs_required_immutable_during_run": true,
+    "partition_inputs": "canonical undirected graph topology only",
+    "region_count_grid": [
+      64,
+      96,
+      128
+    ],
+    "region_count_selection_performed": false,
+    "registered_components_per_corpus": [
+      160,
+      320,
+      512,
+      800
+    ],
+    "required_corpora": [
+      "exploratory",
+      "fresh"
+    ],
+    "rho_grid": [
+      0.0,
+      0.025,
+      0.05,
+      0.1,
+      0.2
+    ],
+    "source_region_cap_fraction": 0.1,
+    "source_regions_claimed_independent": false,
+    "true_weak_component_retained_as_separate_diagnostic": true
+  },
+  "decision": {
+    "candidate_builder_must_stop": true,
+    "downstream_pipeline_must_stop": true,
+    "jointly_passing_region_counts": [
+      64,
+      96,
+      128
+    ],
+    "reason": "at least one identical frozen region count passes the narrow full-region capacity, allocation, and PSD gates in both required corpora; this audit does not include full-procedure source-dependent null calibration or power",
+    "region_count_selected": null,
+    "required_next_action": "extend the complete repeated-judge null and power procedure with source-atomic folds, registered source exposure, prompt incidence, and two-way prompt/source inference before unlocking history or candidates",
+    "structural_bridge_defined": true
+  },
+  "full_payload_record": {
+    "sha256": "bf9a09c35e54bd36c2e7efea19c432ccf1e9105ff67c4154cfc1c6e744a843b2",
+    "size_bytes": 2767735
+  },
+  "implementation_and_protocol": {
+    "DESIGN_repeated_judge_source_dependence.md": {
+      "sha256": "5fbe424fd7f313b83e0be7ebf5dea6ee211fba52565ed491a23a9952183e5d65",
+      "size_bytes": 9434
+    },
+    "PREREG_graph_geometry_repeated_judge.md": {
+      "sha256": "ce71526a19e2239a74eea57703541f9f9e53011719b2da60dcd01e98234c1db7",
+      "size_bytes": 25536
+    },
+    "graph_geometry.py": {
+      "sha256": "b599b8221d8cb5ad5d7398edffde8a2cf5ef5e258873c8f50b1cf565b787cfcd",
+      "size_bytes": 15817
+    },
+    "lmdb_id.py": {
+      "sha256": "2ea3fa8e105e905b1c52147c1f7bd0cb61e524aae507e8091a85f2d50fba9eb0",
+      "size_bytes": 580
+    },
+    "mu_attention.py": {
+      "sha256": "60d187c7ed539097889ab05cfcc6e26d7717e37f6f08afb126bc9636f527a363",
+      "size_bytes": 39873
+    },
+    "repeated_judge_campaign.py": {
+      "sha256": "22d0469bee4bd49aaff484dd6f939246888c61319be6db27c6209c37c142ea74",
+      "size_bytes": 63443
+    },
+    "repeated_judge_candidate_capacity.py": {
+      "sha256": "2a0c15ae06d3c6145ae5c89977b3e33db26ce660486bd046fb68940e26055617",
+      "size_bytes": 8436
+    },
+    "repeated_judge_source_dependence.py": {
+      "sha256": "b7a8e9675b467bb69ef959094f219cf7d0fbf3e98771a46808b0650513687a36",
+      "size_bytes": 22444
+    },
+    "repeated_judge_source_regions.py": {
+      "sha256": "8680222500bba46cd7288277ea27c907cdb27908cb5dac33ac97db6bd8e93cfa",
+      "size_bytes": 23456
+    },
+    "run_product_kalman_realdata.py": {
+      "sha256": "7ce2396132e4568f73f24de846cb8de2407c8f3790bbc8960812647fce230ed2",
+      "size_bytes": 7653
+    },
+    "run_repeated_judge_candidate_capacity.py": {
+      "sha256": "18709c92f3a9e5afe460d408f88e31975c5d241061a1939bdfde25701b4948e3",
+      "size_bytes": 12142
+    },
+    "run_repeated_judge_source_dependence.py": {
+      "sha256": "7febfd93d6bd2afe862828bdf6a2b26916b9d510b7b1c11c689e2eaa2a67d6d8",
+      "size_bytes": 18102
+    },
+    "run_structured_residual_covariance.py": {
+      "sha256": "2c7aabc0c73679ba34b88c44361235e859a06474aafc7b5054ee2b9fad4e3f2d",
+      "size_bytes": 28232
+    },
+    "sample_sigma_hop_fresh_corpus.py": {
+      "sha256": "41c9b4b04bc02330b70e01b09d2b15d5d3f300a103fdfe6f071605264173caec",
+      "size_bytes": 30300
+    },
+    "sigma_hop_confirmatory.py": {
+      "sha256": "b31e34362ab1f2aa9250e505f21d36c1c4b9f40e2279ecc44501e7c54f4ab4d9",
+      "size_bytes": 21589
+    }
+  },
+  "inputs": {
+    "candidate_pool_consumed": false,
+    "graph_bundle": {
+      "sha256": "e451d4b090dba2013b115aae2f80f40211776b240974777f6663f861d1a373bd",
+      "size_bytes": 823
+    },
+    "graphs": {
+      "exploratory": {
+        "artifacts": {
+          "category_parent": {
+            "sha256": "4881beedfd876e3abb9f1783cbc3fb8a7350e108e3f531cc4de28ef9956dc8ec",
+            "size_bytes": 10126922
+          },
+          "dataset_metadata": {
+            "sha256": "15a632799adebd8b4f736c8420add8969bb5e5e4f20aa21ecaae9e2d95a61577",
+            "size_bytes": 308
+          }
+        },
+        "corpus_identity": "SimpleWiki 100k category graph",
+        "format": "UTF-8 child-parent TSV"
+      },
+      "fresh": {
+        "artifacts": {
+          "category_lmdb_data": {
+            "sha256": "3bcfe59a3f85870f377fad1ea77547f7c3566370f6172e27748f4f7ceba5d690",
+            "size_bytes": 1319403520
+          },
+          "exploratory_title_exclusion_graph": {
+            "sha256": "4881beedfd876e3abb9f1783cbc3fb8a7350e108e3f531cc4de28ef9956dc8ec",
+            "size_bytes": 10126922
+          }
+        },
+        "corpus_identity": "enwiki category LMDB retained under Behavior",
+        "excluded_runtime_artifact": "lock.mdb is process state, not graph content",
+        "format": "LMDB uint32 graph with UTF-8 title layer"
+      }
+    },
+    "historical_inventory_consumed": false,
+    "judge_responses_consumed": false,
+    "nomic_cache_consumed": false,
+    "outcomes_consumed": false
+  },
+  "joint_region_count_grid": {
+    "128": {
+      "joint_narrow_structural_gate_passes": true,
+      "passing_corpora": [
+        "exploratory",
+        "fresh"
+      ],
+      "required_corpora": [
+        "exploratory",
+        "fresh"
+      ]
+    },
+    "64": {
+      "joint_narrow_structural_gate_passes": true,
+      "passing_corpora": [
+        "exploratory",
+        "fresh"
+      ],
+      "required_corpora": [
+        "exploratory",
+        "fresh"
+      ]
+    },
+    "96": {
+      "joint_narrow_structural_gate_passes": true,
+      "passing_corpora": [
+        "exploratory",
+        "fresh"
+      ],
+      "required_corpora": [
+        "exploratory",
+        "fresh"
+      ]
+    }
+  },
+  "loader_metadata": {
+    "exploratory": {
+      "feature_graph_source": "child-parent TSV"
+    },
+    "fresh": {
+      "feature_graph_lmdb_stats": {
+        "admin_node": 4022,
+        "child_edges_examined": 105825,
+        "missing_title_nodes": 60,
+        "overlap_node": 1757,
+        "parent_edges_examined": 274545,
+        "retained_edges": 99986,
+        "title_lookups": 509416
+      },
+      "feature_graph_root": "Behavior",
+      "feature_graph_slice_nodes": 75901,
+      "feature_graph_source": "lmdb"
+    }
+  },
+  "non_claims": [
+    "source regions are concentration and dependence-sensitivity units, not independent observations",
+    "region-average topology exposure is not empirical residual covariance or a candidate-level upper bound",
+    "effective component counts are information diagnostics, not power calculations",
+    "the greedy allocation is a prospective diagnostic quota, not exact candidate packability",
+    "no region count is selected or ranked by this audit",
+    "no historical attempted-input identity inventory was consumed or unlocked",
+    "no embedding model, candidate builder, judge, covariance conditioner, QR specialization, or CUDA kernel ran"
+  ],
+  "numerical_runtime": {
+    "blas_runtime": [
+      {
+        "architecture": "Haswell",
+        "internal_api": "openblas",
+        "prefix": "libopenblas",
+        "threading_layer": "pthreads",
+        "user_api": "blas",
+        "version": "0.3.18"
+      },
+      {
+        "architecture": "Haswell",
+        "internal_api": "openblas",
+        "prefix": "libopenblas",
+        "threading_layer": "pthreads",
+        "user_api": "blas",
+        "version": "0.3.21"
+      },
+      {
+        "architecture": null,
+        "internal_api": "openmp",
+        "prefix": "libgomp",
+        "threading_layer": null,
+        "user_api": "openmp",
+        "version": null
+      }
+    ],
+    "blas_thread_limit_policy": "CLI audit requests one BLAS thread via threadpoolctl when available",
+    "numpy_version": "1.24.4",
+    "python_version": "3.8.10"
+  },
+  "results": {
+    "exploratory": {
+      "128": {
+        "actual_region_count": 128,
+        "authorization": {
+          "attempted_input_inventory_authorized": false,
+          "candidate_selection_authorized": false,
+          "covariance_promotion_authorized": false,
+          "cuda_authorized": false,
+          "independent_batching_authorized": false,
+          "live_scoring_authorized": false,
+          "nomic_authorized": false,
+          "qr_specialization_authorized": false
+        },
+        "exposure": {
+          "effective_rank": 123.09941233459338,
+          "eigenvalues_descending": [
+            1.9338402263673602,
+            1.831344621852944,
+            1.7469521712045017,
+            1.6560131767363635,
+            1.4521595080079854,
+            1.3739505523900748,
+            1.3467837703856742,
+            1.2996844856988907,
+            1.2710439089123948,
+            1.2281490691382313,
+            1.212978002379933,
+            1.203457066617376,
+            1.1718781469127881,
+            1.152320092781263,
+            1.149976296649781,
+            1.1186486036866672,
+            1.1145122926507225,
+            1.105710019464805,
+            1.0846979791918534,
+            1.0807579857077885,
+            1.0698834177042733,
+            1.056880303393978,
+            1.0555618495460695,
+            1.051970241110197,
+            1.044375467174191,
+            1.0435084421460261,
+            1.0388024837411696,
+            1.0333776780133128,
+            1.0311038604867546,
+            1.0235073095625742,
+            1.0190820702971093,
+            1.013306484218072,
+            1.0107353399770294,
+            1.0059102072577109,
+            1.0048034191456277,
+            1.0033052987391224,
+            1.00110669976507,
+            1.0000000000000016,
+            1.0000000000000016,
+            1.0000000000000013,
+            1.000000000000001,
+            1.0000000000000009,
+            1.0000000000000007,
+            1.0000000000000004,
+            1.0000000000000004,
+            1.0000000000000002,
+            1.0000000000000002,
+            1.0000000000000002,
+            1.0000000000000002,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            0.9999999999999999,
+            0.9999999999999998,
+            0.9999999999999998,
+            0.9999999999999996,
+            0.9999999999999996,
+            0.9999999999999994,
+            0.9999999999999994,
+            0.9999999999999994,
+            0.9999999999999992,
+            0.9999999999999992,
+            0.9999999999999989,
+            0.9999999999999988,
+            0.9999999999999982,
+            0.9989385306211502,
+            0.9975772262726679,
+            0.9958999928753917,
+            0.9915684516063598,
+            0.9879136136874825,
+            0.9851018819681018,
+            0.9814801238880912,
+            0.9786904223431725,
+            0.9733908736569696,
+            0.9724420035213164,
+            0.9703847998423524,
+            0.9660638848811561,
+            0.9633226062641355,
+            0.9607248221264294,
+            0.9578790524228673,
+            0.9557012980076199,
+            0.9522761212497749,
+            0.9496187566513824,
+            0.9463142115484282,
+            0.9416392668481213,
+            0.9384169734639429,
+            0.9373675599687777,
+            0.9336792435853921,
+            0.9277407907994943,
+            0.9222151930835496,
+            0.9185015093818645,
+            0.9166934727237395,
+            0.9138017092932043,
+            0.9102261596092742,
+            0.9094503382901861,
+            0.9059208936917598,
+            0.9039081034239964,
+            0.8958511918854359,
+            0.891569771194702,
+            0.8879981993376604,
+            0.8837590643579795,
+            0.8771724329408526,
+            0.8686494506831536,
+            0.8673340294238643,
+            0.8608097733985544,
+            0.847793773112436,
+            0.843554259215551,
+            0.8350825921653346,
+            0.8306271421921841,
+            0.8204699458174542,
+            0.8170914421571454,
+            0.8118359516786732,
+            0.800135952677493,
+            0.7925602280001128,
+            0.7865909279834884,
+            0.7857616912725837,
+            0.7729022102604205,
+            0.7621361839166017,
+            0.7454053307300984,
+            0.7131005750630207,
+            0.593963462936361,
+            0.5017357289788388,
+            0.39918025200616913
+          ],
+          "matrix_record": {
+            "sha256": "d8163cb42903ff652685e6d20c7a3817aa3a07b7ce59d75f3f05c60ce50f4c1d",
+            "size_bytes": 223590
+          },
+          "matrix_shape": [
+            128,
+            128
+          ],
+          "mean_outside_landing_mass_by_hop": [
+            1.1275702593849246e-17,
+            0.2862747524093278,
+            0.3225178254168245,
+            0.41870826923110116
+          ],
+          "numerical_rank": 128,
+          "off_diagonal_quantiles": {
+            "0.0": 0.0,
+            "0.25": 0.0,
+            "0.5": 4.019844887906879e-06,
+            "0.75": 0.0014658620300989295,
+            "0.9": 0.009593025769157618,
+            "0.95": 0.0207381977117494,
+            "1.0": 0.584319971426708
+          },
+          "per_region_outside_landing_mass_by_hop": {
+            "region-01fa01f27050cd68": [
+              0.0,
+              0.40323287061094126,
+              0.5217177335067374,
+              0.6352594555617863
+            ],
+            "region-0501fde389b89712": [
+              0.0,
+              0.3048012039371242,
+              0.3796085590518363,
+              0.48728892411865
+            ],
+            "region-0515ae685c846b37": [
+              0.0,
+              0.36217196174823296,
+              0.48728957209902335,
+              0.5928124152080656
+            ],
+            "region-066be0d601faffba": [
+              0.0,
+              0.2331542589843726,
+              0.28454450759235705,
+              0.38489358861972
+            ],
+            "region-0682434ed028a6dc": [
+              1.1102230246251565e-16,
+              0.36954287203610947,
+              0.3718031051359413,
+              0.5264011095022314
+            ],
+            "region-06cbe461e6f0467c": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-0cabae29b6a3d7f1": [
+              0.0,
+              0.34784719115096363,
+              0.40918740217107186,
+              0.5383463014936862
+            ],
+            "region-0dbce03cda2f9272": [
+              0.0,
+              0.37441366375791896,
+              0.4658023017177134,
+              0.5649339584971902
+            ],
+            "region-0f3249f27acd2840": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-111862f68a46a3b9": [
+              0.0,
+              0.7054456906729631,
+              0.5904110981058304,
+              0.8585798450915332
+            ],
+            "region-13ecf2f21fa45eee": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-13edabbe257ada6c": [
+              0.0,
+              0.35584977621997516,
+              0.42825760393706813,
+              0.5468191551328234
+            ],
+            "region-168e3ffd70b9b444": [
+              1.1102230246251565e-16,
+              0.2868813552428371,
+              0.34080461543435314,
+              0.45769739829505196
+            ],
+            "region-178d27f954e59a7b": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-17985e798668d342": [
+              0.0,
+              0.5195308878727865,
+              0.5668959858647465,
+              0.7276257203972591
+            ],
+            "region-186560a3c2f33115": [
+              0.0,
+              0.30716530705358946,
+              0.3775145275272338,
+              0.48645596844333205
+            ],
+            "region-19b4c4987a15a921": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-1a799d3fabaeb59f": [
+              0.0,
+              0.630191974874119,
+              0.5978199842639619,
+              0.7943504321115324
+            ],
+            "region-1bb0951829949fa6": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-1d9226b552f4c309": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-1e79373b63cc55b4": [
+              1.1102230246251565e-16,
+              0.3348127032802407,
+              0.41504145384002156,
+              0.5347149504818467
+            ],
+            "region-206b8221ab5f1954": [
+              0.0,
+              1.1102230246251565e-16,
+              1.1102230246251565e-16,
+              2.220446049250313e-16
+            ],
+            "region-252613a1969b52e8": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-26d0c18430f479c0": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-28c1e85633373272": [
+              0.0,
+              0.35059551465228933,
+              0.4068343913716309,
+              0.5404489673973513
+            ],
+            "region-2c4c0421b745aa03": [
+              0.0,
+              0.42299248682044643,
+              0.5119238052739316,
+              0.637261533274051
+            ],
+            "region-2fa0a59be2e5173b": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-3134fe180064f7f3": [
+              0.0,
+              0.4855205595242238,
+              0.5397218542195749,
+              0.6743525310526426
+            ],
+            "region-35fe9ba83d2232ab": [
+              0.0,
+              0.42237497043850425,
+              0.48136108254423726,
+              0.6250640779543288
+            ],
+            "region-362e7e02b73c6894": [
+              1.1102230246251565e-16,
+              0.3912146318787958,
+              0.5084746520655491,
+              0.6254789538336691
+            ],
+            "region-3910f6ed92bf4f1f": [
+              0.0,
+              0.15876118173102927,
+              0.21559658383708424,
+              0.2753564304889352
+            ],
+            "region-3ad10f956c0f807a": [
+              0.0,
+              0.04967381172274221,
+              0.07538689431844203,
+              0.09377492518683817
+            ],
+            "region-3b0d0f0291e4f7f5": [
+              0.0,
+              0.33575241278129786,
+              0.3777918943491373,
+              0.5064754138734339
+            ],
+            "region-3c2901a617fa3bfb": [
+              1.1102230246251565e-16,
+              0.3951946599707513,
+              0.5003245372404035,
+              0.6180573151481378
+            ],
+            "region-3ce87bc05c8e8741": [
+              0.0,
+              0.31951244288705594,
+              0.3949677225989813,
+              0.4983425681901069
+            ],
+            "region-3f556caa81289b53": [
+              0.0,
+              0.5625365760329744,
+              0.5417724155263465,
+              0.7470791880012035
+            ],
+            "region-42c5dce1ac3770dd": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-4309082c83a74962": [
+              0.0,
+              0.516126844577371,
+              0.5265833737520003,
+              0.6896465140639418
+            ],
+            "region-46df4e61227075db": [
+              0.0,
+              0.44797489689663483,
+              0.5107934300217966,
+              0.6597263136185051
+            ],
+            "region-47808bc508c65b47": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-48341f264dff6376": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-4a655dd4b6f1626e": [
+              0.0,
+              0.4175947110695968,
+              0.3610266878864121,
+              0.574278529370795
+            ],
+            "region-51732bb16fe2fec8": [
+              0.0,
+              0.5299463588298832,
+              0.4071947469981436,
+              0.5947875123455136
+            ],
+            "region-5332e1f5e8fd5de5": [
+              0.0,
+              0.38600494107933614,
+              0.377975899889883,
+              0.4827737974451485
+            ],
+            "region-56861962e15b21d5": [
+              0.0,
+              0.2975410767578093,
+              0.2909466996323943,
+              0.41206540520748824
+            ],
+            "region-5a548bcca6a3d6bf": [
+              0.0,
+              0.5010964147051827,
+              0.5502517727824725,
+              0.7023397524345769
+            ],
+            "region-5fbd8073ebf5c68f": [
+              0.0,
+              0.4679158362015504,
+              0.5345965832810013,
+              0.6914053534968965
+            ],
+            "region-61680173f0654a6d": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-65f4b7af2c2b8439": [
+              0.0,
+              0.32774408232774166,
+              0.4112877536585152,
+              0.5222973368811261
+            ],
+            "region-66140b932acedb47": [
+              0.0,
+              0.44659411752823563,
+              0.4195978507093049,
+              0.5840701649620194
+            ],
+            "region-6645d29d01aa48e6": [
+              0.0,
+              0.3339828837051536,
+              0.5114956353571474,
+              0.5915544898189098
+            ],
+            "region-6697feba9d3597dd": [
+              0.0,
+              0.4054708853064575,
+              0.4622495207379782,
+              0.5901393978279239
+            ],
+            "region-69c7039601f0a770": [
+              1.1102230246251565e-16,
+              0.3599060925904458,
+              0.4602358615721758,
+              0.5551622654477368
+            ],
+            "region-6a8771ab6783efcc": [
+              0.0,
+              0.32626357308814447,
+              0.3403759162243237,
+              0.4694846859046804
+            ],
+            "region-6abb905fc8dd073d": [
+              0.0,
+              0.4778738143630863,
+              0.5348342500647116,
+              0.6769698554985265
+            ],
+            "region-71ea00f35ec405a1": [
+              1.1102230246251565e-16,
+              0.106126620573739,
+              0.34569268997440206,
+              0.27581325243270294
+            ],
+            "region-71f5510877076519": [
+              1.1102230246251565e-16,
+              0.3189167677679655,
+              0.378299092374883,
+              0.49865605279196523
+            ],
+            "region-72cb1f112b3ef91b": [
+              0.0,
+              0.4008135111358877,
+              0.45685739549149473,
+              0.5772762806472178
+            ],
+            "region-7387f3f5126be4ad": [
+              0.0,
+              0.23333333333333328,
+              0.6896155672576716,
+              0.7073454210831476
+            ],
+            "region-75d6ca1c72774b83": [
+              0.0,
+              0.3319659820015246,
+              0.3469800931137188,
+              0.49150909826954603
+            ],
+            "region-78aa78bc0fc9caeb": [
+              0.0,
+              0.4709797631030508,
+              0.481705868639165,
+              0.6677067102897258
+            ],
+            "region-7bccecc94755aa4f": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-7cd13bf29db5e6af": [
+              0.0,
+              0.41787694425682886,
+              0.4773160668581732,
+              0.6010341187625347
+            ],
+            "region-7f159bdbb195fbdd": [
+              0.0,
+              0.490543483374663,
+              0.5416373352129795,
+              0.6690871167339895
+            ],
+            "region-7fde5d3605d4ec12": [
+              0.0,
+              0.0,
+              3.3306690738754696e-16,
+              4.440892098500626e-16
+            ],
+            "region-8067df8554bd8966": [
+              0.0,
+              0.31824165703352425,
+              0.3813349650651041,
+              0.4924554606203704
+            ],
+            "region-81b68850dfb59a18": [
+              0.0,
+              0.2522032708413733,
+              0.3374035599128459,
+              0.42927713378810883
+            ],
+            "region-84321d573af6e0ee": [
+              0.0,
+              0.5622409578690617,
+              0.5776709852990836,
+              0.7384854481773511
+            ],
+            "region-85e48f1247e99b09": [
+              0.0,
+              0.4755390236912794,
+              0.4748679870195235,
+              0.6551717883497448
+            ],
+            "region-8c96107bab459069": [
+              0.0,
+              0.38526617910042116,
+              0.4722583501639317,
+              0.5952966555647714
+            ],
+            "region-92bbca524efa6f10": [
+              0.0,
+              0.42752989441617406,
+              0.493835973429236,
+              0.6314880482637483
+            ],
+            "region-941b80b5aad1d9d4": [
+              0.0,
+              0.46305921182033216,
+              0.5045630686542076,
+              0.6494337720056484
+            ],
+            "region-95186e40451b6314": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-9645df2a631ecf3e": [
+              0.0,
+              0.3532585459544435,
+              0.41370162935997123,
+              0.5417300425257254
+            ],
+            "region-9b32c0584d9e8a26": [
+              0.0,
+              0.3999813892029461,
+              0.32592055449991486,
+              0.5271196977563114
+            ],
+            "region-9d85c169f5ad0bc9": [
+              0.0,
+              0.4040921763183545,
+              0.46845943323956596,
+              0.5908238600095466
+            ],
+            "region-9db5f7ed9310c49c": [
+              1.1102230246251565e-16,
+              0.5062555617627265,
+              0.4846684837858901,
+              0.6568078629921164
+            ],
+            "region-a05f08e7ad6753ba": [
+              0.0,
+              0.4404067861598582,
+              0.36902508126080147,
+              0.5547042645173688
+            ],
+            "region-a15995c7d33b7162": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-a3566e0bc129a1a2": [
+              0.0,
+              0.3571336838506771,
+              0.39576352470925347,
+              0.5342657177912025
+            ],
+            "region-a595c2597f28920b": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-a9201dada3b15e53": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-a9cea6c38e283e8a": [
+              0.0,
+              0.29339074094866247,
+              0.3693462460786112,
+              0.4593198065193722
+            ],
+            "region-aa2f95f0d781d63f": [
+              0.0,
+              0.30730638556165746,
+              0.4090308176555646,
+              0.5161844422210078
+            ],
+            "region-ac2e9e9ffb1015c0": [
+              0.0,
+              0.12473338390153088,
+              0.18514779370460488,
+              0.2103959572450228
+            ],
+            "region-b1f23e8298861fac": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-b24c66a6f80facc5": [
+              0.0,
+              0.46484237206160883,
+              0.6192843648506758,
+              0.7524338121598104
+            ],
+            "region-b53328d157eb65b8": [
+              0.0,
+              0.5972950291537691,
+              0.5417854840733423,
+              0.6809483170303883
+            ],
+            "region-b89899e167892188": [
+              0.0,
+              0.3888210102916051,
+              0.5021396642124788,
+              0.6131015363692569
+            ],
+            "region-b919d5322eb45186": [
+              0.0,
+              0.6680590933853585,
+              0.44307451731306235,
+              0.7868475756700265
+            ],
+            "region-ba0c8b4ef85203cb": [
+              0.0,
+              0.35302745651703316,
+              0.640947324708607,
+              0.7238718882746603
+            ],
+            "region-bd146f6ba302b81f": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-bd783e1ca50a5908": [
+              0.0,
+              0.2965189641611513,
+              0.35775608920571944,
+              0.43272615813555726
+            ],
+            "region-bedfe10acbafaf30": [
+              0.0,
+              0.003031246755943129,
+              0.01292579870926125,
+              0.014710790767122228
+            ],
+            "region-befed3d26b4757a5": [
+              0.0,
+              0.44941317347296494,
+              0.5410998109040404,
+              0.6636949288935327
+            ],
+            "region-c08fd9a5c66be030": [
+              0.0,
+              0.42375661190197544,
+              0.4180880994782704,
+              0.5853815585299884
+            ],
+            "region-c203541fd4d6d680": [
+              1.1102230246251565e-16,
+              0.40246574952323033,
+              0.48464084109090955,
+              0.6092998284687927
+            ],
+            "region-c20a82bce1275e47": [
+              0.0,
+              0.50970325689218,
+              0.5647061512581157,
+              0.727757651599331
+            ],
+            "region-c50c4b624484a189": [
+              0.0,
+              0.36124961102339626,
+              0.41877199926964914,
+              0.5294528777489409
+            ],
+            "region-c5ba8e28fb7020bf": [
+              0.0,
+              0.39727813979811044,
+              0.3832566303136661,
+              0.5466248814414879
+            ],
+            "region-c9d993ae81c06c0a": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-cb3796d294c86ab7": [
+              0.0,
+              0.3455309822347431,
+              0.33410665550605745,
+              0.4761375621995778
+            ],
+            "region-ccea8d4132c59d01": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-cf8beea42b3c0378": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-d0bc27b8c4a8dd26": [
+              0.0,
+              0.42827972972406636,
+              0.4964221861023893,
+              0.61936339277628
+            ],
+            "region-d18114c3fdb614a6": [
+              0.0,
+              0.3992223230849823,
+              0.41788784270138124,
+              0.5579220565627028
+            ],
+            "region-d4a886f78259db47": [
+              1.1102230246251565e-16,
+              0.37964703040137593,
+              0.4535775772746313,
+              0.5887694217017068
+            ],
+            "region-d6e363ff258f9ec2": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-d7e7ab3da257af5a": [
+              0.0,
+              0.39270975014749065,
+              0.4779698625353641,
+              0.585029742976797
+            ],
+            "region-d8a6b69ce678cc08": [
+              0.0,
+              0.4768701671589518,
+              0.5834655145214721,
+              0.7173396472920046
+            ],
+            "region-ddf935d103375839": [
+              0.0,
+              0.3863776474027424,
+              0.4266117064997127,
+              0.5500635306253793
+            ],
+            "region-de230b392d32e6f1": [
+              0.0,
+              0.44706312532642123,
+              0.5026660739206266,
+              0.6512701817032842
+            ],
+            "region-df1e0a108bc7084c": [
+              0.0,
+              0.5149364519275861,
+              0.5484521893324459,
+              0.7072881316269881
+            ],
+            "region-e247bf49f3cd6992": [
+              0.0,
+              0.2819585678427201,
+              0.37564200979030105,
+              0.46920383126510146
+            ],
+            "region-e279de8f4ddb8c05": [
+              0.0,
+              0.009489781526004548,
+              0.02282988562903232,
+              0.027447492379629734
+            ],
+            "region-e3319a1f3047f3e2": [
+              0.0,
+              0.36660288467563806,
+              0.38089307689189156,
+              0.5258163628687743
+            ],
+            "region-e53b2ad152ea96ba": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-e671090c984c4d48": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-e9cb35742ba103fd": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-ee7c295a3725af74": [
+              0.0,
+              0.7547550480196484,
+              0.5909646345687016,
+              0.8928410428575932
+            ],
+            "region-f058236680bc9b43": [
+              1.1102230246251565e-16,
+              0.2676681421028273,
+              0.342941034335846,
+              0.43290621790213524
+            ],
+            "region-f6e8d6553f47012c": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-f729fef5dd4ea9a9": [
+              0.0,
+              0.3884269218045916,
+              0.492973322091798,
+              0.6109619012955738
+            ],
+            "region-f92b6617632aeaad": [
+              1.1102230246251565e-16,
+              0.3569833668280008,
+              0.3149579402253402,
+              0.5244554802068215
+            ],
+            "region-faa705ad2c7f67ef": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-fe09b61e69fced58": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-fea22d4499b6ba60": [
+              0.0,
+              0.3462354544003816,
+              0.3505346608164076,
+              0.48099570669239344
+            ],
+            "region-fef791fdd28a8154": [
+              0.0,
+              0.27254646995852816,
+              0.3695058763002621,
+              0.46403444252186954
+            ]
+          },
+          "region_ids": [
+            "region-01fa01f27050cd68",
+            "region-0501fde389b89712",
+            "region-0515ae685c846b37",
+            "region-066be0d601faffba",
+            "region-0682434ed028a6dc",
+            "region-06cbe461e6f0467c",
+            "region-0cabae29b6a3d7f1",
+            "region-0dbce03cda2f9272",
+            "region-0f3249f27acd2840",
+            "region-111862f68a46a3b9",
+            "region-13ecf2f21fa45eee",
+            "region-13edabbe257ada6c",
+            "region-168e3ffd70b9b444",
+            "region-178d27f954e59a7b",
+            "region-17985e798668d342",
+            "region-186560a3c2f33115",
+            "region-19b4c4987a15a921",
+            "region-1a799d3fabaeb59f",
+            "region-1bb0951829949fa6",
+            "region-1d9226b552f4c309",
+            "region-1e79373b63cc55b4",
+            "region-206b8221ab5f1954",
+            "region-252613a1969b52e8",
+            "region-26d0c18430f479c0",
+            "region-28c1e85633373272",
+            "region-2c4c0421b745aa03",
+            "region-2fa0a59be2e5173b",
+            "region-3134fe180064f7f3",
+            "region-35fe9ba83d2232ab",
+            "region-362e7e02b73c6894",
+            "region-3910f6ed92bf4f1f",
+            "region-3ad10f956c0f807a",
+            "region-3b0d0f0291e4f7f5",
+            "region-3c2901a617fa3bfb",
+            "region-3ce87bc05c8e8741",
+            "region-3f556caa81289b53",
+            "region-42c5dce1ac3770dd",
+            "region-4309082c83a74962",
+            "region-46df4e61227075db",
+            "region-47808bc508c65b47",
+            "region-48341f264dff6376",
+            "region-4a655dd4b6f1626e",
+            "region-51732bb16fe2fec8",
+            "region-5332e1f5e8fd5de5",
+            "region-56861962e15b21d5",
+            "region-5a548bcca6a3d6bf",
+            "region-5fbd8073ebf5c68f",
+            "region-61680173f0654a6d",
+            "region-65f4b7af2c2b8439",
+            "region-66140b932acedb47",
+            "region-6645d29d01aa48e6",
+            "region-6697feba9d3597dd",
+            "region-69c7039601f0a770",
+            "region-6a8771ab6783efcc",
+            "region-6abb905fc8dd073d",
+            "region-71ea00f35ec405a1",
+            "region-71f5510877076519",
+            "region-72cb1f112b3ef91b",
+            "region-7387f3f5126be4ad",
+            "region-75d6ca1c72774b83",
+            "region-78aa78bc0fc9caeb",
+            "region-7bccecc94755aa4f",
+            "region-7cd13bf29db5e6af",
+            "region-7f159bdbb195fbdd",
+            "region-7fde5d3605d4ec12",
+            "region-8067df8554bd8966",
+            "region-81b68850dfb59a18",
+            "region-84321d573af6e0ee",
+            "region-85e48f1247e99b09",
+            "region-8c96107bab459069",
+            "region-92bbca524efa6f10",
+            "region-941b80b5aad1d9d4",
+            "region-95186e40451b6314",
+            "region-9645df2a631ecf3e",
+            "region-9b32c0584d9e8a26",
+            "region-9d85c169f5ad0bc9",
+            "region-9db5f7ed9310c49c",
+            "region-a05f08e7ad6753ba",
+            "region-a15995c7d33b7162",
+            "region-a3566e0bc129a1a2",
+            "region-a595c2597f28920b",
+            "region-a9201dada3b15e53",
+            "region-a9cea6c38e283e8a",
+            "region-aa2f95f0d781d63f",
+            "region-ac2e9e9ffb1015c0",
+            "region-b1f23e8298861fac",
+            "region-b24c66a6f80facc5",
+            "region-b53328d157eb65b8",
+            "region-b89899e167892188",
+            "region-b919d5322eb45186",
+            "region-ba0c8b4ef85203cb",
+            "region-bd146f6ba302b81f",
+            "region-bd783e1ca50a5908",
+            "region-bedfe10acbafaf30",
+            "region-befed3d26b4757a5",
+            "region-c08fd9a5c66be030",
+            "region-c203541fd4d6d680",
+            "region-c20a82bce1275e47",
+            "region-c50c4b624484a189",
+            "region-c5ba8e28fb7020bf",
+            "region-c9d993ae81c06c0a",
+            "region-cb3796d294c86ab7",
+            "region-ccea8d4132c59d01",
+            "region-cf8beea42b3c0378",
+            "region-d0bc27b8c4a8dd26",
+            "region-d18114c3fdb614a6",
+            "region-d4a886f78259db47",
+            "region-d6e363ff258f9ec2",
+            "region-d7e7ab3da257af5a",
+            "region-d8a6b69ce678cc08",
+            "region-ddf935d103375839",
+            "region-de230b392d32e6f1",
+            "region-df1e0a108bc7084c",
+            "region-e247bf49f3cd6992",
+            "region-e279de8f4ddb8c05",
+            "region-e3319a1f3047f3e2",
+            "region-e53b2ad152ea96ba",
+            "region-e671090c984c4d48",
+            "region-e9cb35742ba103fd",
+            "region-ee7c295a3725af74",
+            "region-f058236680bc9b43",
+            "region-f6e8d6553f47012c",
+            "region-f729fef5dd4ea9a9",
+            "region-f92b6617632aeaad",
+            "region-faa705ad2c7f67ef",
+            "region-fe09b61e69fced58",
+            "region-fea22d4499b6ba60",
+            "region-fef791fdd28a8154"
+          ]
+        },
+        "gates": {
+          "all_registered_sizes_pass": true
+        },
+        "partition_assignment_record": {
+          "sha256": "71ff229b0ecc0f76775f785642d187b3a1aaf8310d0999c7cec46a4418b3f8a7",
+          "size_bytes": 7173364
+        },
+        "registered_size_results": {
+          "160": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "4e8f89d0e41d6018ff2763ac3af1e1fe1b822562a6a3f1e4fac27eb8792099d8",
+                "size_bytes": 4162
+              },
+              "counts_by_region_record": {
+                "sha256": "7e7f0877bb571f6a32e13858c2ccfc240b74a3ac88f09bb9d186a781553cc11b",
+                "size_bytes": 3586
+              },
+              "quadratic_exposure": 400.07314201100417,
+              "used_region_count": 103
+            },
+            "capacities_by_region_record": {
+              "sha256": "3769975600b05a46c569cceb05990cd1e4b3a50114fb29adff0f25821939ad79",
+              "size_bytes": 3682
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 6909.8698189731585,
+                "components": 160,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 160.0,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 6909.8698189731585,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 6918.297583618857
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 6909.8698189731585,
+                "components": 160,
+                "design_effect_upper_bound": 2.054667159214556,
+                "effective_components_lower_bound": 77.87149333771592,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 6909.8698189731585,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 6918.297583618857
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 6909.8698189731585,
+                "components": 160,
+                "design_effect_upper_bound": 3.109334318429112,
+                "effective_components_lower_bound": 51.45795968342017,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 6909.8698189731585,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 6918.297583618857
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 6909.8698189731585,
+                "components": 160,
+                "design_effect_upper_bound": 5.218668636858224,
+                "effective_components_lower_bound": 30.65916062766618,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 6909.8698189731585,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 6918.297583618857
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 6909.8698189731585,
+                "components": 160,
+                "design_effect_upper_bound": 9.437337273716448,
+                "effective_components_lower_bound": 16.95393471266621,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 6909.8698189731585,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 6918.297583618857
+              }
+            },
+            "components_per_corpus": 160,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 160,
+                "design_effect": 1.0,
+                "effective_components": 160.0,
+                "one_C_one": 160.0,
+                "quadratic_exposure": 400.07314201100417,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 160,
+                "design_effect": 1.0375114284392193,
+                "effective_components": 154.21516873379994,
+                "one_C_one": 166.0018285502751,
+                "quadratic_exposure": 400.07314201100417,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 160,
+                "design_effect": 1.0750228568784388,
+                "effective_components": 148.83404476123846,
+                "one_C_one": 172.0036571005502,
+                "quadratic_exposure": 400.07314201100417,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 160,
+                "design_effect": 1.1500457137568776,
+                "effective_components": 139.1249044156034,
+                "one_C_one": 184.00731420110043,
+                "quadratic_exposure": 400.07314201100417,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 160,
+                "design_effect": 1.3000914275137554,
+                "effective_components": 123.06826782634651,
+                "one_C_one": 208.01462840220086,
+                "quadratic_exposure": 400.07314201100417,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 1546
+          },
+          "320": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "1d3e1c9f388958a1cdc791127cb6e8fb96307905e25564fbad66010e98ee91ea",
+                "size_bytes": 8322
+              },
+              "counts_by_region_record": {
+                "sha256": "61672646e7b5581a4a34e2a19d143103c7225ec163839ce554321765291ec2b6",
+                "size_bytes": 3586
+              },
+              "quadratic_exposure": 1622.6623726945777,
+              "used_region_count": 103
+            },
+            "capacities_by_region_record": {
+              "sha256": "65f0e4958f6cd76a4d7528abf32d925011fa925ac0f79a85e67f0260e9856439",
+              "size_bytes": 3682
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 27410.08534209894,
+                "components": 320,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 320.0,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 27410.08534209894,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 27673.19033447543
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 27410.08534209894,
+                "components": 320,
+                "design_effect_upper_bound": 3.1164129173514796,
+                "effective_components_lower_bound": 102.6821568535776,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 27410.08534209894,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 27673.19033447543
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 27410.08534209894,
+                "components": 320,
+                "design_effect_upper_bound": 5.232825834702959,
+                "effective_components_lower_bound": 61.152427026680265,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 27410.08534209894,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 27673.19033447543
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 27410.08534209894,
+                "components": 320,
+                "design_effect_upper_bound": 9.465651669405919,
+                "effective_components_lower_bound": 33.80644156115284,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 27410.08534209894,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 27673.19033447543
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 27410.08534209894,
+                "components": 320,
+                "design_effect_upper_bound": 17.931303338811837,
+                "effective_components_lower_bound": 17.84588626680406,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 27410.08534209894,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 27673.19033447543
+              }
+            },
+            "components_per_corpus": 320,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 320,
+                "design_effect": 1.0,
+                "effective_components": 320.0,
+                "one_C_one": 320.0,
+                "quadratic_exposure": 1622.6623726945777,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 320,
+                "design_effect": 1.101770497866764,
+                "effective_components": 290.4416124951435,
+                "one_C_one": 352.56655931736447,
+                "quadratic_exposure": 1622.6623726945777,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 320,
+                "design_effect": 1.2035409957335277,
+                "effective_components": 265.8820938666639,
+                "one_C_one": 385.1331186347289,
+                "quadratic_exposure": 1622.6623726945777,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 320,
+                "design_effect": 1.4070819914670554,
+                "effective_components": 227.42100456161816,
+                "one_C_one": 450.26623726945775,
+                "quadratic_exposure": 1622.6623726945777,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 320,
+                "design_effect": 1.814163982934111,
+                "effective_components": 176.38978780873646,
+                "one_C_one": 580.5324745389155,
+                "quadratic_exposure": 1622.6623726945777,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 3050
+          },
+          "512": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "8742a73c91d3df277d48bed9b485f254210eb8f0f11a12621c0651dd5c1c6dba",
+                "size_bytes": 13314
+              },
+              "counts_by_region_record": {
+                "sha256": "bbb397e72c58889ea09e697c4ccbd0638c4f64450ceeadd3b6157d9da22b2df8",
+                "size_bytes": 3586
+              },
+              "quadratic_exposure": 4212.647633498188,
+              "used_region_count": 104
+            },
+            "capacities_by_region_record": {
+              "sha256": "23c73d52c3b262e6a3a58f48540227f15ddf0288f034a5b377ce7fb86fb8ac6d",
+              "size_bytes": 3682
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 68921.99912920031,
+                "components": 512,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 512.0,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 68921.99912920031,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 70301.79427353945
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 68921.99912920031,
+                "components": 512,
+                "design_effect_upper_bound": 4.340331988730484,
+                "effective_components_lower_bound": 117.96332661404463,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 68921.99912920031,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 70301.79427353945
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 68921.99912920031,
+                "components": 512,
+                "design_effect_upper_bound": 7.680663977460968,
+                "effective_components_lower_bound": 66.66090347168841,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 68921.99912920031,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 70301.79427353945
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 68921.99912920031,
+                "components": 512,
+                "design_effect_upper_bound": 14.361327954921936,
+                "effective_components_lower_bound": 35.65129921182021,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 68921.99912920031,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 70301.79427353945
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 68921.99912920031,
+                "components": 512,
+                "design_effect_upper_bound": 27.722655909843873,
+                "effective_components_lower_bound": 18.46864895142305,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 68921.99912920031,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 70301.79427353945
+              }
+            },
+            "components_per_corpus": 512,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 512,
+                "design_effect": 1.0,
+                "effective_components": 512.0,
+                "one_C_one": 512.0,
+                "quadratic_exposure": 4212.647633498188,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 512,
+                "design_effect": 1.1806956852294037,
+                "effective_components": 433.6426450991229,
+                "one_C_one": 604.5161908374547,
+                "quadratic_exposure": 4212.647633498188,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 512,
+                "design_effect": 1.3613913704588074,
+                "effective_components": 376.08582741893616,
+                "one_C_one": 697.0323816749094,
+                "quadratic_exposure": 4212.647633498188,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 512,
+                "design_effect": 1.7227827409176149,
+                "effective_components": 297.1935972189336,
+                "one_C_one": 882.0647633498188,
+                "quadratic_exposure": 4212.647633498188,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 512,
+                "design_effect": 2.4455654818352297,
+                "effective_components": 209.35853233248082,
+                "one_C_one": 1252.1295266996376,
+                "quadratic_exposure": 4212.647633498188,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 4789
+          },
+          "800": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "03bf83a0c3325d055f93d4035ba42cf64b3ad62b204422498cf660c7d679b0fa",
+                "size_bytes": 20802
+              },
+              "counts_by_region_record": {
+                "sha256": "8d31de90429d3f0ed87c05ec7b75288847097f76dddfb32e98c2092b5cac70fb",
+                "size_bytes": 3612
+              },
+              "quadratic_exposure": 10400.586006853297,
+              "used_region_count": 104
+            },
+            "capacities_by_region_record": {
+              "sha256": "736a4442f7177e3879ceb9991d6b8a9cca22cff1e3ed0c63cb5013ca4edbfd26",
+              "size_bytes": 3682
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 164919.04258723964,
+                "components": 800,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 800.0,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 164919.04258723964,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 172957.43959047145
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 164919.04258723964,
+                "components": 800,
+                "design_effect_upper_bound": 6.128720080851239,
+                "effective_components_lower_bound": 130.53296437857304,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 164919.04258723964,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 172957.43959047145
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 164919.04258723964,
+                "components": 800,
+                "design_effect_upper_bound": 11.257440161702478,
+                "effective_components_lower_bound": 71.06411302292145,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 164919.04258723964,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 172957.43959047145
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 164919.04258723964,
+                "components": 800,
+                "design_effect_upper_bound": 21.514880323404956,
+                "effective_components_lower_bound": 37.183567278769395,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 164919.04258723964,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 172957.43959047145
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 164919.04258723964,
+                "components": 800,
+                "design_effect_upper_bound": 42.02976064680991,
+                "effective_components_lower_bound": 19.034131712589723,
+                "lambda_max_upper": 2.7024599936011158,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 164919.04258723964,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 172957.43959047145
+              }
+            },
+            "components_per_corpus": 800,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 800,
+                "design_effect": 1.0,
+                "effective_components": 800.0,
+                "one_C_one": 800.0,
+                "quadratic_exposure": 10400.586006853297,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 800,
+                "design_effect": 1.3000183127141656,
+                "effective_components": 615.3759467662942,
+                "one_C_one": 1040.0146501713325,
+                "quadratic_exposure": 10400.586006853297,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 800,
+                "design_effect": 1.6000366254283314,
+                "effective_components": 499.988554815637,
+                "one_C_one": 1280.029300342665,
+                "quadratic_exposure": 10400.586006853297,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 800,
+                "design_effect": 2.2000732508566623,
+                "effective_components": 363.6242564598687,
+                "one_C_one": 1760.0586006853298,
+                "quadratic_exposure": 10400.586006853297,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 800,
+                "design_effect": 3.4001465017133246,
+                "effective_components": 235.28397955702266,
+                "one_C_one": 2720.1172013706596,
+                "quadratic_exposure": 10400.586006853297,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 7219
+          }
+        },
+        "rho_grid": [
+          0.0,
+          0.025,
+          0.05,
+          0.1,
+          0.2
+        ],
+        "target_region_count": 128,
+        "walk_weights": [
+          1.0,
+          0.5,
+          0.25,
+          0.125
+        ]
+      },
+      "64": {
+        "actual_region_count": 64,
+        "authorization": {
+          "attempted_input_inventory_authorized": false,
+          "candidate_selection_authorized": false,
+          "covariance_promotion_authorized": false,
+          "cuda_authorized": false,
+          "independent_batching_authorized": false,
+          "live_scoring_authorized": false,
+          "nomic_authorized": false,
+          "qr_specialization_authorized": false
+        },
+        "exposure": {
+          "effective_rank": 62.37691503331935,
+          "eigenvalues_descending": [
+            1.6606882966415508,
+            1.5466952682977244,
+            1.388495265434319,
+            1.2902004679656571,
+            1.178232287432883,
+            1.102298110617246,
+            1.0819978588054098,
+            1.0595094580553082,
+            1.035176974215358,
+            1.0245711931804853,
+            1.0128921390593497,
+            1.0058545402891783,
+            1.0002086740372205,
+            1.0000000000000016,
+            1.000000000000001,
+            1.000000000000001,
+            1.0000000000000009,
+            1.0000000000000007,
+            1.0000000000000004,
+            1.0000000000000004,
+            1.0000000000000002,
+            1.0000000000000002,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            0.9999999999999999,
+            0.9999999999999999,
+            0.9999999999999998,
+            0.9999999999999998,
+            0.9999999999999997,
+            0.9999999999999996,
+            0.9999999999999996,
+            0.9999999999999996,
+            0.9999999999999993,
+            0.9999999999999993,
+            0.9999999999999992,
+            0.9999999999999991,
+            0.9999999999999991,
+            0.999999999999999,
+            0.9999999999999989,
+            0.9941680120394137,
+            0.988803862097825,
+            0.9799144943947391,
+            0.9671906399115441,
+            0.95951647740581,
+            0.9413695869915548,
+            0.9371484909710762,
+            0.9287103726556194,
+            0.9203737180403732,
+            0.900999691622052,
+            0.8900461602267892,
+            0.8757756897851016,
+            0.8572185699149011,
+            0.8138188508641608,
+            0.8000839372295426,
+            0.7250221380993342,
+            0.6976239288359528,
+            0.4353948448825231
+          ],
+          "matrix_record": {
+            "sha256": "f3db8d1745ad6ddeff0207292aa709128d4ba43e960fe82a9432e457c3625107",
+            "size_bytes": 32446
+          },
+          "matrix_shape": [
+            64,
+            64
+          ],
+          "mean_outside_landing_mass_by_hop": [
+            1.0408340855860843e-17,
+            0.1788832056372443,
+            0.1899057016700513,
+            0.2517212607117715
+          ],
+          "numerical_rank": 64,
+          "off_diagonal_quantiles": {
+            "0.0": 0.0,
+            "0.25": 0.0,
+            "0.5": 0.0,
+            "0.75": 0.0,
+            "0.9": 0.008943075620976581,
+            "0.95": 0.024400748040747374,
+            "1.0": 0.5350701191747981
+          },
+          "per_region_outside_landing_mass_by_hop": {
+            "region-060714791b80068b": [
+              0.0,
+              0.41122864262366476,
+              0.4230859323380406,
+              0.5630073075055261
+            ],
+            "region-06cbe461e6f0467c": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-09a79f54ea9f78a7": [
+              0.0,
+              0.37048412658210617,
+              0.4353231963449783,
+              0.5610236370319506
+            ],
+            "region-0d01052c540ffc67": [
+              0.0,
+              0.27799408649025803,
+              0.2818454779882327,
+              0.4000483638787189
+            ],
+            "region-0f3249f27acd2840": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-13ecf2f21fa45eee": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-14eba5ecf870cf1e": [
+              0.0,
+              0.4689840141443449,
+              0.4165083301249276,
+              0.6213846947469894
+            ],
+            "region-178d27f954e59a7b": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-196f3de6e6456f85": [
+              0.0,
+              0.3538906125173731,
+              0.4816429971675009,
+              0.5833679459556596
+            ],
+            "region-19b4c4987a15a921": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-1bb0951829949fa6": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-1d9226b552f4c309": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-206b8221ab5f1954": [
+              0.0,
+              1.1102230246251565e-16,
+              1.1102230246251565e-16,
+              2.220446049250313e-16
+            ],
+            "region-20770fadee0ef677": [
+              0.0,
+              0.2700227488765622,
+              0.3069976739673588,
+              0.4071684412885337
+            ],
+            "region-252613a1969b52e8": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-26d0c18430f479c0": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-2d4043d9485faa3b": [
+              1.1102230246251565e-16,
+              0.17123122940661173,
+              0.22169767448166944,
+              0.2859015826182445
+            ],
+            "region-2fa0a59be2e5173b": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-3caa303497adf42f": [
+              0.0,
+              0.3114232183878194,
+              0.34208022421109696,
+              0.44117018555187815
+            ],
+            "region-3cd733037e94bafd": [
+              0.0,
+              0.46814656480108063,
+              0.4768230515405393,
+              0.6517226795877953
+            ],
+            "region-3d0a5943b1ab752c": [
+              0.0,
+              0.4942085699728975,
+              0.41804672696327294,
+              0.6202075189435716
+            ],
+            "region-429a4cbba244465f": [
+              0.0,
+              0.3616453716870588,
+              0.40442680159717403,
+              0.5113376447485265
+            ],
+            "region-42c5dce1ac3770dd": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-47808bc508c65b47": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-48341f264dff6376": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-55831b777b81572b": [
+              0.0,
+              0.31892162403744573,
+              0.41671445195149703,
+              0.5065388229839904
+            ],
+            "region-58f6700fd8c40e6d": [
+              0.0,
+              0.2919908171482437,
+              0.338945217940973,
+              0.44342683180817366
+            ],
+            "region-61680173f0654a6d": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-68f9e9429953da65": [
+              0.0,
+              0.4827922826217661,
+              0.38394667045347686,
+              0.5541157258155817
+            ],
+            "region-703b32910a646f03": [
+              0.0,
+              0.21991779635066577,
+              0.2597133692865422,
+              0.34565136418834375
+            ],
+            "region-75ad6b2551c479be": [
+              0.0,
+              0.36570667234745835,
+              0.35114096231331116,
+              0.5036285046618976
+            ],
+            "region-7a5dd2ede7b24a5d": [
+              1.1102230246251565e-16,
+              0.5139431442928222,
+              0.5225635839258678,
+              0.6717732739078603
+            ],
+            "region-7bccecc94755aa4f": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-7fde5d3605d4ec12": [
+              0.0,
+              0.0,
+              3.3306690738754696e-16,
+              4.440892098500626e-16
+            ],
+            "region-81e05495c483327f": [
+              0.0,
+              0.26434554730623516,
+              0.4288358790899076,
+              0.4522496327238408
+            ],
+            "region-87f4abeb6d5fe7fa": [
+              1.1102230246251565e-16,
+              0.403584776165254,
+              0.35883300725843637,
+              0.5220514461754948
+            ],
+            "region-95186e40451b6314": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-9af3a4dcce80cb31": [
+              0.0,
+              0.7452234015092781,
+              0.6404560669552224,
+              0.8893073712863614
+            ],
+            "region-9d5d709c29d8b127": [
+              0.0,
+              0.13735655791768453,
+              0.18575959482921078,
+              0.2280289223163905
+            ],
+            "region-9fde113e887390f6": [
+              1.1102230246251565e-16,
+              0.35414040413328296,
+              0.4290760373364314,
+              0.5403003538144492
+            ],
+            "region-a15995c7d33b7162": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-a595c2597f28920b": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-a8772140c62931c6": [
+              0.0,
+              0.27788722173365177,
+              0.30478697149865075,
+              0.41407056853683955
+            ],
+            "region-a9201dada3b15e53": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-acc13b2b4da352fe": [
+              0.0,
+              0.3795510392258049,
+              0.39356765097417135,
+              0.5261419046710433
+            ],
+            "region-b1f23e8298861fac": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-b8ed4c3eea41e249": [
+              0.0,
+              0.3525824143068478,
+              0.4145435357934253,
+              0.535175321589481
+            ],
+            "region-bd146f6ba302b81f": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-c679554122ddd82d": [
+              1.1102230246251565e-16,
+              0.4535359533377953,
+              0.4965602882255281,
+              0.6304924652281099
+            ],
+            "region-c9d993ae81c06c0a": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-ccea8d4132c59d01": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-cf8beea42b3c0378": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-d6e363ff258f9ec2": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-de49302fe6285839": [
+              0.0,
+              0.4111306855510479,
+              0.44401121271137234,
+              0.575088963277328
+            ],
+            "region-e13663547b15fda1": [
+              0.0,
+              0.3926538201653722,
+              0.400532111702098,
+              0.535537648687277
+            ],
+            "region-e53b2ad152ea96ba": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-e671090c984c4d48": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-e99503074ba3bc7c": [
+              0.0,
+              0.4622551955200276,
+              0.4283337228729841,
+              0.6108675670541972
+            ],
+            "region-e9cb35742ba103fd": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-ea998d699ed769de": [
+              0.0,
+              0.35107433033398494,
+              0.37980290017359664,
+              0.501760872849245
+            ],
+            "region-f6e8d6553f47012c": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-faa705ad2c7f67ef": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-fe09b61e69fced58": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-ff1d5fb31a655ec7": [
+              1.1102230246251565e-16,
+              0.3106722912891894,
+              0.36736358486578846,
+              0.47761312212007523
+            ]
+          },
+          "region_ids": [
+            "region-060714791b80068b",
+            "region-06cbe461e6f0467c",
+            "region-09a79f54ea9f78a7",
+            "region-0d01052c540ffc67",
+            "region-0f3249f27acd2840",
+            "region-13ecf2f21fa45eee",
+            "region-14eba5ecf870cf1e",
+            "region-178d27f954e59a7b",
+            "region-196f3de6e6456f85",
+            "region-19b4c4987a15a921",
+            "region-1bb0951829949fa6",
+            "region-1d9226b552f4c309",
+            "region-206b8221ab5f1954",
+            "region-20770fadee0ef677",
+            "region-252613a1969b52e8",
+            "region-26d0c18430f479c0",
+            "region-2d4043d9485faa3b",
+            "region-2fa0a59be2e5173b",
+            "region-3caa303497adf42f",
+            "region-3cd733037e94bafd",
+            "region-3d0a5943b1ab752c",
+            "region-429a4cbba244465f",
+            "region-42c5dce1ac3770dd",
+            "region-47808bc508c65b47",
+            "region-48341f264dff6376",
+            "region-55831b777b81572b",
+            "region-58f6700fd8c40e6d",
+            "region-61680173f0654a6d",
+            "region-68f9e9429953da65",
+            "region-703b32910a646f03",
+            "region-75ad6b2551c479be",
+            "region-7a5dd2ede7b24a5d",
+            "region-7bccecc94755aa4f",
+            "region-7fde5d3605d4ec12",
+            "region-81e05495c483327f",
+            "region-87f4abeb6d5fe7fa",
+            "region-95186e40451b6314",
+            "region-9af3a4dcce80cb31",
+            "region-9d5d709c29d8b127",
+            "region-9fde113e887390f6",
+            "region-a15995c7d33b7162",
+            "region-a595c2597f28920b",
+            "region-a8772140c62931c6",
+            "region-a9201dada3b15e53",
+            "region-acc13b2b4da352fe",
+            "region-b1f23e8298861fac",
+            "region-b8ed4c3eea41e249",
+            "region-bd146f6ba302b81f",
+            "region-c679554122ddd82d",
+            "region-c9d993ae81c06c0a",
+            "region-ccea8d4132c59d01",
+            "region-cf8beea42b3c0378",
+            "region-d6e363ff258f9ec2",
+            "region-de49302fe6285839",
+            "region-e13663547b15fda1",
+            "region-e53b2ad152ea96ba",
+            "region-e671090c984c4d48",
+            "region-e99503074ba3bc7c",
+            "region-e9cb35742ba103fd",
+            "region-ea998d699ed769de",
+            "region-f6e8d6553f47012c",
+            "region-faa705ad2c7f67ef",
+            "region-fe09b61e69fced58",
+            "region-ff1d5fb31a655ec7"
+          ]
+        },
+        "gates": {
+          "all_registered_sizes_pass": true
+        },
+        "partition_assignment_record": {
+          "sha256": "93270af4d6ae9650bb5d80973496ce356a678ffabbcda52a1fa8f512b48f1790",
+          "size_bytes": 7173364
+        },
+        "registered_size_results": {
+          "160": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "390e183cba8c327c71914e717d35e7daee76cc0f76dfea202dfa2b3209ac2d34",
+                "size_bytes": 4162
+              },
+              "counts_by_region_record": {
+                "sha256": "28561e13ab0e536efe63811ffb70588b66dfa17f5dadd5e70239b06e2434eb0f",
+                "size_bytes": 1794
+              },
+              "quadratic_exposure": 1016.7072988782149,
+              "used_region_count": 40
+            },
+            "capacities_by_region_record": {
+              "sha256": "5238c12428651da0fbfa7acdf73effe334c460968ef705c95603822980136472",
+              "size_bytes": 1827
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 5101.5165479200905,
+                "components": 160,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 160.0,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 5101.51654792009,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 5101.51654792009
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 5101.5165479200905,
+                "components": 160,
+                "design_effect_upper_bound": 1.772111960612514,
+                "effective_components_lower_bound": 90.28774905661011,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 5101.51654792009,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 5101.51654792009
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 5101.5165479200905,
+                "components": 160,
+                "design_effect_upper_bound": 2.544223921225028,
+                "effective_components_lower_bound": 62.88754644007946,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 5101.51654792009,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 5101.51654792009
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 5101.5165479200905,
+                "components": 160,
+                "design_effect_upper_bound": 4.088447842450056,
+                "effective_components_lower_bound": 39.1346560273392,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 5101.51654792009,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 5101.51654792009
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 5101.5165479200905,
+                "components": 160,
+                "design_effect_upper_bound": 7.176895684900112,
+                "effective_components_lower_bound": 22.293761401135217,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 5101.51654792009,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 5101.51654792009
+              }
+            },
+            "components_per_corpus": 160,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 160,
+                "design_effect": 1.0,
+                "effective_components": 160.0,
+                "one_C_one": 160.0,
+                "quadratic_exposure": 1016.7072988782149,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 160,
+                "design_effect": 1.133860515449721,
+                "effective_components": 141.1108313764145,
+                "one_C_one": 181.41768247195537,
+                "quadratic_exposure": 1016.7072988782149,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 160,
+                "design_effect": 1.2677210308994422,
+                "effective_components": 126.21073256667576,
+                "one_C_one": 202.83536494391075,
+                "quadratic_exposure": 1016.7072988782149,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 160,
+                "design_effect": 1.5354420617988844,
+                "effective_components": 104.20451802170128,
+                "one_C_one": 245.6707298878215,
+                "quadratic_exposure": 1016.7072988782149,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 160,
+                "design_effect": 2.070884123597769,
+                "effective_components": 77.2616865312726,
+                "one_C_one": 331.341459775643,
+                "quadratic_exposure": 1016.7072988782149,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 538
+          },
+          "320": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "2d9e0e65333475cfbea69531ec7b356735fb141b0e72d46fa76a39e6a6c4bff6",
+                "size_bytes": 8322
+              },
+              "counts_by_region_record": {
+                "sha256": "0390d91e949a6681285ee47b84b6ddc9032b7c20c23570281e102ca3fd6a2ef9",
+                "size_bytes": 1811
+              },
+              "quadratic_exposure": 4257.8949829433195,
+              "used_region_count": 40
+            },
+            "capacities_by_region_record": {
+              "sha256": "7427dab3a7183f5fc1c4eee1d609579f7eda7fbcb3283370b8545901e7666106",
+              "size_bytes": 1827
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 20406.066191680362,
+                "components": 320,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 320.0,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 20406.06619168036,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 20406.06619168036
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 20406.066191680362,
+                "components": 320,
+                "design_effect_upper_bound": 2.569223921225028,
+                "effective_components_lower_bound": 124.5512301813776,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 20406.06619168036,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 20406.06619168036
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 20406.066191680362,
+                "components": 320,
+                "design_effect_upper_bound": 4.138447842450056,
+                "effective_components_lower_bound": 77.32367597281417,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 20406.06619168036,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 20406.06619168036
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 20406.066191680362,
+                "components": 320,
+                "design_effect_upper_bound": 7.276895684900111,
+                "effective_components_lower_bound": 43.974795552451646,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 20406.06619168036,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 20406.06619168036
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 20406.066191680362,
+                "components": 320,
+                "design_effect_upper_bound": 13.553791369800223,
+                "effective_components_lower_bound": 23.609630048829406,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 20406.06619168036,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 20406.06619168036
+              }
+            },
+            "components_per_corpus": 320,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 320,
+                "design_effect": 1.0,
+                "effective_components": 320.0,
+                "one_C_one": 320.0,
+                "quadratic_exposure": 4257.8949829433195,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 320,
+                "design_effect": 1.3076480455424468,
+                "effective_components": 244.7141653221036,
+                "one_C_one": 418.447374573583,
+                "quadratic_exposure": 4257.8949829433195,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 320,
+                "design_effect": 1.6152960910848937,
+                "effective_components": 198.10609445917495,
+                "one_C_one": 516.894749147166,
+                "quadratic_exposure": 4257.8949829433195,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 320,
+                "design_effect": 2.2305921821697874,
+                "effective_components": 143.45966176960374,
+                "one_C_one": 713.7894982943319,
+                "quadratic_exposure": 4257.8949829433195,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 320,
+                "design_effect": 3.4611843643395743,
+                "effective_components": 92.45390199289743,
+                "one_C_one": 1107.5789965886638,
+                "quadratic_exposure": 4257.8949829433195,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 1053
+          },
+          "512": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "42f990c75bc86822fcda8a68c7d46639b69f5bdfb61575b19bd32ef664eaa035",
+                "size_bytes": 13314
+              },
+              "counts_by_region_record": {
+                "sha256": "ea6ed8ea30cf8cb5b1c90d82cc265e6f0a2fd9d094f92be67907f551e58dd230",
+                "size_bytes": 1824
+              },
+              "quadratic_exposure": 11135.009270593746,
+              "used_region_count": 40
+            },
+            "capacities_by_region_record": {
+              "sha256": "0fe4724af1188f0e410614850859fe22573b918b69184d3028ea6a7eedfe07d5",
+              "size_bytes": 1827
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 51772.70062538703,
+                "components": 512,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 512.0,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 51772.70062538703,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 51840.176358434845
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 51772.70062538703,
+                "components": 512,
+                "design_effect_upper_bound": 3.5029638977239763,
+                "effective_components_lower_bound": 146.16194027368311,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 51772.70062538703,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 51840.176358434845
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 51772.70062538703,
+                "components": 512,
+                "design_effect_upper_bound": 6.005927795447953,
+                "effective_components_lower_bound": 85.24911011884925,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 51772.70062538703,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 51840.176358434845
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 51772.70062538703,
+                "components": 512,
+                "design_effect_upper_bound": 11.011855590895905,
+                "effective_components_lower_bound": 46.4953427488913,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 51772.70062538703,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 51840.176358434845
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 51772.70062538703,
+                "components": 512,
+                "design_effect_upper_bound": 21.02371118179181,
+                "effective_components_lower_bound": 24.35345480028437,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 51772.70062538703,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 51840.176358434845
+              }
+            },
+            "components_per_corpus": 512,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 512,
+                "design_effect": 1.0,
+                "effective_components": 512.0,
+                "one_C_one": 512.0,
+                "quadratic_exposure": 11135.009270593746,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 512,
+                "design_effect": 1.5187016245407103,
+                "effective_components": 337.1300798830977,
+                "one_C_one": 777.5752317648437,
+                "quadratic_exposure": 11135.009270593746,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 512,
+                "design_effect": 2.0374032490814207,
+                "effective_components": 251.30027658041638,
+                "one_C_one": 1043.1504635296874,
+                "quadratic_exposure": 11135.009270593746,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 512,
+                "design_effect": 3.074806498162841,
+                "effective_components": 166.514543372376,
+                "one_C_one": 1574.3009270593745,
+                "quadratic_exposure": 11135.009270593746,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 512,
+                "design_effect": 5.149612996325682,
+                "effective_components": 99.42494714948849,
+                "one_C_one": 2636.601854118749,
+                "quadratic_exposure": 11135.009270593746,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 1645
+          },
+          "800": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "6fd64eb27abf55cd4c764b00a2c514057de51614d7e50fceba4ad1b660038747",
+                "size_bytes": 20802
+              },
+              "counts_by_region_record": {
+                "sha256": "8ce96977edb584c4835d2734afa2885ca8fbce68e558120ef46244063a0ee318",
+                "size_bytes": 1827
+              },
+              "quadratic_exposure": 27776.649451328743,
+              "used_region_count": 40
+            },
+            "capacities_by_region_record": {
+              "sha256": "9b47f8411409320c0d6fcec75f8667ab907c825a01ed905acfe8599afc6d85c0",
+              "size_bytes": 1827
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 126435.79174800537,
+                "components": 800,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 800.0,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 126435.79174800537,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 127537.91369800223
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 126435.79174800537,
+                "components": 800,
+                "design_effect_upper_bound": 4.926118492125168,
+                "effective_components_lower_bound": 162.39966644709625,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 126435.79174800537,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 127537.91369800223
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 126435.79174800537,
+                "components": 800,
+                "design_effect_upper_bound": 8.852236984250336,
+                "effective_components_lower_bound": 90.37263704342062,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 126435.79174800537,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 127537.91369800223
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 126435.79174800537,
+                "components": 800,
+                "design_effect_upper_bound": 16.704473968500672,
+                "effective_components_lower_bound": 47.8913614106344,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 126435.79174800537,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 127537.91369800223
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 126435.79174800537,
+                "components": 800,
+                "design_effect_upper_bound": 32.408947937001344,
+                "effective_components_lower_bound": 24.684540872943266,
+                "lambda_max_upper": 1.9927799015312846,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 126435.79174800537,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 127537.91369800223
+              }
+            },
+            "components_per_corpus": 800,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 800,
+                "design_effect": 1.0,
+                "effective_components": 800.0,
+                "one_C_one": 800.0,
+                "quadratic_exposure": 27776.649451328743,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 800,
+                "design_effect": 1.8430202953540231,
+                "effective_components": 434.07009788046264,
+                "one_C_one": 1474.4162362832185,
+                "quadratic_exposure": 27776.649451328743,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 800,
+                "design_effect": 2.6860405907080462,
+                "effective_components": 297.8361543632214,
+                "one_C_one": 2148.832472566437,
+                "quadratic_exposure": 27776.649451328743,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 800,
+                "design_effect": 4.372081181416093,
+                "effective_components": 182.9792190045484,
+                "one_C_one": 3497.6649451328744,
+                "quadratic_exposure": 27776.649451328743,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 800,
+                "design_effect": 7.744162362832186,
+                "effective_components": 103.30361923189649,
+                "one_C_one": 6195.329890265749,
+                "quadratic_exposure": 27776.649451328743,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 2534
+          }
+        },
+        "rho_grid": [
+          0.0,
+          0.025,
+          0.05,
+          0.1,
+          0.2
+        ],
+        "target_region_count": 64,
+        "walk_weights": [
+          1.0,
+          0.5,
+          0.25,
+          0.125
+        ]
+      },
+      "96": {
+        "actual_region_count": 96,
+        "authorization": {
+          "attempted_input_inventory_authorized": false,
+          "candidate_selection_authorized": false,
+          "covariance_promotion_authorized": false,
+          "cuda_authorized": false,
+          "independent_batching_authorized": false,
+          "live_scoring_authorized": false,
+          "nomic_authorized": false,
+          "qr_specialization_authorized": false
+        },
+        "exposure": {
+          "effective_rank": 91.3144471806047,
+          "eigenvalues_descending": [
+            2.076507282896406,
+            1.8649619046941879,
+            1.6466996348299334,
+            1.5861542367972352,
+            1.4787617895224605,
+            1.2864500030144737,
+            1.2209913472122234,
+            1.200946794307039,
+            1.1450337195858302,
+            1.1308614242830417,
+            1.1100923811859675,
+            1.0982447363825638,
+            1.0915611260128695,
+            1.0683577517867102,
+            1.0556041812449706,
+            1.044541131681845,
+            1.0410641332375932,
+            1.035199877434182,
+            1.026901699075999,
+            1.0168282991712996,
+            1.0160914457740966,
+            1.0078407872972786,
+            1.001800439232208,
+            1.0003733079468173,
+            1.000000000000001,
+            1.000000000000001,
+            1.0000000000000009,
+            1.0000000000000009,
+            1.0000000000000009,
+            1.0000000000000007,
+            1.0000000000000007,
+            1.0000000000000007,
+            1.0000000000000004,
+            1.0000000000000004,
+            1.0000000000000004,
+            1.0000000000000004,
+            1.0000000000000002,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            0.9999999999999998,
+            0.9999999999999998,
+            0.9999999999999998,
+            0.9999999999999997,
+            0.9999999999999996,
+            0.9999999999999994,
+            0.9999999999999994,
+            0.9999999999999994,
+            0.9999999999999994,
+            0.9999999999999992,
+            0.999999999999999,
+            0.9999999999999988,
+            0.9999999999999986,
+            0.9998937610138955,
+            0.9958534002356807,
+            0.987149050672152,
+            0.9840176914094378,
+            0.982266846186425,
+            0.9791334557133518,
+            0.9729749241997234,
+            0.9675652348510967,
+            0.9651505372513466,
+            0.9589253315056889,
+            0.9571491591335762,
+            0.9463567313135663,
+            0.94446744115842,
+            0.940434996091634,
+            0.9372086582258907,
+            0.9294821607449442,
+            0.9286598116508679,
+            0.9254048393935611,
+            0.9166480544142663,
+            0.9142946856822528,
+            0.9134297272960157,
+            0.9106781886474421,
+            0.9047848847669692,
+            0.9016222125919879,
+            0.892390159026466,
+            0.8907284080726942,
+            0.8721514497741734,
+            0.8693794039897251,
+            0.8591296217051927,
+            0.8536968541736351,
+            0.8309511169633625,
+            0.8277020743331913,
+            0.7972752200088734,
+            0.7622286668378285,
+            0.7500878499060686,
+            0.7345589344087473,
+            0.4406960113145238,
+            0.3863127408950636,
+            0.21729026983302496
+          ],
+          "matrix_record": {
+            "sha256": "c11d6738d4e575592d72b7eef748e097a158c4537da3086e48a4b2660c9476cd",
+            "size_bytes": 105324
+          },
+          "matrix_shape": [
+            96,
+            96
+          ],
+          "mean_outside_landing_mass_by_hop": [
+            8.0953762212251e-18,
+            0.25306918936412687,
+            0.2737869205289308,
+            0.3611866696954636
+          ],
+          "numerical_rank": 96,
+          "off_diagonal_quantiles": {
+            "0.0": 0.0,
+            "0.25": 0.0,
+            "0.5": 0.0,
+            "0.75": 0.0013283280170398129,
+            "0.9": 0.010951772142789322,
+            "0.95": 0.023013528598504186,
+            "1.0": 0.77429562807179
+          },
+          "per_region_outside_landing_mass_by_hop": {
+            "region-06cbe461e6f0467c": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-08be163f800acd50": [
+              0.0,
+              0.3213462815401077,
+              0.5294881506998514,
+              0.5934368957415865
+            ],
+            "region-0f3249f27acd2840": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-1227867453155a8b": [
+              0.0,
+              0.3720831391376972,
+              0.4664545481960123,
+              0.5659986723283699
+            ],
+            "region-13ecf2f21fa45eee": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-178d27f954e59a7b": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-19b4c4987a15a921": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-1a23bf3e6926f95c": [
+              0.0,
+              0.3649847082825468,
+              0.35782496321031565,
+              0.5031320314949441
+            ],
+            "region-1a4616843c0072be": [
+              0.0,
+              0.4780582191044933,
+              0.4757303340474571,
+              0.6354843023140961
+            ],
+            "region-1a8876b022acc74a": [
+              0.0,
+              0.5526292474463206,
+              0.5957539366267268,
+              0.7725441344128057
+            ],
+            "region-1bb0951829949fa6": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-1c02109b5afd46f7": [
+              0.0,
+              0.3476514548877314,
+              0.37003246282525293,
+              0.49269406071903665
+            ],
+            "region-1d9226b552f4c309": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-206b8221ab5f1954": [
+              0.0,
+              1.1102230246251565e-16,
+              1.1102230246251565e-16,
+              2.220446049250313e-16
+            ],
+            "region-252613a1969b52e8": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-26d0c18430f479c0": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-27cee13372e180a9": [
+              0.0,
+              0.38852690143232516,
+              0.4315980885858919,
+              0.5482928995668387
+            ],
+            "region-280eaeda1f1ae254": [
+              0.0,
+              0.33344697704777504,
+              0.40682411654890016,
+              0.5257891477292215
+            ],
+            "region-287408890512ab27": [
+              0.0,
+              0.36331223236482735,
+              0.429466471490501,
+              0.549153666433688
+            ],
+            "region-2af7128b6dc9b6ee": [
+              0.0,
+              0.3943381106904824,
+              0.4219542533035132,
+              0.567454255729495
+            ],
+            "region-2e60e921281a980c": [
+              0.0,
+              0.3661684724004881,
+              0.4537828729701715,
+              0.569969554953544
+            ],
+            "region-2f6db07db58b9746": [
+              0.0,
+              0.29454221447089435,
+              0.3763266220451186,
+              0.47679194437194294
+            ],
+            "region-2fa0a59be2e5173b": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-308a2781d47dc6fe": [
+              0.0,
+              0.026540498548996982,
+              0.03684079323109146,
+              0.04481597451412245
+            ],
+            "region-34284539e853ccd4": [
+              0.0,
+              0.45064726108514586,
+              0.4536885111735278,
+              0.6107423183488042
+            ],
+            "region-3e39e301a479c2d5": [
+              0.0,
+              0.3860482513013124,
+              0.4714059363758144,
+              0.5959665293227905
+            ],
+            "region-3ee85eea828f9249": [
+              0.0,
+              0.5764811379286613,
+              0.542935503746363,
+              0.6956137994580895
+            ],
+            "region-42c5dce1ac3770dd": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-4515c8beb7f178fd": [
+              0.0,
+              0.4535696767966422,
+              0.3438113728576664,
+              0.5020895235169849
+            ],
+            "region-45807597965af5ef": [
+              0.0,
+              0.33095912614033973,
+              0.37760165237273624,
+              0.505029999151879
+            ],
+            "region-47808bc508c65b47": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-48341f264dff6376": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-4cf37838eb489983": [
+              1.1102230246251565e-16,
+              0.39193815042092983,
+              0.3734619818507178,
+              0.5484745600810244
+            ],
+            "region-4f4778f481fa936a": [
+              0.0,
+              0.40605322091534823,
+              0.46186270225501236,
+              0.5898671382865974
+            ],
+            "region-5092f5444df8fdee": [
+              0.0,
+              0.46605227375965397,
+              0.5212262816870797,
+              0.6668101856144977
+            ],
+            "region-521b0f9e43508610": [
+              0.0,
+              0.24670512097063568,
+              0.3076284639204293,
+              0.39124535016523254
+            ],
+            "region-54f28f601d1c07f8": [
+              0.0,
+              0.10488781979610906,
+              0.13887258853220574,
+              0.17659747910231527
+            ],
+            "region-562dec06db3a23db": [
+              0.0,
+              0.42815668819616426,
+              0.5405181717882943,
+              0.6419178368988481
+            ],
+            "region-5b8c12faf5c50fc0": [
+              0.0,
+              0.5312434815174225,
+              0.50082998580014,
+              0.7005385684452639
+            ],
+            "region-5ced71eb2f3237d8": [
+              0.0,
+              0.41250781699568717,
+              0.4510913791796629,
+              0.5869805487588353
+            ],
+            "region-61680173f0654a6d": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-6331ac066d0dbabf": [
+              0.0,
+              0.3625727577076626,
+              0.4051782668117778,
+              0.5117397135290893
+            ],
+            "region-6628c6914591b544": [
+              0.0,
+              0.3665366041401943,
+              0.3814259325388507,
+              0.526010977940304
+            ],
+            "region-6aefee0f931b20a3": [
+              0.0,
+              0.5329338569549844,
+              0.5633605612969089,
+              0.7120618256537017
+            ],
+            "region-7797ff292bd03164": [
+              0.0,
+              0.7399833887043185,
+              0.6052449152446742,
+              0.8847089212141149
+            ],
+            "region-79a63ea0f7ecf993": [
+              0.0,
+              0.4262155063502252,
+              0.48181125904360655,
+              0.6254813177905327
+            ],
+            "region-7bccecc94755aa4f": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-7f92e78512d97141": [
+              1.1102230246251565e-16,
+              0.274440759091381,
+              0.32067074047070565,
+              0.42003373323882287
+            ],
+            "region-7fde5d3605d4ec12": [
+              0.0,
+              0.0,
+              3.3306690738754696e-16,
+              4.440892098500626e-16
+            ],
+            "region-854da7a52918c424": [
+              0.0,
+              0.27221541582756825,
+              0.365876076073235,
+              0.45030017931523414
+            ],
+            "region-86f5045a4a075548": [
+              0.0,
+              0.32733357004101493,
+              0.3664593313035234,
+              0.49926117888999455
+            ],
+            "region-8ba5a4c8ef27a1f1": [
+              0.0,
+              0.39316452046212247,
+              0.39972001197159823,
+              0.5458942227614085
+            ],
+            "region-8dd60d3ac9ebcbab": [
+              0.0,
+              0.6477567669767494,
+              0.3384633458959462,
+              0.7691153293980553
+            ],
+            "region-8fec67effdce745d": [
+              0.0,
+              0.3039622946439179,
+              0.37452067124648836,
+              0.4805434001043246
+            ],
+            "region-92f15ee48e0a6e34": [
+              0.0,
+              0.3702669570671516,
+              0.44075523157533114,
+              0.5684273795303603
+            ],
+            "region-95186e40451b6314": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-95b9f629605dc537": [
+              0.0,
+              0.3182850961602842,
+              0.40891662750515645,
+              0.5046834886534632
+            ],
+            "region-98002a2f764878dd": [
+              1.1102230246251565e-16,
+              0.43229552133314086,
+              0.41588735016752676,
+              0.5919193068438288
+            ],
+            "region-a15995c7d33b7162": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-a3c2f354262a89eb": [
+              0.0,
+              0.3104470747244036,
+              0.4005743031230351,
+              0.4998596915752207
+            ],
+            "region-a4b5d22cf21d2941": [
+              0.0,
+              0.4510839417213903,
+              0.5438883555156326,
+              0.6624235946703777
+            ],
+            "region-a595c2597f28920b": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-a9201dada3b15e53": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-a9ea0d0ce63f5d9c": [
+              0.0,
+              0.529597588781564,
+              0.5401574940195013,
+              0.6931053587740018
+            ],
+            "region-ae723bb688d8a9ed": [
+              0.0,
+              0.274883853920046,
+              0.3652334329063437,
+              0.4668391553452005
+            ],
+            "region-aef26dfb6618c53a": [
+              0.0,
+              0.26038439092581556,
+              0.25577043435082103,
+              0.3547586721534567
+            ],
+            "region-b1b18547044bf2b2": [
+              0.0,
+              0.3325662679344683,
+              0.3137073211841488,
+              0.4495028883817632
+            ],
+            "region-b1f23e8298861fac": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-b9f3533b686212dc": [
+              1.1102230246251565e-16,
+              0.7301618178846945,
+              0.5817231336287993,
+              0.8693274103588116
+            ],
+            "region-bd146f6ba302b81f": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-c2b660ba23cc8a19": [
+              0.0,
+              0.31910011452073794,
+              0.3782857692678646,
+              0.46998477188370547
+            ],
+            "region-c80feb5962123fc4": [
+              0.0,
+              0.38605574239470997,
+              0.35262846411394766,
+              0.5176819922678024
+            ],
+            "region-c9d993ae81c06c0a": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-cbe4d84301090909": [
+              0.0,
+              0.3783256954201216,
+              0.44327288760302064,
+              0.5765304212554194
+            ],
+            "region-ccea8d4132c59d01": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-cf8beea42b3c0378": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-d17929cbcf9433a8": [
+              0.0,
+              0.3559108722385841,
+              0.4497733955066613,
+              0.5530427935413811
+            ],
+            "region-d1d739ac3ec3a8b3": [
+              1.1102230246251565e-16,
+              0.4484895931558631,
+              0.492822693701366,
+              0.6608560426472152
+            ],
+            "region-d211ec2991b1c13f": [
+              0.0,
+              0.43042538009061115,
+              0.37459546881344996,
+              0.5501350394683866
+            ],
+            "region-d679892c931f172a": [
+              0.0,
+              0.5518940197149917,
+              0.541833231951182,
+              0.7420729669742313
+            ],
+            "region-d6e363ff258f9ec2": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-da41a3333637a966": [
+              0.0,
+              0.48220236624266055,
+              0.5055033807174936,
+              0.6444658590158265
+            ],
+            "region-e0842ceffa0bd980": [
+              0.0,
+              0.37221319782893525,
+              0.4033345637291562,
+              0.5474921650604903
+            ],
+            "region-e1c3c4342bd5d3d1": [
+              1.1102230246251565e-16,
+              0.27313239339530104,
+              0.4502999908732178,
+              0.46036535914656196
+            ],
+            "region-e2fe0a2e10c31be8": [
+              0.0,
+              0.4589591454706594,
+              0.5389577928318072,
+              0.662917578636691
+            ],
+            "region-e53b2ad152ea96ba": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-e671090c984c4d48": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-e9acf2bccd9a2c1c": [
+              1.1102230246251565e-16,
+              0.08944583116195537,
+              0.1456274190248874,
+              0.17324028524068336
+            ],
+            "region-e9cb35742ba103fd": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-ef2a9b7ecd21e20b": [
+              0.0,
+              0.28334997890778435,
+              0.3599339556586789,
+              0.4721804017167974
+            ],
+            "region-ef5d4128aaef8db8": [
+              0.0,
+              0.4463349088915102,
+              0.43702129545709645,
+              0.6037878387189319
+            ],
+            "region-f6e8d6553f47012c": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-f92799b23578fc95": [
+              0.0,
+              0.2579474400560253,
+              0.32945586246908953,
+              0.4119042457819727
+            ],
+            "region-faa705ad2c7f67ef": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "region-fce193731815ab04": [
+              0.0,
+              0.31488906493389535,
+              0.37384125786437306,
+              0.4838334058254873
+            ],
+            "region-fe09b61e69fced58": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "region_ids": [
+            "region-06cbe461e6f0467c",
+            "region-08be163f800acd50",
+            "region-0f3249f27acd2840",
+            "region-1227867453155a8b",
+            "region-13ecf2f21fa45eee",
+            "region-178d27f954e59a7b",
+            "region-19b4c4987a15a921",
+            "region-1a23bf3e6926f95c",
+            "region-1a4616843c0072be",
+            "region-1a8876b022acc74a",
+            "region-1bb0951829949fa6",
+            "region-1c02109b5afd46f7",
+            "region-1d9226b552f4c309",
+            "region-206b8221ab5f1954",
+            "region-252613a1969b52e8",
+            "region-26d0c18430f479c0",
+            "region-27cee13372e180a9",
+            "region-280eaeda1f1ae254",
+            "region-287408890512ab27",
+            "region-2af7128b6dc9b6ee",
+            "region-2e60e921281a980c",
+            "region-2f6db07db58b9746",
+            "region-2fa0a59be2e5173b",
+            "region-308a2781d47dc6fe",
+            "region-34284539e853ccd4",
+            "region-3e39e301a479c2d5",
+            "region-3ee85eea828f9249",
+            "region-42c5dce1ac3770dd",
+            "region-4515c8beb7f178fd",
+            "region-45807597965af5ef",
+            "region-47808bc508c65b47",
+            "region-48341f264dff6376",
+            "region-4cf37838eb489983",
+            "region-4f4778f481fa936a",
+            "region-5092f5444df8fdee",
+            "region-521b0f9e43508610",
+            "region-54f28f601d1c07f8",
+            "region-562dec06db3a23db",
+            "region-5b8c12faf5c50fc0",
+            "region-5ced71eb2f3237d8",
+            "region-61680173f0654a6d",
+            "region-6331ac066d0dbabf",
+            "region-6628c6914591b544",
+            "region-6aefee0f931b20a3",
+            "region-7797ff292bd03164",
+            "region-79a63ea0f7ecf993",
+            "region-7bccecc94755aa4f",
+            "region-7f92e78512d97141",
+            "region-7fde5d3605d4ec12",
+            "region-854da7a52918c424",
+            "region-86f5045a4a075548",
+            "region-8ba5a4c8ef27a1f1",
+            "region-8dd60d3ac9ebcbab",
+            "region-8fec67effdce745d",
+            "region-92f15ee48e0a6e34",
+            "region-95186e40451b6314",
+            "region-95b9f629605dc537",
+            "region-98002a2f764878dd",
+            "region-a15995c7d33b7162",
+            "region-a3c2f354262a89eb",
+            "region-a4b5d22cf21d2941",
+            "region-a595c2597f28920b",
+            "region-a9201dada3b15e53",
+            "region-a9ea0d0ce63f5d9c",
+            "region-ae723bb688d8a9ed",
+            "region-aef26dfb6618c53a",
+            "region-b1b18547044bf2b2",
+            "region-b1f23e8298861fac",
+            "region-b9f3533b686212dc",
+            "region-bd146f6ba302b81f",
+            "region-c2b660ba23cc8a19",
+            "region-c80feb5962123fc4",
+            "region-c9d993ae81c06c0a",
+            "region-cbe4d84301090909",
+            "region-ccea8d4132c59d01",
+            "region-cf8beea42b3c0378",
+            "region-d17929cbcf9433a8",
+            "region-d1d739ac3ec3a8b3",
+            "region-d211ec2991b1c13f",
+            "region-d679892c931f172a",
+            "region-d6e363ff258f9ec2",
+            "region-da41a3333637a966",
+            "region-e0842ceffa0bd980",
+            "region-e1c3c4342bd5d3d1",
+            "region-e2fe0a2e10c31be8",
+            "region-e53b2ad152ea96ba",
+            "region-e671090c984c4d48",
+            "region-e9acf2bccd9a2c1c",
+            "region-e9cb35742ba103fd",
+            "region-ef2a9b7ecd21e20b",
+            "region-ef5d4128aaef8db8",
+            "region-f6e8d6553f47012c",
+            "region-f92799b23578fc95",
+            "region-faa705ad2c7f67ef",
+            "region-fce193731815ab04",
+            "region-fe09b61e69fced58"
+          ]
+        },
+        "gates": {
+          "all_registered_sizes_pass": true
+        },
+        "partition_assignment_record": {
+          "sha256": "bf4a8bccf440a048833bc626c93d40b1c5c55e2ba721ba0e769e7d0f92dfff70",
+          "size_bytes": 7173364
+        },
+        "registered_size_results": {
+          "160": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "28e0174bd4afea3ae1b2b09d68da3ba81762879e521458581a3e7432be7a7406",
+                "size_bytes": 4162
+              },
+              "counts_by_region_record": {
+                "sha256": "93ad64dfe828ac31ea798c2417b191d078cb8b6c98ca1625f9e6893f445cd75c",
+                "size_bytes": 2690
+              },
+              "quadratic_exposure": 573.8728703630068,
+              "used_region_count": 72
+            },
+            "capacities_by_region_record": {
+              "sha256": "468c4dcaf613c855d70a2d7ba67a84328efcd6117d697a6162834e0693d7e959",
+              "size_bytes": 2755
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 6412.125357758005,
+                "components": 160,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 160.0,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 6412.125357758004,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 6412.125357758004
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 6412.125357758005,
+                "components": 160,
+                "design_effect_upper_bound": 1.9768945871496881,
+                "effective_components_lower_bound": 80.93501850834143,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 6412.125357758004,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 6412.125357758004
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 6412.125357758005,
+                "components": 160,
+                "design_effect_upper_bound": 2.9537891742993763,
+                "effective_components_lower_bound": 54.16771155915391,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 6412.125357758004,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 6412.125357758004
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 6412.125357758005,
+                "components": 160,
+                "design_effect_upper_bound": 4.9075783485987525,
+                "effective_components_lower_bound": 32.60263792745853,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 6412.125357758004,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 6412.125357758004
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 6412.125357758005,
+                "components": 160,
+                "design_effect_upper_bound": 8.815156697197505,
+                "effective_components_lower_bound": 18.150556535298666,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 6412.125357758004,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 6412.125357758004
+              }
+            },
+            "components_per_corpus": 160,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 160,
+                "design_effect": 1.0,
+                "effective_components": 160.0,
+                "one_C_one": 160.0,
+                "quadratic_exposure": 573.8728703630068,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 160,
+                "design_effect": 1.0646676359942198,
+                "effective_components": 150.28164151020428,
+                "one_C_one": 170.34682175907517,
+                "quadratic_exposure": 573.8728703630068,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 160,
+                "design_effect": 1.1293352719884395,
+                "effective_components": 141.6762621061904,
+                "one_C_one": 180.69364351815034,
+                "quadratic_exposure": 573.8728703630068,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 160,
+                "design_effect": 1.2586705439768793,
+                "effective_components": 127.11825248127764,
+                "one_C_one": 201.38728703630068,
+                "quadratic_exposure": 573.8728703630068,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 160,
+                "design_effect": 1.5173410879537585,
+                "effective_components": 105.44761574720901,
+                "one_C_one": 242.77457407260135,
+                "quadratic_exposure": 573.8728703630068,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 1050
+          },
+          "320": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "1bd598d3bd8243f68dd14ad2d0c19d209c01132c6c233a680bbf4c0765c669f5",
+                "size_bytes": 8322
+              },
+              "counts_by_region_record": {
+                "sha256": "ecfce8488d3e16e93226654d064a3c1608e1603ddaa2ed71f9cb633c22c48200",
+                "size_bytes": 2690
+              },
+              "quadratic_exposure": 2358.2077922067638,
+              "used_region_count": 72
+            },
+            "capacities_by_region_record": {
+              "sha256": "417350a314cac8b7ff2a4470cdc30233e196a7179a42aa6ac382168da1ae90a7",
+              "size_bytes": 2755
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 25648.50143103202,
+                "components": 320,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 320.0,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 25648.501431032015,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 25648.501431032015
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 25648.50143103202,
+                "components": 320,
+                "design_effect_upper_bound": 2.9787891742993766,
+                "effective_components_lower_bound": 107.42619946417166,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 25648.501431032015,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 25648.501431032015
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 25648.50143103202,
+                "components": 320,
+                "design_effect_upper_bound": 4.957578348598753,
+                "effective_components_lower_bound": 64.54764352649055,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 25648.501431032015,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 25648.501431032015
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 25648.50143103202,
+                "components": 320,
+                "design_effect_upper_bound": 8.915156697197506,
+                "effective_components_lower_bound": 35.89392883027985,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 25648.501431032015,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 25648.501431032015
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 25648.50143103202,
+                "components": 320,
+                "design_effect_upper_bound": 16.830313394395013,
+                "effective_components_lower_bound": 19.01331202225678,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 25648.501431032015,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 25648.501431032015
+              }
+            },
+            "components_per_corpus": 320,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 320,
+                "design_effect": 1.0,
+                "effective_components": 320.0,
+                "one_C_one": 320.0,
+                "quadratic_exposure": 2358.2077922067638,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 320,
+                "design_effect": 1.1592349837661533,
+                "effective_components": 276.0441191658791,
+                "one_C_one": 370.95519480516907,
+                "quadratic_exposure": 2358.2077922067638,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 320,
+                "design_effect": 1.3184699675323068,
+                "effective_components": 242.70556620938652,
+                "one_C_one": 421.9103896103382,
+                "quadratic_exposure": 2358.2077922067638,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 320,
+                "design_effect": 1.6369399350646137,
+                "effective_components": 195.48670855010258,
+                "one_C_one": 523.8207792206764,
+                "quadratic_exposure": 2358.2077922067638,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 320,
+                "design_effect": 2.2738798701292273,
+                "effective_components": 140.7286304802962,
+                "one_C_one": 727.6415584413528,
+                "quadratic_exposure": 2358.2077922067638,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 2077
+          },
+          "512": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "067087518b958a530b94a6ea5d35f36704180f3258bf6c15f3a0e39f06acf9f2",
+                "size_bytes": 13314
+              },
+              "counts_by_region_record": {
+                "sha256": "97841c9e6c8bbd680e22be940a7eb062cdbdfd2cdd8a5f7800767b0a68aab0e9",
+                "size_bytes": 2702
+              },
+              "quadratic_exposure": 6140.580886146135,
+              "used_region_count": 72
+            },
+            "capacities_by_region_record": {
+              "sha256": "99c3857b39a27728fb12f184ae4afeb1bcf2693e615f82cca18dbef2ad0f2669",
+              "size_bytes": 2755
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 61439.28503340406,
+                "components": 512,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 512.0,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 61439.28503340406,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 65158.21447527996
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 61439.28503340406,
+                "components": 512,
+                "design_effect_upper_bound": 3.974965089521683,
+                "effective_components_lower_bound": 128.80616268798732,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 61439.28503340406,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 65158.21447527996
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 61439.28503340406,
+                "components": 512,
+                "design_effect_upper_bound": 6.949930179043366,
+                "effective_components_lower_bound": 73.66980484838123,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 61439.28503340406,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 65158.21447527996
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 61439.28503340406,
+                "components": 512,
+                "design_effect_upper_bound": 12.899860358086732,
+                "effective_components_lower_bound": 39.69035212687669,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 61439.28503340406,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 65158.21447527996
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 61439.28503340406,
+                "components": 512,
+                "design_effect_upper_bound": 24.799720716173464,
+                "effective_components_lower_bound": 20.64539378728134,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 61439.28503340406,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 65158.21447527996
+              }
+            },
+            "components_per_corpus": 512,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 512,
+                "design_effect": 1.0,
+                "effective_components": 512.0,
+                "one_C_one": 512.0,
+                "quadratic_exposure": 6140.580886146135,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 512,
+                "design_effect": 1.2748330510813541,
+                "effective_components": 401.62121586485796,
+                "one_C_one": 652.7145221536533,
+                "quadratic_exposure": 6140.580886146135,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 512,
+                "design_effect": 1.5496661021627083,
+                "effective_components": 330.39375339336306,
+                "one_C_one": 793.4290443073066,
+                "quadratic_exposure": 6140.580886146135,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 512,
+                "design_effect": 2.099332204325417,
+                "effective_components": 243.88707939843283,
+                "one_C_one": 1074.8580886146135,
+                "quadratic_exposure": 6140.580886146135,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 512,
+                "design_effect": 3.198664408650834,
+                "effective_components": 160.06680745103756,
+                "one_C_one": 1637.716177229227,
+                "quadratic_exposure": 6140.580886146135,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 3283
+          },
+          "800": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "450b4eed1693313bf316b7f8e563ad6f75da4777f518f925e9f7f0136bfeb35f",
+                "size_bytes": 20802
+              },
+              "counts_by_region_record": {
+                "sha256": "c51a3148d6bceb0eb2ccc68c9cdd61e75b9e083d599c4fd68574a302d717a99d",
+                "size_bytes": 2742
+              },
+              "quadratic_exposure": 15168.437795775808,
+              "used_region_count": 72
+            },
+            "capacities_by_region_record": {
+              "sha256": "9a08c6f2eb3c7c26a9ada66a907252762cc3d9e9b1c516c888fa947428380b5d",
+              "size_bytes": 2755
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 147974.78358636962,
+                "components": 800,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 800.0,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 147974.78358636962,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 160303.1339439501
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 147974.78358636962,
+                "components": 800,
+                "design_effect_upper_bound": 5.599211987074051,
+                "effective_components_lower_bound": 142.877248056838,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 147974.78358636962,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 160303.1339439501
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 147974.78358636962,
+                "components": 800,
+                "design_effect_upper_bound": 10.198423974148103,
+                "effective_components_lower_bound": 78.44349303656263,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 147974.78358636962,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 160303.1339439501
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 147974.78358636962,
+                "components": 800,
+                "design_effect_upper_bound": 19.396847948296205,
+                "effective_components_lower_bound": 41.2438145688651,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 147974.78358636962,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 160303.1339439501
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 147974.78358636962,
+                "components": 800,
+                "design_effect_upper_bound": 37.79369589659241,
+                "effective_components_lower_bound": 21.167551387111903,
+                "lambda_max_upper": 2.5047364678742197,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 147974.78358636962,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 160303.1339439501
+              }
+            },
+            "components_per_corpus": 800,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 800,
+                "design_effect": 1.0,
+                "effective_components": 800.0,
+                "one_C_one": 800.0,
+                "quadratic_exposure": 15168.437795775808,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 800,
+                "design_effect": 1.449013681117994,
+                "effective_components": 552.0996871352904,
+                "one_C_one": 1159.2109448943952,
+                "quadratic_exposure": 15168.437795775808,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 800,
+                "design_effect": 1.898027362235988,
+                "effective_components": 421.4902355556945,
+                "one_C_one": 1518.4218897887904,
+                "quadratic_exposure": 15168.437795775808,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 800,
+                "design_effect": 2.796054724471976,
+                "effective_components": 286.1174328950507,
+                "one_C_one": 2236.843779577581,
+                "quadratic_exposure": 15168.437795775808,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 800,
+                "design_effect": 4.592109448943952,
+                "effective_components": 174.21187558671454,
+                "one_C_one": 3673.6875591551616,
+                "quadratic_exposure": 15168.437795775808,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 5037
+          }
+        },
+        "rho_grid": [
+          0.0,
+          0.025,
+          0.05,
+          0.1,
+          0.2
+        ],
+        "target_region_count": 96,
+        "walk_weights": [
+          1.0,
+          0.5,
+          0.25,
+          0.125
+        ]
+      }
+    },
+    "fresh": {
+      "128": {
+        "actual_region_count": 128,
+        "authorization": {
+          "attempted_input_inventory_authorized": false,
+          "candidate_selection_authorized": false,
+          "covariance_promotion_authorized": false,
+          "cuda_authorized": false,
+          "independent_batching_authorized": false,
+          "live_scoring_authorized": false,
+          "nomic_authorized": false,
+          "qr_specialization_authorized": false
+        },
+        "exposure": {
+          "effective_rank": 127.47669868123188,
+          "eigenvalues_descending": [
+            1.3704000926318394,
+            1.1574255102900997,
+            1.1494575940237228,
+            1.131858758714684,
+            1.12677607911993,
+            1.1108174937988622,
+            1.1065266900530255,
+            1.0805084959447049,
+            1.0759172813660756,
+            1.0666095433073355,
+            1.0619876226602487,
+            1.0557992571845187,
+            1.049358800047971,
+            1.04870586683811,
+            1.0455006468905141,
+            1.0430666054606688,
+            1.0399459579786972,
+            1.0392873653460595,
+            1.037849020654335,
+            1.034434422394972,
+            1.032511896712979,
+            1.032101084548467,
+            1.0300062604502993,
+            1.027479032619263,
+            1.0261672114018614,
+            1.025136028973727,
+            1.02157072471569,
+            1.0211486867320656,
+            1.0191704788729214,
+            1.0183679849362168,
+            1.0159776400648644,
+            1.0154331113714226,
+            1.0136351889818234,
+            1.0129320640909063,
+            1.012192801740492,
+            1.0097809933692925,
+            1.0090366002330609,
+            1.0081770978522364,
+            1.0078014690164003,
+            1.0067583179542008,
+            1.0059875308253101,
+            1.0055917397039928,
+            1.0051702712353634,
+            1.0049599610964788,
+            1.0043821062969434,
+            1.0034124284246893,
+            1.0028044036029287,
+            1.002429269352796,
+            1.0019757559147775,
+            1.00180461658537,
+            1.0013456731796746,
+            1.0009676276303483,
+            1.0008478744054674,
+            1.0003297214599103,
+            1.000089672725773,
+            0.9998957481960277,
+            0.9998659396008479,
+            0.9997542749123686,
+            0.9995259420646211,
+            0.9992949478040505,
+            0.9990920161599779,
+            0.998909347285401,
+            0.9982493165269056,
+            0.9980670569159305,
+            0.9975837353190949,
+            0.9974354302295043,
+            0.9973153538120857,
+            0.9968408830779452,
+            0.9966146477445421,
+            0.9964487537077905,
+            0.9952571011606298,
+            0.9946079639701544,
+            0.9942748066257148,
+            0.993614376868618,
+            0.9926651011269566,
+            0.9922877471070692,
+            0.9919896781763822,
+            0.9915125337462781,
+            0.9913215923272641,
+            0.9904639518563916,
+            0.9896318611204671,
+            0.9895380539678182,
+            0.9885123784784058,
+            0.9880074634799858,
+            0.9870483819626282,
+            0.9861741982813406,
+            0.9848772959858128,
+            0.9846144811684382,
+            0.9838822968438559,
+            0.9833670318236453,
+            0.982855126939156,
+            0.9816090220183701,
+            0.981183335257758,
+            0.9809076792949921,
+            0.9797198278483165,
+            0.9783437592746972,
+            0.9781883717411272,
+            0.9763882921314924,
+            0.9759968184417626,
+            0.9750138868776045,
+            0.9744668024938312,
+            0.9738042004385662,
+            0.9724478863508238,
+            0.9710160251249503,
+            0.9696124577972077,
+            0.9681430577619866,
+            0.9665935316538722,
+            0.9664150648629326,
+            0.9657436994940637,
+            0.9626663981201528,
+            0.9596337409452075,
+            0.9583550441526446,
+            0.955588514596099,
+            0.9544951109560554,
+            0.9531968500658778,
+            0.9528903204099252,
+            0.9468065607986432,
+            0.9460856559673528,
+            0.9424613141867758,
+            0.9386505308500471,
+            0.937980711576112,
+            0.9347482718463942,
+            0.9302454547577941,
+            0.9290541728568169,
+            0.9068874686568976,
+            0.8681556539527101,
+            0.8597493728653217,
+            0.6356418854163307
+          ],
+          "matrix_record": {
+            "sha256": "cd938b127b4c5d8a978ca8daecc9b9a230600f973e2751003f7b37a715465bad",
+            "size_bytes": 282396
+          },
+          "matrix_shape": [
+            128,
+            128
+          ],
+          "mean_outside_landing_mass_by_hop": [
+            5.204170427930421e-18,
+            0.06731529819125315,
+            0.10078102640540208,
+            0.1343841867360402
+          ],
+          "numerical_rank": 128,
+          "off_diagonal_quantiles": {
+            "0.0": 0.0,
+            "0.25": 0.0,
+            "0.5": 1.3207801090633376e-07,
+            "0.75": 6.650352236901875e-05,
+            "0.9": 0.0019083077400082462,
+            "0.95": 0.004624027068701944,
+            "1.0": 0.3635572427249257
+          },
+          "per_region_outside_landing_mass_by_hop": {
+            "region-01bdd99ddb003fe4": [
+              0.0,
+              0.11785761733948263,
+              0.12206453847640664,
+              0.1924563614866781
+            ],
+            "region-0224a70a39f39b09": [
+              0.0,
+              0.10260205744076711,
+              0.15347533736219732,
+              0.1962156776704168
+            ],
+            "region-056d9a8a1baa380a": [
+              0.0,
+              0.09303961017738871,
+              0.1552005422887729,
+              0.2064811939690958
+            ],
+            "region-06fb6f858c46f982": [
+              0.0,
+              0.05519162687809853,
+              0.0823365090207212,
+              0.10613379260731315
+            ],
+            "region-0d47d76255e2b7c2": [
+              0.0,
+              0.039616356104349215,
+              0.06988729851896747,
+              0.09254332771469709
+            ],
+            "region-0e6035dbc64b8405": [
+              0.0,
+              0.11651837263816434,
+              0.17734232850869036,
+              0.23148923596315696
+            ],
+            "region-0ea52f44cb823dee": [
+              0.0,
+              0.08740113441970465,
+              0.11572739877380256,
+              0.1524503203975487
+            ],
+            "region-134f4510a76f9076": [
+              0.0,
+              0.01710117009844514,
+              0.031351250910904405,
+              0.04104488952280494
+            ],
+            "region-167ebeb742e9a42e": [
+              0.0,
+              0.07748485901396274,
+              0.11559283814416865,
+              0.1499049050619018
+            ],
+            "region-1984c96bd95527a7": [
+              0.0,
+              0.048142053789535844,
+              0.0879010582773313,
+              0.11435822907463333
+            ],
+            "region-1b198355b3541f31": [
+              0.0,
+              0.006355932203389814,
+              0.004931797609014521,
+              0.008562829882709955
+            ],
+            "region-1eed320459293784": [
+              0.0,
+              0.04503613945578244,
+              0.04591058193041764,
+              0.07122352092873863
+            ],
+            "region-20d2dbd2dd6c03d1": [
+              0.0,
+              0.11854269082597257,
+              0.18481722685824353,
+              0.24709895230254197
+            ],
+            "region-22d89fdf0181c425": [
+              0.0,
+              0.04349051907531443,
+              0.09940941438648465,
+              0.11820325985383962
+            ],
+            "region-2b2129fdf36bc6cf": [
+              0.0,
+              0.07910481145775261,
+              0.13443870428666693,
+              0.17243382443436162
+            ],
+            "region-2d2ac315a74290e0": [
+              1.1102230246251565e-16,
+              0.09939703547989698,
+              0.13316648188100622,
+              0.1809653495270369
+            ],
+            "region-2ee48292bf559a79": [
+              0.0,
+              0.023027359171227113,
+              0.038161751873975636,
+              0.051413417566519626
+            ],
+            "region-311eb0eec8c62ab9": [
+              0.0,
+              0.08496582776781136,
+              0.1876168341234581,
+              0.19320157634858204
+            ],
+            "region-33c4c2679b00b209": [
+              0.0,
+              0.02922319888783298,
+              0.049533434430309664,
+              0.06822257160915857
+            ],
+            "region-342ab888567da343": [
+              0.0,
+              0.030672955065502383,
+              0.048761587630903436,
+              0.06670728827071382
+            ],
+            "region-3512b6dbe07df9ab": [
+              0.0,
+              0.024198717948717863,
+              0.04842441239316231,
+              0.06481441862535609
+            ],
+            "region-35949b5578e4b944": [
+              0.0,
+              0.057141858600957884,
+              0.09824301891109821,
+              0.13064374771102027
+            ],
+            "region-35c54b63db1d7c19": [
+              0.0,
+              0.003785505430242142,
+              0.009106563499968856,
+              0.01181961626879624
+            ],
+            "region-378eb2b053e5951a": [
+              0.0,
+              0.11966165460263756,
+              0.18509946334792504,
+              0.23695733040889666
+            ],
+            "region-3bd6d75d48fdcf78": [
+              0.0,
+              0.004340764434661137,
+              0.007314151191908702,
+              0.010232320616361923
+            ],
+            "region-3cb77505a1122c3b": [
+              0.0,
+              0.039059990080374196,
+              0.046156729498610605,
+              0.06812952751917623
+            ],
+            "region-3d32519b6237befa": [
+              0.0,
+              0.02753821622173569,
+              0.04342243810322599,
+              0.06013065751557811
+            ],
+            "region-3e99a66134b7a284": [
+              0.0,
+              0.014568266491343351,
+              0.02564782288564671,
+              0.034694627940652145
+            ],
+            "region-3fc107fd29b150e9": [
+              0.0,
+              0.012627073301230696,
+              0.030213175716621077,
+              0.03212707777050028
+            ],
+            "region-4138ddb59a681e34": [
+              0.0,
+              0.015280027092171355,
+              0.029551531618487448,
+              0.03563712609966363
+            ],
+            "region-42a985c6526b2a22": [
+              0.0,
+              0.08194979140101077,
+              0.11639180603487365,
+              0.16554138538498497
+            ],
+            "region-43fe1a603777dbec": [
+              0.0,
+              0.06850595589901076,
+              0.09878692587640625,
+              0.13359164546935365
+            ],
+            "region-463380084caa4de8": [
+              0.0,
+              0.15003901025591015,
+              0.21990154124991723,
+              0.28595528191142705
+            ],
+            "region-48bf15dcc81aa007": [
+              0.0,
+              0.08649463140825908,
+              0.11580899240965536,
+              0.15645089635639942
+            ],
+            "region-4a1edb82a4e4cbe3": [
+              0.0,
+              0.07531794701931116,
+              0.12188859905141136,
+              0.15648714033916555
+            ],
+            "region-4c7a28c9c365bd78": [
+              0.0,
+              0.07152051847835383,
+              0.11064812941936442,
+              0.14559895790691912
+            ],
+            "region-4cdfb7301cecd7a3": [
+              0.0,
+              0.05762098416401418,
+              0.0741681581837823,
+              0.0994895604353967
+            ],
+            "region-530a60b15c0c0895": [
+              0.0,
+              0.07583431852733324,
+              0.12061948871882999,
+              0.1583955676964286
+            ],
+            "region-5435c0c73ce20c99": [
+              0.0,
+              0.1287848521802144,
+              0.18317714032760157,
+              0.23696638478838528
+            ],
+            "region-59493b131b09eab0": [
+              0.0,
+              0.006135310578951336,
+              0.012462788775970401,
+              0.017037548994202623
+            ],
+            "region-5a5539a2acd91955": [
+              0.0,
+              0.049303956854535036,
+              0.07937882025379439,
+              0.10484506916163439
+            ],
+            "region-5c6fd4053e4e0d59": [
+              0.0,
+              0.06577713901534521,
+              0.11664998405476734,
+              0.14607275081776605
+            ],
+            "region-5fc148297297cb58": [
+              1.1102230246251565e-16,
+              0.09644268957011004,
+              0.1379544404117381,
+              0.17572213181499396
+            ],
+            "region-62c10a53a419e161": [
+              0.0,
+              0.08591172733788055,
+              0.1264768430548503,
+              0.16561922352075942
+            ],
+            "region-6917a86a3cbaf443": [
+              1.1102230246251565e-16,
+              0.059202063417095996,
+              0.09229724346773915,
+              0.11968034103853886
+            ],
+            "region-6a3a379a1f29ade5": [
+              0.0,
+              0.04617174884427977,
+              0.0698234861051551,
+              0.0983148210110949
+            ],
+            "region-6d0e3eb8fa211015": [
+              0.0,
+              0.09320665445736176,
+              0.15285142144721509,
+              0.19945192375311227
+            ],
+            "region-6e5c7473160410eb": [
+              0.0,
+              0.012682962272565601,
+              0.021122590210801095,
+              0.028037630175368422
+            ],
+            "region-70bd99c15aaa8088": [
+              0.0,
+              0.1161326408806248,
+              0.14639444556950465,
+              0.17800291025652548
+            ],
+            "region-70f637e694c54e54": [
+              0.0,
+              0.006025345468343879,
+              0.01116246488502004,
+              0.015192509214794536
+            ],
+            "region-71f8630670657c57": [
+              0.0,
+              0.11958192781005261,
+              0.16550965782907479,
+              0.21533259836337415
+            ],
+            "region-73e1c8f46765497e": [
+              0.0,
+              0.06129158215498365,
+              0.09234627841883081,
+              0.12879586273855648
+            ],
+            "region-74c7a69894da1f44": [
+              0.0,
+              0.09730663288907415,
+              0.15034656900059817,
+              0.1967428714994166
+            ],
+            "region-75f2d517bb815a57": [
+              0.0,
+              0.0566945581369902,
+              0.0979956391062563,
+              0.129531767562152
+            ],
+            "region-77ce1a88360ecb2d": [
+              0.0,
+              0.04501623376623376,
+              0.06881582046983448,
+              0.09400266978387362
+            ],
+            "region-7cb268209d1d7132": [
+              0.0,
+              0.06820088604253449,
+              0.11226456487726866,
+              0.1486087608044876
+            ],
+            "region-7e8661da9c9a1115": [
+              0.0,
+              0.1367796571387201,
+              0.1936713191520718,
+              0.25874462383885644
+            ],
+            "region-7f32a8f3ab890c5f": [
+              0.0,
+              0.0406394056394056,
+              0.07126343090052767,
+              0.09975865228845027
+            ],
+            "region-8329f750bff9e682": [
+              0.0,
+              0.11188373294284626,
+              0.16935555996685758,
+              0.22147790008867374
+            ],
+            "region-84081d0ad8b07a06": [
+              0.0,
+              0.029422240887209128,
+              0.053526607202345144,
+              0.07327886441423248
+            ],
+            "region-844fd636419977fb": [
+              0.0,
+              0.11421475123333757,
+              0.17142885834042876,
+              0.2271164091462663
+            ],
+            "region-8466b03d3c675eb7": [
+              0.0,
+              0.21292965868782499,
+              0.1429410824332683,
+              0.29637012513667993
+            ],
+            "region-84f2822feb1628d3": [
+              0.0,
+              0.05920165164177138,
+              0.09277080800363302,
+              0.12409400508620338
+            ],
+            "region-851ca6ef15a6ae42": [
+              0.0,
+              0.12671263738833616,
+              0.17556846824407835,
+              0.2416522197877159
+            ],
+            "region-856bfb161c195353": [
+              0.0,
+              0.009950454985097057,
+              0.017591859056852344,
+              0.02355844232630866
+            ],
+            "region-88d10afb94ca0acb": [
+              0.0,
+              0.10412660256410255,
+              0.16120336030163118,
+              0.21475941322333558
+            ],
+            "region-8907601b093b3013": [
+              0.0,
+              0.03650943789188621,
+              0.0725362704333945,
+              0.08989993027625087
+            ],
+            "region-89abd9732ac281c1": [
+              0.0,
+              0.1187289357571828,
+              0.17868411476231894,
+              0.22440363969297306
+            ],
+            "region-8a9a47f3a19bd0d7": [
+              0.0,
+              0.07514986636120657,
+              0.15155587600175235,
+              0.1680736829713344
+            ],
+            "region-8b6b566e0b75541d": [
+              0.0,
+              0.13096992931005536,
+              0.19394144187921158,
+              0.25122734006438996
+            ],
+            "region-905b7a48eb897611": [
+              0.0,
+              0.09890657104721623,
+              0.16063739298649482,
+              0.20644381585085259
+            ],
+            "region-9101a37369a562f4": [
+              0.0,
+              0.015054838932192838,
+              0.023026961019389947,
+              0.032192274108191477
+            ],
+            "region-91253bd97d799300": [
+              0.0,
+              0.3378386988321539,
+              0.3027693198499303,
+              0.4904895677082436
+            ],
+            "region-93a2aa911165987a": [
+              0.0,
+              0.05988098965961319,
+              0.0872354494245805,
+              0.11809061714114943
+            ],
+            "region-9412c3bf1ae474dc": [
+              0.0,
+              0.06753056302216776,
+              0.11567201698634966,
+              0.15294387837954326
+            ],
+            "region-9473967c51fe2b29": [
+              0.0,
+              0.05513721683213213,
+              0.09910827611227824,
+              0.1308530959638322
+            ],
+            "region-954ba8ac130a5686": [
+              0.0,
+              0.11430676149091745,
+              0.17417903535923296,
+              0.2329552743149822
+            ],
+            "region-969e92f8c4424004": [
+              0.0,
+              0.032129454554347237,
+              0.0506184738564075,
+              0.069407809264325
+            ],
+            "region-99828d583c7471f2": [
+              0.0,
+              0.10743514764707673,
+              0.15618194419880804,
+              0.20222115720590517
+            ],
+            "region-9f9b52a7f5813c05": [
+              0.0,
+              0.12373294103389465,
+              0.16376242521193995,
+              0.2231200763276694
+            ],
+            "region-a2c7cd4df39b4956": [
+              0.0,
+              0.0265909388931187,
+              0.053584694811905864,
+              0.07300752789366594
+            ],
+            "region-a62536f5c05545a3": [
+              0.0,
+              0.05561479317646301,
+              0.0870876344489,
+              0.11434010694876007
+            ],
+            "region-a6bddff27fa7ac09": [
+              0.0,
+              0.08522144980626667,
+              0.1479930294275379,
+              0.19772251272171426
+            ],
+            "region-ab9da87dce28044b": [
+              0.0,
+              2.9820480706210795e-05,
+              0.0008071410111131216,
+              0.0009077272807119785
+            ],
+            "region-ae1793c2443dc82e": [
+              1.1102230246251565e-16,
+              0.06068840579710144,
+              0.04682635283850067,
+              0.09649450658486947
+            ],
+            "region-aeb4ab59d0e94156": [
+              0.0,
+              0.0009048935703312999,
+              0.003465181771633352,
+              0.003516847357379338
+            ],
+            "region-b72dc2e802fc7434": [
+              0.0,
+              0.05278975123237417,
+              0.08734906509643592,
+              0.11507956508672534
+            ],
+            "region-bba0ef67bd4c1c8a": [
+              0.0,
+              0.05081402937799506,
+              0.11585741945455508,
+              0.15614109180735503
+            ],
+            "region-bf51d8d9b5dd0f5b": [
+              0.0,
+              0.05722105900697261,
+              0.08474569300803081,
+              0.1168848344778296
+            ],
+            "region-c31690131a965f78": [
+              0.0,
+              0.07692202344470844,
+              0.11238372414357245,
+              0.14709488790180836
+            ],
+            "region-c4503087899d2fc0": [
+              0.0,
+              0.059948687711488646,
+              0.09875057060980563,
+              0.12816609023169367
+            ],
+            "region-c4c2d7d3ef282fb4": [
+              0.0,
+              0.05254613964534827,
+              0.0801002043934349,
+              0.10765756696215822
+            ],
+            "region-c5082114766a3652": [
+              0.0,
+              0.06882329875079574,
+              0.11031731801377287,
+              0.14593366209188197
+            ],
+            "region-c8517668fb95c401": [
+              1.1102230246251565e-16,
+              0.09717863824436579,
+              0.15136604300030798,
+              0.19656570628962455
+            ],
+            "region-c9377a0e7ced839f": [
+              0.0,
+              0.02453517622404955,
+              0.0423655938441343,
+              0.058442531708086
+            ],
+            "region-c97663eb2d131e49": [
+              0.0,
+              0.07283579294497544,
+              0.10471240705396723,
+              0.1413891977826317
+            ],
+            "region-ca1c3fdd25966754": [
+              0.0,
+              0.09181248493823146,
+              0.13225843596342635,
+              0.1792021340586918
+            ],
+            "region-cc387a64a545b8c2": [
+              0.0,
+              0.06530359504200745,
+              0.1073644519034872,
+              0.14190342678544876
+            ],
+            "region-ccf899610d491de2": [
+              0.0,
+              0.03244443126087637,
+              0.05260321962619097,
+              0.07020391051322195
+            ],
+            "region-ce1073da32c91d49": [
+              0.0,
+              0.04967539929724796,
+              0.08692902317107687,
+              0.11239618561208686
+            ],
+            "region-d17dd959970bc5bb": [
+              0.0,
+              0.10037889227368213,
+              0.16612268596233404,
+              0.21164826300287265
+            ],
+            "region-d1eef9589538930a": [
+              0.0,
+              0.12317816563128903,
+              0.1426926934789957,
+              0.21285234231703487
+            ],
+            "region-d2a045c36ae33841": [
+              0.0,
+              0.04259594202516581,
+              0.052792589407886226,
+              0.07335649514196585
+            ],
+            "region-d55d8f7df45202fa": [
+              0.0,
+              0.0841085840645518,
+              0.12614512563349467,
+              0.1699087986914355
+            ],
+            "region-d5b7596a5b676188": [
+              0.0,
+              0.03320107111622306,
+              0.053855507405384584,
+              0.07134417118767133
+            ],
+            "region-da151dee0ea0e9d2": [
+              0.0,
+              0.07731895585946824,
+              0.11274992545195173,
+              0.15567454706621886
+            ],
+            "region-da38b12a0e34f738": [
+              0.0,
+              0.07669840680601081,
+              0.1229449771655754,
+              0.16392790476286612
+            ],
+            "region-da462974fca23459": [
+              0.0,
+              0.0233999180266784,
+              0.03729173821724363,
+              0.05178499146131621
+            ],
+            "region-da549b6329dd8997": [
+              0.0,
+              0.05729553608128546,
+              0.07340248970847552,
+              0.09683048522819249
+            ],
+            "region-dbd2da92f6c0c42f": [
+              0.0,
+              0.04502767481034231,
+              0.09082290984645391,
+              0.10961426250824546
+            ],
+            "region-dd145b8d87ba461a": [
+              0.0,
+              0.13913882976766845,
+              0.19216098584567054,
+              0.2520768811771279
+            ],
+            "region-e07bfbb70d6dec55": [
+              0.0,
+              0.021650982030239074,
+              0.03253734886767223,
+              0.045347689668525315
+            ],
+            "region-e15740c6ac9e8784": [
+              0.0,
+              0.03871902826171125,
+              0.056494897702054625,
+              0.07635049392825177
+            ],
+            "region-e4a46dd910a1682a": [
+              0.0,
+              0.004178330741316794,
+              0.0049327742414834175,
+              0.008215388427021408
+            ],
+            "region-e51af2efc70ee54f": [
+              0.0,
+              0.04046210200056355,
+              0.07003673869537075,
+              0.09083510145594087
+            ],
+            "region-e5f1d4d1efc38b0c": [
+              0.0,
+              0.04238301381158516,
+              0.07839899449134213,
+              0.10143842950760806
+            ],
+            "region-e6c5514d93868e39": [
+              0.0,
+              0.13128881987577634,
+              0.24177880083978376,
+              0.2908672933169064
+            ],
+            "region-eac8b3fee5a599ba": [
+              0.0,
+              0.026423259303457125,
+              0.053049443899164106,
+              0.06443717706258068
+            ],
+            "region-ec0b78ea61ee07d6": [
+              0.0,
+              0.10723906857138088,
+              0.16535825501725054,
+              0.21652118441533197
+            ],
+            "region-ec4670a0842db77a": [
+              0.0,
+              0.06953977765812591,
+              0.11368112311443468,
+              0.14585305721192865
+            ],
+            "region-ef362683c72edcb5": [
+              0.0,
+              0.043986226663392025,
+              0.05730295323127177,
+              0.07791495307348184
+            ],
+            "region-f01f5deec701127e": [
+              0.0,
+              0.0839096666026744,
+              0.12317217840524874,
+              0.1678689876566194
+            ],
+            "region-f08361653e859662": [
+              0.0,
+              0.1244602803377638,
+              0.2130269945903921,
+              0.2737693930068571
+            ],
+            "region-f4af7864ec257087": [
+              0.0,
+              0.012969550369948846,
+              0.027137731688501865,
+              0.03520427836298734
+            ],
+            "region-f988ad81a8e7a3f9": [
+              0.0,
+              0.0503798591278527,
+              0.07849501499610034,
+              0.10378250119274601
+            ],
+            "region-fa12ff8fd3641cdd": [
+              1.1102230246251565e-16,
+              0.04147601100950571,
+              0.06901808064786585,
+              0.09175869093540034
+            ],
+            "region-fe3d2664f49ba765": [
+              0.0,
+              0.029871423621423587,
+              0.048708068393495174,
+              0.06481358358606404
+            ],
+            "region-ff7af4e7a35b4de5": [
+              0.0,
+              0.029880367380367368,
+              0.03371273600163727,
+              0.05523053668966893
+            ]
+          },
+          "region_ids": [
+            "region-01bdd99ddb003fe4",
+            "region-0224a70a39f39b09",
+            "region-056d9a8a1baa380a",
+            "region-06fb6f858c46f982",
+            "region-0d47d76255e2b7c2",
+            "region-0e6035dbc64b8405",
+            "region-0ea52f44cb823dee",
+            "region-134f4510a76f9076",
+            "region-167ebeb742e9a42e",
+            "region-1984c96bd95527a7",
+            "region-1b198355b3541f31",
+            "region-1eed320459293784",
+            "region-20d2dbd2dd6c03d1",
+            "region-22d89fdf0181c425",
+            "region-2b2129fdf36bc6cf",
+            "region-2d2ac315a74290e0",
+            "region-2ee48292bf559a79",
+            "region-311eb0eec8c62ab9",
+            "region-33c4c2679b00b209",
+            "region-342ab888567da343",
+            "region-3512b6dbe07df9ab",
+            "region-35949b5578e4b944",
+            "region-35c54b63db1d7c19",
+            "region-378eb2b053e5951a",
+            "region-3bd6d75d48fdcf78",
+            "region-3cb77505a1122c3b",
+            "region-3d32519b6237befa",
+            "region-3e99a66134b7a284",
+            "region-3fc107fd29b150e9",
+            "region-4138ddb59a681e34",
+            "region-42a985c6526b2a22",
+            "region-43fe1a603777dbec",
+            "region-463380084caa4de8",
+            "region-48bf15dcc81aa007",
+            "region-4a1edb82a4e4cbe3",
+            "region-4c7a28c9c365bd78",
+            "region-4cdfb7301cecd7a3",
+            "region-530a60b15c0c0895",
+            "region-5435c0c73ce20c99",
+            "region-59493b131b09eab0",
+            "region-5a5539a2acd91955",
+            "region-5c6fd4053e4e0d59",
+            "region-5fc148297297cb58",
+            "region-62c10a53a419e161",
+            "region-6917a86a3cbaf443",
+            "region-6a3a379a1f29ade5",
+            "region-6d0e3eb8fa211015",
+            "region-6e5c7473160410eb",
+            "region-70bd99c15aaa8088",
+            "region-70f637e694c54e54",
+            "region-71f8630670657c57",
+            "region-73e1c8f46765497e",
+            "region-74c7a69894da1f44",
+            "region-75f2d517bb815a57",
+            "region-77ce1a88360ecb2d",
+            "region-7cb268209d1d7132",
+            "region-7e8661da9c9a1115",
+            "region-7f32a8f3ab890c5f",
+            "region-8329f750bff9e682",
+            "region-84081d0ad8b07a06",
+            "region-844fd636419977fb",
+            "region-8466b03d3c675eb7",
+            "region-84f2822feb1628d3",
+            "region-851ca6ef15a6ae42",
+            "region-856bfb161c195353",
+            "region-88d10afb94ca0acb",
+            "region-8907601b093b3013",
+            "region-89abd9732ac281c1",
+            "region-8a9a47f3a19bd0d7",
+            "region-8b6b566e0b75541d",
+            "region-905b7a48eb897611",
+            "region-9101a37369a562f4",
+            "region-91253bd97d799300",
+            "region-93a2aa911165987a",
+            "region-9412c3bf1ae474dc",
+            "region-9473967c51fe2b29",
+            "region-954ba8ac130a5686",
+            "region-969e92f8c4424004",
+            "region-99828d583c7471f2",
+            "region-9f9b52a7f5813c05",
+            "region-a2c7cd4df39b4956",
+            "region-a62536f5c05545a3",
+            "region-a6bddff27fa7ac09",
+            "region-ab9da87dce28044b",
+            "region-ae1793c2443dc82e",
+            "region-aeb4ab59d0e94156",
+            "region-b72dc2e802fc7434",
+            "region-bba0ef67bd4c1c8a",
+            "region-bf51d8d9b5dd0f5b",
+            "region-c31690131a965f78",
+            "region-c4503087899d2fc0",
+            "region-c4c2d7d3ef282fb4",
+            "region-c5082114766a3652",
+            "region-c8517668fb95c401",
+            "region-c9377a0e7ced839f",
+            "region-c97663eb2d131e49",
+            "region-ca1c3fdd25966754",
+            "region-cc387a64a545b8c2",
+            "region-ccf899610d491de2",
+            "region-ce1073da32c91d49",
+            "region-d17dd959970bc5bb",
+            "region-d1eef9589538930a",
+            "region-d2a045c36ae33841",
+            "region-d55d8f7df45202fa",
+            "region-d5b7596a5b676188",
+            "region-da151dee0ea0e9d2",
+            "region-da38b12a0e34f738",
+            "region-da462974fca23459",
+            "region-da549b6329dd8997",
+            "region-dbd2da92f6c0c42f",
+            "region-dd145b8d87ba461a",
+            "region-e07bfbb70d6dec55",
+            "region-e15740c6ac9e8784",
+            "region-e4a46dd910a1682a",
+            "region-e51af2efc70ee54f",
+            "region-e5f1d4d1efc38b0c",
+            "region-e6c5514d93868e39",
+            "region-eac8b3fee5a599ba",
+            "region-ec0b78ea61ee07d6",
+            "region-ec4670a0842db77a",
+            "region-ef362683c72edcb5",
+            "region-f01f5deec701127e",
+            "region-f08361653e859662",
+            "region-f4af7864ec257087",
+            "region-f988ad81a8e7a3f9",
+            "region-fa12ff8fd3641cdd",
+            "region-fe3d2664f49ba765",
+            "region-ff7af4e7a35b4de5"
+          ]
+        },
+        "gates": {
+          "all_registered_sizes_pass": true
+        },
+        "partition_assignment_record": {
+          "sha256": "0f7f4705ca2a14ef5575c11028630b446af3abc32cf71c7c9d3922f5bc7e2253",
+          "size_bytes": 7101948
+        },
+        "registered_size_results": {
+          "160": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "fb8b2812c341ac7fd34219282aad3c777b1422d54510d43d647659224e4ce23e",
+                "size_bytes": 4162
+              },
+              "counts_by_region_record": {
+                "sha256": "147b109e20e129ac208edf24eda36ed405b63535d0980fa22323281a9d50ccd5",
+                "size_bytes": 3586
+              },
+              "quadratic_exposure": 240.95834922255676,
+              "used_region_count": 128
+            },
+            "capacities_by_region_record": {
+              "sha256": "00e735620890f9e9a667e738efe6b7d3cc01b25f68322aa711a37a8490398fc8",
+              "size_bytes": 3714
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 3783.084321697585,
+                "components": 160,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 160.0,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3783.0843216975845,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 3783.0843216975845
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 3783.084321697585,
+                "components": 160,
+                "design_effect_upper_bound": 1.5661069252652475,
+                "effective_components_lower_bound": 102.16416096423377,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3783.0843216975845,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 3783.0843216975845
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 3783.084321697585,
+                "components": 160,
+                "design_effect_upper_bound": 2.132213850530495,
+                "effective_components_lower_bound": 75.03937748091823,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3783.0843216975845,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 3783.0843216975845
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 3783.084321697585,
+                "components": 160,
+                "design_effect_upper_bound": 3.2644277010609906,
+                "effective_components_lower_bound": 49.01318535803304,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3783.0843216975845,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 3783.0843216975845
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 3783.084321697585,
+                "components": 160,
+                "design_effect_upper_bound": 5.528855402121981,
+                "effective_components_lower_bound": 28.93908202746482,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3783.0843216975845,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 3783.0843216975845
+              }
+            },
+            "components_per_corpus": 160,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 160,
+                "design_effect": 1.0,
+                "effective_components": 160.0,
+                "one_C_one": 160.0,
+                "quadratic_exposure": 240.95834922255676,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 160,
+                "design_effect": 1.0126497420660245,
+                "effective_components": 158.0013240052433,
+                "one_C_one": 162.02395873056392,
+                "quadratic_exposure": 240.95834922255676,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 160,
+                "design_effect": 1.025299484132049,
+                "effective_components": 156.05196576827058,
+                "one_C_one": 164.04791746112784,
+                "quadratic_exposure": 240.95834922255676,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 160,
+                "design_effect": 1.050598968264098,
+                "effective_components": 152.29407683920306,
+                "one_C_one": 168.09583492225568,
+                "quadratic_exposure": 240.95834922255676,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 160,
+                "design_effect": 1.1011979365281959,
+                "effective_components": 145.29631294482837,
+                "one_C_one": 176.19166984451135,
+                "quadratic_exposure": 240.95834922255676,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 2048
+          },
+          "320": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "525a0b5b5cabadfd26ea30e0e368ea6e583af106d7902e7311bae9399b0e99ce",
+                "size_bytes": 8322
+              },
+              "counts_by_region_record": {
+                "sha256": "41e1dcb8d705b1d06727ead2ae22a6c8ab67e6f41fe0917595abf0407b94ecf8",
+                "size_bytes": 3586
+              },
+              "quadratic_exposure": 906.2846717838827,
+              "used_region_count": 128
+            },
+            "capacities_by_region_record": {
+              "sha256": "2b2ccf2473510438b6f56de9b85e248f54333dbecf8097b2616bc2255963746c",
+              "size_bytes": 3714
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 15124.428323529695,
+                "components": 320,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 320.0,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 15124.428323529695,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 15132.337286790338
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 15124.428323529695,
+                "components": 320,
+                "design_effect_upper_bound": 2.1565959627757576,
+                "effective_components_lower_bound": 148.38198972983682,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 15124.428323529695,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 15132.337286790338
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 15124.428323529695,
+                "components": 320,
+                "design_effect_upper_bound": 3.313191925551515,
+                "effective_components_lower_bound": 96.58359889511462,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 15124.428323529695,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 15132.337286790338
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 15124.428323529695,
+                "components": 320,
+                "design_effect_upper_bound": 5.62638385110303,
+                "effective_components_lower_bound": 56.87489664205283,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 15124.428323529695,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 15132.337286790338
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 15124.428323529695,
+                "components": 320,
+                "design_effect_upper_bound": 10.25276770220606,
+                "effective_components_lower_bound": 31.211084586569388,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 15124.428323529695,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 15132.337286790338
+              }
+            },
+            "components_per_corpus": 320,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 320,
+                "design_effect": 1.0,
+                "effective_components": 320.0,
+                "one_C_one": 320.0,
+                "quadratic_exposure": 906.2846717838827,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 320,
+                "design_effect": 1.045803489983116,
+                "effective_components": 305.9848270397016,
+                "one_C_one": 334.6571167945971,
+                "quadratic_exposure": 906.2846717838827,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 320,
+                "design_effect": 1.0916069799662318,
+                "effective_components": 293.14579869203385,
+                "one_C_one": 349.31423358919415,
+                "quadratic_exposure": 906.2846717838827,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 320,
+                "design_effect": 1.1832139599324634,
+                "effective_components": 270.44981789960053,
+                "one_C_one": 378.6284671783883,
+                "quadratic_exposure": 906.2846717838827,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 320,
+                "design_effect": 1.3664279198649267,
+                "effective_components": 234.1872522859694,
+                "one_C_one": 437.2569343567766,
+                "quadratic_exposure": 906.2846717838827,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 4068
+          },
+          "512": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "d20845ef2849bd3c61a49a71be9242d0cb88ab14a355cb92c815ca4dcbea2ba7",
+                "size_bytes": 13314
+              },
+              "counts_by_region_record": {
+                "sha256": "f43abd49584a7a9362d436170fed6948fe52b08d1e9620f7afe21a3ac89d6a69",
+                "size_bytes": 3586
+              },
+              "quadratic_exposure": 2280.5256426403403,
+              "used_region_count": 128
+            },
+            "capacities_by_region_record": {
+              "sha256": "813794913b3fca49ca0e14c7dc01f4174b9529a4c9ee97d8a5f9acea654379c1",
+              "size_bytes": 3714
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 38355.518249468245,
+                "components": 512,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 512.0,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 38355.518249468245,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 38442.63888462538
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 38355.518249468245,
+                "components": 512,
+                "design_effect_upper_bound": 2.8478280395248166,
+                "effective_components_lower_bound": 179.78613627437682,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 38355.518249468245,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 38442.63888462538
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 38355.518249468245,
+                "components": 512,
+                "design_effect_upper_bound": 4.695656079049633,
+                "effective_components_lower_bound": 109.03694635651959,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 38355.518249468245,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 38442.63888462538
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 38355.518249468245,
+                "components": 512,
+                "design_effect_upper_bound": 8.391312158099266,
+                "effective_components_lower_bound": 61.015487250801336,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 38355.518249468245,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 38442.63888462538
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 38355.518249468245,
+                "components": 512,
+                "design_effect_upper_bound": 15.782624316198534,
+                "effective_components_lower_bound": 32.44073924223791,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 38355.518249468245,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 38442.63888462538
+              }
+            },
+            "components_per_corpus": 512,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 512,
+                "design_effect": 1.0,
+                "effective_components": 512.0,
+                "one_C_one": 512.0,
+                "quadratic_exposure": 2280.5256426403403,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 512,
+                "design_effect": 1.0863537911445478,
+                "effective_components": 471.30134231922096,
+                "one_C_one": 556.2131410660085,
+                "quadratic_exposure": 2280.5256426403403,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 512,
+                "design_effect": 1.1727075822890958,
+                "effective_components": 436.59647787097003,
+                "one_C_one": 600.426282132017,
+                "quadratic_exposure": 2280.5256426403403,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 512,
+                "design_effect": 1.3454151645781915,
+                "effective_components": 380.5516791246514,
+                "one_C_one": 688.8525642640341,
+                "quadratic_exposure": 2280.5256426403403,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 512,
+                "design_effect": 1.690830329156383,
+                "effective_components": 302.80980366341987,
+                "one_C_one": 865.7051285280681,
+                "quadratic_exposure": 2280.5256426403403,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 6379
+          },
+          "800": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "8139f596ee81cdb21b027361983d007bca614f3b9d24ba17a1c3da83bd5cf232",
+                "size_bytes": 20802
+              },
+              "counts_by_region_record": {
+                "sha256": "5fc13d77ed80d01cdbac91114de2686f5ea7f9b62935fb08dd7d68fb46e87b27",
+                "size_bytes": 3586
+              },
+              "quadratic_exposure": 5559.225182875445,
+              "used_region_count": 128
+            },
+            "capacities_by_region_record": {
+              "sha256": "114756c976158805011c815bc727a91151847d178a49bcacc723421570033199",
+              "size_bytes": 3714
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 92975.42440670179,
+                "components": 800,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 800.0,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 92975.42440670179,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 94577.10804243962
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 92975.42440670179,
+                "components": 800,
+                "design_effect_upper_bound": 3.8804820127094306,
+                "effective_components_lower_bound": 206.15995574256607,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 92975.42440670179,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 94577.10804243962
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 92975.42440670179,
+                "components": 800,
+                "design_effect_upper_bound": 6.760964025418861,
+                "effective_components_lower_bound": 118.32632106786541,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 92975.42440670179,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 94577.10804243962
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 92975.42440670179,
+                "components": 800,
+                "design_effect_upper_bound": 12.521928050837722,
+                "effective_components_lower_bound": 63.887924986638104,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 92975.42440670179,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 94577.10804243962
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 92975.42440670179,
+                "components": 800,
+                "design_effect_upper_bound": 24.043856101675445,
+                "effective_components_lower_bound": 33.27253318340454,
+                "lambda_max_upper": 1.4777673131631188,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 92975.42440670179,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 94577.10804243962
+              }
+            },
+            "components_per_corpus": 800,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 800,
+                "design_effect": 1.0,
+                "effective_components": 800.0,
+                "one_C_one": 800.0,
+                "quadratic_exposure": 5559.225182875445,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 800,
+                "design_effect": 1.1487257869648575,
+                "effective_components": 696.4238193988363,
+                "one_C_one": 918.9806295718861,
+                "quadratic_exposure": 5559.225182875445,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 800,
+                "design_effect": 1.2974515739297152,
+                "effective_components": 616.5933404180657,
+                "one_C_one": 1037.9612591437722,
+                "quadratic_exposure": 5559.225182875445,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 800,
+                "design_effect": 1.5949031478594307,
+                "effective_components": 501.5978563172974,
+                "one_C_one": 1275.9225182875446,
+                "quadratic_exposure": 5559.225182875445,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 800,
+                "design_effect": 2.1898062957188613,
+                "effective_components": 365.32911681002315,
+                "one_C_one": 1751.8450365750891,
+                "quadratic_exposure": 5559.225182875445,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 9757
+          }
+        },
+        "rho_grid": [
+          0.0,
+          0.025,
+          0.05,
+          0.1,
+          0.2
+        ],
+        "target_region_count": 128,
+        "walk_weights": [
+          1.0,
+          0.5,
+          0.25,
+          0.125
+        ]
+      },
+      "64": {
+        "actual_region_count": 64,
+        "authorization": {
+          "attempted_input_inventory_authorized": false,
+          "candidate_selection_authorized": false,
+          "covariance_promotion_authorized": false,
+          "cuda_authorized": false,
+          "independent_batching_authorized": false,
+          "live_scoring_authorized": false,
+          "nomic_authorized": false,
+          "qr_specialization_authorized": false
+        },
+        "exposure": {
+          "effective_rank": 63.78740431140491,
+          "eigenvalues_descending": [
+            1.251147229576663,
+            1.1464318777166889,
+            1.1298771275538448,
+            1.0814608252058169,
+            1.0677968185060462,
+            1.05623146452105,
+            1.0386076223691387,
+            1.032197335686007,
+            1.0278577422038224,
+            1.0233331651066773,
+            1.021934052920101,
+            1.0198080701274599,
+            1.017681338075948,
+            1.0154776695721188,
+            1.0132502347971664,
+            1.0124315463767641,
+            1.0112983697093827,
+            1.0091991305113899,
+            1.0080696232730086,
+            1.0057088646552363,
+            1.0049272038396253,
+            1.0040303331589273,
+            1.0027827114954742,
+            1.0025426739923868,
+            1.0016893228365902,
+            1.0015786245619975,
+            1.0003015208000072,
+            0.999881967973071,
+            0.9989043768693939,
+            0.9986765388715484,
+            0.9982777499955365,
+            0.9968896415530889,
+            0.9957224908562281,
+            0.9952212967774128,
+            0.9944151816658597,
+            0.9931709358430768,
+            0.991864128164513,
+            0.9913178507481474,
+            0.9902562820660076,
+            0.9889343028881213,
+            0.9882531065311297,
+            0.9878729279203959,
+            0.9868997187244546,
+            0.9858140484166745,
+            0.9838520647270749,
+            0.983488853536618,
+            0.9819839853207155,
+            0.980473943356029,
+            0.9803181114793489,
+            0.978655822456817,
+            0.9744176932516766,
+            0.9740904095799194,
+            0.9733312937627234,
+            0.9710019062104247,
+            0.9694113047205627,
+            0.9686526377314881,
+            0.9624024713612512,
+            0.9601385624623071,
+            0.9581558707800154,
+            0.9568971515759581,
+            0.9533701963099622,
+            0.9521308229365003,
+            0.8950533979894414,
+            0.7521484554371605
+          ],
+          "matrix_record": {
+            "sha256": "5ee04f2dbd73f3174f91a2871b70647a823508a4f03f2daca863a410e37e2d9a",
+            "size_bytes": 80790
+          },
+          "matrix_shape": [
+            64,
+            64
+          ],
+          "mean_outside_landing_mass_by_hop": [
+            1.734723475976807e-17,
+            0.06535309446498772,
+            0.09553710424092432,
+            0.12840370615279906
+          ],
+          "numerical_rank": 64,
+          "off_diagonal_quantiles": {
+            "0.0": 0.0,
+            "0.25": 1.4634129975554608e-08,
+            "0.5": 1.3923956711546721e-05,
+            "0.75": 0.0010888753911592985,
+            "0.9": 0.004459582261572424,
+            "0.95": 0.0086922921418373,
+            "1.0": 0.24624404124592494
+          },
+          "per_region_outside_landing_mass_by_hop": {
+            "region-01bdd99ddb003fe4": [
+              0.0,
+              0.11785761733948263,
+              0.12206453847640664,
+              0.1924563614866781
+            ],
+            "region-04a3f136902a4088": [
+              0.0,
+              0.12560738471346933,
+              0.18419393913544424,
+              0.23567001620022754
+            ],
+            "region-08df249b33afb404": [
+              0.0,
+              0.08853018579040772,
+              0.13180615248160898,
+              0.1746881950202216
+            ],
+            "region-0f9da481e5fec7bd": [
+              0.0,
+              0.05305278037430616,
+              0.08847012227476103,
+              0.11753812830579136
+            ],
+            "region-10a3ff8fb2c77f3c": [
+              0.0,
+              0.007671940527879784,
+              0.01158318048775675,
+              0.015690166449410792
+            ],
+            "region-1686aaf10bf51c70": [
+              0.0,
+              0.06630116885799664,
+              0.1034873525874811,
+              0.13953962108295148
+            ],
+            "region-1c1b662fc6204dd7": [
+              1.1102230246251565e-16,
+              0.05461311223765675,
+              0.07236629737216471,
+              0.1008700625482638
+            ],
+            "region-1cd1c7acc0dab67e": [
+              0.0,
+              0.06091873473563503,
+              0.10223465820561983,
+              0.13417395496131945
+            ],
+            "region-1edfee45cbadbe6f": [
+              0.0,
+              0.05488095406830118,
+              0.0840541419884896,
+              0.11061895959340473
+            ],
+            "region-1fd81300d0be8994": [
+              0.0,
+              0.10568610864941985,
+              0.15997504139212704,
+              0.20744506520744577
+            ],
+            "region-20f36ea97cd072eb": [
+              1.1102230246251565e-16,
+              0.09122258059338662,
+              0.137537133524959,
+              0.18475991762296595
+            ],
+            "region-23ffd1a7e011d0b2": [
+              0.0,
+              0.09557414957604393,
+              0.14765140284113465,
+              0.19428194841459345
+            ],
+            "region-247df116b2ad5f6e": [
+              0.0,
+              0.10577056997004675,
+              0.16340156147120521,
+              0.21035345448239662
+            ],
+            "region-24bc78faf17dac55": [
+              0.0,
+              0.0633658839510638,
+              0.10245061996106763,
+              0.13379597685179512
+            ],
+            "region-24c3ed171b4b4630": [
+              0.0,
+              0.1131053194767726,
+              0.11568686370419368,
+              0.18441153898546037
+            ],
+            "region-2b7979a4c5b13941": [
+              0.0,
+              0.03277941740656898,
+              0.05064448273221123,
+              0.06865711947431441
+            ],
+            "region-3a6aa51d2a800aa4": [
+              0.0,
+              0.043479122468892406,
+              0.0683065785295982,
+              0.08826689023442069
+            ],
+            "region-3bc3e56cc1933b07": [
+              0.0,
+              0.06984323129285674,
+              0.09003706630057973,
+              0.12030138164623538
+            ],
+            "region-3e4d93b5d3f47fb6": [
+              0.0,
+              0.04545362007880582,
+              0.07558092240746783,
+              0.10181833106446614
+            ],
+            "region-42d807ac48c3deca": [
+              0.0,
+              0.06651468770017765,
+              0.11017701624816223,
+              0.14271769220452935
+            ],
+            "region-448ca05863b0ec97": [
+              0.0,
+              0.056158312507324726,
+              0.07182483563006048,
+              0.09922729129369989
+            ],
+            "region-4f17ef63043b357b": [
+              0.0,
+              0.03402893884482294,
+              0.05748634680045006,
+              0.07806497992827188
+            ],
+            "region-513c6b9e00dc8459": [
+              0.0,
+              0.06570195502893172,
+              0.10277822420757088,
+              0.13845767666724795
+            ],
+            "region-52c518867734a4e4": [
+              1.1102230246251565e-16,
+              0.04975942339904038,
+              0.08317089948655398,
+              0.1099000494200636
+            ],
+            "region-56365b6e955d943b": [
+              0.0,
+              0.039643357805992374,
+              0.06417499653590975,
+              0.0826593125870001
+            ],
+            "region-591819bd8a7236c6": [
+              0.0,
+              0.09695286874610998,
+              0.14637626496695555,
+              0.19078880898040762
+            ],
+            "region-615b256f301f48b6": [
+              0.0,
+              0.04645521217981907,
+              0.07180432044571461,
+              0.09618566821076757
+            ],
+            "region-6da1fd3516777f89": [
+              0.0,
+              0.0033792613090436463,
+              0.005212834579600978,
+              0.007462767851262764
+            ],
+            "region-6dce84eaad6792dc": [
+              1.1102230246251565e-16,
+              0.03518589232826297,
+              0.04071134449376601,
+              0.06094822084809126
+            ],
+            "region-76ecdf5eab7f4aa8": [
+              1.1102230246251565e-16,
+              0.018672084093509622,
+              0.03133419052229547,
+              0.04335386287629406
+            ],
+            "region-7b9922a172727aaf": [
+              0.0,
+              0.019642434139853227,
+              0.03252767440463533,
+              0.043812301320815594
+            ],
+            "region-7ee68d61dd92c2b4": [
+              0.0,
+              0.051753259265776674,
+              0.0836687659458295,
+              0.10742229325216623
+            ],
+            "region-7fc14753153498cf": [
+              0.0,
+              0.0015435110810834152,
+              0.0017769749871101581,
+              0.00306940847602144
+            ],
+            "region-807cee8b528cc0aa": [
+              0.0,
+              0.08985743753599473,
+              0.12894572406977456,
+              0.17113820366560684
+            ],
+            "region-84f2822feb1628d3": [
+              0.0,
+              0.05920165164177138,
+              0.09277080800363302,
+              0.12409400508620338
+            ],
+            "region-992a2c8d5ef2e786": [
+              1.1102230246251565e-16,
+              0.10496775627090404,
+              0.1586966486401381,
+              0.2074779210906137
+            ],
+            "region-9ff435b7e0a19714": [
+              0.0,
+              0.030447268009768047,
+              0.054739126279050976,
+              0.06991145793529885
+            ],
+            "region-a2a8854344dd80ca": [
+              0.0,
+              0.08659872293170612,
+              0.14036239011562568,
+              0.18316000714300307
+            ],
+            "region-ae1793c2443dc82e": [
+              1.1102230246251565e-16,
+              0.06068840579710144,
+              0.04682635283850067,
+              0.09649450658486947
+            ],
+            "region-aeb4ab59d0e94156": [
+              0.0,
+              0.0009048935703312999,
+              0.003465181771633352,
+              0.003516847357379338
+            ],
+            "region-b163267090738031": [
+              1.1102230246251565e-16,
+              0.062110592680814425,
+              0.09452109715326196,
+              0.1275743309209858
+            ],
+            "region-b9471b1b485d113b": [
+              0.0,
+              0.07553983092137151,
+              0.11336704946195009,
+              0.14977141935201232
+            ],
+            "region-bb620369bddc27c8": [
+              0.0,
+              0.15426764054495146,
+              0.1968312093003559,
+              0.27466565305328694
+            ],
+            "region-bdc4d69ffb64b2be": [
+              0.0,
+              0.10998267213197122,
+              0.16063307457962905,
+              0.21041300472041236
+            ],
+            "region-c4eb1de883798697": [
+              0.0,
+              0.12032624776162082,
+              0.12139689416046573,
+              0.1935200152339588
+            ],
+            "region-c4f7a7e3f57870fb": [
+              0.0,
+              0.04754436109332871,
+              0.06866345301995269,
+              0.09789214614154729
+            ],
+            "region-c90615e93fe73742": [
+              0.0,
+              0.0629640748329312,
+              0.10175137849881499,
+              0.13279160809037194
+            ],
+            "region-d07bfdc4c72fcd57": [
+              1.1102230246251565e-16,
+              0.032115832124701815,
+              0.05186298890590202,
+              0.06512293816269066
+            ],
+            "region-d175e11ea2f7e011": [
+              0.0,
+              0.06997111731166039,
+              0.10943423293408494,
+              0.14394542194987436
+            ],
+            "region-d1b7336ea17ac337": [
+              0.0,
+              0.04478253072728278,
+              0.06971206482891401,
+              0.09188817238192515
+            ],
+            "region-d22fbb4d4aa3a071": [
+              0.0,
+              0.05516838380217559,
+              0.0904168566498551,
+              0.12069494629934807
+            ],
+            "region-d3764bb3af22ed3f": [
+              0.0,
+              0.08750073577874407,
+              0.11713782169820564,
+              0.15700336767037248
+            ],
+            "region-da8dd8c868101c94": [
+              0.0,
+              0.029181845023228514,
+              0.05020219964407835,
+              0.06573827821025147
+            ],
+            "region-db23141753e2c9aa": [
+              0.0,
+              0.03976840232449086,
+              0.05833999002936607,
+              0.08156260463400966
+            ],
+            "region-e1d3a1fd2fd5290f": [
+              0.0,
+              0.1627001739502265,
+              0.15467324725318443,
+              0.24615690930419887
+            ],
+            "region-e559842f039f1f3a": [
+              1.1102230246251565e-16,
+              0.053815933532536,
+              0.08302299215691111,
+              0.11131981130261703
+            ],
+            "region-eb28081aff99b1fc": [
+              0.0,
+              0.0504724289898969,
+              0.07905618220460497,
+              0.10675084809928737
+            ],
+            "region-efba29c45288f545": [
+              0.0,
+              0.03895248554739483,
+              0.06547802470890196,
+              0.08493383910462837
+            ],
+            "region-f2dd65dcf5a1cacd": [
+              0.0,
+              0.06859372742120629,
+              0.11349107738979924,
+              0.14915906698353265
+            ],
+            "region-f74b75cb2b9d4ab4": [
+              0.0,
+              0.07866442331660384,
+              0.12975127370281825,
+              0.16654808499874074
+            ],
+            "region-fb926caad08708c6": [
+              0.0,
+              0.08369040341003364,
+              0.17621255087428978,
+              0.18396871002584514
+            ],
+            "region-fbb1327b55ee17d7": [
+              0.0,
+              0.07512397348821631,
+              0.11894053886233491,
+              0.1566628367918732
+            ],
+            "region-fc9c2f1842de299b": [
+              0.0,
+              0.07504280286722187,
+              0.12620958622877554,
+              0.16385526395668126
+            ],
+            "region-fd697ac42516e587": [
+              0.0,
+              0.09054620988028628,
+              0.12290591032545084,
+              0.1606975439787106
+            ]
+          },
+          "region_ids": [
+            "region-01bdd99ddb003fe4",
+            "region-04a3f136902a4088",
+            "region-08df249b33afb404",
+            "region-0f9da481e5fec7bd",
+            "region-10a3ff8fb2c77f3c",
+            "region-1686aaf10bf51c70",
+            "region-1c1b662fc6204dd7",
+            "region-1cd1c7acc0dab67e",
+            "region-1edfee45cbadbe6f",
+            "region-1fd81300d0be8994",
+            "region-20f36ea97cd072eb",
+            "region-23ffd1a7e011d0b2",
+            "region-247df116b2ad5f6e",
+            "region-24bc78faf17dac55",
+            "region-24c3ed171b4b4630",
+            "region-2b7979a4c5b13941",
+            "region-3a6aa51d2a800aa4",
+            "region-3bc3e56cc1933b07",
+            "region-3e4d93b5d3f47fb6",
+            "region-42d807ac48c3deca",
+            "region-448ca05863b0ec97",
+            "region-4f17ef63043b357b",
+            "region-513c6b9e00dc8459",
+            "region-52c518867734a4e4",
+            "region-56365b6e955d943b",
+            "region-591819bd8a7236c6",
+            "region-615b256f301f48b6",
+            "region-6da1fd3516777f89",
+            "region-6dce84eaad6792dc",
+            "region-76ecdf5eab7f4aa8",
+            "region-7b9922a172727aaf",
+            "region-7ee68d61dd92c2b4",
+            "region-7fc14753153498cf",
+            "region-807cee8b528cc0aa",
+            "region-84f2822feb1628d3",
+            "region-992a2c8d5ef2e786",
+            "region-9ff435b7e0a19714",
+            "region-a2a8854344dd80ca",
+            "region-ae1793c2443dc82e",
+            "region-aeb4ab59d0e94156",
+            "region-b163267090738031",
+            "region-b9471b1b485d113b",
+            "region-bb620369bddc27c8",
+            "region-bdc4d69ffb64b2be",
+            "region-c4eb1de883798697",
+            "region-c4f7a7e3f57870fb",
+            "region-c90615e93fe73742",
+            "region-d07bfdc4c72fcd57",
+            "region-d175e11ea2f7e011",
+            "region-d1b7336ea17ac337",
+            "region-d22fbb4d4aa3a071",
+            "region-d3764bb3af22ed3f",
+            "region-da8dd8c868101c94",
+            "region-db23141753e2c9aa",
+            "region-e1d3a1fd2fd5290f",
+            "region-e559842f039f1f3a",
+            "region-eb28081aff99b1fc",
+            "region-efba29c45288f545",
+            "region-f2dd65dcf5a1cacd",
+            "region-f74b75cb2b9d4ab4",
+            "region-fb926caad08708c6",
+            "region-fbb1327b55ee17d7",
+            "region-fc9c2f1842de299b",
+            "region-fd697ac42516e587"
+          ]
+        },
+        "gates": {
+          "all_registered_sizes_pass": true
+        },
+        "partition_assignment_record": {
+          "sha256": "4c8a834796978117eadfdf71eb42edd3af60b2b595c99cc0f81375fc8fdac824",
+          "size_bytes": 7101948
+        },
+        "registered_size_results": {
+          "160": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "db74068f1f7df666c7d322dc1862c9c9eec98c42eb55bce9412f98b9af041b0e",
+                "size_bytes": 4162
+              },
+              "counts_by_region_record": {
+                "sha256": "6db931db9260ede4e882c25dfc80d58bd3d934d091bd85e67da3bf0dc467ff27",
+                "size_bytes": 1794
+              },
+              "quadratic_exposure": 451.3907253532415,
+              "used_region_count": 64
+            },
+            "capacities_by_region_record": {
+              "sha256": "8e471917bb6f3d2abfc25c40fd51b165f432adc8e4464396e724851aaae73f5e",
+              "size_bytes": 1858
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 3374.8555563293994,
+                "components": 160,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 160.0,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3374.855556329399,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 3374.855556329399
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 3374.8555563293994,
+                "components": 160,
+                "design_effect_upper_bound": 1.5023211806764685,
+                "effective_components_lower_bound": 106.50185996043459,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3374.855556329399,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 3374.855556329399
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 3374.8555563293994,
+                "components": 160,
+                "design_effect_upper_bound": 2.004642361352937,
+                "effective_components_lower_bound": 79.81473557807873,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3374.855556329399,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 3374.855556329399
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 3374.8555563293994,
+                "components": 160,
+                "design_effect_upper_bound": 3.0092847227058743,
+                "effective_components_lower_bound": 53.16878087100112,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3374.855556329399,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 3374.855556329399
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 3374.8555563293994,
+                "components": 160,
+                "design_effect_upper_bound": 5.018569445411749,
+                "effective_components_lower_bound": 31.881595291319673,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3374.855556329399,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 3374.855556329399
+              }
+            },
+            "components_per_corpus": 160,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 160,
+                "design_effect": 1.0,
+                "effective_components": 160.0,
+                "one_C_one": 160.0,
+                "quadratic_exposure": 451.3907253532415,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 160,
+                "design_effect": 1.045529800836444,
+                "effective_components": 153.03246246256865,
+                "one_C_one": 167.28476813383105,
+                "quadratic_exposure": 451.3907253532415,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 160,
+                "design_effect": 1.091059601672888,
+                "effective_components": 146.6464341220928,
+                "one_C_one": 174.56953626766207,
+                "quadratic_exposure": 451.3907253532415,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 160,
+                "design_effect": 1.182119203345776,
+                "effective_components": 135.35014027954944,
+                "one_C_one": 189.13907253532415,
+                "quadratic_exposure": 451.3907253532415,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 160,
+                "design_effect": 1.3642384066915518,
+                "effective_components": 117.28155373372014,
+                "one_C_one": 218.2781450706483,
+                "quadratic_exposure": 451.3907253532415,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 1024
+          },
+          "320": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "d306fcbbd88a574373fc510521e2bf0df81e336642a965a6584d510ced731854",
+                "size_bytes": 8322
+              },
+              "counts_by_region_record": {
+                "sha256": "6add32ae4d104001d33c46db806b18745a6005b4a3fc429727a26e2af5f6adf1",
+                "size_bytes": 1794
+              },
+              "quadratic_exposure": 1769.8389523855642,
+              "used_region_count": 64
+            },
+            "capacities_by_region_record": {
+              "sha256": "db71a6610e162db9c45be5ae46ac88bb31452daeb6869d5b2afb678b18eeaaf7",
+              "size_bytes": 1858
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 13499.422225317598,
+                "components": 320,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 320.0,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 13499.422225317596,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 13499.422225317596
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 13499.422225317598,
+                "components": 320,
+                "design_effect_upper_bound": 2.029642361352937,
+                "effective_components_lower_bound": 157.66324456624542,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 13499.422225317596,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 13499.422225317596
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 13499.422225317598,
+                "components": 320,
+                "design_effect_upper_bound": 3.0592847227058746,
+                "effective_components_lower_bound": 104.59961363680023,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 13499.422225317596,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 13499.422225317596
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 13499.422225317598,
+                "components": 320,
+                "design_effect_upper_bound": 5.118569445411749,
+                "effective_components_lower_bound": 62.51746770513114,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 13499.422225317596,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 13499.422225317596
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 13499.422225317598,
+                "components": 320,
+                "design_effect_upper_bound": 9.237138890823498,
+                "effective_components_lower_bound": 34.64276155010502,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 13499.422225317596,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 13499.422225317596
+              }
+            },
+            "components_per_corpus": 320,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 320,
+                "design_effect": 1.0,
+                "effective_components": 320.0,
+                "one_C_one": 320.0,
+                "quadratic_exposure": 1769.8389523855642,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 320,
+                "design_effect": 1.1132686681551223,
+                "effective_components": 287.4418450402409,
+                "one_C_one": 356.2459738096391,
+                "quadratic_exposure": 1769.8389523855642,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 320,
+                "design_effect": 1.2265373363102445,
+                "effective_components": 260.8970722103303,
+                "one_C_one": 392.4919476192782,
+                "quadratic_exposure": 1769.8389523855642,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 320,
+                "design_effect": 1.4530746726204888,
+                "effective_components": 220.2226809327761,
+                "one_C_one": 464.98389523855644,
+                "quadratic_exposure": 1769.8389523855642,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 320,
+                "design_effect": 1.9061493452409777,
+                "effective_components": 167.87771682157737,
+                "one_C_one": 609.9677904771129,
+                "quadratic_exposure": 1769.8389523855642,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 2048
+          },
+          "512": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "f8ca26cb9beb9dc5908dfc4a726f09d018b501e52e5323b78a0e342d01d25e9c",
+                "size_bytes": 13314
+              },
+              "counts_by_region_record": {
+                "sha256": "dcd6c4d70e37e0089dbab505d70ed6903c71b08ffc7ef692c8b74f59d2871719",
+                "size_bytes": 1794
+              },
+              "quadratic_exposure": 4525.401976320499,
+              "used_region_count": 64
+            },
+            "capacities_by_region_record": {
+              "sha256": "fe7fa57067a4666c99c53b8b4cd52c2dd8a21ea57898601c5231f77e280c4155",
+              "size_bytes": 1858
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 34423.526662661374,
+                "components": 512,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 512.0,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 34294.33298529414,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 34294.33298529414
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 34423.526662661374,
+                "components": 512,
+                "design_effect_upper_bound": 2.6495279777975655,
+                "effective_components_lower_bound": 193.24196773555218,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 34294.33298529414,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 34294.33298529414
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 34423.526662661374,
+                "components": 512,
+                "design_effect_upper_bound": 4.299055955595131,
+                "effective_components_lower_bound": 119.0959143794448,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 34294.33298529414,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 34294.33298529414
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 34423.526662661374,
+                "components": 512,
+                "design_effect_upper_bound": 7.598111911190262,
+                "effective_components_lower_bound": 67.38516173286976,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 34294.33298529414,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 34294.33298529414
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 34423.526662661374,
+                "components": 512,
+                "design_effect_upper_bound": 14.196223822380524,
+                "effective_components_lower_bound": 36.06592896857723,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 34294.33298529414,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 34294.33298529414
+              }
+            },
+            "components_per_corpus": 512,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 512,
+                "design_effect": 1.0,
+                "effective_components": 512.0,
+                "one_C_one": 512.0,
+                "quadratic_exposure": 4525.401976320499,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 512,
+                "design_effect": 1.1959668933750243,
+                "effective_components": 428.1054959265081,
+                "one_C_one": 612.3350494080124,
+                "quadratic_exposure": 4525.401976320499,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 512,
+                "design_effect": 1.3919337867500488,
+                "effective_components": 367.83358869062386,
+                "one_C_one": 712.670098816025,
+                "quadratic_exposure": 4525.401976320499,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 512,
+                "design_effect": 1.7838675735000975,
+                "effective_components": 287.0168209826322,
+                "one_C_one": 913.3401976320499,
+                "quadratic_exposure": 4525.401976320499,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 512,
+                "design_effect": 2.567735147000195,
+                "effective_components": 199.39751208303304,
+                "one_C_one": 1314.6803952640998,
+                "quadratic_exposure": 4525.401976320499,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 3261
+          },
+          "800": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "d5857eccce8535720d659a9c2605c377aaaeae71d8c2f934297a2c3ef32e8cb1",
+                "size_bytes": 20802
+              },
+              "counts_by_region_record": {
+                "sha256": "27ac11032338cb967140aa9180e2b65061c2947fad75a8d5c45f60e061b24af0",
+                "size_bytes": 1858
+              },
+              "quadratic_exposure": 11039.663294816633,
+              "used_region_count": 64
+            },
+            "capacities_by_region_record": {
+              "sha256": "3cecf0d79e15faaf9b60aaa0fa98a8d01c3af3abf789b6ec405a4300d00136c0",
+              "size_bytes": 1858
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 84371.38870992658,
+                "components": 800,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 800.0,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 84371.38870992658,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 84371.38890823498
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 84371.38870992658,
+                "components": 800,
+                "design_effect_upper_bound": 3.611605897185206,
+                "effective_components_lower_bound": 221.50811101053404,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 84371.38870992658,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 84371.38890823498
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 84371.38870992658,
+                "components": 800,
+                "design_effect_upper_bound": 6.223211794370412,
+                "effective_components_lower_bound": 128.55098403105757,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 84371.38870992658,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 84371.38890823498
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 84371.38870992658,
+                "components": 800,
+                "design_effect_upper_bound": 11.446423588740824,
+                "effective_components_lower_bound": 69.89082605565227,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 84371.38870992658,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 84371.38890823498
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 84371.38870992658,
+                "components": 800,
+                "design_effect_upper_bound": 21.89284717748165,
+                "effective_components_lower_bound": 36.54161532826379,
+                "lambda_max_upper": 1.3183029516911713,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 84371.38870992658,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 84371.38890823498
+              }
+            },
+            "components_per_corpus": 800,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 800,
+                "design_effect": 1.0,
+                "effective_components": 800.0,
+                "one_C_one": 800.0,
+                "quadratic_exposure": 11039.663294816633,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 800,
+                "design_effect": 1.31998947796302,
+                "effective_components": 606.065437153744,
+                "one_C_one": 1055.991582370416,
+                "quadratic_exposure": 11039.663294816633,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 800,
+                "design_effect": 1.6399789559260398,
+                "effective_components": 487.8111375205223,
+                "one_C_one": 1311.9831647408319,
+                "quadratic_exposure": 11039.663294816633,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 800,
+                "design_effect": 2.279957911852079,
+                "effective_components": 350.8836701946553,
+                "one_C_one": 1823.9663294816635,
+                "quadratic_exposure": 11039.663294816633,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 800,
+                "design_effect": 3.559915823704159,
+                "effective_components": 224.72441473843196,
+                "one_C_one": 2847.932658963327,
+                "quadratic_exposure": 11039.663294816633,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 5088
+          }
+        },
+        "rho_grid": [
+          0.0,
+          0.025,
+          0.05,
+          0.1,
+          0.2
+        ],
+        "target_region_count": 64,
+        "walk_weights": [
+          1.0,
+          0.5,
+          0.25,
+          0.125
+        ]
+      },
+      "96": {
+        "actual_region_count": 96,
+        "authorization": {
+          "attempted_input_inventory_authorized": false,
+          "candidate_selection_authorized": false,
+          "covariance_promotion_authorized": false,
+          "cuda_authorized": false,
+          "independent_batching_authorized": false,
+          "live_scoring_authorized": false,
+          "nomic_authorized": false,
+          "qr_specialization_authorized": false
+        },
+        "exposure": {
+          "effective_rank": 95.54873551079568,
+          "eigenvalues_descending": [
+            1.36607736874124,
+            1.2173879593105963,
+            1.1327291820917464,
+            1.0906648855205592,
+            1.0841229532317815,
+            1.0640000182394478,
+            1.0567685668252762,
+            1.054384341395703,
+            1.0505183752856766,
+            1.0476780876664793,
+            1.0404340843103486,
+            1.0382720825486949,
+            1.0356897075228355,
+            1.0342893582966017,
+            1.029812744140939,
+            1.0287820058345316,
+            1.0258279853073302,
+            1.0239841020816962,
+            1.0233851222234307,
+            1.0218606777360808,
+            1.0182950565299755,
+            1.01750108987583,
+            1.0152153939630244,
+            1.014068147771538,
+            1.0135328481895776,
+            1.0123428901618052,
+            1.0116364347946627,
+            1.0100279412239186,
+            1.0089251133947972,
+            1.0083763150525455,
+            1.006250166113095,
+            1.005811822336772,
+            1.0057184425095929,
+            1.0048107820728818,
+            1.0043841040387307,
+            1.0038907243802841,
+            1.0037044680580842,
+            1.002537589569276,
+            1.0023551927987484,
+            1.0013350114298742,
+            1.000587783882837,
+            1.0002859807793634,
+            1.0000818425968196,
+            1.0000575162947016,
+            0.9998636566898763,
+            0.9994054514988784,
+            0.9987480912396702,
+            0.9981271768028038,
+            0.997629768628481,
+            0.9973760060662878,
+            0.9966358888539025,
+            0.9953418449508948,
+            0.995130868773315,
+            0.9948803548258621,
+            0.9942385903011732,
+            0.9932678601546396,
+            0.9930606556087934,
+            0.9915763836038634,
+            0.9906672140264281,
+            0.9905545817164568,
+            0.9893164473252923,
+            0.9884908564257601,
+            0.9879353207235144,
+            0.987412630161073,
+            0.9866462160733966,
+            0.9849778874245485,
+            0.9848834564005903,
+            0.9836195443090945,
+            0.9834032922063022,
+            0.9818797842575526,
+            0.9810269276470065,
+            0.9805944684241538,
+            0.9783494295152743,
+            0.9768240890280192,
+            0.9765325230884015,
+            0.9763677440622321,
+            0.9746273380543341,
+            0.9728572924953999,
+            0.9724084511069337,
+            0.9699908083432428,
+            0.9676633355697128,
+            0.9665678658378759,
+            0.9657920268223239,
+            0.96509857933704,
+            0.963715433374933,
+            0.9624523198572273,
+            0.960619849471337,
+            0.9594433528466829,
+            0.9582752809503868,
+            0.9550295857130272,
+            0.949095549385792,
+            0.9457240969786826,
+            0.9406189980265662,
+            0.9289253186165971,
+            0.792016593140823,
+            0.6359106471278083
+          ],
+          "matrix_record": {
+            "sha256": "10277de8d0600a6831fdaf739720d356ecb41560467197195602ac949d8935d8",
+            "size_bytes": 168584
+          },
+          "matrix_shape": [
+            96,
+            96
+          ],
+          "mean_outside_landing_mass_by_hop": [
+            1.2721305490496585e-17,
+            0.06629838188420188,
+            0.10004408294089107,
+            0.13222455210801065
+          ],
+          "numerical_rank": 96,
+          "off_diagonal_quantiles": {
+            "0.0": 0.0,
+            "0.25": 3.043161927818155e-10,
+            "0.5": 1.3895749297443766e-06,
+            "0.75": 0.000428965870305696,
+            "0.9": 0.003020591017436822,
+            "0.95": 0.006316616721924568,
+            "1.0": 0.3621119454414547
+          },
+          "per_region_outside_landing_mass_by_hop": {
+            "region-037dbf22a7b2d497": [
+              0.0,
+              0.04371281303531138,
+              0.06784102032466,
+              0.0897396396036686
+            ],
+            "region-04780e2c142517c4": [
+              1.1102230246251565e-16,
+              0.11645286661907339,
+              0.18489759643946835,
+              0.23985282171827116
+            ],
+            "region-06cb3a7de69cbcf7": [
+              0.0,
+              0.09120758126533168,
+              0.1413562024756605,
+              0.18399279850309724
+            ],
+            "region-09c7c6f711cf896d": [
+              0.0,
+              0.056641849529780575,
+              0.09808321894472072,
+              0.12497697764944726
+            ],
+            "region-0bcfba38c57412be": [
+              0.0,
+              0.0526208268321704,
+              0.08332656324392229,
+              0.1114111019409122
+            ],
+            "region-0e0a660b032a8822": [
+              1.1102230246251565e-16,
+              0.10796357326369332,
+              0.15673118368374672,
+              0.20445217175376906
+            ],
+            "region-104075ac3b9e656e": [
+              0.0,
+              0.08395770305902572,
+              0.13437112955693964,
+              0.17388903974766667
+            ],
+            "region-1e16f0438236722d": [
+              0.0,
+              0.08629408485630041,
+              0.1056347514813144,
+              0.14823244444106487
+            ],
+            "region-207f40d8a3a62f71": [
+              0.0,
+              0.04217803449727464,
+              0.06690506847473965,
+              0.09023545145002076
+            ],
+            "region-29690c0da32ffa0e": [
+              0.0,
+              0.0665074966461201,
+              0.0972379777885134,
+              0.13070102586963106
+            ],
+            "region-29bd03f70a4b6f29": [
+              0.0,
+              0.086122166465193,
+              0.13008473421822497,
+              0.17482818830666946
+            ],
+            "region-2c5f5b16bca90d9a": [
+              0.0,
+              0.12350944602782854,
+              0.17386536584267442,
+              0.2179788960235135
+            ],
+            "region-2cca36986dd00c22": [
+              0.0,
+              0.12316432423137913,
+              0.17020418279690142,
+              0.22833198318432812
+            ],
+            "region-2fd3800f530a4e01": [
+              0.0,
+              0.07405554600974262,
+              0.1580121596995374,
+              0.16645659877989394
+            ],
+            "region-30074078ddba26ad": [
+              0.0,
+              0.07389571407428552,
+              0.11032568257115882,
+              0.14838806083525813
+            ],
+            "region-31710e95611cd8fe": [
+              0.0,
+              0.07667025634915536,
+              0.10937653848176787,
+              0.14935118547163795
+            ],
+            "region-32106e2d3f03f2e0": [
+              0.0,
+              0.0468489386591584,
+              0.07803636373988088,
+              0.10446359894084045
+            ],
+            "region-323c305f883ea5e9": [
+              0.0,
+              0.030856682274861713,
+              0.054109565294001793,
+              0.07222806081770039
+            ],
+            "region-349d9cae1e8e6fd8": [
+              0.0,
+              0.03077823599605134,
+              0.0559992378353823,
+              0.07508854835223022
+            ],
+            "region-37413cfbf2289938": [
+              0.0,
+              0.11319921228009466,
+              0.16018918391650872,
+              0.20760570917631438
+            ],
+            "region-3a9608a9d1825566": [
+              0.0,
+              0.028774435485542593,
+              0.04517568991207144,
+              0.06198171954076481
+            ],
+            "region-3bd6d75d48fdcf78": [
+              0.0,
+              0.004340764434661137,
+              0.007314151191908702,
+              0.010232320616361923
+            ],
+            "region-3be1f2650f20ca17": [
+              0.0,
+              0.05803568710297835,
+              0.07829824771940008,
+              0.10063260097015547
+            ],
+            "region-3dae044260eedc93": [
+              0.0,
+              0.06359293458609583,
+              0.09873691209846824,
+              0.1307369486509471
+            ],
+            "region-3e9a67d93b77b70d": [
+              0.0,
+              0.0508126821135767,
+              0.09311311275771106,
+              0.12826949806675736
+            ],
+            "region-4023f9bc76cfe30e": [
+              0.0,
+              0.0142138453821401,
+              0.022848069850941122,
+              0.0287702407052165
+            ],
+            "region-46f6777bfbfa5c55": [
+              1.1102230246251565e-16,
+              0.06666997337429015,
+              0.10622660881244872,
+              0.14006629964006334
+            ],
+            "region-49315b30a085185d": [
+              0.0,
+              0.08619641496174446,
+              0.17355704357121748,
+              0.20311379900589532
+            ],
+            "region-53e0d8a7fe662e6c": [
+              0.0,
+              0.05157463965107978,
+              0.08758933198113927,
+              0.11155007795149563
+            ],
+            "region-54d5616a2747ebf6": [
+              0.0,
+              0.0159240857676064,
+              0.02744951925432282,
+              0.03661203934127244
+            ],
+            "region-5804216932d6f51f": [
+              0.0,
+              0.0202764249639249,
+              0.04604282615398292,
+              0.056856841452083584
+            ],
+            "region-5ad7243329d89d29": [
+              0.0,
+              0.0987318020991067,
+              0.15613238047618838,
+              0.20179206089133617
+            ],
+            "region-5c19f5c910802317": [
+              0.0,
+              0.05108247953284273,
+              0.07606390100332117,
+              0.10274560443089364
+            ],
+            "region-600f8424777afb0b": [
+              1.1102230246251565e-16,
+              0.10422263138792631,
+              0.16593914155098588,
+              0.21315496278625712
+            ],
+            "region-61187e085f99af98": [
+              0.0,
+              0.05101465735852939,
+              0.07329252642908235,
+              0.09949683881258675
+            ],
+            "region-64b9763cecf494dc": [
+              0.0,
+              0.0508432388043043,
+              0.08311649381865438,
+              0.10915057019465901
+            ],
+            "region-68d6f359539587d5": [
+              0.0,
+              0.10787408231475681,
+              0.14929985502622134,
+              0.19928308521351878
+            ],
+            "region-69f285a296a04b4d": [
+              0.0,
+              0.033602430404218064,
+              0.05401196703240563,
+              0.0715661822696062
+            ],
+            "region-6d1b0061cc2f887a": [
+              0.0,
+              0.0418825727039942,
+              0.06357108263088229,
+              0.08868992764914707
+            ],
+            "region-706fffa268ca4707": [
+              0.0,
+              0.05146319345070083,
+              0.08473908540083541,
+              0.11156616008068598
+            ],
+            "region-70e942c0ee99d4c8": [
+              1.1102230246251565e-16,
+              0.056824916387889335,
+              0.08476457170173402,
+              0.1247615530371422
+            ],
+            "region-762189b9791ff4c1": [
+              0.0,
+              0.07620049001976559,
+              0.1009842923386054,
+              0.13643011811510164
+            ],
+            "region-76b5b54e30ded096": [
+              0.0,
+              0.08446765936709721,
+              0.14168340349963882,
+              0.18345743174074192
+            ],
+            "region-76bfe4bcad5dfff7": [
+              0.0,
+              0.003178968799671278,
+              0.008619920565976269,
+              0.012696052997797524
+            ],
+            "region-77ce52347e1c382b": [
+              1.1102230246251565e-16,
+              0.10683694687462508,
+              0.14899801604563911,
+              0.20191456102840244
+            ],
+            "region-7ac47cbe2777d5fe": [
+              1.1102230246251565e-16,
+              0.059824155251842814,
+              0.10136131824236017,
+              0.13207888044174376
+            ],
+            "region-7b01b8f2a5a70b17": [
+              0.0,
+              0.05751688333090643,
+              0.09063424230409778,
+              0.11954684789064773
+            ],
+            "region-7fc3efe42b51d80e": [
+              0.0,
+              0.10786788795638025,
+              0.1605450611210968,
+              0.21148108012553513
+            ],
+            "region-80042f40c525e140": [
+              0.0,
+              0.04499559919378626,
+              0.07733523685445132,
+              0.10017939061754821
+            ],
+            "region-8043cf57053cc718": [
+              0.0,
+              0.03810311474066941,
+              0.05868511378524177,
+              0.07652862086010714
+            ],
+            "region-833cdd5d2a586e8e": [
+              0.0,
+              0.009897944777233159,
+              0.017489693367269132,
+              0.024378584464061936
+            ],
+            "region-850675102a88fa52": [
+              0.0,
+              0.05418931262543536,
+              0.07237058188045142,
+              0.10095994587967116
+            ],
+            "region-85f47f5f0adcdb48": [
+              0.0,
+              0.07884620308243262,
+              0.11923864136144613,
+              0.15641469541934483
+            ],
+            "region-874a580277530224": [
+              0.0,
+              0.03332161893047503,
+              0.10298375371734692,
+              0.08993958965960047
+            ],
+            "region-8778a866c075b6d5": [
+              0.0,
+              0.059392903082586046,
+              0.10224354614766495,
+              0.12995798676237424
+            ],
+            "region-8cbca852bdf74686": [
+              0.0,
+              0.06797511280589974,
+              0.11299351742462238,
+              0.1476354114579267
+            ],
+            "region-8ec38b57757a56b7": [
+              0.0,
+              0.060038900064239065,
+              0.0991481486259983,
+              0.1314489180696372
+            ],
+            "region-8f430c7c7866b575": [
+              0.0,
+              0.1179670165815655,
+              0.16702567422801484,
+              0.22766498363328924
+            ],
+            "region-935f2945ee361910": [
+              0.0,
+              0.02750195146468426,
+              0.046088937935905294,
+              0.061086693488871524
+            ],
+            "region-93b385e443472d15": [
+              0.0,
+              0.033360218571184874,
+              0.05853629544671979,
+              0.0753004920938174
+            ],
+            "region-93d2d814ffd3aa82": [
+              0.0,
+              0.07689149325126654,
+              0.12520405646617339,
+              0.16149070223415363
+            ],
+            "region-9751baea990e1216": [
+              0.0,
+              0.11552583210530043,
+              0.17453425185160243,
+              0.23203365947965549
+            ],
+            "region-9ae71a5e63f1d54d": [
+              0.0,
+              0.050571058060272955,
+              0.08325184399327079,
+              0.11103682904119594
+            ],
+            "region-9c7de5bee7128c5b": [
+              0.0,
+              0.08032382044919095,
+              0.13631950996745057,
+              0.17755319587308338
+            ],
+            "region-9c7f9495d60ed270": [
+              0.0,
+              0.02546296296296291,
+              0.041474843723042665,
+              0.054195961796264625
+            ],
+            "region-a183af32858080d0": [
+              0.0,
+              0.07247633313725654,
+              0.1207428949052467,
+              0.14602106889581812
+            ],
+            "region-a1cfb5e13eec3999": [
+              0.0,
+              0.028688657286866426,
+              0.04902950339500456,
+              0.06064550781714728
+            ],
+            "region-a2b9b630524ebf33": [
+              0.0,
+              0.05388357738765692,
+              0.08048659870514407,
+              0.1083042523646649
+            ],
+            "region-a2ecc9ffbefc97af": [
+              1.1102230246251565e-16,
+              0.08146421354356292,
+              0.12737004690087717,
+              0.16751867224539174
+            ],
+            "region-a55a8cb1a0755414": [
+              0.0,
+              0.060878003408286085,
+              0.09889117833767869,
+              0.12815447872713503
+            ],
+            "region-a7753f6b626038dd": [
+              0.0,
+              0.033723494963514566,
+              0.04776752750654811,
+              0.0675848632784698
+            ],
+            "region-a8d8fac190ad9092": [
+              0.0,
+              0.06499083275399054,
+              0.1013106013242312,
+              0.135021078739897
+            ],
+            "region-ab9da87dce28044b": [
+              0.0,
+              2.9820480706210795e-05,
+              0.0008071410111131216,
+              0.0009077272807119785
+            ],
+            "region-b7576061c78e9c18": [
+              0.0,
+              0.034819094642717374,
+              0.033383981150471254,
+              0.04847670977495744
+            ],
+            "region-b7d077d5418cbcf6": [
+              0.0,
+              0.09281258572348328,
+              0.14363671895840147,
+              0.18833559218129992
+            ],
+            "region-bf6c47415a6aa378": [
+              0.0,
+              0.07617837494540936,
+              0.11874373209707412,
+              0.15150721526964694
+            ],
+            "region-c41bea68763b74ba": [
+              0.0,
+              0.09670098829779916,
+              0.13133916518622135,
+              0.17768129421991763
+            ],
+            "region-c6051ef801e08ed1": [
+              0.0,
+              0.07661703106076512,
+              0.12024187073932868,
+              0.15888826056413496
+            ],
+            "region-cd428b5b32e5161b": [
+              0.0,
+              0.10835976391411783,
+              0.1652451520410536,
+              0.2108953774349266
+            ],
+            "region-cfaf6e36f0cf66cd": [
+              0.0,
+              0.01450950859011313,
+              0.02681308062982557,
+              0.03913867561016271
+            ],
+            "region-d0a6529bba19a5a8": [
+              0.0,
+              0.024056430508043403,
+              0.044023186065946684,
+              0.05896460118668734
+            ],
+            "region-d0b7c877d95c2797": [
+              0.0,
+              0.0409677321137919,
+              0.06512501796737857,
+              0.0881622359125881
+            ],
+            "region-d212b652853075c1": [
+              0.0,
+              0.003510907846168032,
+              0.008863719774124368,
+              0.01216238512420309
+            ],
+            "region-dac32ce5165d74a1": [
+              1.1102230246251565e-16,
+              0.08626386739069636,
+              0.1334173234182514,
+              0.16936879657942905
+            ],
+            "region-e3fdb338ebc92b05": [
+              0.0,
+              0.07474208216937894,
+              0.111174622757646,
+              0.1518189725367325
+            ],
+            "region-e4a46dd910a1682a": [
+              0.0,
+              0.004178330741316794,
+              0.0049327742414834175,
+              0.008215388427021408
+            ],
+            "region-f00e9fc663a35e4c": [
+              1.1102230246251565e-16,
+              0.07820122597023982,
+              0.12665126527804937,
+              0.165880509827392
+            ],
+            "region-f12af280610e0a5b": [
+              0.0,
+              0.05819131737499095,
+              0.08379821349302108,
+              0.11487517604665698
+            ],
+            "region-f28557b2972d2975": [
+              1.1102230246251565e-16,
+              0.06723817504287599,
+              0.09540099187104978,
+              0.13137699714904338
+            ],
+            "region-f72d8b22f1cc00a6": [
+              0.0,
+              0.03432779100825922,
+              0.05248660146289397,
+              0.07173587528990355
+            ],
+            "region-f74c24f1fe9d217b": [
+              0.0,
+              0.0722879503851348,
+              0.11619536567883182,
+              0.1521959612437378
+            ],
+            "region-f940495ff1e19265": [
+              0.0,
+              0.0643673409534754,
+              0.09351955441368409,
+              0.12605722864509716
+            ],
+            "region-f9eb981ca95fa130": [
+              0.0,
+              0.06531029555083578,
+              0.10207390503503355,
+              0.13123921669422312
+            ],
+            "region-f9fc4f463034457b": [
+              0.0,
+              0.4713220171321396,
+              0.41459632686458725,
+              0.6694094119202745
+            ],
+            "region-fa0e3d0a72a8e048": [
+              0.0,
+              0.09788505927546176,
+              0.14449410085442183,
+              0.1881005940587921
+            ],
+            "region-fd33e5608432d355": [
+              0.0,
+              0.12081255869511143,
+              0.18004965418318652,
+              0.2362686102796041
+            ]
+          },
+          "region_ids": [
+            "region-037dbf22a7b2d497",
+            "region-04780e2c142517c4",
+            "region-06cb3a7de69cbcf7",
+            "region-09c7c6f711cf896d",
+            "region-0bcfba38c57412be",
+            "region-0e0a660b032a8822",
+            "region-104075ac3b9e656e",
+            "region-1e16f0438236722d",
+            "region-207f40d8a3a62f71",
+            "region-29690c0da32ffa0e",
+            "region-29bd03f70a4b6f29",
+            "region-2c5f5b16bca90d9a",
+            "region-2cca36986dd00c22",
+            "region-2fd3800f530a4e01",
+            "region-30074078ddba26ad",
+            "region-31710e95611cd8fe",
+            "region-32106e2d3f03f2e0",
+            "region-323c305f883ea5e9",
+            "region-349d9cae1e8e6fd8",
+            "region-37413cfbf2289938",
+            "region-3a9608a9d1825566",
+            "region-3bd6d75d48fdcf78",
+            "region-3be1f2650f20ca17",
+            "region-3dae044260eedc93",
+            "region-3e9a67d93b77b70d",
+            "region-4023f9bc76cfe30e",
+            "region-46f6777bfbfa5c55",
+            "region-49315b30a085185d",
+            "region-53e0d8a7fe662e6c",
+            "region-54d5616a2747ebf6",
+            "region-5804216932d6f51f",
+            "region-5ad7243329d89d29",
+            "region-5c19f5c910802317",
+            "region-600f8424777afb0b",
+            "region-61187e085f99af98",
+            "region-64b9763cecf494dc",
+            "region-68d6f359539587d5",
+            "region-69f285a296a04b4d",
+            "region-6d1b0061cc2f887a",
+            "region-706fffa268ca4707",
+            "region-70e942c0ee99d4c8",
+            "region-762189b9791ff4c1",
+            "region-76b5b54e30ded096",
+            "region-76bfe4bcad5dfff7",
+            "region-77ce52347e1c382b",
+            "region-7ac47cbe2777d5fe",
+            "region-7b01b8f2a5a70b17",
+            "region-7fc3efe42b51d80e",
+            "region-80042f40c525e140",
+            "region-8043cf57053cc718",
+            "region-833cdd5d2a586e8e",
+            "region-850675102a88fa52",
+            "region-85f47f5f0adcdb48",
+            "region-874a580277530224",
+            "region-8778a866c075b6d5",
+            "region-8cbca852bdf74686",
+            "region-8ec38b57757a56b7",
+            "region-8f430c7c7866b575",
+            "region-935f2945ee361910",
+            "region-93b385e443472d15",
+            "region-93d2d814ffd3aa82",
+            "region-9751baea990e1216",
+            "region-9ae71a5e63f1d54d",
+            "region-9c7de5bee7128c5b",
+            "region-9c7f9495d60ed270",
+            "region-a183af32858080d0",
+            "region-a1cfb5e13eec3999",
+            "region-a2b9b630524ebf33",
+            "region-a2ecc9ffbefc97af",
+            "region-a55a8cb1a0755414",
+            "region-a7753f6b626038dd",
+            "region-a8d8fac190ad9092",
+            "region-ab9da87dce28044b",
+            "region-b7576061c78e9c18",
+            "region-b7d077d5418cbcf6",
+            "region-bf6c47415a6aa378",
+            "region-c41bea68763b74ba",
+            "region-c6051ef801e08ed1",
+            "region-cd428b5b32e5161b",
+            "region-cfaf6e36f0cf66cd",
+            "region-d0a6529bba19a5a8",
+            "region-d0b7c877d95c2797",
+            "region-d212b652853075c1",
+            "region-dac32ce5165d74a1",
+            "region-e3fdb338ebc92b05",
+            "region-e4a46dd910a1682a",
+            "region-f00e9fc663a35e4c",
+            "region-f12af280610e0a5b",
+            "region-f28557b2972d2975",
+            "region-f72d8b22f1cc00a6",
+            "region-f74c24f1fe9d217b",
+            "region-f940495ff1e19265",
+            "region-f9eb981ca95fa130",
+            "region-f9fc4f463034457b",
+            "region-fa0e3d0a72a8e048",
+            "region-fd33e5608432d355"
+          ]
+        },
+        "gates": {
+          "all_registered_sizes_pass": true
+        },
+        "partition_assignment_record": {
+          "sha256": "0c9ab86b20c71d6ca3ae2b99a9fb44bed3737991fdd15249de1923de5aa22b03",
+          "size_bytes": 7101948
+        },
+        "registered_size_results": {
+          "160": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "ba31dbe34f086080d469ba3384ee0d6fd3d3e66060b179a2c370d3145cdaf656",
+                "size_bytes": 4162
+              },
+              "counts_by_region_record": {
+                "sha256": "4b79a067154a5ac9c5396c2bb5b0f3a82f75197a0a7fbe03650734d106976774",
+                "size_bytes": 2690
+              },
+              "quadratic_exposure": 309.9953693575819,
+              "used_region_count": 96
+            },
+            "capacities_by_region_record": {
+              "sha256": "485c471955c537054924e21c75f665a9d6d05f9ade4b581e9706d336bb3fe03d",
+              "size_bytes": 2786
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 3696.9047511736594,
+                "components": 160,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 160.0,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3696.904751173659,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 3696.904751173659
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 3696.9047511736594,
+                "components": 160,
+                "design_effect_upper_bound": 1.552641367370884,
+                "effective_components_lower_bound": 103.05019778709807,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3696.904751173659,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 3696.904751173659
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 3696.9047511736594,
+                "components": 160,
+                "design_effect_upper_bound": 2.105282734741768,
+                "effective_components_lower_bound": 75.99929328239394,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3696.904751173659,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 3696.904751173659
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 3696.9047511736594,
+                "components": 160,
+                "design_effect_upper_bound": 3.2105654694835364,
+                "effective_components_lower_bound": 49.8354578097852,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3696.904751173659,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 3696.904751173659
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 3696.9047511736594,
+                "components": 160,
+                "design_effect_upper_bound": 5.421130938967074,
+                "effective_components_lower_bound": 29.514136773550415,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 2560,
+                "quadratic_exposure_upper_bound": 3696.904751173659,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 3696.904751173659
+              }
+            },
+            "components_per_corpus": 160,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 160,
+                "design_effect": 1.0,
+                "effective_components": 160.0,
+                "one_C_one": 160.0,
+                "quadratic_exposure": 309.9953693575819,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 160,
+                "design_effect": 1.0234367764621222,
+                "effective_components": 156.3359883871846,
+                "one_C_one": 163.74988423393955,
+                "quadratic_exposure": 309.9953693575819,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 160,
+                "design_effect": 1.0468735529242443,
+                "effective_components": 152.83603215791447,
+                "one_C_one": 167.4997684678791,
+                "quadratic_exposure": 309.9953693575819,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 160,
+                "design_effect": 1.0937471058484887,
+                "effective_components": 146.28610137064354,
+                "one_C_one": 174.9995369357582,
+                "quadratic_exposure": 309.9953693575819,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 160,
+                "design_effect": 1.1874942116969773,
+                "effective_components": 134.73749886439742,
+                "one_C_one": 189.99907387151637,
+                "quadratic_exposure": 309.9953693575819,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 1536
+          },
+          "320": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "217a8a149b0e5a87e56db46af92ca8a452001ad2f89974b79bd61842eeace007",
+                "size_bytes": 8322
+              },
+              "counts_by_region_record": {
+                "sha256": "ce4f1c2a4ac640ab2b9a69af508c6dd334ffa387d8e0ee7d733b3a51e7831bc9",
+                "size_bytes": 2690
+              },
+              "quadratic_exposure": 1191.8097736076934,
+              "used_region_count": 96
+            },
+            "capacities_by_region_record": {
+              "sha256": "9524fc4080a6790955054a384a9862b5a38c767c7496a4dc3b77041037a5a16f",
+              "size_bytes": 2786
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 14780.858952832119,
+                "components": 320,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 320.0,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 14780.858952832119,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 14787.619004694636
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 14780.858952832119,
+                "components": 320,
+                "design_effect_upper_bound": 2.1297546056900094,
+                "effective_components_lower_bound": 150.25205211204351,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 14780.858952832119,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 14787.619004694636
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 14780.858952832119,
+                "components": 320,
+                "design_effect_upper_bound": 3.2595092113800193,
+                "effective_components_lower_bound": 98.17428920979107,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 14780.858952832119,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 14787.619004694636
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 14780.858952832119,
+                "components": 320,
+                "design_effect_upper_bound": 5.519018422760038,
+                "effective_components_lower_bound": 57.981324845799186,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 14780.858952832119,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 14787.619004694636
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 14780.858952832119,
+                "components": 320,
+                "design_effect_upper_bound": 10.038036845520075,
+                "effective_components_lower_bound": 31.878743316509578,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 10240,
+                "quadratic_exposure_upper_bound": 14780.858952832119,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 14787.619004694636
+              }
+            },
+            "components_per_corpus": 320,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 320,
+                "design_effect": 1.0,
+                "effective_components": 320.0,
+                "one_C_one": 320.0,
+                "quadratic_exposure": 1191.8097736076934,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 320,
+                "design_effect": 1.0681101385631009,
+                "effective_components": 299.594572176318,
+                "one_C_one": 341.7952443401923,
+                "quadratic_exposure": 1191.8097736076934,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 320,
+                "design_effect": 1.1362202771262022,
+                "effective_components": 281.6355300482434,
+                "one_C_one": 363.5904886803847,
+                "quadratic_exposure": 1191.8097736076934,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 320,
+                "design_effect": 1.2724405542524042,
+                "effective_components": 251.48522571886218,
+                "one_C_one": 407.18097736076936,
+                "quadratic_exposure": 1191.8097736076934,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 320,
+                "design_effect": 1.5448811085048084,
+                "effective_components": 207.13568069306478,
+                "one_C_one": 494.3619547215387,
+                "quadratic_exposure": 1191.8097736076934,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 3069
+          },
+          "512": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "050516adb9b021e5639158e88a086224e094e598fb89eebd60f2aea142ccf2f3",
+                "size_bytes": 13314
+              },
+              "counts_by_region_record": {
+                "sha256": "55b139dd82668d00f7d6d2652d6e533398c8bf99716720066e1e89fbfe66b93c",
+                "size_bytes": 2690
+              },
+              "quadratic_exposure": 3028.1810118987514,
+              "used_region_count": 96
+            },
+            "capacities_by_region_record": {
+              "sha256": "b3e20e9066afb58fb3a00e836f27152474b6d71bf0806b4b272ce5cf7c31cf57",
+              "size_bytes": 2786
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 37541.30392549736,
+                "components": 512,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 512.0,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 37541.30392549736,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 37566.90632696546
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 37541.30392549736,
+                "components": 512,
+                "design_effect_upper_bound": 2.808071480737176,
+                "effective_components_lower_bound": 182.33154088570052,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 37541.30392549736,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 37566.90632696546
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 37541.30392549736,
+                "components": 512,
+                "design_effect_upper_bound": 4.616142961474352,
+                "effective_components_lower_bound": 110.91510905816317,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 37541.30392549736,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 37566.90632696546
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 37541.30392549736,
+                "components": 512,
+                "design_effect_upper_bound": 8.232285922948703,
+                "effective_components_lower_bound": 62.19414689821754,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 37541.30392549736,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 37566.90632696546
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 37541.30392549736,
+                "components": 512,
+                "design_effect_upper_bound": 15.464571845897408,
+                "effective_components_lower_bound": 33.107932447274855,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 26014,
+                "quadratic_exposure_upper_bound": 37541.30392549736,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 37566.90632696546
+              }
+            },
+            "components_per_corpus": 512,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 512,
+                "design_effect": 1.0,
+                "effective_components": 512.0,
+                "one_C_one": 512.0,
+                "quadratic_exposure": 3028.1810118987514,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 512,
+                "design_effect": 1.1228604009716188,
+                "effective_components": 455.978320686136,
+                "one_C_one": 574.9045252974688,
+                "quadratic_exposure": 3028.1810118987514,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 512,
+                "design_effect": 1.2457208019432375,
+                "effective_components": 411.007024367993,
+                "one_C_one": 637.8090505949376,
+                "quadratic_exposure": 3028.1810118987514,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 512,
+                "design_effect": 1.491441603886475,
+                "effective_components": 343.2920193896993,
+                "one_C_one": 763.6181011898752,
+                "quadratic_exposure": 3028.1810118987514,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 512,
+                "design_effect": 1.98288320777295,
+                "effective_components": 258.20986228182664,
+                "one_C_one": 1015.2362023797504,
+                "quadratic_exposure": 3028.1810118987514,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 4850
+          },
+          "800": {
+            "allocation": {
+              "assignment_region_ids_record": {
+                "sha256": "b85be5b66efd929c685b0fa768ed9a3d127ffc4af73682b56650cdd6b66f93c9",
+                "size_bytes": 20802
+              },
+              "counts_by_region_record": {
+                "sha256": "23f2f99b1d948a4e4b9a0f5c65ef5920af3b1b92b983700048833650758974c0",
+                "size_bytes": 2690
+              },
+              "quadratic_exposure": 7376.74416058592,
+              "used_region_count": 96
+            },
+            "capacities_by_region_record": {
+              "sha256": "df8e348a370ac88211c01cf0fd047db88f933a982977f4dfe19a834e8453f173",
+              "size_bytes": 2786
+            },
+            "certified_mean_ess_lower_bound_by_rho": {
+              "0.0": {
+                "capacity_quadratic_upper_bound": 91514.11687747538,
+                "components": 800,
+                "design_effect_upper_bound": 1.0,
+                "effective_components_lower_bound": 800.0,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 91514.11687747538,
+                "rho": 0.0,
+                "spectral_quadratic_upper_bound": 92422.61877934147
+              },
+              "0.025": {
+                "capacity_quadratic_upper_bound": 91514.11687747538,
+                "components": 800,
+                "design_effect_upper_bound": 3.8348161524211055,
+                "effective_components_lower_bound": 208.6149552423579,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 91514.11687747538,
+                "rho": 0.025,
+                "spectral_quadratic_upper_bound": 92422.61877934147
+              },
+              "0.05": {
+                "capacity_quadratic_upper_bound": 91514.11687747538,
+                "components": 800,
+                "design_effect_upper_bound": 6.669632304842211,
+                "effective_components_lower_bound": 119.94664224880779,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 91514.11687747538,
+                "rho": 0.05,
+                "spectral_quadratic_upper_bound": 92422.61877934147
+              },
+              "0.1": {
+                "capacity_quadratic_upper_bound": 91514.11687747538,
+                "components": 800,
+                "design_effect_upper_bound": 12.339264609684422,
+                "effective_components_lower_bound": 64.8336854185073,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 91514.11687747538,
+                "rho": 0.1,
+                "spectral_quadratic_upper_bound": 92422.61877934147
+              },
+              "0.2": {
+                "capacity_quadratic_upper_bound": 91514.11687747538,
+                "components": 800,
+                "design_effect_upper_bound": 23.678529219368844,
+                "effective_components_lower_bound": 33.78588224751758,
+                "lambda_max_upper": 1.4441034184272104,
+                "lambda_max_upper_method": "maximum nonnegative row sum with outward float guard",
+                "maximum_feasible_sum_squares": 64000,
+                "quadratic_exposure_upper_bound": 91514.11687747538,
+                "rho": 0.2,
+                "spectral_quadratic_upper_bound": 92422.61877934147
+              }
+            },
+            "components_per_corpus": 800,
+            "exact_mean_ess_by_rho": {
+              "0.0": {
+                "components": 800,
+                "design_effect": 1.0,
+                "effective_components": 800.0,
+                "one_C_one": 800.0,
+                "quadratic_exposure": 7376.74416058592,
+                "rho": 0.0
+              },
+              "0.025": {
+                "components": 800,
+                "design_effect": 1.2055232550183101,
+                "effective_components": 663.6122502571294,
+                "one_C_one": 964.418604014648,
+                "quadratic_exposure": 7376.74416058592,
+                "rho": 0.025
+              },
+              "0.05": {
+                "components": 800,
+                "design_effect": 1.41104651003662,
+                "effective_components": 566.9550892261078,
+                "one_C_one": 1128.837208029296,
+                "quadratic_exposure": 7376.74416058592,
+                "rho": 0.05
+              },
+              "0.1": {
+                "components": 800,
+                "design_effect": 1.8220930200732404,
+                "effective_components": 439.05552086898587,
+                "one_C_one": 1457.6744160585922,
+                "quadratic_exposure": 7376.74416058592,
+                "rho": 0.1
+              },
+              "0.2": {
+                "components": 800,
+                "design_effect": 2.6441860401464807,
+                "effective_components": 302.5505724081662,
+                "one_C_one": 2115.3488321171844,
+                "quadratic_exposure": 7376.74416058592,
+                "rho": 0.2
+              }
+            },
+            "gates": {
+              "all_topology_gates_pass": true,
+              "allocation_respects_cap": true,
+              "allocation_supplies_exactly_G": true,
+              "capacity_supplies_all_components": true,
+              "exposure_and_correlation_path_valid": true,
+              "uses_at_least_20_source_regions": true
+            },
+            "optimistic_capacity_upper_bound": 7517
+          }
+        },
+        "rho_grid": [
+          0.0,
+          0.025,
+          0.05,
+          0.1,
+          0.2
+        ],
+        "target_region_count": 96,
+        "walk_weights": [
+          1.0,
+          0.5,
+          0.25,
+          0.125
+        ]
+      }
+    }
+  },
+  "schema_version": 1,
+  "status": "NO-SPEND SOURCE-DEPENDENCE STRUCTURAL BRIDGE DEFINED; DOWNSTREAM BLOCKED"
+}

--- a/prototypes/mu_cosine/run_repeated_judge_source_dependence.py
+++ b/prototypes/mu_cosine/run_repeated_judge_source_dependence.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""Audit topology-only dependence across full repeated-judge source regions.
+
+This command consumes only the two frozen canonical graphs.  It does not read
+historical labels, enumerate candidate triples, generate embeddings, or call a
+judge.  The narrow structural bridge does not itself authorize any downstream
+work: a completed audit exits with status 2 unless ``--audit-only`` is given.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import nullcontext
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import sys
+
+import numpy as np
+
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from repeated_judge_campaign import FROZEN_WALK_WEIGHTS, content_record
+from repeated_judge_candidate_capacity import (
+    ENDPOINTS_PER_COMPONENT,
+    SOURCE_COMPONENT_CAP_FRACTION,
+)
+from repeated_judge_source_dependence import audit_source_dependence
+from repeated_judge_source_regions import DEFAULT_REGION_COUNT_GRID
+from run_repeated_judge_candidate_capacity import (
+    REGISTERED_COMPONENT_SIZES,
+    load_frozen_graphs,
+)
+
+
+SCHEMA_VERSION = 1
+ALGORITHM = "repeated-judge-topology-source-dependence-bridge-v1"
+REQUIRED_CORPORA = ("exploratory", "fresh")
+FROZEN_RHO_GRID = (0.0, 0.025, 0.05, 0.10, 0.20)
+IMPLEMENTATION_FILES = (
+    "repeated_judge_source_dependence.py",
+    "run_repeated_judge_source_dependence.py",
+    "repeated_judge_source_regions.py",
+    "repeated_judge_candidate_capacity.py",
+    "run_repeated_judge_candidate_capacity.py",
+    "repeated_judge_campaign.py",
+    "graph_geometry.py",
+    "sample_sigma_hop_fresh_corpus.py",
+    "sigma_hop_confirmatory.py",
+    "run_product_kalman_realdata.py",
+    "run_structured_residual_covariance.py",
+    "mu_attention.py",
+    "lmdb_id.py",
+    "DESIGN_repeated_judge_source_dependence.md",
+    "PREREG_graph_geometry_repeated_judge.md",
+)
+
+
+def _json_bytes(value):
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _implementation_records(root=HERE):
+    root = Path(root)
+    return {
+        name: content_record((root / name).read_bytes())
+        for name in IMPLEMENTATION_FILES
+    }
+
+
+def _assert_implementation_unchanged(expected):
+    current = _implementation_records()
+    if current != expected:
+        changed = sorted(
+            name
+            for name in set(expected) | set(current)
+            if expected.get(name) != current.get(name)
+        )
+        raise RuntimeError(
+            "implementation or protocol provenance changed during source-dependence audit: "
+            + ", ".join(changed)
+        )
+
+
+def _assert_graph_inputs_unchanged(expected, current):
+    if current != expected:
+        raise RuntimeError(
+            "external graph content provenance changed during source-dependence audit"
+        )
+
+
+def _portable_blas_runtime(records):
+    """Keep numerical runtime identity while excluding host-specific paths."""
+    fields = (
+        "user_api",
+        "internal_api",
+        "prefix",
+        "version",
+        "threading_layer",
+        "architecture",
+    )
+    return sorted(
+        ({field: record.get(field) for field in fields} for record in records),
+        key=lambda record: tuple(str(record[field]) for field in fields),
+    )
+
+
+def _blas_runtime_identity():
+    try:
+        from threadpoolctl import threadpool_info
+    except ImportError:
+        return []
+    return _portable_blas_runtime(threadpool_info())
+
+
+def _single_blas_thread_context():
+    try:
+        from threadpoolctl import threadpool_limits
+    except ImportError:
+        return nullcontext()
+    return threadpool_limits(limits=1, user_api="blas")
+
+
+def _graph_bundle_record(graph_inputs):
+    canonical = json.dumps(
+        graph_inputs,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return content_record(canonical)
+
+
+def _canonical_value_record(value):
+    data = (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+    return content_record(data)
+
+
+def _summary_projection(payload):
+    """Return a reviewable projection with hashes for bulky exact arrays."""
+    full_bytes = _json_bytes(payload)
+    summary = json.loads(full_bytes)
+    summary["artifact_projection"] = "tracked-summary-v1"
+    summary["full_payload_record"] = content_record(full_bytes)
+    for corpus_results in summary.get("results", {}).values():
+        for audit in corpus_results.values():
+            exposure = audit.get("exposure", {})
+            if "matrix" in exposure:
+                matrix = exposure.pop("matrix")
+                exposure["matrix_shape"] = [len(matrix), len(matrix)]
+                exposure["matrix_record"] = _canonical_value_record(matrix)
+            for size_result in audit.get("registered_size_results", {}).values():
+                if "capacities_by_region" in size_result:
+                    capacities = size_result.pop("capacities_by_region")
+                    size_result["capacities_by_region_record"] = (
+                        _canonical_value_record(capacities)
+                    )
+                allocation = size_result.get("allocation")
+                if not isinstance(allocation, dict):
+                    continue
+                for key in ("counts_by_region", "assignment_region_ids"):
+                    if key in allocation:
+                        value = allocation.pop(key)
+                        allocation[f"{key}_record"] = _canonical_value_record(value)
+    return summary
+
+
+def _positive_unique_ints(values, label):
+    values = tuple(values)
+    if not values or any(
+        isinstance(value, bool) or not isinstance(value, int) or value < 1
+        for value in values
+    ):
+        raise ValueError(f"{label} must contain positive non-bool integers")
+    if len(set(values)) != len(values):
+        raise ValueError(f"{label} must be unique")
+    if tuple(sorted(values)) != values:
+        raise ValueError(f"{label} must be increasing")
+    return values
+
+
+def _rho_grid(values):
+    values = tuple(values)
+    if not values:
+        raise ValueError("rho_grid must be nonempty")
+    output = []
+    for value in values:
+        if isinstance(value, bool):
+            raise ValueError("rho_grid must contain finite numbers in [0,1)")
+        try:
+            value = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("rho_grid must contain finite numbers in [0,1)") from exc
+        if not math.isfinite(value) or not 0.0 <= value < 1.0:
+            raise ValueError("rho_grid must contain finite numbers in [0,1)")
+        output.append(value)
+    output = tuple(output)
+    if len(set(output)) != len(output):
+        raise ValueError("rho_grid must be unique")
+    if tuple(sorted(output)) != output:
+        raise ValueError("rho_grid must be increasing")
+    if output[0] != 0.0:
+        raise ValueError("rho_grid must start at zero")
+    return output
+
+
+def _audit_passes(audit, *, corpus, region_count):
+    if not isinstance(audit, dict):
+        raise RuntimeError(
+            f"{corpus} K={region_count} source-dependence audit is not an object"
+        )
+    gates = audit.get("gates")
+    if not isinstance(gates, dict):
+        raise RuntimeError(
+            f"{corpus} K={region_count} source-dependence audit lacks gates"
+        )
+    passed = gates.get("all_registered_sizes_pass")
+    if not isinstance(passed, bool):
+        raise RuntimeError(
+            f"{corpus} K={region_count} all_registered_sizes_pass must be boolean"
+        )
+    return passed
+
+
+def build_source_dependence_payload(
+    graphs,
+    graph_inputs,
+    *,
+    region_count_grid=DEFAULT_REGION_COUNT_GRID,
+    registered_sizes=REGISTERED_COMPONENT_SIZES,
+    rho_grid=FROZEN_RHO_GRID,
+    implementation=None,
+    loader_metadata=None,
+):
+    """Build portable topology-only source-dependence audit JSON."""
+    if set(graphs) != set(REQUIRED_CORPORA):
+        raise ValueError("graphs must contain exactly exploratory and fresh")
+    if set(graph_inputs) != set(REQUIRED_CORPORA):
+        raise ValueError("graph_inputs must align exactly with graphs")
+    region_count_grid = _positive_unique_ints(
+        region_count_grid, "region_count_grid"
+    )
+    registered_sizes = _positive_unique_ints(
+        registered_sizes, "registered_sizes"
+    )
+    rho_grid = _rho_grid(rho_grid)
+
+    verify_live_implementation = implementation is None
+    implementation_snapshot = (
+        _implementation_records() if implementation is None else implementation
+    )
+    results = {
+        corpus: {
+            str(region_count): audit_source_dependence(
+                graphs[corpus]["parents"],
+                graphs[corpus]["children"],
+                region_count,
+                registered_sizes,
+                rho_grid=rho_grid,
+            )
+            for region_count in region_count_grid
+        }
+        for corpus in REQUIRED_CORPORA
+    }
+
+    joint_grid = {}
+    jointly_passing_region_counts = []
+    for region_count in region_count_grid:
+        key = str(region_count)
+        passing_corpora = [
+            corpus
+            for corpus in REQUIRED_CORPORA
+            if _audit_passes(
+                results[corpus][key],
+                corpus=corpus,
+                region_count=region_count,
+            )
+        ]
+        joint_passes = len(passing_corpora) == len(REQUIRED_CORPORA)
+        joint_grid[key] = {
+            "passing_corpora": passing_corpora,
+            "required_corpora": list(REQUIRED_CORPORA),
+            "joint_narrow_structural_gate_passes": joint_passes,
+        }
+        if joint_passes:
+            jointly_passing_region_counts.append(region_count)
+
+    bridge_defined = bool(jointly_passing_region_counts)
+    if bridge_defined:
+        status = "NO-SPEND SOURCE-DEPENDENCE STRUCTURAL BRIDGE DEFINED; DOWNSTREAM BLOCKED"
+        reason = (
+            "at least one identical frozen region count passes the narrow full-region "
+            "capacity, allocation, and PSD gates in both required corpora; this audit "
+            "does not include full-procedure source-dependent null calibration or power"
+        )
+    else:
+        status = "NO-SPEND SOURCE-DEPENDENCE STRUCTURAL BRIDGE FAILED; DOWNSTREAM BLOCKED"
+        reason = (
+            "no identical frozen region count passes every narrow full-region structural "
+            "gate in both required corpora"
+        )
+
+    metadata = loader_metadata or {}
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "algorithm": ALGORITHM,
+        "authorization": {
+            "historical_inventory_unlocked": False,
+            "candidate_enumeration_unlocked": False,
+            "nomic_embedding_unlocked": False,
+            "candidate_builder_unlocked": False,
+            "judge_calls_authorized": False,
+            "live_campaign_authorized": False,
+            "covariance_deployment_unlocked": False,
+            "independent_batching_unlocked": False,
+            "qr_specialization_unlocked": False,
+            "cuda_claim_unlocked": False,
+        },
+        "configuration": {
+            "required_corpora": list(REQUIRED_CORPORA),
+            "registered_components_per_corpus": list(registered_sizes),
+            "region_count_grid": list(region_count_grid),
+            "rho_grid": list(rho_grid),
+            "region_count_selection_performed": False,
+            "all_jointly_passing_region_counts_continue": True,
+            "partition_inputs": "canonical undirected graph topology only",
+            "full_source_regions_used_without_halo_exclusion": True,
+            "source_region_cap_fraction": SOURCE_COMPONENT_CAP_FRACTION,
+            "endpoints_charged_per_campaign_component": ENDPOINTS_PER_COMPONENT,
+            "cumulative_walk_weights": list(FROZEN_WALK_WEIGHTS),
+            "source_regions_claimed_independent": False,
+            "true_weak_component_retained_as_separate_diagnostic": True,
+            "graph_inputs_required_immutable_during_run": True,
+            "external_graph_records_recheck_required_before_write": True,
+        },
+        "numerical_runtime": {
+            "python_version": platform.python_version(),
+            "numpy_version": np.__version__,
+            "blas_runtime": _blas_runtime_identity(),
+            "blas_thread_limit_policy": (
+                "CLI audit requests one BLAS thread via threadpoolctl when available"
+            ),
+        },
+        "implementation_and_protocol": implementation_snapshot,
+        "inputs": {
+            "graph_bundle": _graph_bundle_record(graph_inputs),
+            "graphs": graph_inputs,
+            "outcomes_consumed": False,
+            "historical_inventory_consumed": False,
+            "nomic_cache_consumed": False,
+            "candidate_pool_consumed": False,
+            "judge_responses_consumed": False,
+        },
+        "loader_metadata": {
+            corpus: dict(metadata.get(corpus, {}))
+            for corpus in REQUIRED_CORPORA
+        },
+        "results": results,
+        "joint_region_count_grid": joint_grid,
+        "decision": {
+            "structural_bridge_defined": bridge_defined,
+            "jointly_passing_region_counts": jointly_passing_region_counts,
+            "region_count_selected": None,
+            "downstream_pipeline_must_stop": True,
+            "candidate_builder_must_stop": True,
+            "reason": reason,
+            "required_next_action": (
+                "extend the complete repeated-judge null and power procedure with "
+                "source-atomic folds, registered source exposure, prompt incidence, and "
+                "two-way prompt/source inference before unlocking history or candidates"
+            ),
+        },
+        "non_claims": [
+            "source regions are concentration and dependence-sensitivity units, not independent observations",
+            "region-average topology exposure is not empirical residual covariance or a candidate-level upper bound",
+            "effective component counts are information diagnostics, not power calculations",
+            "the greedy allocation is a prospective diagnostic quota, not exact candidate packability",
+            "no region count is selected or ranked by this audit",
+            "no historical attempted-input identity inventory was consumed or unlocked",
+            "no embedding model, candidate builder, judge, covariance conditioner, QR specialization, or CUDA kernel ran",
+        ],
+    }
+    if verify_live_implementation:
+        _assert_implementation_unchanged(implementation_snapshot)
+    return payload
+
+
+def _atomic_write(path, payload):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    data = _json_bytes(payload)
+    try:
+        temporary.write_bytes(data)
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return content_record(data)
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-repo", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--lmdb-no-lock", action="store_true")
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help=(
+            "write a reviewable projection with content records for bulky exact "
+            "matrices/quotas; scientific computation and decisions are unchanged"
+        ),
+    )
+    parser.add_argument(
+        "--audit-only",
+        action="store_true",
+        help="return zero after the blocked audit; does not unlock anything",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    implementation = _implementation_records()
+    graphs, graph_inputs, metadata = load_frozen_graphs(
+        args.artifact_repo, lmdb_no_lock=args.lmdb_no_lock
+    )
+    with _single_blas_thread_context():
+        payload = build_source_dependence_payload(
+            graphs,
+            graph_inputs,
+            implementation=implementation,
+            loader_metadata=metadata,
+        )
+    del graphs
+    end_graphs, end_graph_inputs, end_metadata = load_frozen_graphs(
+        args.artifact_repo, lmdb_no_lock=args.lmdb_no_lock
+    )
+    del end_graphs
+    _assert_graph_inputs_unchanged(graph_inputs, end_graph_inputs)
+    if end_metadata != metadata:
+        raise RuntimeError(
+            "external graph loader metadata changed during source-dependence audit"
+        )
+    _assert_implementation_unchanged(implementation)
+    output_payload = _summary_projection(payload) if args.summary_only else payload
+    artifact = _atomic_write(args.out, output_payload)
+    print(
+        json.dumps(
+            {
+                "output": os.path.abspath(args.out),
+                "artifact": artifact,
+                "artifact_projection": output_payload.get(
+                    "artifact_projection", "complete"
+                ),
+                "full_payload_record": (
+                    output_payload.get("full_payload_record")
+                    if args.summary_only
+                    else content_record(_json_bytes(payload))
+                ),
+                "structural_bridge_defined": payload["decision"][
+                    "structural_bridge_defined"
+                ],
+                "jointly_passing_region_counts": payload["decision"][
+                    "jointly_passing_region_counts"
+                ],
+                "downstream_pipeline_must_stop": True,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    if not args.audit_only:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_repeated_judge_source_dependence.py
+++ b/prototypes/mu_cosine/test_repeated_judge_source_dependence.py
@@ -1,0 +1,225 @@
+"""Tests for the topology-only repeated-judge source-dependence bridge."""
+
+from dataclasses import replace
+import math
+
+import numpy as np
+import pytest
+
+from repeated_judge_source_dependence import (
+    RegionExposure,
+    SourceDependenceError,
+    audit_source_dependence,
+    build_region_exposure,
+    certified_ess_lower_bound,
+    component_correlation_matrix,
+    compute_per_hop_outside_landing_mass,
+    exact_mean_ess,
+    exposure_aware_greedy_allocation,
+    full_region_capacities,
+)
+from graph_geometry import cumulative_walk_feature_map
+from repeated_judge_source_regions import build_source_region_partition
+
+
+def graph_from_edges(nodes, edges, *, reverse=False):
+    parents = {node: set() for node in nodes}
+    children = {node: set() for node in nodes}
+    for child, parent in edges:
+        parents[child].add(parent)
+        children[parent].add(child)
+    if reverse:
+        parents = dict(reversed(list(parents.items())))
+        children = dict(reversed(list(children.items())))
+    return parents, children
+
+
+def line_graph(size, *, reverse=False):
+    nodes = [f"n{index:03d}" for index in range(size)]
+    return graph_from_edges(
+        nodes,
+        [(nodes[index + 1], nodes[index]) for index in range(size - 1)],
+        reverse=reverse,
+    )
+
+
+def manual_exposure(matrix):
+    matrix = np.asarray(matrix, dtype=float)
+    region_ids = tuple(f"r{index}" for index in range(len(matrix)))
+    return RegionExposure(
+        region_ids,
+        matrix,
+        (1.0,),
+        tuple((0.0,) for _ in region_ids),
+        (0.0,),
+    )
+
+
+def test_exposure_is_psd_unit_diagonal_and_input_order_invariant():
+    first_graph = line_graph(18)
+    second_graph = line_graph(18, reverse=True)
+    first_partition = build_source_region_partition(*first_graph, 3, halo_hops=0)
+    second_partition = build_source_region_partition(*second_graph, 3, halo_hops=0)
+    first = build_region_exposure(*first_graph, first_partition)
+    second = build_region_exposure(*second_graph, second_partition)
+    assert first.region_ids == second.region_ids
+    assert np.array_equal(first.matrix, second.matrix)
+    assert np.allclose(first.matrix, first.matrix.T, atol=1e-14)
+    assert np.allclose(np.diag(first.matrix), 1.0, atol=1e-14)
+    assert np.min(first.matrix) >= 0.0
+    assert np.linalg.eigvalsh(first.matrix)[0] >= -1e-12
+    assert first.matrix.flags.writeable is False
+
+
+def test_per_hop_outside_landing_handles_boundaries_and_isolated_self_mass():
+    edge_graph = graph_from_edges(["a", "b"], [("b", "a")])
+    edge_partition = build_source_region_partition(*edge_graph, 2, halo_hops=0)
+    edge = compute_per_hop_outside_landing_mass(
+        *edge_graph, edge_partition, walk_weights=(1.0, 1.0)
+    )
+    assert edge["mean_by_hop"] == [0.0, 1.0]
+
+    isolated_graph = graph_from_edges(["a", "b"], [])
+    isolated_partition = build_source_region_partition(
+        *isolated_graph, 2, halo_hops=0
+    )
+    isolated = compute_per_hop_outside_landing_mass(
+        *isolated_graph, isolated_partition, walk_weights=(1.0, 1.0, 1.0)
+    )
+    assert isolated["mean_by_hop"] == [0.0, 0.0, 0.0]
+
+
+def test_region_aggregation_matches_canonical_cumulative_walk_features():
+    graph = line_graph(18)
+    partition = build_source_region_partition(*graph, 3, halo_hops=0)
+    exposure = build_region_exposure(*graph, partition)
+    nodes = tuple(sorted(graph[0]))
+    adjacency = {
+        node: set(graph[0][node]) | set(graph[1][node]) for node in nodes
+    }
+    node_features, _basis = cumulative_walk_feature_map(
+        nodes, adjacency, exposure.walk_weights
+    )
+    node_index = {node: index for index, node in enumerate(nodes)}
+    regional = np.vstack([
+        np.asarray(
+            node_features[
+                [node_index[node] for node in partition.region_nodes[region]]
+            ].mean(axis=0)
+        ).ravel()
+        for region in exposure.region_ids
+    ])
+    regional /= np.linalg.norm(regional, axis=1, keepdims=True)
+    direct = regional @ regional.T
+    assert np.allclose(exposure.matrix, direct, atol=2e-15, rtol=0.0)
+
+
+def test_full_region_caps_and_exposure_aware_greedy_allocation():
+    graph = line_graph(80)
+    partition = build_source_region_partition(*graph, 10, halo_hops=0)
+    capacities = full_region_capacities(partition, 20)
+    assert set(capacities.values()) == {2}
+    assert sum(capacities.values()) == 20
+
+    exposure = manual_exposure([
+        [1.0, 0.9, 0.0],
+        [0.9, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ])
+    allocation = exposure_aware_greedy_allocation(
+        exposure, {"r0": 2, "r1": 2, "r2": 2}, 3
+    )
+    assert allocation["assignment_region_ids"] == ["r0", "r2", "r1"]
+    assert allocation["counts_by_region"] == {"r0": 1, "r1": 1, "r2": 1}
+    assert allocation["quadratic_exposure"] == pytest.approx(4.8)
+
+
+def test_exact_mean_ess_matches_materialized_component_correlation():
+    exposure = manual_exposure(np.eye(3))
+    allocation = {"r0": 2, "r1": 1, "r2": 0}
+    result = exact_mean_ess(exposure, allocation, 0.2)
+    correlation = component_correlation_matrix(exposure, allocation, 0.2)
+    direct = float(np.ones(3) @ correlation @ np.ones(3))
+    assert result["quadratic_exposure"] == 5.0
+    assert result["one_C_one"] == pytest.approx(direct)
+    assert result["effective_components"] == pytest.approx(9.0 / direct)
+    assert np.allclose(np.diag(correlation), 1.0)
+    assert np.linalg.eigvalsh(correlation)[0] >= -1e-12
+
+
+def test_certified_bound_covers_every_small_cap_feasible_allocation():
+    exposure = manual_exposure([
+        [1.0, 0.7, 0.2],
+        [0.7, 1.0, 0.4],
+        [0.2, 0.4, 1.0],
+    ])
+    capacities = {"r0": 2, "r1": 2, "r2": 2}
+    bound = certified_ess_lower_bound(exposure, capacities, 3, 0.2)
+    for left in range(3):
+        for middle in range(3):
+            right = 3 - left - middle
+            if 0 <= right <= 2:
+                allocation = {"r0": left, "r1": middle, "r2": right}
+                exact = exact_mean_ess(exposure, allocation, 0.2)
+                assert exact["quadratic_exposure"] <= (
+                    bound["quadratic_exposure_upper_bound"] + 1e-12
+                )
+                assert exact["effective_components"] >= (
+                    bound["effective_components_lower_bound"] - 1e-12
+                )
+
+
+def test_row_sum_bound_covers_fully_coherent_exposure():
+    exposure = manual_exposure(np.ones((3, 3)))
+    capacities = {"r0": 2, "r1": 2, "r2": 2}
+    bound = certified_ess_lower_bound(exposure, capacities, 3, 0.2)
+    exact = exact_mean_ess(exposure, {"r0": 1, "r1": 1, "r2": 1}, 0.2)
+    assert bound["lambda_max_upper"] >= 3.0
+    assert "row sum" in bound["lambda_max_upper_method"]
+    assert bound["quadratic_exposure_upper_bound"] >= 9.0
+    assert bound["effective_components_lower_bound"] <= exact[
+        "effective_components"
+    ]
+
+
+def test_audit_covers_registered_grid_and_keeps_authorization_false():
+    audit = audit_source_dependence(
+        *line_graph(80),
+        20,
+        (20,),
+        rho_grid=(0.0, 0.2),
+    )
+    row = audit["registered_size_results"]["20"]
+    assert row["gates"]["all_topology_gates_pass"] is True
+    assert audit["gates"]["all_registered_sizes_pass"] is True
+    assert row["exact_mean_ess_by_rho"]["0.0"]["effective_components"] == 20
+    assert row["certified_mean_ess_lower_bound_by_rho"]["0.2"][
+        "effective_components_lower_bound"
+    ] <= row["exact_mean_ess_by_rho"]["0.2"]["effective_components"]
+    assert all(value is False for value in audit["authorization"].values())
+
+
+def test_malformed_inputs_fail_closed():
+    graph = line_graph(12)
+    partition = build_source_region_partition(*graph, 3, halo_hops=0)
+    with pytest.raises(SourceDependenceError, match="SourceRegionPartition"):
+        build_region_exposure(*graph, object())
+    with pytest.raises(SourceDependenceError, match="walk weights"):
+        build_region_exposure(*graph, partition, walk_weights=(1.0, -1.0))
+    broken = replace(partition, assignment={})
+    with pytest.raises(SourceDependenceError, match="assignment disagrees"):
+        build_region_exposure(*graph, broken)
+
+    exposure = manual_exposure(np.eye(2))
+    with pytest.raises(SourceDependenceError, match="every canonical region"):
+        exposure_aware_greedy_allocation(exposure, {"r0": 2}, 2)
+    with pytest.raises(SourceDependenceError, match="cannot allocate"):
+        exposure_aware_greedy_allocation(
+            exposure, {"r0": 0, "r1": 1}, 2
+        )
+    with pytest.raises(SourceDependenceError, match=r"\[0,1\]"):
+        exact_mean_ess(exposure, {"r0": 1, "r1": 1}, 1.1)
+    with pytest.raises(SourceDependenceError, match="unique positive"):
+        audit_source_dependence(*graph, 3, (20, 20))
+    with pytest.raises(SourceDependenceError, match="unique values"):
+        audit_source_dependence(*graph, 3, (20,), rho_grid=(0.1, 0.1))

--- a/prototypes/mu_cosine/test_run_repeated_judge_source_dependence.py
+++ b/prototypes/mu_cosine/test_run_repeated_judge_source_dependence.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Tests for the portable topology-only source-dependence runner."""
+
+import json
+
+import pytest
+
+import run_repeated_judge_source_dependence as runner
+
+
+def graph(label):
+    node = f"node-{label}"
+    return {"parents": {node: set()}, "children": {node: set()}}
+
+
+def record(character):
+    return {"size_bytes": 1, "sha256": character * 64}
+
+
+def graph_inputs():
+    return {
+        "exploratory": {
+            "corpus_identity": "fixture-a",
+            "artifacts": {"graph": record("a")},
+        },
+        "fresh": {
+            "corpus_identity": "fixture-b",
+            "artifacts": {"graph": record("b")},
+        },
+    }
+
+
+def fake_audit(passing):
+    def audit(parents, _children, region_count, registered_sizes, *, rho_grid):
+        corpus = "exploratory" if "node-exploratory" in parents else "fresh"
+        passed = bool(passing.get((corpus, region_count), False))
+        return {
+            "target_region_count": region_count,
+            "rho_grid": list(rho_grid),
+            "registered_size_results": {
+                str(size): {
+                    "components_per_corpus": size,
+                    "gates": {"all_topology_gates_pass": passed},
+                }
+                for size in registered_sizes
+            },
+            "gates": {"all_registered_sizes_pass": passed},
+        }
+
+    return audit
+
+
+def build(monkeypatch, passing, **kwargs):
+    monkeypatch.setattr(runner, "audit_source_dependence", fake_audit(passing))
+    return runner.build_source_dependence_payload(
+        {
+            "exploratory": graph("exploratory"),
+            "fresh": graph("fresh"),
+        },
+        graph_inputs(),
+        implementation={"fixture.py": record("c")},
+        **kwargs,
+    )
+
+
+def test_same_region_count_must_pass_both_corpora_and_no_count_is_selected(monkeypatch):
+    payload = build(
+        monkeypatch,
+        {
+            ("exploratory", 64): True,
+            ("fresh", 96): True,
+        },
+        region_count_grid=(64, 96),
+        registered_sizes=(160,),
+    )
+    assert payload["decision"]["structural_bridge_defined"] is False
+    assert payload["decision"]["jointly_passing_region_counts"] == []
+    assert payload["decision"]["region_count_selected"] is None
+    assert payload["joint_region_count_grid"]["64"]["passing_corpora"] == [
+        "exploratory"
+    ]
+    assert payload["joint_region_count_grid"]["96"]["passing_corpora"] == [
+        "fresh"
+    ]
+
+
+def test_joint_structural_pass_unlocks_nothing(monkeypatch):
+    payload = build(
+        monkeypatch,
+        {
+            ("exploratory", 64): True,
+            ("fresh", 64): True,
+            ("exploratory", 96): True,
+            ("fresh", 96): True,
+        },
+        region_count_grid=(64, 96),
+        registered_sizes=(160,),
+    )
+    assert payload["decision"]["structural_bridge_defined"] is True
+    assert payload["decision"]["jointly_passing_region_counts"] == [64, 96]
+    assert payload["configuration"]["region_count_selection_performed"] is False
+    assert payload["configuration"]["all_jointly_passing_region_counts_continue"] is True
+    assert payload["decision"]["downstream_pipeline_must_stop"] is True
+    assert all(value is False for value in payload["authorization"].values())
+    assert payload["authorization"]["historical_inventory_unlocked"] is False
+
+
+def test_default_scientific_grid_is_passed_to_exactly_both_corpora(monkeypatch):
+    calls = []
+
+    def audit(parents, _children, region_count, registered_sizes, *, rho_grid):
+        corpus = "exploratory" if "node-exploratory" in parents else "fresh"
+        calls.append((corpus, region_count, tuple(registered_sizes), tuple(rho_grid)))
+        return {"gates": {"all_registered_sizes_pass": True}}
+
+    monkeypatch.setattr(runner, "audit_source_dependence", audit)
+    payload = runner.build_source_dependence_payload(
+        {
+            "exploratory": graph("exploratory"),
+            "fresh": graph("fresh"),
+        },
+        graph_inputs(),
+        implementation={"fixture.py": record("c")},
+    )
+    assert set(calls) == {
+        (corpus, region_count, (160, 320, 512, 800), runner.FROZEN_RHO_GRID)
+        for corpus in ("exploratory", "fresh")
+        for region_count in (64, 96, 128)
+    }
+    assert payload["configuration"]["region_count_grid"] == [64, 96, 128]
+    assert payload["configuration"]["registered_components_per_corpus"] == [
+        160, 320, 512, 800
+    ]
+    assert payload["configuration"]["rho_grid"] == [0.0, 0.025, 0.05, 0.1, 0.2]
+
+
+def test_payload_is_deterministic_portable_and_atomic(monkeypatch, tmp_path):
+    passing = {("exploratory", 8): True, ("fresh", 8): True}
+    first = build(
+        monkeypatch,
+        passing,
+        region_count_grid=(8,),
+        registered_sizes=(20,),
+        rho_grid=(0.0, 0.2),
+    )
+    second = build(
+        monkeypatch,
+        passing,
+        region_count_grid=(8,),
+        registered_sizes=(20,),
+        rho_grid=(0.0, 0.2),
+    )
+    assert first == second
+    data = runner._json_bytes(first)
+    assert str(tmp_path).encode() not in data
+    output = tmp_path / "nested" / "audit.json"
+    assert runner._atomic_write(output, first) == runner._atomic_write(output, second)
+    assert output.read_bytes() == data
+    assert not output.with_name("audit.json.tmp").exists()
+    loaded = json.loads(data)
+    assert loaded["inputs"]["outcomes_consumed"] is False
+    assert loaded["inputs"]["historical_inventory_consumed"] is False
+    assert loaded["inputs"]["nomic_cache_consumed"] is False
+    assert loaded["inputs"]["candidate_pool_consumed"] is False
+    assert loaded["inputs"]["judge_responses_consumed"] is False
+
+
+def test_summary_projection_hashes_bulky_exact_arrays(monkeypatch):
+    passing = {("exploratory", 8): True, ("fresh", 8): True}
+    payload = build(
+        monkeypatch,
+        passing,
+        region_count_grid=(8,),
+        registered_sizes=(20,),
+        rho_grid=(0.0, 0.2),
+    )
+    for corpus in ("exploratory", "fresh"):
+        audit = payload["results"][corpus]["8"]
+        audit["exposure"] = {"matrix": [[1.0, 0.2], [0.2, 1.0]]}
+        row = audit["registered_size_results"]["20"]
+        row["capacities_by_region"] = {"r0": 10, "r1": 10}
+        row["allocation"] = {
+            "counts_by_region": {"r0": 10, "r1": 10},
+            "assignment_region_ids": ["r0"] * 10 + ["r1"] * 10,
+            "used_region_count": 2,
+        }
+    projected = runner._summary_projection(payload)
+    assert projected["artifact_projection"] == "tracked-summary-v1"
+    assert projected["full_payload_record"] == runner.content_record(
+        runner._json_bytes(payload)
+    )
+    for corpus in ("exploratory", "fresh"):
+        audit = projected["results"][corpus]["8"]
+        assert "matrix" not in audit["exposure"]
+        assert audit["exposure"]["matrix_shape"] == [2, 2]
+        row = audit["registered_size_results"]["20"]
+        assert "capacities_by_region" not in row
+        assert "counts_by_region" not in row["allocation"]
+        assert "assignment_region_ids" not in row["allocation"]
+        assert all(
+            record["size_bytes"] > 0 and len(record["sha256"]) == 64
+            for record in (
+                audit["exposure"]["matrix_record"],
+                row["capacities_by_region_record"],
+                row["allocation"]["counts_by_region_record"],
+                row["allocation"]["assignment_region_ids_record"],
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs,message",
+    [
+        ({"region_count_grid": ()}, "positive"),
+        ({"region_count_grid": (8, 8)}, "unique"),
+        ({"region_count_grid": (16, 8)}, "increasing"),
+        ({"registered_sizes": (True,)}, "positive"),
+        ({"registered_sizes": (20, 10)}, "increasing"),
+        ({"rho_grid": ()}, "nonempty"),
+        ({"rho_grid": (0.0, 0.0)}, "unique"),
+        ({"rho_grid": (0.0, 0.2, 0.1)}, "increasing"),
+        ({"rho_grid": (0.1, 0.2)}, "start at zero"),
+        ({"rho_grid": (0.0, True)}, "finite numbers"),
+        ({"rho_grid": (0.0, 1.0)}, r"\[0,1\)"),
+        ({"rho_grid": (0.0, float("nan"))}, "finite numbers"),
+    ],
+)
+def test_invalid_grids_fail_closed(monkeypatch, kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        build(monkeypatch, {}, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "graphs,inputs,message",
+    [
+        ({"exploratory": graph("exploratory")}, graph_inputs(), "exactly"),
+        (
+            {"exploratory": graph("exploratory"), "fresh": graph("fresh")},
+            {"exploratory": graph_inputs()["exploratory"]},
+            "align exactly",
+        ),
+    ],
+)
+def test_both_corpora_are_required(monkeypatch, graphs, inputs, message):
+    monkeypatch.setattr(runner, "audit_source_dependence", fake_audit({}))
+    with pytest.raises(ValueError, match=message):
+        runner.build_source_dependence_payload(
+            graphs,
+            inputs,
+            implementation={"fixture.py": record("c")},
+        )
+
+
+def test_malformed_module_gate_fails_closed(monkeypatch):
+    monkeypatch.setattr(
+        runner,
+        "audit_source_dependence",
+        lambda *_args, **_kwargs: {"gates": {"all_registered_sizes_pass": 1}},
+    )
+    with pytest.raises(RuntimeError, match="must be boolean"):
+        runner.build_source_dependence_payload(
+            {
+                "exploratory": graph("exploratory"),
+                "fresh": graph("fresh"),
+            },
+            graph_inputs(),
+            region_count_grid=(8,),
+            registered_sizes=(20,),
+            implementation={"fixture.py": record("c")},
+        )
+
+
+def test_default_and_audit_only_exit_behavior(monkeypatch, tmp_path):
+    implementation = {"source.py": record("a")}
+    payload = {
+        "decision": {
+            "structural_bridge_defined": True,
+            "jointly_passing_region_counts": [64],
+        }
+    }
+    monkeypatch.setattr(runner, "_implementation_records", lambda: implementation)
+    monkeypatch.setattr(
+        runner,
+        "load_frozen_graphs",
+        lambda *_args, **_kwargs: ({}, {}, {}),
+    )
+    monkeypatch.setattr(
+        runner,
+        "build_source_dependence_payload",
+        lambda *_args, **_kwargs: payload,
+    )
+    blocked = tmp_path / "blocked.json"
+    assert runner.main(["--artifact-repo", "unused", "--out", str(blocked)]) == 2
+    report = tmp_path / "report.json"
+    assert runner.main(
+        ["--artifact-repo", "unused", "--out", str(report), "--audit-only"]
+    ) == 0
+    assert blocked.read_bytes() == report.read_bytes()
+
+
+def test_direct_payload_fails_if_scientific_records_change(monkeypatch):
+    records = iter(
+        [
+            {"source.py": record("a")},
+            {"source.py": record("b")},
+        ]
+    )
+    monkeypatch.setattr(runner, "_implementation_records", lambda: next(records))
+    monkeypatch.setattr(runner, "audit_source_dependence", fake_audit({}))
+    with pytest.raises(RuntimeError, match="provenance changed"):
+        runner.build_source_dependence_payload(
+            {
+                "exploratory": graph("exploratory"),
+                "fresh": graph("fresh"),
+            },
+            graph_inputs(),
+            region_count_grid=(8,),
+            registered_sizes=(20,),
+        )
+
+
+def test_main_rechecks_scientific_records_before_writing(monkeypatch, tmp_path):
+    records = iter(
+        [
+            {"source.py": record("a")},
+            {"source.py": record("b")},
+        ]
+    )
+    monkeypatch.setattr(runner, "_implementation_records", lambda: next(records))
+    monkeypatch.setattr(
+        runner,
+        "load_frozen_graphs",
+        lambda *_args, **_kwargs: ({}, {}, {}),
+    )
+    monkeypatch.setattr(
+        runner,
+        "build_source_dependence_payload",
+        lambda *_args, **_kwargs: {
+            "decision": {
+                "structural_bridge_defined": False,
+                "jointly_passing_region_counts": [],
+            }
+        },
+    )
+    output = tmp_path / "must-not-exist.json"
+    with pytest.raises(RuntimeError, match="provenance changed"):
+        runner.main(["--artifact-repo", "unused", "--out", str(output)])
+    assert not output.exists()
+
+
+def test_scientific_identity_includes_protocol_and_graph_dependencies():
+    records = runner._implementation_records()
+    for name in (
+        "DESIGN_repeated_judge_source_dependence.md",
+        "PREREG_graph_geometry_repeated_judge.md",
+        "graph_geometry.py",
+        "repeated_judge_source_regions.py",
+        "repeated_judge_source_dependence.py",
+        "run_repeated_judge_candidate_capacity.py",
+    ):
+        assert name in records
+
+
+def test_portable_blas_identity_excludes_machine_paths():
+    portable = runner._portable_blas_runtime([{
+        "user_api": "blas",
+        "internal_api": "openblas",
+        "prefix": "libopenblas",
+        "version": "1.2.3",
+        "threading_layer": "pthreads",
+        "architecture": "x86_64",
+        "filepath": "/machine/specific/libopenblas.so",
+        "num_threads": 99,
+    }])
+    assert portable == [{
+        "user_api": "blas",
+        "internal_api": "openblas",
+        "prefix": "libopenblas",
+        "version": "1.2.3",
+        "threading_layer": "pthreads",
+        "architecture": "x86_64",
+    }]
+
+
+def test_main_rechecks_external_graph_records_before_writing(monkeypatch, tmp_path):
+    implementation = {"source.py": record("a")}
+    graph_records = iter([
+        ({}, {"exploratory": record("a"), "fresh": record("b")}, {}),
+        ({}, {"exploratory": record("a"), "fresh": record("c")}, {}),
+    ])
+    monkeypatch.setattr(runner, "_implementation_records", lambda: implementation)
+    monkeypatch.setattr(
+        runner, "load_frozen_graphs", lambda *_args, **_kwargs: next(graph_records)
+    )
+    monkeypatch.setattr(
+        runner,
+        "build_source_dependence_payload",
+        lambda *_args, **_kwargs: {
+            "decision": {
+                "structural_bridge_defined": False,
+                "jointly_passing_region_counts": [],
+            }
+        },
+    )
+    output = tmp_path / "must-not-exist.json"
+    with pytest.raises(RuntimeError, match="graph content provenance changed"):
+        runner.main(["--artifact-repo", "unused", "--out", str(output)])
+    assert not output.exists()


### PR DESCRIPTION
## Summary

- replace the failed three-hop-core campaign construction with full exclusive source regions plus a PSD topology-only exposure Gram,
  `E = normalize(Z) normalize(Z)^T`, from region-average cumulative-walk landing profiles;
- add deterministic cap-constrained exposure-aware allocations, exact equal-mean design-effect/ESS diagnostics, and numerically guarded allocation-free ESS floors over the frozen `K/G/rho` grid;
- add a portable fail-closed runner with start/end implementation and external-graph provenance checks, path-free numerical-runtime identity, full and tracked-summary output modes, and complete tests;
- amend the preregistration, decision log, earlier source-region/power reports, and document the Stage A / Stage B authorization order.

## Result

All `K={64,96,128}` pass the narrow structural gates in both frozen corpora at every `G={160,320,512,800}`. No `K` is selected.

At `G=800, rho=.20`, the prospective-allocation effective component counts are:

| corpus | K=64 | K=96 | K=128 |
|---|---:|---:|---:|
| exploratory | 103.3 | 174.2 | 235.3 |
| fresh | 224.7 | 302.6 | 365.3 |

The allocation-free guarded floors are 19–25 for exploratory and 33–37 for fresh. These are sensitivity diagnostics under a stipulated source-correlation path, not empirical residual covariance or campaign power.

The two final computations produced the same complete payload record: 2,767,735 bytes, SHA-256 `bf9a09c35e54bd36c2e7efea19c432ccf1e9105ff67c4154cfc1c6e744a843b2`. The tracked review projection is 308,090 bytes and content-addresses every omitted exact matrix/quota.

## Claim and authorization boundary

This PR is no-spend and topology-only. It reads no history, candidates, embeddings, labels, or judge responses. It does not select a region count, estimate covariance, claim end-to-end power, or authorize history, candidate construction, Nomic, judge calls, covariance deployment, independent batching, QR specialization, or CUDA. Every authorization remains false.

The next step is Stage A: extend the complete repeated-judge null/power procedure with the registered source matrices, source-atomic folds, synthetic prompt incidence, and two-way prompt/source inference. Only a passing family-wise null / >=80% power gate may unlock identity-only history. Stage B then performs exact post-exclusion candidate packing and realized-design revalidation.

`JointPosterior` remains the calibrated decision comparator; it is not this exposure kernel or the square-root/QR factorization.

## Validation

- 35 focused source-dependence module/runner tests;
- 99 tests with inherited source-region, capacity, and graph-geometry suites;
- 146 broader repeated-judge tests when the multiprocessing provenance suite is run in its required fresh pytest process;
- Python compilation and `git diff --check`;
- two independent math/code reviews, including direct equivalence to the canonical cumulative-walk feature map, exhaustive toy ESS-bound checks, byte-identical summary reconstruction, and rehashing of all omitted-array records.
