### PR TITLE
WAM/LLVM plawk: string accumulation (x = x $1)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -68,7 +68,7 @@ only (runtime pending) · ❌ missing.
 | arithmetic `+ - * / % //` | ✅ | i64, awk precedence, safe div/mod |
 | comparison, `~`/`!~` | ✅ | |
 | ternary `?:` | ◐ | `COND ? A : B` in print / printf args — numeric comparison condition, numeric branches (fields, `NR`/`NF`, int literals, i64 arithmetic); lowered to an LLVM `select`. Assignment-context (scalar-var operands) and string branches are follow-ons |
-| string concatenation (juxtaposition `$1 $2`) | ✅ | `print` context **and** assignment: `print $1 $2`; `x = $1 $2` / `x = "id:" $1` build a **string-valued scalar** (an interned atom id in an i64 slot, resolved to text on read/print). Arithmetic binds tighter, comma still splits. Scalar-var concat operand (`x = x $1` accumulation) is a follow-on |
+| string concatenation (juxtaposition `$1 $2`) | ✅ | `print` context **and** assignment: `print $1 $2`; `x = $1 $2` / `x = "id:" $1` build a **string-valued scalar** (an interned atom id in an i64 slot, resolved to text on read/print), **incl. accumulation `x = x $1`** (a string-scalar read as a concat operand — resolved to text and re-interned). Arithmetic binds tighter, comma still splits |
 | exponentiation `^` / `**` | ❌ | |
 
 ## Arrays

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -11088,6 +11088,11 @@ plawk_substitute_operation_reads(add(Expr0), Slots, Values, add(Expr)) :-
 plawk_substitute_operation_reads(set(Expr0), Slots, Values, set(Expr)) :-
     !,
     plawk_substitute_scalar_reads(Expr0, Slots, Values, Expr).
+% a string assignment's RHS may read a string scalar (`x = x $1` accumulation);
+% substitute the reads to their current slot values (ssa_str) before the build.
+plawk_substitute_operation_reads(set_str(Src0), Slots, Values, set_str(Src)) :-
+    !,
+    plawk_substitute_scalar_reads(Src0, Slots, Values, Src).
 plawk_substitute_operation_reads(Operation, _Slots, _Values, Operation).
 
 plawk_substitute_scalar_reads(concat(Parts), Slots, Values, concat(SubParts)) :-
@@ -11330,10 +11335,13 @@ plawk_scalar_action_update(set(var(Name), compile_file_handle(Arg)), Name,
         set(compile_file_handle(Arg))) :-
     plawk_foreign_arg(Arg).
 
-% A string-scalar concat part: a field (`$N`, projected as text) or a string
-% literal (embedded in the build format). Other part kinds are a follow-on.
+% A string-scalar concat part: a field (`$N`, projected as text), a string
+% literal (embedded in the build format), or a scalar-variable read (a string
+% scalar, resolved to text -- enables accumulation `x = x $1`). A numeric var in
+% a string concat is the caller's responsibility (it is read as an atom id).
 plawk_str_scalar_part_ok(field(Index)) :- integer(Index), Index >= 0.
 plawk_str_scalar_part_ok(string(Value)) :- string(Value).
+plawk_str_scalar_part_ok(var(Name)) :- atom(Name).
 % Double-typed update expressions: float literals, float($N), and
 % binary trees mixing them with i64 operands or scalar reads. The
 % written slot becomes a double via plawk_scalar_typed_slots/3.
@@ -11886,6 +11894,10 @@ plawk_str_concat_format([], '').
 plawk_str_concat_format([field(_) | Rest], Fmt) :-
     plawk_str_concat_format(Rest, RestFmt),
     atom_concat('%.*s', RestFmt, Fmt).
+% a resolved string-scalar read prints as a null-terminated `%s`.
+plawk_str_concat_format([ssa_str(_) | Rest], Fmt) :-
+    plawk_str_concat_format(Rest, RestFmt),
+    atom_concat('%s', RestFmt, Fmt).
 plawk_str_concat_format([string(Value) | Rest], Fmt) :-
     plawk_str_escape_percent(Value, Escaped),
     plawk_str_concat_format(Rest, RestFmt),
@@ -11905,6 +11917,21 @@ plawk_str_concat_field_lines([], _B, _Empty, _FieldSep, _Pos, [], []).
 plawk_str_concat_field_lines([string(_) | Rest], B, EmptyName, FieldSep, Pos,
         Lines, Frags) :-
     plawk_str_concat_field_lines(Rest, B, EmptyName, FieldSep, Pos, Lines, Frags).
