### PR TITLE
WAM/LLVM plawk: generator blocks PR 4 — tuple emits (item 3)

### DIFF
--- a/docs/design/PLAWK_GENERATOR_BLOCKS.md
+++ b/docs/design/PLAWK_GENERATOR_BLOCKS.md
@@ -255,5 +255,21 @@ the producer direction plus the `emit` collection. A rough PR shape:
    passthrough, `>` filter, `&&` filter, and the transform / computed-emit
    not-yet errors. The AST unified to `gen_block(name(Name), Source, Body)`
    with `Source` = `none` (pure) or `over(query(Src, Vars), LoopVar)`.
-4. **Tuples + durability** — `emit (A, B)` → `name/2`; optional cache/LMDB-backed
-   collected set.
+4. **Tuples — LANDED (constant tuples).** `emit (A, B, …)` parses to
+   `emit(tuple([…]))` and a pure block of constant tuples compiles to arity-n
+   facts (`gen { emit (1, 10); emit (2, 20) } as edge` → `edge(1, 10).
+   edge(2, 20).`), consumed by a multi-column query
+   (`pass over query(edge(X, Y)) { print $1, $2 }`). Elements may mix integer
+   and string literals. A *computed* tuple element, and a durable (cache/LMDB-
+   backed) collected set, remain follow-ons — they need the runtime collection
+   below. `tests/test_plawk_gen_blocks.pl`: an int tuple and a mixed
+   string+int tuple.
+
+### Still open — runtime collection
+
+The remaining generator shapes — a pure block with a *computed* emit, a
+transforming input iterator (`emit v * 2`), a table/non-query source, and
+durability — all need the block to *run and collect* at build/run time rather
+than synthesise clauses. The proven path is `assertz` into the dynamic DB +
+`findall` (the `tests/test_plawk_eval_compile.pl` stateful-grammar pattern),
+driven from the emit sites. That is the next generator PR.

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -366,13 +366,22 @@ check_generator_blocks(_File, _Program).
 
 % A generator block whose clauses can be synthesised at build time:
 %  - a pure block (`Source == none`) whose every action is a constant `emit`
-%    (integer or string literal) -> facts;
+%    (an integer/string literal -> a unary fact, or a tuple of literals -> an
+%    arity-n fact);
 %  - an input iterator over a query source whose body passes the bound var
 %    through (`emit v`), optionally gated by an integer reader guard over `v`
 %    -> a derived rule.
 gen_block_supported(none, Body) :-
-    forall(member(Action, Body),
-        ( Action = emit(int(_)) ; Action = emit(string(_)) )).
+    forall(member(Action, Body), gen_const_emit(Action)).
+gen_block_supported(over(query(_Src, [_SrcVar]), LoopVar), Body) :-
+    gen_over_body_ok(Body, LoopVar).
+
+% A constant emit: a bare integer/string literal, or a tuple whose elements are
+% all integer/string literals.
+gen_const_emit(emit(int(_))).
+gen_const_emit(emit(string(_))).
+gen_const_emit(emit(tuple(Values))) :-
+    forall(member(V, Values), ( V = int(_) ; V = string(_) )).
 gen_block_supported(over(query(_Src, [_SrcVar]), LoopVar), Body) :-
     gen_over_body_ok(Body, LoopVar).
 
@@ -446,13 +455,22 @@ gen_cmp_op(le, =<).
 gen_cmp_op(eq, =:=).
 gen_cmp_op(ne, =\=).
 
-% A constant emit -> a unary fact for the generated relation. An integer emits
-% itself; a string emits the corresponding atom (so `emit "red"` -> `g(red)`).
+% A constant emit -> a fact for the generated relation. A bare integer/string
+% emits a unary fact (an integer itself; a string as the corresponding atom, so
+% `emit "red"` -> `g(red)`); a tuple emits an arity-n fact, one column per
+% element (`emit (1, "a")` -> `g(1, a)`).
 gen_emit_fact(Name, int(N), Fact) :-
     Fact =.. [Name, N].
 gen_emit_fact(Name, string(S), Fact) :-
     atom_string(Atom, S),
     Fact =.. [Name, Atom].
+gen_emit_fact(Name, tuple(Values), Fact) :-
+    maplist(gen_emit_value_arg, Values, Args),
+    Fact =.. [Name | Args].
+
+gen_emit_value_arg(int(N), N).
+gen_emit_value_arg(string(S), Atom) :-
+    atom_string(Atom, S).
 
 % The findall-wrapper clauses to inject into a query program's @prolog
 % predicate set: one `__plawk_query_pred_C(L) :- findall(VC, pred(V1..Vn), L)`

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1842,9 +1842,18 @@ print_action(print(Fields)) -->
 % contributes the value of E to the generated relation's solution set. Parses
 % to emit(Expr) reusing the print field-expression grammar (a field, number,
 % string, or arithmetic expression). Explicit emission keeps the value typed
