### PR TITLE
CONF-R: opt-in hybrid WAM R conformance adapter

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -29,7 +29,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | FS-ARITH-INT-DIV | Conformance gap fix | F# | S | CONF-FSHARP |
 | FS-FUNCTIONS-BUILTINS-LOWER ✅ | Conformance gap fix | F# | M | done — last-slash `parse_functor_fs` for `///2` (`cursor/fs-functions-builtins-lower-f421`); fsharp_functions/builtins green |
 | CONF-LLVM | Conformance adapter | LLVM | L | — |
-| CONF-R | Conformance adapter | R | M | — |
+| CONF-R ✅ | Conformance adapter | R | M | done — opt-in; append/reverse/builtins green; member/fib/ack xfail (Raw switch stubs) |
 | CONF-CLOJURE | Conformance adapter | Clojure | L | — |
 | CONF-LUA | Conformance adapter | Lua | M | — |
 | CONF-KOTLIN ✅ | Conformance adapter | Kotlin | M | done — opt-in (`cursor/conf-kotlin-f421`); append green, 5 xfails |
@@ -127,20 +127,17 @@ external toolchain.
   7. Add `test(llvm, [condition(ct_available(llvm))]) :- run_target_conformance(llvm).` in the tests block.
 - **Acceptance:** `CONFORMANCE_TARGETS=llvm swipl -g run_tests tests/test_wam_cross_target_conformance.pl` passes (skips if `clang`/`llc` absent).
 
-### CONF-R: Register R in the cross-target conformance harness
+### CONF-R: Register R in the cross-target conformance harness ✅
 - **Lever:** Conformance adapters  **Target:** R  **Size:** M  **Depends on:** —
