### PR TITLE
FS-FUNCTIONS-BUILTINS-LOWER: last-slash parse_functor_fs unblocks functions/builtins

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -24,10 +24,10 @@ self-contained so a single coding agent can pick it up in isolation.
 
 | ID | Lever | Target | Size | Depends on |
 |---|---|---|---|---|
-| CONF-FSHARP ✅ | Conformance adapter | F# | M | done — opt-in; classic programs green on interpreter; functions/builtins still skipped |
+| CONF-FSHARP ✅ | Conformance adapter | F# | M | done — opt-in; classic programs green on interpreter + functions |
 | FS-LIST-PARTIAL-TAIL ✅ | Conformance gap fix | F# | M | done — GetValue→unifyVal (`cursor/fs-list-partial-tail-f421`); append/reverse green on fsharp + fsharp_functions |
 | FS-ARITH-INT-DIV | Conformance gap fix | F# | S | CONF-FSHARP |
-| FS-FUNCTIONS-BUILTINS-LOWER | Conformance gap fix | F# | M | CONF-FSHARP |
+| FS-FUNCTIONS-BUILTINS-LOWER ✅ | Conformance gap fix | F# | M | done — last-slash `parse_functor_fs` for `///2` (`cursor/fs-functions-builtins-lower-f421`); fsharp_functions/builtins green |
 | CONF-LLVM | Conformance adapter | LLVM | L | — |
 | CONF-R | Conformance adapter | R | M | — |
 | CONF-CLOJURE | Conformance adapter | Clojure | L | — |
@@ -89,7 +89,7 @@ external toolchain.
 
 ### CONF-FSHARP: Register F# in the cross-target conformance harness
 - **Lever:** Conformance adapters  **Target:** F#  **Size:** M  **Depends on:** —
-- **Status:** ✅ **Landed** on `cursor/conf-fsharp-f421` (2026-07-15). Opt-in `conformance_target(fsharp)` + `fsharp_functions` (`emit_mode(interpreter|functions)`). Added additive `conformance_main(true)` Program.fs driver (`tryRun` → `true`/`false`) without changing the default TSV/LMDB benchmark entrypoint. `dotnet build` gate; `dotnet run --no-build -- <key>` (avoid `--nologo` on the run line — some SDKs forward it as argv[0]). **Measured (updated):** member/fib/ack/builtins/append/reverse green on interpreter; append/reverse also green on `fsharp_functions` after FS-LIST-PARTIAL-TAIL. Remaining: `ct_skip` `fsharp_functions`/builtins (FS-FUNCTIONS-BUILTINS-LOWER).
+- **Status:** ✅ **Landed** on `cursor/conf-fsharp-f421` (2026-07-15). Opt-in `conformance_target(fsharp)` + `fsharp_functions` (`emit_mode(interpreter|functions)`). Added additive `conformance_main(true)` Program.fs driver (`tryRun` → `true`/`false`) without changing the default TSV/LMDB benchmark entrypoint. `dotnet build` gate; `dotnet run --no-build -- <key>` (avoid `--nologo` on the run line — some SDKs forward it as argv[0]). **Measured (updated):** all classic programs green on interpreter; append/reverse + builtins also green on `fsharp_functions` after FS-LIST-PARTIAL-TAIL + FS-FUNCTIONS-BUILTINS-LOWER. No remaining fsharp ct_xfail/ct_skip.
 - **Goal:** Add an F# adapter (`conformance_target(fsharp)` + `ct_toolchain`/`ct_build`/`ct_run`/`ct_teardown`) so the shared WAM spec runs against the F# backend.
 - **Acceptance:** `CONFORMANCE_TARGETS=fsharp[,fsharp_functions] swipl -g run_tests tests/test_wam_cross_target_conformance.pl` runs the adapter (skips cleanly if `dotnet` absent); xfails/skips match measured gaps.
 
@@ -105,11 +105,11 @@ external toolchain.
 - **Root cause (measured):** `WamTypes.evalArith` handles `+,-,*,/,mod` but not `Str ("//", [a;b])`; the compiler emits `PutStructure ("//", 2, …)` for integer div, so `is_lax` binds nothing and the wrapper fails. (`mod` already works.)
 - **Acceptance:** Drop `ct_xfail(fsharp, builtins)`; builtins suite green under `CONFORMANCE_TARGETS=fsharp`.
 
