### PR TITLE
WAM/LLVM plawk: delete arr[k] (assoc-array entry removal)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -44,6 +44,7 @@ only (runtime pending) · ❌ missing.
 | brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |
 | field assignment (`$2 = expr`) | ❌ | rebuilding `$0` from mutated fields not wired |
 | C-style `for (;;)` | ❌ | |
+| `delete arr[k]` | ◐ | `delete arr[$k]` removes the entry keyed by a field (parity with `arr[$k]++`); backward-shift deletion in the runtime (later colliding keys stay reachable), missing key is a no-op. String-literal / var keys are a follow-on |
 | `exit [n]` | ✅ | stops the record loop, runs END, returns N (default 0); `exit` in a rule body, an `if`/`else` branch, or a loop (propagates past the loop) — scalar state at the exit point flows into END |
 | `delete arr[k]` | ❌ | |
 | `getline` | ❌ | the multi-pass / `over` readers cover much of its use |
@@ -77,7 +78,7 @@ only (runtime pending) · ❌ missing.
 | assoc arrays `arr[k]` | ✅ | native assoc tables |
 | `k in arr` (membership / for-in) | ✅ | |
 | multi-dim `arr[i,j]` (SUBSEP) | ❌ | |
-| `delete` | ❌ | |
+| `delete` | ◐ | `delete arr[$k]` (field key) removes an entry; backward-shift runtime delete. String-literal / var keys pending |
 
 ## plawk-specific surface (beyond AWK)
 
@@ -147,8 +148,16 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    `print $1 $2`, rule bodies + `END`; the remaining concat work is assignment
    into a string-valued scalar). Ternary is the next most-missed *expression*
    form; parser + expression-lowering work.
-6. **`delete arr[k]`** — rounds out the assoc-array story (paired with the
-   existing for-in / `in`).
+6. **`delete arr[k]` — LANDED (field key).** `delete arr[$k]` removes the entry
+   keyed by field k, matching the counted inc `arr[$k]++`. The runtime primitive
+   `@wam_assoc_i64_delete` does **backward-shift deletion** on the linear-probing
+   table, so later keys that collided into the same cluster stay reachable and
+   `get`/`inc`/`set` need no change (the no-gap invariant they rely on is
+   preserved); a missing key is a no-op. Wired through the assoc for-in driver
+   (build → delete → for-in report). Tests: `tests/test_plawk_delete.pl` and
+   `tests/core/test_wam_llvm_assoc_i64_runtime.pl` (backward-shift unit test).
+   *Still open (follow-on):* string-literal / variable keys (`delete arr["k"]`,
+   `delete arr[k]`), and `delete` in the scalar/mixed sequence-walker path.
 7. **`split` / `sub` / `gsub` / `match` / `sprintf`** — the string-builtin
    family; larger, lower priority for the DSL's data-pipeline focus.
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4510,6 +4510,7 @@ plawk_passes_tables(Passes, Tables) :-
     sort(Names0, Tables).
 
 plawk_action_table_name(inc_assoc(var(Name), _Key), Name).
+plawk_action_table_name(delete_assoc(var(Name), _Key), Name).
 plawk_action_table_name(add_assoc(var(Name), _Key, _Delta), Name).
 plawk_action_table_name(set_row(var(Name), _Key), Name).
 plawk_action_table_name(set_row_cons(var(Name), _Key, _Fields), Name).
@@ -5201,6 +5202,7 @@ plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays,
         ( member(rule(_Pattern, ActionSpecs, _Control), RuleSpecs),
           ( member(RuleArrayName-_KeyIndex, ActionSpecs)
           ; member(dynassoc(RuleArrayName, _Call), ActionSpecs)
+          ; member(assoc_delete(RuleArrayName, _KeyIndex), ActionSpecs)
           ; plawk_assoc_spec_forin_array(ActionSpecs, RuleArrayName)
           )
         ),
