### PR TITLE
WAM/LLVM plawk: query reader PR 1 — `over query(...)` surface + AST + stub

### DIFF
--- a/docs/design/PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md
@@ -75,14 +75,19 @@ unavailable or too costly; the plan keeps the surface identical either way.)
 
 Each step its own PR, green regressions before the next.
 
-### PR 1 — Surface + AST (parser), codegen stub
+### PR 1 — Surface + AST (parser), codegen stub — **LANDED**
 
-Parse `pass over query(GOAL) { BODY }` to a `pass_query(Goal, Body)` clause
-(GOAL a `pred(args)` term reusing the existing prolog-call parsing). Codegen
-emits a clean, specific "query reader not yet implemented" compile error (like
-the class-A multi-table error) rather than the generic "outside surface". No
-runtime. Deliverable: the surface parses and is diagnosed; parse tests + the
-error test. Low risk, establishes the shape.
+`pass over query(PRED(V1, …, Vn)) { BODY }` parses to `pass_query(query(Pred,
+Vars), Body)` (a new `pass_clauses` clause, tried before `pass over TABLE` — the
+`(` after the predicate name distinguishes a query from a bare table). `Vars` is
+the goal's positional output-variable list; the body's `$1..$n` will address the
+solution's bindings. `plawk_pass_dynentry_rewrite` gains a passthrough clause so
+the top-level program parse accepts it. `check_query_reader/2` in
+`examples/plawk/bin/plawk` emits a clean, specific compile error (naming the
+goal as `pred/arity`) until the runtime lands, rather than the generic "outside
+the multi-pass surface". `tests/test_plawk_query_reader.pl`: parse (two-arg,
+one-arg, `over TABLE` unchanged), the not-yet error (exit 2), and a non-query
+program unaffected. No runtime.
 
 ### PR 2 — `findall` wrapper + solution materialisation (runtime/build)
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -101,6 +101,7 @@ build(File, Out0, KeepLL) :-
     normalize_passes(File, Program0, Program1),
     resolve_cache_use(File, Program1, Program),
     check_multitable_store(File, Program),
