### PR TITLE
WAM/LLVM plawk: optional function-arg typing (typed-fast path)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -51,7 +51,7 @@ only (runtime pending) · ❌ missing.
 
 | Feature | Status | Notes |
 |---|---|---|
-| user functions (`function f(a) { return … }`) | ✅ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts **and text mode** — `print f($1)` auto-coerces the field (awk semantics). |
+| user functions (`function f(a) { return … }`) | ✅ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts **and text mode** — `print f($1)` auto-coerces the field (awk semantics). Optional numeric arg typing (`function f(num x)`) skips the coercion (typed-fast path). |
 | string: `length` `substr` `index` `tolower` `toupper` | ✅ | native, allocation-free |
 | string: `split` `sub` `gsub` `match` `sprintf` | ❌ | |
 | numeric: `int` | ✅ | `sin`/`cos`/`sqrt`/`rand`/… ❌ (f64 machinery exists) |
@@ -95,29 +95,27 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    Enablers landed with it: **bare scalar-var print** (`print i`) and a
    **body-printing scalar chain with no `END`**. PRs 3–4 (general condition,
    `break`/`continue`, nested/multi-pass loops) remain.
-2. **User-function call in text/print context** — `print f($1)` returns `0`: a
-   text field is passed to the foreign call as an *atom*, so the synthesised
-   `f(X,R) :- R is X*2` fails `is`. Works in `BINFMT`/typed mode.
-   **Decision: auto-coerce (awk semantics).** A field (a string) used in a
-   numeric context coerces to a number, matching AWK. Implementation options
-   (a design call for the PR, not the surface): coerce in the WAM arithmetic
-   builtins (an atom operand of `is`/`>`/`*`/… parses to a number — most
-   awk-faithful, but the WAM engine is shared, so scope/gate it to avoid
-   changing Prolog `is/2` for non-plawk callers), or coerce the field arg at the
-   plawk call boundary when the callee uses it numerically (needs light body
-   inference). No explicit `num($1)` is required of the user.
-   *Future direction — a **performance** lever, not just safety:* **optional
-   type annotations** on function inputs (e.g. `function f(num x)` / a `:- ftype`
-   directive). Because plawk compiles to **typed WAM**, a declared arg type would
-   (a) **skip the runtime coercion** — the value is already the right type, so
-   the hot path pays nothing (auto-coerce parses `atom → number` on every call),
-   and (b) enable **compile-time type checking** (a mismatched call is an error).
-   This is the same principle as explicit `emit` in generators
-   (`PLAWK_GENERATOR_BLOCKS.md` §2.1): **static type knowledge lets the compiler
-   elide coercion and serialisation.** Given the per-call coercion cost, this
-   ranks higher than a pure nice-to-have — it is the typed-fast path over the
-   dynamic-correct default. Layered *on* auto-coerce (which stays the annotation-
-   free default), not instead of it; whether/when to build it is open.
+2. **User-function call in text/print context — LANDED (auto-coerce).**
+   `print f($1)` used to return `0`: a text field reached the synthesised
+   `f(X,R) :- R is X*2` as an *atom*, failing `is`. Now the synthesised clause
+   coerces each untyped param inline — `(number(H) -> V = H ; atom_number(H, V))`
+   — so a text field parses to a number (awk semantics) while a typed i64 arg
+   (`BINFMT`) passes straight through. No engine change, no `num($1)` required.
+   *Typed-fast path — LANDED (optional arg typing).* An optional numeric type
+   annotation, `function f(num x)` (also `int` / `float`), declares the param
+   already-numeric, so the synthesised clause **skips the coercion goal** — the
+   head var *is* the value var. Because plawk compiles to **typed WAM**, a
+   declared arg carries in its native representation and the hot path pays
+   nothing (auto-coerce otherwise runs `number/1` every call). This is the same
+   principle as explicit `emit` (`PLAWK_GENERATOR_BLOCKS.md` §2.1,
+   `UNIFYWEAVER_LANGUAGE_PRINCIPLES.md` Principle 2): **static type knowledge
+   elides coercion.** It is layered *on* auto-coerce (the annotation-free
+   default), not instead of it; an unannotated param still auto-coerces. In text
+   mode a typed param is a contract that the arg is numeric — a bare text field
+   passed to it is the caller's responsibility. *Still open (follow-on):*
+   compile-time **type checking** of call sites (a mismatched call → error) and
+   distinguishing `int` vs `float` for representation; all three keywords
+   currently mean "numeric, skip coercion".
 2b. **`if` with a plain guarded body** — `{ if (c) { print $1 } }` doesn't
    compile (the scalar `if` lowering assumes branch bodies update scalars); this
    is what actually blocks regex-in-`if`. Fix the `if`-body lowering.

