### PR TITLE
EMIT-KOTLIN-5: lower deterministic mid-body call + arithmetic builtins

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -57,7 +57,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | EMIT-KOTLIN-2 ✅ | Lowered emitter (structures) | Kotlin | M | done — write-mode structures (`cursor/emit-kotlin-structures-f421`) |
 | EMIT-KOTLIN-3 ✅ | Multi-clause deterministic | Kotlin | M | done — T5/T4 no call (`cursor/emit-kotlin-multi-clause-f421`) |
 | EMIT-KOTLIN-4 ✅ | Last-call `execute` | Kotlin | M | done — tail execute (`cursor/emit-kotlin-execute-f421`) |
-| EMIT-KOTLIN-5 | Mid-body `call` | Kotlin | M | fib/ack / non-tail continuation |
+| EMIT-KOTLIN-5 ✅ | Mid-body `call` + arith builtins | Kotlin | M | done — det-only mid-body + is/2 (`cursor/emit-kotlin-5-f421`) |
 | BENCH-KOTLIN ✅ | Lowered vs interpreter timing | Kotlin | S | done — recursion regresses; short cases noise (`cursor/bench-kotlin-f421`) |
 | KT-DISPATCH-SNAPSHOT-OPT ✅ | Perf: cheapen recursive dispatch | Kotlin | M | done — skip recursive tryRun snap (`cursor/kt-dispatch-snapshot-opt-f421`) |
 | KT-HEAP-SNAPSHOT-OPT-2 ✅ | Perf: eliminate residual T4 `_t4` copy | Kotlin | M | done — peel leading get_constant (`cursor/kt-heap-snapshot-opt-2-f421`) |
@@ -602,11 +602,12 @@ fallback) to the three Tier-D targets. Reference small emitters:
 - **Acceptance:** member/append/(acc)reverse LOWER and match interpreter via gradle differential; fib still declines; unit + `kotlin`/`kotlin_functions` conformance green with no xfails; emitted project registers `lowered_cmem_2` / etc. under kotlin_functions.
 
 ### EMIT-KOTLIN-5: Lower mid-body `call P/N` (non-tail / continuation)
-- **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-4
-- **Goal:** Emit non-tail `call` with saved continuation / environment so fib/ack and non-tail reverse lower.
-- **Out of scope here:** cut, ITE/soft-cut, aggregates, multi-solution enumeration.
-- **Note from BENCH-KOTLIN:** the one reproducible perf finding is that tail `execute` recursion (append) is ~0.6–0.8× (slower) from the per-hop `tryRun`+snapshot tax; mid-body `call` adds more of the same recursion. **Do `KT-DISPATCH-SNAPSHOT-OPT` first**, or treat EMIT-KOTLIN-5 as correctness-only with no perf claim.
-- **Acceptance:** fib (or equivalent) LOWERS under `emit_mode(functions)` and matches interpreter; conformance remains green.
+- **Lever:** Lowered emitters for early scaffolds  **Target:** Kotlin  **Size:** M  **Depends on:** EMIT-KOTLIN-4, KT-DISPATCH-SNAPSHOT-OPT, KT-HEAP-SNAPSHOT-OPT-2
+- **Status:** ✅ **Landed** on `cursor/emit-kotlin-5-f421` (2026-07-15). Arithmetic `builtin_call` via shared `kotlinLoBuiltinCall`/`wamEvalArith`. Mid-body `call` emits `if (!dispatch) return false` **only** for self-recursion or single-clause deterministic callees; multi-clause callees decline (first-solution hazard). Fib/ack LOWER and match interpreter; nondet `choice(X), X=b` stays on the interpreter. Bench: fib_15 **1.85×**, ack_23 **1.78×**. JVM mid-body stack ceiling ~**750–780** frames. Classic non-tail reverse via `append` still declines (`append` is multi-clause). Docs: `WAM_KOTLIN_STATUS.md`, `WAM_KOTLIN_BENCH.md`, `design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`.
+- **Goal:** Emit non-tail `call` + arithmetic builtins so fib/ack lower under `emit_mode(functions)`.
+- **Correctness gate:** deterministic-only mid-body goals — when unsure, decline.
+- **Out of scope:** cut, ITE/soft-cut, aggregates, multi-solution enumeration / backtracking into callees.
+- **Acceptance:** fib/ack LOWER + match interpreter; nondet mid-body declines; unit + both conformance modes green; bench table includes fib/ack; boundary + stack ceiling documented.
 
 ### BENCH-KOTLIN: Measure lowered vs interpreter (in-process)
 - **Lever:** Effective-distance / perf evidence  **Target:** Kotlin  **Size:** S  **Depends on:** EMIT-KOTLIN-4

