### PR TITLE
WAM/LLVM plawk: constant print fields (`print 1`, `print "hi"`)

### DIFF
--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -12958,6 +12958,22 @@ plawk_print_expr_output_ir(f64(FmtPrefix, PrintPrefix, ValueIR), Index, [FmtPtr,
         '  %~w = call i32 (i8*, ...) @printf(i8* %~w, double ~w)',
         [PrintVar, FmtVar, ValueIR]).
 
+% A string-literal print field: the setup already built a pointer to the
+% interned C string (%..._ptr); print it with "%s". This is what lets a
+% constant field appear in a print (`print "hi"`, `print $1, "x"`, and -- via
+% the print grammar's bare-integer-to-string lowering -- `print 1`). The
+% "%s" format global (@.plawk_surface_print_string) is in the driver's runtime
+% globals.
+plawk_print_expr_output_ir(string(Base, PtrIR), Index, [FmtPtr, PrintCall]) :-
+    format(atom(FmtVar), '~w_fmt_~w', [Base, Index]),
+    format(atom(PrintVar), 'printed_~w_~w', [Base, Index]),
+    format(atom(FmtPtr),
+        '  %~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_string, i32 0, i32 0',
+        [FmtVar]),
+    format(atom(PrintCall),
+        '  %~w = call i32 (i8*, ...) @printf(i8* %~w, i8* ~w)',
+        [PrintVar, FmtVar, PtrIR]).
+
 plawk_print_expr_output_ir(case_slice(Mode, PrintBase, LenIR, PtrIR), _Index, [PrintCall]) :-
     llvm_emit_ascii_case_slice_print(Mode, PtrIR, LenIR, PrintBase, PrintCall).
 

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1923,7 +1923,7 @@ printf_args_rest([]) -->
     [].
 
 print_fields([Field | Fields]) -->
-    field_expr(Field),
+    print_field_expr(Field),
     print_fields_rest(Fields).
 
 print_fields_rest([Field | Fields]) -->
@@ -1931,10 +1931,26 @@ print_fields_rest([Field | Fields]) -->
     ",",
     ws,
     !,
-    field_expr(Field),
+    print_field_expr(Field),
     print_fields_rest(Fields).
 print_fields_rest([]) -->
     [].
+
+% A print field: the general field expression, or a bare numeric literal
+% (`print 1`, `print -5`). awk prints a number as its text, and a string
+% literal print field is now compilable, so a bare integer literal lowers to
+% the string of its digits (`print 1` == `print "1"`) -- correct output with no
+% codegen change. This is PRINT-specific: `field_expr` (shared with `emit`,
+% arithmetic, ...) is left untouched, so a bare integer keeps its numeric
+% meaning there (`emit 1` stays the integer 1, not the atom '1'). field_expr is
+% tried first, so arithmetic (`print 1 + 2`) and floats are unaffected; only a
+% lone integer falls through to the literal clause.
+print_field_expr(Field) -->
+    field_expr(Field),
+    !.
+print_field_expr(string(Text)) -->
+    signed_integer_value(N),
+    { format(string(Text), '~w', [N]) }.
 
 field_expr(Expr) -->
     i64_binary_surface_expr(Expr).

--- a/tests/test_plawk_print_literals.pl
+++ b/tests/test_plawk_print_literals.pl
@@ -1,0 +1,98 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Constant print fields in the single-pass driver. awk prints a number as its
+% text, and `print "literal"` is standard; both were rejected before. Two
+% pieces close the gap: a print-specific grammar lowers a bare integer literal
+% to the string of its digits (`print 1` == `print "1"` -- print-only, so
+% `emit`/arithmetic keep a bare integer numeric), and a string-literal print
+% field now emits (a missing plawk_print_expr_output_ir clause). field_expr is
+% tried first, so `print 1 + 2` stays arithmetic.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_print_literals).
+
+% A bare integer print field parses to a string of its digits (print-specific).
+test(bare_integer_parses) :-
+    plawk_parse_string("{ print 1 }\n",
+        program([], [rule(always, [print([string("1")])])], [])),
+    !.
+
+% A bare integer print field does NOT change field_expr elsewhere: an emit of a
+% bare integer stays the integer (int(1)), not a string.
+test(emit_bare_integer_stays_int) :-
+    plawk_parse_string("gen { emit 1 } as g\n",
+        program_passes([], [gen_block(name(g), none, [emit(int(1))])], [])),
+    !.
+
+% Arithmetic is unaffected (field_expr tried before the literal fallback).
+test(print_arithmetic_unchanged) :-
+    plawk_parse_string("{ print 1 + 2 }\n",
+        program([], [rule(always, [print([add_i64(int(1), int(2))])])], [])),
+    !.
+
+% `print 1` compiles and prints the constant once per record.
+test(print_integer_literal_runs, [condition(clang_available)]) :-
+    run_prog("{ print 1 }\n", "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1\n1\n"),
+    !.
+
+% `print "hi"` -- a string literal print field -- compiles and prints.
+test(print_string_literal_runs, [condition(clang_available)]) :-
+    run_prog("{ print \"hi\" }\n", "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "hi\n"),
+    !.
+
+% Literals mixed with fields, separated by the output separator.
+test(print_mixed_literal_and_field_runs, [condition(clang_available)]) :-
+    run_prog("{ print 1, $1, 42 }\n", "a\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1 a 42\n"),
+    !.
+
+% Arithmetic over literals still computes (not printed verbatim).
+test(print_arithmetic_runs, [condition(clang_available)]) :-
+    run_prog("{ print 1 + 2 }\n", "a\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
+    !.
+
+:- end_tests(plawk_print_literals).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+pdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_print_literals', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+% Build a program, run it over Input, capture stdout + exit status.
+run_prog(Src, Input, Out, RunStatus) :-
+    pdir(Dir),
+    directory_file_path(Dir, 'p.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    directory_file_path(Dir, 'in.txt', InPath),
+    setup_call_cleanup(open(InPath, write, IS, [encoding(utf8)]),
+        write(IS, Input), close(IS)),
+    directory_file_path(Dir, 'p_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [InPath],
+        [stdout(pipe(RS)), stderr(std), process(RPid)]),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
Closes the print-literal gap you flagged. awk prints a number as its text and `print "literal"` is standard, but the single-pass driver rejected both ("outside the compilable surface"). Turned out to be **two small, localized fixes** — not the sprawling change I feared once I traced the actual failure:

```
{ print 1 }            → 1
{ print "hi" }         → hi
{ print 1, $1, 42 }    → 1 a 42
{ print 1 + 2 }        → 3        (arithmetic unaffected)
```

## Root cause + fixes
- **Codegen (the real bug):** `plawk_print_expr_output_ir` had clauses for `i64` / `slice` / `f64` / `case_slice` but **none for a string field** — so a string-literal print field produced a `Type` nothing could emit and the whole driver bailed. Added the `string(Base, PtrIR)` clause (print the interned C string with `"%s"`; the format global was already in the driver's runtime globals). This alone makes `print "hi"`, `print $1, "x"` compile.
- **Parser:** a print-specific `print_field_expr` lowers a bare integer literal to the string of its digits (`print 1` ≡ `print "1"`) — correct output, no further codegen. **Print-only**: the shared `field_expr` (used by `emit`, arithmetic, …) is untouched, so a bare integer keeps its numeric meaning there — `emit 1` still yields the integer `1`, not the atom `'1'` (verified: `gen_blocks` suite green). `field_expr` is tried first, so `print 1 + 2` stays arithmetic.

## Why it was worth doing now
It's a foundational papercut affecting every plawk program, and it lives in the core print path — better fixed while that path is freshly mapped than after more shapes pile on. It doesn't touch the query/generator surfaces.

## Tests
`tests/test_plawk_print_literals.pl` (7): parse (bare int → string, `emit` int unchanged, arithmetic unchanged) and run (`print 1`, `print "hi"`, mixed literal+field, arithmetic). Regressions green: `test_plawk_cli`, `test_plawk_functions`, `test_plawk_prolog_blocks`, `test_plawk_multipass`, `test_plawk_gen_blocks`, `test_plawk_rows_reader`.

## Scope note
This covers the **single-pass rule-body** print path (`{ … }`, patterns). `BEGIN`/`END` blocks use a separate restricted print grammar and are unaffected here — a follow-on if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_