### PR TITLE
WAM/LLVM plawk: query reader PR 2 — findall materialisation runtime

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -1074,7 +1074,15 @@ single-pass test before any driver surgery).
   reader **materialises** the solution set (a `findall` collapse at the reader
   boundary — bounded-multiplicity, `UNIFYWEAVER_LANGUAGE_PRINCIPLES.md`
   Principle 1) and iterates it like `over TABLE`, rather than retaining live
-  choicepoints (which §1 forbids in the hot loop).
+  choicepoints (which §1 forbids in the hot loop). **PRs 1–2 landed**: the
+  surface parses to `pass_query(query(Pred, Vars), Body)`, and the runtime for
+  the first shape (an all-query program, single-output goal, body `print $1`)
+  runs end-to-end — the build injects `__plawk_query_pred(L) :- findall(V,
+  pred(V), L)`, materialises the list into a table by position via
+  `@wam_object_call_posarray` on the shared `%WamState`, and prints each
+  solution's integer in key order (ordered, deterministic; a disjunctive goal
+  yields every solution). Higher arity, richer bodies, and mixed passes are the
+  next PRs.
 
 - **Phase 7 — secondary indexes (§3.5).** `index TABLE by FIELD [unique]` on
   record-valued tables; unique lookups return one record; non-unique

--- a/docs/design/PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md
@@ -5,11 +5,12 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk `over query(Goal)` reader — implementation plan (phase 6)
 
-**Status**: plan, not yet implemented. Sequences the work for the query-driven
-reader (`PLAWK_MULTIPASS_CACHE.md` §3.4, phase 6): a pass whose records are the
-**solutions of a Prolog goal**. This is the "most beyond awk" reader and the
-first place plawk admits controlled non-determinism, so it is planned carefully
-and grounded in the actual runtime surface before any build.
+**Status**: PRs 1–2 landed; the arity-1 `print $1` slice runs end-to-end.
+Sequences the work for the query-driven reader (`PLAWK_MULTIPASS_CACHE.md`
+§3.4, phase 6): a pass whose records are the **solutions of a Prolog goal**.
+This is the "most beyond awk" reader and the first place plawk admits
+controlled non-determinism, so it is planned carefully and grounded in the
+actual runtime surface before any build.
 
 ## 1. Where we are (the blocking facts)
 
@@ -52,8 +53,16 @@ result (the list), and the list materialises through the already-built posarray
 / list machinery (`@wam_object_call_posarray`). The pass then iterates that list
 exactly like `over TABLE`. So the hard part (enumeration) is delegated to the
 WAM builtin that already does it, and no new backtracking-driver primitive is
-needed. (A direct engine-driven collector is the alternative if `findall/3` is
-unavailable or too costly; the plan keeps the surface identical either way.)
+needed.
+
+**Feasibility confirmed (the plan's biggest risk, retired).** `findall/3` +
+`call/1` already run end-to-end in a **compiled plawk binary** on the LLVM WAM:
+`tests/test_plawk_eval_compile.pl` has a passing test whose runtime-compiled
+grammar executes `findall(Q, call(G), L), sum_list(L, R)` and returns the folded
+result. So the enumeration builtin the approach depends on is real and works in
+the generated code; PR 2 is wiring, not a new engine capability. (A direct
+engine-driven collector remains the fallback, with the surface unchanged, but is
+no longer expected to be needed.)
 
 ## 3. Design decisions (the surface)
 
@@ -89,21 +98,43 @@ the multi-pass surface". `tests/test_plawk_query_reader.pl`: parse (two-arg,
 one-arg, `over TABLE` unchanged), the not-yet error (exit 2), and a non-query
 program unaffected. No runtime.
 
-### PR 2 — `findall` wrapper + solution materialisation (runtime/build)
+### PR 2 — `findall` wrapper + materialisation + query pass function — **LANDED**
 
-At build time, synthesise the `findall(Template, Goal, List)` wrapper for each
-query site and route it through the object-call so the solution list is
-materialised (list → posarray/table). This is the crux; it reuses the posarray
-list machinery. Verify with a fixed loaded predicate that N solutions produce an
-N-element materialised set.
+The runtime crux, delivered as one end-to-end vertical for the first supported
+shape (arity-1 goal, body `print $1`) so the materialisation is observable:
 
