### PR TITLE
WAM/LLVM plawk: generator blocks PR 1 — surface + AST

### DIFF
--- a/docs/design/PLAWK_GENERATOR_BLOCKS.md
+++ b/docs/design/PLAWK_GENERATOR_BLOCKS.md
@@ -5,7 +5,7 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk generator blocks — `gen { … } as name` (design)
 
-**Status**: design sketch, not yet implemented. This is the **producer dual**
+**Status**: PR 1 (surface + AST) landed; runtime pending. This is the **producer dual**
 of the `over query(Goal)` reader (`PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md`,
 phase 6). Where the query reader lets a **Prolog goal drive a plawk pass**
 (Prolog → plawk records), a generator block lets a **plawk `{}` block be called
@@ -207,9 +207,17 @@ columns, snapshot test): it shares their materialise-then-iterate runtime and
 the per-column mechanism, so it is largely a matter of running that machinery in
 the producer direction plus the `emit` collection. A rough PR shape:
 
-1. **Surface + AST** — parse `gen { BODY } as name` (and the optional
-   `gen over SOURCE as v { BODY }`) to a `gen_block` term; `emit` action; a
-   clean not-yet error until the runtime lands.
+1. **Surface + AST — LANDED.** `gen { BODY } as name` parses to
+   `gen_block(name(Name), Body)` (a new `pass_clauses` clause, tried before the
+   plain `pass`); `emit E` parses to an `emit(Expr)` action (the print
+   field-expression grammar plus a bare-integer-literal fallback `emit(int(N))`,
+   the canonical `emit 1` form). `plawk_pass_dynentry_rewrite` gains a
+   passthrough clause; `check_generator_blocks/2` in `bin/plawk` emits a clean,
+   specific compile error (naming the generated relation) until the runtime
+   lands. `tests/test_plawk_gen_blocks.pl`: parse (integer literals, field /
+   string emit, `pass` unchanged), the not-yet error (exit 2), and a non-gen
+   program unaffected. The optional input iterator (`gen over SOURCE as v`) is
+   deferred to step 3. No runtime.
 2. **Collection runtime** — compile the block to an emit-collecting function;
    expose `name/1` as `member` over the collected list; verify a pure arity-1
    generator feeds a query pass.

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -102,6 +102,7 @@ build(File, Out0, KeepLL) :-
     resolve_cache_use(File, Program1, Program),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
+    check_generator_blocks(File, Program),
     % A query-reader program contributes synthesised findall-wrapper clauses
     % (one per goal predicate) so its enumeration compiles into the binary
     % alongside the user's @prolog predicates. Non-query programs add nothing.
@@ -332,6 +333,24 @@ check_query_reader(File, Program) :-
         [File, Pred, N]),
     halt(2).
 check_query_reader(_File, _Program).
+
+% Generator blocks (PLAWK_GENERATOR_BLOCKS.md): `gen { emit ... } as name`
+% parses (PR 1) but its runtime -- collect the emitted values into a
+% materialised set exposed as a non-deterministic relation `name/1` -- is not
+% wired yet, so a program that defines one gets a clear, specific diagnostic
+% rather than the generic "outside the multi-pass surface". The surface stays
+% stable while the runtime lands.
+check_generator_blocks(File, Program) :-
+    plawk_program_gen_blocks(Program, GenBlocks),
+    GenBlocks = [gen_block(name(Name), _) | _],
+    !,
+    format(user_error,
+        'plawk: ~w defines a generator block `gen { ... } as ~w`. Generator \c
+         blocks parse but their runtime is not yet implemented; see \c
+         PLAWK_GENERATOR_BLOCKS.md.~n',
+        [File, Name]),
+    halt(2).
+check_generator_blocks(_File, _Program).
 
 % The findall-wrapper clauses to inject into a query program's @prolog
 % predicate set: one `__plawk_query_pred_C(L) :- findall(VC, pred(V1..Vn), L)`

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -9,6 +9,7 @@
     plawk_query_helper_name/3,
     plawk_query_helper_clause/4,
     plawk_program_query_passes/2,
+    plawk_program_gen_blocks/2,
     plawk_query_pass_supported/1,
     plawk_program_foreign_specs/3,
     plawk_program_foreign_specs/4,
@@ -3929,6 +3930,14 @@ plawk_query_mixed_support_ir(Program, Options, SupportIR) :-
 plawk_program_query_passes(program_passes(_, Passes, _), QueryPasses) :-
     findall(pass_query(Q, B), member(pass_query(Q, B), Passes), QueryPasses).
 plawk_program_query_passes(program(_, _, _), []).
