### PR TITLE
WAM/LLVM plawk: multi-table stores PR 4 — `as ns` namespace + `ns.table` references

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -1098,13 +1098,16 @@ single-pass test before any driver surgery).
   (`tests/test_plawk_use_table.pl`); (8.9) multiple named tables per store
   (namespaces / LMDB named sub-DBs, §3.5, per `PLAWK_CACHE_BACKENDS.md`) so
   `use ns.table` selects among them — **in progress**, sequenced into five
-  PRs in `PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md`. PRs 1–3 **LANDED**: the
+  PRs in `PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md`. PRs 1–4 **LANDED**: the
   multi-pass driver takes N tables (`tests/test_plawk_multitable.pl`); a
   multi-table *file* store is a class-A compile error while an *lmdb* store
   routes each table to its own named sub-DB — durable and isolated, both i64 and
   row values (`tests/test_plawk_multitable_store.pl`,
-  `tests/test_plawk_multitable_lmdb.pl`). Remaining: the `as ns` namespace and
-  `use ns.table` selection (PRs 4–5). (8.10) **reader guards** — a
+  `tests/test_plawk_multitable_lmdb.pl`); and `cache("db" as ns)` namespaces a
+  store so its tables are referenced `ns.table` (the local part is the sub-DB),
+  a namespaced file store being a class-A error
+  (`tests/test_plawk_namespace.pl`). Remaining: `use ns.table` selection (PR 5,
+  reads each sub-DB's schema so no re-`declare`). (8.10) **reader guards** — a
   `WHERE`-style row filter on any of the three readers: `if (r["col"] CMP int)`
   (records), `if (r[N] CMP int)` (positional), `if ($N CMP int)` (anon), for
   the six operators `== != < <= > >=`. The guard lowers to an i64 field extract

--- a/docs/design/PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
@@ -109,15 +109,26 @@ independently; per-sub-DB schema-mismatch → exit 3). The PR-2
 `lmdb_multitable_is_not_yet_error` test flips to `lmdb_multitable_builds_and_runs`.
 Durable multi-table over LMDB, both i64 and row values.
 
-### PR 4 — `as ns` namespace + `ns.table` references (parser)
+### PR 4 — `as ns` namespace + `ns.table` references (parser) — **LANDED**
 
