### PR TITLE
WAM/LLVM plawk: generator blocks PR 3 — input iterator over a query source

### DIFF
--- a/docs/design/PLAWK_GENERATOR_BLOCKS.md
+++ b/docs/design/PLAWK_GENERATOR_BLOCKS.md
@@ -5,8 +5,9 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk generator blocks — `gen { … } as name` (design)
 
-**Status**: PRs 1–2 landed — a pure generator with constant emits feeds a query
-pass end-to-end. This is the **producer dual**
+**Status**: PRs 1–3 landed — a pure generator with constant emits, and an input
+iterator that passes through / filters a query source, both feed a query pass
+end-to-end (via synthesised facts / a derived rule). This is the **producer dual**
 of the `over query(Goal)` reader (`PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md`,
 phase 6). Where the query reader lets a **Prolog goal drive a plawk pass**
 (Prolog → plawk records), a generator block lets a **plawk `{}` block be called
@@ -239,7 +240,20 @@ the producer direction plus the `emit` collection. A rough PR shape:
    cannot be facts — the block runs and collects at runtime. The proven path is
    `assertz` into the dynamic DB + `findall` (the `test_plawk_eval_compile.pl`
    stateful-grammar pattern), driven from the emit sites.
-3. **Optional input iterator** — `gen over SOURCE as v { … }` for a table /
-   `over query` source (flat-map / filter).
+3. **Optional input iterator (query source) — LANDED.** `gen over query(SRC(V))
+   as v { emit v } as name` compiles to a **derived Prolog rule**
+   `name(A) :- src(A)` (a relation alias / pass-through), and
+   `gen over query(SRC(V)) as v { if (v CMP int [&& …]) emit v } as name` to a
+   filtered rule `name(A) :- src(A), A CMP int [, …]` — again pure clause
+   synthesis (`resolve_generator_blocks` in `bin/plawk`, translating the reader
+   guard to a Prolog arithmetic comparison over the head arg), consumed by the
+   query reader unchanged. So `gen over query(num(V)) as v { if (v > 2) emit v }
+   as big` + `pass over query(big(X)) { print $1 }` prints the source solutions
+   `> 2`. A *transforming* emit (`emit v * 2`, an expression over `v` rather
+   than the bound var itself) or a non-query source needs the runtime
+   collection and is a clean not-yet error. `tests/test_plawk_gen_blocks.pl`:
+   passthrough, `>` filter, `&&` filter, and the transform / computed-emit
+   not-yet errors. The AST unified to `gen_block(name(Name), Source, Body)`
+   with `Source` = `none` (pure) or `over(query(Src, Vars), LoopVar)`.
 4. **Tuples + durability** — `emit (A, B)` → `name/2`; optional cache/LMDB-backed
    collected set.

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -342,49 +342,109 @@ check_query_reader(File, Program) :-
     halt(2).
 check_query_reader(_File, _Program).
 
-% Generator blocks (PLAWK_GENERATOR_BLOCKS.md). PR 2 supports the first shape:
-% a PURE generator whose body is only constant `emit`s (`gen { emit 1; emit 2 }
-% as name`), which compiles to Prolog facts. A generator whose body has a
-% computed emit (a field, arithmetic) or a non-emit action needs runtime
-% collection (a later PR), so it gets a clear, specific not-yet diagnostic
-% rather than the generic "outside the multi-pass surface".
+% Generator blocks (PLAWK_GENERATOR_BLOCKS.md). Two shapes compile to Prolog
+% clauses today: a PURE generator whose body is only constant `emit`s
+% (`gen { emit 1; emit 2 } as name` -> facts), and an INPUT-ITERATOR generator
+% over a query source (`gen over query(src(V)) as v { [if (v CMP int)] emit v }
+% as name` -> a derived rule `name(V) :- src(V) [, V CMP int]`). Anything else
+% -- a pure block with a computed/non-constant emit, or an over-block that
+% transforms rather than passes through the bound var -- needs runtime
+% collection (a later PR), so it gets a clear, specific not-yet diagnostic.
 check_generator_blocks(File, Program) :-
     plawk_program_gen_blocks(Program, GenBlocks),