+    check_query_reader(File, Program),
     (   Clauses == []
     ->  Preds = [user:plawk_cli_marker/0]
     ;   (   plawk_prolog_block_preds(Clauses, Preds)
@@ -298,6 +299,23 @@ multitable_store(Program, Path, Backend, Names) :-
 
 program_begin_clauses(program(BeginClauses, _, _), BeginClauses).
 program_begin_clauses(program_passes(BeginClauses, _, _), BeginClauses).
+
+% Phase 6 (PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md): the `over query(...)`
+% reader parses (PR 1) but its runtime materialisation is not wired yet, so a
+% program that uses it gets a clear, specific diagnostic rather than the generic
+% "outside the multi-pass surface". The surface stays stable while the runtime
+% (PRs 2-3) lands.
+check_query_reader(File, program_passes(_, Passes, _)) :-
+    member(pass_query(query(Pred, Vars), _Body), Passes),
+    !,
+    length(Vars, N),
+    format(user_error,
+        'plawk: ~w uses `over query(~w/~w)`. The query-driven reader parses but \c
+         its runtime is not yet implemented (phase 6); see \c
+         PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md.~n',
+        [File, Pred, N]),
+    halt(2).
+check_query_reader(_File, _Program).
 
 % Multi-pass normalisation (PLAWK_MULTIPASS_CACHE.md phase 2). A single
 % `pass { ... }` block is exactly today's main loop, so it lowers to the

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -248,6 +248,23 @@ pass_clauses([pass_rows_anon(var(Table), Body) | Rest]) -->
 % print body (key / TABLE[VAR] / literal). Tried before the plain `pass`
 % (the `over` keyword is unambiguous). Represented as pass_over/3 so the
 % driver can emit a table-iterating pass function rather than an input scan.
+% A `pass over query(PRED(V1, ..., Vn)) { print $1, ... }` block: the
+% query-driven reader (PLAWK_MULTIPASS_CACHE.md §3.4, phase 6;
+% PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md). Each SOLUTION of the goal is a
+% record; the goal's argument variables (V1..Vn) are its output fields, mapped
+% positionally to `$1..$n`. Parses to pass_query(query(Pred, Vars), Body). Tried
+% before `pass over TABLE` (the `(` after the predicate name distinguishes a
+% query from a bare table name). The codegen surface is staged (PR 1 diagnoses
+% it; the runtime materialisation lands later).
+pass_clauses([pass_query(query(Pred, Vars), Body) | Rest]) -->
+    "pass", identifier_boundary, ws,
+    "over", identifier_boundary, ws,
+    "query", ws, "(", ws,
+    identifier(Pred), ws, "(", ws, query_var_list(Vars), ws, ")", ws,
+    ")", ws,
+    for_in_body(Body),
+    ws,
+    pass_clauses(Rest).
 pass_clauses([pass_over(var(Var), var(Table), Body) | Rest]) -->
     "pass", identifier_boundary, ws,
     "over", identifier_boundary, ws,
@@ -257,6 +274,19 @@ pass_clauses([pass_over(var(Var), var(Table), Body) | Rest]) -->
     for_in_body(Body),
     ws,
     pass_clauses(Rest).
+
+% The output-variable list of a query goal: one or more identifiers. Their
+% NAMES are placeholders; their POSITION is what maps a solution's bindings to
+% `$1..$n`.
+query_var_list([V | Vs]) -->
+    identifier(V),
+    query_var_list_rest(Vs).
+query_var_list_rest([V | Vs]) -->
+    ws, ",", ws, identifier(V),
+    !,
+    query_var_list_rest(Vs).
+query_var_list_rest([]) -->
+    [].
 % A `pass { ACTIONS }` block is one pass carrying a single always-rule with
 % those actions (per-pattern rules within a pass are a later extension).
 pass_clauses([pass([rule(always, Actions)]) | Rest]) -->
@@ -275,6 +305,8 @@ plawk_pass_dynentry_rewrite(_DynEntries, pass_records(V, T, Body), pass_records(
 plawk_pass_dynentry_rewrite(_DynEntries, pass_rows(V, T, Body), pass_rows(V, T, Body)).
 % The no-`as` (`$N`) positional reader likewise has no rule actions.
 plawk_pass_dynentry_rewrite(_DynEntries, pass_rows_anon(T, Body), pass_rows_anon(T, Body)).
+% The `over query(...)` reader has no rule actions to rewrite -- pass it through.
+plawk_pass_dynentry_rewrite(_DynEntries, pass_query(Q, Body), pass_query(Q, Body)).
 
 %% dynentry_decls(-Names)//
 %

--- a/tests/test_plawk_query_reader.pl
+++ b/tests/test_plawk_query_reader.pl
@@ -1,0 +1,92 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk query-driven reader (PLAWK_MULTIPASS_CACHE.md §3.4, phase 6;
+% PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md), PR 1: the SURFACE. `pass over
+% query(PRED(V1, ..., Vn)) { print $1, ... }` parses to pass_query(query(Pred,
+% Vars), Body) -- each solution of the goal will become a record, its argument
+% variables mapped positionally to $1..$n. The runtime materialisation (PRs
+% 2-3) is not wired yet, so building such a program is a clean, specific compile
+% error rather than the generic "outside the multi-pass surface".
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_query_reader).
+
+% `over query(pred(V1, V2))` parses to pass_query with the predicate name and
+% its positional output-variable list; the body's `$N` address the fields.
+test(query_two_args_parses) :-
+    plawk_parse_string(
+        "pass over query(parent(X, Y)) { print $1, $2 }\n\c
+         pass { c[$1]++ }\n",
+        program_passes([],
+            [pass_query(query(parent, ['X', 'Y']), [print([field(1), field(2)])]),
+             pass([rule(always, [inc_assoc(var(c), field(1))])])],
+            [])),
+    !.
+
+% A single-argument goal.
+test(query_one_arg_parses) :-
+    plawk_parse_string(
+        "pass over query(node(N)) { print $1 }\n\c
+         pass { print $1 }\n",
+        program_passes([],
+            [pass_query(query(node, ['N']), [print([field(1)])]),
+             pass([rule(always, [print([field(1)])])])],
+            [])),
+    !.
+
+% The `(` after the predicate name distinguishes a query from a bare table:
+% `pass over t as k` is still the table reader, untouched.
+test(over_table_unchanged) :-
+    plawk_parse_string(
+        "pass over t as k { print k }\n",
+        program_passes([],
+            [pass_over(var(k), var(t), [print([var(k)])])],
+            [])),
+    !.
+
+% Building a query-reader program is a clean compile error (exit 2) until the
+% runtime lands; the message names the goal as pred/arity.
+test(query_reader_is_not_yet_error) :-
+    qdir(Dir),
+    Src = "pass over query(parent(X, Y)) { print $1, $2 }\npass { c[$1]++ }\n",
+    build_status(Dir, 'q', Src, St),
+    assertion(St == 2),
+    !.
+
+% A program that does NOT use the query reader is unaffected (no false trigger).
+test(non_query_program_builds, [condition(clang_available)]) :-
+    qdir(Dir),
+    Src = "pass { t[$1] = $0 }\npass rows of t as r { print r[1] }\n",
+    build_status(Dir, 'ok', Src, St),
+    assertion(St == 0),
+    !.
+
+:- end_tests(plawk_query_reader).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+qdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_query_reader', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_status(Dir, Name, Src, Status) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).


### PR DESCRIPTION
## Summary

**PR 1 of the phase-6 arc** (`PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md`) — the parse surface for the query-driven reader, with a clean "not yet" diagnostic. **No runtime** (that's PRs 2–3).

```awk
pass over query(parent(X, Y)) { print $1, $2 }   # each solution -> a record; args -> $1..$n
```

## What changed

- **Parser**: a new `pass_clauses` clause parses `pass over query(PRED(V1, …, Vn)) { BODY }` → `pass_query(query(Pred, Vars), Body)`. `Vars` is the goal's positional output-variable list (each solution's bindings map to `$1..$n`). Tried before `pass over TABLE` — the `(` after the predicate name distinguishes a query from a bare table, so `pass over t as k` is untouched. `plawk_pass_dynentry_rewrite` gains a `pass_query` passthrough (without it the top-level program parse's `maplist` fails and rejects the whole program — the bug I hit and fixed).
- **`bin/plawk`**: `check_query_reader/2` detects a `pass_query` and emits a specific compile error naming the goal as `pred/arity` — *"the query-driven reader parses but its runtime is not yet implemented (phase 6)"* — instead of the generic "outside the multi-pass surface".

## Tests

`tests/test_plawk_query_reader.pl` (5): parse (two-arg, one-arg, `over TABLE` unchanged); the not-yet error (exit 2, naming `pred/arity`); a non-query program builds normally (no false trigger). Multi-pass and reader suites stay green.

## Next

**PR 2** — the `findall` wrapper + solution materialisation (the runtime crux), then **PR 3** — the query pass function (iterate the materialised set, bind each solution to `$1..$n`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_