### PR TITLE
WAM/LLVM plawk: reader-guard extension — boolean && / || combinations

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -40,9 +40,12 @@ surface, the runtime ABI, and a phased rollout.
   operators `== != < <= > >=`), a **decimal float** (`3.5`, `-1.5`; the column
   is read as a double and compared with `fcmp`, so fractional thresholds and
   values work), or a **string** (`"alice"`, `==` / `!=` only — a
-  length-then-`memcmp` byte comparison). Filtered rows never reach the print
-  block (`tests/test_plawk_reader_guards.pl`, `tests/test_plawk_guard_float.pl`,
-  `tests/test_plawk_guard_string.pl`).
+  length-then-`memcmp` byte comparison). Comparisons combine with **`&&` / `||`**
+  (short-circuit, `&&` tighter than `||`, left-associative, parens allowed),
+  e.g. `if (r["amt"] > 100 && r["cust"] == "alice")`. Filtered rows never reach
+  the print block (`tests/test_plawk_reader_guards.pl`,
+  `tests/test_plawk_guard_float.pl`, `tests/test_plawk_guard_string.pl`,
+  `tests/test_plawk_guard_bool.pl`).
 
 **Not yet:** `rows of`'s `unsafe` / inline check-or-rename spec;
 the `over prev` reader (phase 4
@@ -1117,10 +1120,11 @@ single-pass test before any driver surgery).
   the six operators `== != < <= > >=`. An integer literal lowers to an i64
   field extract + `icmp`; a decimal float literal (`3.5`) to an f64 extract +
   `fcmp`; a string literal (`"alice"`, `==`/`!=`) to a length-then-`memcmp`
-  byte comparison — filtered rows never reach the print block — **LANDED**
+  byte comparison; and comparisons combine with `&&`/`||` (short-circuit
+  branches). Filtered rows never reach the print block — **LANDED**
   (`tests/test_plawk_reader_guards.pl`, `tests/test_plawk_guard_float.pl`,
-  `tests/test_plawk_guard_string.pl`; string ordering and boolean `&&`/`||`
-  combinations remain a follow-on).
+  `tests/test_plawk_guard_string.pl`, `tests/test_plawk_guard_bool.pl`; string
+  *ordering* (`<`/`>` on text) remains a follow-on).
 
 ## 6. Open questions
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3991,6 +3991,12 @@ plawk_reader_body([if(Guard, [print(Fields)], [])], Fields, Guard).
 % Resolve a `records of` guard (name column) to guard(ColIndex, Op, Value),
 % the schema position compared to an integer; `none` passes through.
 plawk_records_guard(none, _Var, _Columns, none).
+plawk_records_guard(and(L, R), Var, Columns, and(PL, PR)) :-
+    plawk_records_guard(L, Var, Columns, PL),
+    plawk_records_guard(R, Var, Columns, PR).
+plawk_records_guard(or(L, R), Var, Columns, or(PL, PR)) :-
+    plawk_records_guard(L, Var, Columns, PL),
+    plawk_records_guard(R, Var, Columns, PR).
 plawk_records_guard(rcol_cmp(Var, Col, Op, Value), Var, Columns,
         guard(Index, Op, Value)) :-
     plawk_records_col_index(Columns, Col, Index).