-### FS-FUNCTIONS-BUILTINS-LOWER: `emit_mode(functions)` stalls on `cbi_eq`
+### FS-FUNCTIONS-BUILTINS-LOWER: `emit_mode(functions)` stalls on builtins
 - **Lever:** Conformance gap fix  **Target:** F#  **Size:** M  **Depends on:** CONF-FSHARP
-- **Goal:** Lowering `cbi_eq` (and friends) completes without hanging; builtins measurable under `fsharp_functions`.
-- **Root cause (measured):** `write_wam_fsharp_project` with `emit_mode(functions)` on the builtins program emits repeated “instruction not supported → Proceed stub” for `=/2` / `put_constant foo` and does not finish `Lowered.fs` / `Program.fs` within a minute-plus — harness uses `ct_skip(fsharp_functions, builtins)`.
-- **Acceptance:** Remove the skip; builtins either lowers cleanly or declines to interpreter without stalling; suite completes under `CONFORMANCE_TARGETS=fsharp_functions`.
+- **Status:** ✅ **Landed** on `cursor/fs-functions-builtins-lower-f421` (2026-07-15). Banner blamed `cbi_eq`/`=/2` Proceed stubs; the real stall was `parse_functor_fs` soft-cutting on the first `/` so `put_structure ///2` (integer-div in `cbi_arith`) failed mid-emit and `lower_all_fs` never finished. Fix: last-slash split (Scala/R/Lua shape) in `wam_fsharp_lowered_emitter.pl`. `=/2` already delegated to `step` via `emit_one_fs(builtin_call)`. **Measured:** `fsharp_functions`/builtins builds and runs green; `ct_skip` retired; interpreter builtins unchanged.
+- **Goal:** Lowering builtins completes without hanging; suite green under `fsharp_functions`.
+- **Acceptance:** Remove the skip; builtins lowers cleanly; suite completes under `CONFORMANCE_TARGETS=fsharp_functions`.
 
 ### CONF-LLVM: Register LLVM in the cross-target conformance harness
 - **Lever:** Conformance adapters  **Target:** LLVM  **Size:** L  **Depends on:** —

--- a/docs/WAM_FSHARP_STATUS.md
+++ b/docs/WAM_FSHARP_STATUS.md
@@ -81,12 +81,12 @@ classic `wam_conformance_smoke` matrix with Scala/Elixir.
 - Bidirectional off by default; enable after cost-model confidence.
 - Classic conformance (**CONF-FSHARP**, 2026-07-15): registered
   opt-in (`fsharp` / `fsharp_functions`) with additive
-  `conformance_main(true)`. **Measured maturity:** member, fib, ack,
-  builtins, append, reverse green on interpreter; append/reverse also
-  green under `emit_mode(functions)` after **FS-LIST-PARTIAL-TAIL**
-  (GetValue→unifyVal; builder was already correct). Remaining:
-  `fsharp_functions`+builtins skipped (FS-FUNCTIONS-BUILTINS-LOWER —
-  lowered emitter stalls on `cbi_eq`).
+  `conformance_main(true)`. **Measured maturity:** all classic
+  programs green on interpreter; append/reverse green under
+  `emit_mode(functions)` after **FS-LIST-PARTIAL-TAIL**
+  (GetValue→unifyVal); builtins also green under functions after
+  **FS-FUNCTIONS-BUILTINS-LOWER** (last-slash `parse_functor_fs` for
+  `///2`). No remaining fsharp ct_xfail/ct_skip.
 - Dynamic database partial (facts via lowered mutation; prefer Python
   for full dynamic-DB semantics — target doc).
 - LMDB scan-mode / workload-segregation wait on Rust R9/R10 reference.
@@ -100,8 +100,7 @@ classic `wam_conformance_smoke` matrix with Scala/Elixir.
 
 ## Path forward
 
-1. Close remaining CONF-FSHARP follow-up:
-   FS-FUNCTIONS-BUILTINS-LOWER (FS-LIST-PARTIAL-TAIL done).
+1. CONF-FSHARP follow-ups closed (list + arith + functions/builtins).
 2. Elixir-style cost-gate calibration for TPL fanout.
 3. Follow Rust scan/segregation LMDB contract when available.
 4. Keep ISO table in sync with C++/Elixir/Python.

--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -1595,15 +1595,30 @@ reg_to_int_fs(Reg, Int) :-
     ).
 
 %% parse_functor_fs(+FnStr, -Name, -Arity)
