### PR TITLE
KT-SELF-REC-SOUNDNESS: pin self-rec mid-body fallback invariant

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -58,6 +58,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | EMIT-KOTLIN-3 ✅ | Multi-clause deterministic | Kotlin | M | done — T5/T4 no call (`cursor/emit-kotlin-multi-clause-f421`) |
 | EMIT-KOTLIN-4 ✅ | Last-call `execute` | Kotlin | M | done — tail execute (`cursor/emit-kotlin-execute-f421`) |
 | EMIT-KOTLIN-5 ✅ | Mid-body `call` + arith builtins | Kotlin | M | done — det-only mid-body + is/2 (`cursor/emit-kotlin-5-f421`) |
+| KT-SELF-REC-SOUNDNESS ✅ | Document+pin self-rec fallback soundness | Kotlin | S | done — adversarial regression + invariant (`cursor/kt-self-rec-soundness-f421`) |
 | BENCH-KOTLIN ✅ | Lowered vs interpreter timing | Kotlin | S | done — recursion regresses; short cases noise (`cursor/bench-kotlin-f421`) |
 | KT-DISPATCH-SNAPSHOT-OPT ✅ | Perf: cheapen recursive dispatch | Kotlin | M | done — skip recursive tryRun snap (`cursor/kt-dispatch-snapshot-opt-f421`) |
 | KT-HEAP-SNAPSHOT-OPT-2 ✅ | Perf: eliminate residual T4 `_t4` copy | Kotlin | M | done — peel leading get_constant (`cursor/kt-heap-snapshot-opt-2-f421`) |
@@ -608,6 +609,12 @@ fallback) to the three Tier-D targets. Reference small emitters:
 - **Correctness gate:** deterministic-only mid-body goals — when unsure, decline.
 - **Out of scope:** cut, ITE/soft-cut, aggregates, multi-solution enumeration / backtracking into callees.
 - **Acceptance:** fib/ack LOWER + match interpreter; nondet mid-body declines; unit + both conformance modes green; bench table includes fib/ack; boundary + stack ceiling documented.
+
+### KT-SELF-REC-SOUNDNESS: Pin self-recursion mid-body fallback invariant (Kotlin)
+- **Lever:** Lowered emitters / correctness closeout  **Target:** Kotlin  **Size:** S  **Depends on:** EMIT-KOTLIN-5
+- **Status:** ✅ **Landed** on `cursor/kt-self-rec-soundness-f421` (2026-07-15). Documents that the unconditional self-recursion exemption in `kotlin_safe_midbody_callee` is sound **only** because top-level `tryRun` native→bytecode fallback catches wrong-false; regression `functions_mode_self_rec_fallback_soundness` asserts the adversarial `p(z,a). p(z,b). p(s(N),R):-p(N,R),R=b` pattern **lowers** and functions == interpreter. Did **not** tighten the gate (would decline the pinning case). See `design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md` KT-SELF-REC-SOUNDNESS.
+- **Goal:** Make the EMIT-KOTLIN-5 self-recursion exemption’s soundness explicit and regression-protected.
+- **Acceptance:** adversarial regression green; unit + both conformance modes green; invariant in emitter comment + history doc.
 
 ### BENCH-KOTLIN: Measure lowered vs interpreter (in-process)
 - **Lever:** Effective-distance / perf evidence  **Target:** Kotlin  **Size:** S  **Depends on:** EMIT-KOTLIN-4

--- a/docs/WAM_KOTLIN_STATUS.md
+++ b/docs/WAM_KOTLIN_STATUS.md
@@ -52,6 +52,8 @@ module in the fleet.
     `if (!dispatch(...)) return false` + `kotlinLoBuiltinCall` — **only**
     when every mid-body callee is self-recursion or single-clause
     deterministic. Fib/ack lower; nondet mid-body callers decline.
+    Self-recursion exemption is sound via top-level tryRun fallback
+    (**KT-SELF-REC-SOUNDNESS** — do not remove that fallback lightly).
   Registered via `WamProgram.registerNative`. `functions` / `mixed`
   modes route lowerable preds through this path.
 
@@ -86,4 +88,4 @@ opts + EMIT-KOTLIN-5: append_500 ~**28×**, fib_15 ~**1.85×**, ack_23
 
 Fleet-aligned snapshot; source-verified against `wam_kotlin_target.pl`,
 `wam_kotlin_lowered_emitter.pl`, and `tests/test_wam_kotlin_target.pl`