-### PR 3 — Codegen: the query pass function
+- **Injected findall wrapper.** For each query goal the build synthesises
+  `__plawk_query_pred(L) :- findall(V, pred(V), L)` and adds it to the
+  program's `@prolog` predicate set (`plawk_query_helper_clause/3` in the
+  codegen; injected in `bin/plawk`), so `write_wam_llvm_project` compiles the
+  enumeration into the same binary as the user's predicates.
+- **Materialise via the posarray path.** A new query driver
+  (`plawk_program_query_driver_ir/3`) emits, per query pass, a self-contained
+  `@plawk_pass_N` that runs the wrapper on a shared `%WamState`
+  (`@plawk_foreign_vm`, emitted standalone since a query program has no
+  foreign-call sites) through `@wam_object_call_posarray`, walking the flat
+  solution list into a fresh assoc table by position (keys `1..N`).
+- **Ordered, deterministic iteration.** The pass walks keys `1..count` in
+  order (not hash-slot order) and prints each solution's integer at `$1`, then
+  frees the table. The multiplicity collapses at the boundary before the body
+  runs (§1 intact); snapshot semantics fall out for free.
+- **Scope + guard.** v1 is an all-query program (no input is read — the records
+  come from the goal). Any query program outside the shape (higher arity,
+  richer body, `END` block, or a query pass mixed with ordinary passes) is a
+  clean not-yet compile error (exit 2, naming `pred/arity`), not a miscompile.
+- **Verified end-to-end.** `tests/test_plawk_query_reader.pl`: facts and a
+  disjunctive (non-deterministic) goal both materialise and print in order; the
+  higher-arity and mixed-pass shapes hit the not-yet error; a non-query program
+  is unaffected.
 
-Model on `pass_over`: after materialising the solution set (PR 2), iterate it,
-bind each solution's arguments to `$1..$n`, and run the body (`print $1, $2`).
-Deliverable: `pass over query(pred(X, Y)) { print $1, $2 }` prints one line per
-solution. Reader-guards (`if (…)`) compose for free if the body reuses the
-row-reader emitter.
+### PR 3 — Higher arity + richer bodies (tuple templates, guards)
+
+Generalise beyond the arity-1 flat-list slice. For `pred(X, Y)` the `findall`
+template becomes a tuple, so the wrapper returns a list of compounds; each
+element is deserialised into `$1..$n` (reuse the record/posarray element
+machinery). Then let the body be more than `print $1`: `print $1, $2`,
+reader-guards (`if (…)`) — composing for free if the body reuses the row-reader
+emitter. Mixed query + ordinary passes in one program is the other axis here.
 
 ### PR 4 — Determinism guarantees + snapshot test + docs
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -102,9 +102,14 @@ build(File, Out0, KeepLL) :-
     resolve_cache_use(File, Program1, Program),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
