### PR TITLE
WAM/LLVM plawk: printf format coverage (flags/width/precision, %c/%x/%o, %f family)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -30,7 +30,7 @@ only (runtime pending) · ❌ missing.
 | Feature | Status | Notes |
 |---|---|---|
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic, **concatenation**) | ✅ | constant fields (`print 1`, `print "x"`) + juxtaposition concat (`print $1 $2`) landed |
-| `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
+| `printf` | ✅ | standard `%[flags][width][.precision][length]conv`: integers `d`/`i`/`x`/`X`/`o`/`u` + `c` (code point), floats `f`/`g`/`e`/`F`/`G`/`E`, strings `%s`; flags `-+ 0#`, width, precision. Field-slice `%s` takes width but not precision (non-terminated buffer); `%c` needs a numeric arg |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`** (`END { if (n > 1) print … ; else print … }`, over final slot values) |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
@@ -130,8 +130,19 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    to update a scalar). Braceless bodies also landed: `if (c) print`,
    `while (c) x++`, `do stmt while (c)`, and braceless else-if chains — a
    control-flow body is a braced block *or* a single statement.
-3. **`printf` format coverage** — add `%f`/`%g` (f64 exists), `%c`, `%x`, and
-   width/precision; the current subset is thin for real formatting.
+3. **`printf` format coverage — LANDED.** The rewriter now parses the standard
+   conversion prefix `%[flags][width][.precision][length]<conv>` and rewrites to
+   a C printf spec driven by each argument's inferred kind: integer args (i64)
+   take `d`/`i`/`x`/`X`/`o`/`u` (with the `l` length modifier) and `c` (code
+   point → character); float args (f64) take `f`/`g`/`e`/`F`/`G`/`E`; string
+   args take `%s` with flags/width/precision. Flags `-+ 0#`, width, and
+   precision are honoured. A record-field `%s` (a non-null-terminated slice)
+   takes flags/width and rides `.*` for its length, so a user precision on a
+   field is a clean compile error (buffer safety) — a follow-on. `%c` needs a
+   numeric arg (a string arg's first-char form is a follow-on). Tests:
+   `tests/test_plawk_printf.pl`. *Still open (follow-on):* `%c` on a string
+   (first char), precision on a field slice, `*`-width (width from an arg), and
+   `printf` in a `BEGIN`/`END` block (a separate driver gap).
 4. **`exit [n]` — LANDED.** A rule-level `exit` / `exit N` stops the record loop,
    runs END, and returns N (default 0). It reuses the rule-level stream-break
    path (`break_close_stream` → END → `ret`), adding an exit code stored in

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -13397,46 +13397,91 @@ plawk_printf_rewrite_codes([Code | Rest], Kinds, [Code | RewrittenRest]) :-
 plawk_printf_rewrite_codes([0'%, 0'% | Rest], Kinds, [0'%, 0'% | RewrittenRest]) :-
     !,
     plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
-plawk_printf_rewrite_codes([0'% | Rest], [i64 | Kinds], [0'%, 0'l, 0'd | RewrittenRest]) :-
-    plawk_printf_i64_spec_codes(Rest, RestAfterSpec),
+% A conversion `%[flags][width][.precision][length]<conv>`: parse the standard
+% prefix, then rewrite the body per the next argument's inferred kind (the arg
+% kind drives the choice, so a mismatched conv -- e.g. %s for an integer arg --
+% cleanly fails the rewrite -> compile error rather than miscompiling).
+plawk_printf_rewrite_codes([0'% | Rest], Kinds0, Rewritten) :-
+    plawk_printf_scan_spec(Rest, Flags, Width, Prec, Conv, RestAfter),
+    plawk_printf_kind_spec(Kinds0, Flags, Width, Prec, Conv, Kinds, SpecBody),
     !,
-    plawk_printf_rewrite_codes(RestAfterSpec, Kinds, RewrittenRest).
-plawk_printf_rewrite_codes([0'%, 0's | Rest], [string | Kinds], [0'%, 0's | RewrittenRest]) :-
-    !,
-    plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
-plawk_printf_rewrite_codes([0'%, 0's | Rest], [slice_len, slice_ptr | Kinds],
-        [0'%, 0'., 0'*, 0's | RewrittenRest]) :-
-    !,
-    plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
-plawk_printf_rewrite_codes([0'% | Rest], [f64 | Kinds], [0'% | RewrittenSpec]) :-
-    plawk_printf_f64_spec_codes(Rest, SpecCodes, RestAfterSpec),
-    !,
-    append(SpecCodes, RewrittenRest, RewrittenSpec),
-    plawk_printf_rewrite_codes(RestAfterSpec, Kinds, RewrittenRest).
+    append([0'% | SpecBody], RewrittenRest, Rewritten),
+    plawk_printf_rewrite_codes(RestAfter, Kinds, RewrittenRest).
 
-% %f / %g / %e with an optional .N precision pass through unchanged for
-% double arguments (C varargs receive the double directly).
-plawk_printf_f64_spec_codes([0'., Digit | Rest0], [0'., Digit | SpecRest], Rest) :-
-    code_type(Digit, digit),
-    !,
-    plawk_printf_f64_precision_codes(Rest0, SpecRest, Rest).
-plawk_printf_f64_spec_codes([Conv | Rest], [Conv], Rest) :-
-    plawk_printf_f64_conversion_code(Conv).
+% Scan the standard printf conversion prefix: flags in `-+ 0#`, decimal width,
+% optional `.precision`, an optional (ignored) length modifier, then the
+% conversion character.
+plawk_printf_scan_spec(Codes, Flags, Width, Prec, Conv, Rest) :-
+    plawk_printf_take_flags(Codes, Flags, C1),
+    plawk_printf_take_digits(C1, Width, C2),
+    plawk_printf_take_prec(C2, Prec, C3),
+    plawk_printf_take_lenmod(C3, C4),
+    C4 = [Conv | Rest].
 
-plawk_printf_f64_precision_codes([Digit | Rest0], [Digit | SpecRest], Rest) :-
-    code_type(Digit, digit),
+plawk_printf_take_flags([C | Cs], [C | Fs], Rest) :-
+    memberchk(C, [0'-, 0'+, 0' , 0'0, 0'#]),
     !,
-    plawk_printf_f64_precision_codes(Rest0, SpecRest, Rest).
-plawk_printf_f64_precision_codes([Conv | Rest], [Conv], Rest) :-
-    plawk_printf_f64_conversion_code(Conv).
+    plawk_printf_take_flags(Cs, Fs, Rest).
+plawk_printf_take_flags(Cs, [], Cs).
+
+plawk_printf_take_digits([C | Cs], [C | Ds], Rest) :-
+    code_type(C, digit),
+    !,
+    plawk_printf_take_digits(Cs, Ds, Rest).
+plawk_printf_take_digits(Cs, [], Cs).
+
+% Precision keeps its leading `.` (a bare `.` is precision 0, as in C).
+plawk_printf_take_prec([0'. | Cs], [0'. | Ds], Rest) :-
+    !,
+    plawk_printf_take_digits(Cs, Ds, Rest).
+plawk_printf_take_prec(Cs, [], Cs).
+
+% A user-written length modifier is consumed and dropped; the emitter supplies
+% the correct one for the argument's representation (i64 -> `l`).
+plawk_printf_take_lenmod([0'l, 0'l | Cs], Cs) :- !.
+plawk_printf_take_lenmod([0'l | Cs], Cs) :- !.
+plawk_printf_take_lenmod([0'h, 0'h | Cs], Cs) :- !.
+plawk_printf_take_lenmod([0'h | Cs], Cs) :- !.
+plawk_printf_take_lenmod(Cs, Cs).
+
+% Map (arg kind, parsed prefix, conversion) to the C conversion body (the codes
+% after the leading `%`), consuming the kind(s) the argument contributed.
+% Integer arg (i64): d/i/x/X/o/u get the `l` length modifier; c takes the code
+% point as a character (no length modifier, precision dropped).
+plawk_printf_kind_spec([i64 | Ks], Flags, Width, _Prec, 0'c, Ks, Body) :-
+    !,
+    append([Flags, Width, [0'c]], Body).
+plawk_printf_kind_spec([i64 | Ks], Flags, Width, Prec, Conv, Ks, Body) :-
+    plawk_printf_int_conversion_code(Conv, OutConv),
+    append([Flags, Width, Prec, [0'l, OutConv]], Body).
+% Float arg (f64): f/g/e/F/G/E pass through with flags/width/precision.
+plawk_printf_kind_spec([f64 | Ks], Flags, Width, Prec, Conv, Ks, Body) :-
+    plawk_printf_f64_conversion_code(Conv),
+    append([Flags, Width, Prec, [Conv]], Body).
+% Null-terminated string arg (%s): flags/width/precision pass through.
+plawk_printf_kind_spec([string | Ks], Flags, Width, Prec, 0's, Ks, Body) :-
+    append([Flags, Width, Prec, [0's]], Body).
+% Record-field slice (%s over len+ptr): the length rides `.*`, so the slice
+% bounds the output; width is kept. A user precision can't be honoured -- the
+% slice pointer is not null-terminated, so `.N` (without `.*`) would read past
+% the field -- so `%.Ns` on a field is a clean compile error (a follow-on).
+plawk_printf_kind_spec([slice_len, slice_ptr | Ks], Flags, Width, [], 0's, Ks, Body) :-
+    append([Flags, Width, [0'., 0'*, 0's]], Body).
+
+% Integer conversions; `i` normalises to `d` (identical output).
+plawk_printf_int_conversion_code(0'd, 0'd).
+plawk_printf_int_conversion_code(0'i, 0'd).
+plawk_printf_int_conversion_code(0'x, 0'x).
+plawk_printf_int_conversion_code(0'X, 0'X).
+plawk_printf_int_conversion_code(0'o, 0'o).
+plawk_printf_int_conversion_code(0'u, 0'u).
 
 plawk_printf_f64_conversion_code(0'f).
 plawk_printf_f64_conversion_code(0'g).
 plawk_printf_f64_conversion_code(0'e).
-
-plawk_printf_i64_spec_codes([0'l, 0'd | Rest], Rest).
-plawk_printf_i64_spec_codes([0'd | Rest], Rest).
-plawk_printf_i64_spec_codes([0'i | Rest], Rest).
+plawk_printf_f64_conversion_code(0'F).
+plawk_printf_f64_conversion_code(0'G).
+plawk_printf_f64_conversion_code(0'E).
 
 plawk_print_ir_parts([], [], []).
 plawk_print_ir_parts([GlobalIR-BodyIR | Parts], [GlobalIR | GlobalParts], [BodyIR | BodyParts]) :-

--- a/tests/test_plawk_printf.pl
+++ b/tests/test_plawk_printf.pl
@@ -1,0 +1,154 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `printf` format coverage. The subset grew from %s/%d/%ld to the standard
+% conversion prefix `%[flags][width][.precision][length]<conv>`: integer args
+% (i64) take d/i/x/X/o/u (with the `l` length modifier) and c (code point ->
+% char); float args take f/g/e/F/G/E; string args (%s) take flags/width/
+% precision; a record-field slice (%s over len+ptr) takes flags/width and rides
+% `.*` for its length (a user precision on a field slice is a clean compile
+% error -- the pointer is not null-terminated). The format is rewritten to a C
+% printf format driven by each argument's inferred kind.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+:- begin_tests(plawk_printf).
+
+% --- integer width / flags --------------------------------------------------
+
+test(int_width, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'iw', "{ printf \"[%5d]\\n\", NR }\n", "a\n", Out, St),
+    assertion(St == 0), assertion(Out == "[    1]\n"), !.
+
+test(int_zero_pad, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'iz', "{ printf \"[%05d]\\n\", NR }\n", "a\n", Out, St),
+    assertion(St == 0), assertion(Out == "[00001]\n"), !.
+
+test(int_left_justify, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'il', "{ printf \"[%-5d]\\n\", NR }\n", "a\n", Out, St),
+    assertion(St == 0), assertion(Out == "[1    ]\n"), !.
+
+% --- hex / octal ------------------------------------------------------------
+
+test(hex_lower_upper, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'hx', "{ printf \"%x %X\\n\", $1 + 0, $1 + 0 }\n", "255\n", Out, St),
+    assertion(St == 0), assertion(Out == "ff FF\n"), !.
+
+test(hex_with_width_and_hash, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'hxw', "{ printf \"%#06x\\n\", $1 + 0 }\n", "255\n", Out, St),
+    assertion(St == 0), assertion(Out == "0x00ff\n"), !.
+
+test(octal, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'oc', "{ printf \"%o\\n\", $1 + 0 }\n", "8\n", Out, St),
+    assertion(St == 0), assertion(Out == "10\n"), !.
+
+% --- %c (code point -> character) -------------------------------------------
+
+test(char_from_code, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ch', "{ printf \"%c\\n\", NR + 64 }\n", "x\ny\n", Out, St),
+    assertion(St == 0), assertion(Out == "A\nB\n"), !.
+
+% --- string width / precision -----------------------------------------------
+
+test(string_literal_width, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'sw', "{ printf \"[%6s]\\n\", \"hi\" }\n", "x\n", Out, St),
+    assertion(St == 0), assertion(Out == "[    hi]\n"), !.
+
+test(string_literal_precision, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'sp', "{ printf \"%.2s\\n\", \"hello\" }\n", "x\n", Out, St),
+    assertion(St == 0), assertion(Out == "he\n"), !.
+
+test(field_slice_width, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'fw', "{ printf \"[%6s]\\n\", $1 }\n", "hi\n", Out, St),
+    assertion(St == 0), assertion(Out == "[    hi]\n"), !.
+
+test(field_slice_left_justify, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'fl', "{ printf \"[%-6s]|\\n\", $1 }\n", "hi\n", Out, St),
+    assertion(St == 0), assertion(Out == "[hi    ]|\n"), !.
+
+% A precision on a (non-null-terminated) field slice is a clean compile error.
+test(field_slice_precision_rejected, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_status(Dir, 'fp', "{ printf \"%.2s\\n\", $1 }\n", St),
+    assertion(St == 3), !.
+
+% --- float width / precision ------------------------------------------------
+
+test(float_width_precision, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'fwp', "{ printf \"[%8.2f]\\n\", float($1) }\n", "3.14159\n", Out, St),
+    assertion(St == 0), assertion(Out == "[    3.14]\n"), !.
+
+% --- unchanged basics -------------------------------------------------------
+
+test(plain_d_and_s_unchanged, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'basic', "{ printf \"%s=%d\\n\", $1, NR }\n", "a\nb\n", Out, St),
+    assertion(St == 0), assertion(Out == "a=1\nb=2\n"), !.
+
+test(percent_literal, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'pct', "{ printf \"%d%%\\n\", NR }\n", "a\n", Out, St),
+    assertion(St == 0), assertion(Out == "1%\n"), !.
+
+% --- mixed ------------------------------------------------------------------
+
+test(mixed_conversions, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'mix', "{ printf \"%-5s|%05d|%x\\n\", $1, $2 + 0, $2 + 0 }\n",
+        "ab 42\n", Out, St),
+    assertion(St == 0), assertion(Out == "ab   |00042|2a\n"), !.
+
+:- end_tests(plawk_printf).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_printf', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Src, Bin, Prog) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin).
+
+build_status(Dir, Name, Src, Status) :-
+    write_prog(Dir, Name, Src, Bin, Prog),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    write_prog(Dir, Name, Src, Bin, Prog),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
Extends `printf` from the `%s`/`%d`/`%ld`/`%f`-family subset to the standard
conversion prefix — flags, width, precision, and the `%c`/`%x`/`%X`/`%o`/`%u`
conversions (audit gap 3).

> **Stacked** on #3796 (`delete arr[k]`). Review/merge that first; this PR's base
> retargets to the feature line once it merges.

## How it works

The format rewriter now parses the full conversion prefix
`%[flags][width][.precision][length]<conv>` and rewrites to a C printf spec
**driven by each argument's inferred kind**:

- **integer arg (i64)** — `d`/`i`/`x`/`X`/`o`/`u` get the `l` length modifier
  (values are i64); `c` prints the code point as a character. `i` normalises to
  `d`.
- **float arg (f64)** — `f`/`g`/`e`/`F`/`G`/`E` pass through.
- **string arg (`%s`, null-terminated)** — flags/width/precision pass through.
- **record-field slice (`%s` over len+ptr)** — flags/width kept, the length
  rides `.*`; a user precision is a **clean compile error** (the pointer is not
  null-terminated, so `.N` without `.*` would read past the field).

Flags `-+ <space> 0 #`, decimal width, `.precision`, and a user length modifier
(`l`/`ll`/`h`/`hh`, consumed and replaced with the correct one) are parsed. A
conversion that doesn't match the arg kind (e.g. `%s` for an integer arg) fails
the rewrite → compile error, not a miscompile. The old `%s`/`%d`/`%ld`/`%.*s`/
`%f` paths are a strict subset, so existing programs are byte-unchanged.

## Tests

`tests/test_plawk_printf.pl` (16): int width / zero-pad / left-justify; hex
lower+upper and `%#06x`; octal; `%c` from a code point; string width and
precision; field-slice width and left-justify; field-slice precision rejected;
float `%8.2f`; `%%` literal; and a mixed `%-5s|%05d|%x`.

Regressions green: `surface_prefix_print` (the main printf suite),
`surface_float_exprs`, `surface_arith_exprs`.

## Docs

`PLAWK_AWK_FEATURE_AUDIT.md` — `printf` → done; follow-ons noted (`%c` on a
string, precision on a field slice, `*`-width, `printf` in `BEGIN`/`END`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_