### PR TITLE
WAM/LLVM plawk: string concatenation in print (juxtaposition)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -29,7 +29,7 @@ only (runtime pending) · ❌ missing.
 
 | Feature | Status | Notes |
 |---|---|---|
-| `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic) | ✅ | constant fields (`print 1`, `print "x"`) landed |
+| `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic, **concatenation**) | ✅ | constant fields (`print 1`, `print "x"`) + juxtaposition concat (`print $1 $2`) landed |
 | `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`** (`END { if (n > 1) print … ; else print … }`, over final slot values) |
@@ -67,7 +67,7 @@ only (runtime pending) · ❌ missing.
 | arithmetic `+ - * / % //` | ✅ | i64, awk precedence, safe div/mod |
 | comparison, `~`/`!~` | ✅ | |
 | ternary `?:` | ❌ | does not parse |
-| string concatenation (juxtaposition `$1 $2`) | ❌ | does not parse |
+| string concatenation (juxtaposition `$1 $2`) | ◐ | **`print` context landed** — `print $1 $2`, `print "x" $1 "-" $2`, in rule bodies and `END`; arithmetic binds tighter, comma still splits. Assignment concat (`x = $1 $2`) needs string-valued scalars — separate |
 | exponentiation `^` / `**` | ❌ | |
 
 ## Arrays
@@ -131,8 +131,10 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    width/precision; the current subset is thin for real formatting.
 4. **`exit [n]`** — common and cheap; a flagged early-terminate of the record
    loop + END.
-5. **String concatenation & ternary `?:`** — the two most-missed *expression*
-   forms; both are parser + expression-lowering work.
+5. **Ternary `?:`** (string concatenation in `print` context **landed** —
+   `print $1 $2`, rule bodies + `END`; the remaining concat work is assignment
+   into a string-valued scalar). Ternary is the next most-missed *expression*
+   form; parser + expression-lowering work.
 6. **`delete arr[k]`** — rounds out the assoc-array story (paired with the
    existing for-in / `in`).
 7. **`split` / `sub` / `gsub` / `match` / `sprintf`** — the string-builtin

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -9865,11 +9865,34 @@ plawk_end_print_string_global_lines([string(Value) | Rest], Index) -->
     },
     [Line],
     plawk_end_print_string_global_lines(Rest, NextIndex).
+% a concatenation's string operands emit globals under the same
+% PrintIndex*1000 + part index scheme the END concat print uses.
+plawk_end_print_string_global_lines([concat(Parts) | Rest], Index) -->
+    plawk_end_concat_string_globals(Parts, Index, 0),
+    { NextIndex is Index + 1 },
+    plawk_end_print_string_global_lines(Rest, NextIndex).
 plawk_end_print_string_global_lines([Field | Rest], Index) -->
     { \+ Field = string(_),
+      \+ Field = concat(_),
       NextIndex is Index + 1
     },
     plawk_end_print_string_global_lines(Rest, NextIndex).
+
+plawk_end_concat_string_globals([], _Index, _PartIndex) -->
+    [].
+plawk_end_concat_string_globals([string(Value) | Rest], Index, PartIndex) -->
+    { CombinedIndex is Index * 1000 + PartIndex,
+      format(atom(GlobalName), 'plawk_end_print_string_~w', [CombinedIndex]),
+      llvm_emit_c_string_global(GlobalName, Value, Line, _StringLen, _BytesLen),
+      NextPartIndex is PartIndex + 1
+    },
+    [Line],
+    plawk_end_concat_string_globals(Rest, Index, NextPartIndex).
+plawk_end_concat_string_globals([Part | Rest], Index, PartIndex) -->
+    { \+ Part = string(_),
+      NextPartIndex is PartIndex + 1
+    },
+    plawk_end_concat_string_globals(Rest, Index, NextPartIndex).
 
 plawk_assoc_print_key_global_lines([], _) -->
     [].
@@ -10116,6 +10139,11 @@ plawk_mixed_end_print_lines([string(Value) | Rest], ScalarPlan, AssocPlan, Outpu
     plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
 
 plawk_scalar_print_expr(var(Name), Name).
+% a concatenation contributes each operand's scalar reads (so a printed scalar
+% inside `print a $1 b` gets a slot).
+plawk_scalar_print_expr(concat(Parts), Name) :-
+    member(Part, Parts),
+    plawk_scalar_print_expr(Part, Name).
 plawk_scalar_print_expr(Expr, Name) :-
     plawk_end_scalar_expr(Expr),
     plawk_expr_scalar_read_name(Expr, Name).
