### PR TITLE
KT-HEAP-SNAPSHOT-OPT-2: peel T4 get_constant so append recursion wins

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -60,6 +60,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | EMIT-KOTLIN-5 | Mid-body `call` | Kotlin | M | fib/ack / non-tail continuation |
 | BENCH-KOTLIN ✅ | Lowered vs interpreter timing | Kotlin | S | done — recursion regresses; short cases noise (`cursor/bench-kotlin-f421`) |
 | KT-DISPATCH-SNAPSHOT-OPT ✅ | Perf: cheapen recursive dispatch | Kotlin | M | done — skip recursive tryRun snap (`cursor/kt-dispatch-snapshot-opt-f421`) |
+| KT-HEAP-SNAPSHOT-OPT-2 ✅ | Perf: eliminate residual T4 `_t4` copy | Kotlin | M | done — peel leading get_constant (`cursor/kt-heap-snapshot-opt-2-f421`) |
 | BENCH-LLVM | Effective-distance bench row | LLVM | L | — |
 | BENCH-CPP | Effective-distance bench row | C++ | L | — |
 | BENCH-C | Effective-distance bench row | C | M | — |
@@ -620,6 +621,12 @@ fallback) to the three Tier-D targets. Reference small emitters:
 - **Status:** ✅ **Landed** on `cursor/kt-dispatch-snapshot-opt-f421` (2026-07-14). Profile: `snapshotForNative` was **~31%** of `append_500` wall with one snap per native entry. Fix: skip snapshot+bytecode-fallback on recursive `tryRun` hops (`skipRecursiveNativeSnapshot`); keep top-level WAT fallback. Bench hardened to 5/15 + min/median. **append_100 ~1.03×**, **append_500 ~0.85×** (from ~0.55×). Remaining: T4 `_t4` per-entry map copy — see `docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`.
 - **Motivation:** BENCH-KOTLIN's reproducible regression — lowered tail recursion (`append`) ~0.6–0.8×, worsening with depth — from per-hop `tryRun`→`snapshotForNative` copying the growing `H<n>` map.
 - **Acceptance:** profile evidence in PR; append improves materially; differential + conformance green; bench doc updated.
+
+### KT-HEAP-SNAPSHOT-OPT-2: Eliminate residual T4 `_t4` snapshot on recursion (Kotlin)
+- **Lever:** Perf / lowered-path payoff  **Target:** Kotlin  **Size:** M  **Depends on:** KT-DISPATCH-SNAPSHOT-OPT
+- **Status:** ✅ **Landed** on `cursor/kt-heap-snapshot-opt-2-f421` (2026-07-14). Profile (all `snapshotForNative`, incl. `_t4`): **~48%** of `append_500` wall; `max_register_map_size≈508`. Fix: peel leading T4 `get_constant`/`get_nil`/`get_integer` so closed discriminant fails skip the entry snapshot. **append_100 ~7.2×**, **append_500 ~30×**. Skipped heap-reclaim / trail-undo — peel removed the hot path. Docs: `WAM_KOTLIN_OPTIMIZATION_HISTORY.md`, `WAM_KOTLIN_BENCH.md`, `WAM_PERF_CROSS_TARGET.md`.
+- **Motivation:** After KT-DISPATCH, append_500 stayed ~0.85× because each recursive T4 entry still deep-copied the growing `H<n>` map.
+- **Acceptance:** profile evidence in PR; append_100/500 ≥1.0× (or profiled reason); differential + both conformance modes + unit suite green; history/perf docs updated.
 
 ---
 

--- a/docs/WAM_KOTLIN_BENCH.md
+++ b/docs/WAM_KOTLIN_BENCH.md
@@ -1,3 +1,6 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
 # Kotlin WAM — interpreter vs lowered (BENCH-KOTLIN)
 
 **Question:** does `emit_mode(functions)` (native lowering) beat the bytecode
@@ -13,66 +16,58 @@ Harness: `examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl`
 LANG=C.UTF-8 swipl -q -s examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl -g main -t halt
 ```
 
-Profiling A/B (functions mode only):
+Profiling (functions mode; attributes **all** `snapshotForNative`, incl. T4 `_t4`):
 
 ```bash