--- a/docs/design/UNIFYWEAVER_LANGUAGE_PRINCIPLES.md
+++ b/docs/design/UNIFYWEAVER_LANGUAGE_PRINCIPLES.md
@@ -137,13 +137,13 @@ the correct-but-slower default.
   §2.1): `emit E` materialises a *typed* value straight into the tagged column
   table — no text exists. An FS-split yield would `print` to text and re-parse
   it, a serialize→text→deserialize cost per value. Known type ⇒ no round-trip.
-- **Optional function-arg typing over auto-coerce**
-  (`PLAWK_AWK_FEATURE_AUDIT.md` gap 2): the awk-faithful default auto-coerces a
+- **Optional function-arg typing over auto-coerce** (LANDED —
+  `PLAWK_AWK_FEATURE_AUDIT.md` gap 2): the awk-faithful default auto-coerces a
   text field used numerically (`atom → number` every call); a declared
   `function f(num x)` lets the compiler pass an already-typed value and skip the
-  coercion — the typed-fast path over the dynamic-correct default. (It also
-  turns a type mismatch into a compile error — the safety face of the same
-  knowledge.)
+  coercion goal entirely — the typed-fast path over the dynamic-correct default.
+  (The safety face — turning a type mismatch into a compile error — is the
+  follow-on; today the annotation buys the elision.)
 - **Typed binary records (`BINFMT`)** vs text fields: a declared record layout
   reads fields as native `i64`/`f64` with no per-field string parse.
 - **The query reader's per-column tagged materialisation**

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -476,7 +476,7 @@ function_def((Head :- Body)) -->
     ws,
     "(",
     ws,
-    function_params(Params),
+    function_params(Params, ParamTypes),
     ws,
     ")",
     ws,
@@ -488,45 +488,66 @@ function_def((Head :- Body)) -->
     function_expr(Params, Pairs, ArithTerm),
     action_block_close,
     { pairs_values(Pairs, Vars),
-      % awk auto-coercion: a function body is `Result is ArithTerm`, so every
-      % parameter is used numerically. Text fields arrive as atoms (e.g. '5'),
-      % which `is/2` would reject -- so the head takes a fresh var per param and
-      % coerces it to a number (`number(H) -> V = H ; atom_number(H, V)`) before
-      % the arithmetic. A typed i64 arg (BINFMT mode) is already a number, so it
-      % passes through unchanged; a text field is parsed. No engine change; the
-      % coercion is local to the synthesised clause (PLAWK_AWK_FEATURE_AUDIT.md
-      % gap 2, decision: auto-coerce).
-      length(Vars, NParams),
-      length(HeadVars, NParams),
-      maplist(plawk_fn_coerce_goal, HeadVars, Vars, CoerceGoals),
+      % awk auto-coercion (PLAWK_AWK_FEATURE_AUDIT.md gap 2): a function body is
+      % `Result is ArithTerm`, so every parameter is used numerically. Text
+      % fields arrive as atoms (e.g. '5'), which `is/2` would reject -- so an
+      % UNTYPED parameter takes a fresh head var that is coerced to a number
+      % (`number(H) -> V = H ; atom_number(H, V)`) before the arithmetic.
+      %
+      % An OPTIONAL type annotation (`function f(num x)`) is a typed-fast path:
+      % the declared param is already numeric, so the head var IS the value var
+      % -- no coercion goal at all (Principle 2: static type knowledge elides
+      % the runtime coercion). The dynamic default (auto-coerce) stays for
+      % unannotated params; the annotation buys the elision, layered on top.
+      maplist(plawk_fn_param_binding, ParamTypes, Vars, HeadVars, CoerceGoals0),
+      exclude(==(true), CoerceGoals0, CoerceGoals),
       append(HeadVars, [Result], HeadArgs),
       Head =.. [Name | HeadArgs],
       append(CoerceGoals, [Result is ArithTerm], BodyGoals),
       plawk_conjunction(BodyGoals, Body)
     }.
 
