### PR TITLE
WAM/LLVM plawk: while general condition (control-flow PR 3)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -34,8 +34,8 @@ only (runtime pending) · ❌ missing.
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
-| `while (VAR CMP int)` | ✅ | runtime landed (loop-header phis) — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2 |
-| `do { } while (VAR CMP int)` | ✅ | runtime landed; body runs at least once |
+| `while (COND)` | ✅ | runtime landed (loop-header phis); condition is scalar comparisons (`VAR CMP int`/`VAR`) combined with `&&`/`||` — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2–3. `break`/`continue` deferred (PR 3b) |
+| `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` / `continue` | ◐ | present in some loop contexts |
 | `if` with a plain (non-accumulator) body | ❌ | `{ if (c) { print $1 } }` is exit 3 — the scalar `if` lowering assumes branch bodies update scalars; blocks regex-in-`if` too |
@@ -91,10 +91,12 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
 1. **`while` / `do-while` loop runtime — LANDED (PR 2).** The loop iterates its
    mutable scalar state via **loop-header phis** (reusing `foreach_loop`'s head
    phis — no memory slots needed after all; see `PLAWK_CONTROL_FLOW_PLAN.md`).
-   Body: `set` / `inc` / `+=` over i64 + `print`; condition `VAR CMP int`.
-   Enablers landed with it: **bare scalar-var print** (`print i`) and a
-   **body-printing scalar chain with no `END`**. PRs 3–4 (general condition,
-   `break`/`continue`, nested/multi-pass loops) remain.
+   Body: `set` / `inc` / `+=` over i64 + `print`. Enablers landed with it:
+   **bare scalar-var print** (`print i`) and a **body-printing scalar chain with
+   no `END`**. **PR 3 (general condition) also LANDED**: the condition is now
+   scalar comparisons `VAR CMP (int | VAR)` combined with `&&` / `||`. Remaining:
+   `break` / `continue` (PR 3b — SSA phi-merge + break's rule-vs-loop semantics)
+   and nested / multi-pass loops (PR 4).
 2. **User-function call in text/print context — LANDED (auto-coerce).**
    `print f($1)` used to return `0`: a text field reached the synthesised
    `f(X,R) :- R is X*2` as an *atom*, failing `is`. Now the synthesised clause

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -84,8 +84,30 @@ while.after.N:
    scalar var** (`print i` — substituted to the slot's SSA value) and a
    **body-printing scalar chain with no `END`** driver clause (all output from
    the per-record body). Tests: `tests/test_plawk_while.pl`.
-3. **General condition + `break`/`continue`.** A boolean/expression condition
-   (reuse the guard grammar) and loop-control statements.
+3. **General condition — LANDED.** The loop condition is now a boolean
+   combination of scalar comparisons: each comparison is `VAR CMP (int | VAR)`
+   (the right side may be another loop variable, not just a literal), combined
+   with `&&` / `||` (`&&` binds tighter). Lowered as a block of i64 `icmp`s
+   folded by `and`/`or i1` at the loop's condition point (`plawk_while_cond_ir`
+   / `plawk_while_cond_build`); every named variable must be an i64 slot
+   (`plawk_while_cond_vars` registers them). A single `VAR CMP int` still parses
+   to a bare `cmp(...)`, so PR 2 is a strict subset. Tests:
+   `tests/test_plawk_while.pl` (var-bound, `&&`, `||`, do-while var-bound).
+3b. **`break` / `continue` — DEFERRED (own PR).** Loop-control statements are a
+   separate, design-sensitive change and were intentionally split out:
+   - **SSA phi merge.** A `break` jumps to the loop's `after`; that block then
+     needs a phi merging the normal exit (head-phi values, condition false) with
+     the value set at *each* break point. A `continue` adds a back-edge into the
+     head phi (`while`) / body-condition (`do-while`) from each continue point.
+     The loop emitter would collect the body's `branch_break` / `branch_next`
+     exits (it already receives them as `InnerNextExits`) and build these merge
+     phis, rather than letting them propagate to the record loop.
+   - **`break` semantics.** plawk currently uses `break` at *rule-body* level to
+     mean "stop the record stream" (`break_close_stream`) — non-standard awk. In
+     a loop, `break` must mean *loop* break instead, so the loop has to intercept
+     its own body's break exits. That contextual re-meaning (plus adding a
+     `continue` keyword, and defining `next`-inside-loop = next record) is the
+     design call this PR defers.
 4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
    nesting; the multi-pass driver's scalar handling.
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4847,26 +4847,86 @@ plawk_icmp_pred(ge, sge).
 
 %% plawk_while_cond_ok(+Cond) is semidet.
 %
