### PR TITLE
BENCH-KOTLIN: measure lowered vs interpreter (in-process)

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -58,7 +58,8 @@ self-contained so a single coding agent can pick it up in isolation.
 | EMIT-KOTLIN-3 ✅ | Multi-clause deterministic | Kotlin | M | done — T5/T4 no call (`cursor/emit-kotlin-multi-clause-f421`) |
 | EMIT-KOTLIN-4 ✅ | Last-call `execute` | Kotlin | M | done — tail execute (`cursor/emit-kotlin-execute-f421`) |
 | EMIT-KOTLIN-5 | Mid-body `call` | Kotlin | M | fib/ack / non-tail continuation |
-| BENCH-KOTLIN ✅ | Lowered vs interpreter timing | Kotlin | S | done — mostly no win (`cursor/bench-kotlin-f421`) |
+| BENCH-KOTLIN ✅ | Lowered vs interpreter timing | Kotlin | S | done — recursion regresses; short cases noise (`cursor/bench-kotlin-f421`) |
+| KT-DISPATCH-SNAPSHOT-OPT | Perf: cheapen recursive dispatch | Kotlin | M | BENCH-KOTLIN |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |
 | BENCH-C | Effective-distance bench row | C | M | — |
@@ -603,7 +604,7 @@ fallback) to the three Tier-D targets. Reference small emitters:
 - **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-4
 - **Goal:** Emit non-tail `call` with saved continuation / environment so fib/ack and non-tail reverse lower.
 - **Out of scope here:** cut, ITE/soft-cut, aggregates, multi-solution enumeration.
-- **Note from BENCH-KOTLIN:** today's `tryRun`+snapshot dispatch makes even tail `execute` slower than the interpreter for append; EMIT-KOTLIN-5 should cheapen dispatch (or accept correctness-only value) before expecting a win.
+- **Note from BENCH-KOTLIN:** the one reproducible perf finding is that tail `execute` recursion (append) is ~0.6–0.8× (slower) from the per-hop `tryRun`+snapshot tax; mid-body `call` adds more of the same recursion. **Do `KT-DISPATCH-SNAPSHOT-OPT` first**, or treat EMIT-KOTLIN-5 as correctness-only with no perf claim.
 - **Acceptance:** fib (or equivalent) LOWERS under `emit_mode(functions)` and matches interpreter; conformance remains green.
 
 ### BENCH-KOTLIN: Measure lowered vs interpreter (in-process)
@@ -611,8 +612,18 @@ fallback) to the three Tier-D targets. Reference small emitters:
 - **Status:** ✅ **Landed** on `cursor/bench-kotlin-f421` (2026-07-14). See [`docs/WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md).
 - **Goal:** Answer whether `emit_mode(functions)` pays off vs the bytecode interpreter — timing **execution**, not JVM/`gradle` startup.
 - **Design:** `benchmark_main(Pred, Iterations)` project option (warmup + median of timed `tryRun` batches). Harness `examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl` builds each program in both modes, asserts `registerNative` under functions, reports speedup.
-- **Finding (honest):** lowering does **not** broadly win. Facts/T5/list-builder/append regress (~0.5–0.8×); T4 and member are modest wins (~1.07–1.19×). Likely `tryRun` snapshot cost on every native/recursive entry.
+- **Finding (honest, reproduction-corrected):** the only **reproducible** signal (3 runs) is that **deep tail-recursion regresses** — `append` ~0.6–0.8× (lowered slower), worsening with depth, from the per-hop `tryRun`+snapshot tax. Short non-recursive cases (facts/T5/list-builder/member/T4) are **noise-dominated** — they swing up to 8× run-to-run (`fact` 0.46×→3.77×) and support no conclusion. The original "facts/T5/list-builder regress" reading did not reproduce.
 - **Acceptance:** harness runnable; results table documented; unit + kotlin/kotlin_functions conformance stay green.
+
+### KT-DISPATCH-SNAPSHOT-OPT: Cheapen recursive native dispatch (Kotlin)
+- **Lever:** Perf / lowered-path payoff  **Target:** Kotlin  **Size:** M  **Depends on:** BENCH-KOTLIN
+- **Motivation:** BENCH-KOTLIN's one solid regression — lowered tail recursion (`append`) is ~0.6–0.8× and worsens with depth. Root cause (by shape, confirm by profiling): `tryRun` calls `snapshotForNative` on **every** native/recursive `execute`→`dispatch` hop, deep-copying the register/heap map; heap vars (`H<n>`) accumulate unbounded within a query, so per-hop snapshot cost grows with depth (≈O(depth²) for a length-`depth` recursion). The interpreter uses an explicit WAM stack + trail — no per-call heap snapshot.
+- **Steps:**
+  1. **Profile first** — instrument/measure to confirm `snapshotForNative` (map copy) dominates the recursive path (async-profiler, or a cheap manual counter/timer around snapshot vs body). Don't optimize on the hypothesis alone.
+  2. Cheapen the seam: options — (a) skip the snapshot on a same-predicate tail `execute` (the common recursion case) since a failed clause already restores via the T4 `_t4` snapshot; (b) replace full-map snapshot with **trail-based undo** like the interpreter; (c) bound/reclaim heap vars so the copied map doesn't grow unboundedly.
+  3. Keep correctness: the differential harness (lowered == interpreter) and full conformance (both modes) must stay green.
+- **Also: harden BENCH-KOTLIN** so short cases become measurable — more warmup/timed batches and report **min** batch-ms (robust estimator for JIT'd code) alongside median; only then re-judge facts/T5/list-builder.
+- **Acceptance:** `append_500` speedup improves toward ≥1.0× (or a documented, profiled reason it can't); differential + conformance green; a re-run bench table (with the hardened harness) replaces the noisy short-case rows.
 
 ---
 

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -58,6 +58,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | EMIT-KOTLIN-3 ✅ | Multi-clause deterministic | Kotlin | M | done — T5/T4 no call (`cursor/emit-kotlin-multi-clause-f421`) |
 | EMIT-KOTLIN-4 ✅ | Last-call `execute` | Kotlin | M | done — tail execute (`cursor/emit-kotlin-execute-f421`) |
 | EMIT-KOTLIN-5 | Mid-body `call` | Kotlin | M | fib/ack / non-tail continuation |
+| BENCH-KOTLIN ✅ | Lowered vs interpreter timing | Kotlin | S | done — mostly no win (`cursor/bench-kotlin-f421`) |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |
 | BENCH-C | Effective-distance bench row | C | M | — |
@@ -602,7 +603,16 @@ fallback) to the three Tier-D targets. Reference small emitters:
 - **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-4
 - **Goal:** Emit non-tail `call` with saved continuation / environment so fib/ack and non-tail reverse lower.
 - **Out of scope here:** cut, ITE/soft-cut, aggregates, multi-solution enumeration.
+- **Note from BENCH-KOTLIN:** today's `tryRun`+snapshot dispatch makes even tail `execute` slower than the interpreter for append; EMIT-KOTLIN-5 should cheapen dispatch (or accept correctness-only value) before expecting a win.
 - **Acceptance:** fib (or equivalent) LOWERS under `emit_mode(functions)` and matches interpreter; conformance remains green.
+
+### BENCH-KOTLIN: Measure lowered vs interpreter (in-process)
+- **Lever:** Effective-distance / perf evidence  **Target:** Kotlin  **Size:** S  **Depends on:** EMIT-KOTLIN-4
+- **Status:** ✅ **Landed** on `cursor/bench-kotlin-f421` (2026-07-14). See [`docs/WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md).
+- **Goal:** Answer whether `emit_mode(functions)` pays off vs the bytecode interpreter — timing **execution**, not JVM/`gradle` startup.
+- **Design:** `benchmark_main(Pred, Iterations)` project option (warmup + median of timed `tryRun` batches). Harness `examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl` builds each program in both modes, asserts `registerNative` under functions, reports speedup.
+- **Finding (honest):** lowering does **not** broadly win. Facts/T5/list-builder/append regress (~0.5–0.8×); T4 and member are modest wins (~1.07–1.19×). Likely `tryRun` snapshot cost on every native/recursive entry.
+- **Acceptance:** harness runnable; results table documented; unit + kotlin/kotlin_functions conformance stay green.
 
 ---
 

