### PR TITLE
WAM/LLVM plawk: re-land printf coverage + ternary + string-valued scalars onto the feature line

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -68,7 +68,7 @@ only (runtime pending) · ❌ missing.
 | arithmetic `+ - * / % //` | ✅ | i64, awk precedence, safe div/mod |
 | comparison, `~`/`!~` | ✅ | |
 | ternary `?:` | ◐ | `COND ? A : B` in print / printf args — numeric comparison condition, numeric branches (fields, `NR`/`NF`, int literals, i64 arithmetic); lowered to an LLVM `select`. Assignment-context (scalar-var operands) and string branches are follow-ons |
-| string concatenation (juxtaposition `$1 $2`) | ◐ | **`print` context landed** — `print $1 $2`, `print "x" $1 "-" $2`, in rule bodies and `END`; arithmetic binds tighter, comma still splits. Assignment concat (`x = $1 $2`) needs string-valued scalars — separate |
+| string concatenation (juxtaposition `$1 $2`) | ✅ | `print` context **and** assignment: `print $1 $2`; `x = $1 $2` / `x = "id:" $1` build a **string-valued scalar** (an interned atom id in an i64 slot, resolved to text on read/print). Arithmetic binds tighter, comma still splits. Scalar-var concat operand (`x = x $1` accumulation) is a follow-on |
 | exponentiation `^` / `**` | ❌ | |
 
 ## Arrays
@@ -165,9 +165,15 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    *Still open (follow-on):* assignment-context ternary (`x = c ? a : b`, needs
    scalar-var operands + the assignment RHS grammar), string-valued branches,
    and boolean-combination conditions (`a && b ? ...`).
-   (String concatenation in `print` context landed earlier — `print $1 $2`,
-   rule bodies + `END`; assignment concat into a string-valued scalar is
-   separate — see gap below.)
+   (String concatenation landed in both contexts — `print $1 $2` earlier, and
+   **assignment concat `x = $1 $2` via string-valued scalars** now: a string
+   scalar's slot holds an interned atom id (an i64, so it reuses the whole
+   SSA/phi scalar machinery), the RHS is built into a buffer and interned at
+   assignment, and a read/print resolves the id to text — id 0 is the unset
+   sentinel, printed as empty. Numeric and string scalars coexist in one
+   program. Tests: `tests/test_plawk_strscalar.pl`. *Still open (follow-on):*
+   a scalar-var concat operand (`x = x $1` accumulation), string scalars in an
+   `if`/loop body, and string comparison/guards on a string scalar.)
 6. **`delete arr[k]` — LANDED (field key).** `delete arr[$k]` removes the entry
    keyed by field k, matching the counted inc `arr[$k]++`. The runtime primitive
    `@wam_assoc_i64_delete` does **backward-shift deletion** on the linear-probing

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -67,7 +67,7 @@ only (runtime pending) · ❌ missing.
 | `FNR` `FILENAME` `ARGV` `ARGC` `RS` `ORS` `SUBSEP` `RSTART` `RLENGTH` | ❌ | single newline-delimited record model |
 | arithmetic `+ - * / % //` | ✅ | i64, awk precedence, safe div/mod |
 | comparison, `~`/`!~` | ✅ | |
-| ternary `?:` | ❌ | does not parse |
+| ternary `?:` | ◐ | `COND ? A : B` in print / printf args — numeric comparison condition, numeric branches (fields, `NR`/`NF`, int literals, i64 arithmetic); lowered to an LLVM `select`. Assignment-context (scalar-var operands) and string branches are follow-ons |
 | string concatenation (juxtaposition `$1 $2`) | ◐ | **`print` context landed** — `print $1 $2`, `print "x" $1 "-" $2`, in rule bodies and `END`; arithmetic binds tighter, comma still splits. Assignment concat (`x = $1 $2`) needs string-valued scalars — separate |
 | exponentiation `^` / `**` | ❌ | |
 
@@ -155,10 +155,19 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    exit point merges into END through the break-close phi. Tests:
    `tests/test_plawk_exit.pl`. *Still open (follow-on):* `exit` inside a `BEGIN`
    or `END` block, and non-constant exit codes (`exit code_var`).
-5. **Ternary `?:`** (string concatenation in `print` context **landed** —
-   `print $1 $2`, rule bodies + `END`; the remaining concat work is assignment
-   into a string-valued scalar). Ternary is the next most-missed *expression*
-   form; parser + expression-lowering work.
+5. **Ternary `?:` — LANDED (print / printf, numeric).** `COND ? A : B` in a
+   print field or printf argument: the condition is a numeric comparison
+   `L <op> R` and both branches are numeric (fields, `NR`/`NF`, integer
+   literals, i64 arithmetic). Lowered to an LLVM `select` — both branches are
+   evaluated (no side effects in an i64 expression), so it composes straight-line
+   anywhere an i64 value is used (`plawk_i64_expr_ir(ternary(...))`), and the
+   `%s`/`%d`/arith paths are unaffected. Tests: `tests/test_plawk_ternary.pl`.
+   *Still open (follow-on):* assignment-context ternary (`x = c ? a : b`, needs
+   scalar-var operands + the assignment RHS grammar), string-valued branches,
+   and boolean-combination conditions (`a && b ? ...`).
+   (String concatenation in `print` context landed earlier — `print $1 $2`,
+   rule bodies + `END`; assignment concat into a string-valued scalar is
+   separate — see gap below.)
 6. **`delete arr[k]` — LANDED (field key).** `delete arr[$k]` removes the entry
    keyed by field k, matching the counted inc `arr[$k]++`. The runtime primitive
    `@wam_assoc_i64_delete` does **backward-shift deletion** on the linear-probing

