### PR TITLE
WAM/LLVM plawk: ternary ?: in print / printf args (numeric, via select)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -67,7 +67,7 @@ only (runtime pending) · ❌ missing.
 | `FNR` `FILENAME` `ARGV` `ARGC` `RS` `ORS` `SUBSEP` `RSTART` `RLENGTH` | ❌ | single newline-delimited record model |
 | arithmetic `+ - * / % //` | ✅ | i64, awk precedence, safe div/mod |
 | comparison, `~`/`!~` | ✅ | |
-| ternary `?:` | ❌ | does not parse |
+| ternary `?:` | ◐ | `COND ? A : B` in print / printf args — numeric comparison condition, numeric branches (fields, `NR`/`NF`, int literals, i64 arithmetic); lowered to an LLVM `select`. Assignment-context (scalar-var operands) and string branches are follow-ons |
 | string concatenation (juxtaposition `$1 $2`) | ◐ | **`print` context landed** — `print $1 $2`, `print "x" $1 "-" $2`, in rule bodies and `END`; arithmetic binds tighter, comma still splits. Assignment concat (`x = $1 $2`) needs string-valued scalars — separate |
 | exponentiation `^` / `**` | ❌ | |
 
@@ -155,10 +155,19 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    exit point merges into END through the break-close phi. Tests:
    `tests/test_plawk_exit.pl`. *Still open (follow-on):* `exit` inside a `BEGIN`
    or `END` block, and non-constant exit codes (`exit code_var`).
-5. **Ternary `?:`** (string concatenation in `print` context **landed** —
-   `print $1 $2`, rule bodies + `END`; the remaining concat work is assignment
-   into a string-valued scalar). Ternary is the next most-missed *expression*
-   form; parser + expression-lowering work.
+5. **Ternary `?:` — LANDED (print / printf, numeric).** `COND ? A : B` in a
+   print field or printf argument: the condition is a numeric comparison
+   `L <op> R` and both branches are numeric (fields, `NR`/`NF`, integer
+   literals, i64 arithmetic). Lowered to an LLVM `select` — both branches are
+   evaluated (no side effects in an i64 expression), so it composes straight-line
+   anywhere an i64 value is used (`plawk_i64_expr_ir(ternary(...))`), and the
+   `%s`/`%d`/arith paths are unaffected. Tests: `tests/test_plawk_ternary.pl`.
+   *Still open (follow-on):* assignment-context ternary (`x = c ? a : b`, needs
+   scalar-var operands + the assignment RHS grammar), string-valued branches,
+   and boolean-combination conditions (`a && b ? ...`).
+   (String concatenation in `print` context landed earlier — `print $1 $2`,
+   rule bodies + `END`; assignment concat into a string-valued scalar is
+   separate — see gap below.)
 6. **`delete arr[k]` — LANDED (field key).** `delete arr[$k]` removes the entry
    keyed by field k, matching the counted inc `arr[$k]++`. The runtime primitive
    `@wam_assoc_i64_delete` does **backward-shift deletion** on the linear-probing

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -10485,6 +10485,14 @@ plawk_rule_body_print_action(printf(string(Format), Args)) :-
 
 plawk_rule_body_print_field(field(_)).
 plawk_rule_body_print_field(string(_)).
+% a ternary `COND ? A : B`: the condition operands and both branches must be
+% i64-valued (field / NR / NF / int literal / length / i64 arithmetic); lowered
+% to an LLVM select.
+plawk_rule_body_print_field(ternary(cmp(Left, _Op, Right), Then, Else)) :-
+    plawk_ternary_i64_operand_ok(Left),
+    plawk_ternary_i64_operand_ok(Right),
+    plawk_ternary_i64_operand_ok(Then),
+    plawk_ternary_i64_operand_ok(Else).
 % a string concatenation (`print $1 $2`): every operand must be a valid print
 % field; they are emitted adjacently with no separator.
 plawk_rule_body_print_field(concat(Parts)) :-
@@ -10553,6 +10561,17 @@ plawk_i64_operand_expr(dyncall_at_named(Name, Source, Args)) :-
     plawk_dyncall_at_expr(dyncall_at_named(Name, Source, Args)).
 plawk_i64_operand_expr(Expr) :-
     plawk_i64_general_binary_expr(Expr).