-    (   Clauses == []
+    % A query-reader program contributes synthesised findall-wrapper clauses
+    % (one per goal predicate) so its enumeration compiles into the binary
+    % alongside the user's @prolog predicates. Non-query programs add nothing.
+    plawk_program_query_helper_clauses(Program, QueryHelperClauses),
+    append(Clauses, QueryHelperClauses, ClausesForPreds),
+    (   ClausesForPreds == []
     ->  Preds = [user:plawk_cli_marker/0]
-    ;   (   plawk_prolog_block_preds(Clauses, Preds)
+    ;   (   plawk_prolog_block_preds(ClausesForPreds, Preds)
         ->  true
         ;   format(user_error,
                 'plawk: invalid @prolog block in ~w (directives are not clauses)~n',
@@ -148,6 +153,9 @@ build(File, Out0, KeepLL) :-
         ; plawk_program_dyncall_posarray_arities(Program, DynPosarrArities), DynPosarrArities \== []
         ; plawk_program_dyncall_named_posarray_str_entries(Program, DynNamedPosarrS), DynNamedPosarrS \== []
         ; plawk_program_dyncall_posarray_str_arities(Program, DynPosarrSArities), DynPosarrSArities \== []
+        % A query reader materialises its goal's solutions via
+        % @wam_object_call_posarray, which lives in the .wamo loader section.
+        ; ( plawk_program_query_passes(Program, QueryPassesG), QueryPassesG \== [] )
         )
     ->  ProjectOptions = [module_name(OutBase), emit_wamo_loader(true)]
     ;   ProjectOptions = [module_name(OutBase)]
@@ -181,7 +189,8 @@ build(File, Out0, KeepLL) :-
                   write_wam_llvm_project(Preds, ProjectOptions, LLPath)),
               wam_llvm_last_compile_counts(InstrCount, LabelCount),
               (   Program = program_passes(_, _, _)
-              ->  (   plawk_program_multipass_driver_ir(Program, DriverIR)
+              ->  (   plawk_program_multipass_driver_ir(Program,
+                          [wam_vm(InstrCount, LabelCount)], DriverIR)
                   ->  true
                   ;   format(user_error,
                           'plawk: ~w uses multi-pass features outside the \c
@@ -301,21 +310,50 @@ program_begin_clauses(program(BeginClauses, _, _), BeginClauses).
 program_begin_clauses(program_passes(BeginClauses, _, _), BeginClauses).
 
 % Phase 6 (PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md): the `over query(...)`
-% reader parses (PR 1) but its runtime materialisation is not wired yet, so a
-% program that uses it gets a clear, specific diagnostic rather than the generic
-% "outside the multi-pass surface". The surface stays stable while the runtime
-% (PRs 2-3) lands.
-check_query_reader(File, program_passes(_, Passes, _)) :-
-    member(pass_query(query(Pred, Vars), _Body), Passes),
+% reader. PR 2 lands the runtime for the first supported shape -- an all-query
+% program whose goals are single-output and whose bodies are `print $1`. Any
+% query program OUTSIDE that surface (higher arity, a richer body, an END
+% block, or a query pass mixed with ordinary passes) still gets a clear,
+% specific not-yet diagnostic rather than the generic "outside the multi-pass
+% surface", while the supported shape flows on to the query driver.
+check_query_reader(File, Program) :-
+    plawk_program_query_passes(Program, QueryPasses),
+    QueryPasses \== [],
+    \+ query_program_supported(Program),
     !,
+    QueryPasses = [pass_query(query(Pred, Vars), _) | _],
     length(Vars, N),
     format(user_error,
-        'plawk: ~w uses `over query(~w/~w)`. The query-driven reader parses but \c
-         its runtime is not yet implemented (phase 6); see \c
+        'plawk: ~w uses `over query(~w/~w)` outside the supported query-reader \c
+         surface (v1: an all-query program, single-output goals, body `print \c
+         $1`); this shape is not yet implemented (phase 6); see \c
          PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md.~n',
         [File, Pred, N]),
     halt(2).
 check_query_reader(_File, _Program).
+
+% A query program the PR-2 driver can lower end-to-end: every pass is a
+% supported `pass over query(...)` and there is no END block.
+query_program_supported(program_passes(_, Passes, End)) :-
+    End == [],
+    Passes = [_ | _],
+    forall(member(P, Passes), P = pass_query(_, _)),
+    forall(member(P, Passes), plawk_query_pass_supported(P)).
+
+% The findall-wrapper clauses to inject into a query program's @prolog
+% predicate set: one `__plawk_query_pred(L) :- findall(V, pred(V), L)` per
+% distinct goal predicate/arity, so write_wam_llvm_project compiles the
+% enumeration into the same binary the query pass-fn calls.
+plawk_program_query_helper_clauses(Program, HelperClauses) :-
+    plawk_program_query_passes(Program, QueryPasses),
+    findall(Pred-A,
+        ( member(pass_query(query(Pred, Vars), _), QueryPasses),
+          length(Vars, A) ),
+        PA0),
+    sort(PA0, PA),
+    findall(HC,
+        ( member(Pred-A, PA), plawk_query_helper_clause(Pred, A, HC) ),
+        HelperClauses).
 
 % Multi-pass normalisation (PLAWK_MULTIPASS_CACHE.md phase 2). A single
 % `pass { ... }` block is exactly today's main loop, so it lowers to the

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5,6 +5,11 @@
     plawk_program_native_driver_ir/3,
     plawk_program_native_driver_ir/4,
     plawk_program_multipass_driver_ir/2,
+    plawk_program_multipass_driver_ir/3,
+    plawk_query_helper_name/2,
+    plawk_query_helper_clause/3,
+    plawk_program_query_passes/2,
+    plawk_query_pass_supported/1,
     plawk_program_foreign_specs/3,
     plawk_program_foreign_specs/4,
     plawk_program_dyncall_arities/2,
@@ -3885,6 +3890,183 @@ get_path:
 }
 ',
         [RuntimeGlobals, PassFnsIR, CombinedEntrySetupIR, CallsIR, FreeIR]).
+
+%% plawk_program_multipass_driver_ir(+Program, +Options, -DriverIR) is semidet.
+%
+%  Options-carrying entry point (PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md,
+%  phase 6). `Options` carries `wam_vm(InstrCount, LabelCount)` -- the sizes
+%  of the module's @module_code / @module_labels arrays, needed to build the
+%  shared %WamState a query reader runs its goal on. A query-reader program
+%  (`pass over query(pred(X)) { print $1 }`) is lowered by the query driver;
+%  everything else delegates to the /2 driver unchanged.
+plawk_program_multipass_driver_ir(Program, Options, DriverIR) :-
+    (   plawk_program_query_driver_ir(Program, Options, DriverIR)
+    ->  true
+    ;   plawk_program_multipass_driver_ir(Program, DriverIR)
+    ).
+
+%% plawk_program_query_passes(+Program, -QueryPasses) is det.
+%  The `pass over query(...)` passes of a program (empty if none).
+plawk_program_query_passes(program_passes(_, Passes, _), QueryPasses) :-
+    findall(pass_query(Q, B), member(pass_query(Q, B), Passes), QueryPasses).
+plawk_program_query_passes(program(_, _, _), []).
+
+%% plawk_query_pass_supported(+Pass) is semidet.
+%  The query-reader surface a build can lower today (phase 6, PR 2): a
+%  single-output goal whose body is exactly `print $1`. Each solution's one
+%  argument is a ground integer materialised at $1. Higher arities and richer
+%  bodies (guards, $2..) are follow-ons; an unsupported shape yields a clean
+%  not-yet compile error rather than a miscompile.
+plawk_query_pass_supported(pass_query(query(_Pred, [_V]), Body)) :-
+    Body == [print([field(1)])].
+
+%% plawk_query_helper_name(+Pred, -Name) is det.
+%  The synthesised findall-wrapper predicate name for a query on `Pred`. The
+%  reserved `__plawk_query_` prefix cannot collide with a user predicate (the
+%  surface parser forbids `$`-free reserved names), so the name is unique per
+%  goal predicate and both the clause injector (bin/plawk) and the pass-fn
+%  emitter derive the same LLVM symbol (`@<Name>_start_pc`) from it.
+plawk_query_helper_name(Pred, Name) :-
+    atom_concat('__plawk_query_', Pred, Name).
+
+%% plawk_query_helper_clause(+Pred, +Arity, -Clause) is semidet.
+%  The Prolog clause that turns the goal's solution set into a materialisable
+%  list: `__plawk_query_pred(L) :- findall(V, pred(V), L)`. findall drives the
+%  goal to exhaustion (the enumeration the plan delegates to the builtin), so
+%  L is the ordered, ground list of first-argument bindings. Injected into the
+%  program's @prolog predicate set so write_wam_llvm_project compiles it into
+%  the same binary; the query pass-fn then calls it and walks L into a table.
+%  v1: arity 1 (single-output generator); the template is a flat list.
+plawk_query_helper_clause(Pred, 1, Clause) :-
+    plawk_query_helper_name(Pred, Name),
+    Goal =.. [Pred, V],
+    Head =.. [Name, L],
+    Clause = (Head :- findall(V, Goal, L)).
+
+%% plawk_program_query_driver_ir(+Program, +Options, -DriverIR) is semidet.
+%
+%  The query-reader execution driver (phase 6, PR 2). Fires only for an
+%  all-query program (every pass is a supported `pass over query(...)`), the
+%  first slice of controlled non-determinism: each pass runs its goal to a
+%  materialised solution set and iterates it -- no input file is read (the
+%  records come from the goal, not stdin). Each pass is its own void function
+%  (materialise-then-iterate, mirroring `over TABLE`); a shared %WamState
+%  (@plawk_foreign_vm) runs the findall-wrapper predicate the injector added.
+%  The materialised list lands in a fresh assoc table by position (keys 1..N),
+%  walked in key order for a deterministic, ordered print (§1 intact -- the
+%  multiplicity is collapsed at the boundary before the body runs).
+plawk_program_query_driver_ir(
+    program_passes(BeginClauses, Passes, End),
+    Options,
+    DriverIR
+) :-
+    Passes = [_ | _],
+    forall(member(P, Passes), P = pass_query(_, _)),   % all-query program (v1)
+    forall(member(P, Passes), plawk_query_pass_supported(P)),
+    End == [],                                          % v1: no END block
+    memberchk(wam_vm(InstrCount, LabelCount), Options),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_query_foreign_vm_ir(InstrCount, LabelCount, VmIR),
+    findall(FnIR,
+        ( nth0(I, Passes, pass_query(query(Pred, _Vars), _Body)),
+          plawk_query_helper_name(Pred, Sym),
+          plawk_multipass_query_fn_ir(I, Sym, FnIR) ),
+        FnIRs),
+    atomic_list_concat(FnIRs, '\n', PassFnsIR),
+    findall(CallLine,
+        ( nth0(I, Passes, _),
+          format(atom(CallLine), '  call void @plawk_pass_~w()', [I]) ),
+        CallLines),
+    atomic_list_concat(CallLines, '\n', CallsIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    format(atom(DriverIR),
+'@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
+~w
+
+~w
+
+define i32 @main(i32 %argc, i8** %argv) {
+entry:
+~w
+~w
+  ret i32 0
+}
+',
+        [VmIR, PassFnsIR, BeginIR, CallsIR]).
+
+%% plawk_query_foreign_vm_ir(+InstrCount, +LabelCount, -IR)
+%  The lazily created process-wide %WamState the query readers run their
+%  goals on -- identical to the foreign-call support VM, emitted standalone
+%  here because a query-reader program has no foreign-call sites to trigger
+%  plawk_foreign_support_ir. References @module_code / @module_labels (the
+%  compiled @prolog + findall-wrapper predicates) sized by the passed counts.
+plawk_query_foreign_vm_ir(InstrCount, LabelCount, IR) :-
+    format(atom(IR),
+'@plawk_foreign_vm = internal global %WamState* null
+
+define %WamState* @plawk_foreign_vm_get() {
+entry:
+  %cur = load %WamState*, %WamState** @plawk_foreign_vm
+  %have = icmp ne %WamState* %cur, null
+  br i1 %have, label %ret_cur, label %make
+
+ret_cur:
+  ret %WamState* %cur
+
+make:
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  store %WamState* %vm, %WamState** @plawk_foreign_vm
+  ret %WamState* %vm
+}',
+        [InstrCount, InstrCount, InstrCount, LabelCount, LabelCount,
+         LabelCount]).
+
+%% plawk_multipass_query_fn_ir(+Index, +Sym, -IR)
+%  A query pass as a self-contained void function: materialise the goal's
+%  solution list into a fresh assoc table (keys 1..N by position), then walk
+%  keys in order printing each solution's integer at $1. Materialisation
+%  routes through @wam_object_call_posarray against the shared VM, calling the
+%  findall-wrapper `@<Sym>_start_pc` with no input args and the list output in
+%  register 0 -- the same flat-list walk the `as array` posarray target uses.
+%  Ordered by key (1..count) rather than hash-slot order, so the print is
+%  deterministic. The table is freed at pass end (nothing persists).
+plawk_multipass_query_fn_ir(Index, Sym, IR) :-
+    format(atom(IR),
+'define void @plawk_pass_~w() {
+entry:
+  %qtable = call %WamAssocI64Table* @wam_assoc_i64_new(i64 64)
+  %vm = call %WamState* @plawk_foreign_vm_get()
+  %pc = load i32, i32* @~w_start_pc
+  %ok = call i1 @wam_object_call_posarray(%WamState* %vm, i32 %pc, i32 0, %Value* null, i32 0, %WamAssocI64Table* %qtable)
+  %count_ptr = getelementptr %WamAssocI64Table, %WamAssocI64Table* %qtable, i32 0, i32 0
+  %count = load i64, i64* %count_ptr
+  br label %q_head
+
+q_head:
+  %pos = phi i64 [ 1, %entry ], [ %pos1, %q_body_done ]
+  %q_done = icmp sgt i64 %pos, %count
+  br i1 %q_done, label %q_after, label %q_body
+
+q_body:
+  %val = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %qtable, i64 %pos)
+  %fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0
+  %pr = call i32 (i8*, ...) @printf(i8* %fmt, i64 %val)
+  %nl = call i32 @putchar(i32 10)
+  br label %q_body_done
+
+q_body_done:
+  %pos1 = add i64 %pos, 1
+  br label %q_head
+
+q_after:
+  call void @wam_assoc_i64_free(%WamAssocI64Table* %qtable)
+  ret void
+}',
+        [Index, Sym]).
 
 %% plawk_passes_tables(+Passes, -Tables)
 %  The assoc tables a multi-pass program shares. Discovered from the passes'

--- a/tests/test_plawk_query_reader.pl
+++ b/tests/test_plawk_query_reader.pl
@@ -3,12 +3,19 @@
 % Copyright (c) 2026 John William Creighton (@s243a)
 %
 % plawk query-driven reader (PLAWK_MULTIPASS_CACHE.md §3.4, phase 6;
-% PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md), PR 1: the SURFACE. `pass over
-% query(PRED(V1, ..., Vn)) { print $1, ... }` parses to pass_query(query(Pred,
-% Vars), Body) -- each solution of the goal will become a record, its argument
-% variables mapped positionally to $1..$n. The runtime materialisation (PRs
-% 2-3) is not wired yet, so building such a program is a clean, specific compile
-% error rather than the generic "outside the multi-pass surface".
+% PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md). PR 1 landed the SURFACE: `pass
+% over query(PRED(V1, ..., Vn)) { print $1, ... }` parses to
+% pass_query(query(Pred, Vars), Body) -- each solution of the goal becomes a
+% record, its argument variables mapped positionally to $1..$n.
+%
+% PR 2 lands the RUNTIME for the first supported shape: an all-query program
+% whose goals are single-output (`pred(X)`) and whose bodies are `print $1`.
+% Each query pass synthesises `__plawk_query_pred(L) :- findall(V, pred(V), L)`,
+% runs it on the shared VM, and walks the materialised solution list into a
+% table by position -- printing each solution's integer in key order (ordered,
+% deterministic; the multiplicity collapses at the boundary). A query program
+% OUTSIDE that surface (higher arity, richer body, END block, mixed with
+% ordinary passes) is still a clean not-yet compile error.
 
 :- use_module(library(plunit)).
 :- use_module(library(process)).
@@ -50,12 +57,47 @@ test(over_table_unchanged) :-
             [])),
     !.
 