--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -30,7 +30,7 @@ only (runtime pending) · ❌ missing.
 | Feature | Status | Notes |
 |---|---|---|
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic, **concatenation**) | ✅ | constant fields (`print 1`, `print "x"`) + juxtaposition concat (`print $1 $2`) landed |
-| `printf` | ◐ | subset `%%`,`%s`,`%d`,`%i`,`%ld`; no `%f`/`%c`/`%x`/width/precision |
+| `printf` | ✅ | standard `%[flags][width][.precision][length]conv`: integers `d`/`i`/`x`/`X`/`o`/`u` + `c` (code point), floats `f`/`g`/`e`/`F`/`G`/`E`, strings `%s`; flags `-+ 0#`, width, precision. Field-slice `%s` takes width but not precision (non-terminated buffer); `%c` needs a numeric arg |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`** (`END { if (n > 1) print … ; else print … }`, over final slot values) |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
@@ -130,8 +130,19 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    to update a scalar). Braceless bodies also landed: `if (c) print`,
    `while (c) x++`, `do stmt while (c)`, and braceless else-if chains — a
    control-flow body is a braced block *or* a single statement.
-3. **`printf` format coverage** — add `%f`/`%g` (f64 exists), `%c`, `%x`, and
-   width/precision; the current subset is thin for real formatting.
+3. **`printf` format coverage — LANDED.** The rewriter now parses the standard
+   conversion prefix `%[flags][width][.precision][length]<conv>` and rewrites to
+   a C printf spec driven by each argument's inferred kind: integer args (i64)
+   take `d`/`i`/`x`/`X`/`o`/`u` (with the `l` length modifier) and `c` (code
+   point → character); float args (f64) take `f`/`g`/`e`/`F`/`G`/`E`; string
+   args take `%s` with flags/width/precision. Flags `-+ 0#`, width, and
+   precision are honoured. A record-field `%s` (a non-null-terminated slice)
+   takes flags/width and rides `.*` for its length, so a user precision on a
+   field is a clean compile error (buffer safety) — a follow-on. `%c` needs a
+   numeric arg (a string arg's first-char form is a follow-on). Tests:
+   `tests/test_plawk_printf.pl`. *Still open (follow-on):* `%c` on a string
+   (first char), precision on a field slice, `*`-width (width from an arg), and
+   `printf` in a `BEGIN`/`END` block (a separate driver gap).
 4. **`exit [n]` — LANDED.** A rule-level `exit` / `exit N` stops the record loop,
    runs END, and returns N (default 0). It reuses the rule-level stream-break
    path (`break_close_stream` → END → `ret`), adding an exit code stored in

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -10485,6 +10485,14 @@ plawk_rule_body_print_action(printf(string(Format), Args)) :-
 
 plawk_rule_body_print_field(field(_)).
 plawk_rule_body_print_field(string(_)).
+% a ternary `COND ? A : B`: the condition operands and both branches must be
+% i64-valued (field / NR / NF / int literal / length / i64 arithmetic); lowered
+% to an LLVM select.
+plawk_rule_body_print_field(ternary(cmp(Left, _Op, Right), Then, Else)) :-
+    plawk_ternary_i64_operand_ok(Left),
+    plawk_ternary_i64_operand_ok(Right),
+    plawk_ternary_i64_operand_ok(Then),
+    plawk_ternary_i64_operand_ok(Else).
 % a string concatenation (`print $1 $2`): every operand must be a valid print
 % field; they are emitted adjacently with no separator.
 plawk_rule_body_print_field(concat(Parts)) :-
@@ -10553,6 +10561,17 @@ plawk_i64_operand_expr(dyncall_at_named(Name, Source, Args)) :-
     plawk_dyncall_at_expr(dyncall_at_named(Name, Source, Args)).
 plawk_i64_operand_expr(Expr) :-
     plawk_i64_general_binary_expr(Expr).
+
+%% plawk_ternary_i64_operand_ok(+Expr) is semidet.
+%  A ternary condition operand or branch: any i64 operand plus the surface
+%  forms the parser emits for fields / NR / NF / length that plawk_i64_expr_ir
+%  lowers directly.
+plawk_ternary_i64_operand_ok(special('NR')).
+plawk_ternary_i64_operand_ok(special('NF')).
+plawk_ternary_i64_operand_ok(int(field(_))).
+plawk_ternary_i64_operand_ok(length(field(_))).
+plawk_ternary_i64_operand_ok(Expr) :-
+    plawk_i64_operand_expr(Expr).
 
 plawk_prolog_call_expr(prolog_call(Name, Args)) :-
     atom(Name),
@@ -11852,6 +11871,12 @@ plawk_scalar_numeric_expr_ir(field_i64(FieldIndex), FieldSeparator, Prefix, Slot
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(field_i64(FieldIndex), FieldSeparator, ParseBase, ParseBase,
         ValueIR, GlobalIR, IR).
+% Ternary in a scalar assignment (`x = COND ? A : B`): an i64 value via select.
+plawk_scalar_numeric_expr_ir(ternary(Cond, Then, Else), FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, GlobalIR, IR) :-
+    format(atom(TernBase), '~w_slot_~w_op_~w_tern', [Prefix, SlotIndex, OpIndex]),
+    plawk_i64_expr_ir_parts(ternary(Cond, Then, Else), FieldSeparator, TernBase, TernBase,
+        ValueIR, GlobalIR, IR).
 plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
         OpIndex, ValueIR, GlobalIR, IR) :-
     plawk_i64_scalar_primary_expr(Expr),
@@ -12066,6 +12091,38 @@ plawk_i64_expr_ir(index(FieldIndex, Needle), FieldSeparator, Base, GlobalBase,
     llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
         Base, GlobalIR-CallIR),
     format(atom(ValueIR), '%~w', [Base]).
+% Ternary `COND ? A : B` over i64 values. COND is a single comparison
+% `L <op> R`; both branches are evaluated (no side effects in an i64 expr) and
+% an LLVM `select` picks one -- straight-line, so a ternary composes anywhere an
+% i64 expression is used (print, printf arg, assignment, arithmetic operand).
+plawk_i64_expr_ir(ternary(cmp(CondLeft, Op, CondRight), Then, Else),
+        FieldSeparator, Base, GlobalBase, ValueIR, GlobalParts, SetupParts) :-
+    plawk_icmp_pred(Op, Pred),
+    format(atom(CondLeftBase), '~w_cl', [Base]),
+    format(atom(CondLeftGlobal), '~w_cl', [GlobalBase]),
+    plawk_i64_expr_ir(CondLeft, FieldSeparator, CondLeftBase, CondLeftGlobal,
+        CondLeftValueIR, CondLeftGlobalParts, CondLeftSetupParts),
+    format(atom(CondRightBase), '~w_cr', [Base]),
+    format(atom(CondRightGlobal), '~w_cr', [GlobalBase]),
+    plawk_i64_expr_ir(CondRight, FieldSeparator, CondRightBase, CondRightGlobal,
+        CondRightValueIR, CondRightGlobalParts, CondRightSetupParts),
+    format(atom(ThenBase), '~w_t', [Base]),
+    format(atom(ThenGlobal), '~w_t', [GlobalBase]),
+    plawk_i64_expr_ir(Then, FieldSeparator, ThenBase, ThenGlobal,
+        ThenValueIR, ThenGlobalParts, ThenSetupParts),
+    format(atom(ElseBase), '~w_e', [Base]),
+    format(atom(ElseGlobal), '~w_e', [GlobalBase]),
+    plawk_i64_expr_ir(Else, FieldSeparator, ElseBase, ElseGlobal,
+        ElseValueIR, ElseGlobalParts, ElseSetupParts),
+    format(atom(CondLine), '  %~w_cond = icmp ~w i64 ~w, ~w',
+        [Base, Pred, CondLeftValueIR, CondRightValueIR]),
+    format(atom(SelLine), '  %~w = select i1 %~w_cond, i64 ~w, i64 ~w',
+        [Base, Base, ThenValueIR, ElseValueIR]),
+    format(atom(ValueIR), '%~w', [Base]),
+    append([CondLeftGlobalParts, CondRightGlobalParts, ThenGlobalParts,
+            ElseGlobalParts], GlobalParts),
+    append([CondLeftSetupParts, CondRightSetupParts, ThenSetupParts,
+            ElseSetupParts, [CondLine, SelLine]], SetupParts).
 
 %% plawk_i64_binary_op_lines(+LLVMOp, +Base, +LeftIR, +RightIR, -Lines)
 %
@@ -13266,6 +13323,12 @@ plawk_expr_uses_nr(special('NR')).
 plawk_expr_uses_nr(concat(Parts)) :-
     member(Part, Parts),
     plawk_expr_uses_nr(Part).
+plawk_expr_uses_nr(ternary(cmp(Left, _Op, Right), Then, Else)) :-
+    ( plawk_expr_uses_nr(Left)
+    ; plawk_expr_uses_nr(Right)
+    ; plawk_expr_uses_nr(Then)
+    ; plawk_expr_uses_nr(Else)
+    ).
 plawk_expr_uses_nr(Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
     ( plawk_expr_uses_nr(Left)
@@ -13612,6 +13675,14 @@ plawk_emit_print_expr_for_context(ssa(Value), FieldSeparator, Context,
     plawk_print_expr_value_base(Context, int, Base),
     plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
     plawk_i64_expr_ir(ssa(Value), FieldSeparator, Base, Base,
+        ValueIR, GlobalParts, SetupParts).
+
+% Ternary print field `print (COND ? A : B)`: an i64 value via select.
+plawk_emit_print_expr_for_context(ternary(Cond, Then, Else), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, int, Base),
+    plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(ternary(Cond, Then, Else), FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(Expr, FieldSeparator, Context,

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -13397,46 +13397,91 @@ plawk_printf_rewrite_codes([Code | Rest], Kinds, [Code | RewrittenRest]) :-
 plawk_printf_rewrite_codes([0'%, 0'% | Rest], Kinds, [0'%, 0'% | RewrittenRest]) :-
     !,
     plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
-plawk_printf_rewrite_codes([0'% | Rest], [i64 | Kinds], [0'%, 0'l, 0'd | RewrittenRest]) :-
-    plawk_printf_i64_spec_codes(Rest, RestAfterSpec),
+% A conversion `%[flags][width][.precision][length]<conv>`: parse the standard
+% prefix, then rewrite the body per the next argument's inferred kind (the arg
+% kind drives the choice, so a mismatched conv -- e.g. %s for an integer arg --
+% cleanly fails the rewrite -> compile error rather than miscompiling).
+plawk_printf_rewrite_codes([0'% | Rest], Kinds0, Rewritten) :-
+    plawk_printf_scan_spec(Rest, Flags, Width, Prec, Conv, RestAfter),
+    plawk_printf_kind_spec(Kinds0, Flags, Width, Prec, Conv, Kinds, SpecBody),
     !,
-    plawk_printf_rewrite_codes(RestAfterSpec, Kinds, RewrittenRest).
-plawk_printf_rewrite_codes([0'%, 0's | Rest], [string | Kinds], [0'%, 0's | RewrittenRest]) :-
-    !,
-    plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
-plawk_printf_rewrite_codes([0'%, 0's | Rest], [slice_len, slice_ptr | Kinds],
-        [0'%, 0'., 0'*, 0's | RewrittenRest]) :-
-    !,
-    plawk_printf_rewrite_codes(Rest, Kinds, RewrittenRest).
-plawk_printf_rewrite_codes([0'% | Rest], [f64 | Kinds], [0'% | RewrittenSpec]) :-
-    plawk_printf_f64_spec_codes(Rest, SpecCodes, RestAfterSpec),
-    !,
-    append(SpecCodes, RewrittenRest, RewrittenSpec),
-    plawk_printf_rewrite_codes(RestAfterSpec, Kinds, RewrittenRest).
+    append([0'% | SpecBody], RewrittenRest, Rewritten),
+    plawk_printf_rewrite_codes(RestAfter, Kinds, RewrittenRest).
 
-% %f / %g / %e with an optional .N precision pass through unchanged for
-% double arguments (C varargs receive the double directly).
-plawk_printf_f64_spec_codes([0'., Digit | Rest0], [0'., Digit | SpecRest], Rest) :-
-    code_type(Digit, digit),
-    !,
-    plawk_printf_f64_precision_codes(Rest0, SpecRest, Rest).
-plawk_printf_f64_spec_codes([Conv | Rest], [Conv], Rest) :-
-    plawk_printf_f64_conversion_code(Conv).
+% Scan the standard printf conversion prefix: flags in `-+ 0#`, decimal width,
+% optional `.precision`, an optional (ignored) length modifier, then the
+% conversion character.
+plawk_printf_scan_spec(Codes, Flags, Width, Prec, Conv, Rest) :-
+    plawk_printf_take_flags(Codes, Flags, C1),
+    plawk_printf_take_digits(C1, Width, C2),
+    plawk_printf_take_prec(C2, Prec, C3),
+    plawk_printf_take_lenmod(C3, C4),
+    C4 = [Conv | Rest].
 
-plawk_printf_f64_precision_codes([Digit | Rest0], [Digit | SpecRest], Rest) :-
-    code_type(Digit, digit),
+plawk_printf_take_flags([C | Cs], [C | Fs], Rest) :-
+    memberchk(C, [0'-, 0'+, 0' , 0'0, 0'#]),
     !,
-    plawk_printf_f64_precision_codes(Rest0, SpecRest, Rest).
-plawk_printf_f64_precision_codes([Conv | Rest], [Conv], Rest) :-
-    plawk_printf_f64_conversion_code(Conv).
+    plawk_printf_take_flags(Cs, Fs, Rest).
+plawk_printf_take_flags(Cs, [], Cs).
+
+plawk_printf_take_digits([C | Cs], [C | Ds], Rest) :-
+    code_type(C, digit),
+    !,
+    plawk_printf_take_digits(Cs, Ds, Rest).
+plawk_printf_take_digits(Cs, [], Cs).
+
+% Precision keeps its leading `.` (a bare `.` is precision 0, as in C).
+plawk_printf_take_prec([0'. | Cs], [0'. | Ds], Rest) :-
+    !,
+    plawk_printf_take_digits(Cs, Ds, Rest).
+plawk_printf_take_prec(Cs, [], Cs).
+
+% A user-written length modifier is consumed and dropped; the emitter supplies
+% the correct one for the argument's representation (i64 -> `l`).
+plawk_printf_take_lenmod([0'l, 0'l | Cs], Cs) :- !.
+plawk_printf_take_lenmod([0'l | Cs], Cs) :- !.
+plawk_printf_take_lenmod([0'h, 0'h | Cs], Cs) :- !.
+plawk_printf_take_lenmod([0'h | Cs], Cs) :- !.
+plawk_printf_take_lenmod(Cs, Cs).
+
+% Map (arg kind, parsed prefix, conversion) to the C conversion body (the codes
+% after the leading `%`), consuming the kind(s) the argument contributed.
+% Integer arg (i64): d/i/x/X/o/u get the `l` length modifier; c takes the code
+% point as a character (no length modifier, precision dropped).
+plawk_printf_kind_spec([i64 | Ks], Flags, Width, _Prec, 0'c, Ks, Body) :-
+    !,
+    append([Flags, Width, [0'c]], Body).
+plawk_printf_kind_spec([i64 | Ks], Flags, Width, Prec, Conv, Ks, Body) :-
+    plawk_printf_int_conversion_code(Conv, OutConv),
+    append([Flags, Width, Prec, [0'l, OutConv]], Body).
+% Float arg (f64): f/g/e/F/G/E pass through with flags/width/precision.
+plawk_printf_kind_spec([f64 | Ks], Flags, Width, Prec, Conv, Ks, Body) :-
+    plawk_printf_f64_conversion_code(Conv),
+    append([Flags, Width, Prec, [Conv]], Body).
+% Null-terminated string arg (%s): flags/width/precision pass through.
+plawk_printf_kind_spec([string | Ks], Flags, Width, Prec, 0's, Ks, Body) :-
+    append([Flags, Width, Prec, [0's]], Body).
+% Record-field slice (%s over len+ptr): the length rides `.*`, so the slice
+% bounds the output; width is kept. A user precision can't be honoured -- the
+% slice pointer is not null-terminated, so `.N` (without `.*`) would read past
+% the field -- so `%.Ns` on a field is a clean compile error (a follow-on).
+plawk_printf_kind_spec([slice_len, slice_ptr | Ks], Flags, Width, [], 0's, Ks, Body) :-
+    append([Flags, Width, [0'., 0'*, 0's]], Body).
+
+% Integer conversions; `i` normalises to `d` (identical output).
+plawk_printf_int_conversion_code(0'd, 0'd).
+plawk_printf_int_conversion_code(0'i, 0'd).
+plawk_printf_int_conversion_code(0'x, 0'x).
+plawk_printf_int_conversion_code(0'X, 0'X).
+plawk_printf_int_conversion_code(0'o, 0'o).
+plawk_printf_int_conversion_code(0'u, 0'u).
 
 plawk_printf_f64_conversion_code(0'f).
 plawk_printf_f64_conversion_code(0'g).
 plawk_printf_f64_conversion_code(0'e).
-
-plawk_printf_i64_spec_codes([0'l, 0'd | Rest], Rest).
-plawk_printf_i64_spec_codes([0'd | Rest], Rest).
-plawk_printf_i64_spec_codes([0'i | Rest], Rest).
+plawk_printf_f64_conversion_code(0'F).
+plawk_printf_f64_conversion_code(0'G).
+plawk_printf_f64_conversion_code(0'E).
 
 plawk_print_ir_parts([], [], []).
 plawk_print_ir_parts([GlobalIR-BodyIR | Parts], [GlobalIR | GlobalParts], [BodyIR | BodyParts]) :-

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5851,12 +5851,17 @@ plawk_state_slot_index(StatePlan, Slot, Index) :-
 % declared, matching awk's untyped surface.
 plawk_slot_name(scalar_counter(Name), Name).
 plawk_slot_name(scalar_double(Name), Name).
+% A string scalar's slot holds an interned atom id (an i64); the id 0 is the
+% "unset" sentinel, printed as the empty string.
+plawk_slot_name(scalar_string(Name), Name).
 
 plawk_slot_llvm_type(scalar_counter(_Name), i64).
 plawk_slot_llvm_type(scalar_double(_Name), double).
+plawk_slot_llvm_type(scalar_string(_Name), i64).
 
 plawk_slot_zero_ir(scalar_counter(_Name), '0').
 plawk_slot_zero_ir(scalar_double(_Name), '0.0').
+plawk_slot_zero_ir(scalar_string(_Name), '0').
 
 plawk_state_slot_lookup(StatePlan, Name, Index, Slot) :-
     plawk_state_plan_slots(StatePlan, Slots),
@@ -6101,7 +6106,22 @@ plawk_scalar_typed_slots(Rules, Names, Slots) :-
         ),
         Updates),
     plawk_scalar_double_fixpoint(Updates, [], Doubles),
-    maplist(plawk_scalar_typed_slot(Doubles), Names, Slots).
+    plawk_scalar_string_names(Rules, Strings),
+    maplist(plawk_scalar_typed_slot(Doubles, Strings), Names, Slots).
+
+% A scalar is string-typed when it is assigned a string RHS (`x = $1 $2` or
+% `x = "text"`), tracked separately from the double/counter fixpoint. v1 looks
+% at top-level rule-body assignments; a nested (if/loop-body) string assignment
+% is a follow-on.
+plawk_scalar_string_names(Rules, Strings) :-
+    findall(Name,
+        ( member(rule(_Pattern, Actions0), Rules),
+          plawk_trim_control_tails(Actions0, Actions),
+          member(Action, Actions),
+          plawk_scalar_action_update(Action, Name, set_str(_Src))
+        ),
+        Names0),
+    sort(Names0, Strings).
 
 plawk_scalar_update_name_expr(Action, Name, Expr) :-
     plawk_scalar_action_update(Action, Name, Operation),
@@ -6164,10 +6184,13 @@ plawk_update_expr_is_double(Expr, Doubles) :-
     memberchk(Name, Doubles),
     !.
 
-plawk_scalar_typed_slot(Doubles, Name, scalar_double(Name)) :-
+plawk_scalar_typed_slot(_Doubles, Strings, Name, scalar_string(Name)) :-
+    memberchk(Name, Strings),
+    !.
+plawk_scalar_typed_slot(Doubles, _Strings, Name, scalar_double(Name)) :-
     memberchk(Name, Doubles),
     !.
-plawk_scalar_typed_slot(_Doubles, Name, scalar_counter(Name)).
+plawk_scalar_typed_slot(_Doubles, _Strings, Name, scalar_counter(Name)).
 
 plawk_mixed_state_plan(Rules, PrintFields, mixed_plan(ScalarPlan, AssocPlan, PlannedRules)) :-
     plawk_mixed_scalar_state_plan(Rules, PrintFields, ScalarPlan),
@@ -11080,6 +11103,8 @@ plawk_substitute_scalar_reads(var(Name), Slots, Values, Substituted) :-
     nth0(SlotIndex, Values, Value),
     ( Slot = scalar_double(_Name)
     -> Substituted = ssa_f64(Value)
+    ;  Slot = scalar_string(_Name)
+    -> Substituted = ssa_str(Value)
     ;  Substituted = ssa(Value)
     ).
 plawk_substitute_print_field(Slots, Values, Field0, Field) :-
@@ -11257,6 +11282,15 @@ plawk_scalar_action_update(add(var(Name), dyncall_at(Source, Args)), Name,
 plawk_scalar_action_update(add(var(Name), dyncall_at_named(E, Source, Args)),
         Name, add(dyncall_at_named(E, Source, Args))) :-
     plawk_dyncall_at_expr(dyncall_at_named(E, Source, Args)).
+% String-valued scalar assignment: `x = $1 $2` (concat) or `x = "text"`. The
+% slot holds an interned atom id (an i64); the RHS is built into a buffer and
+% interned at assignment, and `print x` resolves the id back to text. Recognised
+% before the numeric clauses so a string RHS types the slot as scalar_string.
+plawk_scalar_action_update(set(var(Name), concat(Parts)), Name, set_str(concat(Parts))) :-
+    Parts = [_, _ | _],
+    maplist(plawk_str_scalar_part_ok, Parts).
+plawk_scalar_action_update(set(var(Name), string(Value)), Name, set_str(string(Value))) :-
+    string(Value).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
@@ -11295,6 +11329,11 @@ plawk_scalar_action_update(set(var(Name), compile_handle(Arg)), Name,
 plawk_scalar_action_update(set(var(Name), compile_file_handle(Arg)), Name,
         set(compile_file_handle(Arg))) :-
     plawk_foreign_arg(Arg).
+
+% A string-scalar concat part: a field (`$N`, projected as text) or a string
+% literal (embedded in the build format). Other part kinds are a follow-on.
+plawk_str_scalar_part_ok(field(Index)) :- integer(Index), Index >= 0.
+plawk_str_scalar_part_ok(string(Value)) :- string(Value).
 % Double-typed update expressions: float literals, float($N), and
 % binary trees mixing them with i64 operands or scalar reads. The
 % written slot becomes a double via plawk_scalar_typed_slots/3.
@@ -11776,6 +11815,16 @@ plawk_scalar_update_operation_ir(add(Expr), _Slot, FieldSeparator, Prefix, SlotI
     format(atom(AddLine), '  ~w = add i64 ~w, ~w',
         [NextValue, InputValue, ValueIR]),
     plawk_join_nonempty_ir([SetupIR, AddLine], IR).
+% String scalar assignment (`x = $1 $2` / `x = "text"`): build the RHS bytes,
+% intern to an atom id, and that id becomes the slot's new i64 value. Reads /
+% `print` resolve the id back to text.
+plawk_scalar_update_operation_ir(set_str(Src), scalar_string(_Name), FieldSeparator,
+        Prefix, SlotIndex, OpIndex, _InputValue, NextValue, GlobalIR-IR) :-
+    !,
+    format(atom(Base), '~w_slot_~w_op_~w_str', [Prefix, SlotIndex, OpIndex]),
+    plawk_str_build_ir(Src, FieldSeparator, Base, NextValue, GlobalParts, SetupLines),
+    plawk_join_nonempty_ir(GlobalParts, GlobalIR),
+    atomic_list_concat(SetupLines, '\n', IR).
 plawk_scalar_update_operation_ir(set(Expr), _Slot, FieldSeparator, Prefix, SlotIndex,
         OpIndex, _InputValue, NextValue, GlobalIR-IR) :-
     plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
@@ -11783,6 +11832,102 @@ plawk_scalar_update_operation_ir(set(Expr), _Slot, FieldSeparator, Prefix, SlotI
     format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
     format(atom(SetLine), '  ~w = add i64 0, ~w', [NextValue, ValueIR]),
     plawk_join_nonempty_ir([SetupIR, SetLine], IR).
+
+% Build a string RHS into an interned atom id (returned as the SSA value).
+% A bare literal interns its own global; a concat snprintf's its `%.*s` field
+% slots and literal segments into a 4096-byte stack buffer, then interns the
+% result (the assignment mirror of the print concat).
+plawk_str_build_ir(string(Value), _FieldSeparator, Base, IdValueIR,
+        [GlobalIR], [PtrLine, IdLine]) :-
+    format(atom(StrName), '~w_lit', [Base]),
+    llvm_emit_c_string_global(StrName, Value, GlobalIR, Len, BytesLen),
+    format(atom(PtrLine),
+        '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0',
+        [Base, BytesLen, BytesLen, StrName]),
+    format(atom(IdLine),
+        '  %~w_id = call i64 @wam_intern_atom(i8* %~w_ptr, i64 ~w)',
+        [Base, Base, Len]),
+    format(atom(IdValueIR), '%~w_id', [Base]).
+plawk_str_build_ir(concat(Parts), FieldSeparator, Base, IdValueIR,
+        [FmtGlobal, EmptyGlobal], SetupLines) :-
+    plawk_str_concat_format(Parts, FmtAtom),
+    format(atom(FmtName), '~w_fmt', [Base]),
+    llvm_emit_c_string_global(FmtName, FmtAtom, FmtGlobal, _FmtLen, FmtBytes),
+    format(atom(EmptyName), '~w_empty', [Base]),
+    format(atom(EmptyGlobal),
+        '@.~w = private constant [1 x i8] zeroinitializer', [EmptyName]),
+    plawk_str_concat_field_lines(Parts, Base, EmptyName, FieldSeparator, 0,
+        FieldLines, ArgFrags),
+    ( ArgFrags == []
+    -> ArgsSuffix = ''
+    ;  atomic_list_concat(ArgFrags, ', ', ArgsJoined),
+       atom_concat(', ', ArgsJoined, ArgsSuffix)
+    ),
+    format(atom(BufA), '  %~w_buf = alloca [4096 x i8]', [Base]),
+    format(atom(BufP),
+        '  %~w_bufp = getelementptr [4096 x i8], [4096 x i8]* %~w_buf, i64 0, i64 0',
+        [Base, Base]),
+    format(atom(FmtP),
+        '  %~w_fmtp = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0',
+        [Base, FmtBytes, FmtBytes, FmtName]),
+    format(atom(Snp),
+        '  %~w_wrote = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %~w_bufp, i64 4096, i8* %~w_fmtp~w)',
+        [Base, Base, Base, ArgsSuffix]),
+    format(atom(LenL), '  %~w_len = call i64 @strlen(i8* %~w_bufp)', [Base, Base]),
+    format(atom(IdL),
+        '  %~w_id = call i64 @wam_intern_atom(i8* %~w_bufp, i64 %~w_len)',
+        [Base, Base, Base]),
+    format(atom(IdValueIR), '%~w_id', [Base]),
+    append(FieldLines, [BufA, BufP, FmtP, Snp, LenL, IdL], SetupLines).
+
+% The snprintf format for a string-concat: `%.*s` per field slot, literal
+% segments inline (with `%` escaped). No separator -- operands are adjacent.
+plawk_str_concat_format([], '').
+plawk_str_concat_format([field(_) | Rest], Fmt) :-
+    plawk_str_concat_format(Rest, RestFmt),
+    atom_concat('%.*s', RestFmt, Fmt).
+plawk_str_concat_format([string(Value) | Rest], Fmt) :-
+    plawk_str_escape_percent(Value, Escaped),
+    plawk_str_concat_format(Rest, RestFmt),
+    atom_concat(Escaped, RestFmt, Fmt).
+
+plawk_str_escape_percent(Value, Escaped) :-
+    ( sub_atom(Value, _, _, _, '%')
+    -> atomic_list_concat(Parts, '%', Value),
+       atomic_list_concat(Parts, '%%', Escaped)
+    ;  Escaped = Value
+    ).
+
+% Per concat field, project field N (null-safe empty), yielding an
+% `i32 <len>, i8* <ptr>` snprintf argument pair for its `%.*s` slot. Literal
+% parts contribute no argument (they live in the format).
+plawk_str_concat_field_lines([], _B, _Empty, _FieldSep, _Pos, [], []).
+plawk_str_concat_field_lines([string(_) | Rest], B, EmptyName, FieldSep, Pos,
+        Lines, Frags) :-
+    plawk_str_concat_field_lines(Rest, B, EmptyName, FieldSep, Pos, Lines, Frags).
+plawk_str_concat_field_lines([field(N) | Rest], B, EmptyName, FieldSep, Pos,
+        Lines, [Frag | Frags]) :-
+    format(atom(Slice),
+        '  %~w_c~w_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 ~w)',
+        [B, Pos, N, FieldSep]),
+    format(atom(Ptr), '  %~w_c~w_ptr = extractvalue %WamSlice %~w_c~w_slice, 0',
+        [B, Pos, B, Pos]),
+    format(atom(Len), '  %~w_c~w_len = extractvalue %WamSlice %~w_c~w_slice, 1',
+        [B, Pos, B, Pos]),
+    format(atom(Null), '  %~w_c~w_null = icmp eq i8* %~w_c~w_ptr, null',
+        [B, Pos, B, Pos]),
+    format(atom(SafePtr),
+        '  %~w_c~w_sptr = select i1 %~w_c~w_null, i8* getelementptr ([1 x i8], [1 x i8]* @.~w, i64 0, i64 0), i8* %~w_c~w_ptr',
+        [B, Pos, B, Pos, EmptyName, B, Pos]),
+    format(atom(SafeLen), '  %~w_c~w_slen = select i1 %~w_c~w_null, i64 0, i64 %~w_c~w_len',
+        [B, Pos, B, Pos, B, Pos]),
+    format(atom(Lenw), '  %~w_c~w_lenw = trunc i64 %~w_c~w_slen to i32',
+        [B, Pos, B, Pos]),
+    format(atom(Frag), 'i32 %~w_c~w_lenw, i8* %~w_c~w_sptr', [B, Pos, B, Pos]),
+    ThisLines = [Slice, Ptr, Len, Null, SafePtr, SafeLen, Lenw],
+    Pos1 is Pos + 1,
+    plawk_str_concat_field_lines(Rest, B, EmptyName, FieldSep, Pos1, RestLines, Frags),
+    append(ThisLines, RestLines, Lines).
 
 %% plawk_scalar_f64_numeric_expr_ir(+Expr, +FieldSeparator, +Prefix,
 %%     +SlotIndex, +OpIndex, -ValueIR, -GlobalIR, -SetupIR)
@@ -12709,15 +12854,34 @@ plawk_scalar_end_print_lines([var(Name) | Rest], StatePlan, OutputSeparator, Pri
              [FmtVar]),
          format(atom(PrintCall),
              '  %printed_end_f64_~w = call i32 (i8*, ...) @printf(i8* %~w, double ~w)',
-             [PrintIndex, FmtVar, ValueIR])
+             [PrintIndex, FmtVar, ValueIR]),
+         Lines = [FmtPtr, PrintCall]
+      ;  Slot = scalar_string(_Name)
+      -> % resolve the atom id to text; id 0 (unset) prints as empty (the `%s\0`
+         % global's trailing NUL is a ready-made empty C string).
+         format(atom(StrS), '  %end_str_s_~w = call i8* @wam_atom_to_string(i64 ~w)',
+             [PrintIndex, ValueIR]),
+         format(atom(StrE), '  %end_str_empty_~w = icmp eq i64 ~w, 0',
+             [PrintIndex, ValueIR]),
+         format(atom(StrSel),
+             '  %end_str_ptr_~w = select i1 %end_str_empty_~w, i8* getelementptr ([3 x i8], [3 x i8]* @.plawk_surface_print_string, i64 0, i64 2), i8* %end_str_s_~w',
+             [PrintIndex, PrintIndex, PrintIndex]),
+         format(atom(FmtPtr),
+             '  %end_str_fmt_~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_string, i32 0, i32 0',
+             [PrintIndex]),
+         format(atom(PrintCall),
+             '  %printed_end_str_~w = call i32 (i8*, ...) @printf(i8* %end_str_fmt_~w, i8* %end_str_ptr_~w)',
+             [PrintIndex, PrintIndex, PrintIndex]),
+         Lines = [StrS, StrE, StrSel, FmtPtr, PrintCall]
       ;  format(atom(FmtVar), 'end_i64_fmt_~w', [PrintIndex]),
          format(atom(PrintVar), 'printed_end_i64_~w', [PrintIndex]),
          llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
-             [FmtPtr, PrintCall])
+             [FmtPtr, PrintCall]),
+         Lines = [FmtPtr, PrintCall]
       ),
       NextPrintIndex is PrintIndex + 1
     },
-    [FmtPtr, PrintCall],
+    Lines,
     plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
 plawk_scalar_end_print_lines([special('NR') | Rest], StatePlan, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
@@ -13676,6 +13840,23 @@ plawk_emit_print_expr_for_context(ssa(Value), FieldSeparator, Context,
     plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
     plawk_i64_expr_ir(ssa(Value), FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
+% a substituted STRING-scalar read (var(Name) -> ssa_str(SlotValue)): the slot
+% holds an atom id; resolve it to text (id 0 is the unset sentinel, printed as
+% empty). A select keeps it straight-line -- wam_atom_to_string is always called
+% but its result is discarded when the id is 0.
+plawk_emit_print_expr_for_context(ssa_str(Value), _FieldSeparator, Context,
+        string(Base, PtrIR), [EmptyGlobal], [StrCall, IsEmpty, SelPtr]) :-
+    plawk_print_expr_value_base(Context, string, Base),
+    format(atom(EmptyName), '~w_empty', [Base]),
+    format(atom(EmptyGlobal),
+        '@.~w = private constant [1 x i8] zeroinitializer', [EmptyName]),
+    format(atom(StrCall), '  %~w_s = call i8* @wam_atom_to_string(i64 ~w)',
+        [Base, Value]),
+    format(atom(IsEmpty), '  %~w_empty_c = icmp eq i64 ~w, 0', [Base, Value]),
+    format(atom(SelPtr),
+        '  %~w_sptr = select i1 %~w_empty_c, i8* getelementptr ([1 x i8], [1 x i8]* @.~w, i64 0, i64 0), i8* %~w_s',
+        [Base, Base, EmptyName, Base]),
+    format(atom(PtrIR), '%~w_sptr', [Base]).
 
 % Ternary print field `print (COND ? A : B)`: an i64 value via select.
 plawk_emit_print_expr_for_context(ternary(Cond, Then, Else), FieldSeparator, Context,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2165,7 +2165,7 @@ printf_args([Arg | Args]) -->
     ",",
     ws,
     !,
-    field_expr(Arg),
+    printf_arg_expr(Arg),
     printf_args_rest(Args).
 printf_args([]) -->
     [].
@@ -2175,10 +2175,18 @@ printf_args_rest([Arg | Args]) -->
     ",",
     ws,
     !,
-    field_expr(Arg),
+    printf_arg_expr(Arg),
     printf_args_rest(Args).
 printf_args_rest([]) -->
     [].
+
+% A printf argument: a ternary (tried first for its `?`/`:` structure) or a
+% plain field_expr.
+printf_arg_expr(Ternary) -->
+    ternary_expr(Ternary),
+    !.
+printf_arg_expr(Expr) -->
+    field_expr(Expr).
 
 print_fields([Field | Fields]) -->
     print_field_expr(Field),
@@ -2209,6 +2217,13 @@ print_fields_rest([]) -->
 % concat([...]). Each operand is a field_expr, so arithmetic binds tighter than
 % concatenation (`$1 $2 + $3` == concat($1, $2 + $3)) and a comma still splits
 % print args. A single operand keeps its plain form (no concat wrapper).
+% Ternary `COND ? A : B` (awk `?:`). COND is a numeric comparison `L <op> R`;
+% both branches are numeric field_exprs. Tried before concat / plain field so
+% the `?`/`:` structure is seen first. Defined one level above field_expr (its
+% condition and branches call field_expr) so there is no left recursion.
+print_field_expr(Ternary) -->
+    ternary_expr(Ternary),
+    !.
 print_field_expr(concat([First, Second | Rest])) -->
     field_expr(First),
     required_ws,
@@ -2229,6 +2244,33 @@ concat_rest([Operand | Rest]) -->
     concat_rest(Rest).
 concat_rest([]) -->
     [].
+
+% A ternary `L <op> R ? THEN : ELSE`. The condition is a numeric comparison and
+% each branch is a numeric field_expr (nested ternaries are a follow-on). Used
+% by print fields and printf args.
+ternary_expr(ternary(cmp(Left, Op, Right), Then, Else)) -->
+    ternary_operand(Left),
+    ws,
+    numeric_cmp_op(Op),
+    ws,
+    ternary_operand(Right),
+    ws,
+    "?",
+    ws,
+    ternary_operand(Then),
+    ws,
+    ":",
+    ws,
+    ternary_operand(Else).
+
+% A ternary condition operand or branch: a field_expr (`$N`, `NR`, `NF`,
+% arithmetic, `length(...)`, ...) or a bare integer literal (which field_expr
+% does not accept on its own). Both lower to i64.
+ternary_operand(Expr) -->
+    field_expr(Expr),
+    !.
+ternary_operand(int(Value)) -->
+    signed_integer_value(Value).
 
 field_expr(Expr) -->
     i64_binary_surface_expr(Expr).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2001,6 +2001,21 @@ assignment_action(set(var(Name), Value)) -->
     ws,
     scalar_value_expr(Value).
 
+% String-valued assignment: a concatenation `x = $1 $2` (juxtaposition, no
+% separator -- the assignment mirror of `print $1 $2`) or a bare string literal
+% `x = "text"`. Both make `x` a string scalar (an interned atom id in an i64
+% slot). Tried before the numeric clause; concat needs two whitespace-separated
+% field_expr operands, so `x = $1 + $2` (arithmetic) still falls through.
+scalar_value_expr(concat([First, Second | Rest])) -->
+    field_expr(First),
+    required_ws,
+    field_expr(Second),
+    concat_rest(Rest),
+    !.
+scalar_value_expr(string(Value)) -->
+    quoted_string(Codes),
+    { string_codes(Value, Codes) },
+    !.
 scalar_value_expr(Value) -->
     scalar_delta_expr(Value).
 

--- a/tests/test_plawk_printf.pl
+++ b/tests/test_plawk_printf.pl
@@ -1,0 +1,154 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `printf` format coverage. The subset grew from %s/%d/%ld to the standard
+% conversion prefix `%[flags][width][.precision][length]<conv>`: integer args
+% (i64) take d/i/x/X/o/u (with the `l` length modifier) and c (code point ->
+% char); float args take f/g/e/F/G/E; string args (%s) take flags/width/
+% precision; a record-field slice (%s over len+ptr) takes flags/width and rides
+% `.*` for its length (a user precision on a field slice is a clean compile
+% error -- the pointer is not null-terminated). The format is rewritten to a C
+% printf format driven by each argument's inferred kind.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+
+:- begin_tests(plawk_printf).
+
+% --- integer width / flags --------------------------------------------------
+
+test(int_width, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'iw', "{ printf \"[%5d]\\n\", NR }\n", "a\n", Out, St),
+    assertion(St == 0), assertion(Out == "[    1]\n"), !.
+
+test(int_zero_pad, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'iz', "{ printf \"[%05d]\\n\", NR }\n", "a\n", Out, St),
+    assertion(St == 0), assertion(Out == "[00001]\n"), !.
+
+test(int_left_justify, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'il', "{ printf \"[%-5d]\\n\", NR }\n", "a\n", Out, St),
+    assertion(St == 0), assertion(Out == "[1    ]\n"), !.
+
+% --- hex / octal ------------------------------------------------------------
+
+test(hex_lower_upper, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'hx', "{ printf \"%x %X\\n\", $1 + 0, $1 + 0 }\n", "255\n", Out, St),
+    assertion(St == 0), assertion(Out == "ff FF\n"), !.
+
+test(hex_with_width_and_hash, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'hxw', "{ printf \"%#06x\\n\", $1 + 0 }\n", "255\n", Out, St),
+    assertion(St == 0), assertion(Out == "0x00ff\n"), !.
+
+test(octal, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'oc', "{ printf \"%o\\n\", $1 + 0 }\n", "8\n", Out, St),
+    assertion(St == 0), assertion(Out == "10\n"), !.
+
+% --- %c (code point -> character) -------------------------------------------
+
+test(char_from_code, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ch', "{ printf \"%c\\n\", NR + 64 }\n", "x\ny\n", Out, St),
+    assertion(St == 0), assertion(Out == "A\nB\n"), !.
+
+% --- string width / precision -----------------------------------------------
+
+test(string_literal_width, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'sw', "{ printf \"[%6s]\\n\", \"hi\" }\n", "x\n", Out, St),
+    assertion(St == 0), assertion(Out == "[    hi]\n"), !.
+
+test(string_literal_precision, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'sp', "{ printf \"%.2s\\n\", \"hello\" }\n", "x\n", Out, St),
+    assertion(St == 0), assertion(Out == "he\n"), !.
+
+test(field_slice_width, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'fw', "{ printf \"[%6s]\\n\", $1 }\n", "hi\n", Out, St),
+    assertion(St == 0), assertion(Out == "[    hi]\n"), !.
+
+test(field_slice_left_justify, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'fl', "{ printf \"[%-6s]|\\n\", $1 }\n", "hi\n", Out, St),
+    assertion(St == 0), assertion(Out == "[hi    ]|\n"), !.
+
+% A precision on a (non-null-terminated) field slice is a clean compile error.
+test(field_slice_precision_rejected, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_status(Dir, 'fp', "{ printf \"%.2s\\n\", $1 }\n", St),
+    assertion(St == 3), !.
+
+% --- float width / precision ------------------------------------------------
+
+test(float_width_precision, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'fwp', "{ printf \"[%8.2f]\\n\", float($1) }\n", "3.14159\n", Out, St),
+    assertion(St == 0), assertion(Out == "[    3.14]\n"), !.
+
+% --- unchanged basics -------------------------------------------------------
+
+test(plain_d_and_s_unchanged, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'basic', "{ printf \"%s=%d\\n\", $1, NR }\n", "a\nb\n", Out, St),
+    assertion(St == 0), assertion(Out == "a=1\nb=2\n"), !.
+
+test(percent_literal, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'pct', "{ printf \"%d%%\\n\", NR }\n", "a\n", Out, St),
+    assertion(St == 0), assertion(Out == "1%\n"), !.
+
+% --- mixed ------------------------------------------------------------------
+
+test(mixed_conversions, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'mix', "{ printf \"%-5s|%05d|%x\\n\", $1, $2 + 0, $2 + 0 }\n",
+        "ab 42\n", Out, St),
+    assertion(St == 0), assertion(Out == "ab   |00042|2a\n"), !.
+
+:- end_tests(plawk_printf).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_printf', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Src, Bin, Prog) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin).
+
+build_status(Dir, Name, Src, Status) :-
+    write_prog(Dir, Name, Src, Bin, Prog),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(Status)).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    write_prog(Dir, Name, Src, Bin, Prog),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).

--- a/tests/test_plawk_strscalar.pl
+++ b/tests/test_plawk_strscalar.pl
@@ -1,0 +1,125 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk string-valued scalars: assignment concat `x = $1 $2` and string-literal
+% assignment `x = "text"`. A string scalar's slot holds an interned atom id (an
+% i64, so it threads through the same SSA/phi machinery as numeric scalars); the
+% RHS is built into a buffer and interned at assignment (the mirror of the print
+% concat), and a read / `print` resolves the id back to text (id 0 = unset =
+% empty). Numeric and string scalars coexist in one program. v1 concat parts are
+% fields and string literals; a scalar-var operand (`x = x $1` accumulation) is
+% a follow-on.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_strscalar).
+
+% --- parsing ----------------------------------------------------------------
+
+test(concat_assign_parses) :-
+    plawk_parse_string("{ x = $1 $2 }\n",
+        program([], [rule(always, [set(var(x), concat([field(1), field(2)]))])], [])),
+    !.
+
+test(literal_assign_parses) :-
+    plawk_parse_string("{ x = \"hi\" }\n",
+        program([], [rule(always, [set(var(x), string("hi"))])], [])),
+    !.
+
+test(arithmetic_assign_unchanged) :-
+    plawk_parse_string("{ x = $1 + $2 }\n",
+        program([], [rule(always, [set(var(x), add_i64(field(1), field(2)))])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% `x = $1 $2` concatenates adjacent fields (no separator); END prints the last.
+test(concat_to_end, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ce', "{ x = $1 $2 }\nEND { print x }\n", "ab cd\nef gh\n", Out, St),
+    assertion(St == 0), assertion(Out == "efgh\n"), !.
+
+% a string literal in the middle is kept verbatim.
+test(concat_with_literal, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'cl', "{ x = $1 \"-\" $2 }\nEND { print x }\n", "foo bar\n", Out, St),
+    assertion(St == 0), assertion(Out == "foo-bar\n"), !.
+
+% three-field concat.
+test(concat_three, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'c3', "{ x = $1 $2 $3 }\nEND { print x }\n", "a b c\n", Out, St),
+    assertion(St == 0), assertion(Out == "abc\n"), !.
+
+% a bare string literal assignment.
+test(literal_assign, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'li', "{ x = \"hello\" }\nEND { print x }\n", "a\n", Out, St),
+    assertion(St == 0), assertion(Out == "hello\n"), !.
+
+% a literal prefix + field.
+test(literal_prefix, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'lp', "{ x = \"id:\" $1 }\nEND { print x }\n", "42\n", Out, St),
+    assertion(St == 0), assertion(Out == "id:42\n"), !.
+
+% printing the string scalar in the per-record body.
+test(concat_body_print, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'bp', "{ x = $1 $2; print x }\n", "ab cd\nef gh\n", Out, St),
+    assertion(St == 0), assertion(Out == "abcd\nefgh\n"), !.
+
+% a numeric scalar and a string scalar coexist and print together.
+test(mixed_numeric_and_string, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'mx',
+        "{ n = n + 1; label = $1 $2 }\nEND { print \"count:\", n, \"last:\", label }\n",
+        "a b\nc d\n", Out, St),
+    assertion(St == 0), assertion(Out == "count: 2 last: cd\n"), !.
+
+% a string scalar printed with a leading label in the same print.
+test(string_with_label, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'wl', "{ name = $1 $2 }\nEND { print \"full:\", name }\n", "John Doe\n", Out, St),
+    assertion(St == 0), assertion(Out == "full: JohnDoe\n"), !.
+
+% a plain numeric accumulator is unaffected by the string-scalar machinery.
+test(numeric_unaffected, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nu', "{ s = s + $1 }\nEND { print s }\n", "3\n7\n2\n", Out, St),
+    assertion(St == 0), assertion(Out == "12\n"), !.
+
+:- end_tests(plawk_strscalar).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_strscalar', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).

--- a/tests/test_plawk_ternary.pl
+++ b/tests/test_plawk_ternary.pl
@@ -1,0 +1,107 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk ternary `COND ? A : B` (AWK `?:`) in print / printf argument position.
+% COND is a numeric comparison `L <op> R`; both branches are numeric (fields,
+% NR/NF, integer literals, i64 arithmetic). Lowered to an LLVM `select` (both
+% branches evaluated -- no side effects in an i64 expression -- so it composes
+% straight-line anywhere an i64 value is used). Assignment-context ternary
+% (scalar-var operands) is a follow-on.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_ternary).
+
+% --- parsing ----------------------------------------------------------------
+
+test(ternary_parses) :-
+    plawk_parse_string("{ print $1 > $2 ? $1 : $2 }\n",
+        program([], [rule(always,
+            [print([ternary(cmp(field(1), gt, field(2)), field(1), field(2))])])], [])),
+    !.
+
+test(ternary_int_literal_operands_parse) :-
+    plawk_parse_string("{ print $1 > 0 ? $1 : 0 }\n",
+        program([], [rule(always,
+            [print([ternary(cmp(field(1), gt, int(0)), field(1), int(0))])])], [])),
+    !.
+
+% --- runtime (print) --------------------------------------------------------
+
+% max($1, $2)
+test(ternary_max, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'max', "{ print $1 > $2 ? $1 : $2 }\n", "3 7\n9 2\n", Out, St),
+    assertion(St == 0), assertion(Out == "7\n9\n"), !.
+
+% clamp negatives to 0 (int-literal branch)
+test(ternary_clamp, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'clamp', "{ print $1 > 0 ? $1 : 0 }\n", "5\n-3\n0\n", Out, St),
+    assertion(St == 0), assertion(Out == "5\n0\n0\n"), !.
+
+% NR in the condition and a branch
+test(ternary_nr, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nr', "{ print NR > 1 ? NR : 0 }\n", "a\nb\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == "0\n2\n3\n"), !.
+
+% arithmetic in a branch
+test(ternary_arith_branch, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ar', "{ print $1 > $2 ? $1 + 100 : $2 + 100 }\n", "3 7\n", Out, St),
+    assertion(St == 0), assertion(Out == "107\n"), !.
+
+% equality condition
+test(ternary_eq, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'eq', "{ print $1 == 0 ? 111 : 222 }\n", "0\n5\n", Out, St),
+    assertion(St == 0), assertion(Out == "111\n222\n"), !.
+
+% under a rule guard
+test(ternary_guarded, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'gd', "$1 > 0 { print $1 > 5 ? 1 : 0 }\n", "3\n9\n-1\n", Out, St),
+    assertion(St == 0), assertion(Out == "0\n1\n"), !.
+
+% --- runtime (printf) -------------------------------------------------------
+
+test(ternary_printf_arg, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'pf', "{ printf \"max=%d\\n\", $1 > $2 ? $1 : $2 }\n", "3 7\n", Out, St),
+    assertion(St == 0), assertion(Out == "max=7\n"), !.
+
+:- end_tests(plawk_ternary).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_ternary', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
### Why this PR exists

PRs #3798 (printf), #3799 (ternary), #3800 (string scalars) were opened as a
**stack**, each based on the previous feature's branch. When they were merged,
the changes cascaded **sideways into the intermediate branches** rather than the
main feature line — so only #3796 (`delete`) actually landed on
`claude/plawk-llvm-wam-hybrid-p9ujut`. The three commits are provably not
ancestors of the feature line (their test files are absent from it).

This PR re-lands them cleanly: the same three commits, cherry-picked directly
onto the current feature line (which already has `delete`), so its base is the
feature line and merging it puts the work where it belongs. No new code — it is
exactly the reviewed commits from #3798/#3799/#3800.

### Contents (unchanged from the merged PRs)

- **printf format coverage** — `%[flags][width][.precision][length]conv`;
  integer `d`/`i`/`x`/`X`/`o`/`u`/`c`, float `f`/`g`/`e`/`F`/`G`/`E`, string
  `%s`; flags `-+ 0#`, width, precision. (`tests/test_plawk_printf.pl`)
- **ternary `?:`** in print / printf args, lowered to an LLVM `select`.
  (`tests/test_plawk_ternary.pl`)
- **string-valued scalars** — `x = $1 $2` / `x = "text"`; a string scalar's slot
  holds an interned atom id (i64), so it reuses the whole SSA/phi machinery.
  (`tests/test_plawk_strscalar.pl`)

Smoke-tested after the cherry-pick: `printf "[%05d]"`, `print $1 > $2 ? $1 : $2`,
and `x = $1 $2` all build and run correctly on this branch.

> Going forward I'll base each PR directly on the feature line (cumulative diff
> until predecessors merge) so merges always land on the main line and this
> can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_