-% The per-parameter numeric coercion goal: pass a number through, parse an atom.
-plawk_fn_coerce_goal(Head, Value,
+% Per-parameter head-var binding. Untyped: a fresh head var coerced to a number.
+% Typed (numeric): the head var IS the value var, so no coercion goal (`true`,
+% filtered out) -- the declared arg is already the right type.
+plawk_fn_param_binding(untyped, Value, Head,
     (number(Head) -> Value = Head ; atom_number(Head, Value))).
+plawk_fn_param_binding(number, Value, Value, true).
 
 % Fold a non-empty goal list into a Prolog conjunction.
 plawk_conjunction([Goal], Goal) :- !.
 plawk_conjunction([Goal | Goals], (Goal, Rest)) :-
     plawk_conjunction(Goals, Rest).
 
-function_params([Param | Params]) -->
-    identifier(Param),
-    function_params_rest(Params).
+function_params([Param | Params], [Type | Types]) -->
+    function_param(Param, Type),
+    function_params_rest(Params, Types).
 
-function_params_rest([Param | Params]) -->
+function_params_rest([Param | Params], [Type | Types]) -->
     ws,
     ",",
     ws,
     !,
-    identifier(Param),
-    function_params_rest(Params).
-function_params_rest([]) -->
+    function_param(Param, Type),
+    function_params_rest(Params, Types).
+function_params_rest([], []) -->
     [].
+
+% A parameter is an identifier, optionally prefixed by a numeric type keyword
+% (`num` / `int` / `float`). The typed form is tried first; it backtracks to an
+% untyped param when the keyword is actually the parameter's own name (e.g.
+% `function f(num)` -- `num` is the name, not a type).
+function_param(Name, number) -->
+    param_type_keyword,
+    identifier_boundary,
+    ws,
+    identifier(Name).
+function_param(Name, untyped) -->
+    identifier(Name).
+
+param_type_keyword --> "num".
+param_type_keyword --> "int".
+param_type_keyword --> "float".
 
 % arithmetic over the parameters, with awk precedence: * / % bind
 % tighter than + -, both associate left, parentheses group

--- a/tests/test_plawk_functions.pl
+++ b/tests/test_plawk_functions.pl
@@ -57,6 +57,46 @@ test(surface_functions_mix_with_prolog_blocks) :-
     Src = "@prolog\nplawk_fnt_hot(X) :- X > 10.\n@end\nBEGIN { BINFMT = \"i64 f64\" }\nfunction plawk_fnt_twice(a) { return a * 2 }\nplawk_fnt_hot($1) { s += plawk_fnt_twice($1) }\nEND { print s }\n",
     run_fn_smoke(Src, [rec(3, 0.25), rec(20, 0.25), rec(11, 0.25)], "62\n").
 
