### PR TITLE
WAM/LLVM plawk: scalar `if` conditions (if (i > 2))

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -32,7 +32,7 @@ only (runtime pending) · ❌ missing.
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic) | ✅ | constant fields (`print 1`, `print "x"`) landed |
 | `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
-| `if` / `else` (chains) | ◐ | condition is a field/pattern guard (`$1 > 2`, `$0 ~ /re/`); a **scalar-variable** condition (`if (i > 2)`) does not parse yet — needed for counter-based loop `break` (`PLAWK_CONTROL_FLOW_PLAN.md` §3b) |
+| `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies and loops — the loop-counter guard that unblocks counter-based control. (Scalar `if` in an `END` block is a follow-on: END uses a separate lowering.) |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
 | `while (COND)` | ✅ | runtime landed (loop-header phis); condition is scalar comparisons (`VAR CMP int`/`VAR`) combined with `&&`/`||` — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2–3. `break`/`continue` deferred (PR 3b) |
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -117,12 +117,15 @@ while.after.N:
      `break` must mean *loop* break; the loop intercepts its own body's break
      exits (the guard above makes this a hard boundary today). `next`-inside-loop
      stays "next record" (propagates past the loop).
-   - **Dependency — scalar `if` conditions.** For a *counter-based* break
-     (`if (i > 2) break`) to be useful the `if` condition must accept a scalar
-     variable; today `if (COND)` only takes field/pattern conditions (`$1 > 2`),
-     not `i > 2` (parse error). So this PR also needs the `if` condition grammar
-     extended to scalar comparisons (the same `VAR CMP int/VAR` shape the loop
-     condition already uses). Do it alongside, or first.
+   - **Dependency — scalar `if` conditions — LANDED.** A *counter-based* break
+     (`if (i > 2) break`) needs the `if` condition to accept a scalar variable.
+     This shipped: `if (COND)` now parses a scalar comparison (`i > 2`,
+     `i < n && j > 0`) as `scalar_if(_)`, lowered by `plawk_if_cond_ir` via the
+     loop-condition emitter (reads slot values), alongside the existing
+     field/pattern guards. So a scalar `if` already works inside a loop body
+     (e.g. `while (i < 5) { if (i > 2) print i; i++ }`); only the `break`/
+     `continue` *jump* itself remains to wire. (Scalar `if` in an `END` block is
+     a separate follow-on — END uses its own lowering.)
 4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
    nesting; the multi-pass driver's scalar handling.
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4936,6 +4936,23 @@ plawk_while_cond_operand(var(Name), Slots, CondValues, Ref) :-
     !,
     nth0(Idx, CondValues, Ref).
 
+%% plawk_if_cond_ir(+Cond, +Slots, +Values0, +FieldSeparator, +GlobalBase,
+%%     -CondValue, -GuardGlobalIR-GuardIR)
+%
+%  Lower an `if` condition to an i1 (CondValue). A `scalar_if(_)` condition is a
+%  scalar comparison over slots -- lowered like a loop condition, reading the
+%  current slot SSA values (Values0). A field/pattern guard is lowered by the
+%  existing pattern-guard emitter (which reads the record).
+plawk_if_cond_ir(scalar_if(Cond), Slots, Values0, _FieldSeparator, GlobalBase,
+        CondValue, ''-GuardIR) :-
+    !,
+    plawk_while_cond_ir(Cond, Slots, Values0, GlobalBase, CondValue, GuardIR).
+plawk_if_cond_ir(Pattern, _Slots, _Values0, FieldSeparator, GlobalBase,
+        CondValue, GuardGlobalIR-GuardIR) :-
+    format(atom(CondValue), '%~w_cond', [GlobalBase]),
+    plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, CondValue,
+        GuardGlobalIR-GuardIR).
+
 % Surface comparison op -> ordered LLVM fcmp predicate (row values are finite,
 % so ordered comparisons are correct; a NaN column fails every guard).
 plawk_fcmp_pred(eq, oeq).
@@ -5998,6 +6015,11 @@ plawk_scalar_update_name_expr(if(_Pattern, ThenActions, ElseActions), Name, Expr
     ; member(Action, ElseActions)
     ),
     plawk_scalar_update_name_expr(Action, Name, Expr).