-% Building a query-reader program is a clean compile error (exit 2) until the
-% runtime lands; the message names the goal as pred/arity.
-test(query_reader_is_not_yet_error) :-
+% A supported query program (all-query, single-output goal, body `print $1`)
+% builds and RUNS: `edge/1`'s three facts materialise and print in order. No
+% input file is read -- the records come from the goal, not stdin.
+test(query_reader_facts_run, [condition(clang_available)]) :-
     qdir(Dir),
-    Src = "pass over query(parent(X, Y)) { print $1, $2 }\npass { c[$1]++ }\n",
-    build_status(Dir, 'q', Src, St),
+    Src = "@prolog\nedge(10).\nedge(20).\nedge(30).\n@end\n\c
+           pass over query(edge(X)) { print $1 }\n",
+    build_run(Dir, 'facts', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "10\n20\n30\n"),
+    !.
+
+% Non-determinism is the point: a goal with a disjunction yields every
+% solution, collapsed to an ordered materialised set before the body runs.
+test(query_reader_nondet_run, [condition(clang_available)]) :-
+    qdir(Dir),
+    Src = "@prolog\nedge(A) :- (A = 5 ; A = 6 ; A = 7).\n@end\n\c
+           pass over query(edge(X)) { print $1 }\n",
+    build_run(Dir, 'nondet', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "5\n6\n7\n"),
+    !.
+
+% A query OUTSIDE the supported surface -- here a two-argument goal -- is a
+% clean not-yet compile error (exit 2), not a miscompile; the message names
+% the goal as pred/arity.
+test(query_reader_higher_arity_not_yet) :-
+    qdir(Dir),
+    Src = "@prolog\npair(1, 2).\n@end\n\c
+           pass over query(pair(X, Y)) { print $1, $2 }\n",
+    build_status(Dir, 'arity2', Src, St),
+    assertion(St == 2),
+    !.
+
+% A query pass mixed with an ordinary pass is also outside v1 (all-query
+% only) and gets the same clean not-yet error rather than the generic one.
+test(query_reader_mixed_not_yet) :-
+    qdir(Dir),
+    Src = "@prolog\nnode(1).\n@end\n\c
+           pass over query(node(N)) { print $1 }\npass { c[$1]++ }\n",
+    build_status(Dir, 'mixed', Src, St),
     assertion(St == 2),
     !.
 