+
+%% plawk_program_gen_blocks(+Program, -GenBlocks) is det.
+%  The `gen { ... } as name` generator blocks of a program (empty if none).
+%  The producer dual of the query reader (PLAWK_GENERATOR_BLOCKS.md); collected
+%  alongside the passes at parse time.
+plawk_program_gen_blocks(program_passes(_, Passes, _), GenBlocks) :-
+    findall(gen_block(N, B), member(gen_block(N, B), Passes), GenBlocks).
+plawk_program_gen_blocks(program(_, _, _), []).
 
 %% plawk_query_pass_supported(+Pass) is semidet.
 %  The query-reader surface a build can lower today (phase 6, PRs 2-4): a goal

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -287,6 +287,20 @@ query_var_list_rest([V | Vs]) -->
     query_var_list_rest(Vs).
 query_var_list_rest([]) -->
     [].
+% A `gen { BODY } as name` generator block (PLAWK_GENERATOR_BLOCKS.md): a
+% producer whose `emit E` statements define a relation `name/1`, callable from
+% a Prolog goal (e.g. a query pass's `over query(name(X))`). The producer dual
+% of the query reader. Parses to gen_block(name(Name), Body); the runtime
+% (materialise-then-iterate, mirroring the reader) lands in a later PR, so PR 1
+% is the surface + a clean not-yet compile error. The `gen` keyword is
+% unambiguous (distinct from `pass`); tried before the plain `pass` clause. The
+% optional input iterator (`gen over SOURCE as v { ... }`) is a follow-on.
+pass_clauses([gen_block(name(Name), Body) | Rest]) -->
+    "gen", identifier_boundary, ws,
+    action_block(Body), ws,
+    "as", identifier_boundary, ws,
+    identifier(Name), ws,
+    pass_clauses(Rest).
 % A `pass { ACTIONS }` block is one pass carrying a single always-rule with
 % those actions (per-pattern rules within a pass are a later extension).
 pass_clauses([pass([rule(always, Actions)]) | Rest]) -->
@@ -307,6 +321,9 @@ plawk_pass_dynentry_rewrite(_DynEntries, pass_rows(V, T, Body), pass_rows(V, T, 
 plawk_pass_dynentry_rewrite(_DynEntries, pass_rows_anon(T, Body), pass_rows_anon(T, Body)).
 % The `over query(...)` reader has no rule actions to rewrite -- pass it through.
 plawk_pass_dynentry_rewrite(_DynEntries, pass_query(Q, Body), pass_query(Q, Body)).
+% A `gen { ... } as name` generator block -- pass it through (its body is
+% lowered by the generator runtime in a later PR).
+plawk_pass_dynentry_rewrite(_DynEntries, gen_block(N, Body), gen_block(N, Body)).
 
 %% dynentry_decls(-Names)//
 %
@@ -1382,6 +1399,9 @@ action(Action) -->
     printf_action(Action),
     !.
 action(Action) -->
+    emit_action(Action),
+    !.
+action(Action) -->
     writebin_action(Action),
     !.
 action(Action) -->
@@ -1787,6 +1807,26 @@ print_action(print(Fields)) -->
     "print",
     required_ws,
     print_fields(Fields).
+
+% `emit E` -- the producer counterpart of `print` inside a generator block
+% (PLAWK_GENERATOR_BLOCKS.md). Instead of writing a record to stdout, it
+% contributes the value of E to the generated relation's solution set. Parses
+% to emit(Expr) reusing the print field-expression grammar (a field, number,
+% string, or arithmetic expression). Explicit emission keeps the value typed
+% (design doc section 2.1); a tuple emit (`emit (A, B)` -> arity 2) is a
+% follow-on. `emit` is only meaningful inside a `gen { ... }` block; the
+% codegen (bin/plawk) rejects it elsewhere until the runtime lands.
+emit_action(emit(Expr)) -->
+    "emit",
+    required_ws,
+    field_expr(Expr).
+% A bare numeric literal (`emit 1`) -- the canonical generator form. field_expr
+% (above) covers fields, strings, NR/NF and arithmetic but not a leading bare
+% integer, so fall back to an integer literal, carried as int(N).
+emit_action(emit(int(N))) -->
+    "emit",
+    required_ws,
+    signed_integer_value(N).
 
 printf_action(printf(string(Format), Args)) -->
     "printf",

--- a/tests/test_plawk_gen_blocks.pl
+++ b/tests/test_plawk_gen_blocks.pl
@@ -1,0 +1,93 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk generator blocks (PLAWK_GENERATOR_BLOCKS.md), PR 1: the SURFACE.
+% `gen { emit E ... } as name` parses to gen_block(name(Name), Body) -- a
+% producer whose `emit E` statements will define a non-deterministic relation
+% `name/1` callable from a Prolog goal (the producer dual of the query reader).
+% The runtime (materialise-then-iterate) is not wired yet, so building a program
+% that defines a generator block is a clean, specific compile error rather than
+% the generic "outside the multi-pass surface".
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_gen_blocks).
+
+% `gen { emit N ... } as name` parses to gen_block(name(Name), Body); each
+% `emit E` is an emit(Expr) action. Integer literals fall back to int(N).
+test(gen_block_int_literals_parses) :-
+    plawk_parse_string(
+        "gen { emit 1; emit 2; emit 3 } as small\n\c
+         pass over query(small(X)) { print $1 }\n",
+        program_passes([],
+            [gen_block(name(small),
+                 [emit(int(1)), emit(int(2)), emit(int(3))]),
+             pass_query(query(small, ['X']), [print([field(1)])])],
+            [])),
+    !.
+
+% `emit` accepts the print field-expression grammar: a field ($1) or a string
+% literal (carried as string(_), an atom/string to emit).
+test(gen_block_field_and_string_emit_parses) :-
+    plawk_parse_string(
+        "gen { emit $1; emit \"red\" } as g\n",
+        program_passes([],
+            [gen_block(name(g), Body)],
+            [])),
+    Body = [emit(field(1)), emit(StrEmit)],
+    StrEmit = string(_),
+    !.
+
+% The `gen` keyword is distinct from `pass`: an ordinary pass is untouched.
+test(pass_unchanged) :-
+    plawk_parse_string(
+        "pass { print $1 }\n",
+        program_passes([],
+            [pass([rule(always, [print([field(1)])])])],
+            [])),
+    !.
+
+% Building a generator-block program is a clean compile error (exit 2) until
+% the runtime lands; the message names the generated relation.
+test(gen_block_is_not_yet_error) :-
+    gdir(Dir),
+    Src = "gen { emit 1; emit 2 } as small\npass over query(small(X)) { print $1 }\n",
+    build_status(Dir, 'g', Src, St),
+    assertion(St == 2),
+    !.
+
+% A program with no generator block is unaffected (no false trigger).
+test(non_gen_program_builds, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "@prolog\nedge(1).\nedge(2).\n@end\npass over query(edge(X)) { print $1 }\n",
+    build_status(Dir, 'ok', Src, St),
+    assertion(St == 0),
+    !.
+
+:- end_tests(plawk_gen_blocks).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+gdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_gen_blocks', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_status(Dir, Name, Src, Status) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).


### PR DESCRIPTION
First PR of the **generator blocks** arc — the producer dual of the `over query(Goal)` reader. `gen { emit E … } as name` defines a relation `name/1` a Prolog goal (e.g. a query pass) can call, closing the plawk↔Prolog loop:

```
gen { emit 1; emit 2; emit 3 } as small
pass over query(small(X)) { print $1 }
```

PR 1 is **surface + AST + a clean not-yet error** (mirrors query reader PR 1); no runtime yet.

## Parser
- A new `pass_clauses` clause parses `gen { BODY } as name` → `gen_block(name(Name), Body)` (tried before the plain `pass`; the `gen` keyword is unambiguous).
- `emit E` → `emit(Expr)` action, reusing the `print` field-expression grammar (so `emit $1`, `emit "red"`, arithmetic all work), **plus** a bare-integer-literal fallback `emit(int(N))` — `field_expr` doesn't accept a leading bare integer, and `emit 1` is the canonical generator form.
- `plawk_pass_dynentry_rewrite` gains a `gen_block` passthrough clause so the whole-program parse accepts it.

## Codegen + bin
- `plawk_program_gen_blocks/2` collects a program's generator blocks.
- `check_generator_blocks/2` emits a clean, specific compile error (exit 2, naming the generated relation) until the runtime lands, instead of the generic "outside the multi-pass surface".

## Tests
`tests/test_plawk_gen_blocks.pl` (5): parse (integer literals, field/string emit, `pass` unchanged), the not-yet error, and a non-gen program unaffected. Regressions green: `test_plawk_query_reader`, `test_plawk_multipass`.

## Docs
`PLAWK_GENERATOR_BLOCKS.md` PR 1 marked landed; §9 sequence updated (remaining: PR 2 collection runtime → `name(X) :- member(X, Collected)`; PR 3 optional input iterator; PR 4 tuples + durability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_