### PR TITLE
CONF-FSHARP: register F# hybrid WAM in cross-target conformance harness

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -24,7 +24,10 @@ self-contained so a single coding agent can pick it up in isolation.
 
 | ID | Lever | Target | Size | Depends on |
 |---|---|---|---|---|
-| CONF-FSHARP | Conformance adapter | F# | M | — |
+| CONF-FSHARP ✅ | Conformance adapter | F# | M | done — opt-in (`cursor/conf-fsharp-f421`); member/fib/ack green, append/reverse/builtins xfails + functions/builtins skip |
+| FS-LIST-PARTIAL-TAIL | Conformance gap fix | F# | M | CONF-FSHARP |
+| FS-ARITH-INT-DIV | Conformance gap fix | F# | S | CONF-FSHARP |
+| FS-FUNCTIONS-BUILTINS-LOWER | Conformance gap fix | F# | M | CONF-FSHARP |
 | CONF-LLVM | Conformance adapter | LLVM | L | — |
 | CONF-R | Conformance adapter | R | M | — |
 | CONF-CLOJURE | Conformance adapter | Clojure | L | — |
@@ -86,18 +89,27 @@ external toolchain.
 
 ### CONF-FSHARP: Register F# in the cross-target conformance harness
 - **Lever:** Conformance adapters  **Target:** F#  **Size:** M  **Depends on:** —
+- **Status:** ✅ **Landed** on `cursor/conf-fsharp-f421` (2026-07-15). Opt-in `conformance_target(fsharp)` + `fsharp_functions` (`emit_mode(interpreter|functions)`). Added additive `conformance_main(true)` Program.fs driver (`tryRun` → `true`/`false`) without changing the default TSV/LMDB benchmark entrypoint. `dotnet build` gate; `dotnet run --no-build -- <key>` (avoid `--nologo` on the run line — some SDKs forward it as argv[0]). **Measured:** member/fib/ack green on both emit modes; `ct_xfail` append/reverse (FS-LIST-PARTIAL-TAIL) + builtins (FS-ARITH-INT-DIV); `ct_skip` `fsharp_functions`/builtins (FS-FUNCTIONS-BUILTINS-LOWER). Follow-ups filed below.
 - **Goal:** Add an F# adapter (`conformance_target(fsharp)` + `ct_toolchain`/`ct_build`/`ct_run`/`ct_teardown`) so the shared WAM spec runs against the F# backend.