-    member(gen_block(name(Name), Body), GenBlocks),
-    \+ gen_block_supported(Body),
+    member(gen_block(name(Name), Source, Body), GenBlocks),
+    \+ gen_block_supported(Source, Body),
     !,
     format(user_error,
-        'plawk: ~w defines a generator block `gen { ... } as ~w` with a \c
-         computed or non-constant body; only constant `emit`s (`emit 1`, \c
-         `emit "x"`) are supported yet -- see PLAWK_GENERATOR_BLOCKS.md.~n',
+        'plawk: ~w defines a generator block `... as ~w` outside the supported \c
+         surface (a pure block of constant `emit`s, or `gen over query(src(V)) \c
+         as v { [if (v CMP int)] emit v }`); this shape needs runtime \c
+         collection -- see PLAWK_GENERATOR_BLOCKS.md.~n',
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
 
-% A generator block the PR-2 fact synthesis can lower: every action is a
-% constant `emit` (an integer or string literal). Computed emits (a field /
-% arithmetic) and non-emit actions are follow-ons (runtime collection).
-gen_block_supported(Body) :-
+% A generator block whose clauses can be synthesised at build time:
+%  - a pure block (`Source == none`) whose every action is a constant `emit`
+%    (integer or string literal) -> facts;
+%  - an input iterator over a query source whose body passes the bound var
+%    through (`emit v`), optionally gated by an integer reader guard over `v`
+%    -> a derived rule.
+gen_block_supported(none, Body) :-
     forall(member(Action, Body),
         ( Action = emit(int(_)) ; Action = emit(string(_)) )).
+gen_block_supported(over(query(_Src, [_SrcVar]), LoopVar), Body) :-
+    gen_over_body_ok(Body, LoopVar).
 
-% Lift generator blocks out of the pass list: each supported block's constant
-% emits become facts for its relation (`gen { emit 1; emit 2 } as g` ->
-% `g(1). g(2).`), so the query reader consumes `g/1` like any relation. The
-% returned program has the generator blocks removed.
+% A supported input-iterator body: `emit v` (passthrough), optionally filtered
+% by `if (GUARD) emit v` where GUARD is an integer comparison over `v`.
+gen_over_body_ok([emit(var(LoopVar))], LoopVar).
+gen_over_body_ok([if(Guard, [emit(var(LoopVar))], [])], LoopVar) :-
+    gen_over_guard_ok(Guard, LoopVar).
+gen_over_guard_ok(and(L, R), LoopVar) :-
+    gen_over_guard_ok(L, LoopVar), gen_over_guard_ok(R, LoopVar).
+gen_over_guard_ok(forin_key_cmp(LoopVar, _Op, Value), LoopVar) :-
+    integer(Value).
+
+% Lift generator blocks out of the pass list, synthesising each one's clauses:
+% a pure block's constant emits become facts (`gen { emit 1; emit 2 } as g` ->
+% `g(1). g(2).`); an input iterator becomes a derived rule
+% (`gen over query(src(V)) as v { if (v > 2) emit v } as g` ->
+% `g(A) :- src(A), A > 2.`). The query reader then consumes `g/1` like any
+% relation. The returned program has the generator blocks removed.
 resolve_generator_blocks(program_passes(Begin, Passes, End),
-        program_passes(Begin, Passes1, End), FactClauses) :-
+        program_passes(Begin, Passes1, End), Clauses) :-
     !,
     exclude(is_gen_block, Passes, Passes1),
     include(is_gen_block, Passes, GenBlocks),
-    findall(Fact,
-        ( member(gen_block(name(Name), Body), GenBlocks),
-          member(emit(Value), Body),
-          gen_emit_fact(Name, Value, Fact) ),
-        FactClauses).
+    findall(Clause,
+        ( member(GB, GenBlocks), gen_block_clause(GB, Clause) ),
+        Clauses).
 resolve_generator_blocks(Program, Program, []).
 