@@ -6556,6 +6558,11 @@ plawk_assoc_body_action_spec(inc_assoc(var(ArrayName), field(KeyIndex)),
 plawk_assoc_body_action_spec(inc_assoc(var(ArrayName), Blob),
         ArrayName-blob_key(Blob)) :-
     plawk_assoc_blob_key_ok(Blob).
+% `delete arr[$k]` -- remove the entry keyed by field k (v1: a field key, like
+% the counted inc). Absent key is a no-op (backward-shift delete in the runtime).
+plawk_assoc_body_action_spec(delete_assoc(var(ArrayName), field(KeyIndex)),
+        assoc_delete(ArrayName, KeyIndex)) :-
+    integer(KeyIndex), KeyIndex > 0.
 % Associative add-assign `arr[$k] += DELTA`: fold DELTA (a field value or an
 % integer constant) into the table at the key interned from field k. The
 % general form of `arr[$k]++` and the pass-1 half of per-key normalise. v1
@@ -6858,6 +6865,13 @@ plawk_assoc_planned_actions([ArrayName-KeyIndex | Rest], Tables, StrArrays,
       NextIndex is Index + 1
     },
     [assoc_action(Index, ArrayName, TableIndex, KeyIndex)],
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
+plawk_assoc_planned_actions([assoc_delete(ArrayName, KeyIndex) | Rest],
+        Tables, StrArrays, PosArrays, Index) -->
+    { nth0(TableIndex, Tables, ArrayName),
+      NextIndex is Index + 1
+    },
+    [assoc_delete_action(Index, ArrayName, TableIndex, KeyIndex)],
     plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
 plawk_assoc_planned_actions([assoc_add(ArrayName, KeyIndex, Delta) | Rest],
         Tables, StrArrays, PosArrays, Index) -->
@@ -7666,6 +7680,47 @@ plawk_assoc_rule_action_blocks(RuleIndex, [assoc_action(Index, _ArrayName, Table
       format(atom(Next), '  br label %~w', [ActionNextLabel])
     },
     [Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, KeyId, Inc, Next, ''],
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+% `delete arr[$k]`: same key-intern + missing-key skip as the counted inc, but
+% call the void backward-shift delete instead of the inc. An absent key (null
+% slice) skips to the next action; the runtime delete is itself a no-op if the
+% interned key is not in the table.
+plawk_assoc_rule_action_blocks(RuleIndex, [assoc_delete_action(Index, _ArrayName, TableIndex, KeyIndex) | Rest], NextLabel, FieldSeparator) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(HaveLabel), 'assoc_rule_~w_action_~w_have_key:',
+          [RuleIndex, Index]),
+      format(atom(HaveLabelName), 'assoc_rule_~w_action_~w_have_key',
+          [RuleIndex, Index]),
+      format(atom(Slice),
+          '  %assoc_rule_~w_action_~w_key_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 ~w)',
+          [RuleIndex, Index, KeyIndex, FieldSeparator]),
+      format(atom(Ptr),
+          '  %assoc_rule_~w_action_~w_key_ptr = extractvalue %WamSlice %assoc_rule_~w_action_~w_key_slice, 0',
+          [RuleIndex, Index, RuleIndex, Index]),
+      format(atom(Len),
+          '  %assoc_rule_~w_action_~w_key_len = extractvalue %WamSlice %assoc_rule_~w_action_~w_key_slice, 1',
+          [RuleIndex, Index, RuleIndex, Index]),
+      format(atom(Missing),
+          '  %assoc_rule_~w_action_~w_key_missing = icmp eq i8* %assoc_rule_~w_action_~w_key_ptr, null',
+          [RuleIndex, Index, RuleIndex, Index]),
+      format(atom(Branch),
+          '  br i1 %assoc_rule_~w_action_~w_key_missing, label %~w, label %~w',
+          [RuleIndex, Index, ActionNextLabel, HaveLabelName]),
+      format(atom(KeyId),
+          '  %assoc_rule_~w_action_~w_key_id = call i64 @wam_intern_atom(i8* %assoc_rule_~w_action_~w_key_ptr, i64 %assoc_rule_~w_action_~w_key_len)',
+          [RuleIndex, Index, RuleIndex, Index, RuleIndex, Index]),
+      format(atom(Del),
+          '  call void @wam_assoc_i64_delete(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %assoc_rule_~w_action_~w_key_id)',
+          [TableIndex, RuleIndex, Index]),
+      format(atom(Next), '  br label %~w', [ActionNextLabel])
+    },
+    [Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, KeyId, Del, Next, ''],
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
 % Associative add-assign `arr[$k] += DELTA`: same key-intern + missing-key
 % skip as the counted inc, but the inc delta is the record's DELTA (a field

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1576,8 +1576,28 @@ action(Action) -->
     assignment_action(Action),
     !.
 action(Action) -->
+    delete_action(Action),
+    !.
+action(Action) -->
     increment_action(Action),
     !.
+
+%% delete_action(-Action)//
+%
+%  `delete arr[k]` -- remove the entry keyed by `k` from an assoc table.
+%  Parses to delete_assoc(var(Name), KeyExpr). Same key forms as `arr[k]++`
+%  (a field `$N`, an integer, a quoted string, a blob call, or a bare var).
+delete_action(delete_assoc(var(Name), KeyExpr)) -->
+    "delete",
+    identifier_boundary,
+    ws,
+    table_ident(Name),
+    ws,
+    "[",
+    ws,
+    assoc_key_expr(KeyExpr),
+    ws,
+    "]".
 
 %% if_action(-Action)//
 %

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4644,6 +4644,114 @@ get.miss:
   ret i64 0
 }
 
