### PR TITLE
Add Rust WAM tab/1 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1375,6 +1375,26 @@ compile_execute_io_builtin_to_rust(Code) :-
                     self.pc += 1; true
                 } else { false }
             }
+            "tab/1" => {
+                let mut remaining = match self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::Integer(n)) if n >= 0 => match usize::try_from(n) {
+                        Ok(count) => count,
+                        Err(_) => return false,
+                    },
+                    _ => return false,
+                };
+                let spaces = [b'' ''; 64];
+                let mut stdout = std::io::stdout().lock();
+                while remaining > 0 {
+                    let count = remaining.min(spaces.len());
+                    if std::io::Write::write_all(&mut stdout, &spaces[..count]).is_err() {
+                        return false;
+                    }
+                    remaining -= count;
+                }
+                self.pc += 1; true
+            }
             "nl/0" => { println!(); self.pc += 1; true }
             _ => false,
         }

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -62,6 +62,9 @@ t_string_code(Code) :- string_code(2, hello, Code).
 :- dynamic t_output_aliases/0.
 t_output_aliases :- print(alias), writeln(done).
 
+:- dynamic t_tab/0.
+t_tab :- tab(2).
+
 %% catch/throw + succ predicates (ISO meta-builtin Call fallback path).
 :- dynamic t_thrower/0.
 t_thrower :- throw(oops(42)).
@@ -154,6 +157,7 @@ test_builtin_parity_execution :-
              user:t_string_codes/1, user:t_string_chars/1,
              user:t_string_code/1,
              user:t_output_aliases/0,
+             user:t_tab/0,
              user:t_thrower/0, user:t_deep/0, user:t_mid/0,
              user:t_catch_match/1, user:t_catch_deep/1,
              user:t_catch_nomatch/0, user:t_catch_nothrow/1,
@@ -176,6 +180,7 @@ use builtin_parity_test::{t_between_1, t_msort_1, t_sort_1, t_concat_split_2, t_
     t_string_codes_1, t_string_chars_1,
     t_string_code_1,
     t_output_aliases_0,
+    t_tab_0,
     t_catch_match_1, t_catch_deep_1, t_catch_nomatch_0, t_catch_nothrow_1,
     t_catch_failgoal_0, t_catch_nested_1, t_succ_fwd_1, t_succ_rev_1,
     t_maplist_1, t_maplist_check_0, t_maplist_fail_0, t_include_1, t_exclude_1,
@@ -307,6 +312,9 @@ fn test_string_codes_chars_compiled() {
 fn test_output_aliases_compiled() {
     let mut vm = vmnew();
     assert!(t_output_aliases_0(&mut vm));
+
+    let mut tab_vm = vmnew();
+    assert!(t_tab_0(&mut tab_vm));
 }
 
 #[test]
@@ -1135,6 +1143,15 @@ fn test_atomic_direct() {
     assert!(!call1("atomic/1", Value::List(vec![a("x")])).0);
     assert!(!call1("atomic/1", Value::Str("f".to_string(), vec![a("x")])).0);
     assert!(!call1("atomic/1", ub("X")).0);
+}
+
+#[test]
+fn test_tab_direct() {
+    assert!(call1("tab/1", i(3)).0);
+    assert!(call1("tab/1", i(0)).0);
+    assert!(!call1("tab/1", i(-1)).0);
+    assert!(!call1("tab/1", ub("N")).0);
+    assert!(!call1("tab/1", a("three")).0);
 }
 ',
         setup_call_cleanup(

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -451,6 +451,7 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '!/0'),
         sub_string(S, _, _, _, '"write/1" | "display/1" | "print/1"'),
         sub_string(S, _, _, _, '"writeln/1"'),
+        sub_string(S, _, _, _, '"tab/1"'),
         sub_string(S, _, _, _, 'print!("{}", derefed)'),
         sub_string(S, _, _, _, 'nl/0'),
         sub_string(S, _, _, _, 'atom/1'),


### PR DESCRIPTION
## Summary

- implement `tab/1` for bound, non-negative integers
- write spaces through a fixed 64-byte buffer with no length-proportional allocation
- fail for negative, unbound, and non-integer arguments
- add compiled and direct execution coverage

## Testing

- `swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl`
- `swipl -q -s tests/test_wam_rust_target.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `git diff --check`