### PR TITLE
WAM/LLVM plawk: exit [n] (early terminate + END + exit code)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -34,12 +34,15 @@ only (runtime pending) · ❌ missing.
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
-| `while (VAR CMP int)` | ⏳ | **surface parses; runtime pending** (this arc) |
+| `while (VAR CMP int)` | ⏳ | surface parses; runtime pending — `PLAWK_CONTROL_FLOW_PLAN.md` |
+| `do { } while (VAR CMP int)` | ⏳ | surface parses; shares the loop runtime |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` / `continue` | ◐ | present in some loop contexts |
+| `if` with a plain (non-accumulator) body | ❌ | `{ if (c) { print $1 } }` is exit 3 — the scalar `if` lowering assumes branch bodies update scalars; blocks regex-in-`if` too |
+| regex in `if` (`if ($0 ~ /re/)`) | ◐ | condition parses (`~` ok); blocked by the guarded-print body above, not the regex |
+| brace-less `if`/loop body | ❌ | `if (c) print` (no braces) doesn't parse |
 | field assignment (`$2 = expr`) | ❌ | rebuilding `$0` from mutated fields not wired |
 | C-style `for (;;)` | ❌ | |
-| `do { } while` | ❌ | |
 | `exit [n]` | ❌ | |
 | `delete arr[k]` | ❌ | |
 | `getline` | ❌ | the multi-pass / `over` readers cover much of its use |
@@ -85,12 +88,20 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
 
 ## Prioritised gaps (recommended order)
 
-1. **`while` loop runtime** — the surface just landed; wire the loop (mutable
-   scalar state to a fixed point). The most-requested basic control structure
-   still missing at runtime.
-2. **User-function call in text/print context** — `print f($1)` should coerce
-   the text field like the accumulator path already does; small, high-value fix
-   that makes the *existing* function feature usable in the obvious spot.
+1. **`while` / `do-while` loop runtime** — the surfaces just landed; wire the
+   loop (mutable scalar state to a fixed point). **Plan:**
+   `PLAWK_CONTROL_FLOW_PLAN.md` — bracket each loop with a memory slot (SSA →
+   mem → loop → SSA) so the existing forward-phi scalar machinery is untouched.
+   The most-requested basic control structure still missing at runtime.
+2. **User-function call in text/print context** — `print f($1)` returns `0`: a
+   text field is passed to the foreign call as an *atom*, so the synthesised
+   `f(X,R) :- R is X*2` fails `is`. Works in `BINFMT`/typed mode. A **type-model
+   decision** (auto-coerce a numerically-used field arg to i64, or an explicit
+   `num($1)` at the call site — `int(...)` is not accepted as a call arg today);
+   wants a small design call before coding. See `PLAWK_CONTROL_FLOW_PLAN.md` §4.
+2b. **`if` with a plain guarded body** — `{ if (c) { print $1 } }` doesn't
+   compile (the scalar `if` lowering assumes branch bodies update scalars); this
+   is what actually blocks regex-in-`if`. Fix the `if`-body lowering.
 3. **`printf` format coverage** — add `%f`/`%g` (f64 exists), `%c`, `%x`, and
    width/precision; the current subset is thin for real formatting.
 4. **`exit [n]`** — common and cheap; a flagged early-terminate of the record

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -44,7 +44,7 @@ only (runtime pending) · ❌ missing.
 | brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |
 | field assignment (`$2 = expr`) | ❌ | rebuilding `$0` from mutated fields not wired |
 | C-style `for (;;)` | ❌ | |
-| `exit [n]` | ❌ | |
+| `exit [n]` | ✅ | stops the record loop, runs END, returns N (default 0); `exit` in a rule body, an `if`/`else` branch, or a loop (propagates past the loop) — scalar state at the exit point flows into END |
 | `delete arr[k]` | ❌ | |
 | `getline` | ❌ | the multi-pass / `over` readers cover much of its use |
 
@@ -131,8 +131,18 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    control-flow body is a braced block *or* a single statement.
 3. **`printf` format coverage** — add `%f`/`%g` (f64 exists), `%c`, `%x`, and
    width/precision; the current subset is thin for real formatting.
-4. **`exit [n]`** — common and cheap; a flagged early-terminate of the record
-   loop + END.
+4. **`exit [n]` — LANDED.** A rule-level `exit` / `exit N` stops the record loop,
+   runs END, and returns N (default 0). It reuses the rule-level stream-break
+   path (`break_close_stream` → END → `ret`), adding an exit code stored in
+   `@plawk_exit_code` and read at the final `ret`. `exit` is modelled as a
+   terminal control (`terminal_exit`, like `terminal_break`) at rule-body top
+   level; inside an `if`/`else` branch or a loop it flows via the `branch_exit`
+   exit + `plawk_branch_to_done_ir` (branch to `break_close_stream`). Unlike
+   `break`, an `exit` inside a loop is NOT consumed by the loop — it always ends
+   the whole program (propagates past any enclosing loop). Scalar state at the
+   exit point merges into END through the break-close phi. Tests:
+   `tests/test_plawk_exit.pl`. *Still open (follow-on):* `exit` inside a `BEGIN`
+   or `END` block, and non-constant exit codes (`exit code_var`).
 5. **Ternary `?:`** (string concatenation in `print` context **landed** —
    `print $1 $2`, rule bodies + `END`; the remaining concat work is assignment
    into a string-valued scalar). Ternary is the next most-missed *expression*

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -104,13 +104,18 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    changing Prolog `is/2` for non-plawk callers), or coerce the field arg at the
    plawk call boundary when the callee uses it numerically (needs light body
    inference). No explicit `num($1)` is required of the user.
-   *Future direction (noted, no commitment):* **optional type annotations** on
-   function inputs (e.g. `function f(num x)` / a `:- ftype` directive). Because
-   plawk compiles to **typed WAM**, a declared arg type would both (a) skip the
-   runtime coercion — the value is already the right type — and (b) enable
-   compile-time type checking, where a mismatched call is an error. Gradual
-   typing over an auto-coercing default is a natural fit for plawk's
-   typed-under-dynamic architecture; whether to build it is open.
+   *Future direction — a **performance** lever, not just safety:* **optional
+   type annotations** on function inputs (e.g. `function f(num x)` / a `:- ftype`
+   directive). Because plawk compiles to **typed WAM**, a declared arg type would
+   (a) **skip the runtime coercion** — the value is already the right type, so
+   the hot path pays nothing (auto-coerce parses `atom → number` on every call),
+   and (b) enable **compile-time type checking** (a mismatched call is an error).
+   This is the same principle as explicit `emit` in generators
+   (`PLAWK_GENERATOR_BLOCKS.md` §2.1): **static type knowledge lets the compiler
+   elide coercion and serialisation.** Given the per-call coercion cost, this
+   ranks higher than a pure nice-to-have — it is the typed-fast path over the
+   dynamic-correct default. Layered *on* auto-coerce (which stays the annotation-
+   free default), not instead of it; whether/when to build it is open.
 2b. **`if` with a plain guarded body** — `{ if (c) { print $1 } }` doesn't
    compile (the scalar `if` lowering assumes branch bodies update scalars); this
    is what actually blocks regex-in-`if`. Fix the `if`-body lowering.

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -32,7 +32,7 @@ only (runtime pending) · ❌ missing.
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic) | ✅ | constant fields (`print 1`, `print "x"`) landed |
 | `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
-| `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies and loops — the loop-counter guard that unblocks counter-based control. (Scalar `if` in an `END` block is a follow-on: END uses a separate lowering.) |
+| `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`** (`END { if (n > 1) print … ; else print … }`, over final slot values) |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
 | `while (COND)` | ✅ | runtime landed (loop-header phis); condition is scalar comparisons (`VAR CMP int`/`VAR`) combined with `&&`/`||` — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2–3. `break`/`continue` deferred (PR 3b) |
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -51,7 +51,7 @@ only (runtime pending) · ❌ missing.
 
 | Feature | Status | Notes |
 |---|---|---|
-| user functions (`function f(a) { return … }`) | ✅ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts **and text mode** — `print f($1)` auto-coerces the field (awk semantics). |
+| user functions (`function f(a) { return … }`) | ✅ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts **and text mode** — `print f($1)` auto-coerces the field (awk semantics). Optional numeric arg typing (`function f(num x)`) skips the coercion (typed-fast path). |
 | string: `length` `substr` `index` `tolower` `toupper` | ✅ | native, allocation-free |
 | string: `split` `sub` `gsub` `match` `sprintf` | ❌ | |
 | numeric: `int` | ✅ | `sin`/`cos`/`sqrt`/`rand`/… ❌ (f64 machinery exists) |
@@ -95,29 +95,27 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    Enablers landed with it: **bare scalar-var print** (`print i`) and a
    **body-printing scalar chain with no `END`**. PRs 3–4 (general condition,
    `break`/`continue`, nested/multi-pass loops) remain.
-2. **User-function call in text/print context** — `print f($1)` returns `0`: a
-   text field is passed to the foreign call as an *atom*, so the synthesised
-   `f(X,R) :- R is X*2` fails `is`. Works in `BINFMT`/typed mode.
-   **Decision: auto-coerce (awk semantics).** A field (a string) used in a
-   numeric context coerces to a number, matching AWK. Implementation options
-   (a design call for the PR, not the surface): coerce in the WAM arithmetic
-   builtins (an atom operand of `is`/`>`/`*`/… parses to a number — most
-   awk-faithful, but the WAM engine is shared, so scope/gate it to avoid
-   changing Prolog `is/2` for non-plawk callers), or coerce the field arg at the
-   plawk call boundary when the callee uses it numerically (needs light body
-   inference). No explicit `num($1)` is required of the user.
-   *Future direction — a **performance** lever, not just safety:* **optional
-   type annotations** on function inputs (e.g. `function f(num x)` / a `:- ftype`
-   directive). Because plawk compiles to **typed WAM**, a declared arg type would
-   (a) **skip the runtime coercion** — the value is already the right type, so
-   the hot path pays nothing (auto-coerce parses `atom → number` on every call),
-   and (b) enable **compile-time type checking** (a mismatched call is an error).
-   This is the same principle as explicit `emit` in generators
-   (`PLAWK_GENERATOR_BLOCKS.md` §2.1): **static type knowledge lets the compiler
-   elide coercion and serialisation.** Given the per-call coercion cost, this
-   ranks higher than a pure nice-to-have — it is the typed-fast path over the
-   dynamic-correct default. Layered *on* auto-coerce (which stays the annotation-
-   free default), not instead of it; whether/when to build it is open.
+2. **User-function call in text/print context — LANDED (auto-coerce).**
+   `print f($1)` used to return `0`: a text field reached the synthesised
+   `f(X,R) :- R is X*2` as an *atom*, failing `is`. Now the synthesised clause
+   coerces each untyped param inline — `(number(H) -> V = H ; atom_number(H, V))`
+   — so a text field parses to a number (awk semantics) while a typed i64 arg
+   (`BINFMT`) passes straight through. No engine change, no `num($1)` required.
+   *Typed-fast path — LANDED (optional arg typing).* An optional numeric type
+   annotation, `function f(num x)` (also `int` / `float`), declares the param
+   already-numeric, so the synthesised clause **skips the coercion goal** — the
+   head var *is* the value var. Because plawk compiles to **typed WAM**, a
+   declared arg carries in its native representation and the hot path pays
+   nothing (auto-coerce otherwise runs `number/1` every call). This is the same
+   principle as explicit `emit` (`PLAWK_GENERATOR_BLOCKS.md` §2.1,
+   `UNIFYWEAVER_LANGUAGE_PRINCIPLES.md` Principle 2): **static type knowledge
+   elides coercion.** It is layered *on* auto-coerce (the annotation-free
+   default), not instead of it; an unannotated param still auto-coerces. In text
+   mode a typed param is a contract that the arg is numeric — a bare text field
+   passed to it is the caller's responsibility. *Still open (follow-on):*
+   compile-time **type checking** of call sites (a mismatched call → error) and
+   distinguishing `int` vs `float` for representation; all three keywords
+   currently mean "numeric, skip coercion".
 2b. **`if` with a plain guarded body** — `{ if (c) { print $1 } }` doesn't
    compile (the scalar `if` lowering assumes branch bodies update scalars); this
    is what actually blocks regex-in-`if`. Fix the `if`-body lowering.

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -95,10 +95,22 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    The most-requested basic control structure still missing at runtime.
 2. **User-function call in text/print context** — `print f($1)` returns `0`: a
    text field is passed to the foreign call as an *atom*, so the synthesised
-   `f(X,R) :- R is X*2` fails `is`. Works in `BINFMT`/typed mode. A **type-model
-   decision** (auto-coerce a numerically-used field arg to i64, or an explicit
-   `num($1)` at the call site — `int(...)` is not accepted as a call arg today);
-   wants a small design call before coding. See `PLAWK_CONTROL_FLOW_PLAN.md` §4.
+   `f(X,R) :- R is X*2` fails `is`. Works in `BINFMT`/typed mode.
+   **Decision: auto-coerce (awk semantics).** A field (a string) used in a
+   numeric context coerces to a number, matching AWK. Implementation options
+   (a design call for the PR, not the surface): coerce in the WAM arithmetic
+   builtins (an atom operand of `is`/`>`/`*`/… parses to a number — most
+   awk-faithful, but the WAM engine is shared, so scope/gate it to avoid
+   changing Prolog `is/2` for non-plawk callers), or coerce the field arg at the
+   plawk call boundary when the callee uses it numerically (needs light body
+   inference). No explicit `num($1)` is required of the user.
+   *Future direction (noted, no commitment):* **optional type annotations** on
+   function inputs (e.g. `function f(num x)` / a `:- ftype` directive). Because
+   plawk compiles to **typed WAM**, a declared arg type would both (a) skip the
+   runtime coercion — the value is already the right type — and (b) enable
+   compile-time type checking, where a mismatched call is an error. Gradual
+   typing over an auto-coercing default is a natural fit for plawk's
+   typed-under-dynamic architecture; whether to build it is open.
 2b. **`if` with a plain guarded body** — `{ if (c) { print $1 } }` doesn't
    compile (the scalar `if` lowering assumes branch bodies update scalars); this
    is what actually blocks regex-in-`if`. Fix the `if`-body lowering.

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -34,8 +34,8 @@ only (runtime pending) · ❌ missing.
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
-| `while (VAR CMP int)` | ⏳ | surface parses; runtime pending — `PLAWK_CONTROL_FLOW_PLAN.md` |
-| `do { } while (VAR CMP int)` | ⏳ | surface parses; shares the loop runtime |
+| `while (VAR CMP int)` | ✅ | runtime landed (loop-header phis) — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2 |
+| `do { } while (VAR CMP int)` | ✅ | runtime landed; body runs at least once |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` / `continue` | ◐ | present in some loop contexts |
 | `if` with a plain (non-accumulator) body | ❌ | `{ if (c) { print $1 } }` is exit 3 — the scalar `if` lowering assumes branch bodies update scalars; blocks regex-in-`if` too |
@@ -88,11 +88,13 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
 
 ## Prioritised gaps (recommended order)
 
-1. **`while` / `do-while` loop runtime** — the surfaces just landed; wire the
-   loop (mutable scalar state to a fixed point). **Plan:**
-   `PLAWK_CONTROL_FLOW_PLAN.md` — bracket each loop with a memory slot (SSA →
-   mem → loop → SSA) so the existing forward-phi scalar machinery is untouched.
-   The most-requested basic control structure still missing at runtime.
+1. **`while` / `do-while` loop runtime — LANDED (PR 2).** The loop iterates its
+   mutable scalar state via **loop-header phis** (reusing `foreach_loop`'s head
+   phis — no memory slots needed after all; see `PLAWK_CONTROL_FLOW_PLAN.md`).
+   Body: `set` / `inc` / `+=` over i64 + `print`; condition `VAR CMP int`.
+   Enablers landed with it: **bare scalar-var print** (`print i`) and a
+   **body-printing scalar chain with no `END`**. PRs 3–4 (general condition,
+   `break`/`continue`, nested/multi-pass loops) remain.
 2. **User-function call in text/print context** — `print f($1)` returns `0`: a
    text field is passed to the foreign call as an *atom*, so the synthesised
    `f(X,R) :- R is X*2` fails `is`. Works in `BINFMT`/typed mode.

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -38,9 +38,9 @@ only (runtime pending) · ❌ missing.
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` / `continue` | ◐ | present in some loop contexts |
-| `if` with a plain (non-accumulator) body | ❌ | `{ if (c) { print $1 } }` is exit 3 — the scalar `if` lowering assumes branch bodies update scalars; blocks regex-in-`if` too |
-| regex in `if` (`if ($0 ~ /re/)`) | ◐ | condition parses (`~` ok); blocked by the guarded-print body above, not the regex |
-| brace-less `if`/loop body | ❌ | `if (c) print` (no braces) doesn't parse |
+| `if` with a plain (non-accumulator) body | ✅ | `{ if (c) { print $1 } }` compiles and runs (fixed by the while-runtime body-print enablers); if/else with plain bodies too |
+| regex in `if` (`if ($0 ~ /re/)`) | ✅ | `if ($0 ~ /re/) { … }` and `!~` compile and run — guards a plain body |
+| brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |
 | field assignment (`$2 = expr`) | ❌ | rebuilding `$0` from mutated fields not wired |
 | C-style `for (;;)` | ❌ | |
 | `exit [n]` | ❌ | |
@@ -118,9 +118,13 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    compile-time **type checking** of call sites (a mismatched call → error) and
    distinguishing `int` vs `float` for representation; all three keywords
    currently mean "numeric, skip coercion".
-2b. **`if` with a plain guarded body** — `{ if (c) { print $1 } }` doesn't
-   compile (the scalar `if` lowering assumes branch bodies update scalars); this
-   is what actually blocks regex-in-`if`. Fix the `if`-body lowering.
+2b. **`if` with a plain guarded body + regex-in-`if` + braceless bodies —
+   LANDED.** `{ if (c) { print $1 } }`, `if ($0 ~ /re/) { … }` / `!~`, and
+   if/else with plain bodies all compile and run (the guarded-print gap was
+   fixed by the while-runtime body-print enablers — a plain body no longer has
+   to update a scalar). Braceless bodies also landed: `if (c) print`,
+   `while (c) x++`, `do stmt while (c)`, and braceless else-if chains — a
+   control-flow body is a braced block *or* a single statement.
 3. **`printf` format coverage** — add `%f`/`%g` (f64 exists), `%c`, `%x`, and
    width/precision; the current subset is thin for real formatting.
 4. **`exit [n]`** — common and cheap; a flagged early-terminate of the record

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -32,12 +32,13 @@ only (runtime pending) · ❌ missing.
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic) | ✅ | constant fields (`print 1`, `print "x"`) landed |
 | `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
-| `if` / `else` (chains) | ✅ | |
+| `if` / `else` (chains) | ◐ | condition is a field/pattern guard (`$1 > 2`, `$0 ~ /re/`); a **scalar-variable** condition (`if (i > 2)`) does not parse yet — needed for counter-based loop `break` (`PLAWK_CONTROL_FLOW_PLAN.md` §3b) |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
 | `while (COND)` | ✅ | runtime landed (loop-header phis); condition is scalar comparisons (`VAR CMP int`/`VAR`) combined with `&&`/`||` — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2–3. `break`/`continue` deferred (PR 3b) |
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |
 | `next` | ✅ | structural (guarded clause per rule) |
-| `break` / `continue` | ◐ | present in some loop contexts |
+| `break` (rule-level stream break) | ✅ | non-standard awk extension; stops the record stream |
+| `break` / `continue` (loop-local) | ⏳ | `continue` parses; loop-local break/continue is a clean not-yet error (guards a silent stream-break mis-compile) — runtime pending, `PLAWK_CONTROL_FLOW_PLAN.md` §3b |
 | `if` with a plain (non-accumulator) body | ✅ | `{ if (c) { print $1 } }` compiles and runs (fixed by the while-runtime body-print enablers); if/else with plain bodies too |
 | regex in `if` (`if ($0 ~ /re/)`) | ✅ | `if ($0 ~ /re/) { … }` and `!~` compile and run — guards a plain body |
 | brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -38,7 +38,7 @@ only (runtime pending) · ❌ missing.
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` (rule-level stream break) | ✅ | non-standard awk extension; stops the record stream |
-| `break` / `continue` (loop-local) | ◐ | **`while` loops: landed** (`break` leaves the loop, `continue` re-tests — SSA merge phis at the loop exit/head). `do-while` break/continue and nested-loop break: not yet (`PLAWK_CONTROL_FLOW_PLAN.md` §3b) |
+| `break` / `continue` (loop-local) | ✅ | `while` **and** `do-while`: `break` leaves the loop, `continue` re-tests (SSA merge phis at the loop exit / head / body-done). Works nested (inner break targets the innermost loop) — `PLAWK_CONTROL_FLOW_PLAN.md` §3b |
 | `if` with a plain (non-accumulator) body | ✅ | `{ if (c) { print $1 } }` compiles and runs (fixed by the while-runtime body-print enablers); if/else with plain bodies too |
 | regex in `if` (`if ($0 ~ /re/)`) | ✅ | `if ($0 ~ /re/) { … }` and `!~` compile and run — guards a plain body |
 | brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |
@@ -98,7 +98,9 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    `VAR CMP (int | VAR)` combined with `&&` / `||`. **PR 3b (`while`
    break/continue) LANDED**: SSA merge phis at the loop exit (`break`) and head
    (`continue`); scalar `if` conditions and END scalar-`if` landed alongside.
-   Remaining: `do-while` break/continue, and nested / multi-pass loops (PR 4).
+   **do-while break/continue and nested loops also LANDED** (`while` inside
+   `while`/`do-while`, inner break targets the innermost loop). Remaining: loops
+   inside a multi-pass `pass { }` block (PR 4).
 2. **User-function call in text/print context — LANDED (auto-coerce).**
    `print f($1)` used to return `0`: a text field reached the synthesised
    `f(X,R) :- R is X*2` as an *atom*, failing `is`. Now the synthesised clause

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -32,7 +32,7 @@ only (runtime pending) · ❌ missing.
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic) | ✅ | constant fields (`print 1`, `print "x"`) landed |
 | `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
-| `if` / `else` (chains) | ◐ | condition is a field/pattern guard (`$1 > 2`, `$0 ~ /re/`); a **scalar-variable** condition (`if (i > 2)`) does not parse yet — needed for counter-based loop `break` (`PLAWK_CONTROL_FLOW_PLAN.md` §3b) |
+| `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies and loops — the loop-counter guard that unblocks counter-based control. (Scalar `if` in an `END` block is a follow-on: END uses a separate lowering.) |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
 | `while (COND)` | ✅ | runtime landed (loop-header phis); condition is scalar comparisons (`VAR CMP int`/`VAR`) combined with `&&`/`||` — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2–3. `break`/`continue` deferred (PR 3b) |
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -38,7 +38,7 @@ only (runtime pending) · ❌ missing.
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` (rule-level stream break) | ✅ | non-standard awk extension; stops the record stream |
-| `break` / `continue` (loop-local) | ⏳ | `continue` parses; loop-local break/continue is a clean not-yet error (guards a silent stream-break mis-compile) — runtime pending, `PLAWK_CONTROL_FLOW_PLAN.md` §3b |
+| `break` / `continue` (loop-local) | ◐ | **`while` loops: landed** (`break` leaves the loop, `continue` re-tests — SSA merge phis at the loop exit/head). `do-while` break/continue and nested-loop break: not yet (`PLAWK_CONTROL_FLOW_PLAN.md` §3b) |
 | `if` with a plain (non-accumulator) body | ✅ | `{ if (c) { print $1 } }` compiles and runs (fixed by the while-runtime body-print enablers); if/else with plain bodies too |
 | regex in `if` (`if ($0 ~ /re/)`) | ✅ | `if ($0 ~ /re/) { … }` and `!~` compile and run — guards a plain body |
 | brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |
@@ -94,10 +94,11 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    phis — no memory slots needed after all; see `PLAWK_CONTROL_FLOW_PLAN.md`).
    Body: `set` / `inc` / `+=` over i64 + `print`. Enablers landed with it:
    **bare scalar-var print** (`print i`) and a **body-printing scalar chain with
-   no `END`**. **PR 3 (general condition) also LANDED**: the condition is now
-   scalar comparisons `VAR CMP (int | VAR)` combined with `&&` / `||`. Remaining:
-   `break` / `continue` (PR 3b — SSA phi-merge + break's rule-vs-loop semantics)
-   and nested / multi-pass loops (PR 4).
+   no `END`**. **PR 3 (general condition) LANDED**: scalar comparisons
+   `VAR CMP (int | VAR)` combined with `&&` / `||`. **PR 3b (`while`
+   break/continue) LANDED**: SSA merge phis at the loop exit (`break`) and head
+   (`continue`); scalar `if` conditions and END scalar-`if` landed alongside.
+   Remaining: `do-while` break/continue, and nested / multi-pass loops (PR 4).
 2. **User-function call in text/print context — LANDED (auto-coerce).**
    `print f($1)` used to return `0`: a text field reached the synthesised
    `f(X,R) :- R is X*2` as an *atom*, failing `is`. Now the synthesised clause

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -34,8 +34,8 @@ only (runtime pending) · ❌ missing.
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
-| `while (VAR CMP int)` | ✅ | runtime landed (loop-header phis) — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2 |
-| `do { } while (VAR CMP int)` | ✅ | runtime landed; body runs at least once |
+| `while (COND)` | ✅ | runtime landed (loop-header phis); condition is scalar comparisons (`VAR CMP int`/`VAR`) combined with `&&`/`||` — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2–3. `break`/`continue` deferred (PR 3b) |
+| `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |
 | `next` | ✅ | structural (guarded clause per rule) |
 | `break` / `continue` | ◐ | present in some loop contexts |
 | `if` with a plain (non-accumulator) body | ❌ | `{ if (c) { print $1 } }` is exit 3 — the scalar `if` lowering assumes branch bodies update scalars; blocks regex-in-`if` too |
@@ -91,10 +91,12 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
 1. **`while` / `do-while` loop runtime — LANDED (PR 2).** The loop iterates its
    mutable scalar state via **loop-header phis** (reusing `foreach_loop`'s head
    phis — no memory slots needed after all; see `PLAWK_CONTROL_FLOW_PLAN.md`).
-   Body: `set` / `inc` / `+=` over i64 + `print`; condition `VAR CMP int`.
-   Enablers landed with it: **bare scalar-var print** (`print i`) and a
-   **body-printing scalar chain with no `END`**. PRs 3–4 (general condition,
-   `break`/`continue`, nested/multi-pass loops) remain.
+   Body: `set` / `inc` / `+=` over i64 + `print`. Enablers landed with it:
+   **bare scalar-var print** (`print i`) and a **body-printing scalar chain with
+   no `END`**. **PR 3 (general condition) also LANDED**: the condition is now
+   scalar comparisons `VAR CMP (int | VAR)` combined with `&&` / `||`. Remaining:
+   `break` / `continue` (PR 3b — SSA phi-merge + break's rule-vs-loop semantics)
+   and nested / multi-pass loops (PR 4).
 2. **User-function call in text/print context — LANDED (auto-coerce).**
    `print f($1)` used to return `0`: a text field reached the synthesised
    `f(X,R) :- R is X*2` as an *atom*, failing `is`. Now the synthesised clause

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -29,7 +29,7 @@ only (runtime pending) · ❌ missing.
 
 | Feature | Status | Notes |
 |---|---|---|
-| `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic) | ✅ | constant fields (`print 1`, `print "x"`) landed |
+| `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic, **concatenation**) | ✅ | constant fields (`print 1`, `print "x"`) + juxtaposition concat (`print $1 $2`) landed |
 | `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`** (`END { if (n > 1) print … ; else print … }`, over final slot values) |
@@ -67,7 +67,7 @@ only (runtime pending) · ❌ missing.
 | arithmetic `+ - * / % //` | ✅ | i64, awk precedence, safe div/mod |
 | comparison, `~`/`!~` | ✅ | |
 | ternary `?:` | ❌ | does not parse |
-| string concatenation (juxtaposition `$1 $2`) | ❌ | does not parse |
+| string concatenation (juxtaposition `$1 $2`) | ◐ | **`print` context landed** — `print $1 $2`, `print "x" $1 "-" $2`, in rule bodies and `END`; arithmetic binds tighter, comma still splits. Assignment concat (`x = $1 $2`) needs string-valued scalars — separate |
 | exponentiation `^` / `**` | ❌ | |
 
 ## Arrays
@@ -131,8 +131,10 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    width/precision; the current subset is thin for real formatting.
 4. **`exit [n]`** — common and cheap; a flagged early-terminate of the record
    loop + END.
-5. **String concatenation & ternary `?:`** — the two most-missed *expression*
-   forms; both are parser + expression-lowering work.
+5. **Ternary `?:`** (string concatenation in `print` context **landed** —
+   `print $1 $2`, rule bodies + `END`; the remaining concat work is assignment
+   into a string-valued scalar). Ternary is the next most-missed *expression*
+   form; parser + expression-lowering work.
 6. **`delete arr[k]`** — rounds out the assoc-array story (paired with the
    existing for-in / `in`).
 7. **`split` / `sub` / `gsub` / `match` / `sprintf`** — the string-builtin

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -51,7 +51,7 @@ only (runtime pending) · ❌ missing.
 
 | Feature | Status | Notes |
 |---|---|---|