-(2026-07-15). Through EMIT-KOTLIN-5.
+(2026-07-15). Through KT-SELF-REC-SOUNDNESS.

--- a/docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md
+++ b/docs/design/WAM_KOTLIN_OPTIMIZATION_HISTORY.md
@@ -152,7 +152,7 @@ Append’s recursive cons path is therefore snap-free → append_500
 
 ---
 
-## EMIT-KOTLIN-5 (this change)
+## EMIT-KOTLIN-5
 
 ### Boundary (deterministic-only mid-body `call`)
 
@@ -199,8 +199,50 @@ overflow.
 
 ---
 
+## KT-SELF-REC-SOUNDNESS (this change)
+
+### Invariant
+
+**Self-recursion mid-body lowering is safe ONLY because the top-level
+`tryRun` native→bytecode fallback catches the wrong-false; do not remove
+that fallback without tightening the `kotlin_safe_midbody_callee` SelfKey
+exemption.**
+
+The self-recursion exemption is unconditional (no per-clause determinism
+proof). Adversarial pattern that **lowers** and is correct only via
+fallback:
+
+```prolog
+p(z, a). p(z, b).
+p(s(N), R) :- p(N, R), R = b.
+adv :- p(s(z), _).   % interp true (backtracks to R=b);
+                     % lowered native false → tryRun bytecode fallback
+```
+
+Why this is still sound today:
+
+1. Missed backtracking yields wrong-**false**, never wrong-true.
+2. Top-level `tryRun` snapshots and re-runs on the interpreter when native
+   returns false (WAM registrar still present alongside `registerNative`).
+3. A multi-clause *caller* that could observe a wrong internal binding is
+   declined by the mid-body gate.
+
+Pinned by `functions_mode_self_rec_fallback_soundness` in
+`tests/test_wam_kotlin_target.pl` (asserts the pattern **lowers** and
+functions == interpreter). That test would fail if the top-level fallback
+were removed.
+
+### What we skipped (and why)
+
+| Idea | Why not now |
+|---|---|
+| Tighten SelfKey to require mutually exclusive clause heads | Would decline the adversarial pattern (two `p(z,_)` clauses); task asked to keep the pattern lowering and pin the fallback. Cheap peel-style exclusivity is a future option if fallback is retired. |
+
+---
+
 ## Correctness gates
 
 Differential unit suite + `CONFORMANCE_TARGETS=kotlin,kotlin_functions`
 must stay green whenever this seam changes. Top-level snapshot+fallback
-preserved deliberately for T5 unbound.
+preserved deliberately for T5 unbound **and** for
+KT-SELF-REC-SOUNDNESS (self-recursive first-solution wrong-false).

--- a/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_kotlin_lowered_emitter.pl
@@ -194,6 +194,28 @@ kotlin_call_parts_safe(Module, SelfKey, Parts, Visiting) :-
 %  predicate whose own mid-body calls are similarly safe. Multi-clause
 %  callees DECLINE — first-solution dispatch cannot backtrack into them.
 %  When unsure → fail (decline).
