### PR TITLE
WAM/LLVM plawk: sprintf(fmt, ...) into a string scalar

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -55,7 +55,7 @@ only (runtime pending) · ❌ missing.
 |---|---|---|
 | user functions (`function f(a) { return … }`) | ✅ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts **and text mode** — `print f($1)` auto-coerces the field (awk semantics). Optional numeric arg typing (`function f(num x)`) skips the coercion (typed-fast path). |
 | string: `length` `substr` `index` `tolower` `toupper` | ✅ | native, allocation-free |
-| string: `split` `sub` `gsub` `match` `sprintf` | ❌ | |
+| string: `split` `sub` `gsub` `match` `sprintf` | ◐ | **`sprintf` landed** — `x = sprintf("fmt", args)` formats into a string scalar, reusing the printf format engine (same conversions/flags/width/precision) + `snprintf`→intern. Numeric convs need a numeric arg (`$1+0`/`NR`), as printf. `split`/`sub`/`gsub`/`match` still ❌ |
 | numeric: `int` | ✅ | `sin`/`cos`/`sqrt`/`rand`/… ❌ (f64 machinery exists) |
 | Prolog foreign calls (`pred($1)`, `float(pred(…))`) | ✅ | plawk-specific, beyond AWK |
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -6299,6 +6299,10 @@ plawk_action_scalar_update_expr(Action, Expr) :-
 
 plawk_scalar_operation_expr(add(Expr), Expr).
 plawk_scalar_operation_expr(set(Expr), Expr).
+% a string assignment's RHS is exposed too, so NR used inside it (e.g.
+% `x = sprintf("%d", NR)`) is detected and %current_nr defined. Its shape is not
+% double, so the double-type fixpoint ignores it.
+plawk_scalar_operation_expr(set_str(Expr), Expr).
 
 plawk_actions_body_print_field(Actions, Field) :-
     plawk_trim_control_tails(Actions, ReachableActions),
