### PR TITLE
FS-LIST-PARTIAL-TAIL: F# GetValue structural unify for list spines

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -24,8 +24,8 @@ self-contained so a single coding agent can pick it up in isolation.
 
 | ID | Lever | Target | Size | Depends on |
 |---|---|---|---|---|
-| CONF-FSHARP ✅ | Conformance adapter | F# | M | done — opt-in (`cursor/conf-fsharp-f421`); member/fib/ack green, append/reverse/builtins xfails + functions/builtins skip |
-| FS-LIST-PARTIAL-TAIL | Conformance gap fix | F# | M | CONF-FSHARP |
+| CONF-FSHARP ✅ | Conformance adapter | F# | M | done — opt-in; classic programs green on interpreter; functions/builtins still skipped |
+| FS-LIST-PARTIAL-TAIL ✅ | Conformance gap fix | F# | M | done — GetValue→unifyVal (`cursor/fs-list-partial-tail-f421`); append/reverse green on fsharp + fsharp_functions |
 | FS-ARITH-INT-DIV | Conformance gap fix | F# | S | CONF-FSHARP |
 | FS-FUNCTIONS-BUILTINS-LOWER | Conformance gap fix | F# | M | CONF-FSHARP |
 | CONF-LLVM | Conformance adapter | LLVM | L | — |
@@ -89,14 +89,14 @@ external toolchain.
 
 ### CONF-FSHARP: Register F# in the cross-target conformance harness
 - **Lever:** Conformance adapters  **Target:** F#  **Size:** M  **Depends on:** —
-- **Status:** ✅ **Landed** on `cursor/conf-fsharp-f421` (2026-07-15). Opt-in `conformance_target(fsharp)` + `fsharp_functions` (`emit_mode(interpreter|functions)`). Added additive `conformance_main(true)` Program.fs driver (`tryRun` → `true`/`false`) without changing the default TSV/LMDB benchmark entrypoint. `dotnet build` gate; `dotnet run --no-build -- <key>` (avoid `--nologo` on the run line — some SDKs forward it as argv[0]). **Measured:** member/fib/ack green on both emit modes; `ct_xfail` append/reverse (FS-LIST-PARTIAL-TAIL) + builtins (FS-ARITH-INT-DIV); `ct_skip` `fsharp_functions`/builtins (FS-FUNCTIONS-BUILTINS-LOWER). Follow-ups filed below.
+- **Status:** ✅ **Landed** on `cursor/conf-fsharp-f421` (2026-07-15). Opt-in `conformance_target(fsharp)` + `fsharp_functions` (`emit_mode(interpreter|functions)`). Added additive `conformance_main(true)` Program.fs driver (`tryRun` → `true`/`false`) without changing the default TSV/LMDB benchmark entrypoint. `dotnet build` gate; `dotnet run --no-build -- <key>` (avoid `--nologo` on the run line — some SDKs forward it as argv[0]). **Measured (updated):** member/fib/ack/builtins/append/reverse green on interpreter; append/reverse also green on `fsharp_functions` after FS-LIST-PARTIAL-TAIL. Remaining: `ct_skip` `fsharp_functions`/builtins (FS-FUNCTIONS-BUILTINS-LOWER).
 - **Goal:** Add an F# adapter (`conformance_target(fsharp)` + `ct_toolchain`/`ct_build`/`ct_run`/`ct_teardown`) so the shared WAM spec runs against the F# backend.
 - **Acceptance:** `CONFORMANCE_TARGETS=fsharp[,fsharp_functions] swipl -g run_tests tests/test_wam_cross_target_conformance.pl` runs the adapter (skips cleanly if `dotnet` absent); xfails/skips match measured gaps.
 
 ### FS-LIST-PARTIAL-TAIL: F# PutList/SetVariable result spines vs GetList
 - **Lever:** Conformance gap fix  **Target:** F#  **Size:** M  **Depends on:** CONF-FSHARP
+- **Status:** ✅ **Landed** on `cursor/fs-list-partial-tail-f421` (2026-07-15). Root cause was **not** the builder (`addToBuilder` already emits `Str("[|]",[h;t])` for symbolic tails). Ground `capp([a],[b],[a,b])` failed in the base-case **GetValue** which used F# `=` / shallow bind; A3 was `Str("[|]",…)` while A2 was compact `VList`. Open-tail `capp([a],[b],X),X=[a,b]` already passed via `=/2`→`unifyTerms`. Fix: `GetValue` → `unifyVal`/`unifyTerms` in `wam_fsharp_target.pl` + hand-maintained `fsharp_runtime/WamRuntime.fs`. **Measured:** append/reverse green on `fsharp` and `fsharp_functions` (no xfail); suite exit 0.
 - **Goal:** Make non-empty ground `append`/`reverse` answers succeed under the classic harness (empty-list append base already passes).
