### PR TITLE
WAM/LLVM plawk: generator PR 5 — multi-column source + projection (views)

### DIFF
--- a/docs/design/PLAWK_GENERATOR_BLOCKS.md
+++ b/docs/design/PLAWK_GENERATOR_BLOCKS.md
@@ -275,6 +275,21 @@ the producer direction plus the `emit` collection. A rough PR shape:
    below. `tests/test_plawk_gen_blocks.pl`: an int tuple and a mixed
    string+int tuple.
 
+5. **Multi-column source + projection (views) — LANDED.** The input iterator
+   now binds a loop var per source column (`as (a, b)`) and the body emits a
+   **projection** of them: `gen over query(edge(A, B)) as (a, b) { if (a > 1)
+   emit a } as srcs` → `srcs(A) :- edge(A, _B), A > 1` (only the needed column
+   materialises — the "don't carry the whole row" point), and `emit (b, a)` →
+   `flipped(B, A) :- edge(A, B)` (reorder). This is the **column-projection
+   engine for views** (`PLAWK_MULTIPASS_CACHE.md` §3.9): a filtered/projected
+   derived relation. The AST generalised to `over(query(Src, SrcVars),
+   LoopVars)` with `LoopVars` a list; `emit` tuple elements may now be bound
+   vars. What remains for a full *view* is **materialise-and-cache** (write the
+   projected set to its own row table with a refresh policy) — the generator
+   gives the *derived-relation* half; materialisation is the cache half.
+   `tests/test_plawk_gen_blocks.pl`: a filtered single-column projection and a
+   reordering tuple projection.
+
 ### Still open — runtime collection
 
 The remaining generator shapes — a pure block with a *computed* emit, a

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -400,8 +400,11 @@ program_has_while(Term) :-
 %    -> a derived rule.
 gen_block_supported(none, Body) :-
     forall(member(Action, Body), gen_const_emit(Action)).
-gen_block_supported(over(query(_Src, [_SrcVar]), LoopVar), Body) :-
-    gen_over_body_ok(Body, LoopVar).
+% Input iterator over a query source: one loop var per source column, and the
+% body emits a projection of the bound vars (optionally filtered).
+gen_block_supported(over(query(_Src, SrcVars), LoopVars), Body) :-
+    same_length(SrcVars, LoopVars),
+    gen_over_body_ok(Body, LoopVars).
 
 % A constant emit: a bare integer/string literal, or a tuple whose elements are
 % all integer/string literals.
@@ -409,18 +412,32 @@ gen_const_emit(emit(int(_))).
 gen_const_emit(emit(string(_))).
 gen_const_emit(emit(tuple(Values))) :-
     forall(member(V, Values), ( V = int(_) ; V = string(_) )).
-gen_block_supported(over(query(_Src, [_SrcVar]), LoopVar), Body) :-
-    gen_over_body_ok(Body, LoopVar).
 
-% A supported input-iterator body: `emit v` (passthrough), optionally filtered
-% by `if (GUARD) emit v` where GUARD is an integer comparison over `v`.
-gen_over_body_ok([emit(var(LoopVar))], LoopVar).
-gen_over_body_ok([if(Guard, [emit(var(LoopVar))], [])], LoopVar) :-
-    gen_over_guard_ok(Guard, LoopVar).
-gen_over_guard_ok(and(L, R), LoopVar) :-
-    gen_over_guard_ok(L, LoopVar), gen_over_guard_ok(R, LoopVar).
-gen_over_guard_ok(forin_key_cmp(LoopVar, _Op, Value), LoopVar) :-
-    integer(Value).
+% A supported input-iterator body: emit a projection of the bound loop vars
+% (`emit a` -> one column; `emit (a, b)` -> a tuple, columns reorderable and
+% mixable with literals), optionally filtered by `if (GUARD) emit ...` where
+% GUARD is an integer comparison over the bound vars.
+gen_over_body_ok([emit(Emit)], LoopVars) :-
+    gen_emit_projection_ok(Emit, LoopVars).
+gen_over_body_ok([if(Guard, [emit(Emit)], [])], LoopVars) :-
+    gen_emit_projection_ok(Emit, LoopVars),
+    gen_over_guard_ok(Guard, LoopVars).
+
+% The emitted projection references only bound loop vars (plus literals in a
+% tuple).
+gen_emit_projection_ok(var(V), LoopVars) :-
+    memberchk(V, LoopVars).
+gen_emit_projection_ok(tuple(Vals), LoopVars) :-
+    Vals = [_, _ | _],
+    forall(member(Val, Vals), gen_emit_elem_ok(Val, LoopVars)).
+gen_emit_elem_ok(var(V), LoopVars) :- memberchk(V, LoopVars).
+gen_emit_elem_ok(int(_), _LoopVars).
+gen_emit_elem_ok(string(_), _LoopVars).
+
+gen_over_guard_ok(and(L, R), LoopVars) :-
+    gen_over_guard_ok(L, LoopVars), gen_over_guard_ok(R, LoopVars).
+gen_over_guard_ok(forin_key_cmp(V, _Op, Value), LoopVars) :-
+    memberchk(V, LoopVars), integer(Value).
 
 % Lift generator blocks out of the pass list, synthesising each one's clauses:
 % a pure block's constant emits become facts (`gen { emit 1; emit 2 } as g` ->
