### PR TITLE
WAM/LLVM plawk: reader-guard extension — float-literal comparisons

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -34,10 +34,13 @@ surface, the runtime ABI, and a phased rollout.
   validated on open (phase 8.7); and `use NAME` to attach to an existing
   store without re-`declare` (phase 8.8).
 - **Reader guards** (a `WHERE`-style row filter): any of the three row readers
-  may wrap its `print` in `if (COND) …`, where `COND` compares a column to an
-  integer literal — `r["col"] CMP int` (records), `r[N] CMP int` (positional),
-  or `$N CMP int` (anon). The six operators are `== != < <= > >=`; filtered
-  rows never reach the print block (`tests/test_plawk_reader_guards.pl`).
+  may wrap its `print` in `if (COND) …`, where `COND` compares a column to a
+  numeric literal — `r["col"] CMP N` (records), `r[N] CMP N` (positional),
+  or `$N CMP N` (anon). The six operators are `== != < <= > >=`. The literal is
+  an **integer** (i64 compare) or a **decimal float** (`3.5`, `-1.5`; the column
+  is read as a double and compared with `fcmp`), so fractional thresholds and
+  fractional column values work. Filtered rows never reach the print block
+  (`tests/test_plawk_reader_guards.pl`, `tests/test_plawk_guard_float.pl`).
 
 **Not yet:** `rows of`'s `unsafe` / inline check-or-rename spec;
 the `over prev` reader (phase 4
@@ -1107,12 +1110,14 @@ single-pass test before any driver surgery).
   (`tests/test_plawk_namespace.pl`); and `use ns.table` attaches to a
   multi-table store with no re-`declare`, reading each sub-DB's schema at build
   time (`tests/test_plawk_use_namespace.pl`). (8.10) **reader guards** — a
-  `WHERE`-style row filter on any of the three readers: `if (r["col"] CMP int)`
-  (records), `if (r[N] CMP int)` (positional), `if ($N CMP int)` (anon), for
-  the six operators `== != < <= > >=`. The guard lowers to an i64 field extract
-  + `icmp` + conditional branch, so filtered rows never reach the print block —
-  **LANDED** (`tests/test_plawk_reader_guards.pl`; a guard against a
-  non-integer literal / a boolean combination of guards remain a follow-on).
+  `WHERE`-style row filter on any of the three readers: `if (r["col"] CMP N)`
+  (records), `if (r[N] CMP N)` (positional), `if ($N CMP N)` (anon), for
+  the six operators `== != < <= > >=`. An integer literal lowers to an i64
+  field extract + `icmp`; a decimal float literal (`3.5`) to an f64 extract +
+  `fcmp` — filtered rows never reach the print block — **LANDED**
+  (`tests/test_plawk_reader_guards.pl`, `tests/test_plawk_guard_float.pl`; a
+  string-literal comparison and boolean `&&`/`||` combinations remain a
+  follow-on).
 
 ## 6. Open questions
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4164,17 +4164,29 @@ rec_after:
 
 %% plawk_records_guard_ir(+GuardPlan, +FieldSep, -IR)
 %  The transition out of rec_body: unguarded readers fall straight into
-%  rec_print; a guard extracts its column as i64 (@wam_atom_field_i64_value on
-%  the row %Value), compares to the constant, and branches to rec_print or
-%  skips the row (rec_body_done).
+%  rec_print; a guard extracts its column and compares to the constant, then
+%  branches to rec_print or skips the row (rec_body_done). A bare-integer RHS
+%  extracts the column as i64 (@wam_atom_field_i64_value) and uses icmp; a float
+%  literal (float_const, e.g. `3.5`) extracts it as double
+%  (@wam_atom_field_f64_value) and uses fcmp against the exact decimal ratio.
 plawk_records_guard_ir(none, _FieldSep, '  br label %rec_print').
 plawk_records_guard_ir(guard(ColIndex, Op, Value), FieldSep, IR) :-
+    integer(Value),
+    !,
     plawk_icmp_pred(Op, Pred),
     format(atom(IR),
 '  %rec_gv = call i64 @wam_atom_field_i64_value(%Value %rec_row_v, i64 ~w, i8 ~w)
   %rec_gcmp = icmp ~w i64 %rec_gv, ~w
   br i1 %rec_gcmp, label %rec_print, label %rec_body_done',
         [ColIndex, FieldSep, Pred, Value]).
+plawk_records_guard_ir(guard(ColIndex, Op, float_const(M, D)), FieldSep, IR) :-
+    plawk_fcmp_pred(Op, Pred),
+    format(atom(IR),
+'  %rec_gcst = fdiv double ~w.0, ~w.0
+  %rec_gv = call double @wam_atom_field_f64_value(%Value %rec_row_v, i64 ~w, i8 ~w)
+  %rec_gcmp = fcmp ~w double %rec_gv, %rec_gcst
+  br i1 %rec_gcmp, label %rec_print, label %rec_body_done',
+        [M, D, ColIndex, FieldSep, Pred]).
 
 % Surface comparison op -> signed LLVM icmp predicate.
 plawk_icmp_pred(eq, eq).