-- **Files to touch:** `tests/test_wam_cross_target_conformance.pl`
-- **Reference to copy from:** `tests/test_wam_cross_target_conformance.pl` — the **Python adapter** block (lines ~705-739, interpreted/scripted style) for overall shape; project writer is `write_wam_fsharp_project/3` in `src/unifyweaver/targets/wam_fsharp_target.pl:4926`.
-- **Steps:**
-  1. Add `:- use_module('../src/unifyweaver/targets/wam_fsharp_target', [write_wam_fsharp_project/3]).` near the other target imports (lines ~50-71).
-  2. Add `conformance_target(fsharp).` to the registry (lines ~77-85). Leave it opt-in (do NOT add `ct_default_target`).
-  3. Add `ct_toolchain(fsharp, [dotnet]).` (alongside lines ~283-291). (verify: exact executable — `dotnet` drives `dotnet run`/`dotnet build` for an F# project.)
-  4. `ct_build(fsharp, Preds, Queries, fsharp_ctx(Dir, Map))`: mirror Python's body — `ct_tmp_dir('tmp_ct_fsharp', Dir)`, `synth_wrappers`, `strip_pred`, `qualify_user`, then `write_wam_fsharp_project(AllPreds, [module_name(wam_ct)], Dir)`. Since F# is compiled, add a `dotnet build` gate via `run_proc` like the Go/Rust adapters (throw on nonzero). (verify: whether the generated project self-builds via a `.fsproj` and how the 0-arity wrapper is queried at runtime — inspect what `write_wam_fsharp_project` emits as an entry point / CLI shim; may need a driver overwrite like Go/Rust.)
-  5. `ct_run(fsharp, fsharp_ctx(Dir, Map), K, A, Bool)`: look up wrapper name in `Map`, run `dotnet run -- <key>` via `run_proc_out`, map stdout to bool with `bool_of_string` (or absence-of-`false.` like Python — match whatever the generated runner prints).
-  6. `ct_teardown(fsharp, fsharp_ctx(Dir, Map)) :- cleanup_dir(Dir), abolish_wrappers(Map).`
-  7. Add `test(fsharp, [condition(ct_available(fsharp))]) :- run_target_conformance(fsharp).` inside the `begin_tests/end_tests` block (lines ~323-334).
-- **Acceptance:** `CONFORMANCE_TARGETS=fsharp swipl -g run_tests tests/test_wam_cross_target_conformance.pl` passes (skips cleanly if `dotnet` absent).
+- **Acceptance:** `CONFORMANCE_TARGETS=fsharp[,fsharp_functions] swipl -g run_tests tests/test_wam_cross_target_conformance.pl` runs the adapter (skips cleanly if `dotnet` absent); xfails/skips match measured gaps.
+
+### FS-LIST-PARTIAL-TAIL: F# PutList/SetVariable result spines vs GetList
+- **Lever:** Conformance gap fix  **Target:** F#  **Size:** M  **Depends on:** CONF-FSHARP
+- **Goal:** Make non-empty ground `append`/`reverse` answers succeed under the classic harness (empty-list append base already passes).
+- **Root cause (measured):** Wrapper construction of ground result lists uses `PutList` + `SetVariable` + nested `PutStructure("[|]", …)` while recursive clauses peel with `GetList`/`UnifyValue`; partial-tail materialization does not unify against the expected VList/`"[|]"/2` spine.
+- **Acceptance:** Drop `ct_xfail(fsharp, append/reverse)` and the `fsharp_functions` twins; both emit modes green on those programs.
+
+### FS-ARITH-INT-DIV: F# `evalArith` missing `//`
+- **Lever:** Conformance gap fix  **Target:** F#  **Size:** S  **Depends on:** CONF-FSHARP
+- **Goal:** `cbi_arith(28)` succeeds (`17 // 5` + `17 mod 5` with the rest of the fold).
+- **Root cause (measured):** `WamTypes.evalArith` handles `+,-,*,/,mod` but not `Str ("//", [a;b])`; the compiler emits `PutStructure ("//", 2, …)` for integer div, so `is_lax` binds nothing and the wrapper fails. (`mod` already works.)
+- **Acceptance:** Drop `ct_xfail(fsharp, builtins)`; builtins suite green under `CONFORMANCE_TARGETS=fsharp`.
+
+### FS-FUNCTIONS-BUILTINS-LOWER: `emit_mode(functions)` stalls on `cbi_eq`
+- **Lever:** Conformance gap fix  **Target:** F#  **Size:** M  **Depends on:** CONF-FSHARP
+- **Goal:** Lowering `cbi_eq` (and friends) completes without hanging; builtins measurable under `fsharp_functions`.
+- **Root cause (measured):** `write_wam_fsharp_project` with `emit_mode(functions)` on the builtins program emits repeated “instruction not supported → Proceed stub” for `=/2` / `put_constant foo` and does not finish `Lowered.fs` / `Program.fs` within a minute-plus — harness uses `ct_skip(fsharp_functions, builtins)`.
+- **Acceptance:** Remove the skip; builtins either lowers cleanly or declines to interpreter without stalling; suite completes under `CONFORMANCE_TARGETS=fsharp_functions`.
 
 ### CONF-LLVM: Register LLVM in the cross-target conformance harness
 - **Lever:** Conformance adapters  **Target:** LLVM  **Size:** L  **Depends on:** —

--- a/docs/WAM_FSHARP_STATUS.md
+++ b/docs/WAM_FSHARP_STATUS.md
@@ -79,7 +79,14 @@ classic `wam_conformance_smoke` matrix with Scala/Elixir.
 - Finish F# kernel templates for the remaining shared kinds (or stop
   claiming “7 kernels” without the templates).
 - Bidirectional off by default; enable after cost-model confidence.