@@ -4028,6 +4034,12 @@ plawk_multipass_pass_fn(Index, pass_rows(var(Var), var(Table), Body), Tables,
 
 % Resolve a `rows of` guard (positional) -> guard(N, Op, Value); none passes.
 plawk_rows_guard(none, _Var, none).
+plawk_rows_guard(and(L, R), Var, and(PL, PR)) :-
+    plawk_rows_guard(L, Var, PL),
+    plawk_rows_guard(R, Var, PR).
+plawk_rows_guard(or(L, R), Var, or(PL, PR)) :-
+    plawk_rows_guard(L, Var, PL),
+    plawk_rows_guard(R, Var, PR).
 plawk_rows_guard(rpos_cmp(Var, N, Op, Value), Var, guard(N, Op, Value)) :-
     integer(N), N > 0.
 
@@ -4058,6 +4070,12 @@ plawk_multipass_pass_fn(Index, pass_rows_anon(var(Table), Body), Tables,
 
 % Resolve a no-`as` guard (`$N CMP int`) -> guard(N, Op, Value); none passes.
 plawk_rows_anon_guard(none, none).
+plawk_rows_anon_guard(and(L, R), and(PL, PR)) :-
+    plawk_rows_anon_guard(L, PL),
+    plawk_rows_anon_guard(R, PR).
+plawk_rows_anon_guard(or(L, R), or(PL, PR)) :-
+    plawk_rows_anon_guard(L, PL),
+    plawk_rows_anon_guard(R, PR).
 plawk_rows_anon_guard(rfield_cmp(N, Op, Value), guard(N, Op, Value)) :-
     integer(N), N > 0.
 
@@ -4170,53 +4188,109 @@ rec_after:
 %  literal (float_const, e.g. `3.5`) extracts it as double
 %  (@wam_atom_field_f64_value) and uses fcmp against the exact decimal ratio.
 plawk_records_guard_ir(none, _FieldSep, _Index, '  br label %rec_print', '').
-plawk_records_guard_ir(guard(ColIndex, Op, Value), FieldSep, _Index, IR, '') :-
+plawk_records_guard_ir(Guard, FieldSep, Index, IR, Globals) :-
+    Guard \== none,
+    plawk_guard_tree_lines(Guard, FieldSep, Index, 0, 'rec_print',
+        'rec_body_done', Lines, GlobalList, _N),
+    atomic_list_concat(Lines, '\n', IR),
+    atomic_list_concat(GlobalList, '\n', Globals).
+
+%% plawk_guard_tree_lines(+Guard, +FieldSep, +Index, +N0, +TrueLbl, +FalseLbl,
+%%     -Lines, -Globals, -N1)
+%  Lower a (possibly boolean) reader-guard tree to short-circuit branches: a
+%  leaf comparison branches to TrueLbl (match) / FalseLbl (skip); `and(L, R)`
+%  runs R only when L is true (L's true-target is a fresh block holding R);
+%  `or(L, R)` runs R only when L is false. N threads a counter so every leaf's
+%  SSA names and every join-block label are unique within the function.
+plawk_guard_tree_lines(and(L, R), FieldSep, Index, N0, TrueLbl, FalseLbl,
+        Lines, Globals, N2) :-
+    !,
+    format(atom(Mid), 'grand_~w_~w', [Index, N0]),
+    N1 is N0 + 1,
+    plawk_guard_tree_lines(L, FieldSep, Index, N1, Mid, FalseLbl, LLines, LG, Nm),
+    plawk_guard_tree_lines(R, FieldSep, Index, Nm, TrueLbl, FalseLbl, RLines, RG, N2),
+    format(atom(MidLabel), '~w:', [Mid]),
+    append([LLines, [MidLabel], RLines], Lines),
+    append(LG, RG, Globals).
+plawk_guard_tree_lines(or(L, R), FieldSep, Index, N0, TrueLbl, FalseLbl,
+        Lines, Globals, N2) :-
+    !,
+    format(atom(Mid), 'gror_~w_~w', [Index, N0]),
+    N1 is N0 + 1,
+    plawk_guard_tree_lines(L, FieldSep, Index, N1, TrueLbl, Mid, LLines, LG, Nm),
+    plawk_guard_tree_lines(R, FieldSep, Index, Nm, TrueLbl, FalseLbl, RLines, RG, N2),
+    format(atom(MidLabel), '~w:', [Mid]),
+    append([LLines, [MidLabel], RLines], Lines),
+    append(LG, RG, Globals).
+plawk_guard_tree_lines(guard(ColIndex, Op, Value), FieldSep, Index, N0,
+        TrueLbl, FalseLbl, [LeafIR], Globals, N1) :-
+    N1 is N0 + 1,
+    plawk_guard_leaf_ir(guard(ColIndex, Op, Value), FieldSep, Index, N0,
+        TrueLbl, FalseLbl, LeafIR, GlobalIR),
+    ( GlobalIR == '' -> Globals = [] ; Globals = [GlobalIR] ).
+
+%% plawk_guard_leaf_ir(+guard(Col,Op,Value), +FieldSep, +Index, +N,
+%%     +TrueLbl, +FalseLbl, -IR, -GlobalIR)
+%  One leaf comparison branching to TrueLbl (match) or FalseLbl (skip). SSA
+%  names are suffixed by N so multiple leaves of one boolean guard never
+%  collide. Integer -> i64 icmp; float_const -> f64 fcmp; str -> length + memcmp
+%  (the memcmp runs only when the lengths match, never reading past the field).
+plawk_guard_leaf_ir(guard(ColIndex, Op, Value), FieldSep, _Index, N,
+        TrueLbl, FalseLbl, IR, '') :-
     integer(Value),
     !,
     plawk_icmp_pred(Op, Pred),
     format(atom(IR),
-'  %rec_gv = call i64 @wam_atom_field_i64_value(%Value %rec_row_v, i64 ~w, i8 ~w)
-  %rec_gcmp = icmp ~w i64 %rec_gv, ~w
-  br i1 %rec_gcmp, label %rec_print, label %rec_body_done',
-        [ColIndex, FieldSep, Pred, Value]).
-plawk_records_guard_ir(guard(ColIndex, Op, float_const(M, D)), FieldSep, _Index, IR, '') :-
+'  %rec_gv_~w = call i64 @wam_atom_field_i64_value(%Value %rec_row_v, i64 ~w, i8 ~w)
+  %rec_gcmp_~w = icmp ~w i64 %rec_gv_~w, ~w
+  br i1 %rec_gcmp_~w, label %~w, label %~w',
+        [N, ColIndex, FieldSep, N, Pred, N, Value, N, TrueLbl, FalseLbl]).
+plawk_guard_leaf_ir(guard(ColIndex, Op, float_const(M, D)), FieldSep, _Index, N,
+        TrueLbl, FalseLbl, IR, '') :-
     !,
     plawk_fcmp_pred(Op, Pred),
     format(atom(IR),
-'  %rec_gcst = fdiv double ~w.0, ~w.0
-  %rec_gv = call double @wam_atom_field_f64_value(%Value %rec_row_v, i64 ~w, i8 ~w)
-  %rec_gcmp = fcmp ~w double %rec_gv, %rec_gcst
-  br i1 %rec_gcmp, label %rec_print, label %rec_body_done',
-        [M, D, ColIndex, FieldSep, Pred]).
-% String equality guard (`== "lit"` / `!= "lit"`): extract the column as a byte
-% slice, and match on length THEN memcmp -- the memcmp runs only when the
-% lengths are equal, so it never reads past the field. Ordering (< > …) on
-% strings is unsupported (no clause), so such a guard fails the reader shape.
-plawk_records_guard_ir(guard(ColIndex, Op, str(S)), FieldSep, Index, IR, GlobalIR) :-
-    plawk_str_guard_targets(Op, EqTarget, NeTarget, LenFailTarget),
-    format(atom(GName), 'plawk_guard_lit_~w', [Index]),
+'  %rec_gcst_~w = fdiv double ~w.0, ~w.0
+  %rec_gv_~w = call double @wam_atom_field_f64_value(%Value %rec_row_v, i64 ~w, i8 ~w)
+  %rec_gcmp_~w = fcmp ~w double %rec_gv_~w, %rec_gcst_~w
+  br i1 %rec_gcmp_~w, label %~w, label %~w',
+        [N, M, D, N, ColIndex, FieldSep, N, Pred, N, N, N, TrueLbl, FalseLbl]).
+plawk_guard_leaf_ir(guard(ColIndex, Op, str(S)), FieldSep, Index, N,
+        TrueLbl, FalseLbl, IR, GlobalIR) :-
+    plawk_str_leaf_targets(Op, TrueLbl, FalseLbl, EqT, NeT, LenFailT),
+    format(atom(GName), 'plawk_guard_lit_~w_~w', [Index, N]),
     llvm_emit_c_string_global(GName, S, GlobalIR, StrLen, BytesLen),
     format(atom(Gep),
         'getelementptr inbounds ([~w x i8], [~w x i8]* @.~w, i64 0, i64 0)',
         [BytesLen, BytesLen, GName]),
     format(atom(IR),
-'  %rec_gslice = call %WamSlice @wam_atom_field_slice_value(%Value %rec_row_v, i64 ~w, i8 ~w)
-  %rec_gptr = extractvalue %WamSlice %rec_gslice, 0
-  %rec_glen = extractvalue %WamSlice %rec_gslice, 1
-  %rec_glen_ok = icmp eq i64 %rec_glen, ~w
-  br i1 %rec_glen_ok, label %rec_gmemcmp, label %rec_glenfail
-rec_gmemcmp:
-  %rec_gmc = call i32 @memcmp(i8* %rec_gptr, i8* ~w, i64 ~w)
-  %rec_gmc_eq = icmp eq i32 %rec_gmc, 0
-  br i1 %rec_gmc_eq, label %~w, label %~w
-rec_glenfail:
+'  %rec_gslice_~w = call %WamSlice @wam_atom_field_slice_value(%Value %rec_row_v, i64 ~w, i8 ~w)
+  %rec_gptr_~w = extractvalue %WamSlice %rec_gslice_~w, 0
+  %rec_glen_~w = extractvalue %WamSlice %rec_gslice_~w, 1
+  %rec_glen_ok_~w = icmp eq i64 %rec_glen_~w, ~w
+  br i1 %rec_glen_ok_~w, label %rec_gmemcmp_~w, label %rec_glenfail_~w
+rec_gmemcmp_~w:
+  %rec_gmc_~w = call i32 @memcmp(i8* %rec_gptr_~w, i8* ~w, i64 ~w)
+  %rec_gmc_eq_~w = icmp eq i32 %rec_gmc_~w, 0
+  br i1 %rec_gmc_eq_~w, label %~w, label %~w
+rec_glenfail_~w:
   br label %~w',
-        [ColIndex, FieldSep, StrLen, Gep, StrLen, EqTarget, NeTarget, LenFailTarget]).
+        [N, ColIndex, FieldSep,
+         N, N,
+         N, N,
+         N, N, StrLen,
+         N, N, N,
+         N,
+         N, N, Gep, StrLen,
+         N, N,
+         N, EqT, NeT,
+         N,
+         LenFailT]).
 
