### PR TITLE
WAM/LLVM plawk: do-while break/continue + nested loops (finishes loop control)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -38,7 +38,7 @@ only (runtime pending) · ❌ missing.
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` (rule-level stream break) | ✅ | non-standard awk extension; stops the record stream |
-| `break` / `continue` (loop-local) | ◐ | **`while` loops: landed** (`break` leaves the loop, `continue` re-tests — SSA merge phis at the loop exit/head). `do-while` break/continue and nested-loop break: not yet (`PLAWK_CONTROL_FLOW_PLAN.md` §3b) |
+| `break` / `continue` (loop-local) | ✅ | `while` **and** `do-while`: `break` leaves the loop, `continue` re-tests (SSA merge phis at the loop exit / head / body-done). Works nested (inner break targets the innermost loop) — `PLAWK_CONTROL_FLOW_PLAN.md` §3b |
 | `if` with a plain (non-accumulator) body | ✅ | `{ if (c) { print $1 } }` compiles and runs (fixed by the while-runtime body-print enablers); if/else with plain bodies too |
 | regex in `if` (`if ($0 ~ /re/)`) | ✅ | `if ($0 ~ /re/) { … }` and `!~` compile and run — guards a plain body |
 | brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |
@@ -98,7 +98,9 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    `VAR CMP (int | VAR)` combined with `&&` / `||`. **PR 3b (`while`
    break/continue) LANDED**: SSA merge phis at the loop exit (`break`) and head
    (`continue`); scalar `if` conditions and END scalar-`if` landed alongside.
-   Remaining: `do-while` break/continue, and nested / multi-pass loops (PR 4).
+   **do-while break/continue and nested loops also LANDED** (`while` inside
+   `while`/`do-while`, inner break targets the innermost loop). Remaining: loops
+   inside a multi-pass `pass { }` block (PR 4).
 2. **User-function call in text/print context — LANDED (auto-coerce).**
    `print f($1)` used to return `0`: a text field reached the synthesised
    `f(X,R) :- R is X*2` as an *atom*, failing `is`. Now the synthesised clause

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -117,12 +117,16 @@ while.after.N:
      the record stream" (`break_close_stream`) — non-standard awk. Inside a loop,
      the loop-context stack redirects `break` to the loop exit; outside a loop it
      still means stream-break. `next`-inside-loop stays "next record".
-   - **`do-while` / nested — the remaining work.** `do-while`'s condition sits in
-     the body-done block, so `continue` needs an extra merge phi there (and the
-     head-phi back edge must read it); guarded as not-yet for now. Nested-loop
-     support is a separate codegen item (§4) — the loop-context *stack* already
-     handles the break/continue redirection for nesting, but the underlying
-     nested-loop lowering isn't wired.
+   - **`do-while` / nested — LANDED.** `do-while`'s condition sits in the
+     body-done block, so `continue` targets it and a merge phi there
+     (`plawk_loop_after_ir` reused as the body-done phi) combines the normal body
+     output with each continue value; the condition, the head-phi back edge, and
+     the `after` block all read that merged value; `break` still targets `after`.
+     Nested loops also compile: the only fix needed was validation
+     (`plawk_scalar_rule_body_plain_action` now accepts a nested loop as a body
+     action) — the loop-context *stack* already routed break/continue to the
+     innermost loop, and the emitter's per-loop `Base` naming keeps nested
+     labels/phis distinct.
    - **Dependency — scalar `if` conditions — LANDED.** A *counter-based* break
      (`if (i > 2) break`) needs the `if` condition to accept a scalar variable.
      This shipped: `if (COND)` now parses a scalar comparison (`i > 2`,
@@ -133,8 +137,9 @@ while.after.N:
      `continue` *jump* itself remains to wire. (Scalar `if` in an `END` block --
      `END { if (COND) print … ; else print … }`, over final slot values -- also
      landed.)
-4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
-   nesting; the multi-pass driver's scalar handling.
+4. **Loop in a multi-pass `pass { }` block.** Single-pass nested loops LANDED
+   (per-loop `Base` naming keeps labels/phis distinct); the remaining item is
+   the multi-pass driver's scalar handling for loops inside a `pass { }`.
 
 ## 4. Related AWK gaps found while scoping (see the audit)
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -108,7 +108,6 @@ build(File, Out0, KeepLL) :-
     % removed; `GenFactClauses` are the synthesised facts.
     check_generator_blocks(File, Program2),
     check_materialized_views(File, Program2, Clauses),
-    check_loop_control(File, Program2),
     resolve_generator_blocks(Program2, Program, GenFactClauses),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
@@ -365,47 +364,6 @@ check_generator_blocks(File, Program) :-
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
-
-% `break` / `continue` for loop control (PLAWK_CONTROL_FLOW_PLAN.md §3b). Loop-
-% local break/continue is wired for `while` loops (SSA merge phis at the loop
-% exit / head). `do-while` break/continue is NOT wired yet (its condition sits
-% in the body-done block, so continue needs an extra merge phi there), so a
-% break/continue inside a `do-while` body is a clean not-yet error -- otherwise
-% break would silently lower to the rule-level stream-break. `break` OUTSIDE a
-% loop keeps its existing stream-break meaning.
-check_loop_control(File, Program) :-
-    plawk_dowhile_body_has_control(Program),
-    !,
-    format(user_error,
-        'plawk: ~w uses `break`/`continue` inside a `do-while` loop. `while` \c
-         loop break/continue is wired, but the do-while form is not yet; see \c
-         PLAWK_CONTROL_FLOW_PLAN.md section 3b.~n',
-        [File]),
-    halt(2).
-check_loop_control(_File, _Program).
-
-% True if some `do-while` body contains a `break` or `continue` anywhere in its
-% subtree.
-plawk_dowhile_body_has_control(Term) :-
-    plawk_ast_dowhile_body(Term, Body),
-    ( plawk_ast_contains(Body, break)
-    ; plawk_ast_contains(Body, continue)
-    ),
-    !.
-
-plawk_ast_dowhile_body(do_while_loop(Body, _Cond), Body).
-plawk_ast_dowhile_body(Term, Body) :-
-    compound(Term),
-    arg(_, Term, Arg),
-    plawk_ast_dowhile_body(Arg, Body).
-
-% Structural sub-term search (handles lists, since a body is an action list).
-plawk_ast_contains(Term, Term) :-
-    !.
-plawk_ast_contains(Term, Target) :-
-    compound(Term),
-    arg(_, Term, Arg),
-    plawk_ast_contains(Arg, Target).
 
 % `materialize NAME` (PLAWK_MULTIPASS_CACHE.md §3.9): mark a view / relation to
 % be materialised-and-cached (computed once, reused by every query pass that

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -10377,6 +10377,14 @@ plawk_scalar_rule_body_plain_action(writebin_arm_out(_Tag, ArmTypes, Fields)) :-
 % lowers nested ifs recursively, so validation recurses the same way.
 plawk_scalar_rule_body_plain_action(if(Pattern, ThenActions, ElseActions)) :-
     plawk_scalar_rule_body_action(if(Pattern, ThenActions, ElseActions)).
+% a loop may nest inside another loop body (`while (..) { while (..) { .. } }`);
+% the sequence walker lowers the inner loop recursively, so validation recurses.
+plawk_scalar_rule_body_plain_action(while_loop(Cond, Body)) :-
+    plawk_scalar_rule_body_action(while_loop(Cond, Body)).
+plawk_scalar_rule_body_plain_action(do_while_loop(Body, Cond)) :-
+    plawk_scalar_rule_body_action(do_while_loop(Body, Cond)).
+plawk_scalar_rule_body_plain_action(foreach_loop(Layout, Body)) :-
+    plawk_scalar_rule_body_action(foreach_loop(Layout, Body)).
 
 plawk_rule_body_print_action(print(Fields)) :-
     Fields = [_ | _],
@@ -11500,6 +11508,8 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
             format(atom(PhiValue), '%~w_slot_~w', [Base, SlotIndex])
           ),
           HeadValues),
+      % break -> after, continue -> body_done (which re-tests the condition)
+      plawk_loopctx_push(loop_ctx(AfterLabel, BodyDoneLabel)),
       phrase(plawk_scalar_action_sequence_pairs(Body, Slots, AssocPlan,
           FieldSeparator, OutputSeparator, Base, BodyLabel, RuleIndex, 0,
           HeadValues, BodyOutValues, _InnerOpIndex, InnerExitLabel,
@@ -11508,11 +11518,20 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
       atomic_list_concat(BodyGlobalParts, '\n', GlobalIR),
       atomic_list_concat(BodyLineParts, '\n', BodyIR),
       plawk_branch_to_done_ir(InnerExitLabel, BodyDoneLabel, BodyDoneBrIR),
-      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BodyOutValues,
+      plawk_loopctx_pop,
+      plawk_partition_loop_exits(InnerNextExits, Breaks, Continues, RestExits),
+      % body_done merges the normal body output (from the body's exit block) with
+      % each continue point, and the condition tests that merged value; the head
+      % phi's back edge and the `after` block read it too.
+      format(atom(BdBase), '~w_bd', [Base]),
+      plawk_loop_after_ir(Slots, BodyOutValues, InnerExitLabel, Continues,
+          BdBase, BdValues, BdPhiIR),
+      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BdValues,
           Base, EntryLabel, BodyDoneLabel, 0), HeadPhiLines),
       atomic_list_concat(HeadPhiLines, '\n', HeadPhiIR),
-      % the condition reads the body's output value of the condition variable
-      plawk_while_cond_ir(Cond, Slots, BodyOutValues, Base, CondVar, CondIR),
+      plawk_while_cond_ir(Cond, Slots, BdValues, Base, CondVar, CondIR),
+      plawk_loop_after_ir(Slots, BdValues, BodyDoneLabel, Breaks, Base,
+          AfterValues, AfterPhiIR),
       format(atom(IR),
 '  br label %~w
 
@@ -11526,9 +11545,11 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
 
 ~w:
 ~w
+~w
   br i1 ~w, label %~w, label %~w
 
-~w:',
+~w:
+~w',
           [EntryLabel,
            EntryLabel,
            BodyLabel,
@@ -11537,15 +11558,17 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
            BodyIR,
            BodyDoneBrIR,
            BodyDoneLabel,
+           BdPhiIR,
            CondIR,
            CondVar, BodyLabel, AfterLabel,
-           AfterLabel]),
+           AfterLabel,
+           AfterPhiIR]),
       NextOpIndex is OpIndex + 1
     },
     [GlobalIR-IR],
     plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
-        NextOpIndex, BodyOutValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
-    { append(InnerNextExits, RestNextExits, NextExits) }.
+        NextOpIndex, AfterValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
+    { append(RestExits, RestNextExits, NextExits) }.
 plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest],
         Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex, OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
     { format(atom(GlobalBase), '~w_if_~w', [Prefix, OpIndex]),

--- a/tests/test_plawk_loop_control.pl
+++ b/tests/test_plawk_loop_control.pl
@@ -85,18 +85,65 @@ test(rule_level_break_still_runs, [condition(clang_available)]) :-
     !.
 
 % `do-while` break/continue is a clean not-yet error (runtime pending).
-test(do_while_break_is_not_yet_error) :-
+% --- do-while break/continue ------------------------------------------------
+
+% `do-while` break leaves the loop (the after phi merges the post-condition exit
+% with each break value).
+test(do_while_break, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; do { print i; break } while (i < 5) }\n",
-    build_status(Dir, 'dwb', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; do { if (i > 2) break; print i; i++ } while (i < 10) }\n",
+    build_run(Dir, 'dwb', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
     !.
 
-test(do_while_continue_is_not_yet_error) :-
+% `do-while` continue re-tests the condition (an extra merge phi in the
+% body-done block feeds the condition and the back edge).
+test(do_while_continue, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; do { continue } while (i < 5) }\n",
-    build_status(Dir, 'dwc', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; do { i++; if (i > 3) continue; print i } while (i < 5) }\n",
+    build_run(Dir, 'dwc', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1\n2\n3\n"),
+    !.
+
+% The do-while break value flows past the loop into END.
+test(do_while_break_state_to_end, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; do { if (i > 2) break; i++ } while (i < 10) }\nEND { print i }\n",
+    build_run(Dir, 'dwbe', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
+    !.
+
+% --- nested loops -----------------------------------------------------------
+
+% A while inside a while; the inner loop prints per outer iteration.
+test(nested_while, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 2) { j = 0; while (j < 2) { print j; j++ } i++ } }\n",
+    build_run(Dir, 'nest', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n0\n1\n"),
+    !.
+
+% An inner break breaks only the INNER loop (the loop-context stack targets the
+% innermost loop).
+test(nested_inner_break, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 3) { j = 0; while (j < 5) { if (j > 1) break; print j; j++ } i++ } }\n",
+    build_run(Dir, 'nb', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n0\n1\n0\n1\n"),
+    !.
+
+% A while nested inside a do-while, inner break.
+test(while_in_do_while, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; do { j = 0; while (j < 4) { if (j > 1) break; print j; j++ } i++ } while (i < 2) }\n",
+    build_run(Dir, 'mix', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n0\n1\n"),
     !.
 
 % A plain loop with no break/continue is unaffected.


### PR DESCRIPTION
## Summary

Completes loop control. Two parts:

**do-while break/continue.** The do-while emitter now mirrors the while one but for the post-test shape. `break` targets `after`; `continue` targets `body_done` (where the condition lives), so a **merge phi there** (`plawk_loop_after_ir` reused as the body-done phi) combines the normal body output with each continue value — the condition, the head-phi back edge, and the `after` block all read that merged value. Verified: `do { if (i>2) break; print i; i++ } while (i<10)` → `0/1/2`; `do { i++; if (i>3) continue; print i } while (i<5)` → `1/2/3`; break value reaches END.

**Nested loops.** The only fix needed was **validation** — `plawk_scalar_rule_body_plain_action` now accepts a nested while/do-while/foreach loop as a body action (delegating to the full validator, like `if` does). The loop-context stack already routed a break/continue to the innermost loop, and the emitter's per-loop `Base` naming keeps nested labels/phis distinct. Verified: `while (i<3) { while (j<5) { if (j>1) break; print j; j++ } i++ }` (inner break breaks only the inner loop); a while nested in a do-while likewise.

Removed `check_loop_control` (the do-while not-yet guard) and its now-dead helpers.

## Tests

`tests/test_plawk_loop_control.pl` updated — do-while break/continue, do-while break-state-to-END, nested while, nested inner break, while-in-do-while (the not-yet tests became run tests) — 14 pass. Regression: while (15), if_bodies (13), scalar_if (8), concat (12), foreach_tuples (3), forin_rule_body (3), prefix_print (221) green.

## What's left in the loop arc

Single-pass loops are now complete (while + do-while, break/continue, nested). The one remaining item (PR 4) is loops inside a multi-pass `pass { }` block — the multi-pass driver's scalar handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_