@@ -11320,6 +11324,11 @@ plawk_scalar_action_update(set(var(Name), concat(Parts)), Name, set_str(concat(P
     maplist(plawk_str_scalar_part_ok, Parts).
 plawk_scalar_action_update(set(var(Name), string(Value)), Name, set_str(string(Value))) :-
     string(Value).
+% `x = sprintf("fmt", args)`: format into a string scalar.
+plawk_scalar_action_update(set(var(Name), sprintf(string(Format), Args)), Name,
+        set_str(sprintf(string(Format), Args))) :-
+    string(Format),
+    is_list(Args).
 % Ternary assignment `x = COND ? A : B`: an i64 value via select (the operation
 % lowers through plawk_scalar_numeric_expr_ir(ternary(...)) -> plawk_i64_expr_ir).
 plawk_scalar_action_update(set(var(Name), ternary(cmp(Left, _Op, Right), Then, Else)),
@@ -11877,6 +11886,42 @@ plawk_scalar_update_operation_ir(set(Expr), _Slot, FieldSeparator, Prefix, SlotI
 % A bare literal interns its own global; a concat snprintf's its `%.*s` field
 % slots and literal segments into a 4096-byte stack buffer, then interns the
 % result (the assignment mirror of the print concat).
+% `sprintf("fmt", args...)`: reuse the printf format engine (arg lowering +
+% format rewrite) to snprintf into the buffer, then intern -- the string mirror
+% of the printf action.
+plawk_str_build_ir(sprintf(string(Format), Args), FieldSeparator, Base, IdValueIR,
+        GlobalParts, SetupLines) :-
+    phrase(plawk_printf_arg_pairs(Args, FieldSeparator, Base, 0), ArgPairs),
+    pairs_keys_values(ArgPairs, ArgGlobalParts, ArgInfoPairs),
+    pairs_keys_values(ArgInfoPairs, ArgSetupParts, ArgCallArgLists),
+    append(ArgCallArgLists, CallArgs),
+    maplist(plawk_printf_call_arg_kind, CallArgs, ArgKinds),
+    plawk_printf_rewrite_format(Format, ArgKinds, PrintfFormat),
+    format(atom(FmtName), '~w_fmt', [Base]),
+    llvm_emit_c_string_global(FmtName, PrintfFormat, FmtGlobal, _FmtLen, FmtBytes),
+    plawk_printf_call_args_ir(CallArgs, CallArgsIR),
+    format(atom(FmtP),
+        '  %~w_fmtp = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0',
+        [Base, FmtBytes, FmtBytes, FmtName]),
+    format(atom(BufA), '  %~w_buf = alloca [4096 x i8]', [Base]),
+    format(atom(BufP),
+        '  %~w_bufp = getelementptr [4096 x i8], [4096 x i8]* %~w_buf, i64 0, i64 0',
+        [Base, Base]),
+    ( CallArgsIR == ''
+    -> format(atom(Snp),
+           '  %~w_wrote = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %~w_bufp, i64 4096, i8* %~w_fmtp)',
+           [Base, Base, Base])
+    ;  format(atom(Snp),
+           '  %~w_wrote = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %~w_bufp, i64 4096, i8* %~w_fmtp, ~w)',
+           [Base, Base, Base, CallArgsIR])
+    ),
+    format(atom(LenL), '  %~w_len = call i64 @strlen(i8* %~w_bufp)', [Base, Base]),
+    format(atom(IdL),
+        '  %~w_id = call i64 @wam_intern_atom(i8* %~w_bufp, i64 %~w_len)',
+        [Base, Base, Base]),
+    format(atom(IdValueIR), '%~w_id', [Base]),
+    GlobalParts = [FmtGlobal | ArgGlobalParts],
+    append(ArgSetupParts, [FmtP, BufA, BufP, Snp, LenL, IdL], SetupLines).
 plawk_str_build_ir(string(Value), _FieldSeparator, Base, IdValueIR,
         [GlobalIR], [PtrLine, IdLine]) :-
     format(atom(StrName), '~w_lit', [Base]),
@@ -13552,6 +13597,9 @@ plawk_expr_uses_nr(ternary(cmp(Left, _Op, Right), Then, Else)) :-
     ; plawk_expr_uses_nr(Then)
     ; plawk_expr_uses_nr(Else)
     ).
+plawk_expr_uses_nr(sprintf(_Format, Args)) :-
+    member(Arg, Args),
+    plawk_expr_uses_nr(Arg).
 plawk_expr_uses_nr(Expr) :-
     plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
     ( plawk_expr_uses_nr(Left)

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2008,6 +2008,12 @@ assignment_action(set(var(Name), Value)) -->
     ws,
     scalar_value_expr(Value).
 
+% `x = sprintf("fmt", args...)`: format into a string scalar (the printf format
+% engine + string-valued scalars). Tried first -- the `sprintf(` keyword is
+% unambiguous.
+scalar_value_expr(Sprintf) -->
+    sprintf_expr(Sprintf),
+    !.
 % A ternary assignment `x = COND ? A : B`: numeric comparison condition, numeric
 % branches (the assignment mirror of the print/printf ternary). Tried first --
 % its `?`/`:` structure is unambiguous, and a plain concat / arithmetic RHS has
@@ -2149,6 +2155,23 @@ printf_action(printf(string(Format), Args)) -->
     required_ws,
     quoted_string(FormatCodes),
     printf_args(Args),
+    { string_codes(Format, FormatCodes) }.
+
+%% sprintf_expr(-Expr)//
+%
+%  `sprintf("fmt", args...)` -- the same format + args as `printf`, but the
+%  result is a string (built into a buffer and interned) rather than printed.
+%  Used as a scalar assignment RHS (`x = sprintf(...)`). The format is a string
+%  literal; the args are the printf argument list (a leading comma before each).
+sprintf_expr(sprintf(string(Format), Args)) -->
+    "sprintf",
+    ws,
+    "(",
+    ws,
+    quoted_string(FormatCodes),
+    printf_args(Args),
+    ws,
+    ")",
     { string_codes(Format, FormatCodes) }.
 
 %% foreach_action(-Action)//

--- a/tests/test_plawk_sprintf.pl
+++ b/tests/test_plawk_sprintf.pl
@@ -1,0 +1,106 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `sprintf("fmt", args...)` -- format into a string scalar. Composes the
+% printf format engine (same %[flags][width][.precision]conv coverage, same
+% argument kinds) with string-valued scalars: the args + rewritten format are
+% snprintf'd into a buffer and the result is interned into a string scalar
+% (`x = sprintf(...)`), resolved to text on read/print. Numeric conversions
+% need a numeric arg (`$1 + 0` / `NR`), exactly as `printf` does.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_sprintf).
+
+% --- parsing ----------------------------------------------------------------
+
+test(sprintf_parses) :-
+    plawk_parse_string("{ x = sprintf(\"%05d\", $1) }\n",
+        program([], [rule(always,
+            [set(var(x), sprintf(string("%05d"), [field(1)]))])], [])),
+    !.
+
+test(sprintf_no_args_parses) :-
+    plawk_parse_string("{ x = sprintf(\"hi\") }\n",
+        program([], [rule(always, [set(var(x), sprintf(string("hi"), []))])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% zero-padded integer (numeric arg via + 0), read at END.
+test(zero_pad_int, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'zp', "{ x = sprintf(\"%05d\", $1 + 0) }\nEND { print x }\n",
+        "42\n7\n", Out, St),
+    assertion(St == 0), assertion(Out == "00007\n"), !.
+
+% string conversion of a field.
+test(string_conv, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'sc', "{ x = sprintf(\"[%s]\", $1) }\nEND { print x }\n",
+        "hi\n", Out, St),
+    assertion(St == 0), assertion(Out == "[hi]\n"), !.
+
+% hex conversion with width + flags.
+test(hex_conv, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'hx', "{ x = sprintf(\"0x%04x\", $1 + 0) }\nEND { print x }\n",
+        "255\n", Out, St),
+    assertion(St == 0), assertion(Out == "0x00ff\n"), !.
+
+% mixed %s and %d (field slice + NR); printed per record.
+test(mixed_conversions, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'mx', "{ x = sprintf(\"%s=%d\", $1, NR); print x }\n",
+        "a\nb\n", Out, St),
+    assertion(St == 0), assertion(Out == "a=1\nb=2\n"), !.
+
+% a literal-only format (no args).
+test(literal_only, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'li', "{ x = sprintf(\"tag\") }\nEND { print x }\n",
+        "z\n", Out, St),
+    assertion(St == 0), assertion(Out == "tag\n"), !.
+
+% the built string can be equality-guarded (composes with string guards).
+test(sprintf_then_guard, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'sg',
+        "{ k = sprintf(\"n%d\", NR); if (k == \"n2\") print $1 }\n",
+        "a\nb\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == "b\n"), !.
+
+:- end_tests(plawk_sprintf).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_sprintf', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
`x = sprintf("fmt", args)` formats into a string scalar — the direct
composition of the two features just shipped: the **printf format engine** and
**string-valued scalars**. `x = sprintf("%05d", $1+0)`, `x = sprintf("%s=%d", $1, NR)`.

## How it works

- **Parser** — `sprintf_expr` (`sprintf("fmt", printf-args)`) as a scalar
  assignment RHS, tried first (the `sprintf(` keyword is unambiguous).
- **Codegen** — a `set_str(sprintf(...))` operation whose `plawk_str_build_ir`
  clause **reuses the printf machinery** — `plawk_printf_arg_pairs` for arg
  lowering, `plawk_printf_rewrite_format` for the format — then `snprintf`s into
  the same 4096-byte stack buffer the string-concat build uses, `strlen` +
  interns, and the atom id becomes the string scalar's value. Same conversion
  coverage as printf (flags/width/precision, `%d`/`%s`/`%x`/`%c`/`%f`-family); a
  numeric conversion needs a numeric arg (`$1+0`/`NR`), exactly as printf.
- NR inside a sprintf arg is detected (`plawk_expr_uses_nr(sprintf)` + `set_str`'s
  RHS exposed via `plawk_scalar_operation_expr`), so `%current_nr` is defined.

Because the result is a string scalar, it composes with everything from the
string-scalar work — including string-equality guards
(`k = sprintf("n%d", NR); if (k == "n2") …`, a test in this PR).

## Scope

sprintf as an assignment RHS. **Follow-ons:** sprintf as a concat operand / a
print field, and scalar-var args.

## Tests

`tests/test_plawk_sprintf.pl` (8): parse; zero-pad int; `%s`; hex+width; mixed
`%s`/`%d` with `NR`; literal-only; and sprintf-then-string-guard. Regressions
green: `strscalar`, `printf`, `surface_arith_exprs`, `surface_end_scalar_exprs`.

## Docs

`PLAWK_AWK_FEATURE_AUDIT.md` — string builtins → `sprintf` landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_