-% (design doc section 2.1); a tuple emit (`emit (A, B)` -> arity 2) is a
-% follow-on. `emit` is only meaningful inside a `gen { ... }` block; the
-% codegen (bin/plawk) rejects it elsewhere until the runtime lands.
+% (design doc section 2.1). `emit` is only meaningful inside a `gen { ... }`
+% block; the codegen (bin/plawk) rejects it elsewhere.
+%
+% A TUPLE emit (`emit (A, B, ...)` -> a row of the generated relation, arity n)
+% parses to emit(tuple([V1, ..., Vn])). Tried first -- the `(` after `emit`
+% distinguishes it. Tuple elements are constants (integer or string literals);
+% a computed tuple element is a runtime-collection follow-on.
+emit_action(emit(tuple([V0, V1 | Vs]))) -->
+    "emit", required_ws, "(", ws,
+    emit_tuple_value(V0), ws, ",", ws, emit_tuple_value(V1),
+    emit_tuple_rest(Vs), ws, ")",
+    !.
 emit_action(emit(Expr)) -->
     "emit",
     required_ws,
@@ -1856,6 +1865,21 @@ emit_action(emit(int(N))) -->
     "emit",
     required_ws,
     signed_integer_value(N).
+
+% The remaining elements of a tuple emit, comma-separated.
+emit_tuple_rest([V | Vs]) -->
+    ws, ",", ws, emit_tuple_value(V),
+    !,
+    emit_tuple_rest(Vs).
+emit_tuple_rest([]) -->
+    [].
+% A tuple element: an integer or string literal (constants only for now).
+emit_tuple_value(int(N)) -->
+    signed_integer_value(N),
+    !.
+emit_tuple_value(string(S)) -->
+    quoted_string(Codes),
+    { string_codes(S, Codes) }.
 
 printf_action(printf(string(Format), Args)) -->
     "printf",

--- a/tests/test_plawk_gen_blocks.pl
+++ b/tests/test_plawk_gen_blocks.pl
@@ -88,6 +88,27 @@ test(gen_block_string_run, [condition(clang_available)]) :-
     assertion(Out == "red\ngreen\nblue\n"),
     !.
 
+% A tuple emit produces an arity-n fact per row: `emit (1, 10)` -> `edge(1,10)`,
+% consumed by a two-column query.
+test(gen_block_tuple_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "gen { emit (1, 10); emit (2, 20); emit (3, 30) } as edge\n\c
+           pass over query(edge(X, Y)) { print $1, $2 }\n",
+    build_run(Dir, 'gentup', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "1 10\n2 20\n3 30\n"),
+    !.
+
+% A tuple may mix string and integer columns (`emit ("a", 1)` -> `kv(a, 1)`).
+test(gen_block_tuple_mixed_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "gen { emit (\"a\", 1); emit (\"b\", 2) } as kv\n\c
+           pass over query(kv(K, V)) { print $1, $2 }\n",
+    build_run(Dir, 'gentupmix', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "a 1\nb 2\n"),
+    !.
+
 % A reader guard on the consuming query pass composes with a generator source.
 test(gen_block_guarded_consume_run, [condition(clang_available)]) :-
     gdir(Dir),


### PR DESCRIPTION
**Item 3 of the batch.** Stacked on the BEGIN/END PR.

`emit (A, B, …)` emits a row of the generated relation; a pure block of constant tuples compiles to arity-n facts, consumed by a multi-column query:
```
gen { emit (1, 10); emit (2, 20); emit (3, 30) } as edge
pass over query(edge(X, Y)) { print $1, $2 }        # → 1 10 / 2 20 / 3 30
```

- Parser: `emit_action` gains a tuple form `emit (V0, V1, …)` → `emit(tuple([…]))` (tried first; the `(` distinguishes it). Elements are integer/string literals.
- bin: `gen_const_emit` accepts tuple-of-constants; `gen_emit_fact` maps a tuple to an arity-n fact (`emit (1, "a")` → `g(1, a)`), mixing int/string columns.

Computed tuple elements + durability remain runtime-collection follow-ons (noted in the design doc's new "still open: runtime collection" section). `tests/test_plawk_gen_blocks.pl` (15): int tuple + mixed string+int tuple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_