+
+%% plawk_ternary_i64_operand_ok(+Expr) is semidet.
+%  A ternary condition operand or branch: any i64 operand plus the surface
+%  forms the parser emits for fields / NR / NF / length that plawk_i64_expr_ir
+%  lowers directly.
+plawk_ternary_i64_operand_ok(special('NR')).
+plawk_ternary_i64_operand_ok(special('NF')).
+plawk_ternary_i64_operand_ok(int(field(_))).
+plawk_ternary_i64_operand_ok(length(field(_))).
+plawk_ternary_i64_operand_ok(Expr) :-
+    plawk_i64_operand_expr(Expr).
 
 plawk_prolog_call_expr(prolog_call(Name, Args)) :-
     atom(Name),
@@ -11852,6 +11871,12 @@ plawk_scalar_numeric_expr_ir(field_i64(FieldIndex), FieldSeparator, Prefix, Slot
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(field_i64(FieldIndex), FieldSeparator, ParseBase, ParseBase,
         ValueIR, GlobalIR, IR).
+% Ternary in a scalar assignment (`x = COND ? A : B`): an i64 value via select.
+plawk_scalar_numeric_expr_ir(ternary(Cond, Then, Else), FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, GlobalIR, IR) :-
+    format(atom(TernBase), '~w_slot_~w_op_~w_tern', [Prefix, SlotIndex, OpIndex]),
+    plawk_i64_expr_ir_parts(ternary(Cond, Then, Else), FieldSeparator, TernBase, TernBase,
+        ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
         OpIndex, ValueIR, GlobalIR, IR) :-
     plawk_i64_scalar_primary_expr(Expr),
@@ -12066,6 +12091,38 @@ plawk_i64_expr_ir(index(FieldIndex, Needle), FieldSeparator, Base, GlobalBase,
     llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
         Base, GlobalIR-CallIR),
     format(atom(ValueIR), '%~w', [Base]).
+% Ternary `COND ? A : B` over i64 values. COND is a single comparison
+% `L <op> R`; both branches are evaluated (no side effects in an i64 expr) and
+% an LLVM `select` picks one -- straight-line, so a ternary composes anywhere an
+% i64 expression is used (print, printf arg, assignment, arithmetic operand).
+plawk_i64_expr_ir(ternary(cmp(CondLeft, Op, CondRight), Then, Else),
+        FieldSeparator, Base, GlobalBase, ValueIR, GlobalParts, SetupParts) :-
+    plawk_icmp_pred(Op, Pred),
+    format(atom(CondLeftBase), '~w_cl', [Base]),
+    format(atom(CondLeftGlobal), '~w_cl', [GlobalBase]),
+    plawk_i64_expr_ir(CondLeft, FieldSeparator, CondLeftBase, CondLeftGlobal,
+        CondLeftValueIR, CondLeftGlobalParts, CondLeftSetupParts),
+    format(atom(CondRightBase), '~w_cr', [Base]),
+    format(atom(CondRightGlobal), '~w_cr', [GlobalBase]),
+    plawk_i64_expr_ir(CondRight, FieldSeparator, CondRightBase, CondRightGlobal,
+        CondRightValueIR, CondRightGlobalParts, CondRightSetupParts),
+    format(atom(ThenBase), '~w_t', [Base]),
+    format(atom(ThenGlobal), '~w_t', [GlobalBase]),
+    plawk_i64_expr_ir(Then, FieldSeparator, ThenBase, ThenGlobal,
+        ThenValueIR, ThenGlobalParts, ThenSetupParts),
+    format(atom(ElseBase), '~w_e', [Base]),
+    format(atom(ElseGlobal), '~w_e', [GlobalBase]),
+    plawk_i64_expr_ir(Else, FieldSeparator, ElseBase, ElseGlobal,
+        ElseValueIR, ElseGlobalParts, ElseSetupParts),
+    format(atom(CondLine), '  %~w_cond = icmp ~w i64 ~w, ~w',
+        [Base, Pred, CondLeftValueIR, CondRightValueIR]),
+    format(atom(SelLine), '  %~w = select i1 %~w_cond, i64 ~w, i64 ~w',
+        [Base, Base, ThenValueIR, ElseValueIR]),
+    format(atom(ValueIR), '%~w', [Base]),
+    append([CondLeftGlobalParts, CondRightGlobalParts, ThenGlobalParts,
+            ElseGlobalParts], GlobalParts),
+    append([CondLeftSetupParts, CondRightSetupParts, ThenSetupParts,
+            ElseSetupParts, [CondLine, SelLine]], SetupParts).
 
 %% plawk_i64_binary_op_lines(+LLVMOp, +Base, +LeftIR, +RightIR, -Lines)
 %
@@ -13266,6 +13323,12 @@ plawk_expr_uses_nr(special('NR')).
 plawk_expr_uses_nr(concat(Parts)) :-
     member(Part, Parts),
     plawk_expr_uses_nr(Part).
+plawk_expr_uses_nr(ternary(cmp(Left, _Op, Right), Then, Else)) :-
+    ( plawk_expr_uses_nr(Left)
+    ; plawk_expr_uses_nr(Right)
+    ; plawk_expr_uses_nr(Then)
+    ; plawk_expr_uses_nr(Else)
+    ).
 plawk_expr_uses_nr(Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
     ( plawk_expr_uses_nr(Left)
@@ -13612,6 +13675,14 @@ plawk_emit_print_expr_for_context(ssa(Value), FieldSeparator, Context,
     plawk_print_expr_value_base(Context, int, Base),
     plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
     plawk_i64_expr_ir(ssa(Value), FieldSeparator, Base, Base,
+        ValueIR, GlobalParts, SetupParts).
+
+% Ternary print field `print (COND ? A : B)`: an i64 value via select.
+plawk_emit_print_expr_for_context(ternary(Cond, Then, Else), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, int, Base),
+    plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(ternary(Cond, Then, Else), FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(Expr, FieldSeparator, Context,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2165,7 +2165,7 @@ printf_args([Arg | Args]) -->
     ",",
     ws,
     !,
-    field_expr(Arg),
+    printf_arg_expr(Arg),
     printf_args_rest(Args).
 printf_args([]) -->
     [].
@@ -2175,10 +2175,18 @@ printf_args_rest([Arg | Args]) -->
     ",",
     ws,
     !,
-    field_expr(Arg),
+    printf_arg_expr(Arg),
     printf_args_rest(Args).
 printf_args_rest([]) -->
     [].
+
+% A printf argument: a ternary (tried first for its `?`/`:` structure) or a
+% plain field_expr.
+printf_arg_expr(Ternary) -->
+    ternary_expr(Ternary),
+    !.
+printf_arg_expr(Expr) -->
+    field_expr(Expr).
 
 print_fields([Field | Fields]) -->
     print_field_expr(Field),
@@ -2209,6 +2217,13 @@ print_fields_rest([]) -->
 % concat([...]). Each operand is a field_expr, so arithmetic binds tighter than
 % concatenation (`$1 $2 + $3` == concat($1, $2 + $3)) and a comma still splits
 % print args. A single operand keeps its plain form (no concat wrapper).
+% Ternary `COND ? A : B` (awk `?:`). COND is a numeric comparison `L <op> R`;
+% both branches are numeric field_exprs. Tried before concat / plain field so
+% the `?`/`:` structure is seen first. Defined one level above field_expr (its
+% condition and branches call field_expr) so there is no left recursion.
+print_field_expr(Ternary) -->
+    ternary_expr(Ternary),
+    !.
 print_field_expr(concat([First, Second | Rest])) -->
     field_expr(First),
     required_ws,
@@ -2229,6 +2244,33 @@ concat_rest([Operand | Rest]) -->
     concat_rest(Rest).
 concat_rest([]) -->
     [].
+
+% A ternary `L <op> R ? THEN : ELSE`. The condition is a numeric comparison and
+% each branch is a numeric field_expr (nested ternaries are a follow-on). Used
+% by print fields and printf args.
+ternary_expr(ternary(cmp(Left, Op, Right), Then, Else)) -->
+    ternary_operand(Left),
+    ws,
+    numeric_cmp_op(Op),
+    ws,
+    ternary_operand(Right),
+    ws,
+    "?",
+    ws,
+    ternary_operand(Then),
+    ws,
+    ":",
+    ws,
+    ternary_operand(Else).
+
+% A ternary condition operand or branch: a field_expr (`$N`, `NR`, `NF`,
+% arithmetic, `length(...)`, ...) or a bare integer literal (which field_expr
+% does not accept on its own). Both lower to i64.
+ternary_operand(Expr) -->
+    field_expr(Expr),
+    !.
+ternary_operand(int(Value)) -->
+    signed_integer_value(Value).
 
 field_expr(Expr) -->
     i64_binary_surface_expr(Expr).

--- a/tests/test_plawk_ternary.pl
+++ b/tests/test_plawk_ternary.pl
@@ -1,0 +1,107 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk ternary `COND ? A : B` (AWK `?:`) in print / printf argument position.
+% COND is a numeric comparison `L <op> R`; both branches are numeric (fields,
+% NR/NF, integer literals, i64 arithmetic). Lowered to an LLVM `select` (both
+% branches evaluated -- no side effects in an i64 expression -- so it composes
+% straight-line anywhere an i64 value is used). Assignment-context ternary
+% (scalar-var operands) is a follow-on.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_ternary).
+
+% --- parsing ----------------------------------------------------------------
+
+test(ternary_parses) :-
+    plawk_parse_string("{ print $1 > $2 ? $1 : $2 }\n",
+        program([], [rule(always,
+            [print([ternary(cmp(field(1), gt, field(2)), field(1), field(2))])])], [])),
+    !.
+
+test(ternary_int_literal_operands_parse) :-
+    plawk_parse_string("{ print $1 > 0 ? $1 : 0 }\n",
+        program([], [rule(always,
+            [print([ternary(cmp(field(1), gt, int(0)), field(1), int(0))])])], [])),
+    !.
+
+% --- runtime (print) --------------------------------------------------------
+
+% max($1, $2)
+test(ternary_max, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'max', "{ print $1 > $2 ? $1 : $2 }\n", "3 7\n9 2\n", Out, St),
+    assertion(St == 0), assertion(Out == "7\n9\n"), !.
+
+% clamp negatives to 0 (int-literal branch)
+test(ternary_clamp, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'clamp', "{ print $1 > 0 ? $1 : 0 }\n", "5\n-3\n0\n", Out, St),
+    assertion(St == 0), assertion(Out == "5\n0\n0\n"), !.
+
+% NR in the condition and a branch
+test(ternary_nr, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nr', "{ print NR > 1 ? NR : 0 }\n", "a\nb\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == "0\n2\n3\n"), !.
+
+% arithmetic in a branch
+test(ternary_arith_branch, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ar', "{ print $1 > $2 ? $1 + 100 : $2 + 100 }\n", "3 7\n", Out, St),
+    assertion(St == 0), assertion(Out == "107\n"), !.
+
+% equality condition
+test(ternary_eq, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'eq', "{ print $1 == 0 ? 111 : 222 }\n", "0\n5\n", Out, St),
+    assertion(St == 0), assertion(Out == "111\n222\n"), !.
+
+% under a rule guard
+test(ternary_guarded, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'gd', "$1 > 0 { print $1 > 5 ? 1 : 0 }\n", "3\n9\n-1\n", Out, St),
+    assertion(St == 0), assertion(Out == "0\n1\n"), !.
+
+% --- runtime (printf) -------------------------------------------------------
+
+test(ternary_printf_arg, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'pf', "{ printf \"max=%d\\n\", $1 > $2 ? $1 : $2 }\n", "3 7\n", Out, St),
+    assertion(St == 0), assertion(Out == "max=7\n"), !.
+
+:- end_tests(plawk_ternary).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_ternary', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
The AWK ternary `COND ? A : B` in print-field and printf-argument position
(audit gap 5).

> **Stacked** on #3798 (`printf` coverage), which is stacked on #3796 (`delete`).
> Merge bottom-up: #3796 → #3798 → this.

## How it works

Lowered to an **LLVM `select`** — straight-line, no basic-block split — so a
ternary composes anywhere an i64 value is already used (print, printf arg,
arithmetic operand). Both branches are evaluated, which is safe because an i64
expression has no side effects (and division is already zero-guarded).

- **Codegen** — a `ternary(cmp(L,Op,R), Then, Else)` clause in the shared i64
  expression lowering (`plawk_i64_expr_ir`): the two condition operands and both
  branches lower recursively, an `icmp` computes the condition, a `select` picks
  the branch. Print/printf reach it through a print-context clause; a
  scalar-assignment clause is in place for later reuse.
- **Parser** — `ternary_expr` sits one level above `field_expr` (its operands
  call `field_expr`, so there's no left recursion). A `ternary_operand` also
  accepts a bare integer literal (which `field_expr` alone does not). Wired into
  print fields (before concat) and printf args.
- **Validation** — `plawk_rule_body_print_field` accepts a ternary whose
  operands are i64-valued; `plawk_expr_uses_nr` recurses into it so `NR` inside a
  ternary defines `%current_nr`.

## Scope

Numeric print/printf ternary. **Follow-ons:** assignment-context ternary
(`x = c ? a : b`, needs scalar-var operands + the assignment RHS grammar),
string-valued branches, and boolean-combination conditions (`a && b ? …`).

## Tests

`tests/test_plawk_ternary.pl` (9): parse (field and int-literal operands);
`max($1,$2)`; negative→0 clamp; `NR` in condition + branch; arithmetic branch;
equality condition; guarded; printf argument.

Regressions green: `concat`, `surface_prefix_print`, `printf`, `surface_arith_exprs`.

## Docs

`PLAWK_AWK_FEATURE_AUDIT.md` — ternary → print/printf landed; follow-ons noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_