@@ -90,3 +132,19 @@ build_status(Dir, Name, Src, Status) :-
     process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
         [stdout(null), stderr(null), process(Pid)]),
     process_wait(Pid, exit(Status)).
+
+% Build a program, then run the resulting binary with Args, capturing stdout.
+build_run(Dir, Name, Src, Args, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, Args,
+        [stdout(pipe(RS)), stderr(std), process(RPid)]),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
The runtime crux of the `over query(Goal)` reader (phase 6), delivered as one end-to-end vertical for the first supported shape: an **all-query program** whose goals are **single-output** (`pred(X)`) and whose bodies are **`print $1`**. This is the first place plawk admits controlled non-determinism.

```
@prolog
edge(A) :- (A = 5 ; A = 6 ; A = 7).
@end

pass over query(edge(X)) { print $1 }
```
→ prints `5`, `6`, `7` — one line per solution, in order. No input file is read; the records come from the goal.

## How it works
- **Injected findall wrapper.** For each query goal the build synthesises `__plawk_query_pred(L) :- findall(V, pred(V), L)` and adds it to the program's `@prolog` predicate set (`plawk_query_helper_clause/3`), so `write_wam_llvm_project` compiles the enumeration into the same binary as the user's predicates. `findall` does the enumeration the plan delegates to the builtin — no new backtracking-driver primitive.
- **Materialise via the posarray path.** A new query driver (`plawk_program_query_driver_ir/3`) emits, per query pass, a self-contained `@plawk_pass_N` that runs the wrapper on a shared `%WamState` (`@plawk_foreign_vm`, emitted standalone since a query program has no foreign-call sites) through `@wam_object_call_posarray`, walking the flat solution list into a fresh assoc table by position (keys `1..N`).
- **Ordered, deterministic iteration.** The pass walks keys `1..count` in **key order** (not hash-slot order) and prints each solution's integer at `$1`, then frees the table. The multiplicity collapses at the reader boundary *before* the body runs (determinism model intact; snapshot semantics fall out for free — bounded-multiplicity, `UNIFYWEAVER_LANGUAGE_PRINCIPLES.md` Principle 1).
- **Scope + guard.** Any query program outside the shape (higher arity, richer body, `END` block, or a query pass mixed with ordinary passes) is a clean **not-yet compile error** (exit 2, naming `pred/arity`), not a miscompile.

## Tests
`tests/test_plawk_query_reader.pl` (8 tests): facts and a disjunctive (non-deterministic) goal both materialise and print in order; the higher-arity and mixed-pass shapes hit the not-yet error; a non-query program is unaffected; the PR-1 parse tests are retained. Regressions green: `test_plawk_multipass`, `test_plawk_multipass_cache`, `test_plawk_multitable`, `test_plawk_prolog_blocks`, `test_plawk_dynentry`, `test_plawk_dyncall_posarray`.

## Docs
`PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md` (PRs 1–2 marked landed; feasibility confirmation; PR 3 re-scoped to higher-arity tuple templates + richer bodies) and the phase-6 entry in `PLAWK_MULTIPASS_CACHE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_