-% Where each outcome of a string-equality guard branches. For `==`: equal
-% bytes -> print, unequal or different length -> skip. For `!=`: the mirror.
-plawk_str_guard_targets(eq, 'rec_print', 'rec_body_done', 'rec_body_done').
-plawk_str_guard_targets(ne, 'rec_body_done', 'rec_print', 'rec_print').
+% For a string leaf, map the True/False guard targets onto the memcmp outcomes.
+% `==`: equal bytes -> True, unequal or wrong length -> False. `!=`: the mirror.
+plawk_str_leaf_targets(eq, TrueLbl, FalseLbl, TrueLbl, FalseLbl, FalseLbl).
+plawk_str_leaf_targets(ne, TrueLbl, FalseLbl, FalseLbl, TrueLbl, TrueLbl).
 
 % Surface comparison op -> signed LLVM icmp predicate.
 plawk_icmp_pred(eq, eq).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1200,7 +1200,7 @@ for_in_body(Actions) -->
 % loop, so the operands live here rather than in the global pattern
 % grammar. Gates the per-key print; no cross-iteration state.
 for_in_body([if(Guard, [PrintAction], [])]) -->
-    "{", ws, "if", ws, "(", ws, forin_guard(Guard), ws, ")", ws,
+    "{", ws, "if", ws, "(", ws, guard_expr(Guard), ws, ")", ws,
     print_action(PrintAction), ws, "}",
     !.
 for_in_body([WritebinAction]) -->
