### PR TITLE
WAM/LLVM plawk: reader-guard extension — string-equality comparisons

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -35,12 +35,14 @@ surface, the runtime ABI, and a phased rollout.
   store without re-`declare` (phase 8.8).
 - **Reader guards** (a `WHERE`-style row filter): any of the three row readers
   may wrap its `print` in `if (COND) …`, where `COND` compares a column to a
-  numeric literal — `r["col"] CMP N` (records), `r[N] CMP N` (positional),
-  or `$N CMP N` (anon). The six operators are `== != < <= > >=`. The literal is
-  an **integer** (i64 compare) or a **decimal float** (`3.5`, `-1.5`; the column
-  is read as a double and compared with `fcmp`), so fractional thresholds and
-  fractional column values work. Filtered rows never reach the print block
-  (`tests/test_plawk_reader_guards.pl`, `tests/test_plawk_guard_float.pl`).
+  literal — `r["col"] CMP L` (records), `r[N] CMP L` (positional),
+  or `$N CMP L` (anon). The literal is an **integer** (i64 compare, six
+  operators `== != < <= > >=`), a **decimal float** (`3.5`, `-1.5`; the column
+  is read as a double and compared with `fcmp`, so fractional thresholds and
+  values work), or a **string** (`"alice"`, `==` / `!=` only — a
+  length-then-`memcmp` byte comparison). Filtered rows never reach the print
+  block (`tests/test_plawk_reader_guards.pl`, `tests/test_plawk_guard_float.pl`,
+  `tests/test_plawk_guard_string.pl`).
 
 **Not yet:** `rows of`'s `unsafe` / inline check-or-rename spec;
 the `over prev` reader (phase 4
@@ -1114,10 +1116,11 @@ single-pass test before any driver surgery).
   (records), `if (r[N] CMP N)` (positional), `if ($N CMP N)` (anon), for
   the six operators `== != < <= > >=`. An integer literal lowers to an i64
   field extract + `icmp`; a decimal float literal (`3.5`) to an f64 extract +
-  `fcmp` — filtered rows never reach the print block — **LANDED**
-  (`tests/test_plawk_reader_guards.pl`, `tests/test_plawk_guard_float.pl`; a
-  string-literal comparison and boolean `&&`/`||` combinations remain a
-  follow-on).
+  `fcmp`; a string literal (`"alice"`, `==`/`!=`) to a length-then-`memcmp`
+  byte comparison — filtered rows never reach the print block — **LANDED**
+  (`tests/test_plawk_reader_guards.pl`, `tests/test_plawk_guard_float.pl`,
+  `tests/test_plawk_guard_string.pl`; string ordering and boolean `&&`/`||`
+  combinations remain a follow-on).
 
 ## 6. Open questions
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3972,7 +3972,7 @@ plawk_multipass_pass_fn(Index, pass_over(var(Var), var(Table), Body), Tables,
 % TABLE; each print field must be VAR["col"] with col in the schema (name-only
 % -- numeric/other fields fail the clause, so the driver reports unsupported).
 plawk_multipass_pass_fn(Index, pass_records(var(Var), var(Table), Body), Tables,
-        _StrArrays, Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
+        _StrArrays, Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, GuardGlobals) :-
     plawk_reader_body(Body, PrintFields, GuardTerm),
     PrintFields = [_ | _],
     memberchk(cache_schema(Table, Columns), Schemas),
@@ -3980,7 +3980,7 @@ plawk_multipass_pass_fn(Index, pass_records(var(Var), var(Table), Body), Tables,
     plawk_records_guard(GuardTerm, Var, Columns, GuardPlan),
     nth0(TableIndex, Tables, Table),
     plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, FieldPlans,
-        GuardPlan, FieldSep, OutputSep, FnIR).
+        GuardPlan, FieldSep, OutputSep, FnIR, GuardGlobals).
 
 % A row-reader body is either a bare `{ print ... }` or a guarded
 % `{ if (GUARD) print ... }` (a WHERE-style filter). Extract the print fields
@@ -4017,14 +4017,14 @@ plawk_records_col_index(Columns, Col, Index) :-
 % needed -- for raw stores. Reuses the same row-decode function emitter as
 % `records of`, just sourcing the field indices from the literal positions.
 plawk_multipass_pass_fn(Index, pass_rows(var(Var), var(Table), Body), Tables,
-        _StrArrays, _Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
+        _StrArrays, _Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, GuardGlobals) :-
     plawk_reader_body(Body, PrintFields, GuardTerm),
     PrintFields = [_ | _],
     maplist(plawk_rows_field_plan(Var), PrintFields, FieldPlans),
     plawk_rows_guard(GuardTerm, Var, GuardPlan),
     nth0(TableIndex, Tables, Table),
     plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, FieldPlans,
