### PR TITLE
plawk: while loops PR 1 — surface + AST + not-yet error (item 4)

### DIFF
--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -108,6 +108,7 @@ build(File, Out0, KeepLL) :-
     % removed; `GenFactClauses` are the synthesised facts.
     check_generator_blocks(File, Program2),
     resolve_generator_blocks(Program2, Program, GenFactClauses),
+    check_while_loops(File, Program),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
     % A query-reader program contributes synthesised findall-wrapper clauses
@@ -363,6 +364,30 @@ check_generator_blocks(File, Program) :-
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
+
+% while loops (plawk roadmap): `while (VAR CMP int) { BODY }` parses but its
+% loop runtime -- mutable scalar state iterated to a fixed point -- is not wired
+% yet, so a program that uses one gets a clear, specific diagnostic rather than
+% the generic "outside the multi-pass surface". Surface-first, mirroring the
+% query reader / generator arcs.
+check_while_loops(File, Program) :-
+    program_has_while(Program),
+    !,
+    format(user_error,
+        'plawk: ~w uses a `while` loop. while loops parse but their runtime is \c
+         not yet implemented; see the plawk roadmap.~n',
+        [File]),
+    halt(2).
+check_while_loops(_File, _Program).
+
+% True if the program term contains a while_loop/2 anywhere (rule body, BEGIN,
+% END, pass, ...). A plain structural walk over the AST.
+program_has_while(while_loop(_, _)) :- !.
+program_has_while(Term) :-
+    compound(Term),
+    Term =.. [_ | Args],
+    member(Arg, Args),
+    program_has_while(Arg).
 
 % A generator block whose clauses can be synthesised at build time:
 %  - a pure block (`Source == none`) whose every action is a constant `emit`

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1422,6 +1422,9 @@ action_sep_scan(yes) -->
     [].
 
 action(Action) -->
+    while_action(Action),
+    !.
+action(Action) -->
     if_action(Action),
     !.
 action(Action) -->
@@ -1480,6 +1483,20 @@ action(Action) -->
 %  awk conditionals: `else` is optional (an absent else parses as an
 %  empty branch), and `else if` chains nest as a single-element else
 %  branch containing the next if.
+% A `while (VAR CMP int) { BODY }` loop -- iterate the body while a scalar
+% variable compares to an integer bound (the awk `while` control structure).
+% Parses to while_loop(cmp(var(V), Op, int(N)), Body). This is the SURFACE
+% (mirrors the query reader / generator surface-first PRs): the loop body reuses
+% the general action block, and the codegen (bin/plawk) rejects it with a clean
+% not-yet diagnostic until the loop runtime lands. The condition is a scalar
+% comparison for now; a general boolean condition is a follow-on.
+while_action(while_loop(cmp(var(V), Op, int(N)), Body)) -->
+    "while", identifier_boundary, ws,
+    "(", ws,
+    identifier(V), ws, numeric_cmp_op(Op), ws, signed_integer_value(N), ws,
+    ")", ws,
+    action_block(Body).
+
 if_action(if(Pattern, ThenActions, ElseActions)) -->
     "if",
     ws,

--- a/tests/test_plawk_while.pl
+++ b/tests/test_plawk_while.pl
@@ -1,0 +1,82 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `while` loops, PR 1: the SURFACE. `while (VAR CMP int) { BODY }` parses
+% to while_loop(cmp(var(V), Op, int(N)), Body) -- the awk while control
+% structure. The loop runtime (mutable scalar state iterated to a fixed point)
+% is not wired yet, so building a program that uses one is a clean, specific
+% compile error rather than the generic "outside the multi-pass surface".
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_while).
+
+% `while (i < 3) { ... }` parses to while_loop(cmp(var(i), lt, int(3)), Body);
+% the body is a general action block.
+test(while_parses) :-
+    plawk_parse_string(
+        "{ i = 0; while (i < 3) { print i; i++ } }\n",
+        program([],
+            [rule(always,
+                 [set(var(i), int(0)),
+                  while_loop(cmp(var(i), lt, int(3)),
+                      [print([var(i)]), inc(var(i))])])],
+            [])),
+    !.
+
+% The comparison operators all parse.
+test(while_operators_parse) :-
+    forall(member(Op-Sym,
+               [lt-"<", le-"<=", gt-">", ge-">=", eq-"==", ne-"!="]),
+        ( format(string(Src), "{ while (n ~w 5) { n++ } }\n", [Sym]),
+          plawk_parse_string(Src,
+              program([],
+                  [rule(always,
+                       [while_loop(cmp(var(n), Op, int(5)), [inc(var(n))])])],
+                  [])) )),
+    !.
+
+% Building a program with a while loop is a clean compile error (exit 2) until
+% the loop runtime lands.
+test(while_is_not_yet_error) :-
+    wdir(Dir),
+    Src = "{ i = 0; while (i < 3) { print i; i++ } }\n",
+    build_status(Dir, 'w', Src, St),
+    assertion(St == 2),
+    !.
+
+% A program with no while loop is unaffected (no false trigger).
+test(non_while_program_builds, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ print $1 }\n",
+    build_status(Dir, 'ok', Src, St),
+    assertion(St == 0),
+    !.
+
+:- end_tests(plawk_while).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+wdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_while', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_status(Dir, Name, Src, Status) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).


### PR DESCRIPTION
**Item 4 of the batch.** Stacked on the generator PR4.

`while (VAR CMP int) { BODY }` — the awk `while` control structure — parses to `while_loop(cmp(var(V), Op, int(N)), Body)`. **Surface-first**, mirroring the query-reader and generator arcs: the loop runtime (mutable scalar state iterated to a fixed point) is genuine new control-flow codegen in the shape-matched driver, so it's a well-scoped follow-on rather than a rushed bolt-on.

```
{ i = 0; while (i < 3) { print i; i++ } }
```
→ parses to `while_loop(cmp(var(i), lt, int(3)), [print([var(i)]), inc(var(i))])`; building gives a clean **not-yet** compile error (exit 2, naming `while`), not the generic "outside the multi-pass surface".

- Parser: `while_action` in the action dispatch (before `if`); condition is a scalar comparison (all six operators), body a general action block.
- bin: `check_while_loops` walks the program AST (`program_has_while/1`) and emits the specific diagnostic.

`tests/test_plawk_while.pl` (4): parse (counted loop, all operators), not-yet error, non-while program unaffected. Regression green: `test_plawk_cli`. The runtime is the #1 prioritised gap in the roadmap audit (next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_