### PR TITLE
WAM/LLVM plawk: string-equality guards (if s == "text")

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -32,7 +32,7 @@ only (runtime pending) · ❌ missing.
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic, **concatenation**) | ✅ | constant fields (`print 1`, `print "x"`) + juxtaposition concat (`print $1 $2`) landed |
 | `printf` | ✅ | standard `%[flags][width][.precision][length]conv`: integers `d`/`i`/`x`/`X`/`o`/`u` + `c` (code point), floats `f`/`g`/`e`/`F`/`G`/`E`, strings `%s`; flags `-+ 0#`, width, precision. Field-slice `%s` takes width but not precision (non-terminated buffer); `%c` needs a numeric arg |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
-| `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`) **and scalar-variable conditions** (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`** (`END { if (n > 1) print … ; else print … }`, over final slot values) |
+| `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`), scalar-variable conditions (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`**, **and string-equality guards on a string scalar** (`if (s == "text")` / `!=`, lowered as interned atom-id comparison — single `==`/`!=`, not combined with `&&`/`||`) |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
 | `while (COND)` | ✅ | runtime landed (loop-header phis); condition is scalar comparisons (`VAR CMP int`/`VAR`) combined with `&&`/`||` — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2–3. `break`/`continue` deferred (PR 3b) |
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4952,6 +4952,7 @@ plawk_while_cond_vars(or(A, B), Vars) :-
     plawk_while_cond_vars(B, VB),
     append(VA, VB, Vars).
 plawk_while_cond_vars(cmp(var(V), _Op, int(_N)), [V]) :- !.
+plawk_while_cond_vars(cmp(var(V), _Op, string(_S)), [V]) :- !.
 plawk_while_cond_vars(cmp(var(V), _Op, var(W)), [V, W]).
 
 %% plawk_while_cond_ir(+Cond, +Slots, +CondValues, +Base, -CondVar, -IR)
@@ -5008,6 +5009,29 @@ plawk_while_cond_operand(var(Name), Slots, CondValues, Ref) :-
 %  scalar comparison over slots -- lowered like a loop condition, reading the
 %  current slot SSA values (Values0). A field/pattern guard is lowered by the
 %  existing pattern-guard emitter (which reads the record).
+% String-equality guard `if (s == "text")` / `!=` on a string scalar: intern the
+% literal and compare atom ids (interning is canonical, so equal strings share an
+% id). Only == / != (ordering would need strcmp). A single comparison, not
+% combined with && / || (that stays a clean codegen error) -- v1.
+plawk_if_cond_ir(scalar_if(cmp(var(Name), Op, string(Value))), Slots, Values0,
+        _FieldSeparator, GlobalBase, CondValue, GlobalIR-IR) :-
+    memberchk(Op, [eq, ne]),
+    !,
+    nth0(Idx, Slots, Slot),
+    plawk_slot_name(Slot, Name),
+    !,
+    nth0(Idx, Values0, SlotValue),
+    format(atom(LitName), '~w_lit', [GlobalBase]),
+    llvm_emit_c_string_global(LitName, Value, GlobalIR, Len, BytesLen),
+    plawk_icmp_pred(Op, Pred),
+    format(atom(CondValue), '%~w_cond', [GlobalBase]),
+    format(atom(IR),
+'  %~w_litptr = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0
+  %~w_litid = call i64 @wam_intern_atom(i8* %~w_litptr, i64 ~w)
+  %~w_cond = icmp ~w i64 ~w, %~w_litid',
+        [GlobalBase, BytesLen, BytesLen, LitName,
+         GlobalBase, GlobalBase, Len,
+         GlobalBase, Pred, SlotValue, GlobalBase]).
 plawk_if_cond_ir(scalar_if(Cond), Slots, Values0, _FieldSeparator, GlobalBase,
         CondValue, ''-GuardIR) :-
     !,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1665,6 +1665,13 @@ while_cmp(cmp(var(V), Op, Rhs)) -->
 while_cmp_rhs(int(N)) -->
     signed_integer_value(N),
     !.
+% a string literal RHS -- used by `if (s == "text")` string-equality guards on a
+% string scalar (lowered as interned atom-id comparison). A while loop with a
+% string condition is a clean codegen error (no string loop bound).
+while_cmp_rhs(string(Value)) -->
+    quoted_string(Codes),
+    { string_codes(Value, Codes) },
+    !.
 while_cmp_rhs(var(W)) -->
     identifier(W).
 

--- a/tests/test_plawk_strguard.pl
+++ b/tests/test_plawk_strguard.pl
@@ -1,0 +1,95 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk string-equality guards: `if (s == "text")` / `if (s != "text")` on a
+% string scalar. Lowered as an interned atom-id comparison -- interning is
+% canonical, so two equal strings share an id and `==`/`!=` reduce to an i64
+% icmp of the scalar's atom id against the interned literal. v1 is a single
+% comparison (== / != only; ordering and && / || combinations are follow-ons).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_strguard).
+
+% --- parsing ----------------------------------------------------------------
+
+test(eq_guard_parses) :-
+    plawk_parse_string("{ if (s == \"x\") print $1 }\n",
+        program([], [rule(always,
+            [if(scalar_if(cmp(var(s), eq, string("x"))), [print([field(1)])], [])])], [])),
+    !.
+
+test(ne_guard_parses) :-
+    plawk_parse_string("{ if (s != \"x\") print $1 }\n",
+        program([], [rule(always,
+            [if(scalar_if(cmp(var(s), ne, string("x"))), [print([field(1)])], [])])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% `==` on a string scalar built by concat: fires only on the matching record.
+test(eq_match, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'eq',
+        "{ full = $1 $2; if (full == \"abcd\") print \"match\" }\n",
+        "ab cd\nx y\n", Out, St),
+    assertion(St == 0), assertion(Out == "match\n"), !.
+
+% `!=` filters out the matching value.
+test(ne_filter, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ne',
+        "{ k = $1 \"\" ; if (k != \"skip\") print $1 }\n",
+        "a\nskip\nb\n", Out, St),
+    assertion(St == 0), assertion(Out == "a\nb\n"), !.
+
+% `==` on a single-field string scalar, with an else via a second guard.
+test(eq_selects, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'sel',
+        "{ tag = $1 \"\" ; if (tag == \"err\") print \"E\" }\n",
+        "ok\nerr\nerr\nok\n", Out, St),
+    assertion(St == 0), assertion(Out == "E\nE\n"), !.
+
+% the guard composes with an else branch (plain if/else).
+test(eq_if_else, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ie',
+        "{ tag = $1 \"\" ; if (tag == \"y\") print \"yes\"; else print \"no\" }\n",
+        "y\nn\n", Out, St),
+    assertion(St == 0), assertion(Out == "yes\nno\n"), !.
+
+:- end_tests(plawk_strguard).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_strguard', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
`if (s == "text")` / `if (s != "text")` on a string scalar — follow-on to
string-valued scalars.

## How it works

Lowered as an **interned atom-id comparison**. Interning is canonical, so two
equal strings share an id; `==`/`!=` reduce to an i64 `icmp` of the scalar's
atom id against the interned literal — no `strcmp`, no allocation.

- **Parser** — a `while_cmp` string RHS (`s == "x"`), so an `if` scalar condition
  accepts a string literal. A while-loop string condition stays a clean codegen
  error (there's no string loop bound).
- **Codegen** — a `plawk_if_cond_ir` clause for
  `scalar_if(cmp(var(N), eq|ne, string(V)))` that emits the literal's global,
  interns it, and compares to slot N's current value (its atom id). The literal
  global rides the guard global channel the if-clause already threads, so no new
  plumbing.
- `plawk_while_cond_vars` gives N a slot so the state plan includes it.

## Scope

A single `==` / `!=` comparison. **Follow-ons:** ordering (`<`/`>` on strings,
via `strcmp`), `&&`/`||` combinations of string comparisons, and END-block string
guards.

## Tests

`tests/test_plawk_strguard.pl` (6): parse `==`/`!=`; `==` match; `!=` filter;
`==` selects across records; `if`/`else`. Regressions green: `scalar_if`,
`end_if`, `while`, `loop_control`.

## Docs

`PLAWK_AWK_FEATURE_AUDIT.md` — `if`/`else` → string-equality guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_