### PR TITLE
FS-ARITH-INT-DIV: add integer division (//) to F# WAM arith evaluator

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -886,6 +886,12 @@ let rec evalArith (bindings: Map<int, Value>) (v: Value) : float option =
         match evalArith bindings a, evalArith bindings b with
         | Some x, Some y when y <> 0.0 -> Some (x / y)
         | _ -> None
+    | Str (\"//\", [a; b]) ->
+        // Prolog integer division: truncate quotient toward zero (SWI default,
+        // integer_rounding_function = toward_zero).
+        match evalArith bindings a, evalArith bindings b with
+        | Some x, Some y when y <> 0.0 -> Some (float (truncate (x / y)))
+        | _ -> None
     | Str (\"mod\", [a; b]) ->
         match evalArith bindings a, evalArith bindings b with
         | Some x, Some y when y <> 0.0 -> Some (float (int x % int y))

--- a/src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs
+++ b/src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs
@@ -249,6 +249,12 @@ let rec evalArith (bindings: Map<int, Value>) (v: Value) : float option =
         match evalArith bindings a, evalArith bindings b with
         | Some x, Some y when y <> 0.0 -> Some (x / y)
         | _ -> None
+    | Str ("//", [a; b]) ->
+        // Prolog integer division: truncate quotient toward zero (SWI default,
+        // integer_rounding_function = toward_zero).
+        match evalArith bindings a, evalArith bindings b with
+        | Some x, Some y when y <> 0.0 -> Some (float (truncate (x / y)))
+        | _ -> None
     | Str ("mod", [a; b]) ->
         match evalArith bindings a, evalArith bindings b with
         | Some x, Some y when y <> 0.0 -> Some (float (int x % int y))

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -291,14 +291,15 @@ ct_default_target(elixir).
 %   - append / reverse: non-empty ground answers fail — PutList +
 %     SetVariable partial-tail materialization vs GetList/unify on the
 %     result spine (VList / "[|]"/2). Empty-list append base case passes.
-%   - builtins: evalArith has no Str ("//", ...) clause, so integer-div
-%     `17 // 5` (PutStructure "//") returns None and cbi_arith(28) fails
-%     (mod is present; +,-,*,=/2,cmp pass).
+%   - builtins: now green (interpreter). FS-ARITH-INT-DIV fixed —
+%     evalArith gained a Str ("//", ...) clause (truncate-toward-zero
+%     integer division) in src/unifyweaver/bindings/fsharp_wam_bindings.pl,
+%     so `17 // 5` folds and cbi_arith(28) succeeds (+,-,*,mod,=/2,cmp
+%     already passed).
 %   - fsharp_functions + builtins: lowered emitter loops/stalls on cbi_eq
 %     (unsupported-instruction Proceed stubs for =/2); skip generation.
 ct_xfail(fsharp, append).            % FS-LIST-PARTIAL-TAIL
 ct_xfail(fsharp, reverse).           % FS-LIST-PARTIAL-TAIL
-ct_xfail(fsharp, builtins).          % FS-ARITH-INT-DIV
 ct_xfail(fsharp_functions, append).  % FS-LIST-PARTIAL-TAIL (same class)
 ct_xfail(fsharp_functions, reverse). % FS-LIST-PARTIAL-TAIL
 ct_skip(fsharp_functions, builtins). % FS-FUNCTIONS-BUILTINS-LOWER — codegen stalls


### PR DESCRIPTION
## Summary

The F# hybrid WAM arithmetic evaluator (`evalArith`) supported `+ - * / mod` but not Prolog's `//` (integer division). `X is A // B` folded to `None`, so the `builtins` conformance program (`cbi_arith`) was `ct_xfail`'d for the `fsharp` target.

This adds a `Str ("//", [a; b])` arm that truncates the quotient toward zero (SWI default, `integer_rounding_function = toward_zero`), mirroring the existing `/` and `mod` arms' zero-guard / `None`-on-zero style.

## Changes

- **`src/unifyweaver/bindings/fsharp_wam_bindings.pl`** — generator source of truth: new `//` arm in `evalArith`.
- **`src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs`** — hand-maintained reference runtime kept in sync (its header requires parity with the generator).
- **`tests/test_wam_cross_target_conformance.pl`** — retired `ct_xfail(fsharp, builtins)` (the program is now fully green in interpreter mode; `+,-,*,mod,=/2,cmp` already passed, int-div was the sole gap) and updated the banner note. `ct_skip(fsharp_functions, builtins)` is left as-is — that's a separate lowered-codegen stall, out of scope here.

## Verification

Execution-verified, not inspection: installed .NET SDK 8.0.423 and ran `CONFORMANCE_TARGETS=fsharp` — suite **passes** (~99s). With the xfail removed, `builtins` produces no fail/xfail line (it now matches the SWI reference, i.e. `17 // 5` folds correctly). `append`/`reverse` xfails unchanged; their base cases still XPASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLUKkYGryYYtBtP7siu7uc)_