### PR TITLE
WAM/LLVM plawk: string ordering guards (if s < "text")

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -32,7 +32,7 @@ only (runtime pending) · ❌ missing.
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic, **concatenation**) | ✅ | constant fields (`print 1`, `print "x"`) + juxtaposition concat (`print $1 $2`) landed |
 | `printf` | ✅ | standard `%[flags][width][.precision][length]conv`: integers `d`/`i`/`x`/`X`/`o`/`u` + `c` (code point), floats `f`/`g`/`e`/`F`/`G`/`E`, strings `%s`; flags `-+ 0#`, width, precision. Field-slice `%s` takes width but not precision (non-terminated buffer); `%c` needs a numeric arg |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
-| `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`), scalar-variable conditions (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`**, **and string-equality guards on a string scalar** (`if (s == "text")` / `!=`, lowered as interned atom-id comparison — single `==`/`!=`, not combined with `&&`/`||`) |
+| `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`), scalar-variable conditions (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`**, **and string guards on a string scalar** (`if (s == "text")` — `==`/`!=` via interned atom-id compare, `<`/`<=`/`>`/`>=` via `strcmp` — a single comparison, not combined with `&&`/`||`) |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END) |
 | `while (COND)` | ✅ | runtime landed (loop-header phis); condition is scalar comparisons (`VAR CMP int`/`VAR`) combined with `&&`/`||` — `PLAWK_CONTROL_FLOW_PLAN.md` PR 2–3. `break`/`continue` deferred (PR 3b) |
 | `do { } while (COND)` | ✅ | runtime landed; body runs at least once; same general condition |

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5032,6 +5032,35 @@ plawk_if_cond_ir(scalar_if(cmp(var(Name), Op, string(Value))), Slots, Values0,
         [GlobalBase, BytesLen, BytesLen, LitName,
          GlobalBase, GlobalBase, Len,
          GlobalBase, Pred, SlotValue, GlobalBase]).
+% String-ordering guard `if (s < "text")` / `<=` / `>` / `>=` on a string scalar:
+% atom ids are not ordered by string value, so resolve the scalar's id to text
+% and `strcmp` against the literal, then compare the result to 0. An unset scalar
+% (id 0) resolves to empty via the literal global's trailing NUL.
+plawk_if_cond_ir(scalar_if(cmp(var(Name), Op, string(Value))), Slots, Values0,
+        _FieldSeparator, GlobalBase, CondValue, GlobalIR-IR) :-
+    memberchk(Op, [lt, le, gt, ge]),
+    !,
+    nth0(Idx, Slots, Slot),
+    plawk_slot_name(Slot, Name),
+    !,
+    nth0(Idx, Values0, SlotValue),
+    format(atom(LitName), '~w_lit', [GlobalBase]),
+    llvm_emit_c_string_global(LitName, Value, GlobalIR, Len, BytesLen),
+    plawk_icmp_pred(Op, Pred),
+    format(atom(CondValue), '%~w_cond', [GlobalBase]),
+    format(atom(IR),
+'  %~w_litptr = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0
+  %~w_sraw = call i8* @wam_atom_to_string(i64 ~w)
+  %~w_empty = icmp eq i64 ~w, 0
+  %~w_sptr = select i1 %~w_empty, i8* getelementptr ([~w x i8], [~w x i8]* @.~w, i64 0, i64 ~w), i8* %~w_sraw
+  %~w_scmp = call i32 @strcmp(i8* %~w_sptr, i8* %~w_litptr)
+  %~w_cond = icmp ~w i32 %~w_scmp, 0',
+        [GlobalBase, BytesLen, BytesLen, LitName,
+         GlobalBase, SlotValue,
+         GlobalBase, SlotValue,
+         GlobalBase, GlobalBase, BytesLen, BytesLen, LitName, Len, GlobalBase,
+         GlobalBase, GlobalBase, GlobalBase,
+         GlobalBase, Pred, GlobalBase]).
 plawk_if_cond_ir(scalar_if(Cond), Slots, Values0, _FieldSeparator, GlobalBase,
         CondValue, ''-GuardIR) :-
     !,

--- a/tests/test_plawk_strguard.pl
+++ b/tests/test_plawk_strguard.pl
@@ -63,6 +63,30 @@ test(eq_if_else, [condition(clang_available)]) :-
         "y\nn\n", Out, St),
     assertion(St == 0), assertion(Out == "yes\nno\n"), !.
 
+% --- ordering (< <= > >=, via strcmp) ---------------------------------------
+
+% `<`: select values that sort before a literal.
+test(lt_orders_lexically, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'lt', "{ k = $1 \"\" ; if (k < \"m\") print $1 }\n",
+        "apple\nzebra\nmango\nbanana\n", Out, St),
+    assertion(St == 0), assertion(Out == "apple\nbanana\n"), !.
+
+% `>=`: the complement.
+test(ge_orders_lexically, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ge', "{ k = $1 \"\" ; if (k >= \"m\") print $1 }\n",
+        "apple\nzebra\nmango\nbanana\n", Out, St),
+    assertion(St == 0), assertion(Out == "zebra\nmango\n"), !.
+
+% `>` on a sprintf-built zero-padded key (composes with sprintf).
+test(gt_on_built_key, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'gt',
+        "{ tag = sprintf(\"%03d\", $1 + 0); if (tag > \"005\") print $1 }\n",
+        "3\n9\n1\n7\n", Out, St),
+    assertion(St == 0), assertion(Out == "9\n7\n"), !.
+
 :- end_tests(plawk_strguard).
 
 % --- helpers ---------------------------------------------------------------


### PR DESCRIPTION
Extends string-scalar guards from `==`/`!=` to the ordering operators
`<`/`<=`/`>`/`>=` — the completion of the string-comparison story started with
the equality guards.

## How it works

Atom ids aren't ordered by string value, so (unlike `==`/`!=`, which compare
ids) the scalar's id is resolved to text and `strcmp`'d against the interned
literal, then the result compared to `0` with the op's signed predicate. An
unset scalar (id 0) resolves to empty via the literal global's trailing NUL.

**Codegen-only:** the parser already accepted a string RHS on a `while_cmp` and
`numeric_cmp_op` already covers all six ops, so `if (s < "text")` *parsed* before
this — it only needed the lowering. A single comparison (not combined with
`&&`/`||`), matching the equality guards.

It composes with the rest of the string machinery — e.g. ordering a
`sprintf`-built zero-padded key (`tag = sprintf("%03d", $1+0); if (tag > "005") …`,
a test here).

## Tests

`tests/test_plawk_strguard.pl` +3: `<`/`>=` lexical ordering; `>` on a
sprintf-built key. Regressions green: `strguard`, `scalar_if`, `end_if`,
`sprintf`.

## Docs

`PLAWK_AWK_FEATURE_AUDIT.md` — `if`/`else` string guards → ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_