+; Remove %key from the table. Linear-probing has no tombstones, so a plain
+; "mark empty" would break the probe chains of later keys that collided here.
+; Backward-shift deletion repairs the cluster: after clearing the found slot,
+; walk forward and pull back any entry whose home bucket is not cyclically
+; inside the (hole, j] gap, so every remaining key stays reachable. get/inc/set
+; are unchanged (the no-gap invariant they rely on is preserved). No-op when the
+; key is absent.
+define void @wam_assoc_i64_delete(%WamAssocI64Table* %table, i64 %key) {
+entry:
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %del.done, label %del.load
+
+del.load:
+  %cap_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 1
+  %cap = load i64, i64* %cap_slot
+  %cap_zero = icmp eq i64 %cap, 0
+  br i1 %cap_zero, label %del.done, label %del.start
+
+del.start:
+  %entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  %entries = load %WamAssocI64Entry*, %WamAssocI64Entry** %entries_slot
+  %entries_null = icmp eq %WamAssocI64Entry* %entries, null
+  br i1 %entries_null, label %del.done, label %del.hash
+
+del.hash:
+  %start = urem i64 %key, %cap
+  br label %del.find
+
+del.find:
+  %idx = phi i64 [ %start, %del.hash ], [ %next_idx, %del.find_next ]
+  %probes = phi i64 [ 0, %del.hash ], [ %next_probes, %del.find_next ]
+  %find_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %idx
+  %find_occ_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %find_entry, i32 0, i32 2
+  %find_occ = load i1, i1* %find_occ_slot
+  br i1 %find_occ, label %del.check_key, label %del.done
+
+del.check_key:
+  %find_key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %find_entry, i32 0, i32 0
+  %find_key = load i64, i64* %find_key_slot
+  %find_match = icmp eq i64 %find_key, %key
+  br i1 %find_match, label %del.found, label %del.find_next_check
+
+del.find_next_check:
+  %next_probes = add i64 %probes, 1
+  %find_full = icmp uge i64 %next_probes, %cap
+  br i1 %find_full, label %del.done, label %del.find_next
+
+del.find_next:
+  %idx_plus = add i64 %idx, 1
+  %idx_wrap = icmp uge i64 %idx_plus, %cap
+  %next_idx = select i1 %idx_wrap, i64 0, i64 %idx_plus
+  br label %del.find
+
+del.found:
+  ; clear the found slot and drop the count
+  store i1 false, i1* %find_occ_slot
+  %count_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 0
+  %old_count = load i64, i64* %count_slot
+  %new_count = sub i64 %old_count, 1
+  store i64 %new_count, i64* %count_slot
+  br label %del.scan
+
+del.scan:
+  %hole = phi i64 [ %idx, %del.found ], [ %j, %del.move ], [ %hole, %del.nomove ]
+  %scan_prev = phi i64 [ %idx, %del.found ], [ %j, %del.move ], [ %j, %del.nomove ]
+  %j_plus = add i64 %scan_prev, 1
+  %j_wrap = icmp uge i64 %j_plus, %cap
+  %j = select i1 %j_wrap, i64 0, i64 %j_plus
+  %j_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %j
+  %j_occ_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %j_entry, i32 0, i32 2
+  %j_occ = load i1, i1* %j_occ_slot
+  br i1 %j_occ, label %del.consider, label %del.done
+
+del.consider:
+  %j_key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %j_entry, i32 0, i32 0
+  %j_key = load i64, i64* %j_key_slot
+  %j_home = urem i64 %j_key, %cap
+  ; movable = j_home NOT cyclically in (hole, j]
+  %no_wrap = icmp ult i64 %hole, %j
+  %home_gt_hole = icmp ugt i64 %j_home, %hole
+  %home_le_j = icmp ule i64 %j_home, %j
+  %in_nowrap = and i1 %home_gt_hole, %home_le_j
+  %in_wrap = or i1 %home_gt_hole, %home_le_j
+  %in_gap = select i1 %no_wrap, i1 %in_nowrap, i1 %in_wrap
+  %movable = xor i1 %in_gap, true
+  br i1 %movable, label %del.move, label %del.nomove
+
+del.move:
+  ; pull entries[j] back into the hole, then clear entries[j]
+  %hole_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %hole
+  %hole_key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %hole_entry, i32 0, i32 0
+  store i64 %j_key, i64* %hole_key_slot
+  %j_val_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %j_entry, i32 0, i32 1
+  %j_val = load i64, i64* %j_val_slot
+  %hole_val_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %hole_entry, i32 0, i32 1
+  store i64 %j_val, i64* %hole_val_slot
+  %hole_occ_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %hole_entry, i32 0, i32 2
+  store i1 true, i1* %hole_occ_slot
+  store i1 false, i1* %j_occ_slot
+  br label %del.scan
+
+del.nomove:
+  br label %del.scan
+
+del.done:
+  ret void
+}
+
 define i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 %key, i64 %delta) {
 entry:
   %table_null = icmp eq %WamAssocI64Table* %table, null

--- a/tests/core/test_wam_llvm_assoc_i64_runtime.pl
+++ b/tests/core/test_wam_llvm_assoc_i64_runtime.pl
@@ -28,6 +28,10 @@ test(assoc_i64_resizes_across_many_numeric_keys) :-
     assoc_i64_resize_stress_driver_ir(DriverIR),
     run_assoc_i64_smoke('uw_wam_assoc_i64_resize_stress', DriverIR).
 
+test(assoc_i64_delete_backward_shifts_probe_chain) :-
+    assoc_i64_delete_driver_ir(DriverIR),
+    run_assoc_i64_smoke('uw_wam_assoc_i64_delete', DriverIR).
+
 run_assoc_i64_smoke(Name, DriverIR) :-
     tmp_root(Root),
     directory_file_path(Root, Name, Dir),
@@ -127,6 +131,53 @@ check_counts:
   %missing_ok = icmp eq i64 %got_missing, 0
   %zl_ok = and i1 %zero_ok, %last_ok
   %all_ok = and i1 %zl_ok, %missing_ok
+  call void @wam_assoc_i64_free(%WamAssocI64Table* %table)
+  br i1 %all_ok, label %ok, label %bad_counts
+
+ok:
+  ret i32 0
+
+alloc_fail:
+  ret i32 90
+
+bad_counts:
+  ret i32 91
+}
+').
+
+% Deleting a key in the middle of a probe chain must pull the following
+% colliding key back so it stays reachable (backward-shift), and preserve its
+% value. Keys 1/17/33 all hash to slot 1 at cap 16 -> slots 1,2,3. Delete 17
+% (slot 2); 33 (home 1) shifts back to slot 2. Deleting a missing key is a
+% no-op. After re-adding the deleted key it counts fresh from 0.
+assoc_i64_delete_driver_ir('
+define i32 @main() {
+entry:
+  %table = call %WamAssocI64Table* @wam_assoc_i64_new(i64 16)
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %alloc_fail, label %exercise
+
+exercise:
+  %a1 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 1, i64 1)
+  %b1 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 17, i64 1)
+  %c1 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 33, i64 1)
+  %c2 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 33, i64 1)
+  ; delete the middle of the 1/17/33 chain
+  call void @wam_assoc_i64_delete(%WamAssocI64Table* %table, i64 17)
+  ; deleting an absent key is a no-op
+  call void @wam_assoc_i64_delete(%WamAssocI64Table* %table, i64 99)
+  %got_a = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 1)
+  %got_del = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 17)
+  %got_c = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 33)
+  ; re-adding the deleted key counts fresh from 0
+  %b_re = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 17, i64 1)
+  %a_ok = icmp eq i64 %got_a, 1
+  %del_ok = icmp eq i64 %got_del, 0
+  %c_ok = icmp eq i64 %got_c, 2
+  %re_ok = icmp eq i64 %b_re, 1
+  %ad_ok = and i1 %a_ok, %del_ok
+  %adc_ok = and i1 %ad_ok, %c_ok
+  %all_ok = and i1 %adc_ok, %re_ok
   call void @wam_assoc_i64_free(%WamAssocI64Table* %table)
   br i1 %all_ok, label %ok, label %bad_counts
 