-        GuardPlan, FieldSep, OutputSep, FnIR).
+        GuardPlan, FieldSep, OutputSep, FnIR, GuardGlobals).
 
 % Resolve a `rows of` guard (positional) -> guard(N, Op, Value); none passes.
 plawk_rows_guard(none, _Var, none).
@@ -4047,14 +4047,14 @@ plawk_rows_operand(_Var, int(V), aint(V)) :- integer(V).
 % `$N` field addressing over the stored row. Mirrors plawk_rows_field_plan but
 % sources positions from `field(N)` ($N) rather than `VAR[N]`.
 plawk_multipass_pass_fn(Index, pass_rows_anon(var(Table), Body), Tables,
-        _StrArrays, _Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, '') :-
+        _StrArrays, _Schemas, TableParamsIR, FieldSep, OutputSep, FnIR, GuardGlobals) :-
     plawk_reader_body(Body, PrintFields, GuardTerm),
     PrintFields = [_ | _],
     maplist(plawk_rows_anon_field_plan, PrintFields, FieldPlans),
     plawk_rows_anon_guard(GuardTerm, GuardPlan),
     nth0(TableIndex, Tables, Table),
     plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, FieldPlans,
-        GuardPlan, FieldSep, OutputSep, FnIR).
+        GuardPlan, FieldSep, OutputSep, FnIR, GuardGlobals).
 
 % Resolve a no-`as` guard (`$N CMP int`) -> guard(N, Op, Value); none passes.
 plawk_rows_anon_guard(none, none).
@@ -4127,10 +4127,10 @@ forin_after:
 %  constant, only emitting the row when it passes. Does not open the input;
 %  the table is freed by main.
 plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, ColIndexes,
-        GuardPlan, FieldSep, OutputSep, IR) :-
+        GuardPlan, FieldSep, OutputSep, IR, Globals) :-
     phrase(plawk_records_col_lines(ColIndexes, FieldSep, OutputSep, 0), ColLines),
     atomic_list_concat(ColLines, '\n', ColIR),
-    plawk_records_guard_ir(GuardPlan, FieldSep, GuardIR),
+    plawk_records_guard_ir(GuardPlan, FieldSep, Index, GuardIR, Globals),
     format(atom(IR),
 'define void @plawk_pass_~w(%Value %mp_path~w) {
 entry:
@@ -4169,8 +4169,8 @@ rec_after:
 %  extracts the column as i64 (@wam_atom_field_i64_value) and uses icmp; a float
 %  literal (float_const, e.g. `3.5`) extracts it as double
 %  (@wam_atom_field_f64_value) and uses fcmp against the exact decimal ratio.
-plawk_records_guard_ir(none, _FieldSep, '  br label %rec_print').
-plawk_records_guard_ir(guard(ColIndex, Op, Value), FieldSep, IR) :-
+plawk_records_guard_ir(none, _FieldSep, _Index, '  br label %rec_print', '').
+plawk_records_guard_ir(guard(ColIndex, Op, Value), FieldSep, _Index, IR, '') :-
     integer(Value),
     !,
     plawk_icmp_pred(Op, Pred),
@@ -4179,7 +4179,8 @@ plawk_records_guard_ir(guard(ColIndex, Op, Value), FieldSep, IR) :-
   %rec_gcmp = icmp ~w i64 %rec_gv, ~w
   br i1 %rec_gcmp, label %rec_print, label %rec_body_done',
         [ColIndex, FieldSep, Pred, Value]).
-plawk_records_guard_ir(guard(ColIndex, Op, float_const(M, D)), FieldSep, IR) :-
+plawk_records_guard_ir(guard(ColIndex, Op, float_const(M, D)), FieldSep, _Index, IR, '') :-
+    !,
     plawk_fcmp_pred(Op, Pred),
     format(atom(IR),
 '  %rec_gcst = fdiv double ~w.0, ~w.0
@@ -4187,6 +4188,35 @@ plawk_records_guard_ir(guard(ColIndex, Op, float_const(M, D)), FieldSep, IR) :-
   %rec_gcmp = fcmp ~w double %rec_gv, %rec_gcst
   br i1 %rec_gcmp, label %rec_print, label %rec_body_done',
         [M, D, ColIndex, FieldSep, Pred]).