@@ -10359,6 +10387,11 @@ plawk_rule_body_print_action(printf(string(Format), Args)) :-
 
 plawk_rule_body_print_field(field(_)).
 plawk_rule_body_print_field(string(_)).
+% a string concatenation (`print $1 $2`): every operand must be a valid print
+% field; they are emitted adjacently with no separator.
+plawk_rule_body_print_field(concat(Parts)) :-
+    Parts = [_, _ | _],
+    maplist(plawk_rule_body_print_field, Parts).
 % a bare scalar variable read (`print i`): substitution rewrites var(Name) to
 % the slot's SSA value at emit time, so a scalar can be printed directly. Only
 % names that resolve to a slot compile; a non-slot var fails substitution.
@@ -10917,6 +10950,11 @@ plawk_substitute_operation_reads(set(Expr0), Slots, Values, set(Expr)) :-
     plawk_substitute_scalar_reads(Expr0, Slots, Values, Expr).
 plawk_substitute_operation_reads(Operation, _Slots, _Values, Operation).
 
+plawk_substitute_scalar_reads(concat(Parts), Slots, Values, concat(SubParts)) :-
+    !,
+    maplist(plawk_substitute_scalar_read_part(Slots, Values), Parts, SubParts).
+plawk_substitute_scalar_read_part(Slots, Values, Part, SubPart) :-
+    plawk_substitute_scalar_reads(Part, Slots, Values, SubPart).
 plawk_substitute_scalar_reads(var(Name), Slots, Values, Substituted) :-
     !,
     nth0(SlotIndex, Slots, Slot),
