### PR TITLE
WAM/LLVM plawk: while break/continue runtime (control-flow PR 3b)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -38,7 +38,7 @@ only (runtime pending) · ❌ missing.
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` (rule-level stream break) | ✅ | non-standard awk extension; stops the record stream |
-| `break` / `continue` (loop-local) | ⏳ | `continue` parses; loop-local break/continue is a clean not-yet error (guards a silent stream-break mis-compile) — runtime pending, `PLAWK_CONTROL_FLOW_PLAN.md` §3b |
+| `break` / `continue` (loop-local) | ◐ | **`while` loops: landed** (`break` leaves the loop, `continue` re-tests — SSA merge phis at the loop exit/head). `do-while` break/continue and nested-loop break: not yet (`PLAWK_CONTROL_FLOW_PLAN.md` §3b) |
 | `if` with a plain (non-accumulator) body | ✅ | `{ if (c) { print $1 } }` compiles and runs (fixed by the while-runtime body-print enablers); if/else with plain bodies too |
 | regex in `if` (`if ($0 ~ /re/)`) | ✅ | `if ($0 ~ /re/) { … }` and `!~` compile and run — guards a plain body |
 | brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |
@@ -94,10 +94,11 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    phis — no memory slots needed after all; see `PLAWK_CONTROL_FLOW_PLAN.md`).
    Body: `set` / `inc` / `+=` over i64 + `print`. Enablers landed with it:
    **bare scalar-var print** (`print i`) and a **body-printing scalar chain with
-   no `END`**. **PR 3 (general condition) also LANDED**: the condition is now
-   scalar comparisons `VAR CMP (int | VAR)` combined with `&&` / `||`. Remaining:
-   `break` / `continue` (PR 3b — SSA phi-merge + break's rule-vs-loop semantics)
-   and nested / multi-pass loops (PR 4).
+   no `END`**. **PR 3 (general condition) LANDED**: scalar comparisons
+   `VAR CMP (int | VAR)` combined with `&&` / `||`. **PR 3b (`while`
+   break/continue) LANDED**: SSA merge phis at the loop exit (`break`) and head
+   (`continue`); scalar `if` conditions and END scalar-`if` landed alongside.
+   Remaining: `do-while` break/continue, and nested / multi-pass loops (PR 4).
 2. **User-function call in text/print context — LANDED (auto-coerce).**
    `print f($1)` used to return `0`: a text field reached the synthesised
    `f(X,R) :- R is X*2` as an *atom*, failing `is`. Now the synthesised clause

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -93,30 +93,36 @@ while.after.N:
    (`plawk_while_cond_vars` registers them). A single `VAR CMP int` still parses
    to a bare `cmp(...)`, so PR 2 is a strict subset. Tests:
    `tests/test_plawk_while.pl` (var-bound, `&&`, `||`, do-while var-bound).
-3b. **`break` / `continue` — SURFACE + GUARD LANDED; runtime is the follow-on.**
-   The `continue` keyword parses (to a `continue` action); `break` already did.
-   A `break` inside a loop body, or any `continue`, is now a **clean not-yet
-   error** (`check_loop_control`) — this **guards a silent mis-compile**: inside
-   a loop `break` used to lower to the rule-level stream-break, stopping the
-   record stream entirely instead of leaving the loop. `break` *outside* a loop
-   keeps its existing stream-break meaning. The runtime still to wire:
-   - **SSA phi merge.** A `break` jumps to the loop's `after`; that block then
-     needs a phi merging the normal exit (head-phi values, condition false) with
-     the value set at *each* break point. A `continue` adds a back-edge into the
-     head phi (`while`) / body-condition (`do-while`) from each continue point.
-     The loop emitter collects the body's `branch_break` / `branch_continue`
-     exits (delivered via `InnerNextExits`) and builds these merge phis instead
-     of letting them propagate to the record loop. A **loop-context stack in a
-     global** (pushed/popped around each loop body, read by `break`/`continue`
-     and by `plawk_branch_to_done_ir`) redirects the branches to the enclosing
-     loop's labels without threading a new argument through the ~14-clause
-     sequence walker; nested loops fall out because each loop consumes only the
-     exits generated while it was innermost.
+3b. **`break` / `continue` — `while` LANDED; `do-while` / nested pending.**
+   Loop-local break/continue is wired for `while` loops. `break` leaves the loop;
+   `continue` re-tests the condition. `break` *outside* a loop keeps its
+   stream-break meaning; a break/continue inside a **`do-while`** is still a clean
+   not-yet error (`check_loop_control`), and **nested loops** are outside the
+   compilable surface (a separate gap). How it works:
+   - **SSA phi merge (landed).** A `break` jumps to the loop's `after`, whose phi
+     (`plawk_loop_after_ir`) merges the normal exit (head-phi values, condition
+     false) with the value at *each* break point — so a value set before the
+     break flows past the loop (verified: `while (…) { if (i>2) break; i++ }` then
+     `END { print i }` prints `3`). A `continue` adds an extra incoming to the
+     `while` head phi (`plawk_while_head_phi_ir`) from each continue point and
+     branches back to the head to re-test.
+   - **Loop-context stack (landed).** `plawk_loopctx_push/pop/current` hold
+     `loop_ctx(BreakLabel, ContinueLabel)` around each loop body; `break` /
+     `continue` and `plawk_branch_to_done_ir` read the top, so a break/continue
+     nested in an `if` branches to the enclosing loop's labels — **without**
+     threading a new argument through the ~14-clause sequence walker. The loop
+     partitions its body's exits (`plawk_partition_loop_exits`): `break` /
+     `continue` are consumed here; `next` propagates to the record loop.
    - **`break` semantics.** plawk uses `break` at *rule-body* level to mean "stop
-     the record stream" (`break_close_stream`) — non-standard awk. In a loop,
-     `break` must mean *loop* break; the loop intercepts its own body's break
-     exits (the guard above makes this a hard boundary today). `next`-inside-loop
-     stays "next record" (propagates past the loop).
+     the record stream" (`break_close_stream`) — non-standard awk. Inside a loop,
+     the loop-context stack redirects `break` to the loop exit; outside a loop it
+     still means stream-break. `next`-inside-loop stays "next record".
+   - **`do-while` / nested — the remaining work.** `do-while`'s condition sits in
+     the body-done block, so `continue` needs an extra merge phi there (and the
+     head-phi back edge must read it); guarded as not-yet for now. Nested-loop
+     support is a separate codegen item (§4) — the loop-context *stack* already
+     handles the break/continue redirection for nesting, but the underlying
+     nested-loop lowering isn't wired.
    - **Dependency — scalar `if` conditions — LANDED.** A *counter-based* break
      (`if (i > 2) break`) needs the `if` condition to accept a scalar variable.
      This shipped: `if (COND)` now parses a scalar comparison (`i > 2`,

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -366,43 +366,38 @@ check_generator_blocks(File, Program) :-
     halt(2).
 check_generator_blocks(_File, _Program).
 
-% `break` / `continue` for loop control (PLAWK_CONTROL_FLOW_PLAN.md §3b). The
-% while / do-while loops run, but LOOP-LOCAL break/continue is not yet wired:
-% inside a loop `break` currently lowers to the rule-level stream-break
-% (`break_close_stream`), which stops reading records entirely instead of just
-% leaving the loop -- a silent mis-compile. So a `break` inside a loop body, or
-% any `continue`, is a clean not-yet error until the runtime lands (it needs SSA
-% merge phis at the loop exit + scalar `if` conditions to guard the jump).
-% `break` OUTSIDE a loop keeps its existing stream-break meaning.
+% `break` / `continue` for loop control (PLAWK_CONTROL_FLOW_PLAN.md §3b). Loop-
+% local break/continue is wired for `while` loops (SSA merge phis at the loop
+% exit / head). `do-while` break/continue is NOT wired yet (its condition sits
+% in the body-done block, so continue needs an extra merge phi there), so a
+% break/continue inside a `do-while` body is a clean not-yet error -- otherwise
+% break would silently lower to the rule-level stream-break. `break` OUTSIDE a
+% loop keeps its existing stream-break meaning.
 check_loop_control(File, Program) :-
-    (   plawk_loop_body_has_control(Program)
-    ;   plawk_ast_contains(Program, continue)
-    ),
+    plawk_dowhile_body_has_control(Program),
     !,
     format(user_error,
-        'plawk: ~w uses `break`/`continue` for loop control. The loop runtime \c
-         is landed, but loop-local `break`/`continue` is not yet wired (it needs \c
-         SSA merge phis at the loop exit and scalar `if` conditions); see \c
+        'plawk: ~w uses `break`/`continue` inside a `do-while` loop. `while` \c
+         loop break/continue is wired, but the do-while form is not yet; see \c
          PLAWK_CONTROL_FLOW_PLAN.md section 3b.~n',
         [File]),
     halt(2).
 check_loop_control(_File, _Program).
 
-% True if some `while` / `do-while` body contains a `break` or `continue`
-% anywhere in its subtree.
-plawk_loop_body_has_control(Term) :-
-    plawk_ast_loop_body(Term, Body),
+% True if some `do-while` body contains a `break` or `continue` anywhere in its
+% subtree.
+plawk_dowhile_body_has_control(Term) :-
+    plawk_ast_dowhile_body(Term, Body),
     ( plawk_ast_contains(Body, break)
     ; plawk_ast_contains(Body, continue)
     ),
     !.
 
-plawk_ast_loop_body(while_loop(_Cond, Body), Body).
-plawk_ast_loop_body(do_while_loop(Body, _Cond), Body).
-plawk_ast_loop_body(Term, Body) :-
+plawk_ast_dowhile_body(do_while_loop(Body, _Cond), Body).
+plawk_ast_dowhile_body(Term, Body) :-
     compound(Term),
     arg(_, Term, Arg),
-    plawk_ast_loop_body(Arg, Body).
+    plawk_ast_dowhile_body(Arg, Body).
 
 % Structural sub-term search (handles lists, since a body is an action list).
 plawk_ast_contains(Term, Term) :-

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5859,6 +5859,8 @@ plawk_trim_control_tails([next | _Rest], [next]) :-
     !.
 plawk_trim_control_tails([break | _Rest], [break]) :-
     !.
+plawk_trim_control_tails([continue | _Rest], [continue]) :-
+    !.
 plawk_trim_control_tails([if(Pattern, ThenActions, ElseActions) | Rest],
         [if(Pattern, TrimmedThenActions, TrimmedElseActions) | TrimmedRest]) :-
     !,
@@ -5895,10 +5897,31 @@ plawk_action_has_control(if(_Pattern, ThenActions, ElseActions)) :-
     ).
 plawk_action_has_control(foreach_loop(_Layout, Body)) :-
     plawk_branch_actions_have_unsupported_control(Body).
+% A while/do-while loop consumes its own body's break/continue (loop-local), so
+% those do NOT make the loop-as-action carry control to the rule level; only a
+% `next` inside the body propagates (to the record loop).
 plawk_action_has_control(while_loop(_Cond, Body)) :-
-    plawk_branch_actions_have_unsupported_control(Body).
+    plawk_actions_have_next_control(Body).
 plawk_action_has_control(do_while_loop(Body, _Cond)) :-
-    plawk_branch_actions_have_unsupported_control(Body).
+    plawk_actions_have_next_control(Body).
+
+% True if some action reaches a bare `next` (recursing through ifs and nested
+% loops) -- `next` propagates past loops, break/continue do not.
+plawk_actions_have_next_control(Actions) :-
+    member(Action, Actions),
+    plawk_action_reaches_next(Action).
+
+plawk_action_reaches_next(next).
+plawk_action_reaches_next(if(_Pattern, ThenActions, ElseActions)) :-
+    ( plawk_actions_have_next_control(ThenActions)
+    ; plawk_actions_have_next_control(ElseActions)
+    ).
+plawk_action_reaches_next(while_loop(_Cond, Body)) :-
+    plawk_actions_have_next_control(Body).
+plawk_action_reaches_next(do_while_loop(Body, _Cond)) :-
+    plawk_actions_have_next_control(Body).
+plawk_action_reaches_next(foreach_loop(_Layout, Body)) :-
+    plawk_actions_have_next_control(Body).
 
 plawk_branch_actions_have_unsupported_control(Actions) :-
     plawk_trim_control_tails(Actions, TrimmedActions),
@@ -6291,6 +6314,10 @@ plawk_split_normalized_branch_control(Actions, BodyActions, branch_next) :-
     \+ plawk_actions_have_control(BodyActions).
 plawk_split_normalized_branch_control(Actions, BodyActions, branch_break) :-
     append(BodyActions, [break], Actions),
+    !,
+    \+ plawk_actions_have_control(BodyActions).
+plawk_split_normalized_branch_control(Actions, BodyActions, branch_continue) :-
+    append(BodyActions, [continue], Actions),
     !,
     \+ plawk_actions_have_control(BodyActions).
 plawk_split_normalized_branch_control(Actions, Actions, fallthrough) :-
@@ -11242,6 +11269,12 @@ plawk_scalar_action_sequence_pairs([next], _Slots, _AssocPlan, _FieldSeparator, 
 plawk_scalar_action_sequence_pairs([break], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, break, [branch_break(CurrentLabel, Values)]) -->
     [].
+% `continue` -- like break, it emits no IR of its own; the consumer branches
+% (plawk_branch_to_done_ir) to the enclosing loop's continue target, and the
+% loop consumes the branch_continue exit to wire its head/cond phi.
+plawk_scalar_action_sequence_pairs([continue], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
+        OpIndex, Values, Values, OpIndex, continue, [branch_continue(CurrentLabel, Values)]) -->
+    [].
 % foreach_loop: the one loop in the emitter stack. Loop-carried phis
 % for the element index and every scalar slot; the body memcpys the
 % current element into the staging area and runs one copy of the
@@ -11353,6 +11386,9 @@ plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
             format(atom(PhiValue), '%~w_slot_~w', [Base, SlotIndex])
           ),
           HeadValues),
+      % break -> after, continue -> head (re-test): push the loop context so a
+      % break/continue anywhere in the body branches to these labels.
+      plawk_loopctx_push(loop_ctx(AfterLabel, HeadLabel)),
       phrase(plawk_scalar_action_sequence_pairs(Body, Slots, AssocPlan,
           FieldSeparator, OutputSeparator, Base, BodyLabel, RuleIndex, 0,
           HeadValues, BodyOutValues, _InnerOpIndex, InnerExitLabel,
@@ -11361,11 +11397,14 @@ plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
       atomic_list_concat(BodyGlobalParts, '\n', GlobalIR),
       atomic_list_concat(BodyLineParts, '\n', BodyIR),
       plawk_branch_to_done_ir(InnerExitLabel, BodyDoneLabel, BodyDoneBrIR),
-      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BodyOutValues,
-          Base, EntryLabel, BodyDoneLabel, 0), HeadPhiLines),
-      atomic_list_concat(HeadPhiLines, '\n', HeadPhiIR),
-      % the condition reads the head-phi value of the condition variable
+      plawk_loopctx_pop,
+      plawk_partition_loop_exits(InnerNextExits, Breaks, Continues, RestExits),
+      % head phi carries continue values; the after phi carries break values
+      plawk_while_head_phi_ir(Slots, Values0, BodyOutValues, Continues,
+          Base, EntryLabel, BodyDoneLabel, HeadPhiIR),
       plawk_while_cond_ir(Cond, Slots, HeadValues, Base, CondVar, CondIR),
+      plawk_loop_after_ir(Slots, HeadValues, HeadLabel, Breaks, Base,
+          AfterValues, AfterPhiIR),
       format(atom(IR),
 '  br label %~w
 
@@ -11384,7 +11423,8 @@ plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
 ~w:
   br label %~w
 
-~w:',
+~w:
+~w',
           [EntryLabel,
            EntryLabel,
            HeadLabel,
@@ -11397,13 +11437,14 @@ plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
            BodyDoneBrIR,
            BodyDoneLabel,
            HeadLabel,
-           AfterLabel]),
+           AfterLabel,
+           AfterPhiIR]),
       NextOpIndex is OpIndex + 1
     },
     [GlobalIR-IR],
     plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
-        NextOpIndex, HeadValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
-    { append(InnerNextExits, RestNextExits, NextExits) }.
+        NextOpIndex, AfterValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
+    { append(RestExits, RestNextExits, NextExits) }.
 % do_while_loop: like while_loop but the condition tests AFTER the body, so the
 % body always runs at least once. The head phi sits at the top of the body
 % block; the condition reads the body's OUTPUT values (the exit values), since
@@ -12094,15 +12135,41 @@ plawk_i64_guarded_div_lines(LLVMOp, Base, LeftIR, RightIR, Lines) :-
 
 plawk_branch_to_done_ir(none, _DoneLabel, '  br label %continue_loop') :-
     !.
-plawk_branch_to_done_ir(break, _DoneLabel, '  br label %break_close_stream') :-
-    !.
+% `break` inside a loop leaves that loop (branch to its exit label); at rule
+% level it keeps its stream-break meaning. `continue` (only valid in a loop)
+% branches to the loop's continue target. The enclosing loop is read from the
+% loop-context stack (plawk_loopctx_current).
+plawk_branch_to_done_ir(break, _DoneLabel, IR) :-
+    !,
+    (   plawk_loopctx_current(loop_ctx(BreakLabel, _ContinueLabel))
+    ->  format(atom(IR), '  br label %~w', [BreakLabel])
+    ;   IR = '  br label %break_close_stream'
+    ).
+plawk_branch_to_done_ir(continue, _DoneLabel, IR) :-
+    !,
+    plawk_loopctx_current(loop_ctx(_BreakLabel, ContinueLabel)),
+    format(atom(IR), '  br label %~w', [ContinueLabel]).
 plawk_branch_to_done_ir(ExitLabel, DoneLabel, IR) :-
     ExitLabel \== none,
     ExitLabel \== break,
+    ExitLabel \== continue,
     format(atom(IR), '  br label %~w', [DoneLabel]).
+
+% The loop-context stack: each loop pushes loop_ctx(BreakLabel, ContinueLabel)
+% around its body, so a break/continue anywhere in the body (including nested
+% ifs) branches to the innermost loop's labels. Non-backtrackable global with
+% manual push/pop; nested loops stack naturally.
+plawk_loopctx_push(Ctx) :-
+    ( nb_current(plawk_loopctx, Stack) -> true ; Stack = [] ),
+    nb_setval(plawk_loopctx, [Ctx | Stack]).
+plawk_loopctx_pop :-
+    ( nb_current(plawk_loopctx, [_ | Stack]) -> nb_setval(plawk_loopctx, Stack) ; true ).
+plawk_loopctx_current(Ctx) :-
+    nb_current(plawk_loopctx, [Ctx | _]).
 
 plawk_branch_terminal_exit(none).
 plawk_branch_terminal_exit(break).
+plawk_branch_terminal_exit(continue).
 
 plawk_scalar_if_join_pairs(ThenExitLabel, _ThenValues, ElseExitLabel, _ElseValues, _Slots, _Prefix, _OpIndex, _Pairs) :-
     plawk_branch_terminal_exit(ThenExitLabel),
@@ -12195,6 +12262,77 @@ plawk_foreach_head_phi_lines([Slot | Slots], [InValue | InValues],
     [Line],
     plawk_foreach_head_phi_lines(Slots, InValues, OutValues, FeBase,
         EntryLabel, DoneLabel, NextIndex).
+
+%% Loop break/continue merge phis (PLAWK_CONTROL_FLOW_PLAN.md 3b) --------------
+
+% Partition a loop body's exits: loop-local `break` / `continue` (consumed by
+% the loop) vs everything else (`next`, propagated to the record loop).
+plawk_partition_loop_exits([], [], [], []).
+plawk_partition_loop_exits([branch_break(L, V) | R], [branch_break(L, V) | Bs], Cs, Ns) :-
+    !,
+    plawk_partition_loop_exits(R, Bs, Cs, Ns).
+plawk_partition_loop_exits([branch_continue(L, V) | R], Bs, [branch_continue(L, V) | Cs], Ns) :-
+    !,
+    plawk_partition_loop_exits(R, Bs, Cs, Ns).
+plawk_partition_loop_exits([X | R], Bs, Cs, [X | Ns]) :-
+    plawk_partition_loop_exits(R, Bs, Cs, Ns).
+
+% A `while` head phi per slot: the loop-carried value merges the pre-loop value
+% (from entry), the body's output (from the back edge), and each `continue`
+% point's value.
+plawk_while_head_phi_ir(Slots, InValues, OutValues, Continues, Base,
+        EntryLabel, BodyDoneLabel, IR) :-
+    phrase(plawk_while_head_phi_lines(Slots, InValues, OutValues, Continues,
+        Base, EntryLabel, BodyDoneLabel, 0), Lines),
+    atomic_list_concat(Lines, '\n', IR).
+
+plawk_while_head_phi_lines([], [], [], _Cs, _Base, _E, _BD, _) -->
+    [].
+plawk_while_head_phi_lines([Slot | Slots], [In | Ins], [Out | Outs], Continues,
+        Base, E, BD, I) -->
+    { plawk_slot_llvm_type(Slot, Type),
+      format(atom(BaseIncs), '[~w, %~w], [~w, %~w]', [In, E, Out, BD]),
+      plawk_loop_exit_incomings(Continues, I, ContIncs),
+      atomic_list_concat([BaseIncs | ContIncs], ', ', IncsIR),
+      format(atom(Line), '  %~w_slot_~w = phi ~w ~w', [Base, I, Type, IncsIR]),
+      I1 is I + 1
+    },
+    [Line],
+    plawk_while_head_phi_lines(Slots, Ins, Outs, Continues, Base, E, BD, I1).
+
+% The `after` block phi merging the normal loop exit (NormalValues from
+% NormalLabel) with each `break` point's value. No breaks -> no phi, and the
+% post-loop values are just the normal-exit values.
+plawk_loop_after_ir(_Slots, NormalValues, _NormalLabel, [], _Base, NormalValues, '') :-
+    !.
+plawk_loop_after_ir(Slots, NormalValues, NormalLabel, Breaks, Base, AfterValues, IR) :-
+    phrase(plawk_loop_after_phi_lines(Slots, NormalValues, NormalLabel, Breaks,
+        Base, 0), Lines),
+    atomic_list_concat(Lines, '\n', IR),
+    findall(V,
+        ( nth0(I, Slots, _), format(atom(V), '%~w_after_slot_~w', [Base, I]) ),
+        AfterValues).
+
+plawk_loop_after_phi_lines([], [], _NL, _Bs, _Base, _) -->
+    [].
+plawk_loop_after_phi_lines([Slot | Slots], [NV | NVs], NL, Breaks, Base, I) -->
+    { plawk_slot_llvm_type(Slot, Type),
+      format(atom(Normal), '[~w, %~w]', [NV, NL]),
+      plawk_loop_exit_incomings(Breaks, I, BreakIncs),
+      atomic_list_concat([Normal | BreakIncs], ', ', IncsIR),
+      format(atom(Line), '  %~w_after_slot_~w = phi ~w ~w', [Base, I, Type, IncsIR]),
+      I1 is I + 1
+    },
+    [Line],
+    plawk_loop_after_phi_lines(Slots, NVs, NL, Breaks, Base, I1).
+
+% One phi incoming per break/continue exit for slot I: [value-at-exit, %block].
+plawk_loop_exit_incomings([], _I, []).
+plawk_loop_exit_incomings([Exit | Rest], I, [Inc | Incs]) :-
+    Exit =.. [_Kind, Label, Values],
+    nth0(I, Values, V),
+    format(atom(Inc), '[~w, %~w]', [V, Label]),
+    plawk_loop_exit_incomings(Rest, I, Incs).
 
 replace_nth0(0, [_Old | Rest], Value, [Value | Rest]) :-
     !.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1355,17 +1355,19 @@ for_in_action(for_in(var(LoopVar), var(ArrayName), Body)) -->
     ws,
     for_in_body(Body).
 
-for_in_body(Actions) -->
-    action_block(Actions),
-    !.
 % for-in filter (assoc for-in, stage 1): `{ if (GUARD) print ... }` where
 % GUARD compares the loop key `k` or the value `arr[k]` to an integer.
 % A for-in-scoped condition -- k / arr[k] are only meaningful inside the
 % loop, so the operands live here rather than in the global pattern
-% grammar. Gates the per-key print; no cross-iteration state.
+% grammar. Gates the per-key print; no cross-iteration state. Tried BEFORE the
+% general action_block: `if (k > 0)` would otherwise parse as a scalar_if (`k`
+% is the loop key, not a scalar slot), so the for-in-scoped guard must win.
 for_in_body([if(Guard, [PrintAction], [])]) -->
     "{", ws, "if", ws, "(", ws, guard_expr(Guard), ws, ")", ws,
     print_action(PrintAction), ws, "}",
+    !.
+for_in_body(Actions) -->
+    action_block(Actions),
     !.
 for_in_body([WritebinAction]) -->
     writebin_action(WritebinAction),
@@ -1476,6 +1478,10 @@ actions_rest(_Prev, []) -->
 
 plawk_block_action(if(_Pattern, _Then, _Else)).
 plawk_block_action(foreach(_Body)).
+% a loop is a braced block too: a statement may follow it without a separator
+% (`while (..) { .. } i++`), like an if / foreach.
+plawk_block_action(while_loop(_Cond, _Body)).
+plawk_block_action(do_while_loop(_Body, _Cond)).
 
 %% action_sep//0
 %

--- a/tests/test_plawk_loop_control.pl
+++ b/tests/test_plawk_loop_control.pl
@@ -2,14 +2,13 @@
 % SPDX-License-Identifier: MIT OR Apache-2.0
 % Copyright (c) 2026 John William Creighton (@s243a)
 %
-% plawk loop control -- `break` / `continue` (PLAWK_CONTROL_FLOW_PLAN.md 3b),
-% the SURFACE + a guard. `continue` parses to a `continue` action. The while /
-% do-while loop runtime is landed, but LOOP-LOCAL break/continue is not yet
-% wired: inside a loop `break` would otherwise lower to the rule-level
-% stream-break (stop reading records), a silent mis-compile. So a `break`
-% inside a loop, or any `continue`, is a clean not-yet error until the runtime
-% lands (it needs SSA merge phis at the loop exit + scalar `if` conditions).
-% `break` OUTSIDE a loop keeps its existing stream-break meaning.
+% plawk loop control -- `break` / `continue` (PLAWK_CONTROL_FLOW_PLAN.md 3b).
+% Loop-local break/continue is wired for `while` loops: `break` leaves the loop
+% (an SSA phi at the loop's `after` merges the break value with the normal
+% exit), `continue` re-tests the condition (an extra incoming to the head phi).
+% `break` OUTSIDE a loop keeps its rule-level stream-break meaning. `do-while`
+% break/continue is a clean not-yet error (its condition sits in the body-done
+% block, needing an extra merge phi there).
 
 :- use_module(library(plunit)).
 :- use_module(library(process)).
@@ -18,55 +17,65 @@
 
 :- begin_tests(plawk_loop_control).
 
-% `continue` parses to a `continue` action.
+% `continue` / `break` parse to their actions.
 test(continue_parses) :-
     plawk_parse_string("{ while (i < 3) { continue } }\n",
         program([], [rule(always,
             [while_loop(cmp(var(i), lt, int(3)), [continue])])], [])),
     !.
 
-% `break` still parses (unchanged) as a `break` action.
 test(break_parses) :-
     plawk_parse_string("{ while (i < 3) { break } }\n",
         program([], [rule(always,
             [while_loop(cmp(var(i), lt, int(3)), [break])])], [])),
     !.
 
-% A `break` inside a loop body is a clean not-yet error (exit 2) -- guarding the
-% silent stream-break mis-compile.
-test(break_in_loop_is_not_yet_error) :-
+% --- while break ------------------------------------------------------------
+
+% `break` leaves the loop: `while (i < 10) { if (i > 2) break; print i; i++ }`
+% prints 0/1/2 and stops.
+test(while_break, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; while (i < 3) { print i; break } }\n",
-    build_status(Dir, 'lb', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; while (i < 10) { if (i > 2) break; print i; i++ } }\n",
+    build_run(Dir, 'wb', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
     !.
 
-% A `break` inside an `if` inside a loop is likewise guarded (subtree search).
-test(break_in_if_in_loop_is_not_yet_error) :-
+% The break value flows past the loop: after breaking at i == 3, END sees i = 3
+% (proves the `after` merge phi carries the break-point value).
+test(while_break_state_to_end, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; while (i < 3) { if ($1 > 100) { break } i++ } }\n",
-    build_status(Dir, 'lbif', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; while (i < 10) { if (i > 2) break; i++ } }\nEND { print i }\n",
+    build_run(Dir, 'wbe', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
     !.
 
-% A `continue` anywhere is a clean not-yet error (it only means loop control).
-test(continue_is_not_yet_error) :-
+% An unconditional trailing break runs the body once.
+test(while_break_trailing, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; while (i < 3) { continue } }\n",
-    build_status(Dir, 'lc', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; while (i < 5) { print i; i++; break } }\n",
+    build_run(Dir, 'wbt', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n"),
     !.
 
-% A do-while body with control is also guarded.
-test(break_in_do_while_is_not_yet_error) :-
+% --- while continue ---------------------------------------------------------
+
+% `continue` re-tests the condition, skipping the rest of the body:
+% `while (i < 5) { i++; if (i > 3) continue; print i }` prints 1/2/3.
+test(while_continue, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; do { break } while (i < 3) }\n",
-    build_status(Dir, 'ldw', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; while (i < 5) { i++; if (i > 3) continue; print i } }\n",
+    build_run(Dir, 'wc', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1\n2\n3\n"),
     !.
 
-% `break` OUTSIDE a loop (rule-level stream break) still compiles and runs --
-% the guard only fires for loop bodies.
+% --- boundaries -------------------------------------------------------------
+
+% `break` OUTSIDE a loop (rule-level stream break) still compiles and runs.
 test(rule_level_break_still_runs, [condition(clang_available)]) :-
     ldir(Dir),
     Src = "$1 == \"stop\" { break }\n{ print $1 }\n",
@@ -75,7 +84,22 @@ test(rule_level_break_still_runs, [condition(clang_available)]) :-
     assertion(Out == "a\n"),
     !.
 
-% A plain loop with no break/continue is unaffected (no false trigger).
+% `do-while` break/continue is a clean not-yet error (runtime pending).
+test(do_while_break_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; do { print i; break } while (i < 5) }\n",
+    build_status(Dir, 'dwb', Src, St),
+    assertion(St == 2),
+    !.
+
+test(do_while_continue_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; do { continue } while (i < 5) }\n",
+    build_status(Dir, 'dwc', Src, St),
+    assertion(St == 2),
+    !.
+
+% A plain loop with no break/continue is unaffected.
 test(plain_loop_builds, [condition(clang_available)]) :-
     ldir(Dir),
     Src = "{ i = 0; while (i < 3) { print i; i++ } }\n",


### PR DESCRIPTION
## Summary

Loop-local `break`/`continue` is now wired for **`while` loops** — the SSA merge-phi work the surface+guard PR deferred, now that scalar `if` conditions (its dependency) have landed.

- `continue` action added; `break`/`continue` register a `branch_break`/`branch_continue` exit carrying the block label + slot values.
- A **loop-context stack in a global** (`plawk_loopctx_push/pop/current`) holds `loop_ctx(BreakLabel, ContinueLabel)` around each loop body. `break`/`continue` and `plawk_branch_to_done_ir` read the top, so a break/continue **nested in an `if`** branches to the enclosing loop's labels — without threading a new argument through the ~14-clause sequence walker. `break` *outside* a loop keeps its rule-level stream-break meaning.
- The while emitter partitions its body's exits (`plawk_partition_loop_exits`): break/continue consumed here, `next` propagates. The **`after` block gets a phi** (`plawk_loop_after_ir`) merging the normal exit with each break value — so a value set before a break flows past the loop. The **head phi** (`plawk_while_head_phi_ir`) gets an extra incoming per continue point; continue branches back to re-test.

**Verified:** `while (i<10){ if (i>2) break; print i; i++ }` → `0/1/2`; break value reaches END (`END { print i }` → `3`, proving the after phi); `while (i<5){ i++; if (i>3) continue; print i }` → `1/2/3`.

Also fixes a parser gap nesting exposed: a loop is a block action, so a statement can follow it without a separator (`while (..){..} i++`).

## Scope

- **`do-while` break/continue** stays a clean not-yet error (its condition is in the body-done block, needing an extra merge phi there).
- **Nested loops** remain outside the compilable surface (a separate pre-existing codegen gap — the loop-context stack already handles the break/continue *redirection* for nesting, but the nested-loop lowering isn't wired).
- `check_loop_control` narrowed to the do-while case.

## Regression fix

`scalar_if` made `if (k > 0)` in a for-in body parse as a scalar comparison; the for-in key-guard clause now precedes `action_block` so `k` stays the loop key (`forin_key_cmp`). All for-in suites green.

## Tests

`tests/test_plawk_loop_control.pl` — while break / break-state-to-END / trailing break / while continue / rule-level break / do-while not-yet / plain loop — 10 pass. Regression: if_bodies (13), scalar_if (8), else_if (13), combinators (19), prefix_print (221), end_if (7), forin_filter (7) + forin_accum/decode/rule_body/end_print, crosspass (3), functions (11) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_