### PR TITLE
FS-HYBRID-KERNEL-GATE-TC: F# kernel capability gate + native transitive_closure2

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -53,7 +53,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | ISO-R | ISO three-form (new) | R | L | — |
 | ISO-PYTHON | ISO three-form (finish) | Python | S | — |
 | ISO-FSHARP | ISO three-form (finish) | F# | S | — |
-| KERN-FSHARP | Finish F# kernel templates | F# | L | — |
+| KERN-FSHARP ⚡ | Finish F# native kernel acceleration | F# | L | gate+TC2 done (`FS-HYBRID-KERNEL-GATE-TC`); 5 kinds remain |
 | EMIT-ILASM | Lowered emitter | ILAsm | L | — |
 | EMIT-JVM | Lowered emitter | JVM | L | — |
 | EMIT-KOTLIN ✅ | Lowered emitter | Kotlin | M | done — flat facts/unify (`cursor/emit-kotlin-lowered-f421`) |
@@ -470,28 +470,19 @@ plumbing there.
 
 ## Lever: Finish F# foreign-kernel templates
 
-### KERN-FSHARP: Port the 6 missing F# foreign-kernel templates
+### KERN-FSHARP: Native foreign-kernel acceleration for F#
 - **Lever:** Finish F# foreign-kernel templates  **Target:** F#  **Size:** L  **Depends on:** —
-- **Goal:** Add the 6 missing `.fs.mustache` kernel templates so F#'s detector-fired kinds (transitive_closure2, transitive_distance3, transitive_parent_distance4, transitive_step_parent_distance5, weighted_shortest_path3, astar_shortest_path4) emit real F# instead of the "no F# template available" stub.
-- **Consolidation note:** Emitted as ONE card, not six. The 6 items are mechanically identical — each is a syntax port of the already-complete Haskell template of the same base name into F#, wired through the same code path (`render_kernel_function_fs/2` swaps `.hs.mustache`→`.fs.mustache` and reads `templates/targets/fsharp_wam/`). A Grok agent should do them in one branch, one kind at a time, in the order below.
-- **Files to touch:**
-  - `templates/targets/fsharp_wam/kernel_transitive_closure.fs.mustache` (new)
-  - `templates/targets/fsharp_wam/kernel_transitive_distance.fs.mustache` (new)
-  - `templates/targets/fsharp_wam/kernel_transitive_parent_distance.fs.mustache` (new)
-  - `templates/targets/fsharp_wam/kernel_transitive_step_parent_distance.fs.mustache` (new)
-  - `templates/targets/fsharp_wam/kernel_weighted_shortest_path.fs.mustache` (new)
-  - `templates/targets/fsharp_wam/kernel_astar_shortest_path.fs.mustache` (new)
-  - No `.pl` change expected: `wam_fsharp_target.pl` `render_kernel_function_fs/2` (lines 3554–3585) already derives each F# filename from `kernel_template_file/2` by suffix swap; dropping the files in place activates them. (verify: confirm no per-kind allow-list gate elsewhere restricts F# to the 2 shipped kinds.)
-- **Reference to copy from:**
-  - Structure/algorithm per kind: `templates/targets/haskell_wam/kernel_<base>.hs.mustache` (all exist and are complete) — pair each new file with the same base name.
-  - F# syntax + mustache-var conventions: the two working F# templates `templates/targets/fsharp_wam/kernel_category_ancestor.fs.mustache` and `kernel_bidirectional_ancestor.fs.mustache`.
-  - Var binding contract: `wam_fsharp_target.pl` `config_ops_to_template_vars_fs/2` (just below line 3585) — mustache vars come from the kernel's `ConfigOps` (e.g. `edge_pred`, `max_depth`); mirror the var names the matching `.hs.mustache` consumes.
-- **Steps:**
-  1. For each base name, open the Haskell template and the two working F# templates side by side; identify the mustache vars used.
-  2. Translate the Haskell kernel body to idiomatic F# (recursive/`Seq`/`Map` traversal calling `ILookupSource.Lookup`), keeping the same mustache placeholders and function-name shape as the F# category/bidirectional templates.
-  3. Ensure the emitted F# function name and signature match what `program.fs.mustache` / `execute_foreign.fs.mustache` dispatch to (check `generate_execute_foreign_fs/2` + `emit_execute_foreign_entry_fs/1`, lines ~3586–3600; expect `kernel_register_layout/2` + `kernel_native_call/2` already defined per kind).
-  4. Do the simplest kind first (transitive_closure), validate end-to-end, then the weighted/astar kinds.
-- **Acceptance:** For each kind, generating a project with that kernel produces a template (no `// Kernel …: no F# template available` marker in `WamRuntime.fs`) and `dotnet build` succeeds. Extend the emission+build assertion pattern of `tests/core/test_wam_fsharp_bidirectional_e2e.pl` (Step 5, lines ~125–168) to each new kind; `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` plus `tests/run_wam_fsharp_tests.pl` pass.
+- **Correction (2026-07-16):** Missing `.fs.mustache` files are an *implementation choice*, not a requirement. Rust inlines handlers in `wam_rust_target.pl`; Haskell uses per-kind mustache. F# already had:
+  - generic WAM recursive `tc/2` (correctness path via `no_kernels(true)`),
+  - `nativeKernel_category_ancestor` / `nativeKernel_bidirectional_ancestor`,
+  - LMDB/CSR `reachableToRoot*` demand-pruning BFS (different semantics — includes root, reverse/child edges),
+  - `BuildEmptySet` / `SetInsert` / `NotMemberSet` + `FFIStreamRetry` plumbing.
+- **FS-HYBRID-KERNEL-GATE-TC ✅ (landed):**
+  1. **Capability gate** — `wam_fsharp_native_kernel_kind/1` + filter in `detect_kernels_fs/2`. Unsupported detected kinds fall back to ordinary WAM (no undefined `nativeKernel_*` / FS0039). Logged at generation time.
+  2. **Native `transitive_closure2` acceleration** — `templates/targets/fsharp_wam/kernel_transitive_closure.fs.mustache` (lookup-fn + HashSet visited; stream via existing FFIStreamRetry; bound Target filtered). Describe as “native foreign acceleration for the shared transitive_closure2 pattern,” not “F# transitive closure support.”
+- **Remaining (5 kinds, optional acceleration):** `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, `weighted_shortest_path3`, `astar_shortest_path4` — add to the allow-list only when a real handler exists (mustache *or* inline). Until then they must stay WAM.
+- **Tests:** `tests/core/test_wam_fsharp_kernel_gate_tc.pl`
+- **Acceptance (gate+TC2):** `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_kernel_gate_tc.pl` (dotnet build/run for native TC2 + five WAM-fallback kinds).
 
 ---
 

--- a/docs/WAM_FSHARP_STATUS.md
+++ b/docs/WAM_FSHARP_STATUS.md
@@ -33,12 +33,15 @@ query times competitive with Rust FFI at scale 300.
 **Dual lowering.** Interpreter + `emit_mode(functions)` lowered path
 (mirrors Haskell; deterministic clause-1 for choicepoint-heavy bodies).
 
-**Kernels.** Shared detector can fire for all kinds, but **only two
-F# mustache templates exist** on disk
+**Kernels.** Shared detection can recognize more kinds than F# accelerates.
+The capability gate promotes a predicate to `CallForeign` only when the
+selected kind is allow-listed **and** its F# handler exists; otherwise the
+already-working WAM predicate remains the correctness path. Three F#
+mustache handlers exist on disk
 (`kernel_category_ancestor.fs.mustache`,
-`kernel_bidirectional_ancestor.fs.mustache`). Other kinds fall through
-to a `// Kernel …: template not found` stub at codegen
-(`render_kernel_function_fs/2`). Benchmarks centre on
+`kernel_bidirectional_ancestor.fs.mustache`,
+`kernel_transitive_closure.fs.mustache`). Missing handlers no longer emit
+undefined `nativeKernel_*` calls. Benchmarks centre on
 `category_ancestor/4`. **Bidirectional** upgrade is computed but
 **off by default** — requires `allow_bidirectional_kernel_swap(true)`.
 CSR reverse-index reader (`CsrLookupSource`) and cost/strategy

--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -139,7 +139,7 @@ fsharp_wam_builtin_state_type :-
 "type BuiltinState =
     | FactRetry      of varId: int * remaining: string list * retPC: int
     | HopsRetry      of varId: int * remaining: int list   * retPC: int
-    | FFIStreamRetry of outRegs: int list * outVars: int list * remaining: Value list list * retPC: int
+    | FFIStreamRetry of outRegs: int list * outVars: int list * remaining: Value list list * retPC: int * returnCP: int * returnCutBar: int * returnB0Stack: int list
     /// select/3 enumeration choice point.  Each remaining candidate is
     /// a pair (selected, rest_items): on backtrack the runtime restores
     /// the CP snapshot, unifies elemReg with `selected`, and binds
@@ -381,6 +381,7 @@ fsharp_wam_instruction_type :-
     | Call           of pred: string * arity: int
     | CallResolved   of pc: int * arity: int
     | CallForeign    of pred: string * arity: int
+    | ExecuteForeign of pred: string
     | Execute        of pred: string
     | ExecutePc      of pc: int
     | Proceed

