### PR TITLE
WAM/LLVM plawk: generator blocks PR 2 — constant emits → facts

### DIFF
--- a/docs/design/PLAWK_GENERATOR_BLOCKS.md
+++ b/docs/design/PLAWK_GENERATOR_BLOCKS.md
@@ -5,7 +5,8 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk generator blocks — `gen { … } as name` (design)
 
-**Status**: PR 1 (surface + AST) landed; runtime pending. This is the **producer dual**
+**Status**: PRs 1–2 landed — a pure generator with constant emits feeds a query
+pass end-to-end. This is the **producer dual**
 of the `over query(Goal)` reader (`PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md`,
 phase 6). Where the query reader lets a **Prolog goal drive a plawk pass**
 (Prolog → plawk records), a generator block lets a **plawk `{}` block be called
@@ -218,9 +219,26 @@ the producer direction plus the `emit` collection. A rough PR shape:
    string emit, `pass` unchanged), the not-yet error (exit 2), and a non-gen
    program unaffected. The optional input iterator (`gen over SOURCE as v`) is
    deferred to step 3. No runtime.
-2. **Collection runtime** — compile the block to an emit-collecting function;
-   expose `name/1` as `member` over the collected list; verify a pure arity-1
-   generator feeds a query pass.
+2. **Collection runtime (first shape) — LANDED.** A **pure** generator whose
+   body is only *constant* emits (`gen { emit 1; emit 2 } as name`) compiles to
+   Prolog facts — each `emit int(N)` → `name(N)`, each `emit "s"` →
+   `name(s)` — injected into the program's `@prolog` set (`resolve_generator_blocks`
+   in `bin/plawk`), and the generator block is lifted out of the pass list. The
+   *existing* query reader then consumes `name/1` unchanged (its findall wrapper
+   enumerates the facts), so `gen { emit 1; emit 2; emit 3 } as small` +
+   `pass over query(small(X)) { print $1 }` prints `1/2/3` — no new runtime
+   primitive, the mirror of the query reader's clause injection run in the
+   producer direction. Integer and string emits both work (strings resolve via
+   the reader's tagged column materialisation), and a reader guard on the
+   consumer composes. A *computed* emit (a field / arithmetic) or a non-emit
+   action needs the demand-driven collection runtime and is a clean not-yet
+   error. `tests/test_plawk_gen_blocks.pl`: int, string, guarded-consume runs,
+   and the computed-emit not-yet error.
+
+   *Follow-on (this same PR line):* computed / input-dependent emits, which
+   cannot be facts — the block runs and collects at runtime. The proven path is
+   `assertz` into the dynamic DB + `findall` (the `test_plawk_eval_compile.pl`
+   stateful-grammar pattern), driven from the emit sites.
 3. **Optional input iterator** — `gen over SOURCE as v { … }` for a table /
    `over query` source (flat-map / filter).
 4. **Tuples + durability** — `emit (A, B)` → `name/2`; optional cache/LMDB-backed

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -99,15 +99,23 @@ build(File, Out0, KeepLL) :-
         halt(2)
     ),
     normalize_passes(File, Program0, Program1),
-    resolve_cache_use(File, Program1, Program),
+    resolve_cache_use(File, Program1, Program2),
+    % Generator blocks (PLAWK_GENERATOR_BLOCKS.md): reject unsupported ones,
+    % then lift the supported ones out of the pass list -- a pure generator
+    % with constant emits (`gen { emit 1; emit 2 } as name`) compiles to
+    % Prolog facts (`name(1). name(2).`), consumed by the query reader exactly
+    % like any other relation. `Program` is the program with generator blocks
+    % removed; `GenFactClauses` are the synthesised facts.
+    check_generator_blocks(File, Program2),
+    resolve_generator_blocks(Program2, Program, GenFactClauses),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
-    check_generator_blocks(File, Program),
     % A query-reader program contributes synthesised findall-wrapper clauses
     % (one per goal predicate) so its enumeration compiles into the binary
-    % alongside the user's @prolog predicates. Non-query programs add nothing.
+    % alongside the user's @prolog predicates; a generator block contributes
+    % its emitted facts. Non-query / non-generator programs add nothing.
     plawk_program_query_helper_clauses(Program, QueryHelperClauses),
