### PR TITLE
WAM/LLVM plawk: materialize NAME view surface + runtime plan (views cache)

### DIFF
--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -758,7 +758,44 @@ brevity, the key iterator trades brevity for reach. A nested `pass` (§3.8), if
 built, is the record-returning form gaining its own nested scope — the natural
 extension of the left column, not a new mechanism.
 
-### 3.9 Views (future TODO — brief spec, not planned)
+### 3.9 Views (column projection LANDED; `materialize` surface LANDED, runtime planned)
+
+**Status.** Column projection landed (`PLAWK_GENERATOR_BLOCKS.md` PR 5): a
+generator over a multi-column source projects/reorders columns into a derived
+relation. The **`materialize NAME`** surface landed (surface-first, like the
+query-reader / generator / while arcs): it parses to a `materialize(Name)`
+program item and its reference is validated against the program's defined
+relations (a `gen ... as NAME` view or a @prolog predicate); the
+materialise-and-cache **runtime** is the follow-on planned here.
+
+#### Runtime plan (materialise-and-cache)
+
+A query pass today materialises its goal's columns into **pass-local** tagged
+tables (`%qval_C` / `%qkind_C`), iterates, and frees them at pass end
+(`plawk_multipass_query_fn_ir`). So two passes over the same relation
+materialise it twice. `materialize NAME` lifts that to **once, shared**:
+
+1. **Shared tables.** For each materialised relation, emit **global** column
+   tables (`@qval_<NAME>_<C>` / `@qkind_<NAME>_<C>`) instead of pass-local ones.
+2. **One-time fill.** Emit a `@plawk_materialize_<NAME>()` that runs the
+   per-column findall wrappers against the shared VM and fills the globals; call
+   it once from `main` **before** the pass calls (or lazily behind a
+   done-flag). Do not free the globals per pass.
+3. **Consumer rewiring.** A `pass over query(NAME(...))` reads the shared
+   globals instead of materialising locally and skips the free.
+
+**Refresh policy — resolved for the intra-run case.** The open question was
+eager/lazy/explicit refresh. For the current sources — @prolog facts and
+generator-derived relations are **static within a program run** — the answer is
+**eager-once, no refresh**: materialise on first need, reuse for the rest of the
+run; the source cannot change mid-run, so there is nothing to invalidate. A
+refresh policy only re-enters when a materialised view is backed by a **mutable
+durable cache** across runs (the LMDB / inter-pass-channel case, Phase 3), which
+is where eager-on-write vs lazy-on-read vs explicit becomes a real choice. So
+the runtime splits cleanly: the intra-run share above is unblocked and needs no
+policy; the cross-run persistent view waits on Phase 3.
+
+#### Original sketch (retained)
 
 A **view** is a named, derived query over one or more tables — conceptually a
 stored `records of … WHERE … ` (reader guards have landed; a view would pair
@@ -801,12 +838,13 @@ relation* — and the phase-6 work built the pieces:
   in all but name and materialisation;
 - the query reader's **per-column tagged materialisation** (PR 6) is exactly the
   projection engine.
-So the net-new work for views is narrow: **column projection** (select a subset
+So the net-new work for views was narrow: **column projection** (select a subset
 of columns, not the whole row — the "we might not need a whole row" point) and
-**materialise-and-cache** (write the projected/filtered set to its own row
-table, with a refresh policy — eager/lazy/explicit, the one genuinely open
-question). Both build directly on shipped machinery, which is the other reason
-to do views before a from-scratch auto-cache.
+**materialise-and-cache** (compute the projected/filtered set once, reuse it).
+Projection **landed** (`PLAWK_GENERATOR_BLOCKS.md` PR 5); the `materialize NAME`
+**surface landed** (this doc's §3.9 status), and the runtime is the plan above.
+Both build directly on shipped machinery, which is the other reason views come
+before a from-scratch auto-cache.
 
 ### 3.10 Contained non-determinism — a search construct (future TODO — sketch)
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -107,6 +107,7 @@ build(File, Out0, KeepLL) :-
     % like any other relation. `Program` is the program with generator blocks
     % removed; `GenFactClauses` are the synthesised facts.
     check_generator_blocks(File, Program2),
+    check_materialized_views(File, Program2, Clauses),
     resolve_generator_blocks(Program2, Program, GenFactClauses),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
@@ -363,6 +364,45 @@ check_generator_blocks(File, Program) :-
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
+
+% `materialize NAME` (PLAWK_MULTIPASS_CACHE.md §3.9): mark a view / relation to
+% be materialised-and-cached (computed once, reused by every query pass that
+% reads it). Surface-first, mirroring the query-reader / generator / while arcs:
+% the declaration parses and its reference is validated against the program's
+% defined relations (a `gen ... as NAME` view or a @prolog predicate), but the
+% materialise-and-cache runtime is a follow-on, so a program that uses it gets a
+% clear, specific diagnostic. An unknown reference is a distinct, earlier error.
+check_materialized_views(File, Program, Clauses) :-
+    plawk_program_materialize_views(Program, Names),
+    Names \== [],
+    !,
+    plawk_program_gen_blocks(Program, GenBlocks),
+    findall(GN, member(gen_block(name(GN), _, _), GenBlocks), ViewNames),
+    findall(PN, ( member(Clause, Clauses), materialize_clause_pred(Clause, PN) ),
+        PrologNames),
+    append(ViewNames, PrologNames, Defined),
+    (   member(N, Names), \+ memberchk(N, Defined)
+    ->  format(user_error,
+            'plawk: ~w declares `materialize ~w`, but no view (`gen ... as ~w`) \c
+             or @prolog relation named ~w is defined.~n',
+            [File, N, N, N]),
+        halt(2)
+    ;   format(user_error,
+            'plawk: ~w uses `materialize NAME` (a cached view). The surface \c
+             parses but its materialise-and-cache runtime is not yet \c
+             implemented; see PLAWK_MULTIPASS_CACHE.md section 3.9.~n',
+            [File]),
+        halt(2)
+    ).
+check_materialized_views(_File, _Program, _Clauses).
+
+% The predicate name a @prolog clause defines (a rule head or a bare fact).
+materialize_clause_pred((Head :- _Body), Name) :-
+    !,
+    functor(Head, Name, _).
+materialize_clause_pred(Head, Name) :-
+    callable(Head),
+    functor(Head, Name, _).
 
 % A generator block whose clauses can be synthesised at build time:
 %  - a pure block (`Source == none`) whose every action is a constant `emit`

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -9,6 +9,7 @@
     plawk_query_helper_name/3,
     plawk_query_helper_clause/4,
     plawk_program_query_passes/2,
+    plawk_program_materialize_views/2,
     plawk_program_gen_blocks/2,
     plawk_query_pass_supported/1,
     plawk_program_foreign_specs/3,
@@ -3984,6 +3985,13 @@ plawk_query_mixed_support_ir(Program, Options, SupportIR) :-
 plawk_program_query_passes(program_passes(_, Passes, _), QueryPasses) :-
     findall(pass_query(Q, B), member(pass_query(Q, B), Passes), QueryPasses).
 plawk_program_query_passes(program(_, _, _), []).
+
+%% plawk_program_materialize_views(+Program, -Names) is det.
+%  The names declared by `materialize NAME` (PLAWK_MULTIPASS_CACHE.md §3.9),
+%  in program order (empty if none). Surface-first: the runtime is a follow-on.
+plawk_program_materialize_views(program_passes(_, Passes, _), Names) :-
+    findall(Name, member(materialize(Name), Passes), Names).
+plawk_program_materialize_views(program(_, _, _), []).
 
 %% plawk_program_gen_blocks(+Program, -GenBlocks) is det.
 %  The `gen { ... } as name` generator blocks of a program (empty if none).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -342,6 +342,17 @@ gen_over_binding(Vars) -->
     !.
 gen_over_binding([V]) -->
     identifier(V).
+% A `materialize NAME` declaration (PLAWK_MULTIPASS_CACHE.md §3.9): mark a
+% derived relation (a view produced by a `gen ... as NAME` block, or a @prolog
+% relation) as materialised-and-cached -- its projected/filtered rows are
+% computed once into a shared table and reused by every query pass that reads
+% it, instead of re-running the goal per consumer. Parses to materialize(Name);
+% the runtime is a follow-on (surface-first, like the query-reader / generator
+% arcs), so bin/plawk currently emits a clean not-yet diagnostic.
+pass_clauses([materialize(Name) | Rest]) -->
+    "materialize", identifier_boundary, ws,
+    identifier(Name), ws,
+    pass_clauses(Rest).
 % A `pass { ACTIONS }` block is one pass carrying a single always-rule with
 % those actions (per-pattern rules within a pass are a later extension).
 pass_clauses([pass([rule(always, Actions)]) | Rest]) -->
@@ -365,6 +376,8 @@ plawk_pass_dynentry_rewrite(_DynEntries, pass_query(Q, Body), pass_query(Q, Body
 % A `gen { ... } as name` generator block -- pass it through (its body is
 % lowered by the generator runtime in a later PR).
 plawk_pass_dynentry_rewrite(_DynEntries, gen_block(N, S, Body), gen_block(N, S, Body)).
+% A `materialize NAME` declaration has no rule actions -- pass it through.
+plawk_pass_dynentry_rewrite(_DynEntries, materialize(Name), materialize(Name)).
 
 %% dynentry_decls(-Names)//
 %

--- a/tests/test_plawk_materialize.pl
+++ b/tests/test_plawk_materialize.pl
@@ -1,0 +1,108 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `materialize NAME` (PLAWK_MULTIPASS_CACHE.md section 3.9), the SURFACE.
+% `materialize NAME` marks a view (a `gen ... as NAME` block) or a @prolog
+% relation to be materialised-and-cached: its projected/filtered rows are
+% computed once into a shared table and reused by every query pass that reads
+% it, instead of re-running the goal per consumer. Surface-first (mirroring the
+% query-reader / generator / while arcs): the declaration parses and its
+% reference is validated against the program's defined relations, but the
+% materialise-and-cache runtime is a follow-on, so a program that uses it is a
+% clean, specific compile error rather than the generic "outside the surface".
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_materialize).
+
+% `materialize NAME` parses to a materialize(Name) pass-clause item, in program
+% order alongside the generator that defines the view and the consuming pass.
+test(materialize_parses) :-
+    plawk_parse_string(
+        "gen over query(edge(A, B)) as (a, b) { emit a } as srcs\n\c
+         materialize srcs\n\c
+         pass over query(srcs(X)) { print $1 }\n",
+        program_passes([],
+            [gen_block(name(srcs), over(query(edge, ['A', 'B']), [a, b]),
+                 [emit(var(a))]),
+             materialize(srcs),
+             pass_query(query(srcs, ['X']), [print([field(1)])])],
+            [])),
+    !.
+
+% A program with no `materialize` declaration is untouched.
+test(no_materialize_parses) :-
+    plawk_parse_string(
+        "pass { print $1 }\n",
+        program_passes([],
+            [pass([rule(always, [print([field(1)])])])],
+            [])),
+    !.
+
+% Building a program that materialises a DEFINED view (a `gen ... as NAME`
+% block) is a clean not-yet compile error (exit 2) until the runtime lands.
+test(materialize_defined_view_is_not_yet_error) :-
+    mdir(Dir),
+    Src = "@prolog\nedge(1, 10).\nedge(2, 20).\n@end\n\c
+           gen over query(edge(A, B)) as (a, b) { emit a } as srcs\n\c
+           materialize srcs\n\c
+           pass over query(srcs(X)) { print $1 }\n",
+    build_status(Dir, 'mvdef', Src, St),
+    assertion(St == 2),
+    !.
+
+% Materialising a DEFINED @prolog relation is likewise a clean not-yet error.
+test(materialize_prolog_relation_is_not_yet_error) :-
+    mdir(Dir),
+    Src = "@prolog\nnum(1).\nnum(2).\n@end\n\c
+           materialize num\n\c
+           pass over query(num(X)) { print $1 }\n",
+    build_status(Dir, 'mvpl', Src, St),
+    assertion(St == 2),
+    !.
+
+% Materialising an UNKNOWN relation (no view / @prolog defines it) is a clean
+% compile error (a distinct, earlier diagnostic than the not-yet one).
+test(materialize_unknown_view_is_error) :-
+    mdir(Dir),
+    Src = "materialize nope\npass { print $1 }\n",
+    build_status(Dir, 'mvunk', Src, St),
+    assertion(St == 2),
+    !.
+
+% A program with no `materialize` declaration builds normally (no false
+% trigger).
+test(non_materialize_program_builds, [condition(clang_available)]) :-
+    mdir(Dir),
+    Src = "@prolog\nedge(1).\nedge(2).\n@end\npass over query(edge(X)) { print $1 }\n",
+    build_status(Dir, 'mvok', Src, St),
+    assertion(St == 0),
+    !.
+
+:- end_tests(plawk_materialize).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+mdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_materialize', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_status(Dir, Name, Src, Status) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).


### PR DESCRIPTION
## Summary

The views' remaining half — **materialise-and-cache**. Column projection landed (generator PR 5); this adds the caching side **surface-first**, mirroring the query-reader / generator / while arcs (surface + validation now, runtime as a scoped follow-on).

`materialize NAME` marks a view (a `gen ... as NAME` block) or a @prolog relation to be materialised-and-cached: its rows are computed **once** into a shared table and reused by every query pass that reads it, instead of re-running the goal per consumer. Parses to a `materialize(Name)` pass-clause item; the reference is validated against the program's defined relations (an unknown `NAME` is a distinct, clear error), and a defined one gets a clean not-yet diagnostic until the runtime lands.

## Why surface-first here

The full runtime touches the parser, program threading, and the query driver (**global column tables**, a **one-time materialisation** hoisted before the pass calls, **consumer rewiring**), and its persistent/cross-run variant couples to the unbuilt **Phase 3** (cache as inter-pass channel). Rather than rush a large IR change, this locks the surface and writes the concrete runtime plan.

The design doc (`PLAWK_MULTIPASS_CACHE.md` §3.9) is upgraded from "sketch, not planned" to the concrete lowering, and **resolves the open refresh-policy question**: for @prolog / generator sources (static within a run) the answer is **eager-once, no refresh** — the source can't change mid-run, so nothing invalidates. A refresh policy only re-enters for a mutable durable cache across runs (Phase 3). So the intra-run share is unblocked and needs no policy.

## Changes

- **Parser:** `materialize(Name)` pass-clause + dynentry passthrough.
- **Codegen:** `plawk_program_materialize_views/2` (exported).
- **bin/plawk:** `check_materialized_views` validates the reference and emits the not-yet diagnostic.

## Tests

`tests/test_plawk_materialize.pl` (parse, defined-view not-yet, @prolog-relation not-yet, unknown-view error, no-false-trigger) — 6 pass. Regression: gen_blocks (18), query_reader (19) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_