@@ -445,32 +462,53 @@ is_gen_block(gen_block(_, _, _)).
 gen_block_clause(gen_block(name(Name), none, Body), Fact) :-
     member(emit(Value), Body),
     gen_emit_fact(Name, Value, Fact).
-% Input iterator: a single derived rule over the source goal.
-gen_block_clause(gen_block(name(Name), over(query(Src, [_SrcVar]), LoopVar),
+% Input iterator: a single derived rule over the source goal. Each source column
+% binds a fresh variable; the loop-var names map to those fresh vars positionally
+% (Bindings). The head is the emitted projection over those vars; unused source
+% columns stay as anonymous fresh vars (a projection). So
+% `gen over query(edge(A, B)) as (a, b) { if (a > 2) emit a } as g` ->
+% `g(A) :- edge(A, _B), A > 2`, and `emit (b, a)` -> `g(B, A) :- edge(A, B)`.
+gen_block_clause(gen_block(name(Name), over(query(Src, SrcVars), LoopVars),
         Body), Clause) :-
-    % Arg is a fresh logic variable shared by the head, the source goal, and
-    % the filter -- so `g(A) :- src(A), A > 2` unifies across the three.
-    SrcGoal =.. [Src, Arg],
-    Head =.. [Name, Arg],
-    gen_over_body_goal(Body, LoopVar, Arg, FilterGoal),
+    same_length(SrcVars, SrcArgs),          % fresh vars, one per source column
+    SrcGoal =.. [Src | SrcArgs],
+    pairs_keys_values(Bindings, LoopVars, SrcArgs),
+    gen_over_body_head(Body, Name, Bindings, Head, FilterGoal),
     ( FilterGoal == true
     ->  Clause = (Head :- SrcGoal)
     ;   Clause = (Head :- SrcGoal, FilterGoal)
     ).
 
-% The Prolog goal an input-iterator body adds after the source goal: `true`
-% for a bare passthrough, or the translated guard for a filtered one.
-gen_over_body_goal([emit(var(_LoopVar))], _LoopVar, _Arg, true).
-gen_over_body_goal([if(Guard, [emit(var(_LoopVar))], [])], LoopVar, Arg,
-        Goal) :-
-    gen_guard_goal(Guard, LoopVar, Arg, Goal).
+% The head (emitted projection) and the post-source filter goal for an input
+% iterator body.
+gen_over_body_head([emit(Emit)], Name, Bindings, Head, true) :-
+    gen_emit_head_args(Emit, Bindings, Args),
+    Head =.. [Name | Args].
+gen_over_body_head([if(Guard, [emit(Emit)], [])], Name, Bindings, Head,
+        FilterGoal) :-
+    gen_emit_head_args(Emit, Bindings, Args),
+    Head =.. [Name | Args],
+    gen_over_filter_goal(Guard, Bindings, FilterGoal).
 
-% Translate an integer reader guard over the bound var into a Prolog arithmetic
-% comparison over the head argument.
-gen_guard_goal(and(L, R), LoopVar, Arg, (GL, GR)) :-
-    gen_guard_goal(L, LoopVar, Arg, GL),
-    gen_guard_goal(R, LoopVar, Arg, GR).
-gen_guard_goal(forin_key_cmp(LoopVar, Op, Value), LoopVar, Arg, Goal) :-
+% Map an emitted projection to the head's argument list, resolving each bound
+% var to its fresh source variable (literals pass through).
+gen_emit_head_args(var(V), Bindings, [Arg]) :-
+    memberchk(V-Arg, Bindings).
+gen_emit_head_args(tuple(Vals), Bindings, Args) :-
+    maplist(gen_emit_head_arg(Bindings), Vals, Args).
+gen_emit_head_arg(Bindings, var(V), Arg) :-
+    memberchk(V-Arg, Bindings).
+gen_emit_head_arg(_Bindings, int(N), N).
+gen_emit_head_arg(_Bindings, string(S), Atom) :-
+    atom_string(Atom, S).
+
+% Translate an integer reader guard over the bound vars into a Prolog arithmetic
+% comparison over the corresponding source variables.
+gen_over_filter_goal(and(L, R), Bindings, (GL, GR)) :-
+    gen_over_filter_goal(L, Bindings, GL),
+    gen_over_filter_goal(R, Bindings, GR).
+gen_over_filter_goal(forin_key_cmp(V, Op, Value), Bindings, Goal) :-
+    memberchk(V-Arg, Bindings),
     gen_cmp_op(Op, PrologOp),
     Goal =.. [PrologOp, Arg, Value].
 

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -287,21 +287,24 @@ query_var_list_rest([V | Vs]) -->
     query_var_list_rest(Vs).
 query_var_list_rest([]) -->
     [].
-% A `gen over query(SRC(V)) as v { BODY } as name` generator with an input
-% iterator (PLAWK_GENERATOR_BLOCKS.md, PR 3): a producer that transforms another
-% relation. Each solution of the source goal binds `v`; the body emits from it.
-% Parses to gen_block(name(Name), over(query(Src, SrcVars), LoopVar), Body).
-% Tried before the pure `gen { ... }` form -- the `over` keyword distinguishes
-% them. The body is emit-based (`emit v`, or `if (v CMP int) emit v` to filter),
-% so it uses the reader-guard body grammar rather than a general action block.
+% A `gen over query(SRC(A, ...)) as (a, ...) { BODY } as name` generator with an
+% input iterator (PLAWK_GENERATOR_BLOCKS.md, PR 3 + views/PR 5): a producer that
+% transforms/projects another relation. Each solution of the source goal binds
+% the loop vars positionally; the body emits a projection of them. Parses to
+% gen_block(name(Name), over(query(Src, SrcVars), LoopVars), Body) where LoopVars
+% is a list (`as v` -> [v], `as (a, b)` -> [a, b]). A single-column source keeps
+% the `as v` spelling; a multi-column source binds each column and the body may
+% emit a subset (a column-projection view -- "don't materialise the whole row").
+% Tried before the pure `gen { ... }` form. The body is emit-based (`emit a`,
+% `emit (a, b)`, or `if (a CMP int) emit a` to filter).
 pass_clauses([gen_block(name(Name),
-        over(query(Src, SrcVars), LoopVar), Body) | Rest]) -->
+        over(query(Src, SrcVars), LoopVars), Body) | Rest]) -->
     "gen", identifier_boundary, ws,
     "over", identifier_boundary, ws,
     "query", ws, "(", ws,
     identifier(Src), ws, "(", ws, query_var_list(SrcVars), ws, ")", ws,
     ")", ws,