-- **Goal:** Add an R adapter so the shared WAM spec runs against the R backend (interpreted, no build step).
-- **Files to touch:** `tests/test_wam_cross_target_conformance.pl`
-- **Reference to copy from:** `tests/test_wam_cross_target_conformance.pl` — the **Python adapter** (lines ~705-739; R is interpreted, same no-build shape); project writer is `write_wam_r_project/3` in `src/unifyweaver/targets/wam_r_target.pl:1903`.
-- **Steps:**
-  1. Add `:- use_module('../src/unifyweaver/targets/wam_r_target', [write_wam_r_project/3]).`
-  2. Add `conformance_target(r).` (opt-in only).
-  3. Add `ct_toolchain(r, ['Rscript']).` (verify: exact executable name/case — `Rscript`).
-  4. `ct_build(r, Preds, Queries, r_ctx(Dir, Map))`: exact Python shape — `ct_tmp_dir('tmp_ct_r', Dir)`, `synth_wrappers`, `strip_pred`/`qualify_user`, `write_wam_r_project(AllPreds, [module_name(wam_ct)], Dir)`. No compile gate. (verify: name of the generated entry script, e.g. `main.R`, and how it takes a `pred/arity` arg — inspect `write_wam_r_project` output.)
-  5. `ct_run(r, r_ctx(Dir, Map), K, A, Bool)`: `run_proc_out('Rscript', ['main.R', KeyStr], Dir, _, OutStr)`, map to bool (absence-of-`false.` like Python, or `bool_of_string` — match the generated runner's output).
-  6. `ct_teardown(r, r_ctx(Dir, Map)) :- cleanup_dir(Dir), abolish_wrappers(Map).`
-  7. Add `test(r, [condition(ct_available(r))]) :- run_target_conformance(r).`
-- **Acceptance:** `CONFORMANCE_TARGETS=r swipl -g run_tests tests/test_wam_cross_target_conformance.pl` passes (skips if `Rscript` absent).
+- **Status (2026-07-15):** Landed opt-in (`CONFORMANCE_TARGETS=r[,r_functions]`). Additive
+  `conformance_main(true)` in `templates/targets/r_wam/program.R.mustache`; harness pins
+  `runtime_parser(off)` (wrappers need no CLI parse; R default is `native(parse_term)`).
+  Run cwd is `Dir/R` (`Rscript generated_program.R <key>`).
+- **Measured:** append / reverse / builtins green on interpreter + functions. member / fib /
+  ack are `ct_xfail` — `wam_parts_to_r/2` lacks `switch_on_constant_fallthrough` and
+  `switch_on_term_a2`, so those emit `Raw(...)` and the step dispatcher `stop()`s (negatives
+  still return false → success channel discriminates).
+- **Acceptance:** `CONFORMANCE_TARGETS=r,r_functions swipl -g run_tests -t halt tests/test_wam_cross_target_conformance.pl` exits 0 (skips if `Rscript` absent).
 
 ### CONF-CLOJURE: Register Clojure in the cross-target conformance harness
 - **Lever:** Conformance adapters  **Target:** Clojure  **Size:** L  **Depends on:** —

--- a/docs/WAM_HYBRID_TARGETS_COMPARISON.md
+++ b/docs/WAM_HYBRID_TARGETS_COMPARISON.md
@@ -183,7 +183,8 @@ is still non-WAM `go_target.pl`.
 [`WAM_R_TARGET.md`](WAM_R_TARGET.md) + session handoff: ~30-PR parity
 campaign; **7/7 kernels**; rich builtins; **native parser default**;
 optional LMDB (load-everything). Generator suite ~94 plunit cases;
-**not** in conformance harness yet.
+classic conformance **opt-in** (`CONF-R`): append/reverse/builtins green;
+member/fib/ack xfail (`Raw` switch stubs).
 
 ## Tier C — mid maturity
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -44,8 +44,10 @@ lazy/cached tiers of F#/Haskell).
 
 ## Gaps (relative to Rust / Haskell / F#)
 
-- **Not in the conformance harness** — no `conformance_target(r)`;
-  correctness rests on the generator suite, not the shared spec.
+- **Classic conformance (CONF-R, 2026-07-15):** opt-in adapter registered
+  (`r` / `r_functions`). Green: append, reverse, builtins. xfail: member,
+  fib, ack — `switch_on_term_a2` / `switch_on_constant_fallthrough` fall to
+  `Raw(...)` in `wam_parts_to_r/2` and abort the step loop.
 - **LMDB is load-everything** — no lazy/cached two-level policies.
 - **ISO error support** is `tryCatch`-level only, not the three-form
   contract.
@@ -53,15 +55,13 @@ lazy/cached tiers of F#/Haskell).
 
 ## Path forward
 
-1. Register a conformance adapter (`CONFORMANCE_TARGETS=r`) so R joins
-   the shared spec.
+1. Map `switch_on_constant_fallthrough` / `switch_on_term_a2` in
+   `wam_parts_to_r/2` (Scala-class fix) to retire the three xfails.
 2. Lazy/cached LMDB policies over the load-everything path.
 3. ISO three-form adoption if R joins the error-fidelity set.
 4. Effective-distance cross-target matrix row.
 
 ## Document status
 
-Fleet-aligned snapshot; source-verified line/kernel counts, the native
-runtime-parser default, and the **absence** of conformance registration
-against `wam_r_target.pl`, the parser-capability module, and the
-conformance harness (2026-07-11).
+Fleet-aligned snapshot updated for CONF-R landing (2026-07-15): opt-in
+harness adapter + measured classic-program readout.

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -1922,11 +1922,15 @@ write_wam_r_project(Predicates, Options, ProjectDir) :-
     r_foreign_handlers_code(Options, ForeignHandlersBody),
     r_op_decls_code(Options, OpDeclsBody),
     write_runtime_source(RDir),
+    % Additive conformance driver (CONF-R): when true, the Rscript main
+    % prints only true/false for argv[0]=pred/arity. Default human/bench
+    % CLI is unchanged when the option is absent/false.
+    option(conformance_main(ConfMain), Options, false),
     write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
                          WrapperCode, IdToStringStr, ForeignHandlersBody,
                          LoweredFunctionsCode, FactShapeComments,
                          LoweredDispatchCode, OpDeclsBody,
-                         RuntimeParserModeCode).
+                         RuntimeParserModeCode, ConfMain).
 
 write_description(ProjectDir, ModName) :-
     find_template('templates/targets/r_wam/DESCRIPTION.mustache', Template),
@@ -1947,7 +1951,7 @@ write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
                      WrapperCode, IdToStringStr, ForeignHandlersBody,
                      LoweredFunctionsCode, FactShapeComments,
                      LoweredDispatchCode, OpDeclsBody,
