### PR TITLE
WAM/LLVM plawk: query reader PR 5 — mixed passes + determinism test

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -1085,8 +1085,10 @@ single-pass test before any driver surgery).
   goal). The body may reorder, repeat, or subset the printed columns, and may
   be gated by an `if ($K CMP int)` reader guard (`&&` / `||` combinations) — a
   WHERE over the query's solutions, lowered to pure i1 and/or over the
-  per-column reads. Mixed query + ordinary passes and string columns are the
-  next PRs.
+  per-column reads. A query pass may run **mixed with ordinary passes** in one
+  program (integrated into the general multi-pass driver; the shared `%WamState`
+  the goal runs on is spliced in once), passes executing in program order.
+  String (non-integer) columns are the next PR.
 
 - **Phase 7 — secondary indexes (§3.5).** `index TABLE by FIELD [unique]` on
   record-valued tables; unique lookups return one record; non-unique

--- a/docs/design/PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md
@@ -5,9 +5,9 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk `over query(Goal)` reader — implementation plan (phase 6)
 
-**Status**: PRs 1–4 landed; an all-query program of any goal arity with a
-`print $K...` body — optionally gated by an `if ($K CMP int)` reader guard —
-runs end-to-end.
+**Status**: PRs 1–5 landed; a goal of any arity with a `print $K...` body —
+optionally gated by an `if ($K CMP int)` reader guard — runs end-to-end, in an
+all-query program or mixed with ordinary passes.
 Sequences the work for the query-driven reader (`PLAWK_MULTIPASS_CACHE.md`
 §3.4, phase 6): a pass whose records are the **solutions of a Prolog goal**.
 This is the "most beyond awk" reader and the first place plawk admits
@@ -175,10 +175,46 @@ pass over query(edge(X, Y)) { if ($1 >= 2 && $2 < 40) print $1 }
 - **Verified.** `tests/test_plawk_query_reader.pl`: a `>` filter, an `&&`
   reading a non-printed column, and an `||`.
 
-### PR 5 — Mixed passes + string columns + determinism/snapshot test
+### PR 5 — Mixed passes + determinism test — **LANDED**
 
-A query pass mixed with ordinary passes in one program; non-integer (string)
-columns via the posarray-str path. Plus the determinism/snapshot test below.
+A query pass may now run **alongside ordinary passes** in one program:
+
+```
+pass over query(edge(X, Y)) { print $1, $2 }   # materialised from the goal
+pass { print $1 }                               # scans the input file
+```
+
+- **Integrated into the general multi-pass driver.** A `pass_query` clause on
+  `plawk_multipass_pass_fn` emits the query pass-fn with the *standard*
+  multi-pass signature (`%Value %mp_path` + shared-table params, all ignored —
+  a query reads no input and shares no table), so main's call site is uniform.
+  Query passes contribute no table (`plawk_passes_tables` skips them), so the
+  table/cache machinery is untouched.
+- **VM getter spliced once.** The general driver does not emit the shared
+  `%WamState` a query goal runs on; `plawk_query_mixed_support_ir` adds it (sized
+  by the module code/label counts in `Options`) when a query pass is present.
+  The i64 print-format global the body uses is already among the driver's
+  runtime globals.
+- **Order preserved.** Passes run in program order; a query pass emits its
+  solutions, an ordinary pass scans the input — in either order, with guards on
+  the query pass composing as in PR 4.
+- **Determinism.** A test that the same query in two passes yields byte-identical
+  output (the collapse to a materialised set is order-stable and repeatable; a
+  disjunctive goal appears in the same solution order each pass). A *write*-
+  snapshot test (a pass mutating state the goal reads) is deferred: goals reach
+  the `@prolog` predicate universe, not mutable plawk tables, so there is no
+  path yet for a pass write to perturb a goal's solution set — that awaits goals
+  reading mutable plawk state (a later capability).
+- **Verified.** `tests/test_plawk_query_reader.pl`: query-then-ordinary,
+  ordinary-then-guarded-query, and the two-pass determinism check.
+
+### PR 6 — String columns
+
+Non-integer (atom / string) goal columns via the posarray-str path. The open
+question is per-column typing: columns are i64 today, and the goal's arguments
+are untyped at build. Likely a tagged materialisation primitive
+(`@wam_object_call_posarray_value` storing int-or-atom-id with a tag) so a
+column can carry either without a surface type annotation — its own PR.
 
 ### PR 4 — Determinism guarantees + snapshot test + docs
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -310,36 +310,28 @@ program_begin_clauses(program(BeginClauses, _, _), BeginClauses).
 program_begin_clauses(program_passes(BeginClauses, _, _), BeginClauses).
 
 % Phase 6 (PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md): the `over query(...)`