-%  A supported loop condition: `VAR CMP int(N)` over an i64 comparison.
-plawk_while_cond_ok(cmp(var(_V), Op, int(N))) :-
-    integer(N),
-    plawk_icmp_pred(Op, _Pred).
+%  A supported loop condition: scalar comparisons (`VAR CMP int` or
+%  `VAR CMP VAR`) combined with `and` / `or` (PLAWK_CONTROL_FLOW_PLAN.md PR 3).
+plawk_while_cond_ok(and(A, B)) :-
+    !,
+    plawk_while_cond_ok(A),
+    plawk_while_cond_ok(B).
+plawk_while_cond_ok(or(A, B)) :-
+    !,
+    plawk_while_cond_ok(A),
+    plawk_while_cond_ok(B).
+plawk_while_cond_ok(cmp(var(_V), Op, Rhs)) :-
+    plawk_icmp_pred(Op, _Pred),
+    plawk_while_cond_rhs_ok(Rhs).
+
+plawk_while_cond_rhs_ok(int(N)) :- integer(N).
+plawk_while_cond_rhs_ok(var(_W)).
+
+%% plawk_while_cond_vars(+Cond, -Vars)
+%
+%  Every scalar variable named in the condition (both sides of every
+%  comparison) -- each must get an i64 slot.
+plawk_while_cond_vars(and(A, B), Vars) :-
+    !,
+    plawk_while_cond_vars(A, VA),
+    plawk_while_cond_vars(B, VB),
+    append(VA, VB, Vars).
+plawk_while_cond_vars(or(A, B), Vars) :-
+    !,
+    plawk_while_cond_vars(A, VA),
+    plawk_while_cond_vars(B, VB),
+    append(VA, VB, Vars).
+plawk_while_cond_vars(cmp(var(V), _Op, int(_N)), [V]) :- !.
+plawk_while_cond_vars(cmp(var(V), _Op, var(W)), [V, W]).
 
 %% plawk_while_cond_ir(+Cond, +Slots, +CondValues, +Base, -CondVar, -IR)
 %
-%  Emit the loop-condition icmp. The condition variable's current value is the
-%  slot value in CondValues (head-phi values for `while`, body-output values
-%  for `do-while`); compare it against the integer bound.
-plawk_while_cond_ir(cmp(var(CondName), Op, int(N)), Slots, CondValues, Base,
-        CondVar, IR) :-
-    nth0(Idx, Slots, Slot),
-    plawk_slot_name(Slot, CondName),
+%  Emit the loop-condition test as a block of IR lines ending in an i1 value
+%  (CondVar). Each variable's current value is its slot value in CondValues
+%  (head-phi values for `while`, body-output values for `do-while`);
+%  comparisons are i64 icmps, combined with `and`/`or i1`.
+plawk_while_cond_ir(Cond, Slots, CondValues, Base, CondVar, IR) :-
+    plawk_while_cond_build(Cond, Slots, CondValues, Base, '', CondVar, Lines),
+    atomic_list_concat(Lines, '\n', IR).
+
+plawk_while_cond_build(and(A, B), Slots, CV, Base, Path, CondVar, Lines) :-
     !,