-- **Not registered** in classic conformance harness.
+- Classic conformance (**CONF-FSHARP**, 2026-07-15): registered
+  opt-in (`fsharp` / `fsharp_functions`) with additive
+  `conformance_main(true)`. **Measured maturity:** member, fib, ack
+  green on interpreter and `emit_mode(functions)`. Still xfail:
+  append/reverse (FS-LIST-PARTIAL-TAIL — PutList/SetVariable result
+  spines vs GetList), builtins (FS-ARITH-INT-DIV — `evalArith` lacks
+  `//`). `fsharp_functions`+builtins skipped (FS-FUNCTIONS-BUILTINS-LOWER
+  — lowered emitter stalls on `cbi_eq`).
 - Dynamic database partial (facts via lowered mutation; prefer Python
   for full dynamic-DB semantics — target doc).
 - LMDB scan-mode / workload-segregation wait on Rust R9/R10 reference.
@@ -93,7 +100,8 @@ classic `wam_conformance_smoke` matrix with Scala/Elixir.
 
 ## Path forward
 
-1. Register classic conformance adapter.
+1. Close CONF-FSHARP follow-ups: FS-LIST-PARTIAL-TAIL,
+   FS-ARITH-INT-DIV, FS-FUNCTIONS-BUILTINS-LOWER.
 2. Elixir-style cost-gate calibration for TPL fanout.
 3. Follow Rust scan/segregation LMDB contract when available.
 4. Keep ISO table in sync with C++/Elixir/Python.

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -5237,6 +5237,10 @@ generate_program_fs(_Predicates, DetectedKernels, Options, Code) :-
     ->  KernelKind = FirstKernelKind
     ;   KernelKind = unknown
     ),
+    %% Additive conformance driver (CONF-FSHARP): when true, Program.fs
+    %% prints true/false for argv[0]=pred/arity via tryRun. Default
+    %% benchmark driver (human-facing TSV/LMDB timing) is unchanged.
+    option(conformance_main(ConfMain), Options, false),
     Dict = [
         foreign_preds = ForeignPredsStr,
         lookup_sources_expr = LookupSourcesExpr,
@@ -5248,7 +5252,8 @@ generate_program_fs(_Predicates, DetectedKernels, Options, Code) :-
         branch_factor = BranchFactor,
         dimensionality = Dimensionality,
         materialisation = Materialisation,
-        l2_capacity = L2CapStr
+        l2_capacity = L2CapStr,
+        conformance_main = ConfMain
     ],
     fsharp_program_template_source(Template),
     render_template(Template, Dict, Code).

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -6,6 +6,67 @@ open WamTypes
 open WamRuntime
 open Predicates
 open Lowered