+% String equality guard (`== "lit"` / `!= "lit"`): extract the column as a byte
+% slice, and match on length THEN memcmp -- the memcmp runs only when the
+% lengths are equal, so it never reads past the field. Ordering (< > …) on
+% strings is unsupported (no clause), so such a guard fails the reader shape.
+plawk_records_guard_ir(guard(ColIndex, Op, str(S)), FieldSep, Index, IR, GlobalIR) :-
+    plawk_str_guard_targets(Op, EqTarget, NeTarget, LenFailTarget),
+    format(atom(GName), 'plawk_guard_lit_~w', [Index]),
+    llvm_emit_c_string_global(GName, S, GlobalIR, StrLen, BytesLen),
+    format(atom(Gep),
+        'getelementptr inbounds ([~w x i8], [~w x i8]* @.~w, i64 0, i64 0)',
+        [BytesLen, BytesLen, GName]),
+    format(atom(IR),
+'  %rec_gslice = call %WamSlice @wam_atom_field_slice_value(%Value %rec_row_v, i64 ~w, i8 ~w)
+  %rec_gptr = extractvalue %WamSlice %rec_gslice, 0
+  %rec_glen = extractvalue %WamSlice %rec_gslice, 1
+  %rec_glen_ok = icmp eq i64 %rec_glen, ~w
+  br i1 %rec_glen_ok, label %rec_gmemcmp, label %rec_glenfail
+rec_gmemcmp:
+  %rec_gmc = call i32 @memcmp(i8* %rec_gptr, i8* ~w, i64 ~w)
+  %rec_gmc_eq = icmp eq i32 %rec_gmc, 0
+  br i1 %rec_gmc_eq, label %~w, label %~w
+rec_glenfail:
+  br label %~w',
+        [ColIndex, FieldSep, StrLen, Gep, StrLen, EqTarget, NeTarget, LenFailTarget]).
+
+% Where each outcome of a string-equality guard branches. For `==`: equal
+% bytes -> print, unequal or different length -> skip. For `!=`: the mirror.
+plawk_str_guard_targets(eq, 'rec_print', 'rec_body_done', 'rec_body_done').
+plawk_str_guard_targets(ne, 'rec_body_done', 'rec_print', 'rec_print').
 
 % Surface comparison op -> signed LLVM icmp predicate.
 plawk_icmp_pred(eq, eq).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1240,10 +1240,15 @@ forin_guard(rfield_cmp(N, Op, Value)) -->
     { NCodes \== [], number_codes(N, NCodes), N > 0 }.
 
 % A reader-guard right-hand side: a bare signed integer (an i64 comparison,
-% unchanged) or a signed decimal float literal (`3.5`, an f64 comparison,
-% carried as float_const(Mantissa, Denominator) like other float literals).
-% The float clauses are tried first; a bare integer has no `.` and falls
-% through. (String-literal comparisons are a follow-on.)
+% unchanged); a signed decimal float literal (`3.5`, an f64 comparison, carried
+% as float_const(Mantissa, Denominator) like other float literals); or a string
+% literal (`"alice"`, a byte comparison, carried as str(Text) -- only `==` /
+% `!=` are meaningful). A string starts with `"`, a float has a `.`, and a bare
+% integer is the fallthrough, so the clauses are unambiguous.
+guard_rhs(str(Text)) -->
+    quoted_string(Codes),
+    !,
+    { string_codes(Text, Codes) }.
 guard_rhs(float_const(M, D)) -->
     "-", float_literal_expr(float_const(M0, D)),
     !,