-    "as", identifier_boundary, ws, identifier(LoopVar), ws,
+    "as", identifier_boundary, ws, gen_over_binding(LoopVars), ws,
     gen_over_body(Body), ws,
     "as", identifier_boundary, ws, identifier(Name), ws,
     pass_clauses(Rest).
@@ -330,6 +333,15 @@ gen_over_body([if(Guard, [emit(Emit)], [])]) -->
     !.
 gen_over_body([emit(Emit)]) -->
     "{", ws, emit_action(emit(Emit)), ws, "}".
+
+% The loop-variable binding of an input iterator: `as v` binds one column,
+% `as (a, b, ...)` binds several (one per source column, positionally). Both
+% produce a list of variable names.
+gen_over_binding(Vars) -->
+    "(", ws, query_var_list(Vars), ws, ")",
+    !.
+gen_over_binding([V]) -->
+    identifier(V).
 % A `pass { ACTIONS }` block is one pass carrying a single always-rule with
 % those actions (per-pattern rules within a pass are a later extension).
 pass_clauses([pass([rule(always, Actions)]) | Rest]) -->
@@ -1906,13 +1918,17 @@ emit_tuple_rest([V | Vs]) -->
     emit_tuple_rest(Vs).
 emit_tuple_rest([]) -->
     [].