+% a resolved string-scalar read: resolve its atom id to text (id 0 -> empty via
+% the null-safe global), yielding an `i8* <ptr>` snprintf argument for its `%s`.
+plawk_str_concat_field_lines([ssa_str(Value) | Rest], B, EmptyName, FieldSep, Pos,
+        Lines, [Frag | Frags]) :-
+    format(atom(Str), '  %~w_c~w_s = call i8* @wam_atom_to_string(i64 ~w)',
+        [B, Pos, Value]),
+    format(atom(Empty), '  %~w_c~w_e = icmp eq i64 ~w, 0', [B, Pos, Value]),
+    format(atom(Sel),
+        '  %~w_c~w_sptr = select i1 %~w_c~w_e, i8* getelementptr ([1 x i8], [1 x i8]* @.~w, i64 0, i64 0), i8* %~w_c~w_s',
+        [B, Pos, B, Pos, EmptyName, B, Pos]),
+    format(atom(Frag), 'i8* %~w_c~w_sptr', [B, Pos]),
+    ThisLines = [Str, Empty, Sel],
+    Pos1 is Pos + 1,
+    plawk_str_concat_field_lines(Rest, B, EmptyName, FieldSep, Pos1, RestLines, Frags),
+    append(ThisLines, RestLines, Lines).
 plawk_str_concat_field_lines([field(N) | Rest], B, EmptyName, FieldSep, Pos,
         Lines, [Frag | Frags]) :-
     format(atom(Slice),

--- a/tests/test_plawk_strscalar.pl
+++ b/tests/test_plawk_strscalar.pl
@@ -93,6 +93,26 @@ test(numeric_unaffected, [condition(clang_available)]) :-
     build_run(Dir, 'nu', "{ s = s + $1 }\nEND { print s }\n", "3\n7\n2\n", Out, St),
     assertion(St == 0), assertion(Out == "12\n"), !.
 
+% --- string accumulation (x = x $1) -----------------------------------------
+
+% `acc = acc $1` accumulates across records; an unset string scalar starts empty.
+test(accumulate, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ac', "{ acc = acc $1 }\nEND { print acc }\n", "a\nb\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == "abc\n"), !.
+
+% accumulate with a trailing literal separator (CSV build).
+test(accumulate_with_separator, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'as', "{ s = s $1 \",\" }\nEND { print s }\n", "x\ny\nz\n", Out, St),
+    assertion(St == 0), assertion(Out == "x,y,z,\n"), !.
+
+% accumulate with literal delimiters around each field.
+test(accumulate_wrapped, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'aw', "{ log = log \"[\" $1 \"]\" }\nEND { print log }\n", "a\nb\n", Out, St),
+    assertion(St == 0), assertion(Out == "[a][b]\n"), !.
+
 :- end_tests(plawk_strscalar).
 
 % --- helpers ---------------------------------------------------------------


### PR DESCRIPTION
A string scalar can now be a concat operand on the RHS of an assignment,
enabling **accumulation** — `acc = acc $1`, `s = s $1 ","`, `log = log "[" $1 "]"`.
Follow-on to string-valued scalars.

## How it works

- A scalar-var concat part is accepted (`plawk_str_scalar_part_ok(var(_))`), so a
  concat containing a var operand types the target as a string scalar.
- The `set_str` RHS is now substituted for scalar reads **before** the build
  (`plawk_substitute_operation_reads(set_str(...))`), so a var read becomes
  `ssa_str(SlotValue)` — the *current* slot value (pre-assignment), which is
  exactly the AWK accumulation semantic.
- The concat build handles an `ssa_str` part: resolve the atom id to text
  (`wam_atom_to_string`, id 0 → empty via the null-safe global) and splice it in
  through a `%s` slot. An unset string scalar accumulates from empty.

## Scope

A var operand is read as a string scalar (its atom id resolved to text). A
numeric var placed in a string concat is the caller's responsibility.

## Tests

`tests/test_plawk_strscalar.pl` +3: `acc = acc $1` → `abc`; `s = s $1 ","` →
`x,y,z,`; `log = log "[" $1 "]"` → `[a][b]`. Regressions green: `strscalar`,
`concat`, `surface_arith_exprs`, `surface_end_scalar_exprs`.

## Docs

`PLAWK_AWK_FEATURE_AUDIT.md` — string concatenation → accumulation landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_