+% a scalar `if` condition (`if (i > 2)`) references scalar variables -- each
+% needs an i64 slot, exactly like a loop condition.
+plawk_scalar_update_name_expr(if(scalar_if(Cond), _Then, _Else), Name, int(0)) :-
+    plawk_while_cond_vars(Cond, CondVars),
+    member(Name, CondVars).
 plawk_scalar_update_name_expr(foreach_loop(_Layout, Body), Name, Expr) :-
     member(Action, Body),
     plawk_scalar_update_name_expr(Action, Name, Expr).
@@ -10943,6 +10965,9 @@ plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
     ; member(Action, ElseActions)
     ),
     plawk_scalar_update_action_name(Action, Name).
+plawk_scalar_update_action_name(if(scalar_if(Cond), _Then, _Else), Name) :-
+    plawk_while_cond_vars(Cond, CondVars),
+    member(Name, CondVars).
 plawk_scalar_update_action_name(foreach_loop(_Layout, Body), Name) :-
     member(Action, Body),
     plawk_scalar_update_action_name(Action, Name).
@@ -11388,8 +11413,8 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
 plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest],
         Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex, OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
     { format(atom(GlobalBase), '~w_if_~w', [Prefix, OpIndex]),
-      format(atom(CondValue), '%~w_if_~w_cond', [Prefix, OpIndex]),
-      plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, CondValue, GuardGlobalIR-GuardIR),
+      plawk_if_cond_ir(Pattern, Slots, Values0, FieldSeparator, GlobalBase,
+          CondValue, GuardGlobalIR-GuardIR),
       format(atom(ThenLabel), '~w_if_~w_then', [Prefix, OpIndex]),
       format(atom(ElseLabel), '~w_if_~w_else', [Prefix, OpIndex]),
       format(atom(DoneLabel), '~w_if_~w_done', [Prefix, OpIndex]),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1633,12 +1633,26 @@ while_cmp_rhs(int(N)) -->
 while_cmp_rhs(var(W)) -->
     identifier(W).
 
+%% if_condition(-Cond)//
+%
+%  An `if` condition is either a SCALAR comparison over variables (`if (i > 2)`,
+%  `if (i < n && j > 0)`) -- the same `VAR CMP int/VAR` shape as a loop condition,
+%  wrapped as scalar_if(_) so the lowering reads slot values -- or the existing
+%  field/pattern guard (`$1 > 2`, `$0 ~ /re/`, combinators). The scalar form is
+%  tried first; it fails fast on a field condition (a `$` is not an identifier),
+%  falling through to the pattern. A single condition is scalar OR pattern, not a
+%  mix. (PLAWK_CONTROL_FLOW_PLAN.md 3b -- unblocks counter-based loop control.)
+if_condition(scalar_if(Cond)) -->
+    while_condition(Cond).
+if_condition(Pattern) -->
+    condition_pattern(Pattern).
+
 if_action(if(Pattern, ThenActions, ElseActions)) -->
     "if",
     ws,
     "(",
     ws,
-    condition_pattern(Pattern),
+    if_condition(Pattern),
     ws,
     ")",
     ws,

