### PR TITLE
 Add Rust WAM string_code/3 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -4606,6 +4606,27 @@ compile_execute_ext_builtin_to_rust(Code) :-
                 let a2_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
                 self.builtin_atom_concat_attempt(&a1_raw, &a2_raw, &chars, 0)
             }
+            "string_code/3" => {
+                let offset = match self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::Integer(n)) if n >= 1 => match usize::try_from(n - 1) {
+                        Ok(i) => i,
+                        Err(_) => return false,
+                    },
+                    _ => return false,
+                };
+                let text = match self.get_reg_raw("A2")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::Atom(s)) => s,
+                    _ => return false,
+                };
+                let code = match text.chars().nth(offset) {
+                    Some(ch) => Value::Integer(ch as i64),
+                    None => return false,
+                };
+                let a3 = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+                if self.unify(&a3, &code) { self.pc += 1; true } else { false }
+            }
             "char_code/2" => {
                 let v1 = self.get_reg_raw("A1").map(|v| self.deref_var(&v)).unwrap_or(Value::Uninit);
                 match &v1 {

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -56,6 +56,9 @@ t_string_codes(Codes) :- string_codes(hello, Codes).
 :- dynamic t_string_chars/1.
 t_string_chars(Chars) :- string_chars(hi, Chars).
 
+:- dynamic t_string_code/1.
+t_string_code(Code) :- string_code(2, hello, Code).
+
 %% catch/throw + succ predicates (ISO meta-builtin Call fallback path).
 :- dynamic t_thrower/0.
 t_thrower :- throw(oops(42)).
@@ -146,6 +149,7 @@ test_builtin_parity_execution :-
              user:t_concat_split/2, user:t_select/2,
              user:t_atomic/1, user:t_atomic_number/1,
              user:t_string_codes/1, user:t_string_chars/1,
+             user:t_string_code/1,
              user:t_thrower/0, user:t_deep/0, user:t_mid/0,
              user:t_catch_match/1, user:t_catch_deep/1,
              user:t_catch_nomatch/0, user:t_catch_nothrow/1,
@@ -166,6 +170,7 @@ use builtin_parity_test::value::Value;
 use builtin_parity_test::{t_between_1, t_msort_1, t_sort_1, t_concat_split_2, t_select_2,
     t_atomic_1, t_atomic_number_1,
     t_string_codes_1, t_string_chars_1,
+    t_string_code_1,
     t_catch_match_1, t_catch_deep_1, t_catch_nomatch_0, t_catch_nothrow_1,
     t_catch_failgoal_0, t_catch_nested_1, t_succ_fwd_1, t_succ_rev_1,
     t_maplist_1, t_maplist_check_0, t_maplist_fail_0, t_include_1, t_exclude_1,
@@ -287,6 +292,10 @@ fn test_string_codes_chars_compiled() {
     let mut chars_vm = vmnew();
     assert!(t_string_chars_1(&mut chars_vm, ub("Chars")));
     assert_eq!(read_var(&chars_vm, "Chars"), Value::List(vec![a("h"), a("i")]));
+
+    let mut code_vm = vmnew();
+    assert!(t_string_code_1(&mut code_vm, ub("Code")));
+    assert_eq!(read_var(&code_vm, "Code"), i(101));
 }
 
 #[test]
@@ -625,6 +634,15 @@ fn test_atom_text_ops() {
     let (ok4, vm4) = call2("char_code/2", ub("Ch"), i(98));
     assert!(ok4);
     assert_eq!(read_var(&vm4, "Ch"), a("b"));
+    let (string_code_ok, string_code_vm) = call3("string_code/3", i(2), a("abc"), ub("Code"));
+    assert!(string_code_ok);
+    assert_eq!(read_var(&string_code_vm, "Code"), i(98));
+    assert!(call3("string_code/3", i(1), a("é"), i(233)).0);
+    assert!(!call3("string_code/3", i(0), a("abc"), ub("Code")).0);
+    assert!(!call3("string_code/3", i(4), a("abc"), ub("Code")).0);
+    assert!(!call3("string_code/3", ub("Index"), a("abc"), ub("Code")).0);
+    assert!(!call3("string_code/3", i(1), ub("String"), ub("Code")).0);
+    assert!(!call3("string_code/3", i(1), a("abc"), i(98)).0);
     let (ok5, vm5) = call2("atom_chars/2", a("hi"), ub("Cs"));
     assert!(ok5);
     assert_eq!(read_var(&vm5, "Cs"), Value::List(vec![a("h"), a("i")]));

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -478,6 +478,7 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"atom_codes/2"'),
         sub_string(S, _, _, _, '"string_codes/2"'),
         sub_string(S, _, _, _, '"string_chars/2"'),
+        sub_string(S, _, _, _, '"string_code/3"'),
         sub_string(S, _, _, _, '"number_codes/2"'),
         sub_string(S, _, _, _, '"number_chars/2"'),
         sub_string(S, _, _, _, '"reverse/2"'),


### PR DESCRIPTION
## Summary

- implement deterministic, 1-based `string_code/3`
- support Unicode code-point indexing
- fail for unbound inputs, invalid indices, out-of-range access, and output mismatches
- keep the implementation local to the Rust WAM target
- add compiled and direct execution coverage

## Testing

- `swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl`
- `swipl -q -s tests/test_wam_rust_target.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `git diff --check`