### PR TITLE
WAM/LLVM plawk: scalar `if` in an END block

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -32,7 +32,7 @@ only (runtime pending) · ❌ missing.
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic) | ✅ | constant fields (`print 1`, `print "x"`) landed |
 | `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
-| `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies and loops — the loop-counter guard that unblocks counter-based control. (Scalar `if` in an `END` block is a follow-on: END uses a separate lowering.) |
+| `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`** (`END { if (n > 1) print … ; else print … }`, over final slot values) |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
 | `while (COND)` | ✅ | runtime landed (loop-header phis); condition is scalar comparisons (`VAR CMP int`/`VAR`) combined with `&&`/`||` — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2–3. `break`/`continue` deferred (PR 3b) |
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -124,8 +124,9 @@ while.after.N:
      loop-condition emitter (reads slot values), alongside the existing
      field/pattern guards. So a scalar `if` already works inside a loop body
      (e.g. `while (i < 5) { if (i > 2) print i; i++ }`); only the `break`/
-     `continue` *jump* itself remains to wire. (Scalar `if` in an `END` block is
-     a separate follow-on — END uses its own lowering.)
+     `continue` *jump* itself remains to wire. (Scalar `if` in an `END` block --
+     `END { if (COND) print … ; else print … }`, over final slot values -- also
+     landed.)
 4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
    nesting; the multi-pass driver's scalar handling.
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -354,6 +354,63 @@ plawk_program_native_driver_ir(
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% END { if (COND) print ...; [else print ...] } -- a scalar-guarded print in the
+% END block. COND is a scalar comparison over the final slot values; each branch
+% is a single print. Same lowering as the scalar END-print clause above, but the
+% end_print body is the if (condition + then/else print blocks) instead of a
+% plain print. The state plan sees every field the branches print plus the
+% condition variables (so their slots exist).
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules0, [end([if(scalar_if(Cond), ThenActions, ElseActions)])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_end_if_ok(ThenActions, ElseActions),
+    plawk_end_if_print_fields(Cond, ThenActions, ElseActions, PrintFields),
+    plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules1, WritebinPlan),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_resolve_dynrec_view_rules(Rules1, Rules1b),
+    plawk_resolve_foreach_rules(FieldSeparator, Rules1b, Rules),
+    plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR0),
+    plawk_writebin_entry_lines(WritebinPlan, WritebinEntryIR),
+    plawk_join_nonempty_ir([BeginIR0, WritebinEntryIR], BeginIR),
+    plawk_record_program_ok(FieldSeparator, Rules, PrintFields),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator,
+        RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    plawk_rules_writebin_exprs(Rules, WritebinExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs0),
+    append(PrintExprs0, WritebinExprs, PrintExprs),
+    append(PrintExprs, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
+    plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
+    plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
+    plawk_scalar_rule_controls(Rules, ScalarRuleControls),
+    plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, NextPhiIR),
+    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, done,
+        BreakCloseIR, FinalStatePhiIR),
+    plawk_scalar_end_if_ir(Cond, ThenActions, ElseActions, StatePlan,
+        FieldSeparator, OutputSeparator, EndIfGlobalIR, EndIfIR),
+    plawk_writebin_globals(WritebinPlan, WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, EndIfGlobalIR, RuleGlobalIR, WritebinGlobalIR]),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w~w
+  ret i32 0',
+        [FinalStatePhiIR, EndIfIR]),
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
+        driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
+            NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 % Tag-guard sugar: with a union BINFMT, plain rules whose patterns lead
 % with TAG == K are shorthand for case blocks -- the tag test selects
 % the arm and the rest of the pattern stays as the rule's own guard, so
@@ -12191,6 +12248,75 @@ plawk_branch_next_phi_incomings([_Exit | Rest], SlotIndex, Incomings) :-
 plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, IR) :-
     phrase(plawk_scalar_end_print_lines(PrintFields, StatePlan, OutputSeparator, 0), Lines),
     atomic_list_concat(Lines, '\n', IR).
