### PR TITLE
WAM/LLVM plawk: range patterns /start/,/end/

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -23,7 +23,7 @@ only (runtime pending) · ❌ missing.
 | `&& \|\| !` combinators | ✅ | awk precedence, parens, single-block lowering |
 | `~` / `!~` match | ✅ | POSIX ERE |
 | expression pattern (bare `NR==1`) | ◐ | comparison guards yes; arbitrary expr no |
-| range pattern (`/a/,/b/`) | ❌ | |
+| range pattern (`/a/,/b/`) | ◐ | `/start/,/end/ { … }` fires for records from a /start/ match through a /end/ match (inclusive), via a per-rule i1 latch global; re-arms for later ranges, runs to EOF if unterminated. Regex endpoints (v1); general-pattern endpoints (`NR==1,NR==3`) are a follow-on |
 
 ## Actions & control flow
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -13342,6 +13342,42 @@ plawk_pattern_guard_ir(not_pat(Pattern), FieldSeparator, GlobalBase, MatchValue,
 '~w
   ~w = xor i1 ~w, true',
         [InnerCallIR, MatchValue, InnerValue]).
+% A range pattern `/start/,/end/`: the rule fires for records from a /start/
+% match through a /end/ match (inclusive), tracked by a per-rule i1 flag global
+% (init false = inactive). Latch, per record:
+%   fire        = was_active OR start_matches
+%   next_active = was_active ? NOT end_matches : start_matches
+% i.e. the end is only tested once already active (so a line matching both start
+% and end starts a range that continues -- the common gawk semantics). MatchValue
+% is the fire result; the two endpoints reuse the ordinary pattern guards.
+plawk_pattern_guard_ir(range(Start, End), FieldSeparator, GlobalBase, MatchValue,
+        GlobalIR-GuardCallIR) :-
+    format(atom(StartBase), '~w_rs', [GlobalBase]),
+    format(atom(StartValue), '~w_rs', [MatchValue]),
+    plawk_pattern_guard_ir(Start, FieldSeparator, StartBase, StartValue,
+        StartGlobalIR-StartCallIR),
+    format(atom(EndBase), '~w_re', [GlobalBase]),
+    format(atom(EndValue), '~w_re', [MatchValue]),
+    plawk_pattern_guard_ir(End, FieldSeparator, EndBase, EndValue,
+        EndGlobalIR-EndCallIR),
+    format(atom(FlagName), '~w_range', [GlobalBase]),
+    format(atom(FlagGlobal), '@~w = internal global i1 false', [FlagName]),
+    plawk_join_nonempty_ir([StartGlobalIR, EndGlobalIR, FlagGlobal], GlobalIR),
+    format(atom(GuardCallIR),
+'  %~w_was = load i1, i1* @~w
+~w
+~w
+  %~w_notend = xor i1 ~w, true
+  %~w_next = select i1 %~w_was, i1 %~w_notend, i1 ~w
+  store i1 %~w_next, i1* @~w
+  ~w = or i1 %~w_was, ~w',
+        [GlobalBase, FlagName,
+         StartCallIR,
+         EndCallIR,
+         GlobalBase, EndValue,
+         GlobalBase, GlobalBase, GlobalBase, StartValue,
+         GlobalBase, FlagName,
+         MatchValue, GlobalBase, StartValue]).
 
 plawk_combined_pattern(and_pat(_Left, _Right)).
 plawk_combined_pattern(or_pat(_Left, _Right)).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -671,6 +671,20 @@ rules_rest([Rule | Rules]) -->
 rules_rest([]) -->
     ws.
 
+% A range pattern `/start/,/end/ { ... }`: the rule fires for every record from
+% the one matching /start/ through the one matching /end/ (inclusive), tracked
+% by a per-rule latch. Endpoints are regexes (v1). Tried before the general rule
+% so the comma between the two regexes is seen (a plain `/re/ { }` has no comma,
+% so this clause fails before its cut and falls through).
+rule(rule(range(Start, End), Actions)) -->
+    slash_regex_pattern(Start),
+    ws,
+    ",",
+    ws,
+    slash_regex_pattern(End),
+    !,
+    ws,
+    action_block(Actions).
 rule(rule(Pattern, Actions)) -->
     pattern(Pattern),
     !,