+%
+%  KT-SELF-REC-SOUNDNESS — self-recursion exemption soundness
+%  ---------------------------------------------------------
+%  The SelfKey = CalleeKey clause below is UNCONDITIONAL: we do not prove
+%  the self-recursive predicate deterministic. A multi-clause self-recursive
+%  body like `p(s(N),R) :- p(N,R), R = b` with `p(z,a). p(z,b).` can lower,
+%  take the first solution of the recursive call (R=a), fail `R = b`, and
+%  return false without backtracking into the recursion — a wrong *false*.
+%
+%  That is sound for the project TODAY only because:
+%    (1) missed backtracking yields wrong-false, never wrong-true;
+%    (2) top-level WamRuntime.tryRun still snapshots and falls back to the
+%        bytecode interpreter when the native fn returns false (so the
+%        query is re-run correctly);
+%    (3) a multi-clause *caller* that could observe a wrong internal binding
+%        is declined by this gate (only self / single-clause callees pass).
+%
+%  Do NOT remove the top-level tryRun native→bytecode fallback without
+%  tightening this exemption (e.g. require mutually exclusive clause heads
+%  on the indexed arg). Regression:
+%  tests/test_wam_kotlin_target.pl
+%  functions_mode_self_rec_fallback_soundness.
 kotlin_safe_midbody_callee(_Module, SelfKey, SelfKey, _Visiting) :- !.
 kotlin_safe_midbody_callee(_Module, _SelfKey, CalleeKey, Visiting) :-
     memberchk(CalleeKey, Visiting), !.

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -381,6 +381,12 @@ class WamRuntime(private val program: WamProgram) {
     // lowering). Recursive hops (execute→dispatch→tryRun) skip it when
     // skipRecursiveNativeSnapshot is true (KT-DISPATCH-SNAPSHOT-OPT):
     // T4 already snapshots per clause (`_t4`).
+    //
+    // KT-SELF-REC-SOUNDNESS: the top-level native→bytecode fallback is also
+    // load-bearing for EMIT-KOTLIN-5's unconditional self-recursion mid-body
+    // exemption — a lowered self-recursive wrong-false is re-run on the
+    // interpreter. Do not remove this fallback without tightening
+    // kotlin_safe_midbody_callee's SelfKey exemption.
     private var nativeDepth: Int = 0
 
     /** When true (default), recursive native hops skip snapshotForNative. */
@@ -440,7 +446,8 @@ class WamRuntime(private val program: WamProgram) {
             }
             // Top-level (or recursive with skip disabled for A/B profile):
             // snapshot so a native false can restore before falling back
-            // to bytecode (T5 unbound → interpreter, etc.).
+            // to bytecode (T5 unbound → interpreter; also KT-SELF-REC-
+            // SOUNDNESS wrong-false from self-recursive first-solution).
             val snapshot = initialState.snapshotForNative()
             nativeDepth++
             val ok = try {

--- a/tests/test_wam_kotlin_target.pl
+++ b/tests/test_wam_kotlin_target.pl
@@ -50,6 +50,11 @@
 :- dynamic kt5_ack_bad/0.
 :- dynamic kt5_nd_ok/0.
 :- dynamic kt5_choice/1.
+:- dynamic kt_sr_p/2.
+:- dynamic kt_sr_adv/0.
+:- dynamic kt_sr_ok/0.
+:- dynamic kt_sr_direct/0.
+:- dynamic kt_sr_bad/0.
 
 :- begin_tests(wam_kotlin_target).
 
@@ -1024,6 +1029,95 @@ test(functions_mode_gradle_midbody_fib_ack, [condition(gradle_available), nondet
             retractall(user:kt5_ack(_, _, _)),
             retractall(user:kt5_ack_ok),
             retractall(user:kt5_ack_bad)
+        )
+    ).
+
+% KT-SELF-REC-SOUNDNESS: adversarial self-recursive nondet LOWERS; correct
+% only because top-level tryRun native→bytecode fallback re-runs on wrong
+% native false. Pins that invariant — would FAIL if fallback were removed.
+%   p(z,a). p(z,b).
+%   p(s(N),R) :- p(N,R), R = b.
+%   adv :- p(s(z), _).
+test(functions_mode_self_rec_fallback_soundness, [condition(gradle_available), nondet]) :-
+    TmpDir = 'output/test_wam_kotlin_self_rec_soundness',
+    make_directory_path('output'),
+    clean_dir(TmpDir),
+    Preds = [user:kt_sr_p/2, user:kt_sr_adv/0, user:kt_sr_ok/0,
+             user:kt_sr_direct/0, user:kt_sr_bad/0],
+    setup_call_cleanup(
+        (   retractall(user:kt_sr_p(_, _)),
+            retractall(user:kt_sr_adv),
+            retractall(user:kt_sr_ok),
+            retractall(user:kt_sr_direct),
+            retractall(user:kt_sr_bad),
+            assertz(user:kt_sr_p(z, a)),
+            assertz(user:kt_sr_p(z, b)),
+            assertz(user:(kt_sr_p(s(N), R) :- kt_sr_p(N, R), R = b)),
+            assertz(user:(kt_sr_adv :- kt_sr_p(s(z), _))),
+            assertz(user:(kt_sr_ok :- kt_sr_p(z, a))),
+            assertz(user:(kt_sr_direct :- kt_sr_p(s(z), b))),
+            assertz(user:(kt_sr_bad :- kt_sr_p(s(z), a)))
+        ),
+        (   % Partition: must LOWER (pin: exemption still admits this pattern).
+            wam_kotlin_partition_predicates(functions, Preds, Native, _Wam, Failed),
+            assertion(Failed == []),
+            assertion(memberchk(native(kt_sr_p/2, _), Native)),
+            assertion(memberchk(native(kt_sr_adv/0, _), Native)),
+            memberchk(native(kt_sr_p/2, lowered(_, _, PCode)), Native),
+            assertion(has_substring(PCode, 'if (!dispatch("kt_sr_p/2"')),
+            % Interpreter baseline (matching + backtrack-needed + failure).
+            wam_kotlin_target:write_wam_kotlin_project(
+                Preds, [emit_mode(interpreter), conformance_main(true)], TmpDir),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_sr_ok/0'], IO, _, S1),
+            assertion(S1 == exit(0)),
+            normalize_space(string(IOTrim), IO),
+            assertion(IOTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_sr_adv/0'], IA, _, S2),
+            assertion(S2 == exit(0)),
+            normalize_space(string(IATrim), IA),
+            assertion(IATrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_sr_direct/0'], ID, _, S3),
+            assertion(S3 == exit(0)),
+            normalize_space(string(IDTrim), ID),
+            assertion(IDTrim == "true"),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_sr_bad/0'], IB, _, S4),
+            assertion(S4 == exit(0)),
+            normalize_space(string(IBTrim), IB),
+            assertion(IBTrim == "false"),
+            % Functions: same answers (adv true only via tryRun fallback).
+            wam_kotlin_target:write_wam_kotlin_project(
+                Preds, [emit_mode(functions), conformance_main(true)], TmpDir),
+            read_file_to_string(
+                'output/test_wam_kotlin_self_rec_soundness/src/main/kotlin/generated/wam/Main.kt',
+                Main, []),
+            assertion(has_substring(Main, 'registerNative("kt_sr_p/2"')),
+            assertion(has_substring(Main, 'registerNative("kt_sr_adv/0"')),
+            assertion(has_substring(Main, 'if (!dispatch("kt_sr_p/2"')),
+            run_gradle(TmpDir, ['-q', 'compileKotlin'], _, CompileErr, CS),
+            assertion(CS == exit(0)),
+            assertion(\+ has_substring(CompileErr, "error:")),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_sr_ok/0'], FO, _, S5),
+            assertion(S5 == exit(0)),
+            normalize_space(string(FOTrim), FO),
+            assertion(FOTrim == IOTrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_sr_adv/0'], FA, _, S6),
+            assertion(S6 == exit(0)),
+            normalize_space(string(FATrim), FA),
+            assertion(FATrim == IATrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_sr_direct/0'], FD, _, S7),
+            assertion(S7 == exit(0)),
+            normalize_space(string(FDTrim), FD),
+            assertion(FDTrim == IDTrim),
+            run_gradle(TmpDir, ['-q', 'run', '--args=kt_sr_bad/0'], FB, _, S8),
+            assertion(S8 == exit(0)),
+            normalize_space(string(FBTrim), FB),
+            assertion(FBTrim == IBTrim)
+        ),
+        (   retractall(user:kt_sr_p(_, _)),
+            retractall(user:kt_sr_adv),
+            retractall(user:kt_sr_ok),
+            retractall(user:kt_sr_direct),
+            retractall(user:kt_sr_bad)
         )
     ).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small closeout for EMIT-KOTLIN-5: make the unconditional self-recursion mid-body exemption’s soundness **explicit and regression-protected**.

## Invariant

**Self-recursion mid-body lowering is safe ONLY because the top-level `tryRun` native→bytecode fallback catches the wrong-false; do not remove that fallback without tightening `kotlin_safe_midbody_callee`’s SelfKey exemption.**

Adversarial pattern (lowers; correct only via fallback):

```prolog
p(z, a). p(z, b).
p(s(N), R) :- p(N, R), R = b.
adv :- p(s(z), _).
```

## Changes

1. Regression `functions_mode_self_rec_fallback_soundness` — asserts the pattern **lowers** (`registerNative` + mid-body `dispatch`) and functions == interpreter for matching + backtrack-needed + failure cases.
2. Comments on `kotlin_safe_midbody_callee` + top-level `tryRun` fallback; history entry + fleet card `KT-SELF-REC-SOUNDNESS`.
3. **Skipped** gate tighten (exclusive heads) — would decline this pinning case; task said keep 1+2 if tighten isn’t a small win.

## Depends on

Includes commits from [#3781](https://github.com/s243a/UnifyWeaver/pull/3781) (EMIT-KOTLIN-5) because that PR was still open when this branch was cut. Rebase onto `main` after #3781 merges if needed.

## Acceptance

- [x] Adversarial regression (gradle differential)
- [x] Unit suite + `kotlin`/`kotlin_functions` conformance green
- [x] Invariant documented in emitter + history + fleet card
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

