### PR TITLE
WAM/LLVM plawk: query reader PR 4 — reader guards in the query body

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -1082,9 +1082,11 @@ single-pass test before any driver surgery).
   `@wam_object_call_posarray` on the shared `%WamState`, and walks keys in
   order binding `$1..$n` (ordered, deterministic; a disjunctive goal yields
   every solution; columns stay aligned across the per-column runs for a pure
-  goal). The body may reorder, repeat, or subset the printed columns. Guards
-  in the body, mixed query + ordinary passes, and string columns are the next
-  PRs.
+  goal). The body may reorder, repeat, or subset the printed columns, and may
+  be gated by an `if ($K CMP int)` reader guard (`&&` / `||` combinations) — a
+  WHERE over the query's solutions, lowered to pure i1 and/or over the
+  per-column reads. Mixed query + ordinary passes and string columns are the
+  next PRs.
 
 - **Phase 7 — secondary indexes (§3.5).** `index TABLE by FIELD [unique]` on
   record-valued tables; unique lookups return one record; non-unique

--- a/docs/design/PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md
@@ -5,8 +5,9 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk `over query(Goal)` reader — implementation plan (phase 6)
 
-**Status**: PRs 1–3 landed; an all-query program of any goal arity with a
-`print $K...` body runs end-to-end.
+**Status**: PRs 1–4 landed; an all-query program of any goal arity with a
+`print $K...` body — optionally gated by an `if ($K CMP int)` reader guard —
+runs end-to-end.
 Sequences the work for the query-driven reader (`PLAWK_MULTIPASS_CACHE.md`
 §3.4, phase 6): a pass whose records are the **solutions of a Prolog goal**.
 This is the "most beyond awk" reader and the first place plawk admits
@@ -152,11 +153,32 @@ Generalise beyond the arity-1 flat-list slice to a goal of any arity with a
   a reordered arity-3 disjunctive goal, repeated/subset columns, and the
   out-of-range-column not-yet error.
 
-### PR 4 — Determinism guarantees + richer bodies + mixed passes
+### PR 4 — Reader guards in the query body — **LANDED**
 
-Reader-guards (`if (…)`) in the query body; a query pass mixed with ordinary
-passes in one program; non-integer (string) columns via the posarray-str path.
-Plus the determinism/snapshot test below.
+A query pass body may now be gated by an `if (COND)` reader guard — a WHERE over
+the goal's solutions:
+
+```
+pass over query(edge(X, Y)) { if ($1 >= 2 && $2 < 40) print $1 }
+```
+
+- **Reuses the surface grammar.** `for_in_body` already parses `if (GUARD)
+  print ...` to `[if(Guard, [print(Fields)], [])]` with `$K CMP int` leaves
+  (`rfield_cmp`) combined by `&&` / `||`; the query driver just consumes it.
+- **Pure evaluation.** Each leaf reads `%qtable_K[pos]` (an i64) and compares
+  it (`plawk_icmp_pred`); `and` / `or` combine child i1s. Because the reads are
+  side-effect-free, the tree lowers to plain i1 `and`/`or` with a single branch
+  to a `q_print` block — no short-circuit control flow. The guard may read a
+  column the body does not print.
+- **Guard.** Only integer comparisons are meaningful (columns are i64); a
+  float/string RHS or an out-of-range column stays a not-yet error.
+- **Verified.** `tests/test_plawk_query_reader.pl`: a `>` filter, an `&&`
+  reading a non-printed column, and an `||`.
+
+### PR 5 — Mixed passes + string columns + determinism/snapshot test
+
+A query pass mixed with ordinary passes in one program; non-integer (string)
+columns via the posarray-str path. Plus the determinism/snapshot test below.
 
 ### PR 4 — Determinism guarantees + snapshot test + docs
 