--- a/tests/test_plawk_guard_string.pl
+++ b/tests/test_plawk_guard_string.pl
@@ -1,0 +1,126 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk reader-guard extensions -- STRING equality (follow-on to the integer
+% and float reader guards). A row-reader guard `if (COL == "lit")` / `!= "lit"`
+% filters rows by a TEXT column: the column is extracted as a byte slice and
+% compared to a string literal by length THEN memcmp -- the memcmp runs only
+% when the lengths are equal, so a literal longer than the field never reads out
+% of bounds. Only `==` / `!=` are meaningful (string ordering is a follow-on).
+% Applies to all three readers -- named `r["col"]`, positional `r[N]`, and
+% awk-native `$N`.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_guard_string).
+
+% A string RHS parses to str(Text); ints and floats are unchanged.
+test(string_guard_parses) :-
+    plawk_parse_string(
+        "pass records of t as r { if (r[\"cust\"] == \"alice\") print r[\"amt\"] }\n",
+        program_passes([],
+            [pass_records(var(r), var(t),
+                [if(rcol_cmp(r, "cust", eq, str("alice")),
+                    [print([assoc(var(r), string("amt"))])], [])])],
+            [])),
+    plawk_parse_string(
+        "pass rows of t { if ($1 != \"bob\") print $1 }\n",
+        program_passes([],
+            [pass_rows_anon(var(t),
+                [if(rfield_cmp(1, ne, str("bob")),
+                    [print([field(1)])], [])])],
+            [])),
+    !.
+
+% Named `==` string guard: over a schema'd store, print amt only for cust ==
+% "alice".
+test(records_string_eq, [condition(clang_available)]) :-
+    gdir(Dir),
+    directory_file_path(Dir, 'se.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare t(cust str, amt str) }\n\c
+         pass { t[$1] = row($1, $2) }\n\c
+         pass records of t as r { if (r[\"cust\"] == \"alice\") print r[\"amt\"] }\n", [Store]),
+    run_sorted(Dir, 'rse', Src, "alice 100\nbob 50\ncarol 200\n", S),
+    assertion(S == ["100"]),
+    !.
+
+% Named `!=` string guard: everyone but alice.
+test(records_string_ne, [condition(clang_available)]) :-
+    gdir(Dir),
+    directory_file_path(Dir, 'sn.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare t(cust str, amt str) }\n\c
+         pass { t[$1] = row($1, $2) }\n\c
+         pass records of t as r { if (r[\"cust\"] != \"alice\") print r[\"cust\"] }\n", [Store]),
+    run_sorted(Dir, 'rsn', Src, "alice 100\nbob 50\ncarol 200\n", S),
+    assertion(S == ["bob", "carol"]),
+    !.
+
+% Positional `r[N]` string guard.
+test(rows_string_eq, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t as r { if (r[1] == \"bob\") print r[2] }\n",
+    run_sorted(Dir, 'pse', Src, "alice 100\nbob 50\ncarol 200\n", S),
+    assertion(S == ["50"]),
+    !.
+
+% Awk-native `$N` string guard, plus safety: a literal much LONGER than any
+% field must not read out of bounds (length check gates the memcmp).
+test(anon_string_ne_long_literal, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t { if ($1 != \"verylongliteralname\") print $1 }\n",
+    run_sorted(Dir, 'ase', Src, "alice 1\nbob 2\n", S),
+    assertion(S == ["alice", "bob"]),
+    !.
+
+% Equality is exact (a prefix does not match): `== "al"` matches neither
+% "alice" nor "alicia".
+test(string_eq_is_exact, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t { if ($1 == \"al\") print $1 }\n\c
+           pass rows of t { if ($1 == \"alice\") print $1 }\n",
+    run_sorted(Dir, 'exact', Src, "alice x\nalicia y\n", S),
+    assertion(S == ["alice"]),
+    !.
+
+:- end_tests(plawk_guard_string).
+
+% --- helpers ---------------------------------------------------------------
+
+gdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_guard_string', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Summary

Second of the reader-guard extensions. A guard can now filter by a **text column** against a string literal — the common "WHERE cust = 'alice'" case.

```awk
pass records of t as r { if (r["cust"] == "alice") print r["amt"] }
pass rows    of t as r { if (r[1]      != "bob")   print r[2]      }
pass rows    of t        { if ($1       == "alice") print $1        }
```

Only `==` / `!=` are meaningful (string ordering is a follow-on).

## What changed

- **Parser**: `guard_rhs//1` gains a string-literal clause → `str(Text)`, tried first (a string starts with `"`, unambiguous vs. the float/integer clauses).
- **Codegen**: `plawk_records_guard_ir` dispatches on the RHS kind. A `str(S)` extracts the column as a byte slice (`@wam_atom_field_slice_value`), checks its length equals the literal's, and **only then** `memcmp`s — so a literal longer than the field never reads out of bounds. `==`/`!=` pick opposite branch targets (a length mismatch is "not equal"). The literal is a private c-string global, threaded out through a new `Globals` output on `plawk_multipass_records_fn_ir` (named by pass index) to the pass function's module-globals slot; int/float guards thread an empty global, so their IR is unchanged.

## Tests

`tests/test_plawk_guard_string.pl` (6): parse (`str` RHS, int/float unchanged); named `==`/`!=`, positional, and anon string guards; a literal longer than any field (**out-of-bounds safety**); exactness (a prefix does not match). The integer-/float-guard suites and the records/rows reader suites stay green.

## Next

**Boolean `&&` / `||`** combinations — the last of the three guard extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_