-- **Root cause (measured):** Wrapper construction of ground result lists uses `PutList` + `SetVariable` + nested `PutStructure("[|]", …)` while recursive clauses peel with `GetList`/`UnifyValue`; partial-tail materialization does not unify against the expected VList/`"[|]"/2` spine.
 - **Acceptance:** Drop `ct_xfail(fsharp, append/reverse)` and the `fsharp_functions` twins; both emit modes green on those programs.
 
 ### FS-ARITH-INT-DIV: F# `evalArith` missing `//`

--- a/docs/WAM_FSHARP_STATUS.md
+++ b/docs/WAM_FSHARP_STATUS.md
@@ -81,12 +81,12 @@ classic `wam_conformance_smoke` matrix with Scala/Elixir.
 - Bidirectional off by default; enable after cost-model confidence.
 - Classic conformance (**CONF-FSHARP**, 2026-07-15): registered
   opt-in (`fsharp` / `fsharp_functions`) with additive
-  `conformance_main(true)`. **Measured maturity:** member, fib, ack
-  green on interpreter and `emit_mode(functions)`. Still xfail:
-  append/reverse (FS-LIST-PARTIAL-TAIL — PutList/SetVariable result
-  spines vs GetList), builtins (FS-ARITH-INT-DIV — `evalArith` lacks
-  `//`). `fsharp_functions`+builtins skipped (FS-FUNCTIONS-BUILTINS-LOWER
-  — lowered emitter stalls on `cbi_eq`).
+  `conformance_main(true)`. **Measured maturity:** member, fib, ack,
+  builtins, append, reverse green on interpreter; append/reverse also
+  green under `emit_mode(functions)` after **FS-LIST-PARTIAL-TAIL**
+  (GetValue→unifyVal; builder was already correct). Remaining:
+  `fsharp_functions`+builtins skipped (FS-FUNCTIONS-BUILTINS-LOWER —
+  lowered emitter stalls on `cbi_eq`).
 - Dynamic database partial (facts via lowered mutation; prefer Python
   for full dynamic-DB semantics — target doc).
 - LMDB scan-mode / workload-segregation wait on Rust R9/R10 reference.
@@ -100,8 +100,8 @@ classic `wam_conformance_smoke` matrix with Scala/Elixir.
 
 ## Path forward
 
-1. Close CONF-FSHARP follow-ups: FS-LIST-PARTIAL-TAIL,
-   FS-ARITH-INT-DIV, FS-FUNCTIONS-BUILTINS-LOWER.
+1. Close remaining CONF-FSHARP follow-up:
+   FS-FUNCTIONS-BUILTINS-LOWER (FS-LIST-PARTIAL-TAIL done).
 2. Elixir-style cost-gate calibration for TPL fanout.
 3. Follow Rust scan/segregation LMDB contract when available.
 4. Keep ISO table in sync with C++/Elixir/Python.

--- a/src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs
+++ b/src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs
@@ -221,6 +221,48 @@ let bindOutput (reg: int) (value: Value) (s: WamState) : WamState option =
     | Some existing when existing = value -> Some s
     | _ -> None
 