-    nth0(Idx, CondValues, CondValRef),
+    atom_concat(Path, 'l', PA),
+    atom_concat(Path, 'r', PB),
+    plawk_while_cond_build(A, Slots, CV, Base, PA, VA, LA),
+    plawk_while_cond_build(B, Slots, CV, Base, PB, VB, LB),
+    format(atom(CondVar), '%~w_cond~w', [Base, Path]),
+    format(atom(Line), '  ~w = and i1 ~w, ~w', [CondVar, VA, VB]),
+    append([LA, LB, [Line]], Lines).
+plawk_while_cond_build(or(A, B), Slots, CV, Base, Path, CondVar, Lines) :-
+    !,
+    atom_concat(Path, 'l', PA),
+    atom_concat(Path, 'r', PB),
+    plawk_while_cond_build(A, Slots, CV, Base, PA, VA, LA),
+    plawk_while_cond_build(B, Slots, CV, Base, PB, VB, LB),
+    format(atom(CondVar), '%~w_cond~w', [Base, Path]),
+    format(atom(Line), '  ~w = or i1 ~w, ~w', [CondVar, VA, VB]),
+    append([LA, LB, [Line]], Lines).
+plawk_while_cond_build(cmp(var(CondName), Op, Rhs), Slots, CondValues, Base,
+        Path, CondVar, [Line]) :-
+    plawk_while_cond_operand(var(CondName), Slots, CondValues, LOperand),
+    plawk_while_cond_operand(Rhs, Slots, CondValues, ROperand),
     plawk_icmp_pred(Op, Pred),