-% A tuple element: an integer or string literal (constants only for now).
+% A tuple element: an integer or string literal (constant emits -> facts), or a
+% bound loop variable (an input-iterator projection -> a derived rule).
 emit_tuple_value(int(N)) -->
     signed_integer_value(N),
     !.
 emit_tuple_value(string(S)) -->
     quoted_string(Codes),
+    !,
     { string_codes(S, Codes) }.
+emit_tuple_value(var(V)) -->
+    identifier(V).
 
 printf_action(printf(string(Format), Args)) -->
     "printf",

--- a/tests/test_plawk_gen_blocks.pl
+++ b/tests/test_plawk_gen_blocks.pl
@@ -50,9 +50,19 @@ test(gen_over_query_parses) :-
         "gen over query(num(V)) as v { if (v > 2) emit v } as big\n\c
          pass over query(big(X)) { print $1 }\n",
         program_passes([],
-            [gen_block(name(big), over(query(num, ['V']), v),
+            [gen_block(name(big), over(query(num, ['V']), [v]),
                  [if(forin_key_cmp(v, gt, 2), [emit(var(v))], [])]),
              pass_query(query(big, ['X']), [print([field(1)])])],
+            [])),
+    !.
+
+% A multi-column source with a tuple binding parses to a list of loop vars.
+test(gen_over_multicol_parses) :-
+    plawk_parse_string(
+        "gen over query(edge(A, B)) as (a, b) { emit a } as src\n",
+        program_passes([],
+            [gen_block(name(src), over(query(edge, ['A', 'B']), [a, b]),
+                 [emit(var(a))])],
             [])),
     !.
 
@@ -154,6 +164,30 @@ test(gen_over_filter_and_run, [condition(clang_available)]) :-
     build_run(Dir, 'genand', Src, [], Out, St),
     assertion(St == 0),
     assertion(Out == "2\n3\n4\n"),
+    !.
+
+% A column-projection view: project one column of a two-column source, filtered
+% -- `gen over query(edge(A, B)) as (a, b) { if (a > 1) emit a } as srcs` ->
+% `srcs(A) :- edge(A, _B), A > 1` (only the needed column materialises).
+test(gen_over_projection_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "@prolog\nedge(1, 10).\nedge(2, 20).\nedge(3, 30).\n@end\n\c
+           gen over query(edge(A, B)) as (a, b) { if (a > 1) emit a } as srcs\n\c
+           pass over query(srcs(X)) { print $1 }\n",
+    build_run(Dir, 'vwproj', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "2\n3\n"),
+    !.
+
+% A reordering projection: `emit (b, a)` -> `flipped(B, A) :- edge(A, B)`.
+test(gen_over_reorder_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "@prolog\nedge(1, 10).\nedge(2, 20).\n@end\n\c
+           gen over query(edge(A, B)) as (a, b) { emit (b, a) } as flipped\n\c
+           pass over query(flipped(X, Y)) { print $1, $2 }\n",
+    build_run(Dir, 'vwflip', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "10 1\n20 2\n"),
     !.
 
 % A computed emit (a field, not a constant) in a PURE generator needs runtime


### PR DESCRIPTION
## Summary

Generator PR 5 — the **column-projection view** engine. A generator over a multi-column source can bind a tuple of loop vars and emit a projection/reordering of them, synthesising a derived relation (pure clause synthesis, no new runtime).

- `gen over query(edge(A, B)) as (a, b) { emit a } as srcs` → `srcs(A) :- edge(A, _B)` — project one column of a two-column source (only the needed column materialises).
- Filtered projection: `if (a > 1) emit a` → `srcs(A) :- edge(A, _B), A > 1`.
- Reordering: `emit (b, a)` → `flipped(B, A) :- edge(A, B)`.

Parser: generalised the gen-over `as` binding to a tuple list (`as (a, b)`), added `emit (b, a)` tuple-of-vars parsing. Codegen: `gen_block_supported` / `gen_block_clause` handle a loop-var list, projecting head args from the emit and lowering the guard over the bindings.

A materialised view *is* an auto-cache scoped to a projection + filter — this lands the projection half; materialise-and-cache is the remaining net-new work (`PLAWK_MULTIPASS_CACHE.md` §3.9).

## Tests

`tests/test_plawk_gen_blocks.pl` — 18 pass, including multi-column parse, projection, filtered projection, and reorder end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_