### PR TITLE
Add Rust WAM list_to_set/2 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -4437,6 +4437,27 @@ compile_execute_ext_builtin_to_rust(Code) :-
                     false
                 }
             }
+            "list_to_set/2" => {
+                let items = match self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let mark = self.trail.len();
+                let mut unique = Vec::with_capacity(items.len());
+                for item in &items {
+                    if !self.builtin_unify_member(item, &unique) {
+                        unique.push(item.clone());
+                    }
+                }
+                let output = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+                if self.unify(&output, &Value::List(unique)) {
+                    self.pc += 1; true
+                } else {
+                    self.unwind_trail_to(mark);
+                    false
+                }
+            }
             "select/3" => {
                 let x_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
                 let list = match self.get_reg_raw("A2").map(|v| self.deref_heap(&self.deref_var(&v))) {

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -959,6 +959,76 @@ fn test_union_direct() {
 }
 
 #[test]
+fn test_list_to_set_direct() {
+    let (ok, vm) = call2(
+        "list_to_set/2",
+        Value::List(vec![a("a"), a("b"), a("c"), a("a"), a("b"), a("d")]),
+        ub("Set"),
+    );
+    assert!(ok);
+    assert_eq!(
+        read_var(&vm, "Set"),
+        Value::List(vec![a("a"), a("b"), a("c"), a("d")]),
+    );
+
+    let (empty_ok, empty_vm) =
+        call2("list_to_set/2", Value::List(vec![]), ub("Set"));
+    assert!(empty_ok);
+    assert_eq!(read_var(&empty_vm, "Set"), Value::List(vec![]));
+    assert!(!call2("list_to_set/2", a("bad"), ub("Set")).0);
+
+    let pair = Value::Str("pair/2".to_string(), vec![a("x"), i(1)]);
+    let (compound_ok, compound_vm) = call2(
+        "list_to_set/2",
+        Value::List(vec![pair.clone(), a("keep"), pair]),
+        ub("Set"),
+    );
+    assert!(compound_ok);
+    assert_eq!(
+        read_var(&compound_vm, "Set"),
+        Value::List(vec![
+            Value::Str("pair".to_string(), vec![a("x"), i(1)]),
+            a("keep"),
+        ]),
+    );
+
+    let (vars_ok, vars_vm) = call2(
+        "list_to_set/2",
+        Value::List(vec![ub("X"), a("a"), a("b")]),
+        ub("Set"),
+    );
+    assert!(vars_ok);
+    assert_eq!(read_var(&vars_vm, "X"), a("a"));
+    assert_eq!(read_var(&vars_vm, "Set"), Value::List(vec![a("a"), a("b")]));
+
+    let (miss_ok, miss_vm) = call2(
+        "list_to_set/2",
+        Value::List(vec![
+            Value::Str("f/2".to_string(), vec![ub("X"), a("a")]),
+            Value::Str("f/2".to_string(), vec![a("bound"), a("b")]),
+        ]),
+        ub("Set"),
+    );
+    assert!(miss_ok);
+    assert_eq!(read_var(&miss_vm, "X"), ub("X"));
+    assert_eq!(
+        read_var(&miss_vm, "Set"),
+        Value::List(vec![
+            Value::Str("f".to_string(), vec![ub("X"), a("a")]),
+            Value::Str("f".to_string(), vec![a("bound"), a("b")]),
+        ]),
+    );
+
+    let (mismatch_ok, mismatch_vm) = call2(
+        "list_to_set/2",
+        Value::List(vec![ub("X"), a("a")]),
+        Value::List(vec![]),
+    );
+    assert!(!mismatch_ok);
+    assert_eq!(read_var(&mismatch_vm, "X"), ub("X"));
+}
+
+#[test]
 fn test_ground() {
     assert!(call1("ground/1", a("x")).0);
     assert!(call1("ground/1", Value::List(vec![i(1), a("b")])).0);

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -469,6 +469,7 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"subtract/3"'),
         sub_string(S, _, _, _, '"intersection/3"'),
         sub_string(S, _, _, _, '"union/3"'),
+        sub_string(S, _, _, _, '"list_to_set/2"'),
         sub_string(S, _, _, _, 'builtin_unify_member'),
         %% copy_term_walk helper (sharing-preserving recursive copy).
         sub_string(S, _, _, _, 'copy_term_walk'),


### PR DESCRIPTION
## Summary

- implement `list_to_set/2` for the Rust WAM runtime
- preserve first-occurrence order
- deduplicate using the established unification-membership behavior
- retain successful duplicate-match bindings
- unwind failed comparisons and rejected output unification
- reject improper/non-list input
- add focused generator and generated-Rust coverage

## Testing

- `swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl`
- `swipl -q -s tests/test_wam_rust_target.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `git diff --check`