@@ -4183,6 +4195,15 @@ plawk_icmp_pred(lt, slt).
 plawk_icmp_pred(le, sle).
 plawk_icmp_pred(gt, sgt).
 plawk_icmp_pred(ge, sge).
+
+% Surface comparison op -> ordered LLVM fcmp predicate (row values are finite,
+% so ordered comparisons are correct; a NaN column fails every guard).
+plawk_fcmp_pred(eq, oeq).
+plawk_fcmp_pred(ne, one).
+plawk_fcmp_pred(lt, olt).
+plawk_fcmp_pred(le, ole).
+plawk_fcmp_pred(gt, ogt).
+plawk_fcmp_pred(ge, oge).
 
 %% plawk_records_col_lines(+FieldPlans, +FieldSep, +OutputSep, +PrintIndex)//
 %  Per-field print for the row readers: a separator before each field after

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1226,18 +1226,33 @@ forin_guard(forin_key_cmp(LoopVar, Op, Value)) -->
 % (which fail cleanly on a non-identifier key / `$`, then backtrack here).
 forin_guard(rcol_cmp(Var, Col, Op, Value)) -->
     identifier(Var), ws, "[", ws, quoted_string(CCodes), ws, "]", ws,
-    numeric_cmp_op(Op), ws, signed_integer_value(Value),
+    numeric_cmp_op(Op), ws, guard_rhs(Value),
     { string_codes(Col, CCodes) },
     !.
 forin_guard(rpos_cmp(Var, N, Op, Value)) -->
     identifier(Var), ws, "[", ws, integer_codes(NCodes), ws, "]", ws,
-    numeric_cmp_op(Op), ws, signed_integer_value(Value),
+    numeric_cmp_op(Op), ws, guard_rhs(Value),
     { NCodes \== [], number_codes(N, NCodes), N > 0 },
     !.
 forin_guard(rfield_cmp(N, Op, Value)) -->
     "$", integer_codes(NCodes), ws,
-    numeric_cmp_op(Op), ws, signed_integer_value(Value),
+    numeric_cmp_op(Op), ws, guard_rhs(Value),
     { NCodes \== [], number_codes(N, NCodes), N > 0 }.
+
+% A reader-guard right-hand side: a bare signed integer (an i64 comparison,
+% unchanged) or a signed decimal float literal (`3.5`, an f64 comparison,
+% carried as float_const(Mantissa, Denominator) like other float literals).
+% The float clauses are tried first; a bare integer has no `.` and falls
+% through. (String-literal comparisons are a follow-on.)
+guard_rhs(float_const(M, D)) -->
+    "-", float_literal_expr(float_const(M0, D)),
+    !,
+    { M is -M0 }.
+guard_rhs(FloatConst) -->
+    float_literal_expr(FloatConst),
+    !.
+guard_rhs(Value) -->
+    signed_integer_value(Value).
 
 actions([Action | Actions]) -->
     action(Action),

