### PR TITLE
WAM/LLVM plawk: while / do-while loop runtime (PR 2)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -34,8 +34,8 @@ only (runtime pending) · ❌ missing.
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
-| `while (VAR CMP int)` | ⏳ | surface parses; runtime pending — `PLAWK_CONTROL_FLOW_PLAN.md` |
-| `do { } while (VAR CMP int)` | ⏳ | surface parses; shares the loop runtime |
+| `while (VAR CMP int)` | ✅ | runtime landed (loop-header phis) — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2 |
+| `do { } while (VAR CMP int)` | ✅ | runtime landed; body runs at least once |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` / `continue` | ◐ | present in some loop contexts |
 | `if` with a plain (non-accumulator) body | ❌ | `{ if (c) { print $1 } }` is exit 3 — the scalar `if` lowering assumes branch bodies update scalars; blocks regex-in-`if` too |
@@ -88,11 +88,13 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
 
 ## Prioritised gaps (recommended order)
 
-1. **`while` / `do-while` loop runtime** — the surfaces just landed; wire the
-   loop (mutable scalar state to a fixed point). **Plan:**
-   `PLAWK_CONTROL_FLOW_PLAN.md` — bracket each loop with a memory slot (SSA →
-   mem → loop → SSA) so the existing forward-phi scalar machinery is untouched.
-   The most-requested basic control structure still missing at runtime.
+1. **`while` / `do-while` loop runtime — LANDED (PR 2).** The loop iterates its
+   mutable scalar state via **loop-header phis** (reusing `foreach_loop`'s head
+   phis — no memory slots needed after all; see `PLAWK_CONTROL_FLOW_PLAN.md`).
+   Body: `set` / `inc` / `+=` over i64 + `print`; condition `VAR CMP int`.
+   Enablers landed with it: **bare scalar-var print** (`print i`) and a
+   **body-printing scalar chain with no `END`**. PRs 3–4 (general condition,
+   `break`/`continue`, nested/multi-pass loops) remain.
 2. **User-function call in text/print context** — `print f($1)` returns `0`: a
    text field is passed to the foreign call as an *atom*, so the synthesised
    `f(X,R) :- R is X*2` fails `is`. Works in `BINFMT`/typed mode.

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -5,11 +5,20 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk control-flow runtime — implementation plan
 
-**Status**: plan. The `while` and `do-while` **surfaces** parse (they lower to
-`while_loop(Cond, Body)` / `do_while_loop(Body, Cond)` and today emit a clean
-not-yet error); this doc scopes the **runtime**, grounded in how the single-pass
-driver actually lowers scalar state. Prioritised #1 in
-`PLAWK_AWK_FEATURE_AUDIT.md`.
+**Status**: PR 2 **LANDED**. The `while` and `do-while` **surfaces** parse (they
+lower to `while_loop(Cond, Body)` / `do_while_loop(Body, Cond)`) and their
+**runtime** now compiles: an arithmetic/`print` body over an i64 counter,
+condition `VAR CMP int`. PRs 3–4 (general condition, `break`/`continue`, nested
+loops in multi-pass) remain. This doc scopes the runtime, grounded in how the
+single-pass driver lowers scalar state.
+
+> **Implementation note (what actually shipped).** The §2 "bracket with memory"
+> sketch (alloca/load/store) turned out to be unnecessary: the emitter already
+> has a working **loop-header phi** for exactly this shape — `foreach_loop`'s
+> head phis (`plawk_foreach_head_phi_lines`). The while/do-while lowering reuses
+> that machinery directly (SSA back-edge phis, no memory slots), which is
+> simpler and matches the existing style. §2 is kept below as the original
+> reasoning; the head-phi route is what landed.
 
 ## 1. The blocking fact: scalar state is SSA/phi, not memory
 
@@ -64,10 +73,17 @@ while.after.N:
 
 1. **Surface — LANDED.** `while (VAR CMP int) { BODY }` and
    `do { BODY } while (VAR CMP int)` parse; not-yet compile error.
-2. **Runtime, arithmetic body.** Bracket-with-memory lowering for a body of
-   `set` / `inc` / `+=` over i64 scalars + `print`, condition `VAR CMP int`.
-   Deliverable: `{ i = 0; while (i < 3) { print i; i++ } }` prints `0/1/2`, and
-   the `do-while` mirror runs the body once even when the condition starts false.
+2. **Runtime, arithmetic body — LANDED.** Loop-header-phi lowering (reusing
+   `foreach_loop`'s head phis, **not** memory slots) for a body of `set` /
+   `inc` / `+=` over i64 scalars + `print`, condition `VAR CMP int`. `while`
+   tests before the body (exit values are the head phis, so zero iterations is
+   fine); `do-while` tests after (exit values are the body outputs, so the body
+   always runs once). Deliverable met: `{ i = 0; while (i < 3) { print i; i++ }
+   }` prints `0/1/2`; the `do-while` mirror runs the body once even when the
+   condition starts false. Two enablers landed alongside: **printing a bare
+   scalar var** (`print i` — substituted to the slot's SSA value) and a
+   **body-printing scalar chain with no `END`** driver clause (all output from
+   the per-record body). Tests: `tests/test_plawk_while.pl`.
 3. **General condition + `break`/`continue`.** A boolean/expression condition
    (reuse the guard grammar) and loop-control statements.
 4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -108,7 +108,6 @@ build(File, Out0, KeepLL) :-
     % removed; `GenFactClauses` are the synthesised facts.
     check_generator_blocks(File, Program2),
     resolve_generator_blocks(Program2, Program, GenFactClauses),
-    check_while_loops(File, Program),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
     % A query-reader program contributes synthesised findall-wrapper clauses
@@ -364,32 +363,6 @@ check_generator_blocks(File, Program) :-
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
-
-% while / do-while loops (plawk roadmap): `while (VAR CMP int) { BODY }` and
-% `do { BODY } while (VAR CMP int)` parse but their loop runtime -- mutable
-% scalar state iterated to a fixed point -- is not wired yet, so a program that
-% uses one gets a clear, specific diagnostic rather than the generic "outside
-% the multi-pass surface". Surface-first, mirroring the query reader / generator
-% arcs; see PLAWK_CONTROL_FLOW_PLAN.md for the runtime plan.
-check_while_loops(File, Program) :-
-    program_has_while(Program),
-    !,
-    format(user_error,
-        'plawk: ~w uses a `while` / `do-while` loop. Loops parse but their \c
-         runtime is not yet implemented; see PLAWK_CONTROL_FLOW_PLAN.md.~n',
-        [File]),
-    halt(2).
-check_while_loops(_File, _Program).
-
-% True if the program term contains a while_loop/2 or do_while_loop/2 anywhere
-% (rule body, BEGIN, END, pass, ...). A plain structural walk over the AST.
-program_has_while(while_loop(_, _)) :- !.
-program_has_while(do_while_loop(_, _)) :- !.
-program_has_while(Term) :-
-    compound(Term),
-    Term =.. [_ | Args],
-    member(Arg, Args),
-    program_has_while(Arg).
 
 % A generator block whose clauses can be synthesised at build time:
 %  - a pure block (`Source == none`) whose every action is a constant `emit`

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -207,6 +207,60 @@ print_line:
             success, 'success:\n  ret i32 0'),
         DriverIR).
 
+% A body-printing scalar rule chain with NO END block: all output comes from
+% the per-record body (e.g. `{ i = 0; while (i < 3) { print i; i++ } }`). Same
+% lowering as the scalar END-print chain but with an empty print list and NO
+% end_print body -- the end_print block just returns 0 (no trailing newline).
+% Requires a genuine scalar plan (a rule that updates state or prints in its
+% body); writebin-only / query / single-action programs match their own
+% clauses above.
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules0, []),
+    InputPath,
+    DriverIR
+) :-
+    \+ plawk_begin_has_binfmt(BeginClauses),
+    is_list(Rules0),
+    plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules1, WritebinPlan),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_resolve_dynrec_view_rules(Rules1, Rules1b),
+    plawk_resolve_foreach_rules(FieldSeparator, Rules1b, Rules),
+    plawk_scalar_state_plan(Rules, [], StatePlan),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR0),
+    plawk_writebin_entry_lines(WritebinPlan, WritebinEntryIR),
+    plawk_join_nonempty_ir([BeginIR0, WritebinEntryIR], BeginIR),
+    plawk_record_program_ok(FieldSeparator, Rules, []),
+    plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator,
+        RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    plawk_rules_writebin_exprs(Rules, WritebinExprs),
+    append(BodyPrintFields, WritebinExprs, PrintExprs0),
+    append(PrintExprs0, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
+    plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
+    plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
+    plawk_scalar_rule_controls(Rules, ScalarRuleControls),
+    plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, NextPhiIR),
+    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, done,
+        BreakCloseIR, FinalStatePhiIR),
+    plawk_writebin_globals(WritebinPlan, WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, RuleGlobalIR, WritebinGlobalIR]),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w
+  ret i32 0',
+        [FinalStatePhiIR]),
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
+        driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
+            NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 plawk_program_native_driver_ir(
     program(BeginClauses, Rules, [end([print(PrintFields)])]),
     InputPath,
@@ -4791,6 +4845,29 @@ plawk_icmp_pred(le, sle).
 plawk_icmp_pred(gt, sgt).
 plawk_icmp_pred(ge, sge).
 
+%% plawk_while_cond_ok(+Cond) is semidet.
+%
+%  A supported loop condition: `VAR CMP int(N)` over an i64 comparison.
+plawk_while_cond_ok(cmp(var(_V), Op, int(N))) :-
+    integer(N),
+    plawk_icmp_pred(Op, _Pred).
+
+%% plawk_while_cond_ir(+Cond, +Slots, +CondValues, +Base, -CondVar, -IR)
+%
+%  Emit the loop-condition icmp. The condition variable's current value is the
+%  slot value in CondValues (head-phi values for `while`, body-output values
+%  for `do-while`); compare it against the integer bound.
+plawk_while_cond_ir(cmp(var(CondName), Op, int(N)), Slots, CondValues, Base,
+        CondVar, IR) :-
+    nth0(Idx, Slots, Slot),
+    plawk_slot_name(Slot, CondName),
+    !,
+    nth0(Idx, CondValues, CondValRef),
+    plawk_icmp_pred(Op, Pred),
+    format(atom(CondVar), '%~w_cond', [Base]),
+    format(atom(IR), '  ~w = icmp ~w i64 ~w, ~w',
+        [CondVar, Pred, CondValRef, N]).
+
 % Surface comparison op -> ordered LLVM fcmp predicate (row values are finite,
 % so ordered comparisons are correct; a NaN column fails every guard).
 plawk_fcmp_pred(eq, oeq).
@@ -5676,6 +5753,10 @@ plawk_action_has_control(if(_Pattern, ThenActions, ElseActions)) :-
     ).
 plawk_action_has_control(foreach_loop(_Layout, Body)) :-
     plawk_branch_actions_have_unsupported_control(Body).
+plawk_action_has_control(while_loop(_Cond, Body)) :-
+    plawk_branch_actions_have_unsupported_control(Body).
+plawk_action_has_control(do_while_loop(Body, _Cond)) :-
+    plawk_branch_actions_have_unsupported_control(Body).
 
 plawk_branch_actions_have_unsupported_control(Actions) :-
     plawk_trim_control_tails(Actions, TrimmedActions),
@@ -5852,6 +5933,16 @@ plawk_scalar_update_name_expr(if(_Pattern, ThenActions, ElseActions), Name, Expr
 plawk_scalar_update_name_expr(foreach_loop(_Layout, Body), Name, Expr) :-
     member(Action, Body),
     plawk_scalar_update_name_expr(Action, Name, Expr).
+% while/do-while: the condition variable gets an i64 slot (it is compared with
+% an integer), plus any scalar the body updates.
+plawk_scalar_update_name_expr(while_loop(cmp(var(CondVar), _Op, _N), Body), Name, Expr) :-
+    ( Name = CondVar, Expr = int(0)
+    ; member(Action, Body), plawk_scalar_update_name_expr(Action, Name, Expr)
+    ).
+plawk_scalar_update_name_expr(do_while_loop(Body, cmp(var(CondVar), _Op, _N)), Name, Expr) :-
+    ( Name = CondVar, Expr = int(0)
+    ; member(Action, Body), plawk_scalar_update_name_expr(Action, Name, Expr)
+    ).
 
 plawk_scalar_double_fixpoint(Updates, Doubles0, Doubles) :-
     findall(Name,
@@ -5978,6 +6069,10 @@ plawk_action_body_print_field(if(_Pattern, ThenActions, ElseActions), Field) :-
     ;   plawk_actions_body_print_field(ElseActions, Field)
     ).
 plawk_action_body_print_field(foreach_loop(_Layout, Body), Field) :-
+    plawk_actions_body_print_field(Body, Field).
+plawk_action_body_print_field(while_loop(_Cond, Body), Field) :-
+    plawk_actions_body_print_field(Body, Field).
+plawk_action_body_print_field(do_while_loop(Body, _Cond), Field) :-
     plawk_actions_body_print_field(Body, Field).
 
 plawk_mixed_planned_rules([], _AssocPlan, _Index) -->
@@ -7733,6 +7828,12 @@ plawk_binfmt_action_ok(Descriptor, writebin_arm_out(_Tag, ArmTypes, Fields)) :-
     !,
     plawk_binfmt_writebin_args_ok(Descriptor, ArmTypes, Fields).
 plawk_binfmt_action_ok(Descriptor, foreach_loop(_Layout, Body)) :-
+    !,
+    plawk_binfmt_actions_ok(Descriptor, Body).
+plawk_binfmt_action_ok(Descriptor, while_loop(_Cond, Body)) :-
+    !,
+    plawk_binfmt_actions_ok(Descriptor, Body).
+plawk_binfmt_action_ok(Descriptor, do_while_loop(Body, _Cond)) :-
     !,
     plawk_binfmt_actions_ok(Descriptor, Body).
 
@@ -10040,6 +10141,12 @@ plawk_scalar_rule_body_action(writebin_arm_out(_Tag, ArmTypes, Fields)) :-
     plawk_writebin_args_ok(ArmTypes, Fields).
 plawk_scalar_rule_body_action(foreach_loop(_Layout, Body)) :-
     plawk_scalar_branch_body_actions(Body).
+plawk_scalar_rule_body_action(while_loop(Cond, Body)) :-
+    plawk_while_cond_ok(Cond),
+    plawk_scalar_branch_body_actions(Body).
+plawk_scalar_rule_body_action(do_while_loop(Body, Cond)) :-
+    plawk_while_cond_ok(Cond),
+    plawk_scalar_branch_body_actions(Body).
 plawk_scalar_rule_body_action(if(_Pattern, ThenActions, ElseActions)) :-
     append(ThenActions, ElseActions, Actions),
     Actions \== [],
@@ -10078,6 +10185,10 @@ plawk_rule_body_print_action(printf(string(Format), Args)) :-
 
 plawk_rule_body_print_field(field(_)).
 plawk_rule_body_print_field(string(_)).
+% a bare scalar variable read (`print i`): substitution rewrites var(Name) to
+% the slot's SSA value at emit time, so a scalar can be printed directly. Only
+% names that resolve to a slot compile; a non-slot var fails substitution.
+plawk_rule_body_print_field(var(_)).
 plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(int(field(_))).
@@ -10767,6 +10878,14 @@ plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
 plawk_scalar_update_action_name(foreach_loop(_Layout, Body), Name) :-
     member(Action, Body),
     plawk_scalar_update_action_name(Action, Name).
+plawk_scalar_update_action_name(while_loop(cmp(var(CondVar), _Op, _N), Body), Name) :-
+    ( Name = CondVar
+    ; member(Action, Body), plawk_scalar_update_action_name(Action, Name)
+    ).
+plawk_scalar_update_action_name(do_while_loop(Body, cmp(var(CondVar), _Op, _N)), Name) :-
+    ( Name = CondVar
+    ; member(Action, Body), plawk_scalar_update_action_name(Action, Name)
+    ).
 
 plawk_expr_scalar_read_name(var(Name), Name).
 plawk_expr_scalar_read_name(Expr, Name) :-
@@ -11064,6 +11183,139 @@ plawk_scalar_action_sequence_pairs([foreach_loop(Layout, Body) | Rest],
     [GlobalIR-IR],
     plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
         NextOpIndex, HeadValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
+    { append(InnerNextExits, RestNextExits, NextExits) }.
+% while_loop: a surface loop. Loop-carried head phis for every scalar slot
+% (modelled on foreach_loop's head-phi machinery -- no memory slots needed).
+% The condition tests the condition variable's head-phi value BEFORE the body,
+% so the loop may run zero times; the exit values are the head phis themselves.
+% (PLAWK_CONTROL_FLOW_PLAN.md PR 2.)
+plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
+        Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { format(atom(Base), '~w_while_~w', [Prefix, OpIndex]),
+      format(atom(EntryLabel), '~w_entry', [Base]),
+      format(atom(HeadLabel), '~w_head', [Base]),
+      format(atom(BodyLabel), '~w_body', [Base]),
+      format(atom(BodyDoneLabel), '~w_body_done', [Base]),
+      format(atom(AfterLabel), '~w_after', [Base]),
+      findall(PhiValue,
+          ( nth0(SlotIndex, Slots, _Slot),
+            format(atom(PhiValue), '%~w_slot_~w', [Base, SlotIndex])
+          ),
+          HeadValues),
+      phrase(plawk_scalar_action_sequence_pairs(Body, Slots, AssocPlan,
+          FieldSeparator, OutputSeparator, Base, BodyLabel, RuleIndex, 0,
+          HeadValues, BodyOutValues, _InnerOpIndex, InnerExitLabel,
+          InnerNextExits), BodyPairs),
+      pairs_keys_values(BodyPairs, BodyGlobalParts, BodyLineParts),
+      atomic_list_concat(BodyGlobalParts, '\n', GlobalIR),
+      atomic_list_concat(BodyLineParts, '\n', BodyIR),
+      plawk_branch_to_done_ir(InnerExitLabel, BodyDoneLabel, BodyDoneBrIR),
+      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BodyOutValues,
+          Base, EntryLabel, BodyDoneLabel, 0), HeadPhiLines),
+      atomic_list_concat(HeadPhiLines, '\n', HeadPhiIR),
+      % the condition reads the head-phi value of the condition variable
+      plawk_while_cond_ir(Cond, Slots, HeadValues, Base, CondVar, CondIR),
+      format(atom(IR),
+'  br label %~w
+
+~w:
+  br label %~w
+
+~w:
+~w
+~w
+  br i1 ~w, label %~w, label %~w
+
+~w:
+~w
+~w
+
+~w:
+  br label %~w
+
+~w:',
+          [EntryLabel,
+           EntryLabel,
+           HeadLabel,
+           HeadLabel,
+           HeadPhiIR,
+           CondIR,
+           CondVar, BodyLabel, AfterLabel,
+           BodyLabel,
+           BodyIR,
+           BodyDoneBrIR,
+           BodyDoneLabel,
+           HeadLabel,
+           AfterLabel]),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
+        NextOpIndex, HeadValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
+    { append(InnerNextExits, RestNextExits, NextExits) }.
+% do_while_loop: like while_loop but the condition tests AFTER the body, so the
+% body always runs at least once. The head phi sits at the top of the body
+% block; the condition reads the body's OUTPUT values (the exit values), since
+% control reaches `after` from the post-body condition test.
+plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
+        Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { format(atom(Base), '~w_dowhile_~w', [Prefix, OpIndex]),
+      format(atom(EntryLabel), '~w_entry', [Base]),
+      format(atom(BodyLabel), '~w_body', [Base]),
+      format(atom(BodyDoneLabel), '~w_body_done', [Base]),
+      format(atom(AfterLabel), '~w_after', [Base]),
+      findall(PhiValue,
+          ( nth0(SlotIndex, Slots, _Slot),
+            format(atom(PhiValue), '%~w_slot_~w', [Base, SlotIndex])
+          ),
+          HeadValues),
+      phrase(plawk_scalar_action_sequence_pairs(Body, Slots, AssocPlan,
+          FieldSeparator, OutputSeparator, Base, BodyLabel, RuleIndex, 0,
+          HeadValues, BodyOutValues, _InnerOpIndex, InnerExitLabel,
+          InnerNextExits), BodyPairs),
+      pairs_keys_values(BodyPairs, BodyGlobalParts, BodyLineParts),
+      atomic_list_concat(BodyGlobalParts, '\n', GlobalIR),
+      atomic_list_concat(BodyLineParts, '\n', BodyIR),
+      plawk_branch_to_done_ir(InnerExitLabel, BodyDoneLabel, BodyDoneBrIR),
+      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BodyOutValues,
+          Base, EntryLabel, BodyDoneLabel, 0), HeadPhiLines),
+      atomic_list_concat(HeadPhiLines, '\n', HeadPhiIR),
+      % the condition reads the body's output value of the condition variable
+      plawk_while_cond_ir(Cond, Slots, BodyOutValues, Base, CondVar, CondIR),
+      format(atom(IR),
+'  br label %~w
+
+~w:
+  br label %~w
+
+~w:
+~w
+~w
+~w
+
+~w:
+~w
+  br i1 ~w, label %~w, label %~w
+
+~w:',
+          [EntryLabel,
+           EntryLabel,
+           BodyLabel,
+           BodyLabel,
+           HeadPhiIR,
+           BodyIR,
+           BodyDoneBrIR,
+           BodyDoneLabel,
+           CondIR,
+           CondVar, BodyLabel, AfterLabel,
+           AfterLabel]),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
+        NextOpIndex, BodyOutValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
     { append(InnerNextExits, RestNextExits, NextExits) }.
 plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest],
         Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex, OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
@@ -12710,6 +12962,14 @@ plawk_emit_print_expr_for_context(int(field(FieldIndex)), FieldSeparator, Contex
     plawk_print_expr_value_base(Context, int, Base),
     plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
     plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, Base,
+        ValueIR, GlobalParts, SetupParts).
+% a substituted scalar read (var(Name) -> ssa(SlotValue)): print the i64 SSA
+% value directly. This is what makes `print i` work for a scalar slot.
+plawk_emit_print_expr_for_context(ssa(Value), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, int, Base),
+    plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(ssa(Value), FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(Expr, FieldSeparator, Context,

--- a/tests/test_plawk_while.pl
+++ b/tests/test_plawk_while.pl
@@ -52,21 +52,60 @@ test(do_while_parses) :-
             [])),
     !.
 
-% Building a program with a while loop is a clean compile error (exit 2) until
-% the loop runtime lands.
-test(while_is_not_yet_error) :-
+% RUNTIME (PLAWK_CONTROL_FLOW_PLAN.md PR 2): a `while` loop iterates its
+% mutable scalar state via loop-carried head phis. `{ i = 0; while (i < 3) {
+% print i; i++ } }` prints 0/1/2 and stops.
+test(while_runtime_counts, [condition(clang_available)]) :-
     wdir(Dir),
     Src = "{ i = 0; while (i < 3) { print i; i++ } }\n",
-    build_status(Dir, 'w', Src, St),
-    assertion(St == 2),
+    build_run(Dir, 'w', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
     !.
 
-% A do-while loop is likewise a clean not-yet error (shares the loop runtime).
-test(do_while_is_not_yet_error) :-
+% A `while` whose condition is false at entry runs the body ZERO times.
+test(while_runtime_zero_iterations, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ i = 5; while (i < 3) { print i; i++ } }\n",
+    build_run(Dir, 'wz', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == ""),
+    !.
+
+% `do-while` runs the body at least once even when the condition starts false.
+test(do_while_runtime_runs_once, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ i = 5; do { print i; i++ } while (i < 3) }\n",
+    build_run(Dir, 'dw1', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "5\n"),
+    !.
+
+% `do-while` iterates when the condition holds.
+test(do_while_runtime_counts, [condition(clang_available)]) :-
     wdir(Dir),
     Src = "{ i = 0; do { print i; i++ } while (i < 3) }\n",
-    build_status(Dir, 'dw', Src, St),
-    assertion(St == 2),
+    build_run(Dir, 'dw', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+% The loop restarts per record (mutable state does not leak between records).
+test(while_runtime_per_record, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ i = 0; while (i < 2) { print i; i++ } }\n",
+    build_run(Dir, 'wpr', Src, "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n0\n1\n"),
+    !.
+
+% A loop that accumulates into a scalar read from END.
+test(while_runtime_accumulate_to_end, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ s = 0; i = 0; while (i < 4) { s += i; i++ } }\nEND { print s }\n",
+    build_run(Dir, 'wacc', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "6\n"),
     !.
 
 % A program with no while loop is unaffected (no false trigger).
@@ -100,3 +139,21 @@ build_status(Dir, Name, Src, Status) :-
     process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
         [stdout(null), stderr(null), process(Pid)]),
     process_wait(Pid, exit(Status)).
+
+% Build a program, then run the binary on Input (stdin), capturing stdout.
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

The `while` / `do-while` surfaces parsed but their runtime emitted a not-yet error. This wires the runtime. The plan's blocking fact — scalar state is SSA/phi with no memory slots — turned out to be **already solved**: the emitter's `foreach_loop` lowering carries loop state through **loop-header phis** (`plawk_foreach_head_phi_lines`). The while/do-while lowering reuses that head-phi machinery directly (SSA back-edge phis, no alloca bracket needed — the doc's §2 memory-slot sketch was unnecessary).

- **`while_loop`**: head phi per scalar slot at the loop header; the condition tests the head-phi value **before** the body, so the loop may run zero times and the exit values are the head phis themselves.
- **`do_while_loop`**: the head phi sits at the top of the body; the condition tests the body's **output** values **after** the body, so the body always runs once.
- Body reuses the full scalar action-sequence machinery (prints, updates, nested ifs). Condition is `VAR CMP int` over an i64 counter.

Two enablers landed alongside, both needed by the deliverable `{ i = 0; while (i < 3) { print i; i++ } }`:

- **bare scalar-var print** (`print i`): validation accepts `var(_)`; the existing var→ssa substitution + a new `ssa()` print-context clause emit the i64 value.
- **a body-printing scalar rule chain with no `END`**: a new driver clause lowers the chain with an empty `end_print` (all output from the per-record body, no trailing newline).

Removed the `check_while_loops` not-yet gate. Discovery/validation clauses (state plan, print-field walk, binfmt-ok, body-action) mirror `foreach_loop`.

## Tests

`tests/test_plawk_while.pl` now runs the loops end-to-end (count, zero iterations, do-while-once, per-record reset, accumulate-to-END) — 10 pass. Regression: functions, gen_blocks, query_reader, print_literals, prefix_print (221), arith_exprs, else_if, end_scalar_exprs, crosspass_scalar all green.

Docs: `PLAWK_CONTROL_FLOW_PLAN.md` PR 2 LANDED (head-phi note); audit gap 1 done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_