-% reader. PR 2 lands the runtime for the first supported shape -- an all-query
-% program whose goals are single-output and whose bodies are `print $1`. Any
-% query program OUTSIDE that surface (higher arity, a richer body, an END
-% block, or a query pass mixed with ordinary passes) still gets a clear,
-% specific not-yet diagnostic rather than the generic "outside the multi-pass
-% surface", while the supported shape flows on to the query driver.
+% reader. The runtime supports a goal of any arity with a `print $K...` body,
+% optionally gated by an `if ($K CMP int)` reader guard, in an all-query
+% program OR mixed with ordinary passes (PR 5). A query pass whose OWN shape is
+% outside that surface (bad arity/body, an out-of-range `$K`, a float/string
+% guard RHS) still gets a clear, specific not-yet diagnostic rather than the
+% generic "outside the multi-pass surface"; supported query passes flow on to
+% the driver.
 check_query_reader(File, Program) :-
     plawk_program_query_passes(Program, QueryPasses),
-    QueryPasses \== [],
-    \+ query_program_supported(Program),
+    member(pass_query(query(Pred, Vars), Body), QueryPasses),
+    \+ plawk_query_pass_supported(pass_query(query(Pred, Vars), Body)),
     !,
-    QueryPasses = [pass_query(query(Pred, Vars), _) | _],
     length(Vars, N),
     format(user_error,
         'plawk: ~w uses `over query(~w/~w)` outside the supported query-reader \c
-         surface (v1: an all-query program whose body is a single `print` of \c
-         $K fields, optionally gated by an `if ($K CMP int)` reader guard); \c
-         this shape is not yet implemented (phase 6); see \c
+         surface (v1: a `print` of $K fields over the goal columns, optionally \c
+         gated by an `if ($K CMP int)` reader guard); this shape is not yet \c
+         implemented (phase 6); see \c
          PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md.~n',
         [File, Pred, N]),
     halt(2).
 check_query_reader(_File, _Program).
-
-% A query program the PR-2 driver can lower end-to-end: every pass is a
-% supported `pass over query(...)` and there is no END block.
-query_program_supported(program_passes(_, Passes, End)) :-
-    End == [],
-    Passes = [_ | _],
-    forall(member(P, Passes), P = pass_query(_, _)),
-    forall(member(P, Passes), plawk_query_pass_supported(P)).
 
 % The findall-wrapper clauses to inject into a query program's @prolog
 % predicate set: one `__plawk_query_pred_C(L) :- findall(VC, pred(V1..Vn), L)`

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3901,8 +3901,26 @@ get_path:
 %  everything else delegates to the /2 driver unchanged.
 plawk_program_multipass_driver_ir(Program, Options, DriverIR) :-
     (   plawk_program_query_driver_ir(Program, Options, DriverIR)
-    ->  true
-    ;   plawk_program_multipass_driver_ir(Program, DriverIR)
+    ->  true                                       % all-query: self-contained
+    ;   plawk_program_multipass_driver_ir(Program, BaseIR),
+        plawk_query_mixed_support_ir(Program, Options, SupportIR),
+        atom_concat(SupportIR, BaseIR, DriverIR)
+    ).
+
+%% plawk_query_mixed_support_ir(+Program, +Options, -SupportIR)
+%  Extra module-level IR a general multi-pass program needs when it also
+%  contains a query pass (phase 6, PR 5): the shared %WamState getter the query
+%  reader runs its goal on, which the ordinary multi-pass driver does not emit.
+%  Sized by the module code/label counts in Options. Empty when the program has
+%  no query pass (ordinary multi-pass is unchanged). The i64 print-format global
+%  the query body uses is already emitted by the driver's runtime globals.
+plawk_query_mixed_support_ir(Program, Options, SupportIR) :-
+    plawk_program_query_passes(Program, QueryPasses),
+    (   QueryPasses == []
+    ->  SupportIR = ''
+    ;   memberchk(wam_vm(InstrCount, LabelCount), Options),
+        plawk_query_foreign_vm_ir(InstrCount, LabelCount, VmIR),
+        format(atom(SupportIR), '~w\n\n', [VmIR])
     ).
 
 %% plawk_program_query_passes(+Program, -QueryPasses) is det.