-is_gen_block(gen_block(_, _)).
+is_gen_block(gen_block(_, _, _)).
+
+% The Prolog clause(s) a generator block contributes.
+% Pure block: one fact per constant emit.
+gen_block_clause(gen_block(name(Name), none, Body), Fact) :-
+    member(emit(Value), Body),
+    gen_emit_fact(Name, Value, Fact).
+% Input iterator: a single derived rule over the source goal.
+gen_block_clause(gen_block(name(Name), over(query(Src, [_SrcVar]), LoopVar),
+        Body), Clause) :-
+    % Arg is a fresh logic variable shared by the head, the source goal, and
+    % the filter -- so `g(A) :- src(A), A > 2` unifies across the three.
+    SrcGoal =.. [Src, Arg],
+    Head =.. [Name, Arg],
+    gen_over_body_goal(Body, LoopVar, Arg, FilterGoal),
+    ( FilterGoal == true
+    ->  Clause = (Head :- SrcGoal)
+    ;   Clause = (Head :- SrcGoal, FilterGoal)
+    ).
+
+% The Prolog goal an input-iterator body adds after the source goal: `true`
+% for a bare passthrough, or the translated guard for a filtered one.
+gen_over_body_goal([emit(var(_LoopVar))], _LoopVar, _Arg, true).
+gen_over_body_goal([if(Guard, [emit(var(_LoopVar))], [])], LoopVar, Arg,
+        Goal) :-
+    gen_guard_goal(Guard, LoopVar, Arg, Goal).
+
+% Translate an integer reader guard over the bound var into a Prolog arithmetic
+% comparison over the head argument.
+gen_guard_goal(and(L, R), LoopVar, Arg, (GL, GR)) :-
+    gen_guard_goal(L, LoopVar, Arg, GL),
+    gen_guard_goal(R, LoopVar, Arg, GR).
+gen_guard_goal(forin_key_cmp(LoopVar, Op, Value), LoopVar, Arg, Goal) :-
+    gen_cmp_op(Op, PrologOp),
+    Goal =.. [PrologOp, Arg, Value].
+
+% Surface comparison op -> Prolog arithmetic comparison.
+gen_cmp_op(gt, >).
+gen_cmp_op(lt, <).
+gen_cmp_op(ge, >=).
+gen_cmp_op(le, =<).
+gen_cmp_op(eq, =:=).
+gen_cmp_op(ne, =\=).
 
 % A constant emit -> a unary fact for the generated relation. An integer emits
 % itself; a string emits the corresponding atom (so `emit "red"` -> `g(red)`).

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -3936,7 +3936,7 @@ plawk_program_query_passes(program(_, _, _), []).
 %  The producer dual of the query reader (PLAWK_GENERATOR_BLOCKS.md); collected
 %  alongside the passes at parse time.
 plawk_program_gen_blocks(program_passes(_, Passes, _), GenBlocks) :-
-    findall(gen_block(N, B), member(gen_block(N, B), Passes), GenBlocks).
+    findall(gen_block(N, S, B), member(gen_block(N, S, B), Passes), GenBlocks).
 plawk_program_gen_blocks(program(_, _, _), []).
 
 %% plawk_query_pass_supported(+Pass) is semidet.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -287,20 +287,49 @@ query_var_list_rest([V | Vs]) -->
     query_var_list_rest(Vs).
 query_var_list_rest([]) -->
     [].