-WAM_KT_PROFILE=1 gradle -q run --args='SKIP_RECURSIVE_SNAP=0'   # legacy per-hop snap
-WAM_KT_PROFILE=1 gradle -q run --args='SKIP_RECURSIVE_SNAP=1'   # optimized (default)
+WAM_KT_PROFILE=1 gradle -q run --args='80 2 5 PROFILE=1'
 ```
 
-## Results after KT-DISPATCH-SNAPSHOT-OPT (2026-07-14)
+## Results after KT-HEAP-SNAPSHOT-OPT-2 (2026-07-14)
 
 Hardened harness (5/15, min + median). All functions-mode cases confirmed
 `registerNative` / `lowered_*`.
 
 | program | interp min | lowered min | **speedup min** | speedup med | notes |
 |---|---:|---:|---:|---:|---|
-| fact | 3.23 | 3.43 | 0.94× | 0.87× | ~parity (short) |
-| list_builder | 6.22 | 5.53 | 1.13× | 1.10× | slight win |
-| t5_color | 8.66 | 2.72 | 3.19× | 1.79× | win (still noisy med) |
-| t4_second_arg | 6.25 | 5.51 | 1.14× | 0.92× | ~parity |
-| member_100 | 68.48 | 43.83 | **1.56×** | 1.55× | win |
-| member_500 | 64.45 | 44.62 | **1.44×** | 1.44× | win |
-| append_100 | 222.85 | 216.14 | **1.03×** | 1.04× | ~parity (was ~0.75×) |
-| append_500 | 841.41 | 985.75 | **0.85×** | 0.85× | improved; still under 1.0× |
+| fact | 3.64 | 3.92 | 0.93× | 0.75× | ~parity (short) |
+| list_builder | 6.28 | 5.58 | 1.13× | 1.01× | slight win |
+| t5_color | 8.63 | 3.35 | 2.58× | 1.96× | win |
+| t4_second_arg | 6.62 | 6.12 | 1.08× | 0.97× | ~parity |
+| member_100 | 65.68 | 46.94 | **1.40×** | 1.37× | win |
+| member_500 | 66.12 | 48.34 | **1.37×** | 1.31× | win |
+| append_100 | 235.26 | 32.63 | **7.21×** | 6.88× | win (was ~1.03×) |
+| append_500 | 884.52 | 29.16 | **30.33×** | 28.94× | win (was ~0.85×) |
 
 Speedup = interpreter_ms / lowered_ms (min batch).
 
 ## Before → after (append, the real signal)
 
-| program | before (BENCH-KOTLIN, ~median) | after (speedup min) |
-|---|---:|---:|
-| append_100 | ~0.75× | **1.03×** |
-| append_500 | ~0.55–0.64× | **0.85×** |
+| program | BENCH-KOTLIN | + KT-DISPATCH | **+ KT-HEAP-SNAPSHOT-OPT-2** |
+|---|---:|---:|---:|
+| append_100 | ~0.75× | ~1.03× | **7.21×** |
+| append_500 | ~0.55–0.64× | ~0.85× | **30.33×** |
 
-Functions-only self-speedup on append_500 profile run (80×5): legacy
-per-hop snap **419.7 ms** min → skip-recursive **270.9 ms** min (~1.55×
-faster native path).
+### Profile evidence (append_500, 80×5, functions)
 
-### Profile evidence
-
-| config | snap_fraction_of_wall | snap_count / native_entries |
-|---|---:|---|
-| BEFORE (`SKIP_RECURSIVE_SNAP=0`) | **30.7%** | 200400 / 200400 |
-| AFTER (default skip) | **~0%** | 400 / 200400 |
+| config | snap_fraction_of_wall | snap_count / native_entries | max_register_map_size |
+|---|---:|---|---:|
+| AFTER KT-DISPATCH (entry `_t4` every hop) | **48.1%** | 200800 / 200400 | 508 |
+| AFTER peel leading `get_constant` | **8.6%** | 800 / 200400 | 508 |
 
 See [`design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`](design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md).
 
 ## Honest readout
 
-- **tryRun per-hop snapshot was the dominant recursive tax** (~31% of wall;
-  one snap per native entry). Skipping it on recursive hops fixes
-  append_100 to parity and lifts append_500 from ~0.55× to ~0.85×.
-- **append_500 still does not beat the interpreter.** Remaining cost:
-  T4’s `val _t4 = snapshotForNative()` once per recursive lowered entry
-  (still copies the growing `H<n>` map). Documented follow-up in the
-  optimization history (trail-with-old-values / heap separation).
-- Short cases are more stable with 5/15 + min, but treat sub-10ms rows
-  cautiously; member/append are the durable signals.
+- **tryRun per-hop snapshot** was the first recursive tax (~31% of wall);
+  KT-DISPATCH fixed that and left append_500 at ~0.85×.
+- **T4 `_t4` per-entry map copy** was the residual (~48% of wall once
+  properly attributed). Peeling a leading fail-closed `get_constant` makes
+  append’s cons path snap-free → **≥1.0× with large margin**.
+- Member stays ~1.4× (first instr is `get_list`, not peeled).
+- Short cases: treat sub-10ms rows cautiously; member/append are durable.
 
 ## Implications for EMIT-KOTLIN-5
 
-Mid-body `call` still adds continuation machinery on top of this seam.
-Dispatch is cheaper now for tail `execute`, but EMIT-KOTLIN-5 should not
-claim a win until measured; T4 snapshot cost remains on multi-clause
-recursion.
+Mid-body `call` still needs continuation machinery. Tail `execute`
+recursion is no longer snapshot-bound for peelable T4 heads; re-measure
+after EMIT-KOTLIN-5 lands.

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -49,21 +49,19 @@ module in the fleet.
   Registered via `WamProgram.registerNative`. `functions` / `mixed`
   modes route lowerable preds through this path.
 
-## Perf signal (BENCH-KOTLIN + KT-DISPATCH-SNAPSHOT-OPT)
+## Perf signal (BENCH-KOTLIN → KT-HEAP-SNAPSHOT-OPT-2)
 
 In-process `tryRun` timing (not JVM startup) — see
 [`WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md) and
 [`design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`](design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md).