@@ -4009,7 +4027,7 @@ plawk_program_query_driver_ir(
         ( nth0(I, Passes, pass_query(query(Pred, Vars), Body)),
           length(Vars, Arity),
           plawk_query_body_plan(Body, Fields, Guard),
-          plawk_multipass_query_fn_ir(I, Pred, Arity, Fields, Guard,
+          plawk_multipass_query_fn_ir(I, '', Pred, Arity, Fields, Guard,
               OutputSeparator, FnIR) ),
         FnIRs),
     atomic_list_concat(FnIRs, '\n', PassFnsIR),
@@ -4065,8 +4083,8 @@ make:
         [InstrCount, InstrCount, InstrCount, LabelCount, LabelCount,
          LabelCount]).
 
-%% plawk_multipass_query_fn_ir(+Index, +Pred, +Arity, +Fields, +Guard,
-%%     +OutputSep, -IR)
+%% plawk_multipass_query_fn_ir(+Index, +ParamsIR, +Pred, +Arity, +Fields,
+%%     +Guard, +OutputSep, -IR)
 %  A query pass as a self-contained void function: materialise each goal column
 %  into its own assoc table (`%qtable_C`, keys 1..N by position) via
 %  @wam_object_call_posarray against the shared VM -- calling the per-column
@@ -4077,7 +4095,15 @@ make:
 %  reader guard (`if (COND)`) is evaluated over the per-column values -- pure
 %  i64 reads combined with i1 and/or (no short-circuit branching needed) --
 %  gating the print. All tables are freed at pass end (nothing persists).
-plawk_multipass_query_fn_ir(Index, Pred, Arity, Fields, Guard, OutputSep, IR) :-
+%
+%  `ParamsIR` is the function's parameter list content: empty for the all-query
+%  driver (`@plawk_pass_N()`), or the standard multi-pass signature
+%  (`%Value %mp_path` + the shared-table params) when a query pass runs inside
+%  the general multi-pass driver alongside ordinary passes -- the params are
+%  ignored (a query reads no input and shares no table), but the signature must
+%  match main's call.
+plawk_multipass_query_fn_ir(Index, ParamsIR, Pred, Arity, Fields, Guard,
+        OutputSep, IR) :-
     numlist(1, Arity, Cols),
     findall(MatLine,
         ( member(C, Cols),
@@ -4099,7 +4125,7 @@ plawk_multipass_query_fn_ir(Index, Pred, Arity, Fields, Guard, OutputSep, IR) :-
         FreeLines),
     atomic_list_concat(FreeLines, '\n', FreeIR),
     format(atom(IR),
-'define void @plawk_pass_~w() {
+'define void @plawk_pass_~w(~w) {
 entry:
   %vm = call %WamState* @plawk_foreign_vm_get()
 ~w
@@ -4123,7 +4149,7 @@ q_after:
 ~w
   ret void
 }',
-        [Index, MaterializeIR, BodyIR, FreeIR]).
+        [Index, ParamsIR, MaterializeIR, BodyIR, FreeIR]).
 
 %% plawk_query_body_ir(+Guard, +PrintIR, -BodyIR)
 %  The `q_body` block content. Unguarded: print then fall to `q_body_done`.