+% A `gen over query(SRC(V)) as v { BODY } as name` generator with an input
+% iterator (PLAWK_GENERATOR_BLOCKS.md, PR 3): a producer that transforms another
+% relation. Each solution of the source goal binds `v`; the body emits from it.
+% Parses to gen_block(name(Name), over(query(Src, SrcVars), LoopVar), Body).
+% Tried before the pure `gen { ... }` form -- the `over` keyword distinguishes
+% them. The body is emit-based (`emit v`, or `if (v CMP int) emit v` to filter),
+% so it uses the reader-guard body grammar rather than a general action block.
+pass_clauses([gen_block(name(Name),
+        over(query(Src, SrcVars), LoopVar), Body) | Rest]) -->
+    "gen", identifier_boundary, ws,
+    "over", identifier_boundary, ws,
+    "query", ws, "(", ws,
+    identifier(Src), ws, "(", ws, query_var_list(SrcVars), ws, ")", ws,
+    ")", ws,
+    "as", identifier_boundary, ws, identifier(LoopVar), ws,
+    gen_over_body(Body), ws,
+    "as", identifier_boundary, ws, identifier(Name), ws,
+    pass_clauses(Rest).
 % A `gen { BODY } as name` generator block (PLAWK_GENERATOR_BLOCKS.md): a
 % producer whose `emit E` statements define a relation `name/1`, callable from
 % a Prolog goal (e.g. a query pass's `over query(name(X))`). The producer dual
-% of the query reader. Parses to gen_block(name(Name), Body); the runtime
-% (materialise-then-iterate, mirroring the reader) lands in a later PR, so PR 1
-% is the surface + a clean not-yet compile error. The `gen` keyword is
-% unambiguous (distinct from `pass`); tried before the plain `pass` clause. The
-% optional input iterator (`gen over SOURCE as v { ... }`) is a follow-on.
-pass_clauses([gen_block(name(Name), Body) | Rest]) -->
+% of the query reader. Parses to gen_block(name(Name), none, Body) (`none` =
+% no input source, distinguishing it from the `gen over ...` input iterator).
+% A pure block of constant emits compiles to facts; the `gen` keyword is
+% unambiguous (distinct from `pass`); tried after the `gen over` form and
+% before the plain `pass` clause.
+pass_clauses([gen_block(name(Name), none, Body) | Rest]) -->
     "gen", identifier_boundary, ws,
     action_block(Body), ws,
     "as", identifier_boundary, ws,
     identifier(Name), ws,
     pass_clauses(Rest).
+
+% The body of an input-iterator generator: an `emit E` (transform each source
+% solution), optionally gated by an `if (COND)` reader guard (filter). Mirrors
+% for_in_body's if-print shape, but emit-based -- the guard uses the same
+% guard_expr (so `if (v > 3)` compares the bound var `v` via forin_key_cmp).
+gen_over_body([if(Guard, [emit(Emit)], [])]) -->
+    "{", ws, "if", ws, "(", ws, guard_expr(Guard), ws, ")", ws,
+    emit_action(emit(Emit)), ws, "}",
+    !.
+gen_over_body([emit(Emit)]) -->
+    "{", ws, emit_action(emit(Emit)), ws, "}".
 % A `pass { ACTIONS }` block is one pass carrying a single always-rule with
 % those actions (per-pattern rules within a pass are a later extension).
 pass_clauses([pass([rule(always, Actions)]) | Rest]) -->
@@ -323,7 +352,7 @@ plawk_pass_dynentry_rewrite(_DynEntries, pass_rows_anon(T, Body), pass_rows_anon
 plawk_pass_dynentry_rewrite(_DynEntries, pass_query(Q, Body), pass_query(Q, Body)).
 % A `gen { ... } as name` generator block -- pass it through (its body is
 % lowered by the generator runtime in a later PR).
-plawk_pass_dynentry_rewrite(_DynEntries, gen_block(N, Body), gen_block(N, Body)).
+plawk_pass_dynentry_rewrite(_DynEntries, gen_block(N, S, Body), gen_block(N, S, Body)).
 
 %% dynentry_decls(-Names)//
 %

--- a/tests/test_plawk_gen_blocks.pl
+++ b/tests/test_plawk_gen_blocks.pl
@@ -17,14 +17,15 @@
 
 :- begin_tests(plawk_gen_blocks).
 
-% `gen { emit N ... } as name` parses to gen_block(name(Name), Body); each
-% `emit E` is an emit(Expr) action. Integer literals fall back to int(N).
+% `gen { emit N ... } as name` parses to gen_block(name(Name), none, Body) --
+% a pure generator (no input source); each `emit E` is an emit(Expr) action.
+% Integer literals fall back to int(N).
 test(gen_block_int_literals_parses) :-
     plawk_parse_string(
         "gen { emit 1; emit 2; emit 3 } as small\n\c
          pass over query(small(X)) { print $1 }\n",
         program_passes([],
-            [gen_block(name(small),
+            [gen_block(name(small), none,
                  [emit(int(1)), emit(int(2)), emit(int(3))]),
              pass_query(query(small, ['X']), [print([field(1)])])],
             [])),
@@ -36,10 +37,23 @@ test(gen_block_field_and_string_emit_parses) :-
     plawk_parse_string(
         "gen { emit $1; emit \"red\" } as g\n",
         program_passes([],
-            [gen_block(name(g), Body)],
+            [gen_block(name(g), none, Body)],
             [])),
     Body = [emit(field(1)), emit(StrEmit)],
     StrEmit = string(_),
+    !.
+
+% An input-iterator generator parses to gen_block(name(Name), over(query(Src,
+% Vars), LoopVar), Body); the body is emit-based, guard optional.
+test(gen_over_query_parses) :-
+    plawk_parse_string(
+        "gen over query(num(V)) as v { if (v > 2) emit v } as big\n\c
+         pass over query(big(X)) { print $1 }\n",
+        program_passes([],
+            [gen_block(name(big), over(query(num, ['V']), v),
+                 [if(forin_key_cmp(v, gt, 2), [emit(var(v))], [])]),
+             pass_query(query(big, ['X']), [print([field(1)])])],
+            [])),
     !.
 
 % The `gen` keyword is distinct from `pass`: an ordinary pass is untouched.
@@ -84,12 +98,60 @@ test(gen_block_guarded_consume_run, [condition(clang_available)]) :-
     assertion(Out == "20\n30\n"),
     !.
 
-% A computed emit (a field, not a constant) needs runtime collection -- not yet
-% implemented -- so it is a clean not-yet compile error (exit 2).
+% An input-iterator generator PASSES THROUGH a source relation: `gen over
+% query(num(V)) as v { emit v } as allv` -> `allv(A) :- num(A)`, so the query
+% enumerates the whole source.
+test(gen_over_passthrough_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "@prolog\nnum(1).\nnum(2).\nnum(3).\n@end\n\c
+           gen over query(num(V)) as v { emit v } as allv\n\c
+           pass over query(allv(X)) { print $1 }\n",
+    build_run(Dir, 'genpass', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "1\n2\n3\n"),
+    !.
+
+% An input-iterator generator FILTERS a source: `if (v > 2) emit v` ->
+% `big(A) :- num(A), A > 2`, so the query enumerates only the matching source
+% solutions.
+test(gen_over_filter_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "@prolog\nnum(1).\nnum(2).\nnum(3).\nnum(4).\n@end\n\c
+           gen over query(num(V)) as v { if (v > 2) emit v } as big\n\c
+           pass over query(big(X)) { print $1 }\n",
+    build_run(Dir, 'genfilt', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n4\n"),
+    !.
+
+% `&&` in the filter guard is a conjunction of comparisons over the bound var.
+test(gen_over_filter_and_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "@prolog\nnum(1).\nnum(2).\nnum(3).\nnum(4).\nnum(5).\n@end\n\c
+           gen over query(num(V)) as v { if (v > 1 && v < 5) emit v } as mid\n\c
+           pass over query(mid(X)) { print $1 }\n",
+    build_run(Dir, 'genand', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "2\n3\n4\n"),
+    !.
+
+% A computed emit (a field, not a constant) in a PURE generator needs runtime
+% collection -- not yet implemented -- so it is a clean not-yet compile error.
 test(gen_block_computed_emit_not_yet) :-
     gdir(Dir),
     Src = "gen { emit $1 } as g\npass over query(g(X)) { print $1 }\n",
     build_status(Dir, 'gencomp', Src, St),
+    assertion(St == 2),
+    !.
+
+% An input iterator that TRANSFORMS (emits an expression over v, not v itself)
+% needs runtime collection -- a clean not-yet error for now.
+test(gen_over_transform_not_yet) :-
+    gdir(Dir),
+    Src = "@prolog\nnum(1).\n@end\n\c
+           gen over query(num(V)) as v { emit v * 2 } as dbl\n\c
+           pass over query(dbl(X)) { print $1 }\n",
+    build_status(Dir, 'gentrans', Src, St),
     assertion(St == 2),
     !.
 


### PR DESCRIPTION
The **optional input iterator**: `gen over query(SRC(V)) as v { … } as name` transforms another relation, compiling to a **derived Prolog rule** — again pure clause synthesis, consumed by the query reader unchanged (no new runtime):

```
@prolog
num(1). num(2). num(3). num(4).
@end
gen over query(num(V)) as v { if (v > 2) emit v } as big
pass over query(big(X)) { print $1 }        # → 3 / 4
```
→ synthesises `big(A) :- num(A), A > 2`.

## What it compiles to
- **Passthrough** — `gen over query(num(V)) as v { emit v } as allv` → `allv(A) :- num(A)` (a relation alias).
- **Filter** — `if (v CMP int)` → `name(A) :- src(A), A CMP int`; `&&` is a conjunction. The reader guard (`forin_key_cmp` over the bound var) translates to a Prolog arithmetic comparison (`>`,`<`,`>=`,`=<`,`=:=`,`=\=`) over a shared fresh head variable.

## Parser / bin
- New `pass_clauses` clause for `gen over query(...) as v` (tried before the pure `gen { }` form; `over` distinguishes them), with a dedicated emit-based body grammar (`emit v`, `if (GUARD) emit v`).
- AST unified to `gen_block(name(Name), Source, Body)` — `Source` = `none` (pure) or `over(query(Src, Vars), LoopVar)`; PR1/PR2 code + tests updated.
- `resolve_generator_blocks` synthesises the rule. A **transforming** emit (`emit v * 2` — an expression over `v`, not the bound var) or a non-query source is a clean not-yet error (needs runtime collection).

## Tests
`tests/test_plawk_gen_blocks.pl` (13): parse; passthrough, `>` filter, `&&` filter end-to-end; transform / computed-emit not-yet errors. Regressions green: `test_plawk_query_reader`, `test_plawk_multipass`.

## Docs
`PLAWK_GENERATOR_BLOCKS.md` PR 3 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_