-Recursive native hops **skip** `snapshotForNative` (top-level fallback
-kept). Profile: snaps were ~31% of `append_500` wall. **After:**
-append_100 ~1.03×, append_500 ~0.85× (was ~0.55×); member ~1.4–1.6×.
-Remaining recursive tax: T4 `_t4` map copy per entry.
+Recursive tryRun snaps skipped; T4 peels leading `get_constant` so append’s
+cons path is snap-free. **After KT-HEAP-SNAPSHOT-OPT-2:** append_100
+~**7.2×**, append_500 ~**30×**; member ~1.4×.
 
 ## Gaps
 
 - **Mid-body `call`** — still declined (fib, ack with non-tail call).
   Follow-up **EMIT-KOTLIN-5** (correctness; re-measure after).
-- **T4 `_t4` snapshot cost** on deep recursion (blocks append_500 ≥1.0×).
 - **ITE/soft-cut, cut, aggregates** — not lowered.
 - **Native recursion depth:** `execute` uses the JVM call stack.
   Measured ~1000 peano-depth OK, ~2000 → `StackOverflowError` on the
@@ -77,13 +75,13 @@ Remaining recursive tax: T4 `_t4` map copy per entry.
 
 ## Path forward
 
-1. Cheapen T4 `_t4` restore (trail-with-old-values / heap separation) if
-   append_500 must reach ≥1.0×.
-2. EMIT-KOTLIN-5 for mid-body `call` (correctness; re-measure perf).
+1. EMIT-KOTLIN-5 for mid-body `call` (correctness; re-measure perf).
+2. Optional: heap-outside-map / trail-with-old-values if non-peeled T4 or
+   CP snapshots dominate a new workload.
 3. Optional: ITE/soft-cut; ISO / kernels if Kotlin graduates beyond scaffold.
 
 ## Document status
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
-(2026-07-14). Through KT-DISPATCH-SNAPSHOT-OPT.
+(2026-07-14). Through KT-HEAP-SNAPSHOT-OPT-2.

--- a/docs/WAM_PERF_CROSS_TARGET.md
+++ b/docs/WAM_PERF_CROSS_TARGET.md
@@ -195,14 +195,30 @@ backtracking stays on the lowered T4 `_t4` snapshot. Toggle:
 `SKIP_RECURSIVE_SNAP=0`.
 
 **Result:** append_100 → ~1.03×; append_500 → ~0.85× (from ~0.55×);
-functions-only append_500 self-speedup ~1.55×. Remaining gap is T4’s
-per-entry `_t4` map copy — see
-[`design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`](design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md)
-and [`WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md).
+functions-only append_500 self-speedup ~1.55×. Remaining gap was T4’s
+per-entry `_t4` map copy — closed by **KT-HEAP-SNAPSHOT-OPT-2** (below).
+
+## Case study: Kotlin T4 `_t4` peel (KT-HEAP-SNAPSHOT-OPT-2)
+
+After skipping recursive tryRun snaps, profiling **all**
+`snapshotForNative` (including lowered T4) on `append_500` showed
+**~48% of wall** still in snapshots: `snap_count ≈ native_entries`,
+`max_register_map_size ≈ 508` (heap vars grow with depth → ≈O(depth²)
+copy total).
+
+**Fix:** when T4 clause 1 starts with `get_constant` / `get_nil` /
+`get_integer`, peel the discriminant — closed ground mismatch jumps to
+later clauses with **no** entry snapshot. Append’s cons path is
+snap-free; nil/var paths still snapshot once.
+
+**Result:** append_100 → **~7.2×**; append_500 → **~30×** (hardened
+min harness). Member unchanged (~1.4×; first instr is `get_list`).
+Details: [`design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`](design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md),
+[`WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md).
 
 **Cross-target lesson (unchanged):** profile first; the bottleneck is
-rarely where the sibling target’s was. Here it was fallback-safety
-snapshots on a hot recursive seam, not per-register immutability.
+rarely where the sibling target’s was. Here the residual was clause-entry
+snapshots on a fail-closed discriminant, not trail undo.
 
 ## Related
 

--- a/docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md
+++ b/docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md
@@ -31,7 +31,7 @@ register/heap map while `H<n>` vars accumulate → ≈O(depth²).
 
 ---
 
-## KT-DISPATCH-SNAPSHOT-OPT (this change)
+## KT-DISPATCH-SNAPSHOT-OPT
 
 ### Prior art consulted
 
@@ -90,7 +90,65 @@ recursive hop). After the fix, snaps drop to one per top-level query
 Each lowered T4 entry still does `val _t4 = state.snapshotForNative()` for
 clause backtracking. Recursive append therefore still copies the growing
 `H<n>` map once per depth. **tryRun** no longer doubles that. Follow-up:
-cheapen T4 restore (trail-with-old-values or heap separation).
+**KT-HEAP-SNAPSHOT-OPT-2** (below).
+
+---
+
+## KT-HEAP-SNAPSHOT-OPT-2 (this change)
+
+### Prior art consulted
+
+| Source | What we took |
+|---|---|
+| `WAM_PERF_CROSS_TARGET.md` (F# `putReg`, KT-DISPATCH case study) | Profile → remove copy-the-world on the hot path. |
+| `WAM_RUST_STATE_MANAGEMENT_RETROSPECTIVE.md` | Trail undo as the long-term model for option (b); not chosen here. |
+| `WAM_WAT_OPTIMIZATION_HISTORY.md` | Doc shape: did / skipped+why. |
+| KT-DISPATCH-SNAPSHOT-OPT (above) | Residual `_t4` cost; hardened min/median bench. |
+
+### Profile (append_500, functions, 80 iters × 5 timed batches, `WAM_KT_PROFILE=1`)
+
+Counters now live inside `WamState.snapshotForNative` so **T4 `_t4`** is
+attributed (KT-DISPATCH’s post-fix “~0% snap” only measured tryRun snaps).
+
+| config | min_ms | snap_fraction_of_wall | snap_count | native_entries | max_register_map_size |
+|---|---:|---:|---:|---:|---:|
+| **BEFORE** (entry `_t4` every hop) | 305.6 | **0.481** | 200 800 | 200 400 | **508** |
+| **AFTER** (peel leading `get_constant`) | 17.0 | **0.086** | 800 | 200 400 | 508 |
+
+`avg_register_map_size_at_snap` ≈257 before/after at the remaining snaps
+(top-level tryRun + base-case nil path). The win is **not** shrinking the
+heap — it is **not copying it on every cons hop**.
+
+### What we did
+
+1. **Peel leading `get_constant` / `get_nil` / `get_integer` in T4 emit**
+   (`wam_kotlin_lowered_emitter.pl`): closed discriminant miss (ground
+   mismatch) jumps to later clauses with **no** entry snapshot. Bindable
+   cases (`null` / `Var` / exact match) still snapshot before committing
+   clause 1. Last remaining clause needs no snapshot.
+2. **PROFILE** aggregates all `snapshotForNative` cost + max/avg register
+   map size at snap (`Main.kt.mustache` / `WamRuntime.kt.mustache`).
+3. Skip restore after the last failed T4 clause (no next alternative).
+
+Append’s recursive cons path is therefore snap-free → append_500
+~**30×** vs interpreter (hardened 5/15 min harness).
+
+### Hardened bench after fix (min speedup)
+
+| program | speedup_min |
+|---|---:|
+| append_100 | **7.21×** (was ~1.03×) |
+| append_500 | **30.33×** (was ~0.85×) |
+| member_100 / 500 | 1.37–1.40× (unchanged class — first instr is `get_list`) |
+
+### What we skipped (and why)
+
+| Idea | Why not now |
+|---|---|
+| **(a) Bound/reclaim `H<n>` outside snapshotted map** | Highest leverage for *every* snapshot, but peel already removed the hot-path copy for append. Larger representation change; keep as follow-up if CP / non-peeled T4 snaps dominate. |
+| **(b) Trail-based undo for T4** | Trail still stores names only; needs old values or a native side trail. Bigger than peel; defer. |
+| **(c) Blind “skip `_t4` on last clause” only** | Entry snapshot still ran before clause 1; peel is the stronger form of (c) for fail-closed discriminants. |
+| **Peel `get_structure` / `get_list`** | Not fail-closed on vars (enters write mode); member already wins without it. |
 
 ---
 

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -4883,7 +4883,16 @@ at the scales and deployments where holding all edges resident is not an option.
 Recursive native `tryRun` no longer calls `snapshotForNative` on every
 `execute` hop (default `skipRecursiveNativeSnapshot`). Profile on
 `append_500`: snapshot was ~31% of wall with snap_count == native_entries;
-after skip, snap_fraction ~0 and append_500 speedup vs interpreter rose
+after skip, tryRun snap_fraction ~0 and append_500 speedup vs interpreter rose
 from ~0.55× to ~0.85× (append_100 ~1.03×). Remaining cost: T4 `_t4`
 per-entry map copy. Details: `docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`,
 `docs/WAM_PERF_CROSS_TARGET.md` (Kotlin case study), `docs/WAM_KOTLIN_BENCH.md`.
+
+## Kotlin — KT-HEAP-SNAPSHOT-OPT-2 (2026-07-14)
+
+Attributed all `snapshotForNative` (incl. T4 `_t4`): ~48% of `append_500`
+wall, map size → ~508. Peel leading T4 `get_constant` so closed discriminant
+fails skip the entry snapshot. append_100 ~7.2×, append_500 ~30× (hardened
+min). Skipped heap-reclaim / trail-undo for now — peel removed the hot path.
+Details: `docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`,
+`docs/WAM_PERF_CROSS_TARGET.md`, `docs/WAM_KOTLIN_BENCH.md`.

--- a/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
@@ -238,18 +238,88 @@ fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {
 ', [PredName, FuncName, Body]).
 
 % T4: try each clause as a local fun; restore snapshot between attempts.
+% KT-HEAP-SNAPSHOT-OPT-2: when clause 1 starts with get_constant/get_nil/
+% get_integer, peel that discriminant so a closed fail (ground mismatch)
+% jumps to later clauses with *no* entry snapshot. Deep list recursion
+% (append cons path) therefore avoids the O(depth) map copy per hop.
 emit_multi_clause_n_function(PredName, FuncName, Clauses, Code) :-
-    with_output_to(string(Body), emit_kotlin_t4_clauses(Clauses, 0)),
-    format(string(Code),
+    (   kotlin_t4_peelable_get_constant(Clauses, ConstTok, Reg, FirstBody, RestClauses)
+    ->  emit_multi_clause_n_peeled(PredName, FuncName, ConstTok, Reg, FirstBody, RestClauses, Code)
+    ;   with_output_to(string(Body), emit_kotlin_t4_clauses(Clauses, 0, _t4)),
+        format(string(Code),
 '// Lowered: ~w (T4 all-clauses inline)
 fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {
     val _t4 = state.snapshotForNative()
 ~w    return false
 }
-', [PredName, FuncName, Body]).
+', [PredName, FuncName, Body])
+    ).
 
-emit_kotlin_t4_clauses([], _).
-emit_kotlin_t4_clauses([Clause|Rest], N) :-
+% Peel leading get_constant when ≥2 clauses (need an alternative after miss).
+kotlin_t4_peelable_get_constant([First|Rest], ConstTok, Reg, FirstBody, Rest) :-
+    Rest = [_|_],
+    First = [HeadLine|FirstBody],
+    wam_kotlin_target:tokenize_wam_line(HeadLine, Parts),
+    kotlin_t4_peel_head(Parts, ConstTok, Reg).
+
+kotlin_t4_peel_head(["get_constant", C, R], C, R) :- !.
+kotlin_t4_peel_head(["get_integer", C, R], C, R) :- !.
+kotlin_t4_peel_head(["get_nil", R], '[]', R) :- !.
+
+emit_multi_clause_n_peeled(PredName, FuncName, ConstTok, Reg, FirstBody, RestClauses, Code) :-
+    kotlin_constant_expr(ConstTok, Expr),
+    kotlin_register_lit(Reg, RL),
+    with_output_to(string(FirstFun), (
+        format("        fun clause_1(): Boolean {~n", []),
+        format("            if (!kotlinLoGetConstant(state, ~w, ~w)) return false~n", [Expr, RL]),
+        emit_lines(FirstBody, "            ", return_true),
+        format("        }~n", []),
+        format("        if (clause_1()) return true~n", []),
+        format("        state.restoreFromSnapshot(_t4)~n", [])
+    )),
+    (   RestClauses = [_]
+    ->  % Single remaining clause: last-clause path — no snapshot.
+        with_output_to(string(RestBody), emit_kotlin_t4_last_clauses(RestClauses, 1)),
+        format(string(Code),
+'// Lowered: ~w (T4 peel leading get_constant — skip snap on closed fail)
+fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {
+    val _peel = state.deref(state.readRegister(~w))
+    val _peelHit = _peel == ~w || _peel == null || _peel is Value.Var
+    if (_peelHit) {
+        val _t4 = state.snapshotForNative()
+~w    }
+~w    return false
+}
+', [PredName, FuncName, RL, Expr, FirstFun, RestBody])
+    ;   with_output_to(string(RestBody), emit_kotlin_t4_clauses(RestClauses, 1, _t4b)),
+        format(string(Code),
+'// Lowered: ~w (T4 peel leading get_constant — skip snap on closed fail)
+fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {
+    val _peel = state.deref(state.readRegister(~w))
+    val _peelHit = _peel == ~w || _peel == null || _peel is Value.Var
+    if (_peelHit) {
+        val _t4 = state.snapshotForNative()
+~w    }
+    val _t4b = state.snapshotForNative()
+~w    return false
+}
+', [PredName, FuncName, RL, Expr, FirstFun, RestBody])
+    ).
+
+% Emit remaining clauses without a shared entry snapshot (last-clause / peel miss).
+emit_kotlin_t4_last_clauses([], _).
+emit_kotlin_t4_last_clauses([Clause|Rest], N) :-
+    N1 is N + 1,
+    format(atom(CName), 'clause_~w', [N1]),
+    format("    fun ~w(): Boolean {~n", [CName]),
+    emit_lines(Clause, "        ", return_true),
+    format("    }~n", []),
+    format("    if (~w()) return true~n", [CName]),
+    emit_kotlin_t4_last_clauses(Rest, N1).
+
+% SnapVar is the Kotlin local holding the restore point (_t4 / _t4b).
+emit_kotlin_t4_clauses([], _, _).
+emit_kotlin_t4_clauses([Clause|Rest], N, SnapVar) :-
     N1 is N + 1,
     format(atom(CName), 'clause_~w', [N1]),
     format("    fun ~w(): Boolean {~n", [CName]),
@@ -257,8 +327,11 @@ emit_kotlin_t4_clauses([Clause|Rest], N) :-
     emit_lines(Clause, "        ", return_true),
     format("    }~n", []),
     format("    if (~w()) return true~n", [CName]),
-    format("    state.restoreFromSnapshot(_t4)~n", []),
-    emit_kotlin_t4_clauses(Rest, N1).
+    (   Rest == []
+    ->  true  % last clause: no restore before return false
+    ;   format("    state.restoreFromSnapshot(~w)~n", [SnapVar])
+    ),
+    emit_kotlin_t4_clauses(Rest, N1, SnapVar).
 
 % T5: bound first-arg if-cascade; unbound → false (tryRun → interpreter).
 emit_clause_chain_function(PredName, FuncName, Guards, Code) :-

--- a/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
@@ -245,7 +245,7 @@ fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {
 emit_multi_clause_n_function(PredName, FuncName, Clauses, Code) :-
     (   kotlin_t4_peelable_get_constant(Clauses, ConstTok, Reg, FirstBody, RestClauses)
     ->  emit_multi_clause_n_peeled(PredName, FuncName, ConstTok, Reg, FirstBody, RestClauses, Code)
-    ;   with_output_to(string(Body), emit_kotlin_t4_clauses(Clauses, 0, _t4)),
+    ;   with_output_to(string(Body), emit_kotlin_t4_clauses(Clauses, 0, '_t4')),
         format(string(Code),
 '// Lowered: ~w (T4 all-clauses inline)
 fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {
@@ -291,7 +291,7 @@ fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {
 ~w    return false
 }
 ', [PredName, FuncName, RL, Expr, FirstFun, RestBody])
-    ;   with_output_to(string(RestBody), emit_kotlin_t4_clauses(RestClauses, 1, _t4b)),
+    ;   with_output_to(string(RestBody), emit_kotlin_t4_clauses(RestClauses, 1, '_t4b')),
         format(string(Code),
 '// Lowered: ~w (T4 peel leading get_constant — skip snap on closed fail)
 fun ~w(state: WamState, dispatch: (String, WamState) -> Boolean): Boolean {

--- a/templates/targets/kotlin_wam/Main.kt.mustache
+++ b/templates/targets/kotlin_wam/Main.kt.mustache
@@ -46,10 +46,12 @@ fun main(args: Array<String>) {
     for (b in 0 until timedBatches) {
         val t0 = System.nanoTime()
         repeat(iterations) {
-            if (!runtime.tryRun(predicate, freshState())) {
+            val st = freshState()
+            if (!runtime.tryRun(predicate, st)) {
                 println("BENCH predicate=$predicate ok=false (timed failure)")
                 return
             }
+            runtime.noteStateProfile(st)
         }
         batchMs[b] = (System.nanoTime() - t0) / 1_000_000.0
     }
@@ -65,10 +67,17 @@ fun main(args: Array<String>) {
         val snapMs = runtime.profileSnapNs / 1_000_000.0
         val wallMs = batchMs.sum()
         val frac = if (wallMs > 0.0) snapMs / wallMs else 0.0
+        val avgMap = if (runtime.profileSnapCount > 0L) {
+            runtime.profileSumRegisterMapSize.toDouble() / runtime.profileSnapCount.toDouble()
+        } else {
+            0.0
+        }
         println(
             "PROFILE snap_ms=${"%.3f".format(snapMs)} timed_wall_ms=${"%.3f".format(wallMs)} " +
                 "snap_fraction_of_wall=${"%.3f".format(frac)} snap_count=${runtime.profileSnapCount} " +
-                "native_entries=${runtime.profileNativeEntries}"
+                "native_entries=${runtime.profileNativeEntries} " +
+                "max_register_map_size=${runtime.profileMaxRegisterMapSize} " +
+                "avg_register_map_size_at_snap=${"%.1f".format(avgMap)}"
         )
     }
 {{/benchmark_main}}

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -257,7 +257,36 @@ class WamState(
 
     fun restoreChoicePoint(): Boolean = restoreChoicePointFrame() != null
 
-    fun snapshotForNative(): WamNativeSnapshot =
+    // Optional profile counters (KT-HEAP-SNAPSHOT-OPT-2): attribute ALL
+    // snapshotForNative cost — including T4 `_t4` — not only tryRun.
+    var profileSnaps: Boolean = false
+    var profileSnapNs: Long = 0L
+    var profileSnapCount: Long = 0L
+    var profileMaxRegisterMapSize: Int = 0
+    var profileSumRegisterMapSize: Long = 0L
+
+    fun resetSnapProfile() {
+        profileSnapNs = 0L
+        profileSnapCount = 0L
+        profileMaxRegisterMapSize = 0
+        profileSumRegisterMapSize = 0L
+    }
+
+    fun snapshotForNative(): WamNativeSnapshot {
+        if (profileSnaps) {
+            val mapSize = registers.size
+            if (mapSize > profileMaxRegisterMapSize) profileMaxRegisterMapSize = mapSize
+            profileSumRegisterMapSize += mapSize.toLong()
+            val t0 = System.nanoTime()
+            val snap = snapshotForNativeUnprofiled()
+            profileSnapNs += System.nanoTime() - t0
+            profileSnapCount++
+            return snap
+        }
+        return snapshotForNativeUnprofiled()
+    }
+
+    private fun snapshotForNativeUnprofiled(): WamNativeSnapshot =
         WamNativeSnapshot(
             registers = LinkedHashMap(registers),
             trail = trail.toList(),
@@ -358,16 +387,32 @@ class WamRuntime(private val program: WamProgram) {
     var skipRecursiveNativeSnapshot: Boolean = true
 
     // Optional nanoTime counters for dispatch profiling (append_500 etc.).
-    // Compare profileSnapNs to the BENCH batch wall to get snapshot fraction.
+    // Snap time/count live on the WamState used for each tryRun (includes T4 `_t4`).
+    // Aggregate into these fields across a timed batch via noteStateProfile().
     var profileNativeDispatch: Boolean = false
     var profileSnapNs: Long = 0L
     var profileSnapCount: Long = 0L
     var profileNativeEntries: Long = 0L
+    var profileMaxRegisterMapSize: Int = 0
+    var profileSumRegisterMapSize: Long = 0L
 
     fun resetProfileCounters() {
         profileSnapNs = 0L
         profileSnapCount = 0L
         profileNativeEntries = 0L
+        profileMaxRegisterMapSize = 0
+        profileSumRegisterMapSize = 0L
+    }
+
+    /** Fold per-query state snap counters into the runtime aggregate (bench PROFILE). */
+    fun noteStateProfile(state: WamState) {
+        if (!profileNativeDispatch) return
+        profileSnapNs += state.profileSnapNs
+        profileSnapCount += state.profileSnapCount
+        if (state.profileMaxRegisterMapSize > profileMaxRegisterMapSize) {
+            profileMaxRegisterMapSize = state.profileMaxRegisterMapSize
+        }
+        profileSumRegisterMapSize += state.profileSumRegisterMapSize
     }
 
     fun run(predicate: String, initialState: WamState = WamState()): WamState {
@@ -381,6 +426,9 @@ class WamRuntime(private val program: WamProgram) {
     // exhaustion (no throw). Used by conformance_main projects so ct_run
     // can map stdout true/false without relying on exceptions.
     fun tryRun(predicate: String, initialState: WamState = WamState()): Boolean {
+        if (profileNativeDispatch) {
+            initialState.profileSnaps = true
+        }
         program.findNative(predicate)?.let { nativeFn ->
             profileNativeEntries++
             val recursive = nativeDepth > 0
@@ -393,7 +441,7 @@ class WamRuntime(private val program: WamProgram) {
             // Top-level (or recursive with skip disabled for A/B profile):
             // snapshot so a native false can restore before falling back
             // to bytecode (T5 unbound → interpreter, etc.).
-            val snapshot = takeNativeSnapshot(initialState)
+            val snapshot = initialState.snapshotForNative()
             nativeDepth++
             val ok = try {
                 nativeFn(initialState, this::tryRun)
@@ -417,19 +465,6 @@ class WamRuntime(private val program: WamProgram) {
             }
         }
         return true
-    }
-
-    private fun takeNativeSnapshot(state: WamState): WamNativeSnapshot {
-        return if (profileNativeDispatch) {
-            val t0 = System.nanoTime()
-            val snap = state.snapshotForNative()
-            profileSnapNs += System.nanoTime() - t0
-            profileSnapCount++
-            snap
-        } else {
-            profileSnapCount++
-            state.snapshotForNative()
-        }
     }
 
     fun restoreChoicePoint(state: WamState): Boolean {

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -190,7 +190,9 @@ test(generated_project_compiles_and_runs_fact_variable_and_terms, [condition(gra
                 [emit_mode(interpreter)], TmpDir),
             run_gradle(TmpDir, ['-q', 'compileKotlin'], _CompileOut, CompileErr, CompileStatus),
             assertion(CompileStatus == exit(0)),
-            assertion(CompileErr == ""),
+            % No kotlinc compile errors. (Not `== ""`: gradle daemon emits
+            % benign stderr like `Already watching path` / JAVA_TOOL_OPTIONS.)
+            assertion(\+ has_substring(CompileErr, "error:")),
             run_gradle(TmpDir, ['-q', 'run', '--args=kt_fact/2 alpha beta'], FactOut, _FactErr, FactStatus),
             assertion(FactStatus == exit(0)),
             assertion(has_substring(FactOut, 'Ran kt_fact/2')),
@@ -284,7 +286,9 @@ test(functions_mode_gradle_runs_lowered_fact, [condition(gradle_available), nond
         (   wam_kotlin_target:write_wam_kotlin_project([user:kt_fact/2], [emit_mode(functions)], TmpDir),
             run_gradle(TmpDir, ['-q', 'compileKotlin'], _CompileOut, CompileErr, CompileStatus),
             assertion(CompileStatus == exit(0)),
-            assertion(CompileErr == ""),
+            % No kotlinc compile errors. (Not `== ""`: gradle daemon emits
+            % benign stderr like `Already watching path` / JAVA_TOOL_OPTIONS.)
+            assertion(\+ has_substring(CompileErr, "error:")),
             run_gradle(TmpDir, ['-q', 'run', '--args=kt_fact/2 alpha beta'], FactOut, _FactErr, FactStatus),
             assertion(FactStatus == exit(0)),
             assertion(has_substring(FactOut, 'Ran kt_fact/2')),

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -612,7 +612,9 @@ test(functions_mode_multi_clause_partition, [nondet]) :-
             assertion(has_substring(ColorCode, 'T5 first-argument dispatch')),
             assertion(has_substring(ColorCode, 'Value.Atom("a")')),
             memberchk(native(kt3_t4/2, lowered(_, _, T4Code)), Native),
-            assertion(has_substring(T4Code, 'T4 all-clauses inline')),
+            % KT-HEAP-SNAPSHOT-OPT-2: leading get_constant peels (else plain T4).
+            assertion((has_substring(T4Code, 'T4 peel leading get_constant')
+                      ; has_substring(T4Code, 'T4 all-clauses inline'))),
             assertion(has_substring(T4Code, 'snapshotForNative')),
             assertion(has_substring(T4Code, 'restoreFromSnapshot')),
             memberchk(native(kt3_mem/2, lowered(_, _, MemCode)), Native),
@@ -707,7 +709,8 @@ test(functions_mode_gradle_multi_clause_t4, [condition(gradle_available), nondet
             read_file_to_string(
                 'output/test_wam_kotlin_multi_clause_t4/src/main/kotlin/generated/wam/Main.kt',
                 Main, []),
-            assertion(has_substring(Main, 'T4 all-clauses inline')),
+            assertion((has_substring(Main, 'T4 peel leading get_constant')
+                      ; has_substring(Main, 'T4 all-clauses inline'))),
             assertion(has_substring(Main, 'registerNative("kt3_t4/2"')),
             run_gradle(TmpDir, ['-q', 'compileKotlin'], _CO, _CE, CS),
             assertion(CS == exit(0)),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Eliminate the residual per-recursive-entry T4 `_t4` map copy so lowered `append` under `emit_mode(functions)` beats the interpreter — not just ~0.85× after KT-DISPATCH-SNAPSHOT-OPT.

## Profile first (append_500, functions, 80×5, `WAM_KT_PROFILE=1`)

Instrumentation now times **all** `snapshotForNative` calls (including T4 `_t4`):

| config | min_ms | snap_fraction | snap_count | native_entries | max_register_map_size |
|---|---:|---:|---:|---:|---:|
| **BEFORE** (entry `_t4` every hop) | 305.6 | **0.481** | 200 800 | 200 400 | **508** |
| **AFTER** (peel leading `get_constant`) | 17.0 | **0.086** | 800 | 200 400 | 508 |

Map grows ~O(depth) (`H<n>`) → prior copy was ≈O(depth²) total. After peel: snaps ≈ 2× queries (top-level tryRun + base-case nil path only).

## Fix

When a T4 predicate’s first clause starts with `get_constant` / `get_nil` / `get_integer`, emit a **peel**: closed discriminant miss (ground mismatch) jumps to later clauses **without** an entry snapshot. Bindable cases (`null` / `Var` / exact match) still snapshot before committing clause 1. Last remaining clause needs no snapshot.

Append’s recursive cons path is therefore snap-free.

**Skipped:** (a) heap-outside-map reclaim, (b) trail-with-old-values — peel removed the hot-path copy. Documented in `docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`.

## Hardened bench (5 warmup / 15 batches, min speedup)

| program | before (KT-DISPATCH) | **after** |
|---|---:|---:|
| append_100 | ~1.03× | **7.21×** |
| append_500 | ~0.85× | **30.33×** |
| member_100 / 500 | ~1.4× | ~1.37–1.40× (unchanged; first instr `get_list`) |

## Acceptance

- [x] Unit suite (`tests/test_wam_kotlin_target.pl`) green
- [x] `CONFORMANCE_TARGETS=kotlin,kotlin_functions` green
- [x] `append_100` / `append_500` ≥1.0× with large margin
- [x] Docs: history + bench + fleet card `KT-HEAP-SNAPSHOT-OPT-2` + perf log + cross-target case study

## Env note

`LANG=C.UTF-8`; gradle stderr may include `JAVA_TOOL_OPTIONS` / daemon watch lines — not asserted empty.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

