### PR TITLE
WAM/LLVM plawk: multi-table stores PR 5 — `use ns.table` selection (avoid declare)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -39,10 +39,8 @@ surface, the runtime ABI, and a phased rollout.
   or `$N CMP int` (anon). The six operators are `== != < <= > >=`; filtered
   rows never reach the print block (`tests/test_plawk_reader_guards.pl`).
 
-**Not yet:** `use NAME` over an LMDB store (the build-time schema resolver
-reads the file-backend header, not the LMDB schema key — a follow-on; `declare`
-works over LMDB today); `rows of`'s `unsafe` / inline check-or-rename spec;
-multiple named tables per store (phase 8.9); the `over prev` reader (phase 4
+**Not yet:** `rows of`'s `unsafe` / inline check-or-rename spec;
+the `over prev` reader (phase 4
 follow-on); the query reader (phase 6); `eager` / secondary indexes;
 string-literal print fields. Future sketches: nested pass blocks (§3.8),
 `while`/loop statements (§3.8), views (§3.9), contained non-determinism / a
@@ -1083,8 +1081,9 @@ single-pass test before any driver surgery).
   (`tests/test_plawk_row_durable.pl` for the file backend,
   `tests/test_plawk_row_durable_lmdb.pl` for LMDB via
   `wam_cache_{commit,load}_lmdb_str` — schema stored under a distinguished key
-  and validated on open; `use NAME` over an LMDB store still awaits a
-  build-time LMDB schema resolver); (8.5) the positional `rows of`
+  and validated on open; `use NAME` over an LMDB store reads that schema at
+  build time via a small liblmdb probe, single- and multi-table); (8.5) the
+  positional `rows of`
   reader (`r[N]`, no schema) — **LANDED**
   (`tests/test_plawk_rows_reader.pl`; its `unsafe` / inline check-or-rename
   spec remain a follow-on); (8.6) richer row producers (`row(...)` /
@@ -1097,17 +1096,17 @@ single-pass test before any driver surgery).
   `select` surface, no re-`declare` — **LANDED (file backend)**
   (`tests/test_plawk_use_table.pl`); (8.9) multiple named tables per store
   (namespaces / LMDB named sub-DBs, §3.5, per `PLAWK_CACHE_BACKENDS.md`) so