+/// Structural unify with VList <-> Str("[|]", [h;t]) cons-cell aliasing.
+/// Mirrors wam_fsharp_target.pl unifyTerms (FS-LIST-PARTIAL-TAIL). Does not
+/// advance WsPC — callers (GetValue) bump PC on success.
+let rec unifyTerms (a: Value) (b: Value) (s: WamState) : WamState option =
+    let a = derefVar s.WsBindings a
+    let b = derefVar s.WsBindings b
+    let bindUnbound vid v st =
+        { st with
+            WsBindings = Map.add vid v st.WsBindings
+            WsTrail    = { TrailVarId = vid; TrailOldVal = Map.tryFind vid st.WsBindings } :: st.WsTrail
+            WsTrailLen = st.WsTrailLen + 1 }
+    match a, b with
+    | Unbound vid, v -> Some (bindUnbound vid v s)
+    | v, Unbound vid -> Some (bindUnbound vid v s)
+    | VList [], Atom "[]" -> Some s
+    | Atom "[]", VList [] -> Some s
+    | VList (h1 :: t1), VList (h2 :: t2) ->
+        match unifyTerms h1 h2 s with
+        | None    -> None
+        | Some s1 -> unifyTerms (VList t1) (VList t2) s1
+    | VList (h :: t), Str ("[|]", [hb; tb]) ->
+        match unifyTerms h hb s with
+        | None    -> None
+        | Some s1 -> unifyTerms (VList t) tb s1
+    | Str ("[|]", [ha; ta]), VList (h :: t) ->
+        match unifyTerms ha h s with
+        | None    -> None
+        | Some s1 -> unifyTerms ta (VList t) s1
+    | Str (f1, args1), Str (f2, args2)
+        when f1 = f2 && List.length args1 = List.length args2 ->
+        let rec go xs ys st =
+            match xs, ys with
+            | [], [] -> Some st
+            | x :: xt, y :: yt ->
+                match unifyTerms x y st with
+                | None     -> None
+                | Some st1 -> go xt yt st1
+            | _ -> None
+        go args1 args2 s
+    | x, y when x = y -> Some s
+    | _               -> None
+
 /// Append to the current builder (PutStructure / PutList sequence).
 let addToBuilder (value: Value) (s: WamState) : WamState option =
     match s.WsBuilder with
@@ -450,6 +492,8 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                      WsTrail    = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
                      WsTrailLen = s.WsTrailLen + 1 }
         | Some existing when existing = c -> Some s1
+        // Atom "[]" <-> VList [] empty-list equivalence (read path).
+        | Some (VList []) when c = Atom "[]" -> Some s1
         | _ -> backtrack s
 
     | GetVariable (xn, ai) ->
@@ -459,12 +503,14 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         Some { s1 with WsRegs = Map.add xn src s.WsRegs }
 
     | GetValue (xn, ai) ->
-        // Full unification needed; delegate to unify helper
-        let v1 = Map.tryFind xn s.WsRegs |> Option.map (derefVar s.WsBindings)
-        let v2 = Map.tryFind ai s.WsRegs |> Option.map (derefVar s.WsBindings)
-        match v1, v2 with
-        | Some a, Some b when a = b -> Some s1
-        | _ -> backtrack s  // simplified: full unify handled by generator
+        // Structural unify (VList <-> "[|]"/2), not F# `=`. See
+        // FS-LIST-PARTIAL-TAIL / wam_fsharp_target.pl GetValue.
+        match getReg xn s, getReg ai s with
+        | Some a, Some b ->
+            match unifyTerms a b s with
+            | Some st -> Some { st with WsPC = s1.WsPC }
+            | None    -> backtrack s
+        | _ -> backtrack s
 
     | PutConstant (c, ai) ->
         Some { s1 with WsRegs = Map.add ai c s.WsRegs }
@@ -660,9 +706,10 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | _ -> backtrack s
 
     | GetList ai ->
-        let v = Map.tryFind ai s.WsRegs |> Option.map (derefVar s.WsBindings)
-        match v with
-        | Some (VList _) -> Some s1
+        // Accept both cons encodings (compact VList and Str "[|]"/2).
+        match getReg ai s with
+        | Some (VList (_ :: _)) | Some (Str ("[|]", [_; _])) -> Some s1
+        | Some (Unbound _) -> Some s1  // write-mode stub
         | _ -> backtrack s
 
     | UnifyVariable xn ->

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -753,20 +753,16 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | None    -> None
 
     | GetValue (xn, ai) ->
-        let va = getReg ai s
-        let vx = getReg xn s
-        match va, vx with
-        | Some a, Some x when a = x -> Some { s with WsPC = s.WsPC + 1 }
-        | Some (Unbound vid), Some x ->
-            let r = Array.copy s.WsRegs
-            r.[ai] <- x
-            Some { s with
-                     WsPC      = s.WsPC + 1
-                     WsRegs    = r
-                     WsBindings= Map.add vid x s.WsBindings
-                     WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
-                     WsTrailLen= s.WsTrailLen + 1 }
-        | _ -> None
+        // Structural unify (not F# `=`). Ground append/reverse answers
+        // materialize the result spine as Str("[|]", [h; t]) via
+        // PutList+SetVariable+PutStructure, while A2 / peeled tails are
+        // often compact VList — same VList <-> "[|]"/2 class unifyTerms
+        // already handles for UnifyValue / =/2. Shallow equality made
+        // capp([a],[b],[a,b]) fail in the base-case GetValue while
+        // capp([a],[b],X), X=[a,b] (open + =/2) passed (FS-LIST-PARTIAL-TAIL).
+        match getReg ai s, getReg xn s with
+        | Some a, Some x -> unifyVal a x s
+        | _              -> None
 
     | GetStructure (fn, arity, ai) ->
         // If we''re already inside a build/read context, push it so the

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -287,21 +287,15 @@ ct_default_target(elixir).
 %  KT-Y-ENV-RECURSION (no remaining kotlin ct_xfail entries).
 
 %  F# (CONF-FSHARP, 2026-07-15). Adapter registered (opt-in). Measured:
-%   - Green: member, fib, ack (interpreter + emit_mode(functions)).
-%   - append / reverse: non-empty ground answers fail — PutList +
-%     SetVariable partial-tail materialization vs GetList/unify on the
-%     result spine (VList / "[|]"/2). Empty-list append base case passes.
-%   - builtins: now green (interpreter). FS-ARITH-INT-DIV fixed —
-%     evalArith gained a Str ("//", ...) clause (truncate-toward-zero
-%     integer division) in src/unifyweaver/bindings/fsharp_wam_bindings.pl,
-%     so `17 // 5` folds and cbi_arith(28) succeeds (+,-,*,mod,=/2,cmp
-%     already passed).
+%   - Green: member, fib, ack, builtins, append, reverse on interpreter.
+%   - append / reverse ALSO green under emit_mode(functions) after
+%     FS-LIST-PARTIAL-TAIL (2026-07-15): GetValue routes through
+%     unifyVal/unifyTerms so ground Str("[|]",…) result spines unify with
+%     compact VList. Builder was already correct; open-tail
+%     `capp([a],[b],X),X=[a,b]` already passed via =/2. No remaining
+%     fsharp/fsharp_functions ct_xfail for append/reverse.
 %   - fsharp_functions + builtins: lowered emitter loops/stalls on cbi_eq
 %     (unsupported-instruction Proceed stubs for =/2); skip generation.
-ct_xfail(fsharp, append).            % FS-LIST-PARTIAL-TAIL
-ct_xfail(fsharp, reverse).           % FS-LIST-PARTIAL-TAIL
-ct_xfail(fsharp_functions, append).  % FS-LIST-PARTIAL-TAIL (same class)
-ct_xfail(fsharp_functions, reverse). % FS-LIST-PARTIAL-TAIL
 ct_skip(fsharp_functions, builtins). % FS-FUNCTIONS-BUILTINS-LOWER — codegen stalls
 
 % ============================================================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes ground non-empty `append`/`reverse` answers on the F# hybrid WAM target (CONF-FSHARP follow-up).

### Root cause (pinned, not the builder)
- Builder already correct: `addToBuilder` emits `Str("[|]", [h;t])` for symbolic tails and `VList` for ground tails.
- **Failure site:** base-case `GetValue` used F# `=` / shallow bind.
- Ground `capp([a],[b],[a,b])` leaves A3 as `Str("[|]",…)` while A2 is compact `VList [b]` → shallow eq fails.
- Open-tail `capp([a],[b],X), X=[a,b]` already passed via `=/2` → `unifyTerms`.

### Fix
- Generator (`wam_fsharp_target.pl`): `GetValue` → `unifyVal` / `unifyTerms`.
- Hand-maintained `fsharp_runtime/WamRuntime.fs`: add `unifyTerms`, route `GetValue` through it; accept both cons encodings on `GetList` / empty-list on `GetConstant` (sync).

### Measured (before → after)
| Query | Before | After |
|---|---|---|
| `capp/3([[a],[b],[a,b]])` | false | **true** |
| `clist_reverse/2([[a,b,c],[c,b,a]])` | false | **true** |
| `capp/3([[],[a],[a]])` / empty reverse | XPASS under xfail | ordinary pass |

Retired `ct_xfail(fsharp, append/reverse)` **and** the `fsharp_functions` twins (same fix greens functions mode). Remaining: `ct_skip(fsharp_functions, builtins)` (FS-FUNCTIONS-BUILTINS-LOWER).

### Verify
```bash
LANG=C.UTF-8 CONFORMANCE_TARGETS=fsharp,fsharp_functions \
  swipl -q -g run_tests -t halt tests/test_wam_cross_target_conformance.pl
```
Exit 0; no append/reverse xfail/XPASS lines.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