-                     RuntimeParserModeCode) :-
+                     RuntimeParserModeCode, ConfMain) :-
     find_template('templates/targets/r_wam/program.R.mustache', Template),
     get_time(T), format_time(string(DateStr), "%Y-%m-%d", T),
     render_template(Template,
@@ -1962,7 +1966,8 @@ write_program_source(RDir, InstrBody, LabelBody, DispatchBody,
           'lowered_functions'=LoweredFunctionsCode,
           'fact_shape_comments'=FactShapeComments,
           'op_decls'=OpDeclsBody,
-          'runtime_parser_mode'=RuntimeParserModeCode
+          'runtime_parser_mode'=RuntimeParserModeCode,
+          'conformance_main'=ConfMain
         ], Content),
     directory_file_path(RDir, 'generated_program.R', Path),
     write_file(Path, Content).

--- a/templates/targets/r_wam/program.R.mustache
+++ b/templates/targets/r_wam/program.R.mustache
@@ -127,6 +127,27 @@ shared_program <- list(
 # ----------------------------------------------------------
 if (!interactive() && sys.nframe() == 0L) {
   argv <- commandArgs(trailingOnly = TRUE)
+{{#conformance_main}}
+  # Conformance driver (CONF-R): argv[0] = pred/arity key; print true/false
+  # only. Additive — default CLI (usage/batch/bench/arg parsing) is below
+  # when conformance_main is off. 0-arity wrappers need no CLI args.
+  if (length(argv) == 0L) {
+    cat("false\n")
+    quit(status = 1L)
+  }
+  pred_arity <- argv[1L]
+  start_pc   <- shared_labels[[pred_arity]]
+  if (is.null(start_pc)) {
+    cat("false\n")
+    quit(status = 1L)
+  }
+  ok <- tryCatch(
+    WamRuntime$run_predicate(shared_program, start_pc, list()),
+    error = function(e) FALSE)
+  cat(if (isTRUE(ok)) "true" else "false", "\n", sep = "")
+  quit(status = if (isTRUE(ok)) 0L else 1L)
+{{/conformance_main}}
+{{^conformance_main}}
   if (length(argv) == 0L) {
     cat("usage: Rscript generated_program.R [--bench N] <pred>/<arity> <arg> ...\n")
     cat("       Rscript generated_program.R --batch <pred>/0 ...\n")
@@ -225,4 +246,5 @@ if (!interactive() && sys.nframe() == 0L) {
   ok <- WamRuntime$run_predicate(shared_program, start_pc, parsed)
   cat(if (isTRUE(ok)) "true" else "false", "\n", sep = "")
   quit(status = if (isTRUE(ok)) 0L else 1L)
+{{/conformance_main}}
 }

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -73,6 +73,8 @@
               [write_wam_kotlin_project/3]).
 :- use_module('../src/unifyweaver/targets/wam_fsharp_target',
               [write_wam_fsharp_project/3]).
+:- use_module('../src/unifyweaver/targets/wam_r_target',
+              [write_wam_r_project/3]).
 
 % ============================================================
 % Target registry + known-divergence (xfail) registry
@@ -91,13 +93,15 @@ conformance_target(kotlin).
 conformance_target(kotlin_functions).
 conformance_target(fsharp).
 conformance_target(fsharp_functions).
+conformance_target(r).
+conformance_target(r_functions).
 
 %% ct_default_target(Target): runs unless CONFORMANCE_TARGETS overrides.
 %  Only scala and elixir run by default. Every other registered backend
 %  (wat, haskell, python, go, rust, c, cpp, kotlin, kotlin_functions,
-%  fsharp, fsharp_functions) is opt-in via CONFORMANCE_TARGETS because it
-%  builds a per-program project with an external toolchain. Kotlin/F# are
-%  especially slow (gradle / dotnet compile per program) and stay opt-in.
+%  fsharp, fsharp_functions, r, r_functions) is opt-in via
+%  CONFORMANCE_TARGETS because it builds a per-program project with an
+%  external toolchain. Kotlin/F#/R stay opt-in (slow toolchains / Rscript).
 ct_default_target(scala).
 ct_default_target(elixir).
 
@@ -301,6 +305,13 @@ ct_default_target(elixir).
 %     delegated to step via emit_one_fs(builtin_call). No remaining
 %     fsharp / fsharp_functions ct_xfail or ct_skip.
 
+%  R (CONF-R). Adapter registered (opt-in). Measured maturity and any
+%  ct_xfail(r[,_functions], Program) / ct_skip entries are recorded below
+%  after the first harness run (honest readout — do not force green).
+%  runtime_parser(off) is pinned so generation is deterministic: classic
+%  queries use 0-arity wrappers (no CLI term parsing), matching F#'s
+%  none default and avoiding native-parser variance on an unused path.
+
 % ============================================================
 % Toolchain probes
 % ============================================================
@@ -318,6 +329,8 @@ ct_toolchain(kotlin, [gradle]).
 ct_toolchain(kotlin_functions, [gradle]).
 ct_toolchain(fsharp, [dotnet]).
 ct_toolchain(fsharp_functions, [dotnet]).
+ct_toolchain(r, [Rscript]).
+ct_toolchain(r_functions, [Rscript]).
 
 ct_available(scala) :-
     ct_enabled(scala),
@@ -365,6 +378,9 @@ test(kotlin_functions, [condition(ct_available(kotlin_functions))]) :-
 test(fsharp, [condition(ct_available(fsharp))]) :- run_target_conformance(fsharp).
 test(fsharp_functions, [condition(ct_available(fsharp_functions))]) :-
     run_target_conformance(fsharp_functions).
+test(r, [condition(ct_available(r))]) :- run_target_conformance(r).
+test(r_functions, [condition(ct_available(r_functions))]) :-
+    run_target_conformance(r_functions).
 
 :- end_tests(wam_cross_target_conformance).
 
@@ -1106,6 +1122,69 @@ fsharp_ct_run(fsharp_ctx(Dir, Map), K, A, Bool) :-
 ct_teardown(fsharp, fsharp_ctx(Dir, Map)) :-
     cleanup_dir(Dir), abolish_wrappers(Map).
 ct_teardown(fsharp_functions, fsharp_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+
+% ============================================================
+% Adapter: R  (0-arity wrapper -> `Rscript generated_program.R <key>` -> true/false)
+%
+% write_wam_r_project/3 emits DESCRIPTION + R/wam_runtime.R +
+% R/generated_program.R. The default Rscript main is a human/bench CLI; for
+% conformance we pass conformance_main(true) so main prints only true/false
+% via WamRuntime$run_predicate (additive — default CLI unchanged).
+%
+% runtime_parser(off) is pinned: classic queries use 0-arity wrappers so CLI
+% term parsing is unused; pinning off keeps generation deterministic (R's
+% default is native(parse_term)).
+%
+% Two opt-in targets share this adapter:
+%   r            — emit_mode(interpreter)
+%   r_functions  — emit_mode(functions) (native-first + WAM fallback)
+% No compile step — ct_build writes the project; ct_run sources from R/.
+% Opt-in via CONFORMANCE_TARGETS=r[,r_functions].
+% ============================================================
+
+ct_build(r, Preds, Queries, r_ctx(Dir, Map)) :-
+    r_ct_build(interpreter, Preds, Queries, Dir, Map).
+
+ct_build(r_functions, Preds, Queries, r_ctx(Dir, Map)) :-
+    r_ct_build(functions, Preds, Queries, Dir, Map).
+
+r_ct_build(EmitMode, Preds, Queries, Dir, Map) :-
+    ct_tmp_dir('tmp_ct_r', Dir),
+    synth_wrappers(Queries, WPreds, Map),
+    maplist(strip_pred, Preds, BarePreds),
+    append(WPreds, BarePreds, AllPreds0),
+    maplist(qualify_user, AllPreds0, AllPreds),
+    write_wam_r_project(AllPreds,
+        [module_name(wam_ct),
+         emit_mode(EmitMode),
+         runtime_parser(off),
+         conformance_main(true)], Dir),
+    % Syntax gate: source the generated script once (no predicate run).
+    directory_file_path(Dir, 'R', RDir),
+    run_proc(Rscript, ['-e', 'source("generated_program.R")'],
+             RDir, BExit, BErr),
+    ( BExit =:= 0 -> true ; throw(r_build_failed(BExit, BErr)) ).
+
+ct_run(r, Ctx, K, A, Bool) :-
+    r_ct_run(Ctx, K, A, Bool).
+ct_run(r_functions, Ctx, K, A, Bool) :-
+    r_ct_run(Ctx, K, A, Bool).
+
+r_ct_run(r_ctx(Dir, Map), K, A, Bool) :-
+    memberchk((K-A)-WName, Map),
+    format(atom(KeyAtom), '~w/0', [WName]), atom_string(KeyAtom, KeyStr),
+    directory_file_path(Dir, 'R', RDir),
+    % cwd = R/ so wam_runtime.R resolves next to generated_program.R
+    % (sys.frame(1)$ofile is unreliable under Rscript path invocation).
+    run_proc_out(Rscript, ['generated_program.R', KeyStr],
+                 RDir, _Exit, OutStr),
+    normalize_space(string(Out), OutStr),
+    bool_of_string(Out, Bool).
+
+ct_teardown(r, r_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+ct_teardown(r_functions, r_ctx(Dir, Map)) :-
     cleanup_dir(Dir), abolish_wrappers(Map).
 
 %% c_copy_runtime_header(+Dir) — copy the static wam_runtime.h into Dir.

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -324,9 +324,9 @@ ct_default_target(elixir).
 ct_xfail(r, member).            % Raw(switch_on_term_a2) → stop
 ct_xfail(r, fib).               % Raw(switch_on_constant_fallthrough) → stop
 ct_xfail(r, ack).               % Raw(switch_on_constant_fallthrough) → stop
-ct_xfail(r_functions, member).  % same Raw stubs on WAM fallback path
-ct_xfail(r_functions, fib).
-ct_xfail(r_functions, ack).
+ct_xfail(r_functions, member).  % same as r — Raw(switch_on_term_a2) → stop
+ct_xfail(r_functions, fib).     % same as r — Raw(switch_on_constant_fallthrough) → stop
+ct_xfail(r_functions, ack).     % same as r — Raw(switch_on_constant_fallthrough) → stop
 
 % ============================================================
 % Toolchain probes
@@ -1166,7 +1166,11 @@ ct_build(r_functions, Preds, Queries, r_ctx(Dir, Map)) :-
     r_ct_build(functions, Preds, Queries, Dir, Map).
 
 r_ct_build(EmitMode, Preds, Queries, Dir, Map) :-
-    ct_tmp_dir('tmp_ct_r', Dir),
+    % Distinct prefix per emit mode: both modes write R/generated_program.R
+    % (no compile-artifact isolation), so a shared tmp_ct_r stamp collision
+    % would silently overwrite the other mode's sources.
+    format(atom(TmpPrefix), 'tmp_ct_r_~w', [EmitMode]),
+    ct_tmp_dir(TmpPrefix, Dir),
     synth_wrappers(Queries, WPreds, Map),
     maplist(strip_pred, Preds, BarePreds),
     append(WPreds, BarePreds, AllPreds0),
@@ -1193,6 +1197,9 @@ r_ct_run(r_ctx(Dir, Map), K, A, Bool) :-
     directory_file_path(Dir, 'R', RDir),
     % cwd = R/ so wam_runtime.R resolves next to generated_program.R
     % (sys.frame(1)$ofile is unreliable under Rscript path invocation).
+    % Keep bool_of_string strict: empty/garbage stdout must fail the run
+    % (→ error(run_failed)), not collapse to false — that would mask
+    % crashes as correct negatives.
     run_proc_out('Rscript', ['generated_program.R', KeyStr],
                  RDir, _Exit, OutStr),
     normalize_space(string(Out), OutStr),

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -305,12 +305,28 @@ ct_default_target(elixir).
 %     delegated to step via emit_one_fs(builtin_call). No remaining
 %     fsharp / fsharp_functions ct_xfail or ct_skip.
 
-%  R (CONF-R). Adapter registered (opt-in). Measured maturity and any
-%  ct_xfail(r[,_functions], Program) / ct_skip entries are recorded below
-%  after the first harness run (honest readout — do not force green).
+%  R (CONF-R). Adapter registered (opt-in via CONFORMANCE_TARGETS=r[,r_functions]).
 %  runtime_parser(off) is pinned so generation is deterministic: classic
-%  queries use 0-arity wrappers (no CLI term parsing), matching F#'s
-%  none default and avoiding native-parser variance on an unused path.
+%  queries use 0-arity wrappers (no CLI term parsing); R's default is
+%  native(parse_term), which is unused on the wrapper path.
+%
+%  Measured maturity (interpreter + functions, same gap set):
+%   - GREEN: append, reverse, builtins
+%   - xfail member / fib / ack — see ct_xfail(r, ...) below
+%  Success channel discriminates: negatives return false (XPASS under
+%  xfail), not blanket-true. Root cause for all three xfails is the same
+%  family: wam_parts_to_r/2 has no clause for switch_on_constant_fallthrough
+%  (fib/ack) or switch_on_term_a2 (member), so those instructions emit as
+%  Raw(...) and the R step dispatcher stop()s — tryCatch in the
+%  conformance driver maps that to false. (switch_on_constant and
+%  switch_on_term A1 variants already emit real constructors; fallthrough
+%  / _a2 are the missing Scala-class mapping.)
+ct_xfail(r, member).            % Raw(switch_on_term_a2) → stop
+ct_xfail(r, fib).               % Raw(switch_on_constant_fallthrough) → stop
+ct_xfail(r, ack).               % Raw(switch_on_constant_fallthrough) → stop
+ct_xfail(r_functions, member).  % same Raw stubs on WAM fallback path
+ct_xfail(r_functions, fib).
+ct_xfail(r_functions, ack).
 
 % ============================================================
 % Toolchain probes
@@ -329,8 +345,8 @@ ct_toolchain(kotlin, [gradle]).
 ct_toolchain(kotlin_functions, [gradle]).
 ct_toolchain(fsharp, [dotnet]).
 ct_toolchain(fsharp_functions, [dotnet]).
-ct_toolchain(r, [Rscript]).
-ct_toolchain(r_functions, [Rscript]).
+ct_toolchain(r, ['Rscript']).
+ct_toolchain(r_functions, ['Rscript']).
 
 ct_available(scala) :-
     ct_enabled(scala),
@@ -1160,9 +1176,9 @@ r_ct_build(EmitMode, Preds, Queries, Dir, Map) :-
          emit_mode(EmitMode),
          runtime_parser(off),
          conformance_main(true)], Dir),
-    % Syntax gate: source the generated script once (no predicate run).
+    % Syntax gate: source under Rscript -e (sys.nframe()>0 skips CLI main).
     directory_file_path(Dir, 'R', RDir),
-    run_proc(Rscript, ['-e', 'source("generated_program.R")'],
+    run_proc('Rscript', ['-e', 'source("generated_program.R")'],
              RDir, BExit, BErr),
     ( BExit =:= 0 -> true ; throw(r_build_failed(BExit, BErr)) ).
 
@@ -1177,7 +1193,7 @@ r_ct_run(r_ctx(Dir, Map), K, A, Bool) :-
     directory_file_path(Dir, 'R', RDir),
     % cwd = R/ so wam_runtime.R resolves next to generated_program.R
     % (sys.frame(1)$ofile is unreliable under Rscript path invocation).
-    run_proc_out(Rscript, ['generated_program.R', KeyStr],
+    run_proc_out('Rscript', ['generated_program.R', KeyStr],
                  RDir, _Exit, OutStr),
     normalize_space(string(Out), OutStr),
     bool_of_string(Out, Bool).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Register the hybrid WAM **R** backend in the cross-target conformance harness (opt-in only), mirroring CONF-FSHARP.

## Changes
- Additive `conformance_main(true)` branch in `templates/targets/r_wam/program.R.mustache` — CLI key `pred/arity` → print only `true`/`false`. Default human/bench CLI unchanged.
- Harness targets `r` (interpreter) and `r_functions` (functions), gated by `CONFORMANCE_TARGETS=r[,r_functions]`. Not in `ct_default_target`.
- Pins `runtime_parser(off)` for deterministic wrapper projects (R’s default is `native(parse_term)`; unused on the 0-arity wrapper path).
- `ct_build` writes the project + `Rscript -e 'source(...)'` syntax gate; `ct_run` is `Rscript generated_program.R <key>` with cwd `Dir/R`.
- Tmp dirs are per emit mode (`tmp_ct_r_interpreter` / `tmp_ct_r_functions`) so the two modes cannot overwrite `R/generated_program.R`.

## Measured maturity
| Program | `r` / `r_functions` |
|---|---|
| append, reverse, builtins | green |
| member, fib, ack | `ct_xfail` — `switch_on_term_a2` / `switch_on_constant_fallthrough` fall to `Raw(...)` in `wam_parts_to_r/2` and the step dispatcher `stop()`s |

Negatives under those xfails **XPASS** (return `false`) — success channel discriminates; not blanket-true. Empty/garbage stdout still fails the run (not collapsed to `false`).

## Verify
```bash
CONFORMANCE_TARGETS=r,r_functions swipl -g run_tests -t halt \
  tests/test_wam_cross_target_conformance.pl
```
Exits 0 when `Rscript` is present; skips cleanly when absent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