--- a/tests/test_plawk_guard_float.pl
+++ b/tests/test_plawk_guard_float.pl
@@ -1,0 +1,129 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk reader-guard extensions -- FLOAT literals (follow-on to the integer
+% reader guards). A row-reader guard `if (COL CMP LIT)` now accepts a decimal
+% float literal on the right, e.g. `if (r["amt"] > 3.5)`: the column is
+% extracted as a double (@wam_atom_field_f64_value) and compared with fcmp
+% against the exact decimal ratio, so fractional thresholds and fractional
+% column values compare correctly. A bare-integer RHS is unchanged (i64 icmp).
+% Signed floats (`-1.5`) are supported. Applies to all three readers -- named
+% `r["col"]`, positional `r[N]`, and awk-native `$N`.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_guard_float).
+
+% A float RHS parses to a float_const(Mantissa, Denominator); a bare integer is
+% unchanged.
+test(float_guard_parses) :-
+    plawk_parse_string(
+        "pass rows of t as r { if (r[2] > 3.5) print r[1] }\n",
+        program_passes([],
+            [pass_rows(var(r), var(t),
+                [if(rpos_cmp(r, 2, gt, float_const(35, 10)),
+                    [print([assoc(var(r), int(1))])], [])])],
+            [])),
+    plawk_parse_string(
+        "pass rows of t as r { if (r[2] > 3) print r[1] }\n",
+        program_passes([],
+            [pass_rows(var(r), var(t),
+                [if(rpos_cmp(r, 2, gt, 3),
+                    [print([assoc(var(r), int(1))])], [])])],
+            [])),
+    !.
+
+% A negative float RHS parses to a negative mantissa.
+test(negative_float_parses) :-
+    plawk_parse_string(
+        "pass rows of t { if ($2 <= -1.5) print $1 }\n",
+        program_passes([],
+            [pass_rows_anon(var(t),
+                [if(rfield_cmp(2, le, float_const(-15, 10)),
+                    [print([field(1)])], [])])],
+            [])),
+    !.
+
+% Positional float guard: r[2] > 3.5 over integer-looking columns.
+test(rows_float_guard, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t as r { if (r[2] > 3.5) print r[1] }\n",
+    run_sorted(Dir, 'rf', Src, "a 4\nb 2\nc 10\n", S),
+    assertion(S == ["a", "c"]),
+    !.
+
+% Named float guard over FRACTIONAL column values: amt >= 2.5.
+test(records_float_guard_fractional, [condition(clang_available)]) :-
+    gdir(Dir),
+    directory_file_path(Dir, 'ff.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare t(k str, amt str) }\n\c
+         pass { t[$1] = row($1, $2) }\n\c
+         pass records of t as r { if (r[\"amt\"] >= 2.5) print r[\"k\"] }\n", [Store]),
+    run_sorted(Dir, 'rff', Src, "a 2.5\nb 1.2\nc 9.9\n", S),
+    assertion(S == ["a", "c"]),
+    !.
+
+% Awk-native `$N` with a negative float threshold.
+test(anon_negative_float_guard, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t { if ($2 > -1.5) print $1 }\n",
+    run_sorted(Dir, 'anf', Src, "x 3\ny -2\nz 0\n", S),
+    assertion(S == ["x", "z"]),
+    !.
+
+% All six operators against a float threshold (via the anon reader), over
+% 4 / 2 / 10 with threshold 4.0.
+test(float_op_lt, [condition(clang_available)]) :- fop("$2 < 4.0", ["b"]).
+test(float_op_le, [condition(clang_available)]) :- fop("$2 <= 4.0", ["a", "b"]).
+test(float_op_gt, [condition(clang_available)]) :- fop("$2 > 4.0", ["c"]).
+test(float_op_ge, [condition(clang_available)]) :- fop("$2 >= 4.0", ["a", "c"]).
+test(float_op_eq, [condition(clang_available)]) :- fop("$2 == 4.0", ["a"]).
+test(float_op_ne, [condition(clang_available)]) :- fop("$2 != 4.0", ["b", "c"]).
+
+:- end_tests(plawk_guard_float).
+
+% --- helpers ---------------------------------------------------------------
+
+fop(Cond, Expected) :-
+    gdir(Dir),
+    format(atom(Src),
+        "pass { t[$1] = $0 }\npass rows of t { if (~w) print $1 }\n", [Cond]),
+    run_sorted(Dir, 'fop', Src, "a 4\nb 2\nc 10\n", S),
+    assertion(S == Expected).
+
+gdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_guard_float', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Summary

First of the reader-guard extensions. Reader guards (the `WHERE`-style row filter) compared a column to an **integer** literal only; now they accept a decimal **float** literal too, so fractional thresholds and fractional column values compare correctly.

```awk
pass records of t as r { if (r["amt"] >= 2.5) print r["k"] }
pass rows    of t as r { if (r[2]     > 3.5)  print r[1]   }
pass rows    of t        { if ($2      <= -1.5) print $1     }
```

## What changed

- **Parser**: a new `guard_rhs//1` parses the guard's RHS as either a bare signed integer (**unchanged** — an i64 comparison, so existing guard ASTs/tests are byte-identical) or a signed decimal float, carried as the existing `float_const(Mantissa, Denominator)` exact-ratio form. Float clauses are tried first; a bare integer has no `.` and falls through. Wired into all three reader-guard forms (`rcol_cmp` / `rpos_cmp` / `rfield_cmp`).
- **Codegen**: `plawk_records_guard_ir` dispatches on the RHS — an integer keeps the i64 `@wam_atom_field_i64_value` + `icmp` path; a `float_const` emits the column as a double via `@wam_atom_field_f64_value` and compares with `fcmp` against the exact decimal ratio (`fdiv double M.0, D.0`), using ordered predicates. The shared row-reader emitter means one change covers records, positional, and anon readers.

## Tests

`tests/test_plawk_guard_float.pl` (12): parse (`float_const` RHS, negative float, bare-int unchanged); positional / named-fractional / anon-negative float guards; all six operators against a float threshold. The integer-guard suite and the records/rows reader suites stay green.

## Next (remaining guard extensions)

- **String equality** — `if (r["cust"] == "alice")` (slice extract + byte compare).
- **Boolean combinations** — `&&` / `||`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_