### PR TITLE
docs: phase 6 query-reader implementation plan (over query(Goal))

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -1068,7 +1068,13 @@ single-pass test before any driver surgery).
   query-driven reader (each solution a record, on the `call/1` + dynamic-DB
   machinery); document and (optionally) check that pass bodies remain
   deterministic; surface the closure-based "compute-once, reuse" pattern;
-  confirm commit-barrier snapshot semantics in a test.
+  confirm commit-barrier snapshot semantics in a test. **Planned** in
+  `PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md`: a code-grounded four-PR sequence.
+  The key finding is that the goal-call surface is single-solution only, so the
+  reader **materialises** the solution set (a `findall` collapse at the reader
+  boundary — bounded-multiplicity, `UNIFYWEAVER_LANGUAGE_PRINCIPLES.md`
+  Principle 1) and iterates it like `over TABLE`, rather than retaining live
+  choicepoints (which §1 forbids in the hot loop).
 
 - **Phase 7 — secondary indexes (§3.5).** `index TABLE by FIELD [unique]` on
   record-valued tables; unique lookups return one record; non-unique

--- a/docs/design/PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,123 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2026 John William Creighton (@s243a)
+-->
+
+# plawk `over query(Goal)` reader — implementation plan (phase 6)
+
+**Status**: plan, not yet implemented. Sequences the work for the query-driven
+reader (`PLAWK_MULTIPASS_CACHE.md` §3.4, phase 6): a pass whose records are the
+**solutions of a Prolog goal**. This is the "most beyond awk" reader and the
+first place plawk admits controlled non-determinism, so it is planned carefully
+and grounded in the actual runtime surface before any build.
+
+## 1. Where we are (the blocking facts)
+
+- **The goal-call surface is single-solution.** Every `@wam_object_call_*`
+  primitive (`_i64`, `_bytes`, `_record`, `_posarray`, …) runs a predicate to
+  its **first** solution and returns `{value, i1 success}`, discarding the
+  choicepoint stack. `dyncall` / `dyncall_at` are built on these — they call a
+  predicate and take one deterministic result. Nothing iterates solutions.
+- **The WAM engine does have backtracking** (`try_me_else` / `retry_me_else` /
+  choicepoints / trail rewind), so the solutions exist internally; they are
+  just not exposed to a caller as an enumeration.
+- **`over TABLE` (`pass_over`) is the reader template.** It materialises a set
+  (a table's entries) and iterates it, binding each element and running the
+  body. A query reader is the same shape with a different source.
+
+The gap is therefore **not** backtracking itself but a way to turn a goal's
+solution set into a materialised sequence the pass can iterate.
+
+## 2. Approach: materialise, then iterate (not re-entrant coroutining)
+
+Do **not** expose re-entrant WAM iteration (retain choicepoints across the pass
+loop). Retaining a live choicepoint stack across records is exactly the
+"residual choicepoint in the hot loop" the determinism model (§1) forbids — it
+would pin the trail/heap and break constant-memory streaming. Instead, **run the
+goal to completion, collect all solutions into a buffer, then iterate the
+buffer** — the same move `over TABLE` already makes.
+
+This is the **bounded-multiplicity principle**
+(`UNIFYWEAVER_LANGUAGE_PRINCIPLES.md`, Principle 1) at the reader boundary: the
+query's multiplicity is collapsed into a materialised set *before* the body
+runs, so the body iterates a fixed, deterministic sequence. **Snapshot
+semantics fall out for free** — the solution set is frozen before the first
+record, so writes during the pass cannot perturb it.
+
+**The low-risk realisation — a `findall` wrapper.** Rather than build a new
+"drive the engine and capture each binding" runtime primitive, lower
+`over query(goal(X))` to a **`findall(Template, Goal, List)`** call through the
+*existing* single-solution object-call surface: `findall/3` is one deterministic
+result (the list), and the list materialises through the already-built posarray
+/ list machinery (`@wam_object_call_posarray`). The pass then iterates that list
+exactly like `over TABLE`. So the hard part (enumeration) is delegated to the
+WAM builtin that already does it, and no new backtracking-driver primitive is
+needed. (A direct engine-driven collector is the alternative if `findall/3` is
+unavailable or too costly; the plan keeps the surface identical either way.)
+
+## 3. Design decisions (the surface)
+
+- **What the goal is.** `over query(pred(A1, …, An))` where `pred` is a loaded
+  predicate — from an `@prolog { … }` block in the program or a `.wamo` object,
+  the same predicate universe `dyncall` / `dyncall_at` already reach.
+- **How a solution becomes a record.** Positional first: the goal's argument
+  bindings in each solution map to fields `$1..$n` of the record (mirroring the
+  awk field model and the `rows of` positional reader). A named/record binding
+  (`as r`, `r["field"]`) is a follow-on once the positional core works.
+- **Template.** The `findall` template is the tuple of the goal's arguments, so
+  each list element carries that solution's ground bindings; the reader walks
+  the element into `$1..$n`.
+- **Determinism.** The goal may be non-deterministic (many solutions) — that is
+  the point — but every solution is a ground record, and the collapse to a list
+  happens at the boundary, so the pass body stays deterministic (§1 intact).
+
+## 4. PR sequence
+
+Each step its own PR, green regressions before the next.
+
+### PR 1 — Surface + AST (parser), codegen stub
+
+Parse `pass over query(GOAL) { BODY }` to a `pass_query(Goal, Body)` clause
+(GOAL a `pred(args)` term reusing the existing prolog-call parsing). Codegen
+emits a clean, specific "query reader not yet implemented" compile error (like
+the class-A multi-table error) rather than the generic "outside surface". No
+runtime. Deliverable: the surface parses and is diagnosed; parse tests + the
+error test. Low risk, establishes the shape.
+
+### PR 2 — `findall` wrapper + solution materialisation (runtime/build)
+
+At build time, synthesise the `findall(Template, Goal, List)` wrapper for each
+query site and route it through the object-call so the solution list is
+materialised (list → posarray/table). This is the crux; it reuses the posarray
+list machinery. Verify with a fixed loaded predicate that N solutions produce an
+N-element materialised set.
+
+### PR 3 — Codegen: the query pass function
+
+Model on `pass_over`: after materialising the solution set (PR 2), iterate it,
+bind each solution's arguments to `$1..$n`, and run the body (`print $1, $2`).
+Deliverable: `pass over query(pred(X, Y)) { print $1, $2 }` prints one line per
+solution. Reader-guards (`if (…)`) compose for free if the body reuses the
+row-reader emitter.
+
+### PR 4 — Determinism guarantees + snapshot test + docs
+
+A test that a write during the query pass does not change the solution set
+(snapshot), and that a non-deterministic goal yields exactly its solutions in
+order. Document the containment (collapse-at-boundary) and cross-link
+`UNIFYWEAVER_LANGUAGE_PRINCIPLES.md` Principle 1 and the §3.10 contained-search
+sketch, of which this is the first concrete step.
+
+## 5. Risks / open questions
+
+- **Enumeration cost / memory.** `findall` materialises the whole solution set
+  — fine for bounded queries, unbounded for a generator. Document it; a lazy /
+  streaming query is explicitly out of scope (it would reintroduce the retained
+  choicepoint §1 forbids).
+- **Predicate universe & modes.** The goal's variables must be unbound at call
+  (outputs) or bound from the record (inputs); the first cut is all-output
+  (pure generator). Input binding from prior fields is a follow-on and connects
+  to the §3.10 `X in domain` producer.
+- **If `findall/3` is not a usable builtin here**, PR 2 becomes a direct
+  engine-driven collector (drive `retry_me_else` to exhaustion, capturing each
+  solution's registers) — deeper, but the surface (PRs 1, 3, 4) is unchanged.


### PR DESCRIPTION
## Summary

Opens the **query-driven reader** arc (phase 6) with a code-grounded plan. Documentation-only.

I investigated the runtime before committing, and it clarified the shape of the problem:

- The goal-call surface (`@wam_object_call_*`) is **single-solution** — runs a predicate to its *first* solution, returns `{value, i1}`, discards choicepoints. Nothing exposes a goal's solution *set*.
- The WAM engine *does* backtrack internally (`try_me_else`/`retry_me_else`), so the solutions exist; they're just not enumerable by a caller.

## New: `PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md`

**Core decision — materialise then iterate, not re-entrant coroutining.** Retaining a live choicepoint stack across the pass loop is exactly the residual-choicepoint-in-the-hot-loop the determinism model (§1) forbids, and would break constant-memory streaming. So the reader collapses the solution set to a list *at the boundary* (the **bounded-multiplicity** principle) and iterates it like `over TABLE`; **snapshot semantics fall out for free**.

**Low-risk realisation — a `findall` wrapper.** Lower `over query(goal(X))` to `findall(Template, Goal, List)` through the *existing* single-solution object-call + posarray list machinery — so enumeration is delegated to the WAM builtin and no new backtracking-driver primitive is needed.

**Four PRs:** (1) parser surface + AST + clean "not yet" error; (2) `findall` wrapper + solution materialisation; (3) the query pass function (materialise + iterate, modelled on `pass_over`, binding each solution to `$1..$n`); (4) determinism guarantees + snapshot test + docs. Plus risks (enumeration cost, predicate modes) and the direct engine-driven collector as a fallback with the surface unchanged.

Linked from the §5 phase-6 entry.

## Next

**PR 1** — the parser surface (`pass over query(GOAL) { … }` → `pass_query`) + a clean codegen "not yet" error. Self-contained, no runtime; I'll build it against this plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_