+% --- optional arg typing (typed-fast path over auto-coerce) ------------------
+% `function f(num x)` declares x numeric, so the synthesized clause skips the
+% auto-coercion goal -- the head var IS the value var (Principle 2: static type
+% knowledge elides the runtime coercion). Layered on auto-coerce, which stays
+% the default for unannotated params.
+
+test(typed_param_skips_coercion) :-
+    plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction f(num x) { return x * 2 }\n{ n++ }\nEND { print n }\n",
+        _, [Clause]),
+    % no coercion prefix: the body is exactly the arithmetic
+    assertion(Clause = (f(X, R) :- R is X * 2)),
+    Clause = (f(5, Result) :- Goal),
+    call(Goal),
+    assertion(Result =:= 10).
+
+test(untyped_param_still_coerces) :-
+    plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction g(x) { return x * 2 }\n{ n++ }\nEND { print n }\n",
+        _, [Clause]),
+    Clause = (g(_X, R) :- Body),
+    fn_body_last(Body, (R is _Arith)),
+    % the body has a coercion conjunct before the arithmetic (not a bare `is`)
+    assertion(Body = (_Coerce, _Rest)).
+
+test(mixed_typed_untyped_params) :-
+    plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction h(num a, b) { return a + b }\n{ n++ }\nEND { print n }\n",
+        _, [Clause]),
+    % a is typed (no coercion), b is untyped (one coercion goal) -> exactly one
+    % coercion conjunct precedes the `is`
+    Clause = (h(_A, _B, R) :- (Coerce, R is _Arith)),
+    assertion(Coerce = (number(_) -> _ ; _)),
+    Clause = (h(4, 6, V) :- FullGoal),
+    call(FullGoal),
+    assertion(V =:= 10).
+
+% A typed function used end-to-end in i64 (BINFMT) mode: the field is already a
+% number, so the typed-fast path runs with no coercion.
+test(typed_function_binfmt_end_to_end) :-
+    Src = "BEGIN { BINFMT = \"i64 f64\" }\nfunction plawk_fnt_scale(num a, num b) { return a * b + 1 }\n{ s += plawk_fnt_scale($1, $1) }\nEND { print s }\n",
+    run_fn_smoke(Src, [rec(3, 0.25), rec(5, 0.25)], "36\n").
+
 % --- auto-coerce (awk semantics): a function called on TEXT fields -----------
 % In text mode (no BINFMT) `$1` is an atom. awk auto-coerces a value used
 % numerically, so `print dbl($1)` must coerce the field to a number before the


### PR DESCRIPTION
## Summary

Auto-coerce (previous PR) makes `print f($1)` work by coercing every param inline. An optional numeric type annotation lets a caller opt out of that per-call coercion — the typed-fast path over the dynamic-correct default (Principle 2: static type knowledge elides coercion).

`function f(num x) { return x * 2 }` (also `int` / `float`) declares x already-numeric, so the synthesised clause **skips the coercion goal** — the head var *is* the value var: `f(X, R) :- R is X * 2`. Because plawk compiles to typed WAM, a declared arg carries in its native representation and the hot path pays nothing. Layered **on** auto-coerce, not instead of it: an unannotated param still auto-coerces, so mixed `function h(num a, b)` coerces only `b`.

Parser: a param is `[type_kw] identifier`; the typed form is tried first and backtracks to an untyped param when the keyword is actually the param's own name (`function f(num)` → `num` is the name). Synthesis maps untyped → a coercion goal, typed → identity (no goal, filtered out).

**Semantics:** in text mode a typed param is a contract that the arg is numeric — passing a bare text field to it is the caller's responsibility. *Follow-on (open):* compile-time type checking of call sites (a mismatched call → error) and distinguishing `int` vs `float`; all three keywords currently mean "numeric, skip coercion".

## Tests

4 new in `tests/test_plawk_functions.pl` (typed skips coercion, untyped still coerces, mixed, typed BINFMT end-to-end) — 11 pass.

Docs: audit gap 2 typed path LANDED; `UNIFYWEAVER_LANGUAGE_PRINCIPLES.md` Principle 2 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_