-The name-resolution surface (`PLAWK_MULTIPASS_CACHE.md` §3.7): `cache("db" as
-ns)` (and `cache("db") as ns`) declares a namespace; tables are referenced
-`ns.table` from passes / `END`; a `global`-marked declaration lifts to the bare
-namespace. Parser + name resolution only; lowers onto the PR-1..3 machinery
-(the qualified name maps to a table + its sub-DB name). Bare-but-unique
-multi-table (PRs 1–3) already works without this; `as ns` is collision-avoidance
-sugar.
+The name-resolution surface (`PLAWK_MULTIPASS_CACHE.md` §3.7). `cache("db" as
+ns) { declare orders … }` qualifies each declared table to the dotted atom
+`ns.orders` (parse-time, `plawk_qualify/3`); a `table_ident//1` rule parses
+`ns.table` references to the same atom in every table-name position (the three
+row readers, `over`, and the assoc write/inc/add + print-lookup targets). So the
+qualified name flows uniformly as an ordinary table name, and the codegen only
+needed two small changes: the sub-DB name is now the **local part** (after the
+dot, `plawk_local_table_name/2`), and `plawk_multitable_paths/2` treats a
+namespaced store as multi-table even with one table (so `as ns` really uses
+sub-DBs). A namespaced *file* store is a compile error (class A can't hold named
+sub-tables), alongside the ≥2-table file error. `tests/test_plawk_namespace.pl`:
+parse (qualified declare, namespaced write, bare unchanged); a two-table
+namespaced lmdb store durable across runs; a single-table namespace durable;
+namespaced-file → exit 2. Bare-but-unique multi-table (PRs 1–3) still works
+without a namespace; `as ns` is the collision-avoidance sugar. **Deferred**: the
+`cache("db") as ns` (alias after the paren) spelling, the `global` modifier, and
+namespaced tables in an `END` for-in — noted follow-ons, none needed for the
+core surface.
 
 ### PR 5 — `use ns.table` selection (resolver)
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -260,8 +260,25 @@ check_multitable_store(File, Program) :-
              "lmdb"` store for multiple named tables.~n',
             [File, Names, Path]),
         halt(2)
+    ;   namespaced_file_store(Program, Path, NS)
+    ->  format(user_error,
+            'plawk: ~w namespaces the file store "~w" (`as ~w`). A namespace \c
+             uses named sub-tables, which the file backend (class A) does not \c
+             support; use a `backend "lmdb"` store.~n',
+            [File, Path, NS]),
+        halt(2)
     ;   true
     ).
+
+% A file store carrying a namespaced (`ns.table`) table -- `as ns` asks for
+% named sub-tables, unsupported on the single-table file backend (class A).
+namespaced_file_store(Program, Path, NS) :-
+    program_begin_clauses(Program, BeginClauses),
+    member(begin(Actions), BeginClauses),
+    member(cache_table(Name, Path, file), Actions),
+    sub_atom(Name, Before, _, _, '.'),
+    sub_atom(Name, 0, Before, _, NS),
+    !.
 
 % True when some cache store PATH is declared with two or more distinct table
 % NAMES; binds that path, its backend, and the sorted name list.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -6135,7 +6135,8 @@ plawk_cache_entries(Tables, StrArrays, Schemas, Triples, CacheEntries, PathGloba
           % unnamed default DB.
           ( Backend == lmdb, memberchk(Path, MultiPaths)
           ->  format(atom(SubGName), 'plawk_cache_subdb_~w', [Index]),
-              atom_string(Name, NameStr),
+              plawk_local_table_name(Name, Local),
+              atom_string(Local, NameStr),
               llvm_emit_c_string_global(SubGName, NameStr, SubGlobal, _SubLen, SubBytes),
               format(atom(SubRef),
                   'getelementptr inbounds ([~w x i8], [~w x i8]* @.~w, i64 0, i64 0)',
@@ -6155,16 +6156,32 @@ plawk_cache_entries(Tables, StrArrays, Schemas, Triples, CacheEntries, PathGloba
     atomic_list_concat(AllGlobals, '\n', PathGlobalsIR).
 
 %% plawk_multitable_paths(+Triples, -MultiPaths)
-%  Store paths that carry two or more distinct table names -- i.e. multi-table
-%  stores, whose tables route to named sub-DBs. (A multi-table *file* store is
+%  Store paths whose tables route to named sub-DBs -- either a path carrying two
+%  or more distinct table names, OR a path with a namespaced (`ns.table`) table
+%  (phase 8.9 PR 4): `as ns` asks for sub-databases, so a namespaced store uses
+%  named sub-DBs even with a single table. (A multi-table *file* store is
 %  rejected earlier as a compile error, so in practice these are lmdb.)
 plawk_multitable_paths(Triples, MultiPaths) :-
     findall(Path,
         ( member(ct(_, Path, _), Triples),
-          findall(N, member(ct(N, Path, _), Triples), Ns0),
-          sort(Ns0, Ns), Ns = [_, _ | _] ),
+          ( findall(N, member(ct(N, Path, _), Triples), Ns0),
+            sort(Ns0, Ns), Ns = [_, _ | _]
+          ; member(ct(TN, Path, _), Triples), plawk_is_namespaced(TN)
+          ) ),
         MultiPaths0),
     sort(MultiPaths0, MultiPaths).
+
+%% plawk_is_namespaced(+TableName) / plawk_local_table_name(+Name, -Local)
+%  A namespaced table name is the dotted atom `ns.local` (phase 8.9 PR 4); its
+%  LOCAL part (after the last dot) is the sub-DB it routes to. A bare name has
+%  no dot and is its own local name.
+plawk_is_namespaced(Name) :-
+    sub_atom(Name, _, _, _, '.'),
+    !.
+
+plawk_local_table_name(Name, Local) :-
+    atomic_list_concat(Parts, '.', Name),
+    last(Parts, Local).
 
 %% plawk_lmdb_decls(+CacheEntries, -Decls)
 %  `declare`s for the external LMDB helpers actually referenced: the plain

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -206,7 +206,7 @@ pass_clauses([pass_records(var(Var), var(Table), Body) | Rest]) -->
     "pass", identifier_boundary, ws,
     "records", identifier_boundary, ws,
     "of", identifier_boundary, ws,
-    identifier(Table), ws,
+    table_ident(Table), ws,
     "as", identifier_boundary, ws,
     identifier(Var), ws,
     for_in_body(Body),
@@ -222,7 +222,7 @@ pass_clauses([pass_rows(var(Var), var(Table), Body) | Rest]) -->
     "pass", identifier_boundary, ws,
     "rows", identifier_boundary, ws,
     "of", identifier_boundary, ws,
-    identifier(Table), ws,
+    table_ident(Table), ws,
     "as", identifier_boundary, ws,
     identifier(Var), ws,
     for_in_body(Body),
@@ -237,7 +237,7 @@ pass_clauses([pass_rows_anon(var(Table), Body) | Rest]) -->
     "pass", identifier_boundary, ws,
     "rows", identifier_boundary, ws,
     "of", identifier_boundary, ws,
-    identifier(Table), ws,
+    table_ident(Table), ws,
     for_in_body(Body),
     ws,
     pass_clauses(Rest).
@@ -251,7 +251,7 @@ pass_clauses([pass_rows_anon(var(Table), Body) | Rest]) -->
 pass_clauses([pass_over(var(Var), var(Table), Body) | Rest]) -->
     "pass", identifier_boundary, ws,
     "over", identifier_boundary, ws,
-    identifier(Table), ws,
+    table_ident(Table), ws,
     "as", identifier_boundary, ws,
     identifier(Var), ws,
     for_in_body(Body),
@@ -951,10 +951,10 @@ quoted_string_escape_codes([0'\\, Code]) -->
 % PLAWK_MULTIPASS_CACHE.md.
 begin_clauses([begin(Actions)]) -->
     "BEGIN", ws, "cache", ws, "(", ws, quoted_string(PathCodes), ws,
-    cache_backend(Backend), ws, ")", ws,
+    cache_backend(Backend), cache_namespace(NS), ws, ")", ws,
     "{", ws,
     { string_codes(Path, PathCodes) },
-    cache_decl_list(Path, Backend, Actions),
+    cache_decl_list(Path, Backend, NS, Actions),
     ws, "}", ws,
     !.
 begin_clauses([begin(Actions)]) -->
@@ -979,16 +979,34 @@ cache_backend(Backend) -->
 cache_backend(file) -->
     [].
 
-cache_decl_list(Path, Backend, Actions) -->
-    cache_decl(Path, Backend, First),
-    cache_decl_list_rest(Path, Backend, Rest),
+% Optional namespace alias inside cache(...): `cache("db" as ns)` (phase 8.9
+% PR 4, PLAWK_MULTIPASS_CACHE.md §3.7). `ns` prefixes the store's tables so
+% they are referenced `ns.table` and never collide with global names; the
+% store holds them as named sub-DBs (each a `ns.table` internal name whose
+% LOCAL part is the sub-DB name). No alias -> `none` (global bare names).
+cache_namespace(NS) -->
+    ws, "as", required_ws, identifier(NS),
+    !.
+cache_namespace(none) -->
+    [].
+
+% A namespace-qualified table name: bare `Local` stays `Local`; under a
+% namespace `NS` it becomes the dotted atom `'NS.Local'`, matching how a
+% `ns.table` reference (table_ident) parses.
+plawk_qualify(none, Local, Local) :- !.
+plawk_qualify(NS, Local, QName) :-
+    atomic_list_concat([NS, '.', Local], QName).
+
+cache_decl_list(Path, Backend, NS, Actions) -->
+    cache_decl(Path, Backend, NS, First),
+    cache_decl_list_rest(Path, Backend, NS, Rest),
     { append(First, Rest, Actions) }.
-cache_decl_list_rest(Path, Backend, Actions) -->
-    ws, cache_decl_sep, ws, cache_decl(Path, Backend, First),
+cache_decl_list_rest(Path, Backend, NS, Actions) -->
+    ws, cache_decl_sep, ws, cache_decl(Path, Backend, NS, First),
     !,
-    cache_decl_list_rest(Path, Backend, Rest),
+    cache_decl_list_rest(Path, Backend, NS, Rest),
     { append(First, Rest, Actions) }.
-cache_decl_list_rest(_Path, _Backend, []) -->
+cache_decl_list_rest(_Path, _Backend, _NS, []) -->
     [].
 cache_decl_sep --> ";", !.
 cache_decl_sep --> [].
@@ -1001,13 +1019,15 @@ cache_decl_sep --> [].
 % are untouched and the schema is available to the record readers. Columns are
 % col(Name, Type) with Type in {str, i64}. The column-list clause is tried
 % first; a bare declare falls through.
-cache_decl(Path, Backend,
+cache_decl(Path, Backend, NS,
         [cache_table(Name, Path, Backend), cache_schema(Name, Columns)]) -->
-    "declare", required_ws, identifier(Name), ws,
+    "declare", required_ws, identifier(Local), ws,
     cache_col_list(Columns),
-    !.
-cache_decl(Path, Backend, [cache_table(Name, Path, Backend)]) -->
-    "declare", required_ws, identifier(Name).
+    !,
+    { plawk_qualify(NS, Local, Name) }.
+cache_decl(Path, Backend, NS, [cache_table(Name, Path, Backend)]) -->
+    "declare", required_ws, identifier(Local),
+    { plawk_qualify(NS, Local, Name) }.
 % `use NAME` (PLAWK_MULTIPASS_CACHE.md §3.7, phase 8.8): attach to an EXISTING
 % store without re-stating its columns -- the schema is taken from the store's
 % persisted header (§8.7). Parses to cache_use(NAME, Path, Backend); the plawk
@@ -1015,8 +1035,9 @@ cache_decl(Path, Backend, [cache_table(Name, Path, Backend)]) -->
 % cache_table/cache_schema a matching `declare NAME(cols)` would produce, so
 % the readers need no new machinery. Tried after `declare`; `use` is
 % unambiguous.
-cache_decl(Path, Backend, [cache_use(Name, Path, Backend)]) -->
-    "use", required_ws, identifier(Name).
+cache_decl(Path, Backend, NS, [cache_use(Name, Path, Backend)]) -->
+    "use", required_ws, identifier(Local),
+    { plawk_qualify(NS, Local, Name) }.
 
 cache_col_list(Columns) -->
     "(", ws, cache_cols(Columns), ws, ")".
@@ -1358,7 +1379,7 @@ condition_pattern(Pattern) -->
     or_pattern(Pattern).
 
 increment_action(inc_assoc(var(Name), KeyExpr)) -->
-    identifier(Name),
+    table_ident(Name),
     ws,
     "[",
     ws,
@@ -1543,7 +1564,7 @@ dynrec_type(string) --> "string".
 % an integer literal (i64 table values); other deltas are a follow-on. Tried
 % before the scalar clause -- the `[` distinguishes them.
 add_assign_action(add_assoc(var(Name), KeyExpr, Delta)) -->
-    identifier(Name),
+    table_ident(Name),
     ws,
     "[",
     ws,
@@ -1585,7 +1606,7 @@ assoc_add_delta(int(Value)) -->
 % `records of TABLE as r`). Tried before the scalar `set` -- the `[`
 % distinguishes them; the `!` commits once `TABLE[key] =` is seen.
 assignment_action(Action) -->
-    identifier(Name),
+    table_ident(Name),
     ws, "[", ws, assoc_key_expr(KeyExpr), ws, "]", ws, "=", ws,
     !,
     assoc_row_rhs(var(Name), KeyExpr, Action).
@@ -1833,7 +1854,7 @@ field_expr(toupper(Field)) -->
     ")",
     { Field = field(_) }.
 field_expr(assoc(var(Name), KeyExpr)) -->
-    identifier(Name),
+    table_ident(Name),
     ws,
     "[",
     ws,
@@ -1975,7 +1996,7 @@ i64_factor_expr(Expr) -->
 % An assoc lookup `arr[k]` as an arithmetic operand, e.g. `$2 / total[$1]`
 % (per-key normalise). Tried before the bare identifier -- the `[` commits.
 i64_factor_expr(assoc(var(Name), KeyExpr)) -->
-    identifier(Name),
+    table_ident(Name),
     ws,
     "[",
     ws,
@@ -2358,6 +2379,20 @@ identifier(Name) -->
     identifier_start(Start),
     identifier_rest(Rest),
     { atom_codes(Name, [Start | Rest]) }.
+
+% A table name, optionally namespace-qualified (`ns.table`, phase 8.9 PR 4,
+% PLAWK_MULTIPASS_CACHE.md §3.7). A bare name stays the atom `table`; the
+% qualified form is the dotted atom `'ns.table'`, matching how a namespaced
+% `declare` qualifies it (plawk_qualify). The dotted form's LOCAL part (after
+% the dot) is the sub-DB it routes to. Falls back to a bare identifier, so
+% existing programs are unchanged. Used only in TABLE-name positions (readers
+% and assoc write/read targets), never for scalars or loop variables.
+table_ident(Name) -->
+    identifier(NS), ".", identifier(Local),
+    !,
+    { atomic_list_concat([NS, '.', Local], Name) }.
+table_ident(Name) -->
+    identifier(Name).
 
 identifier_start(Code) -->
     [Code],

--- a/tests/test_plawk_namespace.pl
+++ b/tests/test_plawk_namespace.pl
@@ -1,0 +1,170 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk namespaced cache stores (PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md, phase
+% 8.9 PR 4; PLAWK_MULTIPASS_CACHE.md §3.7): `cache("db" as ns) { declare orders
+% ... }` makes `ns` a namespace, so its tables are referenced `ns.orders` and
+% never collide with global names. A namespaced table's internal name is the
+% dotted atom `ns.orders`; its LOCAL part (`orders`) is the sub-DB it routes to,
+% so `as ns` asks for named sub-DBs (a store uses sub-DBs even with one table).
+% The file backend (class A) is single-table, so a namespaced file store is a
+% compile error.
+%
+% LMDB cases require liblmdb at build+run time; skipped when clang cannot link
+% -llmdb.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_lmdb_available :-
+    catch(( tmp_c(C, Bin),
+            setup_call_cleanup(open(C, write, S),
+                write(S, "#include <lmdb.h>\nint main(void){MDB_env*e;return mdb_env_create(&e);}\n"),
+                close(S)),
+            format(atom(Cmd), 'clang -w ~w -o ~w -llmdb 2>/dev/null', [C, Bin]),
+            process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+tmp_c(C, Bin) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_ns_lmdb_probe.c', C),
+    directory_file_path(Tmp, 'uw_ns_lmdb_probe', Bin).
+
+:- begin_tests(plawk_namespace).
+
+% --- parse -----------------------------------------------------------------
+
+% `cache("db" as ns)` qualifies each declared table to the dotted atom
+% `ns.table`; `ns.table` references parse to the same atom.
+test(namespace_parses) :-
+    plawk_parse_string(
+        "BEGIN cache(\"db\" backend \"lmdb\" as shop) { declare orders(k str, v str) }\n\c
+         pass records of shop.orders as r { print r[\"k\"] }\n\c
+         pass rows of shop.orders as r { print r[1] }\n",
+        program_passes(
+            [begin([cache_table('shop.orders', "db", lmdb),
+                    cache_schema('shop.orders', [col(k, str), col(v, str)])])],
+            [pass_records(var(r), var('shop.orders'), _),
+             pass_rows(var(r), var('shop.orders'), _)],
+            [])),
+    !.
+
+% A namespaced write target (`ns.t[$k] = ...`) parses to the qualified name.
+test(namespace_write_parses) :-
+    plawk_parse_string(
+        "BEGIN cache(\"db\" as ns) { declare t(a str, b str) }\n\c
+         pass { ns.t[$1] = row($1, $2) }\n\c
+         pass rows of ns.t as r { print r[1] }\n",
+        program_passes(
+            [begin([cache_table('ns.t', "db", file), cache_schema('ns.t', _)])],
+            [pass([rule(always, [set_row_cons(var('ns.t'), field(1), _)])]),
+             pass_rows(var(r), var('ns.t'), _)],
+            [])),
+    !.
+
+% A bare (un-namespaced) program is unchanged: no dot, plain atom names.
+test(bare_names_unchanged) :-
+    plawk_parse_string(
+        "pass { t[$1] = $0 }\npass rows of t as r { print r[1] }\n",
+        program_passes([],
+            [pass([rule(always, [set_row(var(t), field(1))])]),
+             pass_rows(var(r), var(t), _)],
+            [])),
+    !.
+
+% --- end to end ------------------------------------------------------------
+
+% A namespaced lmdb store: two `ns.table` tables, durable across runs, each in
+% its own sub-DB (named by the LOCAL part). Readers first, writer last.
+test(namespace_lmdb_durable, [condition(clang_lmdb_available)]) :-
+    ndir(Dir),
+    store(Dir, 'shop.lmdb', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\" backend \"lmdb\" as shop) { declare orders(k str, v str); declare customers(k str, v str) }\n\c
+         pass records of shop.orders as r { print r[\"k\"], r[\"v\"] }\n\c
+         pass records of shop.customers as r { print r[\"k\"], r[\"v\"] }\n\c
+         pass { shop.orders[$1] = row($1, $2); shop.customers[$1] = row($2, $1) }\n", [Store]),
+    build(Dir, 'shop', Src, Bin, In, "a 1\nb 2\n"),
+    run_sorted(Bin, In, S1),
+    assertion(S1 == []),
+    run_sorted(Bin, In, S2),
+    assertion(S2 == ["1 a", "2 b", "a 1", "b 2"]),
+    !.
+
+% A single-table namespaced lmdb store also persists (namespace -> sub-DB even
+% with one table).
+test(namespace_single_table_durable, [condition(clang_lmdb_available)]) :-
+    ndir(Dir),
+    store(Dir, 'one.lmdb', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\" backend \"lmdb\" as ns) { declare t(a str, b str) }\n\c
+         pass records of ns.t as r { print r[\"a\"], r[\"b\"] }\n\c
+         pass { ns.t[$1] = row($1, $2) }\n", [Store]),
+    build(Dir, 'one', Src, Bin, In, "x 10\ny 20\n"),
+    run_sorted(Bin, In, S1), assertion(S1 == []),
+    run_sorted(Bin, In, S2), assertion(S2 == ["x 10", "y 20"]),
+    !.
+
+% A namespaced FILE store is a compile error (exit 2): class A is single-table,
+% so it cannot hold named sub-tables.
+test(namespace_file_is_compile_error) :-
+    ndir(Dir),
+    directory_file_path(Dir, 'nf.db', Store),
+    format(atom(Src),
+        "BEGIN cache(\"~w\" as ns) { declare t(a str, b str) }\n\c
+         pass rows of ns.t as r { print r[1] }\n\c
+         pass rows of ns.t as r { print r[2] }\n", [Store]),
+    build_status(Dir, 'nf', Src, St),
+    assertion(St == 2),
+    !.
+
+:- end_tests(plawk_namespace).
+
+% --- helpers ---------------------------------------------------------------
+
+ndir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_namespace', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+store(Dir, Name, Store) :-
+    directory_file_path(Dir, Name, Store),
+    atom_concat(Store, '-lock', Lock),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    ( exists_file(Lock) -> delete_file(Lock) ; true ).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+build_status(Dir, Name, Src, Status) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).
+
+run_sorted(Bin, In, Sorted) :-
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Summary

**PR 4 of the phase-8.9 arc** — the name-resolution surface, so a store can hold many tables without global name collisions.

```awk
BEGIN cache("shop.lmdb" backend "lmdb" as shop) { declare orders(k str, v str); declare customers(k str, v str) }
pass { shop.orders[$1] = row($1, $2); shop.customers[$1] = row($2, $1) }
pass records of shop.orders    as r { print r["k"], r["v"] }
pass records of shop.customers as r { print r["k"], r["v"] }
```

## What changed

- **Parser**: `cache_namespace//1` parses the optional `as ns` inside `cache(...)`; `plawk_qualify/3` qualifies each declared name to the dotted atom `ns.orders` at parse time. A new `table_ident//1` parses `ns.table` to the same atom in **every table-name position** — the three row readers, `over`, and the assoc write / `++` / `+=` / print-lookup targets — falling back to a bare identifier so existing programs are unchanged. Scalars and loop variables keep plain `identifier`.
- **Codegen**: the qualified name flows as an ordinary table name, so only two small changes were needed — the sub-DB name is the **local part** after the dot (`plawk_local_table_name/2`), and `plawk_multitable_paths/2` treats a namespaced store as multi-table even with one table, so `as ns` genuinely uses named sub-DBs.
- **`bin/plawk`**: a namespaced **file** store is a compile error (`namespaced_file_store/3`) — class A can't hold named sub-tables — alongside the existing ≥2-table file error.

## Tests

`tests/test_plawk_namespace.pl` (6): parse (qualified declare, namespaced write, bare unchanged); a two-table namespaced lmdb store durable across runs in separate sub-DBs; a single-table namespace durable; namespaced file store → exit 2. Full plawk row/cache suite stays green (bare names lower exactly as before — `table_ident` only adds the dotted branch).

## Deferred (noted follow-ons)

The `cache("db") as ns` spelling (alias *after* the paren), the `global` modifier, and namespaced tables in an `END` for-in — none needed for the core surface.

## Next

**PR 5** — `use ns.table` selection: reads each named sub-DB's schema at build time (extends the resolver + gives the LMDB schema probe a sub-DB arg), so you attach to a multi-table store with **no `declare`**. This is the "avoid declare" feature — it builds on the still-open #3727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_