@@ -1208,6 +1208,38 @@ for_in_body([WritebinAction]) -->
     !.
 for_in_body([PrintAction]) -->
     print_action(PrintAction).
+
+% A guard expression: one or more comparisons combined with `&&` / `||`
+% (short-circuit, `&&` binding tighter than `||`, left-associative, parens
+% allowed). A single comparison parses to the bare guard term (unchanged), so
+% existing single-guard `if`s are untouched; combinations parse to and(L, R) /
+% or(L, R). The leaves are the same forin_guard comparisons (reader guards
+% `r["col"] CMP L` etc.); boolean combination is supported by the row readers.
+guard_expr(Expr) -->
+    guard_or(Expr).
+guard_or(Expr) -->
+    guard_and(Left),
+    guard_or_rest(Left, Expr).
+guard_or_rest(Left, Expr) -->
+    ws, "||", ws, guard_and(Right),
+    !,
+    guard_or_rest(or(Left, Right), Expr).
+guard_or_rest(Expr, Expr) -->
+    [].
+guard_and(Expr) -->
+    guard_atom(Left),
+    guard_and_rest(Left, Expr).
+guard_and_rest(Left, Expr) -->
+    ws, "&&", ws, guard_atom(Right),
+    !,
+    guard_and_rest(and(Left, Right), Expr).
+guard_and_rest(Expr, Expr) -->
+    [].
+guard_atom(Expr) -->
+    "(", ws, guard_expr(Expr), ws, ")",
+    !.
+guard_atom(Guard) -->
+    forin_guard(Guard).
 
 % arr[k] CMP int -- value comparison (tried before the bare-key form,
 % since `arr[` also starts with an identifier).