+
+%% END { if (COND) print ...; [else print ...] } support ---------------------
+
+% A supported END-if: each branch is a single print (else optional).
+plawk_end_if_ok([print(_)], []).
+plawk_end_if_ok([print(_)], [print(_)]).
+
+% The scalar fields the state plan must see: the branch print fields (so a
+% printed scalar gets a slot) plus the condition variables. String literals need
+% no slot, but leaving them in is harmless -- the state plan ignores non-vars.
+plawk_end_if_print_fields(Cond, ThenActions, ElseActions, Fields) :-
+    plawk_end_if_branch_fields(ThenActions, ThenFields),
+    plawk_end_if_branch_fields(ElseActions, ElseFields),
+    plawk_while_cond_vars(Cond, CondVars),
+    plawk_vars_as_fields(CondVars, CondFields),
+    append([ThenFields, ElseFields, CondFields], Fields).
+
+plawk_end_if_branch_fields([print(Fields)], Fields).
+plawk_end_if_branch_fields([], []).
+
+plawk_vars_as_fields([], []).
+plawk_vars_as_fields([V | Vs], [var(V) | Fs]) :-
+    plawk_vars_as_fields(Vs, Fs).
+
+% The END-if body IR: evaluate COND against the final slot values, branch to a
+% then/else print block, join. Each branch print uses the PREFIXED print emitter
+% (unique names per branch, so the two blocks' temporaries don't collide) with
+% scalar reads substituted to their final-slot SSA values. Returns the string
+% globals the branch prints need, plus the body IR.
+plawk_scalar_end_if_ir(Cond, ThenActions, ElseActions, StatePlan, FieldSeparator,
+        OutputSeparator, GlobalIR, IR) :-
+    plawk_state_plan_slots(StatePlan, Slots),
+    plawk_final_slot_values(StatePlan, FinalValues),
+    plawk_while_cond_ir(Cond, Slots, FinalValues, plawk_endif, CondVar, CondIR),
+    plawk_end_if_branch_ir(ThenActions, Slots, FinalValues, FieldSeparator,
+        OutputSeparator, plawk_endif_then, ThenGlobal, ThenIR),
+    plawk_end_if_branch_ir(ElseActions, Slots, FinalValues, FieldSeparator,
+        OutputSeparator, plawk_endif_else, ElseGlobal, ElseIR),
+    plawk_join_nonempty_ir([ThenGlobal, ElseGlobal], GlobalIR),
+    format(atom(IR),
+'~w
+  br i1 ~w, label %plawk_endif_then, label %plawk_endif_else
+
+plawk_endif_then:
+~w
+  br label %plawk_endif_done
+
+plawk_endif_else:
+~w
+  br label %plawk_endif_done
+
+plawk_endif_done:',
+        [CondIR, CondVar, ThenIR, ElseIR]).
+
+plawk_end_if_branch_ir([print(Fields)], Slots, FinalValues, FieldSeparator,
+        OutputSeparator, Prefix, GlobalIR, IR) :-
+    maplist(plawk_substitute_print_field(Slots, FinalValues), Fields, SubFields),
+    plawk_prefixed_print_action_ir(SubFields, FieldSeparator, OutputSeparator,
+        Prefix, GlobalIR-IR).
+plawk_end_if_branch_ir([], _Slots, _FinalValues, _FieldSeparator,
+        _OutputSeparator, _Prefix, '', '').
+
+% The final (post-loop) slot values, one per slot: %final_slot_0, %final_slot_1,
+% ... -- the values the END block reads.
+plawk_final_slot_values(StatePlan, Values) :-
+    plawk_state_plan_slots(StatePlan, Slots),
+    findall(V,
+        ( nth0(I, Slots, _Slot), format(atom(V), '%final_slot_~w', [I]) ),
+        Values).
 
 plawk_scalar_end_print_lines([], _StatePlan, _OutputSeparator, _) -->
     { llvm_emit_printf0(plawk_surface_print_newline, 2,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1330,6 +1330,12 @@ forin_accum_operand(_Array, _Key, int(Value)) -->
 end_action(Action) -->
     for_in_action(Action),
     !.
+% a scalar-guarded print in END: `if (n > 1) print ...` [`else print ...`].
+% The condition is a scalar comparison (END has no current record), lowered
+% against the final slot values; each branch is a single print.
+end_action(Action) -->
+    if_action(Action),
+    !.
 end_action(Action) -->
     print_action(Action).
 

--- a/tests/test_plawk_end_if.pl
+++ b/tests/test_plawk_end_if.pl
@@ -1,0 +1,109 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk scalar `if` in an END block: `END { if (COND) print ...; [else print
+% ...] }`. END has no current record, so the condition is a scalar comparison
+% over the final slot values (the same scalar_if(_) shape as a rule-body `if`),
+% lowered in the end_print block. Each branch is a single print, using the
+% prefixed print emitter so the two blocks' temporaries don't collide.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_end_if).
+
+% `END { if (COND) print ... }` parses to end([if(scalar_if(...), [print], [])]).
+test(end_if_parses) :-
+    plawk_parse_string("{ n++ }\nEND { if (n > 1) print n }\n",
+        program([], _Rules,
+            [end([if(scalar_if(cmp(var(n), gt, int(1))), [print([var(n)])], [])])])),
+    !.
+
+test(end_if_else_parses) :-
+    plawk_parse_string("{ n++ }\nEND { if (n > 1) print \"many\"; else print \"few\" }\n",
+        program([], _Rules,
+            [end([if(scalar_if(cmp(var(n), gt, int(1))),
+                     [print([string("many")])],
+                     [print([string("few")])])])])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% if/else in END, condition true.
+test(end_if_else_true, [condition(clang_available)]) :-
+    edir(Dir),
+    Src = "{ n++ }\nEND { if (n > 1) print \"many\"; else print \"few\" }\n",
+    build_run(Dir, 'ie_t', Src, "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "many\n"),
+    !.
+
+% if/else in END, condition false -> the else branch.
+test(end_if_else_false, [condition(clang_available)]) :-
+    edir(Dir),
+    Src = "{ n++ }\nEND { if (n > 1) print \"many\"; else print \"few\" }\n",
+    build_run(Dir, 'ie_f', Src, "a\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "few\n"),
+    !.
+
+% if with no else, condition true -> prints a scalar.
+test(end_if_no_else_true, [condition(clang_available)]) :-
+    edir(Dir),
+    Src = "{ n++ }\nEND { if (n > 1) print n }\n",
+    build_run(Dir, 'ne_t', Src, "a\nb\nc\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
+    !.
+
+% if with no else, condition false -> nothing printed.
+test(end_if_no_else_false, [condition(clang_available)]) :-
+    edir(Dir),
+    Src = "{ n++ }\nEND { if (n > 5) print n }\n",
+    build_run(Dir, 'ne_f', Src, "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == ""),
+    !.
+
+% A plain `END { print ... }` still works (no regression from the new clause).
+test(end_plain_print_still_works, [condition(clang_available)]) :-
+    edir(Dir),
+    Src = "{ n++ }\nEND { print n }\n",
+    build_run(Dir, 'pp', Src, "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2\n"),
+    !.
+
+:- end_tests(plawk_end_if).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+edir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_end_if', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

`END { if (COND) print …; [else print …] }` — a scalar-guarded print in the END block, the follow-on the scalar-`if` PR flagged. END has no current record, so `COND` is a scalar comparison over the **final slot values**, lowered in the `end_print` block; each branch is a single print.

**Parser:** `if_action` is now an END action (alongside for-in and print), so an `if` (with the `scalar_if` condition from the previous PR) parses inside END.

**Codegen:** a driver clause for `program(_, Rules, [end([if(scalar_if(Cond), Then, Else)])])`, mirroring the scalar END-print clause but with the `end_print` body = the if (condition + then/else print blocks). `plawk_scalar_end_if_ir` evaluates `COND` against `%final_slot_N` via the loop-condition emitter, then branches to a then/else print block. Each branch print uses the **prefixed** print emitter with scalar reads substituted to their final-slot SSA values — the prefix keeps the two blocks' temporaries and string globals from colliding. The state plan sees the branch print fields + the condition variables so their slots exist.

Now works: `END { if (n > 1) print "many"; else print "few" }`, `END { if (n > 1) print n }` (no else), condition true/false.

## Tests

`tests/test_plawk_end_if.pl` — parse (if / if-else), if-else true/false, no-else true/false, plain-END-print still works — 7 pass. Regression: end_scalar_exprs (16), forin_accum (7), assoc_print (3) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_