+{{#conformance_main}}
+// Conformance driver (CONF-FSHARP): argv[0] = pred/arity key; print true/false.
+// Additive — default Program.fs below is unchanged when conformance_main is off.
+
+let mkContext () =
+    let foreignPreds : string list = []
+    let resolvedCode =
+        resolveCallInstrs allLabels foreignPreds (Array.toList allCode)
+        |> List.toArray
+    { WcCode              = resolvedCode
+      WcLabels            = allLabels
+      WcForeignFacts      = Map.empty
+      WcFfiFacts          = Map.empty
+      WcFfiWeightedFacts  = Map.empty
+      WcAtomIntern        = Map.empty
+      WcAtomDeintern      = Map.empty
+      WcForeignConfig     = Map.empty
+      WcLoweredPredicates = loweredPredicates
+      WcLookupSources     = Map.empty
+      WcCancellationToken = None }
+
+let mkState () : WamState =
+    { WsPC         = 0
+      WsRegs       = Array.create MaxRegs (Unbound -1)
+      WsStack      = []
+      WsHeap       = []
+      WsHeapLen    = 0
+      WsTrail      = []
+      WsTrailLen   = 0
+      WsCP         = 0
+      WsCPs        = []
+      WsCPsLen     = 0
+      WsBindings   = Map.empty
+      WsCutBar     = 0
+      WsVarCounter = 0
+      WsBuilder    = None
+      WsBuilderStack = []
+      WsAggAccum   = []
+      WsB0Stack    = []
+      WsCatchers   = [] }
+
+/// Boolean success signal for a ground 0-arity wrapper (or any labeled/lowered pred).
+/// dispatchCall already runs the interpreter for WAM labels and invokes lowered fns.
+let tryRun (predKey: string) : bool =
+    let ctx = mkContext ()
+    let s = mkState ()
+    match dispatchCall ctx predKey s with
+    | Some _ -> true
+    | None   -> false
+
+[<EntryPoint>]
+let main argv =
+    match Array.tryHead argv with
+    | None ->
+        printfn "false"
+        0
+    | Some predKey ->
+        printfn "%b" (tryRun predKey)
+        0
+{{/conformance_main}}
+{{^conformance_main}}
 {{#has_lmdb}}open LmdbFactSource
 {{/has_lmdb}}{{#has_csr}}open CsrReader
 {{/has_csr}}
@@ -448,3 +509,4 @@ let main argv =
         lastQueryMs seedCats.Length (totalSolutions / numReps) numReps
     printfn "total_ms=%d" totalMs
     0
+{{/conformance_main}}

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -71,6 +71,8 @@
               [write_wam_cpp_project/3]).
 :- use_module('../src/unifyweaver/targets/wam_kotlin_target',
               [write_wam_kotlin_project/3]).
+:- use_module('../src/unifyweaver/targets/wam_fsharp_target',
+              [write_wam_fsharp_project/3]).
 
 % ============================================================
 % Target registry + known-divergence (xfail) registry
@@ -87,13 +89,15 @@ conformance_target(c).
 conformance_target(cpp).
 conformance_target(kotlin).
 conformance_target(kotlin_functions).
+conformance_target(fsharp).
+conformance_target(fsharp_functions).
 
 %% ct_default_target(Target): runs unless CONFORMANCE_TARGETS overrides.
 %  Only scala and elixir run by default. Every other registered backend
-%  (wat, haskell, python, go, rust, c, cpp, kotlin, kotlin_functions) is
-%  opt-in via CONFORMANCE_TARGETS because it builds a per-program project
-%  with an external toolchain. Kotlin is especially slow (gradle compile
-%  per program) and stays opt-in like Haskell.
+%  (wat, haskell, python, go, rust, c, cpp, kotlin, kotlin_functions,
+%  fsharp, fsharp_functions) is opt-in via CONFORMANCE_TARGETS because it
+%  builds a per-program project with an external toolchain. Kotlin/F# are
+%  especially slow (gradle / dotnet compile per program) and stay opt-in.
 ct_default_target(scala).
 ct_default_target(elixir).
 
@@ -282,6 +286,10 @@ ct_default_target(elixir).
 %  programs green after KT-ARITH-SLASH-FUNCTOR + KT-LIST-BACKTRACK +
 %  KT-Y-ENV-RECURSION (no remaining kotlin ct_xfail entries).
 
+%  F# (CONF-FSHARP). Adapter registered (opt-in). Measured maturity and
+%  any ct_xfail(fsharp[,_functions], Program) entries are recorded below
+%  after the first harness run (honest readout — do not force green).
+
 % ============================================================
 % Toolchain probes
 % ============================================================
@@ -297,6 +305,8 @@ ct_toolchain(c,      [gcc]).
 ct_toolchain(cpp,    ['g++']).
 ct_toolchain(kotlin, [gradle]).
 ct_toolchain(kotlin_functions, [gradle]).
+ct_toolchain(fsharp, [dotnet]).
+ct_toolchain(fsharp_functions, [dotnet]).
 
 ct_available(scala) :-
     ct_enabled(scala),
@@ -341,6 +351,9 @@ test(cpp,    [condition(ct_available(cpp))])    :- run_target_conformance(cpp).
 test(kotlin, [condition(ct_available(kotlin))]) :- run_target_conformance(kotlin).
 test(kotlin_functions, [condition(ct_available(kotlin_functions))]) :-
     run_target_conformance(kotlin_functions).
+test(fsharp, [condition(ct_available(fsharp))]) :- run_target_conformance(fsharp).
+test(fsharp_functions, [condition(ct_available(fsharp_functions))]) :-
+    run_target_conformance(fsharp_functions).
 
 :- end_tests(wam_cross_target_conformance).
 
@@ -1024,6 +1037,61 @@ kotlin_ct_run(kotlin_ctx(Dir, Map), K, A, Bool) :-
 ct_teardown(kotlin, kotlin_ctx(Dir, Map)) :-
     cleanup_dir(Dir), abolish_wrappers(Map).
 ct_teardown(kotlin_functions, kotlin_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+
+% ============================================================
+% Adapter: F#  (0-arity wrapper -> `dotnet run -- <key>` -> true/false)
+%
+% write_wam_fsharp_project/3 emits a .NET F# exe. The default Program.fs is
+% a TSV/LMDB benchmark driver; for conformance we pass conformance_main(true)
+% so Program.fs uses tryRun (dispatchCall) and prints true/false (additive —
+% default human-facing benchmark output for existing smokes is unchanged).
+%
+% Two opt-in targets share this adapter:
+%   fsharp            — emit_mode(interpreter)
+%   fsharp_functions  — emit_mode(functions) (native-first + WAM fallback)
+% Opt-in via CONFORMANCE_TARGETS=fsharp[,fsharp_functions].
+% ============================================================
+
+ct_build(fsharp, Preds, Queries, fsharp_ctx(Dir, Map)) :-
+    fsharp_ct_build(interpreter, Preds, Queries, Dir, Map).
+
+ct_build(fsharp_functions, Preds, Queries, fsharp_ctx(Dir, Map)) :-
+    fsharp_ct_build(functions, Preds, Queries, Dir, Map).
+
+fsharp_ct_build(EmitMode, Preds, Queries, Dir, Map) :-
+    setenv('DOTNET_CLI_TELEMETRY_OPTOUT', '1'),
+    setenv('DOTNET_NOLOGO', '1'),
+    ct_tmp_dir('tmp_ct_fsharp', Dir),
+    synth_wrappers(Queries, WPreds, Map),
+    maplist(strip_pred, Preds, BarePreds),
+    append(WPreds, BarePreds, AllPreds0),
+    maplist(qualify_user, AllPreds0, AllPreds),
+    write_wam_fsharp_project(AllPreds,
+        [module_name(wam_ct),
+         no_kernels(true),
+         emit_mode(EmitMode),
+         conformance_main(true)], Dir),
+    run_proc(dotnet, ['build', '--nologo', '-v', 'q'], Dir, BExit, BErr),
+    ( BExit =:= 0 -> true ; throw(fsharp_build_failed(BExit, BErr)) ).
+
+ct_run(fsharp, Ctx, K, A, Bool) :-
+    fsharp_ct_run(Ctx, K, A, Bool).
+ct_run(fsharp_functions, Ctx, K, A, Bool) :-
+    fsharp_ct_run(Ctx, K, A, Bool).
+
+fsharp_ct_run(fsharp_ctx(Dir, Map), K, A, Bool) :-
+    memberchk((K-A)-WName, Map),
+    format(atom(KeyAtom), '~w/0', [WName]), atom_string(KeyAtom, KeyStr),
+    % --no-build: ct_build already gated compilation; avoids restore noise.
+    run_proc_out(dotnet, ['run', '--no-build', '--nologo', '--', KeyStr],
+                 Dir, _Exit, OutStr),
+    normalize_space(string(Out), OutStr),
+    bool_of_string(Out, Bool).
+
+ct_teardown(fsharp, fsharp_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+ct_teardown(fsharp_functions, fsharp_ctx(Dir, Map)) :-
     cleanup_dir(Dir), abolish_wrappers(Map).
 
 %% c_copy_runtime_header(+Dir) — copy the static wam_runtime.h into Dir.

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -286,9 +286,22 @@ ct_default_target(elixir).
 %  programs green after KT-ARITH-SLASH-FUNCTOR + KT-LIST-BACKTRACK +
 %  KT-Y-ENV-RECURSION (no remaining kotlin ct_xfail entries).
 
-%  F# (CONF-FSHARP). Adapter registered (opt-in). Measured maturity and
-%  any ct_xfail(fsharp[,_functions], Program) entries are recorded below
-%  after the first harness run (honest readout — do not force green).
+%  F# (CONF-FSHARP, 2026-07-15). Adapter registered (opt-in). Measured:
+%   - Green: member, fib, ack (interpreter + emit_mode(functions)).
+%   - append / reverse: non-empty ground answers fail — PutList +
+%     SetVariable partial-tail materialization vs GetList/unify on the
+%     result spine (VList / "[|]"/2). Empty-list append base case passes.
+%   - builtins: evalArith has no Str ("//", ...) clause, so integer-div
+%     `17 // 5` (PutStructure "//") returns None and cbi_arith(28) fails
+%     (mod is present; +,-,*,=/2,cmp pass).
+%   - fsharp_functions + builtins: lowered emitter loops/stalls on cbi_eq
+%     (unsupported-instruction Proceed stubs for =/2); skip generation.
+ct_xfail(fsharp, append).            % FS-LIST-PARTIAL-TAIL
+ct_xfail(fsharp, reverse).           % FS-LIST-PARTIAL-TAIL
+ct_xfail(fsharp, builtins).          % FS-ARITH-INT-DIV
+ct_xfail(fsharp_functions, append).  % FS-LIST-PARTIAL-TAIL (same class)
+ct_xfail(fsharp_functions, reverse). % FS-LIST-PARTIAL-TAIL
+ct_skip(fsharp_functions, builtins). % FS-FUNCTIONS-BUILTINS-LOWER — codegen stalls
 
 % ============================================================
 % Toolchain probes
@@ -1083,8 +1096,11 @@ ct_run(fsharp_functions, Ctx, K, A, Bool) :-
 fsharp_ct_run(fsharp_ctx(Dir, Map), K, A, Bool) :-
     memberchk((K-A)-WName, Map),
     format(atom(KeyAtom), '~w/0', [WName]), atom_string(KeyAtom, KeyStr),
-    % --no-build: ct_build already gated compilation; avoids restore noise.
-    run_proc_out(dotnet, ['run', '--no-build', '--nologo', '--', KeyStr],
+    % --no-build: ct_build already gated compilation. Do NOT pass --nologo
+    % here: on some SDK versions it is forwarded as argv[0] even after `--`,
+    % which makes tryRun look up the wrong predicate key. DOTNET_NOLOGO=1
+    % (set in fsharp_ct_build) suppresses the banner instead.
+    run_proc_out(dotnet, ['run', '--no-build', '--', KeyStr],
                  Dir, _Exit, OutStr),
     normalize_space(string(Out), OutStr),
     bool_of_string(Out, Bool).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Registers the F# hybrid WAM target in the cross-target conformance harness (**CONF-FSHARP**). Opt-in only — no `ct_default_target`.

### Changes
- **Additive `conformance_main(true)`** on `write_wam_fsharp_project/3` / `program.fs.mustache`: Program prints `true`/`false` via local `tryRun` (`dispatchCall`). Default TSV/LMDB benchmark `Program.fs` unchanged.
- **Adapters:** `conformance_target(fsharp)` + `fsharp_functions`, `ct_toolchain([dotnet])`, `dotnet build` gate, `dotnet run --no-build -- <key>` → `bool_of_string`.
  - Note: do not pass `--nologo` on the `dotnet run` line — some SDKs forward it as argv[0]; use `DOTNET_NOLOGO=1` instead.
- **Docs:** fleet card landed + follow-ups; short measured-maturity note in `WAM_FSHARP_STATUS.md`.

### Measured maturity (honest readout)
| Program | `fsharp` (interpreter) | `fsharp_functions` |
|---|---|---|
| member, fib, ack | green | green |
| append, reverse | `ct_xfail` — FS-LIST-PARTIAL-TAIL | same |
| builtins | `ct_xfail` — FS-ARITH-INT-DIV (`evalArith` missing `//`) | `ct_skip` — FS-FUNCTIONS-BUILTINS-LOWER (codegen stalls on `cbi_eq`) |

### Verify
```bash
LANG=C.UTF-8 CONFORMANCE_TARGETS=fsharp,fsharp_functions \
  swipl -q -g run_tests -t halt tests/test_wam_cross_target_conformance.pl
```
Skips cleanly if `dotnet` is absent. Existing `tests/test_wam_fsharp_target.pl` stays green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