-  `use ns.table` selects among them — **in progress**, sequenced into five
-  PRs in `PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md`. PRs 1–4 **LANDED**: the
-  multi-pass driver takes N tables (`tests/test_plawk_multitable.pl`); a
-  multi-table *file* store is a class-A compile error while an *lmdb* store
-  routes each table to its own named sub-DB — durable and isolated, both i64 and
-  row values (`tests/test_plawk_multitable_store.pl`,
-  `tests/test_plawk_multitable_lmdb.pl`); and `cache("db" as ns)` namespaces a
-  store so its tables are referenced `ns.table` (the local part is the sub-DB),
-  a namespaced file store being a class-A error
-  (`tests/test_plawk_namespace.pl`). Remaining: `use ns.table` selection (PR 5,
-  reads each sub-DB's schema so no re-`declare`). (8.10) **reader guards** — a
+  `use ns.table` selects among them — **LANDED** (all five PRs in
+  `PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md`): the multi-pass driver takes N
+  tables (`tests/test_plawk_multitable.pl`); a multi-table *file* store is a
+  class-A compile error while an *lmdb* store routes each table to its own named
+  sub-DB — durable and isolated, both i64 and row values
+  (`tests/test_plawk_multitable_store.pl`, `tests/test_plawk_multitable_lmdb.pl`);
+  `cache("db" as ns)` namespaces a store so its tables are referenced `ns.table`
+  (the local part is the sub-DB), a namespaced file store being a class-A error
+  (`tests/test_plawk_namespace.pl`); and `use ns.table` attaches to a
+  multi-table store with no re-`declare`, reading each sub-DB's schema at build
+  time (`tests/test_plawk_use_namespace.pl`). (8.10) **reader guards** — a
   `WHERE`-style row filter on any of the three readers: `if (r["col"] CMP int)`
   (records), `if (r[N] CMP int)` (positional), `if ($N CMP int)` (anon), for
   the six operators `== != < <= > >=`. The guard lowers to an i64 field extract

--- a/docs/design/PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
@@ -130,14 +130,34 @@ without a namespace; `as ns` is the collision-avoidance sugar. **Deferred**: the
 namespaced tables in an `END` for-in — noted follow-ons, none needed for the
 core surface.
 
-### PR 5 — `use ns.table` selection (resolver)
+### PR 5 — `use ns.table` selection (resolver) — **LANDED**
 
-Extends the build-time `use` resolver (`examples/plawk/bin/plawk`,
-`expand_cache_use`) so `use ns.table` attaches to one named sub-DB of an
-existing multi-table store. The LMDB schema probe (`wam_cache_lmdb_schema.c`,
-added for single-table `use` over LMDB) gains a sub-DB argument so it reads the
-schema from the named sub-DB rather than the unnamed default. Depends on the
-single-table `use`-over-LMDB work (PR #3727) and PR 3.
+The finale: attach to a multi-table store with **no `declare`**, taking each
+table's schema from its sub-DB at build time. This PR is self-contained (it
+subsumes the never-merged single-table `use`-over-LMDB PR #3727): it ships the
+LMDB schema probe (`wam_cache_lmdb_schema.c`) with an **optional sub-DB
+argument** — given a sub-DB name it opens that named DB (`mdb_env_set_maxdbs` +
+named `mdb_dbi_open`) and reads its `__wam_schema__` key, else the unnamed
+default DB. The resolver (`examples/plawk/bin/plawk`) computes the store's
+multi-table paths exactly as the codegen does (≥2 tables, or any namespaced
+`ns.table`), and for a `use` on such a path passes the table's LOCAL name to the
+probe; single-table `use` reads the unnamed DB (file backend unchanged, reads
+its header directly). So `BEGIN cache("db" backend "lmdb" as ns) { use orders;
+use items }` attaches both tables by reading each sub-DB's schema — the
+"avoid-declare" surface for multi-table stores. Tests:
+`tests/test_plawk_use_table_lmdb.pl` (single-table `use` over LMDB, from #3727)
+and `tests/test_plawk_use_namespace.pl` (namespaced multi-table `use` with
+**three-column** tables, including column arithmetic over the schema-read
+fields). Depends on PR 3's per-sub-DB schema storage.
+
+---
+
+**Arc complete.** All five PRs have landed: multi-table stores work end to end —
+the driver takes N tables, an lmdb store routes them to named sub-DBs, `as ns`
+namespaces the references, and `use ns.table` attaches by reading each sub-DB's
+schema. A multi-table *file* store is a clean class-A compile error throughout.
+Deferred sugar (noted in PR 4): the `cache("db") as ns` spelling, the `global`
+modifier, and namespaced tables in an `END` for-in.
 
 ## 4. Risks / decisions
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -320,28 +320,106 @@ normalize_passes(_File, Program, Program).
 % schema check work unchanged. The store must exist and carry a schema at
 % build time; otherwise it is a compile error.
 resolve_cache_use(File, program(B0, R, E), program(B, R, E)) :-
-    !, maplist(resolve_use_begin(File), B0, B).
+    !, resolve_uses(File, B0, B).
 resolve_cache_use(File, program_passes(B0, P, E), program_passes(B, P, E)) :-
-    !, maplist(resolve_use_begin(File), B0, B).
+    !, resolve_uses(File, B0, B).
 resolve_cache_use(_File, Program, Program).
 
-resolve_use_begin(File, begin(As0), begin(As)) :-
-    !,
-    findall(Xs, ( member(A, As0), expand_cache_use(File, A, Xs) ), Nested),
-    append(Nested, As).
-resolve_use_begin(_File, Clause, Clause).
+resolve_uses(File, B0, B) :-
+    use_multitable_paths(B0, MultiPaths),
+    maplist(resolve_use_begin(File, MultiPaths), B0, B).
 
-expand_cache_use(File, cache_use(Name, Path, Backend),
+resolve_use_begin(File, MultiPaths, begin(As0), begin(As)) :-
+    !,
+    findall(Xs, ( member(A, As0), expand_cache_use(File, MultiPaths, A, Xs) ), Nested),
+    append(Nested, As).
+resolve_use_begin(_File, _MultiPaths, Clause, Clause).
+
+% Store paths that hold named sub-tables (phase 8.9): a path with two or more
+% declared/used tables, or any namespaced (`ns.table`) one -- the same rule the
+% codegen uses to route to sub-DBs. A `use` on such a path reads its schema from
+% the named sub-DB (the table's LOCAL name).
+use_multitable_paths(BeginClauses, MultiPaths) :-
+    findall(Name-Path,
+        ( member(begin(As), BeginClauses),
+          ( member(cache_table(Name, Path, _), As)
+          ; member(cache_use(Name, Path, _), As) ) ),
+        NPs),
+    findall(Path,
+        ( member(_-Path, NPs),
+          ( findall(N, member(N-Path, NPs), Ns0), sort(Ns0, Ns), Ns = [_, _ | _]
+          ; member(TN-Path, NPs), sub_atom(TN, _, _, _, '.') ) ),
+        MP0),
+    sort(MP0, MultiPaths).
+
+expand_cache_use(File, MultiPaths, cache_use(Name, Path, Backend),
         [cache_table(Name, Path, Backend), cache_schema(Name, Cols)]) :-
     !,
-    (   store_schema_columns(Path, Cols)
+    ( memberchk(Path, MultiPaths) -> use_local_name(Name, Sub) ; Sub = none ),
+    (   store_schema_columns_for(Backend, Path, Sub, Cols)
     ->  true
     ;   format(user_error,
             'plawk: cannot `use ~w` in ~w: store "~w" is missing or has no schema~n',
             [Name, File, Path]),
         halt(2)
     ).
-expand_cache_use(_File, Action, [Action]).
+expand_cache_use(_File, _MultiPaths, Action, [Action]).
+
+% The sub-DB a `use` reads: a namespaced `ns.table` reads from sub-DB `table`
+% (its LOCAL part); a bare name in a multi-table store reads from sub-DB `name`.
+use_local_name(Name, Sub) :-
+    atomic_list_concat(Parts, '.', Name),
+    last(Parts, Sub).
+
+% Read a store's persisted schema, dispatching on backend and store mode. The
+% file backend's schema is a plain header this process reads directly (file is
+% single-table, so Sub is ignored); the LMDB backend keeps it under a key inside
+% the B-tree -- in the unnamed DB (Sub = none) or a named sub-DB -- so a tiny
+% liblmdb probe (compiled by the build, which already needs clang + liblmdb for
+% lmdb stores) extracts it.
+store_schema_columns_for(lmdb, Path, Sub, Cols) :-
+    !, store_schema_columns_lmdb(Path, Sub, Cols).
+store_schema_columns_for(_Backend, Path, _Sub, Cols) :-
+    store_schema_columns(Path, Cols).
+
+% Build-time schema read for an LMDB row store: compile the schema probe
+% (wam_cache_lmdb_schema.c) once into the build tmp dir, run it against the
+% store (passing the sub-DB name when reading a named sub-DB), and parse the
+% schema string it prints. A missing store/sub-DB, a probe that cannot link/run,
+% or an empty/unparseable schema fails (-> compile error).
+store_schema_columns_lmdb(Path, Sub, Cols) :-
+    atom_string(PathA, Path),
+    exists_file(PathA),
+    lmdb_schema_probe_bin(ProbeBin),
+    ( Sub == none -> ProbeArgs = [PathA] ; ProbeArgs = [PathA, Sub] ),
+    process_create(ProbeBin, ProbeArgs,
+        [stdout(pipe(PS)), stderr(null), process(Pid)]),
+    read_string(PS, _, Out), close(PS),
+    process_wait(Pid, exit(0)),
+    parse_schema_string(Out, Cols),
+    Cols = [_ | _].
+
+% Compile the LMDB schema probe once per build invocation, memoised.
+:- dynamic lmdb_schema_probe_bin_cache/1.
+lmdb_schema_probe_bin(ProbeBin) :-
+    ( lmdb_schema_probe_bin_cache(ProbeBin)
+    ->  true
+    ;   lmdb_schema_probe_source(CFile),
+        tmp_build_dir(Dir),
+        directory_file_path(Dir, 'wam_cache_lmdb_schema_probe', ProbeBin),
+        format(atom(Cmd), 'clang -w -O2 ~w -o ~w -llmdb 2>&1', [CFile, ProbeBin]),
+        process_create(path(sh), ['-c', Cmd],
+            [stdout(pipe(CS)), stderr(std), process(Pid)]),
+        read_string(CS, _, _), close(CS),
+        process_wait(Pid, exit(0)),
+        assertz(lmdb_schema_probe_bin_cache(ProbeBin))
+    ).
+
+% The schema probe source ships beside the LMDB C runtime.
+lmdb_schema_probe_source(CFile) :-
+    module_property(wam_llvm_target, file(TargetPl)),
+    file_directory_name(TargetPl, Dir),
+    directory_file_path(Dir, 'wam_cache_lmdb_schema.c', CFile).
 
 % Read a byte-valued row store's persisted schema header and parse it into
 % col(Name, Type) columns. Header layout (§8.7): [schemalen:i64 (LE)]

--- a/src/unifyweaver/targets/wam_cache_lmdb_schema.c
+++ b/src/unifyweaver/targets/wam_cache_lmdb_schema.c
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0
+ * Copyright (c) 2026 John William Creighton (@s243a)
+ *
+ * Build-time schema probe for the plawk LMDB cache backend
+ * (PLAWK_MULTIPASS_CACHE.md phase 8.8/8.9). A str-valued (row) store on the
+ * LMDB backend keeps its declared schema under a distinguished key
+ * ("__wam_schema__"), written by wam_cache_commit_lmdb_str -- in the unnamed
+ * default DB for a single-table store, or inside each named sub-DB for a
+ * multi-table store. `use NAME` needs that schema at BUILD time, but LMDB's
+ * schema lives inside the B-tree and needs liblmdb to extract, so the plawk
+ * build compiles and runs this tiny helper (it already depends on clang +
+ * liblmdb for lmdb stores). Given a store path -- and, for a multi-table store,
+ * a sub-DB name as argv[2] -- it prints the schema string ("name:type,...") to
+ * stdout and exits 0, or exits non-zero when the store / sub-DB is missing or
+ * has no schema. NOT linked into the plawk binary; a standalone build-time
+ * tool. */
+
+#include <lmdb.h>
+#include <stdio.h>
+#include <stddef.h>
+
+/* Must match WAM_LMDB_SCHEMA_KEY / _KEYLEN in wam_cache_lmdb.c. */
+static const char SCHEMA_KEY[] = "__wam_schema__";
+#define SCHEMA_KEYLEN 14
+
+/* Max named sub-DBs (matches WAM_CACHE_LMDB_MAXDBS in wam_cache_lmdb.c); only
+ * set when opening a named sub-DB. */
+#define SCHEMA_MAXDBS 128
+
+int main(int argc, char **argv) {
+    MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
+    MDB_val k, v;
+    const char *subname;
+    int rc;
+    if (argc < 2) return 2;
+    subname = (argc >= 3) ? argv[2] : NULL;  /* multi-table: a named sub-DB */
+    if (mdb_env_create(&env)) return 1;
+    if (subname) mdb_env_set_maxdbs(env, SCHEMA_MAXDBS);
+    if (mdb_env_open(env, argv[1], MDB_NOSUBDIR | MDB_RDONLY, 0644)) {
+        mdb_env_close(env);
+        return 1;
+    }
+    if (mdb_txn_begin(env, NULL, MDB_RDONLY, &txn)) {
+        mdb_env_close(env);
+        return 1;
+    }
+    if (mdb_dbi_open(txn, subname, 0, &dbi)) {  /* NULL = unnamed default DB */
+        mdb_txn_abort(txn);
+        mdb_env_close(env);
+        return 1;
+    }
+    k.mv_size = SCHEMA_KEYLEN;
+    k.mv_data = (void *)SCHEMA_KEY;
+    rc = mdb_get(txn, dbi, &k, &v);
+    if (rc == 0 && v.mv_size > 0) {
+        fwrite(v.mv_data, 1, v.mv_size, stdout);
+    }
+    mdb_txn_abort(txn);
+    mdb_env_close(env);
+    return (rc == 0 && v.mv_size > 0) ? 0 : 1;
+}

--- a/tests/test_plawk_use_namespace.pl
+++ b/tests/test_plawk_use_namespace.pl
@@ -1,0 +1,119 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `use` over a namespaced multi-table store (PLAWK_MULTITABLE_IMPLEMENTATION_PLAN.md
+% phase 8.9 PR 5; PLAWK_MULTIPASS_CACHE.md §3.7): attach to a multi-table LMDB
+% store WITHOUT re-stating any columns. A namespaced `use orders` (under `as
+% ns`, so the internal name is `ns.orders`) reads its schema from the named
+% sub-DB `orders` -- the build runs the liblmdb schema probe with the sub-DB
+% name. So a reader queries each table of a multi-table store by column name
+% with no `declare`. Exercised with THREE-column tables to confirm the schema
+% read is not limited to two columns.
+%
+% Requires liblmdb at build+run time; skipped when clang cannot link -llmdb.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_lmdb_available :-
+    catch(( tmp_c(C, Bin),
+            setup_call_cleanup(open(C, write, S),
+                write(S, "#include <lmdb.h>\nint main(void){MDB_env*e;return mdb_env_create(&e);}\n"),
+                close(S)),
+            format(atom(Cmd), 'clang -w ~w -o ~w -llmdb 2>/dev/null', [C, Bin]),
+            process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+tmp_c(C, Bin) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_usens_lmdb_probe.c', C),
+    directory_file_path(Tmp, 'uw_usens_lmdb_probe', Bin).
+
+:- begin_tests(plawk_use_namespace).
+
+% A `declare` writer populates a namespaced multi-table LMDB store with two
+% THREE-column tables; a separate `use` reader (NO declare) attaches to both via
+% the namespace and reads them back by column name -- the schema for each comes
+% from its own named sub-DB at build time. Distinct data per table proves each
+% `use` reads the right sub-DB.
+test(use_reads_namespaced_multitable_3col, [condition(clang_lmdb_available)]) :-
+    udir(Dir),
+    store(Dir, 'shop.lmdb', Store),
+    format(atom(WSrc),
+        "BEGIN cache(\"~w\" backend \"lmdb\" as shop) { declare orders(id str, cust str, amt str); declare items(sku str, name str, qty str) }\n\c
+         pass records of shop.orders as r { print r[\"id\"] }\n\c
+         pass { shop.orders[$1] = row($1, $2, $3); shop.items[$1] = row($1, $2, $3) }\n", [Store]),
+    build(Dir, 'nsw', WSrc, WBin, WIn, "o1 alice 100\ns1 widget 7\n"),
+    run_sorted(WBin, WIn, _),                    % populate + commit schemas
+    format(atom(RSrc),
+        "BEGIN cache(\"~w\" backend \"lmdb\" as shop) { use orders; use items }\n\c
+         pass records of shop.orders as r { print r[\"cust\"], r[\"amt\"] }\n\c
+         pass records of shop.items as r { print r[\"name\"], r[\"qty\"] }\n", [Store]),
+    build(Dir, 'nsr', RSrc, RBin, RIn, "o1 alice 100\ns1 widget 7\n"),
+    run_sorted(RBin, RIn, S),
+    % orders rows: (cust, amt) of each stored row; items rows: (name, qty).
+    % Both tables hold the two input records ($1,$2,$3), so:
+    %   orders: "alice 100", "widget 7"  ; items: "alice 100", "widget 7"
+    assertion(S == ["alice 100", "alice 100", "widget 7", "widget 7"]),
+    !.
+
+% Column arithmetic over a `use`d 3-column table: the third column divided by a
+% constant, proving the schema-read columns are fully usable, not just printed.
+test(use_namespaced_3col_arithmetic, [condition(clang_lmdb_available)]) :-
+    udir(Dir),
+    store(Dir, 'arith.lmdb', Store),
+    format(atom(WSrc),
+        "BEGIN cache(\"~w\" backend \"lmdb\" as ns) { declare t(k str, a str, b str) }\n\c
+         pass records of ns.t as r { print r[\"k\"] }\n\c
+         pass { ns.t[$1] = row($1, $2, $3) }\n", [Store]),
+    build(Dir, 'aw', WSrc, WBin, WIn, "x 10 4\ny 9 3\n"),
+    run_sorted(WBin, WIn, _),
+    format(atom(RSrc),
+        "BEGIN cache(\"~w\" backend \"lmdb\" as ns) { use t }\n\c
+         pass records of ns.t as r { print r[\"k\"], r[\"a\"] / r[\"b\"] }\n\c
+         pass rows of ns.t as r { print r[1] }\n", [Store]),
+    build(Dir, 'ar', RSrc, RBin, RIn, "x 10 4\ny 9 3\n"),
+    run_sorted(RBin, RIn, S),
+    % pass 1: 10/4 = 2.5, 9/3 = 3 (by name) ; pass 2: keys by position
+    assertion(S == ["x", "x 2.5", "y", "y 3"]),
+    !.
+
+:- end_tests(plawk_use_namespace).
+
+% --- helpers ---------------------------------------------------------------
+
+udir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_use_namespace', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+store(Dir, Name, Store) :-
+    directory_file_path(Dir, Name, Store),
+    atom_concat(Store, '-lock', Lock),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    ( exists_file(Lock) -> delete_file(Lock) ; true ).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+run_sorted(Bin, In, Sorted) :-
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).

--- a/tests/test_plawk_use_table_lmdb.pl
+++ b/tests/test_plawk_use_table_lmdb.pl
@@ -1,0 +1,112 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk row-oriented records (PLAWK_MULTIPASS_CACHE.md §3.7, phase 8.8): the
+% `use` reader over the LMDB BACKEND. The file-backend counterpart is
+% test_plawk_use_table.pl. `use NAME` attaches to an existing store without
+% re-stating its columns -- the plawk build reads the store's persisted schema
+% and expands `use NAME` into the cache_table + cache_schema a matching
+% `declare` would produce. On the file backend the schema is a plain header the
+% build reads directly; on LMDB it lives under a key inside the B-tree, so the
+% build compiles and runs a small liblmdb probe (wam_cache_lmdb_schema.c) to
+% extract it. This test proves a durable LMDB row store written by a `declare`
+% writer is read back by a separate `use` reader (no re-declare).
+%
+% Requires liblmdb at build+run time (apt-get install liblmdb-dev); skipped
+% when clang cannot link -llmdb.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+clang_lmdb_available :-
+    catch(( tmp_c(C, Bin),
+            setup_call_cleanup(open(C, write, S),
+                write(S, "#include <lmdb.h>\nint main(void){MDB_env*e;return mdb_env_create(&e);}\n"),
+                close(S)),
+            format(atom(Cmd), 'clang -w ~w -o ~w -llmdb 2>/dev/null', [C, Bin]),
+            process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+tmp_c(C, Bin) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_lmdb_use_probe.c', C),
+    directory_file_path(Tmp, 'uw_lmdb_use_probe', Bin).
+
+:- begin_tests(plawk_use_table_lmdb).
+
+% End to end: a `declare` writer populates a durable LMDB store; a separate
+% `use` reader (NO declare(cols)) reads it back by column name and by position.
+% The reader's schema is read from the LMDB store at build time via the probe.
+test(use_reads_existing_lmdb_store, [condition(clang_lmdb_available)]) :-
+    udir(Dir),
+    store(Dir, 'u.lmdb', Store),
+    format(atom(WSrc),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { declare t(a str, b str) }\n\c
+         pass records of t as r { print r[\"a\"] }\n\c
+         pass { t[$1] = row($1, $2) }\n", [Store]),
+    build(Dir, 'luw', WSrc, WBin, WIn, "x 10\ny 20\n"),
+    run_sorted(WBin, WIn, _),                    % populate + commit schema
+    format(atom(RSrc),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { use t }\n\c
+         pass records of t as r { print r[\"a\"], r[\"b\"] }\n\c
+         pass rows of t as r { print r[1] }\n", [Store]),
+    build(Dir, 'lur', RSrc, RBin, RIn, "x 10\ny 20\n"),
+    run_sorted(RBin, RIn, S),
+    assertion(S == ["x", "x 10", "y", "y 20"]),
+    !.
+
+% `use` on a missing LMDB store is a compile error (exit 2): no schema to read.
+test(use_missing_lmdb_store_errors, [condition(clang_lmdb_available)]) :-
+    udir(Dir),
+    store(Dir, 'nope.lmdb', Store),
+    format(atom(RSrc),
+        "BEGIN cache(\"~w\" backend \"lmdb\") { use t }\n\c
+         pass records of t as r { print r[\"a\"] }\n\c
+         pass rows of t as r { print r[1] }\n", [Store]),
+    directory_file_path(Dir, 'lum.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, W, [encoding(utf8)]),
+        write(W, RSrc), close(W)),
+    directory_file_path(Dir, 'lum_bin', Bin),
+    cli([build, Prog, '-o', Bin], 2),            % compile error: no store/schema
+    !.
+
+:- end_tests(plawk_use_table_lmdb).
+
+% --- helpers ---------------------------------------------------------------
+
+udir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_use_table_lmdb', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+% Fresh single-file lmdb store: remove the data file and its -lock sidecar.
+store(Dir, Name, Store) :-
+    directory_file_path(Dir, Name, Store),
+    atom_concat(Store, '-lock', Lock),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    ( exists_file(Lock) -> delete_file(Lock) ; true ).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+run_sorted(Bin, In, Sorted) :-
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Summary

**PR 5 — the finale of the phase-8.9 arc**, and the "avoid `declare`" feature you asked about. Attach to a multi-table store with **no `declare`** — each table's schema is read from its sub-DB at build time.

```awk
BEGIN cache("shop.lmdb" backend "lmdb" as shop) { use orders; use items }   # no declare
pass records of shop.orders as r { print r["cust"], r["amt"] }
pass records of shop.items  as r { print r["name"], r["qty"] }
```

> **Supersedes #3727** (never merged). This PR is self-contained: single-**and** multi-table `use` over LMDB both land here, so #3727 can be closed.

## What changed

- **Build tool** (`wam_cache_lmdb_schema.c`): the liblmdb schema probe now takes an **optional sub-DB name** (`argv[2]`) — given one it sets `maxdbs` and opens that named DB, reading its `__wam_schema__` key; else the unnamed default DB. Not linked into the binary; a build-time helper.
- **Resolver** (`examples/plawk/bin/plawk`): `resolve_cache_use` computes the store's multi-table paths (≥2 tables, or any namespaced `ns.table`) **exactly as the codegen does**, and for a `use` on such a path passes the table's **local** name to the probe. Single-table `use` reads the unnamed DB; the file backend reads its header directly. The expanded `cache_table` keeps the qualified name, so readers and sub-DB routing are unchanged. Missing store / sub-DB / schema → clean compile error.

## Tests (incl. your multi-column request)

- `tests/test_plawk_use_table_lmdb.pl` — single-table `use` over LMDB (from #3727).
- `tests/test_plawk_use_namespace.pl` — namespaced multi-table `use` with **three-column** tables, plus **column arithmetic** (`r["a"] / r["b"]`) over the schema-read fields.

Regressions green: `use_table`, `use_table_lmdb`, `namespace`, `multitable_lmdb`, `multitable_store`, `multipass_cache`, `row_durable`.

## Arc complete 🎉

All five PRs landed: driver → N tables · lmdb named sub-DBs · `as ns` namespace · `use ns.table`. A multi-table *file* store is a clean class-A error throughout. Deferred sugar (noted in PR 4): `cache("db") as ns` spelling, the `global` modifier, and namespaced tables in an `END` for-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_