--- a/src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs
+++ b/src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs
@@ -57,7 +57,7 @@ type AggFrame = { AggType: string; AggValReg: int; AggResReg: int; AggReturnPC: 
 type BuiltinState =
     | FactRetry      of varId: int * remaining: string list * retPC: int
     | HopsRetry      of varId: int * remaining: int list   * retPC: int
-    | FFIStreamRetry of outRegs: int list * outVars: int list * remaining: Value list list * retPC: int
+    | FFIStreamRetry of outRegs: int list * outVars: int list * remaining: Value list list * retPC: int * returnCP: int * returnCutBar: int * returnB0Stack: int list
 
 type EnvFrame = { EfSavedCP: int; EfYRegs: Map<int, Value> }
 
@@ -151,6 +151,7 @@ and Instruction =
     | Call           of pred: string * arity: int
     | CallResolved   of pc: int * arity: int
     | CallForeign    of pred: string * arity: int
+    | ExecuteForeign of pred: string
     | Execute        of pred: string
     | ExecutePc      of pc: int
     | Proceed
@@ -416,19 +417,24 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                  WsBindings = Map.add vid (Integer h) cp.CpBindings
                  WsCPs      = newCPs
                  WsCPsLen   = List.length newCPs }
-    | FFIStreamRetry (_, _, [], _) ->
+    | FFIStreamRetry (_, _, [], _, _, _, _) ->
         backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
-    | FFIStreamRetry (outRegs, outVars, tuple :: restTuples, retPC) ->
+    | FFIStreamRetry (outRegs, outVars, tuple :: restTuples, retPC,
+                      returnCP, returnCutBar, returnB0Stack) ->
         let newRegs     = List.fold2 (fun m rN v -> Map.add rN v m) cp.CpRegs outRegs tuple
         let newBindings = List.fold2
                             (fun m vid v -> if vid = -1 then m else Map.add vid v m)
                             cp.CpBindings outVars tuple
         let newCPs = match restTuples with
                      | [] -> rest