@@ -12498,6 +12536,50 @@ plawk_scalar_end_print_lines([string(Value) | Rest], StatePlan, OutputSeparator,
     plawk_end_string_print_lines(Value, PrintIndex),
     { NextPrintIndex is PrintIndex + 1 },
     plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
+% concatenation in END (`print "total: " sum`): one leading separator, then each
+% operand printed adjacently (no separator between). Each part uses a unique
+% index (PrintIndex*1000 + part) so the fixed-name emitters don't collide.
+plawk_scalar_end_print_lines([concat(Parts) | Rest], StatePlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
+    plawk_end_concat_parts(Parts, StatePlan, PrintIndex, 0),
+    { NextPrintIndex is PrintIndex + 1 },
+    plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
+
+plawk_end_concat_parts([], _StatePlan, _PrintIndex, _PartIndex) -->
+    [].
+plawk_end_concat_parts([Part | Rest], StatePlan, PrintIndex, PartIndex) -->
+    { CombinedIndex is PrintIndex * 1000 + PartIndex },
+    plawk_end_field_print_lines(Part, StatePlan, CombinedIndex),
+    { NextPartIndex is PartIndex + 1 },
+    plawk_end_concat_parts(Rest, StatePlan, PrintIndex, NextPartIndex).
+
+% One END print field WITHOUT a leading separator (the concat driver adds the
+% single separator before the whole concatenation).
+plawk_end_field_print_lines(var(Name), StatePlan, PrintIndex) -->
+    { plawk_state_slot_lookup(StatePlan, Name, SlotIndex, Slot),
+      format(atom(ValueIR), '%final_slot_~w', [SlotIndex]),
+      ( Slot = scalar_double(_Name)
+      -> format(atom(FmtVar), 'end_f64_fmt_~w', [PrintIndex]),
+         format(atom(FmtPtr),
+             '  %~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_f64, i32 0, i32 0',
+             [FmtVar]),
+         format(atom(PrintCall),
+             '  %printed_end_f64_~w = call i32 (i8*, ...) @printf(i8* %~w, double ~w)',
+             [PrintIndex, FmtVar, ValueIR])
+      ;  format(atom(FmtVar), 'end_i64_fmt_~w', [PrintIndex]),
+         format(atom(PrintVar), 'printed_end_i64_~w', [PrintIndex]),
+         llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
+             [FmtPtr, PrintCall])
+      )
+    },
+    [FmtPtr, PrintCall].
+plawk_end_field_print_lines(string(Value), _StatePlan, PrintIndex) -->
+    plawk_end_string_print_lines(Value, PrintIndex).
+plawk_end_field_print_lines(special('NR'), _StatePlan, PrintIndex) -->
+    plawk_end_nr_print_lines(PrintIndex).
+plawk_end_field_print_lines(Expr, StatePlan, PrintIndex) -->
+    { plawk_end_scalar_expr(Expr) },
+    plawk_end_expr_print_lines(Expr, StatePlan, PrintIndex).
 
 plawk_end_nr_print_lines(PrintIndex) -->
     { format(atom(FmtVar), 'end_nr_fmt_~w', [PrintIndex]),
@@ -13039,6 +13121,9 @@ plawk_fields_include_nr(Fields) :-
     plawk_expr_uses_nr(Field).
 
 plawk_expr_uses_nr(special('NR')).
+plawk_expr_uses_nr(concat(Parts)) :-
+    member(Part, Parts),
+    plawk_expr_uses_nr(Part).
 plawk_expr_uses_nr(Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
     ( plawk_expr_uses_nr(Left)
@@ -13275,6 +13360,12 @@ plawk_print_field_ir(Field, FieldSeparator, Index) -->
     },
     [GlobalIR-BodyIR].
 
+% A concatenation prints its operands adjacently -- NO field separator between
+% them (that is what distinguishes `print $1 $2` from `print $1, $2`). Each part
+% lowers via the ordinary print-field emitter under a unique sub-prefix.
+plawk_prefixed_print_field_ir(concat(Parts), FieldSeparator, Prefix, Index) -->
+    { format(atom(ConcatPrefix), '~w_concat_~w', [Prefix, Index]) },
+    plawk_concat_parts_ir(Parts, FieldSeparator, ConcatPrefix, 0).
 plawk_prefixed_print_field_ir(Field, FieldSeparator, Prefix, Index) -->
     { plawk_emit_prefixed_print_expr_ir(Field, FieldSeparator, Prefix, Index,
           Type, GlobalParts, SetupParts),
@@ -13284,6 +13375,13 @@ plawk_prefixed_print_field_ir(Field, FieldSeparator, Prefix, Index) -->
       atomic_list_concat(BodyParts, '\n', BodyIR)
     },
     [GlobalIR-BodyIR].
+
+plawk_concat_parts_ir([], _FieldSeparator, _Prefix, _PartIndex) -->
+    [].
+plawk_concat_parts_ir([Part | Rest], FieldSeparator, Prefix, PartIndex) -->
+    plawk_prefixed_print_field_ir(Part, FieldSeparator, Prefix, PartIndex),
+    { NextIndex is PartIndex + 1 },
+    plawk_concat_parts_ir(Rest, FieldSeparator, Prefix, NextIndex).
 
 plawk_emit_print_expr_ir(Field, FieldSeparator, Index, Type, GlobalParts, SetupParts) :-
     plawk_emit_print_expr_for_context(Field, FieldSeparator, print_context(normal, '', Index),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2167,12 +2167,32 @@ print_fields_rest([]) -->
 % meaning there (`emit 1` stays the integer 1, not the atom '1'). field_expr is
 % tried first, so arithmetic (`print 1 + 2`) and floats are unaffected; only a
 % lone integer falls through to the literal clause.
+% String concatenation by juxtaposition (awk): `print $1 $2`, `print "x" $1`,
+% `print $1 "-" $2` output the operands adjacent, with NO field separator (unlike
+% the comma list). Two or more operands separated by whitespace parse to
+% concat([...]). Each operand is a field_expr, so arithmetic binds tighter than
+% concatenation (`$1 $2 + $3` == concat($1, $2 + $3)) and a comma still splits
+% print args. A single operand keeps its plain form (no concat wrapper).
+print_field_expr(concat([First, Second | Rest])) -->
+    field_expr(First),
+    required_ws,
+    field_expr(Second),
+    concat_rest(Rest),
+    !.
 print_field_expr(Field) -->
     field_expr(Field),
     !.
 print_field_expr(string(Text)) -->
     signed_integer_value(N),
     { format(string(Text), '~w', [N]) }.
+
+concat_rest([Operand | Rest]) -->
+    required_ws,
+    field_expr(Operand),
+    !,
+    concat_rest(Rest).
+concat_rest([]) -->
+    [].
 
 field_expr(Expr) -->
     i64_binary_surface_expr(Expr).

--- a/tests/test_plawk_concat.pl
+++ b/tests/test_plawk_concat.pl
@@ -1,0 +1,138 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk string concatenation by juxtaposition (awk). `print $1 $2`, `print "x"
+% $1`, `print $1 "-" $2` output the operands ADJACENT, with no field separator
+% (unlike the comma list `print $1, $2`). Two or more operands separated by
+% whitespace parse to concat([...]); arithmetic binds tighter than
+% concatenation. Print-only (assignment concat would need string-valued
+% scalars, a separate feature).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_concat).
+
+% --- parsing / precedence ---------------------------------------------------
+
+test(concat_two_fields_parses) :-
+    plawk_parse_string("{ print $1 $2 }\n",
+        program([], [rule(always, [print([concat([field(1), field(2)])])])], [])),
+    !.
+
+test(concat_string_and_field_parses) :-
+    plawk_parse_string("{ print \"x\" $1 }\n",
+        program([], [rule(always, [print([concat([string("x"), field(1)])])])], [])),
+    !.
+
+% A single operand keeps its plain form (no concat wrapper).
+test(single_field_unchanged) :-
+    plawk_parse_string("{ print $1 }\n",
+        program([], [rule(always, [print([field(1)])])], [])),
+    !.
+
+% A comma still splits print args (not concatenation).
+test(comma_splits_not_concat) :-
+    plawk_parse_string("{ print $1, $2 }\n",
+        program([], [rule(always, [print([field(1), field(2)])])], [])),
+    !.
+
+% Arithmetic binds tighter than concatenation: `$1 + $2` stays arithmetic;
+% `$1 $2 + $3` is concat($1, $2 + $3).
+test(arithmetic_tighter_than_concat) :-
+    plawk_parse_string("{ print $1 + $2 }\n",
+        program([], [rule(always, [print([add_i64(field(1), field(2))])])], [])),
+    plawk_parse_string("{ print $1 $2 + $3 }\n",
+        program([], [rule(always,
+            [print([concat([field(1), add_i64(field(2), field(3))])])])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+test(concat_two_fields, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'c2', "{ print $1 $2 }\n", "a b c\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "ab\n"),
+    !.
+
+test(concat_with_string_literal, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'cs', "{ print $1 \"-\" $2 }\n", "a b c\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "a-b\n"),
+    !.
+
+test(concat_prefix_string, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'cp', "{ print \"row: \" $1 }\n", "hello world\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "row: hello\n"),
+    !.
+
+% Concatenation composes with the comma list: `print $1 $2, $3`.
+test(concat_then_comma, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'cc', "{ print $1 $2, $3 }\n", "a b c\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "ab c\n"),
+    !.
+
+% Concatenation with a scalar variable.
+test(concat_with_scalar, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'cv', "{ n++; print \"line\" n }\n", "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "line1\nline2\n"),
+    !.
+
+% Concatenation with NR (record counter) inside the concat.
+test(concat_with_nr, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'cnr', "{ print NR \": \" $1 }\n", "x\ny\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1: x\n2: y\n"),
+    !.
+
+% Concatenation in an END block (`print "total: " sum " done"`).
+test(concat_in_end, [condition(clang_available)]) :-
+    cdir(Dir),
+    Src = "{ s += $1 }\nEND { print \"total: \" s \" done\" }\n",
+    build_run(Dir, 'ce', Src, "10\n20\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "total: 30 done\n"),
+    !.
+
+:- end_tests(plawk_concat).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+cdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_concat', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

awk concatenates adjacent expressions with no operator: `print $1 $2`, `print "x" $1`, `print $1 "-" $2` output the operands **adjacent** — no field separator, unlike the comma list `print $1, $2`. This lands it for the `print` context, the most common everyday-awk idiom that previously didn't parse.

**Parser:** a print field of two-or-more `field_expr`s separated by whitespace parses to `concat([...])`. Using `field_expr` as the operand means **arithmetic binds tighter** than concatenation (`$1 $2 + $3` == `concat($1, $2 + $3)`) and a **comma still splits** print args (`$1 $2, $3` == `[concat($1,$2), $3]`). A single operand keeps its plain form.

**Codegen:** a concat print field emits each operand adjacently via the ordinary print-field emitter under a unique sub-prefix — no separator between parts. Plumbed through everything a concat operand touches: print-field validation, scalar-read substitution (so `print "x" i` reads slot `i`), slot discovery, NR-detection (so `NR` inside a concat still defines `%current_nr`), and the **END print path** (fixed-name emitter + string globals under a `PrintIndex*1000+part` index so the two paths agree).

Works in rule bodies and END: `print $1 $2` → `ab`; `print "row: " $1`; `print NR ": " $1` → `1: x`; `END { print "total: " s " done" }` → `total: 30 done`.

**Scope:** assignment concat (`x = $1 $2`) needs **string-valued scalars** (plawk scalars are i64/f64 today) — a separate feature, noted in the audit.

## Tests

`tests/test_plawk_concat.pl` — parse/precedence (two fields, string+field, single unchanged, comma splits, arithmetic tighter) + runtime (fields, string literal, prefix, concat-then-comma, scalar, NR, END concat) — 12 pass. Regression: prefix_print (221), end_scalar_exprs (16), print_literals (11), assoc_print (3), forin_end_print (14), end_if (7) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_