@@ -4383,6 +4409,21 @@ plawk_multipass_pass_fn(Index, pass_rows_anon(var(Table), Body), Tables,
     nth0(TableIndex, Tables, Table),
     plawk_multipass_records_fn_ir(Index, TableParamsIR, TableIndex, FieldPlans,
         GuardPlan, FieldSep, OutputSep, FnIR, GuardGlobals).
+% A query pass inside a general multi-pass program (phase 6, PR 5: mixed
+% query + ordinary passes). The query reader needs no input and no shared
+% table, but must adopt the standard pass-function signature so main's call
+% site is uniform; the params are ignored. The shared %WamState the goal runs
+% on (@plawk_foreign_vm) is emitted once by the driver (it has the module
+% code/label counts); this clause only emits the pass body. No per-pass string
+% globals (the i64 print format comes from the driver's runtime globals).
+plawk_multipass_pass_fn(Index, pass_query(query(Pred, Vars), Body), _Tables,
+        _StrArrays, _Schemas, TableParamsIR, _FieldSep, OutputSep, FnIR, '') :-
+    plawk_query_pass_supported(pass_query(query(Pred, Vars), Body)),
+    length(Vars, Arity),
+    plawk_query_body_plan(Body, Fields, Guard),
+    atom_concat('%Value %mp_path', TableParamsIR, ParamsIR),
+    plawk_multipass_query_fn_ir(Index, ParamsIR, Pred, Arity, Fields, Guard,
+        OutputSep, FnIR).
 
 % Resolve a no-`as` guard (`$N CMP int`) -> guard(N, Op, Value); none passes.
 plawk_rows_anon_guard(none, none).

--- a/tests/test_plawk_query_reader.pl
+++ b/tests/test_plawk_query_reader.pl
@@ -157,14 +157,45 @@ test(query_reader_guard_or_run, [condition(clang_available)]) :-
     assertion(Out == "1 10\n3 30\n"),
     !.
 
-% A query pass mixed with an ordinary pass is also outside v1 (all-query
-% only) and gets the same clean not-yet error rather than the generic one.
-test(query_reader_mixed_not_yet) :-
+% A query pass mixed with an ordinary input-reading pass: the query pass
+% materialises its goal (no input), the ordinary pass scans the input file.
+% Both run in one program (PR 5) -- query solutions first, then the ordinary
+% pass echoes column 1 of each input line.
+test(query_reader_mixed_run, [condition(clang_available)]) :-
     qdir(Dir),
-    Src = "@prolog\nnode(1).\n@end\n\c
-           pass over query(node(N)) { print $1 }\npass { c[$1]++ }\n",
-    build_status(Dir, 'mixed', Src, St),
-    assertion(St == 2),
+    Src = "@prolog\nedge(1, 10).\nedge(2, 20).\n@end\n\c
+           pass over query(edge(X, Y)) { print $1, $2 }\n\c
+           pass { print $1 }\n",
+    build_run_input(Dir, 'mixed', Src, "a b\nc d\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1 10\n2 20\na\nc\n"),
+    !.
+
+% Reverse order (ordinary pass first) with a guarded query pass: the ordinary
+% pass builds a table off the input, the query pass filters its goal.
+test(query_reader_mixed_reverse_run, [condition(clang_available)]) :-
+    qdir(Dir),
+    Src = "@prolog\nedge(5, 50).\nedge(6, 60).\n@end\n\c
+           pass { c[$1]++ }\n\c
+           pass over query(edge(X, Y)) { if ($1 == 6) print $1, $2 }\n",
+    build_run_input(Dir, 'mixrev', Src, "x\ny\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "6 60\n"),
+    !.
+
+% Determinism: the same query run in two passes yields byte-identical output
+% both times -- the collapse to a materialised set is order-stable and
+% repeatable (the multiplicity is fixed at the boundary; §1 intact). A
+% disjunctive (non-deterministic) goal still appears in the same solution
+% order in each pass.
+test(query_reader_determinism_two_passes, [condition(clang_available)]) :-
+    qdir(Dir),
+    Src = "@prolog\ng(A) :- (A = 7 ; A = 8 ; A = 9).\n@end\n\c
+           pass over query(g(X)) { print $1 }\n\c
+           pass over query(g(X)) { print $1 }\n",
+    build_run(Dir, 'determ', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "7\n8\n9\n7\n8\n9\n"),
     !.
 
 % A program that does NOT use the query reader is unaffected (no false trigger).
@@ -214,3 +245,12 @@ build_run(Dir, Name, Src, Args, Out, RunStatus) :-
     read_string(RS, _, Out),
     close(RS),
     process_wait(RPid, exit(RunStatus)).
+
+% Build a program, write Input to a file, and run the binary over that file
+% (for mixed programs whose ordinary passes scan an input file).
+build_run_input(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '_in.txt', InPath),
+    setup_call_cleanup(open(InPath, write, IS, [encoding(utf8)]),
+        write(IS, Input), close(IS)),
+    build_run(Dir, Name, Src, [InPath], Out, RunStatus).


### PR DESCRIPTION
A query pass may now run **alongside ordinary passes** in one program:

```
@prolog
edge(1, 10). edge(2, 20).
@end

pass over query(edge(X, Y)) { print $1, $2 }   # materialised from the goal
pass { print $1 }                               # scans the input file
```
→ `1 10` / `2 20` (from the goal), then column 1 of each input line.

## How it works
- **Integrated into the general multi-pass driver.** A `pass_query` clause on `plawk_multipass_pass_fn` emits the query pass-fn with the *standard* multi-pass signature (`%Value %mp_path` + shared-table params, all ignored — a query reads no input and shares no table), so main's call site is uniform. Query passes contribute no table (`plawk_passes_tables` already skips them), so the table/cache machinery is untouched.
- **VM getter spliced once.** The general driver doesn't emit the shared `%WamState` a query goal runs on; `plawk_query_mixed_support_ir` adds it (sized by the module code/label counts in `Options`) when a query pass is present. The i64 print-format global is already among the driver's runtime globals.
- **Order preserved.** Passes run in program order, in either arrangement; guards on the query pass compose as in PR 4.
- **`check_query_reader`** now errors only when a query pass's *own* shape is unsupported (bad arity/body/guard), so mixed programs proceed.

## Determinism (and what's deferred)
A test that the **same query in two passes yields byte-identical output** — the collapse to a materialised set is order-stable and repeatable, and a disjunctive (non-deterministic) goal appears in the same solution order each pass.

A **write-snapshot** test (a pass mutating state the goal reads mid-pass) is **deferred**, and I want to flag why: goals reach the `@prolog` predicate universe, not mutable plawk tables, so there is no path yet for a pass write to perturb a goal's solution set. A genuine write-snapshot test needs goals reading mutable plawk state — a later capability. Rather than write a vacuous test, I asserted the determinism guarantee that *is* constructible today.

## Tests
`tests/test_plawk_query_reader.pl` (16): query-then-ordinary, ordinary-then-guarded-query, two-pass determinism. Regressions green: `test_plawk_multipass`, `test_plawk_multipass_cache`, `test_plawk_multitable`, `test_plawk_rows_reader`, `test_plawk_records_reader`, `test_plawk_reader_guards`.

## Docs
Plan PR 5 marked landed; **PR 6 (string columns)** scoped with its design question (per-column typing — likely a tagged `@wam_object_call_posarray_value` primitive, its own PR). Phase-6 entry in `PLAWK_MULTIPASS_CACHE.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_