-                     | _  -> { cp with CpBuiltin = Some (FFIStreamRetry (outRegs, outVars, restTuples, retPC)) } :: rest
+                     | _  -> { cp with CpBuiltin = Some (FFIStreamRetry (outRegs, outVars, restTuples, retPC,
+                                                                         returnCP, returnCutBar, returnB0Stack)) } :: rest
         let base_ = restoreCommon diff
         Some { base_ with
                  WsPC       = retPC
+                 WsCP       = returnCP
+                 WsCutBar   = returnCutBar
+                 WsB0Stack  = returnB0Stack
                  WsRegs     = newRegs
                  WsBindings = newBindings
                  WsCPs      = newCPs
@@ -550,7 +556,13 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         Some { s with WsPC = pc; WsCP = s.WsPC + 1 }
 
     | CallForeign (pred, _arity) ->
-        executeForeign ctx pred { s with WsCP = s.WsPC + 1 }
+        executeForeign ctx pred true
+            { s with WsCP      = s.WsPC + 1
+                     WsB0Stack = s.WsCutBar :: s.WsB0Stack
+                     WsCutBar  = s.WsCPsLen }
+
+    | ExecuteForeign pred ->
+        executeForeign ctx pred true { s with WsCutBar = s.WsCPsLen }
 
     | Execute pred ->
         dispatchCall ctx pred s
@@ -791,11 +803,11 @@ and callIndexedFact2 (ctx: WamContext) (pred: string) (s: WamState) : WamState o
 
 /// Foreign predicate dispatch — auto-generated from kernel detection.
 /// This stub always fails; the generator emits the real version.
-and executeForeign (_ctx: WamContext) (_pred: string) (_s: WamState) : WamState option = None
+and executeForeign (_ctx: WamContext) (_pred: string) (_completeReturn: bool) (_s: WamState) : WamState option = None
 
 /// Foreign call entry point used from lowered functions.
 and callForeign (ctx: WamContext) (pred: string) (sc: WamState) : WamState option =
-    executeForeign ctx pred sc
+    executeForeign ctx pred false sc
 
 // ----------------------------------------------------------------------------
 // resolveCallInstrs — pre-resolve Call labels to PCs at load time (Phase C)
@@ -812,6 +824,8 @@ let resolveCallInstrs (labels: Map<string, int>) (foreignPreds: string list) (in
                 match Map.tryFind pred labels with
                 | Some pc -> CallResolved (pc, arity)
                 | None    -> instr
+        | Execute pred when List.contains pred foreignPreds ->
+            ExecuteForeign pred
         | Execute pred ->
             match Map.tryFind pred labels with
             | Some pc -> ExecutePc pc

--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -1406,11 +1406,12 @@ emit_one_fs(trust_me, PC, SV, SVout, I, _FP) :-
     format("~w| Some ~w ->~n", [I, SVout]).
 
 % Execute — tail call; returns directly (no WsCP change)
-emit_one_fs(execute(PredStr), _PC, SV, SV, I, FP) :-
+emit_one_fs(execute(PredStr), PC, SV, SV, I, FP) :-
     atom_string(PredAtom, PredStr),
     escape_dq_fs(PredStr, EscPred),
     (   member(PredAtom, FP)
-    ->  format("~wcallForeign ctx \"~w\" ~w~n", [I, EscPred, SV])
+    ->  format("~wstep ctx { ~w with WsPC = ~w } (ExecuteForeign \"~w\")~n",
+               [I, SV, PC, EscPred])
     ;   format("~wdispatchCall ctx \"~w\" ~w~n", [I, EscPred, SV])
     ).
 

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -258,9 +258,37 @@ wam_fsharp_native_kernel_kind(category_ancestor).
 wam_fsharp_native_kernel_kind(bidirectional_ancestor).
 wam_fsharp_native_kernel_kind(transitive_closure2).
 
+fsharp_kernel_template_path(Kind, AbsPath) :-
+    kernel_template_file(Kind, HsTemplateFile),
+    atom_concat(Base, '.hs.mustache', HsTemplateFile),
+    atom_concat(Base, '.fs.mustache', TemplateFile),
+    atom_concat('templates/targets/fsharp_wam/', TemplateFile, RelPath),
+    (   source_file(wam_fsharp_target, SrcFile)
+    ->  file_directory_name(SrcFile, SrcDir),
+        file_directory_name(SrcDir, TargetsDir),
+        file_directory_name(TargetsDir, UnifyWeaverDir),
+        file_directory_name(UnifyWeaverDir, ProjectDir),
+        atomic_list_concat([ProjectDir, '/', RelPath], AbsPath)
+    ;   AbsPath = RelPath
+    ).
+
 %% wam_fsharp_native_kernel_supported(+Kernel)
 wam_fsharp_native_kernel_supported(recursive_kernel(Kind, _Pred, _ConfigOps)) :-
-    wam_fsharp_native_kernel_kind(Kind).
+    wam_fsharp_native_kernel_kind(Kind),
+    fsharp_kernel_template_path(Kind, HandlerPath),
+    exists_file(HandlerPath).
+
+filter_supported_kernel_pairs_fs([], []).
+filter_supported_kernel_pairs_fs([Key-Kernel|Rest], Supported) :-
+    (   wam_fsharp_native_kernel_supported(Kernel)
+    ->  Supported = [Key-Kernel|SupportedRest]
+    ;   Kernel = recursive_kernel(Kind, _, _),
+        format(user_error,
+               '[WAM-FSharp] detected ~w (~w) but no native F# handler; falling back to WAM~n',
+               [Key, Kind]),
+        Supported = SupportedRest
+    ),
+    filter_supported_kernel_pairs_fs(Rest, SupportedRest).
 
 detect_kernels_fs([], []).
 detect_kernels_fs([PI|Rest], Kernels) :-
@@ -270,14 +298,8 @@ detect_kernels_fs([PI|Rest], Kernels) :-
     (   Clauses \= [],
         detect_recursive_kernel(Pred, Arity, Clauses, Kernel)
     ->  format(atom(Key), '~w/~w', [Pred, Arity]),
-        (   wam_fsharp_native_kernel_supported(Kernel)
-        ->  Kernels = [Key-Kernel|RestKernels]
-        ;   Kernel = recursive_kernel(Kind, _, _),
-            format(user_error,
-                   '[WAM-FSharp] detected ~w (~w) but no native F# handler; falling back to WAM~n',
-                   [Key, Kind]),
-            Kernels = RestKernels
-        )
+        filter_supported_kernel_pairs_fs([Key-Kernel], Supported),
+        append(Supported, RestKernels, Kernels)
     ;   Kernels = RestKernels
     ),
     detect_kernels_fs(Rest, RestKernels).
@@ -662,9 +684,10 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                     | None -> tryNext more
                 | _ -> tryNext more
         tryNext candidates
-    | FFIStreamRetry (_, _, [], _) ->
+    | FFIStreamRetry (_, _, [], _, _, _, _) ->
         backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
-    | FFIStreamRetry (outRegs, outVars, tuple :: restTuples, retPC) ->
+    | FFIStreamRetry (outRegs, outVars, tuple :: restTuples, retPC,
+                      returnCP, returnCutBar, returnB0Stack) ->
         let newRegs     = Array.copy cp.CpRegs
         List.iter2 (fun rN v -> newRegs.[rN] <- v) outRegs tuple
         let newBindings = List.fold2
@@ -672,20 +695,21 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                             cp.CpBindings outVars tuple
         let newCPs = match restTuples with
                      | [] -> rest
-                     | _  -> { cp with CpBuiltin = Some (FFIStreamRetry (outRegs, outVars, restTuples, retPC)) } :: rest
+                     | _  -> { cp with CpBuiltin = Some (FFIStreamRetry (outRegs, outVars, restTuples, retPC,
+                                                                         returnCP, returnCutBar, returnB0Stack)) } :: rest
         let diff = s.WsTrailLen - cp.CpTrailLen
         Some { s with
                  WsPC       = retPC
                  WsRegs     = newRegs
                  WsStack    = cp.CpStack
-                 WsCP       = cp.CpCP
+                 WsCP       = returnCP
                  WsTrail    = List.skip diff s.WsTrail
                  WsTrailLen = cp.CpTrailLen
                  WsHeap     = List.take cp.CpHeapLen s.WsHeap
                  WsHeapLen  = cp.CpHeapLen
                  WsBindings = newBindings
-                 WsCutBar   = cp.CpCutBar
-                 WsB0Stack  = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
+                 WsCutBar   = returnCutBar
+                 WsB0Stack  = returnB0Stack
                  WsCPs      = newCPs
                  WsCPsLen   = List.length newCPs }
 
@@ -971,16 +995,16 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                       WsCutBar  = s.WsCPsLen }
 
     | CallForeign (pred, _arity) ->
-        // Foreign predicates don''t emit Proceed in the F# WAM (they
-        // either succeed via dispatchForeign''s direct return or push
-        // a builtin CP).  Mirror Call''s B0 protocol so any cut inside
-        // the foreign handler sees the correct barrier; if the
-        // foreign handler bypasses Proceed (e.g. via direct WsPC
-        // assignment) the B0 entry stays — that matches existing
-        // semantics where WsCutBar would not be restored either.
-        executeForeign ctx pred { s with WsCP      = s.WsPC + 1
-                                         WsB0Stack = s.WsCutBar :: s.WsB0Stack
-                                         WsCutBar  = s.WsCPsLen }
+        // The generated binder completes the same return transition as
+        // Proceed for both the first result and every FFIStreamRetry result.
+        executeForeign ctx pred true { s with WsCP      = s.WsPC + 1
+                                              WsB0Stack = s.WsCutBar :: s.WsB0Stack
+                                              WsCutBar  = s.WsCPsLen }
+
+    | ExecuteForeign pred ->
+        // Foreign tail call: preserve the caller''s continuation and do not
+        // push B0. The binder performs the callee''s missing Proceed.
+        executeForeign ctx pred true { s with WsCutBar = s.WsCPsLen }
 
     // catch/3 and throw/1 are emitted by the WAM compiler as
     // Call / Execute (meta-call shape) rather than BuiltinCall.
@@ -3459,7 +3483,9 @@ and dispatchCall (ctx: WamContext) (pred: string) (sc: WamState) : WamState opti
 
 /// Foreign call for lowered functions.
 and callForeign (ctx: WamContext) (pred: string) (sc: WamState) : WamState option =
-    executeForeign ctx pred sc
+    // Lowered/manual callers own their continuation; keep the raw return
+    // shape. Interpreter CallForeign/ExecuteForeign pass completeReturn=true.
+    executeForeign ctx pred false sc
 
 {{execute_foreign}}
 
@@ -3476,6 +3502,8 @@ let resolveCallInstrs (labels: Map<string, int>) (foreignPreds: string list) (in
             match Map.tryFind pred labels with
             | Some pc -> CallResolved (pc, arity)
             | None    -> Call (pred, arity)
+        | Execute pred when List.contains pred foreignPreds ->
+            ExecuteForeign pred
         | Execute pred ->
             match Map.tryFind pred labels with
             | Some pc -> ExecutePc pc
@@ -3571,7 +3599,7 @@ open WamTypes
 
 generate_kernel_fsharp([], KF, EF) :- !,
     KF = "// No kernels detected.",
-    EF = "and executeForeign (_ctx: WamContext) (_pred: string) (_s: WamState) : WamState option = None".
+    EF = "and executeForeign (_ctx: WamContext) (_pred: string) (_completeReturn: bool) (_s: WamState) : WamState option = None".
 generate_kernel_fsharp(DetectedKernels, KernelFunctionsCode, ExecuteForeignCode) :-
     maplist(render_kernel_function_fs, DetectedKernels, KernelParts),
     atomic_list_concat(KernelParts, '\n\n', KernelFunctionsCode),
@@ -3579,28 +3607,14 @@ generate_kernel_fsharp(DetectedKernels, KernelFunctionsCode, ExecuteForeignCode)
 
 render_kernel_function_fs(Key-Kernel, Code) :-
     Kernel = recursive_kernel(Kind, _, ConfigOps),
-    (   kernel_template_file(Kind, HsTemplateFile),
-        % Replace .hs.mustache with .fs.mustache for F# target
-        atom_concat(Base, '.hs.mustache', HsTemplateFile),
-        atom_concat(Base, '.fs.mustache', TemplateFile)
-    ->  atom_concat('templates/targets/fsharp_wam/', TemplateFile, RelPath),
-        (   source_file(wam_fsharp_target, SrcFile)
-        ->  file_directory_name(SrcFile, SrcDir),
-            file_directory_name(SrcDir, TargetsDir),
-            file_directory_name(TargetsDir, UnifyWeaverDir),
-            file_directory_name(UnifyWeaverDir, ProjectDir),
-            atom_concat(ProjectDir, '/', P1),
-            atom_concat(P1, RelPath, AbsPath)
-        ;   AbsPath = RelPath
-        ),
-        (   exists_file(AbsPath)
-        ->  read_file_to_string(AbsPath, Template, []),
-            config_ops_to_template_vars_fs(ConfigOps, TemplateVars),
-            render_template(Template, TemplateVars, Code0),
-            atom_string(Code0, Code)
-        ;   format(atom(Code), '// Kernel ~w: template not found at ~w', [Key, AbsPath])
-        )
-    ;   format(atom(Code), '// Kernel ~w: no F# template available', [Key])
+    (   fsharp_kernel_template_path(Kind, AbsPath),
+        exists_file(AbsPath)
+    ->  read_file_to_string(AbsPath, Template, []),
+        config_ops_to_template_vars_fs(ConfigOps, TemplateVars),
+        render_template(Template, TemplateVars, Code0),
+        atom_string(Code0, Code)
+    ;   throw(error(existence_error(fsharp_native_kernel_handler, Kind),
+                    context(render_kernel_function_fs/2, Key)))
     ).
 
 config_ops_to_template_vars_fs([], []).
@@ -3611,7 +3625,7 @@ config_ops_to_template_vars_fs([Op|Rest], [Key=Value|RestVars]) :-
 
 generate_execute_foreign_fs(DetectedKernels, Code) :-
     with_output_to(string(Code), (
-        format("and executeForeign (ctx: WamContext) (pred: string) (s: WamState) : WamState option =~n"),
+        format("and executeForeign (ctx: WamContext) (pred: string) (completeReturn: bool) (s: WamState) : WamState option =~n"),
         format("    match pred with~n"),
         forall(member(KV, DetectedKernels), emit_execute_foreign_entry_fs(KV)),
         format("    | _ -> None~n")
@@ -3763,6 +3777,13 @@ emit_reg_extraction_fs(VarName, integer) :-
 emit_stream_binding_multi_fs(OutputRegs, Indent) :-
     length(OutputRegs, NOuts),
     format('~wlet retPC = s.WsCP~n', [Indent]),
+    format('~wlet returnCP, returnCutBar, returnB0Stack =~n', [Indent]),
+    format('~w    if completeReturn then~n', [Indent]),
+    format('~w        match s.WsB0Stack with~n', [Indent]),
+    format('~w        | top :: rest -> 0, top, rest~n', [Indent]),
+    format('~w        | [] -> 0, 0, []~n', [Indent]),
+    format('~w    else~n', [Indent]),
+    format('~w        s.WsCP, s.WsCutBar, s.WsB0Stack~n', [Indent]),
     emit_multi_out_derefs_fs(OutputRegs, Indent),
     % Respect already-bound output registers (e.g. tc(+Source, +Target)):
     % filter the native result stream before FFIStreamRetry packing.
@@ -3773,11 +3794,17 @@ emit_stream_binding_multi_fs(OutputRegs, Indent) :-
     format(' =~n', []),
     format('~w    let ', [Indent]),
     emit_multi_wrap_bindings_fs(OutputRegs, 1),
+    format('~w    let trailDelta = [', [Indent]),
+    emit_outreg_values_list_fs(OutputRegs, 1),
+    format('] |> List.sumBy (function Unbound _ -> 1 | _ -> 0)~n', []),
     format('~w    { s with WsPC = retPC~n', [Indent]),
+    format('~w             WsCP = returnCP~n', [Indent]),
+    format('~w             WsCutBar = returnCutBar~n', [Indent]),
+    format('~w             WsB0Stack = returnB0Stack~n', [Indent]),
     emit_multi_reg_updates_fs(OutputRegs, Indent),
     emit_multi_binding_updates_fs(OutputRegs, Indent),
     emit_multi_trail_updates_fs(OutputRegs, Indent),
-    format('~w             WsTrailLen = s.WsTrailLen + ~w }~n', [Indent, NOuts]),
+    format('~w             WsTrailLen = s.WsTrailLen + trailDelta }~n', [Indent]),
     format('~wmatch results with~n', [Indent]),
     format('~w| [] -> None~n', [Indent]),
     format('~w| [h] -> Some (bindResult h)~n', [Indent]),
@@ -3801,7 +3828,7 @@ emit_stream_binding_multi_fs(OutputRegs, Indent) :-
     format('~w               CpAggFrame = None~n', [Indent]),
     format('~w               CpBuiltin  = Some (FFIStreamRetry (', [Indent]),
     emit_outregs_list_fs(OutputRegs),
-    format(', outVars, restWrapped, retPC)) }~n', []),
+    format(', outVars, restWrapped, retPC, returnCP, returnCutBar, returnB0Stack)) }~n', []),
     format('~w    Some { s1 with WsCPs = cp :: s1.WsCPs; WsCPsLen = s1.WsCPsLen + 1 }~n', [Indent]).
 
 %% emit_bound_output_filter_fs(+OutputRegs, +NOuts, +Indent)
@@ -3831,7 +3858,10 @@ emit_bound_output_filter_conds_fs([], _, Indent) :-
 emit_bound_output_filter_conds_fs([output(RegN, Type)|Rest], I, Indent) :-
     format('~w         (match outReg_~w with~n', [Indent, RegN]),
     format('~w          | Unbound _ -> true~n', [Indent]),
-    emit_bound_output_type_match_fs(Type, I, Indent),
+    % Multi-output matches are nested two spaces deeper than the
+    % single-output form. Keep every case at the same offside column.
+    atom_concat(Indent, '  ', NestedIndent),
+    emit_bound_output_type_match_fs(Type, I, NestedIndent),
     format('~w          | _ -> false)~n', [Indent]),
     (   Rest = []
     ->  true
@@ -3856,6 +3886,13 @@ emit_multi_out_derefs_fs([output(RegN, _)|Rest], Indent) :-
     format('~wlet outReg_~w = s.WsRegs.[~w] |> derefVar s.WsBindings~n',
            [Indent, RegN, RegN]),
     emit_multi_out_derefs_fs(Rest, Indent).
+
+emit_outreg_values_list_fs([], _).
+emit_outreg_values_list_fs([output(RegN, _)|Rest], I) :-
+    (   I =:= 1 -> true ; format('; ', []) ),
+    format('outReg_~w', [RegN]),
+    I1 is I + 1,
+    emit_outreg_values_list_fs(Rest, I1).
 
 emit_tuple_pattern_fs(1) :- format('rv_1', []).
 emit_tuple_pattern_fs(N) :-
@@ -5040,7 +5077,11 @@ write_wam_fsharp_project(Predicates, Options0, ProjectDir) :-
         % signals support bidirectional, the selector auto-selects.
         recurrence_inputs:build_workload_signals(Options, ResWorkload),
         maplist(wam_fsharp_apply_strategy_selector(ResWorkload, Options),
-                DetectedKernels0, DetectedKernels),
+                DetectedKernels0, SelectedKernels),
+        % Strategy selection may replace a detected kernel kind. Recheck the
+        % emitted kind so an unsupported upgrade can never reintroduce an
+        % undefined nativeKernel_* call after the initial capability gate.
+        filter_supported_kernel_pairs_fs(SelectedKernels, DetectedKernels),
         (   DetectedKernels \= []
         ->  pairs_keys(DetectedKernels, DetectedKeys),
             format(user_error, '[WAM-FSharp] detected kernels: ~w~n', [DetectedKeys])

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -40,6 +40,8 @@
     compile_wam_predicate_to_fsharp/4,   % +Pred/Arity, +WamCode, +Options, -FSharpCode
     compile_wam_runtime_to_fsharp/3,     % +Options, +DetectedKernels, -Code
     write_wam_fsharp_project/3,          % +Predicates, +Options, +ProjectDir
+    wam_fsharp_native_kernel_supported/1, % +recursive_kernel(Kind,...)
+    wam_fsharp_native_kernel_kind/1,     % ?Kind — authoritative native allow-list
     wam_fsharp_resolve_emit_mode/2,      % +Options, -Mode
     wam_fsharp_partition_predicates/5,   % +Mode, +Predicates, +DK, -Interp, -Lowered
     % Fact-shape classification parity with Haskell/Elixir hybrid targets
@@ -239,6 +241,27 @@ ffi_owned_fact_filter_fs(DetectedKernels, PI) :-
 % Kernel detection (shared with Haskell target pattern)
 % ============================================================================
 
+%% wam_fsharp_native_kernel_kind(?Kind)
+%  Authoritative allow-list of recursive-kernel kinds for which F# can
+%  actually emit a nativeKernel_* handler. Detection may fire on more
+%  kinds (shared detector); unsupported kinds must stay ordinary WAM
+%  predicates — never CallForeign / executeForeign to a missing symbol.
+%
+%  Inventory (do not confuse with this allow-list):
+%   - Generic WAM recursive tc/2 already works (no_kernels(true)).
+%   - category_ancestor / bidirectional_ancestor have .fs.mustache bodies.
+%   - lmdb_fact_source reachableToRoot* is demand-pruning BFS over
+%     category_child (includes root); not a drop-in for transitive_closure2.
+%   - BuildEmptySet / SetInsert / NotMemberSet + FFIStreamRetry are the
+%     WAM/FFI plumbing TC2 streaming reuses.
+wam_fsharp_native_kernel_kind(category_ancestor).
+wam_fsharp_native_kernel_kind(bidirectional_ancestor).
+wam_fsharp_native_kernel_kind(transitive_closure2).
+
+%% wam_fsharp_native_kernel_supported(+Kernel)
+wam_fsharp_native_kernel_supported(recursive_kernel(Kind, _Pred, _ConfigOps)) :-
+    wam_fsharp_native_kernel_kind(Kind).
+
 detect_kernels_fs([], []).
 detect_kernels_fs([PI|Rest], Kernels) :-
     (   PI = _Mod:Pred/Arity -> true ; PI = Pred/Arity ),
@@ -247,7 +270,14 @@ detect_kernels_fs([PI|Rest], Kernels) :-
     (   Clauses \= [],
         detect_recursive_kernel(Pred, Arity, Clauses, Kernel)
     ->  format(atom(Key), '~w/~w', [Pred, Arity]),
-        Kernels = [Key-Kernel|RestKernels]
+        (   wam_fsharp_native_kernel_supported(Kernel)
+        ->  Kernels = [Key-Kernel|RestKernels]
+        ;   Kernel = recursive_kernel(Kind, _, _),
+            format(user_error,
+                   '[WAM-FSharp] detected ~w (~w) but no native F# handler; falling back to WAM~n',
+                   [Key, Kind]),
+            Kernels = RestKernels
+        )
     ;   Kernels = RestKernels
     ),
     detect_kernels_fs(Rest, RestKernels).
@@ -3734,6 +3764,10 @@ emit_stream_binding_multi_fs(OutputRegs, Indent) :-
     length(OutputRegs, NOuts),
     format('~wlet retPC = s.WsCP~n', [Indent]),
     emit_multi_out_derefs_fs(OutputRegs, Indent),
+    % Respect already-bound output registers (e.g. tc(+Source, +Target)):
+    % filter the native result stream before FFIStreamRetry packing.
+    % Mirrors Rust transitive_closure2 target_filter retain.
+    emit_bound_output_filter_fs(OutputRegs, NOuts, Indent),
     format('~wlet bindResult ', [Indent]),
     emit_tuple_pattern_fs(NOuts),
     format(' =~n', []),
@@ -3769,6 +3803,53 @@ emit_stream_binding_multi_fs(OutputRegs, Indent) :-
     emit_outregs_list_fs(OutputRegs),
     format(', outVars, restWrapped, retPC)) }~n', []),
     format('~w    Some { s1 with WsCPs = cp :: s1.WsCPs; WsCPsLen = s1.WsCPsLen + 1 }~n', [Indent]).
+
+%% emit_bound_output_filter_fs(+OutputRegs, +NOuts, +Indent)
+%  Drop native results that conflict with already-bound output registers.
+emit_bound_output_filter_fs(OutputRegs, NOuts, Indent) :-
+    format('~wlet results =~n', [Indent]),
+    format('~w    results~n', [Indent]),
+    format('~w    |> List.filter (fun ', [Indent]),
+    emit_tuple_pattern_fs(NOuts),
+    format(' ->~n', []),
+    emit_bound_output_filter_body_fs(OutputRegs, 1, Indent),
+    format('~w       )~n', [Indent]).
+
+%% Single-output: a bare match expression. Multi-output: &&-chain of matches.
+emit_bound_output_filter_body_fs([output(RegN, Type)], I, Indent) :- !,
+    format('~w        match outReg_~w with~n', [Indent, RegN]),
+    format('~w        | Unbound _ -> true~n', [Indent]),
+    emit_bound_output_type_match_fs(Type, I, Indent),
+    format('~w        | _ -> false~n', [Indent]).
+emit_bound_output_filter_body_fs(OutputRegs, I, Indent) :-
+    format('~w        (~n', [Indent]),
+    emit_bound_output_filter_conds_fs(OutputRegs, I, Indent),
+    format('~w        )~n', [Indent]).
+
+emit_bound_output_filter_conds_fs([], _, Indent) :-
+    format('~w         true~n', [Indent]).
+emit_bound_output_filter_conds_fs([output(RegN, Type)|Rest], I, Indent) :-
+    format('~w         (match outReg_~w with~n', [Indent, RegN]),
+    format('~w          | Unbound _ -> true~n', [Indent]),
+    emit_bound_output_type_match_fs(Type, I, Indent),
+    format('~w          | _ -> false)~n', [Indent]),
+    (   Rest = []
+    ->  true
+    ;   format('~w         &&~n', [Indent]),
+        I1 is I + 1,
+        emit_bound_output_filter_conds_fs(Rest, I1, Indent)
+    ).
+
+emit_bound_output_type_match_fs(atom, I, Indent) :- !,
+    format('~w        | Atom t ->~n', [Indent]),
+    format('~w            match Map.tryFind t ctx.WcAtomIntern with~n', [Indent]),
+    format('~w            | Some id -> id = rv_~w~n', [Indent, I]),
+    format('~w            | None -> false~n', [Indent]).
+emit_bound_output_type_match_fs(integer, I, Indent) :- !,
+    format('~w        | Integer i -> i = rv_~w~n', [Indent, I]).
+emit_bound_output_type_match_fs(float, I, Indent) :- !,
+    format('~w        | Float f -> f = rv_~w~n', [Indent, I]).
+emit_bound_output_type_match_fs(_, _, _Indent).
 
 emit_multi_out_derefs_fs([], _).
 emit_multi_out_derefs_fs([output(RegN, _)|Rest], Indent) :-

--- a/templates/targets/fsharp_wam/kernel_transitive_closure.fs.mustache
+++ b/templates/targets/fsharp_wam/kernel_transitive_closure.fs.mustache
@@ -1,0 +1,33 @@
+/// Native foreign acceleration for the shared transitive_closure2 pattern.
+/// Auto-generated from kernel detection. Edge predicate: {{edge_pred}}.
+///
+/// This is NOT "F# transitive closure support from scratch":
+///   - Ordinary recursive tc/2 already works through the generic WAM
+///     (use no_kernels(true) for that correctness path).
+///   - Lookup-function style matches nativeKernel_category_ancestor so
+///     Eager / LMDB / CSR ILookupSource backends all work.
+///   - HashSet visited-set cycle protection mirrors reachableToRootVia,
+///     but semantics differ: we follow this kernel's configured edge_pred
+///     forward from Source, and Source itself is not a Target solution
+///     (reachableToRoot* walks reverse/category_child edges for demand
+///     pruning and includes the root).
+///
+/// Returns interned Target atom ids; executeForeign streams them via
+/// the existing FFIStreamRetry choice-point machinery (stream-valued
+/// relation — not a deterministic Prolog interface).
+let nativeKernel_transitive_closure
+    (edges: int -> int list)
+    (source: int) : int list =
+    let visited = System.Collections.Generic.HashSet<int>()
+    visited.Add(source) |> ignore
+    let acc = System.Collections.Generic.List<int>()
+    let mutable frontier = [source]
+    while not (List.isEmpty frontier) do
+        let next = System.Collections.Generic.List<int>()
+        for node in frontier do
+            for n in edges node do
+                if visited.Add(n) then
+                    acc.Add(n)
+                    next.Add(n)
+        frontier <- List.ofSeq next
+    List.ofSeq acc

--- a/tests/core/test_wam_fsharp_kernel_gate_tc.pl
+++ b/tests/core/test_wam_fsharp_kernel_gate_tc.pl
@@ -16,6 +16,8 @@
 :- use_module(library(plunit)).
 :- use_module(library(filesex)).
 :- use_module(library(process)).
+:- use_module(library(readutil), [read_file_to_string/3]).
+:- use_module(library(debug), [assertion/1]).
 :- use_module('../../src/unifyweaver/targets/wam_fsharp_target',
               [write_wam_fsharp_project/3,
                wam_fsharp_native_kernel_kind/1,
@@ -25,6 +27,11 @@
 
 :- dynamic user:tc_edge/2.
 :- dynamic user:tc/2.
+:- dynamic user:tc_probe/0.
+:- dynamic user:tc_tail/1.
+:- dynamic user:tc_after/1.
+:- dynamic user:tc_cut/1.
+:- dynamic user:tc_call_after/1.
 :- dynamic user:td_edge/2.
 :- dynamic user:td/3.
 :- dynamic user:tpd_edge/2.
@@ -37,6 +44,9 @@
 :- dynamic user:astar/4.
 :- dynamic user:direct_dist/4.
 :- dynamic user:dimensionality/1.
+:- dynamic user:category_parent/2.
+:- dynamic user:category_ancestor/4.
+:- dynamic user:max_depth/1.
 
 dotnet_available :-
     catch(
@@ -61,9 +71,14 @@ run_dotnet_build(Dir, Exit, Out) :-
         ( catch(close(SO), _, true), catch(close(SE), _, true) )).
 
 run_dotnet_run(Dir, Exit, Out) :-
+    run_dotnet_run(Dir, [], Exit, Out).
+
+run_dotnet_run(Dir, ProgramArgs, Exit, Out) :-
+    append(['run', '--no-build', '-c', 'Release', '--no-launch-profile', '--'],
+           ProgramArgs, DotnetArgs),
     setup_call_cleanup(
         process_create(path(dotnet),
-            ['run', '--no-build', '-c', 'Release', '--no-launch-profile'],
+            DotnetArgs,
             [cwd(Dir),
              environment(['DOTNET_NOLOGO'='1', 'DOTNET_ROLL_FORWARD'='Major']),
              stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
@@ -77,13 +92,26 @@ run_dotnet_run(Dir, Exit, Out) :-
 assert_tc_program :-
     retractall(user:tc_edge(_, _)),
     retractall(user:tc(_, _)),
+    retractall(user:tc_probe),
+    retractall(user:tc_tail(_)),
+    retractall(user:tc_after(_)),
+    retractall(user:tc_cut(_)),
+    retractall(user:tc_call_after(_)),
     % Graph: a->b->c->d, plus cycle c->a, and unreachable z.
     assertz(user:tc_edge(a, b)),
     assertz(user:tc_edge(b, c)),
     assertz(user:tc_edge(c, d)),
     assertz(user:tc_edge(c, a)),
     assertz((user:tc(X, Y) :- tc_edge(X, Y))),
-    assertz((user:tc(X, Y) :- tc_edge(X, Z), tc(Z, Y))).
+    assertz((user:tc(X, Y) :- tc_edge(X, Z), tc(Z, Y))),
+    assertz((user:tc_probe :- tc(a, c))),
+    % tc_tail/1 forces Execute -> ExecuteForeign.  The outer predicates
+    % verify that the foreign tail call returns through its caller, including
+    % retry into a continuation and a cut over the remaining native stream.
+    assertz((user:tc_tail(Y) :- tc(a, Y))),
+    assertz((user:tc_after(Y) :- tc_tail(Y), Y \== b)),
+    assertz((user:tc_cut(Y) :- tc_tail(Y), !)),
+    assertz((user:tc_call_after(Y) :- tc(a, Y), Y \== b)).
 
 assert_td_program :-
     retractall(user:td_edge(_, _)),
@@ -134,6 +162,22 @@ assert_astar_program :-
     assertz((user:astar(X, Y, Dim, Total) :-
                 a_edge(X, Z, W), astar(Z, Y, Dim, Rest),
                 Total is Rest + W)).
+
+assert_bidir_program :-
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor(_, _, _, _)),
+    retractall(user:max_depth(_)),
+    assertz(user:category_parent(a, b)),
+    assertz(user:max_depth(10)),
+    assertz((user:category_ancestor(Cat, Parent, 1, Visited) :-
+                category_parent(Cat, Parent),
+                \+ member(Parent, Visited))),
+    assertz((user:category_ancestor(Cat, Ancestor, Hops, Visited) :-
+                max_depth(MaxD), length(Visited, D), D < MaxD, !,
+                category_parent(Cat, Mid),
+                \+ member(Mid, Visited),
+                category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+                Hops is H1 + 1)).
 
 write_native_tc_driver(ProgPath) :-
     % Custom Program.fs: wires foreignPreds + WcFfiFacts for edge, then
@@ -231,11 +275,68 @@ let collectTargets (ctx: WamContext) (source: string) (boundTarget: string optio
             | None -> List.rev (tgt :: acc)
         gather s1 []
 
+let boundCallTrailIsConsistent (ctx: WamContext) (source: string) (target: string) : bool =
+    let regs = Array.create MaxRegs (Unbound -1)
+    regs.[1] <- Atom source
+    regs.[2] <- Atom target
+    match callForeign ctx \"tc/2\" (mkState regs) with
+    | Some s1 -> s1.WsTrailLen = List.length s1.WsTrail
+    | None -> false
+
+let compiledForeignTailCallSucceeds (ctx: WamContext) : bool =
+    let wasRewritten =
+        ctx.WcCode
+        |> Array.exists (function
+            | ExecuteForeign \"tc/2\" -> true
+            | _ -> false)
+    wasRewritten &&
+        match dispatchCall ctx \"tc_probe/0\" (mkState (Array.create MaxRegs (Unbound -1))) with
+        | Some _ -> true
+        | None -> false
+
+let runUnary (ctx: WamContext) (pred: string) : WamState option =
+    let regs = Array.create MaxRegs (Unbound -1)
+    regs.[1] <- Unbound 200
+    dispatchCall ctx pred (mkState regs)
+
+let nestedTailRetryReturnsToCaller (ctx: WamContext) : bool =
+    // tc_after/1 rejects the first native result (b), backtracks through the
+    // FFIStreamRetry CP, and must resume the outer continuation with c.
+    match runUnary ctx \"tc_after/1\" with
+    | Some s ->
+        getReg 1 s = Some (Atom \"c\") &&
+        s.WsCP = 0 && s.WsCutBar = 0 && List.isEmpty s.WsB0Stack
+    | None -> false
+
+let cutAfterForeignTailUsesCallerBarrier (ctx: WamContext) : bool =
+    match runUnary ctx \"tc_cut/1\" with
+    | Some s ->
+        Map.tryFind 200 s.WsBindings = Some (Atom \"b\") &&
+        s.WsCP = 0 && s.WsCutBar = 0 && List.isEmpty s.WsB0Stack &&
+        s.WsCPsLen = 0 && Option.isNone (backtrack s)
+    | None -> false
+
+let directCallRetryReturnsToCaller (ctx: WamContext) : bool =
+    // Covers the non-tail CallForeign path independently of ExecuteForeign.
+    match runUnary ctx \"tc_call_after/1\" with
+    | Some s ->
+        getReg 1 s = Some (Atom \"c\") &&
+        s.WsCP = 0 && s.WsCutBar = 0 && List.isEmpty s.WsB0Stack
+    | None -> false
+
 [<EntryPoint>]
 let main _argv =
     let ctx = mkContext ()
-    // foreignPreds=[\"tc/2\"] + callForeign proves the native executeForeign path
-    // (conformance_main leaves foreignPreds empty and cannot show this).
+    // foreignPreds=[\"tc/2\"] rewrites the wrapper's tail Execute to
+    // ExecuteForeign; conformance_main leaves foreignPreds empty.
+    assertTrue \"compiled wrapper rewrites and executes foreign tail call\"
+        (compiledForeignTailCallSucceeds ctx)
+    assertTrue \"foreign tail retry resumes the outer continuation\"
+        (nestedTailRetryReturnsToCaller ctx)
+    assertTrue \"cut after foreign tail call uses the caller barrier\"
+        (cutAfterForeignTailUsesCallerBarrier ctx)
+    assertTrue \"non-tail foreign retry resumes its continuation\"
+        (directCallRetryReturnsToCaller ctx)
 
     let fromA = collectTargets ctx \"a\" None |> List.sort
     assertTrue \"direct+multi-hop from a\" (fromA = [\"b\"; \"c\"; \"d\"])
@@ -248,6 +349,8 @@ let main _argv =
 
     let boundOk = collectTargets ctx \"a\" (Some \"c\")
     assertTrue \"bound Target c succeeds\" (boundOk = [\"c\"])
+    assertTrue \"bound Target preserves trail invariant\"
+        (boundCallTrailIsConsistent ctx \"a\" \"c\")
 
     let boundNo = collectTargets ctx \"a\" (Some \"z\")
     assertTrue \"bound unreachable z fails\" (boundNo = [])
@@ -270,6 +373,13 @@ test(capability_allowlist_includes_shipped_and_tc2) :-
     wam_fsharp_native_kernel_kind(transitive_closure2),
     \+ wam_fsharp_native_kernel_kind(transitive_distance3),
     \+ wam_fsharp_native_kernel_kind(weighted_shortest_path3).
+
+test(every_allowlisted_kind_has_a_real_handler) :-
+    forall(
+        wam_fsharp_native_kernel_kind(Kind),
+        assertion(wam_fsharp_native_kernel_supported(
+            recursive_kernel(Kind, probe/0, [])))
+    ).
 
 test(existing_closure_layers_present) :-
     % Characterization: do not invent TC support from scratch.
@@ -305,7 +415,7 @@ test(wam_fallback_control_builds,
     assert_tc_program,
     tmp_proj(wam_tc, Dir),
     write_wam_fsharp_project(
-        [user:tc/2, user:tc_edge/2],
+        [user:tc/2, user:tc_edge/2, user:tc_probe/0],
         [no_kernels(true), module_name('uw_fs_wam_tc'), conformance_main(true)],
         Dir),
     directory_file_path(Dir, 'WamRuntime.fs', RT),
@@ -314,6 +424,9 @@ test(wam_fallback_control_builds,
     run_dotnet_build(Dir, Exit, Out),
     assertion(Exit =:= 0),
     ( Exit =:= 0 -> true ; format(user_error, '~w~n', [Out]), fail ),
+    run_dotnet_run(Dir, ['tc_probe/0'], RunExit, RunOut),
+    assertion(RunExit =:= 0),
+    assertion(sub_string(RunOut, _, _, _, "true")),
     !.
 
 test(native_tc2_codegen_and_build,
@@ -321,7 +434,10 @@ test(native_tc2_codegen_and_build,
     assert_tc_program,
     tmp_proj(native_tc, Dir),
     write_wam_fsharp_project(
-        [user:tc/2, user:tc_edge/2],
+        [ user:tc/2, user:tc_edge/2, user:tc_probe/0,
+          user:tc_tail/1, user:tc_after/1, user:tc_cut/1,
+          user:tc_call_after/1
+        ],
         [module_name('uw_fs_native_tc')],
         Dir),
     directory_file_path(Dir, 'WamRuntime.fs', RT),
@@ -342,15 +458,42 @@ test(native_tc2_codegen_and_build,
     run_dotnet_run(Dir, RunExit, RunOut),
     assertion(RunExit =:= 0),
     assertion(sub_string(RunOut, _, _, _, "RESULT ")),
-    (   sub_string(RunOut, _, _, _, "RESULT 5/5")
+    (   sub_string(RunOut, _, _, _, "RESULT 10/10")
     ->  true
     ;   format(user_error, 'native_tc2 run:~n~w~n', [RunOut]), fail
+    ),
+    !.
+
+test(existing_bidirectional_multi_output_still_builds,
+     [condition(dotnet_available)]) :-
+    assert_bidir_program,
+    tmp_proj(bidir_multi_output, Dir),
+    write_wam_fsharp_project(
+        [user:category_ancestor/4],
+        [ kernel_mode(bidirectional),
+          allow_bidirectional_kernel_swap(true),
+          module_name('uw_fs_bidir_multi_output')
+        ],
+        Dir),
+    directory_file_path(Dir, 'WamRuntime.fs', RT),
+    read_file_to_string(RT, RTS, []),
+    assertion(sub_string(RTS, _, _, _, "nativeKernel_bidirectional_ancestor")),
+    run_dotnet_build(Dir, Exit, Out),
+    assertion(Exit =:= 0),
+    ( Exit =:= 0 -> true
+    ; format(user_error, 'bidirectional multi-output build failed:~n~w~n', [Out]), fail
     ),
     !.
 
 %% Unsupported detected patterns must compile via WAM fallback.
 fallback_kind_builds(Kind, Setup, Preds, ForbiddenNative) :-
     call(Setup),
+    Preds = [user:Pred/Arity|_],
+    functor(Head, Pred, Arity),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    detect_recursive_kernel(Pred, Arity, Clauses, Kernel),
+    assertion(Kernel = recursive_kernel(Kind, _, _)),
+    assertion(\+ wam_fsharp_native_kernel_supported(Kernel)),
     format(atom(Name), 'fb_~w', [Kind]),
     tmp_proj(Name, Dir),
     write_wam_fsharp_project(

--- a/tests/core/test_wam_fsharp_kernel_gate_tc.pl
+++ b/tests/core/test_wam_fsharp_kernel_gate_tc.pl
@@ -1,0 +1,396 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_fsharp_kernel_gate_tc.pl
+%
+% FS-HYBRID-KERNEL-GATE-TC:
+%   1) Capability-gate unsupported detected kernels (no undefined
+%      nativeKernel_* / FS0039).
+%   2) Native foreign acceleration for transitive_closure2 — not
+%      "F# transitive closure from scratch" (generic WAM tc/2 already
+%      works; category/bidirectional/reachableToRoot* already exist).
+%
+% Run: swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_kernel_gate_tc.pl
+% Requires: swipl; dotnet for execute/build cases (skipped if absent).
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../../src/unifyweaver/targets/wam_fsharp_target',
+              [write_wam_fsharp_project/3,
+               wam_fsharp_native_kernel_kind/1,
+               wam_fsharp_native_kernel_supported/1]).
+:- use_module('../../src/unifyweaver/core/recursive_kernel_detection',
+              [detect_recursive_kernel/4]).
+
+:- dynamic user:tc_edge/2.
+:- dynamic user:tc/2.
+:- dynamic user:td_edge/2.
+:- dynamic user:td/3.
+:- dynamic user:tpd_edge/2.
+:- dynamic user:tpd/4.
+:- dynamic user:tspd_edge/2.
+:- dynamic user:tspd/5.
+:- dynamic user:w_edge/3.
+:- dynamic user:wsp/3.
+:- dynamic user:a_edge/3.
+:- dynamic user:astar/4.
+:- dynamic user:direct_dist/4.
+:- dynamic user:dimensionality/1.
+
+dotnet_available :-
+    catch(
+        ( process_create(path(dotnet), ['--version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, _) ),
+        _, fail).
+
+tmp_proj(Name, Dir) :-
+    format(atom(Dir), '/tmp/uw_fs_gate_~w', [Name]),
+    catch(delete_directory_and_contents(Dir), _, true),
+    make_directory_path(Dir).
+
+run_dotnet_build(Dir, Exit, Out) :-
+    setup_call_cleanup(
+        process_create(path(dotnet),
+            ['build', '--nologo', '-v', 'q', '-c', 'Release'],
+            [cwd(Dir), stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
+        ( read_string(SO, _, S1), read_string(SE, _, S2),
+          process_wait(Pid, exit(Exit)),
+          string_concat(S1, S2, Out) ),
+        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
+
+run_dotnet_run(Dir, Exit, Out) :-
+    setup_call_cleanup(
+        process_create(path(dotnet),
+            ['run', '--no-build', '-c', 'Release', '--no-launch-profile'],
+            [cwd(Dir),
+             environment(['DOTNET_NOLOGO'='1', 'DOTNET_ROLL_FORWARD'='Major']),
+             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
+        ( read_string(SO, _, S1), read_string(SE, _, S2),
+          process_wait(Pid, exit(Exit)),
+          string_concat(S1, S2, Out) ),
+        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
+
+% Bodies must be unqualified so detect_recursive_kernel/4 sees
+% edge(X,Y) / edge(X,Z), Pred(Z,Y) — not user:edge(...).
+assert_tc_program :-
+    retractall(user:tc_edge(_, _)),
+    retractall(user:tc(_, _)),
+    % Graph: a->b->c->d, plus cycle c->a, and unreachable z.
+    assertz(user:tc_edge(a, b)),
+    assertz(user:tc_edge(b, c)),
+    assertz(user:tc_edge(c, d)),
+    assertz(user:tc_edge(c, a)),
+    assertz((user:tc(X, Y) :- tc_edge(X, Y))),
+    assertz((user:tc(X, Y) :- tc_edge(X, Z), tc(Z, Y))).
+
+assert_td_program :-
+    retractall(user:td_edge(_, _)),
+    retractall(user:td(_, _, _)),
+    assertz(user:td_edge(a, b)),
+    assertz(user:td_edge(b, c)),
+    assertz((user:td(X, Y, 1) :- td_edge(X, Y))),
+    assertz((user:td(X, Y, D) :- td_edge(X, Z), td(Z, Y, D1), D is D1 + 1)).
+
+assert_tpd_program :-
+    retractall(user:tpd_edge(_, _)),
+    retractall(user:tpd(_, _, _, _)),
+    assertz(user:tpd_edge(a, b)),
+    assertz(user:tpd_edge(b, c)),
+    assertz((user:tpd(X, Y, X, 1) :- tpd_edge(X, Y))),
+    assertz((user:tpd(X, Y, P, D) :-
+                tpd_edge(X, Z), tpd(Z, Y, P, D1), D is D1 + 1)).
+
+assert_tspd_program :-
+    retractall(user:tspd_edge(_, _)),
+    retractall(user:tspd(_, _, _, _, _)),
+    assertz(user:tspd_edge(a, b)),
+    assertz(user:tspd_edge(b, c)),
+    % Base: step==target, parent==source. Rec: head step is the edge Mid.
+    assertz((user:tspd(X, Y, Y, X, 1) :- tspd_edge(X, Y))),
+    assertz((user:tspd(X, Y, Z, P, D) :-
+                tspd_edge(X, Z), tspd(Z, Y, _, P, D1), D is D1 + 1)).
+
+assert_wsp_program :-
+    retractall(user:w_edge(_, _, _)),
+    retractall(user:wsp(_, _, _)),
+    assertz(user:w_edge(a, b, 1.0)),
+    assertz(user:w_edge(b, c, 2.0)),
+    assertz((user:wsp(X, Y, W) :- w_edge(X, Y, W))),
+    assertz((user:wsp(X, Y, Total) :-
+                w_edge(X, Z, W), wsp(Z, Y, Rest), Total is Rest + W)).
+
+assert_astar_program :-
+    retractall(user:a_edge(_, _, _)),
+    retractall(user:astar(_, _, _, _)),
+    retractall(user:direct_dist(_, _, _, _)),
+    retractall(user:dimensionality(_)),
+    assertz(user:dimensionality(2)),
+    assertz(user:direct_dist(a, c, 2, 1.0)),
+    assertz(user:a_edge(a, b, 1.0)),
+    assertz(user:a_edge(b, c, 1.0)),
+    assertz((user:astar(X, Y, Dim, W) :- a_edge(X, Y, W), dimensionality(Dim))),
+    assertz((user:astar(X, Y, Dim, Total) :-
+                a_edge(X, Z, W), astar(Z, Y, Dim, Rest),
+                Total is Rest + W)).
+
+write_native_tc_driver(ProgPath) :-
+    % Custom Program.fs: wires foreignPreds + WcFfiFacts for edge, then
+    % exercises callForeign (native path) — not the empty-foreignPreds
+    % conformance_main driver.
+    Driver = "module Program
+
+open System
+open WamTypes
+open WamRuntime
+open Predicates
+
+let mutable passes = 0
+let mutable fails = 0
+
+let assertTrue (name: string) (cond: bool) =
+    if cond then
+        passes <- passes + 1
+        printfn \"[PASS] %s\" name
+    else
+        fails <- fails + 1
+        printfn \"[FAIL] %s\" name
+
+let mkAtoms () =
+    // Stable intern ids for the fixture graph.
+    let pairs = [(\"a\", 1); (\"b\", 2); (\"c\", 3); (\"d\", 4); (\"z\", 5)]
+    Map.ofList pairs, Map.ofList (pairs |> List.map (fun (s, i) -> (i, s)))
+
+let mkEdgeFacts (intern: Map<string, int>) =
+    let edges = [(\"a\", \"b\"); (\"b\", \"c\"); (\"c\", \"d\"); (\"c\", \"a\")]
+    let grouped =
+        edges
+        |> List.map (fun (f, t) -> Map.find f intern, Map.find t intern)
+        |> List.groupBy fst
+        |> List.map (fun (k, vs) -> k, vs |> List.map snd)
+    Map.ofList [(\"tc_edge\", Map.ofList grouped)]
+
+let mkContext () =
+    let foreignPreds = [\"tc/2\"]
+    let resolvedCode =
+        resolveCallInstrs allLabels foreignPreds (Array.toList allCode)
+        |> List.toArray
+    let intern, deintern = mkAtoms ()
+    { WcCode              = resolvedCode
+      WcLabels            = allLabels
+      WcForeignFacts      = Map.empty
+      WcFfiFacts          = mkEdgeFacts intern
+      WcFfiWeightedFacts  = Map.empty
+      WcAtomIntern        = intern
+      WcAtomDeintern      = deintern
+      WcForeignConfig     = Map.empty
+      WcLoweredPredicates = Map.empty
+      WcLookupSources     = Map.empty
+      WcCancellationToken = None }
+
+let mkState (regs: Value array) : WamState =
+    { WsPC         = 0
+      WsRegs       = regs
+      WsStack      = []
+      WsHeap       = []
+      WsHeapLen    = 0
+      WsTrail      = []
+      WsTrailLen   = 0
+      WsCP         = 0
+      WsCPs        = []
+      WsCPsLen     = 0
+      WsBindings   = Map.empty
+      WsCutBar     = 0
+      WsVarCounter = 0
+      WsBuilder    = None
+      WsBuilderStack = []
+      WsAggAccum   = []
+      WsB0Stack    = []
+      WsCatchers   = [] }
+
+let collectTargets (ctx: WamContext) (source: string) (boundTarget: string option) : string list =
+    let regs = Array.create MaxRegs (Unbound -1)
+    regs.[1] <- Atom source
+    match boundTarget with
+    | Some t -> regs.[2] <- Atom t
+    | None   -> regs.[2] <- Unbound 100
+    let s0 = mkState regs
+    match callForeign ctx \"tc/2\" s0 with
+    | None -> []
+    | Some s1 ->
+        let readTarget (s: WamState) =
+            match getReg 2 s with
+            | Some (Atom a) -> a
+            | _ -> \"?\"
+        // First solution from callForeign; further solutions via FFIStreamRetry backtrack.
+        let rec gather (s: WamState) (acc: string list) =
+            let tgt = readTarget s
+            match backtrack s with
+            | Some s2 -> gather s2 (tgt :: acc)
+            | None -> List.rev (tgt :: acc)
+        gather s1 []
+
+[<EntryPoint>]
+let main _argv =
+    let ctx = mkContext ()
+    // foreignPreds=[\"tc/2\"] + callForeign proves the native executeForeign path
+    // (conformance_main leaves foreignPreds empty and cannot show this).
+
+    let fromA = collectTargets ctx \"a\" None |> List.sort
+    assertTrue \"direct+multi-hop from a\" (fromA = [\"b\"; \"c\"; \"d\"])
+
+    let fromC = collectTargets ctx \"c\" None |> List.sort
+    assertTrue \"cycle-safe from c\" (fromC = [\"a\"; \"b\"; \"d\"])
+
+    let fromD = collectTargets ctx \"d\" None
+    assertTrue \"sink d has no targets\" (fromD = [])
+
+    let boundOk = collectTargets ctx \"a\" (Some \"c\")
+    assertTrue \"bound Target c succeeds\" (boundOk = [\"c\"])
+
+    let boundNo = collectTargets ctx \"a\" (Some \"z\")
+    assertTrue \"bound unreachable z fails\" (boundNo = [])
+
+    printfn \"RESULT %d/%d\" passes (passes + fails)
+    if fails > 0 then 1 else 0
+",
+    setup_call_cleanup(
+        open(ProgPath, write, Out, [encoding(utf8)]),
+        write(Out, Driver),
+        close(Out)).
+
+%% ---------- characterization of existing layers ----------
+
+:- begin_tests(wam_fsharp_kernel_gate_tc).
+
+test(capability_allowlist_includes_shipped_and_tc2) :-
+    wam_fsharp_native_kernel_kind(category_ancestor),
+    wam_fsharp_native_kernel_kind(bidirectional_ancestor),
+    wam_fsharp_native_kernel_kind(transitive_closure2),
+    \+ wam_fsharp_native_kernel_kind(transitive_distance3),
+    \+ wam_fsharp_native_kernel_kind(weighted_shortest_path3).
+
+test(existing_closure_layers_present) :-
+    % Characterization: do not invent TC support from scratch.
+    % Tests are invoked from the repo root (see docs/TESTING.md).
+    Tw = 'templates/targets/fsharp_wam/',
+    atom_concat(Tw, 'kernel_category_ancestor.fs.mustache', Cat),
+    atom_concat(Tw, 'kernel_bidirectional_ancestor.fs.mustache', Bidir),
+    atom_concat(Tw, 'lmdb_fact_source.fs.mustache', Lmdb),
+    atom_concat(Tw, 'kernel_transitive_closure.fs.mustache', Tc),
+    read_file_to_string(Cat, CatS, []),
+    read_file_to_string(Bidir, BidirS, []),
+    read_file_to_string(Lmdb, LmdbS, []),
+    read_file_to_string(Tc, TcS, []),
+    assertion(sub_string(CatS, _, _, _, "nativeKernel_category_ancestor")),
+    assertion(sub_string(BidirS, _, _, _, "nativeKernel_bidirectional_ancestor")),
+    assertion(sub_string(LmdbS, _, _, _, "reachableToRootVia")),
+    assertion(sub_string(LmdbS, _, _, _, "reachableToRoot")),
+    assertion(sub_string(TcS, _, _, _, "let nativeKernel_transitive_closure")),
+    % TC2 must not define the demand-pruning helpers (comments may mention them).
+    assertion(\+ sub_string(TcS, _, _, _, "let reachableToRoot")),
+    !.
+
+test(detector_fires_tc2_and_gate_accepts) :-
+    assert_tc_program,
+    findall(tc(X,Y)-Body, clause(user:tc(X, Y), Body), Clauses),
+    detect_recursive_kernel(tc, 2, Clauses, Kernel),
+    assertion(Kernel = recursive_kernel(transitive_closure2, _, _)),
+    assertion(wam_fsharp_native_kernel_supported(Kernel)),
+    !.
+
+test(wam_fallback_control_builds,
+     [condition(dotnet_available)]) :-
+    assert_tc_program,
+    tmp_proj(wam_tc, Dir),
+    write_wam_fsharp_project(
+        [user:tc/2, user:tc_edge/2],
+        [no_kernels(true), module_name('uw_fs_wam_tc'), conformance_main(true)],
+        Dir),
+    directory_file_path(Dir, 'WamRuntime.fs', RT),
+    read_file_to_string(RT, RTS, []),
+    assertion(\+ sub_string(RTS, _, _, _, "nativeKernel_transitive_closure")),
+    run_dotnet_build(Dir, Exit, Out),
+    assertion(Exit =:= 0),
+    ( Exit =:= 0 -> true ; format(user_error, '~w~n', [Out]), fail ),
+    !.
+
+test(native_tc2_codegen_and_build,
+     [condition(dotnet_available)]) :-
+    assert_tc_program,
+    tmp_proj(native_tc, Dir),
+    write_wam_fsharp_project(
+        [user:tc/2, user:tc_edge/2],
+        [module_name('uw_fs_native_tc')],
+        Dir),
+    directory_file_path(Dir, 'WamRuntime.fs', RT),
+    directory_file_path(Dir, 'Program.fs', Prog),
+    read_file_to_string(RT, RTS, []),
+    assertion(sub_string(RTS, _, _, _, "nativeKernel_transitive_closure")),
+    assertion(sub_string(RTS, _, _, _, "| \"tc/2\" ->")),
+    assertion(\+ sub_string(RTS, _, _, _, "template not found")),
+    assertion(\+ sub_string(RTS, _, _, _, "no F# template available")),
+    % Bound-Target filter present in executeForeign stream binder.
+    assertion(sub_string(RTS, _, _, _, "WcAtomIntern")),
+    write_native_tc_driver(Prog),
+    run_dotnet_build(Dir, Exit, Out),
+    assertion(Exit =:= 0),
+    ( Exit =:= 0 -> true
+    ; format(user_error, 'native_tc2 build failed:~n~w~n', [Out]), fail
+    ),
+    run_dotnet_run(Dir, RunExit, RunOut),
+    assertion(RunExit =:= 0),
+    assertion(sub_string(RunOut, _, _, _, "RESULT ")),
+    (   sub_string(RunOut, _, _, _, "RESULT 5/5")
+    ->  true
+    ;   format(user_error, 'native_tc2 run:~n~w~n', [RunOut]), fail
+    ),
+    !.
+
+%% Unsupported detected patterns must compile via WAM fallback.
+fallback_kind_builds(Kind, Setup, Preds, ForbiddenNative) :-
+    call(Setup),
+    format(atom(Name), 'fb_~w', [Kind]),
+    tmp_proj(Name, Dir),
+    write_wam_fsharp_project(
+        Preds,
+        [module_name(Name), conformance_main(true)],
+        Dir),
+    directory_file_path(Dir, 'WamRuntime.fs', RT),
+    read_file_to_string(RT, RTS, []),
+    assertion(\+ sub_string(RTS, _, _, _, ForbiddenNative)),
+    assertion(\+ sub_string(RTS, _, _, _, "template not found")),
+    run_dotnet_build(Dir, Exit, Out),
+    assertion(Exit =:= 0),
+    ( Exit =:= 0 -> true
+    ; format(user_error, '~w fallback build failed:~n~w~n', [Kind, Out]), fail
+    ),
+    !.
+
+test(fallback_transitive_distance3, [condition(dotnet_available)]) :-
+    fallback_kind_builds(transitive_distance3, assert_td_program,
+                         [user:td/3, user:td_edge/2],
+                         "nativeKernel_transitive_distance").
+
+test(fallback_transitive_parent_distance4, [condition(dotnet_available)]) :-
+    fallback_kind_builds(transitive_parent_distance4, assert_tpd_program,
+                         [user:tpd/4, user:tpd_edge/2],
+                         "nativeKernel_transitive_parent_distance").
+
+test(fallback_transitive_step_parent_distance5, [condition(dotnet_available)]) :-
+    fallback_kind_builds(transitive_step_parent_distance5, assert_tspd_program,
+                         [user:tspd/5, user:tspd_edge/2],
+                         "nativeKernel_transitive_step_parent_distance").
+
+test(fallback_weighted_shortest_path3, [condition(dotnet_available)]) :-
+    fallback_kind_builds(weighted_shortest_path3, assert_wsp_program,
+                         [user:wsp/3, user:w_edge/3],
+                         "nativeKernel_weighted_shortest_path").
+
+test(fallback_astar_shortest_path4, [condition(dotnet_available)]) :-
+    fallback_kind_builds(astar_shortest_path4, assert_astar_program,
+                         [user:astar/4, user:a_edge/3, user:direct_dist/4, user:dimensionality/1],
+                         "nativeKernel_astar_shortest_path").
+
+:- end_tests(wam_fsharp_kernel_gate_tc).

--- a/tests/run_wam_fsharp_tests.pl
+++ b/tests/run_wam_fsharp_tests.pl
@@ -39,6 +39,8 @@ repo_root(Root) :-
 %% then dotnet smokes (slower, may skip on toolchain-less machines).
 fsharp_test('tests/test_wam_fsharp_target.pl',
             'F# WAM codegen tests').
+fsharp_test('tests/core/test_wam_fsharp_kernel_gate_tc.pl',
+            'F# WAM kernel capability gate + native transitive_closure2').
 fsharp_test('tests/core/test_wam_fsharp_dotnet_smoke.pl',
             'F# WAM dotnet runtime smoke').
 fsharp_test('tests/core/test_wam_lmdb_cross_target_conformance.pl',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Capability-gate F# external kernels and add **native foreign acceleration for the shared `transitive_closure2` pattern** — not “F# transitive closure from scratch.”

## Context (preserved layers)
F# already had working closure-related machinery:
1. Generic WAM recursive `tc/2` (`no_kernels(true)`) — correctness path
2. `nativeKernel_category_ancestor` / `nativeKernel_bidirectional_ancestor`
3. LMDB/CSR `reachableToRoot*` demand-pruning BFS (different semantics)
4. `BuildEmptySet` / `SetInsert` / `NotMemberSet` + `FFIStreamRetry`

Primary bug: detection promoted unsupported kinds to `CallForeign` / `executeForeign` even when no `nativeKernel_*` body existed → FS0039.

## Changes
- `wam_fsharp_native_kernel_kind/1` allow-list plus a **real-handler gate** before and after strategy selection. Unsupported detections log and stay ordinary WAM.
- Allow-list today: `category_ancestor`, `bidirectional_ancestor`, `transitive_closure2`.
- `kernel_transitive_closure.fs.mustache`: lookup-fn + HashSet visited BFS; streams through existing `FFIStreamRetry`; bound Target is filtered by the shared stream binder.
- Foreign tail calls now resolve to `ExecuteForeign`, including the lowered emitter.
- First and retry results preserve the WAM invariants for `WsCP`, `WsCutBar`, `WsB0Stack`, `WsTrailLen`, and `WsTrail`.
- Multi-output bound filtering emits valid F# and the existing bidirectional kernel still builds.
- Docs correctly describe generic WAM closure as the fallback and native TC2 as optional acceleration.

## Verify
```bash
# Focused suite (gate + native TC2 + five WAM fallbacks)
swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_kernel_gate_tc.pl

# Existing F# target tests
swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl

# Conformance (opt-in; uses no_kernels(true))
CONFORMANCE_TARGETS=fsharp,fsharp_functions CONFORMANCE_SEED=1 \
  swipl -q -g run_tests -t halt tests/test_wam_cross_target_conformance.pl
```

Review follow-up verification:
- Clean generated native project: build succeeds and runtime driver reports **RESULT 10/10**.
- Driver exercises compiled `CallForeign` and `ExecuteForeign`, nested continuation retry, post-tail cut behavior, bound and unbound targets, and trail invariants.
- Generic WAM fallback builds and `tc_probe/0` returns `true`.
- Existing bidirectional multi-output native project builds.
- Existing F# parity suite reports **All tests passed**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