--- a/tests/test_plawk_guard_bool.pl
+++ b/tests/test_plawk_guard_bool.pl
@@ -1,0 +1,146 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk reader-guard extensions -- BOOLEAN combinations (the capstone of the
+% guard extensions). A row-reader guard may combine comparisons with `&&` and
+% `||`: short-circuit, `&&` binding tighter than `||`, left-associative, parens
+% allowed. `if (r["amt"] > 100 && r["cust"] == "alice")`. A single comparison
+% is unchanged (parses to the bare guard term); combinations parse to and(L, R)
+% / or(L, R) and lower to short-circuit branches (each leaf branches to the next
+% test or to print/skip). Leaves may mix kinds (int / float / string). Applies
+% to all three readers.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_guard_bool).
+
+% --- parse -----------------------------------------------------------------
+
+% `&&` -> and(...), `||` -> or(...), a single comparison stays bare.
+test(and_parses) :-
+    guard_of("pass rows of t as r { if (r[2] > 3 && r[1] == \"a\") print r[1] }\n", G),
+    assertion(G == and(rpos_cmp(r, 2, gt, 3), rpos_cmp(r, 1, eq, str("a")))),
+    !.
+test(or_parses) :-
+    guard_of("pass rows of t as r { if (r[2] > 3 || r[2] < 1) print r[1] }\n", G),
+    assertion(G == or(rpos_cmp(r, 2, gt, 3), rpos_cmp(r, 2, lt, 1))),
+    !.
+test(single_unchanged) :-
+    guard_of("pass rows of t as r { if (r[2] > 3) print r[1] }\n", G),
+    assertion(G == rpos_cmp(r, 2, gt, 3)),
+    !.
+
+% `&&` binds tighter than `||`: a || b && c parses as or(a, and(b, c)).
+test(precedence) :-
+    guard_of("pass rows of t as r { if (r[1] == \"a\" || r[2] > 3 && r[3] < 9) print r[1] }\n", G),
+    assertion(G == or(rpos_cmp(r, 1, eq, str("a")),
+                      and(rpos_cmp(r, 2, gt, 3), rpos_cmp(r, 3, lt, 9)))),
+    !.
+% Parens override: (a || b) && c parses as and(or(a, b), c).
+test(parens) :-
+    guard_of("pass rows of t as r { if ((r[1] == \"a\" || r[2] > 3) && r[3] < 9) print r[1] }\n", G),
+    assertion(G == and(or(rpos_cmp(r, 1, eq, str("a")), rpos_cmp(r, 2, gt, 3)),
+                       rpos_cmp(r, 3, lt, 9))),
+    !.
+
+% --- end to end ------------------------------------------------------------
+
+% `&&` mixing an int and a string leaf.
+test(and_int_string, [condition(clang_available)]) :-
+    gdir(Dir),
+    directory_file_path(Dir, 'a.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare t(cust str, amt str) }\n\c
+         pass { t[$1] = row($1, $2) }\n\c
+         pass records of t as r { if (r[\"amt\"] > 100 && r[\"cust\"] == \"alice\") print r[\"cust\"] }\n", [Store]),
+    run_sorted(Dir, 'ais', Src, "alice 200\nbob 50\ncarol 300\ndan 120\n", S),
+    assertion(S == ["alice"]),          % >100 AND ==alice: only alice(200)
+    !.
+
+% `||` over two comparisons.
+test(or_two, [condition(clang_available)]) :-
+    gdir(Dir),
+    directory_file_path(Dir, 'o.db', Store),
+    ( exists_file(Store) -> delete_file(Store) ; true ),
+    format(atom(Src),
+        "BEGIN cache(\"~w\") { declare t(cust str, amt str) }\n\c
+         pass { t[$1] = row($1, $2) }\n\c
+         pass records of t as r { if (r[\"amt\"] > 150 || r[\"cust\"] == \"bob\") print r[\"cust\"] }\n", [Store]),
+    run_sorted(Dir, 'ot', Src, "alice 200\nbob 50\ncarol 300\ndan 120\n", S),
+    assertion(S == ["alice", "bob", "carol"]),   % >150 (alice,carol) OR ==bob
+    !.
+
+% Three-way `&&` chain over the anon reader ($N).
+test(three_way_and, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t { if ($2 > 1 && $2 < 100 && $3 == \"y\") print $1 }\n",
+    run_sorted(Dir, 'tw', Src, "a 10 y\nb 200 y\nc 3 n\nd 3 y\n", S),
+    assertion(S == ["a", "d"]),         % 1<v<100 AND col3==y: a(10,y), d(3,y)
+    !.
+
+% Precedence end to end: a || b && c (over the anon reader).
+test(precedence_runs, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t { if ($1 == \"z\" || $2 > 5 && $3 == \"y\") print $1 }\n",
+    run_sorted(Dir, 'pr', Src, "a 10 y\nb 200 y\nc 3 n\nz 0 n\nd 3 y\n", S),
+    assertion(S == ["a", "b", "z"]),    % z, OR (>5 AND y): a,b ; z by name
+    !.
+
+% Parens change the meaning: (a || b) && c.
+test(parens_runs, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t { if (($1 == \"z\" || $2 > 5) && $3 == \"y\") print $1 }\n",
+    run_sorted(Dir, 'pn', Src, "a 10 y\nb 200 y\nc 3 n\nz 0 n\nd 3 y\n", S),
+    assertion(S == ["a", "b"]),         % (z or >5) AND y: a,b ; z fails (col3 n)
+    !.
+
+% A float leaf inside a boolean.
+test(float_in_and, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t { if ($2 > 2.5 && $3 == \"y\") print $1 }\n",
+    run_sorted(Dir, 'fa', Src, "a 10 y\nc 3 n\nd 3 y\n", S),
+    assertion(S == ["a", "d"]),
+    !.
+
+:- end_tests(plawk_guard_bool).
+
+% --- helpers ---------------------------------------------------------------
+
+guard_of(Src, Guard) :-
+    plawk_parse_string(Src, program_passes(_, [pass_rows(_, _, [if(Guard, _, _)])], _)).
+
+gdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_guard_bool', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+run_sorted(Dir, Name, Src, Input, Sorted) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out), close(PS), process_wait(Pid, exit(0)),
+    split_string(Out, "\n", "", L0), exclude(==(""), L0, L), msort(L, Sorted).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
## Summary

The **capstone** of the reader-guard extensions. A guard may now combine comparisons with `&&` and `||`:

```awk
pass records of t as r { if (r["amt"] > 100 && r["cust"] == "alice") print r["cust"] }
pass rows    of t        { if ($1 == "z" || $2 > 5 && $3 == "y") print $1 }
```

Short-circuit, `&&` binding tighter than `||`, left-associative, parens allowed. Leaves may mix kinds (int / float / string).

## What changed

- **Parser**: a small precedence grammar (`guard_expr → guard_or → guard_and → guard_atom`, with `(...)`) wraps the existing `forin_guard` leaves into `and(L, R)` / `or(L, R)`. A single comparison still parses to the bare guard term, so existing single-guard `if`s (reader **and** assoc for-in) are byte-unchanged.
- **Codegen**: the three reader guard resolvers recurse through `and`/`or` into a guard tree; `plawk_records_guard_ir` lowers it with **short-circuit branching** — a leaf branches to a true/false target; `and(L, R)` sends L's true-edge to a fresh block holding R; `or(L, R)` sends L's false-edge there. A threaded counter makes every leaf's SSA names and every join-block label unique. The int/float/string leaf emitters were refactored into `plawk_guard_leaf_ir(N, TrueLbl, FalseLbl)` — same comparisons, now parameterized by their branch targets and a name suffix.

## Tests

`tests/test_plawk_guard_bool.pl` (11): parse (and/or, **precedence** — `&&` tighter than `||`, parens, single unchanged); end-to-end — `&&` mixing int+string, `||`, a **three-way** `&&` chain, precedence, parens, and a **float leaf inside a boolean**. The integer/float/string guard suites, the reader suites, and the assoc for-in filter suite all stay green.

## Guard-extension arc complete 🎉

Integer (base) → **float** (#3741) → **string** (#3743) → **boolean** (this). Reader guards are now a real `WHERE`: numeric + text columns, all six ops, combined with `&&`/`||`. Only string *ordering* (`<`/`>` on text) remains a noted follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_