### PR TITLE
WAM/LLVM plawk: auto-coerce function args in text mode (print f($1))

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -51,7 +51,7 @@ only (runtime pending) · ❌ missing.
 
 | Feature | Status | Notes |
 |---|---|---|
-| user functions (`function f(a) { return … }`) | ◐ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts. **Gap: `print f($1)` in text mode returns 0** — the text field isn't coerced into the call. Prioritised below. |
+| user functions (`function f(a) { return … }`) | ✅ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts **and text mode** — `print f($1)` auto-coerces the field (awk semantics). |
 | string: `length` `substr` `index` `tolower` `toupper` | ✅ | native, allocation-free |
 | string: `split` `sub` `gsub` `match` `sprintf` | ❌ | |
 | numeric: `int` | ✅ | `sin`/`cos`/`sqrt`/`rand`/… ❌ (f64 machinery exists) |

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -488,10 +488,31 @@ function_def((Head :- Body)) -->
     function_expr(Params, Pairs, ArithTerm),
     action_block_close,
     { pairs_values(Pairs, Vars),
-      append(Vars, [Result], HeadArgs),
+      % awk auto-coercion: a function body is `Result is ArithTerm`, so every
+      % parameter is used numerically. Text fields arrive as atoms (e.g. '5'),
+      % which `is/2` would reject -- so the head takes a fresh var per param and
+      % coerces it to a number (`number(H) -> V = H ; atom_number(H, V)`) before
+      % the arithmetic. A typed i64 arg (BINFMT mode) is already a number, so it
+      % passes through unchanged; a text field is parsed. No engine change; the
+      % coercion is local to the synthesised clause (PLAWK_AWK_FEATURE_AUDIT.md
+      % gap 2, decision: auto-coerce).
+      length(Vars, NParams),
+      length(HeadVars, NParams),
+      maplist(plawk_fn_coerce_goal, HeadVars, Vars, CoerceGoals),
+      append(HeadVars, [Result], HeadArgs),
       Head =.. [Name | HeadArgs],
-      Body = (Result is ArithTerm)
+      append(CoerceGoals, [Result is ArithTerm], BodyGoals),
+      plawk_conjunction(BodyGoals, Body)
     }.
+
+% The per-parameter numeric coercion goal: pass a number through, parse an atom.
+plawk_fn_coerce_goal(Head, Value,
+    (number(Head) -> Value = Head ; atom_number(Head, Value))).
+
+% Fold a non-empty goal list into a Prolog conjunction.
+plawk_conjunction([Goal], Goal) :- !.
+plawk_conjunction([Goal | Goals], (Goal, Rest)) :-
+    plawk_conjunction(Goals, Rest).
 
 function_params([Param | Params]) -->
     identifier(Param),

--- a/tests/test_plawk_functions.pl
+++ b/tests/test_plawk_functions.pl
@@ -20,17 +20,25 @@ clang_available :-
 test(functions_desugar_to_prolog_clauses) :-
     plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction f(a, b) { return a + b * 2 }\n{ n++ }\nEND { print n }\n",
         _, [Clause]),
-    % awk precedence: * binds tighter than +
-    assertion(Clause = (f(_A, _B, R) :- R is _ + _ * 2)),
+    % auto-coerce prefixes the body with per-param numeric coercion goals; the
+    % final conjunct is the arithmetic. awk precedence: * binds tighter than +.
+    Clause = (f(_A, _B, R) :- Body),
+    fn_body_last(Body, (R is Arith)),
+    assertion(Arith = _ + _ * 2),
     Clause = (f(3, 4, Result) :- Goal),
     call(Goal),
     assertion(Result =:= 11).
 
 test(percent_maps_to_mod_and_parens_group) :-
     plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction g(a, b) { return (a + b) % 7 }\n{ n++ }\nEND { print n }\n",
-        _, [(g(A, B, R) :- R is Goal)]),
-    assertion(Goal == mod(A + B, 7)),
-    ( A = 5, B = 9, V is Goal, assertion(V =:= 0) ).
+        _, [Clause]),
+    Clause = (g(_A, _B, R) :- Body),
+    fn_body_last(Body, (R is Goal)),
+    % % maps to mod and the parens group the sum: mod(_+_, 7)
+    assertion(Goal = mod(_ + _, 7)),
+    Clause = (g(5, 9, V) :- CallGoal),
+    call(CallGoal),
+    assertion(V =:= 0).
 
 test(function_rejections) :-
     % identifiers must be parameters
@@ -49,9 +57,54 @@ test(surface_functions_mix_with_prolog_blocks) :-
     Src = "@prolog\nplawk_fnt_hot(X) :- X > 10.\n@end\nBEGIN { BINFMT = \"i64 f64\" }\nfunction plawk_fnt_twice(a) { return a * 2 }\nplawk_fnt_hot($1) { s += plawk_fnt_twice($1) }\nEND { print s }\n",
     run_fn_smoke(Src, [rec(3, 0.25), rec(20, 0.25), rec(11, 0.25)], "62\n").
 
+% --- auto-coerce (awk semantics): a function called on TEXT fields -----------
+% In text mode (no BINFMT) `$1` is an atom. awk auto-coerces a value used
+% numerically, so `print dbl($1)` must coerce the field to a number before the
+% arithmetic. The synthesized clause wraps each param in
+% `(number(H) -> V = H ; atom_number(H, V))`, so text fields Just Work.
+
+test(auto_coerce_unary_text_field) :-
+    Src = "function dbl(x) { return x * 2 }\n{ print dbl($1) }\n",
+    build_run_text('acdbl', Src, "5\n10\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "10\n20\n").
+
+test(auto_coerce_binary_text_fields) :-
+    Src = "function add(a, b) { return a + b }\n{ print add($1, $2) }\n",
+    build_run_text('acadd', Src, "5 7\n10 23\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "12\n33\n").
+
 :- end_tests(plawk_functions).
 
 % --- helpers ---------------------------------------------------------------
+
+% Peel a body conjunction down to its final conjunct.
+fn_body_last((_, Rest), Last) :- !, fn_body_last(Rest, Last).
+fn_body_last(Goal, Goal).
+
+% Build a text-mode plawk program via the CLI and run it on Input (stdin),
+% capturing stdout. Used for the auto-coerce end-to-end checks.
+build_run_text(Name, Src, Input, Out, RunStatus) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_functions', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ),
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl),
+        ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).
 
 write_i64_le(Out, V) :-
     V64 is V /\ 0xFFFFFFFFFFFFFFFF,


### PR DESCRIPTION
## Summary

A user function `function f(a) { return a * 2 }` desugars to `f(A, R) :- R is A * 2`. In text mode `$1` is an atom, which `is/2` rejects, so `print f($1)` returned `0` — functions only worked on typed (`BINFMT`) fields. This is audit gap 2, decision: **auto-coerce (awk semantics)**.

Every plawk function body is `Result is ArithTerm`, so every parameter is numeric by construction. The synthesised clause now takes a fresh var per param and coerces it inline — `(number(H) -> V = H ; atom_number(H, V))` — before the arithmetic. A typed i64 arg passes through unchanged (`number/1` succeeds); a text field is parsed. No engine change; the coercion is local to the synthesised clause.

## Tests

`tests/test_plawk_functions.pl` — two text-mode end-to-end checks (`print dbl($1)`, `print add($1,$2)`); the two clause-shape unit tests updated to peel the coercion prefix and assert the final arithmetic. 7 pass.

Docs: audit gap 2 → landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_