--- a/tests/test_plawk_range.pl
+++ b/tests/test_plawk_range.pl
@@ -1,0 +1,113 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk range patterns `/start/,/end/ { ... }`: the rule fires for every record
+% from a /start/ match through a /end/ match (inclusive), tracked by a per-rule
+% i1 latch global. The end is tested only once the range is active, so a line
+% matching both start and end starts a range that continues (the common gawk
+% semantics). v1 endpoints are regexes; general-pattern endpoints (NR==1,NR==3)
+% are a follow-on.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_range).
+
+% --- parsing ----------------------------------------------------------------
+
+test(range_parses) :-
+    plawk_parse_string("/start/,/end/ { print $0 }\n",
+        program([], [rule(range(contains("start"), contains("end")),
+            [print([field(0)])])], [])),
+    !.
+
+test(range_prefix_endpoints_parse) :-
+    plawk_parse_string("/^BEGIN/,/^END/ { print $1 }\n",
+        program([], [rule(range(prefix("BEGIN"), prefix("END")),
+            [print([field(1)])])], [])),
+    !.
+
+% a plain single regex rule is unaffected (no comma -> not a range).
+test(plain_regex_unaffected) :-
+    plawk_parse_string("/a/ { print $1 }\n",
+        program([], [rule(contains("a"), [print([field(1)])])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% the section between markers is printed inclusive; outside is skipped.
+test(range_inclusive, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'inc', "/start/,/end/ { print $0 }\n",
+        "a\nstart\nb\nc\nend\nd\n", Out, St),
+    assertion(St == 0), assertion(Out == "start\nb\nc\nend\n"), !.
+
+% two separate ranges in one stream both fire (the latch re-arms).
+test(range_reentry, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 're', "/S/,/E/ { print $0 }\n",
+        "x\nS\n1\nE\ny\nS\n2\nE\nz\n", Out, St),
+    assertion(St == 0), assertion(Out == "S\n1\nE\nS\n2\nE\n"), !.
+
+% a start with no matching end prints to EOF.
+test(range_unterminated, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'un', "/S/,/E/ { print $0 }\n",
+        "a\nS\nb\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == "S\nb\nc\n"), !.
+
+% fields are accessible inside a range body.
+test(range_field_access, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'fl', "/S/,/E/ { print $2 }\n",
+        "S k1\nrow v1\nrow v2\nE k2\n", Out, St),
+    assertion(St == 0), assertion(Out == "k1\nv1\nv2\nk2\n"), !.
+
+% a range rule coexists with an ordinary rule + END.
+test(range_coexists, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'co',
+        "/S/,/E/ { print \"in:\", $0 }\n{ n++ }\nEND { print \"total\", n }\n",
+        "a\nS\nb\nE\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == "in: S\nin: b\nin: E\ntotal 5\n"), !.
+
+% a record matching neither marker never fires the range.
+test(range_no_match, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nm', "/S/,/E/ { print $0 }\n",
+        "a\nb\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == ""), !.
+
+:- end_tests(plawk_range).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_range', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
A range pattern `/start/,/end/ { ... }` fires for every record from a `/start/`
match through a `/end/` match (inclusive) — the classic AWK section-extraction
idiom (audit gap: range pattern).

## How it works

- **Parser** — a range rule clause (`slash_regex_pattern , slash_regex_pattern`)
  tried *before* the general rule, so the comma between the two regexes is seen;
  a plain `/re/ { }` has no comma and falls through cleanly. Parses to
  `range(StartPat, EndPat)`.
- **Codegen** — a `plawk_pattern_guard_ir(range(...))` clause with a per-rule
  **i1 flag global** (init `false`). Latch, per record:
  - `fire = was_active OR start_matches`
  - `next_active = was_active ? NOT end_matches : start_matches`

  The end is tested only once already active, so a line matching both markers
  starts a range that continues — the common gawk semantics. `MatchValue` is the
  fire result; the two endpoints reuse the ordinary regex pattern guards, so
  there's no new matching code.

The latch **re-arms** for later ranges in the same stream, an **unterminated**
range runs to EOF, and range rules **coexist** with ordinary rules / `END`.

## Scope

Regex endpoints. **Follow-on:** general-pattern endpoints (`NR==1,NR==3`).

## Tests

`tests/test_plawk_range.pl` (9): parse (regex + prefix endpoints; plain regex
unaffected); inclusive section; re-entry (two ranges); unterminated-to-EOF;
field access inside the range; coexists with an ordinary rule + `END`; no-match.
Regressions green: `surface_regex_match`, `surface_pattern_combinators`,
`print_literals`, `surface_prefix_print`.

## Docs

`PLAWK_AWK_FEATURE_AUDIT.md` — range pattern → landed (regex endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_