### PR TITLE
Add Rust WAM atomic/1 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -682,6 +682,8 @@ wam_instruction_arm('Instruction::Call(p, _arity)', Body) :-
                 } else if p == "read_term/2" {
                     let options = self.get_reg_raw("A2");
                     self.execute_read_term_builtin(options.as_ref())
+                } else if p == "atomic/1" {
+                    self.execute_builtin(p, *_arity)
                 } else if self.foreign_predicates.contains(p) {
                     self.cp = self.pc + 1;
                     if self.execute_foreign_predicate(p, *_arity) {
@@ -765,6 +767,11 @@ wam_instruction_arm('Instruction::Execute(p)', Body) :-
                 } else if p == "read_term/2" {
                     let options = self.get_reg_raw("A2");
                     if self.execute_read_term_builtin(options.as_ref()) {
+                        self.pc = self.cp;
+                        true
+                    } else { false }
+                } else if p == "atomic/1" {
+                    if self.execute_builtin(p, 1) {
                         self.pc = self.cp;
                         true
                     } else { false }
@@ -1374,6 +1381,12 @@ compile_execute_type_builtin_to_rust(Code) :-
                 "integer/1" => matches!(val, Value::Integer(_)),
                 "float/1" => matches!(val, Value::Float(_)),
                 "number/1" => val.is_number(),
+                "atomic/1" => {
+                    let derefed = self.deref_heap(&self.deref_var(&val));
+                    matches!(&derefed,
+                        Value::Atom(_) | Value::Integer(_) | Value::Float(_) | Value::Bool(_))
+                        || matches!(&derefed, Value::List(items) if items.is_empty())
+                }
                 "compound/1" => val.is_compound(),
                 "var/1" => val.is_unbound(),
                 "nonvar/1" => !val.is_unbound(),

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -44,6 +44,12 @@ t_concat_split(A, B) :- atom_concat(A, B, abc).
 :- dynamic t_select/2.
 t_select(X, R) :- select(X, [a, b, c], R).
 
+:- dynamic t_atomic/1.
+t_atomic(X) :- atomic(X).
+
+:- dynamic t_atomic_number/1.
+t_atomic_number(X) :- atomic(X), number(X).
+
 %% catch/throw + succ predicates (ISO meta-builtin Call fallback path).
 :- dynamic t_thrower/0.
 t_thrower :- throw(oops(42)).
@@ -132,6 +138,7 @@ test_builtin_parity_execution :-
         write_wam_rust_project(
             [user:t_between/1, user:t_msort/1, user:t_sort/1,
              user:t_concat_split/2, user:t_select/2,
+             user:t_atomic/1, user:t_atomic_number/1,
              user:t_thrower/0, user:t_deep/0, user:t_mid/0,
              user:t_catch_match/1, user:t_catch_deep/1,
              user:t_catch_nomatch/0, user:t_catch_nothrow/1,
@@ -150,6 +157,7 @@ test_builtin_parity_execution :-
 use builtin_parity_test::state::WamState;
 use builtin_parity_test::value::Value;
 use builtin_parity_test::{t_between_1, t_msort_1, t_sort_1, t_concat_split_2, t_select_2,
+    t_atomic_1, t_atomic_number_1,
     t_catch_match_1, t_catch_deep_1, t_catch_nomatch_0, t_catch_nothrow_1,
     t_catch_failgoal_0, t_catch_nested_1, t_succ_fwd_1, t_succ_rev_1,
     t_maplist_1, t_maplist_check_0, t_maplist_fail_0, t_include_1, t_exclude_1,
@@ -241,6 +249,24 @@ fn test_select_enumeration_compiled() {
         ("b".to_string(), "a,c".to_string()),
         ("c".to_string(), "a,b".to_string()),
     ]);
+}
+
+#[test]
+fn test_atomic_compiled() {
+    let mut atom_vm = vmnew();
+    assert!(t_atomic_1(&mut atom_vm, a("x")));
+    let mut number_vm = vmnew();
+    assert!(t_atomic_1(&mut number_vm, i(42)));
+    let mut compound_vm = vmnew();
+    assert!(!t_atomic_1(&mut compound_vm,
+        Value::Str("f".to_string(), vec![a("x")])));
+    let mut var_vm = vmnew();
+    assert!(!t_atomic_1(&mut var_vm, ub("X")));
+
+    let mut non_tail_ok_vm = vmnew();
+    assert!(t_atomic_number_1(&mut non_tail_ok_vm, i(42)));
+    let mut non_tail_fail_vm = vmnew();
+    assert!(!t_atomic_number_1(&mut non_tail_fail_vm, a("x")));
 }
 
 #[test]
@@ -1035,6 +1061,17 @@ fn test_ground() {
     assert!(!call1("ground/1", ub("V")).0);
     assert!(!call1("ground/1", Value::List(vec![i(1), ub("V")])).0);
     assert!(!call1("ground/1", Value::Str("f/1".to_string(), vec![ub("V")])).0);
+}
+
+#[test]
+fn test_atomic_direct() {
+    assert!(call1("atomic/1", a("x")).0);
+    assert!(call1("atomic/1", i(1)).0);
+    assert!(call1("atomic/1", Value::Float(1.5)).0);
+    assert!(call1("atomic/1", Value::List(vec![])).0);
+    assert!(!call1("atomic/1", Value::List(vec![a("x")])).0);
+    assert!(!call1("atomic/1", Value::Str("f".to_string(), vec![a("x")])).0);
+    assert!(!call1("atomic/1", ub("X")).0);
 }
 ',
         setup_call_cleanup(

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -453,6 +453,7 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, 'print!("{}", derefed)'),
         sub_string(S, _, _, _, 'nl/0'),
         sub_string(S, _, _, _, 'atom/1'),
+        sub_string(S, _, _, _, 'atomic/1'),
         sub_string(S, _, _, _, 'number/1'),
         sub_string(S, _, _, _, 'member/2'),
         sub_string(S, _, _, _, 'builtin_state'),


### PR DESCRIPTION
## Summary

- implement `atomic/1` for the Rust hybrid WAM runtime
- support atoms, numbers, booleans, and the empty-list atom representation
- route both tail and non-tail compiled calls without changing global WAM dispatch
- add direct and compiled execution coverage

## Testing

- `swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl`
- `swipl -q -s tests/test_wam_rust_target.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `git diff --check`