### PR TITLE
WAM/LLVM plawk: assignment-context ternary (x = COND ? A : B)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -67,7 +67,7 @@ only (runtime pending) · ❌ missing.
 | `FNR` `FILENAME` `ARGV` `ARGC` `RS` `ORS` `SUBSEP` `RSTART` `RLENGTH` | ❌ | single newline-delimited record model |
 | arithmetic `+ - * / % //` | ✅ | i64, awk precedence, safe div/mod |
 | comparison, `~`/`!~` | ✅ | |
-| ternary `?:` | ◐ | `COND ? A : B` in print / printf args — numeric comparison condition, numeric branches (fields, `NR`/`NF`, int literals, i64 arithmetic); lowered to an LLVM `select`. Assignment-context (scalar-var operands) and string branches are follow-ons |
+| ternary `?:` | ✅ | `COND ? A : B` in print / printf args **and scalar assignment** (`x = $1 > $2 ? $1 : $2`) — numeric comparison condition, numeric branches (fields, `NR`/`NF`, int literals, i64 arithmetic); lowered to an LLVM `select`. Scalar-var operands, string branches, and `&&`/`||` conditions are follow-ons |
 | string concatenation (juxtaposition `$1 $2`) | ✅ | `print` context **and** assignment: `print $1 $2`; `x = $1 $2` / `x = "id:" $1` build a **string-valued scalar** (an interned atom id in an i64 slot, resolved to text on read/print). Arithmetic binds tighter, comma still splits. Scalar-var concat operand (`x = x $1` accumulation) is a follow-on |
 | exponentiation `^` / `**` | ❌ | |
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -11291,6 +11291,14 @@ plawk_scalar_action_update(set(var(Name), concat(Parts)), Name, set_str(concat(P
     maplist(plawk_str_scalar_part_ok, Parts).
 plawk_scalar_action_update(set(var(Name), string(Value)), Name, set_str(string(Value))) :-
     string(Value).
+% Ternary assignment `x = COND ? A : B`: an i64 value via select (the operation
+% lowers through plawk_scalar_numeric_expr_ir(ternary(...)) -> plawk_i64_expr_ir).
+plawk_scalar_action_update(set(var(Name), ternary(cmp(Left, _Op, Right), Then, Else)),
+        Name, set(ternary(cmp(Left, _Op, Right), Then, Else))) :-
+    plawk_ternary_i64_operand_ok(Left),
+    plawk_ternary_i64_operand_ok(Right),
+    plawk_ternary_i64_operand_ok(Then),
+    plawk_ternary_i64_operand_ok(Else).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2001,6 +2001,13 @@ assignment_action(set(var(Name), Value)) -->
     ws,
     scalar_value_expr(Value).
 
+% A ternary assignment `x = COND ? A : B`: numeric comparison condition, numeric
+% branches (the assignment mirror of the print/printf ternary). Tried first --
+% its `?`/`:` structure is unambiguous, and a plain concat / arithmetic RHS has
+% no cmp-then-`?`, so it backtracks cleanly.
+scalar_value_expr(Ternary) -->
+    ternary_expr(Ternary),
+    !.
 % String-valued assignment: a concatenation `x = $1 $2` (juxtaposition, no
 % separator -- the assignment mirror of `print $1 $2`) or a bare string literal
 % `x = "text"`. Both make `x` a string scalar (an interned atom id in an i64

--- a/tests/test_plawk_ternary_assign.pl
+++ b/tests/test_plawk_ternary_assign.pl
@@ -1,0 +1,98 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk ternary in a scalar assignment RHS: `x = COND ? A : B` (the assignment
+% mirror of the print/printf ternary). COND is a numeric comparison and both
+% branches are numeric (fields, NR/NF, int literals, i64 arithmetic); the
+% operation lowers through the shared i64 ternary select. Scalar-var operands
+% and string branches remain follow-ons.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_ternary_assign).
+
+% --- parsing ----------------------------------------------------------------
+
+test(assign_ternary_parses) :-
+    plawk_parse_string("{ x = $1 > $2 ? $1 : $2 }\n",
+        program([], [rule(always,
+            [set(var(x), ternary(cmp(field(1), gt, field(2)), field(1), field(2)))])], [])),
+    !.
+
+% a plain arithmetic assignment is unchanged (no cmp-then-?).
+test(assign_arith_unchanged) :-
+    plawk_parse_string("{ x = $1 + $2 }\n",
+        program([], [rule(always, [set(var(x), add_i64(field(1), field(2)))])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% assign the max to a scalar; END reads the last one.
+test(assign_max, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'mx', "{ big = $1 > $2 ? $1 : $2 }\nEND { print big }\n",
+        "3 7\n9 2\n", Out, St),
+    assertion(St == 0), assertion(Out == "9\n"), !.
+
+% clamp-to-zero, printed each record.
+test(assign_clamp_body, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'cl', "{ c = $1 > 0 ? $1 : 0; print c }\n",
+        "5\n-3\n0\n", Out, St),
+    assertion(St == 0), assertion(Out == "5\n0\n0\n"), !.
+
+% NR in the condition and a branch, read at END.
+test(assign_nr, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nr', "{ last = NR > 1 ? NR : 0 }\nEND { print last }\n",
+        "a\nb\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == "3\n"), !.
+
+% assigned scalar printed directly per record.
+test(assign_body_print, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'bp', "{ m = $1 > $2 ? $1 : $2; print m }\n",
+        "3 7\n8 2\n", Out, St),
+    assertion(St == 0), assertion(Out == "7\n8\n"), !.
+
+% equality condition selecting between two literals.
+test(assign_eq, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'eq', "{ f = $1 == 0 ? 100 : 200; print f }\n",
+        "0\n5\n", Out, St),
+    assertion(St == 0), assertion(Out == "100\n200\n"), !.
+
+:- end_tests(plawk_ternary_assign).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_ternary_assign', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
The ternary now works on the RHS of a scalar assignment, not just in print /
printf arguments: `big = $1 > $2 ? $1 : $2`, `c = $1 > 0 ? $1 : 0`,
`last = NR > 1 ? NR : 0`. Follow-on to the ternary PR.

## How it works

- **Parser** — `scalar_value_expr` accepts a `ternary_expr` first (its `?`/`:`
  structure is unambiguous; a plain concat / arithmetic RHS backtracks cleanly,
  so `x = $1 + $2` and `x = $1 $2` are unchanged).
- **Codegen** — a `plawk_scalar_action_update` clause for
  `set(var(N), ternary(...))` keeps the operation as `set(ternary(...))`; it
  lowers through the **existing** `plawk_scalar_numeric_expr_ir(ternary(...))` →
  `plawk_i64_expr_ir` select, so there's no new lowering. Operands are validated
  as i64 (`plawk_ternary_i64_operand_ok`), reusing the print-ternary machinery.

## Scope

Numeric branches (fields, `NR`/`NF`, int literals, i64 arithmetic), matching the
print ternary. **Follow-ons:** scalar-var operands, string branches, and
`&&`/`||` conditions.

## Tests

`tests/test_plawk_ternary_assign.pl` (7): parse (assign / arithmetic-unchanged);
assign max; clamp-to-zero; `NR` condition; body print; equality. Regressions
green: `surface_arith_exprs`, `strscalar`, `while`, `surface_end_scalar_exprs`,
`ternary`.

## Docs

`PLAWK_AWK_FEATURE_AUDIT.md` — ternary → assignment context landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_