-    format(atom(CondVar), '%~w_cond', [Base]),
-    format(atom(IR), '  ~w = icmp ~w i64 ~w, ~w',
-        [CondVar, Pred, CondValRef, N]).
+    format(atom(CondVar), '%~w_cond~w', [Base, Path]),
+    format(atom(Line), '  ~w = icmp ~w i64 ~w, ~w',
+        [CondVar, Pred, LOperand, ROperand]).
+
+% An operand is either an integer literal (emitted inline) or a loop variable
+% (read from its slot's current SSA value).
+plawk_while_cond_operand(int(N), _Slots, _CondValues, N) :-
+    !.
+plawk_while_cond_operand(var(Name), Slots, CondValues, Ref) :-
+    nth0(Idx, Slots, Slot),
+    plawk_slot_name(Slot, Name),
+    !,
+    nth0(Idx, CondValues, Ref).
 
 % Surface comparison op -> ordered LLVM fcmp predicate (row values are finite,
 % so ordered comparisons are correct; a NaN column fails every guard).
@@ -5933,14 +5993,14 @@ plawk_scalar_update_name_expr(if(_Pattern, ThenActions, ElseActions), Name, Expr
 plawk_scalar_update_name_expr(foreach_loop(_Layout, Body), Name, Expr) :-
     member(Action, Body),
     plawk_scalar_update_name_expr(Action, Name, Expr).
-% while/do-while: the condition variable gets an i64 slot (it is compared with
-% an integer), plus any scalar the body updates.
-plawk_scalar_update_name_expr(while_loop(cmp(var(CondVar), _Op, _N), Body), Name, Expr) :-
-    ( Name = CondVar, Expr = int(0)
+% while/do-while: every condition variable gets an i64 slot (each is compared
+% numerically), plus any scalar the body updates.
+plawk_scalar_update_name_expr(while_loop(Cond, Body), Name, Expr) :-
+    ( plawk_while_cond_vars(Cond, CondVars), member(Name, CondVars), Expr = int(0)
     ; member(Action, Body), plawk_scalar_update_name_expr(Action, Name, Expr)
     ).
-plawk_scalar_update_name_expr(do_while_loop(Body, cmp(var(CondVar), _Op, _N)), Name, Expr) :-
-    ( Name = CondVar, Expr = int(0)
+plawk_scalar_update_name_expr(do_while_loop(Body, Cond), Name, Expr) :-
+    ( plawk_while_cond_vars(Cond, CondVars), member(Name, CondVars), Expr = int(0)
     ; member(Action, Body), plawk_scalar_update_name_expr(Action, Name, Expr)
     ).
 
@@ -10878,12 +10938,12 @@ plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
 plawk_scalar_update_action_name(foreach_loop(_Layout, Body), Name) :-
     member(Action, Body),
     plawk_scalar_update_action_name(Action, Name).
-plawk_scalar_update_action_name(while_loop(cmp(var(CondVar), _Op, _N), Body), Name) :-
-    ( Name = CondVar
+plawk_scalar_update_action_name(while_loop(Cond, Body), Name) :-
+    ( plawk_while_cond_vars(Cond, CondVars), member(Name, CondVars)
     ; member(Action, Body), plawk_scalar_update_action_name(Action, Name)
     ).
-plawk_scalar_update_action_name(do_while_loop(Body, cmp(var(CondVar), _Op, _N)), Name) :-
-    ( Name = CondVar
+plawk_scalar_update_action_name(do_while_loop(Body, Cond), Name) :-
+    ( plawk_while_cond_vars(Cond, CondVars), member(Name, CondVars)
     ; member(Action, Body), plawk_scalar_update_action_name(Action, Name)
     ).
 

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1547,10 +1547,10 @@ action(Action) -->
 % the general action block, and the codegen (bin/plawk) rejects it with a clean
 % not-yet diagnostic until the loop runtime lands. The condition is a scalar
 % comparison for now; a general boolean condition is a follow-on.
-while_action(while_loop(cmp(var(V), Op, int(N)), Body)) -->
+while_action(while_loop(Cond, Body)) -->
     "while", identifier_boundary, ws,
     "(", ws,
-    identifier(V), ws, numeric_cmp_op(Op), ws, signed_integer_value(N), ws,
+    while_condition(Cond), ws,
     ")", ws,
     action_block(Body).
 
@@ -1559,13 +1559,50 @@ while_action(while_loop(cmp(var(V), Op, int(N)), Body)) -->
 % to do_while_loop(Body, cmp(var(V), Op, int(N))). Surface only, like `while`;
 % both share the same loop runtime (a later PR). Tried via its own action
 % clause; the leading `do` keyword distinguishes it.
-do_while_action(do_while_loop(Body, cmp(var(V), Op, int(N)))) -->
+do_while_action(do_while_loop(Body, Cond)) -->
     "do", identifier_boundary, ws,
     action_block(Body), ws,
     "while", identifier_boundary, ws,
     "(", ws,
-    identifier(V), ws, numeric_cmp_op(Op), ws, signed_integer_value(N), ws,
+    while_condition(Cond), ws,
     ")".
+
+% A loop condition: scalar comparisons (`VAR CMP int` or `VAR CMP VAR`) combined
+% with `&&` / `||`. `&&` binds tighter than `||` (awk precedence). A single
+% `VAR CMP int` still parses to the bare `cmp(...)` term, so the earlier runtime
+% is a strict subset. (PLAWK_CONTROL_FLOW_PLAN.md PR 3.)
+while_condition(Cond) -->
+    while_cond_and(First),
+    while_cond_or_rest(First, Cond).
+
+while_cond_or_rest(Acc, Cond) -->
+    ws, "||", ws, !,
+    while_cond_and(Next),
+    while_cond_or_rest(or(Acc, Next), Cond).
+while_cond_or_rest(Cond, Cond) -->
+    [].
+
+while_cond_and(Cond) -->
+    while_cmp(First),
+    while_cond_and_rest(First, Cond).
+
+while_cond_and_rest(Acc, Cond) -->
+    ws, "&&", ws, !,
+    while_cmp(Next),
+    while_cond_and_rest(and(Acc, Next), Cond).
+while_cond_and_rest(Cond, Cond) -->
+    [].
+
+% A scalar comparison: the left side is a loop variable; the right side is an
+% integer literal or another loop variable.
+while_cmp(cmp(var(V), Op, Rhs)) -->
+    identifier(V), ws, numeric_cmp_op(Op), ws, while_cmp_rhs(Rhs).
+
+while_cmp_rhs(int(N)) -->
+    signed_integer_value(N),
+    !.
+while_cmp_rhs(var(W)) -->
+    identifier(W).
 
 if_action(if(Pattern, ThenActions, ElseActions)) -->
     "if",

--- a/tests/test_plawk_while.pl
+++ b/tests/test_plawk_while.pl
@@ -108,6 +108,56 @@ test(while_runtime_accumulate_to_end, [condition(clang_available)]) :-
     assertion(Out == "6\n"),
     !.
 
+% GENERAL CONDITION (PR 3): the right side of a comparison may be another loop
+% variable, not just an integer -- `while (i < n)`.
+test(while_condition_var_bound, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ n = 3; i = 0; while (i < n) { print i; i++ } }\n",
+    build_run(Dir, 'wcv', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+% `&&` combines comparisons (both must hold): `i < 5 && i < 3` stops at 3.
+test(while_condition_and, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ i = 0; while (i < 5 && i < 3) { print i; i++ } }\n",
+    build_run(Dir, 'wca', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+% `||` combines comparisons (either may hold): `i < 2 || i < 3` runs while the
+% weaker bound holds, stopping at 3.
+test(while_condition_or, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ i = 0; while (i < 2 || i < 3) { print i; i++ } }\n",
+    build_run(Dir, 'wco', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+% do-while with a variable bound.
+test(do_while_condition_var_bound, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ n = 2; i = 0; do { print i; i++ } while (i < n) }\n",
+    build_run(Dir, 'dwcv', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n"),
+    !.
+
+% The general condition parses to and/or/cmp AST; a single comparison stays a
+% bare cmp (the PR 2 subset is unchanged).
+test(while_condition_ast_shapes) :-
+    plawk_parse_string("{ while (i < n && j > 0) { i++ } }\n",
+        program([], [rule(always,
+            [while_loop(and(cmp(var(i), lt, var(n)), cmp(var(j), gt, int(0))),
+                 [inc(var(i))])])], [])),
+    plawk_parse_string("{ while (i < 3) { i++ } }\n",
+        program([], [rule(always,
+            [while_loop(cmp(var(i), lt, int(3)), [inc(var(i))])])], [])),
+    !.
+
 % A program with no while loop is unaffected (no false trigger).
 test(non_while_program_builds, [condition(clang_available)]) :-
     wdir(Dir),


### PR DESCRIPTION
## Summary

Control-flow PR 3 — the **general loop condition**. The `while` / `do-while` condition was `VAR CMP int`; it is now a boolean combination of scalar comparisons:

- each comparison is `VAR CMP (int | VAR)` — the right side may be **another loop variable**, not just a literal (`while (i < n)`);
- combined with `&&` / `||` (`&&` binds tighter, awk precedence): `while (i < n && j > 0)`.

**Parser:** `while_condition` → or-of-ands-of-comparisons; a single `VAR CMP int` still parses to a bare `cmp(...)`, so PR 2 is a **strict subset** (existing AST and runtime unchanged). The RHS tries an integer first, backtracking to a variable.

**Codegen:** `plawk_while_cond_ir` / `plawk_while_cond_build` lower the condition to a block of i64 `icmp`s folded by `and`/`or i1` at the loop's condition point (head for `while`, body-done for `do-while`), reading each variable's current slot value (head-phi for `while`, body-output for `do-while`). `plawk_while_cond_vars` collects every named variable so all get an i64 slot; discovery/validation use it.

## `break` / `continue` — deferred (PR 3b)

Intentionally split out: done correctly they need SSA break/continue **phi-merging** (a `break` adds an incoming to the loop's `after` phi; a `continue` adds a back-edge into the head phi) **and** a decision on `break`'s current rule-level meaning (`break_close_stream`) vs a loop-level meaning, plus a new `continue` keyword. The design is written up in `PLAWK_CONTROL_FLOW_PLAN.md` §3b.

## Tests

5 new in `tests/test_plawk_while.pl` (var bound, `&&`, `||`, do-while var bound, AST shapes) — 15 pass. Regression: functions (11), prefix_print (221) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_