--- a/tests/test_plawk_scalar_if.pl
+++ b/tests/test_plawk_scalar_if.pl
@@ -1,0 +1,122 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk scalar `if` conditions (PLAWK_CONTROL_FLOW_PLAN.md 3b). An `if` condition
+% may be a SCALAR comparison over variables (`if (i > 2)`, `if (i < n && j > 0)`)
+% -- the same `VAR CMP int/VAR` shape as a loop condition, wrapped as
+% scalar_if(_) so the lowering reads slot values -- in addition to the existing
+% field/pattern guard (`$1 > 2`, `$0 ~ /re/`). This unblocks counter-based
+% conditionals inside loops (a prerequisite for loop-local break/continue).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_scalar_if).
+
+% A scalar comparison parses to scalar_if(cmp(...)); a field comparison stays a
+% field pattern (the two do not collide).
+test(scalar_if_parses) :-
+    plawk_parse_string("{ if (i > 2) { print i } }\n",
+        program([], [rule(always,
+            [if(scalar_if(cmp(var(i), gt, int(2))), [print([var(i)])], [])])], [])),
+    !.
+
+test(field_if_unchanged) :-
+    plawk_parse_string("{ if ($1 > 2) { print $1 } }\n",
+        program([], [rule(always,
+            [if(field_cmp(1, gt, 2), [print([field(1)])], [])])], [])),
+    !.
+
+test(scalar_if_and_parses) :-
+    plawk_parse_string("{ if (i > 2 && j < 5) { print i } }\n",
+        program([], [rule(always,
+            [if(scalar_if(and(cmp(var(i), gt, int(2)),
+                              cmp(var(j), lt, int(5)))),
+                [print([var(i)])], [])])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% A scalar `if` on an accumulator, counted into another scalar read from END.
+test(scalar_if_counter, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "{ n++; if (n > 2) hits++ }\nEND { print hits }\n",
+    build_run(Dir, 'sc', Src, "a\nb\nc\nd\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2\n"),
+    !.
+
+% A scalar `if` guarding a print of a field.
+test(scalar_if_guarded_field_print, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "{ n++; if (n > 1) print $1 }\n",
+    build_run(Dir, 'sp', Src, "x\ny\nz\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "y\nz\n"),
+    !.
+
+% `&&` over scalar comparisons.
+test(scalar_if_and, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "{ n++; if (n > 1 && n < 4) print $1 }\n",
+    build_run(Dir, 'sa', Src, "a\nb\nc\nd\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "b\nc\n"),
+    !.
+
+% The headline enabler: a scalar `if` INSIDE a loop (guard on the loop counter).
+test(scalar_if_inside_loop, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "{ i = 0; while (i < 5) { if (i > 2) print i; i++ } }\n",
+    build_run(Dir, 'sl', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n4\n"),
+    !.
+
+% NOTE: a scalar `if` in an END block (`END { if (n > 1) ... }`) uses the
+% separate END-print lowering, not the rule-body sequence walker, so it is not
+% wired here -- a follow-on. Scalar `if` in rule bodies and loops (the loop
+% control enabler) is what this PR delivers.
+
+% A field/regex condition still compiles and runs (no regression).
+test(field_regex_if_still_runs, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "{ if ($0 ~ /err/) print $1 }\n",
+    build_run(Dir, 'fr', Src, "err 1\nok 2\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "err\n"),
+    !.
+
+:- end_tests(plawk_scalar_if).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+sdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_scalar_if', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

An `if` condition may now be a **scalar comparison over variables** — `if (i > 2)`, `if (i < n && j > 0)` — the same `VAR CMP int/VAR` shape as a loop condition, in addition to the existing field/pattern guards (`$1 > 2`, `$0 ~ /re/`). This unblocks **counter-based conditionals inside loops**, the prerequisite the break/continue investigation surfaced (`PLAWK_CONTROL_FLOW_PLAN.md` §3b).

**Parser:** an `if` condition tries a scalar comparison first (wrapped as `scalar_if(_)`) and falls through to the field/pattern guard — the scalar form fails fast on a `$` (not an identifier), so field conditions are unchanged. A condition is scalar **or** pattern, not mixed.

**Codegen:** `plawk_if_cond_ir` routes `scalar_if(Cond)` to the loop-condition emitter (`plawk_while_cond_ir`), reading the current slot SSA values; a field/pattern guard uses the existing pattern-guard emitter unchanged. Slot discovery registers every `scalar_if` condition variable as an i64 slot, like a loop condition.

Now works: `{ n++; if (n > 2) hits++ }`, `if (n > 1) print $1`, `&&` over scalars, and the headline enabler `while (i < 5) { if (i > 2) print i; i++ }`. Scalar `if` in an `END` block is a follow-on (END has a separate lowering).

## Tests

`tests/test_plawk_scalar_if.pl` — parse (scalar/field/and), counter, guarded field print, `&&`, scalar-if-in-loop, field/regex-still-runs — 8 pass. Regression: else_if (13), if_bodies (13), while (15), pattern_combinators (19), regex_match (21) green. Docs: audit `if/else` → scalar conditions; control-flow plan §3b dependency LANDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_