@@ -179,3 +201,49 @@ sketch, of which this is the first concrete step.
 - **If `findall/3` is not a usable builtin here**, PR 2 becomes a direct
   engine-driven collector (drive `retry_me_else` to exhaustion, capturing each
   solution's registers) — deeper, but the surface (PRs 1, 3, 4) is unchanged.
+
+## 6. Future sketch: generator blocks (the producer dual)
+
+The query reader is the **consumer** side of the plawk/Prolog boundary: a
+Prolog goal *drives* a plawk pass (Prolog → plawk records). The natural dual is
+the **producer** side — a plawk `{}` block that a Prolog goal can *call*
+(plawk → Prolog solutions):
+
+```
+gen { ... emit E ... } as edges     # defines a callable relation edges/1
+
+pass over query(path(edges, A, B)) { print $1, $2 }
+```
+
+Here `gen { … } as edges` is a block that produces a stream of values; naming
+it exposes a predicate `edges(X)` reachable from any goal — including a query
+reader's, so the two features compose (a gen block feeds a query pass).
+
+**Why blocks, not lazy functions (the user's framing).** AWK users read `{}`
+as "streaming work" and functions as eager call-and-return; making a *function*
+lazy would violate that intuition, whereas a `{}` block that emits is already
+the AWK mental model for producing a stream. So streaming is driven from block
+syntax, not from function laziness. Iterating an iterable (array, assoc, DB
+column) is a third, orthogonal producer, but the block form is the one that
+reads as AWK.
+
+**Why it fits the architecture (materialise, don't stream).** A gen block need
+not retain a live choicepoint (which §1 forbids in the hot loop). It runs to
+completion collecting each `emit E` into a list, then exposes that set as an
+ordinary non-deterministic relation — effectively `edges(X) :- member(X,
+Collected)`. That is exactly the **bounded-multiplicity** move
+(`UNIFYWEAVER_LANGUAGE_PRINCIPLES.md` Principle 1) this reader already makes,
+run in the other direction: the block's multiplicity is collapsed to a
+materialised set at definition time, and consumers (findall in a query pass)
+iterate it deterministically. The runtime is the mirror of PR 2 — where the
+query reader *reads* a findall list into a table, a gen block *writes* an
+emitted list into one and wraps it as a callable relation.
+
+**Open questions.** When the block runs (once at load, or per call with
+arguments as inputs — the mode story connects to the §3.10 `X in domain`
+producer and the "inputs bound from the record" follow-on above); whether
+`emit` carries a tuple (arity > 1, matching the per-column materialisation of
+PR 3); and lifetime/caching of the collected set (a durable gen block could
+back its set with a cache/LMDB store, reusing phase 5). Sequenced after the
+query reader's remaining PRs — it shares their materialisation runtime and is
+best built on top of it.

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -326,7 +326,8 @@ check_query_reader(File, Program) :-
     format(user_error,
         'plawk: ~w uses `over query(~w/~w)` outside the supported query-reader \c
          surface (v1: an all-query program whose body is a single `print` of \c
-         $K fields); this shape is not yet implemented (phase 6); see \c
+         $K fields, optionally gated by an `if ($K CMP int)` reader guard); \c
+         this shape is not yet implemented (phase 6); see \c
          PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md.~n',
         [File, Pred, N]),
     halt(2).

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3912,18 +3912,44 @@ plawk_program_query_passes(program_passes(_, Passes, _), QueryPasses) :-
 plawk_program_query_passes(program(_, _, _), []).
 
 %% plawk_query_pass_supported(+Pass) is semidet.
-%  The query-reader surface a build can lower today (phase 6, PRs 2-3): a goal
-%  of any arity >= 1 whose body is a single `print` of `$K` fields, each `K` a
-%  column of the goal (1..arity). Every solution's arguments are ground
-%  integers materialised at $1..$n. Guards, mixed passes, and non-integer
-%  columns are follow-ons; an unsupported shape yields a clean not-yet compile
-%  error rather than a miscompile.
-plawk_query_pass_supported(pass_query(query(_Pred, Vars), [print(Fields)])) :-
+%  The query-reader surface a build can lower today (phase 6, PRs 2-4): a goal
+%  of any arity >= 1 whose body is a single `print` of `$K` fields (each `K` a
+%  column of the goal, 1..arity), optionally gated by a reader guard
+%  `if (COND)` comparing `$K` columns to integers (`&&` / `||` combinations
+%  allowed). Every solution's arguments are ground integers materialised at
+%  $1..$n. Mixed passes and non-integer columns are follow-ons; an unsupported
+%  shape yields a clean not-yet compile error rather than a miscompile.
+plawk_query_pass_supported(pass_query(query(_Pred, Vars), Body)) :-
     Vars = [_ | _],
     length(Vars, Arity),
+    plawk_query_body_plan(Body, Fields, Guard),
     Fields = [_ | _],
     forall(member(F, Fields),
-        ( F = field(K), integer(K), K >= 1, K =< Arity )).
+        ( F = field(K), integer(K), K >= 1, K =< Arity )),
+    plawk_query_guard_ok(Guard, Arity).
+
+%% plawk_query_body_plan(+Body, -Fields, -Guard) is semidet.
+%  Split a query pass body into its print field list and an optional reader
+%  guard. A bare `print` has guard `none`; an `if (COND) print ...` (which
+%  `for_in_body` parses to `[if(Guard, [print(Fields)], [])]`) carries the
+%  condition. No other body shape is a query reader today.
+plawk_query_body_plan([print(Fields)], Fields, none).
+plawk_query_body_plan([if(Guard, [print(Fields)], [])], Fields, Guard).
+
+%% plawk_query_guard_ok(+Guard, +Arity) is semidet.
+%  A reader guard a query pass can lower: `&&` / `||` over `$K CMP int` leaves
+%  (`rfield_cmp`), each column in range. Columns are i64, so only integer
+%  comparisons are meaningful in v1 (float/string RHS are a follow-on).
+plawk_query_guard_ok(none, _Arity).
+plawk_query_guard_ok(and(L, R), Arity) :-
+    plawk_query_guard_ok(L, Arity),
+    plawk_query_guard_ok(R, Arity).
+plawk_query_guard_ok(or(L, R), Arity) :-
+    plawk_query_guard_ok(L, Arity),
+    plawk_query_guard_ok(R, Arity).
+plawk_query_guard_ok(rfield_cmp(N, _Op, Value), Arity) :-
+    integer(N), N >= 1, N =< Arity,
+    integer(Value).
 
 %% plawk_query_helper_name(+Pred, +Col, -Name) is det.
 %  The synthesised findall-wrapper predicate name for column `Col` of a query
@@ -3980,10 +4006,11 @@ plawk_program_query_driver_ir(
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_query_foreign_vm_ir(InstrCount, LabelCount, VmIR),
     findall(FnIR,
-        ( nth0(I, Passes, pass_query(query(Pred, Vars), [print(Fields)])),
+        ( nth0(I, Passes, pass_query(query(Pred, Vars), Body)),
           length(Vars, Arity),
-          plawk_multipass_query_fn_ir(I, Pred, Arity, Fields, OutputSeparator,
-              FnIR) ),
+          plawk_query_body_plan(Body, Fields, Guard),
+          plawk_multipass_query_fn_ir(I, Pred, Arity, Fields, Guard,
+              OutputSeparator, FnIR) ),
         FnIRs),
     atomic_list_concat(FnIRs, '\n', PassFnsIR),
     findall(CallLine,
@@ -4038,17 +4065,19 @@ make:
         [InstrCount, InstrCount, InstrCount, LabelCount, LabelCount,
          LabelCount]).
 
-%% plawk_multipass_query_fn_ir(+Index, +Pred, +Arity, +Fields, +OutputSep, -IR)
+%% plawk_multipass_query_fn_ir(+Index, +Pred, +Arity, +Fields, +Guard,
+%%     +OutputSep, -IR)
 %  A query pass as a self-contained void function: materialise each goal column
 %  into its own assoc table (`%qtable_C`, keys 1..N by position) via
 %  @wam_object_call_posarray against the shared VM -- calling the per-column
 %  findall wrapper `@__plawk_query_pred_C_start_pc` with no input args and the
 %  list output in register 0 (the flat-list walk the `as array` posarray target
 %  uses). Then walk keys in order (1..count of column 1, not hash-slot order,
-%  so the print is deterministic), binding $K to `%qtable_K[pos]` and printing
-%  the requested fields joined by the output separator. All tables are freed at
-%  pass end (nothing persists).
-plawk_multipass_query_fn_ir(Index, Pred, Arity, Fields, OutputSep, IR) :-
+%  so the print is deterministic), binding $K to `%qtable_K[pos]`. An optional
+%  reader guard (`if (COND)`) is evaluated over the per-column values -- pure
+%  i64 reads combined with i1 and/or (no short-circuit branching needed) --
+%  gating the print. All tables are freed at pass end (nothing persists).
+plawk_multipass_query_fn_ir(Index, Pred, Arity, Fields, Guard, OutputSep, IR) :-
     numlist(1, Arity, Cols),
     findall(MatLine,
         ( member(C, Cols),
@@ -4061,6 +4090,7 @@ plawk_multipass_query_fn_ir(Index, Pred, Arity, Fields, OutputSep, IR) :-
         MatLines),
     atomic_list_concat(MatLines, '\n', MaterializeIR),
     plawk_query_print_lines(Fields, OutputSep, PrintIR),
+    plawk_query_body_ir(Guard, PrintIR, BodyIR),
     findall(FreeLine,
         ( member(C, Cols),
           format(atom(FreeLine),
@@ -4084,7 +4114,6 @@ q_head:
 
 q_body:
 ~w
-  br label %q_body_done
 
 q_body_done:
   %pos1 = add i64 %pos, 1
@@ -4094,7 +4123,58 @@ q_after:
 ~w
   ret void
 }',
-        [Index, MaterializeIR, PrintIR, FreeIR]).
+        [Index, MaterializeIR, BodyIR, FreeIR]).
+
+%% plawk_query_body_ir(+Guard, +PrintIR, -BodyIR)
+%  The `q_body` block content. Unguarded: print then fall to `q_body_done`.
+%  Guarded: evaluate the guard to an i1, branch to a `q_print` block on true
+%  (else straight to `q_body_done`). The guard reads are pure, so the tree is
+%  plain and/or over leaf comparisons -- no short-circuit control flow.
+plawk_query_body_ir(none, PrintIR, BodyIR) :-
+    format(atom(BodyIR), '~w\n  br label %q_body_done', [PrintIR]).
+plawk_query_body_ir(Guard, PrintIR, BodyIR) :-
+    Guard \== none,
+    plawk_query_guard_ir(Guard, 0, _C, ResSSA, GuardLines),
+    atomic_list_concat(GuardLines, '\n', GuardIR),
+    format(atom(BodyIR),
+'~w
+  br i1 ~w, label %q_print, label %q_body_done
+
+q_print:
+~w
+  br label %q_body_done',
+        [GuardIR, ResSSA, PrintIR]).
+
+%% plawk_query_guard_ir(+Guard, +N0, -N, -ResultSSA, -Lines)
+%  Lower a reader guard over the per-column tables to a single i1 result.
+%  A leaf `$K CMP int` reads `%qtable_K[pos]` and compares it; `and` / `or`
+%  combine child i1s. SSA names are suffixed by a threaded counter so leaves
+%  never collide. Reads are side-effect-free, so and/or need not short-circuit.
+plawk_query_guard_ir(and(L, R), N0, N, Res, Lines) :-
+    plawk_query_guard_ir(L, N0, N1, LRes, LLines),
+    plawk_query_guard_ir(R, N1, N2, RRes, RLines),
+    N is N2 + 1,
+    format(atom(Res), '%qgand~w', [N2]),
+    format(atom(Line), '  ~w = and i1 ~w, ~w', [Res, LRes, RRes]),
+    append([LLines, RLines, [Line]], Lines).
+plawk_query_guard_ir(or(L, R), N0, N, Res, Lines) :-
+    plawk_query_guard_ir(L, N0, N1, LRes, LLines),
+    plawk_query_guard_ir(R, N1, N2, RRes, RLines),
+    N is N2 + 1,
+    format(atom(Res), '%qgor~w', [N2]),
+    format(atom(Line), '  ~w = or i1 ~w, ~w', [Res, LRes, RRes]),
+    append([LLines, RLines, [Line]], Lines).
+plawk_query_guard_ir(rfield_cmp(K, Op, Value), N0, N, Res, [LoadLine, CmpLine]) :-
+    integer(Value),
+    plawk_icmp_pred(Op, Pred),
+    N is N0 + 1,
+    format(atom(ValSSA), '%qgv~w', [N0]),
+    format(atom(Res), '%qgc~w', [N0]),
+    format(atom(LoadLine),
+        '  ~w = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %qtable_~w, i64 %pos)',
+        [ValSSA, K]),
+    format(atom(CmpLine),
+        '  ~w = icmp ~w i64 ~w, ~w', [Res, Pred, ValSSA, Value]).
 
 %% plawk_query_print_lines(+Fields, +OutputSep, -IR)
 %  The per-record print body: each `field(K)` reads `%qtable_K[pos]` and prints

--- a/tests/test_plawk_query_reader.pl
+++ b/tests/test_plawk_query_reader.pl
@@ -125,6 +125,38 @@ test(query_reader_bad_column_not_yet) :-
     assertion(St == 2),
     !.
 
+% A reader guard filters the solution set: `if ($1 > 2)` keeps only the
+% matching solutions (a WHERE over the query's columns).
+test(query_reader_guard_run, [condition(clang_available)]) :-
+    qdir(Dir),
+    Src = "@prolog\nedge(1, 10).\nedge(2, 20).\nedge(3, 30).\nedge(4, 40).\n@end\n\c
+           pass over query(edge(X, Y)) { if ($1 > 2) print $1, $2 }\n",
+    build_run(Dir, 'guard', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "3 30\n4 40\n"),
+    !.
+
+% `&&` short-circuits at the surface but lowers to pure i1 and over the
+% per-column reads; the guard may read a column the body does not print.
+test(query_reader_guard_and_run, [condition(clang_available)]) :-
+    qdir(Dir),
+    Src = "@prolog\nedge(1, 10).\nedge(2, 20).\nedge(3, 30).\nedge(4, 40).\n@end\n\c
+           pass over query(edge(X, Y)) { if ($1 >= 2 && $2 < 40) print $1 }\n",
+    build_run(Dir, 'guard_and', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "2\n3\n"),
+    !.
+
+% `||` combines two column comparisons.
+test(query_reader_guard_or_run, [condition(clang_available)]) :-
+    qdir(Dir),
+    Src = "@prolog\nedge(1, 10).\nedge(2, 20).\nedge(3, 30).\n@end\n\c
+           pass over query(edge(X, Y)) { if ($1 == 1 || $2 == 30) print $1, $2 }\n",
+    build_run(Dir, 'guard_or', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "1 10\n3 30\n"),
+    !.
+
 % A query pass mixed with an ordinary pass is also outside v1 (all-query
 % only) and gets the same clean not-yet error rather than the generic one.
 test(query_reader_mixed_not_yet) :-


### PR DESCRIPTION
A query pass body may now be gated by an `if (COND)` **reader guard** — a WHERE over the goal's solutions:

```
@prolog
edge(1, 10). edge(2, 20). edge(3, 30). edge(4, 40).
@end

pass over query(edge(X, Y)) { if ($1 >= 2 && $2 < 40) print $1 }
```
→ `2` / `3`.

## How it works
- **Reuses the surface grammar.** `for_in_body` already parses `if (GUARD) print ...` into `[if(Guard, [print(Fields)], [])]` with `$K CMP int` leaves (`rfield_cmp`) combined by `&&` / `||`; the query driver just consumes it (`plawk_query_body_plan/3`).
- **Pure evaluation, no branching tree.** Each leaf reads `%qtable_K[pos]` (an i64) and compares it (`plawk_icmp_pred`); `and` / `or` combine child i1s. Because the per-column reads are side-effect-free, the guard lowers to plain i1 `and`/`or` with a **single** branch to a `q_print` block — no short-circuit control flow. The guard may read a column the body doesn't print (`&&` example above reads `$2`, prints `$1`).
- **Guard.** Only integer comparisons are meaningful (columns are i64); a float/string RHS or an out-of-range column stays a clean not-yet compile error.

## Tests
`tests/test_plawk_query_reader.pl` (14): a `>` filter, an `&&` reading a non-printed column, and an `||`. Regressions green: `test_plawk_reader_guards` (shares `plawk_icmp_pred`), `test_plawk_multipass`.

## Docs
Plan PR 4 marked landed + phase-6 entry in `PLAWK_MULTIPASS_CACHE.md`. **Plus a design sketch** (§6 of the plan) for **generator blocks** — `gen { … emit E … } as name` — the *producer dual* of the query reader you raised: where the query reader has Prolog drive a plawk pass, a gen block lets a plawk `{}` block be called by a Prolog goal (so the two compose). It captures your framing (blocks read as streaming to AWK users; functions shouldn't be lazy) and shows it fits the same **materialise-then-iterate** runtime (`emit` collects into a list → exposed as a non-deterministic relation `name(X) :- member(X, Collected)`), the bounded-multiplicity principle run in the producer direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_