--- a/docs/WAM_KOTLIN_BENCH.md
+++ b/docs/WAM_KOTLIN_BENCH.md
@@ -22,52 +22,40 @@ Profiling (functions mode; attributes **all** `snapshotForNative`, incl. T4 `_t4
 WAM_KT_PROFILE=1 gradle -q run --args='80 2 5 PROFILE=1'
 ```
 
-## Results after KT-HEAP-SNAPSHOT-OPT-2 (2026-07-14)
+## Results after EMIT-KOTLIN-5 (2026-07-15)
 
 Hardened harness (5/15, min + median). All functions-mode cases confirmed
-`registerNative` / `lowered_*`.
+`registerNative` / `lowered_*` (incl. fib/ack).
 
 | program | interp min | lowered min | **speedup min** | speedup med | notes |
 |---|---:|---:|---:|---:|---|
-| fact | 3.64 | 3.92 | 0.93× | 0.75× | ~parity (short) |
-| list_builder | 6.28 | 5.58 | 1.13× | 1.01× | slight win |
-| t5_color | 8.63 | 3.35 | 2.58× | 1.96× | win |
-| t4_second_arg | 6.62 | 6.12 | 1.08× | 0.97× | ~parity |
-| member_100 | 65.68 | 46.94 | **1.40×** | 1.37× | win |
-| member_500 | 66.12 | 48.34 | **1.37×** | 1.31× | win |
-| append_100 | 235.26 | 32.63 | **7.21×** | 6.88× | win (was ~1.03×) |
-| append_500 | 884.52 | 29.16 | **30.33×** | 28.94× | win (was ~0.85×) |
+| fact | 3.10 | 4.02 | 0.77× | 0.70× | ~parity (short) |
+| list_builder | 6.39 | 5.56 | 1.15× | 1.02× | slight win |
+| t5_color | 7.82 | 3.22 | 2.43× | 2.10× | win |
+| t4_second_arg | 8.06 | 5.58 | 1.44× | 1.11× | win |
+| member_100 | 70.44 | 47.19 | **1.49×** | 1.43× | win |
+| member_500 | 70.21 | 46.60 | **1.51×** | 1.43× | win |
+| append_100 | 216.07 | 28.64 | **7.54×** | 7.46× | win |
+| append_500 | 872.58 | 31.31 | **27.87×** | 27.60× | win |
+| fib_15 | 9848.71 | 5310.43 | **1.85×** | 1.81× | mid-body call win |
+| ack_23 | 94.20 | 52.87 | **1.78×** | 1.77× | mid-body call win |
 
 Speedup = interpreter_ms / lowered_ms (min batch).
 
-## Before → after (append, the real signal)
+## Append trajectory (KT-DISPATCH → heap peel)
 
-| program | BENCH-KOTLIN | + KT-DISPATCH | **+ KT-HEAP-SNAPSHOT-OPT-2** |
+| program | BENCH-KOTLIN | + KT-DISPATCH | + KT-HEAP-SNAPSHOT-OPT-2 |
 |---|---:|---:|---:|
-| append_100 | ~0.75× | ~1.03× | **7.21×** |
-| append_500 | ~0.55–0.64× | ~0.85× | **30.33×** |
-
-### Profile evidence (append_500, 80×5, functions)
-
-| config | snap_fraction_of_wall | snap_count / native_entries | max_register_map_size |
-|---|---:|---|---:|
-| AFTER KT-DISPATCH (entry `_t4` every hop) | **48.1%** | 200800 / 200400 | 508 |
-| AFTER peel leading `get_constant` | **8.6%** | 800 / 200400 | 508 |
-
-See [`design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`](design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md).
+| append_100 | ~0.75× | ~1.03× | **~7×** |
+| append_500 | ~0.55–0.64× | ~0.85× | **~28–30×** |
 
 ## Honest readout
 
-- **tryRun per-hop snapshot** was the first recursive tax (~31% of wall);
-  KT-DISPATCH fixed that and left append_500 at ~0.85×.
-- **T4 `_t4` per-entry map copy** was the residual (~48% of wall once
-  properly attributed). Peeling a leading fail-closed `get_constant` makes
-  append’s cons path snap-free → **≥1.0× with large margin**.
-- Member stays ~1.4× (first instr is `get_list`, not peeled).
-- Short cases: treat sub-10ms rows cautiously; member/append are durable.
+- Tail `execute` (append) and mid-body `call` (fib/ack) both **win** after
+  the dispatch/snapshot work — EMIT-KOTLIN-5 is not coverage-only.
+- Fib/ack ~**1.8×**; tree recursion is still JVM-stack-bound (~750 mid-body
+  frames on the default stack; conformance depths are fine).
+- Nondeterministic mid-body call **declines** (first-solution would be wrong).
+- Short cases: treat sub-10ms rows cautiously.
 
-## Implications for EMIT-KOTLIN-5
-
-Mid-body `call` still needs continuation machinery. Tail `execute`
-recursion is no longer snapshot-bound for peelable T4 heads; re-measure
-after EMIT-KOTLIN-5 lands.
+See [`design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`](design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md).

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -1,3 +1,6 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
 # WAM Kotlin Target — Status
 
 Living summary of the hybrid WAM-Kotlin backend
@@ -24,7 +27,7 @@ module in the fleet.
 | Module | Approx. lines |
 |---|---:|
 | `src/unifyweaver/targets/wam_kotlin_target.pl` | ~0.5k |
-| `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl` | ~0.5k (T1 + T4 + T5 + execute) |
+| `src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl` | ~0.6k (T1 + T4 + T5 + execute + mid-body call) |
 | Dedicated tests | ~1 file (plunit + Gradle e2e when available) |
 
 ## What's shipped
@@ -34,54 +37,53 @@ module in the fleet.
   path when the toolchain is available.
 - **WAM-lowered native dispatch:** `wam_kotlin_lowered_emitter.pl` lowers:
   - **T1** deterministic single-clause — flat facts, register unification,
-    write/read-mode structure/list construction, last-call `execute`.
+    write/read-mode structure/list construction, last-call `execute`,
+    arithmetic `builtin_call`, deterministic mid-body `call`.
   - **T5** `clause_chain` — multi-clause with distinct first-arg
     `get_constant` discriminators (bound A1 if-cascade; unbound A1
     returns `false` so `tryRun` falls back to the interpreter).
   - **T4** `multi_clause_n` — all supported deterministic clauses
     inlined, tried in order with `snapshotForNative` /
     `restoreFromSnapshot` between attempts (incl. clauses ending in
-    `execute`).
-  - **Last-call `execute` (EMIT-KOTLIN-4):** native fns take
-    `(state, dispatch)` where `dispatch` is `WamRuntime.tryRun`; emit
-    `return dispatch("P/N", state)`. Tail-recursive member/append and
-    accumulator reverse lower.
+    `execute` / mid-body `call`). Leading `get_constant` peel skips the
+    entry snapshot on closed fail (KT-HEAP-SNAPSHOT-OPT-2).
+  - **Last-call `execute` (EMIT-KOTLIN-4):** `return dispatch("P/N", state)`.
+  - **Mid-body `call` + arith (EMIT-KOTLIN-5):**
+    `if (!dispatch(...)) return false` + `kotlinLoBuiltinCall` — **only**
+    when every mid-body callee is self-recursion or single-clause
+    deterministic. Fib/ack lower; nondet mid-body callers decline.
   Registered via `WamProgram.registerNative`. `functions` / `mixed`
   modes route lowerable preds through this path.
 
-## Perf signal (BENCH-KOTLIN → KT-HEAP-SNAPSHOT-OPT-2)
+## Perf signal
 