-| user functions (`function f(a) { return … }`) | ◐ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts. **Gap: `print f($1)` in text mode returns 0** — the text field isn't coerced into the call. Prioritised below. |
+| user functions (`function f(a) { return … }`) | ✅ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts **and text mode** — `print f($1)` auto-coerces the field (awk semantics). |
 | string: `length` `substr` `index` `tolower` `toupper` | ✅ | native, allocation-free |
 | string: `split` `sub` `gsub` `match` `sprintf` | ❌ | |
 | numeric: `int` | ✅ | `sin`/`cos`/`sqrt`/`rand`/… ❌ (f64 machinery exists) |

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -1,0 +1,108 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2026 John William Creighton (@s243a)
+-->
+
+# plawk — AWK feature audit & roadmap
+
+**Status**: living checklist (audited 2026-07). plawk is a *specialised* awk-like
+front-end for the hybrid WAM/LLVM target, not a full AWK clone — it adds things
+POSIX AWK has no notion of (multi-pass caches, `over query(Goal)` readers,
+generator blocks, durable LMDB stores, a Prolog foreign-call surface). This doc
+tracks how much of the *basic* AWK surface exists, so the DSL stays familiar to
+AWK users, and prioritises the gaps. Legend: ✅ done · ◐ partial · ⏳ surface
+only (runtime pending) · ❌ missing.
+
+## Patterns
+
+| Feature | Status | Notes |
+|---|---|---|
+| `BEGIN` / `END` | ✅ | incl. constant `print` (BEGIN/END literal print) |
+| `/regex/` | ◐ | leading `^` prefix + literal-contains; general ERE metachars limited |
+| `$N == "v"`, `$3 > 100` | ✅ | field-equality + numeric field guards |
+| `&& \|\| !` combinators | ✅ | awk precedence, parens, single-block lowering |
+| `~` / `!~` match | ✅ | POSIX ERE |
+| expression pattern (bare `NR==1`) | ◐ | comparison guards yes; arbitrary expr no |
+| range pattern (`/a/,/b/`) | ❌ | |
+
+## Actions & control flow
+
+| Feature | Status | Notes |
+|---|---|---|
+| `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic) | ✅ | constant fields (`print 1`, `print "x"`) landed |
+| `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
+| var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
+| `if` / `else` (chains) | ✅ | |
+| `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
+| `while (VAR CMP int)` | ⏳ | **surface parses; runtime pending** (this arc) |
+| `next` | ✅ | structural (guarded clause per rule) |
+| `break` / `continue` | ◐ | present in some loop contexts |
+| field assignment (`$2 = expr`) | ❌ | rebuilding `$0` from mutated fields not wired |
+| C-style `for (;;)` | ❌ | |
+| `do { } while` | ❌ | |
+| `exit [n]` | ❌ | |
+| `delete arr[k]` | ❌ | |
+| `getline` | ❌ | the multi-pass / `over` readers cover much of its use |
+
+## Functions
+
+| Feature | Status | Notes |
+|---|---|---|
+| user functions (`function f(a) { return … }`) | ◐ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts. **Gap: `print f($1)` in text mode returns 0** — the text field isn't coerced into the call. Prioritised below. |
+| string: `length` `substr` `index` `tolower` `toupper` | ✅ | native, allocation-free |
+| string: `split` `sub` `gsub` `match` `sprintf` | ❌ | |
+| numeric: `int` | ✅ | `sin`/`cos`/`sqrt`/`rand`/… ❌ (f64 machinery exists) |
+| Prolog foreign calls (`pred($1)`, `float(pred(…))`) | ✅ | plawk-specific, beyond AWK |
+
+## Variables & operators
+
+| Feature | Status | Notes |
+|---|---|---|
+| `$0` `$N` `NR` `NF` `FS` `OFS` | ✅ | |
+| `FNR` `FILENAME` `ARGV` `ARGC` `RS` `ORS` `SUBSEP` `RSTART` `RLENGTH` | ❌ | single newline-delimited record model |
+| arithmetic `+ - * / % //` | ✅ | i64, awk precedence, safe div/mod |
+| comparison, `~`/`!~` | ✅ | |
+| ternary `?:` | ❌ | does not parse |
+| string concatenation (juxtaposition `$1 $2`) | ❌ | does not parse |
+| exponentiation `^` / `**` | ❌ | |
+
+## Arrays
+
+| Feature | Status | Notes |
+|---|---|---|
+| assoc arrays `arr[k]` | ✅ | native assoc tables |
+| `k in arr` (membership / for-in) | ✅ | |
+| multi-dim `arr[i,j]` (SUBSEP) | ❌ | |
+| `delete` | ❌ | |
+
+## plawk-specific surface (beyond AWK)
+
+Multi-pass `pass { }` blocks · `cache(...)` (file / LMDB, namespaces, multi-table)
+· `over TABLE` / `records of` / `rows of` / `over query(Goal)` readers · reader
+guards · generator blocks (`gen { emit … } as name`, input iterators) ·
+`@prolog` blocks · `compile(...)` / `dyncall` eval surface · binary records
+(`BINFMT`) / DCG readers.
+
+## Prioritised gaps (recommended order)
+
+1. **`while` loop runtime** — the surface just landed; wire the loop (mutable
+   scalar state to a fixed point). The most-requested basic control structure
+   still missing at runtime.
+2. **User-function call in text/print context** — `print f($1)` should coerce
+   the text field like the accumulator path already does; small, high-value fix
+   that makes the *existing* function feature usable in the obvious spot.
+3. **`printf` format coverage** — add `%f`/`%g` (f64 exists), `%c`, `%x`, and
+   width/precision; the current subset is thin for real formatting.
+4. **`exit [n]`** — common and cheap; a flagged early-terminate of the record
+   loop + END.
+5. **String concatenation & ternary `?:`** — the two most-missed *expression*
+   forms; both are parser + expression-lowering work.
+6. **`delete arr[k]`** — rounds out the assoc-array story (paired with the
+   existing for-in / `in`).
+7. **`split` / `sub` / `gsub` / `match` / `sprintf`** — the string-builtin
+   family; larger, lower priority for the DSL's data-pipeline focus.
+
+Deferred by design (the DSL's model diverges here): `RS`/multi-char record
+separators, `getline` (the `over`/multi-pass readers subsume most uses),
+multi-file `ARGV`/`FILENAME`/`FNR`, C-style `for(;;)` / `do-while` (the `while`
+runtime + for-in cover the loop needs).

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -5,11 +5,20 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk control-flow runtime — implementation plan
 
-**Status**: plan. The `while` and `do-while` **surfaces** parse (they lower to
-`while_loop(Cond, Body)` / `do_while_loop(Body, Cond)` and today emit a clean
-not-yet error); this doc scopes the **runtime**, grounded in how the single-pass
-driver actually lowers scalar state. Prioritised #1 in
-`PLAWK_AWK_FEATURE_AUDIT.md`.
+**Status**: PR 2 **LANDED**. The `while` and `do-while` **surfaces** parse (they
+lower to `while_loop(Cond, Body)` / `do_while_loop(Body, Cond)`) and their
+**runtime** now compiles: an arithmetic/`print` body over an i64 counter,
+condition `VAR CMP int`. PRs 3–4 (general condition, `break`/`continue`, nested
+loops in multi-pass) remain. This doc scopes the runtime, grounded in how the
+single-pass driver lowers scalar state.
+
+> **Implementation note (what actually shipped).** The §2 "bracket with memory"
+> sketch (alloca/load/store) turned out to be unnecessary: the emitter already
+> has a working **loop-header phi** for exactly this shape — `foreach_loop`'s
+> head phis (`plawk_foreach_head_phi_lines`). The while/do-while lowering reuses
+> that machinery directly (SSA back-edge phis, no memory slots), which is
+> simpler and matches the existing style. §2 is kept below as the original
+> reasoning; the head-phi route is what landed.
 
 ## 1. The blocking fact: scalar state is SSA/phi, not memory
 
@@ -64,10 +73,17 @@ while.after.N:
 
 1. **Surface — LANDED.** `while (VAR CMP int) { BODY }` and
    `do { BODY } while (VAR CMP int)` parse; not-yet compile error.
-2. **Runtime, arithmetic body.** Bracket-with-memory lowering for a body of
-   `set` / `inc` / `+=` over i64 scalars + `print`, condition `VAR CMP int`.
-   Deliverable: `{ i = 0; while (i < 3) { print i; i++ } }` prints `0/1/2`, and
-   the `do-while` mirror runs the body once even when the condition starts false.
+2. **Runtime, arithmetic body — LANDED.** Loop-header-phi lowering (reusing
+   `foreach_loop`'s head phis, **not** memory slots) for a body of `set` /
+   `inc` / `+=` over i64 scalars + `print`, condition `VAR CMP int`. `while`
+   tests before the body (exit values are the head phis, so zero iterations is
+   fine); `do-while` tests after (exit values are the body outputs, so the body
+   always runs once). Deliverable met: `{ i = 0; while (i < 3) { print i; i++ }
+   }` prints `0/1/2`; the `do-while` mirror runs the body once even when the
+   condition starts false. Two enablers landed alongside: **printing a bare
+   scalar var** (`print i` — substituted to the slot's SSA value) and a
+   **body-printing scalar chain with no `END`** driver clause (all output from
+   the per-record body). Tests: `tests/test_plawk_while.pl`.
 3. **General condition + `break`/`continue`.** A boolean/expression condition
    (reuse the guard grammar) and loop-control statements.
 4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -93,21 +93,36 @@ while.after.N:
    (`plawk_while_cond_vars` registers them). A single `VAR CMP int` still parses
    to a bare `cmp(...)`, so PR 2 is a strict subset. Tests:
    `tests/test_plawk_while.pl` (var-bound, `&&`, `||`, do-while var-bound).
-3b. **`break` / `continue` — DEFERRED (own PR).** Loop-control statements are a
-   separate, design-sensitive change and were intentionally split out:
+3b. **`break` / `continue` — SURFACE + GUARD LANDED; runtime is the follow-on.**
+   The `continue` keyword parses (to a `continue` action); `break` already did.
+   A `break` inside a loop body, or any `continue`, is now a **clean not-yet
+   error** (`check_loop_control`) — this **guards a silent mis-compile**: inside
+   a loop `break` used to lower to the rule-level stream-break, stopping the
+   record stream entirely instead of leaving the loop. `break` *outside* a loop
+   keeps its existing stream-break meaning. The runtime still to wire:
    - **SSA phi merge.** A `break` jumps to the loop's `after`; that block then
      needs a phi merging the normal exit (head-phi values, condition false) with
      the value set at *each* break point. A `continue` adds a back-edge into the
      head phi (`while`) / body-condition (`do-while`) from each continue point.
-     The loop emitter would collect the body's `branch_break` / `branch_next`
-     exits (it already receives them as `InnerNextExits`) and build these merge
-     phis, rather than letting them propagate to the record loop.
-   - **`break` semantics.** plawk currently uses `break` at *rule-body* level to
-     mean "stop the record stream" (`break_close_stream`) — non-standard awk. In
-     a loop, `break` must mean *loop* break instead, so the loop has to intercept
-     its own body's break exits. That contextual re-meaning (plus adding a
-     `continue` keyword, and defining `next`-inside-loop = next record) is the
-     design call this PR defers.
+     The loop emitter collects the body's `branch_break` / `branch_continue`
+     exits (delivered via `InnerNextExits`) and builds these merge phis instead
+     of letting them propagate to the record loop. A **loop-context stack in a
+     global** (pushed/popped around each loop body, read by `break`/`continue`
+     and by `plawk_branch_to_done_ir`) redirects the branches to the enclosing
+     loop's labels without threading a new argument through the ~14-clause
+     sequence walker; nested loops fall out because each loop consumes only the
+     exits generated while it was innermost.
+   - **`break` semantics.** plawk uses `break` at *rule-body* level to mean "stop
+     the record stream" (`break_close_stream`) — non-standard awk. In a loop,
+     `break` must mean *loop* break; the loop intercepts its own body's break
+     exits (the guard above makes this a hard boundary today). `next`-inside-loop
+     stays "next record" (propagates past the loop).
+   - **Dependency — scalar `if` conditions.** For a *counter-based* break
+     (`if (i > 2) break`) to be useful the `if` condition must accept a scalar
+     variable; today `if (COND)` only takes field/pattern conditions (`$1 > 2`),
+     not `i > 2` (parse error). So this PR also needs the `if` condition grammar
+     extended to scalar comparisons (the same `VAR CMP int/VAR` shape the loop
+     condition already uses). Do it alongside, or first.
 4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
    nesting; the multi-pass driver's scalar handling.
 

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -124,8 +124,9 @@ while.after.N:
      loop-condition emitter (reads slot values), alongside the existing
      field/pattern guards. So a scalar `if` already works inside a loop body
      (e.g. `while (i < 5) { if (i > 2) print i; i++ }`); only the `break`/
-     `continue` *jump* itself remains to wire. (Scalar `if` in an `END` block is
-     a separate follow-on — END uses its own lowering.)
+     `continue` *jump* itself remains to wire. (Scalar `if` in an `END` block --
+     `END { if (COND) print … ; else print … }`, over final slot values -- also
+     landed.)
 4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
    nesting; the multi-pass driver's scalar handling.
 

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -84,8 +84,30 @@ while.after.N:
    scalar var** (`print i` — substituted to the slot's SSA value) and a
    **body-printing scalar chain with no `END`** driver clause (all output from
    the per-record body). Tests: `tests/test_plawk_while.pl`.
-3. **General condition + `break`/`continue`.** A boolean/expression condition
-   (reuse the guard grammar) and loop-control statements.
+3. **General condition — LANDED.** The loop condition is now a boolean
+   combination of scalar comparisons: each comparison is `VAR CMP (int | VAR)`
+   (the right side may be another loop variable, not just a literal), combined
+   with `&&` / `||` (`&&` binds tighter). Lowered as a block of i64 `icmp`s
+   folded by `and`/`or i1` at the loop's condition point (`plawk_while_cond_ir`
+   / `plawk_while_cond_build`); every named variable must be an i64 slot
+   (`plawk_while_cond_vars` registers them). A single `VAR CMP int` still parses
+   to a bare `cmp(...)`, so PR 2 is a strict subset. Tests:
+   `tests/test_plawk_while.pl` (var-bound, `&&`, `||`, do-while var-bound).
+3b. **`break` / `continue` — DEFERRED (own PR).** Loop-control statements are a
+   separate, design-sensitive change and were intentionally split out:
+   - **SSA phi merge.** A `break` jumps to the loop's `after`; that block then
+     needs a phi merging the normal exit (head-phi values, condition false) with
+     the value set at *each* break point. A `continue` adds a back-edge into the
+     head phi (`while`) / body-condition (`do-while`) from each continue point.
+     The loop emitter would collect the body's `branch_break` / `branch_next`
+     exits (it already receives them as `InnerNextExits`) and build these merge
+     phis, rather than letting them propagate to the record loop.
+   - **`break` semantics.** plawk currently uses `break` at *rule-body* level to
+     mean "stop the record stream" (`break_close_stream`) — non-standard awk. In
+     a loop, `break` must mean *loop* break instead, so the loop has to intercept
+     its own body's break exits. That contextual re-meaning (plus adding a
+     `continue` keyword, and defining `next`-inside-loop = next record) is the
+     design call this PR defers.
 4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
    nesting; the multi-pass driver's scalar handling.
 

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -93,30 +93,36 @@ while.after.N:
    (`plawk_while_cond_vars` registers them). A single `VAR CMP int` still parses
    to a bare `cmp(...)`, so PR 2 is a strict subset. Tests:
    `tests/test_plawk_while.pl` (var-bound, `&&`, `||`, do-while var-bound).
-3b. **`break` / `continue` — SURFACE + GUARD LANDED; runtime is the follow-on.**
-   The `continue` keyword parses (to a `continue` action); `break` already did.
-   A `break` inside a loop body, or any `continue`, is now a **clean not-yet
-   error** (`check_loop_control`) — this **guards a silent mis-compile**: inside
-   a loop `break` used to lower to the rule-level stream-break, stopping the
-   record stream entirely instead of leaving the loop. `break` *outside* a loop
-   keeps its existing stream-break meaning. The runtime still to wire:
-   - **SSA phi merge.** A `break` jumps to the loop's `after`; that block then
-     needs a phi merging the normal exit (head-phi values, condition false) with
-     the value set at *each* break point. A `continue` adds a back-edge into the
-     head phi (`while`) / body-condition (`do-while`) from each continue point.
-     The loop emitter collects the body's `branch_break` / `branch_continue`
-     exits (delivered via `InnerNextExits`) and builds these merge phis instead
-     of letting them propagate to the record loop. A **loop-context stack in a
-     global** (pushed/popped around each loop body, read by `break`/`continue`
-     and by `plawk_branch_to_done_ir`) redirects the branches to the enclosing
-     loop's labels without threading a new argument through the ~14-clause
-     sequence walker; nested loops fall out because each loop consumes only the
-     exits generated while it was innermost.
+3b. **`break` / `continue` — `while` LANDED; `do-while` / nested pending.**
+   Loop-local break/continue is wired for `while` loops. `break` leaves the loop;
+   `continue` re-tests the condition. `break` *outside* a loop keeps its
+   stream-break meaning; a break/continue inside a **`do-while`** is still a clean
+   not-yet error (`check_loop_control`), and **nested loops** are outside the
+   compilable surface (a separate gap). How it works:
+   - **SSA phi merge (landed).** A `break` jumps to the loop's `after`, whose phi
+     (`plawk_loop_after_ir`) merges the normal exit (head-phi values, condition
+     false) with the value at *each* break point — so a value set before the
+     break flows past the loop (verified: `while (…) { if (i>2) break; i++ }` then
+     `END { print i }` prints `3`). A `continue` adds an extra incoming to the
+     `while` head phi (`plawk_while_head_phi_ir`) from each continue point and
+     branches back to the head to re-test.
+   - **Loop-context stack (landed).** `plawk_loopctx_push/pop/current` hold
+     `loop_ctx(BreakLabel, ContinueLabel)` around each loop body; `break` /
+     `continue` and `plawk_branch_to_done_ir` read the top, so a break/continue
+     nested in an `if` branches to the enclosing loop's labels — **without**
+     threading a new argument through the ~14-clause sequence walker. The loop
+     partitions its body's exits (`plawk_partition_loop_exits`): `break` /
+     `continue` are consumed here; `next` propagates to the record loop.
    - **`break` semantics.** plawk uses `break` at *rule-body* level to mean "stop
-     the record stream" (`break_close_stream`) — non-standard awk. In a loop,
-     `break` must mean *loop* break; the loop intercepts its own body's break
-     exits (the guard above makes this a hard boundary today). `next`-inside-loop
-     stays "next record" (propagates past the loop).
+     the record stream" (`break_close_stream`) — non-standard awk. Inside a loop,
+     the loop-context stack redirects `break` to the loop exit; outside a loop it
+     still means stream-break. `next`-inside-loop stays "next record".
+   - **`do-while` / nested — the remaining work.** `do-while`'s condition sits in
+     the body-done block, so `continue` needs an extra merge phi there (and the
+     head-phi back edge must read it); guarded as not-yet for now. Nested-loop
+     support is a separate codegen item (§4) — the loop-context *stack* already
+     handles the break/continue redirection for nesting, but the underlying
+     nested-loop lowering isn't wired.
    - **Dependency — scalar `if` conditions — LANDED.** A *counter-based* break
      (`if (i > 2) break`) needs the `if` condition to accept a scalar variable.
      This shipped: `if (COND)` now parses a scalar comparison (`i > 2`,

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -1,0 +1,98 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2026 John William Creighton (@s243a)
+-->
+
+# plawk control-flow runtime — implementation plan
+
+**Status**: plan. The `while` and `do-while` **surfaces** parse (they lower to
+`while_loop(Cond, Body)` / `do_while_loop(Body, Cond)` and today emit a clean
+not-yet error); this doc scopes the **runtime**, grounded in how the single-pass
+driver actually lowers scalar state. Prioritised #1 in
+`PLAWK_AWK_FEATURE_AUDIT.md`.
+
+## 1. The blocking fact: scalar state is SSA/phi, not memory
+
+plawk's single-pass driver threads scalar variables (`s`, `i`, counters) as
+**SSA values joined by phi nodes**, not memory slots — there are no `alloca`s
+for user scalars. Each rule's body recomputes new SSA values for the scalars it
+touches (`plawk_scalar_match_update_ir`), and the per-rule/per-record boundaries
+phi them together (`plawk_scalar_rule_input_phi_ir`, the `if`-join phis in
+`plawk_scalar_if_join_pairs`). An `if` is already lowered this way: then/else
+branches produce candidate SSA values, and a join block phis them.
+
+A **loop** is the hard case for this model: a variable mutated in the loop body
+depends on its own value from the previous iteration, which SSA expresses with a
+**loop-header phi** (`%i = phi [%i_init, %preheader], [%i_next, %body]`). Nothing
+in the current scalar lowering emits loop-header phis — the `if` join is a
+*forward* phi (two disjoint predecessors), not a *back-edge* phi.
+
+## 2. Approach: bracket the loop with memory (SSA → mem → loop → SSA)
+
+Rather than retrofit loop-header phis through the whole phi-threaded scalar
+machinery (invasive, and every downstream phi site would need to learn about the
+back edge), **bracket each loop with a memory slot** for the scalars it mutates:
+
+```
+; preheader: the scalars are SSA values here (%i_in, %s_in, ...)
+  %i.slot = alloca i64
+  store i64 %i_in, i64* %i.slot        ; seed from the incoming SSA value
+  br label %while.head.N
+while.head.N:
+  %i.cur = load i64, i64* %i.slot
+  %cond  = icmp <op> i64 %i.cur, <bound>
+  br i1 %cond, label %while.body.N, label %while.after.N
+while.body.N:
+  ; body actions load/store the slot(s); print reads %i.cur; i++ stores i+1
+  br label %while.head.N
+while.after.N:
+  %i_out = load i64, i64* %i.slot      ; feed back into the SSA scalar chain
+```
+
+- **Self-contained.** The `alloca`/`load`/`store` bracket lives entirely inside
+  the loop action's IR. Outside the loop the scalar stays SSA; the loop consumes
+  the incoming SSA value (`store` at the preheader) and produces an outgoing SSA
+  value (`load` at `while.after`) that flows into the next phi exactly like an
+  `if` join's result. No change to the forward-phi machinery.
+- **`do-while`** is the same with the condition test *after* the first body
+  pass: `preheader → body → head(cond) → body|after`.
+- **Which scalars to bracket.** The set the body mutates (walk the body for
+  `set` / `inc` / `+=` targets) ∪ the condition variable. Read-only scalars stay
+  SSA and are read once into the preheader.
+
+## 3. PR sequence
+
+1. **Surface — LANDED.** `while (VAR CMP int) { BODY }` and
+   `do { BODY } while (VAR CMP int)` parse; not-yet compile error.
+2. **Runtime, arithmetic body.** Bracket-with-memory lowering for a body of
+   `set` / `inc` / `+=` over i64 scalars + `print`, condition `VAR CMP int`.
+   Deliverable: `{ i = 0; while (i < 3) { print i; i++ } }` prints `0/1/2`, and
+   the `do-while` mirror runs the body once even when the condition starts false.
+3. **General condition + `break`/`continue`.** A boolean/expression condition
+   (reuse the guard grammar) and loop-control statements.
+4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
+   nesting; the multi-pass driver's scalar handling.
+
+## 4. Related AWK gaps found while scoping (see the audit)
+
+These surfaced during the control-flow investigation and are tracked in
+`PLAWK_AWK_FEATURE_AUDIT.md`; noted here because they share the scalar/if
+lowering:
+
+- **`if` with a non-accumulator body doesn't compile.** `{ if (COND) { print
+  $1 } }` (a plain guarded print, no scalar update) is currently *outside the
+  compilable surface* (exit 3) — the scalar `if` lowering assumes the branch
+  bodies update scalar slots. This also blocks **regex/general conditions in
+  `if`** (`if ($0 ~ /re/) { … }`): the condition grammar accepts `~` (rule
+  patterns compile it), but the guarded-print body is the blocker, not the
+  regex. Fix belongs with the `if`-body lowering, not the loop runtime.
+- **Numeric user-function args in text mode.** `print f($1)` returns `0` because
+  a text field is passed to the foreign call as an *atom*, and the synthesised
+  `f(X,R) :- R is X*2` fails `is` on a non-number. In `BINFMT` (typed i64) mode
+  it works. This is a **type-model** decision: auto-coerce a field arg to i64
+  when the callee uses it numerically (needs body inference), or an explicit
+  `num($1)` / `int($1)` coercion at the call site (currently `int(...)` is not
+  accepted as a call arg). Prioritised #2 in the audit; wants a small design
+  call before coding.
+- **brace-less `if`/loop bodies.** `if (COND) print` (no `{ }`) doesn't parse;
+  plawk requires a braced block. Minor parser follow-on.

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -117,12 +117,16 @@ while.after.N:
      the record stream" (`break_close_stream`) — non-standard awk. Inside a loop,
      the loop-context stack redirects `break` to the loop exit; outside a loop it
      still means stream-break. `next`-inside-loop stays "next record".
-   - **`do-while` / nested — the remaining work.** `do-while`'s condition sits in
-     the body-done block, so `continue` needs an extra merge phi there (and the
-     head-phi back edge must read it); guarded as not-yet for now. Nested-loop
-     support is a separate codegen item (§4) — the loop-context *stack* already
-     handles the break/continue redirection for nesting, but the underlying
-     nested-loop lowering isn't wired.
+   - **`do-while` / nested — LANDED.** `do-while`'s condition sits in the
+     body-done block, so `continue` targets it and a merge phi there
+     (`plawk_loop_after_ir` reused as the body-done phi) combines the normal body
+     output with each continue value; the condition, the head-phi back edge, and
+     the `after` block all read that merged value; `break` still targets `after`.
+     Nested loops also compile: the only fix needed was validation
+     (`plawk_scalar_rule_body_plain_action` now accepts a nested loop as a body
+     action) — the loop-context *stack* already routed break/continue to the
+     innermost loop, and the emitter's per-loop `Base` naming keeps nested
+     labels/phis distinct.
    - **Dependency — scalar `if` conditions — LANDED.** A *counter-based* break
      (`if (i > 2) break`) needs the `if` condition to accept a scalar variable.
      This shipped: `if (COND)` now parses a scalar comparison (`i > 2`,
@@ -133,8 +137,9 @@ while.after.N:
      `continue` *jump* itself remains to wire. (Scalar `if` in an `END` block --
      `END { if (COND) print … ; else print … }`, over final slot values -- also
      landed.)
-4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
-   nesting; the multi-pass driver's scalar handling.
+4. **Loop in a multi-pass `pass { }` block.** Single-pass nested loops LANDED
+   (per-loop `Base` naming keeps labels/phis distinct); the remaining item is
+   the multi-pass driver's scalar handling for loops inside a `pass { }`.
 
 ## 4. Related AWK gaps found while scoping (see the audit)
 

--- a/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
+++ b/docs/design/PLAWK_CONTROL_FLOW_PLAN.md
@@ -117,12 +117,15 @@ while.after.N:
      `break` must mean *loop* break; the loop intercepts its own body's break
      exits (the guard above makes this a hard boundary today). `next`-inside-loop
      stays "next record" (propagates past the loop).
-   - **Dependency — scalar `if` conditions.** For a *counter-based* break
-     (`if (i > 2) break`) to be useful the `if` condition must accept a scalar
-     variable; today `if (COND)` only takes field/pattern conditions (`$1 > 2`),
-     not `i > 2` (parse error). So this PR also needs the `if` condition grammar
-     extended to scalar comparisons (the same `VAR CMP int/VAR` shape the loop
-     condition already uses). Do it alongside, or first.
+   - **Dependency — scalar `if` conditions — LANDED.** A *counter-based* break
+     (`if (i > 2) break`) needs the `if` condition to accept a scalar variable.
+     This shipped: `if (COND)` now parses a scalar comparison (`i > 2`,
+     `i < n && j > 0`) as `scalar_if(_)`, lowered by `plawk_if_cond_ir` via the
+     loop-condition emitter (reads slot values), alongside the existing
+     field/pattern guards. So a scalar `if` already works inside a loop body
+     (e.g. `while (i < 5) { if (i > 2) print i; i++ }`); only the `break`/
+     `continue` *jump* itself remains to wire. (Scalar `if` in an `END` block is
+     a separate follow-on — END uses its own lowering.)
 4. **Nested loops / loop in multi-pass `pass { }`.** Unique slot naming per loop
    nesting; the multi-pass driver's scalar handling.
 

--- a/docs/design/PLAWK_GENERATOR_BLOCKS.md
+++ b/docs/design/PLAWK_GENERATOR_BLOCKS.md
@@ -255,5 +255,21 @@ the producer direction plus the `emit` collection. A rough PR shape:
    passthrough, `>` filter, `&&` filter, and the transform / computed-emit
    not-yet errors. The AST unified to `gen_block(name(Name), Source, Body)`
    with `Source` = `none` (pure) or `over(query(Src, Vars), LoopVar)`.
-4. **Tuples + durability** — `emit (A, B)` → `name/2`; optional cache/LMDB-backed
-   collected set.
+4. **Tuples — LANDED (constant tuples).** `emit (A, B, …)` parses to
+   `emit(tuple([…]))` and a pure block of constant tuples compiles to arity-n
+   facts (`gen { emit (1, 10); emit (2, 20) } as edge` → `edge(1, 10).
+   edge(2, 20).`), consumed by a multi-column query
+   (`pass over query(edge(X, Y)) { print $1, $2 }`). Elements may mix integer
+   and string literals. A *computed* tuple element, and a durable (cache/LMDB-
+   backed) collected set, remain follow-ons — they need the runtime collection
+   below. `tests/test_plawk_gen_blocks.pl`: an int tuple and a mixed
+   string+int tuple.
+
+### Still open — runtime collection
+
+The remaining generator shapes — a pure block with a *computed* emit, a
+transforming input iterator (`emit v * 2`), a table/non-query source, and
+durability — all need the block to *run and collect* at build/run time rather
+than synthesise clauses. The proven path is `assertz` into the dynamic DB +
+`findall` (the `tests/test_plawk_eval_compile.pl` stateful-grammar pattern),
+driven from the emit sites. That is the next generator PR.

--- a/docs/design/PLAWK_GENERATOR_BLOCKS.md
+++ b/docs/design/PLAWK_GENERATOR_BLOCKS.md
@@ -72,8 +72,18 @@ per-column integer/string kinds end to end (the tagged materialisation of
 `print` + `FS`, every value would round-trip through text and arrive as a
 string, throwing away exactly that typing — the consumer would have to re-parse.
 `emit E` keeps the term's type (an integer stays an integer, an atom an atom),
-mirroring how the reader materialises columns. Three more reasons:
+mirroring how the reader materialises columns. Four more reasons:
 
+- **No serialize/deserialize round-trip (performance).** With explicit `emit`,
+  the compiler knows each emitted value's type, so it materialises the *typed
+  WAM value* straight into the tagged column table — no text ever exists.
+  Implicit-FS yield would `print` the value to **text** and the consumer would
+  **re-parse** it (`atom → number`), a serialise→text→deserialise cost on every
+  value that explicit `emit` avoids entirely. This is the *same* principle as
+  optional function-arg typing (`PLAWK_AWK_FEATURE_AUDIT.md` gap 2): **static
+  type/structure knowledge lets the compiler elide coercion and serialisation.**
+  It recurs across plawk — typed `BINFMT` records skip parsing, the reader's
+  per-column kinds skip re-typing, and `emit` skips the text round-trip.
 - **Emission ≠ stdout.** Overloading `print` to *also* mean "produce a solution"
   conflates two jobs — a gen block may legitimately want to write to stdout
   (debug/log) without that becoming a solution. `emit` keeps them separate.

--- a/docs/design/PLAWK_GENERATOR_BLOCKS.md
+++ b/docs/design/PLAWK_GENERATOR_BLOCKS.md
@@ -275,6 +275,21 @@ the producer direction plus the `emit` collection. A rough PR shape:
    below. `tests/test_plawk_gen_blocks.pl`: an int tuple and a mixed
    string+int tuple.
 
+5. **Multi-column source + projection (views) — LANDED.** The input iterator
+   now binds a loop var per source column (`as (a, b)`) and the body emits a
+   **projection** of them: `gen over query(edge(A, B)) as (a, b) { if (a > 1)
+   emit a } as srcs` → `srcs(A) :- edge(A, _B), A > 1` (only the needed column
+   materialises — the "don't carry the whole row" point), and `emit (b, a)` →
+   `flipped(B, A) :- edge(A, B)` (reorder). This is the **column-projection
+   engine for views** (`PLAWK_MULTIPASS_CACHE.md` §3.9): a filtered/projected
+   derived relation. The AST generalised to `over(query(Src, SrcVars),
+   LoopVars)` with `LoopVars` a list; `emit` tuple elements may now be bound
+   vars. What remains for a full *view* is **materialise-and-cache** (write the
+   projected set to its own row table with a refresh policy) — the generator
+   gives the *derived-relation* half; materialisation is the cache half.
+   `tests/test_plawk_gen_blocks.pl`: a filtered single-column projection and a
+   reordering tuple projection.
+
 ### Still open — runtime collection
 
 The remaining generator shapes — a pure block with a *computed* emit, a

--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -10,6 +10,7 @@ Copyright (c) 2026 John William Creighton (s243a)
 *Status: Early Design / Prototype Phase*
 
 > **Companion docs:** [Philosophy](PLAWK_PHILOSOPHY.md) ·
+> [AWK feature audit & roadmap](PLAWK_AWK_FEATURE_AUDIT.md) ·
 > [Specification](PLAWK_SPECIFICATION.md) ·
 > [Execution Architecture](PLAWK_EXECUTION_ARCHITECTURE.md) ·
 > [DCG Binary Readers](PLAWK_DCG_BINARY_READERS.md) ·

--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -781,6 +781,33 @@ projection table; the surface (`view NAME as records of T where …`) is
 uniform, and only the evaluation strategy is backend-specific. Depends on
 reader guards (the `WHERE`) and, for multi-table sources, phase 8.9.
 
+**Views before general auto-caching (recommended).** Auto-caching retrieved
+items transparently is convenient, but it caches *whole rows* — often more than
+a pass needs. A view is precisely the "cache only the columns/rows I need"
+construct: a materialised view **is** an auto-cache scoped to a projection +
+filter. So the recommended order is **views first, then (optionally) auto-caching
+layered on the view abstraction** ("auto-cache = materialise this view on first
+access, refresh per policy") rather than a standalone whole-row cache. That
+keeps the cached footprint lean by construction and gives auto-caching a
+principled unit to operate on.
+
+**Most of a view already exists.** A view is a *named, derived, materialised
+relation* — and the phase-6 work built the pieces:
+- the **`over query(Goal)`** reader already evaluates a derived relation, with
+  **reader guards** as the `WHERE`;
+- the **generator input iterator** (`gen over query(src(V)) as v { if (v CMP c)
+  emit v } as name`, `PLAWK_GENERATOR_BLOCKS.md` PR 3) already names a
+  **filtered derived relation** (`name(A) :- src(A), A CMP c`) — a filtered view
+  in all but name and materialisation;
+- the query reader's **per-column tagged materialisation** (PR 6) is exactly the
+  projection engine.
+So the net-new work for views is narrow: **column projection** (select a subset
+of columns, not the whole row — the "we might not need a whole row" point) and
+**materialise-and-cache** (write the projected/filtered set to its own row
+table, with a refresh policy — eager/lazy/explicit, the one genuinely open
+question). Both build directly on shipped machinery, which is the other reason
+to do views before a from-scratch auto-cache.
+
 ### 3.10 Contained non-determinism — a search construct (future TODO — sketch)
 
 The loops discussion (§3.8) draws a line: a `while` gives back *unboundedness*

--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -758,7 +758,44 @@ brevity, the key iterator trades brevity for reach. A nested `pass` (§3.8), if
 built, is the record-returning form gaining its own nested scope — the natural
 extension of the left column, not a new mechanism.
 
-### 3.9 Views (future TODO — brief spec, not planned)
+### 3.9 Views (column projection LANDED; `materialize` surface LANDED, runtime planned)
+
+**Status.** Column projection landed (`PLAWK_GENERATOR_BLOCKS.md` PR 5): a
+generator over a multi-column source projects/reorders columns into a derived
+relation. The **`materialize NAME`** surface landed (surface-first, like the
+query-reader / generator / while arcs): it parses to a `materialize(Name)`
+program item and its reference is validated against the program's defined
+relations (a `gen ... as NAME` view or a @prolog predicate); the
+materialise-and-cache **runtime** is the follow-on planned here.
+
+#### Runtime plan (materialise-and-cache)
+
+A query pass today materialises its goal's columns into **pass-local** tagged
+tables (`%qval_C` / `%qkind_C`), iterates, and frees them at pass end
+(`plawk_multipass_query_fn_ir`). So two passes over the same relation
+materialise it twice. `materialize NAME` lifts that to **once, shared**:
+
+1. **Shared tables.** For each materialised relation, emit **global** column
+   tables (`@qval_<NAME>_<C>` / `@qkind_<NAME>_<C>`) instead of pass-local ones.
+2. **One-time fill.** Emit a `@plawk_materialize_<NAME>()` that runs the
+   per-column findall wrappers against the shared VM and fills the globals; call
+   it once from `main` **before** the pass calls (or lazily behind a
+   done-flag). Do not free the globals per pass.
+3. **Consumer rewiring.** A `pass over query(NAME(...))` reads the shared
+   globals instead of materialising locally and skips the free.
+
+**Refresh policy — resolved for the intra-run case.** The open question was
+eager/lazy/explicit refresh. For the current sources — @prolog facts and
+generator-derived relations are **static within a program run** — the answer is
+**eager-once, no refresh**: materialise on first need, reuse for the rest of the
+run; the source cannot change mid-run, so there is nothing to invalidate. A
+refresh policy only re-enters when a materialised view is backed by a **mutable
+durable cache** across runs (the LMDB / inter-pass-channel case, Phase 3), which
+is where eager-on-write vs lazy-on-read vs explicit becomes a real choice. So
+the runtime splits cleanly: the intra-run share above is unblocked and needs no
+policy; the cross-run persistent view waits on Phase 3.
+
+#### Original sketch (retained)
 
 A **view** is a named, derived query over one or more tables — conceptually a
 stored `records of … WHERE … ` (reader guards have landed; a view would pair
@@ -801,12 +838,13 @@ relation* — and the phase-6 work built the pieces:
   in all but name and materialisation;
 - the query reader's **per-column tagged materialisation** (PR 6) is exactly the
   projection engine.
-So the net-new work for views is narrow: **column projection** (select a subset
+So the net-new work for views was narrow: **column projection** (select a subset
 of columns, not the whole row — the "we might not need a whole row" point) and
-**materialise-and-cache** (write the projected/filtered set to its own row
-table, with a refresh policy — eager/lazy/explicit, the one genuinely open
-question). Both build directly on shipped machinery, which is the other reason
-to do views before a from-scratch auto-cache.
+**materialise-and-cache** (compute the projected/filtered set once, reuse it).
+Projection **landed** (`PLAWK_GENERATOR_BLOCKS.md` PR 5); the `materialize NAME`
+**surface landed** (this doc's §3.9 status), and the runtime is the plan above.
+Both build directly on shipped machinery, which is the other reason views come
+before a from-scratch auto-cache.
 
 ### 3.10 Contained non-determinism — a search construct (future TODO — sketch)
 

--- a/docs/design/PLAWK_MULTIPASS_CACHE.md
+++ b/docs/design/PLAWK_MULTIPASS_CACHE.md
@@ -778,22 +778,37 @@ materialise it twice. `materialize NAME` lifts that to **once, shared**:
 1. **Shared tables.** For each materialised relation, emit **global** column
    tables (`@qval_<NAME>_<C>` / `@qkind_<NAME>_<C>`) instead of pass-local ones.
 2. **One-time fill.** Emit a `@plawk_materialize_<NAME>()` that runs the
-   per-column findall wrappers against the shared VM and fills the globals; call
-   it once from `main` **before** the pass calls (or lazily behind a
-   done-flag). Do not free the globals per pass.
+   per-column findall wrappers against the shared VM and fills the globals **on
+   first access** (behind a done-flag), then reuse. Do not free the globals per
+   pass.
 3. **Consumer rewiring.** A `pass over query(NAME(...))` reads the shared
    globals instead of materialising locally and skips the free.
 
-**Refresh policy — resolved for the intra-run case.** The open question was
-eager/lazy/explicit refresh. For the current sources — @prolog facts and
-generator-derived relations are **static within a program run** — the answer is
-**eager-once, no refresh**: materialise on first need, reuse for the rest of the
-run; the source cannot change mid-run, so there is nothing to invalidate. A
-refresh policy only re-enters when a materialised view is backed by a **mutable
-durable cache** across runs (the LMDB / inter-pass-channel case, Phase 3), which
-is where eager-on-write vs lazy-on-read vs explicit becomes a real choice. So
-the runtime splits cleanly: the intra-run share above is unblocked and needs no
-policy; the cross-run persistent view waits on Phase 3.
+**Two separate axes — don't conflate them.** "Materialise once and reuse" (the
+cache win) is one decision; *when* and *how completely* to build the table is
+another. Keeping them apart:
+
+- **Invalidation / refresh — resolved (none, intra-run).** @prolog facts and
+  generator-derived relations are **static within a program run**, so a
+  materialised view never needs recomputing mid-run. A refresh policy
+  (eager-on-write / lazy-on-read / explicit) only re-enters when a view is backed
+  by a **mutable durable cache** across runs (the LMDB / inter-pass-channel case,
+  Phase 3). This axis is genuinely settled for the current sources.
+
+- **Materialisation strategy — NOT "eager", and scale-sensitive.** An earlier
+  draft called this "eager-once"; that over-generalised. **Lazy** (materialise on
+  first consumer access, then reuse — step 2 above) *dominates* eager: it gives
+  the same cross-consumer dedup, costs nothing for a view that is never reached or
+  is short-circuited, and adds only a done-flag. Eager (fill in `main` up front)
+  is merely simpler codegen, not faster — reserve it as an opt-in for tiny hot
+  views. **And the real ceiling is completeness:** materialising the *whole*
+  relation into in-memory assoc tables breaks on memory at scale, independent of
+  eager-vs-lazy — it wins at low scale and loses at high. The scaling path is
+  **demand-driven materialisation that spills to the durable backend** (LMDB),
+  i.e. exactly the Phase 3 / Phase 5 machinery. So: lazy in-memory whole-relation
+  is the **low-scale default** (simple, correct, a clear win when several passes
+  rescan a bounded set); large or unbounded views want the spilling, demand-driven
+  path and wait on Phase 3.
 
 #### Original sketch (retained)
 

--- a/docs/design/UNIFYWEAVER_LANGUAGE_PRINCIPLES.md
+++ b/docs/design/UNIFYWEAVER_LANGUAGE_PRINCIPLES.md
@@ -116,4 +116,58 @@ the hot loop stays choicepoint-free.
 
 ---
 
+## Principle 2 — Static structure elides coercion and serialization
+
+**When the compiler statically knows a value's type or a boundary's shape, it
+can carry the value in its native representation — skipping the runtime
+coercion, parsing, or serialize/deserialize round-trip a dynamically-typed
+crossing would pay.** The unit of work you *don't* do is the point.
+
+UnifyWeaver compiles a dynamic-feeling surface (awk-like text fields, Prolog
+terms) onto a **typed** substrate (typed WAM values, typed LLVM). Every place
+the surface would otherwise force a value through text or an untyped box is an
+opportunity: if the type/shape is known at compile time, the crossing is free;
+if it is not, a runtime coercion pays for the dynamism. So the design lever is
+**push type/shape knowledge to compile time**, and let the dynamic path remain
+the correct-but-slower default.
+
+### The same principle, several faces
+
+- **Explicit `emit` vs implicit field-separator yield** (`PLAWK_GENERATOR_BLOCKS.md`
+  §2.1): `emit E` materialises a *typed* value straight into the tagged column
+  table — no text exists. An FS-split yield would `print` to text and re-parse
+  it, a serialize→text→deserialize cost per value. Known type ⇒ no round-trip.
+- **Optional function-arg typing over auto-coerce**
+  (`PLAWK_AWK_FEATURE_AUDIT.md` gap 2): the awk-faithful default auto-coerces a
+  text field used numerically (`atom → number` every call); a declared
+  `function f(num x)` lets the compiler pass an already-typed value and skip the
+  coercion — the typed-fast path over the dynamic-correct default. (It also
+  turns a type mismatch into a compile error — the safety face of the same
+  knowledge.)
+- **Typed binary records (`BINFMT`)** vs text fields: a declared record layout
+  reads fields as native `i64`/`f64` with no per-field string parse.
+- **The query reader's per-column tagged materialisation**
+  (`PLAWK_QUERY_READER_IMPLEMENTATION_PLAN.md` PR 6): each column carries its
+  kind (int/atom), so consumers read the native value rather than re-typing text.
+
+### Relationship to gradual typing
+
+This is why **gradual typing fits UnifyWeaver naturally** rather than as a
+bolt-on: the substrate is already typed, so an *optional* annotation is not new
+machinery — it is a compile-time assertion that unlocks the representation the
+compiler can already emit. The dynamic default stays ergonomic (no annotations
+required, awk semantics preserved); the annotation buys the elision. Correctness
+comes from the dynamic path; performance and static checking come from the typed
+path layered on top — never one instead of the other.
+
+### The tension with Principle 1
+
+Principle 1 (collapse multiplicity at a boundary) and Principle 2 (elide work
+when the shape is known) pull the same direction: a **boundary with a known
+shape** is both where non-determinism is contained *and* where representation is
+fixed, so the compiler can specialise it. A well-typed collapse boundary is the
+cheapest one.
+
+---
+
 *Add further principles below as they recur across surfaces.*

--- a/docs/design/UNIFYWEAVER_LANGUAGE_PRINCIPLES.md
+++ b/docs/design/UNIFYWEAVER_LANGUAGE_PRINCIPLES.md
@@ -137,13 +137,13 @@ the correct-but-slower default.
   §2.1): `emit E` materialises a *typed* value straight into the tagged column
   table — no text exists. An FS-split yield would `print` to text and re-parse
   it, a serialize→text→deserialize cost per value. Known type ⇒ no round-trip.
-- **Optional function-arg typing over auto-coerce**
-  (`PLAWK_AWK_FEATURE_AUDIT.md` gap 2): the awk-faithful default auto-coerces a
+- **Optional function-arg typing over auto-coerce** (LANDED —
+  `PLAWK_AWK_FEATURE_AUDIT.md` gap 2): the awk-faithful default auto-coerces a
   text field used numerically (`atom → number` every call); a declared
   `function f(num x)` lets the compiler pass an already-typed value and skip the
-  coercion — the typed-fast path over the dynamic-correct default. (It also
-  turns a type mismatch into a compile error — the safety face of the same
-  knowledge.)
+  coercion goal entirely — the typed-fast path over the dynamic-correct default.
+  (The safety face — turning a type mismatch into a compile error — is the
+  follow-on; today the annotation buys the elision.)
 - **Typed binary records (`BINFMT`)** vs text fields: a declared record layout
   reads fields as native `i64`/`f64` with no per-field string parse.
 - **The query reader's per-column tagged materialisation**

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -108,7 +108,6 @@ build(File, Out0, KeepLL) :-
     % removed; `GenFactClauses` are the synthesised facts.
     check_generator_blocks(File, Program2),
     check_materialized_views(File, Program2, Clauses),
-    check_loop_control(File, Program2),
     resolve_generator_blocks(Program2, Program, GenFactClauses),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
@@ -365,47 +364,6 @@ check_generator_blocks(File, Program) :-
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
-
-% `break` / `continue` for loop control (PLAWK_CONTROL_FLOW_PLAN.md §3b). Loop-
-% local break/continue is wired for `while` loops (SSA merge phis at the loop
-% exit / head). `do-while` break/continue is NOT wired yet (its condition sits
-% in the body-done block, so continue needs an extra merge phi there), so a
-% break/continue inside a `do-while` body is a clean not-yet error -- otherwise
-% break would silently lower to the rule-level stream-break. `break` OUTSIDE a
-% loop keeps its existing stream-break meaning.
-check_loop_control(File, Program) :-
-    plawk_dowhile_body_has_control(Program),
-    !,
-    format(user_error,
-        'plawk: ~w uses `break`/`continue` inside a `do-while` loop. `while` \c
-         loop break/continue is wired, but the do-while form is not yet; see \c
-         PLAWK_CONTROL_FLOW_PLAN.md section 3b.~n',
-        [File]),
-    halt(2).
-check_loop_control(_File, _Program).
-
-% True if some `do-while` body contains a `break` or `continue` anywhere in its
-% subtree.
-plawk_dowhile_body_has_control(Term) :-
-    plawk_ast_dowhile_body(Term, Body),
-    ( plawk_ast_contains(Body, break)
-    ; plawk_ast_contains(Body, continue)
-    ),
-    !.
-
-plawk_ast_dowhile_body(do_while_loop(Body, _Cond), Body).
-plawk_ast_dowhile_body(Term, Body) :-
-    compound(Term),
-    arg(_, Term, Arg),
-    plawk_ast_dowhile_body(Arg, Body).
-
-% Structural sub-term search (handles lists, since a body is an action list).
-plawk_ast_contains(Term, Term) :-
-    !.
-plawk_ast_contains(Term, Target) :-
-    compound(Term),
-    arg(_, Term, Arg),
-    plawk_ast_contains(Arg, Target).
 
 % `materialize NAME` (PLAWK_MULTIPASS_CACHE.md §3.9): mark a view / relation to
 % be materialised-and-cached (computed once, reused by every query pass that

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -108,6 +108,7 @@ build(File, Out0, KeepLL) :-
     % removed; `GenFactClauses` are the synthesised facts.
     check_generator_blocks(File, Program2),
     check_materialized_views(File, Program2, Clauses),
+    check_loop_control(File, Program2),
     resolve_generator_blocks(Program2, Program, GenFactClauses),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
@@ -364,6 +365,52 @@ check_generator_blocks(File, Program) :-
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
+
+% `break` / `continue` for loop control (PLAWK_CONTROL_FLOW_PLAN.md §3b). The
+% while / do-while loops run, but LOOP-LOCAL break/continue is not yet wired:
+% inside a loop `break` currently lowers to the rule-level stream-break
+% (`break_close_stream`), which stops reading records entirely instead of just
+% leaving the loop -- a silent mis-compile. So a `break` inside a loop body, or
+% any `continue`, is a clean not-yet error until the runtime lands (it needs SSA
+% merge phis at the loop exit + scalar `if` conditions to guard the jump).
+% `break` OUTSIDE a loop keeps its existing stream-break meaning.
+check_loop_control(File, Program) :-
+    (   plawk_loop_body_has_control(Program)
+    ;   plawk_ast_contains(Program, continue)
+    ),
+    !,
+    format(user_error,
+        'plawk: ~w uses `break`/`continue` for loop control. The loop runtime \c
+         is landed, but loop-local `break`/`continue` is not yet wired (it needs \c
+         SSA merge phis at the loop exit and scalar `if` conditions); see \c
+         PLAWK_CONTROL_FLOW_PLAN.md section 3b.~n',
+        [File]),
+    halt(2).
+check_loop_control(_File, _Program).
+
+% True if some `while` / `do-while` body contains a `break` or `continue`
+% anywhere in its subtree.
+plawk_loop_body_has_control(Term) :-
+    plawk_ast_loop_body(Term, Body),
+    ( plawk_ast_contains(Body, break)
+    ; plawk_ast_contains(Body, continue)
+    ),
+    !.
+
+plawk_ast_loop_body(while_loop(_Cond, Body), Body).
+plawk_ast_loop_body(do_while_loop(Body, _Cond), Body).
+plawk_ast_loop_body(Term, Body) :-
+    compound(Term),
+    arg(_, Term, Arg),
+    plawk_ast_loop_body(Arg, Body).
+
+% Structural sub-term search (handles lists, since a body is an action list).
+plawk_ast_contains(Term, Term) :-
+    !.
+plawk_ast_contains(Term, Target) :-
+    compound(Term),
+    arg(_, Term, Arg),
+    plawk_ast_contains(Arg, Target).
 
 % `materialize NAME` (PLAWK_MULTIPASS_CACHE.md §3.9): mark a view / relation to
 % be materialised-and-cached (computed once, reused by every query pass that

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -400,8 +400,11 @@ program_has_while(Term) :-
 %    -> a derived rule.
 gen_block_supported(none, Body) :-
     forall(member(Action, Body), gen_const_emit(Action)).
-gen_block_supported(over(query(_Src, [_SrcVar]), LoopVar), Body) :-
-    gen_over_body_ok(Body, LoopVar).
+% Input iterator over a query source: one loop var per source column, and the
+% body emits a projection of the bound vars (optionally filtered).
+gen_block_supported(over(query(_Src, SrcVars), LoopVars), Body) :-
+    same_length(SrcVars, LoopVars),
+    gen_over_body_ok(Body, LoopVars).
 
 % A constant emit: a bare integer/string literal, or a tuple whose elements are
 % all integer/string literals.
@@ -409,18 +412,32 @@ gen_const_emit(emit(int(_))).
 gen_const_emit(emit(string(_))).
 gen_const_emit(emit(tuple(Values))) :-
     forall(member(V, Values), ( V = int(_) ; V = string(_) )).
-gen_block_supported(over(query(_Src, [_SrcVar]), LoopVar), Body) :-
-    gen_over_body_ok(Body, LoopVar).
 
-% A supported input-iterator body: `emit v` (passthrough), optionally filtered
-% by `if (GUARD) emit v` where GUARD is an integer comparison over `v`.
-gen_over_body_ok([emit(var(LoopVar))], LoopVar).
-gen_over_body_ok([if(Guard, [emit(var(LoopVar))], [])], LoopVar) :-
-    gen_over_guard_ok(Guard, LoopVar).
-gen_over_guard_ok(and(L, R), LoopVar) :-
-    gen_over_guard_ok(L, LoopVar), gen_over_guard_ok(R, LoopVar).
-gen_over_guard_ok(forin_key_cmp(LoopVar, _Op, Value), LoopVar) :-
-    integer(Value).
+% A supported input-iterator body: emit a projection of the bound loop vars
+% (`emit a` -> one column; `emit (a, b)` -> a tuple, columns reorderable and
+% mixable with literals), optionally filtered by `if (GUARD) emit ...` where
+% GUARD is an integer comparison over the bound vars.
+gen_over_body_ok([emit(Emit)], LoopVars) :-
+    gen_emit_projection_ok(Emit, LoopVars).
+gen_over_body_ok([if(Guard, [emit(Emit)], [])], LoopVars) :-
+    gen_emit_projection_ok(Emit, LoopVars),
+    gen_over_guard_ok(Guard, LoopVars).
+
+% The emitted projection references only bound loop vars (plus literals in a
+% tuple).
+gen_emit_projection_ok(var(V), LoopVars) :-
+    memberchk(V, LoopVars).
+gen_emit_projection_ok(tuple(Vals), LoopVars) :-
+    Vals = [_, _ | _],
+    forall(member(Val, Vals), gen_emit_elem_ok(Val, LoopVars)).
+gen_emit_elem_ok(var(V), LoopVars) :- memberchk(V, LoopVars).
+gen_emit_elem_ok(int(_), _LoopVars).
+gen_emit_elem_ok(string(_), _LoopVars).
+
+gen_over_guard_ok(and(L, R), LoopVars) :-
+    gen_over_guard_ok(L, LoopVars), gen_over_guard_ok(R, LoopVars).
+gen_over_guard_ok(forin_key_cmp(V, _Op, Value), LoopVars) :-
+    memberchk(V, LoopVars), integer(Value).
 
 % Lift generator blocks out of the pass list, synthesising each one's clauses:
 % a pure block's constant emits become facts (`gen { emit 1; emit 2 } as g` ->
@@ -445,32 +462,53 @@ is_gen_block(gen_block(_, _, _)).
 gen_block_clause(gen_block(name(Name), none, Body), Fact) :-
     member(emit(Value), Body),
     gen_emit_fact(Name, Value, Fact).
-% Input iterator: a single derived rule over the source goal.
-gen_block_clause(gen_block(name(Name), over(query(Src, [_SrcVar]), LoopVar),
+% Input iterator: a single derived rule over the source goal. Each source column
+% binds a fresh variable; the loop-var names map to those fresh vars positionally
+% (Bindings). The head is the emitted projection over those vars; unused source
+% columns stay as anonymous fresh vars (a projection). So
+% `gen over query(edge(A, B)) as (a, b) { if (a > 2) emit a } as g` ->
+% `g(A) :- edge(A, _B), A > 2`, and `emit (b, a)` -> `g(B, A) :- edge(A, B)`.
+gen_block_clause(gen_block(name(Name), over(query(Src, SrcVars), LoopVars),
         Body), Clause) :-
-    % Arg is a fresh logic variable shared by the head, the source goal, and
-    % the filter -- so `g(A) :- src(A), A > 2` unifies across the three.
-    SrcGoal =.. [Src, Arg],
-    Head =.. [Name, Arg],
-    gen_over_body_goal(Body, LoopVar, Arg, FilterGoal),
+    same_length(SrcVars, SrcArgs),          % fresh vars, one per source column
+    SrcGoal =.. [Src | SrcArgs],
+    pairs_keys_values(Bindings, LoopVars, SrcArgs),
+    gen_over_body_head(Body, Name, Bindings, Head, FilterGoal),
     ( FilterGoal == true
     ->  Clause = (Head :- SrcGoal)
     ;   Clause = (Head :- SrcGoal, FilterGoal)
     ).
 
-% The Prolog goal an input-iterator body adds after the source goal: `true`
-% for a bare passthrough, or the translated guard for a filtered one.
-gen_over_body_goal([emit(var(_LoopVar))], _LoopVar, _Arg, true).
-gen_over_body_goal([if(Guard, [emit(var(_LoopVar))], [])], LoopVar, Arg,
-        Goal) :-
-    gen_guard_goal(Guard, LoopVar, Arg, Goal).
+% The head (emitted projection) and the post-source filter goal for an input
+% iterator body.
+gen_over_body_head([emit(Emit)], Name, Bindings, Head, true) :-
+    gen_emit_head_args(Emit, Bindings, Args),
+    Head =.. [Name | Args].
+gen_over_body_head([if(Guard, [emit(Emit)], [])], Name, Bindings, Head,
+        FilterGoal) :-
+    gen_emit_head_args(Emit, Bindings, Args),
+    Head =.. [Name | Args],
+    gen_over_filter_goal(Guard, Bindings, FilterGoal).
 
-% Translate an integer reader guard over the bound var into a Prolog arithmetic
-% comparison over the head argument.
-gen_guard_goal(and(L, R), LoopVar, Arg, (GL, GR)) :-
-    gen_guard_goal(L, LoopVar, Arg, GL),
-    gen_guard_goal(R, LoopVar, Arg, GR).
-gen_guard_goal(forin_key_cmp(LoopVar, Op, Value), LoopVar, Arg, Goal) :-
+% Map an emitted projection to the head's argument list, resolving each bound
+% var to its fresh source variable (literals pass through).
+gen_emit_head_args(var(V), Bindings, [Arg]) :-
+    memberchk(V-Arg, Bindings).
+gen_emit_head_args(tuple(Vals), Bindings, Args) :-
+    maplist(gen_emit_head_arg(Bindings), Vals, Args).
+gen_emit_head_arg(Bindings, var(V), Arg) :-
+    memberchk(V-Arg, Bindings).
+gen_emit_head_arg(_Bindings, int(N), N).
+gen_emit_head_arg(_Bindings, string(S), Atom) :-
+    atom_string(Atom, S).
+
+% Translate an integer reader guard over the bound vars into a Prolog arithmetic
+% comparison over the corresponding source variables.
+gen_over_filter_goal(and(L, R), Bindings, (GL, GR)) :-
+    gen_over_filter_goal(L, Bindings, GL),
+    gen_over_filter_goal(R, Bindings, GR).
+gen_over_filter_goal(forin_key_cmp(V, Op, Value), Bindings, Goal) :-
+    memberchk(V-Arg, Bindings),
     gen_cmp_op(Op, PrologOp),
     Goal =.. [PrologOp, Arg, Value].
 

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -366,43 +366,38 @@ check_generator_blocks(File, Program) :-
     halt(2).
 check_generator_blocks(_File, _Program).
 
-% `break` / `continue` for loop control (PLAWK_CONTROL_FLOW_PLAN.md §3b). The
-% while / do-while loops run, but LOOP-LOCAL break/continue is not yet wired:
-% inside a loop `break` currently lowers to the rule-level stream-break
-% (`break_close_stream`), which stops reading records entirely instead of just
-% leaving the loop -- a silent mis-compile. So a `break` inside a loop body, or
-% any `continue`, is a clean not-yet error until the runtime lands (it needs SSA
-% merge phis at the loop exit + scalar `if` conditions to guard the jump).
-% `break` OUTSIDE a loop keeps its existing stream-break meaning.
+% `break` / `continue` for loop control (PLAWK_CONTROL_FLOW_PLAN.md §3b). Loop-
+% local break/continue is wired for `while` loops (SSA merge phis at the loop
+% exit / head). `do-while` break/continue is NOT wired yet (its condition sits
+% in the body-done block, so continue needs an extra merge phi there), so a
+% break/continue inside a `do-while` body is a clean not-yet error -- otherwise
+% break would silently lower to the rule-level stream-break. `break` OUTSIDE a
+% loop keeps its existing stream-break meaning.
 check_loop_control(File, Program) :-
-    (   plawk_loop_body_has_control(Program)
-    ;   plawk_ast_contains(Program, continue)
-    ),
+    plawk_dowhile_body_has_control(Program),
     !,
     format(user_error,
-        'plawk: ~w uses `break`/`continue` for loop control. The loop runtime \c
-         is landed, but loop-local `break`/`continue` is not yet wired (it needs \c
-         SSA merge phis at the loop exit and scalar `if` conditions); see \c
+        'plawk: ~w uses `break`/`continue` inside a `do-while` loop. `while` \c
+         loop break/continue is wired, but the do-while form is not yet; see \c
          PLAWK_CONTROL_FLOW_PLAN.md section 3b.~n',
         [File]),
     halt(2).
 check_loop_control(_File, _Program).
 
-% True if some `while` / `do-while` body contains a `break` or `continue`
-% anywhere in its subtree.
-plawk_loop_body_has_control(Term) :-
-    plawk_ast_loop_body(Term, Body),
+% True if some `do-while` body contains a `break` or `continue` anywhere in its
+% subtree.
+plawk_dowhile_body_has_control(Term) :-
+    plawk_ast_dowhile_body(Term, Body),
     ( plawk_ast_contains(Body, break)
     ; plawk_ast_contains(Body, continue)
     ),
     !.
 
-plawk_ast_loop_body(while_loop(_Cond, Body), Body).
-plawk_ast_loop_body(do_while_loop(Body, _Cond), Body).
-plawk_ast_loop_body(Term, Body) :-
+plawk_ast_dowhile_body(do_while_loop(Body, _Cond), Body).
+plawk_ast_dowhile_body(Term, Body) :-
     compound(Term),
     arg(_, Term, Arg),
-    plawk_ast_loop_body(Arg, Body).
+    plawk_ast_dowhile_body(Arg, Body).
 
 % Structural sub-term search (handles lists, since a body is an action list).
 plawk_ast_contains(Term, Term) :-

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -108,6 +108,7 @@ build(File, Out0, KeepLL) :-
     % removed; `GenFactClauses` are the synthesised facts.
     check_generator_blocks(File, Program2),
     resolve_generator_blocks(Program2, Program, GenFactClauses),
+    check_while_loops(File, Program),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
     % A query-reader program contributes synthesised findall-wrapper clauses
@@ -363,6 +364,30 @@ check_generator_blocks(File, Program) :-
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
+
+% while loops (plawk roadmap): `while (VAR CMP int) { BODY }` parses but its
+% loop runtime -- mutable scalar state iterated to a fixed point -- is not wired
+% yet, so a program that uses one gets a clear, specific diagnostic rather than
+% the generic "outside the multi-pass surface". Surface-first, mirroring the
+% query reader / generator arcs.
+check_while_loops(File, Program) :-
+    program_has_while(Program),
+    !,
+    format(user_error,
+        'plawk: ~w uses a `while` loop. while loops parse but their runtime is \c
+         not yet implemented; see the plawk roadmap.~n',
+        [File]),
+    halt(2).
+check_while_loops(_File, _Program).
+
+% True if the program term contains a while_loop/2 anywhere (rule body, BEGIN,
+% END, pass, ...). A plain structural walk over the AST.
+program_has_while(while_loop(_, _)) :- !.
+program_has_while(Term) :-
+    compound(Term),
+    Term =.. [_ | Args],
+    member(Arg, Args),
+    program_has_while(Arg).
 
 % A generator block whose clauses can be synthesised at build time:
 %  - a pure block (`Source == none`) whose every action is a constant `emit`

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -366,13 +366,22 @@ check_generator_blocks(_File, _Program).
 
 % A generator block whose clauses can be synthesised at build time:
 %  - a pure block (`Source == none`) whose every action is a constant `emit`
-%    (integer or string literal) -> facts;
+%    (an integer/string literal -> a unary fact, or a tuple of literals -> an
+%    arity-n fact);
 %  - an input iterator over a query source whose body passes the bound var
 %    through (`emit v`), optionally gated by an integer reader guard over `v`
 %    -> a derived rule.
 gen_block_supported(none, Body) :-
-    forall(member(Action, Body),
-        ( Action = emit(int(_)) ; Action = emit(string(_)) )).
+    forall(member(Action, Body), gen_const_emit(Action)).
+gen_block_supported(over(query(_Src, [_SrcVar]), LoopVar), Body) :-
+    gen_over_body_ok(Body, LoopVar).
+
+% A constant emit: a bare integer/string literal, or a tuple whose elements are
+% all integer/string literals.
+gen_const_emit(emit(int(_))).
+gen_const_emit(emit(string(_))).
+gen_const_emit(emit(tuple(Values))) :-
+    forall(member(V, Values), ( V = int(_) ; V = string(_) )).
 gen_block_supported(over(query(_Src, [_SrcVar]), LoopVar), Body) :-
     gen_over_body_ok(Body, LoopVar).
 
@@ -446,13 +455,22 @@ gen_cmp_op(le, =<).
 gen_cmp_op(eq, =:=).
 gen_cmp_op(ne, =\=).
 
-% A constant emit -> a unary fact for the generated relation. An integer emits
-% itself; a string emits the corresponding atom (so `emit "red"` -> `g(red)`).
+% A constant emit -> a fact for the generated relation. A bare integer/string
+% emits a unary fact (an integer itself; a string as the corresponding atom, so
+% `emit "red"` -> `g(red)`); a tuple emits an arity-n fact, one column per
+% element (`emit (1, "a")` -> `g(1, a)`).
 gen_emit_fact(Name, int(N), Fact) :-
     Fact =.. [Name, N].
 gen_emit_fact(Name, string(S), Fact) :-
     atom_string(Atom, S),
     Fact =.. [Name, Atom].
+gen_emit_fact(Name, tuple(Values), Fact) :-
+    maplist(gen_emit_value_arg, Values, Args),
+    Fact =.. [Name | Args].
+
+gen_emit_value_arg(int(N), N).
+gen_emit_value_arg(string(S), Atom) :-
+    atom_string(Atom, S).
 
 % The findall-wrapper clauses to inject into a query program's @prolog
 % predicate set: one `__plawk_query_pred_C(L) :- findall(VC, pred(V1..Vn), L)`

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -365,24 +365,26 @@ check_generator_blocks(File, Program) :-
     halt(2).
 check_generator_blocks(_File, _Program).
 
-% while loops (plawk roadmap): `while (VAR CMP int) { BODY }` parses but its
-% loop runtime -- mutable scalar state iterated to a fixed point -- is not wired
-% yet, so a program that uses one gets a clear, specific diagnostic rather than
-% the generic "outside the multi-pass surface". Surface-first, mirroring the
-% query reader / generator arcs.
+% while / do-while loops (plawk roadmap): `while (VAR CMP int) { BODY }` and
+% `do { BODY } while (VAR CMP int)` parse but their loop runtime -- mutable
+% scalar state iterated to a fixed point -- is not wired yet, so a program that
+% uses one gets a clear, specific diagnostic rather than the generic "outside
+% the multi-pass surface". Surface-first, mirroring the query reader / generator
+% arcs; see PLAWK_CONTROL_FLOW_PLAN.md for the runtime plan.
 check_while_loops(File, Program) :-
     program_has_while(Program),
     !,
     format(user_error,
-        'plawk: ~w uses a `while` loop. while loops parse but their runtime is \c
-         not yet implemented; see the plawk roadmap.~n',
+        'plawk: ~w uses a `while` / `do-while` loop. Loops parse but their \c
+         runtime is not yet implemented; see PLAWK_CONTROL_FLOW_PLAN.md.~n',
         [File]),
     halt(2).
 check_while_loops(_File, _Program).
 
-% True if the program term contains a while_loop/2 anywhere (rule body, BEGIN,
-% END, pass, ...). A plain structural walk over the AST.
+% True if the program term contains a while_loop/2 or do_while_loop/2 anywhere
+% (rule body, BEGIN, END, pass, ...). A plain structural walk over the AST.
 program_has_while(while_loop(_, _)) :- !.
+program_has_while(do_while_loop(_, _)) :- !.
 program_has_while(Term) :-
     compound(Term),
     Term =.. [_ | Args],

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -107,6 +107,7 @@ build(File, Out0, KeepLL) :-
     % like any other relation. `Program` is the program with generator blocks
     % removed; `GenFactClauses` are the synthesised facts.
     check_generator_blocks(File, Program2),
+    check_materialized_views(File, Program2, Clauses),
     resolve_generator_blocks(Program2, Program, GenFactClauses),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
@@ -363,6 +364,45 @@ check_generator_blocks(File, Program) :-
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
+
+% `materialize NAME` (PLAWK_MULTIPASS_CACHE.md §3.9): mark a view / relation to
+% be materialised-and-cached (computed once, reused by every query pass that
+% reads it). Surface-first, mirroring the query-reader / generator / while arcs:
+% the declaration parses and its reference is validated against the program's
+% defined relations (a `gen ... as NAME` view or a @prolog predicate), but the
+% materialise-and-cache runtime is a follow-on, so a program that uses it gets a
+% clear, specific diagnostic. An unknown reference is a distinct, earlier error.
+check_materialized_views(File, Program, Clauses) :-
+    plawk_program_materialize_views(Program, Names),
+    Names \== [],
+    !,
+    plawk_program_gen_blocks(Program, GenBlocks),
+    findall(GN, member(gen_block(name(GN), _, _), GenBlocks), ViewNames),
+    findall(PN, ( member(Clause, Clauses), materialize_clause_pred(Clause, PN) ),
+        PrologNames),
+    append(ViewNames, PrologNames, Defined),
+    (   member(N, Names), \+ memberchk(N, Defined)
+    ->  format(user_error,
+            'plawk: ~w declares `materialize ~w`, but no view (`gen ... as ~w`) \c
+             or @prolog relation named ~w is defined.~n',
+            [File, N, N, N]),
+        halt(2)
+    ;   format(user_error,
+            'plawk: ~w uses `materialize NAME` (a cached view). The surface \c
+             parses but its materialise-and-cache runtime is not yet \c
+             implemented; see PLAWK_MULTIPASS_CACHE.md section 3.9.~n',
+            [File]),
+        halt(2)
+    ).
+check_materialized_views(_File, _Program, _Clauses).
+
+% The predicate name a @prolog clause defines (a rule head or a bare fact).
+materialize_clause_pred((Head :- _Body), Name) :-
+    !,
+    functor(Head, Name, _).
+materialize_clause_pred(Head, Name) :-
+    callable(Head),
+    functor(Head, Name, _).
 
 % A generator block whose clauses can be synthesised at build time:
 %  - a pure block (`Source == none`) whose every action is a constant `emit`

--- a/examples/plawk/bin/plawk
+++ b/examples/plawk/bin/plawk
@@ -108,7 +108,6 @@ build(File, Out0, KeepLL) :-
     % removed; `GenFactClauses` are the synthesised facts.
     check_generator_blocks(File, Program2),
     resolve_generator_blocks(Program2, Program, GenFactClauses),
-    check_while_loops(File, Program),
     check_multitable_store(File, Program),
     check_query_reader(File, Program),
     % A query-reader program contributes synthesised findall-wrapper clauses
@@ -364,32 +363,6 @@ check_generator_blocks(File, Program) :-
         [File, Name]),
     halt(2).
 check_generator_blocks(_File, _Program).
-
-% while / do-while loops (plawk roadmap): `while (VAR CMP int) { BODY }` and
-% `do { BODY } while (VAR CMP int)` parse but their loop runtime -- mutable
-% scalar state iterated to a fixed point -- is not wired yet, so a program that
-% uses one gets a clear, specific diagnostic rather than the generic "outside
-% the multi-pass surface". Surface-first, mirroring the query reader / generator
-% arcs; see PLAWK_CONTROL_FLOW_PLAN.md for the runtime plan.
-check_while_loops(File, Program) :-
-    program_has_while(Program),
-    !,
-    format(user_error,
-        'plawk: ~w uses a `while` / `do-while` loop. Loops parse but their \c
-         runtime is not yet implemented; see PLAWK_CONTROL_FLOW_PLAN.md.~n',
-        [File]),
-    halt(2).
-check_while_loops(_File, _Program).
-
-% True if the program term contains a while_loop/2 or do_while_loop/2 anywhere
-% (rule body, BEGIN, END, pass, ...). A plain structural walk over the AST.
-program_has_while(while_loop(_, _)) :- !.
-program_has_while(do_while_loop(_, _)) :- !.
-program_has_while(Term) :-
-    compound(Term),
-    Term =.. [_ | Args],
-    member(Arg, Args),
-    program_has_while(Arg).
 
 % A generator block whose clauses can be synthesised at build time:
 %  - a pure block (`Source == none`) whose every action is a constant `emit`

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5859,6 +5859,8 @@ plawk_trim_control_tails([next | _Rest], [next]) :-
     !.
 plawk_trim_control_tails([break | _Rest], [break]) :-
     !.
+plawk_trim_control_tails([continue | _Rest], [continue]) :-
+    !.
 plawk_trim_control_tails([if(Pattern, ThenActions, ElseActions) | Rest],
         [if(Pattern, TrimmedThenActions, TrimmedElseActions) | TrimmedRest]) :-
     !,
@@ -5895,10 +5897,31 @@ plawk_action_has_control(if(_Pattern, ThenActions, ElseActions)) :-
     ).
 plawk_action_has_control(foreach_loop(_Layout, Body)) :-
     plawk_branch_actions_have_unsupported_control(Body).
+% A while/do-while loop consumes its own body's break/continue (loop-local), so
+% those do NOT make the loop-as-action carry control to the rule level; only a
+% `next` inside the body propagates (to the record loop).
 plawk_action_has_control(while_loop(_Cond, Body)) :-
-    plawk_branch_actions_have_unsupported_control(Body).
+    plawk_actions_have_next_control(Body).
 plawk_action_has_control(do_while_loop(Body, _Cond)) :-
-    plawk_branch_actions_have_unsupported_control(Body).
+    plawk_actions_have_next_control(Body).
+
+% True if some action reaches a bare `next` (recursing through ifs and nested
+% loops) -- `next` propagates past loops, break/continue do not.
+plawk_actions_have_next_control(Actions) :-
+    member(Action, Actions),
+    plawk_action_reaches_next(Action).
+
+plawk_action_reaches_next(next).
+plawk_action_reaches_next(if(_Pattern, ThenActions, ElseActions)) :-
+    ( plawk_actions_have_next_control(ThenActions)
+    ; plawk_actions_have_next_control(ElseActions)
+    ).
+plawk_action_reaches_next(while_loop(_Cond, Body)) :-
+    plawk_actions_have_next_control(Body).
+plawk_action_reaches_next(do_while_loop(Body, _Cond)) :-
+    plawk_actions_have_next_control(Body).
+plawk_action_reaches_next(foreach_loop(_Layout, Body)) :-
+    plawk_actions_have_next_control(Body).
 
 plawk_branch_actions_have_unsupported_control(Actions) :-
     plawk_trim_control_tails(Actions, TrimmedActions),
@@ -6291,6 +6314,10 @@ plawk_split_normalized_branch_control(Actions, BodyActions, branch_next) :-
     \+ plawk_actions_have_control(BodyActions).
 plawk_split_normalized_branch_control(Actions, BodyActions, branch_break) :-
     append(BodyActions, [break], Actions),
+    !,
+    \+ plawk_actions_have_control(BodyActions).
+plawk_split_normalized_branch_control(Actions, BodyActions, branch_continue) :-
+    append(BodyActions, [continue], Actions),
     !,
     \+ plawk_actions_have_control(BodyActions).
 plawk_split_normalized_branch_control(Actions, Actions, fallthrough) :-
@@ -11242,6 +11269,12 @@ plawk_scalar_action_sequence_pairs([next], _Slots, _AssocPlan, _FieldSeparator, 
 plawk_scalar_action_sequence_pairs([break], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, break, [branch_break(CurrentLabel, Values)]) -->
     [].
+% `continue` -- like break, it emits no IR of its own; the consumer branches
+% (plawk_branch_to_done_ir) to the enclosing loop's continue target, and the
+% loop consumes the branch_continue exit to wire its head/cond phi.
+plawk_scalar_action_sequence_pairs([continue], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
+        OpIndex, Values, Values, OpIndex, continue, [branch_continue(CurrentLabel, Values)]) -->
+    [].
 % foreach_loop: the one loop in the emitter stack. Loop-carried phis
 % for the element index and every scalar slot; the body memcpys the
 % current element into the staging area and runs one copy of the
@@ -11353,6 +11386,9 @@ plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
             format(atom(PhiValue), '%~w_slot_~w', [Base, SlotIndex])
           ),
           HeadValues),
+      % break -> after, continue -> head (re-test): push the loop context so a
+      % break/continue anywhere in the body branches to these labels.
+      plawk_loopctx_push(loop_ctx(AfterLabel, HeadLabel)),
       phrase(plawk_scalar_action_sequence_pairs(Body, Slots, AssocPlan,
           FieldSeparator, OutputSeparator, Base, BodyLabel, RuleIndex, 0,
           HeadValues, BodyOutValues, _InnerOpIndex, InnerExitLabel,
@@ -11361,11 +11397,14 @@ plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
       atomic_list_concat(BodyGlobalParts, '\n', GlobalIR),
       atomic_list_concat(BodyLineParts, '\n', BodyIR),
       plawk_branch_to_done_ir(InnerExitLabel, BodyDoneLabel, BodyDoneBrIR),
-      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BodyOutValues,
-          Base, EntryLabel, BodyDoneLabel, 0), HeadPhiLines),
-      atomic_list_concat(HeadPhiLines, '\n', HeadPhiIR),
-      % the condition reads the head-phi value of the condition variable
+      plawk_loopctx_pop,
+      plawk_partition_loop_exits(InnerNextExits, Breaks, Continues, RestExits),
+      % head phi carries continue values; the after phi carries break values
+      plawk_while_head_phi_ir(Slots, Values0, BodyOutValues, Continues,
+          Base, EntryLabel, BodyDoneLabel, HeadPhiIR),
       plawk_while_cond_ir(Cond, Slots, HeadValues, Base, CondVar, CondIR),
+      plawk_loop_after_ir(Slots, HeadValues, HeadLabel, Breaks, Base,
+          AfterValues, AfterPhiIR),
       format(atom(IR),
 '  br label %~w
 
@@ -11384,7 +11423,8 @@ plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
 ~w:
   br label %~w
 
-~w:',
+~w:
+~w',
           [EntryLabel,
            EntryLabel,
            HeadLabel,
@@ -11397,13 +11437,14 @@ plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
            BodyDoneBrIR,
            BodyDoneLabel,
            HeadLabel,
-           AfterLabel]),
+           AfterLabel,
+           AfterPhiIR]),
       NextOpIndex is OpIndex + 1
     },
     [GlobalIR-IR],
     plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
-        NextOpIndex, HeadValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
-    { append(InnerNextExits, RestNextExits, NextExits) }.
+        NextOpIndex, AfterValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
+    { append(RestExits, RestNextExits, NextExits) }.
 % do_while_loop: like while_loop but the condition tests AFTER the body, so the
 % body always runs at least once. The head phi sits at the top of the body
 % block; the condition reads the body's OUTPUT values (the exit values), since
@@ -12094,15 +12135,41 @@ plawk_i64_guarded_div_lines(LLVMOp, Base, LeftIR, RightIR, Lines) :-
 
 plawk_branch_to_done_ir(none, _DoneLabel, '  br label %continue_loop') :-
     !.
-plawk_branch_to_done_ir(break, _DoneLabel, '  br label %break_close_stream') :-
-    !.
+% `break` inside a loop leaves that loop (branch to its exit label); at rule
+% level it keeps its stream-break meaning. `continue` (only valid in a loop)
+% branches to the loop's continue target. The enclosing loop is read from the
+% loop-context stack (plawk_loopctx_current).
+plawk_branch_to_done_ir(break, _DoneLabel, IR) :-
+    !,
+    (   plawk_loopctx_current(loop_ctx(BreakLabel, _ContinueLabel))
+    ->  format(atom(IR), '  br label %~w', [BreakLabel])
+    ;   IR = '  br label %break_close_stream'
+    ).
+plawk_branch_to_done_ir(continue, _DoneLabel, IR) :-
+    !,
+    plawk_loopctx_current(loop_ctx(_BreakLabel, ContinueLabel)),
+    format(atom(IR), '  br label %~w', [ContinueLabel]).
 plawk_branch_to_done_ir(ExitLabel, DoneLabel, IR) :-
     ExitLabel \== none,
     ExitLabel \== break,
+    ExitLabel \== continue,
     format(atom(IR), '  br label %~w', [DoneLabel]).
+
+% The loop-context stack: each loop pushes loop_ctx(BreakLabel, ContinueLabel)
+% around its body, so a break/continue anywhere in the body (including nested
+% ifs) branches to the innermost loop's labels. Non-backtrackable global with
+% manual push/pop; nested loops stack naturally.
+plawk_loopctx_push(Ctx) :-
+    ( nb_current(plawk_loopctx, Stack) -> true ; Stack = [] ),
+    nb_setval(plawk_loopctx, [Ctx | Stack]).
+plawk_loopctx_pop :-
+    ( nb_current(plawk_loopctx, [_ | Stack]) -> nb_setval(plawk_loopctx, Stack) ; true ).
+plawk_loopctx_current(Ctx) :-
+    nb_current(plawk_loopctx, [Ctx | _]).
 
 plawk_branch_terminal_exit(none).
 plawk_branch_terminal_exit(break).
+plawk_branch_terminal_exit(continue).
 
 plawk_scalar_if_join_pairs(ThenExitLabel, _ThenValues, ElseExitLabel, _ElseValues, _Slots, _Prefix, _OpIndex, _Pairs) :-
     plawk_branch_terminal_exit(ThenExitLabel),
@@ -12195,6 +12262,77 @@ plawk_foreach_head_phi_lines([Slot | Slots], [InValue | InValues],
     [Line],
     plawk_foreach_head_phi_lines(Slots, InValues, OutValues, FeBase,
         EntryLabel, DoneLabel, NextIndex).
+
+%% Loop break/continue merge phis (PLAWK_CONTROL_FLOW_PLAN.md 3b) --------------
+
+% Partition a loop body's exits: loop-local `break` / `continue` (consumed by
+% the loop) vs everything else (`next`, propagated to the record loop).
+plawk_partition_loop_exits([], [], [], []).
+plawk_partition_loop_exits([branch_break(L, V) | R], [branch_break(L, V) | Bs], Cs, Ns) :-
+    !,
+    plawk_partition_loop_exits(R, Bs, Cs, Ns).
+plawk_partition_loop_exits([branch_continue(L, V) | R], Bs, [branch_continue(L, V) | Cs], Ns) :-
+    !,
+    plawk_partition_loop_exits(R, Bs, Cs, Ns).
+plawk_partition_loop_exits([X | R], Bs, Cs, [X | Ns]) :-
+    plawk_partition_loop_exits(R, Bs, Cs, Ns).
+
+% A `while` head phi per slot: the loop-carried value merges the pre-loop value
+% (from entry), the body's output (from the back edge), and each `continue`
+% point's value.
+plawk_while_head_phi_ir(Slots, InValues, OutValues, Continues, Base,
+        EntryLabel, BodyDoneLabel, IR) :-
+    phrase(plawk_while_head_phi_lines(Slots, InValues, OutValues, Continues,
+        Base, EntryLabel, BodyDoneLabel, 0), Lines),
+    atomic_list_concat(Lines, '\n', IR).
+
+plawk_while_head_phi_lines([], [], [], _Cs, _Base, _E, _BD, _) -->
+    [].
+plawk_while_head_phi_lines([Slot | Slots], [In | Ins], [Out | Outs], Continues,
+        Base, E, BD, I) -->
+    { plawk_slot_llvm_type(Slot, Type),
+      format(atom(BaseIncs), '[~w, %~w], [~w, %~w]', [In, E, Out, BD]),
+      plawk_loop_exit_incomings(Continues, I, ContIncs),
+      atomic_list_concat([BaseIncs | ContIncs], ', ', IncsIR),
+      format(atom(Line), '  %~w_slot_~w = phi ~w ~w', [Base, I, Type, IncsIR]),
+      I1 is I + 1
+    },
+    [Line],
+    plawk_while_head_phi_lines(Slots, Ins, Outs, Continues, Base, E, BD, I1).
+
+% The `after` block phi merging the normal loop exit (NormalValues from
+% NormalLabel) with each `break` point's value. No breaks -> no phi, and the
+% post-loop values are just the normal-exit values.
+plawk_loop_after_ir(_Slots, NormalValues, _NormalLabel, [], _Base, NormalValues, '') :-
+    !.
+plawk_loop_after_ir(Slots, NormalValues, NormalLabel, Breaks, Base, AfterValues, IR) :-
+    phrase(plawk_loop_after_phi_lines(Slots, NormalValues, NormalLabel, Breaks,
+        Base, 0), Lines),
+    atomic_list_concat(Lines, '\n', IR),
+    findall(V,
+        ( nth0(I, Slots, _), format(atom(V), '%~w_after_slot_~w', [Base, I]) ),
+        AfterValues).
+
+plawk_loop_after_phi_lines([], [], _NL, _Bs, _Base, _) -->
+    [].
+plawk_loop_after_phi_lines([Slot | Slots], [NV | NVs], NL, Breaks, Base, I) -->
+    { plawk_slot_llvm_type(Slot, Type),
+      format(atom(Normal), '[~w, %~w]', [NV, NL]),
+      plawk_loop_exit_incomings(Breaks, I, BreakIncs),
+      atomic_list_concat([Normal | BreakIncs], ', ', IncsIR),
+      format(atom(Line), '  %~w_after_slot_~w = phi ~w ~w', [Base, I, Type, IncsIR]),
+      I1 is I + 1
+    },
+    [Line],
+    plawk_loop_after_phi_lines(Slots, NVs, NL, Breaks, Base, I1).
+
+% One phi incoming per break/continue exit for slot I: [value-at-exit, %block].
+plawk_loop_exit_incomings([], _I, []).
+plawk_loop_exit_incomings([Exit | Rest], I, [Inc | Incs]) :-
+    Exit =.. [_Kind, Label, Values],
+    nth0(I, Values, V),
+    format(atom(Inc), '[~w, %~w]', [V, Label]),
+    plawk_loop_exit_incomings(Rest, I, Incs).
 
 replace_nth0(0, [_Old | Rest], Value, [Value | Rest]) :-
     !.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -9,6 +9,7 @@
     plawk_query_helper_name/3,
     plawk_query_helper_clause/4,
     plawk_program_query_passes/2,
+    plawk_program_materialize_views/2,
     plawk_program_gen_blocks/2,
     plawk_query_pass_supported/1,
     plawk_program_foreign_specs/3,
@@ -3984,6 +3985,13 @@ plawk_query_mixed_support_ir(Program, Options, SupportIR) :-
 plawk_program_query_passes(program_passes(_, Passes, _), QueryPasses) :-
     findall(pass_query(Q, B), member(pass_query(Q, B), Passes), QueryPasses).
 plawk_program_query_passes(program(_, _, _), []).
+
+%% plawk_program_materialize_views(+Program, -Names) is det.
+%  The names declared by `materialize NAME` (PLAWK_MULTIPASS_CACHE.md §3.9),
+%  in program order (empty if none). Surface-first: the runtime is a follow-on.
+plawk_program_materialize_views(program_passes(_, Passes, _), Names) :-
+    findall(Name, member(materialize(Name), Passes), Names).
+plawk_program_materialize_views(program(_, _, _), []).
 
 %% plawk_program_gen_blocks(+Program, -GenBlocks) is det.
 %  The `gen { ... } as name` generator blocks of a program (empty if none).

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -255,7 +255,8 @@ plawk_program_native_driver_ir(
     format(atom(CloseOkIR),
 'end_print:
 ~w
-  ret i32 0',
+  %plawk_exit_ec = load i32, i32* @plawk_exit_code
+  ret i32 %plawk_exit_ec',
         [FinalStatePhiIR]),
     plawk_emit_record_driver_ir(FieldSeparator, InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
@@ -299,7 +300,8 @@ plawk_program_native_driver_ir(
     format(atom(CloseOkIR),
 'end_print:
 ~w~w
-  ret i32 0',
+  %plawk_exit_ec = load i32, i32* @plawk_exit_code
+  ret i32 %plawk_exit_ec',
         [FinalStatePhiIR, EndPrintIR]),
     llvm_emit_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, LoopPhiIR, lowered_mixed,
@@ -347,7 +349,8 @@ plawk_program_native_driver_ir(
     format(atom(CloseOkIR),
 'end_print:
 ~w~w
-  ret i32 0',
+  %plawk_exit_ec = load i32, i32* @plawk_exit_code
+  ret i32 %plawk_exit_ec',
         [FinalStatePhiIR, EndPrintIR]),
     plawk_emit_record_driver_ir(FieldSeparator, InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
@@ -404,7 +407,8 @@ plawk_program_native_driver_ir(
     format(atom(CloseOkIR),
 'end_print:
 ~w~w
-  ret i32 0',
+  %plawk_exit_ec = load i32, i32* @plawk_exit_code
+  ret i32 %plawk_exit_ec',
         [FinalStatePhiIR, EndIfIR]),
     plawk_emit_record_driver_ir(FieldSeparator, InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
@@ -498,7 +502,8 @@ plawk_program_native_driver_ir(
     format(atom(CloseOkIR),
 'end_print:
 ~w~w
-  ret i32 0',
+  %plawk_exit_ec = load i32, i32* @plawk_exit_code
+  ret i32 %plawk_exit_ec',
         [FinalStatePhiIR, EndPrintIR]),
     plawk_emit_record_driver_ir(Descriptor, InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
@@ -543,7 +548,8 @@ plawk_program_native_driver_ir(
     format(atom(CloseOkIR),
 'end_print:
 ~w
-  ret i32 0',
+  %plawk_exit_ec = load i32, i32* @plawk_exit_code
+  ret i32 %plawk_exit_ec',
         [EndPrintIR]),
     plawk_emit_record_driver_ir(Descriptor, InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, RecordLoopPhiIR, lowered_assoc,
@@ -616,7 +622,8 @@ plawk_program_native_driver_ir(
     format(atom(CloseOkIR),
 'end_print:
 ~w
-  ret i32 0',
+  %plawk_exit_ec = load i32, i32* @plawk_exit_code
+  ret i32 %plawk_exit_ec',
         [EndPrintIR]),
     plawk_emit_record_driver_ir(FieldSeparator, InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, RecordLoopPhiIR, lowered_assoc,
@@ -5818,6 +5825,7 @@ plawk_i64_end_print_globals(SurfaceGlobals, RuntimeGlobals) :-
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 @.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
 @.plawk_surface_print_f64 = private constant [3 x i8] c"%g\\00"
+@plawk_exit_code = internal global i32 0
 ~w
 
 ',
@@ -5882,6 +5890,17 @@ plawk_split_normalized_terminal_control(Actions, BodyActions, terminal_break) :-
     append(BodyActions, [break], Actions),
     !,
     \+ plawk_actions_have_control(BodyActions).
+% A rule-level `exit [N]` is a terminal like `break`: it leaves the record loop
+% via break_close_stream (which runs END and returns @plawk_exit_code). Unlike
+% break, it has a side effect -- storing the code -- so the trailing exit is
+% replaced by an `exit_store(N)` marker kept in the body (the sequence walker
+% lowers it to just the store, no branch); the branch to break_close_stream
+% comes from the terminal_exit rule target.
+plawk_split_normalized_terminal_control(Actions, BodyActions, terminal_exit) :-
+    append(Prefix, [exit(int(Code))], Actions),
+    !,
+    \+ plawk_actions_have_control(Prefix),
+    append(Prefix, [exit_store(Code)], BodyActions).
 plawk_split_normalized_terminal_control(Actions, Actions, fallthrough) :-
     \+ plawk_actions_have_control(Actions).
 
@@ -5935,6 +5954,7 @@ plawk_branch_actions_have_unsupported_control(Actions) :-
 plawk_rule_target(fallthrough, NextLabel, NextLabel).
 plawk_rule_target(terminal_next, _NextLabel, continue_loop).
 plawk_rule_target(terminal_break, _NextLabel, break_close_stream).
+plawk_rule_target(terminal_exit, _NextLabel, break_close_stream).
 
 
 plawk_controls_have_break(Controls) :-
@@ -5952,7 +5972,9 @@ plawk_assoc_break_close_ir(Controls, IR) :-
 plawk_break_close_ir(StatePlan, RuleCount, Controls, BranchControlExits, BreakPredKind, BreakCloseIR, FinalStatePhiIR) :-
     plawk_state_plan_slots(StatePlan, Slots),
     (   plawk_controls_have_break(Controls)
+    ;   member(terminal_exit, Controls)
     ;   member(branch_break(_Label, _Values), BranchControlExits)
+    ;   member(branch_exit(_ExitLabel, _ExitValues), BranchControlExits)
     ),
     !,
     phrase(plawk_break_slot_phi_lines(Slots, RuleCount, Controls, BranchControlExits, BreakPredKind, 0), BreakSlotPhiLines),
@@ -5984,7 +6006,8 @@ plawk_break_slot_phi_lines([Slot | Rest], RuleCount, Controls, BranchControlExit
     { LastRuleIndex is RuleCount - 1,
       findall(Incoming,
           ( between(0, LastRuleIndex, RuleIndex),
-            nth0(RuleIndex, Controls, terminal_break),
+            nth0(RuleIndex, Controls, RuleControl),
+            memberchk(RuleControl, [terminal_break, terminal_exit]),
             plawk_break_predecessor_label(BreakPredKind, RuleIndex, PredLabel),
             format(atom(Incoming), '[%rule_~w_slot_~w, %~w]',
                 [RuleIndex, SlotIndex, PredLabel])
@@ -6002,7 +6025,10 @@ plawk_break_slot_phi_lines([Slot | Rest], RuleCount, Controls, BranchControlExit
     plawk_break_slot_phi_lines(Rest, RuleCount, Controls, BranchControlExits, BreakPredKind, NextSlotIndex).
 
 plawk_branch_break_phi_incomings([], _SlotIndex, []).
-plawk_branch_break_phi_incomings([branch_break(Label, Values) | Rest], SlotIndex, [Incoming | Incomings]) :-
+% `exit` reaches break_close_stream too (it runs END on the way out), so its
+% slot values merge into the break-close phi exactly like a break's.
+plawk_branch_break_phi_incomings([Exit | Rest], SlotIndex, [Incoming | Incomings]) :-
+    ( Exit = branch_break(Label, Values) ; Exit = branch_exit(Label, Values) ),
     !,
     nth0(SlotIndex, Values, Value),
     format(atom(Incoming), '[~w, %~w]', [Value, Label]),
@@ -6461,7 +6487,8 @@ plawk_mixed_scalar_next_phi_lines([Slot | Rest], RuleCount, Controls, BranchNext
       findall(ApplyIncoming,
           ( between(0, LastRuleIndex, RuleIndex),
             ( ( RuleIndex =:= LastRuleIndex,
-                \+ nth0(RuleIndex, Controls, terminal_break)
+                \+ ( nth0(RuleIndex, Controls, LastControl),
+                     memberchk(LastControl, [terminal_break, terminal_exit]) )
               )
             ; nth0(RuleIndex, Controls, terminal_next)
             ),
@@ -10252,7 +10279,7 @@ plawk_scalar_rule_input_phi_lines([Slot | Rest], RuleIndex, Controls, SlotIndex)
 
 plawk_terminal_control_skips_next_rule(Controls, RuleIndex) :-
     nth0(RuleIndex, Controls, Control),
-    memberchk(Control, [terminal_next, terminal_break]).
+    memberchk(Control, [terminal_next, terminal_break, terminal_exit]).
 
 plawk_scalar_rule_input_value(0, SlotIndex, Value) :-
     !,
@@ -10335,6 +10362,9 @@ plawk_scalar_rule_body_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
 plawk_scalar_rule_body_action(Action) :-
     plawk_dynrec_bind_ok(Action).
+% the store-only half of a rule-level `exit N` (terminal_exit split); it is a
+% plain store with no control, valid anywhere a plain body action is.
+plawk_scalar_rule_body_action(exit_store(_Code)).
 plawk_scalar_rule_body_action(Action) :-
     plawk_rule_body_print_action(Action).
 plawk_scalar_rule_body_action(writebin_out(Types, Fields)) :-
@@ -10361,6 +10391,11 @@ plawk_scalar_branch_body_actions(Actions) :-
 
 plawk_scalar_rule_body_plain_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
+% `exit [N]` inside a branch body (`if (c) exit`): the sequence walker lowers it
+% via branch_exit + plawk_branch_to_done_ir (branch to break_close_stream); the
+% store-only marker `exit_store` may appear when a branch ends the rule.
+plawk_scalar_rule_body_plain_action(exit(int(_Code))).
+plawk_scalar_rule_body_plain_action(exit_store(_Code)).
 % a structured-return destructure inside a branch body: the sequence
 % walker lowers dynrec_bind wherever it appears (its slots/call IR is
 % branch-position-independent), so branch-body validation accepts it
@@ -11321,6 +11356,26 @@ plawk_scalar_action_sequence_pairs([break], _Slots, _AssocPlan, _FieldSeparator,
 plawk_scalar_action_sequence_pairs([continue], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, continue, [branch_continue(CurrentLabel, Values)]) -->
     [].
+% `exit N` -- store the exit code, then leave the program via break_close_stream
+% (which runs END and returns the code). The branch_exit exit carries the slot
+% values at the exit point so END sees them (merged into the break_close phi
+% exactly like a break), but a loop does NOT consume it -- exit always ends the
+% program, so it propagates past any enclosing loop.
+plawk_scalar_action_sequence_pairs([exit(int(Code))], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
+        OpIndex, Values, Values, OpIndex, exit, [branch_exit(CurrentLabel, Values)]) -->
+    { format(atom(StoreIR), '  store i32 ~w, i32* @plawk_exit_code', [Code]) },
+    [''-StoreIR].
+% `exit_store(N)` -- the store-only half of a rule-level `exit N` (the terminal
+% control split leaves this in the body; the branch to break_close_stream comes
+% from the terminal_exit rule target). It emits just the store and falls through
+% -- control reaches the rule's done block, which branches to break_close_stream.
+plawk_scalar_action_sequence_pairs([exit_store(Code) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { format(atom(StoreIR), '  store i32 ~w, i32* @plawk_exit_code', [Code]),
+      NextOpIndex is OpIndex + 1 },
+    [''-StoreIR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits).
 % foreach_loop: the one loop in the emitter stack. Loop-carried phis
 % for the element index and every scalar slot; the body memcpys the
 % current element into the staging area and runs one copy of the
@@ -12210,10 +12265,15 @@ plawk_branch_to_done_ir(continue, _DoneLabel, IR) :-
     !,
     plawk_loopctx_current(loop_ctx(_BreakLabel, ContinueLabel)),
     format(atom(IR), '  br label %~w', [ContinueLabel]).
+% `exit` ends the program regardless of any enclosing loop: always branch to
+% break_close_stream (which runs END and returns @plawk_exit_code).
+plawk_branch_to_done_ir(exit, _DoneLabel, '  br label %break_close_stream') :-
+    !.
 plawk_branch_to_done_ir(ExitLabel, DoneLabel, IR) :-
     ExitLabel \== none,
     ExitLabel \== break,
     ExitLabel \== continue,
+    ExitLabel \== exit,
     format(atom(IR), '  br label %~w', [DoneLabel]).
 
 % The loop-context stack: each loop pushes loop_ctx(BreakLabel, ContinueLabel)
@@ -12231,6 +12291,9 @@ plawk_loopctx_current(Ctx) :-
 plawk_branch_terminal_exit(none).
 plawk_branch_terminal_exit(break).
 plawk_branch_terminal_exit(continue).
+% `exit` inside an if branch leaves via break_close_stream, so (like break) that
+% branch does not flow into the if-join phi -- the join takes the other branch.
+plawk_branch_terminal_exit(exit).
 
 plawk_scalar_if_join_pairs(ThenExitLabel, _ThenValues, ElseExitLabel, _ElseValues, _Slots, _Prefix, _OpIndex, _Pairs) :-
     plawk_branch_terminal_exit(ThenExitLabel),
@@ -12417,7 +12480,8 @@ plawk_scalar_next_phi_lines([Slot | Rest], RuleCount, Controls, BranchNextExits,
       findall(ApplyIncoming,
           ( between(0, LastRuleIndex, RuleIndex),
             ( ( RuleIndex =:= LastRuleIndex,
-                \+ nth0(RuleIndex, Controls, terminal_break)
+                \+ ( nth0(RuleIndex, Controls, LastControl),
+                     memberchk(LastControl, [terminal_break, terminal_exit]) )
               )
             ; nth0(RuleIndex, Controls, terminal_next)
             ),

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -10377,6 +10377,14 @@ plawk_scalar_rule_body_plain_action(writebin_arm_out(_Tag, ArmTypes, Fields)) :-
 % lowers nested ifs recursively, so validation recurses the same way.
 plawk_scalar_rule_body_plain_action(if(Pattern, ThenActions, ElseActions)) :-
     plawk_scalar_rule_body_action(if(Pattern, ThenActions, ElseActions)).
+% a loop may nest inside another loop body (`while (..) { while (..) { .. } }`);
+% the sequence walker lowers the inner loop recursively, so validation recurses.
+plawk_scalar_rule_body_plain_action(while_loop(Cond, Body)) :-
+    plawk_scalar_rule_body_action(while_loop(Cond, Body)).
+plawk_scalar_rule_body_plain_action(do_while_loop(Body, Cond)) :-
+    plawk_scalar_rule_body_action(do_while_loop(Body, Cond)).
+plawk_scalar_rule_body_plain_action(foreach_loop(Layout, Body)) :-
+    plawk_scalar_rule_body_action(foreach_loop(Layout, Body)).
 
 plawk_rule_body_print_action(print(Fields)) :-
     Fields = [_ | _],
@@ -11500,6 +11508,8 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
             format(atom(PhiValue), '%~w_slot_~w', [Base, SlotIndex])
           ),
           HeadValues),
+      % break -> after, continue -> body_done (which re-tests the condition)
+      plawk_loopctx_push(loop_ctx(AfterLabel, BodyDoneLabel)),
       phrase(plawk_scalar_action_sequence_pairs(Body, Slots, AssocPlan,
           FieldSeparator, OutputSeparator, Base, BodyLabel, RuleIndex, 0,
           HeadValues, BodyOutValues, _InnerOpIndex, InnerExitLabel,
@@ -11508,11 +11518,20 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
       atomic_list_concat(BodyGlobalParts, '\n', GlobalIR),
       atomic_list_concat(BodyLineParts, '\n', BodyIR),
       plawk_branch_to_done_ir(InnerExitLabel, BodyDoneLabel, BodyDoneBrIR),
-      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BodyOutValues,
+      plawk_loopctx_pop,
+      plawk_partition_loop_exits(InnerNextExits, Breaks, Continues, RestExits),
+      % body_done merges the normal body output (from the body's exit block) with
+      % each continue point, and the condition tests that merged value; the head
+      % phi's back edge and the `after` block read it too.
+      format(atom(BdBase), '~w_bd', [Base]),
+      plawk_loop_after_ir(Slots, BodyOutValues, InnerExitLabel, Continues,
+          BdBase, BdValues, BdPhiIR),
+      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BdValues,
           Base, EntryLabel, BodyDoneLabel, 0), HeadPhiLines),
       atomic_list_concat(HeadPhiLines, '\n', HeadPhiIR),
-      % the condition reads the body's output value of the condition variable
-      plawk_while_cond_ir(Cond, Slots, BodyOutValues, Base, CondVar, CondIR),
+      plawk_while_cond_ir(Cond, Slots, BdValues, Base, CondVar, CondIR),
+      plawk_loop_after_ir(Slots, BdValues, BodyDoneLabel, Breaks, Base,
+          AfterValues, AfterPhiIR),
       format(atom(IR),
 '  br label %~w
 
@@ -11526,9 +11545,11 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
 
 ~w:
 ~w
+~w
   br i1 ~w, label %~w, label %~w
 
-~w:',
+~w:
+~w',
           [EntryLabel,
            EntryLabel,
            BodyLabel,
@@ -11537,15 +11558,17 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
            BodyIR,
            BodyDoneBrIR,
            BodyDoneLabel,
+           BdPhiIR,
            CondIR,
            CondVar, BodyLabel, AfterLabel,
-           AfterLabel]),
+           AfterLabel,
+           AfterPhiIR]),
       NextOpIndex is OpIndex + 1
     },
     [GlobalIR-IR],
     plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
-        NextOpIndex, BodyOutValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
-    { append(InnerNextExits, RestNextExits, NextExits) }.
+        NextOpIndex, AfterValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
+    { append(RestExits, RestNextExits, NextExits) }.
 plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest],
         Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex, OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
     { format(atom(GlobalBase), '~w_if_~w', [Prefix, OpIndex]),

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4936,6 +4936,23 @@ plawk_while_cond_operand(var(Name), Slots, CondValues, Ref) :-
     !,
     nth0(Idx, CondValues, Ref).
 
+%% plawk_if_cond_ir(+Cond, +Slots, +Values0, +FieldSeparator, +GlobalBase,
+%%     -CondValue, -GuardGlobalIR-GuardIR)
+%
+%  Lower an `if` condition to an i1 (CondValue). A `scalar_if(_)` condition is a
+%  scalar comparison over slots -- lowered like a loop condition, reading the
+%  current slot SSA values (Values0). A field/pattern guard is lowered by the
+%  existing pattern-guard emitter (which reads the record).
+plawk_if_cond_ir(scalar_if(Cond), Slots, Values0, _FieldSeparator, GlobalBase,
+        CondValue, ''-GuardIR) :-
+    !,
+    plawk_while_cond_ir(Cond, Slots, Values0, GlobalBase, CondValue, GuardIR).
+plawk_if_cond_ir(Pattern, _Slots, _Values0, FieldSeparator, GlobalBase,
+        CondValue, GuardGlobalIR-GuardIR) :-
+    format(atom(CondValue), '%~w_cond', [GlobalBase]),
+    plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, CondValue,
+        GuardGlobalIR-GuardIR).
+
 % Surface comparison op -> ordered LLVM fcmp predicate (row values are finite,
 % so ordered comparisons are correct; a NaN column fails every guard).
 plawk_fcmp_pred(eq, oeq).
@@ -5998,6 +6015,11 @@ plawk_scalar_update_name_expr(if(_Pattern, ThenActions, ElseActions), Name, Expr
     ; member(Action, ElseActions)
     ),
     plawk_scalar_update_name_expr(Action, Name, Expr).
+% a scalar `if` condition (`if (i > 2)`) references scalar variables -- each
+% needs an i64 slot, exactly like a loop condition.
+plawk_scalar_update_name_expr(if(scalar_if(Cond), _Then, _Else), Name, int(0)) :-
+    plawk_while_cond_vars(Cond, CondVars),
+    member(Name, CondVars).
 plawk_scalar_update_name_expr(foreach_loop(_Layout, Body), Name, Expr) :-
     member(Action, Body),
     plawk_scalar_update_name_expr(Action, Name, Expr).
@@ -10943,6 +10965,9 @@ plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
     ; member(Action, ElseActions)
     ),
     plawk_scalar_update_action_name(Action, Name).
+plawk_scalar_update_action_name(if(scalar_if(Cond), _Then, _Else), Name) :-
+    plawk_while_cond_vars(Cond, CondVars),
+    member(Name, CondVars).
 plawk_scalar_update_action_name(foreach_loop(_Layout, Body), Name) :-
     member(Action, Body),
     plawk_scalar_update_action_name(Action, Name).
@@ -11388,8 +11413,8 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
 plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest],
         Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex, OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
     { format(atom(GlobalBase), '~w_if_~w', [Prefix, OpIndex]),
-      format(atom(CondValue), '%~w_if_~w_cond', [Prefix, OpIndex]),
-      plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, CondValue, GuardGlobalIR-GuardIR),
+      plawk_if_cond_ir(Pattern, Slots, Values0, FieldSeparator, GlobalBase,
+          CondValue, GuardGlobalIR-GuardIR),
       format(atom(ThenLabel), '~w_if_~w_then', [Prefix, OpIndex]),
       format(atom(ElseLabel), '~w_if_~w_else', [Prefix, OpIndex]),
       format(atom(DoneLabel), '~w_if_~w_done', [Prefix, OpIndex]),

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -9865,11 +9865,34 @@ plawk_end_print_string_global_lines([string(Value) | Rest], Index) -->
     },
     [Line],
     plawk_end_print_string_global_lines(Rest, NextIndex).
+% a concatenation's string operands emit globals under the same
+% PrintIndex*1000 + part index scheme the END concat print uses.
+plawk_end_print_string_global_lines([concat(Parts) | Rest], Index) -->
+    plawk_end_concat_string_globals(Parts, Index, 0),
+    { NextIndex is Index + 1 },
+    plawk_end_print_string_global_lines(Rest, NextIndex).
 plawk_end_print_string_global_lines([Field | Rest], Index) -->
     { \+ Field = string(_),
+      \+ Field = concat(_),
       NextIndex is Index + 1
     },
     plawk_end_print_string_global_lines(Rest, NextIndex).
+
+plawk_end_concat_string_globals([], _Index, _PartIndex) -->
+    [].
+plawk_end_concat_string_globals([string(Value) | Rest], Index, PartIndex) -->
+    { CombinedIndex is Index * 1000 + PartIndex,
+      format(atom(GlobalName), 'plawk_end_print_string_~w', [CombinedIndex]),
+      llvm_emit_c_string_global(GlobalName, Value, Line, _StringLen, _BytesLen),
+      NextPartIndex is PartIndex + 1
+    },
+    [Line],
+    plawk_end_concat_string_globals(Rest, Index, NextPartIndex).
+plawk_end_concat_string_globals([Part | Rest], Index, PartIndex) -->
+    { \+ Part = string(_),
+      NextPartIndex is PartIndex + 1
+    },
+    plawk_end_concat_string_globals(Rest, Index, NextPartIndex).
 
 plawk_assoc_print_key_global_lines([], _) -->
     [].
@@ -10116,6 +10139,11 @@ plawk_mixed_end_print_lines([string(Value) | Rest], ScalarPlan, AssocPlan, Outpu
     plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
 
 plawk_scalar_print_expr(var(Name), Name).
+% a concatenation contributes each operand's scalar reads (so a printed scalar
+% inside `print a $1 b` gets a slot).
+plawk_scalar_print_expr(concat(Parts), Name) :-
+    member(Part, Parts),
+    plawk_scalar_print_expr(Part, Name).
 plawk_scalar_print_expr(Expr, Name) :-
     plawk_end_scalar_expr(Expr),
     plawk_expr_scalar_read_name(Expr, Name).
@@ -10359,6 +10387,11 @@ plawk_rule_body_print_action(printf(string(Format), Args)) :-
 
 plawk_rule_body_print_field(field(_)).
 plawk_rule_body_print_field(string(_)).
+% a string concatenation (`print $1 $2`): every operand must be a valid print
+% field; they are emitted adjacently with no separator.
+plawk_rule_body_print_field(concat(Parts)) :-
+    Parts = [_, _ | _],
+    maplist(plawk_rule_body_print_field, Parts).
 % a bare scalar variable read (`print i`): substitution rewrites var(Name) to
 % the slot's SSA value at emit time, so a scalar can be printed directly. Only
 % names that resolve to a slot compile; a non-slot var fails substitution.
@@ -10917,6 +10950,11 @@ plawk_substitute_operation_reads(set(Expr0), Slots, Values, set(Expr)) :-
     plawk_substitute_scalar_reads(Expr0, Slots, Values, Expr).
 plawk_substitute_operation_reads(Operation, _Slots, _Values, Operation).
 
+plawk_substitute_scalar_reads(concat(Parts), Slots, Values, concat(SubParts)) :-
+    !,
+    maplist(plawk_substitute_scalar_read_part(Slots, Values), Parts, SubParts).
+plawk_substitute_scalar_read_part(Slots, Values, Part, SubPart) :-
+    plawk_substitute_scalar_reads(Part, Slots, Values, SubPart).
 plawk_substitute_scalar_reads(var(Name), Slots, Values, Substituted) :-
     !,
     nth0(SlotIndex, Slots, Slot),
@@ -12498,6 +12536,50 @@ plawk_scalar_end_print_lines([string(Value) | Rest], StatePlan, OutputSeparator,
     plawk_end_string_print_lines(Value, PrintIndex),
     { NextPrintIndex is PrintIndex + 1 },
     plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
+% concatenation in END (`print "total: " sum`): one leading separator, then each
+% operand printed adjacently (no separator between). Each part uses a unique
+% index (PrintIndex*1000 + part) so the fixed-name emitters don't collide.
+plawk_scalar_end_print_lines([concat(Parts) | Rest], StatePlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
+    plawk_end_concat_parts(Parts, StatePlan, PrintIndex, 0),
+    { NextPrintIndex is PrintIndex + 1 },
+    plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
+
+plawk_end_concat_parts([], _StatePlan, _PrintIndex, _PartIndex) -->
+    [].
+plawk_end_concat_parts([Part | Rest], StatePlan, PrintIndex, PartIndex) -->
+    { CombinedIndex is PrintIndex * 1000 + PartIndex },
+    plawk_end_field_print_lines(Part, StatePlan, CombinedIndex),
+    { NextPartIndex is PartIndex + 1 },
+    plawk_end_concat_parts(Rest, StatePlan, PrintIndex, NextPartIndex).
+
+% One END print field WITHOUT a leading separator (the concat driver adds the
+% single separator before the whole concatenation).
+plawk_end_field_print_lines(var(Name), StatePlan, PrintIndex) -->
+    { plawk_state_slot_lookup(StatePlan, Name, SlotIndex, Slot),
+      format(atom(ValueIR), '%final_slot_~w', [SlotIndex]),
+      ( Slot = scalar_double(_Name)
+      -> format(atom(FmtVar), 'end_f64_fmt_~w', [PrintIndex]),
+         format(atom(FmtPtr),
+             '  %~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_f64, i32 0, i32 0',
+             [FmtVar]),
+         format(atom(PrintCall),
+             '  %printed_end_f64_~w = call i32 (i8*, ...) @printf(i8* %~w, double ~w)',
+             [PrintIndex, FmtVar, ValueIR])
+      ;  format(atom(FmtVar), 'end_i64_fmt_~w', [PrintIndex]),
+         format(atom(PrintVar), 'printed_end_i64_~w', [PrintIndex]),
+         llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
+             [FmtPtr, PrintCall])
+      )
+    },
+    [FmtPtr, PrintCall].
+plawk_end_field_print_lines(string(Value), _StatePlan, PrintIndex) -->
+    plawk_end_string_print_lines(Value, PrintIndex).
+plawk_end_field_print_lines(special('NR'), _StatePlan, PrintIndex) -->
+    plawk_end_nr_print_lines(PrintIndex).
+plawk_end_field_print_lines(Expr, StatePlan, PrintIndex) -->
+    { plawk_end_scalar_expr(Expr) },
+    plawk_end_expr_print_lines(Expr, StatePlan, PrintIndex).
 
 plawk_end_nr_print_lines(PrintIndex) -->
     { format(atom(FmtVar), 'end_nr_fmt_~w', [PrintIndex]),
@@ -13039,6 +13121,9 @@ plawk_fields_include_nr(Fields) :-
     plawk_expr_uses_nr(Field).
 
 plawk_expr_uses_nr(special('NR')).
+plawk_expr_uses_nr(concat(Parts)) :-
+    member(Part, Parts),
+    plawk_expr_uses_nr(Part).
 plawk_expr_uses_nr(Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
     ( plawk_expr_uses_nr(Left)
@@ -13275,6 +13360,12 @@ plawk_print_field_ir(Field, FieldSeparator, Index) -->
     },
     [GlobalIR-BodyIR].
 
+% A concatenation prints its operands adjacently -- NO field separator between
+% them (that is what distinguishes `print $1 $2` from `print $1, $2`). Each part
+% lowers via the ordinary print-field emitter under a unique sub-prefix.
+plawk_prefixed_print_field_ir(concat(Parts), FieldSeparator, Prefix, Index) -->
+    { format(atom(ConcatPrefix), '~w_concat_~w', [Prefix, Index]) },
+    plawk_concat_parts_ir(Parts, FieldSeparator, ConcatPrefix, 0).
 plawk_prefixed_print_field_ir(Field, FieldSeparator, Prefix, Index) -->
     { plawk_emit_prefixed_print_expr_ir(Field, FieldSeparator, Prefix, Index,
           Type, GlobalParts, SetupParts),
@@ -13284,6 +13375,13 @@ plawk_prefixed_print_field_ir(Field, FieldSeparator, Prefix, Index) -->
       atomic_list_concat(BodyParts, '\n', BodyIR)
     },
     [GlobalIR-BodyIR].
+
+plawk_concat_parts_ir([], _FieldSeparator, _Prefix, _PartIndex) -->
+    [].
+plawk_concat_parts_ir([Part | Rest], FieldSeparator, Prefix, PartIndex) -->
+    plawk_prefixed_print_field_ir(Part, FieldSeparator, Prefix, PartIndex),
+    { NextIndex is PartIndex + 1 },
+    plawk_concat_parts_ir(Rest, FieldSeparator, Prefix, NextIndex).
 
 plawk_emit_print_expr_ir(Field, FieldSeparator, Index, Type, GlobalParts, SetupParts) :-
     plawk_emit_print_expr_for_context(Field, FieldSeparator, print_context(normal, '', Index),

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -354,6 +354,63 @@ plawk_program_native_driver_ir(
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
+% END { if (COND) print ...; [else print ...] } -- a scalar-guarded print in the
+% END block. COND is a scalar comparison over the final slot values; each branch
+% is a single print. Same lowering as the scalar END-print clause above, but the
+% end_print body is the if (condition + then/else print blocks) instead of a
+% plain print. The state plan sees every field the branches print plus the
+% condition variables (so their slots exist).
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules0, [end([if(scalar_if(Cond), ThenActions, ElseActions)])]),
+    InputPath,
+    DriverIR
+) :-
+    plawk_end_if_ok(ThenActions, ElseActions),
+    plawk_end_if_print_fields(Cond, ThenActions, ElseActions, PrintFields),
+    plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules1, WritebinPlan),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_resolve_dynrec_view_rules(Rules1, Rules1b),
+    plawk_resolve_foreach_rules(FieldSeparator, Rules1b, Rules),
+    plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR0),
+    plawk_writebin_entry_lines(WritebinPlan, WritebinEntryIR),
+    plawk_join_nonempty_ir([BeginIR0, WritebinEntryIR], BeginIR),
+    plawk_record_program_ok(FieldSeparator, Rules, PrintFields),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
+    plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator,
+        RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    plawk_rules_writebin_exprs(Rules, WritebinExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs0),
+    append(PrintExprs0, WritebinExprs, PrintExprs),
+    append(PrintExprs, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
+    plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
+    plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
+    plawk_scalar_rule_controls(Rules, ScalarRuleControls),
+    plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, NextPhiIR),
+    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, done,
+        BreakCloseIR, FinalStatePhiIR),
+    plawk_scalar_end_if_ir(Cond, ThenActions, ElseActions, StatePlan,
+        FieldSeparator, OutputSeparator, EndIfGlobalIR, EndIfIR),
+    plawk_writebin_globals(WritebinPlan, WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, EndIfGlobalIR, RuleGlobalIR, WritebinGlobalIR]),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w~w
+  ret i32 0',
+        [FinalStatePhiIR, EndIfIR]),
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
+        driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
+            NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 % Tag-guard sugar: with a union BINFMT, plain rules whose patterns lead
 % with TAG == K are shorthand for case blocks -- the tag test selects
 % the arm and the rest of the pattern stays as the rule's own guard, so
@@ -12191,6 +12248,75 @@ plawk_branch_next_phi_incomings([_Exit | Rest], SlotIndex, Incomings) :-
 plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, IR) :-
     phrase(plawk_scalar_end_print_lines(PrintFields, StatePlan, OutputSeparator, 0), Lines),
     atomic_list_concat(Lines, '\n', IR).
+
+%% END { if (COND) print ...; [else print ...] } support ---------------------
+
+% A supported END-if: each branch is a single print (else optional).
+plawk_end_if_ok([print(_)], []).
+plawk_end_if_ok([print(_)], [print(_)]).
+
+% The scalar fields the state plan must see: the branch print fields (so a
+% printed scalar gets a slot) plus the condition variables. String literals need
+% no slot, but leaving them in is harmless -- the state plan ignores non-vars.
+plawk_end_if_print_fields(Cond, ThenActions, ElseActions, Fields) :-
+    plawk_end_if_branch_fields(ThenActions, ThenFields),
+    plawk_end_if_branch_fields(ElseActions, ElseFields),
+    plawk_while_cond_vars(Cond, CondVars),
+    plawk_vars_as_fields(CondVars, CondFields),
+    append([ThenFields, ElseFields, CondFields], Fields).
+
+plawk_end_if_branch_fields([print(Fields)], Fields).
+plawk_end_if_branch_fields([], []).
+
+plawk_vars_as_fields([], []).
+plawk_vars_as_fields([V | Vs], [var(V) | Fs]) :-
+    plawk_vars_as_fields(Vs, Fs).
+
+% The END-if body IR: evaluate COND against the final slot values, branch to a
+% then/else print block, join. Each branch print uses the PREFIXED print emitter
+% (unique names per branch, so the two blocks' temporaries don't collide) with
+% scalar reads substituted to their final-slot SSA values. Returns the string
+% globals the branch prints need, plus the body IR.
+plawk_scalar_end_if_ir(Cond, ThenActions, ElseActions, StatePlan, FieldSeparator,
+        OutputSeparator, GlobalIR, IR) :-
+    plawk_state_plan_slots(StatePlan, Slots),
+    plawk_final_slot_values(StatePlan, FinalValues),
+    plawk_while_cond_ir(Cond, Slots, FinalValues, plawk_endif, CondVar, CondIR),
+    plawk_end_if_branch_ir(ThenActions, Slots, FinalValues, FieldSeparator,
+        OutputSeparator, plawk_endif_then, ThenGlobal, ThenIR),
+    plawk_end_if_branch_ir(ElseActions, Slots, FinalValues, FieldSeparator,
+        OutputSeparator, plawk_endif_else, ElseGlobal, ElseIR),
+    plawk_join_nonempty_ir([ThenGlobal, ElseGlobal], GlobalIR),
+    format(atom(IR),
+'~w
+  br i1 ~w, label %plawk_endif_then, label %plawk_endif_else
+
+plawk_endif_then:
+~w
+  br label %plawk_endif_done
+
+plawk_endif_else:
+~w
+  br label %plawk_endif_done
+
+plawk_endif_done:',
+        [CondIR, CondVar, ThenIR, ElseIR]).
+
+plawk_end_if_branch_ir([print(Fields)], Slots, FinalValues, FieldSeparator,
+        OutputSeparator, Prefix, GlobalIR, IR) :-
+    maplist(plawk_substitute_print_field(Slots, FinalValues), Fields, SubFields),
+    plawk_prefixed_print_action_ir(SubFields, FieldSeparator, OutputSeparator,
+        Prefix, GlobalIR-IR).
+plawk_end_if_branch_ir([], _Slots, _FinalValues, _FieldSeparator,
+        _OutputSeparator, _Prefix, '', '').
+
+% The final (post-loop) slot values, one per slot: %final_slot_0, %final_slot_1,
+% ... -- the values the END block reads.
+plawk_final_slot_values(StatePlan, Values) :-
+    plawk_state_plan_slots(StatePlan, Slots),
+    findall(V,
+        ( nth0(I, Slots, _Slot), format(atom(V), '%final_slot_~w', [I]) ),
+        Values).
 
 plawk_scalar_end_print_lines([], _StatePlan, _OutputSeparator, _) -->
     { llvm_emit_printf0(plawk_surface_print_newline, 2,

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -207,6 +207,60 @@ print_line:
             success, 'success:\n  ret i32 0'),
         DriverIR).
 
+% A body-printing scalar rule chain with NO END block: all output comes from
+% the per-record body (e.g. `{ i = 0; while (i < 3) { print i; i++ } }`). Same
+% lowering as the scalar END-print chain but with an empty print list and NO
+% end_print body -- the end_print block just returns 0 (no trailing newline).
+% Requires a genuine scalar plan (a rule that updates state or prints in its
+% body); writebin-only / query / single-action programs match their own
+% clauses above.
+plawk_program_native_driver_ir(
+    program(BeginClauses, Rules0, []),
+    InputPath,
+    DriverIR
+) :-
+    \+ plawk_begin_has_binfmt(BeginClauses),
+    is_list(Rules0),
+    plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules1, WritebinPlan),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    plawk_resolve_dynrec_view_rules(Rules1, Rules1b),
+    plawk_resolve_foreach_rules(FieldSeparator, Rules1b, Rules),
+    plawk_scalar_state_plan(Rules, [], StatePlan),
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR0),
+    plawk_writebin_entry_lines(WritebinPlan, WritebinEntryIR),
+    plawk_join_nonempty_ir([BeginIR0, WritebinEntryIR], BeginIR),
+    plawk_record_program_ok(FieldSeparator, Rules, []),
+    plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator,
+        RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    plawk_rules_writebin_exprs(Rules, WritebinExprs),
+    append(BodyPrintFields, WritebinExprs, PrintExprs0),
+    append(PrintExprs0, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
+    plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
+    plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
+    plawk_scalar_rule_controls(Rules, ScalarRuleControls),
+    plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, NextPhiIR),
+    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, done,
+        BreakCloseIR, FinalStatePhiIR),
+    plawk_writebin_globals(WritebinPlan, WritebinGlobalIR),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, RuleGlobalIR, WritebinGlobalIR]),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w
+  ret i32 0',
+        [FinalStatePhiIR]),
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
+        driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
+            NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
+        DriverIR).
+
 plawk_program_native_driver_ir(
     program(BeginClauses, Rules, [end([print(PrintFields)])]),
     InputPath,
@@ -4791,6 +4845,29 @@ plawk_icmp_pred(le, sle).
 plawk_icmp_pred(gt, sgt).
 plawk_icmp_pred(ge, sge).
 
+%% plawk_while_cond_ok(+Cond) is semidet.
+%
+%  A supported loop condition: `VAR CMP int(N)` over an i64 comparison.
+plawk_while_cond_ok(cmp(var(_V), Op, int(N))) :-
+    integer(N),
+    plawk_icmp_pred(Op, _Pred).
+
+%% plawk_while_cond_ir(+Cond, +Slots, +CondValues, +Base, -CondVar, -IR)
+%
+%  Emit the loop-condition icmp. The condition variable's current value is the
+%  slot value in CondValues (head-phi values for `while`, body-output values
+%  for `do-while`); compare it against the integer bound.
+plawk_while_cond_ir(cmp(var(CondName), Op, int(N)), Slots, CondValues, Base,
+        CondVar, IR) :-
+    nth0(Idx, Slots, Slot),
+    plawk_slot_name(Slot, CondName),
+    !,
+    nth0(Idx, CondValues, CondValRef),
+    plawk_icmp_pred(Op, Pred),
+    format(atom(CondVar), '%~w_cond', [Base]),
+    format(atom(IR), '  ~w = icmp ~w i64 ~w, ~w',
+        [CondVar, Pred, CondValRef, N]).
+
 % Surface comparison op -> ordered LLVM fcmp predicate (row values are finite,
 % so ordered comparisons are correct; a NaN column fails every guard).
 plawk_fcmp_pred(eq, oeq).
@@ -5676,6 +5753,10 @@ plawk_action_has_control(if(_Pattern, ThenActions, ElseActions)) :-
     ).
 plawk_action_has_control(foreach_loop(_Layout, Body)) :-
     plawk_branch_actions_have_unsupported_control(Body).
+plawk_action_has_control(while_loop(_Cond, Body)) :-
+    plawk_branch_actions_have_unsupported_control(Body).
+plawk_action_has_control(do_while_loop(Body, _Cond)) :-
+    plawk_branch_actions_have_unsupported_control(Body).
 
 plawk_branch_actions_have_unsupported_control(Actions) :-
     plawk_trim_control_tails(Actions, TrimmedActions),
@@ -5852,6 +5933,16 @@ plawk_scalar_update_name_expr(if(_Pattern, ThenActions, ElseActions), Name, Expr
 plawk_scalar_update_name_expr(foreach_loop(_Layout, Body), Name, Expr) :-
     member(Action, Body),
     plawk_scalar_update_name_expr(Action, Name, Expr).
+% while/do-while: the condition variable gets an i64 slot (it is compared with
+% an integer), plus any scalar the body updates.
+plawk_scalar_update_name_expr(while_loop(cmp(var(CondVar), _Op, _N), Body), Name, Expr) :-
+    ( Name = CondVar, Expr = int(0)
+    ; member(Action, Body), plawk_scalar_update_name_expr(Action, Name, Expr)
+    ).
+plawk_scalar_update_name_expr(do_while_loop(Body, cmp(var(CondVar), _Op, _N)), Name, Expr) :-
+    ( Name = CondVar, Expr = int(0)
+    ; member(Action, Body), plawk_scalar_update_name_expr(Action, Name, Expr)
+    ).
 
 plawk_scalar_double_fixpoint(Updates, Doubles0, Doubles) :-
     findall(Name,
@@ -5978,6 +6069,10 @@ plawk_action_body_print_field(if(_Pattern, ThenActions, ElseActions), Field) :-
     ;   plawk_actions_body_print_field(ElseActions, Field)
     ).
 plawk_action_body_print_field(foreach_loop(_Layout, Body), Field) :-
+    plawk_actions_body_print_field(Body, Field).
+plawk_action_body_print_field(while_loop(_Cond, Body), Field) :-
+    plawk_actions_body_print_field(Body, Field).
+plawk_action_body_print_field(do_while_loop(Body, _Cond), Field) :-
     plawk_actions_body_print_field(Body, Field).
 
 plawk_mixed_planned_rules([], _AssocPlan, _Index) -->
@@ -7733,6 +7828,12 @@ plawk_binfmt_action_ok(Descriptor, writebin_arm_out(_Tag, ArmTypes, Fields)) :-
     !,
     plawk_binfmt_writebin_args_ok(Descriptor, ArmTypes, Fields).
 plawk_binfmt_action_ok(Descriptor, foreach_loop(_Layout, Body)) :-
+    !,
+    plawk_binfmt_actions_ok(Descriptor, Body).
+plawk_binfmt_action_ok(Descriptor, while_loop(_Cond, Body)) :-
+    !,
+    plawk_binfmt_actions_ok(Descriptor, Body).
+plawk_binfmt_action_ok(Descriptor, do_while_loop(Body, _Cond)) :-
     !,
     plawk_binfmt_actions_ok(Descriptor, Body).
 
@@ -10040,6 +10141,12 @@ plawk_scalar_rule_body_action(writebin_arm_out(_Tag, ArmTypes, Fields)) :-
     plawk_writebin_args_ok(ArmTypes, Fields).
 plawk_scalar_rule_body_action(foreach_loop(_Layout, Body)) :-
     plawk_scalar_branch_body_actions(Body).
+plawk_scalar_rule_body_action(while_loop(Cond, Body)) :-
+    plawk_while_cond_ok(Cond),
+    plawk_scalar_branch_body_actions(Body).
+plawk_scalar_rule_body_action(do_while_loop(Body, Cond)) :-
+    plawk_while_cond_ok(Cond),
+    plawk_scalar_branch_body_actions(Body).
 plawk_scalar_rule_body_action(if(_Pattern, ThenActions, ElseActions)) :-
     append(ThenActions, ElseActions, Actions),
     Actions \== [],
@@ -10078,6 +10185,10 @@ plawk_rule_body_print_action(printf(string(Format), Args)) :-
 
 plawk_rule_body_print_field(field(_)).
 plawk_rule_body_print_field(string(_)).
+% a bare scalar variable read (`print i`): substitution rewrites var(Name) to
+% the slot's SSA value at emit time, so a scalar can be printed directly. Only
+% names that resolve to a slot compile; a non-slot var fails substitution.
+plawk_rule_body_print_field(var(_)).
 plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(int(field(_))).
@@ -10767,6 +10878,14 @@ plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
 plawk_scalar_update_action_name(foreach_loop(_Layout, Body), Name) :-
     member(Action, Body),
     plawk_scalar_update_action_name(Action, Name).
+plawk_scalar_update_action_name(while_loop(cmp(var(CondVar), _Op, _N), Body), Name) :-
+    ( Name = CondVar
+    ; member(Action, Body), plawk_scalar_update_action_name(Action, Name)
+    ).
+plawk_scalar_update_action_name(do_while_loop(Body, cmp(var(CondVar), _Op, _N)), Name) :-
+    ( Name = CondVar
+    ; member(Action, Body), plawk_scalar_update_action_name(Action, Name)
+    ).
 
 plawk_expr_scalar_read_name(var(Name), Name).
 plawk_expr_scalar_read_name(Expr, Name) :-
@@ -11064,6 +11183,139 @@ plawk_scalar_action_sequence_pairs([foreach_loop(Layout, Body) | Rest],
     [GlobalIR-IR],
     plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
         NextOpIndex, HeadValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
+    { append(InnerNextExits, RestNextExits, NextExits) }.
+% while_loop: a surface loop. Loop-carried head phis for every scalar slot
+% (modelled on foreach_loop's head-phi machinery -- no memory slots needed).
+% The condition tests the condition variable's head-phi value BEFORE the body,
+% so the loop may run zero times; the exit values are the head phis themselves.
+% (PLAWK_CONTROL_FLOW_PLAN.md PR 2.)
+plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
+        Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { format(atom(Base), '~w_while_~w', [Prefix, OpIndex]),
+      format(atom(EntryLabel), '~w_entry', [Base]),
+      format(atom(HeadLabel), '~w_head', [Base]),
+      format(atom(BodyLabel), '~w_body', [Base]),
+      format(atom(BodyDoneLabel), '~w_body_done', [Base]),
+      format(atom(AfterLabel), '~w_after', [Base]),
+      findall(PhiValue,
+          ( nth0(SlotIndex, Slots, _Slot),
+            format(atom(PhiValue), '%~w_slot_~w', [Base, SlotIndex])
+          ),
+          HeadValues),
+      phrase(plawk_scalar_action_sequence_pairs(Body, Slots, AssocPlan,
+          FieldSeparator, OutputSeparator, Base, BodyLabel, RuleIndex, 0,
+          HeadValues, BodyOutValues, _InnerOpIndex, InnerExitLabel,
+          InnerNextExits), BodyPairs),
+      pairs_keys_values(BodyPairs, BodyGlobalParts, BodyLineParts),
+      atomic_list_concat(BodyGlobalParts, '\n', GlobalIR),
+      atomic_list_concat(BodyLineParts, '\n', BodyIR),
+      plawk_branch_to_done_ir(InnerExitLabel, BodyDoneLabel, BodyDoneBrIR),
+      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BodyOutValues,
+          Base, EntryLabel, BodyDoneLabel, 0), HeadPhiLines),
+      atomic_list_concat(HeadPhiLines, '\n', HeadPhiIR),
+      % the condition reads the head-phi value of the condition variable
+      plawk_while_cond_ir(Cond, Slots, HeadValues, Base, CondVar, CondIR),
+      format(atom(IR),
+'  br label %~w
+
+~w:
+  br label %~w
+
+~w:
+~w
+~w
+  br i1 ~w, label %~w, label %~w
+
+~w:
+~w
+~w
+
+~w:
+  br label %~w
+
+~w:',
+          [EntryLabel,
+           EntryLabel,
+           HeadLabel,
+           HeadLabel,
+           HeadPhiIR,
+           CondIR,
+           CondVar, BodyLabel, AfterLabel,
+           BodyLabel,
+           BodyIR,
+           BodyDoneBrIR,
+           BodyDoneLabel,
+           HeadLabel,
+           AfterLabel]),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
+        NextOpIndex, HeadValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
+    { append(InnerNextExits, RestNextExits, NextExits) }.
+% do_while_loop: like while_loop but the condition tests AFTER the body, so the
+% body always runs at least once. The head phi sits at the top of the body
+% block; the condition reads the body's OUTPUT values (the exit values), since
+% control reaches `after` from the post-body condition test.
+plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
+        Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { format(atom(Base), '~w_dowhile_~w', [Prefix, OpIndex]),
+      format(atom(EntryLabel), '~w_entry', [Base]),
+      format(atom(BodyLabel), '~w_body', [Base]),
+      format(atom(BodyDoneLabel), '~w_body_done', [Base]),
+      format(atom(AfterLabel), '~w_after', [Base]),
+      findall(PhiValue,
+          ( nth0(SlotIndex, Slots, _Slot),
+            format(atom(PhiValue), '%~w_slot_~w', [Base, SlotIndex])
+          ),
+          HeadValues),
+      phrase(plawk_scalar_action_sequence_pairs(Body, Slots, AssocPlan,
+          FieldSeparator, OutputSeparator, Base, BodyLabel, RuleIndex, 0,
+          HeadValues, BodyOutValues, _InnerOpIndex, InnerExitLabel,
+          InnerNextExits), BodyPairs),
+      pairs_keys_values(BodyPairs, BodyGlobalParts, BodyLineParts),
+      atomic_list_concat(BodyGlobalParts, '\n', GlobalIR),
+      atomic_list_concat(BodyLineParts, '\n', BodyIR),
+      plawk_branch_to_done_ir(InnerExitLabel, BodyDoneLabel, BodyDoneBrIR),
+      phrase(plawk_foreach_head_phi_lines(Slots, Values0, BodyOutValues,
+          Base, EntryLabel, BodyDoneLabel, 0), HeadPhiLines),
+      atomic_list_concat(HeadPhiLines, '\n', HeadPhiIR),
+      % the condition reads the body's output value of the condition variable
+      plawk_while_cond_ir(Cond, Slots, BodyOutValues, Base, CondVar, CondIR),
+      format(atom(IR),
+'  br label %~w
+
+~w:
+  br label %~w
+
+~w:
+~w
+~w
+~w
+
+~w:
+~w
+  br i1 ~w, label %~w, label %~w
+
+~w:',
+          [EntryLabel,
+           EntryLabel,
+           BodyLabel,
+           BodyLabel,
+           HeadPhiIR,
+           BodyIR,
+           BodyDoneBrIR,
+           BodyDoneLabel,
+           CondIR,
+           CondVar, BodyLabel, AfterLabel,
+           AfterLabel]),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AfterLabel, RuleIndex,
+        NextOpIndex, BodyOutValues, Values, FinalOpIndex, ExitLabel, RestNextExits),
     { append(InnerNextExits, RestNextExits, NextExits) }.
 plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest],
         Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex, OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
@@ -12710,6 +12962,14 @@ plawk_emit_print_expr_for_context(int(field(FieldIndex)), FieldSeparator, Contex
     plawk_print_expr_value_base(Context, int, Base),
     plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
     plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, Base,
+        ValueIR, GlobalParts, SetupParts).
+% a substituted scalar read (var(Name) -> ssa(SlotValue)): print the i64 SSA
+% value directly. This is what makes `print i` work for a scalar slot.
+plawk_emit_print_expr_for_context(ssa(Value), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, int, Base),
+    plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(ssa(Value), FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(Expr, FieldSeparator, Context,

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4847,26 +4847,86 @@ plawk_icmp_pred(ge, sge).
 
 %% plawk_while_cond_ok(+Cond) is semidet.
 %
-%  A supported loop condition: `VAR CMP int(N)` over an i64 comparison.
-plawk_while_cond_ok(cmp(var(_V), Op, int(N))) :-
-    integer(N),
-    plawk_icmp_pred(Op, _Pred).
+%  A supported loop condition: scalar comparisons (`VAR CMP int` or
+%  `VAR CMP VAR`) combined with `and` / `or` (PLAWK_CONTROL_FLOW_PLAN.md PR 3).
+plawk_while_cond_ok(and(A, B)) :-
+    !,
+    plawk_while_cond_ok(A),
+    plawk_while_cond_ok(B).
+plawk_while_cond_ok(or(A, B)) :-
+    !,
+    plawk_while_cond_ok(A),
+    plawk_while_cond_ok(B).
+plawk_while_cond_ok(cmp(var(_V), Op, Rhs)) :-
+    plawk_icmp_pred(Op, _Pred),
+    plawk_while_cond_rhs_ok(Rhs).
+
+plawk_while_cond_rhs_ok(int(N)) :- integer(N).
+plawk_while_cond_rhs_ok(var(_W)).
+
+%% plawk_while_cond_vars(+Cond, -Vars)
+%
+%  Every scalar variable named in the condition (both sides of every
+%  comparison) -- each must get an i64 slot.
+plawk_while_cond_vars(and(A, B), Vars) :-
+    !,
+    plawk_while_cond_vars(A, VA),
+    plawk_while_cond_vars(B, VB),
+    append(VA, VB, Vars).
+plawk_while_cond_vars(or(A, B), Vars) :-
+    !,
+    plawk_while_cond_vars(A, VA),
+    plawk_while_cond_vars(B, VB),
+    append(VA, VB, Vars).
+plawk_while_cond_vars(cmp(var(V), _Op, int(_N)), [V]) :- !.
+plawk_while_cond_vars(cmp(var(V), _Op, var(W)), [V, W]).
 
 %% plawk_while_cond_ir(+Cond, +Slots, +CondValues, +Base, -CondVar, -IR)
 %
-%  Emit the loop-condition icmp. The condition variable's current value is the
-%  slot value in CondValues (head-phi values for `while`, body-output values
-%  for `do-while`); compare it against the integer bound.
-plawk_while_cond_ir(cmp(var(CondName), Op, int(N)), Slots, CondValues, Base,
-        CondVar, IR) :-
-    nth0(Idx, Slots, Slot),
-    plawk_slot_name(Slot, CondName),
+%  Emit the loop-condition test as a block of IR lines ending in an i1 value
+%  (CondVar). Each variable's current value is its slot value in CondValues
+%  (head-phi values for `while`, body-output values for `do-while`);
+%  comparisons are i64 icmps, combined with `and`/`or i1`.
+plawk_while_cond_ir(Cond, Slots, CondValues, Base, CondVar, IR) :-
+    plawk_while_cond_build(Cond, Slots, CondValues, Base, '', CondVar, Lines),
+    atomic_list_concat(Lines, '\n', IR).
+
+plawk_while_cond_build(and(A, B), Slots, CV, Base, Path, CondVar, Lines) :-
     !,
-    nth0(Idx, CondValues, CondValRef),
+    atom_concat(Path, 'l', PA),
+    atom_concat(Path, 'r', PB),
+    plawk_while_cond_build(A, Slots, CV, Base, PA, VA, LA),
+    plawk_while_cond_build(B, Slots, CV, Base, PB, VB, LB),
+    format(atom(CondVar), '%~w_cond~w', [Base, Path]),
+    format(atom(Line), '  ~w = and i1 ~w, ~w', [CondVar, VA, VB]),
+    append([LA, LB, [Line]], Lines).
+plawk_while_cond_build(or(A, B), Slots, CV, Base, Path, CondVar, Lines) :-
+    !,
+    atom_concat(Path, 'l', PA),
+    atom_concat(Path, 'r', PB),
+    plawk_while_cond_build(A, Slots, CV, Base, PA, VA, LA),
+    plawk_while_cond_build(B, Slots, CV, Base, PB, VB, LB),
+    format(atom(CondVar), '%~w_cond~w', [Base, Path]),
+    format(atom(Line), '  ~w = or i1 ~w, ~w', [CondVar, VA, VB]),
+    append([LA, LB, [Line]], Lines).
+plawk_while_cond_build(cmp(var(CondName), Op, Rhs), Slots, CondValues, Base,
+        Path, CondVar, [Line]) :-
+    plawk_while_cond_operand(var(CondName), Slots, CondValues, LOperand),
+    plawk_while_cond_operand(Rhs, Slots, CondValues, ROperand),
     plawk_icmp_pred(Op, Pred),
-    format(atom(CondVar), '%~w_cond', [Base]),
-    format(atom(IR), '  ~w = icmp ~w i64 ~w, ~w',
-        [CondVar, Pred, CondValRef, N]).
+    format(atom(CondVar), '%~w_cond~w', [Base, Path]),
+    format(atom(Line), '  ~w = icmp ~w i64 ~w, ~w',
+        [CondVar, Pred, LOperand, ROperand]).
+
+% An operand is either an integer literal (emitted inline) or a loop variable
+% (read from its slot's current SSA value).
+plawk_while_cond_operand(int(N), _Slots, _CondValues, N) :-
+    !.
+plawk_while_cond_operand(var(Name), Slots, CondValues, Ref) :-
+    nth0(Idx, Slots, Slot),
+    plawk_slot_name(Slot, Name),
+    !,
+    nth0(Idx, CondValues, Ref).
 
 % Surface comparison op -> ordered LLVM fcmp predicate (row values are finite,
 % so ordered comparisons are correct; a NaN column fails every guard).
@@ -5933,14 +5993,14 @@ plawk_scalar_update_name_expr(if(_Pattern, ThenActions, ElseActions), Name, Expr
 plawk_scalar_update_name_expr(foreach_loop(_Layout, Body), Name, Expr) :-
     member(Action, Body),
     plawk_scalar_update_name_expr(Action, Name, Expr).
-% while/do-while: the condition variable gets an i64 slot (it is compared with
-% an integer), plus any scalar the body updates.
-plawk_scalar_update_name_expr(while_loop(cmp(var(CondVar), _Op, _N), Body), Name, Expr) :-
-    ( Name = CondVar, Expr = int(0)
+% while/do-while: every condition variable gets an i64 slot (each is compared
+% numerically), plus any scalar the body updates.
+plawk_scalar_update_name_expr(while_loop(Cond, Body), Name, Expr) :-
+    ( plawk_while_cond_vars(Cond, CondVars), member(Name, CondVars), Expr = int(0)
     ; member(Action, Body), plawk_scalar_update_name_expr(Action, Name, Expr)
     ).
-plawk_scalar_update_name_expr(do_while_loop(Body, cmp(var(CondVar), _Op, _N)), Name, Expr) :-
-    ( Name = CondVar, Expr = int(0)
+plawk_scalar_update_name_expr(do_while_loop(Body, Cond), Name, Expr) :-
+    ( plawk_while_cond_vars(Cond, CondVars), member(Name, CondVars), Expr = int(0)
     ; member(Action, Body), plawk_scalar_update_name_expr(Action, Name, Expr)
     ).
 
@@ -10878,12 +10938,12 @@ plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
 plawk_scalar_update_action_name(foreach_loop(_Layout, Body), Name) :-
     member(Action, Body),
     plawk_scalar_update_action_name(Action, Name).
-plawk_scalar_update_action_name(while_loop(cmp(var(CondVar), _Op, _N), Body), Name) :-
-    ( Name = CondVar
+plawk_scalar_update_action_name(while_loop(Cond, Body), Name) :-
+    ( plawk_while_cond_vars(Cond, CondVars), member(Name, CondVars)
     ; member(Action, Body), plawk_scalar_update_action_name(Action, Name)
     ).
-plawk_scalar_update_action_name(do_while_loop(Body, cmp(var(CondVar), _Op, _N)), Name) :-
-    ( Name = CondVar
+plawk_scalar_update_action_name(do_while_loop(Body, Cond), Name) :-
+    ( plawk_while_cond_vars(Cond, CondVars), member(Name, CondVars)
     ; member(Action, Body), plawk_scalar_update_action_name(Action, Name)
     ).
 

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1842,9 +1842,18 @@ print_action(print(Fields)) -->
 % contributes the value of E to the generated relation's solution set. Parses
 % to emit(Expr) reusing the print field-expression grammar (a field, number,
 % string, or arithmetic expression). Explicit emission keeps the value typed
-% (design doc section 2.1); a tuple emit (`emit (A, B)` -> arity 2) is a
-% follow-on. `emit` is only meaningful inside a `gen { ... }` block; the
-% codegen (bin/plawk) rejects it elsewhere until the runtime lands.
+% (design doc section 2.1). `emit` is only meaningful inside a `gen { ... }`
+% block; the codegen (bin/plawk) rejects it elsewhere.
+%
+% A TUPLE emit (`emit (A, B, ...)` -> a row of the generated relation, arity n)
+% parses to emit(tuple([V1, ..., Vn])). Tried first -- the `(` after `emit`
+% distinguishes it. Tuple elements are constants (integer or string literals);
+% a computed tuple element is a runtime-collection follow-on.
+emit_action(emit(tuple([V0, V1 | Vs]))) -->
+    "emit", required_ws, "(", ws,
+    emit_tuple_value(V0), ws, ",", ws, emit_tuple_value(V1),
+    emit_tuple_rest(Vs), ws, ")",
+    !.
 emit_action(emit(Expr)) -->
     "emit",
     required_ws,
@@ -1856,6 +1865,21 @@ emit_action(emit(int(N))) -->
     "emit",
     required_ws,
     signed_integer_value(N).
+
+% The remaining elements of a tuple emit, comma-separated.
+emit_tuple_rest([V | Vs]) -->
+    ws, ",", ws, emit_tuple_value(V),
+    !,
+    emit_tuple_rest(Vs).
+emit_tuple_rest([]) -->
+    [].
+% A tuple element: an integer or string literal (constants only for now).
+emit_tuple_value(int(N)) -->
+    signed_integer_value(N),
+    !.
+emit_tuple_value(string(S)) -->
+    quoted_string(Codes),
+    { string_codes(S, Codes) }.
 
 printf_action(printf(string(Format), Args)) -->
     "printf",

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -342,6 +342,17 @@ gen_over_binding(Vars) -->
     !.
 gen_over_binding([V]) -->
     identifier(V).
+% A `materialize NAME` declaration (PLAWK_MULTIPASS_CACHE.md §3.9): mark a
+% derived relation (a view produced by a `gen ... as NAME` block, or a @prolog
+% relation) as materialised-and-cached -- its projected/filtered rows are
+% computed once into a shared table and reused by every query pass that reads
+% it, instead of re-running the goal per consumer. Parses to materialize(Name);
+% the runtime is a follow-on (surface-first, like the query-reader / generator
+% arcs), so bin/plawk currently emits a clean not-yet diagnostic.
+pass_clauses([materialize(Name) | Rest]) -->
+    "materialize", identifier_boundary, ws,
+    identifier(Name), ws,
+    pass_clauses(Rest).
 % A `pass { ACTIONS }` block is one pass carrying a single always-rule with
 % those actions (per-pattern rules within a pass are a later extension).
 pass_clauses([pass([rule(always, Actions)]) | Rest]) -->
@@ -365,6 +376,8 @@ plawk_pass_dynentry_rewrite(_DynEntries, pass_query(Q, Body), pass_query(Q, Body
 % A `gen { ... } as name` generator block -- pass it through (its body is
 % lowered by the generator runtime in a later PR).
 plawk_pass_dynentry_rewrite(_DynEntries, gen_block(N, S, Body), gen_block(N, S, Body)).
+% A `materialize NAME` declaration has no rule actions -- pass it through.
+plawk_pass_dynentry_rewrite(_DynEntries, materialize(Name), materialize(Name)).
 
 %% dynentry_decls(-Names)//
 %

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1422,6 +1422,9 @@ action_sep_scan(yes) -->
     [].
 
 action(Action) -->
+    do_while_action(Action),
+    !.
+action(Action) -->
     while_action(Action),
     !.
 action(Action) -->
@@ -1496,6 +1499,19 @@ while_action(while_loop(cmp(var(V), Op, int(N)), Body)) -->
     identifier(V), ws, numeric_cmp_op(Op), ws, signed_integer_value(N), ws,
     ")", ws,
     action_block(Body).
+
+% A `do { BODY } while (VAR CMP int)` loop -- the body runs at least once, then
+% repeats while the condition holds (the awk do-while control structure). Parses
+% to do_while_loop(Body, cmp(var(V), Op, int(N))). Surface only, like `while`;
+% both share the same loop runtime (a later PR). Tried via its own action
+% clause; the leading `do` keyword distinguishes it.
+do_while_action(do_while_loop(Body, cmp(var(V), Op, int(N)))) -->
+    "do", identifier_boundary, ws,
+    action_block(Body), ws,
+    "while", identifier_boundary, ws,
+    "(", ws,
+    identifier(V), ws, numeric_cmp_op(Op), ws, signed_integer_value(N), ws,
+    ")".
 
 if_action(if(Pattern, ThenActions, ElseActions)) -->
     "if",

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1547,10 +1547,10 @@ action(Action) -->
 % the general action block, and the codegen (bin/plawk) rejects it with a clean
 % not-yet diagnostic until the loop runtime lands. The condition is a scalar
 % comparison for now; a general boolean condition is a follow-on.
-while_action(while_loop(cmp(var(V), Op, int(N)), Body)) -->
+while_action(while_loop(Cond, Body)) -->
     "while", identifier_boundary, ws,
     "(", ws,
-    identifier(V), ws, numeric_cmp_op(Op), ws, signed_integer_value(N), ws,
+    while_condition(Cond), ws,
     ")", ws,
     action_block(Body).
 
@@ -1559,13 +1559,50 @@ while_action(while_loop(cmp(var(V), Op, int(N)), Body)) -->
 % to do_while_loop(Body, cmp(var(V), Op, int(N))). Surface only, like `while`;
 % both share the same loop runtime (a later PR). Tried via its own action
 % clause; the leading `do` keyword distinguishes it.
-do_while_action(do_while_loop(Body, cmp(var(V), Op, int(N)))) -->
+do_while_action(do_while_loop(Body, Cond)) -->
     "do", identifier_boundary, ws,
     action_block(Body), ws,
     "while", identifier_boundary, ws,
     "(", ws,
-    identifier(V), ws, numeric_cmp_op(Op), ws, signed_integer_value(N), ws,
+    while_condition(Cond), ws,
     ")".
+
+% A loop condition: scalar comparisons (`VAR CMP int` or `VAR CMP VAR`) combined
+% with `&&` / `||`. `&&` binds tighter than `||` (awk precedence). A single
+% `VAR CMP int` still parses to the bare `cmp(...)` term, so the earlier runtime
+% is a strict subset. (PLAWK_CONTROL_FLOW_PLAN.md PR 3.)
+while_condition(Cond) -->
+    while_cond_and(First),
+    while_cond_or_rest(First, Cond).
+
+while_cond_or_rest(Acc, Cond) -->
+    ws, "||", ws, !,
+    while_cond_and(Next),
+    while_cond_or_rest(or(Acc, Next), Cond).
+while_cond_or_rest(Cond, Cond) -->
+    [].
+
+while_cond_and(Cond) -->
+    while_cmp(First),
+    while_cond_and_rest(First, Cond).
+
+while_cond_and_rest(Acc, Cond) -->
+    ws, "&&", ws, !,
+    while_cmp(Next),
+    while_cond_and_rest(and(Acc, Next), Cond).
+while_cond_and_rest(Cond, Cond) -->
+    [].
+
+% A scalar comparison: the left side is a loop variable; the right side is an
+% integer literal or another loop variable.
+while_cmp(cmp(var(V), Op, Rhs)) -->
+    identifier(V), ws, numeric_cmp_op(Op), ws, while_cmp_rhs(Rhs).
+
+while_cmp_rhs(int(N)) -->
+    signed_integer_value(N),
+    !.
+while_cmp_rhs(var(W)) -->
+    identifier(W).
 
 if_action(if(Pattern, ThenActions, ElseActions)) -->
     "if",

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1330,6 +1330,12 @@ forin_accum_operand(_Array, _Key, int(Value)) -->
 end_action(Action) -->
     for_in_action(Action),
     !.
+% a scalar-guarded print in END: `if (n > 1) print ...` [`else print ...`].
+% The condition is a scalar comparison (END has no current record), lowered
+% against the final slot values; each branch is a single print.
+end_action(Action) -->
+    if_action(Action),
+    !.
 end_action(Action) -->
     print_action(Action).
 

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1422,6 +1422,9 @@ action_sep_scan(yes) -->
     [].
 
 action(Action) -->
+    while_action(Action),
+    !.
+action(Action) -->
     if_action(Action),
     !.
 action(Action) -->
@@ -1480,6 +1483,20 @@ action(Action) -->
 %  awk conditionals: `else` is optional (an absent else parses as an
 %  empty branch), and `else if` chains nest as a single-element else
 %  branch containing the next if.
+% A `while (VAR CMP int) { BODY }` loop -- iterate the body while a scalar
+% variable compares to an integer bound (the awk `while` control structure).
+% Parses to while_loop(cmp(var(V), Op, int(N)), Body). This is the SURFACE
+% (mirrors the query reader / generator surface-first PRs): the loop body reuses
+% the general action block, and the codegen (bin/plawk) rejects it with a clean
+% not-yet diagnostic until the loop runtime lands. The condition is a scalar
+% comparison for now; a general boolean condition is a follow-on.
+while_action(while_loop(cmp(var(V), Op, int(N)), Body)) -->
+    "while", identifier_boundary, ws,
+    "(", ws,
+    identifier(V), ws, numeric_cmp_op(Op), ws, signed_integer_value(N), ws,
+    ")", ws,
+    action_block(Body).
+
 if_action(if(Pattern, ThenActions, ElseActions)) -->
     "if",
     ws,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -476,7 +476,7 @@ function_def((Head :- Body)) -->
     ws,
     "(",
     ws,
-    function_params(Params),
+    function_params(Params, ParamTypes),
     ws,
     ")",
     ws,
@@ -488,45 +488,66 @@ function_def((Head :- Body)) -->
     function_expr(Params, Pairs, ArithTerm),
     action_block_close,
     { pairs_values(Pairs, Vars),
-      % awk auto-coercion: a function body is `Result is ArithTerm`, so every
-      % parameter is used numerically. Text fields arrive as atoms (e.g. '5'),
-      % which `is/2` would reject -- so the head takes a fresh var per param and
-      % coerces it to a number (`number(H) -> V = H ; atom_number(H, V)`) before
-      % the arithmetic. A typed i64 arg (BINFMT mode) is already a number, so it
-      % passes through unchanged; a text field is parsed. No engine change; the
-      % coercion is local to the synthesised clause (PLAWK_AWK_FEATURE_AUDIT.md
-      % gap 2, decision: auto-coerce).
-      length(Vars, NParams),
-      length(HeadVars, NParams),
-      maplist(plawk_fn_coerce_goal, HeadVars, Vars, CoerceGoals),
+      % awk auto-coercion (PLAWK_AWK_FEATURE_AUDIT.md gap 2): a function body is
+      % `Result is ArithTerm`, so every parameter is used numerically. Text
+      % fields arrive as atoms (e.g. '5'), which `is/2` would reject -- so an
+      % UNTYPED parameter takes a fresh head var that is coerced to a number
+      % (`number(H) -> V = H ; atom_number(H, V)`) before the arithmetic.
+      %
+      % An OPTIONAL type annotation (`function f(num x)`) is a typed-fast path:
+      % the declared param is already numeric, so the head var IS the value var
+      % -- no coercion goal at all (Principle 2: static type knowledge elides
+      % the runtime coercion). The dynamic default (auto-coerce) stays for
+      % unannotated params; the annotation buys the elision, layered on top.
+      maplist(plawk_fn_param_binding, ParamTypes, Vars, HeadVars, CoerceGoals0),
+      exclude(==(true), CoerceGoals0, CoerceGoals),
       append(HeadVars, [Result], HeadArgs),
       Head =.. [Name | HeadArgs],
       append(CoerceGoals, [Result is ArithTerm], BodyGoals),
       plawk_conjunction(BodyGoals, Body)
     }.
 
-% The per-parameter numeric coercion goal: pass a number through, parse an atom.
-plawk_fn_coerce_goal(Head, Value,
+% Per-parameter head-var binding. Untyped: a fresh head var coerced to a number.
+% Typed (numeric): the head var IS the value var, so no coercion goal (`true`,
+% filtered out) -- the declared arg is already the right type.
+plawk_fn_param_binding(untyped, Value, Head,
     (number(Head) -> Value = Head ; atom_number(Head, Value))).
+plawk_fn_param_binding(number, Value, Value, true).
 
 % Fold a non-empty goal list into a Prolog conjunction.
 plawk_conjunction([Goal], Goal) :- !.
 plawk_conjunction([Goal | Goals], (Goal, Rest)) :-
     plawk_conjunction(Goals, Rest).
 
-function_params([Param | Params]) -->
-    identifier(Param),
-    function_params_rest(Params).
+function_params([Param | Params], [Type | Types]) -->
+    function_param(Param, Type),
+    function_params_rest(Params, Types).
 
-function_params_rest([Param | Params]) -->
+function_params_rest([Param | Params], [Type | Types]) -->
     ws,
     ",",
     ws,
     !,
-    identifier(Param),
-    function_params_rest(Params).
-function_params_rest([]) -->
+    function_param(Param, Type),
+    function_params_rest(Params, Types).
+function_params_rest([], []) -->
     [].
+
+% A parameter is an identifier, optionally prefixed by a numeric type keyword
+% (`num` / `int` / `float`). The typed form is tried first; it backtracks to an
+% untyped param when the keyword is actually the parameter's own name (e.g.
+% `function f(num)` -- `num` is the name, not a type).
+function_param(Name, number) -->
+    param_type_keyword,
+    identifier_boundary,
+    ws,
+    identifier(Name).
+function_param(Name, untyped) -->
+    identifier(Name).
+
+param_type_keyword --> "num".
+param_type_keyword --> "int".
+param_type_keyword --> "float".
 
 % arithmetic over the parameters, with awk precedence: * / % bind
 % tighter than + -, both associate left, parentheses group

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -287,21 +287,24 @@ query_var_list_rest([V | Vs]) -->
     query_var_list_rest(Vs).
 query_var_list_rest([]) -->
     [].
-% A `gen over query(SRC(V)) as v { BODY } as name` generator with an input
-% iterator (PLAWK_GENERATOR_BLOCKS.md, PR 3): a producer that transforms another
-% relation. Each solution of the source goal binds `v`; the body emits from it.
-% Parses to gen_block(name(Name), over(query(Src, SrcVars), LoopVar), Body).
-% Tried before the pure `gen { ... }` form -- the `over` keyword distinguishes
-% them. The body is emit-based (`emit v`, or `if (v CMP int) emit v` to filter),
-% so it uses the reader-guard body grammar rather than a general action block.
+% A `gen over query(SRC(A, ...)) as (a, ...) { BODY } as name` generator with an
+% input iterator (PLAWK_GENERATOR_BLOCKS.md, PR 3 + views/PR 5): a producer that
+% transforms/projects another relation. Each solution of the source goal binds
+% the loop vars positionally; the body emits a projection of them. Parses to
+% gen_block(name(Name), over(query(Src, SrcVars), LoopVars), Body) where LoopVars
+% is a list (`as v` -> [v], `as (a, b)` -> [a, b]). A single-column source keeps
+% the `as v` spelling; a multi-column source binds each column and the body may
+% emit a subset (a column-projection view -- "don't materialise the whole row").
+% Tried before the pure `gen { ... }` form. The body is emit-based (`emit a`,
+% `emit (a, b)`, or `if (a CMP int) emit a` to filter).
 pass_clauses([gen_block(name(Name),
-        over(query(Src, SrcVars), LoopVar), Body) | Rest]) -->
+        over(query(Src, SrcVars), LoopVars), Body) | Rest]) -->
     "gen", identifier_boundary, ws,
     "over", identifier_boundary, ws,
     "query", ws, "(", ws,
     identifier(Src), ws, "(", ws, query_var_list(SrcVars), ws, ")", ws,
     ")", ws,
-    "as", identifier_boundary, ws, identifier(LoopVar), ws,
+    "as", identifier_boundary, ws, gen_over_binding(LoopVars), ws,
     gen_over_body(Body), ws,
     "as", identifier_boundary, ws, identifier(Name), ws,
     pass_clauses(Rest).
@@ -330,6 +333,15 @@ gen_over_body([if(Guard, [emit(Emit)], [])]) -->
     !.
 gen_over_body([emit(Emit)]) -->
     "{", ws, emit_action(emit(Emit)), ws, "}".
+
+% The loop-variable binding of an input iterator: `as v` binds one column,
+% `as (a, b, ...)` binds several (one per source column, positionally). Both
+% produce a list of variable names.
+gen_over_binding(Vars) -->
+    "(", ws, query_var_list(Vars), ws, ")",
+    !.
+gen_over_binding([V]) -->
+    identifier(V).
 % A `pass { ACTIONS }` block is one pass carrying a single always-rule with
 % those actions (per-pattern rules within a pass are a later extension).
 pass_clauses([pass([rule(always, Actions)]) | Rest]) -->
@@ -1906,13 +1918,17 @@ emit_tuple_rest([V | Vs]) -->
     emit_tuple_rest(Vs).
 emit_tuple_rest([]) -->
     [].
-% A tuple element: an integer or string literal (constants only for now).
+% A tuple element: an integer or string literal (constant emits -> facts), or a
+% bound loop variable (an input-iterator projection -> a derived rule).
 emit_tuple_value(int(N)) -->
     signed_integer_value(N),
     !.
 emit_tuple_value(string(S)) -->
     quoted_string(Codes),
+    !,
     { string_codes(S, Codes) }.
+emit_tuple_value(var(V)) -->
+    identifier(V).
 
 printf_action(printf(string(Format), Args)) -->
     "printf",

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2167,12 +2167,32 @@ print_fields_rest([]) -->
 % meaning there (`emit 1` stays the integer 1, not the atom '1'). field_expr is
 % tried first, so arithmetic (`print 1 + 2`) and floats are unaffected; only a
 % lone integer falls through to the literal clause.
+% String concatenation by juxtaposition (awk): `print $1 $2`, `print "x" $1`,
+% `print $1 "-" $2` output the operands adjacent, with NO field separator (unlike
+% the comma list). Two or more operands separated by whitespace parse to
+% concat([...]). Each operand is a field_expr, so arithmetic binds tighter than
+% concatenation (`$1 $2 + $3` == concat($1, $2 + $3)) and a comma still splits
+% print args. A single operand keeps its plain form (no concat wrapper).
+print_field_expr(concat([First, Second | Rest])) -->
+    field_expr(First),
+    required_ws,
+    field_expr(Second),
+    concat_rest(Rest),
+    !.
 print_field_expr(Field) -->
     field_expr(Field),
     !.
 print_field_expr(string(Text)) -->
     signed_integer_value(N),
     { format(string(Text), '~w', [N]) }.
+
+concat_rest([Operand | Rest]) -->
+    required_ws,
+    field_expr(Operand),
+    !,
+    concat_rest(Rest).
+concat_rest([]) -->
+    [].
 
 field_expr(Expr) -->
     i64_binary_surface_expr(Expr).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1355,17 +1355,19 @@ for_in_action(for_in(var(LoopVar), var(ArrayName), Body)) -->
     ws,
     for_in_body(Body).
 
-for_in_body(Actions) -->
-    action_block(Actions),
-    !.
 % for-in filter (assoc for-in, stage 1): `{ if (GUARD) print ... }` where
 % GUARD compares the loop key `k` or the value `arr[k]` to an integer.
 % A for-in-scoped condition -- k / arr[k] are only meaningful inside the
 % loop, so the operands live here rather than in the global pattern
-% grammar. Gates the per-key print; no cross-iteration state.
+% grammar. Gates the per-key print; no cross-iteration state. Tried BEFORE the
+% general action_block: `if (k > 0)` would otherwise parse as a scalar_if (`k`
+% is the loop key, not a scalar slot), so the for-in-scoped guard must win.
 for_in_body([if(Guard, [PrintAction], [])]) -->
     "{", ws, "if", ws, "(", ws, guard_expr(Guard), ws, ")", ws,
     print_action(PrintAction), ws, "}",
+    !.
+for_in_body(Actions) -->
+    action_block(Actions),
     !.
 for_in_body([WritebinAction]) -->
     writebin_action(WritebinAction),
@@ -1476,6 +1478,10 @@ actions_rest(_Prev, []) -->
 
 plawk_block_action(if(_Pattern, _Then, _Else)).
 plawk_block_action(foreach(_Body)).
+% a loop is a braced block too: a statement may follow it without a separator
+% (`while (..) { .. } i++`), like an if / foreach.
+plawk_block_action(while_loop(_Cond, _Body)).
+plawk_block_action(do_while_loop(_Body, _Cond)).
 
 %% action_sep//0
 %

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1633,12 +1633,26 @@ while_cmp_rhs(int(N)) -->
 while_cmp_rhs(var(W)) -->
     identifier(W).
 
+%% if_condition(-Cond)//
+%
+%  An `if` condition is either a SCALAR comparison over variables (`if (i > 2)`,
+%  `if (i < n && j > 0)`) -- the same `VAR CMP int/VAR` shape as a loop condition,
+%  wrapped as scalar_if(_) so the lowering reads slot values -- or the existing
+%  field/pattern guard (`$1 > 2`, `$0 ~ /re/`, combinators). The scalar form is
+%  tried first; it fails fast on a field condition (a `$` is not an identifier),
+%  falling through to the pattern. A single condition is scalar OR pattern, not a
+%  mix. (PLAWK_CONTROL_FLOW_PLAN.md 3b -- unblocks counter-based loop control.)
+if_condition(scalar_if(Cond)) -->
+    while_condition(Cond).
+if_condition(Pattern) -->
+    condition_pattern(Pattern).
+
 if_action(if(Pattern, ThenActions, ElseActions)) -->
     "if",
     ws,
     "(",
     ws,
-    condition_pattern(Pattern),
+    if_condition(Pattern),
     ws,
     ")",
     ws,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1547,6 +1547,9 @@ action(Action) -->
     continue_action(Action),
     !.
 action(Action) -->
+    exit_action(Action),
+    !.
+action(Action) -->
     dynrec_view_action(Action),
     !.
 action(Action) -->
@@ -1725,6 +1728,19 @@ break_action(break) -->
 
 continue_action(continue) -->
     "continue",
+    identifier_boundary.
+
+% `exit` / `exit N` -- stop reading records, run END, and return N (default 0).
+% Parses to exit(int(N)). Unlike `break`, it always ends the program (it is not
+% consumed by an enclosing loop).
+exit_action(exit(int(N))) -->
+    "exit",
+    identifier_boundary,
+    ws,
+    signed_integer_value(N),
+    !.
+exit_action(exit(int(0))) -->
+    "exit",
     identifier_boundary.
 
 %% dynrec_bind_action(-Action)//

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -696,6 +696,19 @@ action_block_close -->
     "}",
     ws.
 
+%% body_block(-Actions)//
+%
+%  A control-flow body: either a braced `{ ... }` action block, or -- awk-style
+%  -- a single braceless statement (`if (c) print`, `while (c) x++`). The braced
+%  form is tried first; a braceless body is exactly one action wrapped in a
+%  singleton list, so downstream lowering (which already takes an action list)
+%  is unchanged.
+body_block(Actions) -->
+    action_block(Actions),
+    !.
+body_block([Action]) -->
+    action(Action).
+
 %% pattern(-Pattern)//
 %
 %  awk pattern combinators: `!` binds tighter than `&&`, which binds
@@ -1565,7 +1578,7 @@ while_action(while_loop(Cond, Body)) -->
     "(", ws,
     while_condition(Cond), ws,
     ")", ws,
-    action_block(Body).
+    body_block(Body).
 
 % A `do { BODY } while (VAR CMP int)` loop -- the body runs at least once, then
 % repeats while the condition holds (the awk do-while control structure). Parses
@@ -1574,7 +1587,7 @@ while_action(while_loop(Cond, Body)) -->
 % clause; the leading `do` keyword distinguishes it.
 do_while_action(do_while_loop(Body, Cond)) -->
     "do", identifier_boundary, ws,
-    action_block(Body), ws,
+    body_block(Body), ws,
     "while", identifier_boundary, ws,
     "(", ws,
     while_condition(Cond), ws,
@@ -1626,10 +1639,15 @@ if_action(if(Pattern, ThenActions, ElseActions)) -->
     ws,
     ")",
     ws,
-    action_block(ThenActions),
+    body_block(ThenActions),
     if_else_part(ElseActions).
 
+% `else` may follow a braced then-body directly, or a braceless one across a
+% statement separator (`if (c) print x; else print y`) -- so tolerate an
+% optional separator before `else`. If no `else` follows, the clause fails and
+% backtracks (un-consuming the separator) to the empty else.
 if_else_part(ElseActions) -->
+    opt_action_sep,
     "else",
     identifier_boundary,
     if_else_body(ElseActions),
@@ -1637,13 +1655,19 @@ if_else_part(ElseActions) -->
 if_else_part([]) -->
     [].
 
+opt_action_sep -->
+    action_sep,
+    !.
+opt_action_sep -->
+    ws.
+
 if_else_body([ElseIfAction]) -->
     required_ws,
     if_action(ElseIfAction),
     !.
 if_else_body(ElseActions) -->
     ws,
-    action_block(ElseActions).
+    body_block(ElseActions).
 
 condition_pattern(Pattern) -->
     or_pattern(Pattern).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -488,10 +488,31 @@ function_def((Head :- Body)) -->
     function_expr(Params, Pairs, ArithTerm),
     action_block_close,
     { pairs_values(Pairs, Vars),
-      append(Vars, [Result], HeadArgs),
+      % awk auto-coercion: a function body is `Result is ArithTerm`, so every
+      % parameter is used numerically. Text fields arrive as atoms (e.g. '5'),
+      % which `is/2` would reject -- so the head takes a fresh var per param and
+      % coerces it to a number (`number(H) -> V = H ; atom_number(H, V)`) before
+      % the arithmetic. A typed i64 arg (BINFMT mode) is already a number, so it
+      % passes through unchanged; a text field is parsed. No engine change; the
+      % coercion is local to the synthesised clause (PLAWK_AWK_FEATURE_AUDIT.md
+      % gap 2, decision: auto-coerce).
+      length(Vars, NParams),
+      length(HeadVars, NParams),
+      maplist(plawk_fn_coerce_goal, HeadVars, Vars, CoerceGoals),
+      append(HeadVars, [Result], HeadArgs),
       Head =.. [Name | HeadArgs],
-      Body = (Result is ArithTerm)
+      append(CoerceGoals, [Result is ArithTerm], BodyGoals),
+      plawk_conjunction(BodyGoals, Body)
     }.
+
+% The per-parameter numeric coercion goal: pass a number through, parse an atom.
+plawk_fn_coerce_goal(Head, Value,
+    (number(Head) -> Value = Head ; atom_number(Head, Value))).
+
+% Fold a non-empty goal list into a Prolog conjunction.
+plawk_conjunction([Goal], Goal) :- !.
+plawk_conjunction([Goal | Goals], (Goal, Rest)) :-
+    plawk_conjunction(Goals, Rest).
 
 function_params([Param | Params]) -->
     identifier(Param),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1532,6 +1532,9 @@ action(Action) -->
     break_action(Action),
     !.
 action(Action) -->
+    continue_action(Action),
+    !.
+action(Action) -->
     dynrec_view_action(Action),
     !.
 action(Action) -->
@@ -1692,6 +1695,10 @@ next_action(next) -->
 
 break_action(break) -->
     "break",
+    identifier_boundary.
+
+continue_action(continue) -->
+    "continue",
     identifier_boundary.
 
 %% dynrec_bind_action(-Action)//

--- a/tests/test_plawk_concat.pl
+++ b/tests/test_plawk_concat.pl
@@ -1,0 +1,138 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk string concatenation by juxtaposition (awk). `print $1 $2`, `print "x"
+% $1`, `print $1 "-" $2` output the operands ADJACENT, with no field separator
+% (unlike the comma list `print $1, $2`). Two or more operands separated by
+% whitespace parse to concat([...]); arithmetic binds tighter than
+% concatenation. Print-only (assignment concat would need string-valued
+% scalars, a separate feature).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_concat).
+
+% --- parsing / precedence ---------------------------------------------------
+
+test(concat_two_fields_parses) :-
+    plawk_parse_string("{ print $1 $2 }\n",
+        program([], [rule(always, [print([concat([field(1), field(2)])])])], [])),
+    !.
+
+test(concat_string_and_field_parses) :-
+    plawk_parse_string("{ print \"x\" $1 }\n",
+        program([], [rule(always, [print([concat([string("x"), field(1)])])])], [])),
+    !.
+
+% A single operand keeps its plain form (no concat wrapper).
+test(single_field_unchanged) :-
+    plawk_parse_string("{ print $1 }\n",
+        program([], [rule(always, [print([field(1)])])], [])),
+    !.
+
+% A comma still splits print args (not concatenation).
+test(comma_splits_not_concat) :-
+    plawk_parse_string("{ print $1, $2 }\n",
+        program([], [rule(always, [print([field(1), field(2)])])], [])),
+    !.
+
+% Arithmetic binds tighter than concatenation: `$1 + $2` stays arithmetic;
+% `$1 $2 + $3` is concat($1, $2 + $3).
+test(arithmetic_tighter_than_concat) :-
+    plawk_parse_string("{ print $1 + $2 }\n",
+        program([], [rule(always, [print([add_i64(field(1), field(2))])])], [])),
+    plawk_parse_string("{ print $1 $2 + $3 }\n",
+        program([], [rule(always,
+            [print([concat([field(1), add_i64(field(2), field(3))])])])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+test(concat_two_fields, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'c2', "{ print $1 $2 }\n", "a b c\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "ab\n"),
+    !.
+
+test(concat_with_string_literal, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'cs', "{ print $1 \"-\" $2 }\n", "a b c\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "a-b\n"),
+    !.
+
+test(concat_prefix_string, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'cp', "{ print \"row: \" $1 }\n", "hello world\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "row: hello\n"),
+    !.
+
+% Concatenation composes with the comma list: `print $1 $2, $3`.
+test(concat_then_comma, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'cc', "{ print $1 $2, $3 }\n", "a b c\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "ab c\n"),
+    !.
+
+% Concatenation with a scalar variable.
+test(concat_with_scalar, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'cv', "{ n++; print \"line\" n }\n", "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "line1\nline2\n"),
+    !.
+
+% Concatenation with NR (record counter) inside the concat.
+test(concat_with_nr, [condition(clang_available)]) :-
+    cdir(Dir),
+    build_run(Dir, 'cnr', "{ print NR \": \" $1 }\n", "x\ny\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1: x\n2: y\n"),
+    !.
+
+% Concatenation in an END block (`print "total: " sum " done"`).
+test(concat_in_end, [condition(clang_available)]) :-
+    cdir(Dir),
+    Src = "{ s += $1 }\nEND { print \"total: \" s \" done\" }\n",
+    build_run(Dir, 'ce', Src, "10\n20\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "total: 30 done\n"),
+    !.
+
+:- end_tests(plawk_concat).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+cdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_concat', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).

--- a/tests/test_plawk_end_if.pl
+++ b/tests/test_plawk_end_if.pl
@@ -1,0 +1,109 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk scalar `if` in an END block: `END { if (COND) print ...; [else print
+% ...] }`. END has no current record, so the condition is a scalar comparison
+% over the final slot values (the same scalar_if(_) shape as a rule-body `if`),
+% lowered in the end_print block. Each branch is a single print, using the
+% prefixed print emitter so the two blocks' temporaries don't collide.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_end_if).
+
+% `END { if (COND) print ... }` parses to end([if(scalar_if(...), [print], [])]).
+test(end_if_parses) :-
+    plawk_parse_string("{ n++ }\nEND { if (n > 1) print n }\n",
+        program([], _Rules,
+            [end([if(scalar_if(cmp(var(n), gt, int(1))), [print([var(n)])], [])])])),
+    !.
+
+test(end_if_else_parses) :-
+    plawk_parse_string("{ n++ }\nEND { if (n > 1) print \"many\"; else print \"few\" }\n",
+        program([], _Rules,
+            [end([if(scalar_if(cmp(var(n), gt, int(1))),
+                     [print([string("many")])],
+                     [print([string("few")])])])])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% if/else in END, condition true.
+test(end_if_else_true, [condition(clang_available)]) :-
+    edir(Dir),
+    Src = "{ n++ }\nEND { if (n > 1) print \"many\"; else print \"few\" }\n",
+    build_run(Dir, 'ie_t', Src, "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "many\n"),
+    !.
+
+% if/else in END, condition false -> the else branch.
+test(end_if_else_false, [condition(clang_available)]) :-
+    edir(Dir),
+    Src = "{ n++ }\nEND { if (n > 1) print \"many\"; else print \"few\" }\n",
+    build_run(Dir, 'ie_f', Src, "a\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "few\n"),
+    !.
+
+% if with no else, condition true -> prints a scalar.
+test(end_if_no_else_true, [condition(clang_available)]) :-
+    edir(Dir),
+    Src = "{ n++ }\nEND { if (n > 1) print n }\n",
+    build_run(Dir, 'ne_t', Src, "a\nb\nc\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
+    !.
+
+% if with no else, condition false -> nothing printed.
+test(end_if_no_else_false, [condition(clang_available)]) :-
+    edir(Dir),
+    Src = "{ n++ }\nEND { if (n > 5) print n }\n",
+    build_run(Dir, 'ne_f', Src, "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == ""),
+    !.
+
+% A plain `END { print ... }` still works (no regression from the new clause).
+test(end_plain_print_still_works, [condition(clang_available)]) :-
+    edir(Dir),
+    Src = "{ n++ }\nEND { print n }\n",
+    build_run(Dir, 'pp', Src, "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2\n"),
+    !.
+
+:- end_tests(plawk_end_if).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+edir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_end_if', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).

--- a/tests/test_plawk_exit.pl
+++ b/tests/test_plawk_exit.pl
@@ -1,0 +1,162 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `exit [n]` -- early terminate of the record loop (PLAWK_AWK_FEATURE_AUDIT
+% gap 4). `exit` / `exit N` stops reading records, runs END, and returns N
+% (default 0). It leaves via break_close_stream (like a rule-level `break`) but
+% carries an exit code stored in @plawk_exit_code and read at the final `ret`.
+% Unlike `break`, an `exit` inside a loop is NOT consumed by the loop -- it
+% always ends the whole program (propagates past any enclosing loop). Slot
+% values at the exit point flow into END through the break-close merge phi.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_exit).
+
+% --- parsing ----------------------------------------------------------------
+
+% Bare `exit` parses to `exit(int(0))` (default code 0).
+test(exit_bare_parses) :-
+    plawk_parse_string("{ exit }\n",
+        program([], [rule(always, [exit(int(0))])], [])),
+    !.
+
+% `exit N` parses to `exit(int(N))`.
+test(exit_code_parses) :-
+    plawk_parse_string("{ exit 2 }\n",
+        program([], [rule(always, [exit(int(2))])], [])),
+    !.
+
+% `exit` guarded by a pattern.
+test(exit_guarded_parses) :-
+    plawk_parse_string("$1 == \"stop\" { exit 3 }\n",
+        program([],
+            [rule(field_eq(1, "stop"), [exit(int(3))])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% `exit N` stops the record stream and returns N.
+test(exit_stops_and_returns, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "$1 == \"stop\" { exit 2 }\n{ print $1 }\n",
+    build_run(Dir, 'stop', Src, "a\nstop\nb\n", Out, St),
+    assertion(St == 2),
+    assertion(Out == "a\n"),
+    !.
+
+% Bare `exit` returns 0.
+test(exit_default_zero, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ exit }\n{ print $1 }\n",
+    build_run(Dir, 'def', Src, "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == ""),
+    !.
+
+% END runs on the way out of `exit`.
+test(exit_runs_end, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "$1 == \"stop\" { exit 3 }\n{ print $1 }\nEND { print \"done\" }\n",
+    build_run(Dir, 'end', Src, "a\nstop\nb\n", Out, St),
+    assertion(St == 3),
+    assertion(Out == "a\ndone\n"),
+    !.
+
+% `exit` inside an `if` branch ends the program (branch_exit path).
+test(exit_in_if, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ if ($1 == \"q\") exit 5; print $1 }\n",
+    build_run(Dir, 'inif', Src, "a\nq\nb\n", Out, St),
+    assertion(St == 5),
+    assertion(Out == "a\n"),
+    !.
+
+% `exit` in an `else` branch.
+test(exit_in_else, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ if ($1 == \"go\") print \"going\"; else exit 1 }\n",
+    build_run(Dir, 'inelse', Src, "go\nstop\n", Out, St),
+    assertion(St == 1),
+    assertion(Out == "going\n"),
+    !.
+
+% `exit` inside a loop ends the whole program (not just the loop).
+test(exit_in_loop, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 10) { if (i > 2) exit 7; print i; i++ } }\n",
+    build_run(Dir, 'inloop', Src, "x\n", Out, St),
+    assertion(St == 7),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+% Scalar state at the exit point flows into END (break-close merge phi).
+test(exit_state_to_end, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ x = 5; exit 4 }\nEND { print x }\n",
+    build_run(Dir, 'state', Src, "a\n", Out, St),
+    assertion(St == 4),
+    assertion(Out == "5\n"),
+    !.
+
+% Accumulated state survives an exit into END (count records until "q").
+test(exit_accum_to_end, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ x = x + 1 } $1 == \"q\" { exit 9 }\nEND { print x }\n",
+    build_run(Dir, 'accum', Src, "a\nb\nq\nc\n", Out, St),
+    assertion(St == 9),
+    assertion(Out == "3\n"),
+    !.
+
+% Mixed program: per-record body print + a guarded exit + END.
+test(exit_mixed_body_print, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ print $1 } $1 == \"z\" { exit 2 }\nEND { print \"fin\" }\n",
+    build_run(Dir, 'mixed', Src, "a\nz\nb\n", Out, St),
+    assertion(St == 2),
+    assertion(Out == "a\nz\nfin\n"),
+    !.
+
+% A program with no exit is unaffected (returns 0).
+test(no_exit_returns_zero, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ print $1 }\n",
+    build_run(Dir, 'noexit', Src, "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "a\nb\n"),
+    !.
+
+:- end_tests(plawk_exit).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_exit', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).

--- a/tests/test_plawk_functions.pl
+++ b/tests/test_plawk_functions.pl
@@ -57,6 +57,46 @@ test(surface_functions_mix_with_prolog_blocks) :-
     Src = "@prolog\nplawk_fnt_hot(X) :- X > 10.\n@end\nBEGIN { BINFMT = \"i64 f64\" }\nfunction plawk_fnt_twice(a) { return a * 2 }\nplawk_fnt_hot($1) { s += plawk_fnt_twice($1) }\nEND { print s }\n",
     run_fn_smoke(Src, [rec(3, 0.25), rec(20, 0.25), rec(11, 0.25)], "62\n").
 
+% --- optional arg typing (typed-fast path over auto-coerce) ------------------
+% `function f(num x)` declares x numeric, so the synthesized clause skips the
+% auto-coercion goal -- the head var IS the value var (Principle 2: static type
+% knowledge elides the runtime coercion). Layered on auto-coerce, which stays
+% the default for unannotated params.
+
+test(typed_param_skips_coercion) :-
+    plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction f(num x) { return x * 2 }\n{ n++ }\nEND { print n }\n",
+        _, [Clause]),
+    % no coercion prefix: the body is exactly the arithmetic
+    assertion(Clause = (f(X, R) :- R is X * 2)),
+    Clause = (f(5, Result) :- Goal),
+    call(Goal),
+    assertion(Result =:= 10).
+
+test(untyped_param_still_coerces) :-
+    plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction g(x) { return x * 2 }\n{ n++ }\nEND { print n }\n",
+        _, [Clause]),
+    Clause = (g(_X, R) :- Body),
+    fn_body_last(Body, (R is _Arith)),
+    % the body has a coercion conjunct before the arithmetic (not a bare `is`)
+    assertion(Body = (_Coerce, _Rest)).
+
+test(mixed_typed_untyped_params) :-
+    plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction h(num a, b) { return a + b }\n{ n++ }\nEND { print n }\n",
+        _, [Clause]),
+    % a is typed (no coercion), b is untyped (one coercion goal) -> exactly one
+    % coercion conjunct precedes the `is`
+    Clause = (h(_A, _B, R) :- (Coerce, R is _Arith)),
+    assertion(Coerce = (number(_) -> _ ; _)),
+    Clause = (h(4, 6, V) :- FullGoal),
+    call(FullGoal),
+    assertion(V =:= 10).
+
+% A typed function used end-to-end in i64 (BINFMT) mode: the field is already a
+% number, so the typed-fast path runs with no coercion.
+test(typed_function_binfmt_end_to_end) :-
+    Src = "BEGIN { BINFMT = \"i64 f64\" }\nfunction plawk_fnt_scale(num a, num b) { return a * b + 1 }\n{ s += plawk_fnt_scale($1, $1) }\nEND { print s }\n",
+    run_fn_smoke(Src, [rec(3, 0.25), rec(5, 0.25)], "36\n").
+
 % --- auto-coerce (awk semantics): a function called on TEXT fields -----------
 % In text mode (no BINFMT) `$1` is an atom. awk auto-coerces a value used
 % numerically, so `print dbl($1)` must coerce the field to a number before the

--- a/tests/test_plawk_functions.pl
+++ b/tests/test_plawk_functions.pl
@@ -20,17 +20,25 @@ clang_available :-
 test(functions_desugar_to_prolog_clauses) :-
     plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction f(a, b) { return a + b * 2 }\n{ n++ }\nEND { print n }\n",
         _, [Clause]),
-    % awk precedence: * binds tighter than +
-    assertion(Clause = (f(_A, _B, R) :- R is _ + _ * 2)),
+    % auto-coerce prefixes the body with per-param numeric coercion goals; the
+    % final conjunct is the arithmetic. awk precedence: * binds tighter than +.
+    Clause = (f(_A, _B, R) :- Body),
+    fn_body_last(Body, (R is Arith)),
+    assertion(Arith = _ + _ * 2),
     Clause = (f(3, 4, Result) :- Goal),
     call(Goal),
     assertion(Result =:= 11).
 
 test(percent_maps_to_mod_and_parens_group) :-
     plawk_parse_source("BEGIN { BINFMT = \"i64\" }\nfunction g(a, b) { return (a + b) % 7 }\n{ n++ }\nEND { print n }\n",
-        _, [(g(A, B, R) :- R is Goal)]),
-    assertion(Goal == mod(A + B, 7)),
-    ( A = 5, B = 9, V is Goal, assertion(V =:= 0) ).
+        _, [Clause]),
+    Clause = (g(_A, _B, R) :- Body),
+    fn_body_last(Body, (R is Goal)),
+    % % maps to mod and the parens group the sum: mod(_+_, 7)
+    assertion(Goal = mod(_ + _, 7)),
+    Clause = (g(5, 9, V) :- CallGoal),
+    call(CallGoal),
+    assertion(V =:= 0).
 
 test(function_rejections) :-
     % identifiers must be parameters
@@ -49,9 +57,54 @@ test(surface_functions_mix_with_prolog_blocks) :-
     Src = "@prolog\nplawk_fnt_hot(X) :- X > 10.\n@end\nBEGIN { BINFMT = \"i64 f64\" }\nfunction plawk_fnt_twice(a) { return a * 2 }\nplawk_fnt_hot($1) { s += plawk_fnt_twice($1) }\nEND { print s }\n",
     run_fn_smoke(Src, [rec(3, 0.25), rec(20, 0.25), rec(11, 0.25)], "62\n").
 
+% --- auto-coerce (awk semantics): a function called on TEXT fields -----------
+% In text mode (no BINFMT) `$1` is an atom. awk auto-coerces a value used
+% numerically, so `print dbl($1)` must coerce the field to a number before the
+% arithmetic. The synthesized clause wraps each param in
+% `(number(H) -> V = H ; atom_number(H, V))`, so text fields Just Work.
+
+test(auto_coerce_unary_text_field) :-
+    Src = "function dbl(x) { return x * 2 }\n{ print dbl($1) }\n",
+    build_run_text('acdbl', Src, "5\n10\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "10\n20\n").
+
+test(auto_coerce_binary_text_fields) :-
+    Src = "function add(a, b) { return a + b }\n{ print add($1, $2) }\n",
+    build_run_text('acadd', Src, "5 7\n10 23\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "12\n33\n").
+
 :- end_tests(plawk_functions).
 
 % --- helpers ---------------------------------------------------------------
+
+% Peel a body conjunction down to its final conjunct.
+fn_body_last((_, Rest), Last) :- !, fn_body_last(Rest, Last).
+fn_body_last(Goal, Goal).
+
+% Build a text-mode plawk program via the CLI and run it on Input (stdin),
+% capturing stdout. Used for the auto-coerce end-to-end checks.
+build_run_text(Name, Src, Input, Out, RunStatus) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_functions', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ),
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl),
+        ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).
 
 write_i64_le(Out, V) :-
     V64 is V /\ 0xFFFFFFFFFFFFFFFF,

--- a/tests/test_plawk_gen_blocks.pl
+++ b/tests/test_plawk_gen_blocks.pl
@@ -50,9 +50,19 @@ test(gen_over_query_parses) :-
         "gen over query(num(V)) as v { if (v > 2) emit v } as big\n\c
          pass over query(big(X)) { print $1 }\n",
         program_passes([],
-            [gen_block(name(big), over(query(num, ['V']), v),
+            [gen_block(name(big), over(query(num, ['V']), [v]),
                  [if(forin_key_cmp(v, gt, 2), [emit(var(v))], [])]),
              pass_query(query(big, ['X']), [print([field(1)])])],
+            [])),
+    !.
+
+% A multi-column source with a tuple binding parses to a list of loop vars.
+test(gen_over_multicol_parses) :-
+    plawk_parse_string(
+        "gen over query(edge(A, B)) as (a, b) { emit a } as src\n",
+        program_passes([],
+            [gen_block(name(src), over(query(edge, ['A', 'B']), [a, b]),
+                 [emit(var(a))])],
             [])),
     !.
 
@@ -154,6 +164,30 @@ test(gen_over_filter_and_run, [condition(clang_available)]) :-
     build_run(Dir, 'genand', Src, [], Out, St),
     assertion(St == 0),
     assertion(Out == "2\n3\n4\n"),
+    !.
+
+% A column-projection view: project one column of a two-column source, filtered
+% -- `gen over query(edge(A, B)) as (a, b) { if (a > 1) emit a } as srcs` ->
+% `srcs(A) :- edge(A, _B), A > 1` (only the needed column materialises).
+test(gen_over_projection_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "@prolog\nedge(1, 10).\nedge(2, 20).\nedge(3, 30).\n@end\n\c
+           gen over query(edge(A, B)) as (a, b) { if (a > 1) emit a } as srcs\n\c
+           pass over query(srcs(X)) { print $1 }\n",
+    build_run(Dir, 'vwproj', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "2\n3\n"),
+    !.
+
+% A reordering projection: `emit (b, a)` -> `flipped(B, A) :- edge(A, B)`.
+test(gen_over_reorder_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "@prolog\nedge(1, 10).\nedge(2, 20).\n@end\n\c
+           gen over query(edge(A, B)) as (a, b) { emit (b, a) } as flipped\n\c
+           pass over query(flipped(X, Y)) { print $1, $2 }\n",
+    build_run(Dir, 'vwflip', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "10 1\n20 2\n"),
     !.
 
 % A computed emit (a field, not a constant) in a PURE generator needs runtime

--- a/tests/test_plawk_gen_blocks.pl
+++ b/tests/test_plawk_gen_blocks.pl
@@ -88,6 +88,27 @@ test(gen_block_string_run, [condition(clang_available)]) :-
     assertion(Out == "red\ngreen\nblue\n"),
     !.
 
+% A tuple emit produces an arity-n fact per row: `emit (1, 10)` -> `edge(1,10)`,
+% consumed by a two-column query.
+test(gen_block_tuple_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "gen { emit (1, 10); emit (2, 20); emit (3, 30) } as edge\n\c
+           pass over query(edge(X, Y)) { print $1, $2 }\n",
+    build_run(Dir, 'gentup', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "1 10\n2 20\n3 30\n"),
+    !.
+
+% A tuple may mix string and integer columns (`emit ("a", 1)` -> `kv(a, 1)`).
+test(gen_block_tuple_mixed_run, [condition(clang_available)]) :-
+    gdir(Dir),
+    Src = "gen { emit (\"a\", 1); emit (\"b\", 2) } as kv\n\c
+           pass over query(kv(K, V)) { print $1, $2 }\n",
+    build_run(Dir, 'gentupmix', Src, [], Out, St),
+    assertion(St == 0),
+    assertion(Out == "a 1\nb 2\n"),
+    !.
+
 % A reader guard on the consuming query pass composes with a generator source.
 test(gen_block_guarded_consume_run, [condition(clang_available)]) :-
     gdir(Dir),

--- a/tests/test_plawk_if_bodies.pl
+++ b/tests/test_plawk_if_bodies.pl
@@ -1,0 +1,168 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `if` bodies and regex-in-`if`, plus braceless control-flow bodies.
+%
+% A guarded plain body (`{ if (c) { print $1 } }`) and a regex condition
+% (`if ($0 ~ /re/) { ... }`) compile and run -- the two most common awk
+% conditional idioms. Braceless bodies (`if (c) print`, `while (c) x++`,
+% `do stmt while (c)`) parse as a single statement, awk-style. These lock in the
+% behaviour and the braceless surface.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_if_bodies).
+
+% --- guarded plain bodies (no scalar update) --------------------------------
+
+% `{ if ($1 > 5) { print $1 } }` -- a guarded print, the bread-and-butter awk
+% conditional action.
+test(if_guarded_print, [condition(clang_available)]) :-
+    idir(Dir),
+    build_run(Dir, 'gp', "{ if ($1 > 5) { print $1 } }\n", "3\n7\n9\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "7\n9\n"),
+    !.
+
+% A string-literal print in a guarded body.
+test(if_guarded_literal, [condition(clang_available)]) :-
+    idir(Dir),
+    build_run(Dir, 'gl', "{ if ($1 > 5) { print \"big\" } }\n", "3\n7\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "big\n"),
+    !.
+
+% if / else with plain bodies.
+test(if_else_plain_bodies, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($1 > 5) { print \"big\" } else { print \"small\" } }\n",
+    build_run(Dir, 'ie', Src, "3\n7\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "small\nbig\n"),
+    !.
+
+% --- regex conditions in `if` -----------------------------------------------
+
+% `if ($0 ~ /re/)` -- a regex match as the condition, guarding a print.
+test(if_regex_match, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($0 ~ /err/) { print $1 } }\n",
+    build_run(Dir, 'rx', Src, "err 1\nok 2\nerr 3\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "err\nerr\n"),
+    !.
+
+% `if ($0 !~ /re/)` -- the negated match.
+test(if_regex_no_match, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($0 !~ /err/) { print $1 } }\n",
+    build_run(Dir, 'nx', Src, "err 1\nok 2\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "ok\n"),
+    !.
+
+% A scalar update inside a guarded `if` still works (no regression).
+test(if_scalar_update_still_works, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($1 > 5) { n++ } }\nEND { print n }\n",
+    build_run(Dir, 'su', Src, "3\n7\n9\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2\n"),
+    !.
+
+% --- braceless bodies (awk-style single statement) --------------------------
+
+% `if (c) print` -- a braceless then-body parses to a singleton action list.
+test(braceless_if_parses) :-
+    plawk_parse_string("{ if ($1 > 5) print $1 }\n",
+        program([], [rule(always,
+            [if(_Cond, [print([field(1)])], [])])], [])),
+    !.
+
+test(braceless_if_runs, [condition(clang_available)]) :-
+    idir(Dir),
+    build_run(Dir, 'bif', "{ if ($1 > 5) print $1 }\n", "3\n7\n9\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "7\n9\n"),
+    !.
+
+% `if (c) stmt; else stmt` -- braceless then and else across a separator.
+test(braceless_if_else_runs, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($1 > 5) print \"big\"; else print \"small\" }\n",
+    build_run(Dir, 'bie', Src, "3\n7\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "small\nbig\n"),
+    !.
+
+% A braceless else-if chain.
+test(braceless_else_if_chain, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ if ($1 > 8) print \"hi\"; \c
+             else if ($1 > 4) print \"mid\"; \c
+             else print \"lo\" }\n",
+    build_run(Dir, 'bec', Src, "2\n6\n9\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "lo\nmid\nhi\n"),
+    !.
+
+% `while (c) stmt` -- a braceless loop body.
+test(braceless_while_runs, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ i = 0; while (i < 3) i++; print i }\n",
+    build_run(Dir, 'bw', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
+    !.
+
+% `do stmt while (c)` -- a braceless do-while body.
+test(braceless_do_while_runs, [condition(clang_available)]) :-
+    idir(Dir),
+    Src = "{ i = 0; do i++ while (i < 3); print i }\n",
+    build_run(Dir, 'bdw', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
+    !.
+
+% A braced body still parses and runs (no regression from the braceless path).
+test(braced_if_still_works, [condition(clang_available)]) :-
+    idir(Dir),
+    build_run(Dir, 'braced', "{ if ($1 > 5) { print $1 } }\n", "3\n7\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "7\n"),
+    !.
+
+:- end_tests(plawk_if_bodies).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+idir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_if_bodies', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).

--- a/tests/test_plawk_loop_control.pl
+++ b/tests/test_plawk_loop_control.pl
@@ -1,0 +1,126 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk loop control -- `break` / `continue` (PLAWK_CONTROL_FLOW_PLAN.md 3b),
+% the SURFACE + a guard. `continue` parses to a `continue` action. The while /
+% do-while loop runtime is landed, but LOOP-LOCAL break/continue is not yet
+% wired: inside a loop `break` would otherwise lower to the rule-level
+% stream-break (stop reading records), a silent mis-compile. So a `break`
+% inside a loop, or any `continue`, is a clean not-yet error until the runtime
+% lands (it needs SSA merge phis at the loop exit + scalar `if` conditions).
+% `break` OUTSIDE a loop keeps its existing stream-break meaning.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_loop_control).
+
+% `continue` parses to a `continue` action.
+test(continue_parses) :-
+    plawk_parse_string("{ while (i < 3) { continue } }\n",
+        program([], [rule(always,
+            [while_loop(cmp(var(i), lt, int(3)), [continue])])], [])),
+    !.
+
+% `break` still parses (unchanged) as a `break` action.
+test(break_parses) :-
+    plawk_parse_string("{ while (i < 3) { break } }\n",
+        program([], [rule(always,
+            [while_loop(cmp(var(i), lt, int(3)), [break])])], [])),
+    !.
+
+% A `break` inside a loop body is a clean not-yet error (exit 2) -- guarding the
+% silent stream-break mis-compile.
+test(break_in_loop_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 3) { print i; break } }\n",
+    build_status(Dir, 'lb', Src, St),
+    assertion(St == 2),
+    !.
+
+% A `break` inside an `if` inside a loop is likewise guarded (subtree search).
+test(break_in_if_in_loop_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 3) { if ($1 > 100) { break } i++ } }\n",
+    build_status(Dir, 'lbif', Src, St),
+    assertion(St == 2),
+    !.
+
+% A `continue` anywhere is a clean not-yet error (it only means loop control).
+test(continue_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 3) { continue } }\n",
+    build_status(Dir, 'lc', Src, St),
+    assertion(St == 2),
+    !.
+
+% A do-while body with control is also guarded.
+test(break_in_do_while_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; do { break } while (i < 3) }\n",
+    build_status(Dir, 'ldw', Src, St),
+    assertion(St == 2),
+    !.
+
+% `break` OUTSIDE a loop (rule-level stream break) still compiles and runs --
+% the guard only fires for loop bodies.
+test(rule_level_break_still_runs, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "$1 == \"stop\" { break }\n{ print $1 }\n",
+    build_run(Dir, 'rb', Src, "a\nstop\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "a\n"),
+    !.
+
+% A plain loop with no break/continue is unaffected (no false trigger).
+test(plain_loop_builds, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 3) { print i; i++ } }\n",
+    build_run(Dir, 'plain', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+:- end_tests(plawk_loop_control).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_loop_control', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_status(Dir, Name, Src, Status) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).

--- a/tests/test_plawk_loop_control.pl
+++ b/tests/test_plawk_loop_control.pl
@@ -2,14 +2,13 @@
 % SPDX-License-Identifier: MIT OR Apache-2.0
 % Copyright (c) 2026 John William Creighton (@s243a)
 %
-% plawk loop control -- `break` / `continue` (PLAWK_CONTROL_FLOW_PLAN.md 3b),
-% the SURFACE + a guard. `continue` parses to a `continue` action. The while /
-% do-while loop runtime is landed, but LOOP-LOCAL break/continue is not yet
-% wired: inside a loop `break` would otherwise lower to the rule-level
-% stream-break (stop reading records), a silent mis-compile. So a `break`
-% inside a loop, or any `continue`, is a clean not-yet error until the runtime
-% lands (it needs SSA merge phis at the loop exit + scalar `if` conditions).
-% `break` OUTSIDE a loop keeps its existing stream-break meaning.
+% plawk loop control -- `break` / `continue` (PLAWK_CONTROL_FLOW_PLAN.md 3b).
+% Loop-local break/continue is wired for `while` loops: `break` leaves the loop
+% (an SSA phi at the loop's `after` merges the break value with the normal
+% exit), `continue` re-tests the condition (an extra incoming to the head phi).
+% `break` OUTSIDE a loop keeps its rule-level stream-break meaning. `do-while`
+% break/continue is a clean not-yet error (its condition sits in the body-done
+% block, needing an extra merge phi there).
 
 :- use_module(library(plunit)).
 :- use_module(library(process)).
@@ -18,55 +17,65 @@
 
 :- begin_tests(plawk_loop_control).
 
-% `continue` parses to a `continue` action.
+% `continue` / `break` parse to their actions.
 test(continue_parses) :-
     plawk_parse_string("{ while (i < 3) { continue } }\n",
         program([], [rule(always,
             [while_loop(cmp(var(i), lt, int(3)), [continue])])], [])),
     !.
 
-% `break` still parses (unchanged) as a `break` action.
 test(break_parses) :-
     plawk_parse_string("{ while (i < 3) { break } }\n",
         program([], [rule(always,
             [while_loop(cmp(var(i), lt, int(3)), [break])])], [])),
     !.
 
-% A `break` inside a loop body is a clean not-yet error (exit 2) -- guarding the
-% silent stream-break mis-compile.
-test(break_in_loop_is_not_yet_error) :-
+% --- while break ------------------------------------------------------------
+
+% `break` leaves the loop: `while (i < 10) { if (i > 2) break; print i; i++ }`
+% prints 0/1/2 and stops.
+test(while_break, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; while (i < 3) { print i; break } }\n",
-    build_status(Dir, 'lb', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; while (i < 10) { if (i > 2) break; print i; i++ } }\n",
+    build_run(Dir, 'wb', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
     !.
 
-% A `break` inside an `if` inside a loop is likewise guarded (subtree search).
-test(break_in_if_in_loop_is_not_yet_error) :-
+% The break value flows past the loop: after breaking at i == 3, END sees i = 3
+% (proves the `after` merge phi carries the break-point value).
+test(while_break_state_to_end, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; while (i < 3) { if ($1 > 100) { break } i++ } }\n",
-    build_status(Dir, 'lbif', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; while (i < 10) { if (i > 2) break; i++ } }\nEND { print i }\n",
+    build_run(Dir, 'wbe', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
     !.
 
-% A `continue` anywhere is a clean not-yet error (it only means loop control).
-test(continue_is_not_yet_error) :-
+% An unconditional trailing break runs the body once.
+test(while_break_trailing, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; while (i < 3) { continue } }\n",
-    build_status(Dir, 'lc', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; while (i < 5) { print i; i++; break } }\n",
+    build_run(Dir, 'wbt', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n"),
     !.
 
-% A do-while body with control is also guarded.
-test(break_in_do_while_is_not_yet_error) :-
+% --- while continue ---------------------------------------------------------
+
+% `continue` re-tests the condition, skipping the rest of the body:
+% `while (i < 5) { i++; if (i > 3) continue; print i }` prints 1/2/3.
+test(while_continue, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; do { break } while (i < 3) }\n",
-    build_status(Dir, 'ldw', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; while (i < 5) { i++; if (i > 3) continue; print i } }\n",
+    build_run(Dir, 'wc', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1\n2\n3\n"),
     !.
 
-% `break` OUTSIDE a loop (rule-level stream break) still compiles and runs --
-% the guard only fires for loop bodies.
+% --- boundaries -------------------------------------------------------------
+
+% `break` OUTSIDE a loop (rule-level stream break) still compiles and runs.
 test(rule_level_break_still_runs, [condition(clang_available)]) :-
     ldir(Dir),
     Src = "$1 == \"stop\" { break }\n{ print $1 }\n",
@@ -75,7 +84,22 @@ test(rule_level_break_still_runs, [condition(clang_available)]) :-
     assertion(Out == "a\n"),
     !.
 
-% A plain loop with no break/continue is unaffected (no false trigger).
+% `do-while` break/continue is a clean not-yet error (runtime pending).
+test(do_while_break_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; do { print i; break } while (i < 5) }\n",
+    build_status(Dir, 'dwb', Src, St),
+    assertion(St == 2),
+    !.
+
+test(do_while_continue_is_not_yet_error) :-
+    ldir(Dir),
+    Src = "{ i = 0; do { continue } while (i < 5) }\n",
+    build_status(Dir, 'dwc', Src, St),
+    assertion(St == 2),
+    !.
+
+% A plain loop with no break/continue is unaffected.
 test(plain_loop_builds, [condition(clang_available)]) :-
     ldir(Dir),
     Src = "{ i = 0; while (i < 3) { print i; i++ } }\n",

--- a/tests/test_plawk_loop_control.pl
+++ b/tests/test_plawk_loop_control.pl
@@ -85,18 +85,65 @@ test(rule_level_break_still_runs, [condition(clang_available)]) :-
     !.
 
 % `do-while` break/continue is a clean not-yet error (runtime pending).
-test(do_while_break_is_not_yet_error) :-
+% --- do-while break/continue ------------------------------------------------
+
+% `do-while` break leaves the loop (the after phi merges the post-condition exit
+% with each break value).
+test(do_while_break, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; do { print i; break } while (i < 5) }\n",
-    build_status(Dir, 'dwb', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; do { if (i > 2) break; print i; i++ } while (i < 10) }\n",
+    build_run(Dir, 'dwb', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
     !.
 
-test(do_while_continue_is_not_yet_error) :-
+% `do-while` continue re-tests the condition (an extra merge phi in the
+% body-done block feeds the condition and the back edge).
+test(do_while_continue, [condition(clang_available)]) :-
     ldir(Dir),
-    Src = "{ i = 0; do { continue } while (i < 5) }\n",
-    build_status(Dir, 'dwc', Src, St),
-    assertion(St == 2),
+    Src = "{ i = 0; do { i++; if (i > 3) continue; print i } while (i < 5) }\n",
+    build_run(Dir, 'dwc', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1\n2\n3\n"),
+    !.
+
+% The do-while break value flows past the loop into END.
+test(do_while_break_state_to_end, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; do { if (i > 2) break; i++ } while (i < 10) }\nEND { print i }\n",
+    build_run(Dir, 'dwbe', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n"),
+    !.
+
+% --- nested loops -----------------------------------------------------------
+
+% A while inside a while; the inner loop prints per outer iteration.
+test(nested_while, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 2) { j = 0; while (j < 2) { print j; j++ } i++ } }\n",
+    build_run(Dir, 'nest', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n0\n1\n"),
+    !.
+
+% An inner break breaks only the INNER loop (the loop-context stack targets the
+% innermost loop).
+test(nested_inner_break, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; while (i < 3) { j = 0; while (j < 5) { if (j > 1) break; print j; j++ } i++ } }\n",
+    build_run(Dir, 'nb', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n0\n1\n0\n1\n"),
+    !.
+
+% A while nested inside a do-while, inner break.
+test(while_in_do_while, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ i = 0; do { j = 0; while (j < 4) { if (j > 1) break; print j; j++ } i++ } while (i < 2) }\n",
+    build_run(Dir, 'mix', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n0\n1\n"),
     !.
 
 % A plain loop with no break/continue is unaffected.

--- a/tests/test_plawk_materialize.pl
+++ b/tests/test_plawk_materialize.pl
@@ -1,0 +1,108 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `materialize NAME` (PLAWK_MULTIPASS_CACHE.md section 3.9), the SURFACE.
+% `materialize NAME` marks a view (a `gen ... as NAME` block) or a @prolog
+% relation to be materialised-and-cached: its projected/filtered rows are
+% computed once into a shared table and reused by every query pass that reads
+% it, instead of re-running the goal per consumer. Surface-first (mirroring the
+% query-reader / generator / while arcs): the declaration parses and its
+% reference is validated against the program's defined relations, but the
+% materialise-and-cache runtime is a follow-on, so a program that uses it is a
+% clean, specific compile error rather than the generic "outside the surface".
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_materialize).
+
+% `materialize NAME` parses to a materialize(Name) pass-clause item, in program
+% order alongside the generator that defines the view and the consuming pass.
+test(materialize_parses) :-
+    plawk_parse_string(
+        "gen over query(edge(A, B)) as (a, b) { emit a } as srcs\n\c
+         materialize srcs\n\c
+         pass over query(srcs(X)) { print $1 }\n",
+        program_passes([],
+            [gen_block(name(srcs), over(query(edge, ['A', 'B']), [a, b]),
+                 [emit(var(a))]),
+             materialize(srcs),
+             pass_query(query(srcs, ['X']), [print([field(1)])])],
+            [])),
+    !.
+
+% A program with no `materialize` declaration is untouched.
+test(no_materialize_parses) :-
+    plawk_parse_string(
+        "pass { print $1 }\n",
+        program_passes([],
+            [pass([rule(always, [print([field(1)])])])],
+            [])),
+    !.
+
+% Building a program that materialises a DEFINED view (a `gen ... as NAME`
+% block) is a clean not-yet compile error (exit 2) until the runtime lands.
+test(materialize_defined_view_is_not_yet_error) :-
+    mdir(Dir),
+    Src = "@prolog\nedge(1, 10).\nedge(2, 20).\n@end\n\c
+           gen over query(edge(A, B)) as (a, b) { emit a } as srcs\n\c
+           materialize srcs\n\c
+           pass over query(srcs(X)) { print $1 }\n",
+    build_status(Dir, 'mvdef', Src, St),
+    assertion(St == 2),
+    !.
+
+% Materialising a DEFINED @prolog relation is likewise a clean not-yet error.
+test(materialize_prolog_relation_is_not_yet_error) :-
+    mdir(Dir),
+    Src = "@prolog\nnum(1).\nnum(2).\n@end\n\c
+           materialize num\n\c
+           pass over query(num(X)) { print $1 }\n",
+    build_status(Dir, 'mvpl', Src, St),
+    assertion(St == 2),
+    !.
+
+% Materialising an UNKNOWN relation (no view / @prolog defines it) is a clean
+% compile error (a distinct, earlier diagnostic than the not-yet one).
+test(materialize_unknown_view_is_error) :-
+    mdir(Dir),
+    Src = "materialize nope\npass { print $1 }\n",
+    build_status(Dir, 'mvunk', Src, St),
+    assertion(St == 2),
+    !.
+
+% A program with no `materialize` declaration builds normally (no false
+% trigger).
+test(non_materialize_program_builds, [condition(clang_available)]) :-
+    mdir(Dir),
+    Src = "@prolog\nedge(1).\nedge(2).\n@end\npass over query(edge(X)) { print $1 }\n",
+    build_status(Dir, 'mvok', Src, St),
+    assertion(St == 0),
+    !.
+
+:- end_tests(plawk_materialize).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+mdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_materialize', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_status(Dir, Name, Src, Status) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).

--- a/tests/test_plawk_scalar_if.pl
+++ b/tests/test_plawk_scalar_if.pl
@@ -1,0 +1,122 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk scalar `if` conditions (PLAWK_CONTROL_FLOW_PLAN.md 3b). An `if` condition
+% may be a SCALAR comparison over variables (`if (i > 2)`, `if (i < n && j > 0)`)
+% -- the same `VAR CMP int/VAR` shape as a loop condition, wrapped as
+% scalar_if(_) so the lowering reads slot values -- in addition to the existing
+% field/pattern guard (`$1 > 2`, `$0 ~ /re/`). This unblocks counter-based
+% conditionals inside loops (a prerequisite for loop-local break/continue).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_scalar_if).
+
+% A scalar comparison parses to scalar_if(cmp(...)); a field comparison stays a
+% field pattern (the two do not collide).
+test(scalar_if_parses) :-
+    plawk_parse_string("{ if (i > 2) { print i } }\n",
+        program([], [rule(always,
+            [if(scalar_if(cmp(var(i), gt, int(2))), [print([var(i)])], [])])], [])),
+    !.
+
+test(field_if_unchanged) :-
+    plawk_parse_string("{ if ($1 > 2) { print $1 } }\n",
+        program([], [rule(always,
+            [if(field_cmp(1, gt, 2), [print([field(1)])], [])])], [])),
+    !.
+
+test(scalar_if_and_parses) :-
+    plawk_parse_string("{ if (i > 2 && j < 5) { print i } }\n",
+        program([], [rule(always,
+            [if(scalar_if(and(cmp(var(i), gt, int(2)),
+                              cmp(var(j), lt, int(5)))),
+                [print([var(i)])], [])])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% A scalar `if` on an accumulator, counted into another scalar read from END.
+test(scalar_if_counter, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "{ n++; if (n > 2) hits++ }\nEND { print hits }\n",
+    build_run(Dir, 'sc', Src, "a\nb\nc\nd\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2\n"),
+    !.
+
+% A scalar `if` guarding a print of a field.
+test(scalar_if_guarded_field_print, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "{ n++; if (n > 1) print $1 }\n",
+    build_run(Dir, 'sp', Src, "x\ny\nz\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "y\nz\n"),
+    !.
+
+% `&&` over scalar comparisons.
+test(scalar_if_and, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "{ n++; if (n > 1 && n < 4) print $1 }\n",
+    build_run(Dir, 'sa', Src, "a\nb\nc\nd\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "b\nc\n"),
+    !.
+
+% The headline enabler: a scalar `if` INSIDE a loop (guard on the loop counter).
+test(scalar_if_inside_loop, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "{ i = 0; while (i < 5) { if (i > 2) print i; i++ } }\n",
+    build_run(Dir, 'sl', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "3\n4\n"),
+    !.
+
+% NOTE: a scalar `if` in an END block (`END { if (n > 1) ... }`) uses the
+% separate END-print lowering, not the rule-body sequence walker, so it is not
+% wired here -- a follow-on. Scalar `if` in rule bodies and loops (the loop
+% control enabler) is what this PR delivers.
+
+% A field/regex condition still compiles and runs (no regression).
+test(field_regex_if_still_runs, [condition(clang_available)]) :-
+    sdir(Dir),
+    Src = "{ if ($0 ~ /err/) print $1 }\n",
+    build_run(Dir, 'fr', Src, "err 1\nok 2\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "err\n"),
+    !.
+
+:- end_tests(plawk_scalar_if).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+sdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_scalar_if', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).

--- a/tests/test_plawk_while.pl
+++ b/tests/test_plawk_while.pl
@@ -52,21 +52,60 @@ test(do_while_parses) :-
             [])),
     !.
 
-% Building a program with a while loop is a clean compile error (exit 2) until
-% the loop runtime lands.
-test(while_is_not_yet_error) :-
+% RUNTIME (PLAWK_CONTROL_FLOW_PLAN.md PR 2): a `while` loop iterates its
+% mutable scalar state via loop-carried head phis. `{ i = 0; while (i < 3) {
+% print i; i++ } }` prints 0/1/2 and stops.
+test(while_runtime_counts, [condition(clang_available)]) :-
     wdir(Dir),
     Src = "{ i = 0; while (i < 3) { print i; i++ } }\n",
-    build_status(Dir, 'w', Src, St),
-    assertion(St == 2),
+    build_run(Dir, 'w', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
     !.
 
-% A do-while loop is likewise a clean not-yet error (shares the loop runtime).
-test(do_while_is_not_yet_error) :-
+% A `while` whose condition is false at entry runs the body ZERO times.
+test(while_runtime_zero_iterations, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ i = 5; while (i < 3) { print i; i++ } }\n",
+    build_run(Dir, 'wz', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == ""),
+    !.
+
+% `do-while` runs the body at least once even when the condition starts false.
+test(do_while_runtime_runs_once, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ i = 5; do { print i; i++ } while (i < 3) }\n",
+    build_run(Dir, 'dw1', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "5\n"),
+    !.
+
+% `do-while` iterates when the condition holds.
+test(do_while_runtime_counts, [condition(clang_available)]) :-
     wdir(Dir),
     Src = "{ i = 0; do { print i; i++ } while (i < 3) }\n",
-    build_status(Dir, 'dw', Src, St),
-    assertion(St == 2),
+    build_run(Dir, 'dw', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+% The loop restarts per record (mutable state does not leak between records).
+test(while_runtime_per_record, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ i = 0; while (i < 2) { print i; i++ } }\n",
+    build_run(Dir, 'wpr', Src, "a\nb\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n0\n1\n"),
+    !.
+
+% A loop that accumulates into a scalar read from END.
+test(while_runtime_accumulate_to_end, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ s = 0; i = 0; while (i < 4) { s += i; i++ } }\nEND { print s }\n",
+    build_run(Dir, 'wacc', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "6\n"),
     !.
 
 % A program with no while loop is unaffected (no false trigger).
@@ -100,3 +139,21 @@ build_status(Dir, Name, Src, Status) :-
     process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
         [stdout(null), stderr(null), process(Pid)]),
     process_wait(Pid, exit(Status)).
+
+% Build a program, then run the binary on Input (stdin), capturing stdout.
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).

--- a/tests/test_plawk_while.pl
+++ b/tests/test_plawk_while.pl
@@ -1,0 +1,82 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `while` loops, PR 1: the SURFACE. `while (VAR CMP int) { BODY }` parses
+% to while_loop(cmp(var(V), Op, int(N)), Body) -- the awk while control
+% structure. The loop runtime (mutable scalar state iterated to a fixed point)
+% is not wired yet, so building a program that uses one is a clean, specific
+% compile error rather than the generic "outside the multi-pass surface".
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_while).
+
+% `while (i < 3) { ... }` parses to while_loop(cmp(var(i), lt, int(3)), Body);
+% the body is a general action block.
+test(while_parses) :-
+    plawk_parse_string(
+        "{ i = 0; while (i < 3) { print i; i++ } }\n",
+        program([],
+            [rule(always,
+                 [set(var(i), int(0)),
+                  while_loop(cmp(var(i), lt, int(3)),
+                      [print([var(i)]), inc(var(i))])])],
+            [])),
+    !.
+
+% The comparison operators all parse.
+test(while_operators_parse) :-
+    forall(member(Op-Sym,
+               [lt-"<", le-"<=", gt-">", ge-">=", eq-"==", ne-"!="]),
+        ( format(string(Src), "{ while (n ~w 5) { n++ } }\n", [Sym]),
+          plawk_parse_string(Src,
+              program([],
+                  [rule(always,
+                       [while_loop(cmp(var(n), Op, int(5)), [inc(var(n))])])],
+                  [])) )),
+    !.
+
+% Building a program with a while loop is a clean compile error (exit 2) until
+% the loop runtime lands.
+test(while_is_not_yet_error) :-
+    wdir(Dir),
+    Src = "{ i = 0; while (i < 3) { print i; i++ } }\n",
+    build_status(Dir, 'w', Src, St),
+    assertion(St == 2),
+    !.
+
+% A program with no while loop is unaffected (no false trigger).
+test(non_while_program_builds, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ print $1 }\n",
+    build_status(Dir, 'ok', Src, St),
+    assertion(St == 0),
+    !.
+
+:- end_tests(plawk_while).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+wdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_while', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_status(Dir, Name, Src, Status) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).

--- a/tests/test_plawk_while.pl
+++ b/tests/test_plawk_while.pl
@@ -108,6 +108,56 @@ test(while_runtime_accumulate_to_end, [condition(clang_available)]) :-
     assertion(Out == "6\n"),
     !.
 
+% GENERAL CONDITION (PR 3): the right side of a comparison may be another loop
+% variable, not just an integer -- `while (i < n)`.
+test(while_condition_var_bound, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ n = 3; i = 0; while (i < n) { print i; i++ } }\n",
+    build_run(Dir, 'wcv', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+% `&&` combines comparisons (both must hold): `i < 5 && i < 3` stops at 3.
+test(while_condition_and, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ i = 0; while (i < 5 && i < 3) { print i; i++ } }\n",
+    build_run(Dir, 'wca', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+% `||` combines comparisons (either may hold): `i < 2 || i < 3` runs while the
+% weaker bound holds, stopping at 3.
+test(while_condition_or, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ i = 0; while (i < 2 || i < 3) { print i; i++ } }\n",
+    build_run(Dir, 'wco', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n2\n"),
+    !.
+
+% do-while with a variable bound.
+test(do_while_condition_var_bound, [condition(clang_available)]) :-
+    wdir(Dir),
+    Src = "{ n = 2; i = 0; do { print i; i++ } while (i < n) }\n",
+    build_run(Dir, 'dwcv', Src, "x\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0\n1\n"),
+    !.
+
+% The general condition parses to and/or/cmp AST; a single comparison stays a
+% bare cmp (the PR 2 subset is unchanged).
+test(while_condition_ast_shapes) :-
+    plawk_parse_string("{ while (i < n && j > 0) { i++ } }\n",
+        program([], [rule(always,
+            [while_loop(and(cmp(var(i), lt, var(n)), cmp(var(j), gt, int(0))),
+                 [inc(var(i))])])], [])),
+    plawk_parse_string("{ while (i < 3) { i++ } }\n",
+        program([], [rule(always,
+            [while_loop(cmp(var(i), lt, int(3)), [inc(var(i))])])], [])),
+    !.
+
 % A program with no while loop is unaffected (no false trigger).
 test(non_while_program_builds, [condition(clang_available)]) :-
     wdir(Dir),

--- a/tests/test_plawk_while.pl
+++ b/tests/test_plawk_while.pl
@@ -40,12 +40,32 @@ test(while_operators_parse) :-
                   [])) )),
     !.
 
+% `do { BODY } while (VAR CMP int)` parses to do_while_loop(Body, cmp(...)).
+test(do_while_parses) :-
+    plawk_parse_string(
+        "{ i = 0; do { print i; i++ } while (i < 3) }\n",
+        program([],
+            [rule(always,
+                 [set(var(i), int(0)),
+                  do_while_loop([print([var(i)]), inc(var(i))],
+                      cmp(var(i), lt, int(3)))])],
+            [])),
+    !.
+
 % Building a program with a while loop is a clean compile error (exit 2) until
 % the loop runtime lands.
 test(while_is_not_yet_error) :-
     wdir(Dir),
     Src = "{ i = 0; while (i < 3) { print i; i++ } }\n",
     build_status(Dir, 'w', Src, St),
+    assertion(St == 2),
+    !.
+
+% A do-while loop is likewise a clean not-yet error (shares the loop runtime).
+test(do_while_is_not_yet_error) :-
+    wdir(Dir),
+    Src = "{ i = 0; do { print i; i++ } while (i < 3) }\n",
+    build_status(Dir, 'dw', Src, St),
     assertion(St == 2),
     !.
 


### PR DESCRIPTION
A rule-level `exit` / `exit N` stops the record loop, runs `END`, and returns
`N` (default `0`) — the common AWK early-terminate (audit gap 4).

## How it works

`exit` reuses the existing rule-level stream-break path
(`break_close_stream` → `END` → `ret`), adding an exit code stored in a new
`@plawk_exit_code` global and read at the final `ret`. The global defaults to
`0`, so every non-`exit` program is byte-unchanged (the `end_print` ret just
loads a constant `0`).

- **Parser** — `exit` / `exit N` → `exit(int(N))`, wired into the action
  dispatch after `continue`.
- **Top-level exit** is modelled as a terminal control `terminal_exit` (the
  sibling of `terminal_break`): the trailing `exit` is replaced by a store-only
  `exit_store(N)` body marker (lowered to just the code store, no branch) and
  the rule target branches to `break_close_stream`. The `continue_loop`
  next-slot phi and the next rule's input phi skip a `terminal_exit` rule's
  `done` block — it leaves the record loop, exactly like `terminal_break`.
- **Inside an `if`/`else` branch or a loop**, `exit` flows via the `branch_exit`
  exit + `plawk_branch_to_done_ir` (branch to `break_close_stream`). Unlike
  `break`, a loop does **not** consume it — `exit` always ends the whole program
  (it propagates past any enclosing loop). The if-join treats an exiting branch
  as terminal (the join takes the other branch).
- **Scalar state** at the exit point merges into `END` through the break-close
  phi (both `branch_exit` and `terminal_exit` incomings).

## Tests

`tests/test_plawk_exit.pl` (13): parse (`exit`, `exit N`, guarded); stream stop
+ exit code; default `0`; `END` runs on exit; `exit` in `if` / `else` / loop;
scalar state → `END`; accumulated count → `END`; mixed body-print + guarded
exit + `END`; and a no-`exit` control that still returns `0`.

Regressions green: `loop_control`, `while`, `scalar_if`, `end_if`, `concat`,
`if_bodies`, `print_literals`, `surface_{arith,end_scalar,else_if}`.

## Docs

`PLAWK_AWK_FEATURE_AUDIT.md` — `exit [n]` gap 4 → LANDED (follow-on noted:
`exit` inside `BEGIN`/`END`, and non-constant exit codes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_