-    append(Clauses, QueryHelperClauses, ClausesForPreds),
+    append([Clauses, GenFactClauses, QueryHelperClauses], ClausesForPreds),
     (   ClausesForPreds == []
     ->  Preds = [user:plawk_cli_marker/0]
     ;   (   plawk_prolog_block_preds(ClausesForPreds, Preds)
@@ -334,23 +342,57 @@ check_query_reader(File, Program) :-
     halt(2).
 check_query_reader(_File, _Program).
 
-% Generator blocks (PLAWK_GENERATOR_BLOCKS.md): `gen { emit ... } as name`
-% parses (PR 1) but its runtime -- collect the emitted values into a
-% materialised set exposed as a non-deterministic relation `name/1` -- is not
-% wired yet, so a program that defines one gets a clear, specific diagnostic
-% rather than the generic "outside the multi-pass surface". The surface stays
-% stable while the runtime lands.
+% Generator blocks (PLAWK_GENERATOR_BLOCKS.md). PR 2 supports the first shape:
+% a PURE generator whose body is only constant `emit`s (`gen { emit 1; emit 2 }
+% as name`), which compiles to Prolog facts. A generator whose body has a
+% computed emit (a field, arithmetic) or a non-emit action needs runtime
+% collection (a later PR), so it gets a clear, specific not-yet diagnostic
+% rather than the generic "outside the multi-pass surface".
 check_generator_blocks(File, Program) :-
     plawk_program_gen_blocks(Program, GenBlocks),
-    GenBlocks = [gen_block(name(Name), _) | _],
+    member(gen_block(name(Name), Body), GenBlocks),
+    \+ gen_block_supported(Body),
     !,
     format(user_error,
-        'plawk: ~w defines a generator block `gen { ... } as ~w`. Generator \c
-         blocks parse but their runtime is not yet implemented; see \c
-         PLAWK_GENERATOR_BLOCKS.md.~n',
+        'plawk: ~w defines a generator block `gen { ... } as ~w` with a \c
+         computed or non-constant body; only constant `emit`s (`emit 1`, \c
+         `emit "x"`) are supported yet -- see PLAWK_GENERATOR_BLOCKS.md.~n',
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
+
+% A generator block the PR-2 fact synthesis can lower: every action is a
+% constant `emit` (an integer or string literal). Computed emits (a field /
+% arithmetic) and non-emit actions are follow-ons (runtime collection).
+gen_block_supported(Body) :-
+    forall(member(Action, Body),
+        ( Action = emit(int(_)) ; Action = emit(string(_)) )).
+
+% Lift generator blocks out of the pass list: each supported block's constant
+% emits become facts for its relation (`gen { emit 1; emit 2 } as g` ->
+% `g(1). g(2).`), so the query reader consumes `g/1` like any relation. The
+% returned program has the generator blocks removed.
+resolve_generator_blocks(program_passes(Begin, Passes, End),
+        program_passes(Begin, Passes1, End), FactClauses) :-
+    !,
+    exclude(is_gen_block, Passes, Passes1),
+    include(is_gen_block, Passes, GenBlocks),
+    findall(Fact,
+        ( member(gen_block(name(Name), Body), GenBlocks),
+          member(emit(Value), Body),
+          gen_emit_fact(Name, Value, Fact) ),
+        FactClauses).
+resolve_generator_blocks(Program, Program, []).
+
+is_gen_block(gen_block(_, _)).
+
+% A constant emit -> a unary fact for the generated relation. An integer emits
+% itself; a string emits the corresponding atom (so `emit "red"` -> `g(red)`).
+gen_emit_fact(Name, int(N), Fact) :-
+    Fact =.. [Name, N].
+gen_emit_fact(Name, string(S), Fact) :-
+    atom_string(Atom, S),
+    Fact =.. [Name, Atom].
 
 % The findall-wrapper clauses to inject into a query program's @prolog
 % predicate set: one `__plawk_query_pred_C(L) :- findall(VC, pred(V1..Vn), L)`

--- a/tests/test_plawk_gen_blocks.pl
+++ b/tests/test_plawk_gen_blocks.pl
@@ -51,12 +51,45 @@ test(pass_unchanged) :-
             [])),
     !.
 
-% Building a generator-block program is a clean compile error (exit 2) until
-% the runtime lands; the message names the generated relation.
-test(gen_block_is_not_yet_error) :-
+% A pure generator with constant integer emits compiles to facts and feeds a
+% query pass: `gen { emit 1; emit 2; emit 3 } as small` -> the query prints the
+% three solutions (the producer dual, closing the plawk<->Prolog loop).
+test(gen_block_int_run, [condition(clang_available)]) :-
     gdir(Dir),
-    Src = "gen { emit 1; emit 2 } as small\npass over query(small(X)) { print $1 }\n",
-    build_status(Dir, 'g', Src, St),
+    Src = "gen { emit 1; emit 2; emit 3 } as small\n\c
+           pass over query(small(X)) { print $1 }\n",
+    build_run(Dir, 'genint', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "1\n2\n3\n"),
+    !.
+
+% String emits become atoms (`emit "red"` -> `color(red)`); the query reader
+% resolves them to text via its tagged column materialisation.
+test(gen_block_string_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "gen { emit \"red\"; emit \"green\"; emit \"blue\" } as color\n\c
+           pass over query(color(C)) { print $1 }\n",
+    build_run(Dir, 'genstr', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "red\ngreen\nblue\n"),
+    !.
+
+% A reader guard on the consuming query pass composes with a generator source.
+test(gen_block_guarded_consume_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "gen { emit 10; emit 20; emit 30 } as weight\n\c
+           pass over query(weight(W)) { if ($1 > 10) print $1 }\n",
+    build_run(Dir, 'genguard', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "20\n30\n"),
+    !.
+
+% A computed emit (a field, not a constant) needs runtime collection -- not yet
+% implemented -- so it is a clean not-yet compile error (exit 2).
+test(gen_block_computed_emit_not_yet) :-
+    gdir(Dir),
+    Src = "gen { emit $1 } as g\npass over query(g(X)) { print $1 }\n",
+    build_status(Dir, 'gencomp', Src, St),
     assertion(St == 2),
     !.
 
@@ -91,3 +124,19 @@ build_status(Dir, Name, Src, Status) :-
     process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
         [stdout(null), stderr(null), process(Pid)]),
     process_wait(Pid, exit(Status)).
+
+% Build a program, then run the resulting binary with Args, capturing stdout.
+build_run(Dir, Name, Src, Args, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, Args,
+        [stdout(pipe(RS)), stderr(std), process(RPid)]),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
The generator collection runtime, first shape — and it closes the plawk↔Prolog loop end-to-end:

```
gen { emit 1; emit 2; emit 3 } as small
pass over query(small(X)) { print $1 }        # → 1 / 2 / 3
```

## The realisation
A **pure** generator whose body is only *constant* emits compiles to **Prolog facts**, consumed by the existing query reader unchanged — the mirror of the reader's own clause injection, run in the producer direction (no new runtime primitive).

- `resolve_generator_blocks/3` (bin) lifts generator blocks out of the pass list and turns each constant emit into a unary fact: `emit int(N)` → `name(N)`, `emit "s"` → `name(s)` (the atom). Those facts are injected into the program's `@prolog` set alongside the query reader's findall wrappers, so `name/1` compiles into the binary and the reader enumerates it.
- `check_generator_blocks` now rejects only **unsupported** blocks — a *computed* emit (field/arithmetic) or a non-emit action needs the demand-driven collection runtime (a later PR); constant-emit blocks proceed.
- Integer **and** string emits work (strings resolve via the reader's tagged column materialisation from #3754), and a reader **guard** on the consuming query pass composes:
  ```
  gen { emit 10; emit 20; emit 30 } as weight
  pass over query(weight(W)) { if ($1 > 10) print $1 }   # → 20 / 30
  ```

## Tests
`tests/test_plawk_gen_blocks.pl` (8): int, string, and guarded-consume end-to-end runs; the computed-emit not-yet error; parse tests + non-gen program unaffected. Regressions green: `test_plawk_query_reader`, `test_plawk_multipass`.

## Docs
`PLAWK_GENERATOR_BLOCKS.md` PR 2 marked landed, with the **computed-emit follow-on** noted: input-dependent emits can't be facts, so the block runs and collects at runtime — the proven `assertz` + `findall` path (the `test_plawk_eval_compile.pl` stateful-grammar pattern), driven from the emit sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_