-In-process `tryRun` timing (not JVM startup) — see
-[`WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md) and
-[`design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`](design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md).
-Recursive tryRun snaps skipped; T4 peels leading `get_constant` so append’s
-cons path is snap-free. **After KT-HEAP-SNAPSHOT-OPT-2:** append_100
-~**7.2×**, append_500 ~**30×**; member ~1.4×.
+See [`WAM_KOTLIN_BENCH.md`](WAM_KOTLIN_BENCH.md). After dispatch/snapshot
+opts + EMIT-KOTLIN-5: append_500 ~**28×**, fib_15 ~**1.85×**, ack_23
+~**1.78×**, member ~1.5×.
 
 ## Gaps
 
-- **Mid-body `call`** — still declined (fib, ack with non-tail call).
-  Follow-up **EMIT-KOTLIN-5** (correctness; re-measure after).
+- **Nondeterministic mid-body `call`** — declined (first-solution hazard).
 - **ITE/soft-cut, cut, aggregates** — not lowered.
-- **Native recursion depth:** `execute` uses the JVM call stack.
-  Measured ~1000 peano-depth OK, ~2000 → `StackOverflowError` on the
-  default stack. Conformance depths (list length 3) are fine.
+- **Native recursion depth:** mid-body/tree recursion uses the JVM call
+  stack. Measured ~**750–780** frames before `StackOverflowError` on the
+  default stack (linear mid-body probe). Conformance `fib(10)` /
+  `ack(2,3)` are fine; prefer decline over wrong answers if a workload
+  would overflow.
 - **Conformance (opt-in)** — `conformance_target(kotlin)` /
   `kotlin_functions` registered. **All classic programs green** (append,
-  member, reverse, builtins, fib, ack) — no remaining `ct_xfail`s after
-  KT-ARITH-SLASH-FUNCTOR + KT-LIST-BACKTRACK + KT-Y-ENV-RECURSION.
+  member, reverse, builtins, fib, ack) — no remaining `ct_xfail`s.
 - **No foreign kernels, no LMDB / fact source, no ISO contract.**
 - **No runtime-parser capability entry.**
 
 ## Path forward
 
-1. EMIT-KOTLIN-5 for mid-body `call` (correctness; re-measure perf).
-2. Optional: heap-outside-map / trail-with-old-values if non-peeled T4 or
+1. Optional: heap-outside-map / trail-with-old-values if non-peeled T4 or
    CP snapshots dominate a new workload.
-3. Optional: ITE/soft-cut; ISO / kernels if Kotlin graduates beyond scaffold.
+2. Optional: ITE/soft-cut; ISO / kernels if Kotlin graduates beyond scaffold.
 
 ## Document status
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
-(2026-07-14). Through KT-HEAP-SNAPSHOT-OPT-2.
+(2026-07-15). Through EMIT-KOTLIN-5.

--- a/docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md
+++ b/docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md
@@ -94,7 +94,7 @@ clause backtracking. Recursive append therefore still copies the growing
 
 ---
 
-## KT-HEAP-SNAPSHOT-OPT-2 (this change)
+## KT-HEAP-SNAPSHOT-OPT-2
 
 ### Prior art consulted
 
@@ -149,6 +149,53 @@ Append’s recursive cons path is therefore snap-free → append_500
 | **(b) Trail-based undo for T4** | Trail still stores names only; needs old values or a native side trail. Bigger than peel; defer. |
 | **(c) Blind “skip `_t4` on last clause” only** | Entry snapshot still ran before clause 1; peel is the stronger form of (c) for fail-closed discriminants. |
 | **Peel `get_structure` / `get_list`** | Not fail-closed on vars (enters write mode); member already wins without it. |
+
+---
+
+## EMIT-KOTLIN-5 (this change)
+
+### Boundary (deterministic-only mid-body `call`)
+
+Inline `if (!dispatch("P/N", state)) return false` takes the **first**
+solution only and cannot backtrack into the callee if a later body goal
+fails. Lower mid-body `call` **only** when every target is:
+
+1. **self-recursion**, or
+2. a **single-clause deterministic** predicate (whose own mid-body calls
+   pass the same gate).
+
+Multi-clause callees (e.g. `choice(a). choice(b)` used as
+`choice(X), X = b`) **decline**. When unsure → decline. Top-level tryRun
+snapshot+fallback backstops a wrong `false`, not a wrong first-only
+`true`.
+
+Arithmetic `builtin_call` (`is/2`, compares, `=/2`, `true/0`) lowers by
+calling shared `kotlinLoBuiltinCall` → `wamEvalArith` (same helpers as the
+interpreter — no re-implementation).
+
+### Stack ceiling (tree / mid-body recursion)
+
+Linear mid-body-call recursion overflows the default JVM stack around
+**~750–780** frames (measured). Fib/ack need O(n) frames; conformance
+`fib(10)` / `ack(2,3)` are safe. Practical fib depth is usually time-bound
+before stack. Prefer decline over wrong answers if a workload would
+overflow.
+
+### Hardened bench after landing (min speedup)
+
+| program | speedup_min |
+|---|---:|
+| fib_15 | **1.85×** |
+| ack_23 | **1.78×** |
+| append_500 | ~28× (unchanged class) |
+
+### What we skipped (and why)
+
+| Idea | Why not now |
+|---|---|
+| Mid-body call to multi-clause callees | First-solution ≠ Prolog when later goals reject the first answer. |
+| Classic non-tail `reverse` via `append` | `append/3` is multi-clause — declined as a mid-body callee. Acc-reverse already lowers via `execute`. |
+| Full trail/CP continuation for nondet call | Out of scope; would be a different card. |
 
 ---
 

--- a/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
+++ b/docs/design/WAM_PERF_OPTIMIZATION_LOG.md
@@ -4896,3 +4896,11 @@ fails skip the entry snapshot. append_100 ~7.2×, append_500 ~30× (hardened
 min). Skipped heap-reclaim / trail-undo for now — peel removed the hot path.
 Details: `docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`,
 `docs/WAM_PERF_CROSS_TARGET.md`, `docs/WAM_KOTLIN_BENCH.md`.
+
+## Kotlin — EMIT-KOTLIN-5 (2026-07-15)
+
+Deterministic-only mid-body `call` + arithmetic `builtin_call` (shared
+`wamEvalArith`). Fib/ack lower; nondet mid-body callers decline. Bench
+(hardened min): fib_15 **1.85×**, ack_23 **1.78×**. Mid-body JVM stack
+ceiling ~750–780 frames. Details: `docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md`,
+`docs/WAM_KOTLIN_BENCH.md`, `docs/WAM_KOTLIN_STATUS.md`.

--- a/examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl
+++ b/examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl
@@ -138,13 +138,13 @@ bench_case(append_500,
 bench_case(fib_15,
            [user:bk_fib/2],
            'bk_fib/2',
-           400,
+           80,
            'run { val st = WamState(); st.writeRegister("A1", Value.IntVal(15L)); st.writeRegister("A2", Value.IntVal(610L)); st }',
            ['bk_fib/2']).
 bench_case(ack_23,
            [user:bk_ack/3],
            'bk_ack/3',
-           2000,
+           800,
            'run { val st = WamState(); st.writeRegister("A1", Value.IntVal(2L)); st.writeRegister("A2", Value.IntVal(3L)); st.writeRegister("A3", Value.IntVal(9L)); st }',
            ['bk_ack/3']).
 

--- a/examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl
+++ b/examples/benchmark/run_wam_kotlin_lowered_vs_interpreter.pl
@@ -30,6 +30,8 @@
 :- dynamic user:bk_t4/2.
 :- dynamic user:bk_member/2.
 :- dynamic user:bk_append/3.
+:- dynamic user:bk_fib/2.
+:- dynamic user:bk_ack/3.
 
 main :-
     current_prolog_flag(argv, Argv),
@@ -63,7 +65,15 @@ setup_benchmark_predicates :-
     assertz(user:bk_member(X, [X|_])),
     assertz(user:(bk_member(X, [_|T]) :- bk_member(X, T))),
     assertz(user:bk_append([], L, L)),
-    assertz(user:(bk_append([H|T], L, [H|R]) :- bk_append(T, L, R))).
+    assertz(user:(bk_append([H|T], L, [H|R]) :- bk_append(T, L, R))),
+    assertz(user:bk_fib(0, 0)),
+    assertz(user:bk_fib(1, 1)),
+    assertz(user:(bk_fib(N, R) :- N > 1, N1 is N - 1, N2 is N - 2,
+        bk_fib(N1, R1), bk_fib(N2, R2), R is R1 + R2)),
+    assertz(user:(bk_ack(0, N, R) :- R is N + 1)),
+    assertz(user:(bk_ack(M, 0, R) :- M > 0, M1 is M - 1, bk_ack(M1, 1, R))),
+    assertz(user:(bk_ack(M, N, R) :- M > 0, N > 0, M1 is M - 1, N1 is N - 1,
+        bk_ack(M, N1, R1), bk_ack(M1, R1, R))).
 
 cleanup_benchmark_predicates :-
     retractall(user:bk_fact(_, _)),
@@ -71,7 +81,9 @@ cleanup_benchmark_predicates :-
     retractall(user:bk_color(_)),
     retractall(user:bk_t4(_, _)),
     retractall(user:bk_member(_, _)),
-    retractall(user:bk_append(_, _, _)).
+    retractall(user:bk_append(_, _, _)),
+    retractall(user:bk_fib(_, _)),
+    retractall(user:bk_ack(_, _, _)).
 
 %% case(Name, Preds, PredKey, Iterations, StateSetupKotlin, ExpectNativeKeys)
 bench_case(fact,
@@ -122,6 +134,19 @@ bench_case(append_500,
            300,
            'run { val st = WamState(); val a = intRangeList(500); val b = intRangeList(500); st.writeRegister("A1", a); st.writeRegister("A2", b); st.writeRegister("A3", st.newVariable("R")); st }',
            ['bk_append/3']).
+% EMIT-KOTLIN-5: mid-body call + arithmetic (tree recursion / ack).
+bench_case(fib_15,
+           [user:bk_fib/2],
+           'bk_fib/2',
+           400,
+           'run { val st = WamState(); st.writeRegister("A1", Value.IntVal(15L)); st.writeRegister("A2", Value.IntVal(610L)); st }',
+           ['bk_fib/2']).
+bench_case(ack_23,
+           [user:bk_ack/3],
+           'bk_ack/3',
+           2000,
+           'run { val st = WamState(); st.writeRegister("A1", Value.IntVal(2L)); st.writeRegister("A2", Value.IntVal(3L)); st.writeRegister("A3", Value.IntVal(9L)); st }',
+           ['bk_ack/3']).
 
 %% row(Name, IMin, IMed, LMin, LMed, SpeedupMin, SpeedupMed, NativeOk, Status)
 run_case(OutDir, row(Name, IMin, IMed, LMin, LMed, SpMin, SpMed, NativeOk, Status)) :-

--- a/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
@@ -10,6 +10,7 @@
 :- use_module(library(lists)).
 :- use_module(wam_text_parser, [wam_classify_constant_token/2]).
 :- use_module(wam_clause_chain, [clause_chain/2]).
+:- use_module(wam_target, [compile_predicate_to_wam/3]).
 
 % ============================================================================
 % Emission plan (T5 clause_chain → T4 multi_clause_n → T1 deterministic)
@@ -33,6 +34,7 @@ skippable_prefix_line([]).
 skippable_prefix_line([First|_]) :- sub_string(First, _, 1, 0, ":").
 skippable_prefix_line(["switch_on_constant"|_]).
 skippable_prefix_line(["switch_on_constant_a2"|_]).
+skippable_prefix_line(["switch_on_constant_fallthrough"|_]).
 skippable_prefix_line(["switch_on_structure"|_]).
 skippable_prefix_line(["switch_on_term"|_]).
 skippable_prefix_line(["switch_on_term_a2"|_]).
@@ -45,8 +47,9 @@ classify_clause_shape([FirstLine|Rest],
     clause_chain(Terms, chain(Guards)),
     forall(member(guard(_, Rem), Guards), kotlin_chain_rem_supported(Rem)),
     !.
-% T4: multi-clause with only supported deterministic bodies (no mid-body call).
-% Last-call `execute` is allowed (EMIT-KOTLIN-4); mid-body `call` is EMIT-KOTLIN-5.
+% T4: multi-clause with supported bodies. Last-call `execute` (EMIT-KOTLIN-4)
+% and deterministic mid-body `call` (EMIT-KOTLIN-5) are allowed at classify
+% time; `wam_kotlin_lowerable/3` enforces the mid-body determinism gate.
 classify_clause_shape([FirstLine|Rest], plan(multi_clause_n, none, Clauses)) :-
     wam_kotlin_target:tokenize_wam_line(FirstLine, ["try_me_else", _AltStr]),
     kotlin_split_clause_lines([FirstLine|Rest], Clauses),
@@ -95,10 +98,7 @@ kotlin_chain_rem_supported([T|Rest]) :-
     (   T = get_constant(_, _)
     ->  true
     ;   T = line(Parts)
-    ->  (   Parts = ["call"|_]
-        ->  fail
-        ;   parts_supported(Parts)
-        )
+    ->  parts_supported(Parts)
     ),
     kotlin_chain_rem_supported(Rest).
 
@@ -114,6 +114,7 @@ kotlin_t4_instr_line(Line) :-
     \+ sub_string(F, _, 1, 0, ":"),
     \+ member(F, ["try_me_else", "retry_me_else", "trust_me",
                   "switch_on_constant", "switch_on_constant_a2",
+                  "switch_on_constant_fallthrough",
                   "switch_on_structure", "switch_on_term",
                   "switch_on_term_a2"]).
 
@@ -137,30 +138,86 @@ kotlin_t4_clause_line_supported(Line) :-
     wam_kotlin_target:tokenize_wam_line(Line, Parts),
     ( Parts == [] -> true ; parts_supported(Parts) ),
     Parts \= ["cut_ite"|_],
-    Parts \= ["jump"|_],
-    % Mid-body call needs a continuation — EMIT-KOTLIN-5.
-    \+ (Parts = ["call"|_]).
+    Parts \= ["jump"|_].
 
 kotlin_t4_terminal_line(Line) :-
     wam_kotlin_target:tokenize_wam_line(Line, Parts),
     kotlin_is_terminal_parts(Parts).
 
-wam_kotlin_lowerable(_PI, WamCode, Reason) :-
+%% wam_kotlin_lowerable(+PI, +WamCode, -Reason)
+%  EMIT-KOTLIN-5: mid-body `call` is allowed only when every call target is
+%  safe under first-solution semantics — self-recursion or a single-clause
+%  deterministic callee. Multi-clause callees (member, choice facts) DECLINE
+%  because inline `if (!dispatch) return false` cannot backtrack into them.
+wam_kotlin_lowerable(PI, WamCode, Reason) :-
+    kotlin_pi_module_key(PI, Module, SelfKey),
     catch(build_emission_plan(WamCode, plan(Reason, _, Payload)), _, fail),
+    % Visiting tracks only single-clause callees under proof (not SelfKey),
+    % so a helper that mid-body-calls back into a multi-clause Self declines.
     (   Reason == clause_chain
     ->  Payload = chain_payload(Guards),
-        forall(member(guard(_, Rem), Guards), kotlin_chain_rem_supported(Rem))
+        forall(member(guard(_, Rem), Guards), kotlin_chain_rem_supported(Rem)),
+        forall(member(guard(_, Rem), Guards),
+               kotlin_chain_rem_calls_safe(Module, SelfKey, Rem, []))
     ;   Reason == multi_clause_n
     ->  forall(member(Cl, Payload),
                ( forall(member(Line, Cl), line_supported(Line)),
-                 \+ kotlin_clause_has_call(Cl) ))
+                 kotlin_lines_calls_safe(Module, SelfKey, Cl, []) ))
     ;   forall(member(Line, Payload), line_supported(Line)),
-        \+ kotlin_clause_has_call(Payload)
+        kotlin_lines_calls_safe(Module, SelfKey, Payload, [])
     ).
 
-kotlin_clause_has_call(Lines) :-
-    member(Line, Lines),
-    wam_kotlin_target:tokenize_wam_line(Line, ["call"|_]).
+kotlin_pi_module_key(Module:Pred/Arity, Module, Pred/Arity) :- !.
+kotlin_pi_module_key(Pred/Arity, user, Pred/Arity).
+
+kotlin_chain_rem_calls_safe(Module, SelfKey, Rem, Visiting) :-
+    forall(
+        ( member(T, Rem), T = line(Parts), Parts = ["call"|_] ),
+        kotlin_call_parts_safe(Module, SelfKey, Parts, Visiting)
+    ).
+
+kotlin_lines_calls_safe(Module, SelfKey, Lines, Visiting) :-
+    forall(
+        ( member(Line, Lines),
+          wam_kotlin_target:tokenize_wam_line(Line, Parts),
+          Parts = ["call"|_]
+        ),
+        kotlin_call_parts_safe(Module, SelfKey, Parts, Visiting)
+    ).
+
+kotlin_call_parts_safe(Module, SelfKey, Parts, Visiting) :-
+    kotlin_call_target_key(Parts, CalleeKey),
+    kotlin_safe_midbody_callee(Module, SelfKey, CalleeKey, Visiting).
+
+%% kotlin_safe_midbody_callee(+Module, +SelfKey, +CalleeKey, +Visiting)
+%  Safe iff callee is Self (recursive) or a single-clause deterministic
+%  predicate whose own mid-body calls are similarly safe. Multi-clause
+%  callees DECLINE — first-solution dispatch cannot backtrack into them.
+%  When unsure → fail (decline).
+kotlin_safe_midbody_callee(_Module, SelfKey, SelfKey, _Visiting) :- !.
+kotlin_safe_midbody_callee(_Module, _SelfKey, CalleeKey, Visiting) :-
+    memberchk(CalleeKey, Visiting), !.
+kotlin_safe_midbody_callee(Module, _SelfKey, Pred/Arity, Visiting) :-
+    catch(compile_predicate_to_wam(Module:Pred/Arity, [], WamText), _, fail),
+    catch(build_emission_plan(WamText, plan(Reason, _, Payload)), _, fail),
+    Reason == deterministic,
+    Visiting1 = [Pred/Arity|Visiting],
+    forall(member(Line, Payload), line_supported(Line)),
+    kotlin_lines_calls_safe(Module, Pred/Arity, Payload, Visiting1).
+
+kotlin_call_target_key(["call", PredArity, _ArityStr|_], Key) :-
+    kotlin_pred_key_from_token(PredArity, Key), !.
+kotlin_call_target_key(["call", PredArity], Key) :-
+    kotlin_pred_key_from_token(PredArity, Key).
+
+kotlin_pred_key_from_token(Tok, Pred/Arity) :-
+    kotlin_execute_pred_key(Tok, KeyStr),
+    atom_string(KeyAtom, KeyStr),
+    atomic_list_concat(Parts, '/', KeyAtom),
+    append(NameParts, [ArityAtom], Parts),
+    NameParts \= [],
+    atomic_list_concat(NameParts, '/', Pred),
+    atom_number(ArityAtom, Arity).
 
 line_supported(Line) :-
     wam_kotlin_target:tokenize_wam_line(Line, Parts),
@@ -168,19 +225,21 @@ line_supported(Line) :-
     ->  true
     ;   Parts = [F|_], sub_string(F, _, 1, 0, ":")
     ->  true
-    ;   Parts = ["call"|_]
-    ->  fail
     ;   parts_supported(Parts)
     ).
 
-% Structure/list + unify/set + last-call execute. Mid-body call → EMIT-KOTLIN-5.
-% get_variable/put_variable must emit `run { ... }` — see emit_line_parts/2.
+% Structure/list + unify/set + last-call execute + det mid-body call +
+% arithmetic builtin_call (EMIT-KOTLIN-5). get_variable/put_variable must
+% emit `run { ... }` — see emit_line_parts/2.
 parts_supported(["allocate"]).
 parts_supported(["deallocate"]).
 parts_supported(["proceed"]).
 parts_supported(["fail"]).
 parts_supported(["execute", _]).
 parts_supported(["execute", _, _]).
+parts_supported(["call", _]).
+parts_supported(["call", _, _]).
+parts_supported(["builtin_call", Op, _]) :- kotlin_det_builtin(Op).
 parts_supported(["get_constant", _, _]).
 parts_supported(["get_variable", _, _]).
 parts_supported(["get_value", _, _]).
@@ -204,6 +263,12 @@ parts_supported(["set_value", _]).
 parts_supported(["set_constant", _]).
 parts_supported(["set_nil"]).
 parts_supported(["set_integer", _]).
+
+% Deterministic builtins only — same ops fib/ack/builtins need. Do NOT
+% re-implement; lowered emit calls kotlinLoBuiltinCall → wamEvalArith.
+kotlin_det_builtin(Op) :-
+    atom_string(Op, S),
+    memberchk(S, ["is/2", "=:=/2", "=\\=/2", "</2", ">/2", "=</2", ">=/2", "=/2", "true/0"]).
 
 kotlin_lowered_func_name(Functor/Arity, Name) :-
     atom_string(Functor, S),
@@ -367,6 +432,9 @@ emit_kotlin_t5_rem([line(Parts)|Rest], Ind, Ended) :- !,
     ;   Parts = ["execute"|_]
     ->  emit_line_parts(Parts, Ind),
         Ended = true
+    ;   Parts = ["call"|_]
+    ->  emit_line_parts(Parts, Ind),
+        emit_kotlin_t5_rem(Rest, Ind, Ended)
     ;   emit_line_parts(Parts, Ind),
         emit_kotlin_t5_rem(Rest, Ind, Ended)
     ).
@@ -394,6 +462,19 @@ emit_line_parts(["execute", Pred, ArityStr], I) :- !,
     format(string(PA), '~w/~w', [Name, ArityStr]),
     escape_kotlin_string(PA, Esc),
     format("~wreturn dispatch(\"~w\", state)~n", [I, Esc]).
+% EMIT-KOTLIN-5: mid-body call — first-solution only (determinism gated above).
+emit_line_parts(["call", PredArity], I) :- !,
+    kotlin_execute_pred_key(PredArity, Key),
+    escape_kotlin_string(Key, Esc),
+    format("~wif (!dispatch(\"~w\", state)) return false~n", [I, Esc]).
+emit_line_parts(["call", PredArity, _ArityStr], I) :- !,
+    kotlin_execute_pred_key(PredArity, Key),
+    escape_kotlin_string(Key, Esc),
+    format("~wif (!dispatch(\"~w\", state)) return false~n", [I, Esc]).
+emit_line_parts(["builtin_call", Op, _Arity], I) :- !,
+    atom_string(Op, OpS),
+    escape_kotlin_string(OpS, Esc),
+    format("~wif (!kotlinLoBuiltinCall(state, \"~w\")) return false~n", [I, Esc]).
 emit_line_parts(["allocate"], I) :- !,
     format("~wstate.allocateEnvironment()~n", [I]).
 emit_line_parts(["deallocate"], I) :- !,

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -528,60 +528,10 @@ class WamRuntime(private val program: WamProgram) {
         return jumpToLabel(state, target)
     }
 
-    // M148: arithmetic evaluation for is/2 and the arith compares.
-    // Handles numeric leaves and the standard binary/unary operators
-    // built via put_structure. Returns null for non-evaluable input
-    // (ISO lax semantics: the builtin then fails).
-    fun evalArith(state: WamState, value: Value?): Value? {
-        return when (val d = state.resolve(value)) {
-            is Value.IntVal -> d
-            is Value.FloatVal -> d
-            is Value.Struct -> {
-                // Functor keys are "name/arity". Strip only the trailing
-                // "/<digits>" — a naive split("/") breaks slash-bearing ops
-                // like "//" (key "///2") and "/" (key "//2").
-                val name = functorName(d.functor)
-                if (d.args.size == 2) {
-                    val a = evalArith(state, d.args[0]) ?: return null
-                    val b = evalArith(state, d.args[1]) ?: return null
-                    if (a is Value.IntVal && b is Value.IntVal) {
-                        val x = a.value; val y = b.value
-                        when (name) {
-                            "+" -> Value.IntVal(x + y)
-                            "-" -> Value.IntVal(x - y)
-                            "*" -> Value.IntVal(x * y)
-                            "//" -> if (y == 0L) null else Value.IntVal(x / y)
-                            "mod" -> if (y == 0L) null else Value.IntVal(Math.floorMod(x, y))
-                            "/" -> if (y == 0L) null else if (x % y == 0L) Value.IntVal(x / y) else Value.FloatVal(x.toDouble() / y)
-                            else -> null
-                        }
-                    } else {
-                        val x = arithDouble(a); val y = arithDouble(b)
-                        when (name) {
-                            "+" -> Value.FloatVal(x + y)
-                            "-" -> Value.FloatVal(x - y)
-                            "*" -> Value.FloatVal(x * y)
-                            "/" -> if (y == 0.0) null else Value.FloatVal(x / y)
-                            else -> null
-                        }
-                    }
-                } else if (d.args.size == 1 && name == "-") {
-                    when (val a = evalArith(state, d.args[0])) {
-                        is Value.IntVal -> Value.IntVal(-a.value)
-                        is Value.FloatVal -> Value.FloatVal(-a.value)
-                        else -> null
-                    }
-                } else null
-            }
-            else -> null
-        }
-    }
+    // M148 / EMIT-KOTLIN-5: shared with lowered kotlinLoBuiltinCall.
+    fun evalArith(state: WamState, value: Value?): Value? = wamEvalArith(state, value)
 
-    fun arithDouble(v: Value): Double = when (v) {
-        is Value.IntVal -> v.value.toDouble()
-        is Value.FloatVal -> v.value
-        else -> Double.NaN
-    }
+    fun arithDouble(v: Value): Double = wamArithDouble(v)
 
     fun step(state: WamState, instruction: Instruction): Boolean {
         when (instruction.op) {
@@ -833,23 +783,8 @@ class WamRuntime(private val program: WamProgram) {
                             else -> return false
                         }
                     }
-                    "is/2" -> {
-                        val result = evalArith(state, state.readRegister("A2")) ?: return false
-                        if (!state.unify(state.readRegister("A1"), result)) return false
-                        state.pc += 1; return true
-                    }
-                    "=:=/2", "=\\=/2", "</2", ">/2", "=</2", ">=/2" -> {
-                        val a = arithDouble(evalArith(state, state.readRegister("A1")) ?: return false)
-                        val b = arithDouble(evalArith(state, state.readRegister("A2")) ?: return false)
-                        val ok = when (op) {
-                            "=:=/2" -> a == b
-                            "=\\=/2" -> a != b
-                            "</2" -> a < b
-                            ">/2" -> a > b
-                            "=</2" -> a <= b
-                            else -> a >= b
-                        }
-                        if (!ok) return false
+                    "is/2", "=:=/2", "=\\=/2", "</2", ">/2", "=</2", ">=/2" -> {
+                        if (!kotlinLoBuiltinCall(state, op)) return false
                         state.pc += 1; return true
                     }
                 }
@@ -928,6 +863,55 @@ fun functorArity(functor: String): Int? =
 // "///2" → "//", "//2" → "/", "+/2" → "+".
 fun functorName(functor: String): String =
     functor.substringBeforeLast('/', missingDelimiterValue = functor)
+
+// Shared arithmetic (interpreter step + lowered kotlinLoBuiltinCall).
+fun wamEvalArith(state: WamState, value: Value?): Value? {
+    return when (val d = state.resolve(value)) {
+        is Value.IntVal -> d
+        is Value.FloatVal -> d
+        is Value.Struct -> {
+            val name = functorName(d.functor)
+            if (d.args.size == 2) {
+                val a = wamEvalArith(state, d.args[0]) ?: return null
+                val b = wamEvalArith(state, d.args[1]) ?: return null
+                if (a is Value.IntVal && b is Value.IntVal) {
+                    val x = a.value; val y = b.value
+                    when (name) {
+                        "+" -> Value.IntVal(x + y)
+                        "-" -> Value.IntVal(x - y)
+                        "*" -> Value.IntVal(x * y)
+                        "//" -> if (y == 0L) null else Value.IntVal(x / y)
+                        "mod" -> if (y == 0L) null else Value.IntVal(Math.floorMod(x, y))
+                        "/" -> if (y == 0L) null else if (x % y == 0L) Value.IntVal(x / y) else Value.FloatVal(x.toDouble() / y)
+                        else -> null
+                    }
+                } else {
+                    val x = wamArithDouble(a); val y = wamArithDouble(b)
+                    when (name) {
+                        "+" -> Value.FloatVal(x + y)
+                        "-" -> Value.FloatVal(x - y)
+                        "*" -> Value.FloatVal(x * y)
+                        "/" -> if (y == 0.0) null else Value.FloatVal(x / y)
+                        else -> null
+                    }
+                }
+            } else if (d.args.size == 1 && name == "-") {
+                when (val a = wamEvalArith(state, d.args[0])) {
+                    is Value.IntVal -> Value.IntVal(-a.value)
+                    is Value.FloatVal -> Value.FloatVal(-a.value)
+                    else -> null
+                }
+            } else null
+        }
+        else -> null
+    }
+}
+
+fun wamArithDouble(v: Value): Double = when (v) {
+    is Value.IntVal -> v.value.toDouble()
+    is Value.FloatVal -> v.value
+    else -> Double.NaN
+}
 
 fun parseWamCliValue(token: String): Value =
     parseStructToken(token)
@@ -1011,5 +995,30 @@ fun kotlinLoUnifyConstant(state: WamState, value: Value): Boolean {
     return when (state.context) {
         is WamContext.Write -> state.pushWriteArg(value)
         else -> state.unify(state.nextReadArg(), value)
+    }
+}
+
+/** Lowered arithmetic / compare / unify builtins — same ops as interpreter `builtin_call`. */
+fun kotlinLoBuiltinCall(state: WamState, op: String): Boolean {
+    return when (op) {
+        "true/0" -> true
+        "=/2" -> state.unify(state.readRegister("A1"), state.readRegister("A2"))
+        "is/2" -> {
+            val result = wamEvalArith(state, state.readRegister("A2")) ?: return false
+            state.unify(state.readRegister("A1"), result)
+        }
+        "=:=/2", "=\\=/2", "</2", ">/2", "=</2", ">=/2" -> {
+            val a = wamArithDouble(wamEvalArith(state, state.readRegister("A1")) ?: return false)
+            val b = wamArithDouble(wamEvalArith(state, state.readRegister("A2")) ?: return false)
+            when (op) {
+                "=:=/2" -> a == b
+                "=\\=/2" -> a != b
+                "</2" -> a < b
+                ">/2" -> a > b
+                "=</2" -> a <= b
+                else -> a >= b
+            }
+        }
+        else -> false
     }
 }

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -985,8 +985,8 @@ ct_teardown(cpp, cpp_ctx(Dir, Map)) :-
 %   kotlin            — emit_mode(interpreter)
 %   kotlin_functions  — emit_mode(functions) (native-first + WAM fallback)
 % Classic multi-clause programs with last-call execute (member/append/acc-reverse)
-% lower under kotlin_functions (EMIT-KOTLIN-4). Mid-body call (fib/ack) still
-% declines to the interpreter until EMIT-KOTLIN-5.
+% and deterministic mid-body call + arithmetic (fib/ack) lower under
+% kotlin_functions (EMIT-KOTLIN-4/5). Nondeterministic mid-body call declines.
 % ============================================================
 
 ct_build(kotlin, Preds, Queries, kotlin_ctx(Dir, Map)) :-

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -42,6 +42,14 @@
 :- dynamic kt4_rev_ok/0.
 :- dynamic kt4_rev_bad/0.
 :- dynamic kt4_fib/2.
+:- dynamic kt5_fib/2.
+:- dynamic kt5_fib_ok/0.
+:- dynamic kt5_fib_bad/0.
+:- dynamic kt5_ack/3.
+:- dynamic kt5_ack_ok/0.
+:- dynamic kt5_ack_bad/0.
+:- dynamic kt5_nd_ok/0.
+:- dynamic kt5_choice/1.
 
 :- begin_tests(wam_kotlin_target).
 
@@ -585,8 +593,7 @@ test(y_env_recursion_fib, [condition(gradle_available), nondet]) :-
         )
     ).
 
-% EMIT-KOTLIN-3: deterministic multi-clause (no mid-body call) lowers;
-% EMIT-KOTLIN-4: last-call execute (member) also lowers; fib stays declined.
+% EMIT-KOTLIN-3: deterministic multi-clause lowers; member lowers via execute.
 test(functions_mode_multi_clause_partition, [nondet]) :-
     setup_call_cleanup(
         (   retractall(user:kt3_color(_)),
@@ -734,8 +741,8 @@ test(functions_mode_gradle_multi_clause_t4, [condition(gradle_available), nondet
         retractall(user:kt3_t4(_, _))
     ).
 
-% EMIT-KOTLIN-4: last-call execute — member/append/acc-reverse LOWER;
-% mid-body call (fib) still declines.
+% EMIT-KOTLIN-4/5: last-call execute (member/append/acc-reverse) and
+% deterministic mid-body call (fib) LOWER.
 test(functions_mode_execute_partition, [nondet]) :-
     setup_call_cleanup(
         (   retractall(user:kt4_mem(_, _)),
@@ -764,11 +771,14 @@ test(functions_mode_execute_partition, [nondet]) :-
             assertion(memberchk(native(kt4_app/3, _), Native)),
             assertion(memberchk(native(kt4_rev_acc/3, _), Native)),
             assertion(memberchk(native(kt4_rev/2, _), Native)),
-            assertion(\+ memberchk(native(kt4_fib/2, _), Native)),
+            assertion(memberchk(native(kt4_fib/2, _), Native)),
             memberchk(native(kt4_mem/2, lowered(_, _, MemCode)), Native),
             assertion(has_substring(MemCode, 'return dispatch("kt4_mem/2"')),
             memberchk(native(kt4_app/3, lowered(_, _, AppCode)), Native),
-            assertion(has_substring(AppCode, 'return dispatch("kt4_app/3"'))
+            assertion(has_substring(AppCode, 'return dispatch("kt4_app/3"')),
+            memberchk(native(kt4_fib/2, lowered(_, _, FibCode)), Native),
+            assertion(has_substring(FibCode, 'kotlinLoBuiltinCall')),
+            assertion(has_substring(FibCode, 'if (!dispatch("kt4_fib/2"'))
         ),
         (   retractall(user:kt4_mem(_, _)),
             retractall(user:kt4_app(_, _, _)),
@@ -905,6 +915,115 @@ test(functions_mode_gradle_execute_acc_reverse, [condition(gradle_available), no
             retractall(user:kt4_rev(_, _)),
             retractall(user:kt4_rev_ok),
             retractall(user:kt4_rev_bad)
+        )
+    ).
+
+% EMIT-KOTLIN-5: nondeterministic mid-body call DECLINES (first-solution
+% would wrong-fail `choice(X), X = b` when choice has a before b).
+test(functions_mode_midbody_nondet_declines, [nondet]) :-
+    setup_call_cleanup(
+        (   retractall(user:kt5_nd_ok),
+            retractall(user:kt5_choice(_)),
+            assertz(user:(kt5_nd_ok :- kt5_choice(X), X = b)),
+            assertz(user:kt5_choice(a)),
+            assertz(user:kt5_choice(b))
+        ),
+        (   wam_kotlin_partition_predicates(functions,
+                [user:kt5_nd_ok/0, user:kt5_choice/1], Native, Wam, Failed),
+            assertion(Failed == []),
+            assertion(\+ memberchk(native(kt5_nd_ok/0, _), Native)),
+            assertion(memberchk(wam(kt5_nd_ok/0, _), Wam)),
+            % Choice facts alone may still lower (T5); the *caller* must not.
+            assertion(memberchk(native(kt5_choice/1, _), Native))
+        ),
+        (   retractall(user:kt5_nd_ok),
+            retractall(user:kt5_choice(_))
+        )
+    ).
+
+% EMIT-KOTLIN-5: fib/ack LOWER and match interpreter (ok + bad depths).
+test(functions_mode_gradle_midbody_fib_ack, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_midbody_fib_ack',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    Preds = [user:kt5_fib_ok/0, user:kt5_fib_bad/0, user:kt5_fib/2,
+             user:kt5_ack_ok/0, user:kt5_ack_bad/0, user:kt5_ack/3],
+    setup_call_cleanup(
+        (   retractall(user:kt5_fib(_, _)),
+            retractall(user:kt5_fib_ok),
+            retractall(user:kt5_fib_bad),
+            retractall(user:kt5_ack(_, _, _)),
+            retractall(user:kt5_ack_ok),
+            retractall(user:kt5_ack_bad),
+            assertz(user:kt5_fib(0, 0)),
+            assertz(user:kt5_fib(1, 1)),
+            assertz(user:(kt5_fib(N, R) :- N > 1, N1 is N - 1, N2 is N - 2,
+                kt5_fib(N1, R1), kt5_fib(N2, R2), R is R1 + R2)),
+            assertz(user:(kt5_fib_ok :- kt5_fib(10, 55))),
+            assertz(user:(kt5_fib_bad :- kt5_fib(10, 54))),
+            assertz(user:(kt5_ack(0, N, R) :- R is N + 1)),
+            assertz(user:(kt5_ack(M, 0, R) :- M > 0, M1 is M - 1, kt5_ack(M1, 1, R))),
+            assertz(user:(kt5_ack(M, N, R) :- M > 0, N > 0, M1 is M - 1, N1 is N - 1,
+                kt5_ack(M, N1, R1), kt5_ack(M1, R1, R))),
+            assertz(user:(kt5_ack_ok :- kt5_ack(2, 3, 9))),
+            assertz(user:(kt5_ack_bad :- kt5_ack(2, 3, 8)))
+        ),
+        (   wam_kotlin_target:write_wam_kotlin_project(
+                Preds, [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt5_fib_ok/0'], IFO, _, SF1),
+            assertion(SF1 == exit(0)),
+            normalize_space(string(IFOTrim), IFO),
+            assertion(IFOTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt5_fib_bad/0'], IFB, _, SF2),
+            assertion(SF2 == exit(0)),
+            normalize_space(string(IFBTrim), IFB),
+            assertion(IFBTrim == "false"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt5_ack_ok/0'], IAO, _, SA1),
+            assertion(SA1 == exit(0)),
+            normalize_space(string(IAOTrim), IAO),
+            assertion(IAOTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt5_ack_bad/0'], IAB, _, SA2),
+            assertion(SA2 == exit(0)),
+            normalize_space(string(IABTrim), IAB),
+            assertion(IABTrim == "false"),
+            wam_kotlin_target:write_wam_kotlin_project(
+                Preds, [emit_mode(functions), conformance_main(true)], TmpDir),
+            read_file_to_string(
+                'output/test_wam_kotlin_midbody_fib_ack/src/main/kotlin/generated/wam/Main.kt',
+                Main, []),
+            assertion(has_substring(Main, 'fun lowered_kt5_fib_2')),
+            assertion(has_substring(Main, 'registerNative("kt5_fib/2"')),
+            assertion(has_substring(Main, 'fun lowered_kt5_ack_3')),
+            assertion(has_substring(Main, 'registerNative("kt5_ack/3"')),
+            assertion(has_substring(Main, 'kotlinLoBuiltinCall')),
+            assertion(has_substring(Main, 'if (!dispatch("kt5_fib/2"')),
+            assertion(has_substring(Main, 'if (!dispatch("kt5_ack/3"')),
+            run_gradle(TmpDir, ['-q', 'compileKotlin'], _, CompileErr, CS),
+            assertion(CS == exit(0)),
+            assertion(\+ has_substring(CompileErr, "error:")),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt5_fib_ok/0'], FFO, _, SF3),
+            assertion(SF3 == exit(0)),
+            normalize_space(string(FFOTrim), FFO),
+            assertion(FFOTrim == IFOTrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt5_fib_bad/0'], FFB, _, SF4),
+            assertion(SF4 == exit(0)),
+            normalize_space(string(FFBTrim), FFB),
+            assertion(FFBTrim == IFBTrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt5_ack_ok/0'], FAO, _, SA3),
+            assertion(SA3 == exit(0)),
+            normalize_space(string(FAOTrim), FAO),
+            assertion(FAOTrim == IAOTrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt5_ack_bad/0'], FAB, _, SA4),
+            assertion(SA4 == exit(0)),
+            normalize_space(string(FABTrim), FAB),
+            assertion(FABTrim == IABTrim)
+        ),
+        (   retractall(user:kt5_fib(_, _)),
+            retractall(user:kt5_fib_ok),
+            retractall(user:kt5_fib_bad),
+            retractall(user:kt5_ack(_, _, _)),
+            retractall(user:kt5_ack_ok),
+            retractall(user:kt5_ack_bad)
         )
     ).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lower mid-body deterministic `call` and arithmetic `builtin_call` (`is/2`, compares, `=/2`) so **fib/ack** lower under `emit_mode(functions)` instead of declining.

## Determinism gate (hard correctness constraint)

Inline `if (!dispatch("P/N", state)) return false` takes only the **first** solution and cannot backtrack into the callee. Mid-body `call` lowers **only** when every target is:

- **self-recursion**, or
- a **single-clause deterministic** callee (same gate recursively)

Multi-clause callees decline. Test: `kt5_nd_ok :- choice(X), X = b` stays on the interpreter (would wrong-fail if lowered). When unsure → decline.

## Arithmetic

`kotlinLoBuiltinCall` + top-level `wamEvalArith` — same evaluation as the interpreter `builtin_call` path (no re-implementation).

## Stack ceiling

Linear mid-body-call recursion → `StackOverflowError` around **~750–780** frames on the default JVM stack. Fib/ack need O(n) frames; conformance `fib(10)` / `ack(2,3)` are safe. Prefer decline over wrong answers if a workload would overflow.

Classic non-tail `reverse` via mid-body `append` still declines (`append` is multi-clause). Acc-reverse already lowers via `execute`.

## Bench (hardened 5/15, min speedup)

| program | speedup_min |
|---|---:|
| fib_15 | **1.85×** |
| ack_23 | **1.78×** |
| append_500 | ~28× (unchanged class) |

## Acceptance

- [x] fib/ack LOWER + match interpreter (gradle differential; `registerNative`)
- [x] nondet mid-body caller DECLINES
- [x] unit suite + `CONFORMANCE_TARGETS=kotlin,kotlin_functions` green
- [x] BENCH table extended with fib/ack
- [x] docs: fleet card, STATUS, optimization history (boundary + stack ceiling)

## Env

`LANG=C.UTF-8`; gradle stderr may include daemon/`JAVA_TOOL_OPTIONS` noise — assert no `error:` only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