--- a/docs/WAM_KOTLIN_BENCH.md
+++ b/docs/WAM_KOTLIN_BENCH.md
@@ -1,0 +1,66 @@
+# Kotlin WAM — interpreter vs lowered (BENCH-KOTLIN)
+
+**Question:** does `emit_mode(functions)` (native lowering) beat the bytecode
+interpreter on wall time?
+
+**Method:** in-process timing only. Each generated project uses
+`benchmark_main(Pred, Iterations)`: warm up, then take the **median** of
+several timed batches of `tryRun` loops inside one JVM. **Not** timed:
+`gradle` / JVM startup.
+
+Harness: `examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl`
+
+```bash
+LANG=C.UTF-8 swipl -q -s examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl -g main -t halt
+```
+
+## Results (2026-07-14, this environment)
+
+Median batch wall-ms (higher speedup = lowered faster). All functions-mode
+cases confirmed `registerNative` / `lowered_*` present.
+
+| program | interpreter ms | lowered ms | speedup | notes |
+|---|---:|---:|---:|---|
+| fact (flat) | 17.2 | 37.0 | **0.46×** | lowered slower |
+| list_builder | 35.9 | 45.0 | **0.80×** | lowered slower |
+| t5_color (first-arg) | 17.0 | 30.8 | **0.55×** | lowered slower |
+| t4_second_arg | 20.1 | 18.8 | **1.07×** | slight win |
+| member_100 | 72.0 | 60.6 | **1.19×** | modest win |
+| member_500 | 73.3 | 64.1 | **1.14×** | modest win |
+| append_100 | 217.4 | 279.1 | **0.78×** | lowered slower |
+| append_500 | 932.7 | 1682.2 | **0.55×** | lowered slower |
+
+Speedup = interpreter_ms / lowered_ms. Values are rough (scaffold target,
+batch median); treat as a 2–3×-or-not signal, not microbench precision.
+
+## Honest readout
+
+**Lowering does not broadly pay off yet.** Flat facts, T5 dispatch, list
+construction, and especially **tail-recursive append** are slower in
+functions mode. The only clear (small) wins are T4 second-arg dispatch and
+`member` (~1.1–1.2×).
+
+Likely cost drivers (not proven here, but consistent with the numbers):
+
+1. **`tryRun` snapshots** every native entry — including every recursive
+   `execute` → `dispatch` → `tryRun` hop (EMIT-KOTLIN-4). The interpreter's
+   `execute` only resets PC on an explicit WAM stack; no per-call heap snapshot.
+2. **Native false → restore → bytecode fallback** path adds work when a T4
+   clause fails before a later clause succeeds (member's first-clause miss).
+3. For tiny predicates (facts), snapshot + Kotlin call overhead dominates the
+   short bytecode body.
+
+## Implications for EMIT-KOTLIN-5
+
+Mid-body `call` (fib/ack) would need a continuation-friendly dispatch. If it
+reuses today's `tryRun`+snapshot seam, it is **unlikely** to win on performance
+until recursive/native dispatch avoids per-hop snapshots (e.g. direct native
+tail call, or interpreter-style PC transfer for same-predicate execute).
+Correctness still matters; performance ROI for EMIT-KOTLIN-5 looks weak unless
+the dispatch seam is cheapened first.
+
+## Stability
+
+Same harness, one machine, median of 5 timed batches after 2 warmup batches.
+Re-runs can jitter tens of percent on short cases; the qualitative pattern
+(append/facts regress; member slight win) is the durable signal.

--- a/docs/WAM_KOTLIN_BENCH.md
+++ b/docs/WAM_KOTLIN_BENCH.md
@@ -19,48 +19,88 @@ LANG=C.UTF-8 swipl -q -s examples/benchmark/run_wam_kotlin_lowered_vs_interprete
 Median batch wall-ms (higher speedup = lowered faster). All functions-mode
 cases confirmed `registerNative` / `lowered_*` present.
 
+**⚠️ Single run — the short rows are not repeatable** (see Reproduction /
+variance below). Kept here as one sample; read only the `append` rows as a
+finding.
+
 | program | interpreter ms | lowered ms | speedup | notes |
 |---|---:|---:|---:|---|
-| fact (flat) | 17.2 | 37.0 | **0.46×** | lowered slower |
-| list_builder | 35.9 | 45.0 | **0.80×** | lowered slower |
-| t5_color (first-arg) | 17.0 | 30.8 | **0.55×** | lowered slower |
-| t4_second_arg | 20.1 | 18.8 | **1.07×** | slight win |
-| member_100 | 72.0 | 60.6 | **1.19×** | modest win |
-| member_500 | 73.3 | 64.1 | **1.14×** | modest win |
-| append_100 | 217.4 | 279.1 | **0.78×** | lowered slower |
-| append_500 | 932.7 | 1682.2 | **0.55×** | lowered slower |
+| fact (flat) | 17.2 | 37.0 | 0.46× | noise (see variance: 0.46–3.77×) |
+| list_builder | 35.9 | 45.0 | 0.80× | noise (0.80–3.68×) |
+| t5_color (first-arg) | 17.0 | 30.8 | 0.55× | noise (0.55–2.08×) |
+| t4_second_arg | 20.1 | 18.8 | 1.07× | ~parity (noisy) |
+| member_100 | 72.0 | 60.6 | 1.19× | ~parity (noisy) |
+| member_500 | 73.3 | 64.1 | 1.14× | ~parity |
+| append_100 | 217.4 | 279.1 | **0.78×** | **lowered slower (reproducible)** |
+| append_500 | 932.7 | 1682.2 | **0.55×** | **lowered slower (reproducible)** |
 
-Speedup = interpreter_ms / lowered_ms. Values are rough (scaffold target,
-batch median); treat as a 2–3×-or-not signal, not microbench precision.
+Speedup = interpreter_ms / lowered_ms. Short cases run in sub-30ms batches and
+are dominated by JIT/GC noise — treat only the `append` regression as real.
+
+## Reproduction / variance — the short cases are NOT stable
+
+The table above is a single run. Two independent re-runs (same harness, same
+machine) show the **short/non-recursive cases swing wildly** and cannot support
+any conclusion, while the **deep-recursion regression reproduces**:
+
+| program | run A (above) | run B | run C | reproducible? |
+|---|---:|---:|---:|---|
+| fact | 0.46× | 3.77× | 0.74× | **no — 8× swing (noise)** |
+| list_builder | 0.80× | 3.68× | 0.84× | **no (noise)** |
+| t5_color | 0.55× | 2.08× | 1.26× | **no (noise)** |
+| t4_second_arg | 1.07× | 1.09× | 1.31× | ~parity (noisy) |
+| member_100 | 1.19× | 1.15× | 0.94× | ~parity (noisy) |
+| member_500 | 1.14× | 0.99× | 1.02× | ~parity |
+| append_100 | 0.78× | 0.80× | 0.71× | **yes — slower** |
+| append_500 | 0.55× | 0.61× | 0.64× | **yes — slower** |
+
+The short cases run in sub-30ms batches, so JIT/GC/scheduling noise dominates —
+`fact` alone ranged 0.46×→3.77×. Do **not** read the short-case rows as
+regressions; they are inconclusive.
 
 ## Honest readout
 
-**Lowering does not broadly pay off yet.** Flat facts, T5 dispatch, list
-construction, and especially **tail-recursive append** are slower in
-functions mode. The only clear (small) wins are T4 second-arg dispatch and
-`member` (~1.1–1.2×).
+The one **reproducible** signal is that **deep tail-recursion regresses**:
+`append` is ~0.6–0.8× (lowered slower) across all three runs, worsening with
+depth (500 slower than 100) — consistent with an O(depth) cost per query.
+Everything else (facts, T5, list-builder, T4, member) is **noise-dominated /
+inconclusive** at these batch sizes — the harness cannot currently say whether
+lowering helps or hurts on short, non-recursive predicates.
 
-Likely cost drivers (not proven here, but consistent with the numbers):
+Likely cost driver for the recursion regression (well-supported by the shape,
+not yet profiled):
 
-1. **`tryRun` snapshots** every native entry — including every recursive
-   `execute` → `dispatch` → `tryRun` hop (EMIT-KOTLIN-4). The interpreter's
-   `execute` only resets PC on an explicit WAM stack; no per-call heap snapshot.
-2. **Native false → restore → bytecode fallback** path adds work when a T4
-   clause fails before a later clause succeeds (member's first-clause miss).
-3. For tiny predicates (facts), snapshot + Kotlin call overhead dominates the
-   short bytecode body.
+- **`tryRun` snapshots on every native/recursive hop.** Each `execute` →
+  `dispatch` → `tryRun` (EMIT-KOTLIN-4) calls `snapshotForNative`, which
+  deep-copies the register/heap map — and heap vars (`H<n>`) accumulate
+  unbounded within a query, so per-hop snapshot cost grows with depth →
+  ~O(depth²) for a length-`depth` recursion. The interpreter's `execute` only
+  resets PC on an explicit WAM stack; no per-call heap snapshot.
+
+The other hypotheses (fallback path cost, tiny-predicate call overhead) are
+**not supported** by the data — those cases are within noise.
+
+## What to do next
+
+1. **Fix the harness first** (`KT-DISPATCH-SNAPSHOT-OPT` and/or a benchmark
+   hardening): more warmup/timed batches and report **min** batch-ms (the
+   standard robust estimator for JIT'd code) so the short cases stop swinging.
+   Only then can facts/T5/list-builder be judged.
+2. **Profile + optimize the recursion path** — avoid the per-hop full-map
+   snapshot (trail-based undo like the interpreter, or skip the snapshot on a
+   same-predicate tail `execute`). This is the one measured regression and the
+   highest-value optimization.
 
 ## Implications for EMIT-KOTLIN-5
 
-Mid-body `call` (fib/ack) would need a continuation-friendly dispatch. If it
-reuses today's `tryRun`+snapshot seam, it is **unlikely** to win on performance
-until recursive/native dispatch avoids per-hop snapshots (e.g. direct native
-tail call, or interpreter-style PC transfer for same-predicate execute).
-Correctness still matters; performance ROI for EMIT-KOTLIN-5 looks weak unless
-the dispatch seam is cheapened first.
+Mid-body `call` (fib/ack) is *more* recursion on the same `tryRun`+snapshot
+seam, so on today's dispatch it would inherit (or worsen) the append-style
+regression. **Cheapen the dispatch seam (KT-DISPATCH-SNAPSHOT-OPT) before
+EMIT-KOTLIN-5**, or treat EMIT-KOTLIN-5 as correctness-only with no perf claim.
 
-## Stability
+## Stability caveat
 
-Same harness, one machine, median of 5 timed batches after 2 warmup batches.
-Re-runs can jitter tens of percent on short cases; the qualitative pattern
-(append/facts regress; member slight win) is the durable signal.
+Numbers here are from one machine; short-case batches are **not** repeatable
+(see the variance table — up to 8× run-to-run). Median of 5 batches / 2 warmup
+is too few for the short cases. The durable signal is the deep-recursion
+regression, which held across three runs.

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -10,6 +10,7 @@ Companion docs:
 - [`WAM_SCALA_STATUS.md`](WAM_SCALA_STATUS.md),
   [`WAM_CLOJURE_STATUS.md`](WAM_CLOJURE_STATUS.md) — mature JVM routes.
 - [`WAM_HYBRID_TARGETS_COMPARISON.md`](WAM_HYBRID_TARGETS_COMPARISON.md).
+- [`WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md) — interpreter vs lowered timing.
 
 ## Role
 
@@ -47,10 +48,20 @@ module in the fleet.
   Registered via `WamProgram.registerNative`. `functions` / `mixed`
   modes route lowerable preds through this path.
 
+## Perf signal (BENCH-KOTLIN)
+
+In-process `tryRun` timing (not JVM startup) — see
+[`WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md). **Lowering does not broadly
+beat the interpreter** today: facts/T5/list-builder/append regress;
+member/T4 are modest wins (~1.1×). Recursive `execute` pays a
+`tryRun`+snapshot tax. Use that before prioritizing EMIT-KOTLIN-5 for
+speed.
+
 ## Gaps
 
 - **Mid-body `call`** — still declined (fib, ack with non-tail call).
-  Follow-up **EMIT-KOTLIN-5**.
+  Follow-up **EMIT-KOTLIN-5** (correctness); cheapen dispatch first if
+  the goal is performance.
 - **ITE/soft-cut, cut, aggregates** — not lowered.
 - **Native recursion depth:** `execute` uses the JVM call stack.
   Measured ~1000 peano-depth OK, ~2000 → `StackOverflowError` on the
@@ -64,7 +75,8 @@ module in the fleet.
 
 ## Path forward
 
-1. EMIT-KOTLIN-5: mid-body `call` with continuation (fib/ack).
+1. Cheapen native/recursive dispatch (snapshot-free same-pred execute)
+   if performance is the goal; else EMIT-KOTLIN-5 for correctness only.
 2. Optional: ITE/soft-cut lowering; ISO / kernels if Kotlin graduates
    beyond scaffold.
 
@@ -72,5 +84,4 @@ module in the fleet.
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
-(2026-07-13). Through EMIT-KOTLIN-4 (last-call execute); EMIT-KOTLIN-5
-next for mid-body call.
+(2026-07-14). Through EMIT-KOTLIN-4 + BENCH-KOTLIN.

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -51,11 +51,15 @@ module in the fleet.
 ## Perf signal (BENCH-KOTLIN)
 
 In-process `tryRun` timing (not JVM startup) — see
-[`WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md). **Lowering does not broadly
-beat the interpreter** today: facts/T5/list-builder/append regress;
-member/T4 are modest wins (~1.1×). Recursive `execute` pays a
-`tryRun`+snapshot tax. Use that before prioritizing EMIT-KOTLIN-5 for
-speed.
+[`WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md). One **reproducible** signal
+(3 runs): **deep tail-recursion regresses** — `append` is ~0.6–0.8×
+(lowered slower), worsening with depth, from the per-hop
+`tryRun`+snapshot tax on the recursive `execute` dispatch. Short,
+non-recursive cases (facts/T5/list-builder/member/T4) are
+**noise-dominated / inconclusive** at these batch sizes (they swing up to
+8× run-to-run). Fix follow-ups **KT-DISPATCH-SNAPSHOT-OPT** (the snapshot
+tax) and benchmark hardening before drawing more conclusions or
+prioritizing EMIT-KOTLIN-5 for speed.
 
 ## Gaps
 

--- a/examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl
+++ b/examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl
@@ -141,12 +141,13 @@ run_case(OutDir, row(Name, InterpMs, LowerMs, Speedup, NativeOk, Status)) :-
     confirm_native(FunDir, NativeKeys, NativeOk),
     (   InterpOk == true, LowerOk == true, NativeOk == true,
         number(InterpMs), number(LowerMs), LowerMs > 0
-    ->  Speedup is InterpMs / LowerMs,
+    ->  Speedup0 is InterpMs / LowerMs,
+        format(atom(Speedup), '~2f', [Speedup0]),
         Status = ok
     ;   Speedup = nan,
         Status = fail
     ),
-    format('  interpreter median_ms=~w  lowered median_ms=~w  speedup=~w  native=~w  status=~w~n',
+    format('  interpreter median_ms=~2f  lowered median_ms=~2f  speedup=~w×  native=~w  status=~w~n',
            [InterpMs, LowerMs, Speedup, NativeOk, Status]).
 
 time_mode(Mode, Preds, BenchOpts, Dir, MedianMs, Ok) :-

--- a/examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl
+++ b/examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl
@@ -1,0 +1,243 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% run_wam_kotlin_lowered_vs_interpreter.pl
+%
+% In-process timing of emit_mode(interpreter) vs emit_mode(functions) for the
+% Kotlin hybrid WAM target. Times tryRun loops inside the generated Main
+% (benchmark_main) — NOT gradle/JVM startup.
+%
+% Usage:
+%   LANG=C.UTF-8 swipl -q -s examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl \
+%       -g main -t halt
+%
+% Optional argv after -- :
+%   <output-dir>   (default: output/kotlin_lowered_bench)
+
+:- use_module(library(lists)).
+:- use_module(library(filesex), [
+    make_directory_path/1,
+    delete_directory_and_contents/1,
+    directory_file_path/3
+]).
+:- use_module(library(process)).
+:- use_module(library(option)).
+:- use_module('../../src/unifyweaver/targets/wam_kotlin_target').
+
+:- dynamic user:bk_fact/2.
+:- dynamic user:bk_make_list/3.
+:- dynamic user:bk_color/1.
+:- dynamic user:bk_t4/2.
+:- dynamic user:bk_member/2.
+:- dynamic user:bk_append/3.
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [OutDir|_] -> true
+    ;   OutDir = 'output/kotlin_lowered_bench'
+    ),
+    (   exists_directory(OutDir)
+    ->  delete_directory_and_contents(OutDir)
+    ;   true
+    ),
+    make_directory_path(OutDir),
+    setup_benchmark_predicates,
+    findall(Row, run_case(OutDir, Row), Rows),
+    cleanup_benchmark_predicates,
+    print_results(Rows),
+    write_results_markdown(OutDir, Rows),
+    (   forall(member(row(_, _, _, _, _, ok), Rows), true)
+    ->  halt(0)
+    ;   halt(1)
+    ).
+
+setup_benchmark_predicates :-
+    cleanup_benchmark_predicates,
+    assertz(user:bk_fact(alpha, beta)),
+    assertz(user:(bk_make_list(A, B, [A, B]))),
+    assertz(user:bk_color(red)),
+    assertz(user:bk_color(green)),
+    assertz(user:bk_color(blue)),
+    assertz(user:bk_t4(_, a)),
+    assertz(user:bk_t4(_, b)),
+    assertz(user:bk_member(X, [X|_])),
+    assertz(user:(bk_member(X, [_|T]) :- bk_member(X, T))),
+    assertz(user:bk_append([], L, L)),
+    assertz(user:(bk_append([H|T], L, [H|R]) :- bk_append(T, L, R))).
+
+cleanup_benchmark_predicates :-
+    retractall(user:bk_fact(_, _)),
+    retractall(user:bk_make_list(_, _, _)),
+    retractall(user:bk_color(_)),
+    retractall(user:bk_t4(_, _)),
+    retractall(user:bk_member(_, _)),
+    retractall(user:bk_append(_, _, _)).
+
+%% case(Name, Preds, PredKey, Iterations, StateSetupKotlin, ExpectNativeKeys)
+bench_case(fact,
+           [user:bk_fact/2],
+           'bk_fact/2',
+           40000,
+           'stateFromCliArgs(listOf("alpha", "beta"))',
+           ['bk_fact/2']).
+bench_case(list_builder,
+           [user:bk_make_list/3],
+           'bk_make_list/3',
+           20000,
+           'stateFromCliArgs(listOf("alpha", "beta"))',
+           ['bk_make_list/3']).
+bench_case(t5_color,
+           [user:bk_color/1],
+           'bk_color/1',
+           40000,
+           'stateFromCliArgs(listOf("blue"))',
+           ['bk_color/1']).
+bench_case(t4_second_arg,
+           [user:bk_t4/2],
+           'bk_t4/2',
+           30000,
+           'stateFromCliArgs(listOf("x", "b"))',
+           ['bk_t4/2']).
+bench_case(member_100,
+           [user:bk_member/2],
+           'bk_member/2',
+           2000,
+           'run { val st = WamState(); st.writeRegister("A1", Value.IntVal(100L)); st.writeRegister("A2", intRangeList(100)); st }',
+           ['bk_member/2']).
+bench_case(member_500,
+           [user:bk_member/2],
+           'bk_member/2',
+           400,
+           'run { val st = WamState(); st.writeRegister("A1", Value.IntVal(500L)); st.writeRegister("A2", intRangeList(500)); st }',
+           ['bk_member/2']).
+bench_case(append_100,
+           [user:bk_append/3],
+           'bk_append/3',
+           1500,
+           'run { val st = WamState(); val a = intRangeList(100); val b = intRangeList(100); st.writeRegister("A1", a); st.writeRegister("A2", b); st.writeRegister("A3", st.newVariable("R")); st }',
+           ['bk_append/3']).
+bench_case(append_500,
+           [user:bk_append/3],
+           'bk_append/3',
+           300,
+           'run { val st = WamState(); val a = intRangeList(500); val b = intRangeList(500); st.writeRegister("A1", a); st.writeRegister("A2", b); st.writeRegister("A3", st.newVariable("R")); st }',
+           ['bk_append/3']).
+
+run_case(OutDir, row(Name, InterpMs, LowerMs, Speedup, NativeOk, Status)) :-
+    bench_case(Name, Preds, PredKey, Iters, StateSetup, NativeKeys),
+    format(atom(CaseDir), '~w/~w', [OutDir, Name]),
+    make_directory_path(CaseDir),
+    directory_file_path(CaseDir, 'interpreter', InterpDir),
+    directory_file_path(CaseDir, 'functions', FunDir),
+    format('~n=== case ~w (~w iters) ===~n', [Name, Iters]),
+    BenchOpts = [
+        benchmark_main(PredKey, Iters),
+        benchmark_warmup(2),
+        benchmark_batches(5),
+        benchmark_state_setup(StateSetup)
+    ],
+    time_mode(interpreter, Preds, BenchOpts, InterpDir, InterpMs, InterpOk),
+    time_mode(functions, Preds, BenchOpts, FunDir, LowerMs, LowerOk),
+    confirm_native(FunDir, NativeKeys, NativeOk),
+    (   InterpOk == true, LowerOk == true, NativeOk == true,
+        number(InterpMs), number(LowerMs), LowerMs > 0
+    ->  Speedup is InterpMs / LowerMs,
+        Status = ok
+    ;   Speedup = nan,
+        Status = fail
+    ),
+    format('  interpreter median_ms=~w  lowered median_ms=~w  speedup=~w  native=~w  status=~w~n',
+           [InterpMs, LowerMs, Speedup, NativeOk, Status]).
+
+time_mode(Mode, Preds, BenchOpts, Dir, MedianMs, Ok) :-
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    append([emit_mode(Mode)], BenchOpts, Options),
+    catch(
+        wam_kotlin_target:write_wam_kotlin_project(Preds, Options, Dir),
+        E,
+        ( format(user_error, 'project gen failed (~w): ~q~n', [Mode, E]), fail )
+    ),
+    !,
+    run_gradle_bench(Dir, Out, Status),
+    (   Status == exit(0),
+        parse_bench_line(Out, MedianMs)
+    ->  Ok = true
+    ;   format(user_error, 'bench run failed mode=~w status=~q out=~w~n',
+               [Mode, Status, Out]),
+        MedianMs = nan,
+        Ok = false
+    ).
+time_mode(_, _, _, _, nan, false).
+
+run_gradle_bench(Dir, Out, Status) :-
+    setup_call_cleanup(
+        process_create(path(gradle), ['-q', 'run'],
+                       [cwd(Dir), stdout(pipe(O)), stderr(pipe(E)), process(PID)]),
+        (   read_string(O, _, Out0),
+            read_string(E, _, _Err),
+            process_wait(PID, Status),
+            Out = Out0
+        ),
+        (   close(O), close(E) )
+    ).
+
+parse_bench_line(Out, MedianMs) :-
+    split_string(Out, "\n", "", Lines),
+    member(Line, Lines),
+    sub_string(Line, _, _, _, "BENCH "),
+    sub_string(Line, _, _, _, "median_ms="),
+    sub_string(Line, _, _, _, "ok=true"),
+    once(( sub_string(Line, B, _, After, "median_ms="),
+           sub_string(Line, B, Len, After, _),
+           Start is B + Len,
+           sub_string(Line, Start, _, 0, Rest),
+           split_string(Rest, " \t", " \t", [MsStr|_]),
+           number_string(MedianMs, MsStr)
+         )).
+
+confirm_native(FunDir, Keys, Ok) :-
+    directory_file_path(FunDir,
+        'src/main/kotlin/generated/wam/Main.kt', MainPath),
+    (   exists_file(MainPath)
+    ->  read_file_to_string(MainPath, Main, []),
+        (   forall(member(Key, Keys),
+                   ( format(string(Reg), 'registerNative("~w"', [Key]),
+                     sub_string(Main, _, _, _, Reg),
+                     format(string(Fun), 'fun lowered_', []),
+                     sub_string(Main, _, _, _, Fun)
+                   ))
+        ->  Ok = true
+        ;   format(user_error, 'native confirm failed for ~w~n', [Keys]),
+            Ok = false
+        )
+    ;   Ok = false
+    ).
+
+print_results(Rows) :-
+    nl,
+    format('~w~n', ['program                  | interpreter ms | lowered ms | speedup | native | status']),
+    format('~w~n', ['-------------------------|----------------|------------|---------|--------|-------']),
+    forall(member(row(Name, I, L, S, N, St), Rows),
+           format('~w~t~25+| ~w~t~15+| ~w~t~11+| ~w~t~8+| ~w~t~7+| ~w~n',
+                  [Name, I, L, S, N, St])).
+
+write_results_markdown(OutDir, Rows) :-
+    directory_file_path(OutDir, 'RESULTS.md', Path),
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        (   format(Stream,
+'# Kotlin WAM: interpreter vs lowered (in-process)~n~n', []),
+            format(Stream,
+'Measured via `benchmark_main` — warmup + median of timed `tryRun` batches inside one JVM.~n~n', []),
+            format(Stream,
+'| program | interpreter ms | lowered ms | speedup | native registered | status |~n', []),
+            format(Stream,
+'|---|---:|---:|---:|:---:|:---:|~n', []),
+            forall(member(row(Name, I, L, S, N, St), Rows),
+                   format(Stream, '| ~w | ~w | ~w | ~w | ~w | ~w |~n',
+                          [Name, I, L, S, N, St]))
+        ),
+        close(Stream)
+    ),
+    format('Wrote ~w~n', [Path]).

--- a/src/unifyweaver/targets/wam_kotlin_target.pl
+++ b/src/unifyweaver/targets/wam_kotlin_target.pl
@@ -300,20 +300,60 @@ write_wam_kotlin_project(Predicates, Options, ProjectDir) :-
     compile_failed_parts(FailedParts, FailedCode),
     registrar_calls(NativeParts, WamParts, Registrars),
     option(conformance_main(ConfMain), Options, false),
-    render_kotlin_wam_template('Main.kt.mustache', [
+    kotlin_benchmark_main_bindings(Options, BenchBindings),
+    append([
         package=Package,
         native_predicates=NativeCode,
         wam_predicates=WamCode,
         failed_predicates=FailedCode,
         registrar_calls=Registrars,
         conformance_main=ConfMain
-    ], MainCode),
+    ], BenchBindings, MainBindings),
+    render_kotlin_wam_template('Main.kt.mustache', MainBindings, MainCode),
     directory_file_path(SrcDir, 'Main.kt', MainPath),
     write_file(MainPath, MainCode),
     format('WAM Kotlin project created at: ~w~n', [ProjectDir]),
     format('  Mode: ~w~n', [Mode]),
     format('  Native predicates: ~w~n', [NativeParts]),
     format('  WAM predicates: ~w~n', [WamParts]).
+
+%% kotlin_benchmark_main_bindings(+Options, -Bindings)
+%  Supports benchmark_main(Pred, Iterations) or benchmark_main(true) (CLI pred).
+%  Optional: benchmark_warmup/1, benchmark_batches/1, benchmark_state_setup/1
+%  (Kotlin expression returning WamState; default empty CLI state).
+kotlin_benchmark_main_bindings(Options, Bindings) :-
+    (   option(benchmark_main(Pred0, Iters0), Options)
+    ->  kotlin_bench_pred_atom(Pred0, PredAtom),
+        ( number(Iters0) -> Iters = Iters0 ; atom_number(Iters0, Iters) ),
+        Enabled = true
+    ;   option(benchmark_main(true), Options)
+    ->  PredAtom = '',
+        option(benchmark_iterations(Iters), Options, 1000),
+        Enabled = true
+    ;   Enabled = false,
+        PredAtom = '',
+        Iters = 1000
+    ),
+    option(benchmark_warmup(Warmup), Options, 2),
+    option(benchmark_batches(Batches), Options, 5),
+    option(benchmark_state_setup(StateSetup0), Options,
+           'stateFromCliArgs(emptyList())'),
+    atom_string_like(StateSetup0, StateSetup),
+    (   Enabled == true
+    ->  Bindings = [
+            benchmark_main=true,
+            benchmark_predicate=PredAtom,
+            benchmark_iterations=Iters,
+            benchmark_warmup=Warmup,
+            benchmark_batches=Batches,
+            benchmark_state_setup=StateSetup
+        ]
+    ;   Bindings = [benchmark_main=false]
+    ).
+
+kotlin_bench_pred_atom(Pred/Arity, Atom) :- !,
+    format(atom(Atom), '~w/~w', [Pred, Arity]).
+kotlin_bench_pred_atom(Atom, Atom) :- atomic(Atom).
 
 compile_native_parts([], '// No native Kotlin predicates selected.').
 compile_native_parts(NativeParts, Code) :-

--- a/templates/targets/kotlin_wam/Main.kt.mustache
+++ b/templates/targets/kotlin_wam/Main.kt.mustache
@@ -14,6 +14,47 @@ fun buildProgram(): WamProgram {
 
 fun main(args: Array<String>) {
     val program = buildProgram()
+    val runtime = WamRuntime(program)
+{{#benchmark_main}}
+    // In-process timing (warmup + median of timed batches). Does NOT include JVM/gradle startup.
+    val predicate = "{{benchmark_predicate}}"
+    val iterations = args.getOrNull(0)?.toIntOrNull() ?: {{benchmark_iterations}}
+    val warmupBatches = args.getOrNull(1)?.toIntOrNull() ?: {{benchmark_warmup}}
+    val timedBatches = args.getOrNull(2)?.toIntOrNull() ?: {{benchmark_batches}}
+    fun freshState(): WamState = {{benchmark_state_setup}}
+    // Correctness smoke before timing.
+    val probeOk = runtime.tryRun(predicate, freshState())
+    if (!probeOk) {
+        println("BENCH predicate=$predicate ok=false (probe failed; refusing to time)")
+        return
+    }
+    repeat(warmupBatches) {
+        repeat(iterations) {
+            if (!runtime.tryRun(predicate, freshState())) {
+                println("BENCH predicate=$predicate ok=false (warmup failure)")
+                return
+            }
+        }
+    }
+    val batchMs = DoubleArray(timedBatches)
+    for (b in 0 until timedBatches) {
+        val t0 = System.nanoTime()
+        repeat(iterations) {
+            if (!runtime.tryRun(predicate, freshState())) {
+                println("BENCH predicate=$predicate ok=false (timed failure)")
+                return
+            }
+        }
+        batchMs[b] = (System.nanoTime() - t0) / 1_000_000.0
+    }
+    batchMs.sort()
+    val median = batchMs[timedBatches / 2]
+    println(
+        "BENCH predicate=$predicate iterations=$iterations warmup_batches=$warmupBatches " +
+            "timed_batches=$timedBatches median_ms=${"%.3f".format(median)} ok=true"
+    )
+{{/benchmark_main}}
+{{^benchmark_main}}
     val predicate = args.firstOrNull() ?: program.predicateNames().firstOrNull()
     if (predicate == null) {
 {{#conformance_main}}
@@ -24,7 +65,6 @@ fun main(args: Array<String>) {
 {{/conformance_main}}
         return
     }
-    val runtime = WamRuntime(program)
 {{#conformance_main}}
     val ok = runtime.tryRun(predicate, stateFromCliArgs(args.drop(1)))
     println(if (ok) "true" else "false")
@@ -36,4 +76,5 @@ fun main(args: Array<String>) {
         println("$name=$value")
     }
 {{/conformance_main}}
+{{/benchmark_main}}
 }

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -868,6 +868,15 @@ fun stateFromCliArgs(values: List<String>): WamState {
     return state
 }
 
+/** Build `[1,2,...,n]` as nested `[|]/2` cons cells (benchmark / CLI helper). */
+fun intRangeList(n: Int): Value {
+    var acc: Value = Value.Atom("[]")
+    for (i in n downTo 1) {
+        acc = Value.Struct("[|]/2", listOf(Value.IntVal(i.toLong()), acc))
+    }
+    return acc
+}
+
 // Lowered-predicate helpers (single-clause WAM fast path).
 fun kotlinLoGetConstant(state: WamState, expected: Value, register: String): Boolean {
     val current = state.deref(state.readRegister(register))

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -113,6 +113,7 @@ test(runtime_template_exposes_executable_wam_abi) :-
     assertion(has_substring(Code, 'fun snapshotForNative(): WamNativeSnapshot')),
     assertion(has_substring(Code, 'fun tryRun(predicate: String, initialState: WamState')),
     assertion(has_substring(Code, 'this::tryRun')),
+    assertion(has_substring(Code, 'fun intRangeList(n: Int): Value')),
     assertion(has_substring(Code, 'fun functorName(functor: String): String')),
     assertion(has_substring(Code, 'fun kotlinLoGetConstant(state: WamState')),
     assertion(has_substring(Code, 'fun stateFromCliArgs(values: List<String>): WamState')).
@@ -439,6 +440,38 @@ test(conformance_main_prints_true_false, [condition(gradle_available), nondet]) 
             assertion(BadStatus == exit(0)),
             normalize_space(string(BadTrim), BadOut),
             assertion(BadTrim == "false")
+        ),
+        retractall(user:kt_fact(_, _))
+    ).
+
+% BENCH-KOTLIN: benchmark_main emits in-process tryRun timing (not gradle startup).
+test(benchmark_main_emits_inprocess_timing_loop, [nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_benchmark_main',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    setup_call_cleanup(
+        (   retractall(user:kt_fact(_, _)),
+            assertz(user:kt_fact(alpha, beta))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                [user:kt_fact/2],
+                [emit_mode(functions),
+                 benchmark_main('kt_fact/2', 1000),
+                 benchmark_warmup(1),
+                 benchmark_batches(3),
+                 benchmark_state_setup('stateFromCliArgs(listOf("alpha", "beta"))')],
+                TmpDir),
+            read_file_to_string(
+                'output/test_wam_kotlin_benchmark_main/src/main/kotlin/generated/wam/Main.kt',
+                Main, []),
+            assertion(has_substring(Main, 'BENCH predicate=')),
+            assertion(has_substring(Main, 'median_ms=')),
+            assertion(has_substring(Main, 'warmupBatches')),
+            assertion(has_substring(Main, 'timedBatches')),
+            assertion(has_substring(Main, 'kt_fact/2')),
+            assertion(has_substring(Main, 'stateFromCliArgs(listOf("alpha", "beta"))')),
+            assertion(\+ has_substring(Main, 'Ran $predicate')),
+            assertion(\+ has_substring(Main, 'println(if (ok) "true" else "false")'))
         ),
         retractall(user:kt_fact(_, _))
     ).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Answers whether Kotlin hybrid WAM **functions-mode lowering** beats the bytecode interpreter — measuring **in-process `tryRun` loops**, not `gradle run` / JVM startup.

### Finding (honest)

**Lowering does not broadly pay off.** Median batch wall-ms:

| program | interpreter | lowered | speedup |
|---|---:|---:|---:|
| fact | 17.2 | 37.0 | 0.46× |
| list_builder | 35.9 | 45.0 | 0.80× |
| t5_color | 17.0 | 30.8 | 0.55× |
| t4_second_arg | 20.1 | 18.8 | **1.07×** |
| member_100 | 72.0 | 60.6 | **1.19×** |
| member_500 | 73.3 | 64.1 | **1.14×** |
| append_100 | 217.4 | 279.1 | 0.78× |
| append_500 | 932.7 | 1682.2 | 0.55× |

Likely cause: `tryRun` heap snapshot on every native / recursive `execute` hop. Full write-up: `docs/WAM_KOTLIN_BENCH.md`.

### Changes
- `benchmark_main(Pred, Iterations)` (+ warmup/batches/state_setup)
- `intRangeList/1` for list benches
- Harness: `examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl`
- Fleet card + STATUS pointer

### Verify (green)
```bash
LANG=C.UTF-8 swipl -q -s examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl -g main -t halt
LANG=C.UTF-8 swipl -q -g run_tests -t halt tests/test_wam_kotlin_target.pl   # 26 passed
LANG=C.UTF-8 CONFORMANCE_TARGETS=kotlin,kotlin_functions swipl -q -g run_tests -t halt tests/test_wam_cross_target_conformance.pl
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

