### PR TITLE
WAM/LLVM plawk: break/continue surface + guard (control-flow PR 3b)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -32,12 +32,13 @@ only (runtime pending) · ❌ missing.
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic) | ✅ | constant fields (`print 1`, `print "x"`) landed |
 | `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
-| `if` / `else` (chains) | ✅ | |
+| `if` / `else` (chains) | ◐ | condition is a field/pattern guard (`$1 > 2`, `$0 ~ /re/`); a **scalar-variable** condition (`if (i > 2)`) does not parse yet — needed for counter-based loop `break` (`PLAWK_CONTROL_FLOW_PLAN.md` §3b) |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
 | `while (COND)` | ✅ | runtime landed (loop-header phis); condition is scalar comparisons (`VAR CMP int`/`VAR`) combined with `&&`/`||` — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2–3. `break`/`continue` deferred (PR 3b) |
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |
 | `next` | ✅ | structural (guarded clause per rule) |
-| `break` / `continue` | ◐ | present in some loop contexts |
+| `break` (rule-level stream break) | ✅ | non-standard awk extension; stops the record stream |
+| `break` / `continue` (loop-local) | ⏳ | `continue` parses; loop-local break/continue is a clean not-yet error (guards a silent stream-break mis-compile) — runtime pending, `PLAWK_CONTROL_FLOW_PLAN.md` §3b |
 | `if` with a plain (non-accumulator) body | ✅ | `{ if (c) { print $1 } }` compiles and runs (fixed by the while-runtime body-print enablers); if/else with plain bodies too |
 | regex in `if` (`if ($0 ~ /re/)`) | ✅ | `if ($0 ~ /re/) { … }` and `!~` compile and run — guards a plain body |
 | brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -93,21 +93,36 @@ while.after.N:
    (`plawk_while_cond_vars` registers them). A single `VAR CMP int` still parses
    to a bare `cmp(...)`, so PR 2 is a strict subset. Tests:
    `tests/test_plawk_while.pl` (var-bound, `&&`, `||`, do-while var-bound).
-3b. **`break` / `continue` — DEFERRED (own PR).** Loop-control statements are a
-   separate, design-sensitive change and were intentionally split out:
+3b. **`break` / `continue` — SURFACE + GUARD LANDED; runtime is the follow-on.**
+   The `continue` keyword parses (to a `continue` action); `break` already did.
+   A `break` inside a loop body, or any `continue`, is now a **clean not-yet
+   error** (`check_loop_control`) — this **guards a silent mis-compile**: inside
+   a loop `break` used to lower to the rule-level stream-break, stopping the
+   record stream entirely instead of leaving the loop. `break` *outside* a loop
+   keeps its existing stream-break meaning. The runtime still to wire:
    - **SSA phi merge.** A `break` jumps to the loop's `after`; that block then
      needs a phi merging the normal exit (head-phi values, condition false) with
      the value set at *each* break point. A `continue` adds a back-edge into the
      head phi (`while`) / body-condition (`do-while`) from each continue point.
-     The loop emitter would collect the body's `branch_break` / `branch_next`
-     exits (it already receives them as `InnerNextExits`) and build these merge
-     phis, rather than letting them propagate to the record loop.
-   - **`break` semantics.** plawk currently uses `break` at *rule-body* level to
-     mean "stop the record stream" (`break_close_stream`) — non-standard awk. In
-     a loop, `break` must mean *loop* break instead, so the loop has to intercept
-     its own body's break exits. That contextual re-meaning (plus adding a
-     `continue` keyword, and defining `next`-inside-loop = next record) is the
-     design call this PR defers.
+     The loop emitter collects the body's `branch_break` / `branch_continue`
+     exits (delivered via `InnerNextExits`) and builds these merge phis instead
+     of letting them propagate to the record loop. A **loop-context stack in a
+     global** (pushed/popped around each loop body, read by `break`/`continue`
+     and by `plawk_branch_to_done_ir`) redirects the branches to the enclosing
+     loop's labels without threading a new argument through the ~14-clause
+     sequence walker; nested loops fall out because each loop consumes only the
+     exits generated while it was innermost.
+   - **`break` semantics.** plawk uses `break` at *rule-body* level to mean "stop
+     the record stream" (`break_close_stream`) — non-standard awk. In a loop,
+     `break` must mean *loop* break; the loop intercepts its own body's break
+     exits (the guard above makes this a hard boundary today). `next`-inside-loop
+     stays "next record" (propagates past the loop).
+   - **Dependency — scalar `if` conditions.** For a *counter-based* break
+     (`if (i > 2) break`) to be useful the `if` condition must accept a scalar
+     variable; today `if (COND)` only takes field/pattern conditions (`$1 > 2`),
+     not `i > 2` (parse error). So this PR also needs the `if` condition grammar
+     extended to scalar comparisons (the same `VAR CMP int/VAR` shape the loop
+     condition already uses). Do it alongside, or first.
 4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
    nesting; the multi-pass driver's scalar handling.
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -108,6 +108,7 @@ build(File, Out0, KeepLL) :-
     % removed; `GenFactClauses` are the synthesised facts.
     check_generator_blocks(File, Program2),
     check_materialized_views(File, Program2, Clauses),
+    check_loop_control(File, Program2),
     resolve_generator_blocks(Program2, Program, GenFactClauses),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
@@ -364,6 +365,52 @@ check_generator_blocks(File, Program) :-
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
+
+% `break` / `continue` for loop control (PLAWK_CONTROL_FLOW_PLAN.md §3b). The
+% while / do-while loops run, but LOOP-LOCAL break/continue is not yet wired:
+% inside a loop `break` currently lowers to the rule-level stream-break
+% (`break_close_stream`), which stops reading records entirely instead of just
+% leaving the loop -- a silent mis-compile. So a `break` inside a loop body, or
+% any `continue`, is a clean not-yet error until the runtime lands (it needs SSA
+% merge phis at the loop exit + scalar `if` conditions to guard the jump).
+% `break` OUTSIDE a loop keeps its existing stream-break meaning.
+check_loop_control(File, Program) :-
+    (   plawk_loop_body_has_control(Program)
+    ;   plawk_ast_contains(Program, continue)
+    ),
+    !,
+    format(user_error,
+        'plawk: ~w uses `break`/`continue` for loop control. The loop runtime \c
+         is landed, but loop-local `break`/`continue` is not yet wired (it needs \c
+         SSA merge phis at the loop exit and scalar `if` conditions); see \c
+         PLAWK_CONTROL_FLOW_PLAN.md section 3b.~n',
+        [File]),
+    halt(2).
+check_loop_control(_File, _Program).
+
+% True if some `while` / `do-while` body contains a `break` or `continue`
+% anywhere in its subtree.
+plawk_loop_body_has_control(Term) :-
+    plawk_ast_loop_body(Term, Body),
+    ( plawk_ast_contains(Body, break)
+    ; plawk_ast_contains(Body, continue)
+    ),
+    !.
+
+plawk_ast_loop_body(while_loop(_Cond, Body), Body).
+plawk_ast_loop_body(do_while_loop(Body, _Cond), Body).
+plawk_ast_loop_body(Term, Body) :-
+    compound(Term),
+    arg(_, Term, Arg),
+    plawk_ast_loop_body(Arg, Body).
+
+% Structural sub-term search (handles lists, since a body is an action list).
+plawk_ast_contains(Term, Term) :-
+    !.
+plawk_ast_contains(Term, Target) :-
+    compound(Term),
+    arg(_, Term, Arg),
+    plawk_ast_contains(Arg, Target).
 
 % `materialize NAME` (PLAWK_MULTIPASS_CACHE.md §3.9): mark a view / relation to
 % be materialised-and-cached (computed once, reused by every query pass that

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1532,6 +1532,9 @@ action(Action) -->
     break_action(Action),
     !.
 action(Action) -->
+    continue_action(Action),
+    !.
+action(Action) -->
     dynrec_view_action(Action),
     !.
 action(Action) -->
@@ -1692,6 +1695,10 @@ next_action(next) -->
 
 break_action(break) -->
     "break",
+    identifier_boundary.
+
+continue_action(continue) -->
+    "continue",
     identifier_boundary.
 
 %% dynrec_bind_action(-Action)//

--- a/tests/test_plawk_loop_control.pl
+++ b/tests/test_plawk_loop_control.pl
@@ -1,0 +1,126 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk loop control -- `break` / `continue` (PLAWK_CONTROL_FLOW_PLAN.md 3b),
+% the SURFACE + a guard. `continue` parses to a `continue` action. The while /
+% do-while loop runtime is landed, but LOOP-LOCAL break/continue is not yet
+% wired: inside a loop `break` would otherwise lower to the rule-level
+% stream-break (stop reading records), a silent mis-compile. So a `break`
+% inside a loop, or any `continue`, is a clean not-yet error until the runtime
+% lands (it needs SSA merge phis at the loop exit + scalar `if` conditions).
+% `break` OUTSIDE a loop keeps its existing stream-break meaning.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_loop_control).
+
+% `continue` parses to a `continue` action.
+test(continue_parses) :-
+    plawk_parse_string("{ while (i < 3) { continue } }\n",
+        program([], [rule(always,
+            [while_loop(cmp(var(i), lt, int(3)), [continue])])], [])),
+    !.
+
+% `break` still parses (unchanged) as a `break` action.
+test(break_parses) :-
+    plawk_parse_string("{ while (i < 3) { break } }\n",
+        program([], [rule(always,
+            [while_loop(cmp(var(i), lt, int(3)), [break])])], [])),
+    !.
+
+% A `break` inside a loop body is a clean not-yet error (exit 2) -- guarding the
+% silent stream-break mis-compile.
+test(break_in_loop_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 3) { print i; break } }\n",
+    build_status(Dir, 'lb', Src, St),
+    assertion(St == 2),
+    !.
+
+% A `break` inside an `if` inside a loop is likewise guarded (subtree search).
+test(break_in_if_in_loop_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 3) { if ($1 > 100) { break } i++ } }\n",
+    build_status(Dir, 'lbif', Src, St),
+    assertion(St == 2),
+    !.
+
+% A `continue` anywhere is a clean not-yet error (it only means loop control).
+test(continue_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 3) { continue } }\n",
+    build_status(Dir, 'lc', Src, St),
+    assertion(St == 2),
+    !.
+
+% A do-while body with control is also guarded.
+test(break_in_do_while_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; do { break } while (i < 3) }\n",
+    build_status(Dir, 'ldw', Src, St),
+    assertion(St == 2),
+    !.
+
+% `break` OUTSIDE a loop (rule-level stream break) still compiles and runs --
+% the guard only fires for loop bodies.
+test(rule_level_break_still_runs, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "$1 == \"stop\" { break }\n{ print $1 }\n",
+    build_run(Dir, 'rb', Src, "a\nstop\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "a\n"),
+    !.
+
+% A plain loop with no break/continue is unaffected (no false trigger).
+test(plain_loop_builds, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 3) { print i; i++ } }\n",
+    build_run(Dir, 'plain', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+:- end_tests(plawk_loop_control).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_loop_control', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_status(Dir, Name, Src, Status) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

Adds the `continue` keyword and **guards a silent mis-compile**. Investigating loop-local break/continue found the full runtime is a large, delicate SSA change *and* uncovered a second intertwined gap, so this lands the surface + guard now (surface-first, like the query-reader / generator / while / materialize arcs) and leaves the runtime as the scoped follow-on.

**The footgun:** inside a loop, `break` currently lowers to the **rule-level** stream-break (`break_close_stream`) — it stops reading records entirely instead of just leaving the loop. `{ i=0; while (i<3) { print i; break } }` over two records prints `0` once, not `0\n0`. `check_loop_control` now makes a `break` inside any loop body, or any `continue`, a **clean not-yet error** (exit 2). `break` *outside* a loop keeps its existing stream-break meaning and still runs.

## Runtime design (written up in `PLAWK_CONTROL_FLOW_PLAN.md` §3b)

- **Loop-context stack in a global**, pushed/popped around each loop body and read by `break`/`continue` and `plawk_branch_to_done_ir`, redirects the branches to the enclosing loop's labels **without** threading a new argument through the ~14-clause sequence walker; nested loops fall out because each loop consumes only the exits generated while it was innermost.
- The loop builds **SSA merge phis** at `after` (break) and the head/cond (continue) from the body's branch exits.
- **Dependency uncovered:** a counter-based `break` (`if (i > 2) break`) needs **scalar `if` conditions**, which don't parse yet — `if (COND)` takes field/pattern guards (`$1 > 2`), not `i > 2`. That grammar extension (mirroring the loop-condition machinery) is a prerequisite, noted in the plan and audit.

## Tests

`tests/test_plawk_loop_control.pl` — continue/break parse, break-in-loop / break-in-if-in-loop / continue / do-while-break not-yet, rule-level break still runs, plain loop unaffected — 8 pass. Regression: while (15), if_bodies (13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_