### PR TITLE
WAM/LLVM plawk: braceless if/loop bodies + lock in guarded-if / regex-in-if

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -38,9 +38,9 @@ only (runtime pending) · ❌ missing.
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` / `continue` | ◐ | present in some loop contexts |
-| `if` with a plain (non-accumulator) body | ❌ | `{ if (c) { print $1 } }` is exit 3 — the scalar `if` lowering assumes branch bodies update scalars; blocks regex-in-`if` too |
-| regex in `if` (`if ($0 ~ /re/)`) | ◐ | condition parses (`~` ok); blocked by the guarded-print body above, not the regex |
-| brace-less `if`/loop body | ❌ | `if (c) print` (no braces) doesn't parse |
+| `if` with a plain (non-accumulator) body | ✅ | `{ if (c) { print $1 } }` compiles and runs (fixed by the while-runtime body-print enablers); if/else with plain bodies too |
+| regex in `if` (`if ($0 ~ /re/)`) | ✅ | `if ($0 ~ /re/) { … }` and `!~` compile and run — guards a plain body |
+| brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |
 | field assignment (`$2 = expr`) | ❌ | rebuilding `$0` from mutated fields not wired |
 | C-style `for (;;)` | ❌ | |
 | `exit [n]` | ❌ | |
@@ -118,9 +118,13 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    compile-time **type checking** of call sites (a mismatched call → error) and
    distinguishing `int` vs `float` for representation; all three keywords
    currently mean "numeric, skip coercion".
-2b. **`if` with a plain guarded body** — `{ if (c) { print $1 } }` doesn't
-   compile (the scalar `if` lowering assumes branch bodies update scalars); this
-   is what actually blocks regex-in-`if`. Fix the `if`-body lowering.
+2b. **`if` with a plain guarded body + regex-in-`if` + braceless bodies —
+   LANDED.** `{ if (c) { print $1 } }`, `if ($0 ~ /re/) { … }` / `!~`, and
+   if/else with plain bodies all compile and run (the guarded-print gap was
+   fixed by the while-runtime body-print enablers — a plain body no longer has
+   to update a scalar). Braceless bodies also landed: `if (c) print`,
+   `while (c) x++`, `do stmt while (c)`, and braceless else-if chains — a
+   control-flow body is a braced block *or* a single statement.
 3. **`printf` format coverage** — add `%f`/`%g` (f64 exists), `%c`, `%x`, and
    width/precision; the current subset is thin for real formatting.
 4. **`exit [n]`** — common and cheap; a flagged early-terminate of the record

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -696,6 +696,19 @@ action_block_close -->
     "}",
     ws.
 
+%% body_block(-Actions)//
+%
+%  A control-flow body: either a braced `{ ... }` action block, or -- awk-style
+%  -- a single braceless statement (`if (c) print`, `while (c) x++`). The braced
+%  form is tried first; a braceless body is exactly one action wrapped in a
+%  singleton list, so downstream lowering (which already takes an action list)
+%  is unchanged.
+body_block(Actions) -->
+    action_block(Actions),
+    !.
+body_block([Action]) -->
+    action(Action).
+
 %% pattern(-Pattern)//
 %
 %  awk pattern combinators: `!` binds tighter than `&&`, which binds
@@ -1565,7 +1578,7 @@ while_action(while_loop(Cond, Body)) -->
     "(", ws,
     while_condition(Cond), ws,
     ")", ws,
-    action_block(Body).
+    body_block(Body).
 
 % A `do { BODY } while (VAR CMP int)` loop -- the body runs at least once, then
 % repeats while the condition holds (the awk do-while control structure). Parses
@@ -1574,7 +1587,7 @@ while_action(while_loop(Cond, Body)) -->
 % clause; the leading `do` keyword distinguishes it.
 do_while_action(do_while_loop(Body, Cond)) -->
     "do", identifier_boundary, ws,
-    action_block(Body), ws,
+    body_block(Body), ws,
     "while", identifier_boundary, ws,
     "(", ws,
     while_condition(Cond), ws,
@@ -1626,10 +1639,15 @@ if_action(if(Pattern, ThenActions, ElseActions)) -->
     ws,
     ")",
     ws,
-    action_block(ThenActions),
+    body_block(ThenActions),
     if_else_part(ElseActions).
 
+% `else` may follow a braced then-body directly, or a braceless one across a
+% statement separator (`if (c) print x; else print y`) -- so tolerate an
+% optional separator before `else`. If no `else` follows, the clause fails and
+% backtracks (un-consuming the separator) to the empty else.
 if_else_part(ElseActions) -->
+    opt_action_sep,
     "else",
     identifier_boundary,
     if_else_body(ElseActions),
@@ -1637,13 +1655,19 @@ if_else_part(ElseActions) -->
 if_else_part([]) -->
     [].
 
+opt_action_sep -->
+    action_sep,
+    !.
+opt_action_sep -->
+    ws.
+
 if_else_body([ElseIfAction]) -->
     required_ws,
     if_action(ElseIfAction),
     !.
 if_else_body(ElseActions) -->
     ws,
-    action_block(ElseActions).
+    body_block(ElseActions).
 
 condition_pattern(Pattern) -->
     or_pattern(Pattern).

--- a/tests/test_plawk_if_bodies.pl
+++ b/tests/test_plawk_if_bodies.pl
@@ -1,0 +1,168 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `if` bodies and regex-in-`if`, plus braceless control-flow bodies.
+%
+% A guarded plain body (`{ if (c) { print $1 } }`) and a regex condition
+% (`if ($0 ~ /re/) { ... }`) compile and run -- the two most common awk
+% conditional idioms. Braceless bodies (`if (c) print`, `while (c) x++`,
+% `do stmt while (c)`) parse as a single statement, awk-style. These lock in the
+% behaviour and the braceless surface.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_if_bodies).
+
+% --- guarded plain bodies (no scalar update) --------------------------------
+
+% `{ if ($1 > 5) { print $1 } }` -- a guarded print, the bread-and-butter awk
+% conditional action.
+test(if_guarded_print, [condition(clang_available)]) :-
+    idir(Dir),
+    build_run(Dir, 'gp', "{ if ($1 > 5) { print $1 } }\n", "3\n7\n9\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "7\n9\n"),
+    !.
+
+% A string-literal print in a guarded body.
+test(if_guarded_literal, [condition(clang_available)]) :-
+    idir(Dir),
+    build_run(Dir, 'gl', "{ if ($1 > 5) { print \"big\" } }\n", "3\n7\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "big\n"),
+    !.
+
+% if / else with plain bodies.
+test(if_else_plain_bodies, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($1 > 5) { print \"big\" } else { print \"small\" } }\n",
+    build_run(Dir, 'ie', Src, "3\n7\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "small\nbig\n"),
+    !.
+
+% --- regex conditions in `if` -----------------------------------------------
+
+% `if ($0 ~ /re/)` -- a regex match as the condition, guarding a print.
+test(if_regex_match, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($0 ~ /err/) { print $1 } }\n",
+    build_run(Dir, 'rx', Src, "err 1\nok 2\nerr 3\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "err\nerr\n"),
+    !.
+
+% `if ($0 !~ /re/)` -- the negated match.
+test(if_regex_no_match, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($0 !~ /err/) { print $1 } }\n",
+    build_run(Dir, 'nx', Src, "err 1\nok 2\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "ok\n"),
+    !.
+
+% A scalar update inside a guarded `if` still works (no regression).
+test(if_scalar_update_still_works, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($1 > 5) { n++ } }\nEND { print n }\n",
+    build_run(Dir, 'su', Src, "3\n7\n9\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2\n"),
+    !.
+
+% --- braceless bodies (awk-style single statement) --------------------------
+
+% `if (c) print` -- a braceless then-body parses to a singleton action list.
+test(braceless_if_parses) :-
+    plawk_parse_string("{ if ($1 > 5) print $1 }\n",
+        program([], [rule(always,
+            [if(_Cond, [print([field(1)])], [])])], [])),
+    !.
+
+test(braceless_if_runs, [condition(clang_available)]) :-
+    idir(Dir),
+    build_run(Dir, 'bif', "{ if ($1 > 5) print $1 }\n", "3\n7\n9\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "7\n9\n"),
+    !.
+
+% `if (c) stmt; else stmt` -- braceless then and else across a separator.
+test(braceless_if_else_runs, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($1 > 5) print \"big\"; else print \"small\" }\n",
+    build_run(Dir, 'bie', Src, "3\n7\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "small\nbig\n"),
+    !.
+
+% A braceless else-if chain.
+test(braceless_else_if_chain, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($1 > 8) print \"hi\"; \c
+             else if ($1 > 4) print \"mid\"; \c
+             else print \"lo\" }\n",
+    build_run(Dir, 'bec', Src, "2\n6\n9\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "lo\nmid\nhi\n"),
+    !.
+
+% `while (c) stmt` -- a braceless loop body.
+test(braceless_while_runs, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ i = 0; while (i < 3) i++; print i }\n",
+    build_run(Dir, 'bw', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
+    !.
+
+% `do stmt while (c)` -- a braceless do-while body.
+test(braceless_do_while_runs, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ i = 0; do i++ while (i < 3); print i }\n",
+    build_run(Dir, 'bdw', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
+    !.
+
+% A braced body still parses and runs (no regression from the braceless path).
+test(braced_if_still_works, [condition(clang_available)]) :-
+    idir(Dir),
+    build_run(Dir, 'braced', "{ if ($1 > 5) { print $1 } }\n", "3\n7\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "7\n"),
+    !.
+
+:- end_tests(plawk_if_bodies).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+idir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_if_bodies', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

Investigating the "`if` with a plain guarded body doesn't compile" gap found it **already fixed**: `{ if (c) { print $1 } }`, `if ($0 ~ /re/) { … }` / `!~`, and if/else with plain bodies all compile and run now — the while-runtime body-print enablers (bare scalar-var print + body-printing scalar chain) also made an `if` branch body no longer need to update a scalar. This locks that in with tests.

The one real remaining gap was **braceless bodies**, now added: a control-flow body is a braced `{ … }` block **or** a single statement, awk-style —

```
if (c) print $1
if (c) print x; else print y      (and braceless else-if chains)
while (c) x++
do x++ while (c)
```

A new `body_block//1` tries the braced form first, else one action wrapped in a singleton list (downstream lowering, which takes an action list, is unchanged). `if_else_part` tolerates an optional statement separator before `else` so a braceless then-body composes with `else` across `;`/newline; if no `else` follows it backtracks (un-consuming the separator) to the empty else.

## Tests

`tests/test_plawk_if_bodies.pl` — guarded print/literal, if/else, regex `~` and `!~`, scalar-update-in-if (regression), braceless if / if-else / else-if / while / do-while, braced-still-works — 13 pass. Regression: while (15), else_if (13), prefix_print (221) green. Audit: gap 2b + braceless landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_