### PR TITLE
plawk: do-while surface + control-flow runtime plan + AWK-gap findings

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -34,12 +34,15 @@ only (runtime pending) · ❌ missing.
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
-| `while (VAR CMP int)` | ⏳ | **surface parses; runtime pending** (this arc) |
+| `while (VAR CMP int)` | ⏳ | surface parses; runtime pending — `PLAWK_CONTROL_FLOW_PLAN.md` |
+| `do { } while (VAR CMP int)` | ⏳ | surface parses; shares the loop runtime |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` / `continue` | ◐ | present in some loop contexts |
+| `if` with a plain (non-accumulator) body | ❌ | `{ if (c) { print $1 } }` is exit 3 — the scalar `if` lowering assumes branch bodies update scalars; blocks regex-in-`if` too |
+| regex in `if` (`if ($0 ~ /re/)`) | ◐ | condition parses (`~` ok); blocked by the guarded-print body above, not the regex |
+| brace-less `if`/loop body | ❌ | `if (c) print` (no braces) doesn't parse |
 | field assignment (`$2 = expr`) | ❌ | rebuilding `$0` from mutated fields not wired |
 | C-style `for (;;)` | ❌ | |
-| `do { } while` | ❌ | |
 | `exit [n]` | ❌ | |
 | `delete arr[k]` | ❌ | |
 | `getline` | ❌ | the multi-pass / `over` readers cover much of its use |
@@ -85,12 +88,20 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
 
 ## Prioritised gaps (recommended order)
 
-1. **`while` loop runtime** — the surface just landed; wire the loop (mutable
-   scalar state to a fixed point). The most-requested basic control structure
-   still missing at runtime.
-2. **User-function call in text/print context** — `print f($1)` should coerce
-   the text field like the accumulator path already does; small, high-value fix
-   that makes the *existing* function feature usable in the obvious spot.
+1. **`while` / `do-while` loop runtime** — the surfaces just landed; wire the
+   loop (mutable scalar state to a fixed point). **Plan:**
+   `PLAWK_CONTROL_FLOW_PLAN.md` — bracket each loop with a memory slot (SSA →
+   mem → loop → SSA) so the existing forward-phi scalar machinery is untouched.
+   The most-requested basic control structure still missing at runtime.
+2. **User-function call in text/print context** — `print f($1)` returns `0`: a
+   text field is passed to the foreign call as an *atom*, so the synthesised
+   `f(X,R) :- R is X*2` fails `is`. Works in `BINFMT`/typed mode. A **type-model
+   decision** (auto-coerce a numerically-used field arg to i64, or an explicit
+   `num($1)` at the call site — `int(...)` is not accepted as a call arg today);
+   wants a small design call before coding. See `PLAWK_CONTROL_FLOW_PLAN.md` §4.
+2b. **`if` with a plain guarded body** — `{ if (c) { print $1 } }` doesn't
+   compile (the scalar `if` lowering assumes branch bodies update scalars); this
+   is what actually blocks regex-in-`if`. Fix the `if`-body lowering.
 3. **`printf` format coverage** — add `%f`/`%g` (f64 exists), `%c`, `%x`, and
    width/precision; the current subset is thin for real formatting.
 4. **`exit [n]`** — common and cheap; a flagged early-terminate of the record

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -1,0 +1,98 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2026 John William Creighton (@s243a)
+-->
+
+# plawk control-flow runtime — implementation plan
+
+**Status**: plan. The `while` and `do-while` **surfaces** parse (they lower to
+`while_loop(Cond, Body)` / `do_while_loop(Body, Cond)` and today emit a clean
+not-yet error); this doc scopes the **runtime**, grounded in how the single-pass
+driver actually lowers scalar state. Prioritised #1 in
+`PLAWK_AWK_FEATURE_AUDIT.md`.
+
+## 1. The blocking fact: scalar state is SSA/phi, not memory
+
+plawk's single-pass driver threads scalar variables (`s`, `i`, counters) as
+**SSA values joined by phi nodes**, not memory slots — there are no `alloca`s
+for user scalars. Each rule's body recomputes new SSA values for the scalars it
+touches (`plawk_scalar_match_update_ir`), and the per-rule/per-record boundaries
+phi them together (`plawk_scalar_rule_input_phi_ir`, the `if`-join phis in
+`plawk_scalar_if_join_pairs`). An `if` is already lowered this way: then/else
+branches produce candidate SSA values, and a join block phis them.
+
+A **loop** is the hard case for this model: a variable mutated in the loop body
+depends on its own value from the previous iteration, which SSA expresses with a
+**loop-header phi** (`%i = phi [%i_init, %preheader], [%i_next, %body]`). Nothing
+in the current scalar lowering emits loop-header phis — the `if` join is a
+*forward* phi (two disjoint predecessors), not a *back-edge* phi.
+
+## 2. Approach: bracket the loop with memory (SSA → mem → loop → SSA)
+
+Rather than retrofit loop-header phis through the whole phi-threaded scalar
+machinery (invasive, and every downstream phi site would need to learn about the
+back edge), **bracket each loop with a memory slot** for the scalars it mutates:
+
+```
+; preheader: the scalars are SSA values here (%i_in, %s_in, ...)
+  %i.slot = alloca i64
+  store i64 %i_in, i64* %i.slot        ; seed from the incoming SSA value
+  br label %while.head.N
+while.head.N:
+  %i.cur = load i64, i64* %i.slot
+  %cond  = icmp <op> i64 %i.cur, <bound>
+  br i1 %cond, label %while.body.N, label %while.after.N
+while.body.N:
+  ; body actions load/store the slot(s); print reads %i.cur; i++ stores i+1
+  br label %while.head.N
+while.after.N:
+  %i_out = load i64, i64* %i.slot      ; feed back into the SSA scalar chain
+```
+
+- **Self-contained.** The `alloca`/`load`/`store` bracket lives entirely inside
+  the loop action's IR. Outside the loop the scalar stays SSA; the loop consumes
+  the incoming SSA value (`store` at the preheader) and produces an outgoing SSA
+  value (`load` at `while.after`) that flows into the next phi exactly like an
+  `if` join's result. No change to the forward-phi machinery.
+- **`do-while`** is the same with the condition test *after* the first body
+  pass: `preheader → body → head(cond) → body|after`.
+- **Which scalars to bracket.** The set the body mutates (walk the body for
+  `set` / `inc` / `+=` targets) ∪ the condition variable. Read-only scalars stay
+  SSA and are read once into the preheader.
+
+## 3. PR sequence
+
+1. **Surface — LANDED.** `while (VAR CMP int) { BODY }` and
+   `do { BODY } while (VAR CMP int)` parse; not-yet compile error.
+2. **Runtime, arithmetic body.** Bracket-with-memory lowering for a body of
+   `set` / `inc` / `+=` over i64 scalars + `print`, condition `VAR CMP int`.
+   Deliverable: `{ i = 0; while (i < 3) { print i; i++ } }` prints `0/1/2`, and
+   the `do-while` mirror runs the body once even when the condition starts false.
+3. **General condition + `break`/`continue`.** A boolean/expression condition
+   (reuse the guard grammar) and loop-control statements.
+4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
+   nesting; the multi-pass driver's scalar handling.
+
+## 4. Related AWK gaps found while scoping (see the audit)
+
+These surfaced during the control-flow investigation and are tracked in
+`PLAWK_AWK_FEATURE_AUDIT.md`; noted here because they share the scalar/if
+lowering:
+
+- **`if` with a non-accumulator body doesn't compile.** `{ if (COND) { print
+  $1 } }` (a plain guarded print, no scalar update) is currently *outside the
+  compilable surface* (exit 3) — the scalar `if` lowering assumes the branch
+  bodies update scalar slots. This also blocks **regex/general conditions in
+  `if`** (`if ($0 ~ /re/) { … }`): the condition grammar accepts `~` (rule
+  patterns compile it), but the guarded-print body is the blocker, not the
+  regex. Fix belongs with the `if`-body lowering, not the loop runtime.
+- **Numeric user-function args in text mode.** `print f($1)` returns `0` because
+  a text field is passed to the foreign call as an *atom*, and the synthesised
+  `f(X,R) :- R is X*2` fails `is` on a non-number. In `BINFMT` (typed i64) mode
+  it works. This is a **type-model** decision: auto-coerce a field arg to i64
+  when the callee uses it numerically (needs body inference), or an explicit
+  `num($1)` / `int($1)` coercion at the call site (currently `int(...)` is not
+  accepted as a call arg). Prioritised #2 in the audit; wants a small design
+  call before coding.
+- **brace-less `if`/loop bodies.** `if (COND) print` (no `{ }`) doesn't parse;
+  plawk requires a braced block. Minor parser follow-on.

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -365,24 +365,26 @@ check_generator_blocks(File, Program) :-
     halt(2).
 check_generator_blocks(_File, _Program).
 
-% while loops (plawk roadmap): `while (VAR CMP int) { BODY }` parses but its
-% loop runtime -- mutable scalar state iterated to a fixed point -- is not wired
-% yet, so a program that uses one gets a clear, specific diagnostic rather than
-% the generic "outside the multi-pass surface". Surface-first, mirroring the
-% query reader / generator arcs.
+% while / do-while loops (plawk roadmap): `while (VAR CMP int) { BODY }` and
+% `do { BODY } while (VAR CMP int)` parse but their loop runtime -- mutable
+% scalar state iterated to a fixed point -- is not wired yet, so a program that
+% uses one gets a clear, specific diagnostic rather than the generic "outside
+% the multi-pass surface". Surface-first, mirroring the query reader / generator
+% arcs; see PLAWK_CONTROL_FLOW_PLAN.md for the runtime plan.
 check_while_loops(File, Program) :-
     program_has_while(Program),
     !,
     format(user_error,
-        'plawk: ~w uses a `while` loop. while loops parse but their runtime is \c
-         not yet implemented; see the plawk roadmap.~n',
+        'plawk: ~w uses a `while` / `do-while` loop. Loops parse but their \c
+         runtime is not yet implemented; see PLAWK_CONTROL_FLOW_PLAN.md.~n',
         [File]),
     halt(2).
 check_while_loops(_File, _Program).
 
-% True if the program term contains a while_loop/2 anywhere (rule body, BEGIN,
-% END, pass, ...). A plain structural walk over the AST.
+% True if the program term contains a while_loop/2 or do_while_loop/2 anywhere
+% (rule body, BEGIN, END, pass, ...). A plain structural walk over the AST.
 program_has_while(while_loop(_, _)) :- !.
+program_has_while(do_while_loop(_, _)) :- !.
 program_has_while(Term) :-
     compound(Term),
     Term =.. [_ | Args],

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1422,6 +1422,9 @@ action_sep_scan(yes) -->
     [].
 
 action(Action) -->
+    do_while_action(Action),
+    !.
+action(Action) -->
     while_action(Action),
     !.
 action(Action) -->
@@ -1496,6 +1499,19 @@ while_action(while_loop(cmp(var(V), Op, int(N)), Body)) -->
     identifier(V), ws, numeric_cmp_op(Op), ws, signed_integer_value(N), ws,
     ")", ws,
     action_block(Body).
+
+% A `do { BODY } while (VAR CMP int)` loop -- the body runs at least once, then
+% repeats while the condition holds (the awk do-while control structure). Parses
+% to do_while_loop(Body, cmp(var(V), Op, int(N))). Surface only, like `while`;
+% both share the same loop runtime (a later PR). Tried via its own action
+% clause; the leading `do` keyword distinguishes it.
+do_while_action(do_while_loop(Body, cmp(var(V), Op, int(N)))) -->
+    "do", identifier_boundary, ws,
+    action_block(Body), ws,
+    "while", identifier_boundary, ws,
+    "(", ws,
+    identifier(V), ws, numeric_cmp_op(Op), ws, signed_integer_value(N), ws,
+    ")".
 
 if_action(if(Pattern, ThenActions, ElseActions)) -->
     "if",

--- a/tests/test_plawk_while.pl
+++ b/tests/test_plawk_while.pl
@@ -40,12 +40,32 @@ test(while_operators_parse) :-
                   [])) )),
     !.
 
+% `do { BODY } while (VAR CMP int)` parses to do_while_loop(Body, cmp(...)).
+test(do_while_parses) :-
+    plawk_parse_string(
+        "{ i = 0; do { print i; i++ } while (i < 3) }\n",
+        program([],
+            [rule(always,
+                 [set(var(i), int(0)),
+                  do_while_loop([print([var(i)]), inc(var(i))],
+                      cmp(var(i), lt, int(3)))])],
+            [])),
+    !.
+
 % Building a program with a while loop is a clean compile error (exit 2) until
 % the loop runtime lands.
 test(while_is_not_yet_error) :-
     wdir(Dir),
     Src = "{ i = 0; while (i < 3) { print i; i++ } }\n",
     build_status(Dir, 'w', Src, St),
+    assertion(St == 2),
+    !.
+
+% A do-while loop is likewise a clean not-yet error (shares the loop runtime).
+test(do_while_is_not_yet_error) :-
+    wdir(Dir),
+    Src = "{ i = 0; do { print i; i++ } while (i < 3) }\n",
+    build_status(Dir, 'dw', Src, St),
     assertion(St == 2),
     !.
 


### PR DESCRIPTION
Continues the control-flow arc (stacked on the roadmap-audit PR). **Do-while surface + a rigorous runtime plan grounded in the actual codegen**, rather than a rushed runtime.

## What landed
- **`do { BODY } while (VAR CMP int)`** parses to `do_while_loop(Body, cmp(...))`, alongside `while` — both share the (pending) loop runtime and give the same clean not-yet error. `check_while_loops` now catches both.

## Why not the runtime this turn (honest scoping)
I investigated the while/do-while **runtime** thoroughly. The blocker is architectural, not effort: **plawk's scalar state is SSA/phi with no memory slots**, and a loop needs a *back-edge* phi that the current *forward*-phi `if`-join machinery doesn't emit. Rushing that into the core scalar codegen at the tail of a long session is exactly the kind of risky change I'd rather plan than fumble.

`PLAWK_CONTROL_FLOW_PLAN.md` proposes the clean approach — **bracket each loop with a memory slot** (SSA → mem → loop → SSA) so the phi machinery is untouched — with a 4-step PR sequence. That makes the runtime a well-scoped next PR.

## Gaps found while scoping (recorded in the audit + plan)
- **`if` with a plain non-accumulator body doesn't compile** (`{ if (c) { print $1 } }` → exit 3) — the scalar `if` lowering assumes branch bodies update scalars. **This is what actually blocks regex-in-`if`**, not the regex (the condition grammar accepts `~` fine).
- **`print f($1)` returns `0`** — a text field reaches the foreign call as an *atom*, so the synthesised `f(X,R) :- R is X*2` fails `is`. Works in `BINFMT`/typed mode. A **type-model decision** (auto-coerce vs explicit `num($1)`); `int(...)` isn't accepted as a call arg today.
- **brace-less `if`/loop body** — `if (c) print` (no braces) doesn't parse.

All three are cross-linked and re-prioritised in `PLAWK_AWK_FEATURE_AUDIT.md`.

## Tests
`tests/test_plawk_while.pl` (6): do-while parse + not-yet error, plus the while cases. Regression green: `test_plawk_cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_