+%  Split "name/N" on the *last* "/". Functors that contain "/" themselves
+%  — integer-div "//" (WAM text `///2`) and float-div "/" (`//2`) — must
+%  not soft-cut on the first slash: the previous `(sub_atom(...'/') -> …)`
+%  committed to Before=0, then `atom_number('//2', _)` failed and the
+%  whole parse failed. That made emit_one_fs(put_structure("///2",…))
+%  fail mid-body for cbi_arith under emit_mode(functions), so
+%  lower_all_fs never finished (FS-FUNCTIONS-BUILTINS-LOWER). Mirrors
+%  Scala/R/Lua last_slash_index / parse_functor_arity.
 parse_functor_fs(FnStr, Name, Arity) :-
     atom_string(FA, FnStr),
-    (   sub_atom(FA, B, 1, _, '/')
+    (   last_slash_index_fs(FA, B)
     ->  sub_atom(FA, 0, B, _, Name),
         B1 is B + 1,
         sub_atom(FA, B1, _, 0, AS),
         atom_number(AS, Arity)
     ;   Name = FA, Arity = 0
     ).
+
+%% last_slash_index_fs(+Atom, -Index)
+%  Index of the last "/" in Atom, or fails if none.
+last_slash_index_fs(Atom, Index) :-
+    findall(B, sub_atom(Atom, B, 1, _, '/'), Bs),
+    Bs \= [],
+    last(Bs, Index).
 
 %% escape_dq_fs(+Str, -Escaped)
 %  Escape backslashes and double quotes for F# string literals.

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -292,11 +292,14 @@ ct_default_target(elixir).
 %     FS-LIST-PARTIAL-TAIL (2026-07-15): GetValue routes through
 %     unifyVal/unifyTerms so ground Str("[|]",…) result spines unify with
 %     compact VList. Builder was already correct; open-tail
-%     `capp([a],[b],X),X=[a,b]` already passed via =/2. No remaining
-%     fsharp/fsharp_functions ct_xfail for append/reverse.
-%   - fsharp_functions + builtins: lowered emitter loops/stalls on cbi_eq
-%     (unsupported-instruction Proceed stubs for =/2); skip generation.
-ct_skip(fsharp_functions, builtins). % FS-FUNCTIONS-BUILTINS-LOWER — codegen stalls
+%     `capp([a],[b],X),X=[a,b]` already passed via =/2.
+%   - fsharp_functions + builtins: FIXED FS-FUNCTIONS-BUILTINS-LOWER
+%     (2026-07-15). Stall was not cbi_eq/=/2 — parse_functor_fs soft-cut
+%     on the first "/" so put_structure `///2` (integer-div) failed mid
+%     emit of cbi_arith and lower_all_fs never finished. Last-slash parse
+%     (Scala/R/Lua shape) unblocks all three builtins lowers; =/2 already
+%     delegated to step via emit_one_fs(builtin_call). No remaining
+%     fsharp / fsharp_functions ct_xfail or ct_skip.
 
 % ============================================================
 % Toolchain probes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Retires `ct_skip(fsharp_functions, builtins)` so F# is fully conformant in **both** emit modes.

### Root cause (pinned — not `cbi_eq` / `=/2`)
Banner blamed Proceed stubs for `=/2`. Actual stall:

- `cbi_arith` WAM emits `put_structure ///2, A2` (functor `//`, arity 2).
- `parse_functor_fs` used `(sub_atom(... '/') -> …)`, soft-cutting on the **first** slash → empty name + `atom_number('//2')` fails.
- `emit_one_fs(put_structure("///2", …))` failed mid-body → `lower_all_fs` never finished `Lowered.fs`.
- `=/2` already lowered correctly via `emit_one_fs(builtin_call)` → `step`.

### Fix
Last-slash split in `wam_fsharp_lowered_emitter.pl` (`last_slash_index_fs`), matching Scala/R/Lua. Emits `BuildStruct ("//", 2, 2, [])`. No `step`/interpreter changes.

### Measured
| | Before | After |
|---|---|---|
| `fsharp_functions`/builtins codegen | stall / `ct_skip` | builds + runs green |
| `CONFORMANCE_TARGETS=fsharp,fsharp_functions` | skip line | exit 0, no skip/xfail |

Interpreter builtins unchanged; member/fib/ack/append/reverse still green under functions.

### Verify
```bash
LANG=C.UTF-8 CONFORMANCE_TARGETS=fsharp,fsharp_functions \
  swipl -q -g run_tests -t halt tests/test_wam_cross_target_conformance.pl
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