--- a/tests/test_plawk_delete.pl
+++ b/tests/test_plawk_delete.pl
@@ -1,0 +1,131 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `delete arr[k]` -- remove an entry from an assoc table (AWK
+% `delete arr[k]`). v1 keys on a field (`delete arr[$k]`), matching the counted
+% inc `arr[$k]++`; a string-literal / var key is a clean not-yet (compile error).
+% The runtime primitive (`@wam_assoc_i64_delete`) does backward-shift deletion
+% so later colliding keys stay reachable; a missing key is a no-op. for-in
+% iteration order is hash-dependent, so outputs are compared as sorted sets.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_delete).
+
+% --- parsing ----------------------------------------------------------------
+
+test(delete_field_parses) :-
+    plawk_parse_string("{ delete a[$1] }\n",
+        program([], [rule(always, [delete_assoc(var(a), field(1))])], [])),
+    !.
+
+test(delete_guarded_parses) :-
+    plawk_parse_string("$1 == \"rm\" { delete counts[$2] }\n",
+        program([],
+            [rule(field_eq(1, "rm"), [delete_assoc(var(counts), field(2))])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% `delete` removes a counted key: `drop` is counted then deleted, so END's
+% for-in no longer sees it.
+test(delete_removes_key, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ seen[$1]++ }\n$1 == \"drop\" { delete seen[$1] }\nEND { for (k in seen) print k }\n",
+    build_run_sorted(Dir, 'rm', Src, "a\nb\ndrop\na\n", Lines, St),
+    assertion(St == 0),
+    assertion(Lines == ["a", "b"]),
+    !.
+
+% Deleting resets the count; a later insert of the same key counts fresh from 1.
+test(delete_resets_count, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ seen[$1]++ }\n$2 == \"x\" { delete seen[$1] }\nEND { for (k in seen) print k, seen[k] }\n",
+    build_run_sorted(Dir, 'reset', Src, "a y\na y\na x\na y\nb y\n", Lines, St),
+    assertion(St == 0),
+    assertion(Lines == ["a 1", "b 1"]),
+    !.
+
+% `delete` may key on a different field than the counter.
+test(delete_by_other_field, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ seen[$1]++ }\n$1 == \"rm\" { delete seen[$2] }\nEND { for (k in seen) print k }\n",
+    build_run_sorted(Dir, 'other', Src, "a\nb\nrm a\nc\n", Lines, St),
+    assertion(St == 0),
+    assertion(Lines == ["b", "c", "rm"]),
+    !.
+
+% Deleting an absent key is a no-op (the record's own key stays).
+test(delete_missing_is_noop, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ seen[$1]++ }\n$1 == \"q\" { delete seen[$2] }\nEND { for (k in seen) print k, seen[k] }\n",
+    build_run_sorted(Dir, 'noop', Src, "a\nb\nq z\na\n", Lines, St),
+    assertion(St == 0),
+    assertion(Lines == ["a 2", "b 1", "q 1"]),
+    !.
+
+% A group-by with no delete is unaffected.
+test(no_delete_unaffected, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ counts[$1]++ }\nEND { for (k in counts) print k, counts[k] }\n",
+    build_run_sorted(Dir, 'plain', Src, "a\nb\na\nc\na\n", Lines, St),
+    assertion(St == 0),
+    assertion(Lines == ["a 3", "b 1", "c 1"]),
+    !.
+
+% A string-literal key is a clean not-yet (v1 keys on a field), so the program
+% is rejected with a compile error rather than miscompiled.
+test(delete_string_key_rejected, [condition(clang_available)]) :-
+    ldir(Dir),
+    Src = "{ seen[$1]++ }\n{ delete seen[\"x\"] }\nEND { for (k in seen) print k }\n",
+    build_status(Dir, 'strkey', Src, St),
+    assertion(St == 3),
+    !.
+
+:- end_tests(plawk_delete).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_delete', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Src, Bin) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin0),
+    Bin = Bin0-Prog.
+
+build_status(Dir, Name, Src, Status) :-
+    write_prog(Dir, Name, Src, Bin-Prog),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).
+
+build_run_sorted(Dir, Name, Src, Input, SortedLines, RunStatus) :-
+    write_prog(Dir, Name, Src, Bin-Prog),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)),
+    split_string(Out, "\n", "", Parts0),
+    exclude(==(""), Parts0, Parts),
+    msort(Parts, SortedLines).


### PR DESCRIPTION
`delete arr[$k]` removes the entry keyed by field `k` from an assoc table — the
AWK `delete arr[k]` (audit gap 6), keying on a field for parity with the counted
inc `arr[$k]++`.

## Runtime — `@wam_assoc_i64_delete` (backward-shift deletion)

The assoc table is open-addressing linear-probing with an `occupied` flag and
**no tombstones**, so a naive "mark empty" would break the probe chains of any
later key that collided into the same cluster (a subsequent `get` would stop at
the hole and miss it). The new primitive does **backward-shift deletion**: after
clearing the found slot it walks forward and pulls back any entry whose home
bucket is not cyclically inside the `(hole, j]` gap, so every remaining key
stays reachable and `get`/`inc`/`set`/`resize` are unchanged (the no-gap
invariant they rely on is preserved). A missing key is a no-op.

## Surface

- **Parser** — `delete arr[k]` → `delete_assoc(var(Name), KeyExpr)`, wired into
  the action dispatch (same key grammar as `arr[k]++`).
- **Codegen (assoc for-in driver)** — `delete_assoc(var(A), field(k))` →
  `assoc_delete(A, k)` spec → `assoc_delete_action` plan → an action block that
  interns the field-`k` slice and calls the void delete (mirrors the inc block;
  a null / missing key slice skips). The deleted array is registered as a table
  so a delete-only array is still discovered.
- **Scope** — v1 keys on a field (parity with inc). A string-literal / var key
  (`delete arr["x"]`) is a **clean compile error** (exit 3), not a miscompile.

## Tests

- `tests/test_plawk_delete.pl` (8): parse; remove a counted key; delete resets
  the count then re-add counts fresh; key by a different field; missing-key
  no-op; plain group-by unaffected; string-literal key rejected.
- `tests/core/test_wam_llvm_assoc_i64_runtime.pl`: a backward-shift unit test —
  delete the middle of a 3-key probe chain, verify the following key stays
  reachable **and** keeps its value, deleting an absent key is a no-op, and
  re-adding counts fresh.

Regressions green: `surface_forin_end_print`, `forin_filter`, `perkey`, and the
assoc i64 runtime suite.

## Docs

`PLAWK_AWK_FEATURE_AUDIT.md` — `delete` gap 6 → LANDED (field key); follow-on
noted: string-literal / var keys and the scalar/mixed sequence-walker path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_